### PR TITLE
[Fix] 글 수정 페이지 반응 버튼 아이콘 크기 보정

### DIFF
--- a/front/e2e/mobile-layout.spec.ts
+++ b/front/e2e/mobile-layout.spec.ts
@@ -806,3 +806,58 @@ test("iPhone 15 Pro 상세 액션은 메타/공유/댓글/작성자 유틸리티
   expect((editBox?.y ?? 0)).toBeLessThan((likeBox?.y ?? 0))
   expect((deleteBox?.y ?? 0)).toBeLessThan((likeBox?.y ?? 0))
 })
+
+test.describe("데스크톱 상세 floating reaction 액션", () => {
+  test.use({
+    viewport: { width: 1440, height: 900 },
+    isMobile: false,
+    hasTouch: false,
+  })
+
+  test("하트/공유 아이콘은 원형 버튼 크기에 맞는 시각 크기를 유지한다", async ({ page }) => {
+    await mockDetailEndpoint(page, {
+      id: 993,
+      title: "반응 버튼 아이콘 크기 테스트",
+      likesCount: 0,
+      commentsCount: 0,
+      hitCount: 10,
+    })
+
+    await page.goto("/posts/993")
+    await expect(page.getByRole("heading", { name: "반응 버튼 아이콘 크기 테스트", level: 1 })).toBeVisible()
+
+    const metrics = await page.evaluate(() => {
+      const readMetric = (buttonSelector: string) => {
+        const button = document.querySelector<HTMLButtonElement>(buttonSelector)
+        const icon = button?.querySelector<SVGElement>("svg") ?? null
+        const buttonBox = button?.getBoundingClientRect() ?? null
+        const iconBox = icon?.getBoundingClientRect() ?? null
+        const iconStyle = icon ? window.getComputedStyle(icon) : null
+
+        return {
+          buttonWidth: buttonBox?.width ?? 0,
+          buttonHeight: buttonBox?.height ?? 0,
+          iconWidth: iconBox?.width ?? 0,
+          iconHeight: iconBox?.height ?? 0,
+          iconFontSize: iconStyle ? Number.parseFloat(iconStyle.fontSize) : 0,
+        }
+      }
+
+      return {
+        like: readMetric(".floatingLikeButton"),
+        share: readMetric(".floatingShareButton"),
+      }
+    })
+
+    expect(metrics.like.buttonWidth).toBeGreaterThanOrEqual(55.5)
+    expect(metrics.like.buttonHeight).toBeGreaterThanOrEqual(55.5)
+    expect(metrics.share.buttonWidth).toBeGreaterThanOrEqual(55.5)
+    expect(metrics.share.buttonHeight).toBeGreaterThanOrEqual(55.5)
+    expect(metrics.like.iconWidth).toBeGreaterThanOrEqual(28)
+    expect(metrics.like.iconHeight).toBeGreaterThanOrEqual(28)
+    expect(metrics.share.iconWidth).toBeGreaterThanOrEqual(28)
+    expect(metrics.share.iconHeight).toBeGreaterThanOrEqual(28)
+    expect(metrics.like.iconFontSize).toBeGreaterThanOrEqual(28)
+    expect(metrics.share.iconFontSize).toBeGreaterThanOrEqual(28)
+  })
+})

--- a/front/src/routes/Detail/PostDetail/index.tsx
+++ b/front/src/routes/Detail/PostDetail/index.tsx
@@ -1434,7 +1434,9 @@ const StyledWrapper = styled.div`
     transition: border-color 0.18s ease, background-color 0.18s ease, color 0.18s ease, transform 0.18s ease;
 
     svg {
-      font-size: 1.22rem;
+      width: 1em;
+      height: 1em;
+      font-size: 1.75rem;
     }
 
     &:hover {
@@ -1503,10 +1505,6 @@ const StyledWrapper = styled.div`
 
   .floatingShareButton {
     color: ${({ theme }) => theme.colors.gray10};
-
-    svg {
-      font-size: 1.08rem;
-    }
   }
 
   .floatingLikeCluster {


### PR DESCRIPTION
## 관련 이슈

close #353

## 작업 배경

- 글 수정/미리보기에서 보이는 공개 상세 반응 rail의 하트/공유 SVG가 56px 원형 버튼 대비 작게 보이던 문제를 수정했습니다.
- 두 아이콘을 동일한 28px 시각 크기로 맞추고, 버튼 크기와 배치 리듬은 유지했습니다.

## 작업 내용

- `.floatingActionButton svg` 크기를 1.75rem으로 통일하고 SVG width/height를 `1em` 기준으로 고정했습니다.
- 공유 버튼의 더 작은 개별 override를 제거했습니다.
- 데스크톱 상세 floating reaction 버튼 아이콘 크기를 검증하는 Playwright 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/mobile-layout.spec.ts -g "floating reaction" --workers=1` (RED 확인: 하트 SVG 19.515625px)
  - `PLAYWRIGHT_USE_WEBSERVER=false PLAYWRIGHT_BASE_URL=http://127.0.0.1:3110 yarn --cwd front playwright test e2e/mobile-layout.spec.ts -g "floating reaction" --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/mobile-layout.spec.ts e2e/smoke.spec.ts --workers=1` (2회 연속 통과)
  - commit hook: `yarn build`, `node scripts/check-bundle-size.mjs`, `yarn test:e2e:smoke`
  - Browser/Playwright QA: 1440x900에서 버튼 56x56px, 하트/공유 SVG 각각 28x28px 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 공개 상세 floating reaction rail의 아이콘이 기존보다 커져 주변 여백이 줄어드는 시각 변화가 있습니다. 버튼 자체 크기와 레이아웃은 유지했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `fix(editor): reaction icon 크기 보정`을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
