### PR TITLE
[Fix] editor hover scroll regression

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -841,6 +841,85 @@ test.describe("block editor authoring flow", () => {
     expect(colors.string).not.toBe(colors.base)
   })
 
+  test("코드 블록 hover scroll surface는 wrapper chrome transition과 세로 gesture 차단을 쓰지 않는다", async ({ page }) => {
+    const seed = encodeURIComponent("```javascript\nconst count = 1;\nreturn \"ok\";\n```\n\n아래 문단")
+    await page.goto(`${QA_ENGINE_ROUTE}&seed=${seed}`)
+
+    const codeWrapper = page.locator("[data-code-block-wrapper='true']").first()
+    const codeShell = page.locator(".aq-code-shell").first()
+    await expect(codeWrapper).toBeVisible()
+    await expect(codeShell.locator(".aq-code-highlight-layer .token.keyword").first()).toBeVisible()
+
+    const metrics = await codeWrapper.evaluate((element) => {
+      const wrapperStyle = window.getComputedStyle(element as HTMLElement)
+      const shell = element.querySelector<HTMLElement>(".aq-code-shell")
+      const shellStyle = shell ? window.getComputedStyle(shell) : null
+      return {
+        transitionProperty: wrapperStyle.transitionProperty,
+        shellTouchAction: shellStyle?.touchAction ?? "",
+      }
+    })
+
+    expect(metrics.transitionProperty.split(",").map((property) => property.trim())).not.toEqual(
+      expect.arrayContaining(["background-color", "box-shadow"])
+    )
+    expect(metrics.shellTouchAction === "auto" || metrics.shellTouchAction.includes("pan-y")).toBe(true)
+  })
+
+  test("wide table hover 중 wheel 입력은 page scroll chain을 유지한다", async ({ page }) => {
+    await page.setViewportSize({ width: 980, height: 900 })
+    await page.goto(QA_ENGINE_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.click()
+    const wideTableMarkdown = [
+      "| A | B | C | D | E | F | G |",
+      "| --- | --- | --- | --- | --- | --- | --- |",
+      "| 1 | 2 | 3 | 4 | 5 | 6 | 7 |",
+      "| aa | bb | cc | dd | ee | ff | gg |",
+    ].join("\n")
+    await editor.evaluate((element, markdown) => {
+      const data = new DataTransfer()
+      data.setData("text/plain", markdown)
+      const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true })
+      Object.defineProperty(event, "clipboardData", { value: data })
+      element.dispatchEvent(event)
+    }, wideTableMarkdown)
+
+    const tableWrapper = page.locator(".aq-block-editor__content .tableWrapper").first()
+    const table = tableWrapper.locator("table")
+    await expect(tableWrapper).toBeVisible()
+    await expect(table).toHaveAttribute("data-overflow-mode", "wide")
+    await page.evaluate(() => {
+      const spacer = document.createElement("div")
+      spacer.setAttribute("data-testid", "qa-scroll-spacer")
+      spacer.style.height = "2400px"
+      document.body.appendChild(spacer)
+    })
+
+    await tableWrapper.scrollIntoViewIfNeeded()
+    const box = await tableWrapper.boundingBox()
+    if (!box) {
+      throw new Error("table wrapper metrics are missing before wheel")
+    }
+    const overflowContract = await tableWrapper.evaluate((element) => {
+      const style = window.getComputedStyle(element as HTMLElement)
+      return {
+        overscrollY: (style as CSSStyleDeclaration & { overscrollBehaviorY?: string }).overscrollBehaviorY || "",
+        touchAction: style.touchAction,
+      }
+    })
+    expect(overflowContract.overscrollY || "auto").toBe("auto")
+    expect(overflowContract.touchAction === "auto" || overflowContract.touchAction.includes("pan-y")).toBe(true)
+
+    await page.mouse.move(box.x + Math.min(box.width / 2, 120), box.y + Math.min(box.height / 2, 40))
+
+    const beforeScrollY = await page.evaluate(() => window.scrollY)
+    await page.mouse.wheel(0, 420)
+
+    await expect.poll(async () => page.evaluate(() => window.scrollY)).toBeGreaterThan(beforeScrollY + 120)
+  })
+
   test("코드 언어 선택 팝오버는 본문 숨김 텍스트 스타일을 상속하지 않는다", async ({ page }) => {
     const seed = encodeURIComponent("```javascript\nconst answer = 42;\n```")
     await page.goto(`${QA_ENGINE_ROUTE}&seed=${seed}`)

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -10868,7 +10868,7 @@ const EditorViewport = styled.div`
     overflow-y: hidden;
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-x: contain;
-    touch-action: pan-x;
+    touch-action: pan-x pan-y;
   }
 
   .aq-block-editor__content > *[data-block-hovered="true"] {
@@ -11076,8 +11076,8 @@ const EditorViewport = styled.div`
     box-shadow: ${tableChrome.shadow};
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-x: contain;
-    overscroll-behavior-y: contain;
-    touch-action: pan-x;
+    overscroll-behavior-y: auto;
+    touch-action: pan-x pan-y;
     transition:
       border-color 140ms ease,
       box-shadow 140ms ease,

--- a/front/src/components/editor/extensions.tsx
+++ b/front/src/components/editor/extensions.tsx
@@ -2704,7 +2704,7 @@ const CodeBlockEditorSurface = styled.div`
     overflow-y: hidden;
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-x: contain;
-    touch-action: pan-x;
+    touch-action: pan-x pan-y;
   }
 
   .aq-code-highlight-layer,


### PR DESCRIPTION
## 관련 이슈

close #117

## 작업 배경

- 작성/수정 에디터에서 코드 블록과 wide table의 horizontal overflow surface가 세로 scroll chain을 차단하던 회귀를 수정했습니다.
- 코드 블록 hover 중 깜빡임과 테이블 hover 중 wheel scroll 정지를 같은 scroll-chain 문제로 묶어 회귀 테스트를 추가했습니다.
- 배포 경로는 `fix/editor-hover-scroll` → PR to `main` → `main` merge → 홈서버 자동 배포입니다.

## 작업 내용

- 코드 블록 shell의 `touch-action`을 `pan-x pan-y`로 조정해 가로 overflow는 유지하면서 세로 wheel/touch pan을 막지 않게 했습니다.
- table wrapper의 `overscroll-behavior-y`를 `auto`로 돌리고 `touch-action`에 `pan-y`를 포함해 page scroll chain을 유지했습니다.
- authoring E2E에 코드 블록 hover scroll surface 계약과 wide table hover wheel 계약을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "코드 블록 hover scroll surface|wide table hover" --workers=1` (RED 확인 후 GREEN)
  - `yarn --cwd front test:e2e:authoring`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `yarn --cwd front build`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: touch-action/overscroll 조정으로 horizontal overflow 내부 스크롤 감각이 브라우저별로 달라질 수 있습니다.
- 롤백 방법: commit `ef1bac07`을 revert하면 이전 CSS 계약과 테스트 추가가 함께 되돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
