### PR TITLE
[Fix] live e2e WebKit data prefetch 콘솔 오류 분리

### DIFF
--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -48,7 +48,9 @@ const isRetriableNetworkError = (error: unknown) => {
 }
 
 const isWebKitCorsAccessControlNoise = (message: string) =>
-  /due to access control checks\./i.test(message) && /\/api\.[\w.-]+\//i.test(message)
+  /due to access control checks\./i.test(message) &&
+  (/\/api\.[\w.-]+\//i.test(message) ||
+    /\/(?:www\.)?[\w.-]+\/_next\/data\/[^/\s]+\/[^?\s]+\.json/i.test(message))
 
 const isRetriableLoginStatus = (status: number) => [502, 503, 504, 520, 522, 524, 530].includes(status)
 const isInvalidLoginRequestBody = (status: number, body: string) =>
@@ -478,6 +480,25 @@ const loginThroughUi = async (
 
   throw new Error(`UI login failed after retries. last=${lastFailure}`)
 }
+
+test.describe("live critical error filter", () => {
+  test("WebKit Next data prefetch access-control noise는 critical error에서 제외한다", () => {
+    expect(
+      isWebKitCorsAccessControlNoise(
+        "/www.aquilaxk.site/_next/data/FsB_f7gB6UefGQbKBjMeG/index.json due to access control checks."
+      )
+    ).toBe(true)
+    expect(
+      isWebKitCorsAccessControlNoise(
+        "https://api.aquilaxk.site/member/api/v1/notifications/snapshot due to access control checks."
+      )
+    ).toBe(true)
+    expect(isWebKitCorsAccessControlNoise("TypeError: Cannot read properties of undefined")).toBe(false)
+    expect(
+      isWebKitCorsAccessControlNoise("https://cdn.example.com/widget.js due to access control checks.")
+    ).toBe(false)
+  })
+})
 
 test.describe("live production e2e", () => {
   test.skip(!hasLiveCredentials, "E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD is required")


### PR DESCRIPTION
## 관련 이슈

close #77

## 작업 배경

- Deploy live e2e에서 WebKit이 정상 관리자 순회 중 남기는 `www.* /_next/data/*.json due to access control checks.` console noise를 critical error에서 제외합니다.
- 기존 `api.*` access-control noise 예외는 유지하되, 임의 CDN/script access-control 오류는 계속 critical로 남도록 회귀 테스트를 추가했습니다.

## 작업 내용

- `front/e2e/live.spec.ts`의 WebKit access-control noise filter를 `api.*`와 Next data prefetch JSON에만 좁게 확장했습니다.
- live critical error filter 계약 테스트를 추가해 이번 배포 실패 메시지가 다시 critical error로 분류되지 않게 했습니다.

## 검증

- 실행한 명령과 결과:
  - `gh run view 24705458544 -R AquilaXk/aquila-blog --json name,workflowName,conclusion,status,url,event,headBranch,headSha,jobs`
  - `gh run view 24705458544 -R AquilaXk/aquila-blog --job 72257838049 --log`
  - `yarn --cwd front playwright:preflight`
  - RED: `env -u NO_COLOR PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/live.spec.ts --grep "WebKit Next data prefetch" --workers=1` (`Expected true, Received false`)
  - GREEN: `env -u NO_COLOR PLAYWRIGHT_USE_WEBSERVER=false PLAYWRIGHT_LIVE_MULTI_BROWSER=true yarn --cwd front playwright test e2e/live.spec.ts --grep "WebKit Next data prefetch" --project=webkit --workers=1` (`1 passed`)
  - `env -u NO_COLOR PLAYWRIGHT_USE_WEBSERVER=false PLAYWRIGHT_BASE_URL=https://www.aquilaxk.site E2E_API_BASE_URL=https://api.aquilaxk.site yarn --cwd front playwright test e2e/live.spec.ts --grep "관리자 로그인 후 핵심 운영 경로" --project=chromium --workers=1` (`1 passed`)
  - `env -u NO_COLOR PLAYWRIGHT_USE_WEBSERVER=false PLAYWRIGHT_LIVE_MULTI_BROWSER=true PLAYWRIGHT_BASE_URL=https://www.aquilaxk.site E2E_API_BASE_URL=https://api.aquilaxk.site yarn --cwd front playwright test e2e/live.spec.ts --grep "관리자 로그인 후 핵심 운영 경로" --project=webkit --workers=1` (`1 passed`)
  - `env -u NO_COLOR PLAYWRIGHT_USE_WEBSERVER=false PLAYWRIGHT_LIVE_MULTI_BROWSER=true PLAYWRIGHT_LIVE_FAIL_FAST=true PLAYWRIGHT_BASE_URL=https://www.aquilaxk.site E2E_API_BASE_URL=https://api.aquilaxk.site yarn --cwd front playwright test e2e/live.spec.ts --workers=1 --max-failures=1` (`8 passed`)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: Next data prefetch JSON access-control noise만 좁게 무시하므로 실제 runtime/page error 탐지는 유지됩니다.
- 롤백 방법: `git revert 893218c2` 후 live e2e를 다시 실행합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
