### PR TITLE
[Refactor] EditorStudio legacy utility result panel 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -216,6 +216,22 @@ test.describe("editor studio state", () => {
     const editorStudioLegacyProfileSectionSource = existsSync(editorStudioLegacyProfileSectionPath)
       ? readFileSync(editorStudioLegacyProfileSectionPath, "utf8")
       : ""
+    const editorStudioLegacyUtilityPanelPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioLegacyUtilityPanel.tsx"
+    )
+    expect(existsSync(editorStudioLegacyUtilityPanelPath)).toBe(true)
+    const editorStudioLegacyUtilityPanelSource = existsSync(editorStudioLegacyUtilityPanelPath)
+      ? readFileSync(editorStudioLegacyUtilityPanelPath, "utf8")
+      : ""
+    const editorStudioResultLogPanelPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioResultLogPanel.tsx"
+    )
+    expect(existsSync(editorStudioResultLogPanelPath)).toBe(true)
+    const editorStudioResultLogPanelSource = existsSync(editorStudioResultLogPanelPath)
+      ? readFileSync(editorStudioResultLogPanelPath, "utf8")
+      : ""
     const blockEditorShellSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorShell.tsx"), "utf8")
     const blockEditorEngineSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tsx"), "utf8")
     const blockSelectionModelSource = readFileSync(
@@ -416,6 +432,28 @@ test.describe("editor studio state", () => {
     expect(editorStudioLegacyProfileSectionSource).not.toContain("run(")
     expect(editorStudioLegacyProfileSectionSource).not.toContain("setProfileRoleInput")
     expect(editorStudioLegacyProfileSectionSource).not.toContain("setProfileBioInput")
+    expect(editorStudioLegacyUtilityPanelSource).toContain("export const EditorStudioLegacyUtilityPanel =")
+    expect(editorStudioSource).toContain(
+      'import { EditorStudioLegacyUtilityPanel } from "./EditorStudioLegacyUtilityPanel"'
+    )
+    expect(editorStudioSource.match(/<EditorStudioLegacyUtilityPanel/g)?.length).toBe(1)
+    expect(editorStudioLegacyUtilityPanelSource).toContain("댓글 테스트 도구")
+    expect(editorStudioLegacyUtilityPanelSource).toContain("운영 점검 도구")
+    expect(editorStudioSource).not.toContain("<UtilityGrid>")
+    expect(editorStudioSource).not.toContain("const UtilityGrid = styled.div`")
+    expect(editorStudioLegacyUtilityPanelSource).not.toContain("apiFetch(")
+    expect(editorStudioLegacyUtilityPanelSource).not.toContain("run(")
+    expect(editorStudioLegacyUtilityPanelSource).not.toContain("setPostId")
+    expect(editorStudioLegacyUtilityPanelSource).not.toContain("setCommentId")
+    expect(editorStudioLegacyUtilityPanelSource).not.toContain("setCommentContent")
+    expect(editorStudioResultLogPanelSource).toContain("export const EditorStudioResultLogPanel =")
+    expect(editorStudioSource).toContain(
+      'import { EditorStudioResultLogPanel } from "./EditorStudioResultLogPanel"'
+    )
+    expect(editorStudioSource.match(/<EditorStudioResultLogPanel/g)?.length).toBe(2)
+    expect(editorStudioSource).not.toContain("const ResultPanel = styled.pre`")
+    expect(editorStudioSource).not.toContain("const DevConsoleSection = styled.section`")
+    expect(editorStudioSource).not.toContain("const EditorStudioResultPanel = styled.section`")
     expect(editorStudioStateSource).toContain("export type PostVisibility =")
     expect(editorStudioStateSource).toContain("export const toVisibility")
     expect(editorStudioStateSource).toContain("export const toFlags")

--- a/front/src/routes/Admin/EditorStudioLegacyUtilityPanel.tsx
+++ b/front/src/routes/Admin/EditorStudioLegacyUtilityPanel.tsx
@@ -1,0 +1,262 @@
+import styled from "@emotion/styled"
+
+type EditorStudioLegacyUtilityPanelProps = {
+  postId: string
+  commentId: string
+  commentContent: string
+  isCommentListDisabled: boolean
+  isCommentOneDisabled: boolean
+  isCommentWriteDisabled: boolean
+  isCommentModifyDisabled: boolean
+  isCommentDeleteDisabled: boolean
+  isPostCountDisabled: boolean
+  isSystemHealthDisabled: boolean
+  onPostIdChange: (nextValue: string) => void
+  onCommentIdChange: (nextValue: string) => void
+  onCommentContentChange: (nextValue: string) => void
+  onListComments: () => void
+  onReadComment: () => void
+  onWriteComment: () => void
+  onModifyComment: () => void
+  onDeleteComment: () => void
+  onReadPostCount: () => void
+  onReadSystemHealth: () => void
+}
+
+export const EditorStudioLegacyUtilityPanel = ({
+  postId,
+  commentId,
+  commentContent,
+  isCommentListDisabled,
+  isCommentOneDisabled,
+  isCommentWriteDisabled,
+  isCommentModifyDisabled,
+  isCommentDeleteDisabled,
+  isPostCountDisabled,
+  isSystemHealthDisabled,
+  onPostIdChange,
+  onCommentIdChange,
+  onCommentContentChange,
+  onListComments,
+  onReadComment,
+  onWriteComment,
+  onModifyComment,
+  onDeleteComment,
+  onReadPostCount,
+  onReadSystemHealth,
+}: EditorStudioLegacyUtilityPanelProps) => (
+  <UtilityGrid>
+    <UtilitySection id="comment-studio">
+      <UtilitySectionTop>
+        <div>
+          <UtilitySectionEyebrow>댓글 점검</UtilitySectionEyebrow>
+          <h2>댓글 테스트 도구</h2>
+          <UtilitySectionDescription>댓글 CRUD 동작을 빠르게 점검할 때 사용하는 영역입니다.</UtilitySectionDescription>
+        </div>
+      </UtilitySectionTop>
+      <UtilityFieldGrid>
+        <UtilityFieldBox>
+          <UtilityFieldLabel htmlFor="comment-post-id">post id</UtilityFieldLabel>
+          <UtilityInput
+            id="comment-post-id"
+            placeholder="예: 1"
+            value={postId}
+            onChange={(event) => onPostIdChange(event.target.value)}
+          />
+        </UtilityFieldBox>
+        <UtilityFieldBox>
+          <UtilityFieldLabel htmlFor="comment-id">comment id</UtilityFieldLabel>
+          <UtilityInput
+            id="comment-id"
+            placeholder="예: 1"
+            value={commentId}
+            onChange={(event) => onCommentIdChange(event.target.value)}
+          />
+        </UtilityFieldBox>
+        <UtilityFieldBox className="wide">
+          <UtilityFieldLabel htmlFor="comment-content">comment content</UtilityFieldLabel>
+          <UtilityInput
+            id="comment-content"
+            placeholder="댓글 내용을 입력하세요"
+            value={commentContent}
+            onChange={(event) => onCommentContentChange(event.target.value)}
+          />
+        </UtilityFieldBox>
+      </UtilityFieldGrid>
+      <UtilityActionRow>
+        <UtilityButton type="button" disabled={isCommentListDisabled} onClick={onListComments}>
+          댓글 목록
+        </UtilityButton>
+        <UtilityButton type="button" disabled={isCommentOneDisabled} onClick={onReadComment}>
+          댓글 단건
+        </UtilityButton>
+        <UtilityButton type="button" disabled={isCommentWriteDisabled} onClick={onWriteComment}>
+          댓글 작성
+        </UtilityButton>
+        <UtilityButton type="button" disabled={isCommentModifyDisabled} onClick={onModifyComment}>
+          댓글 수정
+        </UtilityButton>
+        <UtilityButton type="button" disabled={isCommentDeleteDisabled} onClick={onDeleteComment}>
+          댓글 삭제
+        </UtilityButton>
+      </UtilityActionRow>
+    </UtilitySection>
+
+    <UtilitySection id="system-tools">
+      <UtilitySectionTop>
+        <div>
+          <UtilitySectionEyebrow>시스템 점검</UtilitySectionEyebrow>
+          <h2>운영 점검 도구</h2>
+          <UtilitySectionDescription>자주 확인하는 관리성 API를 한곳에 모았습니다.</UtilitySectionDescription>
+        </div>
+      </UtilitySectionTop>
+      <UtilityActionRow>
+        <UtilityButton type="button" disabled={isPostCountDisabled} onClick={onReadPostCount}>
+          전체 글 개수 확인
+        </UtilityButton>
+        <UtilityButton type="button" disabled={isSystemHealthDisabled} onClick={onReadSystemHealth}>
+          서버 상태 조회
+        </UtilityButton>
+      </UtilityActionRow>
+    </UtilitySection>
+  </UtilityGrid>
+)
+
+const UtilityGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+
+  @media (max-width: 980px) {
+    grid-template-columns: 1fr;
+  }
+`
+
+const UtilitySection = styled.section`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 12px;
+  padding: 1rem;
+  background: ${({ theme }) => theme.colors.gray2};
+`
+
+const UtilitySectionTop = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.95rem;
+`
+
+const UtilitySectionEyebrow = styled.span`
+  display: none;
+`
+
+const UtilitySectionDescription = styled.p`
+  margin: 0.22rem 0 0;
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.82rem;
+  line-height: 1.5;
+`
+
+const UtilityFieldGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+
+  @media (max-width: 720px) {
+    grid-template-columns: 1fr;
+  }
+`
+
+const UtilityFieldBox = styled.div`
+  display: grid;
+  gap: 0.26rem;
+
+  &.wide {
+    grid-column: span 2;
+
+    @media (max-width: 720px) {
+      grid-column: span 1;
+    }
+  }
+`
+
+const UtilityFieldLabel = styled.label`
+  font-size: 0.8rem;
+  font-weight: 650;
+  color: ${({ theme }) => theme.colors.gray11};
+`
+
+const UtilityInput = styled.input`
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.72rem 0.8rem;
+  min-height: 44px;
+  min-width: 0;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray12};
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
+  }
+`
+
+const UtilityActionRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 0.85rem;
+  align-items: center;
+
+  > button {
+    min-width: 8.8rem;
+  }
+
+  @media (max-width: 720px) {
+    display: grid;
+    grid-template-columns: 1fr;
+
+    > button {
+      width: 100%;
+    }
+  }
+`
+
+const UtilityButton = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -56,6 +56,8 @@ import { EditorStudioMetadataAssistantPanel } from "./EditorStudioMetadataAssist
 import { EditorStudioSelectedPostPanel } from "./EditorStudioSelectedPostPanel"
 import { EditorStudioSelectedPostToolsPanel } from "./EditorStudioSelectedPostToolsPanel"
 import { EditorStudioLegacyProfileSection } from "./EditorStudioLegacyProfileSection"
+import { EditorStudioLegacyUtilityPanel } from "./EditorStudioLegacyUtilityPanel"
+import { EditorStudioResultLogPanel } from "./EditorStudioResultLogPanel"
 import {
   isServerTempDraftPost,
   TEMP_DRAFT_BODY_PLACEHOLDER,
@@ -1963,6 +1965,48 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
     })
   }
 
+  const handleListComments = () => {
+    void run("commentList", () => apiFetch(`/post/api/v1/posts/${postId}/comments`))
+  }
+
+  const handleReadComment = () => {
+    void run("commentOne", () => apiFetch(`/post/api/v1/posts/${postId}/comments/${commentId}`))
+  }
+
+  const handleWriteComment = () => {
+    void run("commentWrite", () =>
+      apiFetch(`/post/api/v1/posts/${postId}/comments`, {
+        method: "POST",
+        body: JSON.stringify({ content: commentContent }),
+      })
+    )
+  }
+
+  const handleModifyComment = () => {
+    void run("commentModify", () =>
+      apiFetch(`/post/api/v1/posts/${postId}/comments/${commentId}`, {
+        method: "PUT",
+        body: JSON.stringify({ content: commentContent }),
+      })
+    )
+  }
+
+  const handleDeleteComment = () => {
+    void run("commentDelete", () =>
+      apiFetch(`/post/api/v1/posts/${postId}/comments/${commentId}`, {
+        method: "DELETE",
+      })
+    )
+  }
+
+  const handleReadPostCount = () => {
+    void run("admPostCount", () => apiFetch("/post/api/v1/adm/posts/count"))
+  }
+
+  const handleReadSystemHealth = () => {
+    void run("systemHealth", () => apiFetch("/system/api/v1/adm/health"))
+  }
+
   useEffect(() => {
     setCustomTagCatalog(readStoredCatalog(TAG_CATALOG_STORAGE_KEY))
     setCustomCategoryCatalog(
@@ -2470,15 +2514,15 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
   const dedicatedEditorResultPanel = useMemo(
     () =>
       shouldShowResultPanel ? (
-        <EditorStudioResultPanel>
-          <details open={Boolean(loadingKey)}>
-            <summary>
-              <strong>{loadingKey ? "작업 응답 확인 중" : "최근 작업 응답"}</strong>
-              <span>{loadingKey ? `실행 중: ${loadingKey}` : "원본 응답을 확인할 수 있습니다"}</span>
-            </summary>
-            <ResultPanel>{result || "// API 응답 결과가 여기에 표시됩니다."}</ResultPanel>
-          </details>
-        </EditorStudioResultPanel>
+        <EditorStudioResultLogPanel
+          idleDescription="원본 응답을 확인할 수 있습니다"
+          idleTitle="최근 작업 응답"
+          loadingDescription={(currentLoadingKey) => `실행 중: ${currentLoadingKey}`}
+          loadingKey={loadingKey}
+          loadingTitle="작업 응답 확인 중"
+          result={result}
+          variant="dedicated"
+        />
       ) : null,
     [loadingKey, result, shouldShowResultPanel]
   )
@@ -3615,150 +3659,43 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
         ) : null}
 
           {SHOW_LEGACY_UTILITY_STUDIO && (
-          <UtilityGrid>
-            <Section id="comment-studio">
-              <SectionTop>
-                <div>
-                  <SectionEyebrow>댓글 점검</SectionEyebrow>
-                  <h2>댓글 테스트 도구</h2>
-                  <SectionDescription>댓글 CRUD 동작을 빠르게 점검할 때 사용하는 영역입니다.</SectionDescription>
-                </div>
-              </SectionTop>
-              <FieldGrid>
-                <FieldBox>
-                  <FieldLabel htmlFor="comment-post-id">post id</FieldLabel>
-                  <Input
-                    id="comment-post-id"
-                    placeholder="예: 1"
-                    value={postId}
-                    onChange={(e) => setPostId(e.target.value)}
-                  />
-                </FieldBox>
-                <FieldBox>
-                  <FieldLabel htmlFor="comment-id">comment id</FieldLabel>
-                  <Input
-                    id="comment-id"
-                    placeholder="예: 1"
-                    value={commentId}
-                    onChange={(e) => setCommentId(e.target.value)}
-                  />
-                </FieldBox>
-                <FieldBox className="wide">
-                  <FieldLabel htmlFor="comment-content">comment content</FieldLabel>
-                  <Input
-                    id="comment-content"
-                    placeholder="댓글 내용을 입력하세요"
-                    value={commentContent}
-                    onChange={(e) => setCommentContent(e.target.value)}
-                  />
-                </FieldBox>
-              </FieldGrid>
-              <ActionRow>
-                <Button
-                  type="button"
-                  disabled={disabled("commentList")}
-                  onClick={() => run("commentList", () => apiFetch(`/post/api/v1/posts/${postId}/comments`))}
-                >
-                  댓글 목록
-                </Button>
-                <Button
-                  type="button"
-                  disabled={disabled("commentOne")}
-                  onClick={() =>
-                    run("commentOne", () => apiFetch(`/post/api/v1/posts/${postId}/comments/${commentId}`))
-                  }
-                >
-                  댓글 단건
-                </Button>
-                <Button
-                  type="button"
-                  disabled={disabled("commentWrite")}
-                  onClick={() =>
-                    run("commentWrite", () =>
-                      apiFetch(`/post/api/v1/posts/${postId}/comments`, {
-                        method: "POST",
-                        body: JSON.stringify({ content: commentContent }),
-                      })
-                    )
-                  }
-                >
-                  댓글 작성
-                </Button>
-                <Button
-                  type="button"
-                  disabled={disabled("commentModify")}
-                  onClick={() =>
-                    run("commentModify", () =>
-                      apiFetch(`/post/api/v1/posts/${postId}/comments/${commentId}`, {
-                        method: "PUT",
-                        body: JSON.stringify({ content: commentContent }),
-                      })
-                    )
-                  }
-                >
-                  댓글 수정
-                </Button>
-                <Button
-                  type="button"
-                  disabled={disabled("commentDelete")}
-                  onClick={() =>
-                    run("commentDelete", () =>
-                      apiFetch(`/post/api/v1/posts/${postId}/comments/${commentId}`, {
-                        method: "DELETE",
-                      })
-                    )
-                  }
-                >
-                  댓글 삭제
-                </Button>
-              </ActionRow>
-            </Section>
-
-            <Section id="system-tools">
-              <SectionTop>
-                <div>
-                  <SectionEyebrow>시스템 점검</SectionEyebrow>
-                  <h2>운영 점검 도구</h2>
-                  <SectionDescription>자주 확인하는 관리성 API를 한곳에 모았습니다.</SectionDescription>
-                </div>
-              </SectionTop>
-              <ActionRow>
-                <Button
-                  type="button"
-                  disabled={disabled("admPostCount")}
-                  onClick={() => run("admPostCount", () => apiFetch("/post/api/v1/adm/posts/count"))}
-                >
-                  전체 글 개수 확인
-                </Button>
-                <Button
-                  type="button"
-                  disabled={disabled("systemHealth")}
-                  onClick={() => run("systemHealth", () => apiFetch("/system/api/v1/adm/health"))}
-                >
-                  서버 상태 조회
-                </Button>
-              </ActionRow>
-            </Section>
-          </UtilityGrid>
+            <EditorStudioLegacyUtilityPanel
+              commentContent={commentContent}
+              commentId={commentId}
+              isCommentDeleteDisabled={disabled("commentDelete")}
+              isCommentListDisabled={disabled("commentList")}
+              isCommentModifyDisabled={disabled("commentModify")}
+              isCommentOneDisabled={disabled("commentOne")}
+              isCommentWriteDisabled={disabled("commentWrite")}
+              isPostCountDisabled={disabled("admPostCount")}
+              isSystemHealthDisabled={disabled("systemHealth")}
+              postId={postId}
+              onCommentContentChange={setCommentContent}
+              onCommentIdChange={setCommentId}
+              onDeleteComment={handleDeleteComment}
+              onListComments={handleListComments}
+              onModifyComment={handleModifyComment}
+              onPostIdChange={setPostId}
+              onReadComment={handleReadComment}
+              onReadPostCount={handleReadPostCount}
+              onReadSystemHealth={handleReadSystemHealth}
+              onWriteComment={handleWriteComment}
+            />
           )}
         </WorkspaceMain>
 
       </WorkspaceGrid>
 
-      {(loadingKey || result) && (
-        <DevConsoleSection>
-          <details open={Boolean(loadingKey)}>
-            <summary>
-              <div>
-                <SectionEyebrow>실행 로그</SectionEyebrow>
-                <strong>{loadingKey ? "작업 응답 확인 중" : "최근 작업 응답 보기"}</strong>
-              </div>
-              <span>{loadingKey ? `실행 중: ${loadingKey}` : "접어서 숨길 수 있습니다"}</span>
-            </summary>
-            <ResultPanel>{result || "// API 응답 결과가 여기에 표시됩니다."}</ResultPanel>
-          </details>
-        </DevConsoleSection>
-      )}
+      <EditorStudioResultLogPanel
+        eyebrow="실행 로그"
+        idleDescription="접어서 숨길 수 있습니다"
+        idleTitle="최근 작업 응답 보기"
+        loadingDescription={(currentLoadingKey) => `실행 중: ${currentLoadingKey}`}
+        loadingKey={loadingKey}
+        loadingTitle="작업 응답 확인 중"
+        result={result}
+        variant="standard"
+      />
     </Main>
   )
 }
@@ -4375,16 +4312,6 @@ const ActionRow = styled.div`
     > button {
       width: 100%;
     }
-  }
-`
-
-const UtilityGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
-
-  @media (max-width: 980px) {
-    grid-template-columns: 1fr;
   }
 `
 
@@ -5925,43 +5852,6 @@ const EditorStudioCanvas = styled.section`
   overflow-x: visible;
 `
 
-const EditorStudioResultPanel = styled.section`
-  width: 100%;
-  max-width: var(--article-readable-width, 48rem);
-  min-width: 0;
-  margin-inline: auto;
-  border-top: 1px solid ${({ theme }) => theme.colors.gray5};
-  padding-top: 0.9rem;
-
-  details {
-    display: grid;
-    gap: 0.75rem;
-  }
-
-  summary {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 0.8rem;
-    cursor: pointer;
-    list-style: none;
-  }
-
-  summary::-webkit-details-marker {
-    display: none;
-  }
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.92rem;
-  }
-
-  span {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.76rem;
-  }
-`
-
 const WriterFooterBar = styled.div`
   display: flex;
   align-items: flex-start;
@@ -6104,76 +5994,6 @@ const MobileComposeStatusBar = styled.div`
     &[data-tone="error"] {
       border-color: ${({ theme }) => theme.colors.red7};
       background: color-mix(in srgb, ${({ theme }) => theme.colors.red3} 84%, transparent);
-    }
-  }
-`
-
-const ResultPanel = styled.pre`
-  margin: 0;
-  padding: 1rem;
-  border-radius: 8px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray12};
-  font-size: 0.82rem;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
-  min-height: 160px;
-`
-
-const DevConsoleSection = styled.section`
-  margin-top: 1rem;
-  border-radius: 0;
-  border: 0;
-  border-top: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: transparent;
-  overflow: hidden;
-
-  details {
-    display: grid;
-  }
-
-  summary {
-    list-style: none;
-    cursor: pointer;
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 0.8rem;
-    padding: 0.95rem 1rem;
-  }
-
-  summary::-webkit-details-marker {
-    display: none;
-  }
-
-  strong {
-    display: block;
-    margin-top: 0.18rem;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.96rem;
-  }
-
-  span {
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.78rem;
-    line-height: 1.5;
-    white-space: nowrap;
-  }
-
-  > details > pre {
-    margin: 0 1rem 1rem;
-  }
-
-  @media (max-width: 720px) {
-    summary {
-      flex-direction: column;
-    }
-
-    span {
-      white-space: normal;
     }
   }
 `

--- a/front/src/routes/Admin/EditorStudioResultLogPanel.tsx
+++ b/front/src/routes/Admin/EditorStudioResultLogPanel.tsx
@@ -1,0 +1,147 @@
+import styled from "@emotion/styled"
+
+type EditorStudioResultLogPanelProps = {
+  loadingKey: string
+  result: string
+  variant: "dedicated" | "standard"
+  eyebrow?: string
+  loadingTitle: string
+  idleTitle: string
+  loadingDescription: (loadingKey: string) => string
+  idleDescription: string
+}
+
+export const EditorStudioResultLogPanel = ({
+  loadingKey,
+  result,
+  variant,
+  eyebrow,
+  loadingTitle,
+  idleTitle,
+  loadingDescription,
+  idleDescription,
+}: EditorStudioResultLogPanelProps) => {
+  if (!loadingKey && !result) return null
+
+  return (
+    <ResultLogPanel data-variant={variant}>
+      <details open={Boolean(loadingKey)}>
+        <summary>
+          <div>
+            {eyebrow ? <ResultLogEyebrow>{eyebrow}</ResultLogEyebrow> : null}
+            <strong>{loadingKey ? loadingTitle : idleTitle}</strong>
+          </div>
+          <span>{loadingKey ? loadingDescription(loadingKey) : idleDescription}</span>
+        </summary>
+        <ResultLogBody>{result || "// API 응답 결과가 여기에 표시됩니다."}</ResultLogBody>
+      </details>
+    </ResultLogPanel>
+  )
+}
+
+const ResultLogPanel = styled.section`
+  &[data-variant="dedicated"] {
+    width: 100%;
+    max-width: var(--article-readable-width, 48rem);
+    min-width: 0;
+    margin-inline: auto;
+    border-top: 1px solid ${({ theme }) => theme.colors.gray5};
+    padding-top: 0.9rem;
+  }
+
+  &[data-variant="standard"] {
+    margin-top: 1rem;
+    border-radius: 0;
+    border: 0;
+    border-top: 1px solid ${({ theme }) => theme.colors.gray6};
+    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: transparent;
+    overflow: hidden;
+  }
+
+  details {
+    display: grid;
+  }
+
+  &[data-variant="dedicated"] details {
+    gap: 0.75rem;
+  }
+
+  summary {
+    list-style: none;
+    cursor: pointer;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.8rem;
+  }
+
+  &[data-variant="standard"] summary {
+    padding: 0.95rem 1rem;
+  }
+
+  summary::-webkit-details-marker {
+    display: none;
+  }
+
+  strong {
+    display: block;
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &[data-variant="dedicated"] strong {
+    font-size: 0.92rem;
+  }
+
+  &[data-variant="standard"] strong {
+    margin-top: 0.18rem;
+    font-size: 0.96rem;
+  }
+
+  span {
+    color: ${({ theme }) => theme.colors.gray10};
+    line-height: 1.5;
+  }
+
+  &[data-variant="dedicated"] span {
+    font-size: 0.76rem;
+  }
+
+  &[data-variant="standard"] span {
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.78rem;
+    white-space: nowrap;
+  }
+
+  &[data-variant="standard"] > details > pre {
+    margin: 0 1rem 1rem;
+  }
+
+  @media (max-width: 720px) {
+    &[data-variant="standard"] summary {
+      flex-direction: column;
+    }
+
+    &[data-variant="standard"] span {
+      white-space: normal;
+    }
+  }
+`
+
+const ResultLogEyebrow = styled.span`
+  display: none;
+`
+
+const ResultLogBody = styled.pre`
+  margin: 0;
+  padding: 1rem;
+  border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray12};
+  font-size: 0.82rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 160px;
+`


### PR DESCRIPTION
## 관련 이슈

close #199

## 작업 배경

- `EditorStudioPage.tsx`에 남아 있던 legacy comment/system utility section과 실행 로그 shell을 전용 presentational component로 분리했습니다.
- comment/system API 실행과 state 변경은 page callback에 남겨 code-impact 범위를 제한했습니다.
- `EditorStudioPage.tsx`는 6,179 lines에서 5,999 lines로 줄었고, 구조 가드가 utility/result shell 재결합을 막습니다.

## 작업 내용

- `EditorStudioLegacyUtilityPanel.tsx`를 추가해 hidden legacy comment/system utility UI와 스타일을 소유하게 했습니다.
- `EditorStudioResultLogPanel.tsx`를 추가해 dedicated editor와 standard admin shell의 result log UI를 공유하게 했습니다.
- `editor-studio-state` 구조 가드에 새 component 존재, 단일/복수 render, API/state setter 직접 소유 금지, page 내 result/utility styled shell 제거 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - RED 확인: `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` 실패, `EditorStudioLegacyUtilityPanel.tsx` 미존재 가드 확인
  - GREEN 확인: `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` 16 passed
  - 반복 확인: `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` 16 passed
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` 73 passed
  - 반복 확인: `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` 73 passed
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` 16 passed
  - 반복 확인: `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` 16 passed
  - `git diff --check`
  - `CURRENT_TASK_SLUG=editor-studio-legacy-utility-result-split bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: callback props 연결 실수 시 hidden legacy utility action 또는 result log 표시가 동작하지 않을 수 있습니다. 구조 가드, lint, build, editor E2E로 회귀를 막았습니다.
- 롤백 방법: 이 PR의 단일 커밋 `refactor(editor): legacy utility result panel 분리`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
