### PR TITLE
[Fix] 어드민 글 목록 first fold에서 목록 본문 우선 노출

### DIFF
--- a/front/e2e/mobile-layout.spec.ts
+++ b/front/e2e/mobile-layout.spec.ts
@@ -197,6 +197,81 @@ const MOBILE_TAG_ENTRIES = Array.from({ length: 14 }, (_, index) => ({
   count: 14 - index,
 }))
 
+const ADMIN_MEMBER_FIXTURE = {
+  id: 1,
+  username: "aquila",
+  nickname: "aquila",
+  isAdmin: true,
+  profileImageUrl: "/avatar.png",
+  profileImageDirectUrl: "/avatar.png",
+}
+
+const ADMIN_POST_FIXTURES = Array.from({ length: 6 }, (_, index) => ({
+  id: 3200 + index,
+  title: index === 0 ? "First fold 운영 점검" : `관리자 글 목록 회귀 ${index}`,
+  authorName: "관리자",
+  authorProfileImgUrl: "/avatar.png",
+  published: index % 2 === 0,
+  listed: index % 3 !== 0,
+  tempDraft: false,
+  createdAt: `2026-05-${String(10 + index).padStart(2, "0")}T01:00:00Z`,
+  modifiedAt: `2026-05-${String(20 - index).padStart(2, "0")}T08:30:00Z`,
+}))
+
+const createAdminPostPage = () => ({
+  content: ADMIN_POST_FIXTURES,
+  pageable: {
+    pageNumber: 0,
+    pageSize: 20,
+    totalElements: ADMIN_POST_FIXTURES.length,
+    totalPages: 1,
+  },
+})
+
+const mockAdminPostsWorkspaceEndpoints = async (page: Page) => {
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(ADMIN_MEMBER_FIXTURE),
+    })
+  })
+
+  await page.route("**/post/api/v1/adm/posts**", async (route) => {
+    const url = new URL(route.request().url())
+
+    if (url.pathname.endsWith("/bootstrap")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          member: ADMIN_MEMBER_FIXTURE,
+          firstPage: createAdminPostPage(),
+        }),
+      })
+      return
+    }
+
+    if (url.pathname.includes("/deleted")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          content: [],
+          pageable: { pageNumber: 0, pageSize: 20, totalElements: 0, totalPages: 0 },
+        }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(createAdminPostPage()),
+    })
+  })
+}
+
 const mockFeedEndpoints = async (page: Page) => {
   await page.route("**/post/api/v1/posts/feed**", async (route) => {
     await route.fulfill({
@@ -436,6 +511,45 @@ test("모바일 어드민 유틸리티는 검색을 접어 first fold를 보존�
   await searchInput.fill("글 관리")
   await searchInput.press("Enter")
   await expect(page).toHaveURL(/\/admin\/posts(?:$|\?)/)
+})
+
+test("어드민 글 목록 first fold는 목록 본문을 보조 패널보다 먼저 노출한다", async ({ page }) => {
+  await mockAdminPostsWorkspaceEndpoints(page)
+
+  await page.goto("/admin/posts")
+  await expect(page.getByRole("heading", { name: "글 목록" })).toBeVisible()
+  await expect(page.getByLabel("검색어")).toBeVisible()
+
+  const firstListCard = page.locator("article").filter({ hasText: "First fold 운영 점검" }).first()
+  await expect(firstListCard).toBeVisible()
+
+  const foldSnapshot = await page.evaluate(() => {
+    const search = document.querySelector<HTMLElement>("#workspace-post-search")
+    const firstCard = Array.from(document.querySelectorAll<HTMLElement>("article")).find((element) =>
+      element.textContent?.includes("First fold 운영 점검")
+    )
+    const activityLabel = Array.from(document.querySelectorAll<HTMLElement>("strong")).find(
+      (element) => element.textContent?.trim() === "작업 기록"
+    )
+    const activityPanel = activityLabel?.closest<HTMLElement>("section, div")
+    const searchRect = search?.getBoundingClientRect()
+    const firstCardRect = firstCard?.getBoundingClientRect()
+    const activityRect = activityPanel?.getBoundingClientRect()
+
+    return {
+      viewportHeight: window.innerHeight,
+      searchTop: searchRect?.top ?? Number.POSITIVE_INFINITY,
+      firstCardTop: firstCardRect?.top ?? Number.POSITIVE_INFINITY,
+      activityTop: activityRect?.top ?? Number.POSITIVE_INFINITY,
+      bodyScrollWidth: document.body.scrollWidth,
+      viewportWidth: window.innerWidth,
+    }
+  })
+
+  expect(foldSnapshot.searchTop).toBeLessThanOrEqual(610)
+  expect(foldSnapshot.firstCardTop).toBeLessThan(foldSnapshot.viewportHeight)
+  expect(foldSnapshot.firstCardTop).toBeLessThan(foldSnapshot.activityTop)
+  expect(foldSnapshot.bodyScrollWidth).toBeLessThanOrEqual(foldSnapshot.viewportWidth)
 })
 
 test("iPhone 15 Pro 메인 피드는 카드 overflow 없이 viewport 내부에 렌더된다", async ({ page }) => {

--- a/front/src/routes/Admin/AdminPostsWorkspaceFilterToolbar.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspaceFilterToolbar.tsx
@@ -170,6 +170,8 @@ const GhostButton = styled(AdminTextActionButton)`
 const StickyFilterToolbar = styled.div`
   display: grid;
   gap: 0.72rem;
+  min-width: 0;
+  max-width: 100%;
   padding: 0.88rem 0.92rem;
   border-radius: 16px;
   border: 1px solid ${({ theme }) => theme.colors.gray5};
@@ -194,8 +196,13 @@ const StickyFilterToolbar = styled.div`
 const FilterRail = styled.div`
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
+  min-width: 0;
   gap: 0.75rem;
   align-items: end;
+
+  > * {
+    min-width: 0;
+  }
 
   @media (max-width: 900px) {
     grid-template-columns: 1fr;
@@ -210,6 +217,7 @@ const FilterRail = styled.div`
 
 const ScopeTabs = styled.div`
   display: inline-flex;
+  min-width: 0;
   gap: 0.4rem;
   flex-wrap: wrap;
 
@@ -238,6 +246,7 @@ const ScopeTabButton = styled.button<{ "data-active"?: boolean }>`
 
 const SearchField = styled.div`
   display: grid;
+  min-width: 0;
   gap: 0.3rem;
 
   label {
@@ -347,6 +356,7 @@ const FieldBox = styled.div`
 
 const FilterSummaryBar = styled.div`
   display: flex;
+  min-width: 0;
   align-items: flex-start;
   justify-content: space-between;
   gap: 0.8rem;
@@ -392,6 +402,7 @@ const ToolbarUtilityRow = styled(AdminInlineActionRow)`
 
 const SummaryPillRow = styled.div`
   display: flex;
+  min-width: 0;
   flex-wrap: wrap;
   gap: 0.5rem;
 
@@ -403,6 +414,8 @@ const SummaryPillRow = styled.div`
 const SummaryPill = styled.span<{ "data-tone"?: "neutral" }>`
   display: inline-flex;
   align-items: center;
+  max-width: 100%;
+  min-width: 0;
   min-height: 32px;
   padding: 0 0.72rem;
   border-radius: 999px;
@@ -411,6 +424,8 @@ const SummaryPill = styled.span<{ "data-tone"?: "neutral" }>`
   color: ${({ theme }) => theme.colors.gray11};
   font-size: 0.78rem;
   font-weight: 700;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
 
   @media (max-width: 767px) {
     min-height: 26px;

--- a/front/src/routes/Admin/AdminPostsWorkspaceFilterToolbar.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspaceFilterToolbar.tsx
@@ -179,7 +179,9 @@ const StickyFilterToolbar = styled.div`
   box-shadow: 0 12px 28px rgba(15, 23, 42, 0.1);
 
   @media (max-width: 767px) {
-    padding: 0.8rem 0.82rem;
+    gap: 0.52rem;
+    padding: 0.58rem 0.62rem;
+    border-radius: 12px;
   }
 
   &[data-compact="true"] {
@@ -198,12 +200,24 @@ const FilterRail = styled.div`
   @media (max-width: 900px) {
     grid-template-columns: 1fr;
   }
+
+  @media (max-width: 767px) {
+    grid-template-columns: minmax(7.6rem, 0.55fr) minmax(0, 1fr);
+    gap: 0.5rem;
+    align-items: end;
+  }
 `
 
 const ScopeTabs = styled.div`
   display: inline-flex;
   gap: 0.4rem;
   flex-wrap: wrap;
+
+  @media (max-width: 767px) {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.28rem;
+  }
 `
 
 const ScopeTabButton = styled.button<{ "data-active"?: boolean }>`
@@ -213,6 +227,13 @@ const ScopeTabButton = styled.button<{ "data-active"?: boolean }>`
   background: ${({ theme, "data-active": active }) => (active ? theme.colors.gray1 : theme.colors.gray2)};
   color: ${({ theme }) => theme.colors.gray12};
   border-color: ${({ theme, "data-active": active }) => (active ? theme.colors.gray6 : theme.colors.gray5)};
+
+  @media (max-width: 767px) {
+    min-height: 38px;
+    padding: 0 0.46rem;
+    border-radius: 10px;
+    font-size: 0.78rem;
+  }
 `
 
 const SearchField = styled.div`
@@ -233,6 +254,28 @@ const SearchField = styled.div`
     color: ${({ theme }) => theme.colors.gray12};
     padding: 0 0.95rem;
     font-size: 0.95rem;
+  }
+
+  @media (max-width: 767px) {
+    gap: 0;
+
+    label {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    input {
+      min-height: 38px;
+      border-radius: 10px;
+      padding: 0 0.7rem;
+      font-size: 0.86rem;
+    }
   }
 `
 
@@ -323,8 +366,19 @@ const FilterSummaryBar = styled.div`
   }
 
   @media (max-width: 767px) {
+    gap: 0.5rem;
+    padding: 0.54rem 0.6rem;
+    border-radius: 10px;
     flex-direction: column;
     align-items: stretch;
+
+    .summaryCopy {
+      gap: 0.32rem;
+    }
+
+    .summaryCopy > strong {
+      display: none;
+    }
   }
 `
 
@@ -332,7 +386,7 @@ const ToolbarUtilityRow = styled(AdminInlineActionRow)`
   justify-content: flex-end;
 
   @media (max-width: 767px) {
-    justify-content: flex-start;
+    display: none;
   }
 `
 
@@ -340,6 +394,10 @@ const SummaryPillRow = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+
+  @media (max-width: 767px) {
+    gap: 0.32rem;
+  }
 `
 
 const SummaryPill = styled.span<{ "data-tone"?: "neutral" }>`
@@ -353,4 +411,10 @@ const SummaryPill = styled.span<{ "data-tone"?: "neutral" }>`
   color: ${({ theme }) => theme.colors.gray11};
   font-size: 0.78rem;
   font-weight: 700;
+
+  @media (max-width: 767px) {
+    min-height: 26px;
+    padding: 0 0.54rem;
+    font-size: 0.7rem;
+  }
 `

--- a/front/src/routes/Admin/AdminPostsWorkspaceFilterToolbar.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspaceFilterToolbar.tsx
@@ -256,6 +256,9 @@ const SearchField = styled.div`
   }
 
   input {
+    box-sizing: border-box;
+    width: 100%;
+    min-width: 0;
     min-height: 46px;
     border-radius: 12px;
     border: 1px solid ${({ theme }) => theme.colors.gray5};
@@ -345,6 +348,9 @@ const FieldBox = styled.div`
 
   input,
   select {
+    box-sizing: border-box;
+    width: 100%;
+    min-width: 0;
     min-height: 44px;
     border-radius: 12px;
     border: 1px solid ${({ theme }) => theme.colors.gray5};

--- a/front/src/routes/Admin/AdminPostsWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspacePage.tsx
@@ -744,9 +744,9 @@ export const AdminPostWorkspacePage: NextPage<AdminPostsWorkspacePageProps> = ({
       <Main>
         <HeroSection>
           <AdminWorkspaceHeroLayout>
-            <AdminWorkspaceHeroCopy>
+            <PostsHeroCopy>
               <h1>편집과 검수를 한 화면에서 이어갑니다</h1>
-            </AdminWorkspaceHeroCopy>
+            </PostsHeroCopy>
             <AdminWorkspaceHeroActions>
               <PrimaryCta type="button" onClick={() => void openWriteRoute()}>
                 새 글 작성
@@ -891,6 +891,15 @@ const Main = styled.main`
 `
 
 const HeroSection = styled(AdminWorkspaceHero)``
+
+const PostsHeroCopy = styled(AdminWorkspaceHeroCopy)`
+  min-width: 0;
+
+  h1 {
+    max-width: 100%;
+    overflow-wrap: anywhere;
+  }
+`
 
 const WorkspaceBody = styled.div`
   display: grid;

--- a/front/src/routes/Admin/AdminPostsWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspacePage.tsx
@@ -805,6 +805,28 @@ export const AdminPostWorkspacePage: NextPage<AdminPostsWorkspacePageProps> = ({
                 onResetFilters={handleResetListFilters}
               />
 
+              <AdminPostsWorkspaceList
+                listScope={listScope}
+                listKw={listKw}
+                listState={listState}
+                isListLoading={isListLoading}
+                listError={listError}
+                shouldRenderMobileList={shouldRenderMobileList}
+                mutationPending={mutationPending}
+                onLoadList={() => void loadList()}
+                onOpenWriteRoute={(query) => void openWriteRoute(query)}
+                onResetSearch={() => {
+                  setListKw("")
+                  setListPage(DEFAULT_PAGE)
+                }}
+                onContinueRecent={(row) => void handleContinueRecent(row)}
+                onCopyPostDetailLink={(row) => void copyPostDetailLink(row)}
+                onOpenCanonicalPost={(event, row) => void openCanonicalPost(event, row)}
+                onDeletePost={(row) => void handleDeletePost(row)}
+                onRestorePost={(row) => void handleRestorePost(row)}
+                onHardDeletePost={(row) => void handleHardDeletePost(row)}
+              />
+
               {showDeferredSupportPanels ? (
                 <RecentActionPanel aria-live="polite">
                   <div className="panelHead">
@@ -835,28 +857,6 @@ export const AdminPostWorkspacePage: NextPage<AdminPostsWorkspacePageProps> = ({
                   <span>목록이 안정된 뒤 최근 변경 이력을 이어서 불러옵니다.</span>
                 </DeferredPanelPlaceholder>
               )}
-
-              <AdminPostsWorkspaceList
-                listScope={listScope}
-                listKw={listKw}
-                listState={listState}
-                isListLoading={isListLoading}
-                listError={listError}
-                shouldRenderMobileList={shouldRenderMobileList}
-                mutationPending={mutationPending}
-                onLoadList={() => void loadList()}
-                onOpenWriteRoute={(query) => void openWriteRoute(query)}
-                onResetSearch={() => {
-                  setListKw("")
-                  setListPage(DEFAULT_PAGE)
-                }}
-                onContinueRecent={(row) => void handleContinueRecent(row)}
-                onCopyPostDetailLink={(row) => void copyPostDetailLink(row)}
-                onOpenCanonicalPost={(event, row) => void openCanonicalPost(event, row)}
-                onDeletePost={(row) => void handleDeletePost(row)}
-                onRestorePost={(row) => void handleRestorePost(row)}
-                onHardDeletePost={(row) => void handleHardDeletePost(row)}
-              />
             </ListSection>
           </WorkspaceMain>
 

--- a/front/src/routes/Admin/AdminPostsWorkspaceRecentWork.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspaceRecentWork.tsx
@@ -174,8 +174,13 @@ const SectionHeading = styled.div`
 const ResumeGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  min-width: 0;
   gap: 0.6rem;
   align-items: start;
+
+  > * {
+    min-width: 0;
+  }
 
   @media (max-width: 767px) {
     grid-template-columns: minmax(0, 0.76fr) minmax(0, 1.24fr);
@@ -185,6 +190,7 @@ const ResumeGrid = styled.div`
 
 const ResumeCard = styled(AdminRailCard)`
   gap: 0.42rem;
+  min-width: 0;
   width: 100%;
   padding: 0.72rem 0.78rem;
   border-radius: 16px;
@@ -212,6 +218,7 @@ const ResumeCard = styled(AdminRailCard)`
 const ResumeCardButton = styled.button`
   display: grid;
   gap: 0.42rem;
+  min-width: 0;
   width: 100%;
   padding: 0.72rem 0.78rem;
   border-radius: 16px;
@@ -245,11 +252,14 @@ const ResumeCardButton = styled.button`
 
 const ResumeHeader = styled.div`
   display: flex;
+  min-width: 0;
   align-items: center;
   justify-content: space-between;
   gap: 0.6rem;
 
   strong {
+    min-width: 0;
+    overflow-wrap: anywhere;
     font-size: 0.88rem;
   }
 
@@ -275,6 +285,7 @@ const ResumeHeader = styled.div`
 
 const ResumeTitle = styled.strong`
   display: -webkit-box;
+  min-width: 0;
   font-size: 0.9rem;
   line-height: 1.32;
   overflow: hidden;
@@ -450,6 +461,7 @@ const RecentPostItems = styled.ul`
 
   li button {
     width: 100%;
+    min-width: 0;
     padding: 0.58rem 0.68rem;
     border-radius: 10px;
     border: 1px solid ${({ theme }) => theme.colors.gray5};

--- a/front/src/routes/Admin/AdminPostsWorkspaceRecentWork.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspaceRecentWork.tsx
@@ -162,6 +162,13 @@ const SectionHeading = styled.div`
     font-weight: 800;
     letter-spacing: -0.03em;
   }
+
+  @media (max-width: 767px) {
+    h2 {
+      font-size: 0.9rem;
+      letter-spacing: 0;
+    }
+  }
 `
 
 const ResumeGrid = styled.div`
@@ -169,6 +176,11 @@ const ResumeGrid = styled.div`
   grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
   gap: 0.6rem;
   align-items: start;
+
+  @media (max-width: 767px) {
+    grid-template-columns: minmax(0, 0.76fr) minmax(0, 1.24fr);
+    gap: 0.42rem;
+  }
 `
 
 const ResumeCard = styled(AdminRailCard)`
@@ -184,6 +196,16 @@ const ResumeCard = styled(AdminRailCard)`
   &[data-empty="true"] {
     gap: 0.36rem;
     padding-block: 0.68rem;
+  }
+
+  @media (max-width: 767px) {
+    gap: 0.28rem;
+    padding: 0.5rem 0.54rem;
+    border-radius: 12px;
+
+    &[data-empty="true"] {
+      padding-block: 0.5rem;
+    }
   }
 `
 
@@ -213,6 +235,12 @@ const ResumeCardButton = styled.button`
     outline: none;
     box-shadow: ${({ theme }) => `0 0 0 3px ${theme.colors.gray6}`};
   }
+
+  @media (max-width: 767px) {
+    gap: 0.28rem;
+    padding: 0.5rem 0.54rem;
+    border-radius: 12px;
+  }
 `
 
 const ResumeHeader = styled.div`
@@ -230,6 +258,19 @@ const ResumeHeader = styled.div`
     font-size: 0.74rem;
     white-space: nowrap;
   }
+
+  @media (max-width: 767px) {
+    align-items: flex-start;
+
+    strong {
+      font-size: 0.76rem;
+      line-height: 1.2;
+    }
+
+    span {
+      display: none;
+    }
+  }
 `
 
 const ResumeTitle = styled.strong`
@@ -240,6 +281,12 @@ const ResumeTitle = styled.strong`
   word-break: keep-all;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+
+  @media (max-width: 767px) {
+    font-size: 0.78rem;
+    line-height: 1.25;
+    -webkit-line-clamp: 1;
+  }
 `
 
 const EmptyInlineState = styled.div`
@@ -249,6 +296,16 @@ const EmptyInlineState = styled.div`
   strong {
     color: ${({ theme }) => theme.colors.gray12};
     font-size: 0.84rem;
+  }
+
+  @media (max-width: 767px) {
+    gap: 0.08rem;
+
+    strong {
+      color: ${({ theme }) => theme.colors.gray11};
+      font-size: 0.74rem;
+      line-height: 1.2;
+    }
   }
 `
 
@@ -261,6 +318,14 @@ const ResumeMeta = styled.div`
   span {
     color: ${({ theme }) => theme.colors.gray10};
     font-size: 0.76rem;
+  }
+
+  @media (max-width: 767px) {
+    gap: 0.24rem;
+
+    span {
+      display: none;
+    }
   }
 `
 
@@ -292,6 +357,12 @@ const VisibilityBadge = styled(AdminStatusPill)<{ "data-tone": string }>`
       : tone === "PUBLIC_UNLISTED"
         ? theme.colors.orange8
         : theme.colors.green8};
+
+  @media (max-width: 767px) {
+    min-height: 22px;
+    padding: 0 0.46rem;
+    font-size: 0.68rem;
+  }
 `
 
 const ActionRow = styled(AdminInlineActionRow)``
@@ -300,6 +371,10 @@ const PrimaryInlineButton = styled(AdminTextActionButton)`
   color: ${({ theme }) => theme.colors.gray12};
   font-size: 0.92rem;
   font-weight: 800;
+
+  @media (max-width: 767px) {
+    font-size: 0.74rem;
+  }
 `
 
 const WorkspaceEmpty = styled.div`
@@ -355,6 +430,15 @@ const RecentListSkeleton = styled.div`
         ? "linear-gradient(90deg, rgba(148, 163, 184, 0.16), rgba(148, 163, 184, 0.28), rgba(148, 163, 184, 0.16))"
         : "linear-gradient(90deg, rgba(255,255,255,0.06), rgba(255,255,255,0.1), rgba(255,255,255,0.06))"};
   }
+
+  @media (max-width: 767px) {
+    gap: 0.3rem;
+
+    span {
+      height: 28px;
+      border-radius: 8px;
+    }
+  }
 `
 
 const RecentPostItems = styled.ul`
@@ -402,6 +486,28 @@ const RecentPostItems = styled.ul`
       align-items: start;
     }
   }
+
+  @media (max-width: 767px) {
+    gap: 0.3rem;
+
+    li button {
+      min-height: 32px;
+      padding: 0.34rem 0.4rem;
+      border-radius: 8px;
+    }
+
+    li button > div {
+      gap: 0.08rem;
+    }
+
+    strong {
+      font-size: 0.73rem;
+    }
+
+    span {
+      display: none;
+    }
+  }
 `
 
 const RecentMeta = styled.div`
@@ -412,5 +518,9 @@ const RecentMeta = styled.div`
 
   @media (max-width: 820px) {
     justify-items: start;
+  }
+
+  @media (max-width: 767px) {
+    display: none;
   }
 `


### PR DESCRIPTION
## 관련 이슈

close #326

## 작업 배경

- `/admin/posts` 모바일 first fold에서 글 목록 검색과 목록 본문이 최근 작업/작업 기록보다 먼저 읽히도록 조정했습니다.
- 최근 작업은 compact 보조 영역으로 낮추고, 작업 기록 패널은 목록 아래로 이동했습니다.

## 작업 내용

- 최근 작업 카드의 모바일 밀도를 줄여 first fold 점유를 낮췄습니다.
- 모바일 글 목록 필터를 2열 compact rail로 줄이고 summary/action 높이를 낮췄습니다.
- 글 목록 본문을 작업 기록 패널보다 먼저 렌더링하도록 순서를 조정했습니다.
- CI Linux Chromium에서 확인된 모바일 455px body overflow를 막기 위해 hero/filter/recent shrink 계약을 보강했습니다.
- 검색 input과 고급 검색 control의 기본 intrinsic width를 column 안으로 고정했습니다.
- 모바일 first fold 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/mobile-layout.spec.ts --grep '어드민 글 목록 first fold' --workers=1` (RED 확인 후 GREEN 2회)
  - `yarn --cwd front build` (CI overflow 보강 후 통과 포함)
  - `yarn --cwd front test:e2e:smoke` (CI overflow 보강 후 통과 포함)
  - Browser QA: 393x852 `/admin/posts` 검색 top 467.79, 목록 상태 top 665.64, 작업 기록 top 786.84, overflow 없음
  - Browser QA: 1440x900 `/admin/posts` 검색 top 448.78, 목록 상태 top 707.57, 작업 기록 top 828.77, overflow 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 모바일에서 최근 작업의 부가 정보가 덜 보일 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
