### PR TITLE
[Refactor] editor studio model 분리와 code fallback 복구

### DIFF
--- a/front/e2e/block-editor-serialization.spec.ts
+++ b/front/e2e/block-editor-serialization.spec.ts
@@ -246,6 +246,36 @@ test.describe("block editor serialization", () => {
     expect(doc.content?.some((node) => node.type === "resizableImage")).toBe(true)
   })
 
+  test("pretty-code fallback HTML은 data 속성의 원문으로 code block body를 복구한다", async ({ page }) => {
+    const html = `
+      <pre class="aq-code aq-pretty-pre">
+        <code
+          class="language-ts"
+          data-language="ts"
+          data-prism-source="const answer = 42;&#10;return answer"
+        ></code>
+      </pre>
+    `
+
+    const markdown = await page.evaluate(
+      ({ compiledSource, htmlSource }) => {
+        const module = { exports: {} as { convertHtmlToMarkdown?: (html: string) => string } }
+        const exports = module.exports
+        const runner = new Function("module", "exports", compiledSource)
+        runner(module, exports)
+        return module.exports.convertHtmlToMarkdown?.(htmlSource) || ""
+      },
+      { compiledSource: transpiledHtmlToMarkdownModule, htmlSource: html }
+    )
+
+    expect(markdown).toContain(["```ts", "const answer = 42;", "return answer", "```"].join("\n"))
+
+    const doc = parseMarkdownToEditorDoc(markdown)
+    const codeBlock = doc.content?.find((node) => node.type === "codeBlock")
+    expect(codeBlock?.content?.[0]?.text).toContain("const answer = 42;")
+    expect(codeBlock?.content?.[0]?.text).toContain("return answer")
+  })
+
   test("plain text markdown 문서 붙여넣기는 전체 블록을 자동 렌더 상태로 승격한다", async ({ page }) => {
     const markdownSource = [
       "# 시작하며",

--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -135,6 +135,14 @@ test.describe("editor studio state", () => {
     const editorStudioMetaModelSource = existsSync(editorStudioMetaModelPath)
       ? readFileSync(editorStudioMetaModelPath, "utf8")
       : ""
+    const editorStudioStorageModelPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/editorStudioStorageModel.ts"
+    )
+    expect(existsSync(editorStudioStorageModelPath)).toBe(true)
+    const editorStudioStorageModelSource = existsSync(editorStudioStorageModelPath)
+      ? readFileSync(editorStudioStorageModelPath, "utf8")
+      : ""
     const editorStudioThumbnailPreviewPath = path.resolve(
       __dirname,
       "../src/routes/Admin/useEditorStudioThumbnailPreview.ts"
@@ -288,6 +296,14 @@ test.describe("editor studio state", () => {
     expect(editorStudioMetaModelSource).toContain("export const buildLocalDraftFingerprint =")
     expect(editorStudioMetaModelSource).toContain("export const detectPublishPlaceholderIssue =")
     expect(editorStudioSource).toContain('} from "./editorStudioMetaModel"')
+    expect(editorStudioStorageModelSource).toContain("export const TAG_CATALOG_STORAGE_KEY =")
+    expect(editorStudioStorageModelSource).toContain("export const CATEGORY_CATALOG_STORAGE_KEY =")
+    expect(editorStudioStorageModelSource).toContain("export const readStoredCatalog =")
+    expect(editorStudioStorageModelSource).toContain("export const persistCatalog =")
+    expect(editorStudioStorageModelSource).toContain("export const readLocalDraft =")
+    expect(editorStudioStorageModelSource).toContain("export const persistLocalDraft =")
+    expect(editorStudioStorageModelSource).toContain("export const removeLocalDraft =")
+    expect(editorStudioSource).toContain('} from "./editorStudioStorageModel"')
     expect(editorStudioSource).not.toContain("const normalizeMetaItems =")
     expect(editorStudioSource).not.toContain("const extractFirstMarkdownImage =")
     expect(editorStudioSource).not.toContain("const computeContentFingerprint =")
@@ -303,6 +319,14 @@ test.describe("editor studio state", () => {
     expect(editorStudioSource).not.toContain("const composeEditorContent =")
     expect(editorStudioSource).not.toContain("const buildLocalDraftFingerprint =")
     expect(editorStudioSource).not.toContain("const detectPublishPlaceholderIssue =")
+    expect(editorStudioSource).not.toContain("const TAG_CATALOG_STORAGE_KEY =")
+    expect(editorStudioSource).not.toContain("const CATEGORY_CATALOG_STORAGE_KEY =")
+    expect(editorStudioSource).not.toContain("const LOCAL_DRAFT_STORAGE_KEY =")
+    expect(editorStudioSource).not.toContain("const readStoredCatalog =")
+    expect(editorStudioSource).not.toContain("const persistCatalog =")
+    expect(editorStudioSource).not.toContain("const readLocalDraft =")
+    expect(editorStudioSource).not.toContain("const persistLocalDraft =")
+    expect(editorStudioSource).not.toContain("const removeLocalDraft =")
     expect(writerEditorHostSource).toContain('dynamic(() => import("src/components/editor/BlockEditorShell")')
     expect(writerEditorHostSource).toContain("<Profiler")
     expect(writerEditorHostSource).toContain("<LazyBlockEditorShell")

--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -130,6 +130,11 @@ test.describe("editor studio state", () => {
   test("editor studio는 v2 단일 경로와 단일 작성 모드 계약을 유지한다", () => {
     const editorStudioSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/EditorStudioPage.tsx"), "utf8")
     const editorStudioStateSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/editorStudioState.ts"), "utf8")
+    const editorStudioMetaModelPath = path.resolve(__dirname, "../src/routes/Admin/editorStudioMetaModel.ts")
+    expect(existsSync(editorStudioMetaModelPath)).toBe(true)
+    const editorStudioMetaModelSource = existsSync(editorStudioMetaModelPath)
+      ? readFileSync(editorStudioMetaModelPath, "utf8")
+      : ""
     const editorStudioThumbnailPreviewPath = path.resolve(
       __dirname,
       "../src/routes/Admin/useEditorStudioThumbnailPreview.ts"
@@ -262,6 +267,42 @@ test.describe("editor studio state", () => {
     expect(editorStudioStateSource).toContain("export const deriveEditorContentMetrics")
     expect(editorStudioStateSource).toContain("export const deriveComposeViewModel")
     expect(editorStudioStateSource).toContain("export const derivePublishActionViewModel")
+    expect(editorStudioMetaModelSource).toContain("export type ParsedEditorMeta =")
+    expect(editorStudioMetaModelSource).toContain("export type ResolvedEditorMetaSnapshot =")
+    expect(editorStudioMetaModelSource).toContain("export type LocalDraftPayload =")
+    expect(editorStudioMetaModelSource).toContain("export const PREVIEW_SUMMARY_MAX_LENGTH = 150")
+    expect(editorStudioMetaModelSource).toContain("export const PREVIEW_SUMMARY_MAX_CONTENT_LENGTH = 50_000")
+    expect(editorStudioMetaModelSource).toContain("export const dedupeStrings =")
+    expect(editorStudioMetaModelSource).toContain("export const extractFirstMarkdownImage =")
+    expect(editorStudioMetaModelSource).toContain("export const computeContentFingerprint =")
+    expect(editorStudioMetaModelSource).toContain("export const normalizeSafeImageUrl =")
+    expect(editorStudioMetaModelSource).toContain("export const normalizeSafePreviewThumbnailUrl =")
+    expect(editorStudioMetaModelSource).toContain("export const makePreviewSummary =")
+    expect(editorStudioMetaModelSource).toContain("export const normalizeRecommendedTags =")
+    expect(editorStudioMetaModelSource).toContain("export const resolveTagRecommendationErrorMessage =")
+    expect(editorStudioMetaModelSource).toContain("export const formatTagRecommendationReason =")
+    expect(editorStudioMetaModelSource).toContain("export const resolveEditorMetaSnapshot =")
+    expect(editorStudioMetaModelSource).toContain("export const buildEditorStateFingerprint =")
+    expect(editorStudioMetaModelSource).toContain("export const parseEditorMeta =")
+    expect(editorStudioMetaModelSource).toContain("export const composeEditorContent =")
+    expect(editorStudioMetaModelSource).toContain("export const buildLocalDraftFingerprint =")
+    expect(editorStudioMetaModelSource).toContain("export const detectPublishPlaceholderIssue =")
+    expect(editorStudioSource).toContain('} from "./editorStudioMetaModel"')
+    expect(editorStudioSource).not.toContain("const normalizeMetaItems =")
+    expect(editorStudioSource).not.toContain("const extractFirstMarkdownImage =")
+    expect(editorStudioSource).not.toContain("const computeContentFingerprint =")
+    expect(editorStudioSource).not.toContain("const normalizeSafeImageUrl =")
+    expect(editorStudioSource).not.toContain("const normalizeSafePreviewThumbnailUrl =")
+    expect(editorStudioSource).not.toContain("const makePreviewSummary =")
+    expect(editorStudioSource).not.toContain("const normalizeRecommendedTags =")
+    expect(editorStudioSource).not.toContain("const formatTagRecommendationReason =")
+    expect(editorStudioSource).not.toContain("const splitFrontmatterBlock =")
+    expect(editorStudioSource).not.toContain("const resolveEditorMetaSnapshot =")
+    expect(editorStudioSource).not.toContain("const buildEditorStateFingerprint =")
+    expect(editorStudioSource).not.toContain("const parseEditorMeta =")
+    expect(editorStudioSource).not.toContain("const composeEditorContent =")
+    expect(editorStudioSource).not.toContain("const buildLocalDraftFingerprint =")
+    expect(editorStudioSource).not.toContain("const detectPublishPlaceholderIssue =")
     expect(writerEditorHostSource).toContain('dynamic(() => import("src/components/editor/BlockEditorShell")')
     expect(writerEditorHostSource).toContain("<Profiler")
     expect(writerEditorHostSource).toContain("<LazyBlockEditorShell")
@@ -434,10 +475,13 @@ test.describe("editor studio state", () => {
       "Stateless는 서버가 요청 사이 사용자 상태를 저장하지 않고"
     )
 
-    const editorStudioSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/EditorStudioPage.tsx"), "utf8")
-    expect(editorStudioSource).toContain('buildPreviewSummaryFromMarkdown(content, maxLength, "")')
-    expect(editorStudioSource).toContain("summary: normalizePersistedSummary(parsed.summary)")
-    expect(editorStudioSource).toContain("const normalizedSummary = normalizePersistedSummary(options?.summary)")
+    const editorStudioMetaModelSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/editorStudioMetaModel.ts"),
+      "utf8"
+    )
+    expect(editorStudioMetaModelSource).toContain('buildPreviewSummaryFromMarkdown(content, maxLength, "")')
+    expect(editorStudioMetaModelSource).toContain("summary: normalizePersistedSummary(parsed.summary)")
+    expect(editorStudioMetaModelSource).toContain("const normalizedSummary = normalizePersistedSummary(options?.summary)")
   })
 
   test("dedicated editor 나가기는 returnTo 복귀를 replace로 처리해 editor history 엔트리를 남기지 않는다", () => {

--- a/front/src/libs/markdown/htmlToMarkdown.ts
+++ b/front/src/libs/markdown/htmlToMarkdown.ts
@@ -113,6 +113,19 @@ const serializeImage = (element: HTMLImageElement) => {
   return `![${alt}](${escapeLinkHref(src)}${titleSuffix})`
 }
 
+const readCodeSourceAttribute = (...elements: Array<HTMLElement | null | undefined>) => {
+  for (const element of elements) {
+    if (!element) continue
+    const source = (
+      element.getAttribute("data-raw-code") ||
+      element.getAttribute("data-prism-source") ||
+      ""
+    ).trimEnd()
+    if (source) return normalizeClipboardLineEndings(source)
+  }
+  return ""
+}
+
 export const extractPlainTextFromHtml = (html: string) => {
   if (typeof DOMParser === "undefined") return ""
   const parser = new DOMParser()
@@ -352,7 +365,12 @@ export const convertHtmlToMarkdown = (
     if (tag === "ol") return listToMarkdown(element, true)
     if (tag === "pre") {
       const codeElement = element.querySelector("code")
-      const codeText = (codeElement?.textContent || element.textContent || "").trimEnd()
+      const codeText = (
+        readCodeSourceAttribute(codeElement, element) ||
+        codeElement?.textContent ||
+        element.textContent ||
+        ""
+      ).trimEnd()
       const className = codeElement?.className || ""
       const language = (className.match(/language-([a-zA-Z0-9_-]+)/)?.[1] || "").trim()
       return `\`\`\`${language}\n${codeText}\n\`\`\``

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -51,6 +51,27 @@ import {
   TEMP_DRAFT_BODY_PLACEHOLDER,
 } from "./editorTempDraft"
 import {
+  PREVIEW_SUMMARY_MAX_CONTENT_LENGTH,
+  PREVIEW_SUMMARY_MAX_LENGTH,
+  buildEditorStateFingerprint,
+  buildLocalDraftFingerprint,
+  composeEditorContent,
+  computeContentFingerprint,
+  dedupeStrings,
+  detectPublishPlaceholderIssue,
+  extractFirstMarkdownImage,
+  formatTagRecommendationReason,
+  makePreviewSummary,
+  normalizeRecommendedTags,
+  normalizeSafeImageUrl,
+  normalizeSafePreviewThumbnailUrl,
+  resolveEditorMetaSnapshot,
+  resolveTagRecommendationErrorMessage,
+  type LocalDraftPayload,
+  type MetaUsageMap,
+  type ResolvedEditorMetaSnapshot,
+} from "./editorStudioMetaModel"
+import {
   pushRoute,
   replaceShallowRoutePreservingScroll,
 } from "src/libs/router"
@@ -84,8 +105,7 @@ import {
   PROFILE_IMAGE_UPLOAD_RULE_LABEL,
 } from "src/libs/profileImageUpload"
 import { saveProfileCardWithConflictRetry } from "src/libs/profileCardSave"
-import { convertHtmlToMarkdown as convertHtmlClipboardToMarkdown } from "src/libs/markdown/htmlToMarkdown"
-import { buildPreviewSummaryFromMarkdown, normalizePersistedSummary } from "src/libs/postSummary"
+import { normalizePersistedSummary } from "src/libs/postSummary"
 import { articleTypographyScale } from "src/libs/markdown/contentTypography"
 import type { BlockEditorChangeMeta } from "src/components/editor/blockEditorContract"
 
@@ -229,40 +249,6 @@ type NoticeState = {
 }
 type StudioSurface = "manage" | "compose"
 type MobileStudioStep = "query" | "list" | "edit" | "publish"
-type ParsedEditorMeta = {
-  body: string
-  tags: string[]
-  category: string
-  summary: string
-  thumbnail: string
-}
-
-type ResolvedEditorMetaSnapshot = {
-  body: string
-  tags: string[]
-  category: string
-  summary: string
-  thumbnailUrl: string
-  thumbnailFocusX: number
-  thumbnailFocusY: number
-  thumbnailZoom: number
-}
-
-type MetaUsageMap = Record<string, number>
-type LocalDraftPayload = {
-  title: string
-  content: string
-  summary: string
-  thumbnailUrl: string
-  thumbnailFocusX: number
-  thumbnailFocusY: number
-  thumbnailZoom: number
-  tags: string[]
-  category: string
-  visibility: PostVisibility
-  savedAt: string
-}
-
 type PreviewViewportMode = "desktop" | "tablet" | "mobile"
 type ManageMobileStudioStep = "query" | "list"
 type ComposeMobileStudioStep = "edit" | "publish"
@@ -307,7 +293,6 @@ const syncTitleTextareaHeight = (element: HTMLTextAreaElement | null) => {
   element.style.height = "0px"
   element.style.height = `${Math.max(element.scrollHeight, 44)}px`
 }
-const EDITOR_TOGGLE_TITLE_PLACEHOLDER = "토글 제목"
 const PREVIEW_CARD_VIEWPORTS: Record<
   PreviewViewportMode,
   {
@@ -432,15 +417,6 @@ export const getEditorStudioPageProps: GetServerSideProps<AdminPageProps> = asyn
 
 const pretty = (value: unknown) => JSON.stringify(value, null, 2)
 
-const dedupeStrings = (items: string[]) =>
-  Array.from(
-    new Set(
-      items
-        .map((item) => item.trim())
-        .filter(Boolean)
-    )
-  )
-
 const isComposingKeyboardEvent = (
   event: React.KeyboardEvent<HTMLElement>
 ) => {
@@ -455,26 +431,6 @@ const generateIdempotencyKey = () => {
   return `post-write-${Date.now()}-${Math.random().toString(16).slice(2)}`
 }
 
-const normalizeMetaItems = (raw: string): string[] => {
-  const normalized = raw.trim().replace(/^\[|\]$/g, "")
-  if (!normalized) return []
-
-  return dedupeStrings(
-    normalized
-      .split(",")
-      .map((token) => token.trim().replace(/^['"]|['"]$/g, ""))
-  )
-}
-
-const normalizeMetaScalar = (raw: string) => raw.trim().replace(/^['"]|['"]$/g, "")
-
-const markdownImagePattern = /!\[[^\]]*]\(([^)\s]+)(?:\s+"[^"]*")?\)/
-const PREVIEW_SUMMARY_MAX_LENGTH = 150
-const PREVIEW_SUMMARY_MAX_CONTENT_LENGTH = 50_000
-const PREVIEW_THUMBNAIL_ALLOWED_PATH_PREFIX = "/post/api/v1/images/posts/"
-const PREVIEW_THUMBNAIL_DISALLOWED_CHAR_REGEX = /[\u0000-\u001F\u007F<>"'`\\]/
-const PREVIEW_THUMBNAIL_ALLOWED_PATH_REGEX = /^\/post\/api\/v1\/images\/posts\/[A-Za-z0-9._~/%-]+$/
-const PREVIEW_THUMBNAIL_ALLOWED_QUERY_REGEX = /^\?(?:[A-Za-z0-9._~/%=&-]*)$/
 const EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT = 240
 
 type RuntimeGuardWindow = Window & {
@@ -482,21 +438,6 @@ type RuntimeGuardWindow = Window & {
   __AQ_RUNTIME_GUARD__?: {
     editorCommitSamples?: number[]
   }
-}
-
-const extractFirstMarkdownImage = (content: string): string => {
-  const match = markdownImagePattern.exec(content)
-  return match?.[1]?.trim() || ""
-}
-
-const computeContentFingerprint = (content: string): string => {
-  // Lightweight FNV-1a style hash to gate repeated derived calculations.
-  let hash = 2166136261
-  for (let index = 0; index < content.length; index += 1) {
-    hash ^= content.charCodeAt(index)
-    hash = Math.imul(hash, 16777619)
-  }
-  return `${content.length}:${hash >>> 0}`
 }
 
 const recordEditorCommitDurationForRuntimeGuard = (actualDuration: number) => {
@@ -510,135 +451,6 @@ const recordEditorCommitDurationForRuntimeGuard = (actualDuration: number) => {
     nextSamples.splice(0, nextSamples.length - EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT)
   }
   store.editorCommitSamples = nextSamples
-}
-
-const normalizeSafeImageUrl = (raw: string): string => {
-  const value = raw.trim()
-  if (!value) return ""
-
-  if (value.startsWith("/")) {
-    return value.startsWith("//") ? "" : value
-  }
-
-  if (value.startsWith("./") || value.startsWith("../")) {
-    return value
-  }
-
-  try {
-    const parsed = new URL(value)
-    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-      return parsed.toString()
-    }
-  } catch {
-    return ""
-  }
-
-  return ""
-}
-
-const toSafePreviewThumbnailPath = (pathname: string, search: string): string => {
-  if (!PREVIEW_THUMBNAIL_ALLOWED_PATH_REGEX.test(pathname)) return ""
-  if (!search) return pathname
-  if (!PREVIEW_THUMBNAIL_ALLOWED_QUERY_REGEX.test(search)) return ""
-  return `${pathname}${search}`
-}
-
-const resolvePreviewThumbnailApiOrigin = (): string => {
-  try {
-    return new URL(getApiBaseUrl()).origin
-  } catch {
-    return ""
-  }
-}
-
-const normalizeSafePreviewThumbnailUrl = (raw: string): string => {
-  const value = raw.trim()
-  if (!value) return ""
-  if (PREVIEW_THUMBNAIL_DISALLOWED_CHAR_REGEX.test(value)) return ""
-
-  if (value.startsWith("/")) {
-    if (value.startsWith("//")) return ""
-    try {
-      const parsed = new URL(value, "https://preview.local")
-      const safePath = toSafePreviewThumbnailPath(parsed.pathname, parsed.search)
-      if (!safePath) return ""
-      const apiOrigin = resolvePreviewThumbnailApiOrigin()
-      if (typeof window !== "undefined" && apiOrigin && window.location.origin !== apiOrigin) {
-        return `${apiOrigin}${safePath}`
-      }
-      return safePath
-    } catch {
-      return ""
-    }
-  }
-
-  try {
-    const parsed = new URL(value)
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return ""
-    if (parsed.username || parsed.password) return ""
-
-    const allowedHosts = new Set<string>()
-    const baseUrl = getApiBaseUrl()
-    try {
-      allowedHosts.add(new URL(baseUrl).host)
-    } catch {
-      return ""
-    }
-    if (typeof window !== "undefined" && window.location.host) {
-      allowedHosts.add(window.location.host)
-    }
-    if (!allowedHosts.has(parsed.host)) return ""
-    if (!parsed.pathname.startsWith(PREVIEW_THUMBNAIL_ALLOWED_PATH_PREFIX)) return ""
-    const safePath = toSafePreviewThumbnailPath(parsed.pathname, parsed.search)
-    if (!safePath) return ""
-    const apiOrigin = resolvePreviewThumbnailApiOrigin()
-    if (typeof window !== "undefined" && parsed.origin === window.location.origin) {
-      return safePath
-    }
-    if (apiOrigin && parsed.origin === apiOrigin) {
-      return `${apiOrigin}${safePath}`
-    }
-    return `${parsed.origin}${safePath}`
-  } catch {
-    return ""
-  }
-}
-
-const makePreviewSummary = (content: string, maxLength = PREVIEW_SUMMARY_MAX_LENGTH) =>
-  buildPreviewSummaryFromMarkdown(content, maxLength, "")
-
-const normalizeRecommendedTags = (value: unknown, maxTags: number) => {
-  if (!Array.isArray(value)) return []
-  const map = new Map<string, string>()
-  value.forEach((item) => {
-    if (typeof item !== "string") return
-    const normalized = item.replace(/[\r\n]/g, " ").replace(/#/g, "").replace(/\s+/g, " ").trim()
-    if (!normalized) return
-    if (normalized.length < 2 || normalized.length > 24) return
-    if (!/[\p{L}\p{N}]/u.test(normalized)) return
-    if (normalized.toLowerCase() === "aside") return
-    const key = normalized.toLowerCase()
-    if (map.has(key) || map.size >= maxTags) return
-    map.set(key, normalized)
-  })
-  return Array.from(map.values())
-}
-
-const resolveTagRecommendationErrorMessage = (error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error)
-  const normalized = message.trim()
-  if (!normalized) return "태그 추천 요청 처리 중 오류가 발생했습니다."
-
-  const lowered = normalized.toLowerCase()
-  if (lowered.includes("failed to fetch")) {
-    return "네트워크 연결 또는 API 응답 수신에 실패했습니다."
-  }
-
-  if (lowered.includes("abort") || lowered.includes("timeout")) {
-    return "태그 추천 응답 대기 시간이 초과되었습니다."
-  }
-
-  return normalized
 }
 
 const fetchRecommendedTags = async (
@@ -688,257 +500,6 @@ const fetchRecommendedTags = async (
   } finally {
     clearTimeout(timeoutId)
   }
-}
-
-const formatTagRecommendationReason = (rawReason?: string | null) => {
-  const reason = (rawReason || "").trim()
-  switch (reason) {
-    case "ai-disabled":
-      return "AI 태그 추천이 비활성화됨"
-    case "api-key-missing":
-      return "Gemini API 키 누락"
-    case "rate-limited":
-      return "요청 제한으로 규칙 추천 사용"
-    case "quota-exhausted":
-      return "AI API 사용 한도 초과"
-    case "status-503":
-    case "status-504":
-      return "AI API 통신 실패"
-    case "transport":
-      return "AI API 전송 실패"
-    case "parse-error":
-      return "AI 태그 응답 파싱 실패"
-    case "empty-tags":
-      return "AI가 태그를 반환하지 않음"
-    case "internal-error":
-      return "서버 내부 처리 실패"
-    case "proxy-transport":
-      return "프록시 통신 실패(규칙 추천 대체)"
-    default:
-      if (reason.startsWith("proxy-upstream-")) {
-        return `프록시 업스트림 오류(${reason.slice("proxy-upstream-".length)})`
-      }
-      if (reason.startsWith("status-")) return `AI API 상태코드 ${reason.slice("status-".length)}`
-      return reason
-  }
-}
-
-const FRONTMATTER_DELIMITER_REGEX = /^\s*---\s*$/
-const LEADING_EDITOR_METADATA_LINE_REGEX =
-  /^\s*(tags?|categories?|summary|thumbnail|thumb|cover|coverimage|cover_image)\s*:\s*(.+)\s*$/i
-
-const splitFrontmatterBlock = (content: string) => {
-  const normalized = content.replace(/\r\n?/g, "\n").trimStart()
-  const lines = normalized.split("\n")
-  if (!FRONTMATTER_DELIMITER_REGEX.test(lines[0] || "")) {
-    return {
-      metadataLines: [] as string[],
-      body: normalized,
-    }
-  }
-
-  for (let index = 1; index < lines.length; index += 1) {
-    if (!FRONTMATTER_DELIMITER_REGEX.test(lines[index] || "")) continue
-    return {
-      metadataLines: lines.slice(1, index),
-      body: lines
-        .slice(index + 1)
-        .join("\n")
-        .replace(/^\n+/, ""),
-    }
-  }
-
-  return {
-    metadataLines: [] as string[],
-    body: normalized,
-  }
-}
-
-const stripLeadingEditorMetadataLines = (content: string) => {
-  const normalized = content.replace(/\r\n?/g, "\n")
-  const lines = normalized.split("\n")
-  let consumed = 0
-
-  for (const line of lines) {
-    if (!line.trim()) {
-      consumed += 1
-      break
-    }
-    if (!LEADING_EDITOR_METADATA_LINE_REGEX.test(line)) break
-    consumed += 1
-  }
-
-  return {
-    consumed,
-    body: consumed > 0 ? lines.slice(consumed).join("\n").trimStart() : normalized,
-  }
-}
-
-const resolveEditorBodyFallback = (content: string, parsedBody: string) => {
-  const normalized = content.replace(/\r\n?/g, "\n").trimStart()
-  if (parsedBody.trim().length > 0 || normalized.trim().length === 0) return parsedBody
-
-  const frontmatterSplit = splitFrontmatterBlock(normalized)
-  const inlineMetadataSplit = stripLeadingEditorMetadataLines(frontmatterSplit.body)
-  return inlineMetadataSplit.body.trim().length > 0 ? inlineMetadataSplit.body : parsedBody
-}
-
-const resolveEditorMetaSnapshot = (content: string, contentHtml?: string | null): ResolvedEditorMetaSnapshot => {
-  const parsed = parseEditorMeta(content)
-  const normalizedRawContent = content.replace(/\r\n?/g, "\n").trim()
-  const markdownFromHtml = contentHtml?.trim() ? convertHtmlClipboardToMarkdown(contentHtml).trim() : ""
-  const resolvedBody = parsed.body.trim() || markdownFromHtml || normalizedRawContent
-  const parsedThumbnail = normalizeSafeImageUrl(parsed.thumbnail)
-  const fallbackThumbnail = normalizeSafeImageUrl(extractFirstMarkdownImage(resolvedBody))
-  const syncedThumbnail = stripThumbnailFocusFromUrl(parsedThumbnail || fallbackThumbnail)
-  const syncedThumbnailFocusX = parseThumbnailFocusXFromUrl(
-    parsedThumbnail || fallbackThumbnail,
-    DEFAULT_THUMBNAIL_FOCUS_X
-  )
-  const syncedThumbnailFocusY = parseThumbnailFocusYFromUrl(
-    parsedThumbnail || fallbackThumbnail,
-    DEFAULT_THUMBNAIL_FOCUS_Y
-  )
-  const syncedThumbnailZoom = parseThumbnailZoomFromUrl(parsedThumbnail || fallbackThumbnail, DEFAULT_THUMBNAIL_ZOOM)
-
-  return {
-    body: resolvedBody,
-    tags: parsed.tags,
-    category: parsed.category,
-    summary: normalizePersistedSummary(parsed.summary),
-    thumbnailUrl: syncedThumbnail,
-    thumbnailFocusX: syncedThumbnailFocusX,
-    thumbnailFocusY: syncedThumbnailFocusY,
-    thumbnailZoom: syncedThumbnailZoom,
-  }
-}
-
-const buildEditorStateFingerprint = ({
-  title,
-  content,
-  summary,
-  thumbnailUrl,
-  thumbnailFocusX,
-  thumbnailFocusY,
-  thumbnailZoom,
-  tags,
-  category,
-  visibility,
-}: {
-  title: string
-  content: string
-  summary: string
-  thumbnailUrl: string
-  thumbnailFocusX: number
-  thumbnailFocusY: number
-  thumbnailZoom: number
-  tags: string[]
-  category: string
-  visibility: PostVisibility
-}) =>
-  JSON.stringify({
-    title,
-    content,
-    summary,
-    thumbnailUrl,
-    thumbnailFocusX,
-    thumbnailFocusY,
-    thumbnailZoom,
-    tags: dedupeStrings(tags),
-    category: category ? normalizeCategoryValue(category) : "",
-    visibility,
-  })
-
-const parseEditorMeta = (content: string): ParsedEditorMeta => {
-  let trimmed = content.replace(/\r\n?/g, "\n").trimStart()
-  const tags: string[] = []
-  let category = ""
-  let summary = ""
-  let thumbnail = ""
-
-  const pushTags = (items: string[]) => {
-    dedupeStrings(items).forEach((item) => {
-      if (!tags.includes(item)) tags.push(item)
-    })
-  }
-
-  const setCategory = (items: string[]) => {
-    const nextCategory = dedupeStrings(items).map(normalizeCategoryValue)[0] || ""
-    if (nextCategory) category = nextCategory
-  }
-
-  const frontmatterSplit = splitFrontmatterBlock(trimmed)
-  if (frontmatterSplit.metadataLines.length > 0) {
-    frontmatterSplit.metadataLines.forEach((line) => {
-      const [rawKey, ...rest] = line.split(":")
-      if (!rawKey || rest.length === 0) return
-      const key = rawKey.trim().toLowerCase()
-      const value = rest.join(":").trim()
-      if (!value) return
-
-      if (key === "tags" || key === "tag") pushTags(normalizeMetaItems(value))
-      if (key === "category" || key === "categories") setCategory(normalizeMetaItems(value))
-      if (key === "summary") summary = normalizeMetaScalar(value)
-      if (key === "thumbnail" || key === "thumb" || key === "cover" || key === "coverimage" || key === "cover_image") {
-        thumbnail = normalizeMetaScalar(value)
-      }
-    })
-    trimmed = frontmatterSplit.body.trimStart()
-  }
-
-  const leadingMetadataSplit = stripLeadingEditorMetadataLines(trimmed)
-  if (leadingMetadataSplit.consumed > 0) {
-    trimmed
-      .split("\n")
-      .slice(0, leadingMetadataSplit.consumed)
-      .forEach((line) => {
-        const match = line.match(LEADING_EDITOR_METADATA_LINE_REGEX)
-        if (!match) return
-
-        const key = match[1].toLowerCase()
-        const value = match[2]
-        if (key === "tag" || key === "tags") pushTags(normalizeMetaItems(value))
-        if (key === "category" || key === "categories") setCategory(normalizeMetaItems(value))
-        if (key === "summary") summary = normalizeMetaScalar(value)
-        if (key === "thumbnail" || key === "thumb" || key === "cover" || key === "coverimage" || key === "cover_image") {
-          thumbnail = normalizeMetaScalar(value)
-        }
-      })
-    trimmed = leadingMetadataSplit.body
-  }
-
-  return {
-    body: resolveEditorBodyFallback(content, trimmed),
-    tags,
-    category,
-    summary,
-    thumbnail,
-  }
-}
-
-const serializeMetaItems = (items: string[]) => items.map((item) => JSON.stringify(item)).join(", ")
-
-const composeEditorContent = (
-  body: string,
-  tags: string[],
-  options?: { category?: string; summary?: string; thumbnail?: string }
-) => {
-  const normalizedBody = body.trim()
-  const normalizedTags = dedupeStrings(tags)
-  const normalizedCategory = options?.category ? normalizeCategoryValue(options.category) : ""
-  const normalizedSummary = normalizePersistedSummary(options?.summary)
-  const normalizedThumbnail = options?.thumbnail?.trim() || ""
-  const metadataLines: string[] = []
-
-  if (normalizedTags.length > 0) metadataLines.push(`tags: [${serializeMetaItems(normalizedTags)}]`)
-  if (normalizedCategory) metadataLines.push(`category: [${serializeMetaItems([normalizedCategory])}]`)
-  if (normalizedThumbnail) metadataLines.push(`thumbnail: ${JSON.stringify(normalizedThumbnail)}`)
-  if (normalizedSummary) metadataLines.push(`summary: ${JSON.stringify(normalizedSummary)}`)
-
-  if (metadataLines.length === 0) return normalizedBody
-  if (!normalizedBody) return `---\n${metadataLines.join("\n")}\n---`
-
-  return `---\n${metadataLines.join("\n")}\n---\n\n${normalizedBody}`
 }
 
 const readStoredCatalog = (storageKey: string) => {
@@ -1020,9 +581,6 @@ const removeLocalDraft = () => {
   if (typeof window === "undefined") return
   window.localStorage.removeItem(LOCAL_DRAFT_STORAGE_KEY)
 }
-
-const buildLocalDraftFingerprint = (payload: Omit<LocalDraftPayload, "savedAt">) =>
-  JSON.stringify(payload)
 
 const parseResponseErrorBody = async (response: Response): Promise<string> => {
   const text = await response.text().catch(() => "")
@@ -1117,32 +675,6 @@ const uploadWithConflictRetry = async (
   throw new Error(
     `이미지 업로드 실패 (409): ${lastConflictBody || "요청 충돌이 반복되어 업로드를 완료하지 못했습니다."}`
   )
-}
-
-const detectPublishPlaceholderIssue = (content: string): string | null => {
-  let inFence = false
-
-  for (const rawLine of content.replace(/\r\n/g, "\n").split("\n")) {
-    const trimmed = rawLine.trim()
-    if (!trimmed) continue
-
-    if (/^```/.test(trimmed)) {
-      inFence = !inFence
-      continue
-    }
-
-    if (inFence || trimmed.startsWith(">")) continue
-
-    if (trimmed === EDITOR_BODY_PLACEHOLDER) {
-      return "본문에 기본 placeholder 문구가 남아 있습니다. 실제 내용으로 교체한 뒤 다시 시도해주세요."
-    }
-
-    if (trimmed === `:::toggle ${EDITOR_TOGGLE_TITLE_PLACEHOLDER}`) {
-      return "토글 제목이 기본값으로 남아 있습니다. 실제 제목으로 바꾼 뒤 다시 시도해주세요."
-    }
-  }
-
-  return null
 }
 
 const sanitizeNumberInput = (value: string) => value.replace(/[^\d]/g, "")

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -86,15 +86,10 @@ import ProfileImage from "src/components/ProfileImage"
 import AppIcon from "src/components/icons/AppIcon"
 import {
   applyThumbnailTransformToUrl,
-  clampThumbnailFocusX,
-  clampThumbnailFocusY,
   clampThumbnailZoom,
   DEFAULT_THUMBNAIL_FOCUS_X,
   DEFAULT_THUMBNAIL_FOCUS_Y,
   DEFAULT_THUMBNAIL_ZOOM,
-  parseThumbnailFocusXFromUrl,
-  parseThumbnailZoomFromUrl,
-  parseThumbnailFocusYFromUrl,
   stripThumbnailFocusFromUrl,
 } from "src/libs/thumbnailFocus"
 import {
@@ -105,9 +100,17 @@ import {
   PROFILE_IMAGE_UPLOAD_RULE_LABEL,
 } from "src/libs/profileImageUpload"
 import { saveProfileCardWithConflictRetry } from "src/libs/profileCardSave"
-import { normalizePersistedSummary } from "src/libs/postSummary"
 import { articleTypographyScale } from "src/libs/markdown/contentTypography"
 import type { BlockEditorChangeMeta } from "src/components/editor/blockEditorContract"
+import {
+  CATEGORY_CATALOG_STORAGE_KEY,
+  TAG_CATALOG_STORAGE_KEY,
+  persistCatalog,
+  persistLocalDraft,
+  readLocalDraft,
+  readStoredCatalog,
+  removeLocalDraft,
+} from "./editorStudioStorageModel"
 
 const BLOCK_EDITOR_V2_MERMAID_ENABLED = process.env.NEXT_PUBLIC_EDITOR_V2_MERMAID_ENABLED !== "false"
 const ADMIN_POSTS_WORKSPACE_ROUTE = "/admin/posts"
@@ -253,9 +256,6 @@ type PreviewViewportMode = "desktop" | "tablet" | "mobile"
 type ManageMobileStudioStep = "query" | "list"
 type ComposeMobileStudioStep = "edit" | "publish"
 
-const TAG_CATALOG_STORAGE_KEY = "admin.editor.customTags"
-const CATEGORY_CATALOG_STORAGE_KEY = "admin.editor.customCategories"
-const LOCAL_DRAFT_STORAGE_KEY = "admin.editor.localDraft.v1"
 const LIST_CONDITION_STORAGE_KEY = "admin.contentStudio.listConditions.v1"
 const LIST_CACHE_TTL_MS = 45_000
 const GLOBAL_NOTICE_IDLE_TEXT = "운영 작업 상태가 여기에 표시됩니다."
@@ -500,86 +500,6 @@ const fetchRecommendedTags = async (
   } finally {
     clearTimeout(timeoutId)
   }
-}
-
-const readStoredCatalog = (storageKey: string) => {
-  if (typeof window === "undefined") return []
-
-  try {
-    const raw = window.localStorage.getItem(storageKey)
-    if (!raw) return []
-    const parsed = JSON.parse(raw)
-    return Array.isArray(parsed)
-      ? dedupeStrings(parsed.filter((item): item is string => typeof item === "string"))
-      : []
-  } catch {
-    return []
-  }
-}
-
-const persistCatalog = (storageKey: string, values: string[]) => {
-  if (typeof window === "undefined") return
-  window.localStorage.setItem(storageKey, JSON.stringify(dedupeStrings(values)))
-}
-
-const readLocalDraft = (): LocalDraftPayload | null => {
-  if (typeof window === "undefined") return null
-
-  try {
-    const raw = window.localStorage.getItem(LOCAL_DRAFT_STORAGE_KEY)
-    if (!raw) return null
-    const parsed = JSON.parse(raw) as Partial<LocalDraftPayload>
-    if (!parsed || typeof parsed !== "object") return null
-
-    const visibility = parsed.visibility
-    const isValidVisibility =
-      visibility === "PRIVATE" || visibility === "PUBLIC_UNLISTED" || visibility === "PUBLIC_LISTED"
-    const rawThumbnailUrl =
-      typeof parsed.thumbnailUrl === "string" ? normalizeSafeImageUrl(parsed.thumbnailUrl) : ""
-    const legacyFocusX = parseThumbnailFocusXFromUrl(rawThumbnailUrl, DEFAULT_THUMBNAIL_FOCUS_X)
-    const legacyFocusY = parseThumbnailFocusYFromUrl(rawThumbnailUrl, DEFAULT_THUMBNAIL_FOCUS_Y)
-    const legacyZoom = parseThumbnailZoomFromUrl(rawThumbnailUrl, DEFAULT_THUMBNAIL_ZOOM)
-    const parsedFocusX =
-      typeof parsed.thumbnailFocusX === "number"
-        ? clampThumbnailFocusX(parsed.thumbnailFocusX)
-        : legacyFocusX
-    const parsedFocusY =
-      typeof parsed.thumbnailFocusY === "number"
-        ? clampThumbnailFocusY(parsed.thumbnailFocusY)
-        : legacyFocusY
-    const parsedZoom =
-      typeof parsed.thumbnailZoom === "number"
-        ? clampThumbnailZoom(parsed.thumbnailZoom)
-        : legacyZoom
-
-    return {
-      title: typeof parsed.title === "string" ? parsed.title : "",
-      content: typeof parsed.content === "string" ? parsed.content : "",
-      summary: normalizePersistedSummary(parsed.summary),
-      thumbnailUrl: stripThumbnailFocusFromUrl(rawThumbnailUrl),
-      thumbnailFocusX: parsedFocusX,
-      thumbnailFocusY: parsedFocusY,
-      thumbnailZoom: parsedZoom,
-      tags: Array.isArray(parsed.tags)
-        ? dedupeStrings(parsed.tags.filter((item): item is string => typeof item === "string"))
-        : [],
-      category: typeof parsed.category === "string" ? normalizeCategoryValue(parsed.category) : "",
-      visibility: isValidVisibility ? visibility : "PUBLIC_LISTED",
-      savedAt: typeof parsed.savedAt === "string" ? parsed.savedAt : "",
-    }
-  } catch {
-    return null
-  }
-}
-
-const persistLocalDraft = (payload: LocalDraftPayload) => {
-  if (typeof window === "undefined") return
-  window.localStorage.setItem(LOCAL_DRAFT_STORAGE_KEY, JSON.stringify(payload))
-}
-
-const removeLocalDraft = () => {
-  if (typeof window === "undefined") return
-  window.localStorage.removeItem(LOCAL_DRAFT_STORAGE_KEY)
 }
 
 const parseResponseErrorBody = async (response: Response): Promise<string> => {

--- a/front/src/routes/Admin/editorStudioMetaModel.ts
+++ b/front/src/routes/Admin/editorStudioMetaModel.ts
@@ -1,0 +1,505 @@
+import { getApiBaseUrl } from "src/apis/backend/client"
+import { convertHtmlToMarkdown as convertHtmlClipboardToMarkdown } from "src/libs/markdown/htmlToMarkdown"
+import { buildPreviewSummaryFromMarkdown, normalizePersistedSummary } from "src/libs/postSummary"
+import { normalizeCategoryValue } from "src/libs/utils"
+import {
+  DEFAULT_THUMBNAIL_FOCUS_X,
+  DEFAULT_THUMBNAIL_FOCUS_Y,
+  DEFAULT_THUMBNAIL_ZOOM,
+  parseThumbnailFocusXFromUrl,
+  parseThumbnailFocusYFromUrl,
+  parseThumbnailZoomFromUrl,
+  stripThumbnailFocusFromUrl,
+} from "src/libs/thumbnailFocus"
+import type { PostVisibility } from "./editorStudioState"
+
+export type ParsedEditorMeta = {
+  body: string
+  tags: string[]
+  category: string
+  summary: string
+  thumbnail: string
+}
+
+export type ResolvedEditorMetaSnapshot = {
+  body: string
+  tags: string[]
+  category: string
+  summary: string
+  thumbnailUrl: string
+  thumbnailFocusX: number
+  thumbnailFocusY: number
+  thumbnailZoom: number
+}
+
+export type MetaUsageMap = Record<string, number>
+
+export type LocalDraftPayload = {
+  title: string
+  content: string
+  summary: string
+  thumbnailUrl: string
+  thumbnailFocusX: number
+  thumbnailFocusY: number
+  thumbnailZoom: number
+  tags: string[]
+  category: string
+  visibility: PostVisibility
+  savedAt: string
+}
+
+const markdownImagePattern = /!\[[^\]]*]\(([^)\s]+)(?:\s+"[^"]*")?\)/
+const PREVIEW_THUMBNAIL_ALLOWED_PATH_PREFIX = "/post/api/v1/images/posts/"
+const PREVIEW_THUMBNAIL_DISALLOWED_CHAR_REGEX = /[\u0000-\u001F\u007F<>"'`\\]/
+const PREVIEW_THUMBNAIL_ALLOWED_PATH_REGEX = /^\/post\/api\/v1\/images\/posts\/[A-Za-z0-9._~/%-]+$/
+const PREVIEW_THUMBNAIL_ALLOWED_QUERY_REGEX = /^\?(?:[A-Za-z0-9._~/%=&-]*)$/
+const FRONTMATTER_DELIMITER_REGEX = /^\s*---\s*$/
+const LEADING_EDITOR_METADATA_LINE_REGEX =
+  /^\s*(tags?|categories?|summary|thumbnail|thumb|cover|coverimage|cover_image)\s*:\s*(.+)\s*$/i
+const EDITOR_BODY_PLACEHOLDER = "내용을 입력하세요."
+const EDITOR_TOGGLE_TITLE_PLACEHOLDER = "토글 제목"
+
+export const PREVIEW_SUMMARY_MAX_LENGTH = 150
+export const PREVIEW_SUMMARY_MAX_CONTENT_LENGTH = 50_000
+
+export const dedupeStrings = (items: string[]) =>
+  Array.from(
+    new Set(
+      items
+        .map((item) => item.trim())
+        .filter(Boolean)
+    )
+  )
+
+const normalizeMetaItems = (raw: string): string[] => {
+  const normalized = raw.trim().replace(/^\[|\]$/g, "")
+  if (!normalized) return []
+
+  return dedupeStrings(
+    normalized
+      .split(",")
+      .map((token) => token.trim().replace(/^['"]|['"]$/g, ""))
+  )
+}
+
+const normalizeMetaScalar = (raw: string) => raw.trim().replace(/^['"]|['"]$/g, "")
+
+export const extractFirstMarkdownImage = (content: string): string => {
+  const match = markdownImagePattern.exec(content)
+  return match?.[1]?.trim() || ""
+}
+
+export const computeContentFingerprint = (content: string): string => {
+  // Lightweight FNV-1a style hash to gate repeated derived calculations.
+  let hash = 2166136261
+  for (let index = 0; index < content.length; index += 1) {
+    hash ^= content.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return `${content.length}:${hash >>> 0}`
+}
+
+export const normalizeSafeImageUrl = (raw: string): string => {
+  const value = raw.trim()
+  if (!value) return ""
+
+  if (value.startsWith("/")) {
+    return value.startsWith("//") ? "" : value
+  }
+
+  if (value.startsWith("./") || value.startsWith("../")) {
+    return value
+  }
+
+  try {
+    const parsed = new URL(value)
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.toString()
+    }
+  } catch {
+    return ""
+  }
+
+  return ""
+}
+
+const toSafePreviewThumbnailPath = (pathname: string, search: string): string => {
+  if (!PREVIEW_THUMBNAIL_ALLOWED_PATH_REGEX.test(pathname)) return ""
+  if (!search) return pathname
+  if (!PREVIEW_THUMBNAIL_ALLOWED_QUERY_REGEX.test(search)) return ""
+  return `${pathname}${search}`
+}
+
+const resolvePreviewThumbnailApiOrigin = (): string => {
+  try {
+    return new URL(getApiBaseUrl()).origin
+  } catch {
+    return ""
+  }
+}
+
+export const normalizeSafePreviewThumbnailUrl = (raw: string): string => {
+  const value = raw.trim()
+  if (!value) return ""
+  if (PREVIEW_THUMBNAIL_DISALLOWED_CHAR_REGEX.test(value)) return ""
+
+  if (value.startsWith("/")) {
+    if (value.startsWith("//")) return ""
+    try {
+      const parsed = new URL(value, "https://preview.local")
+      const safePath = toSafePreviewThumbnailPath(parsed.pathname, parsed.search)
+      if (!safePath) return ""
+      const apiOrigin = resolvePreviewThumbnailApiOrigin()
+      if (typeof window !== "undefined" && apiOrigin && window.location.origin !== apiOrigin) {
+        return `${apiOrigin}${safePath}`
+      }
+      return safePath
+    } catch {
+      return ""
+    }
+  }
+
+  try {
+    const parsed = new URL(value)
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return ""
+    if (parsed.username || parsed.password) return ""
+
+    const allowedHosts = new Set<string>()
+    const baseUrl = getApiBaseUrl()
+    try {
+      allowedHosts.add(new URL(baseUrl).host)
+    } catch {
+      return ""
+    }
+    if (typeof window !== "undefined" && window.location.host) {
+      allowedHosts.add(window.location.host)
+    }
+    if (!allowedHosts.has(parsed.host)) return ""
+    if (!parsed.pathname.startsWith(PREVIEW_THUMBNAIL_ALLOWED_PATH_PREFIX)) return ""
+    const safePath = toSafePreviewThumbnailPath(parsed.pathname, parsed.search)
+    if (!safePath) return ""
+    const apiOrigin = resolvePreviewThumbnailApiOrigin()
+    if (typeof window !== "undefined" && parsed.origin === window.location.origin) {
+      return safePath
+    }
+    if (apiOrigin && parsed.origin === apiOrigin) {
+      return `${apiOrigin}${safePath}`
+    }
+    return `${parsed.origin}${safePath}`
+  } catch {
+    return ""
+  }
+}
+
+export const makePreviewSummary = (content: string, maxLength = PREVIEW_SUMMARY_MAX_LENGTH) =>
+  buildPreviewSummaryFromMarkdown(content, maxLength, "")
+
+export const normalizeRecommendedTags = (value: unknown, maxTags: number) => {
+  if (!Array.isArray(value)) return []
+  const map = new Map<string, string>()
+  value.forEach((item) => {
+    if (typeof item !== "string") return
+    const normalized = item.replace(/[\r\n]/g, " ").replace(/#/g, "").replace(/\s+/g, " ").trim()
+    if (!normalized) return
+    if (normalized.length < 2 || normalized.length > 24) return
+    if (!/[\p{L}\p{N}]/u.test(normalized)) return
+    if (normalized.toLowerCase() === "aside") return
+    const key = normalized.toLowerCase()
+    if (map.has(key) || map.size >= maxTags) return
+    map.set(key, normalized)
+  })
+  return Array.from(map.values())
+}
+
+export const resolveTagRecommendationErrorMessage = (error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error)
+  const normalized = message.trim()
+  if (!normalized) return "태그 추천 요청 처리 중 오류가 발생했습니다."
+
+  const lowered = normalized.toLowerCase()
+  if (lowered.includes("failed to fetch")) {
+    return "네트워크 연결 또는 API 응답 수신에 실패했습니다."
+  }
+
+  if (lowered.includes("abort") || lowered.includes("timeout")) {
+    return "태그 추천 응답 대기 시간이 초과되었습니다."
+  }
+
+  return normalized
+}
+
+export const formatTagRecommendationReason = (rawReason?: string | null) => {
+  const reason = (rawReason || "").trim()
+  switch (reason) {
+    case "ai-disabled":
+      return "AI 태그 추천이 비활성화됨"
+    case "api-key-missing":
+      return "Gemini API 키 누락"
+    case "rate-limited":
+      return "요청 제한으로 규칙 추천 사용"
+    case "quota-exhausted":
+      return "AI API 사용 한도 초과"
+    case "status-503":
+    case "status-504":
+      return "AI API 통신 실패"
+    case "transport":
+      return "AI API 전송 실패"
+    case "parse-error":
+      return "AI 태그 응답 파싱 실패"
+    case "empty-tags":
+      return "AI가 태그를 반환하지 않음"
+    case "internal-error":
+      return "서버 내부 처리 실패"
+    case "proxy-transport":
+      return "프록시 통신 실패(규칙 추천 대체)"
+    default:
+      if (reason.startsWith("proxy-upstream-")) {
+        return `프록시 업스트림 오류(${reason.slice("proxy-upstream-".length)})`
+      }
+      if (reason.startsWith("status-")) return `AI API 상태코드 ${reason.slice("status-".length)}`
+      return reason
+  }
+}
+
+const splitFrontmatterBlock = (content: string) => {
+  const normalized = content.replace(/\r\n?/g, "\n").trimStart()
+  const lines = normalized.split("\n")
+  if (!FRONTMATTER_DELIMITER_REGEX.test(lines[0] || "")) {
+    return {
+      metadataLines: [] as string[],
+      body: normalized,
+    }
+  }
+
+  for (let index = 1; index < lines.length; index += 1) {
+    if (!FRONTMATTER_DELIMITER_REGEX.test(lines[index] || "")) continue
+    return {
+      metadataLines: lines.slice(1, index),
+      body: lines
+        .slice(index + 1)
+        .join("\n")
+        .replace(/^\n+/, ""),
+    }
+  }
+
+  return {
+    metadataLines: [] as string[],
+    body: normalized,
+  }
+}
+
+const stripLeadingEditorMetadataLines = (content: string) => {
+  const normalized = content.replace(/\r\n?/g, "\n")
+  const lines = normalized.split("\n")
+  let consumed = 0
+
+  for (const line of lines) {
+    if (!line.trim()) {
+      consumed += 1
+      break
+    }
+    if (!LEADING_EDITOR_METADATA_LINE_REGEX.test(line)) break
+    consumed += 1
+  }
+
+  return {
+    consumed,
+    body: consumed > 0 ? lines.slice(consumed).join("\n").trimStart() : normalized,
+  }
+}
+
+const resolveEditorBodyFallback = (content: string, parsedBody: string) => {
+  const normalized = content.replace(/\r\n?/g, "\n").trimStart()
+  if (parsedBody.trim().length > 0 || normalized.trim().length === 0) return parsedBody
+
+  const frontmatterSplit = splitFrontmatterBlock(normalized)
+  const inlineMetadataSplit = stripLeadingEditorMetadataLines(frontmatterSplit.body)
+  return inlineMetadataSplit.body.trim().length > 0 ? inlineMetadataSplit.body : parsedBody
+}
+
+export const resolveEditorMetaSnapshot = (content: string, contentHtml?: string | null): ResolvedEditorMetaSnapshot => {
+  const parsed = parseEditorMeta(content)
+  const normalizedRawContent = content.replace(/\r\n?/g, "\n").trim()
+  const markdownFromHtml = contentHtml?.trim() ? convertHtmlClipboardToMarkdown(contentHtml).trim() : ""
+  const resolvedBody = parsed.body.trim() || markdownFromHtml || normalizedRawContent
+  const parsedThumbnail = normalizeSafeImageUrl(parsed.thumbnail)
+  const fallbackThumbnail = normalizeSafeImageUrl(extractFirstMarkdownImage(resolvedBody))
+  const syncedThumbnail = stripThumbnailFocusFromUrl(parsedThumbnail || fallbackThumbnail)
+  const syncedThumbnailFocusX = parseThumbnailFocusXFromUrl(
+    parsedThumbnail || fallbackThumbnail,
+    DEFAULT_THUMBNAIL_FOCUS_X
+  )
+  const syncedThumbnailFocusY = parseThumbnailFocusYFromUrl(
+    parsedThumbnail || fallbackThumbnail,
+    DEFAULT_THUMBNAIL_FOCUS_Y
+  )
+  const syncedThumbnailZoom = parseThumbnailZoomFromUrl(parsedThumbnail || fallbackThumbnail, DEFAULT_THUMBNAIL_ZOOM)
+
+  return {
+    body: resolvedBody,
+    tags: parsed.tags,
+    category: parsed.category,
+    summary: normalizePersistedSummary(parsed.summary),
+    thumbnailUrl: syncedThumbnail,
+    thumbnailFocusX: syncedThumbnailFocusX,
+    thumbnailFocusY: syncedThumbnailFocusY,
+    thumbnailZoom: syncedThumbnailZoom,
+  }
+}
+
+export const buildEditorStateFingerprint = ({
+  title,
+  content,
+  summary,
+  thumbnailUrl,
+  thumbnailFocusX,
+  thumbnailFocusY,
+  thumbnailZoom,
+  tags,
+  category,
+  visibility,
+}: {
+  title: string
+  content: string
+  summary: string
+  thumbnailUrl: string
+  thumbnailFocusX: number
+  thumbnailFocusY: number
+  thumbnailZoom: number
+  tags: string[]
+  category: string
+  visibility: PostVisibility
+}) =>
+  JSON.stringify({
+    title,
+    content,
+    summary,
+    thumbnailUrl,
+    thumbnailFocusX,
+    thumbnailFocusY,
+    thumbnailZoom,
+    tags: dedupeStrings(tags),
+    category: category ? normalizeCategoryValue(category) : "",
+    visibility,
+  })
+
+export const parseEditorMeta = (content: string): ParsedEditorMeta => {
+  let trimmed = content.replace(/\r\n?/g, "\n").trimStart()
+  const tags: string[] = []
+  let category = ""
+  let summary = ""
+  let thumbnail = ""
+
+  const pushTags = (items: string[]) => {
+    dedupeStrings(items).forEach((item) => {
+      if (!tags.includes(item)) tags.push(item)
+    })
+  }
+
+  const setCategory = (items: string[]) => {
+    const nextCategory = dedupeStrings(items).map(normalizeCategoryValue)[0] || ""
+    if (nextCategory) category = nextCategory
+  }
+
+  const frontmatterSplit = splitFrontmatterBlock(trimmed)
+  if (frontmatterSplit.metadataLines.length > 0) {
+    frontmatterSplit.metadataLines.forEach((line) => {
+      const [rawKey, ...rest] = line.split(":")
+      if (!rawKey || rest.length === 0) return
+      const key = rawKey.trim().toLowerCase()
+      const value = rest.join(":").trim()
+      if (!value) return
+
+      if (key === "tags" || key === "tag") pushTags(normalizeMetaItems(value))
+      if (key === "category" || key === "categories") setCategory(normalizeMetaItems(value))
+      if (key === "summary") summary = normalizeMetaScalar(value)
+      if (key === "thumbnail" || key === "thumb" || key === "cover" || key === "coverimage" || key === "cover_image") {
+        thumbnail = normalizeMetaScalar(value)
+      }
+    })
+    trimmed = frontmatterSplit.body.trimStart()
+  }
+
+  const leadingMetadataSplit = stripLeadingEditorMetadataLines(trimmed)
+  if (leadingMetadataSplit.consumed > 0) {
+    trimmed
+      .split("\n")
+      .slice(0, leadingMetadataSplit.consumed)
+      .forEach((line) => {
+        const match = line.match(LEADING_EDITOR_METADATA_LINE_REGEX)
+        if (!match) return
+
+        const key = match[1].toLowerCase()
+        const value = match[2]
+        if (key === "tag" || key === "tags") pushTags(normalizeMetaItems(value))
+        if (key === "category" || key === "categories") setCategory(normalizeMetaItems(value))
+        if (key === "summary") summary = normalizeMetaScalar(value)
+        if (key === "thumbnail" || key === "thumb" || key === "cover" || key === "coverimage" || key === "cover_image") {
+          thumbnail = normalizeMetaScalar(value)
+        }
+      })
+    trimmed = leadingMetadataSplit.body
+  }
+
+  return {
+    body: resolveEditorBodyFallback(content, trimmed),
+    tags,
+    category,
+    summary,
+    thumbnail,
+  }
+}
+
+const serializeMetaItems = (items: string[]) => items.map((item) => JSON.stringify(item)).join(", ")
+
+export const composeEditorContent = (
+  body: string,
+  tags: string[],
+  options?: { category?: string; summary?: string; thumbnail?: string }
+) => {
+  const normalizedBody = body.trim()
+  const normalizedTags = dedupeStrings(tags)
+  const normalizedCategory = options?.category ? normalizeCategoryValue(options.category) : ""
+  const normalizedSummary = normalizePersistedSummary(options?.summary)
+  const normalizedThumbnail = options?.thumbnail?.trim() || ""
+  const metadataLines: string[] = []
+
+  if (normalizedTags.length > 0) metadataLines.push(`tags: [${serializeMetaItems(normalizedTags)}]`)
+  if (normalizedCategory) metadataLines.push(`category: [${serializeMetaItems([normalizedCategory])}]`)
+  if (normalizedThumbnail) metadataLines.push(`thumbnail: ${JSON.stringify(normalizedThumbnail)}`)
+  if (normalizedSummary) metadataLines.push(`summary: ${JSON.stringify(normalizedSummary)}`)
+
+  if (metadataLines.length === 0) return normalizedBody
+  if (!normalizedBody) return `---\n${metadataLines.join("\n")}\n---`
+
+  return `---\n${metadataLines.join("\n")}\n---\n\n${normalizedBody}`
+}
+
+export const buildLocalDraftFingerprint = (payload: Omit<LocalDraftPayload, "savedAt">) =>
+  JSON.stringify(payload)
+
+export const detectPublishPlaceholderIssue = (content: string): string | null => {
+  let inFence = false
+
+  for (const rawLine of content.replace(/\r\n/g, "\n").split("\n")) {
+    const trimmed = rawLine.trim()
+    if (!trimmed) continue
+
+    if (/^```/.test(trimmed)) {
+      inFence = !inFence
+      continue
+    }
+
+    if (inFence || trimmed.startsWith(">")) continue
+
+    if (trimmed === EDITOR_BODY_PLACEHOLDER) {
+      return "본문에 기본 placeholder 문구가 남아 있습니다. 실제 내용으로 교체한 뒤 다시 시도해주세요."
+    }
+
+    if (trimmed === `:::toggle ${EDITOR_TOGGLE_TITLE_PLACEHOLDER}`) {
+      return "토글 제목이 기본값으로 남아 있습니다. 실제 제목으로 바꾼 뒤 다시 시도해주세요."
+    }
+  }
+
+  return null
+}

--- a/front/src/routes/Admin/editorStudioStorageModel.ts
+++ b/front/src/routes/Admin/editorStudioStorageModel.ts
@@ -1,0 +1,103 @@
+import { normalizePersistedSummary } from "src/libs/postSummary"
+import { normalizeCategoryValue } from "src/libs/utils"
+import {
+  clampThumbnailFocusX,
+  clampThumbnailFocusY,
+  clampThumbnailZoom,
+  DEFAULT_THUMBNAIL_FOCUS_X,
+  DEFAULT_THUMBNAIL_FOCUS_Y,
+  DEFAULT_THUMBNAIL_ZOOM,
+  parseThumbnailFocusXFromUrl,
+  parseThumbnailFocusYFromUrl,
+  parseThumbnailZoomFromUrl,
+  stripThumbnailFocusFromUrl,
+} from "src/libs/thumbnailFocus"
+import {
+  dedupeStrings,
+  normalizeSafeImageUrl,
+  type LocalDraftPayload,
+} from "./editorStudioMetaModel"
+
+export const TAG_CATALOG_STORAGE_KEY = "admin.editor.customTags"
+export const CATEGORY_CATALOG_STORAGE_KEY = "admin.editor.customCategories"
+const LOCAL_DRAFT_STORAGE_KEY = "admin.editor.localDraft.v1"
+
+export const readStoredCatalog = (storageKey: string) => {
+  if (typeof window === "undefined") return []
+
+  try {
+    const raw = window.localStorage.getItem(storageKey)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed)
+      ? dedupeStrings(parsed.filter((item): item is string => typeof item === "string"))
+      : []
+  } catch {
+    return []
+  }
+}
+
+export const persistCatalog = (storageKey: string, values: string[]) => {
+  if (typeof window === "undefined") return
+  window.localStorage.setItem(storageKey, JSON.stringify(dedupeStrings(values)))
+}
+
+export const readLocalDraft = (): LocalDraftPayload | null => {
+  if (typeof window === "undefined") return null
+
+  try {
+    const raw = window.localStorage.getItem(LOCAL_DRAFT_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<LocalDraftPayload>
+    if (!parsed || typeof parsed !== "object") return null
+
+    const visibility = parsed.visibility
+    const isValidVisibility =
+      visibility === "PRIVATE" || visibility === "PUBLIC_UNLISTED" || visibility === "PUBLIC_LISTED"
+    const rawThumbnailUrl =
+      typeof parsed.thumbnailUrl === "string" ? normalizeSafeImageUrl(parsed.thumbnailUrl) : ""
+    const legacyFocusX = parseThumbnailFocusXFromUrl(rawThumbnailUrl, DEFAULT_THUMBNAIL_FOCUS_X)
+    const legacyFocusY = parseThumbnailFocusYFromUrl(rawThumbnailUrl, DEFAULT_THUMBNAIL_FOCUS_Y)
+    const legacyZoom = parseThumbnailZoomFromUrl(rawThumbnailUrl, DEFAULT_THUMBNAIL_ZOOM)
+    const parsedFocusX =
+      typeof parsed.thumbnailFocusX === "number"
+        ? clampThumbnailFocusX(parsed.thumbnailFocusX)
+        : legacyFocusX
+    const parsedFocusY =
+      typeof parsed.thumbnailFocusY === "number"
+        ? clampThumbnailFocusY(parsed.thumbnailFocusY)
+        : legacyFocusY
+    const parsedZoom =
+      typeof parsed.thumbnailZoom === "number"
+        ? clampThumbnailZoom(parsed.thumbnailZoom)
+        : legacyZoom
+
+    return {
+      title: typeof parsed.title === "string" ? parsed.title : "",
+      content: typeof parsed.content === "string" ? parsed.content : "",
+      summary: normalizePersistedSummary(parsed.summary),
+      thumbnailUrl: stripThumbnailFocusFromUrl(rawThumbnailUrl),
+      thumbnailFocusX: parsedFocusX,
+      thumbnailFocusY: parsedFocusY,
+      thumbnailZoom: parsedZoom,
+      tags: Array.isArray(parsed.tags)
+        ? dedupeStrings(parsed.tags.filter((item): item is string => typeof item === "string"))
+        : [],
+      category: typeof parsed.category === "string" ? normalizeCategoryValue(parsed.category) : "",
+      visibility: isValidVisibility ? visibility : "PUBLIC_LISTED",
+      savedAt: typeof parsed.savedAt === "string" ? parsed.savedAt : "",
+    }
+  } catch {
+    return null
+  }
+}
+
+export const persistLocalDraft = (payload: LocalDraftPayload) => {
+  if (typeof window === "undefined") return
+  window.localStorage.setItem(LOCAL_DRAFT_STORAGE_KEY, JSON.stringify(payload))
+}
+
+export const removeLocalDraft = () => {
+  if (typeof window === "undefined") return
+  window.localStorage.removeItem(LOCAL_DRAFT_STORAGE_KEY)
+}


### PR DESCRIPTION
## 관련 이슈

close #175

## 작업 배경

- `EditorStudioPage.tsx`가 직접 소유하던 meta/preview/storage 순수 계산과 localStorage helper를 model 파일로 분리했습니다.
- 수정 진입의 `contentHtml` fallback에서 pretty-code HTML 원문이 `data-prism-source`/`data-raw-code`에만 남은 경우에도 코드블럭 본문을 복구하도록 보강했습니다.

## 작업 내용

- frontmatter/meta parsing, preview summary, thumbnail safety, tag recommendation normalization, fingerprint/content composition, placeholder detection을 `editorStudioMetaModel.ts`로 이동했습니다.
- tag/category catalog와 local draft read/write helper를 `editorStudioStorageModel.ts`로 이동했습니다.
- page-local helper 재정의를 막는 source guard를 `editor-studio-state.spec.ts`에 추가했습니다.
- `htmlToMarkdown`의 `<pre><code>` 변환이 pretty-code data attribute 원문을 fallback으로 읽도록 했고, 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - RED 확인: `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - RED 확인: `yarn --cwd front playwright test e2e/block-editor-serialization.spec.ts --grep "pretty-code fallback" --workers=1`
  - `yarn --cwd front playwright test e2e/block-editor-serialization.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `git diff --check`
  - 참고: `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` 전체 suite는 3회 모두 72/73 통과 후 서로 다른 writer/table interaction 지점에서 실패했습니다. 같은 실패명 targeted 재실행은 통과해 이번 storage model 분리와 무관한 로컬 E2E interaction flake로 분류했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: `htmlToMarkdown` fallback이 pretty-code attribute를 우선 사용하므로, 잘못 저장된 attribute가 있으면 해당 원문을 신뢰해 복구합니다.
- 롤백 방법: 이 PR을 revert하면 editor studio model 분리와 code fallback 보강이 함께 되돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
