### PR TITLE
[Fix] 관리자 글 관리 목록 first fold 노출 개선

### DIFF
--- a/front/e2e/admin-layout-regression.spec.ts
+++ b/front/e2e/admin-layout-regression.spec.ts
@@ -1,4 +1,79 @@
-import { expect, test } from "@playwright/test"
+import { expect, test, type Page } from "@playwright/test"
+
+const ADMIN_MEMBER_FIXTURE = {
+  id: 1,
+  username: "aquila",
+  nickname: "aquila",
+  isAdmin: true,
+  profileImageUrl: "/avatar.png",
+  profileImageDirectUrl: "/avatar.png",
+}
+
+const ADMIN_POST_FIXTURES = Array.from({ length: 6 }, (_, index) => ({
+  id: 4200 + index,
+  title: index === 0 ? "First fold 운영 점검" : `관리자 글 목록 회귀 ${index}`,
+  authorName: "관리자",
+  authorProfileImgUrl: "/avatar.png",
+  published: index % 2 === 0,
+  listed: index % 3 !== 0,
+  tempDraft: false,
+  createdAt: `2026-05-${String(10 + index).padStart(2, "0")}T01:00:00Z`,
+  modifiedAt: `2026-05-${String(20 - index).padStart(2, "0")}T08:30:00Z`,
+}))
+
+const createAdminPostPage = () => ({
+  content: ADMIN_POST_FIXTURES,
+  pageable: {
+    pageNumber: 0,
+    pageSize: 20,
+    totalElements: ADMIN_POST_FIXTURES.length,
+    totalPages: 1,
+  },
+})
+
+const mockAdminPostsWorkspaceEndpoints = async (page: Page) => {
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(ADMIN_MEMBER_FIXTURE),
+    })
+  })
+
+  await page.route("**/post/api/v1/adm/posts**", async (route) => {
+    const url = new URL(route.request().url())
+
+    if (url.pathname.endsWith("/bootstrap")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          member: ADMIN_MEMBER_FIXTURE,
+          firstPage: createAdminPostPage(),
+        }),
+      })
+      return
+    }
+
+    if (url.pathname.includes("/deleted")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          content: [],
+          pageable: { pageNumber: 0, pageSize: 20, totalElements: 0, totalPages: 0 },
+        }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(createAdminPostPage()),
+    })
+  })
+}
 
 test("관리자 프로필 1440px 데스크톱은 편집 폼을 preview rail에 눌리지 않게 유지한다", async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 })
@@ -40,7 +115,7 @@ test("관리자 프로필 1440px 데스크톱은 편집 폼을 preview rail에 �
   expect(layoutSnapshot.bodyScrollWidth).toBeLessThanOrEqual(layoutSnapshot.viewportWidth)
 })
 
-const captureDashboardPrioritySnapshot = async (page: import("@playwright/test").Page) =>
+const captureDashboardPrioritySnapshot = async (page: Page) =>
   page.evaluate(() => {
     const priorityHeading = Array.from(document.querySelectorAll<HTMLElement>("h2")).find(
       (element) => element.textContent?.trim() === "우선 점검 항목",
@@ -83,5 +158,68 @@ test("관리자 대시보드 모바일은 우선 점검 heading을 first fold �
 
   expect(snapshot.headingTop).toBeLessThan(snapshot.viewportHeight)
   expect(snapshot.sectionTop).toBeLessThan(snapshot.viewportHeight)
+  expect(snapshot.bodyScrollWidth).toBeLessThanOrEqual(snapshot.viewportWidth)
+})
+
+const capturePostsFirstFoldSnapshot = async (page: Page) =>
+  page.evaluate(() => {
+    const heading = Array.from(document.querySelectorAll<HTMLElement>("h2")).find(
+      (element) => element.textContent?.trim() === "글 목록",
+    )
+    const listSection = heading?.closest<HTMLElement>("section")
+    const search = listSection?.querySelector<HTMLElement>("#workspace-post-search")
+    const firstRow = Array.from(listSection?.querySelectorAll<HTMLElement>("tbody tr, article") ?? []).find((element) =>
+      element.textContent?.includes("First fold 운영 점검"),
+    )
+    const recentHeading = Array.from(document.querySelectorAll<HTMLElement>("h2")).find(
+      (element) => element.textContent?.trim() === "최근 작업",
+    )
+    const headingRect = heading?.getBoundingClientRect()
+    const searchRect = search?.getBoundingClientRect()
+    const firstRowRect = firstRow?.getBoundingClientRect()
+    const recentRect = recentHeading?.getBoundingClientRect()
+
+    return {
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth,
+      headingTop: headingRect?.top ?? Number.POSITIVE_INFINITY,
+      searchTop: searchRect?.top ?? Number.POSITIVE_INFINITY,
+      firstRowTop: firstRowRect?.top ?? Number.POSITIVE_INFINITY,
+      recentTop: recentRect?.top ?? Number.POSITIVE_INFINITY,
+      bodyScrollWidth: document.body.scrollWidth,
+    }
+  })
+
+test("관리자 글 관리는 1440px 데스크톱에서 첫 글을 최근 작업보다 먼저 first fold에 노출한다", async ({ page }) => {
+  await mockAdminPostsWorkspaceEndpoints(page)
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto("/admin/posts")
+
+  await expect(page.getByRole("heading", { name: "글 목록" })).toBeVisible()
+  await page.getByRole("button", { name: "새로고침" }).click()
+  await expect(page.locator("tbody tr, article").filter({ hasText: "First fold 운영 점검" }).first()).toBeVisible()
+
+  const snapshot = await capturePostsFirstFoldSnapshot(page)
+
+  expect(snapshot.searchTop).toBeLessThanOrEqual(560)
+  expect(snapshot.firstRowTop).toBeLessThanOrEqual(760)
+  expect(snapshot.firstRowTop).toBeLessThan(snapshot.recentTop)
+  expect(snapshot.bodyScrollWidth).toBeLessThanOrEqual(snapshot.viewportWidth)
+})
+
+test("관리자 글 관리는 모바일에서 첫 글 카드를 최근 작업보다 먼저 first fold에 노출한다", async ({ page }) => {
+  await mockAdminPostsWorkspaceEndpoints(page)
+  await page.setViewportSize({ width: 393, height: 852 })
+  await page.goto("/admin/posts")
+
+  await expect(page.getByRole("heading", { name: "글 목록" })).toBeVisible()
+  await page.getByRole("button", { name: "새로고침" }).click()
+  await expect(page.locator("tbody tr, article").filter({ hasText: "First fold 운영 점검" }).first()).toBeVisible()
+
+  const snapshot = await capturePostsFirstFoldSnapshot(page)
+
+  expect(snapshot.searchTop).toBeLessThanOrEqual(520)
+  expect(snapshot.firstRowTop).toBeLessThan(snapshot.viewportHeight)
+  expect(snapshot.firstRowTop).toBeLessThan(snapshot.recentTop)
   expect(snapshot.bodyScrollWidth).toBeLessThanOrEqual(snapshot.viewportWidth)
 })

--- a/front/src/routes/Admin/AdminPostsWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspacePage.tsx
@@ -757,18 +757,6 @@ export const AdminPostWorkspacePage: NextPage<AdminPostsWorkspacePageProps> = ({
 
         <WorkspaceBody>
           <WorkspaceMain>
-            <div ref={continueSectionRef}>
-              <AdminPostsWorkspaceRecentWork
-                localDraft={localDraft}
-                recentPosts={recentPosts}
-                isRecentLoading={isRecentLoading}
-                recentError={recentError}
-                showDeferredSupportPanels={showDeferredSupportPanels}
-                onOpenWriteRoute={(query) => void openWriteRoute(query)}
-                onContinueRecent={(row) => void handleContinueRecent(row)}
-              />
-            </div>
-
             <ListSection ref={listSectionRef}>
               <SectionHeading>
                 <div>
@@ -858,6 +846,18 @@ export const AdminPostWorkspacePage: NextPage<AdminPostsWorkspacePageProps> = ({
                 </DeferredPanelPlaceholder>
               )}
             </ListSection>
+
+            <div ref={continueSectionRef}>
+              <AdminPostsWorkspaceRecentWork
+                localDraft={localDraft}
+                recentPosts={recentPosts}
+                isRecentLoading={isRecentLoading}
+                recentError={recentError}
+                showDeferredSupportPanels={showDeferredSupportPanels}
+                onOpenWriteRoute={(query) => void openWriteRoute(query)}
+                onContinueRecent={(row) => void handleContinueRecent(row)}
+              />
+            </div>
           </WorkspaceMain>
 
         </WorkspaceBody>


### PR DESCRIPTION
## 관련 이슈

close #338

## 작업 배경

- `/admin/posts`에서 최근 작업이 목록보다 먼저 읽혀 첫 글 본문이 늦게 보이던 문제를 수정했습니다.
- 글 목록 섹션을 hero 바로 아래로 올리고, 최근 작업은 작업 기록 아래 보조 섹션으로 이동했습니다.

## 작업 내용

- `AdminPostsWorkspacePage` 렌더 순서를 `글 목록 -> 작업 기록 -> 최근 작업`으로 조정했습니다.
- desktop/mobile 모두 첫 글 row/card가 최근 작업보다 먼저 first fold에 들어오는 regression test를 추가했습니다.
- regression spec은 QA fixture 데이터가 client fetch로 들어오도록 새로고침 후 list section 내부 row/card만 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-layout-regression.spec.ts --project=chromium --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front test:e2e:smoke`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 최근 작업 진입점이 목록 아래로 이동해 기존 사용자가 더 아래에서 이어쓰기 카드를 보게 됩니다.
- 롤백 방법: 이 PR을 revert하면 기존 `최근 작업 -> 글 목록` 순서로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
