### PR TITLE
[Refactor] BlockEditor table paste 모델 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -250,6 +250,10 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/components/editor/tableStructureModel.ts"),
       "utf8"
     )
+    const tablePasteModelSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/tablePasteModel.ts"),
+      "utf8"
+    )
     const editorStudioSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/EditorStudioPage.tsx"),
       "utf8"
@@ -308,6 +312,13 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).not.toContain("const canShrinkTableAxisAtEnd = (")
     expect(blockEditorEngineSource).not.toContain("const countShrinkableTableAxisAtEnd = (")
     expect(blockEditorEngineSource).not.toContain("const countShrinkableRenderedTableAxisAtEnd = (")
+    expect(tablePasteModelSource).toContain("export const normalizeTableContextPasteText = (")
+    expect(tablePasteModelSource).toContain("const normalizeTableContextPasteLine = (")
+    expect(tablePasteModelSource).toContain("const isMarkdownTableRow = (")
+    expect(blockEditorEngineSource).toContain('from "./tablePasteModel"')
+    expect(blockEditorEngineSource).not.toContain("const normalizeTableContextPasteText = (")
+    expect(blockEditorEngineSource).not.toContain("const normalizeTableContextPasteLine = (")
+    expect(blockEditorEngineSource).not.toContain("const isMarkdownTableRow = (")
     expect(blockEditorEngineSource).toContain('data-testid="table-row-drag-shadow"')
     expect(blockEditorEngineSource).toContain('"table-row-reorder-indicator"')
     expect(blockEditorEngineSource).toContain('"table-column-reorder-indicator"')

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -122,6 +122,7 @@ import {
   countShrinkableRenderedTableAxisAtEnd,
   countShrinkableTableAxisAtEnd,
 } from "./tableStructureModel"
+import { normalizeTableContextPasteText } from "./tablePasteModel"
 
 type RuntimeGuardWindow = Window & {
   __AQ_RUNTIME_GUARD_ENABLED__?: boolean
@@ -395,59 +396,6 @@ const MARKDOWN_COMMIT_DEBOUNCE_MS = 140
 const MARKDOWN_COMMIT_IDLE_TIMEOUT_MS = 220
 const MARKDOWN_COMMIT_MAX_WAIT_MS = 700
 const EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT = 240
-const MARKDOWN_TABLE_SEPARATOR_CELL_PATTERN = /^:?-{3,}:?$/
-const MARKDOWN_LIST_PREFIX_PATTERN = /^\s*(?:[-+*]|\d+\.)\s+/
-const MARKDOWN_BLOCKQUOTE_PREFIX_PATTERN = /^\s*>\s?/
-
-const isMarkdownTableRow = (line: string) => {
-  const trimmedLine = line.trim()
-  if (!trimmedLine.includes("|")) return false
-
-  const normalizedLine = trimmedLine.startsWith("|") ? trimmedLine.slice(1) : trimmedLine
-  const rowWithoutEdgePipes = normalizedLine.endsWith("|") ? normalizedLine.slice(0, -1) : normalizedLine
-  return rowWithoutEdgePipes.split("|").length >= 2
-}
-
-const normalizeTableContextPasteLine = (line: string) => {
-  const trimmedLine = line.trim()
-  if (!trimmedLine) return ""
-
-  if (isMarkdownTableRow(trimmedLine)) {
-    const cells = trimmedLine
-      .replace(/^\|/, "")
-      .replace(/\|$/, "")
-      .split("|")
-      .map((cell) => cell.trim())
-      .filter(Boolean)
-      .filter((cell) => !MARKDOWN_TABLE_SEPARATOR_CELL_PATTERN.test(cell))
-
-    return cells.join(" ").trim()
-  }
-
-  return trimmedLine
-    .replace(MARKDOWN_LIST_PREFIX_PATTERN, "")
-    .replace(MARKDOWN_BLOCKQUOTE_PREFIX_PATTERN, "")
-    .trim()
-}
-
-const normalizeTableContextPasteText = (...candidates: string[]) => {
-  for (const candidate of candidates) {
-    if (!candidate.trim()) continue
-
-    const normalized = candidate
-      .replace(/\r\n?/g, "\n")
-      .split("\n")
-      .map(normalizeTableContextPasteLine)
-      .filter(Boolean)
-      .join("\n")
-      .replace(/\n{3,}/g, "\n\n")
-      .trim()
-
-    if (normalized) return normalized
-  }
-
-  return ""
-}
 
 const recordEditorCommitDurationForRuntimeGuard = (durationMs: number) => {
   if (typeof window === "undefined" || !Number.isFinite(durationMs) || durationMs <= 0) return

--- a/front/src/components/editor/tablePasteModel.ts
+++ b/front/src/components/editor/tablePasteModel.ts
@@ -1,0 +1,53 @@
+const MARKDOWN_TABLE_SEPARATOR_CELL_PATTERN = /^:?-{3,}:?$/
+const MARKDOWN_LIST_PREFIX_PATTERN = /^\s*(?:[-+*]|\d+\.)\s+/
+const MARKDOWN_BLOCKQUOTE_PREFIX_PATTERN = /^\s*>\s?/
+
+const isMarkdownTableRow = (line: string) => {
+  const trimmedLine = line.trim()
+  if (!trimmedLine.includes("|")) return false
+
+  const normalizedLine = trimmedLine.startsWith("|") ? trimmedLine.slice(1) : trimmedLine
+  const rowWithoutEdgePipes = normalizedLine.endsWith("|") ? normalizedLine.slice(0, -1) : normalizedLine
+  return rowWithoutEdgePipes.split("|").length >= 2
+}
+
+const normalizeTableContextPasteLine = (line: string) => {
+  const trimmedLine = line.trim()
+  if (!trimmedLine) return ""
+
+  if (isMarkdownTableRow(trimmedLine)) {
+    const cells = trimmedLine
+      .replace(/^\|/, "")
+      .replace(/\|$/, "")
+      .split("|")
+      .map((cell) => cell.trim())
+      .filter(Boolean)
+      .filter((cell) => !MARKDOWN_TABLE_SEPARATOR_CELL_PATTERN.test(cell))
+
+    return cells.join(" ").trim()
+  }
+
+  return trimmedLine
+    .replace(MARKDOWN_LIST_PREFIX_PATTERN, "")
+    .replace(MARKDOWN_BLOCKQUOTE_PREFIX_PATTERN, "")
+    .trim()
+}
+
+export const normalizeTableContextPasteText = (...candidates: string[]) => {
+  for (const candidate of candidates) {
+    if (!candidate.trim()) continue
+
+    const normalized = candidate
+      .replace(/\r\n?/g, "\n")
+      .split("\n")
+      .map(normalizeTableContextPasteLine)
+      .filter(Boolean)
+      .join("\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
+
+    if (normalized) return normalized
+  }
+
+  return ""
+}


### PR DESCRIPTION
## 관련 이슈

close #111

## 작업 배경

- `BlockEditorEngine.tsx` 내부에 남아 있던 table context paste 정규화 helper를 `tablePasteModel.ts`로 분리했습니다.
- table affordance/width/structure model 분리 흐름과 같은 방식으로 source guard를 추가해 helper가 엔진으로 재흡수되는 회귀를 막습니다.
- 작업 브랜치에서 PR을 `main`으로 머지하면 기존 CI 통과 후 홈서버 자동 배포 경로가 이어집니다.

## 작업 내용

- `normalizeTableContextPasteText`와 내부 markdown table/list/blockquote line 정규화 helper를 `front/src/components/editor/tablePasteModel.ts`로 이동했습니다.
- `BlockEditorEngine.tsx`는 table paste normalization을 import만 하도록 정리했습니다.
- `editor-studio-state.spec.ts`에 table paste model source boundary guard를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (RED: `tablePasteModel.ts` ENOENT 확인)
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (GREEN 후 2회 통과)
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (2회 통과)
  - `yarn --cwd front test:e2e:authoring` (1차 범위 밖 hover flake 1건 후, 같은 조건에서 2회 연속 통과)
  - `yarn --cwd front test:e2e:smoke` (2회 통과)
  - `git diff --check`
  - `CURRENT_TASK_SLUG=block-editor-table-paste-model bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table context paste normalization import 경계 변경으로 paste 처리 경로에서 module import 회귀가 생길 수 있습니다. 기존 authoring/table paste E2E와 source guard로 확인했습니다.
- 롤백 방법: 이 PR의 단일 commit `7782b915`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
