### PR TITLE
[Fix] 에디터 리스트 항목 선택 affordance 회귀 재발

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -927,6 +927,48 @@ test.describe("block editor authoring flow", () => {
     await expect.poll(() => countOwnLabel("3단계")).toBe(1)
   })
 
+  test("writer surface의 리스트 항목 안 Tab/Shift+Tab도 단계 승강으로 동작한다", async ({ page }) => {
+    await page.goto(QA_WRITER_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    const blockSelectionOverlay = page.getByTestId("keyboard-block-selection-overlay")
+    await editor.click()
+    await page.getByRole("button", { name: "목록" }).first().click()
+    await page.keyboard.type("1단계")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("2단계")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("3단계")
+
+    await editor.locator("li", { hasText: /^2단계$/ }).locator("p").first().click()
+    await page.keyboard.press("Tab")
+    await editor.locator("li", { hasText: /^3단계$/ }).locator("p").first().click()
+    await page.keyboard.press("Tab")
+    await page.keyboard.press("Tab")
+    await expect(blockSelectionOverlay).toHaveCount(0)
+    const countOwnLabel = (label: string) =>
+      page.evaluate((targetLabel) => {
+        const readOwnLabel = (item: HTMLElement) =>
+          Array.from(item.childNodes)
+            .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+            .map((node) => node.textContent || "")
+            .join(" ")
+            .replace(/\s+/g, " ")
+            .trim()
+        return Array.from(
+          document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+        ).filter((item) => readOwnLabel(item) === targetLabel).length
+      }, label)
+    await expect.poll(() => countOwnLabel("1단계")).toBe(1)
+    await expect.poll(() => countOwnLabel("2단계")).toBe(1)
+    await expect.poll(() => countOwnLabel("3단계")).toBe(1)
+
+    await editor.locator("li", { hasText: /^3단계$/ }).locator("p").first().click()
+    await page.keyboard.press("Shift+Tab")
+    await expect(blockSelectionOverlay).toHaveCount(0)
+    await expect.poll(() => countOwnLabel("3단계")).toBe(1)
+  })
+
   test("리스트 항목 handle은 말머리 묶음 전체가 아니라 각 항목을 따라간다", async ({ page }) => {
     await page.goto(QA_ENGINE_ROUTE)
 
@@ -994,7 +1036,19 @@ test.describe("block editor authoring flow", () => {
 
     const dragHandle = page.getByTestId("block-drag-handle")
     await expect(dragHandle).toBeVisible()
-    await dragHandle.click()
+    const retryItemBox = await retryItem.boundingBox()
+    const dragHandleBox = await dragHandle.boundingBox()
+    if (!retryItemBox || !dragHandleBox) {
+      throw new Error("writer selected list item handle geometry is missing")
+    }
+    expect(
+      Math.abs(
+        dragHandleBox.y +
+          dragHandleBox.height / 2 -
+          (retryItemBox.y + retryItemBox.height / 2)
+      )
+    ).toBeLessThanOrEqual(18)
+    await page.mouse.click(dragHandleBox.x + dragHandleBox.width / 2, dragHandleBox.y + dragHandleBox.height / 2)
     const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
     await expect(selectedDragHandle).toBeVisible()
     await expect(page.getByRole("button", { name: "블록 추가" })).toBeVisible()
@@ -1065,6 +1119,74 @@ test.describe("block editor authoring flow", () => {
     await expect(page.getByRole("button", { name: "블록 이동" })).toHaveCount(0)
   })
 
+  test("writer surface의 선택된 리스트 항목 affordance는 파란 rail 없이 말머리 바깥에 유지된다", async ({
+    page,
+  }) => {
+    await page.goto(QA_WRITER_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.click()
+    await page.getByRole("button", { name: "목록" }).first().click()
+    await page.keyboard.type("Access")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("Refresh")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("Retry")
+
+    const retryItem = editor.locator("li", { hasText: /^Retry$/ }).first()
+    await retryItem.hover()
+
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    const retryItemBox = await retryItem.boundingBox()
+    const dragHandleBox = await dragHandle.boundingBox()
+    if (!retryItemBox || !dragHandleBox) {
+      throw new Error("writer affordance handle geometry is missing")
+    }
+    expect(
+      Math.abs(
+        dragHandleBox.y +
+          dragHandleBox.height / 2 -
+          (retryItemBox.y + retryItemBox.height / 2)
+      )
+    ).toBeLessThanOrEqual(18)
+    await page.mouse.click(dragHandleBox.x + dragHandleBox.width / 2, dragHandleBox.y + dragHandleBox.height / 2)
+    await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
+    const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
+    await expect(selectedDragHandle).toBeVisible()
+    const selectedHandleBox = await selectedDragHandle.boundingBox()
+    if (!selectedHandleBox) {
+      throw new Error("writer selected list item handle bounding box is missing")
+    }
+
+    const affordanceMetrics = await page.evaluate(() => {
+      const readOwnLabel = (item: HTMLElement) =>
+        Array.from(item.childNodes)
+          .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+          .map((node) => node.textContent || "")
+          .join(" ")
+          .replace(/\s+/g, " ")
+          .trim()
+
+      const targetItem =
+        Array.from(
+          document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+        ).find((item) => readOwnLabel(item) === "Retry") ?? null
+      const textBlock = targetItem?.querySelector("p") as HTMLElement | null
+
+      return {
+        boxShadow: targetItem ? window.getComputedStyle(targetItem).boxShadow : null,
+        textLeft: textBlock?.getBoundingClientRect().left ?? null,
+      }
+    })
+
+    expect(affordanceMetrics.boxShadow?.includes("inset")).toBeFalsy()
+    expect(affordanceMetrics.textLeft).not.toBeNull()
+    expect(selectedHandleBox.x + selectedHandleBox.width + 2).toBeLessThanOrEqual(
+      affordanceMetrics.textLeft ?? 0
+    )
+  })
+
   test("engine surface의 선택된 리스트 항목 handle drag는 항목 순서를 갱신한다", async ({ page }) => {
     await page.goto(QA_ENGINE_ROUTE)
 
@@ -1123,12 +1245,14 @@ test.describe("block editor authoring flow", () => {
     const { dragBox, firstBox } = dragGeometry
 
     await page.mouse.move(dragBox.x + dragBox.width / 2, dragBox.y + dragBox.height / 2)
+    await page.waitForTimeout(120)
     await page.mouse.down()
     await page.mouse.move(firstBox.x + firstBox.width / 2, firstBox.y + Math.max(6, firstBox.height * 0.2), {
       steps: 12,
     })
     await expect(page.getByTestId("block-drag-ghost")).toBeVisible()
     await page.mouse.up()
+    await expect(page.getByTestId("block-drag-ghost")).toHaveCount(0)
 
     await expect
       .poll(() =>
@@ -1149,6 +1273,78 @@ test.describe("block editor authoring flow", () => {
         })
       )
       .toEqual(["Retry", "Access", "Refresh"])
+  })
+
+  test("writer surface의 선택된 리스트 항목 handle drag는 항목 순서를 갱신한다", async ({ page }) => {
+    await page.goto(QA_WRITER_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.click()
+    await page.getByRole("button", { name: "목록" }).first().click()
+    await page.keyboard.type("Access")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("Refresh")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("Retry")
+
+    const retryItem = editor.locator("li", { hasText: /^Retry$/ }).first()
+    await retryItem.hover()
+
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    const firstItem = editor.locator("li", { hasText: /^Access$/ }).first()
+    await expect(firstItem).toBeVisible()
+    const retryItemBox = await retryItem.boundingBox()
+    const dragHandleBox = await dragHandle.boundingBox()
+    const firstItemBox = await firstItem.boundingBox()
+    if (!retryItemBox || !dragHandleBox || !firstItemBox) {
+      throw new Error("writer 리스트 항목 drag 좌표를 계산할 수 없습니다.")
+    }
+    expect(
+      Math.abs(
+        dragHandleBox.y +
+          dragHandleBox.height / 2 -
+          (retryItemBox.y + retryItemBox.height / 2)
+      )
+    ).toBeLessThanOrEqual(18)
+
+    await page.mouse.move(
+      dragHandleBox.x + dragHandleBox.width / 2,
+      dragHandleBox.y + dragHandleBox.height / 2
+    )
+    await page.waitForTimeout(120)
+    await page.mouse.down()
+    await page.mouse.move(
+      firstItemBox.x + firstItemBox.width / 2,
+      firstItemBox.y + Math.max(6, firstItemBox.height * 0.2),
+      {
+      steps: 12,
+      }
+    )
+    await expect(page.getByTestId("block-drag-ghost")).toBeVisible()
+    await page.mouse.up()
+    await expect(page.getByTestId("block-drag-ghost")).toHaveCount(0)
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const readOwnLabel = (item: HTMLElement) =>
+            Array.from(item.childNodes)
+              .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+              .map((node) => node.textContent || "")
+              .join(" ")
+              .replace(/\s+/g, " ")
+              .trim()
+
+          return Array.from(
+            document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+          )
+            .map((item) => readOwnLabel(item))
+            .filter(Boolean)
+        })
+      )
+      .toEqual(["Retry", "Access", "Refresh"])
+    await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
   })
 
   test("초기 hydrate 직후 Cmd/Ctrl+Z는 외부 value 동기화를 되돌리지 않는다", async ({ page }) => {

--- a/front/e2e/slash-menu-interaction.spec.ts
+++ b/front/e2e/slash-menu-interaction.spec.ts
@@ -308,15 +308,58 @@ test.describe("block editor slash menu interaction", () => {
 
     const markdownOutput = page.getByTestId("qa-markdown-output")
     const expected = "- [ ] 셋째\n- [ ] 첫째\n- [ ] 둘째"
-    let reorderedByNativeDrag = false
-    try {
-      await taskItems.nth(2).dragTo(taskItems.nth(0), { timeout: 2_000 })
-      reorderedByNativeDrag = ((await markdownOutput.textContent()) || "").includes(expected)
-    } catch {
-      reorderedByNativeDrag = false
+    await taskItems.nth(2).hover()
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    await dragHandle.click()
+
+    const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
+    await expect(selectedDragHandle).toBeVisible()
+
+    const dragGeometry = await page.evaluate(() => {
+      const handle = Array.from(document.querySelectorAll<HTMLElement>("button")).find(
+        (element) =>
+          element.getAttribute("aria-label") === "목록 항목 이동" ||
+          element.getAttribute("title") === "목록 항목 이동"
+      )
+      const firstItem =
+        Array.from(document.querySelectorAll<HTMLElement>("li[data-task-item='true']")).find((item) =>
+          item.textContent?.includes("첫째")
+        ) ?? null
+      if (!handle || !firstItem) return null
+
+      const handleRect = handle.getBoundingClientRect()
+      const firstRect = firstItem.getBoundingClientRect()
+      return {
+        dragBox: {
+          x: handleRect.x,
+          y: handleRect.y,
+          width: handleRect.width,
+          height: handleRect.height,
+        },
+        firstBox: {
+          x: firstRect.x,
+          y: firstRect.y,
+          width: firstRect.width,
+          height: firstRect.height,
+        },
+      }
+    })
+    if (!dragGeometry) {
+      throw new Error("task item drag geometry is missing")
     }
 
-    if (!reorderedByNativeDrag) {
+    const { dragBox, firstBox } = dragGeometry
+    await page.mouse.move(dragBox.x + dragBox.width / 2, dragBox.y + dragBox.height / 2)
+    await page.waitForTimeout(120)
+    await page.mouse.down()
+    await page.mouse.move(firstBox.x + firstBox.width / 2, firstBox.y + Math.max(6, firstBox.height * 0.2), {
+      steps: 12,
+    })
+    await page.mouse.up()
+
+    const reorderedByHandleDrag = ((await markdownOutput.textContent()) || "").includes(expected)
+    if (!reorderedByHandleDrag) {
       const currentLines = ((await markdownOutput.textContent()) || "")
         .split("\n")
         .map((line) => line.trim())

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -8222,9 +8222,10 @@ const BlockEditorEngine = ({
 
     const stickySelectionActive =
       !isCoarsePointer && selectedBlockNodeIndex !== null && keyboardBlockSelectionStickyRef.current
+    const effectiveSelectedListItemContext = resolveEffectiveSelectedListItemContext(editor)
     const activeListItemContext =
-      selectedNestedListItemContext?.listItemElement?.isConnected
-        ? selectedNestedListItemContext
+      effectiveSelectedListItemContext?.listItemElement?.isConnected
+        ? effectiveSelectedListItemContext
         : hoveredListItemContext?.listItemElement?.isConnected
           ? hoveredListItemContext
           : null
@@ -8312,7 +8313,6 @@ const BlockEditorEngine = ({
     isTableStructuralSelection,
     isCoarsePointer,
     isTopLevelBlockHandleEligible,
-    selectedListItemContext,
     selectedBlockIndex,
     selectedBlockNodeIndex,
     selectionTick,
@@ -9018,6 +9018,9 @@ const BlockEditorEngine = ({
       clearPendingNestedListItemHandleDrag()
       flushPendingMarkdownCommit()
       const sourceElement = context.listItemElement
+      if (sourceElement.isConnected) {
+        sourceElement.setAttribute("draggable", "false")
+      }
       const sourceRect = sourceElement.getBoundingClientRect()
       const previewWidth = sourceRect
         ? Math.round(Math.min(Math.max(sourceRect.width, 320), Math.max(320, window.innerWidth - 48)))
@@ -9103,9 +9106,29 @@ const BlockEditorEngine = ({
         const pending = pendingNestedListItemHandleDragRef.current
         if (!pending || doneEvent.pointerId !== pending.pointerId) return
         if (!pending.started) {
+          if (pending.context.listItemElement.isConnected) {
+            pending.context.listItemElement.setAttribute("draggable", "true")
+          }
           clearPendingNestedListItemHandleDrag()
           return
         }
+        if (pending.context.listItemElement.isConnected) {
+          pending.context.listItemElement.setAttribute("draggable", "true")
+        }
+
+        const activeListContext =
+          resolveNestedListItemContextByIndices(
+            pending.context.listBlockIndex,
+            pending.context.listPath,
+            pending.context.itemIndex
+          ) ?? pending.context
+        const indicator = resolveNestedListItemDropIndicatorByClientY(
+          activeListContext.listElement,
+          doneEvent.clientY
+        )
+        pending.targetListBlockIndex = activeListContext.listBlockIndex
+        pending.targetListPath = [...activeListContext.listPath]
+        pending.insertionIndex = indicator.insertionIndex
 
         if (
           pending.targetListBlockIndex === pending.context.listBlockIndex &&
@@ -10575,7 +10598,9 @@ const BlockEditorEngine = ({
                 clearPendingBlockDrag()
                 if (blockHandleState.kind === "list-item" && editor) {
                   const currentHandleListItemContext =
-                    resolveBlockHandleListItemContext() ?? resolveEffectiveSelectedListItemContext(editor)
+                    (hoveredListItemContext?.listItemElement?.isConnected ? hoveredListItemContext : null) ??
+                    resolveBlockHandleListItemContext() ??
+                    resolveEffectiveSelectedListItemContext(editor)
                   if (currentHandleListItemContext) {
                     clearStickyTopLevelBlockSelection()
                     setHoveredListItemContext(currentHandleListItemContext)
@@ -10594,7 +10619,9 @@ const BlockEditorEngine = ({
                 event.stopPropagation()
                 if (blockHandleState.kind === "list-item") {
                   const currentHandleListItemContext =
-                    resolveBlockHandleListItemContext() ?? resolveEffectiveSelectedListItemContext(editor)
+                    (hoveredListItemContext?.listItemElement?.isConnected ? hoveredListItemContext : null) ??
+                    resolveBlockHandleListItemContext() ??
+                    resolveEffectiveSelectedListItemContext(editor)
                   if (editor && currentHandleListItemContext) {
                     event.preventDefault()
                     clearStickyTopLevelBlockSelection()


### PR DESCRIPTION
## 관련 이슈

close #57

## 작업 배경

- 글 작성/수정 페이지에서 선택된 list item의 handle overlay가 말머리 마커를 덮고, top-level selection rail처럼 보이는 affordance가 함께 남는 회귀를 정리합니다.
- writer surface에서 list item drag 이동과 `Tab`/`Shift+Tab` 단계 승강 경로를 함께 안정화하려는 follow-up입니다.
- 현재 브랜치는 코드와 회귀 테스트를 포함하지만, writer drag reorder 시나리오가 아직 남아 있어 draft로 올립니다.

## 작업 내용

- writer surface의 list item selection context와 handle 선택 경로를 조정했습니다.
- selected list item affordance, writer `Tab`/`Shift+Tab`, handle 기반 reorder 시나리오를 editor e2e에 추가했습니다.
- slash menu 상호작용 회귀 테스트도 handle drag 경로 기준으로 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight` ✅
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` ❌ writer surface selected list item drag reorder 시나리오가 남아 있습니다.
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` ✅
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` ⚠️ 개별 시나리오는 통과했지만 combined run 기준으로는 재확인이 더 필요합니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: writer surface의 list item 선택 컨텍스트 변경이 다른 block handle 상호작용에 영향을 줄 수 있습니다.
- 롤백 방법: `fix/editor-list-item-selection-followup` 브랜치의 변경 commit(`9cade192`)을 되돌리고 기존 selection context 계산으로 복구합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
