### PR TITLE
[Fix] Grid 디자인 전페이지 적용 확장

### DIFF
--- a/front/e2e/mobile-layout.spec.ts
+++ b/front/e2e/mobile-layout.spec.ts
@@ -15,7 +15,7 @@ test.use({
 
 const readSourceFile = (sourcePath: string) => readFileSync(path.resolve(__dirname, "..", sourcePath), "utf8")
 
-test("grid design은 공개 화면 토큰만 사용하고 article typography를 변경하지 않는다", () => {
+test("grid design은 전 사용자-facing 화면 토큰을 사용하고 article typography를 변경하지 않는다", () => {
   const publicSurfaceSources = [
     "src/layouts/RootLayout/Header/index.tsx",
     "src/layouts/RootLayout/Header/Logo.tsx",
@@ -40,19 +40,33 @@ test("grid design은 공개 화면 토큰만 사용하고 article typography를 
   const adminShellSource = readSourceFile("src/routes/Admin/AdminShell.tsx")
   const adminToolsSource = readSourceFile("src/pages/admin/tools.tsx")
   const adminDashboardSource = readSourceFile("src/pages/admin/dashboard.tsx")
+  const authShellSource = readSourceFile("src/components/auth/AuthShell.tsx")
+  const errorSource = readSourceFile("src/routes/Error/index.tsx")
+  const editorComposeSource = readSourceFile("src/routes/Admin/EditorStudioComposeWritingSurface.tsx")
+  const editorDedicatedSource = readSourceFile("src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx")
+  const editorPreviewSource = readSourceFile("src/routes/Admin/EditorActualPreviewPage.tsx")
 
   expect(themeSource).toContain('blogDesign === "grid"')
+  expect(themeSource).toContain("#101214")
+  expect(themeSource).toContain("#171a1d")
+  expect(themeSource).toContain("#c2a35b")
   expect(themeSource).toContain("readableSurface")
   expect(themeSource).toContain("operationSurface")
   expect(themeSource).toContain("operationSurfaceElevated")
   expect(rootLayoutSource).toContain("isDesignAwareRoute")
-  expect(rootLayoutSource).toContain('router.pathname.startsWith("/admin")')
+  expect(rootLayoutSource).toContain('!router.pathname.startsWith("/_qa")')
+  expect(rootLayoutSource).toContain("showHeaderThemeToggle")
   expect(rootLayoutSource).toContain("resolvePublicBlogAppearance(isDesignAwareRoute ? adminProfile : null)")
   expect(adminSurfaceSource).toContain("theme.publicDesign.operationSurface")
   expect(adminSurfaceSource).toContain("theme.publicDesign.operationSurfaceElevated")
   expect(adminShellSource).toContain("theme.publicDesign.operationSurface")
   expect(adminToolsSource).toContain("theme.publicDesign.operationSurface")
   expect(adminDashboardSource).toContain("theme.publicDesign.operationSurface")
+  expect(authShellSource).toContain("theme.publicDesign.readableSurface")
+  expect(errorSource).toContain("theme.publicDesign.readableSurface")
+  expect(editorComposeSource).toContain("theme.publicDesign.readableSurface")
+  expect(editorDedicatedSource).toContain("theme.publicDesign.readableSurface")
+  expect(editorPreviewSource).toContain("theme.publicDesign.readableSurface")
   for (const [sourcePath, source] of publicSurfaceSources) {
     expect(source, sourcePath).toContain("theme.publicDesign")
   }

--- a/front/e2e/perf.spec.ts
+++ b/front/e2e/perf.spec.ts
@@ -604,22 +604,6 @@ const applySchemePreference = async (page: Page, scheme: "light" | "dark") => {
   ])
 }
 
-const waitForSchemeReady = async (page: Page, scheme: "light" | "dark") => {
-  const expectedToggleLabel = scheme === "light" ? "다크 모드로 전환" : "라이트 모드로 전환"
-  await expect
-    .poll(
-      async () =>
-        page.evaluate(() => {
-          const toggle = document.querySelector('button[aria-label*="모드로 전환"]')
-          return toggle?.getAttribute("aria-label") ?? null
-        }),
-      {
-        timeout: 8000,
-      }
-    )
-    .toBe(expectedToggleLabel)
-}
-
 const getThemeSurfaceFingerprint = async (page: Page) =>
   page.evaluate(() => {
     const readStyle = (selector: string, property: keyof CSSStyleDeclaration) => {
@@ -1605,7 +1589,7 @@ test("핵심 화면 레이아웃 스냅샷(desktop/iPhone15/iPad mini)을 유지
   }
 })
 
-test("public 핵심 화면은 adminProfile grid 서피스 계층을 유지하고 운영 화면은 visitor scheme을 유지한다", async ({ page }) => {
+test("public/auth 핵심 화면은 adminProfile grid 서피스 계층을 유지한다", async ({ page }) => {
   test.setTimeout(60_000)
   await mockFeedEndpoints(page, {
     adminProfile: {
@@ -1623,7 +1607,7 @@ test("public 핵심 화면은 adminProfile grid 서피스 계층을 유지하고
     { route: "/posts/991", viewport: { width: 393, height: 852 } },
     { route: "/posts/991", viewport: { width: 768, height: 1024 } },
   ] as const
-  const operationalScenarios = [
+  const authScenarios = [
     { route: "/login", viewport: { width: 1440, height: 900 } },
     { route: "/login", viewport: { width: 393, height: 852 } },
     { route: "/login", viewport: { width: 768, height: 1024 } },
@@ -1639,21 +1623,21 @@ test("public 핵심 화면은 adminProfile grid 서피스 계층을 유지하고
       .poll(async () => (await getThemeSurfaceFingerprint(page)).bodyBg, {
         timeout: 8000,
       })
-      .toBe("rgb(9, 9, 9)")
+      .toBe("rgb(16, 18, 20)")
 
     const fingerprint = await getThemeSurfaceFingerprint(page)
 
     expect(fingerprint.route).toBe(scenario.route)
     expect(fingerprint.themeToggleLabel).toBeNull()
-    expect(fingerprint.bodyBg).toBe("rgb(9, 9, 9)")
+    expect(fingerprint.bodyBg).toBe("rgb(16, 18, 20)")
     expect(fingerprint.headerBg).not.toBeNull()
     expect(fingerprint.headerBg).not.toBe(fingerprint.bodyBg)
 
     if (scenario.route === "/") {
-      expect(fingerprint.searchBg).toBe("rgb(16, 16, 15)")
-      expect(fingerprint.searchBorder).toBe("rgba(201, 154, 74, 0.24)")
-      expect(fingerprint.cardBg).toBe("rgb(16, 16, 15)")
-      expect(fingerprint.cardBorder).toBe("rgba(201, 154, 74, 0.24)")
+      expect(fingerprint.searchBg).toBe("rgb(23, 26, 29)")
+      expect(fingerprint.searchBorder).toBe("rgba(109, 90, 53, 0.39)")
+      expect(fingerprint.cardBg).toBe("rgb(23, 26, 29)")
+      expect(fingerprint.cardBorder).toBe("rgba(109, 90, 53, 0.39)")
     }
 
     if (scenario.route === "/posts/991") {
@@ -1662,52 +1646,22 @@ test("public 핵심 화면은 adminProfile grid 서피스 계층을 유지하고
     }
   }
 
-  for (const scheme of ["dark", "light"] as const) {
-    for (const scenario of operationalScenarios) {
-      await applySchemePreference(page, scheme)
-      await page.setViewportSize(scenario.viewport)
-      await gotoForPerf(page, scenario.route)
-      await waitForSchemeReady(page, scheme)
-      await page.waitForTimeout(120)
-
-      const fingerprint = await getThemeSurfaceFingerprint(page)
-      const expected = {
-        dark: {
-          bodyBg: "rgb(18, 18, 18)",
-          headerBgChannel: "18, 18, 18",
-          searchBg: "rgb(18, 18, 18)",
-          searchBorder: "rgb(45, 45, 45)",
-          cardBg: "rgb(18, 18, 18)",
-          cardBorder: "rgb(38, 38, 38)",
-          authShellBg: "rgb(18, 18, 18)",
-          authShellBorder: "rgb(45, 45, 45)",
-          toggleLabel: "라이트 모드로 전환",
-        },
-        light: {
-          bodyBg: "rgb(243, 245, 248)",
-          headerBgChannel: "249, 251, 254",
-          searchBg: "rgb(255, 255, 255)",
-          searchBorder: "rgb(215, 224, 234)",
-          cardBg: "rgb(255, 255, 255)",
-          cardBorder: "rgb(231, 237, 244)",
-          authShellBg: "rgb(255, 255, 255)",
-          authShellBorder: "rgb(215, 224, 234)",
-          toggleLabel: "다크 모드로 전환",
-        },
-      }[scheme]
-
-      expect(fingerprint.route).toBe(scenario.route)
-      expect(fingerprint.bodyBg).toBe(expected.bodyBg)
-      if (scheme === "light") {
-        expect(fingerprint.headerBg).not.toBeNull()
-        expect(fingerprint.headerBg).not.toBe(fingerprint.bodyBg)
-      } else {
-        expect(fingerprint.headerBg?.includes(expected.headerBgChannel)).toBe(true)
-      }
-      expect(fingerprint.themeToggleLabel).toBe(expected.toggleLabel)
-      expect(fingerprint.authShellBg).toBe(expected.authShellBg)
-      expect(fingerprint.authShellBorder).toBe(expected.authShellBorder)
-    }
+  for (const scenario of authScenarios) {
+    await applySchemePreference(page, "light")
+    await page.setViewportSize(scenario.viewport)
+    await gotoForPerf(page, scenario.route)
+    await expect
+      .poll(async () => (await getThemeSurfaceFingerprint(page)).bodyBg, {
+        timeout: 8000,
+      })
+      .toBe("rgb(16, 18, 20)")
+    const fingerprint = await getThemeSurfaceFingerprint(page)
+    expect(fingerprint.route).toBe(scenario.route)
+    expect(fingerprint.bodyBg).toBe("rgb(16, 18, 20)")
+    expect(fingerprint.headerBg).toBe("rgb(23, 26, 29)")
+    expect(fingerprint.themeToggleLabel).toBeNull()
+    expect(fingerprint.authShellBg).toBe("rgba(18, 20, 22, 0.96)")
+    expect(fingerprint.authShellBorder).toBe("rgba(194, 163, 91, 0.54)")
   }
 })
 

--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -207,9 +207,16 @@ test("public blog appearance는 adminProfile 전역 설정에서 resolve된다",
   expect(postDetailPageSource).toContain("initialAdminProfile")
   expect(postDetailPageSource).toContain('initialAdminProfileSource === "static-fallback"')
   expect(appSource).toContain("initialAdminProfileShouldRefetch")
-  expect(rootLayoutSource).toContain('router.pathname.startsWith("/admin")')
+  expect(rootLayoutSource).toContain('!router.pathname.startsWith("/_qa")')
+  expect(rootLayoutSource).toContain("showHeaderThemeToggle")
   expect(rootLayoutSource).toContain("refetchOnMount: isDesignAwareRoute")
   expect(rootLayoutSource).toContain("staleTimeMs: isDesignAwareRoute ? 0 : undefined")
+  expect(rootLayoutSource).toContain('router.pathname.startsWith("/_qa")')
+  expect(rootLayoutSource).toContain('router.pathname !== "/sitemap.xml"')
+  expect(appSource).toContain("initialProfileSnapshot?: AdminProfile | null")
+  expect(readFileSync(path.resolve(__dirname, "../src/libs/server/guestPage.ts"), "utf8")).toContain(
+    "initialProfileSnapshot"
+  )
   expect(useAdminProfileSource).toContain("enabled?: boolean")
   expect(useAdminProfileSource).toContain("refetchOnMount?: boolean")
   expect(useAdminProfileSource).toContain("staleTimeMs?: number")

--- a/front/src/components/auth/AuthShell.tsx
+++ b/front/src/components/auth/AuthShell.tsx
@@ -81,19 +81,25 @@ const Main = styled.main`
 const Backdrop = styled.div`
   position: absolute;
   inset: 0;
-  background: ${({ theme }) => theme.colors.gray1};
+  background:
+    ${({ theme }) =>
+      theme.blogDesign === "grid"
+        ? `linear-gradient(180deg, color-mix(in srgb, ${theme.publicDesign.surfaceElevated} 72%, transparent), ${theme.publicDesign.pageBackgroundColor}), ${theme.publicDesign.pageBackgroundImage}`
+        : theme.colors.gray1};
 `
 
 const Shell = styled.section`
   position: relative;
   z-index: 1;
   width: min(520px, 100%);
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  border-radius: 22px;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray5)};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "22px")};
   overflow: hidden;
-  background: ${({ theme }) => theme.colors.gray1};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : theme.colors.gray1)};
   box-shadow: ${({ theme }) =>
-    theme.scheme === "light"
+    theme.blogDesign === "grid"
+      ? theme.publicDesign.shadow
+      : theme.scheme === "light"
       ? "0 18px 40px rgba(15, 23, 42, 0.08)"
       : "0 18px 40px rgba(0, 0, 0, 0.3)"};
 `
@@ -117,7 +123,7 @@ const Eyebrow = styled.span`
   display: inline-flex;
   align-items: center;
   margin-bottom: 0.38rem;
-  color: ${({ theme }) => theme.colors.gray10};
+  color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray10)};
   font-size: 0.74rem;
   font-weight: 760;
   letter-spacing: 0.08em;
@@ -145,9 +151,14 @@ const Tabs = styled.div`
 `
 
 const ActiveTab = styled.div`
-  border-radius: 11px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray2 : theme.colors.gray3)};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "4px" : "11px")};
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray6)};
+  background: ${({ theme }) =>
+    theme.blogDesign === "grid"
+      ? theme.publicDesign.accentMuted
+      : theme.scheme === "light"
+        ? theme.colors.gray2
+        : theme.colors.gray3};
   color: ${({ theme }) => theme.colors.gray12};
   padding: 0.66rem 0.76rem;
   text-align: center;
@@ -155,9 +166,10 @@ const ActiveTab = styled.div`
 `
 
 const PassiveTab = styled(Link)`
-  border-radius: 11px;
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  background: ${({ theme }) => (theme.scheme === "light" ? "#f8fafc" : theme.colors.gray1)};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "4px" : "11px")};
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
+  background: ${({ theme }) =>
+    theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.scheme === "light" ? "#f8fafc" : theme.colors.gray1};
   color: ${({ theme }) => theme.colors.gray11};
   padding: 0.66rem 0.76rem;
   text-align: center;
@@ -177,7 +189,7 @@ const Footer = styled.div`
   color: ${({ theme }) => theme.colors.gray11};
 
   a {
-    color: ${({ theme }) => theme.colors.accentLink};
+    color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.accentLink)};
     text-decoration: underline;
     text-underline-offset: 3px;
   }

--- a/front/src/layouts/RootLayout/index.tsx
+++ b/front/src/layouts/RootLayout/index.tsx
@@ -75,7 +75,7 @@ const RootLayout = ({
   const [scheme] = useScheme()
   const router = useRouter()
   const isPublicBlogRoute = router.pathname === "/" || router.pathname === "/about" || router.pathname === "/posts/[id]"
-  const isDesignAwareRoute = isPublicBlogRoute || router.pathname.startsWith("/admin")
+  const isDesignAwareRoute = !router.pathname.startsWith("/_qa") && router.pathname !== "/sitemap.xml"
   const adminProfile = usePublicAdminProfile(initialAdminProfile, {
     enabled: isDesignAwareRoute || initialAdminProfileShouldRefetch,
     refetchOnMount: isDesignAwareRoute,
@@ -84,6 +84,7 @@ const RootLayout = ({
   const publicAppearance = resolvePublicBlogAppearance(isDesignAwareRoute ? adminProfile : null)
   const effectiveScheme = isDesignAwareRoute ? publicAppearance.scheme : scheme
   const effectiveBlogDesign = isDesignAwareRoute ? publicAppearance.blogDesign : "legacy"
+  const showHeaderThemeToggle = effectiveBlogDesign === "legacy" && !isPublicBlogRoute
   const headerBlogTitle = isPublicBlogRoute ? adminProfile?.blogTitle?.trim() || CONFIG.blog.title : CONFIG.blog.title
   const [isNavigating, setIsNavigating] = useState(false)
   useGtagEffect()
@@ -188,7 +189,7 @@ const RootLayout = ({
       <Scripts />
       {/* // TODO: replace react query */}
       {/* {metaConfig.type !== "Paper" && <Header />} */}
-      <Header fullWidth={false} showThemeToggle={!isPublicBlogRoute} blogTitle={headerBlogTitle} />
+      <Header fullWidth={false} showThemeToggle={showHeaderThemeToggle} blogTitle={headerBlogTitle} />
       <RouteProgress data-busy={isNavigating} aria-hidden="true" />
       <StyledMain>{children}</StyledMain>
     </ThemeProvider>

--- a/front/src/libs/server/guestPage.ts
+++ b/front/src/libs/server/guestPage.ts
@@ -3,9 +3,17 @@ import { IncomingMessage } from "http"
 import { GetServerSidePropsResult } from "next"
 import { createQueryClient } from "src/libs/react-query"
 import { hydrateServerAuthSession } from "./authSession"
+import type { AdminProfile } from "src/hooks/useAdminProfile"
+import {
+  fetchServerAdminProfile,
+  resolvePublicAdminProfileSnapshot,
+  type StaticAdminProfileSeedSource,
+} from "./adminProfile"
 
 export type GuestPageProps = {
   dehydratedState: DehydratedState
+  initialProfileSnapshot: AdminProfile | null
+  initialAdminProfileSource: StaticAdminProfileSeedSource
 }
 
 export const getGuestPageProps = async (
@@ -22,11 +30,17 @@ export const getGuestPageProps = async (
       },
     }
   }
+  const fallbackProfileSnapshot = resolvePublicAdminProfileSnapshot(req)
+  const publishedProfile = await fetchServerAdminProfile(req, { timeoutMs: 900 })
+  const initialProfileSnapshot = publishedProfile ?? fallbackProfileSnapshot.profile
+  const initialAdminProfileSource: StaticAdminProfileSeedSource =
+    publishedProfile || fallbackProfileSnapshot.source === "cookie-snapshot" ? "published" : "static-fallback"
 
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
+      initialProfileSnapshot,
+      initialAdminProfileSource,
     },
   }
 }
-

--- a/front/src/routes/Admin/EditorActualPreviewPage.tsx
+++ b/front/src/routes/Admin/EditorActualPreviewPage.tsx
@@ -109,7 +109,11 @@ export const EditorActualPreviewPage: NextPage<AdminPageProps> = ({ initialMembe
 const PreviewRoot = styled.div`
   min-height: 100vh;
   padding: calc(var(--app-header-height, 64px) + 1.5rem) 1.5rem 3rem;
-  background: ${({ theme }) => theme.colors.gray1};
+  background:
+    ${({ theme }) =>
+      theme.blogDesign === "grid"
+        ? `linear-gradient(180deg, color-mix(in srgb, ${theme.publicDesign.surfaceElevated} 52%, transparent), transparent 18rem), ${theme.publicDesign.pageBackgroundImage}`
+        : theme.colors.gray1};
 `
 
 const PreviewTopBar = styled.div`
@@ -126,7 +130,7 @@ const PreviewTopBar = styled.div`
     gap: 0.5rem;
     border: 0;
     background: transparent;
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray12)};
     font-size: 0.95rem;
     font-weight: 700;
     cursor: pointer;
@@ -171,6 +175,11 @@ const PreviewArticle = styled.article`
   display: grid;
   gap: 1.15rem;
   min-width: 0;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
+  padding: ${({ theme }) => (theme.blogDesign === "grid" ? "1rem" : "0")};
+  box-shadow: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.shadow : "none")};
 `
 
 const PreviewBody = styled.section`
@@ -182,6 +191,10 @@ const PreviewEmptyState = styled.div`
   margin: 4rem auto 0;
   display: grid;
   gap: 0.5rem;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
+  padding: ${({ theme }) => (theme.blogDesign === "grid" ? "1rem" : "0")};
 
   strong {
     color: ${({ theme }) => theme.colors.gray12};

--- a/front/src/routes/Admin/EditorStudioComposeWorkspace.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeWorkspace.tsx
@@ -326,14 +326,16 @@ export const EditorStudioComposeWorkspace = ({
 const ComposeSurfaceSection = styled.section`
   display: grid;
   gap: 1.2rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray4};
-  border-radius: 14px;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray4)};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "14px")};
   padding: 1.1rem 1.1rem 1.3rem;
   margin-bottom: 1.2rem;
   background:
-    radial-gradient(circle at top left, rgba(96, 165, 250, 0.04), transparent 24%),
-    ${({ theme }) => theme.colors.gray1};
-  box-shadow: none;
+    ${({ theme }) =>
+      theme.blogDesign === "grid"
+        ? `linear-gradient(180deg, ${theme.publicDesign.operationSurfaceElevated}, ${theme.publicDesign.operationSurface})`
+        : `radial-gradient(circle at top left, rgba(96, 165, 250, 0.04), transparent 24%), ${theme.colors.gray1}`};
+  box-shadow: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.shadow : "none")};
 
   h2 {
     margin: 0;
@@ -386,7 +388,7 @@ const SubActionRow = styled.div`
   gap: 0.45rem;
   margin-top: 0.65rem;
   padding-top: 0.65rem;
-  border-top: 1px dashed ${({ theme }) => theme.colors.gray6};
+  border-top: 1px dashed ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
 
   > button {
     border-style: dashed;
@@ -404,11 +406,11 @@ const SubActionRow = styled.div`
 `
 
 const Button = styled.button`
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
   border-radius: 8px;
   padding: 0.62rem 0.92rem;
   min-height: 44px;
-  background: transparent;
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : "transparent")};
   color: ${({ theme }) => theme.colors.gray10};
   cursor: pointer;
   font-size: 0.84rem;
@@ -420,15 +422,15 @@ const Button = styled.button`
     box-shadow 0.18s ease;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.gray8};
-    background: ${({ theme }) => theme.colors.gray3};
+    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray8)};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3)};
     color: ${({ theme }) => theme.colors.gray12};
   }
 
   &:focus-visible {
     outline: none;
-    border-color: ${({ theme }) => theme.colors.blue8};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue8)};
+    box-shadow: 0 0 0 3px ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.blue4)};
   }
 
   &:disabled {
@@ -440,14 +442,14 @@ const Button = styled.button`
 const PrimaryButton = styled(Button)`
   border-radius: 8px;
   padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => theme.colors.blue9};
-  background: ${({ theme }) => theme.colors.blue9};
-  color: ${({ theme }) => theme.colors.gray1};
+  border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue9)};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue9)};
+  color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.pageBackgroundColor : theme.colors.gray1)};
   font-weight: 700;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.blue10};
-    background: ${({ theme }) => theme.colors.blue10};
-    color: ${({ theme }) => theme.colors.gray1};
+    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.blue10)};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.blue10)};
+    color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.pageBackgroundColor : theme.colors.gray1)};
   }
 `

--- a/front/src/routes/Admin/EditorStudioComposeWritingSurface.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeWritingSurface.tsx
@@ -275,7 +275,7 @@ const ComposeStudioKicker = styled.span`
   display: inline-flex;
   align-items: center;
   width: fit-content;
-  color: ${({ theme }) => theme.colors.gray10};
+  color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray10)};
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0;
@@ -298,9 +298,9 @@ const ComposeStudioContextItem = styled.div`
   gap: 0.08rem;
   min-width: 7rem;
   padding: 0.5rem 0.68rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  border-radius: 12px;
-  background: ${({ theme }) => theme.colors.gray2};
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "4px" : "12px")};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2)};
 
   span {
     color: ${({ theme }) => theme.colors.gray10};
@@ -345,7 +345,7 @@ const WriterAccent = styled.div`
   width: 5rem;
   height: 0.42rem;
   border-radius: 999px;
-  background: ${({ theme }) => theme.colors.gray8};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray8)};
 `
 
 const TitleInput = styled.textarea`
@@ -389,6 +389,10 @@ const ComposeReadableIntro = styled.div`
   margin-inline: auto;
   display: grid;
   gap: 1rem;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
+  padding: ${({ theme }) => (theme.blogDesign === "grid" ? "1rem" : "0")};
 `
 
 const ComposeSummaryField = styled.div`
@@ -405,10 +409,10 @@ const FieldLabel = styled.label`
 const ComposeSummaryInput = styled.textarea`
   width: 100%;
   min-height: 5.6rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  border-radius: 16px;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "4px" : "16px")};
   padding: 0.95rem 1rem;
-  background: ${({ theme }) => theme.colors.gray2};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray2)};
   color: ${({ theme }) => theme.colors.gray12};
   font-size: 1rem;
   line-height: 1.7;
@@ -420,8 +424,8 @@ const ComposeSummaryInput = styled.textarea`
 
   &:focus-visible {
     outline: none;
-    border-color: ${({ theme }) => theme.colors.gray7};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray7)};
+    box-shadow: 0 0 0 3px ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.blue4)};
   }
 `
 
@@ -514,8 +518,8 @@ const SelectedTagChip = styled.span`
   max-width: 100%;
   min-height: 32px;
   border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray3};
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3)};
   overflow: hidden;
   transition:
     border-color 0.18s ease,
@@ -548,8 +552,8 @@ const SelectedTagChip = styled.span`
     min-width: 1.92rem;
     padding: 0 0.52rem;
     border: 0;
-    border-left: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray2};
+    border-left: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray2)};
     color: ${({ theme }) => theme.colors.gray10};
     cursor: pointer;
     flex: 0 0 auto;

--- a/front/src/routes/Admin/EditorStudioContentWorkspace.tsx
+++ b/front/src/routes/Admin/EditorStudioContentWorkspace.tsx
@@ -325,12 +325,13 @@ export const EditorStudioContentWorkspace = ({
 )
 
 const Section = styled.section`
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  border-radius: 14px;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "14px")};
   padding: 0.96rem;
   margin-bottom: 1.05rem;
-  background: ${({ theme }) => theme.colors.gray2};
-  box-shadow: none;
+  background: ${({ theme }) =>
+    theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray2};
+  box-shadow: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.shadow : "none")};
 
   h2 {
     margin: 0;
@@ -366,12 +367,12 @@ const GlobalNoticeBar = styled.div`
   border-radius: 10px;
   font-size: 0.84rem;
   line-height: 1.5;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
 
   &[data-tone="idle"] {
     color: ${({ theme }) => theme.colors.gray10};
-    background: ${({ theme }) => theme.colors.gray2};
-    border-color: ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2)};
+    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
   }
 
   &[data-tone="loading"] {
@@ -418,9 +419,9 @@ const ContentStudioLeft = styled.div`
   display: grid;
   gap: 0.95rem;
   min-width: 0;
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  border-radius: 12px;
-  background: ${({ theme }) => theme.colors.gray1};
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "6px" : "12px")};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : theme.colors.gray1)};
   padding: 0.9rem;
   box-shadow: none;
   overflow: hidden;

--- a/front/src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx
+++ b/front/src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx
@@ -218,6 +218,10 @@ const EditorStudioRoot = styled.main`
   display: grid;
   gap: 1.2rem;
   overflow-x: clip;
+  background: ${({ theme }) =>
+    theme.blogDesign === "grid"
+      ? `linear-gradient(180deg, color-mix(in srgb, ${theme.publicDesign.surfaceElevated} 44%, transparent), transparent 18rem)`
+      : "transparent"};
 
   @media (max-width: 1024px) {
     padding: 1rem 1rem 1.4rem;
@@ -291,12 +295,12 @@ const EditorExitAction = styled.button`
     color 0.18s ease;
 
   &:hover {
-    background: ${({ theme }) => theme.colors.gray3};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3)};
   }
 
   &:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+    box-shadow: 0 0 0 3px ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.blue4)};
   }
 
   @media (max-width: 1200px) {
@@ -351,11 +355,11 @@ const EditorStudioSaveState = styled.span`
 `
 
 const Button = styled.button`
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
   border-radius: 8px;
   padding: 0.62rem 0.92rem;
   min-height: 44px;
-  background: transparent;
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : "transparent")};
   color: ${({ theme }) => theme.colors.gray10};
   cursor: pointer;
   font-size: 0.84rem;
@@ -367,15 +371,15 @@ const Button = styled.button`
     box-shadow 0.18s ease;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.gray8};
-    background: ${({ theme }) => theme.colors.gray3};
+    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray8)};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3)};
     color: ${({ theme }) => theme.colors.gray12};
   }
 
   &:focus-visible {
     outline: none;
-    border-color: ${({ theme }) => theme.colors.blue8};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue8)};
+    box-shadow: 0 0 0 3px ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.blue4)};
   }
 
   &:disabled {
@@ -387,15 +391,15 @@ const Button = styled.button`
 const PrimaryButton = styled(Button)`
   border-radius: 8px;
   padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => theme.colors.blue9};
-  background: ${({ theme }) => theme.colors.blue9};
-  color: ${({ theme }) => theme.colors.gray1};
+  border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue9)};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue9)};
+  color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.pageBackgroundColor : theme.colors.gray1)};
   font-weight: 700;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.blue10};
-    background: ${({ theme }) => theme.colors.blue10};
-    color: ${({ theme }) => theme.colors.gray1};
+    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.blue10)};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.blue10)};
+    color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.pageBackgroundColor : theme.colors.gray1)};
   }
 `
 
@@ -427,6 +431,10 @@ const EditorStudioMetaSection = styled.section<{ $compact?: boolean }>`
   margin-inline: auto;
   display: grid;
   gap: ${({ $compact }) => ($compact ? "0.72rem" : "0.9rem")};
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
+  padding: ${({ theme, $compact }) => (theme.blogDesign === "grid" ? ($compact ? "0.8rem" : "1rem") : "0")};
 `
 
 const EditorTagRow = styled.div<{ $compact?: boolean }>`
@@ -658,6 +666,11 @@ const EditorStudioCanvas = styled.section`
   display: grid;
   gap: 0.72rem;
   overflow-x: visible;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
+  padding: ${({ theme }) => (theme.blogDesign === "grid" ? "1rem" : "0")};
+  box-shadow: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.shadow : "none")};
 `
 
 const PublishNotice = styled.div`

--- a/front/src/routes/Error/index.tsx
+++ b/front/src/routes/Error/index.tsx
@@ -35,8 +35,11 @@ const StyledWrapper = styled.div`
   padding-right: 1.5rem;
   padding-top: 3rem;
   padding-bottom: 3rem;
-  border-radius: 1.5rem;
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "1.5rem")};
   max-width: 56rem;
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
+  box-shadow: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.shadow : "none")};
   .wrapper {
     display: flex;
     padding-top: 5rem;
@@ -54,6 +57,7 @@ const StyledWrapper = styled.div`
       .questionIcon {
         font-size: 3.1rem;
         flex: 0 0 auto;
+        color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : "inherit")};
       }
     }
     > .copy {
@@ -90,8 +94,8 @@ const StyledWrapper = styled.div`
       min-height: 44px;
       padding: 0 1rem;
       border-radius: 999px;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
-      background: ${({ theme }) => theme.colors.gray1};
+      border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray6)};
+      background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray1)};
       color: ${({ theme }) => theme.colors.gray12};
       text-decoration: none;
       font-size: 0.92rem;
@@ -104,8 +108,8 @@ const StyledWrapper = styled.div`
 
     > .actions a:hover {
       transform: translateY(-1px);
-      border-color: ${({ theme }) => theme.colors.gray8};
-      background: ${({ theme }) => theme.colors.gray2};
+      border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray8)};
+      background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray2)};
     }
   }
 `

--- a/front/src/styles/theme.ts
+++ b/front/src/styles/theme.ts
@@ -38,17 +38,17 @@ type Options = {
 export const createPublicDesignTokens = (scheme: SchemeType, blogDesign: BlogDesignType): PublicDesignTokens => {
   if (blogDesign === "grid") {
     return {
-      pageBackgroundColor: "#090909",
-      pageBackgroundImage: "repeating-linear-gradient(90deg,#c99a4a14 0 1px,#0000 1px 82px)",
-      surface: "#10100f",
-      surfaceElevated: "#181410",
-      readableSurface: "#141414f5",
-      operationSurface: "#0d0d0c",
-      operationSurfaceElevated: "#17130f",
-      border: "#c99a4a3d",
-      borderStrong: "#d4a95f8a",
-      accent: "#c99a4a",
-      accentMuted: "#c99a4a2b",
+      pageBackgroundColor: "#101214",
+      pageBackgroundImage: "repeating-linear-gradient(90deg,#c2a35b12 1px,#0000 0 5em)",
+      surface: "#171a1d",
+      surfaceElevated: "#202328",
+      readableSurface: "#121416f5",
+      operationSurface: "#101214",
+      operationSurfaceElevated: "#171a1d",
+      border: "#6d5a3563",
+      borderStrong: "#c2a35b8a",
+      accent: "#c2a35b",
+      accentMuted: "#2b2418",
       shadow: "0 20px 56px #0008",
     }
   }


### PR DESCRIPTION
## 관련 이슈

close #239

## 작업 배경

- Grid 디자인 적용 범위를 공개/관리자 일부에서 auth/editor/error까지 확장했습니다.
- `/login`, `/signup`, `/signup/verify`, `/editor/**`, 404 계열도 published `blogDesign=grid`를 따르고, legacy light/dark toggle은 legacy일 때만 남도록 정리했습니다.
- auth form/editor canvas/error box는 readable surface로 분리해 배경 패턴이 글자 가독성을 해치지 않게 했습니다.

## 작업 내용

- `RootLayout`의 design-aware route를 `_qa`/sitemap 내부 route 제외 전체 사용자-facing route로 바꿨습니다.
- 게스트 SSR page props에 published adminProfile seed를 추가해 로그인/회원가입 첫 렌더도 운영자가 공개한 Grid 디자인을 받게 했습니다.
- AuthShell, editor compose/dedicated/preview, error page surface에 grid readable/operation token을 적용했습니다.
- smoke/mobile/perf source/runtime 계약을 전 페이지 Grid 적용과 새 aquila-bank 참고 톤(`#101214`, `#171a1d`, `#c2a35b`)에 맞춰 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=grid-design-tone-readability bash tools/guards/current-task-preflight.sh`
  - `git diff --check`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-profile-state.spec.ts e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `PLAYWRIGHT_JSON_REPORT_PATH=test-results/perf/playwright-perf.json PLAYWRIGHT_PERF_RUNTIME_METRICS_PATH=test-results/perf/runtime-guard-metrics.ndjson yarn --cwd front test:e2e:perf`
  - `node scripts/compare-runtime-guard-metrics.mjs --metrics test-results/perf/runtime-guard-metrics.ndjson --baseline ../deploy/homeserver/monitoring/grafana/dashboards/blog-runtime-guard-baseline.json --output test-results/perf/runtime-guard-summary.md --json-output test-results/perf/runtime-guard-summary.json`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --grep "public/auth" --workers=1`
  - Local production visual check with Grid adminProfile snapshot/API mock: `/login`, `/signup`, missing route 404, `/editor/new`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: auth/editor/error 화면이 published adminProfile fetch에 더 민감해집니다. backend가 없을 때는 static fallback이 legacy로 남지만, published profile이 있으면 client fetch로 Grid가 적용됩니다.
- 롤백 방법: 이 PR의 단일 커밋 `e78dc6dc`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
