### PR TITLE
[Refactor] BlockEditorEngine table width runtime 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -1111,6 +1111,14 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/components/editor/tableWidthModel.ts"),
       "utf8"
     )
+    const tableWidthRuntimeModelPath = path.resolve(
+      __dirname,
+      "../src/components/editor/tableWidthRuntime.ts"
+    )
+    expect(existsSync(tableWidthRuntimeModelPath)).toBe(true)
+    const tableWidthRuntimeSource = existsSync(tableWidthRuntimeModelPath)
+      ? readFileSync(tableWidthRuntimeModelPath, "utf8")
+      : ""
     const tableStructureModelSource = readFileSync(
       path.resolve(__dirname, "../src/components/editor/tableStructureModel.ts"),
       "utf8"
@@ -1213,7 +1221,6 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).toContain('data-testid="table-cell-menu-button"')
     expect(blockEditorEngineSource).toContain('data-testid="table-overflow-mode-normal"')
     expect(blockEditorEngineSource).toContain('data-testid="table-overflow-mode-wide"')
-    expect(blockEditorEngineSource).toContain("const promoteLargeTablesToWideOverflowMode = (editor: TiptapEditor) => {")
     expect(tableWidthModelSource).toContain('export const TABLE_OVERFLOW_MODE_WIDE = "wide"')
     expect(tableWidthModelSource).toContain("export const getTableOverflowMode = (")
     expect(tableWidthModelSource).toContain("export const shouldPromoteWideTableOverflowMode = (")
@@ -1221,11 +1228,26 @@ test.describe("editor studio state", () => {
     expect(tableWidthModelSource).toContain("export const computeNextTableColumnWidthsForResize = (")
     expect(tableWidthModelSource).toContain("export const didTableColumnResizeHitOverflowPolicy = (")
     expect(blockEditorEngineSource).toContain('} from "./tableWidthModel"')
+    expect(blockEditorEngineSource).toContain('} from "./tableWidthRuntime"')
+    expect(tableWidthRuntimeSource).toContain("export type TableWidthSnapshot = {")
+    expect(tableWidthRuntimeSource).toContain("export const getCurrentEditorReadableWidthPx = (")
+    expect(tableWidthRuntimeSource).toContain("export const rebalanceStructurallyChangedNormalTableWidths = (")
+    expect(tableWidthRuntimeSource).toContain("export const normalizeTableWidthsToReadableBudget = (")
+    expect(tableWidthRuntimeSource).toContain("export const promoteLargeTablesToWideOverflowMode = (")
+    expect(tableWidthRuntimeSource).toContain("export const syncRenderedTableOverflowModes = (")
+    expect(tableWidthRuntimeSource).toContain("export const normalizeRenderedTableWidthsToReadableBudget = (")
     expect(blockEditorEngineSource).not.toContain("const TABLE_OVERFLOW_MODE_WIDE =")
     expect(blockEditorEngineSource).not.toContain("const getTableOverflowMode =")
     expect(blockEditorEngineSource).not.toContain("const shouldPromoteWideTableOverflowMode =")
     expect(blockEditorEngineSource).not.toContain("const computeNextTableColumnWidthsForResize = (")
     expect(blockEditorEngineSource).not.toContain("const didTableColumnResizeHitOverflowPolicy = (")
+    expect(blockEditorEngineSource).not.toContain("const getCurrentEditorReadableWidthPx =")
+    expect(blockEditorEngineSource).not.toContain("const readColumnWidthFromCell =")
+    expect(blockEditorEngineSource).not.toContain("const collectTableWidthSnapshots =")
+    expect(blockEditorEngineSource).not.toContain("const normalizeTableWidthsToReadableBudget =")
+    expect(blockEditorEngineSource).not.toContain("const promoteLargeTablesToWideOverflowMode =")
+    expect(blockEditorEngineSource).not.toContain("const normalizeRenderedTableWidthsToReadableBudget =")
+    expect(blockEditorEngineSource.split("\n").length).toBeLessThan(10750)
     expect(tableStructureModelSource).toContain("export const collectSimpleTableColumnCells = (")
     expect(tableStructureModelSource).toContain("export const buildReorderedSimpleTableNode = (")
     expect(tableStructureModelSource).toContain("export const canShrinkTableAxisAtEnd = (")

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -3,7 +3,7 @@ import { keyframes } from "@emotion/react"
 import styled from "@emotion/styled"
 import AppIcon from "src/components/icons/AppIcon"
 import { Fragment, Node as ProseMirrorNode } from "@tiptap/pm/model"
-import { NodeSelection, TextSelection, Transaction } from "@tiptap/pm/state"
+import { NodeSelection, TextSelection } from "@tiptap/pm/state"
 import { CellSelection, selectedRect, TableMap } from "@tiptap/pm/tables"
 import { EditorContent, useEditor } from "@tiptap/react"
 import {
@@ -123,17 +123,23 @@ import {
   computeNextTableColumnWidthsForResize,
   createBalancedTableColumnWidths,
   didTableColumnResizeHitOverflowPolicy,
-  expandTableColumnWidthsToFit,
   getPreferredNormalTableTotalWidth,
   getTableOverflowMode,
-  isLegacyCollapsedTableWidthState,
-  isLegacyFullWidthInitializedTableState,
   promotePastedWideTables,
-  shouldPromoteWideTableOverflowMode,
-  shrinkTableColumnWidthsToFit,
 } from "./tableWidthModel"
 import {
-  type TableColumnCellRef,
+  applyTableColumnWidthsToTransaction,
+  getCurrentEditorReadableWidthPx,
+  hasExplicitColumnWidth,
+  normalizeRenderedTableWidthsToReadableBudget,
+  normalizeTableWidthsToReadableBudget,
+  promoteLargeTablesToWideOverflowMode,
+  readColumnWidthFromCell,
+  rebalanceStructurallyChangedNormalTableWidths,
+  shouldClampTableWidthBudget,
+  syncRenderedTableOverflowModes,
+} from "./tableWidthRuntime"
+import {
   buildReorderedSimpleTableNode,
   canShrinkTableAxisAtEnd,
   collectSimpleTableColumnCells,
@@ -327,8 +333,6 @@ type SlashMenuState =
 
 const BLOCK_HANDLE_MEDIA_QUERY = "(pointer: coarse)"
 const DESKTOP_TABLE_RAIL_MEDIA_QUERY = "(max-width: 768px)"
-const DEFAULT_EDITOR_READABLE_WIDTH_PX = 48 * 16
-const TABLE_RAIL_EDGE_PADDING_PX = 12
 const TABLE_CORNER_BUTTON_SIZE_PX = 22
 const TABLE_CORNER_GROW_MOUSE_POINTER_ID = -1
 const TABLE_CORNER_DRAG_CLICK_GUARD_PX = 4
@@ -543,361 +547,6 @@ const resolveDocPosSafe = (editor: TiptapEditor, pos: number) => {
   } catch {
     return null
   }
-}
-
-const getCurrentEditorReadableWidthPx = (editor?: TiptapEditor | null) => {
-  const contentElement =
-    (editor?.view.dom.closest(".aq-block-editor__content") as HTMLElement | null) ??
-    (typeof document !== "undefined"
-      ? document.querySelector<HTMLElement>(".aq-block-editor__content")
-      : null)
-
-  const contentRect = contentElement?.getBoundingClientRect() ?? null
-  const measuredWidth = contentRect ? Math.round(contentRect.width) : DEFAULT_EDITOR_READABLE_WIDTH_PX
-  const viewportBudget =
-    contentRect && typeof window !== "undefined"
-      ? Math.round(
-          window.innerWidth -
-            Math.max(TABLE_RAIL_EDGE_PADDING_PX, Math.round(contentRect.left)) -
-            TABLE_RAIL_EDGE_PADDING_PX
-        )
-      : DEFAULT_EDITOR_READABLE_WIDTH_PX
-
-  return Math.max(
-    TABLE_MIN_COLUMN_WIDTH_PX,
-    Math.min(
-      measuredWidth || DEFAULT_EDITOR_READABLE_WIDTH_PX,
-      viewportBudget || DEFAULT_EDITOR_READABLE_WIDTH_PX
-    )
-  )
-}
-
-const shouldClampTableWidthBudget = () => {
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false
-  return !window.matchMedia(DESKTOP_TABLE_RAIL_MEDIA_QUERY).matches
-}
-
-const readColumnWidthFromCell = (cell: TableColumnCellRef) => {
-  const widthValue = Array.isArray(cell.node.attrs?.colwidth) ? cell.node.attrs?.colwidth[0] : null
-  return typeof widthValue === "number" && Number.isFinite(widthValue) && widthValue > 0
-    ? Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(widthValue))
-    : TABLE_MIN_COLUMN_WIDTH_PX
-}
-
-const hasExplicitColumnWidth = (column: TableColumnCellRef[]) =>
-  column.every((cell) => {
-    const widthValue = Array.isArray(cell.node.attrs?.colwidth) ? cell.node.attrs?.colwidth[0] : null
-    return typeof widthValue === "number" && Number.isFinite(widthValue) && widthValue > 0
-  })
-
-const applyTableColumnWidthsToTransaction = (
-  transaction: Transaction,
-  columns: TableColumnCellRef[][],
-  currentWidths: number[],
-  nextWidths: number[]
-) => {
-  let nextTransaction = transaction
-  let changed = false
-
-  columns.forEach((column, columnIndex) => {
-    const nextWidth = nextWidths[columnIndex]
-    const explicitWidthMissing = !hasExplicitColumnWidth(column)
-    if (currentWidths[columnIndex] === nextWidth && !explicitWidthMissing) return
-    column.forEach((cell) => {
-      nextTransaction = nextTransaction.setNodeMarkup(cell.pos, undefined, {
-        ...cell.node.attrs,
-        colwidth: [nextWidth],
-      })
-      changed = true
-    })
-  })
-
-  return { transaction: nextTransaction, changed }
-}
-
-type TableWidthSnapshot = {
-  pos: number
-  overflowMode: string
-  columns: TableColumnCellRef[][]
-  columnWidths: number[]
-  totalWidth: number
-}
-
-const collectTableWidthSnapshots = (doc: ProseMirrorNode) => {
-  const snapshots: TableWidthSnapshot[] = []
-
-  doc.descendants((node: any, pos: number) => {
-    if (node.type?.name !== "table") return true
-
-    const columns = collectSimpleTableColumnCells(node, pos)
-    if (!columns || columns.length === 0) {
-      return true
-    }
-
-    const columnWidths = columns.map((column) => readColumnWidthFromCell(column[0]))
-    snapshots.push({
-      pos,
-      overflowMode: getTableOverflowMode(node),
-      columns,
-      columnWidths,
-      totalWidth: columnWidths.reduce((sum, width) => sum + width, 0),
-    })
-
-    return true
-  })
-
-  return snapshots
-}
-
-const rebalanceStructurallyChangedNormalTableWidths = (
-  editor: TiptapEditor,
-  previousDoc: ProseMirrorNode
-) => {
-  if (!shouldClampTableWidthBudget()) return false
-
-  const readableWidthBudget = getCurrentEditorReadableWidthPx(editor) - 2
-  const previousTables = collectTableWidthSnapshots(previousDoc)
-  const nextTables = collectTableWidthSnapshots(editor.state.doc)
-  let transaction = editor.state.tr
-  let changed = false
-
-  nextTables.forEach((nextTable, index) => {
-    const previousTable = previousTables[index]
-    if (!previousTable) return
-    if (previousTable.overflowMode === TABLE_OVERFLOW_MODE_WIDE || nextTable.overflowMode === TABLE_OVERFLOW_MODE_WIDE) {
-      return
-    }
-    if (previousTable.columns.length === nextTable.columns.length) return
-
-    const minBudget = TABLE_MIN_COLUMN_WIDTH_PX * nextTable.columns.length
-    const targetTotalWidth = Math.max(
-      minBudget,
-      Math.min(
-        readableWidthBudget,
-        previousTable.totalWidth > 0 ? previousTable.totalWidth : nextTable.totalWidth
-      )
-    )
-    const nextWidths =
-      nextTable.totalWidth > targetTotalWidth
-        ? shrinkTableColumnWidthsToFit(nextTable.columnWidths, targetTotalWidth)
-        : expandTableColumnWidthsToFit(nextTable.columnWidths, targetTotalWidth)
-
-    if (nextWidths.every((width, widthIndex) => width === nextTable.columnWidths[widthIndex])) {
-      return
-    }
-
-    const applied = applyTableColumnWidthsToTransaction(
-      transaction,
-      nextTable.columns,
-      nextTable.columnWidths,
-      nextWidths
-    )
-    transaction = applied.transaction
-    changed ||= applied.changed
-  })
-
-  if (!changed || !transaction.docChanged) return false
-  transaction = transaction.setMeta(TABLE_WIDTH_BUDGET_META_KEY, true)
-  editor.view.dispatch(transaction)
-  return true
-}
-
-const normalizeTableWidthsToReadableBudget = (editor: TiptapEditor) => {
-  if (!shouldClampTableWidthBudget()) return false
-
-  const maxTableWidth = getCurrentEditorReadableWidthPx(editor) - 2
-  let transaction = editor.state.tr
-  let changed = false
-
-  editor.state.doc.descendants((node: any, pos: number) => {
-    if (node.type?.name !== "table") return true
-    if (getTableOverflowMode(node) === TABLE_OVERFLOW_MODE_WIDE) return true
-
-    const columns = collectSimpleTableColumnCells(node, pos)
-    if (!columns || columns.length === 0) return true
-
-    const currentWidths = columns.map((column) => readColumnWidthFromCell(column[0]))
-    const minBudget = TABLE_MIN_COLUMN_WIDTH_PX * currentWidths.length
-    const safeBudget = Math.max(minBudget, maxTableWidth)
-    const totalWidth = currentWidths.reduce((sum, width) => sum + width, 0)
-    const shouldRecoverLegacyFullWidth = isLegacyFullWidthInitializedTableState(currentWidths, safeBudget)
-    if (totalWidth <= safeBudget && !shouldRecoverLegacyFullWidth) {
-      return true
-    }
-
-    const targetWidth = shouldRecoverLegacyFullWidth
-      ? getPreferredNormalTableTotalWidth(currentWidths.length, safeBudget)
-      : safeBudget
-    const nextWidths = shrinkTableColumnWidthsToFit(currentWidths, targetWidth)
-    if (nextWidths.every((width, index) => width === currentWidths[index])) {
-      return true
-    }
-
-    const applied = applyTableColumnWidthsToTransaction(transaction, columns, currentWidths, nextWidths)
-    transaction = applied.transaction
-    changed ||= applied.changed
-
-    return true
-  })
-
-  if (!changed || !transaction.docChanged) return false
-  transaction = transaction.setMeta(TABLE_WIDTH_BUDGET_META_KEY, true)
-  editor.view.dispatch(transaction)
-  return true
-}
-
-const promoteLargeTablesToWideOverflowMode = (editor: TiptapEditor) => {
-  if (!shouldClampTableWidthBudget()) return false
-
-  const readableWidthBudget = getCurrentEditorReadableWidthPx(editor) - 2
-  let transaction = editor.state.tr
-  let changed = false
-
-  editor.state.doc.descendants((node: any, pos: number) => {
-    if (node.type?.name !== "table") return true
-    if (getTableOverflowMode(node) === TABLE_OVERFLOW_MODE_WIDE) return true
-
-    const columns = collectSimpleTableColumnCells(node, pos)
-    if (!columns || columns.length === 0) return true
-    if (!shouldPromoteWideTableOverflowMode(columns.length, readableWidthBudget)) return true
-
-    const currentWidths = columns.map((column) => readColumnWidthFromCell(column[0]))
-    const nextWidths = currentWidths.map((width) =>
-      Math.max(TABLE_WIDE_COLUMN_MIN_WIDTH_PX, width)
-    )
-    const applied = applyTableColumnWidthsToTransaction(
-      transaction,
-      columns,
-      currentWidths,
-      nextWidths
-    )
-    transaction = applied.transaction.setNodeMarkup(pos, undefined, {
-      ...node.attrs,
-      overflowMode: TABLE_OVERFLOW_MODE_WIDE,
-    })
-    changed = true
-
-    return true
-  })
-
-  if (!changed || !transaction.docChanged) return false
-  transaction = transaction.setMeta(TABLE_WIDTH_BUDGET_META_KEY, true)
-  editor.view.dispatch(transaction)
-  return true
-}
-
-const syncRenderedTableOverflowModes = (editor: TiptapEditor) => {
-  const renderedTables = Array.from(
-    editor.view.dom.querySelectorAll<HTMLElement>(".tableWrapper > table")
-  )
-  let renderedTableIndex = 0
-
-  editor.state.doc.descendants((node: any) => {
-    if (node.type?.name !== "table") return true
-
-    const renderedTable = renderedTables[renderedTableIndex] ?? null
-    renderedTableIndex += 1
-    if (!renderedTable) return true
-
-    const overflowMode = getTableOverflowMode(node)
-    if (overflowMode === TABLE_OVERFLOW_MODE_WIDE) {
-      renderedTable.setAttribute("data-overflow-mode", TABLE_OVERFLOW_MODE_WIDE)
-      renderedTable.parentElement?.setAttribute("data-overflow-mode", TABLE_OVERFLOW_MODE_WIDE)
-    } else {
-      renderedTable.removeAttribute("data-overflow-mode")
-      renderedTable.parentElement?.removeAttribute("data-overflow-mode")
-    }
-
-    return true
-  })
-
-  for (let index = renderedTableIndex; index < renderedTables.length; index += 1) {
-    renderedTables[index]?.removeAttribute("data-overflow-mode")
-    renderedTables[index]?.parentElement?.removeAttribute("data-overflow-mode")
-  }
-}
-
-const getRenderedTableViewportBudgetPx = (tableElement: HTMLElement | null, fallbackBudget: number) => {
-  if (!tableElement || typeof window === "undefined") return fallbackBudget
-
-  const tableRect = tableElement.getBoundingClientRect()
-  return Math.max(
-    TABLE_MIN_COLUMN_WIDTH_PX,
-    Math.round(
-      window.innerWidth -
-        Math.max(TABLE_RAIL_EDGE_PADDING_PX, Math.round(tableRect.left)) -
-        TABLE_RAIL_EDGE_PADDING_PX
-    )
-  )
-}
-
-const normalizeRenderedTableWidthsToReadableBudget = (editor: TiptapEditor) => {
-  if (!shouldClampTableWidthBudget()) return false
-
-  const readableWidthBudget = getCurrentEditorReadableWidthPx(editor) - 2
-  const renderedTables = Array.from(
-    editor.view.dom.querySelectorAll<HTMLElement>(".tableWrapper > table")
-  )
-  let renderedTableIndex = 0
-  let transaction = editor.state.tr
-  let changed = false
-
-  editor.state.doc.descendants((node: any, pos: number) => {
-    if (node.type?.name !== "table") return true
-    if (getTableOverflowMode(node) === TABLE_OVERFLOW_MODE_WIDE) return true
-
-    const columns = collectSimpleTableColumnCells(node, pos)
-    const renderedTable = renderedTables[renderedTableIndex] ?? null
-    renderedTableIndex += 1
-    if (!columns || columns.length === 0) return true
-
-    const currentWidths = columns.map((column) => readColumnWidthFromCell(column[0]))
-    const requiresExplicitWidths = columns.some((column) => !hasExplicitColumnWidth(column))
-    const renderedColumnWidths = readRenderedColumnWidths(renderedTable)
-    const measuredWidths =
-      renderedColumnWidths.length === columns.length ? renderedColumnWidths : currentWidths
-    const shouldRecoverLegacyCollapsedWidths = isLegacyCollapsedTableWidthState(measuredWidths)
-    const measuredTotalWidth = measuredWidths.reduce((sum, width) => sum + width, 0)
-    const minBudget = TABLE_MIN_COLUMN_WIDTH_PX * currentWidths.length
-    const viewportBudget = getRenderedTableViewportBudgetPx(renderedTable, readableWidthBudget)
-    const safeBudget = Math.max(minBudget, Math.min(readableWidthBudget, viewportBudget))
-    const renderedTableWidth = renderedTable
-      ? Math.round(renderedTable.getBoundingClientRect().width)
-      : measuredTotalWidth
-    const borderOverhead = Math.max(0, renderedTableWidth - measuredTotalWidth)
-    const contentBudget = Math.max(minBudget, safeBudget - borderOverhead)
-    const shouldRecoverLegacyFullWidth = isLegacyFullWidthInitializedTableState(currentWidths, contentBudget)
-    if (
-      renderedTableWidth <= safeBudget &&
-      !requiresExplicitWidths &&
-      !shouldRecoverLegacyCollapsedWidths &&
-      !shouldRecoverLegacyFullWidth
-    ) {
-      return true
-    }
-
-    const targetContentBudget = shouldRecoverLegacyFullWidth
-      ? getPreferredNormalTableTotalWidth(currentWidths.length, contentBudget)
-      : contentBudget
-    const nextWidths =
-      measuredTotalWidth > targetContentBudget
-        ? shrinkTableColumnWidthsToFit(measuredWidths, targetContentBudget)
-        : measuredWidths.map((width) => Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(width)))
-    if (nextWidths.every((width, index) => width === currentWidths[index])) {
-      return true
-    }
-
-    const applied = applyTableColumnWidthsToTransaction(transaction, columns, currentWidths, nextWidths)
-    transaction = applied.transaction
-    changed ||= applied.changed
-
-    return true
-  })
-
-  if (!changed || !transaction.docChanged) return false
-  transaction = transaction.setMeta(TABLE_WIDTH_BUDGET_META_KEY, true)
-  editor.view.dispatch(transaction)
-  return true
 }
 
 const TABLE_CONTEXT_NODE_NAMES = new Set(["table", "tableRow", "tableCell", "tableHeader"])

--- a/front/src/components/editor/tableWidthRuntime.ts
+++ b/front/src/components/editor/tableWidthRuntime.ts
@@ -1,0 +1,382 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model"
+import type { Transaction } from "@tiptap/pm/state"
+import {
+  TABLE_MIN_COLUMN_WIDTH_PX,
+  TABLE_WIDE_COLUMN_MIN_WIDTH_PX,
+} from "src/libs/markdown/tableMetadata"
+import { readRenderedColumnWidths } from "./tableRenderedDomModel"
+import {
+  type TableColumnCellRef,
+  collectSimpleTableColumnCells,
+} from "./tableStructureModel"
+import {
+  TABLE_OVERFLOW_MODE_WIDE,
+  TABLE_WIDTH_BUDGET_META_KEY,
+  expandTableColumnWidthsToFit,
+  getPreferredNormalTableTotalWidth,
+  getTableOverflowMode,
+  isLegacyCollapsedTableWidthState,
+  isLegacyFullWidthInitializedTableState,
+  shouldPromoteWideTableOverflowMode,
+  shrinkTableColumnWidthsToFit,
+} from "./tableWidthModel"
+
+const DEFAULT_EDITOR_READABLE_WIDTH_PX = 48 * 16
+const TABLE_RAIL_EDGE_PADDING_PX = 12
+const DESKTOP_TABLE_RAIL_MEDIA_QUERY = "(max-width: 768px)"
+
+export const getCurrentEditorReadableWidthPx = (editor?: TiptapEditor | null) => {
+  const contentElement =
+    (editor?.view.dom.closest(".aq-block-editor__content") as HTMLElement | null) ??
+    (typeof document !== "undefined"
+      ? document.querySelector<HTMLElement>(".aq-block-editor__content")
+      : null)
+
+  const contentRect = contentElement?.getBoundingClientRect() ?? null
+  const measuredWidth = contentRect ? Math.round(contentRect.width) : DEFAULT_EDITOR_READABLE_WIDTH_PX
+  const viewportBudget =
+    contentRect && typeof window !== "undefined"
+      ? Math.round(
+          window.innerWidth -
+            Math.max(TABLE_RAIL_EDGE_PADDING_PX, Math.round(contentRect.left)) -
+            TABLE_RAIL_EDGE_PADDING_PX
+        )
+      : DEFAULT_EDITOR_READABLE_WIDTH_PX
+
+  return Math.max(
+    TABLE_MIN_COLUMN_WIDTH_PX,
+    Math.min(
+      measuredWidth || DEFAULT_EDITOR_READABLE_WIDTH_PX,
+      viewportBudget || DEFAULT_EDITOR_READABLE_WIDTH_PX
+    )
+  )
+}
+
+export const shouldClampTableWidthBudget = () => {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false
+  return !window.matchMedia(DESKTOP_TABLE_RAIL_MEDIA_QUERY).matches
+}
+
+export const readColumnWidthFromCell = (cell: TableColumnCellRef) => {
+  const widthValue = Array.isArray(cell.node.attrs?.colwidth) ? cell.node.attrs?.colwidth[0] : null
+  return typeof widthValue === "number" && Number.isFinite(widthValue) && widthValue > 0
+    ? Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(widthValue))
+    : TABLE_MIN_COLUMN_WIDTH_PX
+}
+
+export const hasExplicitColumnWidth = (column: TableColumnCellRef[]) =>
+  column.every((cell) => {
+    const widthValue = Array.isArray(cell.node.attrs?.colwidth) ? cell.node.attrs?.colwidth[0] : null
+    return typeof widthValue === "number" && Number.isFinite(widthValue) && widthValue > 0
+  })
+
+export const applyTableColumnWidthsToTransaction = (
+  transaction: Transaction,
+  columns: TableColumnCellRef[][],
+  currentWidths: number[],
+  nextWidths: number[]
+) => {
+  let nextTransaction = transaction
+  let changed = false
+
+  columns.forEach((column, columnIndex) => {
+    const nextWidth = nextWidths[columnIndex]
+    const explicitWidthMissing = !hasExplicitColumnWidth(column)
+    if (currentWidths[columnIndex] === nextWidth && !explicitWidthMissing) return
+    column.forEach((cell) => {
+      nextTransaction = nextTransaction.setNodeMarkup(cell.pos, undefined, {
+        ...cell.node.attrs,
+        colwidth: [nextWidth],
+      })
+      changed = true
+    })
+  })
+
+  return { transaction: nextTransaction, changed }
+}
+
+export type TableWidthSnapshot = {
+  pos: number
+  overflowMode: string
+  columns: TableColumnCellRef[][]
+  columnWidths: number[]
+  totalWidth: number
+}
+
+export const collectTableWidthSnapshots = (doc: ProseMirrorNode) => {
+  const snapshots: TableWidthSnapshot[] = []
+
+  doc.descendants((node: any, pos: number) => {
+    if (node.type?.name !== "table") return true
+
+    const columns = collectSimpleTableColumnCells(node, pos)
+    if (!columns || columns.length === 0) {
+      return true
+    }
+
+    const columnWidths = columns.map((column) => readColumnWidthFromCell(column[0]))
+    snapshots.push({
+      pos,
+      overflowMode: getTableOverflowMode(node),
+      columns,
+      columnWidths,
+      totalWidth: columnWidths.reduce((sum, width) => sum + width, 0),
+    })
+
+    return true
+  })
+
+  return snapshots
+}
+
+export const rebalanceStructurallyChangedNormalTableWidths = (
+  editor: TiptapEditor,
+  previousDoc: ProseMirrorNode
+) => {
+  if (!shouldClampTableWidthBudget()) return false
+
+  const readableWidthBudget = getCurrentEditorReadableWidthPx(editor) - 2
+  const previousTables = collectTableWidthSnapshots(previousDoc)
+  const nextTables = collectTableWidthSnapshots(editor.state.doc)
+  let transaction = editor.state.tr
+  let changed = false
+
+  nextTables.forEach((nextTable, index) => {
+    const previousTable = previousTables[index]
+    if (!previousTable) return
+    if (previousTable.overflowMode === TABLE_OVERFLOW_MODE_WIDE || nextTable.overflowMode === TABLE_OVERFLOW_MODE_WIDE) {
+      return
+    }
+    if (previousTable.columns.length === nextTable.columns.length) return
+
+    const minBudget = TABLE_MIN_COLUMN_WIDTH_PX * nextTable.columns.length
+    const targetTotalWidth = Math.max(
+      minBudget,
+      Math.min(
+        readableWidthBudget,
+        previousTable.totalWidth > 0 ? previousTable.totalWidth : nextTable.totalWidth
+      )
+    )
+    const nextWidths =
+      nextTable.totalWidth > targetTotalWidth
+        ? shrinkTableColumnWidthsToFit(nextTable.columnWidths, targetTotalWidth)
+        : expandTableColumnWidthsToFit(nextTable.columnWidths, targetTotalWidth)
+
+    if (nextWidths.every((width, widthIndex) => width === nextTable.columnWidths[widthIndex])) {
+      return
+    }
+
+    const applied = applyTableColumnWidthsToTransaction(
+      transaction,
+      nextTable.columns,
+      nextTable.columnWidths,
+      nextWidths
+    )
+    transaction = applied.transaction
+    changed ||= applied.changed
+  })
+
+  if (!changed || !transaction.docChanged) return false
+  transaction = transaction.setMeta(TABLE_WIDTH_BUDGET_META_KEY, true)
+  editor.view.dispatch(transaction)
+  return true
+}
+
+export const normalizeTableWidthsToReadableBudget = (editor: TiptapEditor) => {
+  if (!shouldClampTableWidthBudget()) return false
+
+  const maxTableWidth = getCurrentEditorReadableWidthPx(editor) - 2
+  let transaction = editor.state.tr
+  let changed = false
+
+  editor.state.doc.descendants((node: any, pos: number) => {
+    if (node.type?.name !== "table") return true
+    if (getTableOverflowMode(node) === TABLE_OVERFLOW_MODE_WIDE) return true
+
+    const columns = collectSimpleTableColumnCells(node, pos)
+    if (!columns || columns.length === 0) return true
+
+    const currentWidths = columns.map((column) => readColumnWidthFromCell(column[0]))
+    const minBudget = TABLE_MIN_COLUMN_WIDTH_PX * currentWidths.length
+    const safeBudget = Math.max(minBudget, maxTableWidth)
+    const totalWidth = currentWidths.reduce((sum, width) => sum + width, 0)
+    const shouldRecoverLegacyFullWidth = isLegacyFullWidthInitializedTableState(currentWidths, safeBudget)
+    if (totalWidth <= safeBudget && !shouldRecoverLegacyFullWidth) {
+      return true
+    }
+
+    const targetWidth = shouldRecoverLegacyFullWidth
+      ? getPreferredNormalTableTotalWidth(currentWidths.length, safeBudget)
+      : safeBudget
+    const nextWidths = shrinkTableColumnWidthsToFit(currentWidths, targetWidth)
+    if (nextWidths.every((width, index) => width === currentWidths[index])) {
+      return true
+    }
+
+    const applied = applyTableColumnWidthsToTransaction(transaction, columns, currentWidths, nextWidths)
+    transaction = applied.transaction
+    changed ||= applied.changed
+
+    return true
+  })
+
+  if (!changed || !transaction.docChanged) return false
+  transaction = transaction.setMeta(TABLE_WIDTH_BUDGET_META_KEY, true)
+  editor.view.dispatch(transaction)
+  return true
+}
+
+export const promoteLargeTablesToWideOverflowMode = (editor: TiptapEditor) => {
+  if (!shouldClampTableWidthBudget()) return false
+
+  const readableWidthBudget = getCurrentEditorReadableWidthPx(editor) - 2
+  let transaction = editor.state.tr
+  let changed = false
+
+  editor.state.doc.descendants((node: any, pos: number) => {
+    if (node.type?.name !== "table") return true
+    if (getTableOverflowMode(node) === TABLE_OVERFLOW_MODE_WIDE) return true
+
+    const columns = collectSimpleTableColumnCells(node, pos)
+    if (!columns || columns.length === 0) return true
+    if (!shouldPromoteWideTableOverflowMode(columns.length, readableWidthBudget)) return true
+
+    const currentWidths = columns.map((column) => readColumnWidthFromCell(column[0]))
+    const nextWidths = currentWidths.map((width) =>
+      Math.max(TABLE_WIDE_COLUMN_MIN_WIDTH_PX, width)
+    )
+    const applied = applyTableColumnWidthsToTransaction(
+      transaction,
+      columns,
+      currentWidths,
+      nextWidths
+    )
+    transaction = applied.transaction.setNodeMarkup(pos, undefined, {
+      ...node.attrs,
+      overflowMode: TABLE_OVERFLOW_MODE_WIDE,
+    })
+    changed = true
+
+    return true
+  })
+
+  if (!changed || !transaction.docChanged) return false
+  transaction = transaction.setMeta(TABLE_WIDTH_BUDGET_META_KEY, true)
+  editor.view.dispatch(transaction)
+  return true
+}
+
+export const syncRenderedTableOverflowModes = (editor: TiptapEditor) => {
+  const renderedTables = Array.from(
+    editor.view.dom.querySelectorAll<HTMLElement>(".tableWrapper > table")
+  )
+  let renderedTableIndex = 0
+
+  editor.state.doc.descendants((node: any) => {
+    if (node.type?.name !== "table") return true
+
+    const renderedTable = renderedTables[renderedTableIndex] ?? null
+    renderedTableIndex += 1
+    if (!renderedTable) return true
+
+    const overflowMode = getTableOverflowMode(node)
+    if (overflowMode === TABLE_OVERFLOW_MODE_WIDE) {
+      renderedTable.setAttribute("data-overflow-mode", TABLE_OVERFLOW_MODE_WIDE)
+      renderedTable.parentElement?.setAttribute("data-overflow-mode", TABLE_OVERFLOW_MODE_WIDE)
+    } else {
+      renderedTable.removeAttribute("data-overflow-mode")
+      renderedTable.parentElement?.removeAttribute("data-overflow-mode")
+    }
+
+    return true
+  })
+
+  for (let index = renderedTableIndex; index < renderedTables.length; index += 1) {
+    renderedTables[index]?.removeAttribute("data-overflow-mode")
+    renderedTables[index]?.parentElement?.removeAttribute("data-overflow-mode")
+  }
+}
+
+export const getRenderedTableViewportBudgetPx = (tableElement: HTMLElement | null, fallbackBudget: number) => {
+  if (!tableElement || typeof window === "undefined") return fallbackBudget
+
+  const tableRect = tableElement.getBoundingClientRect()
+  return Math.max(
+    TABLE_MIN_COLUMN_WIDTH_PX,
+    Math.round(
+      window.innerWidth -
+        Math.max(TABLE_RAIL_EDGE_PADDING_PX, Math.round(tableRect.left)) -
+        TABLE_RAIL_EDGE_PADDING_PX
+    )
+  )
+}
+
+export const normalizeRenderedTableWidthsToReadableBudget = (editor: TiptapEditor) => {
+  if (!shouldClampTableWidthBudget()) return false
+
+  const readableWidthBudget = getCurrentEditorReadableWidthPx(editor) - 2
+  const renderedTables = Array.from(
+    editor.view.dom.querySelectorAll<HTMLElement>(".tableWrapper > table")
+  )
+  let renderedTableIndex = 0
+  let transaction = editor.state.tr
+  let changed = false
+
+  editor.state.doc.descendants((node: any, pos: number) => {
+    if (node.type?.name !== "table") return true
+    if (getTableOverflowMode(node) === TABLE_OVERFLOW_MODE_WIDE) return true
+
+    const columns = collectSimpleTableColumnCells(node, pos)
+    const renderedTable = renderedTables[renderedTableIndex] ?? null
+    renderedTableIndex += 1
+    if (!columns || columns.length === 0) return true
+
+    const currentWidths = columns.map((column) => readColumnWidthFromCell(column[0]))
+    const requiresExplicitWidths = columns.some((column) => !hasExplicitColumnWidth(column))
+    const renderedColumnWidths = readRenderedColumnWidths(renderedTable)
+    const measuredWidths =
+      renderedColumnWidths.length === columns.length ? renderedColumnWidths : currentWidths
+    const shouldRecoverLegacyCollapsedWidths = isLegacyCollapsedTableWidthState(measuredWidths)
+    const measuredTotalWidth = measuredWidths.reduce((sum, width) => sum + width, 0)
+    const minBudget = TABLE_MIN_COLUMN_WIDTH_PX * currentWidths.length
+    const viewportBudget = getRenderedTableViewportBudgetPx(renderedTable, readableWidthBudget)
+    const safeBudget = Math.max(minBudget, Math.min(readableWidthBudget, viewportBudget))
+    const renderedTableWidth = renderedTable
+      ? Math.round(renderedTable.getBoundingClientRect().width)
+      : measuredTotalWidth
+    const borderOverhead = Math.max(0, renderedTableWidth - measuredTotalWidth)
+    const contentBudget = Math.max(minBudget, safeBudget - borderOverhead)
+    const shouldRecoverLegacyFullWidth = isLegacyFullWidthInitializedTableState(currentWidths, contentBudget)
+    if (
+      renderedTableWidth <= safeBudget &&
+      !requiresExplicitWidths &&
+      !shouldRecoverLegacyCollapsedWidths &&
+      !shouldRecoverLegacyFullWidth
+    ) {
+      return true
+    }
+
+    const targetContentBudget = shouldRecoverLegacyFullWidth
+      ? getPreferredNormalTableTotalWidth(currentWidths.length, contentBudget)
+      : contentBudget
+    const nextWidths =
+      measuredTotalWidth > targetContentBudget
+        ? shrinkTableColumnWidthsToFit(measuredWidths, targetContentBudget)
+        : measuredWidths.map((width) => Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(width)))
+    if (nextWidths.every((width, index) => width === currentWidths[index])) {
+      return true
+    }
+
+    const applied = applyTableColumnWidthsToTransaction(transaction, columns, currentWidths, nextWidths)
+    transaction = applied.transaction
+    changed ||= applied.changed
+
+    return true
+  })
+
+  if (!changed || !transaction.docChanged) return false
+  transaction = transaction.setMeta(TABLE_WIDTH_BUDGET_META_KEY, true)
+  editor.view.dispatch(transaction)
+  return true
+}


### PR DESCRIPTION
## 관련 이슈

close #253

## 작업 배경

- BlockEditorEngine 내부에 남아 있던 table width runtime helper를 `tableWidthRuntime.ts`로 분리했습니다.
- engine은 table 폭 측정, normalize, wide 승격, rendered overflow sync를 import 호출만 하도록 줄였습니다.

## 작업 내용

- table width transaction/DOM runtime helper를 새 모듈로 이동했습니다.
- editor source 계약 테스트에 runtime module 소유권과 engine line budget 회귀 방지를 추가했습니다.
- local editor brief에는 `tableWidthRuntime.ts` 소유권 계약을 반영했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/block-editor-serialization.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `yarn --cwd front build`
  - 참고: 관련 E2E 3파일 묶음은 2회 실행 중 각각 변경 범위 밖 UI timing flake 1건으로 121/122였고, 실패 단건 및 해당 spec 단위 재실행은 통과했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table width runtime helper 이동 중 호출 경로 누락 가능성.
- 롤백 방법: 이 PR의 단일 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
