### PR TITLE
[Fix] 모바일 TOC 기본 접힘 유지

### DIFF
--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -1610,6 +1610,10 @@ test("모바일 상세는 compact 액션과 접이식 목차를 노출한다", a
       value: clipboard,
     })
   })
+  const mobileTocContent = Array.from({ length: 12 }, (_, index) => {
+    const sectionNumber = String(index + 1).padStart(2, "0")
+    return [`## 모바일 목차 섹션 ${sectionNumber}`, "모바일 compact 목차 높이 회귀를 검증하는 본문입니다."].join("\n\n")
+  }).join("\n\n")
 
   await page.route("**/post/api/v1/posts/909", async (route) => {
     await route.fulfill({
@@ -1624,7 +1628,7 @@ test("모바일 상세는 compact 액션과 접이식 목차를 노출한다", a
         authorUsername: "aquila",
         authorProfileImageDirectUrl: "/avatar.png",
         title: "모바일 상세 UX 테스트",
-        content: ["## 첫 섹션", "본문", "### 둘째 섹션", "본문"].join("\n\n"),
+        content: mobileTocContent,
         tags: ["모바일"],
         category: [],
         published: true,
@@ -1665,13 +1669,22 @@ test("모바일 상세는 compact 액션과 접이식 목차를 노출한다", a
   const compactTocSummary = page.locator('[aria-label="접이식 목차"] summary')
   await expect(compactTocSummary).toBeVisible()
   await expect(compactTocSummary.getByText("목차")).toBeVisible()
-  await expect(compactTocSummary.getByText("2개 섹션")).toBeVisible()
+  await expect(compactTocSummary.getByText("12개 섹션")).toBeVisible()
+  await expect(page.getByRole("button", { name: "모바일 목차 섹션 01" })).toBeHidden()
+  const compactTocInitialListHeight = await page.locator('[aria-label="접이식 목차"] ol').evaluate((list) => list.clientHeight)
+  expect(compactTocInitialListHeight).toBe(0)
   const compactShareButton = compactActionBar.getByRole("button", { name: /^공유/ })
   await compactShareButton.click()
   await expect(compactShareButton).toBeVisible()
 
   await compactTocSummary.click()
-  await expect(page.getByRole("button", { name: "첫 섹션" })).toBeVisible()
+  await expect(page.getByRole("button", { name: "모바일 목차 섹션 01" })).toBeVisible()
+  const compactTocListMetrics = await page.locator('[aria-label="접이식 목차"] ol').evaluate((list) => ({
+    clientHeight: list.clientHeight,
+    scrollHeight: list.scrollHeight,
+  }))
+  expect(compactTocListMetrics.clientHeight).toBeLessThanOrEqual(240)
+  expect(compactTocListMetrics.scrollHeight).toBeGreaterThan(compactTocListMetrics.clientHeight)
 })
 
 test("상세 페이지 머메이드 블록은 코드 텍스트가 아니라 다이어그램 SVG로 렌더된다", async ({ page }) => {

--- a/front/src/routes/Detail/PostDetail/index.tsx
+++ b/front/src/routes/Detail/PostDetail/index.tsx
@@ -1812,12 +1812,20 @@ const CompactTocSection = styled.section`
     transform: rotate(180deg);
   }
 
+  details:not([open]) ol {
+    display: none;
+  }
+
   ol {
     list-style: none;
     margin: 0;
     padding: 0 0.78rem 0.88rem;
     display: grid;
     gap: 0.12rem;
+    max-height: 14rem;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
   }
 
   li[data-level="3"] button {


### PR DESCRIPTION
## 관련 이슈

close #313

## 작업 배경

- 모바일 공개 상세의 compact 목차가 닫힌 상태에서도 레이아웃 높이를 차지하던 문제를 정리했습니다.
- 목차를 열었을 때도 내부 스크롤로 높이를 제한해 본문 진입을 막지 않도록 했습니다.

## 작업 내용

- 닫힌 compact 목차의 ol을 시각적으로도 display none 처리했습니다.
- 열린 compact 목차 목록은 14rem 높이 안에서 내부 스크롤되도록 제한했습니다.
- 긴 목차 모바일 회귀를 smoke test에 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - yarn --cwd front playwright:preflight
  - yarn --cwd front playwright test e2e/smoke.spec.ts --grep "모바일 상세는 compact 액션과 접이식 목차를 노출한다" --workers=1
  - yarn --cwd front build
  - yarn --cwd front test:e2e:smoke
  - yarn --cwd front check:bundle-size
  - pre-commit: yarn build, node scripts/check-bundle-size.mjs, yarn test:e2e:smoke
  - Browser: /posts/507 393x852에서 닫힘 상태 ol.clientHeight=0, 열림 상태 ol.clientHeight=224, 가로 overflow 0 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 긴 모바일 목차를 열었을 때 내부 스크롤이 추가되어 사용자가 목차 안에서 스크롤해야 합니다.
- 롤백 방법: 이 PR의 CompactTocSection CSS와 smoke 회귀 테스트 변경을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
