### PR TITLE
[Chore] frontend legacy 메타데이터 정리

### DIFF
--- a/front/e2e/legacy-boundary.spec.ts
+++ b/front/e2e/legacy-boundary.spec.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { expect, test } from "@playwright/test"
+
+const readFrontText = (relativePath: string): string => readFileSync(path.resolve(__dirname, "..", relativePath), "utf8")
+
+test.describe("frontend legacy boundary", () => {
+  test("package identity does not point to the upstream template project", () => {
+    const packageJson = JSON.parse(readFrontText("package.json")) as {
+      name?: string
+      repository?: {
+        url?: string
+      }
+    }
+
+    expect(packageJson.name).toBe("aquila-blog")
+    expect(packageJson.repository?.url).toBe("https://github.com/AquilaXk/aquila-blog.git")
+    expect(JSON.stringify(packageJson)).not.toContain("morethan-log")
+    expect(JSON.stringify(packageJson)).not.toContain("morethanmin")
+  })
+
+  test("legacy post routes stay redirect or SSR 404 only", () => {
+    const legacySlugRoute = readFrontText("src/pages/[slug].tsx")
+    const legacyPageRoute = readFrontText("src/pages/page/[pageId].tsx")
+
+    expect(legacySlugRoute).toContain("export const getServerSideProps")
+    expect(legacySlugRoute).toContain("extractPostIdFromLegacySlug")
+    expect(legacySlugRoute).toContain("toCanonicalPostPath(post.id)")
+    expect(legacySlugRoute).toContain("permanent: true")
+    expect(legacySlugRoute).toContain("const LegacyPostRedirectPage = () => null")
+    expect(legacySlugRoute).not.toContain("getStaticProps")
+    expect(legacySlugRoute).not.toContain("MarkdownRenderer")
+
+    expect(legacyPageRoute).toContain("export const getServerSideProps")
+    expect(legacyPageRoute).toContain("toCanonicalPostPath(post.id)")
+    expect(legacyPageRoute).toContain("permanent: true")
+    expect(legacyPageRoute).toContain("res.statusCode = 404")
+    expect(legacyPageRoute).toContain("<CustomError />")
+    expect(legacyPageRoute).not.toContain("getStaticProps")
+    expect(legacyPageRoute).not.toContain("MarkdownRenderer")
+  })
+})

--- a/front/package.json
+++ b/front/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "morethan-log",
+  "name": "aquila-blog",
   "version": "1.3.0",
   "private": true,
   "packageManager": "yarn@1.22.22",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/morethanmin/morethan-log.git"
+    "url": "https://github.com/AquilaXk/aquila-blog.git"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## 관련 이슈

close #127

## 작업 배경

- `front/package.json`에 남아 있던 upstream template identity(`morethan-log`, `morethanmin`)를 현재 저장소 기준으로 정리했습니다.
- legacy `/:slug`, `/page/[pageId]` route는 삭제하지 않고, canonical redirect 또는 SSR 404 전용 계약을 source guard로 고정했습니다.

## 작업 내용

- `front/package.json` name/repository를 `aquila-blog` / `AquilaXk/aquila-blog`로 변경했습니다.
- `front/e2e/legacy-boundary.spec.ts`를 추가해 package identity와 legacy route 계약을 검증합니다.

## 검증

- 실행한 명령과 결과:
  - RED: `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/legacy-boundary.spec.ts --workers=1` failed on `morethan-log` package name
  - GREEN 1: `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/legacy-boundary.spec.ts --workers=1`
  - GREEN 2: `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/legacy-boundary.spec.ts --workers=1`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front lint` 2회
  - `yarn --cwd front build` 2회

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: package metadata만 변경하므로 runtime risk는 낮습니다. legacy route 구현은 수정하지 않았고 source guard로 현 계약만 고정했습니다.
- 롤백 방법: 이 커밋을 revert하면 package metadata와 legacy-boundary source guard가 함께 원복됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
