### PR TITLE
[Refactor] Admin profile persistence model 분리

### DIFF
--- a/front/e2e/admin-profile-state.spec.ts
+++ b/front/e2e/admin-profile-state.spec.ts
@@ -62,6 +62,26 @@ test.describe("admin profile state contract", () => {
     expect(source.split("\n").length).toBeLessThan(2250)
   })
 
+  test("profile page는 persistence helper를 Admin route model로 위임한다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/profile.tsx"), "utf8")
+    const modelPath = path.resolve(__dirname, "../src/routes/Admin/AdminProfilePersistenceModel.ts")
+    expect(existsSync(modelPath)).toBe(true)
+    const modelSource = existsSync(modelPath) ? readFileSync(modelPath, "utf8") : ""
+
+    expect(source).toContain('} from "src/routes/Admin/AdminProfilePersistenceModel"')
+    expect(modelSource).toContain("export const PROFILE_UNSAVED_CHANGES_MESSAGE")
+    expect(modelSource).toContain("export const readImageSourceSizeFromFile =")
+    expect(modelSource).toContain("export const parseResponseErrorBody =")
+    expect(modelSource).toContain("export const revalidatePublicBlogAppearance =")
+    expect(modelSource).toContain("export const requestProfileImageUpload =")
+    expect(source).not.toContain("const PROFILE_UNSAVED_CHANGES_MESSAGE =")
+    expect(source).not.toContain("const readImageSourceSizeFromFile =")
+    expect(source).not.toContain("const parseResponseErrorBody =")
+    expect(source).not.toContain("const revalidatePublicBlogAppearance =")
+    expect(source).not.toContain("const requestProfileImageUpload =")
+    expect(source.split("\n").length).toBeLessThan(2190)
+  })
+
   test("profile 작업공간은 공개 노출 기준의 상세형 hero와 rail copy를 사용한다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/profile.tsx"), "utf8")
 
@@ -189,9 +209,13 @@ test.describe("admin profile state contract", () => {
 
   test("profile 디자인 공개 적용은 primary action에서 저장 후 publish까지 처리한다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/profile.tsx"), "utf8")
+    const persistenceModelSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/AdminProfilePersistenceModel.ts"),
+      "utf8"
+    )
 
-    expect(source).toContain("const revalidatePublicBlogAppearance = async (): Promise<boolean> => {")
-    expect(source).toContain('await fetch("/api/revalidate", {')
+    expect(persistenceModelSource).toContain("export const revalidatePublicBlogAppearance = async (): Promise<boolean> => {")
+    expect(persistenceModelSource).toContain('await fetch("/api/revalidate", {')
     expect(source).toContain("const validateDraftBeforePersistence = useCallback(")
     expect(source).toContain("const saveWorkspaceDraft = useCallback(")
     expect(source).toContain("const shouldPublishWorkspace = workspaceForPublish?.dirtyFromPublished ?? hasPublishedDiff")

--- a/front/src/pages/admin/profile.tsx
+++ b/front/src/pages/admin/profile.tsx
@@ -2,7 +2,7 @@ import { dehydrate, type DehydratedState, useQueryClient } from "@tanstack/react
 import { GetServerSideProps, NextPage } from "next"
 import { useRouter } from "next/router"
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { apiFetch, getApiBaseUrl } from "src/apis/backend/client"
+import { apiFetch } from "src/apis/backend/client"
 import AppIcon from "src/components/icons/AppIcon"
 import ProfileImage from "src/components/ProfileImage"
 import {
@@ -142,6 +142,16 @@ import {
   type WorkspaceSectionId,
 } from "src/routes/Admin/AdminProfileWorkspaceModel"
 import {
+  PROFILE_IMAGE_DRAFT_DEFAULT_SOURCE_SIZE,
+  PROFILE_IMAGE_UPLOAD_RETRY_DELAY_MS,
+  PROFILE_UNSAVED_CHANGES_MESSAGE,
+  parseResponseErrorBody,
+  readImageSourceSizeFromFile,
+  requestProfileImageUpload,
+  revalidatePublicBlogAppearance,
+  sleep,
+} from "src/routes/Admin/AdminProfilePersistenceModel"
+import {
   AdminWorkspaceActionDockInner,
   AdminWorkspaceHeroCopy,
   AdminWorkspaceHeroLayout,
@@ -164,65 +174,6 @@ type AdminProfileWorkspacePageProps = {
 type AdminProfileBootstrapPayload = {
   member: AuthMember
   workspace: ProfileWorkspaceResponse
-}
-
-const PROFILE_UNSAVED_CHANGES_MESSAGE = "저장하지 않은 변경 사항이 있습니다. 이 페이지를 떠날까요?"
-const PROFILE_IMAGE_DRAFT_DEFAULT_SOURCE_SIZE: ProfileImageSourceSize = { width: 1, height: 1 }
-const PROFILE_IMAGE_UPLOAD_RETRY_DELAY_MS = 700
-
-const sleep = (ms: number) =>
-  new Promise<void>((resolve) => {
-    window.setTimeout(resolve, ms)
-  })
-
-const readImageSourceSizeFromFile = (file: File): Promise<ProfileImageSourceSize> =>
-  new Promise((resolve, reject) => {
-    const objectUrl = URL.createObjectURL(file)
-    const image = new window.Image()
-    image.onload = () => {
-      URL.revokeObjectURL(objectUrl)
-      const width = image.naturalWidth || image.width
-      const height = image.naturalHeight || image.height
-      if (width <= 0 || height <= 0) {
-        reject(new Error("이미지 해상도를 확인할 수 없습니다."))
-        return
-      }
-      resolve({ width, height })
-    }
-    image.onerror = () => {
-      URL.revokeObjectURL(objectUrl)
-      reject(new Error("이미지 정보를 읽을 수 없습니다."))
-    }
-    image.src = objectUrl
-  })
-
-const parseResponseErrorBody = async (response: Response): Promise<string> => {
-  const text = await response.text().catch(() => "")
-  if (!text) return ""
-
-  try {
-    const parsed = JSON.parse(text) as { resultCode?: string; msg?: string }
-    const msg = parsed.msg?.trim()
-    if (!msg) return text
-    return parsed.resultCode ? `${msg} (${parsed.resultCode})` : msg
-  } catch {
-    return text
-  }
-}
-
-const revalidatePublicBlogAppearance = async (): Promise<boolean> => {
-  try {
-    const response = await fetch("/api/revalidate", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({}),
-    })
-    return response.ok
-  } catch {
-    return false
-  }
 }
 
 export const getServerSideProps: GetServerSideProps<AdminProfileWorkspacePageProps> = async ({ req, res }) => {
@@ -954,16 +905,6 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
     scheduleProfileImageDraftTransform(profileImageDraftTransformRef.current)
   }, [profileImageDraftSourceSize, profileImageDraftTransformRef, scheduleProfileImageDraftTransform])
 
-  const requestProfileImageUpload = useCallback(async (memberId: number, file: File): Promise<Response> => {
-    const formData = new FormData()
-    formData.append("file", file, file.name)
-    return await fetch(`${getApiBaseUrl()}/member/api/v1/adm/members/${memberId}/profileImageFile`, {
-      method: "POST",
-      credentials: "include",
-      body: formData,
-    })
-  }, [])
-
   const handleUploadMemberProfileImage = useCallback(
     async (selectedFile?: File): Promise<boolean> => {
       const file = selectedFile || profileImageFileInputRef.current?.files?.[0]
@@ -1011,7 +952,7 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
         setLoadingKey("")
       }
     },
-    [refreshWorkspace, requestProfileImageUpload, sessionMember?.id, setMe]
+    [refreshWorkspace, sessionMember?.id, setMe]
   )
 
   const handleApplyProfileImageDraft = useCallback(async () => {

--- a/front/src/routes/Admin/AdminProfilePersistenceModel.ts
+++ b/front/src/routes/Admin/AdminProfilePersistenceModel.ts
@@ -1,0 +1,71 @@
+import { getApiBaseUrl } from "src/apis/backend/client"
+import type { ProfileImageSourceSize } from "src/libs/profileImageUpload"
+
+export const PROFILE_UNSAVED_CHANGES_MESSAGE = "저장하지 않은 변경 사항이 있습니다. 이 페이지를 떠날까요?"
+export const PROFILE_IMAGE_DRAFT_DEFAULT_SOURCE_SIZE: ProfileImageSourceSize = { width: 1, height: 1 }
+export const PROFILE_IMAGE_UPLOAD_RETRY_DELAY_MS = 700
+
+export const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    window.setTimeout(resolve, ms)
+  })
+
+export const readImageSourceSizeFromFile = (file: File): Promise<ProfileImageSourceSize> =>
+  new Promise((resolve, reject) => {
+    const objectUrl = URL.createObjectURL(file)
+    const image = new window.Image()
+    image.onload = () => {
+      URL.revokeObjectURL(objectUrl)
+      const width = image.naturalWidth || image.width
+      const height = image.naturalHeight || image.height
+      if (width <= 0 || height <= 0) {
+        reject(new Error("이미지 해상도를 확인할 수 없습니다."))
+        return
+      }
+      resolve({ width, height })
+    }
+    image.onerror = () => {
+      URL.revokeObjectURL(objectUrl)
+      reject(new Error("이미지 정보를 읽을 수 없습니다."))
+    }
+    image.src = objectUrl
+  })
+
+export const parseResponseErrorBody = async (response: Response): Promise<string> => {
+  const text = await response.text().catch(() => "")
+  if (!text) return ""
+
+  try {
+    const parsed = JSON.parse(text) as { resultCode?: string; msg?: string }
+    const msg = parsed.msg?.trim()
+    if (!msg) return text
+    return parsed.resultCode ? `${msg} (${parsed.resultCode})` : msg
+  } catch {
+    return text
+  }
+}
+
+export const revalidatePublicBlogAppearance = async (): Promise<boolean> => {
+  try {
+    const response = await fetch("/api/revalidate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+    })
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+export const requestProfileImageUpload = async (memberId: number, file: File): Promise<Response> => {
+  const formData = new FormData()
+  formData.append("file", file, file.name)
+  return await fetch(`${getApiBaseUrl()}/member/api/v1/adm/members/${memberId}/profileImageFile`, {
+    method: "POST",
+    credentials: "include",
+    body: formData,
+  })
+}


### PR DESCRIPTION
## 관련 이슈

close #261

## 작업 배경

- `/admin/profile` page에 남아 있던 저장/공개 적용/이미지 업로드 보조 helper를 `AdminProfilePersistenceModel`로 분리했습니다.
- page는 SSR, 세션, 화면 상태 orchestration 중심으로 남기고 source contract로 재비대화를 막았습니다.

## 작업 내용

- `AdminProfilePersistenceModel.ts`를 추가해 revalidate, response body parsing, image source size read, image upload request helper를 소유합니다.
- `profile.tsx`는 새 모델을 import해 사용하고 page-local helper 정의를 제거했습니다.
- `admin-profile-state` spec에 persistence helper 분리 계약과 line-count 상한을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - RED: `yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1` 실패 확인 (`AdminProfilePersistenceModel.ts` 부재)
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts e2e/admin-bootstrap-state.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: browser-only helper 이동으로 import 경계가 바뀌었지만 호출 경로와 API payload는 변경하지 않았습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 page-local helper 구조로 되돌릴 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
