### PR TITLE
[Feat] About 페이지 레이아웃 개편

### DIFF
--- a/front/e2e/mobile-layout.spec.ts
+++ b/front/e2e/mobile-layout.spec.ts
@@ -31,6 +31,45 @@ const mockAnonymousSession = async (page: Page) => {
   })
 }
 
+const addPublicAboutSnapshotCookie = async (page: Page) => {
+  await page.context().addCookies([
+    {
+      name: "admin_profile_snapshot_v1",
+      value: encodeURIComponent(
+        JSON.stringify({
+          username: "aquila",
+          name: "aquila",
+          nickname: "aquila",
+          modifiedAt: new Date().toISOString(),
+          profileImageUrl: "/avatar.png",
+          profileImageDirectUrl: "/avatar.png",
+          profileRole: "Backend Developer",
+          aboutRole: "Backend Developer",
+          aboutBio:
+            "안녕하세요, 백엔드 개발자 아퀼라입니다.\nJava, Kotlin, Spring Boot를 기반으로 견고한 시스템을 설계합니다.\n블로그에는 기술의 본질을 파고드는 과정을 기록하고 있습니다.",
+          aboutSections: [
+            {
+              id: "journey",
+              title: "이력",
+              items: ["ADsP [2025.09.05]", "정보처리기사 [2025.09.12]", "독학사 컴퓨터공학 [2026.02.25]", "SQLD [2026.03.27]"],
+              dividerBefore: false,
+            },
+            {
+              id: "projects",
+              title: "프로젝트",
+              items: ["고구마마켓", "마음-온", "aquila-blog", "aquila-bank"],
+              dividerBefore: false,
+            },
+          ],
+          serviceLinks: [{ icon: "service", label: "aquila-blog", href: "https://github.com/AquilaXk/aquila-blog" }],
+          contactLinks: [{ icon: "github", label: "GitHub", href: "https://github.com/AquilaXk" }],
+        })
+      ),
+      url: "http://127.0.0.1:3000",
+    },
+  ])
+}
+
 const createExplorePage = (title: string, tag = "모바일테스트") => ({
   content: [
     {
@@ -285,6 +324,54 @@ test("iPhone 15 Pro 메인 피드는 카드 overflow 없이 viewport 내부에 �
   expect(secondSnapshot.htmlScrollWidth).toBeLessThanOrEqual(secondSnapshot.viewportWidth)
   expect(secondSnapshot.bodyScrollWidth).toBeLessThanOrEqual(secondSnapshot.viewportWidth)
   expect(Math.abs(firstSnapshot.firstCardWidth - secondSnapshot.firstCardWidth)).toBeLessThanOrEqual(1.5)
+})
+
+test("iPhone 15 Pro about 페이지는 소개/cta/프로젝트/이력/링크 순서와 compact avatar 계약을 유지한다", async ({ page }) => {
+  await addPublicAboutSnapshotCookie(page)
+  await page.goto("/about")
+  await expect(page.locator('[data-ui="about-eyebrow"]')).toHaveText("Profile")
+
+  const snapshot = await page.evaluate(() => {
+    const readRect = (selector: string) => {
+      const element = document.querySelector(selector) as HTMLElement | null
+      if (!element) return null
+      const rect = element.getBoundingClientRect()
+      return {
+        top: rect.top,
+        width: rect.width,
+        right: rect.right,
+      }
+    }
+
+    return {
+      viewportWidth: window.innerWidth,
+      htmlScrollWidth: document.documentElement.scrollWidth,
+      bodyScrollWidth: document.body.scrollWidth,
+      hero: readRect('[data-ui="about-hero"]'),
+      cta: readRect('[data-ui="about-cta-group"]'),
+      projects: readRect('[data-ui="about-projects"]'),
+      timeline: readRect('[data-ui="about-timeline-section"]'),
+      contact: readRect('[data-ui="about-contact-section"]'),
+      service: readRect('[data-ui="about-service-section"]'),
+      avatar: readRect('[data-ui="about-avatar"]'),
+    }
+  })
+
+  expect(snapshot.htmlScrollWidth).toBeLessThanOrEqual(snapshot.viewportWidth)
+  expect(snapshot.bodyScrollWidth).toBeLessThanOrEqual(snapshot.viewportWidth)
+  expect(snapshot.hero).not.toBeNull()
+  expect(snapshot.cta).not.toBeNull()
+  expect(snapshot.projects).not.toBeNull()
+  expect(snapshot.timeline).not.toBeNull()
+  expect(snapshot.contact).not.toBeNull()
+  expect(snapshot.service).not.toBeNull()
+  expect((snapshot.cta?.top ?? 0)).toBeGreaterThan(snapshot.hero?.top ?? 0)
+  expect((snapshot.projects?.top ?? 0)).toBeGreaterThan(snapshot.cta?.top ?? 0)
+  expect((snapshot.timeline?.top ?? 0)).toBeGreaterThan(snapshot.projects?.top ?? 0)
+  expect((snapshot.contact?.top ?? 0)).toBeGreaterThan(snapshot.timeline?.top ?? 0)
+  expect((snapshot.service?.top ?? 0)).toBeGreaterThan(snapshot.contact?.top ?? 0)
+  expect(snapshot.avatar?.width ?? 0).toBeLessThanOrEqual(96)
+  expect(snapshot.avatar?.right ?? 0).toBeLessThanOrEqual(snapshot.viewportWidth + 0.5)
 })
 
 test("iPhone 15 Pro 상세 본문(table/code block)은 가로 클리핑 없이 유지된다", async ({ page }) => {

--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -14,6 +14,46 @@ const mockAvatarAsset = async (page: Page) => {
   })
 }
 
+const addPublicAboutSnapshotCookie = async (page: Page) => {
+  await page.context().addCookies([
+    {
+      name: "admin_profile_snapshot_v1",
+      value: encodeURIComponent(
+        JSON.stringify({
+          username: "aquila",
+          name: "aquila",
+          nickname: "aquila",
+          modifiedAt: new Date().toISOString(),
+          profileImageUrl: "/avatar.png",
+          profileImageDirectUrl: "/avatar.png",
+          profileRole: "Backend Developer",
+          profileBio: "서버 안정성과 운영 복구를 함께 고민합니다.",
+          aboutRole: "Backend Developer",
+          aboutBio:
+            "안녕하세요, 백엔드 개발자 아퀼라입니다.\nJava, Kotlin, Spring Boot를 기반으로 견고한 시스템을 설계합니다.\n블로그에는 기술의 본질을 파고드는 과정을 기록하고 있습니다.",
+          aboutSections: [
+            {
+              id: "journey",
+              title: "이력",
+              items: ["ADsP [2025.09.05]", "정보처리기사 [2025.09.12]", "독학사 컴퓨터공학 [2026.02.25]", "SQLD [2026.03.27]"],
+              dividerBefore: false,
+            },
+            {
+              id: "projects",
+              title: "프로젝트",
+              items: ["고구마마켓", "마음-온", "aquila-blog", "aquila-bank"],
+              dividerBefore: false,
+            },
+          ],
+          serviceLinks: [{ icon: "service", label: "aquila-blog", href: "https://github.com/AquilaXk/aquila-blog" }],
+          contactLinks: [{ icon: "github", label: "GitHub", href: "https://github.com/AquilaXk" }],
+        })
+      ),
+      url: "http://127.0.0.1:3000",
+    },
+  ])
+}
+
 const createExplorePost = (overrides: Partial<Record<string, unknown>> & { title: string }) => ({
   id: 101,
   createdAt: "2026-03-16T00:00:00Z",
@@ -153,8 +193,9 @@ test("about 자기소개 문구는 작성 개행을 유지하는 white-space 계
     })
   })
 
+  await addPublicAboutSnapshotCookie(page)
   await page.goto("/about")
-  await expect(page.getByRole("heading", { level: 1, name: "About Me" })).toBeVisible()
+  await expect(page.locator('[data-ui="about-eyebrow"]')).toHaveText("Profile")
 
   const profileBioStyle = await page.locator(".profile-bio").evaluate((element) => {
     const styles = window.getComputedStyle(element as HTMLElement)
@@ -168,6 +209,54 @@ test("about 자기소개 문구는 작성 개행을 유지하는 white-space 계
   expect(profileBioStyle.whiteSpace).toBe("pre-line")
   expect(profileBioStyle.lineHeight).not.toBe("normal")
   expect(profileBioStyle.text.length).toBeGreaterThan(0)
+})
+
+test("about 공개 프로필은 intro/cta/project/timeline 구조로 재구성된다", async ({ page }) => {
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({ resultCode: "401-1", msg: "unauthorized" }),
+    })
+  })
+
+  await addPublicAboutSnapshotCookie(page)
+  await page.goto("/about")
+
+  await expect(page.getByRole("heading", { level: 1, name: "About Me" })).toHaveCount(0)
+  await expect(page.locator('[data-ui="about-eyebrow"]')).toHaveText("Profile")
+  await expect(page.locator('[data-ui="about-hero"]')).toBeVisible()
+  await expect(page.locator('[data-ui="about-cta-group"]').getByRole("link")).toHaveCount(3)
+  await expect(page.locator('[data-ui="about-projects"]')).toBeVisible()
+  await expect(page.locator('[data-ui="about-project-list"] li').first()).toBeVisible()
+  await expect(page.locator('[data-ui="about-project-list"] li').first().locator('[data-ui="about-project-summary"]')).toBeVisible()
+  await expect(page.locator('[data-ui="about-project-list"] li').first().locator('[data-ui="about-project-role"]')).toBeVisible()
+  await expect(page.locator('[data-ui="about-timeline"] li').first()).toBeVisible()
+
+  const linkStyles = await page.evaluate(() => {
+    const read = (selector: string) => {
+      const element = document.querySelector(selector) as HTMLElement | null
+      if (!element) return null
+      const styles = window.getComputedStyle(element)
+      return {
+        backgroundColor: styles.backgroundColor,
+        borderTopWidth: styles.borderTopWidth,
+        borderBottomWidth: styles.borderBottomWidth,
+      }
+    }
+
+    return {
+      contact: read('[data-ui="about-contact-links"]'),
+      service: read('[data-ui="about-service-links"]'),
+    }
+  })
+
+  expect(linkStyles.contact?.backgroundColor).toBe("rgba(0, 0, 0, 0)")
+  expect(linkStyles.contact?.borderTopWidth).toBe("0px")
+  expect(linkStyles.contact?.borderBottomWidth).toBe("1px")
+  expect(linkStyles.service?.backgroundColor).toBe("rgba(0, 0, 0, 0)")
+  expect(linkStyles.service?.borderTopWidth).toBe("0px")
+  expect(linkStyles.service?.borderBottomWidth).toBe("1px")
 })
 
 test("홈 새로고침 이후에도 레거시 기본 문구로 되돌아가지 않는다", async ({ page }) => {

--- a/front/src/pages/about.tsx
+++ b/front/src/pages/about.tsx
@@ -64,6 +64,63 @@ type AboutPageProps = {
   initialAdminProfile: AdminProfile | null
 }
 
+type AboutListSection = {
+  title: string
+  items: string[]
+  hasDivider: boolean
+}
+
+type AboutTimelineItem = {
+  label: string
+  date: string
+}
+
+type AboutProjectItem = {
+  name: string
+  summary: string
+  role: string
+  href: string
+  linkLabel: string
+}
+
+const PROJECT_PRESETS: Record<string, { summary: string; role: string; href?: string }> = {
+  고구마마켓: {
+    summary: "거래 흐름과 상태 전이를 직접 설계하며 커머스 도메인 감각을 다진 프로젝트입니다.",
+    role: "Backend · 도메인 설계",
+  },
+  "마음-온": {
+    summary: "사용자 감정 기록 흐름을 다루며 서비스 구조와 데이터 설계를 다듬은 프로젝트입니다.",
+    role: "Backend · API 설계",
+  },
+  "aquila-blog": {
+    summary: "글쓰기, 공개 렌더링, 운영 배포까지 직접 관리하는 개인 기술 블로그입니다.",
+    role: "Full-stack · Editor/SSR/Deploy",
+    href: "https://github.com/AquilaXk/aquila-blog",
+  },
+  "aquila-bank": {
+    summary: "금융 도메인을 가정하고 계좌/거래 흐름을 모델링한 학습 프로젝트입니다.",
+    role: "Backend · Transaction Flow",
+    href: "https://github.com/AquilaXk/aquila-bank",
+  },
+}
+
+const normalizeSectionTitle = (title: string) => title.replace(/\s+/g, "").toLowerCase()
+
+const isProjectSection = (title: string) => /프로젝트|project/.test(normalizeSectionTitle(title))
+
+const isTimelineSection = (title: string) => /이력|자격|journey|timeline|credential/.test(normalizeSectionTitle(title))
+
+const parseTimelineItem = (item: string): AboutTimelineItem => {
+  const match = item.match(/^(.*?)(?:\s*\[([0-9./-]+)\])?$/)
+  return {
+    label: (match?.[1] || item).trim(),
+    date: (match?.[2] || "").trim(),
+  }
+}
+
+const isExternalHref = (href: string) =>
+  href.startsWith("https://") || href.startsWith("http://") || href.startsWith("mailto:") || href.startsWith("tel:")
+
 const AboutPage: NextPageWithLayout<AboutPageProps> = ({ initialAdminProfile }) => {
   const adminProfile = useAdminProfile(initialAdminProfile)
 
@@ -76,17 +133,56 @@ const AboutPage: NextPageWithLayout<AboutPageProps> = ({ initialAdminProfile }) 
     adminProfile?.aboutSections && adminProfile.aboutSections.length > 0
       ? adminProfile.aboutSections.map((section) => ({
           title: section.title,
-          items: section.items.map((item) => ({ text: item, bullet: true })),
+          items: section.items,
           hasDivider: section.dividerBefore,
         }))
       : parseLegacyAboutDetails(adminProfile?.aboutDetails || "").map((section) => ({
           title: section.title,
-          items: section.items.map((item) => ({ text: item, bullet: true })),
+          items: section.items,
           hasDivider: section.dividerBefore,
         }))
   const blogTitle = adminProfile?.blogTitle || CONFIG.blog.title
   const contactLinks = resolveContactLinks(adminProfile)
+    .map((item) => {
+      const safeHref = resolveRenderableProfileLinkHref("contact", item.href)
+      return safeHref && isExternalHref(safeHref) ? { ...item, safeHref } : null
+    })
+    .filter((item): item is NonNullable<typeof item> => Boolean(item))
   const serviceLinks = resolveServiceLinks(adminProfile)
+    .map((item) => {
+      const safeHref = resolveRenderableProfileLinkHref("service", item.href)
+      return safeHref && (safeHref.startsWith("https://") || safeHref.startsWith("http://"))
+        ? { ...item, safeHref }
+        : null
+    })
+    .filter((item): item is NonNullable<typeof item> => Boolean(item))
+  const projectSection = aboutDetailSections.find((section) => isProjectSection(section.title))
+  const timelineSection = aboutDetailSections.find((section) => isTimelineSection(section.title))
+  const supplementalSections = aboutDetailSections.filter(
+    (section) => section !== projectSection && section !== timelineSection
+  )
+  const githubHref = contactLinks.find((item) => item.label.toLowerCase().includes("github"))?.safeHref || ""
+  const projectItems: AboutProjectItem[] = (projectSection?.items || []).map((name) => {
+    const preset = PROJECT_PRESETS[name] || {
+      summary: "직접 구현과 운영 경험을 축적하며 시스템 설계 감각을 넓힌 프로젝트입니다.",
+      role: "Implementation · Problem Solving",
+    }
+    const linkedService = serviceLinks.find((item) => item.label.toLowerCase() === name.toLowerCase())
+    const href = linkedService?.safeHref || preset.href || githubHref || "#about-service-links"
+    return {
+      name,
+      summary: preset.summary,
+      role: preset.role,
+      href,
+      linkLabel: linkedService?.label || (href.startsWith("#") ? "섹션 보기" : "링크 보기"),
+    }
+  })
+  const timelineItems = (timelineSection?.items || []).map(parseTimelineItem)
+  const ctaLinks = [
+    { label: "대표 글 보기", href: "/" },
+    { label: "GitHub", href: githubHref || "https://github.com/AquilaXk" },
+    { label: "프로젝트 보기", href: "#about-projects" },
+  ]
 
   const meta = {
     title: `About - ${blogTitle}`,
@@ -100,11 +196,19 @@ const AboutPage: NextPageWithLayout<AboutPageProps> = ({ initialAdminProfile }) 
       <MetaConfig {...meta} />
       <StyledWrapper>
         <article className="about-content">
-          <h1 className="page-title">About Me</h1>
+          <section className="hero-grid">
+            <div className="hero-copy" data-ui="about-hero">
+              <p className="about-eyebrow" data-ui="about-eyebrow">
+                Profile
+              </p>
+              <h1 className="profile-name">{displayName}</h1>
+              <p className="profile-statement">이유를 먼저 따지고, 운영 가능한 시스템을 설계합니다.</p>
+              <p className="profile-role">{displayRole}</p>
+              <p className="profile-bio">{displayBio}</p>
+            </div>
 
-          <div className="profile-section">
-            <div className="profile-identity">
-              <div className="profile-avatar">
+            <aside className="hero-rail">
+              <div className="profile-avatar" data-ui="about-avatar">
                 <ProfileImage
                   src={profileImageSrc}
                   width={108}
@@ -113,88 +217,112 @@ const AboutPage: NextPageWithLayout<AboutPageProps> = ({ initialAdminProfile }) 
                   fillContainer
                 />
               </div>
-              <div className="profile-copy">
-                <h2 className="profile-name">{displayName}</h2>
-                <p className="profile-role">{displayRole}</p>
-                <p className="profile-bio">{displayBio}</p>
-              </div>
-            </div>
-            {aboutDetailSections.length > 0 && (
-              <div className="about-detail-sections" aria-label="about 상세 정보">
-                {aboutDetailSections.map((section, index) => (
-                  <section
-                    key={`${section.title}-${index}`}
-                    className="about-detail-section"
-                    data-has-divider={section.hasDivider ? "true" : "false"}
+
+              <div className="cta-group" data-ui="about-cta-group">
+                {ctaLinks.map((item) => (
+                  <a
+                    key={item.label}
+                    href={item.href}
+                    target={isExternalHref(item.href) ? "_blank" : undefined}
+                    rel={isExternalHref(item.href) ? "noopener noreferrer" : undefined}
                   >
-                    <h3 className="about-detail-title">{section.title}</h3>
-                    <ul className="about-detail-items">
-                      {section.items.map((item, itemIndex) => (
-                        <li key={`${section.title}-${itemIndex}`} data-bullet={item.bullet ? "true" : "false"}>
-                          {item.text}
-                        </li>
-                      ))}
-                    </ul>
-                  </section>
+                    {item.label}
+                  </a>
                 ))}
               </div>
-            )}
-          </div>
+            </aside>
+          </section>
 
-          <div className="section">
-            <h3 className="section-title">Contact</h3>
-            <ul className="contact-list">
-              {contactLinks.map((item) => (
-                (() => {
-                  const safeHref = resolveRenderableProfileLinkHref("contact", item.href)
-                  const canRenderHref = Boolean(
-                    safeHref &&
-                      (safeHref.startsWith("https://") ||
-                        safeHref.startsWith("http://") ||
-                        safeHref.startsWith("mailto:") ||
-                        safeHref.startsWith("tel:"))
-                  )
-                  if (!canRenderHref || !safeHref) return null
+          {projectItems.length > 0 ? (
+            <section className="content-section" id="about-projects" data-ui="about-projects">
+              <h2 className="section-title">{projectSection?.title || "프로젝트"}</h2>
+              <ul className="project-list" data-ui="about-project-list">
+                {projectItems.map((item) => (
+                  <li key={item.name}>
+                    <div className="project-copy">
+                      <h3>{item.name}</h3>
+                      <p data-ui="about-project-summary">{item.summary}</p>
+                    </div>
+                    <div className="project-meta">
+                      <span data-ui="about-project-role">{item.role}</span>
+                      <a
+                        href={item.href}
+                        target={isExternalHref(item.href) ? "_blank" : undefined}
+                        rel={isExternalHref(item.href) ? "noopener noreferrer" : undefined}
+                      >
+                        {item.linkLabel}
+                      </a>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
 
-                  return (
-                    <li key={`${item.icon}-${item.label}-${safeHref}`}>
+          {timelineItems.length > 0 ? (
+            <section className="content-section" data-ui="about-timeline-section">
+              <h2 className="section-title">{timelineSection?.title || "이력"}</h2>
+              <ol className="timeline-list" data-ui="about-timeline">
+                {timelineItems.map((item) => (
+                  <li key={`${item.label}-${item.date}`}>
+                    <span className="timeline-date">{item.date}</span>
+                    <strong>{item.label}</strong>
+                  </li>
+                ))}
+              </ol>
+            </section>
+          ) : null}
+
+          {supplementalSections.map((section, index) => (
+            <section
+              key={`${section.title}-${index}`}
+              className="content-section supplemental-section"
+              data-has-divider={section.hasDivider ? "true" : "false"}
+            >
+              <h2 className="section-title">{section.title}</h2>
+              <ul className="supplemental-list">
+                {section.items.map((item) => (
+                  <li key={`${section.title}-${item}`}>{item}</li>
+                ))}
+              </ul>
+            </section>
+          ))}
+
+          {contactLinks.length > 0 ? (
+            <section className="content-section compact-link-section" data-ui="about-contact-section">
+              <h2 className="section-title">Contact</h2>
+              <ul className="compact-link-list" data-ui="about-contact-links">
+                {contactLinks.map((item) => (
+                  <li key={`${item.icon}-${item.label}-${item.safeHref}`}>
+                    <a href={item.safeHref} target="_blank" rel="noopener noreferrer">
                       <span className="icon">
                         <AppIcon name={item.icon} aria-hidden="true" />
                       </span>
-                      <a href={safeHref} target="_blank" rel="noopener noreferrer">
-                        {item.label}
-                      </a>
-                    </li>
-                  )
-                })()
-              ))}
-            </ul>
-          </div>
-
-          {serviceLinks.length > 0 && (
-            <div className="section">
-              <h3 className="section-title">Service</h3>
-              <ul className="projects-list">
-                {serviceLinks.map((item) => (
-                  (() => {
-                    const safeHref = resolveRenderableProfileLinkHref("service", item.href)
-                    const canRenderHref = Boolean(
-                      safeHref && (safeHref.startsWith("https://") || safeHref.startsWith("http://"))
-                    )
-                    if (!canRenderHref || !safeHref) return null
-
-                    return (
-                      <li key={`${item.icon}-${item.label}-${safeHref}`}>
-                        <a href={safeHref} target="_blank" rel="noopener noreferrer">
-                          <AppIcon name={item.icon} aria-hidden="true" /> {item.label}
-                        </a>
-                      </li>
-                    )
-                  })()
+                      <span>{item.label}</span>
+                    </a>
+                  </li>
                 ))}
               </ul>
-            </div>
-          )}
+            </section>
+          ) : null}
+
+          {serviceLinks.length > 0 ? (
+            <section className="content-section compact-link-section" data-ui="about-service-section">
+              <h2 className="section-title">Service</h2>
+              <ul className="compact-link-list" data-ui="about-service-links" id="about-service-links">
+                {serviceLinks.map((item) => (
+                  <li key={`${item.icon}-${item.label}-${item.safeHref}`}>
+                    <a href={item.safeHref} target="_blank" rel="noopener noreferrer">
+                      <span className="icon">
+                        <AppIcon name={item.icon} aria-hidden="true" />
+                      </span>
+                      <span>{item.label}</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
         </article>
       </StyledWrapper>
     </>
@@ -204,258 +332,389 @@ const AboutPage: NextPageWithLayout<AboutPageProps> = ({ initialAdminProfile }) 
 export default AboutPage
 
 const StyledWrapper = styled.div`
-  max-width: 56rem;
+  max-width: 62rem;
   margin: 0 auto;
-  padding: 1.8rem 0 2.6rem;
+  padding: 2.25rem 0 3rem;
 
   .about-content {
-    .page-title {
-      font-size: 2.5rem;
-      font-weight: 700;
-      margin-bottom: 3rem;
-      color: ${({ theme }) => theme.colors.gray12};
+    display: grid;
+    gap: 2.6rem;
+  }
 
-      @media (max-width: 768px) {
-        font-size: 2rem;
-        margin-bottom: 2rem;
-      }
+  .hero-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.6fr) minmax(220px, 0.9fr);
+    gap: 2.25rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+  }
+
+  .hero-copy {
+    min-width: 0;
+  }
+
+  .about-eyebrow {
+    margin: 0 0 0.9rem;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.82rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .profile-name {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: clamp(2.4rem, 2rem + 1vw, 3.25rem);
+    line-height: 1.02;
+    letter-spacing: -0.045em;
+    font-weight: 800;
+  }
+
+  .profile-statement {
+    margin: 1rem 0 0;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: clamp(1.18rem, 1.02rem + 0.42vw, 1.45rem);
+    line-height: 1.5;
+    font-weight: 650;
+    letter-spacing: -0.02em;
+  }
+
+  .profile-role {
+    margin: 0.8rem 0 0;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.98rem;
+    line-height: 1.5;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+  }
+
+  .profile-bio {
+    margin: 1.1rem 0 0;
+    max-width: 40rem;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 1rem;
+    line-height: 1.8;
+    white-space: pre-line;
+    word-break: keep-all;
+  }
+
+  .hero-rail {
+    display: grid;
+    align-content: start;
+    justify-items: start;
+    gap: 1rem;
+  }
+
+  .profile-avatar {
+    position: relative;
+    width: 148px;
+    border-radius: 999px;
+    overflow: hidden;
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => theme.colors.gray1};
+    box-shadow: 0 18px 38px rgba(0, 0, 0, 0.18);
+
+    &::after {
+      content: "";
+      display: block;
+      padding-bottom: 100%;
     }
+  }
 
-    .profile-section {
-      margin-bottom: 3rem;
-      padding: 1.4rem 1rem 1.3rem;
-      border: 1px solid ${({ theme }) => theme.colors.gray5};
-      border-radius: 16px;
+  .cta-group {
+    width: min(100%, 240px);
+    display: grid;
+    gap: 0.62rem;
+
+    a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 44px;
+      padding: 0.78rem 0.96rem;
+      border-radius: 12px;
+      border: 1px solid ${({ theme }) => theme.colors.gray6};
       background: ${({ theme }) => theme.colors.gray2};
-      box-shadow: 0 14px 32px rgba(0, 0, 0, 0.22);
+      color: ${({ theme }) => theme.colors.gray12};
+      font-size: 0.98rem;
+      font-weight: 700;
+      line-height: 1;
+      transition: border-color 0.2s ease, transform 0.2s ease;
 
-      .profile-identity {
-        width: fit-content;
-        max-width: 100%;
-        margin: 0 auto;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: 1.5rem;
+      &:hover {
+        border-color: ${({ theme }) => theme.colors.gray10};
+        transform: translateY(-1px);
       }
+    }
+  }
 
-      .profile-avatar {
-        position: relative;
-        width: 108px;
-        flex: 0 0 108px;
-        border-radius: 999px;
-        overflow: hidden;
-        border: 1px solid ${({ theme }) => theme.colors.gray6};
-        background: ${({ theme }) => theme.colors.gray1};
+  .content-section {
+    min-width: 0;
+  }
 
-        &::after {
-          content: "";
-          display: block;
-          padding-bottom: 100%;
-        }
+  .section-title {
+    margin: 0 0 1.1rem;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 1.38rem;
+    line-height: 1.35;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+  }
+
+  .project-list,
+  .timeline-list,
+  .supplemental-list,
+  .compact-link-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .project-list {
+    display: grid;
+    gap: 0;
+    border-top: 1px solid ${({ theme }) => theme.colors.gray6};
+    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+
+    li {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 1rem;
+      padding: 1rem 0;
+    }
+
+    li + li {
+      border-top: 1px solid ${({ theme }) => theme.colors.gray6};
+    }
+  }
+
+  .project-copy {
+    min-width: 0;
+
+    h3 {
+      margin: 0;
+      color: ${({ theme }) => theme.colors.gray12};
+      font-size: 1.05rem;
+      line-height: 1.4;
+      font-weight: 720;
+    }
+
+    p {
+      margin: 0.4rem 0 0;
+      color: ${({ theme }) => theme.colors.gray11};
+      font-size: 0.96rem;
+      line-height: 1.7;
+      word-break: keep-all;
+    }
+  }
+
+  .project-meta {
+    display: grid;
+    justify-items: end;
+    align-content: start;
+    gap: 0.44rem;
+
+    span {
+      color: ${({ theme }) => theme.colors.gray10};
+      font-size: 0.84rem;
+      line-height: 1.4;
+      font-weight: 700;
+      text-align: right;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+    }
+
+    a {
+      color: ${({ theme }) => theme.colors.gray12};
+      font-size: 0.92rem;
+      line-height: 1.4;
+      font-weight: 650;
+
+      &:hover {
+        text-decoration: underline;
+        text-underline-offset: 3px;
       }
+    }
+  }
 
-      .profile-copy {
-        display: grid;
-        gap: 0.48rem;
-        text-align: left;
-      }
+  .timeline-list {
+    display: grid;
+    gap: 0.92rem;
 
-      .profile-name {
-        font-size: 2rem;
-        font-weight: 800;
-        margin: 0;
-        color: ${({ theme }) => theme.colors.gray12};
-      }
+    li {
+      display: grid;
+      grid-template-columns: 7.2rem minmax(0, 1fr);
+      gap: 1rem;
+      align-items: start;
+    }
+  }
 
-      .profile-role {
-        color: ${({ theme }) => theme.colors.gray11};
-        font-size: 1.125rem;
-        margin: 0;
-        font-weight: 500;
-      }
+  .timeline-date {
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.9rem;
+    line-height: 1.5;
+    font-weight: 650;
+  }
 
-      .profile-bio {
-        font-size: 1rem;
-        line-height: 1.75;
-        color: ${({ theme }) => theme.colors.gray11};
-        max-width: 600px;
-        margin: 0;
-        white-space: pre-line;
-      }
+  .timeline-list strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 1rem;
+    line-height: 1.6;
+    font-weight: 650;
+  }
 
-      .about-detail-sections {
-        margin: 2rem auto 0;
-        padding-top: 1.5rem;
-        border-top: 1px solid ${({ theme }) => theme.colors.gray5};
-        max-width: 42rem;
-        text-align: left;
+  .supplemental-section[data-has-divider="true"] {
+    padding-top: 1.2rem;
+    border-top: 1px solid ${({ theme }) => theme.colors.gray6};
+  }
 
-        .about-detail-section {
-          padding: 1rem 0 1.08rem;
+  .supplemental-list {
+    display: grid;
+    gap: 0.52rem;
 
-          &[data-has-divider="true"] {
-            border-top: 1px solid ${({ theme }) => theme.colors.gray6};
-          }
-        }
+    li {
+      color: ${({ theme }) => theme.colors.gray11};
+      font-size: 0.98rem;
+      line-height: 1.7;
+    }
+  }
 
-        .about-detail-title {
-          margin: 0;
-          font-size: 1.3rem;
-          line-height: 1.42;
-          letter-spacing: -0.01em;
-          color: ${({ theme }) => theme.colors.gray12};
-        }
+  .compact-link-section {
+    .section-title {
+      margin-bottom: 0.82rem;
+    }
+  }
 
-        .about-detail-items {
-          margin: 0.78rem 0 0;
-          padding: 0;
-          list-style: none;
-          display: grid;
-          gap: 0.42rem;
+  .compact-link-list {
+    background: transparent;
+    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
 
-          li {
-            margin: 0;
-            font-size: 1.02rem;
-            line-height: 1.72;
-            color: ${({ theme }) => theme.colors.gray11};
-            white-space: pre-line;
-            word-break: keep-all;
+    li + li {
+      border-top: 1px solid ${({ theme }) => theme.colors.gray6};
+    }
 
-            &[data-bullet="true"] {
-              position: relative;
-              padding-left: 1rem;
+    a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.7rem;
+      width: 100%;
+      min-height: 44px;
+      padding: 0.84rem 0;
+      color: ${({ theme }) => theme.colors.gray12};
+      font-size: 0.98rem;
+      line-height: 1.5;
 
-              &::before {
-                content: "";
-                position: absolute;
-                left: 0.22rem;
-                top: 0.78rem;
-                width: 0.34rem;
-                height: 0.34rem;
-                border-radius: 999px;
-                background: ${({ theme }) => theme.colors.gray10};
-              }
-            }
-          }
-        }
-      }
-
-      @media (max-width: 768px) {
-        .profile-identity {
-          gap: 1rem;
-        }
-
-        .profile-avatar {
-          width: 88px;
-          flex-basis: 88px;
-        }
-
-        .profile-name {
-          font-size: 1.7rem;
-        }
-
-        .profile-role {
-          font-size: 1rem;
-        }
+      &:hover {
+        text-decoration: underline;
+        text-underline-offset: 3px;
       }
     }
 
-    .section {
-      margin-bottom: 3rem;
+    .icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: ${({ theme }) => theme.colors.gray10};
+      font-size: 1.05rem;
+    }
+  }
 
-      .section-title {
-        font-size: 1.5rem;
-        font-weight: 800;
-        margin-bottom: 1.5rem;
-        color: ${({ theme }) => theme.colors.gray12};
-        padding-bottom: 0.58rem;
-        border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
-      }
+  @media (max-width: 900px) {
+    .hero-grid {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
+    }
 
-      .contact-list,
-      .projects-list {
-        list-style: none;
-        padding: 0;
-        margin: 0;
+    .hero-rail {
+      justify-items: start;
+    }
 
-        li {
-          margin-bottom: 1rem;
-          font-size: 1rem;
-          display: flex;
-          align-items: center;
-          min-height: 44px;
-          padding: 0.58rem 0.72rem;
-          border-radius: 11px;
-          border: 1px solid ${({ theme }) => theme.colors.gray5};
-          background: ${({ theme }) => theme.colors.gray2};
-          box-shadow: 0 8px 18px rgba(0, 0, 0, 0.16);
-          transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    .cta-group {
+      width: 100%;
+      max-width: 28rem;
+    }
 
-          &:hover {
-            background-color: ${({ theme }) => theme.colors.gray2};
-            border-color: ${({ theme }) => theme.colors.gray7};
-            transform: translateY(-2px);
-          }
+    .project-list li {
+      grid-template-columns: 1fr;
+    }
 
-          .icon {
-            margin-right: 0.75rem;
-            font-size: 1.25rem;
-          }
+    .project-meta {
+      justify-items: start;
 
-          a {
-            display: inline-flex;
-            align-items: center;
-            min-height: 34px;
-            color: ${({ theme }) => theme.colors.gray12};
-            text-decoration: none;
-            flex: 1;
-            overflow-wrap: anywhere;
-
-            &:hover {
-              color: ${({ theme }) => theme.colors.gray11};
-              text-decoration: underline;
-            }
-          }
-        }
-      }
-
-      .projects-list {
-        li {
-          a {
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-          }
-        }
+      span {
+        text-align: left;
       }
     }
   }
 
   @media (max-width: 768px) {
+    padding: 1.6rem 0 2.4rem;
+
     .about-content {
-      .about-detail-sections {
-        margin-top: 1.52rem;
-        padding-top: 1.08rem;
+      gap: 2.1rem;
+    }
 
-        .about-detail-section {
-          padding: 0.84rem 0 0.92rem;
-        }
+    .hero-grid {
+      padding-bottom: 1.6rem;
+    }
 
-        .about-detail-title {
-          font-size: 1.08rem;
-        }
+    .profile-name {
+      font-size: 2.25rem;
+    }
 
-        .about-detail-items {
-          margin-top: 0.72rem;
-          gap: 0.36rem;
+    .profile-statement {
+      font-size: 1.08rem;
+      line-height: 1.56;
+    }
 
-          li {
-            font-size: 0.95rem;
-            line-height: 1.63;
-          }
-        }
+    .profile-role {
+      font-size: 0.9rem;
+    }
+
+    .profile-bio {
+      font-size: 0.96rem;
+      line-height: 1.72;
+    }
+
+    .profile-avatar {
+      width: 88px;
+      box-shadow: none;
+    }
+
+    .cta-group {
+      gap: 0.54rem;
+
+      a {
+        min-height: 42px;
+        padding: 0.76rem 0.88rem;
+        font-size: 0.95rem;
       }
+    }
+
+    .section-title {
+      font-size: 1.18rem;
+      margin-bottom: 0.88rem;
+    }
+
+    .timeline-list {
+      gap: 0.74rem;
+
+      li {
+        grid-template-columns: 1fr;
+        gap: 0.18rem;
+      }
+    }
+
+    .timeline-date {
+      font-size: 0.82rem;
+    }
+
+    .project-copy p,
+    .supplemental-list li,
+    .compact-link-list a {
+      font-size: 0.94rem;
     }
   }
 `


### PR DESCRIPTION
## 관련 이슈

close #59

## 작업 배경

- 공개 `/about` 페이지를 `Profile` eyebrow 기반 intro/CTA hero로 재구성했습니다.
- 프로젝트는 설명/역할/링크가 있는 얇은 리스트로, 이력은 compact timeline으로 분리했고 Contact/Service는 borderless row link 언어로 정리했습니다.
- 모바일에서는 `소개 → CTA → 프로젝트 → 이력 → Contact/Service` 순서를 검증 가능하게 고정했습니다.

## 작업 내용

- `/about` 공개 레이아웃을 단일 프로필 카드 구조에서 intro + avatar/CTA rail 구조로 변경했습니다.
- 기존 `aboutSections` 데이터를 프로젝트/이력 섹션으로 재해석해 프로젝트 summary/role 메타와 timeline 표현을 추가했습니다.
- smoke/mobile-layout E2E에 공개 profile snapshot cookie를 주입해 about 레이아웃 회귀를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` (2회 연속 통과 확인)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: `/about`가 static snapshot으로 렌더될 때 sections/service/contact 데이터가 비어 있으면 hero만 보일 수 있습니다.
- 롤백 방법: `feat(about): 공개 about 레이아웃 개편` 커밋을 revert 하면 기존 about 레이아웃과 E2E 계약으로 복귀합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
