### PR TITLE
[Perf] auth 보안 이벤트 cleanup catch-up 강화

### DIFF
--- a/back/src/main/kotlin/com/back/global/security/adapter/persistence/AuthSecurityEventPersistenceAdapter.kt
+++ b/back/src/main/kotlin/com/back/global/security/adapter/persistence/AuthSecurityEventPersistenceAdapter.kt
@@ -27,22 +27,8 @@ class AuthSecurityEventPersistenceAdapter(
         return authSecurityEventRepository.findAll(pageable).content
     }
 
-    override fun findExpired(
+    override fun deleteExpiredBefore(
         cutoff: Instant,
         limit: Int,
-    ): List<AuthSecurityEvent> {
-        val normalizedLimit = limit.coerceIn(1, 1_000)
-        val pageable =
-            PageRequest.of(
-                0,
-                normalizedLimit,
-                Sort.by(Sort.Order.asc("createdAt"), Sort.Order.asc("id")),
-            )
-
-        return authSecurityEventRepository.findByCreatedAtBefore(cutoff, pageable)
-    }
-
-    override fun deleteAll(events: List<AuthSecurityEvent>) {
-        authSecurityEventRepository.deleteAllInBatch(events)
-    }
+    ): Int = authSecurityEventRepository.deleteExpiredBefore(cutoff, limit.coerceIn(1, 1_000))
 }

--- a/back/src/main/kotlin/com/back/global/security/adapter/persistence/AuthSecurityEventRepository.kt
+++ b/back/src/main/kotlin/com/back/global/security/adapter/persistence/AuthSecurityEventRepository.kt
@@ -1,13 +1,29 @@
 package com.back.global.security.adapter.persistence
 
 import com.back.global.security.model.AuthSecurityEvent
-import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.time.Instant
 
 interface AuthSecurityEventRepository : JpaRepository<AuthSecurityEvent, Long> {
-    fun findByCreatedAtBefore(
-        cutoff: Instant,
-        pageable: Pageable,
-    ): List<AuthSecurityEvent>
+    @Modifying(flushAutomatically = true, clearAutomatically = false)
+    @Query(
+        value = """
+        delete from auth_security_event
+        where id in (
+            select id
+            from auth_security_event
+            where created_at < :cutoff
+            order by created_at asc, id asc
+            limit :limit
+        )
+        """,
+        nativeQuery = true,
+    )
+    fun deleteExpiredBefore(
+        @Param("cutoff") cutoff: Instant,
+        @Param("limit") limit: Int,
+    ): Int
 }

--- a/back/src/main/kotlin/com/back/global/security/application/AuthSecurityEventService.kt
+++ b/back/src/main/kotlin/com/back/global/security/application/AuthSecurityEventService.kt
@@ -94,11 +94,7 @@ class AuthSecurityEventService(
         now: Instant = Instant.now(),
     ): Int {
         val cutoff = now.minus(retentionDays.coerceAtLeast(1).toLong(), ChronoUnit.DAYS)
-        val expiredEvents = authSecurityEventStore.findExpired(cutoff, batchSize.coerceIn(1, 1_000))
-        if (expiredEvents.isEmpty()) return 0
-
-        authSecurityEventStore.deleteAll(expiredEvents)
-        return expiredEvents.size
+        return authSecurityEventStore.deleteExpiredBefore(cutoff, batchSize.coerceIn(1, 1_000))
     }
 
     private fun AuthSecurityEvent.toDto(): AuthSecurityEventDto =

--- a/back/src/main/kotlin/com/back/global/security/application/port/output/AuthSecurityEventStore.kt
+++ b/back/src/main/kotlin/com/back/global/security/application/port/output/AuthSecurityEventStore.kt
@@ -12,10 +12,8 @@ interface AuthSecurityEventStore {
 
     fun findRecent(limit: Int): List<AuthSecurityEvent>
 
-    fun findExpired(
+    fun deleteExpiredBefore(
         cutoff: Instant,
         limit: Int,
-    ): List<AuthSecurityEvent>
-
-    fun deleteAll(events: List<AuthSecurityEvent>)
+    ): Int
 }

--- a/back/src/main/resources/application.yaml
+++ b/back/src/main/resources/application.yaml
@@ -219,8 +219,8 @@ custom:
     securityEvent:
       retentionDays: ${CUSTOM__AUTH__SECURITY_EVENT__RETENTION_DAYS:30}
       cleanup:
-        batchSize: ${CUSTOM__AUTH__SECURITY_EVENT__CLEANUP__BATCH_SIZE:500}
-        maxBatches: ${CUSTOM__AUTH__SECURITY_EVENT__CLEANUP__MAX_BATCHES:20}
+        batchSize: ${CUSTOM__AUTH__SECURITY_EVENT__CLEANUP__BATCH_SIZE:1000}
+        maxBatches: ${CUSTOM__AUTH__SECURITY_EVENT__CLEANUP__MAX_BATCHES:100}
         fixedDelayMs: ${CUSTOM__AUTH__SECURITY_EVENT__CLEANUP__FIXED_DELAY_MS:3600000}
     login:
       maxAttempts: ${CUSTOM__AUTH__LOGIN__MAX_ATTEMPTS:5}

--- a/back/src/test/kotlin/com/back/global/security/application/AuthSecurityEventServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/application/AuthSecurityEventServiceTest.kt
@@ -1,7 +1,6 @@
 package com.back.global.security.application
 
 import com.back.global.security.application.port.output.AuthSecurityEventStore
-import com.back.global.security.domain.AuthSecurityEventType
 import com.back.global.security.model.AuthSecurityEvent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -12,66 +11,47 @@ import java.time.temporal.ChronoUnit
 @DisplayName("AuthSecurityEventService 테스트")
 class AuthSecurityEventServiceTest {
     @Test
-    fun `보존 기간을 지난 보안 이벤트를 batch size 안에서 삭제한다`() {
+    fun `보존 기간을 지난 보안 이벤트를 DB batch delete로 삭제한다`() {
         val now = Instant.parse("2026-05-21T00:00:00Z")
         val store = RecordingAuthSecurityEventStore()
-        val expired = authSecurityEventAt(now.minus(31, ChronoUnit.DAYS))
-        val stillRetained = authSecurityEventAt(now.minus(29, ChronoUnit.DAYS))
-        val olderExpired = authSecurityEventAt(now.minus(40, ChronoUnit.DAYS))
-        store.events += listOf(expired, stillRetained, olderExpired)
+        store.nextDeletedCount = 1000
         val service =
             AuthSecurityEventService(
                 authSecurityEventStore = store,
                 retentionDays = 30,
             )
 
-        val purgedCount = service.purgeExpired(batchSize = 1, now = now)
+        val purgedCount = service.purgeExpired(batchSize = 5_000, now = now)
 
-        assertThat(purgedCount).isEqualTo(1)
-        assertThat(store.events).containsExactly(expired, stillRetained)
-        assertThat(store.deletedEvents).containsExactly(olderExpired)
+        assertThat(purgedCount).isEqualTo(1000)
+        assertThat(store.deleteExpiredBeforeCalls).containsExactly(
+            DeleteExpiredBeforeCall(
+                cutoff = now.minus(30, ChronoUnit.DAYS),
+                limit = 1_000,
+            ),
+        )
     }
 
     private class RecordingAuthSecurityEventStore : AuthSecurityEventStore {
-        val events = mutableListOf<AuthSecurityEvent>()
-        val deletedEvents = mutableListOf<AuthSecurityEvent>()
+        var nextDeletedCount = 0
+        val deleteExpiredBeforeCalls = mutableListOf<DeleteExpiredBeforeCall>()
 
         override fun save(event: AuthSecurityEvent) {
-            events += event
         }
 
-        override fun findRecent(limit: Int): List<AuthSecurityEvent> =
-            events
-                .sortedWith(compareByDescending<AuthSecurityEvent> { it.createdAt }.thenByDescending { it.id })
-                .take(limit)
+        override fun findRecent(limit: Int): List<AuthSecurityEvent> = emptyList()
 
-        override fun findExpired(
+        override fun deleteExpiredBefore(
             cutoff: Instant,
             limit: Int,
-        ): List<AuthSecurityEvent> =
-            events
-                .filter { it.createdAt.isBefore(cutoff) }
-                .sortedWith(compareBy<AuthSecurityEvent> { it.createdAt }.thenBy { it.id })
-                .take(limit)
-
-        override fun deleteAll(events: List<AuthSecurityEvent>) {
-            deletedEvents += events
-            this.events.removeAll(events.toSet())
+        ): Int {
+            deleteExpiredBeforeCalls += DeleteExpiredBeforeCall(cutoff, limit)
+            return nextDeletedCount
         }
     }
 
-    private fun authSecurityEventAt(createdAt: Instant): AuthSecurityEvent =
-        AuthSecurityEvent(
-            eventType = AuthSecurityEventType.LOGIN_POLICY_APPLIED,
-            memberId = 54L,
-            loginIdentifier = "admin@example.com",
-            rememberLoginEnabled = true,
-            ipSecurityEnabled = false,
-            clientIpFingerprint = null,
-            requestPath = "/member/api/v1/auth/login",
-            reason = null,
-        ).apply {
-            this.createdAt = createdAt
-            this.modifiedAt = createdAt
-        }
+    private data class DeleteExpiredBeforeCall(
+        val cutoff: Instant,
+        val limit: Int,
+    )
 }

--- a/back/src/test/kotlin/com/back/global/security/job/AuthSecurityEventCleanupScheduledJobTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/job/AuthSecurityEventCleanupScheduledJobTest.kt
@@ -2,21 +2,18 @@ package com.back.global.security.job
 
 import com.back.global.security.application.AuthSecurityEventService
 import com.back.global.security.application.port.output.AuthSecurityEventStore
-import com.back.global.security.domain.AuthSecurityEventType
 import com.back.global.security.model.AuthSecurityEvent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.time.Instant
-import java.time.temporal.ChronoUnit
 
 @DisplayName("AuthSecurityEventCleanupScheduledJob 테스트")
 class AuthSecurityEventCleanupScheduledJobTest {
     @Test
     fun `cleanup은 만료된 보안 이벤트를 정리한다`() {
         val store = RecordingAuthSecurityEventStore()
-        val expiredEvent = authSecurityEventAt(Instant.now().minus(31, ChronoUnit.DAYS))
-        store.events += expiredEvent
+        store.deletedCounts += 1
         val service =
             AuthSecurityEventService(
                 authSecurityEventStore = store,
@@ -31,18 +28,13 @@ class AuthSecurityEventCleanupScheduledJobTest {
 
         job.cleanup()
 
-        assertThat(store.events).isEmpty()
-        assertThat(store.deletedEvents).containsExactly(expiredEvent)
+        assertThat(store.deleteExpiredBeforeCalls).hasSize(1)
     }
 
     @Test
     fun `cleanup은 한 번의 스케줄에서 최대 batch 수만큼 반복 정리한다`() {
-        val now = Instant.now()
         val store = RecordingAuthSecurityEventStore()
-        val first = authSecurityEventAt(now.minus(40, ChronoUnit.DAYS))
-        val second = authSecurityEventAt(now.minus(39, ChronoUnit.DAYS))
-        val third = authSecurityEventAt(now.minus(38, ChronoUnit.DAYS))
-        store.events += listOf(first, second, third)
+        store.deletedCounts += listOf(1, 1, 1)
         val service =
             AuthSecurityEventService(
                 authSecurityEventStore = store,
@@ -57,50 +49,29 @@ class AuthSecurityEventCleanupScheduledJobTest {
 
         job.cleanup()
 
-        assertThat(store.deletedEvents).containsExactly(first, second)
-        assertThat(store.events).containsExactly(third)
+        assertThat(store.deleteExpiredBeforeCalls).hasSize(2)
     }
 
     private class RecordingAuthSecurityEventStore : AuthSecurityEventStore {
-        val events = mutableListOf<AuthSecurityEvent>()
-        val deletedEvents = mutableListOf<AuthSecurityEvent>()
+        val deletedCounts = ArrayDeque<Int>()
+        val deleteExpiredBeforeCalls = mutableListOf<DeleteExpiredBeforeCall>()
 
         override fun save(event: AuthSecurityEvent) {
-            events += event
         }
 
-        override fun findRecent(limit: Int): List<AuthSecurityEvent> =
-            events
-                .sortedWith(compareByDescending<AuthSecurityEvent> { it.createdAt }.thenByDescending { it.id })
-                .take(limit)
+        override fun findRecent(limit: Int): List<AuthSecurityEvent> = emptyList()
 
-        override fun findExpired(
+        override fun deleteExpiredBefore(
             cutoff: Instant,
             limit: Int,
-        ): List<AuthSecurityEvent> =
-            events
-                .filter { it.createdAt.isBefore(cutoff) }
-                .sortedWith(compareBy<AuthSecurityEvent> { it.createdAt }.thenBy { it.id })
-                .take(limit)
-
-        override fun deleteAll(events: List<AuthSecurityEvent>) {
-            deletedEvents += events
-            this.events.removeAll(events.toSet())
+        ): Int {
+            deleteExpiredBeforeCalls += DeleteExpiredBeforeCall(cutoff, limit)
+            return deletedCounts.removeFirstOrNull() ?: 0
         }
     }
 
-    private fun authSecurityEventAt(createdAt: Instant): AuthSecurityEvent =
-        AuthSecurityEvent(
-            eventType = AuthSecurityEventType.LOGIN_POLICY_APPLIED,
-            memberId = 54L,
-            loginIdentifier = "admin@example.com",
-            rememberLoginEnabled = true,
-            ipSecurityEnabled = false,
-            clientIpFingerprint = null,
-            requestPath = "/member/api/v1/auth/login",
-            reason = null,
-        ).apply {
-            this.createdAt = createdAt
-            this.modifiedAt = createdAt
-        }
+    private data class DeleteExpiredBeforeCall(
+        val cutoff: Instant,
+        val limit: Int,
+    )
 }


### PR DESCRIPTION
## 관련 이슈

close #436

## 작업 배경

- auth_security_event retention cleanup이 만료 이벤트 엔티티를 로딩하지 않고 DB batch delete로 직접 정리하도록 변경합니다.
- scheduled cleanup 기본 처리량을 10,000건/run에서 최대 100,000건/run으로 높여 운영 backlog catch-up을 빠르게 끝냅니다.

## 작업 내용

- AuthSecurityEventStore 포트를 deleteExpiredBefore batch delete 계약으로 변경했습니다.
- AuthSecurityEventRepository에 native limited delete 쿼리를 추가했습니다.
- cleanup 기본 batchSize/maxBatches를 1000/100으로 조정하고 관련 unit test를 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - RED: `back/gradlew -p back test --tests com.back.global.security.application.AuthSecurityEventServiceTest --tests com.back.global.security.job.AuthSecurityEventCleanupScheduledJobTest` 실패 확인
  - GREEN: `back/gradlew -p back test --tests com.back.global.security.application.AuthSecurityEventServiceTest --tests com.back.global.security.job.AuthSecurityEventCleanupScheduledJobTest`
  - `back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back test`
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check`
  - 참고: PR 생성 중 본문 quoting 오류로 동일 테스트가 병렬 실행되어 로컬 실패 출력이 발생했으며, 코드 회귀가 아니라 테스트 인프라/동시 실행 충돌로 분류했습니다.
  - main CI/Security 통과 후 홈서버 자동 배포 및 live e2e 통과
  - 운영 확인: worker log `Purged 22175 expired auth security events`, 30일 초과 backlog `4`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: cleanup 1회 실행 시 delete량이 증가하므로 짧은 DB write burst가 발생할 수 있습니다. batch는 1000건 단위이며 maxBatches는 설정값으로 낮출 수 있습니다.
- 롤백 방법: 이 PR revert 또는 `CUSTOM__AUTH__SECURITY_EVENT__CLEANUP__MAX_BATCHES`/`BATCH_SIZE`를 낮춥니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
