### PR TITLE
[Refactor] BlockEditor table corner grow 모델 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -258,6 +258,10 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/components/editor/tableRenderedDomModel.ts"),
       "utf8"
     )
+    const tableCornerGrowModelSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/tableCornerGrowModel.ts"),
+      "utf8"
+    )
     const editorStudioSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/EditorStudioPage.tsx"),
       "utf8"
@@ -338,9 +342,17 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).toContain('const TableCellMenuButton = styled(TableHandleButton)`')
     expect(blockEditorEngineSource).toContain("const updateActiveTableOverflowMode = useCallback(")
     expect(blockEditorEngineSource).toContain("const reorderTableAxisAtPosition = useCallback(")
-    expect(blockEditorEngineSource).toContain("const getTableCornerGrowStepMetrics = useCallback(")
-    expect(blockEditorEngineSource).toContain("type TableCornerPreviewState = {")
-    expect(blockEditorEngineSource).toContain("const resolveTableCornerPreviewState = useCallback(")
+    expect(tableCornerGrowModelSource).toContain("export type TableCornerGrowState = {")
+    expect(tableCornerGrowModelSource).toContain("export type TableCornerPreviewState = {")
+    expect(tableCornerGrowModelSource).toContain("export const resolveTableCornerPreviewState = (")
+    expect(tableCornerGrowModelSource).toContain("export const resolveTableCornerGrowStepMetrics = (")
+    expect(tableCornerGrowModelSource).toContain("export const resolveTableCornerGrowStepMetricsFromDataset = (")
+    expect(blockEditorEngineSource).toContain('} from "./tableCornerGrowModel"')
+    expect(blockEditorEngineSource).not.toContain("type TableCornerGrowState = {")
+    expect(blockEditorEngineSource).not.toContain("type TableCornerPreviewState = {")
+    expect(blockEditorEngineSource).not.toContain("const resolveTableCornerPreviewState = useCallback(")
+    expect(blockEditorEngineSource).not.toContain("const getTableCornerGrowStepMetrics = useCallback(")
+    expect(blockEditorEngineSource).not.toContain("const getTableCornerGrowStepMetricsFromHandle = useCallback(")
     expect(blockEditorEngineSource).toContain("const applyTableCornerGrowSteps = useCallback(")
     expect(blockEditorEngineSource).toContain("const shrinkTableAxisAtEnd = useCallback(")
     expect(blockEditorEngineSource).toContain("const beginTableAxisDragFromPending = useCallback(")
@@ -359,7 +371,7 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).toContain('const isColumnMenuOpen = tableMenuKind === "column"')
     expect(blockEditorEngineSource).toContain("activeTableStructureState.hasHeaderRow")
     expect(blockEditorEngineSource).toContain("activeTableStructureState.hasHeaderColumn")
-    expect(blockEditorEngineSource).toContain("const tableCornerGrowStepMetrics = getTableCornerGrowStepMetrics()")
+    expect(blockEditorEngineSource).toContain("const tableCornerGrowStepMetrics = resolveTableCornerGrowStepMetrics(tableAffordanceGeometry)")
     expect(blockEditorEngineSource).toContain("data-column-step={tableCornerGrowStepMetrics.columnStepPx}")
     expect(blockEditorEngineSource).toContain("data-row-step={tableCornerGrowStepMetrics.rowStepPx}")
     expect(blockEditorEngineSource).toContain('aria-label="표 구조 메뉴"')

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -100,6 +100,14 @@ import {
   resolveDesktopTableRailLayout,
 } from "./tableAffordanceModel"
 import {
+  type TableCornerGrowState,
+  type TableCornerGrowStepMetrics,
+  type TableCornerPreviewState,
+  resolveTableCornerGrowStepMetrics,
+  resolveTableCornerGrowStepMetricsFromDataset,
+  resolveTableCornerPreviewState,
+} from "./tableCornerGrowModel"
+import {
   TABLE_OVERFLOW_MODE_WIDE,
   TABLE_WIDTH_BUDGET_META_KEY,
   computeNextTableColumnWidthsForResize,
@@ -687,30 +695,6 @@ type TableColumnDragGuideState = {
   left: number
   top: number
   height: number
-}
-
-type TableCornerGrowState = {
-  pointerId: number
-  startClientX: number
-  startClientY: number
-  baseLeft: number
-  baseTop: number
-  baseWidth: number
-  baseHeight: number
-  columnStepPx: number
-  rowStepPx: number
-  maxShrinkColumnSteps: number
-  maxShrinkRowSteps: number
-}
-
-type TableCornerPreviewState = {
-  visible: boolean
-  left: number
-  top: number
-  width: number
-  height: number
-  columnSteps: number
-  rowSteps: number
 }
 
 const BLOCK_HANDLE_MEDIA_QUERY = "(pointer: coarse)"
@@ -3654,38 +3638,6 @@ const BlockEditorEngine = ({
     return appendedColumn || appendedRow
   }, [appendTableAxisAtEnd])
 
-  const resolveTableCornerPreviewState = useCallback(
-    (state: TableCornerGrowState, clientX: number, clientY: number): TableCornerPreviewState => {
-      const rawColumnSteps = Math.trunc((clientX - state.startClientX) / state.columnStepPx)
-      const rawRowSteps = Math.trunc((clientY - state.startClientY) / state.rowStepPx)
-      const columnSteps = Math.max(-state.maxShrinkColumnSteps, rawColumnSteps)
-      const rowSteps = Math.max(-state.maxShrinkRowSteps, rawRowSteps)
-
-      if (columnSteps === 0 && rowSteps === 0) {
-        return {
-          visible: false,
-          left: state.baseLeft,
-          top: state.baseTop,
-          width: state.baseWidth,
-          height: state.baseHeight,
-          columnSteps: 0,
-          rowSteps: 0,
-        }
-      }
-
-      return {
-        visible: true,
-        left: state.baseLeft,
-        top: state.baseTop,
-        width: Math.max(TABLE_MIN_COLUMN_WIDTH_PX, state.baseWidth + columnSteps * state.columnStepPx),
-        height: Math.max(TABLE_MIN_ROW_HEIGHT_PX, state.baseHeight + rowSteps * state.rowStepPx),
-        columnSteps,
-        rowSteps,
-      }
-    },
-    []
-  )
-
   const applyTableCornerGrowSteps = useCallback(
     (columnSteps: number, rowSteps: number) => {
       let appliedColumnSteps = 0
@@ -3717,38 +3669,18 @@ const BlockEditorEngine = ({
     [appendTableAxisAtEnd, shrinkTableAxisAtEnd]
   )
 
-  const getTableCornerGrowStepMetrics = useCallback(() => {
-    const lastColumnSegment =
-      tableAffordanceGeometryRef.current.columnSegments[tableAffordanceGeometryRef.current.columnSegments.length - 1]
-    return {
-      columnStepPx: Math.max(
-        TABLE_MIN_COLUMN_WIDTH_PX,
-        Math.round(
-          lastColumnSegment?.width ??
-            tableAffordanceGeometryRef.current.columnWidth ??
-            TABLE_MIN_COLUMN_WIDTH_PX
-        )
-      ),
-      rowStepPx: Math.max(
-        TABLE_MIN_ROW_HEIGHT_PX,
-        Math.round(tableAffordanceGeometryRef.current.rowHeight || TABLE_MIN_ROW_HEIGHT_PX)
-      ),
-    }
-  }, [])
+  const resolveCurrentTableCornerGrowStepMetrics = useCallback(
+    () => resolveTableCornerGrowStepMetrics(tableAffordanceGeometryRef.current),
+    []
+  )
 
-  const getTableCornerGrowStepMetricsFromHandle = useCallback(
-    (element: HTMLElement | null) => {
-      const columnStepPx = Number(element?.dataset.columnStep || "0")
-      const rowStepPx = Number(element?.dataset.rowStep || "0")
-      if (Number.isFinite(columnStepPx) && columnStepPx > 0 && Number.isFinite(rowStepPx) && rowStepPx > 0) {
-        return {
-          columnStepPx,
-          rowStepPx,
-        }
-      }
-      return getTableCornerGrowStepMetrics()
-    },
-    [getTableCornerGrowStepMetrics]
+  const resolveTableCornerGrowStepMetricsFromHandle = useCallback(
+    (element: HTMLElement | null) =>
+      resolveTableCornerGrowStepMetricsFromDataset(
+        element?.dataset,
+        resolveCurrentTableCornerGrowStepMetrics()
+      ),
+    [resolveCurrentTableCornerGrowStepMetrics]
   )
 
   const stopTableCornerGrow = useCallback(() => {
@@ -3762,12 +3694,9 @@ const BlockEditorEngine = ({
       pointerId: number,
       clientX: number,
       clientY: number,
-      stepMetrics?: {
-        columnStepPx: number
-        rowStepPx: number
-      }
+      stepMetrics?: TableCornerGrowStepMetrics
     ) => {
-      const { columnStepPx, rowStepPx } = stepMetrics ?? getTableCornerGrowStepMetrics()
+      const { columnStepPx, rowStepPx } = stepMetrics ?? resolveCurrentTableCornerGrowStepMetrics()
       const currentEditor = editorRef.current
       const rect = currentEditor ? getCurrentSelectedTableRect(currentEditor) : null
       const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
@@ -3802,7 +3731,7 @@ const BlockEditorEngine = ({
       })
       setIsTableCornerGrowActive(true)
     },
-    [getCurrentSelectedTableRect, getTableCornerGrowStepMetrics, updateTableCornerPreviewState]
+    [getCurrentSelectedTableRect, resolveCurrentTableCornerGrowStepMetrics, updateTableCornerPreviewState]
   )
 
   const getCurrentTableColumnResizeContext = useCallback(
@@ -5389,7 +5318,7 @@ const BlockEditorEngine = ({
       window.removeEventListener("mouseup", handleMouseUp)
       stopTableCornerGrow()
     }
-  }, [applyTableCornerGrowSteps, resolveTableCornerPreviewState, stopTableCornerGrow, updateTableCornerPreviewState])
+  }, [applyTableCornerGrowSteps, stopTableCornerGrow, updateTableCornerPreviewState])
 
   useEffect(() => {
     const currentEditor = editorRef.current ?? editor
@@ -8637,7 +8566,7 @@ const BlockEditorEngine = ({
     if (typeof window === "undefined") return null
     return resolveDesktopTableRailLayout(tableAffordanceGeometry)
   }, [tableAffordanceGeometry])
-  const tableCornerGrowStepMetrics = getTableCornerGrowStepMetrics()
+  const tableCornerGrowStepMetrics = resolveTableCornerGrowStepMetrics(tableAffordanceGeometry)
   const shouldShowCellMergeSection = canMergeSelectedTableCells || canSplitSelectedTableCell
 
   useEffect(() => {
@@ -8804,7 +8733,7 @@ const BlockEditorEngine = ({
                       event.pointerId,
                       event.clientX,
                       event.clientY,
-                      getTableCornerGrowStepMetricsFromHandle(event.currentTarget)
+                      resolveTableCornerGrowStepMetricsFromHandle(event.currentTarget)
                     )
                   }}
                   onMouseDown={(event: ReactMouseEvent<HTMLButtonElement>) => {
@@ -8814,7 +8743,7 @@ const BlockEditorEngine = ({
                       TABLE_CORNER_GROW_MOUSE_POINTER_ID,
                       event.clientX,
                       event.clientY,
-                      getTableCornerGrowStepMetricsFromHandle(event.currentTarget)
+                      resolveTableCornerGrowStepMetricsFromHandle(event.currentTarget)
                     )
                   }}
                   onClick={(event: ReactMouseEvent<HTMLButtonElement>) => {

--- a/front/src/components/editor/tableCornerGrowModel.ts
+++ b/front/src/components/editor/tableCornerGrowModel.ts
@@ -1,0 +1,101 @@
+import {
+  TABLE_MIN_COLUMN_WIDTH_PX,
+  TABLE_MIN_ROW_HEIGHT_PX,
+} from "src/libs/markdown/tableMetadata"
+import type { TableAffordanceGeometry } from "./tableAffordanceModel"
+
+export type TableCornerGrowStepMetrics = {
+  columnStepPx: number
+  rowStepPx: number
+}
+
+export type TableCornerGrowState = {
+  pointerId: number
+  startClientX: number
+  startClientY: number
+  baseLeft: number
+  baseTop: number
+  baseWidth: number
+  baseHeight: number
+  columnStepPx: number
+  rowStepPx: number
+  maxShrinkColumnSteps: number
+  maxShrinkRowSteps: number
+}
+
+export type TableCornerPreviewState = {
+  visible: boolean
+  left: number
+  top: number
+  width: number
+  height: number
+  columnSteps: number
+  rowSteps: number
+}
+
+export const resolveTableCornerPreviewState = (
+  state: TableCornerGrowState,
+  clientX: number,
+  clientY: number
+): TableCornerPreviewState => {
+  const rawColumnSteps = Math.trunc((clientX - state.startClientX) / state.columnStepPx)
+  const rawRowSteps = Math.trunc((clientY - state.startClientY) / state.rowStepPx)
+  const columnSteps = Math.max(-state.maxShrinkColumnSteps, rawColumnSteps)
+  const rowSteps = Math.max(-state.maxShrinkRowSteps, rawRowSteps)
+
+  if (columnSteps === 0 && rowSteps === 0) {
+    return {
+      visible: false,
+      left: state.baseLeft,
+      top: state.baseTop,
+      width: state.baseWidth,
+      height: state.baseHeight,
+      columnSteps: 0,
+      rowSteps: 0,
+    }
+  }
+
+  return {
+    visible: true,
+    left: state.baseLeft,
+    top: state.baseTop,
+    width: Math.max(TABLE_MIN_COLUMN_WIDTH_PX, state.baseWidth + columnSteps * state.columnStepPx),
+    height: Math.max(TABLE_MIN_ROW_HEIGHT_PX, state.baseHeight + rowSteps * state.rowStepPx),
+    columnSteps,
+    rowSteps,
+  }
+}
+
+export const resolveTableCornerGrowStepMetrics = (
+  geometry: TableAffordanceGeometry
+): TableCornerGrowStepMetrics => {
+  const lastColumnSegment = geometry.columnSegments[geometry.columnSegments.length - 1]
+
+  return {
+    columnStepPx: Math.max(
+      TABLE_MIN_COLUMN_WIDTH_PX,
+      Math.round(lastColumnSegment?.width ?? geometry.columnWidth ?? TABLE_MIN_COLUMN_WIDTH_PX)
+    ),
+    rowStepPx: Math.max(
+      TABLE_MIN_ROW_HEIGHT_PX,
+      Math.round(geometry.rowHeight || TABLE_MIN_ROW_HEIGHT_PX)
+    ),
+  }
+}
+
+export const resolveTableCornerGrowStepMetricsFromDataset = (
+  dataset: DOMStringMap | undefined,
+  fallbackMetrics: TableCornerGrowStepMetrics
+): TableCornerGrowStepMetrics => {
+  const columnStepPx = Number(dataset?.columnStep || "0")
+  const rowStepPx = Number(dataset?.rowStep || "0")
+
+  if (Number.isFinite(columnStepPx) && columnStepPx > 0 && Number.isFinite(rowStepPx) && rowStepPx > 0) {
+    return {
+      columnStepPx,
+      rowStepPx,
+    }
+  }
+
+  return fallbackMetrics
+}


### PR DESCRIPTION
## 관련 이슈

close #115

## 작업 배경

- BlockEditorEngine이 직접 소유하던 table corner grow preview/step 계산을 `tableCornerGrowModel.ts`로 분리했습니다.
- source guard가 corner grow 계산 타입/helper의 엔진 재흡수를 막도록 갱신했습니다.

## 작업 내용

- `TableCornerGrowState`, `TableCornerPreviewState`, preview outline 계산, step metrics 계산을 전용 모델로 이동했습니다.
- `BlockEditorEngine.tsx`는 모델 import와 현재 geometry/dataset 연결만 맡도록 정리했습니다.
- editor studio source guard가 새 모델 소유권과 엔진 내 직접 정의 금지를 검사합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight` 통과
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` 2회 통과, 각 15/15
  - `git diff --check` 통과
  - `yarn --cwd front lint` 통과
  - `yarn --cwd front build` 통과
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` 2회 통과, 각 16/16
  - `yarn --cwd front test:e2e:authoring` 1회 통과, 71/71
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` 2회 통과, 각 39/39
  - `CURRENT_TASK_SLUG=block-editor-table-corner-grow-model bash tools/guards/current-task-preflight.sh` 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: corner grow step metrics 연결부가 모델로 이동되어 hover handle dataset fallback 경로가 영향을 받을 수 있습니다.
- 롤백 방법: 이 커밋을 revert하면 기존 BlockEditorEngine 내부 계산으로 되돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
