### PR TITLE
[Fix] 관리자 대시보드 렌더링 차단 복구

### DIFF
--- a/front/e2e/admin-surface-primitives.spec.ts
+++ b/front/e2e/admin-surface-primitives.spec.ts
@@ -47,6 +47,8 @@ test.describe("admin surface primitives contract", () => {
     expect(styleSource).toContain("export const InsightLink = styled(AdminTextActionLink)`")
     expect(styleSource).toContain("export const PrioritySummary = styled.div`")
     expect(styleSource).toContain("export const PriorityLink = styled(AdminTextActionLink)`")
+    expect(styleSource).not.toContain("${AdminInfoPanelCard}")
+    expect(styleSource).not.toContain("${AdminInfoLinkCard}")
   })
 
   test("posts/tools reuse shared badge and action primitives", () => {

--- a/front/src/pages/admin/dashboard.tsx
+++ b/front/src/pages/admin/dashboard.tsx
@@ -66,7 +66,9 @@ import {
   PanelFallback,
   InsightRail,
   LeadMetaGrid,
+  LeadMetaCard,
   ActionList,
+  ActionListLinkCard,
   SectionHeader,
   PrioritySection,
   ContextGrid,
@@ -86,7 +88,6 @@ import {
 import {
   AdminInfoLinkCard,
   AdminInfoList,
-  AdminInfoPanelCard,
   AdminInfoStatusItem,
   AdminInfoStatusList,
 } from "src/routes/Admin/AdminSurfacePrimitives"
@@ -653,10 +654,10 @@ const AdminDashboardPage: NextPage<AdminDashboardPageProps> = ({
                 </AdminInfoStatusList>
                 <LeadMetaGrid>
                   {leadFailureMetaItems.map((item) => (
-                    <AdminInfoPanelCard key={item.key}>
+                    <LeadMetaCard key={item.key}>
                       <small>{item.label}</small>
                       <strong>{item.value}</strong>
-                    </AdminInfoPanelCard>
+                    </LeadMetaCard>
                   ))}
                 </LeadMetaGrid>
               </SnapshotLeadBody>
@@ -673,13 +674,13 @@ const AdminDashboardPage: NextPage<AdminDashboardPageProps> = ({
                   <ActionList>
                     {quickActions.map((action) => (
                       <Link key={action.key} href={action.href} passHref legacyBehavior>
-                        <AdminInfoLinkCard
+                        <ActionListLinkCard
                           $withIcon={false}
                           target={action.href.startsWith("http") ? "_blank" : undefined}
                           rel={action.href.startsWith("http") ? "noreferrer noopener" : undefined}
                         >
                           <strong>{action.label}</strong>
-                        </AdminInfoLinkCard>
+                        </ActionListLinkCard>
                       </Link>
                     ))}
                   </ActionList>

--- a/front/src/routes/Admin/AdminDashboardWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminDashboardWorkspace.styles.ts
@@ -325,15 +325,15 @@ export const SnapshotLeadBody = styled(PanelBody)`
   gap: 10px;
   padding: 14px;
 
-  ${AdminInfoPanelCard} {
-    gap: 0.38rem;
-    padding: 0.72rem;
-    border-radius: 14px;
-  }
-
   @media (max-width: 720px) {
     padding: 10px;
   }
+`
+
+export const LeadMetaCard = styled(AdminInfoPanelCard)`
+  gap: 0.38rem;
+  padding: 0.72rem;
+  border-radius: 14px;
 `
 
 export const PanelFrame = styled.iframe`
@@ -419,15 +419,15 @@ export const ActionList = styled(AdminInfoList)`
   gap: 8px;
   padding: 12px;
 
-  ${AdminInfoLinkCard} {
-    padding: 0.64rem 0.72rem;
-    border-radius: 14px;
-  }
-
   @media (max-width: 720px) {
     gap: 6px;
     padding: 9px;
   }
+`
+
+export const ActionListLinkCard = styled(AdminInfoLinkCard)`
+  padding: 0.64rem 0.72rem;
+  border-radius: 14px;
 `
 
 export const SectionHeader = styled(AdminSectionTitleStack)`


### PR DESCRIPTION
## 관련 이슈

close #345

## 작업 배경

- `/admin/dashboard` dev 렌더링을 막던 Emotion component selector 의존을 제거했습니다.
- 동일한 시각 밀도는 dashboard 전용 styled wrapper로 유지하고, source-level 회귀 테스트를 추가했습니다.

## 작업 내용

- `SnapshotLeadBody`/`ActionList` 내부의 `${AdminInfoPanelCard}`/`${AdminInfoLinkCard}` nested component selector를 제거했습니다.
- dashboard page가 새 `LeadMetaCard`, `ActionListLinkCard` wrapper를 사용하도록 바꿨습니다.
- admin surface primitive 계약 테스트가 dashboard styles에 nested component selector가 남지 않도록 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts -g "dashboard context rail" --workers=1` (RED 확인 후 GREEN)
  - `curl -s -o /private/tmp/admin-dashboard-after.html -w "%{http_code} %{time_total}\n" http://localhost:3100/admin/dashboard` → `200`
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts e2e/admin-layout-regression.spec.ts --workers=1`
  - `yarn --cwd front build`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: dashboard wrapper 컴포넌트로 이동한 카드 padding/radius가 의도와 달라질 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
