### PR TITLE
[Fix] 글 선택 후 Cmd+Z 본문 삭제 방지

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -1573,6 +1573,33 @@ test.describe("block editor authoring flow", () => {
     await expect(markdownOutput).not.toContainText("(empty)")
   })
 
+  test("기존 draft 편집 후 외부 글 선택 직후 Cmd/Ctrl+Z는 선택 글 본문을 비우지 않는다", async ({ page }) => {
+    await page.goto(QA_ENGINE_ROUTE)
+
+    const markdownOutput = page.getByTestId("qa-markdown-output")
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.click()
+    await page.keyboard.type("선택 전 draft")
+    await expect(markdownOutput).toContainText("선택 전 draft")
+
+    await page.getByRole("button", { name: "QA 외부 글 선택" }).click()
+    await expect(markdownOutput).toContainText("# 선택 글 제목")
+    await expect(markdownOutput).toContainText("선택 글 본문")
+    await expect
+      .poll(() =>
+        page.evaluate(() => (window as Window & { __qaGetUndoDepth?: () => number }).__qaGetUndoDepth?.() ?? -1)
+      )
+      .toBe(0)
+
+    await editor.click()
+    await page.keyboard.press(UNDO_SHORTCUT)
+
+    await expect(markdownOutput).toContainText("# 선택 글 제목")
+    await expect(markdownOutput).toContainText("선택 글 본문")
+    await expect(markdownOutput).not.toContainText("선택 전 draft")
+    await expect(markdownOutput).not.toContainText("(empty)")
+  })
+
   test("블록 내부 클릭/텍스트 더블클릭은 편집만 유지하고 좌측 외곽 더블클릭에서만 블록 선택된다", async ({ page }) => {
     await page.goto(QA_ENGINE_ROUTE)
 

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -72,6 +72,12 @@ import {
 } from "src/libs/markdown/htmlToMarkdown"
 import { INLINE_TEXT_COLOR_OPTIONS } from "src/libs/markdown/inlineColor"
 import { inferCardKindFromUrl, inferLinkProvider, resolveEmbedPreviewUrl } from "src/libs/unfurl/extractMeta"
+import {
+  captureEmptyEditorHistoryState,
+  getEditorUndoDepth,
+  resetEditorUndoHistory,
+  type EditorHistorySnapshot,
+} from "./editorHistoryModel"
 import type {
   BlockEditorChangeMeta,
   BlockEditorQaActions,
@@ -918,6 +924,7 @@ const BlockEditorEngine = ({
   const initialDocRef = useRef(
     downgradeDisabledFeatureNodes(parseMarkdownToEditorDoc(value), enableMermaidBlocks)
   )
+  const emptyHistoryStateRef = useRef<EditorHistorySnapshot | null>(null)
 
   const isSelectionInEmptyParagraph = useCallback(() => {
     const currentEditor = editorRef.current
@@ -2646,6 +2653,7 @@ const BlockEditorEngine = ({
     if (!currentEditor) return
 
     currentEditor.chain().setMeta("addToHistory", false).setContent(nextDoc, { emitUpdate: false }).run()
+    resetEditorUndoHistory(currentEditor, emptyHistoryStateRef.current)
     markCommittedDoc(nextDoc)
   }, [markCommittedDoc])
 
@@ -2881,6 +2889,7 @@ const BlockEditorEngine = ({
     editable: true,
     onCreate: ({ editor: createdEditor }) => {
       editorRef.current = createdEditor
+      emptyHistoryStateRef.current = captureEmptyEditorHistoryState(createdEditor)
       createdEditor.setEditable(!disabled)
       promoteLargeTablesToWideOverflowMode(createdEditor)
       scheduleTableViewportBudgetNormalize(createdEditor)
@@ -4618,6 +4627,10 @@ const BlockEditorEngine = ({
       },
       moveTaskItemInFirstTaskList: (sourceIndex, insertionIndex) => {
         moveTaskItemInFirstTaskList(sourceIndex, insertionIndex)
+      },
+      getUndoDepth: () => {
+        const currentEditor = editorRef.current ?? editor
+        return currentEditor ? getEditorUndoDepth(currentEditor) : 0
       },
     })
 

--- a/front/src/components/editor/blockEditorContract.ts
+++ b/front/src/components/editor/blockEditorContract.ts
@@ -20,6 +20,7 @@ export type BlockEditorQaActions = {
   appendCalloutBlock: () => void
   appendFormulaBlock: () => void
   moveTaskItemInFirstTaskList: (sourceIndex: number, insertionIndex: number) => void
+  getUndoDepth: () => number
 }
 
 export type BlockEditorUploadAdapters = {

--- a/front/src/components/editor/editorHistoryModel.ts
+++ b/front/src/components/editor/editorHistoryModel.ts
@@ -1,0 +1,41 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import type { Plugin } from "@tiptap/pm/state"
+
+export type EditorHistorySnapshot = {
+  plugin: Plugin
+  state: unknown
+}
+
+const getPluginRuntimeKey = (plugin: Plugin) =>
+  (plugin as Plugin & { key?: string }).key ?? ""
+
+const findHistoryPlugin = (editor: TiptapEditor): Plugin | null =>
+  editor.state.plugins.find((plugin) => getPluginRuntimeKey(plugin).startsWith("history$")) ?? null
+
+export const captureEmptyEditorHistoryState = (editor: TiptapEditor): EditorHistorySnapshot | null => {
+  const historyPlugin = findHistoryPlugin(editor)
+  return historyPlugin ? { plugin: historyPlugin, state: historyPlugin.getState(editor.state) } : null
+}
+
+export const getEditorUndoDepth = (editor: TiptapEditor) => {
+  const historyPlugin = findHistoryPlugin(editor)
+  const historyState = historyPlugin?.getState(editor.state) as
+    | { done?: { eventCount?: number } }
+    | undefined
+  return typeof historyState?.done?.eventCount === "number" ? historyState.done.eventCount : 0
+}
+
+export const resetEditorUndoHistory = (
+  editor: TiptapEditor,
+  snapshot: EditorHistorySnapshot | null
+) => {
+  if (!snapshot) return
+  if (!editor.state.plugins.includes(snapshot.plugin)) return
+  if (getEditorUndoDepth(editor) === 0) return
+
+  editor.view.dispatch(
+    editor.state.tr
+      .setMeta("addToHistory", false)
+      .setMeta(snapshot.plugin, { historyState: snapshot.state })
+  )
+}

--- a/front/src/routes/Admin/QaEditorHarness.tsx
+++ b/front/src/routes/Admin/QaEditorHarness.tsx
@@ -21,6 +21,7 @@ const LazyBlockEditorShell = dynamic(() => import("src/components/editor/BlockEd
 
 const QA_IMAGE_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlH0WkAAAAASUVORK5CYII="
+const QA_EXTERNAL_POST_MARKDOWN = "# 선택 글 제목\n\n선택 글 본문\n\n선택 글 둘째 문단"
 
 type QaEditorHarnessProps = {
   seedMarkdown: string
@@ -33,14 +34,19 @@ export const QaEditorHarness = ({ seedMarkdown }: QaEditorHarnessProps) => {
 
   useEffect(() => {
     if (typeof window === "undefined") return
-    ;(window as unknown as { __qaMoveTaskItemInFirstTaskList?: (sourceIndex: number, insertionIndex: number) => void }).__qaMoveTaskItemInFirstTaskList =
+    const qaWindow = window as unknown as {
+      __qaMoveTaskItemInFirstTaskList?: (sourceIndex: number, insertionIndex: number) => void
+      __qaGetUndoDepth?: () => number
+    }
+    qaWindow.__qaMoveTaskItemInFirstTaskList =
       (sourceIndex, insertionIndex) => {
         qaActionsRef.current?.moveTaskItemInFirstTaskList(sourceIndex, insertionIndex)
       }
+    qaWindow.__qaGetUndoDepth = () => qaActionsRef.current?.getUndoDepth() ?? 0
 
     return () => {
-      delete (window as unknown as { __qaMoveTaskItemInFirstTaskList?: (sourceIndex: number, insertionIndex: number) => void })
-        .__qaMoveTaskItemInFirstTaskList
+      delete qaWindow.__qaMoveTaskItemInFirstTaskList
+      delete qaWindow.__qaGetUndoDepth
     }
   }, [])
 
@@ -112,6 +118,9 @@ export const QaEditorHarness = ({ seedMarkdown }: QaEditorHarnessProps) => {
         </button>
         <button type="button" onClick={() => qaActionsRef.current?.moveTaskItemInFirstTaskList(2, 0)}>
           QA Task 3→1
+        </button>
+        <button type="button" onClick={() => setMarkdown(QA_EXTERNAL_POST_MARKDOWN)}>
+          QA 외부 글 선택
         </button>
       </section>
 


### PR DESCRIPTION
## 관련 이슈

close #277

## 작업 배경

- 글작성/수정 editor에서 기존 글 선택 로드 후 이전 draft/post의 ProseMirror undo stack이 남아 `Cmd+Z`로 본문이 비는 경로를 막았습니다.
- 외부 value hydrate 이후 history plugin state를 초기 empty baseline으로 되돌리고, QA/E2E에서 선택 직후 undo depth가 0인지 검증합니다.

## 작업 내용

- editor 외부 value replace 경로에서 이전 문서의 undo history를 reset합니다.
- QA harness에 외부 글 선택 fixture와 undo depth 관측 action을 추가했습니다.
- 기존 draft 편집 후 외부 글 선택 직후 `Cmd/Ctrl+Z`가 선택 글 본문을 비우지 않는 E2E 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --grep "기존 draft 편집 후 외부 글 선택 직후" --workers=1` (RED: `undoDepth` 1로 실패 확인 후 수정)
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (최종 74 passed)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (최종 17 passed)
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1` (최종 16 passed)
  - `yarn --cwd front build`
  - `BUNDLE_ROUTES=/admin node front/scripts/check-bundle-size.mjs`
  - 참고: default `node front/scripts/check-bundle-size.mjs`는 이번 변경 범위 밖인 `/` raw budget에서 `current=513.9KB`, `budget=513.6KB`로 0.3KB 초과해 실패했습니다. 변경 범위 route인 `/admin` 단독 검증은 통과했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: ProseMirror history plugin 내부 state shape에 의존합니다. QA에서 undo depth 관측과 선택 직후 undo 동작을 함께 검증해 회귀를 잡습니다.
- 롤백 방법: commit `46cd8930` revert.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
