### PR TITLE
[CI] live E2E admin username secret fallback 지원

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -788,8 +788,10 @@ jobs:
       PLAYWRIGHT_USE_WEBSERVER: "false"
       HOME_SERVER_ENV: ${{ secrets.HOME_SERVER_ENV }}
       E2E_LIVE_ADMIN_EMAIL: ${{ secrets.E2E_LIVE_ADMIN_EMAIL || '' }}
+      E2E_LIVE_ADMIN_USERNAME: ${{ secrets.E2E_LIVE_ADMIN_USERNAME || '' }}
       E2E_LIVE_ADMIN_PASSWORD: ${{ secrets.E2E_LIVE_ADMIN_PASSWORD || '' }}
       E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL || '' }}
+      E2E_ADMIN_USERNAME: ${{ secrets.E2E_ADMIN_USERNAME || '' }}
       E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD || '' }}
 
     steps:
@@ -919,10 +921,14 @@ jobs:
 
           # 라이브 E2E 전용 계정을 우선 사용하고, 없으면 운영 관리자 계정으로 fallback 한다.
           resolved_admin_email="${E2E_LIVE_ADMIN_EMAIL:-}"
+          resolved_admin_username="${E2E_LIVE_ADMIN_USERNAME:-}"
           resolved_admin_password="${E2E_LIVE_ADMIN_PASSWORD:-}"
 
           if [ -z "${resolved_admin_email}" ]; then
             resolved_admin_email="$(extract_admin_from_home_server_env "CUSTOM__E2E__ADMIN__EMAIL")"
+          fi
+          if [ -z "${resolved_admin_username}" ]; then
+            resolved_admin_username="$(extract_admin_from_home_server_env "CUSTOM__E2E__ADMIN__USERNAME")"
           fi
           if [ -z "${resolved_admin_password}" ]; then
             resolved_admin_password="$(extract_admin_from_home_server_env "CUSTOM__E2E__ADMIN__PASSWORD")"
@@ -931,6 +937,9 @@ jobs:
           if [ -z "${resolved_admin_email}" ]; then
             resolved_admin_email="$(extract_admin_from_home_server_env "CUSTOM__ADMIN__EMAIL")"
           fi
+          if [ -z "${resolved_admin_username}" ]; then
+            resolved_admin_username="$(extract_admin_from_home_server_env "CUSTOM__ADMIN__USERNAME")"
+          fi
           if [ -z "${resolved_admin_password}" ]; then
             resolved_admin_password="$(extract_admin_from_home_server_env "CUSTOM__ADMIN__PASSWORD")"
           fi
@@ -938,12 +947,18 @@ jobs:
           if [ -z "${resolved_admin_email}" ]; then
             resolved_admin_email="${E2E_ADMIN_EMAIL:-}"
           fi
+          if [ -z "${resolved_admin_username}" ]; then
+            resolved_admin_username="${E2E_ADMIN_USERNAME:-}"
+          fi
           if [ -z "${resolved_admin_password}" ]; then
             resolved_admin_password="${E2E_ADMIN_PASSWORD:-}"
           fi
 
           if [ -n "${resolved_admin_email}" ]; then
             echo "E2E_ADMIN_EMAIL=${resolved_admin_email}" >> "$GITHUB_ENV"
+          fi
+          if [ -n "${resolved_admin_username}" ]; then
+            echo "E2E_ADMIN_USERNAME=${resolved_admin_username}" >> "$GITHUB_ENV"
           fi
           if [ -n "${resolved_admin_password}" ]; then
             echo "E2E_ADMIN_PASSWORD=${resolved_admin_password}" >> "$GITHUB_ENV"
@@ -953,7 +968,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          [ -n "${E2E_ADMIN_EMAIL}" ] || (echo "E2E_ADMIN_EMAIL is required" && exit 1)
+          [ -n "${E2E_ADMIN_EMAIL:-}" ] || [ -n "${E2E_ADMIN_USERNAME:-}" ] || (echo "E2E_ADMIN_EMAIL or E2E_ADMIN_USERNAME is required" && exit 1)
           [ -n "${E2E_ADMIN_PASSWORD}" ] || (echo "E2E_ADMIN_PASSWORD is required" && exit 1)
 
       - name: Live e2e preflight checks (fail-fast)
@@ -1005,13 +1020,19 @@ jobs:
           probe_login() {
             local attempt="$1"
             local code
+            local login_payload
+            if [ -n "${E2E_ADMIN_EMAIL:-}" ]; then
+              login_payload="{\"email\":\"${E2E_ADMIN_EMAIL}\",\"password\":\"${E2E_ADMIN_PASSWORD}\"}"
+            else
+              login_payload="{\"username\":\"${E2E_ADMIN_USERNAME}\",\"password\":\"${E2E_ADMIN_PASSWORD}\"}"
+            fi
             code="$(
               curl "${curl_args[@]}" \
                 -X POST \
                 -H 'Content-Type: application/json' \
                 -o /dev/null \
                 -w '%{http_code}' \
-                --data "{\"email\":\"${E2E_ADMIN_EMAIL}\",\"password\":\"${E2E_ADMIN_PASSWORD}\"}" \
+                --data "${login_payload}" \
                 "${api_base}/member/api/v1/auth/login" || true
             )"
             echo "[preflight] api-login attempt=${attempt} status=${code}"
@@ -1067,7 +1088,12 @@ jobs:
             echo "[preflight-diagnostic] curl headers /member/api/v1/auth/me"
             curl "${curl_args[@]}" -D - -o /dev/null "${api_base}/member/api/v1/auth/me" || true
             echo "[preflight-diagnostic] curl headers /member/api/v1/auth/login"
-            curl "${curl_args[@]}" -X POST -H 'Content-Type: application/json' -D - -o /dev/null --data "{\"email\":\"${E2E_ADMIN_EMAIL}\",\"password\":\"${E2E_ADMIN_PASSWORD}\"}" "${api_base}/member/api/v1/auth/login" || true
+            if [ -n "${E2E_ADMIN_EMAIL:-}" ]; then
+              login_payload="{\"email\":\"${E2E_ADMIN_EMAIL}\",\"password\":\"${E2E_ADMIN_PASSWORD}\"}"
+            else
+              login_payload="{\"username\":\"${E2E_ADMIN_USERNAME}\",\"password\":\"${E2E_ADMIN_PASSWORD}\"}"
+            fi
+            curl "${curl_args[@]}" -X POST -H 'Content-Type: application/json' -D - -o /dev/null --data "${login_payload}" "${api_base}/member/api/v1/auth/login" || true
             exit 1
           fi
 


### PR DESCRIPTION
## 관련 이슈

close #28

## 작업 배경

- 자동 배포 workflow의 live E2E credential resolution에 `E2E_ADMIN_USERNAME` fallback을 추가했습니다.
- `E2E_ADMIN_EMAIL`이 없어도 `E2E_ADMIN_USERNAME` + `E2E_ADMIN_PASSWORD` 조합으로 preflight/login 진단과 live E2E가 계속 동작합니다.

## 작업 내용

- `.github/workflows/deploy.yml`에 `E2E_ADMIN_USERNAME` secret 주입과 username resolution을 추가했습니다.
- secret 검증 단계가 `E2E_ADMIN_EMAIL` 또는 `E2E_ADMIN_USERNAME` 둘 중 하나를 허용하도록 바뀌었습니다.
- preflight/login diagnostic payload가 email-only가 아니라 username fallback을 사용하도록 바뀌었습니다.

## 검증

- 실행한 명령과 결과:
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml")'` x2
  - `git diff --check` x2
  - `rg -n 'E2E_ADMIN_USERNAME|resolved_admin_username|E2E_ADMIN_EMAIL or E2E_ADMIN_USERNAME|"username":"\$\{E2E_ADMIN_USERNAME\}"' .github/workflows/deploy.yml` x2

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: live E2E credential resolution 우선순위가 바뀌므로 email과 username이 동시에 있을 때는 email이 계속 우선됩니다.
- 롤백 방법: commit `773aaf72`를 revert하면 기존 email-only 동작으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
