### PR TITLE
[Fix] 상세 목차 active 자동 표시

### DIFF
--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -1493,6 +1493,104 @@ test("상세 우측 목차 active는 스크롤 anchor를 지난 현재 섹션을
   await expect(rightToc.locator('button[data-active="true"]')).toHaveText("계측 섹션 02")
 })
 
+test("상세 우측 목차는 긴 목록에서도 active 항목을 자동으로 드러낸다", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+
+  const paragraph = "목차 자동 표시 회귀를 검증하기 위한 본문입니다. ".repeat(20).trim()
+  const content = Array.from({ length: 32 }, (_, index) => {
+    const sectionNumber = String(index + 1).padStart(2, "0")
+    return [`## 자동 표시 섹션 ${sectionNumber}`, paragraph].join("\n\n")
+  }).join("\n\n")
+
+  await page.route("**/post/api/v1/posts/913", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: 913,
+        createdAt: "2026-05-14T00:00:00Z",
+        modifiedAt: "2026-05-14T00:00:00Z",
+        authorId: 1,
+        authorName: "관리자",
+        authorUsername: "aquila",
+        authorProfileImageDirectUrl: "/avatar.png",
+        title: "상세 목차 자동 표시 테스트",
+        content,
+        tags: ["목차"],
+        category: [],
+        published: true,
+        listed: true,
+        likesCount: 0,
+        commentsCount: 0,
+        hitCount: 0,
+        actorHasLiked: false,
+        actorCanModify: false,
+        actorCanDelete: false,
+      }),
+    })
+  })
+
+  await page.route("**/post/api/v1/posts/913/hit", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "200-1",
+        msg: "ok",
+        data: { hitCount: 1 },
+      }),
+    })
+  })
+
+  await page.goto("/posts/913")
+  await expect(page.getByRole("heading", { name: "상세 목차 자동 표시 테스트" })).toBeVisible()
+  const rightToc = page.locator('aside.rightRail nav[aria-label="목차"]')
+  await expect(rightToc.getByRole("button", { name: "자동 표시 섹션 32" })).toHaveCount(1)
+
+  await page.evaluate(() => {
+    const target = Array.from(document.querySelectorAll<HTMLElement>("article h2"))
+      .find((heading) => heading.textContent?.trim() === "자동 표시 섹션 28")
+    if (!target) throw new Error("자동 표시 섹션 28 heading을 찾지 못했습니다.")
+    const targetTop = window.scrollY + target.getBoundingClientRect().top - 72
+    window.scrollTo(0, targetTop)
+  })
+
+  await expect
+    .poll(async () => page.evaluate(() => document.querySelector('aside.rightRail nav[aria-label="목차"] button[data-active="true"]')?.textContent?.trim()))
+    .toBe("자동 표시 섹션 28")
+
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(() => {
+          const list = document.querySelector<HTMLElement>('aside.rightRail nav[aria-label="목차"] ol')
+          const activeButton = list?.querySelector<HTMLElement>('button[data-active="true"]') ?? null
+          const listRect = list?.getBoundingClientRect()
+          const activeRect = activeButton?.getBoundingClientRect()
+          if (!list || !activeButton || !listRect || !activeRect) {
+            return "missing"
+          }
+
+          const metrics = {
+            activeText: activeButton.textContent?.trim() || "",
+            scrollTop: Math.round(list.scrollTop),
+            activeTop: Math.round(activeRect.top),
+            activeBottom: Math.round(activeRect.bottom),
+            listTop: Math.round(listRect.top),
+            listBottom: Math.round(listRect.bottom),
+          }
+          const activeVisible =
+            metrics.activeTop >= metrics.listTop - 1 && metrics.activeBottom <= metrics.listBottom + 1
+          const revealComplete =
+            metrics.activeText === "자동 표시 섹션 28" && metrics.scrollTop > 0 && activeVisible
+
+          return revealComplete ? "ready" : JSON.stringify(metrics)
+        }),
+      { timeout: 5_000 }
+    )
+    .toBe("ready")
+})
+
 test("모바일 상세는 compact 액션과 접이식 목차를 노출한다", async ({ page }) => {
   await page.setViewportSize({ width: 393, height: 852 })
   await page.addInitScript(() => {

--- a/front/src/routes/Detail/PostDetail/index.tsx
+++ b/front/src/routes/Detail/PostDetail/index.tsx
@@ -225,6 +225,7 @@ const PostDetail: React.FC<Props> = ({ initialComments = null }) => {
   const leftRailInnerRef = useRef<HTMLDivElement | null>(null)
   const rightRailRef = useRef<HTMLElement | null>(null)
   const rightRailInnerRef = useRef<HTMLElement | null>(null)
+  const rightTocListRef = useRef<HTMLOListElement | null>(null)
   const [likePending, setLikePending] = useState(false)
   const [adminActionPending, setAdminActionPending] = useState(false)
   const [tocItems, setTocItems] = useState<TocItem[]>([])
@@ -451,6 +452,35 @@ const PostDetail: React.FC<Props> = ({ initialComments = null }) => {
   useEffect(() => {
     showStickyTocRef.current = showStickyToc
   }, [showStickyToc])
+
+  useEffect(() => {
+    if (!activeTocId || !showStickyToc || typeof window === "undefined") return
+
+    const frame = window.requestAnimationFrame(() => {
+      const listNode = rightTocListRef.current
+      if (!listNode) return
+
+      const activeButton = listNode.querySelector<HTMLElement>('button[data-active="true"]')
+      if (!activeButton) return
+
+      const listRect = listNode.getBoundingClientRect()
+      const activeRect = activeButton.getBoundingClientRect()
+      const revealPadding = 12
+      const overflowTop = listRect.top + revealPadding - activeRect.top
+
+      if (overflowTop > 0) {
+        listNode.scrollTop = Math.max(0, listNode.scrollTop - overflowTop)
+        return
+      }
+
+      const overflowBottom = activeRect.bottom - (listRect.bottom - revealPadding)
+      if (overflowBottom > 0) {
+        listNode.scrollTop += overflowBottom
+      }
+    })
+
+    return () => window.cancelAnimationFrame(frame)
+  }, [activeTocId, showDetailedToc, showStickyToc, visibleTocItems.length])
 
   useEffect(() => {
     commentsRailActiveRef.current = commentsRailActive
@@ -1265,7 +1295,7 @@ const PostDetail: React.FC<Props> = ({ initialComments = null }) => {
                   </button>
                 )}
               </div>
-              <ol>
+              <ol ref={rightTocListRef}>
                 {visibleTocItems.map((item) => (
                   <li key={item.id} data-level={item.level}>
                     <button


### PR DESCRIPTION
## 관련 이슈

close #245

## 작업 배경

- 긴 공개 상세 페이지에서 우측 목차 active 항목이 목록 viewport 밖에 남는 문제를 수정했습니다.
- active heading 계산과 본문 스크롤은 유지하고, 우측 목차 `ol` 내부 스크롤만 active 버튼이 보이도록 보정합니다.

## 작업 내용

- `PostDetail` 우측 목차 목록에 ref를 연결하고 `activeTocId` 변경 후 active 버튼을 자동 reveal 합니다.
- 긴 목차 fixture를 추가해 active 항목이 보일 때까지 목차 내부 스크롤이 따라오는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=detail-toc-auto-reveal bash tools/guards/current-task-preflight.sh`
  - `git diff --check`
  - `env -u NO_COLOR yarn --cwd front playwright test e2e/smoke.spec.ts --grep "상세 우측 목차는 긴 목록" --workers=1` (RED 확인 후 GREEN 통과)
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright:preflight`
  - `env -u NO_COLOR yarn --cwd front playwright test e2e/smoke.spec.ts --grep "목차" --workers=1`
  - `env -u NO_COLOR yarn --cwd front playwright test e2e/perf.spec.ts --grep "상세" --workers=1`
  - `env -u NO_COLOR yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` (2회 연속 통과)
  - pre-commit: `yarn build`, `node scripts/check-bundle-size.mjs`, `yarn test:e2e:smoke`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 우측 목차 내부 스크롤 위치만 자동 보정되므로 본문 스크롤이나 active heading 산정에는 영향이 없습니다.
- 롤백 방법: `fix(frontend): 상세 목차 active 자동 표시` commit을 revert 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
