### PR TITLE
[Fix] 관리자 글 상세 새로고침 액션 플리커 복구

### DIFF
--- a/front/e2e/header-refresh-auth.spec.ts
+++ b/front/e2e/header-refresh-auth.spec.ts
@@ -31,6 +31,28 @@ const createExplorePage = (title: string) => ({
   },
 })
 
+const createPostDetail = () => ({
+  id: 101,
+  createdAt: "2026-03-16T00:00:00Z",
+  modifiedAt: "2026-03-16T00:00:00Z",
+  authorId: 1,
+  authorName: "관리자",
+  authorUsername: "aquila",
+  authorProfileImageDirectUrl: "/avatar.png",
+  title: "관리자 상세 액션 회귀",
+  content: "본문",
+  tags: ["테스트태그"],
+  category: ["백엔드"],
+  published: true,
+  listed: true,
+  likesCount: 0,
+  commentsCount: 0,
+  hitCount: 0,
+  actorHasLiked: false,
+  actorCanModify: false,
+  actorCanDelete: false,
+})
+
 const mockFeedEndpoints = async (page: Page) => {
   await page.route("**/post/api/v1/posts/feed**", async (route) => {
     await route.fulfill({
@@ -164,4 +186,63 @@ test("인증 snapshot이 있으면 delayed auth probe 동안에도 Admin/Logout�
   await expect(page.getByRole("button", { name: "Logout", exact: true })).toBeVisible()
   const authenticatedGapAfterProbe = await measureHeaderActionGap(page, "authenticated")
   expect(authenticatedGapAfterProbe.gap).toBeLessThanOrEqual(120)
+})
+
+test("인증 snapshot이 있으면 delayed auth probe 동안에도 글 상세 수정/삭제 버튼이 유지된다", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1800, height: 900 })
+  await page.addInitScript(
+    ({ storageKey }) => {
+      window.sessionStorage.setItem(
+        storageKey,
+        JSON.stringify({ authenticated: true, admin: true })
+      )
+    },
+    { storageKey: HEADER_AUTH_SHELL_STORAGE_KEY }
+  )
+
+  await page.route("**/post/api/v1/posts/101", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(createPostDetail()),
+    })
+  })
+
+  await page.route("**/post/api/v1/posts/101/hit", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "200-1",
+        msg: "ok",
+        data: { hitCount: 1 },
+      }),
+    })
+  })
+
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await wait(1500)
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: 1,
+        username: "aquila",
+        nickname: "관리자",
+        isAdmin: true,
+      }),
+    })
+  })
+
+  await page.goto("/posts/101", { waitUntil: "domcontentloaded" })
+  const editButton = page.getByRole("button", { name: "수정" }).first()
+  const deleteButton = page.getByRole("button", { name: "삭제" }).first()
+
+  await expect(editButton).toBeVisible()
+  await expect(deleteButton).toBeVisible()
+  await page.waitForTimeout(300)
+  await expect(editButton).toBeVisible()
+  await expect(deleteButton).toBeVisible()
 })

--- a/front/src/routes/Detail/PostDetail/PostHeader.tsx
+++ b/front/src/routes/Detail/PostDetail/PostHeader.tsx
@@ -5,6 +5,7 @@ import { CONFIG } from "site.config"
 import AppIcon from "src/components/icons/AppIcon"
 import ProfileImage from "src/components/ProfileImage"
 import Tag from "src/components/Tag"
+import { HEADER_AUTH_ADMIN_ATTR } from "src/libs/headerAuthShell"
 import { formatDateTime } from "src/libs/utils"
 import {
   parseThumbnailFocusXFromUrl,
@@ -28,6 +29,7 @@ type Props = {
   onSharePost?: () => void
   showModifyAction?: boolean
   showDeleteAction?: boolean
+  useAdminShellFallback?: boolean
   adminActionPending?: boolean
   onEditPost?: () => void
   onDeletePost?: () => void
@@ -50,6 +52,7 @@ const PostHeader: React.FC<Props> = ({
   onSharePost,
   showModifyAction = false,
   showDeleteAction = false,
+  useAdminShellFallback = false,
   adminActionPending = false,
   onEditPost,
   onDeletePost,
@@ -69,6 +72,11 @@ const PostHeader: React.FC<Props> = ({
   const thumbnailFocusX = parseThumbnailFocusXFromUrl(data.thumbnail || "")
   const thumbnailFocusY = parseThumbnailFocusYFromUrl(data.thumbnail || "")
   const thumbnailZoom = parseThumbnailZoomFromUrl(data.thumbnail || "")
+  const shellModifyFallback = useAdminShellFallback && Boolean(onEditPost) && !showModifyAction
+  const shellDeleteFallback = useAdminShellFallback && Boolean(onDeletePost) && !showDeleteAction
+  const shouldRenderAuthorUtilities =
+    showModifyAction || showDeleteAction || shellModifyFallback || shellDeleteFallback
+  const authorUtilitiesShellOnly = !showModifyAction && !showDeleteAction && (shellModifyFallback || shellDeleteFallback)
   const shareFeedbackMessage =
     shareFeedback === "failed"
       ? "공유에 실패했습니다."
@@ -123,16 +131,28 @@ const PostHeader: React.FC<Props> = ({
                   <span>조회 {hitCount ?? data.hitCount ?? 0}</span>
                 </span>
               </div>
-              {(showModifyAction || showDeleteAction) && (
-                <div className="authorUtilities">
-                  {showModifyAction && (
-                    <button type="button" className="adminButton" onClick={onEditPost} disabled={adminActionPending}>
+              {shouldRenderAuthorUtilities && (
+                <div className="authorUtilities" data-shell-only={authorUtilitiesShellOnly ? "true" : "false"}>
+                  {(showModifyAction || shellModifyFallback) && (
+                    <button
+                      type="button"
+                      className="adminButton"
+                      data-shell-fallback={shellModifyFallback ? "true" : "false"}
+                      onClick={onEditPost}
+                      disabled={adminActionPending}
+                    >
                       <AppIcon name="edit" />
                       <span>수정</span>
                     </button>
                   )}
-                  {showDeleteAction && (
-                    <button type="button" className="adminButton dangerButton" onClick={onDeletePost} disabled={adminActionPending}>
+                  {(showDeleteAction || shellDeleteFallback) && (
+                    <button
+                      type="button"
+                      className="adminButton dangerButton"
+                      data-shell-fallback={shellDeleteFallback ? "true" : "false"}
+                      onClick={onDeletePost}
+                      disabled={adminActionPending}
+                    >
                       <AppIcon name="trash" />
                       <span>{adminActionPending ? "삭제 중..." : "삭제"}</span>
                     </button>
@@ -344,6 +364,14 @@ const StyledWrapper = styled.header`
     margin-top: 0.5rem;
   }
 
+  .authorUtilities[data-shell-only="true"] {
+    display: none;
+  }
+
+  html[${HEADER_AUTH_ADMIN_ATTR}="true"] & .authorUtilities[data-shell-only="true"] {
+    display: inline-flex;
+  }
+
   .actions {
     display: inline-flex;
     align-items: center;
@@ -397,6 +425,14 @@ const StyledWrapper = styled.header`
       opacity: 0.72;
       cursor: not-allowed;
     }
+  }
+
+  .adminButton[data-shell-fallback="true"] {
+    display: none;
+  }
+
+  html[${HEADER_AUTH_ADMIN_ATTR}="true"] & .adminButton[data-shell-fallback="true"] {
+    display: inline-flex;
   }
 
   .dangerButton {

--- a/front/src/routes/Detail/PostDetail/index.tsx
+++ b/front/src/routes/Detail/PostDetail/index.tsx
@@ -12,6 +12,7 @@ import { ApiError, apiFetch } from "src/apis/backend/client"
 import { getExplorePostsPage, getRelatedPostsByAuthor } from "src/apis/backend/posts"
 import { queryKey } from "src/constants/queryKey"
 import { pushRoute, replaceRoute, toLoginPath } from "src/libs/router"
+import { readHeaderAuthShellSnapshot } from "src/libs/headerAuthShell"
 import { formatDate } from "src/libs/utils"
 import { toCanonicalPostPath } from "src/libs/utils/postPath"
 import { PostDetail as PostDetailType, TPostComment } from "src/types"
@@ -210,7 +211,7 @@ const PostDetail: React.FC<Props> = ({ initialComments = null }) => {
   const { post: data } = usePostQuery()
   const router = useRouter()
   const queryClient = useQueryClient()
-  const { me } = useAuthSession()
+  const { me, authStatus } = useAuthSession()
   const postId = data?.id ?? ""
   const detailId = data?.id
   const didIncrementHitRef = useRef<string | null>(null)
@@ -271,8 +272,10 @@ const PostDetail: React.FC<Props> = ({ initialComments = null }) => {
     const next = router.asPath || toCanonicalPostPath(postId)
     return toLoginPath(next, toCanonicalPostPath(postId))
   }, [postId, router.asPath])
-  const canModifyPost = Boolean(me?.isAdmin || data?.actorCanModify)
-  const canDeletePost = Boolean(me?.isAdmin || data?.actorCanDelete)
+  const [authShellSnapshot] = useState(() => readHeaderAuthShellSnapshot())
+  const shellAdmin = authStatus === "loading" ? authShellSnapshot?.admin === true : Boolean(me?.isAdmin)
+  const canModifyPost = Boolean(shellAdmin || data?.actorCanModify)
+  const canDeletePost = Boolean(shellAdmin || data?.actorCanDelete)
   const showFloatingLike = data?.type[0] === "Post"
   const hasDepth4Toc = useMemo(() => tocItems.some((item) => item.level === 4), [tocItems])
   const visibleTocItems = useMemo(
@@ -1118,6 +1121,7 @@ const PostDetail: React.FC<Props> = ({ initialComments = null }) => {
                 onSharePost={handleSharePost}
                 showModifyAction={canModifyPost}
                 showDeleteAction={canDeletePost}
+                useAdminShellFallback
                 adminActionPending={adminActionPending}
                 onEditPost={handleEditPost}
                 onDeletePost={handleDeletePost}


### PR DESCRIPTION
## 관련 이슈

close #38

## 작업 배경

- 관리자 로그인 상태에서 공개 글 상세(`/posts/[id]`)를 새로고침할 때 수정/삭제 버튼이 익명 기준으로 숨겨졌다가 다시 나타나는 플리커를 복구했습니다.
- 정적 상세 payload와 delayed auth probe 사이의 시간차를 header auth shell snapshot으로 메워 첫 화면에서도 액션이 유지되도록 맞췄습니다.

## 작업 내용

- `front/src/routes/Detail/PostDetail/index.tsx`에서 auth loading 구간에도 관리자 shell snapshot을 권한 판정에 반영했습니다.
- `front/src/routes/Detail/PostDetail/PostHeader.tsx`에 shell fallback 액션 슬롯을 추가해 pre-paint admin attr이 있으면 수정/삭제 버튼이 첫 페인트부터 유지되도록 했습니다.
- `front/e2e/header-refresh-auth.spec.ts`에 글 상세 액션 회귀를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front build` x2
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front test:e2e --grep "인증 snapshot이 있으면 delayed auth probe 동안에도 글 상세 수정/삭제 버튼이 유지된다"` x2
  - `yarn --cwd front test:e2e:smoke` x2
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: header auth shell snapshot이 stale 하면 공개 상세 액션이 잠깐 잘못 보일 수 있지만, logout/anonymous 갱신 후에는 즉시 다시 숨겨집니다.
- 롤백 방법: commit `f2992626`을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
