### PR TITLE
[Fix] 데스크톱 상세 목차 밀도 완화

### DIFF
--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -1562,6 +1562,24 @@ test("상세 우측 목차는 긴 목록에서도 active 항목을 자동으로 
   await expect(page.getByRole("heading", { name: "상세 목차 자동 표시 테스트" })).toBeVisible()
   const rightToc = page.locator('aside.rightRail nav[aria-label="목차"]')
   await expect(rightToc.getByRole("button", { name: "자동 표시 섹션 32" })).toHaveCount(1)
+  const tocDensityMetrics = await rightToc.locator("ol").evaluate((list) => {
+    const listRect = list.getBoundingClientRect()
+    const rowHeights = Array.from(list.querySelectorAll<HTMLElement>("button"))
+      .slice(0, 8)
+      .map((button) => button.getBoundingClientRect().height)
+    const firstButton = list.querySelector<HTMLElement>("button")
+    const firstButtonStyle = firstButton ? window.getComputedStyle(firstButton) : null
+
+    return {
+      listHeight: listRect.height,
+      maxRowHeight: Math.max(...rowHeights),
+      rowFontSize: firstButtonStyle ? Number.parseFloat(firstButtonStyle.fontSize) : 0,
+    }
+  })
+
+  expect(tocDensityMetrics.listHeight).toBeLessThanOrEqual(560)
+  expect(tocDensityMetrics.maxRowHeight).toBeLessThanOrEqual(34)
+  expect(tocDensityMetrics.rowFontSize).toBeLessThanOrEqual(13.5)
 
   await page.evaluate(() => {
     const target = Array.from(document.querySelectorAll<HTMLElement>("article h2"))

--- a/front/src/routes/Detail/PostDetail/index.tsx
+++ b/front/src/routes/Detail/PostDetail/index.tsx
@@ -1557,7 +1557,7 @@ const StyledWrapper = styled.div`
       align-items: center;
       justify-content: space-between;
       gap: 0.75rem;
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.42rem;
     }
 
     .rightRailTitleGroup {
@@ -1608,7 +1608,7 @@ const StyledWrapper = styled.div`
       padding: 0;
       list-style: none;
       display: block;
-      max-height: calc(100vh - 8.8rem);
+      max-height: min(34rem, calc(100vh - 10rem));
       overflow-y: auto;
       overflow-x: hidden;
     }
@@ -1619,28 +1619,28 @@ const StyledWrapper = styled.div`
     }
 
     li[data-level="3"] button {
-      padding-left: 0.62rem;
-      font-size: 0.82rem;
+      padding-left: 0.54rem;
+      font-size: 0.78rem;
     }
 
     li[data-level="4"] button {
-      padding-left: 1.02rem;
-      font-size: 0.79rem;
+      padding-left: 0.88rem;
+      font-size: 0.75rem;
     }
 
     button {
       width: 100%;
       text-align: left;
       border: 0;
-      border-radius: 10px;
-      min-height: 38px;
+      border-radius: 8px;
+      min-height: 32px;
       box-sizing: border-box;
       max-width: 100%;
-      padding: 0.52rem 0.82rem 0.52rem 0.12rem;
+      padding: 0.34rem 0.68rem 0.34rem 0.1rem;
       background: transparent;
       color: ${({ theme }) => theme.colors.gray9};
-      font-size: 0.875rem;
-      line-height: 1.5;
+      font-size: 0.8125rem;
+      line-height: 1.36;
       cursor: pointer;
       white-space: normal;
       overflow-wrap: anywhere;
@@ -1660,8 +1660,8 @@ const StyledWrapper = styled.div`
       content: "";
       position: absolute;
       left: -1.18rem;
-      top: 0.24rem;
-      bottom: 0.24rem;
+      top: 0.18rem;
+      bottom: 0.18rem;
       width: 1px;
       opacity: 0;
       background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.accentBorder)};


### PR DESCRIPTION
## 관련 이슈

close #316

## 작업 배경

- 데스크톱 공개 상세 우측 TOC의 긴 버튼 스택 밀도를 낮춰 본문과의 시각적 경쟁을 줄였습니다.
- 긴 TOC에서도 active 항목 auto-reveal이 유지되도록 기존 smoke 테스트에 compact density 계약을 추가했습니다.

## 작업 내용

- 1440px 이상 우측 TOC list max-height를 `min(34rem, calc(100vh - 10rem))`로 제한해 첫 viewport 하단까지 과하게 늘어지지 않게 했습니다.
- TOC row min-height, padding, font-size, nested heading indent를 줄여 compact 보조 내비게이션처럼 보이도록 조정했습니다.
- smoke 테스트에서 TOC list height, row height, row font-size 기준을 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts --grep "상세 우측 목차는 긴 목록에서도 active 항목을 자동으로 드러낸다" --workers=1` (red 확인 후 green 통과)
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:perf`
  - commit hook 재검증: `yarn build`, `node scripts/check-bundle-size.mjs`, `yarn test:e2e:smoke` 통과
  - Browser `/posts/507` 1440x900 확인: `listHeight=544`, `maxRowHeight=32`, `rowFontSize=13`, console error/warn 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 데스크톱 TOC에서 한 번에 보이는 섹션 수가 줄어들며, 긴 목차는 내부 스크롤 의존도가 커집니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 기존 우측 TOC row density와 max-height로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
