### PR TITLE
[Fix] post detail code line numbers hydration

### DIFF
--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -890,6 +890,40 @@ test("상세 본문은 trailing-space malformed strong marker를 그대로 노�
 })
 
 test("상세 코드블럭은 Prism fallback 토큰 하이라이팅을 유지한다", async ({ page }) => {
+  await page.addInitScript(() => {
+    type CodeLineSnapshot = {
+      html: string
+      lineCount: number
+      text: string
+    }
+    const windowWithSnapshots = window as typeof window & {
+      __aqCodeLineSnapshots?: CodeLineSnapshot[]
+    }
+    windowWithSnapshots.__aqCodeLineSnapshots = []
+
+    const capture = () => {
+      const code = document.querySelector<HTMLElement>(".aq-code-block .aq-pretty-pre code")
+      if (!code) return
+      windowWithSnapshots.__aqCodeLineSnapshots?.push({
+        html: code.innerHTML.slice(0, 240),
+        lineCount: code.querySelectorAll("[data-line]").length,
+        text: code.textContent || "",
+      })
+    }
+
+    let frameCount = 0
+    const captureFrame = () => {
+      capture()
+      frameCount += 1
+      if (frameCount < 24) {
+        window.requestAnimationFrame(captureFrame)
+      }
+    }
+    window.requestAnimationFrame(captureFrame)
+    const interval = window.setInterval(capture, 16)
+    window.setTimeout(() => window.clearInterval(interval), 3000)
+  })
+
   await page.route("**/post/api/v1/posts/104", async (route) => {
     await route.fulfill({
       status: 200,
@@ -943,6 +977,25 @@ test("상세 코드블럭은 Prism fallback 토큰 하이라이팅을 유지한�
   await expect(codeRoot).toBeVisible()
   await expect(page.locator(".aq-code-block pre code .token.keyword").first()).toBeVisible()
   await expect(page.locator(".aq-code-block pre code .token.string").first()).toBeVisible()
+
+  const lineSnapshots = await page.evaluate(() => {
+    const windowWithSnapshots = window as typeof window & {
+      __aqCodeLineSnapshots?: Array<{ html: string; lineCount: number; text: string }>
+    }
+    const code = document.querySelector<HTMLElement>(".aq-code-block .aq-pretty-pre code")
+    if (code) {
+      windowWithSnapshots.__aqCodeLineSnapshots?.push({
+        html: code.innerHTML.slice(0, 240),
+        lineCount: code.querySelectorAll("[data-line]").length,
+        text: code.textContent || "",
+      })
+    }
+    return windowWithSnapshots.__aqCodeLineSnapshots || []
+  })
+  expect(lineSnapshots.length).toBeGreaterThan(0)
+  const codeSnapshots = lineSnapshots.filter((snapshot) => snapshot.text.includes("const count"))
+  expect(codeSnapshots.length).toBeGreaterThan(0)
+  expect(codeSnapshots.some((snapshot) => snapshot.lineCount === 0)).toBe(false)
 
   const colors = await page.evaluate(() => {
     const code = document.querySelector<HTMLElement>(".aq-code-block pre code")

--- a/front/src/libs/markdown/MarkdownRenderer.tsx
+++ b/front/src/libs/markdown/MarkdownRenderer.tsx
@@ -362,8 +362,6 @@ const MarkdownBlockquote = ({ children }: { children: ReactNode }) => (
   </MarkdownBlockquoteContext.Provider>
 )
 
-const normalizeCodeLineBreaks = (value: string) => value.replace(/\r\n?|\u2028|\u2029/g, "\n")
-
 const extractTextFromMarkdownNode = (node: ReactNode): string => {
   if (typeof node === "string" || typeof node === "number") return String(node)
   if (Array.isArray(node)) return node.map(extractTextFromMarkdownNode).join("\n")
@@ -814,7 +812,6 @@ const MarkdownRendererComponent: FC<Props> = ({
             source: rawCode,
             language,
           })
-          const initialCodeText = normalizeCodeLineBreaks(rawCode)
 
           return (
             <PrettyCodeBlock
@@ -825,10 +822,11 @@ const MarkdownRendererComponent: FC<Props> = ({
                   <code
                     className={`language-${initialCodePresentation.language}`}
                     data-language={initialCodePresentation.language}
+                    data-prism-language={initialCodePresentation.language}
+                    data-prism-source={rawCode}
                     data-raw-code={rawCode}
-                  >
-                    {initialCodeText}
-                  </code>
+                    dangerouslySetInnerHTML={{ __html: initialCodePresentation.html }}
+                  />
                 </pre>
               }
             />

--- a/front/src/libs/markdown/hooks/usePrismEffect.ts
+++ b/front/src/libs/markdown/hooks/usePrismEffect.ts
@@ -1,4 +1,4 @@
-import { RefObject, useEffect } from "react"
+import { RefObject, useEffect, useLayoutEffect } from "react"
 import {
   inferPrismLanguageFromSource,
   highlightCodeToHtml,
@@ -38,6 +38,19 @@ const blockHasSyntaxMarkup = (block: HTMLElement) =>
 const extractCodeSource = (block: HTMLElement) =>
   block.getAttribute("data-raw-code") || block.dataset.prismSource || block.textContent || ""
 
+const ensureLineWrappedHtml = ({
+  html,
+  language,
+  source,
+}: {
+  html: string
+  language: string
+  source: string
+}) => {
+  if (html.includes("data-line=")) return html
+  return renderImmediateCodeToHtml({ source, language }).html
+}
+
 type PrismEffectOptions = {
   observeMutations?: boolean
   mutationDebounceMs?: number
@@ -45,6 +58,7 @@ type PrismEffectOptions = {
 
 const PRISM_DEFAULT_MUTATION_DEBOUNCE_MS = 72
 const PRISM_INITIAL_HYDRATION_TIMEOUT_MS = 1200
+const usePrismHydrationEffect = typeof window === "undefined" ? useEffect : useLayoutEffect
 
 const resolveElementFromNode = (node: Node | null): Element | null => {
   if (!node) return null
@@ -80,7 +94,7 @@ const usePrismEffect = (
       ? Math.max(16, options.mutationDebounceMs)
       : PRISM_DEFAULT_MUTATION_DEBOUNCE_MS
 
-  useEffect(() => {
+  usePrismHydrationEffect(() => {
     if (!enabled) return
 
     let disposed = false
@@ -122,6 +136,7 @@ const usePrismEffect = (
             ? inferPrismLanguageFromSource(entry.source)
             : entry.rawLanguage
           const hasSyntaxMarkup = blockHasSyntaxMarkup(entry.block)
+          const hasLineWrappers = Boolean(entry.block.querySelector("[data-line]"))
 
           return {
             ...entry,
@@ -129,10 +144,11 @@ const usePrismEffect = (
             shouldHighlight:
               inferred.length > 0 &&
               inferred !== "mermaid" &&
-              !hasSyntaxMarkup,
+              (!hasSyntaxMarkup || !hasLineWrappers),
             alreadyHighlighted:
               entry.block.dataset.prismLanguage === inferred &&
-              entry.block.dataset.prismSource === entry.source,
+              entry.block.dataset.prismSource === entry.source &&
+              hasLineWrappers,
           }
         })
         .filter((entry) => entry.shouldHighlight && !entry.alreadyHighlighted)
@@ -148,7 +164,11 @@ const usePrismEffect = (
           .filter((className) => className.startsWith("language-"))
           .forEach((className) => block.classList.remove(className))
         block.classList.add(`language-${immediate.language}`)
-        block.innerHTML = immediate.html
+        block.innerHTML = ensureLineWrappedHtml({
+          html: immediate.html,
+          language: immediate.language,
+          source,
+        })
         block.dataset.prismLanguage = immediate.language
         block.dataset.prismSource = source
         block.setAttribute("data-language", immediate.language)
@@ -174,7 +194,11 @@ const usePrismEffect = (
           .filter((className) => className.startsWith("language-"))
           .forEach((className) => block.classList.remove(className))
         block.classList.add(`language-${language}`)
-        block.innerHTML = result.html
+        block.innerHTML = ensureLineWrappedHtml({
+          html: result.html,
+          language,
+          source,
+        })
         block.dataset.prismLanguage = language
         block.dataset.prismSource = source
         block.setAttribute("data-language", language)
@@ -222,6 +246,16 @@ const usePrismEffect = (
     const scheduleInitialRun = () => {
       if (initialRunScheduled || disposed) return
       initialRunScheduled = true
+
+      const hasCodeBlockMissingLineWrappers = Array.from(root.querySelectorAll<HTMLElement>("pre > code")).some(
+        (block) => !block.querySelector("[data-line]")
+      )
+      if (hasCodeBlockMissingLineWrappers) {
+        hydrationSettled = true
+        fullRescanRequested = true
+        void run()
+        return
+      }
 
       const idleWindow = window as Window & {
         requestIdleCallback?: (

--- a/front/src/libs/markdown/prismRuntime.ts
+++ b/front/src/libs/markdown/prismRuntime.ts
@@ -18,11 +18,14 @@ import "prismjs/components/prism-kotlin.js"
 
 export type PrismLike = {
   languages?: Record<string, unknown>
+  manual?: boolean
   highlightElement: (element: Element) => void
   highlight?: (text: string, grammar: unknown, language: string) => string
 }
 
-;(globalThis as { Prism?: PrismLike }).Prism = Prism as PrismLike
+const prismRuntime = Prism as PrismLike
+prismRuntime.manual = true
+;(globalThis as { Prism?: PrismLike }).Prism = prismRuntime
 
 let prismLoader: Promise<PrismLike> | null = null
 const loadedLoaders = new Set<string>()


### PR DESCRIPTION
## 관련 이슈

close #134

## 작업 배경

- 공개 글 상세 페이지를 새로고침할 때 Prism 자동 하이라이트가 코드블럭 line number wrapper를 제거하면서 줄번호 gutter가 순간적으로 사라졌다가 복구되는 문제를 수정했습니다.
- 초기 렌더 HTML부터 line wrapper를 주입하고, hydration 이후에도 wrapper 누락을 재복구하도록 하이라이트 완료 판정을 강화했습니다.

## 작업 내용

- Prism 런타임을 manual mode로 고정해 기본 `highlightAll`이 공개 상세 `code.language-*` DOM을 다시 처리하지 못하게 했습니다.
- MarkdownRenderer의 초기 코드블럭 HTML에 token + `data-line` wrapper를 직접 렌더하도록 변경했습니다.
- usePrismEffect가 token span만 보고 완료 처리하지 않고 line wrapper까지 확인하며, 누락 시 즉시 재래핑하도록 보강했습니다.
- 상세 smoke 테스트에 새로고침 직후 코드블럭이 `data-line` 없는 상태로 관측되지 않는 회귀 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts -g "상세 코드블럭은 Prism fallback" --workers=1`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`
  - pre-commit hook: `yarn --cwd front build`, `node front/scripts/check-bundle-size.mjs`, `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: Prism fallback 코드블럭의 초기 HTML과 hydration 보정 경로가 함께 바뀌므로, 지원 언어별 토큰 HTML 차이가 있을 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋 `3bb3ee4b`를 revert하면 기존 Prism fallback 동작으로 복구됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
