### PR TITLE
[Fix] 메인 피드 카드 hover clipping 복구

### DIFF
--- a/front/e2e/perf.spec.ts
+++ b/front/e2e/perf.spec.ts
@@ -1261,6 +1261,55 @@ test("메인 레이아웃은 velog형 width tier(1728/1376/1024/100%)를 유지�
   await expect(page.locator(".rt")).toBeHidden()
 })
 
+test("피드 카드 hover lift는 content-visibility clipping 없이 상단을 그릴 수 있다", async ({ page }) => {
+  await mockFeedEndpoints(page)
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await gotoForPerf(page, "/")
+
+  const firstRegularCard = page.locator('a[data-layout="regular"]').first()
+  await expect(firstRegularCard).toBeVisible()
+
+  const initialMetrics = await firstRegularCard.evaluate((card) => {
+    const article = card.querySelector("article")
+    if (!(article instanceof HTMLElement)) {
+      throw new Error("regular feed card article을 찾지 못했습니다.")
+    }
+
+    const cardStyle = window.getComputedStyle(card as HTMLElement)
+    const articleStyle = window.getComputedStyle(article)
+    return {
+      cardContentVisibility: cardStyle.contentVisibility,
+      articleTransform: articleStyle.transform,
+    }
+  })
+
+  expect(initialMetrics.cardContentVisibility).toBe("visible")
+  expect(initialMetrics.articleTransform).toBe("none")
+
+  await firstRegularCard.hover()
+  await page.waitForTimeout(320)
+
+  const hoverMetrics = await firstRegularCard.evaluate((card) => {
+    const article = card.querySelector("article")
+    if (!(article instanceof HTMLElement)) {
+      throw new Error("regular feed card article을 찾지 못했습니다.")
+    }
+
+    const cardRect = (card as HTMLElement).getBoundingClientRect()
+    const articleRect = article.getBoundingClientRect()
+    const articleStyle = window.getComputedStyle(article)
+
+    return {
+      cardTop: Number(cardRect.top.toFixed(2)),
+      articleTop: Number(articleRect.top.toFixed(2)),
+      articleTransform: articleStyle.transform,
+    }
+  })
+
+  expect(hoverMetrics.articleTransform).not.toBe("none")
+  expect(hoverMetrics.articleTop).toBeLessThan(hoverMetrics.cardTop)
+})
+
 test("메인 태그 레일은 1200/1201 전환과 넓은 데스크톱에서 안전하게 전환된다", async ({ page }) => {
   await mockFeedEndpoints(page)
 

--- a/front/src/routes/Feed/PostList/PostCard.tsx
+++ b/front/src/routes/Feed/PostList/PostCard.tsx
@@ -168,11 +168,6 @@ const StyledWrapper = styled.a`
   --post-card-shadow-current: ${({ theme }) => theme.publicDesign.shadow};
   --post-card-shadow-hover-current: ${({ theme }) => theme.publicDesign.shadow};
 
-  &[data-layout="regular"] {
-    content-visibility: auto;
-    contain-intrinsic-size: 1px 420px;
-  }
-
   &:focus-visible {
     outline: 0;
   }


### PR DESCRIPTION
## 관련 이슈

close #231

## 작업 배경

- 메인 피드 regular 카드 hover에서 상단과 그림자가 잘리는 문제를 복구합니다.
- 원인은 regular 카드 wrapper의 `content-visibility:auto`가 hover `translateY(-8px)` 페인트 영역을 clipping하는 것이었습니다.
- 배포 경로는 작업 브랜치 -> PR to `main` -> `main` merge -> 홈서버 자동 배포입니다.

## 작업 내용

- regular 피드 카드 wrapper의 `content-visibility`/`contain-intrinsic-size` 설정을 제거해 hover lift와 thumbnail zoom이 잘리지 않게 했습니다.
- hover 상태에서 wrapper 밖으로 올라간 article top을 검증하는 Playwright 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --grep "피드 카드 hover" --workers=1` => 1 passed
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/mobile-layout.spec.ts e2e/perf.spec.ts --workers=1` => 18 passed
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` => 42 passed
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `git diff --check`
  - `CURRENT_TASK_SLUG=feed-card-hover-clipping-fix bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: `content-visibility` 제거로 아주 긴 피드에서 카드 렌더 최적화 효과가 일부 줄 수 있습니다. 관련 feed scroll/runtime budget은 perf 회귀 테스트로 확인했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `fix(frontend): feed card hover clipping 복구`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
