### PR TITLE
[Refactor] editor studio metadata assistant 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -184,6 +184,14 @@ test.describe("editor studio state", () => {
     const editorStudioComposeAssistantPanelSource = existsSync(editorStudioComposeAssistantPanelPath)
       ? readFileSync(editorStudioComposeAssistantPanelPath, "utf8")
       : ""
+    const editorStudioMetadataAssistantPanelPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioMetadataAssistantPanel.tsx"
+    )
+    expect(existsSync(editorStudioMetadataAssistantPanelPath)).toBe(true)
+    const editorStudioMetadataAssistantPanelSource = existsSync(editorStudioMetadataAssistantPanelPath)
+      ? readFileSync(editorStudioMetadataAssistantPanelPath, "utf8")
+      : ""
     const blockEditorShellSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorShell.tsx"), "utf8")
     const blockEditorEngineSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tsx"), "utf8")
     const blockSelectionModelSource = readFileSync(
@@ -314,6 +322,15 @@ test.describe("editor studio state", () => {
     expect(editorStudioSource).not.toContain("const ComposeAssistantPanel = styled.div`")
     expect(editorStudioSource).not.toContain("const PreviewResultCard = styled.article`")
     expect(editorStudioSource).not.toContain("const PublishSettingsSummary = styled.div`")
+    expect(editorStudioMetadataAssistantPanelSource).toContain("export const EditorStudioMetadataAssistantPanel =")
+    expect(editorStudioSource).toContain(
+      'import { EditorStudioMetadataAssistantPanel } from "./EditorStudioMetadataAssistantPanel"'
+    )
+    expect(editorStudioSource.match(/<EditorStudioMetadataAssistantPanel/g)?.length).toBe(1)
+    expect(editorStudioMetadataAssistantPanelSource).toContain("<strong>태그 정리</strong>")
+    expect(editorStudioMetadataAssistantPanelSource).toContain("<strong>보조 작업</strong>")
+    expect(editorStudioSource).not.toContain("<strong>태그 정리</strong>")
+    expect(editorStudioSource).not.toContain("<strong>보조 작업</strong>")
     expect(editorStudioStateSource).toContain("export type PostVisibility =")
     expect(editorStudioStateSource).toContain("export const toVisibility")
     expect(editorStudioStateSource).toContain("export const toFlags")

--- a/front/src/routes/Admin/EditorStudioMetadataAssistantPanel.tsx
+++ b/front/src/routes/Admin/EditorStudioMetadataAssistantPanel.tsx
@@ -1,0 +1,322 @@
+import styled from "@emotion/styled"
+import type { ReactNode } from "react"
+
+type NoticeTone = "idle" | "loading" | "success" | "error"
+
+type MetadataNotice = {
+  tone: NoticeTone
+  text: string
+}
+
+type EditorStudioMetadataAssistantPanelProps = {
+  isTagPanelOpen: boolean
+  onToggleTagPanel: () => void
+  isUtilityPanelOpen: boolean
+  onToggleUtilityPanel: () => void
+  metaNotice: MetadataNotice
+  knownTags: string[]
+  selectedTags: string[]
+  tagUsageMap: Record<string, number>
+  onToggleTag: (tag: string) => void
+  onDeleteTag: (tag: string) => void
+  utilityActions: ReactNode
+}
+
+export const EditorStudioMetadataAssistantPanel = ({
+  isTagPanelOpen,
+  onToggleTagPanel,
+  isUtilityPanelOpen,
+  onToggleUtilityPanel,
+  metaNotice,
+  knownTags,
+  selectedTags,
+  tagUsageMap,
+  onToggleTag,
+  onDeleteTag,
+  utilityActions,
+}: EditorStudioMetadataAssistantPanelProps) => (
+  <>
+    <MetadataAssistantDisclosure open={isTagPanelOpen}>
+      <summary
+        onClick={(event) => {
+          event.preventDefault()
+          onToggleTagPanel()
+        }}
+      >
+        <strong>태그 정리</strong>
+        <span>{isTagPanelOpen ? "닫기" : "열기"}</span>
+      </summary>
+      <div className="body">
+        <MetadataStatus data-tone={metaNotice.tone}>{metaNotice.text}</MetadataStatus>
+        <MetadataPanel>
+          <label>태그 선택</label>
+          <TagCatalogList>
+            {knownTags.map((tag) => {
+              const usageCount = tagUsageMap[tag] || 0
+              const isSelected = selectedTags.includes(tag)
+
+              return (
+                <TagCatalogChipGroup
+                  key={tag}
+                  data-active={isSelected}
+                >
+                  <TagCatalogToggle
+                    type="button"
+                    data-active={isSelected}
+                    onClick={() => onToggleTag(tag)}
+                  >
+                    <span className="label">{tag}</span>
+                    {usageCount > 0 ? <span className="count">{usageCount}</span> : null}
+                  </TagCatalogToggle>
+                  <TagCatalogDeleteButton
+                    type="button"
+                    data-active={isSelected}
+                    disabled={usageCount > 0}
+                    title={usageCount > 0 ? "사용 중인 태그는 삭제할 수 없습니다." : "태그 삭제"}
+                    onClick={() => onDeleteTag(tag)}
+                  >
+                    ×
+                  </TagCatalogDeleteButton>
+                </TagCatalogChipGroup>
+              )
+            })}
+            {knownTags.length === 0 ? <EmptyMetaText>아직 저장된 태그가 없습니다.</EmptyMetaText> : null}
+          </TagCatalogList>
+        </MetadataPanel>
+      </div>
+    </MetadataAssistantDisclosure>
+
+    <MetadataAssistantDisclosure open={isUtilityPanelOpen}>
+      <summary
+        onClick={(event) => {
+          event.preventDefault()
+          onToggleUtilityPanel()
+        }}
+      >
+        <strong>보조 작업</strong>
+        <span>{isUtilityPanelOpen ? "닫기" : "열기"}</span>
+      </summary>
+      {isUtilityPanelOpen ? <div className="body">{utilityActions}</div> : null}
+    </MetadataAssistantDisclosure>
+  </>
+)
+
+const MetadataAssistantDisclosure = styled.details`
+  margin-top: 0.68rem;
+  border-top: 1px dashed ${({ theme }) => theme.colors.gray6};
+  padding-top: 0.68rem;
+
+  summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.72rem;
+    list-style: none;
+    cursor: pointer;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.78rem;
+    line-height: 1.45;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+  }
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.8rem;
+    font-weight: 700;
+  }
+
+  summary > span:last-of-type {
+    flex: 0 0 auto;
+    color: ${({ theme }) => theme.colors.blue11};
+    font-size: 0.76rem;
+    font-weight: 700;
+  }
+
+  .body {
+    display: grid;
+    gap: 0.62rem;
+    margin-top: 0.72rem;
+  }
+`
+
+const MetadataStatus = styled.div`
+  padding: 0.62rem 0.74rem;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+
+  &[data-tone="idle"] {
+    color: ${({ theme }) => theme.colors.gray11};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: transparent;
+  }
+
+  &[data-tone="loading"] {
+    color: ${({ theme }) => theme.colors.blue11};
+    border: 1px solid ${({ theme }) => theme.colors.blue7};
+    background: ${({ theme }) => theme.colors.blue3};
+  }
+
+  &[data-tone="success"] {
+    color: ${({ theme }) => theme.colors.green11};
+    border: 1px solid ${({ theme }) => theme.colors.green7};
+    background: ${({ theme }) => theme.colors.green3};
+  }
+
+  &[data-tone="error"] {
+    color: ${({ theme }) => theme.colors.red11};
+    border: 1px solid ${({ theme }) => theme.colors.red7};
+    background: ${({ theme }) => theme.colors.red3};
+  }
+`
+
+const MetadataPanel = styled.div`
+  display: grid;
+  gap: 0.65rem;
+  min-width: 0;
+  padding: 0.55rem 0;
+  border-radius: 0;
+  border: none;
+  background: transparent;
+
+  label {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.84rem;
+    font-weight: 700;
+  }
+`
+
+const TagCatalogList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  min-width: 0;
+`
+
+const TagCatalogChipGroup = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  min-width: 0;
+  max-width: 100%;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: transparent;
+  overflow: hidden;
+  transition:
+    border-color 0.18s ease,
+    transform 0.18s ease,
+    background 0.18s ease;
+
+  &[data-active="true"] {
+    border-color: ${({ theme }) => theme.colors.gray7};
+    background: ${({ theme }) => theme.colors.gray3};
+  }
+
+  &:hover {
+    transform: none;
+  }
+`
+
+const TagCatalogToggle = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.46rem;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray11};
+  padding: 0.5rem 0.88rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background 0.18s ease,
+    color 0.18s ease;
+
+  .label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.35rem;
+    min-height: 1.35rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.16);
+    color: currentColor;
+    font-size: 0.7rem;
+    line-height: 1;
+  }
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.gray2};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &[data-active="true"] {
+    color: ${({ theme }) => theme.colors.gray12};
+
+    &:hover {
+      background: transparent;
+      color: ${({ theme }) => theme.colors.gray12};
+    }
+
+    .count {
+      background: ${({ theme }) => theme.colors.gray4};
+    }
+  }
+`
+
+const TagCatalogDeleteButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
+  min-width: 2.05rem;
+  padding: 0 0.58rem;
+  border: 0;
+  border-left: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray11};
+  cursor: pointer;
+  flex: 0 0 auto;
+  font-size: 0.98rem;
+  line-height: 1;
+  transition:
+    background 0.18s ease,
+    color 0.18s ease,
+    transform 0.18s ease;
+
+  &[data-active="true"] {
+    border-left-color: ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => theme.colors.gray2};
+    color: ${({ theme }) => theme.colors.gray11};
+  }
+
+  &:hover:not(:disabled) {
+    transform: none;
+    background: ${({ theme }) => theme.colors.red3};
+    color: ${({ theme }) => theme.colors.red11};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+const EmptyMetaText = styled.span`
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.78rem;
+  line-height: 1.5;
+`

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -52,6 +52,7 @@ import {
 } from "./EditorStudioThumbnailPanels"
 import { EditorStudioPublishModal } from "./EditorStudioPublishModal"
 import { EditorStudioComposeAssistantPanel } from "./EditorStudioComposeAssistantPanel"
+import { EditorStudioMetadataAssistantPanel } from "./EditorStudioMetadataAssistantPanel"
 import {
   isServerTempDraftPost,
   TEMP_DRAFT_BODY_PLACEHOLDER,
@@ -3732,87 +3733,35 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
                 thumbnailEditorPanel={thumbnailEditorPanel}
                 previewMetaEditorPanel={previewMetaEditorPanel}
               >
-                <InlineDisclosure open={activeMetaPanel === "tag"}>
-                  <summary
-                    onClick={(event) => {
-                      event.preventDefault()
-                      setActiveMetaPanel((prev) => (prev === "tag" ? null : "tag"))
-                    }}
-                  >
-                    <strong>태그 정리</strong>
-                    <span>{activeMetaPanel === "tag" ? "닫기" : "열기"}</span>
-                  </summary>
-                  <div className="body">
-                    <MetadataStatus data-tone={metaNotice.tone}>{metaNotice.text}</MetadataStatus>
-                    <MetadataPanel>
-                      <label>태그 선택</label>
-                      <SelectionRow>
-                        {knownTags.map((tag) => (
-                          <TagCatalogChipGroup
-                            key={tag}
-                            data-active={postTags.includes(tag)}
-                          >
-                            <TagCatalogToggle
-                              type="button"
-                              data-active={postTags.includes(tag)}
-                              onClick={() => (postTags.includes(tag) ? removeTagFromPost(tag) : addTagToPost(tag))}
-                            >
-                              <span className="label">{tag}</span>
-                              {(tagUsageMap[tag] || 0) > 0 ? (
-                                <span className="count">{tagUsageMap[tag] || 0}</span>
-                              ) : null}
-                            </TagCatalogToggle>
-                            <TagCatalogDeleteButton
-                              type="button"
-                              data-active={postTags.includes(tag)}
-                              disabled={(tagUsageMap[tag] || 0) > 0}
-                              title={
-                                (tagUsageMap[tag] || 0) > 0
-                                  ? "사용 중인 태그는 삭제할 수 없습니다."
-                                  : "태그 삭제"
-                              }
-                              onClick={() => deleteTagFromCatalog(tag)}
-                            >
-                              ×
-                            </TagCatalogDeleteButton>
-                          </TagCatalogChipGroup>
-                        ))}
-                        {knownTags.length === 0 ? <EmptyMetaText>아직 저장된 태그가 없습니다.</EmptyMetaText> : null}
-                      </SelectionRow>
-                    </MetadataPanel>
-                  </div>
-                </InlineDisclosure>
-
-                <InlineDisclosure open={isComposeUtilityOpen}>
-                  <summary
-                    onClick={(event) => {
-                      event.preventDefault()
-                      setIsComposeUtilityOpen((prev) => !prev)
-                    }}
-                  >
-                    <strong>보조 작업</strong>
-                    <span>{isComposeUtilityOpen ? "닫기" : "열기"}</span>
-                  </summary>
-                  {isComposeUtilityOpen && (
-                    <div className="body">
-                      <SubActionRow>
-                        <Button type="button" disabled={loadingKey.length > 0} onClick={() => saveLocalDraft()}>
-                          브라우저 임시저장
-                        </Button>
-                        <Button type="button" disabled={loadingKey.length > 0} onClick={restoreLocalDraft}>
-                          임시저장 불러오기
-                        </Button>
-                        <Button
-                          type="button"
-                          disabled={loadingKey.length > 0 || !localDraftSavedAt}
-                          onClick={clearLocalDraft}
-                        >
-                          임시저장 삭제
-                        </Button>
-                      </SubActionRow>
-                    </div>
-                  )}
-                </InlineDisclosure>
+                <EditorStudioMetadataAssistantPanel
+                  isTagPanelOpen={activeMetaPanel === "tag"}
+                  onToggleTagPanel={() => setActiveMetaPanel((prev) => (prev === "tag" ? null : "tag"))}
+                  isUtilityPanelOpen={isComposeUtilityOpen}
+                  onToggleUtilityPanel={() => setIsComposeUtilityOpen((prev) => !prev)}
+                  metaNotice={metaNotice}
+                  knownTags={knownTags}
+                  selectedTags={postTags}
+                  tagUsageMap={tagUsageMap}
+                  onToggleTag={(tag) => (postTags.includes(tag) ? removeTagFromPost(tag) : addTagToPost(tag))}
+                  onDeleteTag={deleteTagFromCatalog}
+                  utilityActions={
+                    <SubActionRow>
+                      <Button type="button" disabled={loadingKey.length > 0} onClick={() => saveLocalDraft()}>
+                        브라우저 임시저장
+                      </Button>
+                      <Button type="button" disabled={loadingKey.length > 0} onClick={restoreLocalDraft}>
+                        임시저장 불러오기
+                      </Button>
+                      <Button
+                        type="button"
+                        disabled={loadingKey.length > 0 || !localDraftSavedAt}
+                        onClick={clearLocalDraft}
+                      >
+                        임시저장 삭제
+                      </Button>
+                    </SubActionRow>
+                  }
+                />
               </EditorStudioComposeAssistantPanel>
             </ComposeAssistantColumn>
           </ComposeStudioLayout>
@@ -5325,60 +5274,6 @@ const PublishNotice = styled.div`
   }
 `
 
-const MetadataStatus = styled.div`
-  padding: 0.62rem 0.74rem;
-  border-radius: 8px;
-  font-size: 0.8rem;
-  line-height: 1.5;
-
-  &[data-tone="idle"] {
-    color: ${({ theme }) => theme.colors.gray11};
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: transparent;
-  }
-
-  &[data-tone="loading"] {
-    color: ${({ theme }) => theme.colors.blue11};
-    border: 1px solid ${({ theme }) => theme.colors.blue7};
-    background: ${({ theme }) => theme.colors.blue3};
-  }
-
-  &[data-tone="success"] {
-    color: ${({ theme }) => theme.colors.green11};
-    border: 1px solid ${({ theme }) => theme.colors.green7};
-    background: ${({ theme }) => theme.colors.green3};
-  }
-
-  &[data-tone="error"] {
-    color: ${({ theme }) => theme.colors.red11};
-    border: 1px solid ${({ theme }) => theme.colors.red7};
-    background: ${({ theme }) => theme.colors.red3};
-  }
-`
-
-const MetadataPanel = styled.div`
-  display: grid;
-  gap: 0.65rem;
-  min-width: 0;
-  padding: 0.55rem 0;
-  border-radius: 0;
-  border: none;
-  background: transparent;
-
-  label {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.84rem;
-    font-weight: 700;
-  }
-`
-
-const SelectionRow = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-  min-width: 0;
-`
-
 const SelectedTagChip = styled.span`
   display: inline-flex;
   align-items: stretch;
@@ -5443,131 +5338,6 @@ const SelectedTagChip = styled.span`
       color: ${({ theme }) => theme.colors.gray12};
     }
   }
-`
-
-const TagCatalogChipGroup = styled.div`
-  display: inline-flex;
-  align-items: center;
-  gap: 0;
-  min-width: 0;
-  max-width: 100%;
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: transparent;
-  overflow: hidden;
-  transition:
-    border-color 0.18s ease,
-    transform 0.18s ease,
-    background 0.18s ease;
-
-  &[data-active="true"] {
-    border-color: ${({ theme }) => theme.colors.gray7};
-    background: ${({ theme }) => theme.colors.gray3};
-  }
-
-  &:hover {
-    transform: none;
-  }
-`
-
-const TagCatalogToggle = styled.button`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.46rem;
-  min-width: 0;
-  border: 0;
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray11};
-  padding: 0.5rem 0.88rem;
-  font-size: 0.8rem;
-  font-weight: 700;
-  cursor: pointer;
-  transition:
-    background 0.18s ease,
-    color 0.18s ease;
-
-  .label {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .count {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 1.35rem;
-    min-height: 1.35rem;
-    border-radius: 999px;
-    background: rgba(15, 23, 42, 0.16);
-    color: currentColor;
-    font-size: 0.7rem;
-    line-height: 1;
-  }
-
-  &:hover {
-    background: ${({ theme }) => theme.colors.gray2};
-    color: ${({ theme }) => theme.colors.gray12};
-  }
-
-  &[data-active="true"] {
-    color: ${({ theme }) => theme.colors.gray12};
-
-    &:hover {
-      background: transparent;
-      color: ${({ theme }) => theme.colors.gray12};
-    }
-
-    .count {
-      background: ${({ theme }) => theme.colors.gray4};
-    }
-  }
-`
-
-const TagCatalogDeleteButton = styled.button`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  align-self: stretch;
-  min-width: 2.05rem;
-  padding: 0 0.58rem;
-  border: 0;
-  border-left: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray11};
-  cursor: pointer;
-  flex: 0 0 auto;
-  font-size: 0.98rem;
-  line-height: 1;
-  transition:
-    background 0.18s ease,
-    color 0.18s ease,
-    transform 0.18s ease;
-
-  &[data-active="true"] {
-    border-left-color: ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray2};
-    color: ${({ theme }) => theme.colors.gray11};
-  }
-
-  &:hover:not(:disabled) {
-    transform: none;
-    background: ${({ theme }) => theme.colors.red3};
-    color: ${({ theme }) => theme.colors.red11};
-  }
-
-  &:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
-  }
-`
-
-const EmptyMetaText = styled.span`
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.78rem;
-  line-height: 1.5;
 `
 
 const ListPanel = styled.div`


### PR DESCRIPTION
## 관련 이슈

close #189

## 작업 배경

- `EditorStudioPage.tsx`가 직접 소유하던 태그 정리/보조 작업 disclosure 렌더링을 `EditorStudioMetadataAssistantPanel`로 분리했습니다.
- 기존 tag/utility 상태와 handler는 page가 계속 관리하고, UI markup과 tag catalog 스타일만 전용 컴포넌트가 소유하도록 책임을 줄였습니다.

## 작업 내용

- metadata assistant 전용 컴포넌트를 추가해 태그 카탈로그, metadata notice, 보조 작업 disclosure를 렌더합니다.
- `EditorStudioPage.tsx`는 새 컴포넌트를 import/render하고 필요한 상태/액션만 props로 전달합니다.
- `editor-studio-state` source guard에 metadata assistant 경계를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - RED 확인: `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` 실패, `EditorStudioMetadataAssistantPanel.tsx` 부재
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `node front/scripts/check-bundle-size.mjs`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: metadata assistant props 연결 실수 시 태그 선택/삭제 또는 보조 작업 토글이 동작하지 않을 수 있습니다. source guard와 editor authoring/state 회귀 테스트로 경계를 확인했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `refactor(editor): studio metadata assistant 분리`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
