### PR TITLE
[Refactor] Table overlay controller 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -1362,7 +1362,7 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).not.toMatch(/const\s+isTabBlockSelectionEligible\s*=/)
     expect(blockEditorEngineControllerSource).toContain('from "./blockHandleLayoutModel"')
     expect(blockEditorEngineControllerSource).toContain('from "./blockDragModel"')
-    expect(blockEditorTableOverlayControllerSource).toContain('from "./tableAxisDragModel"')
+    expect(blockEditorTableOverlayControllerSource).toContain('from "./useBlockEditorTableOverlayAxisDrag"')
     expect(blockEditorEngineSource).not.toMatch(/const\s+resolveBlockHandleAnchorTop\s*=/)
     expect(blockEditorEngineSource).not.toMatch(/const\s+resolveThinBlockHandleAnchorTop\s*=/)
     expect(blockEditorEngineSource).not.toMatch(/const\s+resolveBlockHandleRailLayout\s*=/)
@@ -1455,7 +1455,7 @@ test.describe("editor studio state", () => {
 
   test("editor studio는 SSR 관리자 스냅샷을 hydration auth race 동안 유지한다", () => {
     const editorStudioSource = readFileSync(
-      path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceController.tsx"),
+      path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx"),
       "utf8"
     )
     const editorStudioRoutingSource = readFileSync(
@@ -1614,7 +1614,7 @@ test.describe("editor studio state", () => {
 
   test("공개 글 저장 후 상세 재검증은 client cache eviction과 서버 revalidate를 함께 수행한다", () => {
     const editorStudioSource = readFileSync(
-      path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceController.tsx"),
+      path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx"),
       "utf8"
     )
     const revalidateApiSource = readFileSync(path.resolve(__dirname, "../src/pages/api/revalidate.ts"), "utf8")
@@ -1633,8 +1633,20 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tsx"),
       "utf8"
     )
+    const blockEditorEngineControllerSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/useBlockEditorEngineController.ts"),
+      "utf8"
+    )
     const blockEditorEngineStylesSource = readFileSync(
       path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.styles.tsx"),
+      "utf8"
+    )
+    const blockEditorEditorSurfaceStylesSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.editorSurfaceStyles.tsx"),
+      "utf8"
+    )
+    const blockEditorTableStylesSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.tableStyles.tsx"),
       "utf8"
     )
     const blockEditorEngineLayersSource = readFileSync(
@@ -1647,6 +1659,26 @@ test.describe("editor studio state", () => {
     )
     const blockEditorTableOverlayControllerSource = readFileSync(
       path.resolve(__dirname, "../src/components/editor/useBlockEditorTableOverlayController.ts"),
+      "utf8"
+    )
+    const blockEditorTableOverlayDomAdapterSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/useBlockEditorTableOverlayDomAdapter.ts"),
+      "utf8"
+    )
+    const blockEditorTableOverlayAxisDragSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/useBlockEditorTableOverlayAxisDrag.ts"),
+      "utf8"
+    )
+    const blockEditorTableOverlayResizeSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/useBlockEditorTableOverlayResize.ts"),
+      "utf8"
+    )
+    const blockEditorTableOverlayCornerGrowSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/useBlockEditorTableOverlayCornerGrow.ts"),
+      "utf8"
+    )
+    const blockEditorTableOverlayMenuSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/useBlockEditorTableOverlayMenu.ts"),
       "utf8"
     )
     const tableAffordanceModelSource = readFileSync(
@@ -1697,8 +1729,8 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/components/editor/tableCornerGrowModel.ts"),
       "utf8"
     )
-    const editorStudioSource = readFileSync(
-      path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceController.tsx"),
+    const editorStudioRootSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx"),
       "utf8"
     )
     const editorStudioPersistenceSource = readFileSync(
@@ -1727,7 +1759,8 @@ test.describe("editor studio state", () => {
 
     expect(blockEditorTableOverlayLayerSource).toContain('data-testid="table-column-drag-guide"')
     expect(blockEditorTableOverlayLayerSource).toContain('data-testid={`table-column-resize-boundary-${index}`}')
-    expect(blockEditorTableOverlayControllerSource).toContain('} from "./tableResizeInteractionModel"')
+    expect(blockEditorTableOverlayControllerSource).toContain('from "./useBlockEditorTableOverlayResize"')
+    expect(blockEditorTableOverlayResizeSource).toContain('} from "./tableResizeInteractionModel"')
     expect(tableResizeInteractionModelSource).toContain("export type TableRowResizeState = {")
     expect(tableResizeInteractionModelSource).toContain("export type TableColumnRailResizeState = {")
     expect(tableResizeInteractionModelSource).toContain("export type TableColumnDragGuideState = {")
@@ -1764,7 +1797,7 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineSource).not.toContain("const syncTableColumnDragGuideForColumn = useCallback(")
     expect(blockEditorEngineSource).not.toContain("const startTableColumnResizeFromDomHandle = useCallback(")
     expect(blockEditorTableOverlayControllerSource).toContain('} from "./tableFloatingUiModel"')
-    expect(blockEditorTableOverlayControllerSource).toContain("const getActiveTableRectFromDom = useCallback(")
+    expect(blockEditorTableOverlayDomAdapterSource).toContain("const getActiveTableRectFromDom = useCallback(")
     expect(blockEditorTableOverlayLayerSource).toContain('import { createPortal } from "react-dom"')
     expect(blockEditorTableOverlayLayerSource).toContain("const tableOverlay = (")
     expect(blockEditorTableOverlayLayerSource).toContain("createPortal(tableOverlay, document.body)")
@@ -1843,29 +1876,30 @@ test.describe("editor studio state", () => {
     expect(blockEditorTableOverlayLayerSource).toContain('data-testid="table-row-drag-shadow"')
     expect(blockEditorTableOverlayLayerSource).toContain('"table-row-reorder-indicator"')
     expect(blockEditorTableOverlayLayerSource).toContain('"table-column-reorder-indicator"')
-    expect(blockEditorEngineStylesSource).toContain('const TableCellMenuButton = styled(TableHandleButton)`')
-    expect(blockEditorTableOverlayControllerSource).toContain("const updateActiveTableOverflowMode = useCallback(")
-    expect(blockEditorTableOverlayControllerSource).toContain("const reorderTableAxisAtPosition = useCallback(")
+    expect(blockEditorTableStylesSource).toContain('const TableCellMenuButton = styled(TableHandleButton)`')
+    expect(blockEditorTableOverlayMenuSource).toContain("const updateActiveTableOverflowMode = useCallback(")
+    expect(blockEditorTableOverlayAxisDragSource).toContain("const reorderTableAxisAtPosition = useCallback(")
     expect(tableCornerGrowModelSource).toContain("export type TableCornerGrowState = {")
     expect(tableCornerGrowModelSource).toContain("export type TableCornerPreviewState = {")
     expect(tableCornerGrowModelSource).toContain("export const resolveTableCornerPreviewState = (")
     expect(tableCornerGrowModelSource).toContain("export const resolveTableCornerGrowStepMetrics = (")
     expect(tableCornerGrowModelSource).toContain("export const resolveTableCornerGrowStepMetricsFromDataset = (")
-    expect(blockEditorTableOverlayControllerSource).toContain('} from "./tableCornerGrowModel"')
+    expect(blockEditorTableOverlayControllerSource).toContain('from "./useBlockEditorTableOverlayCornerGrow"')
+    expect(blockEditorTableOverlayCornerGrowSource).toContain('} from "./tableCornerGrowModel"')
     expect(blockEditorEngineSource).not.toContain("type TableCornerGrowState = {")
     expect(blockEditorEngineSource).not.toContain("type TableCornerPreviewState = {")
     expect(blockEditorEngineSource).not.toContain("const resolveTableCornerPreviewState = useCallback(")
     expect(blockEditorEngineSource).not.toContain("const getTableCornerGrowStepMetrics = useCallback(")
     expect(blockEditorEngineSource).not.toContain("const getTableCornerGrowStepMetricsFromHandle = useCallback(")
-    expect(blockEditorTableOverlayControllerSource).toContain("const applyTableCornerGrowSteps = useCallback(")
-    expect(blockEditorTableOverlayControllerSource).toContain("const shrinkTableAxisAtEnd = useCallback(")
-    expect(blockEditorTableOverlayControllerSource).toContain("const beginTableAxisDragFromPending = useCallback(")
-    expect(blockEditorTableOverlayControllerSource).toContain("const startPendingTableAxisDrag = useCallback(")
-    expect(blockEditorTableOverlayControllerSource).toContain("const selectTableAxisAtIndex = useCallback(")
+    expect(blockEditorTableOverlayCornerGrowSource).toContain("const applyTableCornerGrowSteps = useCallback(")
+    expect(blockEditorTableOverlayCornerGrowSource).toContain("const shrinkTableAxisAtEnd = useCallback(")
+    expect(blockEditorTableOverlayAxisDragSource).toContain("const beginTableAxisDragFromPending = useCallback(")
+    expect(blockEditorTableOverlayAxisDragSource).toContain("const startPendingTableAxisDrag = useCallback(")
+    expect(blockEditorTableOverlayAxisDragSource).toContain("const selectTableAxisAtIndex = useCallback(")
     expect(tableStructureModelSource).toContain('overflowMode: getTableOverflowMode(tableNode)')
     expect(tableWidthModelSource).toContain("const maxActiveWidth = Math.max(TABLE_MIN_COLUMN_WIDTH_PX, safeBudget - otherColumnsWidth)")
-    expect(blockEditorTableOverlayControllerSource).toContain("const tableCornerGrowSuppressClickRef = useRef(false)")
-    expect(blockEditorEngineStylesSource).toContain('"grip" | "grow"')
+    expect(blockEditorTableOverlayCornerGrowSource).toContain("const tableCornerGrowSuppressClickRef = useRef(false)")
+    expect(blockEditorTableStylesSource).toContain('"grip" | "grow"')
     expect(blockEditorTableOverlayControllerSource).toContain("isCellMenuOpen,")
     expect(markdownRendererSource).toContain("MarkdownTableRenderer")
     expect(markdownTableRendererSource).toContain("const explicitTableWidth = useMemo(")
@@ -1877,7 +1911,7 @@ test.describe("editor studio state", () => {
     expect(blockEditorTableOverlayControllerSource).toContain("isColumnMenuOpen,")
     expect(blockEditorTableOverlayLayerSource).toContain("activeTableStructureState.hasHeaderRow")
     expect(blockEditorTableOverlayLayerSource).toContain("activeTableStructureState.hasHeaderColumn")
-    expect(blockEditorTableOverlayControllerSource).toContain("const tableCornerGrowStepMetrics = resolveTableCornerGrowStepMetrics(tableAffordanceGeometry)")
+    expect(blockEditorTableOverlayCornerGrowSource).toContain("tableCornerGrowStepMetrics: resolveTableCornerGrowStepMetrics(tableAffordanceGeometry)")
     expect(blockEditorTableOverlayLayerSource).toContain("data-column-step={tableCornerGrowStepMetrics.columnStepPx}")
     expect(blockEditorTableOverlayLayerSource).toContain("data-row-step={tableCornerGrowStepMetrics.rowStepPx}")
     expect(blockEditorTableOverlayLayerSource).toContain('aria-label="표 구조 메뉴"')
@@ -1904,16 +1938,85 @@ test.describe("editor studio state", () => {
     expect(blockEditorTableOverlayControllerSource).toContain("isTableStructureMenuOpen,")
     expect(blockEditorTableOverlayControllerSource).toContain("shouldShowColumnAddBar,")
     expect(blockEditorTableOverlayControllerSource).toContain("shouldShowRowAddBar,")
-    expect(blockEditorTableOverlayControllerSource).toContain(
+    expect(blockEditorTableOverlayDomAdapterSource).toContain(
       "findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)"
     )
-    expect(blockEditorEngineStylesSource).toContain("display: none !important;")
-    expect(editorStudioSource).toContain('import { useEditorStudioPersistence } from "./useEditorStudioPersistence"')
+    expect(blockEditorEditorSurfaceStylesSource).toContain("display: none !important;")
+    expect(editorStudioRootSource).toContain('import { useEditorStudioPersistence } from "./useEditorStudioPersistence"')
     expect(editorStudioPersistenceSource).toContain("const currentPostContent = postContentLiveRef.current")
     expect(
       markdownRendererRootTableStylesSource.match(/table-layout: fixed;/g)?.length ?? 0
     ).toBeGreaterThanOrEqual(2)
     expect(markdownRendererRootTableStylesSource).not.toContain("table-layout: auto;")
+  })
+
+  test("table overlay controller는 책임별 module과 1000 line budget을 유지한다", () => {
+    const controllerPath = path.resolve(
+      __dirname,
+      "../src/components/editor/useBlockEditorTableOverlayController.ts"
+    )
+    const controllerSource = readFileSync(controllerPath, "utf8")
+    const moduleContracts = [
+      {
+        importPath: "./useBlockEditorTableOverlayDomAdapter",
+        path: "../src/components/editor/useBlockEditorTableOverlayDomAdapter.ts",
+        forbiddenInline: [
+          "const focusElementWithoutScroll =",
+          "const resolveDocPosSafe =",
+          "const getTableCellFromTarget = useCallback(",
+          "const getTableCellFromClientPoint = useCallback(",
+        ],
+      },
+      {
+        importPath: "./useBlockEditorTableOverlayAxisDrag",
+        path: "../src/components/editor/useBlockEditorTableOverlayAxisDrag.ts",
+        forbiddenInline: [
+          "const selectTableAxisAtIndex = useCallback(",
+          "const clearPendingTableAxisDrag = useCallback(",
+          "const beginTableAxisDragFromPending = useCallback(",
+          "const startPendingTableAxisDrag = useCallback(",
+        ],
+      },
+      {
+        importPath: "./useBlockEditorTableOverlayResize",
+        path: "../src/components/editor/useBlockEditorTableOverlayResize.ts",
+        forbiddenInline: [
+          "const startTableRowResize = useCallback(",
+          "const commitTableRowHeight = useCallback(",
+          "const resizeTableColumnByIndex = useCallback(",
+          "const startTableColumnRailResize = useCallback(",
+        ],
+      },
+      {
+        importPath: "./useBlockEditorTableOverlayCornerGrow",
+        path: "../src/components/editor/useBlockEditorTableOverlayCornerGrow.ts",
+        forbiddenInline: [
+          "const appendTableAxisAtEnd = useCallback(",
+          "const shrinkTableAxisAtEnd = useCallback(",
+          "const applyTableCornerGrowSteps = useCallback(",
+          "const startTableCornerGrow = useCallback(",
+        ],
+      },
+      {
+        importPath: "./useBlockEditorTableOverlayMenu",
+        path: "../src/components/editor/useBlockEditorTableOverlayMenu.ts",
+        forbiddenInline: [
+          "const updateActiveTableCellAttrs = useCallback(",
+          "const updateActiveTableOverflowMode = useCallback(",
+          "const openSelectionAwareTableMenu = useCallback(",
+          "const runTableMenuEditorAction = useCallback(",
+        ],
+      },
+    ]
+
+    expect(controllerSource.split("\n").length).toBeLessThanOrEqual(1000)
+    moduleContracts.forEach((contract) => {
+      expect(existsSync(path.resolve(__dirname, contract.path))).toBe(true)
+      expect(controllerSource).toContain(`from "${contract.importPath}"`)
+      contract.forbiddenInline.forEach((snippet) => {
+        expect(controllerSource).not.toContain(snippet)
+      })
+    })
   })
 
   test("editor studio SSR은 작성자 카드에 공개 프로필 snapshot을 먼저 seed한다", () => {
@@ -1928,7 +2031,7 @@ test.describe("editor studio state", () => {
 
   test("/editor/new는 temp draft bootstrap이 끝날 때까지 loading state를 먼저 유지한다", () => {
     const editorStudioSource = readFileSync(
-      path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceController.tsx"),
+      path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx"),
       "utf8"
     )
     const editorStudioDraftLifecycleSource = readFileSync(
@@ -1950,7 +2053,7 @@ test.describe("editor studio state", () => {
 
   test("썸네일 편집 패널은 클립보드 이미지 붙여넣기 업로드 계약을 유지한다", () => {
     const editorStudioSource = readFileSync(
-      path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceController.tsx"),
+      path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx"),
       "utf8"
     )
     const editorStudioThumbnailPanelsSource = readFileSync(

--- a/front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts
@@ -1,0 +1,385 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import { CellSelection, selectedRect, TableMap } from "@tiptap/pm/tables"
+import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { TableAffordanceGeometry } from "./tableAffordanceModel"
+import {
+  type DraggedTableAxisState,
+  type PendingTableAxisDragState,
+  type TableAxis,
+  type TableAxisDragGhostPosition,
+  type TableAxisReorderIndicatorState,
+  createDraggedTableAxisState,
+  createHiddenTableAxisReorderIndicatorState,
+  createPendingTableAxisDragState,
+  createTableAxisDragGhostPosition,
+  hideTableAxisReorderIndicatorState,
+  resolveTableAxisIndexFromPointer,
+  resolveTableAxisReorderIndicator,
+} from "./tableAxisDragModel"
+import type { TableMenuState } from "./tableFloatingUiModel"
+import { findActiveRenderedTable } from "./tableRenderedDomModel"
+import { buildReorderedSimpleTableNode } from "./tableStructureModel"
+import { focusElementWithoutScroll, resolveDocPosSafe, type TableOverlaySelectionRect } from "./useBlockEditorTableOverlayDomAdapter"
+
+type UseBlockEditorTableOverlayAxisDragArgs = {
+  cancelTableQuickRailHide: () => void
+  clearStickyTopLevelBlockSelection: () => void
+  editor: TiptapEditor | null
+  editorRef: MutableRefObject<TiptapEditor | null>
+  getCurrentSelectedTableRect: (activeEditor?: TiptapEditor | null) => TableOverlaySelectionRect | null
+  isTableStructuralSelection: boolean
+  selectionTick: number
+  setSelectionTick: Dispatch<SetStateAction<number>>
+  setTableAffordanceGeometry: Dispatch<SetStateAction<TableAffordanceGeometry>>
+  setTableMenuState: Dispatch<SetStateAction<TableMenuState>>
+  tableAffordanceGeometryRef: MutableRefObject<TableAffordanceGeometry>
+  viewportRef: RefObject<HTMLDivElement>
+}
+
+export const useBlockEditorTableOverlayAxisDrag = ({
+  cancelTableQuickRailHide,
+  clearStickyTopLevelBlockSelection,
+  editor,
+  editorRef,
+  getCurrentSelectedTableRect,
+  isTableStructuralSelection,
+  selectionTick,
+  setSelectionTick,
+  setTableAffordanceGeometry,
+  setTableMenuState,
+  tableAffordanceGeometryRef,
+  viewportRef,
+}: UseBlockEditorTableOverlayAxisDragArgs) => {
+  const pendingTableAxisDragRef = useRef<PendingTableAxisDragState | null>(null)
+  const pendingTableAxisDragCleanupRef = useRef<(() => void) | null>(null)
+  const tableAxisDragSuppressClickRef = useRef(false)
+  const [draggedTableAxisState, setDraggedTableAxisState] = useState<DraggedTableAxisState>(null)
+  const [tableAxisDragGhostPosition, setTableAxisDragGhostPosition] = useState<TableAxisDragGhostPosition>(null)
+  const [tableAxisReorderIndicatorState, setTableAxisReorderIndicatorState] =
+    useState<TableAxisReorderIndicatorState>(createHiddenTableAxisReorderIndicatorState)
+
+  const selectTableAxisAtIndex = useCallback(
+    (activeEditor: TiptapEditor, tablePos: number, axis: "row" | "column", axisIndex: number) => {
+      const tableNode = activeEditor.state.doc.nodeAt(tablePos)
+      if (!tableNode || tableNode.type.name !== "table") return false
+
+      const map = TableMap.get(tableNode)
+      if (axis === "column") {
+        if (axisIndex < 0 || axisIndex >= map.width) return false
+        const anchorCellPos = tablePos + 1 + map.positionAt(0, axisIndex, tableNode)
+        const headCellPos = tablePos + 1 + map.positionAt(map.height - 1, axisIndex, tableNode)
+        const anchorResolved = resolveDocPosSafe(activeEditor, anchorCellPos)
+        const headResolved = resolveDocPosSafe(activeEditor, headCellPos)
+        if (!anchorResolved || !headResolved) return false
+
+        clearStickyTopLevelBlockSelection()
+        activeEditor.view.dispatch(
+          activeEditor.state.tr.setSelection(CellSelection.colSelection(anchorResolved, headResolved))
+        )
+        focusElementWithoutScroll(activeEditor.view.dom)
+        return true
+      }
+
+      if (axisIndex < 0 || axisIndex >= map.height) return false
+      const anchorCellPos = tablePos + 1 + map.positionAt(axisIndex, 0, tableNode)
+      const headCellPos = tablePos + 1 + map.positionAt(axisIndex, map.width - 1, tableNode)
+      const anchorResolved = resolveDocPosSafe(activeEditor, anchorCellPos)
+      const headResolved = resolveDocPosSafe(activeEditor, headCellPos)
+      if (!anchorResolved || !headResolved) return false
+
+      clearStickyTopLevelBlockSelection()
+      activeEditor.view.dispatch(
+        activeEditor.state.tr.setSelection(CellSelection.rowSelection(anchorResolved, headResolved))
+      )
+      focusElementWithoutScroll(activeEditor.view.dom)
+      return true
+    },
+    [clearStickyTopLevelBlockSelection]
+  )
+
+  const clearPendingTableAxisDrag = useCallback(() => {
+    pendingTableAxisDragRef.current = null
+    if (pendingTableAxisDragCleanupRef.current) {
+      pendingTableAxisDragCleanupRef.current()
+      pendingTableAxisDragCleanupRef.current = null
+    }
+  }, [])
+
+  const isCurrentTableColumnSelection = useCallback(
+    (columnIndex: number) => {
+      const currentEditor = editorRef.current
+      if (!currentEditor || columnIndex < 0) return false
+      const { selection } = currentEditor.state
+      if (!(selection instanceof CellSelection)) return false
+      let rect: ReturnType<typeof selectedRect> | null = null
+      try {
+        rect = selectedRect(currentEditor.state)
+      } catch {
+        rect = null
+      }
+      if (!rect) return false
+      return rect.left === columnIndex && rect.right === columnIndex + 1 && rect.top === 0 && rect.bottom === rect.map.height
+    },
+    [editorRef]
+  )
+
+  const isCurrentTableRowSelection = useCallback((rowIndex: number) => {
+    const currentEditor = editorRef.current
+    if (!currentEditor || rowIndex < 0) return false
+    const { selection } = currentEditor.state
+    if (!(selection instanceof CellSelection)) return false
+    let rect: ReturnType<typeof selectedRect> | null = null
+    try {
+      rect = selectedRect(currentEditor.state)
+    } catch {
+      rect = null
+    }
+    if (!rect) return false
+    return rect.top === rowIndex && rect.bottom === rowIndex + 1 && rect.left === 0 && rect.right === rect.map.width
+  }, [editorRef])
+
+  const selectTableColumnByIndex = useCallback(
+    (columnIndex: number) => {
+      const currentEditor = editorRef.current
+      if (!currentEditor) return false
+      const rect = getCurrentSelectedTableRect(currentEditor)
+      if (!rect || columnIndex < 0 || columnIndex >= rect.map.width) return false
+
+      return selectTableAxisAtIndex(currentEditor, rect.tableStart - 1, "column", columnIndex)
+    },
+    [editorRef, getCurrentSelectedTableRect, selectTableAxisAtIndex]
+  )
+
+  const selectTableRowByIndex = useCallback(
+    (rowIndex: number) => {
+      const currentEditor = editorRef.current
+      if (!currentEditor) return false
+      const rect = getCurrentSelectedTableRect(currentEditor)
+      if (!rect || rowIndex < 0 || rowIndex >= rect.map.height) return false
+
+      return selectTableAxisAtIndex(currentEditor, rect.tableStart - 1, "row", rowIndex)
+    },
+    [editorRef, getCurrentSelectedTableRect, selectTableAxisAtIndex]
+  )
+
+  const reorderTableAxisAtPosition = useCallback(
+    (tablePos: number, axis: "row" | "column", sourceIndex: number, insertionIndex: number) => {
+      const currentEditor = editorRef.current
+      if (!currentEditor) return false
+
+      const tableNode = currentEditor.state.doc.nodeAt(tablePos)
+      if (!tableNode || tableNode.type.name !== "table") return false
+
+      const reorderedTable = buildReorderedSimpleTableNode(tableNode, axis, sourceIndex, insertionIndex)
+      if (!reorderedTable) return false
+
+      currentEditor.view.dispatch(
+        currentEditor.state.tr.replaceWith(tablePos, tablePos + tableNode.nodeSize, reorderedTable.node)
+      )
+
+      const selected = selectTableAxisAtIndex(currentEditor, tablePos, axis, reorderedTable.nextIndex)
+      setTableAffordanceGeometry((prev) =>
+        axis === "row"
+          ? { ...prev, rowIndex: reorderedTable.nextIndex }
+          : { ...prev, columnIndex: reorderedTable.nextIndex }
+      )
+      setSelectionTick((prev) => prev + 1)
+      return selected
+    },
+    [editorRef, selectTableAxisAtIndex, setSelectionTick, setTableAffordanceGeometry]
+  )
+
+  const beginTableAxisDragFromPending = useCallback(
+    (pending: PendingTableAxisDragState, clientX: number, clientY: number) => {
+      const nextDragState = createDraggedTableAxisState(pending)
+      tableAxisDragSuppressClickRef.current = true
+      const currentEditor = editorRef.current
+      if (currentEditor) {
+        selectTableAxisAtIndex(currentEditor, pending.tablePos, pending.axis, pending.sourceIndex)
+      }
+      setTableMenuState(null)
+      cancelTableQuickRailHide()
+      setDraggedTableAxisState(nextDragState)
+      const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
+      setTableAxisReorderIndicatorState(
+        resolveTableAxisReorderIndicator(renderedTable, pending.axis, pending.sourceIndex, clientX, clientY) ??
+          createHiddenTableAxisReorderIndicatorState(pending.axis, pending.sourceIndex)
+      )
+      setTableAxisDragGhostPosition(createTableAxisDragGhostPosition(pending, clientY))
+      return nextDragState
+    },
+    [cancelTableQuickRailHide, editorRef, selectTableAxisAtIndex, setTableMenuState, tableAffordanceGeometryRef, viewportRef]
+  )
+
+  const startPendingTableAxisDrag = useCallback(
+    (axis: TableAxis, sourceIndex: number, pointerId: number, clientX: number, clientY: number) => {
+      const currentEditor = editorRef.current
+      if (!currentEditor) return
+
+      const tableRect = getCurrentSelectedTableRect(currentEditor)
+      const tablePos = tableRect ? Math.max(0, tableRect.tableStart - 1) : null
+      if (!tableRect || tablePos === null) return
+      const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
+      const resolvedSourceIndex = resolveTableAxisIndexFromPointer(renderedTable, axis, clientX, clientY) ?? sourceIndex
+
+      const withinBounds =
+        axis === "row"
+          ? resolvedSourceIndex >= 0 && resolvedSourceIndex < tableRect.map.height
+          : resolvedSourceIndex >= 0 && resolvedSourceIndex < tableRect.map.width
+      if (!withinBounds) return
+
+      clearPendingTableAxisDrag()
+      tableAxisDragSuppressClickRef.current = false
+
+      pendingTableAxisDragRef.current = createPendingTableAxisDragState(
+        axis,
+        resolvedSourceIndex,
+        pointerId,
+        tablePos,
+        clientX,
+        clientY,
+        tableAffordanceGeometryRef.current
+      )
+
+      const DRAG_THRESHOLD_PX = 5
+      let activeDragState: Exclude<DraggedTableAxisState, null> | null = null
+
+      const handlePendingPointerMove = (moveEvent: PointerEvent) => {
+        if (activeDragState) {
+          if (moveEvent.pointerId !== activeDragState.pointerId) return
+          const activeRenderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
+          const nextIndicator = resolveTableAxisReorderIndicator(
+            activeRenderedTable,
+            activeDragState.axis,
+            activeDragState.sourceIndex,
+            moveEvent.clientX,
+            moveEvent.clientY
+          )
+          setTableAxisReorderIndicatorState(
+            nextIndicator ??
+              createHiddenTableAxisReorderIndicatorState(activeDragState.axis, activeDragState.sourceIndex)
+          )
+          if (activeDragState.axis === "row") {
+            setTableAxisDragGhostPosition(createTableAxisDragGhostPosition(activeDragState, moveEvent.clientY))
+          }
+          return
+        }
+
+        const pending = pendingTableAxisDragRef.current
+        if (!pending || moveEvent.pointerId !== pending.pointerId) return
+
+        const distance = Math.hypot(moveEvent.clientX - pending.startX, moveEvent.clientY - pending.startY)
+        if (distance < DRAG_THRESHOLD_PX) return
+
+        pendingTableAxisDragRef.current = null
+        activeDragState = beginTableAxisDragFromPending(pending, moveEvent.clientX, moveEvent.clientY)
+      }
+
+      const handlePendingPointerDone = (doneEvent: PointerEvent) => {
+        if (activeDragState) {
+          if (doneEvent.pointerId !== activeDragState.pointerId) return
+          const activeRenderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
+          const nextIndicator = resolveTableAxisReorderIndicator(
+            activeRenderedTable,
+            activeDragState.axis,
+            activeDragState.sourceIndex,
+            doneEvent.clientX,
+            doneEvent.clientY
+          )
+          if (nextIndicator) {
+            reorderTableAxisAtPosition(
+              activeDragState.tablePos,
+              activeDragState.axis,
+              activeDragState.sourceIndex,
+              nextIndicator.insertionIndex
+            )
+          }
+          activeDragState = null
+          setDraggedTableAxisState(null)
+          setTableAxisDragGhostPosition(null)
+          setTableAxisReorderIndicatorState(hideTableAxisReorderIndicatorState)
+          clearPendingTableAxisDrag()
+          return
+        }
+
+        const pending = pendingTableAxisDragRef.current
+        if (!pending || doneEvent.pointerId !== pending.pointerId) return
+        clearPendingTableAxisDrag()
+      }
+
+      window.addEventListener("pointermove", handlePendingPointerMove)
+      window.addEventListener("pointerup", handlePendingPointerDone)
+      window.addEventListener("pointercancel", handlePendingPointerDone)
+
+      pendingTableAxisDragCleanupRef.current = () => {
+        window.removeEventListener("pointermove", handlePendingPointerMove)
+        window.removeEventListener("pointerup", handlePendingPointerDone)
+        window.removeEventListener("pointercancel", handlePendingPointerDone)
+      }
+    },
+    [
+      beginTableAxisDragFromPending,
+      clearPendingTableAxisDrag,
+      editorRef,
+      getCurrentSelectedTableRect,
+      reorderTableAxisAtPosition,
+      tableAffordanceGeometryRef,
+      viewportRef,
+    ]
+  )
+
+  const currentTableAxisSelection = useMemo(() => {
+    if (!editor || !isTableStructuralSelection) return null
+    void selectionTick
+    let rect: ReturnType<typeof selectedRect> | null = null
+    try {
+      rect = selectedRect(editor.state)
+    } catch {
+      rect = null
+    }
+    if (!rect) return null
+    if (rect.left === 0 && rect.right === rect.map.width && rect.bottom === rect.top + 1) {
+      return { axis: "row" as const, index: rect.top }
+    }
+    if (rect.top === 0 && rect.bottom === rect.map.height && rect.right === rect.left + 1) {
+      return { axis: "column" as const, index: rect.left }
+    }
+    return null
+  }, [editor, isTableStructuralSelection, selectionTick])
+
+  useEffect(() => {
+    return () => {
+      clearPendingTableAxisDrag()
+    }
+  }, [clearPendingTableAxisDrag])
+
+  useEffect(() => {
+    if (typeof document === "undefined" || !draggedTableAxisState) return
+    const previousCursor = document.body.style.cursor
+    const previousUserSelect = document.body.style.userSelect
+    document.body.style.cursor = draggedTableAxisState.axis === "column" ? "col-resize" : "grabbing"
+    document.body.style.userSelect = "none"
+    return () => {
+      document.body.style.cursor = previousCursor
+      document.body.style.userSelect = previousUserSelect
+    }
+  }, [draggedTableAxisState])
+
+  return {
+    beginTableAxisDragFromPending,
+    clearPendingTableAxisDrag,
+    currentTableAxisSelection,
+    draggedTableAxisState,
+    isCurrentTableColumnSelection,
+    isCurrentTableRowSelection,
+    reorderTableAxisAtPosition,
+    selectTableAxisAtIndex,
+    selectTableColumnByIndex,
+    selectTableRowByIndex,
+    startPendingTableAxisDrag,
+    tableAxisDragGhostPosition,
+    tableAxisDragSuppressClickRef,
+    tableAxisReorderIndicatorState,
+  }
+}

--- a/front/src/components/editor/useBlockEditorTableOverlayController.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayController.ts
@@ -1,22 +1,22 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
-import { Node as ProseMirrorNode } from "@tiptap/pm/model"
-import { NodeSelection, TextSelection } from "@tiptap/pm/state"
-import { CellSelection, selectedRect, TableMap } from "@tiptap/pm/tables"
+import { NodeSelection } from "@tiptap/pm/state"
+import { CellSelection } from "@tiptap/pm/tables"
 import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from "react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { flushSync } from "react-dom"
-import { getEditableTextPositionForTopLevelBlock, getFirstEditableTextPositionInNode, getTopLevelBlockIndexFromSelection, getTopLevelBlockPosition } from "./blockSelectionModel"
 import { type TableAffordanceGeometry, type TableAffordanceVisibility, INITIAL_TABLE_AFFORDANCE_GEOMETRY, INITIAL_TABLE_AFFORDANCE_VISIBILITY, TABLE_ADD_BAR_VIEWPORT_PADDING_PX, TABLE_CELL_MENU_BUTTON_SIZE_PX, TABLE_EDGE_ADD_BUTTON_SIZE_PX, clampViewportPosition, intersectsViewportBounds, resolveDesktopTableRailLayout } from "./tableAffordanceModel"
-import { type DraggedTableAxisState, type PendingTableAxisDragState, type TableAxis, type TableAxisDragGhostPosition, type TableAxisReorderIndicatorState, createDraggedTableAxisState, createHiddenTableAxisReorderIndicatorState, createPendingTableAxisDragState, createTableAxisDragGhostPosition, hideTableAxisReorderIndicatorState, resolveTableAxisIndexFromPointer, resolveTableAxisReorderIndicator } from "./tableAxisDragModel"
-import { type TableCornerGrowState, type TableCornerGrowStepMetrics, type TableCornerPreviewState, resolveTableCornerGrowStepMetrics, resolveTableCornerGrowStepMetricsFromDataset, resolveTableCornerPreviewState } from "./tableCornerGrowModel"
-import { TABLE_OVERFLOW_COACHMARK_DISMISS_MS, createHiddenTableOverflowCoachmarkState, hideTableOverflowCoachmarkState, resolveCompactTableAffordanceKind, resolveTableHandleVisibility, resolveTableMenuFlags, resolveTableMenuState, resolveTableOverflowCoachmarkState, type TableMenuKind, type TableMenuState, type TableOverflowCoachmarkState } from "./tableFloatingUiModel"
-import { findActiveRenderedTable, readRenderedColumnWidths, resolveActiveRenderedTableForFloatingUi, resolveTableScopedSelectedCell } from "./tableRenderedDomModel"
-import { type TableColumnDragGuideState, type TableColumnRailResizeState, type TableRowResizeState, createHiddenTableColumnDragGuideState, createTableColumnRailResizeState, createTableRowResizeState, hideTableColumnDragGuideState, isRowResizeHandleTarget, resolveTableColumnDragGuideState, resolveTableColumnIndexFromResizeHandleTarget } from "./tableResizeInteractionModel"
-import { buildReorderedSimpleTableNode, canShrinkTableAxisAtEnd, collectSimpleTableColumnCells, countShrinkableRenderedTableAxisAtEnd, countShrinkableTableAxisAtEnd, getActiveTableStructureState, isTableSelectionActive } from "./tableStructureModel"
-import { TABLE_OVERFLOW_MODE_WIDE, computeNextTableColumnWidthsForResize, didTableColumnResizeHitOverflowPolicy, getTableOverflowMode } from "./tableWidthModel"
-import { applyTableColumnWidthsToTransaction, getCurrentEditorReadableWidthPx, hasExplicitColumnWidth, normalizeRenderedTableWidthsToReadableBudget, readColumnWidthFromCell, shouldClampTableWidthBudget } from "./tableWidthRuntime"
-import { TABLE_MIN_COLUMN_WIDTH_PX, TABLE_MIN_ROW_HEIGHT_PX } from "src/libs/markdown/tableMetadata"
-
+import { resolveCompactTableAffordanceKind, resolveTableHandleVisibility, resolveTableMenuFlags, type TableMenuState } from "./tableFloatingUiModel"
+import { findActiveRenderedTable, resolveTableScopedSelectedCell } from "./tableRenderedDomModel"
+import { getActiveTableStructureState, isTableSelectionActive } from "./tableStructureModel"
+import { TABLE_OVERFLOW_MODE_WIDE } from "./tableWidthModel"
+import { normalizeRenderedTableWidthsToReadableBudget } from "./tableWidthRuntime"
+import { useBlockEditorTableOverlayAxisDrag } from "./useBlockEditorTableOverlayAxisDrag"
+import { useBlockEditorTableOverlayCornerGrow } from "./useBlockEditorTableOverlayCornerGrow"
+import { useBlockEditorTableOverlayDomAdapter } from "./useBlockEditorTableOverlayDomAdapter"
+import { useBlockEditorTableOverlayInteractionHandlers } from "./useBlockEditorTableOverlayInteractionHandlers"
+import { useBlockEditorTableOverlayMenu } from "./useBlockEditorTableOverlayMenu"
+import { useBlockEditorTableOverlayResize } from "./useBlockEditorTableOverlayResize"
+import { useBlockEditorTableOverlayUiTimers } from "./useBlockEditorTableOverlayUiTimers"
 type UseBlockEditorTableOverlayControllerArgs = {
   clearStickyTopLevelBlockSelection: () => void
   editor: TiptapEditor | null
@@ -27,11 +27,8 @@ type UseBlockEditorTableOverlayControllerArgs = {
   syncSelectedBlockNodeSurface: (blockIndex: number | null) => void
   viewportRef: RefObject<HTMLDivElement>
 }
-
 const DESKTOP_TABLE_RAIL_MEDIA_QUERY = "(max-width: 768px)"
 const TABLE_CORNER_BUTTON_SIZE_PX = 22
-const TABLE_CORNER_GROW_MOUSE_POINTER_ID = -1
-const TABLE_CORNER_DRAG_CLICK_GUARD_PX = 4
 const TABLE_COLUMN_GRIP_WIDTH_PX = 40
 const TABLE_COLUMN_GRIP_HEIGHT_PX = 22
 const TABLE_ROW_GRIP_WIDTH_PX = 22
@@ -44,39 +41,6 @@ const TABLE_EDGE_HANDLE_INSET_PX = 6
 const TABLE_CORNER_CLUSTER_GAP_PX = 6
 const TABLE_CORNER_CLUSTER_WIDTH_PX =
   TABLE_CORNER_BUTTON_SIZE_PX * 2 + TABLE_CORNER_CLUSTER_GAP_PX
-const TABLE_QUICK_RAIL_HIDE_DELAY_MS = 120
-
-const focusElementWithoutScroll = (element: HTMLElement | null) => {
-  if (!element) return
-  if (typeof window === "undefined") {
-    element.focus()
-    return
-  }
-
-  const previousScrollX = window.scrollX
-  const previousScrollY = window.scrollY
-  try {
-    element.focus({ preventScroll: true })
-  } catch {
-    element.focus()
-  }
-  if (window.scrollX !== previousScrollX || window.scrollY !== previousScrollY) {
-    window.scrollTo(previousScrollX, previousScrollY)
-  }
-}
-
-const resolveDocPosSafe = (editor: TiptapEditor, pos: number) => {
-  if (!Number.isFinite(pos)) return null
-  const normalizedPos = Math.round(pos)
-  const maxPos = editor.state.doc.content.size
-  if (normalizedPos < 0 || normalizedPos > maxPos) return null
-  try {
-    return editor.state.doc.resolve(normalizedPos)
-  } catch {
-    return null
-  }
-}
-
 export const useBlockEditorTableOverlayController = ({
   clearStickyTopLevelBlockSelection,
   editor,
@@ -90,126 +54,59 @@ export const useBlockEditorTableOverlayController = ({
   const activeTableElementRef = useRef<HTMLTableElement | null>(null)
   const hoveredTableElementRef = useRef<HTMLTableElement | null>(null)
   const tableHoverAnchorLockUntilRef = useRef(0)
-
-  const pendingTableAxisDragRef = useRef<PendingTableAxisDragState | null>(null)
-  const pendingTableAxisDragCleanupRef = useRef<(() => void) | null>(null)
-  const tableAxisDragSuppressClickRef = useRef(false)
-
-  const tableRowResizeRef = useRef<TableRowResizeState | null>(null)
-  const tableColumnRailResizeRef = useRef<TableColumnRailResizeState | null>(null)
-  const tableCornerGrowRef = useRef<TableCornerGrowState | null>(null)
-  const tableCornerGrowSuppressClickRef = useRef(false)
-  const tableQuickRailHideTimerRef = useRef<number | null>(null)
-  const tableOverflowCoachmarkHideTimerRef = useRef<number | null>(null)
-
   const [isNarrowTableViewport, setIsNarrowTableViewport] = useState(false)
-
   const [tableAffordanceGeometry, setTableAffordanceGeometry] = useState<TableAffordanceGeometry>(
     INITIAL_TABLE_AFFORDANCE_GEOMETRY
   )
   const [tableAffordanceVisibility, setTableAffordanceVisibility] = useState<TableAffordanceVisibility>(
     INITIAL_TABLE_AFFORDANCE_VISIBILITY
   )
-  const [tableColumnDragGuideState, setTableColumnDragGuideState] =
-    useState<TableColumnDragGuideState>(createHiddenTableColumnDragGuideState)
-  const [tableCornerPreviewState, setTableCornerPreviewState] = useState<TableCornerPreviewState>({
-    visible: false,
-    left: 0,
-    top: 0,
-    width: 0,
-    height: 0,
-    columnSteps: 0,
-    rowSteps: 0,
-  })
   const [isTableQuickRailHovered, setIsTableQuickRailHovered] = useState(false)
-  const [isTableColumnResizeActive, setIsTableColumnResizeActive] = useState(false)
-  const [isTableCornerGrowActive, setIsTableCornerGrowActive] = useState(false)
   const [hoveredTableCellMenuLayout, setHoveredTableCellMenuLayout] = useState<{
     cellMenuLeft: number
     cellMenuTop: number
   } | null>(null)
   const [tableMenuState, setTableMenuState] = useState<TableMenuState>(null)
-  const [tableOverflowCoachmarkState, setTableOverflowCoachmarkState] = useState<TableOverflowCoachmarkState>(
-    createHiddenTableOverflowCoachmarkState
-  )
   const tableAffordanceGeometryRef = useRef(tableAffordanceGeometry)
   const tableAffordanceVisibilityRef = useRef(tableAffordanceVisibility)
-  const tableCornerPreviewStateRef = useRef<TableCornerPreviewState>({
-    visible: false,
-    left: 0,
-    top: 0,
-    width: 0,
-    height: 0,
-    columnSteps: 0,
-    rowSteps: 0,
+  const isTableMode = isTableSelectionActive(editor)
+  const isTableStructuralSelection = useMemo(() => {
+    if (!editor) return false
+    void selectionTick
+    const { selection } = editor.state
+    return selection instanceof CellSelection
+  }, [editor, selectionTick])
+  const {
+    focusRenderedTableCell,
+    getCurrentSelectedTableRect,
+    getTableCellFromClientPoint,
+    resolveTableNodePosition,
+    resolveTableQuickRailAnchorElement,
+  } = useBlockEditorTableOverlayDomAdapter({
+    activeTableElementRef,
+    editorRef,
+    hoveredTableElementRef,
+    tableAffordanceGeometryRef,
+    tableHoverAnchorLockUntilRef,
+    viewportRef,
   })
-  const [draggedTableAxisState, setDraggedTableAxisState] = useState<DraggedTableAxisState>(null)
-  const [tableAxisDragGhostPosition, setTableAxisDragGhostPosition] = useState<TableAxisDragGhostPosition>(null)
-  const [tableAxisReorderIndicatorState, setTableAxisReorderIndicatorState] =
-    useState<TableAxisReorderIndicatorState>(createHiddenTableAxisReorderIndicatorState)
-
-  const updateTableCornerPreviewState = useCallback(
-    (
-      nextState:
-        | TableCornerPreviewState
-        | ((prev: TableCornerPreviewState) => TableCornerPreviewState)
-    ) => {
-      setTableCornerPreviewState((prev) => {
-        const resolved =
-          typeof nextState === "function"
-            ? (nextState as (prev: TableCornerPreviewState) => TableCornerPreviewState)(prev)
-            : nextState
-        tableCornerPreviewStateRef.current = resolved
-        return resolved
-      })
-    },
-    []
-  )
-
-  const cancelTableOverflowCoachmarkHide = useCallback(() => {
-    if (typeof window === "undefined") return
-    if (tableOverflowCoachmarkHideTimerRef.current !== null) {
-      window.clearTimeout(tableOverflowCoachmarkHideTimerRef.current)
-      tableOverflowCoachmarkHideTimerRef.current = null
-    }
-  }, [])
-
-  const hideTableOverflowCoachmark = useCallback(() => {
-    cancelTableOverflowCoachmarkHide()
-    setTableOverflowCoachmarkState(hideTableOverflowCoachmarkState)
-  }, [cancelTableOverflowCoachmarkHide])
-
-  const scheduleTableOverflowCoachmarkHide = useCallback(
-    (delayMs = TABLE_OVERFLOW_COACHMARK_DISMISS_MS) => {
-      if (typeof window === "undefined") return
-      cancelTableOverflowCoachmarkHide()
-      tableOverflowCoachmarkHideTimerRef.current = window.setTimeout(() => {
-        tableOverflowCoachmarkHideTimerRef.current = null
-        setTableOverflowCoachmarkState(hideTableOverflowCoachmarkState)
-      }, delayMs)
-    },
-    [cancelTableOverflowCoachmarkHide]
-  )
-  useEffect(() => () => cancelTableOverflowCoachmarkHide(), [cancelTableOverflowCoachmarkHide])
-  const showTableOverflowCoachmark = useCallback(() => {
-    if (isCoarsePointer || isNarrowTableViewport || typeof window === "undefined") return
-    const renderedTable = resolveActiveRenderedTableForFloatingUi(
-      viewportRef.current,
-      tableAffordanceGeometryRef.current
-    )
-    const tableRect = renderedTable?.getBoundingClientRect() ?? null
-    setTableOverflowCoachmarkState(
-      resolveTableOverflowCoachmarkState({
-        tableRect,
-        fallbackAnchor: tableAffordanceGeometryRef.current.cornerAnchor,
-        viewportWidth: window.innerWidth,
-        viewportHeight: window.innerHeight,
-        cornerButtonSize: TABLE_CORNER_BUTTON_SIZE_PX,
-      })
-    )
-    scheduleTableOverflowCoachmarkHide()
-  }, [isCoarsePointer, isNarrowTableViewport, scheduleTableOverflowCoachmarkHide, viewportRef])
-
+  const {
+    cancelTableOverflowCoachmarkHide,
+    cancelTableQuickRailHide,
+    hideTableOverflowCoachmark,
+    hideTableQuickRailImmediately,
+    scheduleTableOverflowCoachmarkHide,
+    scheduleTableQuickRailHide,
+    showTableOverflowCoachmark,
+    tableOverflowCoachmarkState,
+  } = useBlockEditorTableOverlayUiTimers({
+    cornerButtonSize: TABLE_CORNER_BUTTON_SIZE_PX,
+    isCoarsePointer,
+    isNarrowTableViewport,
+    setTableAffordanceVisibility,
+    tableAffordanceGeometryRef,
+    viewportRef,
+  })
   const setViewportRowResizeHot = useCallback((enabled: boolean) => {
     const viewport = viewportRef.current
     if (!viewport) return
@@ -219,319 +116,90 @@ export const useBlockEditorTableOverlayController = ({
     }
     viewport.removeAttribute("data-row-resize-hot")
   }, [viewportRef])
-
-
-  const hideTableQuickRailImmediately = useCallback(() => {
-    if (tableQuickRailHideTimerRef.current !== null && typeof window !== "undefined") {
-      window.clearTimeout(tableQuickRailHideTimerRef.current)
-      tableQuickRailHideTimerRef.current = null
-    }
-    setTableAffordanceVisibility((prev) => (prev.visible ? { ...prev, visible: false } : prev))
-  }, [])
-
-  const cancelTableQuickRailHide = useCallback(() => {
-    if (tableQuickRailHideTimerRef.current !== null && typeof window !== "undefined") {
-      window.clearTimeout(tableQuickRailHideTimerRef.current)
-      tableQuickRailHideTimerRef.current = null
-    }
-  }, [])
-
+  const {
+    currentTableAxisSelection,
+    draggedTableAxisState,
+    isCurrentTableColumnSelection,
+    isCurrentTableRowSelection,
+    selectTableAxisAtIndex,
+    selectTableColumnByIndex,
+    selectTableRowByIndex,
+    startPendingTableAxisDrag,
+    tableAxisDragGhostPosition,
+    tableAxisDragSuppressClickRef,
+    tableAxisReorderIndicatorState,
+  } = useBlockEditorTableOverlayAxisDrag({
+    cancelTableQuickRailHide,
+    clearStickyTopLevelBlockSelection,
+    editor,
+    editorRef,
+    getCurrentSelectedTableRect,
+    isTableStructuralSelection,
+    selectionTick,
+    setSelectionTick,
+    setTableAffordanceGeometry,
+    setTableMenuState,
+    tableAffordanceGeometryRef,
+    viewportRef,
+  })
   const clearWindowTextSelection = useCallback(() => {
     if (typeof window === "undefined") return
     const selection = window.getSelection()
     if (!selection || selection.isCollapsed) return
     selection.removeAllRanges()
   }, [])
-
-  const setColumnResizeUserSelectSuppressed = useCallback((suppressed: boolean) => {
-    if (typeof document === "undefined") return
-    if (suppressed) {
-      document.body.style.setProperty("user-select", "none")
-      document.body.style.setProperty("-webkit-user-select", "none")
-      return
-    }
-    document.body.style.removeProperty("user-select")
-    document.body.style.removeProperty("-webkit-user-select")
-  }, [])
-
-  const hideTableColumnDragGuide = useCallback(() => {
-    setTableColumnDragGuideState(hideTableColumnDragGuideState)
-  }, [])
-
-  const updateTableColumnDragGuideForColumn = useCallback(
-    (columnIndex: number) => {
-      const viewport = viewportRef.current
-      if (!viewport) {
-        hideTableColumnDragGuide()
-        return
-      }
-
-      const tableElement = resolveActiveRenderedTableForFloatingUi(
-        viewport,
-        tableAffordanceGeometryRef.current,
-        activeTableElementRef.current
-      )
-      const guideState = resolveTableColumnDragGuideState(tableElement, columnIndex)
-      if (!guideState) {
-        hideTableColumnDragGuide()
-        return
-      }
-      setTableColumnDragGuideState(guideState)
-    },
-    [hideTableColumnDragGuide, viewportRef]
-  )
-
-  const scheduleTableQuickRailHide = useCallback((delayMs = TABLE_QUICK_RAIL_HIDE_DELAY_MS) => {
-    cancelTableQuickRailHide()
-    if (typeof window === "undefined") return
-    tableQuickRailHideTimerRef.current = window.setTimeout(() => {
-      setTableAffordanceVisibility((prev) => (prev.visible ? { ...prev, visible: false } : prev))
-      tableQuickRailHideTimerRef.current = null
-    }, delayMs)
-  }, [cancelTableQuickRailHide])
-
-
-  const selectTableAxisAtIndex = useCallback(
-    (activeEditor: TiptapEditor, tablePos: number, axis: "row" | "column", axisIndex: number) => {
-      const tableNode = activeEditor.state.doc.nodeAt(tablePos)
-      if (!tableNode || tableNode.type.name !== "table") return false
-
-      const map = TableMap.get(tableNode)
-      if (axis === "column") {
-        if (axisIndex < 0 || axisIndex >= map.width) return false
-        const anchorCellPos = tablePos + 1 + map.positionAt(0, axisIndex, tableNode)
-        const headCellPos = tablePos + 1 + map.positionAt(map.height - 1, axisIndex, tableNode)
-        const anchorResolved = resolveDocPosSafe(activeEditor, anchorCellPos)
-        const headResolved = resolveDocPosSafe(activeEditor, headCellPos)
-        if (!anchorResolved || !headResolved) return false
-
-        clearStickyTopLevelBlockSelection()
-        activeEditor.view.dispatch(
-          activeEditor.state.tr.setSelection(CellSelection.colSelection(anchorResolved, headResolved))
-        )
-        focusElementWithoutScroll(activeEditor.view.dom)
-        return true
-      }
-
-      if (axisIndex < 0 || axisIndex >= map.height) return false
-      const anchorCellPos = tablePos + 1 + map.positionAt(axisIndex, 0, tableNode)
-      const headCellPos = tablePos + 1 + map.positionAt(axisIndex, map.width - 1, tableNode)
-      const anchorResolved = resolveDocPosSafe(activeEditor, anchorCellPos)
-      const headResolved = resolveDocPosSafe(activeEditor, headCellPos)
-      if (!anchorResolved || !headResolved) return false
-
-      clearStickyTopLevelBlockSelection()
-      activeEditor.view.dispatch(
-        activeEditor.state.tr.setSelection(CellSelection.rowSelection(anchorResolved, headResolved))
-      )
-      focusElementWithoutScroll(activeEditor.view.dom)
-      return true
-    },
-    [clearStickyTopLevelBlockSelection]
-  )
-
-  const clearPendingTableAxisDrag = useCallback(() => {
-    pendingTableAxisDragRef.current = null
-    if (pendingTableAxisDragCleanupRef.current) {
-      pendingTableAxisDragCleanupRef.current()
-      pendingTableAxisDragCleanupRef.current = null
-    }
-  }, [])
-
-
-  const getTableCellFromTarget = useCallback((target: EventTarget | null) => {
-    const normalizedTarget =
-      target instanceof Element ? target : target instanceof Node ? target.parentElement : null
-    if (!(normalizedTarget instanceof Element)) return null
-    const cell = normalizedTarget.closest("td, th")
-    if (!(cell instanceof HTMLTableCellElement)) return null
-    return cell
-  }, [])
-
-  const getTableCellFromClientPoint = useCallback(
-    (clientX: number, clientY: number, target: EventTarget | null) => {
-      const targetCell = getTableCellFromTarget(target)
-      if (targetCell) return targetCell
-      if (typeof document === "undefined") return null
-
-      const pointElement = document.elementFromPoint(clientX, clientY)
-      const pointCell = pointElement?.closest("td, th")
-      if (pointCell instanceof HTMLTableCellElement) return pointCell
-
-      const normalizedTarget =
-        target instanceof Element ? target : target instanceof Node ? target.parentElement : null
-      const tableSurfaceElement =
-        normalizedTarget?.closest(".aq-table-shell, .tableWrapper, table") ??
-        pointElement?.closest(".aq-table-shell, .tableWrapper, table") ??
-        null
-      const tableElement =
-        tableSurfaceElement instanceof HTMLTableElement
-          ? tableSurfaceElement
-          : (tableSurfaceElement?.querySelector("table") as HTMLTableElement | null)
-      if (!tableElement) return null
-
-      const cells = Array.from(tableElement.querySelectorAll("th, td")).filter(
-        (cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement
-      )
-      return (
-        cells.find((cell) => {
-          const rect = cell.getBoundingClientRect()
-          return clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom
-        }) ?? null
-      )
-    },
-    [getTableCellFromTarget]
-  )
-
-  const stopTableRowResize = useCallback(() => {
-    const state = tableRowResizeRef.current
-    if (state?.row) {
-      state.row.removeAttribute("data-row-resize-active")
-      if (!state.row.getAttribute("data-row-height")) {
-        state.row.style.removeProperty("height")
-      }
-      state.cells.forEach((cell) => {
-        cell.style.removeProperty("height")
-        cell.style.removeProperty("min-height")
-      })
-    }
-    tableRowResizeRef.current = null
-    setViewportRowResizeHot(false)
-    if (typeof document !== "undefined") {
-      document.body.style.removeProperty("cursor")
-    }
-  }, [setViewportRowResizeHot])
-
-  const startTableRowResize = useCallback(
-    (cell: HTMLTableCellElement, clientY: number) => {
-      const resizeState = createTableRowResizeState(cell, clientY)
-      if (!resizeState) return
-
-      resizeState.row.setAttribute("data-row-resize-active", "true")
-      tableRowResizeRef.current = resizeState
-      setViewportRowResizeHot(true)
-      if (typeof document !== "undefined") {
-        document.body.style.cursor = "row-resize"
-      }
-    },
-    [setViewportRowResizeHot]
-  )
-
-  const commitTableRowHeight = useCallback((rowElement: HTMLTableRowElement, nextHeight: number) => {
-    const currentEditor = editorRef.current
-    if (!currentEditor) return
-
-    let domPosition = 0
-    try {
-      domPosition = currentEditor.view.posAtDOM(rowElement, 0)
-    } catch {
-      return
-    }
-    const resolvedPosition = resolveDocPosSafe(currentEditor, domPosition)
-    if (!resolvedPosition) return
-
-    for (let depth = resolvedPosition.depth; depth > 0; depth -= 1) {
-      if (resolvedPosition.node(depth).type.name !== "tableRow") continue
-
-      const rowPosition = resolvedPosition.before(depth)
-      const rowNode = currentEditor.state.doc.nodeAt(rowPosition)
-      if (!rowNode) return
-
-      const normalizedHeight = Math.max(TABLE_MIN_ROW_HEIGHT_PX, nextHeight)
-      const transaction = currentEditor.state.tr.setNodeMarkup(rowPosition, undefined, {
-        ...rowNode.attrs,
-        rowHeightPx: normalizedHeight,
-      })
-      currentEditor.view.dispatch(transaction)
-      return
-    }
-  }, [editorRef])
-
-  const resizeFirstTableRowBy = useCallback((deltaPx: number) => {
-    const currentEditor = editorRef.current
-    if (!currentEditor) return
-    const firstTableRow = viewportRef.current?.querySelector(".aq-block-editor__content table tr") as HTMLTableRowElement | null
-    if (!firstTableRow) return
-    const nextHeight = Math.max(
-      TABLE_MIN_ROW_HEIGHT_PX,
-      Math.round(firstTableRow.getBoundingClientRect().height + deltaPx)
-    )
-    commitTableRowHeight(firstTableRow, nextHeight)
-  }, [commitTableRowHeight, editorRef, viewportRef])
-
-  const getActiveTableRectFromDom = useCallback((activeEditor?: TiptapEditor | null) => {
-    if (!activeEditor) return null
-
-    const tableElement = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
-    const firstCell = tableElement?.querySelector<HTMLElement>(
-      "thead tr:first-of-type > th, thead tr:first-of-type > td, tbody tr:first-of-type > th, tbody tr:first-of-type > td, tr:first-of-type > th, tr:first-of-type > td"
-    )
-    if (!tableElement || !firstCell) return null
-
-    let domPosition = 0
-    try {
-      domPosition = activeEditor.view.posAtDOM(firstCell, 0)
-    } catch {
-      return null
-    }
-
-    const resolvedPosition = resolveDocPosSafe(activeEditor, domPosition)
-    if (!resolvedPosition) return null
-
-    for (let depth = resolvedPosition.depth; depth > 0; depth -= 1) {
-      if (resolvedPosition.node(depth).type.name !== "table") continue
-      const table = resolvedPosition.node(depth)
-      const tableStart = resolvedPosition.start(depth)
-      return {
-        map: TableMap.get(table),
-        table,
-        tableStart,
-      }
-    }
-
-    return null
-  }, [viewportRef])
-
-  const resolveTableQuickRailAnchorElement = useCallback(() => {
-    const viewport = viewportRef.current
-    if (!viewport) return null
-
-    const now =
-      typeof window !== "undefined" && typeof window.performance !== "undefined"
-        ? window.performance.now()
-        : Date.now()
-    const hoveredTable =
-      hoveredTableElementRef.current?.isConnected &&
-      viewport.contains(hoveredTableElementRef.current) &&
-      now <= tableHoverAnchorLockUntilRef.current
-        ? hoveredTableElementRef.current
-        : null
-    const renderedTable =
-      hoveredTable ??
-      resolveActiveRenderedTableForFloatingUi(
-        viewport,
-        tableAffordanceGeometryRef.current,
-        activeTableElementRef.current
-      )
-    const selectedCell = resolveTableScopedSelectedCell(renderedTable)
-    if (selectedCell) return selectedCell
-
-    if (!renderedTable) return null
-
-    const rows = Array.from(renderedTable.querySelectorAll("tr")).filter(
-      (node): node is HTMLTableRowElement => node instanceof HTMLTableRowElement
-    )
-    const row = rows[tableAffordanceGeometryRef.current.rowIndex] ?? null
-    if (!row) return renderedTable.querySelector("th, td") as HTMLElement | null
-
-    const cells = Array.from(row.children).filter((node): node is HTMLElement => node instanceof HTMLElement)
-    return (
-      cells[tableAffordanceGeometryRef.current.columnIndex] ??
-      (row.querySelector("th, td") as HTMLElement | null) ??
-      (renderedTable.querySelector("th, td") as HTMLElement | null)
-    )
-  }, [viewportRef])
-
+  const {
+    hideTableColumnDragGuide,
+    isTableColumnRailResizeActive,
+    isTableColumnResizeActive,
+    isTableRowResizeActive,
+    isTableRowResizeHandleTarget,
+    resizeFirstTableColumnBy,
+    resizeFirstTableRowBy,
+    startTableColumnRailResize,
+    startTableRowResize,
+    tableColumnDragGuideState,
+    tableColumnRailResizeRef,
+    tableRowResizeRef,
+    tryStartTableColumnResizeFromDomHandle,
+  } = useBlockEditorTableOverlayResize({
+    activeTableElementRef,
+    clearWindowTextSelection,
+    editorRef,
+    getCurrentSelectedTableRect,
+    hideTableOverflowCoachmark,
+    isCurrentTableColumnSelection,
+    resolveTableNodePosition,
+    selectTableColumnByIndex,
+    setSelectionTick,
+    setTableAffordanceGeometry,
+    setViewportRowResizeHot,
+    showTableOverflowCoachmark,
+    tableAffordanceGeometryRef,
+    viewportRef,
+  })
+  const {
+    appendTableAxisAtEnd,
+    growTableFromCorner,
+    isTableCornerGrowActive,
+    resolveTableCornerGrowStepMetricsFromHandle,
+    startTableCornerGrow,
+    tableCornerGrowMousePointerId,
+    tableCornerGrowRef,
+    tableCornerGrowStepMetrics,
+    tableCornerGrowSuppressClickRef,
+    tableCornerPreviewState,
+  } = useBlockEditorTableOverlayCornerGrow({
+    editorRef,
+    focusRenderedTableCell,
+    getCurrentSelectedTableRect,
+    selectTableColumnByIndex,
+    selectTableRowByIndex,
+    setSelectionTick,
+    tableAffordanceGeometry,
+    tableAffordanceGeometryRef,
+    viewportRef,
+  })
   const syncHoveredTableCellMenuLayout = useCallback((
     tableElement: HTMLTableElement | null,
     preferredCell?: HTMLElement | null
@@ -571,694 +239,6 @@ export const useBlockEditorTableOverlayController = ({
       ),
     })
   }, [])
-
-  const getCurrentSelectedTableRect = useCallback((activeEditor?: TiptapEditor | null) => {
-    if (!activeEditor) return null
-    if (isTableSelectionActive(activeEditor)) {
-      try {
-        return selectedRect(activeEditor.state)
-      } catch {
-        return getActiveTableRectFromDom(activeEditor)
-      }
-    }
-
-    return getActiveTableRectFromDom(activeEditor)
-  }, [getActiveTableRectFromDom])
-
-  const resolveTableNodePosition = useCallback((activeEditor: TiptapEditor, tableNode: ProseMirrorNode) => {
-    let tablePos: number | null = null
-    activeEditor.state.doc.descendants((node: ProseMirrorNode, pos: number) => {
-      if (node === tableNode) {
-        tablePos = pos
-        return false
-      }
-      return true
-    })
-    return tablePos
-  }, [])
-
-  const isCurrentTableColumnSelection = useCallback(
-    (columnIndex: number) => {
-      const currentEditor = editorRef.current
-      if (!currentEditor || columnIndex < 0) return false
-      const { selection } = currentEditor.state
-      if (!(selection instanceof CellSelection)) return false
-      let rect: ReturnType<typeof selectedRect> | null = null
-      try {
-        rect = selectedRect(currentEditor.state)
-      } catch {
-        rect = null
-      }
-      if (!rect) return false
-      return rect.left === columnIndex && rect.right === columnIndex + 1 && rect.top === 0 && rect.bottom === rect.map.height
-    },
-    [editorRef]
-  )
-
-  const isCurrentTableRowSelection = useCallback((rowIndex: number) => {
-    const currentEditor = editorRef.current
-    if (!currentEditor || rowIndex < 0) return false
-    const { selection } = currentEditor.state
-    if (!(selection instanceof CellSelection)) return false
-    let rect: ReturnType<typeof selectedRect> | null = null
-    try {
-      rect = selectedRect(currentEditor.state)
-    } catch {
-      rect = null
-    }
-    if (!rect) return false
-    return rect.top === rowIndex && rect.bottom === rowIndex + 1 && rect.left === 0 && rect.right === rect.map.width
-  }, [editorRef])
-
-  const selectTableColumnByIndex = useCallback(
-    (columnIndex: number) => {
-      const currentEditor = editorRef.current
-      if (!currentEditor) return false
-      const rect = getCurrentSelectedTableRect(currentEditor)
-      if (!rect || columnIndex < 0 || columnIndex >= rect.map.width) return false
-
-      return selectTableAxisAtIndex(currentEditor, rect.tableStart - 1, "column", columnIndex)
-    },
-    [editorRef, getCurrentSelectedTableRect, selectTableAxisAtIndex]
-  )
-
-  const selectTableRowByIndex = useCallback(
-    (rowIndex: number) => {
-      const currentEditor = editorRef.current
-      if (!currentEditor) return false
-      const rect = getCurrentSelectedTableRect(currentEditor)
-      if (!rect || rowIndex < 0 || rowIndex >= rect.map.height) return false
-
-      return selectTableAxisAtIndex(currentEditor, rect.tableStart - 1, "row", rowIndex)
-    },
-    [editorRef, getCurrentSelectedTableRect, selectTableAxisAtIndex]
-  )
-
-  const reorderTableAxisAtPosition = useCallback(
-    (tablePos: number, axis: "row" | "column", sourceIndex: number, insertionIndex: number) => {
-      const currentEditor = editorRef.current
-      if (!currentEditor) return false
-
-      const tableNode = currentEditor.state.doc.nodeAt(tablePos)
-      if (!tableNode || tableNode.type.name !== "table") return false
-
-      const reorderedTable = buildReorderedSimpleTableNode(tableNode, axis, sourceIndex, insertionIndex)
-      if (!reorderedTable) return false
-
-      currentEditor.view.dispatch(
-        currentEditor.state.tr.replaceWith(tablePos, tablePos + tableNode.nodeSize, reorderedTable.node)
-      )
-
-      const selected = selectTableAxisAtIndex(currentEditor, tablePos, axis, reorderedTable.nextIndex)
-      setTableAffordanceGeometry((prev) =>
-        axis === "row"
-          ? { ...prev, rowIndex: reorderedTable.nextIndex }
-          : { ...prev, columnIndex: reorderedTable.nextIndex }
-      )
-      setSelectionTick((prev) => prev + 1)
-      return selected
-    },
-    [editorRef, selectTableAxisAtIndex, setSelectionTick]
-  )
-
-  const beginTableAxisDragFromPending = useCallback(
-    (pending: PendingTableAxisDragState, clientX: number, clientY: number) => {
-      const nextDragState = createDraggedTableAxisState(pending)
-      tableAxisDragSuppressClickRef.current = true
-      const currentEditor = editorRef.current
-      if (currentEditor) {
-        selectTableAxisAtIndex(currentEditor, pending.tablePos, pending.axis, pending.sourceIndex)
-      }
-      setTableMenuState(null)
-      cancelTableQuickRailHide()
-      setDraggedTableAxisState(nextDragState)
-      const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
-      setTableAxisReorderIndicatorState(
-        resolveTableAxisReorderIndicator(renderedTable, pending.axis, pending.sourceIndex, clientX, clientY) ??
-          createHiddenTableAxisReorderIndicatorState(pending.axis, pending.sourceIndex)
-      )
-      setTableAxisDragGhostPosition(createTableAxisDragGhostPosition(pending, clientY))
-      return nextDragState
-    },
-    [cancelTableQuickRailHide, editorRef, selectTableAxisAtIndex, viewportRef]
-  )
-
-  const startPendingTableAxisDrag = useCallback(
-    (axis: TableAxis, sourceIndex: number, pointerId: number, clientX: number, clientY: number) => {
-      const currentEditor = editorRef.current
-      if (!currentEditor) return
-
-      const tableRect = getCurrentSelectedTableRect(currentEditor)
-      const tablePos = tableRect ? Math.max(0, tableRect.tableStart - 1) : null
-      if (!tableRect || tablePos === null) return
-      const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
-      const resolvedSourceIndex = resolveTableAxisIndexFromPointer(renderedTable, axis, clientX, clientY) ?? sourceIndex
-
-      const withinBounds =
-        axis === "row"
-          ? resolvedSourceIndex >= 0 && resolvedSourceIndex < tableRect.map.height
-          : resolvedSourceIndex >= 0 && resolvedSourceIndex < tableRect.map.width
-      if (!withinBounds) return
-
-      clearPendingTableAxisDrag()
-      tableAxisDragSuppressClickRef.current = false
-
-      pendingTableAxisDragRef.current = createPendingTableAxisDragState(
-        axis,
-        resolvedSourceIndex,
-        pointerId,
-        tablePos,
-        clientX,
-        clientY,
-        tableAffordanceGeometryRef.current
-      )
-
-      const DRAG_THRESHOLD_PX = 5
-      let activeDragState: Exclude<DraggedTableAxisState, null> | null = null
-
-      const handlePendingPointerMove = (moveEvent: PointerEvent) => {
-        if (activeDragState) {
-          if (moveEvent.pointerId !== activeDragState.pointerId) return
-          const activeRenderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
-          const nextIndicator = resolveTableAxisReorderIndicator(
-            activeRenderedTable,
-            activeDragState.axis,
-            activeDragState.sourceIndex,
-            moveEvent.clientX,
-            moveEvent.clientY
-          )
-          setTableAxisReorderIndicatorState(
-            nextIndicator ??
-              createHiddenTableAxisReorderIndicatorState(activeDragState.axis, activeDragState.sourceIndex)
-          )
-          if (activeDragState.axis === "row") {
-            setTableAxisDragGhostPosition(createTableAxisDragGhostPosition(activeDragState, moveEvent.clientY))
-          }
-          return
-        }
-
-        const pending = pendingTableAxisDragRef.current
-        if (!pending || moveEvent.pointerId !== pending.pointerId) return
-
-        const distance = Math.hypot(moveEvent.clientX - pending.startX, moveEvent.clientY - pending.startY)
-        if (distance < DRAG_THRESHOLD_PX) return
-
-        pendingTableAxisDragRef.current = null
-        activeDragState = beginTableAxisDragFromPending(pending, moveEvent.clientX, moveEvent.clientY)
-      }
-
-      const handlePendingPointerDone = (doneEvent: PointerEvent) => {
-        if (activeDragState) {
-          if (doneEvent.pointerId !== activeDragState.pointerId) return
-          const activeRenderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
-          const nextIndicator = resolveTableAxisReorderIndicator(
-            activeRenderedTable,
-            activeDragState.axis,
-            activeDragState.sourceIndex,
-            doneEvent.clientX,
-            doneEvent.clientY
-          )
-          if (nextIndicator) {
-            reorderTableAxisAtPosition(
-              activeDragState.tablePos,
-              activeDragState.axis,
-              activeDragState.sourceIndex,
-              nextIndicator.insertionIndex
-            )
-          }
-          activeDragState = null
-          setDraggedTableAxisState(null)
-          setTableAxisDragGhostPosition(null)
-          setTableAxisReorderIndicatorState(hideTableAxisReorderIndicatorState)
-          clearPendingTableAxisDrag()
-          return
-        }
-
-        const pending = pendingTableAxisDragRef.current
-        if (!pending || doneEvent.pointerId !== pending.pointerId) return
-        clearPendingTableAxisDrag()
-      }
-
-      window.addEventListener("pointermove", handlePendingPointerMove)
-      window.addEventListener("pointerup", handlePendingPointerDone)
-      window.addEventListener("pointercancel", handlePendingPointerDone)
-
-      pendingTableAxisDragCleanupRef.current = () => {
-        window.removeEventListener("pointermove", handlePendingPointerMove)
-        window.removeEventListener("pointerup", handlePendingPointerDone)
-        window.removeEventListener("pointercancel", handlePendingPointerDone)
-      }
-    },
-    [
-      beginTableAxisDragFromPending,
-      clearPendingTableAxisDrag,
-      editorRef,
-      getCurrentSelectedTableRect,
-      reorderTableAxisAtPosition,
-      viewportRef,
-    ]
-  )
-
-  const focusRenderedTableCell = useCallback((cell: HTMLTableCellElement) => {
-    const currentEditor = editorRef.current
-    if (!currentEditor) return false
-
-    let domPosition = 0
-    try {
-      domPosition = currentEditor.view.posAtDOM(cell, 0)
-    } catch {
-      return false
-    }
-
-    const resolvedPosition = resolveDocPosSafe(currentEditor, domPosition)
-    if (!resolvedPosition) return false
-
-    for (let depth = resolvedPosition.depth; depth > 0; depth -= 1) {
-      const node = resolvedPosition.node(depth)
-      if (node.type.name !== "tableCell" && node.type.name !== "tableHeader") continue
-
-      const cellPosition = resolvedPosition.before(depth)
-      const cellNode = currentEditor.state.doc.nodeAt(cellPosition)
-      if (!cellNode) return false
-
-      const selectionPos =
-        getFirstEditableTextPositionInNode(cellNode, cellPosition) ?? Math.max(1, cellPosition + 1)
-      currentEditor.view.dispatch(
-        currentEditor.state.tr.setSelection(TextSelection.create(currentEditor.state.doc, selectionPos))
-      )
-      focusElementWithoutScroll(currentEditor.view.dom)
-      return true
-    }
-
-    return false
-  }, [editorRef])
-
-  const appendTableAxisAtEnd = useCallback(
-    (axis: "row" | "column") => {
-      const currentEditor = editorRef.current
-      if (!currentEditor) return false
-      let rect = getCurrentSelectedTableRect(currentEditor)
-      if (!rect) {
-        const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
-        const fallbackCell = renderedTable?.querySelector<HTMLTableCellElement>(
-          "tr:last-child > th:last-child, tr:last-child > td:last-child"
-        )
-        if (fallbackCell && focusRenderedTableCell(fallbackCell)) {
-          rect = getCurrentSelectedTableRect(currentEditor)
-        }
-      }
-      if (!rect) return false
-
-      const selected =
-        axis === "column"
-          ? selectTableColumnByIndex(rect.map.width - 1)
-          : selectTableRowByIndex(rect.map.height - 1)
-      if (!selected) return false
-
-      const chain = currentEditor.chain().focus()
-      axis === "column" ? chain.addColumnAfter() : chain.addRowAfter()
-      return chain.run()
-    },
-    [editorRef, focusRenderedTableCell, getCurrentSelectedTableRect, selectTableColumnByIndex, selectTableRowByIndex, viewportRef]
-  )
-
-  const shrinkTableAxisAtEnd = useCallback(
-    (axis: "row" | "column") => {
-      const currentEditor = editorRef.current
-      if (!currentEditor) return false
-      let rect = getCurrentSelectedTableRect(currentEditor)
-      if (!rect) {
-        const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
-        const fallbackCell = renderedTable?.querySelector<HTMLTableCellElement>(
-          "tr:last-child > th:last-child, tr:last-child > td:last-child"
-        )
-        if (fallbackCell && focusRenderedTableCell(fallbackCell)) {
-          rect = getCurrentSelectedTableRect(currentEditor)
-        }
-      }
-      if (!rect || !canShrinkTableAxisAtEnd(rect.table, axis)) return false
-
-      const trailingIndex = axis === "column" ? rect.map.width - 1 : rect.map.height - 1
-      if (trailingIndex < 0) return false
-
-      const selected =
-        axis === "column" ? selectTableColumnByIndex(trailingIndex) : selectTableRowByIndex(trailingIndex)
-      if (!selected) return false
-
-      const chain = currentEditor.chain().focus()
-      axis === "column" ? chain.deleteColumn() : chain.deleteRow()
-      return chain.run()
-    },
-    [editorRef, focusRenderedTableCell, getCurrentSelectedTableRect, selectTableColumnByIndex, selectTableRowByIndex, viewportRef]
-  )
-
-  const growTableFromCorner = useCallback(() => {
-    const appendedColumn = appendTableAxisAtEnd("column")
-    const appendedRow = appendTableAxisAtEnd("row")
-    return appendedColumn || appendedRow
-  }, [appendTableAxisAtEnd])
-
-  const applyTableCornerGrowSteps = useCallback(
-    (columnSteps: number, rowSteps: number) => {
-      let appliedColumnSteps = 0
-      let appliedRowSteps = 0
-
-      while (Math.abs(appliedColumnSteps) < Math.abs(columnSteps)) {
-        const direction = columnSteps > 0 ? 1 : -1
-        const changed = direction > 0 ? appendTableAxisAtEnd("column") : shrinkTableAxisAtEnd("column")
-        if (!changed) break
-        appliedColumnSteps += direction
-      }
-
-      while (Math.abs(appliedRowSteps) < Math.abs(rowSteps)) {
-        const direction = rowSteps > 0 ? 1 : -1
-        const changed = direction > 0 ? appendTableAxisAtEnd("row") : shrinkTableAxisAtEnd("row")
-        if (!changed) break
-        appliedRowSteps += direction
-      }
-
-      if (appliedColumnSteps !== 0 || appliedRowSteps !== 0) {
-        setSelectionTick((prev) => prev + 1)
-      }
-
-      return {
-        appliedColumnSteps,
-        appliedRowSteps,
-      }
-    },
-    [appendTableAxisAtEnd, setSelectionTick, shrinkTableAxisAtEnd]
-  )
-
-  const resolveCurrentTableCornerGrowStepMetrics = useCallback(
-    () => resolveTableCornerGrowStepMetrics(tableAffordanceGeometryRef.current),
-    []
-  )
-
-  const resolveTableCornerGrowStepMetricsFromHandle = useCallback(
-    (element: HTMLElement | null) =>
-      resolveTableCornerGrowStepMetricsFromDataset(
-        element?.dataset,
-        resolveCurrentTableCornerGrowStepMetrics()
-      ),
-    [resolveCurrentTableCornerGrowStepMetrics]
-  )
-
-  const stopTableCornerGrow = useCallback(() => {
-    tableCornerGrowRef.current = null
-    updateTableCornerPreviewState((prev) => (prev.visible ? { ...prev, visible: false, columnSteps: 0, rowSteps: 0 } : prev))
-    setIsTableCornerGrowActive(false)
-  }, [updateTableCornerPreviewState])
-
-  const startTableCornerGrow = useCallback(
-    (
-      pointerId: number,
-      clientX: number,
-      clientY: number,
-      stepMetrics?: TableCornerGrowStepMetrics
-    ) => {
-      const { columnStepPx, rowStepPx } = stepMetrics ?? resolveCurrentTableCornerGrowStepMetrics()
-      const currentEditor = editorRef.current
-      const rect = currentEditor ? getCurrentSelectedTableRect(currentEditor) : null
-      const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
-      const maxShrinkColumnSteps = rect
-        ? countShrinkableTableAxisAtEnd(rect.table, "column")
-        : countShrinkableRenderedTableAxisAtEnd(renderedTable, "column")
-      const maxShrinkRowSteps = rect
-        ? countShrinkableTableAxisAtEnd(rect.table, "row")
-        : countShrinkableRenderedTableAxisAtEnd(renderedTable, "row")
-      tableCornerGrowRef.current = {
-        pointerId,
-        startClientX: clientX,
-        startClientY: clientY,
-        baseLeft: tableAffordanceGeometryRef.current.tableLeft,
-        baseTop: tableAffordanceGeometryRef.current.tableTop,
-        baseWidth: tableAffordanceGeometryRef.current.width,
-        baseHeight: tableAffordanceGeometryRef.current.height,
-        columnStepPx,
-        rowStepPx,
-        maxShrinkColumnSteps,
-        maxShrinkRowSteps,
-      }
-      tableCornerGrowSuppressClickRef.current = false
-      updateTableCornerPreviewState({
-        visible: false,
-        left: tableAffordanceGeometryRef.current.tableLeft,
-        top: tableAffordanceGeometryRef.current.tableTop,
-        width: tableAffordanceGeometryRef.current.width,
-        height: tableAffordanceGeometryRef.current.height,
-        columnSteps: 0,
-        rowSteps: 0,
-      })
-      setIsTableCornerGrowActive(true)
-    },
-    [editorRef, getCurrentSelectedTableRect, resolveCurrentTableCornerGrowStepMetrics, updateTableCornerPreviewState, viewportRef]
-  )
-
-  const getCurrentTableColumnResizeContext = useCallback(
-    (columnIndex: number) => {
-      const currentEditor = editorRef.current
-      if (!currentEditor) return null
-      const rect = getCurrentSelectedTableRect(currentEditor)
-      if (!rect || columnIndex < 0 || columnIndex >= rect.map.width) {
-        return null
-      }
-
-      const tablePos = resolveTableNodePosition(currentEditor, rect.table)
-      if (tablePos === null) {
-        return null
-      }
-
-      const columns = collectSimpleTableColumnCells(rect.table, tablePos)
-      if (!columns || columns.length === 0 || columnIndex >= columns.length) {
-        return null
-      }
-
-      const currentWidths = columns.map((column) => readColumnWidthFromCell(column[0]))
-      const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
-      const renderedColumnWidths = readRenderedColumnWidths(renderedTable)
-      const measuredWidths =
-        columns.some((column) => !hasExplicitColumnWidth(column)) &&
-        renderedColumnWidths.length === columns.length
-          ? renderedColumnWidths
-          : currentWidths
-
-      return {
-        currentEditor,
-        rect,
-        columns,
-        currentWidths,
-        measuredWidths,
-      }
-    },
-    [editorRef, getCurrentSelectedTableRect, resolveTableNodePosition, viewportRef]
-  )
-
-  const resizeTableColumnByIndex = useCallback(
-    (columnIndex: number, deltaPx: number) => {
-      if (deltaPx === 0) return { changed: false, appliedDelta: 0 }
-      const resizeContext = getCurrentTableColumnResizeContext(columnIndex)
-      if (!resizeContext) {
-        return { changed: false, appliedDelta: 0 }
-      }
-
-      const { currentEditor, rect, columns, currentWidths, measuredWidths } = resizeContext
-      const nextWidthsResult = computeNextTableColumnWidthsForResize(
-        measuredWidths,
-        columnIndex,
-        deltaPx,
-        shouldClampTableWidthBudget(),
-        getTableOverflowMode(rect.table),
-        getCurrentEditorReadableWidthPx(currentEditor) - 2
-      )
-
-      const applied = applyTableColumnWidthsToTransaction(
-        currentEditor.state.tr,
-        columns,
-        currentWidths,
-        nextWidthsResult.widths
-      )
-      if (!applied.changed) {
-        return { changed: false, appliedDelta: 0, wasClamped: nextWidthsResult.wasClamped }
-      }
-      currentEditor.view.dispatch(applied.transaction)
-      setSelectionTick((prev) => prev + 1)
-      return {
-        changed: true,
-        appliedDelta: nextWidthsResult.widths[columnIndex] - measuredWidths[columnIndex],
-        wasClamped: nextWidthsResult.wasClamped,
-      }
-    },
-    [getCurrentTableColumnResizeContext, setSelectionTick]
-  )
-
-  const resizeTableColumnBySessionDelta = useCallback(
-    (
-      columnIndex: number,
-      baseWidths: number[],
-      totalDeltaPx: number,
-      overflowMode: string,
-      budget: number
-    ) => {
-      const resizeContext = getCurrentTableColumnResizeContext(columnIndex)
-      if (!resizeContext) {
-        return { changed: false, appliedDelta: 0 }
-      }
-
-      const { currentEditor, columns, currentWidths } = resizeContext
-      const nextWidthsResult = computeNextTableColumnWidthsForResize(
-        baseWidths,
-        columnIndex,
-        totalDeltaPx,
-        shouldClampTableWidthBudget(),
-        overflowMode,
-        budget
-      )
-      const applied = applyTableColumnWidthsToTransaction(
-        currentEditor.state.tr,
-        columns,
-        currentWidths,
-        nextWidthsResult.widths
-      )
-      if (!applied.changed) {
-        return { changed: false, appliedDelta: 0, wasClamped: nextWidthsResult.wasClamped }
-      }
-      currentEditor.view.dispatch(applied.transaction)
-      setSelectionTick((prev) => prev + 1)
-      return {
-        changed: true,
-        appliedDelta: nextWidthsResult.widths[columnIndex] - baseWidths[columnIndex],
-        wasClamped: nextWidthsResult.wasClamped,
-      }
-    },
-    [getCurrentTableColumnResizeContext, setSelectionTick]
-  )
-
-  const resizeFirstTableColumnBy = useCallback((deltaPx: number) => {
-    const currentEditor = editorRef.current
-    if (!currentEditor) return
-    const firstCell = viewportRef.current?.querySelector(".aq-block-editor__content table tr:first-of-type > th, .aq-block-editor__content table tr:first-of-type > td") as HTMLElement | null
-    if (!firstCell) return
-
-    let domPosition = 0
-    try {
-      domPosition = currentEditor.view.posAtDOM(firstCell, 0)
-    } catch {
-      return
-    }
-    const resolvedPosition = resolveDocPosSafe(currentEditor, domPosition)
-    if (!resolvedPosition) return
-
-    for (let depth = resolvedPosition.depth; depth > 0; depth -= 1) {
-      const node = resolvedPosition.node(depth)
-      if (node.type.name !== "tableCell" && node.type.name !== "tableHeader") continue
-      const cellPosition = resolvedPosition.before(depth)
-      const cellNode = currentEditor.state.doc.nodeAt(cellPosition)
-      if (!cellNode) return
-      let tableDepth = depth - 1
-      while (tableDepth > 0 && resolvedPosition.node(tableDepth).type.name !== "table") {
-        tableDepth -= 1
-      }
-
-      const tableNode = tableDepth > 0 ? resolvedPosition.node(tableDepth) : null
-      const tablePosition = tableDepth > 0 ? resolvedPosition.before(tableDepth) : null
-      const columns = tableNode && tablePosition !== null
-        ? collectSimpleTableColumnCells(tableNode, tablePosition)
-        : null
-
-      if (!columns || columns.length === 0) {
-        const currentWidth = Array.isArray(cellNode.attrs?.colwidth) && cellNode.attrs.colwidth[0]
-          ? Number(cellNode.attrs.colwidth[0])
-          : Math.round(firstCell.getBoundingClientRect().width)
-        const nextWidth = Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(currentWidth + deltaPx))
-        const transaction = currentEditor.state.tr.setNodeMarkup(cellPosition, undefined, {
-          ...cellNode.attrs,
-          colwidth: [nextWidth],
-        })
-        currentEditor.view.dispatch(transaction)
-        return
-      }
-
-      const activeColumnIndex = columns.findIndex((column) =>
-        column.some((cell) => cell.pos === cellPosition)
-      )
-      if (activeColumnIndex === -1) return
-      if (!isCurrentTableColumnSelection(activeColumnIndex) && !selectTableColumnByIndex(activeColumnIndex)) {
-        return
-      }
-      const overflowMode = getTableOverflowMode(tableNode)
-      const resizeResult = resizeTableColumnByIndex(activeColumnIndex, deltaPx)
-      if (
-        overflowMode !== TABLE_OVERFLOW_MODE_WIDE &&
-        didTableColumnResizeHitOverflowPolicy(deltaPx, resizeResult)
-      ) {
-        showTableOverflowCoachmark()
-      } else if (deltaPx < 0) {
-        hideTableOverflowCoachmark()
-      }
-      return
-    }
-  }, [
-    hideTableOverflowCoachmark,
-    editorRef,
-    isCurrentTableColumnSelection,
-    resizeTableColumnByIndex,
-    selectTableColumnByIndex,
-    showTableOverflowCoachmark,
-    viewportRef,
-  ])
-
-  const startTableColumnRailResize = useCallback(
-    (pointerId: number, columnIndex: number, clientX: number) => {
-      if (!selectTableColumnByIndex(columnIndex)) return
-      const resizeContext = getCurrentTableColumnResizeContext(columnIndex)
-      if (!resizeContext) return
-      setIsTableColumnResizeActive(true)
-      setTableAffordanceGeometry((prev) => ({ ...prev, columnIndex }))
-      clearWindowTextSelection()
-      setColumnResizeUserSelectSuppressed(true)
-      tableColumnRailResizeRef.current = createTableColumnRailResizeState(
-        pointerId,
-        columnIndex,
-        clientX,
-        resizeContext.measuredWidths,
-        getCurrentEditorReadableWidthPx(resizeContext.currentEditor) - 2,
-        getTableOverflowMode(resizeContext.rect.table)
-      )
-      if (typeof document !== "undefined") {
-        document.body.style.cursor = "col-resize"
-      }
-      updateTableColumnDragGuideForColumn(columnIndex)
-    },
-    [
-      clearWindowTextSelection,
-      getCurrentTableColumnResizeContext,
-      selectTableColumnByIndex,
-      setColumnResizeUserSelectSuppressed,
-      updateTableColumnDragGuideForColumn,
-    ]
-  )
-
-  const tryStartTableColumnResizeFromDomHandle = useCallback(
-    (target: EventTarget | null, pointerId: number, clientX: number) => {
-      const columnIndex = resolveTableColumnIndexFromResizeHandleTarget(target)
-      if (columnIndex === null) return false
-      startTableColumnRailResize(pointerId, columnIndex, clientX)
-      return true
-    },
-    [startTableColumnRailResize]
-  )
-
-  const stopTableColumnRailResize = useCallback(() => {
-    tableColumnRailResizeRef.current = null
-    setIsTableColumnResizeActive(false)
-    hideTableColumnDragGuide()
-    clearWindowTextSelection()
-    setColumnResizeUserSelectSuppressed(false)
-    if (typeof document !== "undefined") {
-      document.body.style.removeProperty("cursor")
-    }
-  }, [clearWindowTextSelection, hideTableColumnDragGuide, setColumnResizeUserSelectSuppressed])
-
   const syncTableQuickRailFromElement = useCallback((
     element: Element | null,
     hoverClientX?: number,
@@ -1481,10 +461,8 @@ export const useBlockEditorTableOverlayController = ({
       showCellMenu: hasHoverPoint ? showCellMenu : prev.showCellMenu,
     }))
   }, [cancelTableQuickRailHide, hideTableQuickRailImmediately, syncHoveredTableCellMenuLayout])
-
   const stabilizeTableSelectionSurface = useCallback((nextEditor?: TiptapEditor | null) => {
     if (typeof window === "undefined") return
-
     const run = () => {
       const activeEditor = nextEditor ?? editorRef.current
       if (!activeEditor) return
@@ -1494,226 +472,19 @@ export const useBlockEditorTableOverlayController = ({
       syncTableQuickRailFromElement(anchorCell)
       setSelectionTick((prev) => prev + 1)
     }
-
     const schedule = (remainingFrames: number) => {
       run()
       if (remainingFrames <= 1) return
       window.requestAnimationFrame(() => schedule(remainingFrames - 1))
     }
-
     window.requestAnimationFrame(() => schedule(4))
   }, [editorRef, resolveTableQuickRailAnchorElement, setSelectionTick, syncTableQuickRailFromElement])
-
   useEffect(() => {
     tableAffordanceGeometryRef.current = tableAffordanceGeometry
   }, [tableAffordanceGeometry])
-
   useEffect(() => {
     tableAffordanceVisibilityRef.current = tableAffordanceVisibility
   }, [tableAffordanceVisibility])
-
-
-  useEffect(() => {
-    if (typeof window === "undefined") return
-
-    const handlePointerMove = (event: PointerEvent) => {
-      const state = tableRowResizeRef.current
-      if (!state) return
-      const nextHeight = Math.max(
-        TABLE_MIN_ROW_HEIGHT_PX,
-        Math.round(state.startHeight + (event.clientY - state.startY))
-      )
-      state.row.style.height = `${nextHeight}px`
-      state.cells.forEach((cell) => {
-        cell.style.height = `${nextHeight}px`
-        cell.style.minHeight = `${nextHeight}px`
-      })
-    }
-
-    const handlePointerUp = () => {
-      const state = tableRowResizeRef.current
-      if (state) {
-        const committedHeight = Math.max(
-          TABLE_MIN_ROW_HEIGHT_PX,
-          Math.round(state.row.getBoundingClientRect().height)
-        )
-        commitTableRowHeight(state.row, committedHeight)
-      }
-      stopTableRowResize()
-    }
-
-    window.addEventListener("pointermove", handlePointerMove)
-    window.addEventListener("pointerup", handlePointerUp)
-    window.addEventListener("pointercancel", handlePointerUp)
-
-    return () => {
-      window.removeEventListener("pointermove", handlePointerMove)
-      window.removeEventListener("pointerup", handlePointerUp)
-      window.removeEventListener("pointercancel", handlePointerUp)
-      stopTableRowResize()
-    }
-  }, [commitTableRowHeight, stopTableRowResize])
-
-  useEffect(() => {
-    if (typeof window === "undefined") return
-
-    const handlePointerMove = (event: PointerEvent) => {
-      const state = tableColumnRailResizeRef.current
-      if (!state || state.pointerId !== event.pointerId) return
-      const nextClientX = event.clientX
-      const resizeResult = resizeTableColumnBySessionDelta(
-        state.columnIndex,
-        state.baseWidths,
-        nextClientX - state.startClientX,
-        state.overflowMode,
-        state.budget
-      )
-      if (
-        state.overflowMode !== TABLE_OVERFLOW_MODE_WIDE &&
-        didTableColumnResizeHitOverflowPolicy(nextClientX - state.startClientX, resizeResult)
-      ) {
-        showTableOverflowCoachmark()
-      } else if (nextClientX <= state.startClientX) {
-        hideTableOverflowCoachmark()
-      }
-      updateTableColumnDragGuideForColumn(state.columnIndex)
-    }
-
-    const handlePointerUp = (event: PointerEvent) => {
-      const state = tableColumnRailResizeRef.current
-      if (!state || state.pointerId !== event.pointerId) return
-      const resizeResult = resizeTableColumnBySessionDelta(
-        state.columnIndex,
-        state.baseWidths,
-        event.clientX - state.startClientX,
-        state.overflowMode,
-        state.budget
-      )
-      if (
-        state.overflowMode !== TABLE_OVERFLOW_MODE_WIDE &&
-        didTableColumnResizeHitOverflowPolicy(event.clientX - state.startClientX, resizeResult)
-      ) {
-        showTableOverflowCoachmark()
-      }
-      stopTableColumnRailResize()
-    }
-
-    window.addEventListener("pointermove", handlePointerMove)
-    window.addEventListener("pointerup", handlePointerUp)
-    window.addEventListener("pointercancel", handlePointerUp)
-
-    return () => {
-      window.removeEventListener("pointermove", handlePointerMove)
-      window.removeEventListener("pointerup", handlePointerUp)
-      window.removeEventListener("pointercancel", handlePointerUp)
-      stopTableColumnRailResize()
-    }
-  }, [
-    hideTableOverflowCoachmark,
-    resizeTableColumnBySessionDelta,
-    showTableOverflowCoachmark,
-    stopTableColumnRailResize,
-    updateTableColumnDragGuideForColumn,
-  ])
-
-  useEffect(() => {
-    if (typeof window === "undefined") return
-
-    const updateCornerPreview = (pointerId: number, clientX: number, clientY: number) => {
-      const state = tableCornerGrowRef.current
-      if (!state || state.pointerId !== pointerId) return
-
-      const totalTravelX = clientX - state.startClientX
-      const totalTravelY = clientY - state.startClientY
-      if (
-        Math.abs(totalTravelX) > TABLE_CORNER_DRAG_CLICK_GUARD_PX ||
-        Math.abs(totalTravelY) > TABLE_CORNER_DRAG_CLICK_GUARD_PX
-      ) {
-        tableCornerGrowSuppressClickRef.current = true
-      }
-      updateTableCornerPreviewState((prev) => {
-        const next = resolveTableCornerPreviewState(state, clientX, clientY)
-        if (
-          prev.visible === next.visible &&
-          prev.left === next.left &&
-          prev.top === next.top &&
-          prev.width === next.width &&
-          prev.height === next.height &&
-          prev.columnSteps === next.columnSteps &&
-          prev.rowSteps === next.rowSteps
-        ) {
-          return prev
-        }
-        return next
-      })
-    }
-
-    const handlePointerMove = (event: PointerEvent) => {
-      updateCornerPreview(event.pointerId, event.clientX, event.clientY)
-    }
-
-    const handlePointerUp = (event: PointerEvent) => {
-      const state = tableCornerGrowRef.current
-      if (!state || state.pointerId !== event.pointerId) return
-      const nextPreview = tableCornerPreviewStateRef.current
-      applyTableCornerGrowSteps(nextPreview.columnSteps, nextPreview.rowSteps)
-      stopTableCornerGrow()
-    }
-
-    const handleMouseMove = (event: MouseEvent) => {
-      updateCornerPreview(TABLE_CORNER_GROW_MOUSE_POINTER_ID, event.clientX, event.clientY)
-    }
-
-    const handleMouseUp = (event: MouseEvent) => {
-      const state = tableCornerGrowRef.current
-      if (!state || state.pointerId !== TABLE_CORNER_GROW_MOUSE_POINTER_ID) return
-      const nextPreview = tableCornerPreviewStateRef.current
-      applyTableCornerGrowSteps(nextPreview.columnSteps, nextPreview.rowSteps)
-      stopTableCornerGrow()
-    }
-
-    window.addEventListener("pointermove", handlePointerMove)
-    window.addEventListener("pointerup", handlePointerUp)
-    window.addEventListener("pointercancel", handlePointerUp)
-    window.addEventListener("mousemove", handleMouseMove)
-    window.addEventListener("mouseup", handleMouseUp)
-
-    return () => {
-      window.removeEventListener("pointermove", handlePointerMove)
-      window.removeEventListener("pointerup", handlePointerUp)
-      window.removeEventListener("pointercancel", handlePointerUp)
-      window.removeEventListener("mousemove", handleMouseMove)
-      window.removeEventListener("mouseup", handleMouseUp)
-      stopTableCornerGrow()
-    }
-  }, [applyTableCornerGrowSteps, stopTableCornerGrow, updateTableCornerPreviewState])
-
-
-  const isTableMode = isTableSelectionActive(editor)
-  const isTableStructuralSelection = useMemo(() => {
-    if (!editor) return false
-    void selectionTick
-    const { selection } = editor.state
-    return selection instanceof CellSelection
-  }, [editor, selectionTick])
-  const currentTableAxisSelection = useMemo(() => {
-    if (!editor || !isTableStructuralSelection) return null
-    void selectionTick
-    let rect: ReturnType<typeof selectedRect> | null = null
-    try {
-      rect = selectedRect(editor.state)
-    } catch {
-      rect = null
-    }
-    if (!rect) return null
-    if (rect.left === 0 && rect.right === rect.map.width && rect.bottom === rect.top + 1) {
-      return { axis: "row" as const, index: rect.top }
-    }
-    if (rect.top === 0 && rect.bottom === rect.map.height && rect.right === rect.left + 1) {
-      return { axis: "column" as const, index: rect.left }
-    }
-    return null
-  }, [editor, isTableStructuralSelection, selectionTick])
   const {
     tableMenuKind,
     isAnyTableMenuOpen,
@@ -1767,25 +538,6 @@ export const useBlockEditorTableOverlayController = ({
       hideTableOverflowCoachmark()
     }
   }, [activeTableStructureState.overflowMode, hideTableOverflowCoachmark, tableMenuState])
-  const canMergeSelectedTableCells = useMemo(() => {
-    if (!editor) return false
-    void selectionTick
-    try {
-      return editor.can().chain().focus().mergeCells().run()
-    } catch {
-      return false
-    }
-  }, [editor, selectionTick])
-  const canSplitSelectedTableCell = useMemo(() => {
-    if (!editor) return false
-    void selectionTick
-    try {
-      return editor.can().chain().focus().splitCell().run()
-    } catch {
-      return false
-    }
-  }, [editor, selectionTick])
-
   useEffect(() => {
     const currentEditor = editorRef.current
     if (!currentEditor || !isTableStructuralSelection) return
@@ -1794,226 +546,27 @@ export const useBlockEditorTableOverlayController = ({
     if (!anchorElement) return
     syncTableQuickRailFromElement(anchorElement)
   }, [editorRef, isTableStructuralSelection, selectionTick, syncTableQuickRailFromElement])
-
-
-  const updateActiveTableCellAttrs = useCallback(
-    (attrs: Record<string, unknown>) => {
-      if (!editor) return
-      const entries = Object.entries(attrs)
-      if (entries.length === 0) return
-
-      const cellPositions = new Set<number>()
-      const { selection } = editor.state
-
-      if (selection instanceof CellSelection) {
-        selection.forEachCell((_node, pos) => {
-          cellPositions.add(pos)
-        })
-      } else {
-        const collectFromResolvedPos = (resolvedPos: typeof selection.$from) => {
-          for (let depth = resolvedPos.depth; depth >= 0; depth -= 1) {
-            const nodeTypeName = resolvedPos.node(depth).type.name
-            if (nodeTypeName !== "tableCell" && nodeTypeName !== "tableHeader") continue
-            cellPositions.add(resolvedPos.before(depth))
-            return
-          }
-        }
-
-        collectFromResolvedPos(selection.$from)
-        collectFromResolvedPos(selection.$to)
-      }
-
-      if (cellPositions.size > 0) {
-        let transaction = editor.state.tr
-        let changed = false
-
-        cellPositions.forEach((cellPos) => {
-          const cellNode = transaction.doc.nodeAt(cellPos)
-          if (!cellNode) return
-
-          const nextAttrs = { ...(cellNode.attrs || {}) }
-          let cellChanged = false
-          entries.forEach(([name, value]) => {
-            if (nextAttrs[name] === value) return
-            nextAttrs[name] = value
-            cellChanged = true
-          })
-
-          if (!cellChanged) return
-          transaction = transaction.setNodeMarkup(cellPos, undefined, nextAttrs, cellNode.marks)
-          changed = true
-        })
-
-        if (changed) {
-          editor.view.dispatch(transaction)
-          setSelectionTick((prev) => prev + 1)
-        }
-        return
-      }
-
-      const chain = editor.chain().focus()
-      const cellNodeType = editor.isActive("tableHeader") ? "tableHeader" : "tableCell"
-      chain.updateAttributes(cellNodeType, attrs).run()
-    },
-    [editor, setSelectionTick]
-  )
-
-  const updateActiveTableOverflowMode = useCallback(
-    (activeEditor: TiptapEditor, overflowMode: "normal" | "wide") => {
-      const tableRect = getCurrentSelectedTableRect(activeEditor)
-      const tablePos = tableRect ? Math.max(0, tableRect.tableStart - 1) : null
-      if (!tableRect || tablePos === null) return false
-
-      const tableNode = activeEditor.state.doc.nodeAt(tablePos)
-      if (!tableNode || tableNode.type.name !== "table") return false
-      if (getTableOverflowMode(tableNode) === overflowMode) return true
-
-      activeEditor.view.dispatch(
-        activeEditor.state.tr.setNodeMarkup(tablePos, undefined, {
-          ...tableNode.attrs,
-          overflowMode,
-        })
-      )
-      setSelectionTick((prev) => prev + 1)
-      return true
-    },
-    [getCurrentSelectedTableRect, setSelectionTick]
-  )
-
-  const selectCurrentTableAxis = useCallback(
-    (axis: "row" | "column") => {
-      if (!editor || !isTableSelectionActive(editor)) return
-
-      let anchorCellPos = -1
-      let headCellPos = -1
-      try {
-        const rect = selectedRect(editor.state)
-        if (rect.bottom <= rect.top || rect.right <= rect.left) return
-        anchorCellPos = rect.tableStart + rect.map.positionAt(rect.top, rect.left, rect.table)
-        headCellPos = rect.tableStart + rect.map.positionAt(rect.bottom - 1, rect.right - 1, rect.table)
-      } catch {
-        return
-      }
-
-      const anchorResolved = resolveDocPosSafe(editor, anchorCellPos)
-      const headResolved = resolveDocPosSafe(editor, headCellPos)
-      if (!anchorResolved || !headResolved) return
-
-      const selection =
-        axis === "row"
-          ? CellSelection.rowSelection(anchorResolved, headResolved)
-          : CellSelection.colSelection(anchorResolved, headResolved)
-
-      clearStickyTopLevelBlockSelection()
-      editor.view.dispatch(editor.state.tr.setSelection(selection))
-      focusElementWithoutScroll(editor.view.dom)
-    },
-    [clearStickyTopLevelBlockSelection, editor]
-  )
-
-  const selectActiveTableBlock = useCallback(() => {
-    if (!editor) return
-    const blockIndex = getTopLevelBlockIndexFromSelection(editor)
-    const position = getTopLevelBlockPosition(editor, blockIndex)
-    const targetNode = editor.state.doc.nodeAt(position)
-    if (!targetNode || targetNode.type.name !== "table") return
-    const selection = NodeSelection.create(editor.state.doc, position)
-    editor.view.dispatch(editor.state.tr.setSelection(selection))
-    focusElementWithoutScroll(editor.view.dom)
-  }, [editor])
-
-
-  const activeTableCellNodeType =
-    editor?.isActive("tableHeader") ?? false ? "tableHeader" : "tableCell"
-  const activeTableCellAttrs = editor?.getAttributes(activeTableCellNodeType) || {}
-
-  useEffect(() => {
-    if (isTableStructuralSelection) return
-    setTableMenuState(null)
-  }, [isTableStructuralSelection])
-
-
-  const closeTableMenu = useCallback(() => setTableMenuState(null), [])
-
-  const runTableMenuEditorAction = useCallback(
-    (action: (activeEditor: TiptapEditor) => void) => {
-      if (!editor) {
-        closeTableMenu()
-        return
-      }
-
-      action(editor)
-      closeTableMenu()
-      stabilizeTableSelectionSurface(editor)
-    },
-    [closeTableMenu, editor, stabilizeTableSelectionSurface]
-  )
-
-  const openTableMenu = useCallback((kind: TableMenuKind, anchorRect: DOMRect) => {
-    cancelTableQuickRailHide()
-    setTableMenuState((prev) =>
-      resolveTableMenuState(
-        prev,
-        kind,
-        anchorRect,
-        typeof window === "undefined"
-          ? null
-          : {
-              width: window.innerWidth,
-              height: window.innerHeight,
-            }
-      )
-    )
-  }, [cancelTableQuickRailHide])
-
-  const openSelectionAwareTableMenu = useCallback(
-    (kind: TableMenuKind, anchorRect: DOMRect) => {
-      if (kind === "row") {
-        selectCurrentTableAxis("row")
-      } else if (kind === "column") {
-        selectCurrentTableAxis("column")
-      } else {
-        selectActiveTableBlock()
-      }
-      openTableMenu(kind, anchorRect)
-    },
-    [openTableMenu, selectActiveTableBlock, selectCurrentTableAxis]
-  )
-
-  const handleTableColumnRailSegmentClick = useCallback(
-    (columnIndex: number, anchorRect: DOMRect) => {
-      const selected = selectTableColumnByIndex(columnIndex)
-      if (!selected) return
-      setTableAffordanceGeometry((prev) => ({ ...prev, columnIndex }))
-      openTableMenu("column", anchorRect)
-    },
-    [openTableMenu, selectTableColumnByIndex]
-  )
-
-  const handleTableRowGripClick = useCallback(
-    (rowIndex: number, anchorRect: DOMRect) => {
-      const selected = selectTableRowByIndex(rowIndex)
-      if (!selected) return
-      setTableAffordanceGeometry((prev) => ({ ...prev, rowIndex }))
-      openTableMenu("row", anchorRect)
-    },
-    [openTableMenu, selectTableRowByIndex]
-  )
-
-
-  useEffect(() => {
-    if (typeof document === "undefined" || !draggedTableAxisState) return
-    const previousCursor = document.body.style.cursor
-    const previousUserSelect = document.body.style.userSelect
-    document.body.style.cursor = draggedTableAxisState.axis === "column" ? "col-resize" : "grabbing"
-    document.body.style.userSelect = "none"
-    return () => {
-      document.body.style.cursor = previousCursor
-      document.body.style.userSelect = previousUserSelect
-    }
-  }, [draggedTableAxisState])
-
-
+  const {
+    activeTableCellAttrs,
+    canMergeSelectedTableCells,
+    canSplitSelectedTableCell,
+    openSelectionAwareTableMenu,
+    openTableMenu,
+    runTableMenuEditorAction,
+    selectCurrentTableAxis,
+    updateActiveTableCellAttrs,
+    updateActiveTableOverflowMode,
+  } = useBlockEditorTableOverlayMenu({
+    cancelTableQuickRailHide,
+    clearStickyTopLevelBlockSelection,
+    editor,
+    getCurrentSelectedTableRect,
+    isTableStructuralSelection,
+    setSelectionTick,
+    setTableMenuState,
+    stabilizeTableSelectionSurface,
+    tableMenuState,
+  })
   useEffect(() => {
     if (typeof window === "undefined") return
     const mediaQuery = window.matchMedia(DESKTOP_TABLE_RAIL_MEDIA_QUERY)
@@ -2022,15 +575,6 @@ export const useBlockEditorTableOverlayController = ({
     mediaQuery.addEventListener?.("change", sync)
     return () => mediaQuery.removeEventListener?.("change", sync)
   }, [])
-
-
-  useEffect(() => {
-    return () => {
-      clearPendingTableAxisDrag()
-    }
-  }, [clearPendingTableAxisDrag])
-
-
   const shouldTrackSelectionLayoutSync =
     tableAffordanceVisibility.visible ||
     isTableQuickRailHovered ||
@@ -2048,7 +592,6 @@ export const useBlockEditorTableOverlayController = ({
     !draggedTableAxisState &&
     !tableAxisReorderIndicatorState.visible
   const shouldSyncSelectionLayoutImmediately = isTableColumnResizeActive || tableColumnDragGuideState.visible || Boolean(draggedTableAxisState) || tableAxisReorderIndicatorState.visible
-
   useEffect(() => {
     if (typeof window === "undefined" || !shouldTrackSelectionLayoutSync) return
     let rafId: number | null = null
@@ -2100,8 +643,6 @@ export const useBlockEditorTableOverlayController = ({
       }
     }
   }, [setSelectionTick, shouldSyncSelectionLayoutImmediately, shouldThrottleSelectionLayoutSync, shouldTrackSelectionLayoutSync])
-
-
   useEffect(() => {
     if (!tableAffordanceVisibility.visible && !isTableQuickRailHovered && !tableMenuState) return
     const anchorCell = resolveTableQuickRailAnchorElement()
@@ -2133,15 +674,12 @@ export const useBlockEditorTableOverlayController = ({
     tableMenuState,
     tableAffordanceVisibility.visible,
   ])
-
   useEffect(() => {
     if (typeof window === "undefined" || isCoarsePointer || (!tableAffordanceVisibility.visible && !isTableQuickRailHovered)) return
     if (tableColumnRailResizeRef.current || tableRowResizeRef.current) return
-
     const anchorElement = resolveTableQuickRailAnchorElement()
     const tableElement = anchorElement?.closest("table") as HTMLTableElement | null
     if (!anchorElement || !tableElement) return
-
     const tableRect = tableElement.getBoundingClientRect()
     const nextWidth = Math.round(tableRect.width)
     const nextSegments = Array.from(
@@ -2155,16 +693,13 @@ export const useBlockEditorTableOverlayController = ({
           width: Math.round(cellRect.width),
         }
       })
-
     const segmentsChanged =
       nextSegments.length !== tableAffordanceGeometry.columnSegments.length ||
       nextSegments.some((segment, index) => {
         const prev = tableAffordanceGeometry.columnSegments[index]
         return !prev || Math.abs(prev.left - segment.left) > 2 || Math.abs(prev.width - segment.width) > 2
       })
-
     if (Math.abs(nextWidth - tableAffordanceGeometry.width) <= 2 && !segmentsChanged) return
-
     syncTableQuickRailFromElement(anchorElement)
   }, [
     isCoarsePointer,
@@ -2175,18 +710,16 @@ export const useBlockEditorTableOverlayController = ({
     tableAffordanceGeometry.columnSegments,
     tableAffordanceVisibility.visible,
     tableAffordanceGeometry.width,
+    tableColumnRailResizeRef,
+    tableRowResizeRef,
   ])
-
   useEffect(() => {
     if (typeof window === "undefined" || typeof MutationObserver === "undefined") return
     if (isCoarsePointer || (!tableAffordanceVisibility.visible && !isTableQuickRailHovered)) return
-
     const resolveAnchorElement = () => resolveTableQuickRailAnchorElement()
-
     const initialAnchorElement = resolveAnchorElement()
     const tableElement = initialAnchorElement?.closest("table") as HTMLTableElement | null
     if (!initialAnchorElement || !tableElement) return
-
     let rafId: number | null = null
     const requestSync = () => {
       if (rafId !== null) {
@@ -2197,31 +730,26 @@ export const useBlockEditorTableOverlayController = ({
         syncTableQuickRailFromElement(resolveAnchorElement())
       })
     }
-
     const resizeObserver =
       typeof ResizeObserver !== "undefined"
         ? new ResizeObserver(() => {
             requestSync()
           })
         : null
-
     resizeObserver?.observe(tableElement)
     const firstRow = tableElement.querySelector("thead tr, tbody tr, tr")
     if (firstRow instanceof HTMLElement) {
       resizeObserver?.observe(firstRow)
     }
-
     const mutationObserver = new MutationObserver(() => {
       requestSync()
     })
-
     mutationObserver.observe(tableElement, {
       childList: true,
       subtree: true,
       attributes: true,
       attributeFilter: ["colspan", "rowspan", "style", "class"],
     })
-
     return () => {
       if (rafId !== null) {
         window.cancelAnimationFrame(rafId)
@@ -2230,8 +758,6 @@ export const useBlockEditorTableOverlayController = ({
       mutationObserver.disconnect()
     }
   }, [isCoarsePointer, isTableQuickRailHovered, resolveTableQuickRailAnchorElement, selectionTick, syncTableQuickRailFromElement, tableAffordanceVisibility.visible])
-
-
   useEffect(() => {
     if (typeof window === "undefined" || !tableMenuState) return
     const scrollOptions: AddEventListenerOptions = { capture: true, passive: true }
@@ -2249,7 +775,6 @@ export const useBlockEditorTableOverlayController = ({
       window.removeEventListener("resize", closeOnViewportChange, resizeOptions)
     }
   }, [hideTableQuickRailImmediately, tableMenuState])
-
   useEffect(() => {
     if (typeof window === "undefined" || !tableMenuState) return
     const close = (event: PointerEvent | KeyboardEvent) => {
@@ -2276,7 +801,6 @@ export const useBlockEditorTableOverlayController = ({
       window.removeEventListener("keydown", close)
     }
   }, [tableMenuState])
-
   const shouldShowTableCellMenu =
     currentTableAxisSelection === null &&
     !shouldUseCompactTableAffordance &&
@@ -2308,36 +832,35 @@ export const useBlockEditorTableOverlayController = ({
     if (typeof window === "undefined") return null
     return resolveDesktopTableRailLayout(tableAffordanceGeometry)
   }, [tableAffordanceGeometry])
-  const tableCornerGrowStepMetrics = resolveTableCornerGrowStepMetrics(tableAffordanceGeometry)
   const shouldShowCellMergeSection = canMergeSelectedTableCells || canSplitSelectedTableCell
-
+  const {
+    clearHoveredTableCellMenuLayout,
+    clearTrackedTableHover,
+    handleTableColumnRailSegmentClick,
+    handleTableRowGripClick,
+    handleTableViewportPointerLeave,
+    setTableQuickRailHovered,
+    syncTrackedHoveredTableCellMenuLayout,
+  } = useBlockEditorTableOverlayInteractionHandlers({
+    activeTableElementRef,
+    hoveredTableElementRef,
+    openTableMenu,
+    scheduleTableQuickRailHide,
+    selectTableColumnByIndex,
+    selectTableRowByIndex,
+    setHoveredTableCellMenuLayout,
+    setIsTableQuickRailHovered,
+    setTableAffordanceGeometry,
+    setViewportRowResizeHot,
+    shouldPersistTableHandles,
+    syncHoveredTableCellMenuLayout,
+    tableHoverAnchorLockUntilRef,
+    tableRowResizeRef,
+  })
   useEffect(() => {
     if (shouldShowDesktopTableHandles) return
     hideTableColumnDragGuide()
   }, [hideTableColumnDragGuide, shouldShowDesktopTableHandles])
-
-
-  const setTableQuickRailHovered = useCallback((hovered: boolean) => {
-    setIsTableQuickRailHovered(hovered)
-  }, [])
-
-  const clearHoveredTableCellMenuLayout = useCallback(() => {
-    setHoveredTableCellMenuLayout(null)
-  }, [])
-
-  const clearTrackedTableHover = useCallback(() => {
-    hoveredTableElementRef.current = null
-    tableHoverAnchorLockUntilRef.current = 0
-    setHoveredTableCellMenuLayout(null)
-  }, [])
-
-  const syncTrackedHoveredTableCellMenuLayout = useCallback(() => {
-    syncHoveredTableCellMenuLayout(hoveredTableElementRef.current ?? activeTableElementRef.current)
-  }, [syncHoveredTableCellMenuLayout])
-
-  const isTableRowResizeActive = useCallback(() => Boolean(tableRowResizeRef.current), [])
-  const isTableColumnRailResizeActive = useCallback(() => Boolean(tableColumnRailResizeRef.current), [])
-
   const hasTableStructuralSelection = useCallback((activeEditor?: TiptapEditor | null) => {
     if (!activeEditor) return false
     const selection = activeEditor.state.selection
@@ -2346,23 +869,10 @@ export const useBlockEditorTableOverlayController = ({
         (selection instanceof NodeSelection && selection.node.type.name === "table")
     )
   }, [])
-
   const isTopLevelInsertBlockedByTableUi = useCallback(
     () => tableAffordanceVisibilityRef.current.visible || tableMenuState !== null,
     [tableMenuState]
   )
-
-  const handleTableViewportPointerLeave = useCallback(() => {
-    setIsTableQuickRailHovered(false)
-    if (!shouldPersistTableHandles) {
-      scheduleTableQuickRailHide()
-    }
-    setHoveredTableCellMenuLayout(null)
-    if (!tableRowResizeRef.current) {
-      setViewportRowResizeHot(false)
-    }
-  }, [scheduleTableQuickRailHide, setViewportRowResizeHot, shouldPersistTableHandles])
-
   return {
     cancelTableQuickRailHide,
     clearHoveredTableCellMenuLayout,
@@ -2379,7 +889,7 @@ export const useBlockEditorTableOverlayController = ({
     isTableColumnRailResizeActive,
     isTableMode,
     isTableRowResizeActive,
-    isTableRowResizeHandleTarget: isRowResizeHandleTarget,
+    isTableRowResizeHandleTarget,
     isTableStructuralSelection,
     isTopLevelInsertBlockedByTableUi,
     layerProps: {
@@ -2429,7 +939,7 @@ export const useBlockEditorTableOverlayController = ({
       tableAxisDragSuppressClickRef,
       tableAxisReorderIndicatorState,
       tableColumnDragGuideState,
-      tableCornerGrowMousePointerId: TABLE_CORNER_GROW_MOUSE_POINTER_ID,
+      tableCornerGrowMousePointerId,
       tableCornerGrowRef,
       tableCornerGrowStepMetrics,
       tableCornerGrowSuppressClickRef,

--- a/front/src/components/editor/useBlockEditorTableOverlayCornerGrow.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayCornerGrow.ts
@@ -1,0 +1,333 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { TableAffordanceGeometry } from "./tableAffordanceModel"
+import {
+  type TableCornerGrowState,
+  type TableCornerGrowStepMetrics,
+  type TableCornerPreviewState,
+  resolveTableCornerGrowStepMetrics,
+  resolveTableCornerGrowStepMetricsFromDataset,
+  resolveTableCornerPreviewState,
+} from "./tableCornerGrowModel"
+import { findActiveRenderedTable } from "./tableRenderedDomModel"
+import {
+  canShrinkTableAxisAtEnd,
+  countShrinkableRenderedTableAxisAtEnd,
+  countShrinkableTableAxisAtEnd,
+} from "./tableStructureModel"
+import type { TableOverlaySelectionRect } from "./useBlockEditorTableOverlayDomAdapter"
+
+type UseBlockEditorTableOverlayCornerGrowArgs = {
+  editorRef: MutableRefObject<TiptapEditor | null>
+  focusRenderedTableCell: (cell: HTMLTableCellElement) => boolean
+  getCurrentSelectedTableRect: (activeEditor?: TiptapEditor | null) => TableOverlaySelectionRect | null
+  selectTableColumnByIndex: (columnIndex: number) => boolean
+  selectTableRowByIndex: (rowIndex: number) => boolean
+  setSelectionTick: Dispatch<SetStateAction<number>>
+  tableAffordanceGeometry: TableAffordanceGeometry
+  tableAffordanceGeometryRef: MutableRefObject<TableAffordanceGeometry>
+  viewportRef: RefObject<HTMLDivElement>
+}
+
+const TABLE_CORNER_GROW_MOUSE_POINTER_ID = -1
+const TABLE_CORNER_DRAG_CLICK_GUARD_PX = 4
+
+export const useBlockEditorTableOverlayCornerGrow = ({
+  editorRef,
+  focusRenderedTableCell,
+  getCurrentSelectedTableRect,
+  selectTableColumnByIndex,
+  selectTableRowByIndex,
+  setSelectionTick,
+  tableAffordanceGeometry,
+  tableAffordanceGeometryRef,
+  viewportRef,
+}: UseBlockEditorTableOverlayCornerGrowArgs) => {
+  const tableCornerGrowRef = useRef<TableCornerGrowState | null>(null)
+  const tableCornerGrowSuppressClickRef = useRef(false)
+  const tableCornerPreviewStateRef = useRef<TableCornerPreviewState>({
+    visible: false,
+    left: 0,
+    top: 0,
+    width: 0,
+    height: 0,
+    columnSteps: 0,
+    rowSteps: 0,
+  })
+  const [tableCornerPreviewState, setTableCornerPreviewState] = useState<TableCornerPreviewState>({
+    visible: false,
+    left: 0,
+    top: 0,
+    width: 0,
+    height: 0,
+    columnSteps: 0,
+    rowSteps: 0,
+  })
+  const [isTableCornerGrowActive, setIsTableCornerGrowActive] = useState(false)
+
+  const updateTableCornerPreviewState = useCallback(
+    (
+      nextState:
+        | TableCornerPreviewState
+        | ((prev: TableCornerPreviewState) => TableCornerPreviewState)
+    ) => {
+      setTableCornerPreviewState((prev) => {
+        const resolved =
+          typeof nextState === "function"
+            ? (nextState as (prev: TableCornerPreviewState) => TableCornerPreviewState)(prev)
+            : nextState
+        tableCornerPreviewStateRef.current = resolved
+        return resolved
+      })
+    },
+    []
+  )
+
+  const appendTableAxisAtEnd = useCallback(
+    (axis: "row" | "column") => {
+      const currentEditor = editorRef.current
+      if (!currentEditor) return false
+      let rect = getCurrentSelectedTableRect(currentEditor)
+      if (!rect) {
+        const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
+        const fallbackCell = renderedTable?.querySelector<HTMLTableCellElement>(
+          "tr:last-child > th:last-child, tr:last-child > td:last-child"
+        )
+        if (fallbackCell && focusRenderedTableCell(fallbackCell)) {
+          rect = getCurrentSelectedTableRect(currentEditor)
+        }
+      }
+      if (!rect) return false
+
+      const selected =
+        axis === "column"
+          ? selectTableColumnByIndex(rect.map.width - 1)
+          : selectTableRowByIndex(rect.map.height - 1)
+      if (!selected) return false
+
+      const chain = currentEditor.chain().focus()
+      axis === "column" ? chain.addColumnAfter() : chain.addRowAfter()
+      return chain.run()
+    },
+    [editorRef, focusRenderedTableCell, getCurrentSelectedTableRect, selectTableColumnByIndex, selectTableRowByIndex, tableAffordanceGeometryRef, viewportRef]
+  )
+
+  const shrinkTableAxisAtEnd = useCallback(
+    (axis: "row" | "column") => {
+      const currentEditor = editorRef.current
+      if (!currentEditor) return false
+      let rect = getCurrentSelectedTableRect(currentEditor)
+      if (!rect) {
+        const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
+        const fallbackCell = renderedTable?.querySelector<HTMLTableCellElement>(
+          "tr:last-child > th:last-child, tr:last-child > td:last-child"
+        )
+        if (fallbackCell && focusRenderedTableCell(fallbackCell)) {
+          rect = getCurrentSelectedTableRect(currentEditor)
+        }
+      }
+      if (!rect || !canShrinkTableAxisAtEnd(rect.table, axis)) return false
+
+      const trailingIndex = axis === "column" ? rect.map.width - 1 : rect.map.height - 1
+      if (trailingIndex < 0) return false
+
+      const selected =
+        axis === "column" ? selectTableColumnByIndex(trailingIndex) : selectTableRowByIndex(trailingIndex)
+      if (!selected) return false
+
+      const chain = currentEditor.chain().focus()
+      axis === "column" ? chain.deleteColumn() : chain.deleteRow()
+      return chain.run()
+    },
+    [editorRef, focusRenderedTableCell, getCurrentSelectedTableRect, selectTableColumnByIndex, selectTableRowByIndex, tableAffordanceGeometryRef, viewportRef]
+  )
+
+  const growTableFromCorner = useCallback(() => {
+    const appendedColumn = appendTableAxisAtEnd("column")
+    const appendedRow = appendTableAxisAtEnd("row")
+    return appendedColumn || appendedRow
+  }, [appendTableAxisAtEnd])
+
+  const applyTableCornerGrowSteps = useCallback(
+    (columnSteps: number, rowSteps: number) => {
+      let appliedColumnSteps = 0
+      let appliedRowSteps = 0
+
+      while (Math.abs(appliedColumnSteps) < Math.abs(columnSteps)) {
+        const direction = columnSteps > 0 ? 1 : -1
+        const changed = direction > 0 ? appendTableAxisAtEnd("column") : shrinkTableAxisAtEnd("column")
+        if (!changed) break
+        appliedColumnSteps += direction
+      }
+
+      while (Math.abs(appliedRowSteps) < Math.abs(rowSteps)) {
+        const direction = rowSteps > 0 ? 1 : -1
+        const changed = direction > 0 ? appendTableAxisAtEnd("row") : shrinkTableAxisAtEnd("row")
+        if (!changed) break
+        appliedRowSteps += direction
+      }
+
+      if (appliedColumnSteps !== 0 || appliedRowSteps !== 0) {
+        setSelectionTick((prev) => prev + 1)
+      }
+
+      return {
+        appliedColumnSteps,
+        appliedRowSteps,
+      }
+    },
+    [appendTableAxisAtEnd, setSelectionTick, shrinkTableAxisAtEnd]
+  )
+
+  const resolveCurrentTableCornerGrowStepMetrics = useCallback(
+    () => resolveTableCornerGrowStepMetrics(tableAffordanceGeometryRef.current),
+    [tableAffordanceGeometryRef]
+  )
+
+  const resolveTableCornerGrowStepMetricsFromHandle = useCallback(
+    (element: HTMLElement | null) =>
+      resolveTableCornerGrowStepMetricsFromDataset(
+        element?.dataset,
+        resolveCurrentTableCornerGrowStepMetrics()
+      ),
+    [resolveCurrentTableCornerGrowStepMetrics]
+  )
+
+  const stopTableCornerGrow = useCallback(() => {
+    tableCornerGrowRef.current = null
+    updateTableCornerPreviewState((prev) => (prev.visible ? { ...prev, visible: false, columnSteps: 0, rowSteps: 0 } : prev))
+    setIsTableCornerGrowActive(false)
+  }, [updateTableCornerPreviewState])
+
+  const startTableCornerGrow = useCallback(
+    (
+      pointerId: number,
+      clientX: number,
+      clientY: number,
+      stepMetrics?: TableCornerGrowStepMetrics
+    ) => {
+      const { columnStepPx, rowStepPx } = stepMetrics ?? resolveCurrentTableCornerGrowStepMetrics()
+      const currentEditor = editorRef.current
+      const rect = currentEditor ? getCurrentSelectedTableRect(currentEditor) : null
+      const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
+      const maxShrinkColumnSteps = rect
+        ? countShrinkableTableAxisAtEnd(rect.table, "column")
+        : countShrinkableRenderedTableAxisAtEnd(renderedTable, "column")
+      const maxShrinkRowSteps = rect
+        ? countShrinkableTableAxisAtEnd(rect.table, "row")
+        : countShrinkableRenderedTableAxisAtEnd(renderedTable, "row")
+      tableCornerGrowRef.current = {
+        pointerId,
+        startClientX: clientX,
+        startClientY: clientY,
+        baseLeft: tableAffordanceGeometryRef.current.tableLeft,
+        baseTop: tableAffordanceGeometryRef.current.tableTop,
+        baseWidth: tableAffordanceGeometryRef.current.width,
+        baseHeight: tableAffordanceGeometryRef.current.height,
+        columnStepPx,
+        rowStepPx,
+        maxShrinkColumnSteps,
+        maxShrinkRowSteps,
+      }
+      tableCornerGrowSuppressClickRef.current = false
+      updateTableCornerPreviewState({
+        visible: false,
+        left: tableAffordanceGeometryRef.current.tableLeft,
+        top: tableAffordanceGeometryRef.current.tableTop,
+        width: tableAffordanceGeometryRef.current.width,
+        height: tableAffordanceGeometryRef.current.height,
+        columnSteps: 0,
+        rowSteps: 0,
+      })
+      setIsTableCornerGrowActive(true)
+    },
+    [editorRef, getCurrentSelectedTableRect, resolveCurrentTableCornerGrowStepMetrics, tableAffordanceGeometryRef, updateTableCornerPreviewState, viewportRef]
+  )
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const updateCornerPreview = (pointerId: number, clientX: number, clientY: number) => {
+      const state = tableCornerGrowRef.current
+      if (!state || state.pointerId !== pointerId) return
+
+      const totalTravelX = clientX - state.startClientX
+      const totalTravelY = clientY - state.startClientY
+      if (
+        Math.abs(totalTravelX) > TABLE_CORNER_DRAG_CLICK_GUARD_PX ||
+        Math.abs(totalTravelY) > TABLE_CORNER_DRAG_CLICK_GUARD_PX
+      ) {
+        tableCornerGrowSuppressClickRef.current = true
+      }
+      updateTableCornerPreviewState((prev) => {
+        const next = resolveTableCornerPreviewState(state, clientX, clientY)
+        if (
+          prev.visible === next.visible &&
+          prev.left === next.left &&
+          prev.top === next.top &&
+          prev.width === next.width &&
+          prev.height === next.height &&
+          prev.columnSteps === next.columnSteps &&
+          prev.rowSteps === next.rowSteps
+        ) {
+          return prev
+        }
+        return next
+      })
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      updateCornerPreview(event.pointerId, event.clientX, event.clientY)
+    }
+
+    const handlePointerUp = (event: PointerEvent) => {
+      const state = tableCornerGrowRef.current
+      if (!state || state.pointerId !== event.pointerId) return
+      const nextPreview = tableCornerPreviewStateRef.current
+      applyTableCornerGrowSteps(nextPreview.columnSteps, nextPreview.rowSteps)
+      stopTableCornerGrow()
+    }
+
+    const handleMouseMove = (event: MouseEvent) => {
+      updateCornerPreview(TABLE_CORNER_GROW_MOUSE_POINTER_ID, event.clientX, event.clientY)
+    }
+
+    const handleMouseUp = () => {
+      const state = tableCornerGrowRef.current
+      if (!state || state.pointerId !== TABLE_CORNER_GROW_MOUSE_POINTER_ID) return
+      const nextPreview = tableCornerPreviewStateRef.current
+      applyTableCornerGrowSteps(nextPreview.columnSteps, nextPreview.rowSteps)
+      stopTableCornerGrow()
+    }
+
+    window.addEventListener("pointermove", handlePointerMove)
+    window.addEventListener("pointerup", handlePointerUp)
+    window.addEventListener("pointercancel", handlePointerUp)
+    window.addEventListener("mousemove", handleMouseMove)
+    window.addEventListener("mouseup", handleMouseUp)
+
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove)
+      window.removeEventListener("pointerup", handlePointerUp)
+      window.removeEventListener("pointercancel", handlePointerUp)
+      window.removeEventListener("mousemove", handleMouseMove)
+      window.removeEventListener("mouseup", handleMouseUp)
+      stopTableCornerGrow()
+    }
+  }, [applyTableCornerGrowSteps, stopTableCornerGrow, updateTableCornerPreviewState])
+
+  return {
+    appendTableAxisAtEnd,
+    growTableFromCorner,
+    isTableCornerGrowActive,
+    resolveTableCornerGrowStepMetricsFromHandle,
+    shrinkTableAxisAtEnd,
+    startTableCornerGrow,
+    tableCornerGrowMousePointerId: TABLE_CORNER_GROW_MOUSE_POINTER_ID,
+    tableCornerGrowRef,
+    tableCornerGrowStepMetrics: resolveTableCornerGrowStepMetrics(tableAffordanceGeometry),
+    tableCornerGrowSuppressClickRef,
+    tableCornerPreviewState,
+  }
+}

--- a/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
@@ -1,0 +1,255 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import { type Node as ProseMirrorNode } from "@tiptap/pm/model"
+import { TextSelection } from "@tiptap/pm/state"
+import { CellSelection, selectedRect, TableMap } from "@tiptap/pm/tables"
+import type { MutableRefObject, RefObject } from "react"
+import { useCallback } from "react"
+import { getFirstEditableTextPositionInNode } from "./blockSelectionModel"
+import type { TableAffordanceGeometry } from "./tableAffordanceModel"
+import { findActiveRenderedTable, resolveTableScopedSelectedCell } from "./tableRenderedDomModel"
+import { isTableSelectionActive } from "./tableStructureModel"
+
+type UseBlockEditorTableOverlayDomAdapterArgs = {
+  activeTableElementRef: MutableRefObject<HTMLTableElement | null>
+  editorRef: MutableRefObject<TiptapEditor | null>
+  hoveredTableElementRef: MutableRefObject<HTMLTableElement | null>
+  tableAffordanceGeometryRef: MutableRefObject<TableAffordanceGeometry>
+  tableHoverAnchorLockUntilRef: MutableRefObject<number>
+  viewportRef: RefObject<HTMLDivElement>
+}
+
+type SelectedTableRect = ReturnType<typeof selectedRect>
+export type TableOverlaySelectionRect = {
+  bottom?: SelectedTableRect["bottom"]
+  left?: SelectedTableRect["left"]
+  map: SelectedTableRect["map"]
+  right?: SelectedTableRect["right"]
+  table: SelectedTableRect["table"]
+  tableStart: SelectedTableRect["tableStart"]
+  top?: SelectedTableRect["top"]
+}
+
+export const focusElementWithoutScroll = (element: HTMLElement | null) => {
+  if (!element) return
+  if (typeof window === "undefined") {
+    element.focus()
+    return
+  }
+
+  const previousScrollX = window.scrollX
+  const previousScrollY = window.scrollY
+  try {
+    element.focus({ preventScroll: true })
+  } catch {
+    element.focus()
+  }
+  if (window.scrollX !== previousScrollX || window.scrollY !== previousScrollY) {
+    window.scrollTo(previousScrollX, previousScrollY)
+  }
+}
+
+export const resolveDocPosSafe = (editor: TiptapEditor, pos: number) => {
+  if (!Number.isFinite(pos)) return null
+  const normalizedPos = Math.round(pos)
+  const maxPos = editor.state.doc.content.size
+  if (normalizedPos < 0 || normalizedPos > maxPos) return null
+  try {
+    return editor.state.doc.resolve(normalizedPos)
+  } catch {
+    return null
+  }
+}
+
+export const useBlockEditorTableOverlayDomAdapter = ({
+  activeTableElementRef,
+  editorRef,
+  hoveredTableElementRef,
+  tableAffordanceGeometryRef,
+  tableHoverAnchorLockUntilRef,
+  viewportRef,
+}: UseBlockEditorTableOverlayDomAdapterArgs) => {
+  const getTableCellFromTarget = useCallback((target: EventTarget | null) => {
+    const normalizedTarget =
+      target instanceof Element ? target : target instanceof Node ? target.parentElement : null
+    if (!(normalizedTarget instanceof Element)) return null
+    const cell = normalizedTarget.closest("td, th")
+    if (!(cell instanceof HTMLTableCellElement)) return null
+    return cell
+  }, [])
+
+  const getTableCellFromClientPoint = useCallback(
+    (clientX: number, clientY: number, target: EventTarget | null) => {
+      const targetCell = getTableCellFromTarget(target)
+      if (targetCell) return targetCell
+      if (typeof document === "undefined") return null
+
+      const pointElement = document.elementFromPoint(clientX, clientY)
+      const pointCell = pointElement?.closest("td, th")
+      if (pointCell instanceof HTMLTableCellElement) return pointCell
+
+      const normalizedTarget =
+        target instanceof Element ? target : target instanceof Node ? target.parentElement : null
+      const tableSurfaceElement =
+        normalizedTarget?.closest(".aq-table-shell, .tableWrapper, table") ??
+        pointElement?.closest(".aq-table-shell, .tableWrapper, table") ??
+        null
+      const tableElement =
+        tableSurfaceElement instanceof HTMLTableElement
+          ? tableSurfaceElement
+          : (tableSurfaceElement?.querySelector("table") as HTMLTableElement | null)
+      if (!tableElement) return null
+
+      const cells = Array.from(tableElement.querySelectorAll("th, td")).filter(
+        (cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement
+      )
+      return (
+        cells.find((cell) => {
+          const rect = cell.getBoundingClientRect()
+          return clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom
+        }) ?? null
+      )
+    },
+    [getTableCellFromTarget]
+  )
+
+  const getActiveTableRectFromDom = useCallback((activeEditor?: TiptapEditor | null) => {
+    if (!activeEditor) return null
+
+    const tableElement = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
+    const firstCell = tableElement?.querySelector<HTMLElement>(
+      "thead tr:first-of-type > th, thead tr:first-of-type > td, tbody tr:first-of-type > th, tbody tr:first-of-type > td, tr:first-of-type > th, tr:first-of-type > td"
+    )
+    if (!tableElement || !firstCell) return null
+
+    let domPosition = 0
+    try {
+      domPosition = activeEditor.view.posAtDOM(firstCell, 0)
+    } catch {
+      return null
+    }
+
+    const resolvedPosition = resolveDocPosSafe(activeEditor, domPosition)
+    if (!resolvedPosition) return null
+
+    for (let depth = resolvedPosition.depth; depth > 0; depth -= 1) {
+      if (resolvedPosition.node(depth).type.name !== "table") continue
+      const table = resolvedPosition.node(depth)
+      const tableStart = resolvedPosition.start(depth)
+      return {
+        map: TableMap.get(table),
+        table,
+        tableStart,
+      }
+    }
+
+    return null
+  }, [tableAffordanceGeometryRef, viewportRef])
+
+  const getCurrentSelectedTableRect = useCallback((activeEditor?: TiptapEditor | null) => {
+    if (!activeEditor) return null
+    if (isTableSelectionActive(activeEditor)) {
+      try {
+        return selectedRect(activeEditor.state)
+      } catch {
+        return getActiveTableRectFromDom(activeEditor)
+      }
+    }
+
+    return getActiveTableRectFromDom(activeEditor)
+  }, [getActiveTableRectFromDom])
+
+  const resolveTableNodePosition = useCallback((activeEditor: TiptapEditor, tableNode: ProseMirrorNode) => {
+    let tablePos: number | null = null
+    activeEditor.state.doc.descendants((node: ProseMirrorNode, pos: number) => {
+      if (node === tableNode) {
+        tablePos = pos
+        return false
+      }
+      return true
+    })
+    return tablePos
+  }, [])
+
+  const focusRenderedTableCell = useCallback((cell: HTMLTableCellElement) => {
+    const currentEditor = editorRef.current
+    if (!currentEditor) return false
+
+    let domPosition = 0
+    try {
+      domPosition = currentEditor.view.posAtDOM(cell, 0)
+    } catch {
+      return false
+    }
+
+    const resolvedPosition = resolveDocPosSafe(currentEditor, domPosition)
+    if (!resolvedPosition) return false
+
+    for (let depth = resolvedPosition.depth; depth > 0; depth -= 1) {
+      const node = resolvedPosition.node(depth)
+      if (node.type.name !== "tableCell" && node.type.name !== "tableHeader") continue
+
+      const cellPosition = resolvedPosition.before(depth)
+      const cellNode = currentEditor.state.doc.nodeAt(cellPosition)
+      if (!cellNode) return false
+
+      const selectionPos =
+        getFirstEditableTextPositionInNode(cellNode, cellPosition) ?? Math.max(1, cellPosition + 1)
+      currentEditor.view.dispatch(
+        currentEditor.state.tr.setSelection(TextSelection.create(currentEditor.state.doc, selectionPos))
+      )
+      focusElementWithoutScroll(currentEditor.view.dom)
+      return true
+    }
+
+    return false
+  }, [editorRef])
+
+  const resolveTableQuickRailAnchorElement = useCallback(() => {
+    const viewport = viewportRef.current
+    if (!viewport) return null
+
+    const now =
+      typeof window !== "undefined" && typeof window.performance !== "undefined"
+        ? window.performance.now()
+        : Date.now()
+    const hoveredTable =
+      hoveredTableElementRef.current?.isConnected &&
+      viewport.contains(hoveredTableElementRef.current) &&
+      now <= tableHoverAnchorLockUntilRef.current
+        ? hoveredTableElementRef.current
+        : null
+    const renderedTable =
+      hoveredTable ??
+      findActiveRenderedTable(
+        viewport,
+        tableAffordanceGeometryRef.current,
+        activeTableElementRef.current
+      )
+    const selectedCell = resolveTableScopedSelectedCell(renderedTable)
+    if (selectedCell) return selectedCell
+
+    if (!renderedTable) return null
+
+    const rows = Array.from(renderedTable.querySelectorAll("tr")).filter(
+      (node): node is HTMLTableRowElement => node instanceof HTMLTableRowElement
+    )
+    const row = rows[tableAffordanceGeometryRef.current.rowIndex] ?? null
+    if (!row) return renderedTable.querySelector("th, td") as HTMLElement | null
+
+    const cells = Array.from(row.children).filter((node): node is HTMLElement => node instanceof HTMLElement)
+    return (
+      cells[tableAffordanceGeometryRef.current.columnIndex] ??
+      (row.querySelector("th, td") as HTMLElement | null) ??
+      (renderedTable.querySelector("th, td") as HTMLElement | null)
+    )
+  }, [activeTableElementRef, hoveredTableElementRef, tableAffordanceGeometryRef, tableHoverAnchorLockUntilRef, viewportRef])
+
+  return {
+    focusRenderedTableCell,
+    getActiveTableRectFromDom,
+    getCurrentSelectedTableRect,
+    getTableCellFromClientPoint,
+    resolveTableNodePosition,
+    resolveTableQuickRailAnchorElement,
+  }
+}

--- a/front/src/components/editor/useBlockEditorTableOverlayInteractionHandlers.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayInteractionHandlers.ts
@@ -1,0 +1,104 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from "react"
+import { useCallback } from "react"
+import type { TableAffordanceGeometry } from "./tableAffordanceModel"
+import type { TableMenuKind } from "./tableFloatingUiModel"
+
+type UseBlockEditorTableOverlayInteractionHandlersArgs = {
+  activeTableElementRef: MutableRefObject<HTMLTableElement | null>
+  hoveredTableElementRef: MutableRefObject<HTMLTableElement | null>
+  openTableMenu: (kind: TableMenuKind, anchorRect: DOMRect) => void
+  scheduleTableQuickRailHide: (delayMs?: number) => void
+  selectTableColumnByIndex: (columnIndex: number) => boolean
+  selectTableRowByIndex: (rowIndex: number) => boolean
+  setHoveredTableCellMenuLayout: Dispatch<SetStateAction<{ cellMenuLeft: number; cellMenuTop: number } | null>>
+  setIsTableQuickRailHovered: Dispatch<SetStateAction<boolean>>
+  setTableAffordanceGeometry: Dispatch<SetStateAction<TableAffordanceGeometry>>
+  setViewportRowResizeHot: (enabled: boolean) => void
+  shouldPersistTableHandles: boolean
+  syncHoveredTableCellMenuLayout: (tableElement: HTMLTableElement | null, preferredCell?: HTMLElement | null) => void
+  tableHoverAnchorLockUntilRef: MutableRefObject<number>
+  tableRowResizeRef: MutableRefObject<unknown | null>
+}
+
+export const useBlockEditorTableOverlayInteractionHandlers = ({
+  activeTableElementRef,
+  hoveredTableElementRef,
+  openTableMenu,
+  scheduleTableQuickRailHide,
+  selectTableColumnByIndex,
+  selectTableRowByIndex,
+  setHoveredTableCellMenuLayout,
+  setIsTableQuickRailHovered,
+  setTableAffordanceGeometry,
+  setViewportRowResizeHot,
+  shouldPersistTableHandles,
+  syncHoveredTableCellMenuLayout,
+  tableHoverAnchorLockUntilRef,
+  tableRowResizeRef,
+}: UseBlockEditorTableOverlayInteractionHandlersArgs) => {
+  const handleTableColumnRailSegmentClick = useCallback(
+    (columnIndex: number, anchorRect: DOMRect) => {
+      const selected = selectTableColumnByIndex(columnIndex)
+      if (!selected) return
+      setTableAffordanceGeometry((prev) => ({ ...prev, columnIndex }))
+      openTableMenu("column", anchorRect)
+    },
+    [openTableMenu, selectTableColumnByIndex, setTableAffordanceGeometry]
+  )
+
+  const handleTableRowGripClick = useCallback(
+    (rowIndex: number, anchorRect: DOMRect) => {
+      const selected = selectTableRowByIndex(rowIndex)
+      if (!selected) return
+      setTableAffordanceGeometry((prev) => ({ ...prev, rowIndex }))
+      openTableMenu("row", anchorRect)
+    },
+    [openTableMenu, selectTableRowByIndex, setTableAffordanceGeometry]
+  )
+
+  const setTableQuickRailHovered = useCallback((hovered: boolean) => {
+    setIsTableQuickRailHovered(hovered)
+  }, [setIsTableQuickRailHovered])
+
+  const clearHoveredTableCellMenuLayout = useCallback(() => {
+    setHoveredTableCellMenuLayout(null)
+  }, [setHoveredTableCellMenuLayout])
+
+  const clearTrackedTableHover = useCallback(() => {
+    hoveredTableElementRef.current = null
+    tableHoverAnchorLockUntilRef.current = 0
+    setHoveredTableCellMenuLayout(null)
+  }, [hoveredTableElementRef, setHoveredTableCellMenuLayout, tableHoverAnchorLockUntilRef])
+
+  const syncTrackedHoveredTableCellMenuLayout = useCallback(() => {
+    syncHoveredTableCellMenuLayout(hoveredTableElementRef.current ?? activeTableElementRef.current)
+  }, [activeTableElementRef, hoveredTableElementRef, syncHoveredTableCellMenuLayout])
+
+  const handleTableViewportPointerLeave = useCallback(() => {
+    setIsTableQuickRailHovered(false)
+    if (!shouldPersistTableHandles) {
+      scheduleTableQuickRailHide()
+    }
+    setHoveredTableCellMenuLayout(null)
+    if (!tableRowResizeRef.current) {
+      setViewportRowResizeHot(false)
+    }
+  }, [
+    scheduleTableQuickRailHide,
+    setHoveredTableCellMenuLayout,
+    setIsTableQuickRailHovered,
+    setViewportRowResizeHot,
+    shouldPersistTableHandles,
+    tableRowResizeRef,
+  ])
+
+  return {
+    clearHoveredTableCellMenuLayout,
+    clearTrackedTableHover,
+    handleTableColumnRailSegmentClick,
+    handleTableRowGripClick,
+    handleTableViewportPointerLeave,
+    setTableQuickRailHovered,
+    syncTrackedHoveredTableCellMenuLayout,
+  }
+}

--- a/front/src/components/editor/useBlockEditorTableOverlayMenu.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayMenu.ts
@@ -1,0 +1,248 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import { NodeSelection } from "@tiptap/pm/state"
+import { CellSelection, selectedRect } from "@tiptap/pm/tables"
+import type { Dispatch, SetStateAction } from "react"
+import { useCallback, useEffect, useMemo } from "react"
+import { getTopLevelBlockIndexFromSelection, getTopLevelBlockPosition } from "./blockSelectionModel"
+import { resolveTableMenuState, type TableMenuKind, type TableMenuState } from "./tableFloatingUiModel"
+import { getTableOverflowMode } from "./tableWidthModel"
+import { focusElementWithoutScroll, resolveDocPosSafe, type TableOverlaySelectionRect } from "./useBlockEditorTableOverlayDomAdapter"
+
+type UseBlockEditorTableOverlayMenuArgs = {
+  cancelTableQuickRailHide: () => void
+  clearStickyTopLevelBlockSelection: () => void
+  editor: TiptapEditor | null
+  getCurrentSelectedTableRect: (activeEditor?: TiptapEditor | null) => TableOverlaySelectionRect | null
+  isTableStructuralSelection: boolean
+  setSelectionTick: Dispatch<SetStateAction<number>>
+  setTableMenuState: Dispatch<SetStateAction<TableMenuState>>
+  stabilizeTableSelectionSurface: (nextEditor?: TiptapEditor | null) => void
+  tableMenuState: TableMenuState
+}
+
+export const useBlockEditorTableOverlayMenu = ({
+  cancelTableQuickRailHide,
+  clearStickyTopLevelBlockSelection,
+  editor,
+  getCurrentSelectedTableRect,
+  isTableStructuralSelection,
+  setSelectionTick,
+  setTableMenuState,
+  stabilizeTableSelectionSurface,
+  tableMenuState,
+}: UseBlockEditorTableOverlayMenuArgs) => {
+  const updateActiveTableCellAttrs = useCallback(
+    (attrs: Record<string, unknown>) => {
+      if (!editor) return
+      const entries = Object.entries(attrs)
+      if (entries.length === 0) return
+
+      const cellPositions = new Set<number>()
+      const { selection } = editor.state
+
+      if (selection instanceof CellSelection) {
+        selection.forEachCell((_node, pos) => {
+          cellPositions.add(pos)
+        })
+      } else {
+        const collectFromResolvedPos = (resolvedPos: typeof selection.$from) => {
+          for (let depth = resolvedPos.depth; depth >= 0; depth -= 1) {
+            const nodeTypeName = resolvedPos.node(depth).type.name
+            if (nodeTypeName !== "tableCell" && nodeTypeName !== "tableHeader") continue
+            cellPositions.add(resolvedPos.before(depth))
+            return
+          }
+        }
+
+        collectFromResolvedPos(selection.$from)
+        collectFromResolvedPos(selection.$to)
+      }
+
+      if (cellPositions.size > 0) {
+        let transaction = editor.state.tr
+        let changed = false
+
+        cellPositions.forEach((cellPos) => {
+          const cellNode = transaction.doc.nodeAt(cellPos)
+          if (!cellNode) return
+
+          const nextAttrs = { ...(cellNode.attrs || {}) }
+          let cellChanged = false
+          entries.forEach(([name, value]) => {
+            if (nextAttrs[name] === value) return
+            nextAttrs[name] = value
+            cellChanged = true
+          })
+
+          if (!cellChanged) return
+          transaction = transaction.setNodeMarkup(cellPos, undefined, nextAttrs, cellNode.marks)
+          changed = true
+        })
+
+        if (changed) {
+          editor.view.dispatch(transaction)
+          setSelectionTick((prev) => prev + 1)
+        }
+        return
+      }
+
+      const chain = editor.chain().focus()
+      const cellNodeType = editor.isActive("tableHeader") ? "tableHeader" : "tableCell"
+      chain.updateAttributes(cellNodeType, attrs).run()
+    },
+    [editor, setSelectionTick]
+  )
+
+  const updateActiveTableOverflowMode = useCallback(
+    (activeEditor: TiptapEditor, overflowMode: "normal" | "wide") => {
+      const tableRect = getCurrentSelectedTableRect(activeEditor)
+      const tablePos = tableRect ? Math.max(0, tableRect.tableStart - 1) : null
+      if (!tableRect || tablePos === null) return false
+
+      const tableNode = activeEditor.state.doc.nodeAt(tablePos)
+      if (!tableNode || tableNode.type.name !== "table") return false
+      if (getTableOverflowMode(tableNode) === overflowMode) return true
+
+      activeEditor.view.dispatch(
+        activeEditor.state.tr.setNodeMarkup(tablePos, undefined, {
+          ...tableNode.attrs,
+          overflowMode,
+        })
+      )
+      setSelectionTick((prev) => prev + 1)
+      return true
+    },
+    [getCurrentSelectedTableRect, setSelectionTick]
+  )
+
+  const selectCurrentTableAxis = useCallback(
+    (axis: "row" | "column") => {
+      if (!editor) return
+
+      let anchorCellPos = -1
+      let headCellPos = -1
+      try {
+        const rect = selectedRect(editor.state)
+        if (rect.bottom <= rect.top || rect.right <= rect.left) return
+        anchorCellPos = rect.tableStart + rect.map.positionAt(rect.top, rect.left, rect.table)
+        headCellPos = rect.tableStart + rect.map.positionAt(rect.bottom - 1, rect.right - 1, rect.table)
+      } catch {
+        return
+      }
+
+      const anchorResolved = resolveDocPosSafe(editor, anchorCellPos)
+      const headResolved = resolveDocPosSafe(editor, headCellPos)
+      if (!anchorResolved || !headResolved) return
+
+      const selection =
+        axis === "row"
+          ? CellSelection.rowSelection(anchorResolved, headResolved)
+          : CellSelection.colSelection(anchorResolved, headResolved)
+
+      clearStickyTopLevelBlockSelection()
+      editor.view.dispatch(editor.state.tr.setSelection(selection))
+      focusElementWithoutScroll(editor.view.dom)
+    },
+    [clearStickyTopLevelBlockSelection, editor]
+  )
+
+  const selectActiveTableBlock = useCallback(() => {
+    if (!editor) return
+    const blockIndex = getTopLevelBlockIndexFromSelection(editor)
+    const position = getTopLevelBlockPosition(editor, blockIndex)
+    const targetNode = editor.state.doc.nodeAt(position)
+    if (!targetNode || targetNode.type.name !== "table") return
+    const selection = NodeSelection.create(editor.state.doc, position)
+    editor.view.dispatch(editor.state.tr.setSelection(selection))
+    focusElementWithoutScroll(editor.view.dom)
+  }, [editor])
+
+  const activeTableCellNodeType =
+    editor?.isActive("tableHeader") ?? false ? "tableHeader" : "tableCell"
+  const activeTableCellAttrs = editor?.getAttributes(activeTableCellNodeType) || {}
+
+  const canMergeSelectedTableCells = useMemo(() => {
+    if (!editor) return false
+    try {
+      return editor.can().chain().focus().mergeCells().run()
+    } catch {
+      return false
+    }
+  }, [editor])
+
+  const canSplitSelectedTableCell = useMemo(() => {
+    if (!editor) return false
+    try {
+      return editor.can().chain().focus().splitCell().run()
+    } catch {
+      return false
+    }
+  }, [editor])
+
+  useEffect(() => {
+    if (isTableStructuralSelection) return
+    setTableMenuState(null)
+  }, [isTableStructuralSelection, setTableMenuState])
+
+  const closeTableMenu = useCallback(() => setTableMenuState(null), [setTableMenuState])
+
+  const runTableMenuEditorAction = useCallback(
+    (action: (activeEditor: TiptapEditor) => void) => {
+      if (!editor) {
+        closeTableMenu()
+        return
+      }
+
+      action(editor)
+      closeTableMenu()
+      stabilizeTableSelectionSurface(editor)
+    },
+    [closeTableMenu, editor, stabilizeTableSelectionSurface]
+  )
+
+  const openTableMenu = useCallback((kind: TableMenuKind, anchorRect: DOMRect) => {
+    cancelTableQuickRailHide()
+    setTableMenuState((prev) =>
+      resolveTableMenuState(
+        prev,
+        kind,
+        anchorRect,
+        typeof window === "undefined"
+          ? null
+          : {
+              width: window.innerWidth,
+              height: window.innerHeight,
+            }
+      )
+    )
+  }, [cancelTableQuickRailHide, setTableMenuState])
+
+  const openSelectionAwareTableMenu = useCallback(
+    (kind: TableMenuKind, anchorRect: DOMRect) => {
+      if (kind === "row") {
+        selectCurrentTableAxis("row")
+      } else if (kind === "column") {
+        selectCurrentTableAxis("column")
+      } else {
+        selectActiveTableBlock()
+      }
+      openTableMenu(kind, anchorRect)
+    },
+    [openTableMenu, selectActiveTableBlock, selectCurrentTableAxis]
+  )
+
+  return {
+    activeTableCellAttrs,
+    canMergeSelectedTableCells,
+    canSplitSelectedTableCell,
+    closeTableMenu,
+    openSelectionAwareTableMenu,
+    openTableMenu,
+    runTableMenuEditorAction,
+    selectActiveTableBlock,
+    selectCurrentTableAxis,
+    tableMenuState,
+    updateActiveTableCellAttrs,
+    updateActiveTableOverflowMode,
+  }
+}

--- a/front/src/components/editor/useBlockEditorTableOverlayResize.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayResize.ts
@@ -1,0 +1,557 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model"
+import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { TableAffordanceGeometry } from "./tableAffordanceModel"
+import { findActiveRenderedTable, readRenderedColumnWidths, resolveActiveRenderedTableForFloatingUi } from "./tableRenderedDomModel"
+import {
+  type TableColumnDragGuideState,
+  type TableColumnRailResizeState,
+  type TableRowResizeState,
+  createHiddenTableColumnDragGuideState,
+  createTableColumnRailResizeState,
+  createTableRowResizeState,
+  hideTableColumnDragGuideState,
+  isRowResizeHandleTarget,
+  resolveTableColumnDragGuideState,
+  resolveTableColumnIndexFromResizeHandleTarget,
+} from "./tableResizeInteractionModel"
+import { collectSimpleTableColumnCells } from "./tableStructureModel"
+import {
+  TABLE_OVERFLOW_MODE_WIDE,
+  computeNextTableColumnWidthsForResize,
+  didTableColumnResizeHitOverflowPolicy,
+  getTableOverflowMode,
+} from "./tableWidthModel"
+import {
+  applyTableColumnWidthsToTransaction,
+  getCurrentEditorReadableWidthPx,
+  hasExplicitColumnWidth,
+  readColumnWidthFromCell,
+  shouldClampTableWidthBudget,
+} from "./tableWidthRuntime"
+import { resolveDocPosSafe, type TableOverlaySelectionRect } from "./useBlockEditorTableOverlayDomAdapter"
+import { TABLE_MIN_COLUMN_WIDTH_PX, TABLE_MIN_ROW_HEIGHT_PX } from "src/libs/markdown/tableMetadata"
+
+type UseBlockEditorTableOverlayResizeArgs = {
+  activeTableElementRef: MutableRefObject<HTMLTableElement | null>
+  clearWindowTextSelection: () => void
+  editorRef: MutableRefObject<TiptapEditor | null>
+  getCurrentSelectedTableRect: (activeEditor?: TiptapEditor | null) => TableOverlaySelectionRect | null
+  hideTableOverflowCoachmark: () => void
+  isCurrentTableColumnSelection: (columnIndex: number) => boolean
+  resolveTableNodePosition: (activeEditor: TiptapEditor, tableNode: ProseMirrorNode) => number | null
+  selectTableColumnByIndex: (columnIndex: number) => boolean
+  setSelectionTick: Dispatch<SetStateAction<number>>
+  setTableAffordanceGeometry: Dispatch<SetStateAction<TableAffordanceGeometry>>
+  setViewportRowResizeHot: (enabled: boolean) => void
+  showTableOverflowCoachmark: () => void
+  tableAffordanceGeometryRef: MutableRefObject<TableAffordanceGeometry>
+  viewportRef: RefObject<HTMLDivElement>
+}
+
+export const useBlockEditorTableOverlayResize = ({
+  activeTableElementRef,
+  clearWindowTextSelection,
+  editorRef,
+  getCurrentSelectedTableRect,
+  hideTableOverflowCoachmark,
+  isCurrentTableColumnSelection,
+  resolveTableNodePosition,
+  selectTableColumnByIndex,
+  setSelectionTick,
+  setTableAffordanceGeometry,
+  setViewportRowResizeHot,
+  showTableOverflowCoachmark,
+  tableAffordanceGeometryRef,
+  viewportRef,
+}: UseBlockEditorTableOverlayResizeArgs) => {
+  const tableRowResizeRef = useRef<TableRowResizeState | null>(null)
+  const tableColumnRailResizeRef = useRef<TableColumnRailResizeState | null>(null)
+  const [tableColumnDragGuideState, setTableColumnDragGuideState] =
+    useState<TableColumnDragGuideState>(createHiddenTableColumnDragGuideState)
+  const [isTableColumnResizeActive, setIsTableColumnResizeActive] = useState(false)
+
+  const setColumnResizeUserSelectSuppressed = useCallback((suppressed: boolean) => {
+    if (typeof document === "undefined") return
+    if (suppressed) {
+      document.body.style.setProperty("user-select", "none")
+      document.body.style.setProperty("-webkit-user-select", "none")
+      return
+    }
+    document.body.style.removeProperty("user-select")
+    document.body.style.removeProperty("-webkit-user-select")
+  }, [])
+
+  const hideTableColumnDragGuide = useCallback(() => {
+    setTableColumnDragGuideState(hideTableColumnDragGuideState)
+  }, [])
+
+  const updateTableColumnDragGuideForColumn = useCallback(
+    (columnIndex: number) => {
+      const viewport = viewportRef.current
+      if (!viewport) {
+        hideTableColumnDragGuide()
+        return
+      }
+
+      const tableElement = resolveActiveRenderedTableForFloatingUi(
+        viewport,
+        tableAffordanceGeometryRef.current,
+        activeTableElementRef.current
+      )
+      const guideState = resolveTableColumnDragGuideState(tableElement, columnIndex)
+      if (!guideState) {
+        hideTableColumnDragGuide()
+        return
+      }
+      setTableColumnDragGuideState(guideState)
+    },
+    [activeTableElementRef, hideTableColumnDragGuide, tableAffordanceGeometryRef, viewportRef]
+  )
+
+  const stopTableRowResize = useCallback(() => {
+    const state = tableRowResizeRef.current
+    if (state?.row) {
+      state.row.removeAttribute("data-row-resize-active")
+      if (!state.row.getAttribute("data-row-height")) {
+        state.row.style.removeProperty("height")
+      }
+      state.cells.forEach((cell) => {
+        cell.style.removeProperty("height")
+        cell.style.removeProperty("min-height")
+      })
+    }
+    tableRowResizeRef.current = null
+    setViewportRowResizeHot(false)
+    if (typeof document !== "undefined") {
+      document.body.style.removeProperty("cursor")
+    }
+  }, [setViewportRowResizeHot])
+
+  const startTableRowResize = useCallback(
+    (cell: HTMLTableCellElement, clientY: number) => {
+      const resizeState = createTableRowResizeState(cell, clientY)
+      if (!resizeState) return
+
+      resizeState.row.setAttribute("data-row-resize-active", "true")
+      tableRowResizeRef.current = resizeState
+      setViewportRowResizeHot(true)
+      if (typeof document !== "undefined") {
+        document.body.style.cursor = "row-resize"
+      }
+    },
+    [setViewportRowResizeHot]
+  )
+
+  const commitTableRowHeight = useCallback((rowElement: HTMLTableRowElement, nextHeight: number) => {
+    const currentEditor = editorRef.current
+    if (!currentEditor) return
+
+    let domPosition = 0
+    try {
+      domPosition = currentEditor.view.posAtDOM(rowElement, 0)
+    } catch {
+      return
+    }
+    const resolvedPosition = resolveDocPosSafe(currentEditor, domPosition)
+    if (!resolvedPosition) return
+
+    for (let depth = resolvedPosition.depth; depth > 0; depth -= 1) {
+      if (resolvedPosition.node(depth).type.name !== "tableRow") continue
+
+      const rowPosition = resolvedPosition.before(depth)
+      const rowNode = currentEditor.state.doc.nodeAt(rowPosition)
+      if (!rowNode) return
+
+      const normalizedHeight = Math.max(TABLE_MIN_ROW_HEIGHT_PX, nextHeight)
+      const transaction = currentEditor.state.tr.setNodeMarkup(rowPosition, undefined, {
+        ...rowNode.attrs,
+        rowHeightPx: normalizedHeight,
+      })
+      currentEditor.view.dispatch(transaction)
+      return
+    }
+  }, [editorRef])
+
+  const resizeFirstTableRowBy = useCallback((deltaPx: number) => {
+    const currentEditor = editorRef.current
+    if (!currentEditor) return
+    const firstTableRow = viewportRef.current?.querySelector(".aq-block-editor__content table tr") as HTMLTableRowElement | null
+    if (!firstTableRow) return
+    const nextHeight = Math.max(
+      TABLE_MIN_ROW_HEIGHT_PX,
+      Math.round(firstTableRow.getBoundingClientRect().height + deltaPx)
+    )
+    commitTableRowHeight(firstTableRow, nextHeight)
+  }, [commitTableRowHeight, editorRef, viewportRef])
+
+  const getCurrentTableColumnResizeContext = useCallback(
+    (columnIndex: number) => {
+      const currentEditor = editorRef.current
+      if (!currentEditor) return null
+      const rect = getCurrentSelectedTableRect(currentEditor)
+      if (!rect || columnIndex < 0 || columnIndex >= rect.map.width) {
+        return null
+      }
+
+      const tablePos = resolveTableNodePosition(currentEditor, rect.table)
+      if (tablePos === null) {
+        return null
+      }
+
+      const columns = collectSimpleTableColumnCells(rect.table, tablePos)
+      if (!columns || columns.length === 0 || columnIndex >= columns.length) {
+        return null
+      }
+
+      const currentWidths = columns.map((column) => readColumnWidthFromCell(column[0]))
+      const renderedTable = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
+      const renderedColumnWidths = readRenderedColumnWidths(renderedTable)
+      const measuredWidths =
+        columns.some((column) => !hasExplicitColumnWidth(column)) &&
+        renderedColumnWidths.length === columns.length
+          ? renderedColumnWidths
+          : currentWidths
+
+      return {
+        currentEditor,
+        rect,
+        columns,
+        currentWidths,
+        measuredWidths,
+      }
+    },
+    [editorRef, getCurrentSelectedTableRect, resolveTableNodePosition, tableAffordanceGeometryRef, viewportRef]
+  )
+
+  const resizeTableColumnByIndex = useCallback(
+    (columnIndex: number, deltaPx: number) => {
+      if (deltaPx === 0) return { changed: false, appliedDelta: 0 }
+      const resizeContext = getCurrentTableColumnResizeContext(columnIndex)
+      if (!resizeContext) {
+        return { changed: false, appliedDelta: 0 }
+      }
+
+      const { currentEditor, rect, columns, currentWidths, measuredWidths } = resizeContext
+      const nextWidthsResult = computeNextTableColumnWidthsForResize(
+        measuredWidths,
+        columnIndex,
+        deltaPx,
+        shouldClampTableWidthBudget(),
+        getTableOverflowMode(rect.table),
+        getCurrentEditorReadableWidthPx(currentEditor) - 2
+      )
+
+      const applied = applyTableColumnWidthsToTransaction(
+        currentEditor.state.tr,
+        columns,
+        currentWidths,
+        nextWidthsResult.widths
+      )
+      if (!applied.changed) {
+        return { changed: false, appliedDelta: 0, wasClamped: nextWidthsResult.wasClamped }
+      }
+      currentEditor.view.dispatch(applied.transaction)
+      setSelectionTick((prev) => prev + 1)
+      return {
+        changed: true,
+        appliedDelta: nextWidthsResult.widths[columnIndex] - measuredWidths[columnIndex],
+        wasClamped: nextWidthsResult.wasClamped,
+      }
+    },
+    [getCurrentTableColumnResizeContext, setSelectionTick]
+  )
+
+  const resizeTableColumnBySessionDelta = useCallback(
+    (
+      columnIndex: number,
+      baseWidths: number[],
+      totalDeltaPx: number,
+      overflowMode: string,
+      budget: number
+    ) => {
+      const resizeContext = getCurrentTableColumnResizeContext(columnIndex)
+      if (!resizeContext) {
+        return { changed: false, appliedDelta: 0 }
+      }
+
+      const { currentEditor, columns, currentWidths } = resizeContext
+      const nextWidthsResult = computeNextTableColumnWidthsForResize(
+        baseWidths,
+        columnIndex,
+        totalDeltaPx,
+        shouldClampTableWidthBudget(),
+        overflowMode,
+        budget
+      )
+      const applied = applyTableColumnWidthsToTransaction(
+        currentEditor.state.tr,
+        columns,
+        currentWidths,
+        nextWidthsResult.widths
+      )
+      if (!applied.changed) {
+        return { changed: false, appliedDelta: 0, wasClamped: nextWidthsResult.wasClamped }
+      }
+      currentEditor.view.dispatch(applied.transaction)
+      setSelectionTick((prev) => prev + 1)
+      return {
+        changed: true,
+        appliedDelta: nextWidthsResult.widths[columnIndex] - baseWidths[columnIndex],
+        wasClamped: nextWidthsResult.wasClamped,
+      }
+    },
+    [getCurrentTableColumnResizeContext, setSelectionTick]
+  )
+
+  const resizeFirstTableColumnBy = useCallback((deltaPx: number) => {
+    const currentEditor = editorRef.current
+    if (!currentEditor) return
+    const firstCell = viewportRef.current?.querySelector(".aq-block-editor__content table tr:first-of-type > th, .aq-block-editor__content table tr:first-of-type > td") as HTMLElement | null
+    if (!firstCell) return
+
+    let domPosition = 0
+    try {
+      domPosition = currentEditor.view.posAtDOM(firstCell, 0)
+    } catch {
+      return
+    }
+    const resolvedPosition = resolveDocPosSafe(currentEditor, domPosition)
+    if (!resolvedPosition) return
+
+    for (let depth = resolvedPosition.depth; depth > 0; depth -= 1) {
+      const node = resolvedPosition.node(depth)
+      if (node.type.name !== "tableCell" && node.type.name !== "tableHeader") continue
+      const cellPosition = resolvedPosition.before(depth)
+      const cellNode = currentEditor.state.doc.nodeAt(cellPosition)
+      if (!cellNode) return
+      let tableDepth = depth - 1
+      while (tableDepth > 0 && resolvedPosition.node(tableDepth).type.name !== "table") {
+        tableDepth -= 1
+      }
+
+      const tableNode = tableDepth > 0 ? resolvedPosition.node(tableDepth) : null
+      const tablePosition = tableDepth > 0 ? resolvedPosition.before(tableDepth) : null
+      const columns = tableNode && tablePosition !== null
+        ? collectSimpleTableColumnCells(tableNode, tablePosition)
+        : null
+
+      if (!columns || columns.length === 0) {
+        const currentWidth = Array.isArray(cellNode.attrs?.colwidth) && cellNode.attrs.colwidth[0]
+          ? Number(cellNode.attrs.colwidth[0])
+          : Math.round(firstCell.getBoundingClientRect().width)
+        const nextWidth = Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(currentWidth + deltaPx))
+        const transaction = currentEditor.state.tr.setNodeMarkup(cellPosition, undefined, {
+          ...cellNode.attrs,
+          colwidth: [nextWidth],
+        })
+        currentEditor.view.dispatch(transaction)
+        return
+      }
+
+      const activeColumnIndex = columns.findIndex((column) =>
+        column.some((cell) => cell.pos === cellPosition)
+      )
+      if (activeColumnIndex === -1) return
+      if (!isCurrentTableColumnSelection(activeColumnIndex) && !selectTableColumnByIndex(activeColumnIndex)) {
+        return
+      }
+      const overflowMode = getTableOverflowMode(tableNode)
+      const resizeResult = resizeTableColumnByIndex(activeColumnIndex, deltaPx)
+      if (
+        overflowMode !== TABLE_OVERFLOW_MODE_WIDE &&
+        didTableColumnResizeHitOverflowPolicy(deltaPx, resizeResult)
+      ) {
+        showTableOverflowCoachmark()
+      } else if (deltaPx < 0) {
+        hideTableOverflowCoachmark()
+      }
+      return
+    }
+  }, [
+    editorRef,
+    hideTableOverflowCoachmark,
+    isCurrentTableColumnSelection,
+    resizeTableColumnByIndex,
+    selectTableColumnByIndex,
+    showTableOverflowCoachmark,
+    viewportRef,
+  ])
+
+  const startTableColumnRailResize = useCallback(
+    (pointerId: number, columnIndex: number, clientX: number) => {
+      if (!selectTableColumnByIndex(columnIndex)) return
+      const resizeContext = getCurrentTableColumnResizeContext(columnIndex)
+      if (!resizeContext) return
+      setIsTableColumnResizeActive(true)
+      setTableAffordanceGeometry((prev) => ({ ...prev, columnIndex }))
+      clearWindowTextSelection()
+      setColumnResizeUserSelectSuppressed(true)
+      tableColumnRailResizeRef.current = createTableColumnRailResizeState(
+        pointerId,
+        columnIndex,
+        clientX,
+        resizeContext.measuredWidths,
+        getCurrentEditorReadableWidthPx(resizeContext.currentEditor) - 2,
+        getTableOverflowMode(resizeContext.rect.table)
+      )
+      if (typeof document !== "undefined") {
+        document.body.style.cursor = "col-resize"
+      }
+      updateTableColumnDragGuideForColumn(columnIndex)
+    },
+    [
+      clearWindowTextSelection,
+      getCurrentTableColumnResizeContext,
+      selectTableColumnByIndex,
+      setColumnResizeUserSelectSuppressed,
+      setTableAffordanceGeometry,
+      updateTableColumnDragGuideForColumn,
+    ]
+  )
+
+  const tryStartTableColumnResizeFromDomHandle = useCallback(
+    (target: EventTarget | null, pointerId: number, clientX: number) => {
+      const columnIndex = resolveTableColumnIndexFromResizeHandleTarget(target)
+      if (columnIndex === null) return false
+      startTableColumnRailResize(pointerId, columnIndex, clientX)
+      return true
+    },
+    [startTableColumnRailResize]
+  )
+
+  const stopTableColumnRailResize = useCallback(() => {
+    tableColumnRailResizeRef.current = null
+    setIsTableColumnResizeActive(false)
+    hideTableColumnDragGuide()
+    clearWindowTextSelection()
+    setColumnResizeUserSelectSuppressed(false)
+    if (typeof document !== "undefined") {
+      document.body.style.removeProperty("cursor")
+    }
+  }, [clearWindowTextSelection, hideTableColumnDragGuide, setColumnResizeUserSelectSuppressed])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const state = tableRowResizeRef.current
+      if (!state) return
+      const nextHeight = Math.max(
+        TABLE_MIN_ROW_HEIGHT_PX,
+        Math.round(state.startHeight + (event.clientY - state.startY))
+      )
+      state.row.style.height = `${nextHeight}px`
+      state.cells.forEach((cell) => {
+        cell.style.height = `${nextHeight}px`
+        cell.style.minHeight = `${nextHeight}px`
+      })
+    }
+
+    const handlePointerUp = () => {
+      const state = tableRowResizeRef.current
+      if (state) {
+        const committedHeight = Math.max(
+          TABLE_MIN_ROW_HEIGHT_PX,
+          Math.round(state.row.getBoundingClientRect().height)
+        )
+        commitTableRowHeight(state.row, committedHeight)
+      }
+      stopTableRowResize()
+    }
+
+    window.addEventListener("pointermove", handlePointerMove)
+    window.addEventListener("pointerup", handlePointerUp)
+    window.addEventListener("pointercancel", handlePointerUp)
+
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove)
+      window.removeEventListener("pointerup", handlePointerUp)
+      window.removeEventListener("pointercancel", handlePointerUp)
+      stopTableRowResize()
+    }
+  }, [commitTableRowHeight, stopTableRowResize])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const state = tableColumnRailResizeRef.current
+      if (!state || state.pointerId !== event.pointerId) return
+      const nextClientX = event.clientX
+      const resizeResult = resizeTableColumnBySessionDelta(
+        state.columnIndex,
+        state.baseWidths,
+        nextClientX - state.startClientX,
+        state.overflowMode,
+        state.budget
+      )
+      if (
+        state.overflowMode !== TABLE_OVERFLOW_MODE_WIDE &&
+        didTableColumnResizeHitOverflowPolicy(nextClientX - state.startClientX, resizeResult)
+      ) {
+        showTableOverflowCoachmark()
+      } else if (nextClientX <= state.startClientX) {
+        hideTableOverflowCoachmark()
+      }
+      updateTableColumnDragGuideForColumn(state.columnIndex)
+    }
+
+    const handlePointerUp = (event: PointerEvent) => {
+      const state = tableColumnRailResizeRef.current
+      if (!state || state.pointerId !== event.pointerId) return
+      const resizeResult = resizeTableColumnBySessionDelta(
+        state.columnIndex,
+        state.baseWidths,
+        event.clientX - state.startClientX,
+        state.overflowMode,
+        state.budget
+      )
+      if (
+        state.overflowMode !== TABLE_OVERFLOW_MODE_WIDE &&
+        didTableColumnResizeHitOverflowPolicy(event.clientX - state.startClientX, resizeResult)
+      ) {
+        showTableOverflowCoachmark()
+      }
+      stopTableColumnRailResize()
+    }
+
+    window.addEventListener("pointermove", handlePointerMove)
+    window.addEventListener("pointerup", handlePointerUp)
+    window.addEventListener("pointercancel", handlePointerUp)
+
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove)
+      window.removeEventListener("pointerup", handlePointerUp)
+      window.removeEventListener("pointercancel", handlePointerUp)
+      stopTableColumnRailResize()
+    }
+  }, [
+    hideTableOverflowCoachmark,
+    resizeTableColumnBySessionDelta,
+    showTableOverflowCoachmark,
+    stopTableColumnRailResize,
+    updateTableColumnDragGuideForColumn,
+  ])
+
+  const isTableRowResizeActive = useCallback(() => Boolean(tableRowResizeRef.current), [])
+  const isTableColumnRailResizeActive = useCallback(() => Boolean(tableColumnRailResizeRef.current), [])
+
+  return {
+    hideTableColumnDragGuide,
+    isTableColumnRailResizeActive,
+    isTableColumnResizeActive,
+    isTableRowResizeActive,
+    isTableRowResizeHandleTarget: isRowResizeHandleTarget,
+    resizeFirstTableColumnBy,
+    resizeFirstTableRowBy,
+    startTableColumnRailResize,
+    startTableRowResize,
+    tableColumnDragGuideState,
+    tableColumnRailResizeRef,
+    tableRowResizeRef,
+    tryStartTableColumnResizeFromDomHandle,
+    updateTableColumnDragGuideForColumn,
+  }
+}

--- a/front/src/components/editor/useBlockEditorTableOverlayUiTimers.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayUiTimers.ts
@@ -1,0 +1,117 @@
+import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { TableAffordanceGeometry, TableAffordanceVisibility } from "./tableAffordanceModel"
+import { resolveActiveRenderedTableForFloatingUi } from "./tableRenderedDomModel"
+import {
+  TABLE_OVERFLOW_COACHMARK_DISMISS_MS,
+  createHiddenTableOverflowCoachmarkState,
+  hideTableOverflowCoachmarkState,
+  resolveTableOverflowCoachmarkState,
+  type TableOverflowCoachmarkState,
+} from "./tableFloatingUiModel"
+
+type UseBlockEditorTableOverlayUiTimersArgs = {
+  cornerButtonSize: number
+  isCoarsePointer: boolean
+  isNarrowTableViewport: boolean
+  setTableAffordanceVisibility: Dispatch<SetStateAction<TableAffordanceVisibility>>
+  tableAffordanceGeometryRef: MutableRefObject<TableAffordanceGeometry>
+  viewportRef: RefObject<HTMLDivElement>
+}
+
+const TABLE_QUICK_RAIL_HIDE_DELAY_MS = 120
+
+export const useBlockEditorTableOverlayUiTimers = ({
+  cornerButtonSize,
+  isCoarsePointer,
+  isNarrowTableViewport,
+  setTableAffordanceVisibility,
+  tableAffordanceGeometryRef,
+  viewportRef,
+}: UseBlockEditorTableOverlayUiTimersArgs) => {
+  const tableQuickRailHideTimerRef = useRef<number | null>(null)
+  const tableOverflowCoachmarkHideTimerRef = useRef<number | null>(null)
+  const [tableOverflowCoachmarkState, setTableOverflowCoachmarkState] =
+    useState<TableOverflowCoachmarkState>(createHiddenTableOverflowCoachmarkState)
+
+  const cancelTableOverflowCoachmarkHide = useCallback(() => {
+    if (typeof window === "undefined") return
+    if (tableOverflowCoachmarkHideTimerRef.current !== null) {
+      window.clearTimeout(tableOverflowCoachmarkHideTimerRef.current)
+      tableOverflowCoachmarkHideTimerRef.current = null
+    }
+  }, [])
+
+  const hideTableOverflowCoachmark = useCallback(() => {
+    cancelTableOverflowCoachmarkHide()
+    setTableOverflowCoachmarkState(hideTableOverflowCoachmarkState)
+  }, [cancelTableOverflowCoachmarkHide])
+
+  const scheduleTableOverflowCoachmarkHide = useCallback(
+    (delayMs = TABLE_OVERFLOW_COACHMARK_DISMISS_MS) => {
+      if (typeof window === "undefined") return
+      cancelTableOverflowCoachmarkHide()
+      tableOverflowCoachmarkHideTimerRef.current = window.setTimeout(() => {
+        tableOverflowCoachmarkHideTimerRef.current = null
+        setTableOverflowCoachmarkState(hideTableOverflowCoachmarkState)
+      }, delayMs)
+    },
+    [cancelTableOverflowCoachmarkHide]
+  )
+
+  useEffect(() => () => cancelTableOverflowCoachmarkHide(), [cancelTableOverflowCoachmarkHide])
+
+  const showTableOverflowCoachmark = useCallback(() => {
+    if (isCoarsePointer || isNarrowTableViewport || typeof window === "undefined") return
+    const renderedTable = resolveActiveRenderedTableForFloatingUi(
+      viewportRef.current,
+      tableAffordanceGeometryRef.current
+    )
+    const tableRect = renderedTable?.getBoundingClientRect() ?? null
+    setTableOverflowCoachmarkState(
+      resolveTableOverflowCoachmarkState({
+        tableRect,
+        fallbackAnchor: tableAffordanceGeometryRef.current.cornerAnchor,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+        cornerButtonSize,
+      })
+    )
+    scheduleTableOverflowCoachmarkHide()
+  }, [cornerButtonSize, isCoarsePointer, isNarrowTableViewport, scheduleTableOverflowCoachmarkHide, tableAffordanceGeometryRef, viewportRef])
+
+  const hideTableQuickRailImmediately = useCallback(() => {
+    if (tableQuickRailHideTimerRef.current !== null && typeof window !== "undefined") {
+      window.clearTimeout(tableQuickRailHideTimerRef.current)
+      tableQuickRailHideTimerRef.current = null
+    }
+    setTableAffordanceVisibility((prev) => (prev.visible ? { ...prev, visible: false } : prev))
+  }, [setTableAffordanceVisibility])
+
+  const cancelTableQuickRailHide = useCallback(() => {
+    if (tableQuickRailHideTimerRef.current !== null && typeof window !== "undefined") {
+      window.clearTimeout(tableQuickRailHideTimerRef.current)
+      tableQuickRailHideTimerRef.current = null
+    }
+  }, [])
+
+  const scheduleTableQuickRailHide = useCallback((delayMs = TABLE_QUICK_RAIL_HIDE_DELAY_MS) => {
+    cancelTableQuickRailHide()
+    if (typeof window === "undefined") return
+    tableQuickRailHideTimerRef.current = window.setTimeout(() => {
+      setTableAffordanceVisibility((prev) => (prev.visible ? { ...prev, visible: false } : prev))
+      tableQuickRailHideTimerRef.current = null
+    }, delayMs)
+  }, [cancelTableQuickRailHide, setTableAffordanceVisibility])
+
+  return {
+    cancelTableOverflowCoachmarkHide,
+    cancelTableQuickRailHide,
+    hideTableOverflowCoachmark,
+    hideTableQuickRailImmediately,
+    scheduleTableOverflowCoachmarkHide,
+    scheduleTableQuickRailHide,
+    showTableOverflowCoachmark,
+    tableOverflowCoachmarkState,
+  }
+}


### PR DESCRIPTION
## 관련 이슈

close #392

## 작업 배경

- `useBlockEditorTableOverlayController.ts`를 1000 line 이하 thin orchestration hook으로 줄이고, table overlay 책임을 DOM adapter/axis drag/resize/corner grow/menu/timer/interaction hook으로 분리했습니다.
- source-boundary test가 controller line budget과 helper 재비대화를 검증하도록 갱신했습니다.
- main merge 후 기존 자동 CI/CD 경로로 홈서버 배포가 이어지는 범위입니다.

## 작업 내용

- table overlay DOM lookup/focus/cell adapter를 `useBlockEditorTableOverlayDomAdapter.ts`로 분리했습니다.
- axis drag/reorder, row/column resize, corner grow/shrink, structure/cell menu, quick rail timer와 hover handler를 각각 전용 hook으로 이동했습니다.
- `editor-studio-state.spec.ts` source contract를 thin entry/Root split 구조와 신규 overlay module 경계에 맞췄습니다.

## 검증

- 실행한 명령과 결과:
  - `wc -l front/src/components/editor/useBlockEditorTableOverlayController.ts front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts front/src/components/editor/useBlockEditorTableOverlayCornerGrow.ts front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts front/src/components/editor/useBlockEditorTableOverlayInteractionHandlers.ts front/src/components/editor/useBlockEditorTableOverlayMenu.ts front/src/components/editor/useBlockEditorTableOverlayResize.ts front/src/components/editor/useBlockEditorTableOverlayUiTimers.ts`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `git diff --cached --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: hook 경계 이동으로 table overlay hover/resize/menu lifecycle dependency 누락 가능성이 있습니다.
- 롤백 방법: 이 PR의 merge commit을 revert하면 기존 controller 단일 파일 구조로 되돌릴 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
