### PR TITLE
[CI] reusable backend workflow 권한 보정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ permissions:
 
 jobs:
   backend-ci:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: ./.github/workflows/reusable-backend-quality.yml
     secrets:
       CI_DB_PASSWORD: ${{ secrets.CI_DB_PASSWORD }}


### PR DESCRIPTION
## 관련 이슈

close #105

## 작업 배경

- `ci.yml`의 reusable backend workflow 호출이 caller token 권한 부족으로 validation 단계에서 실패하는 문제를 보정했습니다.
- 기존 `backend-ci.yml` caller와 동일하게 `backend-ci` job에 필요한 `issues: write`, `pull-requests: write` 권한을 명시했습니다.

## 작업 내용

- `.github/workflows/ci.yml`의 `backend-ci` reusable workflow 호출 job에 `contents: read`, `issues: write`, `pull-requests: write` 권한을 추가했습니다.
- reusable workflow 본문은 변경하지 않고 caller 권한만 맞췄습니다.

## 검증

- 실행한 명령과 결과:
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml ok"'`\n- `git diff --check`\n- `CURRENT_TASK_SLUG=ci-reusable-backend-permissions bash tools/guards/current-task-preflight.sh`\n\n## 📸 Screenshot / API Example\n- N/A\n\n## ⚠️ Risk & Rollback\n- 예상 리스크: `ci.yml`의 backend reusable 호출 job만 토큰 권한이 상승합니다. 기존 `backend-ci.yml` caller와 동일한 권한으로 맞춘 변경입니다.\n- 롤백 방법: 이 PR의 단일 commit을 revert하면 `ci.yml` 권한 보정이 원복됩니다.\n\n## ☑️ Checklist\n- [x] 관련 이슈를 정확히 연결했는가?\n- [x] base branch가 `main`인지 다시 확인했는가?\n- [x] PR 범위 밖 변경을 제외했는가?\n- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?\n- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?\n- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 특이사항 없음

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
