### PR TITLE
[Fix] 모바일 어드민 상단 유틸리티 first fold 점유 축소

### DIFF
--- a/front/e2e/mobile-layout.spec.ts
+++ b/front/e2e/mobile-layout.spec.ts
@@ -399,6 +399,45 @@ test.beforeEach(async ({ page }) => {
   await mockAnonymousSession(page)
 })
 
+test("모바일 어드민 유틸리티는 검색을 접어 first fold를 보존한다", async ({ page }) => {
+  await page.goto("/admin/tools")
+
+  await expect(page.getByRole("heading", { name: /문제 확인과 복구/ })).toBeVisible()
+  await expect(page.getByRole("navigation", { name: "관리자 바로가기" })).toBeVisible()
+  await expect(page.getByRole("link", { name: "글 관리" })).toBeVisible()
+
+  const searchToggle = page.getByRole("button", { name: "관리자 검색 열기" })
+  await expect(searchToggle).toBeVisible()
+  await expect(page.getByRole("searchbox", { name: "관리자 검색" })).toBeHidden()
+
+  const collapsedSnapshot = await page.evaluate(() => {
+    const compactNav = document.querySelector<HTMLElement>('nav[aria-label="관리자 바로가기"]')
+    const utility = compactNav?.closest("header") as HTMLElement | null
+    const heading = document.querySelector("h1")
+    const utilityRect = utility?.getBoundingClientRect()
+    const headingRect = heading?.getBoundingClientRect()
+
+    return {
+      utilityHeight: utilityRect?.height ?? 0,
+      utilityBottom: utilityRect?.bottom ?? 0,
+      headingTop: headingRect?.top ?? 0,
+      bodyScrollWidth: document.body.scrollWidth,
+      viewportWidth: window.innerWidth,
+    }
+  })
+
+  expect(collapsedSnapshot.utilityHeight).toBeLessThanOrEqual(92)
+  expect(collapsedSnapshot.headingTop).toBeLessThanOrEqual(205)
+  expect(collapsedSnapshot.bodyScrollWidth).toBeLessThanOrEqual(collapsedSnapshot.viewportWidth)
+
+  await searchToggle.click()
+  const searchInput = page.getByRole("searchbox", { name: "관리자 검색" })
+  await expect(searchInput).toBeVisible()
+  await searchInput.fill("글 관리")
+  await searchInput.press("Enter")
+  await expect(page).toHaveURL(/\/admin\/posts(?:$|\?)/)
+})
+
 test("iPhone 15 Pro 메인 피드는 카드 overflow 없이 viewport 내부에 렌더된다", async ({ page }) => {
   await mockFeedEndpoints(page)
 

--- a/front/src/routes/Admin/AdminUtilityBar.tsx
+++ b/front/src/routes/Admin/AdminUtilityBar.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled"
 import Link from "next/link"
 import { useRouter } from "next/router"
-import { type FormEvent, useMemo, useState } from "react"
+import { type FormEvent, type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react"
 import AppIcon, { type IconName } from "src/components/icons/AppIcon"
 import { pushRoute } from "src/libs/router"
 
@@ -38,6 +38,8 @@ const matchesShortcut = (item: ShortcutItem, query: string) => {
 const AdminUtilityBar = ({ navItems, currentLabel }: Props) => {
   const router = useRouter()
   const [query, setQuery] = useState("")
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
   const shortcutItems = useMemo<ShortcutItem[]>(
     () => [
       ...navItems.map(({ href, label, icon }) => ({ href, label, icon })),
@@ -52,6 +54,7 @@ const AdminUtilityBar = ({ navItems, currentLabel }: Props) => {
 
   const navigate = (href: string) => {
     setQuery("")
+    setIsSearchOpen(false)
     void pushRoute(router, href)
   }
 
@@ -62,27 +65,44 @@ const AdminUtilityBar = ({ navItems, currentLabel }: Props) => {
     navigate(nextMatch.href)
   }
 
+  const handleSearchToggle = () => {
+    setIsSearchOpen((current) => !current)
+  }
+
+  const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Escape") return
+    setQuery("")
+    setIsSearchOpen(false)
+  }
+
+  useEffect(() => {
+    if (!isSearchOpen) return
+    searchInputRef.current?.focus()
+  }, [isSearchOpen])
+
   return (
-    <UtilityBar>
+    <UtilityBar data-search-open={isSearchOpen ? "true" : "false"}>
       <CompactNav aria-label="관리자 바로가기">
         {navItems.map((item) => (
           <Link key={`compact-${item.key}`} href={item.href} passHref legacyBehavior>
-            <CompactNavLink data-active={item.active ? "true" : "false"} title={item.label}>
+            <CompactNavLink data-active={item.active ? "true" : "false"} title={item.label} aria-label={item.label}>
               <AppIcon name={item.icon} />
             </CompactNavLink>
           </Link>
         ))}
       </CompactNav>
 
-      <SearchForm role="search" onSubmit={handleSearchSubmit}>
+      <SearchForm role="search" onSubmit={handleSearchSubmit} data-open={isSearchOpen ? "true" : "false"}>
         <SearchField>
           <span className="searchIcon" aria-hidden="true">
             <AppIcon name="search" />
           </span>
           <SearchInput
+            ref={searchInputRef}
             type="search"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleSearchKeyDown}
             placeholder="페이지 검색"
             aria-label="관리자 검색"
           />
@@ -90,6 +110,14 @@ const AdminUtilityBar = ({ navItems, currentLabel }: Props) => {
       </SearchForm>
 
       <UtilityActions>
+        <SearchToggleButton
+          type="button"
+          aria-label={isSearchOpen ? "관리자 검색 닫기" : "관리자 검색 열기"}
+          aria-expanded={isSearchOpen}
+          onClick={handleSearchToggle}
+        >
+          <AppIcon name="search" />
+        </SearchToggleButton>
         <CurrentViewChip aria-label="현재 화면">
           <span>현재</span>
           <strong>{currentLabel}</strong>
@@ -122,8 +150,15 @@ const UtilityBar = styled.header`
 
   @media (max-width: 720px) {
     top: calc(var(--app-header-height, 73px) + 0.65rem);
-    flex-direction: column;
-    align-items: stretch;
+    position: sticky;
+    align-items: center;
+    gap: 0.48rem;
+    padding: 0.58rem 0.64rem;
+    border-radius: 18px;
+
+    &[data-search-open="true"] {
+      margin-bottom: 3.15rem;
+    }
   }
 `
 
@@ -138,7 +173,9 @@ const CompactNav = styled.nav`
   }
 
   @media (max-width: 720px) {
-    width: 100%;
+    width: auto;
+    flex: 1;
+    min-width: 0;
     overflow-x: auto;
     padding-bottom: 0.12rem;
     scrollbar-width: none;
@@ -172,6 +209,19 @@ const CompactNavLink = styled.a`
 const SearchForm = styled.form`
   flex: 1;
   min-width: 0;
+
+  @media (max-width: 720px) {
+    display: none;
+    position: absolute;
+    top: calc(100% + 0.42rem);
+    left: 0;
+    right: 0;
+    z-index: 2;
+
+    &[data-open="true"] {
+      display: block;
+    }
+  }
 `
 
 const SearchField = styled.div`
@@ -187,6 +237,14 @@ const SearchField = styled.div`
     align-items: center;
     justify-content: center;
     pointer-events: none;
+  }
+
+  @media (max-width: 720px) {
+    border-radius: 999px;
+    box-shadow: ${({ theme }) =>
+      theme.scheme === "light"
+        ? "0 14px 28px rgba(15, 23, 42, 0.12)"
+        : "0 16px 30px rgba(0, 0, 0, 0.32)"};
   }
 `
 
@@ -221,7 +279,37 @@ const UtilityActions = styled.div`
 
   @media (max-width: 720px) {
     justify-content: flex-start;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    flex-shrink: 0;
+  }
+`
+
+const SearchToggleButton = styled.button`
+  display: none;
+
+  @media (max-width: 720px) {
+    width: 2.75rem;
+    height: 2.75rem;
+    border: 1px solid ${({ theme }) => theme.colors.gray4};
+    border-radius: 15px;
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+    background: ${({ theme }) =>
+      theme.scheme === "light" ? "rgba(243, 246, 250, 0.92)" : "rgba(31, 31, 31, 0.92)"};
+    color: ${({ theme }) => theme.colors.gray11};
+    cursor: pointer;
+
+    &[aria-expanded="true"] {
+      border-color: ${({ theme }) => theme.colors.gray6};
+      background: ${({ theme }) => theme.colors.gray1};
+      color: ${({ theme }) => theme.colors.gray12};
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 4px rgba(148, 163, 184, 0.16);
+    }
   }
 `
 


### PR DESCRIPTION
## 관련 이슈

close #325

## 작업 배경

- 모바일 어드민 utility bar에서 검색 입력을 기본 접힘 상태로 낮춰 first fold 점유를 줄였습니다.
- compact nav 직접 이동은 유지하고 검색 버튼을 열었을 때만 검색 패널이 나타나도록 정리했습니다.

## 작업 내용

- 720px 이하에서 검색 입력을 absolute 검색 패널로 전환하고 기본 utility 높이를 줄였습니다.
- compact nav 링크에 접근 가능한 이름을 부여했습니다.
- 모바일 회귀 테스트로 utility 높이, h1 진입 위치, 검색 토글, 검색 이동을 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/mobile-layout.spec.ts --grep "모바일 어드민 유틸리티는 검색을 접어 first fold를 보존한다" --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front test:e2e:smoke`
  - Browser `/admin/tools` 393x852 확인: collapsed utility height 66.46px, h1 top 178.65px, opened search does not overlap heading, console warn/error 0건

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 모바일 검색 패널이 열린 상태에서 화면 상단 공간이 일시적으로 늘어납니다.
- 롤백 방법: 이 PR revert 후 기존 inline 검색 입력 배치로 복귀합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
