### PR TITLE
[Fix] editor contentHtml raw code fallback 강화

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -7,7 +7,7 @@ import {
   deriveEditorPersistenceState,
   isPublishActionDisabled,
 } from "src/routes/Admin/editorStudioState"
-import { restoreEmptyFencedCodeBlocks } from "src/routes/Admin/editorStudioMetaModel"
+import { resolveEditorMetaSnapshot, restoreEmptyFencedCodeBlocks } from "src/routes/Admin/editorStudioMetaModel"
 import { getEditorStudioPageProps } from "src/routes/Admin/EditorStudioPage"
 import { buildPreviewSummaryFromMarkdown, normalizeCardSummary, normalizePersistedSummary } from "src/libs/postSummary"
 
@@ -615,7 +615,8 @@ test.describe("editor studio state", () => {
     expect(editorStudioMetaModelSource).toContain("export const resolveTagRecommendationErrorMessage =")
     expect(editorStudioMetaModelSource).toContain("export const formatTagRecommendationReason =")
     expect(editorStudioMetaModelSource).toContain("export const restoreEmptyFencedCodeBlocks =")
-    expect(editorStudioMetaModelSource).toContain("restoreEmptyFencedCodeBlocks(parsed.body, markdownFromHtml)")
+    expect(editorStudioMetaModelSource).toContain("const extractRawCodeFencedBlocksFromHtml =")
+    expect(editorStudioMetaModelSource).toContain("restoreEmptyFencedCodeBlocks(parsed.body, recoveredCodeMarkdown)")
     expect(editorStudioMetaModelSource).toContain("export const resolveEditorMetaSnapshot =")
     expect(editorStudioMetaModelSource).toContain("export const buildEditorStateFingerprint =")
     expect(editorStudioMetaModelSource).toContain("export const parseEditorMeta =")
@@ -857,6 +858,34 @@ test.describe("editor studio state", () => {
     ].join("\n")
 
     expect(restoreEmptyFencedCodeBlocks(staleContent, htmlRecoveredContent)).toContain(
+      ["```ts", "const answer = 42;", "return answer", "```"].join("\n")
+    )
+  })
+
+  test("contentHtml fallback은 pretty-code raw attribute만 있어도 빈 코드블럭을 복구한다", () => {
+    const staleContent = [
+      "수정 대상 코드입니다.",
+      "",
+      "```ts",
+      "",
+      "```",
+      "",
+      "다음 문단입니다.",
+    ].join("\n")
+    const prettyCodeHtml = [
+      '<div class="aq-code-block">',
+      '<div class="aq-code-toolbar"><span class="aq-code-language">TS</span></div>',
+      '<div class="aq-code-body"><div class="aq-code-shell">',
+      '<pre class="aq-code aq-pretty-pre">',
+      '<code class="language-ts" data-raw-code="const answer = 42;&#10;return answer">',
+      '<span class="token keyword">const</span> answer = 42;',
+      '</code>',
+      '</pre>',
+      '</div></div>',
+      '</div>',
+    ].join("")
+
+    expect(resolveEditorMetaSnapshot(staleContent, prettyCodeHtml).body).toContain(
       ["```ts", "const answer = 42;", "return answer", "```"].join("\n")
     )
   })

--- a/front/src/routes/Admin/editorStudioMetaModel.ts
+++ b/front/src/routes/Admin/editorStudioMetaModel.ts
@@ -59,6 +59,8 @@ const LEADING_EDITOR_METADATA_LINE_REGEX =
 const EDITOR_BODY_PLACEHOLDER = "내용을 입력하세요."
 const EDITOR_TOGGLE_TITLE_PLACEHOLDER = "토글 제목"
 const FENCED_CODE_BLOCK_REGEX = /(^|\n)(`{3,}|~{3,})([^\n]*)\n([\s\S]*?)\n\2(?=\n|$)/g
+const HTML_CODE_RAW_ATTRIBUTE_TAG_REGEX = /<(?:code|pre)\b([^>]*)>/gi
+const HTML_ATTRIBUTE_REGEX = /\s([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>`]+)))?/g
 
 export const PREVIEW_SUMMARY_MAX_LENGTH = 150
 export const PREVIEW_SUMMARY_MAX_CONTENT_LENGTH = 50_000
@@ -332,6 +334,62 @@ const extractNonEmptyFencedCodeBlocks = (content: string) => {
   return blocks
 }
 
+const decodeHtmlAttributeValue = (value: string) =>
+  value
+    .replace(/&#x([0-9a-f]+);/gi, (_match, code) => String.fromCodePoint(Number.parseInt(code, 16)))
+    .replace(/&#(\d+);/g, (_match, code) => String.fromCodePoint(Number.parseInt(code, 10)))
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/\r\n?/g, "\n")
+
+const readHtmlAttributes = (rawAttributes: string) => {
+  const attributes = new Map<string, string>()
+  rawAttributes.replace(HTML_ATTRIBUTE_REGEX, (_match, name, doubleQuoted, singleQuoted, unquoted) => {
+    const key = String(name).toLowerCase()
+    const value = doubleQuoted ?? singleQuoted ?? unquoted ?? ""
+    attributes.set(key, decodeHtmlAttributeValue(String(value)))
+    return _match
+  })
+  return attributes
+}
+
+const resolveCodeLanguageFromHtmlAttributes = (attributes: Map<string, string>) => {
+  const explicitLanguage = (
+    attributes.get("data-language") ||
+    attributes.get("data-prism-language") ||
+    ""
+  ).trim()
+  if (explicitLanguage) return explicitLanguage
+
+  const className = attributes.get("class") || ""
+  return (className.match(/(?:^|\s)language-([a-zA-Z0-9_-]+)/)?.[1] || "").trim()
+}
+
+const extractRawCodeFencedBlocksFromHtml = (contentHtml?: string | null) => {
+  if (!contentHtml?.trim()) return ""
+
+  const blocks: string[] = []
+  contentHtml.replace(HTML_CODE_RAW_ATTRIBUTE_TAG_REGEX, (_match, rawAttributes) => {
+    const attributes = readHtmlAttributes(String(rawAttributes))
+    const codeSource = (
+      attributes.get("data-raw-code") ||
+      attributes.get("data-prism-source") ||
+      ""
+    ).trimEnd()
+    if (!codeSource.trim()) return _match
+
+    const language = resolveCodeLanguageFromHtmlAttributes(attributes)
+    blocks.push(`\`\`\`${language}\n${codeSource}\n\`\`\``)
+    return _match
+  })
+
+  return blocks.join("\n\n")
+}
+
 export const restoreEmptyFencedCodeBlocks = (content: string, recoveredContent: string) => {
   const recoveredBlocks = extractNonEmptyFencedCodeBlocks(recoveredContent)
   if (recoveredBlocks.length === 0) return content
@@ -353,10 +411,12 @@ export const resolveEditorMetaSnapshot = (content: string, contentHtml?: string 
   const parsed = parseEditorMeta(content)
   const normalizedRawContent = content.replace(/\r\n?/g, "\n").trim()
   const markdownFromHtml = contentHtml?.trim() ? convertHtmlClipboardToMarkdown(contentHtml).trim() : ""
-  const restoredParsedBody = parsed.body.trim() && markdownFromHtml
-    ? restoreEmptyFencedCodeBlocks(parsed.body, markdownFromHtml)
+  const rawCodeMarkdownFromHtml = extractRawCodeFencedBlocksFromHtml(contentHtml)
+  const recoveredCodeMarkdown = [rawCodeMarkdownFromHtml, markdownFromHtml].filter(Boolean).join("\n\n")
+  const restoredParsedBody = parsed.body.trim() && recoveredCodeMarkdown
+    ? restoreEmptyFencedCodeBlocks(parsed.body, recoveredCodeMarkdown)
     : parsed.body
-  const resolvedBody = restoredParsedBody.trim() || markdownFromHtml || normalizedRawContent
+  const resolvedBody = restoredParsedBody.trim() || markdownFromHtml || rawCodeMarkdownFromHtml || normalizedRawContent
   const parsedThumbnail = normalizeSafeImageUrl(parsed.thumbnail)
   const fallbackThumbnail = normalizeSafeImageUrl(extractFirstMarkdownImage(resolvedBody))
   const syncedThumbnail = stripThumbnailFocusFromUrl(parsedThumbnail || fallbackThumbnail)


### PR DESCRIPTION
## 관련 이슈

close #207

## 작업 배경

- 글 수정 페이지에서 `content`의 빈 코드 fence가 `contentHtml` raw code 원문보다 우선되어 코드블럭 본문이 비는 문제를 수정했습니다.
- `resolveEditorMetaSnapshot`이 HTML 변환 결과뿐 아니라 pretty-code `data-raw-code`/`data-prism-source` 속성을 직접 읽어 빈 fenced code body를 복구합니다.

## 작업 내용

- `contentHtml` 안의 `code`/`pre` raw code attribute를 fenced markdown 후보로 추출하는 fallback을 추가했습니다.
- 기존 빈 fenced code block 복구가 `markdownFromHtml`만 보지 않고 raw attribute fallback까지 함께 사용하도록 변경했습니다.
- raw attribute-only pretty-code HTML 케이스를 `editor-studio-state` 회귀 테스트로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (RED 확인 후 GREEN 2회)
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (2회)
  - `yarn --cwd front lint` (2회)
  - `yarn --cwd front build` (2회)
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: `contentHtml` 속성 파싱 fallback이 코드블럭 복구 순서를 바꿀 수 있어 raw attribute-only 케이스와 기존 pretty-code markdown 복구 케이스를 함께 검증했습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 기존 `contentHtml` markdown 변환 기반 복구로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
