### PR TITLE
[Fix] uploaded_file 소유자 상태 정합성 보정

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -912,7 +912,10 @@ class PostApplicationService(
         }
 
         runCatching {
-            uploadedFileRetentionService.restoreDeletedPostAttachments(snapshot.content)
+            uploadedFileRetentionService.restoreDeletedPostAttachments(
+                postId = id,
+                content = snapshot.content,
+            )
         }.onFailure { exception ->
             logger.warn("Failed to restore attachments for restored post id={}", id, exception)
         }

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
@@ -199,13 +199,20 @@ class UploadedFileRetentionService(
      * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
      */
     @Transactional
-    fun restoreDeletedPostAttachments(content: String) {
-        UploadedFileUrlCodec.extractObjectKeysFromContent(content).forEach { objectKey ->
-            val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey) ?: return@forEach
-            if (uploadedFile.status == UploadedFileStatus.DELETED) return@forEach
-            uploadedFile.restoreActive()
-            uploadedFileRepository.save(uploadedFile)
-        }
+    fun restoreDeletedPostAttachments(
+        postId: Long,
+        content: String,
+    ) {
+        restorePostAttachmentKeys(
+            postId = postId,
+            keys = UploadedFileUrlCodec.extractImageObjectKeysFromContent(content),
+            purpose = UploadedFilePurpose.POST_IMAGE,
+        )
+        restorePostAttachmentKeys(
+            postId = postId,
+            keys = UploadedFileUrlCodec.extractFileObjectKeysFromContent(content),
+            purpose = UploadedFilePurpose.POST_FILE,
+        )
     }
 
     private fun syncPostAttachmentKeys(
@@ -241,6 +248,19 @@ class UploadedFileRetentionService(
                 reason = UploadedFileRetentionReason.DELETED_POST_ATTACHMENT,
                 purgeAfter = Instant.now().plusSeconds(retentionProperties.deletedPostAttachmentSeconds),
             )
+        }
+    }
+
+    private fun restorePostAttachmentKeys(
+        postId: Long,
+        keys: Set<String>,
+        purpose: UploadedFilePurpose,
+    ) {
+        keys.forEach { objectKey ->
+            val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey) ?: return@forEach
+            if (uploadedFile.status == UploadedFileStatus.DELETED) return@forEach
+            uploadedFile.attachToPost(postId, purpose)
+            uploadedFileRepository.save(uploadedFile)
         }
     }
 

--- a/back/src/main/resources/db/migration/V20260523_02__repair_uploaded_file_owner_state.sql
+++ b/back/src/main/resources/db/migration/V20260523_02__repair_uploaded_file_owner_state.sql
@@ -1,0 +1,38 @@
+DO $$
+BEGIN
+    IF to_regclass('public.uploaded_file') IS NULL
+        OR to_regclass('public.post') IS NULL THEN
+        RETURN;
+    END IF;
+
+    WITH first_post_match AS (
+        SELECT DISTINCT ON (uf.id)
+            uf.id AS uploaded_file_id,
+            p.id AS post_id
+        FROM public.uploaded_file uf
+        JOIN public.post p
+          ON p.content LIKE ('%' || uf.object_key || '%')
+        WHERE uf.status = 'ACTIVE'
+          AND uf.owner_type IS NULL
+          AND uf.owner_id IS NULL
+          AND uf.purpose IN ('POST_IMAGE', 'POST_FILE')
+        ORDER BY uf.id, p.id
+    )
+    UPDATE public.uploaded_file uf
+    SET owner_type = 'POST',
+        owner_id = first_post_match.post_id,
+        retention_reason = NULL,
+        purge_after = NULL,
+        deleted_at = NULL
+    FROM first_post_match
+    WHERE uf.id = first_post_match.uploaded_file_id;
+
+    UPDATE public.uploaded_file
+    SET status = 'PENDING_DELETE',
+        retention_reason = 'DETACHED_POST_ATTACHMENT',
+        purge_after = COALESCE(purge_after, now() + interval '14 days')
+    WHERE status = 'ACTIVE'
+      AND owner_type IS NULL
+      AND owner_id IS NULL
+      AND purpose IN ('POST_IMAGE', 'POST_FILE');
+END $$;

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceTest.kt
@@ -201,6 +201,24 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
         assertThat(uploadedFileRepository.findByObjectKey(unknownLegacyKey)).isNull()
     }
 
+    @Test
+    fun `삭제 글 복구 첨부파일은 활성화될 때 게시글 소유자를 다시 기록한다`() {
+        val restoredKey = "posts/2026/03/restored-image.png"
+        val content = "![](${UploadedFileUrlCodec.buildImageUrl(restoredKey)})"
+
+        uploadedFileRetentionService.registerTempUpload(restoredKey, "image/png", 100, UploadedFilePurpose.POST_IMAGE)
+        uploadedFileRetentionService.scheduleDeletedPostAttachments(content)
+
+        uploadedFileRetentionService.restoreDeletedPostAttachments(postId = 33, content = content)
+
+        val restoredFile = uploadedFileRepository.findByObjectKey(restoredKey)!!
+        assertThat(restoredFile.status).isEqualTo(UploadedFileStatus.ACTIVE)
+        assertThat(restoredFile.ownerType).isEqualTo(UploadedFileOwnerType.POST)
+        assertThat(restoredFile.ownerId).isEqualTo(33)
+        assertThat(restoredFile.retentionReason).isNull()
+        assertThat(restoredFile.purgeAfter).isNull()
+    }
+
     companion object {
         @JvmStatic
         @BeforeAll


### PR DESCRIPTION
## 관련 이슈

close #400

## 작업 배경

- 삭제 글 복구 경로에서 첨부파일을 `ACTIVE`로 되돌릴 때 게시글 owner 정보가 다시 기록되지 않아 owner null 상태가 남을 수 있었습니다.
- 복구 시 post owner를 재부여하고, 기존 ownerless `uploaded_file` 운영 데이터를 보정하는 migration을 추가합니다.

## 작업 내용

- `restoreDeletedPostAttachments`가 `postId`를 받아 POST_IMAGE/POST_FILE owner를 다시 기록하도록 변경했습니다.
- 관리자 삭제 글 복구 흐름에서 post id를 retention service로 전달합니다.
- ownerless active post attachment를 post content 기준으로 재연결하고, 남은 detached row는 `PENDING_DELETE`로 이동하는 migration을 추가했습니다.
- 회귀 테스트를 추가해 복구 첨부파일 owner 재부여를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back test --tests 'com.back.global.storage.application.UploadedFileRetentionServiceTest.삭제 글 복구 첨부파일은 활성화될 때 게시글 소유자를 다시 기록한다'`
  - `back/gradlew -p back test --tests com.back.global.storage.application.UploadedFileRetentionServiceTest`
  - `back/gradlew -p back testcontainersTest --tests com.back.infrastructure.FlywayTestcontainersIntegrationTest`
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: migration의 content 매칭이 잘못된 post를 선택할 수 있으나 `MIN(post.id)`로 결정적 매칭을 적용하고 남은 row는 purge 예약으로 보수 처리합니다.
- 롤백 방법: PR revert 후 필요 시 `uploaded_file` owner/pending 상태를 운영 백업 기준으로 복원합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
