### PR TITLE
[Fix] 글수정 editor scroll affordance와 code block 복구

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -902,6 +902,285 @@ test.describe("block editor authoring flow", () => {
     await expect(codeBlock.locator(".aq-code-highlight-layer .token.keyword").first()).toBeVisible()
   })
 
+  test("실제 /editor/[id] 수정 진입은 본문 hover scroll, 선택 block affordance, code 원문을 유지한다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const targetLabel = "edit route selected scroll anchor"
+    const paragraphs = Array.from({ length: 36 }, (_, index) =>
+      index === 8
+        ? `${targetLabel} ${index + 1}`
+        : `edit route scroll paragraph ${index + 1}. 본문 hover wheel 입력과 block selection 고정 상태를 확인합니다.`
+    )
+    const content = [
+      paragraphs.slice(0, 12).join("\n\n"),
+      "```ts",
+      "```",
+      paragraphs.slice(12).join("\n\n"),
+    ].join("\n\n")
+    const prettyCodeHtml = [
+      '<section><p>본문 앞 HTML</p>',
+      '<div class="aq-code-block" data-language="ts" data-raw-code="const restored = 305;&#10;return restored">',
+      '<pre class="aq-code aq-pretty-pre">',
+      '<code class="language-ts"></code>',
+      '</pre></div></section>',
+    ].join("")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/992", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 992,
+          version: 8,
+          title: "수정 route scroll/code 회귀 글",
+          content,
+          contentHtml: prettyCodeHtml,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/992")
+
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("수정 route scroll/code 회귀 글")
+    const codeBlock = page.locator(".aq-code-shell").first()
+    await expect(codeBlock).toBeVisible()
+    await expect(codeBlock.locator(".aq-code-highlight-layer")).toContainText("const restored = 305;")
+    await expect(codeBlock.locator(".aq-code-highlight-layer")).toContainText("return restored")
+
+    const readScrollTop = () =>
+      page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    const firstParagraph = editor.locator("p", { hasText: "edit route scroll paragraph 1" }).first()
+    await expect(firstParagraph).toBeVisible()
+    await page.evaluate(() => window.scrollTo(0, 0))
+
+    const firstBox = await firstParagraph.boundingBox()
+    if (!firstBox) {
+      throw new Error("edit route first paragraph metrics are missing before wheel")
+    }
+    await page.mouse.move(firstBox.x + Math.min(firstBox.width / 2, 120), firstBox.y + firstBox.height / 2)
+
+    const hoverScrollBefore = await readScrollTop()
+    await page.mouse.wheel(0, 360)
+    await expect.poll(readScrollTop).toBeGreaterThan(hoverScrollBefore + 120)
+
+    const targetParagraph = editor.locator("p", { hasText: targetLabel }).first()
+    await targetParagraph.scrollIntoViewIfNeeded()
+    const targetBox = await targetParagraph.boundingBox()
+    if (!targetBox) {
+      throw new Error("edit route target paragraph metrics are missing before block selection")
+    }
+    await page.mouse.move(targetBox.x + Math.min(targetBox.width / 2, 120), targetBox.y + targetBox.height / 2)
+    await targetParagraph.hover()
+
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    await dragHandle.click()
+
+    const selectionOverlay = page.getByTestId("keyboard-block-selection-overlay")
+    await expect(selectionOverlay).toBeVisible()
+
+    const readSelectionGeometry = async () =>
+      page.evaluate((label) => {
+        const paragraph =
+          Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] p")).find(
+            (element) => element.textContent?.includes(label)
+          ) ?? null
+        const overlay = document.querySelector<HTMLElement>("[data-testid='keyboard-block-selection-overlay']")
+        const handle = document.querySelector<HTMLElement>("[data-testid='block-drag-handle']")
+        if (!paragraph || !overlay || !handle) return null
+        const paragraphRect = paragraph.getBoundingClientRect()
+        const overlayRect = overlay.getBoundingClientRect()
+        const handleRect = handle.getBoundingClientRect()
+        const overlayStyle = window.getComputedStyle(overlay)
+        const handleStyle = window.getComputedStyle(handle)
+        return {
+          scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+          paragraphTop: paragraphRect.top,
+          overlayTop: overlayRect.top,
+          handleTop: handleRect.top,
+          overlayVisible:
+            overlayRect.width > 0 &&
+            overlayRect.height > 0 &&
+            overlayStyle.display !== "none" &&
+            overlayStyle.visibility !== "hidden",
+          handleVisible:
+            handleRect.width > 0 &&
+            handleRect.height > 0 &&
+            handleStyle.display !== "none" &&
+            handleStyle.visibility !== "hidden" &&
+            Number.parseFloat(handleStyle.opacity || "1") > 0.5,
+        }
+      }, targetLabel)
+
+    const beforeGeometry = await readSelectionGeometry()
+    if (!beforeGeometry) {
+      throw new Error("edit route block selection geometry is missing before scroll")
+    }
+
+    await page.evaluate(
+      ({ label, base }) => {
+        const win = window as Window & {
+          __editorScrollGeometrySamples?: Array<{
+            scrollTop: number
+            paragraphTop: number
+            overlayTop: number
+            handleTop: number
+            overlayError: number
+            handleError: number
+            overlayVisible: boolean
+            handleVisible: boolean
+          }>
+          __cleanupEditorScrollGeometrySamples?: () => void
+        }
+        win.__cleanupEditorScrollGeometrySamples?.()
+        win.__editorScrollGeometrySamples = []
+
+        const read = () => {
+          const paragraph =
+            Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] p")).find(
+              (element) => element.textContent?.includes(label)
+            ) ?? null
+          const overlay = document.querySelector<HTMLElement>("[data-testid='keyboard-block-selection-overlay']")
+          const handle = document.querySelector<HTMLElement>("[data-testid='block-drag-handle']")
+          if (!paragraph || !overlay || !handle) return null
+          const paragraphRect = paragraph.getBoundingClientRect()
+          const overlayRect = overlay.getBoundingClientRect()
+          const handleRect = handle.getBoundingClientRect()
+          const overlayStyle = window.getComputedStyle(overlay)
+          const handleStyle = window.getComputedStyle(handle)
+          const paragraphDelta = paragraphRect.top - base.paragraphTop
+          return {
+            scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+            paragraphTop: paragraphRect.top,
+            overlayTop: overlayRect.top,
+            handleTop: handleRect.top,
+            overlayError: Math.abs(overlayRect.top - base.overlayTop - paragraphDelta),
+            handleError: Math.abs(handleRect.top - base.handleTop - paragraphDelta),
+            overlayVisible:
+              overlayRect.width > 0 &&
+              overlayRect.height > 0 &&
+              overlayStyle.display !== "none" &&
+              overlayStyle.visibility !== "hidden",
+            handleVisible:
+              handleRect.width > 0 &&
+              handleRect.height > 0 &&
+              handleStyle.display !== "none" &&
+              handleStyle.visibility !== "hidden" &&
+              Number.parseFloat(handleStyle.opacity || "1") > 0.5,
+          }
+        }
+
+        const record = () => {
+          if ((win.__editorScrollGeometrySamples?.length ?? 0) >= 8) return
+          const next = read()
+          if (next) win.__editorScrollGeometrySamples?.push(next)
+        }
+
+        window.addEventListener("scroll", record, { capture: true, passive: true })
+        win.__cleanupEditorScrollGeometrySamples = () => {
+          window.removeEventListener("scroll", record, true)
+        }
+      },
+      { label: targetLabel, base: beforeGeometry }
+    )
+
+    await page.mouse.move(targetBox.x + Math.min(targetBox.width / 2, 120), targetBox.y + targetBox.height / 2)
+    await page.mouse.wheel(0, 220)
+    await expect
+      .poll(async () => (await readSelectionGeometry())?.scrollTop ?? 0)
+      .toBeGreaterThan(beforeGeometry.scrollTop + 60)
+
+    const scrollSamples = await page.evaluate(() => {
+      const win = window as Window & {
+        __editorScrollGeometrySamples?: Array<{
+          scrollTop: number
+          overlayError: number
+          handleError: number
+          overlayVisible: boolean
+          handleVisible: boolean
+        }>
+        __cleanupEditorScrollGeometrySamples?: () => void
+      }
+      win.__cleanupEditorScrollGeometrySamples?.()
+      return win.__editorScrollGeometrySamples ?? []
+    })
+    const movedSamples = scrollSamples.filter((sample) => sample.scrollTop > beforeGeometry.scrollTop + 30)
+    expect(movedSamples.length).toBeGreaterThan(0)
+    expect(movedSamples.every((sample) => sample.overlayVisible && sample.handleVisible)).toBe(true)
+    expect(Math.max(...movedSamples.map((sample) => sample.overlayError))).toBeLessThanOrEqual(10)
+    expect(Math.max(...movedSamples.map((sample) => sample.handleError))).toBeLessThanOrEqual(12)
+
+    const samples = await page.evaluate(async (label) => {
+      const nextFrame = () => new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()))
+      const read = () => {
+        const paragraph =
+          Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] p")).find(
+            (element) => element.textContent?.includes(label)
+          ) ?? null
+        const overlay = document.querySelector<HTMLElement>("[data-testid='keyboard-block-selection-overlay']")
+        const handle = document.querySelector<HTMLElement>("[data-testid='block-drag-handle']")
+        if (!paragraph || !overlay || !handle) return null
+        const paragraphRect = paragraph.getBoundingClientRect()
+        const overlayRect = overlay.getBoundingClientRect()
+        const handleRect = handle.getBoundingClientRect()
+        const overlayStyle = window.getComputedStyle(overlay)
+        const handleStyle = window.getComputedStyle(handle)
+        return {
+          paragraphTop: paragraphRect.top,
+          overlayTop: overlayRect.top,
+          handleTop: handleRect.top,
+          overlayVisible:
+            overlayRect.width > 0 &&
+            overlayRect.height > 0 &&
+            overlayStyle.display !== "none" &&
+            overlayStyle.visibility !== "hidden",
+          handleVisible:
+            handleRect.width > 0 &&
+            handleRect.height > 0 &&
+            handleStyle.display !== "none" &&
+            handleStyle.visibility !== "hidden" &&
+            Number.parseFloat(handleStyle.opacity || "1") > 0.5,
+        }
+      }
+
+      const frames: Array<ReturnType<typeof read>> = []
+      for (let index = 0; index < 8; index += 1) {
+        await nextFrame()
+        frames.push(read())
+      }
+      return frames
+    }, targetLabel)
+
+    expect(samples.every((sample) => sample?.overlayVisible && sample.handleVisible)).toBe(true)
+
+    const afterGeometry = await readSelectionGeometry()
+    if (!afterGeometry) {
+      throw new Error("edit route block selection geometry is missing after scroll")
+    }
+
+    const paragraphDelta = afterGeometry.paragraphTop - beforeGeometry.paragraphTop
+    expect(afterGeometry.overlayVisible).toBe(true)
+    expect(afterGeometry.handleVisible).toBe(true)
+    expect(Math.abs(afterGeometry.overlayTop - beforeGeometry.overlayTop - paragraphDelta)).toBeLessThanOrEqual(10)
+    expect(Math.abs(afterGeometry.handleTop - beforeGeometry.handleTop - paragraphDelta)).toBeLessThanOrEqual(12)
+    expect(Math.abs(afterGeometry.overlayTop + 4 - afterGeometry.paragraphTop)).toBeLessThanOrEqual(10)
+  })
+
   test("코드 블록 hover scroll surface는 wrapper chrome transition과 세로 gesture 차단을 쓰지 않는다", async ({ page }) => {
     const seed = encodeURIComponent("```javascript\nconst count = 1;\nreturn \"ok\";\n```\n\n아래 문단")
     await page.goto(`${QA_ENGINE_ROUTE}&seed=${seed}`)

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -6,13 +6,7 @@ import { Fragment, Node as ProseMirrorNode } from "@tiptap/pm/model"
 import { NodeSelection, TextSelection } from "@tiptap/pm/state"
 import { CellSelection, selectedRect, TableMap } from "@tiptap/pm/tables"
 import { EditorContent, useEditor } from "@tiptap/react"
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react"
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import type {
   ChangeEvent,
   DragEvent as ReactDragEvent,
@@ -21,6 +15,7 @@ import type {
   ReactNode,
 } from "react"
 import { createPortal } from "react-dom"
+import { flushSync } from "react-dom"
 import { getPreferredCodeLanguage } from "./extensions"
 import {
   deleteTopLevelBlockAt,
@@ -282,14 +277,9 @@ import {
   resolveFloatingBubbleStateFromCoords,
   useFloatingBubbleState,
 } from "./useFloatingBubbleState"
+import { recordEditorCommitDurationForRuntimeGuard } from "./editorRuntimeGuardModel"
 
-type RuntimeGuardWindow = Window & {
-  __AQ_RUNTIME_GUARD_ENABLED__?: boolean
-  __AQ_RUNTIME_GUARD__?: {
-    editorCommitSamples?: number[]
-  }
-}
-
+const useBlockSelectionLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect
 type SlashKeyboardEventLike = {
   key: string
   shiftKey?: boolean
@@ -309,22 +299,6 @@ type ToolbarAction = {
   run: () => void
   active: boolean
   disabled?: boolean
-}
-
-const EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT = 240
-
-const recordEditorCommitDurationForRuntimeGuard = (durationMs: number) => {
-  if (typeof window === "undefined" || !Number.isFinite(durationMs) || durationMs <= 0) return
-
-  const runtimeWindow = window as RuntimeGuardWindow
-  if (!runtimeWindow.__AQ_RUNTIME_GUARD_ENABLED__) return
-
-  const store = (runtimeWindow.__AQ_RUNTIME_GUARD__ ??= {})
-  const nextSamples = [...(store.editorCommitSamples ?? []), durationMs]
-  if (nextSamples.length > EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT) {
-    nextSamples.splice(0, nextSamples.length - EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT)
-  }
-  store.editorCommitSamples = nextSamples
 }
 
 type BlockMenuState =
@@ -5530,6 +5504,7 @@ const BlockEditorEngine = ({
     !tableColumnDragGuideState.visible &&
     !draggedTableAxisState &&
     !tableAxisReorderIndicatorState.visible
+  const shouldSyncSelectionLayoutImmediately = blockSelectionOverlayState.visible || blockHandleState.visible
 
   useEffect(() => {
     if (typeof window === "undefined" || !shouldTrackSelectionLayoutSync) return
@@ -5540,6 +5515,11 @@ const BlockEditorEngine = ({
     const resizeOptions: AddEventListenerOptions = { passive: true }
     const minSyncIntervalMs = shouldThrottleSelectionLayoutSync ? 72 : 0
     const sync = () => {
+      if (shouldSyncSelectionLayoutImmediately) {
+        lastCommittedAt = window.performance.now()
+        flushSync(() => setSelectionTick((prev) => prev + 1))
+        return
+      }
       if (rafId !== null || timeoutId !== null) return
       const now = window.performance.now()
       const remainingDelayMs = minSyncIntervalMs > 0 ? minSyncIntervalMs - (now - lastCommittedAt) : 0
@@ -5576,9 +5556,9 @@ const BlockEditorEngine = ({
         window.clearTimeout(timeoutId)
       }
     }
-  }, [shouldThrottleSelectionLayoutSync, shouldTrackSelectionLayoutSync])
+  }, [shouldSyncSelectionLayoutImmediately, shouldThrottleSelectionLayoutSync, shouldTrackSelectionLayoutSync])
 
-  useEffect(() => {
+  useBlockSelectionLayoutEffect(() => {
     if (!editor) return
     const rectCache = blockSelectionLayoutRectCacheRef.current
     rectCache.clear()

--- a/front/src/components/editor/editorRuntimeGuardModel.ts
+++ b/front/src/components/editor/editorRuntimeGuardModel.ts
@@ -1,0 +1,22 @@
+type RuntimeGuardWindow = Window & {
+  __AQ_RUNTIME_GUARD_ENABLED__?: boolean
+  __AQ_RUNTIME_GUARD__?: {
+    editorCommitSamples?: number[]
+  }
+}
+
+const EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT = 240
+
+export const recordEditorCommitDurationForRuntimeGuard = (durationMs: number) => {
+  if (typeof window === "undefined" || !Number.isFinite(durationMs) || durationMs <= 0) return
+
+  const runtimeWindow = window as RuntimeGuardWindow
+  if (!runtimeWindow.__AQ_RUNTIME_GUARD_ENABLED__) return
+
+  const store = (runtimeWindow.__AQ_RUNTIME_GUARD__ ??= {})
+  const nextSamples = [...(store.editorCommitSamples ?? []), durationMs]
+  if (nextSamples.length > EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT) {
+    nextSamples.splice(0, nextSamples.length - EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT)
+  }
+  store.editorCommitSamples = nextSamples
+}

--- a/front/src/routes/Admin/editorStudioMetaModel.ts
+++ b/front/src/routes/Admin/editorStudioMetaModel.ts
@@ -59,7 +59,8 @@ const LEADING_EDITOR_METADATA_LINE_REGEX =
 const EDITOR_BODY_PLACEHOLDER = "내용을 입력하세요."
 const EDITOR_TOGGLE_TITLE_PLACEHOLDER = "토글 제목"
 const FENCED_CODE_BLOCK_REGEX = /(^|\n)(`{3,}|~{3,})([^\n]*)\n(?:([\s\S]*?)\n)?\2(?=\n|$)/g
-const HTML_CODE_RAW_ATTRIBUTE_TAG_REGEX = /<(?:code|pre)\b([^>]*)>/gi
+const HTML_CODE_RAW_ATTRIBUTE_TAG_REGEX =
+  /<([a-z][a-z0-9:-]*)\b([^>]*(?:data-raw-code|data-prism-source)[^>]*)>/gi
 const HTML_ATTRIBUTE_REGEX = /\s([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>`]+)))?/g
 
 export const PREVIEW_SUMMARY_MAX_LENGTH = 150
@@ -374,7 +375,7 @@ const extractRawCodeFencedBlocksFromHtml = (contentHtml?: string | null) => {
   if (!contentHtml?.trim()) return ""
 
   const blocks: string[] = []
-  contentHtml.replace(HTML_CODE_RAW_ATTRIBUTE_TAG_REGEX, (_match, rawAttributes) => {
+  contentHtml.replace(HTML_CODE_RAW_ATTRIBUTE_TAG_REGEX, (_match, _tagName, rawAttributes) => {
     const attributes = readHtmlAttributes(String(rawAttributes))
     const codeSource = (
       attributes.get("data-raw-code") ||
@@ -414,10 +415,13 @@ export const resolveEditorMetaSnapshot = (content: string, contentHtml?: string 
   const markdownFromHtml = contentHtml?.trim() ? convertHtmlClipboardToMarkdown(contentHtml).trim() : ""
   const rawCodeMarkdownFromHtml = extractRawCodeFencedBlocksFromHtml(contentHtml)
   const recoveredCodeMarkdown = [rawCodeMarkdownFromHtml, markdownFromHtml].filter(Boolean).join("\n\n")
+  const htmlFallbackBody = rawCodeMarkdownFromHtml
+    ? restoreEmptyFencedCodeBlocks(markdownFromHtml || rawCodeMarkdownFromHtml, rawCodeMarkdownFromHtml)
+    : markdownFromHtml
   const restoredParsedBody = parsed.body.trim() && recoveredCodeMarkdown
     ? restoreEmptyFencedCodeBlocks(parsed.body, recoveredCodeMarkdown)
     : parsed.body
-  const resolvedBody = restoredParsedBody.trim() || markdownFromHtml || rawCodeMarkdownFromHtml || normalizedRawContent
+  const resolvedBody = restoredParsedBody.trim() || htmlFallbackBody || rawCodeMarkdownFromHtml || normalizedRawContent
   const parsedThumbnail = normalizeSafeImageUrl(parsed.thumbnail)
   const fallbackThumbnail = normalizeSafeImageUrl(extractFirstMarkdownImage(resolvedBody))
   const syncedThumbnail = stripThumbnailFocusFromUrl(parsedThumbnail || fallbackThumbnail)


### PR DESCRIPTION
## 관련 이슈

close #305

## 작업 배경

- `/editor/[id]` 실제 수정 route에서 본문 hover wheel scroll과 선택 block affordance가 scroll 첫 프레임부터 같은 block rect를 따라가도록 복구했습니다.
- 수정 진입 시 `contentHtml`의 code wrapper에만 남은 `data-raw-code`/`data-prism-source`도 fenced code body로 복구해 빈 code shell 회귀를 막았습니다.
- main merge 후 자동 CI/CD 경로로 홈서버 배포가 이어지는 변경입니다.

## 작업 내용

- 실제 `/editor/[id]` route 기반 e2e를 추가해 paragraph hover scroll, block selection overlay/handle scroll 동기화, wrapper raw-code 복구를 한 흐름에서 검증합니다.
- block selection layout 계산을 layout effect + scroll event 즉시 flush로 전환해 fixed overlay/handle의 stale 좌표 프레임을 제거했습니다.
- `editorStudioMetaModel`의 `contentHtml` fallback이 wrapper raw-code attribute를 직접 읽고, HTML 변환 결과의 빈 code fence를 raw code로 보강하도록 정리했습니다.
- `BlockEditorEngine` 라인 수 guard 유지를 위해 runtime guard sample 기록을 `editorRuntimeGuardModel`로 분리했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:authoring`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: scroll 중 block selection layout tick을 즉시 flush하므로 선택/hover affordance가 보이는 동안 scroll event당 layout 계산이 늘어날 수 있습니다. authoring/perf guard와 bundle-size는 통과했습니다.
- 롤백 방법: 이 PR revert 후 기존 editor scroll/code fallback 상태로 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
