### PR TITLE
[Fix] 글 관리 에러 상태 UX 정리

### DIFF
--- a/front/e2e/admin-posts-workspace.spec.ts
+++ b/front/e2e/admin-posts-workspace.spec.ts
@@ -5,6 +5,10 @@ import { expect, test } from "@playwright/test"
 test.describe("admin posts workspace link contract", () => {
   test("posts workspace uses detail-like hero copy and checklist rail labels", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspacePage.tsx"), "utf8")
+    const recentWorkSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspaceRecentWork.tsx"),
+      "utf8"
+    )
 
     expect(source).toContain("편집과 검수를 한 화면에서 이어갑니다")
     expect(source).not.toContain("최근 초안 복귀, 공개 상태 점검, 목록 필터링까지 지금 필요한 글 작업 흐름을 한곳에 모읍니다.")
@@ -12,48 +16,54 @@ test.describe("admin posts workspace link contract", () => {
     expect(source).not.toContain("<h2>상태 의미</h2>")
     expect(source).not.toContain("<h2>바로가기</h2>")
     expect(source).not.toContain("const WorkspaceRail = styled(AdminStickyRail)`")
-    expect(source).toContain("grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));")
+    expect(recentWorkSource).toContain("grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));")
   })
 
   test("관리자 글 목록은 제목 링크 same-tab 진입과 링크 복사 액션을 유지한다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspacePage.tsx"), "utf8")
+    const listSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspaceList.tsx"), "utf8")
+    const modelSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspaceModel.ts"), "utf8")
+    const recentWorkSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspaceRecentWork.tsx"),
+      "utf8"
+    )
 
-    expect(source).toContain('if (visibility === "PUBLIC_UNLISTED") return "링크 공개"')
+    expect(modelSource).toContain('if (visibility === "PUBLIC_UNLISTED") return "링크 공개"')
     expect(source).toContain("const buildCanonicalPostUrl = (postId: string | number) => {")
-    expect(source).toContain("const canOpenCanonicalPost = (row:")
-    expect(source).toContain("AdminInlineActionRow,")
-    expect(source).toContain("AdminStatusPill,")
-    expect(source).toContain("AdminTextActionButton,")
+    expect(modelSource).toContain("export const canOpenCanonicalPost = (row:")
+    expect(listSource).toContain("AdminInlineActionRow,")
+    expect(listSource).toContain("AdminStatusPill,")
+    expect(listSource).toContain("AdminTextActionButton,")
     expect(source).toContain("const openCanonicalPost = useCallback(")
-    expect(source).toContain("<TitleAnchor href={toCanonicalPostPath(row.id)} onClick={(event) => void openCanonicalPost(event, row)}>")
-    expect(source).toContain("<TitleText>{getWorkspaceRowTitle(row)}</TitleText>")
-    expect(source).toContain('<div className="metaRow">')
-    expect(source).toContain("const buildWorkspaceAuthorFallbackInitial = (authorName: string) => {")
-    expect(source).toContain('const renderAuthorMeta = (row: Pick<AdminPostListItem, "authorName" | "authorProfileImgUrl">) => {')
-    expect(source).toContain('const avatarSrc = (row.authorProfileImgUrl || "").trim()')
-    expect(source).toContain("<AuthorIdentity>")
-    expect(source).toContain('<AuthorAvatarFrame aria-hidden="true" data-has-image={avatarSrc ? "true" : "false"}>')
-    expect(source).toContain('<ProfileImage src={avatarSrc} alt="" fillContainer />')
-    expect(source).toContain("{renderAuthorMeta(row)}")
-    expect(source).not.toContain("resolveWorkspaceAuthorAvatarSrc")
-    expect(source).not.toContain('<div className="titleRow">')
+    expect(listSource).toContain("<TitleAnchor href={toCanonicalPostPath(row.id)} onClick={(event) => onOpenCanonicalPost(event, row)}>")
+    expect(listSource).toContain("<TitleText>{getWorkspaceRowTitle(row)}</TitleText>")
+    expect(listSource).toContain('<div className="metaRow">')
+    expect(modelSource).toContain("export const buildWorkspaceAuthorFallbackInitial = (authorName: string) => {")
+    expect(listSource).toContain('const renderAuthorMeta = (row: Pick<AdminPostListItem, "authorName" | "authorProfileImgUrl">) => {')
+    expect(listSource).toContain('const avatarSrc = (row.authorProfileImgUrl || "").trim()')
+    expect(listSource).toContain("<AuthorIdentity>")
+    expect(listSource).toContain('<AuthorAvatarFrame aria-hidden="true" data-has-image={avatarSrc ? "true" : "false"}>')
+    expect(listSource).toContain('<ProfileImage src={avatarSrc} alt="" fillContainer />')
+    expect(listSource).toContain("{renderAuthorMeta(row)}")
+    expect(listSource).not.toContain("resolveWorkspaceAuthorAvatarSrc")
+    expect(listSource).not.toContain('<div className="titleRow">')
     expect(source).toContain("copyPostDetailLink(row)")
-    expect(source).not.toContain("상세 열기")
-    expect(source).toContain("링크 복사")
-    expect(source).toContain("recentPosts.slice(0, 3)")
-    expect(source).toContain("grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));")
+    expect(listSource).not.toContain("상세 열기")
+    expect(listSource).toContain("링크 복사")
+    expect(recentWorkSource).toContain("recentPosts.slice(0, 3)")
+    expect(recentWorkSource).toContain("grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));")
     expect(source).toContain("<h1>편집과 검수를 한 화면에서 이어갑니다</h1>")
-    expect(source).toContain("const AuthorAvatarFrame = styled.span`")
-    expect(source).not.toContain("SecondaryLinkButton")
-    expect(source).toContain('<ResumeCardButton type="button" onClick={() => void openWriteRoute({ source: "local-draft" })}>')
-    expect(source).toContain("const ResumeCardButton = styled.button`")
-    expect(source).not.toContain('<PrimaryInlineButton type="button" onClick={() => void openWriteRoute({ source: "local-draft" })}>')
-    expect(source).not.toContain('data-emphasis={localDraft ? "strong" : "soft"}')
-    expect(source).not.toContain('data-clickable={localDraft ? "true" : undefined}')
+    expect(listSource).toContain("const AuthorAvatarFrame = styled.span`")
+    expect(listSource).not.toContain("SecondaryLinkButton")
+    expect(recentWorkSource).toContain('<ResumeCardButton type="button" onClick={() => onOpenWriteRoute({ source: "local-draft" })}>')
+    expect(recentWorkSource).toContain("const ResumeCardButton = styled.button`")
+    expect(recentWorkSource).not.toContain('<PrimaryInlineButton type="button" onClick={() => onOpenWriteRoute({ source: "local-draft" })}>')
+    expect(recentWorkSource).not.toContain('data-emphasis={localDraft ? "strong" : "soft"}')
+    expect(recentWorkSource).not.toContain('data-clickable={localDraft ? "true" : undefined}')
   })
 
   test("브라우저 임시저장 카드는 본문 markdown preview를 직접 노출하지 않는다", () => {
-    const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspacePage.tsx"), "utf8")
+    const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspaceRecentWork.tsx"), "utf8")
 
     expect(source).not.toContain("summary: summary || content.slice(0, 120)")
     expect(source).not.toContain("{localDraft.summary ? <ResumeDescription>{localDraft.summary}</ResumeDescription> : null}")
@@ -61,15 +71,28 @@ test.describe("admin posts workspace link contract", () => {
     expect(source).toContain("<ResumeTitle>{localDraft.title}</ResumeTitle>")
   })
 
+  test("글 관리 API 실패 문구는 raw fetch detail을 사용자-facing 상태에 직접 노출하지 않는다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspacePage.tsx"), "utf8")
+
+    expect(source).toContain("POSTS_LIST_LOAD_ERROR_MESSAGE")
+    expect(source).toContain("RECENT_POSTS_UNAVAILABLE_MESSAGE")
+    expect(source).not.toContain("글 목록을 불러오지 못했습니다: ${message}")
+    expect(source).not.toContain("최근 글을 불러오지 못했습니다: ${message}")
+  })
+
   test("관리자 작성 화면은 현재 편집 중인 글이면 visibility와 무관하게 canonical 링크 열기와 복사 액션을 노출한다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/EditorStudioPage.tsx"), "utf8")
+    const editorSurfaceSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx"),
+      "utf8"
+    )
 
     expect(source).toContain("const canOpenCurrentPostDetail = editorMode === \"edit\" && postId.trim().length > 0")
     expect(source).toContain("copyPostDetailLink(postId, postTitle)")
     expect(source).toContain("openPostDetailRoute(postId)")
-    expect(source).toContain("<EditorHeaderActionButton type=\"button\"")
-    expect(source).toContain("상세 열기")
-    expect(source).toContain("링크 복사")
+    expect(editorSurfaceSource).toContain("<EditorHeaderActionButton type=\"button\" onClick={onOpenPostDetail}>")
+    expect(editorSurfaceSource).toContain("상세 열기")
+    expect(editorSurfaceSource).toContain("링크 복사")
   })
 
   test("canonical detail static props는 ISR 생성 실패 시 recovery shell로 폴백한다", () => {
@@ -79,6 +102,9 @@ test.describe("admin posts workspace link contract", () => {
     expect(source).toContain("postDetail = await getPostDetailById(postId)")
     expect(source).toContain("const shouldServeClientRecoveryShell = shouldClientRecover || (IS_QA_STATIC_RECOVERY_MODE && !postDetail)")
     expect(source).toContain("if (!postDetail && !shouldServeClientRecoveryShell) return { notFound: true }")
-    expect(source).toContain("revalidate: shouldServeClientRecoveryShell ? DETAIL_RECOVERY_REVALIDATE_SECONDS : DETAIL_ISR_REVALIDATE_SECONDS,")
+    expect(source).toContain("revalidate:")
+    expect(source).toContain('shouldServeClientRecoveryShell || initialAdminProfileSource === "static-fallback"')
+    expect(source).toContain("? DETAIL_RECOVERY_REVALIDATE_SECONDS")
+    expect(source).toContain(": DETAIL_ISR_REVALIDATE_SECONDS,")
   })
 })

--- a/front/src/routes/Admin/AdminPostsWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspacePage.tsx
@@ -87,6 +87,8 @@ const EMPTY_INITIAL_SNAPSHOT: AdminPostsWorkspaceInitialSnapshot = {
 }
 const ADMIN_POSTS_SSR_LIST_CACHE_KEY = `admin-posts:list:${DEFAULT_SORT}:page=1:size=${DEFAULT_PAGE_SIZE}`
 const ADMIN_POSTS_SSR_LIST_CACHE_TTL_MS = 5_000
+const POSTS_LIST_LOAD_ERROR_MESSAGE = "글 목록 서버와 연결하지 못했습니다. 잠시 후 다시 시도해 주세요."
+const RECENT_POSTS_UNAVAILABLE_MESSAGE = "목록 연결 후 최근 수정 글을 표시합니다."
 
 const toEditorRoute = (query?: Record<string, string>) => {
   if (query?.postId) {
@@ -324,10 +326,9 @@ export const AdminPostWorkspacePage: NextPage<AdminPostsWorkspacePageProps> = ({
         .sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime())
         .slice(0, 5)
       setRecentPosts(rows)
-    } catch (error) {
+    } catch {
       if (recentRequestIdRef.current !== requestId) return
-      const message = error instanceof Error ? error.message : String(error)
-      setRecentError(`최근 글을 불러오지 못했습니다: ${message}`)
+      setRecentError(RECENT_POSTS_UNAVAILABLE_MESSAGE)
       setRecentPosts([])
     } finally {
       if (recentRequestIdRef.current === requestId) {
@@ -359,10 +360,9 @@ export const AdminPostWorkspacePage: NextPage<AdminPostsWorkspacePageProps> = ({
         total: data.pageable?.totalElements ?? data.content?.length ?? 0,
         loadedAt: new Date().toISOString(),
       })
-    } catch (error) {
+    } catch {
       if (listRequestIdRef.current !== requestId) return
-      const message = error instanceof Error ? error.message : String(error)
-      setListError(`글 목록을 불러오지 못했습니다: ${message}`)
+      setListError(POSTS_LIST_LOAD_ERROR_MESSAGE)
       setListState({ rows: [], total: 0, loadedAt: "" })
     } finally {
       if (listRequestIdRef.current === requestId) {


### PR DESCRIPTION
## 관련 이슈

close #344

## 작업 배경

- `/admin/posts` API 연결 실패 시 raw `Failed to fetch`가 목록과 최근 작업에 반복 노출되던 문제를 정리했습니다.
- 글 목록은 대표 오류 문구로 안내하고, 최근 작업은 목록 연결 후 표시되는 대기 상태로 낮췄습니다.

## 작업 내용

- 글 목록 fetch 실패 문구를 운영자용 고정 문구로 분리했습니다.
- 최근 작업 fetch 실패는 저수준 네트워크 오류 대신 대기 상태 문구를 보여주도록 바꿨습니다.
- 관리자 글 관리 source 계약 테스트를 현재 분리된 컴포넌트 구조 기준으로 갱신하고 raw fetch detail 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/admin-posts-workspace.spec.ts -g "API 실패 문구" --workers=1` (RED 확인 후 GREEN)
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/admin-posts-workspace.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-posts-workspace.spec.ts e2e/admin-layout-regression.spec.ts --workers=1`
  - `yarn --cwd front build`
  - Browser QA: 393x852 `/admin/posts`에서 대표 오류 문구 확인, backend 미연결 콘솔 오류는 QA 재현 조건으로 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: source-level 계약 테스트가 분리된 컴포넌트 파일 구조에 더 직접 의존합니다.
- 롤백 방법: 이 PR 커밋을 revert하면 기존 raw error 노출 방식과 이전 테스트 기대값으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
