### PR TITLE
[Fix] Editor dedicated background clipping 복구

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -373,6 +373,7 @@ test.describe("editor studio state", () => {
     expect(existsSync(floatingBubbleStatePath)).toBe(true)
     const floatingBubbleStateSource = existsSync(floatingBubbleStatePath) ? readFileSync(floatingBubbleStatePath, "utf8") : ""
     const writerEditorHostSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/WriterEditorHost.tsx"), "utf8")
+    const rootLayoutSource = readFileSync(path.resolve(__dirname, "../src/layouts/RootLayout/index.tsx"), "utf8")
     const dedicatedEditorRootStyle = dedicatedEditorSurfaceSource.match(
       /const EditorStudioRoot = styled\.main`([\s\S]*?)`\n\nconst EditorStudioLoadingState/
     )?.[1] ?? ""
@@ -381,6 +382,21 @@ test.describe("editor studio state", () => {
     )?.[1] ?? ""
     const dedicatedEditorTopBarStyle = dedicatedEditorSurfaceSource.match(
       /const EditorStudioTopBar = styled\.div`([\s\S]*?)`\n\nconst EditorExitAction/
+    )?.[1] ?? ""
+    const blockEditorShellStyle = blockEditorEngineSource.match(
+      /const Shell = styled\.div`([\s\S]*?)`\n\nconst Toolbar/
+    )?.[1] ?? ""
+    const toolbarStyle = blockEditorEngineSource.match(
+      /const Toolbar = styled\.div`([\s\S]*?)`\n\nconst ToolbarActions/
+    )?.[1] ?? ""
+    const toolbarActionsStyle = blockEditorEngineSource.match(
+      /const ToolbarActions = styled\.div`([\s\S]*?)`\n\nconst ToolbarGroup/
+    )?.[1] ?? ""
+    const quickInsertActionsStyle = blockEditorEngineSource.match(
+      /const QuickInsertActions = styled\.div`([\s\S]*?)`\n\nconst QuickInsertButton/
+    )?.[1] ?? ""
+    const quickInsertButtonStyle = blockEditorEngineSource.match(
+      /const QuickInsertButton = styled\.button`([\s\S]*?)`\s*$/
     )?.[1] ?? ""
 
     expect(editorStudioSource).not.toContain("BLOCK_EDITOR_V2_ENABLED")
@@ -398,6 +414,20 @@ test.describe("editor studio state", () => {
     expect(dedicatedEditorTopBarStyle).toContain("margin: 0 auto;")
     expect(dedicatedEditorFrameStyle).toContain("width: min(100%, 1600px);")
     expect(dedicatedEditorFrameStyle).toContain("margin: 0 auto;")
+    expect(rootLayoutSource).toContain('const isDedicatedEditorRoute = pathname === "/editor/[id]" || pathname === "/editor/new"')
+    expect(rootLayoutSource).toContain("<StyledMain $fullBleed={isDedicatedEditorRoute}>")
+    expect(rootLayoutSource).toContain("$fullBleed?: boolean")
+    expect(blockEditorShellStyle).toContain("min-width: 0;")
+    expect(blockEditorShellStyle).toContain("max-width: 100%;")
+    expect(toolbarStyle).toContain("width: 100%;")
+    expect(toolbarStyle).toContain("max-width: 100%;")
+    expect(toolbarStyle).toContain("overflow-x: clip;")
+    expect(toolbarActionsStyle).toContain("flex: 1 1 100%;")
+    expect(toolbarActionsStyle).toContain("width: 100%;")
+    expect(toolbarActionsStyle).toContain("max-width: 100%;")
+    expect(quickInsertActionsStyle).toContain("min-width: 0;")
+    expect(quickInsertActionsStyle).toContain("max-width: 100%;")
+    expect(quickInsertButtonStyle).toContain("white-space: nowrap;")
     expect(dedicatedEditorSurfaceSource).toContain("grid-template-columns: minmax(0, 1fr);")
     expect(dedicatedEditorSurfaceSource).toContain('data-testid="editor-studio-frame"')
     expect(editorStudioSource).toContain('import { WriterEditorHost } from "./WriterEditorHost"')

--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -373,6 +373,15 @@ test.describe("editor studio state", () => {
     expect(existsSync(floatingBubbleStatePath)).toBe(true)
     const floatingBubbleStateSource = existsSync(floatingBubbleStatePath) ? readFileSync(floatingBubbleStatePath, "utf8") : ""
     const writerEditorHostSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/WriterEditorHost.tsx"), "utf8")
+    const dedicatedEditorRootStyle = dedicatedEditorSurfaceSource.match(
+      /const EditorStudioRoot = styled\.main`([\s\S]*?)`\n\nconst EditorStudioLoadingState/
+    )?.[1] ?? ""
+    const dedicatedEditorFrameStyle = dedicatedEditorSurfaceSource.match(
+      /const EditorStudioFrame = styled\.div`([\s\S]*?)`\n\nconst EditorStudioWritingColumn/
+    )?.[1] ?? ""
+    const dedicatedEditorTopBarStyle = dedicatedEditorSurfaceSource.match(
+      /const EditorStudioTopBar = styled\.div`([\s\S]*?)`\n\nconst EditorExitAction/
+    )?.[1] ?? ""
 
     expect(editorStudioSource).not.toContain("BLOCK_EDITOR_V2_ENABLED")
     expect(editorStudioSource).not.toContain("EditorStudioLegacyToolbar")
@@ -380,7 +389,15 @@ test.describe("editor studio state", () => {
     expect(editorStudioSource).toContain("const isCompactSplitPreview = false")
     expect(editorStudioSource).toContain("EditorStudioDedicatedEditorSurface")
     expect(editorStudioSource).not.toContain("const EditorStudioRoot")
-    expect(dedicatedEditorSurfaceSource).toContain("width: min(100%, 1600px);")
+    expect(dedicatedEditorRootStyle).toContain("width: 100vw;")
+    expect(dedicatedEditorRootStyle).toContain("margin-left: calc(50% - 50vw);")
+    expect(dedicatedEditorRootStyle).toContain("margin-right: calc(50% - 50vw);")
+    expect(dedicatedEditorRootStyle).not.toContain("width: min(100%, 1600px);")
+    expect(dedicatedEditorRootStyle).not.toContain("margin: 0 auto;")
+    expect(dedicatedEditorTopBarStyle).toContain("width: min(100%, 1600px);")
+    expect(dedicatedEditorTopBarStyle).toContain("margin: 0 auto;")
+    expect(dedicatedEditorFrameStyle).toContain("width: min(100%, 1600px);")
+    expect(dedicatedEditorFrameStyle).toContain("margin: 0 auto;")
     expect(dedicatedEditorSurfaceSource).toContain("grid-template-columns: minmax(0, 1fr);")
     expect(dedicatedEditorSurfaceSource).toContain('data-testid="editor-studio-frame"')
     expect(editorStudioSource).toContain('import { WriterEditorHost } from "./WriterEditorHost"')

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -8320,6 +8320,8 @@ export default BlockEditorEngine
 const Shell = styled.div`
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  max-width: 100%;
   gap: 0.8rem;
 `
 
@@ -8328,16 +8330,23 @@ const Toolbar = styled.div`
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   gap: 0.9rem;
   padding: 0 0 0.7rem;
+  overflow-x: clip;
   border-bottom: 1px solid rgba(148, 163, 184, 0.14);
   background: transparent;
 `
 
 const ToolbarActions = styled.div`
   display: inline-flex;
+  flex: 1 1 100%;
   flex-wrap: wrap;
   align-items: center;
+  width: 100%;
+  max-width: 100%;
   gap: 0.25rem;
   min-width: 0;
 `
@@ -10523,6 +10532,8 @@ const QuickInsertBar = styled.div`
 const QuickInsertActions = styled.div`
   display: flex;
   flex-wrap: wrap;
+  min-width: 0;
+  max-width: 100%;
   gap: 0.55rem;
 `
 
@@ -10536,6 +10547,7 @@ const QuickInsertButton = styled.button`
   color: var(--color-gray12);
   font-size: 0.82rem;
   font-weight: 700;
+  white-space: nowrap;
   padding: 0 0.95rem;
   transition:
     transform 120ms ease,

--- a/front/src/layouts/RootLayout/index.tsx
+++ b/front/src/layouts/RootLayout/index.tsx
@@ -76,6 +76,7 @@ const RootLayout = ({
   const [scheme] = useScheme()
   const { events, pathname } = useRouter()
   const isPublicBlogRoute = pathname === "/" || pathname === "/about" || pathname === "/posts/[id]"
+  const isDedicatedEditorRoute = pathname === "/editor/[id]" || pathname === "/editor/new"
   const isDesignAwareRoute = pathname[1] !== "_" && pathname !== "/sitemap.xml"
   const adminProfile = usePublicAdminProfile(initialAdminProfile, {
     enabled: isDesignAwareRoute || initialAdminProfileShouldRefetch,
@@ -189,38 +190,44 @@ const RootLayout = ({
       {/* {metaConfig.type !== "Paper" && <Header />} */}
       <Header fullWidth={false} showThemeToggle={effectiveBlogDesign === "legacy" && !isPublicBlogRoute} blogTitle={headerBlogTitle} />
       <RouteProgress data-busy={isNavigating} aria-hidden="true" />
-      <StyledMain>{children}</StyledMain>
+      <StyledMain $fullBleed={isDedicatedEditorRoute}>{children}</StyledMain>
     </ThemeProvider>
   )
 }
 
 export default RootLayout
 
-const StyledMain = styled.main`
+const StyledMain = styled.main<{ $fullBleed?: boolean }>`
   margin: 0 auto;
   box-sizing: border-box;
-  width: min(100%, ${CONTENT_MAX_WIDTH_PX}px);
-  padding: 0 clamp(0.85rem, 1.6vw, 1.2rem);
+  width: ${({ $fullBleed }) => ($fullBleed ? "100%" : `min(100%, ${CONTENT_MAX_WIDTH_PX}px)`)};
+  padding: ${({ $fullBleed }) => ($fullBleed ? "0" : "0 clamp(0.85rem, 1.6vw, 1.2rem)")};
+  overflow-x: ${({ $fullBleed }) => ($fullBleed ? "clip" : "visible")};
 
-  @media (max-width: ${WIDE_CONTENT_BREAKPOINT_PX}px) {
-    width: min(100%, ${WIDE_CONTENT_MAX_PX}px);
-  }
+  ${({ $fullBleed }) =>
+    $fullBleed
+      ? ""
+      : `
+        @media (max-width: ${WIDE_CONTENT_BREAKPOINT_PX}px) {
+          width: min(100%, ${WIDE_CONTENT_MAX_PX}px);
+        }
 
-  /* Velog-like desktop width lock: fixed content rail before tablet/mobile fluid mode */
-  @media (max-width: ${DESKTOP_LOCK_MAX_PX}px) and (min-width: ${DESKTOP_LOCK_MIN_PX}px) {
-    width: min(100%, ${DESKTOP_LOCK_WIDTH_PX}px);
-  }
+        /* Velog-like desktop width lock: fixed content rail before tablet/mobile fluid mode */
+        @media (max-width: ${DESKTOP_LOCK_MAX_PX}px) and (min-width: ${DESKTOP_LOCK_MIN_PX}px) {
+          width: min(100%, ${DESKTOP_LOCK_WIDTH_PX}px);
+        }
 
-  @media (max-width: ${FLUID_LAYOUT_MAX_PX}px) {
-    width: 100%;
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
+        @media (max-width: ${FLUID_LAYOUT_MAX_PX}px) {
+          width: 100%;
+          padding-left: 1rem;
+          padding-right: 1rem;
+        }
 
-  @media (max-width: 768px) {
-    padding-left: 0.85rem;
-    padding-right: 0.85rem;
-  }
+        @media (max-width: 768px) {
+          padding-left: 0.85rem;
+          padding-right: 0.85rem;
+        }
+      `}
 `
 
 const RouteProgress = styled.div`

--- a/front/src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx
+++ b/front/src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx
@@ -212,8 +212,10 @@ export const EditorStudioDedicatedEditorSurface = ({
 )
 
 const EditorStudioRoot = styled.main`
-  width: min(100%, 1600px);
-  margin: 0 auto;
+  box-sizing: border-box;
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
   padding: 1.4rem 1.6rem 2rem;
   display: grid;
   gap: 1.2rem;
@@ -254,6 +256,8 @@ const EditorStudioLoadingState = styled.div`
 `
 
 const EditorStudioTopBar = styled.div`
+  width: min(100%, 1600px);
+  margin: 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -404,6 +408,8 @@ const PrimaryButton = styled(Button)`
 `
 
 const EditorStudioFrame = styled.div`
+  width: min(100%, 1600px);
+  margin: 0 auto;
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: 1.4rem;


### PR DESCRIPTION
## 관련 이슈

close #275

## 작업 배경

- `/editor/new`, `/editor/[id]` 전용 작성 화면의 page-level 배경이 wide viewport에서 중앙 shell 폭으로 끊기던 회귀를 복구했습니다.
- follow-up으로 남은 toolbar 구분선과 `다이어그램` chip overflow까지 editor frame 안에 고정했습니다.

## 작업 내용

- editor 전용 route에서는 `RootLayout`의 main shell을 full-bleed로 열어 전역 중앙 레일/padding이 배경을 다시 자르지 않도록 했습니다.
- `EditorStudioRoot`는 viewport 전체 폭을 덮고, toolbar/frame은 기존 1600px 중앙 읽기 폭을 유지하도록 분리했습니다.
- block editor shell/toolbar/quick insert에 `min-width`, `max-width`, `overflow-x` 폭 가드를 추가해 toolbar 선과 chip이 frame 밖으로 밀리지 않게 했습니다.
- `editor-studio-state` 계약 테스트가 root/layout/toolbar 폭 책임을 함께 검증하도록 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-dedicated-background-clipping bash tools/guards/current-task-preflight.sh`
  - `env PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front build`
  - `git diff --check`
  - 로컬 빌드 `http://127.0.0.1:3102/editor/new` 2048px viewport 계측: editor main `left=0/right=2048`, frame `left=224/right=1824`, `다이어그램` chip `right=1396`, frame 밖 overflow `0`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: editor 전용 route에서만 RootLayout main이 full-bleed가 되므로 공개/관리자 일반 화면 영향은 제한적입니다. Toolbar 폭 가드는 quick insert와 top toolbar의 가로 overflow만 제한합니다.
- 롤백 방법: 이 PR의 커밋 `f249187b`, `587e75d9`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
