### PR TITLE
[Refactor] BlockEditor table affordance 모델 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -238,6 +238,10 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tsx"),
       "utf8"
     )
+    const tableAffordanceModelSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/tableAffordanceModel.ts"),
+      "utf8"
+    )
     const editorStudioSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/EditorStudioPage.tsx"),
       "utf8"
@@ -263,7 +267,9 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).toContain("const tableOverlayPortal =")
     expect(blockEditorEngineSource).toContain("createPortal(tableOverlay, document.body)")
     expect(blockEditorEngineSource).toContain("const TABLE_EDGE_HANDLE_INSET_PX = 6")
-    expect(blockEditorEngineSource).toContain("const TABLE_EDGE_ADD_BUTTON_SIZE_PX = 24")
+    expect(tableAffordanceModelSource).toContain("export const TABLE_EDGE_ADD_BUTTON_SIZE_PX = 24")
+    expect(tableAffordanceModelSource).toContain("export const TABLE_CELL_MENU_BUTTON_SIZE_PX = 22")
+    expect(tableAffordanceModelSource).toContain("export const TABLE_ADD_BAR_VIEWPORT_PADDING_PX = 8")
     expect(blockEditorEngineSource).toContain('data-testid="table-corner-grow-handle"')
     expect(blockEditorEngineSource).toContain('data-testid="table-corner-preview-outline"')
     expect(blockEditorEngineSource).toContain('data-testid="table-structure-menu-button"')
@@ -310,10 +316,16 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).toContain("넓은 표")
     expect(blockEditorEngineSource).toContain("제목 행")
     expect(blockEditorEngineSource).toContain("제목 열")
-    expect(blockEditorEngineSource).toContain("type TableAffordanceGeometry = {")
-    expect(blockEditorEngineSource).toContain("type TableAffordanceVisibility = {")
-    expect(blockEditorEngineSource).toContain("const INITIAL_TABLE_AFFORDANCE_GEOMETRY: TableAffordanceGeometry = {")
-    expect(blockEditorEngineSource).toContain("const INITIAL_TABLE_AFFORDANCE_VISIBILITY: TableAffordanceVisibility = {")
+    expect(tableAffordanceModelSource).toContain("export type TableAffordanceGeometry = {")
+    expect(tableAffordanceModelSource).toContain("export type TableAffordanceVisibility = {")
+    expect(tableAffordanceModelSource).toContain("export const INITIAL_TABLE_AFFORDANCE_GEOMETRY: TableAffordanceGeometry = {")
+    expect(tableAffordanceModelSource).toContain("export const INITIAL_TABLE_AFFORDANCE_VISIBILITY: TableAffordanceVisibility = {")
+    expect(tableAffordanceModelSource).toContain("export const resolveDesktopTableRailLayout = (")
+    expect(blockEditorEngineSource).toContain('} from "./tableAffordanceModel"')
+    expect(blockEditorEngineSource).not.toContain("type TableAffordanceGeometry = {")
+    expect(blockEditorEngineSource).not.toContain("type TableAffordanceVisibility = {")
+    expect(blockEditorEngineSource).not.toContain("const INITIAL_TABLE_AFFORDANCE_GEOMETRY: TableAffordanceGeometry = {")
+    expect(blockEditorEngineSource).not.toContain("const INITIAL_TABLE_AFFORDANCE_VISIBILITY: TableAffordanceVisibility = {")
     expect(blockEditorEngineSource).toContain("const [tableAffordanceGeometry, setTableAffordanceGeometry] = useState<TableAffordanceGeometry>(")
     expect(blockEditorEngineSource).toContain(
       "const [tableAffordanceVisibility, setTableAffordanceVisibility] = useState<TableAffordanceVisibility>("

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -88,6 +88,18 @@ import {
   createWriterEditorExtensions,
   TABLE_CONTEXT_BLOCKED_INSERT_IDS,
 } from "./writerEditorPreset"
+import {
+  type TableAffordanceGeometry,
+  type TableAffordanceVisibility,
+  INITIAL_TABLE_AFFORDANCE_GEOMETRY,
+  INITIAL_TABLE_AFFORDANCE_VISIBILITY,
+  TABLE_ADD_BAR_VIEWPORT_PADDING_PX,
+  TABLE_CELL_MENU_BUTTON_SIZE_PX,
+  TABLE_EDGE_ADD_BUTTON_SIZE_PX,
+  clampViewportPosition,
+  intersectsViewportBounds,
+  resolveDesktopTableRailLayout,
+} from "./tableAffordanceModel"
 
 type RuntimeGuardWindow = Window & {
   __AQ_RUNTIME_GUARD_ENABLED__?: boolean
@@ -255,56 +267,6 @@ type FloatingBubbleState = {
   top: number
 }
 
-type TableOverlayAnchor = {
-  left: number
-  top: number
-}
-
-type TableAffordanceGeometry = {
-  left: number
-  top: number
-  tableLeft: number
-  tableTop: number
-  tableRight: number
-  tableBottom: number
-  width: number
-  height: number
-  surfaceLeft: number
-  surfaceTop: number
-  surfaceWidth: number
-  surfaceHeight: number
-  cellLeft: number
-  cellTop: number
-  cellWidth: number
-  cellHeight: number
-  rowIndex: number
-  rowTop: number
-  rowHeight: number
-  columnLeft: number
-  columnWidth: number
-  columnIndex: number
-  rowHandleAnchor: TableOverlayAnchor
-  columnHandleAnchor: TableOverlayAnchor
-  rowAddAnchor: TableOverlayAnchor
-  columnAddAnchor: TableOverlayAnchor
-  cornerAnchor: TableOverlayAnchor
-  cellMenuAnchor: TableOverlayAnchor
-  columnSegments: Array<{
-    left: number
-    width: number
-  }>
-}
-
-type TableAffordanceVisibility = {
-  visible: boolean
-  showColumnRail: boolean
-  showRowRail: boolean
-  showColumnAddBar: boolean
-  showRowAddBar: boolean
-  showCornerControls: boolean
-  showCellMenu: boolean
-}
-
 type TableMenuKind = "row" | "column" | "table" | "cell"
 
 type TableMenuState =
@@ -465,48 +427,6 @@ type TableAxisReorderIndicatorState = {
   top: number
   width: number
   height: number
-}
-
-const INITIAL_TABLE_AFFORDANCE_GEOMETRY: TableAffordanceGeometry = {
-  left: 0,
-  top: 0,
-  tableLeft: 0,
-  tableTop: 0,
-  tableRight: 0,
-  tableBottom: 0,
-  width: 0,
-  height: 0,
-  surfaceLeft: 0,
-  surfaceTop: 0,
-  surfaceWidth: 0,
-  surfaceHeight: 0,
-  cellLeft: 0,
-  cellTop: 0,
-  cellWidth: 0,
-  cellHeight: 0,
-  rowIndex: 0,
-  rowTop: 0,
-  rowHeight: 0,
-  columnLeft: 0,
-  columnWidth: 0,
-  columnIndex: 0,
-  rowHandleAnchor: { left: 0, top: 0 },
-  columnHandleAnchor: { left: 0, top: 0 },
-  rowAddAnchor: { left: 0, top: 0 },
-  columnAddAnchor: { left: 0, top: 0 },
-  cornerAnchor: { left: 0, top: 0 },
-  cellMenuAnchor: { left: 0, top: 0 },
-  columnSegments: [],
-}
-
-const INITIAL_TABLE_AFFORDANCE_VISIBILITY: TableAffordanceVisibility = {
-  visible: false,
-  showColumnRail: false,
-  showRowRail: false,
-  showColumnAddBar: false,
-  showRowAddBar: false,
-  showCornerControls: false,
-  showCellMenu: false,
 }
 
 type BlockSelectionPointerEventLike = {
@@ -965,7 +885,6 @@ const TABLE_ROW_GRIP_BUTTON_WIDTH_PX = 16
 const TABLE_ROW_GRIP_BUTTON_HEIGHT_PX = 26
 const TABLE_AXIS_GRIP_EDGE_INSET_PX = 0
 const TABLE_ADD_BAR_THICKNESS_PX = 28
-const TABLE_ADD_BAR_VIEWPORT_PADDING_PX = 8
 const TABLE_AXIS_RAIL_EDGE_HOTZONE_PX = 18
 const TABLE_TRAILING_ADD_EDGE_HOTZONE_PX = 18
 const TABLE_OVERFLOW_COACHMARK_ESTIMATED_WIDTH_PX = 244
@@ -1134,11 +1053,9 @@ const countShrinkableRenderedTableAxisAtEnd = (tableElement: HTMLTableElement | 
   return shrinkableColumns
 }
 const TABLE_EDGE_HANDLE_INSET_PX = 6
-const TABLE_EDGE_ADD_BUTTON_SIZE_PX = 24
 const TABLE_CORNER_CLUSTER_GAP_PX = 6
 const TABLE_CORNER_CLUSTER_WIDTH_PX =
   TABLE_CORNER_BUTTON_SIZE_PX * 2 + TABLE_CORNER_CLUSTER_GAP_PX
-const TABLE_CELL_MENU_BUTTON_SIZE_PX = 22
 const TABLE_QUICK_RAIL_HIDE_DELAY_MS = 120
 const TABLE_MENU_EDGE_PADDING_PX = 16
 const TABLE_MENU_ESTIMATED_WIDTH_PX = 272
@@ -1162,95 +1079,6 @@ const TABLE_CELL_COLOR_PRESETS = [
   { label: "라일락", value: "#ddd6fe" },
   { label: "회색", value: "#e2e8f0" },
 ] as const
-
-const clampViewportPosition = (
-  value: number,
-  edgePadding: number,
-  viewportSize: number,
-  itemSize: number
-) => {
-  const max = Math.max(edgePadding, viewportSize - itemSize - edgePadding)
-  return Math.min(Math.max(value, edgePadding), max)
-}
-
-const intersectsViewportBounds = (
-  rect: DOMRect | null | undefined,
-  edgePadding = TABLE_ADD_BAR_VIEWPORT_PADDING_PX
-) => {
-  if (!rect) return false
-  if (typeof window === "undefined") return true
-  return (
-    rect.right >= edgePadding &&
-    rect.bottom >= edgePadding &&
-    rect.left <= window.innerWidth - edgePadding &&
-    rect.top <= window.innerHeight - edgePadding
-  )
-}
-
-const resolveDesktopTableRailLayout = (
-  state: TableAffordanceGeometry
-) => {
-  const columnGripTop = Math.round(state.columnHandleAnchor.top)
-  const cornerTop = Math.round(state.cornerAnchor.top)
-  const cornerLeft = Math.round(state.cornerAnchor.left)
-  const columnGripLeft = Math.round(state.columnHandleAnchor.left)
-  const columnAddBarLeft =
-    typeof window === "undefined"
-      ? Math.round(state.columnAddAnchor.left)
-      : clampViewportPosition(
-          Math.round(state.columnAddAnchor.left),
-          TABLE_ADD_BAR_VIEWPORT_PADDING_PX,
-          window.innerWidth,
-          TABLE_EDGE_ADD_BUTTON_SIZE_PX
-        )
-  const columnAddBarTop = Math.round(state.columnAddAnchor.top)
-  const rowGripTop = Math.round(state.rowHandleAnchor.top)
-  const rowGripLeft = Math.round(state.rowHandleAnchor.left)
-  const rowAddBarLeft = Math.round(state.rowAddAnchor.left)
-  const rowAddBarTop =
-    typeof window === "undefined"
-      ? Math.round(state.rowAddAnchor.top)
-      : clampViewportPosition(
-          Math.round(state.rowAddAnchor.top),
-          TABLE_ADD_BAR_VIEWPORT_PADDING_PX,
-          window.innerHeight,
-          TABLE_EDGE_ADD_BUTTON_SIZE_PX
-        )
-
-  const cellMenuLeft =
-    typeof window === "undefined"
-      ? Math.round(state.cellMenuAnchor.left)
-      : clampViewportPosition(
-          Math.round(state.cellMenuAnchor.left),
-          TABLE_ADD_BAR_VIEWPORT_PADDING_PX,
-          window.innerWidth,
-          TABLE_CELL_MENU_BUTTON_SIZE_PX
-        )
-  const cellMenuTop =
-    typeof window === "undefined"
-      ? Math.round(state.cellMenuAnchor.top)
-      : clampViewportPosition(
-          Math.round(state.cellMenuAnchor.top),
-          TABLE_ADD_BAR_VIEWPORT_PADDING_PX,
-          window.innerHeight,
-          TABLE_CELL_MENU_BUTTON_SIZE_PX
-        )
-
-  return {
-    cornerLeft,
-    cornerTop,
-    columnGripLeft,
-    columnGripTop,
-    columnAddBarLeft,
-    columnAddBarTop,
-    rowGripLeft,
-    rowGripTop,
-    rowAddBarLeft,
-    rowAddBarTop,
-    cellMenuLeft,
-    cellMenuTop,
-  }
-}
 
 const blockHasVisibleContent = (node?: BlockEditorDoc | null): boolean => {
   if (!node) return false

--- a/front/src/components/editor/tableAffordanceModel.ts
+++ b/front/src/components/editor/tableAffordanceModel.ts
@@ -1,0 +1,184 @@
+export const TABLE_ADD_BAR_VIEWPORT_PADDING_PX = 8
+export const TABLE_EDGE_ADD_BUTTON_SIZE_PX = 24
+export const TABLE_CELL_MENU_BUTTON_SIZE_PX = 22
+
+export type TableOverlayAnchor = {
+  left: number
+  top: number
+}
+
+export type TableAffordanceGeometry = {
+  left: number
+  top: number
+  tableLeft: number
+  tableTop: number
+  tableRight: number
+  tableBottom: number
+  width: number
+  height: number
+  surfaceLeft: number
+  surfaceTop: number
+  surfaceWidth: number
+  surfaceHeight: number
+  cellLeft: number
+  cellTop: number
+  cellWidth: number
+  cellHeight: number
+  rowIndex: number
+  rowTop: number
+  rowHeight: number
+  columnLeft: number
+  columnWidth: number
+  columnIndex: number
+  rowHandleAnchor: TableOverlayAnchor
+  columnHandleAnchor: TableOverlayAnchor
+  rowAddAnchor: TableOverlayAnchor
+  columnAddAnchor: TableOverlayAnchor
+  cornerAnchor: TableOverlayAnchor
+  cellMenuAnchor: TableOverlayAnchor
+  columnSegments: Array<{
+    left: number
+    width: number
+  }>
+}
+
+export type TableAffordanceVisibility = {
+  visible: boolean
+  showColumnRail: boolean
+  showRowRail: boolean
+  showColumnAddBar: boolean
+  showRowAddBar: boolean
+  showCornerControls: boolean
+  showCellMenu: boolean
+}
+
+export const INITIAL_TABLE_AFFORDANCE_GEOMETRY: TableAffordanceGeometry = {
+  left: 0,
+  top: 0,
+  tableLeft: 0,
+  tableTop: 0,
+  tableRight: 0,
+  tableBottom: 0,
+  width: 0,
+  height: 0,
+  surfaceLeft: 0,
+  surfaceTop: 0,
+  surfaceWidth: 0,
+  surfaceHeight: 0,
+  cellLeft: 0,
+  cellTop: 0,
+  cellWidth: 0,
+  cellHeight: 0,
+  rowIndex: 0,
+  rowTop: 0,
+  rowHeight: 0,
+  columnLeft: 0,
+  columnWidth: 0,
+  columnIndex: 0,
+  rowHandleAnchor: { left: 0, top: 0 },
+  columnHandleAnchor: { left: 0, top: 0 },
+  rowAddAnchor: { left: 0, top: 0 },
+  columnAddAnchor: { left: 0, top: 0 },
+  cornerAnchor: { left: 0, top: 0 },
+  cellMenuAnchor: { left: 0, top: 0 },
+  columnSegments: [],
+}
+
+export const INITIAL_TABLE_AFFORDANCE_VISIBILITY: TableAffordanceVisibility = {
+  visible: false,
+  showColumnRail: false,
+  showRowRail: false,
+  showColumnAddBar: false,
+  showRowAddBar: false,
+  showCornerControls: false,
+  showCellMenu: false,
+}
+
+export const clampViewportPosition = (
+  value: number,
+  edgePadding: number,
+  viewportSize: number,
+  itemSize: number
+) => {
+  const max = Math.max(edgePadding, viewportSize - itemSize - edgePadding)
+  return Math.min(Math.max(value, edgePadding), max)
+}
+
+export const intersectsViewportBounds = (
+  rect: DOMRect | null | undefined,
+  edgePadding = TABLE_ADD_BAR_VIEWPORT_PADDING_PX
+) => {
+  if (!rect) return false
+  if (typeof window === "undefined") return true
+  return (
+    rect.right >= edgePadding &&
+    rect.bottom >= edgePadding &&
+    rect.left <= window.innerWidth - edgePadding &&
+    rect.top <= window.innerHeight - edgePadding
+  )
+}
+
+export const resolveDesktopTableRailLayout = (
+  state: TableAffordanceGeometry
+) => {
+  const columnGripTop = Math.round(state.columnHandleAnchor.top)
+  const cornerTop = Math.round(state.cornerAnchor.top)
+  const cornerLeft = Math.round(state.cornerAnchor.left)
+  const columnGripLeft = Math.round(state.columnHandleAnchor.left)
+  const columnAddBarLeft =
+    typeof window === "undefined"
+      ? Math.round(state.columnAddAnchor.left)
+      : clampViewportPosition(
+          Math.round(state.columnAddAnchor.left),
+          TABLE_ADD_BAR_VIEWPORT_PADDING_PX,
+          window.innerWidth,
+          TABLE_EDGE_ADD_BUTTON_SIZE_PX
+        )
+  const columnAddBarTop = Math.round(state.columnAddAnchor.top)
+  const rowGripTop = Math.round(state.rowHandleAnchor.top)
+  const rowGripLeft = Math.round(state.rowHandleAnchor.left)
+  const rowAddBarLeft = Math.round(state.rowAddAnchor.left)
+  const rowAddBarTop =
+    typeof window === "undefined"
+      ? Math.round(state.rowAddAnchor.top)
+      : clampViewportPosition(
+          Math.round(state.rowAddAnchor.top),
+          TABLE_ADD_BAR_VIEWPORT_PADDING_PX,
+          window.innerHeight,
+          TABLE_EDGE_ADD_BUTTON_SIZE_PX
+        )
+
+  const cellMenuLeft =
+    typeof window === "undefined"
+      ? Math.round(state.cellMenuAnchor.left)
+      : clampViewportPosition(
+          Math.round(state.cellMenuAnchor.left),
+          TABLE_ADD_BAR_VIEWPORT_PADDING_PX,
+          window.innerWidth,
+          TABLE_CELL_MENU_BUTTON_SIZE_PX
+        )
+  const cellMenuTop =
+    typeof window === "undefined"
+      ? Math.round(state.cellMenuAnchor.top)
+      : clampViewportPosition(
+          Math.round(state.cellMenuAnchor.top),
+          TABLE_ADD_BAR_VIEWPORT_PADDING_PX,
+          window.innerHeight,
+          TABLE_CELL_MENU_BUTTON_SIZE_PX
+        )
+
+  return {
+    cornerLeft,
+    cornerTop,
+    columnGripLeft,
+    columnGripTop,
+    columnAddBarLeft,
+    columnAddBarTop,
+    rowGripLeft,
+    rowGripTop,
+    rowAddBarLeft,
+    rowAddBarTop,
+    cellMenuLeft,
+    cellMenuTop,
+  }
+}


### PR DESCRIPTION
## 관련 이슈

close #103

## 작업 배경

- `BlockEditorEngine.tsx`가 직접 소유하던 table affordance geometry/visibility 모델과 viewport layout helper를 별도 모듈로 분리했습니다.
- 동작 변경 없이 engine은 새 `tableAffordanceModel.ts`를 import하고, source-level 회귀 테스트가 이 경계를 검증하도록 갱신했습니다.

## 작업 내용

- `front/src/components/editor/tableAffordanceModel.ts`를 추가해 table affordance 타입, 초기값, clamp/layout helper, 관련 크기 상수를 소유하게 했습니다.
- `BlockEditorEngine.tsx`에서 해당 모델 정의를 제거하고 import로 전환했습니다.
- `editor-studio-state` source-level 테스트가 새 모델 파일과 engine import 경계를 검증하도록 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (RED: 새 모델 파일 부재로 실패 확인)
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front test:e2e:smoke`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: import 경계 변경이므로 table overlay helper import 누락 시 build에서 실패합니다. 검증에서 build와 table authoring 회귀를 함께 통과했습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 모델 분리와 테스트 갱신이 함께 원복됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
