### PR TITLE
[Perf] post FK 기반 정리 쿼리 인덱스 보강

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/model/PostComment.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/model/PostComment.kt
@@ -2,6 +2,7 @@ package com.back.boundedContexts.post.model
 
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.post.domain.postCommentMixin.PostCommentHasPolicy
+import com.back.global.jpa.domain.AfterDDL
 import com.back.global.jpa.domain.BaseTime
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -22,6 +23,18 @@ import java.time.Instant
  */
 @Entity
 @DynamicUpdate
+@AfterDDL(
+    """
+    CREATE INDEX IF NOT EXISTS post_comment_idx_post_id
+    ON post_comment (post_id)
+    """,
+)
+@AfterDDL(
+    """
+    CREATE INDEX IF NOT EXISTS post_comment_idx_parent_comment_id
+    ON post_comment (parent_comment_id)
+    """,
+)
 @SQLRestriction("deleted_at IS NULL")
 class PostComment(
     @field:Id

--- a/back/src/main/kotlin/com/back/boundedContexts/post/model/PostLike.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/model/PostLike.kt
@@ -1,6 +1,7 @@
 package com.back.boundedContexts.post.model
 
 import com.back.boundedContexts.member.domain.shared.Member
+import com.back.global.jpa.domain.AfterDDL
 import com.back.global.jpa.domain.BaseTime
 import jakarta.persistence.*
 import jakarta.persistence.GenerationType.SEQUENCE
@@ -12,6 +13,12 @@ import org.hibernate.annotations.DynamicUpdate
  */
 @Entity
 @DynamicUpdate
+@AfterDDL(
+    """
+    CREATE INDEX IF NOT EXISTS post_like_idx_post_id
+    ON post_like (post_id)
+    """,
+)
 @Table(
     uniqueConstraints = [
         UniqueConstraint(columnNames = ["liker_id", "post_id"]),

--- a/back/src/main/kotlin/com/back/boundedContexts/post/model/PostWriteRequestIdempotency.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/model/PostWriteRequestIdempotency.kt
@@ -1,6 +1,7 @@
 package com.back.boundedContexts.post.model
 
 import com.back.boundedContexts.member.domain.shared.Member
+import com.back.global.jpa.domain.AfterDDL
 import com.back.global.jpa.domain.BaseTime
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -19,6 +20,19 @@ import jakarta.persistence.UniqueConstraint
  * 도메인 불변조건을 지키며 상태 변경을 메서드 단위로 통제합니다.
  */
 @Entity
+@AfterDDL(
+    """
+    CREATE INDEX IF NOT EXISTS post_write_request_idempotency_idx_post_id
+    ON post_write_request_idempotency (post_id)
+    WHERE post_id IS NOT NULL
+    """,
+)
+@AfterDDL(
+    """
+    CREATE INDEX IF NOT EXISTS post_write_request_idempotency_idx_created_at
+    ON post_write_request_idempotency (created_at ASC)
+    """,
+)
 @Table(
     name = "post_write_request_idempotency",
     uniqueConstraints = [

--- a/back/src/main/resources/db/migration/R__operational_indexes.sql
+++ b/back/src/main/resources/db/migration/R__operational_indexes.sql
@@ -105,6 +105,23 @@ BEGIN
         CREATE INDEX IF NOT EXISTS post_comment_idx_subtree_active
             ON post_comment (post_id, parent_comment_id, created_at ASC, id ASC)
             WHERE deleted_at IS NULL;
+        CREATE INDEX IF NOT EXISTS post_comment_idx_post_id
+            ON post_comment (post_id);
+        CREATE INDEX IF NOT EXISTS post_comment_idx_parent_comment_id
+            ON post_comment (parent_comment_id);
+    END IF;
+
+    IF to_regclass('public.post_like') IS NOT NULL THEN
+        CREATE INDEX IF NOT EXISTS post_like_idx_post_id
+            ON post_like (post_id);
+    END IF;
+
+    IF to_regclass('public.post_write_request_idempotency') IS NOT NULL THEN
+        CREATE INDEX IF NOT EXISTS post_write_request_idempotency_idx_post_id
+            ON post_write_request_idempotency (post_id)
+            WHERE post_id IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS post_write_request_idempotency_idx_created_at
+            ON post_write_request_idempotency (created_at ASC);
     END IF;
 
     IF to_regclass('public.post_attr') IS NOT NULL THEN

--- a/back/src/test/kotlin/com/back/boundedContexts/post/model/PostOperationalIndexContractTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/model/PostOperationalIndexContractTest.kt
@@ -1,0 +1,46 @@
+package com.back.boundedContexts.post.model
+
+import com.back.global.jpa.domain.AfterDDL
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.reflect.KClass
+
+class PostOperationalIndexContractTest {
+    private val migrationSql: String =
+        Files.readString(Path.of("src/main/resources/db/migration/R__operational_indexes.sql"))
+
+    @Test
+    fun `post hard-delete와 cleanup 인덱스는 AfterDDL과 repeatable migration에 함께 선언된다`() {
+        val expectedIndexes =
+            mapOf(
+                PostComment::class to
+                    listOf(
+                        "post_comment_idx_post_id",
+                        "post_comment_idx_parent_comment_id",
+                    ),
+                PostLike::class to
+                    listOf("post_like_idx_post_id"),
+                PostWriteRequestIdempotency::class to
+                    listOf(
+                        "post_write_request_idempotency_idx_post_id",
+                        "post_write_request_idempotency_idx_created_at",
+                    ),
+            )
+
+        expectedIndexes.forEach { (entityClass, indexNames) ->
+            val afterDdlSql = entityClass.afterDdlSql()
+
+            indexNames.forEach { indexName ->
+                assertThat(afterDdlSql).contains(indexName)
+                assertThat(migrationSql).contains(indexName)
+            }
+        }
+    }
+
+    private fun KClass<*>.afterDdlSql(): String =
+        java
+            .getAnnotationsByType(AfterDDL::class.java)
+            .joinToString("\n") { it.sql }
+}

--- a/docs/superpowers/plans/2026-05-21-post-fk-indexes.md
+++ b/docs/superpowers/plans/2026-05-21-post-fk-indexes.md
@@ -1,0 +1,38 @@
+# post FK 기반 정리 쿼리 인덱스 보강
+
+## 문제
+- prod DB에서 hard-delete/post cleanup 경로가 사용하는 `post_comment.post_id`, `post_comment.parent_comment_id`, `post_like.post_id`, `post_write_request_idempotency.post_id/created_at` 조회를 받치는 선두 인덱스가 부족하다.
+
+## issue
+- `#287`
+
+## pr
+- `#294 https://github.com/AquilaXk/aquila-blog/pull/294`
+
+## repro
+- Supabase prod schema에서 `post_comment.post_id`, `post_comment.parent_comment_id`, `post_like.post_id`가 FK 선두 인덱스 없이 남아 있고, `post_write_request_idempotency.created_at < ? order by created_at` cleanup query가 pg_stat_statements에 반복 집계된다.
+
+## done_when
+- post hard-delete/cleanup 관련 인덱스가 repeatable migration과 model AfterDDL에 함께 반영되고, 계약 테스트와 CI가 통과한 뒤 PR이 merge된다.
+
+## allow
+- `back/src/main/kotlin/com/back/boundedContexts/post/model/**`
+- `back/src/main/resources/db/migration/R__operational_indexes.sql`
+- `back/src/test/kotlin/com/back/boundedContexts/post/**`
+- `docs/superpowers/plans/2026-05-21-post-fk-indexes.md`
+
+## deny
+- `front/**`
+- `back/src/main/kotlin/com/back/global/**`
+- `back/src/main/resources/db/migration/V*.sql`
+- `infra/**`
+
+## verify
+- `back/gradlew -p back test --tests com.back.boundedContexts.post.model.PostOperationalIndexContractTest`
+- `back/gradlew -p back ktlintCheck`
+- `back/gradlew -p back ciFastCheck --rerun-tasks`
+- GitHub PR CI checks
+
+## commit_plan
+1. `perf(post): FK 정리 인덱스 보강`
+   - post hard-delete와 idempotency cleanup 쿼리 인덱스를 한 기능 단위로 보강한다.


### PR DESCRIPTION
## 관련 이슈

close #287

## 작업 배경

- prod DB schema와 `pg_stat_statements`에서 확인된 post hard-delete/cleanup 인덱스 누락을 보강했습니다.
- `post_comment`, `post_like`, `post_write_request_idempotency`의 운영 인덱스를 repeatable migration과 entity AfterDDL에 함께 반영했습니다.

## 작업 내용

- hard-delete의 `delete from post_comment where post_id = ?`, self-FK 검증, `delete from post_like where post_id = ?` 경로를 위한 선두 인덱스를 추가했습니다.
- idempotency cleanup의 `created_at < ? order by created_at`와 hard-delete의 `post_id = ?` update 경로를 위한 인덱스를 추가했습니다.
- AfterDDL과 `R__operational_indexes.sql`이 같은 인덱스 계약을 유지하는 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - prod DB 조회: FK/index 목록, `pg_stat_statements` post cleanup 관련 query 확인
  - `back/gradlew -p back test --tests com.back.boundedContexts.post.model.PostOperationalIndexContractTest` 실패 확인: 인덱스 계약 누락
  - `back/gradlew -p back test --tests com.back.boundedContexts.post.model.PostOperationalIndexContractTest`
  - `back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back ciFastCheck --rerun-tasks`
  - commit hook: OpenAPI export, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 운영 DB에서 신규 인덱스 생성 시 초기 생성 비용과 약간의 쓰기 오버헤드가 발생할 수 있습니다.
- 롤백 방법: `R__operational_indexes.sql`와 각 post model AfterDDL에서 추가 인덱스를 제거합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
