### PR TITLE
[Fix] editor codeblock contentHtml 복구

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -7,6 +7,7 @@ import {
   deriveEditorPersistenceState,
   isPublishActionDisabled,
 } from "src/routes/Admin/editorStudioState"
+import { restoreEmptyFencedCodeBlocks } from "src/routes/Admin/editorStudioMetaModel"
 import { getEditorStudioPageProps } from "src/routes/Admin/EditorStudioPage"
 import { buildPreviewSummaryFromMarkdown, normalizeCardSummary, normalizePersistedSummary } from "src/libs/postSummary"
 
@@ -334,6 +335,8 @@ test.describe("editor studio state", () => {
     expect(editorStudioMetaModelSource).toContain("export const normalizeRecommendedTags =")
     expect(editorStudioMetaModelSource).toContain("export const resolveTagRecommendationErrorMessage =")
     expect(editorStudioMetaModelSource).toContain("export const formatTagRecommendationReason =")
+    expect(editorStudioMetaModelSource).toContain("export const restoreEmptyFencedCodeBlocks =")
+    expect(editorStudioMetaModelSource).toContain("restoreEmptyFencedCodeBlocks(parsed.body, markdownFromHtml)")
     expect(editorStudioMetaModelSource).toContain("export const resolveEditorMetaSnapshot =")
     expect(editorStudioMetaModelSource).toContain("export const buildEditorStateFingerprint =")
     expect(editorStudioMetaModelSource).toContain("export const parseEditorMeta =")
@@ -551,6 +554,32 @@ test.describe("editor studio state", () => {
     expect(editorStudioMetaModelSource).toContain('buildPreviewSummaryFromMarkdown(content, maxLength, "")')
     expect(editorStudioMetaModelSource).toContain("summary: normalizePersistedSummary(parsed.summary)")
     expect(editorStudioMetaModelSource).toContain("const normalizedSummary = normalizePersistedSummary(options?.summary)")
+  })
+
+  test("contentHtml fallback은 빈 fenced code body를 pretty-code 원문으로 복구한다", () => {
+    const staleContent = [
+      "수정 대상 코드입니다.",
+      "",
+      "```ts",
+      "",
+      "```",
+      "",
+      "다음 문단입니다.",
+    ].join("\n")
+    const htmlRecoveredContent = [
+      "수정 대상 코드입니다.",
+      "",
+      "```ts",
+      "const answer = 42;",
+      "return answer",
+      "```",
+      "",
+      "다음 문단입니다.",
+    ].join("\n")
+
+    expect(restoreEmptyFencedCodeBlocks(staleContent, htmlRecoveredContent)).toContain(
+      ["```ts", "const answer = 42;", "return answer", "```"].join("\n")
+    )
   })
 
   test("dedicated editor 나가기는 returnTo 복귀를 replace로 처리해 editor history 엔트리를 남기지 않는다", () => {

--- a/front/src/routes/Admin/editorStudioMetaModel.ts
+++ b/front/src/routes/Admin/editorStudioMetaModel.ts
@@ -58,6 +58,7 @@ const LEADING_EDITOR_METADATA_LINE_REGEX =
   /^\s*(tags?|categories?|summary|thumbnail|thumb|cover|coverimage|cover_image)\s*:\s*(.+)\s*$/i
 const EDITOR_BODY_PLACEHOLDER = "내용을 입력하세요."
 const EDITOR_TOGGLE_TITLE_PLACEHOLDER = "토글 제목"
+const FENCED_CODE_BLOCK_REGEX = /(^|\n)(`{3,}|~{3,})([^\n]*)\n([\s\S]*?)\n\2(?=\n|$)/g
 
 export const PREVIEW_SUMMARY_MAX_LENGTH = 150
 export const PREVIEW_SUMMARY_MAX_CONTENT_LENGTH = 50_000
@@ -317,11 +318,45 @@ const resolveEditorBodyFallback = (content: string, parsedBody: string) => {
   return inlineMetadataSplit.body.trim().length > 0 ? inlineMetadataSplit.body : parsedBody
 }
 
+const extractNonEmptyFencedCodeBlocks = (content: string) => {
+  const normalized = content.replace(/\r\n?/g, "\n")
+  const blocks: string[] = []
+
+  normalized.replace(FENCED_CODE_BLOCK_REGEX, (_match, _leading, marker, info, codeBody) => {
+    if (String(codeBody).trim().length > 0) {
+      blocks.push(`${marker}${info}\n${codeBody}\n${marker}`)
+    }
+    return _match
+  })
+
+  return blocks
+}
+
+export const restoreEmptyFencedCodeBlocks = (content: string, recoveredContent: string) => {
+  const recoveredBlocks = extractNonEmptyFencedCodeBlocks(recoveredContent)
+  if (recoveredBlocks.length === 0) return content
+
+  let nextRecoveredIndex = 0
+  const normalized = content.replace(/\r\n?/g, "\n")
+
+  return normalized.replace(FENCED_CODE_BLOCK_REGEX, (match, leading, _marker, _info, codeBody) => {
+    if (String(codeBody).trim().length > 0) return match
+
+    const recoveredBlock = recoveredBlocks[nextRecoveredIndex]
+    if (!recoveredBlock) return match
+    nextRecoveredIndex += 1
+    return `${leading}${recoveredBlock}`
+  })
+}
+
 export const resolveEditorMetaSnapshot = (content: string, contentHtml?: string | null): ResolvedEditorMetaSnapshot => {
   const parsed = parseEditorMeta(content)
   const normalizedRawContent = content.replace(/\r\n?/g, "\n").trim()
   const markdownFromHtml = contentHtml?.trim() ? convertHtmlClipboardToMarkdown(contentHtml).trim() : ""
-  const resolvedBody = parsed.body.trim() || markdownFromHtml || normalizedRawContent
+  const restoredParsedBody = parsed.body.trim() && markdownFromHtml
+    ? restoreEmptyFencedCodeBlocks(parsed.body, markdownFromHtml)
+    : parsed.body
+  const resolvedBody = restoredParsedBody.trim() || markdownFromHtml || normalizedRawContent
   const parsedThumbnail = normalizeSafeImageUrl(parsed.thumbnail)
   const fallbackThumbnail = normalizeSafeImageUrl(extractFirstMarkdownImage(resolvedBody))
   const syncedThumbnail = stripThumbnailFocusFromUrl(parsedThumbnail || fallbackThumbnail)


### PR DESCRIPTION
## 관련 이슈

close #187

## 작업 배경

- 글 수정 페이지가 `contentHtml` fallback을 타는 경우, 기존 markdown body의 빈 fenced code block을 pretty-code 변환 결과의 실제 코드 원문으로 보강합니다.
- 코드블럭 shell만 남고 본문 코드가 비는 회귀를 `editor-studio-state` 테스트로 고정했습니다.

## 작업 내용

- `restoreEmptyFencedCodeBlocks`를 추가해 빈 fenced code block만 `contentHtml` 변환 markdown의 non-empty code block으로 순서 보강합니다.
- `resolveEditorMetaSnapshot`이 parsed body를 우선하더라도 `contentHtml` recovered code를 버리지 않도록 연결했습니다.
- source guard와 회귀 테스트를 추가해 같은 fallback 경계가 다시 빠지지 않게 했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (RED 확인 후 GREEN 16 passed)
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `node front/scripts/check-bundle-size.mjs`
  - `git diff --check`
  - `git diff --cached --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: `content`와 `contentHtml`의 코드블럭 순서가 서로 다르면 빈 fence에 다른 HTML code block이 보강될 수 있습니다. non-empty markdown code block은 덮어쓰지 않습니다.
- 롤백 방법: 이 PR의 단일 커밋 `fix(editor): contentHtml 코드블럭 원문 복구`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
