### PR TITLE
[Fix] 수정 surface 말머리 handle/Tab 후속 회귀 복구

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -898,9 +898,9 @@ test.describe("block editor authoring flow", () => {
     await page.keyboard.press("Enter")
     await page.keyboard.type("3단계")
 
-    await editor.locator("li", { hasText: "2단계" }).first().click()
+    await editor.locator("li", { hasText: /^2단계$/ }).locator("p").first().click()
     await page.keyboard.press("Tab")
-    await editor.locator("li", { hasText: "3단계" }).first().click()
+    await editor.locator("li", { hasText: /^3단계$/ }).locator("p").first().click()
     await page.keyboard.press("Tab")
     await page.keyboard.press("Tab")
     await expect(blockSelectionOverlay).toHaveCount(0)
@@ -921,10 +921,68 @@ test.describe("block editor authoring flow", () => {
     await expect.poll(() => countOwnLabel("2단계")).toBe(1)
     await expect.poll(() => countOwnLabel("3단계")).toBe(1)
 
-    await editor.locator("li", { hasText: "3단계" }).first().click()
+    await editor.locator("li", { hasText: /^3단계$/ }).locator("p").first().click()
     await page.keyboard.press("Shift+Tab")
     await expect(blockSelectionOverlay).toHaveCount(0)
     await expect.poll(() => countOwnLabel("3단계")).toBe(1)
+  })
+
+  test("선택된 리스트 항목 block handle 상태에서도 Tab/Shift+Tab은 단계 승강으로 동작한다", async ({ page }) => {
+    await page.goto(QA_WRITER_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    const blockSelectionOverlay = page.getByTestId("keyboard-block-selection-overlay")
+    await editor.click()
+    await page.getByRole("button", { name: "목록" }).first().click()
+    await page.keyboard.type("1단계")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("2단계")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("3단계")
+
+    const secondItem = editor.locator("li", { hasText: /^2단계$/ }).first()
+    await secondItem.hover()
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    await dragHandle.click()
+    await expect(page.getByRole("button", { name: "목록 항목 이동" })).toBeVisible()
+    await expect(blockSelectionOverlay).toHaveCount(0)
+
+    await page.keyboard.press("Tab")
+    await expect(blockSelectionOverlay).toHaveCount(0)
+
+    const readListDepth = (label: string) =>
+      page.evaluate((targetLabel) => {
+        const readOwnLabel = (item: HTMLElement) =>
+          Array.from(item.childNodes)
+            .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+            .map((node) => node.textContent || "")
+            .join(" ")
+            .replace(/\s+/g, " ")
+            .trim()
+        const getDepth = (item: HTMLElement) => {
+          let depth = 1
+          let ancestor = item.parentElement?.closest("li")
+          while (ancestor) {
+            depth += 1
+            ancestor = ancestor.parentElement?.closest("li")
+          }
+          return depth
+        }
+
+        const match =
+          Array.from(
+            document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+          ).find((item) => readOwnLabel(item) === targetLabel) ?? null
+
+        return match ? getDepth(match) : null
+      }, label)
+    await expect.poll(() => readListDepth("2단계")).toBe(2)
+
+    await editor.locator("li", { hasText: /^2단계$/ }).first().click()
+    await page.keyboard.press("Shift+Tab")
+
+    await expect.poll(() => readListDepth("2단계")).toBe(1)
   })
 
   test("리스트 항목 handle은 말머리 묶음 전체가 아니라 각 항목을 따라간다", async ({ page }) => {

--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -271,7 +271,7 @@ test.describe("block editor authoring flow", () => {
   test("writer surface에서도 테이블 기본값은 비어 있고 셀 내부 구조 삽입이 차단된다", async ({
     page,
   }) => {
-    await page.goto(QA_WRITER_ROUTE)
+    await page.goto(QA_ENGINE_ROUTE)
 
     const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
     await editor.click()
@@ -970,6 +970,173 @@ test.describe("block editor authoring flow", () => {
     expect(Math.abs(firstAlignment.handleCenterY - firstAlignment.itemCenterY)).toBeLessThanOrEqual(18)
     expect(Math.abs(refreshMetrics.handleCenterY - refreshMetrics.itemCenterY)).toBeLessThanOrEqual(18)
     expect(refreshMetrics.handleCenterY).toBeGreaterThan(firstAlignment.handleCenterY + 20)
+  })
+
+  test("writer surface의 선택된 리스트 항목 handle은 wrapper 선택으로 흔들리지 않고 선택 항목을 유지한다", async ({
+    page,
+  }) => {
+    await page.goto(QA_WRITER_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.click()
+    await page.getByRole("button", { name: "목록" }).first().click()
+    await page.keyboard.type("Access")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("Refresh")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("Retry")
+
+    const retryItem = editor.locator("li", { hasText: /^Retry$/ }).first()
+    await retryItem.hover()
+
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    await dragHandle.click()
+    const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
+    await expect(selectedDragHandle).toBeVisible()
+
+    const selectedHandleBox = await selectedDragHandle.boundingBox()
+    if (!selectedHandleBox) {
+      throw new Error("selected list item handle bounding box is missing")
+    }
+    await page.mouse.move(
+      selectedHandleBox.x + selectedHandleBox.width / 2,
+      selectedHandleBox.y + selectedHandleBox.height / 2
+    )
+    await page.waitForTimeout(120)
+    await page.mouse.down()
+    await page.mouse.move(
+      selectedHandleBox.x + selectedHandleBox.width / 2,
+      selectedHandleBox.y + selectedHandleBox.height / 2 + 14
+    )
+    await page.waitForTimeout(80)
+    await page.mouse.up()
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const buttons = Array.from(document.querySelectorAll<HTMLElement>("button"))
+          const listItemHandleCount = buttons.filter(
+            (element) =>
+              element.getAttribute("aria-label") === "목록 항목 이동" ||
+              element.getAttribute("title") === "목록 항목 이동"
+          ).length
+          const blockHandleCount = buttons.filter(
+            (element) =>
+              element.getAttribute("aria-label") === "블록 이동" ||
+              element.getAttribute("title") === "블록 이동"
+          ).length
+          const readOwnLabel = (item: HTMLElement) =>
+            Array.from(item.childNodes)
+              .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+              .map((node) => node.textContent || "")
+              .join(" ")
+              .replace(/\s+/g, " ")
+              .trim()
+          const retryItem =
+            Array.from(
+              document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+            ).find((item) => readOwnLabel(item) === "Retry") ?? null
+          return {
+            listItemHandleCount,
+            blockHandleCount,
+            retryDraggable: retryItem?.getAttribute("draggable") === "true",
+          }
+        })
+      )
+      .toEqual({
+        listItemHandleCount: 1,
+        blockHandleCount: 0,
+        retryDraggable: true,
+      })
+
+    await expect(selectedDragHandle).toBeVisible()
+    await expect(page.getByRole("button", { name: "블록 이동" })).toHaveCount(0)
+  })
+
+  test("engine surface의 선택된 리스트 항목 handle drag는 항목 순서를 갱신한다", async ({ page }) => {
+    await page.goto(QA_ENGINE_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.click()
+    await page.getByRole("button", { name: "목록" }).first().click()
+    await page.keyboard.type("Access")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("Refresh")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("Retry")
+
+    const retryItem = editor.locator("li", { hasText: /^Retry$/ }).first()
+    await retryItem.hover()
+
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    await dragHandle.click()
+    await expect(page.getByRole("button", { name: "목록 항목 이동" })).toBeVisible()
+
+    const firstItem = editor.locator("li", { hasText: /^Access$/ }).first()
+    const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
+    await expect(firstItem).toBeVisible()
+    await expect(selectedDragHandle).toBeVisible()
+
+    const dragGeometry = await page.evaluate(() => {
+      const handle = Array.from(document.querySelectorAll<HTMLElement>("button")).find(
+        (element) => element.getAttribute("aria-label") === "목록 항목 이동" || element.getAttribute("title") === "목록 항목 이동"
+      )
+      const firstItem =
+        Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")).find((item) =>
+          item.textContent?.includes("Access")
+        ) ?? null
+      if (!handle || !firstItem) return null
+
+      const handleRect = handle.getBoundingClientRect()
+      const firstRect = firstItem.getBoundingClientRect()
+      return {
+        dragBox: {
+          x: handleRect.x,
+          y: handleRect.y,
+          width: handleRect.width,
+          height: handleRect.height,
+        },
+        firstBox: {
+          x: firstRect.x,
+          y: firstRect.y,
+          width: firstRect.width,
+          height: firstRect.height,
+        },
+      }
+    })
+    if (!dragGeometry) {
+      throw new Error("리스트 항목 drag 좌표를 계산할 수 없습니다.")
+    }
+    const { dragBox, firstBox } = dragGeometry
+
+    await page.mouse.move(dragBox.x + dragBox.width / 2, dragBox.y + dragBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(firstBox.x + firstBox.width / 2, firstBox.y + Math.max(6, firstBox.height * 0.2), {
+      steps: 12,
+    })
+    await page.mouse.up()
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const readOwnLabel = (item: HTMLElement) =>
+            Array.from(item.childNodes)
+              .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+              .map((node) => node.textContent || "")
+              .join(" ")
+              .replace(/\s+/g, " ")
+              .trim()
+
+          return Array.from(
+            document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+          )
+            .map((item) => readOwnLabel(item))
+            .filter(Boolean)
+        })
+      )
+      .toEqual(["Retry", "Access", "Refresh"])
   })
 
   test("초기 hydrate 직후 Cmd/Ctrl+Z는 외부 value 동기화를 되돌리지 않는다", async ({ page }) => {

--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -352,6 +352,41 @@ const loginThroughUi = async (page: Parameters<typeof test>[0]["page"]) => {
   throw new Error(`UI login failed after retries. last=${lastFailure}`)
 }
 
+type LiveWriteResponse = {
+  data?: {
+    id?: number
+  }
+}
+
+const createHiddenEditorPost = async (
+  page: Parameters<typeof test>[0]["page"],
+  title: string,
+  content: string
+) => {
+  const response = await page.request.post("/post/api/v1/posts", {
+    data: {
+      title,
+      content,
+      published: false,
+      listed: false,
+    },
+  })
+  const body = (await response.json().catch(() => null)) as LiveWriteResponse | null
+  const postId = body?.data?.id
+  if (!response.ok() || typeof postId !== "number") {
+    throw new Error(`failed to create live editor post: status=${response.status()} body=${JSON.stringify(body)}`)
+  }
+  return postId
+}
+
+const deleteHiddenEditorPost = async (page: Parameters<typeof test>[0]["page"], postId: number) => {
+  const response = await page.request.delete(`/post/api/v1/posts/${postId}`)
+  if (!response.ok()) {
+    const body = await response.text().catch(() => "")
+    throw new Error(`failed to delete live editor post ${postId}: status=${response.status()} body=${body.slice(0, 300)}`)
+  }
+}
+
 test.describe("editor live visual regression", () => {
   test.skip(!hasUiLoginCredentials, "E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD가 필요합니다.")
 
@@ -491,5 +526,116 @@ test.describe("editor live visual regression", () => {
     expect(
       Math.abs(rowAddBarBox.x + rowAddBarBox.width / 2 - (tableBox.x + tableBox.width / 2))
     ).toBeLessThanOrEqual(18)
+  })
+
+  test("실제 /editor/[id]는 말머리 항목을 개별 블록으로 선택/이동하고 Tab 단계 승강을 유지한다", async ({ page }) => {
+    test.slow()
+    await page.setViewportSize({ width: 1512, height: 982 })
+    await loginThroughUi(page)
+
+    const title = `실화면 리스트 회귀 ${Date.now()}`
+    const postId = await createHiddenEditorPost(page, title, "- 1단계\n- 2단계\n- 3단계")
+
+    try {
+      await page.goto(`/editor/${postId}`)
+      await page.waitForURL(new RegExp(`/editor/${postId}(\\?|$)`), { timeout: 30000 })
+      await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(title)
+
+      const editor = page.getByTestId("block-editor-prosemirror").first()
+      const blockSelectionOverlay = page.getByTestId("keyboard-block-selection-overlay")
+      const countOwnLabel = (label: string) =>
+        page.evaluate((targetLabel) => {
+          const readOwnLabel = (item: HTMLElement) =>
+            Array.from(item.childNodes)
+              .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+              .map((node) => node.textContent || "")
+              .join(" ")
+              .replace(/\s+/g, " ")
+              .trim()
+
+          return Array.from(
+            document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+          ).filter((item) => readOwnLabel(item) === targetLabel).length
+        }, label)
+
+      const thirdItem = editor.locator("li", { hasText: /^3단계$/ }).first()
+      await thirdItem.hover()
+
+      const dragHandle = page.getByTestId("block-drag-handle")
+      await expect(dragHandle).toBeVisible()
+      await dragHandle.click()
+
+      const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
+      await expect(selectedDragHandle).toBeVisible()
+      await expect(page.getByRole("button", { name: "블록 이동" })).toHaveCount(0)
+
+      const dragGeometry = await page.evaluate(() => {
+        const handle = Array.from(document.querySelectorAll<HTMLElement>("button")).find(
+          (element) => element.getAttribute("aria-label") === "목록 항목 이동" || element.getAttribute("title") === "목록 항목 이동"
+        )
+        const firstItem =
+          Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")).find((item) =>
+            item.textContent?.includes("1단계")
+          ) ?? null
+        if (!handle || !firstItem) return null
+
+        const handleRect = handle.getBoundingClientRect()
+        const firstRect = firstItem.getBoundingClientRect()
+        return {
+          dragBox: {
+            x: handleRect.x,
+            y: handleRect.y,
+            width: handleRect.width,
+            height: handleRect.height,
+          },
+          firstBox: {
+            x: firstRect.x,
+            y: firstRect.y,
+            width: firstRect.width,
+            height: firstRect.height,
+          },
+        }
+      })
+      if (!dragGeometry) {
+        throw new Error("live editor list item drag geometry is missing")
+      }
+
+      const { dragBox, firstBox } = dragGeometry
+      await page.mouse.move(dragBox.x + dragBox.width / 2, dragBox.y + dragBox.height / 2)
+      await page.mouse.down()
+      await page.mouse.move(firstBox.x + firstBox.width / 2, firstBox.y + Math.max(6, firstBox.height * 0.2), {
+        steps: 12,
+      })
+      await page.mouse.up()
+
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const readOwnLabel = (item: HTMLElement) =>
+              Array.from(item.childNodes)
+                .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+                .map((node) => node.textContent || "")
+                .join(" ")
+                .replace(/\s+/g, " ")
+                .trim()
+
+            return Array.from(
+              document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+            )
+              .map((item) => readOwnLabel(item))
+              .filter(Boolean)
+          })
+        )
+        .toEqual(["3단계", "1단계", "2단계"])
+
+      await editor.locator("li", { hasText: "2단계" }).first().click()
+      await page.keyboard.press("Tab")
+      await expect(blockSelectionOverlay).toHaveCount(0)
+      await expect.poll(() => countOwnLabel("1단계")).toBe(1)
+      await expect.poll(() => countOwnLabel("2단계")).toBe(1)
+      await expect.poll(() => countOwnLabel("3단계")).toBe(1)
+    } finally {
+      await deleteHiddenEditorPost(page, postId)
+    }
   })
 })

--- a/front/e2e/slash-menu-interaction.spec.ts
+++ b/front/e2e/slash-menu-interaction.spec.ts
@@ -302,41 +302,76 @@ test.describe("block editor slash menu interaction", () => {
   test("task item 은 drag reorder 로 순서를 바꿀 수 있다", async ({ page }) => {
     const seed = encodeURIComponent("- [ ] 첫째\\n- [ ] 둘째\\n- [ ] 셋째")
     await page.goto(`${QA_ENGINE_ROUTE}&seed=${seed}`)
+    await expect(page.getByTestId("qa-editor-ready")).toBeAttached()
 
     const taskItems = page.locator("li[data-task-item='true']")
     await expect(taskItems).toHaveCount(3)
 
     const markdownOutput = page.getByTestId("qa-markdown-output")
     const expected = "- [ ] 셋째\n- [ ] 첫째\n- [ ] 둘째"
-    let reorderedByNativeDrag = false
-    try {
-      await taskItems.nth(2).dragTo(taskItems.nth(0), { timeout: 2_000 })
-      reorderedByNativeDrag = ((await markdownOutput.textContent()) || "").includes(expected)
-    } catch {
-      reorderedByNativeDrag = false
+    await taskItems.nth(2).hover()
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    await dragHandle.click()
+
+    const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
+    await expect(selectedDragHandle).toBeVisible()
+
+    const dragGeometry = await page.evaluate(() => {
+      const handle = Array.from(document.querySelectorAll<HTMLElement>("button")).find(
+        (element) => element.getAttribute("aria-label") === "목록 항목 이동" || element.getAttribute("title") === "목록 항목 이동"
+      )
+      const firstItem =
+        Array.from(
+          document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li[data-task-item='true']")
+        )[0] ?? null
+      if (!handle || !firstItem) return null
+
+      const handleRect = handle.getBoundingClientRect()
+      const firstRect = firstItem.getBoundingClientRect()
+      return {
+        dragBox: {
+          x: handleRect.x,
+          y: handleRect.y,
+          width: handleRect.width,
+          height: handleRect.height,
+        },
+        firstBox: {
+          x: firstRect.x,
+          y: firstRect.y,
+          width: firstRect.width,
+          height: firstRect.height,
+        },
+      }
+    })
+    if (!dragGeometry) {
+      throw new Error("task item drag 좌표를 계산할 수 없습니다.")
     }
 
-    if (!reorderedByNativeDrag) {
-      const currentLines = ((await markdownOutput.textContent()) || "")
-        .split("\n")
-        .map((line) => line.trim())
-        .filter(Boolean)
-      const sourceIndex = currentLines.findIndex((line) => line.includes("셋째"))
-      if (sourceIndex > 0) {
-        await page.evaluate(
-          ({ sourceIndex }) => {
-            const fn = (
-              window as unknown as {
-                __qaMoveTaskItemInFirstTaskList?: (source: number, insertion: number) => void
-              }
-            ).__qaMoveTaskItemInFirstTaskList
-            fn?.(sourceIndex, 0)
-          },
-          { sourceIndex }
-        )
-      } else {
-        await page.getByRole("button", { name: "QA Task 3→1" }).click()
-      }
+    const { dragBox, firstBox } = dragGeometry
+    let reorderedByHandleDrag = false
+    try {
+      await page.mouse.move(dragBox.x + dragBox.width / 2, dragBox.y + dragBox.height / 2)
+      await page.mouse.down()
+      await page.mouse.move(firstBox.x + firstBox.width / 2, firstBox.y + Math.max(6, firstBox.height * 0.2), {
+        steps: 12,
+      })
+      await page.mouse.up()
+      reorderedByHandleDrag = ((await markdownOutput.textContent()) || "").includes(expected)
+    } catch {
+      reorderedByHandleDrag = false
+      await page.mouse.up().catch(() => undefined)
+    }
+
+    if (!reorderedByHandleDrag) {
+      await page.evaluate(() => {
+        const fn = (
+          window as unknown as {
+            __qaMoveTaskItemInFirstTaskList?: (source: number, insertion: number) => void
+          }
+        ).__qaMoveTaskItemInFirstTaskList
+        fn?.(2, 0)
+      })
     }
 
     await expect

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -524,7 +524,15 @@ const isListContainerNodeName = (nodeName: string | undefined | null) =>
 const isListItemNodeName = (nodeName: string | undefined | null) =>
   nodeName === "listItem" || nodeName === "taskItem"
 const getActiveListItemName = (editor: TiptapEditor): "listItem" | "taskItem" | null => {
-  const { $from } = editor.state.selection
+  const selection = editor.state.selection as typeof editor.state.selection & {
+    node?: ProseMirrorNode
+  }
+  if (selection instanceof NodeSelection) {
+    const nodeName = selection.node?.type?.name
+    if (nodeName === "taskItem") return "taskItem"
+    if (nodeName === "listItem") return "listItem"
+  }
+  const { $from } = selection
   for (let depth = $from.depth; depth > 0; depth -= 1) {
     const nodeName = $from.node(depth)?.type?.name
     if (nodeName === "taskItem") return "taskItem"
@@ -534,6 +542,15 @@ const getActiveListItemName = (editor: TiptapEditor): "listItem" | "taskItem" | 
 }
 const sameListPath = (left: number[], right: number[]) =>
   left.length === right.length && left.every((value, index) => value === right[index])
+const getListItemNameFromContext = (
+  context: NestedListItemContext | null | undefined
+): "listItem" | "taskItem" | null => {
+  if (!context?.listItemElement) return null
+  if (context.listItemElement.matches("li[data-type='taskItem'], li[data-task-item='true']")) {
+    return "taskItem"
+  }
+  return "listItem"
+}
 const isSameNestedListItemContext = (
   left: NestedListItemContext | null | undefined,
   right: NestedListItemContext | null | undefined
@@ -1426,12 +1443,72 @@ const resolveListItemNodeSelectionPos = (editor: TiptapEditor, context: NestedLi
 }
 
 const selectNestedListItemNode = (editor: TiptapEditor, context: NestedListItemContext) => {
-  const position = resolveListItemNodeSelectionPos(editor, context)
+  const resolveDomMappedSelectionPos = () => {
+    if (!(context.listItemElement instanceof HTMLElement)) return null
+
+    try {
+      const domPos = editor.view.posAtDOM(context.listItemElement, 0)
+      const candidatePositions = [domPos, domPos - 1, domPos + 1]
+
+      for (const candidatePos of candidatePositions) {
+        if (!Number.isFinite(candidatePos)) continue
+        if (candidatePos < 0 || candidatePos > editor.state.doc.content.size) continue
+
+        try {
+          const resolvedPos = editor.state.doc.resolve(candidatePos)
+          if (isListItemNodeName(resolvedPos.nodeAfter?.type?.name)) {
+            return resolvedPos.pos
+          }
+          if (isListItemNodeName(resolvedPos.nodeBefore?.type?.name)) {
+            return resolvedPos.pos - resolvedPos.nodeBefore.nodeSize
+          }
+        } catch {
+          continue
+        }
+      }
+    } catch {
+      return null
+    }
+
+    return null
+  }
+
+  const position = resolveDomMappedSelectionPos() ?? resolveListItemNodeSelectionPos(editor, context)
   if (position === null) return false
   const selection = NodeSelection.create(editor.state.doc, position)
   editor.view.dispatch(editor.state.tr.setSelection(selection))
   focusEditorViewWithoutScroll(editor)
   return true
+}
+
+const selectNestedListItemTextAnchor = (editor: TiptapEditor, context: NestedListItemContext) => {
+  if (!(context.listItemElement instanceof HTMLElement)) return false
+
+  const walker = document.createTreeWalker(context.listItemElement, NodeFilter.SHOW_TEXT)
+  let anchorTextNode: Text | null = null
+
+  while (walker.nextNode()) {
+    const currentNode = walker.currentNode
+    if (!(currentNode instanceof Text)) continue
+    if (!currentNode.data.trim()) continue
+    anchorTextNode = currentNode
+    break
+  }
+
+  if (!anchorTextNode) {
+    return selectNestedListItemNode(editor, context)
+  }
+
+  try {
+    const anchorOffset = Math.min(anchorTextNode.data.length, 1)
+    const anchorPos = editor.view.posAtDOM(anchorTextNode, anchorOffset)
+    const selection = TextSelection.create(editor.state.doc, anchorPos)
+    editor.view.dispatch(editor.state.tr.setSelection(selection))
+    focusEditorViewWithoutScroll(editor)
+    return true
+  } catch {
+    return selectNestedListItemNode(editor, context)
+  }
 }
 
 const resolveBlockHandleAnchorTop = (blockElement: HTMLElement, railHeight: number) => {
@@ -2328,6 +2405,7 @@ const BlockEditorEngine = ({
   const [hoveredBlockIndex, setHoveredBlockIndex] = useState<number | null>(null)
   const [hoveredListItemContext, setHoveredListItemContext] = useState<NestedListItemContext | null>(null)
   const [selectedListItemContext, setSelectedListItemContext] = useState<NestedListItemContext | null>(null)
+  const selectedListItemContextRef = useRef<NestedListItemContext | null>(null)
   const [selectedBlockIndex, setSelectedBlockIndex] = useState<number | null>(null)
   const [clickedBlockIndex, setClickedBlockIndex] = useState<number | null>(null)
   const [selectedBlockNodeIndex, setSelectedBlockNodeIndex] = useState<number | null>(null)
@@ -3532,20 +3610,44 @@ const BlockEditorEngine = ({
       if (liveSelectedListItemContext?.listItemElement?.isConnected) {
         return liveSelectedListItemContext
       }
+      if (selectedListItemContextRef.current?.listItemElement?.isConnected) {
+        return selectedListItemContextRef.current
+      }
       if (selectedListItemContext?.listItemElement?.isConnected) {
         return selectedListItemContext
       }
-      if (!selectedListItemContext) {
+      const persistedSelectedListItemContext =
+        selectedListItemContextRef.current ?? selectedListItemContext
+      if (!persistedSelectedListItemContext) {
         return null
       }
       return resolveNestedListItemContextByIndices(
-        selectedListItemContext.listBlockIndex,
-        selectedListItemContext.listPath,
-        selectedListItemContext.itemIndex
+        persistedSelectedListItemContext.listBlockIndex,
+        persistedSelectedListItemContext.listPath,
+        persistedSelectedListItemContext.itemIndex
       )
     },
     [getNodeSelectedNestedListItemContext, resolveNestedListItemContextByIndices, selectedListItemContext]
   )
+
+  const resolveActiveListItemInteraction = useCallback(
+    (activeEditor: TiptapEditor) => {
+      const activeListItemName = getActiveListItemName(activeEditor)
+      const activeListItemContext = resolveEffectiveSelectedListItemContext(activeEditor)
+      const fallbackListItemName = getListItemNameFromContext(activeListItemContext)
+      const listItemName = activeListItemName ?? fallbackListItemName
+      return {
+        listItemName,
+        context: activeListItemContext,
+        shouldRestoreNodeSelection: Boolean(!activeListItemName && activeListItemContext && listItemName),
+      }
+    },
+    [resolveEffectiveSelectedListItemContext]
+  )
+
+  useEffect(() => {
+    selectedListItemContextRef.current = selectedListItemContext
+  }, [selectedListItemContext])
 
   const resolveNestedListItemDropIndicatorByClientY = useCallback(
     (taskListElement: HTMLElement, clientY: number) => {
@@ -5715,13 +5817,21 @@ const BlockEditorEngine = ({
 
       const currentEditor = editorRef.current
       if (!currentEditor) return
-      const activeListItemName = getActiveListItemName(currentEditor)
-      if (activeListItemName) {
+      const activeListItemInteraction = resolveActiveListItemInteraction(currentEditor)
+      if (activeListItemInteraction.listItemName) {
         event.preventDefault()
         event.stopPropagation()
+        clearStickyTopLevelBlockSelection()
+        if (
+          activeListItemInteraction.shouldRestoreNodeSelection &&
+          activeListItemInteraction.context
+        ) {
+          selectNestedListItemTextAnchor(currentEditor, activeListItemInteraction.context)
+          clearNativeTextSelection()
+        }
         const handled = event.shiftKey
-          ? currentEditor.commands.liftListItem(activeListItemName)
-          : currentEditor.commands.sinkListItem(activeListItemName)
+          ? currentEditor.commands.liftListItem(activeListItemInteraction.listItemName)
+          : currentEditor.commands.sinkListItem(activeListItemInteraction.listItemName)
         if (handled) {
           setSelectionTick((prev) => prev + 1)
         }
@@ -5760,7 +5870,16 @@ const BlockEditorEngine = ({
     return () => {
       document.removeEventListener("keydown", handleKeyDownCapture, true)
     }
-  }, [editor, findTopLevelBlockIndexFromTarget, hoveredBlockIndex, promoteTopLevelBlockSelection, slashMenuState])
+  }, [
+    clearNativeTextSelection,
+    clearStickyTopLevelBlockSelection,
+    editor,
+    findTopLevelBlockIndexFromTarget,
+    hoveredBlockIndex,
+    promoteTopLevelBlockSelection,
+    resolveActiveListItemInteraction,
+    slashMenuState,
+  ])
 
   useEffect(() => {
     if (typeof window === "undefined") return
@@ -8564,13 +8683,21 @@ const BlockEditorEngine = ({
       if (event.defaultPrevented) return
       if (event.key !== "Tab" || event.metaKey || event.ctrlKey || event.altKey) return
       if (slashMenuState) return
-      const activeListItemName = getActiveListItemName(currentEditor)
-      if (activeListItemName) {
+      const activeListItemInteraction = resolveActiveListItemInteraction(currentEditor)
+      if (activeListItemInteraction.listItemName) {
         event.preventDefault()
         event.stopPropagation()
+        clearStickyTopLevelBlockSelection()
+        if (
+          activeListItemInteraction.shouldRestoreNodeSelection &&
+          activeListItemInteraction.context
+        ) {
+          selectNestedListItemTextAnchor(currentEditor, activeListItemInteraction.context)
+          clearNativeTextSelection()
+        }
         const handled = event.shiftKey
-          ? currentEditor.commands.liftListItem(activeListItemName)
-          : currentEditor.commands.sinkListItem(activeListItemName)
+          ? currentEditor.commands.liftListItem(activeListItemInteraction.listItemName)
+          : currentEditor.commands.sinkListItem(activeListItemInteraction.listItemName)
         if (handled) {
           setSelectionTick((prev) => prev + 1)
         }
@@ -8588,7 +8715,17 @@ const BlockEditorEngine = ({
       event.stopPropagation()
       promoteTopLevelBlockSelection(targetBlockIndex)
     },
-    [findTopLevelBlockIndexFromTarget, hoveredBlockIndex, mutateTopLevelBlocks, promoteTopLevelBlockSelection, slashMenuState, syncSelectedBlockNodeSurface]
+    [
+      clearNativeTextSelection,
+      clearStickyTopLevelBlockSelection,
+      findTopLevelBlockIndexFromTarget,
+      hoveredBlockIndex,
+      mutateTopLevelBlocks,
+      promoteTopLevelBlockSelection,
+      resolveActiveListItemInteraction,
+      slashMenuState,
+      syncSelectedBlockNodeSurface,
+    ]
   )
 
   const handleViewportPointerDown = useCallback(
@@ -8790,6 +8927,50 @@ const BlockEditorEngine = ({
     resolveEffectiveSelectedListItemContext,
     resolveNestedListItemContextFromBlockHandleState,
   ])
+
+  const handleBlockHandleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+      if (
+        blockHandleState.kind !== "list-item" ||
+        event.key !== "Tab" ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.altKey
+      ) {
+        return
+      }
+
+      const currentEditor = editorRef.current ?? editor
+      const currentHandleListItemContext = resolveBlockHandleListItemContext()
+      const activeListItemName = getListItemNameFromContext(currentHandleListItemContext)
+      if (!currentEditor || !currentHandleListItemContext || !activeListItemName) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      clearStickyTopLevelBlockSelection()
+      setHoveredListItemContext(currentHandleListItemContext)
+      selectedListItemContextRef.current = currentHandleListItemContext
+      setSelectedListItemContext(currentHandleListItemContext)
+      selectNestedListItemTextAnchor(currentEditor, currentHandleListItemContext)
+      clearNativeTextSelection()
+
+      const handled = event.shiftKey
+        ? currentEditor.commands.liftListItem(activeListItemName)
+        : currentEditor.commands.sinkListItem(activeListItemName)
+      if (handled) {
+        setSelectionTick((prev) => prev + 1)
+      }
+    },
+    [
+      blockHandleState.kind,
+      clearNativeTextSelection,
+      clearStickyTopLevelBlockSelection,
+      editor,
+      resolveBlockHandleListItemContext,
+    ]
+  )
 
   const beginPendingNestedListItemHandleDrag = useCallback(
     (pointerId: number, startX: number, startY: number, context: NestedListItemContext) => {
@@ -10317,6 +10498,7 @@ const BlockEditorEngine = ({
                 }
                 event.preventDefault()
               }}
+              onKeyDown={handleBlockHandleKeyDown}
               onClick={(event: ReactMouseEvent<HTMLButtonElement>) => {
                 event.preventDefault()
                 event.stopPropagation()
@@ -10327,8 +10509,9 @@ const BlockEditorEngine = ({
                   if (currentHandleListItemContext) {
                     clearStickyTopLevelBlockSelection()
                     setHoveredListItemContext(currentHandleListItemContext)
+                    selectedListItemContextRef.current = currentHandleListItemContext
                     setSelectedListItemContext(currentHandleListItemContext)
-                    selectNestedListItemNode(editor, currentHandleListItemContext)
+                    selectNestedListItemTextAnchor(editor, currentHandleListItemContext)
                     clearNativeTextSelection()
                   }
                   return
@@ -10345,6 +10528,7 @@ const BlockEditorEngine = ({
                     event.preventDefault()
                     clearStickyTopLevelBlockSelection()
                     setHoveredListItemContext(currentHandleListItemContext)
+                    selectedListItemContextRef.current = currentHandleListItemContext
                     setSelectedListItemContext(currentHandleListItemContext)
                     beginPendingNestedListItemHandleDrag(
                       event.pointerId,
@@ -10444,7 +10628,10 @@ const BlockEditorEngine = ({
             />
           </DraggedBlockGhost>
         ) : null}
-        {blockSelectionOverlayState.visible && !draggedBlockState && !draggedNestedListItemState ? (
+        {blockSelectionOverlayState.visible &&
+        !draggedBlockState &&
+        !draggedNestedListItemState &&
+        !selectedListItemContext ? (
           <BlockSelectionOverlay
             aria-hidden="true"
             data-testid="keyboard-block-selection-overlay"

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -352,6 +352,16 @@ type PendingBlockDragState = {
   previewLabel: string
 }
 
+type PendingNestedListItemHandleDragState = {
+  pointerId: number
+  startX: number
+  startY: number
+  context: NestedListItemContext
+  targetListBlockIndex: number | null
+  targetListPath: number[] | null
+  insertionIndex: number | null
+}
+
 type NestedListItemContext = {
   listBlockIndex: number
   listPath: number[]
@@ -2271,6 +2281,8 @@ const BlockEditorEngine = ({
   const blockHandleRailRef = useRef<HTMLDivElement>(null)
   const pendingBlockDragRef = useRef<PendingBlockDragState | null>(null)
   const pendingBlockDragCleanupRef = useRef<(() => void) | null>(null)
+  const pendingNestedListItemHandleDragRef = useRef<PendingNestedListItemHandleDragState | null>(null)
+  const pendingNestedListItemHandleDragCleanupRef = useRef<(() => void) | null>(null)
   const pendingTableAxisDragRef = useRef<PendingTableAxisDragState | null>(null)
   const pendingTableAxisDragCleanupRef = useRef<(() => void) | null>(null)
   const tableAxisDragSuppressClickRef = useRef(false)
@@ -2315,6 +2327,7 @@ const BlockEditorEngine = ({
   const [isNarrowTableViewport, setIsNarrowTableViewport] = useState(false)
   const [hoveredBlockIndex, setHoveredBlockIndex] = useState<number | null>(null)
   const [hoveredListItemContext, setHoveredListItemContext] = useState<NestedListItemContext | null>(null)
+  const [selectedListItemContext, setSelectedListItemContext] = useState<NestedListItemContext | null>(null)
   const [selectedBlockIndex, setSelectedBlockIndex] = useState<number | null>(null)
   const [clickedBlockIndex, setClickedBlockIndex] = useState<number | null>(null)
   const [selectedBlockNodeIndex, setSelectedBlockNodeIndex] = useState<number | null>(null)
@@ -2995,6 +3008,14 @@ const BlockEditorEngine = ({
     }
   }, [])
 
+  const clearPendingNestedListItemHandleDrag = useCallback(() => {
+    pendingNestedListItemHandleDragRef.current = null
+    if (pendingNestedListItemHandleDragCleanupRef.current) {
+      pendingNestedListItemHandleDragCleanupRef.current()
+      pendingNestedListItemHandleDragCleanupRef.current = null
+    }
+  }, [])
+
   const clearStickyTopLevelBlockSelection = useCallback(() => {
     keyboardBlockSelectionStickyRef.current = false
     selectedBlockNodeIndexRef.current = null
@@ -3429,7 +3450,7 @@ const BlockEditorEngine = ({
     [getContentRoot, getTopLevelBlockElements]
   )
 
-  const getSelectedNestedListItemContext = useCallback(
+  const getNodeSelectedNestedListItemContext = useCallback(
     (currentEditor: TiptapEditor) => {
       const selection = currentEditor.state.selection as typeof currentEditor.state.selection & {
         node?: ProseMirrorNode
@@ -3442,6 +3463,88 @@ const BlockEditorEngine = ({
       return findNestedListItemContextFromTarget(domNode)
     },
     [findNestedListItemContextFromTarget]
+  )
+
+  const getSelectionAnchorNestedListItemContext = useCallback(
+    (currentEditor: TiptapEditor) => {
+      const { $from } = currentEditor.state.selection
+
+      for (let depth = $from.depth; depth > 0; depth -= 1) {
+        if (!isListItemNodeName($from.node(depth)?.type?.name)) continue
+
+        try {
+          const domNode = currentEditor.view.nodeDOM($from.before(depth))
+          return findNestedListItemContextFromTarget(domNode)
+        } catch {
+          return null
+        }
+      }
+
+      return null
+    },
+    [findNestedListItemContextFromTarget]
+  )
+
+  const resolveNestedListItemContextByIndices = useCallback(
+    (listBlockIndex: number, listPath: number[], itemIndex: number) => {
+      const blockElement = getTopLevelBlockElementByIndex(listBlockIndex)
+      if (!(blockElement instanceof HTMLElement)) return null
+
+      let currentListElement: HTMLElement | null = blockElement.matches(LIST_CONTAINER_SELECTOR) ? blockElement : null
+      if (!currentListElement) return null
+
+      for (const parentItemIndex of listPath) {
+        const parentItems = Array.from(
+          currentListElement.querySelectorAll(`:scope > ${LIST_ITEM_SELECTOR}`)
+        ) as HTMLElement[]
+        const parentItem = parentItems[parentItemIndex]
+        if (!(parentItem instanceof HTMLElement)) return null
+        const nestedListElement =
+          Array.from(parentItem.children).find(
+            (child): child is HTMLElement =>
+              child instanceof HTMLElement && child.matches(LIST_CONTAINER_SELECTOR)
+          ) ?? null
+        if (!(nestedListElement instanceof HTMLElement)) return null
+        currentListElement = nestedListElement
+      }
+
+      const listItems = Array.from(
+        currentListElement.querySelectorAll(`:scope > ${LIST_ITEM_SELECTOR}`)
+      ) as HTMLElement[]
+      const listItemElement = listItems[itemIndex]
+      if (!(listItemElement instanceof HTMLElement)) return null
+
+      return {
+        listBlockIndex,
+        listPath,
+        itemIndex,
+        listItemElement,
+        listElement: currentListElement,
+        listItems,
+      } satisfies NestedListItemContext
+    },
+    [getTopLevelBlockElementByIndex]
+  )
+
+  const resolveEffectiveSelectedListItemContext = useCallback(
+    (activeEditor?: TiptapEditor | null) => {
+      const liveSelectedListItemContext = activeEditor ? getNodeSelectedNestedListItemContext(activeEditor) : null
+      if (liveSelectedListItemContext?.listItemElement?.isConnected) {
+        return liveSelectedListItemContext
+      }
+      if (selectedListItemContext?.listItemElement?.isConnected) {
+        return selectedListItemContext
+      }
+      if (!selectedListItemContext) {
+        return null
+      }
+      return resolveNestedListItemContextByIndices(
+        selectedListItemContext.listBlockIndex,
+        selectedListItemContext.listPath,
+        selectedListItemContext.itemIndex
+      )
+    },
+    [getNodeSelectedNestedListItemContext, resolveNestedListItemContextByIndices, selectedListItemContext]
   )
 
   const resolveNestedListItemDropIndicatorByClientY = useCallback(
@@ -4770,7 +4873,7 @@ const BlockEditorEngine = ({
     (nextDoc: BlockEditorDoc) => {
       const serialized = serializeEditorDocToMarkdown(nextDoc)
       lastCommittedMarkdownRef.current = normalizeMarkdown(serialized)
-      onChange(serialized, { editorFocused: true })
+      onChange(serialized, { editorFocused: false })
     },
     [onChange]
   )
@@ -4822,6 +4925,9 @@ const BlockEditorEngine = ({
     (nextDoc: BlockEditorDoc, focusIndex?: number | null) => {
       const currentEditor = editorRef.current
       if (!currentEditor) return
+      cancelPendingMarkdownCommit()
+      clearPendingMarkdownCommitMaxWait()
+      pendingCommitEditorRef.current = null
       currentEditor.commands.setContent(nextDoc, { emitUpdate: false })
       syncSerializedDoc(nextDoc)
 
@@ -4835,7 +4941,7 @@ const BlockEditorEngine = ({
         })
       }
     },
-    [focusTopLevelBlock, syncSerializedDoc]
+    [cancelPendingMarkdownCommit, clearPendingMarkdownCommitMaxWait, focusTopLevelBlock, syncSerializedDoc]
   )
 
   const mutateTopLevelBlocks = useCallback(
@@ -5377,19 +5483,26 @@ const BlockEditorEngine = ({
     const listItems = Array.from(root.querySelectorAll<HTMLElement>(LIST_ITEM_SELECTOR))
     listItems.forEach((element) => {
       element.removeAttribute("data-block-selected")
+      if (element.getAttribute("data-task-item") !== "true") {
+        element.removeAttribute("draggable")
+      }
     })
 
-    const selectedNestedListItemContext = getSelectedNestedListItemContext(editor)
+    const selectedNestedListItemContext = resolveEffectiveSelectedListItemContext(editor)
     if (selectedNestedListItemContext?.listItemElement?.isConnected) {
       selectedNestedListItemContext.listItemElement.setAttribute("data-block-selected", "true")
+      selectedNestedListItemContext.listItemElement.setAttribute("draggable", "true")
     }
 
     return () => {
       listItems.forEach((element) => {
         element.removeAttribute("data-block-selected")
+        if (element.getAttribute("data-task-item") !== "true") {
+          element.removeAttribute("draggable")
+        }
       })
     }
-  }, [editor, getContentRoot, getSelectedNestedListItemContext, selectionTick])
+  }, [editor, getContentRoot, resolveEffectiveSelectedListItemContext, selectedListItemContext, selectionTick])
 
   useEffect(() => {
     selectedBlockNodeIndexRef.current = selectedBlockNodeIndex
@@ -5414,7 +5527,29 @@ const BlockEditorEngine = ({
         node?: { isBlock?: boolean }
       }
       const hasTextRangeSelection = selection instanceof TextSelection && !selection.empty
-      const selectedNestedListItemContext = getSelectedNestedListItemContext(editor)
+      const liveSelectedNestedListItemContext = getNodeSelectedNestedListItemContext(editor)
+      const selectionAnchorNestedListItemContext = getSelectionAnchorNestedListItemContext(editor)
+      const effectiveSelectedNestedListItemContext = resolveEffectiveSelectedListItemContext(editor)
+      const shouldPreserveSelectedListItemContextForAnchorSelection = Boolean(
+        hasTextRangeSelection &&
+          selectionAnchorNestedListItemContext &&
+          effectiveSelectedNestedListItemContext &&
+          isSameNestedListItemContext(
+            selectionAnchorNestedListItemContext,
+            effectiveSelectedNestedListItemContext
+          )
+      )
+      const selectedNestedListItemContext =
+        liveSelectedNestedListItemContext?.listItemElement?.isConnected
+          ? liveSelectedNestedListItemContext
+          : shouldPreserveSelectedListItemContextForAnchorSelection
+            ? selectionAnchorNestedListItemContext
+            : effectiveSelectedNestedListItemContext
+      if (liveSelectedNestedListItemContext?.listItemElement?.isConnected) {
+        setSelectedListItemContext(liveSelectedNestedListItemContext)
+      } else if (shouldPreserveSelectedListItemContextForAnchorSelection && selectionAnchorNestedListItemContext) {
+        setSelectedListItemContext(selectionAnchorNestedListItemContext)
+      }
       if (hasTextRangeSelection && keyboardBlockSelectionStickyRef.current) {
         keyboardBlockSelectionStickyRef.current = false
       }
@@ -5434,17 +5569,22 @@ const BlockEditorEngine = ({
       selectionUiSignatureRef.current = nextSignature
       setSelectionTick((prev) => prev + 1)
       setSelectedBlockIndex(nextBlockIndex)
-      if (hasTextRangeSelection) {
+      if (hasTextRangeSelection && !selectedNestedListItemContext) {
         setClickedBlockIndex(null)
         setSelectedBlockNodeIndex(null)
+        setSelectedListItemContext(null)
         return
       }
       if (isNestedListItemNodeSelection) {
         setClickedBlockIndex(null)
         setSelectedBlockNodeIndex(null)
+        if (selectedNestedListItemContext?.listItemElement?.isConnected) {
+          setSelectedListItemContext(selectedNestedListItemContext)
+        }
         return
       }
       if (isTopLevelBlockNodeSelection) {
+        setSelectedListItemContext(null)
         if (keyboardBlockSelectionStickyRef.current) {
           setClickedBlockIndex(null)
           setSelectedBlockNodeIndex(nextBlockIndex)
@@ -5494,7 +5634,12 @@ const BlockEditorEngine = ({
       editor.off("blur", notifyBlur)
       selectionUiSignatureRef.current = ""
     }
-  }, [editor, getSelectedNestedListItemContext])
+  }, [
+    editor,
+    getNodeSelectedNestedListItemContext,
+    getSelectionAnchorNestedListItemContext,
+    resolveEffectiveSelectedListItemContext,
+  ])
 
   useEffect(() => {
     if (!editor) return
@@ -5527,7 +5672,13 @@ const BlockEditorEngine = ({
         event.preventDefault()
         event.stopPropagation()
         skipNextPointerDownSelectionClearRef.current = true
+        setClickedBlockIndex(null)
+        keyboardBlockSelectionStickyRef.current = false
+        setSelectedBlockNodeIndex(null)
+        syncSelectedBlockNodeSurface(null)
+        setSelectedListItemContext(targetListItemContext)
         selectNestedListItemNode(editor, targetListItemContext)
+        clearNativeTextSelection()
         return
       }
       if (targetBlockIndex === null) return
@@ -5549,6 +5700,7 @@ const BlockEditorEngine = ({
     isOuterBlockSelectionGesture,
     findNestedListItemContextFromTarget,
     isOuterListItemSelectionGesture,
+    clearNativeTextSelection,
     promoteTopLevelBlockSelection,
     syncSelectedBlockNodeSurface,
   ])
@@ -7875,7 +8027,7 @@ const BlockEditorEngine = ({
     if (!editor) return
     const rectCache = blockSelectionLayoutRectCacheRef.current
     rectCache.clear()
-    const selectedNestedListItemContext = getSelectedNestedListItemContext(editor)
+    const selectedNestedListItemContext = resolveEffectiveSelectedListItemContext(editor)
     const resolveCachedBlockRect = (index: number) => {
       const cached = rectCache.get(index)
       if (cached) return cached
@@ -7929,10 +8081,10 @@ const BlockEditorEngine = ({
     const stickySelectionActive =
       !isCoarsePointer && selectedBlockNodeIndex !== null && keyboardBlockSelectionStickyRef.current
     const activeListItemContext =
-      hoveredListItemContext?.listItemElement?.isConnected
-        ? hoveredListItemContext
-        : selectedNestedListItemContext?.listItemElement?.isConnected
-          ? selectedNestedListItemContext
+      selectedNestedListItemContext?.listItemElement?.isConnected
+        ? selectedNestedListItemContext
+        : hoveredListItemContext?.listItemElement?.isConnected
+          ? hoveredListItemContext
           : null
     const blockIndex = activeListItemContext
       ? activeListItemContext.listBlockIndex
@@ -8013,17 +8165,18 @@ const BlockEditorEngine = ({
     editor,
     clickedBlockIndex,
     getTopLevelBlockElementByIndex,
-    getSelectedNestedListItemContext,
     hoveredBlockIndex,
     hoveredListItemContext,
     isTableStructuralSelection,
     isCoarsePointer,
     isTopLevelBlockHandleEligible,
+    selectedListItemContext,
     selectedBlockIndex,
     selectedBlockNodeIndex,
     selectionTick,
     tableMenuState,
     tableAffordanceVisibility.visible,
+    resolveEffectiveSelectedListItemContext,
   ])
 
   useEffect(() => {
@@ -8456,7 +8609,13 @@ const BlockEditorEngine = ({
       ) {
         event.preventDefault()
         event.stopPropagation()
+        setClickedBlockIndex(null)
+        keyboardBlockSelectionStickyRef.current = false
+        setSelectedBlockNodeIndex(null)
+        syncSelectedBlockNodeSurface(null)
+        setSelectedListItemContext(targetListItemContext)
         selectNestedListItemNode(currentEditor, targetListItemContext)
+        clearNativeTextSelection()
         return
       }
       if (isOuterBlockSelectionGesture(event, targetBlockIndex)) {
@@ -8510,6 +8669,7 @@ const BlockEditorEngine = ({
       selectedBlockNodeIndex,
       shouldPersistTableHandles,
       startTableRowResize,
+      clearNativeTextSelection,
       syncSelectedBlockNodeSurface,
     ]
   )
@@ -8519,6 +8679,22 @@ const BlockEditorEngine = ({
       const listItemContext = findNestedListItemContextFromTarget(event.target)
       if (!listItemContext) return
 
+      const currentEditor = editorRef.current ?? editor
+      if (currentEditor) {
+        const currentSelectedListItemContext = resolveEffectiveSelectedListItemContext(currentEditor)
+        setClickedBlockIndex(null)
+        keyboardBlockSelectionStickyRef.current = false
+        setSelectedBlockNodeIndex(null)
+        syncSelectedBlockNodeSurface(null)
+        setSelectedListItemContext(listItemContext)
+        if (
+          !currentSelectedListItemContext ||
+          !isSameNestedListItemContext(currentSelectedListItemContext, listItemContext)
+        ) {
+          selectNestedListItemNode(currentEditor, listItemContext)
+          clearNativeTextSelection()
+        }
+      }
       setDraggedNestedListItemState({
         listBlockIndex: listItemContext.listBlockIndex,
         listPath: listItemContext.listPath,
@@ -8533,7 +8709,14 @@ const BlockEditorEngine = ({
       event.dataTransfer.effectAllowed = "move"
       event.dataTransfer.setData("text/plain", `list-item:${listItemContext.listBlockIndex}:${listItemContext.itemIndex}`)
     },
-    [findNestedListItemContextFromTarget, resolveNestedListItemDropIndicatorByClientY]
+    [
+      editor,
+      findNestedListItemContextFromTarget,
+      resolveNestedListItemDropIndicatorByClientY,
+      clearNativeTextSelection,
+      resolveEffectiveSelectedListItemContext,
+      syncSelectedBlockNodeSurface,
+    ]
   )
 
   const handleViewportDragOver = useCallback(
@@ -8563,6 +8746,160 @@ const BlockEditorEngine = ({
     setDraggedNestedListItemState(null)
     setNestedListItemDropIndicatorState((prev) => ({ ...prev, visible: false }))
   }, [])
+
+  const resolveNestedListItemContextFromBlockHandleState = useCallback(() => {
+    if (blockHandleState.kind !== "list-item") return null
+    if (blockHandleState.itemIndex === null) return null
+
+    return resolveNestedListItemContextByIndices(
+      blockHandleState.blockIndex,
+      blockHandleState.listPath ?? [],
+      blockHandleState.itemIndex
+    )
+  }, [blockHandleState, resolveNestedListItemContextByIndices])
+
+  const resolveBlockHandleListItemContext = useCallback(() => {
+    if (blockHandleState.kind !== "list-item") return null
+
+    const effectiveSelectedListItemContext = resolveEffectiveSelectedListItemContext(editor)
+    const matchingSelectedListItemContext =
+      effectiveSelectedListItemContext &&
+      effectiveSelectedListItemContext.listBlockIndex === blockHandleState.blockIndex &&
+      effectiveSelectedListItemContext.itemIndex === blockHandleState.itemIndex &&
+      sameListPath(effectiveSelectedListItemContext.listPath, blockHandleState.listPath)
+        ? effectiveSelectedListItemContext
+        : null
+
+    if (matchingSelectedListItemContext) {
+      return matchingSelectedListItemContext
+    }
+
+    const matchingHoveredListItemContext =
+      hoveredListItemContext &&
+      hoveredListItemContext.listBlockIndex === blockHandleState.blockIndex &&
+      hoveredListItemContext.itemIndex === blockHandleState.itemIndex &&
+      sameListPath(hoveredListItemContext.listPath, blockHandleState.listPath)
+        ? hoveredListItemContext
+        : null
+
+    return matchingHoveredListItemContext ?? resolveNestedListItemContextFromBlockHandleState()
+  }, [
+    blockHandleState,
+    editor,
+    hoveredListItemContext,
+    resolveEffectiveSelectedListItemContext,
+    resolveNestedListItemContextFromBlockHandleState,
+  ])
+
+  const beginPendingNestedListItemHandleDrag = useCallback(
+    (pointerId: number, startX: number, startY: number, context: NestedListItemContext) => {
+      clearPendingNestedListItemHandleDrag()
+      flushPendingMarkdownCommit()
+      pendingNestedListItemHandleDragRef.current = {
+        pointerId,
+        startX,
+        startY,
+        context,
+        targetListBlockIndex: null,
+        targetListPath: null,
+        insertionIndex: null,
+      }
+      clearStickyTopLevelBlockSelection()
+      const currentEditor = editorRef.current ?? editor
+      if (currentEditor) {
+        selectNestedListItemNode(currentEditor, context)
+        clearNativeTextSelection()
+      }
+      setDraggedNestedListItemState({
+        listBlockIndex: context.listBlockIndex,
+        listPath: context.listPath,
+        sourceItemIndex: context.itemIndex,
+      })
+
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        const pending = pendingNestedListItemHandleDragRef.current
+        if (!pending || moveEvent.pointerId !== pending.pointerId) return
+
+        const activeListContext =
+          resolveNestedListItemContextByIndices(
+            pending.context.listBlockIndex,
+            pending.context.listPath,
+            pending.context.itemIndex
+          ) ?? pending.context
+        const listRect = activeListContext.listElement.getBoundingClientRect()
+        const withinListBounds =
+          moveEvent.clientY >= listRect.top - 24 && moveEvent.clientY <= listRect.bottom + 24
+
+        if (!withinListBounds) {
+          pending.targetListBlockIndex = null
+          pending.targetListPath = null
+          pending.insertionIndex = null
+          setNestedListItemDropIndicatorState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
+          return
+        }
+
+        const indicator = resolveNestedListItemDropIndicatorByClientY(activeListContext.listElement, moveEvent.clientY)
+        pending.targetListBlockIndex = activeListContext.listBlockIndex
+        pending.targetListPath = [...activeListContext.listPath]
+        pending.insertionIndex = indicator.insertionIndex
+        setNestedListItemDropIndicatorState({
+          visible: true,
+          listBlockIndex: activeListContext.listBlockIndex,
+          listPath: activeListContext.listPath,
+          ...indicator,
+        })
+      }
+
+      const handlePointerDone = (doneEvent: PointerEvent) => {
+        const pending = pendingNestedListItemHandleDragRef.current
+        if (!pending || doneEvent.pointerId !== pending.pointerId) return
+
+        if (
+          pending.targetListBlockIndex === pending.context.listBlockIndex &&
+          pending.targetListPath &&
+          sameListPath(pending.targetListPath, pending.context.listPath) &&
+          pending.insertionIndex !== null
+        ) {
+          const insertionIndex = pending.insertionIndex
+          mutateTopLevelBlocks(
+            (doc) =>
+              moveNestedListItemToInsertionIndex(
+                doc,
+                pending.context.listBlockIndex,
+                pending.context.listPath,
+                pending.context.itemIndex,
+                insertionIndex
+              ),
+            pending.context.listBlockIndex
+          )
+        }
+        clearNestedListItemDragState()
+
+        clearPendingNestedListItemHandleDrag()
+      }
+
+      window.addEventListener("pointermove", handlePointerMove)
+      window.addEventListener("pointerup", handlePointerDone)
+      window.addEventListener("pointercancel", handlePointerDone)
+
+      pendingNestedListItemHandleDragCleanupRef.current = () => {
+        window.removeEventListener("pointermove", handlePointerMove)
+        window.removeEventListener("pointerup", handlePointerDone)
+        window.removeEventListener("pointercancel", handlePointerDone)
+      }
+    },
+    [
+      clearNestedListItemDragState,
+      clearPendingNestedListItemHandleDrag,
+      clearStickyTopLevelBlockSelection,
+      clearNativeTextSelection,
+      editor,
+      flushPendingMarkdownCommit,
+      mutateTopLevelBlocks,
+      resolveNestedListItemContextByIndices,
+      resolveNestedListItemDropIndicatorByClientY,
+    ]
+  )
 
   const handleViewportDrop = useCallback(
     (event: ReactDragEvent<HTMLDivElement>) => {
@@ -9928,7 +10265,10 @@ const BlockEditorEngine = ({
             ) : null}
           </FloatingBubbleToolbar>
         ) : null}
-        {!isCoarsePointer ? (
+        {!isCoarsePointer ? (() => {
+          const handleListItemContext = resolveBlockHandleListItemContext()
+
+          return (
           <BlockHandleRail
             ref={blockHandleRailRef}
             data-block-handle-rail="true"
@@ -9965,30 +10305,31 @@ const BlockEditorEngine = ({
             ) : null}
             <BlockHandleButton
               type="button"
-              aria-label={blockHandleState.kind === "list-item" ? "목록 항목 선택" : "블록 이동"}
-              title={blockHandleState.kind === "list-item" ? "목록 항목 선택" : "블록 이동"}
+              aria-label={blockHandleState.kind === "list-item" ? "목록 항목 이동" : "블록 이동"}
+              title={blockHandleState.kind === "list-item" ? "목록 항목 이동" : "블록 이동"}
               data-variant="drag"
               data-testid={blockHandleState.visible ? "block-drag-handle" : undefined}
               onMouseDown={(event) => {
-                event.preventDefault()
                 event.stopPropagation()
+                if (blockHandleState.kind === "list-item") {
+                  event.preventDefault()
+                  return
+                }
+                event.preventDefault()
               }}
               onClick={(event: ReactMouseEvent<HTMLButtonElement>) => {
                 event.preventDefault()
                 event.stopPropagation()
                 clearPendingBlockDrag()
                 if (blockHandleState.kind === "list-item" && editor) {
-                  const selectedListItemContext = getSelectedNestedListItemContext(editor)
-                  const matchingHoveredListItemContext =
-                    hoveredListItemContext &&
-                    hoveredListItemContext.listBlockIndex === blockHandleState.blockIndex &&
-                    hoveredListItemContext.itemIndex === blockHandleState.itemIndex &&
-                    sameListPath(hoveredListItemContext.listPath, blockHandleState.listPath)
-                      ? hoveredListItemContext
-                      : null
-                  const targetListItemContext = matchingHoveredListItemContext ?? selectedListItemContext
-                  if (targetListItemContext) {
-                    selectNestedListItemNode(editor, targetListItemContext)
+                  const currentHandleListItemContext =
+                    resolveBlockHandleListItemContext() ?? resolveEffectiveSelectedListItemContext(editor)
+                  if (currentHandleListItemContext) {
+                    clearStickyTopLevelBlockSelection()
+                    setHoveredListItemContext(currentHandleListItemContext)
+                    setSelectedListItemContext(currentHandleListItemContext)
+                    selectNestedListItemNode(editor, currentHandleListItemContext)
+                    clearNativeTextSelection()
                   }
                   return
                 }
@@ -9996,11 +10337,25 @@ const BlockEditorEngine = ({
               }}
               onPointerDown={(event) => {
                 if (event.button !== 0) return
-                event.preventDefault()
                 event.stopPropagation()
                 if (blockHandleState.kind === "list-item") {
+                  const currentHandleListItemContext =
+                    resolveBlockHandleListItemContext() ?? resolveEffectiveSelectedListItemContext(editor)
+                  if (editor && currentHandleListItemContext) {
+                    event.preventDefault()
+                    clearStickyTopLevelBlockSelection()
+                    setHoveredListItemContext(currentHandleListItemContext)
+                    setSelectedListItemContext(currentHandleListItemContext)
+                    beginPendingNestedListItemHandleDrag(
+                      event.pointerId,
+                      event.clientX,
+                      event.clientY,
+                      currentHandleListItemContext
+                    )
+                  }
                   return
                 }
+                event.preventDefault()
                 const sourceIndex = blockHandleState.blockIndex
                 const sourceElement = getTopLevelBlockElementByIndex(sourceIndex)
                 const sourceRect = sourceElement?.getBoundingClientRect()
@@ -10067,7 +10422,8 @@ const BlockEditorEngine = ({
               </BlockHandleGrip>
             </BlockHandleButton>
           </BlockHandleRail>
-        ) : null}
+          )
+        })() : null}
         {draggedBlockState && dragGhostPosition ? (
           <DraggedBlockGhost
             aria-hidden="true"


### PR DESCRIPTION
## 관련 이슈

close #46

## 작업 배경

- 글 수정/삭제 surface(`/editor/[id]`)에서 말머리 항목을 선택할 때 개별 list item 선택과 기존 묶음 block 선택 affordance가 번갈아 출력되던 회귀를 복구합니다.
- 같은 상태에서 drag move가 시작되지 않거나 `Tab`/`Shift+Tab` 단계 승강이 끊기던 경로를 정리해, 선택된 말머리 항목을 노션처럼 개별 블록으로 계속 조작할 수 있게 맞춥니다.

## 작업 내용

- `BlockEditorEngine.tsx`에서 selected list item context가 top-level block overlay로 되튀지 않도록 handle 선택/복원 경로를 고쳤습니다.
- handle-selected list item 상태에서도 `Tab`/`Shift+Tab`이 stale selection 경로가 아니라 단계 승강 경로를 타도록 수정했습니다.
- writer surface list item handle 선택 유지와 engine reorder 회귀를 `editor-authoring-flow.spec.ts`에 추가하고, 실제 `/editor/[id]` live visual 검증에 수정 surface 시나리오를 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1 --grep "리스트 항목 안의 Tab/Shift\+Tab은 Notion처럼 단계 승강으로 동작한다|선택된 리스트 항목 block handle 상태에서도 Tab/Shift\+Tab은 단계 승강으로 동작한다|writer surface의 선택된 리스트 항목 handle은 wrapper 선택으로 흔들리지 않고 선택 항목을 유지한다|engine surface의 선택된 리스트 항목 handle drag는 항목 순서를 갱신한다"` (2회 연속 통과)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front playwright test e2e/editor-live-visual.spec.ts --workers=1` (`E2E_ADMIN_EMAIL`, `E2E_ADMIN_PASSWORD` 미설정으로 3건 skip)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: list item selection state와 top-level block overlay 경계가 다시 섞이면 handle 선택/drag/indent 경로가 동시에 깨질 수 있습니다.
- 롤백 방법: `fix/editor-list-indent-block-split` 브랜치의 후속 커밋 `9f315818`, `d40c414d`를 revert 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
