### PR TITLE
[Fix] 관리자 프로필 데스크톱 편집 열 압축 개선

### DIFF
--- a/front/e2e/admin-layout-regression.spec.ts
+++ b/front/e2e/admin-layout-regression.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test"
+
+test("관리자 프로필 1440px 데스크톱은 편집 폼을 preview rail에 눌리지 않게 유지한다", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto("/admin/profile")
+
+  await expect(page.getByRole("heading", { name: /메인과 About에 보일 인상/ })).toBeVisible()
+  await expect(page.locator("#profile-display-name")).toBeVisible()
+
+  const layoutSnapshot = await page.evaluate(() => {
+    const displayName = document.querySelector<HTMLElement>("#profile-display-name")
+    const role = document.querySelector<HTMLElement>("#profile-role")
+    const bio = document.querySelector<HTMLElement>("#profile-bio")
+    const sectionRail = document.querySelector<HTMLElement>('[aria-label="프로필 섹션"]')
+    const rectOf = (element: HTMLElement | null) => {
+      const rect = element?.getBoundingClientRect()
+      return rect
+        ? {
+            left: rect.left,
+            top: rect.top,
+            width: rect.width,
+          }
+        : null
+    }
+
+    return {
+      displayName: rectOf(displayName),
+      role: rectOf(role),
+      bio: rectOf(bio),
+      sectionRail: rectOf(sectionRail),
+      bodyScrollWidth: document.body.scrollWidth,
+      viewportWidth: window.innerWidth,
+    }
+  })
+
+  expect(layoutSnapshot.displayName?.width ?? 0).toBeGreaterThanOrEqual(240)
+  expect(layoutSnapshot.role?.width ?? 0).toBeGreaterThanOrEqual(240)
+  expect(layoutSnapshot.bio?.width ?? 0).toBeGreaterThanOrEqual(320)
+  expect(layoutSnapshot.sectionRail?.width ?? 0).toBeGreaterThanOrEqual(240)
+  expect(layoutSnapshot.bodyScrollWidth).toBeLessThanOrEqual(layoutSnapshot.viewportWidth)
+})

--- a/front/e2e/admin-profile-state.spec.ts
+++ b/front/e2e/admin-profile-state.spec.ts
@@ -16,7 +16,7 @@ test.describe("admin profile state contract", () => {
     )
 
     expect(styleSource).toContain("export const SectionRail = styled(AdminWorkspaceSectionNav)`")
-    expect(styleSource).toContain("@media (max-width: 1360px)")
+    expect(styleSource).toContain("@media (max-width: 1480px)")
     expect(styleSource).toContain("export const SectionRailButton = styled(AdminWorkspaceSectionNavButton)`")
     expect(source).toContain("role=\"tab\"")
     expect(source).toContain("aria-selected={activeSection === section.id}")

--- a/front/src/routes/Admin/AdminProfileWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspace.styles.ts
@@ -142,10 +142,6 @@ export const WorkspaceShell = styled.section`
   align-items: start;
 
   @media (max-width: 1480px) {
-    grid-template-columns: 176px minmax(0, 1fr) 288px;
-  }
-
-  @media (max-width: 1360px) {
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -155,14 +151,28 @@ export const WorkspaceShell = styled.section`
 `
 
 export const SectionRail = styled(AdminWorkspaceSectionNav)`
-  @media (min-width: 1361px) {
+  @media (max-width: 1480px) {
+    position: static;
+    display: flex;
+    gap: 0.5rem;
+    overflow-x: auto;
+    padding-bottom: 0.2rem;
+    scroll-snap-type: x proximity;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  @media (min-width: 1481px) {
     display: grid;
     gap: 0.24rem;
   }
 `
 
 export const SectionRailButton = styled(AdminWorkspaceSectionNavButton)`
-  @media (min-width: 1361px) {
+  @media (min-width: 1481px) {
     width: 100%;
     min-height: 46px;
     justify-content: flex-start;


### PR DESCRIPTION
## 관련 이슈

close #336

## 작업 배경

- `/admin/profile` 1440px 데스크톱에서 3열 레이아웃이 편집 폼을 과도하게 압축하던 문제를 수정했습니다.
- 1480px 이하에서는 section rail과 preview rail을 단일 흐름으로 내려 편집 입력 최소 폭을 보존합니다.

## 작업 내용

- 관리자 프로필 workspace의 3열 breakpoint를 1481px 이상으로 조정했습니다.
- 1440px 회귀를 잡는 Playwright 레이아웃 테스트를 추가했습니다.
- profile workspace source 계약 테스트를 새 breakpoint 기준으로 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-layout-regression.spec.ts --project=chromium --workers=1`
  - `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --project=chromium --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front test:e2e:smoke`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 1361~1480px 구간에서 preview rail이 우측 고정이 아니라 아래 흐름으로 내려갑니다.
- 롤백 방법: 이 PR을 revert하면 기존 3열 breakpoint로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
