### PR TITLE
[Fix] 작성/수정 표 셀 스타일 오버레이 스크롤 고정 점 잔상 제거

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -2136,6 +2136,48 @@ test.describe("block editor authoring flow", () => {
       .toContain('"backgroundColor":"#fef3c7"')
   })
 
+  test("table 셀 스타일 버튼과 메뉴는 스크롤 후 viewport 잔상 없이 정리된다", async ({ page }) => {
+    await page.goto(QA_ENGINE_ROUTE)
+    const { cellMenuButton } = getTableAffordances(page)
+
+    await page.getByRole("button", { name: "테이블" }).click()
+    const firstTableCell = page.locator("table th, table td").first()
+    await firstTableCell.click()
+    await firstTableCell.hover()
+    await expect(cellMenuButton).toBeVisible()
+
+    await page.evaluate(() => {
+      if (document.querySelector('[data-testid="qa-scroll-spacer"]')) return
+      const spacer = document.createElement("div")
+      spacer.setAttribute("data-testid", "qa-scroll-spacer")
+      spacer.style.height = "2200px"
+      spacer.style.pointerEvents = "none"
+      document.body.appendChild(spacer)
+    })
+
+    await page.evaluate(() => {
+      window.scrollTo({ top: document.body.scrollHeight })
+    })
+    await expect(cellMenuButton).toHaveCount(0)
+
+    await page.evaluate(() => {
+      window.scrollTo({ top: 0 })
+    })
+    await expect(firstTableCell).toBeVisible()
+    await firstTableCell.hover()
+    await expect(cellMenuButton).toBeVisible()
+
+    await cellMenuButton.click()
+    const cellMenu = page.getByTestId("table-cell-menu")
+    await expect(cellMenu).toBeVisible()
+
+    await page.evaluate(() => {
+      window.scrollTo({ top: document.body.scrollHeight })
+    })
+    await expect(cellMenuButton).toHaveCount(0)
+    await expect(cellMenu).toHaveCount(0)
+  })
+
   test("table row/column 메뉴는 axis-level header action을 노출하고 저장 후 재진입해도 유지된다", async ({ page }) => {
     await page.goto(QA_ENGINE_ROUTE)
     const { rowHandle: rowMenuButton, columnHandle: columnMenuButton } = getTableAffordances(page)

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -1096,6 +1096,20 @@ const clampViewportPosition = (
   return Math.min(Math.max(value, edgePadding), max)
 }
 
+const intersectsViewportBounds = (
+  rect: DOMRect | null | undefined,
+  edgePadding = TABLE_ADD_BAR_VIEWPORT_PADDING_PX
+) => {
+  if (!rect) return false
+  if (typeof window === "undefined") return true
+  return (
+    rect.right >= edgePadding &&
+    rect.bottom >= edgePadding &&
+    rect.left <= window.innerWidth - edgePadding &&
+    rect.top <= window.innerHeight - edgePadding
+  )
+}
+
 const resolveDesktopTableRailLayout = (
   state: TableAffordanceGeometry
 ) => {
@@ -7758,16 +7772,27 @@ const BlockEditorEngine = ({
   ])
 
   useEffect(() => {
-    if (!tableAffordanceVisibility.visible && !isTableQuickRailHovered) return
+    if (!tableAffordanceVisibility.visible && !isTableQuickRailHovered && !tableMenuState) return
     const anchorCell = resolveTableQuickRailAnchorElement()
-    if (!anchorCell) {
-      if (!tableMenuState && !isTableColumnResizeActive && !isTableQuickRailHovered) {
+    const tableElement = anchorCell?.closest("table") as HTMLTableElement | null
+    const tableVisible = intersectsViewportBounds(tableElement?.getBoundingClientRect() ?? null)
+    const anchorVisible = intersectsViewportBounds(anchorCell?.getBoundingClientRect() ?? null)
+    if (!anchorCell || !tableElement || !tableVisible || (!anchorVisible && !isTableQuickRailHovered)) {
+      setHoveredTableCellMenuLayout(null)
+      setIsTableQuickRailHovered(false)
+      if (tableMenuState) {
+        setTableMenuState(null)
+        hideTableQuickRailImmediately()
+      } else if (!isTableColumnResizeActive && !isTableQuickRailHovered) {
         scheduleTableQuickRailHide(0)
+      } else {
+        hideTableQuickRailImmediately()
       }
       return
     }
     syncTableQuickRailFromElement(anchorCell)
   }, [
+    hideTableQuickRailImmediately,
     isTableColumnResizeActive,
     isTableQuickRailHovered,
     resolveTableQuickRailAnchorElement,
@@ -8280,6 +8305,24 @@ const BlockEditorEngine = ({
 
   useEffect(() => {
     if (typeof window === "undefined" || !tableMenuState) return
+    const scrollOptions: AddEventListenerOptions = { capture: true, passive: true }
+    const resizeOptions: AddEventListenerOptions = { passive: true }
+    const closeOnViewportChange = () => {
+      setHoveredTableCellMenuLayout(null)
+      setIsTableQuickRailHovered(false)
+      setTableMenuState(null)
+      hideTableQuickRailImmediately()
+    }
+    window.addEventListener("scroll", closeOnViewportChange, scrollOptions)
+    window.addEventListener("resize", closeOnViewportChange, resizeOptions)
+    return () => {
+      window.removeEventListener("scroll", closeOnViewportChange, scrollOptions)
+      window.removeEventListener("resize", closeOnViewportChange, resizeOptions)
+    }
+  }, [hideTableQuickRailImmediately, tableMenuState])
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !tableMenuState) return
     const close = (event: PointerEvent | KeyboardEvent) => {
       if (event instanceof PointerEvent) {
         const target = event.target
@@ -8309,7 +8352,8 @@ const BlockEditorEngine = ({
     currentTableAxisSelection === null &&
     !shouldUseCompactTableAffordance &&
     (isCellMenuOpen ||
-      ((tableAffordanceVisibility.showCellMenu || hasActiveTableCellContext) &&
+      (tableAffordanceVisibility.visible &&
+        (tableAffordanceVisibility.showCellMenu || hasActiveTableCellContext) &&
         !tableAffordanceVisibility.showColumnRail &&
         !tableAffordanceVisibility.showRowRail &&
         !tableAffordanceVisibility.showColumnAddBar &&


### PR DESCRIPTION
## 관련 이슈

close #17

## 작업 배경

- 작성/수정 페이지에서 표 셀 스타일 버튼/메뉴가 열린 뒤 스크롤하면 viewport 위에 점처럼 남던 잔상을 제거했습니다.
- offscreen table cleanup과 cell-menu 노출 조건을 같이 정리해 stale anchor 좌표가 clamp된 상태로 남지 않도록 맞췄습니다.

## 작업 내용

- `BlockEditorEngine`에서 table floating UI가 viewport 밖으로 나가면 quick rail과 cell menu를 즉시 정리하도록 수정했습니다.
- table menu가 열린 상태에서 scroll/resize가 발생하면 stale 위치를 유지하지 않도록 메뉴를 닫도록 보강했습니다.
- editor authoring E2E에 셀 스타일 버튼/메뉴 scroll 잔상 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "table 셀 스타일 버튼과 메뉴는 스크롤 후 viewport 잔상 없이 정리된다" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table cell selection 상태에서 offscreen 판정이 과하면 셀 스타일 버튼이 너무 빨리 닫힐 수 있습니다.
- 롤백 방법: `38e94476` revert 후 기존 table floating UI 동작으로 복원합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
