### PR TITLE
[CI] release/deploy에 프론트 런타임 경계 명시

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -158,6 +158,19 @@ jobs:
           echo "deploy_sha=${DEPLOY_SHA}" >> "$GITHUB_OUTPUT"
           echo "should_deploy=${SHOULD_DEPLOY}" >> "$GITHUB_OUTPUT"
 
+          {
+            echo "## Deploy Boundary"
+            echo "- backend deploy: homeserver blue/green"
+            echo "- frontend runtime: Vercel (external platform)"
+            echo "- frontend step: \`frontLiveE2E\` verifies the current production frontend URL only"
+            if [ "${SHOULD_DEPLOY}" = "true" ]; then
+              echo "- result: backend deploy pipeline continues"
+            else
+              echo "- result: homeserver deploy skipped because backend/deploy paths did not change"
+            fi
+            echo "- decision source: ${CHANGE_SOURCE}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   buildAndPush:
     runs-on: ubuntu-latest
     needs: calculateTag
@@ -835,6 +848,7 @@ jobs:
           REMOTE
 
   frontLiveE2E:
+    name: Frontend Live E2E Verification
     runs-on: ubuntu-latest
     needs:
       - calculateTag
@@ -1260,6 +1274,9 @@ jobs:
               `Release version: ${releaseVersion}`,
               `Deploy SHA: ${deploySha}`,
               `Backend image: ${imageRef}`,
+              `Deployment mode: backend deploy to homeserver`,
+              `Frontend runtime: Vercel (not deployed by this workflow)`,
+              `Frontend verification: frontLiveE2E against the current production frontend URL`,
               `Workflow run: https://github.com/${owner}/${repo}/actions/runs/${context.runId}`
             ].join("\n");
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -107,6 +107,10 @@ jobs:
               "- develop 최신 green 상태를 main release candidate로 반영하기 위한 자동 PR입니다.",
               "- CI 성공 후 workflow가 PR 본문과 auto-merge 요청 상태를 갱신합니다.",
               "",
+              "## 🚦 Runtime Boundary",
+              "- `main` merge 후 `deploy.yml`은 홈서버 백엔드만 blue/green 배포합니다.",
+              "- 프론트 런타임은 Vercel이 담당하며, `frontLiveE2E`는 현재 운영 프론트 URL 검증만 수행합니다.",
+              "",
               "## 🛠 Changes",
               `- \`develop\` -> \`main\` compare 기준 ahead commit: ${process.env.AHEAD_COUNT}`,
               `- compare 기준 behind commit: ${process.env.BEHIND_COUNT}`,
@@ -211,4 +215,5 @@ jobs:
             echo "- head: develop"
             echo "- ahead commits: ${{ steps.decide.outputs.ahead_count }}"
             echo "- develop sha: \`${{ steps.decide.outputs.develop_sha }}\`"
+            echo "- deploy boundary: backend deploy + frontend live verification"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 관련 이슈

close #9

## 작업 배경

- release PR 본문과 deploy workflow metadata에 `백엔드 배포 + 프론트 운영 검증` 경계를 명시했습니다.
- `frontLiveE2E`가 프론트 배포가 아니라 운영 프론트 URL 검증 단계임을 GitHub Actions UI에서 바로 읽을 수 있게 정리했습니다.

## 작업 내용

- `release-pr.yml` 본문/step summary에 runtime boundary 설명 추가
- `deploy.yml` step summary, job display name, release body에 frontend verification 경계 추가
- backend deploy가 프론트를 직접 배포하지 않는다는 표현으로 workflow metadata 정리

## 검증

- 실행한 명령과 결과:
  - `ruby -e 'Dir[".github/workflows/*.yml"].sort.each { |f| require "yaml"; YAML.load_file(f) }'`
  - `ruby -e 'Dir[".github/workflows/*.yml"].sort.each { |f| require "yaml"; YAML.load_file(f) }'` (2회 연속 통과)
  - `CURRENT_TASK_FILE_PATH=.codex/tasks/front-deploy-boundary.local bash tools/guards/check-current-task-scope.sh --worktree`
  - `git diff --check`
  - `rg -n "Deploy Boundary|Frontend Live E2E Verification|frontLiveE2E|Vercel|deploy boundary" .github/workflows/deploy.yml .github/workflows/release-pr.yml`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: release/deploy workflow 본문과 summary 표현만 바뀌므로 런타임 동작 영향은 낮습니다.
- 롤백 방법: 이 PR의 커밋(`31cb690c`)을 revert 하면 기존 표현으로 복구됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
