### PR TITLE
[CI] live E2E Playwright 설치 타임아웃 안정화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1142,13 +1142,13 @@ jobs:
 
       - name: Install Playwright browser
         working-directory: front
-        run: npx playwright install --with-deps chromium webkit
+        run: npx playwright install --with-deps chromium
 
       - name: Run live environment e2e
         working-directory: front
         env:
           PLAYWRIGHT_LIVE_FAIL_FAST: "true"
-          PLAYWRIGHT_LIVE_MULTI_BROWSER: "true"
+          PLAYWRIGHT_LIVE_MULTI_BROWSER: "false"
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## 관련 이슈

close #209

## 작업 배경

- deploy workflow의 live e2e browser install을 `chromium`만 설치하도록 축소했습니다.
- deploy gate의 live e2e를 `PLAYWRIGHT_LIVE_MULTI_BROWSER=false`로 고정해 WebKit apt dependency 설치 timeout을 제거했습니다.

## 작업 내용

- deploy workflow의 live e2e browser install을 `chromium`만 설치하도록 축소했습니다.
- deploy gate의 live e2e를 `PLAYWRIGHT_LIVE_MULTI_BROWSER=false`로 고정해 WebKit apt dependency 설치 timeout을 제거했습니다.

## 검증

- 실행한 명령과 결과:
  - `ruby -e 'Dir[".github/workflows/*.yml"].each { |f| require "yaml"; YAML.load_file(f) }'`
  - `rg -n "Install Playwright browser|PLAYWRIGHT_LIVE_MULTI_BROWSER|chromium webkit|chromium" .github/workflows/deploy.yml`
  - `PLAYWRIGHT_BASE_URL=https://www.aquilaxk.site yarn --cwd front test:e2e:live` -> 8 passed (52.4s)
  - `PLAYWRIGHT_BASE_URL=https://www.aquilaxk.site yarn --cwd front test:e2e:live` -> 8 passed (47.8s)
  - direct live `/editor/[id]` hidden post codeblock sentinel verification -> passed and post cleaned up

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 특이사항 없음

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
