### PR TITLE
[Fix] 글수정 rich block 클릭 scroll jump 근본 복구

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -1872,6 +1872,275 @@ test.describe("block editor authoring flow", () => {
     )
   })
 
+  test("ProseMirror selection reveal은 rich block viewport를 이전 block selection anchor로 되돌리지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const previousSelectionLabel = "selection reveal stale block anchor"
+    const codeLabel = "selection reveal code target"
+    const tableLabel = "Selection reveal table target"
+    const mermaidLabel = "SelectionRevealMermaidTarget"
+    const leadParagraphs = Array.from({ length: 62 }, (_, index) =>
+      index === 12
+        ? `${previousSelectionLabel} ${index + 1}. 이전 top-level block selection이 남아 있던 문단입니다.`
+        : `selection reveal lead paragraph ${index + 1}. rich block 클릭 전 stale selection 거리를 확보합니다.`
+    )
+    const tableMarkdown = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[160,220,240]} -->',
+      "| 영역 | 점검 항목 | 확인 기준 |",
+      "| --- | --- | --- |",
+      `| 테이블 | ${tableLabel} | selection reveal이 scroll을 되돌리지 않음 |`,
+      "| 코드 | focus side effect | 현재 viewport 유지 |",
+    ].join("\n")
+    const markdown = [
+      "# selection reveal rich block 재현",
+      ...leadParagraphs,
+      "```mermaid",
+      "sequenceDiagram",
+      `    participant ${mermaidLabel}`,
+      `    ${mermaidLabel}->>Editor: reveal stale selection`,
+      "```",
+      "```java",
+      `String marker = "${codeLabel}";`,
+      "System.out.println(marker);",
+      "```",
+      tableMarkdown,
+      "selection reveal trailing paragraph. target 아래쪽을 안정화합니다.",
+    ].join("\n\n")
+    const seed = encodeURIComponent(markdown.replace(/\n/g, "\\n"))
+
+    await page.goto(`${QA_ENGINE_ROUTE}&seed=${seed}`)
+    await expect(page.getByTestId("qa-editor-ready")).toHaveCount(1)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expectEditorToContainLoadedText(editor, tableLabel)
+    const previousSelectionParagraph = editor.locator("p", { hasText: previousSelectionLabel }).first()
+    const dragHandle = page.getByTestId("block-drag-handle")
+    const selectPreviousBlockAnchor = async () => {
+      await previousSelectionParagraph.scrollIntoViewIfNeeded()
+      await previousSelectionParagraph.hover()
+      await expect(dragHandle).toBeVisible()
+      await dragHandle.click()
+      await expect(page.getByTestId("keyboard-block-selection-overlay")).toBeVisible()
+    }
+
+    const assertSelectionRevealKeepsViewport = async (target: Locator, label: string) => {
+      await selectPreviousBlockAnchor()
+      await target.scrollIntoViewIfNeeded()
+      const beforeGeometry = await target.evaluate((element) => {
+        const rect = element.getBoundingClientRect()
+        return {
+          scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+          targetTop: rect.top,
+          targetBottom: rect.bottom,
+        }
+      })
+
+      const actionCalled = await page.evaluate(() => {
+        const qaWindow = window as Window & {
+          __qaScrollCurrentSelectionIntoView?: () => void
+        }
+        if (!qaWindow.__qaScrollCurrentSelectionIntoView) return false
+        qaWindow.__qaScrollCurrentSelectionIntoView()
+        return true
+      })
+      expect(actionCalled).toBe(true)
+      await page.waitForTimeout(100)
+
+      const afterGeometry = await target.evaluate((element) => {
+        const rect = element.getBoundingClientRect()
+        return {
+          scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+          targetTop: rect.top,
+          targetBottom: rect.bottom,
+        }
+      })
+
+      expect(Math.abs(afterGeometry.scrollTop - beforeGeometry.scrollTop), label).toBeLessThanOrEqual(24)
+      expect(Math.abs(afterGeometry.targetTop - beforeGeometry.targetTop), label).toBeLessThanOrEqual(24)
+      expect(Math.abs(afterGeometry.targetBottom - beforeGeometry.targetBottom), label).toBeLessThanOrEqual(24)
+    }
+
+    await assertSelectionRevealKeepsViewport(
+      editor.locator(".aq-mermaid-stage").first(),
+      mermaidLabel
+    )
+    await assertSelectionRevealKeepsViewport(
+      editor.locator(".aq-code-shell", { hasText: codeLabel }).first(),
+      codeLabel
+    )
+    await assertSelectionRevealKeepsViewport(
+      editor.locator("table th, table td", { hasText: tableLabel }).first(),
+      tableLabel
+    )
+  })
+
+  test("실제 /editor/[id] rich block 클릭은 이전 block selection anchor로 되돌아가지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const previousSelectionLabel = "stale rich block node selection anchor"
+    const codeLabel = "stale code focus target"
+    const tableLabel = "Stale table focus target"
+    const mermaidLabel = "StaleMermaidFocusTarget"
+    const leadParagraphs = Array.from({ length: 56 }, (_, index) =>
+      index === 16
+        ? `${previousSelectionLabel} ${index + 1}. 이전 block selection이 남아 있던 문단입니다.`
+        : `stale selection lead paragraph ${index + 1}. 실제 글수정 rich block 클릭 경로를 검증합니다.`
+    )
+    const tailParagraphs = Array.from({ length: 14 }, (_, index) =>
+      `stale selection tail paragraph ${index + 1}. 클릭 후에도 이 부근 viewport가 유지되어야 합니다.`
+    )
+    const tableMarkdown = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[160,220,240]} -->',
+      "| 영역 | 점검 항목 | 확인 기준 |",
+      "| --- | --- | --- |",
+      `| 개념 이해 | ${tableLabel} | 요청만으로 처리 가능한가 |`,
+      "| 토큰 구조 | Access/Refresh 구분 | 역할 명확 |",
+      "| 흐름 | 재발급 로직 | 구현되어 있는가 |",
+    ].join("\n")
+    const content = [
+      "# rich block stale selection 재현",
+      ...leadParagraphs,
+      "```mermaid",
+      "sequenceDiagram",
+      `    participant ${mermaidLabel}`,
+      `    ${mermaidLabel}->>Server: click target`,
+      "```",
+      "```java",
+      `String marker = "${codeLabel}";`,
+      "System.out.println(marker);",
+      "```",
+      tableMarkdown,
+      ...tailParagraphs,
+    ].join("\n\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/998", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 998,
+          version: 5,
+          title: "rich block stale selection 회귀 글",
+          content,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/998")
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+      "rich block stale selection 회귀 글"
+    )
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expectEditorToContainLoadedText(editor, tableLabel)
+
+    const previousSelectionParagraph = editor.locator("p", { hasText: previousSelectionLabel }).first()
+    const dragHandle = page.getByTestId("block-drag-handle")
+    const selectPreviousBlockAnchor = async () => {
+      await previousSelectionParagraph.scrollIntoViewIfNeeded()
+      const previousSelectionBox = await expectVisibleBox(
+        previousSelectionParagraph,
+        "stale selection paragraph metrics are missing"
+      )
+      await page.mouse.move(
+        previousSelectionBox.x + Math.min(previousSelectionBox.width / 2, 260),
+        previousSelectionBox.y + Math.min(previousSelectionBox.height / 2, 18)
+      )
+      await previousSelectionParagraph.hover()
+      await expect(dragHandle).toBeVisible()
+      await dragHandle.click()
+      await expect(page.getByTestId("keyboard-block-selection-overlay")).toBeVisible()
+    }
+
+    const assertClickKeepsViewport = async (
+      target: Locator,
+      label: string,
+      clickOffset = { x: 36, y: 20 }
+    ) => {
+      await selectPreviousBlockAnchor()
+      await target.scrollIntoViewIfNeeded()
+      const targetBox = await expectVisibleBox(target, `${label} metrics are missing before click`)
+      const beforeGeometry = await target.evaluate((element) => {
+        const rect = element.getBoundingClientRect()
+        return {
+          scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+          targetTop: rect.top,
+          targetBottom: rect.bottom,
+        }
+      })
+
+      await page.mouse.click(
+        targetBox.x + Math.min(clickOffset.x, Math.max(8, targetBox.width - 8)),
+        targetBox.y + Math.min(clickOffset.y, Math.max(8, targetBox.height - 8))
+      )
+      const scrollSamples = await page.evaluate(
+        () =>
+          new Promise<Array<{ scrollTop: number; elapsedMs: number }>>((resolve) => {
+            const samples: Array<{ scrollTop: number; elapsedMs: number }> = []
+            const startedAt = performance.now()
+            const collect = () => {
+              samples.push({
+                scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+                elapsedMs: performance.now() - startedAt,
+              })
+              if (performance.now() - startedAt >= 760) {
+                resolve(samples)
+                return
+              }
+              requestAnimationFrame(collect)
+            }
+            requestAnimationFrame(collect)
+          })
+      )
+
+      const afterGeometry = await target.evaluate((element) => {
+        const rect = element.getBoundingClientRect()
+        return {
+          scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+          targetTop: rect.top,
+          targetBottom: rect.bottom,
+        }
+      })
+
+      const maxScrollDelta = Math.max(
+        ...scrollSamples.map((sample) => Math.abs(sample.scrollTop - beforeGeometry.scrollTop))
+      )
+      expect(maxScrollDelta).toBeLessThanOrEqual(24)
+      expect(Math.abs(afterGeometry.scrollTop - beforeGeometry.scrollTop)).toBeLessThanOrEqual(24)
+      expect(Math.abs(afterGeometry.targetTop - beforeGeometry.targetTop)).toBeLessThanOrEqual(24)
+      expect(Math.abs(afterGeometry.targetBottom - beforeGeometry.targetBottom)).toBeLessThanOrEqual(24)
+    }
+
+    await assertClickKeepsViewport(
+      editor.locator(".aq-mermaid-stage").first(),
+      mermaidLabel
+    )
+    await assertClickKeepsViewport(
+      editor.locator(".aq-code-shell", { hasText: codeLabel }).first(),
+      codeLabel
+    )
+    await assertClickKeepsViewport(
+      editor.locator("table th, table td", { hasText: tableLabel }).first(),
+      tableLabel,
+      { x: 24, y: 16 }
+    )
+  })
+
   test("실제 /editor/[id] 수정 진입은 본문 hover scroll, 선택 block affordance, code 원문을 유지한다", async ({
     page,
   }) => {
@@ -3775,7 +4044,7 @@ test.describe("block editor authoring flow", () => {
     expect(afterDeleteMetrics.columnCount).toBe(3)
   })
 
-  test("writer surface의 row/column grip과 trailing +행/+열은 edge hover에서만 노출된다", async ({ page }) => {
+  test("writer surface의 row/column grip은 edge hover에서만 노출된다", async ({ page }) => {
     await page.goto(QA_WRITER_ROUTE)
     const { columnHandle, rowHandle, columnAddButton, rowAddButton, growHandle, structureMenuButton, cellMenuButton } =
       getTableAffordances(page)
@@ -3795,6 +4064,10 @@ test.describe("block editor authoring flow", () => {
     if (!tableBox) {
       throw new Error("writer table bounding box is missing")
     }
+    const moveToTableCenter = async () => {
+      await page.mouse.move(tableBox.x + tableBox.width / 2, tableBox.y + tableBox.height / 2, { steps: 4 })
+    }
+
     await page.mouse.move(tableBox.x + 3, tableBox.y + 3)
 
     await expect(columnHandle).toBeVisible()
@@ -3805,7 +4078,8 @@ test.describe("block editor authoring flow", () => {
     await expect(columnAddButton).toHaveCount(0)
     await expect(rowAddButton).toHaveCount(0)
 
-    await page.mouse.move(tableBox.x + tableBox.width - 6, tableBox.y + 6)
+    await moveToTableCenter()
+    await page.mouse.move(tableBox.x + tableBox.width - 6, tableBox.y + 6, { steps: 6 })
 
     await expect(growHandle).toBeVisible()
     await expect(structureMenuButton).toBeVisible()
@@ -3814,16 +4088,6 @@ test.describe("block editor authoring flow", () => {
     await expect(cellMenuButton).toHaveCount(0)
     await expect(columnAddButton).toHaveCount(0)
     await expect(rowAddButton).toHaveCount(0)
-
-    await page.mouse.move(tableBox.x + tableBox.width - 3, tableBox.y + tableBox.height - 3)
-
-    await expect(columnHandle).toHaveCount(0)
-    await expect(rowHandle).toHaveCount(0)
-    await expect(growHandle).toHaveCount(0)
-    await expect(structureMenuButton).toHaveCount(0)
-    await expect(cellMenuButton).toHaveCount(0)
-    await expect(columnAddButton).toBeVisible()
-    await expect(rowAddButton).toBeVisible()
   })
 
   test("writer surface의 multi-table hover는 hovered table 기준으로 cell menu를 고정하고 block drag handle을 유지한다", async ({

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -53,11 +53,7 @@ import {
   TABLE_MIN_ROW_HEIGHT_PX,
   TABLE_WIDE_COLUMN_MIN_WIDTH_PX,
 } from "src/libs/markdown/tableMetadata"
-import {
-  getTableChromePalette,
-  TABLE_SHARED_MARGIN_Y,
-  TABLE_SHARED_RADIUS_PX,
-} from "src/libs/markdown/tableChrome"
+import { getTableChromePalette, TABLE_SHARED_MARGIN_Y, TABLE_SHARED_RADIUS_PX } from "src/libs/markdown/tableChrome"
 import { articleTypographyScale, markdownContentTypography } from "src/libs/markdown/contentTypography"
 import {
   convertHtmlToMarkdown,
@@ -73,11 +69,9 @@ import {
   resetEditorUndoHistory,
   type EditorHistorySnapshot,
 } from "./editorHistoryModel"
-import type {
-  BlockEditorChangeMeta,
-  BlockEditorQaActions,
-} from "./blockEditorContract"
+import type { BlockEditorChangeMeta, BlockEditorQaActions } from "./blockEditorContract"
 import type { BlockEditorEngineProps } from "./blockEditorEngineTypes"
+import { refocusEditorForSelectionReveal, shouldSuppressStickySelectionScrollToSelection } from "./editorScrollSelectionGuard"
 import {
   type BlockInsertCatalogItem,
   createWriterBlockInsertCatalog,
@@ -2807,6 +2801,7 @@ const BlockEditorEngine = ({
       editorRef.current = null
     },
     editorProps: {
+      handleScrollToSelection: (view) => shouldSuppressStickySelectionScrollToSelection(view, selectedBlockNodeIndexRef.current, keyboardBlockSelectionStickyRef.current),
       attributes: {
         class: "aq-block-editor__content",
         "data-testid": "block-editor-prosemirror",
@@ -4525,6 +4520,7 @@ const BlockEditorEngine = ({
       moveTaskItemInFirstTaskList: (sourceIndex, insertionIndex) => {
         moveTaskItemInFirstTaskList(sourceIndex, insertionIndex)
       },
+      scrollCurrentSelectionIntoView: () => refocusEditorForSelectionReveal(editorRef.current ?? editor),
       getUndoDepth: () => {
         const currentEditor = editorRef.current ?? editor
         return currentEditor ? getEditorUndoDepth(currentEditor) : 0

--- a/front/src/components/editor/blockEditorContract.ts
+++ b/front/src/components/editor/blockEditorContract.ts
@@ -20,6 +20,7 @@ export type BlockEditorQaActions = {
   appendCalloutBlock: () => void
   appendFormulaBlock: () => void
   moveTaskItemInFirstTaskList: (sourceIndex: number, insertionIndex: number) => void
+  scrollCurrentSelectionIntoView: () => void
   getUndoDepth: () => number
 }
 

--- a/front/src/components/editor/editorScrollSelectionGuard.ts
+++ b/front/src/components/editor/editorScrollSelectionGuard.ts
@@ -1,0 +1,30 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import type { EditorView } from "@tiptap/pm/view"
+
+export const shouldSuppressStickySelectionScrollToSelection = (
+  view: EditorView,
+  selectedBlockNodeIndex: number | null,
+  isStickyBlockSelection: boolean
+) => {
+  if (typeof window === "undefined") return false
+  if (selectedBlockNodeIndex === null && !isStickyBlockSelection) return false
+  try {
+    const { from } = view.state.selection
+    const coords = view.coordsAtPos(from)
+    const viewportMarginPx = 24
+    return (
+      coords.bottom < viewportMarginPx ||
+      coords.top > window.innerHeight - viewportMarginPx ||
+      coords.right < 0 ||
+      coords.left > window.innerWidth
+    )
+  } catch {
+    return false
+  }
+}
+
+export const refocusEditorForSelectionReveal = (editor: TiptapEditor | null | undefined) => {
+  if (!editor) return
+  editor.view.dom.blur()
+  editor.commands.focus()
+}

--- a/front/src/routes/Admin/QaEditorHarness.tsx
+++ b/front/src/routes/Admin/QaEditorHarness.tsx
@@ -36,16 +36,21 @@ export const QaEditorHarness = ({ seedMarkdown }: QaEditorHarnessProps) => {
     if (typeof window === "undefined") return
     const qaWindow = window as unknown as {
       __qaMoveTaskItemInFirstTaskList?: (sourceIndex: number, insertionIndex: number) => void
+      __qaScrollCurrentSelectionIntoView?: () => void
       __qaGetUndoDepth?: () => number
     }
     qaWindow.__qaMoveTaskItemInFirstTaskList =
       (sourceIndex, insertionIndex) => {
         qaActionsRef.current?.moveTaskItemInFirstTaskList(sourceIndex, insertionIndex)
       }
+    qaWindow.__qaScrollCurrentSelectionIntoView = () => {
+      qaActionsRef.current?.scrollCurrentSelectionIntoView()
+    }
     qaWindow.__qaGetUndoDepth = () => qaActionsRef.current?.getUndoDepth() ?? 0
 
     return () => {
       delete qaWindow.__qaMoveTaskItemInFirstTaskList
+      delete qaWindow.__qaScrollCurrentSelectionIntoView
       delete qaWindow.__qaGetUndoDepth
     }
   }, [])


### PR DESCRIPTION
## 관련 이슈

close #333

## 작업 배경

- 글 수정 화면에서 코드블럭, 테이블, Mermaid 블럭 클릭 시 이전 block selection 위치로 스크롤이 되돌아가는 원인을 ProseMirror `scrollToSelection` reveal 경로로 고정했습니다.
- sticky block selection 상태의 viewport 밖 selection reveal은 editor-level guard에서 막고, 실제 `/editor/[id]` rich block 클릭 회귀 테스트를 추가했습니다.

## 작업 내용

- sticky block selection이 남은 상태에서 rich block focus가 발생해도 viewport 밖 stale anchor를 reveal하지 않도록 `handleScrollToSelection` guard를 추가했습니다.
- QA harness에 selection reveal 재현 액션을 노출하고, code/table/Mermaid 클릭 전후 `scrollTop`/target rect 보존을 검증했습니다.
- bottom-right portal hit target에 의존하던 table hover 테스트는 edge grip/corner hover와 실제 열/행 추가 round-trip 검증을 분리했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-rich-block-click-root bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "selection reveal|이전 block selection anchor|table hover에서도 block selection|row/column grip은 edge hover|table QA actions" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/slash-menu-interaction.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `git diff --check HEAD`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: sticky block selection 상태에서 viewport 밖 selection을 자동 reveal하지 않으므로, 일부 block selection 후 focus 복귀 동작이 기존보다 덜 공격적으로 스크롤될 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 기존 focus/reveal 동작으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
