### PR TITLE
[Feat] Global blog 디자인 설정

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberController.kt
@@ -114,6 +114,10 @@ class ApiV1AdmMemberController(
         val homeIntroTitle: String = "",
         @field:Size(max = 500)
         val homeIntroDescription: String = "",
+        @field:Size(max = 20)
+        val blogDesign: String? = null,
+        @field:Size(max = 20)
+        val legacyBlogScheme: String? = null,
         @field:Size(max = 30)
         val serviceLinks: List<@Valid ProfileCardLinkItemRequest> = emptyList(),
         @field:Size(max = 30)
@@ -181,6 +185,10 @@ class ApiV1AdmMemberController(
         val homeIntroTitle: String = "",
         @field:Size(max = 500)
         val homeIntroDescription: String = "",
+        @field:Size(max = 20)
+        val blogDesign: String? = null,
+        @field:Size(max = 20)
+        val legacyBlogScheme: String? = null,
         @field:Size(max = 30)
         val serviceLinks: List<@Valid ProfileCardLinkItemRequest> = emptyList(),
         @field:Size(max = 30)
@@ -356,6 +364,8 @@ class ApiV1AdmMemberController(
             blogTitle = reqBody.blogTitle.trim(),
             homeIntroTitle = reqBody.homeIntroTitle.trim(),
             homeIntroDescription = reqBody.homeIntroDescription.trim(),
+            blogDesign = reqBody.blogDesign?.trim() ?: member.blogDesign,
+            legacyBlogScheme = reqBody.legacyBlogScheme?.trim() ?: member.legacyBlogScheme,
             serviceLinks = reqBody.serviceLinks.normalize(LinkSection.SERVICE),
             contactLinks = reqBody.contactLinks.normalize(LinkSection.CONTACT),
         )
@@ -371,7 +381,7 @@ class ApiV1AdmMemberController(
         @RequestBody @Valid reqBody: UpdateProfileWorkspaceDraftRequest,
     ): MemberProfileWorkspaceResponseDto {
         val member = memberUseCase.findById(id).orElseThrow()
-        memberUseCase.saveProfileWorkspaceDraft(member, reqBody.toDomain())
+        memberUseCase.saveProfileWorkspaceDraft(member, reqBody.toDomain(member.blogDesign, member.legacyBlogScheme))
         return currentMemberProfileQueryUseCase.getWorkspaceById(id)
     }
 
@@ -410,7 +420,10 @@ class ApiV1AdmMemberController(
             )
         }
 
-    private fun UpdateProfileWorkspaceDraftRequest.toDomain(): MemberProfileWorkspaceContent =
+    private fun UpdateProfileWorkspaceDraftRequest.toDomain(
+        currentBlogDesign: String,
+        currentLegacyBlogScheme: String,
+    ): MemberProfileWorkspaceContent =
         MemberProfileWorkspaceContent(
             profileImageUrl = profileImageUrl.trim(),
             profileRole = profileRole.trim(),
@@ -442,6 +455,8 @@ class ApiV1AdmMemberController(
             blogTitle = blogTitle.trim(),
             homeIntroTitle = homeIntroTitle.trim(),
             homeIntroDescription = homeIntroDescription.trim(),
+            blogDesign = blogDesign?.trim() ?: currentBlogDesign,
+            legacyBlogScheme = legacyBlogScheme?.trim() ?: currentLegacyBlogScheme,
             serviceLinks = serviceLinks.normalize(LinkSection.SERVICE),
             contactLinks = contactLinks.normalize(LinkSection.CONTACT),
         )

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/port/input/MemberUseCase.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/port/input/MemberUseCase.kt
@@ -58,6 +58,8 @@ interface MemberUseCase {
         blogTitle: String,
         homeIntroTitle: String,
         homeIntroDescription: String,
+        blogDesign: String,
+        legacyBlogScheme: String,
         serviceLinks: List<MemberProfileLinkItem>,
         contactLinks: List<MemberProfileLinkItem>,
     )

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt
@@ -3,6 +3,8 @@ package com.back.boundedContexts.member.application.service
 import com.back.boundedContexts.member.application.port.output.MemberAttrRepositoryPort
 import com.back.boundedContexts.member.application.port.output.MemberRepositoryPort
 import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.domain.shared.memberMixin.BLOG_DESIGN
+import com.back.boundedContexts.member.domain.shared.memberMixin.LEGACY_BLOG_SCHEME
 import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileLinkItem
 import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileWorkspaceContent
 import com.back.boundedContexts.member.domain.shared.memberMixin.normalizeMemberProfileWorkspaceContent
@@ -206,6 +208,8 @@ class MemberApplicationService(
         blogTitle: String,
         homeIntroTitle: String,
         homeIntroDescription: String,
+        blogDesign: String,
+        legacyBlogScheme: String,
         serviceLinks: List<MemberProfileLinkItem>,
         contactLinks: List<MemberProfileLinkItem>,
     ) {
@@ -225,6 +229,8 @@ class MemberApplicationService(
         member.blogTitle = blogTitle
         member.homeIntroTitle = homeIntroTitle
         member.homeIntroDescription = homeIntroDescription
+        member.blogDesign = blogDesign
+        member.legacyBlogScheme = legacyBlogScheme
         member.serviceLinks = serviceLinks
         member.contactLinks = contactLinks
         saveProfileRoleAttr(member)
@@ -241,6 +247,8 @@ class MemberApplicationService(
         saveBlogTitleAttr(member)
         saveHomeIntroTitleAttr(member)
         saveHomeIntroDescriptionAttr(member)
+        saveBlogDesignAttr(member)
+        saveLegacyBlogSchemeAttr(member)
         saveServiceLinksAttr(member)
         saveContactLinksAttr(member)
         syncDraftWorkspaceFromLegacy(member)
@@ -266,6 +274,8 @@ class MemberApplicationService(
         saveBlogTitleAttr(member)
         saveHomeIntroTitleAttr(member)
         saveHomeIntroDescriptionAttr(member)
+        saveBlogDesignAttr(member)
+        saveLegacyBlogSchemeAttr(member)
         saveServiceLinksAttr(member)
         saveContactLinksAttr(member)
         member.setProfileWorkspaceDraftContent(normalizedContent)
@@ -404,6 +414,22 @@ class MemberApplicationService(
 
     private fun saveHomeIntroDescriptionAttr(member: Member) {
         memberAttrRepository.save(member.getOrInitHomeIntroDescriptionAttr())
+    }
+
+    private fun saveBlogDesignAttr(member: Member) {
+        val attr =
+            memberAttrRepository.findBySubjectAndName(member, BLOG_DESIGN)
+                ?: member.getOrInitBlogDesignAttr()
+        attr.strValue = member.blogDesign
+        memberAttrRepository.save(attr)
+    }
+
+    private fun saveLegacyBlogSchemeAttr(member: Member) {
+        val attr =
+            memberAttrRepository.findBySubjectAndName(member, LEGACY_BLOG_SCHEME)
+                ?: member.getOrInitLegacyBlogSchemeAttr()
+        attr.strValue = member.legacyBlogScheme
+        memberAttrRepository.save(attr)
     }
 
     private fun saveServiceLinksAttr(member: Member) {

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberProfileHydrator.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberProfileHydrator.kt
@@ -6,9 +6,11 @@ import com.back.boundedContexts.member.domain.shared.MemberAttr
 import com.back.boundedContexts.member.domain.shared.memberMixin.ABOUT_BIO
 import com.back.boundedContexts.member.domain.shared.memberMixin.ABOUT_DETAILS
 import com.back.boundedContexts.member.domain.shared.memberMixin.ABOUT_ROLE
+import com.back.boundedContexts.member.domain.shared.memberMixin.BLOG_DESIGN
 import com.back.boundedContexts.member.domain.shared.memberMixin.BLOG_TITLE
 import com.back.boundedContexts.member.domain.shared.memberMixin.HOME_INTRO_DESCRIPTION
 import com.back.boundedContexts.member.domain.shared.memberMixin.HOME_INTRO_TITLE
+import com.back.boundedContexts.member.domain.shared.memberMixin.LEGACY_BLOG_SCHEME
 import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_BIO
 import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_CONTACT_LINKS
 import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_IMG_URL
@@ -37,6 +39,8 @@ class MemberProfileHydrator(
             BLOG_TITLE,
             HOME_INTRO_TITLE,
             HOME_INTRO_DESCRIPTION,
+            BLOG_DESIGN,
+            LEGACY_BLOG_SCHEME,
             PROFILE_SERVICE_LINKS,
             PROFILE_CONTACT_LINKS,
             PROFILE_WORKSPACE_DRAFT,
@@ -85,6 +89,12 @@ class MemberProfileHydrator(
             }
             member.getOrInitHomeIntroDescriptionAttr {
                 attrsByKey["${member.id}:$HOME_INTRO_DESCRIPTION"] ?: MemberAttr(0, member, HOME_INTRO_DESCRIPTION, "")
+            }
+            member.getOrInitBlogDesignAttr {
+                attrsByKey["${member.id}:$BLOG_DESIGN"] ?: MemberAttr(0, member, BLOG_DESIGN, "")
+            }
+            member.getOrInitLegacyBlogSchemeAttr {
+                attrsByKey["${member.id}:$LEGACY_BLOG_SCHEME"] ?: MemberAttr(0, member, LEGACY_BLOG_SCHEME, "")
             }
             member.getOrInitServiceLinksAttr {
                 attrsByKey["${member.id}:$PROFILE_SERVICE_LINKS"] ?: MemberAttr(0, member, PROFILE_SERVICE_LINKS, "")

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberUseCaseAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberUseCaseAdapter.kt
@@ -62,6 +62,8 @@ class MemberUseCaseAdapter(
         blogTitle: String,
         homeIntroTitle: String,
         homeIntroDescription: String,
+        blogDesign: String,
+        legacyBlogScheme: String,
         serviceLinks: List<MemberProfileLinkItem>,
         contactLinks: List<MemberProfileLinkItem>,
     ) = memberApplicationService.modifyProfileCard(
@@ -74,6 +76,8 @@ class MemberUseCaseAdapter(
         blogTitle = blogTitle,
         homeIntroTitle = homeIntroTitle,
         homeIntroDescription = homeIntroDescription,
+        blogDesign = blogDesign,
+        legacyBlogScheme = legacyBlogScheme,
         serviceLinks = serviceLinks,
         contactLinks = contactLinks,
     )

--- a/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/MemberProxy.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/MemberProxy.kt
@@ -86,6 +86,18 @@ class MemberProxy(
             real.homeIntroDescription = value
         }
 
+    override var blogDesign
+        get() = real.blogDesign
+        set(value) {
+            real.blogDesign = value
+        }
+
+    override var legacyBlogScheme
+        get() = real.legacyBlogScheme
+        set(value) {
+            real.legacyBlogScheme = value
+        }
+
     override var serviceLinks
         get() = real.serviceLinks
         set(value) {

--- a/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberHasProfileCard.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberHasProfileCard.kt
@@ -14,6 +14,8 @@ const val ABOUT_DETAILS = "aboutDetails"
 const val BLOG_TITLE = "blogTitle"
 const val HOME_INTRO_TITLE = "homeIntroTitle"
 const val HOME_INTRO_DESCRIPTION = "homeIntroDescription"
+const val BLOG_DESIGN = "blogDesign"
+const val LEGACY_BLOG_SCHEME = "legacyBlogScheme"
 const val PROFILE_SERVICE_LINKS = "profileServiceLinks"
 const val PROFILE_CONTACT_LINKS = "profileContactLinks"
 
@@ -25,6 +27,8 @@ private const val ABOUT_DETAILS_DEFAULT_VALUE = ""
 private const val BLOG_TITLE_DEFAULT_VALUE = ""
 private const val HOME_INTRO_TITLE_DEFAULT_VALUE = ""
 private const val HOME_INTRO_DESCRIPTION_DEFAULT_VALUE = ""
+private const val BLOG_DESIGN_DEFAULT_VALUE = BLOG_DESIGN_LEGACY
+private const val LEGACY_BLOG_SCHEME_DEFAULT_VALUE = LEGACY_BLOG_SCHEME_DARK
 const val PROFILE_SERVICE_LINK_ICON_DEFAULT_VALUE = "service"
 const val PROFILE_CONTACT_LINK_ICON_DEFAULT_VALUE = "message"
 private const val PROFILE_LINK_LABEL_DEFAULT_VALUE = ""
@@ -203,6 +207,16 @@ interface MemberHasProfileCard : MemberAware {
             loader?.invoke() ?: MemberAttr(0, member, HOME_INTRO_DESCRIPTION, HOME_INTRO_DESCRIPTION_DEFAULT_VALUE)
         }
 
+    fun getOrInitBlogDesignAttr(loader: (() -> MemberAttr)? = null): MemberAttr =
+        member.getOrPutAttr(BLOG_DESIGN) {
+            loader?.invoke() ?: MemberAttr(0, member, BLOG_DESIGN, BLOG_DESIGN_DEFAULT_VALUE)
+        }
+
+    fun getOrInitLegacyBlogSchemeAttr(loader: (() -> MemberAttr)? = null): MemberAttr =
+        member.getOrPutAttr(LEGACY_BLOG_SCHEME) {
+            loader?.invoke() ?: MemberAttr(0, member, LEGACY_BLOG_SCHEME, LEGACY_BLOG_SCHEME_DEFAULT_VALUE)
+        }
+
     fun getOrInitServiceLinksAttr(loader: (() -> MemberAttr)? = null): MemberAttr =
         member.getOrPutAttr(PROFILE_SERVICE_LINKS) {
             loader?.invoke() ?: MemberAttr(0, member, PROFILE_SERVICE_LINKS, "")
@@ -271,6 +285,18 @@ interface MemberHasProfileCard : MemberAware {
             getOrInitHomeIntroDescriptionAttr().strValue = value
         }
 
+    var blogDesign: String
+        get() = normalizeBlogDesign(getOrInitBlogDesignAttr().strValue)
+        set(value) {
+            getOrInitBlogDesignAttr().strValue = normalizeBlogDesign(value)
+        }
+
+    var legacyBlogScheme: String
+        get() = normalizeLegacyBlogScheme(getOrInitLegacyBlogSchemeAttr().strValue)
+        set(value) {
+            getOrInitLegacyBlogSchemeAttr().strValue = normalizeLegacyBlogScheme(value)
+        }
+
     var serviceLinks: List<MemberProfileLinkItem>
         get() =
             decodeProfileLinkItems(
@@ -316,6 +342,8 @@ interface MemberHasProfileCard : MemberAware {
                     blogTitle = blogTitle,
                     homeIntroTitle = homeIntroTitle,
                     homeIntroDescription = homeIntroDescription,
+                    blogDesign = blogDesign,
+                    legacyBlogScheme = legacyBlogScheme,
                     serviceLinks = serviceLinks,
                     contactLinks = contactLinks,
                 ),
@@ -360,6 +388,8 @@ interface MemberHasProfileCard : MemberAware {
         blogTitle = normalized.blogTitle
         homeIntroTitle = normalized.homeIntroTitle
         homeIntroDescription = normalized.homeIntroDescription
+        blogDesign = normalized.blogDesign
+        legacyBlogScheme = normalized.legacyBlogScheme
         serviceLinks = normalized.serviceLinks
         contactLinks = normalized.contactLinks
     }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberProfileWorkspace.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberProfileWorkspace.kt
@@ -4,6 +4,22 @@ import com.back.standard.util.Ut
 
 const val PROFILE_WORKSPACE_DRAFT = "profileWorkspaceDraft"
 const val PROFILE_WORKSPACE_PUBLISHED = "profileWorkspacePublished"
+const val BLOG_DESIGN_LEGACY = "legacy"
+const val BLOG_DESIGN_GRID = "grid"
+const val LEGACY_BLOG_SCHEME_LIGHT = "light"
+const val LEGACY_BLOG_SCHEME_DARK = "dark"
+
+fun normalizeBlogDesign(value: String?): String =
+    when (value?.trim()?.lowercase()) {
+        BLOG_DESIGN_GRID -> BLOG_DESIGN_GRID
+        else -> BLOG_DESIGN_LEGACY
+    }
+
+fun normalizeLegacyBlogScheme(value: String?): String =
+    when (value?.trim()?.lowercase()) {
+        LEGACY_BLOG_SCHEME_LIGHT -> LEGACY_BLOG_SCHEME_LIGHT
+        else -> LEGACY_BLOG_SCHEME_DARK
+    }
 
 data class MemberProfileAboutSectionBlock(
     val id: String = "",
@@ -34,6 +50,8 @@ data class MemberProfileWorkspaceContent(
     val blogTitle: String = "",
     val homeIntroTitle: String = "",
     val homeIntroDescription: String = "",
+    val blogDesign: String = BLOG_DESIGN_LEGACY,
+    val legacyBlogScheme: String = LEGACY_BLOG_SCHEME_DARK,
     val serviceLinks: List<MemberProfileLinkItem> = emptyList(),
     val contactLinks: List<MemberProfileLinkItem> = emptyList(),
 )
@@ -161,6 +179,8 @@ fun normalizeMemberProfileWorkspaceContent(content: MemberProfileWorkspaceConten
         blogTitle = content.blogTitle.trim(),
         homeIntroTitle = content.homeIntroTitle.trim(),
         homeIntroDescription = content.homeIntroDescription.trim(),
+        blogDesign = normalizeBlogDesign(content.blogDesign),
+        legacyBlogScheme = normalizeLegacyBlogScheme(content.legacyBlogScheme),
         serviceLinks =
             content.serviceLinks.map {
                 MemberProfileLinkItem(

--- a/back/src/main/kotlin/com/back/boundedContexts/member/dto/MemberProfileWorkspaceResponseDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/dto/MemberProfileWorkspaceResponseDto.kt
@@ -50,6 +50,8 @@ data class MemberProfileWorkspaceContentDto(
     val blogTitle: String,
     val homeIntroTitle: String,
     val homeIntroDescription: String,
+    val blogDesign: String,
+    val legacyBlogScheme: String,
     val serviceLinks: List<MemberProfileLinkItemDto>,
     val contactLinks: List<MemberProfileLinkItemDto>,
 ) {
@@ -66,6 +68,8 @@ data class MemberProfileWorkspaceContentDto(
         blogTitle = content.blogTitle,
         homeIntroTitle = content.homeIntroTitle,
         homeIntroDescription = content.homeIntroDescription,
+        blogDesign = content.blogDesign,
+        legacyBlogScheme = content.legacyBlogScheme,
         serviceLinks = content.serviceLinks.map(::MemberProfileLinkItemDto),
         contactLinks = content.contactLinks.map(::MemberProfileLinkItemDto),
     )

--- a/back/src/main/kotlin/com/back/boundedContexts/member/dto/MemberWithUsernameDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/dto/MemberWithUsernameDto.kt
@@ -51,6 +51,8 @@ data class MemberWithUsernameDto(
     val blogTitle: String,
     val homeIntroTitle: String,
     val homeIntroDescription: String,
+    val blogDesign: String,
+    val legacyBlogScheme: String,
     val serviceLinks: List<MemberProfileLinkItemDto>,
     val contactLinks: List<MemberProfileLinkItemDto>,
 ) {
@@ -94,6 +96,8 @@ data class MemberWithUsernameDto(
         blogTitle = workspaceContent?.blogTitle ?: member.blogTitle,
         homeIntroTitle = workspaceContent?.homeIntroTitle ?: member.homeIntroTitle,
         homeIntroDescription = workspaceContent?.homeIntroDescription ?: member.homeIntroDescription,
+        blogDesign = workspaceContent?.blogDesign ?: member.blogDesign,
+        legacyBlogScheme = workspaceContent?.legacyBlogScheme ?: member.legacyBlogScheme,
         serviceLinks =
             (
                 workspaceContent?.serviceLinks

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberControllerTest.kt
@@ -2,6 +2,7 @@ package com.back.boundedContexts.member.adapter.web
 
 import com.back.boundedContexts.member.application.service.MemberApplicationService
 import com.back.support.BaseControllerIntegrationTest
+import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.startsWith
@@ -20,6 +21,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler
 class ApiV1AdmMemberControllerTest : BaseControllerIntegrationTest() {
     @Autowired
     private lateinit var memberFacade: MemberApplicationService
+
+    @Autowired
+    private lateinit var entityManager: EntityManager
 
     @Test
     @WithUserDetails("admin@test.com")
@@ -184,6 +188,97 @@ class ApiV1AdmMemberControllerTest : BaseControllerIntegrationTest() {
             assertThat(updatedMember.contactLinks).hasSize(1)
             assertThat(updatedMember.contactLinks[0].label).isEqualTo(newContactLabel)
             assertThat(updatedMember.contactLinks[0].href).isEqualTo(newContactHref)
+        }
+
+        @Test
+        @WithUserDetails("admin@test.com")
+        fun `프로필 카드 저장에서 디자인 필드를 생략하면 기존 설정을 유지한다`() {
+            val member = memberFacade.findByEmail("admin@test.com")!!
+
+            mvc
+                .patch("/member/api/v1/adm/members/${member.id}/profileCard") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                            "role": "Backend Developer",
+                            "bio": "bio",
+                            "blogTitle": "blog",
+                            "homeIntroTitle": "title",
+                            "homeIntroDescription": "description",
+                            "blogDesign": "grid",
+                            "legacyBlogScheme": "light",
+                            "serviceLinks": [],
+                            "contactLinks": []
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.blogDesign") { value("grid") }
+                    jsonPath("$.legacyBlogScheme") { value("light") }
+                }
+
+            mvc
+                .patch("/member/api/v1/adm/members/${member.id}/profileCard") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                            "role": "Backend Developer",
+                            "bio": "updated bio",
+                            "blogTitle": "updated blog",
+                            "homeIntroTitle": "updated title",
+                            "homeIntroDescription": "updated description",
+                            "serviceLinks": [],
+                            "contactLinks": []
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.profileBio") { value("updated bio") }
+                    jsonPath("$.blogDesign") { value("grid") }
+                    jsonPath("$.legacyBlogScheme") { value("light") }
+                }
+        }
+
+        @Test
+        @WithUserDetails("admin@test.com")
+        fun `프로필 카드 디자인 설정은 fresh fallback 조회에서도 유지된다`() {
+            val member = memberFacade.findByEmail("admin@test.com")!!
+
+            mvc
+                .patch("/member/api/v1/adm/members/${member.id}/profileCard") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                            "role": "Backend Developer",
+                            "bio": "bio",
+                            "blogTitle": "blog",
+                            "homeIntroTitle": "title",
+                            "homeIntroDescription": "description",
+                            "blogDesign": "grid",
+                            "legacyBlogScheme": "light",
+                            "serviceLinks": [],
+                            "contactLinks": []
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.blogDesign") { value("grid") }
+                    jsonPath("$.legacyBlogScheme") { value("light") }
+                }
+
+            entityManager.flush()
+            entityManager.clear()
+
+            mvc
+                .get("/member/api/v1/adm/members/${member.id}")
+                .andExpect {
+                    status { isOk() }
+                    jsonPath("$.blogDesign") { value("grid") }
+                    jsonPath("$.legacyBlogScheme") { value("light") }
+                }
         }
 
         @Test
@@ -420,45 +515,22 @@ class ApiV1AdmMemberControllerTest : BaseControllerIntegrationTest() {
 
         @Test
         @WithUserDetails("admin@test.com")
-        fun `draft 저장 후 공개 관리자 프로필은 발행 전까지 기존 공개본을 유지하고 publish 후 반영된다`() {
+        fun `워크스페이스 초안 저장에서 디자인 필드를 생략하면 현재 설정을 유지한다`() {
             val member = memberFacade.findByEmail("admin@test.com")!!
-            val previousPublishedRole = member.profileRole
-            val previousPublishedBlogTitle = member.blogTitle
 
             mvc
-                .put("/member/api/v1/adm/members/${member.id}/profileWorkspace/draft") {
+                .patch("/member/api/v1/adm/members/${member.id}/profileCard") {
                     contentType = MediaType.APPLICATION_JSON
                     content =
                         """
                         {
-                            "profileImageUrl": "",
-                            "profileRole": "Draft Role",
-                            "profileBio": "Draft Bio",
-                            "aboutHeadline": "Draft Headline",
-                            "aboutRole": "Draft About Role",
-                            "aboutBio": "Draft About Bio",
-                            "aboutSections": [
-                                {
-                                    "id": "awards",
-                                    "title": "수상이력",
-                                    "items": ["2026.03 운영 포트폴리오 고도화"],
-                                    "dividerBefore": false
-                                }
-                            ],
-                            "aboutProjectSectionTitle": "Draft Projects",
-                            "aboutProjects": [
-                                {
-                                    "id": "bank",
-                                    "name": "aquila-bank",
-                                    "summary": "Draft Project Summary",
-                                    "role": "Backend",
-                                    "href": "https://github.com/AquilaXk/aquila-bank",
-                                    "linkLabel": "Repository"
-                                }
-                            ],
-                            "blogTitle": "Draft Blog Title",
-                            "homeIntroTitle": "Draft Intro Title",
-                            "homeIntroDescription": "Draft Intro Description",
+                            "role": "Backend Developer",
+                            "bio": "bio",
+                            "blogTitle": "blog",
+                            "homeIntroTitle": "title",
+                            "homeIntroDescription": "description",
+                            "blogDesign": "grid",
+                            "legacyBlogScheme": "light",
                             "serviceLinks": [],
                             "contactLinks": []
                         }
@@ -468,18 +540,92 @@ class ApiV1AdmMemberControllerTest : BaseControllerIntegrationTest() {
                 }
 
             mvc
+                .put("/member/api/v1/adm/members/${member.id}/profileWorkspace/draft") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                            "profileImageUrl": "",
+                            "profileRole": "Platform Engineer",
+                            "profileBio": "운영 가능한 시스템을 설계합니다.",
+                            "aboutHeadline": "이유를 먼저 따집니다.",
+                            "aboutRole": "Architecture Writer",
+                            "aboutBio": "문제와 운영을 같이 봅니다.",
+                            "aboutSections": [],
+                            "aboutProjectSectionTitle": "프로젝트",
+                            "aboutProjects": [],
+                            "blogTitle": "Aquila Workspace",
+                            "homeIntroTitle": "프로필 워크스페이스 실험실",
+                            "homeIntroDescription": "브랜드와 소개 문구를 분리 관리합니다.",
+                            "serviceLinks": [],
+                            "contactLinks": []
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.draft.blogDesign") { value("grid") }
+                    jsonPath("$.draft.legacyBlogScheme") { value("light") }
+                }
+        }
+
+        @Test
+        @WithUserDetails("admin@test.com")
+        fun `draft 저장 후 공개 관리자 프로필은 발행 전까지 기존 공개본을 유지하고 publish 후 반영된다`() {
+            val member = memberFacade.findByEmail("admin@test.com")!!
+            val previousPublishedRole = member.profileRole
+            val previousPublishedBlogTitle = member.blogTitle
+            val previousPublishedDesign = member.blogDesign
+            val previousPublishedScheme = member.legacyBlogScheme
+
+            mvc
+                .put("/member/api/v1/adm/members/${member.id}/profileWorkspace/draft") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                            "profileImageUrl": "",
+                            "profileRole": "Platform Engineer",
+                            "profileBio": "운영 가능한 시스템을 설계합니다.",
+                            "aboutHeadline": "이유를 먼저 따집니다.",
+                            "aboutRole": "Architecture Writer",
+                            "aboutBio": "문제와 운영을 같이 봅니다.",
+                            "aboutSections": [],
+                            "aboutProjectSectionTitle": "프로젝트",
+                            "aboutProjects": [],
+                            "blogTitle": "Aquila Workspace",
+                            "homeIntroTitle": "프로필 워크스페이스 실험실",
+                            "homeIntroDescription": "브랜드와 소개 문구를 분리 관리합니다.",
+                            "blogDesign": "grid",
+                            "legacyBlogScheme": "light",
+                            "serviceLinks": [],
+                            "contactLinks": []
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.draft.blogDesign") { value("grid") }
+                    jsonPath("$.draft.legacyBlogScheme") { value("light") }
+                    jsonPath("$.published.blogDesign") { value(previousPublishedDesign) }
+                    jsonPath("$.published.legacyBlogScheme") { value(previousPublishedScheme) }
+                }
+
+            mvc
                 .get("/member/api/v1/members/adminProfile")
                 .andExpect {
                     status { isOk() }
                     jsonPath("$.profileRole") { value(previousPublishedRole) }
                     jsonPath("$.blogTitle") { value(previousPublishedBlogTitle) }
+                    jsonPath("$.blogDesign") { value(previousPublishedDesign) }
+                    jsonPath("$.legacyBlogScheme") { value(previousPublishedScheme) }
                 }
 
             mvc
                 .post("/member/api/v1/adm/members/${member.id}/profileWorkspace/publish")
                 .andExpect {
                     status { isOk() }
-                    jsonPath("$.published.profileRole") { value("Draft Role") }
+                    jsonPath("$.published.profileRole") { value("Platform Engineer") }
+                    jsonPath("$.published.blogDesign") { value("grid") }
+                    jsonPath("$.published.legacyBlogScheme") { value("light") }
                     jsonPath("$.dirtyFromPublished") { value(false) }
                 }
 
@@ -487,17 +633,17 @@ class ApiV1AdmMemberControllerTest : BaseControllerIntegrationTest() {
                 .get("/member/api/v1/members/adminProfile")
                 .andExpect {
                     status { isOk() }
-                    jsonPath("$.profileRole") { value("Draft Role") }
-                    jsonPath("$.profileBio") { value("Draft Bio") }
-                    jsonPath("$.aboutHeadline") { value("Draft Headline") }
-                    jsonPath("$.aboutRole") { value("Draft About Role") }
-                    jsonPath("$.aboutSections.length()") { value(1) }
-                    jsonPath("$.aboutSections[0].title") { value("수상이력") }
-                    jsonPath("$.aboutProjectSectionTitle") { value("Draft Projects") }
-                    jsonPath("$.aboutProjects.length()") { value(1) }
-                    jsonPath("$.aboutProjects[0].linkLabel") { value("Repository") }
-                    jsonPath("$.blogTitle") { value("Draft Blog Title") }
-                    jsonPath("$.homeIntroTitle") { value("Draft Intro Title") }
+                    jsonPath("$.profileRole") { value("Platform Engineer") }
+                    jsonPath("$.profileBio") { value("운영 가능한 시스템을 설계합니다.") }
+                    jsonPath("$.aboutHeadline") { value("이유를 먼저 따집니다.") }
+                    jsonPath("$.aboutRole") { value("Architecture Writer") }
+                    jsonPath("$.aboutSections.length()") { value(0) }
+                    jsonPath("$.aboutProjectSectionTitle") { value("프로젝트") }
+                    jsonPath("$.aboutProjects.length()") { value(0) }
+                    jsonPath("$.blogTitle") { value("Aquila Workspace") }
+                    jsonPath("$.homeIntroTitle") { value("프로필 워크스페이스 실험실") }
+                    jsonPath("$.blogDesign") { value("grid") }
+                    jsonPath("$.legacyBlogScheme") { value("light") }
                 }
         }
     }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerWebMvcTest.kt
@@ -29,6 +29,8 @@ class ApiV1MemberControllerWebMvcTest : BaseMemberControllerWebMvcTest() {
             adminMember.blogTitle = "aquilaXk's Archive"
             adminMember.homeIntroTitle = "aquilaXk's Blog"
             adminMember.homeIntroDescription = "welcome to my backend dev log!"
+            adminMember.blogDesign = "grid"
+            adminMember.legacyBlogScheme = "light"
             given(memberUseCase.findByEmail("admin@test.com")).willReturn(adminMember)
             given(currentMemberProfileQueryUseCase.getPublishedById(adminMember.id))
                 .willReturn(MemberWithUsernameDto(adminMember))
@@ -51,6 +53,8 @@ class ApiV1MemberControllerWebMvcTest : BaseMemberControllerWebMvcTest() {
                     jsonPath("$.blogTitle") { value("aquilaXk's Archive") }
                     jsonPath("$.homeIntroTitle") { value("aquilaXk's Blog") }
                     jsonPath("$.homeIntroDescription") { value("welcome to my backend dev log!") }
+                    jsonPath("$.blogDesign") { value("grid") }
+                    jsonPath("$.legacyBlogScheme") { value("light") }
                     jsonPath("$.profileImageUrl") { value(startsWith(adminMember.redirectToProfileImgUrlOrDefault)) }
                 }
         }

--- a/docs/superpowers/plans/2026-05-13-global-blog-design-setting.md
+++ b/docs/superpowers/plans/2026-05-13-global-blog-design-setting.md
@@ -692,6 +692,12 @@ git push
 - Modify: `front/src/layouts/RootLayout/index.tsx`
 - Modify: `front/src/layouts/RootLayout/Header/index.tsx`
 - Modify: `front/src/layouts/RootLayout/Header/ThemeToggle.tsx`
+- Modify: `front/src/pages/_app.tsx`
+- Modify: `front/src/pages/admin.tsx`
+- Modify: `front/src/pages/posts/[id].tsx`
+- Modify: `front/src/libs/server/postDetailPage.ts`
+- Modify: `front/src/hooks/useAdminProfile.ts`
+- Modify: `front/src/routes/Admin/AdminShell.tsx`
 - Test: `front/e2e/smoke.spec.ts`
 - Test: `front/e2e/mobile-layout.spec.ts`
 
@@ -704,11 +710,61 @@ test("public blog appearance는 adminProfile 전역 설정에서 resolve된다",
   const resolverSource = readFileSync(path.resolve(__dirname, "../src/libs/blogAppearance.ts"), "utf8")
   const rootLayoutSource = readFileSync(path.resolve(__dirname, "../src/layouts/RootLayout/index.tsx"), "utf8")
   const headerSource = readFileSync(path.resolve(__dirname, "../src/layouts/RootLayout/Header/index.tsx"), "utf8")
+  const logoSource = readFileSync(path.resolve(__dirname, "../src/layouts/RootLayout/Header/Logo.tsx"), "utf8")
+  const adminShellSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminShell.tsx"), "utf8")
+  const appSource = readFileSync(path.resolve(__dirname, "../src/pages/_app.tsx"), "utf8")
+  const postDetailPageSource = readFileSync(path.resolve(__dirname, "../src/libs/server/postDetailPage.ts"), "utf8")
+  const useAdminProfileSource = readFileSync(path.resolve(__dirname, "../src/hooks/useAdminProfile.ts"), "utf8")
 
   expect(resolverSource).toContain('blogDesign === "grid"')
   expect(resolverSource).toContain('scheme: "dark"')
+  expect(resolverSource).not.toContain("src/libs/profileWorkspace")
   expect(rootLayoutSource).toContain("resolvePublicBlogAppearance")
+  expect(rootLayoutSource).toContain("usePublicAdminProfile(initialAdminProfile")
   expect(headerSource).toContain("showThemeToggle")
+  expect(logoSource).not.toContain("useAdminProfile")
+  expect(logoSource).toContain("blogTitle")
+  expect(adminShellSource).not.toContain("useAdminProfile")
+  expect(appSource).toContain("initialAdminProfile={initialAdminProfile}")
+  expect(postDetailPageSource).toContain("queryKey.adminProfile()")
+  expect(postDetailPageSource).toContain("initialAdminProfile")
+  expect(postDetailPageSource).toContain('initialAdminProfileSource === "static-fallback"')
+  expect(appSource).toContain("initialAdminProfileShouldRefetch")
+  expect(rootLayoutSource).toContain("refetchOnMount: initialAdminProfileShouldRefetch")
+  expect(rootLayoutSource).toContain("staleTimeMs: initialAdminProfileShouldRefetch ? 0 : undefined")
+  expect(useAdminProfileSource).toContain("enabled?: boolean")
+  expect(useAdminProfileSource).toContain("refetchOnMount?: boolean")
+  expect(useAdminProfileSource).toContain("staleTimeMs?: number")
+})
+```
+
+Also add behavioral coverage for the post detail admin profile seed helper:
+
+```ts
+import { resolveStaticAdminProfileSeed } from "../src/libs/server/postDetailPage"
+
+test("post detail adminProfile seed marks published and fallback sources", async () => {
+  const publishedProfile = {
+    username: "aquila",
+    name: "aquila",
+    nickname: "aquila",
+    profileImageUrl: "/avatar.png",
+    blogDesign: "grid" as const,
+    legacyBlogScheme: "light" as const,
+  }
+
+  await expect(resolveStaticAdminProfileSeed(async () => publishedProfile)).resolves.toMatchObject({
+    profile: { blogDesign: "grid", legacyBlogScheme: "light" },
+    source: "published",
+  })
+  await expect(
+    resolveStaticAdminProfileSeed(async () => {
+      throw new Error("admin profile unavailable")
+    })
+  ).resolves.toMatchObject({
+    profile: { blogDesign: "legacy", legacyBlogScheme: "dark" },
+    source: "static-fallback",
+  })
 })
 ```
 
@@ -729,7 +785,6 @@ Create `front/src/libs/blogAppearance.ts`:
 import { CONFIG } from "site.config"
 import type { AdminProfile } from "src/hooks/useAdminProfile"
 import type { BlogDesignType, LegacyBlogScheme, SchemeType } from "src/types"
-import { normalizeBlogDesign, normalizeLegacyBlogScheme } from "src/libs/profileWorkspace"
 
 export type PublicBlogAppearance = {
   blogDesign: BlogDesignType
@@ -739,6 +794,12 @@ export type PublicBlogAppearance = {
 
 const resolveConfigScheme = (): LegacyBlogScheme =>
   CONFIG.blog.scheme === "light" ? "light" : "dark"
+
+const normalizeBlogDesign = (value: unknown): BlogDesignType =>
+  value === "grid" ? "grid" : "legacy"
+
+const normalizeLegacyBlogScheme = (value: unknown): LegacyBlogScheme =>
+  value === "light" ? "light" : "dark"
 
 export const resolvePublicBlogAppearance = (
   profile: Pick<AdminProfile, "blogDesign" | "legacyBlogScheme"> | null | undefined
@@ -842,16 +903,34 @@ publicDesign: createPublicDesignTokens(options.scheme, options.blogDesign ?? "le
 
 In `ThemeProvider/index.tsx`, accept `blogDesign` and call `createTheme({ scheme, blogDesign })`.
 
-In `RootLayout/index.tsx`, import `useAdminProfile` and resolver. Add route guard:
+In `_app.tsx`, pass page-level `initialAdminProfile` into `RootLayout` so public pages can render the published admin profile appearance on SSR/first paint:
+
+```ts
+const initialAdminProfile = pageProps.initialAdminProfile ?? null
+```
+
+```tsx
+<RootLayout initialAdminProfile={initialAdminProfile}>
+```
+
+In `RootLayout/index.tsx`, import `AdminProfile`, `useQuery`, and resolver. Add a lightweight public profile query and route guard:
 
 ```ts
 const isPublicBlogRoute =
   router.pathname === "/" || router.pathname === "/about" || router.pathname === "/posts/[id]"
-const adminProfile = useAdminProfile()
-const publicAppearance = resolvePublicBlogAppearance(adminProfile)
+const adminProfile = usePublicAdminProfile(initialAdminProfile, { enabled: isPublicBlogRoute })
+const publicAppearance = resolvePublicBlogAppearance(isPublicBlogRoute ? adminProfile : null)
 const effectiveScheme = isPublicBlogRoute ? publicAppearance.scheme : scheme
 const effectiveBlogDesign = isPublicBlogRoute ? publicAppearance.blogDesign : "legacy"
 ```
+
+In `postDetailPage.ts`, fetch or fall back to the public admin profile during static prop generation, set `queryKey.adminProfile()` in the dehydrated React Query state, and return `initialAdminProfile` plus `initialAdminProfileSource` in props. If the source is `static-fallback`, use the short recovery revalidation window instead of the normal 1-hour ISR window.
+
+In `posts/[id].tsx`, include `initialAdminProfile` and `initialAdminProfileSource` in the page props type so `_app.tsx` can consume them without changing article rendering.
+
+In `_app.tsx`/`RootLayout/index.tsx`, derive `initialAdminProfileShouldRefetch` from `initialAdminProfileSource === "static-fallback"` and pass `refetchOnMount: initialAdminProfileShouldRefetch` plus `staleTimeMs: initialAdminProfileShouldRefetch ? 0 : undefined` into the public-route-only profile query.
+
+In `useAdminProfile.ts`, keep the existing full profile hook for profile/about/admin callers. RootLayout must use a lightweight public profile query so non-public routes do not pull profile workspace/cookie/admin profile fetch code into the shared `_app` chunk.
 
 Pass:
 
@@ -910,6 +989,10 @@ git add front/src/libs/blogAppearance.ts \
   front/src/layouts/RootLayout/ThemeProvider/Global/index.tsx \
   front/src/layouts/RootLayout/index.tsx \
   front/src/layouts/RootLayout/Header/index.tsx \
+  front/src/pages/_app.tsx \
+  front/src/pages/posts/[id].tsx \
+  front/src/libs/server/postDetailPage.ts \
+  front/src/hooks/useAdminProfile.ts \
   front/e2e/smoke.spec.ts
 git commit -m "feat(frontend): public blog appearance resolver 추가"
 git push

--- a/docs/superpowers/plans/2026-05-13-global-blog-design-setting.md
+++ b/docs/superpowers/plans/2026-05-13-global-blog-design-setting.md
@@ -1135,7 +1135,7 @@ Observed:
 - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1` initially failed after the grid refetch fix because Header grid tokens were applied to operational legacy routes. Header was corrected to use `publicDesign` only when `theme.blogDesign === "grid"`.
 - `node front/scripts/check-bundle-size.mjs` initially failed with `/ raw` 19 bytes over budget after the style/refetch patch. The root cause was the long theme background-image literal; preserving the same visual intent with compact CSS hex literals brought the route back under budget.
 
-- [ ] **Step 7: Commit public surface styling**
+- [x] **Step 7: Commit public surface styling**
 
 ```bash
 git add front/src/layouts/RootLayout/Header/index.tsx \
@@ -1162,6 +1162,8 @@ git commit -m "feat(frontend): grid public blog 디자인 적용"
 git push
 ```
 
+Observed: commit `fadbd491` pushed to `feat/grimdark-blog-skin`.
+
 ### Task 5: Contract Docs And Full Verification
 
 **Files:**
@@ -1171,7 +1173,7 @@ git push
 - Modify: `front/contracts/openapi/openapi.json` if the contract generation flow changes it
 - Create or modify: `.codex/tmp/pr-grimdark-blog-skin.md`
 
-- [ ] **Step 1: Update the local source-of-truth plan and briefs**
+- [x] **Step 1: Update the local source-of-truth plan and briefs**
 
 In `docs/agent/grimdark-blog-skin-plan-2026-05-13.md`, make sure `commit_plan` exactly matches the commits created in this work:
 
@@ -1200,7 +1202,7 @@ In `docs/agent/auth.md`, add the member/profile contract invariant:
 - "공개 `/member/api/v1/members/adminProfile`과 관리자 profile workspace 응답은 `blogDesign`과 `legacyBlogScheme`을 포함해야 하며, 누락/invalid 값은 legacy/dark로 정규화한다."
 ```
 
-- [ ] **Step 2: Run full related verification**
+- [x] **Step 2: Run full related verification**
 
 Run in order:
 
@@ -1219,16 +1221,29 @@ CURRENT_TASK_SLUG=grimdark-blog-skin bash tools/guards/current-task-preflight.sh
 
 Expected: PASS. On command failure, classify it as code regression or environment/permission before retrying.
 
-- [ ] **Step 3: Commit docs and contract artifacts**
+Observed:
+- `back/gradlew -p back ktlintCheck` PASS
+- `back/gradlew -p back test` PASS
+- `yarn --cwd front build` PASS
+- `node front/scripts/check-bundle-size.mjs` PASS
+- `yarn --cwd front playwright:preflight` PASS
+- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1` PASS
+- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` PASS
+- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1` PASS
+
+- [x] **Step 3: Commit docs and contract artifacts**
+
+Repository hook forbids tracking ignored `docs/agent/**` files. Keep `docs/agent/frontend-ui.md`, `docs/agent/auth.md`, and `docs/agent/grimdark-blog-skin-plan-2026-05-13.md` updated as local agent briefs, and commit the tracked implementation plan as the PR-visible operating contract.
 
 ```bash
-git add -f docs/agent/frontend-ui.md docs/agent/auth.md docs/agent/grimdark-blog-skin-plan-2026-05-13.md
-git add front/contracts/openapi/openapi.json
+git add docs/superpowers/plans/2026-05-13-global-blog-design-setting.md
 git commit -m "docs(frontend): global blog design 운영 계약 반영"
 git push
 ```
 
-- [ ] **Step 4: Open the PR**
+Observed: docs commit `354364de` pushed to `feat/grimdark-blog-skin`.
+
+- [x] **Step 4: Open the PR**
 
 Create `.codex/tmp/pr-grimdark-blog-skin.md` with the repository PR template. The first section must include:
 
@@ -1263,3 +1278,5 @@ gh pr create --repo AquilaXk/aquila-blog --base main --head feat/grimdark-blog-s
 ```
 
 Expected: a draft PR URL targeting `main`.
+
+Observed: draft PR `#228` targeting `main`: https://github.com/AquilaXk/aquila-blog/pull/228

--- a/docs/superpowers/plans/2026-05-13-global-blog-design-setting.md
+++ b/docs/superpowers/plans/2026-05-13-global-blog-design-setting.md
@@ -1013,10 +1013,15 @@ git push
 - Modify: `front/src/pages/about.tsx`
 - Modify: `front/src/routes/Detail/PostDetail/index.tsx`
 - Modify: `front/src/routes/Detail/PostDetail/PostHeader.tsx`
+- Modify: `front/src/libs/server/adminProfile.ts`
+- Modify: `front/src/libs/server/postDetailPage.ts`
+- Modify: `front/src/pages/index.tsx`
+- Modify: `front/src/styles/theme.ts`
+- Modify: `front/e2e/smoke.spec.ts`
 - Modify: `front/e2e/mobile-layout.spec.ts`
 - Modify: `front/e2e/perf.spec.ts`
 
-- [ ] **Step 1: Add public styling guard checks**
+- [x] **Step 1: Add public styling guard checks**
 
 In `front/e2e/mobile-layout.spec.ts`, add a source contract test:
 
@@ -1041,7 +1046,7 @@ PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/m
 
 Expected: FAIL until public surface styling consumes `theme.publicDesign`.
 
-- [ ] **Step 2: Apply grid tokens to header without layout changes**
+- [x] **Step 2: Apply grid tokens to header without layout changes**
 
 In `Header/index.tsx`, update `StyledWrapper` background and border:
 
@@ -1064,7 +1069,7 @@ In `Logo.tsx`, keep existing font size and weight. Only adjust color for grid:
 color: ${({ theme }) => (theme.blogDesign === "grid" ? "#f4ead7" : theme.colors.gray12)};
 ```
 
-- [ ] **Step 3: Apply grid tokens to feed surfaces**
+- [x] **Step 3: Apply grid tokens to feed surfaces**
 
 In feed cards and rail cards, replace only background/border/shadow/color accents with conditional tokens:
 
@@ -1088,7 +1093,7 @@ border-color: ${({ theme }) =>
 
 Do not change `font-size`, `line-height`, `letter-spacing`, `max-width`, grid breakpoints, or card dimensions.
 
-- [ ] **Step 4: Apply grid tokens to About and Detail surfaces**
+- [x] **Step 4: Apply grid tokens to About and Detail surfaces**
 
 In `front/src/pages/about.tsx` and `front/src/routes/Detail/PostDetail/**`, change only page/container surface colors, borders, shadows, and decorative dividers:
 
@@ -1108,7 +1113,11 @@ color: ${({ theme }) =>
 
 Do not modify article typography declarations in markdown renderer, post content body, heading scales, or readable width variables.
 
-- [ ] **Step 5: Run public layout/perf focused checks**
+- [x] **Step 5: Keep SSG fallback seeds from blocking public design refetch**
+
+Home/About can render a static fallback admin profile when backend fetch is unavailable during SSG/SSR. That fallback must set `initialAdminProfileSource: "static-fallback"` so `RootLayout` refetches the published public admin profile on mount and the grid design is not hidden behind a stale legacy seed.
+
+- [x] **Step 6: Run public layout/perf focused checks**
 
 Run:
 
@@ -1122,11 +1131,18 @@ yarn --cwd front build
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit public surface styling**
+Observed:
+- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1` initially failed after the grid refetch fix because Header grid tokens were applied to operational legacy routes. Header was corrected to use `publicDesign` only when `theme.blogDesign === "grid"`.
+- `node front/scripts/check-bundle-size.mjs` initially failed with `/ raw` 19 bytes over budget after the style/refetch patch. The root cause was the long theme background-image literal; preserving the same visual intent with compact CSS hex literals brought the route back under budget.
+
+- [ ] **Step 7: Commit public surface styling**
 
 ```bash
 git add front/src/layouts/RootLayout/Header/index.tsx \
   front/src/layouts/RootLayout/Header/Logo.tsx \
+  front/src/libs/server/adminProfile.ts \
+  front/src/libs/server/postDetailPage.ts \
+  front/src/pages/index.tsx \
   front/src/routes/Feed/index.tsx \
   front/src/routes/Feed/PostList/PostCard.tsx \
   front/src/routes/Feed/SearchInput.tsx \
@@ -1135,10 +1151,13 @@ git add front/src/layouts/RootLayout/Header/index.tsx \
   front/src/routes/Feed/ServiceCard.tsx \
   front/src/routes/Feed/ContactCard.tsx \
   front/src/pages/about.tsx \
+  front/src/styles/theme.ts \
   front/src/routes/Detail/PostDetail/index.tsx \
   front/src/routes/Detail/PostDetail/PostHeader.tsx \
+  front/e2e/smoke.spec.ts \
   front/e2e/mobile-layout.spec.ts \
-  front/e2e/perf.spec.ts
+  front/e2e/perf.spec.ts \
+  docs/superpowers/plans/2026-05-13-global-blog-design-setting.md
 git commit -m "feat(frontend): grid public blog 디자인 적용"
 git push
 ```

--- a/docs/superpowers/plans/2026-05-13-global-blog-design-setting.md
+++ b/docs/superpowers/plans/2026-05-13-global-blog-design-setting.md
@@ -1,0 +1,1136 @@
+# Global Blog Design Setting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the blog admin publish one global public blog design (`legacy | grid`), with light/dark mode available only for `legacy`.
+
+**Architecture:** Persist `blogDesign` and `legacyBlogScheme` in the member profile workspace contract, publish them through `adminProfile`, and resolve public blog appearance from the published admin profile. Public routes consume additive Emotion theme tokens; admin/editor work surfaces keep their current operational UI except for the settings controls.
+
+**Tech Stack:** Kotlin/Spring Boot member bounded context, Next.js pages router, React Query v5, Emotion styled components, Playwright, Gradle, Yarn.
+
+---
+
+## File Structure
+
+- Modify `back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberProfileWorkspace.kt`: add design defaults, normalization helpers, and workspace content fields.
+- Modify `back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberHasProfileCard.kt`: add legacy member attrs/getters/setters so non-workspace fallback profiles carry the same contract.
+- Modify `back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/MemberProxy.kt`: proxy the new member profile fields.
+- Modify `back/src/main/kotlin/com/back/boundedContexts/member/dto/MemberWithUsernameDto.kt`: expose published design fields in public/admin profile responses.
+- Modify `back/src/main/kotlin/com/back/boundedContexts/member/dto/MemberProfileWorkspaceResponseDto.kt`: expose draft/published design fields.
+- Modify `back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberController.kt`: accept design fields in profile card and workspace draft requests.
+- Modify `back/src/main/kotlin/com/back/boundedContexts/member/application/port/input/MemberUseCase.kt`: add design arguments to the legacy profile-card use case.
+- Modify `back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberUseCaseAdapter.kt`: forward design arguments to the application service.
+- Modify `back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt`: persist design attrs from both legacy and workspace profile flows.
+- Modify `back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberControllerTest.kt`: prove draft/save/publish behavior.
+- Modify `back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerWebMvcTest.kt`: prove public `adminProfile` exposes the published setting.
+- Modify `front/src/types/index.ts`: add `BlogDesignType` and `LegacyBlogScheme`.
+- Modify `front/src/libs/profileWorkspace.ts`: extend workspace model and normalization.
+- Modify `front/src/hooks/useAdminProfile.ts` and `front/src/hooks/useAuthSession.ts`: type the two new fields.
+- Modify `front/src/libs/server/adminProfile.ts`: include design fields in static and persisted public profile snapshots.
+- Modify `front/src/pages/admin/profile.tsx`: add the admin-only public design settings section.
+- Create `front/src/libs/blogAppearance.ts`: resolve effective public design/scheme from `AdminProfile`.
+- Modify `front/src/styles/theme.ts`: add `blogDesign` and public design tokens.
+- Modify `front/src/layouts/RootLayout/index.tsx` and `front/src/layouts/RootLayout/ThemeProvider/index.tsx`: apply global public appearance only on public blog routes.
+- Modify `front/src/layouts/RootLayout/Header/index.tsx`: remove visitor public theme toggle on public blog routes and style header from public design tokens.
+- Modify public surfaces under `front/src/routes/Feed/**`, `front/src/routes/About/**`, and `front/src/routes/Detail/PostDetail/**`: opt into grid tokens without changing article typography.
+- Modify `front/e2e/admin-profile-state.spec.ts`, `front/e2e/smoke.spec.ts`, `front/e2e/mobile-layout.spec.ts`, and `front/e2e/perf.spec.ts`: add structural and public route regression coverage.
+- Modify `front/contracts/openapi/openapi.json` only through the existing contract generation/fetch flow if backend verification updates it.
+- Modify `docs/agent/frontend-ui.md` and `docs/agent/auth.md`: record the new global public design contract.
+
+### Task 1: Backend Profile Contract
+
+**Files:**
+- Modify: `back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberProfileWorkspace.kt`
+- Modify: `back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberHasProfileCard.kt`
+- Modify: `back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/MemberProxy.kt`
+- Modify: `back/src/main/kotlin/com/back/boundedContexts/member/dto/MemberWithUsernameDto.kt`
+- Modify: `back/src/main/kotlin/com/back/boundedContexts/member/dto/MemberProfileWorkspaceResponseDto.kt`
+- Modify: `back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberController.kt`
+- Modify: `back/src/main/kotlin/com/back/boundedContexts/member/application/port/input/MemberUseCase.kt`
+- Modify: `back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberUseCaseAdapter.kt`
+- Modify: `back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt`
+- Test: `back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberControllerTest.kt`
+- Test: `back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerWebMvcTest.kt`
+
+- [ ] **Step 1: Add failing backend assertions for the new public profile fields**
+
+In `back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerWebMvcTest.kt`, extend the `adminProfile` test setup and assertions:
+
+```kotlin
+adminMember.blogDesign = "grid"
+adminMember.legacyBlogScheme = "light"
+
+mockMvc
+    .get("/member/api/v1/members/adminProfile") {
+        secure = true
+    }.andExpect {
+        status { isOk() }
+        jsonPath("$.blogDesign") { value("grid") }
+        jsonPath("$.legacyBlogScheme") { value("light") }
+    }
+```
+
+In `back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberControllerTest.kt`, add draft and publish assertions to the profile workspace test body:
+
+```kotlin
+"""
+{
+  "profileImageUrl": "",
+  "profileRole": "Platform Engineer",
+  "profileBio": "운영 가능한 시스템을 설계합니다.",
+  "aboutHeadline": "이유를 먼저 따집니다.",
+  "aboutRole": "Architecture Writer",
+  "aboutBio": "문제와 운영을 같이 봅니다.",
+  "aboutSections": [],
+  "aboutProjectSectionTitle": "프로젝트",
+  "aboutProjects": [],
+  "blogTitle": "Aquila Workspace",
+  "homeIntroTitle": "프로필 워크스페이스 실험실",
+  "homeIntroDescription": "브랜드와 소개 문구를 분리 관리합니다.",
+  "blogDesign": "grid",
+  "legacyBlogScheme": "light",
+  "serviceLinks": [],
+  "contactLinks": []
+}
+""".trimIndent()
+```
+
+Add assertions after saving and after publishing:
+
+```kotlin
+jsonPath("$.draft.blogDesign") { value("grid") }
+jsonPath("$.draft.legacyBlogScheme") { value("light") }
+jsonPath("$.published.blogDesign") { value(previousPublishedDesign) }
+jsonPath("$.published.legacyBlogScheme") { value(previousPublishedScheme) }
+```
+
+After publish, assert public profile response:
+
+```kotlin
+mockMvc
+    .get("/member/api/v1/members/adminProfile")
+    .andExpect {
+        status { isOk() }
+        jsonPath("$.blogDesign") { value("grid") }
+        jsonPath("$.legacyBlogScheme") { value("light") }
+    }
+```
+
+- [ ] **Step 2: Run backend tests to verify they fail**
+
+Run:
+
+```bash
+./gradlew -p back test --tests '*ApiV1MemberControllerWebMvcTest*' --tests '*ApiV1AdmMemberControllerTest*'
+```
+
+Expected: FAIL with unresolved `blogDesign`/`legacyBlogScheme` properties or missing JSON paths.
+
+- [ ] **Step 3: Implement backend domain fields and normalization**
+
+In `MemberProfileWorkspace.kt`, add constants and helpers near the top:
+
+```kotlin
+const val BLOG_DESIGN_LEGACY = "legacy"
+const val BLOG_DESIGN_GRID = "grid"
+const val LEGACY_BLOG_SCHEME_LIGHT = "light"
+const val LEGACY_BLOG_SCHEME_DARK = "dark"
+
+fun normalizeBlogDesign(value: String?): String =
+    when (value?.trim()?.lowercase()) {
+        BLOG_DESIGN_GRID -> BLOG_DESIGN_GRID
+        else -> BLOG_DESIGN_LEGACY
+    }
+
+fun normalizeLegacyBlogScheme(value: String?): String =
+    when (value?.trim()?.lowercase()) {
+        LEGACY_BLOG_SCHEME_LIGHT -> LEGACY_BLOG_SCHEME_LIGHT
+        else -> LEGACY_BLOG_SCHEME_DARK
+    }
+```
+
+Extend `MemberProfileWorkspaceContent`:
+
+```kotlin
+val blogDesign: String = BLOG_DESIGN_LEGACY,
+val legacyBlogScheme: String = LEGACY_BLOG_SCHEME_DARK,
+```
+
+In `normalizeMemberProfileWorkspaceContent`, return normalized values:
+
+```kotlin
+blogDesign = normalizeBlogDesign(content.blogDesign),
+legacyBlogScheme = normalizeLegacyBlogScheme(content.legacyBlogScheme),
+```
+
+In `MemberHasProfileCard.kt`, add attrs and properties:
+
+```kotlin
+const val BLOG_DESIGN = "blogDesign"
+const val LEGACY_BLOG_SCHEME = "legacyBlogScheme"
+private const val BLOG_DESIGN_DEFAULT_VALUE = BLOG_DESIGN_LEGACY
+private const val LEGACY_BLOG_SCHEME_DEFAULT_VALUE = LEGACY_BLOG_SCHEME_DARK
+```
+
+```kotlin
+fun getOrInitBlogDesignAttr(loader: (() -> MemberAttr)? = null): MemberAttr =
+    member.getOrPutAttr(BLOG_DESIGN) {
+        loader?.invoke() ?: MemberAttr(0, member, BLOG_DESIGN, BLOG_DESIGN_DEFAULT_VALUE)
+    }
+
+fun getOrInitLegacyBlogSchemeAttr(loader: (() -> MemberAttr)? = null): MemberAttr =
+    member.getOrPutAttr(LEGACY_BLOG_SCHEME) {
+        loader?.invoke() ?: MemberAttr(0, member, LEGACY_BLOG_SCHEME, LEGACY_BLOG_SCHEME_DEFAULT_VALUE)
+    }
+
+var blogDesign: String
+    get() = normalizeBlogDesign(getOrInitBlogDesignAttr().strValue)
+    set(value) {
+        getOrInitBlogDesignAttr().strValue = normalizeBlogDesign(value)
+    }
+
+var legacyBlogScheme: String
+    get() = normalizeLegacyBlogScheme(getOrInitLegacyBlogSchemeAttr().strValue)
+    set(value) {
+        getOrInitLegacyBlogSchemeAttr().strValue = normalizeLegacyBlogScheme(value)
+    }
+```
+
+Include the fields in `currentProfileWorkspaceContent` and `applyProfileWorkspaceContent`.
+
+In `MemberProxy.kt`, proxy the properties:
+
+```kotlin
+override var blogDesign
+    get() = real.blogDesign
+    set(value) {
+        real.blogDesign = value
+    }
+
+override var legacyBlogScheme
+    get() = real.legacyBlogScheme
+    set(value) {
+        real.legacyBlogScheme = value
+    }
+```
+
+- [ ] **Step 4: Implement backend DTO/request propagation**
+
+In `MemberWithUsernameDto.kt`, add constructor parameters and values:
+
+```kotlin
+val blogDesign: String,
+val legacyBlogScheme: String,
+```
+
+```kotlin
+blogDesign = workspaceContent?.blogDesign ?: member.blogDesign,
+legacyBlogScheme = workspaceContent?.legacyBlogScheme ?: member.legacyBlogScheme,
+```
+
+In `MemberProfileWorkspaceResponseDto.kt`, add fields to `MemberProfileWorkspaceContentDto`:
+
+```kotlin
+val blogDesign: String,
+val legacyBlogScheme: String,
+```
+
+and constructor values:
+
+```kotlin
+blogDesign = content.blogDesign,
+legacyBlogScheme = content.legacyBlogScheme,
+```
+
+In `ApiV1AdmMemberController.kt`, extend `UpdateProfileCardRequest` and `UpdateProfileWorkspaceDraftRequest`:
+
+```kotlin
+@field:Size(max = 20)
+val blogDesign: String = "",
+@field:Size(max = 20)
+val legacyBlogScheme: String = "",
+```
+
+Pass the fields into `MemberProfileWorkspaceContent` in `toDomain()`:
+
+```kotlin
+blogDesign = blogDesign.trim(),
+legacyBlogScheme = legacyBlogScheme.trim(),
+```
+
+Pass the fields through the legacy profile-card endpoint as well, so older admin flows and workspace fallback snapshots keep the same published contract.
+
+In `ApiV1AdmMemberController.updateProfileCard`, extend the use-case call:
+
+```kotlin
+blogDesign = reqBody.blogDesign.trim(),
+legacyBlogScheme = reqBody.legacyBlogScheme.trim(),
+```
+
+In `MemberUseCase.kt`, add parameters after `homeIntroDescription`:
+
+```kotlin
+blogDesign: String,
+legacyBlogScheme: String,
+```
+
+In `MemberUseCaseAdapter.modifyProfileCard`, add the same parameters and forward them:
+
+```kotlin
+blogDesign = blogDesign,
+legacyBlogScheme = legacyBlogScheme,
+```
+
+In `MemberApplicationService.modifyProfileCard`, add the same parameters, persist normalized member values, and save their attrs before `syncDraftWorkspaceFromLegacy(member)`:
+
+```kotlin
+member.blogDesign = blogDesign
+member.legacyBlogScheme = legacyBlogScheme
+saveBlogDesignAttr(member)
+saveLegacyBlogSchemeAttr(member)
+```
+
+In `MemberApplicationService.saveProfileWorkspaceDraft`, persist the new attrs after the existing home intro attr saves:
+
+```kotlin
+saveBlogDesignAttr(member)
+saveLegacyBlogSchemeAttr(member)
+```
+
+Add private attr savers near the other profile attr save helpers:
+
+```kotlin
+private fun saveBlogDesignAttr(member: Member) {
+    memberAttrRepository.save(member.getOrInitBlogDesignAttr())
+}
+
+private fun saveLegacyBlogSchemeAttr(member: Member) {
+    memberAttrRepository.save(member.getOrInitLegacyBlogSchemeAttr())
+}
+```
+
+- [ ] **Step 5: Run backend targeted tests and style**
+
+Run:
+
+```bash
+./gradlew -p back test --tests '*ApiV1MemberControllerWebMvcTest*' --tests '*ApiV1AdmMemberControllerTest*'
+./gradlew -p back ktlintCheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit backend contract**
+
+```bash
+git add back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberProfileWorkspace.kt \
+  back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberHasProfileCard.kt \
+  back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/MemberProxy.kt \
+  back/src/main/kotlin/com/back/boundedContexts/member/dto/MemberWithUsernameDto.kt \
+  back/src/main/kotlin/com/back/boundedContexts/member/dto/MemberProfileWorkspaceResponseDto.kt \
+  back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberController.kt \
+  back/src/main/kotlin/com/back/boundedContexts/member/application/port/input/MemberUseCase.kt \
+  back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberUseCaseAdapter.kt \
+  back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt \
+  back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberControllerTest.kt \
+  back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerWebMvcTest.kt
+git commit -m "feat(profile): global blog design 계약 추가"
+git push
+```
+
+### Task 2: Frontend Settings Contract
+
+**Files:**
+- Modify: `front/src/types/index.ts`
+- Modify: `front/src/libs/profileWorkspace.ts`
+- Modify: `front/src/hooks/useAdminProfile.ts`
+- Modify: `front/src/hooks/useAuthSession.ts`
+- Modify: `front/src/libs/server/adminProfile.ts`
+- Modify: `front/src/pages/admin/profile.tsx`
+- Test: `front/e2e/admin-profile-state.spec.ts`
+
+- [ ] **Step 1: Add failing frontend model tests**
+
+In `front/e2e/admin-profile-state.spec.ts`, extend the `buildProfileWorkspaceAdminProfileCacheFields` fixture with:
+
+```ts
+blogDesign: "grid",
+legacyBlogScheme: "light",
+```
+
+Add assertions:
+
+```ts
+expect(bridge.blogDesign).toBe("grid")
+expect(bridge.legacyBlogScheme).toBe("light")
+```
+
+Add a normalization test:
+
+```ts
+test("profile workspace 정규화는 전역 블로그 디자인 fallback을 고정한다", () => {
+  const normalized = normalizeProfileWorkspaceContent({
+    profileImageUrl: "",
+    profileRole: "",
+    profileBio: "",
+    aboutHeadline: "",
+    aboutRole: "",
+    aboutBio: "",
+    aboutSections: [],
+    aboutProjectSectionTitle: "",
+    aboutProjects: [],
+    blogTitle: "",
+    homeIntroTitle: "",
+    homeIntroDescription: "",
+    blogDesign: "unknown" as never,
+    legacyBlogScheme: "blue" as never,
+    serviceLinks: [],
+    contactLinks: [],
+  })
+
+  expect(normalized.blogDesign).toBe("legacy")
+  expect(normalized.legacyBlogScheme).toBe("dark")
+})
+```
+
+Add a source contract test:
+
+```ts
+test("profile 화면은 전역 블로그 디자인 설정과 legacy 전용 scheme control을 가진다", () => {
+  const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/profile.tsx"), "utf8")
+
+  expect(source).toContain('id: "design"')
+  expect(source).toContain('label: "디자인"')
+  expect(source).toContain('updateDraft("blogDesign",')
+  expect(source).toContain('updateDraft("legacyBlogScheme",')
+  expect(source).toContain('draft.blogDesign === "legacy"')
+})
+```
+
+- [ ] **Step 2: Run frontend targeted test to verify it fails**
+
+Run:
+
+```bash
+yarn --cwd front playwright:preflight
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1
+```
+
+Expected: FAIL because `blogDesign`/`legacyBlogScheme` are missing from types and the admin page source.
+
+- [ ] **Step 3: Extend frontend types and workspace normalization**
+
+In `front/src/types/index.ts`, add:
+
+```ts
+export type BlogDesignType = "legacy" | "grid"
+export type LegacyBlogScheme = "light" | "dark"
+```
+
+In `front/src/libs/profileWorkspace.ts`, import the types and extend `ProfileWorkspaceContent`/`LegacyProfileLike`:
+
+```ts
+import type { BlogDesignType, LegacyBlogScheme } from "src/types"
+```
+
+```ts
+blogDesign: BlogDesignType
+legacyBlogScheme: LegacyBlogScheme
+```
+
+Add helpers:
+
+```ts
+export const normalizeBlogDesign = (value: unknown): BlogDesignType =>
+  value === "grid" ? "grid" : "legacy"
+
+export const normalizeLegacyBlogScheme = (value: unknown): LegacyBlogScheme =>
+  value === "light" ? "light" : "dark"
+```
+
+Add fields to every `normalizeProfileWorkspaceContent`, `buildProfileWorkspaceAdminProfileCacheFields`, and `buildProfileWorkspaceFromLegacy` object:
+
+```ts
+blogDesign: normalizeBlogDesign(content.blogDesign),
+legacyBlogScheme: normalizeLegacyBlogScheme(content.legacyBlogScheme),
+```
+
+```ts
+blogDesign: normalized.blogDesign,
+legacyBlogScheme: normalized.legacyBlogScheme,
+```
+
+```ts
+blogDesign: normalizeBlogDesign(value?.blogDesign),
+legacyBlogScheme: normalizeLegacyBlogScheme(value?.legacyBlogScheme),
+```
+
+- [ ] **Step 4: Extend admin profile/auth types**
+
+In `front/src/hooks/useAdminProfile.ts`, add to `AdminProfile` and `AdminProfileLike`:
+
+```ts
+blogDesign?: BlogDesignType
+legacyBlogScheme?: LegacyBlogScheme
+```
+
+and in `toAdminProfile`:
+
+```ts
+blogDesign: normalizeBlogDesign(value.blogDesign),
+legacyBlogScheme: normalizeLegacyBlogScheme(value.legacyBlogScheme),
+```
+
+In `front/src/hooks/useAuthSession.ts`, add the optional fields to `AuthMember`.
+
+In `front/src/pages/admin/profile.tsx`, extend `MemberMe` and SSR merge with:
+
+```ts
+blogDesign: profile.blogDesign || member.blogDesign || "legacy",
+legacyBlogScheme: profile.legacyBlogScheme || member.legacyBlogScheme || "dark",
+```
+
+In `front/src/libs/server/adminProfile.ts`, import the same normalizers and add fallback/cookie snapshot fields:
+
+```ts
+import { normalizeBlogDesign, normalizeLegacyBlogScheme } from "src/libs/profileWorkspace"
+```
+
+```ts
+blogDesign: "legacy",
+legacyBlogScheme: "dark",
+```
+
+```ts
+blogDesign: normalizeBlogDesign(profile.blogDesign),
+legacyBlogScheme: normalizeLegacyBlogScheme(profile.legacyBlogScheme),
+```
+
+```ts
+blogDesign: normalizeBlogDesign(parsed.blogDesign),
+legacyBlogScheme: normalizeLegacyBlogScheme(parsed.legacyBlogScheme),
+```
+
+- [ ] **Step 5: Add admin design settings UI**
+
+In `front/src/pages/admin/profile.tsx`, extend the section id:
+
+```ts
+type WorkspaceSectionId = "identity" | "about" | "home" | "design" | "links"
+```
+
+Add a section entry after `home`:
+
+```ts
+{
+  id: "design",
+  label: "디자인",
+},
+```
+
+In `pickWorkspaceSectionContent`, add:
+
+```ts
+case "design":
+  return {
+    blogDesign: content.blogDesign,
+    legacyBlogScheme: content.legacyBlogScheme,
+  }
+```
+
+In the section state initial map, add:
+
+```ts
+design: { dirty: false, publishedDiff: false },
+```
+
+In `renderActiveSection`, add:
+
+```tsx
+case "design":
+  return (
+    <SectionStack>
+      <FieldSectionCard>
+        <SectionBlockHeader>
+          <div>
+            <h3>공개 블로그 디자인</h3>
+            <p>방문자에게 보이는 전역 디자인입니다. Grid는 dark presentation으로 고정됩니다.</p>
+          </div>
+        </SectionBlockHeader>
+        <SegmentedControl aria-label="공개 블로그 디자인">
+          <SegmentButton
+            type="button"
+            data-active={draft.blogDesign === "legacy"}
+            onClick={() => updateDraft("blogDesign", "legacy")}
+          >
+            Legacy
+          </SegmentButton>
+          <SegmentButton
+            type="button"
+            data-active={draft.blogDesign === "grid"}
+            onClick={() => updateDraft("blogDesign", "grid")}
+          >
+            Grid
+          </SegmentButton>
+        </SegmentedControl>
+      </FieldSectionCard>
+
+      {draft.blogDesign === "legacy" ? (
+        <FieldSectionCard>
+          <SectionBlockHeader>
+            <div>
+              <h3>Legacy 색상 모드</h3>
+              <p>Legacy 디자인에서만 공개 블로그의 light/dark를 선택합니다.</p>
+            </div>
+          </SectionBlockHeader>
+          <SegmentedControl aria-label="Legacy 색상 모드">
+            <SegmentButton
+              type="button"
+              data-active={draft.legacyBlogScheme === "light"}
+              onClick={() => updateDraft("legacyBlogScheme", "light")}
+            >
+              Light
+            </SegmentButton>
+            <SegmentButton
+              type="button"
+              data-active={draft.legacyBlogScheme === "dark"}
+              onClick={() => updateDraft("legacyBlogScheme", "dark")}
+            >
+              Dark
+            </SegmentButton>
+          </SegmentedControl>
+        </FieldSectionCard>
+      ) : (
+        <FieldSectionCard>
+          <SectionBlockHeader>
+            <div>
+              <h3>Grid 색상 모드</h3>
+              <p>Grid 디자인은 가독성 보호를 위해 dark presentation으로 고정됩니다.</p>
+            </div>
+          </SectionBlockHeader>
+        </FieldSectionCard>
+      )}
+    </SectionStack>
+  )
+```
+
+Extend the preview rail with a design card when `activeSection === "design"`:
+
+```tsx
+{activeSection === "design" ? (
+  <PreviewHomeCard>
+    <span>Design</span>
+    <strong>{previewContent.blogDesign === "grid" ? "Grid" : "Legacy"}</strong>
+    <p>
+      {previewContent.blogDesign === "legacy"
+        ? `Legacy ${previewContent.legacyBlogScheme}`
+        : "Grid dark presentation"}
+    </p>
+  </PreviewHomeCard>
+) : null}
+```
+
+- [ ] **Step 6: Run frontend admin contract test**
+
+Run:
+
+```bash
+yarn --cwd front playwright:preflight
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit frontend settings contract**
+
+```bash
+git add front/src/types/index.ts \
+  front/src/libs/profileWorkspace.ts \
+  front/src/hooks/useAdminProfile.ts \
+  front/src/hooks/useAuthSession.ts \
+  front/src/libs/server/adminProfile.ts \
+  front/src/pages/admin/profile.tsx \
+  front/e2e/admin-profile-state.spec.ts
+git commit -m "feat(profile): global blog design 설정 UI 추가"
+git push
+```
+
+### Task 3: Public Appearance Resolver And Theme
+
+**Files:**
+- Create: `front/src/libs/blogAppearance.ts`
+- Modify: `front/src/styles/theme.ts`
+- Modify: `front/src/layouts/RootLayout/ThemeProvider/index.tsx`
+- Modify: `front/src/layouts/RootLayout/ThemeProvider/Global/index.tsx`
+- Modify: `front/src/layouts/RootLayout/index.tsx`
+- Modify: `front/src/layouts/RootLayout/Header/index.tsx`
+- Modify: `front/src/layouts/RootLayout/Header/ThemeToggle.tsx`
+- Test: `front/e2e/smoke.spec.ts`
+- Test: `front/e2e/mobile-layout.spec.ts`
+
+- [ ] **Step 1: Add failing resolver unit coverage through Playwright source checks**
+
+In `front/e2e/smoke.spec.ts`, add a source contract test:
+
+```ts
+test("public blog appearance는 adminProfile 전역 설정에서 resolve된다", async () => {
+  const resolverSource = readFileSync(path.resolve(__dirname, "../src/libs/blogAppearance.ts"), "utf8")
+  const rootLayoutSource = readFileSync(path.resolve(__dirname, "../src/layouts/RootLayout/index.tsx"), "utf8")
+  const headerSource = readFileSync(path.resolve(__dirname, "../src/layouts/RootLayout/Header/index.tsx"), "utf8")
+
+  expect(resolverSource).toContain('blogDesign === "grid"')
+  expect(resolverSource).toContain('scheme: "dark"')
+  expect(rootLayoutSource).toContain("resolvePublicBlogAppearance")
+  expect(headerSource).toContain("showThemeToggle")
+})
+```
+
+Run:
+
+```bash
+yarn --cwd front playwright:preflight
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts --workers=1
+```
+
+Expected: FAIL because the resolver does not exist.
+
+- [ ] **Step 2: Create the resolver**
+
+Create `front/src/libs/blogAppearance.ts`:
+
+```ts
+import { CONFIG } from "site.config"
+import type { AdminProfile } from "src/hooks/useAdminProfile"
+import type { BlogDesignType, LegacyBlogScheme, SchemeType } from "src/types"
+import { normalizeBlogDesign, normalizeLegacyBlogScheme } from "src/libs/profileWorkspace"
+
+export type PublicBlogAppearance = {
+  blogDesign: BlogDesignType
+  scheme: SchemeType
+  legacyBlogScheme: LegacyBlogScheme
+}
+
+const resolveConfigScheme = (): LegacyBlogScheme =>
+  CONFIG.blog.scheme === "light" ? "light" : "dark"
+
+export const resolvePublicBlogAppearance = (
+  profile: Pick<AdminProfile, "blogDesign" | "legacyBlogScheme"> | null | undefined
+): PublicBlogAppearance => {
+  const blogDesign = normalizeBlogDesign(profile?.blogDesign)
+  const legacyBlogScheme = normalizeLegacyBlogScheme(profile?.legacyBlogScheme || resolveConfigScheme())
+
+  return {
+    blogDesign,
+    legacyBlogScheme,
+    scheme: blogDesign === "grid" ? "dark" : legacyBlogScheme,
+  }
+}
+```
+
+- [ ] **Step 3: Extend theme tokens**
+
+In `front/src/styles/theme.ts`, add:
+
+```ts
+import { BlogDesignType } from "src/types"
+```
+
+Add token types:
+
+```ts
+type PublicDesignTokens = {
+  pageBackgroundColor: string
+  pageBackgroundImage: string
+  surface: string
+  surfaceElevated: string
+  border: string
+  borderStrong: string
+  accent: string
+  accentMuted: string
+  textMuted: string
+  shadow: string
+}
+```
+
+Extend Emotion theme:
+
+```ts
+blogDesign: BlogDesignType
+publicDesign: PublicDesignTokens
+```
+
+Add factory:
+
+```ts
+const createPublicDesignTokens = (scheme: SchemeType, blogDesign: BlogDesignType): PublicDesignTokens => {
+  if (blogDesign === "grid") {
+    return {
+      pageBackgroundColor: "#090806",
+      pageBackgroundImage:
+        "linear-gradient(180deg, rgba(112, 25, 25, 0.14), transparent 18rem), radial-gradient(circle at 82% 0%, rgba(185, 140, 72, 0.12), transparent 24rem)",
+      surface: "rgba(18, 17, 15, 0.94)",
+      surfaceElevated: "rgba(28, 25, 21, 0.96)",
+      border: "rgba(159, 126, 72, 0.26)",
+      borderStrong: "rgba(185, 140, 72, 0.42)",
+      accent: "#9d2f2f",
+      accentMuted: "rgba(157, 47, 47, 0.18)",
+      textMuted: "#c0b7aa",
+      shadow: "0 18px 42px rgba(0, 0, 0, 0.42)",
+    }
+  }
+
+  return {
+    pageBackgroundColor: scheme === "light" ? "#f3f5f8" : colors.dark.gray1,
+    pageBackgroundImage:
+      scheme === "light"
+        ? "radial-gradient(circle at 18% -12%, rgba(37, 99, 235, 0.025), transparent 26%), radial-gradient(circle at 88% 0%, rgba(148, 163, 184, 0.04), transparent 22%)"
+        : "none",
+    surface: colors[scheme].gray1,
+    surfaceElevated: colors[scheme].gray2,
+    border: colors[scheme].gray5,
+    borderStrong: colors[scheme].gray6,
+    accent: colors[scheme].accentControl,
+    accentMuted: colors[scheme].accentSurfaceSubtle,
+    textMuted: colors[scheme].gray10,
+    shadow: variables.ui.card.shadow,
+  }
+}
+```
+
+Update `Options` and `createTheme`:
+
+```ts
+type Options = {
+  scheme: SchemeType
+  blogDesign?: BlogDesignType
+}
+```
+
+```ts
+blogDesign: options.blogDesign ?? "legacy",
+publicDesign: createPublicDesignTokens(options.scheme, options.blogDesign ?? "legacy"),
+```
+
+- [ ] **Step 4: Apply appearance only on public routes**
+
+In `ThemeProvider/index.tsx`, accept `blogDesign` and call `createTheme({ scheme, blogDesign })`.
+
+In `RootLayout/index.tsx`, import `useAdminProfile` and resolver. Add route guard:
+
+```ts
+const isPublicBlogRoute =
+  router.pathname === "/" || router.pathname === "/about" || router.pathname === "/posts/[id]"
+const adminProfile = useAdminProfile()
+const publicAppearance = resolvePublicBlogAppearance(adminProfile)
+const effectiveScheme = isPublicBlogRoute ? publicAppearance.scheme : scheme
+const effectiveBlogDesign = isPublicBlogRoute ? publicAppearance.blogDesign : "legacy"
+```
+
+Pass:
+
+```tsx
+<ThemeProvider scheme={effectiveScheme} blogDesign={effectiveBlogDesign}>
+  <Scripts />
+  <Header fullWidth={false} showThemeToggle={!isPublicBlogRoute} />
+  ...
+</ThemeProvider>
+```
+
+In `Header/index.tsx`, extend props:
+
+```ts
+type Props = {
+  fullWidth: boolean
+  showThemeToggle?: boolean
+}
+```
+
+Render:
+
+```tsx
+{showThemeToggle ? <ThemeToggle /> : null}
+```
+
+- [ ] **Step 5: Move global background to public design tokens**
+
+In `Global/index.tsx`, replace local body background constants with:
+
+```ts
+const bodyBackgroundColor = theme.publicDesign.pageBackgroundColor
+const bodyBackgroundImage = theme.publicDesign.pageBackgroundImage
+```
+
+Keep `* { color-scheme: ${theme.scheme}; }` so grid uses dark color-scheme through the resolver.
+
+- [ ] **Step 6: Run resolver/theme checks**
+
+Run:
+
+```bash
+yarn --cwd front playwright:preflight
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts --workers=1
+yarn --cwd front build
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit resolver/theme**
+
+```bash
+git add front/src/libs/blogAppearance.ts \
+  front/src/styles/theme.ts \
+  front/src/layouts/RootLayout/ThemeProvider/index.tsx \
+  front/src/layouts/RootLayout/ThemeProvider/Global/index.tsx \
+  front/src/layouts/RootLayout/index.tsx \
+  front/src/layouts/RootLayout/Header/index.tsx \
+  front/e2e/smoke.spec.ts
+git commit -m "feat(frontend): public blog appearance resolver 추가"
+git push
+```
+
+### Task 4: Grid Public Surface Styling
+
+**Files:**
+- Modify: `front/src/layouts/RootLayout/Header/index.tsx`
+- Modify: `front/src/layouts/RootLayout/Header/Logo.tsx`
+- Modify: `front/src/routes/Feed/index.tsx`
+- Modify: `front/src/routes/Feed/PostList/PostCard.tsx`
+- Modify: `front/src/routes/Feed/SearchInput.tsx`
+- Modify: `front/src/routes/Feed/TagList.tsx`
+- Modify: `front/src/routes/Feed/ProfileCard.tsx`
+- Modify: `front/src/routes/Feed/ServiceCard.tsx`
+- Modify: `front/src/routes/Feed/ContactCard.tsx`
+- Modify: `front/src/pages/about.tsx`
+- Modify: `front/src/routes/Detail/PostDetail/index.tsx`
+- Modify: `front/src/routes/Detail/PostDetail/PostHeader.tsx`
+- Modify: `front/e2e/mobile-layout.spec.ts`
+- Modify: `front/e2e/perf.spec.ts`
+
+- [ ] **Step 1: Add public styling guard checks**
+
+In `front/e2e/mobile-layout.spec.ts`, add a source contract test:
+
+```ts
+test("grid design은 공개 화면 토큰만 사용하고 article typography를 변경하지 않는다", () => {
+  const detailSource = readFileSync(path.resolve(__dirname, "../src/routes/Detail/PostDetail/index.tsx"), "utf8")
+  const themeSource = readFileSync(path.resolve(__dirname, "../src/styles/theme.ts"), "utf8")
+
+  expect(themeSource).toContain('blogDesign === "grid"')
+  expect(detailSource).toContain("theme.publicDesign")
+  expect(detailSource).not.toContain("font-size: ${({ theme }) => theme.blogDesign")
+  expect(detailSource).not.toContain("line-height: ${({ theme }) => theme.blogDesign")
+})
+```
+
+Run:
+
+```bash
+yarn --cwd front playwright:preflight
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/mobile-layout.spec.ts --workers=1
+```
+
+Expected: FAIL until public surface styling consumes `theme.publicDesign`.
+
+- [ ] **Step 2: Apply grid tokens to header without layout changes**
+
+In `Header/index.tsx`, update `StyledWrapper` background and border:
+
+```ts
+background-color: ${({ theme }) =>
+  theme.blogDesign === "grid"
+    ? "rgba(9, 8, 6, 0.88)"
+    : theme.scheme === "light"
+      ? "rgba(249, 251, 254, 0.94)"
+      : `${theme.colors.gray1}e6`};
+border-bottom: 1px solid ${({ theme }) =>
+  theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+box-shadow: ${({ theme }) =>
+  theme.blogDesign === "grid" ? "0 10px 28px rgba(0, 0, 0, 0.28)" : "none"};
+```
+
+In `Logo.tsx`, keep existing font size and weight. Only adjust color for grid:
+
+```ts
+color: ${({ theme }) => (theme.blogDesign === "grid" ? "#f4ead7" : theme.colors.gray12)};
+```
+
+- [ ] **Step 3: Apply grid tokens to feed surfaces**
+
+In feed cards and rail cards, replace only background/border/shadow/color accents with conditional tokens:
+
+```ts
+border: ${({ theme }) =>
+  `${theme.variables.ui.card.borderWidth}px solid ${
+    theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray4
+  }`};
+background: ${({ theme }) =>
+  theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray1};
+box-shadow: ${({ theme }) =>
+  theme.blogDesign === "grid" ? theme.publicDesign.shadow : "var(--post-card-shadow)"};
+```
+
+For hover border:
+
+```ts
+border-color: ${({ theme }) =>
+  theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray5};
+```
+
+Do not change `font-size`, `line-height`, `letter-spacing`, `max-width`, grid breakpoints, or card dimensions.
+
+- [ ] **Step 4: Apply grid tokens to About and Detail surfaces**
+
+In `front/src/pages/about.tsx` and `front/src/routes/Detail/PostDetail/**`, change only page/container surface colors, borders, shadows, and decorative dividers:
+
+```ts
+background: ${({ theme }) =>
+  theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray1};
+border-color: ${({ theme }) =>
+  theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+```
+
+For links and small accents:
+
+```ts
+color: ${({ theme }) =>
+  theme.blogDesign === "grid" ? "#d8b46a" : theme.colors.accentLink};
+```
+
+Do not modify article typography declarations in markdown renderer, post content body, heading scales, or readable width variables.
+
+- [ ] **Step 5: Run public layout/perf focused checks**
+
+Run:
+
+```bash
+yarn --cwd front playwright:preflight
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/mobile-layout.spec.ts --workers=1
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1
+node front/scripts/check-bundle-size.mjs
+yarn --cwd front build
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit public surface styling**
+
+```bash
+git add front/src/layouts/RootLayout/Header/index.tsx \
+  front/src/layouts/RootLayout/Header/Logo.tsx \
+  front/src/routes/Feed/index.tsx \
+  front/src/routes/Feed/PostList/PostCard.tsx \
+  front/src/routes/Feed/SearchInput.tsx \
+  front/src/routes/Feed/TagList.tsx \
+  front/src/routes/Feed/ProfileCard.tsx \
+  front/src/routes/Feed/ServiceCard.tsx \
+  front/src/routes/Feed/ContactCard.tsx \
+  front/src/pages/about.tsx \
+  front/src/routes/Detail/PostDetail/index.tsx \
+  front/src/routes/Detail/PostDetail/PostHeader.tsx \
+  front/e2e/mobile-layout.spec.ts \
+  front/e2e/perf.spec.ts
+git commit -m "feat(frontend): grid public blog 디자인 적용"
+git push
+```
+
+### Task 5: Contract Docs And Full Verification
+
+**Files:**
+- Modify: `docs/agent/frontend-ui.md`
+- Modify: `docs/agent/auth.md`
+- Modify: `docs/agent/grimdark-blog-skin-plan-2026-05-13.md`
+- Modify: `front/contracts/openapi/openapi.json` if the contract generation flow changes it
+- Create or modify: `.codex/tmp/pr-grimdark-blog-skin.md`
+
+- [ ] **Step 1: Update the local source-of-truth plan and briefs**
+
+In `docs/agent/grimdark-blog-skin-plan-2026-05-13.md`, make sure `commit_plan` exactly matches the commits created in this work:
+
+```md
+1. `docs(frontend): grimdark blog skin 설계 고정`
+2. `docs(frontend): global blog 디자인 설정 계약 갱신`
+3. `docs(frontend): global blog 디자인 구현 계획 추가`
+4. `feat(profile): global blog design 계약 추가`
+5. `feat(profile): global blog design 설정 UI 추가`
+6. `feat(frontend): public blog appearance resolver 추가`
+7. `feat(frontend): grid public blog 디자인 적용`
+8. `docs(frontend): global blog design 운영 계약 반영`
+```
+
+In `docs/agent/frontend-ui.md`, add the public design invariant:
+
+```yaml
+- "공개 블로그 디자인은 published admin profile의 `blogDesign=legacy|grid` 전역 설정을 따른다. 방문자용 디자인 선택 UI는 두지 않는다."
+- "`legacy`만 `legacyBlogScheme=light|dark`를 적용하고, `grid`는 dark presentation으로 고정한다."
+- "grid 디자인은 배경/surface/border/card/header/link accent만 바꾸며 공개 상세 본문 타이포 scale/line-height/readable width/font는 변경하지 않는다."
+```
+
+In `docs/agent/auth.md`, add the member/profile contract invariant:
+
+```yaml
+- "공개 `/member/api/v1/members/adminProfile`과 관리자 profile workspace 응답은 `blogDesign`과 `legacyBlogScheme`을 포함해야 하며, 누락/invalid 값은 legacy/dark로 정규화한다."
+```
+
+- [ ] **Step 2: Run full related verification**
+
+Run in order:
+
+```bash
+./gradlew -p back ktlintCheck
+./gradlew -p back test
+yarn --cwd front build
+node front/scripts/check-bundle-size.mjs
+yarn --cwd front playwright:preflight
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1
+git diff --check
+CURRENT_TASK_SLUG=grimdark-blog-skin bash tools/guards/current-task-preflight.sh
+```
+
+Expected: PASS. On command failure, classify it as code regression or environment/permission before retrying.
+
+- [ ] **Step 3: Commit docs and contract artifacts**
+
+```bash
+git add -f docs/agent/frontend-ui.md docs/agent/auth.md docs/agent/grimdark-blog-skin-plan-2026-05-13.md
+git add front/contracts/openapi/openapi.json
+git commit -m "docs(frontend): global blog design 운영 계약 반영"
+git push
+```
+
+- [ ] **Step 4: Open the PR**
+
+Create `.codex/tmp/pr-grimdark-blog-skin.md` with the repository PR template. The first section must include:
+
+```md
+close #227
+```
+
+Include:
+
+```md
+## Summary
+- 관리자 전역 설정으로 공개 블로그 디자인 `legacy | grid`를 publish한다.
+- `legacy`에서만 light/dark를 적용하고 `grid`는 dark presentation으로 고정한다.
+- 공개 블로그는 visitor-local 선택 UI 없이 published admin profile을 기준으로 렌더한다.
+
+## Verification
+- [ ] ./gradlew -p back ktlintCheck
+- [ ] ./gradlew -p back test
+- [ ] yarn --cwd front build
+- [ ] node front/scripts/check-bundle-size.mjs
+- [ ] yarn --cwd front playwright:preflight
+- [ ] PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1
+- [ ] PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1
+- [ ] PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1
+- [ ] git diff --check
+```
+
+Run:
+
+```bash
+gh pr create --repo AquilaXk/aquila-blog --base main --head feat/grimdark-blog-skin --title "[Feat] Global blog 디자인 설정" --body-file .codex/tmp/pr-grimdark-blog-skin.md --draft
+```
+
+Expected: a draft PR URL targeting `main`.

--- a/docs/superpowers/plans/2026-05-13-global-blog-design-setting.md
+++ b/docs/superpowers/plans/2026-05-13-global-blog-design-setting.md
@@ -21,6 +21,7 @@
 - Modify `back/src/main/kotlin/com/back/boundedContexts/member/application/port/input/MemberUseCase.kt`: add design arguments to the legacy profile-card use case.
 - Modify `back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberUseCaseAdapter.kt`: forward design arguments to the application service.
 - Modify `back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt`: persist design attrs from both legacy and workspace profile flows.
+- Modify `back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberProfileHydrator.kt`: hydrate persisted design attrs for member fallback responses.
 - Modify `back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberControllerTest.kt`: prove draft/save/publish behavior.
 - Modify `back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerWebMvcTest.kt`: prove public `adminProfile` exposes the published setting.
 - Modify `front/src/types/index.ts`: add `BlogDesignType` and `LegacyBlogScheme`.
@@ -35,6 +36,7 @@
 - Modify public surfaces under `front/src/routes/Feed/**`, `front/src/routes/About/**`, and `front/src/routes/Detail/PostDetail/**`: opt into grid tokens without changing article typography.
 - Modify `front/e2e/admin-profile-state.spec.ts`, `front/e2e/smoke.spec.ts`, `front/e2e/mobile-layout.spec.ts`, and `front/e2e/perf.spec.ts`: add structural and public route regression coverage.
 - Modify `front/contracts/openapi/openapi.json` only through the existing contract generation/fetch flow if backend verification updates it.
+- Modify `front/packages/shared-contracts/src/generated/backend-openapi.d.ts` only through `yarn --cwd front contracts:generate` if the OpenAPI snapshot changes.
 - Modify `docs/agent/frontend-ui.md` and `docs/agent/auth.md`: record the new global public design contract.
 
 ### Task 1: Backend Profile Contract
@@ -49,8 +51,11 @@
 - Modify: `back/src/main/kotlin/com/back/boundedContexts/member/application/port/input/MemberUseCase.kt`
 - Modify: `back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberUseCaseAdapter.kt`
 - Modify: `back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt`
+- Modify: `back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberProfileHydrator.kt`
 - Test: `back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberControllerTest.kt`
 - Test: `back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerWebMvcTest.kt`
+- Generated: `front/contracts/openapi/openapi.json`
+- Generated: `front/packages/shared-contracts/src/generated/backend-openapi.d.ts`
 
 - [ ] **Step 1: Add failing backend assertions for the new public profile fields**
 
@@ -121,7 +126,7 @@ mockMvc
 Run:
 
 ```bash
-./gradlew -p back test --tests '*ApiV1MemberControllerWebMvcTest*' --tests '*ApiV1AdmMemberControllerTest*'
+back/gradlew -p back test --tests '*ApiV1MemberControllerWebMvcTest*' --tests '*ApiV1AdmMemberControllerTest*'
 ```
 
 Expected: FAIL with unresolved `blogDesign`/`legacyBlogScheme` properties or missing JSON paths.
@@ -246,25 +251,25 @@ In `ApiV1AdmMemberController.kt`, extend `UpdateProfileCardRequest` and `UpdateP
 
 ```kotlin
 @field:Size(max = 20)
-val blogDesign: String = "",
+val blogDesign: String? = null,
 @field:Size(max = 20)
-val legacyBlogScheme: String = "",
+val legacyBlogScheme: String? = null,
 ```
 
 Pass the fields into `MemberProfileWorkspaceContent` in `toDomain()`:
 
 ```kotlin
-blogDesign = blogDesign.trim(),
-legacyBlogScheme = legacyBlogScheme.trim(),
+blogDesign = blogDesign?.trim() ?: member.blogDesign,
+legacyBlogScheme = legacyBlogScheme?.trim() ?: member.legacyBlogScheme,
 ```
 
 Pass the fields through the legacy profile-card endpoint as well, so older admin flows and workspace fallback snapshots keep the same published contract.
 
-In `ApiV1AdmMemberController.updateProfileCard`, extend the use-case call:
+For the legacy `profileCard` PATCH path, omitted request fields preserve the current member values:
 
 ```kotlin
-blogDesign = reqBody.blogDesign.trim(),
-legacyBlogScheme = reqBody.legacyBlogScheme.trim(),
+blogDesign = reqBody.blogDesign?.trim() ?: member.blogDesign,
+legacyBlogScheme = reqBody.legacyBlogScheme?.trim() ?: member.legacyBlogScheme,
 ```
 
 In `MemberUseCase.kt`, add parameters after `homeIntroDescription`:
@@ -309,13 +314,32 @@ private fun saveLegacyBlogSchemeAttr(member: Member) {
 }
 ```
 
+In `MemberProfileHydrator.kt`, include the new attr names in `profileAttrNames` and initialize them in `hydrateAll`:
+
+```kotlin
+BLOG_DESIGN,
+LEGACY_BLOG_SCHEME,
+```
+
+```kotlin
+member.getOrInitBlogDesignAttr()
+member.getOrInitLegacyBlogSchemeAttr()
+```
+
 - [ ] **Step 5: Run backend targeted tests and style**
 
 Run:
 
 ```bash
-./gradlew -p back test --tests '*ApiV1MemberControllerWebMvcTest*' --tests '*ApiV1AdmMemberControllerTest*'
-./gradlew -p back ktlintCheck
+back/gradlew -p back test --tests '*ApiV1MemberControllerWebMvcTest*' --tests '*ApiV1AdmMemberControllerTest*'
+back/gradlew -p back ktlintCheck
+back/gradlew -p back test --tests 'com.back.global.springDoc.OpenApiContractExportTest' --no-daemon
+cp back/build/openapi/openapi.json front/contracts/openapi/openapi.json
+yarn --cwd front contracts:generate
+(
+  cd front
+  yarn contracts:check
+)
 ```
 
 Expected: PASS.
@@ -332,8 +356,11 @@ git add back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/membe
   back/src/main/kotlin/com/back/boundedContexts/member/application/port/input/MemberUseCase.kt \
   back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberUseCaseAdapter.kt \
   back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt \
+  back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberProfileHydrator.kt \
   back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberControllerTest.kt \
-  back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerWebMvcTest.kt
+  back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerWebMvcTest.kt \
+  front/contracts/openapi/openapi.json \
+  front/packages/shared-contracts/src/generated/backend-openapi.d.ts
 git commit -m "feat(profile): global blog design 계약 추가"
 git push
 ```
@@ -1076,8 +1103,8 @@ In `docs/agent/auth.md`, add the member/profile contract invariant:
 Run in order:
 
 ```bash
-./gradlew -p back ktlintCheck
-./gradlew -p back test
+back/gradlew -p back ktlintCheck
+back/gradlew -p back test
 yarn --cwd front build
 node front/scripts/check-bundle-size.mjs
 yarn --cwd front playwright:preflight
@@ -1116,8 +1143,8 @@ Include:
 - 공개 블로그는 visitor-local 선택 UI 없이 published admin profile을 기준으로 렌더한다.
 
 ## Verification
-- [ ] ./gradlew -p back ktlintCheck
-- [ ] ./gradlew -p back test
+- [ ] back/gradlew -p back ktlintCheck
+- [ ] back/gradlew -p back test
 - [ ] yarn --cwd front build
 - [ ] node front/scripts/check-bundle-size.mjs
 - [ ] yarn --cwd front playwright:preflight

--- a/docs/superpowers/specs/2026-05-13-grimdark-blog-skin-design.md
+++ b/docs/superpowers/specs/2026-05-13-grimdark-blog-skin-design.md
@@ -100,8 +100,8 @@
 - Playwright preflight: `yarn --cwd front playwright:preflight`.
 - Public regression: `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`.
 - Layout/perf regression: `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`.
-- Backend Kotlin style: `./gradlew -p back ktlintCheck`.
-- Backend tests: `./gradlew -p back test`.
+- Backend Kotlin style: `back/gradlew -p back ktlintCheck`.
+- Backend tests: `back/gradlew -p back test`.
 - Diff hygiene: `git diff --check`.
 
 ## Future Extension

--- a/docs/superpowers/specs/2026-05-13-grimdark-blog-skin-design.md
+++ b/docs/superpowers/specs/2026-05-13-grimdark-blog-skin-design.md
@@ -1,0 +1,88 @@
+# Grimdark Blog Skin Design
+
+## Summary
+- Public blog users can switch between the current `classic` skin and a stronger `grimdark` skin.
+- The first release applies only to public surfaces: home, feed, post detail, and About.
+- Admin and editor surfaces stay on the current design language in this scope.
+- Grimdark is an original gothic sci-fi treatment. It must not use official Warhammer 40K logos, faction marks, artwork, copy, or other IP assets.
+
+## Goals
+- Add a blog-skin axis, `classic | grimdark`, separate from the existing `scheme: light | dark` axis.
+- Make the skin choice persistent across reloads.
+- Preserve text readability by leaving public article typography unchanged.
+- Keep the change reversible and testable through theme tokens and public-surface style hooks.
+
+## Non-Goals
+- No admin skinning.
+- No editor skinning.
+- No official Warhammer 40K assets.
+- No dependency or package changes.
+- No article font, font size, line-height, readable width, heading scale, or body copy changes.
+- No unrelated behavior changes in routing, auth, comments, markdown parsing, or data fetching.
+
+## User Experience
+- The header exposes a compact skin selector near the current light/dark theme toggle.
+- `classic` keeps the current visual language.
+- `grimdark` changes the public blog's visual treatment through:
+  - near-black page background with controlled texture or layered gradients,
+  - dark iron surfaces,
+  - muted brass borders,
+  - deep red accent states,
+  - sharper dividers and thin gothic sci-fi ornament lines,
+  - stronger card/header/button atmosphere without changing layout density.
+- The selected skin is stored client-side and restored on reload.
+- If stored data is invalid or unavailable, the site falls back to `classic`.
+
+## Readability Contract
+- Article text remains the primary constraint.
+- The implementation must not change the existing article typography scale, line-height, readable width, or font family.
+- Background and surface contrast must keep body text, inline links, code, blockquote, callout, and table content readable.
+- Decorative texture must stay behind content and must not reduce text contrast.
+- Mobile screens must keep the current information hierarchy and avoid adding fixed layers that crowd the reading area.
+
+## Architecture
+- Add a `SkinType = "classic" | "grimdark"` type.
+- Add a `useSkin` hook parallel to `useScheme`.
+  - Query key: a dedicated `skin` key.
+  - Persistence: cookie-based, matching the existing scheme persistence pattern.
+  - Default: `classic`.
+  - Invalid cookie values are ignored.
+- Extend the Emotion theme with:
+  - `skin: SkinType`,
+  - public-skin token fields for background, surfaces, borders, accents, and optional decorative CSS snippets.
+- Keep `createTheme({ scheme, skin })` as the single theme factory.
+- Keep existing `colors[scheme]` available so current components continue to work.
+- Add skin-specific values as additive tokens instead of replacing every component color ad hoc.
+
+## Public Surface Application
+- `RootLayout` passes both `scheme` and `skin` to `ThemeProvider`.
+- Global styles may apply page-level grimdark background and selection/focus token adjustments.
+- Header can read skin tokens for control, border, and accent styling.
+- Feed cards, tag controls, profile/contact/service cards, and empty/loading states can opt into public skin tokens.
+- Post detail wrapper/header/footer/comment shell can opt into public skin tokens.
+- About page public sections can opt into public skin tokens.
+- Admin and editor routes must not receive page-specific grimdark changes in this first release.
+
+## Selector Behavior
+- The selector is a small, accessible control in the header.
+- It must expose both choices by name and indicate the selected skin.
+- It must not replace the existing light/dark toggle.
+- It must be usable at the header mobile breakpoint without causing nav/auth layout shifts.
+- It persists immediately when changed.
+
+## Error Handling
+- Unknown stored skin values fall back to `classic`.
+- Cookie write failures do not block rendering; the selected state can still update in memory for the current session.
+- SSR and initial client render should prefer stable defaults to avoid hydration layout jumps.
+
+## Testing
+- Build: `yarn --cwd front build`.
+- Bundle guard: `node front/scripts/check-bundle-size.mjs`.
+- Playwright preflight: `yarn --cwd front playwright:preflight`.
+- Public regression: `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`.
+- Layout/perf regression: `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`.
+- Diff hygiene: `git diff --check`.
+
+## Future Extension
+- A later task can extend the same skin tokens to admin and editor surfaces after the public blog proves stable.
+- That later task should decide whether admin/editor use the same skin selector or a separate preference.

--- a/docs/superpowers/specs/2026-05-13-grimdark-blog-skin-design.md
+++ b/docs/superpowers/specs/2026-05-13-grimdark-blog-skin-design.md
@@ -1,19 +1,25 @@
-# Grimdark Blog Skin Design
+# Global Blog Design Setting
 
 ## Summary
-- Public blog users can switch between the current `classic` skin and a stronger `grimdark` skin.
-- The first release applies only to public surfaces: home, feed, post detail, and About.
-- Admin and editor surfaces stay on the current design language in this scope.
-- Grimdark is an original gothic sci-fi treatment. It must not use official Warhammer 40K logos, faction marks, artwork, copy, or other IP assets.
+- The blog admin controls one global public blog design setting: `legacy | grid`.
+- Visitors do not choose the blog design or color mode from the public header.
+- `legacy` keeps the current blog design and is the only design that supports light/dark mode.
+- `grid` is the stronger gothic sci-fi public design. It is fixed to a dark presentation and ignores light/dark mode.
+- The first release applies the selected global design only to public surfaces: home, feed, post detail, and About.
+- Admin and editor work surfaces stay on the current operational design language in this scope, except for the admin controls needed to manage the global public blog setting.
+- The grid design is an original gothic sci-fi treatment. It must not use official Warhammer 40K logos, faction marks, artwork, copy, or other IP assets.
 
 ## Goals
-- Add a blog-skin axis, `classic | grimdark`, separate from the existing `scheme: light | dark` axis.
-- Make the skin choice persistent across reloads.
+- Add a persisted global public blog design axis, `legacy | grid`, to the admin profile publish contract.
+- Add a persisted global legacy color mode that is enabled only when the design is `legacy`.
+- Make the public blog resolve its appearance from the published admin profile, not from a visitor-local skin selector.
 - Preserve text readability by leaving public article typography unchanged.
 - Keep the change reversible and testable through theme tokens and public-surface style hooks.
 
 ## Non-Goals
-- No admin skinning.
+- No visitor-facing skin selector.
+- No visitor-local design persistence.
+- No admin work-surface skinning beyond settings controls.
 - No editor skinning.
 - No official Warhammer 40K assets.
 - No dependency or package changes.
@@ -21,17 +27,21 @@
 - No unrelated behavior changes in routing, auth, comments, markdown parsing, or data fetching.
 
 ## User Experience
-- The header exposes a compact skin selector near the current light/dark theme toggle.
-- `classic` keeps the current visual language.
-- `grimdark` changes the public blog's visual treatment through:
+- The admin profile/settings workflow exposes a public blog design choice:
+  - `legacy`: current public blog design.
+  - `grid`: gothic sci-fi public blog design.
+- The admin can choose light or dark mode only while `legacy` is selected.
+- When `grid` is selected, the color mode control is disabled or hidden and the public blog renders with the grid dark appearance.
+- Public visitors see the selected design directly. They do not see a design selector.
+- Public visitors also do not get a light/dark toggle for `grid`; legacy light/dark behavior follows the admin's global legacy mode.
+- `grid` changes the public blog's visual treatment through:
   - near-black page background with controlled texture or layered gradients,
   - dark iron surfaces,
   - muted brass borders,
   - deep red accent states,
   - sharper dividers and thin gothic sci-fi ornament lines,
   - stronger card/header/button atmosphere without changing layout density.
-- The selected skin is stored client-side and restored on reload.
-- If stored data is invalid or unavailable, the site falls back to `classic`.
+- If the published setting is invalid or unavailable, the site falls back to `legacy` and the existing configured scheme.
 
 ## Readability Contract
 - Article text remains the primary constraint.
@@ -41,48 +51,59 @@
 - Mobile screens must keep the current information hierarchy and avoid adding fixed layers that crowd the reading area.
 
 ## Architecture
-- Add a `SkinType = "classic" | "grimdark"` type.
-- Add a `useSkin` hook parallel to `useScheme`.
-  - Query key: a dedicated `skin` key.
-  - Persistence: cookie-based, matching the existing scheme persistence pattern.
-  - Default: `classic`.
-  - Invalid cookie values are ignored.
+- Add `BlogDesignType = "legacy" | "grid"`.
+- Add `LegacyBlogScheme = "light" | "dark"`.
+- Extend the admin profile publish/workspace contract with:
+  - `blogDesign: BlogDesignType`.
+  - `legacyBlogScheme: LegacyBlogScheme`.
+- Normalize invalid or missing values to:
+  - `blogDesign = "legacy"`.
+  - `legacyBlogScheme = CONFIG.blog.scheme` if it is `light` or `dark`, otherwise `dark`.
+- Add a front-end appearance resolver:
+  - Input: published `AdminProfile` plus config fallback.
+  - Output: effective design and effective scheme.
+  - Rule: `grid` always resolves to `scheme = "dark"`.
+  - Rule: `legacy` resolves to the global `legacyBlogScheme`.
 - Extend the Emotion theme with:
-  - `skin: SkinType`,
-  - public-skin token fields for background, surfaces, borders, accents, and optional decorative CSS snippets.
-- Keep `createTheme({ scheme, skin })` as the single theme factory.
+  - `blogDesign: BlogDesignType`,
+  - public-design token fields for background, surfaces, borders, accents, and optional decorative CSS snippets.
+- Keep `createTheme({ scheme, blogDesign })` as the single theme factory.
 - Keep existing `colors[scheme]` available so current components continue to work.
-- Add skin-specific values as additive tokens instead of replacing every component color ad hoc.
+- Add design-specific values as additive tokens instead of replacing every component color ad hoc.
 
 ## Public Surface Application
-- `RootLayout` passes both `scheme` and `skin` to `ThemeProvider`.
-- Global styles may apply page-level grimdark background and selection/focus token adjustments.
-- Header can read skin tokens for control, border, and accent styling.
-- Feed cards, tag controls, profile/contact/service cards, and empty/loading states can opt into public skin tokens.
-- Post detail wrapper/header/footer/comment shell can opt into public skin tokens.
-- About page public sections can opt into public skin tokens.
-- Admin and editor routes must not receive page-specific grimdark changes in this first release.
+- `RootLayout` passes both effective `scheme` and `blogDesign` to `ThemeProvider`.
+- Global styles may apply page-level grid background and selection/focus token adjustments.
+- Header can read public design tokens for control, border, and accent styling, but it must not expose a public design selector.
+- Feed cards, tag controls, profile/contact/service cards, and empty/loading states can opt into public design tokens.
+- Post detail wrapper/header/footer/comment shell can opt into public design tokens.
+- About page public sections can opt into public design tokens.
+- Admin and editor routes must not receive page-specific grid styling in this first release.
 
-## Selector Behavior
-- The selector is a small, accessible control in the header.
-- It must expose both choices by name and indicate the selected skin.
-- It must not replace the existing light/dark toggle.
-- It must be usable at the header mobile breakpoint without causing nav/auth layout shifts.
-- It persists immediately when changed.
+## Admin Setting Behavior
+- The admin profile/settings screen owns the public blog design controls.
+- `legacy | grid` is a global setting published with the admin profile.
+- The light/dark mode control is available only for `legacy`.
+- When the admin switches to `grid`, any saved legacy light/dark value is retained for future return to `legacy`, but it does not affect the public grid render.
+- The public profile preview should show the effective public design choice so the admin can verify the global setting before publishing.
 
 ## Error Handling
-- Unknown stored skin values fall back to `classic`.
-- Cookie write failures do not block rendering; the selected state can still update in memory for the current session.
+- Unknown stored or API-provided design values fall back to `legacy`.
+- Unknown legacy scheme values fall back to the configured legacy scheme or `dark`.
+- If backend profile fields are absent during a rolling deploy, the frontend uses the same fallbacks and keeps rendering.
 - SSR and initial client render should prefer stable defaults to avoid hydration layout jumps.
 
 ## Testing
+- Backend member/profile tests must cover persistence, workspace draft/publish, and public `/member/api/v1/members/adminProfile` response fields.
 - Build: `yarn --cwd front build`.
 - Bundle guard: `node front/scripts/check-bundle-size.mjs`.
 - Playwright preflight: `yarn --cwd front playwright:preflight`.
 - Public regression: `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`.
 - Layout/perf regression: `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`.
+- Backend Kotlin style: `./gradlew -p back ktlintCheck`.
+- Backend tests: `./gradlew -p back test`.
 - Diff hygiene: `git diff --check`.
 
 ## Future Extension
-- A later task can extend the same skin tokens to admin and editor surfaces after the public blog proves stable.
-- That later task should decide whether admin/editor use the same skin selector or a separate preference.
+- A later task can extend the same design tokens to admin and editor surfaces after the public blog proves stable.
+- That later task should decide whether admin/editor use the same global public setting, a separate work-surface preference, or no alternate design.

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -2671,6 +2671,16 @@
             "maxLength" : 500,
             "minLength" : 0
           },
+          "blogDesign" : {
+            "type" : "string",
+            "maxLength" : 20,
+            "minLength" : 0
+          },
+          "legacyBlogScheme" : {
+            "type" : "string",
+            "maxLength" : 20,
+            "minLength" : 0
+          },
           "serviceLinks" : {
             "type" : "array",
             "items" : {
@@ -2789,6 +2799,12 @@
             "type" : "string"
           },
           "homeIntroDescription" : {
+            "type" : "string"
+          },
+          "blogDesign" : {
+            "type" : "string"
+          },
+          "legacyBlogScheme" : {
             "type" : "string"
           },
           "serviceLinks" : {
@@ -3668,6 +3684,12 @@
           "homeIntroDescription" : {
             "type" : "string"
           },
+          "blogDesign" : {
+            "type" : "string"
+          },
+          "legacyBlogScheme" : {
+            "type" : "string"
+          },
           "serviceLinks" : {
             "type" : "array",
             "items" : {
@@ -3737,6 +3759,16 @@
           "homeIntroDescription" : {
             "type" : "string",
             "maxLength" : 500,
+            "minLength" : 0
+          },
+          "blogDesign" : {
+            "type" : "string",
+            "maxLength" : 20,
+            "minLength" : 0
+          },
+          "legacyBlogScheme" : {
+            "type" : "string",
+            "maxLength" : 20,
             "minLength" : 0
           },
           "serviceLinks" : {

--- a/front/e2e/admin-profile-state.spec.ts
+++ b/front/e2e/admin-profile-state.spec.ts
@@ -103,6 +103,8 @@ test.describe("admin profile state contract", () => {
       blogTitle: "AquilaLog",
       homeIntroTitle: "비밀스러운 IT 공작소",
       homeIntroDescription: "비밀스러운 지식들을 탐구하는데 목적을 두고 있습니다",
+      blogDesign: "grid",
+      legacyBlogScheme: "light",
       serviceLinks: [],
       contactLinks: [],
     })
@@ -113,8 +115,44 @@ test.describe("admin profile state contract", () => {
     expect(bridge.aboutSections.map((section) => section.title)).toEqual(["경력"])
     expect(bridge.aboutProjectSectionTitle).toBe("프로젝트")
     expect(bridge.aboutProjects.map((project) => project.name)).toEqual(["aquila-blog"])
+    expect(bridge.blogDesign).toBe("grid")
+    expect(bridge.legacyBlogScheme).toBe("light")
     expect(bridge.aboutDetails).toContain("## 경력")
     expect(bridge.aboutDetails).toContain("- 2026.03 Aquila Blog 운영")
+  })
+
+  test("profile workspace 정규화는 전역 블로그 디자인 fallback을 고정한다", () => {
+    const normalized = normalizeProfileWorkspaceContent({
+      profileImageUrl: "",
+      profileRole: "",
+      profileBio: "",
+      aboutHeadline: "",
+      aboutRole: "",
+      aboutBio: "",
+      aboutSections: [],
+      aboutProjectSectionTitle: "",
+      aboutProjects: [],
+      blogTitle: "",
+      homeIntroTitle: "",
+      homeIntroDescription: "",
+      blogDesign: "unknown" as never,
+      legacyBlogScheme: "blue" as never,
+      serviceLinks: [],
+      contactLinks: [],
+    })
+
+    expect(normalized.blogDesign).toBe("legacy")
+    expect(normalized.legacyBlogScheme).toBe("dark")
+  })
+
+  test("profile 화면은 전역 블로그 디자인 설정과 legacy 전용 scheme control을 가진다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/profile.tsx"), "utf8")
+
+    expect(source).toContain('id: "design"')
+    expect(source).toContain('label: "디자인"')
+    expect(source).toContain('updateDraft("blogDesign",')
+    expect(source).toContain('updateDraft("legacyBlogScheme",')
+    expect(source).toContain('draft.blogDesign === "legacy"')
   })
 
   test("profile workspace 정규화는 structured 프로젝트가 있으면 legacy 프로젝트 상세 블록을 제거한다", () => {
@@ -153,6 +191,8 @@ test.describe("admin profile state contract", () => {
       blogTitle: "",
       homeIntroTitle: "",
       homeIntroDescription: "",
+      blogDesign: "legacy",
+      legacyBlogScheme: "dark",
       serviceLinks: [],
       contactLinks: [],
     })

--- a/front/e2e/mobile-layout.spec.ts
+++ b/front/e2e/mobile-layout.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
 import { expect, test, type Page } from "@playwright/test"
 
 const MOBILE_VIEWPORT = { width: 393, height: 852 }
@@ -9,6 +11,39 @@ test.use({
   viewport: MOBILE_VIEWPORT,
   isMobile: true,
   hasTouch: true,
+})
+
+const readSourceFile = (sourcePath: string) => readFileSync(path.resolve(__dirname, "..", sourcePath), "utf8")
+
+test("grid design은 공개 화면 토큰만 사용하고 article typography를 변경하지 않는다", () => {
+  const publicSurfaceSources = [
+    "src/layouts/RootLayout/Header/index.tsx",
+    "src/layouts/RootLayout/Header/Logo.tsx",
+    "src/routes/Feed/index.tsx",
+    "src/routes/Feed/PostList/PostCard.tsx",
+    "src/routes/Feed/SearchInput.tsx",
+    "src/routes/Feed/TagList.tsx",
+    "src/routes/Feed/ProfileCard.tsx",
+    "src/routes/Feed/ServiceCard.tsx",
+    "src/routes/Feed/ContactCard.tsx",
+    "src/pages/about.tsx",
+    "src/routes/Detail/PostDetail/index.tsx",
+    "src/routes/Detail/PostDetail/PostHeader.tsx",
+  ].map((sourcePath) => [sourcePath, readSourceFile(sourcePath)] as const)
+  const themeSource = readSourceFile("src/styles/theme.ts")
+  const articleSurfaceSource = [
+    readSourceFile("src/routes/Detail/PostDetail/index.tsx"),
+    readSourceFile("src/routes/Detail/PostDetail/PostHeader.tsx"),
+  ].join("\n")
+
+  expect(themeSource).toContain('blogDesign === "grid"')
+  for (const [sourcePath, source] of publicSurfaceSources) {
+    expect(source, sourcePath).toContain("theme.publicDesign")
+  }
+  expect(articleSurfaceSource).not.toContain("font-size: ${({ theme }) =>")
+  expect(articleSurfaceSource).not.toContain("line-height: ${({ theme }) =>")
+  expect(articleSurfaceSource).not.toContain("font-family: ${({ theme }) =>")
+  expect(articleSurfaceSource).not.toContain("max-width: ${({ theme }) => theme.blogDesign")
 })
 
 const mockAvatarAsset = async (page: Page) => {

--- a/front/e2e/perf.spec.ts
+++ b/front/e2e/perf.spec.ts
@@ -142,6 +142,7 @@ const mockFeedEndpoints = async (
   options?: {
     feedHandler?: (route: Route) => Promise<void>
     exploreHandler?: (route: Route) => Promise<void>
+    adminProfile?: Record<string, unknown>
   }
 ) => {
   const pixelPng = Buffer.from(
@@ -264,8 +265,11 @@ const mockFeedEndpoints = async (
         profileImageDirectUrl: "/avatar.png",
         profileRole: "Backend Developer",
         profileBio: "Hello World!",
+        blogDesign: "legacy",
+        legacyBlogScheme: "dark",
         serviceLinks: [],
         contactLinks: [],
+        ...options?.adminProfile,
       }),
     })
   })
@@ -1552,30 +1556,68 @@ test("핵심 화면 레이아웃 스냅샷(desktop/iPhone15/iPad mini)을 유지
   }
 })
 
-test("public 핵심 화면은 dark/light 테마 서피스 계층을 유지한다", async ({ page }) => {
+test("public 핵심 화면은 adminProfile grid 서피스 계층을 유지하고 운영 화면은 visitor scheme을 유지한다", async ({ page }) => {
   test.setTimeout(60_000)
-  await mockFeedEndpoints(page)
+  await mockFeedEndpoints(page, {
+    adminProfile: {
+      blogDesign: "grid",
+      legacyBlogScheme: "light",
+    },
+  })
   await mockDetailRailEndpoint(page, 991)
 
-  const scenarios = [
+  const publicScenarios = [
     { route: "/", viewport: { width: 1440, height: 900 } },
     { route: "/", viewport: { width: 393, height: 852 } },
     { route: "/", viewport: { width: 768, height: 1024 } },
     { route: "/posts/991", viewport: { width: 1440, height: 900 } },
     { route: "/posts/991", viewport: { width: 393, height: 852 } },
     { route: "/posts/991", viewport: { width: 768, height: 1024 } },
+  ] as const
+  const operationalScenarios = [
     { route: "/login", viewport: { width: 1440, height: 900 } },
     { route: "/login", viewport: { width: 393, height: 852 } },
     { route: "/login", viewport: { width: 768, height: 1024 } },
   ] as const
 
+  for (const scenario of publicScenarios) {
+    await applySchemePreference(page, "light")
+    await page.setViewportSize(scenario.viewport)
+    await gotoForPerf(page, scenario.route, {
+      readyText: scenario.route === "/posts/991" ? "상세 레일 스티키 회귀 점검" : undefined,
+    })
+    await expect
+      .poll(async () => (await getThemeSurfaceFingerprint(page)).bodyBg, {
+        timeout: 8000,
+      })
+      .toBe("rgb(9, 9, 9)")
+
+    const fingerprint = await getThemeSurfaceFingerprint(page)
+
+    expect(fingerprint.route).toBe(scenario.route)
+    expect(fingerprint.themeToggleLabel).toBeNull()
+    expect(fingerprint.bodyBg).toBe("rgb(9, 9, 9)")
+    expect(fingerprint.headerBg).not.toBeNull()
+    expect(fingerprint.headerBg).not.toBe(fingerprint.bodyBg)
+
+    if (scenario.route === "/") {
+      expect(fingerprint.searchBg).toBe("rgb(17, 17, 17)")
+      expect(fingerprint.searchBorder).toBe("rgba(151, 125, 85, 0.28)")
+      expect(fingerprint.cardBg).toBe("rgb(17, 17, 17)")
+      expect(fingerprint.cardBorder).toBe("rgba(151, 125, 85, 0.28)")
+    }
+
+    if (scenario.route === "/posts/991") {
+      expect(fingerprint.summaryBg).toBeNull()
+      expect(fingerprint.summaryBorder).toBeNull()
+    }
+  }
+
   for (const scheme of ["dark", "light"] as const) {
-    for (const scenario of scenarios) {
+    for (const scenario of operationalScenarios) {
       await applySchemePreference(page, scheme)
       await page.setViewportSize(scenario.viewport)
-      await gotoForPerf(page, scenario.route, {
-        readyText: scenario.route === "/posts/991" ? "상세 레일 스티키 회귀 점검" : undefined,
-      })
+      await gotoForPerf(page, scenario.route)
       await waitForSchemeReady(page, scheme)
       await page.waitForTimeout(120)
 
@@ -1614,23 +1656,8 @@ test("public 핵심 화면은 dark/light 테마 서피스 계층을 유지한다
         expect(fingerprint.headerBg?.includes(expected.headerBgChannel)).toBe(true)
       }
       expect(fingerprint.themeToggleLabel).toBe(expected.toggleLabel)
-
-      if (scenario.route === "/") {
-        expect(fingerprint.searchBg).toBe(expected.searchBg)
-        expect(fingerprint.searchBorder).toBe(expected.searchBorder)
-        expect(fingerprint.cardBg).toBe(expected.cardBg)
-        expect(fingerprint.cardBorder).toBe(expected.cardBorder)
-      }
-
-      if (scenario.route === "/posts/991") {
-        expect(fingerprint.summaryBg).toBeNull()
-        expect(fingerprint.summaryBorder).toBeNull()
-      }
-
-      if (scenario.route === "/login") {
-        expect(fingerprint.authShellBg).toBe(expected.authShellBg)
-        expect(fingerprint.authShellBorder).toBe(expected.authShellBorder)
-      }
+      expect(fingerprint.authShellBg).toBe(expected.authShellBg)
+      expect(fingerprint.authShellBorder).toBe(expected.authShellBorder)
     }
   }
 })

--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -1,4 +1,7 @@
 import { expect, test, type Page } from "@playwright/test"
+import { readFileSync } from "fs"
+import path from "path"
+import { resolveStaticAdminProfileSeed } from "../src/libs/server/postDetailPage"
 
 const AVATAR_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlH0WkAAAAASUVORK5CYII="
@@ -165,6 +168,61 @@ const mockFeedEndpoints = async (page: Page) => {
 
 test.beforeEach(async ({ page }) => {
   await mockAvatarAsset(page)
+})
+
+test("public blog appearance는 adminProfile 전역 설정에서 resolve된다", async () => {
+  const resolverSource = readFileSync(path.resolve(__dirname, "../src/libs/blogAppearance.ts"), "utf8")
+  const rootLayoutSource = readFileSync(path.resolve(__dirname, "../src/layouts/RootLayout/index.tsx"), "utf8")
+  const headerSource = readFileSync(path.resolve(__dirname, "../src/layouts/RootLayout/Header/index.tsx"), "utf8")
+  const logoSource = readFileSync(path.resolve(__dirname, "../src/layouts/RootLayout/Header/Logo.tsx"), "utf8")
+  const adminShellSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminShell.tsx"), "utf8")
+  const appSource = readFileSync(path.resolve(__dirname, "../src/pages/_app.tsx"), "utf8")
+  const postDetailPageSource = readFileSync(path.resolve(__dirname, "../src/libs/server/postDetailPage.ts"), "utf8")
+  const useAdminProfileSource = readFileSync(path.resolve(__dirname, "../src/hooks/useAdminProfile.ts"), "utf8")
+
+  expect(resolverSource).toContain('blogDesign === "grid"')
+  expect(resolverSource).toContain('scheme: "dark"')
+  expect(resolverSource).not.toContain("src/libs/profileWorkspace")
+  expect(rootLayoutSource).toContain("resolvePublicBlogAppearance")
+  expect(rootLayoutSource).toContain("usePublicAdminProfile(initialAdminProfile")
+  expect(headerSource).toContain("showThemeToggle")
+  expect(logoSource).not.toContain("useAdminProfile")
+  expect(logoSource).toContain("blogTitle")
+  expect(adminShellSource).not.toContain("useAdminProfile")
+  expect(appSource).toContain("initialAdminProfile={initialAdminProfile}")
+  expect(postDetailPageSource).toContain("queryKey.adminProfile()")
+  expect(postDetailPageSource).toContain("initialAdminProfile")
+  expect(postDetailPageSource).toContain('initialAdminProfileSource === "static-fallback"')
+  expect(appSource).toContain("initialAdminProfileShouldRefetch")
+  expect(rootLayoutSource).toContain("refetchOnMount: initialAdminProfileShouldRefetch")
+  expect(rootLayoutSource).toContain("staleTimeMs: initialAdminProfileShouldRefetch ? 0 : undefined")
+  expect(useAdminProfileSource).toContain("enabled?: boolean")
+  expect(useAdminProfileSource).toContain("refetchOnMount?: boolean")
+  expect(useAdminProfileSource).toContain("staleTimeMs?: number")
+})
+
+test("post detail adminProfile seed는 published와 fallback source를 구분한다", async () => {
+  const publishedProfile = {
+    username: "aquila",
+    name: "aquila",
+    nickname: "aquila",
+    profileImageUrl: "/avatar.png",
+    blogDesign: "grid" as const,
+    legacyBlogScheme: "light" as const,
+  }
+
+  await expect(resolveStaticAdminProfileSeed(async () => publishedProfile)).resolves.toMatchObject({
+    profile: { blogDesign: "grid", legacyBlogScheme: "light" },
+    source: "published",
+  })
+  await expect(
+    resolveStaticAdminProfileSeed(async () => {
+      throw new Error("admin profile unavailable")
+    })
+  ).resolves.toMatchObject({
+    profile: { blogDesign: "legacy", legacyBlogScheme: "dark" },
+    source: "static-fallback",
+  })
 })
 
 test("홈 피드 기본 UI가 렌더링된다", async ({ page }) => {

--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -177,6 +177,8 @@ test("public blog appearance는 adminProfile 전역 설정에서 resolve된다",
   const logoSource = readFileSync(path.resolve(__dirname, "../src/layouts/RootLayout/Header/Logo.tsx"), "utf8")
   const adminShellSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminShell.tsx"), "utf8")
   const appSource = readFileSync(path.resolve(__dirname, "../src/pages/_app.tsx"), "utf8")
+  const homePageSource = readFileSync(path.resolve(__dirname, "../src/pages/index.tsx"), "utf8")
+  const aboutPageSource = readFileSync(path.resolve(__dirname, "../src/pages/about.tsx"), "utf8")
   const postDetailPageSource = readFileSync(path.resolve(__dirname, "../src/libs/server/postDetailPage.ts"), "utf8")
   const useAdminProfileSource = readFileSync(path.resolve(__dirname, "../src/hooks/useAdminProfile.ts"), "utf8")
 
@@ -190,6 +192,9 @@ test("public blog appearance는 adminProfile 전역 설정에서 resolve된다",
   expect(logoSource).toContain("blogTitle")
   expect(adminShellSource).not.toContain("useAdminProfile")
   expect(appSource).toContain("initialAdminProfile={initialAdminProfile}")
+  expect(homePageSource).toContain("resolveStaticAdminProfileSeed")
+  expect(homePageSource).toContain("initialAdminProfileSource")
+  expect(aboutPageSource).toContain("initialAdminProfileSource")
   expect(postDetailPageSource).toContain("queryKey.adminProfile()")
   expect(postDetailPageSource).toContain("initialAdminProfile")
   expect(postDetailPageSource).toContain('initialAdminProfileSource === "static-fallback"')

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -1243,6 +1243,8 @@ export interface components {
             blogTitle?: string;
             homeIntroTitle?: string;
             homeIntroDescription?: string;
+            blogDesign?: string;
+            legacyBlogScheme?: string;
             serviceLinks?: components["schemas"]["ProfileCardLinkItemRequest"][];
             contactLinks?: components["schemas"]["ProfileCardLinkItemRequest"][];
         };
@@ -1278,6 +1280,8 @@ export interface components {
             blogTitle?: string;
             homeIntroTitle?: string;
             homeIntroDescription?: string;
+            blogDesign?: string;
+            legacyBlogScheme?: string;
             serviceLinks?: components["schemas"]["MemberProfileLinkItemDto"][];
             contactLinks?: components["schemas"]["MemberProfileLinkItemDto"][];
         };
@@ -1593,6 +1597,8 @@ export interface components {
             blogTitle?: string;
             homeIntroTitle?: string;
             homeIntroDescription?: string;
+            blogDesign?: string;
+            legacyBlogScheme?: string;
             serviceLinks?: components["schemas"]["MemberProfileLinkItemDto"][];
             contactLinks?: components["schemas"]["MemberProfileLinkItemDto"][];
             admin?: boolean;
@@ -1609,6 +1615,8 @@ export interface components {
             blogTitle?: string;
             homeIntroTitle?: string;
             homeIntroDescription?: string;
+            blogDesign?: string;
+            legacyBlogScheme?: string;
             serviceLinks?: components["schemas"]["ProfileCardLinkItemRequest"][];
             contactLinks?: components["schemas"]["ProfileCardLinkItemRequest"][];
         };

--- a/front/src/hooks/useAdminProfile.ts
+++ b/front/src/hooks/useAdminProfile.ts
@@ -3,7 +3,9 @@ import { QueryClient, useQuery, useQueryClient } from "@tanstack/react-query"
 import { apiFetch } from "src/apis/backend/client"
 import type { ProfileCardLinkItem } from "src/constants/profileCardLinks"
 import { queryKey } from "src/constants/queryKey"
+import { normalizeBlogDesign, normalizeLegacyBlogScheme } from "src/libs/profileWorkspace"
 import type { AboutProjectBlock, AboutSectionBlock } from "src/libs/profileWorkspace"
+import type { BlogDesignType, LegacyBlogScheme } from "src/types"
 
 const ADMIN_PROFILE_SNAPSHOT_COOKIE = "admin_profile_snapshot_v1"
 const ADMIN_PROFILE_SNAPSHOT_MAX_AGE_SECONDS = 60 * 30
@@ -27,6 +29,8 @@ export type AdminProfile = {
   blogTitle?: string
   homeIntroTitle?: string
   homeIntroDescription?: string
+  blogDesign?: BlogDesignType
+  legacyBlogScheme?: LegacyBlogScheme
   serviceLinks?: ProfileCardLinkItem[]
   contactLinks?: ProfileCardLinkItem[]
 }
@@ -50,6 +54,8 @@ type AdminProfileLike = {
   blogTitle?: string
   homeIntroTitle?: string
   homeIntroDescription?: string
+  blogDesign?: BlogDesignType
+  legacyBlogScheme?: LegacyBlogScheme
   serviceLinks?: ProfileCardLinkItem[]
   contactLinks?: ProfileCardLinkItem[]
 }
@@ -73,6 +79,8 @@ export const toAdminProfile = (value: AdminProfileLike): AdminProfile => ({
   blogTitle: value.blogTitle,
   homeIntroTitle: value.homeIntroTitle,
   homeIntroDescription: value.homeIntroDescription,
+  blogDesign: normalizeBlogDesign(value.blogDesign),
+  legacyBlogScheme: normalizeLegacyBlogScheme(value.legacyBlogScheme),
   serviceLinks: value.serviceLinks || [],
   contactLinks: value.contactLinks || [],
 })

--- a/front/src/hooks/useAdminProfile.ts
+++ b/front/src/hooks/useAdminProfile.ts
@@ -60,6 +60,12 @@ type AdminProfileLike = {
   contactLinks?: ProfileCardLinkItem[]
 }
 
+type UseAdminProfileOptions = {
+  enabled?: boolean
+  refetchOnMount?: boolean
+  staleTimeMs?: number
+}
+
 export const toAdminProfile = (value: AdminProfileLike): AdminProfile => ({
   username: value.username,
   name: value.name || value.nickname || value.username,
@@ -98,8 +104,9 @@ const persistAdminProfileSnapshotCookie = (profile: AdminProfile) => {
   })
 }
 
-export const useAdminProfile = (initialProfile: AdminProfile | null = null) => {
+export const useAdminProfile = (initialProfile: AdminProfile | null = null, options: UseAdminProfileOptions = {}) => {
   const isBrowser = typeof window !== "undefined"
+  const canFetch = options.enabled ?? true
   const queryClient = useQueryClient()
   const cacheKey = queryKey.adminProfile()
   const cachedProfile = queryClient.getQueryData<AdminProfile | null>(cacheKey)
@@ -120,12 +127,12 @@ export const useAdminProfile = (initialProfile: AdminProfile | null = null) => {
         return initialProfile ?? null
       }
     },
-    enabled: isBrowser,
+    enabled: isBrowser && canFetch,
     initialData: seededProfile ?? undefined,
-    staleTime: hasSeedProfile ? 5 * 60 * 1000 : 0,
+    staleTime: options.staleTimeMs ?? (hasSeedProfile ? 5 * 60 * 1000 : 0),
     retry: false,
     refetchOnWindowFocus: false,
-    refetchOnMount: !hasSeedProfile,
+    refetchOnMount: canFetch && (options.refetchOnMount ?? !hasSeedProfile),
   })
 
   return query.data ?? initialProfile

--- a/front/src/hooks/useAuthSession.ts
+++ b/front/src/hooks/useAuthSession.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react"
 import { ApiError, apiFetch } from "src/apis/backend/client"
 import { queryKey } from "src/constants/queryKey"
 import type { ProfileCardLinkItem } from "src/constants/profileCardLinks"
+import type { BlogDesignType, LegacyBlogScheme } from "src/types"
 
 const AUTH_ME_ANON_SUPPRESS_UNTIL_KEY = "auth:me:anon-probe-suppress-until:v1"
 const AUTH_ME_ANON_SUPPRESS_TTL_MS = 5 * 60_000
@@ -49,6 +50,8 @@ export type AuthMember = {
   blogTitle?: string
   homeIntroTitle?: string
   homeIntroDescription?: string
+  blogDesign?: BlogDesignType
+  legacyBlogScheme?: LegacyBlogScheme
   serviceLinks?: ProfileCardLinkItem[]
   contactLinks?: ProfileCardLinkItem[]
 }

--- a/front/src/layouts/RootLayout/Header/Logo.tsx
+++ b/front/src/layouts/RootLayout/Header/Logo.tsx
@@ -27,7 +27,7 @@ const StyledWrapper = styled(Link)`
   min-width: 0;
   max-width: 100%;
   min-height: 40px;
-  color: ${({ theme }) => theme.colors.gray12};
+  color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray12)};
   font-weight: 760;
   font-size: clamp(1.42rem, 1.12rem + 0.8vw, 1.9rem);
   letter-spacing: -0.03em;

--- a/front/src/layouts/RootLayout/Header/Logo.tsx
+++ b/front/src/layouts/RootLayout/Header/Logo.tsx
@@ -2,11 +2,13 @@ import Link from "next/link"
 import { CONFIG } from "site.config"
 import styled from "@emotion/styled"
 import BrandMark from "src/components/branding/BrandMark"
-import { useAdminProfile } from "src/hooks/useAdminProfile"
 
-const Logo = () => {
-  const adminProfile = useAdminProfile()
-  const blogTitle = adminProfile?.blogTitle?.trim() || CONFIG.blog.title
+type Props = {
+  blogTitle?: string
+}
+
+const Logo = ({ blogTitle: blogTitleProp }: Props) => {
+  const blogTitle = blogTitleProp?.trim() || CONFIG.blog.title
 
   return (
     <StyledWrapper href="/" aria-label={blogTitle}>

--- a/front/src/layouts/RootLayout/Header/index.tsx
+++ b/front/src/layouts/RootLayout/Header/index.tsx
@@ -177,8 +177,13 @@ const StyledWrapper = styled.div`
   position: sticky;
   top: 0;
   background-color: ${({ theme }) =>
-    theme.scheme === "light" ? "rgba(249, 251, 254, 0.94)" : `${theme.colors.gray1}e6`};
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+    theme.blogDesign === "grid"
+      ? `color-mix(in srgb, ${theme.publicDesign.pageBackgroundColor} 88%, transparent)`
+      : theme.scheme === "light"
+        ? "rgba(249, 251, 254, 0.94)"
+        : `${theme.colors.gray1}e6`};
+  border-bottom: 1px solid ${({ theme }) =>
+    theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   transform: translateY(0);

--- a/front/src/layouts/RootLayout/Header/index.tsx
+++ b/front/src/layouts/RootLayout/Header/index.tsx
@@ -17,9 +17,11 @@ import {
 
 type Props = {
   fullWidth: boolean
+  showThemeToggle?: boolean
+  blogTitle?: string
 }
 
-const Header: React.FC<Props> = ({ fullWidth }) => {
+const Header: React.FC<Props> = ({ fullWidth, showThemeToggle = true, blogTitle }) => {
   const router = useRouter()
   const isPostDetailRoute = router.pathname === "/posts/[id]"
   const [isHiddenByScroll, setIsHiddenByScroll] = useState(false)
@@ -158,9 +160,9 @@ const Header: React.FC<Props> = ({ fullWidth }) => {
       }
     >
       <div data-full-width={fullWidth} className="container">
-        <Logo />
+        <Logo blogTitle={blogTitle} />
         <div className="nav">
-          <ThemeToggle />
+          {showThemeToggle ? <ThemeToggle /> : null}
           <NavBar />
         </div>
       </div>

--- a/front/src/layouts/RootLayout/ThemeProvider/Global/index.tsx
+++ b/front/src/layouts/RootLayout/ThemeProvider/Global/index.tsx
@@ -1,15 +1,11 @@
 import { Global as _Global, css, useTheme } from "@emotion/react"
 
-import { ThemeProvider as _ThemeProvider } from "@emotion/react"
 import { pretendard } from "src/assets"
 
 export const Global = () => {
   const theme = useTheme()
-  const bodyBackgroundColor = theme.scheme === "light" ? "#f3f5f8" : theme.colors.gray1
-  const bodyBackgroundImage =
-    theme.scheme === "light"
-      ? "radial-gradient(circle at 18% -12%, rgba(37, 99, 235, 0.025), transparent 26%), radial-gradient(circle at 88% 0%, rgba(148, 163, 184, 0.04), transparent 22%)"
-      : "none"
+  const bodyBackgroundColor = theme.publicDesign.pageBackgroundColor
+  const bodyBackgroundImage = theme.publicDesign.pageBackgroundImage
 
   return (
     <_Global

--- a/front/src/layouts/RootLayout/ThemeProvider/index.tsx
+++ b/front/src/layouts/RootLayout/ThemeProvider/index.tsx
@@ -1,15 +1,16 @@
 import { ThemeProvider as _ThemeProvider } from "@emotion/react"
 import { Global } from "./Global"
 import { createTheme } from "src/styles"
-import { SchemeType } from "src/types"
+import type { BlogDesignType, SchemeType } from "src/types"
 
 type Props = {
   scheme: SchemeType
+  blogDesign?: BlogDesignType
   children?: React.ReactNode
 }
 
-export const ThemeProvider = ({ scheme, children }: Props) => {
-  const theme = createTheme({ scheme })
+export const ThemeProvider = ({ scheme, blogDesign, children }: Props) => {
+  const theme = createTheme({ scheme, blogDesign })
 
   return (
     <_ThemeProvider theme={theme}>

--- a/front/src/layouts/RootLayout/index.tsx
+++ b/front/src/layouts/RootLayout/index.tsx
@@ -6,6 +6,10 @@ import styled from "@emotion/styled"
 import Scripts from "src/layouts/RootLayout/Scripts"
 import useGtagEffect from "./useGtagEffect"
 import { useRouter } from "next/router"
+import { useQuery } from "@tanstack/react-query"
+import { CONFIG } from "site.config"
+import type { AdminProfile } from "src/hooks/useAdminProfile"
+import { resolvePublicBlogAppearance } from "src/libs/blogAppearance"
 import { isNavigationCancelledError, isRequestCancelledError } from "src/libs/router"
 import {
   CONTENT_MAX_WIDTH_PX,
@@ -17,13 +21,69 @@ import {
   WIDE_CONTENT_MAX_PX,
 } from "./layoutTiers"
 
-type Props = {
-  children: ReactNode
+const PUBLIC_ADMIN_PROFILE_QUERY_KEY = ["member", "adminProfile"] as const
+
+type UsePublicAdminProfileOptions = {
+  enabled: boolean
+  refetchOnMount: boolean
+  staleTimeMs?: number
 }
 
-const RootLayout = ({ children }: Props) => {
+const resolvePublicApiBaseUrl = () => {
+  const publicUrl = process.env.NEXT_PUBLIC_BACKEND_URL
+  return (publicUrl || "http://localhost:8080").replace(/\/+$/, "")
+}
+
+const fetchPublicAdminProfile = async (): Promise<AdminProfile | null> => {
+  const response = await fetch(`${resolvePublicApiBaseUrl()}/member/api/v1/members/adminProfile`, {
+    credentials: "include",
+  })
+  if (!response.ok) return null
+  return (await response.json()) as AdminProfile
+}
+
+const usePublicAdminProfile = (
+  initialProfile: AdminProfile | null,
+  options: UsePublicAdminProfileOptions
+): AdminProfile | null => {
+  const hasSeedProfile = initialProfile != null
+  const query = useQuery<AdminProfile | null>({
+    queryKey: PUBLIC_ADMIN_PROFILE_QUERY_KEY,
+    queryFn: fetchPublicAdminProfile,
+    enabled: typeof window !== "undefined" && options.enabled,
+    initialData: initialProfile ?? undefined,
+    staleTime: options.staleTimeMs ?? (hasSeedProfile ? 5 * 60 * 1000 : 0),
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: options.enabled && (options.refetchOnMount || !hasSeedProfile),
+  })
+
+  return query.data ?? initialProfile
+}
+
+type Props = {
+  children: ReactNode
+  initialAdminProfile?: AdminProfile | null
+  initialAdminProfileShouldRefetch?: boolean
+}
+
+const RootLayout = ({
+  children,
+  initialAdminProfile = null,
+  initialAdminProfileShouldRefetch = false,
+}: Props) => {
   const [scheme] = useScheme()
   const router = useRouter()
+  const isPublicBlogRoute = router.pathname === "/" || router.pathname === "/about" || router.pathname === "/posts/[id]"
+  const adminProfile = usePublicAdminProfile(initialAdminProfile, {
+    enabled: isPublicBlogRoute,
+    refetchOnMount: initialAdminProfileShouldRefetch,
+    staleTimeMs: initialAdminProfileShouldRefetch ? 0 : undefined,
+  })
+  const publicAppearance = resolvePublicBlogAppearance(isPublicBlogRoute ? adminProfile : null)
+  const effectiveScheme = isPublicBlogRoute ? publicAppearance.scheme : scheme
+  const effectiveBlogDesign = isPublicBlogRoute ? publicAppearance.blogDesign : "legacy"
+  const headerBlogTitle = isPublicBlogRoute ? adminProfile?.blogTitle?.trim() || CONFIG.blog.title : CONFIG.blog.title
   const [isNavigating, setIsNavigating] = useState(false)
   useGtagEffect()
 
@@ -123,11 +183,11 @@ const RootLayout = ({ children }: Props) => {
   }, [])
 
   return (
-    <ThemeProvider scheme={scheme}>
+    <ThemeProvider scheme={effectiveScheme} blogDesign={effectiveBlogDesign}>
       <Scripts />
       {/* // TODO: replace react query */}
       {/* {metaConfig.type !== "Paper" && <Header />} */}
-      <Header fullWidth={false} />
+      <Header fullWidth={false} showThemeToggle={!isPublicBlogRoute} blogTitle={headerBlogTitle} />
       <RouteProgress data-busy={isNavigating} aria-hidden="true" />
       <StyledMain>{children}</StyledMain>
     </ThemeProvider>

--- a/front/src/libs/blogAppearance.ts
+++ b/front/src/libs/blogAppearance.ts
@@ -1,0 +1,36 @@
+import { CONFIG } from "site.config"
+import type { AdminProfile } from "src/hooks/useAdminProfile"
+import type { BlogDesignType, LegacyBlogScheme, SchemeType } from "src/types"
+
+export type PublicBlogAppearance = {
+  blogDesign: BlogDesignType
+  scheme: SchemeType
+  legacyBlogScheme: LegacyBlogScheme
+}
+
+const resolveConfigScheme = (): LegacyBlogScheme => (CONFIG.blog.scheme === "light" ? "light" : "dark")
+
+const normalizeBlogDesign = (value: unknown): BlogDesignType => (value === "grid" ? "grid" : "legacy")
+
+const normalizeLegacyBlogScheme = (value: unknown): LegacyBlogScheme => (value === "light" ? "light" : "dark")
+
+export const resolvePublicBlogAppearance = (
+  profile: Pick<AdminProfile, "blogDesign" | "legacyBlogScheme"> | null | undefined
+): PublicBlogAppearance => {
+  const blogDesign = normalizeBlogDesign(profile?.blogDesign)
+  const legacyBlogScheme = normalizeLegacyBlogScheme(profile?.legacyBlogScheme || resolveConfigScheme())
+
+  if (blogDesign === "grid") {
+    return {
+      blogDesign,
+      legacyBlogScheme,
+      scheme: "dark",
+    }
+  }
+
+  return {
+    blogDesign,
+    legacyBlogScheme,
+    scheme: legacyBlogScheme,
+  }
+}

--- a/front/src/libs/profileWorkspace.ts
+++ b/front/src/libs/profileWorkspace.ts
@@ -1,4 +1,5 @@
 import type { ProfileCardLinkItem } from "src/constants/profileCardLinks"
+import type { BlogDesignType, LegacyBlogScheme } from "src/types"
 
 export type AboutSectionBlock = {
   id: string
@@ -29,6 +30,8 @@ export type ProfileWorkspaceContent = {
   blogTitle: string
   homeIntroTitle: string
   homeIntroDescription: string
+  blogDesign: BlogDesignType
+  legacyBlogScheme: LegacyBlogScheme
   serviceLinks: ProfileCardLinkItem[]
   contactLinks: ProfileCardLinkItem[]
 }
@@ -56,12 +59,18 @@ type LegacyProfileLike = {
   blogTitle?: string
   homeIntroTitle?: string
   homeIntroDescription?: string
+  blogDesign?: BlogDesignType
+  legacyBlogScheme?: LegacyBlogScheme
   serviceLinks?: ProfileCardLinkItem[]
   contactLinks?: ProfileCardLinkItem[]
 }
 
 export const DEFAULT_ABOUT_HEADLINE = "이유를 먼저 따지고, 운영 가능한 시스템을 설계합니다."
 export const DEFAULT_ABOUT_PROJECT_SECTION_TITLE = "프로젝트"
+export const normalizeBlogDesign = (value: unknown): BlogDesignType =>
+  value === "grid" ? "grid" : "legacy"
+export const normalizeLegacyBlogScheme = (value: unknown): LegacyBlogScheme =>
+  value === "light" ? "light" : "dark"
 export const DEFAULT_ABOUT_PROJECTS: AboutProjectBlock[] = [
   {
     id: "project-1",
@@ -197,6 +206,8 @@ export const buildLegacyAboutDetails = (sections: AboutSectionBlock[]): string =
     blogTitle: "",
     homeIntroTitle: "",
     homeIntroDescription: "",
+    blogDesign: "legacy",
+    legacyBlogScheme: "dark",
     serviceLinks: [],
     contactLinks: [],
   }).aboutSections
@@ -306,6 +317,8 @@ export const normalizeProfileWorkspaceContent = (
     blogTitle: (content.blogTitle || "").trim(),
     homeIntroTitle: (content.homeIntroTitle || "").trim(),
     homeIntroDescription: (content.homeIntroDescription || "").trim(),
+    blogDesign: normalizeBlogDesign(content.blogDesign),
+    legacyBlogScheme: normalizeLegacyBlogScheme(content.legacyBlogScheme),
     serviceLinks: normalizeLinkItems(content.serviceLinks),
     contactLinks: normalizeLinkItems(content.contactLinks),
   }
@@ -332,6 +345,8 @@ export const buildProfileWorkspaceAdminProfileCacheFields = (content: ProfileWor
     blogTitle: normalized.blogTitle,
     homeIntroTitle: normalized.homeIntroTitle,
     homeIntroDescription: normalized.homeIntroDescription,
+    blogDesign: normalized.blogDesign,
+    legacyBlogScheme: normalized.legacyBlogScheme,
     serviceLinks: normalized.serviceLinks,
     contactLinks: normalized.contactLinks,
   }
@@ -356,6 +371,8 @@ export const buildProfileWorkspaceFromLegacy = (
     blogTitle: value?.blogTitle || "",
     homeIntroTitle: value?.homeIntroTitle || "",
     homeIntroDescription: value?.homeIntroDescription || "",
+    blogDesign: normalizeBlogDesign(value?.blogDesign),
+    legacyBlogScheme: normalizeLegacyBlogScheme(value?.legacyBlogScheme),
     serviceLinks: value?.serviceLinks || [],
     contactLinks: value?.contactLinks || [],
   })

--- a/front/src/libs/server/adminProfile.ts
+++ b/front/src/libs/server/adminProfile.ts
@@ -14,6 +14,15 @@ type FetchServerAdminProfileOptions = {
   timeoutMs?: number
 }
 
+export type StaticAdminProfileSeedSource = "published" | "static-fallback"
+
+type StaticAdminProfileSeed = {
+  profile: AdminProfile
+  source: StaticAdminProfileSeedSource
+}
+
+type FetchStaticAdminProfile = () => Promise<AdminProfile>
+
 const ADMIN_PROFILE_SNAPSHOT_COOKIE = "admin_profile_snapshot_v1"
 const ADMIN_PROFILE_SNAPSHOT_MAX_STALE_MS = 1000 * 60 * 60 * 6
 
@@ -73,6 +82,22 @@ export const buildStaticAdminProfileSnapshot = (): AdminProfile => ({
   blogDesign: "legacy",
   legacyBlogScheme: "dark",
 })
+
+export const resolveStaticAdminProfileSeed = async (
+  fetchProfile: FetchStaticAdminProfile
+): Promise<StaticAdminProfileSeed> => {
+  try {
+    return {
+      profile: await fetchProfile(),
+      source: "published",
+    }
+  } catch {
+    return {
+      profile: buildStaticAdminProfileSnapshot(),
+      source: "static-fallback",
+    }
+  }
+}
 
 export const buildPersistedAdminProfileSnapshot = (profile: AdminProfile): AdminProfile => ({
   username: profile.username,

--- a/front/src/libs/server/adminProfile.ts
+++ b/front/src/libs/server/adminProfile.ts
@@ -1,7 +1,13 @@
 import { IncomingMessage } from "http"
 import { CONFIG } from "site.config"
 import { AdminProfile } from "src/hooks/useAdminProfile"
-import { DEFAULT_ABOUT_HEADLINE, DEFAULT_ABOUT_PROJECT_SECTION_TITLE, DEFAULT_ABOUT_PROJECTS } from "src/libs/profileWorkspace"
+import {
+  DEFAULT_ABOUT_HEADLINE,
+  DEFAULT_ABOUT_PROJECT_SECTION_TITLE,
+  DEFAULT_ABOUT_PROJECTS,
+  normalizeBlogDesign,
+  normalizeLegacyBlogScheme,
+} from "src/libs/profileWorkspace"
 import { serverApiFetch } from "./backend"
 
 type FetchServerAdminProfileOptions = {
@@ -64,6 +70,8 @@ export const buildStaticAdminProfileSnapshot = (): AdminProfile => ({
   blogTitle: CONFIG.blog.title,
   homeIntroTitle: CONFIG.blog.homeIntroTitle,
   homeIntroDescription: CONFIG.blog.homeIntroDescription,
+  blogDesign: "legacy",
+  legacyBlogScheme: "dark",
 })
 
 export const buildPersistedAdminProfileSnapshot = (profile: AdminProfile): AdminProfile => ({
@@ -85,6 +93,8 @@ export const buildPersistedAdminProfileSnapshot = (profile: AdminProfile): Admin
   blogTitle: profile.blogTitle,
   homeIntroTitle: profile.homeIntroTitle,
   homeIntroDescription: profile.homeIntroDescription,
+  blogDesign: normalizeBlogDesign(profile.blogDesign),
+  legacyBlogScheme: normalizeLegacyBlogScheme(profile.legacyBlogScheme),
   serviceLinks: profile.serviceLinks || [],
   contactLinks: profile.contactLinks || [],
 })
@@ -122,6 +132,8 @@ export const readAdminProfileSnapshotFromCookie = (req: IncomingMessage): AdminP
       blogTitle: parsed.blogTitle,
       homeIntroTitle: parsed.homeIntroTitle,
       homeIntroDescription: parsed.homeIntroDescription,
+      blogDesign: normalizeBlogDesign(parsed.blogDesign),
+      legacyBlogScheme: normalizeLegacyBlogScheme(parsed.legacyBlogScheme),
       serviceLinks: Array.isArray(parsed.serviceLinks) ? parsed.serviceLinks : [],
       contactLinks: Array.isArray(parsed.contactLinks) ? parsed.contactLinks : [],
     })

--- a/front/src/libs/server/postDetailPage.ts
+++ b/front/src/libs/server/postDetailPage.ts
@@ -6,21 +6,19 @@ import { getPostsBootstrap } from "src/apis/backend/posts"
 import { queryKey } from "src/constants/queryKey"
 import type { AdminProfile } from "src/hooks/useAdminProfile"
 import { createQueryClient } from "src/libs/react-query"
-import { buildStaticAdminProfileSnapshot } from "src/libs/server/adminProfile"
+import {
+  resolveStaticAdminProfileSeed,
+  type StaticAdminProfileSeedSource,
+} from "src/libs/server/adminProfile"
 import { TPostComment } from "src/types"
+
+export { resolveStaticAdminProfileSeed } from "src/libs/server/adminProfile"
 
 type DetailPageProps = {
   dehydratedState: unknown
   initialComments: TPostComment[] | null
   initialAdminProfile: AdminProfile | null
   initialAdminProfileSource: StaticAdminProfileSeedSource
-}
-
-type StaticAdminProfileSeedSource = "published" | "static-fallback"
-
-type StaticAdminProfileSeed = {
-  profile: AdminProfile
-  source: StaticAdminProfileSeedSource
 }
 
 type FetchStaticAdminProfile = () => Promise<AdminProfile>
@@ -39,27 +37,11 @@ const fetchPublicAdminProfile: FetchStaticAdminProfile = async () => {
   return await apiFetch<AdminProfile>("/member/api/v1/members/adminProfile")
 }
 
-export const resolveStaticAdminProfileSeed = async (
-  fetchProfile: FetchStaticAdminProfile = fetchPublicAdminProfile
-): Promise<StaticAdminProfileSeed> => {
-  try {
-    return {
-      profile: await fetchProfile(),
-      source: "published",
-    }
-  } catch {
-    return {
-      profile: buildStaticAdminProfileSnapshot(),
-      source: "static-fallback",
-    }
-  }
-}
-
 export const buildCanonicalPostDetailStaticProps = async (
   postId: string
 ): Promise<GetStaticPropsResult<DetailPageProps>> => {
   const queryClient = createQueryClient()
-  const adminProfileSeed = await resolveStaticAdminProfileSeed()
+  const adminProfileSeed = await resolveStaticAdminProfileSeed(fetchPublicAdminProfile)
   const initialAdminProfile = adminProfileSeed.profile
   const initialAdminProfileSource = adminProfileSeed.source
   queryClient.setQueryData(queryKey.adminProfile(), initialAdminProfile)

--- a/front/src/libs/server/postDetailPage.ts
+++ b/front/src/libs/server/postDetailPage.ts
@@ -1,15 +1,29 @@
 import { dehydrate } from "@tanstack/react-query"
 import { GetStaticPathsResult, GetStaticPropsResult } from "next"
 import { getPostDetailById } from "src/apis"
+import { apiFetch } from "src/apis/backend/client"
 import { getPostsBootstrap } from "src/apis/backend/posts"
 import { queryKey } from "src/constants/queryKey"
+import type { AdminProfile } from "src/hooks/useAdminProfile"
 import { createQueryClient } from "src/libs/react-query"
+import { buildStaticAdminProfileSnapshot } from "src/libs/server/adminProfile"
 import { TPostComment } from "src/types"
 
 type DetailPageProps = {
   dehydratedState: unknown
   initialComments: TPostComment[] | null
+  initialAdminProfile: AdminProfile | null
+  initialAdminProfileSource: StaticAdminProfileSeedSource
 }
+
+type StaticAdminProfileSeedSource = "published" | "static-fallback"
+
+type StaticAdminProfileSeed = {
+  profile: AdminProfile
+  source: StaticAdminProfileSeedSource
+}
+
+type FetchStaticAdminProfile = () => Promise<AdminProfile>
 
 const DETAIL_ISR_REVALIDATE_SECONDS = 60 * 60
 const DETAIL_PREBUILD_COUNT = 16
@@ -21,16 +35,42 @@ const toSerializableState = (value: unknown): unknown =>
     JSON.stringify(value, (_key, currentValue) => (currentValue === undefined ? null : currentValue))
   )
 
+const fetchPublicAdminProfile: FetchStaticAdminProfile = async () => {
+  return await apiFetch<AdminProfile>("/member/api/v1/members/adminProfile")
+}
+
+export const resolveStaticAdminProfileSeed = async (
+  fetchProfile: FetchStaticAdminProfile = fetchPublicAdminProfile
+): Promise<StaticAdminProfileSeed> => {
+  try {
+    return {
+      profile: await fetchProfile(),
+      source: "published",
+    }
+  } catch {
+    return {
+      profile: buildStaticAdminProfileSnapshot(),
+      source: "static-fallback",
+    }
+  }
+}
+
 export const buildCanonicalPostDetailStaticProps = async (
   postId: string
 ): Promise<GetStaticPropsResult<DetailPageProps>> => {
   const queryClient = createQueryClient()
+  const adminProfileSeed = await resolveStaticAdminProfileSeed()
+  const initialAdminProfile = adminProfileSeed.profile
+  const initialAdminProfileSource = adminProfileSeed.source
+  queryClient.setQueryData(queryKey.adminProfile(), initialAdminProfile)
 
   if (IS_QA_STATIC_RECOVERY_MODE) {
     return {
       props: {
         dehydratedState: toSerializableState(dehydrate(queryClient)),
         initialComments: null,
+        initialAdminProfile,
+        initialAdminProfileSource,
       },
       revalidate: DETAIL_RECOVERY_REVALIDATE_SECONDS,
     }
@@ -61,8 +101,13 @@ export const buildCanonicalPostDetailStaticProps = async (
     props: {
       dehydratedState: toSerializableState(dehydrate(queryClient)),
       initialComments,
+      initialAdminProfile,
+      initialAdminProfileSource,
     },
-    revalidate: shouldServeClientRecoveryShell ? DETAIL_RECOVERY_REVALIDATE_SECONDS : DETAIL_ISR_REVALIDATE_SECONDS,
+    revalidate:
+      shouldServeClientRecoveryShell || initialAdminProfileSource === "static-fallback"
+        ? DETAIL_RECOVERY_REVALIDATE_SECONDS
+        : DETAIL_ISR_REVALIDATE_SECONDS,
   }
 }
 

--- a/front/src/pages/_app.tsx
+++ b/front/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import type { NextWebVitalsMetric } from "next/app"
 import dynamic from "next/dynamic"
 import Head from "next/head"
 import { RootLayout } from "src/layouts"
+import type { AdminProfile } from "src/hooks/useAdminProfile"
 import createEmotionCache from "src/libs/emotion/createEmotionCache"
 import { createQueryClient } from "src/libs/react-query"
 import { useState } from "react"
@@ -18,8 +19,16 @@ const SpeedInsights = dynamic(() => import("@vercel/speed-insights/next").then((
   ssr: false,
 })
 
+type AppPageProps = AppPropsWithLayout["pageProps"] & {
+  initialAdminProfile?: AdminProfile | null
+  initialAdminProfileSource?: "published" | "static-fallback"
+}
+
 function App({ Component, pageProps, emotionCache = clientSideEmotionCache }: AppPropsWithLayout) {
   const getLayout = Component.getLayout || ((page) => page)
+  const appPageProps = pageProps as AppPageProps
+  const initialAdminProfile = appPageProps.initialAdminProfile ?? null
+  const initialAdminProfileShouldRefetch = appPageProps.initialAdminProfileSource === "static-fallback"
   const [queryClient] = useState(createQueryClient)
 
   return (
@@ -30,7 +39,10 @@ function App({ Component, pageProps, emotionCache = clientSideEmotionCache }: Ap
       </Head>
       <QueryClientProvider client={queryClient}>
         <HydrationBoundary state={pageProps.dehydratedState}>
-          <RootLayout>
+          <RootLayout
+            initialAdminProfile={initialAdminProfile}
+            initialAdminProfileShouldRefetch={initialAdminProfileShouldRefetch}
+          >
             {getLayout(<Component {...pageProps} />)}
             {process.env.NODE_ENV === "production" ? (
               <>

--- a/front/src/pages/about.tsx
+++ b/front/src/pages/about.tsx
@@ -17,6 +17,7 @@ import {
   fetchServerAdminProfile,
   hasServerAuthCookie,
   resolvePublicAdminProfileSnapshot,
+  type StaticAdminProfileSeedSource,
 } from "src/libs/server/adminProfile"
 import { appendSsrDebugTiming, isSsrDebugEnabled, timed } from "src/libs/server/serverTiming"
 import { resolveContactLinks, resolveRenderableProfileLinkHref, resolveServiceLinks } from "src/libs/utils/profileCardLinks"
@@ -37,6 +38,12 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
       : hasAuthCookie
         ? buildStaticAdminProfileSnapshot()
         : fallbackProfileSnapshot?.profile || buildStaticAdminProfileSnapshot()
+  const initialAdminProfileSource: StaticAdminProfileSeedSource =
+    adminProfileResult.ok && adminProfileResult.value
+      ? "published"
+      : fallbackProfileSnapshot?.source === "cookie-snapshot"
+        ? "published"
+        : "static-fallback"
 
   res.setHeader(
     "Cache-Control",
@@ -61,12 +68,14 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
   return {
     props: {
       initialAdminProfile,
+      initialAdminProfileSource,
     },
   }
 }
 
 type AboutPageProps = {
   initialAdminProfile: AdminProfile | null
+  initialAdminProfileSource: StaticAdminProfileSeedSource
 }
 
 type AboutListSection = {
@@ -341,7 +350,8 @@ const StyledWrapper = styled.div`
     grid-template-columns: minmax(0, 1.6fr) minmax(220px, 0.9fr);
     gap: 2.25rem;
     padding-bottom: 2rem;
-    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+    border-bottom: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
   }
 
   .hero-copy {
@@ -408,9 +418,11 @@ const StyledWrapper = styled.div`
     width: 148px;
     border-radius: 999px;
     overflow: hidden;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray1};
-    box-shadow: 0 18px 38px rgba(0, 0, 0, 0.18);
+    border: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray1)};
+    box-shadow: ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.shadow : "0 18px 38px rgba(0, 0, 0, 0.18)"};
 
     &::after {
       content: "";
@@ -432,8 +444,9 @@ const StyledWrapper = styled.div`
       min-height: 40px;
       padding: 0.68rem 0.92rem;
       border-radius: 999px;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
-      background: ${({ theme }) => theme.colors.gray1};
+      border: 1px solid ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+      background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray1)};
       color: ${({ theme }) => theme.colors.gray12};
       font-size: 0.94rem;
       font-weight: 700;
@@ -441,8 +454,10 @@ const StyledWrapper = styled.div`
       transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 
       &:hover {
-        background: ${({ theme }) => theme.colors.gray2};
-        border-color: ${({ theme }) => theme.colors.gray10};
+        background: ${({ theme }) =>
+          theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray2};
+        border-color: ${({ theme }) =>
+          theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray10};
         transform: translateY(-1px);
       }
     }
@@ -479,9 +494,10 @@ const StyledWrapper = styled.div`
       grid-template-columns: minmax(0, 1fr) minmax(10rem, 15rem);
       gap: 1.1rem;
       padding: 1rem 1.1rem;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
+      border: 1px solid ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
       border-radius: 16px;
-      background: ${({ theme }) => theme.colors.gray1};
+      background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray1)};
     }
   }
 
@@ -526,7 +542,8 @@ const StyledWrapper = styled.div`
       align-items: center;
       min-height: 30px;
       padding: 0.42rem 0.7rem;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
+      border: 1px solid ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
       border-radius: 999px;
       color: ${({ theme }) => theme.colors.gray12};
       font-size: 0.86rem;
@@ -534,7 +551,8 @@ const StyledWrapper = styled.div`
       font-weight: 650;
 
       &:hover {
-        border-color: ${({ theme }) => theme.colors.gray10};
+        border-color: ${({ theme }) =>
+          theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray10};
         text-decoration: none;
       }
     }
@@ -570,7 +588,8 @@ const StyledWrapper = styled.div`
 
   .supplemental-section[data-has-divider="true"] {
     padding-top: 1.2rem;
-    border-top: 1px solid ${({ theme }) => theme.colors.gray6};
+    border-top: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
   }
 
   .supplemental-list {
@@ -592,10 +611,12 @@ const StyledWrapper = styled.div`
 
   .compact-link-list {
     background: transparent;
-    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+    border-bottom: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
 
     li + li {
-      border-top: 1px solid ${({ theme }) => theme.colors.gray6};
+      border-top: 1px solid ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
     }
 
     a {

--- a/front/src/pages/admin.tsx
+++ b/front/src/pages/admin.tsx
@@ -270,7 +270,7 @@ const AdminHubPage: NextPage<AdminHubPageProps> = ({ initialMember, initialProfi
   if (!sessionMember) return null
 
   return (
-    <AdminShell currentSection="hub" member={sessionMember}>
+    <AdminShell currentSection="hub" member={sessionMember} profileSnapshot={initialProfileSnapshot}>
       <AdminHubSurface
         displayName={displayName}
         displayNameInitial={displayNameInitial}

--- a/front/src/pages/admin/profile.tsx
+++ b/front/src/pages/admin/profile.tsx
@@ -69,7 +69,7 @@ import {
 } from "src/routes/Admin/AdminSurfacePrimitives"
 
 type NoticeTone = "idle" | "loading" | "success" | "error"
-type WorkspaceSectionId = "identity" | "about" | "home" | "links"
+type WorkspaceSectionId = "identity" | "about" | "home" | "design" | "links"
 type LinkTab = "service" | "contact"
 type PreviewMode = "draft" | "published"
 type OpenIconPicker = `${LinkTab}:${number}` | null
@@ -111,6 +111,10 @@ const WORKSPACE_SECTIONS: {
     label: "헤더 문구",
   },
   {
+    id: "design",
+    label: "디자인",
+  },
+  {
     id: "links",
     label: "외부 링크",
   },
@@ -141,6 +145,11 @@ const pickWorkspaceSectionContent = (
         blogTitle: content.blogTitle,
         homeIntroTitle: content.homeIntroTitle,
         homeIntroDescription: content.homeIntroDescription,
+      }
+    case "design":
+      return {
+        blogDesign: content.blogDesign,
+        legacyBlogScheme: content.legacyBlogScheme,
       }
     case "links":
       return {
@@ -285,9 +294,20 @@ const buildWorkspaceFallback = (
   initialWorkspace: ProfileWorkspaceResponse | null
 ): ProfileWorkspaceResponse => {
   if (initialWorkspace) {
+    const draft = normalizeProfileWorkspaceContent({
+      ...initialWorkspace.draft,
+      blogDesign: initialWorkspace.draft.blogDesign || member.blogDesign || "legacy",
+      legacyBlogScheme: initialWorkspace.draft.legacyBlogScheme || member.legacyBlogScheme || "dark",
+    })
+    const published = normalizeProfileWorkspaceContent({
+      ...initialWorkspace.published,
+      blogDesign: initialWorkspace.published.blogDesign || member.blogDesign || "legacy",
+      legacyBlogScheme: initialWorkspace.published.legacyBlogScheme || member.legacyBlogScheme || "dark",
+    })
+
     return {
-      draft: normalizeProfileWorkspaceContent(initialWorkspace.draft),
-      published: normalizeProfileWorkspaceContent(initialWorkspace.published),
+      draft,
+      published,
       lastDraftSavedAt: initialWorkspace.lastDraftSavedAt || member.modifiedAt || null,
       lastPublishedAt: initialWorkspace.lastPublishedAt || member.modifiedAt || null,
       dirtyFromPublished: initialWorkspace.dirtyFromPublished,
@@ -580,6 +600,7 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
         identity: { dirty: false, publishedDiff: false },
         about: { dirty: false, publishedDiff: false },
         home: { dirty: false, publishedDiff: false },
+        design: { dirty: false, publishedDiff: false },
         links: { dirty: false, publishedDiff: false },
       }
     )
@@ -1640,6 +1661,67 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
           </SectionStack>
         )
 
+      case "design":
+        return (
+          <SectionStack>
+            <FieldSectionCard>
+              <SectionBlockHeader>
+                <div>
+                  <h3>블로그 디자인</h3>
+                </div>
+              </SectionBlockHeader>
+              <FieldGrid data-columns="2">
+                <FieldBox as="div">
+                  <FieldLabel as="span">공개 디자인</FieldLabel>
+                  <SegmentedControl role="group" aria-label="공개 블로그 디자인">
+                    <SegmentButton
+                      type="button"
+                      data-active={draft.blogDesign === "legacy"}
+                      onClick={() => updateDraft("blogDesign", "legacy")}
+                    >
+                      Legacy
+                    </SegmentButton>
+                    <SegmentButton
+                      type="button"
+                      data-active={draft.blogDesign === "grid"}
+                      onClick={() => updateDraft("blogDesign", "grid")}
+                    >
+                      Grid
+                    </SegmentButton>
+                  </SegmentedControl>
+                </FieldBox>
+
+                {draft.blogDesign === "legacy" ? (
+                  <FieldBox as="div">
+                    <FieldLabel as="span">Legacy 색상</FieldLabel>
+                    <SegmentedControl role="group" aria-label="Legacy 색상">
+                      <SegmentButton
+                        type="button"
+                        data-active={draft.legacyBlogScheme === "light"}
+                        onClick={() => updateDraft("legacyBlogScheme", "light")}
+                      >
+                        Light
+                      </SegmentButton>
+                      <SegmentButton
+                        type="button"
+                        data-active={draft.legacyBlogScheme === "dark"}
+                        onClick={() => updateDraft("legacyBlogScheme", "dark")}
+                      >
+                        Dark
+                      </SegmentButton>
+                    </SegmentedControl>
+                  </FieldBox>
+                ) : (
+                  <EmptyStateCard>
+                    <strong>Grid dark presentation</strong>
+                    <p>Grid 디자인은 dark presentation으로 고정됩니다.</p>
+                  </EmptyStateCard>
+                )}
+              </FieldGrid>
+            </FieldSectionCard>
+          </SectionStack>
+        )
+
       case "links":
         return (
           <SectionStack>
@@ -2008,6 +2090,18 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
                     <strong>{previewContent.blogTitle || displayName}</strong>
                     <h4>{previewContent.homeIntroTitle || previewContent.blogTitle || displayName}</h4>
                     {previewContent.homeIntroDescription ? <p>{previewContent.homeIntroDescription}</p> : null}
+                  </PreviewHomeCard>
+                ) : null}
+
+                {activeSection === "design" ? (
+                  <PreviewHomeCard>
+                    <span>Design</span>
+                    <strong>{previewContent.blogDesign === "grid" ? "Grid" : "Legacy"}</strong>
+                    <p>
+                      {previewContent.blogDesign === "legacy"
+                        ? `Legacy ${previewContent.legacyBlogScheme}`
+                        : "Grid dark presentation"}
+                    </p>
                   </PreviewHomeCard>
                 ) : null}
 

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -10,7 +10,8 @@ import { GetStaticProps } from "next"
 import { dehydrate } from "@tanstack/react-query"
 import { AdminProfile } from "src/hooks/useAdminProfile"
 import {
-  buildStaticAdminProfileSnapshot,
+  resolveStaticAdminProfileSeed,
+  type StaticAdminProfileSeedSource,
 } from "src/libs/server/adminProfile"
 import type { TPost } from "src/types"
 import { FEED_EXPLORE_PAGE_SIZE } from "src/constants/feed"
@@ -20,18 +21,15 @@ const HOME_ISR_REVALIDATE_SECONDS = 60
 const HOME_QA_SHELL_REVALIDATE_SECONDS = 15
 const IS_QA_STATIC_SHELL_MODE = process.env.ENABLE_QA_ROUTES === "true"
 
-const fetchPublicAdminProfile = async (): Promise<AdminProfile> => {
-  try {
-    return await apiFetch<AdminProfile>("/member/api/v1/members/adminProfile")
-  } catch {
-    return buildStaticAdminProfileSnapshot()
-  }
-}
+const fetchPublicAdminProfile = async (): Promise<AdminProfile> =>
+  await apiFetch<AdminProfile>("/member/api/v1/members/adminProfile")
 
 export const getStaticProps: GetStaticProps = async () => {
   const queryClient = createQueryClient()
   const currentTag = ""
-  const initialAdminProfile = await fetchPublicAdminProfile()
+  const adminProfileSeed = await resolveStaticAdminProfileSeed(fetchPublicAdminProfile)
+  const initialAdminProfile = adminProfileSeed.profile
+  const initialAdminProfileSource = adminProfileSeed.source
   const bootstrapSnapshot = await (async () => {
     if (IS_QA_STATIC_SHELL_MODE) {
       return {
@@ -120,6 +118,7 @@ export const getStaticProps: GetStaticProps = async () => {
     props: {
       dehydratedState: dehydrate(queryClient),
       initialAdminProfile,
+      initialAdminProfileSource,
     },
     revalidate:
       IS_QA_STATIC_SHELL_MODE || !postsLoaded ? HOME_QA_SHELL_REVALIDATE_SECONDS : HOME_ISR_REVALIDATE_SECONDS,
@@ -128,6 +127,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
 type FeedPageProps = {
   initialAdminProfile: AdminProfile | null
+  initialAdminProfileSource: StaticAdminProfileSeedSource
 }
 
 const FeedPage: NextPageWithLayout<FeedPageProps> = ({ initialAdminProfile }) => {

--- a/front/src/pages/posts/[id].tsx
+++ b/front/src/pages/posts/[id].tsx
@@ -6,6 +6,7 @@ import CustomError from "src/routes/Error"
 import MetaConfig from "src/components/MetaConfig"
 import PostDetail from "src/routes/Detail/PostDetail"
 import usePostQuery from "src/hooks/usePostQuery"
+import type { AdminProfile } from "src/hooks/useAdminProfile"
 import { TPostComment } from "src/types"
 import {
   buildCanonicalPostDetailStaticPaths,
@@ -24,6 +25,8 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
 type DetailPageProps = {
   initialComments: TPostComment[] | null
+  initialAdminProfile: AdminProfile | null
+  initialAdminProfileSource: "published" | "static-fallback"
 }
 
 const CanonicalPostPage: NextPageWithLayout<DetailPageProps> = ({ initialComments }) => {

--- a/front/src/routes/Admin/AdminShell.tsx
+++ b/front/src/routes/Admin/AdminShell.tsx
@@ -4,14 +4,19 @@ import Link from "next/link"
 import { type ReactNode } from "react"
 import AppIcon, { type IconName } from "src/components/icons/AppIcon"
 import ProfileImage from "src/components/ProfileImage"
-import { useAdminProfile } from "src/hooks/useAdminProfile"
 import type { AuthMember } from "src/hooks/useAuthSession"
+
+type AdminShellProfileSnapshot = Pick<
+  AuthMember,
+  "blogTitle" | "profileImageDirectUrl" | "profileImageUrl"
+>
 
 export type AdminShellSection = "hub" | "dashboard" | "posts" | "profile" | "tools"
 
 type AdminShellProps = {
   currentSection: AdminShellSection
   member: AuthMember
+  profileSnapshot?: AdminShellProfileSnapshot | null
   children: ReactNode
 }
 
@@ -60,8 +65,7 @@ const AdminUtilityBar = dynamic(() => import("./AdminUtilityBar"), {
   loading: () => <UtilityBarFallback aria-hidden="true" />,
 })
 
-const AdminShell = ({ currentSection, member, children }: AdminShellProps) => {
-  const adminProfile = useAdminProfile()
+const AdminShell = ({ currentSection, member, profileSnapshot = null, children }: AdminShellProps) => {
   const currentNav = NAV_ITEMS.find((item) => item.id === currentSection) ?? NAV_ITEMS[0]
   const utilityNavItems = NAV_ITEMS.map((item) => ({
     key: item.id,
@@ -70,11 +74,11 @@ const AdminShell = ({ currentSection, member, children }: AdminShellProps) => {
     icon: item.icon,
     active: item.id === currentSection,
   }))
-  const sidebarIdentityName = (adminProfile?.blogTitle || "AquilaLog").trim()
+  const sidebarIdentityName = (profileSnapshot?.blogTitle || member.blogTitle || "AquilaLog").trim()
   const sidebarIdentityInitial = sidebarIdentityName.slice(0, 2).toUpperCase()
   const sidebarProfileImageSrc = (
-    adminProfile?.profileImageDirectUrl ||
-    adminProfile?.profileImageUrl ||
+    profileSnapshot?.profileImageDirectUrl ||
+    profileSnapshot?.profileImageUrl ||
     member.profileImageDirectUrl ||
     member.profileImageUrl ||
     ""

--- a/front/src/routes/Detail/PostDetail/PostHeader.tsx
+++ b/front/src/routes/Detail/PostDetail/PostHeader.tsx
@@ -279,12 +279,14 @@ const StyledWrapper = styled.header`
     min-height: 32px;
     padding: 0.38rem 0.78rem;
     border-radius: 999px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    border: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
     font-size: 0.86rem;
     line-height: 1.2;
     font-weight: 600;
     color: ${({ theme }) => theme.colors.gray11};
-    background-color: ${({ theme }) => theme.colors.gray3};
+    background-color: ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray3};
   }
 
   .title {
@@ -321,7 +323,8 @@ const StyledWrapper = styled.header`
     height: 48px;
     border-radius: 50%;
     overflow: hidden;
-    background: ${({ theme }) => theme.colors.gray3};
+    background: ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray3};
 
     img {
       object-fit: cover;
@@ -396,8 +399,9 @@ const StyledWrapper = styled.header`
     min-height: 34px;
     padding: 0 0.78rem;
     border-radius: 999px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray2};
+    border: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray2)};
     color: ${({ theme }) => theme.colors.gray11};
     font-size: 0.82rem;
     font-weight: 650;
@@ -411,8 +415,9 @@ const StyledWrapper = styled.header`
     min-height: 34px;
     padding: 0 0.76rem;
     border-radius: 999px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray2};
+    border: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray2)};
     color: ${({ theme }) => theme.colors.gray12};
     font-size: 0.82rem;
     font-weight: 700;
@@ -471,7 +476,8 @@ const StyledWrapper = styled.header`
     min-height: 40px;
     padding: 0 0.9rem;
     border-radius: 8px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    border: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
     background: transparent;
     color: ${({ theme }) => theme.colors.gray12};
     font-size: 0.9rem;
@@ -509,7 +515,8 @@ const StyledWrapper = styled.header`
     min-height: 40px;
     padding: 0 0.9rem;
     border-radius: 8px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    border: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
     background: transparent;
     color: ${({ theme }) => theme.colors.gray12};
     font-size: 0.9rem;
@@ -529,7 +536,7 @@ const StyledWrapper = styled.header`
     width: 0.22rem;
     height: 0.22rem;
     border-radius: 50%;
-    background: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray8)};
   }
 
   .statChip {
@@ -539,7 +546,8 @@ const StyledWrapper = styled.header`
     min-height: 40px;
     padding: 0 0.82rem;
     border-radius: 8px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    border: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
     background: transparent;
     color: ${({ theme }) => theme.colors.gray11};
     font-size: 0.9rem;
@@ -575,8 +583,10 @@ const StyledWrapper = styled.header`
     margin-top: 2rem;
     border-radius: 10px;
     width: 100%;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background-color: ${({ theme }) => theme.colors.gray3};
+    border: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+    background-color: ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray3};
     padding-bottom: 52%;
   }
 

--- a/front/src/routes/Detail/PostDetail/index.tsx
+++ b/front/src/routes/Detail/PostDetail/index.tsx
@@ -1408,8 +1408,18 @@ const StyledWrapper = styled.div`
     justify-content: center;
     padding: 0;
     border-radius: 999px;
-    border: 1px solid ${({ theme }) => (theme.scheme === "dark" ? "rgba(148, 163, 184, 0.28)" : theme.colors.gray6)};
-    background: ${({ theme }) => (theme.scheme === "dark" ? "rgba(15, 23, 42, 0.32)" : "rgba(255, 255, 255, 0.92)")};
+    border: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid"
+        ? theme.publicDesign.border
+        : theme.scheme === "dark"
+          ? "rgba(148, 163, 184, 0.28)"
+          : theme.colors.gray6};
+    background: ${({ theme }) =>
+      theme.blogDesign === "grid"
+        ? theme.publicDesign.surface
+        : theme.scheme === "dark"
+          ? "rgba(15, 23, 42, 0.32)"
+          : "rgba(255, 255, 255, 0.92)"};
     color: ${({ theme }) => theme.colors.gray12};
     cursor: pointer;
     transition: border-color 0.18s ease, background-color 0.18s ease, color 0.18s ease, transform 0.18s ease;
@@ -1420,8 +1430,18 @@ const StyledWrapper = styled.div`
 
     &:hover {
       transform: translateY(-1px);
-      border-color: ${({ theme }) => (theme.scheme === "dark" ? "rgba(148, 163, 184, 0.62)" : theme.colors.gray8)};
-      background: ${({ theme }) => (theme.scheme === "dark" ? "rgba(17, 24, 39, 0.62)" : "#ffffff")};
+      border-color: ${({ theme }) =>
+        theme.blogDesign === "grid"
+          ? theme.publicDesign.borderStrong
+          : theme.scheme === "dark"
+            ? "rgba(148, 163, 184, 0.62)"
+            : theme.colors.gray8};
+      background: ${({ theme }) =>
+        theme.blogDesign === "grid"
+          ? theme.publicDesign.surfaceElevated
+          : theme.scheme === "dark"
+            ? "rgba(17, 24, 39, 0.62)"
+            : "#ffffff"};
     }
 
     &:disabled {
@@ -1445,8 +1465,10 @@ const StyledWrapper = styled.div`
       white-space: nowrap;
       padding: 0.3rem 0.48rem;
       border-radius: 8px;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
-      background: ${({ theme }) => theme.colors.gray2};
+      border: 1px solid ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+      background: ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray2};
       color: ${({ theme }) => theme.colors.gray11};
       font-size: 0.68rem;
       line-height: 1;
@@ -1512,7 +1534,12 @@ const StyledWrapper = styled.div`
   }
 
   .rightRailInner {
-    border-left: 1px solid ${({ theme }) => (theme.scheme === "dark" ? "rgba(148, 163, 184, 0.26)" : theme.colors.gray6)};
+    border-left: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid"
+        ? theme.publicDesign.border
+        : theme.scheme === "dark"
+          ? "rgba(148, 163, 184, 0.26)"
+          : theme.colors.gray6};
     padding: 0.2rem 0 0.2rem 1.4rem;
     background: transparent;
 
@@ -1547,9 +1574,11 @@ const StyledWrapper = styled.div`
     }
 
     .tocDepthToggle {
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
+      border: 1px solid ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
       border-radius: 999px;
-      background: ${({ theme }) => theme.colors.gray2};
+      background: ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray2};
       color: ${({ theme }) => theme.colors.gray10};
       font-size: 0.71rem;
       font-weight: 700;
@@ -1560,7 +1589,8 @@ const StyledWrapper = styled.div`
 
       &:hover {
         color: ${({ theme }) => theme.colors.gray12};
-        border-color: ${({ theme }) => theme.colors.gray8};
+        border-color: ${({ theme }) =>
+          theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray8};
       }
     }
 
@@ -1613,7 +1643,8 @@ const StyledWrapper = styled.div`
 
     button:hover {
       color: ${({ theme }) => theme.colors.gray11};
-      background: ${({ theme }) => theme.colors.gray2};
+      background: ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray2};
     }
 
     button::before {
@@ -1624,14 +1655,15 @@ const StyledWrapper = styled.div`
       bottom: 0.24rem;
       width: 1px;
       opacity: 0;
-      background: ${({ theme }) => theme.colors.accentBorder};
+      background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.accentBorder)};
       transition: opacity 0.15s ease;
     }
 
     button[data-active="true"] {
       color: ${({ theme }) => theme.colors.gray12};
       font-weight: 700;
-      background: ${({ theme }) => theme.colors.accentSurfaceSubtle};
+      background: ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.accentSurfaceSubtle};
     }
 
     button[data-active="true"]::before {
@@ -1696,7 +1728,8 @@ const StyledWrapper = styled.div`
 const BodySection = styled.div`
   margin-top: 0.8rem;
   padding-top: 1.05rem;
-  border-top: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-top: 1px solid ${({ theme }) =>
+    theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
   width: 100%;
   min-width: 0;
 
@@ -1709,9 +1742,10 @@ const BodySection = styled.div`
 const CompactTocSection = styled.section`
   display: none;
   margin-top: 0.2rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border: 1px solid ${({ theme }) =>
+    theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
   border-radius: 14px;
-  background: ${({ theme }) => theme.colors.gray2};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray2)};
   overflow: hidden;
 
   details {
@@ -1758,7 +1792,8 @@ const CompactTocSection = styled.section`
     width: 2rem;
     height: 2rem;
     border-radius: 999px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    border: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
     color: ${({ theme }) => theme.colors.gray10};
     flex-shrink: 0;
     transition: transform 0.16s ease;
@@ -1805,12 +1840,14 @@ const CompactTocSection = styled.section`
   }
 
   button:hover {
-    background: ${({ theme }) => theme.colors.gray3};
+    background: ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray3};
     color: ${({ theme }) => theme.colors.gray12};
   }
 
   button[data-active="true"] {
-    background: ${({ theme }) => theme.colors.gray3};
+    background: ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3};
     color: ${({ theme }) => theme.colors.gray12};
     font-weight: 700;
   }
@@ -1841,8 +1878,12 @@ const MobileSummaryBar = styled.div`
       gap: 0.36rem;
       padding: 0 0.55rem;
       border-radius: 999px;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
-      background: color-mix(in srgb, ${({ theme }) => theme.colors.gray1} 88%, transparent);
+      border: 1px solid ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+      background: ${({ theme }) =>
+        theme.blogDesign === "grid"
+          ? `color-mix(in srgb, ${theme.publicDesign.surface} 88%, transparent)`
+          : `color-mix(in srgb, ${theme.colors.gray1} 88%, transparent)`};
       color: ${({ theme }) => theme.colors.gray11};
       box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
       backdrop-filter: blur(12px);
@@ -1853,9 +1894,11 @@ const MobileSummaryBar = styled.div`
     }
 
     button[data-active="true"] {
-      border-color: ${({ theme }) => theme.colors.accentBorder};
-      background: ${({ theme }) => theme.colors.accentSurfaceSubtle};
-      color: ${({ theme }) => theme.colors.accentLink};
+      border-color: ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.accentBorder};
+      background: ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.accentSurfaceSubtle};
+      color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.accentLink)};
     }
 
     button[data-active="true"][data-tone="danger"] {
@@ -1879,7 +1922,8 @@ const MobileSummaryBar = styled.div`
 const RelatedSection = styled.section`
   margin-top: 0.52rem;
   padding-top: 0.88rem;
-  border-top: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-top: 1px solid ${({ theme }) =>
+    theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
   display: grid;
   gap: 0.72rem;
   content-visibility: auto;
@@ -1945,16 +1989,23 @@ const RelatedSection = styled.section`
     min-width: 0;
     padding: 0.68rem 0.74rem;
     border-radius: 10px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray1};
+    border: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray1)};
     text-decoration: none;
     transition: border-color 0.14s ease-in, background-color 0.14s ease-in, box-shadow 0.14s ease-in;
 
     &:hover {
-      border-color: ${({ theme }) => theme.colors.gray8};
-      background: ${({ theme }) => theme.colors.gray2};
+      border-color: ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray8};
+      background: ${({ theme }) =>
+        theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray2};
       box-shadow: ${({ theme }) =>
-        theme.scheme === "light" ? "0 10px 24px rgba(15, 23, 42, 0.05)" : "none"};
+        theme.blogDesign === "grid"
+          ? "0 12px 26px rgba(0, 0, 0, 0.28)"
+          : theme.scheme === "light"
+            ? "0 10px 24px rgba(15, 23, 42, 0.05)"
+            : "none"};
     }
   }
 
@@ -1965,8 +2016,10 @@ const RelatedSection = styled.section`
     min-height: 24px;
     padding: 0 0.52rem;
     border-radius: 999px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray2};
+    border: 1px solid ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+    background: ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray2};
     color: ${({ theme }) => theme.colors.gray11};
     font-size: 0.7rem;
     font-weight: 800;
@@ -2020,15 +2073,17 @@ const RelatedSkeletonItem = styled.li`
   min-width: 0;
   padding: 0.68rem 0.74rem;
   border-radius: 10px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray1};
+  border: 1px solid ${({ theme }) =>
+    theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray1)};
 
   .titleLine,
   .summaryLine,
   .metaLine {
     display: block;
     border-radius: 999px;
-    background: ${({ theme }) => theme.colors.gray3};
+    background: ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray3};
     animation: related-skeleton-pulse 1.18s ease-in-out infinite;
   }
 

--- a/front/src/routes/Feed/ContactCard.tsx
+++ b/front/src/routes/Feed/ContactCard.tsx
@@ -80,7 +80,7 @@ const StyledContent = styled.div`
   gap: 0.22rem;
   width: 100%;
   padding: 0 0 0.8rem;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-bottom: 1px solid ${({ theme }) => theme.publicDesign.border};
 
   a {
     display: grid;
@@ -97,7 +97,7 @@ const StyledContent = styled.div`
 
     &:hover {
       color: ${({ theme }) => theme.colors.gray12};
-      background: rgba(255, 255, 255, 0.028);
+      background: ${({ theme }) => theme.publicDesign.accentMuted};
     }
 
     .icon {
@@ -108,8 +108,8 @@ const StyledContent = styled.div`
       height: 2rem;
       flex: 0 0 2rem;
       border-radius: 12px;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
-      background: rgba(255, 255, 255, 0.01);
+      border: 1px solid ${({ theme }) => theme.publicDesign.border};
+      background: ${({ theme }) => theme.publicDesign.surfaceElevated};
       color: ${({ theme }) => theme.colors.gray10};
       font-size: 0.98rem;
       line-height: 1;

--- a/front/src/routes/Feed/PostList/PostCard.tsx
+++ b/front/src/routes/Feed/PostList/PostCard.tsx
@@ -26,9 +26,6 @@ const FEED_CARD_SUMMARY_LINES = uiTokens.feed.card.summaryLines
 const FEED_CARD_SUMMARY_LINE_HEIGHT = uiTokens.feed.card.summaryLineHeight
 const FEED_CARD_TITLE_LINE_HEIGHT = uiTokens.feed.card.titleLineHeight
 const FEED_CARD_RADIUS_PX = 4
-const FEED_CARD_SHADOW = "0 8px 20px rgba(2, 6, 23, 0.14)"
-const FEED_CARD_SHADOW_HOVER = "0 18px 34px rgba(2, 6, 23, 0.2)"
-const FEED_CARD_HOVER_TRANSLATE_PX = -8
 const PostCard: React.FC<Props> = ({ data, layout = "regular" }) => {
   const author = data.author?.[0]
   const postPath = toCanonicalPostPath(data.id)
@@ -163,9 +160,13 @@ const StyledWrapper = styled.a`
   max-width: 100%;
   min-width: 0;
   text-decoration: none;
-  --post-card-shadow: ${FEED_CARD_SHADOW};
-  --post-card-shadow-hover: ${FEED_CARD_SHADOW_HOVER};
-  --post-card-translate-y: ${FEED_CARD_HOVER_TRANSLATE_PX}px;
+  --post-card-translate-y: -8px;
+  --post-card-border-color: ${({ theme }) => theme.publicDesign.border};
+  --post-card-border-strong: ${({ theme }) => theme.publicDesign.borderStrong};
+  --post-card-surface: ${({ theme }) => theme.publicDesign.surface};
+  --post-card-surface-elevated: ${({ theme }) => theme.publicDesign.surfaceElevated};
+  --post-card-shadow-current: ${({ theme }) => theme.publicDesign.shadow};
+  --post-card-shadow-hover-current: ${({ theme }) => theme.publicDesign.shadow};
 
   &[data-layout="regular"] {
     content-visibility: auto;
@@ -186,16 +187,16 @@ const StyledWrapper = styled.a`
     display: flex;
     flex-direction: column;
     border-radius: ${FEED_CARD_RADIUS_PX}px;
-    border: ${({ theme }) => `${theme.variables.ui.card.borderWidth}px solid ${theme.colors.gray4}`};
-    background: ${({ theme }) => theme.colors.gray1};
-    box-shadow: var(--post-card-shadow);
+    border: ${({ theme }) => `${theme.variables.ui.card.borderWidth}px solid var(--post-card-border-color)`};
+    background: var(--post-card-surface);
+    box-shadow: var(--post-card-shadow-current);
 
     > .thumbnail {
       position: relative;
       width: 100%;
       max-width: 100%;
       aspect-ratio: 1.92 / 1;
-      background-color: ${({ theme }) => theme.colors.gray4};
+      background-color: var(--post-card-surface-elevated);
       overflow: hidden;
       isolation: isolate;
 
@@ -204,7 +205,7 @@ const StyledWrapper = styled.a`
       }
 
       &.placeholder {
-        background: ${({ theme }) => theme.colors.gray3};
+        background: var(--post-card-surface-elevated);
       }
 
       &::after {
@@ -293,7 +294,7 @@ const StyledWrapper = styled.a`
       > .footer {
         margin-top: auto;
         padding-top: 0.74rem;
-        border-top: 1px solid ${({ theme }) => theme.colors.gray4};
+        border-top: 1px solid var(--post-card-border-color);
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -313,7 +314,7 @@ const StyledWrapper = styled.a`
             overflow: hidden;
             flex: 0 0 auto;
             border: none;
-            background: ${({ theme }) => theme.colors.gray4};
+            background: var(--post-card-surface-elevated);
             display: inline-flex;
             align-items: center;
             justify-content: center;
@@ -371,9 +372,8 @@ const StyledWrapper = styled.a`
     &:hover article,
     &:focus-visible article {
       transform: translateY(${({ theme }) => (theme.scheme === "light" ? "-2px" : "var(--post-card-translate-y)")});
-      box-shadow: ${({ theme }) =>
-        theme.scheme === "light" ? "0 8px 18px rgba(15, 23, 42, 0.06)" : "var(--post-card-shadow-hover)"};
-      border-color: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray5 : theme.colors.gray5)};
+      box-shadow: var(--post-card-shadow-hover-current);
+      border-color: var(--post-card-border-strong);
 
       > .thumbnail img {
         transform: scale(${({ theme }) => (theme.scheme === "light" ? 1.01 : 1.025)});
@@ -386,8 +386,6 @@ const StyledWrapper = styled.a`
   }
 
   @media (max-width: 640px) {
-    --post-card-shadow: ${FEED_CARD_SHADOW};
-    --post-card-shadow-hover: ${FEED_CARD_SHADOW_HOVER};
     --post-card-translate-y: -4px;
 
     article {

--- a/front/src/routes/Feed/ProfileCard.tsx
+++ b/front/src/routes/Feed/ProfileCard.tsx
@@ -57,7 +57,7 @@ const StyledWrapper = styled.div`
   > .content {
     margin-bottom: 2.25rem;
     width: 100%;
-    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+    border-bottom: 1px solid ${({ theme }) => theme.publicDesign.border};
     background: transparent;
     padding: 0 0 1rem;
 
@@ -67,8 +67,8 @@ const StyledWrapper = styled.div`
       margin: 0 auto 1rem;
       border-radius: 50%;
       overflow: hidden;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
-      background: transparent;
+      border: 1px solid ${({ theme }) => theme.publicDesign.border};
+      background: ${({ theme }) => theme.publicDesign.surface};
 
       &:after {
         content: "";

--- a/front/src/routes/Feed/SearchInput.tsx
+++ b/front/src/routes/Feed/SearchInput.tsx
@@ -52,6 +52,11 @@ export default SearchInput
 
 const StyledWrapper = styled.div`
   min-width: 0;
+  --feed-search-border: ${({ theme }) => theme.publicDesign.border};
+  --feed-search-border-strong: ${({ theme }) => theme.publicDesign.borderStrong};
+  --feed-search-surface: ${({ theme }) => theme.publicDesign.surface};
+  --feed-search-surface-elevated: ${({ theme }) => theme.publicDesign.surfaceElevated};
+  --feed-search-accent-muted: ${({ theme }) => theme.publicDesign.accentMuted};
 
   > .field {
     display: flex;
@@ -61,10 +66,9 @@ const StyledWrapper = styled.div`
     min-height: ${FEED_SEARCH_FIELD_MIN_HEIGHT_PX}px;
     padding: 0 0.56rem;
     border-radius: ${({ theme }) => `${theme.variables.ui.button.radius}px`};
-    border: 1px solid ${({ theme }) => theme.colors.gray5};
-    background: ${({ theme }) => theme.colors.gray1};
-    box-shadow: ${({ theme }) =>
-      theme.scheme === "light" ? "0 1px 0 rgba(15, 23, 42, 0.02)" : "none"};
+    border: 1px solid var(--feed-search-border);
+    background: var(--feed-search-surface);
+    box-shadow: 0 0 0 1px var(--feed-search-accent-muted);
     transition: border-color 0.125s ease-in, background-color 0.125s ease-in, box-shadow 0.125s ease-in;
 
     .searchIcon {
@@ -92,7 +96,7 @@ const StyledWrapper = styled.div`
       height: 26px;
       padding: 0 0.52rem;
       border-radius: ${({ theme }) => `${theme.variables.ui.button.radiusPill}px`};
-      border: 1px solid ${({ theme }) => theme.colors.gray5};
+      border: 1px solid var(--feed-search-border);
       background: transparent;
       color: ${({ theme }) => theme.colors.gray10};
       font-size: 0.74rem;
@@ -104,8 +108,8 @@ const StyledWrapper = styled.div`
 
       &:hover {
         color: ${({ theme }) => theme.colors.gray12};
-        border-color: ${({ theme }) => theme.colors.gray6};
-        background: ${({ theme }) => theme.colors.gray3};
+        border-color: var(--feed-search-border-strong);
+        background: var(--feed-search-accent-muted);
       }
 
       @media (max-width: ${FEED_TAG_RAIL_CHIP_MAX_PX}px) {
@@ -151,10 +155,9 @@ const StyledWrapper = styled.div`
   }
 
   > .field:focus-within {
-    border-color: ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray1};
-    box-shadow: ${({ theme }) =>
-      theme.scheme === "light" ? "0 0 0 1px rgba(148, 163, 184, 0.16)" : "none"};
+    border-color: var(--feed-search-border-strong);
+    background: var(--feed-search-surface-elevated);
+    box-shadow: 0 0 0 1px var(--feed-search-accent-muted);
 
     .searchIcon {
       color: ${({ theme }) => theme.colors.gray11};

--- a/front/src/routes/Feed/ServiceCard.tsx
+++ b/front/src/routes/Feed/ServiceCard.tsx
@@ -68,7 +68,7 @@ const StyledContent = styled.div`
   gap: 0.22rem;
   width: 100%;
   padding: 0 0 0.8rem;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-bottom: 1px solid ${({ theme }) => theme.publicDesign.border};
 
   > a {
     display: grid;
@@ -85,7 +85,7 @@ const StyledContent = styled.div`
 
     &:hover {
       color: ${({ theme }) => theme.colors.gray12};
-      background: rgba(255, 255, 255, 0.028);
+      background: ${({ theme }) => theme.publicDesign.accentMuted};
     }
 
     .icon {
@@ -96,8 +96,8 @@ const StyledContent = styled.div`
       height: 2rem;
       flex: 0 0 2rem;
       border-radius: 12px;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
-      background: rgba(255, 255, 255, 0.01);
+      border: 1px solid ${({ theme }) => theme.publicDesign.border};
+      background: ${({ theme }) => theme.publicDesign.surfaceElevated};
       color: ${({ theme }) => theme.colors.gray10};
       font-size: 0.98rem;
       line-height: 1;

--- a/front/src/routes/Feed/TagList.tsx
+++ b/front/src/routes/Feed/TagList.tsx
@@ -201,6 +201,13 @@ export default memo(TagList)
 
 const StyledWrapper = styled.div`
   min-width: 0;
+  --feed-tag-border: ${({ theme }) => theme.publicDesign.border};
+  --feed-tag-border-strong: ${({ theme }) => theme.publicDesign.borderStrong};
+  --feed-tag-hover-border: ${({ theme }) => theme.publicDesign.borderStrong};
+  --feed-tag-surface: ${({ theme }) => theme.publicDesign.surface};
+  --feed-tag-surface-elevated: ${({ theme }) => theme.publicDesign.surfaceElevated};
+  --feed-tag-accent: ${({ theme }) => theme.publicDesign.accent};
+  --feed-tag-accent-muted: ${({ theme }) => theme.publicDesign.accentMuted};
 
   .desktopPanel {
     display: none;
@@ -224,7 +231,7 @@ const StyledWrapper = styled.div`
     letter-spacing: -0.01em;
     line-height: 1.5;
     padding: 0 0 0.42rem;
-    border-bottom: 1px solid ${({ theme }) => theme.colors.gray5};
+    border-bottom: 1px solid var(--feed-tag-border);
     display: inline-flex;
     align-items: center;
     gap: 0.44rem;
@@ -290,7 +297,7 @@ const StyledWrapper = styled.div`
     }
 
     &:focus-visible {
-      outline: 2px solid ${({ theme }) => theme.colors.accentBorder};
+      outline: 2px solid var(--feed-tag-border-strong);
       outline-offset: 1px;
     }
 
@@ -315,7 +322,7 @@ const StyledWrapper = styled.div`
     }
 
     &:focus-visible {
-      outline: 2px solid ${({ theme }) => theme.colors.accentBorder};
+      outline: 2px solid var(--feed-tag-border-strong);
       outline-offset: 2px;
       border-radius: 999px;
     }
@@ -333,7 +340,7 @@ const StyledWrapper = styled.div`
   }
 
   .desktopList button[data-active="true"] .name {
-    color: ${({ theme }) => theme.colors.accentLink};
+    color: var(--feed-tag-accent);
     font-weight: 700;
     text-decoration: none;
   }
@@ -346,7 +353,7 @@ const StyledWrapper = styled.div`
   }
 
   .desktopList button[data-active="true"] .count {
-    color: ${({ theme }) => theme.colors.accentLink};
+    color: var(--feed-tag-accent);
   }
 
   .chipRail {
@@ -405,8 +412,8 @@ const StyledWrapper = styled.div`
       position: absolute;
       inset: 5px 0;
       border-radius: 999px;
-      border: 1px solid ${({ theme }) => theme.colors.gray5};
-      background: ${({ theme }) => theme.colors.gray1};
+      border: 1px solid var(--feed-tag-border);
+      background: var(--feed-tag-surface);
       transition: all 0.125s ease-in;
       z-index: 0;
       pointer-events: none;
@@ -414,22 +421,22 @@ const StyledWrapper = styled.div`
 
     &:hover {
       &::after {
-        border-color: ${({ theme }) => theme.colors.gray7};
-        background: ${({ theme }) => theme.colors.gray2};
+        border-color: var(--feed-tag-hover-border);
+        background: var(--feed-tag-surface-elevated);
       }
     }
 
     &[data-active="true"] {
-      color: ${({ theme }) => theme.colors.accentLink};
+      color: var(--feed-tag-accent);
 
       &::after {
-        border-color: ${({ theme }) => theme.colors.accentBorder};
-        background: ${({ theme }) => theme.colors.gray2};
+        border-color: var(--feed-tag-border-strong);
+        background: var(--feed-tag-accent-muted);
       }
     }
 
     &:focus-visible {
-      outline: 2px solid ${({ theme }) => theme.colors.accentBorder};
+      outline: 2px solid var(--feed-tag-border-strong);
       outline-offset: 1px;
     }
 
@@ -450,7 +457,7 @@ const StyledWrapper = styled.div`
   }
 
   .chipRail button[data-active="true"] .count {
-    color: ${({ theme }) => theme.colors.accentLink};
+    color: var(--feed-tag-accent);
   }
 
   .chipRail .chipToggle {

--- a/front/src/routes/Feed/index.tsx
+++ b/front/src/routes/Feed/index.tsx
@@ -119,7 +119,7 @@ const StyledWrapper = styled.div`
 `
 
 const IntroCard = styled.section`
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray5};
+  border-bottom: 1px solid ${({ theme }) => theme.publicDesign.border};
   padding: 0.28rem 0 0.96rem;
 
   h1 {

--- a/front/src/styles/theme.ts
+++ b/front/src/styles/theme.ts
@@ -38,7 +38,7 @@ export const createPublicDesignTokens = (scheme: SchemeType, blogDesign: BlogDes
     return {
       pageBackgroundColor: "#090909",
       pageBackgroundImage:
-        "linear-gradient(180deg, rgba(84, 14, 14, 0.22) 0%, rgba(9, 9, 9, 0) 34%), repeating-linear-gradient(90deg, rgba(184, 138, 76, 0.055) 0, rgba(184, 138, 76, 0.055) 1px, transparent 1px, transparent 96px)",
+        "linear-gradient(#540e0e38,#0000 34%),repeating-linear-gradient(90deg,#b88a4c0e,#b88a4c0e 1px,#0000 1px,#0000 96px)",
       surface: "#111111",
       surfaceElevated: "#181715",
       border: "rgba(151, 125, 85, 0.28)",
@@ -56,7 +56,7 @@ export const createPublicDesignTokens = (scheme: SchemeType, blogDesign: BlogDes
     pageBackgroundColor: scheme === "light" ? "#f3f5f8" : schemeColors.gray1,
     pageBackgroundImage:
       scheme === "light"
-        ? "radial-gradient(circle at 18% -12%, rgba(37, 99, 235, 0.025), transparent 26%), radial-gradient(circle at 88% 0%, rgba(148, 163, 184, 0.04), transparent 22%)"
+        ? "radial-gradient(circle at 18% -12%,#2563eb06,transparent 26%),radial-gradient(circle at 88% 0%,#94a3b80a,transparent 22%)"
         : "none",
     surface: schemeColors.gray1,
     surfaceElevated: scheme === "light" ? schemeColors.gray2 : schemeColors.gray3,

--- a/front/src/styles/theme.ts
+++ b/front/src/styles/theme.ts
@@ -2,11 +2,26 @@ import { Theme } from "@emotion/react"
 import { Colors, colors } from "./colors"
 import { variables } from "./variables"
 import { zIndexes } from "./zIndexes"
-import { SchemeType } from "src/types"
+import type { BlogDesignType, SchemeType } from "src/types"
+
+export type PublicDesignTokens = {
+  pageBackgroundColor: string
+  pageBackgroundImage: string
+  surface: string
+  surfaceElevated: string
+  border: string
+  borderStrong: string
+  accent: string
+  accentMuted: string
+  textMuted: string
+  shadow: string
+}
 
 declare module "@emotion/react" {
   export interface Theme {
     scheme: SchemeType
+    blogDesign: BlogDesignType
+    publicDesign: PublicDesignTokens
     colors: Colors
     zIndexes: typeof zIndexes
     variables: typeof variables
@@ -15,10 +30,49 @@ declare module "@emotion/react" {
 
 type Options = {
   scheme: SchemeType
+  blogDesign?: BlogDesignType
+}
+
+export const createPublicDesignTokens = (scheme: SchemeType, blogDesign: BlogDesignType): PublicDesignTokens => {
+  if (blogDesign === "grid") {
+    return {
+      pageBackgroundColor: "#090909",
+      pageBackgroundImage:
+        "linear-gradient(180deg, rgba(84, 14, 14, 0.22) 0%, rgba(9, 9, 9, 0) 34%), repeating-linear-gradient(90deg, rgba(184, 138, 76, 0.055) 0, rgba(184, 138, 76, 0.055) 1px, transparent 1px, transparent 96px)",
+      surface: "#111111",
+      surfaceElevated: "#181715",
+      border: "rgba(151, 125, 85, 0.28)",
+      borderStrong: "rgba(190, 143, 75, 0.48)",
+      accent: "#b88a4c",
+      accentMuted: "rgba(184, 138, 76, 0.18)",
+      textMuted: "#a7a29a",
+      shadow: "0 18px 50px rgba(0, 0, 0, 0.42)",
+    }
+  }
+
+  const schemeColors = colors[scheme]
+
+  return {
+    pageBackgroundColor: scheme === "light" ? "#f3f5f8" : schemeColors.gray1,
+    pageBackgroundImage:
+      scheme === "light"
+        ? "radial-gradient(circle at 18% -12%, rgba(37, 99, 235, 0.025), transparent 26%), radial-gradient(circle at 88% 0%, rgba(148, 163, 184, 0.04), transparent 22%)"
+        : "none",
+    surface: schemeColors.gray1,
+    surfaceElevated: scheme === "light" ? schemeColors.gray2 : schemeColors.gray3,
+    border: schemeColors.gray6,
+    borderStrong: schemeColors.gray7,
+    accent: schemeColors.accentControl,
+    accentMuted: schemeColors.accentSurfaceSubtle,
+    textMuted: schemeColors.gray10,
+    shadow: variables.ui.card.shadow,
+  }
 }
 
 export const createTheme = (options: Options): Theme => ({
   scheme: options.scheme,
+  blogDesign: options.blogDesign ?? "legacy",
+  publicDesign: createPublicDesignTokens(options.scheme, options.blogDesign ?? "legacy"),
   colors: colors[options.scheme],
   variables: variables,
   zIndexes: zIndexes,

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -97,3 +97,5 @@ export type TCategories = {
 }
 
 export type SchemeType = "light" | "dark"
+export type BlogDesignType = "legacy" | "grid"
+export type LegacyBlogScheme = "light" | "dark"


### PR DESCRIPTION
## 관련 이슈

close #227

## 작업 배경

- 관리자 프로필 설정에서 공개 블로그 전역 디자인 `legacy | grid`를 저장/발행할 수 있게 했습니다.
- `legacy`에서만 light/dark scheme을 적용하고, `grid`는 dark presentation으로 고정했습니다.
- 공개 홈/피드/About/상세는 visitor-local 선택 UI 없이 published admin profile 기준으로 렌더합니다.

## 작업 내용

- member admin profile/workspace 계약에 `blogDesign`, `legacyBlogScheme`을 추가하고 legacy/dark fallback 정규화를 반영했습니다.
- 관리자 프로필 화면에 전역 공개 디자인 설정과 legacy 전용 scheme control을 추가했습니다.
- 공개 RootLayout/theme resolver와 grid surface tokens를 추가해 Feed/About/Detail/Header 표면만 변경하고 본문 타이포 scale/line-height/readable width/font는 유지했습니다.
- SSG/SSR static fallback seed가 공개 adminProfile refetch를 막지 않도록 source를 전달했습니다.
- 운영 계약 문서와 Playwright/source 계약 테스트를 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back test`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`
  - `git diff --check`
  - `CURRENT_TASK_SLUG=grimdark-blog-skin bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 공개 grid 디자인은 published adminProfile에 의존하므로, 배포 직후 캐시/ISR 타이밍에 따라 기존 legacy 화면이 짧게 보일 수 있습니다.
- 롤백 방법: PR revert 또는 관리자 프로필에서 공개 디자인을 `legacy`로 발행합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
