### PR TITLE
[Perf] task 진단 쿼리 인덱스와 호출 주기 최적화

### DIFF
--- a/back/src/main/kotlin/com/back/global/task/application/TaskQueueDiagnosticsService.kt
+++ b/back/src/main/kotlin/com/back/global/task/application/TaskQueueDiagnosticsService.kt
@@ -83,7 +83,7 @@ class TaskQueueDiagnosticsService(
     private val taskHandlerRegistry: TaskHandlerRegistry,
     @Value("\${custom.task.processor.processingTimeoutSeconds:900}")
     private val processingTimeoutSeconds: Long,
-    @Value("\${custom.task.diagnostics.cacheSeconds:3}")
+    @Value("\${custom.task.diagnostics.cacheSeconds:30}")
     private val diagnosticsCacheSeconds: Long,
 ) {
     private data class DiagnosticsSnapshot(

--- a/back/src/main/kotlin/com/back/global/task/model/Task.kt
+++ b/back/src/main/kotlin/com/back/global/task/model/Task.kt
@@ -32,6 +32,24 @@ enum class TaskStatus {
     ON task (status, next_retry_at ASC)
     """,
 )
+@AfterDDL(
+    """
+    CREATE INDEX IF NOT EXISTS task_idx_status_modified_at
+    ON task (status, modified_at ASC)
+    """,
+)
+@AfterDDL(
+    """
+    CREATE INDEX IF NOT EXISTS task_idx_task_type_status_next_retry_at
+    ON task (task_type, status, next_retry_at ASC)
+    """,
+)
+@AfterDDL(
+    """
+    CREATE INDEX IF NOT EXISTS task_idx_task_type_status_modified_at
+    ON task (task_type, status, modified_at ASC)
+    """,
+)
 class Task(
     @field:Id
     @field:SequenceGenerator(name = "task_seq_gen", sequenceName = "task_seq", allocationSize = 50)

--- a/back/src/main/resources/application.yaml
+++ b/back/src/main/resources/application.yaml
@@ -250,7 +250,7 @@ custom:
       perTypeAutoTuneRefreshMs: ${CUSTOM__TASK__PROCESSOR__PER_TYPE_AUTO_TUNE_REFRESH_MS:15000}
       inlineWhenNotProd: ${CUSTOM__TASK__PROCESSOR__INLINE_WHEN_NOT_PROD:false}
     diagnostics:
-      cacheSeconds: ${CUSTOM__TASK__DIAGNOSTICS__CACHE_SECONDS:3}
+      cacheSeconds: ${CUSTOM__TASK__DIAGNOSTICS__CACHE_SECONDS:30}
   runtime:
     workerEnabled: ${CUSTOM__RUNTIME__WORKER_ENABLED:true}
     apiMode: ${CUSTOM__RUNTIME__API_MODE:all}

--- a/back/src/main/resources/db/migration/R__operational_indexes.sql
+++ b/back/src/main/resources/db/migration/R__operational_indexes.sql
@@ -88,6 +88,12 @@ BEGIN
     IF to_regclass('public.task') IS NOT NULL THEN
         CREATE INDEX IF NOT EXISTS task_idx_status_next_retry_at
             ON task (status, next_retry_at ASC);
+        CREATE INDEX IF NOT EXISTS task_idx_status_modified_at
+            ON task (status, modified_at ASC);
+        CREATE INDEX IF NOT EXISTS task_idx_task_type_status_next_retry_at
+            ON task (task_type, status, next_retry_at ASC);
+        CREATE INDEX IF NOT EXISTS task_idx_task_type_status_modified_at
+            ON task (task_type, status, modified_at ASC);
     END IF;
 
     IF to_regclass('public.uploaded_file') IS NOT NULL THEN

--- a/back/src/test/kotlin/com/back/global/task/application/TaskQueueDiagnosticsServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/task/application/TaskQueueDiagnosticsServiceTest.kt
@@ -1,0 +1,133 @@
+package com.back.global.task.application
+
+import com.back.global.task.application.port.output.TaskQueueRepositoryPort
+import com.back.global.task.domain.Task
+import com.back.global.task.domain.TaskStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.domain.Pageable
+import java.time.Instant
+
+class TaskQueueDiagnosticsServiceTest {
+    @Test
+    fun `진단 캐시 기본 TTL은 DB count 부하를 줄이기 위해 30초다`() {
+        val diagnosticsCacheSecondsParameter =
+            TaskQueueDiagnosticsService::class
+                .constructors
+                .single()
+                .parameters
+                .single { it.name == "diagnosticsCacheSeconds" }
+
+        val configuredDefault =
+            diagnosticsCacheSecondsParameter.annotations
+                .filterIsInstance<Value>()
+                .single()
+                .value
+
+        assertThat(configuredDefault).isEqualTo("\${custom.task.diagnostics.cacheSeconds:30}")
+    }
+
+    @Test
+    fun `캐시 TTL 안의 연속 진단은 repository count를 재실행하지 않는다`() {
+        val repository = CountingTaskQueueRepository()
+        val service =
+            TaskQueueDiagnosticsService(
+                taskRepository = repository,
+                taskHandlerRegistry = TaskHandlerRegistry(),
+                processingTimeoutSeconds = 900,
+                diagnosticsCacheSeconds = 30,
+            )
+
+        service.diagnoseQueue()
+        service.diagnoseQueue()
+
+        assertThat(repository.statusCountCalls).isEqualTo(4)
+        assertThat(repository.readyPendingCountCalls).isEqualTo(1)
+        assertThat(repository.staleProcessingCountCalls).isEqualTo(1)
+    }
+
+    private class CountingTaskQueueRepository : TaskQueueRepositoryPort {
+        var statusCountCalls = 0
+            private set
+        var readyPendingCountCalls = 0
+            private set
+        var staleProcessingCountCalls = 0
+            private set
+
+        override fun save(task: Task): Task = error("not used")
+
+        override fun countByStatus(status: TaskStatus): Long {
+            statusCountCalls++
+            return 0
+        }
+
+        override fun countByStatusAndNextRetryAtLessThanEqual(
+            status: TaskStatus,
+            nextRetryAt: Instant,
+        ): Long {
+            readyPendingCountCalls++
+            return 0
+        }
+
+        override fun countByStatusAndModifiedAtBefore(
+            status: TaskStatus,
+            modifiedAt: Instant,
+        ): Long {
+            staleProcessingCountCalls++
+            return 0
+        }
+
+        override fun countByTaskTypeAndStatus(
+            taskType: String,
+            status: TaskStatus,
+        ): Long = error("not used")
+
+        override fun countByTaskTypeAndStatusAndNextRetryAtLessThanEqual(
+            taskType: String,
+            status: TaskStatus,
+            nextRetryAt: Instant,
+        ): Long = error("not used")
+
+        override fun countByTaskTypeAndStatusAndModifiedAtBefore(
+            taskType: String,
+            status: TaskStatus,
+            modifiedAt: Instant,
+        ): Long = error("not used")
+
+        override fun findByStatusAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
+            status: TaskStatus,
+            nextRetryAt: Instant,
+            pageable: Pageable,
+        ): List<Task> = emptyList()
+
+        override fun findByStatusOrderByModifiedAtAsc(
+            status: TaskStatus,
+            pageable: Pageable,
+        ): List<Task> = emptyList()
+
+        override fun findByStatusOrderByModifiedAtDesc(
+            status: TaskStatus,
+            pageable: Pageable,
+        ): List<Task> = emptyList()
+
+        override fun findByStatusAndModifiedAtBeforeOrderByModifiedAtAsc(
+            status: TaskStatus,
+            modifiedAt: Instant,
+            pageable: Pageable,
+        ): List<Task> = emptyList()
+
+        override fun findByTaskTypeAndStatusAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
+            taskType: String,
+            status: TaskStatus,
+            nextRetryAt: Instant,
+            pageable: Pageable,
+        ): List<Task> = error("not used")
+
+        override fun findByTaskTypeAndStatusOrderByModifiedAtDesc(
+            taskType: String,
+            status: TaskStatus,
+            pageable: Pageable,
+        ): List<Task> = error("not used")
+    }
+}

--- a/docs/superpowers/plans/2026-05-21-task-diagnostic-indexes.md
+++ b/docs/superpowers/plans/2026-05-21-task-diagnostic-indexes.md
@@ -1,0 +1,39 @@
+# task 진단 쿼리 인덱스와 호출 주기 최적화
+
+## 문제
+- live DB에서 task 진단/스케줄러 count 쿼리가 수백만 회 반복되고, `task_type/status/next_retry_at/modified_at` 조합과 `PROCESSING modified_at` 조회를 받치는 인덱스가 부족하다.
+
+## issue
+- `#286`
+
+## pr
+- `#293 https://github.com/AquilaXk/aquila-blog/pull/293`
+
+## repro
+- Supabase `pg_stat_statements`에서 `task_type + status` count 계열 쿼리와 `status + modified_at` 계열 쿼리가 hot query로 반복 집계된다.
+
+## done_when
+- task 진단/스케줄러 쿼리 패턴을 받치는 operational index와 AfterDDL 계약이 일치하고, 진단 캐시 기본값이 30초로 늘어나 CI가 통과한 뒤 PR이 merge된다.
+
+## allow
+- `back/src/main/kotlin/com/back/global/task/**`
+- `back/src/main/resources/application.yaml`
+- `back/src/main/resources/db/migration/R__operational_indexes.sql`
+- `back/src/test/kotlin/com/back/global/task/**`
+- `docs/superpowers/plans/2026-05-21-task-diagnostic-indexes.md`
+
+## deny
+- `front/**`
+- `back/src/main/kotlin/com/back/boundedContexts/**`
+- `back/src/main/resources/db/migration/V*.sql`
+- `infra/**`
+
+## verify
+- `back/gradlew -p back test --tests com.back.global.task.application.TaskQueueDiagnosticsServiceTest`
+- `back/gradlew -p back ktlintCheck`
+- `back/gradlew -p back ciFastCheck --rerun-tasks`
+- GitHub PR CI checks
+
+## commit_plan
+1. `perf(task): 진단 쿼리 인덱스 보강`
+   - task 진단 호출 주기와 task 조회 인덱스 계약을 한 기능 단위로 보강한다.


### PR DESCRIPTION
## 관련 이슈

close #286

## 작업 배경

- live DB에서 반복 집계된 task 진단 count hot query를 줄이기 위해 진단 캐시 기본 TTL을 30초로 늘렸습니다.
- `task_type/status/next_retry_at/modified_at` 쿼리 패턴을 받치는 operational index와 AfterDDL 계약을 함께 보강했습니다.

## 작업 내용

- task 진단 캐시 기본값을 `CUSTOM__TASK__DIAGNOSTICS__CACHE_SECONDS` 미설정 시 30초로 조정했습니다.
- `status + modified_at`, `task_type + status + next_retry_at`, `task_type + status + modified_at` composite index를 repeatable operational index와 entity AfterDDL에 반영했습니다.
- 진단 캐시 TTL 계약과 캐시 hit 시 repository count 재호출 방지 동작을 단위 테스트로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests com.back.global.task.application.TaskQueueDiagnosticsServiceTest` 실패 확인: TTL 기본값 3초
  - `back/gradlew -p back test --tests com.back.global.task.application.TaskQueueDiagnosticsServiceTest`
  - `back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back ciFastCheck --rerun-tasks`
  - commit hook: OpenAPI export, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 새 인덱스 생성 시 운영 DB에서 초기 생성 비용과 추가 write amplification이 발생할 수 있습니다.
- 롤백 방법: `R__operational_indexes.sql`와 `Task` AfterDDL에서 추가 인덱스를 제거하고 진단 캐시 기본값을 이전 값으로 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
