### PR TITLE
[Fix] 공개 상세 텍스트 선택 툴바 scroll 고정 회귀 복구

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -622,6 +622,58 @@ test.describe("block editor authoring flow", () => {
     await expect(textBubbleToolbar).toBeVisible()
   })
 
+  test("공개 상세 텍스트 선택 툴바가 scroll 동안 stale viewport 좌표에 고정되지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 })
+    const markdown = Array.from({ length: 18 }, (_, index) =>
+      index === 11
+        ? "스크롤 중에도 버블앵커가 본문 selection을 따라가야 한다."
+        : `긴 본문 ${index + 1}. 버블 툴바 scroll anchor 회귀를 확인하기 위한 충분히 긴 문단입니다. `.repeat(3).trim()
+    ).join("\n\n")
+    const seed = encodeURIComponent(markdown.replace(/\n/g, "\\n"))
+
+    await page.goto(`${QA_ENGINE_ROUTE}&seed=${seed}`)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.evaluate((element, targetWord) => {
+      const root = element as HTMLElement
+      const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+      while (walker.nextNode()) {
+        const current = walker.currentNode as Text
+        if (!current.data.includes(targetWord)) continue
+        ;(current.parentElement || root).scrollIntoView({ block: "center" })
+        return
+      }
+      throw new Error(`could not find target word: ${targetWord}`)
+    }, "버블앵커")
+
+    await selectWordInEditable(page, editor, "버블앵커")
+    const textBubbleToolbar = page.getByTestId("editor-text-bubble-toolbar")
+    if ((await textBubbleToolbar.count()) === 0) {
+      await selectWordInEditable(page, editor, "버블앵커")
+    }
+    await expect(textBubbleToolbar).toBeVisible()
+
+    const beforeScrollBox = await textBubbleToolbar.boundingBox()
+    if (!beforeScrollBox) {
+      throw new Error("text bubble toolbar metrics are missing before scroll")
+    }
+
+    await page.evaluate(() => {
+      window.scrollBy(0, 180)
+    })
+    await page.waitForTimeout(120)
+
+    await expect(textBubbleToolbar).toBeVisible()
+    const afterScrollBox = await textBubbleToolbar.boundingBox()
+    if (!afterScrollBox) {
+      throw new Error("text bubble toolbar metrics are missing after scroll")
+    }
+
+    expect(Math.abs(afterScrollBox.y - beforeScrollBox.y)).toBeGreaterThan(40)
+  })
+
   test("코드 블록은 작성 surface에서도 Prism 하이라이트 토큰을 렌더한다", async ({ page }) => {
     await page.goto(QA_ENGINE_ROUTE)
 

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -5789,6 +5789,8 @@ const BlockEditorEngine = ({
     document.addEventListener("selectionchange", handleDocumentSelectionChange)
     document.addEventListener("pointerdown", handleEditorPointerDownCapture, true)
     document.addEventListener("mousedown", handleEditorMouseDownCapture, true)
+    window.addEventListener("scroll", scheduleSyncBubble, { capture: true, passive: true })
+    window.addEventListener("resize", scheduleSyncBubble, { passive: true })
     window.addEventListener("pointerup", handleWindowPointerUp, true)
     window.addEventListener("pointercancel", handleWindowPointerUp, true)
     return () => {
@@ -5797,6 +5799,8 @@ const BlockEditorEngine = ({
       document.removeEventListener("selectionchange", handleDocumentSelectionChange)
       document.removeEventListener("pointerdown", handleEditorPointerDownCapture, true)
       document.removeEventListener("mousedown", handleEditorMouseDownCapture, true)
+      window.removeEventListener("scroll", scheduleSyncBubble, true)
+      window.removeEventListener("resize", scheduleSyncBubble)
       window.removeEventListener("pointerup", handleWindowPointerUp, true)
       window.removeEventListener("pointercancel", handleWindowPointerUp, true)
       if (rafId !== null && typeof window !== "undefined") {


### PR DESCRIPTION
## 관련 이슈

close #42

## 작업 배경

- 공개 상세에서 텍스트 선택 툴바가 스크롤 뒤에도 같은 viewport 좌표에 남는 회귀를 복구했습니다.
- 선택 툴바를 소유한 shared `BlockEditorEngine`에 viewport `scroll/resize` 재동기화를 추가하고, 같은 회귀를 막는 E2E를 넣었습니다.

## 작업 내용

- `BlockEditorEngine`의 text/image bubble toolbar가 `selectionchange/pointerup`뿐 아니라 `scroll/resize`에도 anchor를 다시 계산하도록 수정했습니다.
- QA engine route에서 긴 본문을 seed로 주입한 뒤 선택 툴바를 띄우고 스크롤해도 stale viewport 좌표에 고정되지 않는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front build`
  - `yarn --cwd front build`
  - `yarn --cwd front test:e2e --grep "공개 상세 텍스트 선택 툴바가 scroll 동안 stale viewport 좌표에 고정되지 않는다"`
  - `yarn --cwd front test:e2e --grep "공개 상세 텍스트 선택 툴바가 scroll 동안 stale viewport 좌표에 고정되지 않는다"`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front test:e2e:smoke`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: bubble toolbar가 scroll/resize 때 더 자주 재계산되므로 editor selection overlay와 간섭하는지 추가 관찰이 필요합니다.
- 롤백 방법: `fix/detail` commit(`64a688c9`)을 revert해 bubble viewport sync listener와 회귀 테스트를 함께 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
