### PR TITLE
[Perf] 누락 FK 인덱스 보강

### DIFF
--- a/back/src/main/resources/db/migration-test/V20260319_01__baseline_schema.sql
+++ b/back/src/main/resources/db/migration-test/V20260319_01__baseline_schema.sql
@@ -240,6 +240,12 @@ CREATE INDEX IF NOT EXISTS idx_post_title_content_pgroonga
 CREATE INDEX IF NOT EXISTS post_comment_idx_subtree_active
     ON post_comment (post_id, parent_comment_id, created_at ASC, id ASC)
     WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS post_comment_idx_author_id
+    ON post_comment (author_id);
+CREATE INDEX IF NOT EXISTS post_comment_idx_post_id
+    ON post_comment (post_id);
+CREATE INDEX IF NOT EXISTS post_comment_idx_parent_comment_id
+    ON post_comment (parent_comment_id);
 
 CREATE INDEX IF NOT EXISTS post_like_uidx_liker_post
     ON post_like (liker_id, post_id);
@@ -250,6 +256,15 @@ CREATE INDEX IF NOT EXISTS member_notification_idx_receiver_unread_created_at_de
     ON member_notification (receiver_id, read_at, created_at DESC);
 CREATE INDEX IF NOT EXISTS member_notification_idx_receiver_id_asc
     ON member_notification (receiver_id, id ASC);
+CREATE INDEX IF NOT EXISTS member_notification_idx_actor_id
+    ON member_notification (actor_id);
+
+CREATE INDEX IF NOT EXISTS member_action_log_idx_primary_owner_id
+    ON member_action_log (primary_owner_id);
+CREATE INDEX IF NOT EXISTS member_action_log_idx_secondary_owner_id
+    ON member_action_log (secondary_owner_id);
+CREATE INDEX IF NOT EXISTS member_action_log_idx_actor_id
+    ON member_action_log (actor_id);
 
 CREATE INDEX IF NOT EXISTS member_signup_verification_idx_email_created_at_desc
     ON member_signup_verification (email, created_at DESC);

--- a/back/src/main/resources/db/migration/R__operational_indexes.sql
+++ b/back/src/main/resources/db/migration/R__operational_indexes.sql
@@ -77,6 +77,8 @@ BEGIN
             ON member_notification (receiver_id, created_at DESC);
         CREATE INDEX IF NOT EXISTS member_notification_idx_receiver_unread_created_at_desc
             ON member_notification (receiver_id, read_at, created_at DESC);
+        CREATE INDEX IF NOT EXISTS member_notification_idx_actor_id
+            ON member_notification (actor_id);
     END IF;
 
     IF to_regclass('public.member_session') IS NOT NULL THEN
@@ -109,6 +111,8 @@ BEGIN
             ON post_comment (post_id);
         CREATE INDEX IF NOT EXISTS post_comment_idx_parent_comment_id
             ON post_comment (parent_comment_id);
+        CREATE INDEX IF NOT EXISTS post_comment_idx_author_id
+            ON post_comment (author_id);
     END IF;
 
     IF to_regclass('public.post_like') IS NOT NULL THEN
@@ -131,5 +135,14 @@ BEGIN
         CREATE INDEX IF NOT EXISTS post_attr_idx_meta_tags_subject_id
             ON post_attr (subject_id)
             WHERE name = 'metaTagsIndex';
+    END IF;
+
+    IF to_regclass('public.member_action_log') IS NOT NULL THEN
+        CREATE INDEX IF NOT EXISTS member_action_log_idx_primary_owner_id
+            ON member_action_log (primary_owner_id);
+        CREATE INDEX IF NOT EXISTS member_action_log_idx_secondary_owner_id
+            ON member_action_log (secondary_owner_id);
+        CREATE INDEX IF NOT EXISTS member_action_log_idx_actor_id
+            ON member_action_log (actor_id);
     END IF;
 END $$;


### PR DESCRIPTION
## 관련 이슈

close #404

## 작업 배경

- 운영 DB 검토에서 `member_action_log`, `post_comment`, `member_notification`의 FK 조건에 대응하는 인덱스가 빠진 것을 확인했습니다.
- 반복 운영 쿼리와 FK 기반 조회/삭제 경로가 sequential scan으로 커지는 것을 막기 위해 operational/test baseline 인덱스를 보강합니다.

## 작업 내용

- `R__operational_indexes.sql`에 누락 FK 인덱스 5개를 추가했습니다.
- `V20260319_01__baseline_schema.sql`에 동일한 FK 인덱스를 반영해 신규 테스트 DB baseline과 운영 repeatable migration의 드리프트를 줄였습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back testcontainersTest --tests com.back.infrastructure.FlywayTestcontainersIntegrationTest`
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 운영 DB에서 인덱스 생성 중 I/O 부하가 일시적으로 증가할 수 있습니다.
- 롤백 방법: 추가된 인덱스를 `DROP INDEX IF EXISTS`로 제거하고 PR을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
