### PR TITLE
[Fix] apiKey 단독 인증 차단

### DIFF
--- a/back/src/main/kotlin/com/back/global/security/config/CustomAuthenticationFilter.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/CustomAuthenticationFilter.kt
@@ -137,7 +137,7 @@ class CustomAuthenticationFilter(
                 val apiKeyMember = actorApplicationService.findByApiKey(apiKey)
                 if (apiKeyMember != null) {
                     val sessionResolution = resolveMemberSession(apiKeyMember.id, sessionKey, payload.sessionKey, payload, request)
-                    ensureSessionIsUsable(sessionResolution)
+                    ensureSessionIsUsable(sessionResolution, requireSession = true)
                     val memberSession = sessionResolution.session
                     val rememberLoginEnabled = memberSession?.rememberLoginEnabled ?: apiKeyMember.rememberLoginEnabled
                     val ipSecurityEnabled = memberSession?.ipSecurityEnabled ?: apiKeyMember.ipSecurityEnabled
@@ -253,7 +253,7 @@ class CustomAuthenticationFilter(
                 ?: throw AppException("401-3", "API 키가 유효하지 않습니다.")
 
         val sessionResolution = resolveMemberSession(member.id, sessionKey, null, null, request)
-        ensureSessionIsUsable(sessionResolution)
+        ensureSessionIsUsable(sessionResolution, requireSession = true)
         val memberSession = sessionResolution.session
         val rememberLoginEnabled = memberSession?.rememberLoginEnabled ?: member.rememberLoginEnabled
         val ipSecurityEnabled = memberSession?.ipSecurityEnabled ?: member.ipSecurityEnabled
@@ -429,7 +429,15 @@ class CustomAuthenticationFilter(
         return resolution.copy(freshTokenFallback = true)
     }
 
-    private fun ensureSessionIsUsable(sessionResolution: SessionResolution) {
+    private fun ensureSessionIsUsable(
+        sessionResolution: SessionResolution,
+        requireSession: Boolean = false,
+    ) {
+        if (!sessionResolution.sessionKeyProvided && requireSession) {
+            authCookieService.expireAuthCookies()
+            throw AppException("401-8", "세션이 만료되었습니다. 다시 로그인해주세요.")
+        }
+
         if (sessionResolution.sessionKeyProvided && sessionResolution.session == null && !sessionResolution.freshTokenFallback) {
             authCookieService.expireAuthCookies()
             throw AppException("401-8", "세션이 만료되었습니다. 다시 로그인해주세요.")

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
@@ -246,7 +246,10 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
             val firstApiKeyCookie =
                 firstLogin.response.cookies.firstOrNull { it.name == "apiKey" && it.value.isNotBlank() }
+            val firstSessionKeyCookie =
+                firstLogin.response.cookies.firstOrNull { it.name == "sessionKey" && it.value.isNotBlank() }
             assertThat(firstApiKeyCookie).isNotNull
+            assertThat(firstSessionKeyCookie).isNotNull
 
             val secondLogin =
                 mvc
@@ -271,6 +274,7 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
             mvc
                 .get("/member/api/v1/auth/me") {
                     cookie(Cookie("apiKey", firstApiKeyCookie.value))
+                    cookie(Cookie("sessionKey", firstSessionKeyCookie!!.value))
                 }.andExpect {
                     status { isOk() }
                     jsonPath("$.id") { value(member.id) }
@@ -475,12 +479,20 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
     @Nested
     inner class Me {
         @Test
-        fun `내 정보 조회는 apiKey 쿠키가 있으면 회원 정보를 반환한다`() {
-            val member = memberFacade.findByLoginId("user1")!!
+        fun `내 정보 조회는 apiKey 와 sessionKey 쿠키가 있으면 회원 정보를 반환한다`() {
+            val member =
+                memberFacade.join(
+                    username = "session-bound-me-user",
+                    password = "Abcd1234!",
+                    nickname = "세션조회",
+                    profileImgUrl = null,
+                    email = "session-bound-me-user@example.com",
+                )
+            val authCookies = loginAuthCookies(member.email!!)
 
             mvc
                 .get("/member/api/v1/auth/me") {
-                    cookie(Cookie("apiKey", member.apiKey))
+                    authCookies.forEach { cookie(it) }
                 }.andExpect {
                     status { isOk() }
                     match(handler().handlerType(ApiV1AuthController::class.java))
@@ -497,12 +509,20 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
         }
 
         @Test
-        fun `세션 정보 조회는 apiKey 쿠키가 있으면 경량 회원 정보를 반환한다`() {
-            val member = memberFacade.findByLoginId("user1")!!
+        fun `세션 정보 조회는 apiKey 와 sessionKey 쿠키가 있으면 경량 회원 정보를 반환한다`() {
+            val member =
+                memberFacade.join(
+                    username = "session-bound-session-user",
+                    password = "Abcd1234!",
+                    nickname = "세션경량조회",
+                    profileImgUrl = null,
+                    email = "session-bound-session-user@example.com",
+                )
+            val authCookies = loginAuthCookies(member.email!!)
 
             mvc
                 .get("/member/api/v1/auth/session") {
-                    cookie(Cookie("apiKey", member.apiKey))
+                    authCookies.forEach { cookie(it) }
                 }.andExpect {
                     status { isOk() }
                     match(handler().handlerType(ApiV1AuthController::class.java))
@@ -511,6 +531,23 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                     jsonPath("$.isAdmin") { value(member.isAdmin) }
                     jsonPath("$.username") { value(member.name) }
                     jsonPath("$.nickname") { value(member.nickname) }
+                }
+        }
+
+        @Test
+        fun `내 정보 조회는 apiKey 쿠키만 있으면 세션 만료로 거부한다`() {
+            val member = memberFacade.findByLoginId("user1")!!
+
+            mvc
+                .get("/member/api/v1/auth/me") {
+                    cookie(Cookie("apiKey", member.apiKey))
+                }.andExpect {
+                    status { isUnauthorized() }
+                    jsonPath("$.resultCode") { value("401-8") }
+                    jsonPath("$.msg") { value("세션이 만료되었습니다. 다시 로그인해주세요.") }
+                    cookie { maxAge("apiKey", 0) }
+                    cookie { maxAge("accessToken", 0) }
+                    cookie { maxAge("sessionKey", 0) }
                 }
         }
 
@@ -538,13 +575,23 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
         }
 
         @Test
-        fun `내 정보 조회에서 Authorization 헤더의 accessToken 이 잘못되어도 apiKey 가 유효하면 accessToken 을 재발급한다`() {
-            val member = memberFacade.findByLoginId("user1")!!
+        fun `내 정보 조회에서 Authorization 헤더의 accessToken 이 잘못되어도 apiKey 와 sessionKey 가 유효하면 accessToken 을 재발급한다`() {
+            val member =
+                memberFacade.join(
+                    username = "session-bound-rotate-user",
+                    password = "Abcd1234!",
+                    nickname = "세션재발급",
+                    profileImgUrl = null,
+                    email = "session-bound-rotate-user@example.com",
+                )
+            val authCookies = loginAuthCookies(member.email!!)
+            val sessionKeyCookie = requireAuthCookie(authCookies, "sessionKey")
 
             val resultActions =
                 mvc
                     .get("/member/api/v1/auth/me") {
                         header(HttpHeaders.AUTHORIZATION, "Bearer ${member.apiKey} wrong-access-token")
+                        cookie(sessionKeyCookie)
                     }.andExpect {
                         status { isOk() }
                         match(handler().handlerType(ApiV1AuthController::class.java))
@@ -648,11 +695,15 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
             val apiKeyCookie =
                 loginResponse.response.cookies.firstOrNull { it.name == "apiKey" && it.value.isNotBlank() }
+            val sessionKeyCookie =
+                loginResponse.response.cookies.firstOrNull { it.name == "sessionKey" && it.value.isNotBlank() }
             assertThat(apiKeyCookie).isNotNull
+            assertThat(sessionKeyCookie).isNotNull
 
             mvc
                 .get("/member/api/v1/auth/me") {
                     cookie(apiKeyCookie!!)
+                    cookie(sessionKeyCookie!!)
                     with(remoteAddr("10.0.0.77"))
                 }.andExpect {
                     status { isUnauthorized() }
@@ -695,11 +746,15 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
             val apiKeyCookie =
                 loginResponse.response.cookies.firstOrNull { it.name == "apiKey" && it.value.isNotBlank() }
+            val sessionKeyCookie =
+                loginResponse.response.cookies.firstOrNull { it.name == "sessionKey" && it.value.isNotBlank() }
             assertThat(apiKeyCookie).isNotNull
+            assertThat(sessionKeyCookie).isNotNull
 
             mvc
                 .get("/member/api/v1/auth/me") {
                     cookie(apiKeyCookie!!)
+                    cookie(sessionKeyCookie!!)
                     header("CF-Connecting-IP", "198.51.100.34")
                     with(remoteAddr("172.18.0.9"))
                 }.andExpect {
@@ -709,6 +764,29 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                 }
         }
     }
+
+    private fun loginAuthCookies(email: String): List<Cookie> =
+        mvc
+            .post("/member/api/v1/auth/login") {
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "email": "$email",
+                        "password": "Abcd1234!"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isOk() }
+            }.andReturn()
+            .response
+            .cookies
+            .filter { it.name in setOf("apiKey", "accessToken", "sessionKey") && it.value.isNotBlank() }
+
+    private fun requireAuthCookie(
+        cookies: List<Cookie>,
+        name: String,
+    ): Cookie = cookies.firstOrNull { it.name == name } ?: error("$name cookie not issued")
 
     private fun remoteAddr(ip: String): RequestPostProcessor =
         RequestPostProcessor { request ->

--- a/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
@@ -4,6 +4,7 @@ import com.back.boundedContexts.member.application.service.ActorApplicationServi
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.dto.shared.AccessTokenPayload
 import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
+import com.back.boundedContexts.member.subContexts.session.model.MemberSessionAuthSnapshot
 import com.back.global.app.AppConfig
 import com.back.global.security.application.AuthIpSecurityService
 import com.back.global.security.application.AuthSecurityEventService
@@ -248,13 +249,24 @@ class CustomAuthenticationFilterTest {
         val request = MockHttpServletRequest("PUT", "/post/api/v1/posts/452")
         val apiKey = "admin-api-key"
         val staleAccessToken = "stale-access-token"
+        val sessionKey = "admin-session-key"
+        val sessionSnapshot =
+            MemberSessionAuthSnapshot(
+                id = 11L,
+                memberId = 54L,
+                sessionKey = sessionKey,
+                rememberLoginEnabled = true,
+                ipSecurityEnabled = false,
+                ipSecurityFingerprint = null,
+                lastAuthenticatedAt = Instant.now(),
+            )
         val persistedAdmin = Member(54L, "internal-admin", null, "aquila", "admin@test.com", apiKey)
 
         given(publicApiRequestMatcher.matches(request)).willReturn(false)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("")
         given(rq.getCookieValue("apiKey", "")).willReturn(apiKey)
         given(rq.getCookieValue("accessToken", "")).willReturn(staleAccessToken)
-        given(rq.getCookieValue("sessionKey", "")).willReturn("")
+        given(rq.getCookieValue("sessionKey", "")).willReturn(sessionKey)
         given(actorApplicationService.payload(staleAccessToken))
             .willReturn(
                 AccessTokenPayload(
@@ -268,7 +280,8 @@ class CustomAuthenticationFilterTest {
                 ),
             )
         given(actorApplicationService.findByApiKey(apiKey)).willReturn(persistedAdmin)
-        given(actorApplicationService.genAccessToken(persistedAdmin)).willReturn("rotated-access-token")
+        given(memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(sessionSnapshot)
+        given(actorApplicationService.genAccessToken(persistedAdmin, sessionKey, true, false, null)).willReturn("rotated-access-token")
         given(clientIpResolver.resolve(request)).willReturn("203.0.113.13")
 
         val filter =


### PR DESCRIPTION
## 관련 이슈

close #281

## 작업 배경

- `apiKey` 인증 경로가 활성 세션 없이 보호 API를 통과하던 문제를 막았습니다.
- `apiKey` 단독 요청은 `401-8`로 거부하고 인증 쿠키를 만료시키며, 정상 세션 쿠키를 포함한 요청은 기존 흐름을 유지합니다.

## 작업 내용

- `CustomAuthenticationFilter`의 `apiKey` fallback/쓰기 권한 복구 경로에 활성 session snapshot 필수 검증을 적용했습니다.
- 인증 컨트롤러/필터 테스트를 `sessionKey` 포함 계약으로 갱신하고 `apiKey` 단독 거부 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd back && ./gradlew test --tests com.back.boundedContexts.member.adapter.web.ApiV1AuthControllerTest."내 정보 조회는 apiKey 쿠키만 있으면 세션 만료로 거부한다"` (RED 확인 후 GREEN)
  - `cd back && ./gradlew test --tests com.back.boundedContexts.member.adapter.web.ApiV1AuthControllerTest --tests com.back.global.security.config.CustomAuthenticationFilterTest`
  - `cd back && ./gradlew ktlintCheck`
  - `cd back && ./gradlew test`
  - pre-commit: `OpenApiContractExportTest`, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 아직 `apiKey` 단독 인증에 의존하는 stale client는 재로그인이 필요합니다.
- 롤백 방법: 이 PR 커밋을 revert해 이전 `apiKey` fallback 정책으로 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
