### PR TITLE
[Refactor] editor slash menu model 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import path from "node:path"
 import { expect, test } from "@playwright/test"
 import { getServerSideProps as getEditPageServerSideProps } from "src/pages/editor/[id]"
@@ -135,6 +135,9 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/components/editor/blockSelectionModel.ts"),
       "utf8"
     )
+    const slashMenuModelPath = path.resolve(__dirname, "../src/components/editor/slashMenuModel.ts")
+    expect(existsSync(slashMenuModelPath)).toBe(true)
+    const slashMenuModelSource = existsSync(slashMenuModelPath) ? readFileSync(slashMenuModelPath, "utf8") : ""
     const writerEditorHostSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/WriterEditorHost.tsx"), "utf8")
 
     expect(editorStudioSource).not.toContain("BLOCK_EDITOR_V2_ENABLED")
@@ -179,6 +182,19 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).toContain("border-radius: 0;")
     expect(blockEditorEngineSource).toContain('from "./blockSelectionModel"')
     expect(blockEditorEngineSource).toContain('from "./useBlockEditorMarkdownCommit"')
+    expect(blockEditorEngineSource).toContain('from "./slashMenuModel"')
+    expect(blockEditorEngineSource).not.toContain("const normalizeSlashSearchText =")
+    expect(blockEditorEngineSource).not.toContain("const compactSlashSearchText =")
+    expect(blockEditorEngineSource).not.toContain("const getSlashSearchTerms =")
+    expect(blockEditorEngineSource).not.toContain("const getSlashActionGlyph =")
+    expect(blockEditorEngineSource).not.toContain("const getSlashMenuContextBonus =")
+    expect(blockEditorEngineSource).not.toContain("const getSlashMenuMatchScore =")
+    expect(blockEditorEngineSource).not.toContain("type SlashMenuContext =")
+    expect(slashMenuModelSource).toContain("export type SlashMenuContext =")
+    expect(slashMenuModelSource).toContain("export const normalizeSlashSearchText =")
+    expect(slashMenuModelSource).toContain("export const getRankedSlashItems =")
+    expect(slashMenuModelSource).toContain("export const buildSlashMenuSections =")
+    expect(slashMenuModelSource).toContain("export const getSlashActionGlyph =")
     expect(blockEditorEngineSource).not.toContain("const normalizeMarkdown =")
     expect(blockEditorEngineSource).not.toContain("markdownCommitTimerRef")
     expect(blockEditorEngineSource).not.toContain("markdownCommitIdleHandleRef")

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -149,6 +149,13 @@ import {
   type TopLevelBlockHandleState,
 } from "./blockSelectionModel"
 import { useBlockEditorMarkdownCommit } from "./useBlockEditorMarkdownCommit"
+import {
+  buildSlashMenuSections,
+  getRankedSlashItems,
+  getSlashActionGlyph,
+  normalizeSlashSearchText,
+  type SlashMenuContext,
+} from "./slashMenuModel"
 
 type RuntimeGuardWindow = Window & {
   __AQ_RUNTIME_GUARD_ENABLED__?: boolean
@@ -336,9 +343,6 @@ type TableAxisReorderIndicatorState = {
   height: number
 }
 
-const normalizeSlashSearchText = (value: string) => value.trim().toLowerCase()
-
-const compactSlashSearchText = (value: string) => normalizeSlashSearchText(value).replace(/\s+/g, "")
 const LIST_ITEM_SELECTOR =
   "li[data-type='taskItem'], li[data-task-item='true'], li[data-list-item='true'], li[data-type='listItem']"
 const LIST_CONTAINER_SELECTOR =
@@ -449,189 +453,6 @@ const INLINE_TEXT_STYLE_OPTIONS: InlineTextStyleOption[] = [
     },
   },
 ]
-
-const getSlashSearchTerms = (item: BlockInsertCatalogItem) =>
-  Array.from(
-    new Set(
-      [item.label, item.helper ?? "", item.slashHint ?? "", item.section, ...(item.keywords ?? [])]
-        .map((value) => normalizeSlashSearchText(value))
-        .filter(Boolean)
-    )
-  )
-
-const getSlashActionGlyph = (item: BlockInsertCatalogItem) => {
-  switch (item.id) {
-    case "paragraph":
-      return "T"
-    case "heading-1":
-      return "H1"
-    case "heading-2":
-      return "H2"
-    case "heading-3":
-      return "H3"
-    case "heading-4":
-      return "H4"
-    case "bullet-list":
-      return "•"
-    case "ordered-list":
-      return "1."
-    case "checklist":
-      return "☑"
-    case "quote":
-      return "❞"
-    case "code-block":
-      return "</>"
-    case "table":
-      return "▦"
-    case "callout":
-      return "!"
-    case "toggle":
-      return "▸"
-    case "bookmark":
-      return "↗"
-    case "embed":
-      return "▶"
-    case "file":
-      return "PDF"
-    case "formula":
-      return "∑"
-    case "divider":
-      return "—"
-    case "image":
-      return "img"
-    case "mermaid":
-      return "M"
-    default:
-      return item.slashHint ?? item.label.slice(0, 1)
-  }
-}
-
-type SlashMenuContext = {
-  currentBlockType: string | null
-  previousBlockType: string | null
-  atDocumentStart: boolean
-}
-
-const getSlashMenuContextBonus = (item: BlockInsertCatalogItem, context: SlashMenuContext) => {
-  let score = 0
-
-  if (context.atDocumentStart) {
-    if (item.id === "heading-1") score += 42
-    if (item.id === "heading-2") score += 28
-    if (item.id === "paragraph") score += 16
-    if (item.id === "image") score += 6
-  }
-
-  if (context.currentBlockType === "paragraph") {
-    if (item.id === "paragraph") score += 8
-    if (item.id === "heading-2") score += 6
-    if (item.id === "bullet-list") score += 6
-    if (item.id === "code-block") score += 4
-  }
-
-  if (context.currentBlockType === "heading") {
-    if (item.id === "paragraph") score += 18
-    if (item.id === "bullet-list") score += 12
-    if (item.id === "quote") score += 10
-    if (item.id === "image") score += 8
-  }
-
-  if (context.previousBlockType === "heading") {
-    if (item.id === "paragraph") score += 24
-    if (item.id === "bullet-list") score += 18
-    if (item.id === "image") score += 10
-    if (item.id === "divider") score += 6
-  }
-
-  if (context.previousBlockType === "bulletList" || context.previousBlockType === "orderedList") {
-    if (item.id === "bullet-list" || item.id === "ordered-list") score += 16
-    if (item.id === "paragraph") score += 14
-    if (item.id === "heading-2") score += 8
-    if (item.id === "divider") score += 6
-  }
-
-  if (
-    context.previousBlockType === "codeBlock" ||
-    context.previousBlockType === "mermaidBlock" ||
-    context.previousBlockType === "table"
-  ) {
-    if (item.id === "paragraph") score += 20
-    if (item.id === "divider") score += 18
-    if (item.id === "callout") score += 8
-    if (item.id === "image") score += 8
-  }
-
-  if (context.previousBlockType === "image") {
-    if (item.id === "paragraph") score += 18
-    if (item.id === "heading-2") score += 10
-    if (item.id === "callout") score += 8
-  }
-
-  if (context.previousBlockType === "calloutBlock" || context.previousBlockType === "toggleBlock") {
-    if (item.id === "paragraph") score += 18
-    if (item.id === "heading-2") score += 10
-    if (item.id === "bullet-list") score += 8
-  }
-
-  return score
-}
-
-const getSlashMenuMatchScore = (
-  item: BlockInsertCatalogItem,
-  normalizedQuery: string,
-  recentIndex: number,
-  context: SlashMenuContext
-) => {
-  const recentBonus = recentIndex >= 0 ? 120 - recentIndex * 8 : 0
-  const recommendedBonus = item.recommended ? 20 : 0
-  const contextBonus = getSlashMenuContextBonus(item, context)
-
-  if (!normalizedQuery) {
-    return recentBonus + recommendedBonus + contextBonus
-  }
-
-  const compactQuery = compactSlashSearchText(normalizedQuery)
-  const contextTieBreaker = Math.round(contextBonus * 0.42)
-  const fields = getSlashSearchTerms(item)
-
-  let score = Number.NEGATIVE_INFINITY
-  let keywordIntentBonus = 0
-
-  for (const field of fields) {
-    const compactField = compactSlashSearchText(field)
-
-    if (field === normalizedQuery || compactField === compactQuery) {
-      score = Math.max(score, 1200)
-      if (item.keywords?.some((keyword) => compactSlashSearchText(keyword) === compactQuery)) {
-        keywordIntentBonus = Math.max(keywordIntentBonus, 120)
-      }
-      continue
-    }
-
-    if (field.startsWith(normalizedQuery) || compactField.startsWith(compactQuery)) {
-      score = Math.max(score, 980)
-      if (item.keywords?.some((keyword) => compactSlashSearchText(keyword).startsWith(compactQuery))) {
-        keywordIntentBonus = Math.max(keywordIntentBonus, 72)
-      }
-      continue
-    }
-
-    if (field.split(/\s+/).some((token) => compactSlashSearchText(token).startsWith(compactQuery))) {
-      score = Math.max(score, 860)
-      continue
-    }
-
-    if (field.includes(normalizedQuery) || compactField.includes(compactQuery)) {
-      score = Math.max(score, 680)
-    }
-  }
-
-  if (!Number.isFinite(score)) {
-    return Number.NEGATIVE_INFINITY
-  }
-
-  return score + recentBonus + recommendedBonus + contextTieBreaker + keywordIntentBonus
-}
 
 type BlockMenuState =
   | {
@@ -6267,26 +6088,11 @@ const BlockEditorEngine = ({
     }
   }, [])
 
-  const getRankedSlashItems = useCallback((query: string, context: SlashMenuContext) => {
-    const normalizedQuery = normalizeSlashSearchText(query)
-    return blockInsertCatalog
-      .map((item, index) => ({
-        item,
-        index,
-        score: getSlashMenuMatchScore(
-          item,
-          normalizedQuery,
-          recentSlashItemIds.indexOf(item.id),
-          context
-        ),
-      }))
-      .filter((entry) => Number.isFinite(entry.score))
-      .sort((left, right) => {
-        if (right.score !== left.score) return right.score - left.score
-        return left.index - right.index
-      })
-      .map((entry) => entry.item)
-  }, [blockInsertCatalog, recentSlashItemIds])
+  const rankSlashItems = useCallback(
+    (query: string, context: SlashMenuContext) =>
+      getRankedSlashItems(blockInsertCatalog, query, recentSlashItemIds, context),
+    [blockInsertCatalog, recentSlashItemIds]
+  )
 
   const slashMenuContext = useMemo<SlashMenuContext>(() => {
     void selectionTick
@@ -6294,33 +6100,11 @@ const BlockEditorEngine = ({
   }, [editor, getSlashMenuContextFromEditor, selectionTick])
 
   const rankedSlashItems = useMemo(() => {
-    return getRankedSlashItems(normalizedSlashQuery, slashMenuContext)
-  }, [getRankedSlashItems, normalizedSlashQuery, slashMenuContext])
+    return rankSlashItems(normalizedSlashQuery, slashMenuContext)
+  }, [rankSlashItems, normalizedSlashQuery, slashMenuContext])
 
   const slashSections = useMemo(() => {
-    const seenItemIds = new Set<string>()
-    const takeUnique = (items: Array<BlockInsertCatalogItem | undefined>) =>
-      items.filter((item): item is BlockInsertCatalogItem => {
-        if (!item || seenItemIds.has(item.id)) return false
-        seenItemIds.add(item.id)
-        return true
-      })
-
-    const recentItems = takeUnique(recentSlashItemIds.map((id) => rankedSlashItems.find((item) => item.id === id)))
-    const recommendedItems = takeUnique(
-      rankedSlashItems.slice(0, normalizedSlashQuery ? Math.min(rankedSlashItems.length, 6) : 5)
-    )
-    const basicItems = takeUnique(rankedSlashItems.filter((item) => item.section === "basic"))
-    const structureItems = takeUnique(rankedSlashItems.filter((item) => item.section === "structure"))
-    const mediaItems = takeUnique(rankedSlashItems.filter((item) => item.section === "media"))
-
-    return [
-      { title: "최근 사용", items: recentItems },
-      { title: "추천", items: recommendedItems },
-      { title: "기본 블록", items: basicItems },
-      { title: "구조 블록", items: structureItems },
-      { title: "미디어", items: mediaItems },
-    ].filter((section) => section.items.length > 0)
+    return buildSlashMenuSections(rankedSlashItems, recentSlashItemIds, normalizedSlashQuery)
   }, [normalizedSlashQuery, rankedSlashItems, recentSlashItemIds])
 
   const flatSlashEntries = useMemo(
@@ -6637,7 +6421,7 @@ const BlockEditorEngine = ({
 
     const query = resolvedSlashState?.query ?? ""
     const context = getSlashMenuContextFromEditor(activeEditor)
-    const rankedItems = getRankedSlashItems(query, context)
+    const rankedItems = rankSlashItems(query, context)
     if (!rankedItems.length) return null
 
     const preferredItemId = flatSlashEntries[selectedSlashIndex]?.item.id
@@ -6657,8 +6441,8 @@ const BlockEditorEngine = ({
   }, [
     editor,
     flatSlashEntries,
-    getRankedSlashItems,
     getSlashMenuContextFromEditor,
+    rankSlashItems,
     resolveSlashMenuState,
     selectedSlashIndex,
   ])

--- a/front/src/components/editor/slashMenuModel.ts
+++ b/front/src/components/editor/slashMenuModel.ts
@@ -1,0 +1,298 @@
+import type { BlockInsertCatalogItem } from "./writerEditorPreset"
+
+export type SlashMenuContext = {
+  currentBlockType: string | null
+  previousBlockType: string | null
+  atDocumentStart: boolean
+}
+
+export type SlashMenuSection = {
+  title: string
+  items: BlockInsertCatalogItem[]
+}
+
+export const normalizeSlashSearchText = (value: string) =>
+  value.trim().toLowerCase()
+
+const compactSlashSearchText = (value: string) =>
+  normalizeSlashSearchText(value).replace(/\s+/g, "")
+
+const getSlashSearchTerms = (item: BlockInsertCatalogItem) =>
+  Array.from(
+    new Set(
+      [
+        item.label,
+        item.helper ?? "",
+        item.slashHint ?? "",
+        item.section,
+        ...(item.keywords ?? []),
+      ]
+        .map((value) => normalizeSlashSearchText(value))
+        .filter(Boolean)
+    )
+  )
+
+export const getSlashActionGlyph = (item: BlockInsertCatalogItem) => {
+  switch (item.id) {
+    case "paragraph":
+      return "T"
+    case "heading-1":
+      return "H1"
+    case "heading-2":
+      return "H2"
+    case "heading-3":
+      return "H3"
+    case "heading-4":
+      return "H4"
+    case "bullet-list":
+      return "•"
+    case "ordered-list":
+      return "1."
+    case "checklist":
+      return "☑"
+    case "quote":
+      return "❞"
+    case "code-block":
+      return "</>"
+    case "table":
+      return "▦"
+    case "callout":
+      return "!"
+    case "toggle":
+      return "▸"
+    case "bookmark":
+      return "↗"
+    case "embed":
+      return "▶"
+    case "file":
+      return "PDF"
+    case "formula":
+      return "∑"
+    case "divider":
+      return "—"
+    case "image":
+      return "img"
+    case "mermaid":
+      return "M"
+    default:
+      return item.slashHint ?? item.label.slice(0, 1)
+  }
+}
+
+const getSlashMenuContextBonus = (
+  item: BlockInsertCatalogItem,
+  context: SlashMenuContext
+) => {
+  let score = 0
+
+  if (context.atDocumentStart) {
+    if (item.id === "heading-1") score += 42
+    if (item.id === "heading-2") score += 28
+    if (item.id === "paragraph") score += 16
+    if (item.id === "image") score += 6
+  }
+
+  if (context.currentBlockType === "paragraph") {
+    if (item.id === "paragraph") score += 8
+    if (item.id === "heading-2") score += 6
+    if (item.id === "bullet-list") score += 6
+    if (item.id === "code-block") score += 4
+  }
+
+  if (context.currentBlockType === "heading") {
+    if (item.id === "paragraph") score += 18
+    if (item.id === "bullet-list") score += 12
+    if (item.id === "quote") score += 10
+    if (item.id === "image") score += 8
+  }
+
+  if (context.previousBlockType === "heading") {
+    if (item.id === "paragraph") score += 24
+    if (item.id === "bullet-list") score += 18
+    if (item.id === "image") score += 10
+    if (item.id === "divider") score += 6
+  }
+
+  if (
+    context.previousBlockType === "bulletList" ||
+    context.previousBlockType === "orderedList"
+  ) {
+    if (item.id === "bullet-list" || item.id === "ordered-list") score += 16
+    if (item.id === "paragraph") score += 14
+    if (item.id === "heading-2") score += 8
+    if (item.id === "divider") score += 6
+  }
+
+  if (
+    context.previousBlockType === "codeBlock" ||
+    context.previousBlockType === "mermaidBlock" ||
+    context.previousBlockType === "table"
+  ) {
+    if (item.id === "paragraph") score += 20
+    if (item.id === "divider") score += 18
+    if (item.id === "callout") score += 8
+    if (item.id === "image") score += 8
+  }
+
+  if (context.previousBlockType === "image") {
+    if (item.id === "paragraph") score += 18
+    if (item.id === "heading-2") score += 10
+    if (item.id === "callout") score += 8
+  }
+
+  if (
+    context.previousBlockType === "calloutBlock" ||
+    context.previousBlockType === "toggleBlock"
+  ) {
+    if (item.id === "paragraph") score += 18
+    if (item.id === "heading-2") score += 10
+    if (item.id === "bullet-list") score += 8
+  }
+
+  return score
+}
+
+const getSlashMenuMatchScore = (
+  item: BlockInsertCatalogItem,
+  normalizedQuery: string,
+  recentIndex: number,
+  context: SlashMenuContext
+) => {
+  const recentBonus = recentIndex >= 0 ? 120 - recentIndex * 8 : 0
+  const recommendedBonus = item.recommended ? 20 : 0
+  const contextBonus = getSlashMenuContextBonus(item, context)
+
+  if (!normalizedQuery) {
+    return recentBonus + recommendedBonus + contextBonus
+  }
+
+  const compactQuery = compactSlashSearchText(normalizedQuery)
+  const contextTieBreaker = Math.round(contextBonus * 0.42)
+  const fields = getSlashSearchTerms(item)
+
+  let score = Number.NEGATIVE_INFINITY
+  let keywordIntentBonus = 0
+
+  for (const field of fields) {
+    const compactField = compactSlashSearchText(field)
+
+    if (field === normalizedQuery || compactField === compactQuery) {
+      score = Math.max(score, 1200)
+      if (
+        item.keywords?.some(
+          (keyword) => compactSlashSearchText(keyword) === compactQuery
+        )
+      ) {
+        keywordIntentBonus = Math.max(keywordIntentBonus, 120)
+      }
+      continue
+    }
+
+    if (
+      field.startsWith(normalizedQuery) ||
+      compactField.startsWith(compactQuery)
+    ) {
+      score = Math.max(score, 980)
+      if (
+        item.keywords?.some((keyword) =>
+          compactSlashSearchText(keyword).startsWith(compactQuery)
+        )
+      ) {
+        keywordIntentBonus = Math.max(keywordIntentBonus, 72)
+      }
+      continue
+    }
+
+    if (
+      field
+        .split(/\s+/)
+        .some((token) => compactSlashSearchText(token).startsWith(compactQuery))
+    ) {
+      score = Math.max(score, 860)
+      continue
+    }
+
+    if (
+      field.includes(normalizedQuery) ||
+      compactField.includes(compactQuery)
+    ) {
+      score = Math.max(score, 680)
+    }
+  }
+
+  if (!Number.isFinite(score)) {
+    return Number.NEGATIVE_INFINITY
+  }
+
+  return (
+    score +
+    recentBonus +
+    recommendedBonus +
+    contextTieBreaker +
+    keywordIntentBonus
+  )
+}
+
+export const getRankedSlashItems = (
+  catalog: BlockInsertCatalogItem[],
+  query: string,
+  recentItemIds: readonly string[],
+  context: SlashMenuContext
+) => {
+  const normalizedQuery = normalizeSlashSearchText(query)
+  return catalog
+    .map((item, index) => ({
+      item,
+      index,
+      score: getSlashMenuMatchScore(
+        item,
+        normalizedQuery,
+        recentItemIds.indexOf(item.id),
+        context
+      ),
+    }))
+    .filter((entry) => Number.isFinite(entry.score))
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score
+      return left.index - right.index
+    })
+    .map((entry) => entry.item)
+}
+
+export const buildSlashMenuSections = (
+  rankedItems: BlockInsertCatalogItem[],
+  recentItemIds: readonly string[],
+  normalizedQuery: string
+): SlashMenuSection[] => {
+  const seenItemIds = new Set<string>()
+  const takeUnique = (items: Array<BlockInsertCatalogItem | undefined>) =>
+    items.filter((item): item is BlockInsertCatalogItem => {
+      if (!item || seenItemIds.has(item.id)) return false
+      seenItemIds.add(item.id)
+      return true
+    })
+
+  const recentItems = takeUnique(
+    recentItemIds.map((id) => rankedItems.find((item) => item.id === id))
+  )
+  const recommendedItems = takeUnique(
+    rankedItems.slice(0, normalizedQuery ? Math.min(rankedItems.length, 6) : 5)
+  )
+  const basicItems = takeUnique(
+    rankedItems.filter((item) => item.section === "basic")
+  )
+  const structureItems = takeUnique(
+    rankedItems.filter((item) => item.section === "structure")
+  )
+  const mediaItems = takeUnique(
+    rankedItems.filter((item) => item.section === "media")
+  )
+
+  return [
+    { title: "최근 사용", items: recentItems },
+    { title: "추천", items: recommendedItems },
+    { title: "기본 블록", items: basicItems },
+    { title: "구조 블록", items: structureItems },
+    { title: "미디어", items: mediaItems },
+  ].filter((section) => section.items.length > 0)
+}


### PR DESCRIPTION
## 관련 이슈

close #145

## 작업 배경

- `BlockEditorEngine.tsx`가 직접 소유하던 slash menu 검색 정규화, scoring/ranking, section grouping, glyph 계산을 `slashMenuModel.ts` pure model로 분리했습니다.
- engine은 editor selection 기반 context 계산과 model 호출만 맡도록 줄이고, source guard로 helper 재결합을 막았습니다.
- `main` merge 후 CI가 성공하면 기존 홈서버 자동 배포 workflow가 이어지는 경로입니다.

## 작업 내용

- slash menu pure helper를 `front/src/components/editor/slashMenuModel.ts`로 이동했습니다.
- `BlockEditorEngine.tsx`는 `getRankedSlashItems`, `buildSlashMenuSections`, `getSlashActionGlyph`, `normalizeSlashSearchText`를 model import로 사용합니다.
- `editor-studio-state` source guard가 model export와 engine 내 재정의 금지 문자열을 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight` (2회 통과)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (source guard RED 확인 후 GREEN 2회 통과)
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (2회 통과)
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (2회 통과)
  - `yarn --cwd front lint` (2회 통과)
  - `yarn --cwd front build` (2회 통과)
  - `git diff --check`
  - `CURRENT_TASK_SLUG=editor-slash-menu-model-split bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: slash menu ranking/section 표시 순서가 변경되면 작성 UX 회귀가 날 수 있습니다. 기존 로직을 pure model로 이동했고 interaction/authoring E2E로 동작 경로를 검증했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `a525b12f`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
