### PR TITLE
[Fix] 글 작성/수정 selection affordance 재발 제거

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -129,6 +129,7 @@ const getTableAffordances = (page: Page) => ({
 })
 
 type ListItemHandleMetrics = {
+  itemLeft: number
   itemCenterY: number
   handleCenterY: number
   handleBox: { x: number; y: number; width: number; height: number }
@@ -185,6 +186,7 @@ const readListItemHandleMetrics = async (
       const textBlock = targetItem.querySelector("p") as HTMLElement | null
 
       return {
+        itemLeft: itemRect.left,
         itemCenterY: itemRect.top + itemRect.height / 2,
         handleCenterY: handleRect.top + handleRect.height / 2,
         handleBox: {
@@ -1262,10 +1264,10 @@ test.describe("block editor authoring flow", () => {
     const selectedMetrics = await expectListItemHandleReady(page, "Retry", "목록 항목 이동")
     const selectedHandleBox = selectedMetrics.handleBox
 
-    expect(selectedMetrics.boxShadow?.includes("inset")).toBeFalsy()
+    expect(selectedMetrics.boxShadow).toBe("none")
     expect(selectedMetrics.textLeft).not.toBeNull()
-    expect(selectedHandleBox.x + selectedHandleBox.width + 2).toBeLessThanOrEqual(
-      selectedMetrics.textLeft ?? 0
+    expect(selectedHandleBox.x + selectedHandleBox.width + 6).toBeLessThanOrEqual(
+      selectedMetrics.itemLeft
     )
   })
 
@@ -1518,7 +1520,15 @@ test.describe("block editor authoring flow", () => {
     if (!textBlockRect) {
       throw new Error("텍스트 블록 좌표를 계산할 수 없습니다.")
     }
-    await textBlock.dblclick({ position: { x: 4, y: Math.max(4, textBlockRect.height / 2) } })
+    await textBlock.dispatchEvent("mousedown", {
+      button: 0,
+      buttons: 1,
+      clientX: textBlockRect.x - 12,
+      clientY: textBlockRect.y + textBlockRect.height / 2,
+      detail: 2,
+      bubbles: true,
+      cancelable: true,
+    })
     await expect(selectionOverlay).toBeVisible()
     await expect
       .poll(() => textBlock.evaluate((element) => window.getComputedStyle(element).boxShadow))
@@ -1751,6 +1761,47 @@ test.describe("block editor authoring flow", () => {
       railBox.y + railBox.height > paragraphBox.y
 
     expect(overlapsParagraph).toBe(false)
+  })
+
+  test("writer surface의 본문 첫 글자 더블클릭은 글블록 전체 선택으로 승격되지 않는다", async ({
+    page,
+  }) => {
+    await page.goto(QA_WRITER_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expect(editor).toBeVisible()
+    await editor.locator("p").first().click()
+    await page.keyboard.type("전체 선택 테두리 방지")
+
+    const paragraph = editor.locator("p", { hasText: "전체 선택 테두리 방지" }).first()
+    await expect(paragraph).toBeVisible()
+    const paragraphBox = await paragraph.boundingBox()
+    if (!paragraphBox) {
+      throw new Error("본문 첫 글자 더블클릭 좌표를 계산할 수 없습니다.")
+    }
+
+    await paragraph.dispatchEvent("mousedown", {
+      button: 0,
+      buttons: 1,
+      clientX: paragraphBox.x + 2,
+      clientY: paragraphBox.y + paragraphBox.height / 2,
+      detail: 2,
+      bubbles: true,
+      cancelable: true,
+    })
+
+    await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
+    await expect
+      .poll(() =>
+        paragraph.evaluate((element) => ({
+          selected: element.getAttribute("data-block-selected"),
+          boxShadow: window.getComputedStyle(element).boxShadow,
+        }))
+      )
+      .toMatchObject({
+        selected: null,
+        boxShadow: "none",
+      })
   })
 
   test("table hover에서도 block selection affordance를 다시 띄우고 table block selection으로 전환할 수 있다", async ({ page }) => {

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -947,7 +947,7 @@ const BLOCK_HANDLE_VIEWPORT_PADDING_PX = 12
 const BLOCK_HANDLE_GUTTER_GAP_PX = 10
 const BLOCK_HANDLE_STACKED_GAP_PX = 8
 const BLOCK_OUTER_SELECT_LEFT_GUTTER_PX = 76
-const BLOCK_OUTER_SELECT_LEFT_EDGE_INNER_PX = 6
+const BLOCK_OUTER_SELECT_LEFT_EDGE_GAP_PX = 2
 const BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX = 10
 const TABLE_ROW_RESIZE_EDGE_PX = 6
 const TABLE_COLUMN_RESIZE_GUARD_PX = 12
@@ -3496,7 +3496,7 @@ const BlockEditorEngine = ({
 
       return (
         event.clientX >= rect.left - BLOCK_OUTER_SELECT_LEFT_GUTTER_PX &&
-        event.clientX <= rect.left + BLOCK_OUTER_SELECT_LEFT_EDGE_INNER_PX
+        event.clientX <= rect.left - BLOCK_OUTER_SELECT_LEFT_EDGE_GAP_PX
       )
     },
     [getTopLevelBlockElementByIndex]
@@ -3531,7 +3531,7 @@ const BlockEditorEngine = ({
 
       return (
         event.clientX >= rect.left - BLOCK_OUTER_SELECT_LEFT_GUTTER_PX &&
-        event.clientX <= rect.left + BLOCK_OUTER_SELECT_LEFT_EDGE_INNER_PX
+        event.clientX <= rect.left - BLOCK_OUTER_SELECT_LEFT_EDGE_GAP_PX
       )
     },
     []


### PR DESCRIPTION
## 관련 이슈

close #44

## 작업 배경

- 글 작성/수정 writer surface에서 본문 첫 글자 또는 말머리 근처 더블클릭이 글블록 전체 선택으로 승격되는 회귀를 수정합니다.
- outer selection hit zone을 본문 내부에서 gutter 바깥으로 되돌리고, list item affordance가 bullet marker 바깥에 유지되는 회귀 테스트를 강화했습니다.

## 작업 내용

- outer block/list item selection x-boundary를 `rect.left - 2px` 바깥으로 제한해 본문 첫 글자와 bullet marker 영역을 selection gutter에서 제외했습니다.
- 기존 외곽 선택 테스트를 실제 gutter 좌표 기준으로 정렬했습니다.
- writer surface 본문 첫 글자 `detail=2` mousedown이 block selection overlay를 만들지 않는 회귀 테스트를 추가했습니다.
- selected list item handle 검증을 텍스트 시작점이 아니라 bullet marker 바깥 기준으로 강화했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight` → pass
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "writer surface의 본문 첫 글자 더블클릭" --workers=1` → RED: overlay 1개 재현
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "블록 내부 클릭/텍스트 더블클릭|writer surface의 본문 첫 글자 더블클릭|writer surface의 선택된 리스트 항목 affordance" --workers=1` → pass
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` → pass, 71 passed; 동일 조건 재실행 pass, 71 passed; 최종 테스트 안정화 후 재실행 pass, 71 passed
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` → pass, 15 passed; 동일 조건 재실행 pass, 15 passed
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` → pass, 16 passed; 동일 조건 재실행 pass, 16 passed

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: gutter 더블클릭 선택 가능 영역이 본문 경계 안쪽 6px에서 바깥쪽 2px으로 줄어들어, 아주 가까운 경계 클릭의 block selection 민감도가 낮아집니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 기존 hit zone과 테스트 계약으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
