### PR TITLE
[Refactor] EditorStudio mobile feedback shell 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -248,6 +248,30 @@ test.describe("editor studio state", () => {
     const editorStudioPostListPanelSource = existsSync(editorStudioPostListPanelPath)
       ? readFileSync(editorStudioPostListPanelPath, "utf8")
       : ""
+    const editorStudioMobileStepNavigatorPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioMobileStepNavigator.tsx"
+    )
+    expect(existsSync(editorStudioMobileStepNavigatorPath)).toBe(true)
+    const editorStudioMobileStepNavigatorSource = existsSync(editorStudioMobileStepNavigatorPath)
+      ? readFileSync(editorStudioMobileStepNavigatorPath, "utf8")
+      : ""
+    const editorStudioUndoToastPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioUndoToast.tsx"
+    )
+    expect(existsSync(editorStudioUndoToastPath)).toBe(true)
+    const editorStudioUndoToastSource = existsSync(editorStudioUndoToastPath)
+      ? readFileSync(editorStudioUndoToastPath, "utf8")
+      : ""
+    const editorStudioDeleteConfirmDialogPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioDeleteConfirmDialog.tsx"
+    )
+    expect(existsSync(editorStudioDeleteConfirmDialogPath)).toBe(true)
+    const editorStudioDeleteConfirmDialogSource = existsSync(editorStudioDeleteConfirmDialogPath)
+      ? readFileSync(editorStudioDeleteConfirmDialogPath, "utf8")
+      : ""
     const blockEditorShellSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorShell.tsx"), "utf8")
     const blockEditorEngineSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tsx"), "utf8")
     const blockSelectionModelSource = readFileSync(
@@ -505,6 +529,46 @@ test.describe("editor studio state", () => {
     expect(editorStudioPostListPanelSource).not.toContain("hardDeleteDeletedPostFromList")
     expect(editorStudioPostListPanelSource).not.toContain("openDeleteConfirm")
     expect(editorStudioPostListPanelSource).not.toContain("setPostId")
+    expect(editorStudioMobileStepNavigatorSource).toContain("export const EditorStudioMobileStepNavigator =")
+    expect(editorStudioSource).toContain(
+      'import { EditorStudioMobileStepNavigator } from "./EditorStudioMobileStepNavigator"'
+    )
+    expect(editorStudioSource.match(/<EditorStudioMobileStepNavigator/g)?.length).toBe(1)
+    expect(editorStudioMobileStepNavigatorSource).toContain("모바일 작업 단계")
+    expect(editorStudioMobileStepNavigatorSource).toContain("현재 단계:")
+    expect(editorStudioSource).not.toContain("<MobileStudioStepper")
+    expect(editorStudioSource).not.toContain("<MobileStepGuide")
+    expect(editorStudioSource).not.toContain("const MobileStudioStepper = styled.div`")
+    expect(editorStudioSource).not.toContain("const MobileStepGuide = styled.section`")
+    expect(editorStudioMobileStepNavigatorSource).not.toContain("apiFetch(")
+    expect(editorStudioMobileStepNavigatorSource).not.toContain("run(")
+    expect(editorStudioMobileStepNavigatorSource).not.toContain("setActiveMobileStudioStep")
+    expect(editorStudioUndoToastSource).toContain("export const EditorStudioUndoToast =")
+    expect(editorStudioSource).toContain(
+      'import { EditorStudioUndoToast } from "./EditorStudioUndoToast"'
+    )
+    expect(editorStudioSource.match(/<EditorStudioUndoToast/g)?.length).toBe(1)
+    expect(editorStudioUndoToastSource).toContain("실행 취소")
+    expect(editorStudioSource).not.toContain("<UndoToast")
+    expect(editorStudioSource).not.toContain("const UndoToast = styled.div`")
+    expect(editorStudioUndoToastSource).not.toContain("apiFetch(")
+    expect(editorStudioUndoToastSource).not.toContain("run(")
+    expect(editorStudioUndoToastSource).not.toContain("handleUndoSoftDelete")
+    expect(editorStudioDeleteConfirmDialogSource).toContain("export const EditorStudioDeleteConfirmDialog =")
+    expect(editorStudioSource).toContain(
+      'import { EditorStudioDeleteConfirmDialog } from "./EditorStudioDeleteConfirmDialog"'
+    )
+    expect(editorStudioSource.match(/<EditorStudioDeleteConfirmDialog/g)?.length).toBe(1)
+    expect(editorStudioDeleteConfirmDialogSource).toContain("글을 삭제할까요?")
+    expect(editorStudioDeleteConfirmDialogSource).toContain("삭제 후에는 삭제 글 목록에서 복구할 수 있습니다.")
+    expect(editorStudioSource).not.toContain("<ModalBackdrop")
+    expect(editorStudioSource).not.toContain("<ConfirmModal")
+    expect(editorStudioSource).not.toContain("const ModalBackdrop = styled.div`")
+    expect(editorStudioSource).not.toContain("const ConfirmModal = styled.div`")
+    expect(editorStudioDeleteConfirmDialogSource).not.toContain("apiFetch(")
+    expect(editorStudioDeleteConfirmDialogSource).not.toContain("run(")
+    expect(editorStudioDeleteConfirmDialogSource).not.toContain("deletePostsFromList")
+    expect(editorStudioDeleteConfirmDialogSource).not.toContain("setDeleteConfirmState")
     expect(editorStudioStateSource).toContain("export type PostVisibility =")
     expect(editorStudioStateSource).toContain("export const toVisibility")
     expect(editorStudioStateSource).toContain("export const toFlags")

--- a/front/src/routes/Admin/EditorStudioDeleteConfirmDialog.tsx
+++ b/front/src/routes/Admin/EditorStudioDeleteConfirmDialog.tsx
@@ -1,0 +1,168 @@
+import styled from "@emotion/styled"
+
+type DeleteConfirmNoticeTone = "idle" | "loading" | "success" | "error"
+
+export type EditorStudioDeleteConfirmState = {
+  ids: number[]
+  headline: string
+}
+
+type EditorStudioDeleteConfirmDialogProps = {
+  state: EditorStudioDeleteConfirmState | null
+  noticeTone: DeleteConfirmNoticeTone
+  noticeText: string
+  isDeleteDisabled: boolean
+  onClose: () => void
+  onConfirm: (state: EditorStudioDeleteConfirmState) => void | Promise<void>
+}
+
+export const EditorStudioDeleteConfirmDialog = ({
+  state,
+  noticeTone,
+  noticeText,
+  isDeleteDisabled,
+  onClose,
+  onConfirm,
+}: EditorStudioDeleteConfirmDialogProps) => {
+  if (!state) return null
+
+  return (
+    <DialogBackdrop onClick={onClose}>
+      <DialogShell onClick={(event) => event.stopPropagation()}>
+        <div className="header">
+          <h4>글을 삭제할까요?</h4>
+          <p>
+            삭제 후에는 삭제 글 목록에서 복구할 수 있습니다.
+            <br />
+            <strong>{state.headline}</strong>
+          </p>
+        </div>
+        {noticeText ? <Notice data-tone={noticeTone}>{noticeText}</Notice> : null}
+        <div className="actions">
+          <Button type="button" disabled={isDeleteDisabled} onClick={onClose}>
+            취소
+          </Button>
+          <PrimaryButton type="button" disabled={isDeleteDisabled} onClick={() => void onConfirm(state)}>
+            {isDeleteDisabled ? "삭제 중..." : "삭제 확정"}
+          </PrimaryButton>
+        </div>
+      </DialogShell>
+    </DialogBackdrop>
+  )
+}
+
+const DialogBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.42);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 120;
+  padding: 1rem;
+`
+
+const DialogShell = styled.div`
+  width: min(440px, 100%);
+  border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray2};
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+
+  .header {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  h4 {
+    margin: 0;
+    font-size: 1rem;
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  p {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray11};
+    line-height: 1.45;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+`
+
+const Notice = styled.div`
+  border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray3};
+  color: ${({ theme }) => theme.colors.gray11};
+  padding: 0.6rem 0.7rem;
+  font-size: 0.82rem;
+  line-height: 1.45;
+
+  &[data-tone="success"] {
+    border-color: ${({ theme }) => theme.colors.green7};
+    background: ${({ theme }) => theme.colors.green3};
+    color: ${({ theme }) => theme.colors.green11};
+  }
+
+  &[data-tone="error"] {
+    border-color: ${({ theme }) => theme.colors.red7};
+    background: ${({ theme }) => theme.colors.red3};
+    color: ${({ theme }) => theme.colors.red11};
+  }
+`
+
+const Button = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+const PrimaryButton = styled(Button)`
+  border-radius: 8px;
+  padding: 0.6rem 0.88rem;
+  border-color: ${({ theme }) => theme.colors.blue9};
+  background: ${({ theme }) => theme.colors.blue9};
+  color: ${({ theme }) => theme.colors.gray1};
+  font-weight: 700;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.blue10};
+    background: ${({ theme }) => theme.colors.blue10};
+    color: ${({ theme }) => theme.colors.gray1};
+  }
+`

--- a/front/src/routes/Admin/EditorStudioMobileStepNavigator.tsx
+++ b/front/src/routes/Admin/EditorStudioMobileStepNavigator.tsx
@@ -1,0 +1,201 @@
+import styled from "@emotion/styled"
+
+type EditorStudioMobileStepNavigatorProps<Step extends string> = {
+  steps: readonly Step[]
+  activeStep: Step
+  stepLabels: Record<Step, string>
+  stepDescriptions: Record<Step, string>
+  prevStep: Step | null
+  nextStep: Step | null
+  prevStepLabel: string
+  nextStepLabel: string
+  isCompactMobileLayout: boolean
+  onStepChange: (step: Step) => void
+}
+
+export const EditorStudioMobileStepNavigator = <Step extends string,>({
+  steps,
+  activeStep,
+  stepLabels,
+  stepDescriptions,
+  prevStep,
+  nextStep,
+  prevStepLabel,
+  nextStepLabel,
+  isCompactMobileLayout,
+  onStepChange,
+}: EditorStudioMobileStepNavigatorProps<Step>) => (
+  <>
+    <MobileStudioStepper role="tablist" aria-label="모바일 작업 단계">
+      {steps.map((step) => (
+        <button
+          key={step}
+          type="button"
+          role="tab"
+          aria-selected={activeStep === step}
+          data-active={activeStep === step}
+          onClick={() => onStepChange(step)}
+        >
+          {stepLabels[step]}
+        </button>
+      ))}
+    </MobileStudioStepper>
+    {isCompactMobileLayout ? (
+      <MobileStepGuide role="status" aria-live="polite">
+        <strong>{`현재 단계: ${stepLabels[activeStep]}`}</strong>
+        <p>{stepDescriptions[activeStep]}</p>
+        <div>
+          <Button
+            type="button"
+            disabled={!prevStep}
+            onClick={() => {
+              if (!prevStep) return
+              onStepChange(prevStep)
+            }}
+          >
+            {prevStepLabel}
+          </Button>
+          <PrimaryButton
+            type="button"
+            disabled={!nextStep}
+            onClick={() => {
+              if (!nextStep) return
+              onStepChange(nextStep)
+            }}
+          >
+            {nextStepLabel}
+          </PrimaryButton>
+        </div>
+      </MobileStepGuide>
+    ) : null}
+  </>
+)
+
+const MobileStudioStepper = styled.div`
+  display: none;
+
+  @media (max-width: 720px) {
+    position: sticky;
+    top: calc(var(--app-header-height, 56px) + 0.32rem);
+    z-index: 12;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.4rem;
+    margin: 0.2rem 0 0.4rem;
+    padding: 0.5rem;
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    border-radius: 10px;
+    background: ${({ theme }) => theme.colors.gray2};
+
+    > button {
+      min-height: 38px;
+      border-radius: 999px;
+      border: 1px solid ${({ theme }) => theme.colors.gray6};
+      background: transparent;
+      color: ${({ theme }) => theme.colors.gray11};
+      font-size: 0.77rem;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    > button[data-active="true"] {
+      border-color: ${({ theme }) => theme.colors.blue8};
+      color: ${({ theme }) => theme.colors.blue11};
+      background: ${({ theme }) => theme.colors.blue3};
+    }
+  }
+`
+
+const MobileStepGuide = styled.section`
+  display: none;
+
+  @media (max-width: 720px) {
+    display: grid;
+    gap: 0.58rem;
+    margin-bottom: 0.28rem;
+    padding: 0.66rem 0.72rem;
+    border-radius: 10px;
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => theme.colors.gray2};
+
+    strong {
+      font-size: 0.86rem;
+      color: ${({ theme }) => theme.colors.gray12};
+      line-height: 1.4;
+    }
+
+    p {
+      margin: 0;
+      font-size: 0.76rem;
+      line-height: 1.5;
+      color: ${({ theme }) => theme.colors.gray10};
+    }
+
+    > div {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.5rem;
+    }
+
+    button {
+      min-height: 38px;
+      width: 100%;
+      justify-content: center;
+    }
+  }
+
+  @media (max-width: 520px) {
+    > div {
+      grid-template-columns: 1fr;
+    }
+  }
+`
+
+const Button = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+const PrimaryButton = styled(Button)`
+  border-radius: 8px;
+  padding: 0.6rem 0.88rem;
+  border-color: ${({ theme }) => theme.colors.blue9};
+  background: ${({ theme }) => theme.colors.blue9};
+  color: ${({ theme }) => theme.colors.gray1};
+  font-weight: 700;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.blue10};
+    background: ${({ theme }) => theme.colors.blue10};
+    color: ${({ theme }) => theme.colors.gray1};
+  }
+`

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -60,6 +60,9 @@ import { EditorStudioLegacyUtilityPanel } from "./EditorStudioLegacyUtilityPanel
 import { EditorStudioResultLogPanel } from "./EditorStudioResultLogPanel"
 import { EditorStudioPostQueryPanel } from "./EditorStudioPostQueryPanel"
 import { EditorStudioPostListPanel } from "./EditorStudioPostListPanel"
+import { EditorStudioMobileStepNavigator } from "./EditorStudioMobileStepNavigator"
+import { EditorStudioUndoToast } from "./EditorStudioUndoToast"
+import { EditorStudioDeleteConfirmDialog } from "./EditorStudioDeleteConfirmDialog"
 import {
   isServerTempDraftPost,
   TEMP_DRAFT_BODY_PLACEHOLDER,
@@ -1574,7 +1577,7 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
     if (uniqueIds.length === 0) return
     setDeleteConfirmNotice({
       tone: "idle",
-      text: "삭제는 즉시 반영되며 되돌릴 수 없습니다.",
+      text: "",
     })
     const headline =
       uniqueIds.length === 1
@@ -2762,48 +2765,18 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
             {shouldShowGlobalNotice ? (
               <GlobalNoticeBar data-tone={globalNotice.tone}>{globalNotice.text}</GlobalNoticeBar>
             ) : null}
-            <MobileStudioStepper role="tablist" aria-label="모바일 작업 단계">
-              {mobileStudioSurfaceSteps.map((step) => (
-                <button
-                  key={step}
-                  type="button"
-                  role="tab"
-                  aria-selected={activeMobileStudioStep === step}
-                  data-active={activeMobileStudioStep === step}
-                  onClick={() => setActiveMobileStudioStep(step)}
-                >
-                  {MOBILE_STUDIO_STEP_LABEL[step]}
-                </button>
-              ))}
-            </MobileStudioStepper>
-            {isCompactMobileLayout ? (
-              <MobileStepGuide role="status" aria-live="polite">
-                <strong>{`현재 단계: ${MOBILE_STUDIO_STEP_LABEL[activeMobileStudioStep]}`}</strong>
-                <p>{MOBILE_STUDIO_STEP_DESCRIPTION[activeMobileStudioStep]}</p>
-                <div>
-                  <Button
-                    type="button"
-                    disabled={!mobileStudioPrevStep}
-                    onClick={() => {
-                      if (!mobileStudioPrevStep) return
-                      setActiveMobileStudioStep(mobileStudioPrevStep)
-                    }}
-                  >
-                    {mobileStudioPrevStepLabel}
-                  </Button>
-                  <PrimaryButton
-                    type="button"
-                    disabled={!mobileStudioNextStep}
-                    onClick={() => {
-                      if (!mobileStudioNextStep) return
-                      setActiveMobileStudioStep(mobileStudioNextStep)
-                    }}
-                  >
-                    {mobileStudioNextStepLabel}
-                  </PrimaryButton>
-                </div>
-              </MobileStepGuide>
-            ) : null}
+            <EditorStudioMobileStepNavigator
+              steps={mobileStudioSurfaceSteps}
+              activeStep={activeMobileStudioStep}
+              stepLabels={MOBILE_STUDIO_STEP_LABEL}
+              stepDescriptions={MOBILE_STUDIO_STEP_DESCRIPTION}
+              prevStep={mobileStudioPrevStep}
+              nextStep={mobileStudioNextStep}
+              prevStepLabel={mobileStudioPrevStepLabel}
+              nextStepLabel={mobileStudioNextStepLabel}
+              isCompactMobileLayout={isCompactMobileLayout}
+              onStepChange={setActiveMobileStudioStep}
+            />
             <ContentStudioGrid>
               <ContentStudioLeft
                 data-mobile-visible={!isCompactMobileLayout || activeMobileStudioStep === "query" || activeMobileStudioStep === "list"}
@@ -2912,53 +2885,26 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
               />
             </ContentStudioGrid>
 
-            {softDeleteUndoState && (
-              <UndoToast role="status" aria-live="polite">
-                <p>{softDeleteUndoState?.message}</p>
-                <Button type="button" onClick={() => void handleUndoSoftDelete()} disabled={disabled("undoDeletePost")}>
-                  실행 취소
-                </Button>
-              </UndoToast>
-            )}
+            <EditorStudioUndoToast
+              isVisible={Boolean(softDeleteUndoState)}
+              message={softDeleteUndoState?.message || ""}
+              isUndoDisabled={disabled("undoDeletePost")}
+              onUndo={() => void handleUndoSoftDelete()}
+            />
           </Section>
           )}
 
-        {deleteConfirmState && (
-          <ModalBackdrop onClick={closeDeleteConfirm}>
-            <ConfirmModal onClick={(e) => e.stopPropagation()}>
-              <div className="header">
-                <h4>글 삭제 확인</h4>
-                <p>
-                  정말 삭제할까요?
-                  <br />
-                  <strong>{deleteConfirmState?.headline}</strong>
-                </p>
-              </div>
-              {deleteConfirmNotice.text ? (
-                <PublishNotice data-tone={deleteConfirmNotice.tone}>{deleteConfirmNotice.text}</PublishNotice>
-              ) : null}
-              <div className="actions">
-                <Button
-                  type="button"
-                  disabled={loadingKey === "deletePost"}
-                  onClick={closeDeleteConfirm}
-                >
-                  취소
-                </Button>
-                <PrimaryButton
-                  type="button"
-                  disabled={loadingKey === "deletePost"}
-                  onClick={async () => {
-                    const ok = await deletePostsFromList(deleteConfirmState?.ids || [])
-                    if (ok) closeDeleteConfirm()
-                  }}
-                >
-                  {loadingKey === "deletePost" ? "삭제 중..." : "삭제 확정"}
-                </PrimaryButton>
-              </div>
-            </ConfirmModal>
-          </ModalBackdrop>
-        )}
+        <EditorStudioDeleteConfirmDialog
+          state={deleteConfirmState}
+          noticeTone={deleteConfirmNotice.tone}
+          noticeText={deleteConfirmNotice.text}
+          isDeleteDisabled={loadingKey === "deletePost"}
+          onClose={closeDeleteConfirm}
+          onConfirm={async (state) => {
+            const ok = await deletePostsFromList(state.ids)
+            if (ok) closeDeleteConfirm()
+          }}
+        />
         {studioSurface === "compose" && (
         <ComposeSurfaceSection>
         <EditorSection data-mobile-visible={!isCompactMobileLayout || studioSurface === "compose"}>
@@ -3542,86 +3488,6 @@ const ContentStudioGrid = styled.div`
 
   @media (max-width: 720px) {
     gap: 0.76rem;
-  }
-`
-
-const MobileStudioStepper = styled.div`
-  display: none;
-
-  @media (max-width: 720px) {
-    position: sticky;
-    top: calc(var(--app-header-height, 56px) + 0.32rem);
-    z-index: 12;
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.4rem;
-    margin: 0.2rem 0 0.4rem;
-    padding: 0.5rem;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    border-radius: 10px;
-    background: ${({ theme }) => theme.colors.gray2};
-
-    > button {
-      min-height: 38px;
-      border-radius: 999px;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
-      background: transparent;
-      color: ${({ theme }) => theme.colors.gray11};
-      font-size: 0.77rem;
-      font-weight: 700;
-      cursor: pointer;
-    }
-
-    > button[data-active="true"] {
-      border-color: ${({ theme }) => theme.colors.blue8};
-      color: ${({ theme }) => theme.colors.blue11};
-      background: ${({ theme }) => theme.colors.blue3};
-    }
-  }
-`
-
-const MobileStepGuide = styled.section`
-  display: none;
-
-  @media (max-width: 720px) {
-    display: grid;
-    gap: 0.58rem;
-    margin-bottom: 0.28rem;
-    padding: 0.66rem 0.72rem;
-    border-radius: 10px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray2};
-
-    strong {
-      font-size: 0.86rem;
-      color: ${({ theme }) => theme.colors.gray12};
-      line-height: 1.4;
-    }
-
-    p {
-      margin: 0;
-      font-size: 0.76rem;
-      line-height: 1.5;
-      color: ${({ theme }) => theme.colors.gray10};
-    }
-
-    > div {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 0.5rem;
-    }
-
-    button {
-      min-height: 38px;
-      width: 100%;
-      justify-content: center;
-    }
-  }
-
-  @media (max-width: 520px) {
-    > div {
-      grid-template-columns: 1fr;
-    }
   }
 `
 
@@ -4303,83 +4169,6 @@ const SubActionRow = styled.div`
       width: 100%;
       justify-content: center;
     }
-  }
-`
-
-const UndoToast = styled.div`
-  position: fixed;
-  right: 1rem;
-  bottom: 1rem;
-  z-index: 140;
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  padding: 0.6rem 0.72rem;
-  border-radius: 10px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
-
-  p {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.8rem;
-  }
-
-  @media (max-width: 720px) {
-    left: 0.85rem;
-    right: 0.85rem;
-    bottom: calc(0.85rem + env(safe-area-inset-bottom));
-    flex-wrap: wrap;
-  }
-`
-
-const ModalBackdrop = styled.div`
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.42);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 120;
-  padding: 1rem;
-
-  &[data-variant="drawer"] {
-    justify-content: flex-end;
-    padding: 0;
-  }
-`
-
-const ConfirmModal = styled.div`
-  width: min(440px, 100%);
-  border-radius: 8px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
-  padding: 1rem;
-  display: grid;
-  gap: 0.75rem;
-
-  .header {
-    display: grid;
-    gap: 0.5rem;
-  }
-
-  h4 {
-    margin: 0;
-    font-size: 1rem;
-    color: ${({ theme }) => theme.colors.gray12};
-  }
-
-  p {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray11};
-    line-height: 1.45;
-  }
-
-  .actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-    flex-wrap: wrap;
   }
 `
 

--- a/front/src/routes/Admin/EditorStudioUndoToast.tsx
+++ b/front/src/routes/Admin/EditorStudioUndoToast.tsx
@@ -1,0 +1,87 @@
+import styled from "@emotion/styled"
+
+type EditorStudioUndoToastProps = {
+  isVisible: boolean
+  message: string
+  isUndoDisabled: boolean
+  onUndo: () => void
+}
+
+export const EditorStudioUndoToast = ({
+  isVisible,
+  message,
+  isUndoDisabled,
+  onUndo,
+}: EditorStudioUndoToastProps) => {
+  if (!isVisible) return null
+
+  return (
+    <ToastShell role="status" aria-live="polite">
+      <p>{message}</p>
+      <Button type="button" onClick={onUndo} disabled={isUndoDisabled}>
+        실행 취소
+      </Button>
+    </ToastShell>
+  )
+}
+
+const ToastShell = styled.div`
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 140;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 0.72rem;
+  border-radius: 10px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray2};
+
+  p {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.8rem;
+  }
+
+  @media (max-width: 720px) {
+    left: 0.85rem;
+    right: 0.85rem;
+    bottom: calc(0.85rem + env(safe-area-inset-bottom));
+    flex-wrap: wrap;
+  }
+`
+
+const Button = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`


### PR DESCRIPTION
## 관련 이슈

close #203

## 작업 배경

- EditorStudio page가 직접 들고 있던 모바일 단계 안내, soft-delete undo toast, 삭제 확인 dialog shell을 전용 presentational component로 분리했습니다.
- 실제 step 전환, undo, 삭제 실행은 기존 page callback 경계에 남겨 동작 영향 범위를 제한했습니다.

## 작업 내용

- `EditorStudioMobileStepNavigator`를 추가해 모바일 stepper/guide JSX와 style을 page 밖으로 이동했습니다.
- `EditorStudioUndoToast`와 `EditorStudioDeleteConfirmDialog`를 추가해 feedback overlay shell을 분리했습니다.
- `editor-studio-state` guard에 새 component 존재, page 직접 shell 미소유, component의 API/flow 직접 호출 금지 조건을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight` (2회 통과)
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (RED 확인 후 2회 통과)
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (2회 통과)
  - `yarn --cwd front lint` (2회 통과)
  - `yarn --cwd front build` (2회 통과)
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (범위 밖 block-editor hover/좌표 케이스가 서로 다른 지점에서 2회 실패)
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1 -g "writer surface의 multi-table hover"` (통과)
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1 -g "writer surface의 본문 첫 글자"` (통과)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: shell component 분리로 인한 mobile/admin overlay wiring 누락.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 기존 page 내부 shell 구조로 돌아갑니다.
- 참고: `main` merge 후 CI가 성공하면 기존 자동 배포 workflow가 이어집니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
