### PR TITLE
[Build] main bundle budget baseline 정렬

### DIFF
--- a/front/scripts/bundle-budget-baseline.json
+++ b/front/scripts/bundle-budget-baseline.json
@@ -1,140 +1,130 @@
 {
   "version": 1,
-  "generatedAt": "2026-03-22T09:44:06.324Z",
+  "generatedAt": "2026-05-21T00:20:12.739Z",
   "routes": {
     "/": {
       "chunkCount": 7,
       "chunks": {
-        "static/chunks/webpack-78552e28875bb33c.js": {
-          "raw": 5691,
-          "gzip": 3025,
-          "brotli": 2511
+        "static/chunks/webpack-4817eae383675402.js": {
+          "raw": 5554,
+          "gzip": 3075,
+          "brotli": 2581
         },
-        "static/chunks/framework-f354ebcce9f3b522.js": {
-          "raw": 140040,
-          "gzip": 44890,
-          "brotli": 39118
+        "static/chunks/framework-97862ef36bc4065f.js": {
+          "raw": 139889,
+          "gzip": 44871,
+          "brotli": 39204
         },
-        "static/chunks/main-e0abd5fe2b3f8058.js": {
-          "raw": 131294,
-          "gzip": 38758,
-          "brotli": 33441
+        "static/chunks/main-3e2251a528591865.js": {
+          "raw": 126528,
+          "gzip": 36379,
+          "brotli": 31104
         },
-        "static/chunks/pages/_app-506d4c312410ec82.js": {
-          "raw": 131911,
-          "gzip": 42130,
-          "brotli": 36908
+        "static/chunks/pages/_app-edd202c69856a730.js": {
+          "raw": 151444,
+          "gzip": 49300,
+          "brotli": 42057
         },
-        "static/chunks/5675-bc9f6d2ef59e5757.js": {
-          "raw": 9550,
-          "gzip": 3985,
-          "brotli": 3545
+        "static/chunks/9253-37d0a9b1c671dde8.js": {
+          "raw": 13075,
+          "gzip": 4600,
+          "brotli": 4036
         },
-        "static/chunks/7930-fab06c865bcfdd46.js": {
-          "raw": 11455,
-          "gzip": 3361,
-          "brotli": 2958
+        "static/chunks/8438-b58cf9908fdb9ec4.js": {
+          "raw": 11769,
+          "gzip": 4175,
+          "brotli": 3643
         },
-        "static/chunks/pages/index-d9c8f7e65764aabc.js": {
-          "raw": 70952,
-          "gzip": 18009,
-          "brotli": 15574
+        "static/chunks/pages/index-a9d7c8eeb97e435a.js": {
+          "raw": 78066,
+          "gzip": 18326,
+          "brotli": 15766
         }
       },
       "totals": {
-        "raw": 500893,
-        "gzip": 154158,
-        "brotli": 134055
+        "raw": 526325,
+        "gzip": 160726,
+        "brotli": 138391
       }
     },
     "/posts/[id]": {
-      "chunkCount": 9,
+      "chunkCount": 7,
       "chunks": {
-        "static/chunks/webpack-78552e28875bb33c.js": {
-          "raw": 5691,
-          "gzip": 3025,
-          "brotli": 2511
+        "static/chunks/webpack-4817eae383675402.js": {
+          "raw": 5554,
+          "gzip": 3075,
+          "brotli": 2581
         },
-        "static/chunks/framework-f354ebcce9f3b522.js": {
-          "raw": 140040,
-          "gzip": 44890,
-          "brotli": 39118
+        "static/chunks/framework-97862ef36bc4065f.js": {
+          "raw": 139889,
+          "gzip": 44871,
+          "brotli": 39204
         },
-        "static/chunks/main-e0abd5fe2b3f8058.js": {
-          "raw": 131294,
-          "gzip": 38758,
-          "brotli": 33441
+        "static/chunks/main-3e2251a528591865.js": {
+          "raw": 126528,
+          "gzip": 36379,
+          "brotli": 31104
         },
-        "static/chunks/pages/_app-506d4c312410ec82.js": {
-          "raw": 131911,
-          "gzip": 42130,
-          "brotli": 36908
+        "static/chunks/pages/_app-edd202c69856a730.js": {
+          "raw": 151444,
+          "gzip": 49300,
+          "brotli": 42057
         },
-        "static/chunks/750-7536c6c7a9772a62.js": {
-          "raw": 149485,
-          "gzip": 43760,
-          "brotli": 37840
+        "static/chunks/9253-37d0a9b1c671dde8.js": {
+          "raw": 13075,
+          "gzip": 4600,
+          "brotli": 4036
         },
-        "static/chunks/5675-bc9f6d2ef59e5757.js": {
-          "raw": 9550,
-          "gzip": 3985,
-          "brotli": 3545
+        "static/chunks/2631-3729af84d4b02c25.js": {
+          "raw": 20548,
+          "gzip": 4965,
+          "brotli": 4331
         },
-        "static/chunks/4796-652f02e10cb96012.js": {
-          "raw": 55579,
-          "gzip": 15939,
-          "brotli": 13891
-        },
-        "static/chunks/7930-fab06c865bcfdd46.js": {
-          "raw": 11455,
-          "gzip": 3361,
-          "brotli": 2958
-        },
-        "static/chunks/pages/posts/[id]-9251880f0b138400.js": {
-          "raw": 31992,
-          "gzip": 8516,
-          "brotli": 7413
+        "static/chunks/pages/posts/[id]-01b741fa9ae8f861.js": {
+          "raw": 57287,
+          "gzip": 14512,
+          "brotli": 12389
         }
       },
       "totals": {
-        "raw": 666997,
-        "gzip": 204364,
-        "brotli": 177625
+        "raw": 514325,
+        "gzip": 157702,
+        "brotli": 135702
       }
     },
     "/admin": {
       "chunkCount": 5,
       "chunks": {
-        "static/chunks/webpack-78552e28875bb33c.js": {
-          "raw": 5691,
-          "gzip": 3025,
-          "brotli": 2511
+        "static/chunks/webpack-4817eae383675402.js": {
+          "raw": 5554,
+          "gzip": 3075,
+          "brotli": 2581
         },
-        "static/chunks/framework-f354ebcce9f3b522.js": {
-          "raw": 140040,
-          "gzip": 44890,
-          "brotli": 39118
+        "static/chunks/framework-97862ef36bc4065f.js": {
+          "raw": 139889,
+          "gzip": 44871,
+          "brotli": 39204
         },
-        "static/chunks/main-e0abd5fe2b3f8058.js": {
-          "raw": 131294,
-          "gzip": 38758,
-          "brotli": 33441
+        "static/chunks/main-3e2251a528591865.js": {
+          "raw": 126528,
+          "gzip": 36379,
+          "brotli": 31104
         },
-        "static/chunks/pages/_app-506d4c312410ec82.js": {
-          "raw": 131911,
-          "gzip": 42130,
-          "brotli": 36908
+        "static/chunks/pages/_app-edd202c69856a730.js": {
+          "raw": 151444,
+          "gzip": 49300,
+          "brotli": 42057
         },
-        "static/chunks/pages/admin-4e51f7558a9bbc4a.js": {
-          "raw": 10888,
-          "gzip": 3073,
-          "brotli": 2572
+        "static/chunks/pages/admin-8e68d8ff2de1a52b.js": {
+          "raw": 13833,
+          "gzip": 4032,
+          "brotli": 3419
         }
       },
       "totals": {
-        "raw": 419824,
-        "gzip": 131876,
-        "brotli": 114550
+        "raw": 437248,
+        "gzip": 137657,
+        "brotli": 118365
       }
     }
   }


### PR DESCRIPTION
## 관련 이슈

close #297

## 작업 배경

- main push CI에서 strict bundle gate가 `/` raw budget 초과로 실패해 홈서버 배포가 skipped 된 문제를 복구합니다.
- PR #296가 통과한 trusted build 결과 기준으로 bundle budget baseline을 재생성했습니다.

## 작업 내용

- `front/scripts/bundle-budget-baseline.json`을 현재 Next build 산출물 기준으로 정렬했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: baseline 정렬로 main strict gate의 기준점이 현재 trusted build로 이동합니다.
- 롤백 방법: 이 PR을 revert하면 이전 bundle baseline으로 되돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
