### PR TITLE
[Refactor] Block editor engine residual hooks 600 line 이하 분리

### DIFF
--- a/front/e2e/editor-authoring-flow.spec.ts
+++ b/front/e2e/editor-authoring-flow.spec.ts
@@ -3686,6 +3686,7 @@ test.describe("block editor authoring flow", () => {
     await page.keyboard.type("말머리 보호")
 
     const paragraph = editor.locator("p", { hasText: "말머리 보호" }).first()
+    await expect(paragraph).toBeVisible()
     const visibleParagraphBox = await expectVisibleBox(
       paragraph,
       "block handle rail 검증 문단 좌표를 계산할 수 없습니다."

--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -440,10 +440,32 @@ test.describe("editor studio state", () => {
     const blockEditorEngineControllerSource = existsSync(blockEditorEngineControllerPath)
       ? readFileSync(blockEditorEngineControllerPath, "utf8")
       : ""
+    const blockEditorEngineControllerStatePath = path.resolve(
+      __dirname,
+      "../src/components/editor/useBlockEditorEngineControllerState.ts"
+    )
+    expect(existsSync(blockEditorEngineControllerStatePath)).toBe(true)
+    const blockEditorEngineControllerStateSource = existsSync(blockEditorEngineControllerStatePath)
+      ? readFileSync(blockEditorEngineControllerStatePath, "utf8")
+      : ""
+    const blockEditorEngineControllerHandlersPath = path.resolve(
+      __dirname,
+      "../src/components/editor/useBlockEditorEngineControllerEditorHandlers.ts"
+    )
+    expect(existsSync(blockEditorEngineControllerHandlersPath)).toBe(true)
+    const blockEditorEngineControllerHandlersSource = existsSync(blockEditorEngineControllerHandlersPath)
+      ? readFileSync(blockEditorEngineControllerHandlersPath, "utf8")
+      : ""
     const blockEditorEngineInsertActionsSource = readFileSync(
       path.resolve(__dirname, "../src/components/editor/useBlockEditorEngineInsertActions.ts"),
       "utf8"
     )
+    const blockEditorEngineControllerRuntimeSource = [
+      blockEditorEngineControllerSource,
+      blockEditorEngineControllerStateSource,
+      blockEditorEngineControllerHandlersSource,
+      blockEditorEngineInsertActionsSource,
+    ].join("\n")
     const blockEditorEngineSlashMenuSource = readFileSync(
       path.resolve(__dirname, "../src/components/editor/useBlockEditorEngineSlashMenu.ts"),
       "utf8"
@@ -1315,13 +1337,13 @@ test.describe("editor studio state", () => {
     expect(blockEditorEditorSurfaceStylesSource).toContain(".aq-block-editor__content blockquote {")
     expect(blockEditorEditorSurfaceStylesSource).toContain("border-left: 4px solid")
     expect(blockEditorEditorSurfaceStylesSource).toContain("border-radius: 0;")
-    expect(blockEditorEngineControllerSource).toContain('from "./blockSelectionModel"')
-    expect(blockEditorEngineControllerSource).toContain('from "./nestedListItemModel"')
+    expect(blockEditorEngineControllerRuntimeSource).toContain('from "./blockSelectionModel"')
+    expect(blockEditorEngineControllerRuntimeSource).toContain('from "./nestedListItemModel"')
     expect(blockEditorEngineControllerSource).toContain('from "./useBlockEditorMarkdownCommit"')
     expect(blockEditorEngineSlashMenuSource).toContain('from "./slashMenuModel"')
-    expect(blockEditorEngineControllerSource).toContain('from "./blockToolbarModel"')
-    expect(blockEditorEngineControllerSource).toContain('from "./inlineToolbarModel"')
-    expect(blockEditorEngineControllerSource).toContain('from "./useFloatingBubbleState"')
+    expect(blockEditorEngineControllerRuntimeSource).toContain('from "./blockToolbarModel"')
+    expect(blockEditorEngineControllerRuntimeSource).toContain('from "./inlineToolbarModel"')
+    expect(blockEditorEngineControllerRuntimeSource).toContain('from "./useFloatingBubbleState"')
     expect(blockEditorEngineSource).not.toContain("type FloatingBubbleState =")
     expect(blockEditorEngineSource).not.toContain("const bubbleHideTimerRef")
     expect(blockEditorEngineSource).not.toContain("const bubbleToolbarHoveredRef = useRef")
@@ -1363,11 +1385,11 @@ test.describe("editor studio state", () => {
     expect(blockEditorEngineInsertActionsSource).toContain('runInlineMarkCommand(editor, "bold")')
     expect(blockEditorEngineInsertActionsSource).toContain('runInlineMarkCommand(editor, "italic")')
     expect(blockEditorEngineInsertActionsSource).toContain('runInlineMarkCommand(editor, "strike")')
-    expect(blockEditorEngineControllerSource).toContain('runBlockToolbarCommand(currentEditor, "heading-2")')
-    expect(blockEditorEngineControllerSource).toContain('runBlockToolbarCommand(currentEditor, "heading-3")')
-    expect(blockEditorEngineControllerSource).toContain('runBlockToolbarCommand(currentEditor, "ordered-list")')
-    expect(blockEditorEngineControllerSource).toContain('runBlockToolbarCommand(currentEditor, "bullet-list")')
-    expect(blockEditorEngineControllerSource).toContain('runBlockToolbarCommand(currentEditor, "quote")')
+    expect(blockEditorEngineControllerRuntimeSource).toContain('runBlockToolbarCommand(currentEditor, "heading-2")')
+    expect(blockEditorEngineControllerRuntimeSource).toContain('runBlockToolbarCommand(currentEditor, "heading-3")')
+    expect(blockEditorEngineControllerRuntimeSource).toContain('runBlockToolbarCommand(currentEditor, "ordered-list")')
+    expect(blockEditorEngineControllerRuntimeSource).toContain('runBlockToolbarCommand(currentEditor, "bullet-list")')
+    expect(blockEditorEngineControllerRuntimeSource).toContain('runBlockToolbarCommand(currentEditor, "quote")')
     expect(blockEditorEngineInsertActionsSource).toContain('runBlockToolbarCommand(editor, "heading-1")')
     expect(blockEditorEngineInsertActionsSource).toContain('runBlockToolbarCommand(editor, "bullet-list")')
     expect(blockEditorEngineInsertActionsSource).toContain("isToolbarBlockInsertActive(editor, item.id)")
@@ -1696,6 +1718,19 @@ test.describe("editor studio state", () => {
       path.resolve(__dirname, "../src/components/editor/useBlockEditorEngineController.ts"),
       "utf8"
     )
+    const blockEditorEngineInsertActionsSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/useBlockEditorEngineInsertActions.ts"),
+      "utf8"
+    )
+    const blockEditorEngineControllerHandlersSource = readFileSync(
+      path.resolve(__dirname, "../src/components/editor/useBlockEditorEngineControllerEditorHandlers.ts"),
+      "utf8"
+    )
+    const blockEditorEngineControllerTableRuntimeSource = [
+      blockEditorEngineControllerSource,
+      blockEditorEngineControllerHandlersSource,
+      blockEditorEngineInsertActionsSource,
+    ].join("\n")
     const blockEditorEngineStylesSource = readFileSync(
       path.resolve(__dirname, "../src/components/editor/BlockEditorEngine.styles.tsx"),
       "utf8"
@@ -1927,7 +1962,7 @@ test.describe("editor studio state", () => {
     expect(tableStructureModelSource).toContain("export const hasTableContextInResolvedPos = (")
     expect(tableStructureModelSource).toContain("export const isTableSelectionActive = (")
     expect(tableStructureModelSource).toContain("export const getActiveTableStructureState = (")
-    expect(blockEditorEngineControllerSource).toContain('} from "./tableStructureModel"')
+    expect(blockEditorEngineControllerTableRuntimeSource).toContain('from "./tableStructureModel"')
     expect(blockEditorEngineSource).not.toContain("const collectSimpleTableColumnCells = (")
     expect(blockEditorEngineSource).not.toContain("const buildReorderedSimpleTableNode = (")
     expect(blockEditorEngineSource).not.toContain("const canShrinkTableAxisAtEnd = (")
@@ -1941,7 +1976,7 @@ test.describe("editor studio state", () => {
     expect(tablePasteModelSource).toContain("export const normalizeTableContextPasteText = (")
     expect(tablePasteModelSource).toContain("const normalizeTableContextPasteLine = (")
     expect(tablePasteModelSource).toContain("const isMarkdownTableRow = (")
-    expect(blockEditorEngineControllerSource).toContain('from "./tablePasteModel"')
+    expect(blockEditorEngineControllerTableRuntimeSource).toContain('from "./tablePasteModel"')
     expect(blockEditorEngineSource).not.toContain("const normalizeTableContextPasteText = (")
     expect(blockEditorEngineSource).not.toContain("const normalizeTableContextPasteLine = (")
     expect(blockEditorEngineSource).not.toContain("const isMarkdownTableRow = (")
@@ -2230,6 +2265,58 @@ test.describe("editor studio state", () => {
         expect(controllerSource).not.toContain(snippet)
       })
     })
+  })
+
+  test("engine residual hooks는 600 line companion budget을 유지한다", () => {
+    const editorDir = path.resolve(__dirname, "../src/components/editor")
+    const residualFiles = [
+      "useBlockEditorEngineController.ts",
+      "useBlockEditorEngineBlockDrag.ts",
+      "useBlockEditorEngineInsertActions.ts",
+      "useBlockEditorEngineSelectionEffects.ts",
+      "useBlockEditorEngineBlockSelectionUi.ts",
+      "useBlockEditorEngineDocumentOps.ts",
+    ]
+    const companionFiles = [
+      "blockEditorEngineDocumentModel.ts",
+      "useBlockEditorEngineControllerState.ts",
+      "useBlockEditorEngineControllerEditorHandlers.ts",
+      "useBlockEditorEngineBlockDragSessions.ts",
+      "useBlockEditorEngineInsertMediaActions.ts",
+      "useBlockEditorEngineQaActions.ts",
+      "useBlockEditorEngineSelectionBubbleEffects.ts",
+      "useBlockEditorEngineSelectionStateEffects.ts",
+      "useBlockEditorEngineBlockSelectionLayout.ts",
+    ]
+
+    for (const residualFile of residualFiles) {
+      const source = readFileSync(path.join(editorDir, residualFile), "utf8")
+      expect(source.split("\n").length, `${residualFile} should stay under the residual budget`).toBeLessThanOrEqual(600)
+    }
+
+    for (const companionFile of companionFiles) {
+      const companionPath = path.join(editorDir, companionFile)
+      expect(existsSync(companionPath), `${companionFile} should own extracted engine responsibility`).toBe(true)
+      const source = readFileSync(companionPath, "utf8")
+      expect(source.split("\n").length, `${companionFile} should stay under the companion budget`).toBeLessThanOrEqual(600)
+    }
+
+    const controllerSource = readFileSync(path.join(editorDir, "useBlockEditorEngineController.ts"), "utf8")
+    const blockDragSource = readFileSync(path.join(editorDir, "useBlockEditorEngineBlockDrag.ts"), "utf8")
+    const insertActionsSource = readFileSync(path.join(editorDir, "useBlockEditorEngineInsertActions.ts"), "utf8")
+    const selectionEffectsSource = readFileSync(path.join(editorDir, "useBlockEditorEngineSelectionEffects.ts"), "utf8")
+    const blockSelectionUiSource = readFileSync(path.join(editorDir, "useBlockEditorEngineBlockSelectionUi.ts"), "utf8")
+    const documentOpsSource = readFileSync(path.join(editorDir, "useBlockEditorEngineDocumentOps.ts"), "utf8")
+
+    expect(controllerSource).toContain('from "./useBlockEditorEngineControllerState"')
+    expect(controllerSource).toContain('from "./useBlockEditorEngineControllerEditorHandlers"')
+    expect(blockDragSource).toContain('from "./useBlockEditorEngineBlockDragSessions"')
+    expect(insertActionsSource).toContain('from "./useBlockEditorEngineInsertMediaActions"')
+    expect(insertActionsSource).toContain('from "./useBlockEditorEngineQaActions"')
+    expect(selectionEffectsSource).toContain('from "./useBlockEditorEngineSelectionBubbleEffects"')
+    expect(selectionEffectsSource).toContain('from "./useBlockEditorEngineSelectionStateEffects"')
+    expect(blockSelectionUiSource).toContain('from "./useBlockEditorEngineBlockSelectionLayout"')
+    expect(documentOpsSource).toContain('from "./blockEditorEngineDocumentModel"')
   })
 
   test("editor studio SSR은 작성자 카드에 공개 프로필 snapshot을 먼저 seed한다", () => {

--- a/front/src/components/editor/blockEditorEngineDocumentModel.ts
+++ b/front/src/components/editor/blockEditorEngineDocumentModel.ts
@@ -1,0 +1,107 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import type { KeyboardEvent as ReactKeyboardEvent } from "react"
+import type { BlockEditorDoc } from "./serialization"
+
+export const blockHasVisibleContent = (node?: BlockEditorDoc | null): boolean => {
+  if (!node) return false
+
+  if (node.type === "text") {
+    return Boolean((node as { text?: string }).text?.trim().length)
+  }
+
+  if (
+    node.type === "resizableImage" ||
+    node.type === "calloutBlock" ||
+    node.type === "taskList" ||
+    node.type === "bookmarkBlock" ||
+    node.type === "embedBlock" ||
+    node.type === "fileBlock" ||
+    node.type === "formulaBlock" ||
+    node.type === "toggleBlock" ||
+    node.type === "mermaidBlock" ||
+    node.type === "rawMarkdownBlock" ||
+    node.type === "table" ||
+    node.type === "horizontalRule"
+  ) {
+    return true
+  }
+
+  return Array.isArray(node.content) && node.content.some((child) => blockHasVisibleContent(child as BlockEditorDoc))
+}
+
+export const normalizeTableColorInputValue = (value: unknown) => {
+  const normalized = String(value || "").trim()
+  return /^#[0-9a-f]{6}$/i.test(normalized) ? normalized : "#dbeafe"
+}
+
+export const isPrimaryModifierPressed = (event: ReactKeyboardEvent | globalThis.KeyboardEvent) =>
+  event.metaKey || event.ctrlKey
+
+export const getActiveSlashRangeFromEditor = (editor: TiptapEditor): { from: number; to: number } | null => {
+  const selection = editor.state.selection
+  if (!selection.empty) return null
+
+  const parent = selection.$from.parent
+  if (parent.type.name !== "paragraph") return null
+
+  const textBeforeCursor = parent.textContent.slice(0, selection.$from.parentOffset)
+  const match = /(^|[\s\u00A0])\/([^\n]*)$/.exec(textBeforeCursor)
+  if (!match) return null
+
+  const slashOffset = (match.index ?? 0) + match[1].length
+  return {
+    from: selection.$from.start() + slashOffset,
+    to: selection.from,
+  }
+}
+
+export const focusElementWithoutScroll = (element: HTMLElement | null) => {
+  if (!element) return
+  if (typeof window === "undefined") {
+    element.focus()
+    return
+  }
+
+  const previousScrollX = window.scrollX
+  const previousScrollY = window.scrollY
+  try {
+    element.focus({ preventScroll: true })
+  } catch {
+    element.focus()
+  }
+  if (window.scrollX !== previousScrollX || window.scrollY !== previousScrollY) {
+    window.scrollTo(previousScrollX, previousScrollY)
+  }
+}
+
+export const resolveDocPosSafe = (editor: TiptapEditor, pos: number) => {
+  if (!Number.isFinite(pos)) return null
+  const normalizedPos = Math.round(pos)
+  const maxPos = editor.state.doc.content.size
+  if (normalizedPos < 0 || normalizedPos > maxPos) return null
+  try {
+    return editor.state.doc.resolve(normalizedPos)
+  } catch {
+    return null
+  }
+}
+
+export const downgradeDisabledFeatureNodes = (node: BlockEditorDoc, enableMermaidBlocks: boolean): BlockEditorDoc => {
+  if (!enableMermaidBlocks && node.type === "mermaidBlock") {
+    const source = String(node.attrs?.source || "").trim()
+    return {
+      type: "rawMarkdownBlock",
+      attrs: {
+        markdown: ["```mermaid", source, "```"].join("\n"),
+        reason: "unsupported-mermaid",
+      },
+    }
+  }
+
+  if (!node.content?.length) return node
+
+  return {
+    ...node,
+    content: node.content.map((child) => downgradeDisabledFeatureNodes(child as BlockEditorDoc, enableMermaidBlocks)),
+  }
+}

--- a/front/src/components/editor/useBlockEditorEngineBlockDrag.ts
+++ b/front/src/components/editor/useBlockEditorEngineBlockDrag.ts
@@ -8,10 +8,6 @@ import type {
   RefObject,
   SetStateAction,
 } from "react"
-import {
-  moveNestedListItemToInsertionIndex,
-  moveTopLevelBlockToInsertionIndex,
-} from "./blockDocumentOps"
 import type { BlockEditorDoc } from "./serialization"
 import type { TopLevelBlockHandleState } from "./blockSelectionModel"
 import {
@@ -19,34 +15,23 @@ import {
   type DropIndicatorState,
   type PendingBlockDragState,
   createBlockDragPreview,
-  createDraggedBlockState,
-  createDropIndicatorState,
   createPendingBlockDragState,
-  hideDropIndicatorState,
-  resolveBlockDropIndicatorByClientY,
 } from "./blockDragModel"
 import {
   type DraggedNestedListItemState,
   type NestedListItemDropIndicatorState,
   type PendingNestedListItemHandleDragState,
-  createDraggedNestedListItemState,
-  createNestedListItemDragPreview,
-  createNestedListItemDropIndicatorState,
-  createPendingNestedListItemHandleDragState,
-  hideNestedListItemDropIndicatorState,
-  isNestedListItemContextInDraggedList,
 } from "./nestedListItemDragModel"
 import {
   type NestedListItemContext,
   type NestedListItemDropIndicatorGeometry,
   getListItemNameFromContext,
-  isSameNestedListItemContext,
   sameListPath,
-  selectNestedListItemNode,
   selectNestedListItemTextAnchor,
 } from "./nestedListItemModel"
 import type { BlockEditorBlockMenuState } from "./BlockEditorEngine.layers"
 import { useBlockEditorEngineBlockMenu } from "./useBlockEditorEngineBlockMenu"
+import { useBlockEditorEngineBlockDragSessions } from "./useBlockEditorEngineBlockDragSessions"
 
 type SetState<T> = Dispatch<SetStateAction<T>>
 
@@ -164,171 +149,43 @@ export const useBlockEditorEngineBlockDrag = ({
     }
   }, [pendingNestedListItemHandleDragCleanupRef, pendingNestedListItemHandleDragRef])
 
-  const clearBlockDragVisualState = useCallback(() => {
-    setDraggedBlockState(null)
-    setDragGhostPosition(null)
-    setDropIndicatorState(hideDropIndicatorState)
-  }, [setDragGhostPosition, setDraggedBlockState, setDropIndicatorState])
-
-  const beginBlockDragFromPending = useCallback(
-    (pending: PendingBlockDragState, clientX: number, clientY: number) => {
-      const indicator = resolveBlockDropIndicatorByClientY(getTopLevelBlockElements(), clientY)
-      setDraggedBlockState(createDraggedBlockState(pending))
-      setDragGhostPosition({
-        x: clientX,
-        y: clientY,
-      })
-      setDropIndicatorState(createDropIndicatorState(indicator))
-
-      let earlyPointerDoneTimeout: number | null = null
-      const cleanupEarlyPointerDone = () => {
-        window.removeEventListener("pointerup", handleEarlyPointerDone, true)
-        window.removeEventListener("pointercancel", handleEarlyPointerDone, true)
-        if (earlyPointerDoneTimeout !== null) {
-          window.clearTimeout(earlyPointerDoneTimeout)
-          earlyPointerDoneTimeout = null
-        }
-      }
-      const handleEarlyPointerDone = (event: PointerEvent) => {
-        if (event.pointerId !== pending.pointerId) return
-        clearBlockDragVisualState()
-        cleanupEarlyPointerDone()
-      }
-
-      window.addEventListener("pointerup", handleEarlyPointerDone, true)
-      window.addEventListener("pointercancel", handleEarlyPointerDone, true)
-      earlyPointerDoneTimeout = window.setTimeout(cleanupEarlyPointerDone, 30000)
-    },
-    [clearBlockDragVisualState, getTopLevelBlockElements, setDragGhostPosition, setDraggedBlockState, setDropIndicatorState]
-  )
-
-  useEffect(() => {
-    if (typeof window === "undefined" || !draggedBlockState) return
-
-    const handlePointerMove = (event: PointerEvent) => {
-      if (event.pointerId !== draggedBlockState.pointerId) return
-      const nextIndicator = resolveBlockDropIndicatorByClientY(getTopLevelBlockElements(), event.clientY)
-      setDropIndicatorState(createDropIndicatorState(nextIndicator))
-      setDragGhostPosition({ x: event.clientX, y: event.clientY })
-    }
-
-    const handlePointerUp = (event: PointerEvent) => {
-      if (event.pointerId !== draggedBlockState.pointerId) return
-
-      const nextIndicator = resolveBlockDropIndicatorByClientY(getTopLevelBlockElements(), event.clientY)
-      const sourceIndex = draggedBlockState.sourceIndex
-      const normalizedInsertionIndex =
-        nextIndicator.insertionIndex > sourceIndex
-          ? nextIndicator.insertionIndex
-          : nextIndicator.insertionIndex
-
-      mutateTopLevelBlocks(
-        (doc) => moveTopLevelBlockToInsertionIndex(doc, sourceIndex, normalizedInsertionIndex),
-        Math.max(0, Math.min(nextIndicator.insertionIndex, ((editorRef.current?.getJSON() as BlockEditorDoc)?.content?.length || 1) - 1))
-      )
-
-      setDraggedBlockState(null)
-      setDragGhostPosition(null)
-      setDropIndicatorState(hideDropIndicatorState)
-      window.removeEventListener("pointermove", handlePointerMove)
-      window.removeEventListener("pointerup", handlePointerUp)
-      window.removeEventListener("pointercancel", handlePointerUp)
-    }
-
-    window.addEventListener("pointermove", handlePointerMove)
-    window.addEventListener("pointerup", handlePointerUp)
-    window.addEventListener("pointercancel", handlePointerUp)
-    return () => {
-      window.removeEventListener("pointermove", handlePointerMove)
-      window.removeEventListener("pointerup", handlePointerUp)
-      window.removeEventListener("pointercancel", handlePointerUp)
-    }
-  }, [draggedBlockState, editorRef, getTopLevelBlockElements, mutateTopLevelBlocks, setDragGhostPosition, setDraggedBlockState, setDropIndicatorState])
-
-  useEffect(() => {
-    if (typeof document === "undefined" || !draggedBlockState) return
-    const previousCursor = document.body.style.cursor
-    const previousUserSelect = document.body.style.userSelect
-    document.body.style.cursor = "grabbing"
-    document.body.style.userSelect = "none"
-    return () => {
-      document.body.style.cursor = previousCursor
-      document.body.style.userSelect = previousUserSelect
-    }
-  }, [draggedBlockState])
-
   useEffect(() => {
     return () => {
       clearPendingBlockDrag()
     }
   }, [clearPendingBlockDrag])
 
-  const handleViewportDragStart = useCallback(
-    (event: React.DragEvent<HTMLDivElement>) => {
-      const listItemContext = findNestedListItemContextFromTarget(event.target)
-      if (!listItemContext) return
-
-      const currentEditor = editorRef.current ?? editor
-      if (currentEditor) {
-        const currentSelectedListItemContext = resolveEffectiveSelectedListItemContext(currentEditor)
-        setSelectedListItemContext(listItemContext)
-        if (
-          !currentSelectedListItemContext ||
-          !isSameNestedListItemContext(currentSelectedListItemContext, listItemContext)
-        ) {
-          selectNestedListItemNode(currentEditor, listItemContext)
-          clearNativeTextSelection()
-        }
-      }
-      const sourceElement = listItemContext.listItemElement
-      const preview = createNestedListItemDragPreview(sourceElement, window.innerWidth)
-      setDraggedNestedListItemState(createDraggedNestedListItemState(listItemContext, preview))
-      setNestedListItemDropIndicatorState(
-        createNestedListItemDropIndicatorState(
-          listItemContext,
-          resolveNestedListItemDropIndicatorByClientY(listItemContext.listElement, event.clientY)
-        )
-      )
-      event.dataTransfer.effectAllowed = "move"
-      event.dataTransfer.setData("text/plain", `list-item:${listItemContext.listBlockIndex}:${listItemContext.itemIndex}`)
-    },
-    [
-      clearNativeTextSelection,
-      editor,
-      editorRef,
-      findNestedListItemContextFromTarget,
-      resolveEffectiveSelectedListItemContext,
-      resolveNestedListItemDropIndicatorByClientY,
-      setDraggedNestedListItemState,
-      setNestedListItemDropIndicatorState,
-      setSelectedListItemContext,
-    ]
-  )
-
-  const handleViewportDragOver = useCallback(
-    (event: React.DragEvent<HTMLDivElement>) => {
-      if (!draggedNestedListItemState) return
-      const taskItemContext = findNestedListItemContextFromTarget(event.target)
-      if (!isNestedListItemContextInDraggedList(taskItemContext, draggedNestedListItemState)) {
-        return
-      }
-
-      event.preventDefault()
-      setNestedListItemDropIndicatorState(
-        createNestedListItemDropIndicatorState(
-          taskItemContext,
-          resolveNestedListItemDropIndicatorByClientY(taskItemContext.listElement, event.clientY)
-        )
-      )
-    },
-    [draggedNestedListItemState, findNestedListItemContextFromTarget, resolveNestedListItemDropIndicatorByClientY, setNestedListItemDropIndicatorState]
-  )
-
-  const clearNestedListItemDragState = useCallback(() => {
-    setDraggedNestedListItemState(null)
-    setDragGhostPosition(null)
-    setNestedListItemDropIndicatorState(hideNestedListItemDropIndicatorState)
-  }, [setDragGhostPosition, setDraggedNestedListItemState, setNestedListItemDropIndicatorState])
+  const {
+    beginBlockDragFromPending,
+    beginPendingNestedListItemHandleDrag,
+    handleViewportDragEnd,
+    handleViewportDragOver,
+    handleViewportDragStart,
+    handleViewportDrop,
+  } = useBlockEditorEngineBlockDragSessions({
+    clearNativeTextSelection,
+    clearPendingNestedListItemHandleDrag,
+    clearStickyTopLevelBlockSelection,
+    draggedBlockState,
+    draggedNestedListItemState,
+    editor,
+    editorRef,
+    findNestedListItemContextFromTarget,
+    flushPendingMarkdownCommit,
+    getTopLevelBlockElements,
+    mutateTopLevelBlocks,
+    pendingNestedListItemHandleDragCleanupRef,
+    pendingNestedListItemHandleDragRef,
+    resolveEffectiveSelectedListItemContext,
+    resolveNestedListItemContextByIndices,
+    resolveNestedListItemDropIndicatorByClientY,
+    setDragGhostPosition,
+    setDraggedBlockState,
+    setDraggedNestedListItemState,
+    setDropIndicatorState,
+    setNestedListItemDropIndicatorState,
+    setSelectedListItemContext,
+  })
 
   const resolveNestedListItemContextFromBlockHandleState = useCallback(() => {
     if (blockHandleState.kind !== "list-item") return null
@@ -427,187 +284,6 @@ export const useBlockEditorEngineBlockDrag = ({
       setSelectionTick,
     ]
   )
-
-  const beginPendingNestedListItemHandleDrag = useCallback(
-    (pointerId: number, startX: number, startY: number, context: NestedListItemContext) => {
-      clearPendingNestedListItemHandleDrag()
-      flushPendingMarkdownCommit()
-      const sourceElement = context.listItemElement
-      if (sourceElement.isConnected) {
-        sourceElement.setAttribute("draggable", "false")
-      }
-      const preview = createNestedListItemDragPreview(sourceElement, window.innerWidth)
-      pendingNestedListItemHandleDragRef.current = createPendingNestedListItemHandleDragState(
-        pointerId,
-        startX,
-        startY,
-        context,
-        preview
-      )
-      clearStickyTopLevelBlockSelection()
-      const currentEditor = editorRef.current ?? editor
-      if (currentEditor) {
-        selectNestedListItemNode(currentEditor, context)
-        clearNativeTextSelection()
-      }
-
-      const handlePointerMove = (moveEvent: PointerEvent) => {
-        const pending = pendingNestedListItemHandleDragRef.current
-        if (!pending || moveEvent.pointerId !== pending.pointerId) return
-        const distance = Math.hypot(moveEvent.clientX - pending.startX, moveEvent.clientY - pending.startY)
-        if (!pending.started) {
-          if (distance < 5) return
-          pending.started = true
-          setDraggedNestedListItemState(createDraggedNestedListItemState(pending.context, pending))
-        }
-
-        const activeListContext =
-          resolveNestedListItemContextByIndices(
-            pending.context.listBlockIndex,
-            pending.context.listPath,
-            pending.context.itemIndex
-          ) ?? pending.context
-        const listRect = activeListContext.listElement.getBoundingClientRect()
-        const withinListBounds =
-          moveEvent.clientY >= listRect.top - 24 && moveEvent.clientY <= listRect.bottom + 24
-
-        setDragGhostPosition({
-          x: moveEvent.clientX,
-          y: moveEvent.clientY,
-        })
-
-        if (!withinListBounds) {
-          pending.targetListBlockIndex = null
-          pending.targetListPath = null
-          pending.insertionIndex = null
-          setNestedListItemDropIndicatorState(hideNestedListItemDropIndicatorState)
-          return
-        }
-
-        const indicator = resolveNestedListItemDropIndicatorByClientY(activeListContext.listElement, moveEvent.clientY)
-        pending.targetListBlockIndex = activeListContext.listBlockIndex
-        pending.targetListPath = [...activeListContext.listPath]
-        pending.insertionIndex = indicator.insertionIndex
-        setNestedListItemDropIndicatorState(createNestedListItemDropIndicatorState(activeListContext, indicator))
-      }
-
-      const handlePointerDone = (doneEvent: PointerEvent) => {
-        const pending = pendingNestedListItemHandleDragRef.current
-        if (!pending || doneEvent.pointerId !== pending.pointerId) return
-        if (!pending.started) {
-          if (pending.context.listItemElement.isConnected) {
-            pending.context.listItemElement.setAttribute("draggable", "true")
-          }
-          clearPendingNestedListItemHandleDrag()
-          return
-        }
-        if (pending.context.listItemElement.isConnected) {
-          pending.context.listItemElement.setAttribute("draggable", "true")
-        }
-
-        const activeListContext =
-          resolveNestedListItemContextByIndices(
-            pending.context.listBlockIndex,
-            pending.context.listPath,
-            pending.context.itemIndex
-          ) ?? pending.context
-        const indicator = resolveNestedListItemDropIndicatorByClientY(
-          activeListContext.listElement,
-          doneEvent.clientY
-        )
-        pending.targetListBlockIndex = activeListContext.listBlockIndex
-        pending.targetListPath = [...activeListContext.listPath]
-        pending.insertionIndex = indicator.insertionIndex
-
-        if (
-          pending.targetListBlockIndex === pending.context.listBlockIndex &&
-          pending.targetListPath &&
-          sameListPath(pending.targetListPath, pending.context.listPath) &&
-          pending.insertionIndex !== null
-        ) {
-          const insertionIndex = pending.insertionIndex
-          mutateTopLevelBlocks(
-            (doc) =>
-              moveNestedListItemToInsertionIndex(
-                doc,
-                pending.context.listBlockIndex,
-                pending.context.listPath,
-                pending.context.itemIndex,
-                insertionIndex
-              ),
-            pending.context.listBlockIndex
-          )
-        }
-        clearNestedListItemDragState()
-
-        clearPendingNestedListItemHandleDrag()
-      }
-
-      window.addEventListener("pointermove", handlePointerMove)
-      window.addEventListener("pointerup", handlePointerDone)
-      window.addEventListener("pointercancel", handlePointerDone)
-
-      pendingNestedListItemHandleDragCleanupRef.current = () => {
-        window.removeEventListener("pointermove", handlePointerMove)
-        window.removeEventListener("pointerup", handlePointerDone)
-        window.removeEventListener("pointercancel", handlePointerDone)
-      }
-    },
-    [
-      clearNativeTextSelection,
-      clearNestedListItemDragState,
-      clearPendingNestedListItemHandleDrag,
-      clearStickyTopLevelBlockSelection,
-      editor,
-      editorRef,
-      flushPendingMarkdownCommit,
-      mutateTopLevelBlocks,
-      pendingNestedListItemHandleDragCleanupRef,
-      pendingNestedListItemHandleDragRef,
-      resolveNestedListItemContextByIndices,
-      resolveNestedListItemDropIndicatorByClientY,
-      setDragGhostPosition,
-      setDraggedNestedListItemState,
-      setNestedListItemDropIndicatorState,
-    ]
-  )
-
-  const handleViewportDrop = useCallback(
-    (event: React.DragEvent<HTMLDivElement>) => {
-      if (!draggedNestedListItemState) return
-      const taskItemContext = findNestedListItemContextFromTarget(event.target)
-      if (!isNestedListItemContextInDraggedList(taskItemContext, draggedNestedListItemState)) {
-        clearNestedListItemDragState()
-        return
-      }
-
-      event.preventDefault()
-      const indicator = resolveNestedListItemDropIndicatorByClientY(taskItemContext.listElement, event.clientY)
-      mutateTopLevelBlocks(
-        (doc) =>
-          moveNestedListItemToInsertionIndex(
-            doc,
-            draggedNestedListItemState.listBlockIndex,
-            draggedNestedListItemState.listPath,
-            draggedNestedListItemState.sourceItemIndex,
-            indicator.insertionIndex
-          ),
-        draggedNestedListItemState.listBlockIndex
-      )
-      clearNestedListItemDragState()
-    },
-    [
-      clearNestedListItemDragState,
-      draggedNestedListItemState,
-      findNestedListItemContextFromTarget,
-      mutateTopLevelBlocks,
-      resolveNestedListItemDropIndicatorByClientY,
-    ]
-  )
-
-  const handleViewportDragEnd = useCallback(() => {
-    clearNestedListItemDragState()
-  }, [clearNestedListItemDragState])
 
   const handleBlockHandleRailPointerEnter = useCallback(() => {
     cancelHoveredBlockClear()

--- a/front/src/components/editor/useBlockEditorEngineBlockDragSessions.ts
+++ b/front/src/components/editor/useBlockEditorEngineBlockDragSessions.ts
@@ -1,0 +1,434 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import { useCallback, useEffect } from "react"
+import type { Dispatch, DragEvent as ReactDragEvent, MutableRefObject, RefObject, SetStateAction } from "react"
+import {
+  moveNestedListItemToInsertionIndex,
+  moveTopLevelBlockToInsertionIndex,
+} from "./blockDocumentOps"
+import type { BlockEditorDoc } from "./serialization"
+import {
+  type DraggedBlockState,
+  type DropIndicatorState,
+  type PendingBlockDragState,
+  createDraggedBlockState,
+  createDropIndicatorState,
+  hideDropIndicatorState,
+  resolveBlockDropIndicatorByClientY,
+} from "./blockDragModel"
+import {
+  type DraggedNestedListItemState,
+  type NestedListItemDropIndicatorState,
+  type PendingNestedListItemHandleDragState,
+  createDraggedNestedListItemState,
+  createNestedListItemDragPreview,
+  createNestedListItemDropIndicatorState,
+  createPendingNestedListItemHandleDragState,
+  hideNestedListItemDropIndicatorState,
+  isNestedListItemContextInDraggedList,
+} from "./nestedListItemDragModel"
+import {
+  type NestedListItemContext,
+  type NestedListItemDropIndicatorGeometry,
+  isSameNestedListItemContext,
+  selectNestedListItemNode,
+  sameListPath,
+} from "./nestedListItemModel"
+
+type SetState<T> = Dispatch<SetStateAction<T>>
+
+type UseBlockEditorEngineBlockDragSessionsArgs = {
+  clearNativeTextSelection: () => void
+  clearPendingNestedListItemHandleDrag: () => void
+  clearStickyTopLevelBlockSelection: () => void
+  draggedBlockState: DraggedBlockState
+  draggedNestedListItemState: DraggedNestedListItemState
+  editor: TiptapEditor | null
+  editorRef: RefObject<TiptapEditor | null>
+  findNestedListItemContextFromTarget: (target: EventTarget | null) => NestedListItemContext | null
+  flushPendingMarkdownCommit: () => void
+  getTopLevelBlockElements: () => HTMLElement[]
+  mutateTopLevelBlocks: (mutator: (doc: BlockEditorDoc) => BlockEditorDoc, focusIndex?: number | null) => void
+  pendingNestedListItemHandleDragCleanupRef: MutableRefObject<(() => void) | null>
+  pendingNestedListItemHandleDragRef: MutableRefObject<PendingNestedListItemHandleDragState | null>
+  resolveEffectiveSelectedListItemContext: (editor?: TiptapEditor | null) => NestedListItemContext | null
+  resolveNestedListItemContextByIndices: (
+    listBlockIndex: number,
+    listPath: number[],
+    itemIndex: number
+  ) => NestedListItemContext | null
+  resolveNestedListItemDropIndicatorByClientY: (
+    listElement: HTMLElement,
+    clientY: number
+  ) => NestedListItemDropIndicatorGeometry
+  setDragGhostPosition: SetState<{ x: number; y: number } | null>
+  setDraggedBlockState: SetState<DraggedBlockState>
+  setDraggedNestedListItemState: SetState<DraggedNestedListItemState>
+  setDropIndicatorState: SetState<DropIndicatorState>
+  setNestedListItemDropIndicatorState: SetState<NestedListItemDropIndicatorState>
+  setSelectedListItemContext: SetState<NestedListItemContext | null>
+}
+
+export const useBlockEditorEngineBlockDragSessions = ({
+  clearNativeTextSelection,
+  clearPendingNestedListItemHandleDrag,
+  clearStickyTopLevelBlockSelection,
+  draggedBlockState,
+  draggedNestedListItemState,
+  editor,
+  editorRef,
+  findNestedListItemContextFromTarget,
+  flushPendingMarkdownCommit,
+  getTopLevelBlockElements,
+  mutateTopLevelBlocks,
+  pendingNestedListItemHandleDragCleanupRef,
+  pendingNestedListItemHandleDragRef,
+  resolveEffectiveSelectedListItemContext,
+  resolveNestedListItemContextByIndices,
+  resolveNestedListItemDropIndicatorByClientY,
+  setDragGhostPosition,
+  setDraggedBlockState,
+  setDraggedNestedListItemState,
+  setDropIndicatorState,
+  setNestedListItemDropIndicatorState,
+  setSelectedListItemContext,
+}: UseBlockEditorEngineBlockDragSessionsArgs) => {
+  const clearBlockDragVisualState = useCallback(() => {
+    setDraggedBlockState(null)
+    setDragGhostPosition(null)
+    setDropIndicatorState(hideDropIndicatorState)
+  }, [setDragGhostPosition, setDraggedBlockState, setDropIndicatorState])
+
+  const beginBlockDragFromPending = useCallback(
+    (pending: PendingBlockDragState, clientX: number, clientY: number) => {
+      const indicator = resolveBlockDropIndicatorByClientY(getTopLevelBlockElements(), clientY)
+      setDraggedBlockState(createDraggedBlockState(pending))
+      setDragGhostPosition({ x: clientX, y: clientY })
+      setDropIndicatorState(createDropIndicatorState(indicator))
+
+      let earlyPointerDoneTimeout: number | null = null
+      const cleanupEarlyPointerDone = () => {
+        window.removeEventListener("pointerup", handleEarlyPointerDone, true)
+        window.removeEventListener("pointercancel", handleEarlyPointerDone, true)
+        if (earlyPointerDoneTimeout !== null) {
+          window.clearTimeout(earlyPointerDoneTimeout)
+          earlyPointerDoneTimeout = null
+        }
+      }
+      const handleEarlyPointerDone = (event: PointerEvent) => {
+        if (event.pointerId !== pending.pointerId) return
+        clearBlockDragVisualState()
+        cleanupEarlyPointerDone()
+      }
+
+      window.addEventListener("pointerup", handleEarlyPointerDone, true)
+      window.addEventListener("pointercancel", handleEarlyPointerDone, true)
+      earlyPointerDoneTimeout = window.setTimeout(cleanupEarlyPointerDone, 30000)
+    },
+    [clearBlockDragVisualState, getTopLevelBlockElements, setDragGhostPosition, setDraggedBlockState, setDropIndicatorState]
+  )
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !draggedBlockState) return
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (event.pointerId !== draggedBlockState.pointerId) return
+      const nextIndicator = resolveBlockDropIndicatorByClientY(getTopLevelBlockElements(), event.clientY)
+      setDropIndicatorState(createDropIndicatorState(nextIndicator))
+      setDragGhostPosition({ x: event.clientX, y: event.clientY })
+    }
+
+    const handlePointerUp = (event: PointerEvent) => {
+      if (event.pointerId !== draggedBlockState.pointerId) return
+
+      const nextIndicator = resolveBlockDropIndicatorByClientY(getTopLevelBlockElements(), event.clientY)
+      const sourceIndex = draggedBlockState.sourceIndex
+      const normalizedInsertionIndex =
+        nextIndicator.insertionIndex > sourceIndex
+          ? nextIndicator.insertionIndex
+          : nextIndicator.insertionIndex
+
+      mutateTopLevelBlocks(
+        (doc) => moveTopLevelBlockToInsertionIndex(doc, sourceIndex, normalizedInsertionIndex),
+        Math.max(0, Math.min(nextIndicator.insertionIndex, ((editorRef.current?.getJSON() as BlockEditorDoc)?.content?.length || 1) - 1))
+      )
+
+      setDraggedBlockState(null)
+      setDragGhostPosition(null)
+      setDropIndicatorState(hideDropIndicatorState)
+      window.removeEventListener("pointermove", handlePointerMove)
+      window.removeEventListener("pointerup", handlePointerUp)
+      window.removeEventListener("pointercancel", handlePointerUp)
+    }
+
+    window.addEventListener("pointermove", handlePointerMove)
+    window.addEventListener("pointerup", handlePointerUp)
+    window.addEventListener("pointercancel", handlePointerUp)
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove)
+      window.removeEventListener("pointerup", handlePointerUp)
+      window.removeEventListener("pointercancel", handlePointerUp)
+    }
+  }, [draggedBlockState, editorRef, getTopLevelBlockElements, mutateTopLevelBlocks, setDragGhostPosition, setDraggedBlockState, setDropIndicatorState])
+
+  useEffect(() => {
+    if (typeof document === "undefined" || !draggedBlockState) return
+    const previousCursor = document.body.style.cursor
+    const previousUserSelect = document.body.style.userSelect
+    document.body.style.cursor = "grabbing"
+    document.body.style.userSelect = "none"
+    return () => {
+      document.body.style.cursor = previousCursor
+      document.body.style.userSelect = previousUserSelect
+    }
+  }, [draggedBlockState])
+
+  const handleViewportDragStart = useCallback(
+    (event: ReactDragEvent<HTMLDivElement>) => {
+      const listItemContext = findNestedListItemContextFromTarget(event.target)
+      if (!listItemContext) return
+
+      const currentEditor = editorRef.current ?? editor
+      if (currentEditor) {
+        const currentSelectedListItemContext = resolveEffectiveSelectedListItemContext(currentEditor)
+        setSelectedListItemContext(listItemContext)
+        if (
+          !currentSelectedListItemContext ||
+          !isSameNestedListItemContext(currentSelectedListItemContext, listItemContext)
+        ) {
+          selectNestedListItemNode(currentEditor, listItemContext)
+          clearNativeTextSelection()
+        }
+      }
+      const sourceElement = listItemContext.listItemElement
+      const preview = createNestedListItemDragPreview(sourceElement, window.innerWidth)
+      setDraggedNestedListItemState(createDraggedNestedListItemState(listItemContext, preview))
+      setNestedListItemDropIndicatorState(
+        createNestedListItemDropIndicatorState(
+          listItemContext,
+          resolveNestedListItemDropIndicatorByClientY(listItemContext.listElement, event.clientY)
+        )
+      )
+      event.dataTransfer.effectAllowed = "move"
+      event.dataTransfer.setData("text/plain", `list-item:${listItemContext.listBlockIndex}:${listItemContext.itemIndex}`)
+    },
+    [
+      clearNativeTextSelection,
+      editor,
+      editorRef,
+      findNestedListItemContextFromTarget,
+      resolveEffectiveSelectedListItemContext,
+      resolveNestedListItemDropIndicatorByClientY,
+      setDraggedNestedListItemState,
+      setNestedListItemDropIndicatorState,
+      setSelectedListItemContext,
+    ]
+  )
+
+  const handleViewportDragOver = useCallback(
+    (event: ReactDragEvent<HTMLDivElement>) => {
+      if (!draggedNestedListItemState) return
+      const taskItemContext = findNestedListItemContextFromTarget(event.target)
+      if (!isNestedListItemContextInDraggedList(taskItemContext, draggedNestedListItemState)) {
+        return
+      }
+
+      event.preventDefault()
+      setNestedListItemDropIndicatorState(
+        createNestedListItemDropIndicatorState(
+          taskItemContext,
+          resolveNestedListItemDropIndicatorByClientY(taskItemContext.listElement, event.clientY)
+        )
+      )
+    },
+    [draggedNestedListItemState, findNestedListItemContextFromTarget, resolveNestedListItemDropIndicatorByClientY, setNestedListItemDropIndicatorState]
+  )
+
+  const clearNestedListItemDragState = useCallback(() => {
+    setDraggedNestedListItemState(null)
+    setDragGhostPosition(null)
+    setNestedListItemDropIndicatorState(hideNestedListItemDropIndicatorState)
+  }, [setDragGhostPosition, setDraggedNestedListItemState, setNestedListItemDropIndicatorState])
+
+  const beginPendingNestedListItemHandleDrag = useCallback(
+    (pointerId: number, startX: number, startY: number, context: NestedListItemContext) => {
+      clearPendingNestedListItemHandleDrag()
+      flushPendingMarkdownCommit()
+      const sourceElement = context.listItemElement
+      if (sourceElement.isConnected) {
+        sourceElement.setAttribute("draggable", "false")
+      }
+      const preview = createNestedListItemDragPreview(sourceElement, window.innerWidth)
+      pendingNestedListItemHandleDragRef.current = createPendingNestedListItemHandleDragState(
+        pointerId,
+        startX,
+        startY,
+        context,
+        preview
+      )
+      clearStickyTopLevelBlockSelection()
+      const currentEditor = editorRef.current ?? editor
+      if (currentEditor) {
+        selectNestedListItemNode(currentEditor, context)
+        clearNativeTextSelection()
+      }
+
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        const pending = pendingNestedListItemHandleDragRef.current
+        if (!pending || moveEvent.pointerId !== pending.pointerId) return
+        const distance = Math.hypot(moveEvent.clientX - pending.startX, moveEvent.clientY - pending.startY)
+        if (!pending.started) {
+          if (distance < 5) return
+          pending.started = true
+          setDraggedNestedListItemState(createDraggedNestedListItemState(pending.context, pending))
+        }
+
+        const activeListContext =
+          resolveNestedListItemContextByIndices(
+            pending.context.listBlockIndex,
+            pending.context.listPath,
+            pending.context.itemIndex
+          ) ?? pending.context
+        const listRect = activeListContext.listElement.getBoundingClientRect()
+        const withinListBounds =
+          moveEvent.clientY >= listRect.top - 24 && moveEvent.clientY <= listRect.bottom + 24
+
+        setDragGhostPosition({ x: moveEvent.clientX, y: moveEvent.clientY })
+
+        if (!withinListBounds) {
+          pending.targetListBlockIndex = null
+          pending.targetListPath = null
+          pending.insertionIndex = null
+          setNestedListItemDropIndicatorState(hideNestedListItemDropIndicatorState)
+          return
+        }
+
+        const indicator = resolveNestedListItemDropIndicatorByClientY(activeListContext.listElement, moveEvent.clientY)
+        pending.targetListBlockIndex = activeListContext.listBlockIndex
+        pending.targetListPath = [...activeListContext.listPath]
+        pending.insertionIndex = indicator.insertionIndex
+        setNestedListItemDropIndicatorState(createNestedListItemDropIndicatorState(activeListContext, indicator))
+      }
+
+      const handlePointerDone = (doneEvent: PointerEvent) => {
+        const pending = pendingNestedListItemHandleDragRef.current
+        if (!pending || doneEvent.pointerId !== pending.pointerId) return
+        if (!pending.started) {
+          if (pending.context.listItemElement.isConnected) {
+            pending.context.listItemElement.setAttribute("draggable", "true")
+          }
+          clearPendingNestedListItemHandleDrag()
+          return
+        }
+        if (pending.context.listItemElement.isConnected) {
+          pending.context.listItemElement.setAttribute("draggable", "true")
+        }
+
+        const activeListContext =
+          resolveNestedListItemContextByIndices(
+            pending.context.listBlockIndex,
+            pending.context.listPath,
+            pending.context.itemIndex
+          ) ?? pending.context
+        const indicator = resolveNestedListItemDropIndicatorByClientY(activeListContext.listElement, doneEvent.clientY)
+        pending.targetListBlockIndex = activeListContext.listBlockIndex
+        pending.targetListPath = [...activeListContext.listPath]
+        pending.insertionIndex = indicator.insertionIndex
+
+        if (
+          pending.targetListBlockIndex === pending.context.listBlockIndex &&
+          pending.targetListPath &&
+          sameListPath(pending.targetListPath, pending.context.listPath) &&
+          pending.insertionIndex !== null
+        ) {
+          mutateTopLevelBlocks(
+            (doc) =>
+              moveNestedListItemToInsertionIndex(
+                doc,
+                pending.context.listBlockIndex,
+                pending.context.listPath,
+                pending.context.itemIndex,
+                pending.insertionIndex!
+              ),
+            pending.context.listBlockIndex
+          )
+        }
+        clearNestedListItemDragState()
+        clearPendingNestedListItemHandleDrag()
+      }
+
+      window.addEventListener("pointermove", handlePointerMove)
+      window.addEventListener("pointerup", handlePointerDone)
+      window.addEventListener("pointercancel", handlePointerDone)
+
+      pendingNestedListItemHandleDragCleanupRef.current = () => {
+        window.removeEventListener("pointermove", handlePointerMove)
+        window.removeEventListener("pointerup", handlePointerDone)
+        window.removeEventListener("pointercancel", handlePointerDone)
+      }
+    },
+    [
+      clearNativeTextSelection,
+      clearNestedListItemDragState,
+      clearPendingNestedListItemHandleDrag,
+      clearStickyTopLevelBlockSelection,
+      editor,
+      editorRef,
+      flushPendingMarkdownCommit,
+      mutateTopLevelBlocks,
+      pendingNestedListItemHandleDragCleanupRef,
+      pendingNestedListItemHandleDragRef,
+      resolveNestedListItemContextByIndices,
+      resolveNestedListItemDropIndicatorByClientY,
+      setDragGhostPosition,
+      setDraggedNestedListItemState,
+      setNestedListItemDropIndicatorState,
+    ]
+  )
+
+  const handleViewportDrop = useCallback(
+    (event: ReactDragEvent<HTMLDivElement>) => {
+      if (!draggedNestedListItemState) return
+      const taskItemContext = findNestedListItemContextFromTarget(event.target)
+      if (!isNestedListItemContextInDraggedList(taskItemContext, draggedNestedListItemState)) {
+        clearNestedListItemDragState()
+        return
+      }
+
+      event.preventDefault()
+      const indicator = resolveNestedListItemDropIndicatorByClientY(taskItemContext.listElement, event.clientY)
+      mutateTopLevelBlocks(
+        (doc) =>
+          moveNestedListItemToInsertionIndex(
+            doc,
+            draggedNestedListItemState.listBlockIndex,
+            draggedNestedListItemState.listPath,
+            draggedNestedListItemState.sourceItemIndex,
+            indicator.insertionIndex
+          ),
+        draggedNestedListItemState.listBlockIndex
+      )
+      clearNestedListItemDragState()
+    },
+    [
+      clearNestedListItemDragState,
+      draggedNestedListItemState,
+      findNestedListItemContextFromTarget,
+      mutateTopLevelBlocks,
+      resolveNestedListItemDropIndicatorByClientY,
+    ]
+  )
+
+  const handleViewportDragEnd = useCallback(() => {
+    clearNestedListItemDragState()
+  }, [clearNestedListItemDragState])
+
+  return {
+    beginBlockDragFromPending,
+    beginPendingNestedListItemHandleDrag,
+    clearNestedListItemDragState,
+    handleViewportDragEnd,
+    handleViewportDragOver,
+    handleViewportDragStart,
+    handleViewportDrop,
+  }
+}

--- a/front/src/components/editor/useBlockEditorEngineBlockSelectionLayout.ts
+++ b/front/src/components/editor/useBlockEditorEngineBlockSelectionLayout.ts
@@ -1,0 +1,308 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import { useEffect, useLayoutEffect } from "react"
+import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from "react"
+import type { BlockEditorDoc } from "./serialization"
+import {
+  isStableBlockHandleState,
+  isStableBlockSelectionOverlayState,
+  type BlockSelectionOverlayState,
+  type TopLevelBlockHandleState,
+} from "./blockSelectionModel"
+import {
+  resolveBlockHandleAnchorTop,
+  resolveBlockChromeTop,
+  resolveBlockHandleRailLayoutForSurface,
+  resolveBlockSelectionOverlayLayout,
+  resolveThinBlockHandleAnchorTop,
+  shouldCenterBlockHandleForNode,
+  shouldUseThinBlockHandleAnchor,
+} from "./blockHandleLayoutModel"
+import {
+  LIST_ITEM_SELECTOR,
+  type NestedListItemContext,
+  isSameNestedListItemContext,
+} from "./nestedListItemModel"
+import type { DraggedBlockState, DropIndicatorState } from "./blockDragModel"
+
+type SetState<T> = Dispatch<SetStateAction<T>>
+
+type UseBlockEditorEngineBlockSelectionLayoutArgs = {
+  blockHandleRailMetricsRef: MutableRefObject<{ width: number; height: number }>
+  blockSelectionLayoutRectCacheRef: MutableRefObject<Map<number, { element: HTMLElement; rect: DOMRect }>>
+  clickedBlockIndex: number | null
+  draggedBlockState: DraggedBlockState
+  dropIndicatorState: DropIndicatorState
+  editor: TiptapEditor | null
+  getContentRoot: () => HTMLElement | null
+  getTopLevelBlockElementByIndex: (blockIndex: number) => HTMLElement | null
+  getTopLevelBlockElements: () => HTMLElement[]
+  hoveredBlockIndex: number | null
+  hoveredListItemContext: NestedListItemContext | null
+  isCoarsePointer: boolean
+  isTableAffordanceVisible: boolean
+  isTableStructuralSelection: boolean
+  isTopLevelBlockHandleEligible: (blockIndex: number) => boolean
+  keyboardBlockSelectionStickyRef: MutableRefObject<boolean>
+  resolveEffectiveSelectedListItemContext: (editor?: TiptapEditor | null) => NestedListItemContext | null
+  selectedBlockIndex: number | null
+  selectedBlockNodeIndex: number | null
+  selectionTick: number
+  setBlockHandleState: SetState<TopLevelBlockHandleState>
+  setBlockSelectionOverlayState: SetState<BlockSelectionOverlayState>
+  tableMenuState: unknown
+  textSelectionBlockIndex: number | null
+  viewportRef: RefObject<HTMLDivElement | null>
+}
+
+const useBlockSelectionLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect
+
+export const useBlockEditorEngineBlockSelectionLayout = ({
+  blockHandleRailMetricsRef,
+  blockSelectionLayoutRectCacheRef,
+  clickedBlockIndex,
+  draggedBlockState,
+  dropIndicatorState,
+  editor,
+  getContentRoot,
+  getTopLevelBlockElementByIndex,
+  getTopLevelBlockElements,
+  hoveredBlockIndex,
+  hoveredListItemContext,
+  isCoarsePointer,
+  isTableAffordanceVisible,
+  isTableStructuralSelection,
+  isTopLevelBlockHandleEligible,
+  keyboardBlockSelectionStickyRef,
+  resolveEffectiveSelectedListItemContext,
+  selectedBlockIndex,
+  selectedBlockNodeIndex,
+  selectionTick,
+  setBlockHandleState,
+  setBlockSelectionOverlayState,
+  tableMenuState,
+  textSelectionBlockIndex,
+  viewportRef,
+}: UseBlockEditorEngineBlockSelectionLayoutArgs) => {
+  useBlockSelectionLayoutEffect(() => {
+    if (!editor) return
+    const viewportRect = viewportRef.current?.getBoundingClientRect() ?? null
+    const handlePositionMode = isCoarsePointer ? "viewport" : "editor-local"
+    const rectCache = blockSelectionLayoutRectCacheRef.current
+    rectCache.clear()
+    const selectedNestedListItemContext = resolveEffectiveSelectedListItemContext(editor)
+    const resolveCachedBlockRect = (index: number) => {
+      const cached = rectCache.get(index)
+      if (cached) return cached
+      const element = getTopLevelBlockElementByIndex(index)
+      if (!element) return null
+      const next = { element, rect: element.getBoundingClientRect() }
+      rectCache.set(index, next)
+      return next
+    }
+    if (selectedNestedListItemContext?.listItemElement?.isConnected) {
+      const rect = selectedNestedListItemContext.listItemElement.getBoundingClientRect()
+      const nextOverlayState: BlockSelectionOverlayState = resolveBlockSelectionOverlayLayout(rect, viewportRect)
+      setBlockSelectionOverlayState((prev) =>
+        isStableBlockSelectionOverlayState(prev, nextOverlayState) ? prev : nextOverlayState
+      )
+    } else {
+      const overlayIndex =
+        selectedBlockNodeIndex !== null
+          ? selectedBlockNodeIndex
+          : clickedBlockIndex
+      if (overlayIndex === null) {
+        setBlockSelectionOverlayState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
+      } else {
+        const overlayTarget = resolveCachedBlockRect(overlayIndex)
+        if (!overlayTarget) {
+          setBlockSelectionOverlayState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
+        } else {
+          const { rect } = overlayTarget
+          const nextOverlayState: BlockSelectionOverlayState = resolveBlockSelectionOverlayLayout(rect, viewportRect)
+          setBlockSelectionOverlayState((prev) =>
+            isStableBlockSelectionOverlayState(prev, nextOverlayState) ? prev : nextOverlayState
+          )
+        }
+      }
+    }
+
+    const stickySelectionActive =
+      !isCoarsePointer && selectedBlockNodeIndex !== null && keyboardBlockSelectionStickyRef.current
+    const effectiveSelectedListItemContext = resolveEffectiveSelectedListItemContext(editor)
+    const activeListItemContext =
+      hoveredListItemContext?.listItemElement?.isConnected
+        ? hoveredListItemContext
+        : effectiveSelectedListItemContext?.listItemElement?.isConnected
+          ? effectiveSelectedListItemContext
+          : null
+    const blockIndex = activeListItemContext
+      ? activeListItemContext.listBlockIndex
+      : isCoarsePointer
+        ? selectedBlockIndex
+        : stickySelectionActive
+          ? selectedBlockNodeIndex
+          : textSelectionBlockIndex ?? hoveredBlockIndex
+    const hideBlockHandle = () =>
+      setBlockHandleState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
+    const hasOuterBlockSelectionIntent = blockIndex !== null
+    if (
+      (isTableStructuralSelection && !hasOuterBlockSelectionIntent) ||
+      (isTableAffordanceVisible && !hasOuterBlockSelectionIntent) ||
+      tableMenuState
+    ) {
+      hideBlockHandle()
+      return
+    }
+    if (blockIndex === null) {
+      hideBlockHandle()
+      return
+    }
+    const { width: railWidth, height: railHeight } = blockHandleRailMetricsRef.current
+    if (activeListItemContext?.listItemElement?.isConnected) {
+      const rect = activeListItemContext.listItemElement.getBoundingClientRect()
+      const railLayout = resolveBlockHandleRailLayoutForSurface(
+        rect,
+        railWidth,
+        railHeight,
+        resolveBlockHandleAnchorTop(activeListItemContext.listItemElement, railHeight),
+        viewportRect,
+        handlePositionMode
+      )
+      const nextState: TopLevelBlockHandleState = {
+        visible: true,
+        kind: "list-item",
+        blockIndex: activeListItemContext.listBlockIndex,
+        listPath: [...activeListItemContext.listPath],
+        itemIndex: activeListItemContext.itemIndex,
+        left: railLayout.left,
+        top: railLayout.top,
+        bottom: resolveBlockChromeTop(rect.bottom + 12, viewportRect, handlePositionMode),
+        width: rect.width,
+      }
+      setBlockHandleState((prev) => (isStableBlockHandleState(prev, nextState) ? prev : nextState))
+      rectCache.clear()
+      return
+    }
+
+    const blockTarget = resolveCachedBlockRect(blockIndex)
+    const blockElement = blockTarget?.element ?? null
+    const canShowHandle = isTopLevelBlockHandleEligible(blockIndex)
+    const shouldShow = Boolean(blockElement && canShowHandle && (isCoarsePointer || stickySelectionActive || textSelectionBlockIndex !== null || hoveredBlockIndex !== null))
+
+    if (!shouldShow || !blockElement) {
+      hideBlockHandle()
+      return
+    }
+
+    const rect = blockTarget?.rect ?? blockElement.getBoundingClientRect()
+    const blocks = ((editor.getJSON() as BlockEditorDoc).content ?? []) as BlockEditorDoc[]
+    const blockNode = blocks[blockIndex]
+    const anchoredTop = shouldUseThinBlockHandleAnchor(blockNode)
+      ? resolveThinBlockHandleAnchorTop(blockElement, railHeight)
+      : shouldCenterBlockHandleForNode(blockNode)
+        ? resolveBlockHandleAnchorTop(blockElement, railHeight)
+        : rect.top + 6
+    const railLayout = resolveBlockHandleRailLayoutForSurface(
+      rect,
+      railWidth,
+      railHeight,
+      anchoredTop,
+      viewportRect,
+      handlePositionMode
+    )
+    const nextState: TopLevelBlockHandleState = {
+      visible: true,
+      kind: "top-level",
+      blockIndex,
+      listPath: [],
+      itemIndex: null,
+      left: railLayout.left,
+      top: railLayout.top,
+      bottom: resolveBlockChromeTop(rect.bottom + 12, viewportRect, handlePositionMode),
+      width: rect.width,
+    }
+
+    setBlockHandleState((prev) => (isStableBlockHandleState(prev, nextState) ? prev : nextState))
+    rectCache.clear()
+  }, [
+    blockHandleRailMetricsRef,
+    blockSelectionLayoutRectCacheRef,
+    clickedBlockIndex,
+    editor,
+    getTopLevelBlockElementByIndex,
+    hoveredBlockIndex,
+    hoveredListItemContext,
+    isCoarsePointer,
+    isTableAffordanceVisible,
+    isTableStructuralSelection,
+    isTopLevelBlockHandleEligible,
+    keyboardBlockSelectionStickyRef,
+    resolveEffectiveSelectedListItemContext,
+    selectedBlockIndex,
+    selectedBlockNodeIndex,
+    selectionTick,
+    setBlockHandleState,
+    setBlockSelectionOverlayState,
+    tableMenuState,
+    textSelectionBlockIndex,
+    viewportRef,
+  ])
+
+  useEffect(() => {
+    const elements = getTopLevelBlockElements()
+    const root = getContentRoot()
+    const listItems = root ? Array.from(root.querySelectorAll<HTMLElement>(LIST_ITEM_SELECTOR)) : []
+
+    elements.forEach((element, index) => {
+      if (hoveredListItemContext) {
+        element.removeAttribute("data-block-hovered")
+      } else if (index === hoveredBlockIndex && !draggedBlockState) {
+        element.setAttribute("data-block-hovered", "true")
+      } else {
+        element.removeAttribute("data-block-hovered")
+      }
+
+      if (draggedBlockState && index === draggedBlockState.sourceIndex) {
+        element.setAttribute("data-block-dragging", "true")
+      } else {
+        element.removeAttribute("data-block-dragging")
+      }
+
+      element.removeAttribute("data-block-drop-target")
+    })
+
+    listItems.forEach((element) => {
+      if (
+        hoveredListItemContext &&
+        !draggedBlockState &&
+        isSameNestedListItemContext(hoveredListItemContext, {
+          ...hoveredListItemContext,
+          listItemElement: element,
+          listElement: hoveredListItemContext.listElement,
+          listItems: hoveredListItemContext.listItems,
+        }) &&
+        element === hoveredListItemContext.listItemElement
+      ) {
+        element.setAttribute("data-block-hovered", "true")
+      } else {
+        element.removeAttribute("data-block-hovered")
+      }
+
+      element.removeAttribute("data-block-dragging")
+      element.removeAttribute("data-block-drop-target")
+    })
+
+    return () => {
+      elements.forEach((element) => {
+        element.removeAttribute("data-block-hovered")
+        element.removeAttribute("data-block-dragging")
+        element.removeAttribute("data-block-drop-target")
+      })
+      listItems.forEach((element) => {
+        element.removeAttribute("data-block-hovered")
+        element.removeAttribute("data-block-dragging")
+        element.removeAttribute("data-block-drop-target")
+      })
+    }
+  }, [draggedBlockState, dropIndicatorState.insertionIndex, getContentRoot, getTopLevelBlockElements, hoveredBlockIndex, hoveredListItemContext])
+}

--- a/front/src/components/editor/useBlockEditorEngineBlockSelectionUi.ts
+++ b/front/src/components/editor/useBlockEditorEngineBlockSelectionUi.ts
@@ -1,5 +1,5 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
-import { useCallback, useEffect, useLayoutEffect } from "react"
+import { useCallback } from "react"
 import type {
   Dispatch,
   KeyboardEvent as ReactKeyboardEvent,
@@ -15,32 +15,22 @@ import {
   BLOCK_OUTER_SELECT_VERTICAL_MARGIN_PX,
   getTopLevelBlockIndexFromSelection,
   isTabBlockSelectionEligible,
-  isStableBlockHandleState,
-  isStableBlockSelectionOverlayState,
   type BlockSelectionOverlayState,
   type BlockSelectionPointerEventLike,
   type TopLevelBlockHandleState,
 } from "./blockSelectionModel"
 import {
-  resolveBlockHandleAnchorTop,
-  resolveBlockChromeTop,
-  resolveBlockHandleRailLayoutForSurface,
-  resolveBlockSelectionOverlayLayout,
-  resolveThinBlockHandleAnchorTop,
   preserveWindowScrollForEditorPointerFocus,
-  shouldCenterBlockHandleForNode,
-  shouldUseThinBlockHandleAnchor,
 } from "./blockHandleLayoutModel"
 import {
-  LIST_ITEM_SELECTOR,
   type NestedListItemContext,
-  isSameNestedListItemContext,
   selectNestedListItemNode,
   selectNestedListItemTextAnchor,
 } from "./nestedListItemModel"
 import { isTableSelectionActive } from "./tableStructureModel"
 import type { DraggedBlockState, DropIndicatorState } from "./blockDragModel"
 import type { BlockEditorBlockMenuState, BlockEditorSlashMenuState } from "./BlockEditorEngine.layers"
+import { useBlockEditorEngineBlockSelectionLayout } from "./useBlockEditorEngineBlockSelectionLayout"
 
 type SetState<T> = Dispatch<SetStateAction<T>>
 
@@ -128,8 +118,6 @@ type UseBlockEditorEngineBlockSelectionUiArgs = {
   viewportRef: RefObject<HTMLDivElement | null>
 }
 
-const useBlockSelectionLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect
-
 export const useBlockEditorEngineBlockSelectionUi = ({
   blockHandleRailMetricsRef,
   blockHandleState,
@@ -203,153 +191,16 @@ export const useBlockEditorEngineBlockSelectionUi = ({
   textSelectionBlockIndex,
   viewportRef,
 }: UseBlockEditorEngineBlockSelectionUiArgs) => {
-  useBlockSelectionLayoutEffect(() => {
-    if (!editor) return
-    const viewportRect = viewportRef.current?.getBoundingClientRect() ?? null
-    const handlePositionMode = isCoarsePointer ? "viewport" : "editor-local"
-    const rectCache = blockSelectionLayoutRectCacheRef.current
-    rectCache.clear()
-    const selectedNestedListItemContext = resolveEffectiveSelectedListItemContext(editor)
-    const resolveCachedBlockRect = (index: number) => {
-      const cached = rectCache.get(index)
-      if (cached) return cached
-      const element = getTopLevelBlockElementByIndex(index)
-      if (!element) return null
-      const next = { element, rect: element.getBoundingClientRect() }
-      rectCache.set(index, next)
-      return next
-    }
-    if (selectedNestedListItemContext?.listItemElement?.isConnected) {
-      const rect = selectedNestedListItemContext.listItemElement.getBoundingClientRect()
-      const nextOverlayState: BlockSelectionOverlayState = resolveBlockSelectionOverlayLayout(rect, viewportRect)
-      setBlockSelectionOverlayState((prev) =>
-        isStableBlockSelectionOverlayState(prev, nextOverlayState) ? prev : nextOverlayState
-      )
-    } else {
-      const overlayIndex =
-        selectedBlockNodeIndex !== null
-          ? selectedBlockNodeIndex
-          : clickedBlockIndex
-      if (overlayIndex === null) {
-        setBlockSelectionOverlayState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
-      } else {
-        const overlayTarget = resolveCachedBlockRect(overlayIndex)
-        if (!overlayTarget) {
-          setBlockSelectionOverlayState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
-        } else {
-          const { rect } = overlayTarget
-          const nextOverlayState: BlockSelectionOverlayState = resolveBlockSelectionOverlayLayout(rect, viewportRect)
-          setBlockSelectionOverlayState((prev) =>
-            isStableBlockSelectionOverlayState(prev, nextOverlayState) ? prev : nextOverlayState
-          )
-        }
-      }
-    }
-
-    const stickySelectionActive =
-      !isCoarsePointer && selectedBlockNodeIndex !== null && keyboardBlockSelectionStickyRef.current
-    const effectiveSelectedListItemContext = resolveEffectiveSelectedListItemContext(editor)
-    const activeListItemContext =
-      hoveredListItemContext?.listItemElement?.isConnected
-        ? hoveredListItemContext
-        : effectiveSelectedListItemContext?.listItemElement?.isConnected
-          ? effectiveSelectedListItemContext
-          : null
-    const blockIndex = activeListItemContext
-      ? activeListItemContext.listBlockIndex
-      : isCoarsePointer
-        ? selectedBlockIndex
-        : stickySelectionActive
-          ? selectedBlockNodeIndex
-          : textSelectionBlockIndex ?? hoveredBlockIndex
-    const hideBlockHandle = () =>
-      setBlockHandleState((prev) => (prev.visible ? { ...prev, visible: false } : prev))
-    const hasOuterBlockSelectionIntent = blockIndex !== null
-    if (
-      (isTableStructuralSelection && !hasOuterBlockSelectionIntent) ||
-      (isTableAffordanceVisible && !hasOuterBlockSelectionIntent) ||
-      tableMenuState
-    ) {
-      hideBlockHandle()
-      return
-    }
-    if (blockIndex === null) {
-      hideBlockHandle()
-      return
-    }
-    const { width: railWidth, height: railHeight } = blockHandleRailMetricsRef.current
-    if (activeListItemContext?.listItemElement?.isConnected) {
-      const rect = activeListItemContext.listItemElement.getBoundingClientRect()
-      const railLayout = resolveBlockHandleRailLayoutForSurface(
-        rect,
-        railWidth,
-        railHeight,
-        resolveBlockHandleAnchorTop(activeListItemContext.listItemElement, railHeight),
-        viewportRect,
-        handlePositionMode
-      )
-      const nextState: TopLevelBlockHandleState = {
-        visible: true,
-        kind: "list-item",
-        blockIndex: activeListItemContext.listBlockIndex,
-        listPath: [...activeListItemContext.listPath],
-        itemIndex: activeListItemContext.itemIndex,
-        left: railLayout.left,
-        top: railLayout.top,
-        bottom: resolveBlockChromeTop(rect.bottom + 12, viewportRect, handlePositionMode),
-        width: rect.width,
-      }
-      setBlockHandleState((prev) => (isStableBlockHandleState(prev, nextState) ? prev : nextState))
-      rectCache.clear()
-      return
-    }
-
-    const blockTarget = resolveCachedBlockRect(blockIndex)
-    const blockElement = blockTarget?.element ?? null
-    const canShowHandle = isTopLevelBlockHandleEligible(blockIndex)
-    const shouldShow = Boolean(blockElement && canShowHandle && (isCoarsePointer || stickySelectionActive || textSelectionBlockIndex !== null || hoveredBlockIndex !== null))
-
-    if (!shouldShow || !blockElement) {
-      hideBlockHandle()
-      return
-    }
-
-    const rect = blockTarget?.rect ?? blockElement.getBoundingClientRect()
-    const blocks = ((editor.getJSON() as BlockEditorDoc).content ?? []) as BlockEditorDoc[]
-    const blockNode = blocks[blockIndex]
-    const anchoredTop = shouldUseThinBlockHandleAnchor(blockNode)
-      ? resolveThinBlockHandleAnchorTop(blockElement, railHeight)
-      : shouldCenterBlockHandleForNode(blockNode)
-        ? resolveBlockHandleAnchorTop(blockElement, railHeight)
-        : rect.top + 6
-    const railLayout = resolveBlockHandleRailLayoutForSurface(
-      rect,
-      railWidth,
-      railHeight,
-      anchoredTop,
-      viewportRect,
-      handlePositionMode
-    )
-    const nextState: TopLevelBlockHandleState = {
-      visible: true,
-      kind: "top-level",
-      blockIndex,
-      listPath: [],
-      itemIndex: null,
-      left: railLayout.left,
-      top: railLayout.top,
-      bottom: resolveBlockChromeTop(rect.bottom + 12, viewportRect, handlePositionMode),
-      width: rect.width,
-    }
-
-    setBlockHandleState((prev) => (isStableBlockHandleState(prev, nextState) ? prev : nextState))
-    rectCache.clear()
-  }, [
+  useBlockEditorEngineBlockSelectionLayout({
     blockHandleRailMetricsRef,
     blockSelectionLayoutRectCacheRef,
     clickedBlockIndex,
+    draggedBlockState,
+    dropIndicatorState,
     editor,
+    getContentRoot,
     getTopLevelBlockElementByIndex,
+    getTopLevelBlockElements,
     hoveredBlockIndex,
     hoveredListItemContext,
     isCoarsePointer,
@@ -366,65 +217,7 @@ export const useBlockEditorEngineBlockSelectionUi = ({
     tableMenuState,
     textSelectionBlockIndex,
     viewportRef,
-  ])
-
-  useEffect(() => {
-    const elements = getTopLevelBlockElements()
-    const root = getContentRoot()
-    const listItems = root ? Array.from(root.querySelectorAll<HTMLElement>(LIST_ITEM_SELECTOR)) : []
-
-    elements.forEach((element, index) => {
-      if (hoveredListItemContext) {
-        element.removeAttribute("data-block-hovered")
-      } else if (index === hoveredBlockIndex && !draggedBlockState) {
-        element.setAttribute("data-block-hovered", "true")
-      } else {
-        element.removeAttribute("data-block-hovered")
-      }
-
-      if (draggedBlockState && index === draggedBlockState.sourceIndex) {
-        element.setAttribute("data-block-dragging", "true")
-      } else {
-        element.removeAttribute("data-block-dragging")
-      }
-
-      element.removeAttribute("data-block-drop-target")
-    })
-
-    listItems.forEach((element) => {
-      if (
-        hoveredListItemContext &&
-        !draggedBlockState &&
-        isSameNestedListItemContext(hoveredListItemContext, {
-          ...hoveredListItemContext,
-          listItemElement: element,
-          listElement: hoveredListItemContext.listElement,
-          listItems: hoveredListItemContext.listItems,
-        }) &&
-        element === hoveredListItemContext.listItemElement
-      ) {
-        element.setAttribute("data-block-hovered", "true")
-      } else {
-        element.removeAttribute("data-block-hovered")
-      }
-
-      element.removeAttribute("data-block-dragging")
-      element.removeAttribute("data-block-drop-target")
-    })
-
-    return () => {
-      elements.forEach((element) => {
-        element.removeAttribute("data-block-hovered")
-        element.removeAttribute("data-block-dragging")
-        element.removeAttribute("data-block-drop-target")
-      })
-      listItems.forEach((element) => {
-        element.removeAttribute("data-block-hovered")
-        element.removeAttribute("data-block-dragging")
-        element.removeAttribute("data-block-drop-target")
-      })
-    }
-  }, [draggedBlockState, dropIndicatorState.insertionIndex, getContentRoot, getTopLevelBlockElements, hoveredBlockIndex, hoveredListItemContext])
+  })
 
   const syncViewportHoverState = useCallback(
     (targetEvent: EventTarget | null, clientX: number, clientY: number) => {

--- a/front/src/components/editor/useBlockEditorEngineController.ts
+++ b/front/src/components/editor/useBlockEditorEngineController.ts
@@ -1,21 +1,10 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
 import { useEditor } from "@tiptap/react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useMemo, useRef } from "react"
 import {
-  deleteTopLevelBlockAt,
-} from "./blockDocumentOps"
-import {
-  createFileBlockNode,
   parseMarkdownToEditorDoc,
   restoreEditorDocCodeBlocksFromMarkdown,
-  type BlockEditorDoc,
 } from "./serialization"
-import {
-  convertHtmlToMarkdown,
-  extractPlainTextFromHtml,
-  looksLikeStructuredMarkdownDocument,
-  normalizeStructuredMarkdownClipboard,
-} from "src/libs/markdown/htmlToMarkdown"
 import {
   captureEmptyEditorHistoryState,
   type EditorHistorySnapshot,
@@ -27,73 +16,34 @@ import {
   createWriterEditorExtensions,
 } from "./writerEditorPreset"
 import {
-  TABLE_OVERFLOW_MODE_WIDE,
   TABLE_WIDTH_BUDGET_META_KEY,
-  promotePastedWideTables,
 } from "./tableWidthModel"
 import {
-  getCurrentEditorReadableWidthPx,
   normalizeRenderedTableWidthsToReadableBudget,
   normalizeTableWidthsToReadableBudget,
   promoteLargeTablesToWideOverflowMode,
   rebalanceStructurallyChangedNormalTableWidths,
   syncRenderedTableOverflowModes,
 } from "./tableWidthRuntime"
-import {
-  isTableSelectionActive,
-} from "./tableStructureModel"
-import { normalizeTableContextPasteText } from "./tablePasteModel"
-import {
-  getTopLevelBlockIndexFromSelection,
-  isTabBlockSelectionEligible,
-  type BlockSelectionOverlayState,
-  type TopLevelBlockHandleState,
-} from "./blockSelectionModel"
-import {
-  type DraggedBlockState,
-  type DropIndicatorState,
-  type PendingBlockDragState,
-  createHiddenDropIndicatorState,
-} from "./blockDragModel"
-import {
-  type NestedListItemContext,
-} from "./nestedListItemModel"
-import {
-  type DraggedNestedListItemState,
-  type NestedListItemDropIndicatorState,
-  type PendingNestedListItemHandleDragState,
-  createHiddenNestedListItemDropIndicatorState,
-} from "./nestedListItemDragModel"
 import { useBlockEditorMarkdownCommit } from "./useBlockEditorMarkdownCommit"
-import {
-  runBlockToolbarCommand,
-} from "./blockToolbarModel"
-import {
-  runInlineMarkCommand,
-} from "./inlineToolbarModel"
-import {
-  useFloatingBubbleState,
-} from "./useFloatingBubbleState"
 import { recordEditorCommitDurationForRuntimeGuard } from "./editorRuntimeGuardModel"
-import type {
-  BlockEditorBlockMenuState,
-  BlockEditorSlashMenuState,
-} from "./BlockEditorEngine.layers"
 import { useBlockEditorTableOverlayController } from "./useBlockEditorTableOverlayController"
 import { useBlockEditorEngineBlockDrag } from "./useBlockEditorEngineBlockDrag"
 import { useBlockEditorEngineBlockSelectionUi } from "./useBlockEditorEngineBlockSelectionUi"
 import {
   downgradeDisabledFeatureNodes,
-  isPrimaryModifierPressed,
   normalizeTableColorInputValue,
   useBlockEditorEngineDocumentOps,
 } from "./useBlockEditorEngineDocumentOps"
+import {
+  handleBlockEditorEngineKeyDown,
+  handleBlockEditorEnginePaste,
+} from "./useBlockEditorEngineControllerEditorHandlers"
+import { useBlockEditorEngineControllerState } from "./useBlockEditorEngineControllerState"
 import { useBlockEditorEngineInsertActions } from "./useBlockEditorEngineInsertActions"
 import { useBlockEditorEngineSelectionEffects } from "./useBlockEditorEngineSelectionEffects"
 import { useBlockEditorEngineSelectionTools } from "./useBlockEditorEngineSelectionTools"
 import { useBlockEditorEngineSlashMenu } from "./useBlockEditorEngineSlashMenu"
-
-const BLOCK_HANDLE_MEDIA_QUERY = "(pointer: coarse)"
 
 export const useBlockEditorEngineController = ({
   value,
@@ -107,128 +57,38 @@ export const useBlockEditorEngineController = ({
   onQaActionsReady,
 }: BlockEditorEngineProps) => {
   const isWriterSurface = typeof className === "string" && className.includes("aq-block-editor--writer-surface")
-  const imageFileInputRef = useRef<HTMLInputElement>(null)
-  const attachmentFileInputRef = useRef<HTMLInputElement>(null)
-  const inlineColorMenuRef = useRef<HTMLDetailsElement>(null)
-  const bubbleTextStyleMenuRef = useRef<HTMLDetailsElement>(null)
-  const bubbleInlineColorMenuRef = useRef<HTMLDetailsElement>(null)
-  const slashMenuRef = useRef<HTMLDivElement>(null)
-  const viewportRef = useRef<HTMLDivElement>(null)
-  const blockHandleRailRef = useRef<HTMLDivElement>(null)
-  const pendingBlockDragRef = useRef<PendingBlockDragState | null>(null)
-  const pendingBlockDragCleanupRef = useRef<(() => void) | null>(null)
-  const pendingNestedListItemHandleDragRef = useRef<PendingNestedListItemHandleDragState | null>(null)
-  const pendingNestedListItemHandleDragCleanupRef = useRef<(() => void) | null>(null)
-  const skipNextPointerDownSelectionClearRef = useRef(false)
-  const pendingImageInsertIndexRef = useRef<number | null>(null)
-  const pendingAttachmentInsertIndexRef = useRef<number | null>(null)
-  const tableViewportBudgetNormalizeFrameRef = useRef<number | null>(null)
-  const editorRef = useRef<TiptapEditor | null>(null)
-  const hoveredBlockClearTimerRef = useRef<number | null>(null)
-  const mouseTextSelectionInProgressRef = useRef(false)
-  const syncBubbleOnMouseUpRef = useRef(false)
-  const [isPreviewOpen, setIsPreviewOpen] = useState(false)
-  const [isSlashMenuOpen, setIsSlashMenuOpen] = useState(false)
-  const [slashQuery, setSlashQuery] = useState("")
-  const [selectedSlashIndex, setSelectedSlashIndex] = useState(0)
-  const [slashMenuState, setSlashMenuState] = useState<BlockEditorSlashMenuState>(null)
-  const [recentSlashItemIds, setRecentSlashItemIds] = useState<string[]>([])
-  const [isSlashImeComposing, setIsSlashImeComposing] = useState(false)
-  const [slashInteractionMode, setSlashInteractionMode] = useState<"keyboard" | "pointer">("keyboard")
-  const slashPointerResumeAtRef = useRef(0)
-  const [isToolbarMoreOpen, setIsToolbarMoreOpen] = useState(false)
-  const [isInlineColorMenuOpen, setIsInlineColorMenuOpen] = useState(false)
-  const [isBubbleTextStyleMenuOpen, setIsBubbleTextStyleMenuOpen] = useState(false)
-  const [isBubbleInlineColorMenuOpen, setIsBubbleInlineColorMenuOpen] = useState(false)
-  const [blockMenuState, setBlockMenuState] = useState<BlockEditorBlockMenuState>(null)
-  const [isCoarsePointer, setIsCoarsePointer] = useState(false)
-  const [hoveredBlockIndex, setHoveredBlockIndex] = useState<number | null>(null)
-  const [hoveredListItemContext, setHoveredListItemContext] = useState<NestedListItemContext | null>(null)
-  const [selectedListItemContext, setSelectedListItemContext] = useState<NestedListItemContext | null>(null)
-  const selectedListItemContextRef = useRef<NestedListItemContext | null>(null)
-  const [selectedBlockIndex, setSelectedBlockIndex] = useState<number | null>(null)
-  const [clickedBlockIndex, setClickedBlockIndex] = useState<number | null>(null)
-  const [selectedBlockNodeIndex, setSelectedBlockNodeIndex] = useState<number | null>(null)
-  const [textSelectionBlockIndex, setTextSelectionBlockIndex] = useState<number | null>(null)
-  const selectedBlockNodeIndexRef = useRef<number | null>(null)
-  const keyboardBlockSelectionStickyRef = useRef(false)
-  const [blockHandleState, setBlockHandleState] = useState<TopLevelBlockHandleState>({
-    visible: false,
-    kind: "top-level",
-    blockIndex: 0,
-    listPath: [],
-    itemIndex: null,
-    left: 0,
-    top: 0,
-    bottom: 0,
-    width: 0,
-  })
-  const [blockSelectionOverlayState, setBlockSelectionOverlayState] = useState<BlockSelectionOverlayState>({
-    visible: false,
-    left: 0,
-    top: 0,
-    width: 0,
-    height: 0,
-  })
   const {
-    bubbleState,
-    setBubbleState,
-    bubbleToolbarHoveredRef,
-    cancelBubbleHide,
-    scheduleBubbleHide,
-  } = useFloatingBubbleState()
-  const [draggedBlockState, setDraggedBlockState] = useState<DraggedBlockState>(null)
-  const [dragGhostPosition, setDragGhostPosition] = useState<{ x: number; y: number } | null>(null)
-  const [dropIndicatorState, setDropIndicatorState] = useState<DropIndicatorState>(createHiddenDropIndicatorState)
-  const [draggedNestedListItemState, setDraggedNestedListItemState] = useState<DraggedNestedListItemState>(null)
-  const [nestedListItemDropIndicatorState, setNestedListItemDropIndicatorState] =
-    useState<NestedListItemDropIndicatorState>(createHiddenNestedListItemDropIndicatorState)
-  const [selectionTick, setSelectionTick] = useState(0)
-
-  const selectionUiSignatureRef = useRef("")
-  const blockSelectionLayoutRectCacheRef = useRef(new Map<number, { element: HTMLElement; rect: DOMRect }>())
-  const blockHandleRailMetricsRef = useRef({ width: 54, height: 40 })
-
-  useEffect(() => {
-    const railElement = blockHandleRailRef.current
-    if (!railElement || typeof ResizeObserver === "undefined") return
-
-    const syncRailMetrics = () => {
-      blockHandleRailMetricsRef.current = {
-        width: railElement.offsetWidth || 54,
-        height: railElement.offsetHeight || 40,
-      }
-    }
-
-    syncRailMetrics()
-    const observer = new ResizeObserver(syncRailMetrics)
-    observer.observe(railElement)
-    return () => observer.disconnect()
-  }, [])
-
-  const cancelHoveredBlockClear = useCallback(() => {
-    if (hoveredBlockClearTimerRef.current !== null && typeof window !== "undefined") {
-      window.clearTimeout(hoveredBlockClearTimerRef.current)
-      hoveredBlockClearTimerRef.current = null
-    }
-  }, [])
-
-  const scheduleHoveredBlockClear = useCallback(() => {
-    cancelHoveredBlockClear()
-    if (typeof window === "undefined") return
-    hoveredBlockClearTimerRef.current = window.setTimeout(() => {
-      setHoveredBlockIndex(null)
-      setHoveredListItemContext(null)
-      hoveredBlockClearTimerRef.current = null
-    }, 260)
-  }, [cancelHoveredBlockClear])
+    attachmentFileInputRef, blockHandleRailMetricsRef, blockHandleRailRef, blockHandleState,
+    blockMenuState, blockSelectionLayoutRectCacheRef, blockSelectionOverlayState, bubbleInlineColorMenuRef,
+    bubbleState, bubbleTextStyleMenuRef, bubbleToolbarHoveredRef, cancelBubbleHide, cancelHoveredBlockClear,
+    clickedBlockIndex, dragGhostPosition, draggedBlockState, draggedNestedListItemState, dropIndicatorState,
+    editorRef, hoveredBlockIndex, hoveredListItemContext, imageFileInputRef, inlineColorMenuRef,
+    isBubbleInlineColorMenuOpen, isBubbleTextStyleMenuOpen, isCoarsePointer, isInlineColorMenuOpen,
+    isPreviewOpen, isSlashImeComposing, isSlashMenuOpen, isToolbarMoreOpen, keyboardBlockSelectionStickyRef,
+    mouseTextSelectionInProgressRef, nestedListItemDropIndicatorState, pendingAttachmentInsertIndexRef,
+    pendingBlockDragCleanupRef, pendingBlockDragRef, pendingImageInsertIndexRef,
+    pendingNestedListItemHandleDragCleanupRef, pendingNestedListItemHandleDragRef, recentSlashItemIds,
+    scheduleBubbleHide, scheduleHoveredBlockClear, selectedBlockIndex, selectedBlockNodeIndex,
+    selectedBlockNodeIndexRef, selectedListItemContext, selectedListItemContextRef, selectedSlashIndex,
+    selectionTick, selectionUiSignatureRef, setBlockHandleState, setBlockMenuState,
+    setBlockSelectionOverlayState, setBubbleState, setClickedBlockIndex, setDragGhostPosition,
+    setDraggedBlockState, setDraggedNestedListItemState, setDropIndicatorState, setHoveredBlockIndex,
+    setHoveredListItemContext, setIsBubbleInlineColorMenuOpen, setIsBubbleTextStyleMenuOpen,
+    setIsInlineColorMenuOpen, setIsPreviewOpen, setIsSlashImeComposing, setIsSlashMenuOpen,
+    setIsToolbarMoreOpen, setNestedListItemDropIndicatorState, setRecentSlashItemIds,
+    setSelectedBlockIndex, setSelectedBlockNodeIndex, setSelectedListItemContext, setSelectedSlashIndex,
+    setSelectionTick, setSlashInteractionMode, setSlashMenuState, setSlashQuery, setTextSelectionBlockIndex,
+    skipNextPointerDownSelectionClearRef, slashInteractionMode, slashMenuRef, slashMenuState,
+    slashPointerResumeAtRef, slashQuery, syncBubbleOnMouseUpRef, tableViewportBudgetNormalizeFrameRef,
+    textSelectionBlockIndex, viewportRef,
+  } = useBlockEditorEngineControllerState()
 
   const cancelScheduledTableViewportBudgetNormalize = useCallback(() => {
     if (tableViewportBudgetNormalizeFrameRef.current !== null && typeof window !== "undefined") {
       window.cancelAnimationFrame(tableViewportBudgetNormalizeFrameRef.current)
       tableViewportBudgetNormalizeFrameRef.current = null
     }
-  }, [])
+  }, [tableViewportBudgetNormalizeFrameRef])
 
   const scheduleTableViewportBudgetNormalize = useCallback(
     (nextEditor: TiptapEditor) => {
@@ -241,7 +101,7 @@ export const useBlockEditorEngineController = ({
         normalizeRenderedTableWidthsToReadableBudget(targetEditor)
       })
     },
-    [cancelScheduledTableViewportBudgetNormalize]
+    [cancelScheduledTableViewportBudgetNormalize, editorRef, tableViewportBudgetNormalizeFrameRef]
   )
 
   const {
@@ -343,260 +203,38 @@ export const useBlockEditorEngineController = ({
       handleKeyDown: (_, event) => {
         const currentEditor = editorRef.current
         if (!currentEditor) return false
-        if (event.defaultPrevented) return false
-        const normalizedKey = event.key.toLowerCase()
-        const hasPrimaryModifier = isPrimaryModifierPressed(event)
-        const selection = currentEditor.state.selection as typeof currentEditor.state.selection & {
-          node?: { isBlock?: boolean }
-        }
-        const isTopLevelBlockNodeSelection = Boolean(
-          selection.$from.depth === 0 && selection.node?.isBlock
-        )
-
-        if (
-          !hasPrimaryModifier &&
-          !event.altKey &&
-          !event.shiftKey &&
-          event.key === "Tab" &&
-          !isTopLevelBlockNodeSelection
-        ) {
-          const targetBlockIndex =
-            hoveredBlockIndex ??
-            findTopLevelBlockIndexFromTarget(event.target) ??
-            getTopLevelBlockIndexFromSelection(currentEditor)
-          if (!isTabBlockSelectionEligible(currentEditor, targetBlockIndex)) return false
-          event.preventDefault()
-          return promoteTopLevelBlockSelection(targetBlockIndex)
-        }
-
-        if (
-          !hasPrimaryModifier &&
-          !event.altKey &&
-          !event.shiftKey &&
-          (event.key === "Backspace" || event.key === "Delete") &&
-          (isTopLevelBlockNodeSelection || selectedBlockNodeIndexRef.current !== null)
-        ) {
-          event.preventDefault()
-          const blockIndex = selectedBlockNodeIndexRef.current ?? getTopLevelBlockIndexFromSelection(currentEditor)
-          const contentLength = (currentEditor.getJSON() as BlockEditorDoc).content?.length ?? 0
-          const nextFocusIndex = Math.max(0, Math.min(blockIndex, Math.max(contentLength - 2, 0)))
-          mutateTopLevelBlocks((doc) => deleteTopLevelBlockAt(doc, blockIndex), nextFocusIndex)
-          setBlockMenuState(null)
-          keyboardBlockSelectionStickyRef.current = false
-          setSelectedBlockNodeIndex(null)
-          syncSelectedBlockNodeSurface(null)
-          return true
-        }
-
-        if (hasPrimaryModifier && !event.altKey && !event.shiftKey && normalizedKey === "b") {
-          event.preventDefault()
-          runInlineMarkCommand(currentEditor, "bold")
-          return true
-        }
-
-        if (hasPrimaryModifier && !event.altKey && !event.shiftKey && normalizedKey === "i") {
-          event.preventDefault()
-          runInlineMarkCommand(currentEditor, "italic")
-          return true
-        }
-
-        if (hasPrimaryModifier && !event.altKey && !event.shiftKey && normalizedKey === "k") {
-          event.preventDefault()
-          openLinkPrompt()
-          return true
-        }
-
-        if (hasPrimaryModifier && event.altKey && !event.shiftKey && normalizedKey === "m") {
-          event.preventDefault()
-          insertInlineFormula()
-          return true
-        }
-
-        if (hasPrimaryModifier && !event.altKey && event.shiftKey && normalizedKey === "m") {
-          event.preventDefault()
-          insertFormulaBlock()
-          return true
-        }
-
-        if (hasPrimaryModifier && event.altKey && !event.shiftKey && normalizedKey === "2") {
-          event.preventDefault()
-          runBlockToolbarCommand(currentEditor, "heading-2")
-          return true
-        }
-
-        if (hasPrimaryModifier && event.altKey && !event.shiftKey && normalizedKey === "3") {
-          event.preventDefault()
-          runBlockToolbarCommand(currentEditor, "heading-3")
-          return true
-        }
-
-        if (hasPrimaryModifier && !event.altKey && event.shiftKey && normalizedKey === "7") {
-          event.preventDefault()
-          runBlockToolbarCommand(currentEditor, "ordered-list")
-          return true
-        }
-
-        if (hasPrimaryModifier && !event.altKey && event.shiftKey && normalizedKey === "8") {
-          event.preventDefault()
-          runBlockToolbarCommand(currentEditor, "bullet-list")
-          return true
-        }
-
-        if (hasPrimaryModifier && !event.altKey && event.shiftKey && normalizedKey === "9") {
-          event.preventDefault()
-          runBlockToolbarCommand(currentEditor, "quote")
-          return true
-        }
-
-        if (hasPrimaryModifier && !event.altKey && !event.shiftKey && normalizedKey === "z") {
-          event.preventDefault()
-          // Guard against OS key repeat causing multiple undo steps in one press.
-          if (event.repeat) return true
-          if (currentEditor.can().chain().focus().undo().run()) {
-            currentEditor.chain().focus().undo().run()
-          }
-          return true
-        }
-
-        if (hasPrimaryModifier && !event.altKey && event.shiftKey && normalizedKey === "z") {
-          event.preventDefault()
-          if (event.repeat) return true
-          if (currentEditor.can().chain().focus().redo().run()) {
-            currentEditor.chain().focus().redo().run()
-          }
-          return true
-        }
-
-        if (selectedBlockNodeIndexRef.current !== null) {
-          keyboardBlockSelectionStickyRef.current = false
-          setSelectedBlockNodeIndex(null)
-          syncSelectedBlockNodeSurface(null)
-        }
-
-        return false
+        return handleBlockEditorEngineKeyDown({
+          currentEditor,
+          event,
+          findTopLevelBlockIndexFromTarget,
+          hoveredBlockIndex,
+          insertFormulaBlock,
+          insertInlineFormula,
+          keyboardBlockSelectionStickyRef,
+          mutateTopLevelBlocks,
+          openLinkPrompt,
+          promoteTopLevelBlockSelection,
+          selectedBlockNodeIndexRef,
+          setBlockMenuState,
+          setSelectedBlockNodeIndex,
+          syncSelectedBlockNodeSurface,
+        })
       },
       handlePaste: (_, event) => {
         const currentEditor = editorRef.current
         if (!currentEditor) return false
-        const isTableContextPaste = isTableSelectionActive(currentEditor)
-
-        const clipboardFiles = Array.from(event.clipboardData?.files || [])
-        const imageFile = clipboardFiles.find((file) => file.type.startsWith("image/"))
-        if (imageFile && !isTableContextPaste) {
-          event.preventDefault()
-          void (async () => {
-            const imageAttrs = await onUploadImage(imageFile)
-            currentEditor
-              .chain()
-              .focus()
-              .insertContent([
-                {
-                  type: "resizableImage",
-                  attrs: {
-                    src: imageAttrs.src,
-                    alt: imageAttrs.alt || "",
-                    title: imageAttrs.title || "",
-                    widthPx: imageAttrs.widthPx ?? null,
-                    align: imageAttrs.align || "center",
-                  },
-                },
-                { type: "paragraph" },
-              ])
-              .run()
-          })()
-          return true
-        }
-
-        const attachmentFile = clipboardFiles.find((file) => !file.type.startsWith("image/"))
-        if (attachmentFile && onUploadFile && !isTableContextPaste) {
-          event.preventDefault()
-          void (async () => {
-            const fileAttrs = await onUploadFile(attachmentFile)
-            insertDocContent(
-              {
-                type: "doc",
-                content: [createFileBlockNode(fileAttrs), { type: "paragraph" }],
-              },
-              isSelectionInEmptyParagraph()
-            )
-          })()
-          return true
-        }
-
-        const plainText = event.clipboardData?.getData("text/plain") || ""
-        const html = event.clipboardData?.getData("text/html") || ""
-        const trimmedPlainText = plainText.trim()
-        const normalizedPlainText = normalizeStructuredMarkdownClipboard(plainText)
-        const normalizedHtmlMarkdown = html ? convertHtmlToMarkdown(html) : ""
-        const extractedPlainTextFromHtml = html ? extractPlainTextFromHtml(html) : ""
-        const calloutPasteText = plainText || extractedPlainTextFromHtml
-
-        if (calloutPasteText && replaceEmptyCalloutBodyWithPlainText(calloutPasteText)) {
-          event.preventDefault()
-          return true
-        }
-
-        if (isTableContextPaste) {
-          const normalizedTablePasteText = normalizeTableContextPasteText(
-            normalizedHtmlMarkdown,
-            normalizedPlainText,
-            extractedPlainTextFromHtml,
-            plainText
-          )
-          if (normalizedTablePasteText) {
-            event.preventDefault()
-            currentEditor.chain().focus().insertContent(normalizedTablePasteText).run()
-            return true
-          }
-        }
-
-        if (
-          isSelectionInEmptyParagraph() &&
-          trimmedPlainText &&
-          !trimmedPlainText.includes("\n") &&
-          isHttpUrl(trimmedPlainText)
-        ) {
-          event.preventDefault()
-          void insertCardBlockFromUrl(trimmedPlainText)
-          return true
-        }
-
-        if (html && normalizedHtmlMarkdown) {
-          event.preventDefault()
-          const parsedDoc = downgradeDisabledFeatureNodes(
-            parseMarkdownToEditorDoc(normalizedHtmlMarkdown),
-            enableMermaidBlocks
-          )
-          const readableWidthBudget = getCurrentEditorReadableWidthPx(currentEditor) - 2
-          return insertDocContent(
-            promotePastedWideTables(parsedDoc, readableWidthBudget),
-            isSelectionInEmptyParagraph()
-          )
-        }
-
-        if (normalizedPlainText && looksLikeStructuredMarkdownDocument(normalizedPlainText)) {
-          event.preventDefault()
-          const parsedDoc = downgradeDisabledFeatureNodes(
-            parseMarkdownToEditorDoc(normalizedPlainText),
-            enableMermaidBlocks
-          )
-          const readableWidthBudget = getCurrentEditorReadableWidthPx(currentEditor) - 2
-          return insertDocContent(
-            promotePastedWideTables(parsedDoc, readableWidthBudget),
-            isSelectionInEmptyParagraph()
-          )
-        }
-
-        if (html && !plainText.trim()) {
-          const extracted = extractedPlainTextFromHtml
-          if (extracted) {
-            event.preventDefault()
-            currentEditor.chain().focus().insertContent(extracted).run()
-            return true
-          }
-        }
-
-        return false
+        return handleBlockEditorEnginePaste({
+          currentEditor,
+          enableMermaidBlocks,
+          event,
+          insertCardBlockFromUrl,
+          insertDocContent,
+          isHttpUrl,
+          isSelectionInEmptyParagraph,
+          onUploadFile,
+          onUploadImage,
+          replaceEmptyCalloutBodyWithPlainText,
+        })
       },
     },
     onUpdate: ({ editor: nextEditor }) => {
@@ -725,7 +363,7 @@ export const useBlockEditorEngineController = ({
         })
       }
     },
-    [editor]
+    [editor, setIsSlashMenuOpen, setSelectedSlashIndex, setSlashMenuState, setSlashQuery]
   )
 
   const insertActions = useBlockEditorEngineInsertActions({
@@ -746,85 +384,6 @@ export const useBlockEditorEngineController = ({
     slashPointerResumeAtRef, slashQuery, transformCurrentParagraphViaSlash,
   })
   const { applyResolvedSlashMenuState, resolveSlashMenuState, syncSlashMenuWhileComposing } = slashMenu
-
-  useEffect(() => {
-    if (typeof window === "undefined" || !isInlineColorMenuOpen) return
-
-    const closeMenu = (event: PointerEvent | KeyboardEvent) => {
-      if (event instanceof KeyboardEvent) {
-        if (event.key !== "Escape") return
-        setIsInlineColorMenuOpen(false)
-        return
-      }
-
-      const target = event.target
-      if (
-        inlineColorMenuRef.current &&
-        target instanceof Node &&
-        inlineColorMenuRef.current.contains(target)
-      ) {
-        return
-      }
-
-      setIsInlineColorMenuOpen(false)
-    }
-
-    window.addEventListener("pointerdown", closeMenu)
-    window.addEventListener("keydown", closeMenu)
-
-    return () => {
-      window.removeEventListener("pointerdown", closeMenu)
-      window.removeEventListener("keydown", closeMenu)
-    }
-  }, [isInlineColorMenuOpen])
-
-  useEffect(() => {
-    if (typeof window === "undefined") return
-    if (!isBubbleTextStyleMenuOpen && !isBubbleInlineColorMenuOpen) return
-
-    const closeMenu = (event: PointerEvent | KeyboardEvent) => {
-      if (event instanceof KeyboardEvent) {
-        if (event.key !== "Escape") return
-        setIsBubbleTextStyleMenuOpen(false)
-        setIsBubbleInlineColorMenuOpen(false)
-        return
-      }
-
-      const target = event.target
-      if (
-        (bubbleTextStyleMenuRef.current && target instanceof Node && bubbleTextStyleMenuRef.current.contains(target)) ||
-        (bubbleInlineColorMenuRef.current && target instanceof Node && bubbleInlineColorMenuRef.current.contains(target))
-      ) {
-        return
-      }
-
-      setIsBubbleTextStyleMenuOpen(false)
-      setIsBubbleInlineColorMenuOpen(false)
-    }
-
-    window.addEventListener("pointerdown", closeMenu)
-    window.addEventListener("keydown", closeMenu)
-
-    return () => {
-      window.removeEventListener("pointerdown", closeMenu)
-      window.removeEventListener("keydown", closeMenu)
-    }
-  }, [isBubbleInlineColorMenuOpen, isBubbleTextStyleMenuOpen])
-
-  useEffect(() => {
-    if (bubbleState.visible && bubbleState.mode === "text") return
-    setIsBubbleTextStyleMenuOpen(false)
-    setIsBubbleInlineColorMenuOpen(false)
-  }, [bubbleState.mode, bubbleState.visible])
-
-  useEffect(() => {
-    if (typeof window === "undefined") return
-    const mediaQuery = window.matchMedia(BLOCK_HANDLE_MEDIA_QUERY)
-    const sync = () => setIsCoarsePointer(mediaQuery.matches)
-    sync()
-    mediaQuery.addEventListener?.("change", sync)
-    return () => mediaQuery.removeEventListener?.("change", sync)
-  }, [])
 
   const blockSelectionUi = useBlockEditorEngineBlockSelectionUi({
     blockHandleRailMetricsRef, blockHandleState, blockSelectionLayoutRectCacheRef, cancelHoveredBlockClear,
@@ -868,12 +427,12 @@ export const useBlockEditorEngineController = ({
             (editorRef.current ?? editor)?.isActive("tableHeader")) &&
             action.section === "structure")
       ),
-    [disabled, editor]
+    [disabled, editor, editorRef]
   )
 
   const handleEditorViewportCompositionStart = useCallback(() => {
     setIsSlashImeComposing(true)
-  }, [])
+  }, [setIsSlashImeComposing])
 
   const handleEditorViewportCompositionUpdate = useCallback(() => {
     requestAnimationFrame(() => {
@@ -886,7 +445,7 @@ export const useBlockEditorEngineController = ({
     requestAnimationFrame(() => {
       applyResolvedSlashMenuState(resolveSlashMenuState())
     })
-  }, [applyResolvedSlashMenuState, resolveSlashMenuState])
+  }, [applyResolvedSlashMenuState, resolveSlashMenuState, setIsSlashImeComposing])
 
   return {
     ...insertActions,

--- a/front/src/components/editor/useBlockEditorEngineControllerEditorHandlers.ts
+++ b/front/src/components/editor/useBlockEditorEngineControllerEditorHandlers.ts
@@ -1,0 +1,340 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import type { MutableRefObject } from "react"
+import { deleteTopLevelBlockAt } from "./blockDocumentOps"
+import {
+  createFileBlockNode,
+  parseMarkdownToEditorDoc,
+  type BlockEditorDoc,
+} from "./serialization"
+import {
+  convertHtmlToMarkdown,
+  extractPlainTextFromHtml,
+  looksLikeStructuredMarkdownDocument,
+  normalizeStructuredMarkdownClipboard,
+} from "src/libs/markdown/htmlToMarkdown"
+import type { BlockEditorEngineProps } from "./blockEditorEngineTypes"
+import { normalizeTableContextPasteText } from "./tablePasteModel"
+import { isTableSelectionActive } from "./tableStructureModel"
+import { getCurrentEditorReadableWidthPx } from "./tableWidthRuntime"
+import { promotePastedWideTables } from "./tableWidthModel"
+import {
+  getTopLevelBlockIndexFromSelection,
+  isTabBlockSelectionEligible,
+} from "./blockSelectionModel"
+import { runBlockToolbarCommand } from "./blockToolbarModel"
+import { runInlineMarkCommand } from "./inlineToolbarModel"
+import {
+  downgradeDisabledFeatureNodes,
+  isPrimaryModifierPressed,
+} from "./useBlockEditorEngineDocumentOps"
+import type { BlockEditorBlockMenuState } from "./BlockEditorEngine.layers"
+
+type HandleBlockEditorEngineKeyDownArgs = {
+  currentEditor: TiptapEditor
+  event: KeyboardEvent
+  findTopLevelBlockIndexFromTarget: (target: EventTarget | null) => number | null
+  hoveredBlockIndex: number | null
+  insertFormulaBlock: () => void
+  insertInlineFormula: () => void
+  keyboardBlockSelectionStickyRef: MutableRefObject<boolean>
+  mutateTopLevelBlocks: (mutator: (doc: BlockEditorDoc) => BlockEditorDoc, focusIndex?: number | null) => void
+  openLinkPrompt: () => void
+  promoteTopLevelBlockSelection: (blockIndex: number) => boolean
+  selectedBlockNodeIndexRef: MutableRefObject<number | null>
+  setBlockMenuState: (value: BlockEditorBlockMenuState) => void
+  setSelectedBlockNodeIndex: (value: number | null) => void
+  syncSelectedBlockNodeSurface: (blockIndex: number | null) => void
+}
+
+export const handleBlockEditorEngineKeyDown = ({
+  currentEditor,
+  event,
+  findTopLevelBlockIndexFromTarget,
+  hoveredBlockIndex,
+  insertFormulaBlock,
+  insertInlineFormula,
+  keyboardBlockSelectionStickyRef,
+  mutateTopLevelBlocks,
+  openLinkPrompt,
+  promoteTopLevelBlockSelection,
+  selectedBlockNodeIndexRef,
+  setBlockMenuState,
+  setSelectedBlockNodeIndex,
+  syncSelectedBlockNodeSurface,
+}: HandleBlockEditorEngineKeyDownArgs) => {
+  if (event.defaultPrevented) return false
+  const normalizedKey = event.key.toLowerCase()
+  const hasPrimaryModifier = isPrimaryModifierPressed(event)
+  const selection = currentEditor.state.selection as typeof currentEditor.state.selection & {
+    node?: { isBlock?: boolean }
+  }
+  const isTopLevelBlockNodeSelection = Boolean(
+    selection.$from.depth === 0 && selection.node?.isBlock
+  )
+
+  if (
+    !hasPrimaryModifier &&
+    !event.altKey &&
+    !event.shiftKey &&
+    event.key === "Tab" &&
+    !isTopLevelBlockNodeSelection
+  ) {
+    const targetBlockIndex =
+      hoveredBlockIndex ??
+      findTopLevelBlockIndexFromTarget(event.target) ??
+      getTopLevelBlockIndexFromSelection(currentEditor)
+    if (!isTabBlockSelectionEligible(currentEditor, targetBlockIndex)) return false
+    event.preventDefault()
+    return promoteTopLevelBlockSelection(targetBlockIndex)
+  }
+
+  if (
+    !hasPrimaryModifier &&
+    !event.altKey &&
+    !event.shiftKey &&
+    (event.key === "Backspace" || event.key === "Delete") &&
+    (isTopLevelBlockNodeSelection || selectedBlockNodeIndexRef.current !== null)
+  ) {
+    event.preventDefault()
+    const blockIndex = selectedBlockNodeIndexRef.current ?? getTopLevelBlockIndexFromSelection(currentEditor)
+    const contentLength = (currentEditor.getJSON() as BlockEditorDoc).content?.length ?? 0
+    const nextFocusIndex = Math.max(0, Math.min(blockIndex, Math.max(contentLength - 2, 0)))
+    mutateTopLevelBlocks((doc) => deleteTopLevelBlockAt(doc, blockIndex), nextFocusIndex)
+    setBlockMenuState(null)
+    keyboardBlockSelectionStickyRef.current = false
+    setSelectedBlockNodeIndex(null)
+    syncSelectedBlockNodeSurface(null)
+    return true
+  }
+
+  if (hasPrimaryModifier && !event.altKey && !event.shiftKey && normalizedKey === "b") {
+    event.preventDefault()
+    runInlineMarkCommand(currentEditor, "bold")
+    return true
+  }
+
+  if (hasPrimaryModifier && !event.altKey && !event.shiftKey && normalizedKey === "i") {
+    event.preventDefault()
+    runInlineMarkCommand(currentEditor, "italic")
+    return true
+  }
+
+  if (hasPrimaryModifier && !event.altKey && !event.shiftKey && normalizedKey === "k") {
+    event.preventDefault()
+    openLinkPrompt()
+    return true
+  }
+
+  if (hasPrimaryModifier && event.altKey && !event.shiftKey && normalizedKey === "m") {
+    event.preventDefault()
+    insertInlineFormula()
+    return true
+  }
+
+  if (hasPrimaryModifier && !event.altKey && event.shiftKey && normalizedKey === "m") {
+    event.preventDefault()
+    insertFormulaBlock()
+    return true
+  }
+
+  if (hasPrimaryModifier && event.altKey && !event.shiftKey && normalizedKey === "2") {
+    event.preventDefault()
+    runBlockToolbarCommand(currentEditor, "heading-2")
+    return true
+  }
+
+  if (hasPrimaryModifier && event.altKey && !event.shiftKey && normalizedKey === "3") {
+    event.preventDefault()
+    runBlockToolbarCommand(currentEditor, "heading-3")
+    return true
+  }
+
+  if (hasPrimaryModifier && !event.altKey && event.shiftKey && normalizedKey === "7") {
+    event.preventDefault()
+    runBlockToolbarCommand(currentEditor, "ordered-list")
+    return true
+  }
+
+  if (hasPrimaryModifier && !event.altKey && event.shiftKey && normalizedKey === "8") {
+    event.preventDefault()
+    runBlockToolbarCommand(currentEditor, "bullet-list")
+    return true
+  }
+
+  if (hasPrimaryModifier && !event.altKey && event.shiftKey && normalizedKey === "9") {
+    event.preventDefault()
+    runBlockToolbarCommand(currentEditor, "quote")
+    return true
+  }
+
+  if (hasPrimaryModifier && !event.altKey && !event.shiftKey && normalizedKey === "z") {
+    event.preventDefault()
+    if (event.repeat) return true
+    if (currentEditor.can().chain().focus().undo().run()) {
+      currentEditor.chain().focus().undo().run()
+    }
+    return true
+  }
+
+  if (hasPrimaryModifier && !event.altKey && event.shiftKey && normalizedKey === "z") {
+    event.preventDefault()
+    if (event.repeat) return true
+    if (currentEditor.can().chain().focus().redo().run()) {
+      currentEditor.chain().focus().redo().run()
+    }
+    return true
+  }
+
+  if (selectedBlockNodeIndexRef.current !== null) {
+    keyboardBlockSelectionStickyRef.current = false
+    setSelectedBlockNodeIndex(null)
+    syncSelectedBlockNodeSurface(null)
+  }
+
+  return false
+}
+
+type HandleBlockEditorEnginePasteArgs = {
+  currentEditor: TiptapEditor
+  enableMermaidBlocks: boolean
+  event: ClipboardEvent
+  insertCardBlockFromUrl: (url: string) => Promise<boolean>
+  insertDocContent: (doc: BlockEditorDoc, replaceCurrentEmptyParagraph?: boolean) => boolean
+  isHttpUrl: (value: string) => boolean
+  isSelectionInEmptyParagraph: () => boolean
+  onUploadFile: BlockEditorEngineProps["onUploadFile"]
+  onUploadImage: BlockEditorEngineProps["onUploadImage"]
+  replaceEmptyCalloutBodyWithPlainText: (text: string) => boolean
+}
+
+export const handleBlockEditorEnginePaste = ({
+  currentEditor,
+  enableMermaidBlocks,
+  event,
+  insertCardBlockFromUrl,
+  insertDocContent,
+  isHttpUrl,
+  isSelectionInEmptyParagraph,
+  onUploadFile,
+  onUploadImage,
+  replaceEmptyCalloutBodyWithPlainText,
+}: HandleBlockEditorEnginePasteArgs) => {
+  const isTableContextPaste = isTableSelectionActive(currentEditor)
+  const clipboardFiles = Array.from(event.clipboardData?.files || [])
+  const imageFile = clipboardFiles.find((file) => file.type.startsWith("image/"))
+  if (imageFile && !isTableContextPaste) {
+    event.preventDefault()
+    void (async () => {
+      const imageAttrs = await onUploadImage(imageFile)
+      currentEditor
+        .chain()
+        .focus()
+        .insertContent([
+          {
+            type: "resizableImage",
+            attrs: {
+              src: imageAttrs.src,
+              alt: imageAttrs.alt || "",
+              title: imageAttrs.title || "",
+              widthPx: imageAttrs.widthPx ?? null,
+              align: imageAttrs.align || "center",
+            },
+          },
+          { type: "paragraph" },
+        ])
+        .run()
+    })()
+    return true
+  }
+
+  const attachmentFile = clipboardFiles.find((file) => !file.type.startsWith("image/"))
+  if (attachmentFile && onUploadFile && !isTableContextPaste) {
+    event.preventDefault()
+    void (async () => {
+      const fileAttrs = await onUploadFile(attachmentFile)
+      insertDocContent(
+        {
+          type: "doc",
+          content: [createFileBlockNode(fileAttrs), { type: "paragraph" }],
+        },
+        isSelectionInEmptyParagraph()
+      )
+    })()
+    return true
+  }
+
+  const plainText = event.clipboardData?.getData("text/plain") || ""
+  const html = event.clipboardData?.getData("text/html") || ""
+  const trimmedPlainText = plainText.trim()
+  const normalizedPlainText = normalizeStructuredMarkdownClipboard(plainText)
+  const normalizedHtmlMarkdown = html ? convertHtmlToMarkdown(html) : ""
+  const extractedPlainTextFromHtml = html ? extractPlainTextFromHtml(html) : ""
+  const calloutPasteText = plainText || extractedPlainTextFromHtml
+
+  if (calloutPasteText && replaceEmptyCalloutBodyWithPlainText(calloutPasteText)) {
+    event.preventDefault()
+    return true
+  }
+
+  if (isTableContextPaste) {
+    const normalizedTablePasteText = normalizeTableContextPasteText(
+      normalizedHtmlMarkdown,
+      normalizedPlainText,
+      extractedPlainTextFromHtml,
+      plainText
+    )
+    if (normalizedTablePasteText) {
+      event.preventDefault()
+      currentEditor.chain().focus().insertContent(normalizedTablePasteText).run()
+      return true
+    }
+  }
+
+  if (
+    isSelectionInEmptyParagraph() &&
+    trimmedPlainText &&
+    !trimmedPlainText.includes("\n") &&
+    isHttpUrl(trimmedPlainText)
+  ) {
+    event.preventDefault()
+    void insertCardBlockFromUrl(trimmedPlainText)
+    return true
+  }
+
+  if (html && normalizedHtmlMarkdown) {
+    event.preventDefault()
+    const parsedDoc = downgradeDisabledFeatureNodes(
+      parseMarkdownToEditorDoc(normalizedHtmlMarkdown),
+      enableMermaidBlocks
+    )
+    const readableWidthBudget = getCurrentEditorReadableWidthPx(currentEditor) - 2
+    return insertDocContent(
+      promotePastedWideTables(parsedDoc, readableWidthBudget),
+      isSelectionInEmptyParagraph()
+    )
+  }
+
+  if (normalizedPlainText && looksLikeStructuredMarkdownDocument(normalizedPlainText)) {
+    event.preventDefault()
+    const parsedDoc = downgradeDisabledFeatureNodes(
+      parseMarkdownToEditorDoc(normalizedPlainText),
+      enableMermaidBlocks
+    )
+    const readableWidthBudget = getCurrentEditorReadableWidthPx(currentEditor) - 2
+    return insertDocContent(
+      promotePastedWideTables(parsedDoc, readableWidthBudget),
+      isSelectionInEmptyParagraph()
+    )
+  }
+
+  if (html && !plainText.trim()) {
+    const extracted = extractedPlainTextFromHtml
+    if (extracted) {
+      event.preventDefault()
+      currentEditor.chain().focus().insertContent(extracted).run()
+      return true
+    }
+  }
+
+  return false
+}

--- a/front/src/components/editor/useBlockEditorEngineControllerState.ts
+++ b/front/src/components/editor/useBlockEditorEngineControllerState.ts
@@ -1,0 +1,306 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { BlockSelectionOverlayState, TopLevelBlockHandleState } from "./blockSelectionModel"
+import {
+  type DraggedBlockState,
+  type DropIndicatorState,
+  type PendingBlockDragState,
+  createHiddenDropIndicatorState,
+} from "./blockDragModel"
+import {
+  type NestedListItemContext,
+} from "./nestedListItemModel"
+import {
+  type DraggedNestedListItemState,
+  type NestedListItemDropIndicatorState,
+  type PendingNestedListItemHandleDragState,
+  createHiddenNestedListItemDropIndicatorState,
+} from "./nestedListItemDragModel"
+import {
+  type BlockEditorBlockMenuState,
+  type BlockEditorSlashMenuState,
+} from "./BlockEditorEngine.layers"
+import { useFloatingBubbleState } from "./useFloatingBubbleState"
+
+const BLOCK_HANDLE_MEDIA_QUERY = "(pointer: coarse)"
+
+export const useBlockEditorEngineControllerState = () => {
+  const imageFileInputRef = useRef<HTMLInputElement>(null)
+  const attachmentFileInputRef = useRef<HTMLInputElement>(null)
+  const inlineColorMenuRef = useRef<HTMLDetailsElement>(null)
+  const bubbleTextStyleMenuRef = useRef<HTMLDetailsElement>(null)
+  const bubbleInlineColorMenuRef = useRef<HTMLDetailsElement>(null)
+  const slashMenuRef = useRef<HTMLDivElement>(null)
+  const viewportRef = useRef<HTMLDivElement>(null)
+  const blockHandleRailRef = useRef<HTMLDivElement>(null)
+  const pendingBlockDragRef = useRef<PendingBlockDragState | null>(null)
+  const pendingBlockDragCleanupRef = useRef<(() => void) | null>(null)
+  const pendingNestedListItemHandleDragRef = useRef<PendingNestedListItemHandleDragState | null>(null)
+  const pendingNestedListItemHandleDragCleanupRef = useRef<(() => void) | null>(null)
+  const skipNextPointerDownSelectionClearRef = useRef(false)
+  const pendingImageInsertIndexRef = useRef<number | null>(null)
+  const pendingAttachmentInsertIndexRef = useRef<number | null>(null)
+  const tableViewportBudgetNormalizeFrameRef = useRef<number | null>(null)
+  const editorRef = useRef<TiptapEditor | null>(null)
+  const hoveredBlockClearTimerRef = useRef<number | null>(null)
+  const mouseTextSelectionInProgressRef = useRef(false)
+  const syncBubbleOnMouseUpRef = useRef(false)
+  const slashPointerResumeAtRef = useRef(0)
+  const selectedListItemContextRef = useRef<NestedListItemContext | null>(null)
+  const selectedBlockNodeIndexRef = useRef<number | null>(null)
+  const keyboardBlockSelectionStickyRef = useRef(false)
+  const selectionUiSignatureRef = useRef("")
+  const blockSelectionLayoutRectCacheRef = useRef(new Map<number, { element: HTMLElement; rect: DOMRect }>())
+  const blockHandleRailMetricsRef = useRef({ width: 54, height: 40 })
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false)
+  const [isSlashMenuOpen, setIsSlashMenuOpen] = useState(false)
+  const [slashQuery, setSlashQuery] = useState("")
+  const [selectedSlashIndex, setSelectedSlashIndex] = useState(0)
+  const [slashMenuState, setSlashMenuState] = useState<BlockEditorSlashMenuState>(null)
+  const [recentSlashItemIds, setRecentSlashItemIds] = useState<string[]>([])
+  const [isSlashImeComposing, setIsSlashImeComposing] = useState(false)
+  const [slashInteractionMode, setSlashInteractionMode] = useState<"keyboard" | "pointer">("keyboard")
+  const [isToolbarMoreOpen, setIsToolbarMoreOpen] = useState(false)
+  const [isInlineColorMenuOpen, setIsInlineColorMenuOpen] = useState(false)
+  const [isBubbleTextStyleMenuOpen, setIsBubbleTextStyleMenuOpen] = useState(false)
+  const [isBubbleInlineColorMenuOpen, setIsBubbleInlineColorMenuOpen] = useState(false)
+  const [blockMenuState, setBlockMenuState] = useState<BlockEditorBlockMenuState>(null)
+  const [isCoarsePointer, setIsCoarsePointer] = useState(false)
+  const [hoveredBlockIndex, setHoveredBlockIndex] = useState<number | null>(null)
+  const [hoveredListItemContext, setHoveredListItemContext] = useState<NestedListItemContext | null>(null)
+  const [selectedListItemContext, setSelectedListItemContext] = useState<NestedListItemContext | null>(null)
+  const [selectedBlockIndex, setSelectedBlockIndex] = useState<number | null>(null)
+  const [clickedBlockIndex, setClickedBlockIndex] = useState<number | null>(null)
+  const [selectedBlockNodeIndex, setSelectedBlockNodeIndex] = useState<number | null>(null)
+  const [textSelectionBlockIndex, setTextSelectionBlockIndex] = useState<number | null>(null)
+  const [blockHandleState, setBlockHandleState] = useState<TopLevelBlockHandleState>({
+    visible: false,
+    kind: "top-level",
+    blockIndex: 0,
+    listPath: [],
+    itemIndex: null,
+    left: 0,
+    top: 0,
+    bottom: 0,
+    width: 0,
+  })
+  const [blockSelectionOverlayState, setBlockSelectionOverlayState] = useState<BlockSelectionOverlayState>({
+    visible: false,
+    left: 0,
+    top: 0,
+    width: 0,
+    height: 0,
+  })
+  const {
+    bubbleState,
+    setBubbleState,
+    bubbleToolbarHoveredRef,
+    cancelBubbleHide,
+    scheduleBubbleHide,
+  } = useFloatingBubbleState()
+  const [draggedBlockState, setDraggedBlockState] = useState<DraggedBlockState>(null)
+  const [dragGhostPosition, setDragGhostPosition] = useState<{ x: number; y: number } | null>(null)
+  const [dropIndicatorState, setDropIndicatorState] = useState<DropIndicatorState>(createHiddenDropIndicatorState)
+  const [draggedNestedListItemState, setDraggedNestedListItemState] = useState<DraggedNestedListItemState>(null)
+  const [nestedListItemDropIndicatorState, setNestedListItemDropIndicatorState] =
+    useState<NestedListItemDropIndicatorState>(createHiddenNestedListItemDropIndicatorState)
+  const [selectionTick, setSelectionTick] = useState(0)
+
+  useEffect(() => {
+    const railElement = blockHandleRailRef.current
+    if (!railElement || typeof ResizeObserver === "undefined") return
+
+    const syncRailMetrics = () => {
+      blockHandleRailMetricsRef.current = {
+        width: railElement.offsetWidth || 54,
+        height: railElement.offsetHeight || 40,
+      }
+    }
+
+    syncRailMetrics()
+    const observer = new ResizeObserver(syncRailMetrics)
+    observer.observe(railElement)
+    return () => observer.disconnect()
+  }, [])
+
+  const cancelHoveredBlockClear = useCallback(() => {
+    if (hoveredBlockClearTimerRef.current !== null && typeof window !== "undefined") {
+      window.clearTimeout(hoveredBlockClearTimerRef.current)
+      hoveredBlockClearTimerRef.current = null
+    }
+  }, [])
+
+  const scheduleHoveredBlockClear = useCallback(() => {
+    cancelHoveredBlockClear()
+    if (typeof window === "undefined") return
+    hoveredBlockClearTimerRef.current = window.setTimeout(() => {
+      setHoveredBlockIndex(null)
+      setHoveredListItemContext(null)
+      hoveredBlockClearTimerRef.current = null
+    }, 260)
+  }, [cancelHoveredBlockClear])
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !isInlineColorMenuOpen) return
+
+    const closeMenu = (event: PointerEvent | KeyboardEvent) => {
+      if (event instanceof KeyboardEvent) {
+        if (event.key !== "Escape") return
+        setIsInlineColorMenuOpen(false)
+        return
+      }
+
+      const target = event.target
+      if (inlineColorMenuRef.current && target instanceof Node && inlineColorMenuRef.current.contains(target)) return
+      setIsInlineColorMenuOpen(false)
+    }
+
+    window.addEventListener("pointerdown", closeMenu)
+    window.addEventListener("keydown", closeMenu)
+
+    return () => {
+      window.removeEventListener("pointerdown", closeMenu)
+      window.removeEventListener("keydown", closeMenu)
+    }
+  }, [isInlineColorMenuOpen])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    if (!isBubbleTextStyleMenuOpen && !isBubbleInlineColorMenuOpen) return
+
+    const closeMenu = (event: PointerEvent | KeyboardEvent) => {
+      if (event instanceof KeyboardEvent) {
+        if (event.key !== "Escape") return
+        setIsBubbleTextStyleMenuOpen(false)
+        setIsBubbleInlineColorMenuOpen(false)
+        return
+      }
+
+      const target = event.target
+      const isTextStyleMenuTarget =
+        bubbleTextStyleMenuRef.current && target instanceof Node && bubbleTextStyleMenuRef.current.contains(target)
+      const isInlineColorMenuTarget =
+        bubbleInlineColorMenuRef.current && target instanceof Node && bubbleInlineColorMenuRef.current.contains(target)
+      if (isTextStyleMenuTarget || isInlineColorMenuTarget) return
+
+      setIsBubbleTextStyleMenuOpen(false)
+      setIsBubbleInlineColorMenuOpen(false)
+    }
+
+    window.addEventListener("pointerdown", closeMenu)
+    window.addEventListener("keydown", closeMenu)
+
+    return () => {
+      window.removeEventListener("pointerdown", closeMenu)
+      window.removeEventListener("keydown", closeMenu)
+    }
+  }, [isBubbleInlineColorMenuOpen, isBubbleTextStyleMenuOpen])
+
+  useEffect(() => {
+    if (bubbleState.visible && bubbleState.mode === "text") return
+    setIsBubbleTextStyleMenuOpen(false)
+    setIsBubbleInlineColorMenuOpen(false)
+  }, [bubbleState.mode, bubbleState.visible])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const mediaQuery = window.matchMedia(BLOCK_HANDLE_MEDIA_QUERY)
+    const sync = () => setIsCoarsePointer(mediaQuery.matches)
+    sync()
+    mediaQuery.addEventListener?.("change", sync)
+    return () => mediaQuery.removeEventListener?.("change", sync)
+  }, [])
+
+  return {
+    attachmentFileInputRef,
+    blockHandleRailMetricsRef,
+    blockHandleRailRef,
+    blockHandleState,
+    blockMenuState,
+    blockSelectionLayoutRectCacheRef,
+    blockSelectionOverlayState,
+    bubbleInlineColorMenuRef,
+    bubbleState,
+    bubbleTextStyleMenuRef,
+    bubbleToolbarHoveredRef,
+    cancelBubbleHide,
+    cancelHoveredBlockClear,
+    clickedBlockIndex,
+    dragGhostPosition,
+    draggedBlockState,
+    draggedNestedListItemState,
+    dropIndicatorState,
+    editorRef,
+    hoveredBlockIndex,
+    hoveredListItemContext,
+    imageFileInputRef,
+    inlineColorMenuRef,
+    isBubbleInlineColorMenuOpen,
+    isBubbleTextStyleMenuOpen,
+    isCoarsePointer,
+    isInlineColorMenuOpen,
+    isPreviewOpen,
+    isSlashImeComposing,
+    isSlashMenuOpen,
+    isToolbarMoreOpen,
+    keyboardBlockSelectionStickyRef,
+    mouseTextSelectionInProgressRef,
+    nestedListItemDropIndicatorState,
+    pendingAttachmentInsertIndexRef,
+    pendingBlockDragCleanupRef,
+    pendingBlockDragRef,
+    pendingImageInsertIndexRef,
+    pendingNestedListItemHandleDragCleanupRef,
+    pendingNestedListItemHandleDragRef,
+    recentSlashItemIds,
+    scheduleBubbleHide,
+    scheduleHoveredBlockClear,
+    selectedBlockIndex,
+    selectedBlockNodeIndex,
+    selectedBlockNodeIndexRef,
+    selectedListItemContext,
+    selectedListItemContextRef,
+    selectedSlashIndex,
+    selectionTick,
+    selectionUiSignatureRef,
+    setBlockHandleState,
+    setBlockMenuState,
+    setBlockSelectionOverlayState,
+    setBubbleState,
+    setClickedBlockIndex,
+    setDragGhostPosition,
+    setDraggedBlockState,
+    setDraggedNestedListItemState,
+    setDropIndicatorState,
+    setHoveredBlockIndex,
+    setHoveredListItemContext,
+    setIsBubbleInlineColorMenuOpen,
+    setIsBubbleTextStyleMenuOpen,
+    setIsInlineColorMenuOpen,
+    setIsPreviewOpen,
+    setIsSlashImeComposing,
+    setIsSlashMenuOpen,
+    setIsToolbarMoreOpen,
+    setNestedListItemDropIndicatorState,
+    setRecentSlashItemIds,
+    setSelectedBlockIndex,
+    setSelectedBlockNodeIndex,
+    setSelectedListItemContext,
+    setSelectedSlashIndex,
+    setSelectionTick,
+    setSlashInteractionMode,
+    setSlashMenuState,
+    setSlashQuery,
+    setTextSelectionBlockIndex,
+    skipNextPointerDownSelectionClearRef,
+    slashInteractionMode,
+    slashMenuRef,
+    slashMenuState,
+    slashPointerResumeAtRef,
+    slashQuery,
+    syncBubbleOnMouseUpRef,
+    tableViewportBudgetNormalizeFrameRef,
+    textSelectionBlockIndex,
+    viewportRef,
+  }
+}

--- a/front/src/components/editor/useBlockEditorEngineDocumentOps.ts
+++ b/front/src/components/editor/useBlockEditorEngineDocumentOps.ts
@@ -2,7 +2,7 @@ import type { Editor as TiptapEditor } from "@tiptap/core"
 import { Fragment } from "@tiptap/pm/model"
 import { TextSelection } from "@tiptap/pm/state"
 import { useCallback } from "react"
-import type { KeyboardEvent as ReactKeyboardEvent, RefObject } from "react"
+import type { RefObject } from "react"
 import { getPreferredCodeLanguage } from "./extensions"
 import {
   deleteTopLevelBlockAt,
@@ -49,110 +49,15 @@ import {
   getTopLevelBlockPosition,
 } from "./blockSelectionModel"
 import { TABLE_CONTEXT_BLOCKED_INSERT_IDS } from "./writerEditorPreset"
-
-export const blockHasVisibleContent = (node?: BlockEditorDoc | null): boolean => {
-  if (!node) return false
-
-  if (node.type === "text") {
-    return Boolean((node as { text?: string }).text?.trim().length)
-  }
-
-  if (
-    node.type === "resizableImage" ||
-    node.type === "calloutBlock" ||
-    node.type === "taskList" ||
-    node.type === "bookmarkBlock" ||
-    node.type === "embedBlock" ||
-    node.type === "fileBlock" ||
-    node.type === "formulaBlock" ||
-    node.type === "toggleBlock" ||
-    node.type === "mermaidBlock" ||
-    node.type === "rawMarkdownBlock" ||
-    node.type === "table" ||
-    node.type === "horizontalRule"
-  ) {
-    return true
-  }
-
-  return Array.isArray(node.content) && node.content.some((child) => blockHasVisibleContent(child as BlockEditorDoc))
-}
-
-export const normalizeTableColorInputValue = (value: unknown) => {
-  const normalized = String(value || "").trim()
-  return /^#[0-9a-f]{6}$/i.test(normalized) ? normalized : "#dbeafe"
-}
-
-export const isPrimaryModifierPressed = (event: ReactKeyboardEvent | globalThis.KeyboardEvent) =>
-  event.metaKey || event.ctrlKey
-
-export const getActiveSlashRangeFromEditor = (editor: TiptapEditor): { from: number; to: number } | null => {
-  const selection = editor.state.selection
-  if (!selection.empty) return null
-
-  const parent = selection.$from.parent
-  if (parent.type.name !== "paragraph") return null
-
-  const textBeforeCursor = parent.textContent.slice(0, selection.$from.parentOffset)
-  const match = /(^|[\s\u00A0])\/([^\n]*)$/.exec(textBeforeCursor)
-  if (!match) return null
-
-  const slashOffset = (match.index ?? 0) + match[1].length
-  return {
-    from: selection.$from.start() + slashOffset,
-    to: selection.from,
-  }
-}
-
-export const focusElementWithoutScroll = (element: HTMLElement | null) => {
-  if (!element) return
-  if (typeof window === "undefined") {
-    element.focus()
-    return
-  }
-
-  const previousScrollX = window.scrollX
-  const previousScrollY = window.scrollY
-  try {
-    element.focus({ preventScroll: true })
-  } catch {
-    element.focus()
-  }
-  if (window.scrollX !== previousScrollX || window.scrollY !== previousScrollY) {
-    window.scrollTo(previousScrollX, previousScrollY)
-  }
-}
-
-export const resolveDocPosSafe = (editor: TiptapEditor, pos: number) => {
-  if (!Number.isFinite(pos)) return null
-  const normalizedPos = Math.round(pos)
-  const maxPos = editor.state.doc.content.size
-  if (normalizedPos < 0 || normalizedPos > maxPos) return null
-  try {
-    return editor.state.doc.resolve(normalizedPos)
-  } catch {
-    return null
-  }
-}
-
-export const downgradeDisabledFeatureNodes = (node: BlockEditorDoc, enableMermaidBlocks: boolean): BlockEditorDoc => {
-  if (!enableMermaidBlocks && node.type === "mermaidBlock") {
-    const source = String(node.attrs?.source || "").trim()
-    return {
-      type: "rawMarkdownBlock",
-      attrs: {
-        markdown: ["```mermaid", source, "```"].join("\n"),
-        reason: "unsupported-mermaid",
-      },
-    }
-  }
-
-  if (!node.content?.length) return node
-
-  return {
-    ...node,
-    content: node.content.map((child) => downgradeDisabledFeatureNodes(child as BlockEditorDoc, enableMermaidBlocks)),
-  }
-}
+export {
+  blockHasVisibleContent,
+  downgradeDisabledFeatureNodes,
+  focusElementWithoutScroll,
+  getActiveSlashRangeFromEditor,
+  isPrimaryModifierPressed,
+  normalizeTableColorInputValue,
+  resolveDocPosSafe,
+} from "./blockEditorEngineDocumentModel"
 
 type UseBlockEditorEngineDocumentOpsArgs = {
   discardPendingMarkdownCommit: () => void

--- a/front/src/components/editor/useBlockEditorEngineInsertActions.ts
+++ b/front/src/components/editor/useBlockEditorEngineInsertActions.ts
@@ -1,8 +1,7 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
 import AppIcon from "src/components/icons/AppIcon"
-import { createElement, useCallback, useEffect, useMemo } from "react"
+import { createElement, useCallback, useMemo } from "react"
 import type {
-  ChangeEvent,
   Dispatch,
   MouseEvent as ReactMouseEvent,
   MutableRefObject,
@@ -25,11 +24,7 @@ import {
   createToggleNode,
   type BlockEditorDoc,
 } from "./serialization"
-import { inferCardKindFromUrl, inferLinkProvider, resolveEmbedPreviewUrl } from "src/libs/unfurl/extractMeta"
-import { getEditorUndoDepth } from "./editorHistoryModel"
-import type { BlockEditorQaActions } from "./blockEditorContract"
 import type { BlockEditorEngineProps } from "./blockEditorEngineTypes"
-import { refocusEditorForSelectionReveal } from "./editorScrollSelectionGuard"
 import {
   type BlockInsertCatalogItem,
   createWriterBlockInsertCatalog,
@@ -37,6 +32,7 @@ import {
 } from "./writerEditorPreset"
 import { isTableSelectionActive } from "./tableStructureModel"
 import { getTopLevelBlockIndexFromSelection } from "./blockSelectionModel"
+import type { BlockEditorQaActions } from "./blockEditorContract"
 import {
   isBlockToolbarCommandActive,
   isToolbarBlockInsertActive,
@@ -54,6 +50,8 @@ import {
   type InlineTextStyleOption,
 } from "./inlineToolbarModel"
 import type { BlockEditorToolbarAction } from "./BlockEditorEngine.layers"
+import { useBlockEditorEngineInsertMediaActions } from "./useBlockEditorEngineInsertMediaActions"
+import { useBlockEditorEngineQaActions } from "./useBlockEditorEngineQaActions"
 
 type SetBoolean = Dispatch<SetStateAction<boolean>>
 
@@ -309,94 +307,23 @@ export const useBlockEditorEngineInsertActions = ({
     insertBlocksAtCursor([createCodeBlockNode(getPreferredCodeLanguage(), "")], true)
   }, [canInsertTopLevelBlockAtSelection, insertBlocksAtCursor])
 
-  const isHttpUrl = useCallback((value: string) => {
-    try {
-      const parsed = new URL(value.trim())
-      return parsed.protocol === "http:" || parsed.protocol === "https:"
-    } catch {
-      return false
-    }
-  }, [])
-
-  const fetchUnfurlMetadata = useCallback(async (url: string) => {
-    try {
-      const response = await fetch(`/api/editor/unfurl?url=${encodeURIComponent(url)}`)
-      const payload = await response.json()
-      if (!response.ok || !payload?.ok || !payload?.data) return null
-      return payload.data as {
-        title?: string
-        description?: string
-        siteName?: string
-        provider?: string
-        thumbnailUrl?: string
-        embedUrl?: string
-      }
-    } catch {
-      return null
-    }
-  }, [])
-
-  const createCardNodeFromUrl = useCallback(
-    async (url: string) => {
-      const trimmedUrl = url.trim()
-      const cardKind = inferCardKindFromUrl(trimmedUrl)
-      const metadata = await fetchUnfurlMetadata(trimmedUrl)
-      const fallbackProvider = inferLinkProvider(trimmedUrl)
-      const fallbackTitle = (() => {
-        try {
-          const parsed = new URL(trimmedUrl)
-          const lastSegment = parsed.pathname.split("/").filter(Boolean).pop() || ""
-          return decodeURIComponent(lastSegment || parsed.hostname.replace(/^www\./i, "")) || trimmedUrl
-        } catch {
-          return trimmedUrl
-        }
-      })()
-
-      if (cardKind === "file") {
-        return createFileBlockNode({
-          url: trimmedUrl,
-          name: String(metadata?.title || fallbackTitle || "첨부 파일").trim(),
-          description: String(metadata?.description || "").trim(),
-        })
-      }
-
-      if (cardKind === "embed") {
-        return createEmbedNode({
-          url: trimmedUrl,
-          title: String(metadata?.title || fallbackProvider || "임베드").trim(),
-          caption: String(metadata?.description || "").trim(),
-          siteName: String(metadata?.siteName || "").trim(),
-          provider: String(metadata?.provider || fallbackProvider || "").trim(),
-          thumbnailUrl: String(metadata?.thumbnailUrl || "").trim(),
-          embedUrl: String(metadata?.embedUrl || resolveEmbedPreviewUrl(trimmedUrl) || "").trim(),
-        })
-      }
-
-      return createBookmarkNode({
-        url: trimmedUrl,
-        title: String(metadata?.title || fallbackTitle || trimmedUrl).trim(),
-        description: String(metadata?.description || "").trim(),
-        siteName: String(metadata?.siteName || "").trim(),
-        provider: String(metadata?.provider || fallbackProvider || "").trim(),
-        thumbnailUrl: String(metadata?.thumbnailUrl || "").trim(),
-      })
-    },
-    [fetchUnfurlMetadata]
-  )
-
-  const insertCardBlockFromUrl = useCallback(
-    async (url: string) => {
-      const nextNode = await createCardNodeFromUrl(url)
-      return insertDocContent(
-        {
-          type: "doc",
-          content: [nextNode, { type: "paragraph" }],
-        },
-        isSelectionInEmptyParagraph()
-      )
-    },
-    [createCardNodeFromUrl, insertDocContent, isSelectionInEmptyParagraph]
-  )
+  const {
+    createCardNodeFromUrl,
+    handleAttachmentInputChange,
+    handleImageInputChange,
+    insertCardBlockFromUrl,
+    isHttpUrl,
+  } = useBlockEditorEngineInsertMediaActions({
+    editor,
+    insertBlocksAtCursor,
+    insertBlocksAtIndex,
+    insertDocContent,
+    isSelectionInEmptyParagraph,
+    onUploadFile,
+    onUploadImage,
+    pendingAttachmentInsertIndexRef,
+    pendingImageInsertIndexRef,
+  })
 
   const openLinkPrompt = useCallback(() => {
     if (!editor || typeof window === "undefined") return
@@ -476,86 +403,7 @@ export const useBlockEditorEngineInsertActions = ({
     [editorRef, mutateTopLevelBlocks]
   )
 
-  useEffect(() => {
-    if (!onQaActionsReady) return
-
-    onQaActionsReady({
-      selectTableAxis: (axis) => {
-        selectCurrentTableAxis(axis)
-      },
-      selectTableColumnViaDomFallback: (columnIndex) => {
-        const currentEditor = editorRef.current ?? editor
-        if (!currentEditor) return
-        currentEditor.chain().focus("end").run()
-        selectTableColumnByIndex(columnIndex)
-      },
-      setActiveTableCellAlign: (align) => {
-        updateActiveTableCellAttrs({ textAlign: align })
-      },
-      setActiveTableCellBackground: (color) => {
-        updateActiveTableCellAttrs({ backgroundColor: color })
-      },
-      addTableRowAfter: () => {
-        editor?.chain().focus().addRowAfter().run()
-      },
-      addTableColumnAfter: () => {
-        editor?.chain().focus().addColumnAfter().run()
-      },
-      deleteSelectedTableRow: () => {
-        editor?.chain().focus().deleteRow().run()
-      },
-      deleteSelectedTableColumn: () => {
-        editor?.chain().focus().deleteColumn().run()
-      },
-      resizeFirstTableRow: (deltaPx) => {
-        resizeFirstTableRowBy(deltaPx)
-      },
-      resizeFirstTableColumn: (deltaPx) => {
-        resizeFirstTableColumnBy(deltaPx)
-      },
-      focusDocumentEnd: () => {
-        editor?.chain().focus("end").run()
-      },
-      appendCalloutBlock: () => {
-        const currentEditor = editorRef.current
-        if (!currentEditor) return
-        insertBlocksAtIndex(
-          currentEditor.state.doc.childCount,
-          withTrailingParagraph([
-            createCalloutNode({
-              kind: "tip",
-              title: "",
-              body: "",
-            }),
-          ])
-        )
-      },
-      appendFormulaBlock: () => {
-        const currentEditor = editorRef.current
-        if (!currentEditor) return
-        insertBlocksAtIndex(
-          currentEditor.state.doc.childCount,
-          withTrailingParagraph([
-            createFormulaNode({
-              formula: "",
-            }),
-          ])
-        )
-      },
-      moveTaskItemInFirstTaskList: (sourceIndex, insertionIndex) => {
-        moveTaskItemInFirstTaskList(sourceIndex, insertionIndex)
-      },
-      scrollCurrentSelectionIntoView: () => refocusEditorForSelectionReveal(editorRef.current ?? editor),
-      getUndoDepth: () => {
-        const currentEditor = editorRef.current ?? editor
-        return currentEditor ? getEditorUndoDepth(currentEditor) : 0
-      },
-    })
-
-    return () => {
-      onQaActionsReady(null)
-    }
-  }, [
+  useBlockEditorEngineQaActions({
     editor,
     editorRef,
     insertBlocksAtIndex,
@@ -563,73 +411,11 @@ export const useBlockEditorEngineInsertActions = ({
     onQaActionsReady,
     resizeFirstTableColumnBy,
     resizeFirstTableRowBy,
-    selectTableColumnByIndex,
     selectCurrentTableAxis,
+    selectTableColumnByIndex,
     updateActiveTableCellAttrs,
     withTrailingParagraph,
-  ])
-
-  const handleImageInputChange = async (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    event.target.value = ""
-    if (!file || !editor) return
-
-    const imageAttrs = await onUploadImage(file)
-    const pendingInsertIndex = pendingImageInsertIndexRef.current
-    pendingImageInsertIndexRef.current = null
-
-    if (typeof pendingInsertIndex === "number") {
-      insertBlocksAtIndex(pendingInsertIndex, [
-        {
-          type: "resizableImage",
-          attrs: {
-            src: imageAttrs.src,
-            alt: imageAttrs.alt || "",
-            title: imageAttrs.title || "",
-            widthPx: imageAttrs.widthPx ?? null,
-            align: imageAttrs.align || "center",
-          },
-        },
-        { type: "paragraph" },
-      ])
-      return
-    }
-
-    editor
-      .chain()
-      .focus()
-      .insertContent([
-        {
-          type: "resizableImage",
-          attrs: {
-            src: imageAttrs.src,
-            alt: imageAttrs.alt || "",
-            title: imageAttrs.title || "",
-            widthPx: imageAttrs.widthPx ?? null,
-            align: imageAttrs.align || "center",
-          },
-        },
-        { type: "paragraph" },
-      ])
-      .run()
-  }
-
-  const handleAttachmentInputChange = async (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    event.target.value = ""
-    if (!file || !editor || !onUploadFile) return
-
-    const fileAttrs = await onUploadFile(file)
-    const pendingInsertIndex = pendingAttachmentInsertIndexRef.current
-    pendingAttachmentInsertIndexRef.current = null
-
-    if (typeof pendingInsertIndex === "number") {
-      insertBlocksAtIndex(pendingInsertIndex, [createFileBlockNode(fileAttrs), { type: "paragraph" }])
-      return
-    }
-
-    insertBlocksAtCursor([createFileBlockNode(fileAttrs)], true)
-  }
+  })
 
   const blockInsertCatalog = useMemo<BlockInsertCatalogItem[]>(
     () =>

--- a/front/src/components/editor/useBlockEditorEngineInsertMediaActions.ts
+++ b/front/src/components/editor/useBlockEditorEngineInsertMediaActions.ts
@@ -1,0 +1,183 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import { useCallback } from "react"
+import type { ChangeEvent, MutableRefObject } from "react"
+import { inferCardKindFromUrl, inferLinkProvider, resolveEmbedPreviewUrl } from "src/libs/unfurl/extractMeta"
+import type { BlockEditorEngineProps } from "./blockEditorEngineTypes"
+import {
+  createBookmarkNode,
+  createEmbedNode,
+  createFileBlockNode,
+  type BlockEditorDoc,
+} from "./serialization"
+
+type UseBlockEditorEngineInsertMediaActionsArgs = {
+  editor: TiptapEditor | null
+  insertBlocksAtCursor: (blocks: BlockEditorDoc[], replaceCurrentEmptyParagraph?: boolean) => void
+  insertBlocksAtIndex: (
+    insertionIndex: number,
+    blocks: NonNullable<BlockEditorDoc["content"]>,
+    focusIndex?: number
+  ) => void
+  insertDocContent: (doc: BlockEditorDoc, replaceCurrentEmptyParagraph?: boolean) => boolean
+  isSelectionInEmptyParagraph: () => boolean
+  onUploadFile: BlockEditorEngineProps["onUploadFile"]
+  onUploadImage: BlockEditorEngineProps["onUploadImage"]
+  pendingAttachmentInsertIndexRef: MutableRefObject<number | null>
+  pendingImageInsertIndexRef: MutableRefObject<number | null>
+}
+
+export const useBlockEditorEngineInsertMediaActions = ({
+  editor,
+  insertBlocksAtCursor,
+  insertBlocksAtIndex,
+  insertDocContent,
+  isSelectionInEmptyParagraph,
+  onUploadFile,
+  onUploadImage,
+  pendingAttachmentInsertIndexRef,
+  pendingImageInsertIndexRef,
+}: UseBlockEditorEngineInsertMediaActionsArgs) => {
+  const isHttpUrl = useCallback((value: string) => {
+    try {
+      const parsed = new URL(value.trim())
+      return parsed.protocol === "http:" || parsed.protocol === "https:"
+    } catch {
+      return false
+    }
+  }, [])
+
+  const fetchUnfurlMetadata = useCallback(async (url: string) => {
+    try {
+      const response = await fetch(`/api/editor/unfurl?url=${encodeURIComponent(url)}`)
+      const payload = await response.json()
+      if (!response.ok || !payload?.ok || !payload?.data) return null
+      return payload.data as {
+        title?: string
+        description?: string
+        siteName?: string
+        provider?: string
+        thumbnailUrl?: string
+        embedUrl?: string
+      }
+    } catch {
+      return null
+    }
+  }, [])
+
+  const createCardNodeFromUrl = useCallback(
+    async (url: string) => {
+      const trimmedUrl = url.trim()
+      const cardKind = inferCardKindFromUrl(trimmedUrl)
+      const metadata = await fetchUnfurlMetadata(trimmedUrl)
+      const fallbackProvider = inferLinkProvider(trimmedUrl)
+      const fallbackTitle = (() => {
+        try {
+          const parsed = new URL(trimmedUrl)
+          const lastSegment = parsed.pathname.split("/").filter(Boolean).pop() || ""
+          return decodeURIComponent(lastSegment || parsed.hostname.replace(/^www\./i, "")) || trimmedUrl
+        } catch {
+          return trimmedUrl
+        }
+      })()
+
+      if (cardKind === "file") {
+        return createFileBlockNode({
+          url: trimmedUrl,
+          name: String(metadata?.title || fallbackTitle || "첨부 파일").trim(),
+          description: String(metadata?.description || "").trim(),
+        })
+      }
+
+      if (cardKind === "embed") {
+        return createEmbedNode({
+          url: trimmedUrl,
+          title: String(metadata?.title || fallbackProvider || "임베드").trim(),
+          caption: String(metadata?.description || "").trim(),
+          siteName: String(metadata?.siteName || "").trim(),
+          provider: String(metadata?.provider || fallbackProvider || "").trim(),
+          thumbnailUrl: String(metadata?.thumbnailUrl || "").trim(),
+          embedUrl: String(metadata?.embedUrl || resolveEmbedPreviewUrl(trimmedUrl) || "").trim(),
+        })
+      }
+
+      return createBookmarkNode({
+        url: trimmedUrl,
+        title: String(metadata?.title || fallbackTitle || trimmedUrl).trim(),
+        description: String(metadata?.description || "").trim(),
+        siteName: String(metadata?.siteName || "").trim(),
+        provider: String(metadata?.provider || fallbackProvider || "").trim(),
+        thumbnailUrl: String(metadata?.thumbnailUrl || "").trim(),
+      })
+    },
+    [fetchUnfurlMetadata]
+  )
+
+  const insertCardBlockFromUrl = useCallback(
+    async (url: string) => {
+      const nextNode = await createCardNodeFromUrl(url)
+      return insertDocContent(
+        {
+          type: "doc",
+          content: [nextNode, { type: "paragraph" }],
+        },
+        isSelectionInEmptyParagraph()
+      )
+    },
+    [createCardNodeFromUrl, insertDocContent, isSelectionInEmptyParagraph]
+  )
+
+  const handleImageInputChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = ""
+    if (!file || !editor) return
+
+    const imageAttrs = await onUploadImage(file)
+    const pendingInsertIndex = pendingImageInsertIndexRef.current
+    pendingImageInsertIndexRef.current = null
+    const imageBlocks: NonNullable<BlockEditorDoc["content"]> = [
+      {
+        type: "resizableImage",
+        attrs: {
+          src: imageAttrs.src,
+          alt: imageAttrs.alt || "",
+          title: imageAttrs.title || "",
+          widthPx: imageAttrs.widthPx ?? null,
+          align: imageAttrs.align || "center",
+        },
+      },
+      { type: "paragraph" },
+    ]
+
+    if (typeof pendingInsertIndex === "number") {
+      insertBlocksAtIndex(pendingInsertIndex, imageBlocks)
+      return
+    }
+
+    editor.chain().focus().insertContent(imageBlocks).run()
+  }
+
+  const handleAttachmentInputChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = ""
+    if (!file || !editor || !onUploadFile) return
+
+    const fileAttrs = await onUploadFile(file)
+    const pendingInsertIndex = pendingAttachmentInsertIndexRef.current
+    pendingAttachmentInsertIndexRef.current = null
+
+    if (typeof pendingInsertIndex === "number") {
+      insertBlocksAtIndex(pendingInsertIndex, [createFileBlockNode(fileAttrs), { type: "paragraph" }])
+      return
+    }
+
+    insertBlocksAtCursor([createFileBlockNode(fileAttrs)], true)
+  }
+
+  return {
+    createCardNodeFromUrl,
+    handleAttachmentInputChange,
+    handleImageInputChange,
+    insertCardBlockFromUrl,
+    isHttpUrl,
+  }
+}

--- a/front/src/components/editor/useBlockEditorEngineQaActions.ts
+++ b/front/src/components/editor/useBlockEditorEngineQaActions.ts
@@ -1,0 +1,133 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import { useEffect } from "react"
+import type { RefObject } from "react"
+import type { BlockEditorQaActions } from "./blockEditorContract"
+import type { BlockEditorDoc } from "./serialization"
+import { createCalloutNode, createFormulaNode } from "./serialization"
+import { getEditorUndoDepth } from "./editorHistoryModel"
+import { refocusEditorForSelectionReveal } from "./editorScrollSelectionGuard"
+
+type UseBlockEditorEngineQaActionsArgs = {
+  editor: TiptapEditor | null
+  editorRef: RefObject<TiptapEditor | null>
+  insertBlocksAtIndex: (
+    insertionIndex: number,
+    blocks: NonNullable<BlockEditorDoc["content"]>,
+    focusIndex?: number
+  ) => void
+  moveTaskItemInFirstTaskList: (sourceIndex: number, insertionIndex: number) => void
+  onQaActionsReady: ((actions: BlockEditorQaActions | null) => void) | undefined
+  resizeFirstTableColumnBy: (deltaPx: number) => void
+  resizeFirstTableRowBy: (deltaPx: number) => void
+  selectCurrentTableAxis: (axis: "row" | "column") => void
+  selectTableColumnByIndex: (columnIndex: number) => void
+  updateActiveTableCellAttrs: (attrs: Record<string, unknown>) => void
+  withTrailingParagraph: (blocks: BlockEditorDoc[]) => NonNullable<BlockEditorDoc["content"]>
+}
+
+export const useBlockEditorEngineQaActions = ({
+  editor,
+  editorRef,
+  insertBlocksAtIndex,
+  moveTaskItemInFirstTaskList,
+  onQaActionsReady,
+  resizeFirstTableColumnBy,
+  resizeFirstTableRowBy,
+  selectCurrentTableAxis,
+  selectTableColumnByIndex,
+  updateActiveTableCellAttrs,
+  withTrailingParagraph,
+}: UseBlockEditorEngineQaActionsArgs) => {
+  useEffect(() => {
+    if (!onQaActionsReady) return
+
+    onQaActionsReady({
+      selectTableAxis: (axis) => {
+        selectCurrentTableAxis(axis)
+      },
+      selectTableColumnViaDomFallback: (columnIndex) => {
+        const currentEditor = editorRef.current ?? editor
+        if (!currentEditor) return
+        currentEditor.chain().focus("end").run()
+        selectTableColumnByIndex(columnIndex)
+      },
+      setActiveTableCellAlign: (align) => {
+        updateActiveTableCellAttrs({ textAlign: align })
+      },
+      setActiveTableCellBackground: (color) => {
+        updateActiveTableCellAttrs({ backgroundColor: color })
+      },
+      addTableRowAfter: () => {
+        editor?.chain().focus().addRowAfter().run()
+      },
+      addTableColumnAfter: () => {
+        editor?.chain().focus().addColumnAfter().run()
+      },
+      deleteSelectedTableRow: () => {
+        editor?.chain().focus().deleteRow().run()
+      },
+      deleteSelectedTableColumn: () => {
+        editor?.chain().focus().deleteColumn().run()
+      },
+      resizeFirstTableRow: (deltaPx) => {
+        resizeFirstTableRowBy(deltaPx)
+      },
+      resizeFirstTableColumn: (deltaPx) => {
+        resizeFirstTableColumnBy(deltaPx)
+      },
+      focusDocumentEnd: () => {
+        editor?.chain().focus("end").run()
+      },
+      appendCalloutBlock: () => {
+        const currentEditor = editorRef.current
+        if (!currentEditor) return
+        insertBlocksAtIndex(
+          currentEditor.state.doc.childCount,
+          withTrailingParagraph([
+            createCalloutNode({
+              kind: "tip",
+              title: "",
+              body: "",
+            }),
+          ])
+        )
+      },
+      appendFormulaBlock: () => {
+        const currentEditor = editorRef.current
+        if (!currentEditor) return
+        insertBlocksAtIndex(
+          currentEditor.state.doc.childCount,
+          withTrailingParagraph([
+            createFormulaNode({
+              formula: "",
+            }),
+          ])
+        )
+      },
+      moveTaskItemInFirstTaskList: (sourceIndex, insertionIndex) => {
+        moveTaskItemInFirstTaskList(sourceIndex, insertionIndex)
+      },
+      scrollCurrentSelectionIntoView: () => refocusEditorForSelectionReveal(editorRef.current ?? editor),
+      getUndoDepth: () => {
+        const currentEditor = editorRef.current ?? editor
+        return currentEditor ? getEditorUndoDepth(currentEditor) : 0
+      },
+    })
+
+    return () => {
+      onQaActionsReady(null)
+    }
+  }, [
+    editor,
+    editorRef,
+    insertBlocksAtIndex,
+    moveTaskItemInFirstTaskList,
+    onQaActionsReady,
+    resizeFirstTableColumnBy,
+    resizeFirstTableRowBy,
+    selectTableColumnByIndex,
+    selectCurrentTableAxis,
+    updateActiveTableCellAttrs,
+    withTrailingParagraph,
+  ])
+}

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -1,0 +1,296 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import { TextSelection } from "@tiptap/pm/state"
+import { useEffect } from "react"
+import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from "react"
+import { preserveWindowScrollForEditorPointerFocus } from "./blockHandleLayoutModel"
+import { isTableSelectionActive } from "./tableStructureModel"
+import {
+  areFloatingBubbleStatesEqual,
+  hideFloatingBubbleState,
+  resolveFloatingBubbleStateFromCoords,
+  type FloatingBubbleState,
+} from "./useFloatingBubbleState"
+
+type SetState<T> = Dispatch<SetStateAction<T>>
+
+type UseBlockEditorEngineSelectionBubbleEffectsArgs = {
+  bubbleToolbarHoveredRef: RefObject<boolean>
+  cancelBubbleHide: () => void
+  clearWindowTextSelection: () => void
+  editor: TiptapEditor | null
+  editorRef: RefObject<TiptapEditor | null>
+  hasTableStructuralSelection: (editor: TiptapEditor) => boolean
+  hideTableQuickRailImmediately: () => void
+  isTableColumnRailResizeActive: () => boolean
+  mouseTextSelectionInProgressRef: MutableRefObject<boolean>
+  scheduleBubbleHide: () => void
+  scheduleTableQuickRailHide: () => void
+  setBubbleState: SetState<FloatingBubbleState>
+  syncBubbleOnMouseUpRef: MutableRefObject<boolean>
+  syncTableQuickRailFromElement: (element: Element, clientX?: number, clientY?: number) => void
+  tableMenuState: unknown
+  tryStartTableColumnResizeFromDomHandle: (target: EventTarget | null, pointerId: number, clientX: number) => boolean
+}
+
+export const useBlockEditorEngineSelectionBubbleEffects = ({
+  bubbleToolbarHoveredRef,
+  cancelBubbleHide,
+  clearWindowTextSelection,
+  editor,
+  editorRef,
+  hasTableStructuralSelection,
+  hideTableQuickRailImmediately,
+  isTableColumnRailResizeActive,
+  mouseTextSelectionInProgressRef,
+  scheduleBubbleHide,
+  scheduleTableQuickRailHide,
+  setBubbleState,
+  syncBubbleOnMouseUpRef,
+  syncTableQuickRailFromElement,
+  tableMenuState,
+  tryStartTableColumnResizeFromDomHandle,
+}: UseBlockEditorEngineSelectionBubbleEffectsArgs) => {
+  useEffect(() => {
+    const currentEditor = editorRef.current ?? editor
+    if (!currentEditor) return
+    let rafId: number | null = null
+
+    const syncBubble = () => {
+      const activeEditor = editorRef.current ?? currentEditor
+      if (!activeEditor) {
+        scheduleBubbleHide()
+        if (!tableMenuState) {
+          hideTableQuickRailImmediately()
+        }
+        return
+      }
+
+      let selection = activeEditor.state.selection
+      if (selection.empty && typeof window !== "undefined" && !isTableColumnRailResizeActive()) {
+        const domSelection = window.getSelection()
+        const range =
+          domSelection && domSelection.rangeCount > 0 ? domSelection.getRangeAt(0) : null
+        const commonAncestor =
+          range?.commonAncestorContainer instanceof Element
+            ? range.commonAncestorContainer
+            : range?.commonAncestorContainer?.parentElement ?? null
+
+        if (range && domSelection && !domSelection.isCollapsed && commonAncestor && activeEditor.view.dom.contains(commonAncestor)) {
+          const syncPmSelectionFromRange = (from: number, to: number) => {
+            if (!Number.isFinite(from) || !Number.isFinite(to) || from === to) return false
+            const nextSelection = TextSelection.create(
+              activeEditor.state.doc,
+              Math.min(from, to),
+              Math.max(from, to)
+            )
+            if (!nextSelection.eq(activeEditor.state.selection)) {
+              activeEditor.view.dispatch(activeEditor.state.tr.setSelection(nextSelection))
+              selection = activeEditor.state.selection
+            }
+            return true
+          }
+
+          let synced = false
+          try {
+            const from = activeEditor.view.posAtDOM(range.startContainer, range.startOffset)
+            const to = activeEditor.view.posAtDOM(range.endContainer, range.endOffset)
+            synced = syncPmSelectionFromRange(from, to)
+          } catch {
+            synced = false
+          }
+
+          if (!synced) {
+            const rangeRects = Array.from(range.getClientRects())
+            const startRect = rangeRects[0] ?? range.getBoundingClientRect()
+            const endRect = rangeRects[rangeRects.length - 1] ?? startRect
+            const startCoords = activeEditor.view.posAtCoords({
+              left: startRect.left + 1,
+              top: startRect.top + startRect.height / 2,
+            })
+            const endCoords = activeEditor.view.posAtCoords({
+              left: Math.max(endRect.left + 1, endRect.right - 1),
+              top: endRect.top + endRect.height / 2,
+            })
+            if (startCoords?.pos && endCoords?.pos) {
+              syncPmSelectionFromRange(startCoords.pos, endCoords.pos)
+            }
+          }
+        }
+      }
+
+      const isImageNodeSelected = activeEditor.isActive("resizableImage")
+      const isTableActive = isTableSelectionActive(activeEditor)
+      const isTableStructuralSelection = hasTableStructuralSelection(activeEditor)
+      const canShowTextToolbar =
+        !selection.empty &&
+        !isImageNodeSelected &&
+        !activeEditor.isActive("codeBlock") &&
+        !activeEditor.isActive("rawMarkdownBlock") &&
+        !isTableStructuralSelection
+
+      if (canShowTextToolbar && mouseTextSelectionInProgressRef.current) {
+        syncBubbleOnMouseUpRef.current = true
+        if (bubbleToolbarHoveredRef.current) return
+        setBubbleState((prev) =>
+          prev.visible && prev.mode === "text" ? hideFloatingBubbleState(prev) : prev
+        )
+        if (!tableMenuState) {
+          hideTableQuickRailImmediately()
+        }
+        return
+      }
+
+      if (!isImageNodeSelected && !canShowTextToolbar && !isTableActive) {
+        if (bubbleToolbarHoveredRef.current) return
+        scheduleBubbleHide()
+        if (!tableMenuState) {
+          scheduleTableQuickRailHide()
+        }
+        return
+      }
+
+      if (isTableActive && !canShowTextToolbar) {
+        cancelBubbleHide()
+        setBubbleState(hideFloatingBubbleState)
+        const anchorDom = activeEditor.view.domAtPos(selection.from).node
+        const anchorElement =
+          anchorDom instanceof Element ? anchorDom : anchorDom.parentElement
+        if (isTableStructuralSelection && anchorElement?.closest(".aq-table-shell, .tableWrapper, table")) {
+          syncTableQuickRailFromElement(anchorElement)
+          return
+        }
+        if (!tableMenuState) {
+          hideTableQuickRailImmediately()
+        }
+        return
+      }
+
+      cancelBubbleHide()
+      hideTableQuickRailImmediately()
+
+      const startCoords = activeEditor.view.coordsAtPos(selection.from)
+      const endCoords = activeEditor.view.coordsAtPos(isImageNodeSelected ? selection.from : selection.to)
+      const nextBubbleState = resolveFloatingBubbleStateFromCoords(
+        isImageNodeSelected ? "image" : "text",
+        startCoords,
+        endCoords
+      )
+      setBubbleState((prev) =>
+        areFloatingBubbleStatesEqual(prev, nextBubbleState) ? prev : nextBubbleState
+      )
+    }
+
+    const scheduleSyncBubble = () => {
+      if (typeof window === "undefined") {
+        syncBubble()
+        return
+      }
+      if (rafId !== null) return
+      rafId = window.requestAnimationFrame(() => {
+        rafId = null
+        syncBubble()
+      })
+    }
+
+    const handleDocumentSelectionChange = () => {
+      const activeEditor = editorRef.current ?? currentEditor
+      if (!activeEditor) return
+      if (isTableColumnRailResizeActive()) {
+        clearWindowTextSelection()
+        return
+      }
+      const selection = window.getSelection()
+      const anchorNode = selection?.anchorNode ?? null
+      const anchorElement =
+        anchorNode instanceof Element ? anchorNode : anchorNode?.parentElement ?? null
+      if (anchorElement && !activeEditor.view.dom.contains(anchorElement)) return
+      scheduleSyncBubble()
+    }
+
+    const handleEditorPointerDownCapture = (event: PointerEvent) => {
+      if (event.pointerType !== "mouse" || event.button !== 0) return
+      const activeEditor = editorRef.current ?? currentEditor
+      if (!activeEditor) return
+      if (!(event.target instanceof Node) || !activeEditor.view.dom.contains(event.target)) return
+      preserveWindowScrollForEditorPointerFocus(event.target, isTableSelectionActive(activeEditor))
+      if (tryStartTableColumnResizeFromDomHandle(event.target, event.pointerId, event.clientX)) {
+        event.preventDefault()
+        event.stopPropagation()
+        event.stopImmediatePropagation?.()
+        mouseTextSelectionInProgressRef.current = false
+        syncBubbleOnMouseUpRef.current = false
+        return
+      }
+      mouseTextSelectionInProgressRef.current = true
+      syncBubbleOnMouseUpRef.current = false
+      if (bubbleToolbarHoveredRef.current) return
+      setBubbleState((prev) =>
+        prev.visible && prev.mode === "text" ? hideFloatingBubbleState(prev) : prev
+      )
+    }
+
+    const handleEditorMouseDownCapture = (event: MouseEvent) => {
+      const activeEditor = editorRef.current ?? currentEditor
+      if (!activeEditor) return
+      if (!(event.target instanceof Node) || !activeEditor.view.dom.contains(event.target)) return
+      if (!(event.target instanceof Element) || !event.target.closest(".column-resize-handle")) return
+      event.preventDefault()
+      event.stopPropagation()
+      event.stopImmediatePropagation?.()
+    }
+
+    const handleWindowPointerUp = (event: PointerEvent) => {
+      if (!mouseTextSelectionInProgressRef.current) return
+      if (event.pointerType && event.pointerType !== "mouse") return
+      mouseTextSelectionInProgressRef.current = false
+      if (!syncBubbleOnMouseUpRef.current) return
+      syncBubbleOnMouseUpRef.current = false
+      scheduleSyncBubble()
+    }
+
+    scheduleSyncBubble()
+    currentEditor.on("selectionUpdate", scheduleSyncBubble)
+    currentEditor.on("focus", scheduleSyncBubble)
+    document.addEventListener("selectionchange", handleDocumentSelectionChange)
+    document.addEventListener("pointerdown", handleEditorPointerDownCapture, true)
+    document.addEventListener("mousedown", handleEditorMouseDownCapture, true)
+    window.addEventListener("scroll", scheduleSyncBubble, { capture: true, passive: true })
+    window.addEventListener("resize", scheduleSyncBubble, { passive: true })
+    window.addEventListener("pointerup", handleWindowPointerUp, true)
+    window.addEventListener("pointercancel", handleWindowPointerUp, true)
+    return () => {
+      currentEditor.off("selectionUpdate", scheduleSyncBubble)
+      currentEditor.off("focus", scheduleSyncBubble)
+      document.removeEventListener("selectionchange", handleDocumentSelectionChange)
+      document.removeEventListener("pointerdown", handleEditorPointerDownCapture, true)
+      document.removeEventListener("mousedown", handleEditorMouseDownCapture, true)
+      window.removeEventListener("scroll", scheduleSyncBubble, true)
+      window.removeEventListener("resize", scheduleSyncBubble)
+      window.removeEventListener("pointerup", handleWindowPointerUp, true)
+      window.removeEventListener("pointercancel", handleWindowPointerUp, true)
+      if (rafId !== null && typeof window !== "undefined") {
+        window.cancelAnimationFrame(rafId)
+      }
+      mouseTextSelectionInProgressRef.current = false
+      syncBubbleOnMouseUpRef.current = false
+      cancelBubbleHide()
+    }
+  }, [
+    bubbleToolbarHoveredRef,
+    cancelBubbleHide,
+    clearWindowTextSelection,
+    editor,
+    editorRef,
+    hasTableStructuralSelection,
+    hideTableQuickRailImmediately,
+    isTableColumnRailResizeActive,
+    mouseTextSelectionInProgressRef,
+    scheduleBubbleHide,
+    scheduleTableQuickRailHide,
+    setBubbleState,
+    syncBubbleOnMouseUpRef,
+    syncTableQuickRailFromElement,
+    tableMenuState,
+    tryStartTableColumnResizeFromDomHandle,
+  ])
+}

--- a/front/src/components/editor/useBlockEditorEngineSelectionEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionEffects.ts
@@ -1,5 +1,4 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
-import { NodeSelection, TextSelection } from "@tiptap/pm/state"
 import { useEffect } from "react"
 import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from "react"
 import {
@@ -8,27 +7,23 @@ import {
   type BlockEditorDoc,
 } from "./serialization"
 import {
-  getEditableTextPositionForTopLevelBlock,
   getTopLevelBlockIndexFromSelection,
   isTabBlockSelectionEligible,
 } from "./blockSelectionModel"
-import { preserveWindowScrollForEditorPointerFocus } from "./blockHandleLayoutModel"
 import {
   LIST_ITEM_SELECTOR,
   type NestedListItemContext,
-  isSameNestedListItemContext,
   selectNestedListItemNode,
   selectNestedListItemTextAnchor,
 } from "./nestedListItemModel"
 import { isTableSelectionActive } from "./tableStructureModel"
 import {
-  areFloatingBubbleStatesEqual,
-  hideFloatingBubbleState,
-  resolveFloatingBubbleStateFromCoords,
   type FloatingBubbleState,
 } from "./useFloatingBubbleState"
 import type { BlockEditorSlashMenuState } from "./BlockEditorEngine.layers"
 import { downgradeDisabledFeatureNodes } from "./useBlockEditorEngineDocumentOps"
+import { useBlockEditorEngineSelectionBubbleEffects } from "./useBlockEditorEngineSelectionBubbleEffects"
+import { useBlockEditorEngineSelectionStateEffects } from "./useBlockEditorEngineSelectionStateEffects"
 
 type SetState<T> = Dispatch<SetStateAction<T>>
 
@@ -213,125 +208,7 @@ export const useBlockEditorEngineSelectionEffects = ({
     root.removeAttribute("data-keyboard-block-selection")
   }, [getContentRoot, keyboardBlockSelectionStickyRef, selectedBlockNodeIndex, selectionTick])
 
-  useEffect(() => {
-    if (!editor) return
-    let disposed = false
-
-    const notifySelection = () => {
-      const selection = editor.state.selection as typeof editor.state.selection & {
-        node?: { isBlock?: boolean }
-      }
-      const hasTextRangeSelection = selection instanceof TextSelection && !selection.empty
-      const liveSelectedNestedListItemContext = getNodeSelectedNestedListItemContext(editor)
-      const selectionAnchorNestedListItemContext = getSelectionAnchorNestedListItemContext(editor)
-      const effectiveSelectedNestedListItemContext = resolveEffectiveSelectedListItemContext(editor)
-      const shouldPreserveSelectedListItemContextForAnchorSelection = Boolean(
-        hasTextRangeSelection &&
-          selectionAnchorNestedListItemContext &&
-          effectiveSelectedNestedListItemContext &&
-          isSameNestedListItemContext(
-            selectionAnchorNestedListItemContext,
-            effectiveSelectedNestedListItemContext
-          )
-      )
-      const selectedNestedListItemContext =
-        liveSelectedNestedListItemContext?.listItemElement?.isConnected
-          ? liveSelectedNestedListItemContext
-          : shouldPreserveSelectedListItemContextForAnchorSelection
-            ? selectionAnchorNestedListItemContext
-            : effectiveSelectedNestedListItemContext
-      if (liveSelectedNestedListItemContext?.listItemElement?.isConnected) {
-        setSelectedListItemContext(liveSelectedNestedListItemContext)
-      } else if (shouldPreserveSelectedListItemContextForAnchorSelection && selectionAnchorNestedListItemContext) {
-        setSelectedListItemContext(selectionAnchorNestedListItemContext)
-      }
-      if (hasTextRangeSelection && keyboardBlockSelectionStickyRef.current) {
-        keyboardBlockSelectionStickyRef.current = false
-      }
-      const nextBlockIndex = getTopLevelBlockIndexFromSelection(editor)
-      const isTopLevelBlockNodeSelection = Boolean(
-        selection instanceof NodeSelection && selection.$from.depth === 0 && selection.node?.isBlock
-      )
-      const isNestedListItemNodeSelection = Boolean(selectedNestedListItemContext)
-      const inTableContext = isTableSelectionActive(editor) ? 1 : 0
-      const selectedNestedListItemSignature = selectedNestedListItemContext
-        ? `${selectedNestedListItemContext.listBlockIndex}:${selectedNestedListItemContext.listPath.join(".")}:${selectedNestedListItemContext.itemIndex}`
-        : "none"
-      const nextSignature = `${nextBlockIndex ?? "none"}:${hasTextRangeSelection ? 1 : 0}:${isTopLevelBlockNodeSelection ? 1 : 0}:${isNestedListItemNodeSelection ? 1 : 0}:${keyboardBlockSelectionStickyRef.current ? 1 : 0}:${inTableContext}:${selectedNestedListItemSignature}`
-      if (nextSignature === selectionUiSignatureRef.current) {
-        return
-      }
-      selectionUiSignatureRef.current = nextSignature
-      setSelectionTick((prev) => prev + 1)
-      setSelectedBlockIndex(nextBlockIndex)
-      if (hasTextRangeSelection && !selectedNestedListItemContext) {
-        setClickedBlockIndex(null)
-        setSelectedBlockNodeIndex(null)
-        setTextSelectionBlockIndex(nextBlockIndex)
-        setSelectedListItemContext(null)
-        return
-      }
-      setTextSelectionBlockIndex(null)
-      if (isNestedListItemNodeSelection) {
-        setClickedBlockIndex(null)
-        setSelectedBlockNodeIndex(null)
-        if (selectedNestedListItemContext?.listItemElement?.isConnected) {
-          setSelectedListItemContext(selectedNestedListItemContext)
-        }
-        return
-      }
-      if (isTopLevelBlockNodeSelection) {
-        setSelectedListItemContext(null)
-        if (keyboardBlockSelectionStickyRef.current) {
-          setClickedBlockIndex(null)
-          setSelectedBlockNodeIndex(nextBlockIndex)
-          return
-        }
-
-        const editablePos = getEditableTextPositionForTopLevelBlock(editor, nextBlockIndex)
-        if (editablePos !== null) {
-          const nextTextSelection = TextSelection.create(editor.state.doc, editablePos)
-          editor.view.dispatch(editor.state.tr.setSelection(nextTextSelection))
-        }
-        setSelectedBlockNodeIndex(null)
-        return
-      }
-      if (!keyboardBlockSelectionStickyRef.current) {
-        setSelectedBlockNodeIndex(null)
-      }
-    }
-
-    const notifyBlur = () => {
-      selectionUiSignatureRef.current = ""
-      setSelectionTick((prev) => prev + 1)
-      const finalizeBlur = () => {
-        if (disposed || editor.isFocused) return
-        setClickedBlockIndex(null)
-        setSelectedBlockIndex(null)
-        setTextSelectionBlockIndex(null)
-        if (!keyboardBlockSelectionStickyRef.current) {
-          setSelectedBlockNodeIndex(null)
-        }
-      }
-      if (typeof window !== "undefined") {
-        window.requestAnimationFrame(finalizeBlur)
-        return
-      }
-      finalizeBlur()
-    }
-
-    notifySelection()
-    editor.on("selectionUpdate", notifySelection)
-    editor.on("focus", notifySelection)
-    editor.on("blur", notifyBlur)
-    return () => {
-      disposed = true
-      editor.off("selectionUpdate", notifySelection)
-      editor.off("focus", notifySelection)
-      editor.off("blur", notifyBlur)
-      selectionUiSignatureRef.current = ""
-    }
-  }, [
+  useBlockEditorEngineSelectionStateEffects({
     editor,
     getNodeSelectedNestedListItemContext,
     getSelectionAnchorNestedListItemContext,
@@ -344,7 +221,7 @@ export const useBlockEditorEngineSelectionEffects = ({
     setSelectedListItemContext,
     setSelectionTick,
     setTextSelectionBlockIndex,
-  ])
+  })
 
   useEffect(() => {
     if (!editor) return
@@ -492,232 +369,7 @@ export const useBlockEditorEngineSelectionEffects = ({
     slashMenuState,
   ])
 
-  useEffect(() => {
-    const currentEditor = editorRef.current ?? editor
-    if (!currentEditor) return
-    let rafId: number | null = null
-
-    const syncBubble = () => {
-      const activeEditor = editorRef.current ?? currentEditor
-      if (!activeEditor) {
-        scheduleBubbleHide()
-        if (!tableMenuState) {
-          hideTableQuickRailImmediately()
-        }
-        return
-      }
-
-      let selection = activeEditor.state.selection
-      if (selection.empty && typeof window !== "undefined" && !isTableColumnRailResizeActive()) {
-        const domSelection = window.getSelection()
-        const range =
-          domSelection && domSelection.rangeCount > 0 ? domSelection.getRangeAt(0) : null
-        const commonAncestor =
-          range?.commonAncestorContainer instanceof Element
-            ? range.commonAncestorContainer
-            : range?.commonAncestorContainer?.parentElement ?? null
-
-        if (range && domSelection && !domSelection.isCollapsed && commonAncestor && activeEditor.view.dom.contains(commonAncestor)) {
-          const syncPmSelectionFromRange = (from: number, to: number) => {
-            if (!Number.isFinite(from) || !Number.isFinite(to) || from === to) return false
-            const nextSelection = TextSelection.create(
-              activeEditor.state.doc,
-              Math.min(from, to),
-              Math.max(from, to)
-            )
-            if (!nextSelection.eq(activeEditor.state.selection)) {
-              activeEditor.view.dispatch(activeEditor.state.tr.setSelection(nextSelection))
-              selection = activeEditor.state.selection
-            }
-            return true
-          }
-
-          let synced = false
-          try {
-            const from = activeEditor.view.posAtDOM(range.startContainer, range.startOffset)
-            const to = activeEditor.view.posAtDOM(range.endContainer, range.endOffset)
-            synced = syncPmSelectionFromRange(from, to)
-          } catch {
-            synced = false
-          }
-
-          if (!synced) {
-            const rangeRects = Array.from(range.getClientRects())
-            const startRect = rangeRects[0] ?? range.getBoundingClientRect()
-            const endRect = rangeRects[rangeRects.length - 1] ?? startRect
-            const startCoords = activeEditor.view.posAtCoords({
-              left: startRect.left + 1,
-              top: startRect.top + startRect.height / 2,
-            })
-            const endCoords = activeEditor.view.posAtCoords({
-              left: Math.max(endRect.left + 1, endRect.right - 1),
-              top: endRect.top + endRect.height / 2,
-            })
-            if (startCoords?.pos && endCoords?.pos) {
-              syncPmSelectionFromRange(startCoords.pos, endCoords.pos)
-            }
-          }
-        }
-      }
-
-      const isImageNodeSelected = activeEditor.isActive("resizableImage")
-      const isTableActive = isTableSelectionActive(activeEditor)
-      const isTableStructuralSelection = hasTableStructuralSelection(activeEditor)
-      const canShowTextToolbar =
-        !selection.empty &&
-        !isImageNodeSelected &&
-        !activeEditor.isActive("codeBlock") &&
-        !activeEditor.isActive("rawMarkdownBlock") &&
-        !isTableStructuralSelection
-
-      if (canShowTextToolbar && mouseTextSelectionInProgressRef.current) {
-        syncBubbleOnMouseUpRef.current = true
-        if (bubbleToolbarHoveredRef.current) return
-        setBubbleState((prev) =>
-          prev.visible && prev.mode === "text" ? hideFloatingBubbleState(prev) : prev
-        )
-        if (!tableMenuState) {
-          hideTableQuickRailImmediately()
-        }
-        return
-      }
-
-      if (!isImageNodeSelected && !canShowTextToolbar && !isTableActive) {
-        if (bubbleToolbarHoveredRef.current) return
-        scheduleBubbleHide()
-        if (!tableMenuState) {
-          scheduleTableQuickRailHide()
-        }
-        return
-      }
-
-      if (isTableActive && !canShowTextToolbar) {
-        cancelBubbleHide()
-        setBubbleState(hideFloatingBubbleState)
-        const anchorDom = activeEditor.view.domAtPos(selection.from).node
-        const anchorElement =
-          anchorDom instanceof Element ? anchorDom : anchorDom.parentElement
-        if (isTableStructuralSelection && anchorElement?.closest(".aq-table-shell, .tableWrapper, table")) {
-          syncTableQuickRailFromElement(anchorElement)
-          return
-        }
-        if (!tableMenuState) {
-          hideTableQuickRailImmediately()
-        }
-        return
-      }
-
-      cancelBubbleHide()
-      hideTableQuickRailImmediately()
-
-      const startCoords = activeEditor.view.coordsAtPos(selection.from)
-      const endCoords = activeEditor.view.coordsAtPos(isImageNodeSelected ? selection.from : selection.to)
-      const nextBubbleState = resolveFloatingBubbleStateFromCoords(
-        isImageNodeSelected ? "image" : "text",
-        startCoords,
-        endCoords
-      )
-      setBubbleState((prev) =>
-        areFloatingBubbleStatesEqual(prev, nextBubbleState) ? prev : nextBubbleState
-      )
-    }
-
-    const scheduleSyncBubble = () => {
-      if (typeof window === "undefined") {
-        syncBubble()
-        return
-      }
-      if (rafId !== null) return
-      rafId = window.requestAnimationFrame(() => {
-        rafId = null
-        syncBubble()
-      })
-    }
-
-    const handleDocumentSelectionChange = () => {
-      const activeEditor = editorRef.current ?? currentEditor
-      if (!activeEditor) return
-      if (isTableColumnRailResizeActive()) {
-        clearWindowTextSelection()
-        return
-      }
-      const selection = window.getSelection()
-      const anchorNode = selection?.anchorNode ?? null
-      const anchorElement =
-        anchorNode instanceof Element ? anchorNode : anchorNode?.parentElement ?? null
-      if (anchorElement && !activeEditor.view.dom.contains(anchorElement)) return
-      scheduleSyncBubble()
-    }
-
-    const handleEditorPointerDownCapture = (event: PointerEvent) => {
-      if (event.pointerType !== "mouse" || event.button !== 0) return
-      const activeEditor = editorRef.current ?? currentEditor
-      if (!activeEditor) return
-      if (!(event.target instanceof Node) || !activeEditor.view.dom.contains(event.target)) return
-      preserveWindowScrollForEditorPointerFocus(event.target, isTableSelectionActive(activeEditor))
-      if (tryStartTableColumnResizeFromDomHandle(event.target, event.pointerId, event.clientX)) {
-        event.preventDefault()
-        event.stopPropagation()
-        event.stopImmediatePropagation?.()
-        mouseTextSelectionInProgressRef.current = false
-        syncBubbleOnMouseUpRef.current = false
-        return
-      }
-      mouseTextSelectionInProgressRef.current = true
-      syncBubbleOnMouseUpRef.current = false
-      if (bubbleToolbarHoveredRef.current) return
-      setBubbleState((prev) =>
-        prev.visible && prev.mode === "text" ? hideFloatingBubbleState(prev) : prev
-      )
-    }
-
-    const handleEditorMouseDownCapture = (event: MouseEvent) => {
-      const activeEditor = editorRef.current ?? currentEditor
-      if (!activeEditor) return
-      if (!(event.target instanceof Node) || !activeEditor.view.dom.contains(event.target)) return
-      if (!(event.target instanceof Element) || !event.target.closest(".column-resize-handle")) return
-      event.preventDefault()
-      event.stopPropagation()
-      event.stopImmediatePropagation?.()
-    }
-
-    const handleWindowPointerUp = (event: PointerEvent) => {
-      if (!mouseTextSelectionInProgressRef.current) return
-      if (event.pointerType && event.pointerType !== "mouse") return
-      mouseTextSelectionInProgressRef.current = false
-      if (!syncBubbleOnMouseUpRef.current) return
-      syncBubbleOnMouseUpRef.current = false
-      scheduleSyncBubble()
-    }
-
-    scheduleSyncBubble()
-    currentEditor.on("selectionUpdate", scheduleSyncBubble)
-    currentEditor.on("focus", scheduleSyncBubble)
-    document.addEventListener("selectionchange", handleDocumentSelectionChange)
-    document.addEventListener("pointerdown", handleEditorPointerDownCapture, true)
-    document.addEventListener("mousedown", handleEditorMouseDownCapture, true)
-    window.addEventListener("scroll", scheduleSyncBubble, { capture: true, passive: true })
-    window.addEventListener("resize", scheduleSyncBubble, { passive: true })
-    window.addEventListener("pointerup", handleWindowPointerUp, true)
-    window.addEventListener("pointercancel", handleWindowPointerUp, true)
-    return () => {
-      currentEditor.off("selectionUpdate", scheduleSyncBubble)
-      currentEditor.off("focus", scheduleSyncBubble)
-      document.removeEventListener("selectionchange", handleDocumentSelectionChange)
-      document.removeEventListener("pointerdown", handleEditorPointerDownCapture, true)
-      document.removeEventListener("mousedown", handleEditorMouseDownCapture, true)
-      window.removeEventListener("scroll", scheduleSyncBubble, true)
-      window.removeEventListener("resize", scheduleSyncBubble)
-      window.removeEventListener("pointerup", handleWindowPointerUp, true)
-      window.removeEventListener("pointercancel", handleWindowPointerUp, true)
-      if (rafId !== null && typeof window !== "undefined") {
-        window.cancelAnimationFrame(rafId)
-      }
-      mouseTextSelectionInProgressRef.current = false
-      syncBubbleOnMouseUpRef.current = false
-      cancelBubbleHide()
-    }
-  }, [
+  useBlockEditorEngineSelectionBubbleEffects({
     bubbleToolbarHoveredRef,
     cancelBubbleHide,
     clearWindowTextSelection,
@@ -734,7 +386,7 @@ export const useBlockEditorEngineSelectionEffects = ({
     syncTableQuickRailFromElement,
     tableMenuState,
     tryStartTableColumnResizeFromDomHandle,
-  ])
+  })
 
   useEffect(() => {
     return () => {

--- a/front/src/components/editor/useBlockEditorEngineSelectionStateEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionStateEffects.ts
@@ -1,0 +1,178 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import { NodeSelection, TextSelection } from "@tiptap/pm/state"
+import { useEffect } from "react"
+import type { Dispatch, MutableRefObject, SetStateAction } from "react"
+import {
+  getEditableTextPositionForTopLevelBlock,
+  getTopLevelBlockIndexFromSelection,
+} from "./blockSelectionModel"
+import {
+  type NestedListItemContext,
+  isSameNestedListItemContext,
+} from "./nestedListItemModel"
+import { isTableSelectionActive } from "./tableStructureModel"
+
+type SetState<T> = Dispatch<SetStateAction<T>>
+
+type UseBlockEditorEngineSelectionStateEffectsArgs = {
+  editor: TiptapEditor | null
+  getNodeSelectedNestedListItemContext: (editor: TiptapEditor) => NestedListItemContext | null
+  getSelectionAnchorNestedListItemContext: (editor: TiptapEditor) => NestedListItemContext | null
+  keyboardBlockSelectionStickyRef: MutableRefObject<boolean>
+  resolveEffectiveSelectedListItemContext: (editor?: TiptapEditor | null) => NestedListItemContext | null
+  selectionUiSignatureRef: MutableRefObject<string>
+  setClickedBlockIndex: SetState<number | null>
+  setSelectedBlockIndex: SetState<number | null>
+  setSelectedBlockNodeIndex: SetState<number | null>
+  setSelectedListItemContext: SetState<NestedListItemContext | null>
+  setSelectionTick: SetState<number>
+  setTextSelectionBlockIndex: SetState<number | null>
+}
+
+export const useBlockEditorEngineSelectionStateEffects = ({
+  editor,
+  getNodeSelectedNestedListItemContext,
+  getSelectionAnchorNestedListItemContext,
+  keyboardBlockSelectionStickyRef,
+  resolveEffectiveSelectedListItemContext,
+  selectionUiSignatureRef,
+  setClickedBlockIndex,
+  setSelectedBlockIndex,
+  setSelectedBlockNodeIndex,
+  setSelectedListItemContext,
+  setSelectionTick,
+  setTextSelectionBlockIndex,
+}: UseBlockEditorEngineSelectionStateEffectsArgs) => {
+  useEffect(() => {
+    if (!editor) return
+    let disposed = false
+
+    const notifySelection = () => {
+      const selection = editor.state.selection as typeof editor.state.selection & {
+        node?: { isBlock?: boolean }
+      }
+      const hasTextRangeSelection = selection instanceof TextSelection && !selection.empty
+      const liveSelectedNestedListItemContext = getNodeSelectedNestedListItemContext(editor)
+      const selectionAnchorNestedListItemContext = getSelectionAnchorNestedListItemContext(editor)
+      const effectiveSelectedNestedListItemContext = resolveEffectiveSelectedListItemContext(editor)
+      const shouldPreserveSelectedListItemContextForAnchorSelection = Boolean(
+        hasTextRangeSelection &&
+          selectionAnchorNestedListItemContext &&
+          effectiveSelectedNestedListItemContext &&
+          isSameNestedListItemContext(
+            selectionAnchorNestedListItemContext,
+            effectiveSelectedNestedListItemContext
+          )
+      )
+      const selectedNestedListItemContext =
+        liveSelectedNestedListItemContext?.listItemElement?.isConnected
+          ? liveSelectedNestedListItemContext
+          : shouldPreserveSelectedListItemContextForAnchorSelection
+            ? selectionAnchorNestedListItemContext
+            : effectiveSelectedNestedListItemContext
+      if (liveSelectedNestedListItemContext?.listItemElement?.isConnected) {
+        setSelectedListItemContext(liveSelectedNestedListItemContext)
+      } else if (shouldPreserveSelectedListItemContextForAnchorSelection && selectionAnchorNestedListItemContext) {
+        setSelectedListItemContext(selectionAnchorNestedListItemContext)
+      }
+      if (hasTextRangeSelection && keyboardBlockSelectionStickyRef.current) {
+        keyboardBlockSelectionStickyRef.current = false
+      }
+      const nextBlockIndex = getTopLevelBlockIndexFromSelection(editor)
+      const isTopLevelBlockNodeSelection = Boolean(
+        selection instanceof NodeSelection && selection.$from.depth === 0 && selection.node?.isBlock
+      )
+      const isNestedListItemNodeSelection = Boolean(selectedNestedListItemContext)
+      const inTableContext = isTableSelectionActive(editor) ? 1 : 0
+      const selectedNestedListItemSignature = selectedNestedListItemContext
+        ? `${selectedNestedListItemContext.listBlockIndex}:${selectedNestedListItemContext.listPath.join(".")}:${selectedNestedListItemContext.itemIndex}`
+        : "none"
+      const nextSignature = `${nextBlockIndex ?? "none"}:${hasTextRangeSelection ? 1 : 0}:${isTopLevelBlockNodeSelection ? 1 : 0}:${isNestedListItemNodeSelection ? 1 : 0}:${keyboardBlockSelectionStickyRef.current ? 1 : 0}:${inTableContext}:${selectedNestedListItemSignature}`
+      if (nextSignature === selectionUiSignatureRef.current) {
+        return
+      }
+      selectionUiSignatureRef.current = nextSignature
+      setSelectionTick((prev) => prev + 1)
+      setSelectedBlockIndex(nextBlockIndex)
+      if (hasTextRangeSelection && !selectedNestedListItemContext) {
+        setClickedBlockIndex(null)
+        setSelectedBlockNodeIndex(null)
+        setTextSelectionBlockIndex(nextBlockIndex)
+        setSelectedListItemContext(null)
+        return
+      }
+      setTextSelectionBlockIndex(null)
+      if (isNestedListItemNodeSelection) {
+        setClickedBlockIndex(null)
+        setSelectedBlockNodeIndex(null)
+        if (selectedNestedListItemContext?.listItemElement?.isConnected) {
+          setSelectedListItemContext(selectedNestedListItemContext)
+        }
+        return
+      }
+      if (isTopLevelBlockNodeSelection) {
+        setSelectedListItemContext(null)
+        if (keyboardBlockSelectionStickyRef.current) {
+          setClickedBlockIndex(null)
+          setSelectedBlockNodeIndex(nextBlockIndex)
+          return
+        }
+
+        const editablePos = getEditableTextPositionForTopLevelBlock(editor, nextBlockIndex)
+        if (editablePos !== null) {
+          const nextTextSelection = TextSelection.create(editor.state.doc, editablePos)
+          editor.view.dispatch(editor.state.tr.setSelection(nextTextSelection))
+        }
+        setSelectedBlockNodeIndex(null)
+        return
+      }
+      if (!keyboardBlockSelectionStickyRef.current) {
+        setSelectedBlockNodeIndex(null)
+      }
+    }
+
+    const notifyBlur = () => {
+      selectionUiSignatureRef.current = ""
+      setSelectionTick((prev) => prev + 1)
+      const finalizeBlur = () => {
+        if (disposed || editor.isFocused) return
+        setClickedBlockIndex(null)
+        setSelectedBlockIndex(null)
+        setTextSelectionBlockIndex(null)
+        if (!keyboardBlockSelectionStickyRef.current) {
+          setSelectedBlockNodeIndex(null)
+        }
+      }
+      if (typeof window !== "undefined") {
+        window.requestAnimationFrame(finalizeBlur)
+        return
+      }
+      finalizeBlur()
+    }
+
+    notifySelection()
+    editor.on("selectionUpdate", notifySelection)
+    editor.on("focus", notifySelection)
+    editor.on("blur", notifyBlur)
+    return () => {
+      disposed = true
+      editor.off("selectionUpdate", notifySelection)
+      editor.off("focus", notifySelection)
+      editor.off("blur", notifyBlur)
+      selectionUiSignatureRef.current = ""
+    }
+  }, [
+    editor,
+    getNodeSelectedNestedListItemContext,
+    getSelectionAnchorNestedListItemContext,
+    keyboardBlockSelectionStickyRef,
+    resolveEffectiveSelectedListItemContext,
+    selectionUiSignatureRef,
+    setClickedBlockIndex,
+    setSelectedBlockIndex,
+    setSelectedBlockNodeIndex,
+    setSelectedListItemContext,
+    setSelectionTick,
+    setTextSelectionBlockIndex,
+  ])
+}


### PR DESCRIPTION
## 관련 이슈

close #414

## 작업 배경

- Block editor engine controller와 주변 residual hook들을 600 line companion budget 안으로 분리했습니다.
- controller는 composition/command wiring 중심으로 줄이고 drag/session, insert media/QA, selection/bubble/state, block selection layout, document model 책임을 companion module로 옮겼습니다.

## 작업 내용

- engine residual budget 테스트를 600 line 기준과 새 companion source-boundary 검사로 확장했습니다.
- `useBlockEditorEngineControllerState`, controller handler, drag session, insert media/QA, selection effect companion, block selection layout, document model module을 추가했습니다.
- 기존 source-boundary 테스트가 분리된 runtime source를 함께 검증하도록 보정하고 narrow-rail 테스트 렌더 대기를 안정화했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=front-refactor-block-editor-engine-residual-hooks bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1 --grep "engine residual"`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts e2e/editor-authoring-flow.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front playwright test e2e/block-editor-serialization.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: controller state/handler companion 분리 과정에서 hook dependency나 source-boundary 테스트가 실제 책임 위치와 어긋날 수 있습니다.
- 롤백 방법: 이 PR의 단일 commit `3df71175`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
