### PR TITLE
[Refactor] EditorStudioWorkspaceControllerRoot 1000 line 이하 분리

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -143,6 +143,23 @@ test.describe("editor studio state", () => {
     const editorStudioSource = existsSync(editorStudioRootPath)
       ? readFileSync(editorStudioRootPath, "utf8")
       : editorStudioControllerSource
+    const editorStudioRootViewPath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/EditorStudioWorkspaceControllerRootView.tsx"
+    )
+    expect(existsSync(editorStudioRootViewPath)).toBe(true)
+    const editorStudioRootViewSource = existsSync(editorStudioRootViewPath)
+      ? readFileSync(editorStudioRootViewPath, "utf8")
+      : ""
+    const editorStudioRuntimePath = path.resolve(
+      __dirname,
+      "../src/routes/Admin/useEditorStudioWorkspaceControllerRuntime.ts"
+    )
+    expect(existsSync(editorStudioRuntimePath)).toBe(true)
+    const editorStudioRuntimeSource = existsSync(editorStudioRuntimePath)
+      ? readFileSync(editorStudioRuntimePath, "utf8")
+      : ""
+    const editorStudioPresentationSource = `${editorStudioSource}\n${editorStudioRootViewSource}\n${editorStudioRuntimeSource}`
     const dedicatedEditorSurfacePath = path.resolve(
       __dirname,
       "../src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx"
@@ -677,8 +694,9 @@ test.describe("editor studio state", () => {
     expect(editorStudioSource).not.toContain("BLOCK_EDITOR_V2_ENABLED")
     expect(editorStudioSource).not.toContain("EditorStudioLegacyToolbar")
     expect(editorStudioSource).not.toContain("RawMarkdownTextarea")
-    expect(editorStudioSource).toContain("const isCompactSplitPreview = false")
-    expect(editorStudioSource).toContain("EditorStudioDedicatedEditorSurface")
+    expect(editorStudioPresentationSource).toContain('import { EditorStudioWorkspaceControllerRootView } from "./EditorStudioWorkspaceControllerRootView"')
+    expect(editorStudioRootViewSource).toContain("const isCompactSplitPreview = false")
+    expect(editorStudioRootViewSource).toContain("EditorStudioDedicatedEditorSurface")
     expect(editorStudioSource).not.toContain("const EditorStudioRoot")
     expect(dedicatedEditorRootStyle).toContain("width: 100vw;")
     expect(dedicatedEditorRootStyle).toContain("margin-left: calc(50% - 50vw);")
@@ -705,9 +723,9 @@ test.describe("editor studio state", () => {
     expect(quickInsertButtonStyle).toContain("white-space: nowrap;")
     expect(dedicatedEditorSurfacePartsSource).toContain("grid-template-columns: minmax(0, 1fr);")
     expect(dedicatedEditorSurfaceSource).toContain('data-testid="editor-studio-frame"')
-    expect(editorStudioSource).toContain('import { WriterEditorHost } from "./WriterEditorHost"')
-    expect(editorStudioSource.match(/<WriterEditorHost/g)?.length).toBe(2)
-    expect(editorStudioSource).not.toContain("<LazyBlockEditorShell")
+    expect(editorStudioRootViewSource).toContain('import { WriterEditorHost } from "./WriterEditorHost"')
+    expect(editorStudioRootViewSource.match(/<WriterEditorHost/g)?.length).toBe(2)
+    expect(editorStudioRootViewSource).not.toContain("<LazyBlockEditorShell")
     expect(editorStudioSource).not.toContain("EditorStudioPreviewColumn")
     expect(editorStudioSource).not.toContain('data-testid="editor-preview-body"')
     expect(editorStudioSource).not.toContain("LazyMarkdownRenderer")
@@ -732,8 +750,8 @@ test.describe("editor studio state", () => {
     expect(editorStudioSource).not.toContain("const publishActionButtonText =")
     expect(editorStudioSource).not.toContain("const publishActionTriggerDisabled =")
     expect(editorStudioSource).not.toContain("const mobilePrimaryActionLabel =")
-    expect(editorStudioSource).toContain('import { useEditorStudioThumbnailPreview } from "./useEditorStudioThumbnailPreview"')
-    expect(editorStudioSource).toContain('import { useEditorStudioThumbnailControls } from "./useEditorStudioThumbnailControls"')
+    expect(editorStudioPresentationSource).toContain('import { useEditorStudioThumbnailPreview } from "./useEditorStudioThumbnailPreview"')
+    expect(editorStudioPresentationSource).toContain('import { useEditorStudioThumbnailControls } from "./useEditorStudioThumbnailControls"')
     expect(editorStudioSource).not.toContain("type ThumbnailSourceSize =")
     expect(editorStudioSource).not.toContain("type ThumbnailTransformState =")
     expect(editorStudioSource).not.toContain("const thumbnailImageFileInputRef = useRef<HTMLInputElement>")
@@ -761,12 +779,12 @@ test.describe("editor studio state", () => {
     expect(editorStudioThumbnailControlsSource).toContain("const applyFirstBodyImageToThumbnail = useCallback")
     expect(editorStudioThumbnailPanelsSource).toContain("export const EditorStudioThumbnailEditorPanel =")
     expect(editorStudioThumbnailPanelsSource).toContain("export const EditorStudioThumbnailMetaPanel =")
-    expect(editorStudioSource).toContain('} from "./EditorStudioThumbnailPanels"')
+    expect(editorStudioPresentationSource).toContain('} from "./EditorStudioThumbnailPanels"')
     expect(editorStudioSource).not.toContain("const thumbnailEditorPanel = useMemo")
     expect(editorStudioSource).not.toContain("const previewMetaEditorPanel = useMemo")
     expect(editorStudioPublishModalSource).toContain("export const EditorStudioPublishModal =")
-    expect(editorStudioSource).toContain('import { EditorStudioPublishModal } from "./EditorStudioPublishModal"')
-    expect(editorStudioSource.match(/<EditorStudioPublishModal/g)?.length).toBe(2)
+    expect(editorStudioPresentationSource).toContain('import { EditorStudioPublishModal } from "./EditorStudioPublishModal"')
+    expect(editorStudioPresentationSource.match(/<EditorStudioPublishModal/g)?.length).toBe(2)
     expect(editorStudioSource).not.toContain("<PublishModal")
     expect(editorStudioSource).not.toContain("const PublishModal = styled.div`")
     expect(editorStudioSource).not.toContain("const PublishOverviewGrid = styled.div`")
@@ -790,10 +808,10 @@ test.describe("editor studio state", () => {
     expect(editorStudioSource).not.toContain("<strong>태그 정리</strong>")
     expect(editorStudioSource).not.toContain("<strong>보조 작업</strong>")
     expect(editorStudioContentWorkspaceSource).toContain("export const EditorStudioContentWorkspace =")
-    expect(editorStudioSource).toContain(
+    expect(editorStudioPresentationSource).toContain(
       'import { EditorStudioContentWorkspace } from "./EditorStudioContentWorkspace"'
     )
-    expect(editorStudioSource.match(/<EditorStudioContentWorkspace/g)?.length).toBe(1)
+    expect(editorStudioPresentationSource.match(/<EditorStudioContentWorkspace/g)?.length).toBe(1)
     expect(editorStudioSelectedPostToolsPanelSource).toContain("export const EditorStudioSelectedPostToolsPanel =")
     expect(editorStudioContentWorkspaceSource).toContain(
       'import { EditorStudioSelectedPostToolsPanel } from "./EditorStudioSelectedPostToolsPanel"'
@@ -806,8 +824,8 @@ test.describe("editor studio state", () => {
     expect(editorStudioSource).not.toContain("<strong>다른 글 직접 불러오기</strong>")
     expect(editorStudioSource).not.toContain("<strong>post id 직접 불러오기</strong>")
     expect(editorStudioSource).not.toContain("<strong>진단 도구</strong>")
-    expect(editorStudioSource).toContain("const handleSelectedPostIdChange = useCallback")
-    expect(editorStudioSource).toContain("onPostIdChange={handleSelectedPostIdChange}")
+    expect(editorStudioPresentationSource).toContain("const handleSelectedPostIdChange = useCallback")
+    expect(editorStudioPresentationSource).toContain("onPostIdChange={handleSelectedPostIdChange}")
     expect(editorStudioSelectedPostToolsPanelSource).not.toContain("apiFetch(")
     expect(editorStudioSelectedPostToolsPanelSource).not.toContain("setPostId")
     expect(editorStudioSelectedPostToolsPanelSource).not.toContain("setEditorMode")
@@ -830,20 +848,20 @@ test.describe("editor studio state", () => {
     expect(editorStudioSource).not.toContain("const SelectedPostPanel = styled.div`")
     expect(editorStudioSource).not.toContain("const SelectedPostHeader = styled.div`")
     expect(editorStudioSource).not.toContain("const SelectedPostStateCard = styled.div`")
-    expect(editorStudioSource).toContain("const handleContinueSelectedPostEditing = useCallback")
-    expect(editorStudioSource).toContain("onContinueEditing={handleContinueSelectedPostEditing}")
-    expect(editorStudioSource).toContain("onCreateNewPost={handleCreateNewPostFromSelectedPanel}")
-    expect(editorStudioSource).toContain("onDeletePost={handleDeleteSelectedPost}")
+    expect(editorStudioPresentationSource).toContain("const handleContinueSelectedPostEditing = useCallback")
+    expect(editorStudioPresentationSource).toContain("onContinueEditing={handleContinueSelectedPostEditing}")
+    expect(editorStudioPresentationSource).toContain("onCreateNewPost={handleCreateNewPostFromSelectedPanel}")
+    expect(editorStudioPresentationSource).toContain("onDeletePost={handleDeleteSelectedPost}")
     expect(editorStudioSelectedPostPanelSource).not.toContain("openPublishModal")
     expect(editorStudioSelectedPostPanelSource).not.toContain("switchToCreateMode")
     expect(editorStudioSelectedPostPanelSource).not.toContain("openDeleteConfirm")
     expect(editorStudioSelectedPostPanelSource).not.toContain("apiFetch(")
     expect(editorStudioSelectedPostPanelSource).not.toContain("run(")
     expect(editorStudioLegacyProfileSectionSource).toContain("export const EditorStudioLegacyProfileSection =")
-    expect(editorStudioSource).toContain(
+    expect(editorStudioPresentationSource).toContain(
       'import { EditorStudioLegacyProfileSection } from "./EditorStudioLegacyProfileSection"'
     )
-    expect(editorStudioSource.match(/<EditorStudioLegacyProfileSection/g)?.length).toBe(1)
+    expect(editorStudioPresentationSource.match(/<EditorStudioLegacyProfileSection/g)?.length).toBe(1)
     expect(editorStudioLegacyProfileSectionSource).toContain("Profile Studio")
     expect(editorStudioLegacyProfileSectionSource).toContain("프로필 이미지 선택")
     expect(editorStudioLegacyProfileSectionSource).toContain("역할/소개 저장")
@@ -856,10 +874,10 @@ test.describe("editor studio state", () => {
     expect(editorStudioLegacyProfileSectionSource).not.toContain("setProfileRoleInput")
     expect(editorStudioLegacyProfileSectionSource).not.toContain("setProfileBioInput")
     expect(editorStudioLegacyUtilityPanelSource).toContain("export const EditorStudioLegacyUtilityPanel =")
-    expect(editorStudioSource).toContain(
+    expect(editorStudioPresentationSource).toContain(
       'import { EditorStudioLegacyUtilityPanel } from "./EditorStudioLegacyUtilityPanel"'
     )
-    expect(editorStudioSource.match(/<EditorStudioLegacyUtilityPanel/g)?.length).toBe(1)
+    expect(editorStudioPresentationSource.match(/<EditorStudioLegacyUtilityPanel/g)?.length).toBe(1)
     expect(editorStudioLegacyUtilityPanelSource).toContain("댓글 테스트 도구")
     expect(editorStudioLegacyUtilityPanelSource).toContain("운영 점검 도구")
     expect(editorStudioSource).not.toContain("<UtilityGrid>")
@@ -870,10 +888,10 @@ test.describe("editor studio state", () => {
     expect(editorStudioLegacyUtilityPanelSource).not.toContain("setCommentId")
     expect(editorStudioLegacyUtilityPanelSource).not.toContain("setCommentContent")
     expect(editorStudioResultLogPanelSource).toContain("export const EditorStudioResultLogPanel =")
-    expect(editorStudioSource).toContain(
+    expect(editorStudioPresentationSource).toContain(
       'import { EditorStudioResultLogPanel } from "./EditorStudioResultLogPanel"'
     )
-    expect(editorStudioSource.match(/<EditorStudioResultLogPanel/g)?.length).toBe(2)
+    expect(editorStudioPresentationSource.match(/<EditorStudioResultLogPanel/g)?.length).toBe(2)
     expect(editorStudioSource).not.toContain("const ResultPanel = styled.pre`")
     expect(editorStudioSource).not.toContain("const DevConsoleSection = styled.section`")
     expect(editorStudioSource).not.toContain("const EditorStudioResultPanel = styled.section`")
@@ -955,8 +973,8 @@ test.describe("editor studio state", () => {
     expect(useEditorStudioListConditionsSource).toContain("export const LIST_SORT_OPTIONS =")
     expect(useEditorStudioListConditionsSource).toContain("export type PostListScope =")
     expect(useEditorStudioListConditionsSource).toContain("export type ListQuickPreset =")
-    expect(editorStudioSource).toContain('} from "./useEditorStudioListConditions"')
-    expect(editorStudioSource).toContain("useEditorStudioListConditions()")
+    expect(editorStudioPresentationSource).toContain('} from "./useEditorStudioListConditions"')
+    expect(editorStudioPresentationSource).toContain("useEditorStudioListConditions()")
     expect(editorStudioSource).not.toContain("const sanitizeNumberInput =")
     expect(editorStudioSource).not.toContain("const applyListQuickPreset = useCallback")
     expect(editorStudioSource).not.toContain("LIST_CONDITION_STORAGE_KEY")
@@ -968,10 +986,10 @@ test.describe("editor studio state", () => {
     expect(useEditorStudioListConditionsSource).not.toContain("openDeleteConfirm")
     expect(useEditorStudioListConditionsSource).not.toContain("deletePostsFromList")
     expect(editorStudioDeleteConfirmDialogSource).toContain("export const EditorStudioDeleteConfirmDialog =")
-    expect(editorStudioSource).toContain(
+    expect(editorStudioPresentationSource).toContain(
       'import { EditorStudioDeleteConfirmDialog } from "./EditorStudioDeleteConfirmDialog"'
     )
-    expect(editorStudioSource.match(/<EditorStudioDeleteConfirmDialog/g)?.length).toBe(1)
+    expect(editorStudioPresentationSource.match(/<EditorStudioDeleteConfirmDialog/g)?.length).toBe(1)
     expect(editorStudioDeleteConfirmDialogSource).toContain("글을 삭제할까요?")
     expect(editorStudioDeleteConfirmDialogSource).toContain("삭제 후에는 삭제 글 목록에서 복구할 수 있습니다.")
     expect(editorStudioSource).not.toContain("<ModalBackdrop")
@@ -996,11 +1014,11 @@ test.describe("editor studio state", () => {
     expect(editorStudioComposeMobileChromeSource).not.toContain("setPostVisibility")
     expect(editorStudioComposeWritingSurfaceSource).toContain("export const EditorStudioComposeWritingSurface =")
     expect(editorStudioComposeWorkspaceSource).toContain("export const EditorStudioComposeWorkspace =")
-    expect(editorStudioSource).toContain(
+    expect(editorStudioPresentationSource).toContain(
       'import { EditorStudioComposeWorkspace } from "./EditorStudioComposeWorkspace"'
     )
-    expect(editorStudioSource.match(/<EditorStudioComposeWorkspace/g)?.length).toBe(1)
-    expect(editorStudioSource).toContain("composeCallToActionLabel={composeCallToActionLabel}")
+    expect(editorStudioPresentationSource.match(/<EditorStudioComposeWorkspace/g)?.length).toBe(1)
+    expect(editorStudioPresentationSource).toContain("composeCallToActionLabel={composeCallToActionLabel}")
     expect(editorStudioSource).not.toContain(
       'import { EditorStudioComposeMobileChrome } from "./EditorStudioComposeMobileChrome"'
     )
@@ -1081,7 +1099,7 @@ test.describe("editor studio state", () => {
     expect(editorStudioMetaModelSource).toContain("export const composeEditorContent =")
     expect(editorStudioMetaModelSource).toContain("export const buildLocalDraftFingerprint =")
     expect(editorStudioMetaModelSource).toContain("export const detectPublishPlaceholderIssue =")
-    expect(editorStudioSource).toContain('} from "./editorStudioMetaModel"')
+    expect(editorStudioPresentationSource).toContain('} from "./editorStudioMetaModel"')
     expect(editorStudioStorageModelSource).toContain("export const TAG_CATALOG_STORAGE_KEY =")
     expect(editorStudioStorageModelSource).toContain("export const CATEGORY_CATALOG_STORAGE_KEY =")
     expect(editorStudioStorageModelSource).toContain("export const readStoredCatalog =")
@@ -1089,15 +1107,17 @@ test.describe("editor studio state", () => {
     expect(editorStudioStorageModelSource).toContain("export const readLocalDraft =")
     expect(editorStudioStorageModelSource).toContain("export const persistLocalDraft =")
     expect(editorStudioStorageModelSource).toContain("export const removeLocalDraft =")
-    expect(editorStudioSource).toContain('} from "./editorStudioStorageModel"')
-    expect(editorStudioSource).toContain('import { useEditorStudioAdminPostFlow } from "./useEditorStudioAdminPostFlow"')
-    expect(editorStudioSource).toContain('import { useEditorStudioUtilityCommands } from "./useEditorStudioUtilityCommands"')
-    expect(editorStudioSource).toContain('import { useEditorStudioProfileCommands } from "./useEditorStudioProfileCommands"')
-    expect(editorStudioSource).toContain('import { useEditorStudioMetaCatalog } from "./useEditorStudioMetaCatalog"')
-    expect(editorStudioSource).toContain('import { useEditorStudioPublishModalFlow } from "./useEditorStudioPublishModalFlow"')
+    expect(editorStudioPresentationSource).toContain('} from "./editorStudioStorageModel"')
+    expect(editorStudioPresentationSource).toContain('import { useEditorStudioAdminPostFlow } from "./useEditorStudioAdminPostFlow"')
+    expect(editorStudioPresentationSource).toContain('import { useEditorStudioUtilityCommands } from "./useEditorStudioUtilityCommands"')
+    expect(editorStudioPresentationSource).toContain('import { useEditorStudioProfileCommands } from "./useEditorStudioProfileCommands"')
+    expect(editorStudioPresentationSource).toContain('import { useEditorStudioMetaCatalog } from "./useEditorStudioMetaCatalog"')
+    expect(editorStudioPresentationSource).toContain('import { useEditorStudioPublishModalFlow } from "./useEditorStudioPublishModalFlow"')
     expect(editorStudioPageSource).toContain('import { EditorStudioWorkspaceController } from "./EditorStudioWorkspaceController"')
     expect(editorStudioPageSource.split("\n").length).toBeLessThanOrEqual(1500)
     expect(editorStudioControllerSource.split("\n").length).toBeLessThanOrEqual(1000)
+    expect(editorStudioSource.split("\n").length).toBeLessThanOrEqual(1000)
+    expect(editorStudioRootViewSource.split("\n").length).toBeLessThanOrEqual(1000)
     expect(editorStudioControllerSource).toContain('from "./EditorStudioWorkspaceControllerRoot"')
     expect(editorStudioSource).not.toContain("const loadAdminPosts = useCallback(")
     expect(editorStudioSource).not.toContain("const deletePostsFromList = async")
@@ -1633,11 +1653,16 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx"),
       "utf8"
     )
+    const editorStudioRuntimeSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/useEditorStudioWorkspaceControllerRuntime.ts"),
+      "utf8"
+    )
     const revalidateApiSource = readFileSync(path.resolve(__dirname, "../src/pages/api/revalidate.ts"), "utf8")
 
-    expect(editorStudioSource).toContain("await invalidatePublicPostReadCaches(queryClient, resolvedPostId || undefined)")
-    expect(editorStudioSource).toContain('const revalidateResponse = await fetch("/api/revalidate", {')
-    expect(editorStudioSource).toContain("paths: [toCanonicalPostPath(resolvedPostId)]")
+    expect(editorStudioSource).toContain('import { useEditorStudioWorkspaceControllerRuntime } from "./useEditorStudioWorkspaceControllerRuntime"')
+    expect(editorStudioRuntimeSource).toContain("await invalidatePublicPostReadCaches(queryClient, resolvedPostId || undefined)")
+    expect(editorStudioRuntimeSource).toContain('const revalidateResponse = await fetch("/api/revalidate", {')
+    expect(editorStudioRuntimeSource).toContain("paths: [toCanonicalPostPath(resolvedPostId)]")
     expect(revalidateApiSource).toContain('import { invalidatePublicPostReadCaches } from "src/apis/backend/posts"')
     expect(revalidateApiSource).toContain('import { fetchServerAdminSession } from "src/libs/server/authSession"')
     expect(revalidateApiSource).toContain("await invalidatePublicPostReadCaches()")
@@ -2157,13 +2182,18 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/routes/Admin/useEditorStudioRouting.ts"),
       "utf8"
     )
+    const editorStudioRootViewSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceControllerRootView.tsx"),
+      "utf8"
+    )
+    const editorStudioBootstrapSource = `${editorStudioSource}\n${editorStudioRootViewSource}`
 
-    expect(editorStudioSource).toContain("const isDedicatedNewEditorRoute = isDedicatedEditorRoute && router.pathname === EDITOR_NEW_ROUTE_PATH")
-    expect(editorStudioSource).toContain("const [isNewEditorBootstrapPending, setIsNewEditorBootstrapPending] = useState(isDedicatedNewEditorRoute)")
+    expect(editorStudioBootstrapSource).toContain("const isDedicatedNewEditorRoute = isDedicatedEditorRoute && router.pathname === EDITOR_NEW_ROUTE_PATH")
+    expect(editorStudioBootstrapSource).toContain("const [isNewEditorBootstrapPending, setIsNewEditorBootstrapPending] = useState(isDedicatedNewEditorRoute)")
     expect(editorStudioDraftLifecycleSource).toContain("if (options?.redirectToEditor && tempPost.id) {")
     expect(editorStudioDraftLifecycleSource).toContain("await replaceRoute(router, destination)")
     expect(editorStudioRoutingSource).toContain("setIsNewEditorBootstrapPending(true)")
-    expect(editorStudioSource).toContain("(isNewEditorBootstrapPending || loadingKey === \"postTemp\")")
+    expect(editorStudioBootstrapSource).toContain("(isNewEditorBootstrapPending || loadingKey === \"postTemp\")")
   })
 
   test("썸네일 편집 패널은 클립보드 이미지 붙여넣기 업로드 계약을 유지한다", () => {
@@ -2179,9 +2209,18 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/routes/Admin/useEditorStudioPersistence.ts"),
       "utf8"
     )
+    const editorStudioModelSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceControllerRootModel.ts"),
+      "utf8"
+    )
+    const editorStudioRootViewSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceControllerRootView.tsx"),
+      "utf8"
+    )
 
-    expect(editorStudioSource).toContain("const extractImageFileFromClipboard = (clipboardData: DataTransfer | null): File | null => {")
-    expect(editorStudioSource).toContain("onThumbnailPaste={handleThumbnailPaste}")
+    expect(editorStudioSource).toContain('from "./EditorStudioWorkspaceControllerRootModel"')
+    expect(editorStudioModelSource).toContain("const extractImageFileFromClipboard = (clipboardData: DataTransfer | null): File | null => {")
+    expect(editorStudioRootViewSource).toContain("onThumbnailPaste={handleThumbnailPaste}")
     expect(editorStudioThumbnailPanelsSource).toContain("<PreviewEditorSection onPasteCapture={onThumbnailPaste}>")
     expect(editorStudioThumbnailPanelsSource).toContain("onPaste={onThumbnailPaste}")
     expect(editorStudioPersistenceSource).toContain("const handleThumbnailPaste = useCallback(")

--- a/front/src/routes/Admin/EditorStudioWorkspaceControllerRoot.styles.ts
+++ b/front/src/routes/Admin/EditorStudioWorkspaceControllerRoot.styles.ts
@@ -1,0 +1,134 @@
+import styled from "@emotion/styled"
+
+export const Main = styled.main`
+  max-width: 1360px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 2.8rem;
+
+  @media (max-width: 720px) {
+    padding-bottom: calc(7rem + env(safe-area-inset-bottom, 0px));
+  }
+
+  @media (max-width: 720px) {
+    padding:
+      1rem
+      max(0.78rem, env(safe-area-inset-right))
+      calc(7rem + env(safe-area-inset-bottom, 0px))
+      max(0.78rem, env(safe-area-inset-left));
+  }
+`
+
+export const HeroCard = styled.section`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.72rem;
+  border-radius: 16px;
+  border: 1px solid ${({ theme }) => theme.colors.gray5};
+  background: ${({ theme }) => theme.colors.gray2};
+  box-shadow: none;
+  padding: 0.88rem 0.96rem;
+  margin-bottom: 0.92rem;
+
+  @media (max-width: 760px) {
+    grid-template-columns: 1fr;
+    gap: 0.78rem;
+    border-radius: 16px;
+    box-shadow: none;
+    padding: 0.88rem 0.92rem;
+  }
+
+  &[data-compact-manage="true"] {
+    margin-bottom: 0.7rem;
+
+    @media (max-width: 760px) {
+      gap: 0.6rem;
+      padding: 0.72rem 0.8rem;
+    }
+  }
+`
+
+export const HeroIntro = styled.div`
+  display: grid;
+  gap: 0.42rem;
+
+  h1 {
+    margin: 0;
+    font-size: clamp(1.74rem, 2.7vw, 2.3rem);
+    line-height: 1.14;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    word-break: keep-all;
+    text-wrap: balance;
+    color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  p {
+    margin: 0;
+    max-width: 32rem;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.84rem;
+    line-height: 1.5;
+  }
+
+  &[data-compact-manage="true"] {
+    gap: 0.5rem;
+
+    p {
+      font-size: 0.86rem;
+      line-height: 1.55;
+    }
+  }
+`
+
+export const StudioStatusStrip = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.42rem;
+
+  @media (max-width: 1100px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (max-width: 560px) {
+    grid-template-columns: 1fr;
+  }
+`
+
+export const StudioStatusItem = styled.div`
+  display: grid;
+  gap: 0.18rem;
+  min-width: 0;
+  padding: 0.48rem 0.58rem;
+  border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray1};
+
+  span {
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.72rem;
+    font-weight: 700;
+  }
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.82rem;
+    line-height: 1.35;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  @media (max-width: 760px) {
+    &[data-optional="true"] {
+      display: none;
+    }
+  }
+`
+
+export const WorkspaceGrid = styled.div`
+  display: block;
+`
+
+export const WorkspaceMain = styled.div`
+  min-width: 0;
+`

--- a/front/src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx
+++ b/front/src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx
@@ -1,8 +1,6 @@
-import styled from "@emotion/styled"
 import { useQueryClient } from "@tanstack/react-query"
 import { useRouter } from "next/router"
 import {
-  type ChangeEvent,
   useDeferredValue,
   useCallback,
   useEffect,
@@ -11,12 +9,9 @@ import {
   useState,
   useTransition,
 } from "react"
-import { getApiBaseUrl } from "src/apis/backend/client"
-import { invalidatePublicPostReadCaches } from "src/apis/backend/posts"
 import useAuthSession from "src/hooks/useAuthSession"
 import {
   compareCategoryValues,
-  formatDate,
   normalizeCategoryValue,
 } from "src/libs/utils"
 import {
@@ -27,53 +22,26 @@ import {
   type BlockEditorLoadGuardState,
 } from "./editorLoadSyncGuard"
 import {
-  deriveComposeViewModel,
-  deriveEditorContentMetrics,
-  deriveEditorPersistenceState,
-  derivePublishActionViewModel,
-  getVisibilityLabel,
   toFlags,
   toVisibility,
   type EditorMode,
   type PostVisibility,
   type PublishActionType,
 } from "./editorStudioState"
-import { WriterEditorHost } from "./WriterEditorHost"
 import { useEditorStudioAdminPostFlow } from "./useEditorStudioAdminPostFlow"
 import { useEditorStudioDraftLifecycle } from "./useEditorStudioDraftLifecycle"
 import { useEditorStudioPersistence } from "./useEditorStudioPersistence"
 import { useEditorStudioRouting } from "./useEditorStudioRouting"
-import {
-  LIST_SORT_OPTIONS,
-  useEditorStudioListConditions,
-} from "./useEditorStudioListConditions"
+import { useEditorStudioListConditions } from "./useEditorStudioListConditions"
 import { useEditorStudioThumbnailControls } from "./useEditorStudioThumbnailControls"
 import { useEditorStudioThumbnailPreview } from "./useEditorStudioThumbnailPreview"
 import { useEditorStudioMetaCatalog } from "./useEditorStudioMetaCatalog"
 import { useEditorStudioPublishModalFlow } from "./useEditorStudioPublishModalFlow"
 import { useEditorStudioProfileCommands } from "./useEditorStudioProfileCommands"
 import { useEditorStudioUtilityCommands } from "./useEditorStudioUtilityCommands"
+import { useEditorStudioWorkspaceControllerRuntime } from "./useEditorStudioWorkspaceControllerRuntime"
+import { EditorStudioWorkspaceControllerRootView } from "./EditorStudioWorkspaceControllerRootView"
 import {
-  EditorStudioThumbnailEditorPanel,
-  EditorStudioThumbnailMetaPanel,
-} from "./EditorStudioThumbnailPanels"
-import { EditorStudioPublishModal } from "./EditorStudioPublishModal"
-import { EditorStudioLegacyProfileSection } from "./EditorStudioLegacyProfileSection"
-import { EditorStudioLegacyUtilityPanel } from "./EditorStudioLegacyUtilityPanel"
-import { EditorStudioResultLogPanel } from "./EditorStudioResultLogPanel"
-import { EditorStudioDeleteConfirmDialog } from "./EditorStudioDeleteConfirmDialog"
-import { EditorStudioComposeWorkspace } from "./EditorStudioComposeWorkspace"
-import { EditorStudioContentWorkspace } from "./EditorStudioContentWorkspace"
-import {
-  EditorStudioDedicatedEditorLoadingState,
-  EditorStudioDedicatedEditorSurface,
-} from "./EditorStudioDedicatedEditorSurface"
-import {
-  isServerTempDraftPost,
-  TEMP_DRAFT_BODY_PLACEHOLDER,
-} from "./editorTempDraft"
-import {
-  PREVIEW_SUMMARY_MAX_LENGTH,
   buildEditorStateFingerprint,
   buildLocalDraftFingerprint,
   composeEditorContent,
@@ -85,28 +53,17 @@ import {
   normalizeSafeImageUrl,
   normalizeSafePreviewThumbnailUrl,
   resolveEditorMetaSnapshot,
-  type LocalDraftPayload,
   type MetaUsageMap,
   type ResolvedEditorMetaSnapshot,
 } from "./editorStudioMetaModel"
-import {
-  pushRoute,
-  replaceShallowRoutePreservingScroll,
-} from "src/libs/router"
-import { toCanonicalPostPath } from "src/libs/utils/postPath"
+import { replaceShallowRoutePreservingScroll } from "src/libs/router"
 import type { AdminPageProps } from "src/libs/server/adminPage"
 import {
-  applyThumbnailTransformToUrl,
-  clampThumbnailZoom,
   DEFAULT_THUMBNAIL_FOCUS_X,
   DEFAULT_THUMBNAIL_FOCUS_Y,
   DEFAULT_THUMBNAIL_ZOOM,
   stripThumbnailFocusFromUrl,
 } from "src/libs/thumbnailFocus"
-import {
-  POST_IMAGE_UPLOAD_RULE_LABEL,
-  PROFILE_IMAGE_UPLOAD_RULE_LABEL,
-} from "src/libs/profileImageUpload"
 import type { BlockEditorChangeMeta } from "src/components/editor/blockEditorContract"
 import {
   CATEGORY_CATALOG_STORAGE_KEY,
@@ -117,307 +74,29 @@ import {
   readStoredCatalog,
   removeLocalDraft,
 } from "./editorStudioStorageModel"
-
-const BLOCK_EDITOR_V2_MERMAID_ENABLED = process.env.NEXT_PUBLIC_EDITOR_V2_MERMAID_ENABLED !== "false"
-const ADMIN_POSTS_WORKSPACE_ROUTE = "/admin/posts"
-const EDITOR_NEW_ROUTE_PATH = "/editor/new"
-
-const toEditorPostRoute = (id: string | number) => `/editor/${encodeURIComponent(String(id))}`
-const buildCanonicalPostUrl = (postId: string | number) => {
-  const path = toCanonicalPostPath(postId)
-  if (typeof window === "undefined") return path
-  return new URL(path, window.location.origin).toString()
-}
-
-const extractImageFileFromClipboard = (clipboardData: DataTransfer | null): File | null => {
-  if (!clipboardData) return null
-
-  const directFile = Array.from(clipboardData.files || []).find((file) => file.type.startsWith("image/"))
-  if (directFile) return directFile
-
-  const clipboardItem = Array.from(clipboardData.items || []).find(
-    (item) => item.kind === "file" && item.type.startsWith("image/")
-  )
-  if (!clipboardItem) return null
-
-  const pastedFile = clipboardItem.getAsFile()
-  if (!pastedFile || !pastedFile.type.startsWith("image/")) return null
-  return pastedFile
-}
-
-const normalizeEditorReturnRoute = (value: string) => {
-  const normalized = value.trim()
-  if (!normalized.startsWith("/") || normalized.startsWith("//")) return ""
-  if (/[\r\n]/.test(normalized)) return ""
-  if (/^\/(?:https?:|javascript:)/i.test(normalized)) return ""
-  if (normalized.startsWith("/editor")) return ""
-  return normalized
-}
-
-type JsonValue = Record<string, unknown> | unknown[] | string | number | boolean | null
-
-type PostForEditor = {
-  id: number
-  title: string
-  content: string
-  contentHtml?: string
-  version?: number
-  published: boolean
-  listed: boolean
-  tempDraft?: boolean
-}
-
-type RsData<T> = {
-  resultCode: string
-  msg: string
-  data: T
-}
-
-type NoticeTone = "idle" | "loading" | "success" | "error"
-type NoticeState = {
-  tone: NoticeTone
-  text: string
-}
-type StudioSurface = "manage" | "compose"
-type MobileStudioStep = "query" | "list" | "edit" | "publish"
-type PreviewViewportMode = "desktop" | "tablet" | "mobile"
-type ManageMobileStudioStep = "query" | "list"
-type ComposeMobileStudioStep = "edit" | "publish"
-
-const GLOBAL_NOTICE_IDLE_TEXT = "운영 작업 상태가 여기에 표시됩니다."
-const TAG_RECOMMENDATION_IDLE_TEXT = "AI 태그 추천 상태가 여기에 표시됩니다."
-const MANAGE_MOBILE_STUDIO_STEPS = ["query", "list"] as const
-const COMPOSE_MOBILE_STUDIO_STEPS = ["edit", "publish"] as const
-
-const MOBILE_STUDIO_STEP_LABEL: Record<MobileStudioStep, string> = {
-  query: "조회",
-  list: "목록",
-  edit: "편집",
-  publish: "발행",
-}
-const MOBILE_STUDIO_STEP_DESCRIPTION: Record<MobileStudioStep, string> = {
-  query: "페이지/키워드/정렬 조건을 먼저 정리하고 목록을 불러오세요.",
-  list: "목록에서 대상 글을 선택하거나 post id를 확인해 편집 단계로 넘깁니다.",
-  edit: "본문, 태그, 메타를 정리한 뒤 발행 설정으로 이동합니다.",
-  publish: "노출 범위와 카드 미리보기를 확인하고 최종 반영하세요.",
-}
-
-const getMobileStudioStepMoveLabel = (step: MobileStudioStep) =>
-  `${MOBILE_STUDIO_STEP_LABEL[step]}${MOBILE_STUDIO_STEP_LABEL[step].endsWith("집") ? "으로" : "로"} 이동`
-
-const PROFILE_IMAGE_UPLOAD_RETRY_DELAY_MS = 700
-const IMAGE_UPLOAD_CONFLICT_MAX_RETRIES = 3
-const EDITOR_BODY_PLACEHOLDER = "내용을 입력하세요."
-
-const syncTitleTextareaHeight = (element: HTMLTextAreaElement | null) => {
-  if (!element) return
-  element.style.height = "0px"
-  element.style.height = `${Math.max(element.scrollHeight, 44)}px`
-}
-const PREVIEW_CARD_VIEWPORTS: Record<
-  PreviewViewportMode,
-  {
-    label: string
-    description: string
-    cardWidth: number
-  }
-> = {
-  desktop: {
-    label: "Desktop",
-    description: "1440px 메인 카드 폭",
-    cardWidth: 368,
-  },
-  tablet: {
-    label: "iPad mini",
-    description: "768px 2열 카드 폭",
-    cardWidth: 320,
-  },
-  mobile: {
-    label: "iPhone 15 Pro",
-    description: "393px 1열 카드 폭",
-    cardWidth: 286,
-  },
-}
-
-const isTempDraftBodyPlaceholder = (value: string) => {
-  const normalized = value.replace(/\r\n?/g, "\n").trim()
-  return normalized === TEMP_DRAFT_BODY_PLACEHOLDER || normalized === EDITOR_BODY_PLACEHOLDER
-}
-
-const isBlankServerTempDraft = (
-  post: Pick<PostForEditor, "title" | "published" | "listed" | "tempDraft">,
-  snapshot: ResolvedEditorMetaSnapshot
-) => isServerTempDraftPost(post) && isTempDraftBodyPlaceholder(snapshot.body)
-
-const buildEmptyEditorMetaSnapshot = (): ResolvedEditorMetaSnapshot => ({
-  body: "",
-  tags: [],
-  category: "",
-  summary: "",
-  thumbnailUrl: "",
-  thumbnailFocusX: DEFAULT_THUMBNAIL_FOCUS_X,
-  thumbnailFocusY: DEFAULT_THUMBNAIL_FOCUS_Y,
-  thumbnailZoom: DEFAULT_THUMBNAIL_ZOOM,
-})
-const PREVIEW_CARD_VIEWPORT_ORDER: PreviewViewportMode[] = ["desktop", "tablet", "mobile"]
-const PUBLISH_VISIBILITY_OPTIONS: Array<{
-  value: PostVisibility
-  label: string
-  description: string
-}> = [
-  {
-    value: "PUBLIC_LISTED",
-    label: "전체 공개",
-    description: "메인 목록과 검색에 노출됩니다.",
-  },
-  {
-    value: "PUBLIC_UNLISTED",
-    label: "링크 공개",
-    description: "URL을 아는 사람만 볼 수 있습니다.",
-  },
-  {
-    value: "PRIVATE",
-    label: "비공개",
-    description: "관리자만 확인합니다.",
-  },
-]
-
-const SHOW_LEGACY_PROFILE_STUDIO = process.env.NEXT_PUBLIC_SHOW_LEGACY_PROFILE_STUDIO === "true"
-const SHOW_LEGACY_CONTENT_STUDIO = process.env.NEXT_PUBLIC_SHOW_LEGACY_CONTENT_STUDIO === "true"
-const SHOW_LEGACY_UTILITY_STUDIO = process.env.NEXT_PUBLIC_SHOW_LEGACY_UTILITY_STUDIO === "true"
-
-const pretty = (value: unknown) => JSON.stringify(value, null, 2)
-
-const isComposingKeyboardEvent = (
-  event: React.KeyboardEvent<HTMLElement>
-) => {
-  const nativeEvent = event.nativeEvent as KeyboardEvent & { isComposing?: boolean; keyCode?: number }
-  return nativeEvent.isComposing === true || nativeEvent.keyCode === 229
-}
-
-const generateIdempotencyKey = () => {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID()
-  }
-  return `post-write-${Date.now()}-${Math.random().toString(16).slice(2)}`
-}
-
-const EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT = 240
-
-type RuntimeGuardWindow = Window & {
-  __AQ_RUNTIME_GUARD_ENABLED__?: boolean
-  __AQ_RUNTIME_GUARD__?: {
-    editorCommitSamples?: number[]
-  }
-}
-
-const recordEditorCommitDurationForRuntimeGuard = (actualDuration: number) => {
-  if (typeof window === "undefined" || !Number.isFinite(actualDuration) || actualDuration <= 0) return
-  const runtimeWindow = window as RuntimeGuardWindow
-  if (!runtimeWindow.__AQ_RUNTIME_GUARD_ENABLED__) return
-
-  const store = (runtimeWindow.__AQ_RUNTIME_GUARD__ ??= {})
-  const nextSamples = [...(store.editorCommitSamples ?? []), actualDuration]
-  if (nextSamples.length > EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT) {
-    nextSamples.splice(0, nextSamples.length - EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT)
-  }
-  store.editorCommitSamples = nextSamples
-}
-
-const parseResponseErrorBody = async (response: Response): Promise<string> => {
-  const text = await response.text().catch(() => "")
-  if (!text) return ""
-
-  try {
-    const parsed = JSON.parse(text) as { resultCode?: string; msg?: string }
-    const msg = parsed.msg?.trim()
-    if (!msg) return text
-    return parsed.resultCode ? `${msg} (${parsed.resultCode})` : msg
-  } catch {
-    return text
-  }
-}
-
-const waitFor = (ms: number) =>
-  new Promise<void>((resolve) => {
-    window.setTimeout(resolve, ms)
-  })
-
-const computeConflictRetryDelay = (attempt: number): number =>
-  PROFILE_IMAGE_UPLOAD_RETRY_DELAY_MS * Math.max(1, attempt + 1)
-
-const TEMP_POST_CONFLICT_MAX_RETRIES = 2
-
-const requestTempPostWithConflictRetry = async (
-  resolveExistingTempPost: () => Promise<PostForEditor | null>,
-  maxRetries: number = TEMP_POST_CONFLICT_MAX_RETRIES
-): Promise<RsData<PostForEditor>> => {
-  let lastConflictBody = ""
-
-  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
-    const response = await fetch(`${getApiBaseUrl()}/post/api/v1/posts/temp`, {
-      method: "POST",
-      credentials: "include",
-    })
-
-    if (response.status !== 409) {
-      if (!response.ok) {
-        const body = await parseResponseErrorBody(response)
-        throw new Error(body || `임시글 불러오기 실패 (${response.status})`)
-      }
-
-      return (await response.json()) as RsData<PostForEditor>
-    }
-
-    lastConflictBody = await parseResponseErrorBody(response)
-    if (attempt < maxRetries) {
-      await waitFor(computeConflictRetryDelay(attempt))
-      continue
-    }
-  }
-
-  const recoveredTempPost = await resolveExistingTempPost()
-  if (recoveredTempPost) {
-    return {
-      resultCode: "200-1",
-      msg: "기존 임시저장 글을 불러옵니다.",
-      data: recoveredTempPost,
-    }
-  }
-
-  throw new Error(lastConflictBody || "요청 충돌이 발생했습니다. 다시 시도해주세요.")
-}
-
-const uploadWithConflictRetry = async (
-  requestUpload: () => Promise<Response>,
-  maxRetries: number = IMAGE_UPLOAD_CONFLICT_MAX_RETRIES
-): Promise<Response> => {
-  let lastConflictBody = ""
-
-  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
-    const response = await requestUpload()
-    if (response.status !== 409) {
-      if (!response.ok) {
-        const body = await parseResponseErrorBody(response)
-        throw new Error(`이미지 업로드 실패 (${response.status}): ${body}`)
-      }
-      return response
-    }
-
-    lastConflictBody = await parseResponseErrorBody(response)
-    if (attempt >= maxRetries) {
-      throw new Error(
-        `이미지 업로드 실패 (409): ${lastConflictBody || "요청 충돌이 반복되어 업로드를 완료하지 못했습니다."}`
-      )
-    }
-
-    await waitFor(computeConflictRetryDelay(attempt))
-  }
-
-  throw new Error(
-    `이미지 업로드 실패 (409): ${lastConflictBody || "요청 충돌이 반복되어 업로드를 완료하지 못했습니다."}`
-  )
-}
+import {
+  ADMIN_POSTS_WORKSPACE_ROUTE,
+  EDITOR_NEW_ROUTE_PATH,
+  GLOBAL_NOTICE_IDLE_TEXT,
+  TAG_RECOMMENDATION_IDLE_TEXT,
+  buildEffectiveThumbnailUrl,
+  buildEmptyEditorMetaSnapshot,
+  extractImageFileFromClipboard,
+  generateIdempotencyKey,
+  isBlankServerTempDraft,
+  normalizeEditorReturnRoute,
+  pretty,
+  requestTempPostWithConflictRetry,
+  toEditorPostRoute,
+  uploadWithConflictRetry,
+  type ComposeMobileStudioStep,
+  type ManageMobileStudioStep,
+  type NoticeState,
+  type PostForEditor,
+  type PreviewViewportMode,
+  type RsData,
+  type StudioSurface,
+} from "./EditorStudioWorkspaceControllerRootModel"
 
 export const EditorStudioWorkspaceController = ({ initialMember }: AdminPageProps) => {
   const router = useRouter()
@@ -502,7 +181,6 @@ export const EditorStudioWorkspaceController = ({ initialMember }: AdminPageProp
   const [isCompactMobileLayout, setIsCompactMobileLayout] = useState(false)
   const [isMobileThumbnailEditorOpen, setIsMobileThumbnailEditorOpen] = useState(false)
   const [isMobileMetaEditorOpen, setIsMobileMetaEditorOpen] = useState(false)
-  const titleFieldRef = useRef<HTMLTextAreaElement | null>(null)
 
   useEffect(() => {
     postContentLiveRef.current = postContent
@@ -577,49 +255,36 @@ export const EditorStudioWorkspaceController = ({ initialMember }: AdminPageProp
   const lastWriteIdempotencyKeyRef = useRef<string>("")
   const lastLocalDraftFingerprintRef = useRef("")
   const serverBaselineEditorFingerprintRef = useRef("")
-  const refreshPublicPostReadViews = useCallback(async (affectedPostId?: string | number) => {
-    const resolvedPostId =
-      typeof affectedPostId === "number"
-        ? affectedPostId
-        : typeof affectedPostId === "string"
-          ? affectedPostId.trim()
-          : postId.trim()
-
-    await invalidatePublicPostReadCaches(queryClient, resolvedPostId || undefined)
-    if (!resolvedPostId) return
-
-    const revalidateResponse = await fetch("/api/revalidate", {
-      method: "POST",
-      credentials: "include",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        paths: [toCanonicalPostPath(resolvedPostId)],
-      }),
-    })
-
-    if (!revalidateResponse.ok) {
-      const reason = (await revalidateResponse.text().catch(() => "")).trim()
-      throw new Error(reason || "공개 상세 재검증 요청에 실패했습니다.")
-    }
-  }, [postId, queryClient])
-
-  const run = async (key: string, fn: () => Promise<JsonValue>) => {
-    try {
-      setLoadingKey(key)
-      setGlobalNotice({ tone: "loading", text: `작업 실행 중: ${key}` })
-      const data = await fn()
-      setResult(pretty(data))
-      setGlobalNotice({ tone: "success", text: `작업 완료: ${key}` })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      setResult(pretty({ error: message }))
-      setGlobalNotice({ tone: "error", text: `작업 실패: ${message}` })
-    } finally {
-      setLoadingKey("")
-    }
-  }
+  const {
+    copyPostDetailLink,
+    disabled,
+    handleSelectedPostIdChange,
+    handleTitleChange,
+    handleTitleFieldRef,
+    handleTitleKeyDown,
+    openPostDetailRoute,
+    publishModalHintByAction,
+    refreshPublicPostReadViews,
+    run,
+    setPublishStatus,
+  } = useEditorStudioWorkspaceControllerRuntime({
+    isPublishModalOpen,
+    loadingKey,
+    postId,
+    postTitle,
+    queryClient,
+    router,
+    setEditorMode,
+    setGlobalNotice,
+    setIsTempDraftMode,
+    setLoadingKey,
+    setPostId,
+    setPostTitle,
+    setPostVersion,
+    setPublishModalNotice,
+    setPublishNotice,
+    setResult,
+  })
 
   const {
     applyProfileState,
@@ -666,8 +331,6 @@ export const EditorStudioWorkspaceController = ({ initialMember }: AdminPageProp
     run,
   })
 
-  const disabled = (key: string) => loadingKey.length > 0 && loadingKey !== key
-
   useEffect(() => {
     if (typeof window === "undefined") return
 
@@ -705,126 +368,6 @@ export const EditorStudioWorkspaceController = ({ initialMember }: AdminPageProp
     delete nextQuery.surface
     void replaceShallowRoutePreservingScroll(router, { query: nextQuery })
   }, [router])
-
-  const handleTitleFieldRef = useCallback((node: HTMLTextAreaElement | null) => {
-    titleFieldRef.current = node
-    syncTitleTextareaHeight(node)
-  }, [])
-
-  const handleTitleChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>) => {
-    setPostTitle(event.target.value.replace(/\r\n?/g, "\n"))
-    syncTitleTextareaHeight(event.target)
-  }, [])
-
-  const handleTitleKeyDown = useCallback((event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (isComposingKeyboardEvent(event)) return
-    if (event.key === "Enter") {
-      event.preventDefault()
-    }
-  }, [])
-
-  useEffect(() => {
-    syncTitleTextareaHeight(titleFieldRef.current)
-  }, [postTitle])
-
-  const handleSelectedPostIdChange = useCallback(
-    (nextPostId: string) => {
-      const normalizedPostId = nextPostId.trim()
-      setPostId(normalizedPostId)
-      if (normalizedPostId !== postId.trim()) {
-        setEditorMode("create")
-        setPostVersion(null)
-        setIsTempDraftMode(false)
-      }
-    },
-    [postId]
-  )
-
-  const publishModalHintByAction = useCallback((actionType: PublishActionType): string => {
-    if (actionType === "create") return "작성 전 확인이 필요한 항목만 이곳에 표시됩니다."
-    if (actionType === "modify") return "수정 전 확인이 필요한 항목만 이곳에 표시됩니다."
-    return "새 글 작성 전 확인이 필요한 항목만 이곳에 표시됩니다."
-  }, [])
-
-  const setPublishStatus = useCallback(
-    (next: NoticeState, target: "auto" | "page" | "modal" = "auto") => {
-      setGlobalNotice(next)
-      if (target === "page") {
-        setPublishNotice(next)
-        return
-      }
-
-      if (target === "modal") {
-        setPublishModalNotice(next)
-        return
-      }
-
-      if (isPublishModalOpen) {
-        setPublishModalNotice(next)
-        return
-      }
-
-      setPublishNotice(next)
-    },
-    [isPublishModalOpen]
-  )
-
-  const openPostDetailRoute = useCallback(
-    async (targetPostId: string | number) => {
-      const resolvedPostId = String(targetPostId).trim()
-      if (!resolvedPostId) {
-        setPublishStatus({ tone: "error", text: "상세 링크를 열 글 ID가 없습니다." }, "page")
-        return
-      }
-
-      const path = toCanonicalPostPath(resolvedPostId)
-      if (typeof window !== "undefined") {
-        const opened = window.open(path, "_blank", "noopener,noreferrer")
-        if (opened) return
-      }
-
-      try {
-        await pushRoute(router, path)
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        setPublishStatus({ tone: "error", text: `상세 열기 실패: ${message}` }, "page")
-      }
-    },
-    [router, setPublishStatus]
-  )
-
-  const copyPostDetailLink = useCallback(
-    async (targetPostId: string | number, title?: string) => {
-      const resolvedPostId = String(targetPostId).trim()
-      if (!resolvedPostId) {
-        setPublishStatus({ tone: "error", text: "복사할 상세 링크가 없습니다." }, "page")
-        return
-      }
-
-      const rowLabel = `#${resolvedPostId} ${title?.trim() || "제목 없는 글"}`
-      const url = buildCanonicalPostUrl(resolvedPostId)
-
-      try {
-        if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
-          await navigator.clipboard.writeText(url)
-          setPublishStatus({ tone: "success", text: `${rowLabel} 링크를 복사했습니다.` }, "page")
-          return
-        }
-
-        if (typeof window !== "undefined") {
-          window.prompt("링크를 복사하세요.", url)
-          setPublishStatus({ tone: "success", text: `${rowLabel} 링크를 표시했습니다.` }, "page")
-          return
-        }
-
-        throw new Error("링크를 복사할 수 없는 환경입니다.")
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        setPublishStatus({ tone: "error", text: `링크 복사 실패: ${message}` }, "page")
-      }
-    },
-    [setPublishStatus]
-  )
 
   const syncEditorMeta = useCallback((content: string, contentHtml?: string | null) => {
     const snapshot = resolveEditorMetaSnapshot(content, contentHtml)
@@ -947,12 +490,11 @@ export const EditorStudioWorkspaceController = ({ initialMember }: AdminPageProp
     return stripThumbnailFocusFromUrl(normalizeSafeImageUrl(deferredContentDerived.firstImage))
   }, [deferredContentDerived.firstImage, postThumbnailUrl])
   const effectiveThumbnailUrl = useMemo(() => {
-    const normalizedThumbnail = resolvedPreviewThumbnail.trim()
-    if (!normalizedThumbnail) return ""
-    return applyThumbnailTransformToUrl(normalizedThumbnail, {
-      focusX: postThumbnailFocusX,
-      focusY: postThumbnailFocusY,
-      zoom: postThumbnailZoom,
+    return buildEffectiveThumbnailUrl({
+      postThumbnailFocusX,
+      postThumbnailFocusY,
+      postThumbnailZoom,
+      resolvedPreviewThumbnail,
     })
   }, [postThumbnailFocusX, postThumbnailFocusY, postThumbnailZoom, resolvedPreviewThumbnail])
   const safePreviewThumbnail = useMemo(() => {
@@ -1231,898 +773,50 @@ export const EditorStudioWorkspaceController = ({ initialMember }: AdminPageProp
     openDeleteConfirm([Number.parseInt(postId, 10)], postTitle)
   }, [openDeleteConfirm, postId, postTitle])
 
-  const currentFlags = toFlags(postVisibility)
-  const editorStateFingerprint = useMemo(
-    () =>
-      buildEditorStateFingerprint({
-        title: postTitle,
-        content: postContent,
-        summary: postSummary,
-        thumbnailUrl: postThumbnailUrl,
-        thumbnailFocusX: postThumbnailFocusX,
-        thumbnailFocusY: postThumbnailFocusY,
-        thumbnailZoom: postThumbnailZoom,
-        tags: postTags,
-        category: postCategory,
-        visibility: postVisibility,
-      }),
-    [
-      postCategory,
-      postContent,
-      postSummary,
-      postTags,
-      postThumbnailFocusX,
-      postThumbnailFocusY,
-      postThumbnailZoom,
-      postThumbnailUrl,
-      postTitle,
-      postVisibility,
-    ]
-  )
-  const currentVisibilityText = getVisibilityLabel(currentFlags.published, currentFlags.listed)
-  const canOpenCurrentPostDetail = editorMode === "edit" && postId.trim().length > 0
-  const composeViewModel = useMemo(
-    () =>
-      deriveComposeViewModel({
-        editorMode,
-        isTempDraftMode,
-        postId,
-        postTitle,
-        postSummary,
-        postTags,
-        currentVisibilityText,
-      }),
-    [currentVisibilityText, editorMode, isTempDraftMode, postId, postSummary, postTags, postTitle]
-  )
-  const {
-    editorModeLabel,
-    hasSelectedManagedPost,
-    currentPostLabel,
-    selectedPostLabel,
-    tagSummaryText,
-    composePageTitle,
-    composeSurfaceSubtitle,
-    composeHeroSummary,
-    composeCallToActionLabel,
-  } = composeViewModel
-  const hasListFiltersApplied =
-    listKw.trim().length > 0 ||
-    listQuickPreset !== "none" ||
-    listPage !== "1" ||
-    listPageSize !== "30" ||
-    (listScope === "active" && listSort !== "CREATED_AT")
-  const deferredContentMetrics = useMemo(
-    () => deriveEditorContentMetrics(deferredPostContent),
-    [deferredPostContent]
-  )
-  const contentLength = deferredContentMetrics.trimmedLength
-  const lineCount = deferredContentMetrics.lineCount
-  const imageCount = deferredContentMetrics.imageCount
-  const hasEditorDraftContent = Boolean(postTitle.trim() || postContent.trim())
-  const hasEditorMinimumFields = Boolean(postTitle.trim() && postContent.trim())
-  const publishPlaceholderIssue = hasEditorMinimumFields
-    ? detectPublishPlaceholderIssue(postContent)
-    : null
-  const editorPersistenceState = deriveEditorPersistenceState({
-    editorMode,
-    hasSelectedManagedPost,
-    hasEditorDraftContent,
-    editorStateFingerprint,
-    serverBaselineFingerprint: serverBaselineEditorFingerprintRef.current,
-    localDraftFingerprint: lastLocalDraftFingerprintRef.current,
-    localDraftSavedAt,
-    loadingKey,
-    publishNoticeTone: publishNotice.tone,
-  })
-  const composeStatusText = editorPersistenceState.text
-  const composeStatusTone = editorPersistenceState.tone
-  const composeSummaryPreview = useMemo(
-    () => postSummary.trim() || deferredContentDerived.summary,
-    [deferredContentDerived.summary, postSummary]
-  )
-  const profilePreviewSrc = profileImgInputUrl.trim()
-  const profileImageStatus = profilePreviewSrc ? "설정됨" : "기본 이미지 사용 중"
-  const profileRoleStatus = profileRoleInput.trim() || "미설정"
-  const profileBioStatus = profileBioInput.trim() || "미설정"
-  const profileUpdatedText = sessionMember?.modifiedAt
-    ? sessionMember.modifiedAt.slice(0, 16).replace("T", " ")
-    : "확인 전"
-  const profileImageHint = profileImageFileName
-    ? `선택 파일: ${profileImageFileName}`
-    : `${PROFILE_IMAGE_UPLOAD_RULE_LABEL} (선택 즉시 업로드)`
-  const publishActionViewModel = derivePublishActionViewModel({
-    publishActionType,
-    editorMode,
-    loadingKey,
-    hasEditorMinimumFields,
-    hasPlaceholderIssue: Boolean(publishPlaceholderIssue),
-    isTempDraftMode,
-  })
-  const {
-    publishActionTitle,
-    publishActionButtonText,
-    publishActionButtonDisabled,
-    publishActionTriggerDisabled,
-    mobilePrimaryActionLabel,
-    mobilePrimaryActionDisabled,
-  } = publishActionViewModel
-  const activeMobileStudioStep = studioSurface === "manage" ? mobileManageStep : mobileComposeStep
-  const mobileStudioSurfaceSteps =
-    studioSurface === "manage"
-      ? ([...MANAGE_MOBILE_STUDIO_STEPS] as MobileStudioStep[])
-      : ([...COMPOSE_MOBILE_STUDIO_STEPS] as MobileStudioStep[])
-  const mobileStudioStepIndex = mobileStudioSurfaceSteps.indexOf(activeMobileStudioStep)
-  const mobileStudioPrevStep: MobileStudioStep | null =
-    mobileStudioStepIndex > 0 ? mobileStudioSurfaceSteps[mobileStudioStepIndex - 1] ?? null : null
-  const mobileStudioNextStep: MobileStudioStep | null =
-    mobileStudioStepIndex < mobileStudioSurfaceSteps.length - 1
-      ? mobileStudioSurfaceSteps[mobileStudioStepIndex + 1] ?? null
-      : null
-  const mobileStudioPrevStepLabel =
-    mobileStudioPrevStep === null ? "이전 단계 없음" : getMobileStudioStepMoveLabel(mobileStudioPrevStep)
-  const mobileStudioNextStepLabel =
-    mobileStudioNextStep === null ? "마지막 단계" : `${MOBILE_STUDIO_STEP_LABEL[mobileStudioNextStep]} 단계로 이동`
-  const setActiveMobileStudioStep = (step: MobileStudioStep) => {
-    if (step === "query" || step === "list") {
-      setMobileManageStep(step)
-      return
-    }
-    setMobileComposeStep(step)
-  }
-  const isCompactManageSurface = isCompactMobileLayout && studioSurface === "manage"
-  const showSelectedPanelInManageSurface = !isCompactMobileLayout || activeMobileStudioStep !== "list" || hasSelectedManagedPost
-  const [previewNowIso] = useState(() => new Date().toISOString())
-  const displayName = member.nickname || member.username || "관리자"
-  const displayNameInitial = displayName.slice(0, 2).toUpperCase()
-  const previewViewportConfig = PREVIEW_CARD_VIEWPORTS[previewViewport]
-  const previewViewportOptions = PREVIEW_CARD_VIEWPORT_ORDER.map((viewport) => ({
-    value: viewport,
-    label: PREVIEW_CARD_VIEWPORTS[viewport].label,
-  }))
-  const previewVisibilityLabel = getVisibilityLabel(postVisibility)
-  const previewThumbnailSrc = safePreviewThumbnail && !isPreviewThumbnailError ? safePreviewThumbnail : ""
-  const shouldShowPublishModalNotice = publishModalNotice.tone !== "idle"
-  const previewAuthorAvatarSrc = (
-    profileImgInputUrl.trim() ||
-    member.profileImageDirectUrl ||
-    member.profileImageUrl ||
-    ""
-  ).trim()
-  const previewDateText = formatDate(previewNowIso, "ko")
-
-  const isCompactSplitPreview = false
-  const shouldShowGlobalNotice =
-    globalNotice.tone !== "idle" || globalNotice.text !== GLOBAL_NOTICE_IDLE_TEXT
-  const shouldShowPublishNotice = publishNotice.tone !== "idle"
-  const shouldShowTagRecommendationNotice =
-    tagRecommendationNotice.tone !== "idle" || tagRecommendationNotice.text !== TAG_RECOMMENDATION_IDLE_TEXT
-  const composeStatusEntries = [
-    shouldShowPublishNotice
-      ? {
-          key: "publish",
-          label: "발행 상태",
-          tone: publishNotice.tone,
-          text: publishNotice.text,
-        }
-      : null,
-    shouldShowTagRecommendationNotice
-      ? {
-          key: "tags",
-          label: "태그 상태",
-          tone: tagRecommendationNotice.tone,
-          text: tagRecommendationNotice.text,
-        }
-      : null,
-    {
-      key: "draft",
-      label: "브라우저 임시저장",
-      tone: localDraftSavedAt ? ("success" as NoticeTone) : ("idle" as NoticeTone),
-      text: localDraftSavedAt
-        ? `${localDraftSavedAt.slice(11, 16)} 저장본이 있습니다.`
-        : "아직 브라우저 임시저장이 없습니다.",
-    },
-  ].filter(
-    (
-      item
-    ): item is {
-      key: string
-      label: string
-      tone: NoticeTone
-      text: string
-    } => Boolean(item)
-  )
-  const mobileComposeStatusPrimary = composeStatusEntries[0] ?? {
-    key: "visibility",
-    label: "공개 범위",
-    tone: "idle" as NoticeTone,
-    text: `${currentVisibilityText} · ${postSummary.trim() ? "요약 입력됨" : "요약 자동 생성"}`,
-  }
-  const mobileComposeStatusSecondary = composeStatusEntries.find((item) => item.key === "draft") ?? null
-  const isThumbnailUploadDisabled = disabled("uploadThumbnail")
-  const handleThumbnailZoomModalChange = useCallback(
-    (nextZoom: number) => {
-      commitPreviewThumbTransform({
-        ...previewThumbTransformRef.current,
-        zoom: clampThumbnailZoom(nextZoom),
-      })
-    },
-    [commitPreviewThumbTransform, previewThumbTransformRef]
-  )
-  const resetThumbnailZoomInModal = useCallback(() => {
-    commitPreviewThumbTransform({
-      ...previewThumbTransformRef.current,
-      zoom: DEFAULT_THUMBNAIL_ZOOM,
-    })
-  }, [commitPreviewThumbTransform, previewThumbTransformRef])
-  const thumbnailEditorPanel = (
-    <EditorStudioThumbnailEditorPanel
-      finalizePreviewThumbPointer={finalizePreviewThumbPointer}
-      handlePreviewThumbPointerDown={handlePreviewThumbPointerDown}
-      handlePreviewThumbPointerMove={handlePreviewThumbPointerMove}
-      isPreviewThumbDragging={isPreviewThumbDragging}
-      isPreviewThumbnailError={isPreviewThumbnailError}
-      postThumbnailZoom={postThumbnailZoom}
-      previewThumbFrameRef={previewThumbFrameRef}
-      safePreviewThumbnail={safePreviewThumbnail}
-      setIsPreviewThumbnailError={setIsPreviewThumbnailError}
-      onThumbnailZoomChange={handleThumbnailZoomModalChange}
-      onResetThumbnailZoom={resetThumbnailZoomInModal}
-    />
-  )
-  const previewMetaEditorPanel = (
-    <EditorStudioThumbnailMetaPanel
-      firstBodyImageUrl={deferredContentDerived.firstImage}
-      isThumbnailUploadDisabled={isThumbnailUploadDisabled}
-      isThumbnailUploading={loadingKey === "uploadThumbnail"}
-      postThumbnailUrl={postThumbnailUrl}
-      thumbnailImageFileName={thumbnailImageFileName}
-      thumbnailUploadRuleLabel={POST_IMAGE_UPLOAD_RULE_LABEL}
-      onApplyFirstBodyImage={applyFirstBodyImageToThumbnail}
-      onOpenThumbnailFileInput={openThumbnailFileInput}
-      onResetThumbnailToAutoMode={resetThumbnailToAutoMode}
-      onThumbnailPaste={handleThumbnailPaste}
-      onThumbnailUrlChange={handleThumbnailUrlModalChange}
-    />
-  )
-  const editorPrimaryActionType: PublishActionType =
-    editorMode === "create" ? "create" : isTempDraftMode ? "temp" : "modify"
-  const editorPrimaryActionLabel =
-    editorPrimaryActionType === "modify"
-      ? "수정 반영"
-      : editorPrimaryActionType === "temp"
-        ? "새 글 작성"
-        : "발행"
-  const isBlockEditorDisabled = loadingKey.length > 0
-  const handleEditorCommitDuration = useCallback((actualDuration: number) => {
-    recordEditorCommitDurationForRuntimeGuard(actualDuration)
-  }, [])
-  const dedicatedEditorCanvas = useMemo(
-    () => (
-      <WriterEditorHost
-        canvasId="editor-dedicated-canvas"
-        markdown={postContent}
-        onMarkdownChange={handleBlockEditorChange}
-        onImageUpload={handleBlockEditorImageUpload}
-        onFileUpload={handleBlockEditorFileUpload}
-        mermaidEnabled={BLOCK_EDITOR_V2_MERMAID_ENABLED}
-        disabled={isBlockEditorDisabled}
-        onCommitDuration={handleEditorCommitDuration}
-      />
-    ),
-    [
-      handleBlockEditorChange,
-      handleBlockEditorFileUpload,
-      handleBlockEditorImageUpload,
-      handleEditorCommitDuration,
-      isBlockEditorDisabled,
-      postContent,
-    ]
-  )
-  const composeEditorCanvas = useMemo(
-    () => (
-      <WriterEditorHost
-        canvasId="editor-compose-canvas"
-        markdown={postContent}
-        onMarkdownChange={handleBlockEditorChange}
-        onImageUpload={handleBlockEditorImageUpload}
-        onFileUpload={handleBlockEditorFileUpload}
-        mermaidEnabled={BLOCK_EDITOR_V2_MERMAID_ENABLED}
-        disabled={isBlockEditorDisabled}
-        onCommitDuration={handleEditorCommitDuration}
-      />
-    ),
-    [
-      handleBlockEditorChange,
-      handleBlockEditorFileUpload,
-      handleBlockEditorImageUpload,
-      handleEditorCommitDuration,
-      isBlockEditorDisabled,
-      postContent,
-    ]
-  )
-  const shouldShowEditorLoadingState =
-    isDedicatedNewEditorRoute &&
-    !postId.trim() &&
-    (isNewEditorBootstrapPending || loadingKey === "postTemp")
-  const shouldShowResultPanel = Boolean(loadingKey || result)
-  const dedicatedEditorResultPanel = useMemo(
-    () =>
-      shouldShowResultPanel ? (
-        <EditorStudioResultLogPanel
-          idleDescription="원본 응답을 확인할 수 있습니다"
-          idleTitle="최근 작업 응답"
-          loadingDescription={(currentLoadingKey) => `실행 중: ${currentLoadingKey}`}
-          loadingKey={loadingKey}
-          loadingTitle="작업 응답 확인 중"
-          result={result}
-          variant="dedicated"
-        />
-      ) : null,
-    [loadingKey, result, shouldShowResultPanel]
-  )
-
-  if (!sessionMember) {
-    return null
-  }
-
-  if (shouldShowEditorLoadingState) {
-    return <EditorStudioDedicatedEditorLoadingState />
-  }
-
-  if (isDedicatedEditorRoute) {
-    return (
-      <EditorStudioDedicatedEditorSurface
-        thumbnailImageFileInputRef={thumbnailImageFileInputRef}
-        onThumbnailImageFileChange={handleThumbnailImageFileChange}
-        onExit={handleExitDedicatedEditor}
-        saveStateText={composeStatusText}
-        saveStateTone={composeStatusTone}
-        primaryActionDisabled={publishActionTriggerDisabled}
-        primaryActionLabel={editorPrimaryActionLabel}
-        onPrimaryAction={() => openPublishModal(editorPrimaryActionType)}
-        isCompactSplitPreview={isCompactSplitPreview}
-        postTags={postTags}
-        tagDraft={tagDraft}
-        onTagDraftChange={setTagDraft}
-        onAddTags={addTagsToPost}
-        onAddTag={addTagToPost}
-        onRemoveTag={removeTagFromPost}
-        titleInputRef={handleTitleFieldRef}
-        postTitle={postTitle}
-        onPostTitleChange={handleTitleChange}
-        onPostTitleKeyDown={handleTitleKeyDown}
-        authorName={displayName}
-        authorInitial={displayNameInitial}
-        authorAvatarSrc={previewAuthorAvatarSrc}
-        previewDateText={previewDateText}
-        currentVisibilityText={currentVisibilityText}
-        canOpenCurrentPostDetail={canOpenCurrentPostDetail}
-        onOpenPostDetail={() => void openPostDetailRoute(postId)}
-        onCopyPostDetailLink={() => void copyPostDetailLink(postId, postTitle)}
-        editorCanvas={dedicatedEditorCanvas}
-        showPublishNotice={shouldShowPublishNotice}
-        publishNoticeTone={publishNotice.tone}
-        publishNoticeText={publishNotice.text}
-        resultPanel={dedicatedEditorResultPanel}
-        publishModal={
-          isPublishModalOpen ? (
-            <EditorStudioPublishModal
-              closeToggleLabel="닫기"
-              displayName={displayName}
-              displayNameInitial={displayNameInitial}
-              isCompactMobileLayout={isCompactMobileLayout}
-              isMobileMetaEditorOpen={isMobileMetaEditorOpen}
-              isMobileThumbnailEditorOpen={isMobileThumbnailEditorOpen}
-              loadingKey={loadingKey}
-              modalNotice={publishModalNotice}
-              postThumbnailFocusX={postThumbnailFocusX}
-              postThumbnailFocusY={postThumbnailFocusY}
-              postThumbnailZoom={postThumbnailZoom}
-              postTitle={postTitle}
-              postVisibility={postVisibility}
-              previewAuthorAvatarSrc={previewAuthorAvatarSrc}
-              previewDateText={previewDateText}
-              previewFrameStyle={{ maxWidth: `${previewViewportConfig.cardWidth}px` }}
-              previewKicker="카드 미리보기"
-              previewMetaEditorPanel={previewMetaEditorPanel}
-              previewSummary={resolvedPreviewSummary}
-              previewSummaryFallback="요약을 비워두면 본문에서 자동 생성한 요약이 카드에 반영됩니다."
-              previewThumbnailSrc={previewThumbnailSrc}
-              previewViewport={previewViewport}
-              previewViewportLabel={previewViewportConfig.label}
-              previewViewportOptions={previewViewportOptions}
-              previewVisibilityLabel={previewVisibilityLabel}
-              publishActionButtonDisabled={publishActionButtonDisabled}
-              publishActionButtonText={publishActionButtonText}
-              publishActionTitle={publishActionTitle}
-              shouldShowNotice={shouldShowPublishModalNotice}
-              thumbnailEditorPanel={thumbnailEditorPanel}
-              variant="drawer"
-              visibilityOptions={PUBLISH_VISIBILITY_OPTIONS}
-              onClose={closePublishModal}
-              onConfirmPublish={() => void handleConfirmPublish()}
-              onPostVisibilityChange={setPostVisibility}
-              onPreviewThumbnailError={() => setIsPreviewThumbnailError(true)}
-              onPreviewViewportChange={setPreviewViewport}
-              onToggleMobileMetaEditor={() => setIsMobileMetaEditorOpen((current) => !current)}
-              onToggleMobileThumbnailEditor={() => setIsMobileThumbnailEditorOpen((current) => !current)}
-            />
-          ) : null
-        }
-      />
-    )
-  }
-
   return (
-    <Main>
-      <HeroCard data-compact-manage={isCompactManageSurface}>
-        <HeroIntro data-compact-manage={isCompactManageSurface}>
-          <h1>{composePageTitle}</h1>
-          <p>제목과 본문에 집중하고, 발행 전 설정은 오른쪽에서 차분하게 마무리합니다.</p>
-          <StudioStatusStrip aria-label="글 작업실 상태 요약">
-            <StudioStatusItem>
-              <span>현재 작업</span>
-              <strong>{composePageTitle}</strong>
-            </StudioStatusItem>
-            {currentPostLabel ? (
-              <StudioStatusItem>
-                <span>원고</span>
-                <strong>{currentPostLabel}</strong>
-              </StudioStatusItem>
-            ) : null}
-            <StudioStatusItem data-optional="true">
-              <span>공개 범위</span>
-              <strong>{currentVisibilityText}</strong>
-            </StudioStatusItem>
-            {composeStatusText ? (
-              <StudioStatusItem data-optional="true">
-                <span>저장 상태</span>
-                <strong>{composeStatusText}</strong>
-              </StudioStatusItem>
-            ) : null}
-          </StudioStatusStrip>
-        </HeroIntro>
-      </HeroCard>
-
-      <WorkspaceGrid>
-        <WorkspaceMain>
-          {SHOW_LEGACY_PROFILE_STUDIO && (
-            <EditorStudioLegacyProfileSection
-              displayName={displayName}
-              displayNameInitial={displayNameInitial}
-              isProfileCardUpdateDisabled={disabled("admMemberProfileCardUpdate")}
-              isProfileImageUploadDisabled={disabled("admMemberProfileImgUpdate")}
-              isProfileImageUploading={loadingKey === "admMemberProfileImgUpdate"}
-              isProfileRefreshDisabled={disabled("admMemberProfileRefresh")}
-              profileBioInput={profileBioInput}
-              profileBioStatus={profileBioStatus}
-              profileImageFileInputRef={profileImageFileInputRef}
-              profileImageHint={profileImageHint}
-              profileImageNotice={profileImageNotice}
-              profileImageStatus={profileImageStatus}
-              profileNotice={profileNotice}
-              profilePreviewSrc={profilePreviewSrc}
-              profileRoleInput={profileRoleInput}
-              profileRoleStatus={profileRoleStatus}
-              profileUpdatedText={profileUpdatedText}
-              onProfileBioChange={setProfileBioInput}
-              onProfileImageSelected={handleProfileImageSelected}
-              onProfileRoleChange={setProfileRoleInput}
-              onRefreshAdminProfile={handleRefreshAdminProfile}
-              onUpdateMemberProfileCard={() => void handleUpdateMemberProfileCard()}
-            />
-          )}
-
-          {SHOW_LEGACY_CONTENT_STUDIO && (
-            <EditorStudioContentWorkspace
-              shouldShowGlobalNotice={shouldShowGlobalNotice}
-              globalNotice={globalNotice}
-              mobileStudioSurfaceSteps={mobileStudioSurfaceSteps}
-              activeMobileStudioStep={activeMobileStudioStep}
-              mobileStudioStepLabels={MOBILE_STUDIO_STEP_LABEL}
-              mobileStudioStepDescriptions={MOBILE_STUDIO_STEP_DESCRIPTION}
-              mobileStudioPrevStep={mobileStudioPrevStep}
-              mobileStudioNextStep={mobileStudioNextStep}
-              mobileStudioPrevStepLabel={mobileStudioPrevStepLabel}
-              mobileStudioNextStepLabel={mobileStudioNextStepLabel}
-              isCompactMobileLayout={isCompactMobileLayout}
-              onMobileStepChange={setActiveMobileStudioStep}
-              listScope={listScope}
-              listKeyword={listKw}
-              listQuickPreset={listQuickPreset}
-              hasListFiltersApplied={hasListFiltersApplied}
-              isListAdvancedOpen={isListAdvancedOpen}
-              listPage={listPage}
-              listPageSize={listPageSize}
-              listSort={listSort}
-              listSortOptions={LIST_SORT_OPTIONS}
-              isListRefreshDisabled={disabled("postList")}
-              isTempPostDisabled={disabled("postTemp")}
-              onListScopeChange={setListScope}
-              onListKeywordChange={setListKw}
-              onRefreshList={() => void loadAdminPosts()}
-              onLoadOrCreateTempPost={() => void handleLoadOrCreateTempPost()}
-              onApplyQuickPreset={applyListQuickPreset}
-              onResetFilters={resetListFilters}
-              onToggleListAdvanced={toggleListAdvanced}
-              onListPageChange={handleListPageChange}
-              onListPageSizeChange={handleListPageSizeChange}
-              onListSortChange={handleListSortChange}
-              selectedPostIds={selectedPostIds}
-              adminPostTotal={adminPostTotal}
-              adminPostRows={adminPostRows}
-              adminPostViewRows={adminPostViewRows}
-              isAllVisiblePostsSelected={isAllVisiblePostsSelected}
-              selectedPostIdSet={selectedPostIdSet}
-              editorMode={editorMode}
-              postId={postId}
-              loadingKey={loadingKey}
-              modifiedSortOrder={modifiedSortOrder}
-              deletedListNotice={deletedListNotice}
-              onToggleSelectAllVisiblePosts={toggleSelectAllVisiblePosts}
-              onClearSelection={() => setSelectedPostIds([])}
-              onRequestDeletePosts={(ids, headline) => openDeleteConfirm(ids, headline)}
-              onTogglePostSelection={togglePostSelection}
-              onToggleModifiedSortOrder={() => setModifiedSortOrder((prev) => (prev === "desc" ? "asc" : "desc"))}
-              onEditPost={(row) => {
-                setPostId(String(row.id))
-                void loadPostForEditor(String(row.id))
-              }}
-              onOpenPostDetail={(id) => void openPostDetailRoute(id)}
-              onCopyPostDetailLink={(id, title) => void copyPostDetailLink(id, title)}
-              onRestoreDeletedPost={(row) => void restoreDeletedPostFromList(row)}
-              onHardDeletePost={(row) => void hardDeleteDeletedPostFromList(row)}
-              showSelectedPanelInManageSurface={showSelectedPanelInManageSurface}
-              hasSelectedManagedPost={hasSelectedManagedPost}
-              editorModeLabel={editorModeLabel}
-              selectedPostLabel={selectedPostLabel}
-              postTitle={postTitle}
-              postVersion={postVersion}
-              isTempDraftMode={isTempDraftMode}
-              postVisibility={postVisibility}
-              currentVisibilityText={currentVisibilityText}
-              isContinueEditingDisabled={editorMode !== "edit" || disabled("modifyPost")}
-              isCreateNewPostDisabled={loadingKey.length > 0}
-              isDeletePostDisabled={disabled("deletePost")}
-              onContinueEditing={handleContinueSelectedPostEditing}
-              onCreateNewPost={handleCreateNewPostFromSelectedPanel}
-              onDeletePost={handleDeleteSelectedPost}
-              isDirectLoadOpen={isDirectLoadOpen}
-              onToggleDirectLoad={() => setIsDirectLoadOpen((prev) => !prev)}
-              isSelectedToolsOpen={isSelectedToolsOpen}
-              onToggleSelectedTools={() => setIsSelectedToolsOpen((prev) => !prev)}
-              onPostIdChange={handleSelectedPostIdChange}
-              isLoadPostDisabled={disabled("postOne")}
-              onLoadPost={() => void loadPostForEditor()}
-              isHitPostDisabled={disabled("hitPost")}
-              onRunHitPost={() =>
-                handleHitPost()
-              }
-              isLikePostDisabled={disabled("likePost")}
-              onRunLikePost={() =>
-                handleLikePost()
-              }
-              softDeleteUndoMessage={softDeleteUndoState?.message || ""}
-              isSoftDeleteUndoVisible={Boolean(softDeleteUndoState)}
-              isUndoDisabled={disabled("undoDeletePost")}
-              onUndoSoftDelete={() => void handleUndoSoftDelete()}
-            />
-          )}
-
-        <EditorStudioDeleteConfirmDialog
-          state={deleteConfirmState}
-          noticeTone={deleteConfirmNotice.tone}
-          noticeText={deleteConfirmNotice.text}
-          isDeleteDisabled={loadingKey === "deletePost"}
-          onClose={closeDeleteConfirm}
-          onConfirm={async (state) => {
-            const ok = await deletePostsFromList(state.ids)
-            if (ok) closeDeleteConfirm()
-          }}
-        />
-        {studioSurface === "compose" && (
-          <EditorStudioComposeWorkspace
-            isCompactMobileLayout={isCompactMobileLayout}
-            isPublishModalOpen={isPublishModalOpen}
-            mobilePrimaryStatus={mobileComposeStatusPrimary}
-            mobileSecondaryStatusText={mobileComposeStatusSecondary?.text}
-            mobilePrimaryActionLabel={mobilePrimaryActionLabel}
-            composeCallToActionLabel={composeCallToActionLabel}
-            mobilePrimaryActionDisabled={mobilePrimaryActionDisabled}
-            onPrimaryAction={() => openPublishModal(editorPrimaryActionType)}
-            currentVisibilityText={currentVisibilityText}
-            editorModeLabel={editorModeLabel}
-            composePageTitle={composePageTitle}
-            composeSurfaceSubtitle={composeSurfaceSubtitle}
-            composeStatusText={composeStatusText}
-            composeStatusTone={composeStatusTone}
-            postSummary={postSummary}
-            postSummaryMaxLength={PREVIEW_SUMMARY_MAX_LENGTH}
-            onPostSummaryChange={setPostSummary}
-            isFillSummaryFromBodyDisabled={!postContent.trim()}
-            onFillSummaryFromBody={() => setPostSummary(makePreviewSummary(postContent))}
-            postTags={postTags}
-            tagDraft={tagDraft}
-            onTagDraftChange={setTagDraft}
-            onAddTags={addTagsToPost}
-            onAddTag={addTagToPost}
-            onRemoveTag={removeTagFromPost}
-            titleInputRef={handleTitleFieldRef}
-            postTitle={postTitle}
-            onPostTitleChange={handleTitleChange}
-            onPostTitleKeyDown={handleTitleKeyDown}
-            thumbnailImageFileInputRef={thumbnailImageFileInputRef}
-            onThumbnailImageFileChange={handleThumbnailImageFileChange}
-            contentLength={contentLength}
-            lineCount={lineCount}
-            imageCount={imageCount}
-            editorCanvas={composeEditorCanvas}
-            tagSummaryText={tagSummaryText}
-            isSaveDraftDisabled={loadingKey.length > 0}
-            onSaveLocalDraft={saveLocalDraft}
-            composeHeroSummary={composeHeroSummary}
-            isRecommendTagsDisabled={disabled("recommendTags") || !postContent.trim()}
-            isRecommendTagsLoading={loadingKey === "recommendTags"}
-            onRecommendTags={() => void handleRecommendTags()}
-            composeStatusEntries={composeStatusEntries}
-            activeVisibility={postVisibility}
-            visibilityOptions={PUBLISH_VISIBILITY_OPTIONS}
-            onVisibilityChange={setPostVisibility}
-            previewViewport={previewViewport}
-            previewViewportLabel={previewViewportConfig.label}
-            previewViewportOptions={previewViewportOptions}
-            onPreviewViewportChange={(viewport) => setPreviewViewport(viewport)}
-            previewFrameStyle={{ width: `min(100%, ${previewViewportConfig.cardWidth}px)` }}
-            previewThumbnailSrc={previewThumbnailSrc}
-            postThumbnailFocusX={postThumbnailFocusX}
-            postThumbnailFocusY={postThumbnailFocusY}
-            postThumbnailZoom={postThumbnailZoom}
-            onPreviewThumbnailError={() => setIsPreviewThumbnailError(true)}
-            previewVisibilityLabel={previewVisibilityLabel}
-            summaryPreview={composeSummaryPreview}
-            previewDateText={previewDateText}
-            previewAuthorAvatarSrc={previewAuthorAvatarSrc}
-            displayNameInitial={displayNameInitial}
-            displayName={displayName}
-            summaryLengthLabel={
-              postSummary.trim() ? `${postSummary.trim().length}/${PREVIEW_SUMMARY_MAX_LENGTH}` : "본문 기준 자동"
-            }
-            isComposeAssistOpen={isComposeAssistOpen}
-            onToggleComposeAssist={() => setIsComposeAssistOpen((prev) => !prev)}
-            thumbnailEditorPanel={thumbnailEditorPanel}
-            previewMetaEditorPanel={previewMetaEditorPanel}
-            isTagPanelOpen={activeMetaPanel === "tag"}
-            onToggleTagPanel={() => setActiveMetaPanel((prev) => (prev === "tag" ? null : "tag"))}
-            isUtilityPanelOpen={isComposeUtilityOpen}
-            onToggleUtilityPanel={() => setIsComposeUtilityOpen((prev) => !prev)}
-            metaNotice={metaNotice}
-            knownTags={knownTags}
-            tagUsageMap={tagUsageMap}
-            onToggleKnownTag={(tag) => (postTags.includes(tag) ? removeTagFromPost(tag) : addTagToPost(tag))}
-            onDeleteKnownTag={deleteTagFromCatalog}
-            onRestoreLocalDraft={restoreLocalDraft}
-            onClearLocalDraft={clearLocalDraft}
-            isClearLocalDraftDisabled={loadingKey.length > 0 || !localDraftSavedAt}
-          />
-        )}
-
-        {isPublishModalOpen ? (
-          <EditorStudioPublishModal
-            closeToggleLabel="접기"
-            displayName={displayName}
-            displayNameInitial={displayNameInitial}
-            isCompactMobileLayout={isCompactMobileLayout}
-            isMobileMetaEditorOpen={isMobileMetaEditorOpen}
-            isMobileThumbnailEditorOpen={isMobileThumbnailEditorOpen}
-            loadingKey={loadingKey}
-            modalNotice={publishModalNotice}
-            postThumbnailFocusX={postThumbnailFocusX}
-            postThumbnailFocusY={postThumbnailFocusY}
-            postThumbnailZoom={postThumbnailZoom}
-            postTitle={postTitle}
-            postVisibility={postVisibility}
-            previewAuthorAvatarSrc={previewAuthorAvatarSrc}
-            previewDateText={previewDateText}
-            previewFrameStyle={{ maxWidth: `${previewViewportConfig.cardWidth}px` }}
-            previewKicker="실제 카드 결과"
-            previewMetaEditorPanel={previewMetaEditorPanel}
-            previewSummary={resolvedPreviewSummary}
-            previewSummaryFallback="요약을 비워두면 본문에서 자동 생성한 요약이 카드에 반영됩니다."
-            previewThumbnailSrc={previewThumbnailSrc}
-            previewViewport={previewViewport}
-            previewViewportLabel={previewViewportConfig.label}
-            previewViewportOptions={previewViewportOptions}
-            previewVisibilityLabel={previewVisibilityLabel}
-            publishActionButtonDisabled={publishActionButtonDisabled}
-            publishActionButtonText={publishActionButtonText}
-            publishActionTitle={publishActionTitle}
-            setupDescription="썸네일 위치와 카드 요약만 조정합니다. 결과는 위 카드에서 바로 확인됩니다."
-            shouldShowNotice={shouldShowPublishModalNotice}
-            thumbnailEditorPanel={thumbnailEditorPanel}
-            visibilityOptions={PUBLISH_VISIBILITY_OPTIONS}
-            onClose={closePublishModal}
-            onConfirmPublish={() => void handleConfirmPublish()}
-            onPostVisibilityChange={setPostVisibility}
-            onPreviewThumbnailError={() => setIsPreviewThumbnailError(true)}
-            onPreviewViewportChange={setPreviewViewport}
-            onToggleMobileMetaEditor={() => setIsMobileMetaEditorOpen((current) => !current)}
-            onToggleMobileThumbnailEditor={() => setIsMobileThumbnailEditorOpen((current) => !current)}
-          />
-        ) : null}
-
-          {SHOW_LEGACY_UTILITY_STUDIO && (
-            <EditorStudioLegacyUtilityPanel
-              commentContent={commentContent}
-              commentId={commentId}
-              isCommentDeleteDisabled={disabled("commentDelete")}
-              isCommentListDisabled={disabled("commentList")}
-              isCommentModifyDisabled={disabled("commentModify")}
-              isCommentOneDisabled={disabled("commentOne")}
-              isCommentWriteDisabled={disabled("commentWrite")}
-              isPostCountDisabled={disabled("admPostCount")}
-              isSystemHealthDisabled={disabled("systemHealth")}
-              postId={postId}
-              onCommentContentChange={setCommentContent}
-              onCommentIdChange={setCommentId}
-              onDeleteComment={handleDeleteComment}
-              onListComments={handleListComments}
-              onModifyComment={handleModifyComment}
-              onPostIdChange={setPostId}
-              onReadComment={handleReadComment}
-              onReadPostCount={handleReadPostCount}
-              onReadSystemHealth={handleReadSystemHealth}
-              onWriteComment={handleWriteComment}
-            />
-          )}
-        </WorkspaceMain>
-
-      </WorkspaceGrid>
-
-      <EditorStudioResultLogPanel
-        eyebrow="실행 로그"
-        idleDescription="접어서 숨길 수 있습니다"
-        idleTitle="최근 작업 응답 보기"
-        loadingDescription={(currentLoadingKey) => `실행 중: ${currentLoadingKey}`}
-        loadingKey={loadingKey}
-        loadingTitle="작업 응답 확인 중"
-        result={result}
-        variant="standard"
-      />
-    </Main>
+    <EditorStudioWorkspaceControllerRootView
+      props={{
+        activeMetaPanel, addTagsToPost, addTagToPost, adminPostRows, adminPostTotal,
+        adminPostViewRows, applyFirstBodyImageToThumbnail, applyListQuickPreset, clearLocalDraft, closeDeleteConfirm,
+        closePublishModal, commentContent, commentId, commitPreviewThumbTransform, copyPostDetailLink,
+        deferredPostContent, deferredContentDerived, deleteConfirmNotice, deleteConfirmState, deletePostsFromList,
+        deletedListNotice,
+        deleteTagFromCatalog, disabled, editorMode, finalizePreviewThumbPointer, globalNotice,
+        handleBlockEditorChange, handleBlockEditorFileUpload, handleBlockEditorImageUpload, handleConfirmPublish, handleContinueSelectedPostEditing,
+        handleCreateNewPostFromSelectedPanel, handleDeleteComment, handleDeleteSelectedPost, handleExitDedicatedEditor, handleHitPost,
+        handleLikePost, handleListComments, handleListPageChange, handleListPageSizeChange, handleListSortChange,
+        handleLoadOrCreateTempPost, handleModifyComment, handlePreviewThumbPointerDown, handlePreviewThumbPointerMove, handleProfileImageSelected,
+        handleReadComment, handleReadPostCount, handleReadSystemHealth, handleRecommendTags, handleRefreshAdminProfile,
+        handleSelectedPostIdChange, handleThumbnailImageFileChange, handleThumbnailPaste, handleThumbnailUrlModalChange, handleTitleChange,
+        handleTitleFieldRef, handleTitleKeyDown, handleUndoSoftDelete, handleUpdateMemberProfileCard, handleWriteComment,
+        hardDeleteDeletedPostFromList, isAllVisiblePostsSelected, isCompactMobileLayout, isComposeAssistOpen, isComposeUtilityOpen,
+        isDedicatedEditorRoute, isDedicatedNewEditorRoute, isDirectLoadOpen, isListAdvancedOpen, isMobileMetaEditorOpen,
+        isMobileThumbnailEditorOpen, isNewEditorBootstrapPending, isPreviewThumbDragging, isPreviewThumbnailError, isPublishModalOpen,
+        isSelectedToolsOpen, isTempDraftMode, knownTags, lastLocalDraftFingerprintRef, listKw,
+        listPage,
+        listPageSize, listQuickPreset, listScope, listSort, loadAdminPosts,
+        loadPostForEditor, loadingKey, localDraftSavedAt, member, metaNotice,
+        mobileComposeStep, mobileManageStep, modifiedSortOrder, openDeleteConfirm, openPostDetailRoute,
+        openPublishModal, openThumbnailFileInput, postCategory, postContent, postId,
+        postSummary, postTags, postThumbnailFocusX, postThumbnailFocusY, postThumbnailUrl,
+        postThumbnailZoom, postTitle, postVersion, postVisibility, profileBioInput,
+        profileImageFileInputRef, profileImageFileName, profileImageNotice, profileImgInputUrl, profileNotice,
+        profileRoleInput, publishActionType, publishModalNotice, publishNotice, previewThumbFrameRef,
+        previewThumbTransformRef, previewViewport, resolvedPreviewSummary, resetListFilters, resetThumbnailToAutoMode,
+        removeTagFromPost, restoreDeletedPostFromList, restoreLocalDraft, result, safePreviewThumbnail,
+        saveLocalDraft,
+        selectedPostIdSet, selectedPostIds, serverBaselineEditorFingerprintRef, sessionMember, setActiveMetaPanel,
+        setCommentContent, setCommentId, setIsComposeAssistOpen, setIsComposeUtilityOpen, setIsDirectLoadOpen,
+        setIsMobileMetaEditorOpen,
+        setIsMobileThumbnailEditorOpen, setIsPreviewThumbnailError, setIsSelectedToolsOpen, setListKw, setListScope,
+        setMobileComposeStep,
+        setMobileManageStep, setModifiedSortOrder, setPostId, setPostSummary, setPostVisibility,
+        setPreviewViewport, setProfileBioInput, setProfileRoleInput, setSelectedPostIds, setTagDraft,
+        softDeleteUndoState, studioSurface, tagDraft, tagRecommendationNotice, tagUsageMap,
+        thumbnailImageFileInputRef, thumbnailImageFileName, toggleListAdvanced, togglePostSelection, toggleSelectAllVisiblePosts,
+      }}
+    />
   )
 }
 
 export default EditorStudioWorkspaceController
-
-const Main = styled.main`
-  max-width: 1360px;
-  margin: 0 auto;
-  padding: 1.5rem 1rem 2.8rem;
-
-  @media (max-width: 720px) {
-    padding-bottom: calc(7rem + env(safe-area-inset-bottom, 0px));
-  }
-
-  @media (max-width: 720px) {
-    padding:
-      1rem
-      max(0.78rem, env(safe-area-inset-right))
-      calc(7rem + env(safe-area-inset-bottom, 0px))
-      max(0.78rem, env(safe-area-inset-left));
-  }
-`
-
-const HeroCard = styled.section`
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 0.72rem;
-  border-radius: 16px;
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  background: ${({ theme }) => theme.colors.gray2};
-  box-shadow: none;
-  padding: 0.88rem 0.96rem;
-  margin-bottom: 0.92rem;
-
-  @media (max-width: 760px) {
-    grid-template-columns: 1fr;
-    gap: 0.78rem;
-    border-radius: 16px;
-    box-shadow: none;
-    padding: 0.88rem 0.92rem;
-  }
-
-  &[data-compact-manage="true"] {
-    margin-bottom: 0.7rem;
-
-    @media (max-width: 760px) {
-      gap: 0.6rem;
-      padding: 0.72rem 0.8rem;
-    }
-  }
-`
-
-const HeroIntro = styled.div`
-  display: grid;
-  gap: 0.42rem;
-
-  h1 {
-    margin: 0;
-    font-size: clamp(1.74rem, 2.7vw, 2.3rem);
-    line-height: 1.14;
-    font-weight: 800;
-    letter-spacing: -0.02em;
-    word-break: keep-all;
-    text-wrap: balance;
-    color: ${({ theme }) => theme.colors.gray12};
-  }
-
-  p {
-    margin: 0;
-    max-width: 32rem;
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.84rem;
-    line-height: 1.5;
-  }
-
-  &[data-compact-manage="true"] {
-    gap: 0.5rem;
-
-    p {
-      font-size: 0.86rem;
-      line-height: 1.55;
-    }
-  }
-`
-
-const StudioStatusStrip = styled.div`
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.42rem;
-
-  @media (max-width: 1100px) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  @media (max-width: 560px) {
-    grid-template-columns: 1fr;
-  }
-`
-
-const StudioStatusItem = styled.div`
-  display: grid;
-  gap: 0.18rem;
-  min-width: 0;
-  padding: 0.48rem 0.58rem;
-  border-radius: 8px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray1};
-
-  span {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.72rem;
-    font-weight: 700;
-  }
-
-  strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.82rem;
-    line-height: 1.35;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  @media (max-width: 760px) {
-    &[data-optional="true"] {
-      display: none;
-    }
-  }
-`
-
-const WorkspaceGrid = styled.div`
-  display: block;
-`
-
-const WorkspaceMain = styled.div`
-  min-width: 0;
-`

--- a/front/src/routes/Admin/EditorStudioWorkspaceControllerRootModel.ts
+++ b/front/src/routes/Admin/EditorStudioWorkspaceControllerRootModel.ts
@@ -1,0 +1,345 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from "react"
+import { getApiBaseUrl } from "src/apis/backend/client"
+import { toCanonicalPostPath } from "src/libs/utils/postPath"
+import {
+  applyThumbnailTransformToUrl,
+  DEFAULT_THUMBNAIL_FOCUS_X,
+  DEFAULT_THUMBNAIL_FOCUS_Y,
+  DEFAULT_THUMBNAIL_ZOOM,
+} from "src/libs/thumbnailFocus"
+import {
+  isServerTempDraftPost,
+  TEMP_DRAFT_BODY_PLACEHOLDER,
+} from "./editorTempDraft"
+import type {
+  PostVisibility,
+} from "./editorStudioState"
+import type {
+  ResolvedEditorMetaSnapshot,
+} from "./editorStudioMetaModel"
+
+export const BLOCK_EDITOR_V2_MERMAID_ENABLED = process.env.NEXT_PUBLIC_EDITOR_V2_MERMAID_ENABLED !== "false"
+export const ADMIN_POSTS_WORKSPACE_ROUTE = "/admin/posts"
+export const EDITOR_NEW_ROUTE_PATH = "/editor/new"
+
+export const toEditorPostRoute = (id: string | number) => `/editor/${encodeURIComponent(String(id))}`
+
+export const buildCanonicalPostUrl = (postId: string | number) => {
+  const path = toCanonicalPostPath(postId)
+  if (typeof window === "undefined") return path
+  return new URL(path, window.location.origin).toString()
+}
+
+export const extractImageFileFromClipboard = (clipboardData: DataTransfer | null): File | null => {
+  if (!clipboardData) return null
+
+  const directFile = Array.from(clipboardData.files || []).find((file) => file.type.startsWith("image/"))
+  if (directFile) return directFile
+
+  const clipboardItem = Array.from(clipboardData.items || []).find(
+    (item) => item.kind === "file" && item.type.startsWith("image/")
+  )
+  if (!clipboardItem) return null
+
+  const pastedFile = clipboardItem.getAsFile()
+  if (!pastedFile || !pastedFile.type.startsWith("image/")) return null
+  return pastedFile
+}
+
+export const normalizeEditorReturnRoute = (value: string) => {
+  const normalized = value.trim()
+  if (!normalized.startsWith("/") || normalized.startsWith("//")) return ""
+  if (/[\r\n]/.test(normalized)) return ""
+  if (/^\/(?:https?:|javascript:)/i.test(normalized)) return ""
+  if (normalized.startsWith("/editor")) return ""
+  return normalized
+}
+
+export type JsonValue = Record<string, unknown> | unknown[] | string | number | boolean | null
+
+export type PostForEditor = {
+  id: number
+  title: string
+  content: string
+  contentHtml?: string
+  version?: number
+  published: boolean
+  listed: boolean
+  tempDraft?: boolean
+}
+
+export type RsData<T> = {
+  resultCode: string
+  msg: string
+  data: T
+}
+
+export type NoticeTone = "idle" | "loading" | "success" | "error"
+export type NoticeState = {
+  tone: NoticeTone
+  text: string
+}
+export type StudioSurface = "manage" | "compose"
+export type MobileStudioStep = "query" | "list" | "edit" | "publish"
+export type PreviewViewportMode = "desktop" | "tablet" | "mobile"
+export type ManageMobileStudioStep = "query" | "list"
+export type ComposeMobileStudioStep = "edit" | "publish"
+
+export const GLOBAL_NOTICE_IDLE_TEXT = "운영 작업 상태가 여기에 표시됩니다."
+export const TAG_RECOMMENDATION_IDLE_TEXT = "AI 태그 추천 상태가 여기에 표시됩니다."
+export const MANAGE_MOBILE_STUDIO_STEPS = ["query", "list"] as const
+export const COMPOSE_MOBILE_STUDIO_STEPS = ["edit", "publish"] as const
+
+export const MOBILE_STUDIO_STEP_LABEL: Record<MobileStudioStep, string> = {
+  query: "조회",
+  list: "목록",
+  edit: "편집",
+  publish: "발행",
+}
+
+export const MOBILE_STUDIO_STEP_DESCRIPTION: Record<MobileStudioStep, string> = {
+  query: "페이지/키워드/정렬 조건을 먼저 정리하고 목록을 불러오세요.",
+  list: "목록에서 대상 글을 선택하거나 post id를 확인해 편집 단계로 넘깁니다.",
+  edit: "본문, 태그, 메타를 정리한 뒤 발행 설정으로 이동합니다.",
+  publish: "노출 범위와 카드 미리보기를 확인하고 최종 반영하세요.",
+}
+
+export const getMobileStudioStepMoveLabel = (step: MobileStudioStep) =>
+  `${MOBILE_STUDIO_STEP_LABEL[step]}${MOBILE_STUDIO_STEP_LABEL[step].endsWith("집") ? "으로" : "로"} 이동`
+
+const PROFILE_IMAGE_UPLOAD_RETRY_DELAY_MS = 700
+const IMAGE_UPLOAD_CONFLICT_MAX_RETRIES = 3
+const EDITOR_BODY_PLACEHOLDER = "내용을 입력하세요."
+
+export const syncTitleTextareaHeight = (element: HTMLTextAreaElement | null) => {
+  if (!element) return
+  element.style.height = "0px"
+  element.style.height = `${Math.max(element.scrollHeight, 44)}px`
+}
+
+export const PREVIEW_CARD_VIEWPORTS: Record<
+  PreviewViewportMode,
+  {
+    label: string
+    description: string
+    cardWidth: number
+  }
+> = {
+  desktop: {
+    label: "Desktop",
+    description: "1440px 메인 카드 폭",
+    cardWidth: 368,
+  },
+  tablet: {
+    label: "iPad mini",
+    description: "768px 2열 카드 폭",
+    cardWidth: 320,
+  },
+  mobile: {
+    label: "iPhone 15 Pro",
+    description: "393px 1열 카드 폭",
+    cardWidth: 286,
+  },
+}
+
+const isTempDraftBodyPlaceholder = (value: string) => {
+  const normalized = value.replace(/\r\n?/g, "\n").trim()
+  return normalized === TEMP_DRAFT_BODY_PLACEHOLDER || normalized === EDITOR_BODY_PLACEHOLDER
+}
+
+export const isBlankServerTempDraft = (
+  post: Pick<PostForEditor, "title" | "published" | "listed" | "tempDraft">,
+  snapshot: ResolvedEditorMetaSnapshot
+) => isServerTempDraftPost(post) && isTempDraftBodyPlaceholder(snapshot.body)
+
+export const buildEmptyEditorMetaSnapshot = (): ResolvedEditorMetaSnapshot => ({
+  body: "",
+  tags: [],
+  category: "",
+  summary: "",
+  thumbnailUrl: "",
+  thumbnailFocusX: DEFAULT_THUMBNAIL_FOCUS_X,
+  thumbnailFocusY: DEFAULT_THUMBNAIL_FOCUS_Y,
+  thumbnailZoom: DEFAULT_THUMBNAIL_ZOOM,
+})
+
+export const PREVIEW_CARD_VIEWPORT_ORDER: PreviewViewportMode[] = ["desktop", "tablet", "mobile"]
+
+export const PUBLISH_VISIBILITY_OPTIONS: Array<{
+  value: PostVisibility
+  label: string
+  description: string
+}> = [
+  {
+    value: "PUBLIC_LISTED",
+    label: "전체 공개",
+    description: "메인 목록과 검색에 노출됩니다.",
+  },
+  {
+    value: "PUBLIC_UNLISTED",
+    label: "링크 공개",
+    description: "URL을 아는 사람만 볼 수 있습니다.",
+  },
+  {
+    value: "PRIVATE",
+    label: "비공개",
+    description: "관리자만 확인합니다.",
+  },
+]
+
+export const SHOW_LEGACY_PROFILE_STUDIO = process.env.NEXT_PUBLIC_SHOW_LEGACY_PROFILE_STUDIO === "true"
+export const SHOW_LEGACY_CONTENT_STUDIO = process.env.NEXT_PUBLIC_SHOW_LEGACY_CONTENT_STUDIO === "true"
+export const SHOW_LEGACY_UTILITY_STUDIO = process.env.NEXT_PUBLIC_SHOW_LEGACY_UTILITY_STUDIO === "true"
+
+export const pretty = (value: unknown) => JSON.stringify(value, null, 2)
+
+export const isComposingKeyboardEvent = (
+  event: ReactKeyboardEvent<HTMLElement>
+) => {
+  const nativeEvent = event.nativeEvent as KeyboardEvent & { isComposing?: boolean; keyCode?: number }
+  return nativeEvent.isComposing === true || nativeEvent.keyCode === 229
+}
+
+export const generateIdempotencyKey = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+  return `post-write-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+const EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT = 240
+
+type RuntimeGuardWindow = Window & {
+  __AQ_RUNTIME_GUARD_ENABLED__?: boolean
+  __AQ_RUNTIME_GUARD__?: {
+    editorCommitSamples?: number[]
+  }
+}
+
+export const recordEditorCommitDurationForRuntimeGuard = (actualDuration: number) => {
+  if (typeof window === "undefined" || !Number.isFinite(actualDuration) || actualDuration <= 0) return
+  const runtimeWindow = window as RuntimeGuardWindow
+  if (!runtimeWindow.__AQ_RUNTIME_GUARD_ENABLED__) return
+
+  const store = (runtimeWindow.__AQ_RUNTIME_GUARD__ ??= {})
+  const nextSamples = [...(store.editorCommitSamples ?? []), actualDuration]
+  if (nextSamples.length > EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT) {
+    nextSamples.splice(0, nextSamples.length - EDITOR_RUNTIME_GUARD_SAMPLE_LIMIT)
+  }
+  store.editorCommitSamples = nextSamples
+}
+
+const parseResponseErrorBody = async (response: Response): Promise<string> => {
+  const text = await response.text().catch(() => "")
+  if (!text) return ""
+
+  try {
+    const parsed = JSON.parse(text) as { resultCode?: string; msg?: string }
+    const msg = parsed.msg?.trim()
+    if (!msg) return text
+    return parsed.resultCode ? `${msg} (${parsed.resultCode})` : msg
+  } catch {
+    return text
+  }
+}
+
+const waitFor = (ms: number) =>
+  new Promise<void>((resolve) => {
+    window.setTimeout(resolve, ms)
+  })
+
+const computeConflictRetryDelay = (attempt: number): number =>
+  PROFILE_IMAGE_UPLOAD_RETRY_DELAY_MS * Math.max(1, attempt + 1)
+
+const TEMP_POST_CONFLICT_MAX_RETRIES = 2
+
+export const requestTempPostWithConflictRetry = async (
+  resolveExistingTempPost: () => Promise<PostForEditor | null>,
+  maxRetries: number = TEMP_POST_CONFLICT_MAX_RETRIES
+): Promise<RsData<PostForEditor>> => {
+  let lastConflictBody = ""
+
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    const response = await fetch(`${getApiBaseUrl()}/post/api/v1/posts/temp`, {
+      method: "POST",
+      credentials: "include",
+    })
+
+    if (response.status !== 409) {
+      if (!response.ok) {
+        const body = await parseResponseErrorBody(response)
+        throw new Error(body || `임시글 불러오기 실패 (${response.status})`)
+      }
+
+      return (await response.json()) as RsData<PostForEditor>
+    }
+
+    lastConflictBody = await parseResponseErrorBody(response)
+    if (attempt < maxRetries) {
+      await waitFor(computeConflictRetryDelay(attempt))
+      continue
+    }
+  }
+
+  const recoveredTempPost = await resolveExistingTempPost()
+  if (recoveredTempPost) {
+    return {
+      resultCode: "200-1",
+      msg: "기존 임시저장 글을 불러옵니다.",
+      data: recoveredTempPost,
+    }
+  }
+
+  throw new Error(lastConflictBody || "요청 충돌이 발생했습니다. 다시 시도해주세요.")
+}
+
+export const uploadWithConflictRetry = async (
+  requestUpload: () => Promise<Response>,
+  maxRetries: number = IMAGE_UPLOAD_CONFLICT_MAX_RETRIES
+): Promise<Response> => {
+  let lastConflictBody = ""
+
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    const response = await requestUpload()
+    if (response.status !== 409) {
+      if (!response.ok) {
+        const body = await parseResponseErrorBody(response)
+        throw new Error(`이미지 업로드 실패 (${response.status}): ${body}`)
+      }
+      return response
+    }
+
+    lastConflictBody = await parseResponseErrorBody(response)
+    if (attempt >= maxRetries) {
+      throw new Error(
+        `이미지 업로드 실패 (409): ${lastConflictBody || "요청 충돌이 반복되어 업로드를 완료하지 못했습니다."}`
+      )
+    }
+
+    await waitFor(computeConflictRetryDelay(attempt))
+  }
+
+  throw new Error(
+    `이미지 업로드 실패 (409): ${lastConflictBody || "요청 충돌이 반복되어 업로드를 완료하지 못했습니다."}`
+  )
+}
+
+export const buildEffectiveThumbnailUrl = ({
+  postThumbnailFocusX,
+  postThumbnailFocusY,
+  postThumbnailZoom,
+  resolvedPreviewThumbnail,
+}: {
+  postThumbnailFocusX: number
+  postThumbnailFocusY: number
+  postThumbnailZoom: number
+  resolvedPreviewThumbnail: string
+}) => {
+  const normalizedThumbnail = resolvedPreviewThumbnail.trim()
+  if (!normalizedThumbnail) return ""
+  return applyThumbnailTransformToUrl(normalizedThumbnail, {
+    focusX: postThumbnailFocusX,
+    focusY: postThumbnailFocusY,
+    zoom: postThumbnailZoom,
+  })
+}

--- a/front/src/routes/Admin/EditorStudioWorkspaceControllerRootView.tsx
+++ b/front/src/routes/Admin/EditorStudioWorkspaceControllerRootView.tsx
@@ -1,0 +1,958 @@
+import { useCallback, useMemo, useState } from "react"
+import { formatDate } from "src/libs/utils"
+import { clampThumbnailZoom, DEFAULT_THUMBNAIL_ZOOM } from "src/libs/thumbnailFocus"
+import { POST_IMAGE_UPLOAD_RULE_LABEL, PROFILE_IMAGE_UPLOAD_RULE_LABEL } from "src/libs/profileImageUpload"
+import { WriterEditorHost } from "./WriterEditorHost"
+import { EditorStudioThumbnailEditorPanel, EditorStudioThumbnailMetaPanel } from "./EditorStudioThumbnailPanels"
+import { EditorStudioPublishModal } from "./EditorStudioPublishModal"
+import { EditorStudioLegacyProfileSection } from "./EditorStudioLegacyProfileSection"
+import { EditorStudioLegacyUtilityPanel } from "./EditorStudioLegacyUtilityPanel"
+import { EditorStudioResultLogPanel } from "./EditorStudioResultLogPanel"
+import { EditorStudioDeleteConfirmDialog } from "./EditorStudioDeleteConfirmDialog"
+import { EditorStudioComposeWorkspace } from "./EditorStudioComposeWorkspace"
+import { EditorStudioContentWorkspace } from "./EditorStudioContentWorkspace"
+import { EditorStudioDedicatedEditorLoadingState, EditorStudioDedicatedEditorSurface } from "./EditorStudioDedicatedEditorSurface"
+import { LIST_SORT_OPTIONS } from "./useEditorStudioListConditions"
+import { deriveComposeViewModel, deriveEditorContentMetrics, deriveEditorPersistenceState, derivePublishActionViewModel, getVisibilityLabel, toFlags, type PublishActionType } from "./editorStudioState"
+import { PREVIEW_SUMMARY_MAX_LENGTH, buildEditorStateFingerprint, detectPublishPlaceholderIssue, makePreviewSummary } from "./editorStudioMetaModel"
+import { Main, HeroCard, HeroIntro, StudioStatusItem, StudioStatusStrip, WorkspaceGrid, WorkspaceMain } from "./EditorStudioWorkspaceControllerRoot.styles"
+import { BLOCK_EDITOR_V2_MERMAID_ENABLED, COMPOSE_MOBILE_STUDIO_STEPS, GLOBAL_NOTICE_IDLE_TEXT, MANAGE_MOBILE_STUDIO_STEPS, MOBILE_STUDIO_STEP_DESCRIPTION, MOBILE_STUDIO_STEP_LABEL, PREVIEW_CARD_VIEWPORT_ORDER, PREVIEW_CARD_VIEWPORTS, PUBLISH_VISIBILITY_OPTIONS, SHOW_LEGACY_CONTENT_STUDIO, SHOW_LEGACY_PROFILE_STUDIO, SHOW_LEGACY_UTILITY_STUDIO, TAG_RECOMMENDATION_IDLE_TEXT, getMobileStudioStepMoveLabel, recordEditorCommitDurationForRuntimeGuard, type MobileStudioStep, type NoticeTone, type PreviewViewportMode } from "./EditorStudioWorkspaceControllerRootModel"
+
+type EditorStudioWorkspaceControllerRootViewProps = {
+  props: Record<string, any>
+}
+
+export const EditorStudioWorkspaceControllerRootView = ({ props }: EditorStudioWorkspaceControllerRootViewProps) => {
+  const {
+    activeMetaPanel,
+    addTagsToPost,
+    addTagToPost,
+    adminPostRows,
+    adminPostTotal,
+    adminPostViewRows,
+    applyFirstBodyImageToThumbnail,
+    applyListQuickPreset,
+    clearLocalDraft,
+    closeDeleteConfirm,
+    closePublishModal,
+    commentContent,
+    commentId,
+    commitPreviewThumbTransform,
+    copyPostDetailLink,
+    deferredPostContent,
+    deferredContentDerived,
+    deleteConfirmNotice,
+    deleteConfirmState,
+    deletePostsFromList,
+    deletedListNotice,
+    deleteTagFromCatalog,
+    disabled,
+    editorMode,
+    finalizePreviewThumbPointer,
+    globalNotice,
+    handleBlockEditorChange,
+    handleBlockEditorFileUpload,
+    handleBlockEditorImageUpload,
+    handleConfirmPublish,
+    handleContinueSelectedPostEditing,
+    handleCreateNewPostFromSelectedPanel,
+    handleDeleteComment,
+    handleDeleteSelectedPost,
+    handleExitDedicatedEditor,
+    handleHitPost,
+    handleLikePost,
+    handleListComments,
+    handleListPageChange,
+    handleListPageSizeChange,
+    handleListSortChange,
+    handleLoadOrCreateTempPost,
+    handleModifyComment,
+    handlePreviewThumbPointerDown,
+    handlePreviewThumbPointerMove,
+    handleProfileImageSelected,
+    handleReadComment,
+    handleReadPostCount,
+    handleReadSystemHealth,
+    handleRecommendTags,
+    handleRefreshAdminProfile,
+    handleSelectedPostIdChange,
+    handleThumbnailImageFileChange,
+    handleThumbnailPaste,
+    handleThumbnailUrlModalChange,
+    handleTitleChange,
+    handleTitleFieldRef,
+    handleTitleKeyDown,
+    handleUndoSoftDelete,
+    handleUpdateMemberProfileCard,
+    handleWriteComment,
+    hardDeleteDeletedPostFromList,
+    isAllVisiblePostsSelected,
+    isCompactMobileLayout,
+    isComposeAssistOpen,
+    isComposeUtilityOpen,
+    isDedicatedEditorRoute,
+    isDedicatedNewEditorRoute,
+    isDirectLoadOpen,
+    isListAdvancedOpen,
+    isMobileMetaEditorOpen,
+    isMobileThumbnailEditorOpen,
+    isNewEditorBootstrapPending,
+    isPreviewThumbDragging,
+    isPreviewThumbnailError,
+    isPublishModalOpen,
+    isSelectedToolsOpen,
+    isTempDraftMode,
+    knownTags,
+    lastLocalDraftFingerprintRef,
+    listKw,
+    listPage,
+    listPageSize,
+    listQuickPreset,
+    listScope,
+    listSort,
+    loadAdminPosts,
+    loadPostForEditor,
+    loadingKey,
+    localDraftSavedAt,
+    member,
+    metaNotice,
+    mobileComposeStep,
+    mobileManageStep,
+    modifiedSortOrder,
+    openDeleteConfirm,
+    openPostDetailRoute,
+    openPublishModal,
+    openThumbnailFileInput,
+    postCategory,
+    postContent,
+    postId,
+    postSummary,
+    postTags,
+    postThumbnailFocusX,
+    postThumbnailFocusY,
+    postThumbnailUrl,
+    postThumbnailZoom,
+    postTitle,
+    postVersion,
+    postVisibility,
+    profileBioInput,
+    profileImageFileInputRef,
+    profileImageFileName,
+    profileImageNotice,
+    profileImgInputUrl,
+    profileNotice,
+    profileRoleInput,
+    publishActionType,
+    publishModalNotice,
+    publishNotice,
+    previewThumbFrameRef,
+    previewThumbTransformRef,
+    previewViewport,
+    resolvedPreviewSummary,
+    resetListFilters,
+    resetThumbnailToAutoMode,
+    removeTagFromPost,
+    restoreDeletedPostFromList,
+    restoreLocalDraft,
+    result,
+    safePreviewThumbnail,
+    saveLocalDraft,
+    selectedPostIdSet,
+    selectedPostIds,
+    serverBaselineEditorFingerprintRef,
+    sessionMember,
+    setActiveMetaPanel,
+    setCommentContent,
+    setCommentId,
+    setIsComposeAssistOpen,
+    setIsComposeUtilityOpen,
+    setIsDirectLoadOpen,
+    setIsMobileMetaEditorOpen,
+    setIsMobileThumbnailEditorOpen,
+    setIsPreviewThumbnailError,
+    setIsSelectedToolsOpen,
+    setListKw,
+    setListScope,
+    setMobileComposeStep,
+    setMobileManageStep,
+    setModifiedSortOrder,
+    setPostId,
+    setPostSummary,
+    setPostVisibility,
+    setPreviewViewport,
+    setProfileBioInput,
+    setProfileRoleInput,
+    setSelectedPostIds,
+    setTagDraft,
+    softDeleteUndoState,
+    studioSurface,
+    tagDraft,
+    tagRecommendationNotice,
+    tagUsageMap,
+    thumbnailImageFileInputRef,
+    thumbnailImageFileName,
+    toggleListAdvanced,
+    togglePostSelection,
+    toggleSelectAllVisiblePosts
+  } = props
+  const currentFlags = toFlags(postVisibility)
+  const editorStateFingerprint = useMemo(
+    () =>
+      buildEditorStateFingerprint({
+        title: postTitle,
+        content: postContent,
+        summary: postSummary,
+        thumbnailUrl: postThumbnailUrl,
+        thumbnailFocusX: postThumbnailFocusX,
+        thumbnailFocusY: postThumbnailFocusY,
+        thumbnailZoom: postThumbnailZoom,
+        tags: postTags,
+        category: postCategory,
+        visibility: postVisibility,
+      }),
+    [
+      postCategory,
+      postContent,
+      postSummary,
+      postTags,
+      postThumbnailFocusX,
+      postThumbnailFocusY,
+      postThumbnailZoom,
+      postThumbnailUrl,
+      postTitle,
+      postVisibility,
+    ]
+  )
+  const currentVisibilityText = getVisibilityLabel(currentFlags.published, currentFlags.listed)
+  const canOpenCurrentPostDetail = editorMode === "edit" && postId.trim().length > 0
+  const composeViewModel = useMemo(
+    () =>
+      deriveComposeViewModel({
+        editorMode,
+        isTempDraftMode,
+        postId,
+        postTitle,
+        postSummary,
+        postTags,
+        currentVisibilityText,
+      }),
+    [currentVisibilityText, editorMode, isTempDraftMode, postId, postSummary, postTags, postTitle]
+  )
+  const {
+    editorModeLabel,
+    hasSelectedManagedPost,
+    currentPostLabel,
+    selectedPostLabel,
+    tagSummaryText,
+    composePageTitle,
+    composeSurfaceSubtitle,
+    composeHeroSummary,
+    composeCallToActionLabel,
+  } = composeViewModel
+  const hasListFiltersApplied =
+    listKw.trim().length > 0 ||
+    listQuickPreset !== "none" ||
+    listPage !== "1" ||
+    listPageSize !== "30" ||
+    (listScope === "active" && listSort !== "CREATED_AT")
+  const deferredContentMetrics = useMemo(
+    () => deriveEditorContentMetrics(deferredPostContent),
+    [deferredPostContent]
+  )
+  const contentLength = deferredContentMetrics.trimmedLength
+  const lineCount = deferredContentMetrics.lineCount
+  const imageCount = deferredContentMetrics.imageCount
+  const hasEditorDraftContent = Boolean(postTitle.trim() || postContent.trim())
+  const hasEditorMinimumFields = Boolean(postTitle.trim() && postContent.trim())
+  const publishPlaceholderIssue = hasEditorMinimumFields
+    ? detectPublishPlaceholderIssue(postContent)
+    : null
+  const editorPersistenceState = deriveEditorPersistenceState({
+    editorMode,
+    hasSelectedManagedPost,
+    hasEditorDraftContent,
+    editorStateFingerprint,
+    serverBaselineFingerprint: serverBaselineEditorFingerprintRef.current,
+    localDraftFingerprint: lastLocalDraftFingerprintRef.current,
+    localDraftSavedAt,
+    loadingKey,
+    publishNoticeTone: publishNotice.tone,
+  })
+  const composeStatusText = editorPersistenceState.text
+  const composeStatusTone = editorPersistenceState.tone
+  const composeSummaryPreview = useMemo(
+    () => postSummary.trim() || deferredContentDerived.summary,
+    [deferredContentDerived.summary, postSummary]
+  )
+  const profilePreviewSrc = profileImgInputUrl.trim()
+  const profileImageStatus = profilePreviewSrc ? "설정됨" : "기본 이미지 사용 중"
+  const profileRoleStatus = profileRoleInput.trim() || "미설정"
+  const profileBioStatus = profileBioInput.trim() || "미설정"
+  const profileUpdatedText = sessionMember?.modifiedAt
+    ? sessionMember.modifiedAt.slice(0, 16).replace("T", " ")
+    : "확인 전"
+  const profileImageHint = profileImageFileName
+    ? `선택 파일: ${profileImageFileName}`
+    : `${PROFILE_IMAGE_UPLOAD_RULE_LABEL} (선택 즉시 업로드)`
+  const publishActionViewModel = derivePublishActionViewModel({
+    publishActionType,
+    editorMode,
+    loadingKey,
+    hasEditorMinimumFields,
+    hasPlaceholderIssue: Boolean(publishPlaceholderIssue),
+    isTempDraftMode,
+  })
+  const {
+    publishActionTitle,
+    publishActionButtonText,
+    publishActionButtonDisabled,
+    publishActionTriggerDisabled,
+    mobilePrimaryActionLabel,
+    mobilePrimaryActionDisabled,
+  } = publishActionViewModel
+  const activeMobileStudioStep = studioSurface === "manage" ? mobileManageStep : mobileComposeStep
+  const mobileStudioSurfaceSteps =
+    studioSurface === "manage"
+      ? ([...MANAGE_MOBILE_STUDIO_STEPS] as MobileStudioStep[])
+      : ([...COMPOSE_MOBILE_STUDIO_STEPS] as MobileStudioStep[])
+  const mobileStudioStepIndex = mobileStudioSurfaceSteps.indexOf(activeMobileStudioStep)
+  const mobileStudioPrevStep: MobileStudioStep | null =
+    mobileStudioStepIndex > 0 ? mobileStudioSurfaceSteps[mobileStudioStepIndex - 1] ?? null : null
+  const mobileStudioNextStep: MobileStudioStep | null =
+    mobileStudioStepIndex < mobileStudioSurfaceSteps.length - 1
+      ? mobileStudioSurfaceSteps[mobileStudioStepIndex + 1] ?? null
+      : null
+  const mobileStudioPrevStepLabel =
+    mobileStudioPrevStep === null ? "이전 단계 없음" : getMobileStudioStepMoveLabel(mobileStudioPrevStep)
+  const mobileStudioNextStepLabel =
+    mobileStudioNextStep === null ? "마지막 단계" : `${MOBILE_STUDIO_STEP_LABEL[mobileStudioNextStep]} 단계로 이동`
+  const setActiveMobileStudioStep = (step: MobileStudioStep) => {
+    if (step === "query" || step === "list") {
+      setMobileManageStep(step)
+      return
+    }
+    setMobileComposeStep(step)
+  }
+  const isCompactManageSurface = isCompactMobileLayout && studioSurface === "manage"
+  const showSelectedPanelInManageSurface = !isCompactMobileLayout || activeMobileStudioStep !== "list" || hasSelectedManagedPost
+  const [previewNowIso] = useState(() => new Date().toISOString())
+  const displayName = member.nickname || member.username || "관리자"
+  const displayNameInitial = displayName.slice(0, 2).toUpperCase()
+  const selectedPreviewViewport = previewViewport as PreviewViewportMode
+  const previewViewportConfig = PREVIEW_CARD_VIEWPORTS[selectedPreviewViewport]
+  const previewViewportOptions = PREVIEW_CARD_VIEWPORT_ORDER.map((viewport) => ({
+    value: viewport,
+    label: PREVIEW_CARD_VIEWPORTS[viewport].label,
+  }))
+  const previewVisibilityLabel = getVisibilityLabel(postVisibility)
+  const previewThumbnailSrc = safePreviewThumbnail && !isPreviewThumbnailError ? safePreviewThumbnail : ""
+  const shouldShowPublishModalNotice = publishModalNotice.tone !== "idle"
+  const previewAuthorAvatarSrc = (
+    profileImgInputUrl.trim() ||
+    member.profileImageDirectUrl ||
+    member.profileImageUrl ||
+    ""
+  ).trim()
+  const previewDateText = formatDate(previewNowIso, "ko")
+
+  const isCompactSplitPreview = false
+  const shouldShowGlobalNotice =
+    globalNotice.tone !== "idle" || globalNotice.text !== GLOBAL_NOTICE_IDLE_TEXT
+  const shouldShowPublishNotice = publishNotice.tone !== "idle"
+  const shouldShowTagRecommendationNotice =
+    tagRecommendationNotice.tone !== "idle" || tagRecommendationNotice.text !== TAG_RECOMMENDATION_IDLE_TEXT
+  const composeStatusEntries = [
+    shouldShowPublishNotice
+      ? {
+          key: "publish",
+          label: "발행 상태",
+          tone: publishNotice.tone,
+          text: publishNotice.text,
+        }
+      : null,
+    shouldShowTagRecommendationNotice
+      ? {
+          key: "tags",
+          label: "태그 상태",
+          tone: tagRecommendationNotice.tone,
+          text: tagRecommendationNotice.text,
+        }
+      : null,
+    {
+      key: "draft",
+      label: "브라우저 임시저장",
+      tone: localDraftSavedAt ? ("success" as NoticeTone) : ("idle" as NoticeTone),
+      text: localDraftSavedAt
+        ? `${localDraftSavedAt.slice(11, 16)} 저장본이 있습니다.`
+        : "아직 브라우저 임시저장이 없습니다.",
+    },
+  ].filter(
+    (
+      item
+    ): item is {
+      key: string
+      label: string
+      tone: NoticeTone
+      text: string
+    } => Boolean(item)
+  )
+  const mobileComposeStatusPrimary = composeStatusEntries[0] ?? {
+    key: "visibility",
+    label: "공개 범위",
+    tone: "idle" as NoticeTone,
+    text: `${currentVisibilityText} · ${postSummary.trim() ? "요약 입력됨" : "요약 자동 생성"}`,
+  }
+  const mobileComposeStatusSecondary = composeStatusEntries.find((item) => item.key === "draft") ?? null
+  const isThumbnailUploadDisabled = disabled("uploadThumbnail")
+  const handleThumbnailZoomModalChange = useCallback(
+    (nextZoom: number) => {
+      commitPreviewThumbTransform({
+        ...previewThumbTransformRef.current,
+        zoom: clampThumbnailZoom(nextZoom),
+      })
+    },
+    [commitPreviewThumbTransform, previewThumbTransformRef]
+  )
+  const resetThumbnailZoomInModal = useCallback(() => {
+    commitPreviewThumbTransform({
+      ...previewThumbTransformRef.current,
+      zoom: DEFAULT_THUMBNAIL_ZOOM,
+    })
+  }, [commitPreviewThumbTransform, previewThumbTransformRef])
+  const thumbnailEditorPanel = (
+    <EditorStudioThumbnailEditorPanel
+      finalizePreviewThumbPointer={finalizePreviewThumbPointer}
+      handlePreviewThumbPointerDown={handlePreviewThumbPointerDown}
+      handlePreviewThumbPointerMove={handlePreviewThumbPointerMove}
+      isPreviewThumbDragging={isPreviewThumbDragging}
+      isPreviewThumbnailError={isPreviewThumbnailError}
+      postThumbnailZoom={postThumbnailZoom}
+      previewThumbFrameRef={previewThumbFrameRef}
+      safePreviewThumbnail={safePreviewThumbnail}
+      setIsPreviewThumbnailError={setIsPreviewThumbnailError}
+      onThumbnailZoomChange={handleThumbnailZoomModalChange}
+      onResetThumbnailZoom={resetThumbnailZoomInModal}
+    />
+  )
+  const previewMetaEditorPanel = (
+    <EditorStudioThumbnailMetaPanel
+      firstBodyImageUrl={deferredContentDerived.firstImage}
+      isThumbnailUploadDisabled={isThumbnailUploadDisabled}
+      isThumbnailUploading={loadingKey === "uploadThumbnail"}
+      postThumbnailUrl={postThumbnailUrl}
+      thumbnailImageFileName={thumbnailImageFileName}
+      thumbnailUploadRuleLabel={POST_IMAGE_UPLOAD_RULE_LABEL}
+      onApplyFirstBodyImage={applyFirstBodyImageToThumbnail}
+      onOpenThumbnailFileInput={openThumbnailFileInput}
+      onResetThumbnailToAutoMode={resetThumbnailToAutoMode}
+      onThumbnailPaste={handleThumbnailPaste}
+      onThumbnailUrlChange={handleThumbnailUrlModalChange}
+    />
+  )
+  const editorPrimaryActionType: PublishActionType =
+    editorMode === "create" ? "create" : isTempDraftMode ? "temp" : "modify"
+  const editorPrimaryActionLabel =
+    editorPrimaryActionType === "modify"
+      ? "수정 반영"
+      : editorPrimaryActionType === "temp"
+        ? "새 글 작성"
+        : "발행"
+  const isBlockEditorDisabled = loadingKey.length > 0
+  const handleEditorCommitDuration = useCallback((actualDuration: number) => {
+    recordEditorCommitDurationForRuntimeGuard(actualDuration)
+  }, [])
+  const dedicatedEditorCanvas = useMemo(
+    () => (
+      <WriterEditorHost
+        canvasId="editor-dedicated-canvas"
+        markdown={postContent}
+        onMarkdownChange={handleBlockEditorChange}
+        onImageUpload={handleBlockEditorImageUpload}
+        onFileUpload={handleBlockEditorFileUpload}
+        mermaidEnabled={BLOCK_EDITOR_V2_MERMAID_ENABLED}
+        disabled={isBlockEditorDisabled}
+        onCommitDuration={handleEditorCommitDuration}
+      />
+    ),
+    [
+      handleBlockEditorChange,
+      handleBlockEditorFileUpload,
+      handleBlockEditorImageUpload,
+      handleEditorCommitDuration,
+      isBlockEditorDisabled,
+      postContent,
+    ]
+  )
+  const composeEditorCanvas = useMemo(
+    () => (
+      <WriterEditorHost
+        canvasId="editor-compose-canvas"
+        markdown={postContent}
+        onMarkdownChange={handleBlockEditorChange}
+        onImageUpload={handleBlockEditorImageUpload}
+        onFileUpload={handleBlockEditorFileUpload}
+        mermaidEnabled={BLOCK_EDITOR_V2_MERMAID_ENABLED}
+        disabled={isBlockEditorDisabled}
+        onCommitDuration={handleEditorCommitDuration}
+      />
+    ),
+    [
+      handleBlockEditorChange,
+      handleBlockEditorFileUpload,
+      handleBlockEditorImageUpload,
+      handleEditorCommitDuration,
+      isBlockEditorDisabled,
+      postContent,
+    ]
+  )
+  const shouldShowEditorLoadingState =
+    isDedicatedNewEditorRoute &&
+    !postId.trim() &&
+    (isNewEditorBootstrapPending || loadingKey === "postTemp")
+  const shouldShowResultPanel = Boolean(loadingKey || result)
+  const dedicatedEditorResultPanel = useMemo(
+    () =>
+      shouldShowResultPanel ? (
+        <EditorStudioResultLogPanel
+          idleDescription="원본 응답을 확인할 수 있습니다"
+          idleTitle="최근 작업 응답"
+          loadingDescription={(currentLoadingKey) => `실행 중: ${currentLoadingKey}`}
+          loadingKey={loadingKey}
+          loadingTitle="작업 응답 확인 중"
+          result={result}
+          variant="dedicated"
+        />
+      ) : null,
+    [loadingKey, result, shouldShowResultPanel]
+  )
+
+  if (!sessionMember) {
+    return null
+  }
+
+  if (shouldShowEditorLoadingState) {
+    return <EditorStudioDedicatedEditorLoadingState />
+  }
+
+  if (isDedicatedEditorRoute) {
+    return (
+      <EditorStudioDedicatedEditorSurface
+        thumbnailImageFileInputRef={thumbnailImageFileInputRef}
+        onThumbnailImageFileChange={handleThumbnailImageFileChange}
+        onExit={handleExitDedicatedEditor}
+        saveStateText={composeStatusText}
+        saveStateTone={composeStatusTone}
+        primaryActionDisabled={publishActionTriggerDisabled}
+        primaryActionLabel={editorPrimaryActionLabel}
+        onPrimaryAction={() => openPublishModal(editorPrimaryActionType)}
+        isCompactSplitPreview={isCompactSplitPreview}
+        postTags={postTags}
+        tagDraft={tagDraft}
+        onTagDraftChange={setTagDraft}
+        onAddTags={addTagsToPost}
+        onAddTag={addTagToPost}
+        onRemoveTag={removeTagFromPost}
+        titleInputRef={handleTitleFieldRef}
+        postTitle={postTitle}
+        onPostTitleChange={handleTitleChange}
+        onPostTitleKeyDown={handleTitleKeyDown}
+        authorName={displayName}
+        authorInitial={displayNameInitial}
+        authorAvatarSrc={previewAuthorAvatarSrc}
+        previewDateText={previewDateText}
+        currentVisibilityText={currentVisibilityText}
+        canOpenCurrentPostDetail={canOpenCurrentPostDetail}
+        onOpenPostDetail={() => void openPostDetailRoute(postId)}
+        onCopyPostDetailLink={() => void copyPostDetailLink(postId, postTitle)}
+        editorCanvas={dedicatedEditorCanvas}
+        showPublishNotice={shouldShowPublishNotice}
+        publishNoticeTone={publishNotice.tone}
+        publishNoticeText={publishNotice.text}
+        resultPanel={dedicatedEditorResultPanel}
+        publishModal={
+          isPublishModalOpen ? (
+            <EditorStudioPublishModal
+              closeToggleLabel="닫기"
+              displayName={displayName}
+              displayNameInitial={displayNameInitial}
+              isCompactMobileLayout={isCompactMobileLayout}
+              isMobileMetaEditorOpen={isMobileMetaEditorOpen}
+              isMobileThumbnailEditorOpen={isMobileThumbnailEditorOpen}
+              loadingKey={loadingKey}
+              modalNotice={publishModalNotice}
+              postThumbnailFocusX={postThumbnailFocusX}
+              postThumbnailFocusY={postThumbnailFocusY}
+              postThumbnailZoom={postThumbnailZoom}
+              postTitle={postTitle}
+              postVisibility={postVisibility}
+              previewAuthorAvatarSrc={previewAuthorAvatarSrc}
+              previewDateText={previewDateText}
+              previewFrameStyle={{ maxWidth: `${previewViewportConfig.cardWidth}px` }}
+              previewKicker="카드 미리보기"
+              previewMetaEditorPanel={previewMetaEditorPanel}
+              previewSummary={resolvedPreviewSummary}
+              previewSummaryFallback="요약을 비워두면 본문에서 자동 생성한 요약이 카드에 반영됩니다."
+              previewThumbnailSrc={previewThumbnailSrc}
+              previewViewport={previewViewport}
+              previewViewportLabel={previewViewportConfig.label}
+              previewViewportOptions={previewViewportOptions}
+              previewVisibilityLabel={previewVisibilityLabel}
+              publishActionButtonDisabled={publishActionButtonDisabled}
+              publishActionButtonText={publishActionButtonText}
+              publishActionTitle={publishActionTitle}
+              shouldShowNotice={shouldShowPublishModalNotice}
+              thumbnailEditorPanel={thumbnailEditorPanel}
+              variant="drawer"
+              visibilityOptions={PUBLISH_VISIBILITY_OPTIONS}
+              onClose={closePublishModal}
+              onConfirmPublish={() => void handleConfirmPublish()}
+              onPostVisibilityChange={setPostVisibility}
+              onPreviewThumbnailError={() => setIsPreviewThumbnailError(true)}
+              onPreviewViewportChange={setPreviewViewport}
+              onToggleMobileMetaEditor={() => setIsMobileMetaEditorOpen((current: boolean) => !current)}
+              onToggleMobileThumbnailEditor={() => setIsMobileThumbnailEditorOpen((current: boolean) => !current)}
+            />
+          ) : null
+        }
+      />
+    )
+  }
+
+  return (
+    <Main>
+      <HeroCard data-compact-manage={isCompactManageSurface}>
+        <HeroIntro data-compact-manage={isCompactManageSurface}>
+          <h1>{composePageTitle}</h1>
+          <p>제목과 본문에 집중하고, 발행 전 설정은 오른쪽에서 차분하게 마무리합니다.</p>
+          <StudioStatusStrip aria-label="글 작업실 상태 요약">
+            <StudioStatusItem>
+              <span>현재 작업</span>
+              <strong>{composePageTitle}</strong>
+            </StudioStatusItem>
+            {currentPostLabel ? (
+              <StudioStatusItem>
+                <span>원고</span>
+                <strong>{currentPostLabel}</strong>
+              </StudioStatusItem>
+            ) : null}
+            <StudioStatusItem data-optional="true">
+              <span>공개 범위</span>
+              <strong>{currentVisibilityText}</strong>
+            </StudioStatusItem>
+            {composeStatusText ? (
+              <StudioStatusItem data-optional="true">
+                <span>저장 상태</span>
+                <strong>{composeStatusText}</strong>
+              </StudioStatusItem>
+            ) : null}
+          </StudioStatusStrip>
+        </HeroIntro>
+      </HeroCard>
+
+      <WorkspaceGrid>
+        <WorkspaceMain>
+          {SHOW_LEGACY_PROFILE_STUDIO && (
+            <EditorStudioLegacyProfileSection
+              displayName={displayName}
+              displayNameInitial={displayNameInitial}
+              isProfileCardUpdateDisabled={disabled("admMemberProfileCardUpdate")}
+              isProfileImageUploadDisabled={disabled("admMemberProfileImgUpdate")}
+              isProfileImageUploading={loadingKey === "admMemberProfileImgUpdate"}
+              isProfileRefreshDisabled={disabled("admMemberProfileRefresh")}
+              profileBioInput={profileBioInput}
+              profileBioStatus={profileBioStatus}
+              profileImageFileInputRef={profileImageFileInputRef}
+              profileImageHint={profileImageHint}
+              profileImageNotice={profileImageNotice}
+              profileImageStatus={profileImageStatus}
+              profileNotice={profileNotice}
+              profilePreviewSrc={profilePreviewSrc}
+              profileRoleInput={profileRoleInput}
+              profileRoleStatus={profileRoleStatus}
+              profileUpdatedText={profileUpdatedText}
+              onProfileBioChange={setProfileBioInput}
+              onProfileImageSelected={handleProfileImageSelected}
+              onProfileRoleChange={setProfileRoleInput}
+              onRefreshAdminProfile={handleRefreshAdminProfile}
+              onUpdateMemberProfileCard={() => void handleUpdateMemberProfileCard()}
+            />
+          )}
+
+          {SHOW_LEGACY_CONTENT_STUDIO && (
+            <EditorStudioContentWorkspace
+              shouldShowGlobalNotice={shouldShowGlobalNotice}
+              globalNotice={globalNotice}
+              mobileStudioSurfaceSteps={mobileStudioSurfaceSteps}
+              activeMobileStudioStep={activeMobileStudioStep}
+              mobileStudioStepLabels={MOBILE_STUDIO_STEP_LABEL}
+              mobileStudioStepDescriptions={MOBILE_STUDIO_STEP_DESCRIPTION}
+              mobileStudioPrevStep={mobileStudioPrevStep}
+              mobileStudioNextStep={mobileStudioNextStep}
+              mobileStudioPrevStepLabel={mobileStudioPrevStepLabel}
+              mobileStudioNextStepLabel={mobileStudioNextStepLabel}
+              isCompactMobileLayout={isCompactMobileLayout}
+              onMobileStepChange={setActiveMobileStudioStep}
+              listScope={listScope}
+              listKeyword={listKw}
+              listQuickPreset={listQuickPreset}
+              hasListFiltersApplied={hasListFiltersApplied}
+              isListAdvancedOpen={isListAdvancedOpen}
+              listPage={listPage}
+              listPageSize={listPageSize}
+              listSort={listSort}
+              listSortOptions={LIST_SORT_OPTIONS}
+              isListRefreshDisabled={disabled("postList")}
+              isTempPostDisabled={disabled("postTemp")}
+              onListScopeChange={setListScope}
+              onListKeywordChange={setListKw}
+              onRefreshList={() => void loadAdminPosts()}
+              onLoadOrCreateTempPost={() => void handleLoadOrCreateTempPost()}
+              onApplyQuickPreset={applyListQuickPreset}
+              onResetFilters={resetListFilters}
+              onToggleListAdvanced={toggleListAdvanced}
+              onListPageChange={handleListPageChange}
+              onListPageSizeChange={handleListPageSizeChange}
+              onListSortChange={handleListSortChange}
+              selectedPostIds={selectedPostIds}
+              adminPostTotal={adminPostTotal}
+              adminPostRows={adminPostRows}
+              adminPostViewRows={adminPostViewRows}
+              isAllVisiblePostsSelected={isAllVisiblePostsSelected}
+              selectedPostIdSet={selectedPostIdSet}
+              editorMode={editorMode}
+              postId={postId}
+              loadingKey={loadingKey}
+              modifiedSortOrder={modifiedSortOrder}
+              deletedListNotice={deletedListNotice}
+              onToggleSelectAllVisiblePosts={toggleSelectAllVisiblePosts}
+              onClearSelection={() => setSelectedPostIds([])}
+              onRequestDeletePosts={(ids, headline) => openDeleteConfirm(ids, headline)}
+              onTogglePostSelection={togglePostSelection}
+              onToggleModifiedSortOrder={() => setModifiedSortOrder((prev: "desc" | "asc") => (prev === "desc" ? "asc" : "desc"))}
+              onEditPost={(row) => {
+                setPostId(String(row.id))
+                void loadPostForEditor(String(row.id))
+              }}
+              onOpenPostDetail={(id) => void openPostDetailRoute(id)}
+              onCopyPostDetailLink={(id, title) => void copyPostDetailLink(id, title)}
+              onRestoreDeletedPost={(row) => void restoreDeletedPostFromList(row)}
+              onHardDeletePost={(row) => void hardDeleteDeletedPostFromList(row)}
+              showSelectedPanelInManageSurface={showSelectedPanelInManageSurface}
+              hasSelectedManagedPost={hasSelectedManagedPost}
+              editorModeLabel={editorModeLabel}
+              selectedPostLabel={selectedPostLabel}
+              postTitle={postTitle}
+              postVersion={postVersion}
+              isTempDraftMode={isTempDraftMode}
+              postVisibility={postVisibility}
+              currentVisibilityText={currentVisibilityText}
+              isContinueEditingDisabled={editorMode !== "edit" || disabled("modifyPost")}
+              isCreateNewPostDisabled={loadingKey.length > 0}
+              isDeletePostDisabled={disabled("deletePost")}
+              onContinueEditing={handleContinueSelectedPostEditing}
+              onCreateNewPost={handleCreateNewPostFromSelectedPanel}
+              onDeletePost={handleDeleteSelectedPost}
+              isDirectLoadOpen={isDirectLoadOpen}
+              onToggleDirectLoad={() => setIsDirectLoadOpen((prev: boolean) => !prev)}
+              isSelectedToolsOpen={isSelectedToolsOpen}
+              onToggleSelectedTools={() => setIsSelectedToolsOpen((prev: boolean) => !prev)}
+              onPostIdChange={handleSelectedPostIdChange}
+              isLoadPostDisabled={disabled("postOne")}
+              onLoadPost={() => void loadPostForEditor()}
+              isHitPostDisabled={disabled("hitPost")}
+              onRunHitPost={() =>
+                handleHitPost()
+              }
+              isLikePostDisabled={disabled("likePost")}
+              onRunLikePost={() =>
+                handleLikePost()
+              }
+              softDeleteUndoMessage={softDeleteUndoState?.message || ""}
+              isSoftDeleteUndoVisible={Boolean(softDeleteUndoState)}
+              isUndoDisabled={disabled("undoDeletePost")}
+              onUndoSoftDelete={() => void handleUndoSoftDelete()}
+            />
+          )}
+
+        <EditorStudioDeleteConfirmDialog
+          state={deleteConfirmState}
+          noticeTone={deleteConfirmNotice.tone}
+          noticeText={deleteConfirmNotice.text}
+          isDeleteDisabled={loadingKey === "deletePost"}
+          onClose={closeDeleteConfirm}
+          onConfirm={async (state) => {
+            const ok = await deletePostsFromList(state.ids)
+            if (ok) closeDeleteConfirm()
+          }}
+        />
+        {studioSurface === "compose" && (
+          <EditorStudioComposeWorkspace
+            isCompactMobileLayout={isCompactMobileLayout}
+            isPublishModalOpen={isPublishModalOpen}
+            mobilePrimaryStatus={mobileComposeStatusPrimary}
+            mobileSecondaryStatusText={mobileComposeStatusSecondary?.text}
+            mobilePrimaryActionLabel={mobilePrimaryActionLabel}
+            composeCallToActionLabel={composeCallToActionLabel}
+            mobilePrimaryActionDisabled={mobilePrimaryActionDisabled}
+            onPrimaryAction={() => openPublishModal(editorPrimaryActionType)}
+            currentVisibilityText={currentVisibilityText}
+            editorModeLabel={editorModeLabel}
+            composePageTitle={composePageTitle}
+            composeSurfaceSubtitle={composeSurfaceSubtitle}
+            composeStatusText={composeStatusText}
+            composeStatusTone={composeStatusTone}
+            postSummary={postSummary}
+            postSummaryMaxLength={PREVIEW_SUMMARY_MAX_LENGTH}
+            onPostSummaryChange={setPostSummary}
+            isFillSummaryFromBodyDisabled={!postContent.trim()}
+            onFillSummaryFromBody={() => setPostSummary(makePreviewSummary(postContent))}
+            postTags={postTags}
+            tagDraft={tagDraft}
+            onTagDraftChange={setTagDraft}
+            onAddTags={addTagsToPost}
+            onAddTag={addTagToPost}
+            onRemoveTag={removeTagFromPost}
+            titleInputRef={handleTitleFieldRef}
+            postTitle={postTitle}
+            onPostTitleChange={handleTitleChange}
+            onPostTitleKeyDown={handleTitleKeyDown}
+            thumbnailImageFileInputRef={thumbnailImageFileInputRef}
+            onThumbnailImageFileChange={handleThumbnailImageFileChange}
+            contentLength={contentLength}
+            lineCount={lineCount}
+            imageCount={imageCount}
+            editorCanvas={composeEditorCanvas}
+            tagSummaryText={tagSummaryText}
+            isSaveDraftDisabled={loadingKey.length > 0}
+            onSaveLocalDraft={saveLocalDraft}
+            composeHeroSummary={composeHeroSummary}
+            isRecommendTagsDisabled={disabled("recommendTags") || !postContent.trim()}
+            isRecommendTagsLoading={loadingKey === "recommendTags"}
+            onRecommendTags={() => void handleRecommendTags()}
+            composeStatusEntries={composeStatusEntries}
+            activeVisibility={postVisibility}
+            visibilityOptions={PUBLISH_VISIBILITY_OPTIONS}
+            onVisibilityChange={setPostVisibility}
+            previewViewport={previewViewport}
+            previewViewportLabel={previewViewportConfig.label}
+            previewViewportOptions={previewViewportOptions}
+            onPreviewViewportChange={(viewport) => setPreviewViewport(viewport)}
+            previewFrameStyle={{ width: `min(100%, ${previewViewportConfig.cardWidth}px)` }}
+            previewThumbnailSrc={previewThumbnailSrc}
+            postThumbnailFocusX={postThumbnailFocusX}
+            postThumbnailFocusY={postThumbnailFocusY}
+            postThumbnailZoom={postThumbnailZoom}
+            onPreviewThumbnailError={() => setIsPreviewThumbnailError(true)}
+            previewVisibilityLabel={previewVisibilityLabel}
+            summaryPreview={composeSummaryPreview}
+            previewDateText={previewDateText}
+            previewAuthorAvatarSrc={previewAuthorAvatarSrc}
+            displayNameInitial={displayNameInitial}
+            displayName={displayName}
+            summaryLengthLabel={
+              postSummary.trim() ? `${postSummary.trim().length}/${PREVIEW_SUMMARY_MAX_LENGTH}` : "본문 기준 자동"
+            }
+            isComposeAssistOpen={isComposeAssistOpen}
+            onToggleComposeAssist={() => setIsComposeAssistOpen((prev: boolean) => !prev)}
+            thumbnailEditorPanel={thumbnailEditorPanel}
+            previewMetaEditorPanel={previewMetaEditorPanel}
+            isTagPanelOpen={activeMetaPanel === "tag"}
+            onToggleTagPanel={() => setActiveMetaPanel((prev: "tag" | "category" | null) => (prev === "tag" ? null : "tag"))}
+            isUtilityPanelOpen={isComposeUtilityOpen}
+            onToggleUtilityPanel={() => setIsComposeUtilityOpen((prev: boolean) => !prev)}
+            metaNotice={metaNotice}
+            knownTags={knownTags}
+            tagUsageMap={tagUsageMap}
+            onToggleKnownTag={(tag) => (postTags.includes(tag) ? removeTagFromPost(tag) : addTagToPost(tag))}
+            onDeleteKnownTag={deleteTagFromCatalog}
+            onRestoreLocalDraft={restoreLocalDraft}
+            onClearLocalDraft={clearLocalDraft}
+            isClearLocalDraftDisabled={loadingKey.length > 0 || !localDraftSavedAt}
+          />
+        )}
+
+        {isPublishModalOpen ? (
+          <EditorStudioPublishModal
+            closeToggleLabel="접기"
+            displayName={displayName}
+            displayNameInitial={displayNameInitial}
+            isCompactMobileLayout={isCompactMobileLayout}
+            isMobileMetaEditorOpen={isMobileMetaEditorOpen}
+            isMobileThumbnailEditorOpen={isMobileThumbnailEditorOpen}
+            loadingKey={loadingKey}
+            modalNotice={publishModalNotice}
+            postThumbnailFocusX={postThumbnailFocusX}
+            postThumbnailFocusY={postThumbnailFocusY}
+            postThumbnailZoom={postThumbnailZoom}
+            postTitle={postTitle}
+            postVisibility={postVisibility}
+            previewAuthorAvatarSrc={previewAuthorAvatarSrc}
+            previewDateText={previewDateText}
+            previewFrameStyle={{ maxWidth: `${previewViewportConfig.cardWidth}px` }}
+            previewKicker="실제 카드 결과"
+            previewMetaEditorPanel={previewMetaEditorPanel}
+            previewSummary={resolvedPreviewSummary}
+            previewSummaryFallback="요약을 비워두면 본문에서 자동 생성한 요약이 카드에 반영됩니다."
+            previewThumbnailSrc={previewThumbnailSrc}
+            previewViewport={previewViewport}
+            previewViewportLabel={previewViewportConfig.label}
+            previewViewportOptions={previewViewportOptions}
+            previewVisibilityLabel={previewVisibilityLabel}
+            publishActionButtonDisabled={publishActionButtonDisabled}
+            publishActionButtonText={publishActionButtonText}
+            publishActionTitle={publishActionTitle}
+            setupDescription="썸네일 위치와 카드 요약만 조정합니다. 결과는 위 카드에서 바로 확인됩니다."
+            shouldShowNotice={shouldShowPublishModalNotice}
+            thumbnailEditorPanel={thumbnailEditorPanel}
+            visibilityOptions={PUBLISH_VISIBILITY_OPTIONS}
+            onClose={closePublishModal}
+            onConfirmPublish={() => void handleConfirmPublish()}
+            onPostVisibilityChange={setPostVisibility}
+            onPreviewThumbnailError={() => setIsPreviewThumbnailError(true)}
+            onPreviewViewportChange={setPreviewViewport}
+            onToggleMobileMetaEditor={() => setIsMobileMetaEditorOpen((current: boolean) => !current)}
+            onToggleMobileThumbnailEditor={() => setIsMobileThumbnailEditorOpen((current: boolean) => !current)}
+          />
+        ) : null}
+
+          {SHOW_LEGACY_UTILITY_STUDIO && (
+            <EditorStudioLegacyUtilityPanel
+              commentContent={commentContent}
+              commentId={commentId}
+              isCommentDeleteDisabled={disabled("commentDelete")}
+              isCommentListDisabled={disabled("commentList")}
+              isCommentModifyDisabled={disabled("commentModify")}
+              isCommentOneDisabled={disabled("commentOne")}
+              isCommentWriteDisabled={disabled("commentWrite")}
+              isPostCountDisabled={disabled("admPostCount")}
+              isSystemHealthDisabled={disabled("systemHealth")}
+              postId={postId}
+              onCommentContentChange={setCommentContent}
+              onCommentIdChange={setCommentId}
+              onDeleteComment={handleDeleteComment}
+              onListComments={handleListComments}
+              onModifyComment={handleModifyComment}
+              onPostIdChange={setPostId}
+              onReadComment={handleReadComment}
+              onReadPostCount={handleReadPostCount}
+              onReadSystemHealth={handleReadSystemHealth}
+              onWriteComment={handleWriteComment}
+            />
+          )}
+        </WorkspaceMain>
+
+      </WorkspaceGrid>
+
+      <EditorStudioResultLogPanel
+        eyebrow="실행 로그"
+        idleDescription="접어서 숨길 수 있습니다"
+        idleTitle="최근 작업 응답 보기"
+        loadingDescription={(currentLoadingKey) => `실행 중: ${currentLoadingKey}`}
+        loadingKey={loadingKey}
+        loadingTitle="작업 응답 확인 중"
+        result={result}
+        variant="standard"
+      />
+    </Main>
+  )
+}

--- a/front/src/routes/Admin/useEditorStudioWorkspaceControllerRuntime.ts
+++ b/front/src/routes/Admin/useEditorStudioWorkspaceControllerRuntime.ts
@@ -1,0 +1,245 @@
+import type { QueryClient } from "@tanstack/react-query"
+import type { NextRouter } from "next/router"
+import {
+  type ChangeEvent,
+  type Dispatch,
+  type KeyboardEvent,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+} from "react"
+import { invalidatePublicPostReadCaches } from "src/apis/backend/posts"
+import { pushRoute } from "src/libs/router"
+import { toCanonicalPostPath } from "src/libs/utils/postPath"
+import {
+  buildCanonicalPostUrl,
+  isComposingKeyboardEvent,
+  pretty,
+  syncTitleTextareaHeight,
+  type JsonValue,
+  type NoticeState,
+} from "./EditorStudioWorkspaceControllerRootModel"
+import type { EditorMode, PublishActionType } from "./editorStudioState"
+
+type PublishNoticeTarget = "auto" | "page" | "modal"
+
+type UseEditorStudioWorkspaceControllerRuntimeArgs = {
+  isPublishModalOpen: boolean
+  loadingKey: string
+  postId: string
+  postTitle: string
+  queryClient: QueryClient
+  router: NextRouter
+  setEditorMode: Dispatch<SetStateAction<EditorMode>>
+  setGlobalNotice: Dispatch<SetStateAction<NoticeState>>
+  setIsTempDraftMode: Dispatch<SetStateAction<boolean>>
+  setLoadingKey: Dispatch<SetStateAction<string>>
+  setPostId: Dispatch<SetStateAction<string>>
+  setPostTitle: Dispatch<SetStateAction<string>>
+  setPostVersion: Dispatch<SetStateAction<number | null>>
+  setPublishModalNotice: Dispatch<SetStateAction<NoticeState>>
+  setPublishNotice: Dispatch<SetStateAction<NoticeState>>
+  setResult: Dispatch<SetStateAction<string>>
+}
+
+export const useEditorStudioWorkspaceControllerRuntime = ({
+  isPublishModalOpen,
+  loadingKey,
+  postId,
+  postTitle,
+  queryClient,
+  router,
+  setEditorMode,
+  setGlobalNotice,
+  setIsTempDraftMode,
+  setLoadingKey,
+  setPostId,
+  setPostTitle,
+  setPostVersion,
+  setPublishModalNotice,
+  setPublishNotice,
+  setResult,
+}: UseEditorStudioWorkspaceControllerRuntimeArgs) => {
+  const titleFieldRef = useRef<HTMLTextAreaElement | null>(null)
+
+  const refreshPublicPostReadViews = useCallback(async (affectedPostId?: string | number) => {
+    const resolvedPostId =
+      typeof affectedPostId === "number"
+        ? affectedPostId
+        : typeof affectedPostId === "string"
+          ? affectedPostId.trim()
+          : postId.trim()
+
+    await invalidatePublicPostReadCaches(queryClient, resolvedPostId || undefined)
+    if (!resolvedPostId) return
+
+    const revalidateResponse = await fetch("/api/revalidate", {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        paths: [toCanonicalPostPath(resolvedPostId)],
+      }),
+    })
+
+    if (!revalidateResponse.ok) {
+      const reason = (await revalidateResponse.text().catch(() => "")).trim()
+      throw new Error(reason || "공개 상세 재검증 요청에 실패했습니다.")
+    }
+  }, [postId, queryClient])
+
+  const run = useCallback(async (key: string, fn: () => Promise<JsonValue>) => {
+    try {
+      setLoadingKey(key)
+      setGlobalNotice({ tone: "loading", text: `작업 실행 중: ${key}` })
+      const data = await fn()
+      setResult(pretty(data))
+      setGlobalNotice({ tone: "success", text: `작업 완료: ${key}` })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      setResult(pretty({ error: message }))
+      setGlobalNotice({ tone: "error", text: `작업 실패: ${message}` })
+    } finally {
+      setLoadingKey("")
+    }
+  }, [setGlobalNotice, setLoadingKey, setResult])
+
+  const disabled = useCallback((key: string) => loadingKey.length > 0 && loadingKey !== key, [loadingKey])
+
+  const handleTitleFieldRef = useCallback((node: HTMLTextAreaElement | null) => {
+    titleFieldRef.current = node
+    syncTitleTextareaHeight(node)
+  }, [])
+
+  const handleTitleChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>) => {
+    setPostTitle(event.target.value.replace(/\r\n?/g, "\n"))
+    syncTitleTextareaHeight(event.target)
+  }, [setPostTitle])
+
+  const handleTitleKeyDown = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (isComposingKeyboardEvent(event)) return
+    if (event.key === "Enter") {
+      event.preventDefault()
+    }
+  }, [])
+
+  useEffect(() => {
+    syncTitleTextareaHeight(titleFieldRef.current)
+  }, [postTitle])
+
+  const handleSelectedPostIdChange = useCallback(
+    (nextPostId: string) => {
+      const normalizedPostId = nextPostId.trim()
+      setPostId(normalizedPostId)
+      if (normalizedPostId !== postId.trim()) {
+        setEditorMode("create")
+        setPostVersion(null)
+        setIsTempDraftMode(false)
+      }
+    },
+    [postId, setEditorMode, setIsTempDraftMode, setPostId, setPostVersion]
+  )
+
+  const publishModalHintByAction = useCallback((actionType: PublishActionType): string => {
+    if (actionType === "create") return "작성 전 확인이 필요한 항목만 이곳에 표시됩니다."
+    if (actionType === "modify") return "수정 전 확인이 필요한 항목만 이곳에 표시됩니다."
+    return "새 글 작성 전 확인이 필요한 항목만 이곳에 표시됩니다."
+  }, [])
+
+  const setPublishStatus = useCallback(
+    (next: NoticeState, target: PublishNoticeTarget = "auto") => {
+      setGlobalNotice(next)
+      if (target === "page") {
+        setPublishNotice(next)
+        return
+      }
+
+      if (target === "modal") {
+        setPublishModalNotice(next)
+        return
+      }
+
+      if (isPublishModalOpen) {
+        setPublishModalNotice(next)
+        return
+      }
+
+      setPublishNotice(next)
+    },
+    [isPublishModalOpen, setGlobalNotice, setPublishModalNotice, setPublishNotice]
+  )
+
+  const openPostDetailRoute = useCallback(
+    async (targetPostId: string | number) => {
+      const resolvedPostId = String(targetPostId).trim()
+      if (!resolvedPostId) {
+        setPublishStatus({ tone: "error", text: "상세 링크를 열 글 ID가 없습니다." }, "page")
+        return
+      }
+
+      const path = toCanonicalPostPath(resolvedPostId)
+      if (typeof window !== "undefined") {
+        const opened = window.open(path, "_blank", "noopener,noreferrer")
+        if (opened) return
+      }
+
+      try {
+        await pushRoute(router, path)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        setPublishStatus({ tone: "error", text: `상세 열기 실패: ${message}` }, "page")
+      }
+    },
+    [router, setPublishStatus]
+  )
+
+  const copyPostDetailLink = useCallback(
+    async (targetPostId: string | number, title?: string) => {
+      const resolvedPostId = String(targetPostId).trim()
+      if (!resolvedPostId) {
+        setPublishStatus({ tone: "error", text: "복사할 상세 링크가 없습니다." }, "page")
+        return
+      }
+
+      const rowLabel = `#${resolvedPostId} ${title?.trim() || "제목 없는 글"}`
+      const url = buildCanonicalPostUrl(resolvedPostId)
+
+      try {
+        if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(url)
+          setPublishStatus({ tone: "success", text: `${rowLabel} 링크를 복사했습니다.` }, "page")
+          return
+        }
+
+        if (typeof window !== "undefined") {
+          window.prompt("링크를 복사하세요.", url)
+          setPublishStatus({ tone: "success", text: `${rowLabel} 링크를 표시했습니다.` }, "page")
+          return
+        }
+
+        throw new Error("링크를 복사할 수 없는 환경입니다.")
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        setPublishStatus({ tone: "error", text: `링크 복사 실패: ${message}` }, "page")
+      }
+    },
+    [setPublishStatus]
+  )
+
+  return {
+    copyPostDetailLink,
+    disabled,
+    handleSelectedPostIdChange,
+    handleTitleChange,
+    handleTitleFieldRef,
+    handleTitleKeyDown,
+    openPostDetailRoute,
+    publishModalHintByAction,
+    refreshPublicPostReadViews,
+    run,
+    setPublishStatus,
+  }
+}


### PR DESCRIPTION
## 관련 이슈

close #398

## 작업 배경

- `EditorStudioWorkspaceControllerRoot.tsx`를 822 lines로 낮추고, view/model/style/runtime companion module로 책임을 분리했습니다.
- editor studio source-boundary 테스트에 root/view/runtime 예산 검증을 추가해 같은 비대화 회귀를 막았습니다.
- 배포 경로는 `작업 브랜치 -> PR to main -> main merge -> 자동 홈서버 배포`입니다.

## 작업 내용

- root controller는 hook orchestration과 props assembly만 맡도록 축소했습니다.
- publish/revalidate/copy route runtime은 `useEditorStudioWorkspaceControllerRuntime.ts`로 분리했습니다.
- view JSX는 `EditorStudioWorkspaceControllerRootView.tsx`, helper/model 값은 `EditorStudioWorkspaceControllerRootModel.ts`, layout primitive는 `EditorStudioWorkspaceControllerRoot.styles.ts`로 이동했습니다.
- `editor-studio-state` source-boundary 테스트가 root와 view line budget을 함께 검증하도록 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=front-refactor-editor-studio-root bash tools/guards/current-task-preflight.sh`
  - `git diff --check`
  - `wc -l front/src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx front/src/routes/Admin/EditorStudioWorkspaceControllerRootView.tsx front/src/routes/Admin/useEditorStudioWorkspaceControllerRuntime.ts front/src/routes/Admin/EditorStudioWorkspaceControllerRootModel.ts front/src/routes/Admin/EditorStudioWorkspaceControllerRoot.styles.ts`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1 --grep "editor studio와 BlockEditorEngine"` (2회 연속 통과)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front test:e2e:live`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: props adapter가 넓어져 후속 분리 전까지 RootView 타입 정밀도가 낮습니다.
- 롤백 방법: PR commit `4b169ece`를 revert하면 기존 단일 root controller 구조로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
