### PR TITLE
[Fix] 글수정 코드블럭 본문 visibility 복구

### DIFF
--- a/front/e2e/editor-authoring-route-rich-focus.spec.ts
+++ b/front/e2e/editor-authoring-route-rich-focus.spec.ts
@@ -140,7 +140,7 @@ test.describe("editor authoring route rich block focus", () => {
               if (!event.target.closest("[data-testid='block-editor-prosemirror']")) return
               window.setTimeout(() => {
                 window.scrollTo(0, staleScrollTop)
-              }, 260)
+              }, 720)
             },
             { capture: true, once: true }
           )
@@ -152,7 +152,7 @@ test.describe("editor authoring route rich block focus", () => {
         targetBox.x + Math.min(clickOffset.x, Math.max(8, targetBox.width - 8)),
         targetBox.y + Math.min(clickOffset.y, Math.max(8, targetBox.height - 8))
       )
-      await page.waitForTimeout(420)
+      await page.waitForTimeout(1_000)
 
       const afterGeometry = await page.evaluate(
         ({ selector, text }) => {

--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -233,4 +233,29 @@ test.describe("editor studio state", () => {
     expect(restored.doc.content?.[2]?.content?.[0]?.text).toContain("return new Token(access, refresh);")
   })
 
+  test("초기 editor doc의 보이지 않는 placeholder 코드블럭은 source markdown의 non-empty fence로 복구한다", () => {
+    const sourceMarkdown = [
+      "코드 본문 visibility 복구 대상입니다.",
+      "",
+      "```text",
+      "로그인 -> 세션 생성 -> 이후 요청에서 세션 확인",
+      "```",
+    ].join("\n")
+    const staleDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "코드 본문 visibility 복구 대상입니다." }],
+        },
+        { type: "codeBlock", attrs: { language: "text" }, content: [{ type: "text", text: "\u200B" }] },
+      ],
+    }
+
+    const restored = restoreEditorDocCodeBlocksFromMarkdown(sourceMarkdown, staleDoc)
+
+    expect(restored.changed).toBe(true)
+    expect(restored.doc.content?.[1]?.content?.[0]?.text).toBe("로그인 -> 세션 생성 -> 이후 요청에서 세션 확인")
+  })
+
 })

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -138,8 +138,8 @@ export const preserveWindowScrollAcrossFrames = (frames = 6, tolerance = 4, minD
 
 let preserveNextEditorPointerAfterTable = false
 
-const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES = 12
-const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS = 520
+const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES = 72
+const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS = 1_120
 const EDITOR_POINTER_SCROLL_PRESERVE_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
 const EDITOR_POINTER_SCROLL_CONTROL_SELECTOR =
   "button, input, textarea, select, summary, [role='button'], [contenteditable='false']"

--- a/front/src/components/editor/serializationLegacyRepair.ts
+++ b/front/src/components/editor/serializationLegacyRepair.ts
@@ -3,10 +3,15 @@ import type { JSONContent } from "@tiptap/core"
 import { parseMarkdownToEditorDoc } from "./serializationHtmlImport"
 import type { BlockEditorDoc, UnsupportedBlock } from "./serializationTypes"
 
+const INVISIBLE_CODE_PLACEHOLDER_REGEX = /[\u00A0\u200B-\u200D\u2060\uFEFF]/g
+
 const readPlainTextFromEditorNode = (node: JSONContent): string => {
   if (node.type === "text") return typeof node.text === "string" ? node.text : ""
   return (node.content || []).map((child) => readPlainTextFromEditorNode(child)).join("")
 }
+
+const hasVisibleCodeText = (value: string) =>
+  value.replace(INVISIBLE_CODE_PLACEHOLDER_REGEX, "").trim().length > 0
 
 const collectCodeBlockSnapshots = (doc: JSONContent) => {
   const blocks: Array<{ language: string | null; text: string }> = []
@@ -32,7 +37,7 @@ export const restoreEditorDocCodeBlocksFromMarkdown = (
   doc: BlockEditorDoc
 ): { doc: BlockEditorDoc; changed: boolean } => {
   const sourceBlocks = collectCodeBlockSnapshots(parseMarkdownToEditorDoc(sourceMarkdown))
-  if (sourceBlocks.every((block) => block.text.trim().length === 0)) {
+  if (sourceBlocks.every((block) => !hasVisibleCodeText(block.text))) {
     return { doc, changed: false }
   }
 
@@ -46,7 +51,7 @@ export const restoreEditorDocCodeBlocksFromMarkdown = (
 
       const currentText = readPlainTextFromEditorNode(node)
       const sourceText = sourceBlock?.text || ""
-      if (currentText.trim().length > 0 || sourceText.trim().length === 0) return node
+      if (hasVisibleCodeText(currentText) || !hasVisibleCodeText(sourceText)) return node
 
       changed = true
       const currentLanguage = typeof node.attrs?.language === "string" ? node.attrs.language : null


### PR DESCRIPTION
## 관련 이슈

close #451

## 작업 배경

- `/editor/[id]` 수정 진입에서 zero-width placeholder만 가진 코드블럭을 빈 코드로 취급하도록 복구했습니다.
- source markdown에 실제 fenced code body가 있으면 editor doc repair가 해당 본문을 다시 채워 코드블럭 shell만 남는 회귀를 막습니다.
- PR follow-up으로 code/table/Mermaid 같은 rich block 내부 클릭 후 지연 focus reveal이 이전 selection anchor로 viewport를 되돌리는 회귀도 함께 막았습니다.

## 작업 내용

- code block repair가 `\u200B` 등 invisible placeholder를 visible code text로 오판하지 않도록 판정 함수를 추가했습니다.
- source markdown의 non-empty fence를 placeholder code node로 복구하는 회귀 테스트를 추가했습니다.
- editor rich block 클릭 시 scroll preserve window를 지연 focus reveal보다 길게 유지하고, 720ms delayed reveal red 케이스를 route rich-focus spec에 반영했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts -g "보이지 않는 placeholder 코드블럭" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-code-recovery.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - RED: `yarn --cwd front playwright test e2e/editor-authoring-route-rich-focus.spec.ts -g "지연된 내부 focus" --workers=1` 실패 확인, scrollTop delta 1220px
  - GREEN: `yarn --cwd front playwright test e2e/editor-authoring-route-rich-focus.spec.ts -g "지연된 내부 focus" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-rich-focus.spec.ts e2e/editor-authoring-route-scroll-selection.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: invisible 문자만 실제 코드로 저장하려던 극단 케이스는 빈 코드로 취급될 수 있습니다. rich block 클릭 후 약 1.1초 안의 wheel/touch/key 입력은 기존 cancel 경로로 보존 루프를 중단합니다.
- 롤백 방법: `d6a71258`, `3d46caf5` 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
