### PR TITLE
[Fix] 작성/수정 selection rail 세로선 제거

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -587,6 +587,14 @@ test.describe("block editor authoring flow", () => {
       await selectWordInEditable(page, editor, "노출")
     }
     await expect(page.getByTestId("editor-text-bubble-toolbar")).toBeVisible()
+    await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => document.querySelectorAll(".aq-block-editor__content > *[data-block-selected='true']").length
+        )
+      )
+      .toBe(0)
 
     await page.keyboard.press("Enter")
     await page.getByRole("button", { name: "콜아웃" }).click()
@@ -599,6 +607,14 @@ test.describe("block editor authoring flow", () => {
       await selectWordInEditable(page, calloutBodyContent, "버블")
     }
     await expect(page.getByTestId("editor-text-bubble-toolbar")).toBeVisible()
+    await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => document.querySelectorAll(".aq-block-editor__content > *[data-block-selected='true']").length
+        )
+      )
+      .toBe(0)
   })
 
   test("writer surface에서는 마우스 드래그 선택 중 버블을 숨기고 mouseup 이후에만 노출한다", async ({

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -5250,6 +5250,10 @@ const BlockEditorEngine = ({
       const selection = editor.state.selection as typeof editor.state.selection & {
         node?: { isBlock?: boolean }
       }
+      const hasTextRangeSelection = selection instanceof TextSelection && !selection.empty
+      if (hasTextRangeSelection && keyboardBlockSelectionStickyRef.current) {
+        keyboardBlockSelectionStickyRef.current = false
+      }
       const nextBlockIndex = getTopLevelBlockIndexFromSelection(editor)
       const isTopLevelBlockNodeSelection = Boolean(
         selection instanceof NodeSelection && selection.$from.depth === 0 && selection.node?.isBlock
@@ -5262,6 +5266,11 @@ const BlockEditorEngine = ({
       selectionUiSignatureRef.current = nextSignature
       setSelectionTick((prev) => prev + 1)
       setSelectedBlockIndex(nextBlockIndex)
+      if (hasTextRangeSelection) {
+        setClickedBlockIndex(null)
+        setSelectedBlockNodeIndex(null)
+        return
+      }
       if (isTopLevelBlockNodeSelection) {
         if (keyboardBlockSelectionStickyRef.current) {
           setClickedBlockIndex(null)


### PR DESCRIPTION
## 관련 이슈

close #44

## 작업 배경

- 글 작성/수정 surface에서 텍스트 선택 버블이 뜰 때 stale top-level block selection이 같이 남아 양측 세로 rail처럼 보이던 회귀를 제거했습니다.
- text range selection으로 전환되면 writer surface의 block selection overlay와 `data-block-selected` 상태를 즉시 해제하도록 정리했습니다.

## 작업 내용

- `BlockEditorEngine` selection update에서 `TextSelection`이 활성화되면 sticky block selection과 선택된 top-level block 인덱스를 즉시 해제하도록 수정했습니다.
- writer authoring E2E에 selection bubble visible 동안 `keyboard-block-selection-overlay`와 `data-block-selected` 블록이 남지 않는 회귀 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-selection-rails bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1 --grep "table 구조 메뉴는 폭 정책과 삭제만 담는 compact popover를 유지한다"`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front build`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table/node selection 경로에서 text range selection과 block selection 전환 타이밍이 엇갈리면 block selection affordance가 늦게 복귀할 수 있습니다.
- 롤백 방법: `fix(editor): writer surface selection rail 세로선을 제거한다` 커밋을 revert해 기존 selection 상태 전환으로 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
