### PR TITLE
[Test] 백엔드 통합 테스트 구조 표준화

### DIFF
--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -9,13 +9,29 @@ import jakarta.persistence.Entity
 import jakarta.persistence.MappedSuperclass
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
 
 @org.junit.jupiter.api.DisplayName("ArchitectureGuard 테스트")
 class ArchitectureGuardTest {
+    private val testSourceRoot: Path = Path.of("src/test/kotlin")
+
     private fun importedClasses(): JavaClasses =
         ClassFileImporter()
             .withImportOption(ImportOption.DoNotIncludeTests())
             .importPackages("com.back")
+
+    private fun kotlinTestSources(): List<Path> =
+        Files
+            .walk(testSourceRoot)
+            .use { paths ->
+                paths
+                    .filter { Files.isRegularFile(it) }
+                    .filter { it.toString().endsWith(".kt") }
+                    .toList()
+            }
+
+    private fun sourceText(path: Path): String = Files.readString(path)
 
     @Test
     fun `bounded context에서 legacy app 패키지는 제거되어야 한다`() {
@@ -178,5 +194,57 @@ class ArchitectureGuardTest {
             .should()
             .beInterfaces()
             .check(importedClasses())
+    }
+
+    @Test
+    fun `Spring 통합 테스트 설정은 support base에만 선언되어야 한다`() {
+        val bannedAnnotations =
+            listOf(
+                "@SpringBootTest",
+                "@DataJpaTest",
+                "@WebMvcTest",
+                "@ActiveProfiles",
+                "@TestPropertySource",
+                "@DirtiesContext",
+            )
+
+        val violations =
+            kotlinTestSources()
+                .filterNot { it.startsWith(testSourceRoot.resolve("com/back/support")) }
+                .filterNot { it.endsWith("ArchitectureGuardTest.kt") }
+                .flatMap { path ->
+                    val text = sourceText(path)
+                    bannedAnnotations
+                        .filter { annotation -> text.contains(annotation) }
+                        .map { annotation -> "${testSourceRoot.relativize(path)} uses $annotation" }
+                }
+
+        assertThat(violations).isEmpty()
+    }
+
+    @Test
+    fun `Spring test bean override는 support base에만 선언되어야 한다`() {
+        val bannedOverrides =
+            listOf(
+                "@MockBean",
+                "@SpyBean",
+                "@MockitoBean",
+                "@MockitoSpyBean",
+                "@MockkBean",
+                "@SpykBean",
+            )
+
+        val violations =
+            kotlinTestSources()
+                .filterNot { it.startsWith(testSourceRoot.resolve("com/back/support")) }
+                .filterNot { it.endsWith("ArchitectureGuardTest.kt") }
+                .flatMap { path ->
+                    val text = sourceText(path)
+                    bannedOverrides
+                        .filter { annotation -> text.contains(annotation) }
+                        .map { annotation -> "${testSourceRoot.relativize(path)} uses $annotation" }
+                }
+
+        assertThat(violations).isEmpty()
     }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberRepositoryTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberRepositoryTest.kt
@@ -1,25 +1,17 @@
 package com.back.boundedContexts.member.adapter.persistence
 
 import com.back.boundedContexts.member.domain.shared.Member
-import com.back.global.jpa.config.JpaConfig
 import com.back.standard.dto.member.type1.MemberSearchSortType1
+import com.back.support.BaseRepositoryIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
-import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase
-import org.springframework.context.annotation.Import
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
-import org.springframework.test.context.ActiveProfiles
 
-@ActiveProfiles("test")
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(JpaConfig::class)
 @org.junit.jupiter.api.DisplayName("MemberRepository 테스트")
-class MemberRepositoryTest {
+class MemberRepositoryTest : BaseRepositoryIntegrationTest() {
     @Autowired
     private lateinit var memberRepository: MemberRepository
 

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberControllerTest.kt
@@ -1,35 +1,23 @@
 package com.back.boundedContexts.member.adapter.web
 
 import com.back.boundedContexts.member.application.service.MemberApplicationService
-import com.back.support.SeededSpringBootTestSupport
+import com.back.support.BaseControllerIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithUserDetails
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler
-import org.springframework.transaction.annotation.Transactional
 
-@ActiveProfiles("test")
-@SpringBootTest
-@AutoConfigureMockMvc
-@Transactional
 @org.junit.jupiter.api.DisplayName("ApiV1AdmMemberController 테스트")
-class ApiV1AdmMemberControllerTest : SeededSpringBootTestSupport() {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
+class ApiV1AdmMemberControllerTest : BaseControllerIntegrationTest() {
     @Autowired
     private lateinit var memberFacade: MemberApplicationService
 

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberControllerWebMvcTest.kt
@@ -1,89 +1,22 @@
 package com.back.boundedContexts.member.adapter.web
 
-import com.back.boundedContexts.member.application.port.input.CurrentMemberProfileQueryUseCase
-import com.back.boundedContexts.member.application.port.input.MemberUseCase
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.dto.MemberWithUsernameDto
-import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
-import com.back.boundedContexts.post.config.PostImageStorageProperties
-import com.back.global.app.AppConfig
-import com.back.global.security.config.CustomAuthenticationFilter
-import com.back.global.storage.application.UploadedFileRetentionService
 import com.back.standard.dto.member.type1.MemberSearchSortType1
 import com.back.standard.dto.page.PagedResult
+import com.back.support.BaseAdmMemberControllerWebMvcTest
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.startsWith
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.ComponentScan
-import org.springframework.context.annotation.FilterType
-import org.springframework.context.annotation.Import
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
-import org.springframework.security.config.annotation.web.builders.HttpSecurity
-import org.springframework.security.config.annotation.web.invoke
-import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.security.web.AuthenticationEntryPoint
-import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.access.AccessDeniedHandler
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.bean.override.mockito.MockitoBean
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler
 import java.time.Instant
 
-@ActiveProfiles("test")
-@WebMvcTest(
-    ApiV1AdmMemberController::class,
-    excludeFilters = [
-        ComponentScan.Filter(
-            type = FilterType.ASSIGNABLE_TYPE,
-            classes = [CustomAuthenticationFilter::class],
-        ),
-    ],
-)
-@Import(ApiV1AdmMemberControllerWebMvcTest.TestSecurityConfig::class)
 @org.junit.jupiter.api.DisplayName("ApiV1AdmMemberControllerWebMvc 테스트")
-class ApiV1AdmMemberControllerWebMvcTest {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
-    @MockitoBean
-    private lateinit var memberUseCase: MemberUseCase
-
-    @MockitoBean
-    private lateinit var currentMemberProfileQueryUseCase: CurrentMemberProfileQueryUseCase
-
-    @MockitoBean
-    private lateinit var postImageStoragePort: PostImageStoragePort
-
-    @MockitoBean
-    private lateinit var uploadedFileRetentionService: UploadedFileRetentionService
-
-    @MockitoBean(name = "jpaMappingContext")
-    private lateinit var jpaMappingContext: JpaMetamodelMappingContext
-
-    companion object {
-        @JvmStatic
-        @BeforeAll
-        fun setUpAppConfig() {
-            AppConfig(
-                siteBackUrl = "http://localhost:8080",
-                siteFrontUrl = "http://localhost:3000",
-                adminUsername = "admin",
-                adminEmail = "",
-                adminPassword = "test-password",
-            )
-        }
-    }
-
+class ApiV1AdmMemberControllerWebMvcTest : BaseAdmMemberControllerWebMvcTest() {
     @Nested
     inner class GetItems {
         @Test
@@ -303,50 +236,5 @@ class ApiV1AdmMemberControllerWebMvcTest {
         member.modifiedAt = Instant.parse("2026-03-13T00:01:00Z")
         check(!isAdmin || username == "admin") { "admin 샘플은 username=admin 이어야 한다." }
         return member
-    }
-
-    @TestConfiguration
-    class TestSecurityConfig {
-        @Bean
-        fun postImageStorageProperties(): PostImageStorageProperties = PostImageStorageProperties()
-
-        @Bean
-        fun testSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
-            http {
-                csrf { disable() }
-                formLogin { disable() }
-                logout { disable() }
-                httpBasic { disable() }
-                sessionManagement {
-                    sessionCreationPolicy = SessionCreationPolicy.STATELESS
-                }
-                authorizeHttpRequests {
-                    authorize("/member/api/v1/adm/**", hasRole("ADMIN"))
-                    authorize(anyRequest, permitAll)
-                }
-                exceptionHandling {
-                    authenticationEntryPoint = jsonAuthenticationEntryPoint()
-                    accessDeniedHandler = jsonAccessDeniedHandler()
-                }
-            }
-
-            return http.build()
-        }
-
-        @Bean
-        fun jsonAuthenticationEntryPoint(): AuthenticationEntryPoint =
-            AuthenticationEntryPoint { _, response, _ ->
-                response.status = 401
-                response.contentType = "application/json;charset=UTF-8"
-                response.writer.write("""{"resultCode":"401-1","msg":"로그인 후 이용해주세요."}""")
-            }
-
-        @Bean
-        fun jsonAccessDeniedHandler(): AccessDeniedHandler =
-            AccessDeniedHandler { _, response, _ ->
-                response.status = 403
-                response.contentType = "application/json;charset=UTF-8"
-                response.writer.write("""{"resultCode":"403-1","msg":"권한이 없습니다."}""")
-            }
     }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
@@ -4,7 +4,7 @@ import com.back.boundedContexts.member.application.service.AuthTokenService
 import com.back.boundedContexts.member.application.service.LoginAttemptService
 import com.back.boundedContexts.member.application.service.MemberApplicationService
 import com.back.boundedContexts.member.subContexts.session.adapter.persistence.MemberSessionRepository
-import com.back.support.SeededSpringBootTestSupport
+import com.back.support.BaseControllerIntegrationTest
 import jakarta.servlet.http.Cookie
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers.startsWith
@@ -12,28 +12,16 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.request.RequestPostProcessor
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler
-import org.springframework.transaction.annotation.Transactional
 
-@ActiveProfiles("test")
-@SpringBootTest
-@AutoConfigureMockMvc
-@Transactional
 @org.junit.jupiter.api.DisplayName("ApiV1AuthController 테스트")
-class ApiV1AuthControllerTest : SeededSpringBootTestSupport() {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
+class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
     @Autowired
     private lateinit var memberFacade: MemberApplicationService
 

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerTest.kt
@@ -1,29 +1,17 @@
 package com.back.boundedContexts.member.adapter.web
 
 import com.back.boundedContexts.member.application.service.MemberApplicationService
-import com.back.support.SeededSpringBootTestSupport
+import com.back.support.BaseControllerIntegrationTest
 import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler
-import org.springframework.transaction.annotation.Transactional
 
-@ActiveProfiles("test")
-@SpringBootTest
-@AutoConfigureMockMvc
-@Transactional
 @org.junit.jupiter.api.DisplayName("ApiV1MemberController 테스트")
-class ApiV1MemberControllerTest : SeededSpringBootTestSupport() {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
+class ApiV1MemberControllerTest : BaseControllerIntegrationTest() {
     @Autowired
     private lateinit var memberFacade: MemberApplicationService
 

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerWebMvcTest.kt
@@ -1,82 +1,22 @@
 package com.back.boundedContexts.member.adapter.web
 
-import com.back.boundedContexts.member.application.port.input.CurrentMemberProfileQueryUseCase
-import com.back.boundedContexts.member.application.port.input.MemberUseCase
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.dto.MemberWithUsernameDto
-import com.back.global.app.AppConfig
-import com.back.global.security.application.SecurityTipProvider
-import com.back.global.security.config.CustomAuthenticationFilter
+import com.back.support.BaseMemberControllerWebMvcTest
 import jakarta.servlet.http.Cookie
 import org.hamcrest.Matchers.startsWith
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.ComponentScan
-import org.springframework.context.annotation.FilterType
-import org.springframework.context.annotation.Import
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
-import org.springframework.security.config.annotation.web.builders.HttpSecurity
-import org.springframework.security.config.annotation.web.invoke
-import org.springframework.security.web.SecurityFilterChain
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.bean.override.mockito.MockitoBean
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler
-import org.springframework.web.servlet.mvc.annotation.ResponseStatusExceptionResolver
 import java.time.Instant
 import java.util.Optional
 
-@ActiveProfiles("test")
-@WebMvcTest(
-    ApiV1MemberController::class,
-    excludeFilters = [
-        ComponentScan.Filter(
-            type = FilterType.ASSIGNABLE_TYPE,
-            classes = [CustomAuthenticationFilter::class],
-        ),
-    ],
-)
-@Import(ApiV1MemberControllerWebMvcTest.TestSecurityConfig::class)
 @org.junit.jupiter.api.DisplayName("ApiV1MemberControllerWebMvc 테스트")
-class ApiV1MemberControllerWebMvcTest {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
-    @MockitoBean
-    private lateinit var memberUseCase: MemberUseCase
-
-    @MockitoBean
-    private lateinit var currentMemberProfileQueryUseCase: CurrentMemberProfileQueryUseCase
-
-    @MockitoBean
-    private lateinit var securityTipProvider: SecurityTipProvider
-
-    @MockitoBean(name = "jpaMappingContext")
-    private lateinit var jpaMappingContext: JpaMetamodelMappingContext
-
-    companion object {
-        @JvmStatic
-        @BeforeAll
-        fun setUpAppConfig() {
-            AppConfig(
-                siteBackUrl = "http://localhost:8080",
-                siteFrontUrl = "http://localhost:3000",
-                adminUsername = "admin",
-                adminEmail = "admin@test.com",
-                adminPassword = "test-password",
-            )
-        }
-    }
-
+class ApiV1MemberControllerWebMvcTest : BaseMemberControllerWebMvcTest() {
     @Nested
     inner class AdminProfile {
         @Test
@@ -187,26 +127,5 @@ class ApiV1MemberControllerWebMvcTest {
         member.createdAt = Instant.parse("2026-03-13T00:00:00Z")
         member.modifiedAt = Instant.parse("2026-03-13T00:01:00Z")
         return member
-    }
-
-    @TestConfiguration
-    class TestSecurityConfig {
-        @Bean
-        fun testSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
-            http {
-                csrf { disable() }
-                formLogin { disable() }
-                logout { disable() }
-                httpBasic { disable() }
-                authorizeHttpRequests {
-                    authorize(anyRequest, permitAll)
-                }
-            }
-
-            return http.build()
-        }
-
-        @Bean
-        fun appExceptionStatusCodeResolver(): ResponseStatusExceptionResolver = ResponseStatusExceptionResolver()
     }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationServiceTest.kt
@@ -1,36 +1,16 @@
 package com.back.boundedContexts.member.application.service
 
-import com.back.boundedContexts.member.adapter.persistence.MemberAttrPersistenceAdapter
 import com.back.boundedContexts.member.adapter.persistence.MemberAttrRepository
 import com.back.boundedContexts.member.adapter.persistence.MemberRepository
-import com.back.boundedContexts.member.adapter.persistence.MemberRepositoryAdapter
 import com.back.boundedContexts.member.domain.shared.Member
-import com.back.global.app.AppConfig
-import com.back.global.jpa.config.JpaConfig
-import com.back.global.storage.application.UploadedFileRetentionService
+import com.back.support.BaseMemberApplicationServiceIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
-import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase
-import org.springframework.context.annotation.Import
 import org.springframework.security.crypto.password.PasswordEncoder
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.bean.override.mockito.MockitoBean
 
-@ActiveProfiles("test")
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(
-    MemberApplicationService::class,
-    MemberRepositoryAdapter::class,
-    MemberAttrPersistenceAdapter::class,
-    MemberProfileHydrator::class,
-    JpaConfig::class,
-    AppConfig::class,
-)
 @org.junit.jupiter.api.DisplayName("MemberApplicationService 테스트")
-class MemberApplicationServiceTest {
+class MemberApplicationServiceTest : BaseMemberApplicationServiceIntegrationTest() {
     @Autowired
     private lateinit var memberFacade: MemberApplicationService
 
@@ -42,9 +22,6 @@ class MemberApplicationServiceTest {
 
     @Autowired
     private lateinit var passwordEncoder: PasswordEncoder
-
-    @MockitoBean
-    private lateinit var uploadedFileRetentionService: UploadedFileRetentionService
 
     @Test
     fun `회원 생성에서 profileImgUrl 을 함께 넘기면 기본 이미지 대신 저장된 이미지가 사용된다`() {

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationEventListenerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationEventListenerTest.kt
@@ -5,20 +5,16 @@ import com.back.boundedContexts.member.subContexts.notification.adapter.persiste
 import com.back.boundedContexts.member.subContexts.notification.domain.MemberNotificationType
 import com.back.boundedContexts.post.application.service.PostApplicationService
 import com.back.standard.extensions.getOrThrow
-import com.back.support.SeededSpringBootTestSupport
+import com.back.support.BaseSeededIntegrationTest
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.domain.PageRequest
-import org.springframework.test.context.ActiveProfiles
 
-@ActiveProfiles("test")
-@SpringBootTest
 @org.junit.jupiter.api.DisplayName("MemberNotificationEventListener 테스트")
-class MemberNotificationEventListenerTest : SeededSpringBootTestSupport() {
+class MemberNotificationEventListenerTest : BaseSeededIntegrationTest() {
     @Autowired
     private lateinit var actorApplicationService: ActorApplicationService
 

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationControllerTest.kt
@@ -4,31 +4,19 @@ import com.back.boundedContexts.member.application.service.MemberApplicationServ
 import com.back.boundedContexts.member.subContexts.signupVerification.adapter.persistence.MemberSignupVerificationRepository
 import com.back.global.task.adapter.persistence.TaskRepository
 import com.back.global.task.domain.TaskStatus
-import com.back.support.SeededSpringBootTestSupport
+import com.back.support.BaseControllerIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler
-import org.springframework.transaction.annotation.Transactional
 
-@ActiveProfiles("test")
-@SpringBootTest
-@AutoConfigureMockMvc
-@Transactional
 @org.junit.jupiter.api.DisplayName("ApiV1SignupVerificationController 테스트")
-class ApiV1SignupVerificationControllerTest : SeededSpringBootTestSupport() {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
+class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
     @Autowired
     private lateinit var memberApplicationService: MemberApplicationService
 

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/persistence/PostDeletedQueryRepositoryTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/persistence/PostDeletedQueryRepositoryTest.kt
@@ -6,23 +6,15 @@ import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.domain.shared.MemberAttr
 import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_IMG_URL
 import com.back.boundedContexts.post.domain.Post
-import com.back.global.jpa.config.JpaConfig
+import com.back.support.BaseRepositoryIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
-import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase
-import org.springframework.context.annotation.Import
 import org.springframework.data.domain.PageRequest
-import org.springframework.test.context.ActiveProfiles
 import java.time.Instant
 
-@ActiveProfiles("test")
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(JpaConfig::class, PostDeletedQueryRepository::class)
 @org.junit.jupiter.api.DisplayName("PostDeletedQueryRepository 테스트")
-class PostDeletedQueryRepositoryTest {
+class PostDeletedQueryRepositoryTest : BaseRepositoryIntegrationTest() {
     @Autowired
     private lateinit var memberRepository: MemberRepository
 

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1AdmPostControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1AdmPostControllerTest.kt
@@ -1,91 +1,29 @@
 package com.back.boundedContexts.post.adapter.web
 
 import com.back.boundedContexts.member.domain.shared.Member
-import com.back.boundedContexts.post.application.port.input.AdminPostListSnapshotUseCase
-import com.back.boundedContexts.post.application.port.input.PostTagRecommendationUseCase
-import com.back.boundedContexts.post.application.port.input.PostUseCase
 import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.dto.AdmDeletedPostDto
 import com.back.boundedContexts.post.dto.PostDto
 import com.back.boundedContexts.post.dto.PostTagRecommendationResult
-import com.back.global.app.AppConfig
-import com.back.global.security.config.CustomAuthenticationFilter
 import com.back.global.security.domain.SecurityUser
 import com.back.standard.dto.page.PageDto
 import com.back.standard.dto.page.PagedResult
+import com.back.support.BaseAdmPostControllerWebMvcTest
 import org.hamcrest.Matchers.startsWith
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.never
 import org.mockito.BDDMockito.then
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.ComponentScan
-import org.springframework.context.annotation.FilterType
-import org.springframework.context.annotation.Import
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
-import org.springframework.security.config.annotation.web.builders.HttpSecurity
-import org.springframework.security.config.annotation.web.invoke
-import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
-import org.springframework.security.web.AuthenticationEntryPoint
-import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.access.AccessDeniedHandler
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.bean.override.mockito.MockitoBean
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import java.time.Instant
 
-@ActiveProfiles("test")
-@WebMvcTest(
-    ApiV1AdmPostController::class,
-    excludeFilters = [
-        ComponentScan.Filter(
-            type = FilterType.ASSIGNABLE_TYPE,
-            classes = [CustomAuthenticationFilter::class],
-        ),
-    ],
-)
-@Import(ApiV1AdmPostControllerTest.TestSecurityConfig::class)
 @org.junit.jupiter.api.DisplayName("ApiV1AdmPostController 테스트")
-class ApiV1AdmPostControllerTest {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
-    @MockitoBean
-    private lateinit var postUseCase: PostUseCase
-
-    @MockitoBean
-    private lateinit var postTagRecommendationUseCase: PostTagRecommendationUseCase
-
-    @MockitoBean
-    private lateinit var adminPostListSnapshotService: AdminPostListSnapshotUseCase
-
-    @MockitoBean(name = "jpaMappingContext")
-    private lateinit var jpaMappingContext: JpaMetamodelMappingContext
-
-    companion object {
-        @JvmStatic
-        @BeforeAll
-        fun setUpAppConfig() {
-            AppConfig(
-                siteBackUrl = "http://localhost:8080",
-                siteFrontUrl = "http://localhost:3000",
-                adminUsername = "admin",
-                adminEmail = "",
-                adminPassword = "test-password",
-            )
-        }
-    }
-
+class ApiV1AdmPostControllerTest : BaseAdmPostControllerWebMvcTest() {
     @Test
     @WithMockUser(roles = ["ADMIN"])
     fun `관리자는 글 통계를 조회할 수 있다`() {
@@ -456,47 +394,5 @@ class ApiV1AdmPostControllerTest {
         post.createdAt = Instant.parse("2026-03-13T00:00:00Z")
         post.modifiedAt = Instant.parse("2026-03-13T00:01:00Z")
         return post
-    }
-
-    @TestConfiguration
-    class TestSecurityConfig {
-        @Bean
-        fun testSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
-            http {
-                csrf { disable() }
-                formLogin { disable() }
-                logout { disable() }
-                httpBasic { disable() }
-                sessionManagement {
-                    sessionCreationPolicy = SessionCreationPolicy.STATELESS
-                }
-                authorizeHttpRequests {
-                    authorize("/post/api/v1/adm/**", hasRole("ADMIN"))
-                    authorize(anyRequest, permitAll)
-                }
-                exceptionHandling {
-                    authenticationEntryPoint = jsonAuthenticationEntryPoint()
-                    accessDeniedHandler = jsonAccessDeniedHandler()
-                }
-            }
-
-            return http.build()
-        }
-
-        @Bean
-        fun jsonAuthenticationEntryPoint(): AuthenticationEntryPoint =
-            AuthenticationEntryPoint { _, response, _ ->
-                response.status = 401
-                response.contentType = "application/json;charset=UTF-8"
-                response.writer.write("""{"resultCode":"401-1","msg":"로그인 후 이용해주세요."}""")
-            }
-
-        @Bean
-        fun jsonAccessDeniedHandler(): AccessDeniedHandler =
-            AccessDeniedHandler { _, response, _ ->
-                response.status = 403
-                response.contentType = "application/json;charset=UTF-8"
-                response.writer.write("""{"resultCode":"403-1","msg":"권한이 없습니다."}""")
-            }
     }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostCommentControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostCommentControllerTest.kt
@@ -5,36 +5,24 @@ import com.back.boundedContexts.post.application.service.PostApplicationService
 import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostComment
 import com.back.standard.extensions.getOrThrow
-import com.back.support.SeededSpringBootTestSupport
+import com.back.support.BaseControllerIntegrationTest
 import jakarta.servlet.http.Cookie
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.security.test.context.support.WithUserDetails
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler
-import org.springframework.transaction.annotation.Transactional
 
-@ActiveProfiles("test")
-@SpringBootTest
-@AutoConfigureMockMvc
-@Transactional
 @org.junit.jupiter.api.DisplayName("ApiV1PostCommentController 테스트")
-class ApiV1PostCommentControllerTest : SeededSpringBootTestSupport() {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
+class ApiV1PostCommentControllerTest : BaseControllerIntegrationTest() {
     @Autowired
     private lateinit var postFacade: PostApplicationService
 

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostControllerTest.kt
@@ -7,7 +7,7 @@ import com.back.boundedContexts.post.application.service.PostQueryCacheNames
 import com.back.boundedContexts.post.dto.PublicPostDetailSnapshotCacheDto
 import com.back.standard.dto.post.type1.PostSearchSortType1
 import com.back.standard.extensions.getOrThrow
-import com.back.support.SeededSpringBootTestSupport
+import com.back.support.BaseControllerIntegrationTest
 import com.jayway.jsonpath.JsonPath
 import jakarta.persistence.EntityManager
 import jakarta.servlet.http.Cookie
@@ -17,31 +17,19 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.cache.CacheManager
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.security.test.context.support.WithUserDetails
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler
-import org.springframework.transaction.annotation.Transactional
 
-@ActiveProfiles("test")
-@SpringBootTest
-@AutoConfigureMockMvc
-@Transactional
 @org.junit.jupiter.api.DisplayName("ApiV1PostController 테스트")
-class ApiV1PostControllerTest : SeededSpringBootTestSupport() {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
+class ApiV1PostControllerTest : BaseControllerIntegrationTest() {
     @Autowired
     private lateinit var postFacade: PostApplicationService
 
@@ -76,7 +64,9 @@ class ApiV1PostControllerTest : SeededSpringBootTestSupport() {
                     content = """{"title": "제목", "content": "내용"}"""
                 }
 
-            val post = postFacade.findLatest().getOrThrow()
+            val responseBody = resultActions.andReturn().response.contentAsString
+            val postId = JsonPath.read<Int>(responseBody, "$.data.id").toLong()
+            val post = postFacade.findById(postId).getOrThrow()
 
             resultActions.andExpect {
                 match(handler().handlerType(ApiV1PostController::class.java))
@@ -181,22 +171,25 @@ class ApiV1PostControllerTest : SeededSpringBootTestSupport() {
         @Test
         @WithUserDetails("admin@test.com")
         fun `contentHtml 저장 시 위험한 스크립트와 이벤트 속성은 제거된다`() {
-            mvc
-                .post("/post/api/v1/posts") {
-                    contentType = MediaType.APPLICATION_JSON
-                    content =
-                        """
-                        {
-                          "title": "보안 테스트",
-                          "content": "본문",
-                          "contentHtml": "<p onclick=\"alert('x')\">safe</p><script>alert('x')</script>"
-                        }
-                        """.trimIndent()
-                }.andExpect {
-                    status { isCreated() }
-                }
+            val resultActions =
+                mvc
+                    .post("/post/api/v1/posts") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content =
+                            """
+                            {
+                              "title": "보안 테스트",
+                              "content": "본문",
+                              "contentHtml": "<p onclick=\"alert('x')\">safe</p><script>alert('x')</script>"
+                            }
+                            """.trimIndent()
+                    }.andExpect {
+                        status { isCreated() }
+                    }
 
-            val post = postFacade.findLatest().getOrThrow()
+            val responseBody = resultActions.andReturn().response.contentAsString
+            val postId = JsonPath.read<Int>(responseBody, "$.data.id").toLong()
+            val post = postFacade.findById(postId).getOrThrow()
             assertThat(post.contentHtml).contains("<p>safe</p>")
             assertThat(post.contentHtml).doesNotContain("onclick")
             assertThat(post.contentHtml).doesNotContain("<script")

--- a/back/src/test/kotlin/com/back/global/revalidate/RevalidateEventListenerTest.kt
+++ b/back/src/test/kotlin/com/back/global/revalidate/RevalidateEventListenerTest.kt
@@ -8,18 +8,14 @@ import com.back.boundedContexts.post.event.PostWrittenEvent
 import com.back.global.revalidate.adapter.event.RevalidateEventListener
 import com.back.global.task.adapter.persistence.TaskRepository
 import com.back.global.task.domain.TaskStatus
-import com.back.support.SeededSpringBootTestSupport
+import com.back.support.BaseSeededIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import java.util.UUID
 
-@ActiveProfiles("test")
-@SpringBootTest
 @org.junit.jupiter.api.DisplayName("RevalidateEventListener 테스트")
-class RevalidateEventListenerTest : SeededSpringBootTestSupport() {
+class RevalidateEventListenerTest : BaseSeededIntegrationTest() {
     @Autowired
     private lateinit var memberApplicationService: MemberApplicationService
 

--- a/back/src/test/kotlin/com/back/global/springDoc/OpenApiContractExportTest.kt
+++ b/back/src/test/kotlin/com/back/global/springDoc/OpenApiContractExportTest.kt
@@ -1,27 +1,17 @@
 package com.back.global.springDoc
 
-import com.back.support.SeededSpringBootTestSupport
+import com.back.support.BaseControllerIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import tools.jackson.databind.ObjectMapper
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 
-@ActiveProfiles("test")
-@SpringBootTest
-@AutoConfigureMockMvc
 @org.junit.jupiter.api.DisplayName("OpenAPI 계약 산출물 테스트")
-class OpenApiContractExportTest : SeededSpringBootTestSupport() {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
+class OpenApiContractExportTest : BaseControllerIntegrationTest() {
     @Autowired
     private lateinit var objectMapper: ObjectMapper
 

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceTest.kt
@@ -1,51 +1,27 @@
 package com.back.global.storage.application
 
-import com.back.boundedContexts.member.application.port.output.MemberAttrRepositoryPort
-import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
-import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
-import com.back.boundedContexts.post.config.PostImageStorageProperties
 import com.back.global.app.AppConfig
-import com.back.global.jpa.config.JpaConfig
 import com.back.global.storage.adapter.persistence.UploadedFileRepository
 import com.back.global.storage.domain.UploadedFileOwnerType
 import com.back.global.storage.domain.UploadedFilePurpose
 import com.back.global.storage.domain.UploadedFileRetentionReason
 import com.back.global.storage.domain.UploadedFileStatus
+import com.back.support.BaseUploadedFileRetentionServiceIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
-import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase
-import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.Duration
 import java.time.Instant
 
-@ActiveProfiles("test")
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(UploadedFileRetentionService::class, JpaConfig::class, UploadedFileRetentionServiceTest.TestConfig::class)
 @org.junit.jupiter.api.DisplayName("UploadedFileRetentionService 테스트")
-class UploadedFileRetentionServiceTest {
+class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegrationTest() {
     @Autowired
     private lateinit var uploadedFileRetentionService: UploadedFileRetentionService
 
     @Autowired
     private lateinit var uploadedFileRepository: UploadedFileRepository
-
-    @MockitoBean
-    private lateinit var postRepository: PostRepositoryPort
-
-    @MockitoBean
-    private lateinit var memberAttrRepository: MemberAttrRepositoryPort
-
-    @MockitoBean
-    private lateinit var postImageStoragePort: PostImageStoragePort
 
     @Test
     fun `업로드 직후 파일은 1일 보존 임시 파일로 등록된다`() {
@@ -233,18 +209,9 @@ class UploadedFileRetentionServiceTest {
                 siteBackUrl = "http://localhost:8080",
                 siteFrontUrl = "http://localhost:3000",
                 adminUsername = "admin",
-                adminEmail = "",
+                adminEmail = "admin@test.com",
                 adminPassword = "",
             )
         }
-    }
-
-    @TestConfiguration
-    class TestConfig {
-        @Bean
-        fun postImageStorageProperties(): PostImageStorageProperties = PostImageStorageProperties()
-
-        @Bean
-        fun uploadedFileRetentionProperties(): UploadedFileRetentionProperties = UploadedFileRetentionProperties()
     }
 }

--- a/back/src/test/kotlin/com/back/global/system/adapter/web/ApiV1AdmSystemControllerTest.kt
+++ b/back/src/test/kotlin/com/back/global/system/adapter/web/ApiV1AdmSystemControllerTest.kt
@@ -2,109 +2,36 @@ package com.back.global.system.adapter.web
 
 import com.back.boundedContexts.member.subContexts.notification.application.service.MemberNotificationSseService
 import com.back.boundedContexts.member.subContexts.signupVerification.application.service.SignupMailDiagnostics
-import com.back.boundedContexts.member.subContexts.signupVerification.application.service.SignupMailDiagnosticsService
-import com.back.boundedContexts.post.application.service.PostKeywordSearchPipelineService
 import com.back.boundedContexts.post.application.service.PostSearchEngineMirrorService
 import com.back.global.security.application.AuthSecurityEventDto
-import com.back.global.security.application.AuthSecurityEventService
-import com.back.global.security.config.CustomAuthenticationFilter
 import com.back.global.security.domain.SecurityUser
 import com.back.global.storage.application.UploadedFileCleanupDiagnostics
-import com.back.global.storage.application.UploadedFileRetentionService
 import com.back.global.system.application.AdminDashboardAuthSecuritySnapshot
 import com.back.global.system.application.AdminDashboardSignupMailSnapshot
 import com.back.global.system.application.AdminDashboardSnapshot
-import com.back.global.system.application.AdminDashboardSnapshotService
 import com.back.global.system.application.AdminDashboardStorageCleanupSnapshot
 import com.back.global.system.application.AdminDashboardTaskQueueSnapshot
-import com.back.global.system.application.AdminSystemHealthSnapshotService
 import com.back.global.task.application.TaskDlqReplayResult
-import com.back.global.task.application.TaskDlqReplayService
 import com.back.global.task.application.TaskExecutionSample
 import com.back.global.task.application.TaskProcessingLockDiagnostics
 import com.back.global.task.application.TaskQueueDiagnostics
-import com.back.global.task.application.TaskQueueDiagnosticsService
 import com.back.global.task.application.TaskRetryPolicy
 import com.back.global.task.application.TaskTypeDiagnostics
 import com.back.global.task.domain.TaskStatus
+import com.back.support.BaseAdmSystemControllerWebMvcTest
 import org.hamcrest.Matchers.anyOf
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.ComponentScan
-import org.springframework.context.annotation.FilterType
-import org.springframework.context.annotation.Import
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
-import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
-import org.springframework.security.config.annotation.web.builders.HttpSecurity
-import org.springframework.security.config.annotation.web.invoke
-import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
-import org.springframework.security.web.AuthenticationEntryPoint
-import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.access.AccessDeniedHandler
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.bean.override.mockito.MockitoBean
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import java.time.Instant
 
-@ActiveProfiles("test")
-@WebMvcTest(
-    ApiV1AdmSystemController::class,
-    excludeFilters = [
-        ComponentScan.Filter(
-            type = FilterType.ASSIGNABLE_TYPE,
-            classes = [CustomAuthenticationFilter::class],
-        ),
-    ],
-)
-@Import(ApiV1AdmSystemControllerTest.TestSecurityConfig::class)
 @org.junit.jupiter.api.DisplayName("ApiV1AdmSystemController 테스트")
-class ApiV1AdmSystemControllerTest {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
-    @MockitoBean
-    private lateinit var adminSystemHealthSnapshotService: AdminSystemHealthSnapshotService
-
-    @MockitoBean
-    private lateinit var adminDashboardSnapshotService: AdminDashboardSnapshotService
-
-    @MockitoBean
-    private lateinit var signupMailDiagnosticsService: SignupMailDiagnosticsService
-
-    @MockitoBean
-    private lateinit var memberNotificationSseService: MemberNotificationSseService
-
-    @MockitoBean
-    private lateinit var authSecurityEventService: AuthSecurityEventService
-
-    @MockitoBean
-    private lateinit var taskQueueDiagnosticsService: TaskQueueDiagnosticsService
-
-    @MockitoBean
-    private lateinit var taskDlqReplayService: TaskDlqReplayService
-
-    @MockitoBean
-    private lateinit var uploadedFileRetentionService: UploadedFileRetentionService
-
-    @MockitoBean
-    private lateinit var postKeywordSearchPipelineService: PostKeywordSearchPipelineService
-
-    @MockitoBean
-    private lateinit var postSearchEngineMirrorService: PostSearchEngineMirrorService
-
-    @MockitoBean(name = "jpaMappingContext")
-    private lateinit var jpaMappingContext: JpaMetamodelMappingContext
-
+class ApiV1AdmSystemControllerTest : BaseAdmSystemControllerWebMvcTest() {
     @Test
     fun `관리자는 시스템 bootstrap을 조회할 수 있다`() {
         val securityUser =
@@ -674,44 +601,4 @@ class ApiV1AdmSystemControllerTest {
                     oldestEligiblePurgeAfter = Instant.parse("2026-03-13T00:00:00Z"),
                 ),
         )
-
-    @TestConfiguration
-    class TestSecurityConfig {
-        @Bean
-        fun filterChain(http: HttpSecurity): SecurityFilterChain {
-            http {
-                authorizeHttpRequests {
-                    authorize("/system/api/v1/adm/**", hasRole("ADMIN"))
-                    authorize(anyRequest, permitAll)
-                }
-
-                csrf { disable() }
-                formLogin { disable() }
-                logout { disable() }
-                httpBasic { disable() }
-
-                sessionManagement {
-                    sessionCreationPolicy = SessionCreationPolicy.STATELESS
-                }
-
-                exceptionHandling {
-                    authenticationEntryPoint =
-                        AuthenticationEntryPoint { _, response, _ ->
-                            response.contentType = "$APPLICATION_JSON_VALUE; charset=UTF-8"
-                            response.status = 401
-                            response.writer.write("""{"resultCode":"401-1","msg":"로그인 후 이용해주세요."}""")
-                        }
-
-                    accessDeniedHandler =
-                        AccessDeniedHandler { _, response, _ ->
-                            response.contentType = "$APPLICATION_JSON_VALUE; charset=UTF-8"
-                            response.status = 403
-                            response.writer.write("""{"resultCode":"403-1","msg":"권한이 없습니다."}""")
-                        }
-                }
-            }
-
-            return http.build()
-        }
-    }
 }

--- a/back/src/test/kotlin/com/back/perf/PerformanceSanityTest.kt
+++ b/back/src/test/kotlin/com/back/perf/PerformanceSanityTest.kt
@@ -3,40 +3,21 @@ package com.back.perf
 import com.back.boundedContexts.member.application.service.ActorApplicationService
 import com.back.boundedContexts.member.application.service.MemberApplicationService
 import com.back.boundedContexts.post.application.service.PostApplicationService
-import com.back.support.SeededSpringBootTestSupport
+import com.back.support.BasePerformanceIntegrationTest
 import jakarta.persistence.EntityManagerFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.hibernate.SessionFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithUserDetails
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestPropertySource
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.put
-import org.springframework.transaction.annotation.Transactional
 
-@ActiveProfiles("test")
-@SpringBootTest
-@AutoConfigureMockMvc
-@Transactional
-@TestPropertySource(
-    properties = [
-        "spring.jpa.properties.hibernate.generate_statistics=true",
-        "spring.task.scheduling.enabled=false",
-    ],
-)
 @org.junit.jupiter.api.DisplayName("PerformanceSanity 테스트")
-class PerformanceSanityTest : SeededSpringBootTestSupport() {
-    @Autowired
-    private lateinit var mvc: MockMvc
-
+class PerformanceSanityTest : BasePerformanceIntegrationTest() {
     @Autowired
     private lateinit var actorApplicationService: ActorApplicationService
 

--- a/back/src/test/kotlin/com/back/support/BaseAdmMemberControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseAdmMemberControllerWebMvcTest.kt
@@ -1,0 +1,116 @@
+package com.back.support
+
+import com.back.boundedContexts.member.adapter.web.ApiV1AdmMemberController
+import com.back.boundedContexts.member.application.port.input.CurrentMemberProfileQueryUseCase
+import com.back.boundedContexts.member.application.port.input.MemberUseCase
+import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
+import com.back.boundedContexts.post.config.PostImageStorageProperties
+import com.back.global.app.AppConfig
+import com.back.global.security.config.CustomAuthenticationFilter
+import com.back.global.storage.application.UploadedFileRetentionService
+import org.junit.jupiter.api.BeforeAll
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.context.annotation.Import
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+
+@WebMvcTest(
+    ApiV1AdmMemberController::class,
+    excludeFilters = [
+        ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = [CustomAuthenticationFilter::class],
+        ),
+    ],
+)
+@Import(BaseAdmMemberControllerWebMvcTest.TestSecurityConfig::class)
+abstract class BaseAdmMemberControllerWebMvcTest : BaseIntegrationTest() {
+    @Autowired
+    protected lateinit var mvc: MockMvc
+
+    @MockitoBean
+    protected lateinit var memberUseCase: MemberUseCase
+
+    @MockitoBean
+    protected lateinit var currentMemberProfileQueryUseCase: CurrentMemberProfileQueryUseCase
+
+    @MockitoBean
+    protected lateinit var postImageStoragePort: PostImageStoragePort
+
+    @MockitoBean
+    protected lateinit var uploadedFileRetentionService: UploadedFileRetentionService
+
+    @MockitoBean(name = "jpaMappingContext")
+    protected lateinit var jpaMappingContext: JpaMetamodelMappingContext
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setUpAppConfig() {
+            AppConfig(
+                siteBackUrl = "http://localhost:8080",
+                siteFrontUrl = "http://localhost:3000",
+                adminUsername = "admin",
+                adminEmail = "admin@test.com",
+                adminPassword = "test-password",
+            )
+        }
+    }
+
+    @TestConfiguration
+    class TestSecurityConfig {
+        @Bean
+        fun postImageStorageProperties(): PostImageStorageProperties = PostImageStorageProperties()
+
+        @Bean
+        fun testSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+            http {
+                csrf { disable() }
+                formLogin { disable() }
+                logout { disable() }
+                httpBasic { disable() }
+                sessionManagement {
+                    sessionCreationPolicy = SessionCreationPolicy.STATELESS
+                }
+                authorizeHttpRequests {
+                    authorize("/member/api/v1/adm/**", hasRole("ADMIN"))
+                    authorize(anyRequest, permitAll)
+                }
+                exceptionHandling {
+                    authenticationEntryPoint = jsonAuthenticationEntryPoint()
+                    accessDeniedHandler = jsonAccessDeniedHandler()
+                }
+            }
+
+            return http.build()
+        }
+
+        @Bean
+        fun jsonAuthenticationEntryPoint(): AuthenticationEntryPoint =
+            AuthenticationEntryPoint { _, response, _ ->
+                response.status = 401
+                response.contentType = "application/json;charset=UTF-8"
+                response.writer.write("""{"resultCode":"401-1","msg":"로그인 후 이용해주세요."}""")
+            }
+
+        @Bean
+        fun jsonAccessDeniedHandler(): AccessDeniedHandler =
+            AccessDeniedHandler { _, response, _ ->
+                response.status = 403
+                response.contentType = "application/json;charset=UTF-8"
+                response.writer.write("""{"resultCode":"403-1","msg":"권한이 없습니다."}""")
+            }
+    }
+}

--- a/back/src/test/kotlin/com/back/support/BaseAdmPostControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseAdmPostControllerWebMvcTest.kt
@@ -1,0 +1,109 @@
+package com.back.support
+
+import com.back.boundedContexts.post.adapter.web.ApiV1AdmPostController
+import com.back.boundedContexts.post.application.port.input.AdminPostListSnapshotUseCase
+import com.back.boundedContexts.post.application.port.input.PostTagRecommendationUseCase
+import com.back.boundedContexts.post.application.port.input.PostUseCase
+import com.back.global.app.AppConfig
+import com.back.global.security.config.CustomAuthenticationFilter
+import org.junit.jupiter.api.BeforeAll
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.context.annotation.Import
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+
+@WebMvcTest(
+    ApiV1AdmPostController::class,
+    excludeFilters = [
+        ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = [CustomAuthenticationFilter::class],
+        ),
+    ],
+)
+@Import(BaseAdmPostControllerWebMvcTest.TestSecurityConfig::class)
+abstract class BaseAdmPostControllerWebMvcTest : BaseIntegrationTest() {
+    @Autowired
+    protected lateinit var mvc: MockMvc
+
+    @MockitoBean
+    protected lateinit var postUseCase: PostUseCase
+
+    @MockitoBean
+    protected lateinit var postTagRecommendationUseCase: PostTagRecommendationUseCase
+
+    @MockitoBean
+    protected lateinit var adminPostListSnapshotService: AdminPostListSnapshotUseCase
+
+    @MockitoBean(name = "jpaMappingContext")
+    protected lateinit var jpaMappingContext: JpaMetamodelMappingContext
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setUpAppConfig() {
+            AppConfig(
+                siteBackUrl = "http://localhost:8080",
+                siteFrontUrl = "http://localhost:3000",
+                adminUsername = "admin",
+                adminEmail = "admin@test.com",
+                adminPassword = "test-password",
+            )
+        }
+    }
+
+    @TestConfiguration
+    class TestSecurityConfig {
+        @Bean
+        fun testSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+            http {
+                csrf { disable() }
+                formLogin { disable() }
+                logout { disable() }
+                httpBasic { disable() }
+                sessionManagement {
+                    sessionCreationPolicy = SessionCreationPolicy.STATELESS
+                }
+                authorizeHttpRequests {
+                    authorize("/post/api/v1/adm/**", hasRole("ADMIN"))
+                    authorize(anyRequest, permitAll)
+                }
+                exceptionHandling {
+                    authenticationEntryPoint = jsonAuthenticationEntryPoint()
+                    accessDeniedHandler = jsonAccessDeniedHandler()
+                }
+            }
+
+            return http.build()
+        }
+
+        @Bean
+        fun jsonAuthenticationEntryPoint(): AuthenticationEntryPoint =
+            AuthenticationEntryPoint { _, response, _ ->
+                response.status = 401
+                response.contentType = "$APPLICATION_JSON_VALUE;charset=UTF-8"
+                response.writer.write("""{"resultCode":"401-1","msg":"로그인 후 이용해주세요."}""")
+            }
+
+        @Bean
+        fun jsonAccessDeniedHandler(): AccessDeniedHandler =
+            AccessDeniedHandler { _, response, _ ->
+                response.status = 403
+                response.contentType = "$APPLICATION_JSON_VALUE;charset=UTF-8"
+                response.writer.write("""{"resultCode":"403-1","msg":"권한이 없습니다."}""")
+            }
+    }
+}

--- a/back/src/test/kotlin/com/back/support/BaseAdmSystemControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseAdmSystemControllerWebMvcTest.kt
@@ -1,0 +1,117 @@
+package com.back.support
+
+import com.back.boundedContexts.member.subContexts.notification.application.service.MemberNotificationSseService
+import com.back.boundedContexts.member.subContexts.signupVerification.application.service.SignupMailDiagnosticsService
+import com.back.boundedContexts.post.application.service.PostKeywordSearchPipelineService
+import com.back.boundedContexts.post.application.service.PostSearchEngineMirrorService
+import com.back.global.security.application.AuthSecurityEventService
+import com.back.global.security.config.CustomAuthenticationFilter
+import com.back.global.storage.application.UploadedFileRetentionService
+import com.back.global.system.adapter.web.ApiV1AdmSystemController
+import com.back.global.system.application.AdminDashboardSnapshotService
+import com.back.global.system.application.AdminSystemHealthSnapshotService
+import com.back.global.task.application.TaskDlqReplayService
+import com.back.global.task.application.TaskQueueDiagnosticsService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.context.annotation.Import
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+
+@WebMvcTest(
+    ApiV1AdmSystemController::class,
+    excludeFilters = [
+        ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = [CustomAuthenticationFilter::class],
+        ),
+    ],
+)
+@Import(BaseAdmSystemControllerWebMvcTest.TestSecurityConfig::class)
+abstract class BaseAdmSystemControllerWebMvcTest : BaseIntegrationTest() {
+    @Autowired
+    protected lateinit var mvc: MockMvc
+
+    @MockitoBean
+    protected lateinit var adminSystemHealthSnapshotService: AdminSystemHealthSnapshotService
+
+    @MockitoBean
+    protected lateinit var adminDashboardSnapshotService: AdminDashboardSnapshotService
+
+    @MockitoBean
+    protected lateinit var signupMailDiagnosticsService: SignupMailDiagnosticsService
+
+    @MockitoBean
+    protected lateinit var memberNotificationSseService: MemberNotificationSseService
+
+    @MockitoBean
+    protected lateinit var authSecurityEventService: AuthSecurityEventService
+
+    @MockitoBean
+    protected lateinit var taskQueueDiagnosticsService: TaskQueueDiagnosticsService
+
+    @MockitoBean
+    protected lateinit var taskDlqReplayService: TaskDlqReplayService
+
+    @MockitoBean
+    protected lateinit var uploadedFileRetentionService: UploadedFileRetentionService
+
+    @MockitoBean
+    protected lateinit var postKeywordSearchPipelineService: PostKeywordSearchPipelineService
+
+    @MockitoBean
+    protected lateinit var postSearchEngineMirrorService: PostSearchEngineMirrorService
+
+    @MockitoBean(name = "jpaMappingContext")
+    protected lateinit var jpaMappingContext: JpaMetamodelMappingContext
+
+    @TestConfiguration
+    class TestSecurityConfig {
+        @Bean
+        fun filterChain(http: HttpSecurity): SecurityFilterChain {
+            http {
+                authorizeHttpRequests {
+                    authorize("/system/api/v1/adm/**", hasRole("ADMIN"))
+                    authorize(anyRequest, permitAll)
+                }
+
+                csrf { disable() }
+                formLogin { disable() }
+                logout { disable() }
+                httpBasic { disable() }
+
+                sessionManagement {
+                    sessionCreationPolicy = SessionCreationPolicy.STATELESS
+                }
+
+                exceptionHandling {
+                    authenticationEntryPoint =
+                        org.springframework.security.web.AuthenticationEntryPoint { _, response, _ ->
+                            response.contentType = "$APPLICATION_JSON_VALUE; charset=UTF-8"
+                            response.status = 401
+                            response.writer.write("""{"resultCode":"401-1","msg":"로그인 후 이용해주세요."}""")
+                        }
+
+                    accessDeniedHandler =
+                        org.springframework.security.web.access.AccessDeniedHandler { _, response, _ ->
+                            response.contentType = "$APPLICATION_JSON_VALUE; charset=UTF-8"
+                            response.status = 403
+                            response.writer.write("""{"resultCode":"403-1","msg":"권한이 없습니다."}""")
+                        }
+                }
+            }
+
+            return http.build()
+        }
+    }
+}

--- a/back/src/test/kotlin/com/back/support/BaseControllerIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseControllerIntegrationTest.kt
@@ -1,0 +1,13 @@
+package com.back.support
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.transaction.annotation.Transactional
+
+@AutoConfigureMockMvc
+@Transactional
+abstract class BaseControllerIntegrationTest : BaseSeededIntegrationTest() {
+    @Autowired
+    protected lateinit var mvc: MockMvc
+}

--- a/back/src/test/kotlin/com/back/support/BaseIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseIntegrationTest.kt
@@ -1,0 +1,6 @@
+package com.back.support
+
+import org.springframework.test.context.ActiveProfiles
+
+@ActiveProfiles("test")
+abstract class BaseIntegrationTest

--- a/back/src/test/kotlin/com/back/support/BaseMemberApplicationServiceIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseMemberApplicationServiceIntegrationTest.kt
@@ -1,0 +1,28 @@
+package com.back.support
+
+import com.back.boundedContexts.member.adapter.persistence.MemberAttrPersistenceAdapter
+import com.back.boundedContexts.member.adapter.persistence.MemberRepositoryAdapter
+import com.back.boundedContexts.member.application.service.MemberApplicationService
+import com.back.boundedContexts.member.application.service.MemberProfileHydrator
+import com.back.global.app.AppConfig
+import com.back.global.jpa.config.JpaConfig
+import com.back.global.storage.application.UploadedFileRetentionService
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(
+    MemberApplicationService::class,
+    MemberRepositoryAdapter::class,
+    MemberAttrPersistenceAdapter::class,
+    MemberProfileHydrator::class,
+    JpaConfig::class,
+    AppConfig::class,
+)
+abstract class BaseMemberApplicationServiceIntegrationTest : BaseIntegrationTest() {
+    @MockitoBean
+    protected lateinit var uploadedFileRetentionService: UploadedFileRetentionService
+}

--- a/back/src/test/kotlin/com/back/support/BaseMemberControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseMemberControllerWebMvcTest.kt
@@ -1,0 +1,85 @@
+package com.back.support
+
+import com.back.boundedContexts.member.adapter.web.ApiV1MemberController
+import com.back.boundedContexts.member.application.port.input.CurrentMemberProfileQueryUseCase
+import com.back.boundedContexts.member.application.port.input.MemberUseCase
+import com.back.global.app.AppConfig
+import com.back.global.security.application.SecurityTipProvider
+import com.back.global.security.config.CustomAuthenticationFilter
+import org.junit.jupiter.api.BeforeAll
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.context.annotation.Import
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.web.servlet.mvc.annotation.ResponseStatusExceptionResolver
+
+@WebMvcTest(
+    ApiV1MemberController::class,
+    excludeFilters = [
+        ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = [CustomAuthenticationFilter::class],
+        ),
+    ],
+)
+@Import(BaseMemberControllerWebMvcTest.TestSecurityConfig::class)
+abstract class BaseMemberControllerWebMvcTest : BaseIntegrationTest() {
+    @Autowired
+    protected lateinit var mvc: MockMvc
+
+    @MockitoBean
+    protected lateinit var memberUseCase: MemberUseCase
+
+    @MockitoBean
+    protected lateinit var currentMemberProfileQueryUseCase: CurrentMemberProfileQueryUseCase
+
+    @MockitoBean
+    protected lateinit var securityTipProvider: SecurityTipProvider
+
+    @MockitoBean(name = "jpaMappingContext")
+    protected lateinit var jpaMappingContext: JpaMetamodelMappingContext
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setUpAppConfig() {
+            AppConfig(
+                siteBackUrl = "http://localhost:8080",
+                siteFrontUrl = "http://localhost:3000",
+                adminUsername = "admin",
+                adminEmail = "admin@test.com",
+                adminPassword = "test-password",
+            )
+        }
+    }
+
+    @TestConfiguration
+    class TestSecurityConfig {
+        @Bean
+        fun testSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+            http {
+                csrf { disable() }
+                formLogin { disable() }
+                logout { disable() }
+                httpBasic { disable() }
+                authorizeHttpRequests {
+                    authorize(anyRequest, permitAll)
+                }
+            }
+
+            return http.build()
+        }
+
+        @Bean
+        fun appExceptionStatusCodeResolver(): ResponseStatusExceptionResolver = ResponseStatusExceptionResolver()
+    }
+}

--- a/back/src/test/kotlin/com/back/support/BasePerformanceIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BasePerformanceIntegrationTest.kt
@@ -1,0 +1,11 @@
+package com.back.support
+
+import org.springframework.test.context.TestPropertySource
+
+@TestPropertySource(
+    properties = [
+        "spring.jpa.properties.hibernate.generate_statistics=true",
+        "spring.task.scheduling.enabled=false",
+    ],
+)
+abstract class BasePerformanceIntegrationTest : BaseControllerIntegrationTest()

--- a/back/src/test/kotlin/com/back/support/BaseRepositoryIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseRepositoryIntegrationTest.kt
@@ -1,0 +1,12 @@
+package com.back.support
+
+import com.back.boundedContexts.post.adapter.persistence.PostDeletedQueryRepository
+import com.back.global.jpa.config.JpaConfig
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase
+import org.springframework.context.annotation.Import
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig::class, PostDeletedQueryRepository::class)
+abstract class BaseRepositoryIntegrationTest : BaseIntegrationTest()

--- a/back/src/test/kotlin/com/back/support/BaseSeededIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseSeededIntegrationTest.kt
@@ -1,0 +1,11 @@
+package com.back.support
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestExecutionListeners
+
+@SpringBootTest
+@TestExecutionListeners(
+    value = [ResetAndSeedTestExecutionListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+abstract class BaseSeededIntegrationTest : BaseIntegrationTest()

--- a/back/src/test/kotlin/com/back/support/BaseTransactionalIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseTransactionalIntegrationTest.kt
@@ -1,0 +1,8 @@
+package com.back.support
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@Transactional
+abstract class BaseTransactionalIntegrationTest : BaseIntegrationTest()

--- a/back/src/test/kotlin/com/back/support/BaseUploadedFileRetentionServiceIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseUploadedFileRetentionServiceIntegrationTest.kt
@@ -1,0 +1,58 @@
+package com.back.support
+
+import com.back.boundedContexts.member.application.port.output.MemberAttrRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.boundedContexts.post.config.PostImageStorageProperties
+import com.back.global.app.AppConfig
+import com.back.global.jpa.config.JpaConfig
+import com.back.global.storage.application.UploadedFileRetentionProperties
+import com.back.global.storage.application.UploadedFileRetentionService
+import org.junit.jupiter.api.BeforeAll
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(
+    UploadedFileRetentionService::class,
+    JpaConfig::class,
+    BaseUploadedFileRetentionServiceIntegrationTest.TestConfig::class,
+)
+abstract class BaseUploadedFileRetentionServiceIntegrationTest : BaseIntegrationTest() {
+    @MockitoBean
+    protected lateinit var postRepository: PostRepositoryPort
+
+    @MockitoBean
+    protected lateinit var memberAttrRepository: MemberAttrRepositoryPort
+
+    @MockitoBean
+    protected lateinit var postImageStoragePort: PostImageStoragePort
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setUpAppConfig() {
+            AppConfig(
+                siteBackUrl = "http://localhost:8080",
+                siteFrontUrl = "http://localhost:3000",
+                adminUsername = "admin",
+                adminEmail = "admin@test.com",
+                adminPassword = "",
+            )
+        }
+    }
+
+    @TestConfiguration
+    class TestConfig {
+        @Bean
+        fun postImageStorageProperties(): PostImageStorageProperties = PostImageStorageProperties()
+
+        @Bean
+        fun uploadedFileRetentionProperties(): UploadedFileRetentionProperties = UploadedFileRetentionProperties()
+    }
+}

--- a/back/src/test/kotlin/com/back/support/DatabaseCleanup.kt
+++ b/back/src/test/kotlin/com/back/support/DatabaseCleanup.kt
@@ -1,0 +1,54 @@
+package com.back.support
+
+import com.back.boundedContexts.member.adapter.bootstrap.MemberNotProdInitData
+import com.back.boundedContexts.post.adapter.bootstrap.PostNotProdInitData
+import jakarta.persistence.EntityManager
+import org.springframework.context.ApplicationContext
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.jdbc.core.JdbcTemplate
+
+class DatabaseCleanup(
+    private val jdbcTemplate: JdbcTemplate,
+    private val entityManager: EntityManager,
+    private val applicationContext: ApplicationContext,
+) {
+    fun cleanup() {
+        entityManager.clear()
+
+        jdbcTemplate.execute(
+            """
+            TRUNCATE TABLE
+                uploaded_file,
+                task,
+                member_notification,
+                member_action_log,
+                member_signup_verification,
+                post_comment,
+                post_like,
+                post_attr,
+                post,
+                member_attr,
+                member
+            RESTART IDENTITY
+            CASCADE
+            """.trimIndent(),
+        )
+
+        entityManager.clear()
+
+        applicationContext
+            .getBeanProvider(RedisConnectionFactory::class.java)
+            .ifAvailable
+            ?.connection
+            ?.use { redisConnection ->
+                redisConnection.serverCommands().flushDb()
+            }
+    }
+
+    fun resetAndSeed() {
+        cleanup()
+        applicationContext.getBean(MemberNotProdInitData::class.java).makeBaseMembers()
+        applicationContext.getBean(PostNotProdInitData::class.java).makeBasePosts()
+        entityManager.clear()
+    }
+}

--- a/back/src/test/kotlin/com/back/support/ResetAndSeedTestExecutionListener.kt
+++ b/back/src/test/kotlin/com/back/support/ResetAndSeedTestExecutionListener.kt
@@ -1,10 +1,7 @@
 package com.back.support
 
-import com.back.boundedContexts.member.adapter.bootstrap.MemberNotProdInitData
-import com.back.boundedContexts.post.adapter.bootstrap.PostNotProdInitData
 import jakarta.persistence.EntityManager
 import org.springframework.core.Ordered
-import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.TestContext
 import org.springframework.test.context.support.AbstractTestExecutionListener
@@ -13,42 +10,17 @@ class ResetAndSeedTestExecutionListener : AbstractTestExecutionListener() {
     override fun getOrder(): Int = Ordered.HIGHEST_PRECEDENCE
 
     override fun beforeTestMethod(testContext: TestContext) {
-        val applicationContext = testContext.applicationContext
-        val jdbcTemplate = applicationContext.getBean(JdbcTemplate::class.java)
-        val entityManager = applicationContext.getBean(EntityManager::class.java)
-
-        entityManager.clear()
-
-        jdbcTemplate.execute(
-            """
-            TRUNCATE TABLE
-                uploaded_file,
-                task,
-                member_notification,
-                member_action_log,
-                member_signup_verification,
-                post_comment,
-                post_like,
-                post_attr,
-                post,
-                member_attr,
-                member
-            RESTART IDENTITY
-            CASCADE
-            """.trimIndent(),
-        )
-
-        entityManager.clear()
-
-        applicationContext
-            .getBeanProvider(RedisConnectionFactory::class.java)
-            .ifAvailable
-            ?.connection
-            ?.use { redisConnection ->
-                redisConnection.serverCommands().flushDb()
-            }
-
-        applicationContext.getBean(MemberNotProdInitData::class.java).makeBaseMembers()
-        applicationContext.getBean(PostNotProdInitData::class.java).makeBasePosts()
+        databaseCleanup(testContext).resetAndSeed()
     }
+
+    override fun afterTestMethod(testContext: TestContext) {
+        databaseCleanup(testContext).cleanup()
+    }
+
+    private fun databaseCleanup(testContext: TestContext): DatabaseCleanup =
+        DatabaseCleanup(
+            jdbcTemplate = testContext.applicationContext.getBean(JdbcTemplate::class.java),
+            entityManager = testContext.applicationContext.getBean(EntityManager::class.java),
+            applicationContext = testContext.applicationContext,
+        )
 }

--- a/back/src/test/kotlin/com/back/support/SeededSpringBootTestSupport.kt
+++ b/back/src/test/kotlin/com/back/support/SeededSpringBootTestSupport.kt
@@ -1,11 +1,7 @@
 package com.back.support
 
-import org.springframework.test.annotation.DirtiesContext
-import org.springframework.test.context.TestExecutionListeners
-
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@TestExecutionListeners(
-    value = [ResetAndSeedTestExecutionListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+@Deprecated(
+    message = "Use BaseControllerIntegrationTest or BaseTransactionalIntegrationTest.",
+    replaceWith = ReplaceWith("BaseControllerIntegrationTest"),
 )
-abstract class SeededSpringBootTestSupport
+abstract class SeededSpringBootTestSupport : BaseControllerIntegrationTest()


### PR DESCRIPTION
## 관련 이슈

close #89

## 작업 배경

- 백엔드 Spring 통합 테스트 설정을 support base 계층으로 모아 자식 테스트 클래스의 직접 설정 선언을 제거했습니다.
- DatabaseCleanup 기반 reset/cleanup 경로와 ArchitectureGuard 구조 검사를 추가해 컨텍스트 캐시 파괴 회귀를 막습니다.

## 작업 내용

- `BaseIntegrationTest`, `BaseControllerIntegrationTest`, `BaseRepositoryIntegrationTest`, `BaseSeededIntegrationTest` 등 공통 테스트 베이스를 추가했습니다.
- Controller/Service/Repository/WebMvc/성능 테스트가 각 목적에 맞는 support base를 상속하도록 전환했습니다.
- `ResetAndSeedTestExecutionListener`가 `DatabaseCleanup`을 사용해 테스트 전 reset+seed, 테스트 후 cleanup을 수행하도록 정리했습니다.
- `ArchitectureGuardTest`에 support 밖 Spring test 설정/bean override 직접 선언 금지 검사를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests com.back.architecture.ArchitectureGuardTest` (RED 확인 후 GREEN)
  - `back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back test`
  - `back/gradlew -p back test --rerun-tasks`
  - pre-commit: `OpenApiContractExportTest`
  - pre-commit: `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 테스트 support 계층 변경으로 일부 테스트의 seed/transaction 전제가 달라질 수 있습니다. 전체 `back test`를 2회 조건으로 확인했고 구조 가드로 직접 설정 회귀를 차단했습니다.
- 롤백 방법: PR commit `c00ecf57`을 revert하면 기존 테스트 구조로 되돌릴 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
