### PR TITLE
[Refactor] Admin tools execution rail 분리

### DIFF
--- a/front/e2e/admin-surface-primitives.spec.ts
+++ b/front/e2e/admin-surface-primitives.spec.ts
@@ -178,6 +178,10 @@ test.describe("admin surface primitives contract", () => {
 
   test("tools workspace uses detail-like hero copy and ops rail labels", () => {
     const toolsSource = readFileSync(path.resolve(__dirname, "../src/pages/admin/tools.tsx"), "utf8")
+    const toolsExecutionRailSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/AdminToolsExecutionRail.tsx"),
+      "utf8",
+    )
     const toolsResultsSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/AdminToolsResultsPanel.tsx"),
       "utf8",
@@ -199,9 +203,9 @@ test.describe("admin surface primitives contract", () => {
     expect(toolsStyleSource).toContain("AdminStickyRail,")
     expect(toolsStyleSource).toContain("export const ExecutionLayout = styled.div`")
     expect(toolsStyleSource).toContain("export const ExecutionRail = styled(AdminStickyRail)`")
-    expect(toolsSource).toContain("<h3>실행 전 체크</h3>")
-    expect(toolsSource).toContain("<h3>위험 액션</h3>")
-    expect(toolsSource).toContain("<h3>런북/장애 문서</h3>")
+    expect(toolsExecutionRailSource).toContain("<h3>실행 전 체크</h3>")
+    expect(toolsExecutionRailSource).toContain("<h3>위험 액션</h3>")
+    expect(toolsExecutionRailSource).toContain("<h3>런북/장애 문서</h3>")
     expect(toolsSource).not.toContain("메일, 작업 큐, 정리 상태, 보안 이벤트처럼 장애와 직접 연결되는 항목만 우선 다룹니다.")
     expect(toolsSource).not.toContain("운영 변경 없이 현재 상태와 영향 범위를 먼저 다시 확인합니다.")
     expect(toolsSource).not.toContain("<ExecutionGrid>")

--- a/front/e2e/admin-tools-state.spec.ts
+++ b/front/e2e/admin-tools-state.spec.ts
@@ -69,4 +69,27 @@ test.describe("admin tools state contract", () => {
     expect(source).not.toContain("<EmptyResultState")
     expect(source.split("\n").length).toBeLessThan(1760)
   })
+
+  test("운영 도구는 execution rail 렌더링을 Admin route component로 위임한다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/tools.tsx"), "utf8")
+    const executionRailPath = path.resolve(__dirname, "../src/routes/Admin/AdminToolsExecutionRail.tsx")
+    expect(existsSync(executionRailPath)).toBe(true)
+    const executionRailSource = existsSync(executionRailPath) ? readFileSync(executionRailPath, "utf8") : ""
+
+    expect(source).toContain('AdminToolsExecutionRail from "src/routes/Admin/AdminToolsExecutionRail"')
+    expect(source).toContain("<AdminToolsExecutionRail")
+    expect(executionRailSource).toContain("export type AdminToolsExecutionRailProps")
+    expect(executionRailSource).toContain("export default function AdminToolsExecutionRail")
+    expect(executionRailSource).toContain("<ExecutionRail")
+    expect(executionRailSource).toContain("<ActionGroupCard")
+    expect(executionRailSource).toContain("실행 전 체크")
+    expect(executionRailSource).toContain("위험 액션")
+    expect(executionRailSource).toContain("런북/장애 문서")
+    expect(source).not.toContain("<ExecutionRail")
+    expect(source).not.toContain("<ActionGroupCard")
+    expect(source).not.toContain("실행 전 체크")
+    expect(source).not.toContain("위험 액션")
+    expect(source).not.toContain("런북/장애 문서")
+    expect(source.split("\n").length).toBeLessThan(1700)
+  })
 })

--- a/front/src/pages/admin/tools.tsx
+++ b/front/src/pages/admin/tools.tsx
@@ -77,20 +77,14 @@ import {
   CompactCodeList,
   ExecutionLayout,
   ExecutionMain,
-  ExecutionRail,
-  ActionGroupCard,
-  CardSectionHeading,
   ActionToneBadge,
   ActionList,
   ActionRowButton,
-  ActionRowLink,
-  FieldStack,
   FieldGrid,
   FieldBox,
   FieldLabel,
   Input,
   TextArea,
-  PrimaryButton,
   DangerPanel,
   SandboxSection,
   SandboxHeader,
@@ -98,6 +92,7 @@ import {
   ConfirmDeleteRow,
   DangerButton,
 } from "src/routes/Admin/AdminToolsWorkspace.styles"
+import AdminToolsExecutionRail from "src/routes/Admin/AdminToolsExecutionRail"
 import AdminToolsResultsPanel from "src/routes/Admin/AdminToolsResultsPanel"
 
 type SignupMailDiagnostics = {
@@ -1653,77 +1648,22 @@ const AdminToolsPage: NextPage<AdminToolsPageProps> = ({ initialMember, initialS
                 </DetailsPanel>
               </ExecutionMain>
 
-              <ExecutionRail>
-                <ActionGroupCard>
-                  <CardSectionHeading>
-                    <div>
-                      <h3>실행 전 체크</h3>
-                    </div>
-                  </CardSectionHeading>
-                  <ActionList>
-                    <ActionRowButton
-                      type="button"
-                      disabled={isBusy}
-                      onClick={() =>
-                        void executeAction("systemHealth", () => fetchSystemHealthCached(), {
-                          onSuccess: () => {
-                            setSystemHealthCheckedAt(new Date().toISOString())
-                          },
-                        })
-                      }
-                    >
-                      <span>서비스 상태 조회</span>
-                    </ActionRowButton>
-                    <ActionRowButton type="button" disabled={isBusy} onClick={() => void executeAction("admPostCount", () => apiFetch("/post/api/v1/adm/posts/count"))}>
-                      <span>전체 글 수 확인</span>
-                    </ActionRowButton>
-                  </ActionList>
-                </ActionGroupCard>
-
-                <ActionGroupCard>
-                  <CardSectionHeading>
-                    <div>
-                      <h3>위험 액션</h3>
-                    </div>
-                    <ActionToneBadge data-tone="write">실행 가능</ActionToneBadge>
-                  </CardSectionHeading>
-                  <FieldStack>
-                    <FieldBox>
-                      <FieldLabel htmlFor="signup-mail-test-email">테스트 메일 주소</FieldLabel>
-                      <Input
-                        id="signup-mail-test-email"
-                        type="email"
-                        value={testEmail}
-                        placeholder="메일 수신을 확인할 주소를 입력하세요"
-                        onChange={(event) => setTestEmail(event.target.value)}
-                      />
-                    </FieldBox>
-                    <PrimaryButton type="button" disabled={isBusy} onClick={() => void sendSignupTestMail()}>
-                      테스트 메일 발송
-                    </PrimaryButton>
-                    {!!mailTestNotice.text && <InlineNotice data-tone={mailTestNotice.tone}>{mailTestNotice.text}</InlineNotice>}
-                  </FieldStack>
-                </ActionGroupCard>
-
-                <ActionGroupCard>
-                  <CardSectionHeading>
-                    <div>
-                      <h3>런북/장애 문서</h3>
-                    </div>
-                  </CardSectionHeading>
-                  <ActionList>
-                    <Link href="/admin/dashboard" passHref legacyBehavior>
-                      <ActionRowLink>운영 대시보드 열기</ActionRowLink>
-                    </Link>
-                    <ActionRowButton type="button" disabled={isBusy} onClick={() => focusSection("diagnostics", "queue")}>
-                      <span>작업 큐 진단으로 이동</span>
-                    </ActionRowButton>
-                    <ActionRowButton type="button" disabled={isBusy} onClick={() => focusSection("execution", "auth")}>
-                      <span>인증 보안 기록으로 이동</span>
-                    </ActionRowButton>
-                  </ActionList>
-                </ActionGroupCard>
-              </ExecutionRail>
+              <AdminToolsExecutionRail
+                isBusy={isBusy}
+                mailTestNotice={mailTestNotice}
+                onFocusSection={focusSection}
+                onPostCountCheck={() => void executeAction("admPostCount", () => apiFetch("/post/api/v1/adm/posts/count"))}
+                onSendSignupTestMail={() => void sendSignupTestMail()}
+                onSystemHealthCheck={() =>
+                  void executeAction("systemHealth", () => fetchSystemHealthCached(), {
+                    onSuccess: () => {
+                      setSystemHealthCheckedAt(new Date().toISOString())
+                    },
+                  })
+                }
+                onTestEmailChange={setTestEmail}
+                testEmail={testEmail}
+              />
             </ExecutionLayout>
           </WorkspaceSection>
 

--- a/front/src/routes/Admin/AdminToolsExecutionRail.tsx
+++ b/front/src/routes/Admin/AdminToolsExecutionRail.tsx
@@ -1,0 +1,111 @@
+import Link from "next/link"
+
+import {
+  type DiagnosticTab,
+  type InlineNoticeTone,
+  type SectionKey,
+} from "src/routes/Admin/AdminToolsWorkspaceModel"
+import {
+  ActionGroupCard,
+  ActionList,
+  ActionRowButton,
+  ActionRowLink,
+  ActionToneBadge,
+  CardSectionHeading,
+  ExecutionRail,
+  FieldBox,
+  FieldLabel,
+  FieldStack,
+  InlineNotice,
+  Input,
+  PrimaryButton,
+} from "src/routes/Admin/AdminToolsWorkspace.styles"
+
+export type AdminToolsExecutionRailProps = {
+  isBusy: boolean
+  mailTestNotice: {
+    tone: InlineNoticeTone
+    text: string
+  }
+  onFocusSection: (section: SectionKey, tab?: DiagnosticTab) => void
+  onPostCountCheck: () => void
+  onSendSignupTestMail: () => void
+  onSystemHealthCheck: () => void
+  onTestEmailChange: (value: string) => void
+  testEmail: string
+}
+
+export default function AdminToolsExecutionRail({
+  isBusy,
+  mailTestNotice,
+  onFocusSection,
+  onPostCountCheck,
+  onSendSignupTestMail,
+  onSystemHealthCheck,
+  onTestEmailChange,
+  testEmail,
+}: AdminToolsExecutionRailProps) {
+  return (
+    <ExecutionRail>
+      <ActionGroupCard>
+        <CardSectionHeading>
+          <div>
+            <h3>실행 전 체크</h3>
+          </div>
+        </CardSectionHeading>
+        <ActionList>
+          <ActionRowButton type="button" disabled={isBusy} onClick={onSystemHealthCheck}>
+            <span>서비스 상태 조회</span>
+          </ActionRowButton>
+          <ActionRowButton type="button" disabled={isBusy} onClick={onPostCountCheck}>
+            <span>전체 글 수 확인</span>
+          </ActionRowButton>
+        </ActionList>
+      </ActionGroupCard>
+
+      <ActionGroupCard>
+        <CardSectionHeading>
+          <div>
+            <h3>위험 액션</h3>
+          </div>
+          <ActionToneBadge data-tone="write">실행 가능</ActionToneBadge>
+        </CardSectionHeading>
+        <FieldStack>
+          <FieldBox>
+            <FieldLabel htmlFor="signup-mail-test-email">테스트 메일 주소</FieldLabel>
+            <Input
+              id="signup-mail-test-email"
+              type="email"
+              value={testEmail}
+              placeholder="메일 수신을 확인할 주소를 입력하세요"
+              onChange={(event) => onTestEmailChange(event.target.value)}
+            />
+          </FieldBox>
+          <PrimaryButton type="button" disabled={isBusy} onClick={onSendSignupTestMail}>
+            테스트 메일 발송
+          </PrimaryButton>
+          {!!mailTestNotice.text && <InlineNotice data-tone={mailTestNotice.tone}>{mailTestNotice.text}</InlineNotice>}
+        </FieldStack>
+      </ActionGroupCard>
+
+      <ActionGroupCard>
+        <CardSectionHeading>
+          <div>
+            <h3>런북/장애 문서</h3>
+          </div>
+        </CardSectionHeading>
+        <ActionList>
+          <Link href="/admin/dashboard" passHref legacyBehavior>
+            <ActionRowLink>운영 대시보드 열기</ActionRowLink>
+          </Link>
+          <ActionRowButton type="button" disabled={isBusy} onClick={() => onFocusSection("diagnostics", "queue")}>
+            <span>작업 큐 진단으로 이동</span>
+          </ActionRowButton>
+          <ActionRowButton type="button" disabled={isBusy} onClick={() => onFocusSection("execution", "auth")}>
+            <span>인증 보안 기록으로 이동</span>
+          </ActionRowButton>
+        </ActionList>
+      </ActionGroupCard>
+    </ExecutionRail>
+  )
+}


### PR DESCRIPTION
## 관련 이슈

close #269

## 작업 배경

- `/admin/tools` 우측 execution rail 렌더링을 `AdminToolsExecutionRail` route component로 분리했습니다.
- page 파일은 실행 state와 API orchestration, handler 전달만 소유하도록 줄였습니다.

## 작업 내용

- 실행 전 체크/위험 액션/런북 레일 JSX를 `front/src/routes/Admin/AdminToolsExecutionRail.tsx`로 이동했습니다.
- `front/src/pages/admin/tools.tsx`는 busy/test email state와 실행 handler만 props로 전달합니다.
- admin 계약 테스트가 실행 레일 분리와 page line count 상한을 검증하도록 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `env PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/admin-tools-state.spec.ts --workers=1`
  - `env PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts e2e/admin-bootstrap-state.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `env PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 레일 버튼 handler 전달 누락 시 운영 도구 quick action이 동작하지 않을 수 있습니다.
- 롤백 방법: `fa92e68b` 커밋을 revert하면 기존 inline 렌더링으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
