### PR TITLE
[Fix] legacy table inline HTML entity 정규화

### DIFF
--- a/front/e2e/block-editor-serialization.spec.ts
+++ b/front/e2e/block-editor-serialization.spec.ts
@@ -544,6 +544,29 @@ test.describe("block editor serialization", () => {
     expect(serializeEditorDocToMarkdown(doc)).toBe(markdown)
   })
 
+  test("legacy table inline HTML mark 내부 entity 는 editor text 로 정규화된다", () => {
+    const markdown = [
+      "| 항목 | 값 |",
+      "| --- | --- |",
+      "| 코드 | <code>&lt;section&gt;</code> |",
+      "| 강조 | <strong>A &amp; B</strong> |",
+      "| 이탤릭 | &lt;em&gt;slow&nbsp;path&lt;/em&gt; |",
+      "| 취소 | <del>&#35;old</del> |",
+      "| 보존 | <strong>&#999999999999;</strong> |",
+    ].join("\n")
+
+    const serialized = serializeEditorDocToMarkdown(parseMarkdownToEditorDoc(markdown))
+
+    expect(serialized).toContain("| 코드 | `<section>` |")
+    expect(serialized).toContain("| 강조 | **A & B** |")
+    expect(serialized).toContain("| 이탤릭 | *slow path* |")
+    expect(serialized).toContain("| 취소 | ~~#old~~ |")
+    expect(serialized).toContain("| 보존 | **&#999999999999;** |")
+    expect(serialized).not.toContain("<strong>")
+    expect(serialized).not.toContain("&amp;")
+    expect(serialized).not.toContain("&lt;em")
+  })
+
   test("렌더 모델은 테이블 메타 comment 를 분리하고 본문 markdown 에서는 제거한다", () => {
     const markdown = [
       '<!-- aq-table {"columnWidths":[220,320],"rowHeights":[52,68,44]} -->',

--- a/front/src/libs/markdown/inlineHtmlNormalization.ts
+++ b/front/src/libs/markdown/inlineHtmlNormalization.ts
@@ -10,13 +10,13 @@ const isLikelyTableRow = (line: string) => {
 }
 
 const wrapWithMarkdownMark = (content: string, marker: string) => {
-  const normalized = content.trim()
+  const normalized = decodeLegacyHtmlEntities(content).trim()
   if (!normalized) return ""
   return `${marker}${normalized}${marker}`
 }
 
 const wrapWithMarkdownCodeMark = (content: string) => {
-  const normalized = content.trim()
+  const normalized = decodeLegacyHtmlEntities(content).trim()
   if (!normalized) return ""
   const backtickRuns = normalized.match(/`+/g)
   const longestRun = backtickRuns?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0
@@ -25,6 +25,34 @@ const wrapWithMarkdownCodeMark = (content: string) => {
     normalized.startsWith("`") || normalized.endsWith("`") ? ` ${normalized} ` : normalized
   return `${marker}${paddedContent}${marker}`
 }
+
+const LEGACY_HTML_ENTITY_MAP: Record<string, string> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  nbsp: " ",
+  quot: '"',
+}
+
+const decodeLegacyHtmlCodePoint = (codePoint: number, fallback: string) => {
+  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) return fallback
+  return String.fromCodePoint(codePoint)
+}
+
+const decodeLegacyHtmlEntities = (input: string) =>
+  String(input || "").replace(/&(#x[\da-f]+|#\d+|amp|apos|gt|lt|nbsp|quot);/gi, (entity, token: string) => {
+    const normalizedToken = token.toLowerCase()
+    if (normalizedToken.startsWith("#x")) {
+      const codePoint = Number.parseInt(normalizedToken.slice(2), 16)
+      return decodeLegacyHtmlCodePoint(codePoint, entity)
+    }
+    if (normalizedToken.startsWith("#")) {
+      const codePoint = Number.parseInt(normalizedToken.slice(1), 10)
+      return decodeLegacyHtmlCodePoint(codePoint, entity)
+    }
+    return LEGACY_HTML_ENTITY_MAP[normalizedToken] || entity
+  })
 
 const normalizeCodeTagMatch = (rawInner: string) => {
   return wrapWithMarkdownCodeMark(String(rawInner || ""))
@@ -40,7 +68,7 @@ export const normalizeLegacyInlineHtmlSpans = (input: string) => {
     (_match, rawInner: string) => normalizeCodeTagMatch(rawInner)
   )
   normalized = normalized.replace(
-    /&lt;\s*code(?:\s+[^&]*)&gt;([\s\S]*?)&lt;\s*\/\s*code\s*&gt;/gi,
+    /&lt;\s*code(?:\s+[^&]*)?&gt;([\s\S]*?)&lt;\s*\/\s*code\s*&gt;/gi,
     (_match, rawInner: string) => normalizeCodeTagMatch(rawInner)
   )
   normalized = normalized.replace(
@@ -48,7 +76,7 @@ export const normalizeLegacyInlineHtmlSpans = (input: string) => {
     (_match, rawInner: string) => wrapWithMarkdownMark(String(rawInner || ""), "**")
   )
   normalized = normalized.replace(
-    /&lt;\s*(?:strong|b)(?:\s+[^&]*)&gt;([\s\S]*?)&lt;\s*\/\s*(?:strong|b)\s*&gt;/gi,
+    /&lt;\s*(?:strong|b)(?:\s+[^&]*)?&gt;([\s\S]*?)&lt;\s*\/\s*(?:strong|b)\s*&gt;/gi,
     (_match, rawInner: string) => wrapWithMarkdownMark(String(rawInner || ""), "**")
   )
   normalized = normalized.replace(
@@ -56,7 +84,7 @@ export const normalizeLegacyInlineHtmlSpans = (input: string) => {
     (_match, rawInner: string) => wrapWithMarkdownMark(String(rawInner || ""), "*")
   )
   normalized = normalized.replace(
-    /&lt;\s*(?:em|i)(?:\s+[^&]*)&gt;([\s\S]*?)&lt;\s*\/\s*(?:em|i)\s*&gt;/gi,
+    /&lt;\s*(?:em|i)(?:\s+[^&]*)?&gt;([\s\S]*?)&lt;\s*\/\s*(?:em|i)\s*&gt;/gi,
     (_match, rawInner: string) => wrapWithMarkdownMark(String(rawInner || ""), "*")
   )
   normalized = normalized.replace(
@@ -64,7 +92,7 @@ export const normalizeLegacyInlineHtmlSpans = (input: string) => {
     (_match, rawInner: string) => wrapWithMarkdownMark(String(rawInner || ""), "~~")
   )
   normalized = normalized.replace(
-    /&lt;\s*(?:del|s)(?:\s+[^&]*)&gt;([\s\S]*?)&lt;\s*\/\s*(?:del|s)\s*&gt;/gi,
+    /&lt;\s*(?:del|s)(?:\s+[^&]*)?&gt;([\s\S]*?)&lt;\s*\/\s*(?:del|s)\s*&gt;/gi,
     (_match, rawInner: string) => wrapWithMarkdownMark(String(rawInner || ""), "~~")
   )
 
@@ -100,7 +128,7 @@ export const normalizeLegacyInlineHtmlMarkdown = (markdown: string) => {
 }
 
 export const normalizeInlineHtmlInMarkdownTables = (markdown: string) => {
-  if (!markdown || !markdown.includes("<")) return markdown
+  if (!markdown || (!markdown.includes("<") && !markdown.includes("&lt;"))) return markdown
 
   return markdown
     .split("\n")


### PR DESCRIPTION
## 관련 이슈

close #141

## 작업 배경

- legacy table 셀의 inline HTML mark 내부 `&amp;`, `&lt;`, `&nbsp;`, numeric entity를 editor text로 정규화합니다.
- escaped inline HTML tag(`&lt;em&gt;...&lt;/em&gt;`)도 attribute가 없는 기본 tag 형태에서 markdown mark로 승격되도록 보정했습니다.
- invalid numeric entity는 parser throw 없이 원문 entity를 보존합니다.

## 작업 내용

- `normalizeLegacyInlineHtmlSpans`가 mark 내부 HTML entity를 decode한 뒤 markdown mark를 생성합니다.
- escaped inline HTML tag regex에서 attribute 그룹을 optional로 수정했습니다.
- `block-editor-serialization`에 legacy table inline HTML/entity round-trip 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - RED 확인: `yarn --cwd front playwright test e2e/block-editor-serialization.spec.ts --workers=1` expected fail
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/block-editor-serialization.spec.ts --workers=1` 2회 통과
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` 2회 통과
  - `yarn --cwd front lint` 2회 통과
  - `yarn --cwd front build` 2회 통과 + pre-commit 1회 추가 통과
  - `node front/scripts/check-bundle-size.mjs` 2회 통과 + pre-commit 1회 추가 통과
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` 2회 통과
  - pre-commit: `yarn playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts` 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: legacy HTML entity decode 범위가 넓어져 일부 오래된 표 셀의 직렬화 결과가 더 canonical하게 바뀔 수 있습니다. code fence 내부는 기존 normalization 제외 경로를 유지했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `98cb2b7b`을 revert합니다.
- 배포 경로: 작업 브랜치 -> PR to `main` -> `main` merge -> 자동 배포 workflow.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
