### PR TITLE
[Fix] 관리자 대시보드 연결 채널 카드 줄바꿈 안정화

### DIFF
--- a/front/e2e/admin-hub-state.spec.ts
+++ b/front/e2e/admin-hub-state.spec.ts
@@ -65,4 +65,14 @@ test.describe("admin hub state contract", () => {
     expect(source).not.toContain("운영 조치는 앱 내부 도구에서 먼저 처리하고, 외부 보드는 드릴다운으로만 엽니다.")
     expect(source).not.toContain("장기 추이와 원본 지표 확인은 아래 연결 채널에서 이어서 봅니다.")
   })
+
+  test("dashboard 연결된 채널 카드는 좁은 폭에서도 제목이 세로로 쪼개지지 않는 레이아웃 계약을 사용한다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/dashboard.tsx"), "utf8")
+
+    expect(source).toContain("<ContextMonitoringLinkCard key={item.key}")
+    expect(source).toContain("grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));")
+    expect(source).toContain("const ContextMonitoringLinkCard = styled(AdminInfoLinkCard)`")
+    expect(source).toContain("word-break: keep-all;")
+    expect(source).not.toContain("grid-template-columns: repeat(3, minmax(0, 1fr));")
+  })
 })

--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -151,18 +151,19 @@ const readListItemHandleMetrics = async (
           .replace(/\s+/g, " ")
           .trim()
 
+      const expectedHandleLabel = targetHandleLabel ?? "목록 항목 이동"
       const targetItem =
         Array.from(
           document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
         ).find((item) => readOwnLabel(item) === targetLabel) ?? null
-      const handle = targetHandleLabel
-        ? Array.from(document.querySelectorAll<HTMLElement>("button")).find(
-            (element) =>
-              (element.getAttribute("aria-label") === targetHandleLabel ||
-                element.getAttribute("title") === targetHandleLabel) &&
-              element.offsetParent !== null
-          ) ?? null
-        : (document.querySelector<HTMLElement>("[data-testid='block-drag-handle']") as HTMLElement | null)
+      const handle =
+        Array.from(document.querySelectorAll<HTMLElement>("button")).find(
+          (element) =>
+            (element.getAttribute("aria-label") === expectedHandleLabel ||
+              element.getAttribute("title") === expectedHandleLabel) &&
+            (targetHandleLabel || element.getAttribute("data-testid") === "block-drag-handle") &&
+            element.offsetParent !== null
+        ) ?? null
 
       if (!targetItem || !handle || handle.offsetParent === null) {
         return null
@@ -1072,7 +1073,7 @@ test.describe("block editor authoring flow", () => {
       }, label)
 
     const firstItem = editor.locator("li", { hasText: "Access" }).first()
-    await firstItem.hover()
+    await firstItem.locator("p").first().hover()
     await expect(blockHandleRail.getByRole("button", { name: "블록 추가" })).toBeVisible()
     await expect.poll(() => measureHandleAlignment("Access")).not.toBeNull()
     const firstAlignment = await measureHandleAlignment("Access")
@@ -1081,7 +1082,7 @@ test.describe("block editor authoring flow", () => {
     }
 
     const secondItem = editor.locator("li", { hasText: "Refresh" }).first()
-    await secondItem.hover()
+    await secondItem.locator("p").first().hover()
     await expect(blockHandleRail.getByRole("button", { name: "블록 추가" })).toBeVisible()
     await expect.poll(() => measureHandleAlignment("Refresh")).not.toBeNull()
     const refreshMetrics = await measureHandleAlignment("Refresh")
@@ -1110,7 +1111,7 @@ test.describe("block editor authoring flow", () => {
 
     const retryItem = editor.locator("li", { hasText: /^Retry$/ }).first()
     await retryItem.locator("p").first().click()
-    await retryItem.hover()
+    await retryItem.locator("p").first().hover()
 
     const dragHandle = page.getByTestId("block-drag-handle")
     await expect(dragHandle).toBeVisible()
@@ -1183,6 +1184,46 @@ test.describe("block editor authoring flow", () => {
     await expect(page.getByRole("button", { name: "블록 이동" })).toHaveCount(0)
   })
 
+  test("writer surface의 리스트 항목 handle은 row gutter hover에서도 항목을 따라간다", async ({
+    page,
+  }) => {
+    await page.goto(QA_WRITER_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.click()
+    await page.getByRole("button", { name: "목록" }).first().click()
+    await page.keyboard.type("Access")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("Refresh")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("Retry")
+
+    const hoverPoint = await page.evaluate(() => {
+      const readOwnLabel = (item: HTMLElement) =>
+        Array.from(item.childNodes)
+          .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+          .map((node) => node.textContent || "")
+          .join(" ")
+          .replace(/\s+/g, " ")
+          .trim()
+      const retryItem = Array.from(
+        document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+      ).find((item) => readOwnLabel(item) === "Retry")
+      if (!retryItem) {
+        throw new Error("Retry item is missing")
+      }
+      const rect = retryItem.getBoundingClientRect()
+      return {
+        x: rect.left - 8,
+        y: rect.top + rect.height / 2,
+      }
+    })
+    await page.mouse.move(hoverPoint.x, hoverPoint.y)
+
+    await expect(page.getByRole("button", { name: "목록 항목 이동" })).toBeVisible()
+    await expectListItemHandleReady(page, "Retry", "목록 항목 이동")
+  })
+
   test("writer surface의 선택된 리스트 항목 affordance는 파란 rail 없이 말머리 바깥에 유지된다", async ({
     page,
   }) => {
@@ -1198,7 +1239,7 @@ test.describe("block editor authoring flow", () => {
     await page.keyboard.type("Retry")
 
     const retryItem = editor.locator("li", { hasText: /^Retry$/ }).first()
-    await retryItem.hover()
+    await retryItem.locator("p").first().hover()
 
     const dragHandle = page.getByTestId("block-drag-handle")
     await expect(dragHandle).toBeVisible()
@@ -1230,7 +1271,7 @@ test.describe("block editor authoring flow", () => {
     await page.keyboard.type("Retry")
 
     const retryItem = editor.locator("li", { hasText: /^Retry$/ }).first()
-    await retryItem.hover()
+    await retryItem.locator("p").first().hover()
 
     const dragHandle = page.getByTestId("block-drag-handle")
     await expect(dragHandle).toBeVisible()
@@ -1318,7 +1359,7 @@ test.describe("block editor authoring flow", () => {
     await page.keyboard.type("Retry")
 
     const retryItem = editor.locator("li", { hasText: /^Retry$/ }).first()
-    await retryItem.hover()
+    await retryItem.locator("p").first().hover()
 
     const dragHandle = page.getByTestId("block-drag-handle")
     await expect(dragHandle).toBeVisible()

--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -128,6 +128,83 @@ const getTableAffordances = (page: Page) => ({
   cellMenuButton: page.locator("[data-table-affordance='cell-menu']").first(),
 })
 
+type ListItemHandleMetrics = {
+  itemCenterY: number
+  handleCenterY: number
+  handleBox: { x: number; y: number; width: number; height: number }
+  textLeft: number | null
+  boxShadow: string | null
+}
+
+const readListItemHandleMetrics = async (
+  page: Page,
+  label: string,
+  handleLabel?: string
+): Promise<ListItemHandleMetrics | null> =>
+  page.evaluate(
+    ({ targetLabel, targetHandleLabel }) => {
+      const readOwnLabel = (item: HTMLElement) =>
+        Array.from(item.childNodes)
+          .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+          .map((node) => node.textContent || "")
+          .join(" ")
+          .replace(/\s+/g, " ")
+          .trim()
+
+      const targetItem =
+        Array.from(
+          document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+        ).find((item) => readOwnLabel(item) === targetLabel) ?? null
+      const handle = targetHandleLabel
+        ? Array.from(document.querySelectorAll<HTMLElement>("button")).find(
+            (element) =>
+              (element.getAttribute("aria-label") === targetHandleLabel ||
+                element.getAttribute("title") === targetHandleLabel) &&
+              element.offsetParent !== null
+          ) ?? null
+        : (document.querySelector<HTMLElement>("[data-testid='block-drag-handle']") as HTMLElement | null)
+
+      if (!targetItem || !handle || handle.offsetParent === null) {
+        return null
+      }
+
+      const itemRect = targetItem.getBoundingClientRect()
+      const handleRect = handle.getBoundingClientRect()
+      const textBlock = targetItem.querySelector("p") as HTMLElement | null
+
+      return {
+        itemCenterY: itemRect.top + itemRect.height / 2,
+        handleCenterY: handleRect.top + handleRect.height / 2,
+        handleBox: {
+          x: handleRect.x,
+          y: handleRect.y,
+          width: handleRect.width,
+          height: handleRect.height,
+        },
+        textLeft: textBlock?.getBoundingClientRect().left ?? null,
+        boxShadow: window.getComputedStyle(targetItem).boxShadow,
+      }
+    },
+    { targetLabel: label, targetHandleLabel: handleLabel ?? null }
+  )
+
+const expectListItemHandleReady = async (page: Page, label: string, handleLabel?: string) => {
+  await expect.poll(() => readListItemHandleMetrics(page, label, handleLabel)).not.toBeNull()
+  await expect
+    .poll(async () => {
+      const metrics = await readListItemHandleMetrics(page, label, handleLabel)
+      if (!metrics) return null
+      return Math.abs(metrics.handleCenterY - metrics.itemCenterY)
+    })
+    .toBeLessThanOrEqual(18)
+
+  const metrics = await readListItemHandleMetrics(page, label, handleLabel)
+  if (!metrics) {
+    throw new Error(`list item handle metrics are missing: ${label}`)
+  }
+  return metrics
+}
+
 test.describe("block editor authoring flow", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
@@ -1037,27 +1114,13 @@ test.describe("block editor authoring flow", () => {
 
     const dragHandle = page.getByTestId("block-drag-handle")
     await expect(dragHandle).toBeVisible()
-    const retryItemBox = await retryItem.boundingBox()
-    const dragHandleBox = await dragHandle.boundingBox()
-    if (!retryItemBox || !dragHandleBox) {
-      throw new Error("writer selected list item handle geometry is missing")
-    }
-    expect(
-      Math.abs(
-        dragHandleBox.y +
-          dragHandleBox.height / 2 -
-          (retryItemBox.y + retryItemBox.height / 2)
-      )
-    ).toBeLessThanOrEqual(18)
+    const { handleBox: dragHandleBox } = await expectListItemHandleReady(page, "Retry")
     await page.mouse.click(dragHandleBox.x + dragHandleBox.width / 2, dragHandleBox.y + dragHandleBox.height / 2)
     const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
     await expect(selectedDragHandle).toBeVisible()
     await expect(page.getByRole("button", { name: "블록 추가" })).toBeVisible()
 
-    const selectedHandleBox = await selectedDragHandle.boundingBox()
-    if (!selectedHandleBox) {
-      throw new Error("selected list item handle bounding box is missing")
-    }
+    const { handleBox: selectedHandleBox } = await expectListItemHandleReady(page, "Retry", "목록 항목 이동")
     await page.mouse.move(
       selectedHandleBox.x + selectedHandleBox.width / 2,
       selectedHandleBox.y + selectedHandleBox.height / 2
@@ -1139,52 +1202,18 @@ test.describe("block editor authoring flow", () => {
 
     const dragHandle = page.getByTestId("block-drag-handle")
     await expect(dragHandle).toBeVisible()
-    const retryItemBox = await retryItem.boundingBox()
-    const dragHandleBox = await dragHandle.boundingBox()
-    if (!retryItemBox || !dragHandleBox) {
-      throw new Error("writer affordance handle geometry is missing")
-    }
-    expect(
-      Math.abs(
-        dragHandleBox.y +
-          dragHandleBox.height / 2 -
-          (retryItemBox.y + retryItemBox.height / 2)
-      )
-    ).toBeLessThanOrEqual(18)
+    const { handleBox: dragHandleBox } = await expectListItemHandleReady(page, "Retry")
     await page.mouse.click(dragHandleBox.x + dragHandleBox.width / 2, dragHandleBox.y + dragHandleBox.height / 2)
     await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
     const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
     await expect(selectedDragHandle).toBeVisible()
-    const selectedHandleBox = await selectedDragHandle.boundingBox()
-    if (!selectedHandleBox) {
-      throw new Error("writer selected list item handle bounding box is missing")
-    }
+    const selectedMetrics = await expectListItemHandleReady(page, "Retry", "목록 항목 이동")
+    const selectedHandleBox = selectedMetrics.handleBox
 
-    const affordanceMetrics = await page.evaluate(() => {
-      const readOwnLabel = (item: HTMLElement) =>
-        Array.from(item.childNodes)
-          .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
-          .map((node) => node.textContent || "")
-          .join(" ")
-          .replace(/\s+/g, " ")
-          .trim()
-
-      const targetItem =
-        Array.from(
-          document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
-        ).find((item) => readOwnLabel(item) === "Retry") ?? null
-      const textBlock = targetItem?.querySelector("p") as HTMLElement | null
-
-      return {
-        boxShadow: targetItem ? window.getComputedStyle(targetItem).boxShadow : null,
-        textLeft: textBlock?.getBoundingClientRect().left ?? null,
-      }
-    })
-
-    expect(affordanceMetrics.boxShadow?.includes("inset")).toBeFalsy()
-    expect(affordanceMetrics.textLeft).not.toBeNull()
+    expect(selectedMetrics.boxShadow?.includes("inset")).toBeFalsy()
+    expect(selectedMetrics.textLeft).not.toBeNull()
     expect(selectedHandleBox.x + selectedHandleBox.width + 2).toBeLessThanOrEqual(
-      affordanceMetrics.textLeft ?? 0
+      selectedMetrics.textLeft ?? 0
     )
   })
 

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -3537,6 +3537,32 @@ const BlockEditorEngine = ({
     [getContentRoot, getTopLevelBlockElements]
   )
 
+  const findNestedListItemContextByClientPosition = useCallback(
+    (clientX: number, clientY: number) => {
+      const root = getContentRoot()
+      if (!root) return null
+
+      const candidates = Array.from(root.querySelectorAll<HTMLElement>(LIST_ITEM_SELECTOR))
+        .map((element) => {
+          const rect = element.getBoundingClientRect()
+          return { element, rect, area: rect.width * rect.height }
+        })
+        .filter(({ rect }) => {
+          if (rect.width <= 0 || rect.height <= 0) return false
+          return (
+            clientY >= rect.top &&
+            clientY <= rect.bottom &&
+            clientX >= rect.left - BLOCK_OUTER_SELECT_LEFT_GUTTER_PX &&
+            clientX <= rect.right + 8
+          )
+        })
+        .sort((left, right) => left.area - right.area)
+
+      return candidates[0] ? findNestedListItemContextFromTarget(candidates[0].element) : null
+    },
+    [findNestedListItemContextFromTarget, getContentRoot]
+  )
+
   const getNodeSelectedNestedListItemContext = useCallback(
     (currentEditor: TiptapEditor) => {
       const selection = currentEditor.state.selection as typeof currentEditor.state.selection & {
@@ -8529,7 +8555,9 @@ const BlockEditorEngine = ({
       const target =
         targetEvent instanceof Element ? targetEvent : targetEvent instanceof Node ? targetEvent.parentElement : null
       const cell = getTableCellFromClientPoint(clientX, clientY, targetEvent)
-      const targetListItemContext = findNestedListItemContextFromTarget(targetEvent)
+      const targetListItemContext =
+        findNestedListItemContextFromTarget(targetEvent) ??
+        findNestedListItemContextByClientPosition(clientX, clientY)
       const targetBlockIndex =
         findTopLevelBlockIndexFromTarget(targetEvent) ??
         findTopLevelBlockIndexByClientPosition(clientX, clientY)
@@ -8623,6 +8651,7 @@ const BlockEditorEngine = ({
       cancelTableQuickRailHide,
       findTopLevelBlockIndexByClientPosition,
       findTopLevelBlockIndexFromTarget,
+      findNestedListItemContextByClientPosition,
       findNestedListItemContextFromTarget,
       getTableCellFromClientPoint,
       getTopLevelBlockElementByIndex,

--- a/front/src/pages/admin/dashboard.tsx
+++ b/front/src/pages/admin/dashboard.tsx
@@ -866,13 +866,13 @@ const AdminDashboardPage: NextPage<AdminDashboardPageProps> = ({
               </SectionHeader>
               <ContextLinkGrid>
                 {monitoringItems.map((item) => (
-                  <AdminInfoLinkCard key={item.key} href={item.href} target="_blank" rel="noreferrer noopener">
+                  <ContextMonitoringLinkCard key={item.key} href={item.href} target="_blank" rel="noreferrer noopener">
                     <span className="iconWrap">{renderMonitoringBrand(item.brand.icon, item.brand.fallbackIcon, item.title)}</span>
                     <span className="copy">
                       <strong>{item.title}</strong>
                       <span>{item.status}</span>
                     </span>
-                  </AdminInfoLinkCard>
+                  </ContextMonitoringLinkCard>
                 ))}
               </ContextLinkGrid>
             </ContextSection>
@@ -1276,14 +1276,30 @@ const ContextSection = styled(AdminPlainCard)`
 `
 
 const ContextLinkGrid = styled(AdminInfoList)`
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+`
 
-  @media (max-width: 1180px) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+const ContextMonitoringLinkCard = styled(AdminInfoLinkCard)`
+  min-height: 100%;
+  align-items: flex-start;
+  gap: 0.8rem;
+  padding: 0.94rem 0.98rem;
+
+  .copy {
+    gap: 0.22rem;
   }
 
-  @media (max-width: 720px) {
-    grid-template-columns: 1fr;
+  .copy strong {
+    font-size: 1rem;
+    line-height: 1.18;
+    overflow-wrap: normal;
+    word-break: keep-all;
+  }
+
+  .copy span {
+    line-height: 1.38;
+    overflow-wrap: normal;
+    word-break: keep-all;
   }
 `
 


### PR DESCRIPTION
## 관련 이슈

close #73

## 작업 배경

- `/admin/dashboard`의 `연결된 채널` 카드가 좁은 폭에서 영문 채널명을 한 글자씩 세로로 쪼개던 레이아웃을 정리했습니다.
- `/admin/profile`과 공개 `/about`이 같은 About 프로필 계약을 계속 유지하는지도 admin contract로 다시 확인했습니다.
- PR CI에서 재발한 `editor-authoring-flow` writer list-item handle/drag 86.8px 오프셋은 top-level handle 오인식과 viewport hover fallback 누락을 함께 고정했습니다.

## 작업 내용

- `연결된 채널` 카드만 대시보드 전용 variant로 분리해 공통 카드의 aggressive wrapping을 끊었습니다.
- 카드 grid를 `auto-fit + minmax(14rem, 1fr)`로 바꿔 1065px 전후 폭에서도 제목/상태를 1~2줄 블록으로 읽히게 했습니다.
- `admin-hub-state`에 연결 채널 카드 레이아웃 계약 테스트를 추가했습니다.
- writer list item hover가 viewport/top-level target으로 들어와도 client 좌표 아래의 `li` context를 fallback으로 찾아 `목록 항목 이동` handle을 유지하도록 했습니다.
- editor e2e의 list item handle metric은 기본적으로 `목록 항목 이동`만 측정하게 강화하고, row gutter hover 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/admin-hub-state.spec.ts --workers=1` (RED -> GREEN 확인)
  - `yarn --cwd front playwright test e2e/admin-bootstrap-state.spec.ts e2e/admin-hub-state.spec.ts e2e/admin-profile-state.spec.ts e2e/admin-surface-primitives.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --grep "wrapper 선택으로 흔들리지 않고 선택 항목을 유지한다|handle drag는 항목 순서를 갱신한다|row gutter hover" --workers=1 --repeat-each=3` (`12 passed`)
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (`68 passed`, CI 대상 spec 2회 연속 통과 후 최종 1회 재확인)
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (`15 passed`)
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (`15 passed`)
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` (`37 passed`)
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test --workers=1` (`237 passed`, `6 skipped`, 이번 CI 후속 범위 밖의 기존 정적 계약 실패 2건 남음)
  - `node front/scripts/compare-runtime-guard-metrics.mjs` (`pass=7`, `warn=0`, `fail=0`, `missing=0`)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 대시보드 `연결된 채널` 카드가 기존 3열 고정보다 더 일찍 2열로 내려갈 수 있습니다.
- 예상 리스크: editor hover fallback이 좌측 gutter hover에서 가장 작은 `li`를 우선 선택하므로, deeply nested list에서 handle 타깃이 더 적극적으로 항목 단위로 잡힐 수 있습니다.
- 롤백 방법: `git revert e75b9198 535f16e0 1d88cbc9` 후 admin/editor contract와 smoke/mobile 세트를 다시 실행합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
