### PR TITLE
[Fix] 쿠키 인증 mutation CSRF 방어 추가

### DIFF
--- a/back/src/main/kotlin/com/back/global/security/config/ApiCorsPolicy.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/ApiCorsPolicy.kt
@@ -35,6 +35,12 @@ class ApiCorsPolicy(
 
     fun corsConfiguration(): CorsConfiguration = CorsConfiguration(configuration)
 
+    fun isAllowedOrigin(origin: String?): Boolean {
+        val normalizedOrigin = origin?.trim().orEmpty()
+        if (normalizedOrigin.isBlank()) return false
+        return configuration.checkOrigin(normalizedOrigin) != null
+    }
+
     /**
      * 허용된 Origin 요청인 경우 응답 헤더에 CORS 필드를 보강합니다.
      * 인증 실패/인가 실패 응답에서도 헤더가 유지되도록 Security 예외 경로에서 호출합니다.

--- a/back/src/main/kotlin/com/back/global/security/config/ApiMutationCsrfGuardFilter.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/ApiMutationCsrfGuardFilter.kt
@@ -1,0 +1,80 @@
+package com.back.global.security.config
+
+import com.back.global.rsData.RsData
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.web.filter.OncePerRequestFilter
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * 쿠키 인증 mutation 요청은 브라우저가 CORS preflight를 수행할 수 있는 custom header를 요구한다.
+ */
+class ApiMutationCsrfGuardFilter(
+    private val apiCorsPolicy: ApiCorsPolicy,
+    private val objectMapper: ObjectMapper,
+) : OncePerRequestFilter() {
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        val method = request.method.uppercase()
+        if (method == "OPTIONS" || method in SAFE_METHODS) return true
+        if (!API_PATH_REGEX.matches(requestPath(request))) return true
+        return !hasAuthCookie(request)
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val origin = request.getHeader(HttpHeaders.ORIGIN)?.trim().orEmpty()
+        if (origin.isNotBlank() && !apiCorsPolicy.isAllowedOrigin(origin)) {
+            writeForbidden(response, "403-2", "허용되지 않은 Origin의 요청입니다.")
+            return
+        }
+
+        if (request.getHeader(CSRF_PREFLIGHT_HEADER)?.trim() != CSRF_PREFLIGHT_VALUE) {
+            apiCorsPolicy.applyResponseHeadersIfAllowed(request, response)
+            writeForbidden(response, "403-3", "CSRF preflight 헤더가 필요합니다.")
+            return
+        }
+
+        filterChain.doFilter(request, response)
+    }
+
+    private fun hasAuthCookie(request: HttpServletRequest): Boolean =
+        request.cookies
+            ?.any { cookie -> cookie.name in AUTH_COOKIE_NAMES && cookie.value.isNotBlank() }
+            ?: false
+
+    private fun requestPath(request: HttpServletRequest): String {
+        val contextPath = request.contextPath.orEmpty()
+        val uri = request.requestURI.orEmpty()
+        return if (contextPath.isNotBlank() && uri.startsWith(contextPath)) {
+            uri.removePrefix(contextPath)
+        } else {
+            uri
+        }
+    }
+
+    private fun writeForbidden(
+        response: HttpServletResponse,
+        resultCode: String,
+        message: String,
+    ) {
+        response.status = HttpServletResponse.SC_FORBIDDEN
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = Charsets.UTF_8.name()
+        response.writer.write(objectMapper.writeValueAsString(RsData<Void>(resultCode, message)))
+    }
+
+    companion object {
+        const val CSRF_PREFLIGHT_HEADER = "X-Aquila-CSRF"
+        const val CSRF_PREFLIGHT_VALUE = "1"
+
+        private val SAFE_METHODS = setOf("GET", "HEAD")
+        private val AUTH_COOKIE_NAMES = setOf("apiKey", "accessToken", "sessionKey")
+        private val API_PATH_REGEX = Regex("^/[^/]+/api/.*")
+    }
+}

--- a/back/src/main/kotlin/com/back/global/security/config/SecurityConfig.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/SecurityConfig.kt
@@ -46,7 +46,10 @@ class SecurityConfig(
      * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
      */
     @Bean
-    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+    fun filterChain(
+        http: HttpSecurity,
+        apiMutationCsrfGuardFilter: ApiMutationCsrfGuardFilter,
+    ): SecurityFilterChain {
         http {
             authorizeHttpRequests {
                 authorize(HttpMethod.OPTIONS, "/**", permitAll)
@@ -107,6 +110,7 @@ class SecurityConfig(
                 }
             }
 
+            addFilterBefore<UsernamePasswordAuthenticationFilter>(apiMutationCsrfGuardFilter)
             addFilterBefore<UsernamePasswordAuthenticationFilter>(customAuthenticationFilter)
 
             exceptionHandling {
@@ -148,6 +152,13 @@ class SecurityConfig(
         UrlBasedCorsConfigurationSource().apply {
             registerCorsConfiguration("/**", apiCorsPolicy.corsConfiguration())
         }
+
+    @Bean
+    fun apiMutationCsrfGuardFilter(): ApiMutationCsrfGuardFilter =
+        ApiMutationCsrfGuardFilter(
+            apiCorsPolicy = apiCorsPolicy,
+            objectMapper = objectMapper,
+        )
 
     private fun applyNoStoreHeaders(response: HttpServletResponse) {
         response.setHeader(HttpHeaders.CACHE_CONTROL, "private, no-store, max-age=0")

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
@@ -446,6 +446,7 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                 mvc
                     .delete("/member/api/v1/auth/logout") {
                         cookie(sessionKeyCookie!!)
+                        header("X-Aquila-CSRF", "1")
                     }.andExpect {
                         status { isOk() }
                         match(handler().handlerType(ApiV1AuthController::class.java))

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostCommentControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostCommentControllerTest.kt
@@ -201,6 +201,43 @@ class ApiV1PostCommentControllerTest : BaseControllerIntegrationTest() {
         }
 
         @Test
+        fun `쿠키 인증 댓글 작성은 CSRF preflight 헤더가 없으면 거부된다`() {
+            val postId = post.id
+            val authCookies = loginAuthCookies("user1@test.com")
+
+            mvc
+                .post("/post/api/v1/posts/$postId/comments") {
+                    authCookies.forEach { cookie(it) }
+                    contentType = MediaType.APPLICATION_JSON
+                    content = """{"content": "csrf 없는 댓글"}"""
+                }.andExpect {
+                    status { isForbidden() }
+                    jsonPath("$.resultCode") { value("403-3") }
+                    jsonPath("$.msg") { value("CSRF preflight 헤더가 필요합니다.") }
+                }
+        }
+
+        @Test
+        fun `쿠키 인증 댓글 작성은 CSRF preflight 헤더가 있으면 처리된다`() {
+            val postId = post.id
+            val authCookies = loginAuthCookies("user1@test.com")
+
+            mvc
+                .post("/post/api/v1/posts/$postId/comments") {
+                    authCookies.forEach { cookie(it) }
+                    header("X-Aquila-CSRF", "1")
+                    contentType = MediaType.APPLICATION_JSON
+                    content = """{"content": "csrf 헤더 댓글"}"""
+                }.andExpect {
+                    match(handler().handlerType(ApiV1PostCommentController::class.java))
+                    match(handler().methodName("write"))
+                    status { isCreated() }
+                    jsonPath("$.resultCode") { value("201-1") }
+                    jsonPath("$.data.content") { value("csrf 헤더 댓글") }
+                }
+        }
+
+        @Test
         @WithUserDetails("user3@test.com")
         fun `인증된 사용자가 기존 댓글에 대댓글을 작성하면 부모 댓글 식별자가 함께 저장된다`() {
             val postId = post.id
@@ -375,4 +412,22 @@ class ApiV1PostCommentControllerTest : BaseControllerIntegrationTest() {
             }
         }
     }
+
+    private fun loginAuthCookies(email: String): List<Cookie> =
+        mvc
+            .post("/member/api/v1/auth/login") {
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "email": "$email",
+                        "password": "1234"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isOk() }
+            }.andReturn()
+            .response
+            .cookies
+            .filter { it.name in setOf("apiKey", "accessToken", "sessionKey") && it.value.isNotBlank() }
 }

--- a/back/src/test/kotlin/com/back/global/security/config/ApiCorsPolicyTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/ApiCorsPolicyTest.kt
@@ -28,6 +28,9 @@ class ApiCorsPolicyTest {
             "http://localhost:*",
             "http://127.0.0.1:*",
         )
+        assertThat(policy.isAllowedOrigin("https://www.aquilaxk.site")).isTrue
+        assertThat(policy.isAllowedOrigin("http://localhost:3000")).isTrue
+        assertThat(policy.isAllowedOrigin("https://evil.example")).isFalse
     }
 
     @Test

--- a/back/src/test/kotlin/com/back/global/security/config/ApiMutationCsrfGuardFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/ApiMutationCsrfGuardFilterTest.kt
@@ -1,0 +1,125 @@
+package com.back.global.security.config
+
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.mock.env.MockEnvironment
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import tools.jackson.databind.ObjectMapper
+
+@DisplayName("ApiMutationCsrfGuardFilter 테스트")
+class ApiMutationCsrfGuardFilterTest {
+    @Test
+    @DisplayName("쿠키 인증 mutation은 CSRF preflight 헤더가 없으면 403으로 차단한다")
+    fun `cookie authenticated mutation without csrf preflight header is forbidden`() {
+        val filter = createFilter()
+        val request = MockHttpServletRequest("POST", "/post/api/v1/posts/1/comments")
+        request.setCookies(Cookie("apiKey", "api-key"))
+        request.addHeader(HttpHeaders.ORIGIN, "https://www.aquilaxk.site")
+        val response = MockHttpServletResponse()
+
+        filter.doFilter(request, response, MockFilterChain())
+
+        assertThat(response.status).isEqualTo(HttpServletResponse.SC_FORBIDDEN)
+        assertThat(response.contentAsString).contains("\"resultCode\":\"403-3\"")
+        assertThat(response.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("https://www.aquilaxk.site")
+    }
+
+    @Test
+    @DisplayName("쿠키 인증 mutation은 CSRF preflight 헤더가 있으면 통과한다")
+    fun `cookie authenticated mutation with csrf preflight header passes`() {
+        val filter = createFilter()
+        val request = MockHttpServletRequest("POST", "/post/api/v1/posts/1/comments")
+        request.setCookies(Cookie("apiKey", "api-key"))
+        request.addHeader(ApiMutationCsrfGuardFilter.CSRF_PREFLIGHT_HEADER, "1")
+        val response = MockHttpServletResponse()
+        val filterChain =
+            MockFilterChain(
+                object : jakarta.servlet.http.HttpServlet() {
+                    override fun service(
+                        req: HttpServletRequest,
+                        res: HttpServletResponse,
+                    ) {
+                        res.status = HttpServletResponse.SC_CREATED
+                    }
+                },
+            )
+
+        filter.doFilter(request, response, filterChain)
+
+        assertThat(response.status).isEqualTo(HttpServletResponse.SC_CREATED)
+    }
+
+    @Test
+    @DisplayName("context path가 붙은 API mutation도 실제 API 경로로 판정한다")
+    fun `api mutation with context path is matched after removing context path`() {
+        val filter = createFilter()
+        val request = MockHttpServletRequest("POST", "/app/post/api/v1/posts/1/comments")
+        request.contextPath = "/app"
+        request.setCookies(Cookie("apiKey", "api-key"))
+        request.addHeader(ApiMutationCsrfGuardFilter.CSRF_PREFLIGHT_HEADER, "1")
+        val response = MockHttpServletResponse()
+        val filterChain =
+            MockFilterChain(
+                object : jakarta.servlet.http.HttpServlet() {
+                    override fun service(
+                        req: HttpServletRequest,
+                        res: HttpServletResponse,
+                    ) {
+                        res.status = HttpServletResponse.SC_CREATED
+                    }
+                },
+            )
+
+        filter.doFilter(request, response, filterChain)
+
+        assertThat(response.status).isEqualTo(HttpServletResponse.SC_CREATED)
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 Origin의 쿠키 인증 mutation은 CSRF 헤더가 있어도 403으로 차단한다")
+    fun `cookie authenticated mutation from disallowed origin is forbidden`() {
+        val filter = createFilter()
+        val request = MockHttpServletRequest("POST", "/post/api/v1/posts/1/comments")
+        request.setCookies(Cookie("apiKey", "api-key"))
+        request.addHeader(HttpHeaders.ORIGIN, "https://evil.example")
+        request.addHeader(ApiMutationCsrfGuardFilter.CSRF_PREFLIGHT_HEADER, "1")
+        val response = MockHttpServletResponse()
+
+        filter.doFilter(request, response, MockFilterChain())
+
+        assertThat(response.status).isEqualTo(HttpServletResponse.SC_FORBIDDEN)
+        assertThat(response.contentAsString).contains("\"resultCode\":\"403-2\"")
+        assertThat(response.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isNull()
+    }
+
+    @Test
+    @DisplayName("인증 쿠키가 없는 mutation은 CSRF guard 대상이 아니다")
+    fun `mutation without auth cookies passes csrf guard`() {
+        val filter = createFilter()
+        val request = MockHttpServletRequest("POST", "/post/api/v1/posts/1/hit")
+        val response = MockHttpServletResponse()
+
+        filter.doFilter(request, response, MockFilterChain())
+
+        assertThat(response.status).isEqualTo(HttpServletResponse.SC_OK)
+    }
+
+    private fun createFilter(): ApiMutationCsrfGuardFilter =
+        ApiMutationCsrfGuardFilter(
+            apiCorsPolicy =
+                ApiCorsPolicy(
+                    environment = MockEnvironment().withProperty("spring.profiles.active", "dev"),
+                    siteFrontUrl = "https://www.aquilaxk.site",
+                    siteBackUrl = "https://api.aquilaxk.site",
+                    siteCookieDomain = "aquilaxk.site",
+                ),
+            objectMapper = ObjectMapper(),
+        )
+}

--- a/front/src/apis/backend/client.ts
+++ b/front/src/apis/backend/client.ts
@@ -7,6 +7,7 @@ const REVALIDATE_CACHE_MAX_TTL_MS = 300_000
 const REVALIDATE_CACHE_MAX_ENTRIES = 200
 const DEFAULT_GET_TRANSIENT_RETRY_COUNT = 1
 const DEFAULT_GET_TRANSIENT_RETRY_DELAY_MS = 120
+const CSRF_PREFLIGHT_HEADER = "X-Aquila-CSRF"
 const GET_RETRYABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504])
 const STALE_IF_ERROR_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504])
 
@@ -371,6 +372,9 @@ export const apiFetch = async <T>(path: string, init: ApiFetchOptions = {}): Pro
 
   if (hasBody && !isFormLikeBody && !headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json")
+  }
+  if (!isReadMethod && requestCredentials !== "omit" && !headers.has(CSRF_PREFLIGHT_HEADER)) {
+    headers.set(CSRF_PREFLIGHT_HEADER, "1")
   }
   if (canUseRevalidateCache && revalidateCacheEntry && !headers.has("If-None-Match")) {
     headers.set("If-None-Match", revalidateCacheEntry.etag)


### PR DESCRIPTION
## 관련 이슈

close #284

## 작업 배경

- 쿠키 인증 POST/PUT/PATCH/DELETE API에 명시적 CSRF preflight 계약을 추가했습니다.
- 프론트 `apiFetch`는 쿠키 포함 mutation 요청에 `X-Aquila-CSRF: 1` 헤더를 자동 설정합니다.

## 작업 내용

- `ApiMutationCsrfGuardFilter`를 Security chain에 등록해 인증 쿠키가 있는 mutation 요청에서 `X-Aquila-CSRF: 1` 헤더와 허용 Origin을 검증합니다.
- `ApiCorsPolicy`에 Origin 허용 여부 판별 API를 추가하고 guard/CORS/WebMvc 회귀 테스트를 추가했습니다.
- logout/comment mutation 테스트와 프론트 backend client를 새 preflight 계약에 맞췄습니다.

## 검증

- 실행한 명령과 결과:
  - `cd back && ./gradlew test --tests com.back.boundedContexts.post.adapter.web.ApiV1PostCommentControllerTest."쿠키 인증 댓글 작성은 CSRF preflight 헤더가 없으면 거부된다"` (RED 확인 후 GREEN)
  - `cd back && ./gradlew test --tests com.back.global.security.config.ApiMutationCsrfGuardFilterTest --tests com.back.global.security.config.ApiCorsPolicyTest --tests com.back.boundedContexts.post.adapter.web.ApiV1PostCommentControllerTest --tests com.back.boundedContexts.member.adapter.web.ApiV1AuthControllerTest`
  - `cd back && ./gradlew ktlintCheck`
  - `cd back && ./gradlew test`
  - `cd back && ./gradlew ciFastCheck --rerun-tasks`
  - `cd front && yarn build`
  - pre-commit: `OpenApiContractExportTest`, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: `apiFetch`를 거치지 않는 브라우저 mutation 호출부는 새 헤더를 직접 추가해야 합니다.
- 롤백 방법: 이 PR 커밋을 revert해 guard filter 등록과 프론트 기본 헤더 설정을 제거합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
