### PR TITLE
[Hotfix] DB runtime env fallback 복구

### DIFF
--- a/back/src/main/resources/application-prod.yaml
+++ b/back/src/main/resources/application-prod.yaml
@@ -13,7 +13,7 @@ spring:
     redis:
       password: "${PROD___SPRING__DATA__REDIS__PASSWORD}"
   datasource:
-    username: "${PROD___SPRING__DATASOURCE__USERNAME}"
+    username: "${PROD___SPRING__DATASOURCE__USERNAME:postgres}"
     password: "${PROD___SPRING__DATASOURCE__PASSWORD}"
     hikari:
       # 홈서버 환경에서 worker + API 동시 부하 시 커넥션 대기(수초~수십초)를 줄인다.

--- a/deploy/env/env.contract.json
+++ b/deploy/env/env.contract.json
@@ -40,7 +40,7 @@
         { "name": "GRAFANA_ADMIN_USER" },
         { "name": "GRAFANA_ADMIN_PASSWORD", "secret": true, "minLength": 8 },
         { "name": "GRAFANA_ROOT_URL", "kind": "https-url" },
-        { "name": "PROD___SPRING__DATASOURCE__USERNAME" },
+        { "name": "PROD___SPRING__DATASOURCE__USERNAME", "required": false },
         { "name": "PROD___SPRING__DATASOURCE__PASSWORD", "secret": true, "minLength": 8 },
         { "name": "PROD___POSTGRES__PASSWORD", "secret": true, "required": false, "minLength": 8 },
         { "name": "PROD___SPRING__DATA__REDIS__PASSWORD", "secret": true, "minLength": 8 },

--- a/deploy/homeserver/blue_green_deploy.sh
+++ b/deploy/homeserver/blue_green_deploy.sh
@@ -960,7 +960,6 @@ require_pinned_image_env_key() {
 validate_required_runtime_env() {
   require_nonempty_env_key "API_DOMAIN"
   require_nonempty_env_key "CF_TUNNEL_TOKEN"
-  require_nonempty_env_key "PROD___SPRING__DATASOURCE__USERNAME"
   require_nonempty_env_key "PROD___SPRING__DATASOURCE__PASSWORD"
   ensure_image_env_key_from_local_digest "CLOUDFLARED_IMAGE" "cloudflare/cloudflared:latest"
   ensure_image_env_key_from_local_digest "DB_IMAGE" "jangka512/pgj:latest"
@@ -998,8 +997,8 @@ validate_db_runtime_role_env() {
   runtime_user="$(trim_quotes "$(env_value "PROD___SPRING__DATASOURCE__USERNAME")")"
 
   if [[ -z "${runtime_user}" ]]; then
-    echo "runtime datasource user is missing: PROD___SPRING__DATASOURCE__USERNAME" >&2
-    return 1
+    echo "runtime datasource user is not set; falling back to legacy postgres user" >&2
+    return 0
   fi
   if [[ "${runtime_user}" == "postgres" ]]; then
     echo "runtime datasource user must not be postgres" >&2

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -87,6 +87,19 @@ test("home-server-source contract accepts a complete deployment env without BACK
   assert.equal(result.ok, true, result.errors.map((error) => error.message).join("\n"))
 })
 
+test("home-server-source keeps DB runtime username optional until the role is provisioned", async () => {
+  const { loadContract, validateEnvText } = await import("../env/validate-env.mjs")
+  const text = baseHomeServerEnv.replace(/^PROD___SPRING__DATASOURCE__USERNAME=.*\n/m, "")
+
+  const result = validateEnvText({
+    contract: loadContract(contractPath),
+    target: "home-server-source",
+    text,
+  })
+
+  assert.equal(result.ok, true, result.errors.map((error) => error.message).join("\n"))
+})
+
 test("validator reports key-level failures without leaking secret values", async () => {
   const { loadContract, validateEnvText } = await import("../env/validate-env.mjs")
   const text = baseHomeServerEnv
@@ -162,7 +175,7 @@ test("prod datasource uses a non-superuser runtime role contract", () => {
   const applicationProd = readFileSync(applicationProdPath, "utf8")
   const deployScript = readFileSync(deployScriptPath, "utf8")
 
-  assert.match(applicationProd, /username:\s*"\$\{PROD___SPRING__DATASOURCE__USERNAME\}"/)
+  assert.match(applicationProd, /username:\s*"\$\{PROD___SPRING__DATASOURCE__USERNAME:postgres\}"/)
   assert.match(compose, /POSTGRES_PASSWORD:\s*\$\{PROD___POSTGRES__PASSWORD:-\$\{PROD___SPRING__DATASOURCE__PASSWORD\}\}/)
   assert(!compose.includes("POSTGRES_PASSWORD: ${PROD___SPRING__DATASOURCE__PASSWORD}"))
   assert.match(deployScript, /validate_db_runtime_role_env/)


### PR DESCRIPTION
## 관련 이슈

close #424

## 작업 배경

- #411 merge 후 HOME_SERVER_ENV에 `PROD___SPRING__DATASOURCE__USERNAME`이 아직 없어 자동 배포가 contract validation 단계에서 실패했습니다.
- DB role/secret을 운영에서 준비하기 전까지 main 배포 가능성을 유지하도록 runtime username을 optional 전환 키로 보정했습니다.

## 작업 내용

- `PROD___SPRING__DATASOURCE__USERNAME`을 env contract에서 optional로 변경했습니다.
- prod datasource username은 키가 없으면 기존 `postgres` fallback을 사용하도록 복구했습니다.
- deploy guard는 키가 없으면 legacy fallback 경고만 남기고, 키가 명시적으로 `postgres`이면 실패하도록 유지했습니다.
- HOME_SERVER_ENV에 새 username이 없는 상태를 검증하는 regression test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/test/env-contract.test.mjs` (RED 확인 후 GREEN)
  - `bash -n deploy/homeserver/blue_green_deploy.sh deploy/homeserver/doctor.sh`
  - `git diff --check`
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 운영 DB role을 준비하기 전까지 JDBC user는 기존처럼 `postgres` fallback을 사용합니다. 다만 `PROD___SPRING__DATASOURCE__USERNAME`을 설정하면 non-postgres role로 전환할 수 있고, 명시적 `postgres` 값은 guard가 거부합니다.
- 롤백 방법: PR revert. 단, revert하면 HOME_SERVER_ENV에 username이 없는 현재 상태에서 자동 배포가 다시 실패합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
