### PR TITLE
[Perf] task diagnostics DB count 폴링 축소

### DIFF
--- a/back/src/main/kotlin/com/back/global/task/application/TaskQueueMetricsBinder.kt
+++ b/back/src/main/kotlin/com/back/global/task/application/TaskQueueMetricsBinder.kt
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.binder.MeterBinder
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.util.concurrent.atomic.AtomicLong
@@ -15,6 +16,10 @@ import java.util.concurrent.atomic.AtomicLong
 @Component
 class TaskQueueMetricsBinder(
     private val taskQueueDiagnosticsService: TaskQueueDiagnosticsService,
+    @Value("\${custom.runtime.workerEnabled:true}")
+    private val workerEnabled: Boolean,
+    @Value("\${custom.task.metrics.refreshEnabled:true}")
+    private val refreshEnabled: Boolean,
 ) : MeterBinder {
     private val logger = LoggerFactory.getLogger(TaskQueueMetricsBinder::class.java)
 
@@ -48,8 +53,12 @@ class TaskQueueMetricsBinder(
      * 메트릭/상태 스냅샷을 갱신해 관측 지표를 최신화합니다.
      * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
      */
-    @Scheduled(fixedDelayString = "\${custom.task.metrics.refreshFixedDelayMs:15000}")
+    @Scheduled(fixedDelayString = "\${custom.task.metrics.refreshFixedDelayMs:60000}")
     fun refreshSnapshot() {
+        if (!refreshEnabled || !workerEnabled) {
+            return
+        }
+
         runCatching { taskQueueDiagnosticsService.diagnoseQueue() }
             .onSuccess { diagnostics ->
                 pending.set(diagnostics.pendingCount)

--- a/back/src/main/resources/application.yaml
+++ b/back/src/main/resources/application.yaml
@@ -251,6 +251,9 @@ custom:
       inlineWhenNotProd: ${CUSTOM__TASK__PROCESSOR__INLINE_WHEN_NOT_PROD:false}
     diagnostics:
       cacheSeconds: ${CUSTOM__TASK__DIAGNOSTICS__CACHE_SECONDS:30}
+    metrics:
+      refreshEnabled: ${CUSTOM__TASK__METRICS__REFRESH_ENABLED:true}
+      refreshFixedDelayMs: ${CUSTOM__TASK__METRICS__REFRESH_FIXED_DELAY_MS:60000}
   runtime:
     workerEnabled: ${CUSTOM__RUNTIME__WORKER_ENABLED:true}
     apiMode: ${CUSTOM__RUNTIME__API_MODE:all}

--- a/back/src/test/kotlin/com/back/global/task/application/TaskQueueMetricsBinderTest.kt
+++ b/back/src/test/kotlin/com/back/global/task/application/TaskQueueMetricsBinderTest.kt
@@ -1,0 +1,74 @@
+package com.back.global.task.application
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.springframework.scheduling.annotation.Scheduled
+
+class TaskQueueMetricsBinderTest {
+    @Test
+    fun `worker disabled runtime은 diagnostics refresh를 실행하지 않는다`() {
+        val diagnosticsService = mock(TaskQueueDiagnosticsService::class.java)
+        val binder =
+            TaskQueueMetricsBinder(
+                taskQueueDiagnosticsService = diagnosticsService,
+                workerEnabled = false,
+                refreshEnabled = true,
+            )
+
+        binder.refreshSnapshot()
+
+        verifyNoInteractions(diagnosticsService)
+    }
+
+    @Test
+    fun `worker runtime은 diagnostics refresh를 실행한다`() {
+        val diagnosticsService = mock(TaskQueueDiagnosticsService::class.java)
+        given(diagnosticsService.diagnoseQueue()).willReturn(emptyDiagnostics())
+        val binder =
+            TaskQueueMetricsBinder(
+                taskQueueDiagnosticsService = diagnosticsService,
+                workerEnabled = true,
+                refreshEnabled = true,
+            )
+
+        binder.refreshSnapshot()
+
+        verify(diagnosticsService).diagnoseQueue()
+    }
+
+    @Test
+    fun `metrics refresh 기본 주기는 운영 count 부하를 줄이기 위해 60초다`() {
+        val scheduled =
+            TaskQueueMetricsBinder::class
+                .members
+                .single { it.name == "refreshSnapshot" }
+                .annotations
+                .filterIsInstance<Scheduled>()
+                .single()
+
+        assertThat(scheduled.fixedDelayString).isEqualTo("\${custom.task.metrics.refreshFixedDelayMs:60000}")
+    }
+
+    private fun emptyDiagnostics(): TaskQueueDiagnostics =
+        TaskQueueDiagnostics(
+            pendingCount = 0,
+            readyPendingCount = 0,
+            delayedPendingCount = 0,
+            processingCount = 0,
+            completedCount = 0,
+            failedCount = 0,
+            staleProcessingCount = 0,
+            oldestReadyPendingAt = null,
+            oldestProcessingAt = null,
+            oldestReadyPendingAgeSeconds = null,
+            oldestProcessingAgeSeconds = null,
+            processingTimeoutSeconds = 900,
+            taskTypes = emptyList(),
+            recentFailures = emptyList(),
+            staleProcessingSamples = emptyList(),
+        )
+}


### PR DESCRIPTION
## 관련 이슈

close #428

## 작업 배경

- task diagnostics metrics refresh가 모든 backend runtime에서 DB count 쿼리를 반복 호출하던 경로를 worker runtime으로 제한했습니다.
- 기본 refresh 주기를 15초에서 60초로 늘려 운영 `task` count polling 부하를 낮춥니다.

## 작업 내용

- `TaskQueueMetricsBinder`에 `custom.runtime.workerEnabled`와 `custom.task.metrics.refreshEnabled` gating을 추가했습니다.
- `custom.task.metrics.refreshFixedDelayMs` 기본값을 60000ms로 고정하고 application 설정에 env 계약을 추가했습니다.
- worker-disabled runtime에서 diagnostics service가 호출되지 않는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests com.back.global.task.application.TaskQueueMetricsBinderTest` (RED: constructor 계약 없음으로 실패 확인)
  - `back/gradlew -p back test --tests com.back.global.task.application.TaskQueueMetricsBinderTest`
  - `back/gradlew -p back test --tests com.back.global.task.application.TaskQueueMetricsBinderTest --tests com.back.global.task.application.TaskQueueDiagnosticsServiceTest --tests com.back.global.task.application.TaskProcessingLockDiagnosticsServiceTest`
  - `back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back test`
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: worker-disabled runtime에서는 task queue gauge가 해당 process에서 자체 refresh되지 않습니다. worker runtime의 Prometheus metrics가 canonical queue 지표가 됩니다.
- 롤백 방법: 이 PR revert 후 기존 15초 all-runtime refresh로 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
