### PR TITLE
[Fix] 글 상세 테이블 hover 시 세로 스크롤 잠김

### DIFF
--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -956,6 +956,85 @@ test("상세 normal table metadata는 저장 viewport 폭이 아니라 현재 �
   expect(metrics?.headerWidths[1] || 0).toBeGreaterThan(metrics?.headerWidths[0] || 0)
 })
 
+test("상세 table hover 중 wheel 입력도 page scroll chain을 유지한다", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 })
+
+  const spacerParagraphs = Array.from({ length: 12 }, (_, index) =>
+    `문단 ${index + 1}. 공개 상세 table hover 스크롤 체인이 유지되는지 확인하기 위한 충분히 긴 본문입니다. `.repeat(4).trim()
+  )
+
+  await page.route("**/post/api/v1/posts/468", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: 468,
+        createdAt: "2026-04-17T00:00:00Z",
+        modifiedAt: "2026-04-17T00:00:00Z",
+        authorId: 1,
+        authorName: "관리자",
+        authorUsername: "aquila",
+        authorProfileImageDirectUrl: "/avatar.png",
+        title: "table hover scroll chain 회귀 방지",
+        content: [
+          ...spacerParagraphs.slice(0, 6),
+          [
+            '<!-- aq-table {"overflowMode":"wide","columnWidths":[280,420]} -->',
+            "| 항목 | 설명 |",
+            "| --- | --- |",
+            "| 문제 | table hover 상태에서 세로 스크롤 입력이 page scroll로 이어져야 합니다. |",
+            "| 회귀 방지 | 가로 overflow는 table wrapper가 처리하되, 세로 wheel 입력은 본문 scroll chain을 막지 않습니다. |",
+          ].join("\n"),
+          ...spacerParagraphs.slice(6),
+        ].join("\n\n"),
+        tags: ["테스트태그"],
+        category: [],
+        published: true,
+        listed: true,
+        likesCount: 0,
+        commentsCount: 0,
+        hitCount: 0,
+        actorHasLiked: false,
+        actorCanModify: false,
+        actorCanDelete: false,
+      }),
+    })
+  })
+
+  await page.route("**/post/api/v1/posts/468/hit", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "200-1",
+        msg: "ok",
+        data: { hitCount: 1 },
+      }),
+    })
+  })
+
+  await page.goto("/posts/468")
+  await expect(page.getByText("table hover scroll chain 회귀 방지")).toBeVisible()
+
+  const tableScroll = page.locator(".aq-table-scroll").first()
+  await expect(tableScroll).toBeVisible()
+
+  await page.evaluate(() => {
+    const shell = document.querySelector<HTMLElement>(".aq-table-scroll")
+    if (!shell) return
+    const rect = shell.getBoundingClientRect()
+    const targetTop = window.scrollY + rect.top - Math.round(window.innerHeight * 0.35)
+    window.scrollTo({ top: Math.max(0, targetTop) })
+  })
+
+  await tableScroll.hover()
+  const scrollBeforeWheel = await page.evaluate(() => window.scrollY)
+
+  await page.mouse.wheel(0, 960)
+
+  await expect.poll(async () => page.evaluate(() => window.scrollY)).toBeGreaterThan(scrollBeforeWheel + 120)
+})
+
 test("모바일 상세는 compact 액션과 접이식 목차를 노출한다", async ({ page }) => {
   await page.setViewportSize({ width: 393, height: 852 })
   await page.addInitScript(() => {

--- a/front/src/libs/markdown/components/MarkdownRendererRoot.tsx
+++ b/front/src/libs/markdown/components/MarkdownRendererRoot.tsx
@@ -994,7 +994,7 @@ const MarkdownRendererRoot = styled.div`
     box-shadow: ${tableChrome.shadow};
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-x: contain;
-    overscroll-behavior-y: contain;
+    overscroll-behavior-y: auto;
     touch-action: pan-x;
       `
     }}


### PR DESCRIPTION
## 관련 이슈

close #26

## 작업 배경

- 공개 글 상세에서 커서가 table 위에 올라간 뒤에도 세로 wheel/trackpad 입력이 페이지 scroll chain으로 이어지도록 복구했습니다.
- 동일 증상이 다시 들어오지 않도록 상세 table hover 회귀 케이스를 smoke에 추가했습니다.

## 작업 내용

- `.aq-table-scroll`의 세로 overscroll chaining 차단을 제거해 page scroll이 멈추지 않도록 수정
- 공개 상세 table hover + wheel 동작을 검증하는 Playwright smoke 회귀 테스트 추가
- 로컬 content-rendering brief에 table scroll 계약 메모 동기화

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts -g "상세 table hover 중 wheel 입력도 page scroll chain을 유지한다" --workers=1`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` (2회 연속 통과)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table wrapper의 세로 overscroll 제약을 풀면서 터치/트랙패드에서 가로 scroll 감각이 달라질 수 있습니다.
- 롤백 방법: `aq-table-scroll`의 `overscroll-behavior-y` 변경과 smoke 회귀 케이스를 함께 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
