### PR TITLE
[Fix] 글수정 selection scroll 후속 복구

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -1109,6 +1109,236 @@ test.describe("block editor authoring flow", () => {
     expect(Math.abs(afterGeometry.handleTop - beforeGeometry.handleTop - paragraphDelta)).toBeLessThanOrEqual(12)
   })
 
+  test("실제 /editor/[id] 본문 클릭과 텍스트 선택 상태의 wheel scroll chain을 유지한다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const targetLabel = "edit route body-selected wheel anchor"
+    const paragraphs = Array.from({ length: 42 }, (_, index) =>
+      index === 12
+        ? `${targetLabel} ${index + 1}. 선택된 글의 좌측 block handle은 본문 위 wheel 중에도 글과 같이 움직여야 합니다.`
+        : `body click wheel regression paragraph ${index + 1}. 본문 클릭 후 wheel scroll chain 회귀를 확인합니다.`
+    )
+    const content = paragraphs.join("\n\n")
+    const contentHtml = paragraphs.map((paragraph) => `<p>${paragraph}</p>`).join("")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/996", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 996,
+          version: 12,
+          title: "본문 클릭 wheel scroll chain 회귀 글",
+          content,
+          contentHtml,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/996")
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("본문 클릭 wheel scroll chain 회귀 글")
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expectEditorToContainLoadedText(editor, "body click wheel regression paragraph 42")
+
+    const readScrollTop = () =>
+      page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+
+    await page.evaluate(() => window.scrollTo(0, 0))
+    const firstParagraph = editor.locator("p", { hasText: "body click wheel regression paragraph 1" }).first()
+    const firstBox = await expectVisibleBox(firstParagraph, "body click paragraph metrics are missing")
+    await page.mouse.click(firstBox.x + Math.min(firstBox.width / 2, 180), firstBox.y + firstBox.height / 2)
+
+    const clickScrollBefore = await readScrollTop()
+    await page.mouse.wheel(0, 420)
+    await expect.poll(readScrollTop).toBeGreaterThan(clickScrollBefore + 120)
+
+    const targetParagraph = editor.locator("p", { hasText: targetLabel }).first()
+    await targetParagraph.scrollIntoViewIfNeeded()
+    const targetBox = await expectVisibleBox(targetParagraph, "body-selected target paragraph metrics are missing")
+    const selectionY = targetBox.y + Math.min(targetBox.height / 2, 18)
+    const selectionStartX = targetBox.x + 34
+    const selectionEndX = targetBox.x + Math.min(targetBox.width - 24, 500)
+
+    await page.mouse.move(selectionStartX, selectionY)
+    await page.mouse.down()
+    await page.mouse.move(selectionEndX, selectionY, { steps: 14 })
+    await page.mouse.up()
+
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+
+    const readSelectionGeometry = async () =>
+      page.evaluate((label) => {
+        const paragraph =
+          Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] p")).find(
+            (element) => element.textContent?.includes(label)
+          ) ?? null
+        const handle = document.querySelector<HTMLElement>("[data-testid='block-drag-handle']")
+        if (!paragraph || !handle) return null
+        const paragraphRect = paragraph.getBoundingClientRect()
+        const handleRect = handle.getBoundingClientRect()
+        const handleStyle = window.getComputedStyle(handle)
+        return {
+          scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+          paragraphTop: paragraphRect.top,
+          handleTop: handleRect.top,
+          handleVisible:
+            handleRect.width > 0 &&
+            handleRect.height > 0 &&
+            handleStyle.display !== "none" &&
+            handleStyle.visibility !== "hidden" &&
+            Number.parseFloat(handleStyle.opacity || "1") > 0.5,
+        }
+      }, targetLabel)
+
+    const beforeGeometry = await readSelectionGeometry()
+    if (!beforeGeometry) {
+      throw new Error("body-selected text handle geometry is missing before scroll")
+    }
+
+    const immediateGeometry = await page.evaluate((label) => {
+      const read = () => {
+        const paragraph =
+          Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] p")).find(
+            (element) => element.textContent?.includes(label)
+          ) ?? null
+        const handle = document.querySelector<HTMLElement>("[data-testid='block-drag-handle']")
+        if (!paragraph || !handle) return null
+        const paragraphRect = paragraph.getBoundingClientRect()
+        const handleRect = handle.getBoundingClientRect()
+        const handleStyle = window.getComputedStyle(handle)
+        return {
+          scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+          paragraphTop: paragraphRect.top,
+          handleTop: handleRect.top,
+          handleVisible:
+            handleRect.width > 0 &&
+            handleRect.height > 0 &&
+            handleStyle.display !== "none" &&
+            handleStyle.visibility !== "hidden" &&
+            Number.parseFloat(handleStyle.opacity || "1") > 0.5,
+        }
+      }
+      window.scrollBy(0, 160)
+      return read()
+    }, targetLabel)
+    if (!immediateGeometry) {
+      throw new Error("body-selected text handle geometry is missing during immediate scroll")
+    }
+    const immediateParagraphDelta = immediateGeometry.paragraphTop - beforeGeometry.paragraphTop
+    expect(immediateGeometry.scrollTop).toBeGreaterThan(beforeGeometry.scrollTop + 80)
+    expect(immediateGeometry.handleVisible).toBe(true)
+    expect(
+      Math.abs(immediateGeometry.handleTop - beforeGeometry.handleTop - immediateParagraphDelta)
+    ).toBeLessThanOrEqual(12)
+
+    await page.evaluate(
+      ({ label, base }) => {
+        const win = window as Window & {
+          __bodySelectedWheelSamples?: Array<{
+            scrollTop: number
+            paragraphTop: number
+            handleTop: number
+            handleError: number
+            handleVisible: boolean
+          }>
+          __bodySelectedWheelCleanup?: () => void
+        }
+        win.__bodySelectedWheelCleanup?.()
+        win.__bodySelectedWheelSamples = []
+        let rafId = 0
+        let stopped = false
+        const read = () => {
+          const paragraph =
+            Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] p")).find(
+              (element) => element.textContent?.includes(label)
+            ) ?? null
+          const handle = document.querySelector<HTMLElement>("[data-testid='block-drag-handle']")
+          if (!paragraph || !handle) return null
+          const paragraphRect = paragraph.getBoundingClientRect()
+          const handleRect = handle.getBoundingClientRect()
+          const handleStyle = window.getComputedStyle(handle)
+          const paragraphDelta = paragraphRect.top - base.paragraphTop
+          return {
+            scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+            paragraphTop: paragraphRect.top,
+            handleTop: handleRect.top,
+            handleError: Math.abs(handleRect.top - base.handleTop - paragraphDelta),
+            handleVisible:
+              handleRect.width > 0 &&
+              handleRect.height > 0 &&
+              handleStyle.display !== "none" &&
+              handleStyle.visibility !== "hidden" &&
+              Number.parseFloat(handleStyle.opacity || "1") > 0.5,
+          }
+        }
+        const record = () => {
+          if (stopped) return
+          const next = read()
+          if (next) win.__bodySelectedWheelSamples?.push(next)
+          if ((win.__bodySelectedWheelSamples?.length ?? 0) < 18) {
+            rafId = window.requestAnimationFrame(record)
+          }
+        }
+        rafId = window.requestAnimationFrame(record)
+        win.__bodySelectedWheelCleanup = () => {
+          stopped = true
+          window.cancelAnimationFrame(rafId)
+        }
+      },
+      { label: targetLabel, base: beforeGeometry }
+    )
+
+    await page.mouse.wheel(0, 140)
+    await page.waitForTimeout(24)
+    await page.mouse.wheel(0, 140)
+    await page.waitForTimeout(24)
+    await page.mouse.wheel(0, 140)
+
+    await expect
+      .poll(async () => (await readSelectionGeometry())?.scrollTop ?? 0)
+      .toBeGreaterThan(beforeGeometry.scrollTop + 80)
+
+    const scrollSamples = await page.evaluate(() => {
+      const win = window as Window & {
+        __bodySelectedWheelSamples?: Array<{
+          scrollTop: number
+          handleError: number
+          handleVisible: boolean
+        }>
+        __bodySelectedWheelCleanup?: () => void
+      }
+      win.__bodySelectedWheelCleanup?.()
+      return win.__bodySelectedWheelSamples ?? []
+    })
+    const movedSamples = scrollSamples.filter((sample) => sample.scrollTop > beforeGeometry.scrollTop + 20)
+    expect(movedSamples.length).toBeGreaterThan(0)
+    expect(movedSamples.every((sample) => sample.handleVisible)).toBe(true)
+    expect(Math.max(...movedSamples.map((sample) => sample.handleError))).toBeLessThanOrEqual(12)
+
+    const afterGeometry = await readSelectionGeometry()
+    if (!afterGeometry) {
+      throw new Error("body-selected text handle geometry is missing after scroll")
+    }
+    const paragraphDelta = afterGeometry.paragraphTop - beforeGeometry.paragraphTop
+    expect(afterGeometry.handleVisible).toBe(true)
+    expect(Math.abs(afterGeometry.handleTop - beforeGeometry.handleTop - paragraphDelta)).toBeLessThanOrEqual(12)
+  })
+
   test("실제 /editor/[id] 수정 진입은 본문 hover scroll, 선택 block affordance, code 원문을 유지한다", async ({
     page,
   }) => {

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -201,7 +201,9 @@ import {
 } from "./blockSelectionModel"
 import {
   resolveBlockHandleAnchorTop,
-  resolveBlockHandleRailLayout,
+  resolveBlockChromeTop,
+  resolveBlockHandleRailLayoutForSurface,
+  resolveBlockSelectionOverlayLayout,
   resolveThinBlockHandleAnchorTop,
   shouldCenterBlockHandleForNode,
   shouldUseThinBlockHandleAnchor,
@@ -5492,8 +5494,6 @@ const BlockEditorEngine = ({
   }, [clearPendingTableAxisDrag])
 
   const shouldTrackSelectionLayoutSync =
-    blockSelectionOverlayState.visible ||
-    blockHandleState.visible ||
     tableAffordanceVisibility.visible ||
     isTableQuickRailHovered ||
     tableMenuState !== null ||
@@ -5502,7 +5502,6 @@ const BlockEditorEngine = ({
     Boolean(draggedTableAxisState) ||
     tableAxisReorderIndicatorState.visible
   const shouldThrottleSelectionLayoutSync =
-    !blockSelectionOverlayState.visible &&
     !tableAffordanceVisibility.visible &&
     !isTableQuickRailHovered &&
     tableMenuState === null &&
@@ -5510,7 +5509,7 @@ const BlockEditorEngine = ({
     !tableColumnDragGuideState.visible &&
     !draggedTableAxisState &&
     !tableAxisReorderIndicatorState.visible
-  const shouldSyncSelectionLayoutImmediately = blockSelectionOverlayState.visible || blockHandleState.visible
+  const shouldSyncSelectionLayoutImmediately = isTableColumnResizeActive || tableColumnDragGuideState.visible || Boolean(draggedTableAxisState) || tableAxisReorderIndicatorState.visible
 
   useEffect(() => {
     if (typeof window === "undefined" || !shouldTrackSelectionLayoutSync) return
@@ -5566,6 +5565,8 @@ const BlockEditorEngine = ({
 
   useBlockSelectionLayoutEffect(() => {
     if (!editor) return
+    const viewportRect = viewportRef.current?.getBoundingClientRect() ?? null
+    const handlePositionMode = isCoarsePointer ? "viewport" : "editor-local"
     const rectCache = blockSelectionLayoutRectCacheRef.current
     rectCache.clear()
     const selectedNestedListItemContext = resolveEffectiveSelectedListItemContext(editor)
@@ -5580,13 +5581,7 @@ const BlockEditorEngine = ({
     }
     if (selectedNestedListItemContext?.listItemElement?.isConnected) {
       const rect = selectedNestedListItemContext.listItemElement.getBoundingClientRect()
-      const nextOverlayState: BlockSelectionOverlayState = {
-        visible: true,
-        left: rect.left - 6,
-        top: rect.top - 4,
-        width: rect.width + 12,
-        height: rect.height + 8,
-      }
+      const nextOverlayState: BlockSelectionOverlayState = resolveBlockSelectionOverlayLayout(rect, viewportRect)
       setBlockSelectionOverlayState((prev) =>
         isStableBlockSelectionOverlayState(prev, nextOverlayState) ? prev : nextOverlayState
       )
@@ -5605,13 +5600,7 @@ const BlockEditorEngine = ({
           setBlockSelectionOverlayState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
         } else {
           const { rect } = overlayTarget
-          const nextOverlayState: BlockSelectionOverlayState = {
-            visible: true,
-            left: rect.left - 6,
-            top: rect.top - 4,
-            width: rect.width + 12,
-            height: rect.height + 8,
-          }
+          const nextOverlayState: BlockSelectionOverlayState = resolveBlockSelectionOverlayLayout(rect, viewportRect)
           setBlockSelectionOverlayState((prev) =>
             isStableBlockSelectionOverlayState(prev, nextOverlayState) ? prev : nextOverlayState
           )
@@ -5653,11 +5642,13 @@ const BlockEditorEngine = ({
     const { width: railWidth, height: railHeight } = blockHandleRailMetricsRef.current
     if (activeListItemContext?.listItemElement?.isConnected) {
       const rect = activeListItemContext.listItemElement.getBoundingClientRect()
-      const railLayout = resolveBlockHandleRailLayout(
+      const railLayout = resolveBlockHandleRailLayoutForSurface(
         rect,
         railWidth,
         railHeight,
-        resolveBlockHandleAnchorTop(activeListItemContext.listItemElement, railHeight)
+        resolveBlockHandleAnchorTop(activeListItemContext.listItemElement, railHeight),
+        viewportRect,
+        handlePositionMode
       )
       const nextState: TopLevelBlockHandleState = {
         visible: true,
@@ -5667,7 +5658,7 @@ const BlockEditorEngine = ({
         itemIndex: activeListItemContext.itemIndex,
         left: railLayout.left,
         top: railLayout.top,
-        bottom: rect.bottom + 12,
+        bottom: resolveBlockChromeTop(rect.bottom + 12, viewportRect, handlePositionMode),
         width: rect.width,
       }
       setBlockHandleState((prev) => (isStableBlockHandleState(prev, nextState) ? prev : nextState))
@@ -5693,7 +5684,14 @@ const BlockEditorEngine = ({
       : shouldCenterBlockHandleForNode(blockNode)
         ? resolveBlockHandleAnchorTop(blockElement, railHeight)
         : rect.top + 6
-    const railLayout = resolveBlockHandleRailLayout(rect, railWidth, railHeight, anchoredTop)
+    const railLayout = resolveBlockHandleRailLayoutForSurface(
+      rect,
+      railWidth,
+      railHeight,
+      anchoredTop,
+      viewportRect,
+      handlePositionMode
+    )
     const nextState: TopLevelBlockHandleState = {
       visible: true,
       kind: "top-level",
@@ -5702,7 +5700,7 @@ const BlockEditorEngine = ({
       itemIndex: null,
       left: railLayout.left,
       top: railLayout.top,
-      bottom: rect.bottom + 12,
+      bottom: resolveBlockChromeTop(rect.bottom + 12, viewportRect, handlePositionMode),
       width: rect.width,
     }
 
@@ -8817,10 +8815,11 @@ const SlashEmptyState = styled.div`
 `
 
 const EditorViewport = styled.div`
+  position: relative;
   border: 0;
   border-radius: 0;
   background: transparent;
-  overflow: hidden;
+  overflow: visible;
 
   &[data-row-resize-hot="true"] {
     cursor: row-resize;
@@ -10091,7 +10090,7 @@ const TableMenuHint = styled.div`
 `
 
 const BlockHandleRail = styled.div`
-  position: fixed;
+  position: absolute;
   z-index: 55;
   display: flex;
   flex-direction: row;
@@ -10286,7 +10285,7 @@ const BlockDropIndicator = styled.div`
 `
 
 const BlockSelectionOverlay = styled.div`
-  position: fixed;
+  position: absolute;
   z-index: 2;
   pointer-events: none;
   border-radius: 0.95rem;

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -9,6 +9,32 @@ export type BlockHandleRailLayout = {
   top: number
 }
 
+export type BlockChromePositionMode = "editor-local" | "viewport"
+type BlockChromeSurfaceRect = Pick<DOMRect, "left" | "top"> | null
+
+export const resolveBlockChromeLeft = (
+  left: number,
+  surfaceRect: BlockChromeSurfaceRect,
+  mode: BlockChromePositionMode
+) => (mode === "editor-local" ? left - (surfaceRect?.left ?? 0) : left)
+
+export const resolveBlockChromeTop = (
+  top: number,
+  surfaceRect: BlockChromeSurfaceRect,
+  mode: BlockChromePositionMode
+) => (mode === "editor-local" ? top - (surfaceRect?.top ?? 0) : top)
+
+export const resolveBlockSelectionOverlayLayout = (
+  rect: DOMRect,
+  surfaceRect: BlockChromeSurfaceRect
+) => ({
+  visible: true,
+  left: resolveBlockChromeLeft(rect.left - 6, surfaceRect, "editor-local"),
+  top: resolveBlockChromeTop(rect.top - 4, surfaceRect, "editor-local"),
+  width: rect.width + 12,
+  height: rect.height + 8,
+})
+
 export const resolveBlockHandleAnchorTop = (blockElement: HTMLElement, railHeight: number) => {
   const rect = blockElement.getBoundingClientRect()
   if (typeof window === "undefined") return rect.top + 6
@@ -55,6 +81,21 @@ export const resolveBlockHandleRailLayout = (
   return {
     left: Math.min(Math.max(BLOCK_HANDLE_VIEWPORT_PADDING_PX, rect.left), maxLeft),
     top: rect.top - railHeight - BLOCK_HANDLE_STACKED_GAP_PX,
+  }
+}
+
+export const resolveBlockHandleRailLayoutForSurface = (
+  rect: DOMRect,
+  railWidth: number,
+  railHeight: number,
+  anchoredTop: number,
+  surfaceRect: BlockChromeSurfaceRect,
+  mode: BlockChromePositionMode
+): BlockHandleRailLayout => {
+  const railLayout = resolveBlockHandleRailLayout(rect, railWidth, railHeight, anchoredTop)
+  return {
+    left: resolveBlockChromeLeft(railLayout.left, surfaceRect, mode),
+    top: resolveBlockChromeTop(railLayout.top, surfaceRect, mode),
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

close #305

## 작업 배경

- 글수정 에디터에서 텍스트 선택 후 좌측 블록 핸들이 스크롤 첫 프레임부터 본문 블록과 같은 delta로 이동하도록 복구했습니다.
- 본문 클릭 후 wheel 입력이 editor body에서 막히지 않고 page scroll chain으로 이어지는 회귀를 자동화 테스트와 Browser QA로 고정했습니다.
- main merge 후 CI 성공 시 홈서버 배포 workflow가 자동으로 이어지는 경로입니다.

## 작업 내용

- block handle rail과 selection overlay를 viewport fixed 좌표 보정 방식에서 editor-local absolute layout으로 전환했습니다.
- scroll마다 block handle/overlay를 React sync loop로 재계산하던 경로를 제거해 flicker/lag와 위치 분리를 줄였습니다.
- 실제 `/editor/[id]` 계열 authoring flow를 대체하는 QA route에서 본문 클릭 wheel 및 선택 상태 scroll anchoring 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3107 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3107 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts e2e/editor-load-sync-guard.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3107 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - Browser QA: `http://127.0.0.1:3108/_qa/block-editor-slash?...`에서 본문 클릭 후 scrollY 0 -> 420, 선택 handle/paragraph delta 유지 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: block handle/selection overlay 좌표 기준 변경으로 desktop editor floating chrome 위치에 영향이 있을 수 있습니다. editor authoring flow와 studio guard 회귀로 기본 동작을 고정했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `fix(editor): selection scroll 후속 복구`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
