### PR TITLE
[Refactor] 프론트 대형 파일 회귀 가드 추가

### DIFF
--- a/front/e2e/source-boundary-refactor-guard.spec.ts
+++ b/front/e2e/source-boundary-refactor-guard.spec.ts
@@ -1,0 +1,20 @@
+import { execFileSync } from "node:child_process"
+import path from "node:path"
+import { expect, test } from "@playwright/test"
+
+test.describe("refactor boundary guard", () => {
+  test("large file and ownership boundary guard passes", () => {
+    const frontRoot = path.resolve(__dirname, "..")
+    const output = execFileSync(process.execPath, [path.join(frontRoot, "scripts/check-refactor-boundaries.mjs")], {
+      cwd: frontRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FORCE_COLOR: "0",
+        NO_COLOR: "1",
+      },
+    })
+
+    expect(output).toContain("[refactor-boundaries] ok")
+  })
+})

--- a/front/package.json
+++ b/front/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "dev": "next dev",
+    "prebuild": "yarn check:refactor-boundaries",
     "build": "node scripts/with-test-lock.mjs --resource front-verify --label build -- next build",
     "postinstall": "node scripts/patch-lodash-template.cjs",
     "start": "next start",
@@ -32,6 +33,7 @@
     "storybook:gate": "node scripts/storybook/run-storybook-gate.mjs",
     "storybook:test": "HOME=$PWD/.storybook-home CI=1 STORYBOOK_DISABLE_TELEMETRY=1 STORYBOOK_DISABLE_UPDATE_CHECK=1 storybook test --watch=false",
     "check:bundle-size": "node scripts/with-test-lock.mjs --resource front-verify --label bundle-size -- node scripts/check-bundle-size.mjs",
+    "check:refactor-boundaries": "node scripts/check-refactor-boundaries.mjs",
     "check:runtime-guard": "node scripts/compare-runtime-guard-metrics.mjs",
     "postbuild": "echo \"skip next-sitemap (handled by pages/sitemap.xml.tsx)\"",
     "lint": "next lint"

--- a/front/scripts/check-refactor-boundaries.mjs
+++ b/front/scripts/check-refactor-boundaries.mjs
@@ -1,0 +1,278 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const frontRoot = path.resolve(scriptDir, "..")
+
+const PRODUCTION_HARD_LIMIT = 1000
+const PRODUCTION_SOFT_LIMIT = 600
+const E2E_ROOT_SPEC_LIMIT = 800
+
+const normalizePath = (value) => value.split(path.sep).join("/")
+
+const productionSoftAllowlist = {
+  "src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx": {
+    issue: "#398",
+    reason: "editor studio route orchestrator is below the 1,000 line hard budget after root split",
+    expires: "split below 600 when routing/runtime state can be moved without re-coupling the editor flow",
+  },
+  "src/routes/Admin/EditorStudioWorkspaceControllerRootView.tsx": {
+    issue: "#398",
+    reason: "editor studio root view owns the dedicated editor/admin layout bridge and remains below hard budget",
+    expires: "split below 600 when view props are reduced by a narrower editor surface contract",
+  },
+  "src/components/editor/BlockEditorEngine.editorSurfaceStyles.tsx": {
+    issue: "#390",
+    reason: "editor surface style module is a style-only companion and remains below the 1,000 line style budget",
+    expires: "split when shared typography/style tokens remove editor-surface-only declarations",
+  },
+  "src/components/editor/BlockEditorEngine.viewportLayer.tsx": {
+    issue: "#390",
+    reason: "viewport layer is a single render layer below the 1,000 line layer budget",
+    expires: "split when block handle, bubble toolbar, and viewport props are independently owned",
+  },
+  "src/components/editor/BlockEditorEngine.tableStyles.tsx": {
+    issue: "#390",
+    reason: "table style module is a style-only companion and remains below the 1,000 line style budget",
+    expires: "split when table chrome tokens are promoted to shared primitives",
+  },
+}
+
+const e2eRootAllowlist = {
+  "e2e/source-boundary-editor-studio.spec.ts": {
+    issue: "#423",
+    reason: "aggregate source-boundary contracts moved out of editor-studio-state; final guard script covers recurring budgets",
+    expires: "shrink below 800 after exact string contracts are fully migrated into data-driven guard tables",
+  },
+}
+
+const productionRoots = ["src", "pages"]
+const generatedPathPatterns = [
+  /(^|\/)__generated__\//,
+  /(^|\/)generated\//,
+  /\.generated\./,
+  /\.d\.ts$/,
+]
+
+const isSourceFile = (filePath) => /\.(ts|tsx|mts|cts)$/.test(filePath)
+const isProductionFile = (filePath) => isSourceFile(filePath) && !generatedPathPatterns.some((pattern) => pattern.test(filePath))
+
+const readSource = (relativePath) => {
+  const absolutePath = path.join(frontRoot, relativePath)
+  if (!existsSync(absolutePath)) {
+    throw new Error(`Missing required boundary file: ${relativePath}`)
+  }
+  return readFileSync(absolutePath, "utf8")
+}
+
+const countLines = (source) => source.split(/\r?\n/).length
+
+const walk = (relativeDir) => {
+  const absoluteDir = path.join(frontRoot, relativeDir)
+  const files = []
+
+  for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+    const relativePath = normalizePath(path.join(relativeDir, entry.name))
+    if (entry.isDirectory()) {
+      files.push(...walk(relativePath))
+      continue
+    }
+
+    if (entry.isFile()) {
+      files.push(relativePath)
+    }
+  }
+
+  return files
+}
+
+const validateAllowlistEntry = (allowlistName, relativePath, entry) => {
+  const missingFields = ["issue", "reason", "expires"].filter((field) => !entry?.[field])
+  if (missingFields.length > 0) {
+    return `${allowlistName} allowlist entry ${relativePath} is missing: ${missingFields.join(", ")}`
+  }
+  return null
+}
+
+const failures = []
+
+for (const relativePath of Object.keys(productionSoftAllowlist)) {
+  const error = validateAllowlistEntry("production-soft", relativePath, productionSoftAllowlist[relativePath])
+  if (error) failures.push(error)
+}
+
+for (const relativePath of Object.keys(e2eRootAllowlist)) {
+  const error = validateAllowlistEntry("e2e-root", relativePath, e2eRootAllowlist[relativePath])
+  if (error) failures.push(error)
+}
+
+const productionFiles = productionRoots.filter((relativeDir) => existsSync(path.join(frontRoot, relativeDir))).flatMap(walk).filter(isProductionFile)
+
+for (const relativePath of productionFiles) {
+  const lines = countLines(readSource(relativePath))
+
+  if (lines > PRODUCTION_HARD_LIMIT) {
+    failures.push(
+      `${relativePath} has ${lines} lines; production files must stay <= ${PRODUCTION_HARD_LIMIT}. Split orchestration/view/model responsibility and link the owning issue.`
+    )
+    continue
+  }
+
+  if (lines > PRODUCTION_SOFT_LIMIT && !productionSoftAllowlist[relativePath]) {
+    failures.push(
+      `${relativePath} has ${lines} lines; files over ${PRODUCTION_SOFT_LIMIT} require an explicit allowlist entry with issue, reason, and expiry.`
+    )
+  }
+}
+
+for (const relativePath of Object.keys(productionSoftAllowlist)) {
+  if (!productionFiles.includes(relativePath)) {
+    failures.push(`Stale production soft allowlist entry: ${relativePath}`)
+  }
+}
+
+const e2eRootSpecs = walk("e2e").filter((relativePath) => /^e2e\/[^/]+\.spec\.ts$/.test(relativePath))
+
+for (const relativePath of e2eRootSpecs) {
+  const lines = countLines(readSource(relativePath))
+  if (lines > E2E_ROOT_SPEC_LIMIT && !e2eRootAllowlist[relativePath]) {
+    failures.push(
+      `${relativePath} has ${lines} lines; root E2E specs must stay <= ${E2E_ROOT_SPEC_LIMIT} or move responsibility into split specs/helpers with an allowlist expiry.`
+    )
+  }
+}
+
+for (const relativePath of Object.keys(e2eRootAllowlist)) {
+  if (!e2eRootSpecs.includes(relativePath)) {
+    failures.push(`Stale E2E root allowlist entry: ${relativePath}`)
+  }
+}
+
+const ownershipRules = [
+  {
+    file: "src/components/editor/BlockEditorEngine.tsx",
+    required: [
+      'from "./useBlockEditorEngineController"',
+      'from "./BlockEditorEngine.layers"',
+      'from "./BlockEditorEngine.tableOverlayLayer"',
+      'from "./BlockEditorEngine.styles"',
+    ],
+    forbidden: [/\bstyled\./, /\buseEditor\(/, /\buseEffect\(/],
+    hint: "BlockEditorEngine must remain a render wrapper; controller, layers, and styles own the heavy work.",
+  },
+  {
+    file: "src/components/editor/useBlockEditorEngineController.ts",
+    required: [
+      'from "./useBlockEditorTableOverlayController"',
+      'from "./useBlockEditorEngineBlockDrag"',
+      'from "./useBlockEditorEngineBlockSelectionUi"',
+      'from "./useBlockEditorEngineControllerState"',
+      'from "./useBlockEditorEngineInsertActions"',
+      'from "./useBlockEditorEngineSlashMenu"',
+    ],
+    forbidden: [/\bstyled\./],
+    hint: "The engine controller must delegate table, drag, selection, insert, and slash responsibilities.",
+  },
+  {
+    file: "src/routes/Admin/EditorStudioWorkspaceController.tsx",
+    required: ['from "./EditorStudioWorkspaceControllerRoot"'],
+    forbidden: [/\buseState\(/, /\buseEffect\(/, /\bapiFetch\b/],
+    hint: "EditorStudioWorkspaceController is a thin compatibility entry.",
+  },
+  {
+    file: "src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx",
+    required: [
+      'from "./EditorStudioWorkspaceControllerRootModel"',
+      'from "./EditorStudioWorkspaceControllerRootView"',
+      'from "./useEditorStudioAdminPostFlow"',
+      'from "./useEditorStudioDraftLifecycle"',
+      'from "./useEditorStudioPersistence"',
+      'from "./useEditorStudioRouting"',
+    ],
+    forbidden: [/\bstyled\./],
+    hint: "Editor studio root must keep runtime, model, and view contracts delegated.",
+  },
+  {
+    file: "src/routes/Detail/PostDetail/index.tsx",
+    required: [
+      'from "./PostDetail.styles"',
+      'from "./PostDetailRelatedSection"',
+      'from "./PostDetailTocModel"',
+      'from "./PostDetailRailModel"',
+      'from "./PostDetailActionSections"',
+      'from "./usePostDetailEngagementActions"',
+      'from "./usePostDetailRelatedPosts"',
+    ],
+    forbidden: [/\bstyled\./],
+    hint: "PostDetail must keep rail, toc, actions, related posts, and styles delegated.",
+  },
+  {
+    file: "src/routes/Feed/FeedExplorer.tsx",
+    required: ['from "./FeedExplorer.styles"', 'from "./FeedExplorerRestoreModel"'],
+    forbidden: [/\bstyled\./],
+    hint: "FeedExplorer must keep restore/cache model and styles delegated.",
+  },
+  {
+    file: "src/routes/Admin/AdminPostsWorkspacePage.tsx",
+    required: [
+      'from "./AdminPostsWorkspaceModel"',
+      'from "./AdminPostsWorkspacePageCommands"',
+      'from "./AdminPostsWorkspacePageView"',
+    ],
+    forbidden: [/\bstyled\./],
+    hint: "Admin posts workspace page must keep command/model/view responsibilities split.",
+  },
+  {
+    file: "src/layouts/RootLayout/Header/NotificationBell.tsx",
+    required: [
+      'from "./NotificationBellPanel"',
+      'from "./NotificationBell.styles"',
+      'from "./useNotificationBellState"',
+    ],
+    forbidden: [/\bEventSource\b/, /\blocalStorage\b/, /\bfetch\(/],
+    hint: "NotificationBell must assemble state, panel, and styles without owning transport/storage.",
+  },
+  {
+    file: "src/apis/backend/posts.ts",
+    required: [
+      'from "./posts/PostApiDtos"',
+      'from "./posts/PostApiCache"',
+      'from "./posts/PostApiMappers"',
+      'from "./posts/PostApiRequests"',
+    ],
+    forbidden: [/\bapiFetch\b/, /\baxios\b/, /\bqueryClient\b/],
+    hint: "posts.ts must stay a facade over DTO/cache/mapper/request modules.",
+  },
+]
+
+for (const rule of ownershipRules) {
+  const source = readSource(rule.file)
+  for (const expected of rule.required) {
+    if (!source.includes(expected)) {
+      failures.push(`${rule.file} is missing required boundary token ${JSON.stringify(expected)}. ${rule.hint}`)
+    }
+  }
+  for (const pattern of rule.forbidden) {
+    if (pattern.test(source)) {
+      failures.push(`${rule.file} contains forbidden ownership pattern ${pattern}. ${rule.hint}`)
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error("[refactor-boundaries] failed")
+  for (const failure of failures) {
+    console.error(`- ${failure}`)
+  }
+  process.exit(1)
+}
+
+console.log(
+  [
+    "[refactor-boundaries] ok",
+    `production=${productionFiles.length} hard<=${PRODUCTION_HARD_LIMIT} soft<=${PRODUCTION_SOFT_LIMIT} allowlist=${Object.keys(productionSoftAllowlist).length}`,
+    `e2eRootSpecs=${e2eRootSpecs.length} limit<=${E2E_ROOT_SPEC_LIMIT} allowlist=${Object.keys(e2eRootAllowlist).length}`,
+    `ownershipRules=${ownershipRules.length}`,
+  ].join(" | ")
+)


### PR DESCRIPTION
## 관련 이슈

close #374

## 작업 배경

- 프론트 대형 파일 리팩터링 완료 상태를 CI build 경로에서 자동 차단하는 refactor boundary guard를 추가했습니다.
- production hard/soft line budget, E2E root spec budget, 핵심 ownership boundary token을 검사하고 source-boundary Playwright spec에서도 같은 guard를 실행합니다.

## 작업 내용

- `front/scripts/check-refactor-boundaries.mjs` 추가: production 1,000 lines hard budget, 600 lines soft allowlist, E2E root spec 800 lines budget, ownership guard 9개 검사.
- `front/package.json`에 `check:refactor-boundaries`와 `prebuild`를 연결해 기존 `yarn --cwd front build`/frontend CI build 경로에서 자동 실행되도록 했습니다.
- `front/e2e/source-boundary-refactor-guard.spec.ts`를 추가해 source-boundary 검증에서도 guard 실행을 확인합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front check:refactor-boundaries`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/source-boundary-editor-studio.spec.ts e2e/source-boundary-refactor-guard.spec.ts --workers=1` (19 passed, 2회 연속 통과)
  - `yarn --cwd front test:e2e:perf` (14 passed)
  - `yarn --cwd front check:bundle-size`
  - `git diff --check`
  - `env CURRENT_TASK_SLUG=front-refactor-final-guard bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: `prebuild` guard가 새 파일 추가 시 line budget/allowlist 누락을 즉시 실패시킬 수 있습니다. 실패 메시지에 파일, limit, allowlist 필요 조건을 출력합니다.
- 롤백 방법: 이 PR revert 후 `prebuild` guard 연결과 source-boundary guard spec을 제거합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
