### PR TITLE
[Refactor] editor dedicated surface 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -130,6 +130,14 @@ test.describe("editor studio state", () => {
 
   test("editor studio는 v2 단일 경로와 단일 작성 모드 계약을 유지한다", () => {
     const editorStudioSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/EditorStudioPage.tsx"), "utf8")
+    const dedicatedEditorSurfacePath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx"
+    )
+    expect(existsSync(dedicatedEditorSurfacePath)).toBe(true)
+    const dedicatedEditorSurfaceSource = existsSync(dedicatedEditorSurfacePath)
+      ? readFileSync(dedicatedEditorSurfacePath, "utf8")
+      : ""
     const editorStudioStateSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/editorStudioState.ts"), "utf8")
     const editorStudioMetaModelPath = path.resolve(__dirname, "../src/routes/Admin/editorStudioMetaModel.ts")
     expect(existsSync(editorStudioMetaModelPath)).toBe(true)
@@ -333,8 +341,11 @@ test.describe("editor studio state", () => {
     expect(editorStudioSource).not.toContain("EditorStudioLegacyToolbar")
     expect(editorStudioSource).not.toContain("RawMarkdownTextarea")
     expect(editorStudioSource).toContain("const isCompactSplitPreview = false")
-    expect(editorStudioSource).toContain("width: min(100%, 1600px);")
-    expect(editorStudioSource).toContain("grid-template-columns: minmax(0, 1fr);")
+    expect(editorStudioSource).toContain("EditorStudioDedicatedEditorSurface")
+    expect(editorStudioSource).not.toContain("const EditorStudioRoot")
+    expect(dedicatedEditorSurfaceSource).toContain("width: min(100%, 1600px);")
+    expect(dedicatedEditorSurfaceSource).toContain("grid-template-columns: minmax(0, 1fr);")
+    expect(dedicatedEditorSurfaceSource).toContain('data-testid="editor-studio-frame"')
     expect(editorStudioSource).toContain('import { WriterEditorHost } from "./WriterEditorHost"')
     expect(editorStudioSource.match(/<WriterEditorHost/g)?.length).toBe(2)
     expect(editorStudioSource).not.toContain("<LazyBlockEditorShell")
@@ -349,10 +360,10 @@ test.describe("editor studio state", () => {
     expect(editorStudioSource).not.toContain('aria-label="미리보기 기기 폭"')
     expect(editorStudioSource).not.toContain('zoom: var(--preview-scale, 1);')
     expect(editorStudioSource).not.toContain("--preview-scale")
-    expect(editorStudioSource).toContain("const EditorExitAction = styled.button`")
-    expect(editorStudioSource).toContain("min-height: 42px;")
-    expect(editorStudioSource).toContain("const EditorStudioFrame = styled.div`")
-    expect(editorStudioSource).toContain("const EditorStudioWritingColumn = styled.section<{ $compact?: boolean }>`")
+    expect(dedicatedEditorSurfaceSource).toContain("const EditorExitAction = styled.button`")
+    expect(dedicatedEditorSurfaceSource).toContain("min-height: 42px;")
+    expect(dedicatedEditorSurfaceSource).toContain("const EditorStudioFrame = styled.div`")
+    expect(dedicatedEditorSurfaceSource).toContain("const EditorStudioWritingColumn = styled.section<{ $compact?: boolean }>`")
     expect(editorStudioSource).not.toContain("type EditorMode =")
     expect(editorStudioSource).not.toContain("type PublishActionType =")
     expect(editorStudioSource).not.toContain("type PostVisibility =")

--- a/front/src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx
+++ b/front/src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx
@@ -1,0 +1,699 @@
+import styled from "@emotion/styled"
+import type {
+  ChangeEventHandler,
+  KeyboardEvent as ReactKeyboardEvent,
+  KeyboardEventHandler,
+  ReactNode,
+  Ref,
+} from "react"
+import ProfileImage from "src/components/ProfileImage"
+import { articleTypographyScale } from "src/libs/markdown/contentTypography"
+
+type NoticeTone = "idle" | "loading" | "success" | "error"
+
+type EditorStudioDedicatedEditorSurfaceProps = {
+  thumbnailImageFileInputRef: Ref<HTMLInputElement>
+  onThumbnailImageFileChange: ChangeEventHandler<HTMLInputElement>
+  onExit: () => void
+  saveStateText: string
+  saveStateTone: string
+  primaryActionDisabled: boolean
+  primaryActionLabel: string
+  onPrimaryAction: () => void
+  isCompactSplitPreview: boolean
+  postTags: string[]
+  tagDraft: string
+  onTagDraftChange: (value: string) => void
+  onAddTags: (values: string[]) => void
+  onAddTag: (value: string) => void
+  onRemoveTag: (value: string) => void
+  titleInputRef: (node: HTMLTextAreaElement | null) => void
+  postTitle: string
+  onPostTitleChange: ChangeEventHandler<HTMLTextAreaElement>
+  onPostTitleKeyDown: KeyboardEventHandler<HTMLTextAreaElement>
+  authorName: string
+  authorInitial: string
+  authorAvatarSrc: string
+  previewDateText: string
+  currentVisibilityText: string
+  canOpenCurrentPostDetail: boolean
+  onOpenPostDetail: () => void
+  onCopyPostDetailLink: () => void
+  editorCanvas: ReactNode
+  showPublishNotice: boolean
+  publishNoticeTone: NoticeTone
+  publishNoticeText: string
+  resultPanel: ReactNode
+  publishModal: ReactNode
+}
+
+const isComposingKeyboardEvent = (event: ReactKeyboardEvent<HTMLElement>) => {
+  const nativeEvent = event.nativeEvent as globalThis.KeyboardEvent & {
+    isComposing?: boolean
+    keyCode?: number
+  }
+  return nativeEvent.isComposing === true || nativeEvent.keyCode === 229
+}
+
+export const EditorStudioDedicatedEditorLoadingState = () => (
+  <EditorStudioRoot>
+    <EditorStudioLoadingState>
+      <strong>편집 화면을 준비하고 있습니다.</strong>
+      <span>잠시만 기다려 주세요.</span>
+    </EditorStudioLoadingState>
+  </EditorStudioRoot>
+)
+
+export const EditorStudioDedicatedEditorSurface = ({
+  thumbnailImageFileInputRef,
+  onThumbnailImageFileChange,
+  onExit,
+  saveStateText,
+  saveStateTone,
+  primaryActionDisabled,
+  primaryActionLabel,
+  onPrimaryAction,
+  isCompactSplitPreview,
+  postTags,
+  tagDraft,
+  onTagDraftChange,
+  onAddTags,
+  onAddTag,
+  onRemoveTag,
+  titleInputRef,
+  postTitle,
+  onPostTitleChange,
+  onPostTitleKeyDown,
+  authorName,
+  authorInitial,
+  authorAvatarSrc,
+  previewDateText,
+  currentVisibilityText,
+  canOpenCurrentPostDetail,
+  onOpenPostDetail,
+  onCopyPostDetailLink,
+  editorCanvas,
+  showPublishNotice,
+  publishNoticeTone,
+  publishNoticeText,
+  resultPanel,
+  publishModal,
+}: EditorStudioDedicatedEditorSurfaceProps) => (
+  <EditorStudioRoot>
+    <input
+      ref={thumbnailImageFileInputRef}
+      type="file"
+      accept="image/*"
+      onChange={onThumbnailImageFileChange}
+      style={{ display: "none" }}
+    />
+
+    <EditorStudioTopBar>
+      <EditorExitAction type="button" onClick={onExit}>
+        ← 나가기
+      </EditorExitAction>
+      <EditorStudioTopBarActions>
+        {saveStateText ? (
+          <EditorStudioSaveState data-tone={saveStateTone}>{saveStateText}</EditorStudioSaveState>
+        ) : null}
+        <PrimaryButton type="button" disabled={primaryActionDisabled} onClick={onPrimaryAction}>
+          {primaryActionLabel}
+        </PrimaryButton>
+      </EditorStudioTopBarActions>
+    </EditorStudioTopBar>
+
+    <EditorStudioFrame data-testid="editor-studio-frame">
+      <EditorStudioWritingColumn data-testid="editor-writing-column" $compact={isCompactSplitPreview}>
+        <EditorStudioMetaSection $compact={isCompactSplitPreview}>
+          <EditorTagRow aria-label="태그 입력" $compact={isCompactSplitPreview}>
+            {postTags.map((tag) => (
+              <SelectedTagChip key={tag}>
+                <span className="label">{tag}</span>
+                <button type="button" onClick={() => onRemoveTag(tag)} aria-label={`${tag} 삭제`}>
+                  ×
+                </button>
+              </SelectedTagChip>
+            ))}
+            <InlineMetaInput
+              placeholder="태그 입력 후 Enter"
+              value={tagDraft}
+              onChange={(event) => {
+                const nextValue = event.target.value
+                const commaSeparated = /[,，]/
+                if (!commaSeparated.test(nextValue)) {
+                  onTagDraftChange(nextValue)
+                  return
+                }
+
+                const fragments = nextValue.split(commaSeparated)
+                const tailDraft = fragments.pop() ?? ""
+                const tagsToAdd = fragments.map((fragment) => fragment.trim()).filter(Boolean)
+                if (tagsToAdd.length > 0) onAddTags(tagsToAdd)
+                onTagDraftChange(tailDraft)
+              }}
+              onKeyDown={(event) => {
+                if (isComposingKeyboardEvent(event)) return
+                if (event.key === "Enter" || event.key === ",") {
+                  event.preventDefault()
+                  onAddTag(event.currentTarget.value)
+                }
+              }}
+            />
+          </EditorTagRow>
+          <TitleInput
+            $compact={isCompactSplitPreview}
+            ref={titleInputRef}
+            id="post-title"
+            placeholder="제목을 입력하세요"
+            rows={1}
+            value={postTitle}
+            onChange={onPostTitleChange}
+            onKeyDown={onPostTitleKeyDown}
+          />
+          <EditorHeaderMetaRow>
+            <EditorHeaderAuthor>
+              <EditorHeaderAvatar $compact={isCompactSplitPreview}>
+                {authorAvatarSrc ? (
+                  <ProfileImage src={authorAvatarSrc} alt={`${authorName} 프로필 이미지`} fillContainer />
+                ) : (
+                  <span className="initial">{authorInitial}</span>
+                )}
+              </EditorHeaderAvatar>
+              <EditorHeaderAuthorText $compact={isCompactSplitPreview}>
+                <strong>{authorName}</strong>
+                <span>{previewDateText}</span>
+              </EditorHeaderAuthorText>
+            </EditorHeaderAuthor>
+            <EditorHeaderMetaActions>
+              <EditorHeaderMetaPill $compact={isCompactSplitPreview}>{currentVisibilityText}</EditorHeaderMetaPill>
+              {canOpenCurrentPostDetail ? (
+                <>
+                  <EditorHeaderActionButton type="button" onClick={onOpenPostDetail}>
+                    상세 열기
+                  </EditorHeaderActionButton>
+                  <EditorHeaderActionButton type="button" onClick={onCopyPostDetailLink}>
+                    링크 복사
+                  </EditorHeaderActionButton>
+                </>
+              ) : null}
+            </EditorHeaderMetaActions>
+          </EditorHeaderMetaRow>
+        </EditorStudioMetaSection>
+
+        <EditorStudioCanvas>{editorCanvas}</EditorStudioCanvas>
+
+        {showPublishNotice ? <PublishNotice data-tone={publishNoticeTone}>{publishNoticeText}</PublishNotice> : null}
+      </EditorStudioWritingColumn>
+    </EditorStudioFrame>
+
+    {resultPanel}
+    {publishModal}
+  </EditorStudioRoot>
+)
+
+const EditorStudioRoot = styled.main`
+  width: min(100%, 1600px);
+  margin: 0 auto;
+  padding: 1.4rem 1.6rem 2rem;
+  display: grid;
+  gap: 1.2rem;
+  overflow-x: clip;
+
+  @media (max-width: 1024px) {
+    padding: 1rem 1rem 1.4rem;
+  }
+
+  @media (max-width: 768px) {
+    padding-top: 0.92rem;
+    padding-bottom: 1.2rem;
+    padding-left: max(0.82rem, env(safe-area-inset-left, 0px));
+    padding-right: max(0.82rem, env(safe-area-inset-right, 0px));
+  }
+`
+
+const EditorStudioLoadingState = styled.div`
+  min-height: calc(100vh - 10rem);
+  display: grid;
+  place-content: center;
+  gap: 0.4rem;
+  text-align: center;
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 1.1rem;
+  }
+
+  span {
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.9rem;
+  }
+`
+
+const EditorStudioTopBar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 48px;
+
+  @media (max-width: 1200px) {
+    align-items: center;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    gap: 0.8rem;
+  }
+
+  @media (max-width: 760px) {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0.7rem;
+  }
+`
+
+const EditorExitAction = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0.2rem 0.32rem;
+  margin: -0.2rem -0.32rem;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray12};
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color 0.18s ease,
+    color 0.18s ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.gray3};
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  @media (max-width: 1200px) {
+    justify-content: flex-start;
+  }
+`
+
+const EditorStudioTopBarActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: nowrap;
+  justify-content: flex-end;
+
+  @media (max-width: 1200px) {
+    width: auto;
+    margin-left: auto;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+  }
+
+  @media (max-width: 760px) {
+    width: 100%;
+    margin-left: 0;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+`
+
+const EditorStudioSaveState = styled.span`
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.84rem;
+  font-weight: 600;
+  white-space: nowrap;
+  text-align: right;
+
+  &[data-tone="success"] {
+    color: ${({ theme }) => theme.colors.green10};
+  }
+
+  &[data-tone="loading"] {
+    color: ${({ theme }) => theme.colors.blue9};
+  }
+
+  &[data-tone="error"] {
+    color: ${({ theme }) => theme.colors.red10};
+  }
+
+  @media (max-width: 680px) {
+    width: 100%;
+  }
+`
+
+const Button = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+const PrimaryButton = styled(Button)`
+  border-radius: 8px;
+  padding: 0.6rem 0.88rem;
+  border-color: ${({ theme }) => theme.colors.blue9};
+  background: ${({ theme }) => theme.colors.blue9};
+  color: ${({ theme }) => theme.colors.gray1};
+  font-weight: 700;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.blue10};
+    background: ${({ theme }) => theme.colors.blue10};
+    color: ${({ theme }) => theme.colors.gray1};
+  }
+`
+
+const EditorStudioFrame = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.4rem;
+  align-items: start;
+  justify-content: center;
+  overflow-x: visible;
+
+  @media (min-width: 1024px) {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.4rem;
+  }
+`
+
+const EditorStudioWritingColumn = styled.section<{ $compact?: boolean }>`
+  display: grid;
+  min-width: 0;
+  gap: ${({ $compact }) => ($compact ? "0.88rem" : "1rem")};
+  overflow-x: visible;
+`
+
+const EditorStudioMetaSection = styled.section<{ $compact?: boolean }>`
+  width: 100%;
+  max-width: var(--article-readable-width, 48rem);
+  min-width: 0;
+  margin-inline: auto;
+  display: grid;
+  gap: ${({ $compact }) => ($compact ? "0.72rem" : "0.9rem")};
+`
+
+const EditorTagRow = styled.div<{ $compact?: boolean }>`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: ${({ $compact }) => ($compact ? "0.44rem" : "0.55rem")};
+  min-height: 32px;
+`
+
+const SelectedTagChip = styled.span`
+  display: inline-flex;
+  align-items: stretch;
+  gap: 0;
+  min-width: 0;
+  max-width: 100%;
+  min-height: 32px;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray3};
+  overflow: hidden;
+  transition:
+    border-color 0.18s ease,
+    transform 0.18s ease,
+    background 0.18s ease;
+
+  &:hover {
+    transform: none;
+  }
+
+  .label {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding: 0.38rem 0.78rem;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.86rem;
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    align-self: stretch;
+    min-width: 1.92rem;
+    padding: 0 0.52rem;
+    border: 0;
+    border-left: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => theme.colors.gray2};
+    color: ${({ theme }) => theme.colors.gray10};
+    cursor: pointer;
+    flex: 0 0 auto;
+    font-size: 0.98rem;
+    line-height: 1;
+    transition:
+      transform 0.18s ease,
+      background 0.18s ease,
+      color 0.18s ease;
+
+    &:hover {
+      transform: none;
+      background: ${({ theme }) => theme.colors.gray4};
+      color: ${({ theme }) => theme.colors.gray12};
+    }
+  }
+`
+
+const InlineMetaInput = styled.input`
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  flex: 1 1 12rem;
+  min-width: 11rem;
+  border: 0;
+  border-bottom: 1px dashed ${({ theme }) => theme.colors.gray6};
+  outline: none;
+  min-height: 32px;
+  padding: 0 0.12rem;
+  border-radius: 0;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray12};
+  font-size: 0.86rem;
+  font-weight: 500;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray10};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
+  }
+`
+
+const TitleInput = styled.textarea<{ $compact?: boolean }>`
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  min-height: 44px;
+  background: transparent;
+  box-shadow: none;
+  font-family: inherit;
+  font-size: ${articleTypographyScale.postTitleFontSize};
+  font-weight: 700;
+  line-height: ${articleTypographyScale.postTitleLineHeight};
+  letter-spacing: 0;
+  resize: none;
+  overflow: hidden;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray9};
+  }
+
+  &:focus {
+    box-shadow: none;
+    border-color: transparent;
+  }
+
+  @media (max-width: 720px) {
+    font-size: ${articleTypographyScale.postTitleFontSizeMobile};
+    line-height: ${articleTypographyScale.postTitleLineHeightMobile};
+  }
+`
+
+const EditorHeaderMetaRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  min-width: 0;
+`
+
+const EditorHeaderMetaActions = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  min-width: 0;
+`
+
+const EditorHeaderAuthor = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  min-width: 0;
+`
+
+const EditorHeaderAvatar = styled.div<{ $compact?: boolean }>`
+  position: relative;
+  width: ${({ $compact }) => ($compact ? "40px" : "48px")};
+  height: ${({ $compact }) => ($compact ? "40px" : "48px")};
+  flex-shrink: 0;
+  border-radius: 999px;
+  overflow: hidden;
+  background: ${({ theme }) => theme.colors.gray3};
+
+  .initial {
+    display: inline-flex;
+    width: 100%;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.84rem;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+  }
+`
+
+const EditorHeaderAuthorText = styled.div<{ $compact?: boolean }>`
+  display: grid;
+  gap: ${({ $compact }) => ($compact ? "0.12rem" : "0.18rem")};
+  min-width: 0;
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: ${({ $compact }) => ($compact ? "0.94rem" : "1rem")};
+    font-weight: 700;
+    overflow-wrap: anywhere;
+  }
+
+  span {
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: ${({ $compact }) => ($compact ? "0.82rem" : "0.9rem")};
+    font-weight: 500;
+  }
+`
+
+const EditorHeaderMetaPill = styled.span<{ $compact?: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  min-height: ${({ $compact }) => ($compact ? "30px" : "34px")};
+  padding: ${({ $compact }) => ($compact ? "0 0.72rem" : "0 0.82rem")};
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray2};
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: ${({ $compact }) => ($compact ? "0.74rem" : "0.82rem")};
+  font-weight: 650;
+  line-height: 1;
+`
+
+const EditorHeaderActionButton = styled(Button)`
+  min-height: 34px;
+  padding: 0.45rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+`
+
+const EditorStudioCanvas = styled.section`
+  --compose-pane-readable-width: var(--article-readable-width, 48rem);
+  width: 100%;
+  max-width: var(--article-readable-width, 48rem);
+  min-width: 0;
+  margin-inline: auto;
+  min-height: clamp(28rem, 70vh, 56rem);
+  display: grid;
+  gap: 0.72rem;
+  overflow-x: visible;
+`
+
+const PublishNotice = styled.div`
+  margin: 0;
+  padding: 0.55rem 0.7rem;
+  border-radius: 10px;
+  font-size: 0.83rem;
+  line-height: 1.4;
+  width: 100%;
+  box-sizing: border-box;
+
+  &[data-tone="idle"] {
+    color: ${({ theme }) => theme.colors.gray11};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: transparent;
+  }
+
+  &[data-tone="loading"] {
+    color: ${({ theme }) => theme.colors.blue11};
+    border: 1px solid ${({ theme }) => theme.colors.blue7};
+    background: ${({ theme }) => theme.colors.blue3};
+  }
+
+  &[data-tone="success"] {
+    color: ${({ theme }) => theme.colors.green11};
+    border: 1px solid ${({ theme }) => theme.colors.green7};
+    background: ${({ theme }) => theme.colors.green3};
+  }
+
+  &[data-tone="error"] {
+    color: ${({ theme }) => theme.colors.red11};
+    border: 1px solid ${({ theme }) => theme.colors.red7};
+    background: ${({ theme }) => theme.colors.red3};
+  }
+
+  @media (max-width: 720px) {
+    width: 100%;
+  }
+`

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -65,6 +65,10 @@ import { EditorStudioUndoToast } from "./EditorStudioUndoToast"
 import { EditorStudioDeleteConfirmDialog } from "./EditorStudioDeleteConfirmDialog"
 import { EditorStudioComposeMobileChrome } from "./EditorStudioComposeMobileChrome"
 import {
+  EditorStudioDedicatedEditorLoadingState,
+  EditorStudioDedicatedEditorSurface,
+} from "./EditorStudioDedicatedEditorSurface"
+import {
   isServerTempDraftPost,
   TEMP_DRAFT_BODY_PLACEHOLDER,
 } from "./editorTempDraft"
@@ -100,7 +104,6 @@ import {
   getAdminPageProps,
   readAdminProtectedBootstrap,
 } from "src/libs/server/adminPage"
-import ProfileImage from "src/components/ProfileImage"
 import {
   applyThumbnailTransformToUrl,
   clampThumbnailZoom,
@@ -2486,36 +2489,6 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
     !postId.trim() &&
     (isNewEditorBootstrapPending || loadingKey === "postTemp")
   const shouldShowResultPanel = Boolean(loadingKey || result)
-  const dedicatedEditorTopBar = useMemo(
-    () => (
-      <EditorStudioTopBar>
-        <EditorExitAction type="button" onClick={handleExitDedicatedEditor}>
-          ← 나가기
-        </EditorExitAction>
-        <EditorStudioTopBarActions>
-          {composeStatusText ? (
-            <EditorStudioSaveState data-tone={composeStatusTone}>{composeStatusText}</EditorStudioSaveState>
-          ) : null}
-          <PrimaryButton
-            type="button"
-            disabled={publishActionTriggerDisabled}
-            onClick={() => openPublishModal(editorPrimaryActionType)}
-          >
-            {editorPrimaryActionLabel}
-          </PrimaryButton>
-        </EditorStudioTopBarActions>
-      </EditorStudioTopBar>
-    ),
-    [
-      composeStatusText,
-      composeStatusTone,
-      editorPrimaryActionLabel,
-      editorPrimaryActionType,
-      handleExitDedicatedEditor,
-      openPublishModal,
-      publishActionTriggerDisabled,
-    ]
-  )
   const dedicatedEditorResultPanel = useMemo(
     () =>
       shouldShowResultPanel ? (
@@ -2537,161 +2510,90 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
   }
 
   if (shouldShowEditorLoadingState) {
-    return (
-      <EditorStudioRoot>
-        <EditorStudioLoadingState>
-          <strong>편집 화면을 준비하고 있습니다.</strong>
-          <span>잠시만 기다려 주세요.</span>
-        </EditorStudioLoadingState>
-      </EditorStudioRoot>
-    )
+    return <EditorStudioDedicatedEditorLoadingState />
   }
 
   if (isDedicatedEditorRoute) {
     return (
-      <EditorStudioRoot>
-      <input
-        ref={thumbnailImageFileInputRef}
-        type="file"
-        accept="image/*"
-        onChange={handleThumbnailImageFileChange}
-        style={{ display: "none" }}
-      />
-
-      {dedicatedEditorTopBar}
-
-      <EditorStudioFrame data-testid="editor-studio-frame">
-        <EditorStudioWritingColumn data-testid="editor-writing-column" $compact={isCompactSplitPreview}>
-          <EditorStudioMetaSection $compact={isCompactSplitPreview}>
-            <EditorTagRow aria-label="태그 입력" $compact={isCompactSplitPreview}>
-              {postTags.map((tag) => (
-                <SelectedTagChip key={tag}>
-                  <span className="label">{tag}</span>
-                  <button type="button" onClick={() => removeTagFromPost(tag)} aria-label={`${tag} 삭제`}>
-                    ×
-                  </button>
-                </SelectedTagChip>
-              ))}
-              <InlineMetaInput
-                placeholder="태그 입력 후 Enter"
-                value={tagDraft}
-                onChange={(e) => {
-                  const nextValue = e.target.value
-                  const commaSeparated = /[,，]/
-                  if (!commaSeparated.test(nextValue)) {
-                    setTagDraft(nextValue)
-                    return
-                  }
-
-                  const fragments = nextValue.split(commaSeparated)
-                  const tailDraft = fragments.pop() ?? ""
-                  const tagsToAdd = fragments.map((fragment) => fragment.trim()).filter(Boolean)
-                  if (tagsToAdd.length > 0) addTagsToPost(tagsToAdd)
-                  setTagDraft(tailDraft)
-                }}
-                onKeyDown={(e) => {
-                  if (isComposingKeyboardEvent(e)) return
-                  if (e.key === "Enter" || e.key === ",") {
-                    e.preventDefault()
-                    addTagToPost(e.currentTarget.value)
-                  }
-                }}
-              />
-            </EditorTagRow>
-            <TitleInput
-              $compact={isCompactSplitPreview}
-              ref={handleTitleFieldRef}
-              id="post-title"
-              placeholder="제목을 입력하세요"
-              rows={1}
-              value={postTitle}
-              onChange={handleTitleChange}
-              onKeyDown={handleTitleKeyDown}
+      <EditorStudioDedicatedEditorSurface
+        thumbnailImageFileInputRef={thumbnailImageFileInputRef}
+        onThumbnailImageFileChange={handleThumbnailImageFileChange}
+        onExit={handleExitDedicatedEditor}
+        saveStateText={composeStatusText}
+        saveStateTone={composeStatusTone}
+        primaryActionDisabled={publishActionTriggerDisabled}
+        primaryActionLabel={editorPrimaryActionLabel}
+        onPrimaryAction={() => openPublishModal(editorPrimaryActionType)}
+        isCompactSplitPreview={isCompactSplitPreview}
+        postTags={postTags}
+        tagDraft={tagDraft}
+        onTagDraftChange={setTagDraft}
+        onAddTags={addTagsToPost}
+        onAddTag={addTagToPost}
+        onRemoveTag={removeTagFromPost}
+        titleInputRef={handleTitleFieldRef}
+        postTitle={postTitle}
+        onPostTitleChange={handleTitleChange}
+        onPostTitleKeyDown={handleTitleKeyDown}
+        authorName={displayName}
+        authorInitial={displayNameInitial}
+        authorAvatarSrc={previewAuthorAvatarSrc}
+        previewDateText={previewDateText}
+        currentVisibilityText={currentVisibilityText}
+        canOpenCurrentPostDetail={canOpenCurrentPostDetail}
+        onOpenPostDetail={() => void openPostDetailRoute(postId)}
+        onCopyPostDetailLink={() => void copyPostDetailLink(postId, postTitle)}
+        editorCanvas={dedicatedEditorCanvas}
+        showPublishNotice={shouldShowPublishNotice}
+        publishNoticeTone={publishNotice.tone}
+        publishNoticeText={publishNotice.text}
+        resultPanel={dedicatedEditorResultPanel}
+        publishModal={
+          isPublishModalOpen ? (
+            <EditorStudioPublishModal
+              closeToggleLabel="닫기"
+              displayName={displayName}
+              displayNameInitial={displayNameInitial}
+              isCompactMobileLayout={isCompactMobileLayout}
+              isMobileMetaEditorOpen={isMobileMetaEditorOpen}
+              isMobileThumbnailEditorOpen={isMobileThumbnailEditorOpen}
+              loadingKey={loadingKey}
+              modalNotice={publishModalNotice}
+              postThumbnailFocusX={postThumbnailFocusX}
+              postThumbnailFocusY={postThumbnailFocusY}
+              postThumbnailZoom={postThumbnailZoom}
+              postTitle={postTitle}
+              postVisibility={postVisibility}
+              previewAuthorAvatarSrc={previewAuthorAvatarSrc}
+              previewDateText={previewDateText}
+              previewFrameStyle={{ maxWidth: `${previewViewportConfig.cardWidth}px` }}
+              previewKicker="카드 미리보기"
+              previewMetaEditorPanel={previewMetaEditorPanel}
+              previewSummary={resolvedPreviewSummary}
+              previewSummaryFallback="요약을 비워두면 본문에서 자동 생성한 요약이 카드에 반영됩니다."
+              previewThumbnailSrc={previewThumbnailSrc}
+              previewViewport={previewViewport}
+              previewViewportLabel={previewViewportConfig.label}
+              previewViewportOptions={previewViewportOptions}
+              previewVisibilityLabel={previewVisibilityLabel}
+              publishActionButtonDisabled={publishActionButtonDisabled}
+              publishActionButtonText={publishActionButtonText}
+              publishActionTitle={publishActionTitle}
+              shouldShowNotice={shouldShowPublishModalNotice}
+              thumbnailEditorPanel={thumbnailEditorPanel}
+              variant="drawer"
+              visibilityOptions={PUBLISH_VISIBILITY_OPTIONS}
+              onClose={closePublishModal}
+              onConfirmPublish={() => void handleConfirmPublish()}
+              onPostVisibilityChange={setPostVisibility}
+              onPreviewThumbnailError={() => setIsPreviewThumbnailError(true)}
+              onPreviewViewportChange={setPreviewViewport}
+              onToggleMobileMetaEditor={() => setIsMobileMetaEditorOpen((current) => !current)}
+              onToggleMobileThumbnailEditor={() => setIsMobileThumbnailEditorOpen((current) => !current)}
             />
-            <EditorHeaderMetaRow>
-              <EditorHeaderAuthor>
-                <EditorHeaderAvatar $compact={isCompactSplitPreview}>
-                  {previewAuthorAvatarSrc ? (
-                    <ProfileImage src={previewAuthorAvatarSrc} alt={`${displayName} 프로필 이미지`} fillContainer />
-                  ) : (
-                    <span className="initial">{displayNameInitial}</span>
-                  )}
-                </EditorHeaderAvatar>
-                <EditorHeaderAuthorText $compact={isCompactSplitPreview}>
-                  <strong>{displayName}</strong>
-                  <span>{previewDateText}</span>
-                </EditorHeaderAuthorText>
-              </EditorHeaderAuthor>
-              <EditorHeaderMetaActions>
-                <EditorHeaderMetaPill $compact={isCompactSplitPreview}>{currentVisibilityText}</EditorHeaderMetaPill>
-                {canOpenCurrentPostDetail ? (
-                  <>
-                    <EditorHeaderActionButton type="button" onClick={() => void openPostDetailRoute(postId)}>
-                      상세 열기
-                    </EditorHeaderActionButton>
-                    <EditorHeaderActionButton type="button" onClick={() => void copyPostDetailLink(postId, postTitle)}>
-                      링크 복사
-                    </EditorHeaderActionButton>
-                  </>
-                ) : null}
-              </EditorHeaderMetaActions>
-            </EditorHeaderMetaRow>
-          </EditorStudioMetaSection>
-
-          <EditorStudioCanvas>
-            {dedicatedEditorCanvas}
-          </EditorStudioCanvas>
-
-          {shouldShowPublishNotice ? <PublishNotice data-tone={publishNotice.tone}>{publishNotice.text}</PublishNotice> : null}
-        </EditorStudioWritingColumn>
-      </EditorStudioFrame>
-
-      {dedicatedEditorResultPanel}
-
-      {isPublishModalOpen ? (
-        <EditorStudioPublishModal
-          closeToggleLabel="닫기"
-          displayName={displayName}
-          displayNameInitial={displayNameInitial}
-          isCompactMobileLayout={isCompactMobileLayout}
-          isMobileMetaEditorOpen={isMobileMetaEditorOpen}
-          isMobileThumbnailEditorOpen={isMobileThumbnailEditorOpen}
-          loadingKey={loadingKey}
-          modalNotice={publishModalNotice}
-          postThumbnailFocusX={postThumbnailFocusX}
-          postThumbnailFocusY={postThumbnailFocusY}
-          postThumbnailZoom={postThumbnailZoom}
-          postTitle={postTitle}
-          postVisibility={postVisibility}
-          previewAuthorAvatarSrc={previewAuthorAvatarSrc}
-          previewDateText={previewDateText}
-          previewFrameStyle={{ maxWidth: `${previewViewportConfig.cardWidth}px` }}
-          previewKicker="카드 미리보기"
-          previewMetaEditorPanel={previewMetaEditorPanel}
-          previewSummary={resolvedPreviewSummary}
-          previewSummaryFallback="요약을 비워두면 본문에서 자동 생성한 요약이 카드에 반영됩니다."
-          previewThumbnailSrc={previewThumbnailSrc}
-          previewViewport={previewViewport}
-          previewViewportLabel={previewViewportConfig.label}
-          previewViewportOptions={previewViewportOptions}
-          previewVisibilityLabel={previewVisibilityLabel}
-          publishActionButtonDisabled={publishActionButtonDisabled}
-          publishActionButtonText={publishActionButtonText}
-          publishActionTitle={publishActionTitle}
-          shouldShowNotice={shouldShowPublishModalNotice}
-          thumbnailEditorPanel={thumbnailEditorPanel}
-          variant="drawer"
-          visibilityOptions={PUBLISH_VISIBILITY_OPTIONS}
-          onClose={closePublishModal}
-          onConfirmPublish={() => void handleConfirmPublish()}
-          onPostVisibilityChange={setPostVisibility}
-          onPreviewThumbnailError={() => setIsPreviewThumbnailError(true)}
-          onPreviewViewportChange={setPreviewViewport}
-          onToggleMobileMetaEditor={() => setIsMobileMetaEditorOpen((current) => !current)}
-          onToggleMobileThumbnailEditor={() => setIsMobileThumbnailEditorOpen((current) => !current)}
-        />
-      ) : null}
-      </EditorStudioRoot>
+          ) : null
+        }
+      />
     )
   }
 
@@ -4157,282 +4059,6 @@ const SubActionRow = styled.div`
       justify-content: center;
     }
   }
-`
-
-const EditorStudioRoot = styled.main`
-  width: min(100%, 1600px);
-  margin: 0 auto;
-  padding: 1.4rem 1.6rem 2rem;
-  display: grid;
-  gap: 1.2rem;
-  overflow-x: clip;
-
-  @media (max-width: 1024px) {
-    padding: 1rem 1rem 1.4rem;
-  }
-
-  @media (max-width: 768px) {
-    padding-top: 0.92rem;
-    padding-bottom: 1.2rem;
-    padding-left: max(0.82rem, env(safe-area-inset-left, 0px));
-    padding-right: max(0.82rem, env(safe-area-inset-right, 0px));
-  }
-`
-
-const EditorStudioLoadingState = styled.div`
-  min-height: calc(100vh - 10rem);
-  display: grid;
-  place-content: center;
-  gap: 0.4rem;
-  text-align: center;
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 1.1rem;
-  }
-
-  span {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.9rem;
-  }
-`
-
-const EditorStudioTopBar = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  min-height: 48px;
-
-  @media (max-width: 1200px) {
-    align-items: center;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    justify-content: space-between;
-    gap: 0.8rem;
-  }
-
-  @media (max-width: 760px) {
-    align-items: stretch;
-    flex-direction: column;
-    gap: 0.7rem;
-  }
-`
-
-const EditorExitAction = styled.button`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 42px;
-  padding: 0.2rem 0.32rem;
-  margin: -0.2rem -0.32rem;
-  border: 0;
-  border-radius: 10px;
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray12};
-  font-size: 0.98rem;
-  font-weight: 700;
-  line-height: 1;
-  cursor: pointer;
-  transition:
-    background-color 0.18s ease,
-    color 0.18s ease;
-
-  &:hover {
-    background: ${({ theme }) => theme.colors.gray3};
-  }
-
-  &:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
-  }
-
-  @media (max-width: 1200px) {
-    justify-content: flex-start;
-  }
-`
-
-const EditorStudioTopBarActions = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  flex-wrap: nowrap;
-  justify-content: flex-end;
-
-  @media (max-width: 1200px) {
-    width: auto;
-    margin-left: auto;
-    justify-content: flex-end;
-    flex-wrap: nowrap;
-  }
-
-  @media (max-width: 760px) {
-    width: 100%;
-    margin-left: 0;
-    justify-content: flex-end;
-    flex-wrap: wrap;
-  }
-`
-
-const EditorStudioSaveState = styled.span`
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.84rem;
-  font-weight: 600;
-  white-space: nowrap;
-  text-align: right;
-
-  &[data-tone="success"] {
-    color: ${({ theme }) => theme.colors.green10};
-  }
-
-  &[data-tone="loading"] {
-    color: ${({ theme }) => theme.colors.blue9};
-  }
-
-  &[data-tone="error"] {
-    color: ${({ theme }) => theme.colors.red10};
-  }
-
-  @media (max-width: 680px) {
-    width: 100%;
-  }
-`
-
-const EditorStudioFrame = styled.div`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 1.4rem;
-  align-items: start;
-  justify-content: center;
-  overflow-x: visible;
-
-  @media (min-width: 1024px) {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 1.4rem;
-  }
-`
-
-const EditorStudioWritingColumn = styled.section<{ $compact?: boolean }>`
-  display: grid;
-  min-width: 0;
-  gap: ${({ $compact }) => ($compact ? "0.88rem" : "1rem")};
-  overflow-x: visible;
-`
-
-const EditorStudioMetaSection = styled.section<{ $compact?: boolean }>`
-  width: 100%;
-  max-width: var(--article-readable-width, 48rem);
-  min-width: 0;
-  margin-inline: auto;
-  display: grid;
-  gap: ${({ $compact }) => ($compact ? "0.72rem" : "0.9rem")};
-`
-
-const EditorTagRow = styled.div<{ $compact?: boolean }>`
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: ${({ $compact }) => ($compact ? "0.44rem" : "0.55rem")};
-  min-height: 32px;
-`
-
-const EditorHeaderMetaRow = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 0.85rem;
-  min-width: 0;
-`
-
-const EditorHeaderMetaActions = styled.div`
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-end;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-  min-width: 0;
-`
-
-const EditorHeaderAuthor = styled.div`
-  display: inline-flex;
-  align-items: center;
-  gap: 0.85rem;
-  min-width: 0;
-`
-
-const EditorHeaderAvatar = styled.div<{ $compact?: boolean }>`
-  position: relative;
-  width: ${({ $compact }) => ($compact ? "40px" : "48px")};
-  height: ${({ $compact }) => ($compact ? "40px" : "48px")};
-  flex-shrink: 0;
-  border-radius: 999px;
-  overflow: hidden;
-  background: ${({ theme }) => theme.colors.gray3};
-
-  .initial {
-    display: inline-flex;
-    width: 100%;
-    height: 100%;
-    align-items: center;
-    justify-content: center;
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.84rem;
-    font-weight: 800;
-    letter-spacing: 0.04em;
-  }
-`
-
-const EditorHeaderAuthorText = styled.div<{ $compact?: boolean }>`
-  display: grid;
-  gap: ${({ $compact }) => ($compact ? "0.12rem" : "0.18rem")};
-  min-width: 0;
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: ${({ $compact }) => ($compact ? "0.94rem" : "1rem")};
-    font-weight: 700;
-    overflow-wrap: anywhere;
-  }
-
-  span {
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: ${({ $compact }) => ($compact ? "0.82rem" : "0.9rem")};
-    font-weight: 500;
-  }
-`
-
-const EditorHeaderMetaPill = styled.span<{ $compact?: boolean }>`
-  display: inline-flex;
-  align-items: center;
-  min-height: ${({ $compact }) => ($compact ? "30px" : "34px")};
-  padding: ${({ $compact }) => ($compact ? "0 0.72rem" : "0 0.82rem")};
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
-  color: ${({ theme }) => theme.colors.gray11};
-  font-size: ${({ $compact }) => ($compact ? "0.74rem" : "0.82rem")};
-  font-weight: 650;
-  line-height: 1;
-`
-
-const EditorHeaderActionButton = styled(Button)`
-  min-height: 34px;
-  padding: 0.45rem 0.7rem;
-  border-radius: 999px;
-  font-size: 0.78rem;
-`
-
-const EditorStudioCanvas = styled.section`
-  --compose-pane-readable-width: var(--article-readable-width, 48rem);
-  width: 100%;
-  max-width: var(--article-readable-width, 48rem);
-  min-width: 0;
-  margin-inline: auto;
-  min-height: clamp(28rem, 70vh, 56rem);
-  display: grid;
-  gap: 0.72rem;
-  overflow-x: visible;
 `
 
 const WriterFooterBar = styled.div`


### PR DESCRIPTION
## 관련 이슈

close #211

## 작업 배경

- 전용 글쓰기 route의 top bar, tag/title/header, canvas shell, loading state를 `EditorStudioDedicatedEditorSurface`로 분리했습니다.
- `EditorStudioPage.tsx`는 dedicated editor 상태/핸들러 wiring과 publish modal 조립만 맡도록 줄였고, 구조 가드 테스트도 새 책임 경계 기준으로 갱신했습니다.

## 작업 내용

- `EditorStudioDedicatedEditorSurface.tsx`를 추가해 dedicated editor surface/layout JSX와 스타일을 소유하게 했습니다.
- `EditorStudioPage.tsx`에서 dedicated editor surface styled shell과 inline JSX를 제거하고 component props로 연결했습니다.
- `editor-studio-state.spec.ts` 구조 가드가 dedicated surface component에서 layout contract를 확인하도록 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front test:e2e:authoring` (73 passed, 2회 연속 통과)
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (17 passed, 2회 연속 통과; sandbox bind EPERM 후 동일 명령을 권한 밖에서 실행)
  - `git diff --check`
  - `git diff --cached --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: dedicated editor surface prop wiring 누락 시 `/editor/new` 또는 `/editor/[id]` 상단 액션/태그/제목 UI가 영향을 받을 수 있습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 기존 inline dedicated editor surface로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
