### PR TITLE
[Refactor] post query legacy slug fallback 제거

### DIFF
--- a/front/e2e/legacy-boundary.spec.ts
+++ b/front/e2e/legacy-boundary.spec.ts
@@ -39,4 +39,13 @@ test.describe("frontend legacy boundary", () => {
     expect(legacyPageRoute).not.toContain("getStaticProps")
     expect(legacyPageRoute).not.toContain("MarkdownRenderer")
   })
+
+  test("canonical post query hook does not own legacy slug fallback", () => {
+    const postQueryHook = readFrontText("src/hooks/usePostQuery.ts")
+
+    expect(postQueryHook).toContain("extractCanonicalPostIdFromAsPath")
+    expect(postQueryHook).toContain('pathname.match(/^\\/posts\\/(\\d+)(?:\\/)?$/)')
+    expect(postQueryHook).not.toContain("extractPostIdFromLegacySlug")
+    expect(postQueryHook).not.toContain("router.query.slug")
+  })
 })

--- a/front/src/hooks/usePostQuery.ts
+++ b/front/src/hooks/usePostQuery.ts
@@ -2,16 +2,12 @@ import { useQuery } from "@tanstack/react-query"
 import { useRouter } from "next/router"
 import { getPostDetailById } from "src/apis"
 import { queryKey } from "src/constants/queryKey"
-import { extractPostIdFromLegacySlug } from "src/libs/utils/postPath"
 import { PostDetail } from "src/types"
 
-const extractPostIdFromAsPath = (asPath: string): string => {
+const extractCanonicalPostIdFromAsPath = (asPath: string): string => {
   const pathname = asPath.split(/[?#]/, 1)[0] || ""
   const canonicalMatch = pathname.match(/^\/posts\/(\d+)(?:\/)?$/)
-  if (canonicalMatch) return canonicalMatch[1]
-
-  const legacyId = extractPostIdFromLegacySlug(pathname)
-  return legacyId ? String(legacyId) : ""
+  return canonicalMatch ? canonicalMatch[1] : ""
 }
 
 const usePostQuery = () => {
@@ -19,9 +15,7 @@ const usePostQuery = () => {
   const routeId =
     typeof router.query.id === "string"
       ? router.query.id
-      : typeof router.query.slug === "string"
-        ? String(extractPostIdFromLegacySlug(router.query.slug) || "")
-        : extractPostIdFromAsPath(router.asPath || "")
+      : extractCanonicalPostIdFromAsPath(router.asPath || "")
   const hasRouteId = routeId.length > 0
   const query = useQuery<PostDetail | null>({
     queryKey: queryKey.post(routeId),


### PR DESCRIPTION
## 관련 이슈

close #136

## 작업 배경

- canonical `/posts/[id]` 상세 조회 훅에서 legacy slug fallback을 제거했습니다.
- legacy 호환성은 `/:slug`와 `/page/[pageId]` SSR entrypoint가 소유하고, 런타임 post query hook은 canonical id만 사용하도록 경계를 고정했습니다.

## 작업 내용

- `usePostQuery`에서 `extractPostIdFromLegacySlug` import와 `router.query.slug` fallback을 제거했습니다.
- canonical `/posts/:id` asPath fallback helper만 남겨 router query 준비 전에도 canonical 상세만 복구합니다.
- `legacy-boundary` source guard에 runtime hook legacy fallback 재도입 방지 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - RED 확인: `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/legacy-boundary.spec.ts --workers=1` expected fail
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/legacy-boundary.spec.ts --workers=1` 2회 통과
  - `yarn --cwd front playwright test e2e/smoke.spec.ts --workers=1` 2회 통과
  - `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1` 2회 통과
  - `yarn --cwd front lint` 2회 통과
  - `yarn --cwd front build` 2회 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: canonical 상세 진입에서 router query가 비어 있는 짧은 구간에 id 복구가 필요합니다. `/posts/:id` 전용 asPath fallback은 유지했고 smoke/perf 상세 진입으로 검증했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `e5246957`을 revert합니다.
- 배포 경로: 작업 브랜치 -> PR to `main` -> `main` merge -> 자동 배포 workflow.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
