### PR TITLE
[Fix] 글수정 테이블 후 하단 본문 클릭 scroll jump 복구

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -1339,6 +1339,197 @@ test.describe("block editor authoring flow", () => {
     expect(Math.abs(afterGeometry.handleTop - beforeGeometry.handleTop - paragraphDelta)).toBeLessThanOrEqual(12)
   })
 
+  test("실제 /editor/[id] 테이블 클릭 후 하단 본문 클릭은 scrollTop을 다른 본문 위치로 되돌리지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const tableCellLabel = "table click scroll anchor cell"
+    const bottomLabel = "edit route table then bottom click scroll jump target"
+    const previousSelectionLabel = "pre table selection anchor paragraph"
+    const leadParagraphs = Array.from({ length: 72 }, (_, index) =>
+      index === 66
+        ? `${previousSelectionLabel} ${index + 1}. 하단 표를 클릭하기 전 이전 caret이 남아 있는 중간 본문입니다.`
+        : `pre table scroll paragraph ${index + 1}. 긴 글에서 하단 표 클릭 scrollTop 보존 회귀를 확인합니다.`
+    )
+    const closingParagraphs = Array.from({ length: 20 }, (_, index) =>
+      index === 18
+        ? `${bottomLabel} ${index + 1}. 테이블을 먼저 클릭한 뒤 글의 맨 아래쪽 본문을 클릭해도 화면 위치가 다른 문단으로 순간이동하면 안 됩니다.`
+        : `post table bottom paragraph ${index + 1}. 하단 본문 클릭은 caret/focus만 이동해야 합니다.`
+    )
+    const tableMarkdown = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[119,192,210]} -->',
+      "| 기준 | 상태 | 메모 |",
+      "| --- | --- | --- |",
+      `| ${tableCellLabel} | 선택 유지 | 하단 본문 클릭 전 테이블 selection anchor를 만듭니다. |`,
+      "| 다음 행 | 보조 값 | 표가 포함된 긴 수정 글을 재현합니다. |",
+    ].join("\n")
+    const content = [
+      "테이블 클릭 후 하단 본문 클릭 scroll jump 회귀 재현용 글입니다.",
+      ...leadParagraphs,
+      tableMarkdown,
+      ...closingParagraphs,
+    ].join("\n\n")
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/995", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 995,
+          version: 13,
+          title: "테이블 후 하단 본문 클릭 scroll jump 회귀 글",
+          content,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/995")
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+      "테이블 후 하단 본문 클릭 scroll jump 회귀 글"
+    )
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expectEditorToContainLoadedText(editor, bottomLabel)
+
+    const previousSelectionParagraph = editor.locator("p", { hasText: previousSelectionLabel }).first()
+    await previousSelectionParagraph.scrollIntoViewIfNeeded()
+    const previousSelectionBox = await expectVisibleBox(
+      previousSelectionParagraph,
+      "previous selection paragraph metrics are missing"
+    )
+    await page.mouse.click(
+      previousSelectionBox.x + Math.min(previousSelectionBox.width / 2, 260),
+      previousSelectionBox.y + Math.min(previousSelectionBox.height / 2, 18)
+    )
+
+    const tableCell = editor.locator("table th, table td", { hasText: tableCellLabel }).first()
+    await tableCell.scrollIntoViewIfNeeded()
+    const tableCellBox = await expectVisibleBox(tableCell, "table click anchor cell metrics are missing")
+    const beforeTableClickState = await page.evaluate((label) => {
+      const cell =
+        Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] th, [data-testid='block-editor-prosemirror'] td")).find(
+          (element) => element.textContent?.includes(label)
+        ) ?? null
+      const rect = cell?.getBoundingClientRect() ?? null
+      return rect
+        ? {
+            scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+            tableCellTop: rect.top,
+          }
+        : null
+    }, tableCellLabel)
+    if (!beforeTableClickState) {
+      throw new Error("table click geometry is missing before click")
+    }
+    await page.mouse.click(tableCellBox.x + Math.min(tableCellBox.width / 2, 120), tableCellBox.y + tableCellBox.height / 2)
+
+    const tableAnchorState = await page.evaluate((label) => {
+      const cell =
+        Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] th, [data-testid='block-editor-prosemirror'] td")).find(
+          (element) => element.textContent?.includes(label)
+        ) ?? null
+      const selection = window.getSelection()
+      const anchorElement =
+        selection?.anchorNode instanceof HTMLElement
+          ? selection.anchorNode
+          : selection?.anchorNode?.parentElement ?? null
+      return {
+        activeInsideTable: Boolean(
+          cell &&
+            (document.activeElement?.closest("th, td") === cell ||
+              anchorElement?.closest("th, td") === cell)
+        ),
+        scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+      }
+    }, tableCellLabel)
+    expect(tableAnchorState.activeInsideTable).toBe(true)
+    expect(Math.abs(tableAnchorState.scrollTop - beforeTableClickState.scrollTop)).toBeLessThanOrEqual(24)
+
+    const tableElement = editor.locator(".tableWrapper table").first()
+    const tableBox = await expectVisibleBox(tableElement, "table metrics are missing before structural selection")
+    await page.mouse.move(tableBox.x + 3, tableBox.y + 3)
+    const rowHandle = page.locator("[data-table-affordance='row-handle']").first()
+    await expect(rowHandle).toBeVisible()
+    await rowHandle.click()
+
+    const tableSelectionState = await page.evaluate(() => ({
+      scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+      selectedCellCount: document.querySelectorAll("[data-testid='block-editor-prosemirror'] .selectedCell").length,
+    }))
+    expect(tableSelectionState.selectedCellCount).toBeGreaterThan(0)
+
+    await page.evaluate(() => {
+      window.scrollTo(0, document.scrollingElement?.scrollHeight ?? document.body.scrollHeight)
+    })
+    await page.waitForTimeout(80)
+
+    const beforeGeometry = await page.evaluate((label) => {
+      const root = document.querySelector<HTMLElement>("[data-testid='block-editor-prosemirror']")
+      const paragraph =
+        Array.from(root?.querySelectorAll<HTMLElement>("p") ?? []).find(
+          (element) => element.textContent?.includes(label)
+        ) ?? null
+      if (!root || !paragraph) return null
+      const rootRect = root.getBoundingClientRect()
+      const rect = paragraph.getBoundingClientRect()
+      const clickX = Math.min(rootRect.left + 260, rootRect.right - 32)
+      const clickY = Math.min(window.innerHeight - 36, rootRect.bottom - 18)
+      const clickTarget = document.elementFromPoint(clickX, clickY)
+      return {
+        scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+        paragraphTop: rect.top,
+        rootBottom: rootRect.bottom,
+        clickX,
+        clickY,
+        clickInsideEditor: Boolean(clickTarget?.closest("[data-testid='block-editor-prosemirror']")),
+        paragraphText: paragraph.textContent || "",
+      }
+    }, bottomLabel)
+    if (!beforeGeometry) {
+      throw new Error("bottom click geometry is missing before click")
+    }
+    expect(beforeGeometry.clickInsideEditor).toBe(true)
+
+    await page.mouse.click(beforeGeometry.clickX, beforeGeometry.clickY)
+    await page.waitForTimeout(180)
+
+    const afterGeometry = await page.evaluate((label) => {
+      const paragraph =
+        Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] p")).find(
+          (element) => element.textContent?.includes(label)
+        ) ?? null
+      const activeElement = document.activeElement
+      if (!paragraph) return null
+      const rect = paragraph.getBoundingClientRect()
+      return {
+        scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+        paragraphTop: rect.top,
+        activeInsideEditor: Boolean(
+          activeElement?.closest("[data-testid='block-editor-prosemirror']")
+        ),
+      }
+    }, bottomLabel)
+    if (!afterGeometry) {
+      throw new Error("bottom click geometry is missing after click")
+    }
+
+    expect(afterGeometry.activeInsideEditor).toBe(true)
+    expect(Math.abs(afterGeometry.scrollTop - beforeGeometry.scrollTop)).toBeLessThanOrEqual(24)
+    expect(Math.abs(afterGeometry.paragraphTop - beforeGeometry.paragraphTop)).toBeLessThanOrEqual(24)
+  })
+
   test("실제 /editor/[id] 수정 진입은 본문 hover scroll, 선택 block affordance, code 원문을 유지한다", async ({
     page,
   }) => {

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -205,6 +205,7 @@ import {
   resolveBlockHandleRailLayoutForSurface,
   resolveBlockSelectionOverlayLayout,
   resolveThinBlockHandleAnchorTop,
+  preserveWindowScrollForTablePointerFocus,
   shouldCenterBlockHandleForNode,
   shouldUseThinBlockHandleAnchor,
 } from "./blockHandleLayoutModel"
@@ -1028,7 +1029,7 @@ const BlockEditorEngine = ({
         activeEditor.view.dispatch(
           activeEditor.state.tr.setSelection(CellSelection.colSelection(anchorResolved, headResolved))
         )
-        activeEditor.view.focus()
+        focusElementWithoutScroll(activeEditor.view.dom)
         return true
       }
 
@@ -1043,7 +1044,7 @@ const BlockEditorEngine = ({
       activeEditor.view.dispatch(
         activeEditor.state.tr.setSelection(CellSelection.rowSelection(anchorResolved, headResolved))
       )
-      activeEditor.view.focus()
+      focusElementWithoutScroll(activeEditor.view.dom)
       return true
     },
     [clearStickyTopLevelBlockSelection]
@@ -1841,7 +1842,7 @@ const BlockEditorEngine = ({
       currentEditor.view.dispatch(
         currentEditor.state.tr.setSelection(TextSelection.create(currentEditor.state.doc, selectionPos))
       )
-      currentEditor.view.focus()
+      focusElementWithoutScroll(currentEditor.view.dom)
       return true
     }
 
@@ -4418,7 +4419,7 @@ const BlockEditorEngine = ({
 
       clearStickyTopLevelBlockSelection()
       editor.view.dispatch(editor.state.tr.setSelection(selection))
-      editor.view.focus()
+      focusElementWithoutScroll(editor.view.dom)
     },
     [clearStickyTopLevelBlockSelection, editor]
   )
@@ -4431,7 +4432,7 @@ const BlockEditorEngine = ({
     if (!targetNode || targetNode.type.name !== "table") return
     const selection = NodeSelection.create(editor.state.doc, position)
     editor.view.dispatch(editor.state.tr.setSelection(selection))
-    editor.view.focus()
+    focusElementWithoutScroll(editor.view.dom)
   }, [editor])
 
   const moveTaskItemInFirstTaskList = useCallback(
@@ -6155,7 +6156,6 @@ const BlockEditorEngine = ({
       syncSelectedBlockNodeSurface,
     ]
   )
-
   const handleViewportPointerDown = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       if (skipNextPointerDownSelectionClearRef.current) {
@@ -6167,6 +6167,7 @@ const BlockEditorEngine = ({
         findTopLevelBlockIndexFromTarget(event.target) ??
         findTopLevelBlockIndexByClientPosition(event.clientX, event.clientY)
       const currentEditor = editorRef.current ?? editor
+      if (currentEditor) preserveWindowScrollForTablePointerFocus(event.target, isTableSelectionActive(currentEditor))
       if (
         currentEditor &&
         isOuterListItemSelectionGesture(event, targetListItemContext) &&

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -99,6 +99,28 @@ export const resolveBlockHandleRailLayoutForSurface = (
   }
 }
 
+export const preserveWindowScrollAcrossFrames = (frames = 6, tolerance = 4) => {
+  if (typeof window === "undefined" || typeof document === "undefined") return
+  const scrollingElement = document.scrollingElement
+  const startX = window.scrollX
+  const startY = scrollingElement?.scrollTop ?? window.scrollY
+  let frame = 0
+  const restore = () => {
+    const currentY = scrollingElement?.scrollTop ?? window.scrollY
+    if (Math.abs(window.scrollX - startX) > tolerance || Math.abs(currentY - startY) > tolerance) {
+      window.scrollTo(startX, startY)
+    }
+    frame += 1
+    if (frame < frames) window.requestAnimationFrame(restore)
+  }
+  window.requestAnimationFrame(restore)
+}
+
+export const preserveWindowScrollForTablePointerFocus = (target: EventTarget | null, tableSelectionActive: boolean) => {
+  const targetElement = target instanceof Element ? target : target instanceof Node ? target.parentElement : null
+  if (targetElement?.closest(".aq-table-shell, .tableWrapper, table") || tableSelectionActive) preserveWindowScrollAcrossFrames()
+}
+
 export const shouldCenterBlockHandleForNode = (node?: BlockEditorDoc | null) =>
   Boolean(
     node &&


### PR DESCRIPTION
## 관련 이슈

close #333

## 작업 배경

- 글 수정 화면에서 테이블 클릭 후 하단 본문을 클릭할 때 이전 selection 위치로 scrollTop이 되돌아가는 문제를 복구했습니다.
- 테이블 focus/selection 경로는 preventScroll 기반 focus와 짧은 window scroll 보존 프레임을 사용해 클릭 대상 viewport를 유지합니다.
- main merge 후 자동 배포가 이어지면 실제 /editor/507 경로에서 같은 시나리오를 다시 확인합니다.

## 작업 내용

- 테이블 행/열/셀/table block selection focus 경로를 focusElementWithoutScroll로 전환했습니다.
- table surface 또는 table selection 상태에서 pointerdown 직후 focus-induced window scroll을 6프레임 동안 보존하는 helper를 추가했습니다.
- /editor/[id]에서 테이블 클릭 후 하단 본문 클릭 scroll jump를 막는 e2e 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3107 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (81 passed)
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3107 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --grep "테이블 클릭 후 하단 본문" --workers=1` (1 passed, final diff)
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3107 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts e2e/editor-load-sync-guard.spec.ts --workers=1` (22 passed, final diff)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size` (all tracked budgets OK)
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3107 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` (49 passed, final diff)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table selection 상태의 pointerdown 직후 약 6프레임 동안 window scroll 보존이 동작하므로, 해당 짧은 구간에서 의도한 focus scroll과 충돌할 수 있습니다. 적용 범위는 table surface/table selection 상태로 제한했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `99d5eb2c`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
