### PR TITLE
[Refactor] editor nested list item model 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -152,6 +152,14 @@ test.describe("editor studio state", () => {
     const blockHandleLayoutModelSource = existsSync(blockHandleLayoutModelPath)
       ? readFileSync(blockHandleLayoutModelPath, "utf8")
       : ""
+    const nestedListItemModelPath = path.resolve(
+      __dirname,
+      "../src/components/editor/nestedListItemModel.ts"
+    )
+    expect(existsSync(nestedListItemModelPath)).toBe(true)
+    const nestedListItemModelSource = existsSync(nestedListItemModelPath)
+      ? readFileSync(nestedListItemModelPath, "utf8")
+      : ""
     const slashMenuModelPath = path.resolve(__dirname, "../src/components/editor/slashMenuModel.ts")
     expect(existsSync(slashMenuModelPath)).toBe(true)
     const slashMenuModelSource = existsSync(slashMenuModelPath) ? readFileSync(slashMenuModelPath, "utf8") : ""
@@ -236,6 +244,7 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).toContain("border-left: 4px solid")
     expect(blockEditorEngineSource).toContain("border-radius: 0;")
     expect(blockEditorEngineSource).toContain('from "./blockSelectionModel"')
+    expect(blockEditorEngineSource).toContain('from "./nestedListItemModel"')
     expect(blockEditorEngineSource).toContain('from "./useBlockEditorMarkdownCommit"')
     expect(blockEditorEngineSource).toContain('from "./slashMenuModel"')
     expect(blockEditorEngineSource).toContain('from "./inlineToolbarModel"')
@@ -285,6 +294,12 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).not.toMatch(/const\s+resolveBlockHandleRailLayout\s*=/)
     expect(blockEditorEngineSource).not.toMatch(/const\s+shouldCenterBlockHandleForNode\s*=/)
     expect(blockEditorEngineSource).not.toMatch(/const\s+shouldUseThinBlockHandleAnchor\s*=/)
+    expect(blockEditorEngineSource).not.toContain("type NestedListItemContext =")
+    expect(blockEditorEngineSource).not.toMatch(/const\s+LIST_ITEM_SELECTOR\s*=/)
+    expect(blockEditorEngineSource).not.toMatch(/const\s+LIST_CONTAINER_SELECTOR\s*=/)
+    expect(blockEditorEngineSource).not.toMatch(/const\s+sameListPath\s*=/)
+    expect(blockEditorEngineSource).not.toMatch(/const\s+selectNestedListItemNode\s*=/)
+    expect(blockEditorEngineSource).not.toMatch(/const\s+selectNestedListItemTextAnchor\s*=/)
     expect(blockSelectionModelSource).toContain("export const resolveOuterBlockSelectionGesture")
     expect(blockSelectionModelSource).toContain("export const resolveOuterListItemSelectionGesture")
     expect(blockHandleLayoutModelSource).toContain("export const resolveBlockHandleAnchorTop")
@@ -292,6 +307,12 @@ test.describe("editor studio state", () => {
     expect(blockHandleLayoutModelSource).toContain("export const resolveBlockHandleRailLayout")
     expect(blockHandleLayoutModelSource).toContain("export const shouldCenterBlockHandleForNode")
     expect(blockHandleLayoutModelSource).toContain("export const shouldUseThinBlockHandleAnchor")
+    expect(nestedListItemModelSource).toContain("export type NestedListItemContext =")
+    expect(nestedListItemModelSource).toContain("export const LIST_ITEM_SELECTOR")
+    expect(nestedListItemModelSource).toContain("export const LIST_CONTAINER_SELECTOR")
+    expect(nestedListItemModelSource).toContain("export const sameListPath")
+    expect(nestedListItemModelSource).toContain("export const selectNestedListItemNode")
+    expect(nestedListItemModelSource).toContain("export const selectNestedListItemTextAnchor")
     const selectionRuleMatch = blockEditorEngineSource.match(/\.aq-block-editor__content ::selection\s*\{([^}]*)\}/)
     expect(selectionRuleMatch?.[1]).toBeTruthy()
     expect(selectionRuleMatch?.[1]).not.toMatch(/\bcolor\s*:/)

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -152,6 +152,18 @@ import {
   shouldCenterBlockHandleForNode,
   shouldUseThinBlockHandleAnchor,
 } from "./blockHandleLayoutModel"
+import {
+  type NestedListItemContext,
+  LIST_CONTAINER_SELECTOR,
+  LIST_ITEM_SELECTOR,
+  getActiveListItemName,
+  getListItemNameFromContext,
+  isListItemNodeName,
+  isSameNestedListItemContext,
+  sameListPath,
+  selectNestedListItemNode,
+  selectNestedListItemTextAnchor,
+} from "./nestedListItemModel"
 import { useBlockEditorMarkdownCommit } from "./useBlockEditorMarkdownCommit"
 import {
   buildSlashMenuSections,
@@ -245,15 +257,6 @@ type PendingNestedListItemHandleDragState = {
   previewLabel: string
 }
 
-type NestedListItemContext = {
-  listBlockIndex: number
-  listPath: number[]
-  itemIndex: number
-  listItemElement: HTMLElement
-  listElement: HTMLElement
-  listItems: HTMLElement[]
-}
-
 type DraggedBlockState =
   | {
       sourceIndex: number
@@ -345,53 +348,6 @@ type TableAxisReorderIndicatorState = {
   height: number
 }
 
-const LIST_ITEM_SELECTOR =
-  "li[data-type='taskItem'], li[data-task-item='true'], li[data-list-item='true'], li[data-type='listItem']"
-const LIST_CONTAINER_SELECTOR =
-  "ul[data-type='taskList'], ul[data-task-list='true'], ul[data-type='bulletList'], ol[data-type='orderedList'], ul, ol"
-const isListContainerNodeName = (nodeName: string | undefined | null) =>
-  nodeName === "bulletList" || nodeName === "orderedList" || nodeName === "taskList"
-const isListItemNodeName = (nodeName: string | undefined | null) =>
-  nodeName === "listItem" || nodeName === "taskItem"
-const getActiveListItemName = (editor: TiptapEditor): "listItem" | "taskItem" | null => {
-  const selection = editor.state.selection as typeof editor.state.selection & {
-    node?: ProseMirrorNode
-  }
-  if (selection instanceof NodeSelection) {
-    const nodeName = selection.node?.type?.name
-    if (nodeName === "taskItem") return "taskItem"
-    if (nodeName === "listItem") return "listItem"
-  }
-  const { $from } = selection
-  for (let depth = $from.depth; depth > 0; depth -= 1) {
-    const nodeName = $from.node(depth)?.type?.name
-    if (nodeName === "taskItem") return "taskItem"
-    if (nodeName === "listItem") return "listItem"
-  }
-  return null
-}
-const sameListPath = (left: number[], right: number[]) =>
-  left.length === right.length && left.every((value, index) => value === right[index])
-const getListItemNameFromContext = (
-  context: NestedListItemContext | null | undefined
-): "listItem" | "taskItem" | null => {
-  if (!context?.listItemElement) return null
-  if (context.listItemElement.matches("li[data-type='taskItem'], li[data-task-item='true']")) {
-    return "taskItem"
-  }
-  return "listItem"
-}
-const isSameNestedListItemContext = (
-  left: NestedListItemContext | null | undefined,
-  right: NestedListItemContext | null | undefined
-) =>
-  Boolean(
-    left &&
-      right &&
-      left.listBlockIndex === right.listBlockIndex &&
-      left.itemIndex === right.itemIndex &&
-      sameListPath(left.listPath, right.listPath)
-  )
 const EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT = 240
 
 const recordEditorCommitDurationForRuntimeGuard = (durationMs: number) => {
@@ -657,116 +613,6 @@ const selectTopLevelBlockNode = (editor: TiptapEditor, blockIndex: number) => {
   const selection = NodeSelection.create(doc, position)
   editor.view.dispatch(tr.setSelection(selection))
   focusEditorViewWithoutScroll(editor)
-}
-
-const getChildNodePosition = (parentNode: ProseMirrorNode, parentPos: number, childIndex: number) => {
-  let position = parentPos + 1
-  for (let index = 0; index < childIndex; index += 1) {
-    position += parentNode.child(index).nodeSize
-  }
-  return position
-}
-
-const findNestedListChildIndexInNode = (node: ProseMirrorNode | null | undefined) => {
-  if (!node) return -1
-  for (let index = 0; index < node.childCount; index += 1) {
-    if (isListContainerNodeName(node.child(index)?.type?.name)) {
-      return index
-    }
-  }
-  return -1
-}
-
-const resolveListItemNodeSelectionPos = (editor: TiptapEditor, context: NestedListItemContext) => {
-  const { doc } = editor.state
-  if (context.listBlockIndex < 0 || context.listBlockIndex >= doc.childCount) return null
-
-  let currentListNode = doc.child(context.listBlockIndex)
-  if (!isListContainerNodeName(currentListNode.type.name)) return null
-
-  let currentListPos = getTopLevelBlockPosition(editor, context.listBlockIndex)
-  for (const pathIndex of context.listPath) {
-    if (pathIndex < 0 || pathIndex >= currentListNode.childCount) return null
-    const parentItemPos = getChildNodePosition(currentListNode, currentListPos, pathIndex)
-    const parentItemNode = currentListNode.child(pathIndex)
-    const nestedListChildIndex = findNestedListChildIndexInNode(parentItemNode)
-    if (nestedListChildIndex < 0) return null
-    currentListPos = getChildNodePosition(parentItemNode, parentItemPos, nestedListChildIndex)
-    currentListNode = parentItemNode.child(nestedListChildIndex)
-    if (!isListContainerNodeName(currentListNode.type.name)) return null
-  }
-
-  if (context.itemIndex < 0 || context.itemIndex >= currentListNode.childCount) return null
-  return getChildNodePosition(currentListNode, currentListPos, context.itemIndex)
-}
-
-const selectNestedListItemNode = (editor: TiptapEditor, context: NestedListItemContext) => {
-  const resolveDomMappedSelectionPos = () => {
-    if (!(context.listItemElement instanceof HTMLElement)) return null
-
-    try {
-      const domPos = editor.view.posAtDOM(context.listItemElement, 0)
-      const candidatePositions = [domPos, domPos - 1, domPos + 1]
-
-      for (const candidatePos of candidatePositions) {
-        if (!Number.isFinite(candidatePos)) continue
-        if (candidatePos < 0 || candidatePos > editor.state.doc.content.size) continue
-
-        try {
-          const resolvedPos = editor.state.doc.resolve(candidatePos)
-          if (isListItemNodeName(resolvedPos.nodeAfter?.type?.name)) {
-            return resolvedPos.pos
-          }
-          if (isListItemNodeName(resolvedPos.nodeBefore?.type?.name)) {
-            return resolvedPos.pos - resolvedPos.nodeBefore.nodeSize
-          }
-        } catch {
-          continue
-        }
-      }
-    } catch {
-      return null
-    }
-
-    return null
-  }
-
-  const position = resolveDomMappedSelectionPos() ?? resolveListItemNodeSelectionPos(editor, context)
-  if (position === null) return false
-  const selection = NodeSelection.create(editor.state.doc, position)
-  editor.view.dispatch(editor.state.tr.setSelection(selection))
-  focusEditorViewWithoutScroll(editor)
-  return true
-}
-
-const selectNestedListItemTextAnchor = (editor: TiptapEditor, context: NestedListItemContext) => {
-  if (!(context.listItemElement instanceof HTMLElement)) return false
-
-  const walker = document.createTreeWalker(context.listItemElement, NodeFilter.SHOW_TEXT)
-  let anchorTextNode: Text | null = null
-
-  while (walker.nextNode()) {
-    const currentNode = walker.currentNode
-    if (!(currentNode instanceof Text)) continue
-    if (!currentNode.data.trim()) continue
-    anchorTextNode = currentNode
-    break
-  }
-
-  if (!anchorTextNode) {
-    return selectNestedListItemNode(editor, context)
-  }
-
-  try {
-    const anchorOffset = Math.min(anchorTextNode.data.length, 1)
-    const anchorPos = editor.view.posAtDOM(anchorTextNode, anchorOffset)
-    const selection = TextSelection.create(editor.state.doc, anchorPos)
-    editor.view.dispatch(editor.state.tr.setSelection(selection))
-    focusEditorViewWithoutScroll(editor)
-    return true
-  } catch {
-    return selectNestedListItemNode(editor, context)
-  }
 }
 
 const isTabBlockSelectionEligible = (editor: TiptapEditor, blockIndex: number | null) => {

--- a/front/src/components/editor/nestedListItemModel.ts
+++ b/front/src/components/editor/nestedListItemModel.ts
@@ -1,0 +1,209 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model"
+import { NodeSelection, TextSelection } from "@tiptap/pm/state"
+
+export type NestedListItemContext = {
+  listBlockIndex: number
+  listPath: number[]
+  itemIndex: number
+  listItemElement: HTMLElement
+  listElement: HTMLElement
+  listItems: HTMLElement[]
+}
+
+export const LIST_ITEM_SELECTOR =
+  "li[data-type='taskItem'], li[data-task-item='true'], li[data-list-item='true'], li[data-type='listItem']"
+
+export const LIST_CONTAINER_SELECTOR =
+  "ul[data-type='taskList'], ul[data-task-list='true'], ul[data-type='bulletList'], ol[data-type='orderedList'], ul, ol"
+
+export const isListContainerNodeName = (nodeName: string | undefined | null) =>
+  nodeName === "bulletList" || nodeName === "orderedList" || nodeName === "taskList"
+
+export const isListItemNodeName = (nodeName: string | undefined | null) =>
+  nodeName === "listItem" || nodeName === "taskItem"
+
+export const getActiveListItemName = (editor: TiptapEditor): "listItem" | "taskItem" | null => {
+  const selection = editor.state.selection as typeof editor.state.selection & {
+    node?: ProseMirrorNode
+  }
+  if (selection instanceof NodeSelection) {
+    const nodeName = selection.node?.type?.name
+    if (nodeName === "taskItem") return "taskItem"
+    if (nodeName === "listItem") return "listItem"
+  }
+
+  const { $from } = selection
+  for (let depth = $from.depth; depth > 0; depth -= 1) {
+    const nodeName = $from.node(depth)?.type?.name
+    if (nodeName === "taskItem") return "taskItem"
+    if (nodeName === "listItem") return "listItem"
+  }
+  return null
+}
+
+export const sameListPath = (left: number[], right: number[]) =>
+  left.length === right.length && left.every((value, index) => value === right[index])
+
+export const getListItemNameFromContext = (
+  context: NestedListItemContext | null | undefined
+): "listItem" | "taskItem" | null => {
+  if (!context?.listItemElement) return null
+  if (context.listItemElement.matches("li[data-type='taskItem'], li[data-task-item='true']")) {
+    return "taskItem"
+  }
+  return "listItem"
+}
+
+export const isSameNestedListItemContext = (
+  left: NestedListItemContext | null | undefined,
+  right: NestedListItemContext | null | undefined
+) =>
+  Boolean(
+    left &&
+      right &&
+      left.listBlockIndex === right.listBlockIndex &&
+      left.itemIndex === right.itemIndex &&
+      sameListPath(left.listPath, right.listPath)
+  )
+
+const getTopLevelBlockPosition = (editor: TiptapEditor, blockIndex: number) => {
+  const { doc } = editor.state
+  if (doc.childCount === 0) return 1
+  const clampedIndex = Math.max(0, Math.min(blockIndex, doc.childCount - 1))
+  let position = 1
+  for (let index = 0; index < clampedIndex; index += 1) {
+    position += doc.child(index).nodeSize
+  }
+  return position
+}
+
+const getChildNodePosition = (parentNode: ProseMirrorNode, parentPos: number, childIndex: number) => {
+  let position = parentPos + 1
+  for (let index = 0; index < childIndex; index += 1) {
+    position += parentNode.child(index).nodeSize
+  }
+  return position
+}
+
+const findNestedListChildIndexInNode = (node: ProseMirrorNode | null | undefined) => {
+  if (!node) return -1
+  for (let index = 0; index < node.childCount; index += 1) {
+    if (isListContainerNodeName(node.child(index)?.type?.name)) {
+      return index
+    }
+  }
+  return -1
+}
+
+const resolveListItemNodeSelectionPos = (editor: TiptapEditor, context: NestedListItemContext) => {
+  const { doc } = editor.state
+  if (context.listBlockIndex < 0 || context.listBlockIndex >= doc.childCount) return null
+
+  let currentListNode = doc.child(context.listBlockIndex)
+  if (!isListContainerNodeName(currentListNode.type.name)) return null
+
+  let currentListPos = getTopLevelBlockPosition(editor, context.listBlockIndex)
+  for (const pathIndex of context.listPath) {
+    if (pathIndex < 0 || pathIndex >= currentListNode.childCount) return null
+    const parentItemPos = getChildNodePosition(currentListNode, currentListPos, pathIndex)
+    const parentItemNode = currentListNode.child(pathIndex)
+    const nestedListChildIndex = findNestedListChildIndexInNode(parentItemNode)
+    if (nestedListChildIndex < 0) return null
+    currentListPos = getChildNodePosition(parentItemNode, parentItemPos, nestedListChildIndex)
+    currentListNode = parentItemNode.child(nestedListChildIndex)
+    if (!isListContainerNodeName(currentListNode.type.name)) return null
+  }
+
+  if (context.itemIndex < 0 || context.itemIndex >= currentListNode.childCount) return null
+  return getChildNodePosition(currentListNode, currentListPos, context.itemIndex)
+}
+
+const focusEditorViewWithoutScroll = (editor: TiptapEditor) => {
+  if (typeof window === "undefined") {
+    editor.view.focus()
+    return
+  }
+
+  const previousScrollX = window.scrollX
+  const previousScrollY = window.scrollY
+  editor.view.focus()
+  if (window.scrollX !== previousScrollX || window.scrollY !== previousScrollY) {
+    window.scrollTo(previousScrollX, previousScrollY)
+  }
+}
+
+export const selectNestedListItemNode = (editor: TiptapEditor, context: NestedListItemContext) => {
+  const resolveDomMappedSelectionPos = () => {
+    if (typeof HTMLElement === "undefined" || !(context.listItemElement instanceof HTMLElement)) return null
+
+    try {
+      const domPos = editor.view.posAtDOM(context.listItemElement, 0)
+      const candidatePositions = [domPos, domPos - 1, domPos + 1]
+
+      for (const candidatePos of candidatePositions) {
+        if (!Number.isFinite(candidatePos)) continue
+        if (candidatePos < 0 || candidatePos > editor.state.doc.content.size) continue
+
+        try {
+          const resolvedPos = editor.state.doc.resolve(candidatePos)
+          if (isListItemNodeName(resolvedPos.nodeAfter?.type?.name)) {
+            return resolvedPos.pos
+          }
+          if (isListItemNodeName(resolvedPos.nodeBefore?.type?.name)) {
+            return resolvedPos.pos - resolvedPos.nodeBefore.nodeSize
+          }
+        } catch {
+          continue
+        }
+      }
+    } catch {
+      return null
+    }
+
+    return null
+  }
+
+  const position = resolveDomMappedSelectionPos() ?? resolveListItemNodeSelectionPos(editor, context)
+  if (position === null) return false
+  const selection = NodeSelection.create(editor.state.doc, position)
+  editor.view.dispatch(editor.state.tr.setSelection(selection))
+  focusEditorViewWithoutScroll(editor)
+  return true
+}
+
+export const selectNestedListItemTextAnchor = (editor: TiptapEditor, context: NestedListItemContext) => {
+  if (
+    typeof document === "undefined" ||
+    typeof HTMLElement === "undefined" ||
+    !(context.listItemElement instanceof HTMLElement)
+  ) {
+    return false
+  }
+
+  const walker = document.createTreeWalker(context.listItemElement, NodeFilter.SHOW_TEXT)
+  let anchorTextNode: Text | null = null
+
+  while (walker.nextNode()) {
+    const currentNode = walker.currentNode
+    if (!(currentNode instanceof Text)) continue
+    if (!currentNode.data.trim()) continue
+    anchorTextNode = currentNode
+    break
+  }
+
+  if (!anchorTextNode) {
+    return selectNestedListItemNode(editor, context)
+  }
+
+  try {
+    const anchorOffset = Math.min(anchorTextNode.data.length, 1)
+    const anchorPos = editor.view.posAtDOM(anchorTextNode, anchorOffset)
+    const selection = TextSelection.create(editor.state.doc, anchorPos)
+    editor.view.dispatch(editor.state.tr.setSelection(selection))
+    focusEditorViewWithoutScroll(editor)
+    return true
+  } catch {
+    return selectNestedListItemNode(editor, context)
+  }
+}


### PR DESCRIPTION
## 관련 이슈

close #159

## 작업 배경

- BlockEditorEngine.tsx 내부에 남아 있던 nested list item context/selector/list path 비교/selection helper를 nestedListItemModel.ts로 분리했습니다.
- source guard가 새 모델 경계를 고정하도록 보강했고, list item Tab/handle/drag 회귀 세트를 반복 검증했습니다.

## 작업 내용

- nestedListItemModel.ts가 list item selector, context 타입, list path 비교, node/text anchor selection helper를 소유합니다.
- BlockEditorEngine.tsx는 해당 helper를 import해 사용하고 내부 중복 구현을 제거했습니다.
- editor-studio-state source guard가 nested list item helper 재유입을 차단합니다.

## 검증

- 실행한 명령과 결과:
  - RED: `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` 실패 확인: nestedListItemModel.ts 부재
  - `CURRENT_TASK_SLUG=editor-nested-list-item-model bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front lint`
  - `yarn --cwd front build` (2회)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (GREEN 2회)
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (2회)
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (2회)
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: helper 이동 중 list item selection pos 계산이 어긋나면 list item handle drag/anchor selection UX가 흔들릴 수 있습니다. 관련 authoring/slash 회귀를 반복 통과시켜 확인했습니다.
- 롤백 방법: 이 PR commit을 revert하면 nested list item helper가 기존 engine 내부 구현 상태로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
