### PR TITLE
[Refactor] editor content workspace shell 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -256,6 +256,14 @@ test.describe("editor studio state", () => {
     const editorStudioPostListPanelSource = existsSync(editorStudioPostListPanelPath)
       ? readFileSync(editorStudioPostListPanelPath, "utf8")
       : ""
+    const editorStudioContentWorkspacePath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioContentWorkspace.tsx"
+    )
+    expect(existsSync(editorStudioContentWorkspacePath)).toBe(true)
+    const editorStudioContentWorkspaceSource = existsSync(editorStudioContentWorkspacePath)
+      ? readFileSync(editorStudioContentWorkspacePath, "utf8")
+      : ""
     const editorStudioMobileStepNavigatorPath = path.resolve(
       __dirname,
       "../src/routes/Admin/EditorStudioMobileStepNavigator.tsx"
@@ -446,11 +454,16 @@ test.describe("editor studio state", () => {
     expect(editorStudioMetadataAssistantPanelSource).toContain("<strong>보조 작업</strong>")
     expect(editorStudioSource).not.toContain("<strong>태그 정리</strong>")
     expect(editorStudioSource).not.toContain("<strong>보조 작업</strong>")
-    expect(editorStudioSelectedPostToolsPanelSource).toContain("export const EditorStudioSelectedPostToolsPanel =")
+    expect(editorStudioContentWorkspaceSource).toContain("export const EditorStudioContentWorkspace =")
     expect(editorStudioSource).toContain(
+      'import { EditorStudioContentWorkspace } from "./EditorStudioContentWorkspace"'
+    )
+    expect(editorStudioSource.match(/<EditorStudioContentWorkspace/g)?.length).toBe(1)
+    expect(editorStudioSelectedPostToolsPanelSource).toContain("export const EditorStudioSelectedPostToolsPanel =")
+    expect(editorStudioContentWorkspaceSource).toContain(
       'import { EditorStudioSelectedPostToolsPanel } from "./EditorStudioSelectedPostToolsPanel"'
     )
-    expect(editorStudioSource.match(/<EditorStudioSelectedPostToolsPanel/g)?.length).toBe(1)
+    expect(editorStudioContentWorkspaceSource.match(/<EditorStudioSelectedPostToolsPanel/g)?.length).toBe(1)
     expect(editorStudioSelectedPostToolsPanelSource).toContain("다른 글 직접 불러오기")
     expect(editorStudioSelectedPostToolsPanelSource).toContain("post id 직접 불러오기")
     expect(editorStudioSelectedPostToolsPanelSource).toContain("<strong>{directLoadTitle}</strong>")
@@ -468,10 +481,10 @@ test.describe("editor studio state", () => {
     expect(editorStudioSelectedPostToolsPanelSource).not.toContain('run("hitPost"')
     expect(editorStudioSelectedPostToolsPanelSource).not.toContain('run("likePost"')
     expect(editorStudioSelectedPostPanelSource).toContain("export const EditorStudioSelectedPostPanel =")
-    expect(editorStudioSource).toContain(
+    expect(editorStudioContentWorkspaceSource).toContain(
       'import { EditorStudioSelectedPostPanel } from "./EditorStudioSelectedPostPanel"'
     )
-    expect(editorStudioSource.match(/<EditorStudioSelectedPostPanel/g)?.length).toBe(1)
+    expect(editorStudioContentWorkspaceSource.match(/<EditorStudioSelectedPostPanel/g)?.length).toBe(1)
     expect(editorStudioSelectedPostPanelSource).toContain("선택한 글")
     expect(editorStudioSelectedPostPanelSource).toContain("빠른 작업")
     expect(editorStudioSelectedPostPanelSource).toContain("편집 계속")
@@ -530,10 +543,10 @@ test.describe("editor studio state", () => {
     expect(editorStudioSource).not.toContain("const DevConsoleSection = styled.section`")
     expect(editorStudioSource).not.toContain("const EditorStudioResultPanel = styled.section`")
     expect(editorStudioPostQueryPanelSource).toContain("export const EditorStudioPostQueryPanel =")
-    expect(editorStudioSource).toContain(
+    expect(editorStudioContentWorkspaceSource).toContain(
       'import { EditorStudioPostQueryPanel } from "./EditorStudioPostQueryPanel"'
     )
-    expect(editorStudioSource.match(/<EditorStudioPostQueryPanel/g)?.length).toBe(1)
+    expect(editorStudioContentWorkspaceSource.match(/<EditorStudioPostQueryPanel/g)?.length).toBe(1)
     expect(editorStudioPostQueryPanelSource).toContain("글 목록 조회 조건")
     expect(editorStudioPostQueryPanelSource).toContain("고급 조회 옵션")
     expect(editorStudioSource).not.toContain("<QueryPanel")
@@ -546,10 +559,10 @@ test.describe("editor studio state", () => {
     expect(editorStudioPostQueryPanelSource).not.toContain("setListPageSize")
     expect(editorStudioPostQueryPanelSource).not.toContain("setListSort")
     expect(editorStudioPostListPanelSource).toContain("export const EditorStudioPostListPanel =")
-    expect(editorStudioSource).toContain(
+    expect(editorStudioContentWorkspaceSource).toContain(
       'import { EditorStudioPostListPanel } from "./EditorStudioPostListPanel"'
     )
-    expect(editorStudioSource.match(/<EditorStudioPostListPanel/g)?.length).toBe(1)
+    expect(editorStudioContentWorkspaceSource.match(/<EditorStudioPostListPanel/g)?.length).toBe(1)
     expect(editorStudioPostListPanelSource).toContain("관리자 글 리스트")
     expect(editorStudioPostListPanelSource).toContain("삭제 글 리스트")
     expect(editorStudioPostListPanelSource).toContain("현재 목록 전체 선택")
@@ -565,10 +578,10 @@ test.describe("editor studio state", () => {
     expect(editorStudioPostListPanelSource).not.toContain("openDeleteConfirm")
     expect(editorStudioPostListPanelSource).not.toContain("setPostId")
     expect(editorStudioMobileStepNavigatorSource).toContain("export const EditorStudioMobileStepNavigator =")
-    expect(editorStudioSource).toContain(
+    expect(editorStudioContentWorkspaceSource).toContain(
       'import { EditorStudioMobileStepNavigator } from "./EditorStudioMobileStepNavigator"'
     )
-    expect(editorStudioSource.match(/<EditorStudioMobileStepNavigator/g)?.length).toBe(1)
+    expect(editorStudioContentWorkspaceSource.match(/<EditorStudioMobileStepNavigator/g)?.length).toBe(1)
     expect(editorStudioMobileStepNavigatorSource).toContain("모바일 작업 단계")
     expect(editorStudioMobileStepNavigatorSource).toContain("현재 단계:")
     expect(editorStudioSource).not.toContain("<MobileStudioStepper")
@@ -579,16 +592,30 @@ test.describe("editor studio state", () => {
     expect(editorStudioMobileStepNavigatorSource).not.toContain("run(")
     expect(editorStudioMobileStepNavigatorSource).not.toContain("setActiveMobileStudioStep")
     expect(editorStudioUndoToastSource).toContain("export const EditorStudioUndoToast =")
-    expect(editorStudioSource).toContain(
+    expect(editorStudioContentWorkspaceSource).toContain(
       'import { EditorStudioUndoToast } from "./EditorStudioUndoToast"'
     )
-    expect(editorStudioSource.match(/<EditorStudioUndoToast/g)?.length).toBe(1)
+    expect(editorStudioContentWorkspaceSource.match(/<EditorStudioUndoToast/g)?.length).toBe(1)
     expect(editorStudioUndoToastSource).toContain("실행 취소")
     expect(editorStudioSource).not.toContain("<UndoToast")
     expect(editorStudioSource).not.toContain("const UndoToast = styled.div`")
     expect(editorStudioUndoToastSource).not.toContain("apiFetch(")
     expect(editorStudioUndoToastSource).not.toContain("run(")
     expect(editorStudioUndoToastSource).not.toContain("handleUndoSoftDelete")
+    expect(editorStudioSource).not.toContain("<ContentStudioGrid")
+    expect(editorStudioSource).not.toContain("<ContentStudioLeft")
+    expect(editorStudioSource).not.toContain("const ContentStudioGrid = styled.div`")
+    expect(editorStudioSource).not.toContain("const ContentStudioLeft = styled.div`")
+    expect(editorStudioSource).not.toContain("const GlobalNoticeBar = styled.div`")
+    expect(editorStudioContentWorkspaceSource).toContain("const ContentStudioGrid = styled.div`")
+    expect(editorStudioContentWorkspaceSource).toContain("const ContentStudioLeft = styled.div`")
+    expect(editorStudioContentWorkspaceSource).toContain("const GlobalNoticeBar = styled.div`")
+    expect(editorStudioContentWorkspaceSource).not.toContain("apiFetch(")
+    expect(editorStudioContentWorkspaceSource).not.toContain("run(")
+    expect(editorStudioContentWorkspaceSource).not.toContain("loadPostForEditor")
+    expect(editorStudioContentWorkspaceSource).not.toContain("openDeleteConfirm")
+    expect(editorStudioContentWorkspaceSource).not.toContain("setListScope")
+    expect(editorStudioContentWorkspaceSource).not.toContain("setSelectedPostIds")
     expect(editorStudioDeleteConfirmDialogSource).toContain("export const EditorStudioDeleteConfirmDialog =")
     expect(editorStudioSource).toContain(
       'import { EditorStudioDeleteConfirmDialog } from "./EditorStudioDeleteConfirmDialog"'

--- a/front/src/routes/Admin/EditorStudioContentWorkspace.tsx
+++ b/front/src/routes/Admin/EditorStudioContentWorkspace.tsx
@@ -1,0 +1,438 @@
+import styled from "@emotion/styled"
+import type { ChangeEvent } from "react"
+import type { EditorMode, PostVisibility } from "./editorStudioState"
+import { EditorStudioMobileStepNavigator } from "./EditorStudioMobileStepNavigator"
+import { EditorStudioPostListPanel } from "./EditorStudioPostListPanel"
+import type { EditorStudioPostListItem } from "./EditorStudioPostListPanel"
+import { EditorStudioPostQueryPanel } from "./EditorStudioPostQueryPanel"
+import { EditorStudioSelectedPostPanel } from "./EditorStudioSelectedPostPanel"
+import { EditorStudioSelectedPostToolsPanel } from "./EditorStudioSelectedPostToolsPanel"
+import { EditorStudioUndoToast } from "./EditorStudioUndoToast"
+
+type NoticeTone = "idle" | "loading" | "success" | "error"
+type ManageMobileStudioStep = "query" | "list"
+type MobileStudioStep = "query" | "list" | "edit" | "publish"
+type PostListScope = "active" | "deleted"
+type ListQuickPreset = "none" | "today" | "temp"
+
+type NoticeState = {
+  tone: NoticeTone
+  text: string
+}
+
+type ListSortOption = {
+  value: string
+  label: string
+}
+
+type EditorStudioContentWorkspaceProps = {
+  shouldShowGlobalNotice: boolean
+  globalNotice: NoticeState
+  mobileStudioSurfaceSteps: readonly MobileStudioStep[]
+  activeMobileStudioStep: MobileStudioStep
+  mobileStudioStepLabels: Record<MobileStudioStep, string>
+  mobileStudioStepDescriptions: Record<MobileStudioStep, string>
+  mobileStudioPrevStep: MobileStudioStep | null
+  mobileStudioNextStep: MobileStudioStep | null
+  mobileStudioPrevStepLabel: string
+  mobileStudioNextStepLabel: string
+  isCompactMobileLayout: boolean
+  onMobileStepChange: (step: MobileStudioStep) => void
+  listScope: PostListScope
+  listKeyword: string
+  listQuickPreset: ListQuickPreset
+  hasListFiltersApplied: boolean
+  isListAdvancedOpen: boolean
+  listPage: string
+  listPageSize: string
+  listSort: string
+  listSortOptions: readonly ListSortOption[]
+  isListRefreshDisabled: boolean
+  isTempPostDisabled: boolean
+  onListScopeChange: (scope: PostListScope) => void
+  onListKeywordChange: (value: string) => void
+  onRefreshList: () => void
+  onLoadOrCreateTempPost: () => void
+  onApplyQuickPreset: (preset: Exclude<ListQuickPreset, "none">) => void
+  onResetFilters: () => void
+  onToggleListAdvanced: () => void
+  onListPageChange: (event: ChangeEvent<HTMLInputElement>) => void
+  onListPageSizeChange: (event: ChangeEvent<HTMLInputElement>) => void
+  onListSortChange: (event: ChangeEvent<HTMLSelectElement>) => void
+  selectedPostIds: readonly number[]
+  adminPostTotal: number
+  adminPostRows: readonly EditorStudioPostListItem[]
+  adminPostViewRows: readonly EditorStudioPostListItem[]
+  isAllVisiblePostsSelected: boolean
+  selectedPostIdSet: ReadonlySet<number>
+  editorMode: EditorMode
+  postId: string
+  loadingKey: string
+  modifiedSortOrder: "desc" | "asc"
+  deletedListNotice: NoticeState
+  onToggleSelectAllVisiblePosts: () => void
+  onClearSelection: () => void
+  onRequestDeletePosts: (ids: number[], headline?: string) => void
+  onTogglePostSelection: (id: number) => void
+  onToggleModifiedSortOrder: () => void
+  onEditPost: (row: EditorStudioPostListItem) => void
+  onOpenPostDetail: (id: number) => void
+  onCopyPostDetailLink: (id: number, title: string) => void
+  onRestoreDeletedPost: (row: EditorStudioPostListItem) => void
+  onHardDeletePost: (row: EditorStudioPostListItem) => void
+  showSelectedPanelInManageSurface: boolean
+  hasSelectedManagedPost: boolean
+  editorModeLabel: string
+  selectedPostLabel: string
+  postTitle: string
+  postVersion: number | null
+  isTempDraftMode: boolean
+  postVisibility: PostVisibility
+  currentVisibilityText: string
+  isContinueEditingDisabled: boolean
+  isCreateNewPostDisabled: boolean
+  isDeletePostDisabled: boolean
+  onContinueEditing: () => void
+  onCreateNewPost: () => void
+  onDeletePost: () => void
+  isDirectLoadOpen: boolean
+  onToggleDirectLoad: () => void
+  isSelectedToolsOpen: boolean
+  onToggleSelectedTools: () => void
+  onPostIdChange: (postId: string) => void
+  isLoadPostDisabled: boolean
+  onLoadPost: () => void
+  isHitPostDisabled: boolean
+  onRunHitPost: () => void
+  isLikePostDisabled: boolean
+  onRunLikePost: () => void
+  softDeleteUndoMessage: string
+  isSoftDeleteUndoVisible: boolean
+  isUndoDisabled: boolean
+  onUndoSoftDelete: () => void
+}
+
+export const EditorStudioContentWorkspace = ({
+  shouldShowGlobalNotice,
+  globalNotice,
+  mobileStudioSurfaceSteps,
+  activeMobileStudioStep,
+  mobileStudioStepLabels,
+  mobileStudioStepDescriptions,
+  mobileStudioPrevStep,
+  mobileStudioNextStep,
+  mobileStudioPrevStepLabel,
+  mobileStudioNextStepLabel,
+  isCompactMobileLayout,
+  onMobileStepChange,
+  listScope,
+  listKeyword,
+  listQuickPreset,
+  hasListFiltersApplied,
+  isListAdvancedOpen,
+  listPage,
+  listPageSize,
+  listSort,
+  listSortOptions,
+  isListRefreshDisabled,
+  isTempPostDisabled,
+  onListScopeChange,
+  onListKeywordChange,
+  onRefreshList,
+  onLoadOrCreateTempPost,
+  onApplyQuickPreset,
+  onResetFilters,
+  onToggleListAdvanced,
+  onListPageChange,
+  onListPageSizeChange,
+  onListSortChange,
+  selectedPostIds,
+  adminPostTotal,
+  adminPostRows,
+  adminPostViewRows,
+  isAllVisiblePostsSelected,
+  selectedPostIdSet,
+  editorMode,
+  postId,
+  loadingKey,
+  modifiedSortOrder,
+  deletedListNotice,
+  onToggleSelectAllVisiblePosts,
+  onClearSelection,
+  onRequestDeletePosts,
+  onTogglePostSelection,
+  onToggleModifiedSortOrder,
+  onEditPost,
+  onOpenPostDetail,
+  onCopyPostDetailLink,
+  onRestoreDeletedPost,
+  onHardDeletePost,
+  showSelectedPanelInManageSurface,
+  hasSelectedManagedPost,
+  editorModeLabel,
+  selectedPostLabel,
+  postTitle,
+  postVersion,
+  isTempDraftMode,
+  postVisibility,
+  currentVisibilityText,
+  isContinueEditingDisabled,
+  isCreateNewPostDisabled,
+  isDeletePostDisabled,
+  onContinueEditing,
+  onCreateNewPost,
+  onDeletePost,
+  isDirectLoadOpen,
+  onToggleDirectLoad,
+  isSelectedToolsOpen,
+  onToggleSelectedTools,
+  onPostIdChange,
+  isLoadPostDisabled,
+  onLoadPost,
+  isHitPostDisabled,
+  onRunHitPost,
+  isLikePostDisabled,
+  onRunLikePost,
+  softDeleteUndoMessage,
+  isSoftDeleteUndoVisible,
+  isUndoDisabled,
+  onUndoSoftDelete,
+}: EditorStudioContentWorkspaceProps) => (
+  <Section id="content-studio">
+    <SectionTop>
+      <div>
+        <h2>글 목록 관리</h2>
+        <SectionDescription>조회·선택·편집만 남겨 정리에 집중합니다.</SectionDescription>
+      </div>
+    </SectionTop>
+    {shouldShowGlobalNotice ? (
+      <GlobalNoticeBar data-tone={globalNotice.tone}>{globalNotice.text}</GlobalNoticeBar>
+    ) : null}
+    <EditorStudioMobileStepNavigator
+      steps={mobileStudioSurfaceSteps}
+      activeStep={activeMobileStudioStep}
+      stepLabels={mobileStudioStepLabels}
+      stepDescriptions={mobileStudioStepDescriptions}
+      prevStep={mobileStudioPrevStep}
+      nextStep={mobileStudioNextStep}
+      prevStepLabel={mobileStudioPrevStepLabel}
+      nextStepLabel={mobileStudioNextStepLabel}
+      isCompactMobileLayout={isCompactMobileLayout}
+      onStepChange={onMobileStepChange}
+    />
+    <ContentStudioGrid>
+      <ContentStudioLeft
+        data-mobile-visible={!isCompactMobileLayout || activeMobileStudioStep === "query" || activeMobileStudioStep === "list"}
+      >
+        <EditorStudioPostQueryPanel
+          activeMobileStep={activeMobileStudioStep as ManageMobileStudioStep}
+          isCompactMobileLayout={isCompactMobileLayout}
+          listScope={listScope}
+          listKeyword={listKeyword}
+          listQuickPreset={listQuickPreset}
+          hasListFiltersApplied={hasListFiltersApplied}
+          isAdvancedOpen={isListAdvancedOpen}
+          listPage={listPage}
+          listPageSize={listPageSize}
+          listSort={listSort}
+          listSortOptions={listSortOptions}
+          isRefreshDisabled={isListRefreshDisabled}
+          isTempPostDisabled={isTempPostDisabled}
+          onListScopeChange={onListScopeChange}
+          onListKeywordChange={onListKeywordChange}
+          onRefreshList={onRefreshList}
+          onLoadOrCreateTempPost={onLoadOrCreateTempPost}
+          onApplyQuickPreset={onApplyQuickPreset}
+          onResetFilters={onResetFilters}
+          onToggleAdvanced={onToggleListAdvanced}
+          onListPageChange={onListPageChange}
+          onListPageSizeChange={onListPageSizeChange}
+          onListSortChange={onListSortChange}
+        />
+        <EditorStudioPostListPanel
+          mobileVisible={!isCompactMobileLayout || activeMobileStudioStep === "list"}
+          listScope={listScope}
+          selectedPostIds={selectedPostIds}
+          adminPostTotal={adminPostTotal}
+          adminPostRows={adminPostRows}
+          adminPostViewRows={adminPostViewRows}
+          isAllVisiblePostsSelected={isAllVisiblePostsSelected}
+          selectedPostIdSet={selectedPostIdSet}
+          editorMode={editorMode}
+          postId={postId}
+          loadingKey={loadingKey}
+          modifiedSortOrder={modifiedSortOrder}
+          deletedListNotice={deletedListNotice}
+          isRefreshDisabled={isListRefreshDisabled}
+          onToggleSelectAllVisiblePosts={onToggleSelectAllVisiblePosts}
+          onClearSelection={onClearSelection}
+          onRequestDeletePosts={onRequestDeletePosts}
+          onRefreshList={onRefreshList}
+          onTogglePostSelection={onTogglePostSelection}
+          onToggleModifiedSortOrder={onToggleModifiedSortOrder}
+          onEditPost={onEditPost}
+          onOpenPostDetail={onOpenPostDetail}
+          onCopyPostDetailLink={onCopyPostDetailLink}
+          onRestoreDeletedPost={onRestoreDeletedPost}
+          onHardDeletePost={onHardDeletePost}
+        />
+      </ContentStudioLeft>
+
+      <EditorStudioSelectedPostPanel
+        mobileVisible={showSelectedPanelInManageSurface}
+        hasSelectedManagedPost={hasSelectedManagedPost}
+        editorModeLabel={editorModeLabel}
+        selectedPostLabel={selectedPostLabel}
+        postTitle={postTitle}
+        postId={postId}
+        postVersion={postVersion}
+        isTempDraftMode={isTempDraftMode}
+        postVisibility={postVisibility}
+        currentVisibilityText={currentVisibilityText}
+        isContinueEditingDisabled={isContinueEditingDisabled}
+        isCreateNewPostDisabled={isCreateNewPostDisabled}
+        isDeletePostDisabled={isDeletePostDisabled}
+        onContinueEditing={onContinueEditing}
+        onCreateNewPost={onCreateNewPost}
+        onDeletePost={onDeletePost}
+        toolsPanel={
+          <EditorStudioSelectedPostToolsPanel
+            hasSelectedManagedPost={hasSelectedManagedPost}
+            isDirectLoadOpen={isDirectLoadOpen}
+            onToggleDirectLoad={onToggleDirectLoad}
+            isSelectedToolsOpen={isSelectedToolsOpen}
+            onToggleSelectedTools={onToggleSelectedTools}
+            postId={postId}
+            onPostIdChange={onPostIdChange}
+            isLoadPostDisabled={isLoadPostDisabled}
+            onLoadPost={onLoadPost}
+            isHitPostDisabled={isHitPostDisabled}
+            onRunHitPost={onRunHitPost}
+            isLikePostDisabled={isLikePostDisabled}
+            onRunLikePost={onRunLikePost}
+          />
+        }
+      />
+    </ContentStudioGrid>
+
+    <EditorStudioUndoToast
+      isVisible={isSoftDeleteUndoVisible}
+      message={softDeleteUndoMessage}
+      isUndoDisabled={isUndoDisabled}
+      onUndo={onUndoSoftDelete}
+    />
+  </Section>
+)
+
+const Section = styled.section`
+  border: 1px solid ${({ theme }) => theme.colors.gray5};
+  border-radius: 14px;
+  padding: 0.96rem;
+  margin-bottom: 1.05rem;
+  background: ${({ theme }) => theme.colors.gray2};
+  box-shadow: none;
+
+  h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  @media (max-width: 420px) {
+    border-radius: 12px;
+    padding: 0.74rem;
+    margin-bottom: 0.95rem;
+  }
+`
+
+const SectionTop = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.95rem;
+`
+
+const SectionDescription = styled.p`
+  margin: 0.22rem 0 0;
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.82rem;
+  line-height: 1.5;
+`
+
+const GlobalNoticeBar = styled.div`
+  margin-bottom: 0.9rem;
+  padding: 0.66rem 0.78rem;
+  border-radius: 10px;
+  font-size: 0.84rem;
+  line-height: 1.5;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+
+  &[data-tone="idle"] {
+    color: ${({ theme }) => theme.colors.gray10};
+    background: ${({ theme }) => theme.colors.gray2};
+    border-color: ${({ theme }) => theme.colors.gray6};
+  }
+
+  &[data-tone="loading"] {
+    color: ${({ theme }) => theme.colors.blue11};
+    background: ${({ theme }) => theme.colors.blue3};
+    border-color: ${({ theme }) => theme.colors.blue7};
+  }
+
+  &[data-tone="success"] {
+    color: ${({ theme }) => theme.colors.green11};
+    background: ${({ theme }) => theme.colors.green3};
+    border-color: ${({ theme }) => theme.colors.green7};
+  }
+
+  &[data-tone="error"] {
+    color: ${({ theme }) => theme.colors.red11};
+    background: ${({ theme }) => theme.colors.red3};
+    border-color: ${({ theme }) => theme.colors.red7};
+  }
+
+  @media (max-width: 420px) {
+    margin-bottom: 0.7rem;
+    padding: 0.58rem 0.62rem;
+    font-size: 0.8rem;
+  }
+`
+
+const ContentStudioGrid = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+
+  @media (min-width: 1320px) {
+    grid-template-columns: minmax(0, 1fr) minmax(320px, 360px);
+  }
+
+  @media (max-width: 720px) {
+    gap: 0.76rem;
+  }
+`
+
+const ContentStudioLeft = styled.div`
+  display: grid;
+  gap: 0.95rem;
+  min-width: 0;
+  border: 1px solid ${({ theme }) => theme.colors.gray5};
+  border-radius: 12px;
+  background: ${({ theme }) => theme.colors.gray1};
+  padding: 0.9rem;
+  box-shadow: none;
+  overflow: hidden;
+
+  @media (max-width: 720px) {
+    padding: 0.72rem;
+    gap: 0.8rem;
+  }
+
+  @media (max-width: 720px) {
+    &[data-mobile-visible="false"] {
+      display: none;
+    }
+  }
+`

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -51,17 +51,12 @@ import {
   EditorStudioThumbnailMetaPanel,
 } from "./EditorStudioThumbnailPanels"
 import { EditorStudioPublishModal } from "./EditorStudioPublishModal"
-import { EditorStudioSelectedPostPanel } from "./EditorStudioSelectedPostPanel"
-import { EditorStudioSelectedPostToolsPanel } from "./EditorStudioSelectedPostToolsPanel"
 import { EditorStudioLegacyProfileSection } from "./EditorStudioLegacyProfileSection"
 import { EditorStudioLegacyUtilityPanel } from "./EditorStudioLegacyUtilityPanel"
 import { EditorStudioResultLogPanel } from "./EditorStudioResultLogPanel"
-import { EditorStudioPostQueryPanel } from "./EditorStudioPostQueryPanel"
-import { EditorStudioPostListPanel } from "./EditorStudioPostListPanel"
-import { EditorStudioMobileStepNavigator } from "./EditorStudioMobileStepNavigator"
-import { EditorStudioUndoToast } from "./EditorStudioUndoToast"
 import { EditorStudioDeleteConfirmDialog } from "./EditorStudioDeleteConfirmDialog"
 import { EditorStudioComposeWorkspace } from "./EditorStudioComposeWorkspace"
+import { EditorStudioContentWorkspace } from "./EditorStudioContentWorkspace"
 import {
   EditorStudioDedicatedEditorLoadingState,
   EditorStudioDedicatedEditorSurface,
@@ -2655,143 +2650,105 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
           )}
 
           {SHOW_LEGACY_CONTENT_STUDIO && (
-          <Section id="content-studio">
-            <SectionTop>
-              <div>
-                <h2>글 목록 관리</h2>
-                <SectionDescription>조회·선택·편집만 남겨 정리에 집중합니다.</SectionDescription>
-              </div>
-            </SectionTop>
-            {shouldShowGlobalNotice ? (
-              <GlobalNoticeBar data-tone={globalNotice.tone}>{globalNotice.text}</GlobalNoticeBar>
-            ) : null}
-            <EditorStudioMobileStepNavigator
-              steps={mobileStudioSurfaceSteps}
-              activeStep={activeMobileStudioStep}
-              stepLabels={MOBILE_STUDIO_STEP_LABEL}
-              stepDescriptions={MOBILE_STUDIO_STEP_DESCRIPTION}
-              prevStep={mobileStudioPrevStep}
-              nextStep={mobileStudioNextStep}
-              prevStepLabel={mobileStudioPrevStepLabel}
-              nextStepLabel={mobileStudioNextStepLabel}
+            <EditorStudioContentWorkspace
+              shouldShowGlobalNotice={shouldShowGlobalNotice}
+              globalNotice={globalNotice}
+              mobileStudioSurfaceSteps={mobileStudioSurfaceSteps}
+              activeMobileStudioStep={activeMobileStudioStep}
+              mobileStudioStepLabels={MOBILE_STUDIO_STEP_LABEL}
+              mobileStudioStepDescriptions={MOBILE_STUDIO_STEP_DESCRIPTION}
+              mobileStudioPrevStep={mobileStudioPrevStep}
+              mobileStudioNextStep={mobileStudioNextStep}
+              mobileStudioPrevStepLabel={mobileStudioPrevStepLabel}
+              mobileStudioNextStepLabel={mobileStudioNextStepLabel}
               isCompactMobileLayout={isCompactMobileLayout}
-              onStepChange={setActiveMobileStudioStep}
-            />
-            <ContentStudioGrid>
-              <ContentStudioLeft
-                data-mobile-visible={!isCompactMobileLayout || activeMobileStudioStep === "query" || activeMobileStudioStep === "list"}
-              >
-                <EditorStudioPostQueryPanel
-                  activeMobileStep={activeMobileStudioStep as ManageMobileStudioStep}
-                  isCompactMobileLayout={isCompactMobileLayout}
-                  listScope={listScope}
-                  listKeyword={listKw}
-                  listQuickPreset={listQuickPreset}
-                  hasListFiltersApplied={hasListFiltersApplied}
-                  isAdvancedOpen={isListAdvancedOpen}
-                  listPage={listPage}
-                  listPageSize={listPageSize}
-                  listSort={listSort}
-                  listSortOptions={LIST_SORT_OPTIONS}
-                  isRefreshDisabled={disabled("postList")}
-                  isTempPostDisabled={disabled("postTemp")}
-                  onListScopeChange={setListScope}
-                  onListKeywordChange={setListKw}
-                  onRefreshList={() => void loadAdminPosts()}
-                  onLoadOrCreateTempPost={() => void handleLoadOrCreateTempPost()}
-                  onApplyQuickPreset={applyListQuickPreset}
-                  onResetFilters={() => {
-                    setListQuickPreset("none")
-                    setListKw("")
-                    setListPage("1")
-                    setListPageSize("30")
-                    setListSort("CREATED_AT")
-                  }}
-                  onToggleAdvanced={() => setIsListAdvancedOpen((prev) => !prev)}
-                  onListPageChange={handleListPageChange}
-                  onListPageSizeChange={handleListPageSizeChange}
-                  onListSortChange={handleListSortChange}
-                />
-                <EditorStudioPostListPanel
-                  mobileVisible={!isCompactMobileLayout || activeMobileStudioStep === "list"}
-                  listScope={listScope}
-                  selectedPostIds={selectedPostIds}
-                  adminPostTotal={adminPostTotal}
-                  adminPostRows={adminPostRows}
-                  adminPostViewRows={adminPostViewRows}
-                  isAllVisiblePostsSelected={isAllVisiblePostsSelected}
-                  selectedPostIdSet={selectedPostIdSet}
-                  editorMode={editorMode}
-                  postId={postId}
-                  loadingKey={loadingKey}
-                  modifiedSortOrder={modifiedSortOrder}
-                  deletedListNotice={deletedListNotice}
-                  isRefreshDisabled={disabled("postList")}
-                  onToggleSelectAllVisiblePosts={toggleSelectAllVisiblePosts}
-                  onClearSelection={() => setSelectedPostIds([])}
-                  onRequestDeletePosts={(ids, headline) => openDeleteConfirm(ids, headline)}
-                  onRefreshList={() => void loadAdminPosts()}
-                  onTogglePostSelection={togglePostSelection}
-                  onToggleModifiedSortOrder={() => setModifiedSortOrder((prev) => (prev === "desc" ? "asc" : "desc"))}
-                  onEditPost={(row) => {
-                    setPostId(String(row.id))
-                    void loadPostForEditor(String(row.id))
-                  }}
-                  onOpenPostDetail={(id) => void openPostDetailRoute(id)}
-                  onCopyPostDetailLink={(id, title) => void copyPostDetailLink(id, title)}
-                  onRestoreDeletedPost={(row) => void restoreDeletedPostFromList(row)}
-                  onHardDeletePost={(row) => void hardDeleteDeletedPostFromList(row)}
-                />
-              </ContentStudioLeft>
-
-              <EditorStudioSelectedPostPanel
-                mobileVisible={showSelectedPanelInManageSurface}
-                hasSelectedManagedPost={hasSelectedManagedPost}
-                editorModeLabel={editorModeLabel}
-                selectedPostLabel={selectedPostLabel}
-                postTitle={postTitle}
-                postId={postId}
-                postVersion={postVersion}
-                isTempDraftMode={isTempDraftMode}
-                postVisibility={postVisibility}
-                currentVisibilityText={currentVisibilityText}
-                isContinueEditingDisabled={editorMode !== "edit" || disabled("modifyPost")}
-                isCreateNewPostDisabled={loadingKey.length > 0}
-                isDeletePostDisabled={disabled("deletePost")}
-                onContinueEditing={handleContinueSelectedPostEditing}
-                onCreateNewPost={handleCreateNewPostFromSelectedPanel}
-                onDeletePost={handleDeleteSelectedPost}
-                toolsPanel={
-                  <EditorStudioSelectedPostToolsPanel
-                    hasSelectedManagedPost={hasSelectedManagedPost}
-                    isDirectLoadOpen={isDirectLoadOpen}
-                    onToggleDirectLoad={() => setIsDirectLoadOpen((prev) => !prev)}
-                    isSelectedToolsOpen={isSelectedToolsOpen}
-                    onToggleSelectedTools={() => setIsSelectedToolsOpen((prev) => !prev)}
-                    postId={postId}
-                    onPostIdChange={handleSelectedPostIdChange}
-                    isLoadPostDisabled={disabled("postOne")}
-                    onLoadPost={() => void loadPostForEditor()}
-                    isHitPostDisabled={disabled("hitPost")}
-                    onRunHitPost={() =>
-                      void run("hitPost", () => apiFetch(`/post/api/v1/posts/${postId}/hit`, { method: "POST" }))
-                    }
-                    isLikePostDisabled={disabled("likePost")}
-                    onRunLikePost={() =>
-                      void run("likePost", () => apiFetch(`/post/api/v1/posts/${postId}/like`, { method: "PUT" }))
-                    }
-                  />
-                }
-              />
-            </ContentStudioGrid>
-
-            <EditorStudioUndoToast
-              isVisible={Boolean(softDeleteUndoState)}
-              message={softDeleteUndoState?.message || ""}
+              onMobileStepChange={setActiveMobileStudioStep}
+              listScope={listScope}
+              listKeyword={listKw}
+              listQuickPreset={listQuickPreset}
+              hasListFiltersApplied={hasListFiltersApplied}
+              isListAdvancedOpen={isListAdvancedOpen}
+              listPage={listPage}
+              listPageSize={listPageSize}
+              listSort={listSort}
+              listSortOptions={LIST_SORT_OPTIONS}
+              isListRefreshDisabled={disabled("postList")}
+              isTempPostDisabled={disabled("postTemp")}
+              onListScopeChange={setListScope}
+              onListKeywordChange={setListKw}
+              onRefreshList={() => void loadAdminPosts()}
+              onLoadOrCreateTempPost={() => void handleLoadOrCreateTempPost()}
+              onApplyQuickPreset={applyListQuickPreset}
+              onResetFilters={() => {
+                setListQuickPreset("none")
+                setListKw("")
+                setListPage("1")
+                setListPageSize("30")
+                setListSort("CREATED_AT")
+              }}
+              onToggleListAdvanced={() => setIsListAdvancedOpen((prev) => !prev)}
+              onListPageChange={handleListPageChange}
+              onListPageSizeChange={handleListPageSizeChange}
+              onListSortChange={handleListSortChange}
+              selectedPostIds={selectedPostIds}
+              adminPostTotal={adminPostTotal}
+              adminPostRows={adminPostRows}
+              adminPostViewRows={adminPostViewRows}
+              isAllVisiblePostsSelected={isAllVisiblePostsSelected}
+              selectedPostIdSet={selectedPostIdSet}
+              editorMode={editorMode}
+              postId={postId}
+              loadingKey={loadingKey}
+              modifiedSortOrder={modifiedSortOrder}
+              deletedListNotice={deletedListNotice}
+              onToggleSelectAllVisiblePosts={toggleSelectAllVisiblePosts}
+              onClearSelection={() => setSelectedPostIds([])}
+              onRequestDeletePosts={(ids, headline) => openDeleteConfirm(ids, headline)}
+              onTogglePostSelection={togglePostSelection}
+              onToggleModifiedSortOrder={() => setModifiedSortOrder((prev) => (prev === "desc" ? "asc" : "desc"))}
+              onEditPost={(row) => {
+                setPostId(String(row.id))
+                void loadPostForEditor(String(row.id))
+              }}
+              onOpenPostDetail={(id) => void openPostDetailRoute(id)}
+              onCopyPostDetailLink={(id, title) => void copyPostDetailLink(id, title)}
+              onRestoreDeletedPost={(row) => void restoreDeletedPostFromList(row)}
+              onHardDeletePost={(row) => void hardDeleteDeletedPostFromList(row)}
+              showSelectedPanelInManageSurface={showSelectedPanelInManageSurface}
+              hasSelectedManagedPost={hasSelectedManagedPost}
+              editorModeLabel={editorModeLabel}
+              selectedPostLabel={selectedPostLabel}
+              postTitle={postTitle}
+              postVersion={postVersion}
+              isTempDraftMode={isTempDraftMode}
+              postVisibility={postVisibility}
+              currentVisibilityText={currentVisibilityText}
+              isContinueEditingDisabled={editorMode !== "edit" || disabled("modifyPost")}
+              isCreateNewPostDisabled={loadingKey.length > 0}
+              isDeletePostDisabled={disabled("deletePost")}
+              onContinueEditing={handleContinueSelectedPostEditing}
+              onCreateNewPost={handleCreateNewPostFromSelectedPanel}
+              onDeletePost={handleDeleteSelectedPost}
+              isDirectLoadOpen={isDirectLoadOpen}
+              onToggleDirectLoad={() => setIsDirectLoadOpen((prev) => !prev)}
+              isSelectedToolsOpen={isSelectedToolsOpen}
+              onToggleSelectedTools={() => setIsSelectedToolsOpen((prev) => !prev)}
+              onPostIdChange={handleSelectedPostIdChange}
+              isLoadPostDisabled={disabled("postOne")}
+              onLoadPost={() => void loadPostForEditor()}
+              isHitPostDisabled={disabled("hitPost")}
+              onRunHitPost={() =>
+                void run("hitPost", () => apiFetch(`/post/api/v1/posts/${postId}/hit`, { method: "POST" }))
+              }
+              isLikePostDisabled={disabled("likePost")}
+              onRunLikePost={() =>
+                void run("likePost", () => apiFetch(`/post/api/v1/posts/${postId}/like`, { method: "PUT" }))
+              }
+              softDeleteUndoMessage={softDeleteUndoState?.message || ""}
+              isSoftDeleteUndoVisible={Boolean(softDeleteUndoState)}
               isUndoDisabled={disabled("undoDeletePost")}
-              onUndo={() => void handleUndoSoftDelete()}
+              onUndoSoftDelete={() => void handleUndoSoftDelete()}
             />
-          </Section>
           )}
 
         <EditorStudioDeleteConfirmDialog
@@ -3110,229 +3067,4 @@ const WorkspaceGrid = styled.div`
 
 const WorkspaceMain = styled.div`
   min-width: 0;
-`
-
-const Section = styled.section`
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  border-radius: 14px;
-  padding: 0.9rem;
-  margin-bottom: 1.2rem;
-  background: ${({ theme }) => theme.colors.gray2};
-  box-shadow: none;
-
-  h2 {
-    margin: 0;
-    font-size: 1.2rem;
-    color: ${({ theme }) => theme.colors.gray12};
-  }
-
-  &[id="content-studio"] {
-    border: 1px solid ${({ theme }) => theme.colors.gray5};
-    border-radius: 14px;
-    padding: 0.96rem;
-    background: ${({ theme }) => theme.colors.gray2};
-    box-shadow: none;
-    margin-bottom: 1.05rem;
-  }
-
-  @media (max-width: 420px) {
-    border-radius: 12px;
-    padding: 0.74rem;
-    margin-bottom: 0.95rem;
-  }
-`
-
-const SectionTop = styled.div`
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 0.95rem;
-`
-
-const SectionEyebrow = styled.span`
-  display: none;
-`
-
-const SectionDescription = styled.p`
-  margin: 0.22rem 0 0;
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.82rem;
-  line-height: 1.5;
-`
-
-const GlobalNoticeBar = styled.div`
-  margin-bottom: 0.9rem;
-  padding: 0.66rem 0.78rem;
-  border-radius: 10px;
-  font-size: 0.84rem;
-  line-height: 1.5;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-
-  &[data-tone="idle"] {
-    color: ${({ theme }) => theme.colors.gray10};
-    background: ${({ theme }) => theme.colors.gray2};
-    border-color: ${({ theme }) => theme.colors.gray6};
-  }
-
-  &[data-tone="loading"] {
-    color: ${({ theme }) => theme.colors.blue11};
-    background: ${({ theme }) => theme.colors.blue3};
-    border-color: ${({ theme }) => theme.colors.blue7};
-  }
-
-  &[data-tone="success"] {
-    color: ${({ theme }) => theme.colors.green11};
-    background: ${({ theme }) => theme.colors.green3};
-    border-color: ${({ theme }) => theme.colors.green7};
-  }
-
-  &[data-tone="error"] {
-    color: ${({ theme }) => theme.colors.red11};
-    background: ${({ theme }) => theme.colors.red3};
-    border-color: ${({ theme }) => theme.colors.red7};
-  }
-
-  @media (max-width: 420px) {
-    margin-bottom: 0.7rem;
-    padding: 0.58rem 0.62rem;
-    font-size: 0.8rem;
-  }
-`
-
-const ContentStudioGrid = styled.div`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 1rem;
-  align-items: start;
-
-  @media (min-width: 1320px) {
-    grid-template-columns: minmax(0, 1fr) minmax(320px, 360px);
-  }
-
-  @media (max-width: 720px) {
-    gap: 0.76rem;
-  }
-`
-
-const ContentStudioLeft = styled.div`
-  display: grid;
-  gap: 0.95rem;
-  min-width: 0;
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  border-radius: 12px;
-  background: ${({ theme }) => theme.colors.gray1};
-  padding: 0.9rem;
-  box-shadow: none;
-  overflow: hidden;
-
-  @media (max-width: 720px) {
-    padding: 0.72rem;
-    gap: 0.8rem;
-  }
-
-  @media (max-width: 720px) {
-    &[data-mobile-visible="false"] {
-      display: none;
-    }
-  }
-`
-
-const FieldBox = styled.div`
-  display: grid;
-  gap: 0.26rem;
-
-  &.wide {
-    grid-column: span 2;
-
-    @media (max-width: 720px) {
-      grid-column: span 1;
-    }
-  }
-`
-
-const InlineStatus = styled.div`
-  margin-bottom: 0.85rem;
-  padding: 0.62rem 0.72rem;
-  border-radius: 8px;
-  font-size: 0.82rem;
-  line-height: 1.5;
-  width: 100%;
-  min-width: 0;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-
-  &[data-tone="idle"] {
-    color: ${({ theme }) => theme.colors.gray11};
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: transparent;
-  }
-
-  &[data-tone="loading"] {
-    color: ${({ theme }) => theme.colors.blue11};
-    border: 1px solid ${({ theme }) => theme.colors.blue7};
-    background: ${({ theme }) => theme.colors.blue3};
-  }
-
-  &[data-tone="success"] {
-    color: ${({ theme }) => theme.colors.green11};
-    border: 1px solid ${({ theme }) => theme.colors.green7};
-    background: ${({ theme }) => theme.colors.green3};
-  }
-
-  &[data-tone="error"] {
-    color: ${({ theme }) => theme.colors.red11};
-    border: 1px solid ${({ theme }) => theme.colors.red7};
-    background: ${({ theme }) => theme.colors.red3};
-  }
-`
-
-const FieldGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.7rem;
-
-  @media (max-width: 720px) {
-    grid-template-columns: 1fr;
-  }
-`
-
-const ActionRow = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
-  margin-top: 0.85rem;
-  align-items: center;
-
-  > button {
-    min-width: 8.8rem;
-  }
-
-  @media (max-width: 720px) {
-    display: grid;
-    grid-template-columns: 1fr;
-
-    > button {
-      width: 100%;
-    }
-  }
-`
-
-const Input = styled.input`
-  width: 100%;
-  max-width: 100%;
-  box-sizing: border-box;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 8px;
-  padding: 0.72rem 0.8rem;
-  min-height: 44px;
-  min-width: 0;
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray12};
-
-  &:focus-visible {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors.blue8};
-    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
-  }
 `


### PR DESCRIPTION
## 관련 이슈

close #217

## 작업 배경

- `EditorStudioPage.tsx`에 남아 있던 content/manage workspace shell 조립 책임을 `EditorStudioContentWorkspace.tsx`로 분리했습니다.
- 목록 조회, 글 선택, 선택 도구, undo toast의 실제 실행 흐름은 기존 page callback에 남겨 동작 영향 범위를 presentational shell로 제한했습니다.

## 작업 내용

- content workspace shell 컴포넌트를 추가해 mobile step navigator, query/list panel, selected post panel, selected tools panel, undo toast 배치를 위임했습니다.
- `EditorStudioPage.tsx`는 상태와 handler를 새 shell에 전달하는 orchestration 역할만 유지하도록 정리했습니다.
- `editor-studio-state` 구조 가드가 새 shell 파일과 금지 의존성(`apiFetch`, `run`, `loadPostForEditor`, `openDeleteConfirm`, state setter 직접 호출)을 검증하도록 확장했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front test:e2e:authoring` (2회 연속 통과)
  - `git diff --cached --check`
  - `CURRENT_TASK_SLUG=editor-studio-content-workspace-shell-split bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: prop 전달 누락이 있으면 content/manage 영역의 일부 버튼 상태나 모바일 단계 표시가 어긋날 수 있습니다. 구조 가드와 authoring/e2e 검증으로 기존 flow callback 직접 호출 경계를 확인했습니다.
- 롤백 방법: `git revert 0f29d4e41203cc5049ebc544c5c2fbb793f82555`

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
