### PR TITLE
[Fix] 글수정 rich block 클릭 scroll jump 복구

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -1677,6 +1677,200 @@ test.describe("block editor authoring flow", () => {
     expect(Math.abs(afterGeometry.paragraphTop - beforeGeometry.paragraphTop)).toBeLessThanOrEqual(24)
   })
 
+  test("실제 /editor/[id] rich block 클릭은 이전 선택 위치로 scroll jump하지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const previousSelectionLabel = "rich block previous selection anchor"
+    const codeLabel = "rich code click scroll jump target"
+    const tableLabel = "rich table click scroll jump target"
+    const mermaidLabel = "RichMermaidClickTarget"
+    const leadParagraphs = Array.from({ length: 72 }, (_, index) =>
+      index === 50
+        ? `${previousSelectionLabel} ${index + 1}. rich block 클릭 전 이전 selection anchor가 남아 있는 본문입니다.`
+        : `rich block lead paragraph ${index + 1}. 긴 수정 문서에서 rich block 클릭 scrollTop 보존을 검증합니다.`
+    )
+    const codeMarkdown = ["```ts", `const marker = "${codeLabel}";`, "console.log(marker);", "```"].join("\n")
+    const tableMarkdown = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[160,220]} -->',
+      "| 구분 | 값 |",
+      "| --- | --- |",
+      `| table | ${tableLabel} |`,
+      "| expected | scroll 유지 |",
+    ].join("\n")
+    const mermaidMarkdown = [
+      "```mermaid",
+      "flowchart TD",
+      `  A[${mermaidLabel}] --> B[scroll 유지]`,
+      "```",
+    ].join("\n")
+    const trailingParagraphs = Array.from({ length: 20 }, (_, index) =>
+      `rich block trailing paragraph ${index + 1}. rich block 클릭 이후에도 화면 위치가 유지되어야 합니다.`
+    )
+    const content = [
+      "rich block 클릭 scroll jump 회귀 재현용 글입니다.",
+      ...leadParagraphs,
+      codeMarkdown,
+      tableMarkdown,
+      mermaidMarkdown,
+      ...trailingParagraphs,
+    ].join("\n\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/997", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 997,
+          version: 5,
+          title: "rich block 클릭 scroll jump 회귀 글",
+          content,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/997")
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+      "rich block 클릭 scroll jump 회귀 글"
+    )
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expectEditorToContainLoadedText(editor, codeLabel)
+
+    const previousSelectionParagraph = editor.locator("p", { hasText: previousSelectionLabel }).first()
+    await previousSelectionParagraph.scrollIntoViewIfNeeded()
+    const previousSelectionBox = await expectVisibleBox(
+      previousSelectionParagraph,
+      "previous rich block selection paragraph metrics are missing"
+    )
+    await page.mouse.move(
+      previousSelectionBox.x + Math.min(previousSelectionBox.width / 2, 260),
+      previousSelectionBox.y + Math.min(previousSelectionBox.height / 2, 18)
+    )
+    await previousSelectionParagraph.hover()
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    await dragHandle.click()
+    await expect(page.getByTestId("keyboard-block-selection-overlay")).toBeVisible()
+    const staleSelectionScrollTop = await page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+
+    const assertRichBlockClickPreservesScroll = async (
+      target: Locator,
+      label: string,
+      clickOffset = { x: 40, y: 24 }
+    ) => {
+      await target.scrollIntoViewIfNeeded()
+      const targetBox = await expectVisibleBox(target, `${label} metrics are missing before click`)
+
+      const beforeGeometry = await page.evaluate(
+        ({ selector, text }) => {
+          const candidates = Array.from(document.querySelectorAll<HTMLElement>(selector))
+          const target =
+            candidates.find((element) => {
+              const elementText =
+                element instanceof HTMLTextAreaElement ? element.value : element.textContent ?? ""
+              return elementText.includes(text)
+            }) ??
+            candidates[0] ??
+            null
+          if (!target) return null
+          const rect = target.getBoundingClientRect()
+          return {
+            scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+            targetTop: rect.top,
+            targetBottom: rect.bottom,
+            visible: rect.bottom > 0 && rect.top < window.innerHeight,
+          }
+        },
+        { selector: label === mermaidLabel ? ".aq-mermaid-code-input" : "[data-testid='block-editor-prosemirror'] *", text: label }
+      )
+      if (!beforeGeometry) {
+        throw new Error(`${label} geometry is missing before click`)
+      }
+      expect(beforeGeometry.visible).toBe(true)
+      await page.evaluate(
+        ({ staleScrollTop }) => {
+          const root = document.querySelector<HTMLElement>("[data-testid='block-editor-prosemirror']")
+          root?.addEventListener(
+            "pointerdown",
+            (event) => {
+              if (!(event.target instanceof Element)) return
+              if (!event.target.closest("[data-testid='block-editor-prosemirror']")) return
+              window.requestAnimationFrame(() => {
+                window.scrollTo(0, staleScrollTop)
+              })
+            },
+            { capture: true, once: true }
+          )
+        },
+        { staleScrollTop: staleSelectionScrollTop }
+      )
+
+      await page.mouse.click(
+        targetBox.x + Math.min(clickOffset.x, Math.max(8, targetBox.width - 8)),
+        targetBox.y + Math.min(clickOffset.y, Math.max(8, targetBox.height - 8))
+      )
+      await page.waitForTimeout(180)
+
+      const afterGeometry = await page.evaluate(
+        ({ selector, text }) => {
+          const candidates = Array.from(document.querySelectorAll<HTMLElement>(selector))
+          const target =
+            candidates.find((element) => {
+              const elementText =
+                element instanceof HTMLTextAreaElement ? element.value : element.textContent ?? ""
+              return elementText.includes(text)
+            }) ??
+            candidates[0] ??
+            null
+          if (!target) return null
+          const rect = target.getBoundingClientRect()
+          return {
+            scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+            targetTop: rect.top,
+            targetBottom: rect.bottom,
+          }
+        },
+        { selector: label === mermaidLabel ? ".aq-mermaid-code-input" : "[data-testid='block-editor-prosemirror'] *", text: label }
+      )
+      if (!afterGeometry) {
+        throw new Error(`${label} geometry is missing after click`)
+      }
+
+      expect(Math.abs(afterGeometry.scrollTop - beforeGeometry.scrollTop)).toBeLessThanOrEqual(24)
+      expect(Math.abs(afterGeometry.targetTop - beforeGeometry.targetTop)).toBeLessThanOrEqual(24)
+      expect(Math.abs(afterGeometry.targetBottom - beforeGeometry.targetBottom)).toBeLessThanOrEqual(24)
+    }
+
+    await assertRichBlockClickPreservesScroll(
+      editor.locator(".aq-mermaid-code-input").first(),
+      mermaidLabel,
+      { x: 42, y: 24 }
+    )
+    await assertRichBlockClickPreservesScroll(
+      editor.locator(".aq-code-editor-content", { hasText: codeLabel }).first(),
+      codeLabel
+    )
+    await assertRichBlockClickPreservesScroll(
+      editor.locator("table th, table td", { hasText: tableLabel }).first(),
+      tableLabel,
+      { x: 24, y: 16 }
+    )
+  })
+
   test("실제 /editor/[id] 수정 진입은 본문 hover scroll, 선택 block affordance, code 원문을 유지한다", async ({
     page,
   }) => {

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -3742,6 +3742,7 @@ const BlockEditorEngine = ({
       const activeEditor = editorRef.current ?? currentEditor
       if (!activeEditor) return
       if (!(event.target instanceof Node) || !activeEditor.view.dom.contains(event.target)) return
+      preserveWindowScrollForEditorPointerFocus(event.target, isTableSelectionActive(activeEditor))
       if (tryStartTableColumnResizeFromDomHandle(event.target, event.pointerId, event.clientX)) {
         event.preventDefault()
         event.stopPropagation()

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -139,13 +139,26 @@ let preserveNextEditorPointerAfterTable = false
 const EDITOR_POINTER_SCROLL_PRESERVE_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
 const EDITOR_POINTER_SCROLL_CONTROL_SELECTOR =
   "button, input, textarea, select, summary, [role='button'], [contenteditable='false']"
+const EDITOR_POINTER_SCROLL_RICH_BLOCK_SELECTOR = [
+  ".aq-code-shell",
+  ".aq-code-editor-content",
+  "[data-code-block-wrapper='true']",
+  ".aq-table-shell",
+  ".tableWrapper",
+  "table",
+  "[data-mermaid-block]",
+  ".aq-mermaid-code-input",
+  ".aq-mermaid",
+  ".aq-mermaid-stage",
+].join(", ")
 
 export const preserveWindowScrollForEditorPointerFocus = (target: EventTarget | null, tableSelectionActive: boolean) => {
   const targetElement = target instanceof Element ? target : target instanceof Node ? target.parentElement : null
   const tablePointerTarget = Boolean(targetElement?.closest(".aq-table-shell, .tableWrapper, table"))
   const editorPointerTarget = Boolean(targetElement?.closest(EDITOR_POINTER_SCROLL_PRESERVE_SELECTOR))
   const editorControlTarget = Boolean(targetElement?.closest(EDITOR_POINTER_SCROLL_CONTROL_SELECTOR))
-  const shouldPreserveEditorPointer = editorPointerTarget && !editorControlTarget
+  const editorRichBlockTarget = Boolean(targetElement?.closest(EDITOR_POINTER_SCROLL_RICH_BLOCK_SELECTOR))
+  const shouldPreserveEditorPointer = editorPointerTarget && (editorRichBlockTarget || !editorControlTarget)
   const shouldPreserveFollowUp = !tablePointerTarget && preserveNextEditorPointerAfterTable
   if (tablePointerTarget) {
     preserveNextEditorPointerAfterTable = true


### PR DESCRIPTION
## 관련 이슈

close #333

## 작업 배경

- 글 수정 화면에서 이전 block selection/focus anchor가 남은 상태로 코드블럭, 테이블, Mermaid 블럭을 클릭하면 이전 위치로 되돌아가는 scroll jump를 막습니다.
- rich block 내부 textarea/contenteditable/control target도 editor pointer scroll 보존 대상으로 포함하고, native capture 단계에서 보존을 시작하도록 정리했습니다.

## 작업 내용

- Mermaid textarea, code block, table 등 rich block 내부 클릭을 scroll preserve 대상으로 추가했습니다.
- document pointerdown capture에서 ProseMirror focus/selection reveal보다 먼저 window scroll 보존을 시작합니다.
- /editor/[id] rich block 클릭 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "rich block 클릭은 이전 선택 위치로 scroll jump하지 않는다"` (수정 전 RED: scroll delta 1220px, 수정 후 GREEN)
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (83 passed)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` (49 passed)
  - `git diff --cached --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: editor pointerdown 경로에서 scroll preserve 대상이 넓어져 rich block 내부 클릭 직후 의도하지 않은 programmatic scroll도 보존될 수 있습니다. wheel/touch/key 입력 시 기존 cancel guard가 유지됩니다.
- 롤백 방법: 이 PR의 단일 커밋 `c44328a6`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
