### PR TITLE
[Refactor] editor inline toolbar model 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -138,6 +138,9 @@ test.describe("editor studio state", () => {
     const slashMenuModelPath = path.resolve(__dirname, "../src/components/editor/slashMenuModel.ts")
     expect(existsSync(slashMenuModelPath)).toBe(true)
     const slashMenuModelSource = existsSync(slashMenuModelPath) ? readFileSync(slashMenuModelPath, "utf8") : ""
+    const inlineToolbarModelPath = path.resolve(__dirname, "../src/components/editor/inlineToolbarModel.ts")
+    expect(existsSync(inlineToolbarModelPath)).toBe(true)
+    const inlineToolbarModelSource = existsSync(inlineToolbarModelPath) ? readFileSync(inlineToolbarModelPath, "utf8") : ""
     const writerEditorHostSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/WriterEditorHost.tsx"), "utf8")
 
     expect(editorStudioSource).not.toContain("BLOCK_EDITOR_V2_ENABLED")
@@ -183,6 +186,10 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).toContain('from "./blockSelectionModel"')
     expect(blockEditorEngineSource).toContain('from "./useBlockEditorMarkdownCommit"')
     expect(blockEditorEngineSource).toContain('from "./slashMenuModel"')
+    expect(blockEditorEngineSource).toContain('from "./inlineToolbarModel"')
+    expect(blockEditorEngineSource).not.toContain("type InlineTextStyleOption =")
+    expect(blockEditorEngineSource).not.toContain("const INLINE_TEXT_STYLE_OPTIONS")
+    expect(blockEditorEngineSource).not.toContain("normalizeInlineColorToken")
     expect(blockEditorEngineSource).not.toContain("const normalizeSlashSearchText =")
     expect(blockEditorEngineSource).not.toContain("const compactSlashSearchText =")
     expect(blockEditorEngineSource).not.toContain("const getSlashSearchTerms =")
@@ -195,6 +202,11 @@ test.describe("editor studio state", () => {
     expect(slashMenuModelSource).toContain("export const getRankedSlashItems =")
     expect(slashMenuModelSource).toContain("export const buildSlashMenuSections =")
     expect(slashMenuModelSource).toContain("export const getSlashActionGlyph =")
+    expect(inlineToolbarModelSource).toContain("export type InlineTextStyleOption =")
+    expect(inlineToolbarModelSource).toContain("export const INLINE_TEXT_STYLE_OPTIONS")
+    expect(inlineToolbarModelSource).toContain("export const getActiveInlineColor")
+    expect(inlineToolbarModelSource).toContain("export const getActiveInlineTextStyleOption")
+    expect(inlineToolbarModelSource).toContain("export const runInlineTextStyle")
     expect(blockEditorEngineSource).not.toContain("const normalizeMarkdown =")
     expect(blockEditorEngineSource).not.toContain("markdownCommitTimerRef")
     expect(blockEditorEngineSource).not.toContain("markdownCommitIdleHandleRef")

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -70,10 +70,7 @@ import {
   looksLikeStructuredMarkdownDocument,
   normalizeStructuredMarkdownClipboard,
 } from "src/libs/markdown/htmlToMarkdown"
-import {
-  INLINE_TEXT_COLOR_OPTIONS,
-  normalizeInlineColorToken,
-} from "src/libs/markdown/inlineColor"
+import { INLINE_TEXT_COLOR_OPTIONS } from "src/libs/markdown/inlineColor"
 import { inferCardKindFromUrl, inferLinkProvider, resolveEmbedPreviewUrl } from "src/libs/unfurl/extractMeta"
 import type {
   BlockEditorChangeMeta,
@@ -156,6 +153,14 @@ import {
   normalizeSlashSearchText,
   type SlashMenuContext,
 } from "./slashMenuModel"
+import {
+  INLINE_TEXT_STYLE_OPTIONS,
+  getActiveInlineColor,
+  getActiveInlineTextStyleOption,
+  isInlineCodeMarkActive,
+  runInlineTextStyle,
+  type InlineTextStyleOption,
+} from "./inlineToolbarModel"
 
 type RuntimeGuardWindow = Window & {
   __AQ_RUNTIME_GUARD_ENABLED__?: boolean
@@ -183,14 +188,6 @@ type ToolbarAction = {
   run: () => void
   active: boolean
   disabled?: boolean
-}
-
-type InlineTextStyleOption = {
-  id: "paragraph" | "heading-1" | "heading-2" | "heading-3" | "heading-4"
-  label: string
-  shortLabel: string
-  isActive: (activeEditor: TiptapEditor) => boolean
-  run: (activeEditor: TiptapEditor) => void
 }
 
 type FloatingBubbleState = {
@@ -405,54 +402,6 @@ const recordEditorCommitDurationForRuntimeGuard = (durationMs: number) => {
   }
   store.editorCommitSamples = nextSamples
 }
-
-const INLINE_TEXT_STYLE_OPTIONS: InlineTextStyleOption[] = [
-  {
-    id: "paragraph",
-    label: "본문",
-    shortLabel: "T",
-    isActive: (activeEditor) => activeEditor.isActive("paragraph"),
-    run: (activeEditor) => {
-      activeEditor.chain().focus().setParagraph().run()
-    },
-  },
-  {
-    id: "heading-1",
-    label: "제목 1",
-    shortLabel: "H1",
-    isActive: (activeEditor) => activeEditor.isActive("heading", { level: 1 }),
-    run: (activeEditor) => {
-      activeEditor.chain().focus().setHeading({ level: 1 }).run()
-    },
-  },
-  {
-    id: "heading-2",
-    label: "제목 2",
-    shortLabel: "H2",
-    isActive: (activeEditor) => activeEditor.isActive("heading", { level: 2 }),
-    run: (activeEditor) => {
-      activeEditor.chain().focus().setHeading({ level: 2 }).run()
-    },
-  },
-  {
-    id: "heading-3",
-    label: "제목 3",
-    shortLabel: "H3",
-    isActive: (activeEditor) => activeEditor.isActive("heading", { level: 3 }),
-    run: (activeEditor) => {
-      activeEditor.chain().focus().setHeading({ level: 3 }).run()
-    },
-  },
-  {
-    id: "heading-4",
-    label: "제목 4",
-    shortLabel: "H4",
-    isActive: (activeEditor) => activeEditor.isActive("heading", { level: 4 }),
-    run: (activeEditor) => {
-      activeEditor.chain().focus().setHeading({ level: 4 }).run()
-    },
-  },
-]
 
 type BlockMenuState =
   | {
@@ -5515,8 +5464,8 @@ const BlockEditorEngine = ({
     editor?.chain().focus().toggleStrike().run()
   }, [editor])
 
-  const activeInlineColor = normalizeInlineColorToken(String(editor?.getAttributes("inlineColor").color || ""))
-  const isInlineCodeActive = editor?.isActive("code") ?? false
+  const activeInlineColor = getActiveInlineColor(editor)
+  const isInlineCodeActive = isInlineCodeMarkActive(editor)
   const isTableMode = isTableSelectionActive(editor)
   const isTableStructuralSelection = useMemo(() => {
     if (!editor) return false
@@ -5628,9 +5577,8 @@ const BlockEditorEngine = ({
     }
   }, [editor, selectionTick])
   const activeInlineTextStyleOption = useMemo(() => {
-    if (!editor) return INLINE_TEXT_STYLE_OPTIONS[0]
     void selectionTick
-    return INLINE_TEXT_STYLE_OPTIONS.find((option) => option.isActive(editor)) || INLINE_TEXT_STYLE_OPTIONS[0]
+    return getActiveInlineTextStyleOption(editor)
   }, [editor, selectionTick])
 
   useEffect(() => {
@@ -5660,11 +5608,9 @@ const BlockEditorEngine = ({
 
   const applyInlineTextStyle = useCallback(
     (styleId: InlineTextStyleOption["id"]) => {
-      if (!editor) return
-      const option = INLINE_TEXT_STYLE_OPTIONS.find((entry) => entry.id === styleId)
-      if (!option) return
-      option.run(editor)
-      setIsBubbleTextStyleMenuOpen(false)
+      if (runInlineTextStyle(editor, styleId)) {
+        setIsBubbleTextStyleMenuOpen(false)
+      }
     },
     [editor]
   )

--- a/front/src/components/editor/inlineToolbarModel.ts
+++ b/front/src/components/editor/inlineToolbarModel.ts
@@ -1,0 +1,88 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import { normalizeInlineColorToken } from "src/libs/markdown/inlineColor"
+
+export type InlineTextStyleOption = {
+  id: "paragraph" | "heading-1" | "heading-2" | "heading-3" | "heading-4"
+  label: string
+  shortLabel: string
+  isActive: (activeEditor: TiptapEditor) => boolean
+  run: (activeEditor: TiptapEditor) => void
+}
+
+export const INLINE_TEXT_STYLE_OPTIONS: InlineTextStyleOption[] = [
+  {
+    id: "paragraph",
+    label: "본문",
+    shortLabel: "T",
+    isActive: (activeEditor) => activeEditor.isActive("paragraph"),
+    run: (activeEditor) => {
+      activeEditor.chain().focus().setParagraph().run()
+    },
+  },
+  {
+    id: "heading-1",
+    label: "제목 1",
+    shortLabel: "H1",
+    isActive: (activeEditor) => activeEditor.isActive("heading", { level: 1 }),
+    run: (activeEditor) => {
+      activeEditor.chain().focus().setHeading({ level: 1 }).run()
+    },
+  },
+  {
+    id: "heading-2",
+    label: "제목 2",
+    shortLabel: "H2",
+    isActive: (activeEditor) => activeEditor.isActive("heading", { level: 2 }),
+    run: (activeEditor) => {
+      activeEditor.chain().focus().setHeading({ level: 2 }).run()
+    },
+  },
+  {
+    id: "heading-3",
+    label: "제목 3",
+    shortLabel: "H3",
+    isActive: (activeEditor) => activeEditor.isActive("heading", { level: 3 }),
+    run: (activeEditor) => {
+      activeEditor.chain().focus().setHeading({ level: 3 }).run()
+    },
+  },
+  {
+    id: "heading-4",
+    label: "제목 4",
+    shortLabel: "H4",
+    isActive: (activeEditor) => activeEditor.isActive("heading", { level: 4 }),
+    run: (activeEditor) => {
+      activeEditor.chain().focus().setHeading({ level: 4 }).run()
+    },
+  },
+]
+
+export const getActiveInlineColor = (editor: TiptapEditor | null | undefined) =>
+  normalizeInlineColorToken(
+    String(editor?.getAttributes("inlineColor").color || "")
+  )
+
+export const isInlineCodeMarkActive = (
+  editor: TiptapEditor | null | undefined
+) => editor?.isActive("code") ?? false
+
+export const getActiveInlineTextStyleOption = (
+  editor: TiptapEditor | null | undefined
+) => {
+  if (!editor) return INLINE_TEXT_STYLE_OPTIONS[0]
+  return (
+    INLINE_TEXT_STYLE_OPTIONS.find((option) => option.isActive(editor)) ||
+    INLINE_TEXT_STYLE_OPTIONS[0]
+  )
+}
+
+export const runInlineTextStyle = (
+  editor: TiptapEditor | null | undefined,
+  styleId: InlineTextStyleOption["id"]
+) => {
+  if (!editor) return false
+  const option = INLINE_TEXT_STYLE_OPTIONS.find((entry) => entry.id === styleId)
+  if (!option) return false
+  option.run(editor)
+  return true
+}


### PR DESCRIPTION
## 관련 이슈

close #147

## 작업 배경

- `BlockEditorEngine.tsx`가 직접 소유하던 inline toolbar text style option, active inline color/code/style 계산, style command lookup을 `inlineToolbarModel.ts`로 분리했습니다.
- engine은 editor/menu open state와 UI rendering을 유지하고, inline toolbar 계산은 model import로 위임합니다.
- `main` merge 후 CI가 성공하면 기존 홈서버 자동 배포 workflow가 이어지는 경로입니다.

## 작업 내용

- inline toolbar helper를 `front/src/components/editor/inlineToolbarModel.ts`로 추가했습니다.
- `BlockEditorEngine.tsx`는 active inline color/code/style 계산과 text style 실행을 model helper로 위임합니다.
- `editor-studio-state` source guard가 model export와 engine 내 재정의 금지 문자열을 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight` (2회 통과)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (source guard RED 확인 후 GREEN 2회 통과)
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (2회 통과)
  - `yarn --cwd front lint` (2회 통과)
  - `yarn --cwd front build` (2회 통과)
  - `git diff --check`
  - `CURRENT_TASK_SLUG=editor-inline-toolbar-model-split bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: selection bubble의 글자 스타일/색상 active state 또는 style command 경로가 달라지면 작성 UX 회귀가 날 수 있습니다. 기존 로직을 model로 이동했고 authoring E2E로 bubble/inline formatting 경로를 검증했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `68fc894c`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
