### PR TITLE
[Fix] writer 리스트 항목 handle CI 회귀 수정

### DIFF
--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -8224,10 +8224,10 @@ const BlockEditorEngine = ({
       !isCoarsePointer && selectedBlockNodeIndex !== null && keyboardBlockSelectionStickyRef.current
     const effectiveSelectedListItemContext = resolveEffectiveSelectedListItemContext(editor)
     const activeListItemContext =
-      effectiveSelectedListItemContext?.listItemElement?.isConnected
-        ? effectiveSelectedListItemContext
-        : hoveredListItemContext?.listItemElement?.isConnected
-          ? hoveredListItemContext
+      hoveredListItemContext?.listItemElement?.isConnected
+        ? hoveredListItemContext
+        : effectiveSelectedListItemContext?.listItemElement?.isConnected
+          ? effectiveSelectedListItemContext
           : null
     const blockIndex = activeListItemContext
       ? activeListItemContext.listBlockIndex


### PR DESCRIPTION
## 관련 이슈

close #67

## 작업 배경

- merge된 admin PR 이후 branch head에 남아 있던 writer 리스트 항목 handle CI 회귀를 별도 follow-up으로 분리했습니다.
- `BlockEditorEngine`에서 list-item handle의 active context 우선순위를 조정해 hover한 항목이 stale 선택 항목보다 먼저 rail 기준점이 되도록 복구했습니다.

## 작업 내용

- writer/engine 공통 list-item handle state가 `hoveredListItemContext`를 먼저 사용하도록 정리했습니다.
- 선택/drag affordance가 이전 항목(`Access`)에 남아 `Retry` 기준 정렬이 깨지던 CI 시나리오를 복구했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --grep "리스트 항목" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (1차)
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (2차)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts e2e/slash-menu-interaction.spec.ts --workers=1`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: list-item hover 우선순위 변경으로 block handle이 기존 selected item 대신 현재 hover item을 더 적극적으로 따라갑니다.
- 롤백 방법: `fix(editor): 리스트 항목 handle 선택 우선순위를 바로잡는다` commit 하나를 revert 하면 됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
