### PR TITLE
[Fix] 글 작성/수정 selection affordance 잔류 제거

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -1644,6 +1644,115 @@ test.describe("block editor authoring flow", () => {
     )
   })
 
+  test("빠른 block drag release 뒤에는 drop indicator가 남지 않는다", async ({ page }) => {
+    await page.goto(QA_ENGINE_ROUTE)
+
+    await expect(page.getByTestId("qa-editor-ready")).toHaveCount(1)
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.click()
+    await page.keyboard.type("첫 줄")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("둘째 줄")
+
+    const firstParagraph = editor.locator("p").first()
+    const secondParagraph = editor.locator("p").nth(1)
+    await firstParagraph.hover()
+
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+
+    const [dragBox, targetBox] = await Promise.all([
+      dragHandle.boundingBox(),
+      secondParagraph.boundingBox(),
+    ])
+    if (!dragBox || !targetBox) {
+      throw new Error("빠른 block drag 좌표를 계산할 수 없습니다.")
+    }
+
+    const pointerId = 44
+    const startX = dragBox.x + dragBox.width / 2
+    const startY = dragBox.y + dragBox.height / 2
+    const endX = targetBox.x + Math.min(24, targetBox.width / 3)
+    const endY = targetBox.y + targetBox.height / 2
+
+    await dragHandle.dispatchEvent("pointerdown", {
+      pointerId,
+      pointerType: "mouse",
+      button: 0,
+      buttons: 1,
+      clientX: startX,
+      clientY: startY,
+      bubbles: true,
+      cancelable: true,
+    })
+    await page.evaluate(
+      ({ pointerId: nextPointerId, endX: nextEndX, endY: nextEndY }) => {
+        window.dispatchEvent(
+          new PointerEvent("pointermove", {
+            pointerId: nextPointerId,
+            pointerType: "mouse",
+            button: 0,
+            buttons: 1,
+            clientX: nextEndX,
+            clientY: nextEndY,
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+        window.dispatchEvent(
+          new PointerEvent("pointerup", {
+            pointerId: nextPointerId,
+            pointerType: "mouse",
+            button: 0,
+            buttons: 0,
+            clientX: nextEndX,
+            clientY: nextEndY,
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+      },
+      { pointerId, endX, endY }
+    )
+
+    await expect(page.getByTestId("block-drag-ghost")).toHaveCount(0)
+    await expect(page.getByTestId("block-drop-indicator")).toHaveCount(0)
+  })
+
+  test("writer surface 좁은 폭에서도 block handle rail은 본문 첫 줄을 덮지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 640, height: 720 })
+    await page.goto(QA_WRITER_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expect(editor).toBeVisible()
+    await editor.click()
+    await page.keyboard.type("말머리 보호")
+
+    const paragraph = editor.locator("p", { hasText: "말머리 보호" }).first()
+    await paragraph.hover({ force: true })
+
+    const handleRail = page.locator("[data-block-handle-rail='true'][data-visible='true']").first()
+    await expect(handleRail).toBeVisible()
+
+    const [paragraphBox, railBox] = await Promise.all([
+      paragraph.boundingBox(),
+      handleRail.boundingBox(),
+    ])
+    if (!paragraphBox || !railBox) {
+      throw new Error("block handle rail 겹침 좌표를 계산할 수 없습니다.")
+    }
+
+    const overlapsParagraph =
+      railBox.x < paragraphBox.x + paragraphBox.width &&
+      railBox.x + railBox.width > paragraphBox.x &&
+      railBox.y < paragraphBox.y + paragraphBox.height &&
+      railBox.y + railBox.height > paragraphBox.y
+
+    expect(overlapsParagraph).toBe(false)
+  })
+
   test("table hover에서도 block selection affordance를 다시 띄우고 table block selection으로 전환할 수 있다", async ({ page }) => {
     await page.goto(QA_ENGINE_ROUTE)
     const {

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -943,6 +943,9 @@ const BLOCK_HANDLE_MEDIA_QUERY = "(pointer: coarse)"
 const DESKTOP_TABLE_RAIL_MEDIA_QUERY = "(max-width: 768px)"
 const DEFAULT_EDITOR_READABLE_WIDTH_PX = 48 * 16
 const BLOCK_HANDLE_POSITION_EPSILON_PX = 0.4
+const BLOCK_HANDLE_VIEWPORT_PADDING_PX = 12
+const BLOCK_HANDLE_GUTTER_GAP_PX = 10
+const BLOCK_HANDLE_STACKED_GAP_PX = 8
 const BLOCK_OUTER_SELECT_LEFT_GUTTER_PX = 76
 const BLOCK_OUTER_SELECT_LEFT_EDGE_INNER_PX = 6
 const BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX = 10
@@ -1542,6 +1545,31 @@ const resolveBlockHandleAnchorTop = (blockElement: HTMLElement, railHeight: numb
 const resolveThinBlockHandleAnchorTop = (blockElement: HTMLElement, railHeight: number) => {
   const rect = blockElement.getBoundingClientRect()
   return Math.max(0, rect.top + rect.height / 2 - railHeight / 2)
+}
+
+const resolveBlockHandleRailLayout = (
+  rect: DOMRect,
+  railWidth: number,
+  railHeight: number,
+  anchoredTop: number
+) => {
+  const gutterLeft = rect.left - railWidth - BLOCK_HANDLE_GUTTER_GAP_PX
+  if (gutterLeft >= BLOCK_HANDLE_VIEWPORT_PADDING_PX || typeof window === "undefined") {
+    return {
+      left: Math.max(BLOCK_HANDLE_VIEWPORT_PADDING_PX, gutterLeft),
+      top: anchoredTop,
+    }
+  }
+
+  const maxLeft = Math.max(
+    BLOCK_HANDLE_VIEWPORT_PADDING_PX,
+    window.innerWidth - railWidth - BLOCK_HANDLE_VIEWPORT_PADDING_PX
+  )
+
+  return {
+    left: Math.min(Math.max(BLOCK_HANDLE_VIEWPORT_PADDING_PX, rect.left), maxLeft),
+    top: Math.max(BLOCK_HANDLE_VIEWPORT_PADDING_PX, rect.top - railHeight - BLOCK_HANDLE_STACKED_GAP_PX),
+  }
 }
 
 const isWithinBlockHandleEpsilon = (prev: number, next: number) =>
@@ -3111,6 +3139,12 @@ const BlockEditorEngine = ({
     syncSelectedBlockNodeSurface(null)
   }, [syncSelectedBlockNodeSurface])
 
+  const clearBlockDragVisualState = useCallback(() => {
+    setDraggedBlockState(null)
+    setDragGhostPosition(null)
+    setDropIndicatorState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
+  }, [])
+
   const selectTableAxisAtIndex = useCallback(
     (activeEditor: TiptapEditor, tablePos: number, axis: "row" | "column", axisIndex: number) => {
       const tableNode = activeEditor.state.doc.nodeAt(tablePos)
@@ -3291,8 +3325,27 @@ const BlockEditorEngine = ({
         visible: true,
         ...indicator,
       })
+
+      let earlyPointerDoneTimeout: number | null = null
+      const cleanupEarlyPointerDone = () => {
+        window.removeEventListener("pointerup", handleEarlyPointerDone, true)
+        window.removeEventListener("pointercancel", handleEarlyPointerDone, true)
+        if (earlyPointerDoneTimeout !== null) {
+          window.clearTimeout(earlyPointerDoneTimeout)
+          earlyPointerDoneTimeout = null
+        }
+      }
+      const handleEarlyPointerDone = (event: PointerEvent) => {
+        if (event.pointerId !== pending.pointerId) return
+        clearBlockDragVisualState()
+        cleanupEarlyPointerDone()
+      }
+
+      window.addEventListener("pointerup", handleEarlyPointerDone, true)
+      window.addEventListener("pointercancel", handleEarlyPointerDone, true)
+      earlyPointerDoneTimeout = window.setTimeout(cleanupEarlyPointerDone, 30000)
     },
-    [resolveDropIndicatorByClientY]
+    [clearBlockDragVisualState, resolveDropIndicatorByClientY]
   )
 
   const clearNativeTextSelection = useCallback(() => {
@@ -8280,14 +8333,20 @@ const BlockEditorEngine = ({
     const { width: railWidth, height: railHeight } = blockHandleRailMetricsRef.current
     if (activeListItemContext?.listItemElement?.isConnected) {
       const rect = activeListItemContext.listItemElement.getBoundingClientRect()
+      const railLayout = resolveBlockHandleRailLayout(
+        rect,
+        railWidth,
+        railHeight,
+        resolveBlockHandleAnchorTop(activeListItemContext.listItemElement, railHeight)
+      )
       const nextState: TopLevelBlockHandleState = {
         visible: true,
         kind: "list-item",
         blockIndex: activeListItemContext.listBlockIndex,
         listPath: [...activeListItemContext.listPath],
         itemIndex: activeListItemContext.itemIndex,
-        left: Math.max(12, rect.left - railWidth - 10),
-        top: resolveBlockHandleAnchorTop(activeListItemContext.listItemElement, railHeight),
+        left: railLayout.left,
+        top: railLayout.top,
         bottom: rect.bottom + 12,
         width: rect.width,
       }
@@ -8316,14 +8375,15 @@ const BlockEditorEngine = ({
       : shouldCenterBlockHandleForNode(blockNode)
         ? resolveBlockHandleAnchorTop(blockElement, railHeight)
         : rect.top + 6
+    const railLayout = resolveBlockHandleRailLayout(rect, railWidth, railHeight, anchoredTop)
     const nextState: TopLevelBlockHandleState = {
       visible: true,
       kind: "top-level",
       blockIndex,
       listPath: [],
       itemIndex: null,
-      left: Math.max(12, rect.left - railWidth - 10),
-      top: anchoredTop,
+      left: railLayout.left,
+      top: railLayout.top,
       bottom: rect.bottom + 12,
       width: rect.width,
     }


### PR DESCRIPTION
## 관련 이슈

close #44

## 작업 배경

- 글 작성/수정 화면에서 좁은 writer 폭의 block handle rail이 본문 말머리를 덮지 않도록 배치 fallback을 추가했습니다.
- 빠른 block drag release 중 pointerup listener 등록 race로 남던 파란 drop indicator/drag ghost를 즉시 정리합니다.
- 작업 브랜치에서 `main` 대상 PR로 머지되면 기존 main CI/CD 경로를 통해 자동 배포됩니다.

## 작업 내용

- 왼쪽 gutter가 부족한 경우 block handle rail을 본문 첫 줄과 겹치지 않는 위쪽 위치로 쌓아 배치합니다.
- drag 시작 직후 release가 먼저 들어와도 block drag visual state를 정리하는 early pointer cleanup을 추가했습니다.
- 빠른 drag release와 좁은 writer 폭 handle overlap 회귀를 authoring E2E에 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "빠른 block drag release|writer surface 좁은 폭" --workers=1` (RED 확인 후 GREEN)
  - `yarn --cwd front test:e2e:authoring` (70 passed)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (15 passed, 2회)
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (16 passed, 2회)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke` (39 passed)
  - 반복 authoring 검증 중 기존 `writer surface의 리스트 항목 안 Tab/Shift+Tab도 단계 승강으로 동작한다` 1회 실패가 있었고, 단일 재실행 및 최종 전체 authoring 재실행에서 통과해 입력 타이밍 flake로 분류했습니다.
  - PR 원격 체크: backend-ci, frontend-ci, Vercel 모두 pass. frontend-ci는 기존 `writer surface의 리스트 항목 handle은 row gutter hover에서도 항목을 따라간다` 테스트 1건이 retry에서 flaky로 표시됐으나 최종 job 결론은 pass입니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 좁은 폭에서 block handle rail이 본문 위쪽으로 배치되어 기존 hover 위치와 달라질 수 있습니다.
- 롤백 방법: 이 PR의 `BlockEditorEngine.tsx` drag cleanup/handle layout 변경과 authoring 회귀 테스트 추가 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
