### PR TITLE
[Refactor] Admin profile preview rail 분리

### DIFF
--- a/front/e2e/admin-profile-state.spec.ts
+++ b/front/e2e/admin-profile-state.spec.ts
@@ -10,6 +10,10 @@ test.describe("admin profile state contract", () => {
       path.resolve(__dirname, "../src/routes/Admin/AdminProfileWorkspace.styles.ts"),
       "utf8",
     )
+    const previewSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/AdminProfilePreviewRail.tsx"),
+      "utf8",
+    )
 
     expect(styleSource).toContain("export const SectionRail = styled(AdminWorkspaceSectionNav)`")
     expect(styleSource).toContain("@media (max-width: 1360px)")
@@ -19,7 +23,7 @@ test.describe("admin profile state contract", () => {
     expect(styleSource).toContain("export const EditorActionDock = styled(AdminWorkspaceActionDock)``")
     expect(source).toContain("<AdminWorkspaceActionDockInner>")
     expect(styleSource).toContain("export const PreviewViewport = styled(AdminInfoPanelCard)`")
-    expect(source).toContain('className="identityRow"')
+    expect(previewSource).toContain('className="identityRow"')
     expect(source).toContain('id="profile-display-name"')
     expect(source).toContain('apiFetch<AuthMember>(`/member/api/v1/adm/members/${memberId}/nickname`')
     expect(styleSource).toContain("export const FieldSectionCard = styled.div`")
@@ -80,6 +84,28 @@ test.describe("admin profile state contract", () => {
     expect(source).not.toContain("const revalidatePublicBlogAppearance =")
     expect(source).not.toContain("const requestProfileImageUpload =")
     expect(source.split("\n").length).toBeLessThan(2190)
+  })
+
+  test("profile page는 preview rail 렌더링을 Admin route component로 위임한다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/profile.tsx"), "utf8")
+    const previewPath = path.resolve(__dirname, "../src/routes/Admin/AdminProfilePreviewRail.tsx")
+    expect(existsSync(previewPath)).toBe(true)
+    const previewSource = existsSync(previewPath) ? readFileSync(previewPath, "utf8") : ""
+
+    expect(source).toContain('AdminProfilePreviewRail from "src/routes/Admin/AdminProfilePreviewRail"')
+    expect(source).toContain("<AdminProfilePreviewRail")
+    expect(previewSource).toContain("export type AdminProfilePreviewRailProps")
+    expect(previewSource).toContain("export default function AdminProfilePreviewRail")
+    expect(previewSource).toContain("<PreviewRail>")
+    expect(previewSource).toContain("<PreviewProfileCard>")
+    expect(previewSource).toContain("<PreviewAboutCard>")
+    expect(previewSource).toContain("<PreviewLinksCard>")
+    expect(previewSource).toContain('className="identityRow"')
+    expect(source).not.toContain("<PreviewRail>")
+    expect(source).not.toContain("<PreviewProfileCard>")
+    expect(source).not.toContain("<PreviewAboutCard>")
+    expect(source).not.toContain("<PreviewLinksCard>")
+    expect(source.split("\n").length).toBeLessThan(2050)
   })
 
   test("profile 작업공간은 공개 노출 기준의 상세형 hero와 rail copy를 사용한다", () => {
@@ -209,6 +235,7 @@ test.describe("admin profile state contract", () => {
 
   test("profile 디자인 공개 적용은 primary action에서 저장 후 publish까지 처리한다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/profile.tsx"), "utf8")
+    const previewSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminProfilePreviewRail.tsx"), "utf8")
     const persistenceModelSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/AdminProfilePersistenceModel.ts"),
       "utf8"
@@ -223,8 +250,8 @@ test.describe("admin profile state contract", () => {
     expect(source).toContain("공개 적용과 공개 사이트 갱신을 완료했습니다.")
     expect(source).toContain('hasUnsavedChanges ? "저장 후 공개 적용" : "공개 적용"')
     expect(source).toContain("초안 저장")
-    expect(source).toContain("편집 중")
-    expect(source).toContain("현재 공개")
+    expect(previewSource).toContain("편집 중")
+    expect(previewSource).toContain("현재 공개")
     expect(source).not.toContain("로컬 변경 사항을 먼저 임시 저장한 뒤 공개할 수 있습니다.")
   })
 

--- a/front/src/pages/admin/profile.tsx
+++ b/front/src/pages/admin/profile.tsx
@@ -97,20 +97,9 @@ import {
   IconOptionButton,
   IconOptionText,
   LinkInputs,
-  PreviewRail,
-  PreviewCardShell,
-  PreviewHeader,
-  PreviewHeaderActions,
-  PreviewToggleButton,
-  PreviewBody,
   EditorActionDock,
   DockSecondaryButton,
   DockPrimaryButton,
-  PreviewViewport,
-  PreviewProfileCard,
-  PreviewAboutCard,
-  PreviewHomeCard,
-  PreviewLinksCard,
   ToastStack,
   ToastCard,
   ModalNotice,
@@ -141,6 +130,7 @@ import {
   validateLinkInputs,
   type WorkspaceSectionId,
 } from "src/routes/Admin/AdminProfileWorkspaceModel"
+import AdminProfilePreviewRail from "src/routes/Admin/AdminProfilePreviewRail"
 import {
   PROFILE_IMAGE_DRAFT_DEFAULT_SOURCE_SIZE,
   PROFILE_IMAGE_UPLOAD_RETRY_DELAY_MS,
@@ -1888,151 +1878,18 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
           </EditorActionDock>
         </EditorColumn>
 
-        <PreviewRail>
-          <PreviewCardShell data-incomplete={previewMode === "draft" && hasMissingExposureItems ? "true" : undefined}>
-            <PreviewHeader>
-              <div>
-                <strong>{activeSectionMeta.label}</strong>
-              </div>
-              <PreviewHeaderActions>
-                <SegmentedControl>
-                  <SegmentButton
-                    type="button"
-                    data-active={previewMode === "draft"}
-                    onClick={() => setPreviewMode("draft")}
-                  >
-                    편집 중
-                  </SegmentButton>
-                  <SegmentButton
-                    type="button"
-                    data-active={previewMode === "published"}
-                    onClick={() => setPreviewMode("published")}
-                  >
-                    현재 공개
-                  </SegmentButton>
-                </SegmentedControl>
-                <PreviewToggleButton
-                  type="button"
-                  aria-expanded={isPreviewExpanded}
-                  onClick={() => setIsPreviewExpanded((current) => !current)}
-                >
-                  {isPreviewExpanded ? "닫기" : "열기"}
-                </PreviewToggleButton>
-              </PreviewHeaderActions>
-            </PreviewHeader>
-
-            <PreviewBody data-expanded={isPreviewExpanded}>
-              <PreviewViewport>
-                {activeSection === "identity" ? (
-                  <PreviewProfileCard>
-                    <div className="identityRow">
-                      <div className="avatar">
-                        {previewContent.profileImageUrl ? (
-                          <ProfileImage
-                            src={previewContent.profileImageUrl}
-                            alt={displayName}
-                            width={72}
-                            height={72}
-                            priority
-                          />
-                        ) : (
-                          <AvatarFallback>{displayNameInitial}</AvatarFallback>
-                        )}
-                      </div>
-                      <div className="identityCopy">
-                        <strong>{displayName}</strong>
-                        {previewContent.profileRole ? <span>{previewContent.profileRole}</span> : null}
-                      </div>
-                    </div>
-                    {previewContent.profileBio ? <p>{previewContent.profileBio}</p> : null}
-                  </PreviewProfileCard>
-                ) : null}
-
-                {activeSection === "about" ? (
-                  <PreviewAboutCard>
-                    <header>
-                      <span>About</span>
-                      <strong>{displayName}</strong>
-                    </header>
-                    {previewContent.aboutHeadline ? <h4>{previewContent.aboutHeadline}</h4> : null}
-                    {previewContent.aboutRole ? <h4>{previewContent.aboutRole}</h4> : null}
-                    {previewContent.aboutBio ? <p>{previewContent.aboutBio}</p> : null}
-                    {previewContent.aboutProjects.length > 0 ? (
-                      <div className="sections">
-                        <section>
-                          <strong>{previewContent.aboutProjectSectionTitle || "프로젝트"}</strong>
-                          <ul>
-                            {previewContent.aboutProjects.slice(0, 3).map((project, index) => (
-                              <li key={`${project.id}-${index}`}>{project.name || "프로젝트 제목"}</li>
-                            ))}
-                          </ul>
-                        </section>
-                      </div>
-                    ) : null}
-                    {previewContent.aboutSections.length > 0 ? (
-                      <div className="sections">
-                        {previewContent.aboutSections.map((section) => (
-                          <section key={section.id}>
-                            <strong>{section.title || "블록 제목"}</strong>
-                            <ul>
-                              {section.items.slice(0, 3).map((item, index) => (
-                                <li key={`${section.id}-${index}`}>{item}</li>
-                              ))}
-                            </ul>
-                          </section>
-                        ))}
-                      </div>
-                    ) : null}
-                  </PreviewAboutCard>
-                ) : null}
-
-                {activeSection === "home" ? (
-                  <PreviewHomeCard>
-                    <span>Home</span>
-                    <strong>{previewContent.blogTitle || displayName}</strong>
-                    <h4>{previewContent.homeIntroTitle || previewContent.blogTitle || displayName}</h4>
-                    {previewContent.homeIntroDescription ? <p>{previewContent.homeIntroDescription}</p> : null}
-                  </PreviewHomeCard>
-                ) : null}
-
-                {activeSection === "design" ? (
-                  <PreviewHomeCard>
-                    <span>Design</span>
-                    <strong>{previewContent.blogDesign === "grid" ? "Grid" : "Legacy"}</strong>
-                    <p>
-                      {previewContent.blogDesign === "legacy"
-                        ? `Legacy ${previewContent.legacyBlogScheme}`
-                        : "Grid dark presentation"}
-                    </p>
-                  </PreviewHomeCard>
-                ) : null}
-
-                {activeSection === "links" ? (
-                  <PreviewLinksCard>
-                    {([
-                      ["Service", previewContent.serviceLinks],
-                      ["Contact", previewContent.contactLinks],
-                    ] as const).map(([title, items]) => (
-                      <section key={title}>
-                        <strong>{title}</strong>
-                        {items.length > 0 ? (
-                          <ul>
-                            {items.map((item) => (
-                              <li key={`${title}-${item.icon}-${item.label}-${item.href}`}>
-                                <AppIcon name={item.icon} />
-                                <span>{item.label}</span>
-                              </li>
-                            ))}
-                          </ul>
-                        ) : null}
-                      </section>
-                    ))}
-                  </PreviewLinksCard>
-                ) : null}
-              </PreviewViewport>
-            </PreviewBody>
-          </PreviewCardShell>
-        </PreviewRail>
+        <AdminProfilePreviewRail
+          activeSection={activeSection}
+          activeSectionLabel={activeSectionMeta.label}
+          displayName={displayName}
+          displayNameInitial={displayNameInitial}
+          hasMissingExposureItems={hasMissingExposureItems}
+          isPreviewExpanded={isPreviewExpanded}
+          onPreviewModeChange={setPreviewMode}
+          onToggleExpanded={() => setIsPreviewExpanded((current) => !current)}
+          previewContent={previewContent}
+          previewMode={previewMode}
+        />
       </WorkspaceShell>
 
       {pageToasts.length > 0 ? (

--- a/front/src/routes/Admin/AdminProfilePreviewRail.tsx
+++ b/front/src/routes/Admin/AdminProfilePreviewRail.tsx
@@ -1,0 +1,190 @@
+import AppIcon from "src/components/icons/AppIcon"
+import ProfileImage from "src/components/ProfileImage"
+import type { ProfileWorkspaceContent } from "src/libs/profileWorkspace"
+import {
+  AvatarFallback,
+  PreviewAboutCard,
+  PreviewBody,
+  PreviewCardShell,
+  PreviewHeader,
+  PreviewHeaderActions,
+  PreviewHomeCard,
+  PreviewLinksCard,
+  PreviewProfileCard,
+  PreviewRail,
+  PreviewToggleButton,
+  PreviewViewport,
+  SegmentButton,
+  SegmentedControl,
+} from "src/routes/Admin/AdminProfileWorkspace.styles"
+import type { PreviewMode, WorkspaceSectionId } from "src/routes/Admin/AdminProfileWorkspaceModel"
+
+export type AdminProfilePreviewRailProps = {
+  activeSection: WorkspaceSectionId
+  activeSectionLabel: string
+  displayName: string
+  displayNameInitial: string
+  hasMissingExposureItems: boolean
+  isPreviewExpanded: boolean
+  onPreviewModeChange: (mode: PreviewMode) => void
+  onToggleExpanded: () => void
+  previewContent: ProfileWorkspaceContent
+  previewMode: PreviewMode
+}
+
+export default function AdminProfilePreviewRail({
+  activeSection,
+  activeSectionLabel,
+  displayName,
+  displayNameInitial,
+  hasMissingExposureItems,
+  isPreviewExpanded,
+  onPreviewModeChange,
+  onToggleExpanded,
+  previewContent,
+  previewMode,
+}: AdminProfilePreviewRailProps) {
+  return (
+    <PreviewRail>
+      <PreviewCardShell data-incomplete={previewMode === "draft" && hasMissingExposureItems ? "true" : undefined}>
+        <PreviewHeader>
+          <div>
+            <strong>{activeSectionLabel}</strong>
+          </div>
+          <PreviewHeaderActions>
+            <SegmentedControl>
+              <SegmentButton
+                type="button"
+                data-active={previewMode === "draft"}
+                onClick={() => onPreviewModeChange("draft")}
+              >
+                편집 중
+              </SegmentButton>
+              <SegmentButton
+                type="button"
+                data-active={previewMode === "published"}
+                onClick={() => onPreviewModeChange("published")}
+              >
+                현재 공개
+              </SegmentButton>
+            </SegmentedControl>
+            <PreviewToggleButton type="button" aria-expanded={isPreviewExpanded} onClick={onToggleExpanded}>
+              {isPreviewExpanded ? "닫기" : "열기"}
+            </PreviewToggleButton>
+          </PreviewHeaderActions>
+        </PreviewHeader>
+
+        <PreviewBody data-expanded={isPreviewExpanded}>
+          <PreviewViewport>
+            {activeSection === "identity" ? (
+              <PreviewProfileCard>
+                <div className="identityRow">
+                  <div className="avatar">
+                    {previewContent.profileImageUrl ? (
+                      <ProfileImage
+                        src={previewContent.profileImageUrl}
+                        alt={displayName}
+                        width={72}
+                        height={72}
+                        priority
+                      />
+                    ) : (
+                      <AvatarFallback>{displayNameInitial}</AvatarFallback>
+                    )}
+                  </div>
+                  <div className="identityCopy">
+                    <strong>{displayName}</strong>
+                    {previewContent.profileRole ? <span>{previewContent.profileRole}</span> : null}
+                  </div>
+                </div>
+                {previewContent.profileBio ? <p>{previewContent.profileBio}</p> : null}
+              </PreviewProfileCard>
+            ) : null}
+
+            {activeSection === "about" ? (
+              <PreviewAboutCard>
+                <header>
+                  <span>About</span>
+                  <strong>{displayName}</strong>
+                </header>
+                {previewContent.aboutHeadline ? <h4>{previewContent.aboutHeadline}</h4> : null}
+                {previewContent.aboutRole ? <h4>{previewContent.aboutRole}</h4> : null}
+                {previewContent.aboutBio ? <p>{previewContent.aboutBio}</p> : null}
+                {previewContent.aboutProjects.length > 0 ? (
+                  <div className="sections">
+                    <section>
+                      <strong>{previewContent.aboutProjectSectionTitle || "프로젝트"}</strong>
+                      <ul>
+                        {previewContent.aboutProjects.slice(0, 3).map((project, index) => (
+                          <li key={`${project.id}-${index}`}>{project.name || "프로젝트 제목"}</li>
+                        ))}
+                      </ul>
+                    </section>
+                  </div>
+                ) : null}
+                {previewContent.aboutSections.length > 0 ? (
+                  <div className="sections">
+                    {previewContent.aboutSections.map((section) => (
+                      <section key={section.id}>
+                        <strong>{section.title || "블록 제목"}</strong>
+                        <ul>
+                          {section.items.slice(0, 3).map((item, index) => (
+                            <li key={`${section.id}-${index}`}>{item}</li>
+                          ))}
+                        </ul>
+                      </section>
+                    ))}
+                  </div>
+                ) : null}
+              </PreviewAboutCard>
+            ) : null}
+
+            {activeSection === "home" ? (
+              <PreviewHomeCard>
+                <span>Home</span>
+                <strong>{previewContent.blogTitle || displayName}</strong>
+                <h4>{previewContent.homeIntroTitle || previewContent.blogTitle || displayName}</h4>
+                {previewContent.homeIntroDescription ? <p>{previewContent.homeIntroDescription}</p> : null}
+              </PreviewHomeCard>
+            ) : null}
+
+            {activeSection === "design" ? (
+              <PreviewHomeCard>
+                <span>Design</span>
+                <strong>{previewContent.blogDesign === "grid" ? "Grid" : "Legacy"}</strong>
+                <p>
+                  {previewContent.blogDesign === "legacy"
+                    ? `Legacy ${previewContent.legacyBlogScheme}`
+                    : "Grid dark presentation"}
+                </p>
+              </PreviewHomeCard>
+            ) : null}
+
+            {activeSection === "links" ? (
+              <PreviewLinksCard>
+                {([
+                  ["Service", previewContent.serviceLinks],
+                  ["Contact", previewContent.contactLinks],
+                ] as const).map(([title, items]) => (
+                  <section key={title}>
+                    <strong>{title}</strong>
+                    {items.length > 0 ? (
+                      <ul>
+                        {items.map((item) => (
+                          <li key={`${title}-${item.icon}-${item.label}-${item.href}`}>
+                            <AppIcon name={item.icon} />
+                            <span>{item.label}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : null}
+                  </section>
+                ))}
+              </PreviewLinksCard>
+            ) : null}
+          </PreviewViewport>
+        </PreviewBody>
+      </PreviewCardShell>
+    </PreviewRail>
+  )
+}


### PR DESCRIPTION
## 관련 이슈

close #263

## 작업 배경

- `/admin/profile` page에 남아 있던 우측 preview rail JSX를 `AdminProfilePreviewRail` 컴포넌트로 분리했습니다.
- page는 draft/session/save/publish orchestration 중심으로 남기고 preview 렌더링은 route component가 소유합니다.

## 작업 내용

- `AdminProfilePreviewRail.tsx`를 추가해 identity/about/home/design/links preview rail 렌더링을 소유합니다.
- `profile.tsx`는 preview rail에 필요한 상태와 핸들러만 props로 전달하도록 정리했습니다.
- `admin-profile-state` spec에 preview rail 분리 계약과 page line-count 상한을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - RED: `yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1` 실패 확인 (`AdminProfilePreviewRail.tsx` 부재)
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts e2e/admin-bootstrap-state.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: preview rail props 경계가 새로 생겼지만 표시 문자열과 렌더링 조건은 기존 JSX를 그대로 이동했습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 preview rail JSX가 page-local 구조로 되돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
