### PR TITLE
[Refactor] EditorStudio legacy profile section 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -208,6 +208,14 @@ test.describe("editor studio state", () => {
     const editorStudioSelectedPostPanelSource = existsSync(editorStudioSelectedPostPanelPath)
       ? readFileSync(editorStudioSelectedPostPanelPath, "utf8")
       : ""
+    const editorStudioLegacyProfileSectionPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioLegacyProfileSection.tsx"
+    )
+    expect(existsSync(editorStudioLegacyProfileSectionPath)).toBe(true)
+    const editorStudioLegacyProfileSectionSource = existsSync(editorStudioLegacyProfileSectionPath)
+      ? readFileSync(editorStudioLegacyProfileSectionPath, "utf8")
+      : ""
     const blockEditorShellSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorShell.tsx"), "utf8")
     const blockEditorEngineSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tsx"), "utf8")
     const blockSelectionModelSource = readFileSync(
@@ -392,6 +400,22 @@ test.describe("editor studio state", () => {
     expect(editorStudioSelectedPostPanelSource).not.toContain("openDeleteConfirm")
     expect(editorStudioSelectedPostPanelSource).not.toContain("apiFetch(")
     expect(editorStudioSelectedPostPanelSource).not.toContain("run(")
+    expect(editorStudioLegacyProfileSectionSource).toContain("export const EditorStudioLegacyProfileSection =")
+    expect(editorStudioSource).toContain(
+      'import { EditorStudioLegacyProfileSection } from "./EditorStudioLegacyProfileSection"'
+    )
+    expect(editorStudioSource.match(/<EditorStudioLegacyProfileSection/g)?.length).toBe(1)
+    expect(editorStudioLegacyProfileSectionSource).toContain("Profile Studio")
+    expect(editorStudioLegacyProfileSectionSource).toContain("프로필 이미지 선택")
+    expect(editorStudioLegacyProfileSectionSource).toContain("역할/소개 저장")
+    expect(editorStudioSource).not.toContain("<ProfileStudioGrid>")
+    expect(editorStudioSource).not.toContain("const ProfileStudioGrid = styled.div`")
+    expect(editorStudioSource).not.toContain("const ProfileCardPanel = styled.div`")
+    expect(editorStudioSource).not.toContain("const ProfileCurrentGrid = styled.div`")
+    expect(editorStudioLegacyProfileSectionSource).not.toContain("apiFetch(")
+    expect(editorStudioLegacyProfileSectionSource).not.toContain("run(")
+    expect(editorStudioLegacyProfileSectionSource).not.toContain("setProfileRoleInput")
+    expect(editorStudioLegacyProfileSectionSource).not.toContain("setProfileBioInput")
     expect(editorStudioStateSource).toContain("export type PostVisibility =")
     expect(editorStudioStateSource).toContain("export const toVisibility")
     expect(editorStudioStateSource).toContain("export const toFlags")

--- a/front/src/routes/Admin/EditorStudioLegacyProfileSection.tsx
+++ b/front/src/routes/Admin/EditorStudioLegacyProfileSection.tsx
@@ -1,0 +1,533 @@
+import type { RefObject } from "react"
+import styled from "@emotion/styled"
+
+import ProfileImage from "src/components/ProfileImage"
+
+type NoticeState = {
+  tone: "idle" | "loading" | "success" | "error"
+  text: string
+}
+
+type EditorStudioLegacyProfileSectionProps = {
+  displayName: string
+  displayNameInitial: string
+  profilePreviewSrc: string
+  profileRoleInput: string
+  profileBioInput: string
+  profileImageFileInputRef: RefObject<HTMLInputElement>
+  profileImageHint: string
+  profileImageNotice: NoticeState
+  profileNotice: NoticeState
+  profileImageStatus: string
+  profileRoleStatus: string
+  profileBioStatus: string
+  profileUpdatedText: string
+  isProfileImageUploadDisabled: boolean
+  isProfileImageUploading: boolean
+  isProfileRefreshDisabled: boolean
+  isProfileCardUpdateDisabled: boolean
+  onProfileImageSelected: (file: File | null, fileName: string) => void
+  onProfileRoleChange: (value: string) => void
+  onProfileBioChange: (value: string) => void
+  onRefreshAdminProfile: () => void
+  onUpdateMemberProfileCard: () => void
+}
+
+export const EditorStudioLegacyProfileSection = ({
+  displayName,
+  displayNameInitial,
+  profilePreviewSrc,
+  profileRoleInput,
+  profileBioInput,
+  profileImageFileInputRef,
+  profileImageHint,
+  profileImageNotice,
+  profileNotice,
+  profileImageStatus,
+  profileRoleStatus,
+  profileBioStatus,
+  profileUpdatedText,
+  isProfileImageUploadDisabled,
+  isProfileImageUploading,
+  isProfileRefreshDisabled,
+  isProfileCardUpdateDisabled,
+  onProfileImageSelected,
+  onProfileRoleChange,
+  onProfileBioChange,
+  onRefreshAdminProfile,
+  onUpdateMemberProfileCard,
+}: EditorStudioLegacyProfileSectionProps) => (
+  <Section id="profile-studio">
+    <SectionTop>
+      <div>
+        <SectionEyebrow>Profile Studio</SectionEyebrow>
+        <h2>관리자 프로필 관리</h2>
+        <SectionDescription>
+          현재 로그인한 관리자 1명의 프로필만 여기서 수정합니다. 프로필 사진은 파일 선택 즉시
+          업로드되고, 역할과 소개 문구는 별도 저장으로 반영됩니다.
+        </SectionDescription>
+      </div>
+    </SectionTop>
+    <ProfileStudioGrid>
+      <ProfileCardPanel>
+        <ProfilePreview>
+          {profilePreviewSrc ? (
+            <ProfileImage
+              className="previewImage"
+              src={profilePreviewSrc}
+              alt="profile preview"
+              width={120}
+              height={120}
+              priority
+            />
+          ) : (
+            <ProfileFallback>{displayNameInitial}</ProfileFallback>
+          )}
+        </ProfilePreview>
+        <ProfileSummary>
+          <strong>{displayName}</strong>
+          <span>{profileRoleInput.trim() || "역할을 아직 입력하지 않았습니다."}</span>
+          <p>{profileBioInput.trim() || "소개 문구를 입력하면 메인 프로필 카드에 반영됩니다."}</p>
+        </ProfileSummary>
+        <input
+          ref={profileImageFileInputRef}
+          type="file"
+          accept="image/*"
+          style={{ display: "none" }}
+          onChange={(event) => {
+            const file = event.target.files?.[0] ?? null
+            onProfileImageSelected(file, file?.name || "")
+          }}
+        />
+        <PrimaryButton
+          type="button"
+          disabled={isProfileImageUploadDisabled}
+          onClick={() => profileImageFileInputRef.current?.click()}
+        >
+          {isProfileImageUploading ? "업로드 중..." : "프로필 이미지 선택"}
+        </PrimaryButton>
+        <InlineHint title={profileImageHint}>{profileImageHint}</InlineHint>
+        <InlineStatus data-tone={profileImageNotice.tone}>{profileImageNotice.text}</InlineStatus>
+      </ProfileCardPanel>
+
+      <FormPanelCard>
+        <ProfileCurrentGrid>
+          <ProfileCurrentItem>
+            <label>현재 프로필 이미지</label>
+            <strong>{profileImageStatus}</strong>
+          </ProfileCurrentItem>
+          <ProfileCurrentItem>
+            <label>현재 역할</label>
+            <strong>{profileRoleStatus}</strong>
+          </ProfileCurrentItem>
+          <ProfileCurrentItem className="wide">
+            <label>현재 소개</label>
+            <strong>{profileBioStatus}</strong>
+          </ProfileCurrentItem>
+          <ProfileCurrentItem>
+            <label>최종 수정 시각</label>
+            <strong>{profileUpdatedText}</strong>
+          </ProfileCurrentItem>
+        </ProfileCurrentGrid>
+        <FieldGrid>
+          <FieldBox>
+            <FieldLabel htmlFor="profile-role">프로필 역할</FieldLabel>
+            <Input
+              id="profile-role"
+              placeholder="예: backend developer"
+              value={profileRoleInput}
+              onChange={(event) => onProfileRoleChange(event.target.value)}
+            />
+          </FieldBox>
+          <FieldBox className="wide">
+            <FieldLabel htmlFor="profile-bio">소개 문구</FieldLabel>
+            <ProfileBioTextArea
+              id="profile-bio"
+              placeholder="메인 페이지 소개문구"
+              value={profileBioInput}
+              onChange={(event) => onProfileBioChange(event.target.value)}
+            />
+          </FieldBox>
+        </FieldGrid>
+        <ActionRow>
+          <Button type="button" disabled={isProfileRefreshDisabled} onClick={onRefreshAdminProfile}>
+            현재 저장값 다시 불러오기
+          </Button>
+          <PrimaryButton type="button" disabled={isProfileCardUpdateDisabled} onClick={onUpdateMemberProfileCard}>
+            역할/소개 저장
+          </PrimaryButton>
+        </ActionRow>
+        <InlineStatus data-tone={profileNotice.tone}>{profileNotice.text}</InlineStatus>
+      </FormPanelCard>
+    </ProfileStudioGrid>
+  </Section>
+)
+
+const Section = styled.section`
+  border: 1px solid ${({ theme }) => theme.colors.gray5};
+  border-radius: 14px;
+  padding: 0.9rem;
+  margin-bottom: 1.2rem;
+  background: ${({ theme }) => theme.colors.gray2};
+  box-shadow: none;
+
+  h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  @media (max-width: 420px) {
+    border-radius: 12px;
+    padding: 0.74rem;
+    margin-bottom: 0.95rem;
+  }
+`
+
+const SectionTop = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.95rem;
+`
+
+const SectionEyebrow = styled.span`
+  display: none;
+`
+
+const SectionDescription = styled.p`
+  margin: 0.22rem 0 0;
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.82rem;
+  line-height: 1.5;
+`
+
+const ProfileStudioGrid = styled.div`
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 0.9rem;
+  align-items: start;
+
+  @media (max-width: 980px) {
+    grid-template-columns: 1fr;
+  }
+`
+
+const ProfileCardPanel = styled.div`
+  border-radius: 0;
+  border: 0;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: transparent;
+  padding: 0 0 0.9rem;
+  display: grid;
+  gap: 0.85rem;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  justify-items: center;
+  text-align: center;
+  align-content: start;
+`
+
+const ProfilePreview = styled.div`
+  display: grid;
+  place-items: center;
+  padding: 0.15rem;
+  width: 124px;
+  height: 124px;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: transparent;
+  overflow: hidden;
+  flex-shrink: 0;
+
+  .previewImage {
+    width: 120px;
+    height: 120px;
+    object-fit: cover;
+    object-position: center 38%;
+    border-radius: 999px;
+    display: block;
+    border: none;
+  }
+`
+
+const ProfileFallback = styled.div`
+  width: 120px;
+  height: 120px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  background: ${({ theme }) => theme.colors.gray4};
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: 1.6rem;
+  font-weight: 800;
+`
+
+const ProfileSummary = styled.div`
+  display: grid;
+  gap: 0.18rem;
+  width: 100%;
+  min-width: 0;
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 1rem;
+    overflow-wrap: anywhere;
+  }
+
+  span {
+    color: ${({ theme }) => theme.colors.blue11};
+    font-size: 0.84rem;
+    font-weight: 600;
+    overflow-wrap: anywhere;
+  }
+
+  p {
+    margin: 0.2rem 0 0;
+    color: ${({ theme }) => theme.colors.gray11};
+    line-height: 1.6;
+    font-size: 0.85rem;
+    white-space: pre-line;
+    overflow-wrap: anywhere;
+  }
+`
+
+const InlineHint = styled.p`
+  margin: 0;
+  width: 100%;
+  min-width: 0;
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: 0.8rem;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+`
+
+const FormPanelCard = styled.div`
+  border-radius: 0;
+  border: 0;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: transparent;
+  padding: 0 0 0.9rem;
+`
+
+const ProfileCurrentGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin-bottom: 0.85rem;
+
+  @media (max-width: 720px) {
+    grid-template-columns: 1fr;
+  }
+`
+
+const ProfileCurrentItem = styled.div`
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.56rem 0;
+  border-radius: 0;
+  border: 0;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: transparent;
+  min-width: 0;
+
+  &.wide {
+    grid-column: span 2;
+
+    @media (max-width: 720px) {
+      grid-column: span 1;
+    }
+
+    strong {
+      white-space: pre-line;
+    }
+  }
+
+  label {
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.74rem;
+    font-weight: 700;
+  }
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.86rem;
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+  }
+`
+
+const FieldGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+
+  @media (max-width: 720px) {
+    grid-template-columns: 1fr;
+  }
+`
+
+const FieldBox = styled.div`
+  display: grid;
+  gap: 0.26rem;
+
+  &.wide {
+    grid-column: span 2;
+
+    @media (max-width: 720px) {
+      grid-column: span 1;
+    }
+  }
+`
+
+const FieldLabel = styled.label`
+  font-size: 0.8rem;
+  font-weight: 650;
+  color: ${({ theme }) => theme.colors.gray11};
+`
+
+const Input = styled.input`
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.72rem 0.8rem;
+  min-height: 44px;
+  min-width: 0;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray12};
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
+  }
+`
+
+const ProfileBioTextArea = styled.textarea`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.72rem 0.8rem;
+  min-height: 96px;
+  min-width: 0;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray12};
+  line-height: 1.6;
+  resize: vertical;
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
+  }
+`
+
+const ActionRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 0.85rem;
+  align-items: center;
+
+  > button {
+    min-width: 8.8rem;
+  }
+
+  @media (max-width: 720px) {
+    display: grid;
+    grid-template-columns: 1fr;
+
+    > button {
+      width: 100%;
+    }
+  }
+`
+
+const InlineStatus = styled.div`
+  margin-bottom: 0.85rem;
+  padding: 0.62rem 0.72rem;
+  border-radius: 8px;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+
+  &[data-tone="idle"] {
+    color: ${({ theme }) => theme.colors.gray11};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: transparent;
+  }
+
+  &[data-tone="loading"] {
+    color: ${({ theme }) => theme.colors.blue11};
+    border: 1px solid ${({ theme }) => theme.colors.blue7};
+    background: ${({ theme }) => theme.colors.blue3};
+  }
+
+  &[data-tone="success"] {
+    color: ${({ theme }) => theme.colors.green11};
+    border: 1px solid ${({ theme }) => theme.colors.green7};
+    background: ${({ theme }) => theme.colors.green3};
+  }
+
+  &[data-tone="error"] {
+    color: ${({ theme }) => theme.colors.red11};
+    border: 1px solid ${({ theme }) => theme.colors.red7};
+    background: ${({ theme }) => theme.colors.red3};
+  }
+`
+
+const Button = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+const PrimaryButton = styled(Button)`
+  border-radius: 8px;
+  padding: 0.6rem 0.88rem;
+  border-color: ${({ theme }) => theme.colors.blue9};
+  background: ${({ theme }) => theme.colors.blue9};
+  color: ${({ theme }) => theme.colors.gray1};
+  font-weight: 700;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.blue10};
+    background: ${({ theme }) => theme.colors.blue10};
+    color: ${({ theme }) => theme.colors.gray1};
+  }
+`

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -55,6 +55,7 @@ import { EditorStudioComposeAssistantPanel } from "./EditorStudioComposeAssistan
 import { EditorStudioMetadataAssistantPanel } from "./EditorStudioMetadataAssistantPanel"
 import { EditorStudioSelectedPostPanel } from "./EditorStudioSelectedPostPanel"
 import { EditorStudioSelectedPostToolsPanel } from "./EditorStudioSelectedPostToolsPanel"
+import { EditorStudioLegacyProfileSection } from "./EditorStudioLegacyProfileSection"
 import {
   isServerTempDraftPost,
   TEMP_DRAFT_BODY_PLACEHOLDER,
@@ -1902,6 +1903,13 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
     }
   }
 
+  const handleProfileImageSelected = (file: File | null, fileName: string) => {
+    setProfileImageFileName(fileName)
+    if (file) {
+      void handleUploadMemberProfileImage(file)
+    }
+  }
+
   const handleUpdateMemberProfileCard = async () => {
     if (!sessionMember?.id) {
       setResult(pretty({ error: "현재 관리자 정보를 확인할 수 없습니다." }))
@@ -1939,6 +1947,20 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
     } finally {
       setLoadingKey("")
     }
+  }
+
+  const handleRefreshAdminProfile = () => {
+    void run("admMemberProfileRefresh", async () => {
+      if (!member.id) throw new Error("현재 관리자 정보를 확인할 수 없습니다.")
+      setProfileNotice({ tone: "loading", text: "현재 저장값을 다시 불러오는 중입니다..." })
+      const refreshed = await refreshAdminProfile(member.id, member)
+      if (!refreshed) throw new Error("현재 저장값을 불러오지 못했습니다.")
+      setProfileNotice({
+        tone: "success",
+        text: "현재 저장값을 다시 불러왔습니다. 입력창과 미리보기가 최신 상태입니다.",
+      })
+      return refreshed as unknown as JsonValue
+    })
   }
 
   useEffect(() => {
@@ -2658,133 +2680,30 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
       <WorkspaceGrid>
         <WorkspaceMain>
           {SHOW_LEGACY_PROFILE_STUDIO && (
-          <Section id="profile-studio">
-            <SectionTop>
-              <div>
-                <SectionEyebrow>Profile Studio</SectionEyebrow>
-                <h2>관리자 프로필 관리</h2>
-                <SectionDescription>
-                  현재 로그인한 관리자 1명의 프로필만 여기서 수정합니다. 프로필 사진은 파일 선택 즉시
-                  업로드되고, 역할과 소개 문구는 별도 저장으로 반영됩니다.
-                </SectionDescription>
-              </div>
-            </SectionTop>
-            <ProfileStudioGrid>
-              <ProfileCardPanel>
-                <ProfilePreview>
-                  {profilePreviewSrc ? (
-                    <ProfileImage
-                      className="previewImage"
-                      src={profilePreviewSrc}
-                      alt="profile preview"
-                      width={120}
-                      height={120}
-                      priority
-                    />
-                  ) : (
-                    <ProfileFallback>{displayNameInitial}</ProfileFallback>
-                  )}
-                </ProfilePreview>
-                <ProfileSummary>
-                  <strong>{displayName}</strong>
-                  <span>{profileRoleInput.trim() || "역할을 아직 입력하지 않았습니다."}</span>
-                  <p>{profileBioInput.trim() || "소개 문구를 입력하면 메인 프로필 카드에 반영됩니다."}</p>
-                </ProfileSummary>
-                <input
-                  ref={profileImageFileInputRef}
-                  type="file"
-                  accept="image/*"
-                  style={{ display: "none" }}
-                  onChange={(e) => {
-                    const file = e.target.files?.[0]
-                    setProfileImageFileName(file?.name || "")
-                    if (file) {
-                      void handleUploadMemberProfileImage(file)
-                    }
-                  }}
-                />
-                <PrimaryButton
-                  type="button"
-                  disabled={disabled("admMemberProfileImgUpdate")}
-                  onClick={() => profileImageFileInputRef.current?.click()}
-                >
-                  {loadingKey === "admMemberProfileImgUpdate" ? "업로드 중..." : "프로필 이미지 선택"}
-                </PrimaryButton>
-                <InlineHint title={profileImageHint}>{profileImageHint}</InlineHint>
-                <InlineStatus data-tone={profileImageNotice.tone}>{profileImageNotice.text}</InlineStatus>
-              </ProfileCardPanel>
-
-              <FormPanelCard>
-                <ProfileCurrentGrid>
-                  <ProfileCurrentItem>
-                    <label>현재 프로필 이미지</label>
-                    <strong>{profileImageStatus}</strong>
-                  </ProfileCurrentItem>
-                  <ProfileCurrentItem>
-                    <label>현재 역할</label>
-                    <strong>{profileRoleStatus}</strong>
-                  </ProfileCurrentItem>
-                  <ProfileCurrentItem className="wide">
-                    <label>현재 소개</label>
-                    <strong>{profileBioStatus}</strong>
-                  </ProfileCurrentItem>
-                  <ProfileCurrentItem>
-                    <label>최종 수정 시각</label>
-                    <strong>{profileUpdatedText}</strong>
-                  </ProfileCurrentItem>
-                </ProfileCurrentGrid>
-                <FieldGrid>
-                  <FieldBox>
-                    <FieldLabel htmlFor="profile-role">프로필 역할</FieldLabel>
-                    <Input
-                      id="profile-role"
-                      placeholder="예: backend developer"
-                      value={profileRoleInput}
-                      onChange={(e) => setProfileRoleInput(e.target.value)}
-                    />
-                  </FieldBox>
-                  <FieldBox className="wide">
-                    <FieldLabel htmlFor="profile-bio">소개 문구</FieldLabel>
-                    <ProfileBioTextArea
-                      id="profile-bio"
-                      placeholder="메인 페이지 소개문구"
-                      value={profileBioInput}
-                      onChange={(e) => setProfileBioInput(e.target.value)}
-                    />
-                  </FieldBox>
-                </FieldGrid>
-                <ActionRow>
-                  <Button
-                    type="button"
-                    disabled={disabled("admMemberProfileRefresh")}
-                    onClick={() =>
-                      run("admMemberProfileRefresh", async () => {
-                        if (!member.id) throw new Error("현재 관리자 정보를 확인할 수 없습니다.")
-                        setProfileNotice({ tone: "loading", text: "현재 저장값을 다시 불러오는 중입니다..." })
-                        const refreshed = await refreshAdminProfile(member.id, member)
-                        if (!refreshed) throw new Error("현재 저장값을 불러오지 못했습니다.")
-                        setProfileNotice({
-                          tone: "success",
-                          text: "현재 저장값을 다시 불러왔습니다. 입력창과 미리보기가 최신 상태입니다.",
-                        })
-                        return refreshed as unknown as JsonValue
-                      })
-                    }
-                  >
-                    현재 저장값 다시 불러오기
-                  </Button>
-                  <PrimaryButton
-                    type="button"
-                    disabled={disabled("admMemberProfileCardUpdate")}
-                    onClick={() => void handleUpdateMemberProfileCard()}
-                  >
-                    역할/소개 저장
-                  </PrimaryButton>
-                </ActionRow>
-                <InlineStatus data-tone={profileNotice.tone}>{profileNotice.text}</InlineStatus>
-              </FormPanelCard>
-            </ProfileStudioGrid>
-          </Section>
+            <EditorStudioLegacyProfileSection
+              displayName={displayName}
+              displayNameInitial={displayNameInitial}
+              isProfileCardUpdateDisabled={disabled("admMemberProfileCardUpdate")}
+              isProfileImageUploadDisabled={disabled("admMemberProfileImgUpdate")}
+              isProfileImageUploading={loadingKey === "admMemberProfileImgUpdate"}
+              isProfileRefreshDisabled={disabled("admMemberProfileRefresh")}
+              profileBioInput={profileBioInput}
+              profileBioStatus={profileBioStatus}
+              profileImageFileInputRef={profileImageFileInputRef}
+              profileImageHint={profileImageHint}
+              profileImageNotice={profileImageNotice}
+              profileImageStatus={profileImageStatus}
+              profileNotice={profileNotice}
+              profilePreviewSrc={profilePreviewSrc}
+              profileRoleInput={profileRoleInput}
+              profileRoleStatus={profileRoleStatus}
+              profileUpdatedText={profileUpdatedText}
+              onProfileBioChange={setProfileBioInput}
+              onProfileImageSelected={handleProfileImageSelected}
+              onProfileRoleChange={setProfileRoleInput}
+              onRefreshAdminProfile={handleRefreshAdminProfile}
+              onUpdateMemberProfileCard={() => void handleUpdateMemberProfileCard()}
+            />
           )}
 
           {SHOW_LEGACY_CONTENT_STUDIO && (
@@ -4392,163 +4311,6 @@ const PresetButton = styled.button`
   }
 `
 
-const ProfileStudioGrid = styled.div`
-  display: grid;
-  grid-template-columns: 280px minmax(0, 1fr);
-  gap: 0.9rem;
-  align-items: start;
-
-  @media (max-width: 980px) {
-    grid-template-columns: 1fr;
-  }
-`
-
-const ProfileCardPanel = styled.div`
-  border-radius: 0;
-  border: 0;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: transparent;
-  padding: 0 0 0.9rem;
-  display: grid;
-  gap: 0.85rem;
-  width: 100%;
-  min-width: 0;
-  overflow: hidden;
-  justify-items: center;
-  text-align: center;
-  align-content: start;
-`
-
-const ProfilePreview = styled.div`
-  display: grid;
-  place-items: center;
-  padding: 0.15rem;
-  width: 124px;
-  height: 124px;
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: transparent;
-  overflow: hidden;
-  flex-shrink: 0;
-
-  .previewImage {
-    width: 120px;
-    height: 120px;
-    object-fit: cover;
-    object-position: center 38%;
-    border-radius: 999px;
-    display: block;
-    border: none;
-  }
-`
-
-const ProfileFallback = styled.div`
-  width: 120px;
-  height: 120px;
-  border-radius: 999px;
-  display: grid;
-  place-items: center;
-  background: ${({ theme }) => theme.colors.gray4};
-  color: ${({ theme }) => theme.colors.gray11};
-  font-size: 1.6rem;
-  font-weight: 800;
-`
-
-const ProfileSummary = styled.div`
-  display: grid;
-  gap: 0.18rem;
-  width: 100%;
-  min-width: 0;
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 1rem;
-    overflow-wrap: anywhere;
-  }
-
-  span {
-    color: ${({ theme }) => theme.colors.blue11};
-    font-size: 0.84rem;
-    font-weight: 600;
-    overflow-wrap: anywhere;
-  }
-
-  p {
-    margin: 0.2rem 0 0;
-    color: ${({ theme }) => theme.colors.gray11};
-    line-height: 1.6;
-    font-size: 0.85rem;
-    white-space: pre-line;
-    overflow-wrap: anywhere;
-  }
-`
-
-const InlineHint = styled.p`
-  margin: 0;
-  width: 100%;
-  min-width: 0;
-  color: ${({ theme }) => theme.colors.gray11};
-  font-size: 0.8rem;
-  line-height: 1.5;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-`
-
-const FormPanelCard = styled.div`
-  border-radius: 0;
-  border: 0;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: transparent;
-  padding: 0 0 0.9rem;
-`
-
-const ProfileCurrentGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.65rem;
-  margin-bottom: 0.85rem;
-
-  @media (max-width: 720px) {
-    grid-template-columns: 1fr;
-  }
-`
-
-const ProfileCurrentItem = styled.div`
-  display: grid;
-  gap: 0.2rem;
-  padding: 0.56rem 0;
-  border-radius: 0;
-  border: 0;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: transparent;
-  min-width: 0;
-
-  &.wide {
-    grid-column: span 2;
-
-    @media (max-width: 720px) {
-      grid-column: span 1;
-    }
-
-    strong {
-      white-space: pre-line;
-    }
-  }
-
-  label {
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.74rem;
-    font-weight: 700;
-  }
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.86rem;
-    line-height: 1.5;
-    overflow-wrap: anywhere;
-  }
-`
-
 const InlineStatus = styled.div`
   margin-bottom: 0.85rem;
   padding: 0.62rem 0.72rem;
@@ -4637,24 +4399,6 @@ const Input = styled.input`
   min-width: 0;
   background: transparent;
   color: ${({ theme }) => theme.colors.gray12};
-
-  &:focus-visible {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors.blue8};
-    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
-  }
-`
-
-const ProfileBioTextArea = styled.textarea`
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 8px;
-  padding: 0.72rem 0.8rem;
-  min-height: 96px;
-  min-width: 0;
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray12};
-  line-height: 1.6;
-  resize: vertical;
 
   &:focus-visible {
     outline: none;


### PR DESCRIPTION
## 관련 이슈

close #197

## 작업 배경

- `EditorStudioPage.tsx`에 남아 있던 hidden legacy profile studio section의 JSX와 profile-only styled components를 전용 presentational component로 분리했습니다.
- profile state, API 실행, `run` orchestration은 기존 page에 남기고 새 컴포넌트는 callback props만 호출하도록 유지했습니다.
- `EditorStudioPage.tsx`는 6,435 lines에서 6,179 lines로 줄었고, 구조 가드가 profile section 재결합을 막습니다.

## 작업 내용

- `EditorStudioLegacyProfileSection.tsx`를 추가해 legacy profile section 렌더링과 관련 스타일을 소유하게 했습니다.
- `EditorStudioPage.tsx`는 legacy profile section을 import/render하고, image upload와 profile refresh callback만 page orchestration으로 유지합니다.
- `editor-studio-state` 구조 가드에 새 component 존재, 단일 render, API/state setter 직접 소유 금지, page 내 profile-only styled component 제거 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - RED 확인: `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` 실패, `EditorStudioLegacyProfileSection.tsx` 미존재 가드 확인
  - GREEN 확인: `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` 16 passed
  - 반복 확인: `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` 16 passed
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` 73 passed
  - 반복 확인: `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` 73 passed
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` 16 passed
  - 반복 확인: `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` 16 passed
  - `git diff --check`
  - `CURRENT_TASK_SLUG=editor-studio-legacy-profile-section-split bash tools/guards/current-task-preflight.sh`

  참고: `editor-authoring-flow.spec.ts` 첫 실행에서 `table 셀 텍스트 selection bubble도 mouseup 이후에만 노출된다`가 1회 timeout으로 실패했으나, 이 PR은 hidden legacy profile section 분리만 다루며 같은 조건 재실행 2회가 연속 통과해 unrelated flake로 분류했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: callback props 전달 실수 시 hidden legacy profile studio의 profile image/profile text action이 동작하지 않을 수 있습니다. 구조 가드와 build/lint로 API/state 직접 소유와 타입 회귀를 막았습니다.
- 롤백 방법: 이 PR의 단일 커밋 `refactor(editor): legacy profile section 분리`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
