### PR TITLE
[Refactor] editor compose writing surface 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -288,6 +288,14 @@ test.describe("editor studio state", () => {
     const editorStudioComposeMobileChromeSource = existsSync(editorStudioComposeMobileChromePath)
       ? readFileSync(editorStudioComposeMobileChromePath, "utf8")
       : ""
+    const editorStudioComposeWritingSurfacePath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioComposeWritingSurface.tsx"
+    )
+    expect(existsSync(editorStudioComposeWritingSurfacePath)).toBe(true)
+    const editorStudioComposeWritingSurfaceSource = existsSync(editorStudioComposeWritingSurfacePath)
+      ? readFileSync(editorStudioComposeWritingSurfacePath, "utf8")
+      : ""
     const blockEditorShellSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorShell.tsx"), "utf8")
     const blockEditorEngineSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tsx"), "utf8")
     const blockSelectionModelSource = readFileSync(
@@ -604,6 +612,22 @@ test.describe("editor studio state", () => {
     expect(editorStudioComposeMobileChromeSource).not.toContain("openPublishModal")
     expect(editorStudioComposeMobileChromeSource).not.toContain("setMobileComposeStep")
     expect(editorStudioComposeMobileChromeSource).not.toContain("setPostVisibility")
+    expect(editorStudioComposeWritingSurfaceSource).toContain("export const EditorStudioComposeWritingSurface =")
+    expect(editorStudioSource).toContain(
+      'import { EditorStudioComposeWritingSurface } from "./EditorStudioComposeWritingSurface"'
+    )
+    expect(editorStudioSource.match(/<EditorStudioComposeWritingSurface/g)?.length).toBe(1)
+    expect(editorStudioComposeWritingSurfaceSource).toContain("const ComposeMainColumn = styled.div`")
+    expect(editorStudioComposeWritingSurfaceSource).toContain("const TitleInput = styled.textarea`")
+    expect(editorStudioComposeWritingSurfaceSource).toContain("const WriterFooterBar = styled.div`")
+    expect(editorStudioSource).not.toContain("const ComposeMainColumn = styled.div`")
+    expect(editorStudioSource).not.toContain("const TitleInput = styled.textarea")
+    expect(editorStudioSource).not.toContain("const WriterFooterBar = styled.div`")
+    expect(editorStudioComposeWritingSurfaceSource).not.toContain("apiFetch(")
+    expect(editorStudioComposeWritingSurfaceSource).not.toContain("run(")
+    expect(editorStudioComposeWritingSurfaceSource).not.toContain("openPublishModal")
+    expect(editorStudioComposeWritingSurfaceSource).not.toContain("WriterEditorHost")
+    expect(editorStudioComposeWritingSurfaceSource).not.toContain("setPost")
     expect(editorStudioStateSource).toContain("export type PostVisibility =")
     expect(editorStudioStateSource).toContain("export const toVisibility")
     expect(editorStudioStateSource).toContain("export const toFlags")

--- a/front/src/routes/Admin/EditorStudioComposeWritingSurface.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeWritingSurface.tsx
@@ -1,0 +1,711 @@
+import styled from "@emotion/styled"
+import type {
+  ChangeEventHandler,
+  KeyboardEvent as ReactKeyboardEvent,
+  KeyboardEventHandler,
+  ReactNode,
+  Ref,
+} from "react"
+import { articleTypographyScale } from "src/libs/markdown/contentTypography"
+
+type EditorStudioComposeWritingSurfaceProps = {
+  editorModeLabel: string
+  composePageTitle: string
+  composeSurfaceSubtitle: string
+  composeStatusText: string
+  composeStatusTone: string
+  currentVisibilityText: string
+  postSummary: string
+  postSummaryMaxLength: number
+  onPostSummaryChange: (value: string) => void
+  isFillSummaryFromBodyDisabled: boolean
+  onFillSummaryFromBody: () => void
+  postTags: string[]
+  tagDraft: string
+  onTagDraftChange: (value: string) => void
+  onAddTags: (values: string[]) => void
+  onAddTag: (value: string) => void
+  onRemoveTag: (value: string) => void
+  titleInputRef: (node: HTMLTextAreaElement | null) => void
+  postTitle: string
+  onPostTitleChange: ChangeEventHandler<HTMLTextAreaElement>
+  onPostTitleKeyDown: KeyboardEventHandler<HTMLTextAreaElement>
+  thumbnailImageFileInputRef: Ref<HTMLInputElement>
+  onThumbnailImageFileChange: ChangeEventHandler<HTMLInputElement>
+  contentLength: number
+  lineCount: number
+  imageCount: number
+  editorCanvas: ReactNode
+  tagSummaryText: string
+  isSaveDraftDisabled: boolean
+  onSaveDraft: () => void
+  primaryActionDisabled: boolean
+  primaryActionLabel: string
+  onPrimaryAction: () => void
+}
+
+const isComposingKeyboardEvent = (event: ReactKeyboardEvent<HTMLElement>) => {
+  const nativeEvent = event.nativeEvent as globalThis.KeyboardEvent & {
+    isComposing?: boolean
+    keyCode?: number
+  }
+  return nativeEvent.isComposing === true || nativeEvent.keyCode === 229
+}
+
+export const EditorStudioComposeWritingSurface = ({
+  editorModeLabel,
+  composePageTitle,
+  composeSurfaceSubtitle,
+  composeStatusText,
+  composeStatusTone,
+  currentVisibilityText,
+  postSummary,
+  postSummaryMaxLength,
+  onPostSummaryChange,
+  isFillSummaryFromBodyDisabled,
+  onFillSummaryFromBody,
+  postTags,
+  tagDraft,
+  onTagDraftChange,
+  onAddTags,
+  onAddTag,
+  onRemoveTag,
+  titleInputRef,
+  postTitle,
+  onPostTitleChange,
+  onPostTitleKeyDown,
+  thumbnailImageFileInputRef,
+  onThumbnailImageFileChange,
+  contentLength,
+  lineCount,
+  imageCount,
+  editorCanvas,
+  tagSummaryText,
+  isSaveDraftDisabled,
+  onSaveDraft,
+  primaryActionDisabled,
+  primaryActionLabel,
+  onPrimaryAction,
+}: EditorStudioComposeWritingSurfaceProps) => {
+  const trimmedSummary = postSummary.trim()
+
+  return (
+    <ComposeMainColumn>
+      <ComposeStudioHeader>
+        <ComposeStudioHeaderCopy>
+          <ComposeStudioKicker>{editorModeLabel}</ComposeStudioKicker>
+          <h2>{composePageTitle}</h2>
+          <p>{composeSurfaceSubtitle}</p>
+        </ComposeStudioHeaderCopy>
+        <ComposeStudioContextBar aria-label="원고 상태">
+          {composeStatusText ? (
+            <ComposeStudioContextItem data-tone={composeStatusTone}>
+              <span>상태</span>
+              <strong>{composeStatusText}</strong>
+            </ComposeStudioContextItem>
+          ) : null}
+          <ComposeStudioContextItem>
+            <span>공개 범위</span>
+            <strong>{currentVisibilityText}</strong>
+          </ComposeStudioContextItem>
+          <ComposeStudioContextItem>
+            <span>카드 요약</span>
+            <strong>{trimmedSummary ? `${trimmedSummary.length}자` : "자동 생성"}</strong>
+          </ComposeStudioContextItem>
+        </ComposeStudioContextBar>
+      </ComposeStudioHeader>
+
+      <ComposeReadableIntro>
+        <WriterHeader>
+          <div className="titleField">
+            <TitleInput
+              ref={titleInputRef}
+              id="post-title"
+              placeholder="제목을 입력하세요"
+              rows={1}
+              value={postTitle}
+              onChange={onPostTitleChange}
+              onKeyDown={onPostTitleKeyDown}
+            />
+            <WriterAccent />
+          </div>
+        </WriterHeader>
+        <ComposeSummaryField>
+          <FieldLabel htmlFor="post-summary-inline">요약</FieldLabel>
+          <ComposeSummaryInput
+            id="post-summary-inline"
+            placeholder="이 글의 핵심을 짧게 정리하세요"
+            value={postSummary}
+            maxLength={postSummaryMaxLength}
+            onChange={(event) => onPostSummaryChange(event.target.value)}
+          />
+          <ComposeSummaryMeta>
+            <SummaryCounter>
+              {postSummary.length}/{postSummaryMaxLength}
+            </SummaryCounter>
+            <Button type="button" disabled={isFillSummaryFromBodyDisabled} onClick={onFillSummaryFromBody}>
+              본문 기준으로 채우기
+            </Button>
+          </ComposeSummaryMeta>
+        </ComposeSummaryField>
+        <InlineTagComposer>
+          <div className="headerRow">
+            <span className="label">태그</span>
+          </div>
+          <InlineTagList>
+            {postTags.map((tag) => (
+              <SelectedTagChip key={tag}>
+                <span className="label">{tag}</span>
+                <button type="button" onClick={() => onRemoveTag(tag)} aria-label={`${tag} 삭제`}>
+                  ×
+                </button>
+              </SelectedTagChip>
+            ))}
+            <InlineMetaInput
+              placeholder="태그 입력 후 Enter"
+              value={tagDraft}
+              onChange={(event) => {
+                const nextValue = event.target.value
+                const commaSeparated = /[,，]/
+                if (!commaSeparated.test(nextValue)) {
+                  onTagDraftChange(nextValue)
+                  return
+                }
+
+                const fragments = nextValue.split(commaSeparated)
+                const tailDraft = fragments.pop() ?? ""
+                const tagsToAdd = fragments.map((fragment) => fragment.trim()).filter(Boolean)
+                if (tagsToAdd.length > 0) onAddTags(tagsToAdd)
+                onTagDraftChange(tailDraft)
+              }}
+              onKeyDown={(event) => {
+                if (isComposingKeyboardEvent(event)) return
+                if (event.key === "Enter" || event.key === ",") {
+                  event.preventDefault()
+                  onAddTag(event.currentTarget.value)
+                }
+              }}
+            />
+          </InlineTagList>
+        </InlineTagComposer>
+      </ComposeReadableIntro>
+
+      <input
+        ref={thumbnailImageFileInputRef}
+        type="file"
+        accept="image/*"
+        onChange={onThumbnailImageFileChange}
+        style={{ display: "none" }}
+      />
+
+      <ComposeBodySection>
+        <ComposeBodyHeader>
+          <ComposeBodyTitleGroup>
+            <h3>본문</h3>
+          </ComposeBodyTitleGroup>
+          <ComposeBodyMetrics>
+            <span>{contentLength.toLocaleString()}자</span>
+            <span>{lineCount}줄</span>
+            <span>{imageCount}개 이미지</span>
+          </ComposeBodyMetrics>
+        </ComposeBodyHeader>
+        {editorCanvas}
+      </ComposeBodySection>
+
+      <WriterFooterBar>
+        <WriterFooterSummary>
+          <span>{tagSummaryText}</span>
+          <span>{contentLength}자 · {lineCount}줄</span>
+        </WriterFooterSummary>
+        <WriterFooterControls>
+          <WriterFooterActions>
+            <Button type="button" disabled={isSaveDraftDisabled} onClick={onSaveDraft}>
+              임시 저장
+            </Button>
+            <PrimaryButton type="button" disabled={primaryActionDisabled} onClick={onPrimaryAction}>
+              {primaryActionLabel}
+            </PrimaryButton>
+          </WriterFooterActions>
+        </WriterFooterControls>
+      </WriterFooterBar>
+    </ComposeMainColumn>
+  )
+}
+
+const ComposeMainColumn = styled.div`
+  display: grid;
+  gap: 1.1rem;
+  min-width: 0;
+`
+
+const ComposeStudioHeader = styled.div`
+  display: grid;
+  gap: 0.9rem;
+
+  @media (min-width: 960px) {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+  }
+`
+
+const ComposeStudioHeaderCopy = styled.div`
+  display: grid;
+  gap: 0.28rem;
+  min-width: 0;
+
+  h2 {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: clamp(1.45rem, 2.3vw, 2rem);
+    line-height: 1.15;
+    font-weight: 760;
+    letter-spacing: 0;
+  }
+
+  p {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.92rem;
+    line-height: 1.58;
+    max-width: 34rem;
+  }
+`
+
+const ComposeStudioKicker = styled.span`
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+`
+
+const ComposeStudioContextBar = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  justify-content: flex-start;
+
+  @media (min-width: 960px) {
+    justify-content: flex-end;
+  }
+`
+
+const ComposeStudioContextItem = styled.div`
+  display: grid;
+  gap: 0.08rem;
+  min-width: 7rem;
+  padding: 0.5rem 0.68rem;
+  border: 1px solid ${({ theme }) => theme.colors.gray5};
+  border-radius: 12px;
+  background: ${({ theme }) => theme.colors.gray2};
+
+  span {
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.68rem;
+    font-weight: 700;
+  }
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.82rem;
+    font-weight: 720;
+    line-height: 1.35;
+  }
+
+  &[data-tone="loading"] strong {
+    color: ${({ theme }) => theme.colors.blue11};
+  }
+
+  &[data-tone="success"] strong {
+    color: ${({ theme }) => theme.colors.green11};
+  }
+
+  &[data-tone="error"] strong {
+    color: ${({ theme }) => theme.colors.red11};
+  }
+`
+
+const WriterHeader = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin-bottom: 0.55rem;
+
+  .titleField {
+    display: grid;
+    gap: 1rem;
+    min-width: 0;
+  }
+`
+
+const WriterAccent = styled.div`
+  width: 5rem;
+  height: 0.42rem;
+  border-radius: 999px;
+  background: ${({ theme }) => theme.colors.gray8};
+`
+
+const TitleInput = styled.textarea`
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  min-height: 44px;
+  background: transparent;
+  box-shadow: none;
+  font-family: inherit;
+  font-size: ${articleTypographyScale.postTitleFontSize};
+  font-weight: 700;
+  line-height: ${articleTypographyScale.postTitleLineHeight};
+  letter-spacing: 0;
+  resize: none;
+  overflow: hidden;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray9};
+  }
+
+  &:focus {
+    box-shadow: none;
+    border-color: transparent;
+  }
+
+  @media (max-width: 720px) {
+    font-size: ${articleTypographyScale.postTitleFontSizeMobile};
+    line-height: ${articleTypographyScale.postTitleLineHeightMobile};
+  }
+`
+
+const ComposeReadableIntro = styled.div`
+  width: 100%;
+  max-width: var(--article-readable-width, 48rem);
+  min-width: 0;
+  margin-inline: auto;
+  display: grid;
+  gap: 1rem;
+`
+
+const ComposeSummaryField = styled.div`
+  display: grid;
+  gap: 0.45rem;
+`
+
+const FieldLabel = styled.label`
+  font-size: 0.8rem;
+  font-weight: 650;
+  color: ${({ theme }) => theme.colors.gray11};
+`
+
+const ComposeSummaryInput = styled.textarea`
+  width: 100%;
+  min-height: 5.6rem;
+  border: 1px solid ${({ theme }) => theme.colors.gray5};
+  border-radius: 16px;
+  padding: 0.95rem 1rem;
+  background: ${({ theme }) => theme.colors.gray2};
+  color: ${({ theme }) => theme.colors.gray12};
+  font-size: 1rem;
+  line-height: 1.7;
+  resize: vertical;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray10};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.gray7};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+`
+
+const ComposeSummaryMeta = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+`
+
+const SummaryCounter = styled.span`
+  justify-self: end;
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.74rem;
+  line-height: 1;
+`
+
+const InlineTagComposer = styled.div`
+  display: grid;
+  gap: 0.55rem;
+  min-width: 0;
+
+  .label {
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.88rem;
+    font-weight: 700;
+  }
+
+  .headerRow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+  }
+
+  .status {
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.78rem;
+    font-weight: 600;
+  }
+`
+
+const InlineTagList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  min-height: auto;
+  align-items: center;
+  border-radius: 0;
+  border: none;
+  background: transparent;
+  padding: 0;
+`
+
+const InlineMetaInput = styled.input`
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  flex: 1 1 12rem;
+  min-width: 11rem;
+  border: 0;
+  border-bottom: 1px dashed ${({ theme }) => theme.colors.gray6};
+  outline: none;
+  min-height: 32px;
+  padding: 0 0.12rem;
+  border-radius: 0;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray12};
+  font-size: 0.86rem;
+  font-weight: 500;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray10};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
+  }
+`
+
+const SelectedTagChip = styled.span`
+  display: inline-flex;
+  align-items: stretch;
+  gap: 0;
+  min-width: 0;
+  max-width: 100%;
+  min-height: 32px;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray3};
+  overflow: hidden;
+  transition:
+    border-color 0.18s ease,
+    transform 0.18s ease,
+    background 0.18s ease;
+
+  &:hover {
+    transform: none;
+  }
+
+  .label {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding: 0.38rem 0.78rem;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.86rem;
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    align-self: stretch;
+    min-width: 1.92rem;
+    padding: 0 0.52rem;
+    border: 0;
+    border-left: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => theme.colors.gray2};
+    color: ${({ theme }) => theme.colors.gray10};
+    cursor: pointer;
+    flex: 0 0 auto;
+    font-size: 0.98rem;
+    line-height: 1;
+    transition:
+      transform 0.18s ease,
+      background 0.18s ease,
+      color 0.18s ease;
+
+    &:hover {
+      transform: none;
+      background: ${({ theme }) => theme.colors.gray4};
+      color: ${({ theme }) => theme.colors.gray12};
+    }
+  }
+`
+
+const ComposeBodySection = styled.section`
+  display: grid;
+  gap: 0.82rem;
+`
+
+const ComposeBodyHeader = styled.div`
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  max-width: var(--article-readable-width, 48rem);
+  min-width: 0;
+  margin-inline: auto;
+  padding-top: 0.2rem;
+
+  @media (max-width: 720px) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+`
+
+const ComposeBodyTitleGroup = styled.div`
+  display: grid;
+  gap: 0.14rem;
+
+  h3 {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.98rem;
+    font-weight: 760;
+    line-height: 1.3;
+  }
+`
+
+const ComposeBodyMetrics = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.76rem;
+  line-height: 1.4;
+`
+
+const WriterFooterBar = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+  margin-top: 0.84rem;
+  padding-top: 0.72rem;
+  border-top: 1px solid ${({ theme }) => theme.colors.gray6};
+`
+
+const WriterFooterSummary = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.52rem 0.72rem;
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: 0.76rem;
+  line-height: 1.45;
+`
+
+const WriterFooterControls = styled.div`
+  display: grid;
+  gap: 0.52rem;
+  justify-items: stretch;
+  flex: 1 1 34rem;
+  width: min(100%, 48rem);
+  min-width: min(100%, 34rem);
+  max-width: 100%;
+  margin-left: auto;
+
+  @media (max-width: 720px) {
+    width: 100%;
+    min-width: 100%;
+  }
+`
+
+const WriterFooterActions = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  justify-content: flex-end;
+  align-items: center;
+
+  @media (max-width: 720px) {
+    display: none;
+  }
+`
+
+const Button = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+const PrimaryButton = styled(Button)`
+  border-radius: 8px;
+  padding: 0.6rem 0.88rem;
+  border-color: ${({ theme }) => theme.colors.blue9};
+  background: ${({ theme }) => theme.colors.blue9};
+  color: ${({ theme }) => theme.colors.gray1};
+  font-weight: 700;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.blue10};
+    background: ${({ theme }) => theme.colors.blue10};
+    color: ${({ theme }) => theme.colors.gray1};
+  }
+`

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -64,6 +64,7 @@ import { EditorStudioMobileStepNavigator } from "./EditorStudioMobileStepNavigat
 import { EditorStudioUndoToast } from "./EditorStudioUndoToast"
 import { EditorStudioDeleteConfirmDialog } from "./EditorStudioDeleteConfirmDialog"
 import { EditorStudioComposeMobileChrome } from "./EditorStudioComposeMobileChrome"
+import { EditorStudioComposeWritingSurface } from "./EditorStudioComposeWritingSurface"
 import {
   EditorStudioDedicatedEditorLoadingState,
   EditorStudioDedicatedEditorSurface,
@@ -120,7 +121,6 @@ import {
   PROFILE_IMAGE_UPLOAD_RULE_LABEL,
 } from "src/libs/profileImageUpload"
 import { saveProfileCardWithConflictRetry } from "src/libs/profileCardSave"
-import { articleTypographyScale } from "src/libs/markdown/contentTypography"
 import type { BlockEditorChangeMeta } from "src/components/editor/blockEditorContract"
 import {
   CATEGORY_CATALOG_STORAGE_KEY,
@@ -2819,156 +2819,44 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
             secondaryStatusText={mobileComposeStatusSecondary?.text}
             primaryActionLabel={mobilePrimaryActionLabel}
             primaryActionDisabled={mobilePrimaryActionDisabled}
-            onPrimaryAction={() => openPublishModal(editorMode === "create" ? "create" : isTempDraftMode ? "temp" : "modify")}
+            onPrimaryAction={() => openPublishModal(editorPrimaryActionType)}
           />
           <ComposeStudioLayout>
-            <ComposeMainColumn>
-              <ComposeStudioHeader>
-                <ComposeStudioHeaderCopy>
-                  <ComposeStudioKicker>{editorModeLabel}</ComposeStudioKicker>
-                  <h2>{composePageTitle}</h2>
-                  <p>{composeSurfaceSubtitle}</p>
-                </ComposeStudioHeaderCopy>
-                <ComposeStudioContextBar aria-label="원고 상태">
-                  {composeStatusText ? (
-                    <ComposeStudioContextItem data-tone={composeStatusTone}>
-                      <span>상태</span>
-                      <strong>{composeStatusText}</strong>
-                    </ComposeStudioContextItem>
-                  ) : null}
-                  <ComposeStudioContextItem>
-                    <span>공개 범위</span>
-                    <strong>{currentVisibilityText}</strong>
-                  </ComposeStudioContextItem>
-                  <ComposeStudioContextItem>
-                    <span>카드 요약</span>
-                    <strong>{postSummary.trim() ? `${postSummary.trim().length}자` : "자동 생성"}</strong>
-                  </ComposeStudioContextItem>
-                </ComposeStudioContextBar>
-              </ComposeStudioHeader>
-
-              <ComposeReadableIntro>
-                <WriterHeader>
-                  <div className="titleField">
-                    <TitleInput
-                      ref={handleTitleFieldRef}
-                      id="post-title"
-                      placeholder="제목을 입력하세요"
-                      rows={1}
-                      value={postTitle}
-                      onChange={handleTitleChange}
-                      onKeyDown={handleTitleKeyDown}
-                    />
-                    <WriterAccent />
-                  </div>
-                </WriterHeader>
-                <ComposeSummaryField>
-                  <FieldLabel htmlFor="post-summary-inline">요약</FieldLabel>
-                  <ComposeSummaryInput
-                    id="post-summary-inline"
-                    placeholder="이 글의 핵심을 짧게 정리하세요"
-                    value={postSummary}
-                    maxLength={PREVIEW_SUMMARY_MAX_LENGTH}
-                    onChange={(e) => setPostSummary(e.target.value)}
-                  />
-                  <ComposeSummaryMeta>
-                    <SummaryCounter>
-                      {postSummary.length}/{PREVIEW_SUMMARY_MAX_LENGTH}
-                    </SummaryCounter>
-                    <Button
-                      type="button"
-                      disabled={!postContent.trim()}
-                      onClick={() => setPostSummary(makePreviewSummary(postContent))}
-                    >
-                      본문 기준으로 채우기
-                    </Button>
-                  </ComposeSummaryMeta>
-                </ComposeSummaryField>
-                <InlineTagComposer>
-                  <div className="headerRow">
-                    <span className="label">태그</span>
-                  </div>
-                  <InlineTagList>
-                    {postTags.map((tag) => (
-                      <SelectedTagChip key={tag}>
-                        <span className="label">{tag}</span>
-                        <button type="button" onClick={() => removeTagFromPost(tag)} aria-label={`${tag} 삭제`}>
-                          ×
-                        </button>
-                      </SelectedTagChip>
-                    ))}
-                    <InlineMetaInput
-                      placeholder="태그 입력 후 Enter"
-                      value={tagDraft}
-                      onChange={(e) => {
-                        const nextValue = e.target.value
-                        const commaSeparated = /[,，]/
-                        if (!commaSeparated.test(nextValue)) {
-                          setTagDraft(nextValue)
-                          return
-                        }
-
-                        const fragments = nextValue.split(commaSeparated)
-                        const tailDraft = fragments.pop() ?? ""
-                        const tagsToAdd = fragments.map((fragment) => fragment.trim()).filter(Boolean)
-                        if (tagsToAdd.length > 0) addTagsToPost(tagsToAdd)
-                        setTagDraft(tailDraft)
-                      }}
-                      onKeyDown={(e) => {
-                        if (isComposingKeyboardEvent(e)) return
-                        if (e.key === "Enter" || e.key === ",") {
-                          e.preventDefault()
-                          addTagToPost(e.currentTarget.value)
-                        }
-                      }}
-                    />
-                  </InlineTagList>
-                </InlineTagComposer>
-              </ComposeReadableIntro>
-
-              <input
-                ref={thumbnailImageFileInputRef}
-                type="file"
-                accept="image/*"
-                onChange={handleThumbnailImageFileChange}
-                style={{ display: "none" }}
-              />
-
-              <ComposeBodySection>
-                <ComposeBodyHeader>
-                  <ComposeBodyTitleGroup>
-                    <h3>본문</h3>
-                  </ComposeBodyTitleGroup>
-                  <ComposeBodyMetrics>
-                    <span>{contentLength.toLocaleString()}자</span>
-                    <span>{lineCount}줄</span>
-                    <span>{imageCount}개 이미지</span>
-                  </ComposeBodyMetrics>
-                </ComposeBodyHeader>
-                {composeEditorCanvas}
-              </ComposeBodySection>
-
-              <WriterFooterBar>
-                <WriterFooterSummary>
-                  <span>{tagSummaryText}</span>
-                  <span>{contentLength}자 · {lineCount}줄</span>
-                </WriterFooterSummary>
-                <WriterFooterControls>
-                  <WriterFooterActions>
-                    <Button type="button" disabled={loadingKey.length > 0} onClick={() => saveLocalDraft()}>
-                      임시 저장
-                    </Button>
-                    <PrimaryButton
-                      type="button"
-                      disabled={mobilePrimaryActionDisabled}
-                      onClick={() => openPublishModal(editorMode === "create" ? "create" : isTempDraftMode ? "temp" : "modify")}
-                    >
-                      {composeCallToActionLabel}
-                    </PrimaryButton>
-                  </WriterFooterActions>
-                </WriterFooterControls>
-              </WriterFooterBar>
-            </ComposeMainColumn>
+            <EditorStudioComposeWritingSurface
+              editorModeLabel={editorModeLabel}
+              composePageTitle={composePageTitle}
+              composeSurfaceSubtitle={composeSurfaceSubtitle}
+              composeStatusText={composeStatusText}
+              composeStatusTone={composeStatusTone}
+              currentVisibilityText={currentVisibilityText}
+              postSummary={postSummary}
+              postSummaryMaxLength={PREVIEW_SUMMARY_MAX_LENGTH}
+              onPostSummaryChange={setPostSummary}
+              isFillSummaryFromBodyDisabled={!postContent.trim()}
+              onFillSummaryFromBody={() => setPostSummary(makePreviewSummary(postContent))}
+              postTags={postTags}
+              tagDraft={tagDraft}
+              onTagDraftChange={setTagDraft}
+              onAddTags={addTagsToPost}
+              onAddTag={addTagToPost}
+              onRemoveTag={removeTagFromPost}
+              titleInputRef={handleTitleFieldRef}
+              postTitle={postTitle}
+              onPostTitleChange={handleTitleChange}
+              onPostTitleKeyDown={handleTitleKeyDown}
+              thumbnailImageFileInputRef={thumbnailImageFileInputRef}
+              onThumbnailImageFileChange={handleThumbnailImageFileChange}
+              contentLength={contentLength}
+              lineCount={lineCount}
+              imageCount={imageCount}
+              editorCanvas={composeEditorCanvas}
+              tagSummaryText={tagSummaryText}
+              isSaveDraftDisabled={loadingKey.length > 0}
+              onSaveDraft={saveLocalDraft}
+              primaryActionDisabled={mobilePrimaryActionDisabled}
+              primaryActionLabel={composeCallToActionLabel}
+              onPrimaryAction={() => openPublishModal(editorPrimaryActionType)}
+            />
 
             <ComposeAssistantColumn>
               <EditorStudioComposeAssistantPanel
@@ -2977,7 +2865,7 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
                   <PrimaryButton
                     type="button"
                     disabled={mobilePrimaryActionDisabled}
-                    onClick={() => openPublishModal(editorMode === "create" ? "create" : isTempDraftMode ? "temp" : "modify")}
+                    onClick={() => openPublishModal(editorPrimaryActionType)}
                   >
                     {composeCallToActionLabel}
                   </PrimaryButton>
@@ -3416,12 +3304,6 @@ const FieldBox = styled.div`
   }
 `
 
-const FieldLabel = styled.label`
-  font-size: 0.8rem;
-  font-weight: 650;
-  color: ${({ theme }) => theme.colors.gray11};
-`
-
 const InlineStatus = styled.div`
   margin-bottom: 0.85rem;
   padding: 0.62rem 0.72rem;
@@ -3505,40 +3387,6 @@ const Input = styled.input`
     outline: none;
     border-color: ${({ theme }) => theme.colors.blue8};
     box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
-  }
-`
-
-const TitleInput = styled.textarea<{ $compact?: boolean }>`
-  width: 100%;
-  min-width: 0;
-  border: 0;
-  border-radius: 0;
-  padding: 0;
-  min-height: 44px;
-  background: transparent;
-  box-shadow: none;
-  font-family: inherit;
-  font-size: ${articleTypographyScale.postTitleFontSize};
-  font-weight: 700;
-  line-height: ${articleTypographyScale.postTitleLineHeight};
-  letter-spacing: 0;
-  resize: none;
-  overflow: hidden;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.gray9};
-  }
-
-  &:focus {
-    box-shadow: none;
-    border-color: transparent;
-  }
-
-  @media (max-width: 720px) {
-    font-size: ${articleTypographyScale.postTitleFontSizeMobile};
-    line-height: ${articleTypographyScale.postTitleLineHeightMobile};
   }
 `
 
@@ -3660,382 +3508,8 @@ const ComposeStudioLayout = styled.div`
   }
 `
 
-const ComposeMainColumn = styled.div`
-  display: grid;
-  gap: 1.1rem;
-  min-width: 0;
-`
-
 const ComposeAssistantColumn = styled.aside`
   min-width: 0;
-`
-
-const ComposeStudioHeader = styled.div`
-  display: grid;
-  gap: 0.9rem;
-
-  @media (min-width: 960px) {
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: start;
-  }
-`
-
-const ComposeStudioHeaderCopy = styled.div`
-  display: grid;
-  gap: 0.28rem;
-  min-width: 0;
-
-  h2 {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: clamp(1.45rem, 2.3vw, 2rem);
-    line-height: 1.15;
-    font-weight: 760;
-    letter-spacing: -0.02em;
-  }
-
-  p {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.92rem;
-    line-height: 1.58;
-    max-width: 34rem;
-  }
-`
-
-const ComposeStudioKicker = styled.span`
-  display: inline-flex;
-  align-items: center;
-  width: fit-content;
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-`
-
-const ComposeStudioContextBar = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-  justify-content: flex-start;
-
-  @media (min-width: 960px) {
-    justify-content: flex-end;
-  }
-`
-
-const ComposeStudioContextItem = styled.div`
-  display: grid;
-  gap: 0.08rem;
-  min-width: 7rem;
-  padding: 0.5rem 0.68rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  border-radius: 12px;
-  background: ${({ theme }) => theme.colors.gray2};
-
-  span {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.68rem;
-    font-weight: 700;
-  }
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.82rem;
-    font-weight: 720;
-    line-height: 1.35;
-  }
-
-  &[data-tone="loading"] strong {
-    color: ${({ theme }) => theme.colors.blue11};
-  }
-
-  &[data-tone="success"] strong {
-    color: ${({ theme }) => theme.colors.green11};
-  }
-
-  &[data-tone="error"] strong {
-    color: ${({ theme }) => theme.colors.red11};
-  }
-`
-
-const WriterHeader = styled.div`
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1rem;
-  margin-bottom: 0.55rem;
-
-  .titleField {
-    display: grid;
-    gap: 1rem;
-    min-width: 0;
-  }
-`
-
-const WriterAccent = styled.div`
-  width: 5rem;
-  height: 0.42rem;
-  border-radius: 999px;
-  background: ${({ theme }) => theme.colors.gray8};
-`
-
-const InlineTagComposer = styled.div`
-  display: grid;
-  gap: 0.55rem;
-  min-width: 0;
-
-  .label {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.88rem;
-    font-weight: 700;
-  }
-
-  .headerRow {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.6rem;
-    flex-wrap: wrap;
-  }
-
-  .status {
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.78rem;
-    font-weight: 600;
-  }
-`
-
-const InlineTagList = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  min-height: auto;
-  align-items: center;
-  border-radius: 0;
-  border: none;
-  background: transparent;
-  padding: 0;
-`
-
-const InlineMetaInput = styled(Input)`
-  flex: 1 1 12rem;
-  min-width: 11rem;
-  border: 0;
-  border-bottom: 1px dashed ${({ theme }) => theme.colors.gray6};
-  outline: none;
-  min-height: 32px;
-  padding: 0 0.12rem;
-  border-radius: 0;
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray12};
-  font-size: 0.86rem;
-  font-weight: 500;
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.gray10};
-  }
-`
-
-const SummaryCounter = styled.span`
-  justify-self: end;
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.74rem;
-  line-height: 1;
-`
-
-const ComposeReadableIntro = styled.div`
-  width: 100%;
-  max-width: var(--article-readable-width, 48rem);
-  min-width: 0;
-  margin-inline: auto;
-  display: grid;
-  gap: 1rem;
-`
-
-const ComposeSummaryField = styled.div`
-  display: grid;
-  gap: 0.45rem;
-`
-
-const ComposeSummaryInput = styled.textarea`
-  width: 100%;
-  min-height: 5.6rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  border-radius: 16px;
-  padding: 0.95rem 1rem;
-  background: ${({ theme }) => theme.colors.gray2};
-  color: ${({ theme }) => theme.colors.gray12};
-  font-size: 1rem;
-  line-height: 1.7;
-  resize: vertical;
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.gray10};
-  }
-
-  &:focus-visible {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors.gray7};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
-  }
-`
-
-const ComposeSummaryMeta = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.7rem;
-  flex-wrap: wrap;
-`
-
-const ComposeBodySection = styled.section`
-  display: grid;
-  gap: 0.82rem;
-`
-
-const ComposeBodyHeader = styled.div`
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 0.75rem;
-  width: 100%;
-  max-width: var(--article-readable-width, 48rem);
-  min-width: 0;
-  margin-inline: auto;
-  padding-top: 0.2rem;
-
-  @media (max-width: 720px) {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-`
-
-const ComposeBodyTitleGroup = styled.div`
-  display: grid;
-  gap: 0.14rem;
-
-  h3 {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.98rem;
-    font-weight: 760;
-    line-height: 1.3;
-  }
-`
-
-const ComposeBodyMetrics = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  flex-wrap: wrap;
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.76rem;
-  line-height: 1.4;
-`
-
-const PublishNotice = styled.div`
-  margin: 0;
-  padding: 0.55rem 0.7rem;
-  border-radius: 10px;
-  font-size: 0.83rem;
-  line-height: 1.4;
-  width: 100%;
-  box-sizing: border-box;
-
-  &[data-tone="idle"] {
-    color: ${({ theme }) => theme.colors.gray11};
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: transparent;
-  }
-
-  &[data-tone="loading"] {
-    color: ${({ theme }) => theme.colors.blue11};
-    border: 1px solid ${({ theme }) => theme.colors.blue7};
-    background: ${({ theme }) => theme.colors.blue3};
-  }
-
-  &[data-tone="success"] {
-    color: ${({ theme }) => theme.colors.green11};
-    border: 1px solid ${({ theme }) => theme.colors.green7};
-    background: ${({ theme }) => theme.colors.green3};
-  }
-
-  &[data-tone="error"] {
-    color: ${({ theme }) => theme.colors.red11};
-    border: 1px solid ${({ theme }) => theme.colors.red7};
-    background: ${({ theme }) => theme.colors.red3};
-  }
-
-  @media (max-width: 720px) {
-    width: 100%;
-  }
-`
-
-const SelectedTagChip = styled.span`
-  display: inline-flex;
-  align-items: stretch;
-  gap: 0;
-  min-width: 0;
-  max-width: 100%;
-  min-height: 32px;
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray3};
-  overflow: hidden;
-  transition:
-    border-color 0.18s ease,
-    transform 0.18s ease,
-    background 0.18s ease;
-
-  &:hover {
-    transform: none;
-  }
-
-  .label {
-    display: inline-flex;
-    align-items: center;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    padding: 0.38rem 0.78rem;
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.86rem;
-    font-weight: 600;
-    line-height: 1;
-  }
-
-  > button {
-    margin-left: 0;
-  }
-
-  button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    align-self: stretch;
-    min-width: 1.92rem;
-    padding: 0 0.52rem;
-    border: 0;
-    border-left: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray2};
-    color: ${({ theme }) => theme.colors.gray10};
-    cursor: pointer;
-    flex: 0 0 auto;
-    font-size: 0.98rem;
-    line-height: 1;
-    transition:
-      transform 0.18s ease,
-      background 0.18s ease,
-      color 0.18s ease;
-
-    &:hover {
-      transform: none;
-      background: ${({ theme }) => theme.colors.gray4};
-      color: ${({ theme }) => theme.colors.gray12};
-    }
-  }
 `
 
 const SubActionRow = styled.div`
@@ -4058,53 +3532,5 @@ const SubActionRow = styled.div`
       width: 100%;
       justify-content: center;
     }
-  }
-`
-
-const WriterFooterBar = styled.div`
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.8rem;
-  flex-wrap: wrap;
-  margin-top: 0.84rem;
-  padding-top: 0.72rem;
-  border-top: 1px solid ${({ theme }) => theme.colors.gray6};
-`
-
-const WriterFooterSummary = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.52rem 0.72rem;
-  color: ${({ theme }) => theme.colors.gray11};
-  font-size: 0.76rem;
-  line-height: 1.45;
-`
-
-const WriterFooterControls = styled.div`
-  display: grid;
-  gap: 0.52rem;
-  justify-items: stretch;
-  flex: 1 1 34rem;
-  width: min(100%, 48rem);
-  min-width: min(100%, 34rem);
-  max-width: 100%;
-  margin-left: auto;
-
-  @media (max-width: 720px) {
-    width: 100%;
-    min-width: 100%;
-  }
-`
-
-const WriterFooterActions = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
-  justify-content: flex-end;
-  align-items: center;
-
-  @media (max-width: 720px) {
-    display: none;
   }
 `


### PR DESCRIPTION
## 관련 이슈

close #213

## 작업 배경

- `EditorStudioPage.tsx`가 직접 소유하던 compose main writing surface의 header/context/title/summary/tag/body/footer 표시 책임을 `EditorStudioComposeWritingSurface.tsx`로 분리했습니다.
- 저장/발행/요약 생성/editor canvas 생성은 기존 page callback에 남겨 동작 변경 없이 page의 orchestration 책임만 유지했습니다.
- main merge 후 기존 CI가 통과하면 홈서버 자동 배포 경로로 이어지는 일반 PR 흐름입니다.

## 작업 내용

- compose writing surface 전용 presentational component를 추가했습니다.
- `EditorStudioPage.tsx`는 새 컴포넌트에 state, handler, editor canvas만 전달하도록 정리했습니다.
- `editor-studio-state` 구조 가드에 새 component 경계와 금지 의존성(`apiFetch`, `run`, `openPublishModal`, `WriterEditorHost`, post setter 직접 호출)을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front lint` PASS
  - `yarn --cwd front build` PASS
  - `yarn --cwd front playwright:preflight` PASS
  - `yarn --cwd front test:e2e:authoring` PASS, 73 passed, 2회 연속
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` PASS, 17 passed, 권한 보정 후 2회 연속
  - `git diff --cached --check` PASS
  - `CURRENT_TASK_SLUG=editor-studio-compose-writing-surface-split bash tools/guards/current-task-preflight.sh` PASS

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: prop wiring 누락 시 compose 작성 화면의 제목/요약/태그/footer action 표시가 깨질 수 있습니다. 구조 가드와 authoring 회귀로 기존 작성 동작을 확인했습니다.
- 롤백 방법: 이 PR의 단일 commit `81df7236`을 revert하면 기존 page 내부 JSX 소유 구조로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
