### PR TITLE
[Refactor] App shell notification과 auth entry 600 line 이하 분리

### DIFF
--- a/front/e2e/header-refresh-auth.spec.ts
+++ b/front/e2e/header-refresh-auth.spec.ts
@@ -1,6 +1,27 @@
 import { expect, test, type Page } from "@playwright/test"
+import { existsSync, readFileSync } from "fs"
+import path from "path"
 
 const HEADER_AUTH_SHELL_STORAGE_KEY = "header.auth-shell.v1"
+
+test("header notification and login residual files stay below the 600 line budget", () => {
+  const sourceRoot = path.resolve(__dirname, "../src")
+  const targetFiles = [
+    "layouts/RootLayout/Header/useNotificationBellState.ts",
+    "pages/login.tsx",
+  ]
+
+  const oversizedFiles = targetFiles
+    .map((relativePath) => path.join(sourceRoot, relativePath))
+    .filter((sourcePath) => existsSync(sourcePath))
+    .map((sourcePath) => ({
+      sourcePath: path.relative(sourceRoot, sourcePath),
+      lineCount: readFileSync(sourcePath, "utf8").split("\n").length,
+    }))
+    .filter(({ lineCount }) => lineCount > 600)
+
+  expect(oversizedFiles).toEqual([])
+})
 
 const createExplorePage = (title: string) => ({
   content: [

--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -919,10 +919,11 @@ test("상단 내비 컨트롤은 공통 높이 토큰을 유지한다", async ({
 
 test("로그인 화면은 활성 소셜 provider가 없으면 빈 소셜 로그인 섹션을 렌더하지 않는다", async () => {
   const loginSource = readFileSync(path.resolve(__dirname, "../src/pages/login.tsx"), "utf8")
+  const loginFormSource = readFileSync(path.resolve(__dirname, "../src/components/auth/LoginPageForm.tsx"), "utf8")
 
   expect(loginSource).toContain("const hasSocialItems = socialItems.length > 0")
   expect(loginSource).toContain("if (!hasSocialItems || showSocialAuth")
-  expect(loginSource).toContain("{hasSocialItems ? (")
+  expect(loginFormSource).toContain("{hasSocialItems ? (")
 })
 
 test("로그인 화면은 visible 페이지 제목을 h1로 노출한다", async ({ page }) => {

--- a/front/src/components/auth/LoginPage.styles.ts
+++ b/front/src/components/auth/LoginPage.styles.ts
@@ -1,0 +1,346 @@
+import styled from "@emotion/styled"
+
+export const NaverField = styled.div`
+  position: relative;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 14px;
+  background: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray1 : theme.colors.gray2)};
+  min-height: 76px;
+  padding: 1.55rem 0.92rem 0.48rem;
+  box-shadow: ${({ theme }) =>
+    theme.scheme === "light" ? "0 1px 0 rgba(15, 23, 42, 0.03)" : "none"};
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+
+  &[data-active="true"] {
+    border-color: ${({ theme }) => theme.colors.gray7};
+    box-shadow: ${({ theme }) =>
+      theme.scheme === "light" ? "0 0 0 2px rgba(148, 163, 184, 0.12)" : "0 0 0 2px rgba(148, 163, 184, 0.1)"};
+  }
+`
+
+export const NaverFieldLabel = styled.label`
+  position: absolute;
+  left: 0.92rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1;
+  pointer-events: none;
+  transition: top 0.2s ease, transform 0.2s ease, font-size 0.2s ease, color 0.2s ease;
+
+  &[data-active="true"] {
+    top: 0.82rem;
+    transform: translateY(0);
+    font-size: 0.72rem;
+    color: ${({ theme }) => theme.colors.gray11};
+  }
+`
+
+export const NaverInput = styled.input`
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray12};
+  min-height: 42px;
+  padding: 0;
+  font-size: 1.05rem;
+  font-weight: 650;
+  line-height: 1.3;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.96rem;
+    font-weight: 500;
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &[data-password="true"] {
+    padding-right: 8.35rem;
+  }
+`
+
+export const FieldActions = styled.div`
+  position: absolute;
+  top: 50%;
+  right: 0.5rem;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+`
+
+export const PasswordActions = styled.div`
+  position: absolute;
+  top: 50%;
+  right: 0.5rem;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+`
+
+export const GhostIconButton = styled.button`
+  min-width: 44px;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 999px;
+  background: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray1 : theme.colors.gray2)};
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.72rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: filter 0.16s ease;
+
+  &:hover:not(:disabled) {
+    filter: brightness(1.08);
+  }
+
+  &:disabled {
+    opacity: 0.62;
+    cursor: not-allowed;
+  }
+
+  &.visibilityToggle {
+    border: 0;
+    background: transparent;
+    color: ${({ theme }) => theme.colors.gray11};
+    width: 44px;
+    min-width: 44px;
+  }
+
+  svg {
+    font-size: 0.74rem;
+  }
+
+  &.visibilityToggle svg {
+    font-size: 1.12rem;
+  }
+`
+
+export const LoginStateRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.9rem;
+  margin-top: 0.12rem;
+  margin-bottom: 0.06rem;
+
+  @media (max-width: 640px) {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.42rem;
+  }
+`
+
+export const FeedbackSlot = styled.div`
+  min-height: 4.6rem;
+  display: flex;
+  align-items: stretch;
+
+  &[data-filled="false"] {
+    min-height: 4.1rem;
+  }
+
+  > * {
+    width: 100%;
+  }
+`
+
+export const KeepSignedInButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.46rem;
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.9rem;
+  font-weight: 650;
+  min-height: 44px;
+  padding: 0.22rem 0.2rem;
+  border-radius: 10px;
+  touch-action: manipulation;
+
+  .checkIcon {
+    width: 28px;
+    height: 28px;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: ${({ theme }) => theme.colors.gray9};
+    transition: color 0.2s ease, transform 0.2s ease;
+  }
+
+  .checkIcon svg {
+    font-size: 1.45rem;
+  }
+
+  &[data-on="true"] .checkIcon {
+    color: ${({ theme }) => theme.colors.gray11};
+    transform: scale(1.03);
+  }
+`
+
+export const IpSecurityToggle = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: 0.9rem;
+  font-weight: 700;
+  min-height: 44px;
+  padding: 0.22rem 0;
+  touch-action: manipulation;
+
+  .switch {
+    width: 52px;
+    height: 30px;
+    border-radius: 999px;
+    border: 1px solid ${({ theme }) => theme.colors.gray7};
+    background: ${({ theme }) => theme.colors.gray5};
+    padding: 2px;
+    display: inline-flex;
+    align-items: center;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+  }
+
+  .thumb {
+    width: 24px;
+    height: 24px;
+    border-radius: 999px;
+    background: ${({ theme }) => theme.colors.gray1};
+    transition: transform 0.22s ease;
+    transform: translateX(0);
+  }
+
+  .state {
+    width: 28px;
+    text-align: right;
+    color: ${({ theme }) => theme.colors.gray10};
+    transition: color 0.2s ease;
+  }
+
+  &[data-on="true"] .switch {
+    background: rgba(18, 184, 134, 0.44);
+    border-color: rgba(18, 184, 134, 0.76);
+  }
+
+  &[data-on="true"] .thumb {
+    transform: translateX(20px);
+  }
+
+  &[data-on="true"] .state {
+    color: ${({ theme }) => theme.colors.green10};
+  }
+`
+
+export const IpSecurityControl = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.46rem;
+
+  @media (max-width: 640px) {
+    align-self: flex-end;
+  }
+`
+
+export const IpSecurityInfoButton = styled.button`
+  border: 0;
+  min-height: 44px;
+  padding: 0.15rem 0.3rem;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-color: ${({ theme }) => theme.colors.gray7};
+  text-underline-offset: 2px;
+  cursor: pointer;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.accentLink};
+    text-decoration-color: ${({ theme }) => theme.colors.accentBorder};
+  }
+`
+
+export const PrimaryButton = styled.button`
+  border: 0;
+  border-radius: 12px;
+  padding: 0.84rem 1rem;
+  background: #12b886;
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: ${({ theme }) =>
+    theme.scheme === "light" ? "0 10px 22px rgba(18, 184, 134, 0.18)" : "none"};
+  transition: filter 0.16s ease, box-shadow 0.16s ease;
+
+  &:hover:not(:disabled) {
+    filter: brightness(1.06);
+  }
+
+  &:disabled {
+    opacity: 0.68;
+    cursor: not-allowed;
+  }
+`
+
+export const ErrorText = styled.p`
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid ${({ theme }) => theme.colors.statusDangerBorder};
+  background: ${({ theme }) => theme.colors.statusDangerSurface};
+  color: ${({ theme }) => theme.colors.statusDangerText};
+  padding: 0.82rem 0.9rem;
+  font-size: 0.9rem;
+  line-height: 1.55;
+`
+
+export const SuccessText = styled.p`
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid ${({ theme }) => theme.colors.statusSuccessBorder};
+  background: ${({ theme }) => theme.colors.statusSuccessSurface};
+  color: ${({ theme }) => theme.colors.statusSuccessText};
+  padding: 0.82rem 0.9rem;
+  font-size: 0.87rem;
+  line-height: 1.65;
+
+  strong {
+    font-weight: 800;
+  }
+`
+
+export const FooterText = styled.p`
+  margin: 0;
+
+  a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 34px;
+  }
+`
+
+export const SocialSection = styled.div`
+  display: grid;
+  gap: 0.8rem;
+  margin-top: 0.15rem;
+
+  > span {
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.88rem;
+    font-weight: 700;
+  }
+`
+
+export const SocialButtonRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`

--- a/front/src/components/auth/LoginPageForm.tsx
+++ b/front/src/components/auth/LoginPageForm.tsx
@@ -1,0 +1,196 @@
+import dynamic from "next/dynamic"
+import type { Dispatch, FormEvent, ReactNode, SetStateAction } from "react"
+import AppIcon from "src/components/icons/AppIcon"
+import type { SocialAuthItem } from "./SocialAuthButtons"
+import {
+  FeedbackSlot,
+  FieldActions,
+  GhostIconButton,
+  IpSecurityControl,
+  IpSecurityInfoButton,
+  IpSecurityToggle,
+  KeepSignedInButton,
+  LoginStateRow,
+  NaverField,
+  NaverFieldLabel,
+  NaverInput,
+  PasswordActions,
+  PrimaryButton,
+  SocialButtonRow,
+  SocialSection,
+} from "./LoginPage.styles"
+
+const SocialAuthButtons = dynamic(() => import("src/components/auth/SocialAuthButtons"), {
+  ssr: false,
+})
+
+const IpSecurityInfoModal = dynamic(() => import("src/components/auth/IpSecurityInfoModal"), {
+  ssr: false,
+})
+
+type LoginPageFormProps = {
+  email: string
+  password: string
+  showPassword: boolean
+  loading: boolean
+  loginIdActive: boolean
+  passwordActive: boolean
+  keepSignedIn: boolean
+  ipSecurityOn: boolean
+  showIpSecurityInfo: boolean
+  feedbackMessage: ReactNode
+  hasSocialItems: boolean
+  showSocialAuth: boolean
+  socialItems: SocialAuthItem[]
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void
+  setEmail: Dispatch<SetStateAction<string>>
+  setPassword: Dispatch<SetStateAction<string>>
+  setShowPassword: Dispatch<SetStateAction<boolean>>
+  setLoginIdFocused: Dispatch<SetStateAction<boolean>>
+  setPasswordFocused: Dispatch<SetStateAction<boolean>>
+  setKeepSignedIn: Dispatch<SetStateAction<boolean>>
+  setIpSecurityOn: Dispatch<SetStateAction<boolean>>
+  setShowIpSecurityInfo: Dispatch<SetStateAction<boolean>>
+}
+
+export const LoginPageForm = ({
+  email,
+  password,
+  showPassword,
+  loading,
+  loginIdActive,
+  passwordActive,
+  keepSignedIn,
+  ipSecurityOn,
+  showIpSecurityInfo,
+  feedbackMessage,
+  hasSocialItems,
+  showSocialAuth,
+  socialItems,
+  onSubmit,
+  setEmail,
+  setPassword,
+  setShowPassword,
+  setLoginIdFocused,
+  setPasswordFocused,
+  setKeepSignedIn,
+  setIpSecurityOn,
+  setShowIpSecurityInfo,
+}: LoginPageFormProps) => {
+  return (
+    <>
+      <form onSubmit={onSubmit} noValidate>
+        <NaverField data-active={loginIdActive}>
+          <NaverFieldLabel htmlFor="email" data-active={loginIdActive ? "true" : "false"}>
+            이메일
+          </NaverFieldLabel>
+          <NaverInput
+            id="email"
+            type="email"
+            inputMode="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            onFocus={() => setLoginIdFocused(true)}
+            onBlur={() => setLoginIdFocused(false)}
+            placeholder=""
+            autoComplete="email"
+          />
+          {email.length > 0 && (
+            <FieldActions>
+              <GhostIconButton type="button" aria-label="이메일 입력 지우기" onClick={() => setEmail("")}>
+                <AppIcon name="close" />
+              </GhostIconButton>
+            </FieldActions>
+          )}
+        </NaverField>
+
+        <NaverField data-active={passwordActive}>
+          <NaverFieldLabel htmlFor="password" data-active={passwordActive ? "true" : "false"}>
+            비밀번호
+          </NaverFieldLabel>
+          <NaverInput
+            id="password"
+            type={showPassword ? "text" : "password"}
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            onFocus={() => setPasswordFocused(true)}
+            onBlur={() => setPasswordFocused(false)}
+            placeholder=""
+            autoComplete="current-password"
+            data-password="true"
+          />
+          <PasswordActions>
+            {password.length > 0 && (
+              <GhostIconButton type="button" aria-label="비밀번호 입력 지우기" onClick={() => setPassword("")}>
+                <AppIcon name="close" />
+              </GhostIconButton>
+            )}
+            <GhostIconButton
+              className="visibilityToggle"
+              type="button"
+              onClick={() => setShowPassword((value) => !value)}
+              aria-label="비밀번호 표시 전환"
+            >
+              <AppIcon name={showPassword ? "eye-off" : "eye"} />
+            </GhostIconButton>
+          </PasswordActions>
+        </NaverField>
+
+        <LoginStateRow>
+          <KeepSignedInButton
+            type="button"
+            data-on={keepSignedIn}
+            aria-pressed={keepSignedIn}
+            onClick={() => setKeepSignedIn((value) => !value)}
+          >
+            <span className="checkIcon" aria-hidden="true">
+              <AppIcon name="check-circle" />
+            </span>
+            <span>로그인 상태 유지</span>
+          </KeepSignedInButton>
+
+          <IpSecurityControl>
+            <IpSecurityInfoButton
+              type="button"
+              onClick={() => setShowIpSecurityInfo(true)}
+              aria-haspopup="dialog"
+              aria-controls="ip-security-info-dialog"
+            >
+              IP보안
+            </IpSecurityInfoButton>
+            <IpSecurityToggle
+              type="button"
+              data-on={ipSecurityOn}
+              aria-pressed={ipSecurityOn}
+              aria-label="IP보안 ON/OFF"
+              onClick={() => setIpSecurityOn((value) => !value)}
+            >
+              <span className="switch" aria-hidden="true">
+                <span className="thumb" />
+              </span>
+              <span className="state">{ipSecurityOn ? "ON" : "OFF"}</span>
+            </IpSecurityToggle>
+          </IpSecurityControl>
+        </LoginStateRow>
+
+        <FeedbackSlot aria-live="polite" data-filled={feedbackMessage ? "true" : "false"}>
+          {feedbackMessage}
+        </FeedbackSlot>
+
+        <PrimaryButton type="submit" disabled={loading}>
+          {loading ? "로그인 중..." : "로그인"}
+        </PrimaryButton>
+
+        {hasSocialItems ? (
+          <SocialSection>
+            <span>소셜 계정으로 로그인</span>
+            <SocialButtonRow>
+              {showSocialAuth ? <SocialAuthButtons items={socialItems} /> : null}
+            </SocialButtonRow>
+          </SocialSection>
+        ) : null}
+      </form>
+      {showIpSecurityInfo ? <IpSecurityInfoModal open={showIpSecurityInfo} onClose={() => setShowIpSecurityInfo(false)} /> : null}
+    </>
+  )
+}

--- a/front/src/layouts/RootLayout/Header/useNotificationBellState.ts
+++ b/front/src/layouts/RootLayout/Header/useNotificationBellState.ts
@@ -1,44 +1,25 @@
 import { useRouter } from "next/router"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { ApiError, ApiTimeoutError } from "src/apis/backend/client"
+import { ApiError } from "src/apis/backend/client"
 import {
   buildNotificationStreamUrl,
   getNotificationSnapshot,
   markAllNotificationsRead,
   markNotificationRead,
 } from "src/apis/backend/notifications"
-import {
-  canProbeNotificationStreamRecovery,
-  createNotificationStreamRecoveryState,
-  markNotificationPollingFallbackEntered,
-  recordNotificationStreamFailure,
-  resetNotificationStreamFailures,
-  shouldSwitchNotificationStreamToPolling,
-} from "src/layouts/RootLayout/Header/notificationStreamRecovery"
+import { createNotificationStreamRecoveryState } from "src/layouts/RootLayout/Header/notificationStreamRecovery"
 import { acquireBodyScrollLock } from "src/libs/utils/bodyScrollLock"
 import { toCanonicalPostPath } from "src/libs/utils/postPath"
 import { pushRoute } from "src/libs/router"
-import { TMemberNotification, TMemberNotificationStreamPayload } from "src/types"
+import { TMemberNotification } from "src/types"
+import { useNotificationBellTransport } from "./useNotificationBellTransport"
 import {
   AVATAR_PRELOAD_CACHE_MAX,
   AVATAR_PRELOAD_LIMIT,
   EventSourceLifecycleState,
-  HIDDEN_GRACE_CLOSE_MS,
   NOTIFICATION_TRANSPORT_MODE,
-  POLLING_FAILURE_COOLDOWN_MS,
-  POLLING_FAILURE_COOLDOWN_THRESHOLD,
-  POLLING_INTERVAL_MS,
-  POLLING_MAX_BACKOFF_MULTIPLIER,
-  POLLING_MIN_INTERVAL_MS,
-  POLLING_SAVE_DATA_MULTIPLIER,
-  POLLING_SLOW_NETWORK_MULTIPLIER,
-  SNAPSHOT_FAILURE_LOG_THRESHOLD,
-  STREAM_MAX_RECONNECT_ATTEMPTS,
   SnapshotLoadStatus,
   clearStoredSnapshot,
-  getNavigatorConnection,
-  getNextPollingDelayMs,
-  isNavigatorOnline,
   isSameNotificationList,
   isSameSiteOrigin,
   loadStoredLastEventId,
@@ -106,62 +87,9 @@ export const useNotificationBellState = (enabled: boolean) => {
   const unreadCountRef = useRef(0)
   const preloadedAvatarSrcRef = useRef<Set<string>>(new Set())
 
-  const describeSnapshotError = useCallback((error: unknown) => {
-    if (error instanceof ApiTimeoutError) {
-      return `timeout(${error.timeoutMs}ms)`
-    }
-    if (error instanceof ApiError) {
-      return `api-${error.status}`
-    }
-    if (error instanceof DOMException) {
-      return error.name
-    }
-    if (error instanceof Error) {
-      return error.name
-    }
-    return "unknown"
-  }, [])
-
   const resetSnapshotFailureObservation = useCallback(() => {
     lastSnapshotErrorRef.current = null
     lastLoggedSnapshotFailureStreakRef.current = 0
-  }, [])
-
-  const reportSnapshotFailureIfNeeded = useCallback(
-    (nextFailureStreak: number) => {
-      if (nextFailureStreak < SNAPSHOT_FAILURE_LOG_THRESHOLD) return
-      if (lastLoggedSnapshotFailureStreakRef.current >= nextFailureStreak) return
-
-      lastLoggedSnapshotFailureStreakRef.current = nextFailureStreak
-      console.warn("[notifications] snapshot polling is recovering from repeated failures", {
-        streak: nextFailureStreak,
-        reason: describeSnapshotError(lastSnapshotErrorRef.current),
-        mode: streamMode,
-        fallback: lastSnapshotErrorRef.current ? "none-or-session" : "cache",
-      })
-    },
-    [describeSnapshotError, streamMode]
-  )
-
-  const resolvePollingBaseIntervalMs = useCallback((failureStreak: number) => {
-    let baseMs = POLLING_INTERVAL_MS
-    const connection = getNavigatorConnection()
-    if (connection?.saveData) {
-      baseMs = Math.round(baseMs * POLLING_SAVE_DATA_MULTIPLIER)
-    } else if (connection?.effectiveType === "slow-2g" || connection?.effectiveType === "2g") {
-      baseMs = Math.round(baseMs * POLLING_SLOW_NETWORK_MULTIPLIER)
-    }
-
-    if (failureStreak > 0) {
-      const multiplier = Math.min(POLLING_MAX_BACKOFF_MULTIPLIER, 2 ** failureStreak)
-      baseMs = Math.round(baseMs * multiplier)
-    }
-
-    if (failureStreak >= POLLING_FAILURE_COOLDOWN_THRESHOLD) {
-      baseMs = Math.max(baseMs, POLLING_FAILURE_COOLDOWN_MS)
-    }
-
-    return Math.max(POLLING_MIN_INTERVAL_MS, baseMs)
   }, [])
 
   const setLastNotificationEventId = useCallback((eventId: string | null) => {
@@ -444,326 +372,40 @@ export const useNotificationBellState = (enabled: boolean) => {
     persistSnapshot({ items, unreadCount })
   }, [enabled, isReady, items, unreadCount])
 
-  useEffect(() => {
-    if (!enabled || !isRealtimeActive || streamMode !== "sse" || notificationAccessState !== "ready") {
-      clearReconnectTimerRef.current()
-      attachEventSourceRef.current = null
-      closeEventSource(true)
-      return
-    }
-
-    let disposed = false
-
-    const clearReconnectTimer = () => {
-      if (reconnectTimerRef.current !== null) {
-        window.clearTimeout(reconnectTimerRef.current)
-        reconnectTimerRef.current = null
-      }
-    }
-
-    clearReconnectTimerRef.current = clearReconnectTimer
-
-    const scheduleReconnect = () => {
-      if (disposed || reconnectTimerRef.current !== null || intentionalCloseRef.current) return
-
-      setIsReady(false)
-      const nextAttempt = reconnectAttemptRef.current + 1
-      reconnectAttemptRef.current = nextAttempt
-      recoveryStateRef.current = recordNotificationStreamFailure(recoveryStateRef.current, Date.now())
-
-      if (shouldSwitchNotificationStreamToPolling(recoveryStateRef.current, Date.now())) {
-        closeEventSource(false)
-        recoveryStateRef.current = markNotificationPollingFallbackEntered(recoveryStateRef.current, Date.now())
-        setStreamMode("poll")
-        return
-      }
-
-      if (nextAttempt > STREAM_MAX_RECONNECT_ATTEMPTS) {
-        closeEventSource(false)
-        recoveryStateRef.current = markNotificationPollingFallbackEntered(recoveryStateRef.current, Date.now())
-        setStreamMode("poll")
-        return
-      }
-
-      const retryDelay = Math.min(1500 * nextAttempt, 10000)
-      reconnectTimerRef.current = window.setTimeout(() => {
-        reconnectTimerRef.current = null
-        attachEventSourceRef.current?.()
-      }, retryDelay)
-    }
-
-    const attachEventSource = () => {
-      if (disposed) return
-      if (!isDocumentVisibleRef.current) return
-      if (streamLifecycleRef.current === "connecting" || streamLifecycleRef.current === "open") return
-      if (eventSourceRef.current) return
-
-      clearReconnectTimer()
-      intentionalCloseRef.current = false
-      streamLifecycleRef.current = "connecting"
-      const streamUrl = new URL(buildNotificationStreamUrl(), window.location.origin)
-      if (lastEventIdRef.current) {
-        // We recreate EventSource manually (for backoff/fallback control), so we pass the last id explicitly.
-        streamUrl.searchParams.set("lastEventId", lastEventIdRef.current)
-      }
-
-      const eventSource = new EventSource(streamUrl.toString(), { withCredentials: true })
-      eventSourceRef.current = eventSource
-
-      const markStreamOpen = () => {
-        streamLifecycleRef.current = "open"
-      }
-
-      const handleNotification = (event: MessageEvent<string>) => {
-        markStreamOpen()
-        try {
-          const payload = JSON.parse(event.data) as TMemberNotificationStreamPayload
-          setLastNotificationEventId(
-            sanitizeNotificationEventId(event.lastEventId) || `notification-${payload.notification.id}`
-          )
-          pushNotification(payload.notification)
-          setUnreadCount((prev) => {
-            if (prev === payload.unreadCount) return prev
-            unreadCountRef.current = payload.unreadCount
-            return payload.unreadCount
-          })
-          setIsReady(true)
-          setIsSnapshotFallback(false)
-        } catch {
-          // ignore malformed payloads
-        }
-      }
-
-      const handleConnected = (_event: MessageEvent<string>) => {
-        markStreamOpen()
-        const recovered = reconnectAttemptRef.current > 0
-        reconnectAttemptRef.current = 0
-        recoveryStateRef.current = resetNotificationStreamFailures(recoveryStateRef.current)
-        setIsReady(true)
-        setIsSnapshotFallback(false)
-
-        if (recovered) {
-          void loadSnapshot()
-        }
-      }
-
-      const handleHeartbeat = (_event: MessageEvent<string>) => {
-        markStreamOpen()
-        recoveryStateRef.current = resetNotificationStreamFailures(recoveryStateRef.current)
-        setIsReady(true)
-      }
-
-      const detachListeners = () => {
-        eventSource.removeEventListener("connected", handleConnected)
-        eventSource.removeEventListener("notification", handleNotification)
-        eventSource.removeEventListener("heartbeat", handleHeartbeat)
-        eventSource.onerror = null
-      }
-
-      eventSourceCleanupRef.current = detachListeners
-      eventSource.addEventListener("connected", handleConnected)
-      eventSource.addEventListener("notification", handleNotification)
-      eventSource.addEventListener("heartbeat", handleHeartbeat)
-      eventSource.onerror = () => {
-        const isIntentionalClose = intentionalCloseRef.current || disposed
-        detachListeners()
-        eventSource.close()
-        if (eventSourceRef.current === eventSource) {
-          eventSourceRef.current = null
-        }
-        streamLifecycleRef.current = "idle"
-        if (isIntentionalClose) return
-        scheduleReconnect()
-      }
-    }
-
-    attachEventSourceRef.current = attachEventSource
-    if (isDocumentVisibleRef.current) {
-      attachEventSource()
-    }
-
-    return () => {
-      disposed = true
-      attachEventSourceRef.current = null
-      clearReconnectTimer()
-      clearReconnectTimerRef.current = () => {}
-      closeEventSource(true)
-    }
-  }, [
-    closeEventSource,
+  useNotificationBellTransport({
     enabled,
     isRealtimeActive,
-    loadSnapshot,
+    streamMode,
     notificationAccessState,
+    isDocumentVisible,
+    preferPolling,
+    isDocumentVisibleRef,
+    eventSourceRef,
+    eventSourceCleanupRef,
+    attachEventSourceRef,
+    clearReconnectTimerRef,
+    hiddenCloseTimerRef,
+    intentionalCloseRef,
+    streamLifecycleRef,
+    reconnectTimerRef,
+    reconnectAttemptRef,
+    recoveryStateRef,
+    lastEventIdRef,
+    pollingFailureStreakRef,
+    lastSnapshotErrorRef,
+    lastLoggedSnapshotFailureStreakRef,
+    unreadCountRef,
+    closeEventSource,
+    clearHiddenCloseTimer,
+    loadSnapshot,
     pushNotification,
     setLastNotificationEventId,
-    streamMode,
-  ])
-
-  useEffect(() => {
-    if (!enabled || !isRealtimeActive || streamMode !== "sse" || notificationAccessState !== "ready") {
-      clearHiddenCloseTimer()
-      return
-    }
-
-    if (!isDocumentVisible) {
-      if (hiddenCloseTimerRef.current !== null) return
-      hiddenCloseTimerRef.current = window.setTimeout(() => {
-        hiddenCloseTimerRef.current = null
-        clearReconnectTimerRef.current()
-        closeEventSource(true)
-      }, HIDDEN_GRACE_CLOSE_MS)
-      return
-    }
-
-    clearHiddenCloseTimer()
-    reconnectAttemptRef.current = 0
-    attachEventSourceRef.current?.()
-  }, [
-    clearHiddenCloseTimer,
-    closeEventSource,
-    enabled,
-    isDocumentVisible,
-    isRealtimeActive,
-    notificationAccessState,
-    streamMode,
-  ])
-
-  useEffect(() => {
-    if (typeof window === "undefined") return
-
-    const handlePageExit = () => {
-      clearHiddenCloseTimer()
-      clearReconnectTimerRef.current()
-      closeEventSource(true)
-    }
-
-    window.addEventListener("pagehide", handlePageExit)
-    window.addEventListener("beforeunload", handlePageExit)
-    return () => {
-      window.removeEventListener("pagehide", handlePageExit)
-      window.removeEventListener("beforeunload", handlePageExit)
-    }
-  }, [clearHiddenCloseTimer, closeEventSource])
-
-  useEffect(() => {
-    if (!enabled || !isRealtimeActive || streamMode !== "poll" || !isDocumentVisible || notificationAccessState !== "ready") return
-
-    let disposed = false
-    let timer: number | null = null
-
-    const run = async () => {
-      if (disposed) return
-      let nextFailureStreak: number
-
-      if (!isNavigatorOnline()) {
-        lastSnapshotErrorRef.current = new Error("NetworkOffline")
-        nextFailureStreak = Math.min(
-          pollingFailureStreakRef.current + 1,
-          STREAM_MAX_RECONNECT_ATTEMPTS + POLLING_FAILURE_COOLDOWN_THRESHOLD
-        )
-        pollingFailureStreakRef.current = nextFailureStreak
-        reportSnapshotFailureIfNeeded(nextFailureStreak)
-      } else {
-        const snapshotStatus = await loadSnapshot()
-        if (disposed) return
-
-        if (snapshotStatus === "success") {
-          pollingFailureStreakRef.current = 0
-          lastLoggedSnapshotFailureStreakRef.current = 0
-          nextFailureStreak = 0
-        } else if (snapshotStatus === "blocked") {
-          pollingFailureStreakRef.current = 0
-          lastLoggedSnapshotFailureStreakRef.current = 0
-          setIsRealtimeActive(false)
-          return
-        } else {
-          nextFailureStreak = Math.min(
-            pollingFailureStreakRef.current + 1,
-            STREAM_MAX_RECONNECT_ATTEMPTS + POLLING_FAILURE_COOLDOWN_THRESHOLD
-          )
-          pollingFailureStreakRef.current = nextFailureStreak
-          reportSnapshotFailureIfNeeded(nextFailureStreak)
-        }
-      }
-
-      if (disposed) return
-
-      if (nextFailureStreak === 0) {
-        pollingFailureStreakRef.current = 0
-        lastLoggedSnapshotFailureStreakRef.current = 0
-      }
-
-      const pollingBaseIntervalMs = resolvePollingBaseIntervalMs(nextFailureStreak)
-      timer = window.setTimeout(() => {
-        void run()
-      }, getNextPollingDelayMs(pollingBaseIntervalMs))
-    }
-
-    void run()
-
-    return () => {
-      disposed = true
-      if (timer !== null) {
-        window.clearTimeout(timer)
-      }
-    }
-  }, [
-    enabled,
-    isDocumentVisible,
-    isRealtimeActive,
-    loadSnapshot,
-    notificationAccessState,
-    reportSnapshotFailureIfNeeded,
-    resolvePollingBaseIntervalMs,
-    streamMode,
-  ])
-
-  useEffect(() => {
-    if (!enabled || !isRealtimeActive || streamMode !== "poll" || notificationAccessState !== "ready") return
-
-    const handleOnline = () => {
-      pollingFailureStreakRef.current = 0
-      void loadSnapshot()
-    }
-
-    window.addEventListener("online", handleOnline)
-    return () => {
-      window.removeEventListener("online", handleOnline)
-    }
-  }, [enabled, isRealtimeActive, loadSnapshot, notificationAccessState, streamMode])
-
-  useEffect(() => {
-    if (!enabled) return
-    if (!isRealtimeActive) return
-    if (!isDocumentVisible) return
-    if (preferPolling) return
-    if (streamMode !== "poll") return
-    if (
-      !canProbeNotificationStreamRecovery({
-        state: recoveryStateRef.current,
-        nowMs: Date.now(),
-        enabled,
-        isDocumentVisible,
-        preferPolling,
-        streamMode,
-        notificationAccessState,
-      })
-    ) {
-      return
-    }
-
-    const timer = window.setTimeout(() => {
-      pollingFailureStreakRef.current = 0
-      reconnectAttemptRef.current = 0
-      recoveryStateRef.current = resetNotificationStreamFailures(recoveryStateRef.current)
-      setStreamMode("sse")
-    }, 0)
-
-    return () => {
-      window.clearTimeout(timer)
-    }
-  }, [enabled, isDocumentVisible, isRealtimeActive, notificationAccessState, preferPolling, streamMode])
+    setUnreadCount,
+    setIsReady,
+    setIsSnapshotFallback,
+    setIsRealtimeActive,
+    setStreamMode,
+  })
 
   useEffect(() => {
     if (!open) return

--- a/front/src/layouts/RootLayout/Header/useNotificationBellTransport.ts
+++ b/front/src/layouts/RootLayout/Header/useNotificationBellTransport.ts
@@ -1,0 +1,506 @@
+import { type Dispatch, type MutableRefObject, type SetStateAction, useEffect } from "react"
+import { ApiError, ApiTimeoutError } from "src/apis/backend/client"
+import { buildNotificationStreamUrl } from "src/apis/backend/notifications"
+import type { TMemberNotification, TMemberNotificationStreamPayload } from "src/types"
+import {
+  canProbeNotificationStreamRecovery,
+  markNotificationPollingFallbackEntered,
+  type NotificationStreamRecoveryState,
+  recordNotificationStreamFailure,
+  resetNotificationStreamFailures,
+  shouldSwitchNotificationStreamToPolling,
+} from "./notificationStreamRecovery"
+import {
+  EventSourceLifecycleState,
+  getNavigatorConnection,
+  getNextPollingDelayMs,
+  HIDDEN_GRACE_CLOSE_MS,
+  isNavigatorOnline,
+  POLLING_FAILURE_COOLDOWN_MS,
+  POLLING_FAILURE_COOLDOWN_THRESHOLD,
+  POLLING_INTERVAL_MS,
+  POLLING_MAX_BACKOFF_MULTIPLIER,
+  POLLING_MIN_INTERVAL_MS,
+  POLLING_SAVE_DATA_MULTIPLIER,
+  POLLING_SLOW_NETWORK_MULTIPLIER,
+  sanitizeNotificationEventId,
+  SNAPSHOT_FAILURE_LOG_THRESHOLD,
+  SnapshotLoadStatus,
+  STREAM_MAX_RECONNECT_ATTEMPTS,
+} from "./NotificationBellModel"
+
+type NotificationStreamMode = "sse" | "poll"
+type NotificationAccessState = "pending" | "ready" | "blocked"
+
+type UseNotificationBellTransportParams = {
+  enabled: boolean
+  isRealtimeActive: boolean
+  streamMode: NotificationStreamMode
+  notificationAccessState: NotificationAccessState
+  isDocumentVisible: boolean
+  preferPolling: boolean
+  isDocumentVisibleRef: MutableRefObject<boolean>
+  eventSourceRef: MutableRefObject<EventSource | null>
+  eventSourceCleanupRef: MutableRefObject<(() => void) | null>
+  attachEventSourceRef: MutableRefObject<(() => void) | null>
+  clearReconnectTimerRef: MutableRefObject<() => void>
+  hiddenCloseTimerRef: MutableRefObject<number | null>
+  intentionalCloseRef: MutableRefObject<boolean>
+  streamLifecycleRef: MutableRefObject<EventSourceLifecycleState>
+  reconnectTimerRef: MutableRefObject<number | null>
+  reconnectAttemptRef: MutableRefObject<number>
+  recoveryStateRef: MutableRefObject<NotificationStreamRecoveryState>
+  lastEventIdRef: MutableRefObject<string | null>
+  pollingFailureStreakRef: MutableRefObject<number>
+  lastSnapshotErrorRef: MutableRefObject<unknown>
+  lastLoggedSnapshotFailureStreakRef: MutableRefObject<number>
+  unreadCountRef: MutableRefObject<number>
+  closeEventSource: (intentional: boolean) => void
+  clearHiddenCloseTimer: () => void
+  loadSnapshot: () => Promise<SnapshotLoadStatus>
+  pushNotification: (incoming: TMemberNotification) => void
+  setLastNotificationEventId: (eventId: string | null) => void
+  setUnreadCount: Dispatch<SetStateAction<number>>
+  setIsReady: Dispatch<SetStateAction<boolean>>
+  setIsSnapshotFallback: Dispatch<SetStateAction<boolean>>
+  setIsRealtimeActive: Dispatch<SetStateAction<boolean>>
+  setStreamMode: Dispatch<SetStateAction<NotificationStreamMode>>
+}
+
+const describeSnapshotError = (error: unknown) => {
+  if (error instanceof ApiTimeoutError) {
+    return `timeout(${error.timeoutMs}ms)`
+  }
+  if (error instanceof ApiError) {
+    return `api-${error.status}`
+  }
+  if (error instanceof DOMException) {
+    return error.name
+  }
+  if (error instanceof Error) {
+    return error.name
+  }
+  return "unknown"
+}
+
+const resolvePollingBaseIntervalMs = (failureStreak: number) => {
+  let baseMs = POLLING_INTERVAL_MS
+  const connection = getNavigatorConnection()
+  if (connection?.saveData) {
+    baseMs = Math.round(baseMs * POLLING_SAVE_DATA_MULTIPLIER)
+  } else if (connection?.effectiveType === "slow-2g" || connection?.effectiveType === "2g") {
+    baseMs = Math.round(baseMs * POLLING_SLOW_NETWORK_MULTIPLIER)
+  }
+
+  if (failureStreak > 0) {
+    const multiplier = Math.min(POLLING_MAX_BACKOFF_MULTIPLIER, 2 ** failureStreak)
+    baseMs = Math.round(baseMs * multiplier)
+  }
+
+  if (failureStreak >= POLLING_FAILURE_COOLDOWN_THRESHOLD) {
+    baseMs = Math.max(baseMs, POLLING_FAILURE_COOLDOWN_MS)
+  }
+
+  return Math.max(POLLING_MIN_INTERVAL_MS, baseMs)
+}
+
+export const useNotificationBellTransport = ({
+  enabled,
+  isRealtimeActive,
+  streamMode,
+  notificationAccessState,
+  isDocumentVisible,
+  preferPolling,
+  isDocumentVisibleRef,
+  eventSourceRef,
+  eventSourceCleanupRef,
+  attachEventSourceRef,
+  clearReconnectTimerRef,
+  hiddenCloseTimerRef,
+  intentionalCloseRef,
+  streamLifecycleRef,
+  reconnectTimerRef,
+  reconnectAttemptRef,
+  recoveryStateRef,
+  lastEventIdRef,
+  pollingFailureStreakRef,
+  lastSnapshotErrorRef,
+  lastLoggedSnapshotFailureStreakRef,
+  unreadCountRef,
+  closeEventSource,
+  clearHiddenCloseTimer,
+  loadSnapshot,
+  pushNotification,
+  setLastNotificationEventId,
+  setUnreadCount,
+  setIsReady,
+  setIsSnapshotFallback,
+  setIsRealtimeActive,
+  setStreamMode,
+}: UseNotificationBellTransportParams) => {
+  useEffect(() => {
+    if (!enabled || !isRealtimeActive || streamMode !== "sse" || notificationAccessState !== "ready") {
+      clearReconnectTimerRef.current()
+      attachEventSourceRef.current = null
+      closeEventSource(true)
+      return
+    }
+
+    let disposed = false
+
+    const clearReconnectTimer = () => {
+      if (reconnectTimerRef.current !== null) {
+        window.clearTimeout(reconnectTimerRef.current)
+        reconnectTimerRef.current = null
+      }
+    }
+
+    clearReconnectTimerRef.current = clearReconnectTimer
+
+    const scheduleReconnect = () => {
+      if (disposed || reconnectTimerRef.current !== null || intentionalCloseRef.current) return
+
+      setIsReady(false)
+      const nextAttempt = reconnectAttemptRef.current + 1
+      reconnectAttemptRef.current = nextAttempt
+      recoveryStateRef.current = recordNotificationStreamFailure(recoveryStateRef.current, Date.now())
+
+      if (shouldSwitchNotificationStreamToPolling(recoveryStateRef.current, Date.now())) {
+        closeEventSource(false)
+        recoveryStateRef.current = markNotificationPollingFallbackEntered(recoveryStateRef.current, Date.now())
+        setStreamMode("poll")
+        return
+      }
+
+      if (nextAttempt > STREAM_MAX_RECONNECT_ATTEMPTS) {
+        closeEventSource(false)
+        recoveryStateRef.current = markNotificationPollingFallbackEntered(recoveryStateRef.current, Date.now())
+        setStreamMode("poll")
+        return
+      }
+
+      const retryDelay = Math.min(1500 * nextAttempt, 10000)
+      reconnectTimerRef.current = window.setTimeout(() => {
+        reconnectTimerRef.current = null
+        attachEventSourceRef.current?.()
+      }, retryDelay)
+    }
+
+    const attachEventSource = () => {
+      if (disposed) return
+      if (!isDocumentVisibleRef.current) return
+      if (streamLifecycleRef.current === "connecting" || streamLifecycleRef.current === "open") return
+      if (eventSourceRef.current) return
+
+      clearReconnectTimer()
+      intentionalCloseRef.current = false
+      streamLifecycleRef.current = "connecting"
+      const streamUrl = new URL(buildNotificationStreamUrl(), window.location.origin)
+      if (lastEventIdRef.current) {
+        streamUrl.searchParams.set("lastEventId", lastEventIdRef.current)
+      }
+
+      const eventSource = new EventSource(streamUrl.toString(), { withCredentials: true })
+      eventSourceRef.current = eventSource
+
+      const markStreamOpen = () => {
+        streamLifecycleRef.current = "open"
+      }
+
+      const handleNotification = (event: MessageEvent<string>) => {
+        markStreamOpen()
+        try {
+          const payload = JSON.parse(event.data) as TMemberNotificationStreamPayload
+          setLastNotificationEventId(
+            sanitizeNotificationEventId(event.lastEventId) || `notification-${payload.notification.id}`
+          )
+          pushNotification(payload.notification)
+          setUnreadCount((prev) => {
+            if (prev === payload.unreadCount) return prev
+            unreadCountRef.current = payload.unreadCount
+            return payload.unreadCount
+          })
+          setIsReady(true)
+          setIsSnapshotFallback(false)
+        } catch {
+          // ignore malformed payloads
+        }
+      }
+
+      const handleConnected = (_event: MessageEvent<string>) => {
+        markStreamOpen()
+        const recovered = reconnectAttemptRef.current > 0
+        reconnectAttemptRef.current = 0
+        recoveryStateRef.current = resetNotificationStreamFailures(recoveryStateRef.current)
+        setIsReady(true)
+        setIsSnapshotFallback(false)
+
+        if (recovered) {
+          void loadSnapshot()
+        }
+      }
+
+      const handleHeartbeat = (_event: MessageEvent<string>) => {
+        markStreamOpen()
+        recoveryStateRef.current = resetNotificationStreamFailures(recoveryStateRef.current)
+        setIsReady(true)
+      }
+
+      const detachListeners = () => {
+        eventSource.removeEventListener("connected", handleConnected)
+        eventSource.removeEventListener("notification", handleNotification)
+        eventSource.removeEventListener("heartbeat", handleHeartbeat)
+        eventSource.onerror = null
+      }
+
+      eventSourceCleanupRef.current = detachListeners
+      eventSource.addEventListener("connected", handleConnected)
+      eventSource.addEventListener("notification", handleNotification)
+      eventSource.addEventListener("heartbeat", handleHeartbeat)
+      eventSource.onerror = () => {
+        const isIntentionalClose = intentionalCloseRef.current || disposed
+        detachListeners()
+        eventSource.close()
+        if (eventSourceRef.current === eventSource) {
+          eventSourceRef.current = null
+        }
+        streamLifecycleRef.current = "idle"
+        if (isIntentionalClose) return
+        scheduleReconnect()
+      }
+    }
+
+    attachEventSourceRef.current = attachEventSource
+    if (isDocumentVisibleRef.current) {
+      attachEventSource()
+    }
+
+    return () => {
+      disposed = true
+      attachEventSourceRef.current = null
+      clearReconnectTimer()
+      clearReconnectTimerRef.current = () => {}
+      closeEventSource(true)
+    }
+  }, [
+    attachEventSourceRef,
+    clearReconnectTimerRef,
+    closeEventSource,
+    enabled,
+    eventSourceCleanupRef,
+    eventSourceRef,
+    intentionalCloseRef,
+    isDocumentVisibleRef,
+    isRealtimeActive,
+    lastEventIdRef,
+    loadSnapshot,
+    notificationAccessState,
+    pushNotification,
+    reconnectAttemptRef,
+    reconnectTimerRef,
+    recoveryStateRef,
+    setIsReady,
+    setIsSnapshotFallback,
+    setLastNotificationEventId,
+    setStreamMode,
+    setUnreadCount,
+    streamLifecycleRef,
+    streamMode,
+    unreadCountRef,
+  ])
+
+  useEffect(() => {
+    if (!enabled || !isRealtimeActive || streamMode !== "sse" || notificationAccessState !== "ready") {
+      clearHiddenCloseTimer()
+      return
+    }
+
+    if (!isDocumentVisible) {
+      if (hiddenCloseTimerRef.current !== null) return
+      hiddenCloseTimerRef.current = window.setTimeout(() => {
+        hiddenCloseTimerRef.current = null
+        clearReconnectTimerRef.current()
+        closeEventSource(true)
+      }, HIDDEN_GRACE_CLOSE_MS)
+      return
+    }
+
+    clearHiddenCloseTimer()
+    reconnectAttemptRef.current = 0
+    attachEventSourceRef.current?.()
+  }, [
+    attachEventSourceRef,
+    clearHiddenCloseTimer,
+    clearReconnectTimerRef,
+    closeEventSource,
+    enabled,
+    hiddenCloseTimerRef,
+    isDocumentVisible,
+    isRealtimeActive,
+    notificationAccessState,
+    reconnectAttemptRef,
+    streamMode,
+  ])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const handlePageExit = () => {
+      clearHiddenCloseTimer()
+      clearReconnectTimerRef.current()
+      closeEventSource(true)
+    }
+
+    window.addEventListener("pagehide", handlePageExit)
+    window.addEventListener("beforeunload", handlePageExit)
+    return () => {
+      window.removeEventListener("pagehide", handlePageExit)
+      window.removeEventListener("beforeunload", handlePageExit)
+    }
+  }, [clearHiddenCloseTimer, clearReconnectTimerRef, closeEventSource])
+
+  useEffect(() => {
+    if (!enabled || !isRealtimeActive || streamMode !== "poll" || !isDocumentVisible || notificationAccessState !== "ready") return
+
+    let disposed = false
+    let timer: number | null = null
+
+    const reportSnapshotFailureIfNeeded = (nextFailureStreak: number) => {
+      if (nextFailureStreak < SNAPSHOT_FAILURE_LOG_THRESHOLD) return
+      if (lastLoggedSnapshotFailureStreakRef.current >= nextFailureStreak) return
+
+      lastLoggedSnapshotFailureStreakRef.current = nextFailureStreak
+      console.warn("[notifications] snapshot polling is recovering from repeated failures", {
+        streak: nextFailureStreak,
+        reason: describeSnapshotError(lastSnapshotErrorRef.current),
+        mode: streamMode,
+        fallback: lastSnapshotErrorRef.current ? "none-or-session" : "cache",
+      })
+    }
+
+    const run = async () => {
+      if (disposed) return
+      let nextFailureStreak: number
+
+      if (!isNavigatorOnline()) {
+        lastSnapshotErrorRef.current = new Error("NetworkOffline")
+        nextFailureStreak = Math.min(
+          pollingFailureStreakRef.current + 1,
+          STREAM_MAX_RECONNECT_ATTEMPTS + POLLING_FAILURE_COOLDOWN_THRESHOLD
+        )
+        pollingFailureStreakRef.current = nextFailureStreak
+        reportSnapshotFailureIfNeeded(nextFailureStreak)
+      } else {
+        const snapshotStatus = await loadSnapshot()
+        if (disposed) return
+
+        if (snapshotStatus === "success") {
+          pollingFailureStreakRef.current = 0
+          lastLoggedSnapshotFailureStreakRef.current = 0
+          nextFailureStreak = 0
+        } else if (snapshotStatus === "blocked") {
+          pollingFailureStreakRef.current = 0
+          lastLoggedSnapshotFailureStreakRef.current = 0
+          setIsRealtimeActive(false)
+          return
+        } else {
+          nextFailureStreak = Math.min(
+            pollingFailureStreakRef.current + 1,
+            STREAM_MAX_RECONNECT_ATTEMPTS + POLLING_FAILURE_COOLDOWN_THRESHOLD
+          )
+          pollingFailureStreakRef.current = nextFailureStreak
+          reportSnapshotFailureIfNeeded(nextFailureStreak)
+        }
+      }
+
+      if (disposed) return
+
+      if (nextFailureStreak === 0) {
+        pollingFailureStreakRef.current = 0
+        lastLoggedSnapshotFailureStreakRef.current = 0
+      }
+
+      const pollingBaseIntervalMs = resolvePollingBaseIntervalMs(nextFailureStreak)
+      timer = window.setTimeout(() => {
+        void run()
+      }, getNextPollingDelayMs(pollingBaseIntervalMs))
+    }
+
+    void run()
+
+    return () => {
+      disposed = true
+      if (timer !== null) {
+        window.clearTimeout(timer)
+      }
+    }
+  }, [
+    enabled,
+    isDocumentVisible,
+    isRealtimeActive,
+    lastLoggedSnapshotFailureStreakRef,
+    lastSnapshotErrorRef,
+    loadSnapshot,
+    notificationAccessState,
+    pollingFailureStreakRef,
+    setIsRealtimeActive,
+    streamMode,
+  ])
+
+  useEffect(() => {
+    if (!enabled || !isRealtimeActive || streamMode !== "poll" || notificationAccessState !== "ready") return
+
+    const handleOnline = () => {
+      pollingFailureStreakRef.current = 0
+      void loadSnapshot()
+    }
+
+    window.addEventListener("online", handleOnline)
+    return () => {
+      window.removeEventListener("online", handleOnline)
+    }
+  }, [enabled, isRealtimeActive, loadSnapshot, notificationAccessState, pollingFailureStreakRef, streamMode])
+
+  useEffect(() => {
+    if (!enabled) return
+    if (!isRealtimeActive) return
+    if (!isDocumentVisible) return
+    if (preferPolling) return
+    if (streamMode !== "poll") return
+    if (
+      !canProbeNotificationStreamRecovery({
+        state: recoveryStateRef.current,
+        nowMs: Date.now(),
+        enabled,
+        isDocumentVisible,
+        preferPolling,
+        streamMode,
+        notificationAccessState,
+      })
+    ) {
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      pollingFailureStreakRef.current = 0
+      reconnectAttemptRef.current = 0
+      recoveryStateRef.current = resetNotificationStreamFailures(recoveryStateRef.current)
+      setStreamMode("sse")
+    }, 0)
+
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [
+    enabled,
+    isDocumentVisible,
+    isRealtimeActive,
+    notificationAccessState,
+    pollingFailureStreakRef,
+    preferPolling,
+    reconnectAttemptRef,
+    recoveryStateRef,
+    setStreamMode,
+    streamMode,
+  ])
+}

--- a/front/src/pages/login.tsx
+++ b/front/src/pages/login.tsx
@@ -1,13 +1,12 @@
-import styled from "@emotion/styled"
-import dynamic from "next/dynamic"
 import { GetServerSideProps } from "next"
 import Link from "next/link"
 import { useRouter } from "next/router"
 import { FormEvent, useEffect, useMemo, useState } from "react"
 import { apiFetch } from "src/apis/backend/client"
 import { toAuthErrorMessage } from "src/apis/backend/errorMessages"
+import { ErrorText, FooterText, SuccessText } from "src/components/auth/LoginPage.styles"
+import { LoginPageForm } from "src/components/auth/LoginPageForm"
 import AuthShell from "src/components/auth/AuthShell"
-import AppIcon from "src/components/icons/AppIcon"
 import { buildSocialAuthItems } from "src/components/auth/socialAuth"
 import useAuthSession from "src/hooks/useAuthSession"
 import type { AuthMember } from "src/hooks/useAuthSession"
@@ -21,14 +20,6 @@ type RsData<T> = {
   msg: string
   data: T
 }
-
-const SocialAuthButtons = dynamic(() => import("src/components/auth/SocialAuthButtons"), {
-  ssr: false,
-})
-
-const IpSecurityInfoModal = dynamic(() => import("src/components/auth/IpSecurityInfoModal"), {
-  ssr: false,
-})
 
 export const getServerSideProps: GetServerSideProps<GuestPageProps> = async ({ req }) => {
   return await getGuestPageProps(req)
@@ -178,460 +169,32 @@ const LoginPage = () => {
       loginHref={toLoginPath(next)}
       signupHref={toSignupPath(next)}
     >
-      <form onSubmit={onSubmit} noValidate>
-        <NaverField data-active={loginIdActive}>
-          <NaverFieldLabel htmlFor="email" data-active={loginIdActive ? "true" : "false"}>
-            이메일
-          </NaverFieldLabel>
-          <NaverInput
-            id="email"
-            type="email"
-            inputMode="email"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-            onFocus={() => setLoginIdFocused(true)}
-            onBlur={() => setLoginIdFocused(false)}
-            placeholder=""
-            autoComplete="email"
-          />
-          {email.length > 0 && (
-            <FieldActions>
-              <GhostIconButton type="button" aria-label="이메일 입력 지우기" onClick={() => setEmail("")}>
-                <AppIcon name="close" />
-              </GhostIconButton>
-            </FieldActions>
-          )}
-        </NaverField>
-
-        <NaverField data-active={passwordActive}>
-          <NaverFieldLabel htmlFor="password" data-active={passwordActive ? "true" : "false"}>
-            비밀번호
-          </NaverFieldLabel>
-          <NaverInput
-            id="password"
-            type={showPassword ? "text" : "password"}
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-            onFocus={() => setPasswordFocused(true)}
-            onBlur={() => setPasswordFocused(false)}
-            placeholder=""
-            autoComplete="current-password"
-            data-password="true"
-          />
-          <PasswordActions>
-            {password.length > 0 && (
-              <GhostIconButton type="button" aria-label="비밀번호 입력 지우기" onClick={() => setPassword("")}>
-                <AppIcon name="close" />
-              </GhostIconButton>
-            )}
-            <GhostIconButton className="visibilityToggle" type="button" onClick={() => setShowPassword((value) => !value)} aria-label="비밀번호 표시 전환">
-              <AppIcon name={showPassword ? "eye-off" : "eye"} />
-            </GhostIconButton>
-          </PasswordActions>
-        </NaverField>
-
-        <LoginStateRow>
-          <KeepSignedInButton
-            type="button"
-            data-on={keepSignedIn}
-            aria-pressed={keepSignedIn}
-            onClick={() => setKeepSignedIn((value) => !value)}
-          >
-            <span className="checkIcon" aria-hidden="true">
-              <AppIcon name="check-circle" />
-            </span>
-            <span>로그인 상태 유지</span>
-          </KeepSignedInButton>
-
-          <IpSecurityControl>
-            <IpSecurityInfoButton
-              type="button"
-              onClick={() => setShowIpSecurityInfo(true)}
-              aria-haspopup="dialog"
-              aria-controls="ip-security-info-dialog"
-            >
-              IP보안
-            </IpSecurityInfoButton>
-            <IpSecurityToggle
-              type="button"
-              data-on={ipSecurityOn}
-              aria-pressed={ipSecurityOn}
-              aria-label="IP보안 ON/OFF"
-              onClick={() => setIpSecurityOn((value) => !value)}
-            >
-              <span className="switch" aria-hidden="true">
-                <span className="thumb" />
-              </span>
-              <span className="state">{ipSecurityOn ? "ON" : "OFF"}</span>
-            </IpSecurityToggle>
-          </IpSecurityControl>
-        </LoginStateRow>
-
-        <FeedbackSlot aria-live="polite" data-filled={feedbackMessage ? "true" : "false"}>
-          {feedbackMessage}
-        </FeedbackSlot>
-
-        <PrimaryButton type="submit" disabled={loading}>
-          {loading ? "로그인 중..." : "로그인"}
-        </PrimaryButton>
-
-        {hasSocialItems ? (
-          <SocialSection>
-            <span>소셜 계정으로 로그인</span>
-            <SocialButtonRow>
-              {showSocialAuth ? <SocialAuthButtons items={socialItems} /> : null}
-            </SocialButtonRow>
-          </SocialSection>
-        ) : null}
-      </form>
-      {showIpSecurityInfo ? <IpSecurityInfoModal open={showIpSecurityInfo} onClose={() => setShowIpSecurityInfo(false)} /> : null}
+      <LoginPageForm
+        email={email}
+        password={password}
+        showPassword={showPassword}
+        loading={loading}
+        loginIdActive={loginIdActive}
+        passwordActive={passwordActive}
+        keepSignedIn={keepSignedIn}
+        ipSecurityOn={ipSecurityOn}
+        showIpSecurityInfo={showIpSecurityInfo}
+        feedbackMessage={feedbackMessage}
+        hasSocialItems={hasSocialItems}
+        showSocialAuth={showSocialAuth}
+        socialItems={socialItems}
+        onSubmit={onSubmit}
+        setEmail={setEmail}
+        setPassword={setPassword}
+        setShowPassword={setShowPassword}
+        setLoginIdFocused={setLoginIdFocused}
+        setPasswordFocused={setPasswordFocused}
+        setKeepSignedIn={setKeepSignedIn}
+        setIpSecurityOn={setIpSecurityOn}
+        setShowIpSecurityInfo={setShowIpSecurityInfo}
+      />
     </AuthShell>
   )
 }
 
 export default LoginPage
-
-const NaverField = styled.div`
-  position: relative;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 14px;
-  background: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray1 : theme.colors.gray2)};
-  min-height: 76px;
-  padding: 1.55rem 0.92rem 0.48rem;
-  box-shadow: ${({ theme }) =>
-    theme.scheme === "light" ? "0 1px 0 rgba(15, 23, 42, 0.03)" : "none"};
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
-
-  &[data-active="true"] {
-    border-color: ${({ theme }) => theme.colors.gray7};
-    box-shadow: ${({ theme }) =>
-      theme.scheme === "light" ? "0 0 0 2px rgba(148, 163, 184, 0.12)" : "0 0 0 2px rgba(148, 163, 184, 0.1)"};
-  }
-`
-
-const NaverFieldLabel = styled.label`
-  position: absolute;
-  left: 0.92rem;
-  top: 50%;
-  transform: translateY(-50%);
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.9rem;
-  font-weight: 600;
-  line-height: 1;
-  pointer-events: none;
-  transition: top 0.2s ease, transform 0.2s ease, font-size 0.2s ease, color 0.2s ease;
-
-  &[data-active="true"] {
-    top: 0.82rem;
-    transform: translateY(0);
-    font-size: 0.72rem;
-    color: ${({ theme }) => theme.colors.gray11};
-  }
-`
-
-const NaverInput = styled.input`
-  width: 100%;
-  border: 0;
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray12};
-  min-height: 42px;
-  padding: 0;
-  font-size: 1.05rem;
-  font-weight: 650;
-  line-height: 1.3;
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.96rem;
-    font-weight: 500;
-  }
-
-  &:focus {
-    outline: none;
-  }
-
-  &[data-password="true"] {
-    padding-right: 8.35rem;
-  }
-`
-
-const FieldActions = styled.div`
-  position: absolute;
-  top: 50%;
-  right: 0.5rem;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  gap: 0.3rem;
-`
-
-const PasswordActions = styled.div`
-  position: absolute;
-  top: 50%;
-  right: 0.5rem;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  gap: 0.3rem;
-`
-
-const GhostIconButton = styled.button`
-  min-width: 44px;
-  width: 44px;
-  height: 44px;
-  padding: 0;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 999px;
-  background: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray1 : theme.colors.gray2)};
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.72rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: filter 0.16s ease;
-
-  &:hover:not(:disabled) {
-    filter: brightness(1.08);
-  }
-
-  &:disabled {
-    opacity: 0.62;
-    cursor: not-allowed;
-  }
-
-  &.visibilityToggle {
-    border: 0;
-    background: transparent;
-    color: ${({ theme }) => theme.colors.gray11};
-    width: 44px;
-    min-width: 44px;
-  }
-
-  svg {
-    font-size: 0.74rem;
-  }
-
-  &.visibilityToggle svg {
-    font-size: 1.12rem;
-  }
-`
-
-const LoginStateRow = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.9rem;
-  margin-top: 0.12rem;
-  margin-bottom: 0.06rem;
-
-  @media (max-width: 640px) {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.42rem;
-  }
-`
-
-const FeedbackSlot = styled.div`
-  min-height: 4.6rem;
-  display: flex;
-  align-items: stretch;
-
-  &[data-filled="false"] {
-    min-height: 4.1rem;
-  }
-
-  > * {
-    width: 100%;
-  }
-`
-
-const KeepSignedInButton = styled.button`
-  display: inline-flex;
-  align-items: center;
-  gap: 0.46rem;
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.9rem;
-  font-weight: 650;
-  min-height: 44px;
-  padding: 0.22rem 0.2rem;
-  border-radius: 10px;
-  touch-action: manipulation;
-
-  .checkIcon {
-    width: 28px;
-    height: 28px;
-    border-radius: 999px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: ${({ theme }) => theme.colors.gray9};
-    transition: color 0.2s ease, transform 0.2s ease;
-  }
-
-  .checkIcon svg {
-    font-size: 1.45rem;
-  }
-
-  &[data-on="true"] .checkIcon {
-    color: ${({ theme }) => theme.colors.gray11};
-    transform: scale(1.03);
-  }
-`
-
-const IpSecurityToggle = styled.button`
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  color: ${({ theme }) => theme.colors.gray11};
-  font-size: 0.9rem;
-  font-weight: 700;
-  min-height: 44px;
-  padding: 0.22rem 0;
-  touch-action: manipulation;
-
-  .switch {
-    width: 52px;
-    height: 30px;
-    border-radius: 999px;
-    border: 1px solid ${({ theme }) => theme.colors.gray7};
-    background: ${({ theme }) => theme.colors.gray5};
-    padding: 2px;
-    display: inline-flex;
-    align-items: center;
-    transition: background-color 0.2s ease, border-color 0.2s ease;
-  }
-
-  .thumb {
-    width: 24px;
-    height: 24px;
-    border-radius: 999px;
-    background: ${({ theme }) => theme.colors.gray1};
-    transition: transform 0.22s ease;
-    transform: translateX(0);
-  }
-
-  .state {
-    width: 28px;
-    text-align: right;
-    color: ${({ theme }) => theme.colors.gray10};
-    transition: color 0.2s ease;
-  }
-
-  &[data-on="true"] .switch {
-    background: rgba(18, 184, 134, 0.44);
-    border-color: rgba(18, 184, 134, 0.76);
-  }
-
-  &[data-on="true"] .thumb {
-    transform: translateX(20px);
-  }
-
-  &[data-on="true"] .state {
-    color: ${({ theme }) => theme.colors.green10};
-  }
-`
-
-const IpSecurityControl = styled.div`
-  display: inline-flex;
-  align-items: center;
-  gap: 0.46rem;
-
-  @media (max-width: 640px) {
-    align-self: flex-end;
-  }
-`
-
-const IpSecurityInfoButton = styled.button`
-  border: 0;
-  min-height: 44px;
-  padding: 0.15rem 0.3rem;
-  background: transparent;
-  color: ${({ theme }) => theme.colors.gray11};
-  font-size: 0.9rem;
-  font-weight: 700;
-  text-decoration: underline;
-  text-decoration-color: ${({ theme }) => theme.colors.gray7};
-  text-underline-offset: 2px;
-  cursor: pointer;
-
-  &:hover {
-    color: ${({ theme }) => theme.colors.accentLink};
-    text-decoration-color: ${({ theme }) => theme.colors.accentBorder};
-  }
-`
-
-const PrimaryButton = styled.button`
-  border: 0;
-  border-radius: 12px;
-  padding: 0.84rem 1rem;
-  background: #12b886;
-  color: #fff;
-  font-weight: 700;
-  cursor: pointer;
-  box-shadow: ${({ theme }) =>
-    theme.scheme === "light" ? "0 10px 22px rgba(18, 184, 134, 0.18)" : "none"};
-  transition: filter 0.16s ease, box-shadow 0.16s ease;
-
-  &:hover:not(:disabled) {
-    filter: brightness(1.06);
-  }
-
-  &:disabled {
-    opacity: 0.68;
-    cursor: not-allowed;
-  }
-`
-
-const ErrorText = styled.p`
-  margin: 0;
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.statusDangerBorder};
-  background: ${({ theme }) => theme.colors.statusDangerSurface};
-  color: ${({ theme }) => theme.colors.statusDangerText};
-  padding: 0.82rem 0.9rem;
-  font-size: 0.9rem;
-  line-height: 1.55;
-`
-
-const SuccessText = styled.p`
-  margin: 0;
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.statusSuccessBorder};
-  background: ${({ theme }) => theme.colors.statusSuccessSurface};
-  color: ${({ theme }) => theme.colors.statusSuccessText};
-  padding: 0.82rem 0.9rem;
-  font-size: 0.87rem;
-  line-height: 1.65;
-
-  strong {
-    font-weight: 800;
-  }
-`
-
-const FooterText = styled.p`
-  margin: 0;
-
-  a {
-    display: inline-flex;
-    align-items: center;
-    min-height: 34px;
-  }
-`
-
-const SocialSection = styled.div`
-  display: grid;
-  gap: 0.8rem;
-  margin-top: 0.15rem;
-
-  > span {
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 0.88rem;
-    font-weight: 700;
-  }
-`
-
-const SocialButtonRow = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-`


### PR DESCRIPTION
## 관련 이슈

close #419

## 작업 배경

- App shell notification hook과 login entry의 residual 대형 파일을 600 line budget 아래로 분리했습니다.
- notification SSE/polling transport는 dedicated hook으로, login form/input/social view는 auth companion modules로 이동했습니다.
- main merge 후 기존 자동 배포 경로를 그대로 타며, 배포 후 live e2e로 실제 페이지를 재확인합니다.

## 작업 내용

- `useNotificationBellState.ts`는 snapshot/state orchestration만 남기고 SSE reconnect, hidden close, polling recovery, online recovery를 `useNotificationBellTransport.ts`로 분리했습니다.
- `pages/login.tsx`는 SSR/bootstrap과 submit flow만 소유하고 form markup/styles를 `LoginPageForm.tsx`, `LoginPage.styles.ts`로 분리했습니다.
- `header-refresh-auth.spec.ts`에 #419 residual line-budget guard를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/header-refresh-auth.spec.ts --workers=1 --grep "header notification and login residual"`
  - `yarn --cwd front playwright test e2e/header-refresh-auth.spec.ts e2e/mobile-layout.spec.ts e2e/accessibility.spec.ts e2e/perf.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front build` (2회 연속 통과)
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: notification transport effect dependency 또는 login form prop wiring 회귀.
- 롤백 방법: 이 PR commit을 revert하면 기존 inline hook/page 구조로 복귀합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
