### PR TITLE
[Fix] 운영 도구 fallback 상태의 경고 라벨 계층 정리

### DIFF
--- a/front/e2e/admin-tools-state.spec.ts
+++ b/front/e2e/admin-tools-state.spec.ts
@@ -92,4 +92,20 @@ test.describe("admin tools state contract", () => {
     expect(source).not.toContain("런북/장애 문서")
     expect(source.split("\n").length).toBeLessThan(1700)
   })
+
+  test("운영 도구 fallback 상태는 미수집 라벨과 중립 tone으로 분류한다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/tools.tsx"), "utf8")
+    const modelSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminToolsWorkspaceModel.ts"), "utf8")
+
+    expect(modelSource).toContain('export const DATA_MISSING_STATUS_LABEL = "데이터 미수집"')
+    expect(modelSource).toContain("export const isOperationalStatusMissing")
+    expect(modelSource).toContain("export const normalizeOperationalStatusLabel")
+    expect(source).toContain("normalizeOperationalStatusLabel(systemHealthQuery.data?.status")
+    expect(source).toContain("isOperationalStatusMissing(rawSystemHealthStatus)")
+    expect(source).toContain("DATA_MISSING_STATUS_LABEL")
+    expect(source).not.toContain('systemHealthQuery.data?.status || "UNKNOWN"')
+    expect(source).not.toContain('taskType: typeof parsed.taskQueue.taskType === "string" ? parsed.taskQueue.taskType : "UNKNOWN"')
+    expect(source).not.toContain(': "미확인"')
+    expect(source).not.toContain('? "갱신 중"\\n        : "열기"')
+  })
 })

--- a/front/src/pages/admin/tools.tsx
+++ b/front/src/pages/admin/tools.tsx
@@ -16,6 +16,8 @@ import { appendSsrDebugTiming, timed } from "src/libs/server/serverTiming"
 import AdminShell from "src/routes/Admin/AdminShell"
 import {
   ACTION_META,
+  CHECK_REQUIRED_STATUS_LABEL,
+  DATA_MISSING_STATUS_LABEL,
   HEALTH_CACHE_MS,
   RESULTS_FILTER_STORAGE_KEY,
   SECTION_IDS,
@@ -27,7 +29,9 @@ import {
   getFreshnessMeta,
   getStatusTone,
   getSystemHealthSummary,
+  isOperationalStatusMissing,
   isExecutionResultFilter,
+  normalizeOperationalStatusLabel,
   type DiagnosticTab,
   type ExecutionEntry,
   type ExecutionResultFilter,
@@ -327,7 +331,7 @@ const readMailSnapshotFromCookie = (req: IncomingMessage): SignupMailDiagnostics
       taskQueue:
         parsed.taskQueue && typeof parsed.taskQueue === "object"
           ? {
-              taskType: typeof parsed.taskQueue.taskType === "string" ? parsed.taskQueue.taskType : "UNKNOWN",
+              taskType: typeof parsed.taskQueue.taskType === "string" ? parsed.taskQueue.taskType : "미분류",
               pendingCount: typeof parsed.taskQueue.pendingCount === "number" ? parsed.taskQueue.pendingCount : 0,
               readyPendingCount:
                 typeof parsed.taskQueue.readyPendingCount === "number" ? parsed.taskQueue.readyPendingCount : 0,
@@ -915,7 +919,9 @@ const AdminToolsPage: NextPage<AdminToolsPageProps> = ({ initialMember, initialS
     return filteredExecutions.find((entry) => entry.id === selectedExecutionId) ?? filteredExecutions[0]
   }, [filteredExecutions, selectedExecutionId])
 
-  const systemHealthStatus = systemHealthQuery.data?.status || "UNKNOWN"
+  const rawSystemHealthStatus = systemHealthQuery.data?.status ?? null
+  const hasSystemHealthStatus = !isOperationalStatusMissing(rawSystemHealthStatus)
+  const systemHealthStatus = normalizeOperationalStatusLabel(systemHealthQuery.data?.status)
   const mailFreshness = getFreshnessMeta(mailDiagnostics?.checkedAt ?? null, freshnessClock)
   const taskQueueFreshness = getFreshnessMeta(taskQueueCheckedAt, freshnessClock)
   const cleanupFreshness = getFreshnessMeta(cleanupCheckedAt, freshnessClock)
@@ -935,14 +941,14 @@ const AdminToolsPage: NextPage<AdminToolsPageProps> = ({ initialMember, initialS
     !hasMailDiagnostics
       ? isMailLoading
         ? "갱신 중"
-        : "열기"
+        : DATA_MISSING_STATUS_LABEL
       : mailDiagnostics?.status === "READY"
       ? "정상"
       : mailDiagnostics?.status === "CONNECTION_FAILED"
         ? "오류"
         : mailDiagnostics?.status === "MISCONFIGURED"
           ? "확인 필요"
-          : "열기"
+          : CHECK_REQUIRED_STATUS_LABEL
   const signupMailTaskQueue = mailDiagnostics?.taskQueue ?? null
   const signupMailQueueStatusLabel =
     signupMailTaskQueue?.staleProcessingCount && signupMailTaskQueue.staleProcessingCount > 0
@@ -953,7 +959,7 @@ const AdminToolsPage: NextPage<AdminToolsPageProps> = ({ initialMember, initialS
           ? "대기 중"
           : signupMailTaskQueue
             ? "정상"
-            : "미확인"
+            : DATA_MISSING_STATUS_LABEL
   const signupMailQueueStatusMessage =
     signupMailTaskQueue?.staleProcessingCount && signupMailTaskQueue.staleProcessingCount > 0
       ? `stale ${signupMailTaskQueue.staleProcessingCount}건`
@@ -966,20 +972,22 @@ const AdminToolsPage: NextPage<AdminToolsPageProps> = ({ initialMember, initialS
     !hasTaskQueueDiagnostics
       ? isQueueLoading
         ? "갱신 중"
-        : "열기"
+        : DATA_MISSING_STATUS_LABEL
       : taskQueueDiagnostics?.staleProcessingCount && taskQueueDiagnostics.staleProcessingCount > 0
       ? "오류"
       : taskQueueDiagnostics?.failedCount && taskQueueDiagnostics.failedCount > 0
         ? "확인 필요"
         : taskQueueDiagnostics
           ? "정상"
-          : "열기"
-  const cleanupStatusLabel = !hasCleanupDiagnostics ? (isCleanupLoading ? "갱신 중" : "열기") : cleanupDiagnostics?.blockedBySafetyThreshold ? "확인 필요" : "정상"
+          : DATA_MISSING_STATUS_LABEL
+  const cleanupStatusLabel = !hasCleanupDiagnostics
+    ? isCleanupLoading ? "갱신 중" : DATA_MISSING_STATUS_LABEL
+    : cleanupDiagnostics?.blockedBySafetyThreshold ? CHECK_REQUIRED_STATUS_LABEL : "정상"
   const authSecurityStatusLabel =
     !hasAuthDiagnostics
       ? isAuthLoading
         ? "갱신 중"
-        : "열기"
+        : DATA_MISSING_STATUS_LABEL
       : authSecurityEvents.length > 0
       ? authSecurityEvents[0]?.eventType === "IP_SECURITY_MISMATCH_BLOCKED"
         ? "확인 필요"
@@ -998,14 +1006,16 @@ const AdminToolsPage: NextPage<AdminToolsPageProps> = ({ initialMember, initialS
   }, [systemHealthCheckedAt, mailDiagnostics?.checkedAt])
 
   const overviewStatusLabel =
-    systemHealthStatus !== "UP" || mailDiagnostics?.status === "CONNECTION_FAILED"
+    (hasSystemHealthStatus && rawSystemHealthStatus !== "UP") || mailDiagnostics?.status === "CONNECTION_FAILED"
       ? "오류"
       : mailDiagnostics?.status === "MISCONFIGURED"
-        ? "확인 필요"
-        : "정상"
+        ? CHECK_REQUIRED_STATUS_LABEL
+        : !hasSystemHealthStatus && !hasMailDiagnostics
+          ? DATA_MISSING_STATUS_LABEL
+          : "정상"
 
   const attentionItems = [
-    systemHealthStatus !== "UP" ? "서비스 상태를 먼저 확인하세요." : null,
+    hasSystemHealthStatus && rawSystemHealthStatus !== "UP" ? "서비스 상태를 먼저 확인하세요." : null,
     mailDiagnostics?.status === "MISCONFIGURED" ? "메일 설정 누락을 정리해야 합니다." : null,
     mailDiagnostics?.status === "CONNECTION_FAILED" ? "SMTP 연결 실패 원인을 확인해야 합니다." : null,
     (signupMailTaskQueue?.failedCount ?? 0) > 0 ? "회원가입 메일 큐에 실패 작업이 있습니다." : null,
@@ -1074,7 +1084,7 @@ const AdminToolsPage: NextPage<AdminToolsPageProps> = ({ initialMember, initialS
             <FeaturedStatusCard as="a">
               <CardEyebrow>운영 대시보드</CardEyebrow>
               <CardMainLine>
-                <strong>{systemHealthStatus === "UP" ? "정상" : systemHealthStatus}</strong>
+                <strong>{systemHealthStatus}</strong>
               </CardMainLine>
               <CardDetail>{systemHealthSummary[0] || `최근 확인 ${systemHealthFetchedAt}`}</CardDetail>
             </FeaturedStatusCard>

--- a/front/src/routes/Admin/AdminToolsWorkspaceModel.ts
+++ b/front/src/routes/Admin/AdminToolsWorkspaceModel.ts
@@ -34,6 +34,8 @@ export type ExecutionEntry = {
 }
 
 export const ADMIN_TOOLS_DISPLAY_TIME_ZONE = "Asia/Seoul"
+export const DATA_MISSING_STATUS_LABEL = "데이터 미수집"
+export const CHECK_REQUIRED_STATUS_LABEL = "확인 필요"
 export const SYSTEM_HEALTH_QUERY_KEY = ["admin", "tools", "system-health"] as const
 export const HEALTH_CACHE_MS = 10_000
 export const RESULTS_FILTER_STORAGE_KEY = "admin.tools.resultsFilter.v1"
@@ -102,10 +104,10 @@ export const getFreshnessMeta = (
   value: string | null | undefined,
   referenceNow: number | null
 ): { label: string; tone: "fresh" | "aging" | "stale" } => {
-  if (!value) return { label: "미확인", tone: "stale" }
+  if (!value) return { label: DATA_MISSING_STATUS_LABEL, tone: "stale" }
 
   const timestamp = new Date(value).getTime()
-  if (Number.isNaN(timestamp)) return { label: "미확인", tone: "stale" }
+  if (Number.isNaN(timestamp)) return { label: DATA_MISSING_STATUS_LABEL, tone: "stale" }
 
   if (referenceNow == null) return { label: "확인됨", tone: "fresh" }
 
@@ -119,6 +121,20 @@ export const getFreshnessMeta = (
 export const formatRetryPolicy = (policy: TaskRetryPolicy) =>
   `${policy.maxRetries}회 / ${policy.baseDelaySeconds}초 시작 / x${policy.backoffMultiplier.toFixed(1)} / 최대 ${policy.maxDelaySeconds}초`
 
+export const isOperationalStatusMissing = (value: string | null | undefined) => {
+  const normalized = value?.trim()
+  return !normalized || normalized === "UNKNOWN"
+}
+
+export const normalizeOperationalStatusLabel = (value: string | null | undefined) => {
+  const normalized = value?.trim()
+  if (isOperationalStatusMissing(normalized)) return DATA_MISSING_STATUS_LABEL
+  if (normalized === "UP" || normalized === "READY") return "정상"
+  if (normalized === "CONNECTION_FAILED" || normalized === "DOWN" || normalized === "ERROR") return "오류"
+  if (normalized === "MISCONFIGURED") return CHECK_REQUIRED_STATUS_LABEL
+  return normalized
+}
+
 export const getSystemHealthSummary = (health: SystemHealthPayload | null) => {
   if (!health?.details || typeof health.details !== "object") return []
 
@@ -126,10 +142,10 @@ export const getSystemHealthSummary = (health: SystemHealthPayload | null) => {
     .slice(0, 4)
     .map(([key, value]) => {
       if (value && typeof value === "object" && "status" in value && typeof value.status === "string") {
-        return `${key}: ${String(value.status)}`
+        return `${key}: ${normalizeOperationalStatusLabel(value.status)}`
       }
 
-      return `${key}: ${typeof value === "string" ? value : "ok"}`
+      return `${key}: ${typeof value === "string" ? normalizeOperationalStatusLabel(value) : "ok"}`
     })
 }
 


### PR DESCRIPTION
## 관련 이슈

close #327

## 작업 배경

- `/admin/tools` fallback/미수집 상태를 `데이터 미수집`/`확인 필요` 계층으로 정리했습니다.
- 실제 장애 상태만 `오류`로 승격되도록 overview와 진단 카드의 상태 계산을 분리했습니다.

## 작업 내용

- system health와 nested status 값을 표시용 라벨로 정규화하는 model helper를 추가했습니다.
- backend snapshot 부재 시 `UNKNOWN`, `미확인`, 반복 `열기`로 보이던 fallback 라벨을 중립 라벨로 바꿨습니다.
- 상태 계약 테스트에 fallback 라벨 회귀 케이스를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-tools-state.spec.ts --grep 'fallback 상태' --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front test:e2e:smoke`
  - Browser QA: `http://127.0.0.1:3100/admin/tools`, 393x852 및 desktop snapshot

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 운영자가 기존 `UNKNOWN` 원문을 보고 판단하던 경우 표시 라벨이 바뀝니다.
- 롤백 방법: 이 PR의 revert commit을 생성해 상태 라벨 정규화와 테스트 변경을 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
