### PR TITLE
[Refactor] editor studio selected post panel 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -200,6 +200,14 @@ test.describe("editor studio state", () => {
     const editorStudioSelectedPostToolsPanelSource = existsSync(editorStudioSelectedPostToolsPanelPath)
       ? readFileSync(editorStudioSelectedPostToolsPanelPath, "utf8")
       : ""
+    const editorStudioSelectedPostPanelPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioSelectedPostPanel.tsx"
+    )
+    expect(existsSync(editorStudioSelectedPostPanelPath)).toBe(true)
+    const editorStudioSelectedPostPanelSource = existsSync(editorStudioSelectedPostPanelPath)
+      ? readFileSync(editorStudioSelectedPostPanelPath, "utf8")
+      : ""
     const blockEditorShellSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorShell.tsx"), "utf8")
     const blockEditorEngineSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tsx"), "utf8")
     const blockSelectionModelSource = readFileSync(
@@ -360,6 +368,30 @@ test.describe("editor studio state", () => {
     expect(editorStudioSelectedPostToolsPanelSource).not.toContain("setIsTempDraftMode")
     expect(editorStudioSelectedPostToolsPanelSource).not.toContain('run("hitPost"')
     expect(editorStudioSelectedPostToolsPanelSource).not.toContain('run("likePost"')
+    expect(editorStudioSelectedPostPanelSource).toContain("export const EditorStudioSelectedPostPanel =")
+    expect(editorStudioSource).toContain(
+      'import { EditorStudioSelectedPostPanel } from "./EditorStudioSelectedPostPanel"'
+    )
+    expect(editorStudioSource.match(/<EditorStudioSelectedPostPanel/g)?.length).toBe(1)
+    expect(editorStudioSelectedPostPanelSource).toContain("선택한 글")
+    expect(editorStudioSelectedPostPanelSource).toContain("빠른 작업")
+    expect(editorStudioSelectedPostPanelSource).toContain("편집 계속")
+    expect(editorStudioSelectedPostPanelSource).toContain("새 글 작성")
+    expect(editorStudioSelectedPostPanelSource).toContain("글 삭제")
+    expect(editorStudioSource).not.toContain("<SelectedPostHeader>")
+    expect(editorStudioSource).not.toContain("<SelectedPostStateCard")
+    expect(editorStudioSource).not.toContain("const SelectedPostPanel = styled.div`")
+    expect(editorStudioSource).not.toContain("const SelectedPostHeader = styled.div`")
+    expect(editorStudioSource).not.toContain("const SelectedPostStateCard = styled.div`")
+    expect(editorStudioSource).toContain("const handleContinueSelectedPostEditing = useCallback")
+    expect(editorStudioSource).toContain("onContinueEditing={handleContinueSelectedPostEditing}")
+    expect(editorStudioSource).toContain("onCreateNewPost={handleCreateNewPostFromSelectedPanel}")
+    expect(editorStudioSource).toContain("onDeletePost={handleDeleteSelectedPost}")
+    expect(editorStudioSelectedPostPanelSource).not.toContain("openPublishModal")
+    expect(editorStudioSelectedPostPanelSource).not.toContain("switchToCreateMode")
+    expect(editorStudioSelectedPostPanelSource).not.toContain("openDeleteConfirm")
+    expect(editorStudioSelectedPostPanelSource).not.toContain("apiFetch(")
+    expect(editorStudioSelectedPostPanelSource).not.toContain("run(")
     expect(editorStudioStateSource).toContain("export type PostVisibility =")
     expect(editorStudioStateSource).toContain("export const toVisibility")
     expect(editorStudioStateSource).toContain("export const toFlags")

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -53,6 +53,7 @@ import {
 import { EditorStudioPublishModal } from "./EditorStudioPublishModal"
 import { EditorStudioComposeAssistantPanel } from "./EditorStudioComposeAssistantPanel"
 import { EditorStudioMetadataAssistantPanel } from "./EditorStudioMetadataAssistantPanel"
+import { EditorStudioSelectedPostPanel } from "./EditorStudioSelectedPostPanel"
 import { EditorStudioSelectedPostToolsPanel } from "./EditorStudioSelectedPostToolsPanel"
 import {
   isServerTempDraftPost,
@@ -2053,6 +2054,18 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
     safePreviewThumbnail,
   ])
 
+  const handleContinueSelectedPostEditing = useCallback(() => {
+    openPublishModal("modify")
+  }, [openPublishModal])
+
+  const handleCreateNewPostFromSelectedPanel = useCallback(() => {
+    switchToCreateMode({ keepContent: false })
+  }, [switchToCreateMode])
+
+  const handleDeleteSelectedPost = useCallback(() => {
+    openDeleteConfirm([Number.parseInt(postId, 10)], postTitle)
+  }, [openDeleteConfirm, postId, postTitle])
+
   const closePublishModal = () => {
     if (
       loadingKey === "writePost" ||
@@ -3288,97 +3301,45 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
               </ListPanel>
               </ContentStudioLeft>
 
-              <SelectedPostPanel data-mobile-visible={showSelectedPanelInManageSurface}>
-                <SelectedPostHeader>
-                  <div>
-                    <h3>{hasSelectedManagedPost ? "선택한 글" : "빠른 작업"}</h3>
-                    <p>
-                      {hasSelectedManagedPost
-                        ? "선택한 글만 바로 이어서 다룹니다."
-                        : "새 글 작성이나 번호 불러오기만 남깁니다."}
-                    </p>
-                  </div>
-                  <SelectedPostBadge>{`${editorModeLabel} · ${selectedPostLabel}`}</SelectedPostBadge>
-                </SelectedPostHeader>
-                {hasSelectedManagedPost ? (
-                  <>
-                    <SelectedPostStateCard data-tone="active">
-                      <div className="headline">
-                        <strong>{postTitle.trim() || "제목 없음"}</strong>
-                        {isTempDraftMode ? (
-                          <LoadedBadge>임시 저장</LoadedBadge>
-                        ) : (
-                          <VisibilityBadge data-tone={postVisibility}>{currentVisibilityText}</VisibilityBadge>
-                        )}
-                      </div>
-                      <p>추가 작업은 필요할 때만 엽니다.</p>
-                      <div className="meta">
-                        <span>{`post id #${postId}`}</span>
-                        <span>{`버전 ${postVersion ?? "-"}`}</span>
-                      </div>
-                    </SelectedPostStateCard>
-                    <ActionRow>
-                      <PrimaryButton
-                        type="button"
-                        disabled={editorMode !== "edit" || disabled("modifyPost")}
-                        onClick={() => openPublishModal("modify")}
-                      >
-                        편집 계속
-                      </PrimaryButton>
-                      <Button
-                        type="button"
-                        disabled={loadingKey.length > 0}
-                        onClick={() => switchToCreateMode({ keepContent: false })}
-                      >
-                        새 글 작성
-                      </Button>
-                      <Button
-                        type="button"
-                        data-variant="danger"
-                        disabled={disabled("deletePost")}
-                        onClick={() => openDeleteConfirm([Number.parseInt(postId, 10)], postTitle)}
-                      >
-                        글 삭제
-                      </Button>
-                    </ActionRow>
-                  </>
-                ) : (
-                  <>
-                    <SelectedPostStateCard data-tone="idle">
-                      <strong>목록에서 글을 고르면 바로 이어집니다.</strong>
-                      <p>새 글 작성이나 번호 불러오기만 사용합니다.</p>
-                    </SelectedPostStateCard>
-                    <ActionRow>
-                      <PrimaryButton
-                        type="button"
-                        disabled={loadingKey.length > 0}
-                        onClick={() => switchToCreateMode({ keepContent: false })}
-                      >
-                        새 글 작성 시작
-                      </PrimaryButton>
-                    </ActionRow>
-                  </>
-                )}
-                <EditorStudioSelectedPostToolsPanel
-                  hasSelectedManagedPost={hasSelectedManagedPost}
-                  isDirectLoadOpen={isDirectLoadOpen}
-                  onToggleDirectLoad={() => setIsDirectLoadOpen((prev) => !prev)}
-                  isSelectedToolsOpen={isSelectedToolsOpen}
-                  onToggleSelectedTools={() => setIsSelectedToolsOpen((prev) => !prev)}
-                  postId={postId}
-                  onPostIdChange={handleSelectedPostIdChange}
-                  isLoadPostDisabled={disabled("postOne")}
-                  onLoadPost={() => void loadPostForEditor()}
-                  isHitPostDisabled={disabled("hitPost")}
-                  onRunHitPost={() =>
-                    void run("hitPost", () => apiFetch(`/post/api/v1/posts/${postId}/hit`, { method: "POST" }))
-                  }
-                  isLikePostDisabled={disabled("likePost")}
-                  onRunLikePost={() =>
-                    void run("likePost", () => apiFetch(`/post/api/v1/posts/${postId}/like`, { method: "PUT" }))
-                  }
-                />
-              </SelectedPostPanel>
+              <EditorStudioSelectedPostPanel
+                mobileVisible={showSelectedPanelInManageSurface}
+                hasSelectedManagedPost={hasSelectedManagedPost}
+                editorModeLabel={editorModeLabel}
+                selectedPostLabel={selectedPostLabel}
+                postTitle={postTitle}
+                postId={postId}
+                postVersion={postVersion}
+                isTempDraftMode={isTempDraftMode}
+                postVisibility={postVisibility}
+                currentVisibilityText={currentVisibilityText}
+                isContinueEditingDisabled={editorMode !== "edit" || disabled("modifyPost")}
+                isCreateNewPostDisabled={loadingKey.length > 0}
+                isDeletePostDisabled={disabled("deletePost")}
+                onContinueEditing={handleContinueSelectedPostEditing}
+                onCreateNewPost={handleCreateNewPostFromSelectedPanel}
+                onDeletePost={handleDeleteSelectedPost}
+                toolsPanel={
+                  <EditorStudioSelectedPostToolsPanel
+                    hasSelectedManagedPost={hasSelectedManagedPost}
+                    isDirectLoadOpen={isDirectLoadOpen}
+                    onToggleDirectLoad={() => setIsDirectLoadOpen((prev) => !prev)}
+                    isSelectedToolsOpen={isSelectedToolsOpen}
+                    onToggleSelectedTools={() => setIsSelectedToolsOpen((prev) => !prev)}
+                    postId={postId}
+                    onPostIdChange={handleSelectedPostIdChange}
+                    isLoadPostDisabled={disabled("postOne")}
+                    onLoadPost={() => void loadPostForEditor()}
+                    isHitPostDisabled={disabled("hitPost")}
+                    onRunHitPost={() =>
+                      void run("hitPost", () => apiFetch(`/post/api/v1/posts/${postId}/hit`, { method: "POST" }))
+                    }
+                    isLikePostDisabled={disabled("likePost")}
+                    onRunLikePost={() =>
+                      void run("likePost", () => apiFetch(`/post/api/v1/posts/${postId}/like`, { method: "PUT" }))
+                    }
+                  />
+                }
+              />
             </ContentStudioGrid>
 
             {softDeleteUndoState && (
@@ -5380,131 +5341,6 @@ const ListTableWrap = styled.div`
 
   @media (max-width: 1100px) {
     display: none;
-  }
-`
-
-const SelectedPostPanel = styled.div`
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  border-radius: 10px;
-  background: ${({ theme }) => theme.colors.gray1};
-  padding: 0.72rem;
-  margin: 0;
-  box-shadow: none;
-
-  @media (min-width: 1320px) {
-    position: sticky;
-    top: calc(var(--app-header-height, 56px) + 0.72rem);
-  }
-
-  @media (max-width: 420px) {
-    border-radius: 10px;
-    padding: 0.68rem;
-  }
-
-  @media (max-width: 720px) {
-    &[data-mobile-visible="false"] {
-      display: none;
-    }
-  }
-`
-
-const SelectedPostHeader = styled.div`
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.75rem;
-  margin-bottom: 0.72rem;
-
-  h3 {
-    margin: 0;
-    font-size: 0.94rem;
-    font-weight: 720;
-    color: ${({ theme }) => theme.colors.gray12};
-  }
-
-  p {
-    margin: 0.24rem 0 0;
-    font-size: 0.76rem;
-    line-height: 1.45;
-    color: ${({ theme }) => theme.colors.gray11};
-  }
-
-  @media (max-width: 720px) {
-    flex-direction: column;
-  }
-`
-
-const SelectedPostBadge = styled.span`
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  padding: 0.3rem 0.62rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray12};
-  font-size: 0.74rem;
-  font-weight: 700;
-  white-space: nowrap;
-
-  @media (max-width: 420px) {
-    white-space: normal;
-    line-height: 1.45;
-  }
-`
-
-const SelectedPostStateCard = styled.div`
-  display: grid;
-  gap: 0.52rem;
-  padding: 0.72rem 0.76rem;
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
-  margin-bottom: 0.72rem;
-
-  &[data-tone="active"] {
-    border-color: ${({ theme }) => theme.colors.blue7};
-    background: ${({ theme }) => theme.colors.blue3};
-  }
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.84rem;
-    font-weight: 760;
-    line-height: 1.45;
-  }
-
-  p {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.76rem;
-    line-height: 1.58;
-  }
-
-  .headline {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.55rem;
-    flex-wrap: wrap;
-  }
-
-  .meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.42rem;
-  }
-
-  .meta span {
-    display: inline-flex;
-    align-items: center;
-    min-height: 28px;
-    border-radius: 999px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: transparent;
-    color: ${({ theme }) => theme.colors.gray11};
-    padding: 0 0.62rem;
-    font-size: 0.74rem;
-    font-weight: 700;
   }
 `
 

--- a/front/src/routes/Admin/EditorStudioSelectedPostPanel.tsx
+++ b/front/src/routes/Admin/EditorStudioSelectedPostPanel.tsx
@@ -1,0 +1,361 @@
+import type { ReactNode } from "react"
+import styled from "@emotion/styled"
+
+import type { PostVisibility } from "./editorStudioState"
+
+type EditorStudioSelectedPostPanelProps = {
+  mobileVisible: boolean
+  hasSelectedManagedPost: boolean
+  editorModeLabel: string
+  selectedPostLabel: string
+  postTitle: string
+  postId: string
+  postVersion: number | null
+  isTempDraftMode: boolean
+  postVisibility: PostVisibility
+  currentVisibilityText: string
+  isContinueEditingDisabled: boolean
+  isCreateNewPostDisabled: boolean
+  isDeletePostDisabled: boolean
+  onContinueEditing: () => void
+  onCreateNewPost: () => void
+  onDeletePost: () => void
+  toolsPanel: ReactNode
+}
+
+export const EditorStudioSelectedPostPanel = ({
+  mobileVisible,
+  hasSelectedManagedPost,
+  editorModeLabel,
+  selectedPostLabel,
+  postTitle,
+  postId,
+  postVersion,
+  isTempDraftMode,
+  postVisibility,
+  currentVisibilityText,
+  isContinueEditingDisabled,
+  isCreateNewPostDisabled,
+  isDeletePostDisabled,
+  onContinueEditing,
+  onCreateNewPost,
+  onDeletePost,
+  toolsPanel,
+}: EditorStudioSelectedPostPanelProps) => (
+  <SelectedPostPanel data-mobile-visible={mobileVisible}>
+    <SelectedPostHeader>
+      <div>
+        <h3>{hasSelectedManagedPost ? "선택한 글" : "빠른 작업"}</h3>
+        <p>
+          {hasSelectedManagedPost
+            ? "선택한 글만 바로 이어서 다룹니다."
+            : "새 글 작성이나 번호 불러오기만 남깁니다."}
+        </p>
+      </div>
+      <SelectedPostBadge>{`${editorModeLabel} · ${selectedPostLabel}`}</SelectedPostBadge>
+    </SelectedPostHeader>
+    {hasSelectedManagedPost ? (
+      <>
+        <SelectedPostStateCard data-tone="active">
+          <div className="headline">
+            <strong>{postTitle.trim() || "제목 없음"}</strong>
+            {isTempDraftMode ? (
+              <LoadedBadge>임시 저장</LoadedBadge>
+            ) : (
+              <VisibilityBadge data-tone={postVisibility}>{currentVisibilityText}</VisibilityBadge>
+            )}
+          </div>
+          <p>추가 작업은 필요할 때만 엽니다.</p>
+          <div className="meta">
+            <span>{`post id #${postId}`}</span>
+            <span>{`버전 ${postVersion ?? "-"}`}</span>
+          </div>
+        </SelectedPostStateCard>
+        <ActionRow>
+          <PrimaryButton
+            type="button"
+            disabled={isContinueEditingDisabled}
+            onClick={onContinueEditing}
+          >
+            편집 계속
+          </PrimaryButton>
+          <Button
+            type="button"
+            disabled={isCreateNewPostDisabled}
+            onClick={onCreateNewPost}
+          >
+            새 글 작성
+          </Button>
+          <Button
+            type="button"
+            data-variant="danger"
+            disabled={isDeletePostDisabled}
+            onClick={onDeletePost}
+          >
+            글 삭제
+          </Button>
+        </ActionRow>
+      </>
+    ) : (
+      <>
+        <SelectedPostStateCard data-tone="idle">
+          <strong>목록에서 글을 고르면 바로 이어집니다.</strong>
+          <p>새 글 작성이나 번호 불러오기만 사용합니다.</p>
+        </SelectedPostStateCard>
+        <ActionRow>
+          <PrimaryButton
+            type="button"
+            disabled={isCreateNewPostDisabled}
+            onClick={onCreateNewPost}
+          >
+            새 글 작성 시작
+          </PrimaryButton>
+        </ActionRow>
+      </>
+    )}
+    {toolsPanel}
+  </SelectedPostPanel>
+)
+
+const SelectedPostPanel = styled.div`
+  border: 1px solid ${({ theme }) => theme.colors.gray5};
+  border-radius: 10px;
+  background: ${({ theme }) => theme.colors.gray1};
+  padding: 0.72rem;
+  margin: 0;
+  box-shadow: none;
+
+  @media (min-width: 1320px) {
+    position: sticky;
+    top: calc(var(--app-header-height, 56px) + 0.72rem);
+  }
+
+  @media (max-width: 420px) {
+    border-radius: 10px;
+    padding: 0.68rem;
+  }
+
+  @media (max-width: 720px) {
+    &[data-mobile-visible="false"] {
+      display: none;
+    }
+  }
+`
+
+const SelectedPostHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.72rem;
+
+  h3 {
+    margin: 0;
+    font-size: 0.94rem;
+    font-weight: 720;
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  p {
+    margin: 0.24rem 0 0;
+    font-size: 0.76rem;
+    line-height: 1.45;
+    color: ${({ theme }) => theme.colors.gray11};
+  }
+
+  @media (max-width: 720px) {
+    flex-direction: column;
+  }
+`
+
+const SelectedPostBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.3rem 0.62rem;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray12};
+  font-size: 0.74rem;
+  font-weight: 700;
+  white-space: nowrap;
+
+  @media (max-width: 420px) {
+    white-space: normal;
+    line-height: 1.45;
+  }
+`
+
+const SelectedPostStateCard = styled.div`
+  display: grid;
+  gap: 0.52rem;
+  padding: 0.72rem 0.76rem;
+  border-radius: 12px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray2};
+  margin-bottom: 0.72rem;
+
+  &[data-tone="active"] {
+    border-color: ${({ theme }) => theme.colors.blue7};
+    background: ${({ theme }) => theme.colors.blue3};
+  }
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.84rem;
+    font-weight: 760;
+    line-height: 1.45;
+  }
+
+  p {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.76rem;
+    line-height: 1.58;
+  }
+
+  .headline {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.55rem;
+    flex-wrap: wrap;
+  }
+
+  .meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.42rem;
+  }
+
+  .meta span {
+    display: inline-flex;
+    align-items: center;
+    min-height: 28px;
+    border-radius: 999px;
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: transparent;
+    color: ${({ theme }) => theme.colors.gray11};
+    padding: 0 0.62rem;
+    font-size: 0.74rem;
+    font-weight: 700;
+  }
+`
+
+const ActionRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 0.85rem;
+  align-items: center;
+
+  > button {
+    min-width: 8.8rem;
+  }
+
+  @media (max-width: 720px) {
+    display: grid;
+    grid-template-columns: 1fr;
+
+    > button {
+      width: 100%;
+    }
+  }
+`
+
+const Button = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &[data-variant="danger"] {
+    border-color: ${({ theme }) => theme.colors.red8};
+    background: ${({ theme }) => theme.colors.red3};
+    color: ${({ theme }) => theme.colors.red11};
+  }
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+const PrimaryButton = styled(Button)`
+  border-radius: 8px;
+  padding: 0.6rem 0.88rem;
+  border-color: ${({ theme }) => theme.colors.blue9};
+  background: ${({ theme }) => theme.colors.blue9};
+  color: ${({ theme }) => theme.colors.gray1};
+  font-weight: 700;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.blue10};
+    background: ${({ theme }) => theme.colors.blue10};
+    color: ${({ theme }) => theme.colors.gray1};
+  }
+`
+
+const LoadedBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.blue7};
+  background: ${({ theme }) => theme.colors.blue3};
+  color: ${({ theme }) => theme.colors.blue11};
+  padding: 0 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 800;
+  line-height: 1;
+  flex: 0 0 auto;
+`
+
+const VisibilityBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.16rem 0.46rem;
+  font-size: 0.72rem;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  color: ${({ theme }) => theme.colors.gray11};
+  background: ${({ theme }) => theme.colors.gray2};
+
+  &[data-tone="PRIVATE"] {
+    color: ${({ theme }) => theme.colors.gray11};
+  }
+
+  &[data-tone="PUBLIC_UNLISTED"] {
+    color: ${({ theme }) => theme.colors.blue11};
+    border-color: ${({ theme }) => theme.colors.blue7};
+    background: ${({ theme }) => theme.colors.blue3};
+  }
+
+  &[data-tone="PUBLIC_LISTED"] {
+    color: ${({ theme }) => theme.colors.green11};
+    border-color: ${({ theme }) => theme.colors.green7};
+    background: ${({ theme }) => theme.colors.green3};
+  }
+`


### PR DESCRIPTION
## 관련 이슈

close #193

## 작업 배경

- `EditorStudioPage.tsx`의 선택 글 panel header/state/action JSX를 전용 패널 컴포넌트로 분리했습니다.
- 코드 영향 범위가 섞이지 않도록 편집 계속/새 글 작성/글 삭제 흐름 호출은 기존 page callback에만 유지했습니다.

## 작업 내용

- `EditorStudioSelectedPostPanel`을 추가해 선택 글/빠른 작업 panel UI와 기존 스타일을 이동했습니다.
- `EditorStudioPage`는 새 패널을 1회 렌더하고, `handleContinueSelectedPostEditing`, `handleCreateNewPostFromSelectedPanel`, `handleDeleteSelectedPost` callback만 소유하도록 정리했습니다.
- source guard가 새 패널의 `openPublishModal`, `switchToCreateMode`, `openDeleteConfirm`, `apiFetch`, `run` 직접 결합과 page direct panel markup 재도입을 막도록 확장됐습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --grep "writer surface의 table column boundary drag는 native text selection 없이 guide만 남긴다" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `node front/scripts/check-bundle-size.mjs`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 새 패널은 표시 전용으로 제한했고, 편집/삭제/create flow 실행은 page callback에 유지했습니다. source guard가 이 경계를 검사합니다.
- 영향 확인: 변경 파일은 Admin editor page, 새 selected-post panel, source guard로 한정됩니다. `/editor/new`와 `/editor/[id]` build first-load JS는 `204 kB`로 이전 PR 기준과 동일했고, `/admin` bundle-size는 raw `423.3KB / 430.5KB`, gzip `133.6KB / 135.2KB`, brotli `114.6KB / 117.5KB`로 모두 예산 내 OK입니다.
- 검증 중 1차 `editor-authoring-flow` 전체 실행에서 writer table column boundary drag guide가 1회 누락됐으나, 이번 diff가 건드리지 않은 `front/src/components/editor/**`/QA writer 영역의 hover timing flake로 분류했습니다. 같은 테스트 targeted rerun과 전체 rerun은 통과했습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 `EditorStudioPage` 내부 선택 글 panel JSX 경로로 되돌릴 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
