### PR TITLE
[Refactor] Post API client request layer 600 line 이하 분리

### DIFF
--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -405,6 +405,8 @@ test("backend posts API client는 dto/mapper/request/cache module로 분리된�
     path.join(postsModuleRoot, "PostApiDtos.ts"),
     path.join(postsModuleRoot, "PostApiMappers.ts"),
     path.join(postsModuleRoot, "PostApiRequests.ts"),
+    path.join(postsModuleRoot, "PostApiRequestModel.ts"),
+    path.join(postsModuleRoot, "PostApiDetailRequests.ts"),
     path.join(postsModuleRoot, "PostApiCache.ts"),
   ]
 
@@ -415,6 +417,7 @@ test("backend posts API client는 dto/mapper/request/cache module로 분리된�
   const boundedSourceFiles = [
     path.join(backendApiRoot, "posts.ts"),
     path.join(backendApiRoot, "client.ts"),
+    path.join(postsModuleRoot, "PostApiRequests.ts"),
   ]
 
   const oversizedBudgetFiles = boundedSourceFiles
@@ -423,7 +426,7 @@ test("backend posts API client는 dto/mapper/request/cache module로 분리된�
       sourcePath: path.relative(backendApiRoot, sourcePath),
       lineCount: readFileSync(sourcePath, "utf8").split("\n").length,
     }))
-    .filter(({ lineCount }) => lineCount > 700)
+    .filter(({ lineCount }) => lineCount > 600)
 
   expect(oversizedBudgetFiles).toEqual([])
 

--- a/front/src/apis/backend/posts/PostApiDetailRequests.ts
+++ b/front/src/apis/backend/posts/PostApiDetailRequests.ts
@@ -1,0 +1,92 @@
+import type { PostDetail } from "src/types"
+import { ApiError, apiFetch } from "../client"
+import type { ApiPostWithContentDto } from "./PostApiDtos"
+import { extractPostIdFromSlug, mapPostDetail } from "./PostApiMappers"
+import {
+  getFreshServerSnapshot,
+  isServerRuntime,
+  POST_DETAIL_SSR_CACHE_MAX_ENTRIES,
+  POST_DETAIL_SSR_CACHE_TTL_MS,
+  setServerSnapshot,
+} from "./PostApiRequestModel"
+
+let postDetailSsrCache = new Map<string, { value: PostDetail; cachedAt: number }>()
+let pendingPostDetailPromises = new Map<string, Promise<PostDetail | null>>()
+
+export const resetPostDetailRequestCaches = () => {
+  postDetailSsrCache = new Map()
+  pendingPostDetailPromises = new Map()
+}
+
+export const getPostDetailBySlug = async (slug: string): Promise<PostDetail | null> => {
+  const postId = extractPostIdFromSlug(slug)
+  if (!postId) return null
+
+  try {
+    const post = await apiFetch<ApiPostWithContentDto>(`/post/api/v1/posts/${postId}`)
+    const mapped = mapPostDetail(post)
+
+    // slug mismatch should 404 to avoid duplicate-url indexing.
+    if (mapped.slug !== slug) return null
+
+    return mapped
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      return null
+    }
+    throw error
+  }
+}
+
+export const getPostDetailById = async (id: string): Promise<PostDetail | null> => {
+  const postId = Number(id)
+  if (!Number.isInteger(postId) || postId <= 0) return null
+  const endpoint = `/post/api/v1/posts/${postId}`
+  const canUseServerSnapshot = isServerRuntime
+  const cachedSnapshot =
+    canUseServerSnapshot
+      ? getFreshServerSnapshot(postDetailSsrCache, endpoint, POST_DETAIL_SSR_CACHE_TTL_MS)
+      : null
+  if (cachedSnapshot) return cachedSnapshot
+
+  if (canUseServerSnapshot) {
+    const pendingSnapshot = pendingPostDetailPromises.get(endpoint)
+    if (pendingSnapshot) return pendingSnapshot
+  }
+
+  const loadPostDetail = async () => {
+    const post = await apiFetch<ApiPostWithContentDto>(endpoint)
+    return mapPostDetail(post)
+  }
+
+  if (!canUseServerSnapshot) {
+    try {
+      return await loadPostDetail()
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) {
+        return null
+      }
+      throw error
+    }
+  }
+
+  const snapshotPromise = (async () => {
+    try {
+      const nextDetail = await loadPostDetail()
+      setServerSnapshot(postDetailSsrCache, endpoint, nextDetail, POST_DETAIL_SSR_CACHE_MAX_ENTRIES)
+      return nextDetail
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) {
+        return null
+      }
+      const staleSnapshot = postDetailSsrCache.get(endpoint)?.value
+      if (staleSnapshot) return staleSnapshot
+      throw error
+    } finally {
+      pendingPostDetailPromises.delete(endpoint)
+    }
+  })()
+
+  pendingPostDetailPromises.set(endpoint, snapshotPromise)
+  return snapshotPromise
+}

--- a/front/src/apis/backend/posts/PostApiRequestModel.ts
+++ b/front/src/apis/backend/posts/PostApiRequestModel.ts
@@ -1,0 +1,242 @@
+import { normalizeKeywordQuery, normalizeTagQuery } from "src/libs/query/normalize"
+import { ApiError } from "../client"
+import { asOpenApiPath } from "../openapiContract"
+import type { ExplorePostsParams } from "./PostApiDtos"
+
+export const PAGE_SIZE = 30
+export const POSTS_CACHE_TTL_MS = 90_000
+export const POSTS_BOOTSTRAP_SSR_CACHE_TTL_MS = 60_000
+export const POST_DETAIL_SSR_CACHE_TTL_MS = 120_000
+export const POSTS_BOOTSTRAP_SSR_CACHE_MAX_ENTRIES = 6
+export const POST_DETAIL_SSR_CACHE_MAX_ENTRIES = 24
+export const isServerRuntime = typeof window === "undefined"
+
+export const POSTS_TAGS_API_PATH = asOpenApiPath("/post/api/v1/posts/tags")
+
+const PUBLIC_CURSOR_DISABLED_SESSION_KEY = "posts:public-cursor-disabled:v1"
+const POSTS_EXPLORE_API_PATH = asOpenApiPath("/post/api/v1/posts/explore")
+const POSTS_SEARCH_API_PATH = asOpenApiPath("/post/api/v1/posts/search")
+const POSTS_FEED_API_PATH = asOpenApiPath("/post/api/v1/posts/feed")
+const POSTS_FEED_CURSOR_API_PATH = asOpenApiPath("/post/api/v1/posts/feed/cursor")
+const POSTS_EXPLORE_CURSOR_API_PATH = asOpenApiPath("/post/api/v1/posts/explore/cursor")
+const POSTS_RELATED_AUTHOR_API_PATH = "/post/api/v1/posts/related/author"
+const POSTS_BOOTSTRAP_API_PATH = "/post/api/v1/posts/bootstrap"
+const POSTS_ENDPOINT_TRACE_KEY = "posts:runtime-endpoints:v1"
+const POSTS_ENDPOINT_TRACE_MAX = 60
+
+let isPublicCursorDisabledCache: boolean | null = null
+
+export const resetPostRequestRuntimeState = () => {
+  isPublicCursorDisabledCache = null
+}
+
+export const isAbortError = (error: unknown): boolean => error instanceof Error && error.name === "AbortError"
+
+export const getFreshServerSnapshot = <T>(
+  cache: Map<string, { value: T; cachedAt: number }>,
+  key: string,
+  ttlMs: number
+): T | null => {
+  if (!isServerRuntime) return null
+  const cached = cache.get(key)
+  if (!cached) return null
+  if (Date.now() - cached.cachedAt > ttlMs) {
+    cache.delete(key)
+    return null
+  }
+  return cached.value
+}
+
+export const setServerSnapshot = <T>(
+  cache: Map<string, { value: T; cachedAt: number }>,
+  key: string,
+  value: T,
+  maxEntries: number
+) => {
+  cache.set(key, { value, cachedAt: Date.now() })
+  if (cache.size <= maxEntries) return
+  const oldestKey = cache.keys().next().value
+  if (oldestKey) cache.delete(oldestKey)
+}
+
+export const readPublicCursorDisabled = () => {
+  if (isServerRuntime) return false
+  if (isPublicCursorDisabledCache !== null) return isPublicCursorDisabledCache
+
+  try {
+    isPublicCursorDisabledCache = window.sessionStorage.getItem(PUBLIC_CURSOR_DISABLED_SESSION_KEY) === "1"
+  } catch {
+    isPublicCursorDisabledCache = false
+  }
+
+  return isPublicCursorDisabledCache
+}
+
+export const markPublicCursorDisabled = () => {
+  isPublicCursorDisabledCache = true
+  if (isServerRuntime) return
+
+  try {
+    window.sessionStorage.setItem(PUBLIC_CURSOR_DISABLED_SESSION_KEY, "1")
+  } catch {
+    // ignore storage permission/quota errors
+  }
+}
+
+export const recordRuntimeEndpoint = (path: string, paginationMode: "page" | "cursor") => {
+  if (isServerRuntime) return
+  const now = new Date().toISOString()
+  const entry = `${now} ${paginationMode.toUpperCase()} ${path}`
+  const traceWindow = window as Window & {
+    __aqPostEndpointTrace?: string[]
+  }
+
+  try {
+    const raw = window.sessionStorage.getItem(POSTS_ENDPOINT_TRACE_KEY)
+    const parsed = raw ? (JSON.parse(raw) as string[]) : []
+    const next = [...parsed, entry].slice(-POSTS_ENDPOINT_TRACE_MAX)
+    window.sessionStorage.setItem(POSTS_ENDPOINT_TRACE_KEY, JSON.stringify(next))
+    traceWindow.__aqPostEndpointTrace = next
+  } catch {
+    // ignore trace storage failures
+  }
+
+  if (paginationMode === "cursor") {
+    console.info("[posts-runtime-endpoint] cursor endpoint detected", path)
+  }
+}
+
+export const isAuthRequiredError = (error: unknown) =>
+  error instanceof ApiError && (error.status === 401 || error.status === 403)
+
+const toSortParam = (order: "asc" | "desc") => (order === "asc" ? "CREATED_AT_ASC" : "CREATED_AT")
+
+export const toValidPage = (page: number | undefined) => {
+  if (!Number.isFinite(page)) return 1
+  return Math.max(1, Math.trunc(page || 1))
+}
+
+export const toValidPageSize = (pageSize: number | undefined) => {
+  if (!Number.isFinite(pageSize)) return PAGE_SIZE
+  return Math.min(30, Math.max(1, Math.trunc(pageSize || PAGE_SIZE)))
+}
+
+export const buildExplorePath = ({
+  kw = "",
+  tag = "",
+  order = "desc",
+  page = 1,
+  pageSize = PAGE_SIZE,
+}: ExplorePostsParams) => {
+  const normalizedKw = normalizeKeywordQuery(kw)
+  const normalizedTag = normalizeTagQuery(tag)
+  const params = new URLSearchParams()
+  params.set("kw", normalizedKw)
+  params.set("tag", normalizedTag)
+  params.set("sort", toSortParam(order))
+  params.set("page", String(toValidPage(page)))
+  params.set("pageSize", String(toValidPageSize(pageSize)))
+  return `${POSTS_EXPLORE_API_PATH}?${params.toString()}`
+}
+
+export const buildSearchPath = ({
+  kw = "",
+  order = "desc",
+  page = 1,
+  pageSize = PAGE_SIZE,
+}: ExplorePostsParams) => {
+  const normalizedKw = normalizeKeywordQuery(kw)
+  const params = new URLSearchParams()
+  params.set("kw", normalizedKw)
+  params.set("sort", toSortParam(order))
+  params.set("page", String(toValidPage(page)))
+  params.set("pageSize", String(toValidPageSize(pageSize)))
+  return `${POSTS_SEARCH_API_PATH}?${params.toString()}`
+}
+
+export const buildFeedPath = ({
+  order = "desc",
+  page = 1,
+  pageSize = PAGE_SIZE,
+}: Pick<ExplorePostsParams, "order" | "page" | "pageSize">) => {
+  const params = new URLSearchParams()
+  params.set("sort", toSortParam(order))
+  params.set("page", String(toValidPage(page)))
+  params.set("pageSize", String(toValidPageSize(pageSize)))
+  return `${POSTS_FEED_API_PATH}?${params.toString()}`
+}
+
+export const buildFeedCursorPath = ({
+  order = "desc",
+  pageSize = PAGE_SIZE,
+  cursor,
+}: {
+  order?: "asc" | "desc"
+  pageSize?: number
+  cursor?: string
+}) => {
+  const params = new URLSearchParams()
+  params.set("sort", toSortParam(order))
+  params.set("pageSize", String(toValidPageSize(pageSize)))
+  if (cursor && cursor.trim()) {
+    params.set("cursor", cursor.trim())
+  }
+  return `${POSTS_FEED_CURSOR_API_PATH}?${params.toString()}`
+}
+
+export const buildExploreCursorPath = ({
+  tag = "",
+  order = "desc",
+  pageSize = PAGE_SIZE,
+  cursor,
+}: {
+  tag?: string
+  order?: "asc" | "desc"
+  pageSize?: number
+  cursor?: string
+}) => {
+  const normalizedTag = normalizeTagQuery(tag)
+  const params = new URLSearchParams()
+  params.set("tag", normalizedTag)
+  params.set("sort", toSortParam(order))
+  params.set("pageSize", String(toValidPageSize(pageSize)))
+  if (cursor && cursor.trim()) {
+    params.set("cursor", cursor.trim())
+  }
+  return `${POSTS_EXPLORE_CURSOR_API_PATH}?${params.toString()}`
+}
+
+export const buildBootstrapPath = ({
+  tag = "",
+  order = "desc",
+  pageSize = PAGE_SIZE,
+}: {
+  tag?: string
+  order?: "asc" | "desc"
+  pageSize?: number
+}) => {
+  const normalizedTag = normalizeTagQuery(tag)
+  const params = new URLSearchParams()
+  params.set("tag", normalizedTag)
+  params.set("sort", toSortParam(order))
+  params.set("pageSize", String(toValidPageSize(pageSize)))
+  return `${POSTS_BOOTSTRAP_API_PATH}?${params.toString()}`
+}
+
+export const buildRelatedByAuthorPath = ({
+  authorId,
+  excludePostId,
+  limit,
+}: {
+  authorId: number
+  excludePostId?: number
+  limit: number
+}) => {
+  const params = new URLSearchParams()
+  params.set("authorId", String(authorId))
+  params.set("limit", String(limit))
+  if (typeof excludePostId === "number" && Number.isFinite(excludePostId) && excludePostId > 0) {
+    params.set("excludePostId", String(Math.trunc(excludePostId)))
+  }
+  return `${POSTS_RELATED_AUTHOR_API_PATH}?${params.toString()}`
+}

--- a/front/src/apis/backend/posts/PostApiRequests.ts
+++ b/front/src/apis/backend/posts/PostApiRequests.ts
@@ -1,10 +1,9 @@
-import { normalizeKeywordQuery, normalizeTagQuery } from "src/libs/query/normalize"
-import type { PostDetail, TPost } from "src/types"
+import { normalizeTagQuery } from "src/libs/query/normalize"
+import type { TPost } from "src/types"
 import { ApiError, apiFetch } from "../client"
-import { asOpenApiPath } from "../openapiContract"
+import { resetPostDetailRequestCaches } from "./PostApiDetailRequests"
 import type {
   ApiPostDto,
-  ApiPostWithContentDto,
   ApiTagCountDto,
   CursorPageDto,
   ExplorePostsPage,
@@ -13,34 +12,40 @@ import type {
   PostsBootstrapDto,
   PostsBootstrapResult,
 } from "./PostApiDtos"
-import { extractPostIdFromSlug, mapPostDetail, mapPostDto } from "./PostApiMappers"
+import { mapPostDto } from "./PostApiMappers"
+import {
+  buildBootstrapPath,
+  buildExploreCursorPath,
+  buildExplorePath,
+  buildFeedCursorPath,
+  buildFeedPath,
+  buildRelatedByAuthorPath,
+  buildSearchPath,
+  getFreshServerSnapshot,
+  isAbortError,
+  isAuthRequiredError,
+  isServerRuntime,
+  markPublicCursorDisabled,
+  PAGE_SIZE,
+  POSTS_BOOTSTRAP_SSR_CACHE_MAX_ENTRIES,
+  POSTS_BOOTSTRAP_SSR_CACHE_TTL_MS,
+  POSTS_CACHE_TTL_MS,
+  POSTS_TAGS_API_PATH,
+  readPublicCursorDisabled,
+  recordRuntimeEndpoint,
+  resetPostRequestRuntimeState,
+  setServerSnapshot,
+  toValidPage,
+  toValidPageSize,
+} from "./PostApiRequestModel"
 
-const PAGE_SIZE = 30
-const POSTS_CACHE_TTL_MS = 90_000
-const POSTS_BOOTSTRAP_SSR_CACHE_TTL_MS = 60_000
-const POST_DETAIL_SSR_CACHE_TTL_MS = 120_000
-const POSTS_BOOTSTRAP_SSR_CACHE_MAX_ENTRIES = 6
-const POST_DETAIL_SSR_CACHE_MAX_ENTRIES = 24
-const isServerRuntime = typeof window === "undefined"
-const PUBLIC_CURSOR_DISABLED_SESSION_KEY = "posts:public-cursor-disabled:v1"
-const POSTS_EXPLORE_API_PATH = asOpenApiPath("/post/api/v1/posts/explore")
-const POSTS_SEARCH_API_PATH = asOpenApiPath("/post/api/v1/posts/search")
-const POSTS_FEED_API_PATH = asOpenApiPath("/post/api/v1/posts/feed")
-const POSTS_FEED_CURSOR_API_PATH = asOpenApiPath("/post/api/v1/posts/feed/cursor")
-const POSTS_EXPLORE_CURSOR_API_PATH = asOpenApiPath("/post/api/v1/posts/explore/cursor")
-const POSTS_TAGS_API_PATH = asOpenApiPath("/post/api/v1/posts/tags")
-const POSTS_RELATED_AUTHOR_API_PATH = "/post/api/v1/posts/related/author"
-const POSTS_BOOTSTRAP_API_PATH = "/post/api/v1/posts/bootstrap"
-const POSTS_ENDPOINT_TRACE_KEY = "posts:runtime-endpoints:v1"
-const POSTS_ENDPOINT_TRACE_MAX = 60
+export { getPostDetailById, getPostDetailBySlug } from "./PostApiDetailRequests"
+
 let postsCache: TPost[] | null = null
 let postsCacheAt = 0
 let pendingPostsPromise: Promise<TPost[]> | null = null
 let postsBootstrapSsrCache = new Map<string, { value: PostsBootstrapResult; cachedAt: number }>()
 let pendingPostsBootstrapPromises = new Map<string, Promise<PostsBootstrapResult>>()
-let postDetailSsrCache = new Map<string, { value: PostDetail; cachedAt: number }>()
-let pendingPostDetailPromises = new Map<string, Promise<PostDetail | null>>()
-let isPublicCursorDisabledCache: boolean | null = null
 
 type GetPostsOptions = {
   throwOnError?: boolean
@@ -52,219 +57,8 @@ export const resetPostsRequestCaches = () => {
   pendingPostsPromise = null
   postsBootstrapSsrCache = new Map()
   pendingPostsBootstrapPromises = new Map()
-  postDetailSsrCache = new Map()
-  pendingPostDetailPromises = new Map()
-}
-
-const isAbortError = (error: unknown): boolean => error instanceof Error && error.name === "AbortError"
-const getFreshServerSnapshot = <T>(
-  cache: Map<string, { value: T; cachedAt: number }>,
-  key: string,
-  ttlMs: number
-): T | null => {
-  if (!isServerRuntime) return null
-  const cached = cache.get(key)
-  if (!cached) return null
-  if (Date.now() - cached.cachedAt > ttlMs) {
-    cache.delete(key)
-    return null
-  }
-  return cached.value
-}
-
-const setServerSnapshot = <T>(
-  cache: Map<string, { value: T; cachedAt: number }>,
-  key: string,
-  value: T,
-  maxEntries: number
-) => {
-  cache.set(key, { value, cachedAt: Date.now() })
-  if (cache.size <= maxEntries) return
-  const oldestKey = cache.keys().next().value
-  if (oldestKey) cache.delete(oldestKey)
-}
-
-
-const readPublicCursorDisabled = () => {
-  if (isServerRuntime) return false
-  if (isPublicCursorDisabledCache !== null) return isPublicCursorDisabledCache
-
-  try {
-    isPublicCursorDisabledCache = window.sessionStorage.getItem(PUBLIC_CURSOR_DISABLED_SESSION_KEY) === "1"
-  } catch {
-    isPublicCursorDisabledCache = false
-  }
-
-  return isPublicCursorDisabledCache
-}
-
-const markPublicCursorDisabled = () => {
-  isPublicCursorDisabledCache = true
-  if (isServerRuntime) return
-
-  try {
-    window.sessionStorage.setItem(PUBLIC_CURSOR_DISABLED_SESSION_KEY, "1")
-  } catch {
-    // ignore storage permission/quota errors
-  }
-}
-
-const recordRuntimeEndpoint = (path: string, paginationMode: "page" | "cursor") => {
-  if (isServerRuntime) return
-  const now = new Date().toISOString()
-  const entry = `${now} ${paginationMode.toUpperCase()} ${path}`
-  const traceWindow = window as Window & {
-    __aqPostEndpointTrace?: string[]
-  }
-
-  try {
-    const raw = window.sessionStorage.getItem(POSTS_ENDPOINT_TRACE_KEY)
-    const parsed = raw ? (JSON.parse(raw) as string[]) : []
-    const next = [...parsed, entry].slice(-POSTS_ENDPOINT_TRACE_MAX)
-    window.sessionStorage.setItem(POSTS_ENDPOINT_TRACE_KEY, JSON.stringify(next))
-    traceWindow.__aqPostEndpointTrace = next
-  } catch {
-    // ignore trace storage failures
-  }
-
-  if (paginationMode === "cursor") {
-    console.info("[posts-runtime-endpoint] cursor endpoint detected", path)
-  }
-}
-
-const isAuthRequiredError = (error: unknown) =>
-  error instanceof ApiError && (error.status === 401 || error.status === 403)
-
-const toSortParam = (order: "asc" | "desc") => (order === "asc" ? "CREATED_AT_ASC" : "CREATED_AT")
-
-const toValidPage = (page: number | undefined) => {
-  if (!Number.isFinite(page)) return 1
-  return Math.max(1, Math.trunc(page || 1))
-}
-
-const toValidPageSize = (pageSize: number | undefined) => {
-  if (!Number.isFinite(pageSize)) return PAGE_SIZE
-  return Math.min(30, Math.max(1, Math.trunc(pageSize || PAGE_SIZE)))
-}
-
-const buildExplorePath = ({
-  kw = "",
-  tag = "",
-  order = "desc",
-  page = 1,
-  pageSize = PAGE_SIZE,
-}: ExplorePostsParams) => {
-  const normalizedKw = normalizeKeywordQuery(kw)
-  const normalizedTag = normalizeTagQuery(tag)
-  const params = new URLSearchParams()
-  params.set("kw", normalizedKw)
-  params.set("tag", normalizedTag)
-  params.set("sort", toSortParam(order))
-  params.set("page", String(toValidPage(page)))
-  params.set("pageSize", String(toValidPageSize(pageSize)))
-  return `${POSTS_EXPLORE_API_PATH}?${params.toString()}`
-}
-
-const buildSearchPath = ({
-  kw = "",
-  order = "desc",
-  page = 1,
-  pageSize = PAGE_SIZE,
-}: ExplorePostsParams) => {
-  const normalizedKw = normalizeKeywordQuery(kw)
-  const params = new URLSearchParams()
-  params.set("kw", normalizedKw)
-  params.set("sort", toSortParam(order))
-  params.set("page", String(toValidPage(page)))
-  params.set("pageSize", String(toValidPageSize(pageSize)))
-  return `${POSTS_SEARCH_API_PATH}?${params.toString()}`
-}
-
-const buildFeedPath = ({
-  order = "desc",
-  page = 1,
-  pageSize = PAGE_SIZE,
-}: Pick<ExplorePostsParams, "order" | "page" | "pageSize">) => {
-  const params = new URLSearchParams()
-  params.set("sort", toSortParam(order))
-  params.set("page", String(toValidPage(page)))
-  params.set("pageSize", String(toValidPageSize(pageSize)))
-  return `${POSTS_FEED_API_PATH}?${params.toString()}`
-}
-
-const buildFeedCursorPath = ({
-  order = "desc",
-  pageSize = PAGE_SIZE,
-  cursor,
-}: {
-  order?: "asc" | "desc"
-  pageSize?: number
-  cursor?: string
-}) => {
-  const params = new URLSearchParams()
-  params.set("sort", toSortParam(order))
-  params.set("pageSize", String(toValidPageSize(pageSize)))
-  if (cursor && cursor.trim()) {
-    params.set("cursor", cursor.trim())
-  }
-  return `${POSTS_FEED_CURSOR_API_PATH}?${params.toString()}`
-}
-
-const buildExploreCursorPath = ({
-  tag = "",
-  order = "desc",
-  pageSize = PAGE_SIZE,
-  cursor,
-}: {
-  tag?: string
-  order?: "asc" | "desc"
-  pageSize?: number
-  cursor?: string
-}) => {
-  const normalizedTag = normalizeTagQuery(tag)
-  const params = new URLSearchParams()
-  params.set("tag", normalizedTag)
-  params.set("sort", toSortParam(order))
-  params.set("pageSize", String(toValidPageSize(pageSize)))
-  if (cursor && cursor.trim()) {
-    params.set("cursor", cursor.trim())
-  }
-  return `${POSTS_EXPLORE_CURSOR_API_PATH}?${params.toString()}`
-}
-
-const buildBootstrapPath = ({
-  tag = "",
-  order = "desc",
-  pageSize = PAGE_SIZE,
-}: {
-  tag?: string
-  order?: "asc" | "desc"
-  pageSize?: number
-}) => {
-  const normalizedTag = normalizeTagQuery(tag)
-  const params = new URLSearchParams()
-  params.set("tag", normalizedTag)
-  params.set("sort", toSortParam(order))
-  params.set("pageSize", String(toValidPageSize(pageSize)))
-  return `${POSTS_BOOTSTRAP_API_PATH}?${params.toString()}`
-}
-
-const buildRelatedByAuthorPath = ({
-  authorId,
-  excludePostId,
-  limit,
-}: {
-  authorId: number
-  excludePostId?: number
-  limit: number
-}) => {
-  const params = new URLSearchParams()
-  params.set("authorId", String(authorId))
-  params.set("limit", String(limit))
-  if (typeof excludePostId === "number" && Number.isFinite(excludePostId) && excludePostId > 0) {
-    params.set("excludePostId", String(Math.trunc(excludePostId)))
-  }
-  return `${POSTS_RELATED_AUTHOR_API_PATH}?${params.toString()}`
+  resetPostDetailRequestCaches()
+  resetPostRequestRuntimeState()
 }
 
 export const getPostsBootstrap = async ({
@@ -756,78 +550,4 @@ export const getPosts = async (
   } finally {
     pendingPostsPromise = null
   }
-}
-
-
-export const getPostDetailBySlug = async (slug: string): Promise<PostDetail | null> => {
-  const postId = extractPostIdFromSlug(slug)
-  if (!postId) return null
-
-  try {
-    const post = await apiFetch<ApiPostWithContentDto>(`/post/api/v1/posts/${postId}`)
-    const mapped = mapPostDetail(post)
-
-    // slug mismatch should 404 to avoid duplicate-url indexing.
-    if (mapped.slug !== slug) return null
-
-    return mapped
-  } catch (error) {
-    if (error instanceof ApiError && error.status === 404) {
-      return null
-    }
-    throw error
-  }
-}
-
-export const getPostDetailById = async (id: string): Promise<PostDetail | null> => {
-  const postId = Number(id)
-  if (!Number.isInteger(postId) || postId <= 0) return null
-  const endpoint = `/post/api/v1/posts/${postId}`
-  const canUseServerSnapshot = isServerRuntime
-  const cachedSnapshot =
-    canUseServerSnapshot
-      ? getFreshServerSnapshot(postDetailSsrCache, endpoint, POST_DETAIL_SSR_CACHE_TTL_MS)
-      : null
-  if (cachedSnapshot) return cachedSnapshot
-
-  if (canUseServerSnapshot) {
-    const pendingSnapshot = pendingPostDetailPromises.get(endpoint)
-    if (pendingSnapshot) return pendingSnapshot
-  }
-
-  const loadPostDetail = async () => {
-    const post = await apiFetch<ApiPostWithContentDto>(endpoint)
-    return mapPostDetail(post)
-  }
-
-  if (!canUseServerSnapshot) {
-    try {
-      return await loadPostDetail()
-    } catch (error) {
-      if (error instanceof ApiError && error.status === 404) {
-        return null
-      }
-      throw error
-    }
-  }
-
-  const snapshotPromise = (async () => {
-    try {
-      const nextDetail = await loadPostDetail()
-      setServerSnapshot(postDetailSsrCache, endpoint, nextDetail, POST_DETAIL_SSR_CACHE_MAX_ENTRIES)
-      return nextDetail
-    } catch (error) {
-      if (error instanceof ApiError && error.status === 404) {
-        return null
-      }
-      const staleSnapshot = postDetailSsrCache.get(endpoint)?.value
-      if (staleSnapshot) return staleSnapshot
-      throw error
-    } finally {
-      pendingPostDetailPromises.delete(endpoint)
-    }
-  })()
-
-  pendingPostDetailPromises.set(endpoint, snapshotPromise)
-  return snapshotPromise
 }


### PR DESCRIPTION
## 관련 이슈

close #420

## 작업 배경

- Post API request layer의 residual 대형 파일을 600 line budget 아래로 분리했습니다.
- runtime path/trace/cursor fallback helper는 request model로, detail SSR cache/detail fetch는 detail request module로 이동했습니다.
- main merge 후 기존 자동 배포 경로를 그대로 타며, 배포 후 live e2e로 실제 페이지를 재확인합니다.

## 작업 내용

- `PostApiRequests.ts`는 list/query/bootstrap orchestration과 facade re-export만 남기고 553 lines로 축소했습니다.
- `PostApiRequestModel.ts`가 endpoint path builder, page size normalization, cursor fallback/session trace, SSR snapshot helper를 소유합니다.
- `PostApiDetailRequests.ts`가 post detail by id/slug와 detail SSR cache를 소유합니다.
- smoke source-boundary guard가 `PostApiRequests.ts <= 600`과 새 companion modules 존재를 확인합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts --workers=1 --grep "backend posts API client"` (RED -> GREEN)
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/editor-authoring-flow.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front check:bundle-size` (2회 연속 통과)
  - `yarn --cwd front build` (2회 통과)
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: posts facade export 또는 SSR snapshot reset wiring 회귀.
- 롤백 방법: 이 PR commit을 revert하면 기존 단일 `PostApiRequests.ts` 구조로 복귀합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
