### PR TITLE
[Fix] 에디터 writer 리스트 drag CI 회귀 복구

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -1032,6 +1032,7 @@ test.describe("block editor authoring flow", () => {
     await page.keyboard.type("Retry")
 
     const retryItem = editor.locator("li", { hasText: /^Retry$/ }).first()
+    await retryItem.locator("p").first().click()
     await retryItem.hover()
 
     const dragHandle = page.getByTestId("block-drag-handle")
@@ -1292,33 +1293,79 @@ test.describe("block editor authoring flow", () => {
 
     const dragHandle = page.getByTestId("block-drag-handle")
     await expect(dragHandle).toBeVisible()
-    const firstItem = editor.locator("li", { hasText: /^Access$/ }).first()
-    await expect(firstItem).toBeVisible()
-    const retryItemBox = await retryItem.boundingBox()
-    const dragHandleBox = await dragHandle.boundingBox()
-    const firstItemBox = await firstItem.boundingBox()
-    if (!retryItemBox || !dragHandleBox || !firstItemBox) {
-      throw new Error("writer 리스트 항목 drag 좌표를 계산할 수 없습니다.")
-    }
-    expect(
-      Math.abs(
+    const measureHandleAlignment = async () => {
+      const retryItemBox = await retryItem.boundingBox()
+      const dragHandleBox = await dragHandle.boundingBox()
+      if (!retryItemBox || !dragHandleBox) {
+        return null
+      }
+      return Math.abs(
         dragHandleBox.y +
           dragHandleBox.height / 2 -
           (retryItemBox.y + retryItemBox.height / 2)
       )
-    ).toBeLessThanOrEqual(18)
-
-    await page.mouse.move(
+    }
+    await expect.poll(measureHandleAlignment).not.toBeNull()
+    await expect.poll(measureHandleAlignment).toBeLessThanOrEqual(18)
+    const dragHandleBox = await dragHandle.boundingBox()
+    if (!dragHandleBox) {
+      throw new Error("writer hover handle geometry is missing")
+    }
+    await page.mouse.click(
       dragHandleBox.x + dragHandleBox.width / 2,
       dragHandleBox.y + dragHandleBox.height / 2
+    )
+    const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
+    await expect(selectedDragHandle).toBeVisible()
+    const firstItem = editor.locator("li", { hasText: /^Access$/ }).first()
+    await expect(firstItem).toBeVisible()
+
+    const dragGeometry = await page.evaluate(() => {
+      const handle = Array.from(document.querySelectorAll<HTMLElement>("button")).find(
+        (element) =>
+          (element.getAttribute("aria-label") === "목록 항목 이동" ||
+            element.getAttribute("title") === "목록 항목 이동") &&
+          element.offsetParent !== null
+      )
+      const firstItem =
+        Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")).find(
+          (item) => item.textContent?.includes("Access")
+        ) ?? null
+      if (!handle || !firstItem) return null
+
+      const handleRect = handle.getBoundingClientRect()
+      const firstRect = firstItem.getBoundingClientRect()
+      return {
+        dragBox: {
+          x: handleRect.x,
+          y: handleRect.y,
+          width: handleRect.width,
+          height: handleRect.height,
+        },
+        firstBox: {
+          x: firstRect.x,
+          y: firstRect.y,
+          width: firstRect.width,
+          height: firstRect.height,
+        },
+      }
+    })
+    if (!dragGeometry) {
+      throw new Error("writer 리스트 항목 drag 좌표를 계산할 수 없습니다.")
+    }
+    const { dragBox, firstBox } = dragGeometry
+
+    await page.mouse.move(
+      dragBox.x + dragBox.width / 2,
+      dragBox.y + dragBox.height / 2
     )
     await page.waitForTimeout(120)
     await page.mouse.down()
     await page.mouse.move(
-      firstItemBox.x + firstItemBox.width / 2,
-      firstItemBox.y + Math.max(6, firstItemBox.height * 0.2),
+      firstBox.x + firstBox.width / 2,
+      firstBox.y + Math.max(6, firstBox.height * 0.2),
       {
-      steps: 12,
+        steps: 12,
       }
     )
     await expect(page.getByTestId("block-drag-ghost")).toBeVisible()


### PR DESCRIPTION
## 관련 이슈

close #61

## 작업 배경

- `Frontend CI`에서만 재현되던 writer list item drag 회귀를 테스트 입력 경로 기준으로 복구했습니다.
- hover handle에 `locator.click()`을 보내던 경로를 selected handle 승격이 보장되는 좌표 클릭으로 정리해 CI misalignment/geometry missing 실패를 제거했습니다.

## 작업 내용

- `front/e2e/editor-authoring-flow.spec.ts`의 writer drag 시나리오에서 대상 list item 본문을 먼저 활성화한 뒤 hover handle 정렬을 poll 하도록 보강했습니다.
- hover handle 중심을 `page.mouse.click()`으로 눌러 selected drag handle로 승격한 다음, 실제 DOM rect 기준으로 drag 좌표를 계산하도록 테스트를 안정화했습니다.
- CI에서 실패하던 원래 재현 명령을 같은 조건으로 2회 연속 통과시켜 회귀 방지 근거를 남겼습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-writer-drag-ci-regression bash tools/guards/current-task-preflight.sh`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: list item hover/selected handle 계약이 다시 바뀌면 writer drag 회귀가 재발할 수 있습니다.
- 롤백 방법: `fix(editor): writer drag CI 회귀를 복구한다` commit을 revert하고 이전 authoring-flow 테스트 입력 경로로 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
