### PR TITLE
[Refactor] BlockEditor table rendered DOM 모델 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -254,6 +254,10 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/components/editor/tablePasteModel.ts"),
       "utf8"
     )
+    const tableRenderedDomModelSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/tableRenderedDomModel.ts"),
+      "utf8"
+    )
     const editorStudioSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/EditorStudioPage.tsx"),
       "utf8"
@@ -319,6 +323,15 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).not.toContain("const normalizeTableContextPasteText = (")
     expect(blockEditorEngineSource).not.toContain("const normalizeTableContextPasteLine = (")
     expect(blockEditorEngineSource).not.toContain("const isMarkdownTableRow = (")
+    expect(tableRenderedDomModelSource).toContain("export const findActiveRenderedTable = (")
+    expect(tableRenderedDomModelSource).toContain("export const resolveTableScopedSelectedCell = (")
+    expect(tableRenderedDomModelSource).toContain("export const resolveActiveRenderedTableForFloatingUi = (")
+    expect(tableRenderedDomModelSource).toContain("export const readRenderedColumnWidths = (")
+    expect(blockEditorEngineSource).toContain('} from "./tableRenderedDomModel"')
+    expect(blockEditorEngineSource).not.toContain("const findActiveRenderedTable = (")
+    expect(blockEditorEngineSource).not.toContain("const resolveTableScopedSelectedCell = (")
+    expect(blockEditorEngineSource).not.toContain("const resolveActiveRenderedTableForFloatingUi = (")
+    expect(blockEditorEngineSource).not.toContain("const readRenderedColumnWidths = (")
     expect(blockEditorEngineSource).toContain('data-testid="table-row-drag-shadow"')
     expect(blockEditorEngineSource).toContain('"table-row-reorder-indicator"')
     expect(blockEditorEngineSource).toContain('"table-column-reorder-indicator"')

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -123,6 +123,12 @@ import {
   countShrinkableTableAxisAtEnd,
 } from "./tableStructureModel"
 import { normalizeTableContextPasteText } from "./tablePasteModel"
+import {
+  findActiveRenderedTable,
+  readRenderedColumnWidths,
+  resolveActiveRenderedTableForFloatingUi,
+  resolveTableScopedSelectedCell,
+} from "./tableRenderedDomModel"
 
 type RuntimeGuardWindow = Window & {
   __AQ_RUNTIME_GUARD_ENABLED__?: boolean
@@ -1175,51 +1181,6 @@ const shouldClampTableWidthBudget = () => {
   return !window.matchMedia(DESKTOP_TABLE_RAIL_MEDIA_QUERY).matches
 }
 
-const findActiveRenderedTable = (
-  viewport: HTMLElement | null,
-  quickRailGeometry: TableAffordanceGeometry | null,
-  preferredTable?: HTMLTableElement | null
-) => {
-  if (!viewport || !quickRailGeometry) return null
-
-  if (preferredTable?.isConnected && viewport.contains(preferredTable)) {
-    return preferredTable
-  }
-
-  const renderedTables = Array.from(
-    viewport.querySelectorAll<HTMLTableElement>(".aq-block-editor__content .tableWrapper table, .aq-block-editor__content table")
-  )
-  if (!renderedTables.length) return null
-
-  const withinHorizontalTolerance = (left: number, right: number) =>
-    Math.abs(left - quickRailGeometry.tableLeft) <= 6 &&
-    Math.abs(right - (quickRailGeometry.tableLeft + quickRailGeometry.width)) <= 6
-  const withinFullTolerance = (rect: DOMRect) =>
-    withinHorizontalTolerance(rect.left, rect.right) && Math.abs(rect.top - quickRailGeometry.tableTop) <= 6
-
-  return (
-    renderedTables.find((table) => {
-      const rect = table.getBoundingClientRect()
-      return withinFullTolerance(rect)
-    }) ??
-    renderedTables.find((table) => {
-      const rect = table.getBoundingClientRect()
-      return withinHorizontalTolerance(rect.left, rect.right)
-    }) ?? renderedTables[0] ?? null
-  )
-}
-
-const resolveTableScopedSelectedCell = (tableElement: ParentNode | null) =>
-  (tableElement?.querySelector(".selectedCell") as HTMLElement | null) ?? null
-
-const resolveActiveRenderedTableForFloatingUi = (
-  viewport: HTMLElement | null,
-  quickRailGeometry: TableAffordanceGeometry | null,
-  preferredTable?: HTMLTableElement | null
-) =>
-  findActiveRenderedTable(viewport, quickRailGeometry, preferredTable) ??
-  (viewport?.querySelector(".aq-block-editor__content .tableWrapper table, .aq-block-editor__content table") as HTMLTableElement | null)
-
 const readColumnWidthFromCell = (cell: TableColumnCellRef) => {
   const widthValue = Array.isArray(cell.node.attrs?.colwidth) ? cell.node.attrs?.colwidth[0] : null
   return typeof widthValue === "number" && Number.isFinite(widthValue) && widthValue > 0
@@ -1232,14 +1193,6 @@ const hasExplicitColumnWidth = (column: TableColumnCellRef[]) =>
     const widthValue = Array.isArray(cell.node.attrs?.colwidth) ? cell.node.attrs?.colwidth[0] : null
     return typeof widthValue === "number" && Number.isFinite(widthValue) && widthValue > 0
   })
-
-const readRenderedColumnWidths = (tableElement: HTMLElement | null) => {
-  if (!tableElement) return []
-
-  return Array.from(
-    tableElement.querySelectorAll<HTMLElement>("thead tr:first-of-type > th, thead tr:first-of-type > td, tbody tr:first-of-type > th, tbody tr:first-of-type > td, tr:first-of-type > th, tr:first-of-type > td")
-  ).map((cell) => Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(cell.getBoundingClientRect().width)))
-}
 
 const applyTableColumnWidthsToTransaction = (
   transaction: Transaction,

--- a/front/src/components/editor/tableRenderedDomModel.ts
+++ b/front/src/components/editor/tableRenderedDomModel.ts
@@ -1,0 +1,58 @@
+import { TABLE_MIN_COLUMN_WIDTH_PX } from "src/libs/markdown/tableMetadata"
+import type { TableAffordanceGeometry } from "./tableAffordanceModel"
+
+const RENDERED_TABLE_SELECTOR =
+  ".aq-block-editor__content .tableWrapper table, .aq-block-editor__content table"
+const FIRST_ROW_CELL_SELECTOR =
+  "thead tr:first-of-type > th, thead tr:first-of-type > td, tbody tr:first-of-type > th, tbody tr:first-of-type > td, tr:first-of-type > th, tr:first-of-type > td"
+
+export const findActiveRenderedTable = (
+  viewport: HTMLElement | null,
+  quickRailGeometry: TableAffordanceGeometry | null,
+  preferredTable?: HTMLTableElement | null
+) => {
+  if (!viewport || !quickRailGeometry) return null
+
+  if (preferredTable?.isConnected && viewport.contains(preferredTable)) {
+    return preferredTable
+  }
+
+  const renderedTables = Array.from(viewport.querySelectorAll<HTMLTableElement>(RENDERED_TABLE_SELECTOR))
+  if (!renderedTables.length) return null
+
+  const withinHorizontalTolerance = (left: number, right: number) =>
+    Math.abs(left - quickRailGeometry.tableLeft) <= 6 &&
+    Math.abs(right - (quickRailGeometry.tableLeft + quickRailGeometry.width)) <= 6
+  const withinFullTolerance = (rect: DOMRect) =>
+    withinHorizontalTolerance(rect.left, rect.right) && Math.abs(rect.top - quickRailGeometry.tableTop) <= 6
+
+  return (
+    renderedTables.find((table) => {
+      const rect = table.getBoundingClientRect()
+      return withinFullTolerance(rect)
+    }) ??
+    renderedTables.find((table) => {
+      const rect = table.getBoundingClientRect()
+      return withinHorizontalTolerance(rect.left, rect.right)
+    }) ?? renderedTables[0] ?? null
+  )
+}
+
+export const resolveTableScopedSelectedCell = (tableElement: ParentNode | null) =>
+  (tableElement?.querySelector(".selectedCell") as HTMLElement | null) ?? null
+
+export const resolveActiveRenderedTableForFloatingUi = (
+  viewport: HTMLElement | null,
+  quickRailGeometry: TableAffordanceGeometry | null,
+  preferredTable?: HTMLTableElement | null
+) =>
+  findActiveRenderedTable(viewport, quickRailGeometry, preferredTable) ??
+  (viewport?.querySelector(RENDERED_TABLE_SELECTOR) as HTMLTableElement | null)
+
+export const readRenderedColumnWidths = (tableElement: HTMLElement | null) => {
+  if (!tableElement) return []
+
+  return Array.from(tableElement.querySelectorAll<HTMLElement>(FIRST_ROW_CELL_SELECTOR)).map((cell) =>
+    Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(cell.getBoundingClientRect().width))
+  )
+}


### PR DESCRIPTION
## 관련 이슈

close #113

## 작업 배경

- `BlockEditorEngine.tsx` 내부에 남아 있던 rendered table DOM lookup/floating UI fallback helper를 `tableRenderedDomModel.ts`로 분리했습니다.
- table affordance/width/structure/paste model 분리 흐름과 같은 방식으로 source guard를 추가해 helper가 엔진으로 재흡수되는 회귀를 막습니다.
- 작업 브랜치에서 PR을 `main`으로 머지하면 기존 CI 통과 후 홈서버 자동 배포 경로가 이어집니다.

## 작업 내용

- `findActiveRenderedTable`, `resolveTableScopedSelectedCell`, `resolveActiveRenderedTableForFloatingUi`, `readRenderedColumnWidths`를 `front/src/components/editor/tableRenderedDomModel.ts`로 이동했습니다.
- `BlockEditorEngine.tsx`는 rendered table DOM helper를 import만 하도록 정리했습니다.
- `editor-studio-state.spec.ts`에 rendered DOM model source boundary guard를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (RED: `tableRenderedDomModel.ts` ENOENT 확인)
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (GREEN 후 2회 통과)
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (2회 통과)
  - `yarn --cwd front test:e2e:authoring` (2회 통과)
  - `yarn --cwd front test:e2e:smoke` (병렬 worker에서 검색 smoke `kw=alpha beta` 캡처 timeout flake 재현)
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` (동일 smoke/mobile 세트 2회 연속 통과)
  - `git diff --check`
  - `CURRENT_TASK_SLUG=block-editor-table-rendered-dom-model bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: rendered table DOM lookup import 경계 변경으로 table overlay/floating anchor 경로에서 module import 회귀가 생길 수 있습니다. 기존 authoring/table E2E와 source guard로 확인했습니다.
- 롤백 방법: 이 PR의 단일 commit `bbe27208`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
