### PR TITLE
[Perf] 미사용 auth 세션 인덱스 정리

### DIFF
--- a/back/src/main/kotlin/com/back/global/security/model/AuthSecurityEvent.kt
+++ b/back/src/main/kotlin/com/back/global/security/model/AuthSecurityEvent.kt
@@ -20,8 +20,6 @@ import jakarta.persistence.Table
     name = "auth_security_event",
     indexes = [
         Index(name = "idx_auth_security_event_created_at", columnList = "created_at"),
-        Index(name = "idx_auth_security_event_event_type_created_at", columnList = "event_type,created_at"),
-        Index(name = "idx_auth_security_event_member_created_at", columnList = "member_id,created_at"),
     ],
 )
 class AuthSecurityEvent(

--- a/back/src/main/resources/db/migration/V20260523_04__drop_unused_auth_session_indexes.sql
+++ b/back/src/main/resources/db/migration/V20260523_04__drop_unused_auth_session_indexes.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS public.idx_auth_security_event_event_type_created_at;
+DROP INDEX IF EXISTS public.idx_auth_security_event_member_created_at;
+DROP INDEX IF EXISTS public.member_session_idx_member_session_active;

--- a/back/src/test/kotlin/com/back/global/jpa/AuthUnusedIndexPruneMigrationContractTest.kt
+++ b/back/src/test/kotlin/com/back/global/jpa/AuthUnusedIndexPruneMigrationContractTest.kt
@@ -1,0 +1,41 @@
+package com.back.global.jpa
+
+import com.back.global.security.model.AuthSecurityEvent
+import jakarta.persistence.Table
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class AuthUnusedIndexPruneMigrationContractTest {
+    private val migrationSql: String =
+        Files.readString(
+            Path.of("src/main/resources/db/migration/V20260523_04__drop_unused_auth_session_indexes.sql"),
+        )
+
+    @Test
+    fun `운영에서 미사용으로 확인된 auth session 인덱스를 제거한다`() {
+        val droppedIndexes =
+            listOf(
+                "idx_auth_security_event_event_type_created_at",
+                "idx_auth_security_event_member_created_at",
+                "member_session_idx_member_session_active",
+            )
+
+        droppedIndexes.forEach { indexName ->
+            assertThat(migrationSql).contains("DROP INDEX IF EXISTS public.$indexName")
+        }
+        assertThat(migrationSql).doesNotContain("member_session_idx_member_active_recent")
+    }
+
+    @Test
+    fun `AuthSecurityEvent JPA metadata는 유지 인덱스만 선언한다`() {
+        val indexNames =
+            AuthSecurityEvent::class.java
+                .getAnnotation(Table::class.java)
+                .indexes
+                .map { it.name }
+
+        assertThat(indexNames).containsExactly("idx_auth_security_event_created_at")
+    }
+}


### PR DESCRIPTION
## 관련 이슈

close #437

## 작업 배경

- 운영 pg_stat에서 0 scan으로 확인된 auth/security/session 인덱스 중 현재 코드 조회 경로와 겹치는 항목을 제거합니다.
- 보안 이벤트 최근 조회용 created_at 인덱스와 session rare-path partial index는 유지합니다.

## 작업 내용

- `idx_auth_security_event_event_type_created_at`, `idx_auth_security_event_member_created_at`, `member_session_idx_member_session_active` 제거 migration을 추가했습니다.
- AuthSecurityEvent JPA metadata에서 제거 대상 복합 인덱스를 삭제했습니다.
- migration contract test로 제거/유지 계약을 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - RED: `back/gradlew -p back test --tests com.back.global.jpa.AuthUnusedIndexPruneMigrationContractTest` 실패 확인
  - GREEN: `back/gradlew -p back test --tests com.back.global.jpa.AuthUnusedIndexPruneMigrationContractTest`
  - `back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back test`
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check`
  - 참고: PR 생성 중 본문 quoting 오류로 동일 테스트가 병렬 실행되어 로컬 실패 출력이 발생했으며, 코드 회귀가 아니라 테스트 인프라/동시 실행 충돌로 분류했습니다.
  - main CI/Security 통과 후 홈서버 자동 배포 및 live e2e 통과
  - 운영 확인: Flyway `20260523.04|drop unused auth session indexes|true`
  - 운영 확인: 제거 대상 인덱스 3개는 조회되지 않고, 유지 대상 `idx_auth_security_event_created_at`, `member_session_idx_member_active_recent`만 남음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 숨은 운영 쿼리가 제거 대상 인덱스를 사용 중이었다면 해당 쿼리가 느려질 수 있습니다. 코드 조회 경로와 pg_stat 기준으로 대상 범위를 제한했습니다.
- 롤백 방법: 이 PR revert 후 migration으로 인덱스를 재생성합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
