### PR TITLE
[Fix] tracked 작업 done PR guard follow-up

### DIFF
--- a/tools/guards/check-current-task-state.sh
+++ b/tools/guards/check-current-task-state.sh
@@ -11,6 +11,8 @@ if [[ ! -f "${CURRENT_TASK_FILE}" ]]; then
 fi
 
 status=""
+issue_ref=""
+pr_ref=""
 task=""
 repro=""
 done_when=""
@@ -32,6 +34,8 @@ while IFS= read -r raw_line || [[ -n "${raw_line}" ]]; do
 
   case "${line}" in
     status=*) status="${line#status=}" ;;
+    issue_ref=*) issue_ref="${line#issue_ref=}" ;;
+    pr_ref=*) pr_ref="${line#pr_ref=}" ;;
     task=*) task="${line#task=}" ;;
     repro=*) repro="${line#repro=}" ;;
     done_when=*) done_when="${line#done_when=}" ;;
@@ -58,7 +62,21 @@ if [[ "${status}" != "draft" && "${status}" != "active" && "${status}" != "done"
   exit 1
 fi
 
-if [[ "${status}" == "draft" || "${status}" == "done" ]]; then
+if [[ "${status}" == "draft" ]]; then
+  exit 0
+fi
+
+if [[ "${status}" == "done" ]]; then
+  if [[ -z "${issue_ref}" ]]; then
+    echo "[current-task-state] done task인데 issue_ref= 이 비어 있습니다." >&2
+    exit 1
+  fi
+
+  if [[ "${issue_ref}" != "local-only" && -z "${pr_ref}" ]]; then
+    echo "[current-task-state] tracked done task인데 pr_ref= 이 비어 있습니다." >&2
+    exit 1
+  fi
+
   exit 0
 fi
 

--- a/tools/guards/current-task-common.sh
+++ b/tools/guards/current-task-common.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+current_task_repo_root() {
+  git rev-parse --show-toplevel
+}
+
+current_task_tasks_dir() {
+  local repo_root="$1"
+  printf '%s\n' "${CURRENT_TASK_TASKS_DIR:-${repo_root}/.codex/tasks}"
+}
+
+current_task_legacy_file() {
+  local repo_root="$1"
+  printf '%s\n' "${CURRENT_TASK_LEGACY_FILE:-${repo_root}/.codex/current-task.local}"
+}
+
+current_task_archive_dir() {
+  local repo_root="$1"
+  local tasks_dir
+  tasks_dir="$(current_task_tasks_dir "${repo_root}")"
+  printf '%s\n' "${CURRENT_TASK_ARCHIVE_DIR:-${tasks_dir}/archive}"
+}
+
+current_task_slugify() {
+  local raw="$1"
+  printf '%s' "${raw}" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's#[^a-z0-9]+#-#g; s#^-+##; s#-+$##; s#--+#-#g'
+}
+
+current_task_work_item_file() {
+  local repo_root="$1"
+  local raw_key="${CURRENT_TASK_SLUG:-${CURRENT_TASK_KEY:-}}"
+  [[ -n "${raw_key}" ]] || return 0
+
+  local tasks_dir slug
+  tasks_dir="$(current_task_tasks_dir "${repo_root}")"
+  slug="$(current_task_slugify "${raw_key}")"
+  [[ -n "${slug}" ]] || return 0
+
+  printf '%s/%s.local\n' "${tasks_dir}" "${slug}"
+}
+
+current_task_file_key() {
+  local file="$1"
+  local base_name
+  base_name="$(basename "${file}")"
+  printf '%s\n' "${base_name%.local}"
+}
+
+current_task_as_relative() {
+  local repo_root="$1"
+  local absolute_path="$2"
+  if [[ "${absolute_path}" == "${repo_root}/"* ]]; then
+    printf '%s\n' "${absolute_path#${repo_root}/}"
+    return 0
+  fi
+
+  if [[ "${absolute_path}" == "${repo_root}" ]]; then
+    printf '.\n'
+    return 0
+  fi
+
+  printf '%s\n' "${absolute_path}"
+}
+
+current_task_iter_files() {
+  local repo_root="$1"
+  local tasks_dir legacy_file
+  tasks_dir="$(current_task_tasks_dir "${repo_root}")"
+  legacy_file="$(current_task_legacy_file "${repo_root}")"
+
+  if [[ -d "${tasks_dir}" ]]; then
+    find "${tasks_dir}" -maxdepth 1 -type f -name '*.local' | LC_ALL=C sort
+  fi
+
+  if [[ -f "${legacy_file}" ]]; then
+    printf '%s\n' "${legacy_file}"
+  fi
+}
+
+current_task_read_field() {
+  local file="$1"
+  local key="$2"
+  local prefix="${key}="
+
+  if [[ ! -f "${file}" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r raw_line || [[ -n "${raw_line}" ]]; do
+    local line="${raw_line%%$'\r'}"
+    [[ -z "${line}" ]] && continue
+    [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+    if [[ "${line}" == "${prefix}"* ]]; then
+      printf '%s\n' "${line#${prefix}}"
+      return 0
+    fi
+  done < "${file}"
+}
+
+current_task_read_scope_mode() {
+  local file="$1"
+  local scope_mode
+  scope_mode="$(current_task_read_field "${file}" "scope_mode")"
+  if [[ -z "${scope_mode}" ]]; then
+    scope_mode="staged"
+  fi
+  printf '%s\n' "${scope_mode}"
+}

--- a/tools/guards/current-task-resolve.sh
+++ b/tools/guards/current-task-resolve.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+source tools/guards/current-task-common.sh
+
+output_mode="absolute"
+prefer_thread="false"
+
+for arg in "$@"; do
+  case "${arg}" in
+    --relative)
+      output_mode="relative"
+      ;;
+    --prefer-thread)
+      prefer_thread="true"
+      ;;
+    *)
+      echo "[current-task-resolve] usage: $0 [--relative] [--prefer-thread]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+normalize_path() {
+  local raw="$1"
+  if [[ "${raw}" == /* ]]; then
+    printf '%s\n' "${raw}"
+    return 0
+  fi
+
+  local trimmed="${raw#./}"
+  printf '%s/%s\n' "${REPO_ROOT}" "${trimmed}"
+}
+
+as_relative() {
+  local absolute_path="$1"
+  if [[ "${absolute_path}" == "${REPO_ROOT}/"* ]]; then
+    printf '%s\n' "${absolute_path#${REPO_ROOT}/}"
+    return 0
+  fi
+
+  if [[ "${absolute_path}" == "${REPO_ROOT}" ]]; then
+    printf '.\n'
+    return 0
+  fi
+
+  printf '%s\n' "${absolute_path}"
+}
+
+legacy_file="$(current_task_legacy_file "${REPO_ROOT}")"
+work_item_file="$(current_task_work_item_file "${REPO_ROOT}")"
+thread_file=""
+if [[ -n "${CODEX_THREAD_ID:-}" ]]; then
+  thread_file="$(current_task_tasks_dir "${REPO_ROOT}")/${CODEX_THREAD_ID}.local"
+fi
+
+resolved_file=""
+if [[ -n "${CURRENT_TASK_FILE_PATH:-}" ]]; then
+  resolved_file="$(normalize_path "${CURRENT_TASK_FILE_PATH}")"
+elif [[ -n "${work_item_file}" ]]; then
+  resolved_file="${work_item_file}"
+elif [[ -n "${thread_file}" && ( "${prefer_thread}" == "true" || -f "${thread_file}" ) ]]; then
+  resolved_file="${thread_file}"
+else
+  resolved_file="${legacy_file}"
+fi
+
+if [[ "${output_mode}" == "relative" ]]; then
+  as_relative "${resolved_file}"
+  exit 0
+fi
+
+printf '%s\n' "${resolved_file}"

--- a/tools/templates/agent-plan.compact.md
+++ b/tools/templates/agent-plan.compact.md
@@ -6,6 +6,9 @@
 ## issue
 - `#번호 또는 local-only`
 
+## pr
+- `main 대상 PR URL/번호 또는 local-only`
+
 ## repro
 -
 

--- a/tools/templates/current-task.local.example
+++ b/tools/templates/current-task.local.example
@@ -13,6 +13,9 @@
 # 새 스레드 handoff 출력은 `bash tools/guards/current-task-handoff.sh` 를 사용합니다.
 
 status=draft
+plan_ref=
+issue_ref=
+pr_ref=
 task=
 repro=
 done_when=


### PR DESCRIPTION
## 관련 이슈

close #51

## 작업 배경

- tracked 작업이 `status=done`으로 넘어갈 때 `pr_ref` 누락을 막는 guard를 다시 self-contained 하게 복구합니다.
- `main` 기준으로 빠져 있던 current-task resolver 의존 파일까지 함께 포함해 pre-commit/guard 경로가 실제로 동작하도록 맞춥니다.

## 작업 내용

- `check-current-task-state.sh`가 `done` 상태에서 `issue_ref`와 `pr_ref`를 검증하도록 보강했습니다.
- `current-task-common.sh`, `current-task-resolve.sh`를 함께 포함해 guard가 `main` 기준에서도 실행 가능하도록 복구했습니다.
- current-task / plan 템플릿에 `issue_ref`, `pr_ref`, `## pr` 섹션을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `bash -n tools/guards/current-task-common.sh tools/guards/current-task-resolve.sh tools/guards/check-current-task-state.sh`
  - `rg -n "issue_ref|pr_ref|## pr" tools/guards/check-current-task-state.sh tools/templates/current-task.local.example tools/templates/agent-plan.compact.md`
  - `CURRENT_TASK_FILE_PATH=/tmp/current-task-done-missing-pr.local bash tools/guards/check-current-task-state.sh` → `tracked done task인데 pr_ref= 이 비어 있습니다.` 실패 확인
  - `CURRENT_TASK_FILE_PATH=/tmp/current-task-done-with-pr.local bash tools/guards/check-current-task-state.sh` → 통과 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: current-task helper 파일이 아직 `main`의 다른 guard 경로와 완전히 정렬되지 않았으면 hook 실행 흐름이 어긋날 수 있습니다.
- 롤백 방법: `fix/pr-completion-guard-followup` 브랜치의 커밋 `db4a1eee`를 revert 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
