### PR TITLE
[Fix] member session 보안 이벤트 retention 추가

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepository.kt
@@ -114,4 +114,24 @@ interface MemberSessionRepository : JpaRepository<MemberSession, Long> {
         @Param("keepLimit") keepLimit: Int,
         @Param("now") now: Instant,
     ): Int
+
+    @Modifying(flushAutomatically = true, clearAutomatically = false)
+    @Query(
+        value = """
+        delete from member_session
+        where id in (
+            select id
+            from member_session
+            where revoked_at is not null
+              and revoked_at < :cutoff
+            order by revoked_at asc, id asc
+            limit :limit
+        )
+        """,
+        nativeQuery = true,
+    )
+    fun deleteRevokedBefore(
+        @Param("cutoff") cutoff: Instant,
+        @Param("limit") limit: Int,
+    ): Int
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepositoryAdapter.kt
@@ -45,4 +45,9 @@ class MemberSessionRepositoryAdapter(
         keepLimit: Int,
         now: Instant,
     ): Int = memberSessionRepository.revokeActiveSessionsBeyondLimit(memberId, keepLimit.coerceAtLeast(1), now)
+
+    override fun deleteRevokedBefore(
+        cutoff: Instant,
+        limit: Int,
+    ): Int = memberSessionRepository.deleteRevokedBefore(cutoff, limit.coerceIn(1, 1_000))
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/port/output/MemberSessionStorePort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/port/output/MemberSessionStorePort.kt
@@ -36,4 +36,9 @@ interface MemberSessionStorePort {
         keepLimit: Int,
         now: Instant,
     ): Int
+
+    fun deleteRevokedBefore(
+        cutoff: Instant,
+        limit: Int,
+    ): Int
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionService.kt
@@ -14,6 +14,7 @@ import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 /**
  * 로그인 세션 생성/조회/폐기를 담당하는 서비스입니다.
@@ -28,6 +29,8 @@ class MemberSessionService(
     private val refreshTokenExpirationSeconds: Long = 2_592_000,
     @param:Value("\${custom.auth.session.maxActivePerMember:32}")
     private val maxActivePerMember: Int = 32,
+    @param:Value("\${custom.auth.session.revokedRetentionDays:30}")
+    private val revokedSessionRetentionDays: Int = 30,
 ) : MemberSessionUseCase {
     @Transactional
     override fun createSession(
@@ -174,6 +177,15 @@ class MemberSessionService(
         val session = memberSessionStorePort.findBySessionKeyAndRevokedAtIsNull(sessionKey) ?: return
         session.revoke()
         evictActiveSnapshot(session.member.id, sessionKey)
+    }
+
+    @Transactional
+    fun purgeExpiredRevokedSessions(
+        batchSize: Int,
+        now: Instant = Instant.now(),
+    ): Int {
+        val cutoff = now.minus(revokedSessionRetentionDays.coerceAtLeast(1).toLong(), ChronoUnit.DAYS)
+        return memberSessionStorePort.deleteRevokedBefore(cutoff, batchSize.coerceIn(1, 1_000))
     }
 
     private fun evictActiveSnapshot(

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/job/MemberSessionCleanupScheduledJob.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/job/MemberSessionCleanupScheduledJob.kt
@@ -1,0 +1,38 @@
+package com.back.boundedContexts.member.subContexts.session.job
+
+import com.back.boundedContexts.member.subContexts.session.application.service.MemberSessionService
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+@Component
+@ConditionalOnProperty(
+    prefix = "custom.runtime",
+    name = ["worker-enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+class MemberSessionCleanupScheduledJob(
+    private val memberSessionService: MemberSessionService,
+    @param:Value("\${custom.auth.session.cleanup.batchSize:500}")
+    private val batchSize: Int,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(fixedDelayString = "\${custom.auth.session.cleanup.fixedDelayMs:3600000}")
+    @SchedulerLock(name = "memberSessionCleanup", lockAtLeastFor = "PT1M")
+    fun cleanup() {
+        cleanup(Instant.now())
+    }
+
+    fun cleanup(now: Instant) {
+        val purgedCount = memberSessionService.purgeExpiredRevokedSessions(batchSize, now)
+        if (purgedCount > 0) {
+            log.info("Purged {} expired revoked member sessions", purgedCount)
+        }
+    }
+}

--- a/back/src/main/kotlin/com/back/global/security/job/AuthSecurityEventCleanupScheduledJob.kt
+++ b/back/src/main/kotlin/com/back/global/security/job/AuthSecurityEventCleanupScheduledJob.kt
@@ -19,15 +19,29 @@ class AuthSecurityEventCleanupScheduledJob(
     private val authSecurityEventService: AuthSecurityEventService,
     @param:Value("\${custom.auth.securityEvent.cleanup.batchSize:500}")
     private val batchSize: Int,
+    @param:Value("\${custom.auth.securityEvent.cleanup.maxBatches:20}")
+    private val maxBatches: Int,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     @Scheduled(fixedDelayString = "\${custom.auth.securityEvent.cleanup.fixedDelayMs:3600000}")
     @SchedulerLock(name = "authSecurityEventCleanup", lockAtLeastFor = "PT1M")
     fun cleanup() {
-        val purgedCount = authSecurityEventService.purgeExpired(batchSize)
-        if (purgedCount > 0) {
-            log.info("Purged {} expired auth security events", purgedCount)
+        val normalizedBatchSize = batchSize.coerceIn(1, 1_000)
+        val normalizedMaxBatches = maxBatches.coerceIn(1, 100)
+        var totalPurged = 0
+        var completedBatches = 0
+
+        while (completedBatches < normalizedMaxBatches) {
+            val purgedCount = authSecurityEventService.purgeExpired(normalizedBatchSize)
+            if (purgedCount <= 0) break
+            totalPurged += purgedCount
+            completedBatches += 1
+            if (purgedCount < normalizedBatchSize) break
+        }
+
+        if (totalPurged > 0) {
+            log.info("Purged {} expired auth security events", totalPurged)
         }
     }
 }

--- a/back/src/main/resources/application.yaml
+++ b/back/src/main/resources/application.yaml
@@ -212,10 +212,15 @@ custom:
       freshLookupGraceSeconds: ${CUSTOM__AUTH__SESSION__FRESH_LOOKUP_GRACE_SECONDS:15}
       touchMinIntervalSeconds: ${CUSTOM__AUTH__SESSION__TOUCH_MIN_INTERVAL_SECONDS:60}
       maxActivePerMember: ${CUSTOM__AUTH__SESSION__MAX_ACTIVE_PER_MEMBER:32}
+      revokedRetentionDays: ${CUSTOM__AUTH__SESSION__REVOKED_RETENTION_DAYS:30}
+      cleanup:
+        batchSize: ${CUSTOM__AUTH__SESSION__CLEANUP__BATCH_SIZE:500}
+        fixedDelayMs: ${CUSTOM__AUTH__SESSION__CLEANUP__FIXED_DELAY_MS:3600000}
     securityEvent:
       retentionDays: ${CUSTOM__AUTH__SECURITY_EVENT__RETENTION_DAYS:30}
       cleanup:
         batchSize: ${CUSTOM__AUTH__SECURITY_EVENT__CLEANUP__BATCH_SIZE:500}
+        maxBatches: ${CUSTOM__AUTH__SECURITY_EVENT__CLEANUP__MAX_BATCHES:20}
         fixedDelayMs: ${CUSTOM__AUTH__SECURITY_EVENT__CLEANUP__FIXED_DELAY_MS:3600000}
     login:
       maxAttempts: ${CUSTOM__AUTH__LOGIN__MAX_ATTEMPTS:5}

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionServiceTest.kt
@@ -178,6 +178,33 @@ class MemberSessionServiceTest {
         assertThat(store.lastTouchedSessionId).isEqualTo(1L)
     }
 
+    @Test
+    fun `revoked session cleanup은 보존 기간을 지난 폐기 세션만 batch size 만큼 삭제한다`() {
+        val now = Instant.parse("2026-05-23T00:00:00Z")
+        val store = RecordingMemberSessionStorePort()
+        val service =
+            MemberSessionService(
+                memberSessionStorePort = store,
+                cacheManager = ConcurrentMapCacheManager(),
+                touchMinIntervalSeconds = 60,
+                revokedSessionRetentionDays = 30,
+            )
+        val member = Member(57L, "session-retention-user", null, "세션정리", "session-retention@example.com", MemberPolicy.genApiKey())
+        val expiredRevoked = memberSession(member, "expired-revoked").apply { revoke(now.minusSeconds(31 * 24 * 60 * 60)) }
+        val retainedRevoked = memberSession(member, "retained-revoked").apply { revoke(now.minusSeconds(29 * 24 * 60 * 60)) }
+        val active = memberSession(member, "active-session")
+        store.save(expiredRevoked)
+        store.save(retainedRevoked)
+        store.save(active)
+
+        val purgedCount = service.purgeExpiredRevokedSessions(batchSize = 1, now = now)
+
+        assertThat(purgedCount).isEqualTo(1)
+        assertThat(store.findBySessionKey("expired-revoked")).isNull()
+        assertThat(store.findBySessionKey("retained-revoked")).isSameAs(retainedRevoked)
+        assertThat(store.findBySessionKey("active-session")).isSameAs(active)
+    }
+
     private class RecordingMemberSessionStorePort : MemberSessionStorePort {
         var touchCallCount: Int = 0
         var lastTouchedSessionId: Long? = null
@@ -236,6 +263,19 @@ class MemberSessionServiceTest {
             return sessionsToRevoke.size
         }
 
+        override fun deleteRevokedBefore(
+            cutoff: Instant,
+            limit: Int,
+        ): Int {
+            val sessionsToDelete =
+                sessionsByKey.values
+                    .filter { session -> session.revokedAt?.isBefore(cutoff) == true }
+                    .sortedWith(compareBy<MemberSession> { it.revokedAt }.thenBy { it.id })
+                    .take(limit)
+            sessionsToDelete.forEach { sessionsByKey.remove(it.sessionKey) }
+            return sessionsToDelete.size
+        }
+
         fun activeSessionKeys(memberId: Long): List<String> =
             sessionsByKey.values
                 .filter { it.member.id == memberId && it.revokedAt == null }
@@ -252,4 +292,13 @@ class MemberSessionServiceTest {
                 lastAuthenticatedAt = lastAuthenticatedAt,
             )
     }
+
+    private fun memberSession(
+        member: Member,
+        sessionKey: String,
+    ): MemberSession =
+        MemberSession(
+            member = member,
+            sessionKey = sessionKey,
+        )
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/job/MemberSessionCleanupScheduledJobTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/job/MemberSessionCleanupScheduledJobTest.kt
@@ -1,0 +1,90 @@
+package com.back.boundedContexts.member.subContexts.session.job
+
+import com.back.boundedContexts.member.domain.shared.MemberPolicy
+import com.back.boundedContexts.member.model.shared.Member
+import com.back.boundedContexts.member.subContexts.session.application.port.output.MemberSessionStorePort
+import com.back.boundedContexts.member.subContexts.session.application.service.MemberSessionService
+import com.back.boundedContexts.member.subContexts.session.model.MemberSession
+import com.back.boundedContexts.member.subContexts.session.model.MemberSessionAuthSnapshot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import java.time.Instant
+
+class MemberSessionCleanupScheduledJobTest {
+    @Test
+    fun `cleanup은 만료된 revoked session을 정리한다`() {
+        val now = Instant.now()
+        val store = RecordingMemberSessionStorePort()
+        val member = Member(58L, "session-cleanup-user", null, "세션스케줄", "session-cleanup@example.com", MemberPolicy.genApiKey())
+        val expired = MemberSession(member = member, sessionKey = "expired").apply { revoke(now.minusSeconds(31 * 24 * 60 * 60)) }
+        store.save(expired)
+        val service =
+            MemberSessionService(
+                memberSessionStorePort = store,
+                cacheManager = ConcurrentMapCacheManager(),
+                touchMinIntervalSeconds = 60,
+                revokedSessionRetentionDays = 30,
+            )
+        val job =
+            MemberSessionCleanupScheduledJob(
+                memberSessionService = service,
+                batchSize = 10,
+            )
+
+        job.cleanup(now)
+
+        assertThat(store.findBySessionKey("expired")).isNull()
+    }
+
+    private class RecordingMemberSessionStorePort : MemberSessionStorePort {
+        private val sessionsByKey = linkedMapOf<String, MemberSession>()
+
+        override fun save(memberSession: MemberSession): MemberSession {
+            sessionsByKey[memberSession.sessionKey] = memberSession
+            return memberSession
+        }
+
+        override fun findBySessionKey(sessionKey: String): MemberSession? = sessionsByKey[sessionKey]
+
+        override fun findBySessionKeyAndRevokedAtIsNull(sessionKey: String): MemberSession? = null
+
+        override fun findWithMemberBySessionKeyAndRevokedAtIsNull(sessionKey: String): MemberSession? = null
+
+        override fun findByMemberIdAndSessionKeyAndRevokedAtIsNull(
+            memberId: Long,
+            sessionKey: String,
+        ): MemberSession? = null
+
+        override fun findActiveSnapshotBySessionKeyAndRevokedAtIsNull(sessionKey: String): MemberSessionAuthSnapshot? = null
+
+        override fun findActiveSnapshotByMemberIdAndSessionKeyAndRevokedAtIsNull(
+            memberId: Long,
+            sessionKey: String,
+        ): MemberSessionAuthSnapshot? = null
+
+        override fun touchAuthenticatedIfDue(
+            sessionId: Long,
+            threshold: Instant,
+            now: Instant,
+        ): Boolean = false
+
+        override fun revokeActiveSessionsBeyondLimit(
+            memberId: Long,
+            keepLimit: Int,
+            now: Instant,
+        ): Int = 0
+
+        override fun deleteRevokedBefore(
+            cutoff: Instant,
+            limit: Int,
+        ): Int {
+            val sessionsToDelete =
+                sessionsByKey.values
+                    .filter { session -> session.revokedAt?.isBefore(cutoff) == true }
+                    .take(limit)
+            sessionsToDelete.forEach { sessionsByKey.remove(it.sessionKey) }
+            return sessionsToDelete.size
+        }
+    }
+}

--- a/back/src/test/kotlin/com/back/global/security/job/AuthSecurityEventCleanupScheduledJobTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/job/AuthSecurityEventCleanupScheduledJobTest.kt
@@ -26,12 +26,39 @@ class AuthSecurityEventCleanupScheduledJobTest {
             AuthSecurityEventCleanupScheduledJob(
                 authSecurityEventService = service,
                 batchSize = 10,
+                maxBatches = 1,
             )
 
         job.cleanup()
 
         assertThat(store.events).isEmpty()
         assertThat(store.deletedEvents).containsExactly(expiredEvent)
+    }
+
+    @Test
+    fun `cleanup은 한 번의 스케줄에서 최대 batch 수만큼 반복 정리한다`() {
+        val now = Instant.now()
+        val store = RecordingAuthSecurityEventStore()
+        val first = authSecurityEventAt(now.minus(40, ChronoUnit.DAYS))
+        val second = authSecurityEventAt(now.minus(39, ChronoUnit.DAYS))
+        val third = authSecurityEventAt(now.minus(38, ChronoUnit.DAYS))
+        store.events += listOf(first, second, third)
+        val service =
+            AuthSecurityEventService(
+                authSecurityEventStore = store,
+                retentionDays = 30,
+            )
+        val job =
+            AuthSecurityEventCleanupScheduledJob(
+                authSecurityEventService = service,
+                batchSize = 1,
+                maxBatches = 2,
+            )
+
+        job.cleanup()
+
+        assertThat(store.deletedEvents).containsExactly(first, second)
+        assertThat(store.events).containsExactly(third)
     }
 
     private class RecordingAuthSecurityEventStore : AuthSecurityEventStore {


### PR DESCRIPTION
## 관련 이슈

close #429

## 작업 배경

- revoked `member_session` 보존 기간 정리 job을 추가했습니다.
- 기존 보안 이벤트 cleanup은 한 번의 스케줄에서 여러 batch를 처리하도록 개선해 과거 backlog를 더 빠르게 줄입니다.

## 작업 내용

- `MemberSessionService.purgeExpiredRevokedSessions`와 repository native batch delete를 추가했습니다.
- worker runtime 전용 `MemberSessionCleanupScheduledJob`을 추가했습니다.
- `AuthSecurityEventCleanupScheduledJob`에 `maxBatches` 설정을 추가했습니다.
- session/security event cleanup 설정과 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests com.back.boundedContexts.member.subContexts.session.application.service.MemberSessionServiceTest --tests com.back.boundedContexts.member.subContexts.session.job.MemberSessionCleanupScheduledJobTest --tests com.back.global.security.job.AuthSecurityEventCleanupScheduledJobTest` (RED: session cleanup/maxBatches 계약 없음으로 실패 확인)
  - `back/gradlew -p back test --tests com.back.boundedContexts.member.subContexts.session.application.service.MemberSessionServiceTest --tests com.back.boundedContexts.member.subContexts.session.job.MemberSessionCleanupScheduledJobTest --tests com.back.global.security.job.AuthSecurityEventCleanupScheduledJobTest`
  - `back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back test`
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: worker runtime에서 hourly cleanup이 실행되며 DB delete 부하가 batch size만큼 발생합니다. 기본값은 session 500건, security event 최대 20 batch로 제한했습니다.
- 롤백 방법: 이 PR revert 후 cleanup job/설정을 제거합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
