### PR TITLE
[Refactor] editor selection drag model 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -131,6 +131,10 @@ test.describe("editor studio state", () => {
     const editorStudioSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/EditorStudioPage.tsx"), "utf8")
     const blockEditorShellSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorShell.tsx"), "utf8")
     const blockEditorEngineSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tsx"), "utf8")
+    const blockSelectionModelSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/blockSelectionModel.ts"),
+      "utf8"
+    )
     const writerEditorHostSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/WriterEditorHost.tsx"), "utf8")
 
     expect(editorStudioSource).not.toContain("BLOCK_EDITOR_V2_ENABLED")
@@ -173,6 +177,12 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).toContain(".aq-block-editor__content blockquote {")
     expect(blockEditorEngineSource).toContain("border-left: 4px solid")
     expect(blockEditorEngineSource).toContain("border-radius: 0;")
+    expect(blockEditorEngineSource).toContain('from "./blockSelectionModel"')
+    expect(blockEditorEngineSource).not.toMatch(/const\s+isStableBlockHandleState\s*=/)
+    expect(blockEditorEngineSource).not.toMatch(/const\s+isStableBlockSelectionOverlayState\s*=/)
+    expect(blockEditorEngineSource).not.toMatch(/const\s+resolveOuterBlockSelectionGesture\s*=/)
+    expect(blockSelectionModelSource).toContain("export const resolveOuterBlockSelectionGesture")
+    expect(blockSelectionModelSource).toContain("export const resolveOuterListItemSelectionGesture")
     const selectionRuleMatch = blockEditorEngineSource.match(/\.aq-block-editor__content ::selection\s*\{([^}]*)\}/)
     expect(selectionRuleMatch?.[1]).toBeTruthy()
     expect(selectionRuleMatch?.[1]).not.toMatch(/\bcolor\s*:/)

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -137,6 +137,18 @@ import {
   resolveActiveRenderedTableForFloatingUi,
   resolveTableScopedSelectedCell,
 } from "./tableRenderedDomModel"
+import {
+  BLOCK_OUTER_SELECT_LEFT_GUTTER_PX,
+  BLOCK_OUTER_SELECT_LEFT_EDGE_GAP_PX,
+  BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX,
+  isStableBlockHandleState,
+  isStableBlockSelectionOverlayState,
+  resolveOuterBlockSelectionGesture,
+  resolveOuterListItemSelectionGesture,
+  type BlockSelectionOverlayState,
+  type BlockSelectionPointerEventLike,
+  type TopLevelBlockHandleState,
+} from "./blockSelectionModel"
 
 type RuntimeGuardWindow = Window & {
   __AQ_RUNTIME_GUARD_ENABLED__?: boolean
@@ -196,26 +208,6 @@ type TableOverflowCoachmarkState = {
   visible: boolean
   left: number
   top: number
-}
-
-type TopLevelBlockHandleState = {
-  visible: boolean
-  kind: "top-level" | "list-item"
-  blockIndex: number
-  listPath: number[]
-  itemIndex: number | null
-  left: number
-  top: number
-  bottom: number
-  width: number
-}
-
-type BlockSelectionOverlayState = {
-  visible: boolean
-  left: number
-  top: number
-  width: number
-  height: number
 }
 
 type PendingBlockDragState = {
@@ -342,18 +334,6 @@ type TableAxisReorderIndicatorState = {
   top: number
   width: number
   height: number
-}
-
-type BlockSelectionPointerEventLike = {
-  button: number
-  detail: number
-  clientX: number
-  clientY: number
-  target: EventTarget | null
-  metaKey?: boolean
-  ctrlKey?: boolean
-  altKey?: boolean
-  shiftKey?: boolean
 }
 
 const normalizeSlashSearchText = (value: string) => value.trim().toLowerCase()
@@ -700,13 +680,9 @@ type TableColumnDragGuideState = {
 const BLOCK_HANDLE_MEDIA_QUERY = "(pointer: coarse)"
 const DESKTOP_TABLE_RAIL_MEDIA_QUERY = "(max-width: 768px)"
 const DEFAULT_EDITOR_READABLE_WIDTH_PX = 48 * 16
-const BLOCK_HANDLE_POSITION_EPSILON_PX = 0.4
 const BLOCK_HANDLE_VIEWPORT_PADDING_PX = 12
 const BLOCK_HANDLE_GUTTER_GAP_PX = 10
 const BLOCK_HANDLE_STACKED_GAP_PX = 8
-const BLOCK_OUTER_SELECT_LEFT_GUTTER_PX = 76
-const BLOCK_OUTER_SELECT_LEFT_EDGE_GAP_PX = 2
-const BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX = 10
 const TABLE_ROW_RESIZE_EDGE_PX = 6
 const TABLE_COLUMN_RESIZE_GUARD_PX = 12
 const TABLE_RAIL_EDGE_PADDING_PX = 12
@@ -1074,33 +1050,6 @@ const resolveBlockHandleRailLayout = (
     top: Math.max(BLOCK_HANDLE_VIEWPORT_PADDING_PX, rect.top - railHeight - BLOCK_HANDLE_STACKED_GAP_PX),
   }
 }
-
-const isWithinBlockHandleEpsilon = (prev: number, next: number) =>
-  Math.abs(prev - next) <= BLOCK_HANDLE_POSITION_EPSILON_PX
-
-const isStableBlockHandleState = (
-  prev: TopLevelBlockHandleState,
-  next: TopLevelBlockHandleState
-) =>
-  prev.visible === next.visible &&
-  prev.kind === next.kind &&
-  prev.blockIndex === next.blockIndex &&
-  prev.itemIndex === next.itemIndex &&
-  sameListPath(prev.listPath, next.listPath) &&
-  isWithinBlockHandleEpsilon(prev.left, next.left) &&
-  isWithinBlockHandleEpsilon(prev.top, next.top) &&
-  isWithinBlockHandleEpsilon(prev.bottom, next.bottom) &&
-  isWithinBlockHandleEpsilon(prev.width, next.width)
-
-const isStableBlockSelectionOverlayState = (
-  prev: BlockSelectionOverlayState,
-  next: BlockSelectionOverlayState
-) =>
-  prev.visible === next.visible &&
-  isWithinBlockHandleEpsilon(prev.left, next.left) &&
-  isWithinBlockHandleEpsilon(prev.top, next.top) &&
-  isWithinBlockHandleEpsilon(prev.width, next.width) &&
-  isWithinBlockHandleEpsilon(prev.height, next.height)
 
 const shouldCenterBlockHandleForNode = (node?: BlockEditorDoc | null) =>
   Boolean(
@@ -2681,75 +2630,15 @@ const BlockEditorEngine = ({
 
   const isOuterBlockSelectionGesture = useCallback(
     (event: BlockSelectionPointerEventLike, targetBlockIndex: number | null) => {
-      if (targetBlockIndex === null) return false
-      if (event.button !== 0) return false
-      if (event.detail < 2) return false
-      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return false
-
-      const targetElement =
-        event.target instanceof Element
-          ? event.target
-          : event.target instanceof Node
-            ? event.target.parentElement
-            : null
-      const blockElement = getTopLevelBlockElementByIndex(targetBlockIndex)
-      if (!blockElement) return false
-      const rect = blockElement.getBoundingClientRect()
-      const clickedTableAxisRail = targetElement?.closest("[data-table-axis-rail='true']")
-      if (
-        targetElement?.closest("[data-block-handle-rail='true'] button") ||
-        targetElement?.closest("[data-block-menu-root='true']") ||
-        targetElement?.closest("[data-table-menu-root='true']") ||
-        clickedTableAxisRail ||
-        targetElement?.closest("[data-table-corner-handle='true']") ||
-        targetElement?.closest("[data-table-menu-trigger='true']")
-      ) {
-        return false
-      }
-      const withinVerticalRange =
-        event.clientY >= rect.top - BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX &&
-        event.clientY <= rect.bottom + BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX
-      if (!withinVerticalRange) return false
-
-      return (
-        event.clientX >= rect.left - BLOCK_OUTER_SELECT_LEFT_GUTTER_PX &&
-        event.clientX <= rect.left - BLOCK_OUTER_SELECT_LEFT_EDGE_GAP_PX
-      )
+      const blockElement = targetBlockIndex !== null ? getTopLevelBlockElementByIndex(targetBlockIndex) : null
+      return resolveOuterBlockSelectionGesture(event, blockElement)
     },
     [getTopLevelBlockElementByIndex]
   )
 
   const isOuterListItemSelectionGesture = useCallback(
     (event: BlockSelectionPointerEventLike, targetListItem: NestedListItemContext | null) => {
-      if (!targetListItem) return false
-      if (event.button !== 0) return false
-      if (event.detail < 2) return false
-      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return false
-
-      const targetElement =
-        event.target instanceof Element
-          ? event.target
-          : event.target instanceof Node
-            ? event.target.parentElement
-            : null
-      if (
-        targetElement?.closest("[data-block-handle-rail='true'] button") ||
-        targetElement?.closest("[data-block-menu-root='true']") ||
-        targetElement?.closest("[data-table-menu-root='true']")
-      ) {
-        return false
-      }
-
-      const rect = targetListItem.listItemElement.getBoundingClientRect()
-      const withinVerticalRange =
-        event.clientY >= rect.top - BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX &&
-        event.clientY <= rect.bottom + BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX
-      if (!withinVerticalRange) return false
-
-      return (
-        event.clientX >= rect.left - BLOCK_OUTER_SELECT_LEFT_GUTTER_PX &&
-        event.clientX <= rect.left - BLOCK_OUTER_SELECT_LEFT_EDGE_GAP_PX
-      )
+      return resolveOuterListItemSelectionGesture(event, targetListItem?.listItemElement ?? null)
     },
     []
   )

--- a/front/src/components/editor/blockSelectionModel.ts
+++ b/front/src/components/editor/blockSelectionModel.ts
@@ -1,0 +1,137 @@
+export type TopLevelBlockHandleState = {
+  visible: boolean
+  kind: "top-level" | "list-item"
+  blockIndex: number
+  listPath: number[]
+  itemIndex: number | null
+  left: number
+  top: number
+  bottom: number
+  width: number
+}
+
+export type BlockSelectionOverlayState = {
+  visible: boolean
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+export type BlockSelectionPointerEventLike = {
+  button: number
+  detail: number
+  clientX: number
+  clientY: number
+  target: EventTarget | null
+  metaKey?: boolean
+  ctrlKey?: boolean
+  altKey?: boolean
+  shiftKey?: boolean
+}
+
+type BlockSelectionRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">
+
+export const BLOCK_HANDLE_POSITION_EPSILON_PX = 0.4
+export const BLOCK_OUTER_SELECT_LEFT_GUTTER_PX = 76
+export const BLOCK_OUTER_SELECT_LEFT_EDGE_GAP_PX = 2
+export const BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX = 10
+
+const sameListPath = (left: number[], right: number[]) =>
+  left.length === right.length && left.every((value, index) => value === right[index])
+
+const isWithinBlockHandleEpsilon = (prev: number, next: number) =>
+  Math.abs(prev - next) <= BLOCK_HANDLE_POSITION_EPSILON_PX
+
+export const isStableBlockHandleState = (
+  prev: TopLevelBlockHandleState,
+  next: TopLevelBlockHandleState
+) =>
+  prev.visible === next.visible &&
+  prev.kind === next.kind &&
+  prev.blockIndex === next.blockIndex &&
+  prev.itemIndex === next.itemIndex &&
+  sameListPath(prev.listPath, next.listPath) &&
+  isWithinBlockHandleEpsilon(prev.left, next.left) &&
+  isWithinBlockHandleEpsilon(prev.top, next.top) &&
+  isWithinBlockHandleEpsilon(prev.bottom, next.bottom) &&
+  isWithinBlockHandleEpsilon(prev.width, next.width)
+
+export const isStableBlockSelectionOverlayState = (
+  prev: BlockSelectionOverlayState,
+  next: BlockSelectionOverlayState
+) =>
+  prev.visible === next.visible &&
+  isWithinBlockHandleEpsilon(prev.left, next.left) &&
+  isWithinBlockHandleEpsilon(prev.top, next.top) &&
+  isWithinBlockHandleEpsilon(prev.width, next.width) &&
+  isWithinBlockHandleEpsilon(prev.height, next.height)
+
+const isSelectionPointerGesture = (event: BlockSelectionPointerEventLike) =>
+  event.button === 0 &&
+  event.detail >= 2 &&
+  !event.metaKey &&
+  !event.ctrlKey &&
+  !event.altKey &&
+  !event.shiftKey
+
+const getEventTargetElement = (target: EventTarget | null) =>
+  target instanceof Element ? target : target instanceof Node ? target.parentElement : null
+
+const hasClosestTarget = (target: Element | null, selectors: string[]) =>
+  Boolean(target && selectors.some((selector) => target.closest(selector)))
+
+const isOuterSelectionHit = (event: BlockSelectionPointerEventLike, rect: BlockSelectionRect) => {
+  const withinVerticalRange =
+    event.clientY >= rect.top - BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX &&
+    event.clientY <= rect.bottom + BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX
+  if (!withinVerticalRange) return false
+
+  return (
+    event.clientX >= rect.left - BLOCK_OUTER_SELECT_LEFT_GUTTER_PX &&
+    event.clientX <= rect.left - BLOCK_OUTER_SELECT_LEFT_EDGE_GAP_PX
+  )
+}
+
+export const resolveOuterBlockSelectionGesture = (
+  event: BlockSelectionPointerEventLike,
+  blockElement: HTMLElement | null
+) => {
+  if (!blockElement || !isSelectionPointerGesture(event)) return false
+
+  const targetElement = getEventTargetElement(event.target)
+  if (
+    hasClosestTarget(targetElement, [
+      "[data-block-handle-rail='true'] button",
+      "[data-block-menu-root='true']",
+      "[data-table-menu-root='true']",
+      "[data-table-axis-rail='true']",
+      "[data-table-corner-handle='true']",
+      "[data-table-menu-trigger='true']",
+    ])
+  ) {
+    return false
+  }
+
+  return isOuterSelectionHit(event, blockElement.getBoundingClientRect())
+}
+
+export const resolveOuterListItemSelectionGesture = (
+  event: BlockSelectionPointerEventLike,
+  listItemElement: HTMLElement | null
+) => {
+  if (!listItemElement || !isSelectionPointerGesture(event)) return false
+
+  const targetElement = getEventTargetElement(event.target)
+  if (
+    hasClosestTarget(targetElement, [
+      "[data-block-handle-rail='true'] button",
+      "[data-block-menu-root='true']",
+      "[data-table-menu-root='true']",
+    ])
+  ) {
+    return false
+  }
+
+  return isOuterSelectionHit(event, listItemElement.getBoundingClientRect())
+}


### PR DESCRIPTION
## 관련 이슈

close #121

## 작업 배경

- `BlockEditorEngine.tsx` 내부의 top-level block handle/selection overlay 안정성 비교와 outer selection gesture 판정을 `blockSelectionModel.ts` pure model로 분리했습니다.
- source guard를 추가해 selection/drag helper 소유권이 다시 엔진 대형 파일 안으로 돌아가지 않도록 고정했습니다.
- 작업 브랜치가 `main`으로 merge되면 기존 CI 후 홈서버 자동 배포 경로를 그대로 탑니다.

## 작업 내용

- `front/src/components/editor/blockSelectionModel.ts`를 추가해 block handle state equality, selection overlay equality, outer block/list item selection hit-test를 소유하게 했습니다.
- `front/src/components/editor/BlockEditorEngine.tsx`는 DOM 조회와 React state 연결만 유지하고 pure 판정은 model helper import로 위임합니다.
- `front/e2e/editor-studio-state.spec.ts`에 `blockSelectionModel` 소유권 source guard를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (RED: `blockSelectionModel.ts` 부재 확인 후, GREEN 2회 연속 통과)
  - `yarn --cwd front test:e2e:authoring` (2회 연속 통과)
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front build` (2회 연속 통과)
  - `git diff --check -- front/src/components/editor/BlockEditorEngine.tsx front/src/components/editor/blockSelectionModel.ts front/e2e/editor-studio-state.spec.ts`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: selection/drag helper 이동 과정에서 outer gutter double-click 또는 list item drag affordance 판정이 달라질 수 있습니다.
- 롤백 방법: 이 PR의 commit을 revert하면 helper가 기존 엔진 내부 구현으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
