### PR TITLE
[Refactor] admin profile legacy bridge 분리

### DIFF
--- a/front/e2e/admin-profile-state.spec.ts
+++ b/front/e2e/admin-profile-state.spec.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs"
 import path from "node:path"
 import { expect, test } from "@playwright/test"
-import { normalizeProfileWorkspaceContent } from "src/libs/profileWorkspace"
+import { buildProfileWorkspaceAdminProfileCacheFields, normalizeProfileWorkspaceContent } from "src/libs/profileWorkspace"
 
 test.describe("admin profile state contract", () => {
   test("profile 작업공간은 공통 section nav/action dock primitive 위에서 반응형 분기를 유지한다", () => {
@@ -61,12 +61,9 @@ test.describe("admin profile state contract", () => {
     const aboutSource = readFileSync(path.resolve(__dirname, "../src/pages/about.tsx"), "utf8")
 
     expect(profileSource).toContain("syncPublishedAdminProfileCache(normalizeProfileWorkspaceContent(nextWorkspace.published))")
-    expect(profileSource).toContain("aboutHeadline: content.aboutHeadline")
-    expect(profileSource).toContain("aboutRole: content.aboutRole")
-    expect(profileSource).toContain("aboutBio: content.aboutBio")
-    expect(profileSource).toContain("aboutSections: content.aboutSections")
-    expect(profileSource).toContain("aboutProjectSectionTitle: content.aboutProjectSectionTitle")
-    expect(profileSource).toContain("aboutProjects: content.aboutProjects")
+    expect(profileSource).toContain("...buildProfileWorkspaceAdminProfileCacheFields(content)")
+    expect(profileSource).not.toContain("buildLegacyAboutDetails")
+    expect(profileSource).not.toContain("aboutDetails:")
     expect(aboutSource).toContain("const displayHeadline = adminProfile?.aboutHeadline || DEFAULT_ABOUT_HEADLINE")
     expect(aboutSource).toContain("const displayRole = adminProfile?.aboutRole || CONFIG.profile.role")
     expect(aboutSource).toContain("const displayBio = adminProfile?.aboutBio || CONFIG.profile.bio")
@@ -74,6 +71,50 @@ test.describe("admin profile state contract", () => {
     expect(aboutSource).toContain("adminProfile?.aboutProjects && adminProfile.aboutProjects.length > 0")
     expect(aboutSource).not.toContain("PROJECT_PRESETS")
     expect(aboutSource).not.toContain("대표 글 보기")
+  })
+
+  test("profile workspace legacy cache bridge는 structured about 필드와 aboutDetails를 함께 만든다", () => {
+    const bridge = buildProfileWorkspaceAdminProfileCacheFields({
+      profileImageUrl: "/profile.png",
+      profileRole: "Backend",
+      profileBio: "운영 가능한 시스템을 설계합니다.",
+      aboutHeadline: "이유를 먼저 따집니다.",
+      aboutRole: "Full-stack",
+      aboutBio: "문제와 운영을 같이 봅니다.",
+      aboutSections: [
+        {
+          id: "career",
+          title: "경력",
+          items: ["2026.03 Aquila Blog 운영"],
+          dividerBefore: false,
+        },
+      ],
+      aboutProjectSectionTitle: "프로젝트",
+      aboutProjects: [
+        {
+          id: "blog",
+          name: "aquila-blog",
+          summary: "관리자에서 직접 수정하는 프로젝트",
+          role: "Full-stack",
+          href: "https://github.com/AquilaXk/aquila-blog",
+          linkLabel: "GitHub",
+        },
+      ],
+      blogTitle: "AquilaLog",
+      homeIntroTitle: "비밀스러운 IT 공작소",
+      homeIntroDescription: "비밀스러운 지식들을 탐구하는데 목적을 두고 있습니다",
+      serviceLinks: [],
+      contactLinks: [],
+    })
+
+    expect(bridge.profileImageUrl).toBe("/profile.png")
+    expect(bridge.profileImageDirectUrl).toBe("/profile.png")
+    expect(bridge.aboutHeadline).toBe("이유를 먼저 따집니다.")
+    expect(bridge.aboutSections.map((section) => section.title)).toEqual(["경력"])
+    expect(bridge.aboutProjectSectionTitle).toBe("프로젝트")
+    expect(bridge.aboutProjects.map((project) => project.name)).toEqual(["aquila-blog"])
+    expect(bridge.aboutDetails).toContain("## 경력")
+    expect(bridge.aboutDetails).toContain("- 2026.03 Aquila Blog 운영")
   })
 
   test("profile workspace 정규화는 structured 프로젝트가 있으면 legacy 프로젝트 상세 블록을 제거한다", () => {

--- a/front/src/libs/profileWorkspace.ts
+++ b/front/src/libs/profileWorkspace.ts
@@ -314,6 +314,29 @@ export const normalizeProfileWorkspaceContent = (
 export const serializeProfileWorkspaceContent = (content: ProfileWorkspaceContent) =>
   JSON.stringify(normalizeProfileWorkspaceContent(content))
 
+export const buildProfileWorkspaceAdminProfileCacheFields = (content: ProfileWorkspaceContent) => {
+  const normalized = normalizeProfileWorkspaceContent(content)
+
+  return {
+    profileImageUrl: normalized.profileImageUrl,
+    profileImageDirectUrl: normalized.profileImageUrl,
+    profileRole: normalized.profileRole,
+    profileBio: normalized.profileBio,
+    aboutHeadline: normalized.aboutHeadline,
+    aboutRole: normalized.aboutRole,
+    aboutBio: normalized.aboutBio,
+    aboutDetails: buildLegacyAboutDetails(normalized.aboutSections),
+    aboutSections: normalized.aboutSections,
+    aboutProjectSectionTitle: normalized.aboutProjectSectionTitle,
+    aboutProjects: normalized.aboutProjects,
+    blogTitle: normalized.blogTitle,
+    homeIntroTitle: normalized.homeIntroTitle,
+    homeIntroDescription: normalized.homeIntroDescription,
+    serviceLinks: normalized.serviceLinks,
+    contactLinks: normalized.contactLinks,
+  }
+}
+
 export const buildProfileWorkspaceFromLegacy = (
   value: LegacyProfileLike | null | undefined
 ): ProfileWorkspaceContent =>

--- a/front/src/pages/admin/profile.tsx
+++ b/front/src/pages/admin/profile.tsx
@@ -21,7 +21,7 @@ import { setAdminProfileCache, toAdminProfile } from "src/hooks/useAdminProfile"
 import { setProfileWorkspaceCache, useProfileWorkspace } from "src/hooks/useProfileWorkspace"
 import useViewportImageEditor from "src/libs/imageEditor/useViewportImageEditor"
 import {
-  buildLegacyAboutDetails,
+  buildProfileWorkspaceAdminProfileCacheFields,
   buildProfileWorkspaceFromLegacy,
   AboutProjectBlock,
   normalizeProfileWorkspaceContent,
@@ -461,22 +461,7 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
           username: owner.username,
           name: owner.nickname || owner.username,
           nickname: owner.nickname || owner.username,
-          profileImageUrl: content.profileImageUrl,
-          profileImageDirectUrl: content.profileImageUrl,
-          profileRole: content.profileRole,
-          profileBio: content.profileBio,
-          aboutHeadline: content.aboutHeadline,
-          aboutRole: content.aboutRole,
-          aboutBio: content.aboutBio,
-          aboutDetails: buildLegacyAboutDetails(content.aboutSections),
-          aboutSections: content.aboutSections,
-          aboutProjectSectionTitle: content.aboutProjectSectionTitle,
-          aboutProjects: content.aboutProjects,
-          blogTitle: content.blogTitle,
-          homeIntroTitle: content.homeIntroTitle,
-          homeIntroDescription: content.homeIntroDescription,
-          serviceLinks: content.serviceLinks,
-          contactLinks: content.contactLinks,
+          ...buildProfileWorkspaceAdminProfileCacheFields(content),
         })
       )
     },


### PR DESCRIPTION
## 관련 이슈

close #131

## 작업 배경

- `/admin/profile` 페이지가 legacy `aboutDetails` 문자열 생성을 직접 소유하던 구조를 정리했습니다.
- admin profile publish cache용 호환 필드는 `profileWorkspace` helper에서 한 번에 만들고, 페이지는 structured workspace content만 넘기도록 경계를 고정했습니다.

## 작업 내용

- `buildProfileWorkspaceAdminProfileCacheFields` helper를 추가해 structured about 필드와 legacy `aboutDetails` bridge를 한곳에서 생성합니다.
- `/admin/profile`의 publish cache 동기화 로직에서 legacy helper 직접 import와 필드 수동 매핑을 제거했습니다.
- `admin-profile-state` E2E contract에 페이지 경계와 helper payload 계약을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - RED 확인: `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1` expected fail
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1` 2회 통과
  - `yarn --cwd front lint` 2회 통과
  - `yarn --cwd front build` 2회 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: admin profile cache payload 필드 누락 시 공개 About fallback이 바뀔 수 있습니다. helper contract test로 핵심 필드를 고정했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `11223397`을 revert합니다.
- 배포 경로: 작업 브랜치 -> PR to `main` -> `main` merge -> 자동 배포 workflow.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
