### PR TITLE
[Refactor] editor block handle layout 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -144,6 +144,14 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/components/editor/blockSelectionModel.ts"),
       "utf8"
     )
+    const blockHandleLayoutModelPath = path.resolve(
+      __dirname,
+      "../src/components/editor/blockHandleLayoutModel.ts"
+    )
+    expect(existsSync(blockHandleLayoutModelPath)).toBe(true)
+    const blockHandleLayoutModelSource = existsSync(blockHandleLayoutModelPath)
+      ? readFileSync(blockHandleLayoutModelPath, "utf8")
+      : ""
     const slashMenuModelPath = path.resolve(__dirname, "../src/components/editor/slashMenuModel.ts")
     expect(existsSync(slashMenuModelPath)).toBe(true)
     const slashMenuModelSource = existsSync(slashMenuModelPath) ? readFileSync(slashMenuModelPath, "utf8") : ""
@@ -271,8 +279,19 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).not.toMatch(/const\s+isStableBlockHandleState\s*=/)
     expect(blockEditorEngineSource).not.toMatch(/const\s+isStableBlockSelectionOverlayState\s*=/)
     expect(blockEditorEngineSource).not.toMatch(/const\s+resolveOuterBlockSelectionGesture\s*=/)
+    expect(blockEditorEngineSource).toContain('from "./blockHandleLayoutModel"')
+    expect(blockEditorEngineSource).not.toMatch(/const\s+resolveBlockHandleAnchorTop\s*=/)
+    expect(blockEditorEngineSource).not.toMatch(/const\s+resolveThinBlockHandleAnchorTop\s*=/)
+    expect(blockEditorEngineSource).not.toMatch(/const\s+resolveBlockHandleRailLayout\s*=/)
+    expect(blockEditorEngineSource).not.toMatch(/const\s+shouldCenterBlockHandleForNode\s*=/)
+    expect(blockEditorEngineSource).not.toMatch(/const\s+shouldUseThinBlockHandleAnchor\s*=/)
     expect(blockSelectionModelSource).toContain("export const resolveOuterBlockSelectionGesture")
     expect(blockSelectionModelSource).toContain("export const resolveOuterListItemSelectionGesture")
+    expect(blockHandleLayoutModelSource).toContain("export const resolveBlockHandleAnchorTop")
+    expect(blockHandleLayoutModelSource).toContain("export const resolveThinBlockHandleAnchorTop")
+    expect(blockHandleLayoutModelSource).toContain("export const resolveBlockHandleRailLayout")
+    expect(blockHandleLayoutModelSource).toContain("export const shouldCenterBlockHandleForNode")
+    expect(blockHandleLayoutModelSource).toContain("export const shouldUseThinBlockHandleAnchor")
     const selectionRuleMatch = blockEditorEngineSource.match(/\.aq-block-editor__content ::selection\s*\{([^}]*)\}/)
     expect(selectionRuleMatch?.[1]).toBeTruthy()
     expect(selectionRuleMatch?.[1]).not.toMatch(/\bcolor\s*:/)

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -145,6 +145,13 @@ import {
   type BlockSelectionPointerEventLike,
   type TopLevelBlockHandleState,
 } from "./blockSelectionModel"
+import {
+  resolveBlockHandleAnchorTop,
+  resolveBlockHandleRailLayout,
+  resolveThinBlockHandleAnchorTop,
+  shouldCenterBlockHandleForNode,
+  shouldUseThinBlockHandleAnchor,
+} from "./blockHandleLayoutModel"
 import { useBlockEditorMarkdownCommit } from "./useBlockEditorMarkdownCommit"
 import {
   buildSlashMenuSections,
@@ -445,9 +452,6 @@ type TableColumnDragGuideState = {
 const BLOCK_HANDLE_MEDIA_QUERY = "(pointer: coarse)"
 const DESKTOP_TABLE_RAIL_MEDIA_QUERY = "(max-width: 768px)"
 const DEFAULT_EDITOR_READABLE_WIDTH_PX = 48 * 16
-const BLOCK_HANDLE_VIEWPORT_PADDING_PX = 12
-const BLOCK_HANDLE_GUTTER_GAP_PX = 10
-const BLOCK_HANDLE_STACKED_GAP_PX = 8
 const TABLE_ROW_RESIZE_EDGE_PX = 6
 const TABLE_COLUMN_RESIZE_GUARD_PX = 12
 const TABLE_RAIL_EDGE_PADDING_PX = 12
@@ -764,68 +768,6 @@ const selectNestedListItemTextAnchor = (editor: TiptapEditor, context: NestedLis
     return selectNestedListItemNode(editor, context)
   }
 }
-
-const resolveBlockHandleAnchorTop = (blockElement: HTMLElement, railHeight: number) => {
-  const rect = blockElement.getBoundingClientRect()
-  if (typeof window === "undefined") return rect.top + 6
-
-  const lineAnchorElement =
-    (blockElement.matches("p, h1, h2, h3, h4, blockquote")
-      ? blockElement
-      : blockElement.querySelector(":scope > p, :scope > h1, :scope > h2, :scope > h3, :scope > h4, :scope > blockquote")) ||
-    blockElement
-
-  const computedStyle = window.getComputedStyle(lineAnchorElement as Element)
-  const fontSize = Number.parseFloat(computedStyle.fontSize || "16")
-  const parsedLineHeight = Number.parseFloat(computedStyle.lineHeight || "")
-  const lineHeight =
-    Number.isFinite(parsedLineHeight) && parsedLineHeight > 0 ? parsedLineHeight : fontSize * 1.42
-
-  return rect.top + Math.max(0, (lineHeight - railHeight) / 2)
-}
-
-const resolveThinBlockHandleAnchorTop = (blockElement: HTMLElement, railHeight: number) => {
-  const rect = blockElement.getBoundingClientRect()
-  return Math.max(0, rect.top + rect.height / 2 - railHeight / 2)
-}
-
-const resolveBlockHandleRailLayout = (
-  rect: DOMRect,
-  railWidth: number,
-  railHeight: number,
-  anchoredTop: number
-) => {
-  const gutterLeft = rect.left - railWidth - BLOCK_HANDLE_GUTTER_GAP_PX
-  if (gutterLeft >= BLOCK_HANDLE_VIEWPORT_PADDING_PX || typeof window === "undefined") {
-    return {
-      left: Math.max(BLOCK_HANDLE_VIEWPORT_PADDING_PX, gutterLeft),
-      top: anchoredTop,
-    }
-  }
-
-  const maxLeft = Math.max(
-    BLOCK_HANDLE_VIEWPORT_PADDING_PX,
-    window.innerWidth - railWidth - BLOCK_HANDLE_VIEWPORT_PADDING_PX
-  )
-
-  return {
-    left: Math.min(Math.max(BLOCK_HANDLE_VIEWPORT_PADDING_PX, rect.left), maxLeft),
-    top: Math.max(BLOCK_HANDLE_VIEWPORT_PADDING_PX, rect.top - railHeight - BLOCK_HANDLE_STACKED_GAP_PX),
-  }
-}
-
-const shouldCenterBlockHandleForNode = (node?: BlockEditorDoc | null) =>
-  Boolean(
-    node &&
-      (node.type === "paragraph" ||
-        node.type === "heading" ||
-        node.type === "blockquote" ||
-        node.type === "bulletList" ||
-        node.type === "orderedList" ||
-        node.type === "taskList")
-  )
-
-const shouldUseThinBlockHandleAnchor = (node?: BlockEditorDoc | null) => Boolean(node && node.type === "horizontalRule")
 
 const isTabBlockSelectionEligible = (editor: TiptapEditor, blockIndex: number | null) => {
   if (blockIndex === null || isTableSelectionActive(editor)) return false

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -1,0 +1,73 @@
+import type { BlockEditorDoc } from "./serialization"
+
+export const BLOCK_HANDLE_VIEWPORT_PADDING_PX = 12
+export const BLOCK_HANDLE_GUTTER_GAP_PX = 10
+export const BLOCK_HANDLE_STACKED_GAP_PX = 8
+
+export type BlockHandleRailLayout = {
+  left: number
+  top: number
+}
+
+export const resolveBlockHandleAnchorTop = (blockElement: HTMLElement, railHeight: number) => {
+  const rect = blockElement.getBoundingClientRect()
+  if (typeof window === "undefined") return rect.top + 6
+
+  const lineAnchorElement =
+    (blockElement.matches("p, h1, h2, h3, h4, blockquote")
+      ? blockElement
+      : blockElement.querySelector(":scope > p, :scope > h1, :scope > h2, :scope > h3, :scope > h4, :scope > blockquote")) ||
+    blockElement
+
+  const computedStyle = window.getComputedStyle(lineAnchorElement as Element)
+  const fontSize = Number.parseFloat(computedStyle.fontSize || "16")
+  const parsedLineHeight = Number.parseFloat(computedStyle.lineHeight || "")
+  const lineHeight =
+    Number.isFinite(parsedLineHeight) && parsedLineHeight > 0 ? parsedLineHeight : fontSize * 1.42
+
+  return rect.top + Math.max(0, (lineHeight - railHeight) / 2)
+}
+
+export const resolveThinBlockHandleAnchorTop = (blockElement: HTMLElement, railHeight: number) => {
+  const rect = blockElement.getBoundingClientRect()
+  return Math.max(0, rect.top + rect.height / 2 - railHeight / 2)
+}
+
+export const resolveBlockHandleRailLayout = (
+  rect: DOMRect,
+  railWidth: number,
+  railHeight: number,
+  anchoredTop: number
+): BlockHandleRailLayout => {
+  const gutterLeft = rect.left - railWidth - BLOCK_HANDLE_GUTTER_GAP_PX
+  if (gutterLeft >= BLOCK_HANDLE_VIEWPORT_PADDING_PX || typeof window === "undefined") {
+    return {
+      left: Math.max(BLOCK_HANDLE_VIEWPORT_PADDING_PX, gutterLeft),
+      top: anchoredTop,
+    }
+  }
+
+  const maxLeft = Math.max(
+    BLOCK_HANDLE_VIEWPORT_PADDING_PX,
+    window.innerWidth - railWidth - BLOCK_HANDLE_VIEWPORT_PADDING_PX
+  )
+
+  return {
+    left: Math.min(Math.max(BLOCK_HANDLE_VIEWPORT_PADDING_PX, rect.left), maxLeft),
+    top: Math.max(BLOCK_HANDLE_VIEWPORT_PADDING_PX, rect.top - railHeight - BLOCK_HANDLE_STACKED_GAP_PX),
+  }
+}
+
+export const shouldCenterBlockHandleForNode = (node?: BlockEditorDoc | null) =>
+  Boolean(
+    node &&
+      (node.type === "paragraph" ||
+        node.type === "heading" ||
+        node.type === "blockquote" ||
+        node.type === "bulletList" ||
+        node.type === "orderedList" ||
+        node.type === "taskList")
+  )
+
+export const shouldUseThinBlockHandleAnchor = (node?: BlockEditorDoc | null) =>
+  Boolean(node && node.type === "horizontalRule")


### PR DESCRIPTION
## 관련 이슈

close #157

## 작업 배경

- `BlockEditorEngine.tsx`가 직접 들고 있던 block handle anchor/layout/thin block 판정 helper를 전용 모델 파일로 분리했습니다.
- source guard를 갱신해 같은 layout helper가 engine에 다시 쌓이는 회귀를 막습니다.
- 배포 경로는 `작업 브랜치 -> PR to main -> main merge -> 자동 배포`입니다.

## 작업 내용

- `blockHandleLayoutModel.ts`를 추가해 handle anchor, thin block anchor, viewport clamp layout, handle 대상 node 판정을 소유하게 했습니다.
- `BlockEditorEngine.tsx`는 새 모델 helper를 import해 selection/drag orchestration만 유지합니다.
- `editor-studio-state` source guard가 새 모델 존재와 engine-local helper 재도입 금지를 확인합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (RED 확인 후 2회 통과)
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (2회 통과)
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (2회 통과)
  - `yarn --cwd front lint`
  - `yarn --cwd front build` (2회 통과)
  - `git diff --check`
  - `CURRENT_TASK_SLUG=editor-block-handle-layout-model bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: block handle 위치 계산이 모델 경계로 이동하면서 좁은 화면 또는 divider/list item handle 위치가 회귀할 수 있습니다.
- 롤백 방법: 이 PR의 commit을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
