### PR TITLE
[Fix] sessionless accessToken 보호 API 인증 차단

### DIFF
--- a/back/src/main/kotlin/com/back/global/security/config/CustomAuthenticationFilter.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/CustomAuthenticationFilter.kt
@@ -185,7 +185,7 @@ class CustomAuthenticationFilter(
             }
 
             val sessionResolution = resolveMemberSession(payload.id, sessionKey, payload.sessionKey, payload, request)
-            ensureSessionIsUsable(sessionResolution)
+            ensureSessionIsUsable(sessionResolution, requireSession = true)
             val memberSession = sessionResolution.session
             val rememberLoginEnabled = memberSession?.rememberLoginEnabled ?: payload.rememberLoginEnabled
             val ipSecurityEnabled = memberSession?.ipSecurityEnabled ?: payload.ipSecurityEnabled

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
@@ -620,13 +620,24 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
         @Test
         fun `내 정보 조회에서 Authorization 헤더의 apiKey 와 accessToken 이 모두 유효하면 회원 정보를 반환하고 accessToken 을 재발급하지 않는다`() {
-            val member = memberFacade.findByLoginId("user1")!!
-            val accessToken = authTokenService.genAccessToken(member)
+            val member =
+                memberFacade.join(
+                    username = "session-bound-bearer-user",
+                    password = "Abcd1234!",
+                    nickname = "세션토큰유저",
+                    profileImgUrl = null,
+                    email = "session-bound-bearer-user@example.com",
+                )
+            val authCookies = loginAuthCookies(member.email!!)
+            val apiKeyCookie = requireAuthCookie(authCookies, "apiKey")
+            val accessTokenCookie = requireAuthCookie(authCookies, "accessToken")
+            val sessionKeyCookie = requireAuthCookie(authCookies, "sessionKey")
 
             val resultActions =
                 mvc
                     .get("/member/api/v1/auth/me") {
-                        header(HttpHeaders.AUTHORIZATION, "Bearer ${member.apiKey} $accessToken")
+                        header(HttpHeaders.AUTHORIZATION, "Bearer ${apiKeyCookie.value} ${accessTokenCookie.value}")
+                        cookie(sessionKeyCookie)
                     }.andExpect {
                         status { isOk() }
                         match(handler().handlerType(ApiV1AuthController::class.java))
@@ -648,7 +659,7 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
         }
 
         @Test
-        fun `내 정보 조회에서 표준 Bearer accessToken 형식도 허용한다`() {
+        fun `내 정보 조회에서 sessionKey 없는 Bearer accessToken 은 세션 만료로 거부한다`() {
             val member = memberFacade.findByLoginId("user1")!!
             val accessToken = authTokenService.genAccessToken(member)
 
@@ -656,13 +667,12 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                 .get("/member/api/v1/auth/me") {
                     header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
                 }.andExpect {
-                    status { isOk() }
-                    match(handler().handlerType(ApiV1AuthController::class.java))
-                    match(handler().methodName("me"))
-                    jsonPath("$.id") { value(member.id) }
-                    jsonPath("$.username") { value(member.name) }
-                    jsonPath("$.nickname") { value(member.nickname) }
-                    jsonPath("$.profileImageUrl") { value(startsWith(member.redirectToProfileImgUrlOrDefault)) }
+                    status { isUnauthorized() }
+                    jsonPath("$.resultCode") { value("401-8") }
+                    jsonPath("$.msg") { value("세션이 만료되었습니다. 다시 로그인해주세요.") }
+                    cookie { maxAge("apiKey", 0) }
+                    cookie { maxAge("accessToken", 0) }
+                    cookie { maxAge("sessionKey", 0) }
                 }
         }
 

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostCommentControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostCommentControllerTest.kt
@@ -1,6 +1,7 @@
 package com.back.boundedContexts.post.adapter.web
 
 import com.back.boundedContexts.member.application.service.ActorApplicationService
+import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
 import com.back.boundedContexts.post.application.service.PostApplicationService
 import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostComment
@@ -28,6 +29,9 @@ class ApiV1PostCommentControllerTest : BaseControllerIntegrationTest() {
 
     @Autowired
     private lateinit var actorApplicationService: ActorApplicationService
+
+    @Autowired
+    private lateinit var memberSessionUseCase: MemberSessionUseCase
 
     @Autowired
     private lateinit var jdbcTemplate: JdbcTemplate
@@ -105,12 +109,29 @@ class ApiV1PostCommentControllerTest : BaseControllerIntegrationTest() {
             postFacade.writeComment(user1, privatePost, "비공개 댓글")
             val driftedEmail = "admin-drift-${System.currentTimeMillis()}@test.com"
             jdbcTemplate.update("update member set email = ? where id = ?", driftedEmail, admin.id)
-            val accessToken = actorApplicationService.genAccessToken(admin)
+            val session =
+                memberSessionUseCase.createSession(
+                    member = admin,
+                    rememberLoginEnabled = true,
+                    ipSecurityEnabled = false,
+                    ipSecurityFingerprint = null,
+                    createdIp = null,
+                    userAgent = null,
+                )
+            val accessToken =
+                actorApplicationService.genAccessToken(
+                    member = admin,
+                    sessionKey = session.sessionKey,
+                    rememberLoginEnabled = true,
+                    ipSecurityEnabled = false,
+                    ipSecurityFingerprint = null,
+                )
 
             mvc
                 .get("/post/api/v1/posts/${privatePost.id}/comments") {
                     cookie(Cookie("apiKey", admin.apiKey))
                     cookie(Cookie("accessToken", accessToken))
+                    cookie(Cookie("sessionKey", session.sessionKey))
                 }.andExpect {
                     status { isOk() }
                     match(handler().handlerType(ApiV1PostCommentController::class.java))

--- a/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
@@ -158,15 +158,27 @@ class CustomAuthenticationFilterTest {
         val objectMapper = ObjectMapper()
         val request = MockHttpServletRequest("PUT", "/post/api/v1/posts/452")
         val legacyToken = "legacy-access-token"
+        val sessionKey = "legacy-session-key"
+        val sessionSnapshot =
+            MemberSessionAuthSnapshot(
+                id = 10L,
+                memberId = 54L,
+                sessionKey = sessionKey,
+                rememberLoginEnabled = true,
+                ipSecurityEnabled = false,
+                ipSecurityFingerprint = null,
+                lastAuthenticatedAt = Instant.now(),
+            )
         val persistedAdmin = Member(54L, "internal-admin", null, "aquila", "admin@test.com")
 
         given(publicApiRequestMatcher.matches(request)).willReturn(false)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("Bearer $legacyToken")
-        given(rq.getCookieValue("sessionKey", "")).willReturn("")
+        given(rq.getCookieValue("sessionKey", "")).willReturn(sessionKey)
         given(actorApplicationService.payload(legacyToken))
             .willReturn(
                 AccessTokenPayload(
                     id = 54L,
+                    sessionKey = sessionKey,
                     username = "internal-admin",
                     email = null,
                     name = "aquila",
@@ -175,8 +187,9 @@ class CustomAuthenticationFilterTest {
                     ipSecurityFingerprint = null,
                 ),
             )
+        given(memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(sessionSnapshot)
         given(actorApplicationService.findById(54L)).willReturn(persistedAdmin)
-        given(actorApplicationService.genAccessToken(persistedAdmin)).willReturn("rotated-access-token")
+        given(actorApplicationService.genAccessToken(persistedAdmin, sessionKey, true, false, null)).willReturn("rotated-access-token")
         given(clientIpResolver.resolve(request)).willReturn("203.0.113.12")
 
         val filter =


### PR DESCRIPTION
## 관련 이슈

close #283

## 작업 배경

- `sessionKey`가 없는 Bearer accessToken만으로 보호 API 인증이 통과하던 경로를 차단했습니다.
- 로그인 발급처럼 session-bound token/cookie가 있는 요청과 fresh token safe-read fallback은 유지했습니다.

## 작업 내용

- `CustomAuthenticationFilter`의 payload accessToken 경로도 활성 session snapshot을 필수로 검증하도록 변경했습니다.
- sessionless Bearer accessToken 거부 회귀 테스트를 추가하고, 기존 테스트 fixture를 session-bound 인증 계약에 맞췄습니다.

## 검증

- 실행한 명령과 결과:
  - `cd back && ./gradlew test --tests com.back.boundedContexts.member.adapter.web.ApiV1AuthControllerTest."내 정보 조회에서 sessionKey 없는 Bearer accessToken 은 세션 만료로 거부한다"` (RED 확인 후 GREEN)
  - `cd back && ./gradlew test --tests com.back.boundedContexts.member.adapter.web.ApiV1AuthControllerTest --tests com.back.global.security.config.CustomAuthenticationFilterTest --tests com.back.boundedContexts.post.adapter.web.ApiV1PostCommentControllerTest`
  - `cd back && ./gradlew ktlintCheck`
  - `cd back && ./gradlew test`
  - pre-commit: `OpenApiContractExportTest`, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: sessionless token을 직접 호출에 쓰던 stale client는 재로그인이 필요합니다.
- 롤백 방법: 이 PR 커밋을 revert해 payload accessToken 경로의 세션 필수 검증을 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
