### PR TITLE
[Refactor] Admin profile image modal 분리

### DIFF
--- a/front/e2e/admin-profile-state.spec.ts
+++ b/front/e2e/admin-profile-state.spec.ts
@@ -108,6 +108,28 @@ test.describe("admin profile state contract", () => {
     expect(source.split("\n").length).toBeLessThan(2050)
   })
 
+  test("profile page는 이미지 편집 modal 렌더링을 Admin route component로 위임한다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/profile.tsx"), "utf8")
+    const modalPath = path.resolve(__dirname, "../src/routes/Admin/AdminProfileImageEditorModal.tsx")
+    expect(existsSync(modalPath)).toBe(true)
+    const modalSource = existsSync(modalPath) ? readFileSync(modalPath, "utf8") : ""
+
+    expect(source).toContain('AdminProfileImageEditorModal from "src/routes/Admin/AdminProfileImageEditorModal"')
+    expect(source).toContain("<AdminProfileImageEditorModal")
+    expect(modalSource).toContain("export type AdminProfileImageEditorModalProps")
+    expect(modalSource).toContain("export default function AdminProfileImageEditorModal")
+    expect(modalSource).toContain("<ModalOverlay")
+    expect(modalSource).toContain("<ModalEditorFrame")
+    expect(modalSource).toContain("<ModalSliderWrap")
+    expect(modalSource).toContain("프로필 이미지 편집")
+    expect(modalSource).toContain("편집 결과 저장")
+    expect(source).not.toContain("<ModalOverlay")
+    expect(source).not.toContain("<ModalEditorFrame")
+    expect(source).not.toContain("<ModalSliderWrap")
+    expect(source).not.toContain('aria-label="프로필 이미지 편집"')
+    expect(source.split("\n").length).toBeLessThan(1950)
+  })
+
   test("profile 작업공간은 공개 노출 기준의 상세형 hero와 rail copy를 사용한다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/profile.tsx"), "utf8")
 

--- a/front/src/pages/admin/profile.tsx
+++ b/front/src/pages/admin/profile.tsx
@@ -35,7 +35,6 @@ import {
   ProfileImageSourceSize,
   PROFILE_IMAGE_EDIT_DEFAULT_FOCUS_X,
   PROFILE_IMAGE_EDIT_DEFAULT_FOCUS_Y,
-  PROFILE_IMAGE_EDIT_MAX_ZOOM,
   PROFILE_IMAGE_EDIT_MIN_ZOOM,
   resolveProfileImageEditDrawRatios,
 } from "src/libs/profileImageUpload"
@@ -52,7 +51,6 @@ import {
   Main,
   BaseButton,
   GhostButton,
-  PrimaryButton,
   PublishButton,
   MiniButton,
   DangerButton,
@@ -102,18 +100,7 @@ import {
   DockPrimaryButton,
   ToastStack,
   ToastCard,
-  ModalNotice,
   AvatarFallback,
-  ModalOverlay,
-  ModalCard,
-  ModalHeader,
-  ModalCloseButton,
-  ModalConstraintList,
-  ModalActions,
-  ModalEditorFrame,
-  ModalSliderWrap,
-  ModalEmptyState,
-  ModalFooter,
 } from "src/routes/Admin/AdminProfileWorkspace.styles"
 import {
   WORKSPACE_SECTIONS,
@@ -130,6 +117,7 @@ import {
   validateLinkInputs,
   type WorkspaceSectionId,
 } from "src/routes/Admin/AdminProfileWorkspaceModel"
+import AdminProfileImageEditorModal from "src/routes/Admin/AdminProfileImageEditorModal"
 import AdminProfilePreviewRail from "src/routes/Admin/AdminProfilePreviewRail"
 import {
   PROFILE_IMAGE_DRAFT_DEFAULT_SOURCE_SIZE,
@@ -1903,124 +1891,32 @@ const AdminProfileWorkspacePage: NextPage<AdminProfileWorkspacePageProps> = ({
       ) : null}
 
       {isProfileImageEditorOpen ? (
-        <ModalOverlay
-          role="presentation"
-          onClick={(event) => {
-            if (event.target === event.currentTarget && loadingKey !== "upload") {
-              setIsProfileImageEditorOpen(false)
-              resetProfileImageDraftInteractions()
-            }
+        <AdminProfileImageEditorModal
+          frameRef={profileImageDraftFrameRef}
+          hasDraftFile={Boolean(profileImageDraftFile)}
+          isDragging={isProfileImageDraftDragging}
+          isUploading={loadingKey === "upload"}
+          notice={profileImageDraftNotice}
+          onApply={() => void handleApplyProfileImageDraft()}
+          onClear={clearProfileImageDraft}
+          onPointerCancel={finalizeProfileImageDraftPointer}
+          onPointerDown={handleProfileImageDraftPointerDown}
+          onPointerMove={handleProfileImageDraftPointerMove}
+          onPointerUp={finalizeProfileImageDraftPointer}
+          onRequestClose={() => {
+            setIsProfileImageEditorOpen(false)
+            resetProfileImageDraftInteractions()
           }}
-        >
-          <ModalCard role="dialog" aria-modal="true" aria-label="프로필 이미지 편집">
-            <ModalHeader>
-              <div>
-                <h2>프로필 이미지 편집</h2>
-              </div>
-              <ModalCloseButton
-                type="button"
-                disabled={loadingKey === "upload"}
-                onClick={() => {
-                  setIsProfileImageEditorOpen(false)
-                  resetProfileImageDraftInteractions()
-                }}
-              >
-                <AppIcon name="close" />
-              </ModalCloseButton>
-            </ModalHeader>
-
-            <ModalConstraintList>
-              <li>지원 형식: JPG/PNG/GIF/WebP</li>
-              <li>업로드 기준: 자동 최적화 후 최대 2MB</li>
-            </ModalConstraintList>
-
-            <ModalActions>
-              <GhostButton type="button" onClick={() => profileImageFileInputRef.current?.click()} disabled={loadingKey === "upload"}>
-                파일 선택
-              </GhostButton>
-              <GhostButton type="button" onClick={clearProfileImageDraft} disabled={loadingKey === "upload"}>
-                편집값 초기화
-              </GhostButton>
-            </ModalActions>
-
-            {profileImageDraftPreviewUrl ? (
-              <>
-                <ModalEditorFrame
-                  ref={profileImageDraftFrameRef}
-                  data-draggable={profileImageDraftFile ? "true" : "false"}
-                  data-dragging={isProfileImageDraftDragging ? "true" : "false"}
-                  onPointerDown={handleProfileImageDraftPointerDown}
-                  onPointerMove={handleProfileImageDraftPointerMove}
-                  onPointerUp={finalizeProfileImageDraftPointer}
-                  onPointerCancel={finalizeProfileImageDraftPointer}
-                >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={profileImageDraftPreviewUrl}
-                    alt="프로필 편집 미리보기"
-                    loading="eager"
-                    decoding="async"
-                    style={{
-                      objectFit: "cover",
-                      width: "var(--profile-draft-width)",
-                      height: "var(--profile-draft-height)",
-                      left: "var(--profile-draft-left)",
-                      top: "var(--profile-draft-top)",
-                      maxWidth: "none",
-                      transform: "translateZ(0)",
-                    }}
-                    draggable={false}
-                  />
-                </ModalEditorFrame>
-
-                <ModalSliderWrap>
-                  <label htmlFor="profile-image-zoom">확대/축소</label>
-                  <input
-                    id="profile-image-zoom"
-                    type="range"
-                    min={PROFILE_IMAGE_EDIT_MIN_ZOOM}
-                    max={PROFILE_IMAGE_EDIT_MAX_ZOOM}
-                    step={0.01}
-                    value={profileImageDraftZoom}
-                    onChange={(event) =>
-                      scheduleProfileImageDraftTransform({
-                        ...profileImageDraftTransformRef.current,
-                        zoom: clampProfileImageEditZoom(Number(event.target.value)),
-                      })
-                    }
-                  />
-                  <span>{profileImageDraftZoom.toFixed(2)}x</span>
-                </ModalSliderWrap>
-              </>
-            ) : (
-              <ModalEmptyState>먼저 프로필 이미지를 선택해주세요.</ModalEmptyState>
-            )}
-
-            {profileImageDraftNotice.text ? (
-              <ModalNotice data-tone={profileImageDraftNotice.tone}>{profileImageDraftNotice.text}</ModalNotice>
-            ) : null}
-
-            <ModalFooter>
-              <GhostButton
-                type="button"
-                disabled={loadingKey === "upload"}
-                onClick={() => {
-                  setIsProfileImageEditorOpen(false)
-                  resetProfileImageDraftInteractions()
-                }}
-              >
-                취소
-              </GhostButton>
-              <PrimaryButton
-                type="button"
-                disabled={loadingKey === "upload" || !profileImageDraftFile}
-                onClick={() => void handleApplyProfileImageDraft()}
-              >
-                {loadingKey === "upload" ? "저장 중..." : "편집 결과 저장"}
-              </PrimaryButton>
-            </ModalFooter>
-          </ModalCard>
-        </ModalOverlay>
+          onSelectFile={() => profileImageFileInputRef.current?.click()}
+          onZoomChange={(zoom) =>
+            scheduleProfileImageDraftTransform({
+              ...profileImageDraftTransformRef.current,
+              zoom: clampProfileImageEditZoom(zoom),
+            })
+          }
+          previewUrl={profileImageDraftPreviewUrl}
+          zoom={profileImageDraftZoom}
+        />
       ) : null}
       </Main>
     </AdminShell>

--- a/front/src/routes/Admin/AdminProfileImageEditorModal.tsx
+++ b/front/src/routes/Admin/AdminProfileImageEditorModal.tsx
@@ -1,0 +1,161 @@
+import type { PointerEventHandler, Ref } from "react"
+import AppIcon from "src/components/icons/AppIcon"
+import { PROFILE_IMAGE_EDIT_MAX_ZOOM, PROFILE_IMAGE_EDIT_MIN_ZOOM } from "src/libs/profileImageUpload"
+import {
+  GhostButton,
+  ModalActions,
+  ModalCard,
+  ModalCloseButton,
+  ModalConstraintList,
+  ModalEditorFrame,
+  ModalEmptyState,
+  ModalFooter,
+  ModalHeader,
+  ModalNotice,
+  ModalOverlay,
+  ModalSliderWrap,
+  PrimaryButton,
+} from "src/routes/Admin/AdminProfileWorkspace.styles"
+
+type ModalNoticeTone = "idle" | "loading" | "success" | "error"
+
+export type AdminProfileImageEditorModalProps = {
+  frameRef: Ref<HTMLDivElement>
+  hasDraftFile: boolean
+  isDragging: boolean
+  isUploading: boolean
+  notice: {
+    tone: ModalNoticeTone
+    text: string
+  }
+  onApply: () => void
+  onClear: () => void
+  onPointerCancel: PointerEventHandler<HTMLDivElement>
+  onPointerDown: PointerEventHandler<HTMLDivElement>
+  onPointerMove: PointerEventHandler<HTMLDivElement>
+  onPointerUp: PointerEventHandler<HTMLDivElement>
+  onRequestClose: () => void
+  onSelectFile: () => void
+  onZoomChange: (zoom: number) => void
+  previewUrl: string
+  zoom: number
+}
+
+export default function AdminProfileImageEditorModal({
+  frameRef,
+  hasDraftFile,
+  isDragging,
+  isUploading,
+  notice,
+  onApply,
+  onClear,
+  onPointerCancel,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  onRequestClose,
+  onSelectFile,
+  onZoomChange,
+  previewUrl,
+  zoom,
+}: AdminProfileImageEditorModalProps) {
+  const closeWhenIdle = () => {
+    if (isUploading) return
+    onRequestClose()
+  }
+
+  return (
+    <ModalOverlay
+      role="presentation"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          closeWhenIdle()
+        }
+      }}
+    >
+      <ModalCard role="dialog" aria-modal="true" aria-label="프로필 이미지 편집">
+        <ModalHeader>
+          <div>
+            <h2>프로필 이미지 편집</h2>
+          </div>
+          <ModalCloseButton type="button" disabled={isUploading} onClick={closeWhenIdle}>
+            <AppIcon name="close" />
+          </ModalCloseButton>
+        </ModalHeader>
+
+        <ModalConstraintList>
+          <li>지원 형식: JPG/PNG/GIF/WebP</li>
+          <li>업로드 기준: 자동 최적화 후 최대 2MB</li>
+        </ModalConstraintList>
+
+        <ModalActions>
+          <GhostButton type="button" onClick={onSelectFile} disabled={isUploading}>
+            파일 선택
+          </GhostButton>
+          <GhostButton type="button" onClick={onClear} disabled={isUploading}>
+            편집값 초기화
+          </GhostButton>
+        </ModalActions>
+
+        {previewUrl ? (
+          <>
+            <ModalEditorFrame
+              ref={frameRef}
+              data-draggable={hasDraftFile ? "true" : "false"}
+              data-dragging={isDragging ? "true" : "false"}
+              onPointerDown={onPointerDown}
+              onPointerMove={onPointerMove}
+              onPointerUp={onPointerUp}
+              onPointerCancel={onPointerCancel}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={previewUrl}
+                alt="프로필 편집 미리보기"
+                loading="eager"
+                decoding="async"
+                style={{
+                  objectFit: "cover",
+                  width: "var(--profile-draft-width)",
+                  height: "var(--profile-draft-height)",
+                  left: "var(--profile-draft-left)",
+                  top: "var(--profile-draft-top)",
+                  maxWidth: "none",
+                  transform: "translateZ(0)",
+                }}
+                draggable={false}
+              />
+            </ModalEditorFrame>
+
+            <ModalSliderWrap>
+              <label htmlFor="profile-image-zoom">확대/축소</label>
+              <input
+                id="profile-image-zoom"
+                type="range"
+                min={PROFILE_IMAGE_EDIT_MIN_ZOOM}
+                max={PROFILE_IMAGE_EDIT_MAX_ZOOM}
+                step={0.01}
+                value={zoom}
+                onChange={(event) => onZoomChange(Number(event.target.value))}
+              />
+              <span>{zoom.toFixed(2)}x</span>
+            </ModalSliderWrap>
+          </>
+        ) : (
+          <ModalEmptyState>먼저 프로필 이미지를 선택해주세요.</ModalEmptyState>
+        )}
+
+        {notice.text ? <ModalNotice data-tone={notice.tone}>{notice.text}</ModalNotice> : null}
+
+        <ModalFooter>
+          <GhostButton type="button" disabled={isUploading} onClick={closeWhenIdle}>
+            취소
+          </GhostButton>
+          <PrimaryButton type="button" disabled={isUploading || !hasDraftFile} onClick={onApply}>
+            {isUploading ? "저장 중..." : "편집 결과 저장"}
+          </PrimaryButton>
+        </ModalFooter>
+      </ModalCard>
+    </ModalOverlay>
+  )
+}


### PR DESCRIPTION
## 관련 이슈

close #265

## 작업 배경

- `/admin/profile`의 프로필 이미지 편집 modal 렌더링을 `AdminProfileImageEditorModal` route component로 분리했습니다.
- 이미지 편집 상태, pan/zoom, 저장 액션은 page orchestration에 유지하고 modal surface만 분리해 유지보수 범위를 줄였습니다.

## 작업 내용

- `front/src/routes/Admin/AdminProfileImageEditorModal.tsx`를 추가해 overlay/dialog/editor frame/zoom slider/notice/footer 렌더링을 소유하게 했습니다.
- `front/src/pages/admin/profile.tsx`는 modal open state와 handlers만 props로 전달하도록 정리했습니다.
- `front/e2e/admin-profile-state.spec.ts`에 modal 분리 계약과 page line count 상한을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `env PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1`
  - `env PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts e2e/admin-bootstrap-state.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `env PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: modal props wiring 누락 시 이미지 선택/편집/저장 UX가 회귀할 수 있습니다. 계약 테스트와 build로 분리 경계를 확인했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `e26f3232`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
