### PR TITLE
[Fix] 에디터 코드블럭 본문 소실 복구

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -1003,6 +1003,155 @@ test.describe("block editor authoring flow", () => {
     await expect(codeBlock.locator(".aq-code-highlight-layer")).toContainText("return invisibleRestored")
   })
 
+  test("실제 /editor/[id] 수정 진입은 content markdown 코드 본문만 있어도 코드블럭 본문을 유지한다", async ({
+    page,
+  }) => {
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const markdownOnlyContent = [
+      "코드 본문 보존 대상입니다.",
+      "",
+      "```text",
+      "로그인 -> 세션 생성 -> 이후 요청에서 세션 확인",
+      "```",
+      "",
+      "```java",
+      "public Token login(User user) {",
+      "",
+      "    String access = createAccessToken(user);",
+      "    String refresh = createRefreshToken(user);",
+      "",
+      "    return new Token(access, refresh);",
+      "}",
+      "```",
+      "",
+      "마지막 문단입니다.",
+    ].join("\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/994", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 994,
+          version: 10,
+          title: "코드 markdown-only 글",
+          content: markdownOnlyContent,
+          contentHtml: "",
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/994")
+
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("코드 markdown-only 글")
+    await expectEditorToContainLoadedText(
+      page.locator("[data-testid='block-editor-prosemirror']").first(),
+      "마지막 문단입니다."
+    )
+
+    const codeBlocks = page.locator(".aq-code-shell")
+    await expect(codeBlocks).toHaveCount(2)
+    await expect(codeBlocks.nth(0).locator(".aq-code-highlight-layer")).toContainText(
+      "로그인 -> 세션 생성 -> 이후 요청에서 세션 확인"
+    )
+    await expect(codeBlocks.nth(1).locator(".aq-code-highlight-layer")).toContainText("public Token login")
+    await expect(codeBlocks.nth(1).locator(".aq-code-highlight-layer")).toContainText(
+      "return new Token(access, refresh);"
+    )
+
+    await page.waitForTimeout(1_500)
+    await expect(codeBlocks.nth(0).locator(".aq-code-highlight-layer")).toContainText(
+      "로그인 -> 세션 생성 -> 이후 요청에서 세션 확인"
+    )
+    await expect(codeBlocks.nth(1).locator(".aq-code-highlight-layer")).toContainText("public Token login")
+  })
+
+  test("실제 /editor/[id] 수정 진입은 frontmatter와 inline color 뒤의 코드블럭 본문을 유지한다", async ({
+    page,
+  }) => {
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const markdownWithMetaAndColor = [
+      "---",
+      'tags: ["Stateless", "인증", "JWT"]',
+      'thumbnail: "https://api.aquilaxk.site/post/api/v1/images/posts/test.jpg#::aqfx=50::aqfy=60.1::aqfz=1"',
+      "---",
+      "",
+      "## **시작하며**",
+      "",
+      '왜냐하면 중요한건 {{color:#34d399|**"어디에" **}}저장하느냐가 아니라',
+      "",
+      "요청을 처리할 때 {{color:#fb923c|**\"무엇이\"**}} 필요하냐 이기 때문입니다.",
+      "",
+      "---",
+      "",
+      "## 왜 이 문제가 중요한가",
+      "",
+      "보통 처음 인증을 구현한다면 이런 식으로 할 것 입니다",
+      "",
+      "```text",
+      "로그인 -> 세션 생성 -> 이후 요청에서 세션 확인",
+      "```",
+      "",
+      "마지막 문단입니다.",
+    ].join("\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/995", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 995,
+          version: 11,
+          title: "코드 frontmatter 글",
+          content: markdownWithMetaAndColor,
+          contentHtml: "",
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/995")
+
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("코드 frontmatter 글")
+    await expectEditorToContainLoadedText(
+      page.locator("[data-testid='block-editor-prosemirror']").first(),
+      "마지막 문단입니다."
+    )
+
+    const codeBlock = page.locator(".aq-code-shell").first()
+    await expect(codeBlock).toBeVisible({ timeout: 15_000 })
+    await expect(codeBlock.locator(".aq-code-highlight-layer")).toContainText(
+      "로그인 -> 세션 생성 -> 이후 요청에서 세션 확인"
+    )
+    await page.waitForTimeout(1_500)
+    await expect(codeBlock.locator(".aq-code-highlight-layer")).toContainText(
+      "로그인 -> 세션 생성 -> 이후 요청에서 세션 확인"
+    )
+  })
+
   test("실제 /editor/[id] 텍스트 선택 후 block handle은 wheel scroll 중 선택 문단을 따라간다", async ({
     page,
   }) => {

--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -10,6 +10,7 @@ import {
 import { resolveEditorMetaSnapshot, restoreEmptyFencedCodeBlocks } from "src/routes/Admin/editorStudioMetaModel"
 import { getEditorStudioPageProps } from "src/routes/Admin/EditorStudioPage"
 import { buildPreviewSummaryFromMarkdown, normalizeCardSummary, normalizePersistedSummary } from "src/libs/postSummary"
+import { restoreEditorDocCodeBlocksFromMarkdown } from "src/components/editor/serialization"
 
 test.describe("editor studio state", () => {
   test("기존 글은 서버 baseline과 같으면 저장됨으로 본다", () => {
@@ -1155,6 +1156,40 @@ test.describe("editor studio state", () => {
     expect(resolveEditorMetaSnapshot(staleContent, prettyCodeHtml).body).toContain(
       ["```ts", "const answer = 42;", "return answer", "```"].join("\n")
     )
+  })
+
+  test("초기 editor doc의 빈 코드블럭은 source markdown의 non-empty fence로 복구한다", () => {
+    const sourceMarkdown = [
+      "코드 본문 보존 대상입니다.",
+      "",
+      "```text",
+      "로그인 -> 세션 생성 -> 이후 요청에서 세션 확인",
+      "```",
+      "",
+      "```java",
+      "public Token login(User user) {",
+      "",
+      "    return new Token(access, refresh);",
+      "}",
+      "```",
+    ].join("\n")
+    const staleDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "코드 본문 보존 대상입니다." }],
+        },
+        { type: "codeBlock", attrs: { language: "text" }, content: [] },
+        { type: "codeBlock", attrs: { language: "java" }, content: [] },
+      ],
+    }
+
+    const restored = restoreEditorDocCodeBlocksFromMarkdown(sourceMarkdown, staleDoc)
+
+    expect(restored.changed).toBe(true)
+    expect(restored.doc.content?.[1]?.content?.[0]?.text).toBe("로그인 -> 세션 생성 -> 이후 요청에서 세션 확인")
+    expect(restored.doc.content?.[2]?.content?.[0]?.text).toContain("return new Token(access, refresh);")
   })
 
   test("dedicated editor 나가기는 returnTo 복귀를 replace로 처리해 editor history 엔트리를 남기지 않는다", () => {

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -44,6 +44,7 @@ import {
   createToggleNode,
   createBulletListNode,
   parseMarkdownToEditorDoc,
+  restoreEditorDocCodeBlocksFromMarkdown,
   createEmptyTableNode,
   type BlockEditorDoc,
 } from "./serialization"
@@ -806,9 +807,7 @@ const BlockEditorEngine = ({
     scheduleMarkdownCommit,
     syncSerializedDoc,
   } = useBlockEditorMarkdownCommit({ value, onChange })
-  const initialDocRef = useRef(
-    downgradeDisabledFeatureNodes(parseMarkdownToEditorDoc(value), enableMermaidBlocks)
-  )
+  const initialDocRef = useRef(restoreEditorDocCodeBlocksFromMarkdown(value, downgradeDisabledFeatureNodes(parseMarkdownToEditorDoc(value), enableMermaidBlocks)).doc)
   const emptyHistoryStateRef = useRef<EditorHistorySnapshot | null>(null)
 
   const isSelectionInEmptyParagraph = useCallback(() => {
@@ -3823,15 +3822,18 @@ const BlockEditorEngine = ({
   }, [cancelBubbleHide, cancelHoveredBlockClear, cancelTableQuickRailHide])
 
   useEffect(() => {
-    if (!editor) return
-    if (!hasExternalMarkdownChanged(value)) {
-      return
-    }
-
+    if (!editor || !hasExternalMarkdownChanged(value)) return
     discardPendingMarkdownCommit()
-    const nextDoc = downgradeDisabledFeatureNodes(parseMarkdownToEditorDoc(value), enableMermaidBlocks)
+    const nextDoc = restoreEditorDocCodeBlocksFromMarkdown(value, downgradeDisabledFeatureNodes(parseMarkdownToEditorDoc(value), enableMermaidBlocks)).doc
     replaceEditorDocFromExternalValue(nextDoc, editor)
   }, [discardPendingMarkdownCommit, editor, enableMermaidBlocks, hasExternalMarkdownChanged, replaceEditorDocFromExternalValue, value])
+
+  useEffect(() => {
+    const restored = editor && value.trim() ? restoreEditorDocCodeBlocksFromMarkdown(value, editor.getJSON() as BlockEditorDoc) : null
+    if (!restored?.changed) return
+    discardPendingMarkdownCommit()
+    replaceEditorDocFromExternalValue(restored.doc, editor!)
+  }, [discardPendingMarkdownCommit, editor, replaceEditorDocFromExternalValue, value])
 
   useEffect(
     () => () => {

--- a/front/src/components/editor/serialization.ts
+++ b/front/src/components/editor/serialization.ts
@@ -1372,6 +1372,79 @@ export const parseMarkdownToEditorDoc = (markdown: string): BlockEditorDoc => {
   }
 }
 
+const readPlainTextFromEditorNode = (node: JSONContent): string => {
+  if (node.type === "text") return typeof node.text === "string" ? node.text : ""
+  return (node.content || []).map((child) => readPlainTextFromEditorNode(child)).join("")
+}
+
+const collectCodeBlockSnapshots = (doc: JSONContent) => {
+  const blocks: Array<{ language: string | null; text: string }> = []
+
+  const visit = (node: JSONContent) => {
+    if (node.type === "codeBlock") {
+      blocks.push({
+        language: typeof node.attrs?.language === "string" ? node.attrs.language : null,
+        text: readPlainTextFromEditorNode(node),
+      })
+      return
+    }
+
+    ;(node.content || []).forEach(visit)
+  }
+
+  visit(doc)
+  return blocks
+}
+
+export const restoreEditorDocCodeBlocksFromMarkdown = (
+  sourceMarkdown: string,
+  doc: BlockEditorDoc
+): { doc: BlockEditorDoc; changed: boolean } => {
+  const sourceBlocks = collectCodeBlockSnapshots(parseMarkdownToEditorDoc(sourceMarkdown))
+  if (sourceBlocks.every((block) => block.text.trim().length === 0)) {
+    return { doc, changed: false }
+  }
+
+  let codeBlockIndex = 0
+  let changed = false
+
+  const restoreNode = (node: JSONContent): JSONContent => {
+    if (node.type === "codeBlock") {
+      const sourceBlock = sourceBlocks[codeBlockIndex]
+      codeBlockIndex += 1
+
+      const currentText = readPlainTextFromEditorNode(node)
+      const sourceText = sourceBlock?.text || ""
+      if (currentText.trim().length > 0 || sourceText.trim().length === 0) return node
+
+      changed = true
+      const currentLanguage = typeof node.attrs?.language === "string" ? node.attrs.language : null
+      return {
+        ...node,
+        attrs: {
+          ...(node.attrs || {}),
+          language: currentLanguage || sourceBlock?.language || null,
+        },
+        content: [{ type: "text", text: sourceText }],
+      }
+    }
+
+    if (!node.content?.length) return node
+
+    let childChanged = false
+    const nextContent = node.content.map((child) => {
+      const nextChild = restoreNode(child)
+      if (nextChild !== child) childChanged = true
+      return nextChild
+    })
+
+    return childChanged ? { ...node, content: nextContent } : node
+  }
+
+  const restoredDoc = restoreNode(doc)
+  return { doc: changed ? restoredDoc : doc, changed }
+}
+
 const escapePipeText = (text: string) => text.replace(/\\/g, "\\\\").replace(/\|/g, "\\|")
 
 const serializeTextNode = (node: JSONContent) => {


### PR DESCRIPTION
## 관련 이슈

close #357

## 작업 배경

- `/editor/[id]` 수정 진입에서 서버 원문 markdown에는 fenced code body가 있지만 에디터 doc의 `codeBlock` 본문만 빈 노드가 되는 회귀를 복구합니다.
- 빈 `codeBlock` doc이 감지되면 source markdown의 non-empty fence를 기준으로 본문을 재주입해 코드블럭 shell만 남는 상태를 막습니다.
- code/table/Mermaid 중심 editor authoring 회귀와 smoke/mobile 회귀를 같은 조건에서 2회 연속 확인했습니다.

## 작업 내용

- source markdown에서 non-empty `codeBlock` snapshot을 수집하고, 빈 editor doc `codeBlock`만 복구하는 serialization helper를 추가했습니다.
- `BlockEditorEngine` 초기 hydrate, 외부 value 동기화, 이미 비어버린 live editor doc 보정 경로에 코드블럭 복구를 연결했습니다.
- `/editor/[id]` markdown-only 글과 frontmatter/inline color 뒤 코드블럭 본문 유지 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-code-block-content bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts -g "빈 코드블럭|contentHtml fallback" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts -g "markdown 코드 본문|frontmatter와 inline color|코드|code" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (2회 연속 통과; 1차 라인 수 가드 실패 후 수정, 이후 2회 연속 통과)
  - `yarn --cwd front build` (2회 연속 통과)
  - `yarn --cwd front check:bundle-size` (2회 연속 통과)
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` (2회 연속 통과)
  - `git diff --check HEAD`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: source markdown과 editor doc의 code block 순서가 이미 크게 어긋난 비정상 상태에서는 positional 복구가 의도와 다를 수 있습니다. 현재 복구는 빈 `codeBlock`에만 적용하고, non-empty code block은 덮어쓰지 않습니다.
- 롤백 방법: 이 PR의 단일 커밋 `fix(editor): code block 본문 소실 복구`를 revert하면 됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
