### PR TITLE
[Fix] 세션 단위 refresh token 모델 도입

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthController.kt
@@ -126,8 +126,8 @@ class ApiV1AuthController(
         if (member.apiKey.isBlank() || member.apiKey == member.username) {
             member.modifyApiKey(MemberPolicy.genApiKey())
         }
-        val session =
-            memberSessionUseCase.createSession(
+        val createdSession =
+            memberSessionUseCase.createSessionWithRefreshToken(
                 member = member,
                 rememberLoginEnabled = reqBody.rememberMe,
                 ipSecurityEnabled = reqBody.ipSecurity,
@@ -135,6 +135,7 @@ class ApiV1AuthController(
                 createdIp = clientIp,
                 userAgent = request.getHeader("User-Agent"),
             )
+        val session = createdSession.session
 
         val sessionBoundAccessToken =
             authTokenIssueUseCase.genAccessToken(
@@ -147,6 +148,7 @@ class ApiV1AuthController(
         authCookieService.issueAuthCookies(
             apiKey = member.apiKey,
             accessToken = sessionBoundAccessToken,
+            refreshToken = createdSession.refreshToken,
             sessionKey = session.sessionKey,
             rememberLoginEnabled = session.rememberLoginEnabled,
         )

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepository.kt
@@ -16,6 +16,19 @@ interface MemberSessionRepository : JpaRepository<MemberSession, Long> {
 
     fun findBySessionKeyAndRevokedAtIsNull(sessionKey: String): MemberSession?
 
+    @Query(
+        """
+        select session
+        from MemberSession session
+        join fetch session.member
+        where session.sessionKey = :sessionKey
+          and session.revokedAt is null
+        """,
+    )
+    fun findWithMemberBySessionKeyAndRevokedAtIsNull(
+        @Param("sessionKey") sessionKey: String,
+    ): MemberSession?
+
     fun findByMemberIdAndSessionKeyAndRevokedAtIsNull(
         memberId: Long,
         sessionKey: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepositoryAdapter.kt
@@ -17,6 +17,9 @@ class MemberSessionRepositoryAdapter(
     override fun findBySessionKeyAndRevokedAtIsNull(sessionKey: String): MemberSession? =
         memberSessionRepository.findBySessionKeyAndRevokedAtIsNull(sessionKey)
 
+    override fun findWithMemberBySessionKeyAndRevokedAtIsNull(sessionKey: String): MemberSession? =
+        memberSessionRepository.findWithMemberBySessionKeyAndRevokedAtIsNull(sessionKey)
+
     override fun findByMemberIdAndSessionKeyAndRevokedAtIsNull(
         memberId: Long,
         sessionKey: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/port/input/MemberSessionUseCase.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/port/input/MemberSessionUseCase.kt
@@ -3,6 +3,7 @@ package com.back.boundedContexts.member.subContexts.session.application.port.inp
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.subContexts.session.model.MemberSession
 import com.back.boundedContexts.member.subContexts.session.model.MemberSessionAuthSnapshot
+import com.back.boundedContexts.member.subContexts.session.model.MemberSessionWithRefreshToken
 
 interface MemberSessionUseCase {
     fun createSession(
@@ -13,6 +14,15 @@ interface MemberSessionUseCase {
         createdIp: String?,
         userAgent: String?,
     ): MemberSession
+
+    fun createSessionWithRefreshToken(
+        member: Member,
+        rememberLoginEnabled: Boolean,
+        ipSecurityEnabled: Boolean,
+        ipSecurityFingerprint: String?,
+        createdIp: String?,
+        userAgent: String?,
+    ): MemberSessionWithRefreshToken
 
     fun findActiveSession(sessionKey: String): MemberSession?
 
@@ -31,6 +41,11 @@ interface MemberSessionUseCase {
     fun touchAuthenticated(memberSession: MemberSession)
 
     fun touchAuthenticated(snapshot: MemberSessionAuthSnapshot)
+
+    fun rotateRefreshToken(
+        sessionKey: String,
+        refreshToken: String,
+    ): MemberSessionWithRefreshToken?
 
     fun revokeSession(sessionKey: String)
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/port/output/MemberSessionStorePort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/port/output/MemberSessionStorePort.kt
@@ -11,6 +11,8 @@ interface MemberSessionStorePort {
 
     fun findBySessionKeyAndRevokedAtIsNull(sessionKey: String): MemberSession?
 
+    fun findWithMemberBySessionKeyAndRevokedAtIsNull(sessionKey: String): MemberSession?
+
     fun findByMemberIdAndSessionKeyAndRevokedAtIsNull(
         memberId: Long,
         sessionKey: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionService.kt
@@ -6,6 +6,8 @@ import com.back.boundedContexts.member.subContexts.session.application.port.inpu
 import com.back.boundedContexts.member.subContexts.session.application.port.output.MemberSessionStorePort
 import com.back.boundedContexts.member.subContexts.session.model.MemberSession
 import com.back.boundedContexts.member.subContexts.session.model.MemberSessionAuthSnapshot
+import com.back.boundedContexts.member.subContexts.session.model.MemberSessionRefreshTokenPolicy
+import com.back.boundedContexts.member.subContexts.session.model.MemberSessionWithRefreshToken
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.Cacheable
@@ -22,6 +24,8 @@ class MemberSessionService(
     private val cacheManager: CacheManager,
     @param:Value("\${custom.auth.session.touchMinIntervalSeconds:60}")
     private val touchMinIntervalSeconds: Long,
+    @param:Value("\${custom.auth.refreshToken.expirationSeconds:2592000}")
+    private val refreshTokenExpirationSeconds: Long = 2_592_000,
 ) : MemberSessionUseCase {
     @Transactional
     override fun createSession(
@@ -31,7 +35,27 @@ class MemberSessionService(
         ipSecurityFingerprint: String?,
         createdIp: String?,
         userAgent: String?,
-    ): MemberSession {
+    ): MemberSession =
+        createSessionWithRefreshToken(
+            member = member,
+            rememberLoginEnabled = rememberLoginEnabled,
+            ipSecurityEnabled = ipSecurityEnabled,
+            ipSecurityFingerprint = ipSecurityFingerprint,
+            createdIp = createdIp,
+            userAgent = userAgent,
+        ).session
+
+    @Transactional
+    override fun createSessionWithRefreshToken(
+        member: Member,
+        rememberLoginEnabled: Boolean,
+        ipSecurityEnabled: Boolean,
+        ipSecurityFingerprint: String?,
+        createdIp: String?,
+        userAgent: String?,
+    ): MemberSessionWithRefreshToken {
+        val now = Instant.now()
+        val refreshToken = MemberSessionRefreshTokenPolicy.generate()
         val session =
             MemberSession(
                 member = member,
@@ -42,8 +66,12 @@ class MemberSessionService(
                 createdIp = createdIp?.take(120),
                 userAgent = userAgent?.take(512),
             )
-        session.touchAuthenticated()
-        return memberSessionStorePort.save(session)
+        session.touchAuthenticated(now)
+        session.bindRefreshToken(refreshToken, refreshTokenExpiresAt(now), now)
+        return MemberSessionWithRefreshToken(
+            session = memberSessionStorePort.save(session),
+            refreshToken = refreshToken,
+        )
     }
 
     @Transactional(readOnly = true)
@@ -103,6 +131,32 @@ class MemberSessionService(
     }
 
     @Transactional
+    override fun rotateRefreshToken(
+        sessionKey: String,
+        refreshToken: String,
+    ): MemberSessionWithRefreshToken? {
+        if (sessionKey.isBlank() || refreshToken.isBlank()) return null
+        val session = memberSessionStorePort.findWithMemberBySessionKeyAndRevokedAtIsNull(sessionKey) ?: return null
+        val now = Instant.now()
+
+        if (!session.matchesRefreshToken(refreshToken, now)) {
+            if (session.isRefreshTokenExpired(now)) {
+                session.revoke(now)
+            } else {
+                session.markRefreshTokenReused(now)
+            }
+            evictActiveSnapshot(session.member.id, session.sessionKey)
+            return null
+        }
+
+        val nextRefreshToken = MemberSessionRefreshTokenPolicy.generate()
+        session.bindRefreshToken(nextRefreshToken, refreshTokenExpiresAt(now), now)
+        session.touchAuthenticated(now)
+        evictActiveSnapshot(session.member.id, session.sessionKey)
+        return MemberSessionWithRefreshToken(session = session, refreshToken = nextRefreshToken)
+    }
+
+    @Transactional
     override fun revokeSession(sessionKey: String) {
         if (sessionKey.isBlank()) return
         val session = memberSessionStorePort.findBySessionKeyAndRevokedAtIsNull(sessionKey) ?: return
@@ -127,4 +181,6 @@ class MemberSessionService(
         if (touchMinIntervalSeconds <= 0) return true
         return lastAuthenticatedAt == null || !now.isBefore(lastAuthenticatedAt.plusSeconds(touchMinIntervalSeconds))
     }
+
+    private fun refreshTokenExpiresAt(now: Instant): Instant = now.plusSeconds(refreshTokenExpirationSeconds.coerceAtLeast(1))
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/model/MemberSession.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/model/MemberSession.kt
@@ -35,6 +35,11 @@ class MemberSession(
     var createdIp: String? = null,
     @field:Column(length = 512)
     var userAgent: String? = null,
+    @field:Column(length = 128)
+    var refreshTokenHash: String? = null,
+    var refreshTokenExpiresAt: Instant? = null,
+    var refreshTokenRotatedAt: Instant? = null,
+    var refreshTokenReusedAt: Instant? = null,
     var lastAuthenticatedAt: Instant? = null,
     var revokedAt: Instant? = null,
 ) : BaseTime(id) {
@@ -44,6 +49,37 @@ class MemberSession(
 
     fun touchAuthenticated(now: Instant = Instant.now()) {
         lastAuthenticatedAt = now
+    }
+
+    fun bindRefreshToken(
+        refreshToken: String,
+        expiresAt: Instant,
+        now: Instant = Instant.now(),
+    ) {
+        refreshTokenHash = MemberSessionRefreshTokenPolicy.hash(refreshToken)
+        refreshTokenExpiresAt = expiresAt
+        refreshTokenRotatedAt = now
+        refreshTokenReusedAt = null
+    }
+
+    fun matchesRefreshToken(
+        refreshToken: String,
+        now: Instant = Instant.now(),
+    ): Boolean {
+        val storedHash = refreshTokenHash ?: return false
+        val expiresAt = refreshTokenExpiresAt ?: return false
+        if (!now.isBefore(expiresAt)) return false
+        return storedHash == MemberSessionRefreshTokenPolicy.hash(refreshToken)
+    }
+
+    fun isRefreshTokenExpired(now: Instant = Instant.now()): Boolean {
+        val expiresAt = refreshTokenExpiresAt ?: return true
+        return !now.isBefore(expiresAt)
+    }
+
+    fun markRefreshTokenReused(now: Instant = Instant.now()) {
+        refreshTokenReusedAt = now
+        revoke(now)
     }
 
     fun touchAuthenticatedIfDue(

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/model/MemberSessionRefreshTokenPolicy.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/model/MemberSessionRefreshTokenPolicy.kt
@@ -1,0 +1,21 @@
+package com.back.boundedContexts.member.subContexts.session.model
+
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+object MemberSessionRefreshTokenPolicy {
+    private val secureRandom = SecureRandom()
+    private val encoder: Base64.Encoder = Base64.getUrlEncoder().withoutPadding()
+
+    fun generate(): String {
+        val bytes = ByteArray(32)
+        secureRandom.nextBytes(bytes)
+        return encoder.encodeToString(bytes)
+    }
+
+    fun hash(refreshToken: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(refreshToken.toByteArray(Charsets.UTF_8))
+        return encoder.encodeToString(digest)
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/model/MemberSessionWithRefreshToken.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/model/MemberSessionWithRefreshToken.kt
@@ -1,0 +1,6 @@
+package com.back.boundedContexts.member.subContexts.session.model
+
+data class MemberSessionWithRefreshToken(
+    val session: MemberSession,
+    val refreshToken: String,
+)

--- a/back/src/main/kotlin/com/back/global/security/config/CustomAuthenticationFilter.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/CustomAuthenticationFilter.kt
@@ -125,9 +125,10 @@ class CustomAuthenticationFilter(
         val apiKey = tokens.apiKey
         val accessToken = tokens.accessToken
         val sessionKey = tokens.sessionKey
+        val refreshToken = tokens.refreshToken
         val clientIp = clientIpResolver.resolve(request)
 
-        if (apiKey.isBlank() && accessToken.isBlank()) return
+        if (apiKey.isBlank() && accessToken.isBlank() && refreshToken.isBlank()) return
 
         val payload = accessToken.takeIf { it.isNotBlank() }?.let(actorApplicationService::payload)
 
@@ -248,16 +249,23 @@ class CustomAuthenticationFilter(
             return
         }
 
-        val member =
-            actorApplicationService.findByApiKey(apiKey)
-                ?: throw AppException("401-3", "API 키가 유효하지 않습니다.")
+        if (sessionKey.isBlank() || refreshToken.isBlank()) {
+            authCookieService.expireAuthCookies()
+            throw AppException("401-8", "세션이 만료되었습니다. 다시 로그인해주세요.")
+        }
 
-        val sessionResolution = resolveMemberSession(member.id, sessionKey, null, null, request)
-        ensureSessionIsUsable(sessionResolution, requireSession = true)
-        val memberSession = sessionResolution.session
-        val rememberLoginEnabled = memberSession?.rememberLoginEnabled ?: member.rememberLoginEnabled
-        val ipSecurityEnabled = memberSession?.ipSecurityEnabled ?: member.ipSecurityEnabled
-        val ipSecurityFingerprint = memberSession?.ipSecurityFingerprint ?: member.ipSecurityFingerprint
+        val refreshedSession =
+            memberSessionUseCase.rotateRefreshToken(sessionKey, refreshToken)
+                ?: run {
+                    authCookieService.expireAuthCookies()
+                    throw AppException("401-8", "세션이 만료되었습니다. 다시 로그인해주세요.")
+                }
+
+        val memberSession = refreshedSession.session
+        val member = memberSession.member
+        val rememberLoginEnabled = memberSession.rememberLoginEnabled
+        val ipSecurityEnabled = memberSession.ipSecurityEnabled
+        val ipSecurityFingerprint = memberSession.ipSecurityFingerprint
 
         if (ipSecurityEnabled) {
             val matched = authIpSecurityService.matches(ipSecurityFingerprint, clientIp)
@@ -270,11 +278,12 @@ class CustomAuthenticationFilter(
                         ipSecurityEnabled = ipSecurityEnabled,
                         expectedIpFingerprint = ipSecurityFingerprint,
                         requestPath = request.requestURI,
-                        reason = "apikey-ip-mismatch",
+                        reason = "refresh-token-ip-mismatch",
                     )
                 }.onFailure { exception ->
-                    log.warn("auth_security_event_record_failed reason=apikey-ip-mismatch", exception)
+                    log.warn("auth_security_event_record_failed reason=refresh-token-ip-mismatch", exception)
                 }
+                memberSessionUseCase.revokeSession(memberSession.sessionKey)
                 authCookieService.expireAuthCookies()
                 throw AppException("401-7", "IP 보안 검증에 실패했습니다. 다시 로그인해주세요.")
             }
@@ -283,7 +292,7 @@ class CustomAuthenticationFilter(
         val newAccessToken =
             actorApplicationService.genAccessToken(
                 member = member,
-                sessionKey = memberSession?.sessionKey,
+                sessionKey = memberSession.sessionKey,
                 rememberLoginEnabled = rememberLoginEnabled,
                 ipSecurityEnabled = ipSecurityEnabled,
                 ipSecurityFingerprint = ipSecurityFingerprint,
@@ -291,10 +300,10 @@ class CustomAuthenticationFilter(
         authCookieService.issueAccessToken(
             accessToken = newAccessToken,
             rememberLoginEnabled = rememberLoginEnabled,
-            sessionKey = memberSession?.sessionKey,
+            sessionKey = memberSession.sessionKey,
+            refreshToken = refreshedSession.refreshToken,
         )
         rq.setHeader(HttpHeaders.AUTHORIZATION, "Bearer $newAccessToken")
-        memberSession?.let { memberSessionUseCase.touchAuthenticated(it) }
 
         authenticate(member)
     }
@@ -304,8 +313,9 @@ class CustomAuthenticationFilter(
      * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
      */
     private fun extractTokens(): ExtractedTokens {
-        val headerAuthorization = rq.getHeader(HttpHeaders.AUTHORIZATION, "")
-        val sessionKey = rq.getCookieValue("sessionKey", "")
+        val headerAuthorization = rq.getHeader(HttpHeaders.AUTHORIZATION, "").orEmpty()
+        val sessionKey = rq.getCookieValue("sessionKey", "").orEmpty()
+        val refreshToken = rq.getCookieValue("refreshToken", "").orEmpty()
 
         return if (headerAuthorization.isNotBlank()) {
             if (!headerAuthorization.startsWith("Bearer ")) {
@@ -316,21 +326,22 @@ class CustomAuthenticationFilter(
             when (bits.size) {
                 2 -> {
                     if (bits[1].isBlank()) throw AppException("401-2", "${HttpHeaders.AUTHORIZATION} 헤더가 Bearer 형식이 아닙니다.")
-                    ExtractedTokens("", bits[1], sessionKey)
+                    ExtractedTokens("", bits[1], sessionKey, refreshToken)
                 }
                 3 -> {
                     if (bits[1].isBlank() || bits[2].isBlank()) {
                         throw AppException("401-2", "${HttpHeaders.AUTHORIZATION} 헤더가 Bearer 형식이 아닙니다.")
                     }
-                    ExtractedTokens(bits[1], bits[2], sessionKey)
+                    ExtractedTokens(bits[1], bits[2], sessionKey, refreshToken)
                 }
                 else -> throw AppException("401-2", "${HttpHeaders.AUTHORIZATION} 헤더가 Bearer 형식이 아닙니다.")
             }
         } else {
             ExtractedTokens(
-                apiKey = rq.getCookieValue("apiKey", ""),
-                accessToken = rq.getCookieValue("accessToken", ""),
+                apiKey = rq.getCookieValue("apiKey", "").orEmpty(),
+                accessToken = rq.getCookieValue("accessToken", "").orEmpty(),
                 sessionKey = sessionKey,
+                refreshToken = refreshToken,
             )
         }
     }
@@ -384,6 +395,7 @@ class CustomAuthenticationFilter(
         val apiKey: String,
         val accessToken: String,
         val sessionKey: String,
+        val refreshToken: String,
     )
 
     private data class SessionResolution(

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginSuccessHandler.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginSuccessHandler.kt
@@ -45,8 +45,8 @@ class CustomOAuth2LoginSuccessHandler(
         if (actor.apiKey.isBlank() || actor.apiKey == actor.username) {
             actor.modifyApiKey(MemberPolicy.genApiKey())
         }
-        val session =
-            memberSessionUseCase.createSession(
+        val createdSession =
+            memberSessionUseCase.createSessionWithRefreshToken(
                 member = actor,
                 rememberLoginEnabled = true,
                 ipSecurityEnabled = false,
@@ -54,6 +54,7 @@ class CustomOAuth2LoginSuccessHandler(
                 createdIp = clientIpResolver.resolve(request),
                 userAgent = request.getHeader("User-Agent"),
             )
+        val session = createdSession.session
         val accessToken =
             actorApplicationService.genAccessToken(
                 member = actor,
@@ -66,6 +67,7 @@ class CustomOAuth2LoginSuccessHandler(
         authCookieService.issueAuthCookies(
             apiKey = actor.apiKey,
             accessToken = accessToken,
+            refreshToken = createdSession.refreshToken,
             sessionKey = session.sessionKey,
             rememberLoginEnabled = session.rememberLoginEnabled,
         )

--- a/back/src/main/kotlin/com/back/global/web/application/AuthCookieService.kt
+++ b/back/src/main/kotlin/com/back/global/web/application/AuthCookieService.kt
@@ -20,15 +20,19 @@ class AuthCookieService(
     private val apiKeyCookieMaxAgeSeconds: Int,
     @param:Value("\${custom.accessToken.expirationSeconds:1200}")
     private val accessTokenCookieMaxAgeSeconds: Int,
+    @param:Value("\${custom.auth.refreshToken.cookieMaxAgeSeconds:2592000}")
+    private val refreshTokenCookieMaxAgeSeconds: Int,
 ) {
     fun issueAuthCookies(
         apiKey: String,
         accessToken: String,
+        refreshToken: String,
         sessionKey: String? = null,
         rememberLoginEnabled: Boolean = true,
     ) {
         issueCookie("apiKey", apiKey, apiKeyCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
         issueCookie("accessToken", accessToken, accessTokenCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
+        issueCookie("refreshToken", refreshToken, refreshTokenCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
         if (!sessionKey.isNullOrBlank()) {
             issueCookie("sessionKey", sessionKey, apiKeyCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
         }
@@ -38,6 +42,7 @@ class AuthCookieService(
         accessToken: String,
         rememberLoginEnabled: Boolean = true,
         sessionKey: String? = null,
+        refreshToken: String? = null,
     ) {
         issueCookie(
             "accessToken",
@@ -45,6 +50,9 @@ class AuthCookieService(
             accessTokenCookieMaxAgeSeconds,
             sessionOnly = !rememberLoginEnabled,
         )
+        if (!refreshToken.isNullOrBlank()) {
+            issueCookie("refreshToken", refreshToken, refreshTokenCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
+        }
         if (!sessionKey.isNullOrBlank()) {
             issueCookie("sessionKey", sessionKey, apiKeyCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
         }
@@ -53,6 +61,7 @@ class AuthCookieService(
     fun expireAuthCookies() {
         expireCookie("apiKey")
         expireCookie("accessToken")
+        expireCookie("refreshToken")
         expireCookie("sessionKey")
     }
 

--- a/back/src/main/resources/db/migration-test/V20260520_01__add_member_session_refresh_token.sql
+++ b/back/src/main/resources/db/migration-test/V20260520_01__add_member_session_refresh_token.sql
@@ -1,0 +1,8 @@
+ALTER TABLE member_session
+    ADD COLUMN IF NOT EXISTS refresh_token_hash VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS refresh_token_expires_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN IF NOT EXISTS refresh_token_rotated_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN IF NOT EXISTS refresh_token_reused_at TIMESTAMP WITH TIME ZONE;
+
+CREATE INDEX IF NOT EXISTS member_session_idx_refresh_token_expires_at
+    ON member_session (refresh_token_expires_at);

--- a/back/src/main/resources/db/migration/V20260520_01__add_member_session_refresh_token.sql
+++ b/back/src/main/resources/db/migration/V20260520_01__add_member_session_refresh_token.sql
@@ -1,0 +1,8 @@
+ALTER TABLE member_session
+    ADD COLUMN IF NOT EXISTS refresh_token_hash VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS refresh_token_expires_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN IF NOT EXISTS refresh_token_rotated_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN IF NOT EXISTS refresh_token_reused_at TIMESTAMP WITH TIME ZONE;
+
+CREATE INDEX IF NOT EXISTS member_session_idx_refresh_token_expires_at
+    ON member_session (refresh_token_expires_at);

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
@@ -94,12 +94,22 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
             assertThat(accessTokenCookie.path).isEqualTo("/")
             assertThat(accessTokenCookie.isHttpOnly).isTrue
 
+            val refreshTokenCookie =
+                result.response.cookies.firstOrNull { it.name == "refreshToken" && it.value.isNotBlank() }
+            assertThat(refreshTokenCookie).isNotNull
+            assertThat(refreshTokenCookie!!.value).isNotBlank()
+            assertThat(refreshTokenCookie.path).isEqualTo("/")
+            assertThat(refreshTokenCookie.isHttpOnly).isTrue
+
             val sessionKeyCookie =
                 result.response.cookies.firstOrNull { it.name == "sessionKey" && it.value.isNotBlank() }
             assertThat(sessionKeyCookie).isNotNull
             val activeSession = memberSessionRepository.findBySessionKeyAndRevokedAtIsNull(sessionKeyCookie!!.value)
             assertThat(activeSession).isNotNull
             assertThat(activeSession!!.member.id).isEqualTo(member.id)
+            assertThat(activeSession.refreshTokenHash).isNotBlank()
+            assertThat(activeSession.refreshTokenHash).isNotEqualTo(refreshTokenCookie.value)
+            assertThat(activeSession.refreshTokenExpiresAt).isNotNull
         }
 
         @Test
@@ -161,6 +171,8 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                 result.response.cookies.firstOrNull { it.name == "apiKey" && it.value.isNotBlank() }
             val issuedAccessTokenCookie =
                 result.response.cookies.firstOrNull { it.name == "accessToken" && it.value.isNotBlank() }
+            val issuedRefreshTokenCookie =
+                result.response.cookies.firstOrNull { it.name == "refreshToken" && it.value.isNotBlank() }
             val issuedSessionKeyCookie =
                 result.response.cookies.firstOrNull { it.name == "sessionKey" && it.value.isNotBlank() }
 
@@ -170,6 +182,8 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
             assertThat(issuedAccessTokenCookie).isNotNull
             assertThat(issuedAccessTokenCookie!!.maxAge).isEqualTo(-1)
+            assertThat(issuedRefreshTokenCookie).isNotNull
+            assertThat(issuedRefreshTokenCookie!!.maxAge).isEqualTo(-1)
             assertThat(issuedSessionKeyCookie).isNotNull
             assertThat(issuedSessionKeyCookie!!.maxAge).isEqualTo(-1)
         }
@@ -201,10 +215,10 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
             val issuedCookies =
                 loginResult.response.cookies.filter {
-                    it.name in setOf("apiKey", "accessToken", "sessionKey") && it.value.isNotBlank()
+                    it.name in setOf("apiKey", "accessToken", "refreshToken", "sessionKey") && it.value.isNotBlank()
                 }
 
-            assertThat(issuedCookies.map { it.name }).contains("apiKey", "accessToken", "sessionKey")
+            assertThat(issuedCookies.map { it.name }).contains("apiKey", "accessToken", "refreshToken", "sessionKey")
 
             mvc
                 .get("/member/api/v1/auth/session") {
@@ -246,9 +260,12 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
             val firstApiKeyCookie =
                 firstLogin.response.cookies.firstOrNull { it.name == "apiKey" && it.value.isNotBlank() }
+            val firstAccessTokenCookie =
+                firstLogin.response.cookies.firstOrNull { it.name == "accessToken" && it.value.isNotBlank() }
             val firstSessionKeyCookie =
                 firstLogin.response.cookies.firstOrNull { it.name == "sessionKey" && it.value.isNotBlank() }
             assertThat(firstApiKeyCookie).isNotNull
+            assertThat(firstAccessTokenCookie).isNotNull
             assertThat(firstSessionKeyCookie).isNotNull
 
             val secondLogin =
@@ -274,6 +291,7 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
             mvc
                 .get("/member/api/v1/auth/me") {
                     cookie(Cookie("apiKey", firstApiKeyCookie.value))
+                    cookie(Cookie("accessToken", firstAccessTokenCookie!!.value))
                     cookie(Cookie("sessionKey", firstSessionKeyCookie!!.value))
                 }.andExpect {
                     status { isOk() }
@@ -471,6 +489,20 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
             assertThat(accessTokenCookie.path).isEqualTo("/")
             assertThat(accessTokenCookie.isHttpOnly).isTrue
 
+            val refreshTokenCookie: Cookie? = result.response.getCookie("refreshToken")
+            assertThat(refreshTokenCookie).isNotNull
+            assertThat(refreshTokenCookie!!.value).isEmpty()
+            assertThat(refreshTokenCookie.maxAge).isEqualTo(0)
+            assertThat(refreshTokenCookie.path).isEqualTo("/")
+            assertThat(refreshTokenCookie.isHttpOnly).isTrue
+
+            val expiredSessionKeyCookie: Cookie? = result.response.getCookie("sessionKey")
+            assertThat(expiredSessionKeyCookie).isNotNull
+            assertThat(expiredSessionKeyCookie!!.value).isEmpty()
+            assertThat(expiredSessionKeyCookie.maxAge).isEqualTo(0)
+            assertThat(expiredSessionKeyCookie.path).isEqualTo("/")
+            assertThat(expiredSessionKeyCookie.isHttpOnly).isTrue
+
             val revokedSession = memberSessionRepository.findBySessionKey(sessionKeyCookie!!.value)
             assertThat(revokedSession).isNotNull
             assertThat(revokedSession!!.revokedAt).isNotNull
@@ -548,6 +580,7 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                     jsonPath("$.msg") { value("세션이 만료되었습니다. 다시 로그인해주세요.") }
                     cookie { maxAge("apiKey", 0) }
                     cookie { maxAge("accessToken", 0) }
+                    cookie { maxAge("refreshToken", 0) }
                     cookie { maxAge("sessionKey", 0) }
                 }
         }
@@ -576,7 +609,7 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
         }
 
         @Test
-        fun `내 정보 조회에서 Authorization 헤더의 accessToken 이 잘못되어도 apiKey 와 sessionKey 가 유효하면 accessToken 을 재발급한다`() {
+        fun `내 정보 조회에서 accessToken 이 잘못되어도 refreshToken 과 sessionKey 가 유효하면 토큰을 회전한다`() {
             val member =
                 memberFacade.join(
                     username = "session-bound-rotate-user",
@@ -587,11 +620,13 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                 )
             val authCookies = loginAuthCookies(member.email!!)
             val sessionKeyCookie = requireAuthCookie(authCookies, "sessionKey")
+            val refreshTokenCookie = requireAuthCookie(authCookies, "refreshToken")
 
             val resultActions =
                 mvc
                     .get("/member/api/v1/auth/me") {
-                        header(HttpHeaders.AUTHORIZATION, "Bearer ${member.apiKey} wrong-access-token")
+                        cookie(Cookie("accessToken", "wrong-access-token"))
+                        cookie(refreshTokenCookie)
                         cookie(sessionKeyCookie)
                     }.andExpect {
                         status { isOk() }
@@ -610,13 +645,64 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
             val result = resultActions.andReturn()
             val accessTokenCookie =
                 result.response.cookies.firstOrNull { it.name == "accessToken" && it.value.isNotBlank() }
+            val rotatedRefreshTokenCookie =
+                result.response.cookies.firstOrNull { it.name == "refreshToken" && it.value.isNotBlank() }
 
             assertThat(accessTokenCookie).isNotNull
             assertThat(accessTokenCookie!!.value).isNotBlank()
             assertThat(accessTokenCookie.path).isEqualTo("/")
             assertThat(accessTokenCookie.isHttpOnly).isTrue
+            assertThat(rotatedRefreshTokenCookie).isNotNull
+            assertThat(rotatedRefreshTokenCookie!!.value).isNotBlank()
+            assertThat(rotatedRefreshTokenCookie.value).isNotEqualTo(refreshTokenCookie.value)
+            assertThat(rotatedRefreshTokenCookie.path).isEqualTo("/")
+            assertThat(rotatedRefreshTokenCookie.isHttpOnly).isTrue
             assertThat(result.response.getHeader(HttpHeaders.AUTHORIZATION))
                 .isEqualTo("Bearer ${accessTokenCookie.value}")
+        }
+
+        @Test
+        fun `내 정보 조회에서 이미 회전된 refreshToken 을 다시 사용하면 세션을 폐기한다`() {
+            val member =
+                memberFacade.join(
+                    username = "session-bound-reuse-user",
+                    password = "Abcd1234!",
+                    nickname = "세션재사용",
+                    profileImgUrl = null,
+                    email = "session-bound-reuse-user@example.com",
+                )
+            val authCookies = loginAuthCookies(member.email!!)
+            val sessionKeyCookie = requireAuthCookie(authCookies, "sessionKey")
+            val staleRefreshTokenCookie = requireAuthCookie(authCookies, "refreshToken")
+
+            mvc
+                .get("/member/api/v1/auth/me") {
+                    cookie(Cookie("accessToken", "wrong-access-token"))
+                    cookie(staleRefreshTokenCookie)
+                    cookie(sessionKeyCookie)
+                }.andExpect {
+                    status { isOk() }
+                }
+
+            mvc
+                .get("/member/api/v1/auth/me") {
+                    cookie(Cookie("accessToken", "wrong-access-token"))
+                    cookie(staleRefreshTokenCookie)
+                    cookie(sessionKeyCookie)
+                }.andExpect {
+                    status { isUnauthorized() }
+                    jsonPath("$.resultCode") { value("401-8") }
+                    jsonPath("$.msg") { value("세션이 만료되었습니다. 다시 로그인해주세요.") }
+                    cookie { maxAge("apiKey", 0) }
+                    cookie { maxAge("accessToken", 0) }
+                    cookie { maxAge("refreshToken", 0) }
+                    cookie { maxAge("sessionKey", 0) }
+                }
+
+            val revokedSession = memberSessionRepository.findBySessionKey(sessionKeyCookie.value)
+            assertThat(revokedSession).isNotNull
+            assertThat(revokedSession!!.refreshTokenReusedAt).isNotNull
+            assertThat(revokedSession.revokedAt).isNotNull
         }
 
         @Test
@@ -673,6 +759,7 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                     jsonPath("$.msg") { value("세션이 만료되었습니다. 다시 로그인해주세요.") }
                     cookie { maxAge("apiKey", 0) }
                     cookie { maxAge("accessToken", 0) }
+                    cookie { maxAge("refreshToken", 0) }
                     cookie { maxAge("sessionKey", 0) }
                 }
         }
@@ -706,14 +793,18 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
             val apiKeyCookie =
                 loginResponse.response.cookies.firstOrNull { it.name == "apiKey" && it.value.isNotBlank() }
+            val accessTokenCookie =
+                loginResponse.response.cookies.firstOrNull { it.name == "accessToken" && it.value.isNotBlank() }
             val sessionKeyCookie =
                 loginResponse.response.cookies.firstOrNull { it.name == "sessionKey" && it.value.isNotBlank() }
             assertThat(apiKeyCookie).isNotNull
+            assertThat(accessTokenCookie).isNotNull
             assertThat(sessionKeyCookie).isNotNull
 
             mvc
                 .get("/member/api/v1/auth/me") {
                     cookie(apiKeyCookie!!)
+                    cookie(accessTokenCookie!!)
                     cookie(sessionKeyCookie!!)
                     with(remoteAddr("10.0.0.77"))
                 }.andExpect {
@@ -723,6 +814,8 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                 }.andExpect {
                     cookie { maxAge("apiKey", 0) }
                     cookie { maxAge("accessToken", 0) }
+                    cookie { maxAge("refreshToken", 0) }
+                    cookie { maxAge("sessionKey", 0) }
                 }
         }
 
@@ -757,14 +850,18 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
             val apiKeyCookie =
                 loginResponse.response.cookies.firstOrNull { it.name == "apiKey" && it.value.isNotBlank() }
+            val accessTokenCookie =
+                loginResponse.response.cookies.firstOrNull { it.name == "accessToken" && it.value.isNotBlank() }
             val sessionKeyCookie =
                 loginResponse.response.cookies.firstOrNull { it.name == "sessionKey" && it.value.isNotBlank() }
             assertThat(apiKeyCookie).isNotNull
+            assertThat(accessTokenCookie).isNotNull
             assertThat(sessionKeyCookie).isNotNull
 
             mvc
                 .get("/member/api/v1/auth/me") {
                     cookie(apiKeyCookie!!)
+                    cookie(accessTokenCookie!!)
                     cookie(sessionKeyCookie!!)
                     header("CF-Connecting-IP", "198.51.100.34")
                     with(remoteAddr("172.18.0.9"))
@@ -792,7 +889,7 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
             }.andReturn()
             .response
             .cookies
-            .filter { it.name in setOf("apiKey", "accessToken", "sessionKey") && it.value.isNotBlank() }
+            .filter { it.name in setOf("apiKey", "accessToken", "refreshToken", "sessionKey") && it.value.isNotBlank() }
 
     private fun requireAuthCookie(
         cookies: List<Cookie>,

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionServiceTest.kt
@@ -1,5 +1,7 @@
 package com.back.boundedContexts.member.subContexts.session.application.service
 
+import com.back.boundedContexts.member.domain.shared.MemberPolicy
+import com.back.boundedContexts.member.model.shared.Member
 import com.back.boundedContexts.member.subContexts.session.application.port.output.MemberSessionStorePort
 import com.back.boundedContexts.member.subContexts.session.model.MemberSession
 import com.back.boundedContexts.member.subContexts.session.model.MemberSessionAuthSnapshot
@@ -11,6 +13,72 @@ import java.time.Instant
 
 @DisplayName("MemberSessionService 테스트")
 class MemberSessionServiceTest {
+    @Test
+    fun `세션 생성 시 refreshToken 원문은 한 번만 반환하고 저장소에는 hash 와 만료시각만 저장한다`() {
+        val store = RecordingMemberSessionStorePort()
+        val service =
+            MemberSessionService(
+                memberSessionStorePort = store,
+                cacheManager = ConcurrentMapCacheManager(),
+                touchMinIntervalSeconds = 60,
+                refreshTokenExpirationSeconds = 3600,
+            )
+        val member = Member(54L, "refresh-create-user", null, "리프레시생성", "refresh-create@example.com", MemberPolicy.genApiKey())
+
+        val created =
+            service.createSessionWithRefreshToken(
+                member = member,
+                rememberLoginEnabled = true,
+                ipSecurityEnabled = false,
+                ipSecurityFingerprint = null,
+                createdIp = "203.0.113.20",
+                userAgent = "test-agent",
+            )
+
+        assertThat(created.refreshToken).isNotBlank()
+        assertThat(created.session.refreshTokenHash).isNotBlank()
+        assertThat(created.session.refreshTokenHash).isNotEqualTo(created.refreshToken)
+        assertThat(created.session.refreshTokenExpiresAt).isAfter(Instant.now())
+        assertThat(store.findBySessionKey(created.session.sessionKey)).isSameAs(created.session)
+    }
+
+    @Test
+    fun `refreshToken 회전 후 이전 토큰을 다시 쓰면 세션을 폐기한다`() {
+        val store = RecordingMemberSessionStorePort()
+        val service =
+            MemberSessionService(
+                memberSessionStorePort = store,
+                cacheManager = ConcurrentMapCacheManager(),
+                touchMinIntervalSeconds = 60,
+                refreshTokenExpirationSeconds = 3600,
+            )
+        val member = Member(55L, "refresh-reuse-user", null, "리프레시재사용", "refresh-reuse@example.com", MemberPolicy.genApiKey())
+        val created =
+            service.createSessionWithRefreshToken(
+                member = member,
+                rememberLoginEnabled = true,
+                ipSecurityEnabled = false,
+                ipSecurityFingerprint = null,
+                createdIp = "203.0.113.21",
+                userAgent = "test-agent",
+            )
+        val originalHash = created.session.refreshTokenHash
+
+        val rotated = service.rotateRefreshToken(created.session.sessionKey, created.refreshToken)
+
+        assertThat(rotated).isNotNull
+        assertThat(rotated!!.refreshToken).isNotBlank()
+        assertThat(rotated.refreshToken).isNotEqualTo(created.refreshToken)
+        assertThat(rotated.session.refreshTokenHash).isNotEqualTo(originalHash)
+        assertThat(rotated.session.matchesRefreshToken(rotated.refreshToken)).isTrue()
+
+        val reused = service.rotateRefreshToken(created.session.sessionKey, created.refreshToken)
+
+        assertThat(reused).isNull()
+        assertThat(created.session.refreshTokenReusedAt).isNotNull
+        assertThat(created.session.revokedAt).isNotNull
+    }
+
     @Test
     fun `snapshot lastAuthenticatedAt 이 최소 간격 이내면 DB touch update를 생략한다`() {
         val store = RecordingMemberSessionStorePort()
@@ -65,24 +133,35 @@ class MemberSessionServiceTest {
     private class RecordingMemberSessionStorePort : MemberSessionStorePort {
         var touchCallCount: Int = 0
         var lastTouchedSessionId: Long? = null
+        private val sessionsByKey = linkedMapOf<String, MemberSession>()
 
-        override fun save(memberSession: MemberSession): MemberSession = error("not used")
+        override fun save(memberSession: MemberSession): MemberSession {
+            sessionsByKey[memberSession.sessionKey] = memberSession
+            return memberSession
+        }
 
-        override fun findBySessionKey(sessionKey: String): MemberSession? = error("not used")
+        override fun findBySessionKey(sessionKey: String): MemberSession? = sessionsByKey[sessionKey]
 
-        override fun findBySessionKeyAndRevokedAtIsNull(sessionKey: String): MemberSession? = error("not used")
+        override fun findBySessionKeyAndRevokedAtIsNull(sessionKey: String): MemberSession? =
+            sessionsByKey[sessionKey]?.takeIf { it.revokedAt == null }
+
+        override fun findWithMemberBySessionKeyAndRevokedAtIsNull(sessionKey: String): MemberSession? =
+            findBySessionKeyAndRevokedAtIsNull(sessionKey)
 
         override fun findByMemberIdAndSessionKeyAndRevokedAtIsNull(
             memberId: Long,
             sessionKey: String,
-        ): MemberSession? = error("not used")
+        ): MemberSession? =
+            sessionsByKey[sessionKey]
+                ?.takeIf { it.member.id == memberId && it.revokedAt == null }
 
-        override fun findActiveSnapshotBySessionKeyAndRevokedAtIsNull(sessionKey: String): MemberSessionAuthSnapshot? = error("not used")
+        override fun findActiveSnapshotBySessionKeyAndRevokedAtIsNull(sessionKey: String): MemberSessionAuthSnapshot? =
+            findBySessionKeyAndRevokedAtIsNull(sessionKey)?.toSnapshot()
 
         override fun findActiveSnapshotByMemberIdAndSessionKeyAndRevokedAtIsNull(
             memberId: Long,
             sessionKey: String,
-        ): MemberSessionAuthSnapshot? = error("not used")
+        ): MemberSessionAuthSnapshot? = findByMemberIdAndSessionKeyAndRevokedAtIsNull(memberId, sessionKey)?.toSnapshot()
 
         override fun touchAuthenticatedIfDue(
             sessionId: Long,
@@ -93,5 +172,16 @@ class MemberSessionServiceTest {
             lastTouchedSessionId = sessionId
             return false
         }
+
+        private fun MemberSession.toSnapshot(): MemberSessionAuthSnapshot =
+            MemberSessionAuthSnapshot(
+                id = id,
+                memberId = member.id,
+                sessionKey = sessionKey,
+                rememberLoginEnabled = rememberLoginEnabled,
+                ipSecurityEnabled = ipSecurityEnabled,
+                ipSecurityFingerprint = ipSecurityFingerprint,
+                lastAuthenticatedAt = lastAuthenticatedAt,
+            )
     }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostControllerTest.kt
@@ -136,7 +136,7 @@ class ApiV1PostControllerTest : BaseControllerIntegrationTest() {
                     content = """{"title": "제목", "content": "내용"}"""
                 }.andExpect {
                     status { isUnauthorized() }
-                    jsonPath("$.resultCode") { value("401-3") }
+                    jsonPath("$.resultCode") { value("401-8") }
                 }
         }
 

--- a/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
@@ -49,11 +49,12 @@ class CustomAuthenticationFilterTest {
 
         given(publicApiRequestMatcher.matches(request)).willReturn(false)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("")
-        given(rq.getCookieValue("apiKey", "")).willReturn("broken-api-key")
-        given(rq.getCookieValue("accessToken", "")).willReturn("")
+        given(rq.getCookieValue("apiKey", "")).willReturn("")
+        given(rq.getCookieValue("accessToken", "")).willReturn("broken-access-token")
         given(rq.getCookieValue("sessionKey", "")).willReturn("")
+        given(rq.getCookieValue("refreshToken", "")).willReturn("")
         given(clientIpResolver.resolve(request)).willReturn("203.0.113.10")
-        given(actorApplicationService.findByApiKey("broken-api-key")).willThrow(RuntimeException("db down"))
+        given(actorApplicationService.payload("broken-access-token")).willThrow(RuntimeException("jwt down"))
 
         val filter =
             CustomAuthenticationFilter(
@@ -96,11 +97,12 @@ class CustomAuthenticationFilterTest {
 
         given(publicApiRequestMatcher.matches(request)).willReturn(true)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("")
-        given(rq.getCookieValue("apiKey", "")).willReturn("broken-api-key")
-        given(rq.getCookieValue("accessToken", "")).willReturn("")
+        given(rq.getCookieValue("apiKey", "")).willReturn("")
+        given(rq.getCookieValue("accessToken", "")).willReturn("broken-access-token")
         given(rq.getCookieValue("sessionKey", "")).willReturn("")
+        given(rq.getCookieValue("refreshToken", "")).willReturn("")
         given(clientIpResolver.resolve(request)).willReturn("203.0.113.11")
-        given(actorApplicationService.findByApiKey("broken-api-key")).willThrow(RuntimeException("db down"))
+        given(actorApplicationService.payload("broken-access-token")).willThrow(RuntimeException("jwt down"))
 
         val filter =
             CustomAuthenticationFilter(


### PR DESCRIPTION
## 관련 이슈

close #282

## 작업 배경

- 세션별 refresh token hash/만료/회전/재사용 탐지 모델을 `member_session`에 추가했습니다.
- 로그인/OAuth는 HttpOnly refreshToken 쿠키를 발급하고, accessToken 재발급은 `refreshToken + sessionKey` 검증/회전으로만 수행합니다.

## 작업 내용

- `member_session`에 refresh token hash, expiry, rotated/reused timestamp 컬럼과 test/prod Flyway migration을 추가했습니다.
- auth cookie 발급/만료 대상에 `refreshToken`을 포함하고 logout 시 함께 폐기합니다.
- 인증 필터의 invalid/missing accessToken 재발급 경로를 account `apiKey` 기반에서 세션 refresh token rotation 기반으로 변경했습니다.
- refresh token 원문 비저장, 회전, 재사용 시 세션 revoke를 검증하는 controller/service/filter 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests 'com.back.boundedContexts.member.adapter.web.ApiV1AuthControllerTest.로그인 요청이 성공하면 회원 정보와 인증 쿠키를 반환한다'`
  - `./gradlew test --tests 'com.back.boundedContexts.member.adapter.web.ApiV1AuthControllerTest' --tests 'com.back.boundedContexts.member.subContexts.session.application.service.MemberSessionServiceTest' --tests 'com.back.global.security.config.CustomAuthenticationFilterTest'`
  - `./gradlew test --tests 'com.back.boundedContexts.post.adapter.web.ApiV1PostControllerTest.실패 - 인증 헤더 없이 post api 접근시 401'`
  - `./gradlew ktlintCheck`
  - `./gradlew test`
  - `./gradlew ciFastCheck --rerun-tasks`
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 기존 stale/invalid accessToken 재발급 경로가 `apiKey + sessionKey` 대신 `refreshToken + sessionKey`를 요구하므로, 오래된 쿠키 조합은 재로그인이 필요합니다.
- 롤백 방법: PR revert. 추가된 DB 컬럼은 남아도 기존 코드 경로에서는 참조되지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
