### PR TITLE
[Fix] 글수정 selection affordance와 code block 후속 복구

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -941,6 +941,168 @@ test.describe("block editor authoring flow", () => {
     await expect(codeBlock.locator(".aq-code-highlight-layer .token.keyword").first()).toBeVisible()
   })
 
+  test("실제 /editor/[id] 수정 진입은 보이지 않는 placeholder 코드 fence를 pretty-code 원문으로 복구한다", async ({
+    page,
+  }) => {
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const staleContent = [
+      "코드 placeholder 복구 대상입니다.",
+      "",
+      "```ts",
+      "\u200B",
+      "```",
+      "",
+      "복구 뒤 문단입니다.",
+    ].join("\n")
+    const prettyCodeHtml = [
+      '<section><p>본문 앞 HTML</p>',
+      '<div class="aq-code-block" data-language="ts" data-raw-code="const invisibleRestored = 306;&#10;return invisibleRestored">',
+      '<pre class="aq-code aq-pretty-pre">',
+      '<code class="language-ts"></code>',
+      "</pre></div></section>",
+    ].join("")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/993", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 993,
+          version: 9,
+          title: "코드 invisible placeholder 복구 글",
+          content: staleContent,
+          contentHtml: prettyCodeHtml,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/993")
+
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("코드 invisible placeholder 복구 글")
+    const codeBlock = page.locator(".aq-code-shell").first()
+    await expect(codeBlock).toBeVisible({ timeout: 15_000 })
+    await expect(codeBlock.locator(".aq-code-highlight-layer")).toContainText("const invisibleRestored = 306;")
+    await expect(codeBlock.locator(".aq-code-highlight-layer")).toContainText("return invisibleRestored")
+  })
+
+  test("실제 /editor/[id] 텍스트 선택 후 block handle은 wheel scroll 중 선택 문단을 따라간다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const targetLabel = "edit route text selection scroll anchor"
+    const paragraphs = Array.from({ length: 38 }, (_, index) =>
+      index === 10
+        ? `${targetLabel} ${index + 1}. 선택한 텍스트의 좌측 block handle이 scroll 동안 같은 문단에 붙어야 합니다.`
+        : `text selection scroll paragraph ${index + 1}. 좌측 block handle scroll anchoring을 확인합니다.`
+    )
+    const content = paragraphs.join("\n\n")
+    const contentHtml = paragraphs.map((paragraph) => `<p>${paragraph}</p>`).join("")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/994", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 994,
+          version: 10,
+          title: "텍스트 선택 scroll handle 회귀 글",
+          content,
+          contentHtml,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/994")
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("텍스트 선택 scroll handle 회귀 글")
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    const targetParagraph = editor.locator("p", { hasText: targetLabel }).first()
+    await targetParagraph.scrollIntoViewIfNeeded()
+    const targetBox = await targetParagraph.boundingBox()
+    if (!targetBox) {
+      throw new Error("text selection target paragraph metrics are missing")
+    }
+
+    const textY = targetBox.y + Math.min(targetBox.height / 2, 18)
+    await page.mouse.move(targetBox.x + 36, textY)
+    await page.mouse.down()
+    await page.mouse.move(targetBox.x + Math.min(targetBox.width - 24, 430), textY, { steps: 12 })
+    await page.mouse.up()
+
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    const handleBox = await dragHandle.boundingBox()
+    if (!handleBox) {
+      throw new Error("text selection block handle metrics are missing")
+    }
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2)
+
+    const readHandleGeometry = async () =>
+      page.evaluate((label) => {
+        const paragraph =
+          Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] p")).find(
+            (element) => element.textContent?.includes(label)
+          ) ?? null
+        const handle = document.querySelector<HTMLElement>("[data-testid='block-drag-handle']")
+        if (!paragraph || !handle) return null
+        const paragraphRect = paragraph.getBoundingClientRect()
+        const handleRect = handle.getBoundingClientRect()
+        const handleStyle = window.getComputedStyle(handle)
+        return {
+          scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+          paragraphTop: paragraphRect.top,
+          handleTop: handleRect.top,
+          handleVisible:
+            handleRect.width > 0 &&
+            handleRect.height > 0 &&
+            handleStyle.display !== "none" &&
+            handleStyle.visibility !== "hidden" &&
+            Number.parseFloat(handleStyle.opacity || "1") > 0.5,
+        }
+      }, targetLabel)
+
+    const beforeGeometry = await readHandleGeometry()
+    if (!beforeGeometry) {
+      throw new Error("text selection handle geometry is missing before scroll")
+    }
+
+    await page.mouse.wheel(0, 360)
+    await page.waitForTimeout(360)
+
+    const afterGeometry = await readHandleGeometry()
+    if (!afterGeometry) {
+      throw new Error("text selection handle geometry is missing after scroll")
+    }
+    const paragraphDelta = afterGeometry.paragraphTop - beforeGeometry.paragraphTop
+    expect(afterGeometry.scrollTop).toBeGreaterThan(beforeGeometry.scrollTop + 80)
+    expect(afterGeometry.handleVisible).toBe(true)
+    expect(Math.abs(afterGeometry.handleTop - beforeGeometry.handleTop - paragraphDelta)).toBeLessThanOrEqual(12)
+  })
+
   test("실제 /editor/[id] 수정 진입은 본문 hover scroll, 선택 block affordance, code 원문을 유지한다", async ({
     page,
   }) => {
@@ -964,11 +1126,14 @@ test.describe("block editor authoring flow", () => {
       paragraphs.slice(12).join("\n\n"),
     ].join("\n\n")
     const prettyCodeHtml = [
-      '<section><p>본문 앞 HTML</p>',
+      "<section>",
+      ...paragraphs.slice(0, 12).map((paragraph) => `<p>${paragraph}</p>`),
       '<div class="aq-code-block" data-language="ts" data-raw-code="const restored = 305;&#10;return restored">',
       '<pre class="aq-code aq-pretty-pre">',
       '<code class="language-ts"></code>',
-      '</pre></div></section>',
+      '</pre></div>',
+      ...paragraphs.slice(12).map((paragraph) => `<p>${paragraph}</p>`),
+      "</section>",
     ].join("")
 
     await page.route("**/member/api/v1/auth/me", async (route) => {

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -531,6 +531,7 @@ const BlockEditorEngine = ({
   const [selectedBlockIndex, setSelectedBlockIndex] = useState<number | null>(null)
   const [clickedBlockIndex, setClickedBlockIndex] = useState<number | null>(null)
   const [selectedBlockNodeIndex, setSelectedBlockNodeIndex] = useState<number | null>(null)
+  const [textSelectionBlockIndex, setTextSelectionBlockIndex] = useState<number | null>(null)
   const selectedBlockNodeIndexRef = useRef<number | null>(null)
   const keyboardBlockSelectionStickyRef = useRef(false)
   const [blockHandleState, setBlockHandleState] = useState<TopLevelBlockHandleState>({
@@ -997,6 +998,7 @@ const BlockEditorEngine = ({
     selectedBlockNodeIndexRef.current = null
     setClickedBlockIndex(null)
     setSelectedBlockNodeIndex(null)
+    setTextSelectionBlockIndex(null)
     syncSelectedBlockNodeSurface(null)
   }, [syncSelectedBlockNodeSurface])
 
@@ -1113,6 +1115,7 @@ const BlockEditorEngine = ({
       setClickedBlockIndex(null)
       setSelectedBlockIndex(blockIndex)
       setSelectedBlockNodeIndex(blockIndex)
+      setTextSelectionBlockIndex(null)
       syncSelectedBlockNodeSurface(blockIndex)
       setSelectionTick((prev) => prev + 1)
       clearNativeTextSelection()
@@ -2535,8 +2538,8 @@ const BlockEditorEngine = ({
     })
   }, [focusTopLevelBlock])
 
-  const replaceEditorDocFromExternalValue = useCallback((nextDoc: BlockEditorDoc) => {
-    const currentEditor = editorRef.current
+  const replaceEditorDocFromExternalValue = useCallback((nextDoc: BlockEditorDoc, fallbackEditor?: TiptapEditor | null) => {
+    const currentEditor = editorRef.current ?? fallbackEditor
     if (!currentEditor) return
 
     currentEditor.chain().setMeta("addToHistory", false).setContent(nextDoc, { emitUpdate: false }).run()
@@ -3177,7 +3180,7 @@ const BlockEditorEngine = ({
       const selectedNestedListItemSignature = selectedNestedListItemContext
         ? `${selectedNestedListItemContext.listBlockIndex}:${selectedNestedListItemContext.listPath.join(".")}:${selectedNestedListItemContext.itemIndex}`
         : "none"
-      const nextSignature = `${nextBlockIndex ?? "none"}:${isTopLevelBlockNodeSelection ? 1 : 0}:${isNestedListItemNodeSelection ? 1 : 0}:${keyboardBlockSelectionStickyRef.current ? 1 : 0}:${inTableContext}:${selectedNestedListItemSignature}`
+      const nextSignature = `${nextBlockIndex ?? "none"}:${hasTextRangeSelection ? 1 : 0}:${isTopLevelBlockNodeSelection ? 1 : 0}:${isNestedListItemNodeSelection ? 1 : 0}:${keyboardBlockSelectionStickyRef.current ? 1 : 0}:${inTableContext}:${selectedNestedListItemSignature}`
       if (nextSignature === selectionUiSignatureRef.current) {
         return
       }
@@ -3187,9 +3190,11 @@ const BlockEditorEngine = ({
       if (hasTextRangeSelection && !selectedNestedListItemContext) {
         setClickedBlockIndex(null)
         setSelectedBlockNodeIndex(null)
+        setTextSelectionBlockIndex(nextBlockIndex)
         setSelectedListItemContext(null)
         return
       }
+      setTextSelectionBlockIndex(null)
       if (isNestedListItemNodeSelection) {
         setClickedBlockIndex(null)
         setSelectedBlockNodeIndex(null)
@@ -3227,6 +3232,7 @@ const BlockEditorEngine = ({
         if (disposed || editor.isFocused) return
         setClickedBlockIndex(null)
         setSelectedBlockIndex(null)
+        setTextSelectionBlockIndex(null)
         if (!keyboardBlockSelectionStickyRef.current) {
           setSelectedBlockNodeIndex(null)
         }
@@ -3825,7 +3831,7 @@ const BlockEditorEngine = ({
 
     discardPendingMarkdownCommit()
     const nextDoc = downgradeDisabledFeatureNodes(parseMarkdownToEditorDoc(value), enableMermaidBlocks)
-    replaceEditorDocFromExternalValue(nextDoc)
+    replaceEditorDocFromExternalValue(nextDoc, editor)
   }, [discardPendingMarkdownCommit, editor, enableMermaidBlocks, hasExternalMarkdownChanged, replaceEditorDocFromExternalValue, value])
 
   useEffect(
@@ -5628,7 +5634,7 @@ const BlockEditorEngine = ({
         ? selectedBlockIndex
         : stickySelectionActive
           ? selectedBlockNodeIndex
-          : hoveredBlockIndex
+          : textSelectionBlockIndex ?? hoveredBlockIndex
     const hideBlockHandle = () =>
       setBlockHandleState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
     const hasOuterBlockSelectionIntent = blockIndex !== null
@@ -5672,9 +5678,7 @@ const BlockEditorEngine = ({
     const blockTarget = resolveCachedBlockRect(blockIndex)
     const blockElement = blockTarget?.element ?? null
     const canShowHandle = isTopLevelBlockHandleEligible(blockIndex)
-    const shouldShow = Boolean(
-      blockElement && canShowHandle && (isCoarsePointer || stickySelectionActive || hoveredBlockIndex !== null)
-    )
+    const shouldShow = Boolean(blockElement && canShowHandle && (isCoarsePointer || stickySelectionActive || textSelectionBlockIndex !== null || hoveredBlockIndex !== null))
 
     if (!shouldShow || !blockElement) {
       hideBlockHandle()
@@ -5718,6 +5722,7 @@ const BlockEditorEngine = ({
     selectionTick,
     tableMenuState,
     tableAffordanceVisibility.visible,
+    textSelectionBlockIndex,
     resolveEffectiveSelectedListItemContext,
   ])
 

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -726,6 +726,15 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
 
     let nextGuardState = consumeGuardOnExpectedUpdate(blockEditorLoadGuardStateRef.current, nextMarkdown)
 
+    if (shouldIgnoreBlockEditorEmptyUpdate({
+      nextMarkdown,
+      currentMarkdown: previousMarkdown,
+      guardState: nextGuardState,
+    })) {
+      blockEditorLoadGuardStateRef.current = markGuardEmptyUpdateIgnored(nextGuardState)
+      return
+    }
+
     if (meta?.editorFocused) {
       nextGuardState = {
         ...nextGuardState,
@@ -737,15 +746,6 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
       startPostContentTransition(() => {
         setPostContent(nextMarkdown)
       })
-      return
-    }
-
-    if (shouldIgnoreBlockEditorEmptyUpdate({
-      nextMarkdown,
-      currentMarkdown: previousMarkdown,
-      guardState: nextGuardState,
-    })) {
-      blockEditorLoadGuardStateRef.current = markGuardEmptyUpdateIgnored(nextGuardState)
       return
     }
 
@@ -1041,6 +1041,7 @@ export const EditorStudioPage: NextPage<AdminPageProps> = ({ initialMember }) =>
   const syncEditorMeta = useCallback((content: string, contentHtml?: string | null) => {
     const snapshot = resolveEditorMetaSnapshot(content, contentHtml)
     blockEditorLoadGuardStateRef.current = createBlockEditorLoadGuardState(snapshot.body)
+    postContentLiveRef.current = snapshot.body
     setPostContent(snapshot.body)
     setPostSummary(snapshot.summary)
     setPostThumbnailUrl(snapshot.thumbnailUrl)

--- a/front/src/routes/Admin/editorStudioMetaModel.ts
+++ b/front/src/routes/Admin/editorStudioMetaModel.ts
@@ -62,6 +62,7 @@ const FENCED_CODE_BLOCK_REGEX = /(^|\n)(`{3,}|~{3,})([^\n]*)\n(?:([\s\S]*?)\n)?\
 const HTML_CODE_RAW_ATTRIBUTE_TAG_REGEX =
   /<([a-z][a-z0-9:-]*)\b([^>]*(?:data-raw-code|data-prism-source)[^>]*)>/gi
 const HTML_ATTRIBUTE_REGEX = /\s([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>`]+)))?/g
+const INVISIBLE_CODE_PLACEHOLDER_REGEX = /[\u00A0\u200B-\u200D\u2060\uFEFF]/g
 
 export const PREVIEW_SUMMARY_MAX_LENGTH = 150
 export const PREVIEW_SUMMARY_MAX_CONTENT_LENGTH = 50_000
@@ -321,13 +322,16 @@ const resolveEditorBodyFallback = (content: string, parsedBody: string) => {
   return inlineMetadataSplit.body.trim().length > 0 ? inlineMetadataSplit.body : parsedBody
 }
 
+const isCodeFenceBodyVisiblyEmpty = (value: string) =>
+  value.replace(INVISIBLE_CODE_PLACEHOLDER_REGEX, "").trim().length === 0
+
 const extractNonEmptyFencedCodeBlocks = (content: string) => {
   const normalized = content.replace(/\r\n?/g, "\n")
   const blocks: string[] = []
 
   normalized.replace(FENCED_CODE_BLOCK_REGEX, (_match, _leading, marker, info, codeBody) => {
     const body = String(codeBody ?? "")
-    if (body.trim().length > 0) {
+    if (!isCodeFenceBodyVisiblyEmpty(body)) {
       blocks.push(`${marker}${info}\n${body}\n${marker}`)
     }
     return _match
@@ -400,7 +404,7 @@ export const restoreEmptyFencedCodeBlocks = (content: string, recoveredContent: 
   const normalized = content.replace(/\r\n?/g, "\n")
 
   return normalized.replace(FENCED_CODE_BLOCK_REGEX, (match, leading, _marker, _info, codeBody) => {
-    if (String(codeBody ?? "").trim().length > 0) return match
+    if (!isCodeFenceBodyVisiblyEmpty(String(codeBody ?? ""))) return match
 
     const recoveredBlock = recoveredBlocks[nextRecoveredIndex]
     if (!recoveredBlock) return match


### PR DESCRIPTION
## 관련 이슈

close #305

## 작업 배경

- `/editor/[id]` 수정 진입에서 code block 원문이 비어 보이는 후속 회귀를 복구합니다.
- 텍스트 선택 상태의 좌측 block handle이 wheel scroll 중 사라지거나 선택 문단과 분리되는 문제를 고정합니다.

## 작업 내용

- zero-width placeholder만 들어간 fenced code block도 빈 code fence로 판정해 `contentHtml` raw code fallback을 적용합니다.
- 수정 글 로드 직후 focused empty update와 editorRef 초기화 타이밍 때문에 본문 주입이 누락되지 않도록 load guard와 외부 markdown sync를 보강했습니다.
- text range selection의 block index를 별도 anchor로 유지해 hover rail pointerleave 이후에도 block handle이 선택 문단 rect를 따라가게 했습니다.
- `/editor/[id]` 실제 route 회귀 테스트를 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3101 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "pretty-code 원문|보이지 않는 placeholder|텍스트 선택 후 block handle|본문 hover scroll" --workers=1 --repeat-each=3`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3101 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3101 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts e2e/editor-load-sync-guard.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3101 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=2`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: editor load guard가 수정 진입 직후의 실제 빈 입력을 짧은 guard window 안에서 무시할 수 있습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 기존 editor 로드/selection 동작으로 되돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
