### PR TITLE
[Fix] front CodeQL alert 정리

### DIFF
--- a/front/scripts/with-test-lock.mjs
+++ b/front/scripts/with-test-lock.mjs
@@ -25,6 +25,34 @@ const readOwnerInfo = (ownerPath) => {
   }
 }
 
+const ensurePrivateDir = (dirPath) => {
+  fs.mkdirSync(dirPath, { recursive: true, mode: 0o700 })
+  try {
+    fs.chmodSync(dirPath, 0o700)
+  } catch {
+    // ignore chmod failures on unsupported platforms/filesystems
+  }
+}
+
+const writeOwnerInfoSecurely = (targetPath, value) => {
+  const exclusiveFlags =
+    fs.constants.O_WRONLY |
+    fs.constants.O_CREAT |
+    fs.constants.O_EXCL |
+    (typeof fs.constants.O_NOFOLLOW === "number" ? fs.constants.O_NOFOLLOW : 0)
+
+  let fd
+  try {
+    fd = fs.openSync(targetPath, exclusiveFlags, 0o600)
+    fs.writeFileSync(fd, JSON.stringify(value, null, 2), "utf8")
+    fs.fsyncSync(fd)
+  } finally {
+    if (typeof fd === "number") {
+      fs.closeSync(fd)
+    }
+  }
+}
+
 const isPidAlive = (pid) => {
   if (!Number.isInteger(pid) || pid <= 0) return false
   try {
@@ -163,14 +191,24 @@ for (const signal of signals) {
 const acquireLock = async () => {
   if (reentrant) return
 
-  fs.mkdirSync(lockRoot, { recursive: true })
+  ensurePrivateDir(lockRoot)
   const waitStartedAt = Date.now()
   let lastOwnerSignature = ""
 
   while (true) {
     try {
-      fs.mkdirSync(lockDir)
-      fs.writeFileSync(ownerPath, JSON.stringify(ownerInfo, null, 2))
+      fs.mkdirSync(lockDir, { mode: 0o700 })
+      try {
+        fs.chmodSync(lockDir, 0o700)
+      } catch {
+        // ignore chmod failures on unsupported platforms/filesystems
+      }
+      try {
+        writeOwnerInfoSecurely(ownerPath, ownerInfo)
+      } catch (error) {
+        fs.rmSync(lockDir, { recursive: true, force: true })
+        throw error
+      }
       lockAcquired = true
       console.error(`[test-lock] acquired ${safeResource} (${runLabel})`)
       return

--- a/front/src/pages/admin/profile.tsx
+++ b/front/src/pages/admin/profile.tsx
@@ -2321,12 +2321,6 @@ const FieldLabel = styled.label`
   font-weight: 800;
 `
 
-const FieldHint = styled.span`
-  color: ${({ theme }) => theme.colors.gray9};
-  font-size: 0.76rem;
-  line-height: 1.45;
-`
-
 const Input = styled.input`
   width: 100%;
   min-height: 42px;

--- a/front/src/pages/admin/tools.tsx
+++ b/front/src/pages/admin/tools.tsx
@@ -537,13 +537,6 @@ const SECTION_IDS = {
 
 type SectionKey = keyof typeof SECTION_IDS
 
-const DIAGNOSTIC_TAB_LABELS: Record<DiagnosticTab, string> = {
-  mail: "메일 진단",
-  queue: "작업 큐 진단",
-  cleanup: "파일 정리 진단",
-  auth: "인증 보안 기록",
-}
-
 const isExecutionResultFilter = (value: string): value is ExecutionResultFilter =>
   value === "all" || value === "success" || value === "error" || value === "stale"
 
@@ -1072,7 +1065,6 @@ const AdminToolsPage: NextPage<AdminToolsPageProps> = ({ initialMember, initialS
   }, [filteredExecutions, selectedExecutionId])
 
   const systemHealthStatus = systemHealthQuery.data?.status || "UNKNOWN"
-  const systemHealthFreshness = getFreshnessMeta(systemHealthCheckedAt, freshnessClock)
   const mailFreshness = getFreshnessMeta(mailDiagnostics?.checkedAt ?? null, freshnessClock)
   const taskQueueFreshness = getFreshnessMeta(taskQueueCheckedAt, freshnessClock)
   const cleanupFreshness = getFreshnessMeta(cleanupCheckedAt, freshnessClock)
@@ -2321,16 +2313,6 @@ const WorkspaceSection = styled.section`
   }
 `
 
-const MonitoringLinkRail = styled.div`
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.65rem;
-
-  @media (max-width: 960px) {
-    grid-template-columns: 1fr;
-  }
-`
-
 const ObservabilityNotice = styled.p`
   margin: 0;
   color: ${({ theme }) => theme.colors.gray10};
@@ -2341,27 +2323,6 @@ const ObservabilityNotice = styled.p`
     color: ${({ theme }) => theme.colors.gray12};
     font-weight: 820;
   }
-`
-
-const DashboardShortcutRow = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-`
-
-const DashboardShortcutLink = styled.a`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 36px;
-  padding: 0 0.9rem;
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray1};
-  color: ${({ theme }) => theme.colors.gray12};
-  text-decoration: none;
-  font-size: 0.8rem;
-  font-weight: 800;
 `
 
 const SectionHeading = styled(AdminSectionHeading)`


### PR DESCRIPTION
## 관련 이슈

close #40

## 작업 배경

- `front/scripts/with-test-lock.mjs`의 owner 파일 생성을 exclusive open/write/close 경로로 바꿔 CodeQL의 insecure temporary file alert를 줄였습니다.
- `front/src/pages/admin/profile.tsx`, `front/src/pages/admin/tools.tsx`에 남아 있던 unused 선언 7건을 제거했습니다.

## 작업 내용

- `with-test-lock.mjs`에 private dir 보정과 secure owner file write helper를 추가했습니다.
- admin profile의 미사용 `FieldHint` styled component를 삭제했습니다.
- admin tools의 미사용 상수/파생값/styled component를 삭제했습니다.

## 검증

- 실행한 명령과 결과:
  - `node front/scripts/with-test-lock.mjs --resource codeql-smoke --label smoke -- /usr/bin/env true` x2
  - `yarn --cwd front build` x2
  - `git diff --check`
  - `rg -n "FieldHint\b|DIAGNOSTIC_TAB_LABELS|systemHealthFreshness|MonitoringLinkRail|DashboardShortcutRow|DashboardShortcutLink" front/src/pages/admin -g '*.tsx'` (no match)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: test lock owner 파일 생성 플래그가 POSIX 계열 의존성을 일부 사용하므로 비지원 파일시스템에서는 chmod/no-follow 보정이 best-effort로만 동작합니다.
- 롤백 방법: commits `3adc789d`, `82b0ffee`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
