### PR TITLE
[Fix] 글 수정 후 공개 상세 즉시 반영 복구

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -220,6 +220,19 @@ test.describe("editor studio state", () => {
     expect(editorStudioRoutingSource).not.toContain("void pushRoute(router, dedicatedEditorReturnRoute)")
   })
 
+  test("공개 글 저장 후 상세 재검증은 client cache eviction과 서버 revalidate를 함께 수행한다", () => {
+    const editorStudioSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/EditorStudioPage.tsx"), "utf8")
+    const revalidateApiSource = readFileSync(path.resolve(__dirname, "../src/pages/api/revalidate.ts"), "utf8")
+
+    expect(editorStudioSource).toContain("await invalidatePublicPostReadCaches(queryClient, resolvedPostId || undefined)")
+    expect(editorStudioSource).toContain('const revalidateResponse = await fetch("/api/revalidate", {')
+    expect(editorStudioSource).toContain("paths: [toCanonicalPostPath(resolvedPostId)]")
+    expect(revalidateApiSource).toContain('import { invalidatePublicPostReadCaches } from "src/apis/backend/posts"')
+    expect(revalidateApiSource).toContain('import { fetchServerAdminSession } from "src/libs/server/authSession"')
+    expect(revalidateApiSource).toContain("await invalidatePublicPostReadCaches()")
+    expect(revalidateApiSource).toContain("Invalid token or admin session required")
+  })
+
   test("table resize metadata와 상세 렌더 계약은 colgroup width와 drag guide를 유지한다", () => {
     const blockEditorEngineSource = readFileSync(
       path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tsx"),

--- a/front/src/pages/api/revalidate.ts
+++ b/front/src/pages/api/revalidate.ts
@@ -1,8 +1,10 @@
 import { NextApiRequest, NextApiResponse } from "next"
 import { getPosts } from "../../apis"
+import { invalidatePublicPostReadCaches } from "src/apis/backend/posts"
+import { fetchServerAdminSession } from "src/libs/server/authSession"
 
 // Revalidate endpoint (POST only)
-// - token: x-revalidate-token header only
+// - token: x-revalidate-token header only, or authenticated admin session
 // - path: JSON body { path: "/target" } (or ?path=... fallback)
 export default async function handler(
   req: NextApiRequest,
@@ -14,17 +16,16 @@ export default async function handler(
   }
 
   const expectedSecret = process.env.TOKEN_FOR_REVALIDATE
-  if (!expectedSecret) {
-    return res.status(500).json({ message: "Missing revalidate token on server" })
-  }
-
   const headerSecret =
     typeof req.headers["x-revalidate-token"] === "string"
       ? req.headers["x-revalidate-token"]
       : ""
+  const hasValidSecret = Boolean(expectedSecret) && headerSecret === expectedSecret
+  const adminSession = hasValidSecret ? null : await fetchServerAdminSession(req)
+  const isAdminRequest = adminSession?.isAdmin === true
 
-  if (headerSecret !== expectedSecret) {
-    return res.status(401).json({ message: "Invalid token" })
+  if (!hasValidSecret && !isAdminRequest) {
+    return res.status(401).json({ message: "Invalid token or admin session required" })
   }
 
   const pathFromQuery = typeof req.query.path === "string" ? req.query.path : ""
@@ -36,6 +37,8 @@ export default async function handler(
   const targetPaths = [pathFromBody || pathFromQuery, ...pathsFromBody].filter((value) => value.trim().length > 0)
 
   try {
+    await invalidatePublicPostReadCaches()
+
     let paths: string[] = []
 
     if (targetPaths.length > 0) {

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -1489,6 +1489,23 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
           : postId.trim()
 
     await invalidatePublicPostReadCaches(queryClient, resolvedPostId || undefined)
+    if (!resolvedPostId) return
+
+    const revalidateResponse = await fetch("/api/revalidate", {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        paths: [toCanonicalPostPath(resolvedPostId)],
+      }),
+    })
+
+    if (!revalidateResponse.ok) {
+      const reason = (await revalidateResponse.text().catch(() => "")).trim()
+      throw new Error(reason || "공개 상세 재검증 요청에 실패했습니다.")
+    }
   }, [postId, queryClient])
 
   const refreshAdminProfile = useCallback(async (memberId: number, fallback?: MemberMe) => {


### PR DESCRIPTION
## 관련 이슈

close #36

## 작업 배경

- 관리자에서 공개 글을 수정해도 `/posts/[id]` 상세가 ISR/SSR 캐시 때문에 이전 내용을 계속 보여주던 문제를 복구합니다.
- 저장 성공 직후 클라이언트 public read cache eviction과 서버 revalidate/cache clear를 같은 경로에서 수행해 상세가 즉시 최신 본문을 반영하도록 맞췄습니다.

## 작업 내용

- 관리자 저장 후처리에서 `/api/revalidate`를 호출해 canonical 상세 경로를 즉시 재검증하도록 연결했습니다.
- revalidate API가 관리자 세션으로도 호출되도록 열고, 실행 전에 서버 public post detail cache를 함께 비우도록 보강했습니다.
- 저장 후 상세 재검증 계약이 다시 빠지지 않도록 source-level Playwright 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: `/api/revalidate` 호출 실패 시 저장 성공 이후 후처리 단계에서 사용자에게 실패로 보일 수 있습니다.
- 롤백 방법: 관리자 저장 후처리의 revalidate 호출과 API 세션 허용/cache clear 변경을 이전 상태로 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
