### PR TITLE
[Fix] tracked 작업 완료 전 PR 누락 방지

### DIFF
--- a/tools/guards/check-current-task-state.sh
+++ b/tools/guards/check-current-task-state.sh
@@ -11,6 +11,8 @@ if [[ ! -f "${CURRENT_TASK_FILE}" ]]; then
 fi
 
 status=""
+issue_ref=""
+pr_ref=""
 task=""
 repro=""
 done_when=""
@@ -32,6 +34,8 @@ while IFS= read -r raw_line || [[ -n "${raw_line}" ]]; do
 
   case "${line}" in
     status=*) status="${line#status=}" ;;
+    issue_ref=*) issue_ref="${line#issue_ref=}" ;;
+    pr_ref=*) pr_ref="${line#pr_ref=}" ;;
     task=*) task="${line#task=}" ;;
     repro=*) repro="${line#repro=}" ;;
     done_when=*) done_when="${line#done_when=}" ;;
@@ -58,7 +62,21 @@ if [[ "${status}" != "draft" && "${status}" != "active" && "${status}" != "done"
   exit 1
 fi
 
-if [[ "${status}" == "draft" || "${status}" == "done" ]]; then
+if [[ "${status}" == "draft" ]]; then
+  exit 0
+fi
+
+if [[ "${status}" == "done" ]]; then
+  if [[ -z "${issue_ref}" ]]; then
+    echo "[current-task-state] done task인데 issue_ref= 이 비어 있습니다." >&2
+    exit 1
+  fi
+
+  if [[ "${issue_ref}" != "local-only" && -z "${pr_ref}" ]]; then
+    echo "[current-task-state] tracked done task인데 pr_ref= 이 비어 있습니다." >&2
+    exit 1
+  fi
+
   exit 0
 fi
 

--- a/tools/templates/agent-plan.compact.md
+++ b/tools/templates/agent-plan.compact.md
@@ -6,6 +6,9 @@
 ## issue
 - `#번호 또는 local-only`
 
+## pr
+- `main 대상 PR URL/번호 또는 local-only`
+
 ## repro
 -
 

--- a/tools/templates/current-task.local.example
+++ b/tools/templates/current-task.local.example
@@ -13,6 +13,9 @@
 # 새 스레드 handoff 출력은 `bash tools/guards/current-task-handoff.sh` 를 사용합니다.
 
 status=draft
+plan_ref=
+issue_ref=
+pr_ref=
 task=
 repro=
 done_when=


### PR DESCRIPTION
## 관련 이슈

close #51

## 작업 배경

- tracked 작업이 검증까지 끝난 뒤에도 `current-task` 완료 가드가 PR 생성 여부를 확인하지 않아 final이 먼저 나갈 수 있었습니다.
- `done` 상태의 current-task가 `issue_ref`와 `pr_ref`를 함께 확인하도록 막고, 템플릿도 같은 publish 상태를 남기도록 정리했습니다.

## 작업 내용

- `check-current-task-state.sh`에서 `status=done`일 때 `issue_ref`를 확인하고, `local-only`가 아닌 tracked 작업은 `pr_ref` 없이는 통과하지 않도록 변경했습니다.
- `current-task.local.example`에 `plan_ref`, `issue_ref`, `pr_ref` 필드를 추가해 publish 상태를 로컬 실행 커서에 남기도록 했습니다.
- `agent-plan.compact.md`에 `pr` 섹션을 추가해 계획서 단계에서 main 대상 PR URL/번호를 source of truth에 맞춰 기록하도록 했습니다.

## 검증

- 실행한 명령과 결과:
  - `bash -n tools/guards/check-current-task-state.sh`
  - `CURRENT_TASK_SLUG=pr-completion-guard bash tools/guards/current-task-preflight.sh`
  - `CURRENT_TASK_FILE_PATH=<temp> bash tools/guards/check-current-task-state.sh`로 `status=done + issue_ref=#51 + pr_ref 누락` 실패 확인
  - `CURRENT_TASK_FILE_PATH=<temp> bash tools/guards/check-current-task-state.sh`로 `status=done + issue_ref=#51 + pr_ref 존재` 통과 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 기존 done current-task 중 `issue_ref` 또는 `pr_ref`를 비워 둔 로컬 작업은 새 가드에 걸릴 수 있습니다.
- 롤백 방법: 이 커밋을 되돌리면 기존 완료 가드 동작으로 복구됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
