### PR TITLE
[Fix] 글수정 코드블럭 원문 복구

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -841,6 +841,67 @@ test.describe("block editor authoring flow", () => {
     expect(colors.string).not.toBe(colors.base)
   })
 
+  test("실제 /editor/[id] 수정 진입은 pretty-code 원문으로 빈 코드블럭을 복구한다", async ({
+    page,
+  }) => {
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const staleContent = [
+      "수정 대상 코드입니다.",
+      "",
+      "```ts",
+      "```",
+      "",
+      "다음 문단입니다.",
+    ].join("\n")
+    const prettyCodeHtml = [
+      '<div class="aq-code-block">',
+      '<div class="aq-code-toolbar"><span class="aq-code-language">TS</span></div>',
+      '<div class="aq-code-body"><div class="aq-code-shell">',
+      '<pre class="aq-code aq-pretty-pre">',
+      '<code class="language-ts" data-raw-code="const answer = 42;&#10;return answer">',
+      '<span class="token keyword">const</span> answer = 42;',
+      '</code>',
+      '</pre>',
+      '</div></div>',
+      '</div>',
+    ].join("")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/991", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 991,
+          version: 7,
+          title: "코드 복구 글",
+          content: staleContent,
+          contentHtml: prettyCodeHtml,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/991")
+
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("코드 복구 글")
+    const codeBlock = page.locator(".aq-code-shell").first()
+    await expect(codeBlock).toBeVisible()
+    await expect(codeBlock.locator(".aq-code-highlight-layer")).toContainText("const answer = 42;")
+    await expect(codeBlock.locator(".aq-code-highlight-layer")).toContainText("return answer")
+    await expect(codeBlock.locator(".aq-code-highlight-layer .token.keyword").first()).toBeVisible()
+  })
+
   test("코드 블록 hover scroll surface는 wrapper chrome transition과 세로 gesture 차단을 쓰지 않는다", async ({ page }) => {
     const seed = encodeURIComponent("```javascript\nconst count = 1;\nreturn \"ok\";\n```\n\n아래 문단")
     await page.goto(`${QA_ENGINE_ROUTE}&seed=${seed}`)

--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -1134,6 +1134,29 @@ test.describe("editor studio state", () => {
     )
   })
 
+  test("contentHtml fallback은 두 줄짜리 빈 fenced code body도 pretty-code 원문으로 복구한다", () => {
+    const staleContent = [
+      "수정 대상 코드입니다.",
+      "",
+      "```ts",
+      "```",
+      "",
+      "다음 문단입니다.",
+    ].join("\n")
+    const prettyCodeHtml = [
+      '<div class="aq-code-block">',
+      '<pre class="aq-code aq-pretty-pre">',
+      '<code class="language-ts" data-raw-code="const answer = 42;&#10;return answer">',
+      '</code>',
+      '</pre>',
+      '</div>',
+    ].join("")
+
+    expect(resolveEditorMetaSnapshot(staleContent, prettyCodeHtml).body).toContain(
+      ["```ts", "const answer = 42;", "return answer", "```"].join("\n")
+    )
+  })
+
   test("dedicated editor 나가기는 returnTo 복귀를 replace로 처리해 editor history 엔트리를 남기지 않는다", () => {
     const editorStudioRoutingSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/useEditorStudioRouting.ts"),

--- a/front/src/routes/Admin/editorStudioMetaModel.ts
+++ b/front/src/routes/Admin/editorStudioMetaModel.ts
@@ -58,7 +58,7 @@ const LEADING_EDITOR_METADATA_LINE_REGEX =
   /^\s*(tags?|categories?|summary|thumbnail|thumb|cover|coverimage|cover_image)\s*:\s*(.+)\s*$/i
 const EDITOR_BODY_PLACEHOLDER = "내용을 입력하세요."
 const EDITOR_TOGGLE_TITLE_PLACEHOLDER = "토글 제목"
-const FENCED_CODE_BLOCK_REGEX = /(^|\n)(`{3,}|~{3,})([^\n]*)\n([\s\S]*?)\n\2(?=\n|$)/g
+const FENCED_CODE_BLOCK_REGEX = /(^|\n)(`{3,}|~{3,})([^\n]*)\n(?:([\s\S]*?)\n)?\2(?=\n|$)/g
 const HTML_CODE_RAW_ATTRIBUTE_TAG_REGEX = /<(?:code|pre)\b([^>]*)>/gi
 const HTML_ATTRIBUTE_REGEX = /\s([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>`]+)))?/g
 
@@ -325,8 +325,9 @@ const extractNonEmptyFencedCodeBlocks = (content: string) => {
   const blocks: string[] = []
 
   normalized.replace(FENCED_CODE_BLOCK_REGEX, (_match, _leading, marker, info, codeBody) => {
-    if (String(codeBody).trim().length > 0) {
-      blocks.push(`${marker}${info}\n${codeBody}\n${marker}`)
+    const body = String(codeBody ?? "")
+    if (body.trim().length > 0) {
+      blocks.push(`${marker}${info}\n${body}\n${marker}`)
     }
     return _match
   })
@@ -398,7 +399,7 @@ export const restoreEmptyFencedCodeBlocks = (content: string, recoveredContent: 
   const normalized = content.replace(/\r\n?/g, "\n")
 
   return normalized.replace(FENCED_CODE_BLOCK_REGEX, (match, leading, _marker, _info, codeBody) => {
-    if (String(codeBody).trim().length > 0) return match
+    if (String(codeBody ?? "").trim().length > 0) return match
 
     const recoveredBlock = recoveredBlocks[nextRecoveredIndex]
     if (!recoveredBlock) return match


### PR DESCRIPTION
## 관련 이슈

close #295

## 작업 배경

- 글수정 진입 시 두 줄짜리 빈 fenced code block이 남아 있으면 `contentHtml`의 pretty-code raw 원문으로 복구하지 못하던 문제를 수정했습니다.
- compact empty fence(````lang` 다음 줄 바로 closing fence)도 복구 대상에 포함해 코드블럭 shell만 남는 회귀를 막습니다.

## 작업 내용

- 수정 진입 메타 복구 regex가 compact empty fence를 인식하도록 보강했습니다.
- `data-raw-code` 기반 복구가 실제 `/editor/[id]` writer surface까지 표시되는 E2E를 추가했습니다.
- 기존 `contentHtml fallback` 회귀 테스트에 compact empty fence 케이스를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts -g "contentHtml fallback" --workers=1`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front lint`
  - `yarn --cwd front contracts:check`
  - 참고: `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`는 기존 `BlockEditorEngine.tsx` line budget guard가 `10494 >= 10480`으로 실패했습니다. 이번 변경 파일과 무관합니다.
  - 참고: `yarn --cwd front check:bundle-size`는 `/` raw budget이 514.0KB vs 513.6KB로 실패했습니다. 이 PR의 admin editor parser 변경과 무관하며 PR CI에서는 warn 모드입니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: fenced code block 매칭 범위가 넓어져 빈 코드블럭 복구 대상이 늘어납니다. non-empty code block은 그대로 유지하도록 테스트했습니다.
- 롤백 방법: 이 PR revert 후 기존 `contentHtml` fallback 동작으로 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
