### PR TITLE
[Fix] 글수정 rich block 클릭 scroll jump 복구

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -1677,7 +1677,7 @@ test.describe("block editor authoring flow", () => {
     expect(Math.abs(afterGeometry.paragraphTop - beforeGeometry.paragraphTop)).toBeLessThanOrEqual(24)
   })
 
-  test("실제 /editor/[id] rich block 클릭은 이전 선택 위치로 scroll jump하지 않는다", async ({
+  test("실제 /editor/[id] rich block 클릭은 지연된 내부 focus reveal 이후에도 scroll jump하지 않는다", async ({
     page,
   }) => {
     await page.setViewportSize({ width: 980, height: 720 })
@@ -1809,9 +1809,9 @@ test.describe("block editor authoring flow", () => {
             (event) => {
               if (!(event.target instanceof Element)) return
               if (!event.target.closest("[data-testid='block-editor-prosemirror']")) return
-              window.requestAnimationFrame(() => {
+              window.setTimeout(() => {
                 window.scrollTo(0, staleScrollTop)
-              })
+              }, 260)
             },
             { capture: true, once: true }
           )
@@ -1823,7 +1823,7 @@ test.describe("block editor authoring flow", () => {
         targetBox.x + Math.min(clickOffset.x, Math.max(8, targetBox.width - 8)),
         targetBox.y + Math.min(clickOffset.y, Math.max(8, targetBox.height - 8))
       )
-      await page.waitForTimeout(180)
+      await page.waitForTimeout(420)
 
       const afterGeometry = await page.evaluate(
         ({ selector, text }) => {
@@ -1853,6 +1853,7 @@ test.describe("block editor authoring flow", () => {
       expect(Math.abs(afterGeometry.scrollTop - beforeGeometry.scrollTop)).toBeLessThanOrEqual(24)
       expect(Math.abs(afterGeometry.targetTop - beforeGeometry.targetTop)).toBeLessThanOrEqual(24)
       expect(Math.abs(afterGeometry.targetBottom - beforeGeometry.targetBottom)).toBeLessThanOrEqual(24)
+      await page.waitForTimeout(180)
     }
 
     await assertRichBlockClickPreservesScroll(

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -99,11 +99,12 @@ export const resolveBlockHandleRailLayoutForSurface = (
   }
 }
 
-export const preserveWindowScrollAcrossFrames = (frames = 6, tolerance = 4) => {
+export const preserveWindowScrollAcrossFrames = (frames = 6, tolerance = 4, minDurationMs = 0) => {
   if (typeof window === "undefined" || typeof document === "undefined") return
   const scrollingElement = document.scrollingElement
   const startX = window.scrollX
   const startY = scrollingElement?.scrollTop ?? window.scrollY
+  const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now()
   let cancelled = false
   let frame = 0
   const cancel = () => {
@@ -125,7 +126,8 @@ export const preserveWindowScrollAcrossFrames = (frames = 6, tolerance = 4) => {
       window.scrollTo(startX, startY)
     }
     frame += 1
-    if (frame < frames) {
+    const elapsedMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt
+    if (frame < frames || elapsedMs < minDurationMs) {
       window.requestAnimationFrame(restore)
     } else {
       cleanup()
@@ -136,6 +138,8 @@ export const preserveWindowScrollAcrossFrames = (frames = 6, tolerance = 4) => {
 
 let preserveNextEditorPointerAfterTable = false
 
+const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES = 12
+const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS = 520
 const EDITOR_POINTER_SCROLL_PRESERVE_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
 const EDITOR_POINTER_SCROLL_CONTROL_SELECTOR =
   "button, input, textarea, select, summary, [role='button'], [contenteditable='false']"
@@ -166,7 +170,11 @@ export const preserveWindowScrollForEditorPointerFocus = (target: EventTarget | 
     preserveNextEditorPointerAfterTable = false
   }
   if (shouldPreserveEditorPointer || tablePointerTarget || tableSelectionActive || shouldPreserveFollowUp) {
-    preserveWindowScrollAcrossFrames(12)
+    preserveWindowScrollAcrossFrames(
+      EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES,
+      4,
+      EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS
+    )
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

close #333

## 작업 배경

- `/editor/[id]`에서 코드블럭, 테이블, Mermaid 블럭 클릭 후 내부 focus/selection reveal이 늦게 실행될 때 이전 selection anchor로 scroll이 되돌아가는 경로를 막습니다.
- rich block pointer focus의 scroll 보존을 최소 시간 기준으로 보강하고, 동일 지연 reveal을 재현하는 editor e2e 회귀 테스트를 추가했습니다.
- main merge 후 기존 자동 배포 경로로 Vercel frontend 배포가 이어지며, 배포 후 실제 URL에서 같은 rich block 클릭 경로를 재확인합니다.

## 작업 내용

- rich block/table follow-up pointer focus scroll 보존을 12 frame + 최소 520ms로 확장했습니다.
- 코드블럭/테이블/Mermaid 클릭 시 260ms 지연 focus reveal이 발생해도 scrollY와 target rect가 유지되는 회귀 테스트로 교체했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "rich block 클릭은 지연된 내부 focus reveal 이후에도 scroll jump하지 않는다"` RED 확인: 기존 코드에서 `scrollTop` 1220px jump로 실패
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "rich block 클릭은 지연된 내부 focus reveal 이후에도 scroll jump하지 않는다"` GREEN 확인
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: rich block 클릭 직후 약 520ms 동안 programmatic scroll 보존이 유지됩니다. 사용자의 wheel/touch/key 입력은 기존처럼 즉시 취소되므로 의도적 스크롤은 막지 않습니다.
- 롤백 방법: 이 PR의 단일 커밋 `fix(editor): rich block scroll jump 재현 경로 보강`을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
