### PR TITLE
[Fix] 관리자 browser 임시저장 복구 안정화

### DIFF
--- a/front/e2e/admin-posts-workspace.spec.ts
+++ b/front/e2e/admin-posts-workspace.spec.ts
@@ -52,6 +52,15 @@ test.describe("admin posts workspace link contract", () => {
     expect(source).not.toContain('data-clickable={localDraft ? "true" : undefined}')
   })
 
+  test("브라우저 임시저장 카드는 본문 markdown preview를 직접 노출하지 않는다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspacePage.tsx"), "utf8")
+
+    expect(source).not.toContain("summary: summary || content.slice(0, 120)")
+    expect(source).not.toContain("{localDraft.summary ? <ResumeDescription>{localDraft.summary}</ResumeDescription> : null}")
+    expect(source).toContain("{localDraft.savedAt ? <span>{formatDateTime(localDraft.savedAt)}</span> : null}")
+    expect(source).toContain("<ResumeTitle>{localDraft.title}</ResumeTitle>")
+  })
+
   test("관리자 작성 화면은 현재 편집 중인 글이면 visibility와 무관하게 canonical 링크 열기와 복사 액션을 노출한다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/EditorStudioPage.tsx"), "utf8")
 

--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -151,26 +151,37 @@ const readListItemHandleMetrics = async (
           .replace(/\s+/g, " ")
           .trim()
 
-      const expectedHandleLabel = targetHandleLabel ?? "목록 항목 이동"
       const targetItem =
         Array.from(
           document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
         ).find((item) => readOwnLabel(item) === targetLabel) ?? null
-      const handle =
-        Array.from(document.querySelectorAll<HTMLElement>("button")).find(
+      if (!targetItem) {
+        return null
+      }
+
+      const expectedHandleLabel = targetHandleLabel ?? "목록 항목 이동"
+      const itemRect = targetItem.getBoundingClientRect()
+      const itemCenterY = itemRect.top + itemRect.height / 2
+      const handleCandidates = Array.from(document.querySelectorAll<HTMLElement>("button"))
+        .filter(
           (element) =>
             (element.getAttribute("aria-label") === expectedHandleLabel ||
               element.getAttribute("title") === expectedHandleLabel) &&
             (targetHandleLabel || element.getAttribute("data-testid") === "block-drag-handle") &&
             element.offsetParent !== null
-        ) ?? null
+        )
+        .map((element) => {
+          const rect = element.getBoundingClientRect()
+          return { element, rect, delta: Math.abs(rect.top + rect.height / 2 - itemCenterY) }
+        })
+        .sort((left, right) => left.delta - right.delta)
+      const handle = handleCandidates[0] ?? null
 
-      if (!targetItem || !handle || handle.offsetParent === null) {
+      if (!handle || handle.element.offsetParent === null) {
         return null
       }
 
-      const itemRect = targetItem.getBoundingClientRect()
-      const handleRect = handle.getBoundingClientRect()
+      const handleRect = handle.rect
       const textBlock = targetItem.querySelector("p") as HTMLElement | null
 
       return {
@@ -194,7 +205,7 @@ const expectListItemHandleReady = async (page: Page, label: string, handleLabel?
   await expect
     .poll(async () => {
       const metrics = await readListItemHandleMetrics(page, label, handleLabel)
-      if (!metrics) return null
+      if (!metrics) return Number.POSITIVE_INFINITY
       return Math.abs(metrics.handleCenterY - metrics.itemCenterY)
     })
     .toBeLessThanOrEqual(18)
@@ -204,6 +215,31 @@ const expectListItemHandleReady = async (page: Page, label: string, handleLabel?
     throw new Error(`list item handle metrics are missing: ${label}`)
   }
   return metrics
+}
+
+const hoverListItemGutter = async (page: Page, label: string) => {
+  const hoverPoint = await page.evaluate((targetLabel) => {
+    const readOwnLabel = (item: HTMLElement) =>
+      Array.from(item.childNodes)
+        .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+        .map((node) => node.textContent || "")
+        .join(" ")
+        .replace(/\s+/g, " ")
+        .trim()
+    const targetItem = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+    ).find((item) => readOwnLabel(item) === targetLabel)
+    if (!targetItem) {
+      throw new Error(`list item is missing: ${targetLabel}`)
+    }
+    const rect = targetItem.getBoundingClientRect()
+    return {
+      x: rect.left - 8,
+      y: rect.top + rect.height / 2,
+    }
+  }, label)
+
+  await page.mouse.move(hoverPoint.x, hoverPoint.y)
 }
 
 test.describe("block editor authoring flow", () => {
@@ -1111,11 +1147,9 @@ test.describe("block editor authoring flow", () => {
 
     const retryItem = editor.locator("li", { hasText: /^Retry$/ }).first()
     await retryItem.locator("p").first().click()
-    await retryItem.locator("p").first().hover()
+    await hoverListItemGutter(page, "Retry")
 
-    const dragHandle = page.getByTestId("block-drag-handle")
-    await expect(dragHandle).toBeVisible()
-    const { handleBox: dragHandleBox } = await expectListItemHandleReady(page, "Retry")
+    const { handleBox: dragHandleBox } = await expectListItemHandleReady(page, "Retry", "목록 항목 이동")
     await page.mouse.click(dragHandleBox.x + dragHandleBox.width / 2, dragHandleBox.y + dragHandleBox.height / 2)
     const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
     await expect(selectedDragHandle).toBeVisible()
@@ -1198,27 +1232,7 @@ test.describe("block editor authoring flow", () => {
     await page.keyboard.press("Enter")
     await page.keyboard.type("Retry")
 
-    const hoverPoint = await page.evaluate(() => {
-      const readOwnLabel = (item: HTMLElement) =>
-        Array.from(item.childNodes)
-          .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
-          .map((node) => node.textContent || "")
-          .join(" ")
-          .replace(/\s+/g, " ")
-          .trim()
-      const retryItem = Array.from(
-        document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
-      ).find((item) => readOwnLabel(item) === "Retry")
-      if (!retryItem) {
-        throw new Error("Retry item is missing")
-      }
-      const rect = retryItem.getBoundingClientRect()
-      return {
-        x: rect.left - 8,
-        y: rect.top + rect.height / 2,
-      }
-    })
-    await page.mouse.move(hoverPoint.x, hoverPoint.y)
+    await hoverListItemGutter(page, "Retry")
 
     await expect(page.getByRole("button", { name: "목록 항목 이동" })).toBeVisible()
     await expectListItemHandleReady(page, "Retry", "목록 항목 이동")
@@ -1238,12 +1252,9 @@ test.describe("block editor authoring flow", () => {
     await page.keyboard.press("Enter")
     await page.keyboard.type("Retry")
 
-    const retryItem = editor.locator("li", { hasText: /^Retry$/ }).first()
-    await retryItem.locator("p").first().hover()
+    await hoverListItemGutter(page, "Retry")
 
-    const dragHandle = page.getByTestId("block-drag-handle")
-    await expect(dragHandle).toBeVisible()
-    const { handleBox: dragHandleBox } = await expectListItemHandleReady(page, "Retry")
+    const { handleBox: dragHandleBox } = await expectListItemHandleReady(page, "Retry", "목록 항목 이동")
     await page.mouse.click(dragHandleBox.x + dragHandleBox.width / 2, dragHandleBox.y + dragHandleBox.height / 2)
     await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
     const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
@@ -1270,8 +1281,7 @@ test.describe("block editor authoring flow", () => {
     await page.keyboard.press("Enter")
     await page.keyboard.type("Retry")
 
-    const retryItem = editor.locator("li", { hasText: /^Retry$/ }).first()
-    await retryItem.locator("p").first().hover()
+    await hoverListItemGutter(page, "Retry")
 
     const dragHandle = page.getByTestId("block-drag-handle")
     await expect(dragHandle).toBeVisible()
@@ -1358,29 +1368,9 @@ test.describe("block editor authoring flow", () => {
     await page.keyboard.press("Enter")
     await page.keyboard.type("Retry")
 
-    const retryItem = editor.locator("li", { hasText: /^Retry$/ }).first()
-    await retryItem.locator("p").first().hover()
+    await hoverListItemGutter(page, "Retry")
 
-    const dragHandle = page.getByTestId("block-drag-handle")
-    await expect(dragHandle).toBeVisible()
-    const measureHandleAlignment = async () => {
-      const retryItemBox = await retryItem.boundingBox()
-      const dragHandleBox = await dragHandle.boundingBox()
-      if (!retryItemBox || !dragHandleBox) {
-        return null
-      }
-      return Math.abs(
-        dragHandleBox.y +
-          dragHandleBox.height / 2 -
-          (retryItemBox.y + retryItemBox.height / 2)
-      )
-    }
-    await expect.poll(measureHandleAlignment).not.toBeNull()
-    await expect.poll(measureHandleAlignment).toBeLessThanOrEqual(18)
-    const dragHandleBox = await dragHandle.boundingBox()
-    if (!dragHandleBox) {
-      throw new Error("writer hover handle geometry is missing")
-    }
+    const { handleBox: dragHandleBox } = await expectListItemHandleReady(page, "Retry", "목록 항목 이동")
     await page.mouse.click(
       dragHandleBox.x + dragHandleBox.width / 2,
       dragHandleBox.y + dragHandleBox.height / 2
@@ -1391,19 +1381,40 @@ test.describe("block editor authoring flow", () => {
     await expect(firstItem).toBeVisible()
 
     const dragGeometry = await page.evaluate(() => {
-      const handle = Array.from(document.querySelectorAll<HTMLElement>("button")).find(
-        (element) =>
-          (element.getAttribute("aria-label") === "목록 항목 이동" ||
-            element.getAttribute("title") === "목록 항목 이동") &&
-          element.offsetParent !== null
-      )
+      const readOwnLabel = (item: HTMLElement) =>
+        Array.from(item.childNodes)
+          .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+          .map((node) => node.textContent || "")
+          .join(" ")
+          .replace(/\s+/g, " ")
+          .trim()
+      const retryItem =
+        Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")).find(
+          (item) => readOwnLabel(item) === "Retry"
+        ) ?? null
       const firstItem =
         Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")).find(
-          (item) => item.textContent?.includes("Access")
+          (item) => readOwnLabel(item) === "Access"
         ) ?? null
-      if (!handle || !firstItem) return null
+      if (!retryItem || !firstItem) return null
 
-      const handleRect = handle.getBoundingClientRect()
+      const retryRect = retryItem.getBoundingClientRect()
+      const retryCenterY = retryRect.top + retryRect.height / 2
+      const handleCandidate = Array.from(document.querySelectorAll<HTMLElement>("button"))
+        .filter(
+          (element) =>
+            (element.getAttribute("aria-label") === "목록 항목 이동" ||
+              element.getAttribute("title") === "목록 항목 이동") &&
+            element.offsetParent !== null
+        )
+        .map((element) => {
+          const rect = element.getBoundingClientRect()
+          return { rect, delta: Math.abs(rect.top + rect.height / 2 - retryCenterY) }
+        })
+        .sort((left, right) => left.delta - right.delta)[0]
+      if (!handleCandidate) return null
+
+      const handleRect = handleCandidate.rect
       const firstRect = firstItem.getBoundingClientRect()
       return {
         dragBox: {

--- a/front/e2e/editor-temp-draft.spec.ts
+++ b/front/e2e/editor-temp-draft.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "@playwright/test"
+import { readFileSync } from "node:fs"
+import path from "node:path"
 import { isServerTempDraftPost } from "src/routes/Admin/editorTempDraft"
 
 test.describe("editor temp draft", () => {
@@ -31,5 +33,75 @@ test.describe("editor temp draft", () => {
         listed: false,
       })
     ).toBe(false)
+  })
+
+  test("/editor/new local draft 복구는 서버 temp draft bootstrap으로 덮어쓰지 않는다", () => {
+    const routingSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/useEditorStudioRouting.ts"), "utf8")
+
+    expect(routingSource).toContain('if (source !== "local-draft") return')
+    expect(routingSource).toContain("autoCreatedTempDraftRef.current = true")
+    expect(routingSource).toContain("setIsNewEditorBootstrapPending(false)")
+    expect(routingSource).toContain('if (source === "local-draft") return')
+  })
+
+  test("/editor/new?source=local-draft는 브라우저 임시저장 제목과 본문을 실제로 복구한다", async ({
+    page,
+  }) => {
+    let tempDraftRequestCount = 0
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const localDraft = {
+      title: "브라우저 임시저장 복구 제목",
+      content: "복구된 임시저장 본문입니다.",
+      summary: "복구 요약",
+      thumbnailUrl: "",
+      thumbnailFocusX: 50,
+      thumbnailFocusY: 50,
+      thumbnailZoom: 1,
+      tags: ["draft", "restore"],
+      category: "",
+      visibility: "PUBLIC_UNLISTED",
+      savedAt: "2026-04-20T11:25:00.000Z",
+    }
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/posts/temp", async (route) => {
+      tempDraftRequestCount += 1
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          resultCode: "200-1",
+          msg: "temp draft",
+          data: {
+            id: 990,
+            title: "임시글",
+            content: "",
+            published: false,
+            listed: false,
+            tempDraft: true,
+          },
+        }),
+      })
+    })
+    await page.addInitScript((draft) => {
+      window.localStorage.setItem("admin.editor.localDraft.v1", JSON.stringify(draft))
+    }, localDraft)
+
+    await page.goto("/editor/new?source=local-draft")
+
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(localDraft.title)
+    await expect(page.getByText(localDraft.content)).toBeVisible()
+    await expect(page.getByText("draft")).toBeVisible()
+    await page.waitForTimeout(600)
+    expect(tempDraftRequestCount).toBe(0)
   })
 })

--- a/front/src/routes/Admin/AdminPostsWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspacePage.tsx
@@ -74,7 +74,6 @@ type LocalDraftPayload = {
 
 type LocalDraftSummary = {
   title: string
-  summary: string
   savedAt: string
   tagCount: number
   visibility: LocalDraftPayload["visibility"]
@@ -193,8 +192,8 @@ const readLocalDraft = (): LocalDraftSummary | null => {
     if (!parsed || typeof parsed !== "object") return null
 
     const title = typeof parsed.title === "string" ? parsed.title.trim() : ""
-    const summary = typeof parsed.summary === "string" ? parsed.summary.trim() : ""
     const content = typeof parsed.content === "string" ? parsed.content.trim() : ""
+    const summary = typeof parsed.summary === "string" ? parsed.summary.trim() : ""
     const savedAt = typeof parsed.savedAt === "string" ? parsed.savedAt : ""
     const tags = Array.isArray(parsed.tags)
       ? parsed.tags.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
@@ -208,7 +207,6 @@ const readLocalDraft = (): LocalDraftSummary | null => {
 
     return {
       title: title || "제목 없는 임시저장",
-      summary: summary || content.slice(0, 120),
       savedAt,
       tagCount: tags.length,
       visibility,
@@ -1006,7 +1004,6 @@ export const AdminPostWorkspacePage: NextPage<AdminPostsWorkspacePageProps> = ({
                           {localDraft.savedAt ? <span>{formatDateTime(localDraft.savedAt)}</span> : null}
                         </ResumeHeader>
                         <ResumeTitle>{localDraft.title}</ResumeTitle>
-                        {localDraft.summary ? <ResumeDescription>{localDraft.summary}</ResumeDescription> : null}
                         <ResumeMeta>
                           <VisibilityBadge data-tone={localDraft.visibility}>
                             {visibilityLabelFromValue(localDraft.visibility)}
@@ -1612,17 +1609,6 @@ const ResumeTitle = styled.strong`
   word-break: keep-all;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
-`
-
-const ResumeDescription = styled.p`
-  margin: 0;
-  color: ${({ theme }) => theme.colors.gray11};
-  font-size: 0.8rem;
-  line-height: 1.45;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
 `
 
 const EmptyInlineState = styled.div`

--- a/front/src/routes/Admin/useEditorStudioRouting.ts
+++ b/front/src/routes/Admin/useEditorStudioRouting.ts
@@ -137,11 +137,13 @@ export const useEditorStudioRouting = ({
     if (!router.isReady) return
     const source = typeof router.query.source === "string" ? router.query.source.trim() : ""
     if (source !== "local-draft") return
+    autoCreatedTempDraftRef.current = true
+    setIsNewEditorBootstrapPending(false)
     restoreLocalDraft()
     const nextQuery = { ...router.query }
     delete nextQuery.source
     void replaceShallowRoutePreservingScroll(router, { query: nextQuery })
-  }, [restoreLocalDraft, router])
+  }, [autoCreatedTempDraftRef, restoreLocalDraft, router, setIsNewEditorBootstrapPending])
 
   useEffect(() => {
     if (!isDedicatedNewEditorRoute) {
@@ -150,18 +152,25 @@ export const useEditorStudioRouting = ({
       return
     }
 
+    const source = typeof router.query.source === "string" ? router.query.source.trim() : ""
+    if (source === "local-draft" || autoCreatedTempDraftRef.current) {
+      setIsNewEditorBootstrapPending(false)
+      return
+    }
+
     if (!postId.trim()) {
       setIsNewEditorBootstrapPending(true)
     }
-  }, [autoCreatedTempDraftRef, isDedicatedNewEditorRoute, postId, setIsNewEditorBootstrapPending])
+  }, [autoCreatedTempDraftRef, isDedicatedNewEditorRoute, postId, router.query.source, setIsNewEditorBootstrapPending])
 
   useEffect(() => {
     if (!router.isReady || !isDedicatedEditorRoute || !sessionMember?.isAdmin) return
     if (router.pathname !== editorNewRoutePath) return
+    const source = typeof router.query.source === "string" ? router.query.source.trim() : ""
+    if (source === "local-draft") return
     if (autoCreatedTempDraftRef.current) return
 
     autoCreatedTempDraftRef.current = true
-    const source = typeof router.query.source === "string" ? router.query.source.trim() : ""
     const returnTo =
       typeof router.query.returnTo === "string"
         ? normalizeEditorReturnRoute(router.query.returnTo)


### PR DESCRIPTION
## 관련 이슈

close #75

## 작업 배경

- `/admin/posts`의 `브라우저 임시저장` 카드가 본문 markdown preview처럼 커지는 UI를 제거했습니다.
- `/editor/new?source=local-draft` 진입 시 local draft 복구 후 서버 temp draft bootstrap이 다시 실행되어 빈 화면으로 덮는 흐름을 차단했습니다.
- PR CI에서 재발한 writer list-item handle flake를 `목록 항목 이동` handle의 실제 target `li` 기준으로 고정했습니다.
- 실제 브라우저 e2e로 localStorage draft 제목/본문/태그가 복구되고 temp draft API 호출이 0회임을 확인했습니다.

## 작업 내용

- local draft resume 카드에서 본문/요약 fallback 렌더링을 제거하고 제목, 저장 시각, 공개 범위, 태그 수만 남겼습니다.
- local-draft source 처리 시 bootstrap pending을 종료하고 temp draft auto-create effect를 건너뛰도록 routing guard를 추가했습니다.
- writer list-item handle 테스트가 상위 block handle이나 다른 list item handle을 잡지 않도록 `li` gutter hover와 target 중심 기반 metric helper를 사용하게 정리했습니다.
- `admin-posts-workspace`, `editor-temp-draft`, `editor-authoring-flow` 회귀 테스트에 preview 제거, local draft 복구, handle flake 방지 시나리오를 반영했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-posts-workspace.spec.ts e2e/editor-temp-draft.spec.ts e2e/editor-studio-state.spec.ts --workers=1` (`25 passed`)
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-hub-state.spec.ts e2e/admin-profile-state.spec.ts e2e/admin-posts-workspace.spec.ts e2e/admin-bootstrap-state.spec.ts e2e/admin-tools-state.spec.ts --workers=1` (`19 passed`)
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` (`37 passed`)
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --grep 'writer surface의 선택된 리스트 항목 handle|writer surface의 선택된 리스트 항목 affordance|writer surface의 선택된 리스트 항목 handle drag|engine surface의 선택된 리스트 항목 handle drag|table corner grow handle' --workers=1 --repeat-each=3` (`15 passed`)
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (`68 passed`, 2회 연속)
  - PR #76 checks: backend-ci, frontend-ci, Vercel, Vercel Preview Comments 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 브라우저 임시저장 카드에서 본문 preview가 사라져 정보량은 줄지만, 클릭 대상과 복구 목적은 더 명확해집니다.
- 롤백 방법: `git revert 9e715068 9302dcc4` 후 admin/editor temp draft 검증 세트와 `editor-authoring-flow.spec.ts`를 다시 실행합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
