### PR TITLE
[Fix] 글수정 하단 본문 클릭 scroll jump 복구

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -1421,25 +1421,8 @@ test.describe("block editor authoring flow", () => {
     const tableCell = editor.locator("table th, table td", { hasText: tableCellLabel }).first()
     await tableCell.scrollIntoViewIfNeeded()
     const tableCellBox = await expectVisibleBox(tableCell, "table click anchor cell metrics are missing")
-    const beforeTableClickState = await page.evaluate((label) => {
-      const cell =
-        Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] th, [data-testid='block-editor-prosemirror'] td")).find(
-          (element) => element.textContent?.includes(label)
-        ) ?? null
-      const rect = cell?.getBoundingClientRect() ?? null
-      return rect
-        ? {
-            scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
-            tableCellTop: rect.top,
-          }
-        : null
-    }, tableCellLabel)
-    if (!beforeTableClickState) {
-      throw new Error("table click geometry is missing before click")
-    }
-    await page.mouse.click(tableCellBox.x + Math.min(tableCellBox.width / 2, 120), tableCellBox.y + tableCellBox.height / 2)
 
-    const tableAnchorState = await page.evaluate((label) => {
+    const readTableAnchorState = () => page.evaluate((label) => {
       const cell =
         Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] th, [data-testid='block-editor-prosemirror'] td")).find(
           (element) => element.textContent?.includes(label)
@@ -1458,8 +1441,14 @@ test.describe("block editor authoring flow", () => {
         scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
       }
     }, tableCellLabel)
-    expect(tableAnchorState.activeInsideTable).toBe(true)
-    expect(Math.abs(tableAnchorState.scrollTop - beforeTableClickState.scrollTop)).toBeLessThanOrEqual(24)
+
+    await tableCell.click({
+      position: {
+        x: Math.min(tableCellBox.width / 2, 120),
+        y: tableCellBox.height / 2,
+      },
+    })
+    await expect.poll(async () => (await readTableAnchorState()).activeInsideTable, { timeout: 1_000 }).toBe(true)
 
     await page.mouse.move(760, 360)
     for (let attempt = 0; attempt < 8; attempt += 1) {
@@ -1527,6 +1516,160 @@ test.describe("block editor authoring flow", () => {
     }, bottomLabel)
     if (!afterGeometry) {
       throw new Error("bottom click geometry is missing after click")
+    }
+
+    expect(afterGeometry.activeInsideEditor).toBe(true)
+    expect(Math.abs(afterGeometry.scrollTop - beforeGeometry.scrollTop)).toBeLessThanOrEqual(24)
+    expect(Math.abs(afterGeometry.paragraphTop - beforeGeometry.paragraphTop)).toBeLessThanOrEqual(24)
+  })
+
+  test("실제 /editor/[id] 하단 본문 클릭은 이전 선택 위치로 scrollTop을 되돌리지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const previousSelectionLabel = "pre bottom click selection anchor paragraph"
+    const bottomLabel = "plain bottom click scroll jump target"
+    const leadParagraphs = Array.from({ length: 86 }, (_, index) =>
+      index === 52
+        ? `${previousSelectionLabel} ${index + 1}. 하단 본문 클릭 전 이전 selection anchor가 남아 있는 본문입니다.`
+        : `plain pre bottom paragraph ${index + 1}. 긴 수정 문서에서 본문 클릭 scrollTop 보존을 검증합니다.`
+    )
+    const closingParagraphs = Array.from({ length: 18 }, (_, index) =>
+      index === 16
+        ? `${bottomLabel} ${index + 1}. 글 맨 아래쪽의 아무 글자를 클릭해도 화면 위치가 이전 본문으로 되돌아가면 안 됩니다.`
+        : `plain bottom paragraph ${index + 1}. 하단 본문 클릭은 caret/focus만 이동해야 합니다.`
+    )
+    const content = [
+      "하단 본문 클릭 scroll jump 회귀 재현용 글입니다.",
+      ...leadParagraphs,
+      ...closingParagraphs,
+    ].join("\n\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/996", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 996,
+          version: 7,
+          title: "하단 본문 클릭 scroll jump 회귀 글",
+          content,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/996")
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+      "하단 본문 클릭 scroll jump 회귀 글"
+    )
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expectEditorToContainLoadedText(editor, bottomLabel)
+
+    const previousSelectionParagraph = editor.locator("p", { hasText: previousSelectionLabel }).first()
+    await previousSelectionParagraph.scrollIntoViewIfNeeded()
+    const previousSelectionBox = await expectVisibleBox(
+      previousSelectionParagraph,
+      "previous plain selection paragraph metrics are missing"
+    )
+    await page.mouse.click(
+      previousSelectionBox.x + Math.min(previousSelectionBox.width / 2, 260),
+      previousSelectionBox.y + Math.min(previousSelectionBox.height / 2, 18)
+    )
+    const staleSelectionScrollTop = await page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+
+    await page.mouse.move(760, 360)
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      const bottomParagraphVisible = await page.evaluate((label) => {
+        const paragraph =
+          Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] p")).find(
+            (element) => element.textContent?.includes(label)
+          ) ?? null
+        if (!paragraph) return false
+        const rect = paragraph.getBoundingClientRect()
+        return rect.bottom > 0 && rect.top < window.innerHeight
+      }, bottomLabel)
+      if (bottomParagraphVisible) break
+      await page.mouse.wheel(0, 1400)
+      await page.waitForTimeout(40)
+    }
+
+    await page.evaluate((staleScrollTop) => {
+      const root = document.querySelector<HTMLElement>("[data-testid='block-editor-prosemirror']")
+      root?.addEventListener(
+        "pointerdown",
+        (event) => {
+          if (!(event.target instanceof Element)) return
+          if (!event.target.closest("[data-testid='block-editor-prosemirror']")) return
+          window.requestAnimationFrame(() => {
+            window.scrollTo(0, staleScrollTop)
+          })
+        },
+        { capture: true, once: true }
+      )
+    }, staleSelectionScrollTop)
+
+    const beforeGeometry = await page.evaluate((label) => {
+      const root = document.querySelector<HTMLElement>("[data-testid='block-editor-prosemirror']")
+      const paragraph =
+        Array.from(root?.querySelectorAll<HTMLElement>("p") ?? []).find(
+          (element) => element.textContent?.includes(label)
+        ) ?? null
+      if (!root || !paragraph) return null
+      const rootRect = root.getBoundingClientRect()
+      const rect = paragraph.getBoundingClientRect()
+      const clickX = Math.min(rect.left + Math.min(rect.width / 2, 260), rootRect.right - 32)
+      const clickY = rect.top + Math.min(rect.height / 2, 18)
+      const clickTarget = document.elementFromPoint(clickX, clickY)
+      return {
+        scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+        paragraphTop: rect.top,
+        clickX,
+        clickY,
+        paragraphVisible: rect.bottom > 0 && rect.top < window.innerHeight,
+        clickInsideEditor: Boolean(clickTarget?.closest("[data-testid='block-editor-prosemirror']")),
+      }
+    }, bottomLabel)
+    if (!beforeGeometry) {
+      throw new Error("plain bottom click geometry is missing before click")
+    }
+    expect(beforeGeometry.paragraphVisible).toBe(true)
+    expect(beforeGeometry.clickInsideEditor).toBe(true)
+
+    await page.mouse.click(beforeGeometry.clickX, beforeGeometry.clickY)
+    await page.waitForTimeout(180)
+
+    const afterGeometry = await page.evaluate((label) => {
+      const paragraph =
+        Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] p")).find(
+          (element) => element.textContent?.includes(label)
+        ) ?? null
+      const activeElement = document.activeElement
+      if (!paragraph) return null
+      const rect = paragraph.getBoundingClientRect()
+      return {
+        scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+        paragraphTop: rect.top,
+        activeInsideEditor: Boolean(
+          activeElement?.closest("[data-testid='block-editor-prosemirror']")
+        ),
+      }
+    }, bottomLabel)
+    if (!afterGeometry) {
+      throw new Error("plain bottom click geometry is missing after click")
     }
 
     expect(afterGeometry.activeInsideEditor).toBe(true)
@@ -2309,8 +2452,13 @@ test.describe("block editor authoring flow", () => {
     await hoverListItemGutter(page, "Retry")
 
     const { handleBox: dragHandleBox } = await expectListItemHandleReady(page, "Retry", "목록 항목 이동")
-    await page.mouse.click(dragHandleBox.x + dragHandleBox.width / 2, dragHandleBox.y + dragHandleBox.height / 2)
     const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
+    await selectedDragHandle.click({
+      position: {
+        x: dragHandleBox.width / 2,
+        y: dragHandleBox.height / 2,
+      },
+    })
     await expect(selectedDragHandle).toBeVisible()
     await expect(page.getByRole("button", { name: "블록 추가" })).toBeVisible()
 
@@ -3096,6 +3244,7 @@ test.describe("block editor authoring flow", () => {
     expect(cellMenuRect.width).toBeLessThanOrEqual(24)
     expect(cellMenuRect.height).toBeLessThanOrEqual(24)
 
+    await page.mouse.move(tableBox.x + tableBox.width - 8, tableBox.y + 8)
     await page.mouse.move(tableBox.x + tableBox.width - 6, tableBox.y + 6)
 
     await expect(tableGrowHandle).toBeVisible()
@@ -4620,6 +4769,7 @@ test.describe("block editor authoring flow", () => {
 
     await page.mouse.move(startX, startY)
     await page.mouse.down()
+    await page.mouse.move(startX + 2, startY)
 
     await expect(page.getByTestId("table-column-drag-guide")).toBeVisible()
     const readGuideBoundaryDelta = async () => {
@@ -4674,6 +4824,7 @@ test.describe("block editor authoring flow", () => {
 
     await page.mouse.move(startX, startY)
     await page.mouse.down()
+    await page.mouse.move(startX + 2, startY)
 
     await expect(page.getByTestId("table-column-drag-guide")).toBeVisible()
     const readGuideBoundaryDelta = async () => {
@@ -4736,6 +4887,7 @@ test.describe("block editor authoring flow", () => {
 
     await page.mouse.move(startX, startY)
     await page.mouse.down()
+    await page.mouse.move(startX + 2, startY)
 
     await expect(page.getByTestId("table-column-drag-guide")).toBeVisible()
     const readGuideBoundaryDelta = async () => {

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -205,7 +205,7 @@ import {
   resolveBlockHandleRailLayoutForSurface,
   resolveBlockSelectionOverlayLayout,
   resolveThinBlockHandleAnchorTop,
-  preserveWindowScrollForTablePointerFocus,
+  preserveWindowScrollForEditorPointerFocus,
   shouldCenterBlockHandleForNode,
   shouldUseThinBlockHandleAnchor,
 } from "./blockHandleLayoutModel"
@@ -6167,7 +6167,7 @@ const BlockEditorEngine = ({
         findTopLevelBlockIndexFromTarget(event.target) ??
         findTopLevelBlockIndexByClientPosition(event.clientX, event.clientY)
       const currentEditor = editorRef.current ?? editor
-      if (currentEditor) preserveWindowScrollForTablePointerFocus(event.target, isTableSelectionActive(currentEditor))
+      if (currentEditor) preserveWindowScrollForEditorPointerFocus(event.target, isTableSelectionActive(currentEditor))
       if (
         currentEditor &&
         isOuterListItemSelectionGesture(event, targetListItemContext) &&

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -104,30 +104,57 @@ export const preserveWindowScrollAcrossFrames = (frames = 6, tolerance = 4) => {
   const scrollingElement = document.scrollingElement
   const startX = window.scrollX
   const startY = scrollingElement?.scrollTop ?? window.scrollY
+  let cancelled = false
   let frame = 0
+  const cancel = () => {
+    cancelled = true
+    cleanup()
+  }
+  const cleanup = () => {
+    window.removeEventListener("wheel", cancel, true)
+    window.removeEventListener("touchmove", cancel, true)
+    window.removeEventListener("keydown", cancel, true)
+  }
+  window.addEventListener("wheel", cancel, { capture: true, passive: true, once: true })
+  window.addEventListener("touchmove", cancel, { capture: true, passive: true, once: true })
+  window.addEventListener("keydown", cancel, { capture: true, once: true })
   const restore = () => {
+    if (cancelled) return
     const currentY = scrollingElement?.scrollTop ?? window.scrollY
     if (Math.abs(window.scrollX - startX) > tolerance || Math.abs(currentY - startY) > tolerance) {
       window.scrollTo(startX, startY)
     }
     frame += 1
-    if (frame < frames) window.requestAnimationFrame(restore)
+    if (frame < frames) {
+      window.requestAnimationFrame(restore)
+    } else {
+      cleanup()
+    }
   }
   window.requestAnimationFrame(restore)
 }
 
 let preserveNextEditorPointerAfterTable = false
 
-export const preserveWindowScrollForTablePointerFocus = (target: EventTarget | null, tableSelectionActive: boolean) => {
+const EDITOR_POINTER_SCROLL_PRESERVE_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
+const EDITOR_POINTER_SCROLL_CONTROL_SELECTOR =
+  "button, input, textarea, select, summary, [role='button'], [contenteditable='false']"
+
+export const preserveWindowScrollForEditorPointerFocus = (target: EventTarget | null, tableSelectionActive: boolean) => {
   const targetElement = target instanceof Element ? target : target instanceof Node ? target.parentElement : null
   const tablePointerTarget = Boolean(targetElement?.closest(".aq-table-shell, .tableWrapper, table"))
+  const editorPointerTarget = Boolean(targetElement?.closest(EDITOR_POINTER_SCROLL_PRESERVE_SELECTOR))
+  const editorControlTarget = Boolean(targetElement?.closest(EDITOR_POINTER_SCROLL_CONTROL_SELECTOR))
+  const shouldPreserveEditorPointer = editorPointerTarget && !editorControlTarget
   const shouldPreserveFollowUp = !tablePointerTarget && preserveNextEditorPointerAfterTable
   if (tablePointerTarget) {
     preserveNextEditorPointerAfterTable = true
   } else if (shouldPreserveFollowUp) {
     preserveNextEditorPointerAfterTable = false
   }
-  if (tablePointerTarget || tableSelectionActive || shouldPreserveFollowUp) preserveWindowScrollAcrossFrames(12)
+  if (shouldPreserveEditorPointer || tablePointerTarget || tableSelectionActive || shouldPreserveFollowUp) {
+    preserveWindowScrollAcrossFrames(12)
+  }
 }
 
 export const shouldCenterBlockHandleForNode = (node?: BlockEditorDoc | null) =>


### PR DESCRIPTION
## 관련 이슈

close #333

## 작업 배경

- `/editor/[id]` 하단 본문 클릭 시 이전 selection anchor로 scrollTop이 되돌아가는 재발을 수정했습니다.
- ProseMirror 본문 pointer focus에서도 클릭 전 scrollTop을 보존하되, 사용자의 즉시 wheel/touch/key 입력은 보정을 취소해 본문 스크롤 차단 회귀를 막습니다.

## 작업 내용

- table 전용 scroll 보정을 editor 본문 pointer focus까지 확장했습니다.
- scroll 보정 중 실제 사용자 스크롤/키 입력이 들어오면 보정을 즉시 취소하도록 했습니다.
- 하단 본문 클릭 회귀 테스트를 추가하고, headless 병렬 실행에서 흔들리던 기존 handle/guide 시작 동작을 locator/미세 이동 기반으로 안정화했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "하단 본문 클릭은 이전 선택 위치"`: 패치 전 실패 확인
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "하단 본문 클릭|본문 클릭과 텍스트 선택|wide table hover"`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "writer surface의 table column resize drag|최우측 table column boundary|좌우로 흔들어도 guide"`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "edge hover에서만|native text selection 없이"`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 본문 pointer focus 보정 범위가 넓어졌으므로, 클릭 직후 입력/스크롤 이벤트와 충돌할 수 있습니다. wheel/touch/key 입력 시 보정 취소로 방어했습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
