### PR TITLE
[Fix] 에디터 본문 hover scroll과 블록 선택 overlay drift 수정

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -981,6 +981,108 @@ test.describe("block editor authoring flow", () => {
     await expect.poll(async () => page.evaluate(() => window.scrollY)).toBeGreaterThan(beforeScrollY + 120)
   })
 
+  test("본문 hover wheel scroll과 블록 선택 overlay scroll 정렬을 유지한다", async ({ page }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const targetLabel = "scroll anchor target block"
+    const seed = encodeURIComponent(
+      Array.from({ length: 28 }, (_, index) =>
+        index === 4
+          ? `${targetLabel} ${index + 1}`
+          : `scroll regression paragraph ${index + 1}. 본문 hover wheel 입력과 block selection overlay 정렬을 확인합니다.`
+      ).join("\\n\\n")
+    )
+
+    await page.goto(`${QA_ENGINE_ROUTE}&seed=${seed}`)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    const firstParagraph = editor.locator("p").first()
+    await expect(firstParagraph).toBeVisible()
+    await page.evaluate(() => window.scrollTo(0, 0))
+
+    const firstBox = await firstParagraph.boundingBox()
+    if (!firstBox) {
+      throw new Error("first paragraph metrics are missing before wheel")
+    }
+    await page.mouse.move(firstBox.x + Math.min(firstBox.width / 2, 120), firstBox.y + firstBox.height / 2)
+
+    const hoverScrollBefore = await page.evaluate(() => window.scrollY)
+    await page.mouse.wheel(0, 360)
+    await expect.poll(async () => page.evaluate(() => window.scrollY)).toBeGreaterThan(hoverScrollBefore + 120)
+
+    const targetParagraph = editor.locator("p", { hasText: targetLabel }).first()
+    await targetParagraph.scrollIntoViewIfNeeded()
+    const targetBox = await targetParagraph.boundingBox()
+    if (!targetBox) {
+      throw new Error("target paragraph metrics are missing before block selection")
+    }
+    await page.mouse.move(targetBox.x + Math.min(targetBox.width / 2, 120), targetBox.y + targetBox.height / 2)
+    await targetParagraph.hover()
+
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    await dragHandle.click()
+
+    const selectionOverlay = page.getByTestId("keyboard-block-selection-overlay")
+    await expect(selectionOverlay).toBeVisible()
+
+    const readSelectionGeometry = async () =>
+      page.evaluate((label) => {
+        const paragraph =
+          Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] p")).find(
+            (element) => element.textContent?.includes(label)
+          ) ?? null
+        const overlay = document.querySelector<HTMLElement>("[data-testid='keyboard-block-selection-overlay']")
+        const handle = document.querySelector<HTMLElement>("[data-testid='block-drag-handle']")
+        if (!paragraph || !overlay || !handle) return null
+        const paragraphRect = paragraph.getBoundingClientRect()
+        const overlayRect = overlay.getBoundingClientRect()
+        const handleRect = handle.getBoundingClientRect()
+        const overlayStyle = window.getComputedStyle(overlay)
+        const handleStyle = window.getComputedStyle(handle)
+        return {
+          scrollY: window.scrollY,
+          paragraphTop: paragraphRect.top,
+          overlayTop: overlayRect.top,
+          handleTop: handleRect.top,
+          overlayVisible:
+            overlayRect.width > 0 &&
+            overlayRect.height > 0 &&
+            overlayStyle.display !== "none" &&
+            overlayStyle.visibility !== "hidden",
+          handleVisible:
+            handleRect.width > 0 &&
+            handleRect.height > 0 &&
+            handleStyle.display !== "none" &&
+            handleStyle.visibility !== "hidden" &&
+            Number.parseFloat(handleStyle.opacity || "1") > 0.5,
+        }
+      }, targetLabel)
+
+    const beforeGeometry = await readSelectionGeometry()
+    if (!beforeGeometry) {
+      throw new Error("block selection geometry is missing before scroll")
+    }
+
+    await page.mouse.move(targetBox.x + Math.min(targetBox.width / 2, 120), targetBox.y + targetBox.height / 2)
+    await page.mouse.wheel(0, 180)
+
+    await expect
+      .poll(async () => (await readSelectionGeometry())?.scrollY ?? 0)
+      .toBeGreaterThan(beforeGeometry.scrollY + 60)
+
+    const afterGeometry = await readSelectionGeometry()
+    if (!afterGeometry) {
+      throw new Error("block selection geometry is missing after scroll")
+    }
+
+    const paragraphDelta = afterGeometry.paragraphTop - beforeGeometry.paragraphTop
+    expect(afterGeometry.overlayVisible).toBe(true)
+    expect(afterGeometry.handleVisible).toBe(true)
+    expect(Math.abs(afterGeometry.overlayTop - beforeGeometry.overlayTop - paragraphDelta)).toBeLessThanOrEqual(10)
+    expect(Math.abs(afterGeometry.handleTop - beforeGeometry.handleTop - paragraphDelta)).toBeLessThanOrEqual(12)
+    expect(Math.abs(afterGeometry.overlayTop + 4 - afterGeometry.paragraphTop)).toBeLessThanOrEqual(10)
+  })
+
   test("코드 언어 선택 팝오버는 본문 숨김 텍스트 스타일을 상속하지 않는다", async ({ page }) => {
     const seed = encodeURIComponent("```javascript\nconst answer = 42;\n```")
     await page.goto(`${QA_ENGINE_ROUTE}&seed=${seed}`)

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -54,7 +54,7 @@ export const resolveBlockHandleRailLayout = (
 
   return {
     left: Math.min(Math.max(BLOCK_HANDLE_VIEWPORT_PADDING_PX, rect.left), maxLeft),
-    top: Math.max(BLOCK_HANDLE_VIEWPORT_PADDING_PX, rect.top - railHeight - BLOCK_HANDLE_STACKED_GAP_PX),
+    top: rect.top - railHeight - BLOCK_HANDLE_STACKED_GAP_PX,
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

close #303

## 작업 배경

- 에디터 본문 위 wheel 입력이 page scroll chain을 유지하는지 회귀 테스트로 고정했습니다.
- 좁은 gutter에서 block handle rail이 viewport 상단 padding에 clamp되어 선택 블록과 분리되던 동작을 제거해, overlay와 handle이 같은 block rect delta를 따라가게 했습니다.
- main merge 후 기존 자동 CI/CD 경로가 이어집니다.

## 작업 내용

- block handle narrow-gutter fallback의 세로 clamp를 제거했습니다.
- 본문 hover wheel scroll과 block selection overlay/handle scroll 정렬을 검증하는 authoring E2E를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "본문 hover wheel scroll과 블록 선택 overlay scroll 정렬을 유지한다" --workers=1` (RED 확인 후 GREEN)
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 좁은 gutter에서 선택 블록이 viewport 상단을 벗어날 때 handle도 함께 일부 화면 밖으로 이동합니다. 선택 블록과 분리되는 기존 drift보다 낮은 리스크입니다.
- 롤백 방법: 이 PR revert

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
