### PR TITLE
[Refactor] editor studio selected post tools 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -192,6 +192,14 @@ test.describe("editor studio state", () => {
     const editorStudioMetadataAssistantPanelSource = existsSync(editorStudioMetadataAssistantPanelPath)
       ? readFileSync(editorStudioMetadataAssistantPanelPath, "utf8")
       : ""
+    const editorStudioSelectedPostToolsPanelPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioSelectedPostToolsPanel.tsx"
+    )
+    expect(existsSync(editorStudioSelectedPostToolsPanelPath)).toBe(true)
+    const editorStudioSelectedPostToolsPanelSource = existsSync(editorStudioSelectedPostToolsPanelPath)
+      ? readFileSync(editorStudioSelectedPostToolsPanelPath, "utf8")
+      : ""
     const blockEditorShellSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorShell.tsx"), "utf8")
     const blockEditorEngineSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tsx"), "utf8")
     const blockSelectionModelSource = readFileSync(
@@ -331,6 +339,27 @@ test.describe("editor studio state", () => {
     expect(editorStudioMetadataAssistantPanelSource).toContain("<strong>보조 작업</strong>")
     expect(editorStudioSource).not.toContain("<strong>태그 정리</strong>")
     expect(editorStudioSource).not.toContain("<strong>보조 작업</strong>")
+    expect(editorStudioSelectedPostToolsPanelSource).toContain("export const EditorStudioSelectedPostToolsPanel =")
+    expect(editorStudioSource).toContain(
+      'import { EditorStudioSelectedPostToolsPanel } from "./EditorStudioSelectedPostToolsPanel"'
+    )
+    expect(editorStudioSource.match(/<EditorStudioSelectedPostToolsPanel/g)?.length).toBe(1)
+    expect(editorStudioSelectedPostToolsPanelSource).toContain("다른 글 직접 불러오기")
+    expect(editorStudioSelectedPostToolsPanelSource).toContain("post id 직접 불러오기")
+    expect(editorStudioSelectedPostToolsPanelSource).toContain("<strong>{directLoadTitle}</strong>")
+    expect(editorStudioSelectedPostToolsPanelSource).toContain("<strong>진단 도구</strong>")
+    expect(editorStudioSource).not.toContain("<strong>다른 글 직접 불러오기</strong>")
+    expect(editorStudioSource).not.toContain("<strong>post id 직접 불러오기</strong>")
+    expect(editorStudioSource).not.toContain("<strong>진단 도구</strong>")
+    expect(editorStudioSource).toContain("const handleSelectedPostIdChange = useCallback")
+    expect(editorStudioSource).toContain("onPostIdChange={handleSelectedPostIdChange}")
+    expect(editorStudioSelectedPostToolsPanelSource).not.toContain("apiFetch(")
+    expect(editorStudioSelectedPostToolsPanelSource).not.toContain("setPostId")
+    expect(editorStudioSelectedPostToolsPanelSource).not.toContain("setEditorMode")
+    expect(editorStudioSelectedPostToolsPanelSource).not.toContain("setPostVersion")
+    expect(editorStudioSelectedPostToolsPanelSource).not.toContain("setIsTempDraftMode")
+    expect(editorStudioSelectedPostToolsPanelSource).not.toContain('run("hitPost"')
+    expect(editorStudioSelectedPostToolsPanelSource).not.toContain('run("likePost"')
     expect(editorStudioStateSource).toContain("export type PostVisibility =")
     expect(editorStudioStateSource).toContain("export const toVisibility")
     expect(editorStudioStateSource).toContain("export const toFlags")

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -53,6 +53,7 @@ import {
 import { EditorStudioPublishModal } from "./EditorStudioPublishModal"
 import { EditorStudioComposeAssistantPanel } from "./EditorStudioComposeAssistantPanel"
 import { EditorStudioMetadataAssistantPanel } from "./EditorStudioMetadataAssistantPanel"
+import { EditorStudioSelectedPostToolsPanel } from "./EditorStudioSelectedPostToolsPanel"
 import {
   isServerTempDraftPost,
   TEMP_DRAFT_BODY_PLACEHOLDER,
@@ -955,6 +956,19 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
     }
     setListQuickPreset(preset)
   }, [])
+
+  const handleSelectedPostIdChange = useCallback(
+    (nextPostId: string) => {
+      const normalizedPostId = nextPostId.trim()
+      setPostId(normalizedPostId)
+      if (normalizedPostId !== postId.trim()) {
+        setEditorMode("create")
+        setPostVersion(null)
+        setIsTempDraftMode(false)
+      }
+    },
+    [postId]
+  )
 
   const publishModalHintByAction = useCallback((actionType: PublishActionType): string => {
     if (actionType === "create") return "작성 전 확인이 필요한 항목만 이곳에 표시됩니다."
@@ -3327,86 +3341,6 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
                         글 삭제
                       </Button>
                     </ActionRow>
-                    <InlineDisclosure open={isDirectLoadOpen}>
-                      <summary
-                        onClick={(event) => {
-                          event.preventDefault()
-                          setIsDirectLoadOpen((prev) => !prev)
-                        }}
-                      >
-                        <strong>다른 글 직접 불러오기</strong>
-                        <span>{isDirectLoadOpen ? "닫기" : "열기"}</span>
-                      </summary>
-                      {isDirectLoadOpen && (
-                        <div className="body">
-                          <SelectedPostGrid>
-                            <FieldBox>
-                              <FieldLabel htmlFor="selected-post-id">post id</FieldLabel>
-                              <Input
-                                id="selected-post-id"
-                                placeholder="예: 1"
-                                value={postId}
-                                onChange={(e) => {
-                                  const nextId = e.target.value.trim()
-                                  setPostId(nextId)
-                                  if (nextId !== postId.trim()) {
-                                    setEditorMode("create")
-                                    setPostVersion(null)
-                                    setIsTempDraftMode(false)
-                                  }
-                                }}
-                              />
-                            </FieldBox>
-                          </SelectedPostGrid>
-                          <SelectedPostHint>번호를 알고 있을 때만 씁니다.</SelectedPostHint>
-                          <ActionRow>
-                            <Button
-                              type="button"
-                              disabled={disabled("postOne")}
-                              onClick={() => void loadPostForEditor()}
-                            >
-                              글 불러오기
-                            </Button>
-                          </ActionRow>
-                        </div>
-                      )}
-                    </InlineDisclosure>
-                    <InlineDisclosure open={isSelectedToolsOpen}>
-                      <summary
-                        onClick={(event) => {
-                          event.preventDefault()
-                          setIsSelectedToolsOpen((prev) => !prev)
-                        }}
-                      >
-                        <strong>진단 도구</strong>
-                        <span>{isSelectedToolsOpen ? "닫기" : "열기"}</span>
-                      </summary>
-                      {isSelectedToolsOpen && (
-                        <div className="body">
-                          <SelectedPostHint>진단이 필요할 때만 실행합니다.</SelectedPostHint>
-                          <SubActionRow>
-                            <Button
-                              type="button"
-                              disabled={disabled("hitPost")}
-                              onClick={() =>
-                                run("hitPost", () => apiFetch(`/post/api/v1/posts/${postId}/hit`, { method: "POST" }))
-                              }
-                            >
-                              조회수 테스트
-                            </Button>
-                            <Button
-                              type="button"
-                              disabled={disabled("likePost")}
-                              onClick={() =>
-                                run("likePost", () => apiFetch(`/post/api/v1/posts/${postId}/like`, { method: "PUT" }))
-                              }
-                            >
-                              좋아요 반영 테스트
-                            </Button>
-                          </SubActionRow>
-                        </div>
-                      )}
-                    </InlineDisclosure>
                   </>
                 ) : (
                   <>
@@ -3423,52 +3357,27 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
                         새 글 작성 시작
                       </PrimaryButton>
                     </ActionRow>
-                    <InlineDisclosure open={isDirectLoadOpen}>
-                      <summary
-                        onClick={(event) => {
-                          event.preventDefault()
-                          setIsDirectLoadOpen((prev) => !prev)
-                        }}
-                      >
-                        <strong>post id 직접 불러오기</strong>
-                        <span>{isDirectLoadOpen ? "닫기" : "열기"}</span>
-                      </summary>
-                      {isDirectLoadOpen && (
-                        <div className="body">
-                          <SelectedPostGrid>
-                            <FieldBox>
-                              <FieldLabel htmlFor="selected-post-id">post id</FieldLabel>
-                              <Input
-                                id="selected-post-id"
-                                placeholder="예: 1"
-                                value={postId}
-                                onChange={(e) => {
-                                  const nextId = e.target.value.trim()
-                                  setPostId(nextId)
-                                  if (nextId !== postId.trim()) {
-                                    setEditorMode("create")
-                                    setPostVersion(null)
-                                    setIsTempDraftMode(false)
-                                  }
-                                }}
-                              />
-                            </FieldBox>
-                          </SelectedPostGrid>
-                          <SelectedPostHint>특정 글 번호를 알고 있을 때만 씁니다.</SelectedPostHint>
-                          <ActionRow>
-                            <Button
-                              type="button"
-                              disabled={disabled("postOne")}
-                              onClick={() => void loadPostForEditor()}
-                            >
-                              글 불러오기
-                            </Button>
-                          </ActionRow>
-                        </div>
-                      )}
-                    </InlineDisclosure>
                   </>
                 )}
+                <EditorStudioSelectedPostToolsPanel
+                  hasSelectedManagedPost={hasSelectedManagedPost}
+                  isDirectLoadOpen={isDirectLoadOpen}
+                  onToggleDirectLoad={() => setIsDirectLoadOpen((prev) => !prev)}
+                  isSelectedToolsOpen={isSelectedToolsOpen}
+                  onToggleSelectedTools={() => setIsSelectedToolsOpen((prev) => !prev)}
+                  postId={postId}
+                  onPostIdChange={handleSelectedPostIdChange}
+                  isLoadPostDisabled={disabled("postOne")}
+                  onLoadPost={() => void loadPostForEditor()}
+                  isHitPostDisabled={disabled("hitPost")}
+                  onRunHitPost={() =>
+                    void run("hitPost", () => apiFetch(`/post/api/v1/posts/${postId}/hit`, { method: "POST" }))
+                  }
+                  isLikePostDisabled={disabled("likePost")}
+                  onRunLikePost={() =>
+                    void run("likePost", () => apiFetch(`/post/api/v1/posts/${postId}/like`, { method: "PUT" }))
+                  }
+                />
               </SelectedPostPanel>
             </ContentStudioGrid>
 
@@ -5543,12 +5452,6 @@ const SelectedPostBadge = styled.span`
   }
 `
 
-const SelectedPostGrid = styled.div`
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 0.7rem;
-`
-
 const SelectedPostStateCard = styled.div`
   display: grid;
   gap: 0.52rem;
@@ -5603,13 +5506,6 @@ const SelectedPostStateCard = styled.div`
     font-size: 0.74rem;
     font-weight: 700;
   }
-`
-
-const SelectedPostHint = styled.p`
-  margin: 0.1rem 0 0;
-  font-size: 0.74rem;
-  color: ${({ theme }) => theme.colors.gray11};
-  line-height: 1.45;
 `
 
 const SubActionRow = styled.div`

--- a/front/src/routes/Admin/EditorStudioSelectedPostToolsPanel.tsx
+++ b/front/src/routes/Admin/EditorStudioSelectedPostToolsPanel.tsx
@@ -1,0 +1,276 @@
+import styled from "@emotion/styled"
+
+type EditorStudioSelectedPostToolsPanelProps = {
+  hasSelectedManagedPost: boolean
+  isDirectLoadOpen: boolean
+  onToggleDirectLoad: () => void
+  isSelectedToolsOpen: boolean
+  onToggleSelectedTools: () => void
+  postId: string
+  onPostIdChange: (postId: string) => void
+  isLoadPostDisabled: boolean
+  onLoadPost: () => void
+  isHitPostDisabled: boolean
+  onRunHitPost: () => void
+  isLikePostDisabled: boolean
+  onRunLikePost: () => void
+}
+
+export const EditorStudioSelectedPostToolsPanel = ({
+  hasSelectedManagedPost,
+  isDirectLoadOpen,
+  onToggleDirectLoad,
+  isSelectedToolsOpen,
+  onToggleSelectedTools,
+  postId,
+  onPostIdChange,
+  isLoadPostDisabled,
+  onLoadPost,
+  isHitPostDisabled,
+  onRunHitPost,
+  isLikePostDisabled,
+  onRunLikePost,
+}: EditorStudioSelectedPostToolsPanelProps) => {
+  const directLoadTitle = hasSelectedManagedPost ? "다른 글 직접 불러오기" : "post id 직접 불러오기"
+  const directLoadHint = hasSelectedManagedPost
+    ? "번호를 알고 있을 때만 씁니다."
+    : "특정 글 번호를 알고 있을 때만 씁니다."
+
+  return (
+    <>
+      <SelectedPostToolsDisclosure open={isDirectLoadOpen}>
+        <summary
+          onClick={(event) => {
+            event.preventDefault()
+            onToggleDirectLoad()
+          }}
+        >
+          <strong>{directLoadTitle}</strong>
+          <span>{isDirectLoadOpen ? "닫기" : "열기"}</span>
+        </summary>
+        {isDirectLoadOpen ? (
+          <div className="body">
+            <SelectedPostGrid>
+              <FieldBox>
+                <FieldLabel htmlFor="selected-post-id">post id</FieldLabel>
+                <Input
+                  id="selected-post-id"
+                  placeholder="예: 1"
+                  value={postId}
+                  onChange={(event) => onPostIdChange(event.target.value)}
+                />
+              </FieldBox>
+            </SelectedPostGrid>
+            <SelectedPostHint>{directLoadHint}</SelectedPostHint>
+            <ActionRow>
+              <Button
+                type="button"
+                disabled={isLoadPostDisabled}
+                onClick={onLoadPost}
+              >
+                글 불러오기
+              </Button>
+            </ActionRow>
+          </div>
+        ) : null}
+      </SelectedPostToolsDisclosure>
+
+      {hasSelectedManagedPost ? (
+        <SelectedPostToolsDisclosure open={isSelectedToolsOpen}>
+          <summary
+            onClick={(event) => {
+              event.preventDefault()
+              onToggleSelectedTools()
+            }}
+          >
+            <strong>진단 도구</strong>
+            <span>{isSelectedToolsOpen ? "닫기" : "열기"}</span>
+          </summary>
+          {isSelectedToolsOpen ? (
+            <div className="body">
+              <SelectedPostHint>진단이 필요할 때만 실행합니다.</SelectedPostHint>
+              <SubActionRow>
+                <Button
+                  type="button"
+                  disabled={isHitPostDisabled}
+                  onClick={onRunHitPost}
+                >
+                  조회수 테스트
+                </Button>
+                <Button
+                  type="button"
+                  disabled={isLikePostDisabled}
+                  onClick={onRunLikePost}
+                >
+                  좋아요 반영 테스트
+                </Button>
+              </SubActionRow>
+            </div>
+          ) : null}
+        </SelectedPostToolsDisclosure>
+      ) : null}
+    </>
+  )
+}
+
+const SelectedPostToolsDisclosure = styled.details`
+  margin-top: 0.68rem;
+  border-top: 1px dashed ${({ theme }) => theme.colors.gray6};
+  padding-top: 0.68rem;
+
+  summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.72rem;
+    list-style: none;
+    cursor: pointer;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.78rem;
+    line-height: 1.45;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+  }
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.8rem;
+    font-weight: 700;
+  }
+
+  summary > span:last-of-type {
+    flex: 0 0 auto;
+    color: ${({ theme }) => theme.colors.blue11};
+    font-size: 0.76rem;
+    font-weight: 700;
+  }
+
+  .body {
+    display: grid;
+    gap: 0.62rem;
+    margin-top: 0.72rem;
+  }
+`
+
+const FieldBox = styled.div`
+  display: grid;
+  gap: 0.26rem;
+`
+
+const FieldLabel = styled.label`
+  font-size: 0.8rem;
+  font-weight: 650;
+  color: ${({ theme }) => theme.colors.gray11};
+`
+
+const Input = styled.input`
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.72rem 0.8rem;
+  min-height: 44px;
+  min-width: 0;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray12};
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
+  }
+`
+
+const ActionRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 0.85rem;
+  align-items: center;
+
+  > button {
+    min-width: 8.8rem;
+  }
+
+  @media (max-width: 720px) {
+    display: grid;
+    grid-template-columns: 1fr;
+
+    > button {
+      width: 100%;
+    }
+  }
+`
+
+const Button = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+const SelectedPostGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.7rem;
+`
+
+const SelectedPostHint = styled.p`
+  margin: 0.1rem 0 0;
+  font-size: 0.74rem;
+  color: ${({ theme }) => theme.colors.gray11};
+  line-height: 1.45;
+`
+
+const SubActionRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.65rem;
+  padding-top: 0.65rem;
+  border-top: 1px dashed ${({ theme }) => theme.colors.gray6};
+
+  > button {
+    border-style: dashed;
+  }
+
+  @media (max-width: 720px) {
+    display: grid;
+    grid-template-columns: 1fr;
+
+    > button {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+`


### PR DESCRIPTION
## 관련 이슈

close #191

## 작업 배경

- `EditorStudioPage.tsx`의 선택 글 직접 불러오기/진단 도구 disclosure JSX를 전용 패널 컴포넌트로 분리했습니다.
- 코드 영향 범위가 섞이지 않도록 post id 변경 시 editor state reset과 hit/like API 실행은 기존 page callback에만 유지했습니다.

## 작업 내용

- `EditorStudioSelectedPostToolsPanel`을 추가해 선택 글 direct-load/diagnostic UI와 기존 스타일을 이동했습니다.
- `EditorStudioPage`는 새 패널을 1회 렌더하고, `handleSelectedPostIdChange`와 `run/apiFetch` 콜백만 소유하도록 정리했습니다.
- source guard가 새 패널의 `apiFetch`, editor state setter, `run("hitPost"|"likePost")` 직접 결합과 page direct markup 재도입을 막도록 확장됐습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --grep "writer surface의 리스트 항목 handle은 row gutter hover에서도 항목을 따라간다" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `node front/scripts/check-bundle-size.mjs`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 새 패널은 표시 전용으로 제한했고, 상태 초기화/API 실행은 page callback에 유지했습니다. source guard가 이 경계를 검사합니다.
- 영향 확인: 변경 파일은 Admin editor page, 새 selected-post tools panel, source guard로 한정됩니다. `/admin` bundle-size는 raw `423.3KB / 430.5KB`, gzip `133.6KB / 135.2KB`, brotli `114.6KB / 117.5KB`로 모두 예산 내 OK입니다.
- 검증 중 1차 `editor-authoring-flow` 전체 실행에서 writer list handle hover metrics가 1회 누락됐으나, 이번 diff가 건드리지 않은 `front/src/components/editor/**`/QA writer 영역의 hover timing flake로 분류했습니다. 같은 테스트 targeted rerun과 전체 rerun은 통과했습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 `EditorStudioPage` 내부 disclosure JSX 경로로 되돌릴 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
