### PR TITLE
[Refactor] editor list conditions hook 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -264,6 +264,14 @@ test.describe("editor studio state", () => {
     const editorStudioContentWorkspaceSource = existsSync(editorStudioContentWorkspacePath)
       ? readFileSync(editorStudioContentWorkspacePath, "utf8")
       : ""
+    const useEditorStudioListConditionsPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/useEditorStudioListConditions.ts"
+    )
+    expect(existsSync(useEditorStudioListConditionsPath)).toBe(true)
+    const useEditorStudioListConditionsSource = existsSync(useEditorStudioListConditionsPath)
+      ? readFileSync(useEditorStudioListConditionsPath, "utf8")
+      : ""
     const editorStudioMobileStepNavigatorPath = path.resolve(
       __dirname,
       "../src/routes/Admin/EditorStudioMobileStepNavigator.tsx"
@@ -616,6 +624,22 @@ test.describe("editor studio state", () => {
     expect(editorStudioContentWorkspaceSource).not.toContain("openDeleteConfirm")
     expect(editorStudioContentWorkspaceSource).not.toContain("setListScope")
     expect(editorStudioContentWorkspaceSource).not.toContain("setSelectedPostIds")
+    expect(useEditorStudioListConditionsSource).toContain("export const useEditorStudioListConditions =")
+    expect(useEditorStudioListConditionsSource).toContain("export const LIST_SORT_OPTIONS =")
+    expect(useEditorStudioListConditionsSource).toContain("export type PostListScope =")
+    expect(useEditorStudioListConditionsSource).toContain("export type ListQuickPreset =")
+    expect(editorStudioSource).toContain('} from "./useEditorStudioListConditions"')
+    expect(editorStudioSource).toContain("useEditorStudioListConditions()")
+    expect(editorStudioSource).not.toContain("const sanitizeNumberInput =")
+    expect(editorStudioSource).not.toContain("const applyListQuickPreset = useCallback")
+    expect(editorStudioSource).not.toContain("LIST_CONDITION_STORAGE_KEY")
+    expect(editorStudioSource).not.toContain("localStorage.getItem(LIST_CONDITION_STORAGE_KEY)")
+    expect(editorStudioSource).not.toContain("localStorage.setItem(LIST_CONDITION_STORAGE_KEY")
+    expect(useEditorStudioListConditionsSource).not.toContain("apiFetch(")
+    expect(useEditorStudioListConditionsSource).not.toContain("run(")
+    expect(useEditorStudioListConditionsSource).not.toContain("loadAdminPosts")
+    expect(useEditorStudioListConditionsSource).not.toContain("openDeleteConfirm")
+    expect(useEditorStudioListConditionsSource).not.toContain("deletePostsFromList")
     expect(editorStudioDeleteConfirmDialogSource).toContain("export const EditorStudioDeleteConfirmDialog =")
     expect(editorStudioSource).toContain(
       'import { EditorStudioDeleteConfirmDialog } from "./EditorStudioDeleteConfirmDialog"'

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import { GetServerSideProps, NextPage } from "next"
 import { useRouter } from "next/router"
 import {
-  ChangeEvent,
+  type ChangeEvent,
   useDeferredValue,
   useCallback,
   useEffect,
@@ -44,6 +44,11 @@ import { WriterEditorHost } from "./WriterEditorHost"
 import { useEditorStudioDraftLifecycle } from "./useEditorStudioDraftLifecycle"
 import { useEditorStudioPersistence } from "./useEditorStudioPersistence"
 import { useEditorStudioRouting } from "./useEditorStudioRouting"
+import {
+  LIST_SORT_OPTIONS,
+  useEditorStudioListConditions,
+  type PostListScope,
+} from "./useEditorStudioListConditions"
 import { useEditorStudioThumbnailControls } from "./useEditorStudioThumbnailControls"
 import { useEditorStudioThumbnailPreview } from "./useEditorStudioThumbnailPreview"
 import {
@@ -192,8 +197,6 @@ type PostForEditor = {
   tempDraft?: boolean
 }
 
-type PostListScope = "active" | "deleted"
-
 type RsData<T> = {
   resultCode: string
   msg: string
@@ -234,8 +237,6 @@ type DeleteConfirmState = {
   headline: string
 }
 
-type ListQuickPreset = "none" | "today" | "temp"
-
 type SoftDeleteUndoState = {
   ids: number[]
   expiresAt: number
@@ -268,17 +269,11 @@ type PreviewViewportMode = "desktop" | "tablet" | "mobile"
 type ManageMobileStudioStep = "query" | "list"
 type ComposeMobileStudioStep = "edit" | "publish"
 
-const LIST_CONDITION_STORAGE_KEY = "admin.contentStudio.listConditions.v1"
 const LIST_CACHE_TTL_MS = 45_000
 const GLOBAL_NOTICE_IDLE_TEXT = "운영 작업 상태가 여기에 표시됩니다."
 const TAG_RECOMMENDATION_IDLE_TEXT = "AI 태그 추천 상태가 여기에 표시됩니다."
 const MANAGE_MOBILE_STUDIO_STEPS = ["query", "list"] as const
 const COMPOSE_MOBILE_STUDIO_STEPS = ["edit", "publish"] as const
-
-const LIST_SORT_OPTIONS = [
-  { value: "CREATED_AT", label: "최신순" },
-  { value: "CREATED_AT_ASC", label: "오래된순" },
-] as const
 
 const MOBILE_STUDIO_STEP_LABEL: Record<MobileStudioStep, string> = {
   query: "조회",
@@ -609,8 +604,6 @@ const uploadWithConflictRetry = async (
   )
 }
 
-const sanitizeNumberInput = (value: string) => value.replace(/[^\d]/g, "")
-
 const getTodayDateKey = () => new Date().toISOString().slice(0, 10)
 
 const buildListCacheKey = (params: {
@@ -761,13 +754,24 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
     setPostContent(nextMarkdown)
   }, [startPostContentTransition])
 
-  const [listPage, setListPage] = useState("1")
-  const [listPageSize, setListPageSize] = useState("30")
-  const [listKw, setListKw] = useState("")
-  const [listSort, setListSort] = useState("CREATED_AT")
-  const [listScope, setListScope] = useState<PostListScope>("active")
-  const [listQuickPreset, setListQuickPreset] = useState<ListQuickPreset>("none")
-  const [isListAdvancedOpen, setIsListAdvancedOpen] = useState(false)
+  const {
+    listPage,
+    listPageSize,
+    listKw,
+    setListKw,
+    listSort,
+    listScope,
+    setListScope,
+    listQuickPreset,
+    setListQuickPreset,
+    isListAdvancedOpen,
+    handleListPageChange,
+    handleListPageSizeChange,
+    handleListSortChange,
+    applyListQuickPreset,
+    resetListFilters,
+    toggleListAdvanced,
+  } = useEditorStudioListConditions()
   const [isDirectLoadOpen, setIsDirectLoadOpen] = useState(false)
   const [isSelectedToolsOpen, setIsSelectedToolsOpen] = useState(false)
 
@@ -934,32 +938,6 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
   useEffect(() => {
     syncTitleTextareaHeight(titleFieldRef.current)
   }, [postTitle])
-
-  const handleListPageChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-    setListPage(sanitizeNumberInput(e.target.value))
-  }, [])
-
-  const handleListPageSizeChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-    setListPageSize(sanitizeNumberInput(e.target.value))
-  }, [])
-
-  const handleListSortChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
-    setListSort(e.target.value)
-  }, [])
-
-  const applyListQuickPreset = useCallback((preset: ListQuickPreset) => {
-    setListScope("active")
-    setListPage("1")
-    setListPageSize("30")
-    if (preset === "today") {
-      setListKw("")
-      setListSort("CREATED_AT")
-    } else if (preset === "temp") {
-      setListKw("")
-      setListSort("MODIFIED_AT")
-    }
-    setListQuickPreset(preset)
-  }, [])
 
   const handleSelectedPostIdChange = useCallback(
     (nextPostId: string) => {
@@ -1466,8 +1444,8 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
 
   const loadAdminPosts = useCallback(async () => {
     activateManageSurface()
-    const safePage = sanitizeNumberInput(listPage || "1") || "1"
-    const safePageSize = sanitizeNumberInput(listPageSize || "30") || "30"
+    const safePage = listPage || "1"
+    const safePageSize = listPageSize || "30"
     const safeSort =
       LIST_SORT_OPTIONS.find((option) => option.value === listSort)?.value || LIST_SORT_OPTIONS[0].value
     const cacheKey = buildListCacheKey({
@@ -1832,7 +1810,7 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
       tone: "idle",
       text: "",
     })
-  }, [listScope])
+  }, [listScope, setListQuickPreset])
 
   useEffect(() => {
     if (!softDeleteUndoState) return
@@ -2014,47 +1992,7 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
         compareCategoryValues
       )
     )
-    try {
-      const raw = localStorage.getItem(LIST_CONDITION_STORAGE_KEY)
-      if (raw) {
-        const parsed = JSON.parse(raw) as Partial<{
-          page: string
-          pageSize: string
-          kw: string
-          sort: string
-          scope: PostListScope
-          preset: ListQuickPreset
-        }>
-        if (typeof parsed.page === "string") setListPage(sanitizeNumberInput(parsed.page) || "1")
-        if (typeof parsed.pageSize === "string") setListPageSize(sanitizeNumberInput(parsed.pageSize) || "30")
-        if (typeof parsed.kw === "string") setListKw(parsed.kw)
-        if (typeof parsed.sort === "string") {
-          const hasOption = LIST_SORT_OPTIONS.some((option) => option.value === parsed.sort)
-          setListSort(hasOption ? parsed.sort : LIST_SORT_OPTIONS[0].value)
-        }
-        if (parsed.scope === "active" || parsed.scope === "deleted") setListScope(parsed.scope)
-        if (parsed.preset === "none" || parsed.preset === "today" || parsed.preset === "temp") {
-          setListQuickPreset(parsed.preset)
-        }
-      }
-    } catch {
-      // noop: 깨진 저장값은 무시하고 기본값 사용
-    }
   }, [])
-
-  useEffect(() => {
-    localStorage.setItem(
-      LIST_CONDITION_STORAGE_KEY,
-      JSON.stringify({
-        page: listPage,
-        pageSize: listPageSize,
-        kw: listKw,
-        sort: listSort,
-        scope: listScope,
-        preset: listQuickPreset,
-      })
-    )
-  }, [listKw, listPage, listPageSize, listQuickPreset, listScope, listSort])
 
   useEffect(() => {
     persistCatalog(TAG_CATALOG_STORAGE_KEY, customTagCatalog)
@@ -2679,14 +2617,8 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
               onRefreshList={() => void loadAdminPosts()}
               onLoadOrCreateTempPost={() => void handleLoadOrCreateTempPost()}
               onApplyQuickPreset={applyListQuickPreset}
-              onResetFilters={() => {
-                setListQuickPreset("none")
-                setListKw("")
-                setListPage("1")
-                setListPageSize("30")
-                setListSort("CREATED_AT")
-              }}
-              onToggleListAdvanced={() => setIsListAdvancedOpen((prev) => !prev)}
+              onResetFilters={resetListFilters}
+              onToggleListAdvanced={toggleListAdvanced}
               onListPageChange={handleListPageChange}
               onListPageSizeChange={handleListPageSizeChange}
               onListSortChange={handleListSortChange}

--- a/front/src/routes/Admin/useEditorStudioListConditions.ts
+++ b/front/src/routes/Admin/useEditorStudioListConditions.ts
@@ -1,0 +1,128 @@
+import type { ChangeEvent } from "react"
+import { useCallback, useEffect, useState } from "react"
+
+export type PostListScope = "active" | "deleted"
+export type ListQuickPreset = "none" | "today" | "temp"
+
+const LIST_CONDITION_STORAGE_KEY = "admin.contentStudio.listConditions.v1"
+
+export const LIST_SORT_OPTIONS = [
+  { value: "CREATED_AT", label: "최신순" },
+  { value: "CREATED_AT_ASC", label: "오래된순" },
+] as const
+
+const sanitizeNumberInput = (value: string) => value.replace(/[^\d]/g, "")
+
+export const useEditorStudioListConditions = () => {
+  const [listPage, setListPage] = useState("1")
+  const [listPageSize, setListPageSize] = useState("30")
+  const [listKw, setListKw] = useState("")
+  const [listSort, setListSort] = useState("CREATED_AT")
+  const [listScope, setListScope] = useState<PostListScope>("active")
+  const [listQuickPreset, setListQuickPreset] = useState<ListQuickPreset>("none")
+  const [isListAdvancedOpen, setIsListAdvancedOpen] = useState(false)
+
+  const handleListPageChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setListPage(sanitizeNumberInput(event.target.value))
+  }, [])
+
+  const handleListPageSizeChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setListPageSize(sanitizeNumberInput(event.target.value))
+  }, [])
+
+  const handleListSortChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
+    setListSort(event.target.value)
+  }, [])
+
+  const applyListQuickPreset = useCallback((preset: ListQuickPreset) => {
+    setListScope("active")
+    setListPage("1")
+    setListPageSize("30")
+    if (preset === "today") {
+      setListKw("")
+      setListSort("CREATED_AT")
+    } else if (preset === "temp") {
+      setListKw("")
+      setListSort("MODIFIED_AT")
+    }
+    setListQuickPreset(preset)
+  }, [])
+
+  const resetListFilters = useCallback(() => {
+    setListQuickPreset("none")
+    setListKw("")
+    setListPage("1")
+    setListPageSize("30")
+    setListSort("CREATED_AT")
+  }, [])
+
+  const toggleListAdvanced = useCallback(() => {
+    setIsListAdvancedOpen((prev) => !prev)
+  }, [])
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(LIST_CONDITION_STORAGE_KEY)
+      if (!raw) return
+
+      const parsed = JSON.parse(raw) as Partial<{
+        page: string
+        pageSize: string
+        kw: string
+        sort: string
+        scope: PostListScope
+        preset: ListQuickPreset
+      }>
+      if (typeof parsed.page === "string") setListPage(sanitizeNumberInput(parsed.page) || "1")
+      if (typeof parsed.pageSize === "string") setListPageSize(sanitizeNumberInput(parsed.pageSize) || "30")
+      if (typeof parsed.kw === "string") setListKw(parsed.kw)
+      if (typeof parsed.sort === "string") {
+        const hasOption = LIST_SORT_OPTIONS.some((option) => option.value === parsed.sort)
+        setListSort(hasOption ? parsed.sort : LIST_SORT_OPTIONS[0].value)
+      }
+      if (parsed.scope === "active" || parsed.scope === "deleted") setListScope(parsed.scope)
+      if (parsed.preset === "none" || parsed.preset === "today" || parsed.preset === "temp") {
+        setListQuickPreset(parsed.preset)
+      }
+    } catch {
+      // noop: 깨진 저장값은 무시하고 기본값 사용
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem(
+      LIST_CONDITION_STORAGE_KEY,
+      JSON.stringify({
+        page: listPage,
+        pageSize: listPageSize,
+        kw: listKw,
+        sort: listSort,
+        scope: listScope,
+        preset: listQuickPreset,
+      })
+    )
+  }, [listKw, listPage, listPageSize, listQuickPreset, listScope, listSort])
+
+  return {
+    listPage,
+    setListPage,
+    listPageSize,
+    setListPageSize,
+    listKw,
+    setListKw,
+    listSort,
+    setListSort,
+    listScope,
+    setListScope,
+    listQuickPreset,
+    setListQuickPreset,
+    isListAdvancedOpen,
+    setIsListAdvancedOpen,
+    handleListPageChange,
+    handleListPageSizeChange,
+    handleListSortChange,
+    applyListQuickPreset,
+    resetListFilters,
+    toggleListAdvanced,
+  }
+}


### PR DESCRIPTION
## 관련 이슈

close #219

## 작업 배경

- `EditorStudioPage.tsx`에 남아 있던 content/manage 목록 조건 상태와 localStorage persistence를 `useEditorStudioListConditions.ts` hook으로 분리했습니다.
- 목록 조회/삭제/복구/API 실행 flow는 page callback에 그대로 남겨 동작 영향 범위를 목록 조건 controller로 제한했습니다.

## 작업 내용

- `useEditorStudioListConditions.ts`를 추가해 page/pageSize/keyword/sort/scope/quick preset 상태, 입력 정규화, 조건 초기화, 고급 옵션 토글, localStorage 복구/저장을 소유하게 했습니다.
- `EditorStudioPage.tsx`는 hook에서 제공하는 상태와 handler를 `EditorStudioContentWorkspace`에 전달하도록 정리했습니다.
- `editor-studio-state` 구조 가드가 새 hook 파일과 금지 의존성(`apiFetch`, `run`, `loadAdminPosts`, `openDeleteConfirm`, `deletePostsFromList`)을 검증하도록 확장했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (RED 확인 후 2회 연속 통과)
  - `git diff --cached --check`
  - `CURRENT_TASK_SLUG=editor-studio-list-conditions-hook bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: list condition hook prop 연결 누락 시 목록 조회 조건 저장/복구 또는 preset 상태가 어긋날 수 있습니다. 구조 가드와 editor-state 검증으로 hook 경계와 기존 page flow 유지 여부를 확인했습니다.
- 롤백 방법: `git revert f663afc2`

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
