### PR TITLE
[Refactor] editor table floating ui model 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -497,6 +497,14 @@ test.describe("editor studio state", () => {
     const tableResizeInteractionModelSource = existsSync(tableResizeInteractionModelPath)
       ? readFileSync(tableResizeInteractionModelPath, "utf8")
       : ""
+    const tableFloatingUiModelPath = path.resolve(
+      __dirname,
+      "../src/components/editor/tableFloatingUiModel.ts"
+    )
+    expect(existsSync(tableFloatingUiModelPath)).toBe(true)
+    const tableFloatingUiModelSource = existsSync(tableFloatingUiModelPath)
+      ? readFileSync(tableFloatingUiModelPath, "utf8")
+      : ""
     const tableCornerGrowModelSource = readFileSync(
       path.resolve(__dirname, "../src/components/editor/tableCornerGrowModel.ts"),
       "utf8"
@@ -531,12 +539,32 @@ test.describe("editor studio state", () => {
     expect(tableResizeInteractionModelSource).toContain("export const isRowResizeHandleTarget =")
     expect(tableResizeInteractionModelSource).toContain("export const resolveTableColumnDragGuideState =")
     expect(tableResizeInteractionModelSource).toContain("export const resolveTableColumnIndexFromResizeHandleTarget =")
+    expect(tableFloatingUiModelSource).toContain("export type TableMenuKind =")
+    expect(tableFloatingUiModelSource).toContain("export type TableMenuState =")
+    expect(tableFloatingUiModelSource).toContain("export type TableOverflowCoachmarkState =")
+    expect(tableFloatingUiModelSource).toContain("export const TABLE_OVERFLOW_COACHMARK_ESTIMATED_WIDTH_PX = 244")
+    expect(tableFloatingUiModelSource).toContain("export const TABLE_OVERFLOW_COACHMARK_DISMISS_MS = 4200")
+    expect(tableFloatingUiModelSource).toContain("export const resolveTableOverflowCoachmarkState =")
+    expect(tableFloatingUiModelSource).toContain("export const hideTableOverflowCoachmarkState =")
+    expect(tableFloatingUiModelSource).toContain("export const resolveTableMenuState =")
+    expect(tableFloatingUiModelSource).toContain("export const resolveTableMenuFlags =")
+    expect(tableFloatingUiModelSource).toContain("export const resolveCompactTableAffordanceKind =")
+    expect(tableFloatingUiModelSource).toContain("export const resolveTableHandleVisibility =")
     expect(blockEditorEngineSource).not.toContain("type TableRowResizeState = {")
     expect(blockEditorEngineSource).not.toContain("type TableColumnRailResizeState = {")
     expect(blockEditorEngineSource).not.toContain("type TableColumnDragGuideState = {")
+    expect(blockEditorEngineSource).not.toContain("type TableMenuKind =")
+    expect(blockEditorEngineSource).not.toContain("type TableMenuState =")
+    expect(blockEditorEngineSource).not.toContain("type TableOverflowCoachmarkState =")
+    expect(blockEditorEngineSource).not.toContain("const TABLE_MENU_EDGE_PADDING_PX =")
+    expect(blockEditorEngineSource).not.toContain("const tableMenuKind = tableMenuState?.kind ?? null")
+    expect(blockEditorEngineSource).not.toContain("const compactTableAffordanceKind = useMemo(")
+    expect(blockEditorEngineSource).not.toContain("const shouldShowColumnRail =")
+    expect(blockEditorEngineSource).not.toContain("const shouldShowRowRail =")
     expect(blockEditorEngineSource).not.toContain("const isRowResizeHandleTarget = useCallback(")
     expect(blockEditorEngineSource).not.toContain("const syncTableColumnDragGuideForColumn = useCallback(")
     expect(blockEditorEngineSource).not.toContain("const startTableColumnResizeFromDomHandle = useCallback(")
+    expect(blockEditorEngineSource).toContain('} from "./tableFloatingUiModel"')
     expect(blockEditorEngineSource).toContain("const getActiveTableRectFromDom = useCallback(")
     expect(blockEditorEngineSource).toContain('import { createPortal } from "react-dom"')
     expect(blockEditorEngineSource).toContain("const tableOverlayPortal =")
@@ -617,13 +645,13 @@ test.describe("editor studio state", () => {
     expect(tableWidthModelSource).toContain("const maxActiveWidth = Math.max(TABLE_MIN_COLUMN_WIDTH_PX, safeBudget - otherColumnsWidth)")
     expect(blockEditorEngineSource).toContain("const tableCornerGrowSuppressClickRef = useRef(false)")
     expect(blockEditorEngineSource).toContain('"grip" | "grow"')
-    expect(blockEditorEngineSource).toContain('const isCellMenuOpen = tableMenuKind === "cell"')
+    expect(blockEditorEngineSource).toContain("isCellMenuOpen,")
     expect(markdownRendererSource).toContain("const explicitTableWidth = useMemo(")
     expect(markdownRendererSource).toContain("minWidth: `${explicitTableWidth}px`")
     expect(markdownRendererRootSource).toContain("width: auto;")
     expect(markdownRendererRootSource).toContain("max-width: none;")
-    expect(blockEditorEngineSource).toContain('const isRowMenuOpen = tableMenuKind === "row"')
-    expect(blockEditorEngineSource).toContain('const isColumnMenuOpen = tableMenuKind === "column"')
+    expect(blockEditorEngineSource).toContain("isRowMenuOpen,")
+    expect(blockEditorEngineSource).toContain("isColumnMenuOpen,")
     expect(blockEditorEngineSource).toContain("activeTableStructureState.hasHeaderRow")
     expect(blockEditorEngineSource).toContain("activeTableStructureState.hasHeaderColumn")
     expect(blockEditorEngineSource).toContain("const tableCornerGrowStepMetrics = resolveTableCornerGrowStepMetrics(tableAffordanceGeometry)")
@@ -650,19 +678,9 @@ test.describe("editor studio state", () => {
     )
     expect(blockEditorEngineSource).toContain("const tableAffordanceVisibilityRef = useRef(tableAffordanceVisibility)")
     expect(blockEditorEngineSource).not.toContain("type TableQuickRailState =")
-    expect(blockEditorEngineSource).toContain('const isTableStructureMenuOpen = tableMenuKind === "table"')
-    expect(blockEditorEngineSource).toContain(
-      "const shouldShowColumnAddBar ="
-    )
-    expect(blockEditorEngineSource).toContain(
-      "shouldShowDesktopTableHandles && (tableAffordanceVisibility.showColumnAddBar || isColumnMenuOpen)"
-    )
-    expect(blockEditorEngineSource).toContain(
-      "const shouldShowRowAddBar ="
-    )
-    expect(blockEditorEngineSource).toContain(
-      "shouldShowDesktopTableHandles && (tableAffordanceVisibility.showRowAddBar || isRowMenuOpen)"
-    )
+    expect(blockEditorEngineSource).toContain("isTableStructureMenuOpen,")
+    expect(blockEditorEngineSource).toContain("shouldShowColumnAddBar,")
+    expect(blockEditorEngineSource).toContain("shouldShowRowAddBar,")
     expect(blockEditorEngineSource).toContain("findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)")
     expect(blockEditorEngineSource).toContain("display: none !important;")
     expect(editorStudioSource).toContain('import { useEditorStudioPersistence } from "./useEditorStudioPersistence"')

--- a/front/e2e/slash-menu-interaction.spec.ts
+++ b/front/e2e/slash-menu-interaction.spec.ts
@@ -312,6 +312,8 @@ test.describe("block editor slash menu interaction", () => {
     const heading2Action = page.locator("[data-slash-action-id='heading-2']")
     await expect.poll(async () => slashMenu.locator("button[data-active='true']").count()).toBeGreaterThan(0)
     await expect(heading2Action).not.toHaveAttribute("data-active", "true")
+    // The menu intentionally suppresses pointer takeover for a short window after keyboard navigation.
+    await page.waitForTimeout(220)
     await heading2Action.scrollIntoViewIfNeeded()
     await heading2Action.hover({ force: true })
     await heading2Action.dispatchEvent("pointerenter")

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -160,6 +160,20 @@ import {
   resolveTableColumnIndexFromResizeHandleTarget,
 } from "./tableResizeInteractionModel"
 import {
+  TABLE_OVERFLOW_COACHMARK_DISMISS_MS,
+  TABLE_OVERFLOW_COACHMARK_ESTIMATED_WIDTH_PX,
+  createHiddenTableOverflowCoachmarkState,
+  hideTableOverflowCoachmarkState,
+  resolveCompactTableAffordanceKind,
+  resolveTableHandleVisibility,
+  resolveTableMenuFlags,
+  resolveTableMenuState,
+  resolveTableOverflowCoachmarkState,
+  type TableMenuKind,
+  type TableMenuState,
+  type TableOverflowCoachmarkState,
+} from "./tableFloatingUiModel"
+import {
   BLOCK_OUTER_SELECT_LEFT_GUTTER_PX,
   BLOCK_OUTER_SELECT_LEFT_EDGE_GAP_PX,
   BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX,
@@ -269,22 +283,6 @@ type ToolbarAction = {
   disabled?: boolean
 }
 
-type TableMenuKind = "row" | "column" | "table" | "cell"
-
-type TableMenuState =
-  | {
-      kind: TableMenuKind
-      left: number
-      top: number
-    }
-  | null
-
-type TableOverflowCoachmarkState = {
-  visible: boolean
-  left: number
-  top: number
-}
-
 const EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT = 240
 
 const recordEditorCommitDurationForRuntimeGuard = (durationMs: number) => {
@@ -338,17 +336,11 @@ const TABLE_AXIS_GRIP_EDGE_INSET_PX = 0
 const TABLE_ADD_BAR_THICKNESS_PX = 28
 const TABLE_AXIS_RAIL_EDGE_HOTZONE_PX = 18
 const TABLE_TRAILING_ADD_EDGE_HOTZONE_PX = 18
-const TABLE_OVERFLOW_COACHMARK_ESTIMATED_WIDTH_PX = 244
-const TABLE_OVERFLOW_COACHMARK_DISMISS_MS = 4200
-
 const TABLE_EDGE_HANDLE_INSET_PX = 6
 const TABLE_CORNER_CLUSTER_GAP_PX = 6
 const TABLE_CORNER_CLUSTER_WIDTH_PX =
   TABLE_CORNER_BUTTON_SIZE_PX * 2 + TABLE_CORNER_CLUSTER_GAP_PX
 const TABLE_QUICK_RAIL_HIDE_DELAY_MS = 120
-const TABLE_MENU_EDGE_PADDING_PX = 16
-const TABLE_MENU_ESTIMATED_WIDTH_PX = 272
-const TABLE_MENU_ESTIMATED_HEIGHT_PX = 420
 const SLASH_MENU_RECENT_IDS_STORAGE_KEY = "editor:block-slash-recent:v1"
 const SLASH_MENU_MAX_RECENT_ITEMS = 6
 const SLASH_MENU_EDGE_PADDING_PX = 16
@@ -1118,11 +1110,9 @@ const BlockEditorEngine = ({
     cellMenuTop: number
   } | null>(null)
   const [tableMenuState, setTableMenuState] = useState<TableMenuState>(null)
-  const [tableOverflowCoachmarkState, setTableOverflowCoachmarkState] = useState<TableOverflowCoachmarkState>({
-    visible: false,
-    left: 0,
-    top: 0,
-  })
+  const [tableOverflowCoachmarkState, setTableOverflowCoachmarkState] = useState<TableOverflowCoachmarkState>(
+    createHiddenTableOverflowCoachmarkState
+  )
   const tableAffordanceGeometryRef = useRef(tableAffordanceGeometry)
   const tableAffordanceVisibilityRef = useRef(tableAffordanceVisibility)
   const tableCornerPreviewStateRef = useRef<TableCornerPreviewState>({
@@ -1174,14 +1164,7 @@ const BlockEditorEngine = ({
 
   const hideTableOverflowCoachmark = useCallback(() => {
     cancelTableOverflowCoachmarkHide()
-    setTableOverflowCoachmarkState((prev) =>
-      prev.visible
-        ? {
-            ...prev,
-            visible: false,
-          }
-        : prev
-    )
+    setTableOverflowCoachmarkState(hideTableOverflowCoachmarkState)
   }, [cancelTableOverflowCoachmarkHide])
 
   const scheduleTableOverflowCoachmarkHide = useCallback(
@@ -1190,7 +1173,7 @@ const BlockEditorEngine = ({
       cancelTableOverflowCoachmarkHide()
       tableOverflowCoachmarkHideTimerRef.current = window.setTimeout(() => {
         tableOverflowCoachmarkHideTimerRef.current = null
-        setTableOverflowCoachmarkState((prev) => ({ ...prev, visible: false }))
+        setTableOverflowCoachmarkState(hideTableOverflowCoachmarkState)
       }, delayMs)
     },
     [cancelTableOverflowCoachmarkHide]
@@ -1203,22 +1186,15 @@ const BlockEditorEngine = ({
       tableAffordanceGeometryRef.current
     )
     const tableRect = renderedTable?.getBoundingClientRect() ?? null
-    const fallbackAnchor = tableAffordanceGeometryRef.current.cornerAnchor
-    const anchorRight = tableRect ? tableRect.right : fallbackAnchor.left + TABLE_CORNER_BUTTON_SIZE_PX
-    const anchorTop = tableRect ? tableRect.top : fallbackAnchor.top
-    const nextLeft = Math.min(
-      Math.max(16, Math.round(anchorRight - TABLE_OVERFLOW_COACHMARK_ESTIMATED_WIDTH_PX)),
-      Math.max(16, window.innerWidth - TABLE_OVERFLOW_COACHMARK_ESTIMATED_WIDTH_PX - 16)
+    setTableOverflowCoachmarkState(
+      resolveTableOverflowCoachmarkState({
+        tableRect,
+        fallbackAnchor: tableAffordanceGeometryRef.current.cornerAnchor,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+        cornerButtonSize: TABLE_CORNER_BUTTON_SIZE_PX,
+      })
     )
-    const preferredTop = Math.round(anchorTop - 54)
-    const nextTop =
-      preferredTop >= 16 ? preferredTop : Math.min(window.innerHeight - 52, Math.round(anchorTop + 12))
-
-    setTableOverflowCoachmarkState({
-      visible: true,
-      left: nextLeft,
-      top: Math.max(16, nextTop),
-    })
     scheduleTableOverflowCoachmarkHide()
   }, [isCoarsePointer, isNarrowTableViewport, scheduleTableOverflowCoachmarkHide])
   const selectionUiSignatureRef = useRef("")
@@ -4744,12 +4720,14 @@ const BlockEditorEngine = ({
     }
     return null
   }, [editor, isTableStructuralSelection, selectionTick])
-  const tableMenuKind = tableMenuState?.kind ?? null
-  const isAnyTableMenuOpen = tableMenuKind !== null
-  const isTableStructureMenuOpen = tableMenuKind === "table"
-  const isRowMenuOpen = tableMenuKind === "row"
-  const isColumnMenuOpen = tableMenuKind === "column"
-  const isCellMenuOpen = tableMenuKind === "cell"
+  const {
+    tableMenuKind,
+    isAnyTableMenuOpen,
+    isTableStructureMenuOpen,
+    isRowMenuOpen,
+    isColumnMenuOpen,
+    isCellMenuOpen,
+  } = resolveTableMenuFlags(tableMenuState)
   const hasActiveTableCellContext = useMemo(() => {
     if (!editor || isTableStructuralSelection) return false
     void selectionTick
@@ -4761,47 +4739,31 @@ const BlockEditorEngine = ({
   const shouldShowDesktopTableHandles =
     !shouldUseCompactTableAffordance &&
     (tableAffordanceVisibility.visible || isTableQuickRailHovered || shouldPersistTableHandles || isTableColumnResizeActive)
-  const compactTableAffordanceKind = useMemo(() => {
-    if (!shouldUseCompactTableAffordance) return null
-    if (currentTableAxisSelection?.axis === "row" || draggedTableAxisState?.axis === "row" || isRowMenuOpen) {
-      return "row" as const
-    }
-    if (currentTableAxisSelection?.axis === "column" || draggedTableAxisState?.axis === "column" || isColumnMenuOpen) {
-      return "column" as const
-    }
-    if (tableAffordanceVisibility.visible || shouldPersistTableHandles || isTableStructureMenuOpen || hasActiveTableCellContext) {
-      return "table" as const
-    }
-    return null
-  }, [
-    currentTableAxisSelection?.axis,
-    draggedTableAxisState?.axis,
+  const compactTableAffordanceKind = resolveCompactTableAffordanceKind({
+    shouldUseCompactTableAffordance,
+    currentTableAxisSelection,
+    draggedTableAxis: draggedTableAxisState?.axis ?? null,
+    isRowMenuOpen,
+    isColumnMenuOpen,
+    tableAffordanceVisible: tableAffordanceVisibility.visible,
+    shouldPersistTableHandles,
+    isTableStructureMenuOpen,
     hasActiveTableCellContext,
+  })
+  const {
+    shouldShowColumnRail,
+    shouldShowRowRail,
+    shouldShowColumnAddBar,
+    shouldShowRowAddBar,
+  } = resolveTableHandleVisibility({
+    compactTableAffordanceKind,
+    shouldShowDesktopTableHandles,
+    tableAffordanceVisibility,
+    currentTableAxisSelection,
+    draggedTableAxis: draggedTableAxisState?.axis ?? null,
     isColumnMenuOpen,
     isRowMenuOpen,
-    isTableStructureMenuOpen,
-    shouldPersistTableHandles,
-    shouldUseCompactTableAffordance,
-    tableAffordanceVisibility.visible,
-  ])
-  const shouldShowColumnRail =
-    compactTableAffordanceKind === "column" ||
-    (shouldShowDesktopTableHandles &&
-      (tableAffordanceVisibility.showColumnRail ||
-        currentTableAxisSelection?.axis === "column" ||
-        draggedTableAxisState?.axis === "column" ||
-        isColumnMenuOpen))
-  const shouldShowRowRail =
-    compactTableAffordanceKind === "row" ||
-    (shouldShowDesktopTableHandles &&
-      (tableAffordanceVisibility.showRowRail ||
-        currentTableAxisSelection?.axis === "row" ||
-        draggedTableAxisState?.axis === "row" ||
-        isRowMenuOpen))
-  const shouldShowColumnAddBar =
-    shouldShowDesktopTableHandles && (tableAffordanceVisibility.showColumnAddBar || isColumnMenuOpen)
-  const shouldShowRowAddBar =
-    shouldShowDesktopTableHandles && (tableAffordanceVisibility.showRowAddBar || isRowMenuOpen)
+  })
   const activeTableStructureState = useMemo(() => {
     void selectionTick
     return getActiveTableStructureState(editor)
@@ -5875,35 +5837,18 @@ const BlockEditorEngine = ({
 
   const openTableMenu = useCallback((kind: TableMenuKind, anchorRect: DOMRect) => {
     cancelTableQuickRailHide()
-    const nextLeft =
-      typeof window !== "undefined"
-        ? Math.min(
-            Math.max(TABLE_MENU_EDGE_PADDING_PX, Math.round(anchorRect.left)),
-            Math.max(
-              TABLE_MENU_EDGE_PADDING_PX,
-              window.innerWidth - TABLE_MENU_ESTIMATED_WIDTH_PX - TABLE_MENU_EDGE_PADDING_PX
-            )
-          )
-        : Math.round(anchorRect.left)
-    const nextTop =
-      typeof window !== "undefined"
-        ? Math.min(
-            Math.max(TABLE_MENU_EDGE_PADDING_PX, Math.round(anchorRect.bottom + 8)),
-            Math.max(
-              TABLE_MENU_EDGE_PADDING_PX,
-              window.innerHeight - TABLE_MENU_ESTIMATED_HEIGHT_PX - TABLE_MENU_EDGE_PADDING_PX
-            )
-          )
-        : Math.round(anchorRect.bottom + 8)
-
     setTableMenuState((prev) =>
-      prev && prev.kind === kind
-        ? null
-        : {
-            kind,
-            left: nextLeft,
-            top: nextTop,
-        }
+      resolveTableMenuState(
+        prev,
+        kind,
+        anchorRect,
+        typeof window === "undefined"
+          ? null
+          : {
+              width: window.innerWidth,
+              height: window.innerHeight,
+            }
+      )
     )
   }, [cancelTableQuickRailHide])
 

--- a/front/src/components/editor/tableFloatingUiModel.ts
+++ b/front/src/components/editor/tableFloatingUiModel.ts
@@ -1,0 +1,203 @@
+import type {
+  TableAffordanceVisibility,
+  TableOverlayAnchor,
+} from "./tableAffordanceModel"
+import type { TableAxis } from "./tableAxisDragModel"
+
+export type TableMenuKind = "row" | "column" | "table" | "cell"
+
+export type TableMenuState =
+  | {
+      kind: TableMenuKind
+      left: number
+      top: number
+    }
+  | null
+
+export type TableOverflowCoachmarkState = {
+  visible: boolean
+  left: number
+  top: number
+}
+
+export type CompactTableAffordanceKind = TableAxis | "table" | null
+
+type ViewportSize = {
+  width: number
+  height: number
+}
+
+type TableMenuAnchorRect = Pick<DOMRect, "left" | "bottom">
+
+type TableCoachmarkRect = Pick<DOMRect, "right" | "top"> | null
+
+type TableAxisSelectionLike = {
+  axis: TableAxis
+} | null
+
+export const TABLE_OVERFLOW_COACHMARK_ESTIMATED_WIDTH_PX = 244
+export const TABLE_OVERFLOW_COACHMARK_DISMISS_MS = 4200
+export const TABLE_MENU_EDGE_PADDING_PX = 16
+export const TABLE_MENU_ESTIMATED_WIDTH_PX = 272
+export const TABLE_MENU_ESTIMATED_HEIGHT_PX = 420
+
+export const createHiddenTableOverflowCoachmarkState = (): TableOverflowCoachmarkState => ({
+  visible: false,
+  left: 0,
+  top: 0,
+})
+
+export const hideTableOverflowCoachmarkState = (
+  state: TableOverflowCoachmarkState
+): TableOverflowCoachmarkState => (state.visible ? { ...state, visible: false } : state)
+
+export const resolveTableOverflowCoachmarkState = ({
+  tableRect,
+  fallbackAnchor,
+  viewportWidth,
+  viewportHeight,
+  cornerButtonSize,
+}: {
+  tableRect: TableCoachmarkRect
+  fallbackAnchor: TableOverlayAnchor
+  viewportWidth: number
+  viewportHeight: number
+  cornerButtonSize: number
+}): TableOverflowCoachmarkState => {
+  const anchorRight = tableRect ? tableRect.right : fallbackAnchor.left + cornerButtonSize
+  const anchorTop = tableRect ? tableRect.top : fallbackAnchor.top
+  const nextLeft = Math.min(
+    Math.max(TABLE_MENU_EDGE_PADDING_PX, Math.round(anchorRight - TABLE_OVERFLOW_COACHMARK_ESTIMATED_WIDTH_PX)),
+    Math.max(
+      TABLE_MENU_EDGE_PADDING_PX,
+      viewportWidth - TABLE_OVERFLOW_COACHMARK_ESTIMATED_WIDTH_PX - TABLE_MENU_EDGE_PADDING_PX
+    )
+  )
+  const preferredTop = Math.round(anchorTop - 54)
+  const nextTop =
+    preferredTop >= TABLE_MENU_EDGE_PADDING_PX
+      ? preferredTop
+      : Math.min(viewportHeight - 52, Math.round(anchorTop + 12))
+
+  return {
+    visible: true,
+    left: nextLeft,
+    top: Math.max(TABLE_MENU_EDGE_PADDING_PX, nextTop),
+  }
+}
+
+export const resolveTableMenuState = (
+  currentState: TableMenuState,
+  kind: TableMenuKind,
+  anchorRect: TableMenuAnchorRect,
+  viewport: ViewportSize | null
+): TableMenuState => {
+  const nextLeft = viewport
+    ? Math.min(
+        Math.max(TABLE_MENU_EDGE_PADDING_PX, Math.round(anchorRect.left)),
+        Math.max(
+          TABLE_MENU_EDGE_PADDING_PX,
+          viewport.width - TABLE_MENU_ESTIMATED_WIDTH_PX - TABLE_MENU_EDGE_PADDING_PX
+        )
+      )
+    : Math.round(anchorRect.left)
+  const nextTop = viewport
+    ? Math.min(
+        Math.max(TABLE_MENU_EDGE_PADDING_PX, Math.round(anchorRect.bottom + 8)),
+        Math.max(
+          TABLE_MENU_EDGE_PADDING_PX,
+          viewport.height - TABLE_MENU_ESTIMATED_HEIGHT_PX - TABLE_MENU_EDGE_PADDING_PX
+        )
+      )
+    : Math.round(anchorRect.bottom + 8)
+
+  return currentState && currentState.kind === kind
+    ? null
+    : {
+        kind,
+        left: nextLeft,
+        top: nextTop,
+      }
+}
+
+export const resolveTableMenuFlags = (state: TableMenuState) => {
+  const tableMenuKind = state?.kind ?? null
+
+  return {
+    tableMenuKind,
+    isAnyTableMenuOpen: tableMenuKind !== null,
+    isTableStructureMenuOpen: tableMenuKind === "table",
+    isRowMenuOpen: tableMenuKind === "row",
+    isColumnMenuOpen: tableMenuKind === "column",
+    isCellMenuOpen: tableMenuKind === "cell",
+  }
+}
+
+export const resolveCompactTableAffordanceKind = ({
+  shouldUseCompactTableAffordance,
+  currentTableAxisSelection,
+  draggedTableAxis,
+  isRowMenuOpen,
+  isColumnMenuOpen,
+  tableAffordanceVisible,
+  shouldPersistTableHandles,
+  isTableStructureMenuOpen,
+  hasActiveTableCellContext,
+}: {
+  shouldUseCompactTableAffordance: boolean
+  currentTableAxisSelection: TableAxisSelectionLike
+  draggedTableAxis: TableAxis | null
+  isRowMenuOpen: boolean
+  isColumnMenuOpen: boolean
+  tableAffordanceVisible: boolean
+  shouldPersistTableHandles: boolean
+  isTableStructureMenuOpen: boolean
+  hasActiveTableCellContext: boolean
+}): CompactTableAffordanceKind => {
+  if (!shouldUseCompactTableAffordance) return null
+  if (currentTableAxisSelection?.axis === "row" || draggedTableAxis === "row" || isRowMenuOpen) return "row"
+  if (currentTableAxisSelection?.axis === "column" || draggedTableAxis === "column" || isColumnMenuOpen) {
+    return "column"
+  }
+  if (tableAffordanceVisible || shouldPersistTableHandles || isTableStructureMenuOpen || hasActiveTableCellContext) {
+    return "table"
+  }
+  return null
+}
+
+export const resolveTableHandleVisibility = ({
+  compactTableAffordanceKind,
+  shouldShowDesktopTableHandles,
+  tableAffordanceVisibility,
+  currentTableAxisSelection,
+  draggedTableAxis,
+  isColumnMenuOpen,
+  isRowMenuOpen,
+}: {
+  compactTableAffordanceKind: CompactTableAffordanceKind
+  shouldShowDesktopTableHandles: boolean
+  tableAffordanceVisibility: TableAffordanceVisibility
+  currentTableAxisSelection: TableAxisSelectionLike
+  draggedTableAxis: TableAxis | null
+  isColumnMenuOpen: boolean
+  isRowMenuOpen: boolean
+}) => ({
+  shouldShowColumnRail:
+    compactTableAffordanceKind === "column" ||
+    (shouldShowDesktopTableHandles &&
+      (tableAffordanceVisibility.showColumnRail ||
+        currentTableAxisSelection?.axis === "column" ||
+        draggedTableAxis === "column" ||
+        isColumnMenuOpen)),
+  shouldShowRowRail:
+    compactTableAffordanceKind === "row" ||
+    (shouldShowDesktopTableHandles &&
+      (tableAffordanceVisibility.showRowRail ||
+        currentTableAxisSelection?.axis === "row" ||
+        draggedTableAxis === "row" ||
+        isRowMenuOpen)),
+  shouldShowColumnAddBar:
+    shouldShowDesktopTableHandles && (tableAffordanceVisibility.showColumnAddBar || isColumnMenuOpen),
+  shouldShowRowAddBar:
+    shouldShowDesktopTableHandles && (tableAffordanceVisibility.showRowAddBar || isRowMenuOpen),
+})


### PR DESCRIPTION
## 관련 이슈

close #173

## 작업 배경

- `BlockEditorEngine.tsx`가 직접 들고 있던 table menu/overflow coachmark/compact affordance/rail visibility 순수 계산을 `tableFloatingUiModel.ts`로 분리했습니다.
- engine은 DOM 조회, editor mutation, React state wiring 중심으로 남기고 source guard로 재결합을 막았습니다.
- slash hover 검증은 keyboard navigation 직후 pointer takeover suppression window를 기다리도록 안정화했습니다.

## 작업 내용

- table floating UI state type, menu placement, overflow coachmark placement, menu flags, compact affordance, rail/add-bar visibility helper를 새 모델 파일로 이동했습니다.
- `BlockEditorEngine.tsx`는 새 모델 helper를 호출하도록 교체하고 기존 inline type/constant/helper 계산을 제거했습니다.
- `editor-studio-state` source guard에 floating UI model export와 engine-local 재정의 금지 조건을 추가했습니다.
- `slash-menu-interaction`의 synthetic hover 테스트가 실제 pointer resume guard와 같은 타이밍 계약을 따르도록 했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - RED 확인: `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` failed because `tableFloatingUiModel.ts` did not exist
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (15 passed, final state)
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (73 passed, final state)
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (16 passed twice after test timing stabilization)
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table floating UI 계산 분리 중 배치 clamp나 handle visibility 조건이 어긋날 수 있음. 관련 editor source guard와 authoring/table E2E로 검증했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `b7043f17`을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
