### PR TITLE
[Fix] steady-state 로그인 probe 세션 증식 차단

### DIFF
--- a/deploy/homeserver/.env.prod.example
+++ b/deploy/homeserver/.env.prod.example
@@ -25,6 +25,9 @@ GRAFANA_ROOT_URL=https://grafana.example.com
 # GRAFANA_DS_FAIL_THRESHOLD=3
 # 재기동 쿨다운 초(기본 900초)
 # GRAFANA_DS_RECREATE_COOLDOWN_SECONDS=900
+# 인증이 필요한 Grafana embed/SSE deep probe는 로그인 세션과 보안 이벤트를 생성하므로 기본 비활성화한다.
+# 장애 조사 중 일시적으로만 true로 켠다.
+# STEADY_GUARD_AUTH_PROBES_ENABLED=false
 # Back container auto-heal (restart unhealthy app containers)
 # AUTOHEAL_INTERVAL_SECONDS=15
 # AUTOHEAL_START_PERIOD_SECONDS=300

--- a/deploy/homeserver/steady_state_guard.sh
+++ b/deploy/homeserver/steady_state_guard.sh
@@ -58,6 +58,19 @@ normalize_non_negative_int() {
   fi
 }
 
+auth_probes_enabled() {
+  local value
+  value="$(trim_quotes "$(env_value "STEADY_GUARD_AUTH_PROBES_ENABLED")")"
+  case "${value,,}" in
+    1|true|yes|on)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 GRAFANA_DS_FAIL_COUNT=0
 GRAFANA_DS_LAST_RECREATE_EPOCH=0
 GRAFANA_EMBED_FAIL_COUNT=0
@@ -557,6 +570,10 @@ check_grafana_embed_route() {
   api_domain="$(trim_quotes "$(env_value "API_DOMAIN")")"
   grafana_domain="$(trim_quotes "$(env_value "GRAFANA_DOMAIN")")"
   path="$(monitoring_embed_candidate_path)"
+  if ! auth_probes_enabled; then
+    log "skip grafana origin route check (STEADY_GUARD_AUTH_PROBES_ENABLED is not enabled)"
+    return 0
+  fi
   admin_email="$(trim_quotes "$(env_value "CUSTOM__ADMIN__EMAIL")")"
   admin_password="$(trim_quotes "$(env_value "CUSTOM__ADMIN__PASSWORD")")"
   if [[ -z "${grafana_domain}" ]]; then
@@ -690,6 +707,10 @@ check_notification_sse_route() {
   if [[ -z "${api_domain}" ]]; then
     log "FAIL missing API_DOMAIN in ${ENV_FILE}"
     return 1
+  fi
+  if ! auth_probes_enabled; then
+    log "skip notification sse route check (STEADY_GUARD_AUTH_PROBES_ENABLED is not enabled)"
+    return 0
   fi
 
   local fail_threshold cooldown_seconds


### PR DESCRIPTION
## 관련 이슈

close #402

## 작업 배경

- steady-state guard의 인증 필요 deep probe가 기본 실행에서 로그인 API를 호출하지 않도록 gate를 추가했습니다.
- 필요 시 `STEADY_GUARD_AUTH_PROBES_ENABLED=true`로 일시 활성화할 수 있어 운영 조사 경로는 남기고, 기본 cron 실행의 세션/보안 이벤트 증식을 차단합니다.

## 작업 내용

- `steady_state_guard.sh`에 `auth_probes_enabled` gate를 추가했습니다.
- Grafana embed origin probe와 notification SSE probe를 기본 skip 처리했습니다.
- `.env.prod.example`에 옵션과 운영 주의 설명을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `test "$(rg -c 'STEADY_GUARD_AUTH_PROBES_ENABLED' deploy/homeserver/steady_state_guard.sh)" -gt 0` 실패 확인
  - `bash -n deploy/homeserver/steady_state_guard.sh deploy/homeserver/blue_green_deploy.sh deploy/homeserver/doctor.sh`
  - `count=$(rg -o 'STEADY_GUARD_AUTH_PROBES_ENABLED' deploy/homeserver/steady_state_guard.sh deploy/homeserver/.env.prod.example | wc -l | tr -d ' '); test "$count" -ge 4`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 기본 steady-state guard에서 Grafana embed/SSE deep auth probe는 수행하지 않습니다. readiness, Caddy mount, datasource 등 비인증 점검은 유지됩니다.
- 롤백 방법: 이 PR을 revert하거나, 운영 조사 중에는 `STEADY_GUARD_AUTH_PROBES_ENABLED=true`를 설정해 기존 deep probe를 일시 활성화합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
