### PR TITLE
[Refactor] editor nested list drag model 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -168,6 +168,14 @@ test.describe("editor studio state", () => {
     const nestedListItemModelSource = existsSync(nestedListItemModelPath)
       ? readFileSync(nestedListItemModelPath, "utf8")
       : ""
+    const nestedListItemDragModelPath = path.resolve(
+      __dirname,
+      "../src/components/editor/nestedListItemDragModel.ts"
+    )
+    expect(existsSync(nestedListItemDragModelPath)).toBe(true)
+    const nestedListItemDragModelSource = existsSync(nestedListItemDragModelPath)
+      ? readFileSync(nestedListItemDragModelPath, "utf8")
+      : ""
     const slashMenuModelPath = path.resolve(__dirname, "../src/components/editor/slashMenuModel.ts")
     expect(existsSync(slashMenuModelPath)).toBe(true)
     const slashMenuModelSource = existsSync(slashMenuModelPath) ? readFileSync(slashMenuModelPath, "utf8") : ""
@@ -323,6 +331,11 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).not.toContain("currentListElement.querySelectorAll(`:scope > ${LIST_ITEM_SELECTOR}`)")
     expect(blockEditorEngineSource).not.toContain("taskListElement.querySelectorAll(`:scope > ${LIST_ITEM_SELECTOR}`)")
     expect(blockEditorEngineSource).not.toContain("const taskItems = Array.from(")
+    expect(blockEditorEngineSource).not.toContain("type PendingNestedListItemHandleDragState =")
+    expect(blockEditorEngineSource).not.toContain("type DraggedNestedListItemState =")
+    expect(blockEditorEngineSource).not.toContain("type NestedListItemDropIndicatorState =")
+    expect(blockEditorEngineSource).not.toContain("sourceElement.textContent?.trim().slice(0, 100)")
+    expect(blockEditorEngineSource).not.toContain("sourceElement.textContent?.trim().replace(/\\s+/g, \" \").slice(0, 220)")
     expect(blockSelectionModelSource).toContain("export const resolveOuterBlockSelectionGesture")
     expect(blockSelectionModelSource).toContain("export const resolveOuterListItemSelectionGesture")
     expect(blockHandleLayoutModelSource).toContain("export const resolveBlockHandleAnchorTop")
@@ -342,6 +355,14 @@ test.describe("editor studio state", () => {
     expect(nestedListItemModelSource).toContain("export const resolveSelectionAnchorNestedListItemContext")
     expect(nestedListItemModelSource).toContain("export const resolveNestedListItemContextByIndices")
     expect(nestedListItemModelSource).toContain("export const resolveNestedListItemDropIndicator")
+    expect(nestedListItemDragModelSource).toContain("export type PendingNestedListItemHandleDragState")
+    expect(nestedListItemDragModelSource).toContain("export type DraggedNestedListItemState")
+    expect(nestedListItemDragModelSource).toContain("export type NestedListItemDropIndicatorState")
+    expect(nestedListItemDragModelSource).toContain("export const createNestedListItemDragPreview")
+    expect(nestedListItemDragModelSource).toContain("export const createDraggedNestedListItemState")
+    expect(nestedListItemDragModelSource).toContain("export const createNestedListItemDropIndicatorState")
+    expect(nestedListItemDragModelSource).toContain("export const hideNestedListItemDropIndicatorState")
+    expect(nestedListItemDragModelSource).toContain("export const isNestedListItemContextInDraggedList")
     const selectionRuleMatch = blockEditorEngineSource.match(/\.aq-block-editor__content ::selection\s*\{([^}]*)\}/)
     expect(selectionRuleMatch?.[1]).toBeTruthy()
     expect(selectionRuleMatch?.[1]).not.toMatch(/\bcolor\s*:/)

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -168,6 +168,18 @@ import {
   selectNestedListItemNode,
   selectNestedListItemTextAnchor,
 } from "./nestedListItemModel"
+import {
+  type DraggedNestedListItemState,
+  type NestedListItemDropIndicatorState,
+  type PendingNestedListItemHandleDragState,
+  createDraggedNestedListItemState,
+  createHiddenNestedListItemDropIndicatorState,
+  createNestedListItemDragPreview,
+  createNestedListItemDropIndicatorState,
+  createPendingNestedListItemHandleDragState,
+  hideNestedListItemDropIndicatorState,
+  isNestedListItemContextInDraggedList,
+} from "./nestedListItemDragModel"
 import { useBlockEditorMarkdownCommit } from "./useBlockEditorMarkdownCommit"
 import {
   buildSlashMenuSections,
@@ -246,21 +258,6 @@ type PendingBlockDragState = {
   previewLabel: string
 }
 
-type PendingNestedListItemHandleDragState = {
-  pointerId: number
-  startX: number
-  startY: number
-  started: boolean
-  context: NestedListItemContext
-  targetListBlockIndex: number | null
-  targetListPath: number[] | null
-  insertionIndex: number | null
-  previewWidth: number
-  previewHeight: number
-  previewText: string
-  previewLabel: string
-}
-
 type DraggedBlockState =
   | {
       sourceIndex: number
@@ -271,38 +268,6 @@ type DraggedBlockState =
       previewLabel: string
     }
   | null
-
-type DraggedNestedListItemState =
-  | {
-      listBlockIndex: number
-      listPath: number[]
-      sourceItemIndex: number
-      previewWidth: number
-      previewHeight: number
-      previewText: string
-      previewLabel: string
-    }
-  | null
-
-type NestedListItemDropIndicatorState =
-  | {
-      visible: boolean
-      listBlockIndex: number
-      listPath: number[]
-      insertionIndex: number
-      top: number
-      left: number
-      width: number
-    }
-  | {
-      visible: false
-      listBlockIndex: number
-      listPath: number[]
-      insertionIndex: number
-      top: number
-      left: number
-      width: number
-    }
 
 type DropIndicatorState = {
   visible: boolean
@@ -1255,15 +1220,8 @@ const BlockEditorEngine = ({
     highlightHeight: 0,
   })
   const [draggedNestedListItemState, setDraggedNestedListItemState] = useState<DraggedNestedListItemState>(null)
-  const [nestedListItemDropIndicatorState, setNestedListItemDropIndicatorState] = useState<NestedListItemDropIndicatorState>({
-    visible: false,
-    listBlockIndex: 0,
-    listPath: [],
-    insertionIndex: 0,
-    top: 0,
-    left: 0,
-    width: 0,
-  })
+  const [nestedListItemDropIndicatorState, setNestedListItemDropIndicatorState] =
+    useState<NestedListItemDropIndicatorState>(createHiddenNestedListItemDropIndicatorState)
   const [selectionTick, setSelectionTick] = useState(0)
 
   const updateTableCornerPreviewState = useCallback(
@@ -7237,28 +7195,14 @@ const BlockEditorEngine = ({
         }
       }
       const sourceElement = listItemContext.listItemElement
-      const sourceRect = sourceElement.getBoundingClientRect()
-      const previewWidth = sourceRect
-        ? Math.round(Math.min(Math.max(sourceRect.width, 320), Math.max(320, window.innerWidth - 48)))
-        : 480
-      const previewHeight = sourceRect ? Math.round(Math.min(Math.max(sourceRect.height, 44), 320)) : 120
-      const previewLabel = sourceElement.textContent?.trim().slice(0, 100) || "목록 항목 이동"
-      const previewText = sourceElement.textContent?.trim().replace(/\s+/g, " ").slice(0, 220) || previewLabel
-      setDraggedNestedListItemState({
-        listBlockIndex: listItemContext.listBlockIndex,
-        listPath: listItemContext.listPath,
-        sourceItemIndex: listItemContext.itemIndex,
-        previewWidth,
-        previewHeight,
-        previewText,
-        previewLabel,
-      })
-      setNestedListItemDropIndicatorState({
-        visible: true,
-        listBlockIndex: listItemContext.listBlockIndex,
-        listPath: listItemContext.listPath,
-        ...resolveNestedListItemDropIndicatorByClientY(listItemContext.listElement, event.clientY),
-      })
+      const preview = createNestedListItemDragPreview(sourceElement, window.innerWidth)
+      setDraggedNestedListItemState(createDraggedNestedListItemState(listItemContext, preview))
+      setNestedListItemDropIndicatorState(
+        createNestedListItemDropIndicatorState(
+          listItemContext,
+          resolveNestedListItemDropIndicatorByClientY(listItemContext.listElement, event.clientY)
+        )
+      )
       event.dataTransfer.effectAllowed = "move"
       event.dataTransfer.setData("text/plain", `list-item:${listItemContext.listBlockIndex}:${listItemContext.itemIndex}`)
     },
@@ -7276,21 +7220,17 @@ const BlockEditorEngine = ({
     (event: ReactDragEvent<HTMLDivElement>) => {
       if (!draggedNestedListItemState) return
       const taskItemContext = findNestedListItemContextFromTarget(event.target)
-      if (
-        !taskItemContext ||
-        taskItemContext.listBlockIndex !== draggedNestedListItemState.listBlockIndex ||
-        taskItemContext.listPath.join(",") !== draggedNestedListItemState.listPath.join(",")
-      ) {
+      if (!isNestedListItemContextInDraggedList(taskItemContext, draggedNestedListItemState)) {
         return
       }
 
       event.preventDefault()
-      setNestedListItemDropIndicatorState({
-        visible: true,
-        listBlockIndex: taskItemContext.listBlockIndex,
-        listPath: taskItemContext.listPath,
-        ...resolveNestedListItemDropIndicatorByClientY(taskItemContext.listElement, event.clientY),
-      })
+      setNestedListItemDropIndicatorState(
+        createNestedListItemDropIndicatorState(
+          taskItemContext,
+          resolveNestedListItemDropIndicatorByClientY(taskItemContext.listElement, event.clientY)
+        )
+      )
     },
     [draggedNestedListItemState, findNestedListItemContextFromTarget, resolveNestedListItemDropIndicatorByClientY]
   )
@@ -7298,7 +7238,7 @@ const BlockEditorEngine = ({
   const clearNestedListItemDragState = useCallback(() => {
     setDraggedNestedListItemState(null)
     setDragGhostPosition(null)
-    setNestedListItemDropIndicatorState((prev) => ({ ...prev, visible: false }))
+    setNestedListItemDropIndicatorState(hideNestedListItemDropIndicatorState)
   }, [])
 
   const resolveNestedListItemContextFromBlockHandleState = useCallback(() => {
@@ -7402,27 +7342,14 @@ const BlockEditorEngine = ({
       if (sourceElement.isConnected) {
         sourceElement.setAttribute("draggable", "false")
       }
-      const sourceRect = sourceElement.getBoundingClientRect()
-      const previewWidth = sourceRect
-        ? Math.round(Math.min(Math.max(sourceRect.width, 320), Math.max(320, window.innerWidth - 48)))
-        : 480
-      const previewHeight = sourceRect ? Math.round(Math.min(Math.max(sourceRect.height, 44), 320)) : 120
-      const previewLabel = sourceElement.textContent?.trim().slice(0, 100) || "목록 항목 이동"
-      const previewText = sourceElement.textContent?.trim().replace(/\s+/g, " ").slice(0, 220) || previewLabel
-      pendingNestedListItemHandleDragRef.current = {
+      const preview = createNestedListItemDragPreview(sourceElement, window.innerWidth)
+      pendingNestedListItemHandleDragRef.current = createPendingNestedListItemHandleDragState(
         pointerId,
         startX,
         startY,
-        started: false,
         context,
-        targetListBlockIndex: null,
-        targetListPath: null,
-        insertionIndex: null,
-        previewWidth,
-        previewHeight,
-        previewText,
-        previewLabel,
-      }
+        preview
+      )
       clearStickyTopLevelBlockSelection()
       const currentEditor = editorRef.current ?? editor
       if (currentEditor) {
@@ -7437,15 +7364,7 @@ const BlockEditorEngine = ({
         if (!pending.started) {
           if (distance < 5) return
           pending.started = true
-          setDraggedNestedListItemState({
-            listBlockIndex: pending.context.listBlockIndex,
-            listPath: pending.context.listPath,
-            sourceItemIndex: pending.context.itemIndex,
-            previewWidth: pending.previewWidth,
-            previewHeight: pending.previewHeight,
-            previewText: pending.previewText,
-            previewLabel: pending.previewLabel,
-          })
+          setDraggedNestedListItemState(createDraggedNestedListItemState(pending.context, pending))
         }
 
         const activeListContext =
@@ -7467,7 +7386,7 @@ const BlockEditorEngine = ({
           pending.targetListBlockIndex = null
           pending.targetListPath = null
           pending.insertionIndex = null
-          setNestedListItemDropIndicatorState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
+          setNestedListItemDropIndicatorState(hideNestedListItemDropIndicatorState)
           return
         }
 
@@ -7475,12 +7394,7 @@ const BlockEditorEngine = ({
         pending.targetListBlockIndex = activeListContext.listBlockIndex
         pending.targetListPath = [...activeListContext.listPath]
         pending.insertionIndex = indicator.insertionIndex
-        setNestedListItemDropIndicatorState({
-          visible: true,
-          listBlockIndex: activeListContext.listBlockIndex,
-          listPath: activeListContext.listPath,
-          ...indicator,
-        })
+        setNestedListItemDropIndicatorState(createNestedListItemDropIndicatorState(activeListContext, indicator))
       }
 
       const handlePointerDone = (doneEvent: PointerEvent) => {
@@ -7562,11 +7476,7 @@ const BlockEditorEngine = ({
     (event: ReactDragEvent<HTMLDivElement>) => {
       if (!draggedNestedListItemState) return
       const taskItemContext = findNestedListItemContextFromTarget(event.target)
-      if (
-        !taskItemContext ||
-        taskItemContext.listBlockIndex !== draggedNestedListItemState.listBlockIndex ||
-        taskItemContext.listPath.join(",") !== draggedNestedListItemState.listPath.join(",")
-      ) {
+      if (!isNestedListItemContextInDraggedList(taskItemContext, draggedNestedListItemState)) {
         clearNestedListItemDragState()
         return
       }

--- a/front/src/components/editor/nestedListItemDragModel.ts
+++ b/front/src/components/editor/nestedListItemDragModel.ts
@@ -1,0 +1,122 @@
+import type {
+  NestedListItemContext,
+  NestedListItemDropIndicatorGeometry,
+} from "./nestedListItemModel"
+import { sameListPath } from "./nestedListItemModel"
+
+export type NestedListItemDragPreview = {
+  previewWidth: number
+  previewHeight: number
+  previewText: string
+  previewLabel: string
+}
+
+export type PendingNestedListItemHandleDragState = {
+  pointerId: number
+  startX: number
+  startY: number
+  started: boolean
+  context: NestedListItemContext
+  targetListBlockIndex: number | null
+  targetListPath: number[] | null
+  insertionIndex: number | null
+} & NestedListItemDragPreview
+
+export type DraggedNestedListItemState =
+  | ({
+      listBlockIndex: number
+      listPath: number[]
+      sourceItemIndex: number
+    } & NestedListItemDragPreview)
+  | null
+
+export type NestedListItemDropIndicatorState = {
+  visible: boolean
+  listBlockIndex: number
+  listPath: number[]
+  insertionIndex: number
+  top: number
+  left: number
+  width: number
+}
+
+export const createHiddenNestedListItemDropIndicatorState = (): NestedListItemDropIndicatorState => ({
+  visible: false,
+  listBlockIndex: -1,
+  listPath: [],
+  insertionIndex: -1,
+  top: 0,
+  left: 0,
+  width: 0,
+})
+
+export const createNestedListItemDragPreview = (
+  sourceElement: HTMLElement,
+  viewportWidth: number
+): NestedListItemDragPreview => {
+  const sourceRect = sourceElement.getBoundingClientRect()
+  const trimmedText = sourceElement.textContent?.trim() ?? ""
+  const previewLabel = trimmedText.slice(0, 100) || "목록 항목 이동"
+  const previewText = trimmedText.replace(/\s+/g, " ").slice(0, 220) || previewLabel
+  const effectiveViewportWidth = Number.isFinite(viewportWidth) && viewportWidth > 0 ? viewportWidth : 528
+
+  return {
+    previewWidth: Math.round(Math.min(Math.max(sourceRect.width, 320), Math.max(320, effectiveViewportWidth - 48))),
+    previewHeight: Math.round(Math.min(Math.max(sourceRect.height, 44), 320)),
+    previewText,
+    previewLabel,
+  }
+}
+
+export const createDraggedNestedListItemState = (
+  context: NestedListItemContext,
+  preview: NestedListItemDragPreview
+): DraggedNestedListItemState => ({
+  listBlockIndex: context.listBlockIndex,
+  listPath: [...context.listPath],
+  sourceItemIndex: context.itemIndex,
+  ...preview,
+})
+
+export const createPendingNestedListItemHandleDragState = (
+  pointerId: number,
+  startX: number,
+  startY: number,
+  context: NestedListItemContext,
+  preview: NestedListItemDragPreview
+): PendingNestedListItemHandleDragState => ({
+  pointerId,
+  startX,
+  startY,
+  started: false,
+  context,
+  targetListBlockIndex: null,
+  targetListPath: null,
+  insertionIndex: null,
+  ...preview,
+})
+
+export const createNestedListItemDropIndicatorState = (
+  context: NestedListItemContext,
+  indicator: NestedListItemDropIndicatorGeometry
+): NestedListItemDropIndicatorState => ({
+  visible: true,
+  listBlockIndex: context.listBlockIndex,
+  listPath: [...context.listPath],
+  ...indicator,
+})
+
+export const hideNestedListItemDropIndicatorState = (
+  state: NestedListItemDropIndicatorState
+): NestedListItemDropIndicatorState => (state.visible ? { ...state, visible: false } : state)
+
+export const isNestedListItemContextInDraggedList = (
+  context: NestedListItemContext | null | undefined,
+  draggedState: DraggedNestedListItemState
+): context is NestedListItemContext =>
+  Boolean(
+    context &&
+      draggedState &&
+      context.listBlockIndex === draggedState.listBlockIndex &&
+      sameListPath(context.listPath, draggedState.listPath)
+  )


### PR DESCRIPTION
## 관련 이슈

close #165

## 작업 배경

- `BlockEditorEngine.tsx`에 남아 있던 nested list item drag state 타입과 preview/drop state helper를 `nestedListItemDragModel.ts`로 분리했습니다.
- engine은 drag/drop 이벤트 wiring과 editor mutation만 유지하고, drag preview/state/drop indicator state 생성은 모델 helper를 호출합니다.

## 작업 내용

- nested list item pending drag session, dragged state, drop indicator state 타입을 새 모델 파일로 이동했습니다.
- drag preview width/height/text/label 계산과 same-list context 판정을 helper로 분리했습니다.
- source guard를 확장해 engine에 drag state 타입/preview 계산이 되돌아오는 회귀를 차단했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-nested-list-drag-model bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (RED 1회, GREEN 2회 이상)
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (2회 이상)
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (2회 이상)
  - `yarn --cwd front lint`
  - `yarn --cwd front build` (2회 이상)
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: nested list item drag preview/drop indicator state helper 경계 변경으로 list item reorder 피드백에 회귀가 생길 수 있습니다. 관련 E2E의 engine/writer list item drag reorder 케이스와 slash task drag reorder 케이스로 확인했습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 기존 engine 내부 drag state 경로로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
