### PR TITLE
[Refactor] frontend import 방향 가드 확장

### DIFF
--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -16,6 +16,54 @@
           }
         ]
       }
+    },
+    {
+      "files": ["src/libs/**/*.{ts,tsx}"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["src/routes/**", "src/pages/**"],
+                "message": "Shared lib modules must not import UI route or page layers. Move shared helpers to src/libs or src/constants."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": ["src/components/**/*.{ts,tsx}"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["src/routes/**", "src/pages/**"],
+                "message": "Reusable components must not import route or page layers. Pass data/actions in from routes or move shared helpers to src/libs."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": ["src/routes/**/*.{ts,tsx}"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["src/pages/**"],
+                "message": "Route modules must not import Next.js page entrypoints. Keep page wiring in src/pages and shared helpers in src/libs."
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/front/e2e/import-boundary.spec.ts
+++ b/front/e2e/import-boundary.spec.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { expect, test } from "@playwright/test"
+
+type RestrictedImportPattern = {
+  group?: string[]
+}
+
+type RestrictedImportRule = [
+  "error",
+  {
+    patterns?: RestrictedImportPattern[]
+  }
+]
+
+type EslintOverride = {
+  files?: string[]
+  rules?: {
+    "no-restricted-imports"?: RestrictedImportRule
+  }
+}
+
+const readEslintOverrides = (): EslintOverride[] => {
+  const eslintConfig = JSON.parse(readFileSync(path.resolve(__dirname, "../.eslintrc.json"), "utf8")) as {
+    overrides?: EslintOverride[]
+  }
+
+  return eslintConfig.overrides ?? []
+}
+
+const restrictedImportGroupsFor = (filePattern: string): string[] => {
+  const override = readEslintOverrides().find((candidate) => candidate.files?.includes(filePattern))
+  const restrictedImportRule = override?.rules?.["no-restricted-imports"]
+
+  return restrictedImportRule?.[1].patterns?.flatMap((pattern) => pattern.group ?? []) ?? []
+}
+
+test.describe("frontend import boundary", () => {
+  test("lower layers cannot import route or page UI layers", () => {
+    expect(restrictedImportGroupsFor("src/apis/**/*.{ts,tsx}")).toEqual(
+      expect.arrayContaining(["src/routes/**", "src/components/**", "src/pages/**"])
+    )
+    expect(restrictedImportGroupsFor("src/libs/**/*.{ts,tsx}")).toEqual(
+      expect.arrayContaining(["src/routes/**", "src/pages/**"])
+    )
+    expect(restrictedImportGroupsFor("src/components/**/*.{ts,tsx}")).toEqual(
+      expect.arrayContaining(["src/routes/**", "src/pages/**"])
+    )
+    expect(restrictedImportGroupsFor("src/routes/**/*.{ts,tsx}")).toEqual(expect.arrayContaining(["src/pages/**"]))
+  })
+})


### PR DESCRIPTION
## 관련 이슈

close #123

## 작업 배경

- 프론트 import boundary를 apis 단일 가드에서 libs/components/routes까지 확장했습니다.
- 현재 코드가 이미 만족하는 방향만 ESLint로 잠가, 이후 lower layer가 route/page entrypoint를 역참조하는 회귀를 PR 단계에서 차단합니다.

## 작업 내용

- `front/.eslintrc.json`에 libs/components/routes 전용 `no-restricted-imports` override를 추가했습니다.
- `front/e2e/import-boundary.spec.ts`로 ESLint boundary 계약을 source guard 테스트로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - RED: `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/import-boundary.spec.ts --workers=1` failed on missing libs override
  - GREEN 1: `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/import-boundary.spec.ts --workers=1`
  - GREEN 2: `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/import-boundary.spec.ts --workers=1`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front lint` 2회
  - `yarn --cwd front build` 2회

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 향후 기존 방향을 어기는 import를 추가하면 lint가 실패합니다. 이번 PR 기준 현재 코드는 전체 lint를 통과했습니다.
- 롤백 방법: 이 커밋을 revert하면 ESLint override와 import boundary spec이 함께 제거됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
