### PR TITLE
[CI] tracked 문서 guard 보강

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,14 @@ on:
       - "back/**"
       - "front/**"
       - "deploy/**"
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - "GEMINI.md"
+      - "CURSOR.md"
+      - "COPILOT.md"
+      - "docs/**"
       - "tools/guards/check-forbidden-tracked-files.sh"
+      - "tools/test/check-forbidden-tracked-files.test.sh"
       - ".github/workflows/**"
 
 permissions:

--- a/.github/workflows/reusable-backend-quality.yml
+++ b/.github/workflows/reusable-backend-quality.yml
@@ -38,6 +38,7 @@ jobs:
               - 'deploy/homeserver/**'
               - 'tools/ci/**'
               - 'tools/guards/check-forbidden-tracked-files.sh'
+              - 'tools/test/check-forbidden-tracked-files.test.sh'
               - '.github/workflows/backend-ci.yml'
               - '.github/workflows/ci.yml'
               - '.github/workflows/deploy.yml'
@@ -45,6 +46,9 @@ jobs:
 
       - name: Guard forbidden AI docs and tool metadata
         run: bash tools/guards/check-forbidden-tracked-files.sh
+
+      - name: Test forbidden tracked file guard
+        run: bash tools/test/check-forbidden-tracked-files.test.sh
 
       - name: Dependency review readiness
         if: github.event_name == 'pull_request'

--- a/tools/guards/check-forbidden-tracked-files.sh
+++ b/tools/guards/check-forbidden-tracked-files.sh
@@ -10,11 +10,40 @@ if [[ "${mode}" != "tracked" && "${mode}" != "--staged" ]]; then
   exit 2
 fi
 
+is_allowed_markdown() {
+  case "$1" in
+    README.md|\
+    .github/pull_request_template.md|\
+    SECURITY.md|\
+    back/PERF_SANITY_REPORT.md|\
+    back/README.md|\
+    back/REFACTORING_ROADMAP.md|\
+    deploy/homeserver/HARDENING.md|\
+    front/.github/CODE_OF_CONDUCT.md|\
+    front/.github/CONTRIBUTING.md|\
+    front/.github/PULL_REQUEST_TEMPLATE.md|\
+    front/README.md|\
+    infra/README.md|\
+    perf/k6/README.md|\
+    tools/templates/agent-plan.compact.md|\
+    tools/templates/bug-report.compact.md)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
 declare -a targets=()
 while IFS= read -r -d '' file; do
   case "${file}" in
-    AGENTS.md|CLAUDE.md|GEMINI.md|CURSOR.md|COPILOT.md|docs/AGENT-CONTEXT.md|docs/agent/*|.cursor/*|.claude/*|.aider/*|.aider*|.windsurf/*|.codex/*|.ai/*)
+    docs/*|AGENTS.md|CLAUDE.md|GEMINI.md|CURSOR.md|COPILOT.md|.cursor/*|.claude/*|.aider/*|.aider*|.windsurf/*|.codex/*|.ai/*)
       targets+=("${file}")
+      ;;
+    *.md)
+      if ! is_allowed_markdown "${file}"; then
+        targets+=("${file}")
+      fi
       ;;
   esac
 done < <(
@@ -29,7 +58,7 @@ if [[ "${#targets[@]}" -eq 0 ]]; then
   exit 0
 fi
 
-echo "[guard] 금지된 AI/agent 문서 경로가 감지되어 중단합니다." >&2
+echo "[guard] 비허용 문서/AI tool metadata가 감지되어 중단합니다." >&2
 for file in "${targets[@]}"; do
   echo " - ${file}" >&2
 done

--- a/tools/test/check-forbidden-tracked-files.test.sh
+++ b/tools/test/check-forbidden-tracked-files.test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+guard="tools/guards/check-forbidden-tracked-files.sh"
+readme_blob="$(git rev-parse HEAD:README.md)"
+guard_output="$(mktemp)"
+trap 'rm -f "${guard_output}"' EXIT
+
+run_with_temp_index() {
+  local command="$1"
+  local tmp_index
+  tmp_index="$(mktemp)"
+  GIT_INDEX_FILE="${tmp_index}" git read-tree HEAD
+  set +e
+  GIT_INDEX_FILE="${tmp_index}" bash -c "${command}"
+  local status=$?
+  set -e
+  rm -f "${tmp_index}"
+  return "${status}"
+}
+
+if ! bash "${guard}"; then
+  echo "[test] expected current tracked files to pass forbidden-doc guard" >&2
+  exit 1
+fi
+
+if run_with_temp_index "git update-index --add --cacheinfo 100644 '${readme_blob}' docs/leak.md && bash '${guard}' >'${guard_output}' 2>&1"; then
+  echo "[test] expected tracked docs/leak.md to be rejected" >&2
+  exit 1
+fi
+
+if run_with_temp_index "git update-index --add --cacheinfo 100644 '${readme_blob}' back/new-report.md && bash '${guard}' >'${guard_output}' 2>&1"; then
+  echo "[test] expected tracked back/new-report.md to be rejected" >&2
+  exit 1
+fi
+
+if run_with_temp_index "git update-index --add --cacheinfo 100644 '${readme_blob}' docs/leak.md && bash '${guard}' --staged >'${guard_output}' 2>&1"; then
+  echo "[test] expected staged docs/leak.md to be rejected" >&2
+  exit 1
+fi
+
+echo "[test] forbidden tracked docs guard passed"


### PR DESCRIPTION
## 관련 이슈

close #317

## 작업 배경

- PR #318에서 `docs/superpowers/*` 추적 문서 7개는 제거됐지만, 재발 방지 guard 커밋은 merge 이후 별도 follow-up으로 남았습니다.
- `.gitignore`만으로는 이미 추적되거나 force-add된 문서를 막지 못하므로, 현재 main의 기존 Markdown allowlist 밖 신규 문서와 `docs/*` 추적을 CI guard에서 차단합니다.

## 작업 내용

- `tools/guards/check-forbidden-tracked-files.sh`가 `docs/*`, AI metadata, 기존 allowlist 밖 `*.md`를 금지하도록 확장했습니다.
- `tools/test/check-forbidden-tracked-files.test.sh`를 추가해 tracked/staged `docs/leak.md`와 신규 `back/new-report.md`가 실패하는지 검증합니다.
- CI push path와 backend reusable workflow에 guard test를 연결했습니다.

## 검증

- 실행한 명령과 결과:
  - `bash tools/test/check-forbidden-tracked-files.test.sh`
  - `bash tools/guards/check-forbidden-tracked-files.sh`
  - `git diff --name-status origin/main...HEAD`
  - `git ls-files docs/superpowers`
  - `git commit -m "ci(docs): tracked 문서 guard 보강"` (pre-commit `yarn contracts:check` 통과)
  - `gh pr view 320 --repo AquilaXk/aquila-blog --json url,number,state,baseRefName,headRefName,title,commits`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: CI guard 보강이며 런타임 영향은 없습니다.
- 롤백 방법: 필요 시 guard 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
