### PR TITLE
[Fix] 블로그 디자인 공개 적용 UX 명확화

### DIFF
--- a/front/e2e/admin-profile-state.spec.ts
+++ b/front/e2e/admin-profile-state.spec.ts
@@ -155,6 +155,19 @@ test.describe("admin profile state contract", () => {
     expect(source).toContain('draft.blogDesign === "legacy"')
   })
 
+  test("profile 디자인 공개 적용은 primary action에서 저장 후 publish까지 처리한다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/profile.tsx"), "utf8")
+
+    expect(source).toContain("const validateDraftBeforePersistence = useCallback(")
+    expect(source).toContain("const saveWorkspaceDraft = useCallback(")
+    expect(source).toContain("const shouldPublishWorkspace = workspaceForPublish?.dirtyFromPublished ?? hasPublishedDiff")
+    expect(source).toContain('hasUnsavedChanges ? "저장 후 공개 적용" : "공개 적용"')
+    expect(source).toContain("초안 저장")
+    expect(source).toContain("편집 중")
+    expect(source).toContain("현재 공개")
+    expect(source).not.toContain("로컬 변경 사항을 먼저 임시 저장한 뒤 공개할 수 있습니다.")
+  })
+
   test("profile workspace 정규화는 structured 프로젝트가 있으면 legacy 프로젝트 상세 블록을 제거한다", () => {
     const normalized = normalizeProfileWorkspaceContent({
       profileImageUrl: "",

--- a/front/src/pages/admin/profile.tsx
+++ b/front/src/pages/admin/profile.tsx
@@ -662,6 +662,57 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
     [queryClient, setMe]
   )
 
+  const validateDraftBeforePersistence = useCallback(() => {
+    const serviceValidationError = validateLinkInputs("service", "서비스", draft.serviceLinks)
+    if (serviceValidationError) {
+      setWorkspaceNotice({ tone: "error", text: serviceValidationError })
+      setActiveSection("links")
+      setLinkTab("service")
+      return false
+    }
+
+    const contactValidationError = validateLinkInputs("contact", "연락 채널", draft.contactLinks)
+    if (contactValidationError) {
+      setWorkspaceNotice({ tone: "error", text: contactValidationError })
+      setActiveSection("links")
+      setLinkTab("contact")
+      return false
+    }
+
+    const normalizedDisplayName = displayNameInput.trim()
+    if (hasDisplayNameDirty && (normalizedDisplayName.length < 2 || normalizedDisplayName.length > 30)) {
+      setWorkspaceNotice({ tone: "error", text: "계정 이름은 2자 이상 30자 이하로 입력해주세요." })
+      setActiveSection("identity")
+      return false
+    }
+
+    return true
+  }, [displayNameInput, draft.contactLinks, draft.serviceLinks, hasDisplayNameDirty])
+
+  const buildDraftPayload = useCallback(
+    () =>
+      normalizeProfileWorkspaceContent({
+        ...draft,
+        serviceLinks: toPayloadLinks("service", draft.serviceLinks, DEFAULT_SERVICE_ITEM_ICON),
+        contactLinks: toPayloadLinks("contact", draft.contactLinks, DEFAULT_CONTACT_ITEM_ICON),
+      }),
+    [draft]
+  )
+
+  const saveWorkspaceDraft = useCallback(async () => {
+    if (!sessionMember?.id) {
+      throw new Error("관리자 세션을 확인할 수 없습니다.")
+    }
+
+    const normalizedDraft = buildDraftPayload()
+    return saveProfileCardWithConflictRetry(() =>
+      apiFetch<ProfileWorkspaceResponse>(`/member/api/v1/adm/members/${sessionMember.id}/profileWorkspace/draft`, {
+        method: "PUT",
+        body: JSON.stringify(normalizedDraft),
+      })
+    )
+  }, [buildDraftPayload, sessionMember?.id])
+
   const updateDraft = useCallback(
     (
       field: keyof ProfileWorkspaceContent,
@@ -1095,32 +1146,11 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
 
   const handleSaveDraft = useCallback(async () => {
     if (!sessionMember?.id) return
-
-    const serviceValidationError = validateLinkInputs("service", "서비스", draft.serviceLinks)
-    if (serviceValidationError) {
-      setWorkspaceNotice({ tone: "error", text: serviceValidationError })
-      setActiveSection("links")
-      setLinkTab("service")
-      return
-    }
-
-    const contactValidationError = validateLinkInputs("contact", "연락 채널", draft.contactLinks)
-    if (contactValidationError) {
-      setWorkspaceNotice({ tone: "error", text: contactValidationError })
-      setActiveSection("links")
-      setLinkTab("contact")
-      return
-    }
+    if (!validateDraftBeforePersistence()) return
 
     const normalizedDisplayName = displayNameInput.trim()
     const shouldSaveDisplayName = hasDisplayNameDirty
     const shouldSaveWorkspace = hasWorkspaceUnsavedChanges
-
-    if (shouldSaveDisplayName && (normalizedDisplayName.length < 2 || normalizedDisplayName.length > 30)) {
-      setWorkspaceNotice({ tone: "error", text: "계정 이름은 2자 이상 30자 이하로 입력해주세요." })
-      setActiveSection("identity")
-      return
-    }
 
     if (!shouldSaveDisplayName && !shouldSaveWorkspace) {
       setWorkspaceNotice({ tone: "idle", text: "이미 최신 상태입니다." })
@@ -1142,17 +1172,7 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
       })
 
       if (shouldSaveWorkspace) {
-        const normalizedDraft = normalizeProfileWorkspaceContent({
-          ...draft,
-          serviceLinks: toPayloadLinks("service", draft.serviceLinks, DEFAULT_SERVICE_ITEM_ICON),
-          contactLinks: toPayloadLinks("contact", draft.contactLinks, DEFAULT_CONTACT_ITEM_ICON),
-        })
-        const nextWorkspace = await saveProfileCardWithConflictRetry(() =>
-          apiFetch<ProfileWorkspaceResponse>(`/member/api/v1/adm/members/${sessionMember.id}/profileWorkspace/draft`, {
-            method: "PUT",
-            body: JSON.stringify(normalizedDraft),
-          })
-        )
+        const nextWorkspace = await saveWorkspaceDraft()
         applyWorkspaceState(nextWorkspace)
         workspaceSaved = true
       }
@@ -1191,49 +1211,81 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
   }, [
     applyWorkspaceState,
     displayNameInput,
-    draft,
     hasDisplayNameDirty,
     hasWorkspaceUnsavedChanges,
     persistDisplayName,
+    saveWorkspaceDraft,
     sessionMember?.id,
+    validateDraftBeforePersistence,
   ])
 
   const handlePublish = useCallback(async () => {
     if (!sessionMember?.id) return
-    if (hasUnsavedChanges) {
-      setWorkspaceNotice({ tone: "error", text: "로컬 변경 사항을 먼저 임시 저장한 뒤 공개할 수 있습니다." })
-      return
-    }
-    if (!hasPublishedDiff) {
-      setWorkspaceNotice({ tone: "idle", text: "이미 공개본과 임시 저장본이 같습니다." })
+    if (!validateDraftBeforePersistence()) return
+
+    const normalizedDisplayName = displayNameInput.trim()
+    const shouldSaveDisplayName = hasDisplayNameDirty
+    const shouldSaveWorkspace = hasWorkspaceUnsavedChanges
+    const shouldApplyWorkspace = shouldSaveWorkspace || hasPublishedDiff
+
+    if (!shouldSaveDisplayName && !shouldApplyWorkspace) {
+      setWorkspaceNotice({ tone: "idle", text: "이미 공개본과 편집 중인 내용이 같습니다." })
       return
     }
 
+    let workspaceForPublish: ProfileWorkspaceResponse | null = null
+
     try {
       setLoadingKey("publish")
-      setWorkspaceNotice({ tone: "loading", text: "공개 중..." })
-      const nextWorkspace = await apiFetch<ProfileWorkspaceResponse>(
-        `/member/api/v1/adm/members/${sessionMember.id}/profileWorkspace/publish`,
-        {
-          method: "POST",
-        }
-      )
-      applyWorkspaceState(nextWorkspace)
-      syncPublishedAdminProfileCache(normalizeProfileWorkspaceContent(nextWorkspace.published))
-      setPreviewMode("published")
-      setWorkspaceNotice({ tone: "success", text: "지금 공개하기가 완료되었습니다. 공개 사이트가 최신 상태를 사용합니다." })
+      setWorkspaceNotice({
+        tone: "loading",
+        text: shouldSaveWorkspace ? "초안을 저장한 뒤 공개 적용 중..." : "공개 적용 중...",
+      })
+
+      if (shouldSaveWorkspace) {
+        workspaceForPublish = await saveWorkspaceDraft()
+      }
+
+      if (shouldSaveDisplayName) {
+        await persistDisplayName(sessionMember.id, normalizedDisplayName)
+      }
+
+      const shouldPublishWorkspace = workspaceForPublish?.dirtyFromPublished ?? hasPublishedDiff
+      if (shouldPublishWorkspace) {
+        const nextWorkspace = await apiFetch<ProfileWorkspaceResponse>(
+          `/member/api/v1/adm/members/${sessionMember.id}/profileWorkspace/publish`,
+          {
+            method: "POST",
+          }
+        )
+        applyWorkspaceState(nextWorkspace)
+        syncPublishedAdminProfileCache(normalizeProfileWorkspaceContent(nextWorkspace.published))
+        setPreviewMode("published")
+        setWorkspaceNotice({ tone: "success", text: "공개 적용이 완료되었습니다. 공개 사이트가 최신 설정을 사용합니다." })
+        return
+      }
+
+      if (workspaceForPublish) {
+        applyWorkspaceState(workspaceForPublish)
+      }
+      setWorkspaceNotice({ tone: "success", text: "변경 사항을 저장했습니다." })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      setWorkspaceNotice({ tone: "error", text: `공개 실패: ${message}` })
+      setWorkspaceNotice({ tone: "error", text: `공개 적용 실패: ${message}` })
     } finally {
       setLoadingKey("")
     }
   }, [
     applyWorkspaceState,
+    displayNameInput,
+    hasDisplayNameDirty,
     hasPublishedDiff,
-    hasUnsavedChanges,
+    hasWorkspaceUnsavedChanges,
+    persistDisplayName,
+    saveWorkspaceDraft,
     sessionMember?.id,
     syncPublishedAdminProfileCache,
+    validateDraftBeforePersistence,
   ])
 
   useEffect(() => {
@@ -1258,8 +1310,10 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
   const pageToasts = [workspaceNotice, imageNotice].filter(
     (notice) => notice.tone !== "idle" && notice.text.trim().length > 0
   )
-  const canPublish = !hasUnsavedChanges && hasPublishedDiff && loadingKey !== "publish" && loadingKey !== "save"
+  const canPublish = (hasUnsavedChanges || hasPublishedDiff) && loadingKey !== "publish" && loadingKey !== "save"
   const canSave = hasUnsavedChanges && loadingKey !== "save"
+  const publishActionLabel =
+    loadingKey === "publish" ? "공개 적용 중..." : hasUnsavedChanges ? "저장 후 공개 적용" : "공개 적용"
   const activeSectionState = sectionStateMap[activeSection]
   const renderActiveSection = () => {
     switch (activeSection) {
@@ -1977,10 +2031,10 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
           <EditorActionDock>
             <AdminWorkspaceActionDockInner>
               <DockSecondaryButton type="button" disabled={!canSave} onClick={() => void handleSaveDraft()}>
-                {loadingKey === "save" ? "저장 중..." : "임시 저장"}
+                {loadingKey === "save" ? "저장 중..." : "초안 저장"}
               </DockSecondaryButton>
               <DockPrimaryButton type="button" disabled={!canPublish} onClick={() => void handlePublish()}>
-                {loadingKey === "publish" ? "공개 중..." : "지금 공개하기"}
+                {publishActionLabel}
               </DockPrimaryButton>
             </AdminWorkspaceActionDockInner>
           </EditorActionDock>
@@ -1999,14 +2053,14 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
                     data-active={previewMode === "draft"}
                     onClick={() => setPreviewMode("draft")}
                   >
-                    초안
+                    편집 중
                   </SegmentButton>
                   <SegmentButton
                     type="button"
                     data-active={previewMode === "published"}
                     onClick={() => setPreviewMode("published")}
                   >
-                    공개본
+                    현재 공개
                   </SegmentButton>
                 </SegmentedControl>
                 <PreviewToggleButton


### PR DESCRIPTION
## 관련 이슈

close #233

## 작업 배경

- 블로그 디자인 도입 작업 상태를 확인했고, 핵심 기능 PR #228, bundle 회귀 PR #230, hover clipping PR #232는 모두 `main`에 병합된 상태입니다.
- 남은 문제는 디자인 선택 자체가 draft만 바꾸는데 `지금 공개하기`가 저장 전 비활성이라 관리자가 공개 적용 경로를 이해하기 어려운 UX였습니다.
- 이 PR은 디자인 선택 후 primary action 한 번으로 초안 저장과 공개 적용을 이어서 처리합니다.

## 작업 내용

- `/admin/profile` primary action을 `저장 후 공개 적용` / `공개 적용`으로 정리하고, 저장되지 않은 디자인 변경도 primary action에서 draft 저장 후 publish까지 실행되게 했습니다.
- secondary action 문구를 `초안 저장`으로 바꿔 공개 반영과 구분했습니다.
- preview 토글을 `편집 중` / `현재 공개`로 바꿔 현재 보고 있는 상태를 명확히 했습니다.
- admin profile state 회귀 테스트에 디자인 공개 적용 계약을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --grep "디자인" --workers=1` => 3 passed
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1` => 9 passed
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` => 42 passed
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `git diff --check`
  - `CURRENT_TASK_SLUG=blog-design-publish-ux-fix bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: primary action이 draft 저장과 publish를 연속 호출하므로 기존에 publish 전 별도 초안 확인을 기대하던 사용자는 `초안 저장`을 선택해야 합니다.
- 롤백 방법: 이 PR의 단일 커밋 `fix(frontend): blog design publish UX 명확화`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
