### PR TITLE
[Refactor] editor table resize interaction model 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -489,6 +489,14 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/components/editor/tableRenderedDomModel.ts"),
       "utf8"
     )
+    const tableResizeInteractionModelPath = path.resolve(
+      __dirname,
+      "../src/components/editor/tableResizeInteractionModel.ts"
+    )
+    expect(existsSync(tableResizeInteractionModelPath)).toBe(true)
+    const tableResizeInteractionModelSource = existsSync(tableResizeInteractionModelPath)
+      ? readFileSync(tableResizeInteractionModelPath, "utf8")
+      : ""
     const tableCornerGrowModelSource = readFileSync(
       path.resolve(__dirname, "../src/components/editor/tableCornerGrowModel.ts"),
       "utf8"
@@ -512,7 +520,23 @@ test.describe("editor studio state", () => {
 
     expect(blockEditorEngineSource).toContain('data-testid="table-column-drag-guide"')
     expect(blockEditorEngineSource).toContain('data-testid={`table-column-resize-boundary-${index}`}')
-    expect(blockEditorEngineSource).toContain("const syncTableColumnDragGuideForColumn = useCallback(")
+    expect(blockEditorEngineSource).toContain('} from "./tableResizeInteractionModel"')
+    expect(tableResizeInteractionModelSource).toContain("export type TableRowResizeState = {")
+    expect(tableResizeInteractionModelSource).toContain("export type TableColumnRailResizeState = {")
+    expect(tableResizeInteractionModelSource).toContain("export type TableColumnDragGuideState = {")
+    expect(tableResizeInteractionModelSource).toContain("export const createHiddenTableColumnDragGuideState =")
+    expect(tableResizeInteractionModelSource).toContain("export const hideTableColumnDragGuideState =")
+    expect(tableResizeInteractionModelSource).toContain("export const createTableRowResizeState =")
+    expect(tableResizeInteractionModelSource).toContain("export const createTableColumnRailResizeState =")
+    expect(tableResizeInteractionModelSource).toContain("export const isRowResizeHandleTarget =")
+    expect(tableResizeInteractionModelSource).toContain("export const resolveTableColumnDragGuideState =")
+    expect(tableResizeInteractionModelSource).toContain("export const resolveTableColumnIndexFromResizeHandleTarget =")
+    expect(blockEditorEngineSource).not.toContain("type TableRowResizeState = {")
+    expect(blockEditorEngineSource).not.toContain("type TableColumnRailResizeState = {")
+    expect(blockEditorEngineSource).not.toContain("type TableColumnDragGuideState = {")
+    expect(blockEditorEngineSource).not.toContain("const isRowResizeHandleTarget = useCallback(")
+    expect(blockEditorEngineSource).not.toContain("const syncTableColumnDragGuideForColumn = useCallback(")
+    expect(blockEditorEngineSource).not.toContain("const startTableColumnResizeFromDomHandle = useCallback(")
     expect(blockEditorEngineSource).toContain("const getActiveTableRectFromDom = useCallback(")
     expect(blockEditorEngineSource).toContain('import { createPortal } from "react-dom"')
     expect(blockEditorEngineSource).toContain("const tableOverlayPortal =")

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -148,6 +148,18 @@ import {
   resolveTableScopedSelectedCell,
 } from "./tableRenderedDomModel"
 import {
+  type TableColumnDragGuideState,
+  type TableColumnRailResizeState,
+  type TableRowResizeState,
+  createHiddenTableColumnDragGuideState,
+  createTableColumnRailResizeState,
+  createTableRowResizeState,
+  hideTableColumnDragGuideState,
+  isRowResizeHandleTarget,
+  resolveTableColumnDragGuideState,
+  resolveTableColumnIndexFromResizeHandleTarget,
+} from "./tableResizeInteractionModel"
+import {
   BLOCK_OUTER_SELECT_LEFT_GUTTER_PX,
   BLOCK_OUTER_SELECT_LEFT_EDGE_GAP_PX,
   BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX,
@@ -307,34 +319,9 @@ type SlashMenuState =
     }
   | null
 
-type TableRowResizeState = {
-  row: HTMLTableRowElement
-  cells: HTMLTableCellElement[]
-  startY: number
-  startHeight: number
-}
-
-type TableColumnRailResizeState = {
-  pointerId: number
-  columnIndex: number
-  startClientX: number
-  baseWidths: number[]
-  budget: number
-  overflowMode: string
-}
-
-type TableColumnDragGuideState = {
-  visible: boolean
-  left: number
-  top: number
-  height: number
-}
-
 const BLOCK_HANDLE_MEDIA_QUERY = "(pointer: coarse)"
 const DESKTOP_TABLE_RAIL_MEDIA_QUERY = "(max-width: 768px)"
 const DEFAULT_EDITOR_READABLE_WIDTH_PX = 48 * 16
-const TABLE_ROW_RESIZE_EDGE_PX = 6
-const TABLE_COLUMN_RESIZE_GUARD_PX = 12
 const TABLE_RAIL_EDGE_PADDING_PX = 12
 const TABLE_CORNER_BUTTON_SIZE_PX = 22
 const TABLE_CORNER_GROW_MOUSE_POINTER_ID = -1
@@ -1112,12 +1099,8 @@ const BlockEditorEngine = ({
   const [tableAffordanceVisibility, setTableAffordanceVisibility] = useState<TableAffordanceVisibility>(
     INITIAL_TABLE_AFFORDANCE_VISIBILITY
   )
-  const [tableColumnDragGuideState, setTableColumnDragGuideState] = useState<TableColumnDragGuideState>({
-    visible: false,
-    left: 0,
-    top: 0,
-    height: 0,
-  })
+  const [tableColumnDragGuideState, setTableColumnDragGuideState] =
+    useState<TableColumnDragGuideState>(createHiddenTableColumnDragGuideState)
   const [tableCornerPreviewState, setTableCornerPreviewState] = useState<TableCornerPreviewState>({
     visible: false,
     left: 0,
@@ -1310,10 +1293,10 @@ const BlockEditorEngine = ({
   }, [])
 
   const hideTableColumnDragGuide = useCallback(() => {
-    setTableColumnDragGuideState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
+    setTableColumnDragGuideState(hideTableColumnDragGuideState)
   }, [])
 
-  const syncTableColumnDragGuideForColumn = useCallback(
+  const updateTableColumnDragGuideForColumn = useCallback(
     (columnIndex: number) => {
       const viewport = viewportRef.current
       if (!viewport) {
@@ -1326,28 +1309,12 @@ const BlockEditorEngine = ({
         tableAffordanceGeometryRef.current,
         activeTableElementRef.current
       )
-      const headerRow = tableElement?.querySelector("thead tr, tbody tr, tr")
-      if (!tableElement || !headerRow) {
+      const guideState = resolveTableColumnDragGuideState(tableElement, columnIndex)
+      if (!guideState) {
         hideTableColumnDragGuide()
         return
       }
-
-      const cells = Array.from(headerRow.children).filter(
-        (node): node is HTMLElement => node instanceof HTMLElement
-      )
-      if (columnIndex < 0 || columnIndex >= cells.length) {
-        hideTableColumnDragGuide()
-        return
-      }
-
-      const tableRect = tableElement.getBoundingClientRect()
-      const cellRect = cells[columnIndex].getBoundingClientRect()
-      setTableColumnDragGuideState({
-        visible: true,
-        left: Math.round(Math.min(tableRect.right, cellRect.right)),
-        top: Math.round(tableRect.top),
-        height: Math.round(tableRect.height),
-      })
+      setTableColumnDragGuideState(guideState)
     },
     [hideTableColumnDragGuide]
   )
@@ -1958,21 +1925,6 @@ const BlockEditorEngine = ({
     [getTableCellFromTarget]
   )
 
-  const isRowResizeHandleTarget = useCallback(
-    (cell: HTMLTableCellElement | null, clientX: number, clientY: number) => {
-      if (!cell) return false
-      const rect = cell.getBoundingClientRect()
-      const distanceToBottom = rect.bottom - clientY
-      const distanceToRight = rect.right - clientX
-      return (
-        distanceToBottom >= -1 &&
-        distanceToBottom <= TABLE_ROW_RESIZE_EDGE_PX &&
-        distanceToRight > TABLE_COLUMN_RESIZE_GUARD_PX
-      )
-    },
-    []
-  )
-
   const stopTableRowResize = useCallback(() => {
     const state = tableRowResizeRef.current
     if (state?.row) {
@@ -1994,18 +1946,11 @@ const BlockEditorEngine = ({
 
   const startTableRowResize = useCallback(
     (cell: HTMLTableCellElement, clientY: number) => {
-      const row = cell.parentElement
-      if (!(row instanceof HTMLTableRowElement)) return
-      const cells = Array.from(row.cells)
-      if (cells.length === 0) return
+      const resizeState = createTableRowResizeState(cell, clientY)
+      if (!resizeState) return
 
-      row.setAttribute("data-row-resize-active", "true")
-      tableRowResizeRef.current = {
-        row,
-        cells,
-        startY: clientY,
-        startHeight: row.getBoundingClientRect().height,
-      }
+      resizeState.row.setAttribute("data-row-resize-active", "true")
+      tableRowResizeRef.current = resizeState
       setViewportRowResizeHot(true)
       if (typeof document !== "undefined") {
         document.body.style.cursor = "row-resize"
@@ -2809,37 +2754,32 @@ const BlockEditorEngine = ({
       setTableAffordanceGeometry((prev) => ({ ...prev, columnIndex }))
       clearWindowTextSelection()
       setColumnResizeUserSelectSuppressed(true)
-      tableColumnRailResizeRef.current = {
+      tableColumnRailResizeRef.current = createTableColumnRailResizeState(
         pointerId,
         columnIndex,
-        startClientX: clientX,
-        baseWidths: resizeContext.measuredWidths,
-        budget: getCurrentEditorReadableWidthPx(resizeContext.currentEditor) - 2,
-        overflowMode: getTableOverflowMode(resizeContext.rect.table),
-      }
+        clientX,
+        resizeContext.measuredWidths,
+        getCurrentEditorReadableWidthPx(resizeContext.currentEditor) - 2,
+        getTableOverflowMode(resizeContext.rect.table)
+      )
       if (typeof document !== "undefined") {
         document.body.style.cursor = "col-resize"
       }
-      syncTableColumnDragGuideForColumn(columnIndex)
+      updateTableColumnDragGuideForColumn(columnIndex)
     },
     [
       clearWindowTextSelection,
       getCurrentTableColumnResizeContext,
       selectTableColumnByIndex,
       setColumnResizeUserSelectSuppressed,
-      syncTableColumnDragGuideForColumn,
+      updateTableColumnDragGuideForColumn,
     ]
   )
 
-  const startTableColumnResizeFromDomHandle = useCallback(
+  const tryStartTableColumnResizeFromDomHandle = useCallback(
     (target: EventTarget | null, pointerId: number, clientX: number) => {
-      const handleElement =
-        target instanceof Element ? target.closest(".column-resize-handle") : null
-      if (!(handleElement instanceof HTMLElement)) return false
-      const cell = handleElement.closest("th, td")
-      if (!(cell instanceof HTMLElement) || !(cell.parentElement instanceof HTMLTableRowElement)) return false
-      const columnIndex = Array.from(cell.parentElement.children).findIndex((candidate) => candidate === cell)
-      if (columnIndex < 0) return false
+      const columnIndex = resolveTableColumnIndexFromResizeHandleTarget(target)
+      if (columnIndex === null) return false
       startTableColumnRailResize(pointerId, columnIndex, clientX)
       return true
     },
@@ -4065,7 +4005,7 @@ const BlockEditorEngine = ({
       } else if (nextClientX <= state.startClientX) {
         hideTableOverflowCoachmark()
       }
-      syncTableColumnDragGuideForColumn(state.columnIndex)
+      updateTableColumnDragGuideForColumn(state.columnIndex)
     }
 
     const handlePointerUp = (event: PointerEvent) => {
@@ -4102,7 +4042,7 @@ const BlockEditorEngine = ({
     resizeTableColumnBySessionDelta,
     showTableOverflowCoachmark,
     stopTableColumnRailResize,
-    syncTableColumnDragGuideForColumn,
+    updateTableColumnDragGuideForColumn,
   ])
 
   useEffect(() => {
@@ -4341,7 +4281,7 @@ const BlockEditorEngine = ({
       const activeEditor = editorRef.current ?? currentEditor
       if (!activeEditor) return
       if (!(event.target instanceof Node) || !activeEditor.view.dom.contains(event.target)) return
-      if (startTableColumnResizeFromDomHandle(event.target, event.pointerId, event.clientX)) {
+      if (tryStartTableColumnResizeFromDomHandle(event.target, event.pointerId, event.clientX)) {
         event.preventDefault()
         event.stopPropagation()
         event.stopImmediatePropagation?.()
@@ -4412,7 +4352,7 @@ const BlockEditorEngine = ({
     scheduleBubbleHide,
     scheduleTableQuickRailHide,
     setBubbleState,
-    startTableColumnResizeFromDomHandle,
+    tryStartTableColumnResizeFromDomHandle,
     syncTableQuickRailFromElement,
     tableMenuState,
   ])
@@ -6690,7 +6630,6 @@ const BlockEditorEngine = ({
       isCoarsePointer,
       isWriterSurface,
       isTableStructuralSelection,
-      isRowResizeHandleTarget,
       selectedBlockNodeIndex,
       setViewportRowResizeHot,
       hoveredListItemContext,
@@ -6883,7 +6822,6 @@ const BlockEditorEngine = ({
       isOuterBlockSelectionGesture,
       isOuterListItemSelectionGesture,
       isCoarsePointer,
-      isRowResizeHandleTarget,
       promoteTopLevelBlockSelection,
       selectedBlockNodeIndex,
       shouldPersistTableHandles,

--- a/front/src/components/editor/tableResizeInteractionModel.ts
+++ b/front/src/components/editor/tableResizeInteractionModel.ts
@@ -1,0 +1,124 @@
+export type TableRowResizeState = {
+  row: HTMLTableRowElement
+  cells: HTMLTableCellElement[]
+  startY: number
+  startHeight: number
+}
+
+export type TableColumnRailResizeState = {
+  pointerId: number
+  columnIndex: number
+  startClientX: number
+  baseWidths: number[]
+  budget: number
+  overflowMode: string
+}
+
+export type TableColumnDragGuideState = {
+  visible: boolean
+  left: number
+  top: number
+  height: number
+}
+
+export const TABLE_ROW_RESIZE_EDGE_PX = 6
+export const TABLE_COLUMN_RESIZE_GUARD_PX = 12
+
+export const createHiddenTableColumnDragGuideState = (): TableColumnDragGuideState => ({
+  visible: false,
+  left: 0,
+  top: 0,
+  height: 0,
+})
+
+export const hideTableColumnDragGuideState = (
+  state: TableColumnDragGuideState
+): TableColumnDragGuideState => (state.visible ? { ...state, visible: false } : state)
+
+export const createTableRowResizeState = (
+  cell: HTMLTableCellElement,
+  startY: number
+): TableRowResizeState | null => {
+  const row = cell.parentElement
+  if (!(row instanceof HTMLTableRowElement)) return null
+
+  const cells = Array.from(row.cells)
+  if (cells.length === 0) return null
+
+  return {
+    row,
+    cells,
+    startY,
+    startHeight: row.getBoundingClientRect().height,
+  }
+}
+
+export const createTableColumnRailResizeState = (
+  pointerId: number,
+  columnIndex: number,
+  startClientX: number,
+  baseWidths: number[],
+  budget: number,
+  overflowMode: string
+): TableColumnRailResizeState => ({
+  pointerId,
+  columnIndex,
+  startClientX,
+  baseWidths,
+  budget,
+  overflowMode,
+})
+
+export const isRowResizeHandleTarget = (
+  cell: HTMLTableCellElement | null,
+  clientX: number,
+  clientY: number
+) => {
+  if (!cell) return false
+
+  const rect = cell.getBoundingClientRect()
+  const distanceToBottom = rect.bottom - clientY
+  const distanceToRight = rect.right - clientX
+  return (
+    distanceToBottom >= -1 &&
+    distanceToBottom <= TABLE_ROW_RESIZE_EDGE_PX &&
+    distanceToRight > TABLE_COLUMN_RESIZE_GUARD_PX
+  )
+}
+
+export const resolveTableColumnDragGuideState = (
+  tableElement: HTMLTableElement | null | undefined,
+  columnIndex: number
+): TableColumnDragGuideState | null => {
+  const headerRow = tableElement?.querySelector("thead tr, tbody tr, tr")
+  if (!tableElement || !headerRow) return null
+
+  const cells = Array.from(headerRow.children).filter(
+    (node): node is HTMLElement => node instanceof HTMLElement
+  )
+  if (columnIndex < 0 || columnIndex >= cells.length) return null
+
+  const tableRect = tableElement.getBoundingClientRect()
+  const cellRect = cells[columnIndex].getBoundingClientRect()
+  return {
+    visible: true,
+    left: Math.round(Math.min(tableRect.right, cellRect.right)),
+    top: Math.round(tableRect.top),
+    height: Math.round(tableRect.height),
+  }
+}
+
+export const resolveTableColumnIndexFromResizeHandleTarget = (
+  target: EventTarget | null
+) => {
+  const handleElement = target instanceof Element ? target.closest(".column-resize-handle") : null
+  if (!(handleElement instanceof HTMLElement)) return null
+
+  const cell = handleElement.closest("th, td")
+  if (!(cell instanceof HTMLElement) || !(cell.parentElement instanceof HTMLTableRowElement)) {
+    return null
+  }
+
+  const columnIndex = Array.from(cell.parentElement.children).findIndex((candidate) => candidate === cell)
+  return columnIndex >= 0 ? columnIndex : null
+}


### PR DESCRIPTION
## 관련 이슈

close #171

## 작업 배경

- `BlockEditorEngine.tsx`에 남아 있던 table row/column resize interaction 책임을 `tableResizeInteractionModel.ts`로 분리했습니다.
- 이전 PR보다 범위를 넓혀 resize session state, row resize hit-test, column drag guide resolver, DOM resize handle resolver를 한 번에 묶었습니다.

## 작업 내용

- `TableRowResizeState`, `TableColumnRailResizeState`, `TableColumnDragGuideState`와 관련 factory/helper를 새 모델 파일로 이동했습니다.
- engine은 rendered table lookup, pointer event wiring, editor transaction dispatch만 유지하도록 정리했습니다.
- `editor-studio-state` source guard가 resize interaction model export와 engine-local 재정의 금지를 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - RED 확인: `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (`tableResizeInteractionModel.ts` 부재로 expected fail)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (15 passed)
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (73 passed)
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (16 passed)
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts:1125 e2e/editor-authoring-flow.spec.ts:1215 e2e/slash-menu-interaction.spec.ts:162 --workers=1` (3 passed)
  - `git diff --check`

  참고: combined local run `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts e2e/editor-authoring-flow.spec.ts e2e/slash-menu-interaction.spec.ts --workers=1`는 2회 시도 중 변경 범위 밖 writer list/slash 입력 readiness 케이스에서 실패했습니다. 해당 실패 케이스들은 단독 재실행에서 통과했고, 이번 변경의 table resize 테스트(행/열 resize, drag guide, width metadata)는 개별 authoring e2e에서 통과했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: column drag guide 계산 경로가 분리되며 특정 DOM 구조에서 guide 위치가 어긋날 수 있습니다. 기존 계산식을 모델로 이동했고 table resize/drag guide e2e로 회귀를 확인했습니다.
- 롤백 방법: 이 PR을 revert하면 engine-local table resize helper 경로로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
