### PR TITLE
[Test] backend bounded context dependency guard 추가

### DIFF
--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -14,7 +14,12 @@ import java.nio.file.Path
 
 @org.junit.jupiter.api.DisplayName("ArchitectureGuard 테스트")
 class ArchitectureGuardTest {
+    private val mainBoundedContextSourceRoot: Path = Path.of("src/main/kotlin/com/back/boundedContexts")
     private val testSourceRoot: Path = Path.of("src/test/kotlin")
+    private val boundedContextPackageRegex =
+        Regex("""^package\s+com\.back\.boundedContexts\.([A-Za-z][A-Za-z0-9_]*)(?:\.|$)""", RegexOption.MULTILINE)
+    private val boundedContextImportRegex =
+        Regex("""^import\s+com\.back\.boundedContexts\.([A-Za-z][A-Za-z0-9_]*)\.([A-Za-z0-9_.*]+)(?:\s+as\s+\w+)?\s*$""")
 
     private fun importedClasses(): JavaClasses =
         ClassFileImporter()
@@ -31,7 +36,27 @@ class ArchitectureGuardTest {
                     .toList()
             }
 
+    private fun kotlinMainBoundedContextSources(): List<Path> =
+        Files
+            .walk(mainBoundedContextSourceRoot)
+            .use { paths ->
+                paths
+                    .filter { Files.isRegularFile(it) }
+                    .filter { it.toString().endsWith(".kt") }
+                    .toList()
+            }
+
     private fun sourceText(path: Path): String = Files.readString(path)
+
+    private fun sourceBoundedContextName(source: String): String? =
+        boundedContextPackageRegex
+            .find(source)
+            ?.groupValues
+            ?.get(1)
+
+    private fun isForbiddenDirectCrossBoundedContextImport(targetMemberPath: String): Boolean =
+        targetMemberPath.startsWith("model.") ||
+            targetMemberPath.startsWith("application.service.")
 
     @Test
     fun `bounded context에서 legacy app 패키지는 제거되어야 한다`() {
@@ -170,6 +195,48 @@ class ArchitectureGuardTest {
             .dependOnClassesThat()
             .resideInAnyPackage("org.springframework.data.domain..")
             .check(importedClasses())
+    }
+
+    @Test
+    fun `bounded context dependency classifier는 직접 model service import만 차단한다`() {
+        assertThat(isForbiddenDirectCrossBoundedContextImport("model.Post")).isTrue()
+        assertThat(isForbiddenDirectCrossBoundedContextImport("application.service.PostApplicationService")).isTrue()
+        assertThat(isForbiddenDirectCrossBoundedContextImport("event.PostWrittenEvent")).isFalse()
+        assertThat(isForbiddenDirectCrossBoundedContextImport("application.port.input.PostUseCase")).isFalse()
+        assertThat(isForbiddenDirectCrossBoundedContextImport("application.port.output.PostRepositoryPort")).isFalse()
+        assertThat(isForbiddenDirectCrossBoundedContextImport("domain.shared.Member")).isFalse()
+        assertThat(isForbiddenDirectCrossBoundedContextImport("dto.MemberDto")).isFalse()
+        assertThat(isForbiddenDirectCrossBoundedContextImport("config.shared.AuthSecurityConfigurer")).isFalse()
+    }
+
+    @Test
+    fun `bounded context는 다른 context의 model 또는 application service를 직접 import하지 않는다`() {
+        val violations =
+            kotlinMainBoundedContextSources()
+                .flatMap { path ->
+                    val source = sourceText(path)
+                    val sourceContext = sourceBoundedContextName(source) ?: return@flatMap emptyList()
+
+                    source
+                        .lineSequence()
+                        .mapNotNull { line ->
+                            val match = boundedContextImportRegex.matchEntire(line.trim()) ?: return@mapNotNull null
+                            val targetContext = match.groupValues[1]
+                            val targetMemberPath = match.groupValues[2]
+
+                            if (targetContext == sourceContext) {
+                                return@mapNotNull null
+                            }
+
+                            if (!isForbiddenDirectCrossBoundedContextImport(targetMemberPath)) {
+                                return@mapNotNull null
+                            }
+
+                            "${mainBoundedContextSourceRoot.relativize(path)} imports $targetContext.$targetMemberPath"
+                        }.toList()
+                }
+
+        assertThat(violations).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈

close #177

## 작업 배경

- bounded context 간 직접 `model`/`application.service` import가 다시 들어오면 `ArchitectureGuardTest`에서 실패하도록 구조 guard를 추가했습니다.
- 런타임 Kotlin 코드는 변경하지 않고 테스트 guard만 보강해 기존 동작 영향 없이 구조 계약을 명시했습니다.

## 작업 내용

- `ArchitectureGuardTest`가 `back/src/main/kotlin/com/back/boundedContexts` source import를 스캔해 다른 context의 `model`/`application.service` 직접 참조를 차단합니다.
- classifier 회귀 테스트로 차단 대상과 허용 seam(`event`, `application.port.*`, `domain.shared`, `dto`, `config.shared`)을 분리해 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - RED 확인: `./back/gradlew -p back test --tests com.back.architecture.ArchitectureGuardTest`
  - `./back/gradlew -p back test --tests com.back.architecture.ArchitectureGuardTest` (2회 연속 통과)
  - `./back/gradlew -p back ktlintCheck`
  - `./back/gradlew -p back check`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 새 source scan guard가 향후 의도적인 context 간 직접 결합을 막을 수 있습니다. 필요한 경우 event/port/shared kernel로 seam을 먼저 명확히 해야 합니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 guard 추가가 제거됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
