### PR TITLE
[Fix] Grimdark bundle budget 회귀 복구

### DIFF
--- a/front/src/styles/theme.ts
+++ b/front/src/styles/theme.ts
@@ -13,7 +13,6 @@ export type PublicDesignTokens = {
   borderStrong: string
   accent: string
   accentMuted: string
-  textMuted: string
   shadow: string
 }
 
@@ -38,15 +37,14 @@ export const createPublicDesignTokens = (scheme: SchemeType, blogDesign: BlogDes
     return {
       pageBackgroundColor: "#090909",
       pageBackgroundImage:
-        "linear-gradient(#540e0e38,#0000 34%),repeating-linear-gradient(90deg,#b88a4c0e,#b88a4c0e 1px,#0000 1px,#0000 96px)",
+        "linear-gradient(#540e0e38,#0000 34%),repeating-linear-gradient(90deg,#b88a4c0e 0 1px,#0000 1px 96px)",
       surface: "#111111",
       surfaceElevated: "#181715",
-      border: "rgba(151, 125, 85, 0.28)",
-      borderStrong: "rgba(190, 143, 75, 0.48)",
+      border: "#977d5547",
+      borderStrong: "#be8f4b7a",
       accent: "#b88a4c",
-      accentMuted: "rgba(184, 138, 76, 0.18)",
-      textMuted: "#a7a29a",
-      shadow: "0 18px 50px rgba(0, 0, 0, 0.42)",
+      accentMuted: "#b88a4c2e",
+      shadow: "0 18px 50px #0000006b",
     }
   }
 
@@ -56,7 +54,7 @@ export const createPublicDesignTokens = (scheme: SchemeType, blogDesign: BlogDes
     pageBackgroundColor: scheme === "light" ? "#f3f5f8" : schemeColors.gray1,
     pageBackgroundImage:
       scheme === "light"
-        ? "radial-gradient(circle at 18% -12%,#2563eb06,transparent 26%),radial-gradient(circle at 88% 0%,#94a3b80a,transparent 22%)"
+        ? "radial-gradient(circle at 18% -12%,#2563eb06,#0000 26%),radial-gradient(circle at 88% 0,#94a3b80a,#0000 22%)"
         : "none",
     surface: schemeColors.gray1,
     surfaceElevated: scheme === "light" ? schemeColors.gray2 : schemeColors.gray3,
@@ -64,7 +62,6 @@ export const createPublicDesignTokens = (scheme: SchemeType, blogDesign: BlogDes
     borderStrong: schemeColors.gray7,
     accent: schemeColors.accentControl,
     accentMuted: schemeColors.accentSurfaceSubtle,
-    textMuted: schemeColors.gray10,
     shadow: variables.ui.card.shadow,
   }
 }


### PR DESCRIPTION
## 관련 이슈

close #229

## 작업 배경

- PR #228 merge 후 main CI가 `/` raw bundle-size strict budget에서 0.1KB 차이로 실패한 문제를 복구합니다.
- grid 디자인의 시각 의도와 본문 타이포는 유지하고 public design token 문자열만 압축해 CI 환경 차이를 흡수할 예산 여유를 확보했습니다.

## 작업 내용

- `front/src/styles/theme.ts`에서 미사용 public token `textMuted`를 제거했습니다.
- grid/legacy background gradient와 rgba token을 동등한 짧은 CSS 표현으로 정리했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs` (`/` raw 525811 / 525938 bytes, headroom 127B)
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/mobile-layout.spec.ts e2e/perf.spec.ts --workers=1` (17 passed)
  - `git diff --check`
  - `CURRENT_TASK_SLUG=grimdark-bundle-budget-fix bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: bundle budget 여유 확보를 위해 CSS 표현을 압축했으므로 구형 브라우저 CSS 해석 차이가 있을 수 있습니다. Playwright Chromium 기준 공개 핵심 화면과 perf 회귀는 통과했습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 이전 token 문자열로 복구됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
