### PR TITLE
[Refactor] Admin dashboard workspace model 분리

### DIFF
--- a/front/e2e/admin-dashboard-state.spec.ts
+++ b/front/e2e/admin-dashboard-state.spec.ts
@@ -1,0 +1,34 @@
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { expect, test } from "@playwright/test"
+
+test.describe("admin dashboard state contract", () => {
+  test("운영 대시보드 workspace model helper는 route-level model이 소유한다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/dashboard.tsx"), "utf8")
+    const modelPath = path.resolve(__dirname, "../src/routes/Admin/AdminDashboardWorkspaceModel.ts")
+
+    if (!existsSync(modelPath)) {
+      expect(existsSync(modelPath), "AdminDashboardWorkspaceModel.ts should exist").toBe(true)
+      return
+    }
+
+    const modelSource = readFileSync(modelPath, "utf8")
+
+    expect(source).toContain('from "src/routes/Admin/AdminDashboardWorkspaceModel"')
+    expect(modelSource).toContain("export const EMPTY_INITIAL_SNAPSHOT")
+    expect(modelSource).toContain("export const ADMIN_DASHBOARD_DISPLAY_TIME_ZONE")
+    expect(modelSource).toContain("export const formatInstant")
+    expect(modelSource).toContain("export const formatAge")
+    expect(modelSource).toContain("export const getMailStatusLabel")
+    expect(modelSource).toContain("export const getMailStatusTone")
+    expect(modelSource).toContain("export const getTaskQueueTone")
+    expect(modelSource).toContain("export type DashboardSnapshotPayload")
+    expect(modelSource).toContain("export type DashboardKpiCard")
+    expect(modelSource).toContain("export type DashboardPriorityRow")
+    expect(modelSource).toContain("export type DashboardQuickAction")
+    expect(source).not.toContain("const ADMIN_DASHBOARD_DISPLAY_TIME_ZONE")
+    expect(source).not.toContain("const formatInstant")
+    expect(source).not.toContain("const getMailStatusLabel")
+    expect(source).not.toContain("const getTaskQueueTone")
+  })
+})

--- a/front/src/pages/admin/dashboard.tsx
+++ b/front/src/pages/admin/dashboard.tsx
@@ -5,7 +5,7 @@ import Link from "next/link"
 import type { SimpleIcon } from "simple-icons"
 import { useEffect, useRef, useState } from "react"
 import { apiFetch } from "src/apis/backend/client"
-import AppIcon, { type IconName } from "src/components/icons/AppIcon"
+import AppIcon from "src/components/icons/AppIcon"
 import type { AuthMember } from "src/hooks/useAuthSession"
 import useAuthSession from "src/hooks/useAuthSession"
 import { AdminPageProps, buildAdminPagePropsFromMember, getAdminPageProps, readAdminProtectedBootstrap } from "src/libs/server/adminPage"
@@ -19,6 +19,20 @@ import {
   getMonitoringEnv,
 } from "src/routes/Admin/adminMonitoring"
 import AdminShell from "src/routes/Admin/AdminShell"
+import {
+  EMPTY_INITIAL_SNAPSHOT,
+  formatAge,
+  formatInstant,
+  getMailStatusLabel,
+  getMailStatusTone,
+  getTaskQueueTone,
+  type AdminDashboardInitialSnapshot,
+  type DashboardKpiCard,
+  type DashboardPriorityRow,
+  type DashboardQuickAction,
+  type DashboardSnapshotPayload,
+  type SystemHealthPayload,
+} from "src/routes/Admin/AdminDashboardWorkspaceModel"
 import {
   Main,
   Shell,
@@ -72,48 +86,6 @@ import {
   AdminInfoStatusList,
 } from "src/routes/Admin/AdminSurfacePrimitives"
 
-type SystemHealthPayload = {
-  status?: string
-}
-
-type DashboardSnapshotPayload = {
-  generatedAt: string
-  taskQueue: {
-    pendingCount: number
-    readyPendingCount: number
-    processingCount: number
-    failedCount: number
-    staleProcessingCount: number
-    oldestReadyPendingAgeSeconds: number | null
-    latestFailureAt: string | null
-    latestFailureMessage: string | null
-  }
-  signupMail: {
-    status: string
-    queueLagSeconds: number | null
-    latestFailureAt: string | null
-    latestFailureMessage: string | null
-  }
-  authSecurity: {
-    recentEventCount: number
-    blockedEventCount: number
-    latestEventAt: string | null
-    latestBlockedAt: string | null
-  }
-  storageCleanup: {
-    eligibleForPurgeCount: number
-    blockedBySafetyThreshold: boolean
-    oldestEligiblePurgeAfter: string | null
-  }
-}
-
-type AdminDashboardInitialSnapshot = {
-  systemHealth: SystemHealthPayload | null
-  dashboard: DashboardSnapshotPayload | null
-  systemHealthFetchedAt: string | null
-  dashboardFetchedAt: string | null
-}
-
 type AdminDashboardPageProps = AdminPageProps & {
   initialSnapshot: AdminDashboardInitialSnapshot
 }
@@ -122,37 +94,6 @@ type AdminDashboardBootstrapPayload = {
   member: AuthMember
   health: SystemHealthPayload
   dashboard: DashboardSnapshotPayload
-}
-
-type DashboardKpiCard = {
-  key: string
-  label: string
-  value: string
-  detail: string
-  tone: "neutral" | "good" | "warn"
-  icon: IconName
-}
-
-type DashboardPriorityRow = {
-  key: string
-  title: string
-  summary: string
-  tone: "neutral" | "good" | "warn"
-  href: string
-  actionLabel: string
-}
-
-type DashboardQuickAction = {
-  key: string
-  href: string
-  label: string
-}
-
-const EMPTY_INITIAL_SNAPSHOT: AdminDashboardInitialSnapshot = {
-  systemHealth: null,
-  dashboard: null,
-  systemHealthFetchedAt: null,
-  dashboardFetchedAt: null,
 }
 
 async function readJsonIfOk<T>(req: IncomingMessage, path: string): Promise<T | null> {
@@ -165,61 +106,6 @@ async function readJsonIfOk<T>(req: IncomingMessage, path: string): Promise<T | 
   } catch {
     return null
   }
-}
-
-const ADMIN_DASHBOARD_DISPLAY_TIME_ZONE = "Asia/Seoul"
-
-const formatInstant = (value: string | null | undefined) => {
-  if (!value) return "-"
-
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return value
-
-  return new Intl.DateTimeFormat("ko-KR", {
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-    timeZone: ADMIN_DASHBOARD_DISPLAY_TIME_ZONE,
-  }).format(date)
-}
-
-const formatAge = (seconds: number | null | undefined) => {
-  if (seconds == null) return "-"
-  if (seconds < 60) return `${seconds}초`
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}분`
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)}시간`
-  return `${Math.floor(seconds / 86400)}일`
-}
-
-const getMailStatusLabel = (value: string | null | undefined) => {
-  switch (value) {
-    case "READY":
-      return "전송 준비"
-    case "TEST_MODE":
-      return "테스트 모드"
-    case "MISCONFIGURED":
-      return "설정 누락"
-    case "QUEUE_LOCKED":
-      return "큐 잠금"
-    case "CONNECTION_FAILED":
-      return "연결 실패"
-    case "UNAVAILABLE":
-      return "비활성"
-    default:
-      return value || "미확인"
-  }
-}
-
-const getMailStatusTone = (value: string | null | undefined): DashboardKpiCard["tone"] =>
-  value === "READY" || value === "TEST_MODE" ? "good" : value ? "warn" : "neutral"
-
-const getTaskQueueTone = (snapshot: DashboardSnapshotPayload | null | undefined): DashboardKpiCard["tone"] => {
-  if (!snapshot) return "neutral"
-  if (snapshot.taskQueue.failedCount > 0 || snapshot.taskQueue.staleProcessingCount > 0) return "warn"
-  if (snapshot.taskQueue.readyPendingCount === 0 && snapshot.taskQueue.processingCount === 0) return "good"
-  return "neutral"
 }
 
 export const getServerSideProps: GetServerSideProps<AdminDashboardPageProps> = async ({ req, res }) => {

--- a/front/src/routes/Admin/AdminDashboardWorkspaceModel.ts
+++ b/front/src/routes/Admin/AdminDashboardWorkspaceModel.ts
@@ -1,0 +1,129 @@
+import type { IconName } from "src/components/icons/AppIcon"
+
+export type SystemHealthPayload = {
+  status?: string
+}
+
+export type DashboardSnapshotPayload = {
+  generatedAt: string
+  taskQueue: {
+    pendingCount: number
+    readyPendingCount: number
+    processingCount: number
+    failedCount: number
+    staleProcessingCount: number
+    oldestReadyPendingAgeSeconds: number | null
+    latestFailureAt: string | null
+    latestFailureMessage: string | null
+  }
+  signupMail: {
+    status: string
+    queueLagSeconds: number | null
+    latestFailureAt: string | null
+    latestFailureMessage: string | null
+  }
+  authSecurity: {
+    recentEventCount: number
+    blockedEventCount: number
+    latestEventAt: string | null
+    latestBlockedAt: string | null
+  }
+  storageCleanup: {
+    eligibleForPurgeCount: number
+    blockedBySafetyThreshold: boolean
+    oldestEligiblePurgeAfter: string | null
+  }
+}
+
+export type AdminDashboardInitialSnapshot = {
+  systemHealth: SystemHealthPayload | null
+  dashboard: DashboardSnapshotPayload | null
+  systemHealthFetchedAt: string | null
+  dashboardFetchedAt: string | null
+}
+
+export type DashboardKpiCard = {
+  key: string
+  label: string
+  value: string
+  detail: string
+  tone: "neutral" | "good" | "warn"
+  icon: IconName
+}
+
+export type DashboardPriorityRow = {
+  key: string
+  title: string
+  summary: string
+  tone: "neutral" | "good" | "warn"
+  href: string
+  actionLabel: string
+}
+
+export type DashboardQuickAction = {
+  key: string
+  href: string
+  label: string
+}
+
+export const EMPTY_INITIAL_SNAPSHOT: AdminDashboardInitialSnapshot = {
+  systemHealth: null,
+  dashboard: null,
+  systemHealthFetchedAt: null,
+  dashboardFetchedAt: null,
+}
+
+export const ADMIN_DASHBOARD_DISPLAY_TIME_ZONE = "Asia/Seoul"
+
+export const formatInstant = (value: string | null | undefined) => {
+  if (!value) return "-"
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: ADMIN_DASHBOARD_DISPLAY_TIME_ZONE,
+  }).format(date)
+}
+
+export const formatAge = (seconds: number | null | undefined) => {
+  if (seconds == null) return "-"
+  if (seconds < 60) return `${seconds}초`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}분`
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}시간`
+  return `${Math.floor(seconds / 86400)}일`
+}
+
+export const getMailStatusLabel = (value: string | null | undefined) => {
+  switch (value) {
+    case "READY":
+      return "전송 준비"
+    case "TEST_MODE":
+      return "테스트 모드"
+    case "MISCONFIGURED":
+      return "설정 누락"
+    case "QUEUE_LOCKED":
+      return "큐 잠금"
+    case "CONNECTION_FAILED":
+      return "연결 실패"
+    case "UNAVAILABLE":
+      return "비활성"
+    default:
+      return value || "미확인"
+  }
+}
+
+export const getMailStatusTone = (value: string | null | undefined): DashboardKpiCard["tone"] =>
+  value === "READY" || value === "TEST_MODE" ? "good" : value ? "warn" : "neutral"
+
+export const getTaskQueueTone = (snapshot: DashboardSnapshotPayload | null | undefined): DashboardKpiCard["tone"] => {
+  if (!snapshot) return "neutral"
+  if (snapshot.taskQueue.failedCount > 0 || snapshot.taskQueue.staleProcessingCount > 0) return "warn"
+  if (snapshot.taskQueue.readyPendingCount === 0 && snapshot.taskQueue.processingCount === 0) return "good"
+  return "neutral"
+}


### PR DESCRIPTION
## 관련 이슈

close #259

## 작업 배경

- /admin/dashboard page에 남아 있던 snapshot payload, KPI/priority/action type, 시간/상태 tone helper를 route-level model로 분리했습니다.
- page는 SSR, React Query, deferred Grafana panel runtime, JSX composition 중심으로 남도록 줄였습니다.

## 작업 내용

- AdminDashboardWorkspaceModel을 추가해 dashboard snapshot/KPI/formatting/tone model을 소유하게 했습니다.
- /admin/dashboard page가 새 model을 import하도록 정리해 943줄에서 829줄로 줄였습니다.
- dashboard model source contract를 새로 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/admin-dashboard-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts e2e/admin-bootstrap-state.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: source-level helper 이동으로 import 누락 시 dashboard page build가 실패할 수 있습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 기존 page-local helper 구조로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
