### PR TITLE
[Perf] auth 테이블 autovacuum 튜닝

### DIFF
--- a/back/src/main/resources/db/migration/V20260523_03__tune_auth_table_autovacuum.sql
+++ b/back/src/main/resources/db/migration/V20260523_03__tune_auth_table_autovacuum.sql
@@ -1,0 +1,13 @@
+ALTER TABLE public.member_session SET (
+    autovacuum_vacuum_scale_factor = 0.05,
+    autovacuum_analyze_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    autovacuum_analyze_threshold = 50
+);
+
+ALTER TABLE public.auth_security_event SET (
+    autovacuum_vacuum_scale_factor = 0.05,
+    autovacuum_analyze_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    autovacuum_analyze_threshold = 50
+);

--- a/back/src/test/kotlin/com/back/global/jpa/AuthAutovacuumMigrationContractTest.kt
+++ b/back/src/test/kotlin/com/back/global/jpa/AuthAutovacuumMigrationContractTest.kt
@@ -1,0 +1,27 @@
+package com.back.global.jpa
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class AuthAutovacuumMigrationContractTest {
+    private val migrationSql: String =
+        Files.readString(
+            Path.of("src/main/resources/db/migration/V20260523_03__tune_auth_table_autovacuum.sql"),
+        )
+
+    @Test
+    fun `auth high churn 테이블은 table level autovacuum 설정을 가진다`() {
+        assertRelOptions("member_session")
+        assertRelOptions("auth_security_event")
+    }
+
+    private fun assertRelOptions(tableName: String) {
+        assertThat(migrationSql).contains("ALTER TABLE public.$tableName SET")
+        assertThat(migrationSql).contains("autovacuum_vacuum_scale_factor = 0.05")
+        assertThat(migrationSql).contains("autovacuum_analyze_scale_factor = 0.02")
+        assertThat(migrationSql).contains("autovacuum_vacuum_threshold = 50")
+        assertThat(migrationSql).contains("autovacuum_analyze_threshold = 50")
+    }
+}


### PR DESCRIPTION
## 관련 이슈

close #430

## 작업 배경

- 운영 DB에서 dead tuple이 누적되는 `member_session`, `auth_security_event` high-churn 테이블에 table-level autovacuum/analyze 설정을 추가했습니다.
- retention cleanup 이후에도 vacuum/analyze가 기본 scale factor보다 빠르게 실행되도록 migration 계약을 고정했습니다.

## 작업 내용

- `V20260523_03__tune_auth_table_autovacuum.sql` migration을 추가했습니다.
- 두 auth/session 테이블에 vacuum scale factor 0.05, analyze scale factor 0.02, threshold 50을 설정했습니다.
- migration SQL에 두 테이블 reloptions가 포함되는지 확인하는 계약 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests com.back.global.jpa.AuthAutovacuumMigrationContractTest` (RED: migration 파일 없음으로 실패 확인)
  - `back/gradlew -p back test --tests com.back.global.jpa.AuthAutovacuumMigrationContractTest`
  - `back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back test`
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: autovacuum wake-up 빈도가 증가해 아주 짧은 유지보수 작업이 더 자주 실행될 수 있습니다. 대상은 auth/session 두 테이블로 제한했습니다.
- 롤백 방법: 이 PR revert 후 다음 배포에서 reloptions migration을 되돌리는 후속 migration을 적용합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
