### PR TITLE
[CI] CD HOME_SERVER_ENV shell 주입 방지

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -205,21 +205,28 @@ jobs:
           ref: ${{ needs.calculateTag.outputs.deploy_sha }}
 
       - name: Verify required secrets
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          HOME_SSH_USER: ${{ secrets.HOME_SSH_USER }}
+          HOME_APP_DIR: ${{ secrets.HOME_APP_DIR }}
+          HOME_HOST: ${{ secrets.HOME_TAILSCALE_HOST || secrets.HOME_TS_HOST || secrets.HOME_SSH_HOST || secrets.HOME_HOST }}
+          HOME_SSH_KEY: ${{ secrets.HOME_SSH_KEY || secrets.HOME_SSH_PRIVATE_KEY }}
+          HOME_SERVER_ENV: ${{ secrets.HOME_SERVER_ENV }}
         shell: bash
         run: |
           required=(
-            "TS_OAUTH_CLIENT_ID=${{ secrets.TS_OAUTH_CLIENT_ID }}"
-            "TS_OAUTH_SECRET=${{ secrets.TS_OAUTH_SECRET }}"
-            "HOME_SSH_USER=${{ secrets.HOME_SSH_USER }}"
-            "HOME_APP_DIR=${{ secrets.HOME_APP_DIR }}"
-            "HOME_HOST=${{ secrets.HOME_TAILSCALE_HOST || secrets.HOME_TS_HOST || secrets.HOME_SSH_HOST || secrets.HOME_HOST }}"
-            "HOME_SSH_KEY=${{ secrets.HOME_SSH_KEY || secrets.HOME_SSH_PRIVATE_KEY }}"
-            "HOME_SERVER_ENV=${{ secrets.HOME_SERVER_ENV }}"
+            TS_OAUTH_CLIENT_ID
+            TS_OAUTH_SECRET
+            HOME_SSH_USER
+            HOME_APP_DIR
+            HOME_HOST
+            HOME_SSH_KEY
+            HOME_SERVER_ENV
           )
 
-          for item in "${required[@]}"; do
-            key="${item%%=*}"
-            value="${item#*=}"
+          for key in "${required[@]}"; do
+            value="${!key:-}"
             if [ -z "$value" ]; then
               echo "$key missing"
               exit 1

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -135,6 +135,14 @@ test("deploy workflow validates HOME_SERVER_ENV before SSH deployment", () => {
   assert(workflow.indexOf("Validate HOME_SERVER_ENV contract") < workflow.indexOf("Deploy over SSH"))
 })
 
+test("required secret check does not inject multi-line HOME_SERVER_ENV into shell", () => {
+  const workflow = readFileSync(workflowPath, "utf8")
+
+  assert(!workflow.includes("HOME_SERVER_ENV=${{ secrets.HOME_SERVER_ENV }}"))
+  assert.match(workflow, /env:\n(?:.*\n)*\s+HOME_SERVER_ENV: \$\{\{ secrets\.HOME_SERVER_ENV \}\}/)
+  assert.match(workflow, /value="\$\{!key:-\}"/)
+})
+
 test("runtime contract accounts for every compose env interpolation", async () => {
   const { loadContract } = await import("../env/validate-env.mjs")
   const contractKeys = new Set(targetKeyNames(loadContract(contractPath), "home-server-runtime"))


### PR DESCRIPTION
## 관련 이슈

close #301

## 작업 배경

- CD `blueGreenDeploy / Verify required secrets`가 multi-line `HOME_SERVER_ENV`를 shell script 본문으로 해석하던 문제를 수정했습니다.
- required secret 값은 step `env:`로 전달하고, bash에서는 변수명 목록과 indirect expansion으로 present/missing만 검사합니다.

## 작업 내용

- `.github/workflows/deploy.yml`의 required secret 검사에서 `${{ secrets.* }}` 직접 삽입을 제거했습니다.
- `HOME_SERVER_ENV=${{ secrets.HOME_SERVER_ENV }}` 패턴이 재발하면 실패하는 regression test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/test/env-contract.test.mjs` (RED 후 GREEN, 이후 1회 추가 통과)
  - `node tools/env/validate-env.mjs --target home-server-source --file deploy/homeserver/.env.prod`
  - `docker compose --env-file deploy/homeserver/.env.prod -f deploy/homeserver/docker-compose.prod.yml config -q`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: `Verify required secrets` 단계의 출력 방식이 key present/missing만 유지되므로 secret 값 노출 위험은 낮아집니다.
- 롤백 방법: 커밋 `8ae4c9c4`를 revert하면 이전 직접 삽입 방식으로 돌아가지만, multi-line `HOME_SERVER_ENV`에서는 CD가 다시 실패할 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
