### PR TITLE
[Fix] 글수정 테이블 후 본문 클릭 scroll jump 후속 복구

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -1349,7 +1349,7 @@ test.describe("block editor authoring flow", () => {
       nickname: "aquila",
       isAdmin: true,
     }
-    const tableCellLabel = "table click scroll anchor cell"
+    const tableCellLabel = "table click scroll anchor lower cell"
     const bottomLabel = "edit route table then bottom click scroll jump target"
     const previousSelectionLabel = "pre table selection anchor paragraph"
     const leadParagraphs = Array.from({ length: 72 }, (_, index) =>
@@ -1364,10 +1364,14 @@ test.describe("block editor authoring flow", () => {
     )
     const tableMarkdown = [
       '<!-- aq-table {"overflowMode":"normal","columnWidths":[119,192,210]} -->',
-      "| 기준 | 상태 | 메모 |",
+      "| 영역 | 점검 항목 | 확인 기준 |",
       "| --- | --- | --- |",
-      `| ${tableCellLabel} | 선택 유지 | 하단 본문 클릭 전 테이블 selection anchor를 만듭니다. |`,
-      "| 다음 행 | 보조 값 | 표가 포함된 긴 수정 글을 재현합니다. |",
+      "| 개념 이해 | Stateless 의미 | 요청만으로 처리 가능한가 |",
+      "| 토큰 구조 | Access/Refresh 구분 | 역할 명확 |",
+      "| 보안 | HTTPS 사용 | 필수 |",
+      "| 저장소 | Refresh 저장 | DB/Redis |",
+      "| 만료 | Access 짧게 | 15~60분 |",
+      `| 흐름 | ${tableCellLabel} | 구현되어 있는가 |`,
     ].join("\n")
     const content = [
       "테이블 클릭 후 하단 본문 클릭 scroll jump 회귀 재현용 글입니다.",
@@ -1457,23 +1461,21 @@ test.describe("block editor authoring flow", () => {
     expect(tableAnchorState.activeInsideTable).toBe(true)
     expect(Math.abs(tableAnchorState.scrollTop - beforeTableClickState.scrollTop)).toBeLessThanOrEqual(24)
 
-    const tableElement = editor.locator(".tableWrapper table").first()
-    const tableBox = await expectVisibleBox(tableElement, "table metrics are missing before structural selection")
-    await page.mouse.move(tableBox.x + 3, tableBox.y + 3)
-    const rowHandle = page.locator("[data-table-affordance='row-handle']").first()
-    await expect(rowHandle).toBeVisible()
-    await rowHandle.click()
-
-    const tableSelectionState = await page.evaluate(() => ({
-      scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
-      selectedCellCount: document.querySelectorAll("[data-testid='block-editor-prosemirror'] .selectedCell").length,
-    }))
-    expect(tableSelectionState.selectedCellCount).toBeGreaterThan(0)
-
-    await page.evaluate(() => {
-      window.scrollTo(0, document.scrollingElement?.scrollHeight ?? document.body.scrollHeight)
-    })
-    await page.waitForTimeout(80)
+    await page.mouse.move(760, 360)
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      const bottomParagraphVisible = await page.evaluate((label) => {
+        const paragraph =
+          Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] p")).find(
+            (element) => element.textContent?.includes(label)
+          ) ?? null
+        if (!paragraph) return false
+        const rect = paragraph.getBoundingClientRect()
+        return rect.bottom > 0 && rect.top < window.innerHeight
+      }, bottomLabel)
+      if (bottomParagraphVisible) break
+      await page.mouse.wheel(0, 1400)
+      await page.waitForTimeout(40)
+    }
 
     const beforeGeometry = await page.evaluate((label) => {
       const root = document.querySelector<HTMLElement>("[data-testid='block-editor-prosemirror']")
@@ -1484,8 +1486,8 @@ test.describe("block editor authoring flow", () => {
       if (!root || !paragraph) return null
       const rootRect = root.getBoundingClientRect()
       const rect = paragraph.getBoundingClientRect()
-      const clickX = Math.min(rootRect.left + 260, rootRect.right - 32)
-      const clickY = Math.min(window.innerHeight - 36, rootRect.bottom - 18)
+      const clickX = Math.min(rect.left + Math.min(rect.width / 2, 260), rootRect.right - 32)
+      const clickY = rect.top + Math.min(rect.height / 2, 18)
       const clickTarget = document.elementFromPoint(clickX, clickY)
       return {
         scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
@@ -1493,6 +1495,7 @@ test.describe("block editor authoring flow", () => {
         rootBottom: rootRect.bottom,
         clickX,
         clickY,
+        paragraphVisible: rect.bottom > 0 && rect.top < window.innerHeight,
         clickInsideEditor: Boolean(clickTarget?.closest("[data-testid='block-editor-prosemirror']")),
         paragraphText: paragraph.textContent || "",
       }
@@ -1500,6 +1503,7 @@ test.describe("block editor authoring flow", () => {
     if (!beforeGeometry) {
       throw new Error("bottom click geometry is missing before click")
     }
+    expect(beforeGeometry.paragraphVisible).toBe(true)
     expect(beforeGeometry.clickInsideEditor).toBe(true)
 
     await page.mouse.click(beforeGeometry.clickX, beforeGeometry.clickY)

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -116,9 +116,18 @@ export const preserveWindowScrollAcrossFrames = (frames = 6, tolerance = 4) => {
   window.requestAnimationFrame(restore)
 }
 
+let preserveNextEditorPointerAfterTable = false
+
 export const preserveWindowScrollForTablePointerFocus = (target: EventTarget | null, tableSelectionActive: boolean) => {
   const targetElement = target instanceof Element ? target : target instanceof Node ? target.parentElement : null
-  if (targetElement?.closest(".aq-table-shell, .tableWrapper, table") || tableSelectionActive) preserveWindowScrollAcrossFrames()
+  const tablePointerTarget = Boolean(targetElement?.closest(".aq-table-shell, .tableWrapper, table"))
+  const shouldPreserveFollowUp = !tablePointerTarget && preserveNextEditorPointerAfterTable
+  if (tablePointerTarget) {
+    preserveNextEditorPointerAfterTable = true
+  } else if (shouldPreserveFollowUp) {
+    preserveNextEditorPointerAfterTable = false
+  }
+  if (tablePointerTarget || tableSelectionActive || shouldPreserveFollowUp) preserveWindowScrollAcrossFrames(12)
 }
 
 export const shouldCenterBlockHandleForNode = (node?: BlockEditorDoc | null) =>


### PR DESCRIPTION
## 관련 이슈

close #333

## 작업 배경

- 배포본 /editor/507에서 하단 표 셀 클릭 후 본문을 클릭하면 표 위치로 다시 reveal 되는 scroll jump를 후속 복구합니다.
- 테이블 pointer 직후 다음 editor pointer 1회까지 scroll 보존 guard를 carry해 PM selection context가 사라져도 위치가 튀지 않게 했습니다.

## 작업 내용

- 큰 표 하단 셀 클릭 후 하단 본문 클릭 경로를 editor-authoring-flow 회귀 fixture로 보강했습니다.
- table pointer 이후 follow-up body click에서 window scroll을 12 frame 동안 보존하도록 block handle layout guard를 확장했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3107 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --grep "테이블 클릭 후 하단 본문" --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3107 yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3107 yarn --cwd front playwright test e2e/editor-studio-state.spec.ts e2e/editor-load-sync-guard.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3107 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table pointer 이후 다음 editor click에서 의도치 않은 programmatic scroll만 보존하므로 일반 wheel scroll 영향은 낮습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
