### PR TITLE
[Fix] 에디터 리스트 단계/묶음 블록 분리 동작

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -885,6 +885,93 @@ test.describe("block editor authoring flow", () => {
       .toBe("")
   })
 
+  test("리스트 항목 안의 Tab/Shift+Tab은 Notion처럼 단계 승강으로 동작한다", async ({ page }) => {
+    await page.goto(QA_ENGINE_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    const blockSelectionOverlay = page.getByTestId("keyboard-block-selection-overlay")
+    await editor.click()
+    await page.getByRole("button", { name: "목록" }).first().click()
+    await page.keyboard.type("1단계")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("2단계")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("3단계")
+
+    await editor.locator("li", { hasText: "2단계" }).first().click()
+    await page.keyboard.press("Tab")
+    await editor.locator("li", { hasText: "3단계" }).first().click()
+    await page.keyboard.press("Tab")
+    await page.keyboard.press("Tab")
+    await expect(blockSelectionOverlay).toHaveCount(0)
+    const countOwnLabel = (label: string) =>
+      page.evaluate((targetLabel) => {
+        const readOwnLabel = (item: HTMLElement) =>
+          Array.from(item.childNodes)
+            .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+            .map((node) => node.textContent || "")
+            .join(" ")
+            .replace(/\s+/g, " ")
+            .trim()
+        return Array.from(
+          document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+        ).filter((item) => readOwnLabel(item) === targetLabel).length
+      }, label)
+    await expect.poll(() => countOwnLabel("1단계")).toBe(1)
+    await expect.poll(() => countOwnLabel("2단계")).toBe(1)
+    await expect.poll(() => countOwnLabel("3단계")).toBe(1)
+
+    await editor.locator("li", { hasText: "3단계" }).first().click()
+    await page.keyboard.press("Shift+Tab")
+    await expect(blockSelectionOverlay).toHaveCount(0)
+    await expect.poll(() => countOwnLabel("3단계")).toBe(1)
+  })
+
+  test("리스트 항목 handle은 말머리 묶음 전체가 아니라 각 항목을 따라간다", async ({ page }) => {
+    await page.goto(QA_ENGINE_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.click()
+    await page.getByRole("button", { name: "목록" }).first().click()
+    await page.keyboard.type("Access")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("Refresh")
+
+    const measureHandleAlignment = async (label: string) =>
+      page.evaluate((targetLabel) => {
+        const items = Array.from(document.querySelectorAll<HTMLElement>(".aq-block-editor__content li"))
+        const targetItem = items.find((item) => item.textContent?.includes(targetLabel)) ?? null
+        const handle = document.querySelector<HTMLElement>("[data-testid='block-drag-handle']")
+        if (!targetItem || !handle) return null
+        const itemRect = targetItem.getBoundingClientRect()
+        const handleRect = handle.getBoundingClientRect()
+        return {
+          itemCenterY: Math.round(itemRect.top + itemRect.height / 2),
+          handleCenterY: Math.round(handleRect.top + handleRect.height / 2),
+        }
+      }, label)
+
+    const firstItem = editor.locator("li", { hasText: "Access" }).first()
+    await firstItem.hover()
+    await expect.poll(() => measureHandleAlignment("Access")).not.toBeNull()
+    const firstAlignment = await measureHandleAlignment("Access")
+    if (!firstAlignment) {
+      throw new Error("Access handle metrics are missing")
+    }
+
+    const secondItem = editor.locator("li", { hasText: "Refresh" }).first()
+    await secondItem.hover()
+    await expect.poll(() => measureHandleAlignment("Refresh")).not.toBeNull()
+    const refreshMetrics = await measureHandleAlignment("Refresh")
+    if (!refreshMetrics) {
+      throw new Error("Refresh handle metrics are missing")
+    }
+
+    expect(Math.abs(firstAlignment.handleCenterY - firstAlignment.itemCenterY)).toBeLessThanOrEqual(18)
+    expect(Math.abs(refreshMetrics.handleCenterY - refreshMetrics.itemCenterY)).toBeLessThanOrEqual(18)
+    expect(refreshMetrics.handleCenterY).toBeGreaterThan(firstAlignment.handleCenterY + 20)
+  })
+
   test("초기 hydrate 직후 Cmd/Ctrl+Z는 외부 value 동기화를 되돌리지 않는다", async ({ page }) => {
     const seed = encodeURIComponent("# 제목\\n\\n첫 문단\\n\\n둘째 문단")
     await page.goto(`${QA_ENGINE_ROUTE}&seed=${seed}`)

--- a/front/e2e/slash-menu-interaction.spec.ts
+++ b/front/e2e/slash-menu-interaction.spec.ts
@@ -306,11 +306,15 @@ test.describe("block editor slash menu interaction", () => {
     const taskItems = page.locator("li[data-task-item='true']")
     await expect(taskItems).toHaveCount(3)
 
-    await taskItems.nth(2).dragTo(taskItems.nth(0))
-
     const markdownOutput = page.getByTestId("qa-markdown-output")
     const expected = "- [ ] 셋째\n- [ ] 첫째\n- [ ] 둘째"
-    const reorderedByNativeDrag = ((await markdownOutput.textContent()) || "").includes(expected)
+    let reorderedByNativeDrag = false
+    try {
+      await taskItems.nth(2).dragTo(taskItems.nth(0), { timeout: 2_000 })
+      reorderedByNativeDrag = ((await markdownOutput.textContent()) || "").includes(expected)
+    } catch {
+      reorderedByNativeDrag = false
+    }
 
     if (!reorderedByNativeDrag) {
       const currentLines = ((await markdownOutput.textContent()) || "")

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -323,7 +323,10 @@ type TableOverflowCoachmarkState = {
 
 type TopLevelBlockHandleState = {
   visible: boolean
+  kind: "top-level" | "list-item"
   blockIndex: number
+  listPath: number[]
+  itemIndex: number | null
   left: number
   top: number
   bottom: number
@@ -347,6 +350,15 @@ type PendingBlockDragState = {
   previewHeight: number
   previewHtml: string
   previewLabel: string
+}
+
+type NestedListItemContext = {
+  listBlockIndex: number
+  listPath: number[]
+  itemIndex: number
+  listItemElement: HTMLElement
+  listElement: HTMLElement
+  listItems: HTMLElement[]
 }
 
 type DraggedBlockState =
@@ -497,6 +509,32 @@ const LIST_ITEM_SELECTOR =
   "li[data-type='taskItem'], li[data-task-item='true'], li[data-list-item='true'], li[data-type='listItem']"
 const LIST_CONTAINER_SELECTOR =
   "ul[data-type='taskList'], ul[data-task-list='true'], ul[data-type='bulletList'], ol[data-type='orderedList'], ul, ol"
+const isListContainerNodeName = (nodeName: string | undefined | null) =>
+  nodeName === "bulletList" || nodeName === "orderedList" || nodeName === "taskList"
+const isListItemNodeName = (nodeName: string | undefined | null) =>
+  nodeName === "listItem" || nodeName === "taskItem"
+const getActiveListItemName = (editor: TiptapEditor): "listItem" | "taskItem" | null => {
+  const { $from } = editor.state.selection
+  for (let depth = $from.depth; depth > 0; depth -= 1) {
+    const nodeName = $from.node(depth)?.type?.name
+    if (nodeName === "taskItem") return "taskItem"
+    if (nodeName === "listItem") return "listItem"
+  }
+  return null
+}
+const sameListPath = (left: number[], right: number[]) =>
+  left.length === right.length && left.every((value, index) => value === right[index])
+const isSameNestedListItemContext = (
+  left: NestedListItemContext | null | undefined,
+  right: NestedListItemContext | null | undefined
+) =>
+  Boolean(
+    left &&
+      right &&
+      left.listBlockIndex === right.listBlockIndex &&
+      left.itemIndex === right.itemIndex &&
+      sameListPath(left.listPath, right.listPath)
+  )
 const MARKDOWN_COMMIT_DEBOUNCE_MS = 140
 const MARKDOWN_COMMIT_IDLE_TIMEOUT_MS = 220
 const MARKDOWN_COMMIT_MAX_WAIT_MS = 700
@@ -1336,6 +1374,56 @@ const selectTopLevelBlockNode = (editor: TiptapEditor, blockIndex: number) => {
   focusEditorViewWithoutScroll(editor)
 }
 
+const getChildNodePosition = (parentNode: ProseMirrorNode, parentPos: number, childIndex: number) => {
+  let position = parentPos + 1
+  for (let index = 0; index < childIndex; index += 1) {
+    position += parentNode.child(index).nodeSize
+  }
+  return position
+}
+
+const findNestedListChildIndexInNode = (node: ProseMirrorNode | null | undefined) => {
+  if (!node) return -1
+  for (let index = 0; index < node.childCount; index += 1) {
+    if (isListContainerNodeName(node.child(index)?.type?.name)) {
+      return index
+    }
+  }
+  return -1
+}
+
+const resolveListItemNodeSelectionPos = (editor: TiptapEditor, context: NestedListItemContext) => {
+  const { doc } = editor.state
+  if (context.listBlockIndex < 0 || context.listBlockIndex >= doc.childCount) return null
+
+  let currentListNode = doc.child(context.listBlockIndex)
+  if (!isListContainerNodeName(currentListNode.type.name)) return null
+
+  let currentListPos = getTopLevelBlockPosition(editor, context.listBlockIndex)
+  for (const pathIndex of context.listPath) {
+    if (pathIndex < 0 || pathIndex >= currentListNode.childCount) return null
+    const parentItemPos = getChildNodePosition(currentListNode, currentListPos, pathIndex)
+    const parentItemNode = currentListNode.child(pathIndex)
+    const nestedListChildIndex = findNestedListChildIndexInNode(parentItemNode)
+    if (nestedListChildIndex < 0) return null
+    currentListPos = getChildNodePosition(parentItemNode, parentItemPos, nestedListChildIndex)
+    currentListNode = parentItemNode.child(nestedListChildIndex)
+    if (!isListContainerNodeName(currentListNode.type.name)) return null
+  }
+
+  if (context.itemIndex < 0 || context.itemIndex >= currentListNode.childCount) return null
+  return getChildNodePosition(currentListNode, currentListPos, context.itemIndex)
+}
+
+const selectNestedListItemNode = (editor: TiptapEditor, context: NestedListItemContext) => {
+  const position = resolveListItemNodeSelectionPos(editor, context)
+  if (position === null) return false
+  const selection = NodeSelection.create(editor.state.doc, position)
+  editor.view.dispatch(editor.state.tr.setSelection(selection))
+  focusEditorViewWithoutScroll(editor)
+  return true
+}
+
 const resolveBlockHandleAnchorTop = (blockElement: HTMLElement, railHeight: number) => {
   const rect = blockElement.getBoundingClientRect()
   if (typeof window === "undefined") return rect.top + 6
@@ -1368,7 +1456,10 @@ const isStableBlockHandleState = (
   next: TopLevelBlockHandleState
 ) =>
   prev.visible === next.visible &&
+  prev.kind === next.kind &&
   prev.blockIndex === next.blockIndex &&
+  prev.itemIndex === next.itemIndex &&
+  sameListPath(prev.listPath, next.listPath) &&
   isWithinBlockHandleEpsilon(prev.left, next.left) &&
   isWithinBlockHandleEpsilon(prev.top, next.top) &&
   isWithinBlockHandleEpsilon(prev.bottom, next.bottom) &&
@@ -2223,6 +2314,7 @@ const BlockEditorEngine = ({
   const [isCoarsePointer, setIsCoarsePointer] = useState(false)
   const [isNarrowTableViewport, setIsNarrowTableViewport] = useState(false)
   const [hoveredBlockIndex, setHoveredBlockIndex] = useState<number | null>(null)
+  const [hoveredListItemContext, setHoveredListItemContext] = useState<NestedListItemContext | null>(null)
   const [selectedBlockIndex, setSelectedBlockIndex] = useState<number | null>(null)
   const [clickedBlockIndex, setClickedBlockIndex] = useState<number | null>(null)
   const [selectedBlockNodeIndex, setSelectedBlockNodeIndex] = useState<number | null>(null)
@@ -2230,7 +2322,10 @@ const BlockEditorEngine = ({
   const keyboardBlockSelectionStickyRef = useRef(false)
   const [blockHandleState, setBlockHandleState] = useState<TopLevelBlockHandleState>({
     visible: false,
+    kind: "top-level",
     blockIndex: 0,
+    listPath: [],
+    itemIndex: null,
     left: 0,
     top: 0,
     bottom: 0,
@@ -2439,6 +2534,7 @@ const BlockEditorEngine = ({
     if (typeof window === "undefined") return
     hoveredBlockClearTimerRef.current = window.setTimeout(() => {
       setHoveredBlockIndex(null)
+      setHoveredListItemContext(null)
       hoveredBlockClearTimerRef.current = null
     }, 260)
   }, [cancelHoveredBlockClear])
@@ -3245,61 +3341,107 @@ const BlockEditorEngine = ({
     [getTopLevelBlockElementByIndex]
   )
 
-  const findNestedListItemDragContextFromTarget = useCallback(
+  const isOuterListItemSelectionGesture = useCallback(
+    (event: BlockSelectionPointerEventLike, targetListItem: NestedListItemContext | null) => {
+      if (!targetListItem) return false
+      if (event.button !== 0) return false
+      if (event.detail < 2) return false
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return false
+
+      const targetElement =
+        event.target instanceof Element
+          ? event.target
+          : event.target instanceof Node
+            ? event.target.parentElement
+            : null
+      if (
+        targetElement?.closest("[data-block-handle-rail='true'] button") ||
+        targetElement?.closest("[data-block-menu-root='true']") ||
+        targetElement?.closest("[data-table-menu-root='true']")
+      ) {
+        return false
+      }
+
+      const rect = targetListItem.listItemElement.getBoundingClientRect()
+      const withinVerticalRange =
+        event.clientY >= rect.top - BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX &&
+        event.clientY <= rect.bottom + BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX
+      if (!withinVerticalRange) return false
+
+      return (
+        event.clientX >= rect.left - BLOCK_OUTER_SELECT_LEFT_GUTTER_PX &&
+        event.clientX <= rect.left + BLOCK_OUTER_SELECT_LEFT_EDGE_INNER_PX
+      )
+    },
+    []
+  )
+
+  const findNestedListItemContextFromTarget = useCallback(
     (target: EventTarget | null) => {
       const root = getContentRoot()
       if (!root || !(target instanceof Element)) return null
 
-      const taskItemElement = target.closest(LIST_ITEM_SELECTOR)
-      if (!(taskItemElement instanceof HTMLElement)) return null
-      const taskListElement = taskItemElement.closest(LIST_CONTAINER_SELECTOR)
-      if (!(taskListElement instanceof HTMLElement)) return null
+      const listItemElement = target.closest(LIST_ITEM_SELECTOR)
+      if (!(listItemElement instanceof HTMLElement)) return null
+      const listElement = listItemElement.closest(LIST_CONTAINER_SELECTOR)
+      if (!(listElement instanceof HTMLElement)) return null
 
-      let blockElement: Element | null = taskListElement
+      let blockElement: Element | null = listElement
       while (blockElement && blockElement.parentElement !== root) {
         blockElement = blockElement.parentElement
       }
 
       if (!(blockElement instanceof HTMLElement) || blockElement.parentElement !== root) return null
-      const taskListBlockIndex = getTopLevelBlockElements().indexOf(blockElement)
-      if (taskListBlockIndex < 0) return null
+      const listBlockIndex = getTopLevelBlockElements().indexOf(blockElement)
+      if (listBlockIndex < 0) return null
 
-      const taskItems = Array.from(
-        taskListElement.querySelectorAll(`:scope > ${LIST_ITEM_SELECTOR}`)
-      ) as HTMLElement[]
-      const sourceItemIndex = taskItems.indexOf(taskItemElement)
-      if (sourceItemIndex < 0) return null
+      const listItems = Array.from(listElement.querySelectorAll(`:scope > ${LIST_ITEM_SELECTOR}`)) as HTMLElement[]
+      const itemIndex = listItems.indexOf(listItemElement)
+      if (itemIndex < 0) return null
 
-      const taskListPath: number[] = []
-      let currentListElement: HTMLElement | null = taskListElement
+      const listPath: number[] = []
+      let currentListElement: HTMLElement | null = listElement
       while (currentListElement && currentListElement !== blockElement) {
-        const parentTaskItem: HTMLElement | null =
+        const parentListItem: HTMLElement | null =
           currentListElement.parentElement?.closest(LIST_ITEM_SELECTOR) ?? null
-        if (!(parentTaskItem instanceof HTMLElement)) break
-        const parentTaskList: HTMLElement | null =
-          parentTaskItem.parentElement?.closest(LIST_CONTAINER_SELECTOR) ?? null
-        if (!(parentTaskList instanceof HTMLElement)) break
+        if (!(parentListItem instanceof HTMLElement)) break
+        const parentList: HTMLElement | null =
+          parentListItem.parentElement?.closest(LIST_CONTAINER_SELECTOR) ?? null
+        if (!(parentList instanceof HTMLElement)) break
 
-        const siblingItems = Array.from(
-          parentTaskList.querySelectorAll(`:scope > ${LIST_ITEM_SELECTOR}`)
-        ) as HTMLElement[]
-        const parentItemIndex = siblingItems.indexOf(parentTaskItem)
+        const siblingItems = Array.from(parentList.querySelectorAll(`:scope > ${LIST_ITEM_SELECTOR}`)) as HTMLElement[]
+        const parentItemIndex = siblingItems.indexOf(parentListItem)
         if (parentItemIndex < 0) break
 
-        taskListPath.unshift(parentItemIndex)
-        currentListElement = parentTaskList
+        listPath.unshift(parentItemIndex)
+        currentListElement = parentList
       }
 
       return {
-        listBlockIndex: taskListBlockIndex,
-        listPath: taskListPath,
-        sourceItemIndex,
-        taskItemElement,
-        listElement: taskListElement,
-        taskItems,
+        listBlockIndex,
+        listPath,
+        itemIndex,
+        listItemElement,
+        listElement,
+        listItems,
       }
     },
     [getContentRoot, getTopLevelBlockElements]
+  )
+
+  const getSelectedNestedListItemContext = useCallback(
+    (currentEditor: TiptapEditor) => {
+      const selection = currentEditor.state.selection as typeof currentEditor.state.selection & {
+        node?: ProseMirrorNode
+      }
+      if (!(selection instanceof NodeSelection) || !isListItemNodeName(selection.node?.type?.name)) {
+        return null
+      }
+
+      const domNode = currentEditor.view.nodeDOM(selection.from)
+      return findNestedListItemContextFromTarget(domNode)
+    },
+    [findNestedListItemContextFromTarget]
   )
 
   const resolveNestedListItemDropIndicatorByClientY = useCallback(
@@ -5229,6 +5371,27 @@ const BlockEditorEngine = ({
   }, [disabled, editor])
 
   useEffect(() => {
+    const root = getContentRoot()
+    if (!root || !editor) return
+
+    const listItems = Array.from(root.querySelectorAll<HTMLElement>(LIST_ITEM_SELECTOR))
+    listItems.forEach((element) => {
+      element.removeAttribute("data-block-selected")
+    })
+
+    const selectedNestedListItemContext = getSelectedNestedListItemContext(editor)
+    if (selectedNestedListItemContext?.listItemElement?.isConnected) {
+      selectedNestedListItemContext.listItemElement.setAttribute("data-block-selected", "true")
+    }
+
+    return () => {
+      listItems.forEach((element) => {
+        element.removeAttribute("data-block-selected")
+      })
+    }
+  }, [editor, getContentRoot, getSelectedNestedListItemContext, selectionTick])
+
+  useEffect(() => {
     selectedBlockNodeIndexRef.current = selectedBlockNodeIndex
   }, [selectedBlockNodeIndex])
 
@@ -5251,6 +5414,7 @@ const BlockEditorEngine = ({
         node?: { isBlock?: boolean }
       }
       const hasTextRangeSelection = selection instanceof TextSelection && !selection.empty
+      const selectedNestedListItemContext = getSelectedNestedListItemContext(editor)
       if (hasTextRangeSelection && keyboardBlockSelectionStickyRef.current) {
         keyboardBlockSelectionStickyRef.current = false
       }
@@ -5258,8 +5422,12 @@ const BlockEditorEngine = ({
       const isTopLevelBlockNodeSelection = Boolean(
         selection instanceof NodeSelection && selection.$from.depth === 0 && selection.node?.isBlock
       )
+      const isNestedListItemNodeSelection = Boolean(selectedNestedListItemContext)
       const inTableContext = isTableSelectionActive(editor) ? 1 : 0
-      const nextSignature = `${nextBlockIndex ?? "none"}:${isTopLevelBlockNodeSelection ? 1 : 0}:${keyboardBlockSelectionStickyRef.current ? 1 : 0}:${inTableContext}`
+      const selectedNestedListItemSignature = selectedNestedListItemContext
+        ? `${selectedNestedListItemContext.listBlockIndex}:${selectedNestedListItemContext.listPath.join(".")}:${selectedNestedListItemContext.itemIndex}`
+        : "none"
+      const nextSignature = `${nextBlockIndex ?? "none"}:${isTopLevelBlockNodeSelection ? 1 : 0}:${isNestedListItemNodeSelection ? 1 : 0}:${keyboardBlockSelectionStickyRef.current ? 1 : 0}:${inTableContext}:${selectedNestedListItemSignature}`
       if (nextSignature === selectionUiSignatureRef.current) {
         return
       }
@@ -5267,6 +5435,11 @@ const BlockEditorEngine = ({
       setSelectionTick((prev) => prev + 1)
       setSelectedBlockIndex(nextBlockIndex)
       if (hasTextRangeSelection) {
+        setClickedBlockIndex(null)
+        setSelectedBlockNodeIndex(null)
+        return
+      }
+      if (isNestedListItemNodeSelection) {
         setClickedBlockIndex(null)
         setSelectedBlockNodeIndex(null)
         return
@@ -5321,18 +5494,20 @@ const BlockEditorEngine = ({
       editor.off("blur", notifyBlur)
       selectionUiSignatureRef.current = ""
     }
-  }, [editor])
+  }, [editor, getSelectedNestedListItemContext])
 
   useEffect(() => {
     if (!editor) return
 
     const handleEditorMouseDownCapture = (event: MouseEvent) => {
+      const targetListItemContext = findNestedListItemContextFromTarget(event.target)
       const targetBlockIndex =
         findTopLevelBlockIndexFromTarget(event.target) ??
         findTopLevelBlockIndexByClientPosition(event.clientX, event.clientY)
+      const isOuterListItemGesture = isOuterListItemSelectionGesture(event, targetListItemContext)
       const isOuterSelectionGesture = isOuterBlockSelectionGesture(event, targetBlockIndex)
-      if (isTableSelectionActive(editor) && !isOuterSelectionGesture) return
-      if (!isOuterSelectionGesture) {
+      if (isTableSelectionActive(editor) && !isOuterSelectionGesture && !isOuterListItemGesture) return
+      if (!isOuterSelectionGesture && !isOuterListItemGesture) {
         const shouldReleaseStickyBlockSelection =
           event.button === 0 &&
           !event.metaKey &&
@@ -5346,6 +5521,13 @@ const BlockEditorEngine = ({
           setSelectedBlockNodeIndex(null)
           syncSelectedBlockNodeSurface(null)
         }
+        return
+      }
+      if (isOuterListItemGesture && targetListItemContext) {
+        event.preventDefault()
+        event.stopPropagation()
+        skipNextPointerDownSelectionClearRef.current = true
+        selectNestedListItemNode(editor, targetListItemContext)
         return
       }
       if (targetBlockIndex === null) return
@@ -5365,6 +5547,8 @@ const BlockEditorEngine = ({
     findTopLevelBlockIndexByClientPosition,
     findTopLevelBlockIndexFromTarget,
     isOuterBlockSelectionGesture,
+    findNestedListItemContextFromTarget,
+    isOuterListItemSelectionGesture,
     promoteTopLevelBlockSelection,
     syncSelectedBlockNodeSurface,
   ])
@@ -5374,11 +5558,23 @@ const BlockEditorEngine = ({
 
     const handleKeyDownCapture = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return
-      if (event.key !== "Tab" || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return
+      if (event.key !== "Tab" || event.metaKey || event.ctrlKey || event.altKey) return
       if (slashMenuState) return
 
       const currentEditor = editorRef.current
       if (!currentEditor) return
+      const activeListItemName = getActiveListItemName(currentEditor)
+      if (activeListItemName) {
+        event.preventDefault()
+        event.stopPropagation()
+        const handled = event.shiftKey
+          ? currentEditor.commands.liftListItem(activeListItemName)
+          : currentEditor.commands.sinkListItem(activeListItemName)
+        if (handled) {
+          setSelectionTick((prev) => prev + 1)
+        }
+        return
+      }
       const editorDom = currentEditor.view.dom
       const activeElement = document.activeElement
       const domSelection = window.getSelection()
@@ -7679,6 +7875,7 @@ const BlockEditorEngine = ({
     if (!editor) return
     const rectCache = blockSelectionLayoutRectCacheRef.current
     rectCache.clear()
+    const selectedNestedListItemContext = getSelectedNestedListItemContext(editor)
     const resolveCachedBlockRect = (index: number) => {
       const cached = rectCache.get(index)
       if (cached) return cached
@@ -7688,40 +7885,62 @@ const BlockEditorEngine = ({
       rectCache.set(index, next)
       return next
     }
-    const overlayIndex =
-      selectedBlockNodeIndex !== null
-        ? selectedBlockNodeIndex
-        : clickedBlockIndex !== null
-          ? clickedBlockIndex
-          : null
-    if (overlayIndex === null) {
-      setBlockSelectionOverlayState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
+    if (selectedNestedListItemContext?.listItemElement?.isConnected) {
+      const rect = selectedNestedListItemContext.listItemElement.getBoundingClientRect()
+      const nextOverlayState: BlockSelectionOverlayState = {
+        visible: true,
+        left: rect.left - 6,
+        top: rect.top - 4,
+        width: rect.width + 12,
+        height: rect.height + 8,
+      }
+      setBlockSelectionOverlayState((prev) =>
+        isStableBlockSelectionOverlayState(prev, nextOverlayState) ? prev : nextOverlayState
+      )
     } else {
-      const overlayTarget = resolveCachedBlockRect(overlayIndex)
-      if (!overlayTarget) {
+      const overlayIndex =
+        selectedBlockNodeIndex !== null
+          ? selectedBlockNodeIndex
+          : clickedBlockIndex !== null
+            ? clickedBlockIndex
+            : null
+      if (overlayIndex === null) {
         setBlockSelectionOverlayState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
       } else {
-        const { rect } = overlayTarget
-        const nextOverlayState: BlockSelectionOverlayState = {
-          visible: true,
-          left: rect.left - 6,
-          top: rect.top - 4,
-          width: rect.width + 12,
-          height: rect.height + 8,
+        const overlayTarget = resolveCachedBlockRect(overlayIndex)
+        if (!overlayTarget) {
+          setBlockSelectionOverlayState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
+        } else {
+          const { rect } = overlayTarget
+          const nextOverlayState: BlockSelectionOverlayState = {
+            visible: true,
+            left: rect.left - 6,
+            top: rect.top - 4,
+            width: rect.width + 12,
+            height: rect.height + 8,
+          }
+          setBlockSelectionOverlayState((prev) =>
+            isStableBlockSelectionOverlayState(prev, nextOverlayState) ? prev : nextOverlayState
+          )
         }
-        setBlockSelectionOverlayState((prev) =>
-          isStableBlockSelectionOverlayState(prev, nextOverlayState) ? prev : nextOverlayState
-        )
       }
     }
 
     const stickySelectionActive =
       !isCoarsePointer && selectedBlockNodeIndex !== null && keyboardBlockSelectionStickyRef.current
-    const blockIndex = isCoarsePointer
-      ? selectedBlockIndex
-      : stickySelectionActive
-        ? selectedBlockNodeIndex
-        : hoveredBlockIndex
+    const activeListItemContext =
+      hoveredListItemContext?.listItemElement?.isConnected
+        ? hoveredListItemContext
+        : selectedNestedListItemContext?.listItemElement?.isConnected
+          ? selectedNestedListItemContext
+          : null
+    const blockIndex = activeListItemContext
+      ? activeListItemContext.listBlockIndex
+      : isCoarsePointer
+        ? selectedBlockIndex
+        : stickySelectionActive
+          ? selectedBlockNodeIndex
+          : hoveredBlockIndex
     const hideBlockHandle = () =>
       setBlockHandleState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
     const hasOuterBlockSelectionIntent = blockIndex !== null
@@ -7737,6 +7956,25 @@ const BlockEditorEngine = ({
       hideBlockHandle()
       return
     }
+    const { width: railWidth, height: railHeight } = blockHandleRailMetricsRef.current
+    if (activeListItemContext?.listItemElement?.isConnected) {
+      const rect = activeListItemContext.listItemElement.getBoundingClientRect()
+      const nextState: TopLevelBlockHandleState = {
+        visible: true,
+        kind: "list-item",
+        blockIndex: activeListItemContext.listBlockIndex,
+        listPath: [...activeListItemContext.listPath],
+        itemIndex: activeListItemContext.itemIndex,
+        left: Math.max(12, rect.left - railWidth - 10),
+        top: resolveBlockHandleAnchorTop(activeListItemContext.listItemElement, railHeight),
+        bottom: rect.bottom + 12,
+        width: rect.width,
+      }
+      setBlockHandleState((prev) => (isStableBlockHandleState(prev, nextState) ? prev : nextState))
+      rectCache.clear()
+      return
+    }
+
     const blockTarget = resolveCachedBlockRect(blockIndex)
     const blockElement = blockTarget?.element ?? null
     const canShowHandle = isTopLevelBlockHandleEligible(blockIndex)
@@ -7750,7 +7988,6 @@ const BlockEditorEngine = ({
     }
 
     const rect = blockTarget?.rect ?? blockElement.getBoundingClientRect()
-    const { width: railWidth, height: railHeight } = blockHandleRailMetricsRef.current
     const blocks = ((editor.getJSON() as BlockEditorDoc).content ?? []) as BlockEditorDoc[]
     const blockNode = blocks[blockIndex]
     const anchoredTop = shouldUseThinBlockHandleAnchor(blockNode)
@@ -7760,7 +7997,10 @@ const BlockEditorEngine = ({
         : rect.top + 6
     const nextState: TopLevelBlockHandleState = {
       visible: true,
+      kind: "top-level",
       blockIndex,
+      listPath: [],
+      itemIndex: null,
       left: Math.max(12, rect.left - railWidth - 10),
       top: anchoredTop,
       bottom: rect.bottom + 12,
@@ -7773,7 +8013,9 @@ const BlockEditorEngine = ({
     editor,
     clickedBlockIndex,
     getTopLevelBlockElementByIndex,
+    getSelectedNestedListItemContext,
     hoveredBlockIndex,
+    hoveredListItemContext,
     isTableStructuralSelection,
     isCoarsePointer,
     isTopLevelBlockHandleEligible,
@@ -7915,9 +8157,13 @@ const BlockEditorEngine = ({
 
   useEffect(() => {
     const elements = getTopLevelBlockElements()
+    const root = getContentRoot()
+    const listItems = root ? Array.from(root.querySelectorAll<HTMLElement>(LIST_ITEM_SELECTOR)) : []
 
     elements.forEach((element, index) => {
-      if (index === hoveredBlockIndex && !draggedBlockState) {
+      if (hoveredListItemContext) {
+        element.removeAttribute("data-block-hovered")
+      } else if (index === hoveredBlockIndex && !draggedBlockState) {
         element.setAttribute("data-block-hovered", "true")
       } else {
         element.removeAttribute("data-block-hovered")
@@ -7932,14 +8178,40 @@ const BlockEditorEngine = ({
       element.removeAttribute("data-block-drop-target")
     })
 
+    listItems.forEach((element) => {
+      if (
+        hoveredListItemContext &&
+        !draggedBlockState &&
+        isSameNestedListItemContext(hoveredListItemContext, {
+          ...hoveredListItemContext,
+          listItemElement: element,
+          listElement: hoveredListItemContext.listElement,
+          listItems: hoveredListItemContext.listItems,
+        }) &&
+        element === hoveredListItemContext.listItemElement
+      ) {
+        element.setAttribute("data-block-hovered", "true")
+      } else {
+        element.removeAttribute("data-block-hovered")
+      }
+
+      element.removeAttribute("data-block-dragging")
+      element.removeAttribute("data-block-drop-target")
+    })
+
     return () => {
       elements.forEach((element) => {
         element.removeAttribute("data-block-hovered")
         element.removeAttribute("data-block-dragging")
         element.removeAttribute("data-block-drop-target")
       })
+      listItems.forEach((element) => {
+        element.removeAttribute("data-block-hovered")
+        element.removeAttribute("data-block-dragging")
+        element.removeAttribute("data-block-drop-target")
+      })
     }
-  }, [draggedBlockState, dropIndicatorState.insertionIndex, getTopLevelBlockElements, hoveredBlockIndex])
+  }, [draggedBlockState, dropIndicatorState.insertionIndex, getContentRoot, getTopLevelBlockElements, hoveredBlockIndex, hoveredListItemContext])
 
   const syncViewportHoverState = useCallback(
     (targetEvent: EventTarget | null, clientX: number, clientY: number) => {
@@ -7962,6 +8234,7 @@ const BlockEditorEngine = ({
       const target =
         targetEvent instanceof Element ? targetEvent : targetEvent instanceof Node ? targetEvent.parentElement : null
       const cell = getTableCellFromClientPoint(clientX, clientY, targetEvent)
+      const targetListItemContext = findNestedListItemContextFromTarget(targetEvent)
       const targetBlockIndex =
         findTopLevelBlockIndexFromTarget(targetEvent) ??
         findTopLevelBlockIndexByClientPosition(clientX, clientY)
@@ -7985,6 +8258,7 @@ const BlockEditorEngine = ({
         cancelTableQuickRailHide()
         setIsTableQuickRailHovered(true)
         syncHoveredTableCellMenuLayout(hoveredTableElementRef.current ?? activeTableElementRef.current)
+        setHoveredListItemContext(null)
         if (isWriterSurface || currentTableAxisSelection !== null) {
           setHoveredBlockIndex(targetBlockIndex)
         }
@@ -7996,6 +8270,7 @@ const BlockEditorEngine = ({
         setHoveredTableCellMenuLayout(null)
         setIsTableQuickRailHovered(false)
         setViewportRowResizeHot(false)
+        setHoveredListItemContext(null)
         setHoveredBlockIndex(targetBlockIndex)
         return
       }
@@ -8004,6 +8279,7 @@ const BlockEditorEngine = ({
         syncTableQuickRailFromElement(cell ?? target ?? hoveredTableElement, clientX, clientY)
         setIsTableQuickRailHovered(true)
         setViewportRowResizeHot(isRowResizeHandleTarget(cell, clientX, clientY))
+        setHoveredListItemContext(null)
         setHoveredBlockIndex(isWriterSurface || currentTableAxisSelection !== null ? targetBlockIndex : null)
         if (selectedBlockNodeIndex !== null && !keyboardBlockSelectionStickyRef.current) {
           keyboardBlockSelectionStickyRef.current = false
@@ -8019,16 +8295,21 @@ const BlockEditorEngine = ({
         scheduleTableQuickRailHide()
       }
       if (isTableStructuralSelection) {
+        setHoveredListItemContext(null)
         setHoveredBlockIndex(null)
         return
       }
       if (target?.closest("[data-block-handle-rail='true']") || target?.closest("[data-block-menu-root='true']")) {
         if (blockHandleState.visible) {
+          if (blockHandleState.kind === "list-item" && hoveredListItemContext) {
+            setHoveredListItemContext(hoveredListItemContext)
+          }
           setHoveredBlockIndex(blockHandleState.blockIndex)
         }
         return
       }
       setViewportRowResizeHot(isRowResizeHandleTarget(cell, clientX, clientY))
+      setHoveredListItemContext(targetListItemContext)
       setHoveredBlockIndex(
         findTopLevelBlockIndexByClientPosition(clientX, clientY) ??
           findTopLevelBlockIndexFromTarget(targetEvent)
@@ -8041,11 +8322,13 @@ const BlockEditorEngine = ({
     },
     [
       blockHandleState.blockIndex,
+      blockHandleState.kind,
       blockHandleState.visible,
       cancelHoveredBlockClear,
       cancelTableQuickRailHide,
       findTopLevelBlockIndexByClientPosition,
       findTopLevelBlockIndexFromTarget,
+      findNestedListItemContextFromTarget,
       getTableCellFromClientPoint,
       getTopLevelBlockElementByIndex,
       draggedTableAxisState,
@@ -8056,6 +8339,7 @@ const BlockEditorEngine = ({
       isRowResizeHandleTarget,
       selectedBlockNodeIndex,
       setViewportRowResizeHot,
+      hoveredListItemContext,
       syncSelectedBlockNodeSurface,
       syncHoveredTableCellMenuLayout,
       scheduleTableQuickRailHide,
@@ -8125,8 +8409,20 @@ const BlockEditorEngine = ({
       }
 
       if (event.defaultPrevented) return
-      if (event.key !== "Tab" || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return
+      if (event.key !== "Tab" || event.metaKey || event.ctrlKey || event.altKey) return
       if (slashMenuState) return
+      const activeListItemName = getActiveListItemName(currentEditor)
+      if (activeListItemName) {
+        event.preventDefault()
+        event.stopPropagation()
+        const handled = event.shiftKey
+          ? currentEditor.commands.liftListItem(activeListItemName)
+          : currentEditor.commands.sinkListItem(activeListItemName)
+        if (handled) {
+          setSelectionTick((prev) => prev + 1)
+        }
+        return
+      }
 
       const targetBlockIndex =
         hoveredBlockIndex ??
@@ -8148,9 +8444,21 @@ const BlockEditorEngine = ({
         skipNextPointerDownSelectionClearRef.current = false
         return
       }
+      const targetListItemContext = findNestedListItemContextFromTarget(event.target)
       const targetBlockIndex =
         findTopLevelBlockIndexFromTarget(event.target) ??
         findTopLevelBlockIndexByClientPosition(event.clientX, event.clientY)
+      const currentEditor = editorRef.current ?? editor
+      if (
+        currentEditor &&
+        isOuterListItemSelectionGesture(event, targetListItemContext) &&
+        targetListItemContext
+      ) {
+        event.preventDefault()
+        event.stopPropagation()
+        selectNestedListItemNode(currentEditor, targetListItemContext)
+        return
+      }
       if (isOuterBlockSelectionGesture(event, targetBlockIndex)) {
         if (targetBlockIndex === null) return
         event.preventDefault()
@@ -8166,7 +8474,6 @@ const BlockEditorEngine = ({
       }
       if (isCoarsePointer || tableRowResizeRef.current || tableColumnRailResizeRef.current) return
       const cell = getTableCellFromClientPoint(event.clientX, event.clientY, event.target)
-      const currentEditor = editorRef.current ?? editor
       const hasTableStructuralSelection = Boolean(
         currentEditor &&
           (currentEditor.state.selection instanceof CellSelection ||
@@ -8188,13 +8495,15 @@ const BlockEditorEngine = ({
       startTableRowResize(cell, event.clientY)
     },
     [
+      editor,
+      findNestedListItemContextFromTarget,
       findTopLevelBlockIndexFromTarget,
       findTopLevelBlockIndexByClientPosition,
-      editor,
       focusRenderedTableCell,
       getTableCellFromClientPoint,
       hideTableQuickRailImmediately,
       isOuterBlockSelectionGesture,
+      isOuterListItemSelectionGesture,
       isCoarsePointer,
       isRowResizeHandleTarget,
       promoteTopLevelBlockSelection,
@@ -8207,30 +8516,30 @@ const BlockEditorEngine = ({
 
   const handleViewportDragStart = useCallback(
     (event: ReactDragEvent<HTMLDivElement>) => {
-      const taskItemContext = findNestedListItemDragContextFromTarget(event.target)
-      if (!taskItemContext) return
+      const listItemContext = findNestedListItemContextFromTarget(event.target)
+      if (!listItemContext) return
 
       setDraggedNestedListItemState({
-        listBlockIndex: taskItemContext.listBlockIndex,
-        listPath: taskItemContext.listPath,
-        sourceItemIndex: taskItemContext.sourceItemIndex,
+        listBlockIndex: listItemContext.listBlockIndex,
+        listPath: listItemContext.listPath,
+        sourceItemIndex: listItemContext.itemIndex,
       })
       setNestedListItemDropIndicatorState({
         visible: true,
-        listBlockIndex: taskItemContext.listBlockIndex,
-        listPath: taskItemContext.listPath,
-        ...resolveNestedListItemDropIndicatorByClientY(taskItemContext.listElement, event.clientY),
+        listBlockIndex: listItemContext.listBlockIndex,
+        listPath: listItemContext.listPath,
+        ...resolveNestedListItemDropIndicatorByClientY(listItemContext.listElement, event.clientY),
       })
       event.dataTransfer.effectAllowed = "move"
-      event.dataTransfer.setData("text/plain", `list-item:${taskItemContext.listBlockIndex}:${taskItemContext.sourceItemIndex}`)
+      event.dataTransfer.setData("text/plain", `list-item:${listItemContext.listBlockIndex}:${listItemContext.itemIndex}`)
     },
-    [findNestedListItemDragContextFromTarget, resolveNestedListItemDropIndicatorByClientY]
+    [findNestedListItemContextFromTarget, resolveNestedListItemDropIndicatorByClientY]
   )
 
   const handleViewportDragOver = useCallback(
     (event: ReactDragEvent<HTMLDivElement>) => {
       if (!draggedNestedListItemState) return
-      const taskItemContext = findNestedListItemDragContextFromTarget(event.target)
+      const taskItemContext = findNestedListItemContextFromTarget(event.target)
       if (
         !taskItemContext ||
         taskItemContext.listBlockIndex !== draggedNestedListItemState.listBlockIndex ||
@@ -8247,7 +8556,7 @@ const BlockEditorEngine = ({
         ...resolveNestedListItemDropIndicatorByClientY(taskItemContext.listElement, event.clientY),
       })
     },
-    [draggedNestedListItemState, findNestedListItemDragContextFromTarget, resolveNestedListItemDropIndicatorByClientY]
+    [draggedNestedListItemState, findNestedListItemContextFromTarget, resolveNestedListItemDropIndicatorByClientY]
   )
 
   const clearNestedListItemDragState = useCallback(() => {
@@ -8258,7 +8567,7 @@ const BlockEditorEngine = ({
   const handleViewportDrop = useCallback(
     (event: ReactDragEvent<HTMLDivElement>) => {
       if (!draggedNestedListItemState) return
-      const taskItemContext = findNestedListItemDragContextFromTarget(event.target)
+      const taskItemContext = findNestedListItemContextFromTarget(event.target)
       if (
         !taskItemContext ||
         taskItemContext.listBlockIndex !== draggedNestedListItemState.listBlockIndex ||
@@ -8286,7 +8595,7 @@ const BlockEditorEngine = ({
     [
       clearNestedListItemDragState,
       draggedNestedListItemState,
-      findNestedListItemDragContextFromTarget,
+      findNestedListItemContextFromTarget,
       mutateTopLevelBlocks,
       resolveNestedListItemDropIndicatorByClientY,
     ]
@@ -9626,7 +9935,9 @@ const BlockEditorEngine = ({
             data-visible={blockHandleState.visible}
             onPointerEnter={() => {
               cancelHoveredBlockClear()
-              setHoveredBlockIndex(blockHandleState.blockIndex)
+              if (blockHandleState.kind === "top-level") {
+                setHoveredBlockIndex(blockHandleState.blockIndex)
+              }
             }}
             onPointerLeave={() => {
               scheduleHoveredBlockClear()
@@ -9636,24 +9947,26 @@ const BlockEditorEngine = ({
               top: `${blockHandleState.top}px`,
             }}
           >
+            {blockHandleState.kind === "top-level" ? (
+              <BlockHandleButton
+                type="button"
+                aria-label="블록 추가"
+                title="블록 추가"
+                onClick={(event: ReactMouseEvent<HTMLButtonElement>) => {
+                  event.stopPropagation()
+                  openBlockMenu(blockHandleState.blockIndex, event.currentTarget.getBoundingClientRect())
+                }}
+              >
+                <BlockHandlePlus aria-hidden="true">
+                  <span />
+                  <span />
+                </BlockHandlePlus>
+              </BlockHandleButton>
+            ) : null}
             <BlockHandleButton
               type="button"
-              aria-label="블록 추가"
-              title="블록 추가"
-              onClick={(event: ReactMouseEvent<HTMLButtonElement>) => {
-                event.stopPropagation()
-                openBlockMenu(blockHandleState.blockIndex, event.currentTarget.getBoundingClientRect())
-              }}
-            >
-              <BlockHandlePlus aria-hidden="true">
-                <span />
-                <span />
-              </BlockHandlePlus>
-            </BlockHandleButton>
-            <BlockHandleButton
-              type="button"
-              aria-label="블록 이동"
-              title="블록 이동"
+              aria-label={blockHandleState.kind === "list-item" ? "목록 항목 선택" : "블록 이동"}
+              title={blockHandleState.kind === "list-item" ? "목록 항목 선택" : "블록 이동"}
               data-variant="drag"
               data-testid={blockHandleState.visible ? "block-drag-handle" : undefined}
               onMouseDown={(event) => {
@@ -9664,12 +9977,30 @@ const BlockEditorEngine = ({
                 event.preventDefault()
                 event.stopPropagation()
                 clearPendingBlockDrag()
+                if (blockHandleState.kind === "list-item" && editor) {
+                  const selectedListItemContext = getSelectedNestedListItemContext(editor)
+                  const matchingHoveredListItemContext =
+                    hoveredListItemContext &&
+                    hoveredListItemContext.listBlockIndex === blockHandleState.blockIndex &&
+                    hoveredListItemContext.itemIndex === blockHandleState.itemIndex &&
+                    sameListPath(hoveredListItemContext.listPath, blockHandleState.listPath)
+                      ? hoveredListItemContext
+                      : null
+                  const targetListItemContext = matchingHoveredListItemContext ?? selectedListItemContext
+                  if (targetListItemContext) {
+                    selectNestedListItemNode(editor, targetListItemContext)
+                  }
+                  return
+                }
                 promoteTopLevelBlockSelection(blockHandleState.blockIndex)
               }}
               onPointerDown={(event) => {
                 if (event.button !== 0) return
                 event.preventDefault()
                 event.stopPropagation()
+                if (blockHandleState.kind === "list-item") {
+                  return
+                }
                 const sourceIndex = blockHandleState.blockIndex
                 const sourceElement = getTopLevelBlockElementByIndex(sourceIndex)
                 const sourceRect = sourceElement?.getBoundingClientRect()
@@ -9789,7 +10120,7 @@ const BlockEditorEngine = ({
             }}
           />
         ) : null}
-        {isCoarsePointer && blockHandleState.visible ? (
+        {isCoarsePointer && blockHandleState.visible && blockHandleState.kind === "top-level" ? (
           <MobileBlockActionBar
             style={{
               left: `${Math.max(16, blockHandleState.left + 54 + blockHandleState.width / 2)}px`,
@@ -10583,6 +10914,22 @@ const EditorViewport = styled.div`
     background: ${({ theme }) =>
       theme.scheme === "dark" ? "rgba(59, 130, 246, 0.12)" : "rgba(59, 130, 246, 0.1)"};
     box-shadow: none;
+  }
+
+  .aq-block-editor__content li[data-list-item="true"][data-block-hovered="true"],
+  .aq-block-editor__content li[data-task-item="true"][data-block-hovered="true"] {
+    background: ${({ theme }) =>
+      theme.scheme === "dark" ? "rgba(59, 130, 246, 0.08)" : "rgba(59, 130, 246, 0.08)"};
+    box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.18);
+    border-radius: 10px;
+  }
+
+  .aq-block-editor__content li[data-list-item="true"][data-block-selected="true"],
+  .aq-block-editor__content li[data-task-item="true"][data-block-selected="true"] {
+    background: ${({ theme }) =>
+      theme.scheme === "dark" ? "rgba(59, 130, 246, 0.12)" : "rgba(59, 130, 246, 0.1)"};
+    box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.2);
+    border-radius: 10px;
   }
 
   .aq-block-editor__content > *[data-block-dragging="true"] {


### PR DESCRIPTION
## 관련 이슈

close #46

## 작업 배경

- 관리자 block editor에서 리스트 항목 내부 `Tab`/`Shift+Tab`이 top-level 블록 선택으로 승격되던 경로를 분리해, Notion처럼 단계 승강이 우선되도록 복구했습니다.
- 연속된 bullet/ordered/task list를 wrapper 한 덩어리가 아니라 각 list item 기준으로 hover/selection/handle 대상이 되도록 정렬했습니다.
- drag reorder E2E는 native drag 타임아웃 시 즉시 fallback 경로로 내려가도록 안정화했습니다.

## 작업 내용

- `BlockEditorEngine`의 Tab capture, outer selection gesture, block handle target 계산을 nested list item 기준으로 보강했습니다.
- writer/engine authoring 회귀에 리스트 단계 승강과 항목별 handle 검증을 추가했습니다.
- slash menu interaction의 task reorder 검증을 fail-fast fallback 구조로 바꿔 CI flake를 줄였습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (2회 연속)
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` (2회 연속)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: nested list item selection 계산이 다른 block handle hover 경로와 충돌하면 writer surface에서 외곽 클릭 선택 UX가 달라질 수 있습니다.
- 롤백 방법: `fix(editor): list indent 단계 전환과 개별 블록 취급 복구` commit revert

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
