### PR TITLE
[Refactor] BlockEditor table width 모델 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -242,6 +242,10 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/components/editor/tableAffordanceModel.ts"),
       "utf8"
     )
+    const tableWidthModelSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/tableWidthModel.ts"),
+      "utf8"
+    )
     const editorStudioSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/EditorStudioPage.tsx"),
       "utf8"
@@ -277,7 +281,18 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).toContain('data-testid="table-overflow-mode-normal"')
     expect(blockEditorEngineSource).toContain('data-testid="table-overflow-mode-wide"')
     expect(blockEditorEngineSource).toContain("const promoteLargeTablesToWideOverflowMode = (editor: TiptapEditor) => {")
-    expect(blockEditorEngineSource).toContain("shouldPromoteWideTableOverflowMode(columns.length, readableWidthBudget)")
+    expect(tableWidthModelSource).toContain('export const TABLE_OVERFLOW_MODE_WIDE = "wide"')
+    expect(tableWidthModelSource).toContain("export const getTableOverflowMode = (")
+    expect(tableWidthModelSource).toContain("export const shouldPromoteWideTableOverflowMode = (")
+    expect(tableWidthModelSource).toContain("export const promotePastedWideTables = (")
+    expect(tableWidthModelSource).toContain("export const computeNextTableColumnWidthsForResize = (")
+    expect(tableWidthModelSource).toContain("export const didTableColumnResizeHitOverflowPolicy = (")
+    expect(blockEditorEngineSource).toContain('} from "./tableWidthModel"')
+    expect(blockEditorEngineSource).not.toContain("const TABLE_OVERFLOW_MODE_WIDE =")
+    expect(blockEditorEngineSource).not.toContain("const getTableOverflowMode =")
+    expect(blockEditorEngineSource).not.toContain("const shouldPromoteWideTableOverflowMode =")
+    expect(blockEditorEngineSource).not.toContain("const computeNextTableColumnWidthsForResize = (")
+    expect(blockEditorEngineSource).not.toContain("const didTableColumnResizeHitOverflowPolicy = (")
     expect(blockEditorEngineSource).toContain('data-testid="table-row-drag-shadow"')
     expect(blockEditorEngineSource).toContain('"table-row-reorder-indicator"')
     expect(blockEditorEngineSource).toContain('"table-column-reorder-indicator"')
@@ -296,7 +311,7 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).toContain("const startPendingTableAxisDrag = useCallback(")
     expect(blockEditorEngineSource).toContain("const selectTableAxisAtIndex = useCallback(")
     expect(blockEditorEngineSource).toContain('overflowMode: getTableOverflowMode(tableNode)')
-    expect(blockEditorEngineSource).toContain("const maxActiveWidth = Math.max(TABLE_MIN_COLUMN_WIDTH_PX, safeBudget - otherColumnsWidth)")
+    expect(tableWidthModelSource).toContain("const maxActiveWidth = Math.max(TABLE_MIN_COLUMN_WIDTH_PX, safeBudget - otherColumnsWidth)")
     expect(blockEditorEngineSource).toContain("const tableCornerGrowSuppressClickRef = useRef(false)")
     expect(blockEditorEngineSource).toContain('"grip" | "grow"')
     expect(blockEditorEngineSource).toContain('const isCellMenuOpen = tableMenuKind === "cell"')

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -1,4 +1,4 @@
-import type { Editor as TiptapEditor, JSONContent } from "@tiptap/core"
+import type { Editor as TiptapEditor } from "@tiptap/core"
 import { keyframes } from "@emotion/react"
 import styled from "@emotion/styled"
 import AppIcon from "src/components/icons/AppIcon"
@@ -58,7 +58,6 @@ import {
   TABLE_MIN_COLUMN_WIDTH_PX,
   TABLE_MIN_ROW_HEIGHT_PX,
   TABLE_WIDE_COLUMN_MIN_WIDTH_PX,
-  TABLE_WIDE_PROMOTION_COLUMN_BUDGET_PX,
 } from "src/libs/markdown/tableMetadata"
 import {
   getTableChromePalette,
@@ -100,134 +99,27 @@ import {
   intersectsViewportBounds,
   resolveDesktopTableRailLayout,
 } from "./tableAffordanceModel"
+import {
+  TABLE_OVERFLOW_MODE_WIDE,
+  TABLE_WIDTH_BUDGET_META_KEY,
+  computeNextTableColumnWidthsForResize,
+  createBalancedTableColumnWidths,
+  didTableColumnResizeHitOverflowPolicy,
+  expandTableColumnWidthsToFit,
+  getPreferredNormalTableTotalWidth,
+  getTableOverflowMode,
+  isLegacyCollapsedTableWidthState,
+  isLegacyFullWidthInitializedTableState,
+  promotePastedWideTables,
+  shouldPromoteWideTableOverflowMode,
+  shrinkTableColumnWidthsToFit,
+} from "./tableWidthModel"
 
 type RuntimeGuardWindow = Window & {
   __AQ_RUNTIME_GUARD_ENABLED__?: boolean
   __AQ_RUNTIME_GUARD__?: {
     editorCommitSamples?: number[]
   }
-}
-
-const TABLE_OVERFLOW_MODE_WIDE = "wide"
-
-const getTableOverflowMode = (tableNode: { attrs?: Record<string, unknown> } | null | undefined) =>
-  tableNode?.attrs?.overflowMode === TABLE_OVERFLOW_MODE_WIDE ? TABLE_OVERFLOW_MODE_WIDE : "normal"
-
-const readSimpleTableColumnCount = (tableNode: JSONContent): number => {
-  const rows = Array.isArray(tableNode.content) ? tableNode.content : []
-  return rows.reduce((max, row) => {
-    const cells = Array.isArray(row.content)
-      ? row.content.filter((cell) => cell?.type === "tableCell" || cell?.type === "tableHeader")
-      : []
-    return Math.max(max, cells.length)
-  }, 0)
-}
-
-const shouldPromoteWideTableOverflowMode = (columnCount: number, readableWidthBudget: number) =>
-  columnCount > 0 && columnCount * TABLE_WIDE_PROMOTION_COLUMN_BUDGET_PX >= readableWidthBudget
-
-const getPreferredNormalTableTotalWidth = (columnCount: number, readableWidthBudget: number) => {
-  const minBudget = TABLE_MIN_COLUMN_WIDTH_PX * Math.max(1, columnCount)
-  const preferredBudget = Math.max(
-    minBudget,
-    Math.round(columnCount * TABLE_WIDE_PROMOTION_COLUMN_BUDGET_PX)
-  )
-  return Math.max(minBudget, Math.min(Math.round(readableWidthBudget), preferredBudget))
-}
-
-const createBalancedTableColumnWidths = (columnCount: number, totalWidth: number) => {
-  if (columnCount <= 0) return []
-
-  const safeTotalWidth = Math.max(TABLE_MIN_COLUMN_WIDTH_PX * columnCount, Math.round(totalWidth))
-  const baseColumnWidth = Math.max(
-    TABLE_MIN_COLUMN_WIDTH_PX,
-    Math.floor(safeTotalWidth / columnCount)
-  )
-  const lastColumnWidth = safeTotalWidth - baseColumnWidth * (columnCount - 1)
-
-  return Array.from({ length: columnCount }, (_, columnIndex) =>
-    columnIndex === columnCount - 1
-      ? Math.max(TABLE_MIN_COLUMN_WIDTH_PX, lastColumnWidth)
-      : baseColumnWidth
-  )
-}
-
-const promoteTableBlockToWideOverflowMode = (
-  tableNode: JSONContent,
-  readableWidthBudget: number
-): JSONContent => {
-  if (tableNode.type !== "table") return tableNode
-  if (getTableOverflowMode(tableNode) === TABLE_OVERFLOW_MODE_WIDE) return tableNode
-
-  const rows = Array.isArray(tableNode.content) ? tableNode.content : []
-  const columnCount = readSimpleTableColumnCount(tableNode)
-  if (!shouldPromoteWideTableOverflowMode(columnCount, readableWidthBudget)) return tableNode
-
-  const nextColumnWidths = Array.from({ length: columnCount }, (_, columnIndex) => {
-    let nextWidth = TABLE_WIDE_COLUMN_MIN_WIDTH_PX
-    rows.forEach((row) => {
-      const cell = Array.isArray(row.content) ? row.content[columnIndex] : null
-      const widthValue = Array.isArray(cell?.attrs?.colwidth) ? cell?.attrs?.colwidth[0] : null
-      if (typeof widthValue === "number" && Number.isFinite(widthValue) && widthValue > 0) {
-        nextWidth = Math.max(nextWidth, Math.round(widthValue))
-      }
-    })
-    return nextWidth
-  })
-
-  let changed = false
-  const nextRows = rows.map((row) => {
-    if (!Array.isArray(row.content)) return row
-
-    let rowChanged = false
-    const nextCells = row.content.map((cell, columnIndex) => {
-      if (cell?.type !== "tableCell" && cell?.type !== "tableHeader") return cell
-
-      const nextWidth = nextColumnWidths[columnIndex]
-      const currentWidth = Array.isArray(cell.attrs?.colwidth) ? cell.attrs?.colwidth[0] : null
-      if (currentWidth === nextWidth) return cell
-
-      rowChanged = true
-      changed = true
-      return {
-        ...cell,
-        attrs: {
-          ...(cell.attrs || {}),
-          colwidth: [nextWidth],
-        },
-      }
-    })
-
-    return rowChanged ? { ...row, content: nextCells } : row
-  })
-
-  return {
-    ...tableNode,
-    attrs: {
-      ...(tableNode.attrs || {}),
-      overflowMode: TABLE_OVERFLOW_MODE_WIDE,
-    },
-    ...(changed ? { content: nextRows } : {}),
-  }
-}
-
-const promotePastedWideTables = (
-  doc: BlockEditorDoc,
-  readableWidthBudget: number
-): BlockEditorDoc => {
-  if (!Array.isArray(doc.content) || doc.content.length === 0) return doc
-
-  let changed = false
-  const nextContent = doc.content.map((block) => {
-    if (!block || block.type !== "table") return block
-    const nextBlock = promoteTableBlockToWideOverflowMode(block, readableWidthBudget)
-    if (nextBlock !== block) {
-      changed = true
-    }
-    return nextBlock
-  })
-
-  return changed ? { ...doc, content: nextContent } : doc
 }
 
 type SlashKeyboardEventLike = {
@@ -1060,7 +952,6 @@ const TABLE_QUICK_RAIL_HIDE_DELAY_MS = 120
 const TABLE_MENU_EDGE_PADDING_PX = 16
 const TABLE_MENU_ESTIMATED_WIDTH_PX = 272
 const TABLE_MENU_ESTIMATED_HEIGHT_PX = 420
-const TABLE_WIDTH_BUDGET_META_KEY = "aq-table-width-budget-normalized"
 const SLASH_MENU_RECENT_IDS_STORAGE_KEY = "editor:block-slash-recent:v1"
 const SLASH_MENU_MAX_RECENT_ITEMS = 6
 const SLASH_MENU_EDGE_PADDING_PX = 16
@@ -1667,126 +1558,6 @@ const readRenderedColumnWidths = (tableElement: HTMLElement | null) => {
   return Array.from(
     tableElement.querySelectorAll<HTMLElement>("thead tr:first-of-type > th, thead tr:first-of-type > td, tbody tr:first-of-type > th, tbody tr:first-of-type > td, tr:first-of-type > th, tr:first-of-type > td")
   ).map((cell) => Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(cell.getBoundingClientRect().width)))
-}
-
-const shrinkTableColumnWidthsToFit = (widths: number[], budget: number) => {
-  const nextWidths = widths.map((width) => Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(width)))
-  let overflow = nextWidths.reduce((sum, width) => sum + width, 0) - budget
-
-  while (overflow > 0) {
-    const shrinkableColumns = nextWidths
-      .map((width, index) => ({ index, capacity: width - TABLE_MIN_COLUMN_WIDTH_PX, width }))
-      .filter((column) => column.capacity > 0)
-      .sort((left, right) => right.width - left.width)
-
-    if (shrinkableColumns.length === 0) break
-
-    let changed = false
-    const targetShare = Math.max(1, Math.ceil(overflow / shrinkableColumns.length))
-    for (const column of shrinkableColumns) {
-      if (overflow <= 0) break
-      const shrinkBy = Math.min(column.capacity, targetShare, overflow)
-      if (shrinkBy <= 0) continue
-      nextWidths[column.index] -= shrinkBy
-      overflow -= shrinkBy
-      changed = true
-    }
-
-    if (!changed) break
-  }
-
-  return nextWidths
-}
-
-const expandTableColumnWidthsToFit = (widths: number[], budget: number) => {
-  const nextWidths = widths.map((width) => Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(width)))
-  let remaining = Math.max(0, budget - nextWidths.reduce((sum, width) => sum + width, 0))
-
-  while (remaining > 0) {
-    const targetShare = Math.max(1, Math.floor(remaining / nextWidths.length) || 1)
-    nextWidths.forEach((_, index) => {
-      if (remaining <= 0) return
-      const addBy = index === nextWidths.length - 1 ? remaining : Math.min(targetShare, remaining)
-      nextWidths[index] += addBy
-      remaining -= addBy
-    })
-  }
-
-  return nextWidths
-}
-
-const isLegacyCollapsedTableWidthState = (widths: number[]) => {
-  if (widths.length <= 1) return false
-  return widths.every((width) => width <= TABLE_MIN_COLUMN_WIDTH_PX + 2)
-}
-
-const isLegacyFullWidthInitializedTableState = (
-  widths: number[],
-  readableWidthBudget: number
-) => {
-  if (widths.length <= 1) return false
-
-  const totalWidth = widths.reduce((sum, width) => sum + width, 0)
-  const maxBudget = Math.max(TABLE_MIN_COLUMN_WIDTH_PX * widths.length, Math.round(readableWidthBudget))
-  const preferredWidth = getPreferredNormalTableTotalWidth(widths.length, maxBudget)
-  if (totalWidth <= preferredWidth + widths.length * 2) return false
-  if (Math.abs(totalWidth - maxBudget) > widths.length * 4) return false
-
-  const minWidth = Math.min(...widths)
-  const maxWidth = Math.max(...widths)
-  return maxWidth - minWidth <= 2
-}
-
-const computeNextTableColumnWidthsForResize = (
-  widths: number[],
-  activeColumnIndex: number,
-  deltaPx: number,
-  shouldClampToBudget: boolean,
-  overflowMode: string,
-  budget: number
-) => {
-  const nextWidths = widths.map((width) => Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(width)))
-  const activeIndex = Math.max(0, Math.min(activeColumnIndex, nextWidths.length - 1))
-  if (!nextWidths.length) {
-    return {
-      widths: nextWidths,
-      wasClamped: false,
-    }
-  }
-
-  const proposedWidth = Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(nextWidths[activeIndex] + deltaPx))
-  if (!shouldClampToBudget || overflowMode === TABLE_OVERFLOW_MODE_WIDE) {
-    nextWidths[activeIndex] = proposedWidth
-    return {
-      widths: nextWidths,
-      wasClamped: false,
-    }
-  }
-
-  const minBudget = TABLE_MIN_COLUMN_WIDTH_PX * nextWidths.length
-  const safeBudget = Math.max(minBudget, Math.round(budget))
-  const otherColumnsWidth = nextWidths.reduce(
-    (sum, width, index) => (index === activeIndex ? sum : sum + width),
-    0
-  )
-  const maxActiveWidth = Math.max(TABLE_MIN_COLUMN_WIDTH_PX, safeBudget - otherColumnsWidth)
-  const nextActiveWidth = Math.min(proposedWidth, maxActiveWidth)
-  nextWidths[activeIndex] = nextActiveWidth
-  return {
-    widths: nextWidths,
-    wasClamped: proposedWidth >= maxActiveWidth,
-  }
-}
-
-const didTableColumnResizeHitOverflowPolicy = (
-  requestedDeltaPx: number,
-  resizeResult: { appliedDelta?: number; wasClamped?: boolean } | null | undefined
-) => {
-  if (requestedDeltaPx <= 0) return false
-  if (!resizeResult) return false
-  if (resizeResult.wasClamped) return true
-  const appliedDelta = typeof resizeResult.appliedDelta === "number" ? resizeResult.appliedDelta : requestedDeltaPx
-  return requestedDeltaPx - appliedDelta >= 2
 }
 
 const applyTableColumnWidthsToTransaction = (

--- a/front/src/components/editor/tableWidthModel.ts
+++ b/front/src/components/editor/tableWidthModel.ts
@@ -1,0 +1,251 @@
+import type { JSONContent } from "@tiptap/core"
+import {
+  TABLE_MIN_COLUMN_WIDTH_PX,
+  TABLE_WIDE_COLUMN_MIN_WIDTH_PX,
+  TABLE_WIDE_PROMOTION_COLUMN_BUDGET_PX,
+} from "src/libs/markdown/tableMetadata"
+import type { BlockEditorDoc } from "./serialization"
+
+export const TABLE_OVERFLOW_MODE_WIDE = "wide"
+export const TABLE_WIDTH_BUDGET_META_KEY = "aq-table-width-budget-normalized"
+
+export const getTableOverflowMode = (
+  tableNode: { attrs?: Record<string, unknown> } | null | undefined
+) => tableNode?.attrs?.overflowMode === TABLE_OVERFLOW_MODE_WIDE ? TABLE_OVERFLOW_MODE_WIDE : "normal"
+
+const readSimpleTableColumnCount = (tableNode: JSONContent): number => {
+  const rows = Array.isArray(tableNode.content) ? tableNode.content : []
+  return rows.reduce((max, row) => {
+    const cells = Array.isArray(row.content)
+      ? row.content.filter((cell) => cell?.type === "tableCell" || cell?.type === "tableHeader")
+      : []
+    return Math.max(max, cells.length)
+  }, 0)
+}
+
+export const shouldPromoteWideTableOverflowMode = (columnCount: number, readableWidthBudget: number) =>
+  columnCount > 0 && columnCount * TABLE_WIDE_PROMOTION_COLUMN_BUDGET_PX >= readableWidthBudget
+
+export const getPreferredNormalTableTotalWidth = (columnCount: number, readableWidthBudget: number) => {
+  const minBudget = TABLE_MIN_COLUMN_WIDTH_PX * Math.max(1, columnCount)
+  const preferredBudget = Math.max(
+    minBudget,
+    Math.round(columnCount * TABLE_WIDE_PROMOTION_COLUMN_BUDGET_PX)
+  )
+  return Math.max(minBudget, Math.min(Math.round(readableWidthBudget), preferredBudget))
+}
+
+export const createBalancedTableColumnWidths = (columnCount: number, totalWidth: number) => {
+  if (columnCount <= 0) return []
+
+  const safeTotalWidth = Math.max(TABLE_MIN_COLUMN_WIDTH_PX * columnCount, Math.round(totalWidth))
+  const baseColumnWidth = Math.max(
+    TABLE_MIN_COLUMN_WIDTH_PX,
+    Math.floor(safeTotalWidth / columnCount)
+  )
+  const lastColumnWidth = safeTotalWidth - baseColumnWidth * (columnCount - 1)
+
+  return Array.from({ length: columnCount }, (_, columnIndex) =>
+    columnIndex === columnCount - 1
+      ? Math.max(TABLE_MIN_COLUMN_WIDTH_PX, lastColumnWidth)
+      : baseColumnWidth
+  )
+}
+
+const promoteTableBlockToWideOverflowMode = (
+  tableNode: JSONContent,
+  readableWidthBudget: number
+): JSONContent => {
+  if (tableNode.type !== "table") return tableNode
+  if (getTableOverflowMode(tableNode) === TABLE_OVERFLOW_MODE_WIDE) return tableNode
+
+  const rows = Array.isArray(tableNode.content) ? tableNode.content : []
+  const columnCount = readSimpleTableColumnCount(tableNode)
+  if (!shouldPromoteWideTableOverflowMode(columnCount, readableWidthBudget)) return tableNode
+
+  const nextColumnWidths = Array.from({ length: columnCount }, (_, columnIndex) => {
+    let nextWidth = TABLE_WIDE_COLUMN_MIN_WIDTH_PX
+    rows.forEach((row) => {
+      const cell = Array.isArray(row.content) ? row.content[columnIndex] : null
+      const widthValue = Array.isArray(cell?.attrs?.colwidth) ? cell?.attrs?.colwidth[0] : null
+      if (typeof widthValue === "number" && Number.isFinite(widthValue) && widthValue > 0) {
+        nextWidth = Math.max(nextWidth, Math.round(widthValue))
+      }
+    })
+    return nextWidth
+  })
+
+  let changed = false
+  const nextRows = rows.map((row) => {
+    if (!Array.isArray(row.content)) return row
+
+    let rowChanged = false
+    const nextCells = row.content.map((cell, columnIndex) => {
+      if (cell?.type !== "tableCell" && cell?.type !== "tableHeader") return cell
+
+      const nextWidth = nextColumnWidths[columnIndex]
+      const currentWidth = Array.isArray(cell.attrs?.colwidth) ? cell.attrs?.colwidth[0] : null
+      if (currentWidth === nextWidth) return cell
+
+      rowChanged = true
+      changed = true
+      return {
+        ...cell,
+        attrs: {
+          ...(cell.attrs || {}),
+          colwidth: [nextWidth],
+        },
+      }
+    })
+
+    return rowChanged ? { ...row, content: nextCells } : row
+  })
+
+  return {
+    ...tableNode,
+    attrs: {
+      ...(tableNode.attrs || {}),
+      overflowMode: TABLE_OVERFLOW_MODE_WIDE,
+    },
+    ...(changed ? { content: nextRows } : {}),
+  }
+}
+
+export const promotePastedWideTables = (
+  doc: BlockEditorDoc,
+  readableWidthBudget: number
+): BlockEditorDoc => {
+  if (!Array.isArray(doc.content) || doc.content.length === 0) return doc
+
+  let changed = false
+  const nextContent = doc.content.map((block) => {
+    if (!block || block.type !== "table") return block
+    const nextBlock = promoteTableBlockToWideOverflowMode(block, readableWidthBudget)
+    if (nextBlock !== block) {
+      changed = true
+    }
+    return nextBlock
+  })
+
+  return changed ? { ...doc, content: nextContent } : doc
+}
+
+export const shrinkTableColumnWidthsToFit = (widths: number[], budget: number) => {
+  const nextWidths = widths.map((width) => Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(width)))
+  let overflow = nextWidths.reduce((sum, width) => sum + width, 0) - budget
+
+  while (overflow > 0) {
+    const shrinkableColumns = nextWidths
+      .map((width, index) => ({ index, capacity: width - TABLE_MIN_COLUMN_WIDTH_PX, width }))
+      .filter((column) => column.capacity > 0)
+      .sort((left, right) => right.width - left.width)
+
+    if (shrinkableColumns.length === 0) break
+
+    let changed = false
+    const targetShare = Math.max(1, Math.ceil(overflow / shrinkableColumns.length))
+    for (const column of shrinkableColumns) {
+      if (overflow <= 0) break
+      const shrinkBy = Math.min(column.capacity, targetShare, overflow)
+      if (shrinkBy <= 0) continue
+      nextWidths[column.index] -= shrinkBy
+      overflow -= shrinkBy
+      changed = true
+    }
+
+    if (!changed) break
+  }
+
+  return nextWidths
+}
+
+export const expandTableColumnWidthsToFit = (widths: number[], budget: number) => {
+  const nextWidths = widths.map((width) => Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(width)))
+  let remaining = Math.max(0, budget - nextWidths.reduce((sum, width) => sum + width, 0))
+
+  while (remaining > 0) {
+    const targetShare = Math.max(1, Math.floor(remaining / nextWidths.length) || 1)
+    nextWidths.forEach((_, index) => {
+      if (remaining <= 0) return
+      const addBy = index === nextWidths.length - 1 ? remaining : Math.min(targetShare, remaining)
+      nextWidths[index] += addBy
+      remaining -= addBy
+    })
+  }
+
+  return nextWidths
+}
+
+export const isLegacyCollapsedTableWidthState = (widths: number[]) => {
+  if (widths.length <= 1) return false
+  return widths.every((width) => width <= TABLE_MIN_COLUMN_WIDTH_PX + 2)
+}
+
+export const isLegacyFullWidthInitializedTableState = (
+  widths: number[],
+  readableWidthBudget: number
+) => {
+  if (widths.length <= 1) return false
+
+  const totalWidth = widths.reduce((sum, width) => sum + width, 0)
+  const maxBudget = Math.max(TABLE_MIN_COLUMN_WIDTH_PX * widths.length, Math.round(readableWidthBudget))
+  const preferredWidth = getPreferredNormalTableTotalWidth(widths.length, maxBudget)
+  if (totalWidth <= preferredWidth + widths.length * 2) return false
+  if (Math.abs(totalWidth - maxBudget) > widths.length * 4) return false
+
+  const minWidth = Math.min(...widths)
+  const maxWidth = Math.max(...widths)
+  return maxWidth - minWidth <= 2
+}
+
+export const computeNextTableColumnWidthsForResize = (
+  widths: number[],
+  activeColumnIndex: number,
+  deltaPx: number,
+  shouldClampToBudget: boolean,
+  overflowMode: string,
+  budget: number
+) => {
+  const nextWidths = widths.map((width) => Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(width)))
+  const activeIndex = Math.max(0, Math.min(activeColumnIndex, nextWidths.length - 1))
+  if (!nextWidths.length) {
+    return {
+      widths: nextWidths,
+      wasClamped: false,
+    }
+  }
+
+  const proposedWidth = Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(nextWidths[activeIndex] + deltaPx))
+  if (!shouldClampToBudget || overflowMode === TABLE_OVERFLOW_MODE_WIDE) {
+    nextWidths[activeIndex] = proposedWidth
+    return {
+      widths: nextWidths,
+      wasClamped: false,
+    }
+  }
+
+  const minBudget = TABLE_MIN_COLUMN_WIDTH_PX * nextWidths.length
+  const safeBudget = Math.max(minBudget, Math.round(budget))
+  const otherColumnsWidth = nextWidths.reduce(
+    (sum, width, index) => (index === activeIndex ? sum : sum + width),
+    0
+  )
+  const maxActiveWidth = Math.max(TABLE_MIN_COLUMN_WIDTH_PX, safeBudget - otherColumnsWidth)
+  const nextActiveWidth = Math.min(proposedWidth, maxActiveWidth)
+  nextWidths[activeIndex] = nextActiveWidth
+  return {
+    widths: nextWidths,
+    wasClamped: proposedWidth >= maxActiveWidth,
+  }
+}
+
+export const didTableColumnResizeHitOverflowPolicy = (
+  requestedDeltaPx: number,
+  resizeResult: { appliedDelta?: number; wasClamped?: boolean } | null | undefined
+) => {
+  if (requestedDeltaPx <= 0) return false
+  if (!resizeResult) return false
+  if (resizeResult.wasClamped) return true
+  const appliedDelta = typeof resizeResult.appliedDelta === "number" ? resizeResult.appliedDelta : requestedDeltaPx
+  return requestedDeltaPx - appliedDelta >= 2
+}


### PR DESCRIPTION
## 관련 이슈

close #107

## 작업 배경

- BlockEditorEngine가 직접 소유하던 table width/overflow 순수 정책을 `tableWidthModel.ts`로 분리했습니다.
- source-level 회귀 테스트가 새 모델 파일의 export와 engine import 경계를 검증하도록 갱신했습니다.

## 작업 내용

- table overflow mode, width budget meta key, normal/wide width 계산, resize clamp, pasted/large table auto-wide helper를 전용 모델로 이동했습니다.
- `BlockEditorEngine.tsx`는 모델 helper를 import해 기존 동작 경로를 유지합니다.
- editor writing-flow brief에 table width 정책 소유권 invariant를 반영했습니다.

## 검증

- 실행한 명령과 결과:
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (RED: `tableWidthModel.ts` 없음으로 실패 확인)
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (15 passed)
  - `yarn --cwd front playwright:preflight`
  - `git diff --check`
  - `CURRENT_TASK_SLUG=block-editor-table-width-model bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front test:e2e:authoring` (71 passed, 2회 연속)
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front test:e2e:smoke` (39 passed, 2회 연속)
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (15 passed, 2회 연속)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: helper 이동 과정에서 table width resize/auto-wide 경로의 import 누락이 생기면 작성 surface table 회귀가 발생할 수 있습니다.
- 롤백 방법: PR commit을 revert하면 `BlockEditorEngine.tsx` 내부 helper 정의 경계로 되돌릴 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
