### PR TITLE
[CI] main 배포 판정과 live 검증 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
   group: homeserver-deploy-main
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -34,15 +34,17 @@ jobs:
       image_ref: ${{ steps.meta.outputs.image_ref }}
       image_latest_ref: ${{ steps.meta.outputs.image_latest_ref }}
       deploy_sha: ${{ steps.meta.outputs.deploy_sha }}
-      should_deploy: ${{ steps.meta.outputs.should_deploy }}
+      backend_deploy: ${{ steps.meta.outputs.backend_deploy }}
+      front_live_verify: ${{ steps.meta.outputs.front_live_verify }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
 
-      - name: Calculate image tags
+      - name: Calculate deploy targets and image tags
         id: meta
         env:
           DEPLOY_SHA_INPUT: ${{ github.event.workflow_run.head_sha }}
@@ -63,33 +65,56 @@ jobs:
           IMAGE_TAG="sha-${SHORT_SHA}"
           IMAGE_REF="${IMAGE_NAME}:${IMAGE_TAG}"
           IMAGE_LATEST_REF="${IMAGE_NAME}:latest"
-          SHOULD_DEPLOY="true"
-          CHANGE_SOURCE="head-commit"
-          REQUIRED_PATHS_PATTERN='^(back/|deploy/homeserver/|\.github/workflows/deploy\.yml|\.github/workflows/ci\.yml|\.github/workflows/reusable-backend-quality\.yml)'
+          BACKEND_DEPLOY="false"
+          FRONT_LIVE_VERIFY="false"
+          CHANGE_SOURCE="first-parent-diff"
+          BACKEND_DEPLOY_PATHS_PATTERN='^(back/|deploy/homeserver/|\.github/workflows/deploy\.yml|\.github/workflows/ci\.yml|\.github/workflows/reusable-backend-quality\.yml)'
+          FRONT_LIVE_VERIFY_PATHS_PATTERN='^(front/|\.github/workflows/deploy\.yml|\.github/workflows/ci\.yml|\.github/workflows/frontend-ci\.yml|\.github/workflows/reusable-frontend-verify\.yml)'
           CHANGED_FILES=""
-          CHANGED_FILES="$(git diff-tree --no-commit-id --name-only -r "${DEPLOY_SHA}" || true)"
-          if [ -n "${CHANGED_FILES}" ] && ! echo "${CHANGED_FILES}" | grep -Eq "${REQUIRED_PATHS_PATTERN}"; then
-            SHOULD_DEPLOY="false"
-            CHANGE_SOURCE="skip:no-backend-deploy-path-change"
+          CHANGED_FILES="$(git diff --name-only "${DEPLOY_SHA}^1" "${DEPLOY_SHA}" 2>/dev/null || true)"
+          if [ -z "${CHANGED_FILES}" ]; then
+            CHANGE_SOURCE="merge-diff-tree"
+            CHANGED_FILES="$(git diff-tree --no-commit-id --name-only -r -m "${DEPLOY_SHA}" || true)"
+          fi
+          if [ -z "${CHANGED_FILES}" ]; then
+            BACKEND_DEPLOY="true"
+            FRONT_LIVE_VERIFY="true"
+            CHANGE_SOURCE="fail-open:no-changed-files"
+          else
+            if echo "${CHANGED_FILES}" | grep -Eq "${BACKEND_DEPLOY_PATHS_PATTERN}"; then
+              BACKEND_DEPLOY="true"
+              FRONT_LIVE_VERIFY="true"
+            fi
+            if echo "${CHANGED_FILES}" | grep -Eq "${FRONT_LIVE_VERIFY_PATHS_PATTERN}"; then
+              FRONT_LIVE_VERIFY="true"
+            fi
           fi
 
-          echo "should_deploy_source=${CHANGE_SOURCE}"
+          echo "deploy_target_source=${CHANGE_SOURCE}"
 
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           echo "image_ref=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
           echo "image_latest_ref=${IMAGE_LATEST_REF}" >> "$GITHUB_OUTPUT"
           echo "deploy_sha=${DEPLOY_SHA}" >> "$GITHUB_OUTPUT"
-          echo "should_deploy=${SHOULD_DEPLOY}" >> "$GITHUB_OUTPUT"
+          echo "backend_deploy=${BACKEND_DEPLOY}" >> "$GITHUB_OUTPUT"
+          echo "front_live_verify=${FRONT_LIVE_VERIFY}" >> "$GITHUB_OUTPUT"
 
           {
             echo "## Deploy Boundary"
             echo "- backend deploy: homeserver blue/green"
             echo "- frontend runtime: Vercel (external platform)"
             echo "- frontend step: \`frontLiveE2E\` verifies the current live URL after main deploy"
-            if [ "${SHOULD_DEPLOY}" = "true" ]; then
-              echo "- result: backend deploy pipeline continues"
+            echo "- backend_deploy: ${BACKEND_DEPLOY}"
+            echo "- front_live_verify: ${FRONT_LIVE_VERIFY}"
+            if [ "${BACKEND_DEPLOY}" = "true" ]; then
+              echo "- backend result: backend deploy pipeline continues"
             else
-              echo "- result: homeserver deploy skipped because backend/deploy paths did not change"
+              echo "- backend result: homeserver deploy skipped because backend/deploy paths did not change"
+            fi
+            if [ "${FRONT_LIVE_VERIFY}" = "true" ]; then
+              echo "- frontend result: live frontend verification will run"
+            else
+              echo "- frontend result: live frontend verification skipped because frontend/backend deploy paths did not change"
             fi
             echo "- decision source: ${CHANGE_SOURCE}"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -97,7 +122,7 @@ jobs:
   buildAndPush:
     runs-on: ubuntu-latest
     needs: calculateTag
-    if: needs.calculateTag.outputs.should_deploy == 'true'
+    if: needs.calculateTag.outputs.backend_deploy == 'true'
     timeout-minutes: 30
     permissions:
       contents: read
@@ -137,7 +162,7 @@ jobs:
       - calculateTag
       - buildAndPush
     if: >
-      needs.calculateTag.outputs.should_deploy == 'true' &&
+      needs.calculateTag.outputs.backend_deploy == 'true' &&
       needs.buildAndPush.result == 'success'
     timeout-minutes: 30
     permissions:
@@ -778,7 +803,14 @@ jobs:
     needs:
       - calculateTag
       - blueGreenDeploy
-    if: needs.calculateTag.outputs.should_deploy == 'true'
+    if: >
+      always() &&
+      needs.calculateTag.result == 'success' &&
+      needs.calculateTag.outputs.front_live_verify == 'true' &&
+      (
+        needs.calculateTag.outputs.backend_deploy != 'true' ||
+        needs.blueGreenDeploy.result == 'success'
+      )
     timeout-minutes: 20
     permissions:
       contents: read

--- a/tools/test/verify-deploy-workflow-classification.sh
+++ b/tools/test/verify-deploy-workflow-classification.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/deploy.yml"
+
+if [[ ! -f "${workflow}" ]]; then
+  echo "missing workflow: ${workflow}" >&2
+  exit 1
+fi
+
+require_pattern() {
+  local pattern="$1"
+  local message="$2"
+
+  if ! grep -Eq "${pattern}" "${workflow}"; then
+    echo "missing: ${message}" >&2
+    exit 1
+  fi
+}
+
+reject_pattern() {
+  local pattern="$1"
+  local message="$2"
+
+  if grep -Eq "${pattern}" "${workflow}"; then
+    echo "unexpected: ${message}" >&2
+    exit 1
+  fi
+}
+
+require_pattern 'cancel-in-progress:[[:space:]]*false' "homeserver deploy concurrency must serialize instead of cancelling in-progress deploys"
+reject_pattern 'cancel-in-progress:[[:space:]]*true' "homeserver deploy must not cancel an in-progress stateful deploy"
+
+require_pattern 'backend_deploy:' "workflow must expose a backend_deploy output"
+require_pattern 'front_live_verify:' "workflow must expose a front_live_verify output"
+require_pattern 'git diff-tree --no-commit-id --name-only -r -m "\$\{DEPLOY_SHA\}"' "merge commit changed-file detection must use -m fallback"
+reject_pattern 'git diff-tree --no-commit-id --name-only -r "\$\{DEPLOY_SHA\}"' "single-parent diff-tree form can return empty changed files for merge commits"
+
+require_pattern 'needs\.calculateTag\.outputs\.backend_deploy' "backend jobs must be gated by backend_deploy"
+require_pattern 'needs\.calculateTag\.outputs\.front_live_verify' "frontend live verification must be gated by front_live_verify"
+require_pattern 'always\(\)[[:space:]]*&&' "frontLiveE2E must handle skipped backend deploy dependencies explicitly"


### PR DESCRIPTION
## 관련 이슈

close #96

## 작업 배경

- main merge commit의 변경 파일을 first-parent diff와 merge diff-tree fallback으로 계산하도록 고쳤습니다.
- 백엔드 홈서버 배포와 프론트 live E2E 검증 조건을 `backend_deploy` / `front_live_verify`로 분리했습니다.
- 홈서버 배포 concurrency는 중간 취소 대신 직렬 실행되도록 변경했습니다.

## 작업 내용

- `Deploy to Home Server` workflow가 backend/deploy 변경과 frontend 변경을 별도로 판정합니다.
- front-only main merge는 백엔드 배포 없이 `frontLiveE2E`만 실행할 수 있습니다.
- backend/deploy 변경은 기존처럼 이미지 빌드, blue/green 배포, live E2E 순서로 진행됩니다.
- workflow classification smoke script를 추가해 회귀를 잡습니다.

## 검증

- 실행한 명령과 결과:
  - `bash tools/test/verify-deploy-workflow-classification.sh` (2회 연속 통과)
  - `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts f }'`
  - `git diff --check HEAD~1..HEAD`
  - `rg -n "backend_deploy|front_live_verify|cancel-in-progress: false|git diff-tree --no-commit-id --name-only -r -m|Frontend Live E2E Verification" .github/workflows/deploy.yml tools/test/verify-deploy-workflow-classification.sh docs/agent/main-deploy-classification-plan-2026-05-07.md`
  - front-only merge commit 샘플 `536c0c9312a5c1e608e57558746e4c4a9558dce8` 분류 확인: `backend_deploy=false`, `front_live_verify=true`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: deploy workflow 조건식 변경으로 특정 path 조합에서 배포/검증 job이 의도와 다르게 skip될 수 있습니다.
- 롤백 방법: 이 PR의 commit을 revert하면 기존 `should_deploy` 기반 단일 조건으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
