### PR TITLE
[Fix] Backend profile contract 배포 경로 복구

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,18 @@ on:
       - completed
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      force_backend_deploy:
+        description: "Build and deploy the backend image even when changed-file detection would skip it."
+        required: false
+        default: true
+        type: boolean
+      force_front_live_verify:
+        description: "Run live frontend verification after deploy target calculation."
+        required: false
+        default: true
+        type: boolean
 
 concurrency:
   group: homeserver-deploy-main
@@ -25,10 +37,17 @@ jobs:
     permissions:
       contents: read
     if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      ) ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        github.ref == 'refs/heads/main'
+      )
     outputs:
       image_tag: ${{ steps.meta.outputs.image_tag }}
       image_ref: ${{ steps.meta.outputs.image_ref }}
@@ -41,13 +60,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
 
       - name: Calculate deploy targets and image tags
         id: meta
         env:
-          DEPLOY_SHA_INPUT: ${{ github.event.workflow_run.head_sha }}
+          DEPLOY_SHA_INPUT: ${{ github.event.workflow_run.head_sha || github.sha }}
+          FORCE_BACKEND_DEPLOY_INPUT: ${{ github.event.inputs.force_backend_deploy || 'false' }}
+          FORCE_FRONT_LIVE_VERIFY_INPUT: ${{ github.event.inputs.force_front_live_verify || 'false' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -88,6 +109,15 @@ jobs:
             if echo "${CHANGED_FILES}" | grep -Eq "${FRONT_LIVE_VERIFY_PATHS_PATTERN}"; then
               FRONT_LIVE_VERIFY="true"
             fi
+          fi
+
+          if [ "${FORCE_BACKEND_DEPLOY_INPUT}" = "true" ]; then
+            BACKEND_DEPLOY="true"
+            FRONT_LIVE_VERIFY="true"
+            CHANGE_SOURCE="${CHANGE_SOURCE}+manual-force-backend"
+          elif [ "${FORCE_FRONT_LIVE_VERIFY_INPUT}" = "true" ]; then
+            FRONT_LIVE_VERIFY="true"
+            CHANGE_SOURCE="${CHANGE_SOURCE}+manual-force-front-live-verify"
           fi
 
           echo "deploy_target_source=${CHANGE_SOURCE}"


### PR DESCRIPTION
## 관련 이슈

close #233

## 작업 배경

- PR #234 merge 후에도 live 공개 화면이 grid를 반영하지 않는 원인은 Home Server backend deploy가 skipped 되어 live API가 `blogDesign`/`legacyBlogScheme`를 반환하지 않는 상태였기 때문입니다.
- 배포 워크플로에 main 전용 수동 backend deploy fallback을 추가해, changed-file detection이 skip한 경우에도 backend profile contract를 재배포할 수 있게 합니다.

## 작업 내용

- `Deploy to Home Server`에 `workflow_dispatch` 입력을 추가했습니다.
- manual dispatch는 `main` ref에서만 deploy job이 진행되도록 제한했습니다.
- 수동 backend 강제 배포 시 backend image build/deploy와 live frontend verification을 함께 켜도록 deploy target 계산을 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml"); puts "yaml ok"'`
  - `CURRENT_TASK_SLUG=blog-design-publish-ux-fix bash tools/guards/current-task-preflight.sh`
  - `curl https://api.aquilaxk.site/member/api/v1/members/adminProfile`에서 live API에 `blogDesign`/`legacyBlogScheme`가 없는 상태 확인
  - main deploy `25836486660`에서 `buildAndPush`/`blueGreenDeploy` skipped 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: workflow_dispatch를 잘못 실행하면 backend deploy가 의도보다 자주 실행될 수 있습니다. 이를 막기 위해 `main` ref에서만 job이 진행되도록 제한했습니다.
- 롤백 방법: 이 PR을 revert하면 기존 workflow_run 기반 deploy target 계산으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
