### PR TITLE
[Fix] 상세 목차 active scroll 안정화

### DIFF
--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -1418,6 +1418,81 @@ test("상세 table hover 중 wheel 입력도 page scroll chain을 유지한다",
   await expect.poll(async () => page.evaluate(() => window.scrollY)).toBeGreaterThan(scrollBeforeWheel + 120)
 })
 
+test("상세 우측 목차 active는 스크롤 anchor를 지난 현재 섹션을 유지한다", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+
+  const leadParagraph = "목차 active scrollspy 회귀를 재현하기 위한 본문입니다. ".repeat(70).trim()
+  const sectionBody = "짧은 섹션 본문입니다. ".repeat(8).trim()
+  const content = [
+    "## 계측 섹션 01",
+    leadParagraph,
+    "## 계측 섹션 02",
+    sectionBody,
+    "### 계측 섹션 03",
+    sectionBody,
+    "### 계측 섹션 04",
+    sectionBody,
+    "## 계측 섹션 05",
+    leadParagraph,
+  ].join("\n\n")
+
+  await page.route("**/post/api/v1/posts/912", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: 912,
+        createdAt: "2026-05-14T00:00:00Z",
+        modifiedAt: "2026-05-14T00:00:00Z",
+        authorId: 1,
+        authorName: "관리자",
+        authorUsername: "aquila",
+        authorProfileImageDirectUrl: "/avatar.png",
+        title: "상세 목차 active 안정성 테스트",
+        content,
+        tags: ["목차"],
+        category: [],
+        published: true,
+        listed: true,
+        likesCount: 0,
+        commentsCount: 0,
+        hitCount: 0,
+        actorHasLiked: false,
+        actorCanModify: false,
+        actorCanDelete: false,
+      }),
+    })
+  })
+
+  await page.route("**/post/api/v1/posts/912/hit", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "200-1",
+        msg: "ok",
+        data: { hitCount: 1 },
+      }),
+    })
+  })
+
+  await page.goto("/posts/912")
+  await expect(page.getByRole("heading", { name: "상세 목차 active 안정성 테스트" })).toBeVisible()
+  const rightToc = page.locator('aside.rightRail nav[aria-label="목차"]')
+  await expect(rightToc.getByRole("button", { name: "계측 섹션 02" })).toBeVisible()
+
+  await page.evaluate(() => {
+    const target = Array.from(document.querySelectorAll<HTMLElement>("article h2, article h3"))
+      .find((heading) => heading.textContent?.trim() === "계측 섹션 02")
+    if (!target) throw new Error("계측 섹션 02 heading을 찾지 못했습니다.")
+    const targetTop = window.scrollY + target.getBoundingClientRect().top - 72
+    window.scrollTo(0, targetTop)
+  })
+
+  await expect.poll(async () => page.evaluate(() => Math.round(window.scrollY))).toBeGreaterThan(0)
+  await expect(rightToc.locator('button[data-active="true"]')).toHaveText("계측 섹션 02")
+})
+
 test("모바일 상세는 compact 액션과 접이식 목차를 노출한다", async ({ page }) => {
   await page.setViewportSize({ width: 393, height: 852 })
   await page.addInitScript(() => {

--- a/front/src/routes/Detail/PostDetail/index.tsx
+++ b/front/src/routes/Detail/PostDetail/index.tsx
@@ -241,7 +241,6 @@ const PostDetail: React.FC<Props> = ({ initialComments = null }) => {
     actorHasLiked: data?.actorHasLiked ?? false,
   }))
   const visibleTocItemsRef = useRef<TocItem[]>([])
-  const tocVisibilityRef = useRef(new Map<string, { ratio: number; top: number }>())
   const showFloatingLikeRef = useRef(false)
   const showStickyTocRef = useRef(false)
   const commentsRailActiveRef = useRef(false)
@@ -657,37 +656,36 @@ const PostDetail: React.FC<Props> = ({ initialComments = null }) => {
       applyHybridRail(rightRailInnerRef.current, hybridRailMetricsRef.current.right)
     }
 
-    const resolveActiveByRatio = () => {
+    const resolveActiveByScrollPosition = () => {
       const items = visibleTocItemsRef.current
       if (!items.length) return ""
 
       const anchorTop = resolveRailTopOffset() + 12
-      const candidates = items.map((item) => {
-        const entry = tocVisibilityRef.current.get(item.id)
-        const top = entry?.top ?? Number.POSITIVE_INFINITY
-        const ratio = entry?.ratio ?? 0
-        return { id: item.id, ratio, top }
-      })
-
-      const intersecting = candidates
-        .filter((candidate) => candidate.ratio > 0.04 && Number.isFinite(candidate.top))
-        .sort((a, b) => {
-          if (b.ratio !== a.ratio) return b.ratio - a.ratio
-          return Math.abs(a.top - anchorTop) - Math.abs(b.top - anchorTop)
+      const activeBoundary = anchorTop + 4
+      const candidates = items
+        .map((item) => {
+          const heading = document.getElementById(item.id)
+          if (!heading) return null
+          return {
+            id: item.id,
+            top: heading.getBoundingClientRect().top,
+          }
         })
+        .filter((candidate): candidate is { id: string; top: number } => Boolean(candidate))
 
-      if (intersecting.length > 0) return intersecting[0].id
+      if (!candidates.length) return items[0]?.id || ""
 
-      const passed = candidates
-        .filter((candidate) => Number.isFinite(candidate.top) && candidate.top <= anchorTop)
-        .sort((a, b) => a.top - b.top)
-      if (passed.length > 0) return passed[passed.length - 1].id
+      let activeId = candidates[0].id
+      for (const candidate of candidates) {
+        if (candidate.top > activeBoundary) break
+        activeId = candidate.id
+      }
 
-      return items[0]?.id || ""
+      return activeId
     }
 
     const scheduler = createRafScheduler(() => {
-      const nextActiveId = resolveActiveByRatio()
+      const nextActiveId = resolveActiveByScrollPosition()
       setActiveTocId((prev) => (prev === nextActiveId ? prev : nextActiveId))
     })
     const railScheduler = createRafScheduler(() => {
@@ -695,45 +693,6 @@ const PostDetail: React.FC<Props> = ({ initialComments = null }) => {
       syncHybridRails()
     })
     const registry = createObserverRegistry()
-
-    const visibleIdSet = new Set(visibleTocItemsRef.current.map((item) => item.id))
-    const headingNodes = visibleTocItemsRef.current
-      .map((item) => document.getElementById(item.id))
-      .filter((node): node is HTMLElement => Boolean(node))
-
-    registry.addIntersectionObserver(
-      headingNodes,
-      (entries) => {
-        let didChange = false
-        for (const entry of entries) {
-          const id = (entry.target as HTMLElement).id
-          if (!id || !visibleIdSet.has(id)) continue
-          const nextRatio = entry.isIntersecting ? entry.intersectionRatio : 0
-          const nextTop = Math.round(entry.boundingClientRect.top)
-          const previous = tocVisibilityRef.current.get(id)
-          if (
-            previous &&
-            Math.abs(previous.ratio - nextRatio) < 0.04 &&
-            Math.abs(previous.top - nextTop) < 8
-          ) {
-            continue
-          }
-          tocVisibilityRef.current.set(id, {
-            ratio: nextRatio,
-            top: nextTop,
-          })
-          didChange = true
-        }
-        if (didChange) {
-          scheduler.schedule()
-        }
-      },
-      {
-        root: null,
-        rootMargin: `-${resolveRailTopOffset() + 12}px 0px -52% 0px`,
-        threshold: [0, 0.15, 0.4, 0.75, 1],
-      }
-    )
 
     const commentsNode = commentsSectionRef.current
     if (commentsNode) {
@@ -760,6 +719,7 @@ const PostDetail: React.FC<Props> = ({ initialComments = null }) => {
     registry.addWindowEvent(
       "scroll",
       () => {
+        scheduler.schedule()
         if (!leftHybridRailActiveRef.current && !rightHybridRailActiveRef.current) return
         railScheduler.schedule()
       },
@@ -794,13 +754,10 @@ const PostDetail: React.FC<Props> = ({ initialComments = null }) => {
     scheduler.schedule()
     railScheduler.schedule()
 
-    const tocVisibility = tocVisibilityRef.current
-
     return () => {
       registry.cleanup()
       scheduler.cancel()
       railScheduler.cancel()
-      tocVisibility.clear()
       clearInlineRailStyle(leftRailInnerNode)
       clearInlineRailStyle(rightRailInnerNode)
       if (leftHybridRailActiveRef.current) {


### PR DESCRIPTION
## 관련 이슈

close #243

## 작업 배경

- 상세 페이지 우측 목차 active 표시가 스크롤 중 현재 섹션이 아닌 앞/뒤 섹션으로 튀는 문제를 수정했습니다.
- IntersectionObserver ratio 기반 후보 정렬 대신 현재 heading 위치를 scroll anchor 기준으로 직접 계산하도록 바꿨습니다.

## 작업 내용

- 우측 목차 active 산정을 실제 DOM heading top 기준으로 변경해 stale intersection 후보가 active를 덮어쓰지 않게 했습니다.
- 현재 섹션이 anchor를 지난 직후 다음 섹션으로 먼저 튀지 않는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - 운영 `https://www.aquilaxk.site/posts/507` Playwright probe로 active 튐 재현
  - `CURRENT_TASK_SLUG=detail-toc-active-scroll bash tools/guards/current-task-preflight.sh`
  - `git diff --check`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright:preflight`
  - `env -u NO_COLOR yarn --cwd front playwright test e2e/smoke.spec.ts --grep "상세 우측 목차 active" --workers=1` (RED 확인 후 GREEN)
  - `env -u NO_COLOR yarn --cwd front playwright test e2e/smoke.spec.ts --grep "목차" --workers=1`
  - `env -u NO_COLOR yarn --cwd front playwright test e2e/perf.spec.ts --grep "상세" --workers=1`
  - `env -u NO_COLOR yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - 커밋 훅: `yarn --cwd front build`, `node front/scripts/check-bundle-size.mjs`, `yarn test:e2e:smoke`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: scroll 이벤트마다 rAF 스케줄로 active를 재계산하므로 긴 목차에서 scrollspy 계산 빈도가 늘어날 수 있습니다. 계산은 visible TOC heading의 rect 조회로 제한했습니다.
- 롤백 방법: 이 PR의 커밋 `345edf6f`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
