### PR TITLE
[Refactor] EditorStudio compose mobile chrome 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -272,6 +272,14 @@ test.describe("editor studio state", () => {
     const editorStudioDeleteConfirmDialogSource = existsSync(editorStudioDeleteConfirmDialogPath)
       ? readFileSync(editorStudioDeleteConfirmDialogPath, "utf8")
       : ""
+    const editorStudioComposeMobileChromePath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioComposeMobileChrome.tsx"
+    )
+    expect(existsSync(editorStudioComposeMobileChromePath)).toBe(true)
+    const editorStudioComposeMobileChromeSource = existsSync(editorStudioComposeMobileChromePath)
+      ? readFileSync(editorStudioComposeMobileChromePath, "utf8")
+      : ""
     const blockEditorShellSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorShell.tsx"), "utf8")
     const blockEditorEngineSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tsx"), "utf8")
     const blockSelectionModelSource = readFileSync(
@@ -569,6 +577,22 @@ test.describe("editor studio state", () => {
     expect(editorStudioDeleteConfirmDialogSource).not.toContain("run(")
     expect(editorStudioDeleteConfirmDialogSource).not.toContain("deletePostsFromList")
     expect(editorStudioDeleteConfirmDialogSource).not.toContain("setDeleteConfirmState")
+    expect(editorStudioComposeMobileChromeSource).toContain("export const EditorStudioComposeMobileChrome =")
+    expect(editorStudioSource).toContain(
+      'import { EditorStudioComposeMobileChrome } from "./EditorStudioComposeMobileChrome"'
+    )
+    expect(editorStudioSource.match(/<EditorStudioComposeMobileChrome/g)?.length).toBe(1)
+    expect(editorStudioComposeMobileChromeSource).toContain("const MobileComposeStatusBar = styled.div`")
+    expect(editorStudioComposeMobileChromeSource).toContain("const MobilePrimaryActionBar = styled.div`")
+    expect(editorStudioSource).not.toContain("<MobileComposeStatusBar")
+    expect(editorStudioSource).not.toContain("<MobilePrimaryActionBar")
+    expect(editorStudioSource).not.toContain("const MobileComposeStatusBar = styled.div`")
+    expect(editorStudioSource).not.toContain("const MobilePrimaryActionBar = styled.div`")
+    expect(editorStudioComposeMobileChromeSource).not.toContain("apiFetch(")
+    expect(editorStudioComposeMobileChromeSource).not.toContain("run(")
+    expect(editorStudioComposeMobileChromeSource).not.toContain("openPublishModal")
+    expect(editorStudioComposeMobileChromeSource).not.toContain("setMobileComposeStep")
+    expect(editorStudioComposeMobileChromeSource).not.toContain("setPostVisibility")
     expect(editorStudioStateSource).toContain("export type PostVisibility =")
     expect(editorStudioStateSource).toContain("export const toVisibility")
     expect(editorStudioStateSource).toContain("export const toFlags")

--- a/front/src/routes/Admin/EditorStudioComposeMobileChrome.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeMobileChrome.tsx
@@ -1,0 +1,200 @@
+import styled from "@emotion/styled"
+
+type EditorStudioComposeMobileChromeTone = "idle" | "loading" | "success" | "error"
+
+export type EditorStudioComposeMobileStatus = {
+  label: string
+  tone: EditorStudioComposeMobileChromeTone
+  text: string
+}
+
+type EditorStudioComposeMobileChromeProps = {
+  showStatus: boolean
+  showAction: boolean
+  primaryStatus: EditorStudioComposeMobileStatus
+  visibilityText: string
+  secondaryStatusText?: string | null
+  primaryActionLabel: string
+  primaryActionDisabled: boolean
+  onPrimaryAction: () => void
+}
+
+export const EditorStudioComposeMobileChrome = ({
+  showStatus,
+  showAction,
+  primaryStatus,
+  visibilityText,
+  secondaryStatusText,
+  primaryActionLabel,
+  primaryActionDisabled,
+  onPrimaryAction,
+}: EditorStudioComposeMobileChromeProps) => (
+  <>
+    {showStatus ? (
+      <MobileComposeStatusBar data-tone={primaryStatus.tone}>
+        <div className="headline">
+          <strong>{primaryStatus.label}</strong>
+          <span>{primaryStatus.text}</span>
+        </div>
+        <div className="meta">
+          <span className="pill">{visibilityText}</span>
+          {secondaryStatusText ? <span className="pill">{secondaryStatusText}</span> : null}
+        </div>
+      </MobileComposeStatusBar>
+    ) : null}
+    {showAction ? (
+      <MobilePrimaryActionBar>
+        <PrimaryButton type="button" disabled={primaryActionDisabled} onClick={onPrimaryAction}>
+          {primaryActionLabel}
+        </PrimaryButton>
+      </MobilePrimaryActionBar>
+    ) : null}
+  </>
+)
+
+const MobilePrimaryActionBar = styled.div`
+  display: none;
+
+  @media (max-width: 720px) {
+    position: fixed;
+    left: max(0.72rem, env(safe-area-inset-left, 0px));
+    right: max(0.72rem, env(safe-area-inset-right, 0px));
+    bottom: calc(0.72rem + env(safe-area-inset-bottom, 0px));
+    z-index: 145;
+    display: grid;
+    gap: 0.42rem;
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    border-radius: 12px;
+    background: ${({ theme }) => theme.colors.gray2};
+    padding: 0.54rem;
+    box-shadow: 0 12px 28px rgba(2, 6, 23, 0.28);
+
+    > button {
+      width: 100%;
+      justify-content: center;
+      min-height: 40px;
+    }
+  }
+`
+
+const MobileComposeStatusBar = styled.div`
+  display: none;
+
+  @media (max-width: 720px) {
+    position: sticky;
+    top: calc(var(--app-header-height, 64px) + 0.3rem);
+    z-index: 22;
+    display: grid;
+    gap: 0.5rem;
+    margin-bottom: 0.72rem;
+    padding: 0.72rem 0.82rem;
+    border-radius: 14px;
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: color-mix(in srgb, ${({ theme }) => theme.colors.gray2} 92%, transparent);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 12px 28px rgba(2, 6, 23, 0.16);
+
+    .headline {
+      display: grid;
+      gap: 0.16rem;
+    }
+
+    .headline strong {
+      color: ${({ theme }) => theme.colors.gray12};
+      font-size: 0.78rem;
+      font-weight: 800;
+      letter-spacing: -0.01em;
+    }
+
+    .headline span {
+      color: ${({ theme }) => theme.colors.gray10};
+      font-size: 0.76rem;
+      line-height: 1.45;
+    }
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.42rem;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      min-height: 26px;
+      padding: 0 0.58rem;
+      border-radius: 999px;
+      border: 1px solid ${({ theme }) => theme.colors.gray6};
+      background: ${({ theme }) => theme.colors.gray1};
+      color: ${({ theme }) => theme.colors.gray11};
+      font-size: 0.72rem;
+      font-weight: 800;
+      letter-spacing: -0.01em;
+    }
+
+    &[data-tone="loading"] {
+      border-color: ${({ theme }) => theme.colors.blue7};
+      background: color-mix(in srgb, ${({ theme }) => theme.colors.blue3} 82%, transparent);
+    }
+
+    &[data-tone="success"] {
+      border-color: ${({ theme }) => theme.colors.green7};
+      background: color-mix(in srgb, ${({ theme }) => theme.colors.green3} 84%, transparent);
+    }
+
+    &[data-tone="error"] {
+      border-color: ${({ theme }) => theme.colors.red7};
+      background: color-mix(in srgb, ${({ theme }) => theme.colors.red3} 84%, transparent);
+    }
+  }
+`
+
+const Button = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+const PrimaryButton = styled(Button)`
+  border-radius: 8px;
+  padding: 0.6rem 0.88rem;
+  border-color: ${({ theme }) => theme.colors.blue9};
+  background: ${({ theme }) => theme.colors.blue9};
+  color: ${({ theme }) => theme.colors.gray1};
+  font-weight: 700;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.blue10};
+    background: ${({ theme }) => theme.colors.blue10};
+    color: ${({ theme }) => theme.colors.gray1};
+  }
+`

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -63,6 +63,7 @@ import { EditorStudioPostListPanel } from "./EditorStudioPostListPanel"
 import { EditorStudioMobileStepNavigator } from "./EditorStudioMobileStepNavigator"
 import { EditorStudioUndoToast } from "./EditorStudioUndoToast"
 import { EditorStudioDeleteConfirmDialog } from "./EditorStudioDeleteConfirmDialog"
+import { EditorStudioComposeMobileChrome } from "./EditorStudioComposeMobileChrome"
 import {
   isServerTempDraftPost,
   TEMP_DRAFT_BODY_PLACEHOLDER,
@@ -2908,18 +2909,16 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
         {studioSurface === "compose" && (
         <ComposeSurfaceSection>
         <EditorSection data-mobile-visible={!isCompactMobileLayout || studioSurface === "compose"}>
-          {isCompactMobileLayout ? (
-            <MobileComposeStatusBar data-tone={mobileComposeStatusPrimary.tone}>
-              <div className="headline">
-                <strong>{mobileComposeStatusPrimary.label}</strong>
-                <span>{mobileComposeStatusPrimary.text}</span>
-              </div>
-              <div className="meta">
-                <span className="pill">{currentVisibilityText}</span>
-                {mobileComposeStatusSecondary ? <span className="pill">{mobileComposeStatusSecondary.text}</span> : null}
-              </div>
-            </MobileComposeStatusBar>
-          ) : null}
+          <EditorStudioComposeMobileChrome
+            showStatus={isCompactMobileLayout}
+            showAction={isCompactMobileLayout && !isPublishModalOpen}
+            primaryStatus={mobileComposeStatusPrimary}
+            visibilityText={currentVisibilityText}
+            secondaryStatusText={mobileComposeStatusSecondary?.text}
+            primaryActionLabel={mobilePrimaryActionLabel}
+            primaryActionDisabled={mobilePrimaryActionDisabled}
+            onPrimaryAction={() => openPublishModal(editorMode === "create" ? "create" : isTempDraftMode ? "temp" : "modify")}
+          />
           <ComposeStudioLayout>
             <ComposeMainColumn>
               <ComposeStudioHeader>
@@ -3153,18 +3152,6 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
           </ComposeStudioLayout>
         </EditorSection>
         </ComposeSurfaceSection>
-        )}
-
-        {isCompactMobileLayout && studioSurface === "compose" && !isPublishModalOpen && (
-          <MobilePrimaryActionBar>
-            <PrimaryButton
-              type="button"
-              disabled={mobilePrimaryActionDisabled}
-              onClick={() => openPublishModal(editorMode === "create" ? "create" : isTempDraftMode ? "temp" : "modify")}
-            >
-              {mobilePrimaryActionLabel}
-            </PrimaryButton>
-          </MobilePrimaryActionBar>
         )}
 
         {isPublishModalOpen ? (
@@ -4493,103 +4480,5 @@ const WriterFooterActions = styled.div`
 
   @media (max-width: 720px) {
     display: none;
-  }
-`
-
-const MobilePrimaryActionBar = styled.div`
-  display: none;
-
-  @media (max-width: 720px) {
-    position: fixed;
-    left: max(0.72rem, env(safe-area-inset-left, 0px));
-    right: max(0.72rem, env(safe-area-inset-right, 0px));
-    bottom: calc(0.72rem + env(safe-area-inset-bottom, 0px));
-    z-index: 145;
-    display: grid;
-    gap: 0.42rem;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    border-radius: 12px;
-    background: ${({ theme }) => theme.colors.gray2};
-    padding: 0.54rem;
-    box-shadow: 0 12px 28px rgba(2, 6, 23, 0.28);
-
-    > button {
-      width: 100%;
-      justify-content: center;
-      min-height: 40px;
-    }
-  }
-`
-
-const MobileComposeStatusBar = styled.div`
-  display: none;
-
-  @media (max-width: 720px) {
-    position: sticky;
-    top: calc(var(--app-header-height, 64px) + 0.3rem);
-    z-index: 22;
-    display: grid;
-    gap: 0.5rem;
-    margin-bottom: 0.72rem;
-    padding: 0.72rem 0.82rem;
-    border-radius: 14px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: color-mix(in srgb, ${({ theme }) => theme.colors.gray2} 92%, transparent);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    box-shadow: 0 12px 28px rgba(2, 6, 23, 0.16);
-
-    .headline {
-      display: grid;
-      gap: 0.16rem;
-    }
-
-    .headline strong {
-      color: ${({ theme }) => theme.colors.gray12};
-      font-size: 0.78rem;
-      font-weight: 800;
-      letter-spacing: -0.01em;
-    }
-
-    .headline span {
-      color: ${({ theme }) => theme.colors.gray10};
-      font-size: 0.76rem;
-      line-height: 1.45;
-    }
-
-    .meta {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.42rem;
-    }
-
-    .pill {
-      display: inline-flex;
-      align-items: center;
-      min-height: 26px;
-      padding: 0 0.58rem;
-      border-radius: 999px;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
-      background: ${({ theme }) => theme.colors.gray1};
-      color: ${({ theme }) => theme.colors.gray11};
-      font-size: 0.72rem;
-      font-weight: 800;
-      letter-spacing: -0.01em;
-    }
-
-    &[data-tone="loading"] {
-      border-color: ${({ theme }) => theme.colors.blue7};
-      background: color-mix(in srgb, ${({ theme }) => theme.colors.blue3} 82%, transparent);
-    }
-
-    &[data-tone="success"] {
-      border-color: ${({ theme }) => theme.colors.green7};
-      background: color-mix(in srgb, ${({ theme }) => theme.colors.green3} 84%, transparent);
-    }
-
-    &[data-tone="error"] {
-      border-color: ${({ theme }) => theme.colors.red7};
-      background: color-mix(in srgb, ${({ theme }) => theme.colors.red3} 84%, transparent);
-    }
   }
 `


### PR DESCRIPTION
## 관련 이슈

close #205

## 작업 배경

- EditorStudio compose 모바일 상태 바와 하단 주요 액션 바를 전용 presentational component로 분리했습니다.
- 페이지는 publish modal open flow와 상태 계산만 유지하고, 모바일 chrome JSX/style은 `EditorStudioComposeMobileChrome`이 소유합니다.

## 작업 내용

- `EditorStudioComposeMobileChrome` 컴포넌트를 추가해 모바일 compose status/action shell을 캡슐화했습니다.
- `EditorStudioPage`에서 직접 소유하던 `MobileComposeStatusBar`/`MobilePrimaryActionBar` styled shell을 제거했습니다.
- `editor-studio-state` guard에 컴포넌트 분리와 page 역소유 방지 계약을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 모바일 compose chrome 위치/상태 표시 회귀 가능성이 있어 구조 guard와 authoring/slash 회귀를 함께 실행했습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 기존 inline mobile chrome 소유 구조로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
