### PR TITLE
[Perf] task 스케줄러 DB 폴링 부하 축소

### DIFF
--- a/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt
+++ b/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt
@@ -156,11 +156,7 @@ class TaskProcessingScheduledJob(
             if (!dynamicConcurrencyEnabled) {
                 workerConcurrency
             } else {
-                val readyPending = taskRepository.countByStatusAndNextRetryAtLessThanEqual(TaskStatus.PENDING, Instant.now())
-                val backlogPerSlot = dynamicBacklogPerSlot.coerceAtLeast(1)
-                val scaled = ceil(readyPending.toDouble() / backlogPerSlot).toInt().coerceAtLeast(1)
-                val minConcurrency = dynamicMinConcurrent.coerceIn(1, workerConcurrency)
-                scaled.coerceIn(minConcurrency, workerConcurrency)
+                workerConcurrency
             }
 
         return (targetConcurrency - activeWorkers).coerceIn(0, workerConcurrency)
@@ -174,12 +170,6 @@ class TaskProcessingScheduledJob(
             return minOf(safeBatchSize, availableWorkerSlots)
         }
 
-        val now = Instant.now()
-        val readyPending = taskRepository.countByStatusAndNextRetryAtLessThanEqual(TaskStatus.PENDING, now).coerceAtLeast(0)
-        val backlogPerStep = dynamicBatchBacklogPerStep.coerceAtLeast(1)
-        val backlogSteps = ceil(readyPending.toDouble() / backlogPerStep).toInt().coerceAtLeast(1)
-        val backlogBoost = (backlogSteps - 1).coerceAtLeast(0)
-
         val avgHandlerMs = recentHandlerDurationMs.get().coerceAtLeast(1)
         val targetMs = dynamicBatchTargetHandlerDurationMs.coerceIn(100, 60_000)
         val latencyFactor =
@@ -188,12 +178,11 @@ class TaskProcessingScheduledJob(
                 else -> (targetMs.toDouble() / avgHandlerMs.toDouble()).coerceIn(0.35, 1.0)
             }
 
-        val minBatch = dynamicBatchMinSize.coerceIn(1, safeBatchSize)
-        val maxPrefetchMultiplier = dynamicBatchMaxPrefetchMultiplier.coerceIn(1, 8)
-        val maxPrefetch = minOf(safeBatchSize, availableWorkerSlots.coerceAtLeast(1) * maxPrefetchMultiplier)
-        val raw = ceil((availableWorkerSlots + backlogBoost).toDouble() * latencyFactor).toInt()
+        val maxClaim = minOf(safeBatchSize, availableWorkerSlots.coerceAtLeast(1))
+        val minClaim = minOf(dynamicBatchMinSize.coerceIn(1, safeBatchSize), maxClaim)
+        val raw = ceil(availableWorkerSlots.toDouble() * latencyFactor).toInt().coerceAtLeast(1)
 
-        return raw.coerceIn(minBatch, maxPrefetch.coerceAtLeast(minBatch))
+        return raw.coerceIn(minClaim, maxClaim)
     }
 
     private fun tryAcquirePerTypePermit(taskType: String): Boolean {
@@ -265,9 +254,7 @@ class TaskProcessingScheduledJob(
             return
         }
 
-        val now = Instant.now()
         val minConcurrent = perTypeAutoTuneMinConcurrent.coerceIn(1, workerConcurrency)
-        val backlogPerSlot = perTypeAutoTuneBacklogPerSlot.coerceAtLeast(1)
         val explicitReserved = explicitPerTypeMaxConcurrent.values.sum().coerceIn(0, workerConcurrency)
         val dynamicBudget = (workerConcurrency - explicitReserved).coerceAtLeast(0)
         if (dynamicBudget == 0) {
@@ -276,30 +263,21 @@ class TaskProcessingScheduledJob(
             return
         }
 
-        val readyBacklogByType =
-            dynamicTypes.associateWith { taskType ->
-                taskRepository.countByTaskTypeAndStatusAndNextRetryAtLessThanEqual(taskType, TaskStatus.PENDING, now)
-            }
+        val baseLimit = (dynamicBudget / dynamicTypes.size.coerceAtLeast(1)).coerceAtLeast(minConcurrent)
         val desiredByType =
-            readyBacklogByType
-                .mapValues { (_, readyPending) ->
-                    if (readyPending <= 0L) {
-                        0
-                    } else {
-                        val scaled = ceil(readyPending.toDouble() / backlogPerSlot).toInt().coerceAtLeast(minConcurrent)
-                        scaled.coerceIn(1, workerConcurrency)
-                    }
-                }.toMutableMap()
+            dynamicTypes
+                .associateWith { baseLimit.coerceIn(1, workerConcurrency) }
+                .toMutableMap()
 
         while (desiredByType.values.sum() > dynamicBudget) {
             val typeToReduce = desiredByType.maxByOrNull { it.value }?.key ?: break
             val current = desiredByType[typeToReduce] ?: break
-            if (current <= 0) break
+            if (current <= 1) break
             desiredByType[typeToReduce] = current - 1
         }
 
         perTypeDynamicLimits.clear()
-        perTypeDynamicLimits.putAll(desiredByType.filterValues { it > 0 })
+        perTypeDynamicLimits.putAll(desiredByType)
         perTypeDynamicRefreshedAtEpochMs = nowEpochMs
     }
 

--- a/back/src/test/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJobPerTypeLimitTest.kt
+++ b/back/src/test/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJobPerTypeLimitTest.kt
@@ -1,16 +1,57 @@
 package com.back.global.task.adapter.scheduler
 
 import com.back.global.task.adapter.persistence.TaskRepository
+import com.back.global.task.application.TaskHandlerEntry
+import com.back.global.task.application.TaskHandlerMethod
 import com.back.global.task.application.TaskHandlerRegistry
+import com.back.global.task.application.TaskRetryPolicy
+import com.back.standard.dto.TaskPayload
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verifyNoInteractions
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.support.TransactionTemplate
 import tools.jackson.databind.ObjectMapper
+import java.util.UUID
 
 class TaskProcessingScheduledJobPerTypeLimitTest {
+    @Test
+    @DisplayName("dynamic capacity 산정은 claim 전에 ready backlog count를 조회하지 않는다")
+    fun `dynamic capacity resolution avoids ready backlog count before claim`() {
+        val fixture =
+            createFixture(
+                maxConcurrent = 8,
+                perTypeMaxConcurrentRaw = "",
+                perTypeAutoTuneEnabled = true,
+                perTypeAutoTuneMinConcurrent = 1,
+            )
+
+        invokeResolveAvailableWorkerSlots(fixture.job)
+        invokeResolveFetchLimit(fixture.job, safeBatchSize = 50, availableWorkerSlots = 8)
+
+        verifyNoInteractions(fixture.taskRepository)
+    }
+
+    @Test
+    @DisplayName("per-type auto-tune refresh는 task type별 ready backlog count를 조회하지 않는다")
+    fun `per type auto tune refresh avoids ready backlog count by task type`() {
+        val fixture =
+            createFixture(
+                maxConcurrent = 8,
+                perTypeMaxConcurrentRaw = "",
+                perTypeAutoTuneEnabled = true,
+                perTypeAutoTuneMinConcurrent = 1,
+                registeredTaskTypes = listOf("post.search-index.sync", "post.read.prewarm"),
+            )
+
+        invokeRefreshPerTypeDynamicLimitsIfNeeded(fixture.job)
+
+        verifyNoInteractions(fixture.taskRepository)
+        assertThat(invokeResolvePerTypeLimit(fixture.job, "post.search-index.sync")).isGreaterThanOrEqualTo(1)
+    }
+
     @Test
     @DisplayName("auto-tune limit map이 비어도 미지정 task type은 최소 1 permit을 보장한다")
     fun `unknown task type fallback never returns zero permit`() {
@@ -43,36 +84,119 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
         assertThat(resolved).isEqualTo(2)
     }
 
+    private data class JobFixture(
+        val job: TaskProcessingScheduledJob,
+        val taskRepository: TaskRepository,
+    )
+
+    private data class StubPayload(
+        override val uid: UUID = UUID.randomUUID(),
+        override val aggregateType: String = "test",
+        override val aggregateId: Long = 1,
+    ) : TaskPayload
+
     private fun createJob(
         maxConcurrent: Int,
         perTypeMaxConcurrentRaw: String,
         perTypeAutoTuneEnabled: Boolean,
         perTypeAutoTuneMinConcurrent: Int,
     ): TaskProcessingScheduledJob =
-        TaskProcessingScheduledJob(
-            taskRepository = mock(TaskRepository::class.java),
-            taskHandlerRegistry = mock(TaskHandlerRegistry::class.java),
-            transactionTemplate = TransactionTemplate(mock(PlatformTransactionManager::class.java)),
-            objectMapper = ObjectMapper(),
-            batchSize = 50,
-            processingTimeoutSeconds = 900,
+        createFixture(
             maxConcurrent = maxConcurrent,
-            handlerTimeoutSeconds = 120,
-            dynamicConcurrencyEnabled = true,
-            dynamicMinConcurrent = 2,
-            dynamicBacklogPerSlot = 25,
-            dynamicBatchSizeEnabled = true,
-            dynamicBatchMinSize = 4,
-            dynamicBatchBacklogPerStep = 120,
-            dynamicBatchTargetHandlerDurationMs = 900,
-            dynamicBatchMaxPrefetchMultiplier = 2,
             perTypeMaxConcurrentRaw = perTypeMaxConcurrentRaw,
             perTypeAutoTuneEnabled = perTypeAutoTuneEnabled,
             perTypeAutoTuneMinConcurrent = perTypeAutoTuneMinConcurrent,
-            perTypeAutoTuneBacklogPerSlot = 20,
-            perTypeAutoTuneRefreshMs = 15_000,
-            meterRegistry = null,
+        ).job
+
+    private fun createFixture(
+        maxConcurrent: Int,
+        perTypeMaxConcurrentRaw: String,
+        perTypeAutoTuneEnabled: Boolean,
+        perTypeAutoTuneMinConcurrent: Int,
+        registeredTaskTypes: List<String> = emptyList(),
+    ): JobFixture {
+        val taskRepository = mock(TaskRepository::class.java)
+        val taskHandlerRegistry = mock(TaskHandlerRegistry::class.java)
+        if (registeredTaskTypes.isNotEmpty()) {
+            org.mockito.Mockito
+                .`when`(taskHandlerRegistry.getRegisteredEntries())
+                .thenReturn(registeredTaskTypes.map { taskType -> taskHandlerEntry(taskType) })
+        }
+
+        val job =
+            TaskProcessingScheduledJob(
+                taskRepository = taskRepository,
+                taskHandlerRegistry = taskHandlerRegistry,
+                transactionTemplate = TransactionTemplate(mock(PlatformTransactionManager::class.java)),
+                objectMapper = ObjectMapper(),
+                batchSize = 50,
+                processingTimeoutSeconds = 900,
+                maxConcurrent = maxConcurrent,
+                handlerTimeoutSeconds = 120,
+                dynamicConcurrencyEnabled = true,
+                dynamicMinConcurrent = 2,
+                dynamicBacklogPerSlot = 25,
+                dynamicBatchSizeEnabled = true,
+                dynamicBatchMinSize = 4,
+                dynamicBatchBacklogPerStep = 120,
+                dynamicBatchTargetHandlerDurationMs = 900,
+                dynamicBatchMaxPrefetchMultiplier = 2,
+                perTypeMaxConcurrentRaw = perTypeMaxConcurrentRaw,
+                perTypeAutoTuneEnabled = perTypeAutoTuneEnabled,
+                perTypeAutoTuneMinConcurrent = perTypeAutoTuneMinConcurrent,
+                perTypeAutoTuneBacklogPerSlot = 20,
+                perTypeAutoTuneRefreshMs = 15_000,
+                meterRegistry = null,
+            )
+
+        return JobFixture(job, taskRepository)
+    }
+
+    private fun taskHandlerEntry(taskType: String): TaskHandlerEntry =
+        TaskHandlerEntry(
+            taskType = taskType,
+            payloadClass = StubPayload::class.java,
+            handlerMethod =
+                TaskHandlerMethod(
+                    bean = this,
+                    method =
+                        TaskProcessingScheduledJobPerTypeLimitTest::class.java.getDeclaredMethod(
+                            "handleStubPayload",
+                            StubPayload::class.java,
+                        ),
+                ),
+            retryPolicy = TaskRetryPolicy.fallback(taskType),
         )
+
+    @Suppress("unused")
+    private fun handleStubPayload(payload: StubPayload) = Unit
+
+    private fun invokeResolveAvailableWorkerSlots(job: TaskProcessingScheduledJob): Int {
+        val method = TaskProcessingScheduledJob::class.java.getDeclaredMethod("resolveAvailableWorkerSlots")
+        method.isAccessible = true
+        return method.invoke(job) as Int
+    }
+
+    private fun invokeResolveFetchLimit(
+        job: TaskProcessingScheduledJob,
+        safeBatchSize: Int,
+        availableWorkerSlots: Int,
+    ): Int {
+        val method =
+            TaskProcessingScheduledJob::class.java.getDeclaredMethod(
+                "resolveFetchLimit",
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
+            )
+        method.isAccessible = true
+        return method.invoke(job, safeBatchSize, availableWorkerSlots) as Int
+    }
+
+    private fun invokeRefreshPerTypeDynamicLimitsIfNeeded(job: TaskProcessingScheduledJob) {
+        val method = TaskProcessingScheduledJob::class.java.getDeclaredMethod("refreshPerTypeDynamicLimitsIfNeeded")
+        method.isAccessible = true
+        method.invoke(job)
+    }
 
     private fun invokeResolvePerTypeLimit(
         job: TaskProcessingScheduledJob,


### PR DESCRIPTION
## 관련 이슈

close #399

## 작업 배경

- 운영 `pg_stat_statements`에서 task scheduler의 ready backlog count/select 호출이 수천만 회 누적되는 것을 확인했습니다.
- scheduler가 매 tick count-before-claim을 반복하지 않고 실제 claim query 중심으로 동작하도록 줄였습니다.

## 작업 내용

- dynamic worker slot 산정에서 `countByStatusAndNextRetryAtLessThanEqual` 호출을 제거했습니다.
- dynamic batch fetch limit 산정에서 backlog count 기반 boost를 제거하고 현재 사용 가능한 worker slot 범위로 제한했습니다.
- per-type auto tune refresh에서 task type별 ready backlog count를 제거하고 등록 타입에 budget을 분배하도록 변경했습니다.
- count 호출 회귀를 잡는 scheduler 단위 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests com.back.global.task.adapter.scheduler.TaskProcessingScheduledJobPerTypeLimitTest` (RED 확인 후 GREEN)
  - `back/gradlew -p back test --tests 'com.back.global.task.adapter.scheduler.*'`
  - `back/gradlew -p back ktlintCheck`
  - `git diff --check`
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: backlog size 기반 동시성 scaling이 제거되어 극단적 backlog에서 한 tick의 claim량이 worker slot으로 제한됩니다.
- 롤백 방법: PR revert로 기존 backlog count 기반 scaling을 복원합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
