### PR TITLE
[Fix] 로그인 자동화 세션 누적 차단

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepository.kt
@@ -90,4 +90,28 @@ interface MemberSessionRepository : JpaRepository<MemberSession, Long> {
         @Param("threshold") threshold: Instant,
         @Param("now") now: Instant,
     ): Int
+
+    @Modifying(flushAutomatically = true, clearAutomatically = false)
+    @Query(
+        value = """
+        update member_session
+        set revoked_at = :now
+        where member_id = :memberId
+          and revoked_at is null
+          and id not in (
+              select id
+              from member_session
+              where member_id = :memberId
+                and revoked_at is null
+              order by last_authenticated_at desc nulls last, id desc
+              limit :keepLimit
+          )
+        """,
+        nativeQuery = true,
+    )
+    fun revokeActiveSessionsBeyondLimit(
+        @Param("memberId") memberId: Long,
+        @Param("keepLimit") keepLimit: Int,
+        @Param("now") now: Instant,
+    ): Int
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepositoryAdapter.kt
@@ -39,4 +39,10 @@ class MemberSessionRepositoryAdapter(
         threshold: Instant,
         now: Instant,
     ): Boolean = memberSessionRepository.touchAuthenticatedIfDue(sessionId, threshold, now) > 0
+
+    override fun revokeActiveSessionsBeyondLimit(
+        memberId: Long,
+        keepLimit: Int,
+        now: Instant,
+    ): Int = memberSessionRepository.revokeActiveSessionsBeyondLimit(memberId, keepLimit.coerceAtLeast(1), now)
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/port/output/MemberSessionStorePort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/port/output/MemberSessionStorePort.kt
@@ -30,4 +30,10 @@ interface MemberSessionStorePort {
         threshold: Instant,
         now: Instant,
     ): Boolean
+
+    fun revokeActiveSessionsBeyondLimit(
+        memberId: Long,
+        keepLimit: Int,
+        now: Instant,
+    ): Int
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionService.kt
@@ -26,6 +26,8 @@ class MemberSessionService(
     private val touchMinIntervalSeconds: Long,
     @param:Value("\${custom.auth.refreshToken.expirationSeconds:2592000}")
     private val refreshTokenExpirationSeconds: Long = 2_592_000,
+    @param:Value("\${custom.auth.session.maxActivePerMember:32}")
+    private val maxActivePerMember: Int = 32,
 ) : MemberSessionUseCase {
     @Transactional
     override fun createSession(
@@ -68,8 +70,18 @@ class MemberSessionService(
             )
         session.touchAuthenticated(now)
         session.bindRefreshToken(refreshToken, refreshTokenExpiresAt(now), now)
+        val savedSession = memberSessionStorePort.save(session)
+        val revokedCount =
+            memberSessionStorePort.revokeActiveSessionsBeyondLimit(
+                memberId = savedSession.member.id,
+                keepLimit = maxActivePerMember.coerceAtLeast(1),
+                now = now,
+            )
+        if (revokedCount > 0) {
+            evictAllActiveSnapshots()
+        }
         return MemberSessionWithRefreshToken(
-            session = memberSessionStorePort.save(session),
+            session = savedSession,
             refreshToken = refreshToken,
         )
     }
@@ -172,6 +184,10 @@ class MemberSessionService(
             cache.evict("session:$sessionKey")
             cache.evict("member:$memberId:session:$sessionKey")
         }
+    }
+
+    private fun evictAllActiveSnapshots() {
+        cacheManager.getCache(MemberSessionCacheNames.ACTIVE)?.clear()
     }
 
     private fun isTouchDue(

--- a/back/src/main/kotlin/com/back/global/security/adapter/persistence/AuthSecurityEventPersistenceAdapter.kt
+++ b/back/src/main/kotlin/com/back/global/security/adapter/persistence/AuthSecurityEventPersistenceAdapter.kt
@@ -5,6 +5,7 @@ import com.back.global.security.model.AuthSecurityEvent
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Component
+import java.time.Instant
 
 @Component
 class AuthSecurityEventPersistenceAdapter(
@@ -24,5 +25,24 @@ class AuthSecurityEventPersistenceAdapter(
             )
 
         return authSecurityEventRepository.findAll(pageable).content
+    }
+
+    override fun findExpired(
+        cutoff: Instant,
+        limit: Int,
+    ): List<AuthSecurityEvent> {
+        val normalizedLimit = limit.coerceIn(1, 1_000)
+        val pageable =
+            PageRequest.of(
+                0,
+                normalizedLimit,
+                Sort.by(Sort.Order.asc("createdAt"), Sort.Order.asc("id")),
+            )
+
+        return authSecurityEventRepository.findByCreatedAtBefore(cutoff, pageable)
+    }
+
+    override fun deleteAll(events: List<AuthSecurityEvent>) {
+        authSecurityEventRepository.deleteAllInBatch(events)
     }
 }

--- a/back/src/main/kotlin/com/back/global/security/adapter/persistence/AuthSecurityEventRepository.kt
+++ b/back/src/main/kotlin/com/back/global/security/adapter/persistence/AuthSecurityEventRepository.kt
@@ -1,6 +1,13 @@
 package com.back.global.security.adapter.persistence
 
 import com.back.global.security.model.AuthSecurityEvent
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import java.time.Instant
 
-interface AuthSecurityEventRepository : JpaRepository<AuthSecurityEvent, Long>
+interface AuthSecurityEventRepository : JpaRepository<AuthSecurityEvent, Long> {
+    fun findByCreatedAtBefore(
+        cutoff: Instant,
+        pageable: Pageable,
+    ): List<AuthSecurityEvent>
+}

--- a/back/src/main/kotlin/com/back/global/security/application/AuthSecurityEventService.kt
+++ b/back/src/main/kotlin/com/back/global/security/application/AuthSecurityEventService.kt
@@ -4,10 +4,12 @@ import com.back.boundedContexts.member.domain.shared.Member
 import com.back.global.security.application.port.output.AuthSecurityEventStore
 import com.back.global.security.domain.AuthSecurityEventType
 import com.back.global.security.model.AuthSecurityEvent
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 data class AuthSecurityEventDto(
     val id: Long,
@@ -28,6 +30,8 @@ data class AuthSecurityEventDto(
 @Service
 class AuthSecurityEventService(
     private val authSecurityEventStore: AuthSecurityEventStore,
+    @param:Value("\${custom.auth.securityEvent.retentionDays:30}")
+    private val retentionDays: Int = 30,
 ) {
     /**
      * 로그인 성공 시 적용된 정책값을 운영 관측용 이벤트로 남깁니다.
@@ -83,6 +87,19 @@ class AuthSecurityEventService(
 
     @Transactional(readOnly = true)
     fun getRecent(limit: Int): List<AuthSecurityEventDto> = authSecurityEventStore.findRecent(limit).map { it.toDto() }
+
+    @Transactional
+    fun purgeExpired(
+        batchSize: Int,
+        now: Instant = Instant.now(),
+    ): Int {
+        val cutoff = now.minus(retentionDays.coerceAtLeast(1).toLong(), ChronoUnit.DAYS)
+        val expiredEvents = authSecurityEventStore.findExpired(cutoff, batchSize.coerceIn(1, 1_000))
+        if (expiredEvents.isEmpty()) return 0
+
+        authSecurityEventStore.deleteAll(expiredEvents)
+        return expiredEvents.size
+    }
 
     private fun AuthSecurityEvent.toDto(): AuthSecurityEventDto =
         AuthSecurityEventDto(

--- a/back/src/main/kotlin/com/back/global/security/application/port/output/AuthSecurityEventStore.kt
+++ b/back/src/main/kotlin/com/back/global/security/application/port/output/AuthSecurityEventStore.kt
@@ -1,6 +1,7 @@
 package com.back.global.security.application.port.output
 
 import com.back.global.security.model.AuthSecurityEvent
+import java.time.Instant
 
 /**
  * 인증 보안 이벤트 저장소 포트.
@@ -10,4 +11,11 @@ interface AuthSecurityEventStore {
     fun save(event: AuthSecurityEvent)
 
     fun findRecent(limit: Int): List<AuthSecurityEvent>
+
+    fun findExpired(
+        cutoff: Instant,
+        limit: Int,
+    ): List<AuthSecurityEvent>
+
+    fun deleteAll(events: List<AuthSecurityEvent>)
 }

--- a/back/src/main/kotlin/com/back/global/security/job/AuthSecurityEventCleanupScheduledJob.kt
+++ b/back/src/main/kotlin/com/back/global/security/job/AuthSecurityEventCleanupScheduledJob.kt
@@ -1,0 +1,33 @@
+package com.back.global.security.job
+
+import com.back.global.security.application.AuthSecurityEventService
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(
+    prefix = "custom.runtime",
+    name = ["worker-enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+class AuthSecurityEventCleanupScheduledJob(
+    private val authSecurityEventService: AuthSecurityEventService,
+    @param:Value("\${custom.auth.securityEvent.cleanup.batchSize:500}")
+    private val batchSize: Int,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(fixedDelayString = "\${custom.auth.securityEvent.cleanup.fixedDelayMs:3600000}")
+    @SchedulerLock(name = "authSecurityEventCleanup", lockAtLeastFor = "PT1M")
+    fun cleanup() {
+        val purgedCount = authSecurityEventService.purgeExpired(batchSize)
+        if (purgedCount > 0) {
+            log.info("Purged {} expired auth security events", purgedCount)
+        }
+    }
+}

--- a/back/src/main/resources/application.yaml
+++ b/back/src/main/resources/application.yaml
@@ -211,6 +211,12 @@ custom:
     session:
       freshLookupGraceSeconds: ${CUSTOM__AUTH__SESSION__FRESH_LOOKUP_GRACE_SECONDS:15}
       touchMinIntervalSeconds: ${CUSTOM__AUTH__SESSION__TOUCH_MIN_INTERVAL_SECONDS:60}
+      maxActivePerMember: ${CUSTOM__AUTH__SESSION__MAX_ACTIVE_PER_MEMBER:32}
+    securityEvent:
+      retentionDays: ${CUSTOM__AUTH__SECURITY_EVENT__RETENTION_DAYS:30}
+      cleanup:
+        batchSize: ${CUSTOM__AUTH__SECURITY_EVENT__CLEANUP__BATCH_SIZE:500}
+        fixedDelayMs: ${CUSTOM__AUTH__SECURITY_EVENT__CLEANUP__FIXED_DELAY_MS:3600000}
     login:
       maxAttempts: ${CUSTOM__AUTH__LOGIN__MAX_ATTEMPTS:5}
       windowSeconds: ${CUSTOM__AUTH__LOGIN__WINDOW_SECONDS:300}

--- a/back/src/main/resources/db/migration/R__operational_indexes.sql
+++ b/back/src/main/resources/db/migration/R__operational_indexes.sql
@@ -79,6 +79,12 @@ BEGIN
             ON member_notification (receiver_id, read_at, created_at DESC);
     END IF;
 
+    IF to_regclass('public.member_session') IS NOT NULL THEN
+        CREATE INDEX IF NOT EXISTS member_session_idx_member_active_recent
+            ON member_session (member_id, last_authenticated_at DESC, id DESC)
+            WHERE revoked_at IS NULL;
+    END IF;
+
     IF to_regclass('public.task') IS NOT NULL THEN
         CREATE INDEX IF NOT EXISTS task_idx_status_next_retry_at
             ON task (status, next_retry_at ASC);

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionServiceTest.kt
@@ -80,6 +80,54 @@ class MemberSessionServiceTest {
     }
 
     @Test
+    fun `세션 생성 후 계정별 활성 세션 상한을 넘는 이전 세션을 폐기한다`() {
+        val store = RecordingMemberSessionStorePort()
+        val service =
+            MemberSessionService(
+                memberSessionStorePort = store,
+                cacheManager = ConcurrentMapCacheManager(),
+                touchMinIntervalSeconds = 60,
+                refreshTokenExpirationSeconds = 3600,
+                maxActivePerMember = 2,
+            )
+        val member = Member(56L, "session-cap-user", null, "세션상한", "session-cap@example.com", MemberPolicy.genApiKey())
+
+        val first =
+            service.createSessionWithRefreshToken(
+                member = member,
+                rememberLoginEnabled = true,
+                ipSecurityEnabled = false,
+                ipSecurityFingerprint = null,
+                createdIp = "203.0.113.30",
+                userAgent = "test-agent",
+            )
+        val second =
+            service.createSessionWithRefreshToken(
+                member = member,
+                rememberLoginEnabled = true,
+                ipSecurityEnabled = false,
+                ipSecurityFingerprint = null,
+                createdIp = "203.0.113.31",
+                userAgent = "test-agent",
+            )
+        val third =
+            service.createSessionWithRefreshToken(
+                member = member,
+                rememberLoginEnabled = true,
+                ipSecurityEnabled = false,
+                ipSecurityFingerprint = null,
+                createdIp = "203.0.113.32",
+                userAgent = "test-agent",
+            )
+
+        assertThat(first.session.revokedAt).isNotNull
+        assertThat(second.session.revokedAt).isNull()
+        assertThat(third.session.revokedAt).isNull()
+        assertThat(store.activeSessionKeys(member.id)).containsExactly(second.session.sessionKey, third.session.sessionKey)
+        assertThat(store.lastRevokedBeyondLimit).isEqualTo(2)
+    }
+
+    @Test
     fun `snapshot lastAuthenticatedAt 이 최소 간격 이내면 DB touch update를 생략한다`() {
         val store = RecordingMemberSessionStorePort()
         val service =
@@ -133,6 +181,7 @@ class MemberSessionServiceTest {
     private class RecordingMemberSessionStorePort : MemberSessionStorePort {
         var touchCallCount: Int = 0
         var lastTouchedSessionId: Long? = null
+        var lastRevokedBeyondLimit: Int? = null
         private val sessionsByKey = linkedMapOf<String, MemberSession>()
 
         override fun save(memberSession: MemberSession): MemberSession {
@@ -172,6 +221,25 @@ class MemberSessionServiceTest {
             lastTouchedSessionId = sessionId
             return false
         }
+
+        override fun revokeActiveSessionsBeyondLimit(
+            memberId: Long,
+            keepLimit: Int,
+            now: Instant,
+        ): Int {
+            lastRevokedBeyondLimit = keepLimit
+            val activeSessions =
+                sessionsByKey.values
+                    .filter { it.member.id == memberId && it.revokedAt == null }
+            val sessionsToRevoke = activeSessions.dropLast(keepLimit.coerceAtLeast(1))
+            sessionsToRevoke.forEach { it.revoke(now) }
+            return sessionsToRevoke.size
+        }
+
+        fun activeSessionKeys(memberId: Long): List<String> =
+            sessionsByKey.values
+                .filter { it.member.id == memberId && it.revokedAt == null }
+                .map { it.sessionKey }
 
         private fun MemberSession.toSnapshot(): MemberSessionAuthSnapshot =
             MemberSessionAuthSnapshot(

--- a/back/src/test/kotlin/com/back/global/security/application/AuthSecurityEventServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/application/AuthSecurityEventServiceTest.kt
@@ -1,0 +1,77 @@
+package com.back.global.security.application
+
+import com.back.global.security.application.port.output.AuthSecurityEventStore
+import com.back.global.security.domain.AuthSecurityEventType
+import com.back.global.security.model.AuthSecurityEvent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@DisplayName("AuthSecurityEventService 테스트")
+class AuthSecurityEventServiceTest {
+    @Test
+    fun `보존 기간을 지난 보안 이벤트를 batch size 안에서 삭제한다`() {
+        val now = Instant.parse("2026-05-21T00:00:00Z")
+        val store = RecordingAuthSecurityEventStore()
+        val expired = authSecurityEventAt(now.minus(31, ChronoUnit.DAYS))
+        val stillRetained = authSecurityEventAt(now.minus(29, ChronoUnit.DAYS))
+        val olderExpired = authSecurityEventAt(now.minus(40, ChronoUnit.DAYS))
+        store.events += listOf(expired, stillRetained, olderExpired)
+        val service =
+            AuthSecurityEventService(
+                authSecurityEventStore = store,
+                retentionDays = 30,
+            )
+
+        val purgedCount = service.purgeExpired(batchSize = 1, now = now)
+
+        assertThat(purgedCount).isEqualTo(1)
+        assertThat(store.events).containsExactly(expired, stillRetained)
+        assertThat(store.deletedEvents).containsExactly(olderExpired)
+    }
+
+    private class RecordingAuthSecurityEventStore : AuthSecurityEventStore {
+        val events = mutableListOf<AuthSecurityEvent>()
+        val deletedEvents = mutableListOf<AuthSecurityEvent>()
+
+        override fun save(event: AuthSecurityEvent) {
+            events += event
+        }
+
+        override fun findRecent(limit: Int): List<AuthSecurityEvent> =
+            events
+                .sortedWith(compareByDescending<AuthSecurityEvent> { it.createdAt }.thenByDescending { it.id })
+                .take(limit)
+
+        override fun findExpired(
+            cutoff: Instant,
+            limit: Int,
+        ): List<AuthSecurityEvent> =
+            events
+                .filter { it.createdAt.isBefore(cutoff) }
+                .sortedWith(compareBy<AuthSecurityEvent> { it.createdAt }.thenBy { it.id })
+                .take(limit)
+
+        override fun deleteAll(events: List<AuthSecurityEvent>) {
+            deletedEvents += events
+            this.events.removeAll(events.toSet())
+        }
+    }
+
+    private fun authSecurityEventAt(createdAt: Instant): AuthSecurityEvent =
+        AuthSecurityEvent(
+            eventType = AuthSecurityEventType.LOGIN_POLICY_APPLIED,
+            memberId = 54L,
+            loginIdentifier = "admin@example.com",
+            rememberLoginEnabled = true,
+            ipSecurityEnabled = false,
+            clientIpFingerprint = null,
+            requestPath = "/member/api/v1/auth/login",
+            reason = null,
+        ).apply {
+            this.createdAt = createdAt
+            this.modifiedAt = createdAt
+        }
+}

--- a/back/src/test/kotlin/com/back/global/security/job/AuthSecurityEventCleanupScheduledJobTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/job/AuthSecurityEventCleanupScheduledJobTest.kt
@@ -1,0 +1,79 @@
+package com.back.global.security.job
+
+import com.back.global.security.application.AuthSecurityEventService
+import com.back.global.security.application.port.output.AuthSecurityEventStore
+import com.back.global.security.domain.AuthSecurityEventType
+import com.back.global.security.model.AuthSecurityEvent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@DisplayName("AuthSecurityEventCleanupScheduledJob 테스트")
+class AuthSecurityEventCleanupScheduledJobTest {
+    @Test
+    fun `cleanup은 만료된 보안 이벤트를 정리한다`() {
+        val store = RecordingAuthSecurityEventStore()
+        val expiredEvent = authSecurityEventAt(Instant.now().minus(31, ChronoUnit.DAYS))
+        store.events += expiredEvent
+        val service =
+            AuthSecurityEventService(
+                authSecurityEventStore = store,
+                retentionDays = 30,
+            )
+        val job =
+            AuthSecurityEventCleanupScheduledJob(
+                authSecurityEventService = service,
+                batchSize = 10,
+            )
+
+        job.cleanup()
+
+        assertThat(store.events).isEmpty()
+        assertThat(store.deletedEvents).containsExactly(expiredEvent)
+    }
+
+    private class RecordingAuthSecurityEventStore : AuthSecurityEventStore {
+        val events = mutableListOf<AuthSecurityEvent>()
+        val deletedEvents = mutableListOf<AuthSecurityEvent>()
+
+        override fun save(event: AuthSecurityEvent) {
+            events += event
+        }
+
+        override fun findRecent(limit: Int): List<AuthSecurityEvent> =
+            events
+                .sortedWith(compareByDescending<AuthSecurityEvent> { it.createdAt }.thenByDescending { it.id })
+                .take(limit)
+
+        override fun findExpired(
+            cutoff: Instant,
+            limit: Int,
+        ): List<AuthSecurityEvent> =
+            events
+                .filter { it.createdAt.isBefore(cutoff) }
+                .sortedWith(compareBy<AuthSecurityEvent> { it.createdAt }.thenBy { it.id })
+                .take(limit)
+
+        override fun deleteAll(events: List<AuthSecurityEvent>) {
+            deletedEvents += events
+            this.events.removeAll(events.toSet())
+        }
+    }
+
+    private fun authSecurityEventAt(createdAt: Instant): AuthSecurityEvent =
+        AuthSecurityEvent(
+            eventType = AuthSecurityEventType.LOGIN_POLICY_APPLIED,
+            memberId = 54L,
+            loginIdentifier = "admin@example.com",
+            rememberLoginEnabled = true,
+            ipSecurityEnabled = false,
+            clientIpFingerprint = null,
+            requestPath = "/member/api/v1/auth/login",
+            reason = null,
+        ).apply {
+            this.createdAt = createdAt
+            this.modifiedAt = createdAt
+        }
+}

--- a/docs/superpowers/plans/2026-05-21-login-session-retention.md
+++ b/docs/superpowers/plans/2026-05-21-login-session-retention.md
@@ -1,0 +1,52 @@
+# Login Session Retention Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development while implementing. This plan is the source of truth for issue, scope, verification, and commit mapping.
+
+**Goal:** Close #285 by bounding active member sessions and adding retention cleanup for authentication security events.
+
+**Architecture:** Enforce an account-level active session cap immediately after creating a refresh-token-backed session, using a bulk repository update that keeps the most recent active sessions. Add a worker-only scheduled cleanup path for old `auth_security_event` rows so repeated login events do not grow without a retention boundary.
+
+**Tech Stack:** Kotlin, Spring Boot, Spring Data JPA, Flyway SQL, ShedLock, JUnit 5, AssertJ.
+
+---
+
+## 문제
+- 운영 DB에서 반복 `/member/api/v1/auth/login` 호출이 하루 약 3,000회 수준으로 쌓이며 단일 회원의 활성 `member_session`이 146k+까지 누적된다.
+- `auth_security_event`도 `LOGIN_POLICY_APPLIED` 이벤트가 153k+ 누적되어 로그인 보안 관측성이 자동화 트래픽에 묻힌다.
+
+## issue
+- `#285`
+
+## pr
+- 생성 전
+
+## repro
+- `ssh aquila-home` 후 `blog_home-db_1-1/blog_prod`에서 `member_session where revoked_at is null`과 `auth_security_event where request_path='/member/api/v1/auth/login'`를 집계하면 반복 로그인 누적이 재현된다.
+
+## done_when
+- 새 로그인 세션 생성 후 계정별 활성 세션이 `custom.auth.session.maxActivePerMember` 이내로 유지된다.
+- 오래된 `auth_security_event`는 `custom.auth.securityEvent.retentionDays`와 batch size 기준으로 worker cleanup에서 제거된다.
+- 단위 테스트, ktlint, 백엔드 관련 테스트, 전체 백엔드 테스트가 통과한다.
+
+## allow
+- `back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/**`
+- `back/src/main/kotlin/com/back/global/security/**`
+- `back/src/main/resources/application*.yaml`
+- `back/src/main/resources/db/migration/R__operational_indexes.sql`
+- `back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/**`
+- `back/src/test/kotlin/com/back/global/security/**`
+- `docs/superpowers/plans/2026-05-21-login-session-retention.md`
+
+## deny
+- frontend, deploy workflow, unrelated auth API contract, unrelated open issues #286/#287
+
+## verify
+- `./gradlew -p back test --tests com.back.boundedContexts.member.subContexts.session.application.service.MemberSessionServiceTest`
+- `./gradlew -p back test --tests com.back.global.security.application.AuthSecurityEventServiceTest`
+- `./gradlew -p back ktlintCheck`
+- `./gradlew -p back test`
+- PR CI check
+
+## commit_plan
+1. `fix(auth): 로그인 세션 보존 정책 추가`
+   - 기능 단위 1개: 활성 세션 상한, 보안 이벤트 retention, 운영 인덱스, 관련 테스트를 함께 반영한다.


### PR DESCRIPTION
## 관련 이슈

close #285

## 작업 배경

- 반복 로그인에도 계정별 활성 `member_session`이 무제한 누적되지 않도록 로그인 세션 생성 직후 최신 세션만 남기는 서버 측 상한을 추가했습니다.
- `auth_security_event`는 retention day와 batch size 기준으로 worker cleanup이 오래된 이벤트를 제거하도록 보존 경계를 추가했습니다.

## 작업 내용

- `custom.auth.session.maxActivePerMember` 설정을 추가하고 기본값 32개를 초과한 활성 세션을 bulk revoke합니다.
- `custom.auth.securityEvent.retentionDays` 및 cleanup schedule/batch 설정을 추가해 오래된 인증 보안 이벤트를 정리합니다.
- 세션 상한 쿼리를 위한 `member_session_idx_member_active_recent` 운영 인덱스를 추가했습니다.
- 세션 상한과 보안 이벤트 retention 단위 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests com.back.boundedContexts.member.subContexts.session.application.service.MemberSessionServiceTest`
  - `back/gradlew -p back test --tests com.back.global.security.application.AuthSecurityEventServiceTest`
  - `back/gradlew -p back test --tests com.back.boundedContexts.member.subContexts.session.application.service.MemberSessionServiceTest --tests com.back.global.security.application.AuthSecurityEventServiceTest`
  - `back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back test`
  - `git diff --check`
  - pre-commit hook: `OpenApiContractExportTest`, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 반복 로그인 중 이전 세션이 상한 초과로 revoke되어, 같은 계정의 오래된 기기 세션이 재인증을 요구할 수 있습니다. 기본 상한은 32개이며 환경변수 `CUSTOM__AUTH__SESSION__MAX_ACTIVE_PER_MEMBER`로 조정 가능합니다.
- 롤백 방법: 이 PR을 revert하면 세션 상한과 보안 이벤트 cleanup job, 운영 인덱스 추가가 이전 상태로 돌아갑니다. 이미 revoke된 과거 세션은 자동 복구하지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
