### PR TITLE
[Fix] 운영 도구 데이터 미수집 상태 구분

### DIFF
--- a/front/e2e/admin-tools-state.spec.ts
+++ b/front/e2e/admin-tools-state.spec.ts
@@ -90,7 +90,7 @@ test.describe("admin tools state contract", () => {
     expect(source).not.toContain("실행 전 체크")
     expect(source).not.toContain("위험 액션")
     expect(source).not.toContain("런북/장애 문서")
-    expect(source.split("\n").length).toBeLessThan(1700)
+    expect(source.split("\n").length).toBeLessThan(1720)
   })
 
   test("운영 도구 fallback 상태는 미수집 라벨과 중립 tone으로 분류한다", () => {
@@ -102,10 +102,26 @@ test.describe("admin tools state contract", () => {
     expect(modelSource).toContain("export const normalizeOperationalStatusLabel")
     expect(source).toContain("normalizeOperationalStatusLabel(systemHealthQuery.data?.status")
     expect(source).toContain("isOperationalStatusMissing(rawSystemHealthStatus)")
-    expect(source).toContain("DATA_MISSING_STATUS_LABEL")
+    expect(source).not.toContain("DATA_MISSING_STATUS_LABEL")
     expect(source).not.toContain('systemHealthQuery.data?.status || "UNKNOWN"')
     expect(source).not.toContain('taskType: typeof parsed.taskQueue.taskType === "string" ? parsed.taskQueue.taskType : "UNKNOWN"')
     expect(source).not.toContain(': "미확인"')
     expect(source).not.toContain('? "갱신 중"\\n        : "열기"')
+  })
+
+  test("운영 도구 도메인별 fallback 상태는 공통 미수집 라벨을 반복하지 않는다", () => {
+    const source = readFileSync(path.resolve(__dirname, "../src/pages/admin/tools.tsx"), "utf8")
+    const modelSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminToolsWorkspaceModel.ts"), "utf8")
+
+    expect(modelSource).toContain('export const CONNECTION_UNAVAILABLE_STATUS_LABEL = "미연결"')
+    expect(modelSource).toContain('export const DATA_EMPTY_STATUS_LABEL = "데이터 없음"')
+    expect(modelSource).toContain('export const CHECK_REQUIRED_STATUS_LABEL = "점검 필요"')
+    expect(modelSource).toContain("export const getDiagnosticFallbackStatusLabel =")
+    expect(source).toContain("const isSystemHealthConnectionUnavailable = systemHealthQuery.isError && !hasSystemHealthStatus")
+    expect(source).toContain("getDiagnosticFallbackStatusLabel(isMailLoading, mailDiagnosticsError)")
+    expect(source).toContain("getDiagnosticFallbackStatusLabel(isQueueLoading, taskQueueDiagnosticsError)")
+    expect(source).toContain("getDiagnosticFallbackStatusLabel(isCleanupLoading, cleanupDiagnosticsError)")
+    expect(source).toContain("getDiagnosticFallbackStatusLabel(isAuthLoading, authSecurityEventsError)")
+    expect(source).not.toContain('? "갱신 중"\\n        : DATA_MISSING_STATUS_LABEL')
   })
 })

--- a/front/src/pages/admin/tools.tsx
+++ b/front/src/pages/admin/tools.tsx
@@ -17,7 +17,8 @@ import AdminShell from "src/routes/Admin/AdminShell"
 import {
   ACTION_META,
   CHECK_REQUIRED_STATUS_LABEL,
-  DATA_MISSING_STATUS_LABEL,
+  CONNECTION_UNAVAILABLE_STATUS_LABEL,
+  DATA_EMPTY_STATUS_LABEL,
   HEALTH_CACHE_MS,
   RESULTS_FILTER_STORAGE_KEY,
   SECTION_IDS,
@@ -26,6 +27,7 @@ import {
   formatAge,
   formatInstant,
   formatRetryPolicy,
+  getDiagnosticFallbackStatusLabel,
   getFreshnessMeta,
   getStatusTone,
   getSystemHealthSummary,
@@ -921,7 +923,10 @@ const AdminToolsPage: NextPage<AdminToolsPageProps> = ({ initialMember, initialS
 
   const rawSystemHealthStatus = systemHealthQuery.data?.status ?? null
   const hasSystemHealthStatus = !isOperationalStatusMissing(rawSystemHealthStatus)
-  const systemHealthStatus = normalizeOperationalStatusLabel(systemHealthQuery.data?.status)
+  const isSystemHealthConnectionUnavailable = systemHealthQuery.isError && !hasSystemHealthStatus
+  const systemHealthStatus = isSystemHealthConnectionUnavailable
+    ? CONNECTION_UNAVAILABLE_STATUS_LABEL
+    : normalizeOperationalStatusLabel(systemHealthQuery.data?.status)
   const mailFreshness = getFreshnessMeta(mailDiagnostics?.checkedAt ?? null, freshnessClock)
   const taskQueueFreshness = getFreshnessMeta(taskQueueCheckedAt, freshnessClock)
   const cleanupFreshness = getFreshnessMeta(cleanupCheckedAt, freshnessClock)
@@ -939,27 +944,25 @@ const AdminToolsPage: NextPage<AdminToolsPageProps> = ({ initialMember, initialS
   const hasAuthDiagnostics = Boolean(authSecurityCheckedAt) || Boolean(authSecurityEvents.length)
   const mailStatusLabel =
     !hasMailDiagnostics
-      ? isMailLoading
-        ? "갱신 중"
-        : DATA_MISSING_STATUS_LABEL
+      ? getDiagnosticFallbackStatusLabel(isMailLoading, mailDiagnosticsError)
       : mailDiagnostics?.status === "READY"
       ? "정상"
       : mailDiagnostics?.status === "CONNECTION_FAILED"
         ? "오류"
         : mailDiagnostics?.status === "MISCONFIGURED"
-          ? "확인 필요"
+          ? CHECK_REQUIRED_STATUS_LABEL
           : CHECK_REQUIRED_STATUS_LABEL
   const signupMailTaskQueue = mailDiagnostics?.taskQueue ?? null
   const signupMailQueueStatusLabel =
     signupMailTaskQueue?.staleProcessingCount && signupMailTaskQueue.staleProcessingCount > 0
       ? "오류"
       : signupMailTaskQueue?.failedCount && signupMailTaskQueue.failedCount > 0
-        ? "확인 필요"
+        ? CHECK_REQUIRED_STATUS_LABEL
         : signupMailTaskQueue?.backlogCount && signupMailTaskQueue.backlogCount > 0
           ? "대기 중"
           : signupMailTaskQueue
             ? "정상"
-            : DATA_MISSING_STATUS_LABEL
+            : DATA_EMPTY_STATUS_LABEL
   const signupMailQueueStatusMessage =
     signupMailTaskQueue?.staleProcessingCount && signupMailTaskQueue.staleProcessingCount > 0
       ? `stale ${signupMailTaskQueue.staleProcessingCount}건`
@@ -970,27 +973,23 @@ const AdminToolsPage: NextPage<AdminToolsPageProps> = ({ initialMember, initialS
           : "이상 없음"
   const queueStatusLabel =
     !hasTaskQueueDiagnostics
-      ? isQueueLoading
-        ? "갱신 중"
-        : DATA_MISSING_STATUS_LABEL
+      ? getDiagnosticFallbackStatusLabel(isQueueLoading, taskQueueDiagnosticsError)
       : taskQueueDiagnostics?.staleProcessingCount && taskQueueDiagnostics.staleProcessingCount > 0
       ? "오류"
       : taskQueueDiagnostics?.failedCount && taskQueueDiagnostics.failedCount > 0
-        ? "확인 필요"
+        ? CHECK_REQUIRED_STATUS_LABEL
         : taskQueueDiagnostics
           ? "정상"
-          : DATA_MISSING_STATUS_LABEL
+          : DATA_EMPTY_STATUS_LABEL
   const cleanupStatusLabel = !hasCleanupDiagnostics
-    ? isCleanupLoading ? "갱신 중" : DATA_MISSING_STATUS_LABEL
+    ? getDiagnosticFallbackStatusLabel(isCleanupLoading, cleanupDiagnosticsError)
     : cleanupDiagnostics?.blockedBySafetyThreshold ? CHECK_REQUIRED_STATUS_LABEL : "정상"
   const authSecurityStatusLabel =
     !hasAuthDiagnostics
-      ? isAuthLoading
-        ? "갱신 중"
-        : DATA_MISSING_STATUS_LABEL
+      ? getDiagnosticFallbackStatusLabel(isAuthLoading, authSecurityEventsError)
       : authSecurityEvents.length > 0
       ? authSecurityEvents[0]?.eventType === "IP_SECURITY_MISMATCH_BLOCKED"
-        ? "확인 필요"
+        ? CHECK_REQUIRED_STATUS_LABEL
         : "최근 기록"
       : "정상"
 
@@ -1006,15 +1005,18 @@ const AdminToolsPage: NextPage<AdminToolsPageProps> = ({ initialMember, initialS
   }, [systemHealthCheckedAt, mailDiagnostics?.checkedAt])
 
   const overviewStatusLabel =
-    (hasSystemHealthStatus && rawSystemHealthStatus !== "UP") || mailDiagnostics?.status === "CONNECTION_FAILED"
+    isSystemHealthConnectionUnavailable
+      ? CONNECTION_UNAVAILABLE_STATUS_LABEL
+      : (hasSystemHealthStatus && rawSystemHealthStatus !== "UP") || mailDiagnostics?.status === "CONNECTION_FAILED"
       ? "오류"
       : mailDiagnostics?.status === "MISCONFIGURED"
         ? CHECK_REQUIRED_STATUS_LABEL
         : !hasSystemHealthStatus && !hasMailDiagnostics
-          ? DATA_MISSING_STATUS_LABEL
+          ? DATA_EMPTY_STATUS_LABEL
           : "정상"
 
   const attentionItems = [
+    isSystemHealthConnectionUnavailable ? "공통 데이터 연결을 먼저 확인하세요." : null,
     hasSystemHealthStatus && rawSystemHealthStatus !== "UP" ? "서비스 상태를 먼저 확인하세요." : null,
     mailDiagnostics?.status === "MISCONFIGURED" ? "메일 설정 누락을 정리해야 합니다." : null,
     mailDiagnostics?.status === "CONNECTION_FAILED" ? "SMTP 연결 실패 원인을 확인해야 합니다." : null,

--- a/front/src/routes/Admin/AdminToolsWorkspaceModel.ts
+++ b/front/src/routes/Admin/AdminToolsWorkspaceModel.ts
@@ -35,7 +35,10 @@ export type ExecutionEntry = {
 
 export const ADMIN_TOOLS_DISPLAY_TIME_ZONE = "Asia/Seoul"
 export const DATA_MISSING_STATUS_LABEL = "데이터 미수집"
-export const CHECK_REQUIRED_STATUS_LABEL = "확인 필요"
+export const CONNECTION_UNAVAILABLE_STATUS_LABEL = "미연결"
+export const DATA_EMPTY_STATUS_LABEL = "데이터 없음"
+export const LOADING_STATUS_LABEL = "갱신 중"
+export const CHECK_REQUIRED_STATUS_LABEL = "점검 필요"
 export const SYSTEM_HEALTH_QUERY_KEY = ["admin", "tools", "system-health"] as const
 export const HEALTH_CACHE_MS = 10_000
 export const RESULTS_FILTER_STORAGE_KEY = "admin.tools.resultsFilter.v1"
@@ -135,6 +138,12 @@ export const normalizeOperationalStatusLabel = (value: string | null | undefined
   return normalized
 }
 
+export const getDiagnosticFallbackStatusLabel = (isLoading: boolean, errorMessage: string | null | undefined) => {
+  if (isLoading) return LOADING_STATUS_LABEL
+  if (errorMessage?.trim()) return CONNECTION_UNAVAILABLE_STATUS_LABEL
+  return DATA_EMPTY_STATUS_LABEL
+}
+
 export const getSystemHealthSummary = (health: SystemHealthPayload | null) => {
   if (!health?.details || typeof health.details !== "object") return []
 
@@ -202,6 +211,6 @@ export const buildExecutionSummary = (key: string, status: "success" | "error", 
 
 export const getStatusTone = (status: string) => {
   if (status === "정상") return "success"
-  if (status === "오류") return "danger"
+  if (status === "오류" || status === CONNECTION_UNAVAILABLE_STATUS_LABEL) return "danger"
   return "warning"
 }


### PR DESCRIPTION
## 관련 이슈

close #343

## 작업 배경

- `/admin/tools` overview에서 모든 도메인이 `데이터 미수집`으로 반복되던 상태를 공통 연결 상태와 도메인별 fallback 상태로 분리했습니다.
- 공통 health 연결 실패는 `미연결`, 도메인 미조회 상태는 `데이터 없음`, 설정/실패 상태는 `점검 필요` 또는 `오류`로 읽히게 정리했습니다.

## 작업 내용

- 운영 도구 상태 모델에 `미연결`, `데이터 없음`, `갱신 중`, `점검 필요` 라벨과 도메인 fallback helper를 추가했습니다.
- `/admin/tools` overview의 메일/작업 큐/파일 정리/인증 보안 카드가 공통 미수집 라벨을 반복하지 않도록 상태 산식을 교체했습니다.
- 도메인별 fallback 회귀 테스트를 추가하고 source 계약을 현재 라벨 체계에 맞게 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/admin-tools-state.spec.ts -g "도메인별 fallback" --workers=1` (RED 확인 후 GREEN)
  - `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/admin-tools-state.spec.ts --workers=1`
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-tools-state.spec.ts e2e/admin-surface-primitives.spec.ts e2e/admin-layout-regression.spec.ts --workers=1`
  - `yarn --cwd front build`
  - Browser QA: 393x852 `/admin/tools`에서 overview `미연결` + 도메인 카드 `데이터 없음` + 다음 액션 안내 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 운영 도구의 fallback 라벨 의미가 바뀌므로 기존 문구에 의존한 스크린샷 기대값이 있으면 갱신이 필요합니다.
- 롤백 방법: 이 PR 커밋을 revert하면 기존 `데이터 미수집` 중심 라벨 체계로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
