### PR TITLE
[Test] live editor hover-wheel 회귀 검증 추가

### DIFF
--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page, type Response } from "@playwright/test"
+import { expect, test, type Locator, type Page, type Response } from "@playwright/test"
 
 const adminEmail = process.env.E2E_ADMIN_EMAIL?.trim() || ""
 const adminLegacyLoginId = process.env.E2E_ADMIN_USERNAME?.trim() || ""
@@ -278,6 +278,99 @@ const appendTextToBlockEditor = async (page: Page, text: string) => {
     .toContain(text)
 
   return blockEditor
+}
+
+const liveHoverWheelTableMarkdown = [
+  "| A | B | C | D | E | F | G |",
+  "| --- | --- | --- | --- | --- | --- | --- |",
+  "| 1 | 2 | 3 | 4 | 5 | 6 | 7 |",
+  "| aa | bb | cc | dd | ee | ff | gg |",
+].join("\n")
+
+const pasteMarkdownIntoBlockEditor = async (blockEditor: Locator, markdown: string) => {
+  await blockEditor.evaluate((element, payload) => {
+    const data = new DataTransfer()
+    data.setData("text/plain", payload)
+    const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true })
+    Object.defineProperty(event, "clipboardData", { value: data })
+    element.dispatchEvent(event)
+  }, markdown)
+}
+
+const ensureLiveHoverWheelFixture = async (page: Page, blockEditor: Locator) => {
+  await blockEditor.click({ position: { x: 24, y: 24 } })
+  await page.keyboard.press("Enter")
+
+  const codeButton = page.getByRole("button", { name: "코드", exact: true }).first()
+  if (await codeButton.isVisible().catch(() => false)) {
+    await codeButton.click()
+  } else {
+    await page.keyboard.type("/코드")
+    await page.keyboard.press("Enter")
+  }
+
+  await expect(page.locator("[data-code-block-wrapper='true']").first()).toBeVisible()
+  await expect(page.locator(".aq-code-shell").first()).toBeVisible()
+  await page.keyboard.type("const liveHoverWheel = true")
+
+  const tableButton = page.getByRole("button", { name: "테이블", exact: true }).first()
+  if (await tableButton.isVisible().catch(() => false)) {
+    await tableButton.click()
+  } else {
+    await pasteMarkdownIntoBlockEditor(blockEditor, liveHoverWheelTableMarkdown)
+  }
+
+  await expect(page.locator(".aq-block-editor__content .tableWrapper").first()).toBeVisible()
+}
+
+const readDocumentScrollTop = (page: Page) =>
+  page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+
+const expectHoverWheelChainsToPageScroll = async (page: Page, target: Locator, label: string) => {
+  await page.evaluate(() => {
+    if (document.querySelector("[data-testid='live-hover-wheel-scroll-spacer']")) return
+    const spacer = document.createElement("div")
+    spacer.setAttribute("data-testid", "live-hover-wheel-scroll-spacer")
+    spacer.style.height = "2400px"
+    document.body.appendChild(spacer)
+  })
+
+  await target.scrollIntoViewIfNeeded()
+  const box = await target.boundingBox()
+  if (!box) {
+    throw new Error(`${label} metrics are missing before wheel`)
+  }
+
+  const overflowContract = await target.evaluate((element) => {
+    const style = window.getComputedStyle(element as HTMLElement)
+    return {
+      overscrollY: (style as CSSStyleDeclaration & { overscrollBehaviorY?: string }).overscrollBehaviorY || "",
+      touchAction: style.touchAction,
+    }
+  })
+  expect(overflowContract.overscrollY || "auto").toBe("auto")
+  expect(overflowContract.touchAction === "auto" || overflowContract.touchAction.includes("pan-y")).toBe(true)
+
+  await page.mouse.move(box.x + Math.min(box.width / 2, 120), box.y + Math.min(box.height / 2, 40))
+
+  const beforeScrollTop = await readDocumentScrollTop(page)
+  await page.mouse.wheel(0, 420)
+
+  await expect.poll(() => readDocumentScrollTop(page)).toBeGreaterThan(beforeScrollTop + 80)
+}
+
+const expectLiveEditorHoverWheelScrollChain = async (page: Page, blockEditor: Locator) => {
+  await ensureLiveHoverWheelFixture(page, blockEditor)
+  await expectHoverWheelChainsToPageScroll(
+    page,
+    page.locator("[data-code-block-wrapper='true']").first(),
+    "live code block"
+  )
+  await expectHoverWheelChainsToPageScroll(
+    page,
+    page.locator(".aq-block-editor__content .tableWrapper").first(),
+    "live table wrapper"
+  )
 }
 
 type LoginPayloadCandidate = {
@@ -580,7 +673,8 @@ test.describe("live production e2e", () => {
     } else {
       await expect(legacyTitleInput).toBeVisible()
     }
-    await appendTextToBlockEditor(page, "라이브 E2E 편집 확인")
+    const blockEditor = await appendTextToBlockEditor(page, "라이브 E2E 편집 확인")
+    await expectLiveEditorHoverWheelScrollChain(page, blockEditor)
 
     await page.getByRole("button", { name: "Logout", exact: true }).click()
     await expect(page).toHaveURL(/\/login/)

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
     "test:e2e:authoring": "yarn playwright:preflight && env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn playwright test e2e/editor-authoring-flow.spec.ts --workers=1",
     "test:e2e:perf": "yarn playwright:preflight && node scripts/run-playwright-perf.mjs",
     "test:e2e:a11y": "yarn playwright:preflight && env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn playwright test e2e/accessibility.spec.ts",
-    "test:e2e:live": "yarn playwright:preflight && env -u NO_COLOR PLAYWRIGHT_LIVE_MULTI_BROWSER=true yarn playwright test e2e/live.spec.ts --workers=1",
+    "test:e2e:live": "yarn playwright:preflight && node scripts/run-live-e2e.mjs",
     "storybook": "HOME=$PWD/.storybook-home CI=1 STORYBOOK_DISABLE_TELEMETRY=1 STORYBOOK_DISABLE_UPDATE_CHECK=1 storybook dev -p 6006",
     "storybook:build:raw": "HOME=$PWD/.storybook-home CI=1 STORYBOOK_DISABLE_TELEMETRY=1 STORYBOOK_DISABLE_UPDATE_CHECK=1 storybook build",
     "storybook:build": "yarn storybook:build:raw",

--- a/front/scripts/run-live-e2e.mjs
+++ b/front/scripts/run-live-e2e.mjs
@@ -1,0 +1,108 @@
+import { spawn } from "node:child_process"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import nextEnv from "@next/env"
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const frontRoot = path.resolve(scriptDir, "..")
+const { loadEnvConfig } = nextEnv
+const credentialKeys = [
+  "E2E_ADMIN_EMAIL",
+  "E2E_ADMIN_USERNAME",
+  "E2E_ADMIN_PASSWORD",
+  "E2E_LIVE_ADMIN_EMAIL",
+  "E2E_LIVE_ADMIN_USERNAME",
+  "E2E_LIVE_ADMIN_PASSWORD",
+]
+const initialCredentialEnv = Object.fromEntries(credentialKeys.map((key) => [key, process.env[key]]))
+
+const mutedEnvLog = {
+  info: () => {},
+  error: (message, error) => {
+    console.error(`[live-e2e] ${message}`, error)
+  },
+}
+
+const { loadedEnvFiles } = loadEnvConfig(frontRoot, true, mutedEnvLog, true)
+
+// E2E passwords often contain dotenv comment/interpolation characters, so preserve local literals.
+const stripOptionalQuotes = (value) => {
+  const trimmed = value.trim()
+  const quote = trimmed[0]
+  if ((quote === "\"" || quote === "'" || quote === "`") && trimmed.endsWith(quote)) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+const literalCredentialEnv = new Map()
+for (const envFile of loadedEnvFiles) {
+  for (const line of envFile.contents.split(/\r?\n/)) {
+    const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/)
+    if (!match) continue
+    const [, key, value] = match
+    if (!credentialKeys.includes(key) || literalCredentialEnv.has(key)) continue
+    literalCredentialEnv.set(key, stripOptionalQuotes(value))
+  }
+}
+
+for (const [key, value] of literalCredentialEnv.entries()) {
+  if (!initialCredentialEnv[key]?.trim()) {
+    process.env[key] = value
+  }
+}
+
+const applyFallbackEnv = (target, source) => {
+  const targetValue = process.env[target]?.trim()
+  const sourceValue = process.env[source]?.trim()
+  if (!targetValue && sourceValue) {
+    process.env[target] = sourceValue
+  }
+}
+
+applyFallbackEnv("E2E_ADMIN_EMAIL", "E2E_LIVE_ADMIN_EMAIL")
+applyFallbackEnv("E2E_ADMIN_USERNAME", "E2E_LIVE_ADMIN_USERNAME")
+applyFallbackEnv("E2E_ADMIN_PASSWORD", "E2E_LIVE_ADMIN_PASSWORD")
+
+const loadedEnvFileNames = loadedEnvFiles.map((envFile) => envFile.path).join(", ")
+if (loadedEnvFileNames) {
+  console.log(`[live-e2e] loaded env files: ${loadedEnvFileNames}`)
+}
+
+const hasLiveCredentials = Boolean(
+  (process.env.E2E_ADMIN_EMAIL?.trim() || process.env.E2E_ADMIN_USERNAME?.trim()) &&
+    process.env.E2E_ADMIN_PASSWORD?.trim()
+)
+
+if (!hasLiveCredentials) {
+  console.warn(
+    "[live-e2e] credentials missing: set E2E_ADMIN_EMAIL or E2E_ADMIN_USERNAME and E2E_ADMIN_PASSWORD in front/.env.local or shell; credentialed tests will skip."
+  )
+}
+
+const childEnv = {
+  ...process.env,
+  PLAYWRIGHT_LIVE_MULTI_BROWSER: process.env.PLAYWRIGHT_LIVE_MULTI_BROWSER || "true",
+  PLAYWRIGHT_USE_WEBSERVER: process.env.PLAYWRIGHT_USE_WEBSERVER || "false",
+}
+
+delete childEnv.NO_COLOR
+
+const child = spawn("yarn", ["playwright", "test", "e2e/live.spec.ts", "--workers=1", ...process.argv.slice(2)], {
+  cwd: frontRoot,
+  stdio: "inherit",
+  env: childEnv,
+})
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal)
+    return
+  }
+  process.exit(code ?? 1)
+})
+
+child.on("error", (error) => {
+  console.error(`[live-e2e] ${error instanceof Error ? error.message : String(error)}`)
+  process.exit(1)
+})


### PR DESCRIPTION
## 관련 이슈

close #119

## 작업 배경

- live production E2E가 `/editor/new`에서 코드블럭과 테이블 hover wheel 입력 후 page scroll chain 유지를 직접 검증합니다.
- `test:e2e:live`가 `front/.env.local`과 `E2E_LIVE_ADMIN_*` fallback을 로드하고, credential 값의 dotenv comment/interpolation 파싱 손실을 막습니다.
- main merge 후 홈서버 자동 배포 workflow에서 같은 live E2E 경로가 다시 실행됩니다.

## 작업 내용

- live E2E의 관리자 핵심 운영 경로에 코드블럭/테이블 hover wheel scroll-chain assertion을 추가했습니다.
- `front/scripts/run-live-e2e.mjs`를 추가해 로컬 live credentials 로딩, live multi-browser 기본값, webServer 비활성 기본값을 한 곳에서 관리합니다.
- `yarn --cwd front test:e2e:live`가 새 runner를 사용하도록 package script를 연결했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:live` (1차: `.env.local` 로드 후 password dotenv literal 손실로 401 확인, runner 수정 후 재실행 통과)
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `git diff --check -- front/e2e/live.spec.ts front/package.json front/scripts/run-live-e2e.mjs`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: live E2E가 실제 관리자 계정과 운영 URL에 의존하므로 secret 값이 바뀌면 credentialed test가 실패합니다.
- 롤백 방법: 이 PR의 commit을 revert하면 live hover-wheel assertion과 local live runner 연결이 제거됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
