### PR TITLE
[Refactor] Admin tools workspace model 분리

### DIFF
--- a/front/e2e/admin-bootstrap-state.spec.ts
+++ b/front/e2e/admin-bootstrap-state.spec.ts
@@ -32,6 +32,7 @@ test.describe("admin bootstrap state contract", () => {
 
   test("운영 진단은 auth/session 선조회 대신 protected bootstrap으로 health summary를 first paint에 주입한다", () => {
     const toolsSource = readFileSync(path.resolve(__dirname, "../src/pages/admin/tools.tsx"), "utf8")
+    const toolsModelSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminToolsWorkspaceModel.ts"), "utf8")
 
     expect(toolsSource).toContain('"/system/api/v1/adm/bootstrap"')
     expect(toolsSource).toContain("readAdminProtectedBootstrap<AdminToolsBootstrapPayload>(req, \"/system/api/v1/adm/bootstrap\", \"/admin/tools\")")
@@ -39,8 +40,10 @@ test.describe("admin bootstrap state contract", () => {
     expect(toolsSource).toContain("systemHealth: bootstrapResult.value.value.health")
     expect(toolsSource).toContain('source: "bootstrap"')
     expect(toolsSource).toContain("const [systemHealthCheckedAt, setSystemHealthCheckedAt] = useState<string | null>(initialSnapshot.systemHealthFetchedAt)")
-    expect(toolsSource).toContain('const ADMIN_TOOLS_DISPLAY_TIME_ZONE = "Asia/Seoul"')
-    expect(toolsSource).toContain("timeZone: ADMIN_TOOLS_DISPLAY_TIME_ZONE")
+    expect(toolsSource).toContain("formatInstant,")
+    expect(toolsSource).toContain("getFreshnessMeta,")
+    expect(toolsModelSource).toContain('export const ADMIN_TOOLS_DISPLAY_TIME_ZONE = "Asia/Seoul"')
+    expect(toolsModelSource).toContain("timeZone: ADMIN_TOOLS_DISPLAY_TIME_ZONE")
     expect(toolsSource).toContain("const [freshnessClock, setFreshnessClock] = useState<number | null>(null)")
     expect(toolsSource).toContain("const systemHealthFreshness = getFreshnessMeta(systemHealthCheckedAt, freshnessClock)")
     expect(toolsSource).toContain("const systemHealthFetchedAt = systemHealthCheckedAt ? formatInstant(systemHealthCheckedAt) : \"-\"")

--- a/front/e2e/admin-tools-state.spec.ts
+++ b/front/e2e/admin-tools-state.spec.ts
@@ -1,8 +1,36 @@
-import { readFileSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import path from "node:path"
 import { expect, test } from "@playwright/test"
 
 test.describe("admin tools state contract", () => {
+  test("운영 도구 workspace model helper는 route-level model이 소유한다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/tools.tsx"), "utf8")
+    const modelPath = path.resolve(__dirname, "../src/routes/Admin/AdminToolsWorkspaceModel.ts")
+
+    if (!existsSync(modelPath)) {
+      expect(existsSync(modelPath), "AdminToolsWorkspaceModel.ts should exist").toBe(true)
+      return
+    }
+
+    const modelSource = readFileSync(modelPath, "utf8")
+
+    expect(source).toContain('from "src/routes/Admin/AdminToolsWorkspaceModel"')
+    expect(modelSource).toContain("export const ADMIN_TOOLS_DISPLAY_TIME_ZONE")
+    expect(modelSource).toContain("export const ACTION_META")
+    expect(modelSource).toContain("export const SECTION_IDS")
+    expect(modelSource).toContain("export const formatInstant")
+    expect(modelSource).toContain("export const getFreshnessMeta")
+    expect(modelSource).toContain("export const buildExecutionSummary")
+    expect(modelSource).toContain("export const getStatusTone")
+    expect(modelSource).toContain("export type ExecutionEntry")
+    expect(modelSource).toContain("export type ExecutionResultFilter")
+    expect(source).not.toContain("const ACTION_META")
+    expect(source).not.toContain("const formatInstant")
+    expect(source).not.toContain("const getFreshnessMeta")
+    expect(source).not.toContain("const buildExecutionSummary")
+    expect(source).not.toContain("const getStatusTone")
+  })
+
   test("운영 도구는 helper copy와 읽기 전용 pill 없이 요약 카드와 실행 버튼만 남긴다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/tools.tsx"), "utf8")
     const styleSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminToolsWorkspace.styles.ts"), "utf8")

--- a/front/src/pages/admin/tools.tsx
+++ b/front/src/pages/admin/tools.tsx
@@ -15,6 +15,29 @@ import { readServerSnapshot } from "src/libs/server/serverSnapshotCache"
 import { appendSsrDebugTiming, timed } from "src/libs/server/serverTiming"
 import AdminShell from "src/routes/Admin/AdminShell"
 import {
+  ACTION_META,
+  HEALTH_CACHE_MS,
+  RESULTS_FILTER_STORAGE_KEY,
+  SECTION_IDS,
+  SYSTEM_HEALTH_QUERY_KEY,
+  buildExecutionSummary,
+  formatAge,
+  formatInstant,
+  formatRetryPolicy,
+  getFreshnessMeta,
+  getStatusTone,
+  getSystemHealthSummary,
+  isExecutionResultFilter,
+  type DiagnosticTab,
+  type ExecutionEntry,
+  type ExecutionResultFilter,
+  type InlineNoticeTone,
+  type JsonValue,
+  type SectionKey,
+  type SystemHealthPayload,
+  type TaskRetryPolicy,
+} from "src/routes/Admin/AdminToolsWorkspaceModel"
+import {
   Main,
   OpsOverview,
   OverviewHeader,
@@ -89,8 +112,6 @@ import {
   EmptyResultState,
 } from "src/routes/Admin/AdminToolsWorkspace.styles"
 
-type JsonValue = unknown
-
 const pretty = (value: JsonValue) => JSON.stringify(value, null, 2)
 
 type SignupMailDiagnostics = {
@@ -109,14 +130,6 @@ type SignupMailDiagnostics = {
   verifyPath: string
   connectionError?: string | null
   taskQueue?: TaskTypeDiagnostics | null
-}
-
-type TaskRetryPolicy = {
-  label: string
-  maxRetries: number
-  baseDelaySeconds: number
-  backoffMultiplier: number
-  maxDelaySeconds: number
 }
 
 type TaskTypeDiagnostics = {
@@ -227,12 +240,6 @@ type AdminToolsPageProps = AdminPageProps & {
   initialSnapshot: AdminToolsInitialSnapshot
 }
 
-type SystemHealthPayload = {
-  status?: string
-  details?: Record<string, unknown>
-  [key: string]: unknown
-}
-
 type PageDto<T> = {
   content?: T[]
 }
@@ -255,7 +262,6 @@ const ADMIN_TOOLS_MAIL_SNAPSHOT_MAX_AGE_SECONDS = 60 * 30
 const ADMIN_TOOLS_MAIL_SNAPSHOT_MAX_STALE_MS = 1000 * 60 * 60 * 6
 const ADMIN_TOOLS_HEALTH_SSR_CACHE_KEY = "admin-tools:system-health"
 const ADMIN_TOOLS_HEALTH_SSR_CACHE_TTL_MS = 10_000
-const ADMIN_TOOLS_DISPLAY_TIME_ZONE = "Asia/Seoul"
 
 const readCookieValue = (req: IncomingMessage, key: string) => {
   const rawCookie = req.headers.cookie || ""
@@ -562,181 +568,6 @@ export const getServerSideProps: GetServerSideProps<AdminToolsPageProps> = async
       },
     },
   }
-}
-
-type ActionCardTone = "read" | "write" | "danger" | "infra"
-type InlineNoticeTone = "warning" | "danger" | "success"
-type DiagnosticTab = "mail" | "queue" | "cleanup" | "auth"
-type ExecutionDomain = "overview" | "diagnostics" | "execution" | "mutation"
-type ExecutionResultFilter = "all" | "success" | "error" | "stale"
-
-type ExecutionEntry = {
-  id: string
-  key: string
-  source: string
-  domain: ExecutionDomain
-  tone: ActionCardTone
-  status: "success" | "error"
-  startedAt: string
-  completedAt: string
-  summary: string
-  payload: JsonValue
-}
-
-const SYSTEM_HEALTH_QUERY_KEY = ["admin", "tools", "system-health"] as const
-const HEALTH_CACHE_MS = 10_000
-const RESULTS_FILTER_STORAGE_KEY = "admin.tools.resultsFilter.v1"
-const SECTION_IDS = {
-  overview: "ops-overview",
-  diagnostics: "ops-diagnostics",
-  execution: "ops-execution",
-  mutation: "ops-mutation",
-  results: "ops-results",
-} as const
-
-type SectionKey = keyof typeof SECTION_IDS
-
-const isExecutionResultFilter = (value: string): value is ExecutionResultFilter =>
-  value === "all" || value === "success" || value === "error" || value === "stale"
-
-const ACTION_META: Record<
-  string,
-  {
-    label: string
-    domain: ExecutionDomain
-    tone: ActionCardTone
-  }
-> = {
-  commentList: { label: "댓글 목록 조회", domain: "mutation", tone: "read" },
-  commentOne: { label: "댓글 상세 조회", domain: "mutation", tone: "read" },
-  commentWrite: { label: "댓글 생성", domain: "mutation", tone: "write" },
-  commentModify: { label: "댓글 수정", domain: "mutation", tone: "write" },
-  commentDelete: { label: "댓글 삭제", domain: "mutation", tone: "danger" },
-  admPostCount: { label: "전체 글 수 확인", domain: "execution", tone: "read" },
-  systemHealth: { label: "서비스 상태 조회", domain: "execution", tone: "infra" },
-  mailStatus: { label: "메일 진단", domain: "diagnostics", tone: "infra" },
-  mailConnectivity: { label: "SMTP 연결 확인", domain: "diagnostics", tone: "infra" },
-  mailTest: { label: "테스트 메일 발송", domain: "execution", tone: "write" },
-  taskQueueStatus: { label: "작업 큐 진단", domain: "diagnostics", tone: "infra" },
-  cleanupStatus: { label: "파일 정리 진단", domain: "diagnostics", tone: "infra" },
-  authSecurityEvents: { label: "인증 보안 기록 조회", domain: "diagnostics", tone: "infra" },
-  seedPostId: { label: "실데이터 테스트 대상 글 준비", domain: "mutation", tone: "read" },
-}
-
-const formatInstant = (value: string | null | undefined) => {
-  if (!value) return "-"
-
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return value
-
-  return new Intl.DateTimeFormat("ko-KR", {
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-    timeZone: ADMIN_TOOLS_DISPLAY_TIME_ZONE,
-  }).format(date)
-}
-
-const formatAge = (seconds: number | null | undefined) => {
-  if (seconds == null) return "-"
-  if (seconds < 60) return `${seconds}초`
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}분`
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)}시간`
-  return `${Math.floor(seconds / 86400)}일`
-}
-
-const getFreshnessMeta = (
-  value: string | null | undefined,
-  referenceNow: number | null
-): { label: string; tone: "fresh" | "aging" | "stale" } => {
-  if (!value) return { label: "미확인", tone: "stale" }
-
-  const timestamp = new Date(value).getTime()
-  if (Number.isNaN(timestamp)) return { label: "미확인", tone: "stale" }
-
-  if (referenceNow == null) return { label: "확인됨", tone: "fresh" }
-
-  const diffMs = referenceNow - timestamp
-  if (diffMs < 90_000) return { label: "방금 확인", tone: "fresh" }
-  if (diffMs < 15 * 60_000) return { label: `${Math.max(1, Math.floor(diffMs / 60_000))}분 전`, tone: "fresh" }
-  if (diffMs < 60 * 60_000) return { label: `${Math.max(15, Math.floor(diffMs / 60_000))}분 전`, tone: "aging" }
-  return { label: `${Math.max(1, Math.floor(diffMs / 3_600_000))}시간 전`, tone: "stale" }
-}
-
-const formatRetryPolicy = (policy: TaskRetryPolicy) =>
-  `${policy.maxRetries}회 / ${policy.baseDelaySeconds}초 시작 / x${policy.backoffMultiplier.toFixed(1)} / 최대 ${policy.maxDelaySeconds}초`
-
-const getSystemHealthSummary = (health: SystemHealthPayload | null) => {
-  if (!health?.details || typeof health.details !== "object") return []
-
-  return Object.entries(health.details)
-    .slice(0, 4)
-    .map(([key, value]) => {
-      if (value && typeof value === "object" && "status" in value && typeof value.status === "string") {
-        return `${key}: ${String(value.status)}`
-      }
-
-      return `${key}: ${typeof value === "string" ? value : "ok"}`
-    })
-}
-
-const getResultMessage = (payload: JsonValue) => {
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null
-  if ("msg" in payload && typeof (payload as { msg?: unknown }).msg === "string") {
-    return (payload as { msg: string }).msg
-  }
-  if ("message" in payload && typeof (payload as { message?: unknown }).message === "string") {
-    return (payload as { message: string }).message
-  }
-  if ("error" in payload && typeof (payload as { error?: unknown }).error === "string") {
-    return (payload as { error: string }).error
-  }
-  return null
-}
-
-const buildExecutionSummary = (key: string, status: "success" | "error", payload: JsonValue) => {
-  if (status === "error") return getResultMessage(payload) || "실행에 실패했습니다."
-
-  switch (key) {
-    case "systemHealth": {
-      const health = payload as SystemHealthPayload
-      return `서비스 상태 ${health?.status || "확인"}`
-    }
-    case "admPostCount":
-      return typeof payload === "number" ? `전체 글 ${payload}건을 확인했습니다.` : getResultMessage(payload) || "전체 글 수를 확인했습니다."
-    case "commentList":
-      return Array.isArray(payload) ? `댓글 ${payload.length}건을 불러왔습니다.` : "댓글 목록을 불러왔습니다."
-    case "commentOne":
-      return "댓글 상세를 불러왔습니다."
-    case "commentWrite":
-      return getResultMessage(payload) || "댓글을 생성했습니다."
-    case "commentModify":
-      return getResultMessage(payload) || "댓글을 수정했습니다."
-    case "commentDelete":
-      return getResultMessage(payload) || "댓글을 삭제했습니다."
-    case "mailStatus":
-      return "메일 준비 상태를 다시 확인했습니다."
-    case "mailConnectivity":
-      return "SMTP 연결 상태를 다시 확인했습니다."
-    case "mailTest":
-      return getResultMessage(payload) || "테스트 메일 발송을 요청했습니다."
-    case "taskQueueStatus":
-      return "작업 큐 진단을 새로고침했습니다."
-    case "cleanupStatus":
-      return "파일 정리 진단을 새로고침했습니다."
-    case "authSecurityEvents":
-      return "인증 보안 기록을 새로고침했습니다."
-    default:
-      return getResultMessage(payload) || ACTION_META[key]?.label || "작업을 실행했습니다."
-  }
-}
-
-const getStatusTone = (status: string) => {
-  if (status === "정상") return "success"
-  if (status === "오류") return "danger"
-  return "warning"
 }
 
 const AdminToolsPage: NextPage<AdminToolsPageProps> = ({ initialMember, initialSnapshot = EMPTY_INITIAL_SNAPSHOT }) => {

--- a/front/src/routes/Admin/AdminToolsWorkspaceModel.ts
+++ b/front/src/routes/Admin/AdminToolsWorkspaceModel.ts
@@ -1,0 +1,191 @@
+export type JsonValue = unknown
+
+export type TaskRetryPolicy = {
+  label: string
+  maxRetries: number
+  baseDelaySeconds: number
+  backoffMultiplier: number
+  maxDelaySeconds: number
+}
+
+export type SystemHealthPayload = {
+  status?: string
+  details?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+export type ActionCardTone = "read" | "write" | "danger" | "infra"
+export type InlineNoticeTone = "warning" | "danger" | "success"
+export type DiagnosticTab = "mail" | "queue" | "cleanup" | "auth"
+export type ExecutionDomain = "overview" | "diagnostics" | "execution" | "mutation"
+export type ExecutionResultFilter = "all" | "success" | "error" | "stale"
+
+export type ExecutionEntry = {
+  id: string
+  key: string
+  source: string
+  domain: ExecutionDomain
+  tone: ActionCardTone
+  status: "success" | "error"
+  startedAt: string
+  completedAt: string
+  summary: string
+  payload: JsonValue
+}
+
+export const ADMIN_TOOLS_DISPLAY_TIME_ZONE = "Asia/Seoul"
+export const SYSTEM_HEALTH_QUERY_KEY = ["admin", "tools", "system-health"] as const
+export const HEALTH_CACHE_MS = 10_000
+export const RESULTS_FILTER_STORAGE_KEY = "admin.tools.resultsFilter.v1"
+export const SECTION_IDS = {
+  overview: "ops-overview",
+  diagnostics: "ops-diagnostics",
+  execution: "ops-execution",
+  mutation: "ops-mutation",
+  results: "ops-results",
+} as const
+
+export type SectionKey = keyof typeof SECTION_IDS
+
+export const isExecutionResultFilter = (value: string): value is ExecutionResultFilter =>
+  value === "all" || value === "success" || value === "error" || value === "stale"
+
+export const ACTION_META: Record<
+  string,
+  {
+    label: string
+    domain: ExecutionDomain
+    tone: ActionCardTone
+  }
+> = {
+  commentList: { label: "댓글 목록 조회", domain: "mutation", tone: "read" },
+  commentOne: { label: "댓글 상세 조회", domain: "mutation", tone: "read" },
+  commentWrite: { label: "댓글 생성", domain: "mutation", tone: "write" },
+  commentModify: { label: "댓글 수정", domain: "mutation", tone: "write" },
+  commentDelete: { label: "댓글 삭제", domain: "mutation", tone: "danger" },
+  admPostCount: { label: "전체 글 수 확인", domain: "execution", tone: "read" },
+  systemHealth: { label: "서비스 상태 조회", domain: "execution", tone: "infra" },
+  mailStatus: { label: "메일 진단", domain: "diagnostics", tone: "infra" },
+  mailConnectivity: { label: "SMTP 연결 확인", domain: "diagnostics", tone: "infra" },
+  mailTest: { label: "테스트 메일 발송", domain: "execution", tone: "write" },
+  taskQueueStatus: { label: "작업 큐 진단", domain: "diagnostics", tone: "infra" },
+  cleanupStatus: { label: "파일 정리 진단", domain: "diagnostics", tone: "infra" },
+  authSecurityEvents: { label: "인증 보안 기록 조회", domain: "diagnostics", tone: "infra" },
+  seedPostId: { label: "실데이터 테스트 대상 글 준비", domain: "mutation", tone: "read" },
+}
+
+export const formatInstant = (value: string | null | undefined) => {
+  if (!value) return "-"
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: ADMIN_TOOLS_DISPLAY_TIME_ZONE,
+  }).format(date)
+}
+
+export const formatAge = (seconds: number | null | undefined) => {
+  if (seconds == null) return "-"
+  if (seconds < 60) return `${seconds}초`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}분`
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}시간`
+  return `${Math.floor(seconds / 86400)}일`
+}
+
+export const getFreshnessMeta = (
+  value: string | null | undefined,
+  referenceNow: number | null
+): { label: string; tone: "fresh" | "aging" | "stale" } => {
+  if (!value) return { label: "미확인", tone: "stale" }
+
+  const timestamp = new Date(value).getTime()
+  if (Number.isNaN(timestamp)) return { label: "미확인", tone: "stale" }
+
+  if (referenceNow == null) return { label: "확인됨", tone: "fresh" }
+
+  const diffMs = referenceNow - timestamp
+  if (diffMs < 90_000) return { label: "방금 확인", tone: "fresh" }
+  if (diffMs < 15 * 60_000) return { label: `${Math.max(1, Math.floor(diffMs / 60_000))}분 전`, tone: "fresh" }
+  if (diffMs < 60 * 60_000) return { label: `${Math.max(15, Math.floor(diffMs / 60_000))}분 전`, tone: "aging" }
+  return { label: `${Math.max(1, Math.floor(diffMs / 3_600_000))}시간 전`, tone: "stale" }
+}
+
+export const formatRetryPolicy = (policy: TaskRetryPolicy) =>
+  `${policy.maxRetries}회 / ${policy.baseDelaySeconds}초 시작 / x${policy.backoffMultiplier.toFixed(1)} / 최대 ${policy.maxDelaySeconds}초`
+
+export const getSystemHealthSummary = (health: SystemHealthPayload | null) => {
+  if (!health?.details || typeof health.details !== "object") return []
+
+  return Object.entries(health.details)
+    .slice(0, 4)
+    .map(([key, value]) => {
+      if (value && typeof value === "object" && "status" in value && typeof value.status === "string") {
+        return `${key}: ${String(value.status)}`
+      }
+
+      return `${key}: ${typeof value === "string" ? value : "ok"}`
+    })
+}
+
+export const getResultMessage = (payload: JsonValue) => {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null
+  if ("msg" in payload && typeof (payload as { msg?: unknown }).msg === "string") {
+    return (payload as { msg: string }).msg
+  }
+  if ("message" in payload && typeof (payload as { message?: unknown }).message === "string") {
+    return (payload as { message: string }).message
+  }
+  if ("error" in payload && typeof (payload as { error?: unknown }).error === "string") {
+    return (payload as { error: string }).error
+  }
+  return null
+}
+
+export const buildExecutionSummary = (key: string, status: "success" | "error", payload: JsonValue) => {
+  if (status === "error") return getResultMessage(payload) || "실행에 실패했습니다."
+
+  switch (key) {
+    case "systemHealth": {
+      const health = payload as SystemHealthPayload
+      return `서비스 상태 ${health?.status || "확인"}`
+    }
+    case "admPostCount":
+      return typeof payload === "number" ? `전체 글 ${payload}건을 확인했습니다.` : getResultMessage(payload) || "전체 글 수를 확인했습니다."
+    case "commentList":
+      return Array.isArray(payload) ? `댓글 ${payload.length}건을 불러왔습니다.` : "댓글 목록을 불러왔습니다."
+    case "commentOne":
+      return "댓글 상세를 불러왔습니다."
+    case "commentWrite":
+      return getResultMessage(payload) || "댓글을 생성했습니다."
+    case "commentModify":
+      return getResultMessage(payload) || "댓글을 수정했습니다."
+    case "commentDelete":
+      return getResultMessage(payload) || "댓글을 삭제했습니다."
+    case "mailStatus":
+      return "메일 준비 상태를 다시 확인했습니다."
+    case "mailConnectivity":
+      return "SMTP 연결 상태를 다시 확인했습니다."
+    case "mailTest":
+      return getResultMessage(payload) || "테스트 메일 발송을 요청했습니다."
+    case "taskQueueStatus":
+      return "작업 큐 진단을 새로고침했습니다."
+    case "cleanupStatus":
+      return "파일 정리 진단을 새로고침했습니다."
+    case "authSecurityEvents":
+      return "인증 보안 기록을 새로고침했습니다."
+    default:
+      return getResultMessage(payload) || ACTION_META[key]?.label || "작업을 실행했습니다."
+  }
+}
+
+export const getStatusTone = (status: string) => {
+  if (status === "정상") return "success"
+  if (status === "오류") return "danger"
+  return "warning"
+}


### PR DESCRIPTION
## 관련 이슈

close #257

## 작업 배경

- /admin/tools page에 남아 있던 pure workspace metadata, formatting, freshness, execution summary helper를 route-level model로 분리했습니다.
- page는 SSR, React state, query/mutation orchestration과 JSX composition 중심으로 남도록 줄였습니다.

## 작업 내용

- AdminToolsWorkspaceModel을 추가해 action metadata, section ids, result filter guard, 시간/freshness/summary helper를 소유하게 했습니다.
- /admin/tools page가 새 model을 import하도록 정리해 2,029줄에서 1,860줄로 줄였습니다.
- admin tools/bootstrap source contract를 model 경계에 맞춰 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/admin-tools-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts e2e/admin-bootstrap-state.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: source-level helper 이동으로 import 누락 시 tools page build가 실패할 수 있습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 기존 page-local helper 구조로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
