### PR TITLE
[Refactor] editor compose workspace shell 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -296,6 +296,14 @@ test.describe("editor studio state", () => {
     const editorStudioComposeWritingSurfaceSource = existsSync(editorStudioComposeWritingSurfacePath)
       ? readFileSync(editorStudioComposeWritingSurfacePath, "utf8")
       : ""
+    const editorStudioComposeWorkspacePath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioComposeWorkspace.tsx"
+    )
+    expect(existsSync(editorStudioComposeWorkspacePath)).toBe(true)
+    const editorStudioComposeWorkspaceSource = existsSync(editorStudioComposeWorkspacePath)
+      ? readFileSync(editorStudioComposeWorkspacePath, "utf8")
+      : ""
     const blockEditorShellSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorShell.tsx"), "utf8")
     const blockEditorEngineSource = readFileSync(path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tsx"), "utf8")
     const blockSelectionModelSource = readFileSync(
@@ -420,20 +428,20 @@ test.describe("editor studio state", () => {
     expect(editorStudioSource).not.toContain("const PublishModal = styled.div`")
     expect(editorStudioSource).not.toContain("const PublishOverviewGrid = styled.div`")
     expect(editorStudioComposeAssistantPanelSource).toContain("export const EditorStudioComposeAssistantPanel =")
-    expect(editorStudioSource).toContain(
+    expect(editorStudioComposeWorkspaceSource).toContain(
       'import { EditorStudioComposeAssistantPanel } from "./EditorStudioComposeAssistantPanel"'
     )
-    expect(editorStudioSource.match(/<EditorStudioComposeAssistantPanel/g)?.length).toBe(1)
+    expect(editorStudioComposeWorkspaceSource.match(/<EditorStudioComposeAssistantPanel/g)?.length).toBe(1)
     expect(editorStudioComposeAssistantPanelSource).toContain("const ComposeAssistantPanel = styled.div`")
     expect(editorStudioComposeAssistantPanelSource).toContain("const PreviewResultCard = styled.article`")
     expect(editorStudioSource).not.toContain("const ComposeAssistantPanel = styled.div`")
     expect(editorStudioSource).not.toContain("const PreviewResultCard = styled.article`")
     expect(editorStudioSource).not.toContain("const PublishSettingsSummary = styled.div`")
     expect(editorStudioMetadataAssistantPanelSource).toContain("export const EditorStudioMetadataAssistantPanel =")
-    expect(editorStudioSource).toContain(
+    expect(editorStudioComposeWorkspaceSource).toContain(
       'import { EditorStudioMetadataAssistantPanel } from "./EditorStudioMetadataAssistantPanel"'
     )
-    expect(editorStudioSource.match(/<EditorStudioMetadataAssistantPanel/g)?.length).toBe(1)
+    expect(editorStudioComposeWorkspaceSource.match(/<EditorStudioMetadataAssistantPanel/g)?.length).toBe(1)
     expect(editorStudioMetadataAssistantPanelSource).toContain("<strong>태그 정리</strong>")
     expect(editorStudioMetadataAssistantPanelSource).toContain("<strong>보조 작업</strong>")
     expect(editorStudioSource).not.toContain("<strong>태그 정리</strong>")
@@ -597,10 +605,6 @@ test.describe("editor studio state", () => {
     expect(editorStudioDeleteConfirmDialogSource).not.toContain("deletePostsFromList")
     expect(editorStudioDeleteConfirmDialogSource).not.toContain("setDeleteConfirmState")
     expect(editorStudioComposeMobileChromeSource).toContain("export const EditorStudioComposeMobileChrome =")
-    expect(editorStudioSource).toContain(
-      'import { EditorStudioComposeMobileChrome } from "./EditorStudioComposeMobileChrome"'
-    )
-    expect(editorStudioSource.match(/<EditorStudioComposeMobileChrome/g)?.length).toBe(1)
     expect(editorStudioComposeMobileChromeSource).toContain("const MobileComposeStatusBar = styled.div`")
     expect(editorStudioComposeMobileChromeSource).toContain("const MobilePrimaryActionBar = styled.div`")
     expect(editorStudioSource).not.toContain("<MobileComposeStatusBar")
@@ -613,16 +617,57 @@ test.describe("editor studio state", () => {
     expect(editorStudioComposeMobileChromeSource).not.toContain("setMobileComposeStep")
     expect(editorStudioComposeMobileChromeSource).not.toContain("setPostVisibility")
     expect(editorStudioComposeWritingSurfaceSource).toContain("export const EditorStudioComposeWritingSurface =")
+    expect(editorStudioComposeWorkspaceSource).toContain("export const EditorStudioComposeWorkspace =")
     expect(editorStudioSource).toContain(
+      'import { EditorStudioComposeWorkspace } from "./EditorStudioComposeWorkspace"'
+    )
+    expect(editorStudioSource.match(/<EditorStudioComposeWorkspace/g)?.length).toBe(1)
+    expect(editorStudioSource).toContain("composeCallToActionLabel={composeCallToActionLabel}")
+    expect(editorStudioSource).not.toContain(
+      'import { EditorStudioComposeMobileChrome } from "./EditorStudioComposeMobileChrome"'
+    )
+    expect(editorStudioSource).not.toContain(
       'import { EditorStudioComposeWritingSurface } from "./EditorStudioComposeWritingSurface"'
     )
-    expect(editorStudioSource.match(/<EditorStudioComposeWritingSurface/g)?.length).toBe(1)
+    expect(editorStudioSource).not.toContain(
+      'import { EditorStudioComposeAssistantPanel } from "./EditorStudioComposeAssistantPanel"'
+    )
+    expect(editorStudioSource).not.toContain(
+      'import { EditorStudioMetadataAssistantPanel } from "./EditorStudioMetadataAssistantPanel"'
+    )
+    expect(editorStudioSource).not.toContain("<EditorStudioComposeMobileChrome")
+    expect(editorStudioSource).not.toContain("<EditorStudioComposeWritingSurface")
+    expect(editorStudioSource).not.toContain("<EditorStudioComposeAssistantPanel")
+    expect(editorStudioSource).not.toContain("<EditorStudioMetadataAssistantPanel")
+    expect(editorStudioComposeWorkspaceSource).toContain(
+      'import { EditorStudioComposeAssistantPanel } from "./EditorStudioComposeAssistantPanel"'
+    )
+    expect(editorStudioComposeWorkspaceSource).toContain("EditorStudioComposeMobileChrome")
+    expect(editorStudioComposeWorkspaceSource).toContain("EditorStudioComposeWritingSurface")
+    expect(editorStudioComposeWorkspaceSource).toContain("EditorStudioMetadataAssistantPanel")
+    expect(editorStudioComposeWorkspaceSource).toContain("primaryActionLabel={composeCallToActionLabel}")
+    expect(editorStudioComposeWorkspaceSource).toContain("{composeCallToActionLabel}")
+    expect(editorStudioComposeWorkspaceSource).toContain("const ComposeSurfaceSection = styled.section`")
+    expect(editorStudioComposeWorkspaceSource).toContain("const ComposeStudioLayout = styled.div`")
+    expect(editorStudioComposeWorkspaceSource).toContain("const SubActionRow = styled.div`")
+    expect(editorStudioComposeWorkspaceSource).toContain("const PrimaryButton = styled(Button)`")
+    expect(editorStudioComposeWorkspaceSource).not.toContain("data-mobile-visible={!isCompactMobileLayout}")
+    expect(editorStudioComposeWorkspaceSource).not.toContain('[data-mobile-visible="false"]')
     expect(editorStudioComposeWritingSurfaceSource).toContain("const ComposeMainColumn = styled.div`")
     expect(editorStudioComposeWritingSurfaceSource).toContain("const TitleInput = styled.textarea`")
     expect(editorStudioComposeWritingSurfaceSource).toContain("const WriterFooterBar = styled.div`")
+    expect(editorStudioSource).not.toContain("const ComposeSurfaceSection = styled")
+    expect(editorStudioSource).not.toContain("const ComposeStudioLayout = styled.div`")
+    expect(editorStudioSource).not.toContain("const SubActionRow = styled.div`")
+    expect(editorStudioSource).not.toContain("const PrimaryButton = styled(Button)`")
     expect(editorStudioSource).not.toContain("const ComposeMainColumn = styled.div`")
     expect(editorStudioSource).not.toContain("const TitleInput = styled.textarea")
     expect(editorStudioSource).not.toContain("const WriterFooterBar = styled.div`")
+    expect(editorStudioComposeWorkspaceSource).not.toContain("apiFetch(")
+    expect(editorStudioComposeWorkspaceSource).not.toContain("run(")
+    expect(editorStudioComposeWorkspaceSource).not.toContain("openPublishModal")
+    expect(editorStudioComposeWorkspaceSource).not.toContain("WriterEditorHost")
+    expect(editorStudioComposeWorkspaceSource).not.toContain("setPost")
     expect(editorStudioComposeWritingSurfaceSource).not.toContain("apiFetch(")
     expect(editorStudioComposeWritingSurfaceSource).not.toContain("run(")
     expect(editorStudioComposeWritingSurfaceSource).not.toContain("openPublishModal")

--- a/front/src/routes/Admin/EditorStudioComposeWorkspace.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeWorkspace.tsx
@@ -1,0 +1,453 @@
+import styled from "@emotion/styled"
+import type {
+  ChangeEventHandler,
+  CSSProperties,
+  KeyboardEventHandler,
+  ReactNode,
+  Ref,
+} from "react"
+import type { PostVisibility } from "./editorStudioState"
+import { EditorStudioComposeAssistantPanel } from "./EditorStudioComposeAssistantPanel"
+import {
+  EditorStudioComposeMobileChrome,
+  type EditorStudioComposeMobileStatus,
+} from "./EditorStudioComposeMobileChrome"
+import { EditorStudioComposeWritingSurface } from "./EditorStudioComposeWritingSurface"
+import { EditorStudioMetadataAssistantPanel } from "./EditorStudioMetadataAssistantPanel"
+
+type NoticeTone = "idle" | "loading" | "success" | "error"
+type PreviewViewportMode = "desktop" | "tablet" | "mobile"
+
+type VisibilityOption = {
+  value: PostVisibility
+  label: string
+  description: string
+}
+
+type PreviewViewportOption = {
+  value: PreviewViewportMode
+  label: string
+}
+
+type ComposeStatusEntry = {
+  key: string
+  label: string
+  text: string
+  tone: NoticeTone
+}
+
+type EditorStudioComposeWorkspaceProps = {
+  isCompactMobileLayout: boolean
+  isPublishModalOpen: boolean
+  mobilePrimaryStatus: EditorStudioComposeMobileStatus
+  mobileSecondaryStatusText?: string | null
+  mobilePrimaryActionLabel: string
+  composeCallToActionLabel: string
+  mobilePrimaryActionDisabled: boolean
+  onPrimaryAction: () => void
+  currentVisibilityText: string
+  editorModeLabel: string
+  composePageTitle: string
+  composeSurfaceSubtitle: string
+  composeStatusText: string
+  composeStatusTone: string
+  postSummary: string
+  postSummaryMaxLength: number
+  onPostSummaryChange: (value: string) => void
+  isFillSummaryFromBodyDisabled: boolean
+  onFillSummaryFromBody: () => void
+  postTags: string[]
+  tagDraft: string
+  onTagDraftChange: (value: string) => void
+  onAddTags: (values: string[]) => void
+  onAddTag: (value: string) => void
+  onRemoveTag: (value: string) => void
+  titleInputRef: (node: HTMLTextAreaElement | null) => void
+  postTitle: string
+  onPostTitleChange: ChangeEventHandler<HTMLTextAreaElement>
+  onPostTitleKeyDown: KeyboardEventHandler<HTMLTextAreaElement>
+  thumbnailImageFileInputRef: Ref<HTMLInputElement>
+  onThumbnailImageFileChange: ChangeEventHandler<HTMLInputElement>
+  contentLength: number
+  lineCount: number
+  imageCount: number
+  editorCanvas: ReactNode
+  tagSummaryText: string
+  isSaveDraftDisabled: boolean
+  onSaveLocalDraft: () => void
+  composeHeroSummary: string[]
+  isRecommendTagsDisabled: boolean
+  isRecommendTagsLoading: boolean
+  onRecommendTags: () => void
+  composeStatusEntries: ComposeStatusEntry[]
+  activeVisibility: PostVisibility
+  visibilityOptions: VisibilityOption[]
+  onVisibilityChange: (visibility: PostVisibility) => void
+  previewViewport: PreviewViewportMode
+  previewViewportLabel: string
+  previewViewportOptions: PreviewViewportOption[]
+  onPreviewViewportChange: (viewport: PreviewViewportMode) => void
+  previewFrameStyle?: CSSProperties
+  previewThumbnailSrc: string
+  postThumbnailFocusX: number
+  postThumbnailFocusY: number
+  postThumbnailZoom: number
+  onPreviewThumbnailError: () => void
+  previewVisibilityLabel: string
+  summaryPreview: string
+  previewDateText: string
+  previewAuthorAvatarSrc: string
+  displayNameInitial: string
+  displayName: string
+  summaryLengthLabel: string
+  isComposeAssistOpen: boolean
+  onToggleComposeAssist: () => void
+  thumbnailEditorPanel: ReactNode
+  previewMetaEditorPanel: ReactNode
+  isTagPanelOpen: boolean
+  onToggleTagPanel: () => void
+  isUtilityPanelOpen: boolean
+  onToggleUtilityPanel: () => void
+  metaNotice: {
+    tone: NoticeTone
+    text: string
+  }
+  knownTags: string[]
+  tagUsageMap: Record<string, number>
+  onToggleKnownTag: (tag: string) => void
+  onDeleteKnownTag: (tag: string) => void
+  onRestoreLocalDraft: () => void
+  onClearLocalDraft: () => void
+  isClearLocalDraftDisabled: boolean
+}
+
+export const EditorStudioComposeWorkspace = ({
+  isCompactMobileLayout,
+  isPublishModalOpen,
+  mobilePrimaryStatus,
+  mobileSecondaryStatusText,
+  mobilePrimaryActionLabel,
+  composeCallToActionLabel,
+  mobilePrimaryActionDisabled,
+  onPrimaryAction,
+  currentVisibilityText,
+  editorModeLabel,
+  composePageTitle,
+  composeSurfaceSubtitle,
+  composeStatusText,
+  composeStatusTone,
+  postSummary,
+  postSummaryMaxLength,
+  onPostSummaryChange,
+  isFillSummaryFromBodyDisabled,
+  onFillSummaryFromBody,
+  postTags,
+  tagDraft,
+  onTagDraftChange,
+  onAddTags,
+  onAddTag,
+  onRemoveTag,
+  titleInputRef,
+  postTitle,
+  onPostTitleChange,
+  onPostTitleKeyDown,
+  thumbnailImageFileInputRef,
+  onThumbnailImageFileChange,
+  contentLength,
+  lineCount,
+  imageCount,
+  editorCanvas,
+  tagSummaryText,
+  isSaveDraftDisabled,
+  onSaveLocalDraft,
+  composeHeroSummary,
+  isRecommendTagsDisabled,
+  isRecommendTagsLoading,
+  onRecommendTags,
+  composeStatusEntries,
+  activeVisibility,
+  visibilityOptions,
+  onVisibilityChange,
+  previewViewport,
+  previewViewportLabel,
+  previewViewportOptions,
+  onPreviewViewportChange,
+  previewFrameStyle,
+  previewThumbnailSrc,
+  postThumbnailFocusX,
+  postThumbnailFocusY,
+  postThumbnailZoom,
+  onPreviewThumbnailError,
+  previewVisibilityLabel,
+  summaryPreview,
+  previewDateText,
+  previewAuthorAvatarSrc,
+  displayNameInitial,
+  displayName,
+  summaryLengthLabel,
+  isComposeAssistOpen,
+  onToggleComposeAssist,
+  thumbnailEditorPanel,
+  previewMetaEditorPanel,
+  isTagPanelOpen,
+  onToggleTagPanel,
+  isUtilityPanelOpen,
+  onToggleUtilityPanel,
+  metaNotice,
+  knownTags,
+  tagUsageMap,
+  onToggleKnownTag,
+  onDeleteKnownTag,
+  onRestoreLocalDraft,
+  onClearLocalDraft,
+  isClearLocalDraftDisabled,
+}: EditorStudioComposeWorkspaceProps) => (
+  <ComposeSurfaceSection>
+    <EditorSection>
+      <EditorStudioComposeMobileChrome
+        showStatus={isCompactMobileLayout}
+        showAction={isCompactMobileLayout && !isPublishModalOpen}
+        primaryStatus={mobilePrimaryStatus}
+        visibilityText={currentVisibilityText}
+        secondaryStatusText={mobileSecondaryStatusText}
+        primaryActionLabel={mobilePrimaryActionLabel}
+        primaryActionDisabled={mobilePrimaryActionDisabled}
+        onPrimaryAction={onPrimaryAction}
+      />
+      <ComposeStudioLayout>
+        <EditorStudioComposeWritingSurface
+          editorModeLabel={editorModeLabel}
+          composePageTitle={composePageTitle}
+          composeSurfaceSubtitle={composeSurfaceSubtitle}
+          composeStatusText={composeStatusText}
+          composeStatusTone={composeStatusTone}
+          currentVisibilityText={currentVisibilityText}
+          postSummary={postSummary}
+          postSummaryMaxLength={postSummaryMaxLength}
+          onPostSummaryChange={onPostSummaryChange}
+          isFillSummaryFromBodyDisabled={isFillSummaryFromBodyDisabled}
+          onFillSummaryFromBody={onFillSummaryFromBody}
+          postTags={postTags}
+          tagDraft={tagDraft}
+          onTagDraftChange={onTagDraftChange}
+          onAddTags={onAddTags}
+          onAddTag={onAddTag}
+          onRemoveTag={onRemoveTag}
+          titleInputRef={titleInputRef}
+          postTitle={postTitle}
+          onPostTitleChange={onPostTitleChange}
+          onPostTitleKeyDown={onPostTitleKeyDown}
+          thumbnailImageFileInputRef={thumbnailImageFileInputRef}
+          onThumbnailImageFileChange={onThumbnailImageFileChange}
+          contentLength={contentLength}
+          lineCount={lineCount}
+          imageCount={imageCount}
+          editorCanvas={editorCanvas}
+          tagSummaryText={tagSummaryText}
+          isSaveDraftDisabled={isSaveDraftDisabled}
+          onSaveDraft={onSaveLocalDraft}
+          primaryActionDisabled={mobilePrimaryActionDisabled}
+          primaryActionLabel={composeCallToActionLabel}
+          onPrimaryAction={onPrimaryAction}
+        />
+
+        <ComposeAssistantColumn>
+          <EditorStudioComposeAssistantPanel
+            composeHeroSummary={composeHeroSummary}
+            publishAction={
+              <PrimaryButton type="button" disabled={mobilePrimaryActionDisabled} onClick={onPrimaryAction}>
+                {composeCallToActionLabel}
+              </PrimaryButton>
+            }
+            tagRecommendationAction={
+              <Button type="button" disabled={isRecommendTagsDisabled} onClick={onRecommendTags}>
+                {isRecommendTagsLoading ? "태그 제안 중..." : "태그 제안"}
+              </Button>
+            }
+            composeStatusEntries={composeStatusEntries}
+            activeVisibility={activeVisibility}
+            visibilityOptions={visibilityOptions}
+            onVisibilityChange={onVisibilityChange}
+            previewViewport={previewViewport}
+            previewViewportLabel={previewViewportLabel}
+            previewViewportOptions={previewViewportOptions}
+            onPreviewViewportChange={onPreviewViewportChange}
+            previewFrameStyle={previewFrameStyle}
+            previewThumbnailSrc={previewThumbnailSrc}
+            postThumbnailFocusX={postThumbnailFocusX}
+            postThumbnailFocusY={postThumbnailFocusY}
+            postThumbnailZoom={postThumbnailZoom}
+            onPreviewThumbnailError={onPreviewThumbnailError}
+            previewVisibilityLabel={previewVisibilityLabel}
+            postTitle={postTitle}
+            summaryPreview={summaryPreview}
+            previewDateText={previewDateText}
+            previewAuthorAvatarSrc={previewAuthorAvatarSrc}
+            displayNameInitial={displayNameInitial}
+            displayName={displayName}
+            summaryLengthLabel={summaryLengthLabel}
+            isComposeAssistOpen={isComposeAssistOpen}
+            onToggleComposeAssist={onToggleComposeAssist}
+            thumbnailEditorPanel={thumbnailEditorPanel}
+            previewMetaEditorPanel={previewMetaEditorPanel}
+          >
+            <EditorStudioMetadataAssistantPanel
+              isTagPanelOpen={isTagPanelOpen}
+              onToggleTagPanel={onToggleTagPanel}
+              isUtilityPanelOpen={isUtilityPanelOpen}
+              onToggleUtilityPanel={onToggleUtilityPanel}
+              metaNotice={metaNotice}
+              knownTags={knownTags}
+              selectedTags={postTags}
+              tagUsageMap={tagUsageMap}
+              onToggleTag={onToggleKnownTag}
+              onDeleteTag={onDeleteKnownTag}
+              utilityActions={
+                <SubActionRow>
+                  <Button type="button" disabled={isSaveDraftDisabled} onClick={onSaveLocalDraft}>
+                    브라우저 임시저장
+                  </Button>
+                  <Button type="button" disabled={isSaveDraftDisabled} onClick={onRestoreLocalDraft}>
+                    임시저장 불러오기
+                  </Button>
+                  <Button type="button" disabled={isClearLocalDraftDisabled} onClick={onClearLocalDraft}>
+                    임시저장 삭제
+                  </Button>
+                </SubActionRow>
+              }
+            />
+          </EditorStudioComposeAssistantPanel>
+        </ComposeAssistantColumn>
+      </ComposeStudioLayout>
+    </EditorSection>
+  </ComposeSurfaceSection>
+)
+
+const ComposeSurfaceSection = styled.section`
+  display: grid;
+  gap: 1.2rem;
+  border: 1px solid ${({ theme }) => theme.colors.gray4};
+  border-radius: 14px;
+  padding: 1.1rem 1.1rem 1.3rem;
+  margin-bottom: 1.2rem;
+  background:
+    radial-gradient(circle at top left, rgba(96, 165, 250, 0.04), transparent 24%),
+    ${({ theme }) => theme.colors.gray1};
+  box-shadow: none;
+
+  h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  @media (max-width: 420px) {
+    gap: 1rem;
+    border-radius: 12px;
+    padding: 0.82rem 0.82rem 1rem;
+    margin-bottom: 0.95rem;
+  }
+`
+
+const EditorSection = styled.div`
+  margin: 1.12rem 0 0.25rem;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  background: transparent;
+
+  @media (max-width: 720px) {
+    padding: 0;
+    margin-top: 0.92rem;
+  }
+`
+
+const ComposeStudioLayout = styled.div`
+  display: grid;
+  gap: 1.4rem;
+  align-items: start;
+
+  @media (min-width: 1180px) {
+    grid-template-columns: minmax(0, 1fr) minmax(300px, 340px);
+  }
+
+  @media (max-width: 720px) {
+    gap: 1rem;
+  }
+`
+
+const ComposeAssistantColumn = styled.aside`
+  min-width: 0;
+`
+
+const SubActionRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.65rem;
+  padding-top: 0.65rem;
+  border-top: 1px dashed ${({ theme }) => theme.colors.gray6};
+
+  > button {
+    border-style: dashed;
+  }
+
+  @media (max-width: 720px) {
+    display: grid;
+    grid-template-columns: 1fr;
+
+    > button {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+`
+
+const Button = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+const PrimaryButton = styled(Button)`
+  border-radius: 8px;
+  padding: 0.6rem 0.88rem;
+  border-color: ${({ theme }) => theme.colors.blue9};
+  background: ${({ theme }) => theme.colors.blue9};
+  color: ${({ theme }) => theme.colors.gray1};
+  font-weight: 700;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.blue10};
+    background: ${({ theme }) => theme.colors.blue10};
+    color: ${({ theme }) => theme.colors.gray1};
+  }
+`

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -51,8 +51,6 @@ import {
   EditorStudioThumbnailMetaPanel,
 } from "./EditorStudioThumbnailPanels"
 import { EditorStudioPublishModal } from "./EditorStudioPublishModal"
-import { EditorStudioComposeAssistantPanel } from "./EditorStudioComposeAssistantPanel"
-import { EditorStudioMetadataAssistantPanel } from "./EditorStudioMetadataAssistantPanel"
 import { EditorStudioSelectedPostPanel } from "./EditorStudioSelectedPostPanel"
 import { EditorStudioSelectedPostToolsPanel } from "./EditorStudioSelectedPostToolsPanel"
 import { EditorStudioLegacyProfileSection } from "./EditorStudioLegacyProfileSection"
@@ -63,8 +61,7 @@ import { EditorStudioPostListPanel } from "./EditorStudioPostListPanel"
 import { EditorStudioMobileStepNavigator } from "./EditorStudioMobileStepNavigator"
 import { EditorStudioUndoToast } from "./EditorStudioUndoToast"
 import { EditorStudioDeleteConfirmDialog } from "./EditorStudioDeleteConfirmDialog"
-import { EditorStudioComposeMobileChrome } from "./EditorStudioComposeMobileChrome"
-import { EditorStudioComposeWritingSurface } from "./EditorStudioComposeWritingSurface"
+import { EditorStudioComposeWorkspace } from "./EditorStudioComposeWorkspace"
 import {
   EditorStudioDedicatedEditorLoadingState,
   EditorStudioDedicatedEditorSurface,
@@ -2809,139 +2806,89 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
           }}
         />
         {studioSurface === "compose" && (
-        <ComposeSurfaceSection>
-        <EditorSection data-mobile-visible={!isCompactMobileLayout || studioSurface === "compose"}>
-          <EditorStudioComposeMobileChrome
-            showStatus={isCompactMobileLayout}
-            showAction={isCompactMobileLayout && !isPublishModalOpen}
-            primaryStatus={mobileComposeStatusPrimary}
-            visibilityText={currentVisibilityText}
-            secondaryStatusText={mobileComposeStatusSecondary?.text}
-            primaryActionLabel={mobilePrimaryActionLabel}
-            primaryActionDisabled={mobilePrimaryActionDisabled}
+          <EditorStudioComposeWorkspace
+            isCompactMobileLayout={isCompactMobileLayout}
+            isPublishModalOpen={isPublishModalOpen}
+            mobilePrimaryStatus={mobileComposeStatusPrimary}
+            mobileSecondaryStatusText={mobileComposeStatusSecondary?.text}
+            mobilePrimaryActionLabel={mobilePrimaryActionLabel}
+            composeCallToActionLabel={composeCallToActionLabel}
+            mobilePrimaryActionDisabled={mobilePrimaryActionDisabled}
             onPrimaryAction={() => openPublishModal(editorPrimaryActionType)}
+            currentVisibilityText={currentVisibilityText}
+            editorModeLabel={editorModeLabel}
+            composePageTitle={composePageTitle}
+            composeSurfaceSubtitle={composeSurfaceSubtitle}
+            composeStatusText={composeStatusText}
+            composeStatusTone={composeStatusTone}
+            postSummary={postSummary}
+            postSummaryMaxLength={PREVIEW_SUMMARY_MAX_LENGTH}
+            onPostSummaryChange={setPostSummary}
+            isFillSummaryFromBodyDisabled={!postContent.trim()}
+            onFillSummaryFromBody={() => setPostSummary(makePreviewSummary(postContent))}
+            postTags={postTags}
+            tagDraft={tagDraft}
+            onTagDraftChange={setTagDraft}
+            onAddTags={addTagsToPost}
+            onAddTag={addTagToPost}
+            onRemoveTag={removeTagFromPost}
+            titleInputRef={handleTitleFieldRef}
+            postTitle={postTitle}
+            onPostTitleChange={handleTitleChange}
+            onPostTitleKeyDown={handleTitleKeyDown}
+            thumbnailImageFileInputRef={thumbnailImageFileInputRef}
+            onThumbnailImageFileChange={handleThumbnailImageFileChange}
+            contentLength={contentLength}
+            lineCount={lineCount}
+            imageCount={imageCount}
+            editorCanvas={composeEditorCanvas}
+            tagSummaryText={tagSummaryText}
+            isSaveDraftDisabled={loadingKey.length > 0}
+            onSaveLocalDraft={saveLocalDraft}
+            composeHeroSummary={composeHeroSummary}
+            isRecommendTagsDisabled={disabled("recommendTags") || !postContent.trim()}
+            isRecommendTagsLoading={loadingKey === "recommendTags"}
+            onRecommendTags={() => void handleRecommendTags()}
+            composeStatusEntries={composeStatusEntries}
+            activeVisibility={postVisibility}
+            visibilityOptions={PUBLISH_VISIBILITY_OPTIONS}
+            onVisibilityChange={setPostVisibility}
+            previewViewport={previewViewport}
+            previewViewportLabel={previewViewportConfig.label}
+            previewViewportOptions={previewViewportOptions}
+            onPreviewViewportChange={(viewport) => setPreviewViewport(viewport)}
+            previewFrameStyle={{ width: `min(100%, ${previewViewportConfig.cardWidth}px)` }}
+            previewThumbnailSrc={previewThumbnailSrc}
+            postThumbnailFocusX={postThumbnailFocusX}
+            postThumbnailFocusY={postThumbnailFocusY}
+            postThumbnailZoom={postThumbnailZoom}
+            onPreviewThumbnailError={() => setIsPreviewThumbnailError(true)}
+            previewVisibilityLabel={previewVisibilityLabel}
+            summaryPreview={composeSummaryPreview}
+            previewDateText={previewDateText}
+            previewAuthorAvatarSrc={previewAuthorAvatarSrc}
+            displayNameInitial={displayNameInitial}
+            displayName={displayName}
+            summaryLengthLabel={
+              postSummary.trim() ? `${postSummary.trim().length}/${PREVIEW_SUMMARY_MAX_LENGTH}` : "본문 기준 자동"
+            }
+            isComposeAssistOpen={isComposeAssistOpen}
+            onToggleComposeAssist={() => setIsComposeAssistOpen((prev) => !prev)}
+            thumbnailEditorPanel={thumbnailEditorPanel}
+            previewMetaEditorPanel={previewMetaEditorPanel}
+            isTagPanelOpen={activeMetaPanel === "tag"}
+            onToggleTagPanel={() => setActiveMetaPanel((prev) => (prev === "tag" ? null : "tag"))}
+            isUtilityPanelOpen={isComposeUtilityOpen}
+            onToggleUtilityPanel={() => setIsComposeUtilityOpen((prev) => !prev)}
+            metaNotice={metaNotice}
+            knownTags={knownTags}
+            tagUsageMap={tagUsageMap}
+            onToggleKnownTag={(tag) => (postTags.includes(tag) ? removeTagFromPost(tag) : addTagToPost(tag))}
+            onDeleteKnownTag={deleteTagFromCatalog}
+            onRestoreLocalDraft={restoreLocalDraft}
+            onClearLocalDraft={clearLocalDraft}
+            isClearLocalDraftDisabled={loadingKey.length > 0 || !localDraftSavedAt}
           />
-          <ComposeStudioLayout>
-            <EditorStudioComposeWritingSurface
-              editorModeLabel={editorModeLabel}
-              composePageTitle={composePageTitle}
-              composeSurfaceSubtitle={composeSurfaceSubtitle}
-              composeStatusText={composeStatusText}
-              composeStatusTone={composeStatusTone}
-              currentVisibilityText={currentVisibilityText}
-              postSummary={postSummary}
-              postSummaryMaxLength={PREVIEW_SUMMARY_MAX_LENGTH}
-              onPostSummaryChange={setPostSummary}
-              isFillSummaryFromBodyDisabled={!postContent.trim()}
-              onFillSummaryFromBody={() => setPostSummary(makePreviewSummary(postContent))}
-              postTags={postTags}
-              tagDraft={tagDraft}
-              onTagDraftChange={setTagDraft}
-              onAddTags={addTagsToPost}
-              onAddTag={addTagToPost}
-              onRemoveTag={removeTagFromPost}
-              titleInputRef={handleTitleFieldRef}
-              postTitle={postTitle}
-              onPostTitleChange={handleTitleChange}
-              onPostTitleKeyDown={handleTitleKeyDown}
-              thumbnailImageFileInputRef={thumbnailImageFileInputRef}
-              onThumbnailImageFileChange={handleThumbnailImageFileChange}
-              contentLength={contentLength}
-              lineCount={lineCount}
-              imageCount={imageCount}
-              editorCanvas={composeEditorCanvas}
-              tagSummaryText={tagSummaryText}
-              isSaveDraftDisabled={loadingKey.length > 0}
-              onSaveDraft={saveLocalDraft}
-              primaryActionDisabled={mobilePrimaryActionDisabled}
-              primaryActionLabel={composeCallToActionLabel}
-              onPrimaryAction={() => openPublishModal(editorPrimaryActionType)}
-            />
-
-            <ComposeAssistantColumn>
-              <EditorStudioComposeAssistantPanel
-                composeHeroSummary={composeHeroSummary}
-                publishAction={
-                  <PrimaryButton
-                    type="button"
-                    disabled={mobilePrimaryActionDisabled}
-                    onClick={() => openPublishModal(editorPrimaryActionType)}
-                  >
-                    {composeCallToActionLabel}
-                  </PrimaryButton>
-                }
-                tagRecommendationAction={
-                  <Button
-                    type="button"
-                    disabled={disabled("recommendTags") || !postContent.trim()}
-                    onClick={() => void handleRecommendTags()}
-                  >
-                    {loadingKey === "recommendTags" ? "태그 제안 중..." : "태그 제안"}
-                  </Button>
-                }
-                composeStatusEntries={composeStatusEntries}
-                activeVisibility={postVisibility}
-                visibilityOptions={PUBLISH_VISIBILITY_OPTIONS}
-                onVisibilityChange={setPostVisibility}
-                previewViewport={previewViewport}
-                previewViewportLabel={previewViewportConfig.label}
-                previewViewportOptions={previewViewportOptions}
-                onPreviewViewportChange={(viewport) => setPreviewViewport(viewport)}
-                previewFrameStyle={{ width: `min(100%, ${previewViewportConfig.cardWidth}px)` }}
-                previewThumbnailSrc={previewThumbnailSrc}
-                postThumbnailFocusX={postThumbnailFocusX}
-                postThumbnailFocusY={postThumbnailFocusY}
-                postThumbnailZoom={postThumbnailZoom}
-                onPreviewThumbnailError={() => setIsPreviewThumbnailError(true)}
-                previewVisibilityLabel={previewVisibilityLabel}
-                postTitle={postTitle}
-                summaryPreview={composeSummaryPreview}
-                previewDateText={previewDateText}
-                previewAuthorAvatarSrc={previewAuthorAvatarSrc}
-                displayNameInitial={displayNameInitial}
-                displayName={displayName}
-                summaryLengthLabel={
-                  postSummary.trim() ? `${postSummary.trim().length}/${PREVIEW_SUMMARY_MAX_LENGTH}` : "본문 기준 자동"
-                }
-                isComposeAssistOpen={isComposeAssistOpen}
-                onToggleComposeAssist={() => setIsComposeAssistOpen((prev) => !prev)}
-                thumbnailEditorPanel={thumbnailEditorPanel}
-                previewMetaEditorPanel={previewMetaEditorPanel}
-              >
-                <EditorStudioMetadataAssistantPanel
-                  isTagPanelOpen={activeMetaPanel === "tag"}
-                  onToggleTagPanel={() => setActiveMetaPanel((prev) => (prev === "tag" ? null : "tag"))}
-                  isUtilityPanelOpen={isComposeUtilityOpen}
-                  onToggleUtilityPanel={() => setIsComposeUtilityOpen((prev) => !prev)}
-                  metaNotice={metaNotice}
-                  knownTags={knownTags}
-                  selectedTags={postTags}
-                  tagUsageMap={tagUsageMap}
-                  onToggleTag={(tag) => (postTags.includes(tag) ? removeTagFromPost(tag) : addTagToPost(tag))}
-                  onDeleteTag={deleteTagFromCatalog}
-                  utilityActions={
-                    <SubActionRow>
-                      <Button type="button" disabled={loadingKey.length > 0} onClick={() => saveLocalDraft()}>
-                        브라우저 임시저장
-                      </Button>
-                      <Button type="button" disabled={loadingKey.length > 0} onClick={restoreLocalDraft}>
-                        임시저장 불러오기
-                      </Button>
-                      <Button
-                        type="button"
-                        disabled={loadingKey.length > 0 || !localDraftSavedAt}
-                        onClick={clearLocalDraft}
-                      >
-                        임시저장 삭제
-                      </Button>
-                    </SubActionRow>
-                  }
-                />
-              </EditorStudioComposeAssistantPanel>
-            </ComposeAssistantColumn>
-          </ComposeStudioLayout>
-        </EditorSection>
-        </ComposeSurfaceSection>
         )}
 
         {isPublishModalOpen ? (
@@ -3387,150 +3334,5 @@ const Input = styled.input`
     outline: none;
     border-color: ${({ theme }) => theme.colors.blue8};
     box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
-  }
-`
-
-const Button = styled.button`
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 8px;
-  padding: 0.62rem 0.92rem;
-  min-height: 44px;
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray10};
-  cursor: pointer;
-  font-size: 0.84rem;
-  font-weight: 600;
-  transition:
-    border-color 0.18s ease,
-    background-color 0.18s ease,
-    color 0.18s ease,
-    box-shadow 0.18s ease;
-
-  &[data-variant="danger"] {
-    border-color: ${({ theme }) => theme.colors.red8};
-    background: ${({ theme }) => theme.colors.red3};
-    color: ${({ theme }) => theme.colors.red11};
-  }
-
-  &[data-variant="text"] {
-    min-height: auto;
-    padding: 0;
-    border: 0;
-    border-radius: 0;
-    background: transparent;
-    color: ${({ theme }) => theme.colors.gray11};
-  }
-
-  &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.gray8};
-    background: ${({ theme }) => theme.colors.gray3};
-    color: ${({ theme }) => theme.colors.gray12};
-  }
-
-  &[data-variant="text"]:hover:not(:disabled) {
-    border-color: transparent;
-    background: transparent;
-    color: ${({ theme }) => theme.colors.gray12};
-  }
-
-  &:focus-visible {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors.blue8};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
-  }
-
-  &:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
-  }
-`
-
-const PrimaryButton = styled(Button)`
-  border-radius: 8px;
-  padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => theme.colors.blue9};
-  background: ${({ theme }) => theme.colors.blue9};
-  color: ${({ theme }) => theme.colors.gray1};
-  font-weight: 700;
-
-  &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.blue10};
-    background: ${({ theme }) => theme.colors.blue10};
-    color: ${({ theme }) => theme.colors.gray1};
-  }
-`
-
-const EditorSection = styled.div`
-  margin: 1.12rem 0 0.25rem;
-  border: none;
-  border-radius: 0;
-  padding: 0;
-  background: transparent;
-
-  @media (max-width: 720px) {
-    padding: 0;
-    margin-top: 0.92rem;
-  }
-
-  @media (max-width: 720px) {
-    &[data-mobile-visible="false"] {
-      display: none;
-    }
-  }
-`
-
-const ComposeSurfaceSection = styled(Section)`
-  display: grid;
-  gap: 1.2rem;
-  padding: 1.1rem 1.1rem 1.3rem;
-  border-color: ${({ theme }) => theme.colors.gray4};
-  background:
-    radial-gradient(circle at top left, rgba(96, 165, 250, 0.04), transparent 24%),
-    ${({ theme }) => theme.colors.gray1};
-
-  @media (max-width: 420px) {
-    gap: 1rem;
-    padding: 0.82rem 0.82rem 1rem;
-  }
-`
-
-const ComposeStudioLayout = styled.div`
-  display: grid;
-  gap: 1.4rem;
-  align-items: start;
-
-  @media (min-width: 1180px) {
-    grid-template-columns: minmax(0, 1fr) minmax(300px, 340px);
-  }
-
-  @media (max-width: 720px) {
-    gap: 1rem;
-  }
-`
-
-const ComposeAssistantColumn = styled.aside`
-  min-width: 0;
-`
-
-const SubActionRow = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-  margin-top: 0.65rem;
-  padding-top: 0.65rem;
-  border-top: 1px dashed ${({ theme }) => theme.colors.gray6};
-
-  > button {
-    border-style: dashed;
-  }
-
-  @media (max-width: 720px) {
-    display: grid;
-    grid-template-columns: 1fr;
-
-    > button {
-      width: 100%;
-      justify-content: center;
-    }
   }
 `


### PR DESCRIPTION
## 관련 이슈

close #215

## 작업 배경

- `EditorStudioPage.tsx`가 직접 조립하던 compose workspace shell을 `EditorStudioComposeWorkspace.tsx` presentational component로 분리했습니다.
- page는 기존처럼 state/handler/canvas 값만 계산해 전달하고, workspace는 mobile chrome, writing surface, assistant, metadata panel 조립과 layout style만 소유합니다.
- compact mobile writing surface visibility와 desktop/mobile CTA label 계약을 editor-state 가드에 반영했습니다.

## 작업 내용

- compose branch의 layout styled component와 panel wiring을 새 `EditorStudioComposeWorkspace.tsx`로 이동했습니다.
- `EditorStudioPage.tsx` compose branch를 workspace component 호출로 축소했습니다.
- `editor-studio-state.spec.ts`에 workspace 소유 경계, 금지 의존성, compact mobile visibility, desktop CTA label 계약을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front test:e2e:authoring` (최신 패치 기준 2회 연속 통과)
  - `git diff --check`
  - `CURRENT_TASK_SLUG=editor-studio-compose-workspace-shell-split bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: compose workspace prop wiring 누락 시 작성 화면의 보조 패널 또는 CTA label이 달라질 수 있습니다. editor-state와 authoring E2E로 mobile visibility/CTA/editor writer 경로를 확인했습니다.
- 롤백 방법: `git revert 137dd625`

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
