### PR TITLE
[Refactor] EditorStudio workspace panel props 계약 축소

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -143,6 +143,14 @@ test.describe("editor studio state", () => {
     const dedicatedEditorSurfaceSource = existsSync(dedicatedEditorSurfacePath)
       ? readFileSync(dedicatedEditorSurfacePath, "utf8")
       : ""
+    const dedicatedEditorSurfacePartsPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx"
+    )
+    expect(existsSync(dedicatedEditorSurfacePartsPath)).toBe(true)
+    const dedicatedEditorSurfacePartsSource = existsSync(dedicatedEditorSurfacePartsPath)
+      ? readFileSync(dedicatedEditorSurfacePartsPath, "utf8")
+      : ""
     const editorStudioStateSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/editorStudioState.ts"), "utf8")
     const editorStudioMetaModelPath = path.resolve(__dirname, "../src/routes/Admin/editorStudioMetaModel.ts")
     expect(existsSync(editorStudioMetaModelPath)).toBe(true)
@@ -301,6 +309,14 @@ test.describe("editor studio state", () => {
     const editorStudioPostListPanelSource = existsSync(editorStudioPostListPanelPath)
       ? readFileSync(editorStudioPostListPanelPath, "utf8")
       : ""
+    const editorStudioPostListPanelPartsPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioPostListPanelParts.tsx"
+    )
+    expect(existsSync(editorStudioPostListPanelPartsPath)).toBe(true)
+    const editorStudioPostListPanelPartsSource = existsSync(editorStudioPostListPanelPartsPath)
+      ? readFileSync(editorStudioPostListPanelPartsPath, "utf8")
+      : ""
     const editorStudioContentWorkspacePath = path.resolve(
       __dirname,
       "../src/routes/Admin/EditorStudioContentWorkspace.tsx"
@@ -356,6 +372,14 @@ test.describe("editor studio state", () => {
     expect(existsSync(editorStudioComposeWritingSurfacePath)).toBe(true)
     const editorStudioComposeWritingSurfaceSource = existsSync(editorStudioComposeWritingSurfacePath)
       ? readFileSync(editorStudioComposeWritingSurfacePath, "utf8")
+      : ""
+    const editorStudioComposeWritingSurfacePartsPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioComposeWritingSurfaceParts.tsx"
+    )
+    expect(existsSync(editorStudioComposeWritingSurfacePartsPath)).toBe(true)
+    const editorStudioComposeWritingSurfacePartsSource = existsSync(editorStudioComposeWritingSurfacePartsPath)
+      ? readFileSync(editorStudioComposeWritingSurfacePartsPath, "utf8")
       : ""
     const editorStudioComposeWorkspacePath = path.resolve(
       __dirname,
@@ -553,14 +577,14 @@ test.describe("editor studio state", () => {
     const floatingBubbleStateSource = existsSync(floatingBubbleStatePath) ? readFileSync(floatingBubbleStatePath, "utf8") : ""
     const writerEditorHostSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/WriterEditorHost.tsx"), "utf8")
     const rootLayoutSource = readFileSync(path.resolve(__dirname, "../src/layouts/RootLayout/index.tsx"), "utf8")
-    const dedicatedEditorRootStyle = dedicatedEditorSurfaceSource.match(
-      /const EditorStudioRoot = styled\.main`([\s\S]*?)`\n\nconst EditorStudioLoadingState/
+    const dedicatedEditorRootStyle = dedicatedEditorSurfacePartsSource.match(
+      /export const EditorStudioRoot = styled\.main`([\s\S]*?)`\n\nexport const EditorStudioLoadingState/
     )?.[1] ?? ""
-    const dedicatedEditorFrameStyle = dedicatedEditorSurfaceSource.match(
-      /const EditorStudioFrame = styled\.div`([\s\S]*?)`\n\nconst EditorStudioWritingColumn/
+    const dedicatedEditorFrameStyle = dedicatedEditorSurfacePartsSource.match(
+      /export const EditorStudioFrame = styled\.div`([\s\S]*?)`\n\nexport const EditorStudioWritingColumn/
     )?.[1] ?? ""
-    const dedicatedEditorTopBarStyle = dedicatedEditorSurfaceSource.match(
-      /const EditorStudioTopBar = styled\.div`([\s\S]*?)`\n\nconst EditorExitAction/
+    const dedicatedEditorTopBarStyle = dedicatedEditorSurfacePartsSource.match(
+      /export const EditorStudioDedicatedTopBar = styled\.div`([\s\S]*?)`\n\nexport const EditorExitAction/
     )?.[1] ?? ""
     const blockEditorShellStyle = blockEditorEngineStylesSource.match(
       /const Shell = styled\.div`([\s\S]*?)`\n\nconst Toolbar/
@@ -607,7 +631,7 @@ test.describe("editor studio state", () => {
     expect(quickInsertActionsStyle).toContain("min-width: 0;")
     expect(quickInsertActionsStyle).toContain("max-width: 100%;")
     expect(quickInsertButtonStyle).toContain("white-space: nowrap;")
-    expect(dedicatedEditorSurfaceSource).toContain("grid-template-columns: minmax(0, 1fr);")
+    expect(dedicatedEditorSurfacePartsSource).toContain("grid-template-columns: minmax(0, 1fr);")
     expect(dedicatedEditorSurfaceSource).toContain('data-testid="editor-studio-frame"')
     expect(editorStudioSource).toContain('import { WriterEditorHost } from "./WriterEditorHost"')
     expect(editorStudioSource.match(/<WriterEditorHost/g)?.length).toBe(2)
@@ -623,10 +647,10 @@ test.describe("editor studio state", () => {
     expect(editorStudioSource).not.toContain('aria-label="미리보기 기기 폭"')
     expect(editorStudioSource).not.toContain('zoom: var(--preview-scale, 1);')
     expect(editorStudioSource).not.toContain("--preview-scale")
-    expect(dedicatedEditorSurfaceSource).toContain("const EditorExitAction = styled.button`")
-    expect(dedicatedEditorSurfaceSource).toContain("min-height: 42px;")
-    expect(dedicatedEditorSurfaceSource).toContain("const EditorStudioFrame = styled.div`")
-    expect(dedicatedEditorSurfaceSource).toContain("const EditorStudioWritingColumn = styled.section<{ $compact?: boolean }>`")
+    expect(dedicatedEditorSurfacePartsSource).toContain("export const EditorExitAction = styled.button`")
+    expect(dedicatedEditorSurfacePartsSource).toContain("min-height: 42px;")
+    expect(dedicatedEditorSurfacePartsSource).toContain("export const EditorStudioFrame = styled.div`")
+    expect(dedicatedEditorSurfacePartsSource).toContain("export const EditorStudioWritingColumn = styled.section<{ $compact?: boolean }>`")
     expect(editorStudioSource).not.toContain("type EditorMode =")
     expect(editorStudioSource).not.toContain("type PublishActionType =")
     expect(editorStudioSource).not.toContain("type PostVisibility =")
@@ -802,9 +826,9 @@ test.describe("editor studio state", () => {
       'import { EditorStudioPostListPanel } from "./EditorStudioPostListPanel"'
     )
     expect(editorStudioContentWorkspaceSource.match(/<EditorStudioPostListPanel/g)?.length).toBe(1)
-    expect(editorStudioPostListPanelSource).toContain("관리자 글 리스트")
-    expect(editorStudioPostListPanelSource).toContain("삭제 글 리스트")
-    expect(editorStudioPostListPanelSource).toContain("현재 목록 전체 선택")
+    expect(editorStudioPostListPanelPartsSource).toContain("관리자 글 리스트")
+    expect(editorStudioPostListPanelPartsSource).toContain("삭제 글 리스트")
+    expect(editorStudioPostListPanelPartsSource).toContain("현재 목록 전체 선택")
     expect(editorStudioSource).not.toContain("<ListPanel")
     expect(editorStudioSource).not.toContain("const ListPanel = styled.div`")
     expect(editorStudioSource).not.toContain("const ListTable = styled.table`")
@@ -935,9 +959,9 @@ test.describe("editor studio state", () => {
     expect(editorStudioComposeWorkspaceSource).toContain("const PrimaryButton = styled(Button)`")
     expect(editorStudioComposeWorkspaceSource).not.toContain("data-mobile-visible={!isCompactMobileLayout}")
     expect(editorStudioComposeWorkspaceSource).not.toContain('[data-mobile-visible="false"]')
-    expect(editorStudioComposeWritingSurfaceSource).toContain("const ComposeMainColumn = styled.div`")
-    expect(editorStudioComposeWritingSurfaceSource).toContain("const TitleInput = styled.textarea`")
-    expect(editorStudioComposeWritingSurfaceSource).toContain("const WriterFooterBar = styled.div`")
+    expect(editorStudioComposeWritingSurfacePartsSource).toContain("export const EditorStudioComposeMainColumn = styled.div`")
+    expect(editorStudioComposeWritingSurfacePartsSource).toContain("export const TitleInput = styled.textarea`")
+    expect(editorStudioComposeWritingSurfacePartsSource).toContain("export const EditorStudioComposeFooterBar = styled.div`")
     expect(editorStudioSource).not.toContain("const ComposeSurfaceSection = styled")
     expect(editorStudioSource).not.toContain("const ComposeStudioLayout = styled.div`")
     expect(editorStudioSource).not.toContain("const SubActionRow = styled.div`")
@@ -1873,5 +1897,76 @@ test.describe("editor studio state", () => {
     expect(qaHarnessSource).toContain('dynamic(() => import("src/components/editor/BlockEditorShell")')
     expect(qaHarnessSource).toContain("BlockEditorShell 엔진 QA")
     expect(qaHarnessSource).toContain("실제 글쓰기 화면 레이아웃과 제목 입력칸 회귀는")
+  })
+
+  test("editor studio workspace panel props는 하위 view contract로 분리된다", () => {
+    const routeAdminDir = path.resolve(__dirname, "../src/routes/Admin")
+    const targetFiles = [
+      "EditorStudioPostListPanel.tsx",
+      "EditorStudioPublishModal.tsx",
+      "EditorStudioComposeWritingSurface.tsx",
+      "EditorStudioDedicatedEditorSurface.tsx",
+    ]
+    const partFiles = [
+      "EditorStudioPostListPanelParts.tsx",
+      "EditorStudioPostListPanelStyles.tsx",
+      "EditorStudioPostListActionStyles.tsx",
+      "EditorStudioPublishModalParts.tsx",
+      "EditorStudioPublishModalStyles.tsx",
+      "EditorStudioComposeWritingSurfaceParts.tsx",
+      "EditorStudioDedicatedEditorSurfaceParts.tsx",
+    ]
+
+    for (const partFile of partFiles) {
+      expect(existsSync(path.join(routeAdminDir, partFile)), `${partFile} should own extracted panel views`).toBe(true)
+    }
+
+    for (const targetFile of targetFiles) {
+      const source = readFileSync(path.join(routeAdminDir, targetFile), "utf8")
+      expect(source.split("\n").length, `${targetFile} should stay under the panel root budget`).toBeLessThanOrEqual(600)
+      expect(source).not.toContain("apiFetch(")
+      expect(source).not.toContain("run(")
+      expect(source).not.toContain("setPost")
+      expect(source).not.toContain("WriterEditorHost")
+    }
+
+    for (const partFile of partFiles) {
+      const source = readFileSync(path.join(routeAdminDir, partFile), "utf8")
+      expect(source.split("\n").length, `${partFile} should stay under the companion budget`).toBeLessThanOrEqual(600)
+    }
+
+    const postListSource = readFileSync(path.join(routeAdminDir, "EditorStudioPostListPanel.tsx"), "utf8")
+    const postListPartsSource = readFileSync(path.join(routeAdminDir, "EditorStudioPostListPanelParts.tsx"), "utf8")
+    expect(postListSource).toContain('from "./EditorStudioPostListPanelParts"')
+    expect(postListPartsSource).toContain("export const EditorStudioPostListTable =")
+    expect(postListPartsSource).toContain("export const EditorStudioPostListMobileCards =")
+
+    const publishModalSource = readFileSync(path.join(routeAdminDir, "EditorStudioPublishModal.tsx"), "utf8")
+    const publishModalPartsSource = readFileSync(path.join(routeAdminDir, "EditorStudioPublishModalParts.tsx"), "utf8")
+    expect(publishModalSource).toContain('from "./EditorStudioPublishModalParts"')
+    expect(publishModalPartsSource).toContain("export const EditorStudioPublishVisibilitySection =")
+    expect(publishModalPartsSource).toContain("export const EditorStudioPublishPreviewCard =")
+    expect(publishModalPartsSource).toContain("export const EditorStudioPublishCardSettings =")
+
+    const composeSurfaceSource = readFileSync(path.join(routeAdminDir, "EditorStudioComposeWritingSurface.tsx"), "utf8")
+    const composeSurfacePartsSource = readFileSync(
+      path.join(routeAdminDir, "EditorStudioComposeWritingSurfaceParts.tsx"),
+      "utf8"
+    )
+    expect(composeSurfaceSource).toContain('from "./EditorStudioComposeWritingSurfaceParts"')
+    expect(composeSurfacePartsSource).toContain("export const EditorStudioComposeHeaderSection =")
+    expect(composeSurfacePartsSource).toContain("export const EditorStudioComposeMetadataSection =")
+    expect(composeSurfacePartsSource).toContain("export const EditorStudioComposeBodySection =")
+    expect(composeSurfacePartsSource).toContain("export const EditorStudioComposeFooterBar =")
+
+    const dedicatedSurfaceSource = readFileSync(path.join(routeAdminDir, "EditorStudioDedicatedEditorSurface.tsx"), "utf8")
+    const dedicatedSurfacePartsSource = readFileSync(
+      path.join(routeAdminDir, "EditorStudioDedicatedEditorSurfaceParts.tsx"),
+      "utf8"
+    )
+    expect(dedicatedSurfaceSource).toContain('from "./EditorStudioDedicatedEditorSurfaceParts"')
+    expect(dedicatedSurfacePartsSource).toContain("export const EditorStudioDedicatedTopBar =")
+    expect(dedicatedSurfacePartsSource).toContain("export const EditorStudioDedicatedMetaSection =")
+    expect(dedicatedSurfacePartsSource).toContain("export const EditorStudioDedicatedCanvasSection =")
   })
 })

--- a/front/e2e/mobile-layout.spec.ts
+++ b/front/e2e/mobile-layout.spec.ts
@@ -48,8 +48,14 @@ test("grid design은 전 사용자-facing 화면 토큰을 사용하고 article 
   ].join("\n")
   const authShellSource = readSourceFile("src/components/auth/AuthShell.tsx")
   const errorSource = readSourceFile("src/routes/Error/index.tsx")
-  const editorComposeSource = readSourceFile("src/routes/Admin/EditorStudioComposeWritingSurface.tsx")
-  const editorDedicatedSource = readSourceFile("src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx")
+  const editorComposeSource = [
+    readSourceFile("src/routes/Admin/EditorStudioComposeWritingSurface.tsx"),
+    readSourceFile("src/routes/Admin/EditorStudioComposeWritingSurfaceParts.tsx"),
+  ].join("\n")
+  const editorDedicatedSource = [
+    readSourceFile("src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx"),
+    readSourceFile("src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx"),
+  ].join("\n")
   const editorPreviewSource = readSourceFile("src/routes/Admin/EditorActualPreviewPage.tsx")
 
   expect(themeSource).toContain('blogDesign === "grid"')

--- a/front/src/routes/Admin/EditorStudioComposeWritingSurface.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeWritingSurface.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled"
 import type {
   ChangeEventHandler,
   KeyboardEvent as ReactKeyboardEvent,
@@ -6,7 +5,37 @@ import type {
   ReactNode,
   Ref,
 } from "react"
-import { articleTypographyScale } from "src/libs/markdown/contentTypography"
+import {
+  ComposeBodyHeader,
+  ComposeBodyMetrics,
+  ComposeBodyTitleGroup,
+  ComposeStudioContextBar,
+  ComposeStudioContextItem,
+  ComposeStudioHeaderCopy,
+  ComposeStudioKicker,
+  ComposeSummaryField,
+  ComposeSummaryInput,
+  ComposeSummaryMeta,
+  EditorStudioComposeBodySection,
+  EditorStudioComposeFooterBar,
+  EditorStudioComposeHeaderSection,
+  EditorStudioComposeMainColumn,
+  EditorStudioComposeMetadataSection,
+  FieldLabel,
+  InlineMetaInput,
+  InlineTagComposer,
+  InlineTagList,
+  PrimaryButton,
+  SelectedTagChip,
+  SummaryCounter,
+  TitleInput,
+  WriterAccent,
+  WriterFooterActions,
+  WriterFooterControls,
+  WriterFooterSummary,
+  WriterHeader,
+  Button,
+} from "./EditorStudioComposeWritingSurfaceParts"
 
 type EditorStudioComposeWritingSurfaceProps = {
   editorModeLabel: string
@@ -90,8 +119,8 @@ export const EditorStudioComposeWritingSurface = ({
   const trimmedSummary = postSummary.trim()
 
   return (
-    <ComposeMainColumn>
-      <ComposeStudioHeader>
+    <EditorStudioComposeMainColumn>
+      <EditorStudioComposeHeaderSection>
         <ComposeStudioHeaderCopy>
           <ComposeStudioKicker>{editorModeLabel}</ComposeStudioKicker>
           <h2>{composePageTitle}</h2>
@@ -113,9 +142,9 @@ export const EditorStudioComposeWritingSurface = ({
             <strong>{trimmedSummary ? `${trimmedSummary.length}자` : "자동 생성"}</strong>
           </ComposeStudioContextItem>
         </ComposeStudioContextBar>
-      </ComposeStudioHeader>
+      </EditorStudioComposeHeaderSection>
 
-      <ComposeReadableIntro>
+      <EditorStudioComposeMetadataSection>
         <WriterHeader>
           <div className="titleField">
             <TitleInput
@@ -188,7 +217,7 @@ export const EditorStudioComposeWritingSurface = ({
             />
           </InlineTagList>
         </InlineTagComposer>
-      </ComposeReadableIntro>
+      </EditorStudioComposeMetadataSection>
 
       <input
         ref={thumbnailImageFileInputRef}
@@ -198,7 +227,7 @@ export const EditorStudioComposeWritingSurface = ({
         style={{ display: "none" }}
       />
 
-      <ComposeBodySection>
+      <EditorStudioComposeBodySection>
         <ComposeBodyHeader>
           <ComposeBodyTitleGroup>
             <h3>본문</h3>
@@ -210,9 +239,9 @@ export const EditorStudioComposeWritingSurface = ({
           </ComposeBodyMetrics>
         </ComposeBodyHeader>
         {editorCanvas}
-      </ComposeBodySection>
+      </EditorStudioComposeBodySection>
 
-      <WriterFooterBar>
+      <EditorStudioComposeFooterBar>
         <WriterFooterSummary>
           <span>{tagSummaryText}</span>
           <span>{contentLength}자 · {lineCount}줄</span>
@@ -227,489 +256,7 @@ export const EditorStudioComposeWritingSurface = ({
             </PrimaryButton>
           </WriterFooterActions>
         </WriterFooterControls>
-      </WriterFooterBar>
-    </ComposeMainColumn>
+      </EditorStudioComposeFooterBar>
+    </EditorStudioComposeMainColumn>
   )
 }
-
-const ComposeMainColumn = styled.div`
-  display: grid;
-  gap: 1.1rem;
-  min-width: 0;
-`
-
-const ComposeStudioHeader = styled.div`
-  display: grid;
-  gap: 0.9rem;
-
-  @media (min-width: 960px) {
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: start;
-  }
-`
-
-const ComposeStudioHeaderCopy = styled.div`
-  display: grid;
-  gap: 0.28rem;
-  min-width: 0;
-
-  h2 {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: clamp(1.45rem, 2.3vw, 2rem);
-    line-height: 1.15;
-    font-weight: 760;
-    letter-spacing: 0;
-  }
-
-  p {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.92rem;
-    line-height: 1.58;
-    max-width: 34rem;
-  }
-`
-
-const ComposeStudioKicker = styled.span`
-  display: inline-flex;
-  align-items: center;
-  width: fit-content;
-  color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray10)};
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0;
-  text-transform: uppercase;
-`
-
-const ComposeStudioContextBar = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-  justify-content: flex-start;
-
-  @media (min-width: 960px) {
-    justify-content: flex-end;
-  }
-`
-
-const ComposeStudioContextItem = styled.div`
-  display: grid;
-  gap: 0.08rem;
-  min-width: 7rem;
-  padding: 0.5rem 0.68rem;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "4px" : "12px")};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2)};
-
-  span {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.68rem;
-    font-weight: 700;
-  }
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.82rem;
-    font-weight: 720;
-    line-height: 1.35;
-  }
-
-  &[data-tone="loading"] strong {
-    color: ${({ theme }) => theme.colors.blue11};
-  }
-
-  &[data-tone="success"] strong {
-    color: ${({ theme }) => theme.colors.green11};
-  }
-
-  &[data-tone="error"] strong {
-    color: ${({ theme }) => theme.colors.red11};
-  }
-`
-
-const WriterHeader = styled.div`
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1rem;
-  margin-bottom: 0.55rem;
-
-  .titleField {
-    display: grid;
-    gap: 1rem;
-    min-width: 0;
-  }
-`
-
-const WriterAccent = styled.div`
-  width: 5rem;
-  height: 0.42rem;
-  border-radius: 999px;
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray8)};
-`
-
-const TitleInput = styled.textarea`
-  width: 100%;
-  min-width: 0;
-  border: 0;
-  border-radius: 0;
-  padding: 0;
-  min-height: 44px;
-  background: transparent;
-  box-shadow: none;
-  font-family: inherit;
-  font-size: ${articleTypographyScale.postTitleFontSize};
-  font-weight: 700;
-  line-height: ${articleTypographyScale.postTitleLineHeight};
-  letter-spacing: 0;
-  resize: none;
-  overflow: hidden;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.gray9};
-  }
-
-  &:focus {
-    box-shadow: none;
-    border-color: transparent;
-  }
-
-  @media (max-width: 720px) {
-    font-size: ${articleTypographyScale.postTitleFontSizeMobile};
-    line-height: ${articleTypographyScale.postTitleLineHeightMobile};
-  }
-`
-
-const ComposeReadableIntro = styled.div`
-  width: 100%;
-  max-width: var(--article-readable-width, 48rem);
-  min-width: 0;
-  margin-inline: auto;
-  display: grid;
-  gap: 1rem;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
-  padding: ${({ theme }) => (theme.blogDesign === "grid" ? "1rem" : "0")};
-`
-
-const ComposeSummaryField = styled.div`
-  display: grid;
-  gap: 0.45rem;
-`
-
-const FieldLabel = styled.label`
-  font-size: 0.8rem;
-  font-weight: 650;
-  color: ${({ theme }) => theme.colors.gray11};
-`
-
-const ComposeSummaryInput = styled.textarea`
-  width: 100%;
-  min-height: 5.6rem;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "4px" : "16px")};
-  padding: 0.95rem 1rem;
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray2)};
-  color: ${({ theme }) => theme.colors.gray12};
-  font-size: 1rem;
-  line-height: 1.7;
-  resize: vertical;
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.gray10};
-  }
-
-  &:focus-visible {
-    outline: none;
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray7)};
-    box-shadow: 0 0 0 3px ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.blue4)};
-  }
-`
-
-const ComposeSummaryMeta = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.7rem;
-  flex-wrap: wrap;
-`
-
-const SummaryCounter = styled.span`
-  justify-self: end;
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.74rem;
-  line-height: 1;
-`
-
-const InlineTagComposer = styled.div`
-  display: grid;
-  gap: 0.55rem;
-  min-width: 0;
-
-  .label {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.88rem;
-    font-weight: 700;
-  }
-
-  .headerRow {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.6rem;
-    flex-wrap: wrap;
-  }
-
-  .status {
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.78rem;
-    font-weight: 600;
-  }
-`
-
-const InlineTagList = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  min-height: auto;
-  align-items: center;
-  border-radius: 0;
-  border: none;
-  background: transparent;
-  padding: 0;
-`
-
-const InlineMetaInput = styled.input`
-  width: 100%;
-  max-width: 100%;
-  box-sizing: border-box;
-  flex: 1 1 12rem;
-  min-width: 11rem;
-  border: 0;
-  border-bottom: 1px dashed ${({ theme }) => theme.colors.gray6};
-  outline: none;
-  min-height: 32px;
-  padding: 0 0.12rem;
-  border-radius: 0;
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray12};
-  font-size: 0.86rem;
-  font-weight: 500;
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.gray10};
-  }
-
-  &:focus-visible {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors.blue8};
-    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
-  }
-`
-
-const SelectedTagChip = styled.span`
-  display: inline-flex;
-  align-items: stretch;
-  gap: 0;
-  min-width: 0;
-  max-width: 100%;
-  min-height: 32px;
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3)};
-  overflow: hidden;
-  transition:
-    border-color 0.18s ease,
-    transform 0.18s ease,
-    background 0.18s ease;
-
-  &:hover {
-    transform: none;
-  }
-
-  .label {
-    display: inline-flex;
-    align-items: center;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    padding: 0.38rem 0.78rem;
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.86rem;
-    font-weight: 600;
-    line-height: 1;
-  }
-
-  button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    align-self: stretch;
-    min-width: 1.92rem;
-    padding: 0 0.52rem;
-    border: 0;
-    border-left: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray2)};
-    color: ${({ theme }) => theme.colors.gray10};
-    cursor: pointer;
-    flex: 0 0 auto;
-    font-size: 0.98rem;
-    line-height: 1;
-    transition:
-      transform 0.18s ease,
-      background 0.18s ease,
-      color 0.18s ease;
-
-    &:hover {
-      transform: none;
-      background: ${({ theme }) => theme.colors.gray4};
-      color: ${({ theme }) => theme.colors.gray12};
-    }
-  }
-`
-
-const ComposeBodySection = styled.section`
-  display: grid;
-  gap: 0.82rem;
-`
-
-const ComposeBodyHeader = styled.div`
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 0.75rem;
-  width: 100%;
-  max-width: var(--article-readable-width, 48rem);
-  min-width: 0;
-  margin-inline: auto;
-  padding-top: 0.2rem;
-
-  @media (max-width: 720px) {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-`
-
-const ComposeBodyTitleGroup = styled.div`
-  display: grid;
-  gap: 0.14rem;
-
-  h3 {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.98rem;
-    font-weight: 760;
-    line-height: 1.3;
-  }
-`
-
-const ComposeBodyMetrics = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  flex-wrap: wrap;
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.76rem;
-  line-height: 1.4;
-`
-
-const WriterFooterBar = styled.div`
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.8rem;
-  flex-wrap: wrap;
-  margin-top: 0.84rem;
-  padding-top: 0.72rem;
-  border-top: 1px solid ${({ theme }) => theme.colors.gray6};
-`
-
-const WriterFooterSummary = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.52rem 0.72rem;
-  color: ${({ theme }) => theme.colors.gray11};
-  font-size: 0.76rem;
-  line-height: 1.45;
-`
-
-const WriterFooterControls = styled.div`
-  display: grid;
-  gap: 0.52rem;
-  justify-items: stretch;
-  flex: 1 1 34rem;
-  width: min(100%, 48rem);
-  min-width: min(100%, 34rem);
-  max-width: 100%;
-  margin-left: auto;
-
-  @media (max-width: 720px) {
-    width: 100%;
-    min-width: 100%;
-  }
-`
-
-const WriterFooterActions = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
-  justify-content: flex-end;
-  align-items: center;
-
-  @media (max-width: 720px) {
-    display: none;
-  }
-`
-
-const Button = styled.button`
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 8px;
-  padding: 0.62rem 0.92rem;
-  min-height: 44px;
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray10};
-  cursor: pointer;
-  font-size: 0.84rem;
-  font-weight: 600;
-  transition:
-    border-color 0.18s ease,
-    background-color 0.18s ease,
-    color 0.18s ease,
-    box-shadow 0.18s ease;
-
-  &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.gray8};
-    background: ${({ theme }) => theme.colors.gray3};
-    color: ${({ theme }) => theme.colors.gray12};
-  }
-
-  &:focus-visible {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors.blue8};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
-  }
-
-  &:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
-  }
-`
-
-const PrimaryButton = styled(Button)`
-  border-radius: 8px;
-  padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => theme.colors.blue9};
-  background: ${({ theme }) => theme.colors.blue9};
-  color: ${({ theme }) => theme.colors.gray1};
-  font-weight: 700;
-
-  &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.blue10};
-    background: ${({ theme }) => theme.colors.blue10};
-    color: ${({ theme }) => theme.colors.gray1};
-  }
-`

--- a/front/src/routes/Admin/EditorStudioComposeWritingSurfaceParts.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeWritingSurfaceParts.tsx
@@ -1,0 +1,484 @@
+import styled from "@emotion/styled"
+import { articleTypographyScale } from "src/libs/markdown/contentTypography"
+
+export const EditorStudioComposeMainColumn = styled.div`
+  display: grid;
+  gap: 1.1rem;
+  min-width: 0;
+`
+
+export const EditorStudioComposeHeaderSection = styled.div`
+  display: grid;
+  gap: 0.9rem;
+
+  @media (min-width: 960px) {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+  }
+`
+
+export const ComposeStudioHeaderCopy = styled.div`
+  display: grid;
+  gap: 0.28rem;
+  min-width: 0;
+
+  h2 {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: clamp(1.45rem, 2.3vw, 2rem);
+    line-height: 1.15;
+    font-weight: 760;
+    letter-spacing: 0;
+  }
+
+  p {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.92rem;
+    line-height: 1.58;
+    max-width: 34rem;
+  }
+`
+
+export const ComposeStudioKicker = styled.span`
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray10)};
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+`
+
+export const ComposeStudioContextBar = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  justify-content: flex-start;
+
+  @media (min-width: 960px) {
+    justify-content: flex-end;
+  }
+`
+
+export const ComposeStudioContextItem = styled.div`
+  display: grid;
+  gap: 0.08rem;
+  min-width: 7rem;
+  padding: 0.5rem 0.68rem;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "4px" : "12px")};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2)};
+
+  span {
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.68rem;
+    font-weight: 700;
+  }
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.82rem;
+    font-weight: 720;
+    line-height: 1.35;
+  }
+
+  &[data-tone="loading"] strong {
+    color: ${({ theme }) => theme.colors.blue11};
+  }
+
+  &[data-tone="success"] strong {
+    color: ${({ theme }) => theme.colors.green11};
+  }
+
+  &[data-tone="error"] strong {
+    color: ${({ theme }) => theme.colors.red11};
+  }
+`
+
+export const WriterHeader = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin-bottom: 0.55rem;
+
+  .titleField {
+    display: grid;
+    gap: 1rem;
+    min-width: 0;
+  }
+`
+
+export const WriterAccent = styled.div`
+  width: 5rem;
+  height: 0.42rem;
+  border-radius: 999px;
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray8)};
+`
+
+export const TitleInput = styled.textarea`
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  min-height: 44px;
+  background: transparent;
+  box-shadow: none;
+  font-family: inherit;
+  font-size: ${articleTypographyScale.postTitleFontSize};
+  font-weight: 700;
+  line-height: ${articleTypographyScale.postTitleLineHeight};
+  letter-spacing: 0;
+  resize: none;
+  overflow: hidden;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray9};
+  }
+
+  &:focus {
+    box-shadow: none;
+    border-color: transparent;
+  }
+
+  @media (max-width: 720px) {
+    font-size: ${articleTypographyScale.postTitleFontSizeMobile};
+    line-height: ${articleTypographyScale.postTitleLineHeightMobile};
+  }
+`
+
+export const EditorStudioComposeMetadataSection = styled.div`
+  width: 100%;
+  max-width: var(--article-readable-width, 48rem);
+  min-width: 0;
+  margin-inline: auto;
+  display: grid;
+  gap: 1rem;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
+  padding: ${({ theme }) => (theme.blogDesign === "grid" ? "1rem" : "0")};
+`
+
+export const ComposeSummaryField = styled.div`
+  display: grid;
+  gap: 0.45rem;
+`
+
+export const FieldLabel = styled.label`
+  font-size: 0.8rem;
+  font-weight: 650;
+  color: ${({ theme }) => theme.colors.gray11};
+`
+
+export const ComposeSummaryInput = styled.textarea`
+  width: 100%;
+  min-height: 5.6rem;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "4px" : "16px")};
+  padding: 0.95rem 1rem;
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray2)};
+  color: ${({ theme }) => theme.colors.gray12};
+  font-size: 1rem;
+  line-height: 1.7;
+  resize: vertical;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray10};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray7)};
+    box-shadow: 0 0 0 3px ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.blue4)};
+  }
+`
+
+export const ComposeSummaryMeta = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+`
+
+export const SummaryCounter = styled.span`
+  justify-self: end;
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.74rem;
+  line-height: 1;
+`
+
+export const InlineTagComposer = styled.div`
+  display: grid;
+  gap: 0.55rem;
+  min-width: 0;
+
+  .label {
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.88rem;
+    font-weight: 700;
+  }
+
+  .headerRow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+  }
+
+  .status {
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.78rem;
+    font-weight: 600;
+  }
+`
+
+export const InlineTagList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  min-height: auto;
+  align-items: center;
+  border-radius: 0;
+  border: none;
+  background: transparent;
+  padding: 0;
+`
+
+export const InlineMetaInput = styled.input`
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  flex: 1 1 12rem;
+  min-width: 11rem;
+  border: 0;
+  border-bottom: 1px dashed ${({ theme }) => theme.colors.gray6};
+  outline: none;
+  min-height: 32px;
+  padding: 0 0.12rem;
+  border-radius: 0;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray12};
+  font-size: 0.86rem;
+  font-weight: 500;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray10};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
+  }
+`
+
+export const SelectedTagChip = styled.span`
+  display: inline-flex;
+  align-items: stretch;
+  gap: 0;
+  min-width: 0;
+  max-width: 100%;
+  min-height: 32px;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3)};
+  overflow: hidden;
+  transition:
+    border-color 0.18s ease,
+    transform 0.18s ease,
+    background 0.18s ease;
+
+  &:hover {
+    transform: none;
+  }
+
+  .label {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding: 0.38rem 0.78rem;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.86rem;
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    align-self: stretch;
+    min-width: 1.92rem;
+    padding: 0 0.52rem;
+    border: 0;
+    border-left: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray2)};
+    color: ${({ theme }) => theme.colors.gray10};
+    cursor: pointer;
+    flex: 0 0 auto;
+    font-size: 0.98rem;
+    line-height: 1;
+    transition:
+      transform 0.18s ease,
+      background 0.18s ease,
+      color 0.18s ease;
+
+    &:hover {
+      transform: none;
+      background: ${({ theme }) => theme.colors.gray4};
+      color: ${({ theme }) => theme.colors.gray12};
+    }
+  }
+`
+
+export const EditorStudioComposeBodySection = styled.section`
+  display: grid;
+  gap: 0.82rem;
+`
+
+export const ComposeBodyHeader = styled.div`
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  max-width: var(--article-readable-width, 48rem);
+  min-width: 0;
+  margin-inline: auto;
+  padding-top: 0.2rem;
+
+  @media (max-width: 720px) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+`
+
+export const ComposeBodyTitleGroup = styled.div`
+  display: grid;
+  gap: 0.14rem;
+
+  h3 {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.98rem;
+    font-weight: 760;
+    line-height: 1.3;
+  }
+`
+
+export const ComposeBodyMetrics = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.76rem;
+  line-height: 1.4;
+`
+
+export const EditorStudioComposeFooterBar = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+  margin-top: 0.84rem;
+  padding-top: 0.72rem;
+  border-top: 1px solid ${({ theme }) => theme.colors.gray6};
+`
+
+export const WriterFooterSummary = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.52rem 0.72rem;
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: 0.76rem;
+  line-height: 1.45;
+`
+
+export const WriterFooterControls = styled.div`
+  display: grid;
+  gap: 0.52rem;
+  justify-items: stretch;
+  flex: 1 1 34rem;
+  width: min(100%, 48rem);
+  min-width: min(100%, 34rem);
+  max-width: 100%;
+  margin-left: auto;
+
+  @media (max-width: 720px) {
+    width: 100%;
+    min-width: 100%;
+  }
+`
+
+export const WriterFooterActions = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  justify-content: flex-end;
+  align-items: center;
+
+  @media (max-width: 720px) {
+    display: none;
+  }
+`
+
+export const Button = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+export const PrimaryButton = styled(Button)`
+  border-radius: 8px;
+  padding: 0.6rem 0.88rem;
+  border-color: ${({ theme }) => theme.colors.blue9};
+  background: ${({ theme }) => theme.colors.blue9};
+  color: ${({ theme }) => theme.colors.gray1};
+  font-weight: 700;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.blue10};
+    background: ${({ theme }) => theme.colors.blue10};
+    color: ${({ theme }) => theme.colors.gray1};
+  }
+`

--- a/front/src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx
+++ b/front/src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled"
 import type {
   ChangeEventHandler,
   KeyboardEvent as ReactKeyboardEvent,
@@ -7,7 +6,31 @@ import type {
   Ref,
 } from "react"
 import ProfileImage from "src/components/ProfileImage"
-import { articleTypographyScale } from "src/libs/markdown/contentTypography"
+import {
+  EditorExitAction,
+  EditorHeaderActionButton,
+  EditorHeaderAuthor,
+  EditorHeaderAuthorText,
+  EditorHeaderAvatar,
+  EditorHeaderMetaActions,
+  EditorHeaderMetaPill,
+  EditorHeaderMetaRow,
+  EditorStudioDedicatedCanvasSection,
+  EditorStudioDedicatedMetaSection,
+  EditorStudioDedicatedTopBar,
+  EditorStudioFrame,
+  EditorStudioLoadingState,
+  EditorStudioRoot,
+  EditorStudioSaveState,
+  EditorStudioTopBarActions,
+  EditorStudioWritingColumn,
+  EditorTagRow,
+  InlineMetaInput,
+  PrimaryButton,
+  PublishNotice,
+  SelectedTagChip,
+  TitleInput,
+} from "./EditorStudioDedicatedEditorSurfaceParts"
 
 type NoticeTone = "idle" | "loading" | "success" | "error"
 
@@ -108,7 +131,7 @@ export const EditorStudioDedicatedEditorSurface = ({
       style={{ display: "none" }}
     />
 
-    <EditorStudioTopBar>
+    <EditorStudioDedicatedTopBar>
       <EditorExitAction type="button" onClick={onExit}>
         ← 나가기
       </EditorExitAction>
@@ -120,11 +143,11 @@ export const EditorStudioDedicatedEditorSurface = ({
           {primaryActionLabel}
         </PrimaryButton>
       </EditorStudioTopBarActions>
-    </EditorStudioTopBar>
+    </EditorStudioDedicatedTopBar>
 
     <EditorStudioFrame data-testid="editor-studio-frame">
       <EditorStudioWritingColumn data-testid="editor-writing-column" $compact={isCompactSplitPreview}>
-        <EditorStudioMetaSection $compact={isCompactSplitPreview}>
+        <EditorStudioDedicatedMetaSection $compact={isCompactSplitPreview}>
           <EditorTagRow aria-label="태그 입력" $compact={isCompactSplitPreview}>
             {postTags.map((tag) => (
               <SelectedTagChip key={tag}>
@@ -198,9 +221,9 @@ export const EditorStudioDedicatedEditorSurface = ({
               ) : null}
             </EditorHeaderMetaActions>
           </EditorHeaderMetaRow>
-        </EditorStudioMetaSection>
+        </EditorStudioDedicatedMetaSection>
 
-        <EditorStudioCanvas>{editorCanvas}</EditorStudioCanvas>
+        <EditorStudioDedicatedCanvasSection>{editorCanvas}</EditorStudioDedicatedCanvasSection>
 
         {showPublishNotice ? <PublishNotice data-tone={publishNoticeTone}>{publishNoticeText}</PublishNotice> : null}
       </EditorStudioWritingColumn>
@@ -210,509 +233,3 @@ export const EditorStudioDedicatedEditorSurface = ({
     {publishModal}
   </EditorStudioRoot>
 )
-
-const EditorStudioRoot = styled.main`
-  box-sizing: border-box;
-  width: 100vw;
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
-  padding: 1.4rem 1.6rem 2rem;
-  display: grid;
-  gap: 1.2rem;
-  overflow-x: clip;
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid"
-      ? `linear-gradient(180deg, color-mix(in srgb, ${theme.publicDesign.surfaceElevated} 44%, transparent), transparent 18rem)`
-      : "transparent"};
-
-  @media (max-width: 1024px) {
-    padding: 1rem 1rem 1.4rem;
-  }
-
-  @media (max-width: 768px) {
-    padding-top: 0.92rem;
-    padding-bottom: 1.2rem;
-    padding-left: max(0.82rem, env(safe-area-inset-left, 0px));
-    padding-right: max(0.82rem, env(safe-area-inset-right, 0px));
-  }
-`
-
-const EditorStudioLoadingState = styled.div`
-  min-height: calc(100vh - 10rem);
-  display: grid;
-  place-content: center;
-  gap: 0.4rem;
-  text-align: center;
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 1.1rem;
-  }
-
-  span {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.9rem;
-  }
-`
-
-const EditorStudioTopBar = styled.div`
-  width: min(100%, 1600px);
-  margin: 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  min-height: 48px;
-
-  @media (max-width: 1200px) {
-    align-items: center;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    justify-content: space-between;
-    gap: 0.8rem;
-  }
-
-  @media (max-width: 760px) {
-    align-items: stretch;
-    flex-direction: column;
-    gap: 0.7rem;
-  }
-`
-
-const EditorExitAction = styled.button`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 42px;
-  padding: 0.2rem 0.32rem;
-  margin: -0.2rem -0.32rem;
-  border: 0;
-  border-radius: 10px;
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray12};
-  font-size: 0.98rem;
-  font-weight: 700;
-  line-height: 1;
-  cursor: pointer;
-  transition:
-    background-color 0.18s ease,
-    color 0.18s ease;
-
-  &:hover {
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3)};
-  }
-
-  &:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.blue4)};
-  }
-
-  @media (max-width: 1200px) {
-    justify-content: flex-start;
-  }
-`
-
-const EditorStudioTopBarActions = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  flex-wrap: nowrap;
-  justify-content: flex-end;
-
-  @media (max-width: 1200px) {
-    width: auto;
-    margin-left: auto;
-    justify-content: flex-end;
-    flex-wrap: nowrap;
-  }
-
-  @media (max-width: 760px) {
-    width: 100%;
-    margin-left: 0;
-    justify-content: flex-end;
-    flex-wrap: wrap;
-  }
-`
-
-const EditorStudioSaveState = styled.span`
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.84rem;
-  font-weight: 600;
-  white-space: nowrap;
-  text-align: right;
-
-  &[data-tone="success"] {
-    color: ${({ theme }) => theme.colors.green10};
-  }
-
-  &[data-tone="loading"] {
-    color: ${({ theme }) => theme.colors.blue9};
-  }
-
-  &[data-tone="error"] {
-    color: ${({ theme }) => theme.colors.red10};
-  }
-
-  @media (max-width: 680px) {
-    width: 100%;
-  }
-`
-
-const Button = styled.button`
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
-  border-radius: 8px;
-  padding: 0.62rem 0.92rem;
-  min-height: 44px;
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : "transparent")};
-  color: ${({ theme }) => theme.colors.gray10};
-  cursor: pointer;
-  font-size: 0.84rem;
-  font-weight: 600;
-  transition:
-    border-color 0.18s ease,
-    background-color 0.18s ease,
-    color 0.18s ease,
-    box-shadow 0.18s ease;
-
-  &:hover:not(:disabled) {
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray8)};
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3)};
-    color: ${({ theme }) => theme.colors.gray12};
-  }
-
-  &:focus-visible {
-    outline: none;
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue8)};
-    box-shadow: 0 0 0 3px ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.blue4)};
-  }
-
-  &:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
-  }
-`
-
-const PrimaryButton = styled(Button)`
-  border-radius: 8px;
-  padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue9)};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue9)};
-  color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.pageBackgroundColor : theme.colors.gray1)};
-  font-weight: 700;
-
-  &:hover:not(:disabled) {
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.blue10)};
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.blue10)};
-    color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.pageBackgroundColor : theme.colors.gray1)};
-  }
-`
-
-const EditorStudioFrame = styled.div`
-  width: min(100%, 1600px);
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 1.4rem;
-  align-items: start;
-  justify-content: center;
-  overflow-x: visible;
-
-  @media (min-width: 1024px) {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 1.4rem;
-  }
-`
-
-const EditorStudioWritingColumn = styled.section<{ $compact?: boolean }>`
-  display: grid;
-  min-width: 0;
-  gap: ${({ $compact }) => ($compact ? "0.88rem" : "1rem")};
-  overflow-x: visible;
-`
-
-const EditorStudioMetaSection = styled.section<{ $compact?: boolean }>`
-  width: 100%;
-  max-width: var(--article-readable-width, 48rem);
-  min-width: 0;
-  margin-inline: auto;
-  display: grid;
-  gap: ${({ $compact }) => ($compact ? "0.72rem" : "0.9rem")};
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
-  padding: ${({ theme, $compact }) => (theme.blogDesign === "grid" ? ($compact ? "0.8rem" : "1rem") : "0")};
-`
-
-const EditorTagRow = styled.div<{ $compact?: boolean }>`
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: ${({ $compact }) => ($compact ? "0.44rem" : "0.55rem")};
-  min-height: 32px;
-`
-
-const SelectedTagChip = styled.span`
-  display: inline-flex;
-  align-items: stretch;
-  gap: 0;
-  min-width: 0;
-  max-width: 100%;
-  min-height: 32px;
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray3};
-  overflow: hidden;
-  transition:
-    border-color 0.18s ease,
-    transform 0.18s ease,
-    background 0.18s ease;
-
-  &:hover {
-    transform: none;
-  }
-
-  .label {
-    display: inline-flex;
-    align-items: center;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    padding: 0.38rem 0.78rem;
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.86rem;
-    font-weight: 600;
-    line-height: 1;
-  }
-
-  button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    align-self: stretch;
-    min-width: 1.92rem;
-    padding: 0 0.52rem;
-    border: 0;
-    border-left: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray2};
-    color: ${({ theme }) => theme.colors.gray10};
-    cursor: pointer;
-    flex: 0 0 auto;
-    font-size: 0.98rem;
-    line-height: 1;
-    transition:
-      transform 0.18s ease,
-      background 0.18s ease,
-      color 0.18s ease;
-
-    &:hover {
-      transform: none;
-      background: ${({ theme }) => theme.colors.gray4};
-      color: ${({ theme }) => theme.colors.gray12};
-    }
-  }
-`
-
-const InlineMetaInput = styled.input`
-  width: 100%;
-  max-width: 100%;
-  box-sizing: border-box;
-  flex: 1 1 12rem;
-  min-width: 11rem;
-  border: 0;
-  border-bottom: 1px dashed ${({ theme }) => theme.colors.gray6};
-  outline: none;
-  min-height: 32px;
-  padding: 0 0.12rem;
-  border-radius: 0;
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray12};
-  font-size: 0.86rem;
-  font-weight: 500;
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.gray10};
-  }
-
-  &:focus-visible {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors.blue8};
-    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
-  }
-`
-
-const TitleInput = styled.textarea<{ $compact?: boolean }>`
-  width: 100%;
-  min-width: 0;
-  border: 0;
-  border-radius: 0;
-  padding: 0;
-  min-height: 44px;
-  background: transparent;
-  box-shadow: none;
-  font-family: inherit;
-  font-size: ${articleTypographyScale.postTitleFontSize};
-  font-weight: 700;
-  line-height: ${articleTypographyScale.postTitleLineHeight};
-  letter-spacing: 0;
-  resize: none;
-  overflow: hidden;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.gray9};
-  }
-
-  &:focus {
-    box-shadow: none;
-    border-color: transparent;
-  }
-
-  @media (max-width: 720px) {
-    font-size: ${articleTypographyScale.postTitleFontSizeMobile};
-    line-height: ${articleTypographyScale.postTitleLineHeightMobile};
-  }
-`
-
-const EditorHeaderMetaRow = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 0.85rem;
-  min-width: 0;
-`
-
-const EditorHeaderMetaActions = styled.div`
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-end;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-  min-width: 0;
-`
-
-const EditorHeaderAuthor = styled.div`
-  display: inline-flex;
-  align-items: center;
-  gap: 0.85rem;
-  min-width: 0;
-`
-
-const EditorHeaderAvatar = styled.div<{ $compact?: boolean }>`
-  position: relative;
-  width: ${({ $compact }) => ($compact ? "40px" : "48px")};
-  height: ${({ $compact }) => ($compact ? "40px" : "48px")};
-  flex-shrink: 0;
-  border-radius: 999px;
-  overflow: hidden;
-  background: ${({ theme }) => theme.colors.gray3};
-
-  .initial {
-    display: inline-flex;
-    width: 100%;
-    height: 100%;
-    align-items: center;
-    justify-content: center;
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.84rem;
-    font-weight: 800;
-    letter-spacing: 0.04em;
-  }
-`
-
-const EditorHeaderAuthorText = styled.div<{ $compact?: boolean }>`
-  display: grid;
-  gap: ${({ $compact }) => ($compact ? "0.12rem" : "0.18rem")};
-  min-width: 0;
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: ${({ $compact }) => ($compact ? "0.94rem" : "1rem")};
-    font-weight: 700;
-    overflow-wrap: anywhere;
-  }
-
-  span {
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: ${({ $compact }) => ($compact ? "0.82rem" : "0.9rem")};
-    font-weight: 500;
-  }
-`
-
-const EditorHeaderMetaPill = styled.span<{ $compact?: boolean }>`
-  display: inline-flex;
-  align-items: center;
-  min-height: ${({ $compact }) => ($compact ? "30px" : "34px")};
-  padding: ${({ $compact }) => ($compact ? "0 0.72rem" : "0 0.82rem")};
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
-  color: ${({ theme }) => theme.colors.gray11};
-  font-size: ${({ $compact }) => ($compact ? "0.74rem" : "0.82rem")};
-  font-weight: 650;
-  line-height: 1;
-`
-
-const EditorHeaderActionButton = styled(Button)`
-  min-height: 34px;
-  padding: 0.45rem 0.7rem;
-  border-radius: 999px;
-  font-size: 0.78rem;
-`
-
-const EditorStudioCanvas = styled.section`
-  --compose-pane-readable-width: var(--article-readable-width, 48rem);
-  width: 100%;
-  max-width: var(--article-readable-width, 48rem);
-  min-width: 0;
-  margin-inline: auto;
-  min-height: clamp(28rem, 70vh, 56rem);
-  display: grid;
-  gap: 0.72rem;
-  overflow-x: visible;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
-  padding: ${({ theme }) => (theme.blogDesign === "grid" ? "1rem" : "0")};
-  box-shadow: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.shadow : "none")};
-`
-
-const PublishNotice = styled.div`
-  margin: 0;
-  padding: 0.55rem 0.7rem;
-  border-radius: 10px;
-  font-size: 0.83rem;
-  line-height: 1.4;
-  width: 100%;
-  box-sizing: border-box;
-
-  &[data-tone="idle"] {
-    color: ${({ theme }) => theme.colors.gray11};
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: transparent;
-  }
-
-  &[data-tone="loading"] {
-    color: ${({ theme }) => theme.colors.blue11};
-    border: 1px solid ${({ theme }) => theme.colors.blue7};
-    background: ${({ theme }) => theme.colors.blue3};
-  }
-
-  &[data-tone="success"] {
-    color: ${({ theme }) => theme.colors.green11};
-    border: 1px solid ${({ theme }) => theme.colors.green7};
-    background: ${({ theme }) => theme.colors.green3};
-  }
-
-  &[data-tone="error"] {
-    color: ${({ theme }) => theme.colors.red11};
-    border: 1px solid ${({ theme }) => theme.colors.red7};
-    background: ${({ theme }) => theme.colors.red3};
-  }
-
-  @media (max-width: 720px) {
-    width: 100%;
-  }
-`

--- a/front/src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx
+++ b/front/src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx
@@ -1,0 +1,508 @@
+import styled from "@emotion/styled"
+import { articleTypographyScale } from "src/libs/markdown/contentTypography"
+
+export const EditorStudioRoot = styled.main`
+  box-sizing: border-box;
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  padding: 1.4rem 1.6rem 2rem;
+  display: grid;
+  gap: 1.2rem;
+  overflow-x: clip;
+  background: ${({ theme }) =>
+    theme.blogDesign === "grid"
+      ? `linear-gradient(180deg, color-mix(in srgb, ${theme.publicDesign.surfaceElevated} 44%, transparent), transparent 18rem)`
+      : "transparent"};
+
+  @media (max-width: 1024px) {
+    padding: 1rem 1rem 1.4rem;
+  }
+
+  @media (max-width: 768px) {
+    padding-top: 0.92rem;
+    padding-bottom: 1.2rem;
+    padding-left: max(0.82rem, env(safe-area-inset-left, 0px));
+    padding-right: max(0.82rem, env(safe-area-inset-right, 0px));
+  }
+`
+
+export const EditorStudioLoadingState = styled.div`
+  min-height: calc(100vh - 10rem);
+  display: grid;
+  place-content: center;
+  gap: 0.4rem;
+  text-align: center;
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 1.1rem;
+  }
+
+  span {
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.9rem;
+  }
+`
+
+export const EditorStudioDedicatedTopBar = styled.div`
+  width: min(100%, 1600px);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 48px;
+
+  @media (max-width: 1200px) {
+    align-items: center;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    gap: 0.8rem;
+  }
+
+  @media (max-width: 760px) {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0.7rem;
+  }
+`
+
+export const EditorExitAction = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0.2rem 0.32rem;
+  margin: -0.2rem -0.32rem;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray12};
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color 0.18s ease,
+    color 0.18s ease;
+
+  &:hover {
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3)};
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.blue4)};
+  }
+
+  @media (max-width: 1200px) {
+    justify-content: flex-start;
+  }
+`
+
+export const EditorStudioTopBarActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: nowrap;
+  justify-content: flex-end;
+
+  @media (max-width: 1200px) {
+    width: auto;
+    margin-left: auto;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+  }
+
+  @media (max-width: 760px) {
+    width: 100%;
+    margin-left: 0;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+`
+
+export const EditorStudioSaveState = styled.span`
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.84rem;
+  font-weight: 600;
+  white-space: nowrap;
+  text-align: right;
+
+  &[data-tone="success"] {
+    color: ${({ theme }) => theme.colors.green10};
+  }
+
+  &[data-tone="loading"] {
+    color: ${({ theme }) => theme.colors.blue9};
+  }
+
+  &[data-tone="error"] {
+    color: ${({ theme }) => theme.colors.red10};
+  }
+
+  @media (max-width: 680px) {
+    width: 100%;
+  }
+`
+
+const Button = styled.button`
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : "transparent")};
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray8)};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3)};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue8)};
+    box-shadow: 0 0 0 3px ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.blue4)};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+export const PrimaryButton = styled(Button)`
+  border-radius: 8px;
+  padding: 0.6rem 0.88rem;
+  border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue9)};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue9)};
+  color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.pageBackgroundColor : theme.colors.gray1)};
+  font-weight: 700;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.blue10)};
+    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.blue10)};
+    color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.pageBackgroundColor : theme.colors.gray1)};
+  }
+`
+
+export const EditorStudioFrame = styled.div`
+  width: min(100%, 1600px);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.4rem;
+  align-items: start;
+  justify-content: center;
+  overflow-x: visible;
+
+  @media (min-width: 1024px) {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.4rem;
+  }
+`
+
+export const EditorStudioWritingColumn = styled.section<{ $compact?: boolean }>`
+  display: grid;
+  min-width: 0;
+  gap: ${({ $compact }) => ($compact ? "0.88rem" : "1rem")};
+  overflow-x: visible;
+`
+
+export const EditorStudioDedicatedMetaSection = styled.section<{ $compact?: boolean }>`
+  width: 100%;
+  max-width: var(--article-readable-width, 48rem);
+  min-width: 0;
+  margin-inline: auto;
+  display: grid;
+  gap: ${({ $compact }) => ($compact ? "0.72rem" : "0.9rem")};
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
+  padding: ${({ theme, $compact }) => (theme.blogDesign === "grid" ? ($compact ? "0.8rem" : "1rem") : "0")};
+`
+
+export const EditorTagRow = styled.div<{ $compact?: boolean }>`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: ${({ $compact }) => ($compact ? "0.44rem" : "0.55rem")};
+  min-height: 32px;
+`
+
+export const SelectedTagChip = styled.span`
+  display: inline-flex;
+  align-items: stretch;
+  gap: 0;
+  min-width: 0;
+  max-width: 100%;
+  min-height: 32px;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray3};
+  overflow: hidden;
+  transition:
+    border-color 0.18s ease,
+    transform 0.18s ease,
+    background 0.18s ease;
+
+  &:hover {
+    transform: none;
+  }
+
+  .label {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding: 0.38rem 0.78rem;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.86rem;
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    align-self: stretch;
+    min-width: 1.92rem;
+    padding: 0 0.52rem;
+    border: 0;
+    border-left: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => theme.colors.gray2};
+    color: ${({ theme }) => theme.colors.gray10};
+    cursor: pointer;
+    flex: 0 0 auto;
+    font-size: 0.98rem;
+    line-height: 1;
+    transition:
+      transform 0.18s ease,
+      background 0.18s ease,
+      color 0.18s ease;
+
+    &:hover {
+      transform: none;
+      background: ${({ theme }) => theme.colors.gray4};
+      color: ${({ theme }) => theme.colors.gray12};
+    }
+  }
+`
+
+export const InlineMetaInput = styled.input`
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  flex: 1 1 12rem;
+  min-width: 11rem;
+  border: 0;
+  border-bottom: 1px dashed ${({ theme }) => theme.colors.gray6};
+  outline: none;
+  min-height: 32px;
+  padding: 0 0.12rem;
+  border-radius: 0;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray12};
+  font-size: 0.86rem;
+  font-weight: 500;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray10};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
+  }
+`
+
+export const TitleInput = styled.textarea<{ $compact?: boolean }>`
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  min-height: 44px;
+  background: transparent;
+  box-shadow: none;
+  font-family: inherit;
+  font-size: ${articleTypographyScale.postTitleFontSize};
+  font-weight: 700;
+  line-height: ${articleTypographyScale.postTitleLineHeight};
+  letter-spacing: 0;
+  resize: none;
+  overflow: hidden;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray9};
+  }
+
+  &:focus {
+    box-shadow: none;
+    border-color: transparent;
+  }
+
+  @media (max-width: 720px) {
+    font-size: ${articleTypographyScale.postTitleFontSizeMobile};
+    line-height: ${articleTypographyScale.postTitleLineHeightMobile};
+  }
+`
+
+export const EditorHeaderMetaRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  min-width: 0;
+`
+
+export const EditorHeaderMetaActions = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  min-width: 0;
+`
+
+export const EditorHeaderAuthor = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  min-width: 0;
+`
+
+export const EditorHeaderAvatar = styled.div<{ $compact?: boolean }>`
+  position: relative;
+  width: ${({ $compact }) => ($compact ? "40px" : "48px")};
+  height: ${({ $compact }) => ($compact ? "40px" : "48px")};
+  flex-shrink: 0;
+  border-radius: 999px;
+  overflow: hidden;
+  background: ${({ theme }) => theme.colors.gray3};
+
+  .initial {
+    display: inline-flex;
+    width: 100%;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.84rem;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+  }
+`
+
+export const EditorHeaderAuthorText = styled.div<{ $compact?: boolean }>`
+  display: grid;
+  gap: ${({ $compact }) => ($compact ? "0.12rem" : "0.18rem")};
+  min-width: 0;
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: ${({ $compact }) => ($compact ? "0.94rem" : "1rem")};
+    font-weight: 700;
+    overflow-wrap: anywhere;
+  }
+
+  span {
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: ${({ $compact }) => ($compact ? "0.82rem" : "0.9rem")};
+    font-weight: 500;
+  }
+`
+
+export const EditorHeaderMetaPill = styled.span<{ $compact?: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  min-height: ${({ $compact }) => ($compact ? "30px" : "34px")};
+  padding: ${({ $compact }) => ($compact ? "0 0.72rem" : "0 0.82rem")};
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray2};
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: ${({ $compact }) => ($compact ? "0.74rem" : "0.82rem")};
+  font-weight: 650;
+  line-height: 1;
+`
+
+export const EditorHeaderActionButton = styled(Button)`
+  min-height: 34px;
+  padding: 0.45rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+`
+
+export const EditorStudioDedicatedCanvasSection = styled.section`
+  --compose-pane-readable-width: var(--article-readable-width, 48rem);
+  width: 100%;
+  max-width: var(--article-readable-width, 48rem);
+  min-width: 0;
+  margin-inline: auto;
+  min-height: clamp(28rem, 70vh, 56rem);
+  display: grid;
+  gap: 0.72rem;
+  overflow-x: visible;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
+  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
+  padding: ${({ theme }) => (theme.blogDesign === "grid" ? "1rem" : "0")};
+  box-shadow: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.shadow : "none")};
+`
+
+export const PublishNotice = styled.div`
+  margin: 0;
+  padding: 0.55rem 0.7rem;
+  border-radius: 10px;
+  font-size: 0.83rem;
+  line-height: 1.4;
+  width: 100%;
+  box-sizing: border-box;
+
+  &[data-tone="idle"] {
+    color: ${({ theme }) => theme.colors.gray11};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: transparent;
+  }
+
+  &[data-tone="loading"] {
+    color: ${({ theme }) => theme.colors.blue11};
+    border: 1px solid ${({ theme }) => theme.colors.blue7};
+    background: ${({ theme }) => theme.colors.blue3};
+  }
+
+  &[data-tone="success"] {
+    color: ${({ theme }) => theme.colors.green11};
+    border: 1px solid ${({ theme }) => theme.colors.green7};
+    background: ${({ theme }) => theme.colors.green3};
+  }
+
+  &[data-tone="error"] {
+    color: ${({ theme }) => theme.colors.red11};
+    border: 1px solid ${({ theme }) => theme.colors.red7};
+    background: ${({ theme }) => theme.colors.red3};
+  }
+
+  @media (max-width: 720px) {
+    width: 100%;
+  }
+`

--- a/front/src/routes/Admin/EditorStudioPostListActionStyles.tsx
+++ b/front/src/routes/Admin/EditorStudioPostListActionStyles.tsx
@@ -1,0 +1,149 @@
+import styled from "@emotion/styled"
+
+export const Button = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &[data-variant="danger"] {
+    border-color: ${({ theme }) => theme.colors.red8};
+    background: ${({ theme }) => theme.colors.red3};
+    color: ${({ theme }) => theme.colors.red11};
+  }
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+export const PrimaryButton = styled(Button)`
+  border-radius: 8px;
+  padding: 0.6rem 0.88rem;
+  border-color: ${({ theme }) => theme.colors.blue9};
+  background: ${({ theme }) => theme.colors.blue9};
+  color: ${({ theme }) => theme.colors.gray1};
+  font-weight: 700;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.blue10};
+    background: ${({ theme }) => theme.colors.blue10};
+    color: ${({ theme }) => theme.colors.gray1};
+  }
+`
+
+export const RowActionButton = styled(Button)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.42rem;
+  width: 100%;
+  min-height: 40px;
+  padding: 0.42rem 0.62rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  white-space: nowrap;
+
+  svg {
+    flex: 0 0 auto;
+  }
+
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &[data-variant="primary"] {
+    border-color: ${({ theme }) => theme.colors.blue8};
+    background: ${({ theme }) => theme.colors.blue3};
+    color: ${({ theme }) => theme.colors.blue11};
+  }
+
+  &[data-variant="primary"]:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.blue9};
+    background: ${({ theme }) => theme.colors.blue4};
+    color: ${({ theme }) => theme.colors.blue12};
+  }
+`
+
+export const RowActionMenu = styled.details`
+  position: relative;
+
+  summary {
+    list-style: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.3rem;
+    width: 100%;
+    min-height: 40px;
+    border-radius: 8px;
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: transparent;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.76rem;
+    font-weight: 700;
+    cursor: pointer;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+  }
+
+  .menu {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 0.3rem);
+    z-index: 8;
+    display: grid;
+    min-width: 7rem;
+    padding: 0.32rem;
+    border-radius: 10px;
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => theme.colors.gray2};
+    box-shadow: none;
+  }
+
+  .menu button {
+    min-height: 36px;
+    border: 0;
+    border-radius: 8px;
+    background: transparent;
+    color: ${({ theme }) => theme.colors.red11};
+    font-size: 0.78rem;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .menu button:hover:not(:disabled) {
+    background: ${({ theme }) => theme.colors.red3};
+  }
+
+  .menu button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`

--- a/front/src/routes/Admin/EditorStudioPostListPanel.tsx
+++ b/front/src/routes/Admin/EditorStudioPostListPanel.tsx
@@ -1,10 +1,17 @@
-import styled from "@emotion/styled"
-import AppIcon from "src/components/icons/AppIcon"
-import { getVisibilityLabel, toVisibility } from "./editorStudioState"
+import {
+  EditorStudioPostListEmptyState,
+  EditorStudioPostListHeader,
+  EditorStudioPostListInlineStatus,
+  EditorStudioPostListMobileCards,
+  EditorStudioPostListPanelShell,
+  EditorStudioPostListSelectionBar,
+  EditorStudioPostListTable,
+  type EditorStudioPostListCommands,
+} from "./EditorStudioPostListPanelParts"
 
-type PostListScope = "active" | "deleted"
-type EditorMode = "create" | "edit"
-type NoticeTone = "idle" | "loading" | "success" | "error"
+export type EditorStudioPostListScope = "active" | "deleted"
+export type EditorStudioPostListEditorMode = "create" | "edit"
+export type EditorStudioPostListNoticeTone = "idle" | "loading" | "success" | "error"
 
 export type EditorStudioPostListItem = {
   id: number
@@ -18,23 +25,25 @@ export type EditorStudioPostListItem = {
   deletedAt?: string
 }
 
+export type EditorStudioPostListNoticeState = {
+  tone: EditorStudioPostListNoticeTone
+  text: string
+}
+
 type Props = {
   mobileVisible: boolean
-  listScope: PostListScope
+  listScope: EditorStudioPostListScope
   selectedPostIds: readonly number[]
   adminPostTotal: number
   adminPostRows: readonly EditorStudioPostListItem[]
   adminPostViewRows: readonly EditorStudioPostListItem[]
   isAllVisiblePostsSelected: boolean
   selectedPostIdSet: ReadonlySet<number>
-  editorMode: EditorMode
+  editorMode: EditorStudioPostListEditorMode
   postId: string
   loadingKey: string
   modifiedSortOrder: "desc" | "asc"
-  deletedListNotice: {
-    tone: NoticeTone
-    text: string
-  }
+  deletedListNotice: EditorStudioPostListNoticeState
   isRefreshDisabled: boolean
   onToggleSelectAllVisiblePosts: () => void
   onClearSelection: () => void
@@ -77,925 +86,76 @@ export const EditorStudioPostListPanel = ({
   onHardDeletePost,
 }: Props) => {
   const isLoading = loadingKey.length > 0
+  const commands: EditorStudioPostListCommands = {
+    clearSelection: onClearSelection,
+    copyPostDetailLink: onCopyPostDetailLink,
+    editPost: onEditPost,
+    hardDeletePost: onHardDeletePost,
+    openPostDetail: onOpenPostDetail,
+    refreshList: onRefreshList,
+    requestDeletePosts: onRequestDeletePosts,
+    restoreDeletedPost: onRestoreDeletedPost,
+    toggleModifiedSortOrder: onToggleModifiedSortOrder,
+    togglePostSelection: onTogglePostSelection,
+    toggleSelectAllVisiblePosts: onToggleSelectAllVisiblePosts,
+  }
 
   return (
-    <ListPanel data-mobile-visible={mobileVisible}>
-      <ListHeader>
-        <h3>{listScope === "active" ? "관리자 글 리스트" : "삭제 글 리스트"}</h3>
-        <ListHeaderActions>
-          <span>{selectedPostIds.length > 0 ? `${selectedPostIds.length}개 선택` : `총 ${adminPostTotal}건`}</span>
-          {listScope === "active" ? (
-            adminPostViewRows.length > 0 ? (
-              <Button type="button" disabled={isLoading} onClick={onToggleSelectAllVisiblePosts}>
-                {isAllVisiblePostsSelected ? "현재 목록 선택 해제" : "현재 목록 전체 선택"}
-              </Button>
-            ) : null
-          ) : (
-            <ReadOnlyHint>삭제 글은 복구 또는 영구삭제로 정리할 수 있습니다.</ReadOnlyHint>
-          )}
-        </ListHeaderActions>
-      </ListHeader>
+    <EditorStudioPostListPanelShell data-mobile-visible={mobileVisible}>
+      <EditorStudioPostListHeader
+        listScope={listScope}
+        selectedPostCount={selectedPostIds.length}
+        totalCount={adminPostTotal}
+        hasVisibleRows={adminPostViewRows.length > 0}
+        isAllVisiblePostsSelected={isAllVisiblePostsSelected}
+        isLoading={isLoading}
+        commands={commands}
+      />
 
       {listScope === "active" && selectedPostIds.length > 0 ? (
-        <SelectionStickyBar role="status" aria-live="polite">
-          <strong>{selectedPostIds.length}개 선택됨</strong>
-          <div>
-            <Button type="button" onClick={onClearSelection} disabled={isLoading}>
-              선택 해제
-            </Button>
-            <Button
-              type="button"
-              data-variant="danger"
-              disabled={isLoading}
-              onClick={() => onRequestDeletePosts([...selectedPostIds])}
-            >
-              선택 삭제
-            </Button>
-          </div>
-        </SelectionStickyBar>
+        <EditorStudioPostListSelectionBar
+          selectedPostIds={selectedPostIds}
+          isLoading={isLoading}
+          commands={commands}
+        />
       ) : null}
 
       {adminPostRows.length === 0 ? (
-        <ListEmpty>
-          <p>
-            {listScope === "active"
-              ? "목록이 없습니다. 위 조회 조건에서 목록 새로고침을 눌러 시작하세요."
-              : "삭제된 글이 없습니다. 삭제 글 목록을 조회해 최신 상태를 확인하세요."}
-          </p>
-          <div className="actions">
-            <PrimaryButton type="button" disabled={isRefreshDisabled} onClick={onRefreshList}>
-              {listScope === "active" ? "목록 새로고침" : "삭제 글 목록 조회"}
-            </PrimaryButton>
-          </div>
-        </ListEmpty>
+        <EditorStudioPostListEmptyState
+          listScope={listScope}
+          isRefreshDisabled={isRefreshDisabled}
+          commands={commands}
+        />
       ) : (
         <>
-          <ListTableWrap>
-            <ListTable>
-              <thead>
-                <tr>
-                  {listScope === "active" ? (
-                    <th className="checkboxCell">
-                      <input
-                        type="checkbox"
-                        aria-label="현재 목록 전체 선택"
-                        checked={isAllVisiblePostsSelected}
-                        onChange={onToggleSelectAllVisiblePosts}
-                      />
-                    </th>
-                  ) : null}
-                  <th className="idCell">ID</th>
-                  <th>제목</th>
-                  <th className="dateCell">
-                    {listScope === "active" ? (
-                      <SortHeaderButton type="button" onClick={onToggleModifiedSortOrder}>
-                        수정일 {modifiedSortOrder === "desc" ? "↓" : "↑"}
-                      </SortHeaderButton>
-                    ) : (
-                      "삭제일"
-                    )}
-                  </th>
-                  <th className="actionsCell">작업</th>
-                </tr>
-              </thead>
-              <tbody>
-                {adminPostViewRows.map((row) => {
-                  const isLoadedRow = listScope === "active" && editorMode === "edit" && postId.trim() === String(row.id)
-                  return (
-                    <tr key={row.id} data-active={isLoadedRow}>
-                      {listScope === "active" ? (
-                        <td className="checkboxCell">
-                          <input
-                            type="checkbox"
-                            aria-label={`${row.id}번 글 선택`}
-                            checked={selectedPostIdSet.has(row.id)}
-                            onChange={() => onTogglePostSelection(row.id)}
-                          />
-                        </td>
-                      ) : null}
-                      <td className="idCell">{row.id}</td>
-                      <td className="title">
-                        <TitleCell>
-                          <div className="titleMain">
-                            <span className="text">{row.title}</span>
-                            {isLoadedRow ? <LoadedBadge>현재 편집 중</LoadedBadge> : null}
-                            {listScope === "deleted" ? <DeletedBadge>삭제됨</DeletedBadge> : null}
-                            <VisibilityBadge className="inlineVisibility" data-tone={toVisibility(row.published, row.listed)}>
-                              {getVisibilityLabel(row.published, row.listed)}
-                            </VisibilityBadge>
-                          </div>
-                          <span className="meta">{row.authorName || "작성자 미상"}</span>
-                        </TitleCell>
-                      </td>
-                      <td className="dateCell">{(listScope === "deleted" ? row.deletedAt : row.modifiedAt)?.slice(0, 10) || "-"}</td>
-                      <td className="actionsCell">
-                        <InlineActions>
-                          <PostRowActions
-                            row={row}
-                            listScope={listScope}
-                            isLoadedRow={isLoadedRow}
-                            isLoading={isLoading}
-                            onEditPost={onEditPost}
-                            onOpenPostDetail={onOpenPostDetail}
-                            onCopyPostDetailLink={onCopyPostDetailLink}
-                            onRequestDeletePosts={onRequestDeletePosts}
-                            onRestoreDeletedPost={onRestoreDeletedPost}
-                            onHardDeletePost={onHardDeletePost}
-                          />
-                        </InlineActions>
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </ListTable>
-          </ListTableWrap>
-
-          <MobileListCards>
-            {adminPostViewRows.map((row) => {
-              const isLoadedRow = listScope === "active" && editorMode === "edit" && postId.trim() === String(row.id)
-              return (
-                <article key={`mobile-${row.id}`} data-active={isLoadedRow}>
-                  <header>
-                    <div className="metaLeading">
-                      {listScope === "active" ? (
-                        <input
-                          type="checkbox"
-                          aria-label={`${row.id}번 글 선택`}
-                          checked={selectedPostIdSet.has(row.id)}
-                          onChange={() => onTogglePostSelection(row.id)}
-                        />
-                      ) : null}
-                      <span className="rowId">#{row.id}</span>
-                    </div>
-                    {isLoadedRow ? <LoadedBadge>현재 편집 중</LoadedBadge> : null}
-                  </header>
-                  <h4>{row.title}</h4>
-                  <p className="metaLine">
-                    <span>
-                      {row.authorName}
-                      <span className="dot">•</span>
-                      {(listScope === "deleted" ? row.deletedAt : row.modifiedAt)?.slice(0, 10) || "-"}
-                    </span>
-                    <VisibilityBadge data-tone={toVisibility(row.published, row.listed)}>
-                      {getVisibilityLabel(row.published, row.listed)}
-                    </VisibilityBadge>
-                  </p>
-                  <div className="mainAction">
-                    <PostRowActions
-                      row={row}
-                      listScope={listScope}
-                      isLoadedRow={isLoadedRow}
-                      isLoading={isLoading}
-                      onEditPost={onEditPost}
-                      onOpenPostDetail={onOpenPostDetail}
-                      onCopyPostDetailLink={onCopyPostDetailLink}
-                      onRequestDeletePosts={onRequestDeletePosts}
-                      onRestoreDeletedPost={onRestoreDeletedPost}
-                      onHardDeletePost={onHardDeletePost}
-                    />
-                  </div>
-                </article>
-              )
-            })}
-          </MobileListCards>
+          <EditorStudioPostListTable
+            listScope={listScope}
+            rows={adminPostViewRows}
+            selectedPostIdSet={selectedPostIdSet}
+            isAllVisiblePostsSelected={isAllVisiblePostsSelected}
+            editorMode={editorMode}
+            postId={postId}
+            modifiedSortOrder={modifiedSortOrder}
+            isLoading={isLoading}
+            commands={commands}
+          />
+          <EditorStudioPostListMobileCards
+            listScope={listScope}
+            rows={adminPostViewRows}
+            selectedPostIdSet={selectedPostIdSet}
+            editorMode={editorMode}
+            postId={postId}
+            isLoading={isLoading}
+            commands={commands}
+          />
         </>
       )}
 
       {listScope === "deleted" && deletedListNotice.text ? (
-        <InlineStatus data-tone={deletedListNotice.tone}>{deletedListNotice.text}</InlineStatus>
+        <EditorStudioPostListInlineStatus data-tone={deletedListNotice.tone}>
+          {deletedListNotice.text}
+        </EditorStudioPostListInlineStatus>
       ) : null}
-    </ListPanel>
+    </EditorStudioPostListPanelShell>
   )
 }
-
-type PostRowActionsProps = {
-  row: EditorStudioPostListItem
-  listScope: PostListScope
-  isLoadedRow: boolean
-  isLoading: boolean
-  onEditPost: (row: EditorStudioPostListItem) => void
-  onOpenPostDetail: (id: number) => void
-  onCopyPostDetailLink: (id: number, title: string) => void
-  onRequestDeletePosts: (ids: number[], headline?: string) => void
-  onRestoreDeletedPost: (row: EditorStudioPostListItem) => void
-  onHardDeletePost: (row: EditorStudioPostListItem) => void
-}
-
-const PostRowActions = ({
-  row,
-  listScope,
-  isLoadedRow,
-  isLoading,
-  onEditPost,
-  onOpenPostDetail,
-  onCopyPostDetailLink,
-  onRequestDeletePosts,
-  onRestoreDeletedPost,
-  onHardDeletePost,
-}: PostRowActionsProps) =>
-  listScope === "active" ? (
-    <>
-      <RowActionButton type="button" data-variant="primary" disabled={isLoading} onClick={() => onEditPost(row)}>
-        <AppIcon name="edit" />
-        <span>{isLoadedRow ? "계속 편집" : "편집"}</span>
-      </RowActionButton>
-      <RowActionMenu>
-        <summary>
-          <span>더보기</span>
-          <AppIcon name="chevron-down" />
-        </summary>
-        <div className="menu">
-          <button type="button" disabled={isLoading} onClick={() => onOpenPostDetail(row.id)}>
-            상세 열기
-          </button>
-          <button type="button" disabled={isLoading} onClick={() => onCopyPostDetailLink(row.id, row.title)}>
-            링크 복사
-          </button>
-          <button type="button" disabled={isLoading} onClick={() => onRequestDeletePosts([row.id], row.title)}>
-            삭제
-          </button>
-        </div>
-      </RowActionMenu>
-    </>
-  ) : (
-    <>
-      <RowActionButton type="button" data-variant="primary" disabled={isLoading} onClick={() => onRestoreDeletedPost(row)}>
-        <AppIcon name="check-circle" />
-        <span>복구</span>
-      </RowActionButton>
-      <RowActionMenu>
-        <summary>
-          <span>더보기</span>
-          <AppIcon name="chevron-down" />
-        </summary>
-        <div className="menu">
-          <button type="button" disabled={isLoading} onClick={() => onHardDeletePost(row)}>
-            영구삭제
-          </button>
-        </div>
-      </RowActionMenu>
-    </>
-  )
-
-const ListPanel = styled.div`
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  border-radius: 12px;
-  background: ${({ theme }) => theme.colors.gray1};
-  padding: 0.82rem;
-  margin: 0;
-  min-width: 0;
-  display: grid;
-  gap: 0.62rem;
-
-  @media (max-width: 720px) {
-    &[data-mobile-visible="false"] {
-      display: none;
-    }
-  }
-`
-
-const ListHeader = styled.div`
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.64rem;
-  margin-bottom: 0.75rem;
-
-  h3 {
-    margin: 0;
-    font-size: 1rem;
-    font-weight: 720;
-    color: ${({ theme }) => theme.colors.gray12};
-  }
-
-  span {
-    font-size: 0.8rem;
-    color: ${({ theme }) => theme.colors.gray11};
-  }
-
-  @media (max-width: 920px) {
-    flex-direction: column;
-  }
-`
-
-const ListHeaderActions = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  justify-content: flex-end;
-  align-items: center;
-
-  span {
-    display: inline-flex;
-    align-items: center;
-    min-height: 34px;
-    padding: 0 0.72rem;
-    border-radius: 999px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray2};
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.8rem;
-    font-weight: 700;
-    white-space: nowrap;
-  }
-
-  @media (max-width: 920px) {
-    justify-content: flex-start;
-  }
-
-  @media (max-width: 720px) {
-    width: 100%;
-
-    span {
-      width: 100%;
-      margin-right: 0;
-    }
-
-    > button {
-      width: 100%;
-      justify-content: center;
-    }
-  }
-`
-
-const ReadOnlyHint = styled.span`
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
-  color: ${({ theme }) => theme.colors.gray11};
-  min-height: 28px;
-  padding: 0 0.58rem;
-  font-size: 0.72rem;
-  font-weight: 600;
-`
-
-const ListEmpty = styled.div`
-  margin: 0;
-  min-height: 13.5rem;
-  display: grid;
-  place-items: center;
-  text-align: center;
-  padding: 0.8rem 1rem;
-  border-radius: 10px;
-  border: 1px dashed ${({ theme }) => theme.colors.gray6};
-  color: ${({ theme }) => theme.colors.gray11};
-  gap: 0.72rem;
-
-  p {
-    margin: 0;
-    font-size: 0.86rem;
-    line-height: 1.65;
-  }
-
-  .actions {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.5rem;
-  }
-`
-
-const SelectionStickyBar = styled.div`
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  margin: 0 0 0.68rem;
-  padding: 0.55rem 0.62rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 10px;
-  background: ${({ theme }) => theme.colors.gray2};
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.8rem;
-  }
-
-  > div {
-    display: flex;
-    gap: 0.4rem;
-    flex-wrap: wrap;
-  }
-
-  @media (max-width: 900px) {
-    top: calc(var(--app-header-height, 56px) + 0.35rem);
-  }
-`
-
-const ListTableWrap = styled.div`
-  width: 100%;
-  overflow-x: auto;
-  overflow-y: auto;
-  max-height: 52vh;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 10px;
-  overscroll-behavior: contain;
-
-  @media (max-width: 1100px) {
-    display: none;
-  }
-`
-
-const ListTable = styled.table`
-  width: 100%;
-  min-width: 980px;
-  border-collapse: collapse;
-  table-layout: fixed;
-
-  th,
-  td {
-    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
-    padding: 0.5rem 0.45rem;
-    text-align: left;
-    font-size: 0.8rem;
-    color: ${({ theme }) => theme.colors.gray12};
-    vertical-align: middle;
-  }
-
-  th {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    background: ${({ theme }) => theme.colors.gray2};
-    font-size: 0.75rem;
-    color: ${({ theme }) => theme.colors.gray11};
-    font-weight: 700;
-  }
-
-  tbody tr:last-of-type td {
-    border-bottom: 0;
-  }
-
-  tbody tr {
-    transition: background-color 0.18s ease, box-shadow 0.18s ease;
-  }
-
-  tbody tr:hover td {
-    background: rgba(255, 255, 255, 0.02);
-  }
-
-  tbody tr[data-active="true"] td {
-    background:
-      linear-gradient(90deg, rgba(59, 130, 246, 0.14) 0, rgba(59, 130, 246, 0.04) 28px, rgba(255, 255, 255, 0.02) 28px);
-  }
-
-  .checkboxCell {
-    width: 2rem;
-    text-align: center;
-    padding-left: 0.2rem;
-    padding-right: 0.2rem;
-  }
-
-  th.idCell,
-  td.idCell {
-    width: 4.75rem;
-    white-space: nowrap;
-  }
-
-  input[type="checkbox"] {
-    width: 0.92rem;
-    height: 0.92rem;
-    cursor: pointer;
-    accent-color: ${({ theme }) => theme.colors.blue9};
-  }
-
-  td.title {
-    min-width: 0;
-  }
-
-  th.dateCell,
-  td.dateCell {
-    width: 112px;
-    white-space: nowrap;
-  }
-
-  th.actionsCell,
-  td.actionsCell {
-    width: 132px;
-    min-width: 132px;
-  }
-
-  @media (max-width: 1520px) {
-    th.actionsCell,
-    td.actionsCell {
-      width: 124px;
-      min-width: 124px;
-    }
-  }
-`
-
-const TitleCell = styled.div`
-  display: grid;
-  gap: 0.36rem;
-  max-width: 100%;
-  min-width: 0;
-
-  .titleMain {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    min-width: 0;
-    flex-wrap: wrap;
-  }
-
-  .text {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-weight: 700;
-  }
-
-  .meta {
-    display: inline-flex;
-    align-items: center;
-    min-width: 0;
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.72rem;
-    font-weight: 600;
-    white-space: nowrap;
-  }
-
-  .inlineVisibility {
-    display: inline-flex;
-  }
-`
-
-const DeletedBadge = styled.span`
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray11};
-  font-size: 0.68rem;
-  font-weight: 700;
-  padding: 0.12rem 0.42rem;
-  flex: 0 0 auto;
-`
-
-const LoadedBadge = styled.span`
-  display: inline-flex;
-  align-items: center;
-  min-height: 24px;
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.blue7};
-  background: ${({ theme }) => theme.colors.blue3};
-  color: ${({ theme }) => theme.colors.blue11};
-  padding: 0 0.5rem;
-  font-size: 0.7rem;
-  font-weight: 800;
-  line-height: 1;
-  flex: 0 0 auto;
-`
-
-const SortHeaderButton = styled.button`
-  border: 0;
-  background: transparent;
-  padding: 0;
-  color: ${({ theme }) => theme.colors.gray11};
-  font-size: 0.74rem;
-  font-weight: 700;
-  cursor: pointer;
-`
-
-const VisibilityBadge = styled.span`
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  padding: 0.16rem 0.46rem;
-  font-size: 0.72rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  color: ${({ theme }) => theme.colors.gray11};
-  background: ${({ theme }) => theme.colors.gray2};
-
-  &[data-tone="PRIVATE"] {
-    color: ${({ theme }) => theme.colors.gray11};
-  }
-
-  &[data-tone="PUBLIC_UNLISTED"] {
-    color: ${({ theme }) => theme.colors.blue11};
-    border-color: ${({ theme }) => theme.colors.blue7};
-    background: ${({ theme }) => theme.colors.blue3};
-  }
-
-  &[data-tone="PUBLIC_LISTED"] {
-    color: ${({ theme }) => theme.colors.green11};
-    border-color: ${({ theme }) => theme.colors.green7};
-    background: ${({ theme }) => theme.colors.green3};
-  }
-`
-
-const InlineActions = styled.div`
-  display: grid;
-  gap: 0.42rem;
-  align-items: stretch;
-`
-
-const MobileListCards = styled.div`
-  display: none;
-  margin-top: 0.65rem;
-
-  @media (max-width: 1100px) {
-    display: grid;
-    gap: 0.6rem;
-  }
-
-  article {
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    border-radius: 10px;
-    padding: 0.62rem;
-    background: ${({ theme }) => theme.colors.gray2};
-    display: grid;
-    gap: 0.5rem;
-    content-visibility: auto;
-    contain-intrinsic-size: 1px 172px;
-    transition: background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
-  }
-
-  article[data-active="true"] {
-    border-color: ${({ theme }) => theme.colors.blue7};
-    background: ${({ theme }) => theme.colors.blue3};
-    box-shadow: none;
-  }
-
-  header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.45rem;
-  }
-
-  .metaLeading {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    min-width: 0;
-  }
-
-  .metaLeading input[type="checkbox"] {
-    width: 1rem;
-    height: 1rem;
-    accent-color: ${({ theme }) => theme.colors.gray10};
-  }
-
-  h4 {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.9rem;
-    line-height: 1.45;
-    word-break: break-word;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-
-  p {
-    margin: 0;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.4rem;
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.78rem;
-  }
-
-  .metaLine {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.42rem;
-
-    .dot {
-      margin: 0 0.26rem;
-      opacity: 0.65;
-    }
-  }
-
-  .mainAction {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.42rem;
-  }
-
-  .mainAction > button {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .rowId {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.78rem;
-  }
-
-  @media (max-width: 420px) {
-    gap: 0.52rem;
-
-    article {
-      padding: 0.56rem;
-    }
-
-    p {
-      align-items: flex-start;
-      flex-wrap: wrap;
-      justify-content: flex-start;
-    }
-
-    .mainAction {
-      grid-template-columns: 1fr;
-    }
-  }
-`
-
-const InlineStatus = styled.div`
-  margin-bottom: 0.85rem;
-  padding: 0.62rem 0.72rem;
-  border-radius: 8px;
-  font-size: 0.82rem;
-  line-height: 1.5;
-  width: 100%;
-  min-width: 0;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-
-  &[data-tone="idle"] {
-    color: ${({ theme }) => theme.colors.gray11};
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: transparent;
-  }
-
-  &[data-tone="loading"] {
-    color: ${({ theme }) => theme.colors.blue11};
-    border: 1px solid ${({ theme }) => theme.colors.blue7};
-    background: ${({ theme }) => theme.colors.blue3};
-  }
-
-  &[data-tone="success"] {
-    color: ${({ theme }) => theme.colors.green11};
-    border: 1px solid ${({ theme }) => theme.colors.green7};
-    background: ${({ theme }) => theme.colors.green3};
-  }
-
-  &[data-tone="error"] {
-    color: ${({ theme }) => theme.colors.red11};
-    border: 1px solid ${({ theme }) => theme.colors.red7};
-    background: ${({ theme }) => theme.colors.red3};
-  }
-`
-
-const Button = styled.button`
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 8px;
-  padding: 0.62rem 0.92rem;
-  min-height: 44px;
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray10};
-  cursor: pointer;
-  font-size: 0.84rem;
-  font-weight: 600;
-  transition:
-    border-color 0.18s ease,
-    background-color 0.18s ease,
-    color 0.18s ease,
-    box-shadow 0.18s ease;
-
-  &[data-variant="danger"] {
-    border-color: ${({ theme }) => theme.colors.red8};
-    background: ${({ theme }) => theme.colors.red3};
-    color: ${({ theme }) => theme.colors.red11};
-  }
-
-  &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.gray8};
-    background: ${({ theme }) => theme.colors.gray3};
-    color: ${({ theme }) => theme.colors.gray12};
-  }
-
-  &:focus-visible {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors.blue8};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
-  }
-
-  &:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
-  }
-`
-
-const PrimaryButton = styled(Button)`
-  border-radius: 8px;
-  padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => theme.colors.blue9};
-  background: ${({ theme }) => theme.colors.blue9};
-  color: ${({ theme }) => theme.colors.gray1};
-  font-weight: 700;
-
-  &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.blue10};
-    background: ${({ theme }) => theme.colors.blue10};
-    color: ${({ theme }) => theme.colors.gray1};
-  }
-`
-
-const RowActionButton = styled(Button)`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.42rem;
-  width: 100%;
-  min-height: 40px;
-  padding: 0.42rem 0.62rem;
-  font-size: 0.78rem;
-  font-weight: 700;
-  white-space: nowrap;
-
-  svg {
-    flex: 0 0 auto;
-  }
-
-  span {
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  &[data-variant="primary"] {
-    border-color: ${({ theme }) => theme.colors.blue8};
-    background: ${({ theme }) => theme.colors.blue3};
-    color: ${({ theme }) => theme.colors.blue11};
-  }
-
-  &[data-variant="primary"]:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.blue9};
-    background: ${({ theme }) => theme.colors.blue4};
-    color: ${({ theme }) => theme.colors.blue12};
-  }
-`
-
-const RowActionMenu = styled.details`
-  position: relative;
-
-  summary {
-    list-style: none;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.3rem;
-    width: 100%;
-    min-height: 40px;
-    border-radius: 8px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: transparent;
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.76rem;
-    font-weight: 700;
-    cursor: pointer;
-
-    &::-webkit-details-marker {
-      display: none;
-    }
-  }
-
-  .menu {
-    position: absolute;
-    right: 0;
-    top: calc(100% + 0.3rem);
-    z-index: 8;
-    display: grid;
-    min-width: 7rem;
-    padding: 0.32rem;
-    border-radius: 10px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray2};
-    box-shadow: none;
-  }
-
-  .menu button {
-    min-height: 36px;
-    border: 0;
-    border-radius: 8px;
-    background: transparent;
-    color: ${({ theme }) => theme.colors.red11};
-    font-size: 0.78rem;
-    font-weight: 700;
-    cursor: pointer;
-  }
-
-  .menu button:hover:not(:disabled) {
-    background: ${({ theme }) => theme.colors.red3};
-  }
-
-  .menu button:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
-  }
-`

--- a/front/src/routes/Admin/EditorStudioPostListPanelParts.tsx
+++ b/front/src/routes/Admin/EditorStudioPostListPanelParts.tsx
@@ -1,0 +1,343 @@
+import AppIcon from "src/components/icons/AppIcon"
+import { Button, PrimaryButton, RowActionButton, RowActionMenu } from "./EditorStudioPostListActionStyles"
+import {
+  DeletedBadge,
+  EditorStudioPostListInlineStatus,
+  EditorStudioPostListPanelShell,
+  InlineActions,
+  ListEmpty,
+  ListHeader,
+  ListHeaderActions,
+  ListTable,
+  ListTableWrap,
+  LoadedBadge,
+  MobileListCards,
+  ReadOnlyHint,
+  SelectionStickyBar,
+  SortHeaderButton,
+  TitleCell,
+  VisibilityBadge,
+} from "./EditorStudioPostListPanelStyles"
+import { getVisibilityLabel, toVisibility } from "./editorStudioState"
+import type {
+  EditorStudioPostListEditorMode,
+  EditorStudioPostListItem,
+  EditorStudioPostListScope,
+} from "./EditorStudioPostListPanel"
+
+export type EditorStudioPostListCommands = {
+  clearSelection: () => void
+  copyPostDetailLink: (id: number, title: string) => void
+  editPost: (row: EditorStudioPostListItem) => void
+  hardDeletePost: (row: EditorStudioPostListItem) => void
+  openPostDetail: (id: number) => void
+  refreshList: () => void
+  requestDeletePosts: (ids: number[], headline?: string) => void
+  restoreDeletedPost: (row: EditorStudioPostListItem) => void
+  toggleModifiedSortOrder: () => void
+  togglePostSelection: (id: number) => void
+  toggleSelectAllVisiblePosts: () => void
+}
+
+type HeaderProps = {
+  listScope: EditorStudioPostListScope
+  selectedPostCount: number
+  totalCount: number
+  hasVisibleRows: boolean
+  isAllVisiblePostsSelected: boolean
+  isLoading: boolean
+  commands: EditorStudioPostListCommands
+}
+
+export const EditorStudioPostListHeader = ({
+  listScope,
+  selectedPostCount,
+  totalCount,
+  hasVisibleRows,
+  isAllVisiblePostsSelected,
+  isLoading,
+  commands,
+}: HeaderProps) => (
+  <ListHeader>
+    <h3>{listScope === "active" ? "관리자 글 리스트" : "삭제 글 리스트"}</h3>
+    <ListHeaderActions>
+      <span>{selectedPostCount > 0 ? `${selectedPostCount}개 선택` : `총 ${totalCount}건`}</span>
+      {listScope === "active" ? (
+        hasVisibleRows ? (
+          <Button type="button" disabled={isLoading} onClick={commands.toggleSelectAllVisiblePosts}>
+            {isAllVisiblePostsSelected ? "현재 목록 선택 해제" : "현재 목록 전체 선택"}
+          </Button>
+        ) : null
+      ) : (
+        <ReadOnlyHint>삭제 글은 복구 또는 영구삭제로 정리할 수 있습니다.</ReadOnlyHint>
+      )}
+    </ListHeaderActions>
+  </ListHeader>
+)
+
+type SelectionBarProps = {
+  selectedPostIds: readonly number[]
+  isLoading: boolean
+  commands: EditorStudioPostListCommands
+}
+
+export const EditorStudioPostListSelectionBar = ({
+  selectedPostIds,
+  isLoading,
+  commands,
+}: SelectionBarProps) => (
+  <SelectionStickyBar role="status" aria-live="polite">
+    <strong>{selectedPostIds.length}개 선택됨</strong>
+    <div>
+      <Button type="button" onClick={commands.clearSelection} disabled={isLoading}>
+        선택 해제
+      </Button>
+      <Button
+        type="button"
+        data-variant="danger"
+        disabled={isLoading}
+        onClick={() => commands.requestDeletePosts([...selectedPostIds])}
+      >
+        선택 삭제
+      </Button>
+    </div>
+  </SelectionStickyBar>
+)
+
+type EmptyStateProps = {
+  listScope: EditorStudioPostListScope
+  isRefreshDisabled: boolean
+  commands: EditorStudioPostListCommands
+}
+
+export const EditorStudioPostListEmptyState = ({
+  listScope,
+  isRefreshDisabled,
+  commands,
+}: EmptyStateProps) => (
+  <ListEmpty>
+    <p>
+      {listScope === "active"
+        ? "목록이 없습니다. 위 조회 조건에서 목록 새로고침을 눌러 시작하세요."
+        : "삭제된 글이 없습니다. 삭제 글 목록을 조회해 최신 상태를 확인하세요."}
+    </p>
+    <div className="actions">
+      <PrimaryButton type="button" disabled={isRefreshDisabled} onClick={commands.refreshList}>
+        {listScope === "active" ? "목록 새로고침" : "삭제 글 목록 조회"}
+      </PrimaryButton>
+    </div>
+  </ListEmpty>
+)
+
+type ListRowsProps = {
+  listScope: EditorStudioPostListScope
+  rows: readonly EditorStudioPostListItem[]
+  selectedPostIdSet: ReadonlySet<number>
+  editorMode: EditorStudioPostListEditorMode
+  postId: string
+  isLoading: boolean
+  commands: EditorStudioPostListCommands
+}
+
+type TableProps = ListRowsProps & {
+  isAllVisiblePostsSelected: boolean
+  modifiedSortOrder: "desc" | "asc"
+}
+
+export const EditorStudioPostListTable = ({
+  listScope,
+  rows,
+  selectedPostIdSet,
+  isAllVisiblePostsSelected,
+  editorMode,
+  postId,
+  modifiedSortOrder,
+  isLoading,
+  commands,
+}: TableProps) => (
+  <ListTableWrap>
+    <ListTable>
+      <thead>
+        <tr>
+          {listScope === "active" ? (
+            <th className="checkboxCell">
+              <input
+                type="checkbox"
+                aria-label="현재 목록 전체 선택"
+                checked={isAllVisiblePostsSelected}
+                onChange={commands.toggleSelectAllVisiblePosts}
+              />
+            </th>
+          ) : null}
+          <th className="idCell">ID</th>
+          <th>제목</th>
+          <th className="dateCell">
+            {listScope === "active" ? (
+              <SortHeaderButton type="button" onClick={commands.toggleModifiedSortOrder}>
+                수정일 {modifiedSortOrder === "desc" ? "↓" : "↑"}
+              </SortHeaderButton>
+            ) : (
+              "삭제일"
+            )}
+          </th>
+          <th className="actionsCell">작업</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => {
+          const isLoadedRow = listScope === "active" && editorMode === "edit" && postId.trim() === String(row.id)
+          return (
+            <tr key={row.id} data-active={isLoadedRow}>
+              {listScope === "active" ? (
+                <td className="checkboxCell">
+                  <input
+                    type="checkbox"
+                    aria-label={`${row.id}번 글 선택`}
+                    checked={selectedPostIdSet.has(row.id)}
+                    onChange={() => commands.togglePostSelection(row.id)}
+                  />
+                </td>
+              ) : null}
+              <td className="idCell">{row.id}</td>
+              <td className="title">
+                <TitleCell>
+                  <div className="titleMain">
+                    <span className="text">{row.title}</span>
+                    {isLoadedRow ? <LoadedBadge>현재 편집 중</LoadedBadge> : null}
+                    {listScope === "deleted" ? <DeletedBadge>삭제됨</DeletedBadge> : null}
+                    <VisibilityBadge className="inlineVisibility" data-tone={toVisibility(row.published, row.listed)}>
+                      {getVisibilityLabel(row.published, row.listed)}
+                    </VisibilityBadge>
+                  </div>
+                  <span className="meta">{row.authorName || "작성자 미상"}</span>
+                </TitleCell>
+              </td>
+              <td className="dateCell">{(listScope === "deleted" ? row.deletedAt : row.modifiedAt)?.slice(0, 10) || "-"}</td>
+              <td className="actionsCell">
+                <InlineActions>
+                  <PostRowActions
+                    row={row}
+                    listScope={listScope}
+                    isLoadedRow={isLoadedRow}
+                    isLoading={isLoading}
+                    commands={commands}
+                  />
+                </InlineActions>
+              </td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </ListTable>
+  </ListTableWrap>
+)
+
+export const EditorStudioPostListMobileCards = ({
+  listScope,
+  rows,
+  selectedPostIdSet,
+  editorMode,
+  postId,
+  isLoading,
+  commands,
+}: ListRowsProps) => (
+  <MobileListCards>
+    {rows.map((row) => {
+      const isLoadedRow = listScope === "active" && editorMode === "edit" && postId.trim() === String(row.id)
+      return (
+        <article key={`mobile-${row.id}`} data-active={isLoadedRow}>
+          <header>
+            <div className="metaLeading">
+              {listScope === "active" ? (
+                <input
+                  type="checkbox"
+                  aria-label={`${row.id}번 글 선택`}
+                  checked={selectedPostIdSet.has(row.id)}
+                  onChange={() => commands.togglePostSelection(row.id)}
+                />
+              ) : null}
+              <span className="rowId">#{row.id}</span>
+            </div>
+            {isLoadedRow ? <LoadedBadge>현재 편집 중</LoadedBadge> : null}
+          </header>
+          <h4>{row.title}</h4>
+          <p className="metaLine">
+            <span>
+              {row.authorName}
+              <span className="dot">•</span>
+              {(listScope === "deleted" ? row.deletedAt : row.modifiedAt)?.slice(0, 10) || "-"}
+            </span>
+            <VisibilityBadge data-tone={toVisibility(row.published, row.listed)}>
+              {getVisibilityLabel(row.published, row.listed)}
+            </VisibilityBadge>
+          </p>
+          <div className="mainAction">
+            <PostRowActions
+              row={row}
+              listScope={listScope}
+              isLoadedRow={isLoadedRow}
+              isLoading={isLoading}
+              commands={commands}
+            />
+          </div>
+        </article>
+      )
+    })}
+  </MobileListCards>
+)
+
+type PostRowActionsProps = {
+  row: EditorStudioPostListItem
+  listScope: EditorStudioPostListScope
+  isLoadedRow: boolean
+  isLoading: boolean
+  commands: EditorStudioPostListCommands
+}
+
+const PostRowActions = ({ row, listScope, isLoadedRow, isLoading, commands }: PostRowActionsProps) =>
+  listScope === "active" ? (
+    <>
+      <RowActionButton type="button" data-variant="primary" disabled={isLoading} onClick={() => commands.editPost(row)}>
+        <AppIcon name="edit" />
+        <span>{isLoadedRow ? "계속 편집" : "편집"}</span>
+      </RowActionButton>
+      <RowActionMenu>
+        <summary>
+          <span>더보기</span>
+          <AppIcon name="chevron-down" />
+        </summary>
+        <div className="menu">
+          <button type="button" disabled={isLoading} onClick={() => commands.openPostDetail(row.id)}>
+            상세 열기
+          </button>
+          <button type="button" disabled={isLoading} onClick={() => commands.copyPostDetailLink(row.id, row.title)}>
+            링크 복사
+          </button>
+          <button type="button" disabled={isLoading} onClick={() => commands.requestDeletePosts([row.id], row.title)}>
+            삭제
+          </button>
+        </div>
+      </RowActionMenu>
+    </>
+  ) : (
+    <>
+      <RowActionButton type="button" data-variant="primary" disabled={isLoading} onClick={() => commands.restoreDeletedPost(row)}>
+        <AppIcon name="check-circle" />
+        <span>복구</span>
+      </RowActionButton>
+      <RowActionMenu>
+        <summary>
+          <span>더보기</span>
+          <AppIcon name="chevron-down" />
+        </summary>
+        <div className="menu">
+          <button type="button" disabled={isLoading} onClick={() => commands.hardDeletePost(row)}>
+            영구삭제
+          </button>
+        </div>
+      </RowActionMenu>
+    </>
+  )
+
+export { EditorStudioPostListInlineStatus, EditorStudioPostListPanelShell } from "./EditorStudioPostListPanelStyles"
+

--- a/front/src/routes/Admin/EditorStudioPostListPanelStyles.tsx
+++ b/front/src/routes/Admin/EditorStudioPostListPanelStyles.tsx
@@ -1,0 +1,515 @@
+import styled from "@emotion/styled"
+
+export const EditorStudioPostListPanelShell = styled.div`
+  border: 1px solid ${({ theme }) => theme.colors.gray5};
+  border-radius: 12px;
+  background: ${({ theme }) => theme.colors.gray1};
+  padding: 0.82rem;
+  margin: 0;
+  min-width: 0;
+  display: grid;
+  gap: 0.62rem;
+
+  @media (max-width: 720px) {
+    &[data-mobile-visible="false"] {
+      display: none;
+    }
+  }
+`
+
+export const ListHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.64rem;
+  margin-bottom: 0.75rem;
+
+  h3 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 720;
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  span {
+    font-size: 0.8rem;
+    color: ${({ theme }) => theme.colors.gray11};
+  }
+
+  @media (max-width: 920px) {
+    flex-direction: column;
+  }
+`
+
+export const ListHeaderActions = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  align-items: center;
+
+  span {
+    display: inline-flex;
+    align-items: center;
+    min-height: 34px;
+    padding: 0 0.72rem;
+    border-radius: 999px;
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => theme.colors.gray2};
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.8rem;
+    font-weight: 700;
+    white-space: nowrap;
+  }
+
+  @media (max-width: 920px) {
+    justify-content: flex-start;
+  }
+
+  @media (max-width: 720px) {
+    width: 100%;
+
+    span {
+      width: 100%;
+      margin-right: 0;
+    }
+
+    > button {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+`
+
+export const ReadOnlyHint = styled.span`
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray2};
+  color: ${({ theme }) => theme.colors.gray11};
+  min-height: 28px;
+  padding: 0 0.58rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+`
+
+export const ListEmpty = styled.div`
+  margin: 0;
+  min-height: 13.5rem;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 0.8rem 1rem;
+  border-radius: 10px;
+  border: 1px dashed ${({ theme }) => theme.colors.gray6};
+  color: ${({ theme }) => theme.colors.gray11};
+  gap: 0.72rem;
+
+  p {
+    margin: 0;
+    font-size: 0.86rem;
+    line-height: 1.65;
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+  }
+`
+
+export const SelectionStickyBar = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  margin: 0 0 0.68rem;
+  padding: 0.55rem 0.62rem;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 10px;
+  background: ${({ theme }) => theme.colors.gray2};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.8rem;
+  }
+
+  > div {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+
+  @media (max-width: 900px) {
+    top: calc(var(--app-header-height, 56px) + 0.35rem);
+  }
+`
+
+export const ListTableWrap = styled.div`
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: auto;
+  max-height: 52vh;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 10px;
+  overscroll-behavior: contain;
+
+  @media (max-width: 1100px) {
+    display: none;
+  }
+`
+
+export const ListTable = styled.table`
+  width: 100%;
+  min-width: 980px;
+  border-collapse: collapse;
+  table-layout: fixed;
+
+  th,
+  td {
+    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+    padding: 0.5rem 0.45rem;
+    text-align: left;
+    font-size: 0.8rem;
+    color: ${({ theme }) => theme.colors.gray12};
+    vertical-align: middle;
+  }
+
+  th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: ${({ theme }) => theme.colors.gray2};
+    font-size: 0.75rem;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-weight: 700;
+  }
+
+  tbody tr:last-of-type td {
+    border-bottom: 0;
+  }
+
+  tbody tr {
+    transition: background-color 0.18s ease, box-shadow 0.18s ease;
+  }
+
+  tbody tr:hover td {
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  tbody tr[data-active="true"] td {
+    background:
+      linear-gradient(90deg, rgba(59, 130, 246, 0.14) 0, rgba(59, 130, 246, 0.04) 28px, rgba(255, 255, 255, 0.02) 28px);
+  }
+
+  .checkboxCell {
+    width: 2rem;
+    text-align: center;
+    padding-left: 0.2rem;
+    padding-right: 0.2rem;
+  }
+
+  th.idCell,
+  td.idCell {
+    width: 4.75rem;
+    white-space: nowrap;
+  }
+
+  input[type="checkbox"] {
+    width: 0.92rem;
+    height: 0.92rem;
+    cursor: pointer;
+    accent-color: ${({ theme }) => theme.colors.blue9};
+  }
+
+  td.title {
+    min-width: 0;
+  }
+
+  th.dateCell,
+  td.dateCell {
+    width: 112px;
+    white-space: nowrap;
+  }
+
+  th.actionsCell,
+  td.actionsCell {
+    width: 132px;
+    min-width: 132px;
+  }
+
+  @media (max-width: 1520px) {
+    th.actionsCell,
+    td.actionsCell {
+      width: 124px;
+      min-width: 124px;
+    }
+  }
+`
+
+export const TitleCell = styled.div`
+  display: grid;
+  gap: 0.36rem;
+  max-width: 100%;
+  min-width: 0;
+
+  .titleMain {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-width: 0;
+    flex-wrap: wrap;
+  }
+
+  .text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-weight: 700;
+  }
+
+  .meta {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.72rem;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .inlineVisibility {
+    display: inline-flex;
+  }
+`
+
+export const DeletedBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 0.12rem 0.42rem;
+  flex: 0 0 auto;
+`
+
+export const LoadedBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.blue7};
+  background: ${({ theme }) => theme.colors.blue3};
+  color: ${({ theme }) => theme.colors.blue11};
+  padding: 0 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 800;
+  line-height: 1;
+  flex: 0 0 auto;
+`
+
+export const SortHeaderButton = styled.button`
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: 0.74rem;
+  font-weight: 700;
+  cursor: pointer;
+`
+
+export const VisibilityBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.16rem 0.46rem;
+  font-size: 0.72rem;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  color: ${({ theme }) => theme.colors.gray11};
+  background: ${({ theme }) => theme.colors.gray2};
+
+  &[data-tone="PRIVATE"] {
+    color: ${({ theme }) => theme.colors.gray11};
+  }
+
+  &[data-tone="PUBLIC_UNLISTED"] {
+    color: ${({ theme }) => theme.colors.blue11};
+    border-color: ${({ theme }) => theme.colors.blue7};
+    background: ${({ theme }) => theme.colors.blue3};
+  }
+
+  &[data-tone="PUBLIC_LISTED"] {
+    color: ${({ theme }) => theme.colors.green11};
+    border-color: ${({ theme }) => theme.colors.green7};
+    background: ${({ theme }) => theme.colors.green3};
+  }
+`
+
+export const InlineActions = styled.div`
+  display: grid;
+  gap: 0.42rem;
+  align-items: stretch;
+`
+
+export const MobileListCards = styled.div`
+  display: none;
+  margin-top: 0.65rem;
+
+  @media (max-width: 1100px) {
+    display: grid;
+    gap: 0.6rem;
+  }
+
+  article {
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    border-radius: 10px;
+    padding: 0.62rem;
+    background: ${({ theme }) => theme.colors.gray2};
+    display: grid;
+    gap: 0.5rem;
+    content-visibility: auto;
+    contain-intrinsic-size: 1px 172px;
+    transition: background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+  }
+
+  article[data-active="true"] {
+    border-color: ${({ theme }) => theme.colors.blue7};
+    background: ${({ theme }) => theme.colors.blue3};
+    box-shadow: none;
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.45rem;
+  }
+
+  .metaLeading {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-width: 0;
+  }
+
+  .metaLeading input[type="checkbox"] {
+    width: 1rem;
+    height: 1rem;
+    accent-color: ${({ theme }) => theme.colors.gray10};
+  }
+
+  h4 {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.9rem;
+    line-height: 1.45;
+    word-break: break-word;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  p {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.4rem;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.78rem;
+  }
+
+  .metaLine {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.42rem;
+
+    .dot {
+      margin: 0 0.26rem;
+      opacity: 0.65;
+    }
+  }
+
+  .mainAction {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.42rem;
+  }
+
+  .mainAction > button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .rowId {
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.78rem;
+  }
+
+  @media (max-width: 420px) {
+    gap: 0.52rem;
+
+    article {
+      padding: 0.56rem;
+    }
+
+    p {
+      align-items: flex-start;
+      flex-wrap: wrap;
+      justify-content: flex-start;
+    }
+
+    .mainAction {
+      grid-template-columns: 1fr;
+    }
+  }
+`
+
+export const EditorStudioPostListInlineStatus = styled.div`
+  margin-bottom: 0.85rem;
+  padding: 0.62rem 0.72rem;
+  border-radius: 8px;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+
+  &[data-tone="idle"] {
+    color: ${({ theme }) => theme.colors.gray11};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: transparent;
+  }
+
+  &[data-tone="loading"] {
+    color: ${({ theme }) => theme.colors.blue11};
+    border: 1px solid ${({ theme }) => theme.colors.blue7};
+    background: ${({ theme }) => theme.colors.blue3};
+  }
+
+  &[data-tone="success"] {
+    color: ${({ theme }) => theme.colors.green11};
+    border: 1px solid ${({ theme }) => theme.colors.green7};
+    background: ${({ theme }) => theme.colors.green3};
+  }
+
+  &[data-tone="error"] {
+    color: ${({ theme }) => theme.colors.red11};
+    border: 1px solid ${({ theme }) => theme.colors.red7};
+    background: ${({ theme }) => theme.colors.red3};
+  }
+`

--- a/front/src/routes/Admin/EditorStudioPublishModal.tsx
+++ b/front/src/routes/Admin/EditorStudioPublishModal.tsx
@@ -1,25 +1,23 @@
 import styled from "@emotion/styled"
 import type { CSSProperties, ReactNode } from "react"
-import ProfileImage from "src/components/ProfileImage"
-import AppIcon from "src/components/icons/AppIcon"
 import type { PostVisibility } from "./editorStudioState"
+import {
+  EditorStudioPublishCardSettings,
+  EditorStudioPublishPreviewCard,
+  EditorStudioPublishVisibilitySection,
+  PublishButton,
+  PublishModalNotice,
+  PublishOverviewGrid,
+  PublishPrimaryButton,
+  type EditorStudioPreviewViewportOption,
+  type EditorStudioPublishVisibilityOption,
+} from "./EditorStudioPublishModalParts"
 
 type NoticeTone = "idle" | "loading" | "success" | "error"
 
 type PublishNoticeState = {
   tone: NoticeTone
   text: string
-}
-
-type PublishVisibilityOption = {
-  value: PostVisibility
-  label: string
-  description: string
-}
-
-type PreviewViewportOption<TViewport extends string> = {
-  value: TViewport
-  label: string
 }
 
 type EditorStudioPublishModalProps<TViewport extends string> = {
@@ -46,7 +44,7 @@ type EditorStudioPublishModalProps<TViewport extends string> = {
   previewThumbnailSrc: string
   previewViewport: TViewport
   previewViewportLabel: string
-  previewViewportOptions: Array<PreviewViewportOption<TViewport>>
+  previewViewportOptions: Array<EditorStudioPreviewViewportOption<TViewport>>
   previewVisibilityLabel: string
   publishActionButtonDisabled: boolean
   publishActionButtonText: string
@@ -55,7 +53,7 @@ type EditorStudioPublishModalProps<TViewport extends string> = {
   shouldShowNotice: boolean
   thumbnailEditorPanel: ReactNode
   variant?: "drawer"
-  visibilityOptions: PublishVisibilityOption[]
+  visibilityOptions: EditorStudioPublishVisibilityOption[]
   onClose: () => void
   onConfirmPublish: () => void
   onPreviewThumbnailError: () => void
@@ -126,147 +124,45 @@ export const EditorStudioPublishModal = <TViewport extends string,>({
             <PublishModalNotice data-tone={modalNotice.tone}>{modalNotice.text}</PublishModalNotice>
           ) : null}
           <PublishOverviewGrid>
-            <VisibilityCard>
-              <SectionKicker>노출 범위</SectionKicker>
-              <strong>누가 이 글을 볼 수 있나요?</strong>
-              <VisibilityOptionGrid role="group" aria-label="노출 범위 선택">
-                {visibilityOptions.map((option) => (
-                  <VisibilityOptionButton
-                    key={option.value}
-                    type="button"
-                    data-active={postVisibility === option.value}
-                    aria-pressed={postVisibility === option.value}
-                    onClick={() => onPostVisibilityChange(option.value)}
-                  >
-                    <strong>{option.label}</strong>
-                    <span>{option.description}</span>
-                  </VisibilityOptionButton>
-                ))}
-              </VisibilityOptionGrid>
-              <FieldHelp>메인 피드 노출은 전체 공개에서만 활성화됩니다.</FieldHelp>
-            </VisibilityCard>
-            <PreviewResultPanel>
-              <PreviewResultHeader>
-                <div>
-                  <SectionKicker>{previewKicker}</SectionKicker>
-                  <strong>{previewViewportLabel}</strong>
-                </div>
-                <PreviewViewportTabs role="tablist" aria-label="포스트 카드 미리보기 기기">
-                  {previewViewportOptions.map((viewport) => (
-                    <PreviewViewportButton
-                      key={viewport.value}
-                      type="button"
-                      role="tab"
-                      aria-selected={previewViewport === viewport.value}
-                      data-active={previewViewport === viewport.value}
-                      onClick={() => onPreviewViewportChange(viewport.value)}
-                    >
-                      {viewport.label}
-                    </PreviewViewportButton>
-                  ))}
-                </PreviewViewportTabs>
-              </PreviewResultHeader>
-              <PreviewResultFrame style={previewFrameStyle}>
-                <PreviewResultCard>
-                  <div className="thumbnail">
-                    {previewThumbnailSrc ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        src={previewThumbnailSrc}
-                        alt="실제 카드 기준 포스트 썸네일 미리보기"
-                        style={{
-                          objectFit: "cover",
-                          objectPosition: `${postThumbnailFocusX}% ${postThumbnailFocusY}%`,
-                          transform: `scale(${postThumbnailZoom})`,
-                          transformOrigin: `${postThumbnailFocusX}% ${postThumbnailFocusY}%`,
-                        }}
-                        onError={onPreviewThumbnailError}
-                      />
-                    ) : (
-                      <div className="thumbnail-placeholder">
-                        <em>썸네일 없음</em>
-                        <span>본문 첫 이미지가 자동 카드 썸네일로 사용됩니다.</span>
-                      </div>
-                    )}
-                  </div>
-                  <div className="content">
-                    <PreviewVisibilityBadge>{previewVisibilityLabel}</PreviewVisibilityBadge>
-                    <h4>{postTitle.trim() || "제목을 입력하면 카드 결과가 여기에 표시됩니다."}</h4>
-                    <p className="summary">{previewSummary || previewSummaryFallback}</p>
-                    <div className="meta">
-                      <span>{previewDateText}</span>
-                      <span className="dot">·</span>
-                      <span className="comment">
-                        <AppIcon name="message" />
-                        0개의 댓글
-                      </span>
-                    </div>
-                    <div className="footer">
-                      <div className="author">
-                        <span className="avatar" aria-hidden="true">
-                          {previewAuthorAvatarSrc ? (
-                            <ProfileImage src={previewAuthorAvatarSrc} alt="" fillContainer />
-                          ) : (
-                            <span className="initial">{displayNameInitial}</span>
-                          )}
-                        </span>
-                        <span className="by">by</span>
-                        <strong>{displayName}</strong>
-                      </div>
-                      <div className="like">
-                        <AppIcon name="heart" />
-                        <span>0</span>
-                      </div>
-                    </div>
-                  </div>
-                </PreviewResultCard>
-              </PreviewResultFrame>
-            </PreviewResultPanel>
+            <EditorStudioPublishVisibilitySection
+              postVisibility={postVisibility}
+              visibilityOptions={visibilityOptions}
+              onPostVisibilityChange={onPostVisibilityChange}
+            />
+            <EditorStudioPublishPreviewCard
+              displayName={displayName}
+              displayNameInitial={displayNameInitial}
+              postThumbnailFocusX={postThumbnailFocusX}
+              postThumbnailFocusY={postThumbnailFocusY}
+              postThumbnailZoom={postThumbnailZoom}
+              postTitle={postTitle}
+              previewAuthorAvatarSrc={previewAuthorAvatarSrc}
+              previewDateText={previewDateText}
+              previewFrameStyle={previewFrameStyle}
+              previewKicker={previewKicker}
+              previewSummary={previewSummary}
+              previewSummaryFallback={previewSummaryFallback}
+              previewThumbnailSrc={previewThumbnailSrc}
+              previewViewport={previewViewport}
+              previewViewportLabel={previewViewportLabel}
+              previewViewportOptions={previewViewportOptions}
+              previewVisibilityLabel={previewVisibilityLabel}
+              onPreviewThumbnailError={onPreviewThumbnailError}
+              onPreviewViewportChange={onPreviewViewportChange}
+            />
           </PublishOverviewGrid>
 
-          <PostPreviewSetup>
-            <PostPreviewHeader>
-              <strong>카드 요소 편집</strong>
-              {setupDescription ? <span>{setupDescription}</span> : null}
-            </PostPreviewHeader>
-            {isCompactMobileLayout ? (
-              <CompactPublishEditorStack>
-                <CompactPublishEditorCard>
-                  <CompactPublishEditorToggle
-                    type="button"
-                    aria-expanded={isMobileThumbnailEditorOpen}
-                    onClick={onToggleMobileThumbnailEditor}
-                  >
-                    <div>
-                      <strong>썸네일 위치 조정</strong>
-                      <span>드래그/확대로 카드 크롭을 빠르게 맞춥니다.</span>
-                    </div>
-                    <span>{isMobileThumbnailEditorOpen ? closeToggleLabel : "열기"}</span>
-                  </CompactPublishEditorToggle>
-                  {isMobileThumbnailEditorOpen ? thumbnailEditorPanel : null}
-                </CompactPublishEditorCard>
-                <CompactPublishEditorCard>
-                  <CompactPublishEditorToggle
-                    type="button"
-                    aria-expanded={isMobileMetaEditorOpen}
-                    onClick={onToggleMobileMetaEditor}
-                  >
-                    <div>
-                      <strong>카드 메타 편집</strong>
-                      <span>썸네일 URL과 요약만 따로 정리합니다.</span>
-                    </div>
-                    <span>{isMobileMetaEditorOpen ? closeToggleLabel : "열기"}</span>
-                  </CompactPublishEditorToggle>
-                  {isMobileMetaEditorOpen ? previewMetaEditorPanel : null}
-                </CompactPublishEditorCard>
-              </CompactPublishEditorStack>
-            ) : (
-              <PreviewEditorGrid>
-                {thumbnailEditorPanel}
-                {previewMetaEditorPanel}
-              </PreviewEditorGrid>
-            )}
-          </PostPreviewSetup>
+          <EditorStudioPublishCardSettings
+            closeToggleLabel={closeToggleLabel}
+            isCompactMobileLayout={isCompactMobileLayout}
+            isMobileMetaEditorOpen={isMobileMetaEditorOpen}
+            isMobileThumbnailEditorOpen={isMobileThumbnailEditorOpen}
+            previewMetaEditorPanel={previewMetaEditorPanel}
+            setupDescription={setupDescription}
+            thumbnailEditorPanel={thumbnailEditorPanel}
+            onToggleMobileMetaEditor={onToggleMobileMetaEditor}
+            onToggleMobileThumbnailEditor={onToggleMobileThumbnailEditor}
+          />
         </PublishModalBody>
         <PublishModalFooter>
           <PublishButton type="button" disabled={isCloseDisabled} onClick={onClose}>
@@ -330,567 +226,41 @@ const PublishDialog = styled.div`
 `
 
 const PublishModalHeader = styled.div`
-  display: grid;
-  gap: 0.75rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
 
   h4 {
     margin: 0;
-    font-size: 1.08rem;
     color: ${({ theme }) => theme.colors.gray12};
+    font-size: 1.04rem;
+    font-weight: 750;
   }
 `
 
 const PublishModalBody = styled.div`
   display: grid;
-  gap: 0.8rem;
-  padding-bottom: 0.6rem;
-
-  @media (max-width: 720px) {
-    gap: 0.7rem;
-  }
+  gap: 0.86rem;
+  padding-bottom: 0.95rem;
 `
 
 const PublishModalFooter = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.5rem;
-  flex-wrap: wrap;
   position: sticky;
   bottom: 0;
-  z-index: 2;
-  margin: 0 -1rem;
-  padding: 0.9rem 1rem 1rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.52rem;
+  padding: 0.78rem 0;
   border-top: 1px solid ${({ theme }) => theme.colors.gray6};
   background: ${({ theme }) => theme.colors.gray2};
-  box-shadow: 0 -10px 28px rgba(2, 6, 23, 0.12);
 
-  @media (max-width: 720px) {
-    margin: 0 -0.82rem;
-    padding: 0.82rem 0.82rem calc(0.9rem + env(safe-area-inset-bottom, 0px));
-  }
-`
+  @media (max-width: 480px) {
+    flex-direction: column-reverse;
 
-const PublishOverviewGrid = styled.div`
-  display: grid;
-  gap: 0.8rem;
-
-  @media (min-width: 1080px) {
-    grid-template-columns: minmax(0, 1fr) minmax(320px, 368px);
-    align-items: start;
-  }
-`
-
-const VisibilityCard = styled.section`
-  display: grid;
-  gap: 0.62rem;
-  align-content: start;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 14px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0)),
-    ${({ theme }) => theme.colors.gray1};
-  padding: 0.9rem;
-
-  > strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.94rem;
-    font-weight: 700;
-    line-height: 1.35;
-  }
-`
-
-const SectionKicker = styled.span`
-  display: inline-flex;
-  align-items: center;
-  width: fit-content;
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-`
-
-const VisibilityOptionGrid = styled.div`
-  display: grid;
-  gap: 0.5rem;
-`
-
-const VisibilityOptionButton = styled.button`
-  display: grid;
-  gap: 0.16rem;
-  width: 100%;
-  padding: 0.72rem 0.78rem;
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
-  text-align: left;
-  cursor: pointer;
-  transition:
-    border-color 0.18s ease,
-    background-color 0.18s ease,
-    box-shadow 0.18s ease;
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.84rem;
-    font-weight: 700;
-    line-height: 1.3;
-  }
-
-  span {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.75rem;
-    line-height: 1.45;
-  }
-
-  &[data-active="true"] {
-    border-color: ${({ theme }) => theme.colors.blue8};
-    background: ${({ theme }) => theme.colors.blue3};
-    box-shadow: 0 0 0 1px ${({ theme }) => theme.colors.blue6} inset;
-  }
-`
-
-const FieldHelp = styled.span`
-  display: block;
-  width: 100%;
-  min-width: 0;
-  color: ${({ theme }) => theme.colors.gray11};
-  font-size: 0.74rem;
-  line-height: 1.45;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-
-  @media (max-width: 720px) {
-    display: none;
-  }
-`
-
-const PreviewResultPanel = styled.div`
-  display: grid;
-  gap: 0.75rem;
-  min-width: 0;
-  overflow: hidden;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 14px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0)),
-    ${({ theme }) => theme.colors.gray1};
-  padding: 0.9rem;
-`
-
-const PreviewResultHeader = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.75rem;
-
-  > div:first-of-type {
-    display: grid;
-    gap: 0.16rem;
-    min-width: 0;
-  }
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.9rem;
-    font-weight: 700;
-    line-height: 1.3;
-  }
-
-  span {
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.76rem;
-    line-height: 1.45;
-  }
-
-  @media (max-width: 1079px) {
-    flex-direction: column;
-  }
-`
-
-const PreviewViewportTabs = styled.div`
-  display: inline-flex;
-  flex-wrap: nowrap;
-  gap: 0.4rem;
-  max-width: 100%;
-  overflow-x: auto;
-  padding-bottom: 0.1rem;
-`
-
-const PreviewViewportButton = styled.button`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 34px;
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray10};
-  padding: 0 0.78rem;
-  font-size: 0.76rem;
-  font-weight: 700;
-  cursor: pointer;
-  transition:
-    border-color 0.18s ease,
-    background-color 0.18s ease,
-    color 0.18s ease,
-    box-shadow 0.18s ease;
-
-  &[data-active="true"] {
-    border-color: ${({ theme }) => theme.colors.gray7};
-    background: ${({ theme }) => theme.colors.gray3};
-    color: ${({ theme }) => theme.colors.gray12};
-    box-shadow: 0 0 0 1px ${({ theme }) => theme.colors.gray5} inset;
-  }
-
-  &:hover:not([data-active="true"]) {
-    border-color: ${({ theme }) => theme.colors.gray8};
-    color: ${({ theme }) => theme.colors.gray12};
-  }
-`
-
-const PreviewResultFrame = styled.div`
-  width: 100%;
-  margin: 0 auto;
-`
-
-const PreviewVisibilityBadge = styled.span`
-  display: inline-flex;
-  align-items: center;
-  min-height: 24px;
-  width: fit-content;
-  border-radius: 999px;
-  border: 1px solid rgba(45, 212, 191, 0.34);
-  background: rgba(20, 184, 166, 0.12);
-  color: #99f6e4;
-  padding: 0 0.56rem;
-  font-size: 0.72rem;
-  font-weight: 700;
-  line-height: 1;
-`
-
-const PreviewResultCard = styled.article`
-  overflow: hidden;
-  width: 100%;
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.gray4};
-  background: ${({ theme }) => theme.colors.gray1};
-  box-shadow: 0 10px 28px rgba(2, 6, 23, 0.22);
-
-  .thumbnail {
-    position: relative;
-    aspect-ratio: 1.94 / 1;
-    overflow: hidden;
-    background:
-      radial-gradient(circle at top left, rgba(96, 165, 250, 0.08), transparent 48%),
-      ${({ theme }) => theme.colors.gray3};
-    border-bottom: 1px solid ${({ theme }) => theme.colors.gray4};
-  }
-
-  .thumbnail img {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-  }
-
-  .thumbnail-placeholder {
-    width: 100%;
-    height: 100%;
-    display: grid;
-    place-content: center;
-    gap: 0.28rem;
-    padding: 1rem;
-    text-align: center;
-  }
-
-  .thumbnail-placeholder em {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.84rem;
-    font-style: normal;
-    font-weight: 700;
-  }
-
-  .thumbnail-placeholder span {
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.74rem;
-    line-height: 1.45;
-  }
-
-  .content {
-    display: grid;
-    gap: 0.72rem;
-    padding: 1rem;
-  }
-
-  h4 {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 1rem;
-    font-weight: 760;
-    line-height: 1.33;
-    letter-spacing: -0.015em;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-
-  .summary {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.86rem;
-    line-height: 1.55;
-    min-height: calc(1.55em * 3);
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-
-  .meta,
-  .footer {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.65rem;
-    flex-wrap: wrap;
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.75rem;
-  }
-
-  .meta {
-    padding-top: 0.05rem;
-  }
-
-  .meta .dot {
-    opacity: 0.7;
-  }
-
-  .comment,
-  .like,
-  .author {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.34rem;
-  }
-
-  .author {
-    min-width: 0;
-  }
-
-  .author strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.86rem;
-    font-weight: 700;
-  }
-
-  .author .by {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.75rem;
-    font-weight: 600;
-  }
-
-  .avatar {
-    position: relative;
-    flex: 0 0 1.85rem;
-    width: 1.85rem;
-    height: 1.85rem;
-    border-radius: 999px;
-    overflow: hidden;
-    background: ${({ theme }) => theme.colors.gray4};
-    border: 1px solid ${({ theme }) => theme.colors.gray5};
-  }
-
-  .initial {
-    display: grid;
-    place-content: center;
-    width: 100%;
-    height: 100%;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.72rem;
-    font-weight: 800;
-  }
-
-  .like {
-    color: ${({ theme }) => theme.colors.gray11};
-    font-weight: 700;
-  }
-`
-
-const PostPreviewSetup = styled.section`
-  display: grid;
-  gap: 0.82rem;
-  border: none;
-  border-radius: 0;
-  background: transparent;
-  padding: 0;
-`
-
-const PostPreviewHeader = styled.div`
-  display: grid;
-  gap: 0.18rem;
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.92rem;
-    font-weight: 700;
-    line-height: 1.3;
-  }
-
-  span {
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.76rem;
-    line-height: 1.45;
-  }
-`
-
-const PreviewEditorGrid = styled.div`
-  display: grid;
-  gap: 0.8rem;
-
-  @media (min-width: 840px) {
-    grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
-    align-items: start;
-  }
-`
-
-const CompactPublishEditorStack = styled.div`
-  display: grid;
-  gap: 0.7rem;
-`
-
-const CompactPublishEditorCard = styled.div`
-  display: grid;
-  gap: 0.62rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 12px;
-  background: ${({ theme }) => theme.colors.gray2};
-  padding: 0.72rem;
-`
-
-const CompactPublishEditorToggle = styled.button`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.7rem;
-  width: 100%;
-  min-height: 44px;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  text-align: left;
-  cursor: pointer;
-
-  > div {
-    display: grid;
-    gap: 0.14rem;
-    min-width: 0;
-  }
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.86rem;
-    font-weight: 700;
-    line-height: 1.3;
-  }
-
-  span {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.76rem;
-    line-height: 1.45;
-  }
-
-  > span:last-of-type {
-    flex: 0 0 auto;
-    color: ${({ theme }) => theme.colors.blue11};
-    font-weight: 700;
-  }
-`
-
-const PublishModalNotice = styled.div`
-  margin: 0;
-  padding: 0.55rem 0.7rem;
-  border-radius: 10px;
-  font-size: 0.83rem;
-  line-height: 1.4;
-  width: 100%;
-  box-sizing: border-box;
-
-  &[data-tone="idle"] {
-    color: ${({ theme }) => theme.colors.gray11};
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: transparent;
-  }
-
-  &[data-tone="loading"] {
-    color: ${({ theme }) => theme.colors.blue11};
-    border: 1px solid ${({ theme }) => theme.colors.blue7};
-    background: ${({ theme }) => theme.colors.blue3};
-  }
-
-  &[data-tone="success"] {
-    color: ${({ theme }) => theme.colors.green11};
-    border: 1px solid ${({ theme }) => theme.colors.green7};
-    background: ${({ theme }) => theme.colors.green3};
-  }
-
-  &[data-tone="error"] {
-    color: ${({ theme }) => theme.colors.red11};
-    border: 1px solid ${({ theme }) => theme.colors.red7};
-    background: ${({ theme }) => theme.colors.red3};
-  }
-
-  @media (max-width: 720px) {
-    width: 100%;
-  }
-`
-
-const PublishButton = styled.button`
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 8px;
-  padding: 0.62rem 0.92rem;
-  min-height: 44px;
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray10};
-  cursor: pointer;
-  font-size: 0.84rem;
-  font-weight: 600;
-  transition:
-    border-color 0.18s ease,
-    background-color 0.18s ease,
-    color 0.18s ease,
-    box-shadow 0.18s ease;
-
-  &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.gray8};
-    background: ${({ theme }) => theme.colors.gray3};
-    color: ${({ theme }) => theme.colors.gray12};
-  }
-
-  &:focus-visible {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors.blue8};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
-  }
-
-  &:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
-  }
-`
-
-const PublishPrimaryButton = styled(PublishButton)`
-  padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => theme.colors.blue9};
-  background: ${({ theme }) => theme.colors.blue9};
-  color: ${({ theme }) => theme.colors.gray1};
-  font-weight: 700;
-
-  &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.blue10};
-    background: ${({ theme }) => theme.colors.blue10};
-    color: ${({ theme }) => theme.colors.gray1};
+    > button {
+      width: 100%;
+      justify-content: center;
+    }
   }
 `

--- a/front/src/routes/Admin/EditorStudioPublishModalParts.tsx
+++ b/front/src/routes/Admin/EditorStudioPublishModalParts.tsx
@@ -1,0 +1,260 @@
+import type { CSSProperties, ReactNode } from "react"
+import ProfileImage from "src/components/ProfileImage"
+import {
+  CompactPublishEditorCard,
+  CompactPublishEditorStack,
+  CompactPublishEditorToggle,
+  FieldHelp,
+  PostPreviewHeader,
+  PostPreviewSetup,
+  PreviewEditorGrid,
+  PreviewResultCard,
+  PreviewResultFrame,
+  PreviewResultHeader,
+  PreviewResultPanel,
+  PreviewViewportButton,
+  PreviewViewportTabs,
+  PreviewVisibilityBadge,
+  SectionKicker,
+  VisibilityCard,
+  VisibilityOptionButton,
+  VisibilityOptionGrid,
+} from "./EditorStudioPublishModalStyles"
+import AppIcon from "src/components/icons/AppIcon"
+import type { PostVisibility } from "./editorStudioState"
+
+export type EditorStudioPublishVisibilityOption = {
+  value: PostVisibility
+  label: string
+  description: string
+}
+
+export type EditorStudioPreviewViewportOption<TViewport extends string> = {
+  value: TViewport
+  label: string
+}
+
+type VisibilitySectionProps = {
+  postVisibility: PostVisibility
+  visibilityOptions: EditorStudioPublishVisibilityOption[]
+  onPostVisibilityChange: (nextVisibility: PostVisibility) => void
+}
+
+export const EditorStudioPublishVisibilitySection = ({
+  postVisibility,
+  visibilityOptions,
+  onPostVisibilityChange,
+}: VisibilitySectionProps) => (
+  <VisibilityCard>
+    <SectionKicker>노출 범위</SectionKicker>
+    <strong>누가 이 글을 볼 수 있나요?</strong>
+    <VisibilityOptionGrid role="group" aria-label="노출 범위 선택">
+      {visibilityOptions.map((option) => (
+        <VisibilityOptionButton
+          key={option.value}
+          type="button"
+          data-active={postVisibility === option.value}
+          aria-pressed={postVisibility === option.value}
+          onClick={() => onPostVisibilityChange(option.value)}
+        >
+          <strong>{option.label}</strong>
+          <span>{option.description}</span>
+        </VisibilityOptionButton>
+      ))}
+    </VisibilityOptionGrid>
+    <FieldHelp>메인 피드 노출은 전체 공개에서만 활성화됩니다.</FieldHelp>
+  </VisibilityCard>
+)
+
+type PreviewCardProps<TViewport extends string> = {
+  displayName: string
+  displayNameInitial: string
+  postThumbnailFocusX: number
+  postThumbnailFocusY: number
+  postThumbnailZoom: number
+  postTitle: string
+  previewAuthorAvatarSrc: string
+  previewDateText: string
+  previewFrameStyle: CSSProperties
+  previewKicker: string
+  previewSummary: string
+  previewSummaryFallback: string
+  previewThumbnailSrc: string
+  previewViewport: TViewport
+  previewViewportLabel: string
+  previewViewportOptions: Array<EditorStudioPreviewViewportOption<TViewport>>
+  previewVisibilityLabel: string
+  onPreviewThumbnailError: () => void
+  onPreviewViewportChange: (nextViewport: TViewport) => void
+}
+
+export const EditorStudioPublishPreviewCard = <TViewport extends string,>({
+  displayName,
+  displayNameInitial,
+  postThumbnailFocusX,
+  postThumbnailFocusY,
+  postThumbnailZoom,
+  postTitle,
+  previewAuthorAvatarSrc,
+  previewDateText,
+  previewFrameStyle,
+  previewKicker,
+  previewSummary,
+  previewSummaryFallback,
+  previewThumbnailSrc,
+  previewViewport,
+  previewViewportLabel,
+  previewViewportOptions,
+  previewVisibilityLabel,
+  onPreviewThumbnailError,
+  onPreviewViewportChange,
+}: PreviewCardProps<TViewport>) => (
+  <PreviewResultPanel>
+    <PreviewResultHeader>
+      <div>
+        <SectionKicker>{previewKicker}</SectionKicker>
+        <strong>{previewViewportLabel}</strong>
+      </div>
+      <PreviewViewportTabs role="tablist" aria-label="포스트 카드 미리보기 기기">
+        {previewViewportOptions.map((viewport) => (
+          <PreviewViewportButton
+            key={viewport.value}
+            type="button"
+            role="tab"
+            aria-selected={previewViewport === viewport.value}
+            data-active={previewViewport === viewport.value}
+            onClick={() => onPreviewViewportChange(viewport.value)}
+          >
+            {viewport.label}
+          </PreviewViewportButton>
+        ))}
+      </PreviewViewportTabs>
+    </PreviewResultHeader>
+    <PreviewResultFrame style={previewFrameStyle}>
+      <PreviewResultCard>
+        <div className="thumbnail">
+          {previewThumbnailSrc ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={previewThumbnailSrc}
+              alt="실제 카드 기준 포스트 썸네일 미리보기"
+              style={{
+                objectFit: "cover",
+                objectPosition: `${postThumbnailFocusX}% ${postThumbnailFocusY}%`,
+                transform: `scale(${postThumbnailZoom})`,
+                transformOrigin: `${postThumbnailFocusX}% ${postThumbnailFocusY}%`,
+              }}
+              onError={onPreviewThumbnailError}
+            />
+          ) : (
+            <div className="thumbnail-placeholder">
+              <em>썸네일 없음</em>
+              <span>본문 첫 이미지가 자동 카드 썸네일로 사용됩니다.</span>
+            </div>
+          )}
+        </div>
+        <div className="content">
+          <PreviewVisibilityBadge>{previewVisibilityLabel}</PreviewVisibilityBadge>
+          <h4>{postTitle.trim() || "제목을 입력하면 카드 결과가 여기에 표시됩니다."}</h4>
+          <p className="summary">{previewSummary || previewSummaryFallback}</p>
+          <div className="meta">
+            <span>{previewDateText}</span>
+            <span className="dot">·</span>
+            <span className="comment">
+              <AppIcon name="message" />
+              0개의 댓글
+            </span>
+          </div>
+          <div className="footer">
+            <div className="author">
+              <span className="avatar" aria-hidden="true">
+                {previewAuthorAvatarSrc ? (
+                  <ProfileImage src={previewAuthorAvatarSrc} alt="" fillContainer />
+                ) : (
+                  <span className="initial">{displayNameInitial}</span>
+                )}
+              </span>
+              <span className="by">by</span>
+              <strong>{displayName}</strong>
+            </div>
+            <div className="like">
+              <AppIcon name="heart" />
+              <span>0</span>
+            </div>
+          </div>
+        </div>
+      </PreviewResultCard>
+    </PreviewResultFrame>
+  </PreviewResultPanel>
+)
+
+type CardSettingsProps = {
+  closeToggleLabel: string
+  isCompactMobileLayout: boolean
+  isMobileMetaEditorOpen: boolean
+  isMobileThumbnailEditorOpen: boolean
+  previewMetaEditorPanel: ReactNode
+  setupDescription?: string
+  thumbnailEditorPanel: ReactNode
+  onToggleMobileMetaEditor: () => void
+  onToggleMobileThumbnailEditor: () => void
+}
+
+export const EditorStudioPublishCardSettings = ({
+  closeToggleLabel,
+  isCompactMobileLayout,
+  isMobileMetaEditorOpen,
+  isMobileThumbnailEditorOpen,
+  previewMetaEditorPanel,
+  setupDescription,
+  thumbnailEditorPanel,
+  onToggleMobileMetaEditor,
+  onToggleMobileThumbnailEditor,
+}: CardSettingsProps) => (
+  <PostPreviewSetup>
+    <PostPreviewHeader>
+      <strong>카드 요소 편집</strong>
+      {setupDescription ? <span>{setupDescription}</span> : null}
+    </PostPreviewHeader>
+    {isCompactMobileLayout ? (
+      <CompactPublishEditorStack>
+        <CompactPublishEditorCard>
+          <CompactPublishEditorToggle
+            type="button"
+            aria-expanded={isMobileThumbnailEditorOpen}
+            onClick={onToggleMobileThumbnailEditor}
+          >
+            <div>
+              <strong>썸네일 위치 조정</strong>
+              <span>드래그/확대로 카드 크롭을 빠르게 맞춥니다.</span>
+            </div>
+            <span>{isMobileThumbnailEditorOpen ? closeToggleLabel : "열기"}</span>
+          </CompactPublishEditorToggle>
+          {isMobileThumbnailEditorOpen ? thumbnailEditorPanel : null}
+        </CompactPublishEditorCard>
+        <CompactPublishEditorCard>
+          <CompactPublishEditorToggle
+            type="button"
+            aria-expanded={isMobileMetaEditorOpen}
+            onClick={onToggleMobileMetaEditor}
+          >
+            <div>
+              <strong>카드 메타 편집</strong>
+              <span>썸네일 URL과 요약만 따로 정리합니다.</span>
+            </div>
+            <span>{isMobileMetaEditorOpen ? closeToggleLabel : "열기"}</span>
+          </CompactPublishEditorToggle>
+          {isMobileMetaEditorOpen ? previewMetaEditorPanel : null}
+        </CompactPublishEditorCard>
+      </CompactPublishEditorStack>
+    ) : (
+      <PreviewEditorGrid>
+        {thumbnailEditorPanel}
+        {previewMetaEditorPanel}
+      </PreviewEditorGrid>
+    )}
+  </PostPreviewSetup>
+)
+
+export { PublishButton, PublishModalNotice, PublishOverviewGrid, PublishPrimaryButton } from "./EditorStudioPublishModalStyles"
+

--- a/front/src/routes/Admin/EditorStudioPublishModalStyles.tsx
+++ b/front/src/routes/Admin/EditorStudioPublishModalStyles.tsx
@@ -1,0 +1,526 @@
+import styled from "@emotion/styled"
+
+export const PublishOverviewGrid = styled.div`
+  display: grid;
+  gap: 0.8rem;
+
+  @media (min-width: 1080px) {
+    grid-template-columns: minmax(0, 1fr) minmax(320px, 368px);
+    align-items: start;
+  }
+`
+
+export const VisibilityCard = styled.section`
+  display: grid;
+  gap: 0.62rem;
+  align-content: start;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0)),
+    ${({ theme }) => theme.colors.gray1};
+  padding: 0.9rem;
+
+  > strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.94rem;
+    font-weight: 700;
+    line-height: 1.35;
+  }
+`
+
+export const SectionKicker = styled.span`
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+`
+
+export const VisibilityOptionGrid = styled.div`
+  display: grid;
+  gap: 0.5rem;
+`
+
+export const VisibilityOptionButton = styled.button`
+  display: grid;
+  gap: 0.16rem;
+  width: 100%;
+  padding: 0.72rem 0.78rem;
+  border-radius: 12px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray2};
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.84rem;
+    font-weight: 700;
+    line-height: 1.3;
+  }
+
+  span {
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.75rem;
+    line-height: 1.45;
+  }
+
+  &[data-active="true"] {
+    border-color: ${({ theme }) => theme.colors.blue8};
+    background: ${({ theme }) => theme.colors.blue3};
+    box-shadow: 0 0 0 1px ${({ theme }) => theme.colors.blue6} inset;
+  }
+`
+
+export const FieldHelp = styled.span`
+  display: block;
+  width: 100%;
+  min-width: 0;
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: 0.74rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+
+  @media (max-width: 720px) {
+    display: none;
+  }
+`
+
+export const PreviewResultPanel = styled.div`
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0)),
+    ${({ theme }) => theme.colors.gray1};
+  padding: 0.9rem;
+`
+
+export const PreviewResultHeader = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+
+  > div:first-of-type {
+    display: grid;
+    gap: 0.16rem;
+    min-width: 0;
+  }
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.9rem;
+    font-weight: 700;
+    line-height: 1.3;
+  }
+
+  span {
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.76rem;
+    line-height: 1.45;
+  }
+
+  @media (max-width: 1079px) {
+    flex-direction: column;
+  }
+`
+
+export const PreviewViewportTabs = styled.div`
+  display: inline-flex;
+  flex-wrap: nowrap;
+  gap: 0.4rem;
+  max-width: 100%;
+  overflow-x: auto;
+  padding-bottom: 0.1rem;
+`
+
+export const PreviewViewportButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  padding: 0 0.78rem;
+  font-size: 0.76rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &[data-active="true"] {
+    border-color: ${({ theme }) => theme.colors.gray7};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+    box-shadow: 0 0 0 1px ${({ theme }) => theme.colors.gray5} inset;
+  }
+
+  &:hover:not([data-active="true"]) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+`
+
+export const PreviewResultFrame = styled.div`
+  width: 100%;
+  margin: 0 auto;
+`
+
+export const PreviewVisibilityBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  width: fit-content;
+  border-radius: 999px;
+  border: 1px solid rgba(45, 212, 191, 0.34);
+  background: rgba(20, 184, 166, 0.12);
+  color: #99f6e4;
+  padding: 0 0.56rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+`
+
+export const PreviewResultCard = styled.article`
+  overflow: hidden;
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid ${({ theme }) => theme.colors.gray4};
+  background: ${({ theme }) => theme.colors.gray1};
+  box-shadow: 0 10px 28px rgba(2, 6, 23, 0.22);
+
+  .thumbnail {
+    position: relative;
+    aspect-ratio: 1.94 / 1;
+    overflow: hidden;
+    background:
+      radial-gradient(circle at top left, rgba(96, 165, 250, 0.08), transparent 48%),
+      ${({ theme }) => theme.colors.gray3};
+    border-bottom: 1px solid ${({ theme }) => theme.colors.gray4};
+  }
+
+  .thumbnail img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .thumbnail-placeholder {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-content: center;
+    gap: 0.28rem;
+    padding: 1rem;
+    text-align: center;
+  }
+
+  .thumbnail-placeholder em {
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.84rem;
+    font-style: normal;
+    font-weight: 700;
+  }
+
+  .thumbnail-placeholder span {
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.74rem;
+    line-height: 1.45;
+  }
+
+  .content {
+    display: grid;
+    gap: 0.72rem;
+    padding: 1rem;
+  }
+
+  h4 {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 1rem;
+    font-weight: 760;
+    line-height: 1.33;
+    letter-spacing: -0.015em;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .summary {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.86rem;
+    line-height: 1.55;
+    min-height: calc(1.55em * 3);
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .meta,
+  .footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.65rem;
+    flex-wrap: wrap;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.75rem;
+  }
+
+  .meta {
+    padding-top: 0.05rem;
+  }
+
+  .meta .dot {
+    opacity: 0.7;
+  }
+
+  .comment,
+  .like,
+  .author {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.34rem;
+  }
+
+  .author {
+    min-width: 0;
+  }
+
+  .author strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.86rem;
+    font-weight: 700;
+  }
+
+  .author .by {
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+
+  .avatar {
+    position: relative;
+    flex: 0 0 1.85rem;
+    width: 1.85rem;
+    height: 1.85rem;
+    border-radius: 999px;
+    overflow: hidden;
+    background: ${({ theme }) => theme.colors.gray4};
+    border: 1px solid ${({ theme }) => theme.colors.gray5};
+  }
+
+  .initial {
+    display: grid;
+    place-content: center;
+    width: 100%;
+    height: 100%;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.72rem;
+    font-weight: 800;
+  }
+
+  .like {
+    color: ${({ theme }) => theme.colors.gray11};
+    font-weight: 700;
+  }
+`
+
+export const PostPreviewSetup = styled.section`
+  display: grid;
+  gap: 0.82rem;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+`
+
+export const PostPreviewHeader = styled.div`
+  display: grid;
+  gap: 0.18rem;
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.92rem;
+    font-weight: 700;
+    line-height: 1.3;
+  }
+
+  span {
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.76rem;
+    line-height: 1.45;
+  }
+`
+
+export const PreviewEditorGrid = styled.div`
+  display: grid;
+  gap: 0.8rem;
+
+  @media (min-width: 840px) {
+    grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+    align-items: start;
+  }
+`
+
+export const CompactPublishEditorStack = styled.div`
+  display: grid;
+  gap: 0.7rem;
+`
+
+export const CompactPublishEditorCard = styled.div`
+  display: grid;
+  gap: 0.62rem;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 12px;
+  background: ${({ theme }) => theme.colors.gray2};
+  padding: 0.72rem;
+`
+
+export const CompactPublishEditorToggle = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  width: 100%;
+  min-height: 44px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+
+  > div {
+    display: grid;
+    gap: 0.14rem;
+    min-width: 0;
+  }
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.86rem;
+    font-weight: 700;
+    line-height: 1.3;
+  }
+
+  span {
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.76rem;
+    line-height: 1.45;
+  }
+
+  > span:last-of-type {
+    flex: 0 0 auto;
+    color: ${({ theme }) => theme.colors.blue11};
+    font-weight: 700;
+  }
+`
+
+export const PublishModalNotice = styled.div`
+  margin: 0;
+  padding: 0.55rem 0.7rem;
+  border-radius: 10px;
+  font-size: 0.83rem;
+  line-height: 1.4;
+  width: 100%;
+  box-sizing: border-box;
+
+  &[data-tone="idle"] {
+    color: ${({ theme }) => theme.colors.gray11};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: transparent;
+  }
+
+  &[data-tone="loading"] {
+    color: ${({ theme }) => theme.colors.blue11};
+    border: 1px solid ${({ theme }) => theme.colors.blue7};
+    background: ${({ theme }) => theme.colors.blue3};
+  }
+
+  &[data-tone="success"] {
+    color: ${({ theme }) => theme.colors.green11};
+    border: 1px solid ${({ theme }) => theme.colors.green7};
+    background: ${({ theme }) => theme.colors.green3};
+  }
+
+  &[data-tone="error"] {
+    color: ${({ theme }) => theme.colors.red11};
+    border: 1px solid ${({ theme }) => theme.colors.red7};
+    background: ${({ theme }) => theme.colors.red3};
+  }
+
+  @media (max-width: 720px) {
+    width: 100%;
+  }
+`
+
+export const PublishButton = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 8px;
+  padding: 0.62rem 0.92rem;
+  min-height: 44px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 600;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.gray8};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+`
+
+export const PublishPrimaryButton = styled(PublishButton)`
+  padding: 0.6rem 0.88rem;
+  border-color: ${({ theme }) => theme.colors.blue9};
+  background: ${({ theme }) => theme.colors.blue9};
+  color: ${({ theme }) => theme.colors.gray1};
+  font-weight: 700;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.blue10};
+    background: ${({ theme }) => theme.colors.blue10};
+    color: ${({ theme }) => theme.colors.gray1};
+  }
+`


### PR DESCRIPTION
## 관련 이슈

close #367

## 작업 배경

- EditorStudio workspace의 post list, publish modal, compose, dedicated editor surface를 root wiring과 하위 view/style companion로 분리했습니다.
- 각 panel root/parts/styles companion 파일을 600 lines 이하로 유지하도록 source contract e2e 검증을 확장했습니다.
- 배포 경로는 작업 브랜치 -> PR to main -> main merge -> 자동 홈서버 배포입니다.

## 작업 내용

- `EditorStudioPostListPanel`은 value/command contract만 조립하고 table/mobile/actions view와 style primitive를 companion 파일로 분리했습니다.
- `EditorStudioPublishModal`은 modal shell/footer만 유지하고 visibility, preview, card settings view와 style primitive를 분리했습니다.
- compose/dedicated writing surface는 root assembly와 view primitive를 나눠 panel props surface를 줄였습니다.
- `editor-studio-state` source contract가 새 companion 파일 존재, 600 lines 이하, root 파일의 API/state/editor host 직접 소유 금지를 검사합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1 --grep "workspace panel props"` RED/GREEN
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` 2회 통과
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1` 2회 통과
  - `yarn --cwd front test:e2e:smoke` 2회 통과
  - `yarn --cwd front build` 2회 통과
  - `yarn --cwd front check:bundle-size` 2회 통과
  - `git diff --check`
  - `CURRENT_TASK_SLUG=front-refactor-editor-studio-panel-contracts bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: view/style companion 분리 과정에서 admin editor panel의 버튼 wiring이나 responsive list/modal layout이 누락될 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋 `refactor(editor): studio panel contracts 분리`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
