### PR TITLE
[Fix] about 자기소개 문구 개행 복구

### DIFF
--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -144,6 +144,32 @@ test("홈 피드 기본 UI가 렌더링된다", async ({ page }) => {
   expect(sidebarStyles.contact?.borderBottomWidth).toBe("1px")
 })
 
+test("about 자기소개 문구는 작성 개행을 유지하는 white-space 계약을 가진다", async ({ page }) => {
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({ resultCode: "401-1", msg: "unauthorized" }),
+    })
+  })
+
+  await page.goto("/about")
+  await expect(page.getByRole("heading", { level: 1, name: "About Me" })).toBeVisible()
+
+  const profileBioStyle = await page.locator(".profile-bio").evaluate((element) => {
+    const styles = window.getComputedStyle(element as HTMLElement)
+    return {
+      whiteSpace: styles.whiteSpace,
+      lineHeight: styles.lineHeight,
+      text: element.textContent || "",
+    }
+  })
+
+  expect(profileBioStyle.whiteSpace).toBe("pre-line")
+  expect(profileBioStyle.lineHeight).not.toBe("normal")
+  expect(profileBioStyle.text.length).toBeGreaterThan(0)
+})
+
 test("홈 새로고침 이후에도 레거시 기본 문구로 되돌아가지 않는다", async ({ page }) => {
   await mockFeedEndpoints(page)
 

--- a/front/src/pages/about.tsx
+++ b/front/src/pages/about.tsx
@@ -281,6 +281,7 @@ const StyledWrapper = styled.div`
         color: ${({ theme }) => theme.colors.gray11};
         max-width: 600px;
         margin: 0;
+        white-space: pre-line;
       }
 
       .about-detail-sections {


### PR DESCRIPTION
## 관련 이슈

close #34

## 작업 배경

- about 페이지 자기소개 문구가 plain `<p>`로 렌더될 때 기본 `white-space: normal` 때문에 작성 개행이 공백으로 접히던 회귀를 복구합니다.
- `.profile-bio`에 개행 보존 계약을 추가하고, `/about` 회귀 가드를 smoke 테스트에 보강했습니다.

## 작업 내용

- `front/src/pages/about.tsx`의 `.profile-bio`에 `white-space: pre-line`을 추가했습니다.
- `front/e2e/smoke.spec.ts`에 `/about` 자기소개 white-space 계약 검증을 추가했습니다.
- 로컬 content-rendering brief/plan에도 동일 계약을 반영했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` (2회 연속 통과)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: `white-space: pre-line` 적용 범위가 자기소개 문구 전체라 연속 공백 처리 방식이 기존과 달라질 수 있습니다.
- 롤백 방법: `.profile-bio`의 `white-space: pre-line`과 about smoke 회귀 테스트를 함께 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
