### PR TITLE
[Refactor] Admin profile workspace model 분리

### DIFF
--- a/front/e2e/admin-bootstrap-state.spec.ts
+++ b/front/e2e/admin-bootstrap-state.spec.ts
@@ -16,7 +16,10 @@ test.describe("admin bootstrap state contract", () => {
     const adminPageSource = readFileSync(path.resolve(__dirname, "../src/libs/server/adminPage.ts"), "utf8")
     const postsSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspacePage.tsx"), "utf8")
 
-    expect(adminPageSource).toContain("export const buildAdminPagePropsFromMember = (member: AuthMember): AdminPageProps => {")
+    expect(adminPageSource).toContain("export const buildAdminPagePropsFromMember = (")
+    expect(adminPageSource).toContain("member: AuthMember,")
+    expect(adminPageSource).toContain("initialProfileSnapshot: AdminProfile | null = buildAdminProfileSnapshotFromMember(member)")
+    expect(adminPageSource).toContain("): AdminPageProps => {")
     expect(adminPageSource).toContain("queryClient.setQueryData(queryKey.authMeProbe(), true)")
     expect(adminPageSource).toContain("queryClient.setQueryData(queryKey.authMe(), member)")
     expect(adminPageSource).toContain("export const readAdminProtectedBootstrap = async <T>(")

--- a/front/e2e/admin-profile-state.spec.ts
+++ b/front/e2e/admin-profile-state.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import path from "node:path"
 import { expect, test } from "@playwright/test"
 import { buildProfileWorkspaceAdminProfileCacheFields, normalizeProfileWorkspaceContent } from "src/libs/profileWorkspace"
@@ -36,6 +36,30 @@ test.describe("admin profile state contract", () => {
     expect(styleSource).not.toContain("const PreviewStatusMeta = styled.small`")
     expect(source).not.toContain('data-tone="synced">동기화됨')
     expect(source).not.toContain("현재 이미지")
+  })
+
+  test("profile page는 workspace 순수 모델을 Admin route model로 위임한다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/profile.tsx"), "utf8")
+    const modelPath = path.resolve(__dirname, "../src/routes/Admin/AdminProfileWorkspaceModel.ts")
+    expect(existsSync(modelPath)).toBe(true)
+    const modelSource = existsSync(modelPath) ? readFileSync(modelPath, "utf8") : ""
+
+    expect(source).toContain('} from "src/routes/Admin/AdminProfileWorkspaceModel"')
+    expect(modelSource).toContain("export const WORKSPACE_SECTIONS")
+    expect(modelSource).toContain("export const serializeWorkspaceSection = (")
+    expect(modelSource).toContain("export const createBlankLinkItem = (")
+    expect(modelSource).toContain("export const validateLinkInputs = (")
+    expect(modelSource).toContain("export const toPayloadLinks = (")
+    expect(modelSource).toContain("export const buildWorkspaceFallback = (")
+    expect(source).not.toContain("const WORKSPACE_SECTIONS:")
+    expect(source).not.toContain("const pickWorkspaceSectionContent =")
+    expect(source).not.toContain("const serializeWorkspaceSection =")
+    expect(source).not.toContain("const moveListItem =")
+    expect(source).not.toContain("const createBlankLinkItem =")
+    expect(source).not.toContain("const validateLinkInputs =")
+    expect(source).not.toContain("const toPayloadLinks =")
+    expect(source).not.toContain("const buildWorkspaceFallback =")
+    expect(source.split("\n").length).toBeLessThan(2250)
   })
 
   test("profile 작업공간은 공개 노출 기준의 상세형 hero와 rail copy를 사용한다", () => {
@@ -151,9 +175,13 @@ test.describe("admin profile state contract", () => {
 
   test("profile 화면은 전역 블로그 디자인 설정과 legacy 전용 scheme control을 가진다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/profile.tsx"), "utf8")
+    const modelSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/AdminProfileWorkspaceModel.ts"),
+      "utf8"
+    )
 
-    expect(source).toContain('id: "design"')
-    expect(source).toContain('label: "디자인"')
+    expect(modelSource).toContain('id: "design"')
+    expect(modelSource).toContain('label: "디자인"')
     expect(source).toContain('updateDraft("blogDesign",')
     expect(source).toContain('updateDraft("legacyBlogScheme",')
     expect(source).toContain('draft.blogDesign === "legacy"')

--- a/front/src/pages/admin/profile.tsx
+++ b/front/src/pages/admin/profile.tsx
@@ -3,16 +3,13 @@ import { GetServerSideProps, NextPage } from "next"
 import { useRouter } from "next/router"
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { apiFetch, getApiBaseUrl } from "src/apis/backend/client"
-import AppIcon, { IconName } from "src/components/icons/AppIcon"
+import AppIcon from "src/components/icons/AppIcon"
 import ProfileImage from "src/components/ProfileImage"
 import {
-  DEFAULT_CONTACT_ITEM_ICON,
-  DEFAULT_SERVICE_ITEM_ICON,
   getProfileCardIconOptions,
   isAllowedProfileLinkHref,
   normalizeProfileLinkHref,
   ProfileCardLinkItem,
-  ProfileCardLinkSection,
 } from "src/constants/profileCardLinks"
 import { queryKey } from "src/constants/queryKey"
 import useAuthSession, { AuthMember } from "src/hooks/useAuthSession"
@@ -21,7 +18,6 @@ import { setProfileWorkspaceCache, useProfileWorkspace } from "src/hooks/useProf
 import useViewportImageEditor from "src/libs/imageEditor/useViewportImageEditor"
 import {
   buildProfileWorkspaceAdminProfileCacheFields,
-  buildProfileWorkspaceFromLegacy,
   AboutProjectBlock,
   normalizeProfileWorkspaceContent,
   ProfileWorkspaceContent,
@@ -131,15 +127,27 @@ import {
   ModalFooter,
 } from "src/routes/Admin/AdminProfileWorkspace.styles"
 import {
+  WORKSPACE_SECTIONS,
+  buildWorkspaceFallback,
+  createBlankAboutProject,
+  createBlankAboutSection,
+  createBlankLinkItem,
+  type LinkTab,
+  moveListItem,
+  type PreviewMode,
+  reorderListItem,
+  serializeWorkspaceSection,
+  toPayloadLinks,
+  validateLinkInputs,
+  type WorkspaceSectionId,
+} from "src/routes/Admin/AdminProfileWorkspaceModel"
+import {
   AdminWorkspaceActionDockInner,
   AdminWorkspaceHeroCopy,
   AdminWorkspaceHeroLayout,
 } from "src/routes/Admin/AdminSurfacePrimitives"
 
 type NoticeTone = "idle" | "loading" | "success" | "error"
-type WorkspaceSectionId = "identity" | "about" | "home" | "design" | "links"
-type LinkTab = "service" | "contact"
-type PreviewMode = "draft" | "published"
 type OpenIconPicker = `${LinkTab}:${number}` | null
 type ProfileImageDraftTransformState = {
   focusX: number
@@ -161,76 +169,6 @@ type AdminProfileBootstrapPayload = {
 const PROFILE_UNSAVED_CHANGES_MESSAGE = "저장하지 않은 변경 사항이 있습니다. 이 페이지를 떠날까요?"
 const PROFILE_IMAGE_DRAFT_DEFAULT_SOURCE_SIZE: ProfileImageSourceSize = { width: 1, height: 1 }
 const PROFILE_IMAGE_UPLOAD_RETRY_DELAY_MS = 700
-
-const WORKSPACE_SECTIONS: {
-  id: WorkspaceSectionId
-  label: string
-}[] = [
-  {
-    id: "identity",
-    label: "프로필",
-  },
-  {
-    id: "about",
-    label: "About 페이지",
-  },
-  {
-    id: "home",
-    label: "헤더 문구",
-  },
-  {
-    id: "design",
-    label: "디자인",
-  },
-  {
-    id: "links",
-    label: "외부 링크",
-  },
-]
-
-const pickWorkspaceSectionContent = (
-  content: ProfileWorkspaceContent,
-  sectionId: WorkspaceSectionId
-) => {
-  switch (sectionId) {
-    case "identity":
-      return {
-        profileImageUrl: content.profileImageUrl,
-        profileRole: content.profileRole,
-        profileBio: content.profileBio,
-      }
-    case "about":
-      return {
-        aboutHeadline: content.aboutHeadline,
-        aboutRole: content.aboutRole,
-        aboutBio: content.aboutBio,
-        aboutSections: content.aboutSections,
-        aboutProjectSectionTitle: content.aboutProjectSectionTitle,
-        aboutProjects: content.aboutProjects,
-      }
-    case "home":
-      return {
-        blogTitle: content.blogTitle,
-        homeIntroTitle: content.homeIntroTitle,
-        homeIntroDescription: content.homeIntroDescription,
-      }
-    case "design":
-      return {
-        blogDesign: content.blogDesign,
-        legacyBlogScheme: content.legacyBlogScheme,
-      }
-    case "links":
-      return {
-        serviceLinks: content.serviceLinks,
-        contactLinks: content.contactLinks,
-      }
-  }
-}
-
-const serializeWorkspaceSection = (
-  content: ProfileWorkspaceContent,
-  sectionId: WorkspaceSectionId
-) => JSON.stringify(pickWorkspaceSectionContent(normalizeProfileWorkspaceContent(content), sectionId))
 
 const sleep = (ms: number) =>
   new Promise<void>((resolve) => {
@@ -284,126 +222,6 @@ const revalidatePublicBlogAppearance = async (): Promise<boolean> => {
     return response.ok
   } catch {
     return false
-  }
-}
-
-const moveListItem = <T,>(items: T[], index: number, direction: -1 | 1) => {
-  const nextIndex = index + direction
-  if (nextIndex < 0 || nextIndex >= items.length) return items
-  const next = items.slice()
-  const [item] = next.splice(index, 1)
-  next.splice(nextIndex, 0, item)
-  return next
-}
-
-const createLocalId = (prefix: string) => `${prefix}-${Math.random().toString(36).slice(2, 9)}`
-
-const createBlankLinkItem = (section: LinkTab): ProfileCardLinkItem =>
-  section === "service"
-    ? { icon: DEFAULT_SERVICE_ITEM_ICON, label: "", href: "" }
-    : { icon: DEFAULT_CONTACT_ITEM_ICON, label: "", href: "" }
-
-const createBlankAboutSection = (): AboutSectionBlock => ({
-  id: createLocalId("about"),
-  title: "",
-  items: [""],
-  dividerBefore: false,
-})
-
-const createBlankAboutProject = (): AboutProjectBlock => ({
-  id: createLocalId("project"),
-  name: "",
-  summary: "",
-  role: "",
-  href: "",
-  linkLabel: "",
-})
-
-const reorderListItem = <T,>(items: T[], fromIndex: number, toIndex: number) => {
-  if (fromIndex === toIndex) return items
-  if (fromIndex < 0 || toIndex < 0 || fromIndex >= items.length || toIndex >= items.length) {
-    return items
-  }
-
-  const next = items.slice()
-  const [item] = next.splice(fromIndex, 1)
-  next.splice(toIndex, 0, item)
-  return next
-}
-
-const validateLinkInputs = (
-  section: ProfileCardLinkSection,
-  sectionLabel: string,
-  items: ProfileCardLinkItem[]
-): string | null => {
-  for (let index = 0; index < items.length; index += 1) {
-    const item = items[index]
-    const label = item.label.trim()
-    const href = item.href.trim()
-    const rowLabel = `${sectionLabel} ${index + 1}번 링크`
-
-    if (!label && !href) {
-      return `${rowLabel}이 비어 있습니다. 입력하거나 삭제해주세요.`
-    }
-    if (!label || !href) {
-      return `${rowLabel}은 이름과 연결 주소를 모두 입력해야 합니다.`
-    }
-    if (!isAllowedProfileLinkHref(section, href)) {
-      if (section === "service") {
-        return `${rowLabel} 주소는 https:// 또는 http:// 형식만 허용됩니다.`
-      }
-      return `${rowLabel} 주소는 https://, http://, mailto:, tel: 형식만 허용됩니다.`
-    }
-  }
-
-  return null
-}
-
-const toPayloadLinks = (
-  section: ProfileCardLinkSection,
-  items: ProfileCardLinkItem[],
-  defaultIcon: IconName
-): ProfileCardLinkItem[] =>
-  items
-    .map((item) => ({
-      icon: item.icon || defaultIcon,
-      label: item.label.trim(),
-      href: normalizeProfileLinkHref(section, item.href),
-    }))
-    .filter((item) => item.label && item.href)
-
-const buildWorkspaceFallback = (
-  member: AuthMember,
-  initialWorkspace: ProfileWorkspaceResponse | null
-): ProfileWorkspaceResponse => {
-  if (initialWorkspace) {
-    const draft = normalizeProfileWorkspaceContent({
-      ...initialWorkspace.draft,
-      blogDesign: initialWorkspace.draft.blogDesign || member.blogDesign || "legacy",
-      legacyBlogScheme: initialWorkspace.draft.legacyBlogScheme || member.legacyBlogScheme || "dark",
-    })
-    const published = normalizeProfileWorkspaceContent({
-      ...initialWorkspace.published,
-      blogDesign: initialWorkspace.published.blogDesign || member.blogDesign || "legacy",
-      legacyBlogScheme: initialWorkspace.published.legacyBlogScheme || member.legacyBlogScheme || "dark",
-    })
-
-    return {
-      draft,
-      published,
-      lastDraftSavedAt: initialWorkspace.lastDraftSavedAt || member.modifiedAt || null,
-      lastPublishedAt: initialWorkspace.lastPublishedAt || member.modifiedAt || null,
-      dirtyFromPublished: initialWorkspace.dirtyFromPublished,
-    }
-  }
-
-  const content = buildProfileWorkspaceFromLegacy(member)
-  return {
-    draft: content,
-    published: content,
-    lastDraftSavedAt: member.modifiedAt || null,
-    lastPublishedAt: member.modifiedAt || null,
-    dirtyFromPublished: false,
   }
 }
 
@@ -776,8 +594,8 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
     () =>
       normalizeProfileWorkspaceContent({
         ...draft,
-        serviceLinks: toPayloadLinks("service", draft.serviceLinks, DEFAULT_SERVICE_ITEM_ICON),
-        contactLinks: toPayloadLinks("contact", draft.contactLinks, DEFAULT_CONTACT_ITEM_ICON),
+        serviceLinks: toPayloadLinks("service", draft.serviceLinks),
+        contactLinks: toPayloadLinks("contact", draft.contactLinks),
       }),
     [draft]
   )

--- a/front/src/routes/Admin/AdminProfileWorkspaceModel.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspaceModel.ts
@@ -1,0 +1,214 @@
+import type { IconName } from "src/components/icons/AppIcon"
+import {
+  DEFAULT_CONTACT_ITEM_ICON,
+  DEFAULT_SERVICE_ITEM_ICON,
+  isAllowedProfileLinkHref,
+  normalizeProfileLinkHref,
+  type ProfileCardLinkItem,
+  type ProfileCardLinkSection,
+} from "src/constants/profileCardLinks"
+import type { AuthMember } from "src/hooks/useAuthSession"
+import {
+  type AboutProjectBlock,
+  type AboutSectionBlock,
+  buildProfileWorkspaceFromLegacy,
+  normalizeProfileWorkspaceContent,
+  type ProfileWorkspaceContent,
+  type ProfileWorkspaceResponse,
+} from "src/libs/profileWorkspace"
+
+export type WorkspaceSectionId = "identity" | "about" | "home" | "design" | "links"
+export type LinkTab = "service" | "contact"
+export type PreviewMode = "draft" | "published"
+
+export const WORKSPACE_SECTIONS: {
+  id: WorkspaceSectionId
+  label: string
+}[] = [
+  {
+    id: "identity",
+    label: "프로필",
+  },
+  {
+    id: "about",
+    label: "About 페이지",
+  },
+  {
+    id: "home",
+    label: "헤더 문구",
+  },
+  {
+    id: "design",
+    label: "디자인",
+  },
+  {
+    id: "links",
+    label: "외부 링크",
+  },
+]
+
+const pickWorkspaceSectionContent = (
+  content: ProfileWorkspaceContent,
+  sectionId: WorkspaceSectionId
+) => {
+  switch (sectionId) {
+    case "identity":
+      return {
+        profileImageUrl: content.profileImageUrl,
+        profileRole: content.profileRole,
+        profileBio: content.profileBio,
+      }
+    case "about":
+      return {
+        aboutHeadline: content.aboutHeadline,
+        aboutRole: content.aboutRole,
+        aboutBio: content.aboutBio,
+        aboutSections: content.aboutSections,
+        aboutProjectSectionTitle: content.aboutProjectSectionTitle,
+        aboutProjects: content.aboutProjects,
+      }
+    case "home":
+      return {
+        blogTitle: content.blogTitle,
+        homeIntroTitle: content.homeIntroTitle,
+        homeIntroDescription: content.homeIntroDescription,
+      }
+    case "design":
+      return {
+        blogDesign: content.blogDesign,
+        legacyBlogScheme: content.legacyBlogScheme,
+      }
+    case "links":
+      return {
+        serviceLinks: content.serviceLinks,
+        contactLinks: content.contactLinks,
+      }
+  }
+}
+
+export const serializeWorkspaceSection = (
+  content: ProfileWorkspaceContent,
+  sectionId: WorkspaceSectionId
+) => JSON.stringify(pickWorkspaceSectionContent(normalizeProfileWorkspaceContent(content), sectionId))
+
+export const moveListItem = <T,>(items: T[], index: number, direction: -1 | 1) => {
+  const nextIndex = index + direction
+  if (nextIndex < 0 || nextIndex >= items.length) return items
+  const next = items.slice()
+  const [item] = next.splice(index, 1)
+  next.splice(nextIndex, 0, item)
+  return next
+}
+
+const createLocalId = (prefix: string) => `${prefix}-${Math.random().toString(36).slice(2, 9)}`
+
+export const createBlankLinkItem = (section: LinkTab): ProfileCardLinkItem =>
+  section === "service"
+    ? { icon: DEFAULT_SERVICE_ITEM_ICON, label: "", href: "" }
+    : { icon: DEFAULT_CONTACT_ITEM_ICON, label: "", href: "" }
+
+export const createBlankAboutSection = (): AboutSectionBlock => ({
+  id: createLocalId("about"),
+  title: "",
+  items: [""],
+  dividerBefore: false,
+})
+
+export const createBlankAboutProject = (): AboutProjectBlock => ({
+  id: createLocalId("project"),
+  name: "",
+  summary: "",
+  role: "",
+  href: "",
+  linkLabel: "",
+})
+
+export const reorderListItem = <T,>(items: T[], fromIndex: number, toIndex: number) => {
+  if (fromIndex === toIndex) return items
+  if (fromIndex < 0 || toIndex < 0 || fromIndex >= items.length || toIndex >= items.length) {
+    return items
+  }
+
+  const next = items.slice()
+  const [item] = next.splice(fromIndex, 1)
+  next.splice(toIndex, 0, item)
+  return next
+}
+
+export const validateLinkInputs = (
+  section: ProfileCardLinkSection,
+  sectionLabel: string,
+  items: ProfileCardLinkItem[]
+): string | null => {
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index]
+    const label = item.label.trim()
+    const href = item.href.trim()
+    const rowLabel = `${sectionLabel} ${index + 1}번 링크`
+
+    if (!label && !href) {
+      return `${rowLabel}이 비어 있습니다. 입력하거나 삭제해주세요.`
+    }
+    if (!label || !href) {
+      return `${rowLabel}은 이름과 연결 주소를 모두 입력해야 합니다.`
+    }
+    if (!isAllowedProfileLinkHref(section, href)) {
+      if (section === "service") {
+        return `${rowLabel} 주소는 https:// 또는 http:// 형식만 허용됩니다.`
+      }
+      return `${rowLabel} 주소는 https://, http://, mailto:, tel: 형식만 허용됩니다.`
+    }
+  }
+
+  return null
+}
+
+const getDefaultLinkIcon = (section: ProfileCardLinkSection): IconName =>
+  section === "service" ? DEFAULT_SERVICE_ITEM_ICON : DEFAULT_CONTACT_ITEM_ICON
+
+export const toPayloadLinks = (
+  section: ProfileCardLinkSection,
+  items: ProfileCardLinkItem[]
+): ProfileCardLinkItem[] =>
+  items
+    .map((item) => ({
+      icon: item.icon || getDefaultLinkIcon(section),
+      label: item.label.trim(),
+      href: normalizeProfileLinkHref(section, item.href),
+    }))
+    .filter((item) => item.label && item.href)
+
+export const buildWorkspaceFallback = (
+  member: AuthMember,
+  initialWorkspace: ProfileWorkspaceResponse | null
+): ProfileWorkspaceResponse => {
+  if (initialWorkspace) {
+    const draft = normalizeProfileWorkspaceContent({
+      ...initialWorkspace.draft,
+      blogDesign: initialWorkspace.draft.blogDesign || member.blogDesign || "legacy",
+      legacyBlogScheme: initialWorkspace.draft.legacyBlogScheme || member.legacyBlogScheme || "dark",
+    })
+    const published = normalizeProfileWorkspaceContent({
+      ...initialWorkspace.published,
+      blogDesign: initialWorkspace.published.blogDesign || member.blogDesign || "legacy",
+      legacyBlogScheme: initialWorkspace.published.legacyBlogScheme || member.legacyBlogScheme || "dark",
+    })
+
+    return {
+      draft,
+      published,
+      lastDraftSavedAt: initialWorkspace.lastDraftSavedAt || member.modifiedAt || null,
+      lastPublishedAt: initialWorkspace.lastPublishedAt || member.modifiedAt || null,
+      dirtyFromPublished: initialWorkspace.dirtyFromPublished,
+    }
+  }
+
+  const content = buildProfileWorkspaceFromLegacy(member)
+  return {
+    draft: content,
+    published: content,
+    lastDraftSavedAt: member.modifiedAt || null,
+    lastPublishedAt: member.modifiedAt || null,
+    dirtyFromPublished: false,
+  }
+}


### PR DESCRIPTION
## 관련 이슈

close #255

## 작업 배경

- `/admin/profile` page에 남아 있던 workspace/link/fallback 순수 helper를 `AdminProfileWorkspaceModel.ts`로 분리했습니다.
- page는 SSR/client orchestration과 profile image runtime을 유지하고, UI/스타일/문구는 변경하지 않았습니다.

## 작업 내용

- workspace section metadata, section serialization, link 생성/검증/정규화, list reorder, fallback workspace 생성을 Admin route model로 이동했습니다.
- admin profile source contract에 model 소유권과 page line budget 회귀 방지를 추가했습니다.
- 관련 검증 중 드러난 admin bootstrap source contract의 stale 함수 시그니처 기대값을 현재 코드 계약에 맞췄습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts e2e/admin-bootstrap-state.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: model helper import 누락 시 profile page compile/runtime 오류 가능성.
- 롤백 방법: 이 PR의 단일 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
