### PR TITLE
[Refactor] editor table axis drag model 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -163,6 +163,11 @@ test.describe("editor studio state", () => {
     const blockDragModelPath = path.resolve(__dirname, "../src/components/editor/blockDragModel.ts")
     expect(existsSync(blockDragModelPath)).toBe(true)
     const blockDragModelSource = existsSync(blockDragModelPath) ? readFileSync(blockDragModelPath, "utf8") : ""
+    const tableAxisDragModelPath = path.resolve(__dirname, "../src/components/editor/tableAxisDragModel.ts")
+    expect(existsSync(tableAxisDragModelPath)).toBe(true)
+    const tableAxisDragModelSource = existsSync(tableAxisDragModelPath)
+      ? readFileSync(tableAxisDragModelPath, "utf8")
+      : ""
     const nestedListItemModelPath = path.resolve(
       __dirname,
       "../src/components/editor/nestedListItemModel.ts"
@@ -320,6 +325,7 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).not.toMatch(/const\s+resolveOuterBlockSelectionGesture\s*=/)
     expect(blockEditorEngineSource).toContain('from "./blockHandleLayoutModel"')
     expect(blockEditorEngineSource).toContain('from "./blockDragModel"')
+    expect(blockEditorEngineSource).toContain('from "./tableAxisDragModel"')
     expect(blockEditorEngineSource).not.toMatch(/const\s+resolveBlockHandleAnchorTop\s*=/)
     expect(blockEditorEngineSource).not.toMatch(/const\s+resolveThinBlockHandleAnchorTop\s*=/)
     expect(blockEditorEngineSource).not.toMatch(/const\s+resolveBlockHandleRailLayout\s*=/)
@@ -331,6 +337,11 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).not.toContain("const resolveDropIndicatorByClientY = useCallback(")
     expect(blockEditorEngineSource).not.toContain("sourceElement?.textContent?.trim().slice(0, 100)")
     expect(blockEditorEngineSource).not.toContain("sourceElement?.textContent?.trim().replace(/\\s+/g, \" \").slice(0, 220)")
+    expect(blockEditorEngineSource).not.toContain("type PendingTableAxisDragState =")
+    expect(blockEditorEngineSource).not.toContain("type DraggedTableAxisState =")
+    expect(blockEditorEngineSource).not.toContain("type TableAxisReorderIndicatorState =")
+    expect(blockEditorEngineSource).not.toContain("const resolveTableAxisReorderIndicator = useCallback(")
+    expect(blockEditorEngineSource).not.toContain("const resolveTableAxisIndexFromPointer = useCallback(")
     expect(blockEditorEngineSource).not.toContain("type NestedListItemContext =")
     expect(blockEditorEngineSource).not.toMatch(/const\s+LIST_ITEM_SELECTOR\s*=/)
     expect(blockEditorEngineSource).not.toMatch(/const\s+LIST_CONTAINER_SELECTOR\s*=/)
@@ -363,6 +374,16 @@ test.describe("editor studio state", () => {
     expect(blockDragModelSource).toContain("export const createDropIndicatorState")
     expect(blockDragModelSource).toContain("export const hideDropIndicatorState")
     expect(blockDragModelSource).toContain("export const resolveBlockDropIndicatorByClientY")
+    expect(tableAxisDragModelSource).toContain("export type PendingTableAxisDragState")
+    expect(tableAxisDragModelSource).toContain("export type DraggedTableAxisState")
+    expect(tableAxisDragModelSource).toContain("export type TableAxisReorderIndicatorState")
+    expect(tableAxisDragModelSource).toContain("export const createHiddenTableAxisReorderIndicatorState")
+    expect(tableAxisDragModelSource).toContain("export const createPendingTableAxisDragState")
+    expect(tableAxisDragModelSource).toContain("export const createDraggedTableAxisState")
+    expect(tableAxisDragModelSource).toContain("export const createTableAxisDragGhostPosition")
+    expect(tableAxisDragModelSource).toContain("export const hideTableAxisReorderIndicatorState")
+    expect(tableAxisDragModelSource).toContain("export const resolveTableAxisReorderIndicator")
+    expect(tableAxisDragModelSource).toContain("export const resolveTableAxisIndexFromPointer")
     expect(nestedListItemModelSource).toContain("export type NestedListItemContext =")
     expect(nestedListItemModelSource).toContain("export const LIST_ITEM_SELECTOR")
     expect(nestedListItemModelSource).toContain("export const LIST_CONTAINER_SELECTOR")

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -104,6 +104,20 @@ import {
   resolveTableCornerPreviewState,
 } from "./tableCornerGrowModel"
 import {
+  type DraggedTableAxisState,
+  type PendingTableAxisDragState,
+  type TableAxis,
+  type TableAxisDragGhostPosition,
+  type TableAxisReorderIndicatorState,
+  createDraggedTableAxisState,
+  createHiddenTableAxisReorderIndicatorState,
+  createPendingTableAxisDragState,
+  createTableAxisDragGhostPosition,
+  hideTableAxisReorderIndicatorState,
+  resolveTableAxisIndexFromPointer,
+  resolveTableAxisReorderIndicator,
+} from "./tableAxisDragModel"
+import {
   TABLE_OVERFLOW_MODE_WIDE,
   TABLE_WIDTH_BUDGET_META_KEY,
   computeNextTableColumnWidthsForResize,
@@ -257,42 +271,6 @@ type TableOverflowCoachmarkState = {
   visible: boolean
   left: number
   top: number
-}
-
-type PendingTableAxisDragState = {
-  axis: "row" | "column"
-  sourceIndex: number
-  pointerId: number
-  tablePos: number
-  startX: number
-  startY: number
-  previewLeft: number
-  previewTop: number
-  previewWidth: number
-  previewHeight: number
-}
-
-type DraggedTableAxisState =
-  | {
-      axis: "row" | "column"
-      sourceIndex: number
-      pointerId: number
-      tablePos: number
-      previewLeft: number
-      previewTop: number
-      previewWidth: number
-      previewHeight: number
-    }
-  | null
-
-type TableAxisReorderIndicatorState = {
-  visible: boolean
-  axis: "row" | "column"
-  insertionIndex: number
-  left: number
-  top: number
-  width: number
-  height: number
 }
 
 const EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT = 240
@@ -1174,16 +1152,9 @@ const BlockEditorEngine = ({
     rowSteps: 0,
   })
   const [draggedTableAxisState, setDraggedTableAxisState] = useState<DraggedTableAxisState>(null)
-  const [tableAxisDragGhostPosition, setTableAxisDragGhostPosition] = useState<{ x: number; y: number } | null>(null)
-  const [tableAxisReorderIndicatorState, setTableAxisReorderIndicatorState] = useState<TableAxisReorderIndicatorState>({
-    visible: false,
-    axis: "row",
-    insertionIndex: 0,
-    left: 0,
-    top: 0,
-    width: 0,
-    height: 0,
-  })
+  const [tableAxisDragGhostPosition, setTableAxisDragGhostPosition] = useState<TableAxisDragGhostPosition>(null)
+  const [tableAxisReorderIndicatorState, setTableAxisReorderIndicatorState] =
+    useState<TableAxisReorderIndicatorState>(createHiddenTableAxisReorderIndicatorState)
   const [draggedBlockState, setDraggedBlockState] = useState<DraggedBlockState>(null)
   const [dragGhostPosition, setDragGhostPosition] = useState<{ x: number; y: number } | null>(null)
   const [dropIndicatorState, setDropIndicatorState] = useState<DropIndicatorState>(createHiddenDropIndicatorState)
@@ -1664,120 +1635,6 @@ const BlockEditorEngine = ({
       pendingTableAxisDragCleanupRef.current = null
     }
   }, [])
-
-  const resolveTableAxisReorderIndicator = useCallback(
-    (axis: "row" | "column", sourceIndex: number, clientX: number, clientY: number) => {
-      const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
-      if (!renderedTable) return null
-
-      const tableRect = renderedTable.getBoundingClientRect()
-      const rows = Array.from(renderedTable.querySelectorAll("tr")).filter(
-        (row): row is HTMLTableRowElement => row instanceof HTMLTableRowElement && row.cells.length > 0
-      )
-      if (rows.length === 0) return null
-
-      if (axis === "row") {
-        const boundedSourceIndex = Math.max(0, Math.min(sourceIndex, rows.length - 1))
-        let insertionIndex = rows.length
-        let top = tableRect.bottom
-
-        rows.forEach((row, rowIndex) => {
-          if (insertionIndex !== rows.length) return
-          const rowRect = row.getBoundingClientRect()
-          if (clientY < rowRect.top + rowRect.height / 2) {
-            insertionIndex = rowIndex
-            top = rowRect.top
-          }
-        })
-
-        return {
-          visible: true,
-          axis,
-          insertionIndex,
-          left: Math.round(tableRect.left),
-          top: Math.round(top),
-          width: Math.round(tableRect.width),
-          height: Math.max(2, Math.round(Math.min(rows[boundedSourceIndex]?.getBoundingClientRect().height ?? 2, 3))),
-        }
-      }
-
-      const firstRowCells = Array.from(rows[0].cells).filter(
-        (cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement
-      )
-      if (firstRowCells.length === 0) return null
-
-      let insertionIndex = firstRowCells.length
-      let left = tableRect.right
-      firstRowCells.forEach((cell, columnIndex) => {
-        if (insertionIndex !== firstRowCells.length) return
-        const cellRect = cell.getBoundingClientRect()
-        if (clientX < cellRect.left + cellRect.width / 2) {
-          insertionIndex = columnIndex
-          left = cellRect.left
-        }
-      })
-
-      return {
-        visible: true,
-        axis,
-        insertionIndex,
-        left: Math.round(left),
-        top: Math.round(tableRect.top),
-        width: 2,
-        height: Math.round(tableRect.height),
-      }
-    },
-    []
-  )
-
-  const resolveTableAxisIndexFromPointer = useCallback(
-    (axis: "row" | "column", clientX: number, clientY: number) => {
-      const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
-      if (!renderedTable) return null
-
-      const rows = Array.from(renderedTable.querySelectorAll("tr")).filter(
-        (row): row is HTMLTableRowElement => row instanceof HTMLTableRowElement && row.cells.length > 0
-      )
-      if (rows.length === 0) return null
-
-      if (axis === "row") {
-        const matchedRowIndex = rows.findIndex((row) => {
-          const rowRect = row.getBoundingClientRect()
-          return clientY >= rowRect.top && clientY <= rowRect.bottom
-        })
-        if (matchedRowIndex >= 0) return matchedRowIndex
-
-        return rows.reduce((bestIndex, row, rowIndex) => {
-          const rowRect = row.getBoundingClientRect()
-          const nextDistance = Math.abs(clientY - (rowRect.top + rowRect.height / 2))
-          const currentDistance = Math.abs(
-            clientY - (rows[bestIndex].getBoundingClientRect().top + rows[bestIndex].getBoundingClientRect().height / 2)
-          )
-          return nextDistance < currentDistance ? rowIndex : bestIndex
-        }, 0)
-      }
-
-      const firstRowCells = Array.from(rows[0].cells).filter(
-        (cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement
-      )
-      if (firstRowCells.length === 0) return null
-
-      const matchedColumnIndex = firstRowCells.findIndex((cell) => {
-        const cellRect = cell.getBoundingClientRect()
-        return clientX >= cellRect.left && clientX <= cellRect.right
-      })
-      if (matchedColumnIndex >= 0) return matchedColumnIndex
-
-      return firstRowCells.reduce((bestIndex, cell, columnIndex) => {
-        const cellRect = cell.getBoundingClientRect()
-        const nextDistance = Math.abs(clientX - (cellRect.left + cellRect.width / 2))
-        const currentRect = firstRowCells[bestIndex].getBoundingClientRect()
-        const currentDistance = Math.abs(clientX - (currentRect.left + currentRect.width / 2))
-        return nextDistance < currentDistance ? columnIndex : bestIndex
-      }, 0)
-    },
-    []
-  )
 
   const beginBlockDragFromPending = useCallback(
     (pending: PendingBlockDragState, clientX: number, clientY: number) => {
@@ -2423,16 +2280,7 @@ const BlockEditorEngine = ({
 
   const beginTableAxisDragFromPending = useCallback(
     (pending: PendingTableAxisDragState, clientX: number, clientY: number) => {
-      const nextDragState = {
-        axis: pending.axis,
-        sourceIndex: pending.sourceIndex,
-        pointerId: pending.pointerId,
-        tablePos: pending.tablePos,
-        previewLeft: pending.previewLeft,
-        previewTop: pending.previewTop,
-        previewWidth: pending.previewWidth,
-        previewHeight: pending.previewHeight,
-      } satisfies Exclude<DraggedTableAxisState, null>
+      const nextDragState = createDraggedTableAxisState(pending)
       tableAxisDragSuppressClickRef.current = true
       const currentEditor = editorRef.current
       if (currentEditor) {
@@ -2441,39 +2289,27 @@ const BlockEditorEngine = ({
       setTableMenuState(null)
       cancelTableQuickRailHide()
       setDraggedTableAxisState(nextDragState)
+      const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
       setTableAxisReorderIndicatorState(
-        resolveTableAxisReorderIndicator(pending.axis, pending.sourceIndex, clientX, clientY) ?? {
-          visible: false,
-          axis: pending.axis,
-          insertionIndex: pending.sourceIndex,
-          left: 0,
-          top: 0,
-          width: 0,
-          height: 0,
-        }
+        resolveTableAxisReorderIndicator(renderedTable, pending.axis, pending.sourceIndex, clientX, clientY) ??
+          createHiddenTableAxisReorderIndicatorState(pending.axis, pending.sourceIndex)
       )
-      setTableAxisDragGhostPosition(
-        pending.axis === "row"
-          ? {
-              x: pending.previewLeft,
-              y: Math.round(clientY - pending.previewHeight / 2),
-            }
-          : null
-      )
+      setTableAxisDragGhostPosition(createTableAxisDragGhostPosition(pending, clientY))
       return nextDragState
     },
-    [cancelTableQuickRailHide, resolveTableAxisReorderIndicator, selectTableAxisAtIndex]
+    [cancelTableQuickRailHide, selectTableAxisAtIndex]
   )
 
   const startPendingTableAxisDrag = useCallback(
-    (axis: "row" | "column", sourceIndex: number, pointerId: number, clientX: number, clientY: number) => {
+    (axis: TableAxis, sourceIndex: number, pointerId: number, clientX: number, clientY: number) => {
       const currentEditor = editorRef.current
       if (!currentEditor) return
 
       const tableRect = getCurrentSelectedTableRect(currentEditor)
       const tablePos = tableRect ? Math.max(0, tableRect.tableStart - 1) : null
       if (!tableRect || tablePos === null) return
-      const resolvedSourceIndex = resolveTableAxisIndexFromPointer(axis, clientX, clientY) ?? sourceIndex
+      const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
+      const resolvedSourceIndex = resolveTableAxisIndexFromPointer(renderedTable, axis, clientX, clientY) ?? sourceIndex
 
       const withinBounds =
         axis === "row"
@@ -2484,18 +2320,15 @@ const BlockEditorEngine = ({
       clearPendingTableAxisDrag()
       tableAxisDragSuppressClickRef.current = false
 
-      pendingTableAxisDragRef.current = {
+      pendingTableAxisDragRef.current = createPendingTableAxisDragState(
         axis,
-        sourceIndex: resolvedSourceIndex,
+        resolvedSourceIndex,
         pointerId,
         tablePos,
-        startX: clientX,
-        startY: clientY,
-        previewLeft: axis === "row" ? tableAffordanceGeometryRef.current.tableLeft : tableAffordanceGeometryRef.current.columnLeft,
-        previewTop: axis === "row" ? tableAffordanceGeometryRef.current.rowTop : tableAffordanceGeometryRef.current.tableTop,
-        previewWidth: axis === "row" ? tableAffordanceGeometryRef.current.width : tableAffordanceGeometryRef.current.columnWidth,
-        previewHeight: axis === "row" ? tableAffordanceGeometryRef.current.rowHeight : tableAffordanceGeometryRef.current.height,
-      }
+        clientX,
+        clientY,
+        tableAffordanceGeometryRef.current
+      )
 
       const DRAG_THRESHOLD_PX = 5
       let activeDragState: Exclude<DraggedTableAxisState, null> | null = null
@@ -2503,28 +2336,20 @@ const BlockEditorEngine = ({
       const handlePendingPointerMove = (moveEvent: PointerEvent) => {
         if (activeDragState) {
           if (moveEvent.pointerId !== activeDragState.pointerId) return
+          const activeRenderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
           const nextIndicator = resolveTableAxisReorderIndicator(
+            activeRenderedTable,
             activeDragState.axis,
             activeDragState.sourceIndex,
             moveEvent.clientX,
             moveEvent.clientY
           )
           setTableAxisReorderIndicatorState(
-            nextIndicator ?? {
-              visible: false,
-              axis: activeDragState.axis,
-              insertionIndex: activeDragState.sourceIndex,
-              left: 0,
-              top: 0,
-              width: 0,
-              height: 0,
-            }
+            nextIndicator ??
+              createHiddenTableAxisReorderIndicatorState(activeDragState.axis, activeDragState.sourceIndex)
           )
           if (activeDragState.axis === "row") {
-            setTableAxisDragGhostPosition({
-              x: activeDragState.previewLeft,
-              y: Math.round(moveEvent.clientY - activeDragState.previewHeight / 2),
-            })
+            setTableAxisDragGhostPosition(createTableAxisDragGhostPosition(activeDragState, moveEvent.clientY))
           }
           return
         }
@@ -2542,7 +2367,9 @@ const BlockEditorEngine = ({
       const handlePendingPointerDone = (doneEvent: PointerEvent) => {
         if (activeDragState) {
           if (doneEvent.pointerId !== activeDragState.pointerId) return
+          const activeRenderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
           const nextIndicator = resolveTableAxisReorderIndicator(
+            activeRenderedTable,
             activeDragState.axis,
             activeDragState.sourceIndex,
             doneEvent.clientX,
@@ -2559,7 +2386,7 @@ const BlockEditorEngine = ({
           activeDragState = null
           setDraggedTableAxisState(null)
           setTableAxisDragGhostPosition(null)
-          setTableAxisReorderIndicatorState((prev) => ({ ...prev, visible: false }))
+          setTableAxisReorderIndicatorState(hideTableAxisReorderIndicatorState)
           clearPendingTableAxisDrag()
           return
         }
@@ -2584,8 +2411,6 @@ const BlockEditorEngine = ({
       clearPendingTableAxisDrag,
       getCurrentSelectedTableRect,
       reorderTableAxisAtPosition,
-      resolveTableAxisIndexFromPointer,
-      resolveTableAxisReorderIndicator,
     ]
   )
 

--- a/front/src/components/editor/tableAxisDragModel.ts
+++ b/front/src/components/editor/tableAxisDragModel.ts
@@ -1,0 +1,223 @@
+import type { TableAffordanceGeometry } from "./tableAffordanceModel"
+
+export type TableAxis = "row" | "column"
+
+export type PendingTableAxisDragState = {
+  axis: TableAxis
+  sourceIndex: number
+  pointerId: number
+  tablePos: number
+  startX: number
+  startY: number
+  previewLeft: number
+  previewTop: number
+  previewWidth: number
+  previewHeight: number
+}
+
+export type DraggedTableAxisState =
+  | {
+      axis: TableAxis
+      sourceIndex: number
+      pointerId: number
+      tablePos: number
+      previewLeft: number
+      previewTop: number
+      previewWidth: number
+      previewHeight: number
+    }
+  | null
+
+export type TableAxisReorderIndicatorState = {
+  visible: boolean
+  axis: TableAxis
+  insertionIndex: number
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+export type TableAxisDragGhostPosition = {
+  x: number
+  y: number
+} | null
+
+export const createHiddenTableAxisReorderIndicatorState = (
+  axis: TableAxis = "row",
+  insertionIndex = 0
+): TableAxisReorderIndicatorState => ({
+  visible: false,
+  axis,
+  insertionIndex,
+  left: 0,
+  top: 0,
+  width: 0,
+  height: 0,
+})
+
+export const createPendingTableAxisDragState = (
+  axis: TableAxis,
+  sourceIndex: number,
+  pointerId: number,
+  tablePos: number,
+  startX: number,
+  startY: number,
+  geometry: TableAffordanceGeometry
+): PendingTableAxisDragState => ({
+  axis,
+  sourceIndex,
+  pointerId,
+  tablePos,
+  startX,
+  startY,
+  previewLeft: axis === "row" ? geometry.tableLeft : geometry.columnLeft,
+  previewTop: axis === "row" ? geometry.rowTop : geometry.tableTop,
+  previewWidth: axis === "row" ? geometry.width : geometry.columnWidth,
+  previewHeight: axis === "row" ? geometry.rowHeight : geometry.height,
+})
+
+export const createDraggedTableAxisState = (
+  pending: PendingTableAxisDragState
+): Exclude<DraggedTableAxisState, null> => ({
+  axis: pending.axis,
+  sourceIndex: pending.sourceIndex,
+  pointerId: pending.pointerId,
+  tablePos: pending.tablePos,
+  previewLeft: pending.previewLeft,
+  previewTop: pending.previewTop,
+  previewWidth: pending.previewWidth,
+  previewHeight: pending.previewHeight,
+})
+
+export const createTableAxisDragGhostPosition = (
+  dragState: Pick<PendingTableAxisDragState, "axis" | "previewLeft" | "previewHeight">,
+  clientY: number
+): TableAxisDragGhostPosition =>
+  dragState.axis === "row"
+    ? {
+        x: dragState.previewLeft,
+        y: Math.round(clientY - dragState.previewHeight / 2),
+      }
+    : null
+
+export const hideTableAxisReorderIndicatorState = (
+  state: TableAxisReorderIndicatorState
+): TableAxisReorderIndicatorState => (state.visible ? { ...state, visible: false } : state)
+
+export const resolveTableAxisReorderIndicator = (
+  renderedTable: HTMLTableElement | null | undefined,
+  axis: TableAxis,
+  sourceIndex: number,
+  clientX: number,
+  clientY: number
+): TableAxisReorderIndicatorState | null => {
+  if (!renderedTable) return null
+
+  const tableRect = renderedTable.getBoundingClientRect()
+  const rows = Array.from(renderedTable.querySelectorAll("tr")).filter(
+    (row): row is HTMLTableRowElement => row instanceof HTMLTableRowElement && row.cells.length > 0
+  )
+  if (rows.length === 0) return null
+
+  if (axis === "row") {
+    const boundedSourceIndex = Math.max(0, Math.min(sourceIndex, rows.length - 1))
+    let insertionIndex = rows.length
+    let top = tableRect.bottom
+
+    rows.forEach((row, rowIndex) => {
+      if (insertionIndex !== rows.length) return
+      const rowRect = row.getBoundingClientRect()
+      if (clientY < rowRect.top + rowRect.height / 2) {
+        insertionIndex = rowIndex
+        top = rowRect.top
+      }
+    })
+
+    return {
+      visible: true,
+      axis,
+      insertionIndex,
+      left: Math.round(tableRect.left),
+      top: Math.round(top),
+      width: Math.round(tableRect.width),
+      height: Math.max(2, Math.round(Math.min(rows[boundedSourceIndex]?.getBoundingClientRect().height ?? 2, 3))),
+    }
+  }
+
+  const firstRowCells = Array.from(rows[0].cells).filter(
+    (cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement
+  )
+  if (firstRowCells.length === 0) return null
+
+  let insertionIndex = firstRowCells.length
+  let left = tableRect.right
+  firstRowCells.forEach((cell, columnIndex) => {
+    if (insertionIndex !== firstRowCells.length) return
+    const cellRect = cell.getBoundingClientRect()
+    if (clientX < cellRect.left + cellRect.width / 2) {
+      insertionIndex = columnIndex
+      left = cellRect.left
+    }
+  })
+
+  return {
+    visible: true,
+    axis,
+    insertionIndex,
+    left: Math.round(left),
+    top: Math.round(tableRect.top),
+    width: 2,
+    height: Math.round(tableRect.height),
+  }
+}
+
+export const resolveTableAxisIndexFromPointer = (
+  renderedTable: HTMLTableElement | null | undefined,
+  axis: TableAxis,
+  clientX: number,
+  clientY: number
+) => {
+  if (!renderedTable) return null
+
+  const rows = Array.from(renderedTable.querySelectorAll("tr")).filter(
+    (row): row is HTMLTableRowElement => row instanceof HTMLTableRowElement && row.cells.length > 0
+  )
+  if (rows.length === 0) return null
+
+  if (axis === "row") {
+    const matchedRowIndex = rows.findIndex((row) => {
+      const rowRect = row.getBoundingClientRect()
+      return clientY >= rowRect.top && clientY <= rowRect.bottom
+    })
+    if (matchedRowIndex >= 0) return matchedRowIndex
+
+    return rows.reduce((bestIndex, row, rowIndex) => {
+      const rowRect = row.getBoundingClientRect()
+      const nextDistance = Math.abs(clientY - (rowRect.top + rowRect.height / 2))
+      const currentDistance = Math.abs(
+        clientY - (rows[bestIndex].getBoundingClientRect().top + rows[bestIndex].getBoundingClientRect().height / 2)
+      )
+      return nextDistance < currentDistance ? rowIndex : bestIndex
+    }, 0)
+  }
+
+  const firstRowCells = Array.from(rows[0].cells).filter(
+    (cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement
+  )
+  if (firstRowCells.length === 0) return null
+
+  const matchedColumnIndex = firstRowCells.findIndex((cell) => {
+    const cellRect = cell.getBoundingClientRect()
+    return clientX >= cellRect.left && clientX <= cellRect.right
+  })
+  if (matchedColumnIndex >= 0) return matchedColumnIndex
+
+  return firstRowCells.reduce((bestIndex, cell, columnIndex) => {
+    const cellRect = cell.getBoundingClientRect()
+    const nextDistance = Math.abs(clientX - (cellRect.left + cellRect.width / 2))
+    const currentRect = firstRowCells[bestIndex].getBoundingClientRect()
+    const currentDistance = Math.abs(clientX - (currentRect.left + currentRect.width / 2))
+    return nextDistance < currentDistance ? columnIndex : bestIndex
+  }, 0)
+}


### PR DESCRIPTION
## 관련 이슈

close #169

## 작업 배경

- `BlockEditorEngine.tsx`가 직접 들고 있던 table row/column drag state와 reorder indicator/index 계산을 `tableAxisDragModel.ts`로 분리했습니다.
- engine은 rendered table lookup, pointer event wiring, editor mutation만 유지하도록 줄이고 source guard로 재비대화를 막았습니다.

## 작업 내용

- table axis drag state, drag ghost position, hidden indicator state factory, reorder indicator resolver, pointer axis index resolver를 새 모델 파일로 이동했습니다.
- `BlockEditorEngine.tsx`의 local type/helper 정의를 제거하고 모델 helper import 경로로 교체했습니다.
- `editor-studio-state` source guard가 `tableAxisDragModel.ts` 존재와 export 계약, engine-local 재정의 금지를 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - RED 확인: `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (`tableAxisDragModel.ts` 부재로 expected fail)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (15 passed)
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (73 passed)
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (16 passed)
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts e2e/editor-authoring-flow.spec.ts e2e/slash-menu-interaction.spec.ts --workers=1` (104 passed)
  - `yarn --cwd front build`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table row/column drag 중 reorder indicator 계산 경로가 분리되며 edge case에서 hover 기준이 어긋날 수 있습니다. 기존 DOM 계산을 그대로 모델로 이동했고 authoring/table 관련 E2E로 회귀를 확인했습니다.
- 롤백 방법: 이 PR을 revert하면 engine-local table axis drag helper 경로로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
