### PR TITLE
[Fix] 글 상세 malformed strong marker 정규화

### DIFF
--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -831,6 +831,64 @@ test("상세 본문은 inline color quoted strong 토큰과 blockquote soft line
   expect(markdownText).not.toContain('*"요청이 진짜 우리 사용자의 의도인가"*를')
 })
 
+test("상세 본문은 trailing-space malformed strong marker를 그대로 노출하지 않는다", async ({ page }) => {
+  await page.route("**/post/api/v1/posts/508", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: 508,
+        createdAt: "2026-04-08T00:36:08.787Z",
+        modifiedAt: "2026-04-23T01:03:59.132Z",
+        authorId: 1,
+        authorName: "관리자",
+        authorUsername: "aquila",
+        authorProfileImageDirectUrl: "/avatar.png",
+        title: "post 508 malformed strong 회귀 방지",
+        content: [
+          '왜냐하면 중요한건 {{color:#34d399|**"어디에" **}}저장하느냐가 아니라',
+          "",
+          "## **구현 예시 **",
+        ].join("\n"),
+        tags: ["테스트태그"],
+        category: [],
+        published: true,
+        listed: true,
+        likesCount: 0,
+        commentsCount: 0,
+        hitCount: 0,
+        actorHasLiked: false,
+        actorCanModify: false,
+        actorCanDelete: false,
+      }),
+    })
+  })
+
+  await page.route("**/post/api/v1/posts/508/hit", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "200-1",
+        msg: "ok",
+        data: { hitCount: 1 },
+      }),
+    })
+  })
+
+  await page.goto("/posts/508")
+  await expect(page.getByText("post 508 malformed strong 회귀 방지")).toBeVisible()
+
+  const coloredMalformedStrong = page.locator(".aq-inline-color").filter({ hasText: '"어디에"' }).first()
+  await expect(coloredMalformedStrong).toBeVisible()
+  await expect(coloredMalformedStrong).not.toContainText("**")
+  await expect(page.getByRole("heading", { name: "구현 예시" })).toBeVisible()
+
+  const markdownText = await page.locator(".aq-markdown").first().evaluate((element) => element.textContent || "")
+  expect(markdownText).not.toContain('**"어디에" **')
+  expect(markdownText).not.toContain("**구현 예시 **")
+})
+
 test("상세 코드블럭은 Prism fallback 토큰 하이라이팅을 유지한다", async ({ page }) => {
   await page.route("**/post/api/v1/posts/104", async (route) => {
     await route.fulfill({

--- a/front/src/libs/markdown/rendering.ts
+++ b/front/src/libs/markdown/rendering.ts
@@ -110,6 +110,8 @@ graph TD
   | --- | --- |
   | a | 1 |`
 
+const FENCE_MARKER_PATTERN = /^(`{3,}|~{3,})/
+
 const CALLOUT_KIND_MAP: Record<string, CalloutKind> = {
   TIP: "tip",
   INFO: "info",
@@ -1082,10 +1084,60 @@ const normalizeSplitInlineColorQuotedEmphasis = (markdown: string) => {
   return normalized
 }
 
+const normalizeMalformedTrailingSpaceEmphasisLine = (line: string) => {
+  let normalized = line
+
+  normalized = normalized.replace(
+    /(\*\*|__)(\S(?:.*?\S)?)\s+(\1)/g,
+    (_match, marker: string, inner: string) => `${marker}${inner}${marker}`
+  )
+
+  normalized = normalized.replace(
+    /(^|[^*])\*([^*\n]*?\S)\s+\*(?!\*)/g,
+    (_match, prefix: string, inner: string) => `${prefix}*${inner}*`
+  )
+
+  normalized = normalized.replace(
+    /(^|[^_])_([^_\n]*?\S)\s+_(?!_)/g,
+    (_match, prefix: string, inner: string) => `${prefix}_${inner}_`
+  )
+
+  return normalized
+}
+
+const normalizeMalformedTrailingSpaceEmphasis = (markdown: string) => {
+  if ((!markdown.includes("*") && !markdown.includes("_")) || !markdown.includes(" ")) return markdown
+
+  let activeFenceMarker = ""
+
+  return markdown
+    .split("\n")
+    .map((line) => {
+      const trimmedStart = line.trimStart()
+      const fenceMatch = trimmedStart.match(FENCE_MARKER_PATTERN)
+
+      if (fenceMatch) {
+        const marker = fenceMatch[1]
+        if (!activeFenceMarker) {
+          activeFenceMarker = marker
+        } else if (marker[0] === activeFenceMarker[0] && marker.length >= activeFenceMarker.length) {
+          activeFenceMarker = ""
+        }
+        return line
+      }
+
+      if (activeFenceMarker) return line
+      return normalizeMalformedTrailingSpaceEmphasisLine(line)
+    })
+    .join("\n")
+}
+
 export const normalizeMarkdownForRender = (rawMarkdown: string) =>
   normalizeLegacyInlineHtmlMarkdown(
     normalizeLegacyCollapsedBlockquoteStrongLines(
-      normalizeSplitInlineColorQuotedEmphasis(normalizeEscapedMarkdownFences(rawMarkdown.trim()))
+      normalizeMalformedTrailingSpaceEmphasis(
+        normalizeSplitInlineColorQuotedEmphasis(normalizeEscapedMarkdownFences(rawMarkdown.trim()))
+      )
     )
   )
 


### PR DESCRIPTION
## 관련 이슈

close #91

## 작업 배경

- 공개 글 상세 `/posts/507`에서 closing strong marker 앞 공백이 남은 malformed markdown이 literal `**`로 노출되는 문제를 정규화했습니다.
- inline color 본문과 heading 모두 같은 원인이라 markdown render normalization 한 곳에서 함께 복구했습니다.

## 작업 내용

- detail markdown 정규화 단계에 trailing-space malformed emphasis(`**구현 예시 **`, `{{color:#34d399|**"어디에" **}}`) trim 복원을 추가했습니다.
- smoke 회귀 테스트에 `/posts/507` 유형의 malformed strong 본문/heading 케이스를 추가했습니다.
- content-rendering brief에 malformed trailing-space emphasis 복원 계약을 반영했습니다. (local brief sync)

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts --workers=1 --grep "malformed strong"` (RED)
  - `yarn --cwd front playwright test e2e/smoke.spec.ts --workers=1 --grep "malformed strong"` (GREEN)
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` (same condition 2nd pass)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: malformed emphasis trim 정규화가 일반 문단에도 적용되므로, plain text로 literal marker를 의도한 드문 케이스가 있다면 강조로 복원될 수 있습니다.
- 롤백 방법: commit `5493284e`를 revert하면 기존 렌더 경로로 되돌릴 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
