### PR TITLE
[Refactor] Admin tools results panel 분리

### DIFF
--- a/front/e2e/admin-surface-primitives.spec.ts
+++ b/front/e2e/admin-surface-primitives.spec.ts
@@ -178,6 +178,10 @@ test.describe("admin surface primitives contract", () => {
 
   test("tools workspace uses detail-like hero copy and ops rail labels", () => {
     const toolsSource = readFileSync(path.resolve(__dirname, "../src/pages/admin/tools.tsx"), "utf8")
+    const toolsResultsSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/AdminToolsResultsPanel.tsx"),
+      "utf8",
+    )
     const toolsStyleSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/AdminToolsWorkspace.styles.ts"),
       "utf8",
@@ -187,7 +191,7 @@ test.describe("admin surface primitives contract", () => {
     expect(toolsStyleSource).toContain("grid-template-columns: repeat(auto-fit, minmax(13.5rem, 1fr));")
     expect(toolsSource).toContain("<h2>메일과 큐</h2>")
     expect(toolsSource).toContain("<h2>정리와 보안</h2>")
-    expect(toolsSource).toContain("<h2>최근 진단 결과</h2>")
+    expect(toolsResultsSource).toContain("<h2>최근 진단 결과</h2>")
     expect(toolsSource).not.toContain("<h2>진단</h2>")
     expect(toolsSource).not.toContain("<h2>실행</h2>")
     expect(toolsSource).not.toContain("<h2>최근 실행 결과</h2>")

--- a/front/e2e/admin-tools-state.spec.ts
+++ b/front/e2e/admin-tools-state.spec.ts
@@ -45,4 +45,28 @@ test.describe("admin tools state contract", () => {
     expect(source).not.toContain("복구 전에 같이 읽어야 할 화면과 기록으로 바로 이동합니다.")
     expect(source).not.toContain('data-emphasis="primary"')
   })
+
+  test("운영 도구는 최근 진단 결과 panel 렌더링을 Admin route component로 위임한다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/tools.tsx"), "utf8")
+    const resultsPanelPath = path.resolve(__dirname, "../src/routes/Admin/AdminToolsResultsPanel.tsx")
+    expect(existsSync(resultsPanelPath)).toBe(true)
+    const resultsPanelSource = existsSync(resultsPanelPath) ? readFileSync(resultsPanelPath, "utf8") : ""
+
+    expect(source).toContain('AdminToolsResultsPanel from "src/routes/Admin/AdminToolsResultsPanel"')
+    expect(source).toContain("<AdminToolsResultsPanel")
+    expect(resultsPanelSource).toContain("export type AdminToolsResultsPanelProps")
+    expect(resultsPanelSource).toContain("export default function AdminToolsResultsPanel")
+    expect(resultsPanelSource).toContain("<ResultFilterRow")
+    expect(resultsPanelSource).toContain("<ResultsLayout")
+    expect(resultsPanelSource).toContain("<ResultPrimaryCard")
+    expect(resultsPanelSource).toContain("<ResultHistoryCard")
+    expect(resultsPanelSource).toContain("<EmptyResultState")
+    expect(resultsPanelSource).toContain("최근 진단 결과")
+    expect(source).not.toContain("<ResultFilterRow")
+    expect(source).not.toContain("<ResultsLayout")
+    expect(source).not.toContain("<ResultPrimaryCard")
+    expect(source).not.toContain("<ResultHistoryCard")
+    expect(source).not.toContain("<EmptyResultState")
+    expect(source.split("\n").length).toBeLessThan(1760)
+  })
 })

--- a/front/src/pages/admin/tools.tsx
+++ b/front/src/pages/admin/tools.tsx
@@ -97,22 +97,8 @@ import {
   DangerActionRow,
   ConfirmDeleteRow,
   DangerButton,
-  ResultFilterRow,
-  ResultFilterButton,
-  ResultsLayout,
-  ResultPrimaryCard,
-  ResultTop,
-  ResultBadgeRow,
-  ResultMetaGrid,
-  ResultSummary,
-  ResultHistoryCard,
-  HistoryList,
-  HistoryButton,
-  ResultPanel,
-  EmptyResultState,
 } from "src/routes/Admin/AdminToolsWorkspace.styles"
-
-const pretty = (value: JsonValue) => JSON.stringify(value, null, 2)
+import AdminToolsResultsPanel from "src/routes/Admin/AdminToolsResultsPanel"
 
 type SignupMailDiagnostics = {
   status: string
@@ -1741,114 +1727,16 @@ const AdminToolsPage: NextPage<AdminToolsPageProps> = ({ initialMember, initialS
             </ExecutionLayout>
           </WorkspaceSection>
 
-          <WorkspaceSection id={SECTION_IDS.results} data-ops-section="results" data-emphasis="secondary">
-            <SectionHeading>
-              <SectionTitleBlock>
-                <h2>최근 진단 결과</h2>
-              </SectionTitleBlock>
-            </SectionHeading>
-
-            <ResultFilterRow aria-label="실행 결과 필터">
-              <ResultFilterButton
-                type="button"
-                data-active={resultsFilter === "all"}
-                onClick={() => setResultsFilter("all")}
-              >
-                전체
-                <span>{resultFilterCounts.all}</span>
-              </ResultFilterButton>
-              <ResultFilterButton
-                type="button"
-                data-active={resultsFilter === "success"}
-                onClick={() => setResultsFilter("success")}
-              >
-                성공
-                <span>{resultFilterCounts.success}</span>
-              </ResultFilterButton>
-              <ResultFilterButton
-                type="button"
-                data-active={resultsFilter === "error"}
-                onClick={() => setResultsFilter("error")}
-              >
-                실패
-                <span>{resultFilterCounts.error}</span>
-              </ResultFilterButton>
-              <ResultFilterButton
-                type="button"
-                data-active={resultsFilter === "stale"}
-                onClick={() => setResultsFilter("stale")}
-              >
-                오래됨
-                <span>{resultFilterCounts.stale}</span>
-              </ResultFilterButton>
-            </ResultFilterRow>
-
-            {selectedExecution ? (
-              <ResultsLayout>
-                <ResultPrimaryCard>
-                  <ResultTop>
-                    <div>
-                      <small>방금 실행한 작업</small>
-                      <strong>{selectedExecution.source}</strong>
-                    </div>
-                    <ResultBadgeRow>
-                      <ActionToneBadge data-tone={selectedExecution.status === "error" ? "danger" : selectedExecution.tone === "danger" ? "danger" : selectedExecution.tone === "write" ? "write" : "read"}>
-                        {selectedExecution.status === "error" ? "실패" : "성공"}
-                      </ActionToneBadge>
-                      <FreshnessBadge data-tone={getFreshnessMeta(selectedExecution.completedAt, freshnessClock).tone}>
-                        {getFreshnessMeta(selectedExecution.completedAt, freshnessClock).label}
-                      </FreshnessBadge>
-                    </ResultBadgeRow>
-                  </ResultTop>
-                  <ResultMetaGrid>
-                    <SubtleMetaItem>
-                      <span>영역</span>
-                      <strong>{selectedExecution.domain}</strong>
-                    </SubtleMetaItem>
-                    <SubtleMetaItem>
-                      <span>실행 시각</span>
-                      <strong>{formatInstant(selectedExecution.completedAt)}</strong>
-                    </SubtleMetaItem>
-                  </ResultMetaGrid>
-                  <ResultSummary>{selectedExecution.summary}</ResultSummary>
-                  <DetailsPanel>
-                    <DetailsSummary>
-                      <span>원본 응답 보기</span>
-                      <small>JSON</small>
-                    </DetailsSummary>
-                    <ResultPanel>{pretty(selectedExecution.payload)}</ResultPanel>
-                  </DetailsPanel>
-                </ResultPrimaryCard>
-
-                <ResultHistoryCard>
-                  <CardSectionHeading>
-                    <div>
-                      <h3>최근 기록</h3>
-                    </div>
-                  </CardSectionHeading>
-                  <HistoryList>
-                    {filteredExecutions.map((entry) => (
-                      <HistoryButton
-                        key={entry.id}
-                        type="button"
-                        data-active={selectedExecution.id === entry.id}
-                        onClick={() => setSelectedExecutionId(entry.id)}
-                      >
-                        <span>{entry.source}</span>
-                        <small>
-                          {entry.status === "error" ? "실패" : "성공"} · {formatInstant(entry.completedAt)} · {getFreshnessMeta(entry.completedAt, freshnessClock).label}
-                        </small>
-                      </HistoryButton>
-                    ))}
-                  </HistoryList>
-                </ResultHistoryCard>
-              </ResultsLayout>
-              ) : (
-              <EmptyResultState>
-                {executions.length === 0 ? "실행 기록 없음" : "현재 필터에 맞는 실행 결과가 없습니다."}
-              </EmptyResultState>
-            )}
-          </WorkspaceSection>
+          <AdminToolsResultsPanel
+            executions={executions}
+            filteredExecutions={filteredExecutions}
+            freshnessClock={freshnessClock}
+            onResultFilterChange={setResultsFilter}
+            onSelectedExecutionChange={setSelectedExecutionId}
+            resultFilterCounts={resultFilterCounts}
+            resultsFilter={resultsFilter}
+            selectedExecution={selectedExecution}
+          />
 
         </WorkspaceColumn>
       </WorkspaceShell>

--- a/front/src/routes/Admin/AdminToolsResultsPanel.tsx
+++ b/front/src/routes/Admin/AdminToolsResultsPanel.tsx
@@ -1,0 +1,163 @@
+import {
+  formatInstant,
+  getFreshnessMeta,
+  SECTION_IDS,
+  type ExecutionEntry,
+  type ExecutionResultFilter,
+} from "src/routes/Admin/AdminToolsWorkspaceModel"
+import {
+  ActionToneBadge,
+  CardSectionHeading,
+  DetailsPanel,
+  DetailsSummary,
+  EmptyResultState,
+  FreshnessBadge,
+  HistoryButton,
+  HistoryList,
+  ResultBadgeRow,
+  ResultFilterButton,
+  ResultFilterRow,
+  ResultHistoryCard,
+  ResultMetaGrid,
+  ResultPanel,
+  ResultPrimaryCard,
+  ResultSummary,
+  ResultsLayout,
+  ResultTop,
+  SectionHeading,
+  SectionTitleBlock,
+  SubtleMetaItem,
+  WorkspaceSection,
+} from "src/routes/Admin/AdminToolsWorkspace.styles"
+
+const pretty = (value: unknown) => JSON.stringify(value, null, 2)
+
+export type AdminToolsResultsPanelProps = {
+  executions: ExecutionEntry[]
+  filteredExecutions: ExecutionEntry[]
+  freshnessClock: number | null
+  onResultFilterChange: (filter: ExecutionResultFilter) => void
+  onSelectedExecutionChange: (id: string) => void
+  resultFilterCounts: Record<ExecutionResultFilter, number>
+  resultsFilter: ExecutionResultFilter
+  selectedExecution: ExecutionEntry | null
+}
+
+const RESULT_FILTERS: Array<{ key: ExecutionResultFilter; label: string }> = [
+  { key: "all", label: "전체" },
+  { key: "success", label: "성공" },
+  { key: "error", label: "실패" },
+  { key: "stale", label: "오래됨" },
+]
+
+export default function AdminToolsResultsPanel({
+  executions,
+  filteredExecutions,
+  freshnessClock,
+  onResultFilterChange,
+  onSelectedExecutionChange,
+  resultFilterCounts,
+  resultsFilter,
+  selectedExecution,
+}: AdminToolsResultsPanelProps) {
+  return (
+    <WorkspaceSection id={SECTION_IDS.results} data-ops-section="results" data-emphasis="secondary">
+      <SectionHeading>
+        <SectionTitleBlock>
+          <h2>최근 진단 결과</h2>
+        </SectionTitleBlock>
+      </SectionHeading>
+
+      <ResultFilterRow aria-label="실행 결과 필터">
+        {RESULT_FILTERS.map((filter) => (
+          <ResultFilterButton
+            key={filter.key}
+            type="button"
+            data-active={resultsFilter === filter.key}
+            onClick={() => onResultFilterChange(filter.key)}
+          >
+            {filter.label}
+            <span>{resultFilterCounts[filter.key]}</span>
+          </ResultFilterButton>
+        ))}
+      </ResultFilterRow>
+
+      {selectedExecution ? (
+        <ResultsLayout>
+          <ResultPrimaryCard>
+            <ResultTop>
+              <div>
+                <small>방금 실행한 작업</small>
+                <strong>{selectedExecution.source}</strong>
+              </div>
+              <ResultBadgeRow>
+                <ActionToneBadge
+                  data-tone={
+                    selectedExecution.status === "error"
+                      ? "danger"
+                      : selectedExecution.tone === "danger"
+                        ? "danger"
+                        : selectedExecution.tone === "write"
+                          ? "write"
+                          : "read"
+                  }
+                >
+                  {selectedExecution.status === "error" ? "실패" : "성공"}
+                </ActionToneBadge>
+                <FreshnessBadge data-tone={getFreshnessMeta(selectedExecution.completedAt, freshnessClock).tone}>
+                  {getFreshnessMeta(selectedExecution.completedAt, freshnessClock).label}
+                </FreshnessBadge>
+              </ResultBadgeRow>
+            </ResultTop>
+            <ResultMetaGrid>
+              <SubtleMetaItem>
+                <span>영역</span>
+                <strong>{selectedExecution.domain}</strong>
+              </SubtleMetaItem>
+              <SubtleMetaItem>
+                <span>실행 시각</span>
+                <strong>{formatInstant(selectedExecution.completedAt)}</strong>
+              </SubtleMetaItem>
+            </ResultMetaGrid>
+            <ResultSummary>{selectedExecution.summary}</ResultSummary>
+            <DetailsPanel>
+              <DetailsSummary>
+                <span>원본 응답 보기</span>
+                <small>JSON</small>
+              </DetailsSummary>
+              <ResultPanel>{pretty(selectedExecution.payload)}</ResultPanel>
+            </DetailsPanel>
+          </ResultPrimaryCard>
+
+          <ResultHistoryCard>
+            <CardSectionHeading>
+              <div>
+                <h3>최근 기록</h3>
+              </div>
+            </CardSectionHeading>
+            <HistoryList>
+              {filteredExecutions.map((entry) => (
+                <HistoryButton
+                  key={entry.id}
+                  type="button"
+                  data-active={selectedExecution.id === entry.id}
+                  onClick={() => onSelectedExecutionChange(entry.id)}
+                >
+                  <span>{entry.source}</span>
+                  <small>
+                    {entry.status === "error" ? "실패" : "성공"} · {formatInstant(entry.completedAt)} ·{" "}
+                    {getFreshnessMeta(entry.completedAt, freshnessClock).label}
+                  </small>
+                </HistoryButton>
+              ))}
+            </HistoryList>
+          </ResultHistoryCard>
+        </ResultsLayout>
+      ) : (
+        <EmptyResultState>
+          {executions.length === 0 ? "실행 기록 없음" : "현재 필터에 맞는 실행 결과가 없습니다."}
+        </EmptyResultState>
+      )}
+    </WorkspaceSection>
+  )
+}


### PR DESCRIPTION
## 관련 이슈

close #267

## 작업 배경

- `/admin/tools`의 최근 진단 결과 section 렌더링을 `AdminToolsResultsPanel` route component로 분리했습니다.
- 실행 기록 생성, 필터링, 선택 state 계산은 page에 유지하고 결과 panel UI만 분리해 page orchestration 범위를 줄였습니다.

## 작업 내용

- `front/src/routes/Admin/AdminToolsResultsPanel.tsx`를 추가해 결과 필터, 선택 결과 카드, 최근 기록 리스트, empty state를 소유하게 했습니다.
- `front/src/pages/admin/tools.tsx`는 계산된 execution props를 `AdminToolsResultsPanel`에 전달하도록 정리했습니다.
- `front/e2e/admin-tools-state.spec.ts`와 `front/e2e/admin-surface-primitives.spec.ts`에 results panel 분리 계약을 반영했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `env PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/admin-tools-state.spec.ts --workers=1`
  - `env PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts e2e/admin-bootstrap-state.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `env PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: results panel props wiring 누락 시 실행 결과 필터나 최근 기록 선택 UX가 회귀할 수 있습니다. source 계약 테스트와 build/perf로 분리 경계를 확인했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `2b08112e`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
