### PR TITLE
[Refactor] editor studio thumbnail panel 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -159,6 +159,14 @@ test.describe("editor studio state", () => {
     const editorStudioThumbnailControlsSource = existsSync(editorStudioThumbnailControlsPath)
       ? readFileSync(editorStudioThumbnailControlsPath, "utf8")
       : ""
+    const editorStudioThumbnailPanelsPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioThumbnailPanels.tsx"
+    )
+    expect(existsSync(editorStudioThumbnailPanelsPath)).toBe(true)
+    const editorStudioThumbnailPanelsSource = existsSync(editorStudioThumbnailPanelsPath)
+      ? readFileSync(editorStudioThumbnailPanelsPath, "utf8")
+      : ""
     const blockEditorShellSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorShell.tsx"), "utf8")
     const blockEditorEngineSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tsx"), "utf8")
     const blockSelectionModelSource = readFileSync(
@@ -268,6 +276,11 @@ test.describe("editor studio state", () => {
     expect(editorStudioThumbnailControlsSource).toContain("export const useEditorStudioThumbnailControls")
     expect(editorStudioThumbnailControlsSource).toContain("const handleThumbnailUrlModalChange = useCallback")
     expect(editorStudioThumbnailControlsSource).toContain("const applyFirstBodyImageToThumbnail = useCallback")
+    expect(editorStudioThumbnailPanelsSource).toContain("export const EditorStudioThumbnailEditorPanel =")
+    expect(editorStudioThumbnailPanelsSource).toContain("export const EditorStudioThumbnailMetaPanel =")
+    expect(editorStudioSource).toContain('} from "./EditorStudioThumbnailPanels"')
+    expect(editorStudioSource).not.toContain("const thumbnailEditorPanel = useMemo")
+    expect(editorStudioSource).not.toContain("const previewMetaEditorPanel = useMemo")
     expect(editorStudioStateSource).toContain("export type PostVisibility =")
     expect(editorStudioStateSource).toContain("export const toVisibility")
     expect(editorStudioStateSource).toContain("export const toFlags")
@@ -788,14 +801,19 @@ test.describe("editor studio state", () => {
 
   test("썸네일 편집 패널은 클립보드 이미지 붙여넣기 업로드 계약을 유지한다", () => {
     const editorStudioSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/EditorStudioPage.tsx"), "utf8")
+    const editorStudioThumbnailPanelsSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/EditorStudioThumbnailPanels.tsx"),
+      "utf8"
+    )
     const editorStudioPersistenceSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/useEditorStudioPersistence.ts"),
       "utf8"
     )
 
     expect(editorStudioSource).toContain("const extractImageFileFromClipboard = (clipboardData: DataTransfer | null): File | null => {")
-    expect(editorStudioSource).toContain("<PreviewEditorSection onPasteCapture={handleThumbnailPaste}>")
-    expect(editorStudioSource).toContain("onPaste={handleThumbnailPaste}")
+    expect(editorStudioSource).toContain("onThumbnailPaste={handleThumbnailPaste}")
+    expect(editorStudioThumbnailPanelsSource).toContain("<PreviewEditorSection onPasteCapture={onThumbnailPaste}>")
+    expect(editorStudioThumbnailPanelsSource).toContain("onPaste={onThumbnailPaste}")
     expect(editorStudioPersistenceSource).toContain("const handleThumbnailPaste = useCallback(")
     expect(editorStudioPersistenceSource).toContain("setThumbnailImageFileName(imageFile.name || \"clipboard-image.png\")")
     expect(editorStudioPersistenceSource).toContain("void handleUploadThumbnailImage(imageFile)")

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -47,6 +47,10 @@ import { useEditorStudioRouting } from "./useEditorStudioRouting"
 import { useEditorStudioThumbnailControls } from "./useEditorStudioThumbnailControls"
 import { useEditorStudioThumbnailPreview } from "./useEditorStudioThumbnailPreview"
 import {
+  EditorStudioThumbnailEditorPanel,
+  EditorStudioThumbnailMetaPanel,
+} from "./EditorStudioThumbnailPanels"
+import {
   isServerTempDraftPost,
   TEMP_DRAFT_BODY_PLACEHOLDER,
 } from "./editorTempDraft"
@@ -2286,132 +2290,36 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
       zoom: DEFAULT_THUMBNAIL_ZOOM,
     })
   }, [commitPreviewThumbTransform, previewThumbTransformRef])
-  const thumbnailEditorPanel = useMemo(() => (
-    <PreviewEditorSection>
-      <PreviewEditorSectionHeader>
-        <strong>썸네일 위치 조정</strong>
-      </PreviewEditorSectionHeader>
-      <PreviewThumbFrame
-        ref={previewThumbFrameRef}
-        data-draggable={safePreviewThumbnail && !isPreviewThumbnailError}
-        data-dragging={isPreviewThumbDragging}
-        onPointerDown={handlePreviewThumbPointerDown}
-        onPointerMove={handlePreviewThumbPointerMove}
-        onPointerUp={finalizePreviewThumbPointer}
-        onPointerCancel={finalizePreviewThumbPointer}
-      >
-        {safePreviewThumbnail && !isPreviewThumbnailError ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={safePreviewThumbnail}
-            alt="포스트 미리보기 썸네일"
-            style={{
-              width: "var(--preview-thumb-width)",
-              height: "var(--preview-thumb-height)",
-              left: "var(--preview-thumb-left)",
-              top: "var(--preview-thumb-top)",
-              maxWidth: "none",
-              transform: "translateZ(0)",
-            }}
-            onError={() => setIsPreviewThumbnailError(true)}
-          />
-        ) : (
-          <div className="placeholder">
-            <em>썸네일 없음</em>
-          </div>
-        )}
-      </PreviewThumbFrame>
-      {safePreviewThumbnail && !isPreviewThumbnailError ? (
-        <ZoomControlRow>
-          <FieldLabel htmlFor="post-thumbnail-zoom-modal">썸네일 배율</FieldLabel>
-          <ZoomRangeInput
-            id="post-thumbnail-zoom-modal"
-            type="range"
-            min={1}
-            max={2.5}
-            step={0.01}
-            value={postThumbnailZoom}
-            onChange={(e) => handleThumbnailZoomModalChange(Number(e.target.value))}
-          />
-          <ZoomControlMeta>
-            <ZoomValue>{postThumbnailZoom.toFixed(2)}x</ZoomValue>
-            <Button type="button" onClick={resetThumbnailZoomInModal}>
-              배율 초기화
-            </Button>
-          </ZoomControlMeta>
-        </ZoomControlRow>
-      ) : null}
-    </PreviewEditorSection>
-  ), [
-    finalizePreviewThumbPointer,
-    handlePreviewThumbPointerDown,
-    handlePreviewThumbPointerMove,
-    handleThumbnailZoomModalChange,
-    isPreviewThumbDragging,
-    isPreviewThumbnailError,
-    postThumbnailZoom,
-    previewThumbFrameRef,
-    resetThumbnailZoomInModal,
-    safePreviewThumbnail,
-    setIsPreviewThumbnailError,
-  ])
-  const previewMetaEditorPanel = useMemo(() => {
-    const hasManualThumbnail = postThumbnailUrl.trim().length > 0
-    const hasFirstBodyImage = deferredContentDerived.firstImage.trim().length > 0
-    const sourceTone = hasManualThumbnail ? "manual" : hasFirstBodyImage ? "auto" : "empty"
-    const sourceLabel = hasManualThumbnail
-      ? "수동 썸네일 URL 사용 중"
-      : hasFirstBodyImage
-        ? "본문 첫 이미지를 자동으로 사용 중"
-        : "현재 썸네일이 없습니다"
-
-    return (
-      <PreviewEditorSection onPasteCapture={handleThumbnailPaste}>
-        <PreviewEditorSectionHeader>
-          <strong>썸네일 이미지</strong>
-          <ThumbnailSourceStatus data-tone={sourceTone}>{sourceLabel}</ThumbnailSourceStatus>
-        </PreviewEditorSectionHeader>
-        <FieldLabel htmlFor="post-thumbnail-url-modal">썸네일 URL</FieldLabel>
-        <Input
-          id="post-thumbnail-url-modal"
-          placeholder="https://... (비우면 본문 첫 이미지 자동 사용)"
-          value={postThumbnailUrl}
-          onChange={(e) => handleThumbnailUrlModalChange(e.target.value)}
-          onPaste={handleThumbnailPaste}
-        />
-        <MetaPrimaryActionRow>
-          <PrimaryButton
-            type="button"
-            title={POST_IMAGE_UPLOAD_RULE_LABEL}
-            disabled={isThumbnailUploadDisabled}
-            onClick={openThumbnailFileInput}
-          >
-            {loadingKey === "uploadThumbnail" ? "업로드 중..." : "썸네일 파일 업로드"}
-          </PrimaryButton>
-        </MetaPrimaryActionRow>
-        <MetaSecondaryActionRow>
-          <Button type="button" disabled={!hasFirstBodyImage} onClick={applyFirstBodyImageToThumbnail}>
-            본문 첫 이미지 사용
-          </Button>
-          <Button type="button" data-variant="text" onClick={resetThumbnailToAutoMode}>
-            자동 모드로 되돌리기
-          </Button>
-        </MetaSecondaryActionRow>
-        {thumbnailImageFileName ? <FieldHelp>선택 파일: {thumbnailImageFileName}</FieldHelp> : null}
-      </PreviewEditorSection>
-    )
-  }, [
-    applyFirstBodyImageToThumbnail,
-    deferredContentDerived.firstImage,
-    handleThumbnailUrlModalChange,
-    isThumbnailUploadDisabled,
-    loadingKey,
-    openThumbnailFileInput,
-    handleThumbnailPaste,
-    postThumbnailUrl,
-    resetThumbnailToAutoMode,
-    thumbnailImageFileName,
-  ])
+  const thumbnailEditorPanel = (
+    <EditorStudioThumbnailEditorPanel
+      finalizePreviewThumbPointer={finalizePreviewThumbPointer}
+      handlePreviewThumbPointerDown={handlePreviewThumbPointerDown}
+      handlePreviewThumbPointerMove={handlePreviewThumbPointerMove}
+      isPreviewThumbDragging={isPreviewThumbDragging}
+      isPreviewThumbnailError={isPreviewThumbnailError}
+      postThumbnailZoom={postThumbnailZoom}
+      previewThumbFrameRef={previewThumbFrameRef}
+      safePreviewThumbnail={safePreviewThumbnail}
+      setIsPreviewThumbnailError={setIsPreviewThumbnailError}
+      onThumbnailZoomChange={handleThumbnailZoomModalChange}
+      onResetThumbnailZoom={resetThumbnailZoomInModal}
+    />
+  )
+  const previewMetaEditorPanel = (
+    <EditorStudioThumbnailMetaPanel
+      firstBodyImageUrl={deferredContentDerived.firstImage}
+      isThumbnailUploadDisabled={isThumbnailUploadDisabled}
+      isThumbnailUploading={loadingKey === "uploadThumbnail"}
+      postThumbnailUrl={postThumbnailUrl}
+      thumbnailImageFileName={thumbnailImageFileName}
+      thumbnailUploadRuleLabel={POST_IMAGE_UPLOAD_RULE_LABEL}
+      onApplyFirstBodyImage={applyFirstBodyImageToThumbnail}
+      onOpenThumbnailFileInput={openThumbnailFileInput}
+      onResetThumbnailToAutoMode={resetThumbnailToAutoMode}
+      onThumbnailPaste={handleThumbnailPaste}
+      onThumbnailUrlChange={handleThumbnailUrlModalChange}
+    />
+  )
   const editorPrimaryActionType: PublishActionType =
     editorMode === "create" ? "create" : isTempDraftMode ? "temp" : "modify"
   const editorPrimaryActionLabel =
@@ -6157,107 +6065,6 @@ const CompactPublishEditorToggle = styled.button`
   }
 `
 
-const PreviewEditorSection = styled.div`
-  display: grid;
-  gap: 0.58rem;
-  min-width: 0;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 12px;
-  background: ${({ theme }) => theme.colors.gray2};
-  padding: 0.85rem;
-`
-
-const PreviewEditorSectionHeader = styled.div`
-  display: grid;
-  gap: 0.14rem;
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.86rem;
-    font-weight: 700;
-    line-height: 1.3;
-  }
-
-  span {
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.74rem;
-    line-height: 1.45;
-  }
-`
-
-const PreviewThumbFrame = styled.div`
-  --preview-thumb-width: 100%;
-  --preview-thumb-height: 100%;
-  --preview-thumb-left: 0%;
-  --preview-thumb-top: 0%;
-
-  position: relative;
-  width: min(100%, 360px);
-  justify-self: start;
-  aspect-ratio: 1.94 / 1;
-  border-radius: ${({ theme }) => `${theme.variables.ui.card.radius}px`};
-  border: ${({ theme }) => `${theme.variables.ui.card.borderWidth}px solid ${theme.colors.gray4}`};
-  background: ${({ theme }) => theme.colors.gray4};
-  overflow: hidden;
-  user-select: none;
-  isolation: isolate;
-
-  &[data-draggable="true"] {
-    cursor: grab;
-    touch-action: none;
-  }
-
-  &[data-dragging="true"] {
-    cursor: grabbing;
-  }
-
-  @media (max-width: 780px) {
-    width: 100%;
-  }
-
-  img {
-    position: absolute;
-    display: block;
-    pointer-events: none;
-    user-select: none;
-    touch-action: none;
-    -webkit-user-drag: none;
-    will-change: top, left, width, height;
-  }
-
-  &::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(180deg, rgba(0, 0, 0, 0) 45%, rgba(0, 0, 0, 0.16) 100%);
-    opacity: 0.9;
-    pointer-events: none;
-  }
-
-  .placeholder {
-    width: 100%;
-    height: 100%;
-    display: grid;
-    place-content: center;
-    text-align: center;
-    gap: 0.24rem;
-    padding: 0.7rem;
-
-    em {
-      font-style: normal;
-      color: ${({ theme }) => theme.colors.gray10};
-      font-weight: 700;
-      font-size: 0.84rem;
-    }
-
-    span {
-      color: ${({ theme }) => theme.colors.gray11};
-      font-size: 0.74rem;
-      line-height: 1.4;
-    }
-  }
-`
-
 const SummaryCounter = styled.span`
   justify-self: end;
   color: ${({ theme }) => theme.colors.gray10};
@@ -6316,99 +6123,6 @@ const ComposeStatusRow = styled.div`
     span {
       color: ${({ theme }) => theme.colors.red11};
     }
-  }
-`
-
-const ZoomControlRow = styled.div`
-  display: grid;
-  gap: 0.42rem;
-  align-items: start;
-  justify-items: start;
-  width: min(100%, 360px);
-
-  @media (max-width: 780px) {
-    width: 100%;
-  }
-`
-
-const ZoomRangeInput = styled.input`
-  width: 100%;
-  accent-color: ${({ theme }) => theme.colors.blue9};
-`
-
-const ZoomValue = styled.span`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 30px;
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  padding: 0 0.55rem;
-  color: ${({ theme }) => theme.colors.gray11};
-  font-size: 0.78rem;
-  line-height: 1;
-  font-weight: 700;
-`
-
-const ZoomControlMeta = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  flex-wrap: wrap;
-`
-
-const ThumbnailSourceStatus = styled.span`
-  display: inline-flex;
-  align-items: center;
-  width: fit-content;
-  min-height: 24px;
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  padding: 0 0.54rem;
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.72rem;
-  font-weight: 700;
-  line-height: 1;
-
-  &[data-tone="manual"] {
-    border-color: ${({ theme }) => theme.colors.blue7};
-    background: ${({ theme }) => theme.colors.blue3};
-    color: ${({ theme }) => theme.colors.blue11};
-  }
-
-  &[data-tone="auto"] {
-    border-color: ${({ theme }) => theme.colors.green7};
-    background: ${({ theme }) => theme.colors.green3};
-    color: ${({ theme }) => theme.colors.green11};
-  }
-`
-
-const MetaPrimaryActionRow = styled.div`
-  display: grid;
-
-  > button {
-    width: 100%;
-    justify-content: center;
-    text-align: center;
-    white-space: normal;
-    line-height: 1.32;
-  }
-`
-
-const MetaSecondaryActionRow = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.55rem;
-
-  > button:first-of-type {
-    flex: 1 1 11rem;
-  }
-
-  > button[data-variant="text"] {
-    flex: 0 0 auto;
-    text-align: left;
   }
 `
 

--- a/front/src/routes/Admin/EditorStudioThumbnailPanels.tsx
+++ b/front/src/routes/Admin/EditorStudioThumbnailPanels.tsx
@@ -1,0 +1,463 @@
+import styled from "@emotion/styled"
+import type {
+  ClipboardEventHandler,
+  PointerEventHandler,
+  RefObject,
+} from "react"
+
+type ThumbnailSourceTone = "manual" | "auto" | "empty"
+
+type EditorStudioThumbnailEditorPanelProps = {
+  finalizePreviewThumbPointer: PointerEventHandler<HTMLDivElement>
+  handlePreviewThumbPointerDown: PointerEventHandler<HTMLDivElement>
+  handlePreviewThumbPointerMove: PointerEventHandler<HTMLDivElement>
+  isPreviewThumbDragging: boolean
+  isPreviewThumbnailError: boolean
+  postThumbnailZoom: number
+  previewThumbFrameRef: RefObject<HTMLDivElement>
+  safePreviewThumbnail: string
+  setIsPreviewThumbnailError: (nextValue: boolean) => void
+  onThumbnailZoomChange: (nextZoom: number) => void
+  onResetThumbnailZoom: () => void
+}
+
+type EditorStudioThumbnailMetaPanelProps = {
+  firstBodyImageUrl: string
+  isThumbnailUploadDisabled: boolean
+  isThumbnailUploading: boolean
+  postThumbnailUrl: string
+  thumbnailImageFileName: string
+  thumbnailUploadRuleLabel: string
+  onApplyFirstBodyImage: () => void
+  onOpenThumbnailFileInput: () => void
+  onResetThumbnailToAutoMode: () => void
+  onThumbnailPaste: ClipboardEventHandler<HTMLElement>
+  onThumbnailUrlChange: (nextValue: string) => void
+}
+
+export const EditorStudioThumbnailEditorPanel = ({
+  finalizePreviewThumbPointer,
+  handlePreviewThumbPointerDown,
+  handlePreviewThumbPointerMove,
+  isPreviewThumbDragging,
+  isPreviewThumbnailError,
+  postThumbnailZoom,
+  previewThumbFrameRef,
+  safePreviewThumbnail,
+  setIsPreviewThumbnailError,
+  onThumbnailZoomChange,
+  onResetThumbnailZoom,
+}: EditorStudioThumbnailEditorPanelProps) => (
+  <PreviewEditorSection>
+    <PreviewEditorSectionHeader>
+      <strong>썸네일 위치 조정</strong>
+    </PreviewEditorSectionHeader>
+    <PreviewThumbFrame
+      ref={previewThumbFrameRef}
+      data-draggable={safePreviewThumbnail && !isPreviewThumbnailError}
+      data-dragging={isPreviewThumbDragging}
+      onPointerDown={handlePreviewThumbPointerDown}
+      onPointerMove={handlePreviewThumbPointerMove}
+      onPointerUp={finalizePreviewThumbPointer}
+      onPointerCancel={finalizePreviewThumbPointer}
+    >
+      {safePreviewThumbnail && !isPreviewThumbnailError ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={safePreviewThumbnail}
+          alt="포스트 미리보기 썸네일"
+          style={{
+            width: "var(--preview-thumb-width)",
+            height: "var(--preview-thumb-height)",
+            left: "var(--preview-thumb-left)",
+            top: "var(--preview-thumb-top)",
+            maxWidth: "none",
+            transform: "translateZ(0)",
+          }}
+          onError={() => setIsPreviewThumbnailError(true)}
+        />
+      ) : (
+        <div className="placeholder">
+          <em>썸네일 없음</em>
+        </div>
+      )}
+    </PreviewThumbFrame>
+    {safePreviewThumbnail && !isPreviewThumbnailError ? (
+      <ZoomControlRow>
+        <ThumbnailFieldLabel htmlFor="post-thumbnail-zoom-modal">썸네일 배율</ThumbnailFieldLabel>
+        <ZoomRangeInput
+          id="post-thumbnail-zoom-modal"
+          type="range"
+          min={1}
+          max={2.5}
+          step={0.01}
+          value={postThumbnailZoom}
+          onChange={(event) => onThumbnailZoomChange(Number(event.target.value))}
+        />
+        <ZoomControlMeta>
+          <ZoomValue>{postThumbnailZoom.toFixed(2)}x</ZoomValue>
+          <ThumbnailButton type="button" onClick={onResetThumbnailZoom}>
+            배율 초기화
+          </ThumbnailButton>
+        </ZoomControlMeta>
+      </ZoomControlRow>
+    ) : null}
+  </PreviewEditorSection>
+)
+
+export const EditorStudioThumbnailMetaPanel = ({
+  firstBodyImageUrl,
+  isThumbnailUploadDisabled,
+  isThumbnailUploading,
+  postThumbnailUrl,
+  thumbnailImageFileName,
+  thumbnailUploadRuleLabel,
+  onApplyFirstBodyImage,
+  onOpenThumbnailFileInput,
+  onResetThumbnailToAutoMode,
+  onThumbnailPaste,
+  onThumbnailUrlChange,
+}: EditorStudioThumbnailMetaPanelProps) => {
+  const hasManualThumbnail = postThumbnailUrl.trim().length > 0
+  const hasFirstBodyImage = firstBodyImageUrl.trim().length > 0
+  const sourceTone: ThumbnailSourceTone = hasManualThumbnail ? "manual" : hasFirstBodyImage ? "auto" : "empty"
+  const sourceLabel = hasManualThumbnail
+    ? "수동 썸네일 URL 사용 중"
+    : hasFirstBodyImage
+      ? "본문 첫 이미지를 자동으로 사용 중"
+      : "현재 썸네일이 없습니다"
+
+  return (
+    <PreviewEditorSection onPasteCapture={onThumbnailPaste}>
+      <PreviewEditorSectionHeader>
+        <strong>썸네일 이미지</strong>
+        <ThumbnailSourceStatus data-tone={sourceTone}>{sourceLabel}</ThumbnailSourceStatus>
+      </PreviewEditorSectionHeader>
+      <ThumbnailFieldLabel htmlFor="post-thumbnail-url-modal">썸네일 URL</ThumbnailFieldLabel>
+      <ThumbnailInput
+        id="post-thumbnail-url-modal"
+        placeholder="https://... (비우면 본문 첫 이미지 자동 사용)"
+        value={postThumbnailUrl}
+        onChange={(event) => onThumbnailUrlChange(event.target.value)}
+        onPaste={onThumbnailPaste}
+      />
+      <MetaPrimaryActionRow>
+        <ThumbnailPrimaryButton
+          type="button"
+          title={thumbnailUploadRuleLabel}
+          disabled={isThumbnailUploadDisabled}
+          onClick={onOpenThumbnailFileInput}
+        >
+          {isThumbnailUploading ? "업로드 중..." : "썸네일 파일 업로드"}
+        </ThumbnailPrimaryButton>
+      </MetaPrimaryActionRow>
+      <MetaSecondaryActionRow>
+        <ThumbnailButton type="button" disabled={!hasFirstBodyImage} onClick={onApplyFirstBodyImage}>
+          본문 첫 이미지 사용
+        </ThumbnailButton>
+        <ThumbnailButton type="button" data-variant="text" onClick={onResetThumbnailToAutoMode}>
+          자동 모드로 되돌리기
+        </ThumbnailButton>
+      </MetaSecondaryActionRow>
+      {thumbnailImageFileName ? <ThumbnailFieldHelp>선택 파일: {thumbnailImageFileName}</ThumbnailFieldHelp> : null}
+    </PreviewEditorSection>
+  )
+}
+
+const PreviewEditorSection = styled.div`
+  display: grid;
+  gap: 0.58rem;
+  min-width: 0;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 12px;
+  background: ${({ theme }) => theme.colors.gray2};
+  padding: 0.85rem;
+`
+
+const PreviewEditorSectionHeader = styled.div`
+  display: grid;
+  gap: 0.14rem;
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.86rem;
+    font-weight: 700;
+    line-height: 1.3;
+  }
+
+  span {
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.74rem;
+    line-height: 1.45;
+  }
+`
+
+const PreviewThumbFrame = styled.div`
+  --preview-thumb-width: 100%;
+  --preview-thumb-height: 100%;
+  --preview-thumb-left: 0%;
+  --preview-thumb-top: 0%;
+
+  position: relative;
+  width: min(100%, 360px);
+  justify-self: start;
+  aspect-ratio: 1.94 / 1;
+  border-radius: ${({ theme }) => `${theme.variables.ui.card.radius}px`};
+  border: ${({ theme }) => `${theme.variables.ui.card.borderWidth}px solid ${theme.colors.gray4}`};
+  background: ${({ theme }) => theme.colors.gray4};
+  overflow: hidden;
+  user-select: none;
+  isolation: isolate;
+
+  &[data-draggable="true"] {
+    cursor: grab;
+    touch-action: none;
+  }
+
+  &[data-dragging="true"] {
+    cursor: grabbing;
+  }
+
+  @media (max-width: 780px) {
+    width: 100%;
+  }
+
+  img {
+    position: absolute;
+    display: block;
+    pointer-events: none;
+    user-select: none;
+    touch-action: none;
+    -webkit-user-drag: none;
+    will-change: top, left, width, height;
+  }
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0) 45%, rgba(0, 0, 0, 0.16) 100%);
+    opacity: 0.9;
+    pointer-events: none;
+  }
+
+  .placeholder {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-content: center;
+    text-align: center;
+    gap: 0.24rem;
+    padding: 0.7rem;
+
+    em {
+      font-style: normal;
+      color: ${({ theme }) => theme.colors.gray10};
+      font-weight: 700;
+      font-size: 0.84rem;
+    }
+
+    span {
+      color: ${({ theme }) => theme.colors.gray11};
+      font-size: 0.74rem;
+      line-height: 1.4;
+    }
+  }
+`
+
+const ThumbnailFieldLabel = styled.label`
+  font-size: 0.8rem;
+  font-weight: 650;
+  color: ${({ theme }) => theme.colors.gray11};
+`
+
+const ThumbnailInput = styled.input`
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.72rem 0.8rem;
+  min-height: 44px;
+  min-width: 0;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray12};
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
+  }
+`
+
+const ThumbnailButton = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &[data-variant="text"] {
+    min-height: auto;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    color: ${({ theme }) => theme.colors.gray11};
+  }
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &[data-variant="text"]:hover:not(:disabled) {
+    border-color: transparent;
+    background: transparent;
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+const ThumbnailPrimaryButton = styled(ThumbnailButton)`
+  border-radius: 8px;
+  padding: 0.6rem 0.88rem;
+  border-color: ${({ theme }) => theme.colors.blue9};
+  background: ${({ theme }) => theme.colors.blue9};
+  color: ${({ theme }) => theme.colors.gray1};
+  font-weight: 700;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.blue10};
+    background: ${({ theme }) => theme.colors.blue10};
+    color: ${({ theme }) => theme.colors.gray1};
+  }
+`
+
+const ZoomControlRow = styled.div`
+  display: grid;
+  gap: 0.42rem;
+  align-items: start;
+  justify-items: start;
+  width: min(100%, 360px);
+
+  @media (max-width: 780px) {
+    width: 100%;
+  }
+`
+
+const ZoomRangeInput = styled.input`
+  width: 100%;
+  accent-color: ${({ theme }) => theme.colors.blue9};
+`
+
+const ZoomValue = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  padding: 0 0.55rem;
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: 0.78rem;
+  line-height: 1;
+  font-weight: 700;
+`
+
+const ZoomControlMeta = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+`
+
+const ThumbnailSourceStatus = styled.span`
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 24px;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  padding: 0 0.54rem;
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+
+  &[data-tone="manual"] {
+    border-color: ${({ theme }) => theme.colors.blue7};
+    background: ${({ theme }) => theme.colors.blue3};
+    color: ${({ theme }) => theme.colors.blue11};
+  }
+
+  &[data-tone="auto"] {
+    border-color: ${({ theme }) => theme.colors.green7};
+    background: ${({ theme }) => theme.colors.green3};
+    color: ${({ theme }) => theme.colors.green11};
+  }
+`
+
+const MetaPrimaryActionRow = styled.div`
+  display: grid;
+
+  > button {
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+    white-space: normal;
+    line-height: 1.32;
+  }
+`
+
+const MetaSecondaryActionRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.55rem;
+
+  > button:first-of-type {
+    flex: 1 1 11rem;
+  }
+
+  > button[data-variant="text"] {
+    flex: 0 0 auto;
+    text-align: left;
+  }
+`
+
+const ThumbnailFieldHelp = styled.span`
+  display: block;
+  width: 100%;
+  min-width: 0;
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: 0.74rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+
+  @media (max-width: 720px) {
+    display: none;
+  }
+`


### PR DESCRIPTION
## 관련 이슈

close #179

## 작업 배경

- `EditorStudioPage.tsx`가 직접 렌더하던 썸네일 위치 조정/이미지 입력 패널 JSX를 `EditorStudioThumbnailPanels.tsx`로 분리했습니다.
- 기존 thumbnail preview/control hook 동작은 유지하고, page는 상태와 handler props 전달만 맡도록 정리했습니다.

## 작업 내용

- `EditorStudioThumbnailEditorPanel`, `EditorStudioThumbnailMetaPanel` presentational component를 추가했습니다.
- `EditorStudioPage.tsx`에서 thumbnail panel JSX와 관련 전용 styled component를 제거했습니다.
- `editor-studio-state.spec.ts`에 panel component 존재와 page-local panel JSX 재도입 방지 source guard를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - RED 확인: `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - GREEN: `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: thumbnail panel styles를 component 파일로 옮기며 기존 shared button/input 스타일과 별도 복사본이 생겼습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 page-local panel JSX 구조로 되돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
