### PR TITLE
[Chore] 중복 unique index 정리

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/model/shared/Member.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/model/shared/Member.kt
@@ -22,6 +22,11 @@ import java.util.Locale
 @Entity
 @DynamicUpdate
 @SQLRestriction("deleted_at IS NULL")
+@Table(
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_member_login_id", columnNames = ["login_id"]),
+    ],
+)
 @AfterDDL(
     """
     CREATE INDEX IF NOT EXISTS member_idx_created_at_desc
@@ -47,7 +52,7 @@ class Member(
     @field:GeneratedValue(strategy = SEQUENCE, generator = "member_seq_gen")
     override val id: Long = 0,
     @field:NaturalId
-    @field:Column(name = "login_id", unique = true, nullable = false)
+    @field:Column(name = "login_id", nullable = false)
     val username: String,
     @field:Column(nullable = true)
     var password: String? = null,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/model/PostLike.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/model/PostLike.kt
@@ -21,7 +21,7 @@ import org.hibernate.annotations.DynamicUpdate
 )
 @Table(
     uniqueConstraints = [
-        UniqueConstraint(columnNames = ["liker_id", "post_id"]),
+        UniqueConstraint(name = "uk_post_like_liker_post", columnNames = ["liker_id", "post_id"]),
     ],
 )
 class PostLike(

--- a/back/src/main/resources/db/migration-test/V20260319_01__baseline_schema.sql
+++ b/back/src/main/resources/db/migration-test/V20260319_01__baseline_schema.sql
@@ -241,9 +241,6 @@ CREATE INDEX IF NOT EXISTS post_comment_idx_subtree_active
     ON post_comment (post_id, parent_comment_id, created_at ASC, id ASC)
     WHERE deleted_at IS NULL;
 
-CREATE INDEX IF NOT EXISTS post_like_uidx_liker_post
-    ON post_like (liker_id, post_id);
-
 CREATE INDEX IF NOT EXISTS member_notification_idx_receiver_created_at_desc
     ON member_notification (receiver_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS member_notification_idx_receiver_unread_created_at_desc

--- a/back/src/main/resources/db/migration/V20260523_01__drop_duplicate_unique_indexes.sql
+++ b/back/src/main/resources/db/migration/V20260523_01__drop_duplicate_unique_indexes.sql
@@ -1,0 +1,23 @@
+DO $$
+BEGIN
+    IF to_regclass('public.member') IS NOT NULL
+        AND EXISTS(
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = 'public.member'::regclass
+              AND conname = 'uk_member_login_id'
+        ) THEN
+        ALTER TABLE public.member
+            DROP CONSTRAINT IF EXISTS uk9q1eki2d9720sgfev4g41igla;
+        ALTER TABLE public.member
+            DROP CONSTRAINT IF EXISTS ukgc3jmn7c2abyo3wf6syln5t2i;
+        DROP INDEX IF EXISTS public.uk9q1eki2d9720sgfev4g41igla;
+        DROP INDEX IF EXISTS public.ukgc3jmn7c2abyo3wf6syln5t2i;
+    END IF;
+
+    IF to_regclass('public.post_like') IS NOT NULL
+        AND to_regclass('public.post_like_uidx_liker_post') IS NOT NULL THEN
+        ALTER TABLE public.post_like
+            DROP CONSTRAINT IF EXISTS ukfe981nv3v4qefofcqympm581p;
+    END IF;
+END $$;


### PR DESCRIPTION
## 관련 이슈

close #401

## 작업 배경

- 운영 DB에서 `member.login_id`, `post_like(liker_id, post_id)`에 중복 unique index/constraint가 남아 쓰기 비용과 schema drift를 만들고 있었습니다.
- JPA unique constraint 이름을 고정하고, 운영 중복 index/constraint를 안전하게 정리하는 migration을 추가합니다.

## 작업 내용

- `Member`의 `login_id` unique 선언을 named table constraint로 고정했습니다.
- `PostLike`의 복합 unique constraint 이름을 `uk_post_like_liker_post`로 고정했습니다.
- baseline의 중복 `post_like_uidx_liker_post`를 제거했습니다.
- 운영 DB에 남은 랜덤명 중복 unique index/constraint 제거 migration을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back testcontainersTest --tests com.back.infrastructure.FlywayTestcontainersIntegrationTest`
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 잘못된 대상 index/constraint 제거 시 unique 보장이 약해질 수 있으나, canonical unique가 존재할 때만 duplicate를 제거하도록 guard했습니다.
- 롤백 방법: PR revert 후 필요한 경우 canonical unique 제약을 기준으로 중복 index를 재생성합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
