### PR TITLE
[Test] editor list item live regression coverage follow-up

### DIFF
--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -352,6 +352,41 @@ const loginThroughUi = async (page: Parameters<typeof test>[0]["page"]) => {
   throw new Error(`UI login failed after retries. last=${lastFailure}`)
 }
 
+type LiveWriteResponse = {
+  data?: {
+    id?: number
+  }
+}
+
+const createHiddenEditorPost = async (
+  page: Parameters<typeof test>[0]["page"],
+  title: string,
+  content: string
+) => {
+  const response = await page.request.post("/post/api/v1/posts", {
+    data: {
+      title,
+      content,
+      published: false,
+      listed: false,
+    },
+  })
+  const body = (await response.json().catch(() => null)) as LiveWriteResponse | null
+  const postId = body?.data?.id
+  if (!response.ok() || typeof postId !== "number") {
+    throw new Error(`failed to create live editor post: status=${response.status()} body=${JSON.stringify(body)}`)
+  }
+  return postId
+}
+
+const deleteHiddenEditorPost = async (page: Parameters<typeof test>[0]["page"], postId: number) => {
+  const response = await page.request.delete(`/post/api/v1/posts/${postId}`)
+  if (!response.ok()) {
+    const body = await response.text().catch(() => "")
+    throw new Error(`failed to delete live editor post ${postId}: status=${response.status()} body=${body.slice(0, 300)}`)
+  }
+}
+
 test.describe("editor live visual regression", () => {
   test.skip(!hasUiLoginCredentials, "E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD가 필요합니다.")
 
@@ -491,5 +526,116 @@ test.describe("editor live visual regression", () => {
     expect(
       Math.abs(rowAddBarBox.x + rowAddBarBox.width / 2 - (tableBox.x + tableBox.width / 2))
     ).toBeLessThanOrEqual(18)
+  })
+
+  test("실제 /editor/[id]는 말머리 항목을 개별 블록으로 선택/이동하고 Tab 단계 승강을 유지한다", async ({ page }) => {
+    test.slow()
+    await page.setViewportSize({ width: 1512, height: 982 })
+    await loginThroughUi(page)
+
+    const title = `실화면 리스트 회귀 ${Date.now()}`
+    const postId = await createHiddenEditorPost(page, title, "- 1단계\n- 2단계\n- 3단계")
+
+    try {
+      await page.goto(`/editor/${postId}`)
+      await page.waitForURL(new RegExp(`/editor/${postId}(\\?|$)`), { timeout: 30000 })
+      await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(title)
+
+      const editor = page.getByTestId("block-editor-prosemirror").first()
+      const blockSelectionOverlay = page.getByTestId("keyboard-block-selection-overlay")
+      const countOwnLabel = (label: string) =>
+        page.evaluate((targetLabel) => {
+          const readOwnLabel = (item: HTMLElement) =>
+            Array.from(item.childNodes)
+              .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+              .map((node) => node.textContent || "")
+              .join(" ")
+              .replace(/\s+/g, " ")
+              .trim()
+
+          return Array.from(
+            document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+          ).filter((item) => readOwnLabel(item) === targetLabel).length
+        }, label)
+
+      const thirdItem = editor.locator("li", { hasText: /^3단계$/ }).first()
+      await thirdItem.hover()
+
+      const dragHandle = page.getByTestId("block-drag-handle")
+      await expect(dragHandle).toBeVisible()
+      await dragHandle.click()
+
+      const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
+      await expect(selectedDragHandle).toBeVisible()
+      await expect(page.getByRole("button", { name: "블록 이동" })).toHaveCount(0)
+
+      const dragGeometry = await page.evaluate(() => {
+        const handle = Array.from(document.querySelectorAll<HTMLElement>("button")).find(
+          (element) => element.getAttribute("aria-label") === "목록 항목 이동" || element.getAttribute("title") === "목록 항목 이동"
+        )
+        const firstItem =
+          Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")).find((item) =>
+            item.textContent?.includes("1단계")
+          ) ?? null
+        if (!handle || !firstItem) return null
+
+        const handleRect = handle.getBoundingClientRect()
+        const firstRect = firstItem.getBoundingClientRect()
+        return {
+          dragBox: {
+            x: handleRect.x,
+            y: handleRect.y,
+            width: handleRect.width,
+            height: handleRect.height,
+          },
+          firstBox: {
+            x: firstRect.x,
+            y: firstRect.y,
+            width: firstRect.width,
+            height: firstRect.height,
+          },
+        }
+      })
+      if (!dragGeometry) {
+        throw new Error("live editor list item drag geometry is missing")
+      }
+
+      const { dragBox, firstBox } = dragGeometry
+      await page.mouse.move(dragBox.x + dragBox.width / 2, dragBox.y + dragBox.height / 2)
+      await page.mouse.down()
+      await page.mouse.move(firstBox.x + firstBox.width / 2, firstBox.y + Math.max(6, firstBox.height * 0.2), {
+        steps: 12,
+      })
+      await page.mouse.up()
+
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const readOwnLabel = (item: HTMLElement) =>
+              Array.from(item.childNodes)
+                .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+                .map((node) => node.textContent || "")
+                .join(" ")
+                .replace(/\s+/g, " ")
+                .trim()
+
+            return Array.from(
+              document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+            )
+              .map((item) => readOwnLabel(item))
+              .filter(Boolean)
+          })
+        )
+        .toEqual(["3단계", "1단계", "2단계"])
+
+      await editor.locator("li", { hasText: "2단계" }).first().click()
+      await page.keyboard.press("Tab")
+      await expect(blockSelectionOverlay).toHaveCount(0)
+      await expect.poll(() => countOwnLabel("1단계")).toBe(1)
+      await expect.poll(() => countOwnLabel("2단계")).toBe(1)
+      await expect.poll(() => countOwnLabel("3단계")).toBe(1)
+    } finally {
+      await deleteHiddenEditorPost(page, postId)
+    }
   })
 })

--- a/front/e2e/slash-menu-interaction.spec.ts
+++ b/front/e2e/slash-menu-interaction.spec.ts
@@ -302,41 +302,76 @@ test.describe("block editor slash menu interaction", () => {
   test("task item 은 drag reorder 로 순서를 바꿀 수 있다", async ({ page }) => {
     const seed = encodeURIComponent("- [ ] 첫째\\n- [ ] 둘째\\n- [ ] 셋째")
     await page.goto(`${QA_ENGINE_ROUTE}&seed=${seed}`)
+    await expect(page.getByTestId("qa-editor-ready")).toBeAttached()
 
     const taskItems = page.locator("li[data-task-item='true']")
     await expect(taskItems).toHaveCount(3)
 
     const markdownOutput = page.getByTestId("qa-markdown-output")
     const expected = "- [ ] 셋째\n- [ ] 첫째\n- [ ] 둘째"
-    let reorderedByNativeDrag = false
-    try {
-      await taskItems.nth(2).dragTo(taskItems.nth(0), { timeout: 2_000 })
-      reorderedByNativeDrag = ((await markdownOutput.textContent()) || "").includes(expected)
-    } catch {
-      reorderedByNativeDrag = false
+    await taskItems.nth(2).hover()
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    await dragHandle.click()
+
+    const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
+    await expect(selectedDragHandle).toBeVisible()
+
+    const dragGeometry = await page.evaluate(() => {
+      const handle = Array.from(document.querySelectorAll<HTMLElement>("button")).find(
+        (element) => element.getAttribute("aria-label") === "목록 항목 이동" || element.getAttribute("title") === "목록 항목 이동"
+      )
+      const firstItem =
+        Array.from(
+          document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li[data-task-item='true']")
+        )[0] ?? null
+      if (!handle || !firstItem) return null
+
+      const handleRect = handle.getBoundingClientRect()
+      const firstRect = firstItem.getBoundingClientRect()
+      return {
+        dragBox: {
+          x: handleRect.x,
+          y: handleRect.y,
+          width: handleRect.width,
+          height: handleRect.height,
+        },
+        firstBox: {
+          x: firstRect.x,
+          y: firstRect.y,
+          width: firstRect.width,
+          height: firstRect.height,
+        },
+      }
+    })
+    if (!dragGeometry) {
+      throw new Error("task item drag 좌표를 계산할 수 없습니다.")
     }
 
-    if (!reorderedByNativeDrag) {
-      const currentLines = ((await markdownOutput.textContent()) || "")
-        .split("\n")
-        .map((line) => line.trim())
-        .filter(Boolean)
-      const sourceIndex = currentLines.findIndex((line) => line.includes("셋째"))
-      if (sourceIndex > 0) {
-        await page.evaluate(
-          ({ sourceIndex }) => {
-            const fn = (
-              window as unknown as {
-                __qaMoveTaskItemInFirstTaskList?: (source: number, insertion: number) => void
-              }
-            ).__qaMoveTaskItemInFirstTaskList
-            fn?.(sourceIndex, 0)
-          },
-          { sourceIndex }
-        )
-      } else {
-        await page.getByRole("button", { name: "QA Task 3→1" }).click()
-      }
+    const { dragBox, firstBox } = dragGeometry
+    let reorderedByHandleDrag = false
+    try {
+      await page.mouse.move(dragBox.x + dragBox.width / 2, dragBox.y + dragBox.height / 2)
+      await page.mouse.down()
+      await page.mouse.move(firstBox.x + firstBox.width / 2, firstBox.y + Math.max(6, firstBox.height * 0.2), {
+        steps: 12,
+      })
+      await page.mouse.up()
+      reorderedByHandleDrag = ((await markdownOutput.textContent()) || "").includes(expected)
+    } catch {
+      reorderedByHandleDrag = false
+      await page.mouse.up().catch(() => undefined)
+    }
+
+    if (!reorderedByHandleDrag) {
+      await page.evaluate(() => {
+        const fn = (
+          window as unknown as {
+            __qaMoveTaskItemInFirstTaskList?: (source: number, insertion: number) => void
+          }
+        ).__qaMoveTaskItemInFirstTaskList
+        fn?.(2, 0)
+      })
     }
 
     await expect


### PR DESCRIPTION
## 관련 이슈

close #46

## 작업 배경

- list item 개별 선택/drag/Tab 회귀를 실제 writer shell과 QA slash 시나리오에서 다시 잠그는 follow-up 테스트를 추가합니다.
- 구현 코드는 건드리지 않고, 빠져 있던 live visual / slash-menu 회귀 커버리지만 보강합니다.

## 작업 내용

- `editor-live-visual.spec.ts`에 실제 `/editor/[id]`에서 list item 선택/drag/Tab 승강을 검증하는 시나리오를 추가했습니다.
- `slash-menu-interaction.spec.ts`의 task item reorder를 실제 `목록 항목 이동` handle 경로 기준으로 검증하도록 바꿨습니다.
- native drag가 실패하는 환경에서는 기존 QA helper fallback으로만 보정하도록 정리했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` → 2회 연속 `15 passed`
  - `yarn --cwd front playwright test e2e/editor-live-visual.spec.ts --workers=1` → 2회 연속 `3 skipped`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: test-only 변경이라 런타임 영향은 없지만, 실제 writer shell에서 handle 명칭이나 selection contract가 다시 바뀌면 flaky가 아니라 기대값 mismatch가 날 수 있습니다.
- 롤백 방법: `test/editor-list-item-live-followup` 브랜치의 커밋 `f1adb91e`를 revert 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
