### PR TITLE
[Fix] 글수정 본문 클릭 scroll flicker 복구

### DIFF
--- a/front/e2e/editor-authoring-route-body-click-flicker.spec.ts
+++ b/front/e2e/editor-authoring-route-body-click-flicker.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test } from "@playwright/test"
+import {
+  expectEditorToContainLoadedText,
+  expectVisibleBox,
+} from "./helpers/editorAuthoringFlow"
+
+test.describe("editor authoring route body click flicker", () => {
+  test("실제 /editor/[id] 일반 본문 클릭은 지연 reveal scroll을 restore loop로 되돌리지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const targetLabel = "plain body click delayed reveal target"
+    const paragraphs = Array.from({ length: 78 }, (_, index) =>
+      index === 46
+        ? `${targetLabel} ${index + 1}. 일반 본문 클릭은 focus reveal scroll을 장시간 restore loop로 되돌리면 안 됩니다.`
+        : `plain delayed reveal paragraph ${index + 1}. 일반 본문 클릭 flicker 회귀를 확인합니다.`
+    )
+    const content = paragraphs.join("\n\n")
+    const contentHtml = paragraphs.map((paragraph) => `<p>${paragraph}</p>`).join("")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/990", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 990,
+          version: 3,
+          title: "일반 본문 클릭 delayed reveal 회귀 글",
+          content,
+          contentHtml,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/990")
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+      "일반 본문 클릭 delayed reveal 회귀 글"
+    )
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expectEditorToContainLoadedText(editor, targetLabel)
+
+    const targetParagraph = editor.locator("p", { hasText: targetLabel }).first()
+    await targetParagraph.scrollIntoViewIfNeeded()
+    const targetBox = await expectVisibleBox(targetParagraph, "plain delayed reveal target metrics are missing")
+    const beforeGeometry = await page.evaluate((label) => {
+      const paragraph =
+        Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] p")).find(
+          (element) => element.textContent?.includes(label)
+        ) ?? null
+      if (!paragraph) return null
+      const rect = paragraph.getBoundingClientRect()
+      return {
+        scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+        paragraphTop: rect.top,
+        visible: rect.bottom > 0 && rect.top < window.innerHeight,
+      }
+    }, targetLabel)
+    if (!beforeGeometry) {
+      throw new Error("plain delayed reveal geometry is missing before click")
+    }
+    expect(beforeGeometry.visible).toBe(true)
+
+    await page.evaluate(
+      ({ label, beforeScrollTop }) => {
+        const win = window as Window & {
+          __plainBodyClickScrollCalls?: Array<{ targetY: number; elapsedMs: number }>
+          __restorePlainBodyClickScrollTo?: () => void
+        }
+        const root = document.querySelector<HTMLElement>("[data-testid='block-editor-prosemirror']")
+        const originalScrollTo = window.scrollTo.bind(window)
+        const startedAt = performance.now()
+        win.__plainBodyClickScrollCalls = []
+        win.__restorePlainBodyClickScrollTo = () => {
+          window.scrollTo = originalScrollTo
+        }
+        window.scrollTo = ((xOrOptions?: number | ScrollToOptions, y?: number) => {
+          const targetY =
+            typeof xOrOptions === "object"
+              ? Number(xOrOptions.top ?? window.scrollY)
+              : Number(y ?? window.scrollY)
+          win.__plainBodyClickScrollCalls?.push({
+            targetY,
+            elapsedMs: performance.now() - startedAt,
+          })
+          return originalScrollTo(xOrOptions as never, y as never)
+        }) as typeof window.scrollTo
+        root?.addEventListener(
+          "pointerdown",
+          (event) => {
+            if (!(event.target instanceof Element)) return
+            const paragraph = event.target.closest("p")
+            if (!paragraph?.textContent?.includes(label)) return
+            window.setTimeout(() => {
+              window.scrollTo(0, beforeScrollTop + 96)
+            }, 80)
+          },
+          { capture: true, once: true }
+        )
+      },
+      { label: targetLabel, beforeScrollTop: beforeGeometry.scrollTop }
+    )
+
+    await page.mouse.click(
+      targetBox.x + Math.min(targetBox.width / 2, 260),
+      targetBox.y + Math.min(targetBox.height / 2, 18)
+    )
+    await page.waitForTimeout(360)
+
+    const afterGeometry = await page.evaluate(() => {
+      const win = window as Window & {
+        __plainBodyClickScrollCalls?: Array<{ targetY: number; elapsedMs: number }>
+        __restorePlainBodyClickScrollTo?: () => void
+      }
+      const scrollCalls = win.__plainBodyClickScrollCalls ?? []
+      win.__restorePlainBodyClickScrollTo?.()
+      return {
+        scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+        scrollCalls,
+      }
+    })
+    const restoreCalls = afterGeometry.scrollCalls.filter(
+      (call) => call.elapsedMs > 90 && Math.abs(call.targetY - beforeGeometry.scrollTop) <= 4
+    )
+    expect(afterGeometry.scrollTop).toBeGreaterThan(beforeGeometry.scrollTop + 60)
+    expect(restoreCalls).toHaveLength(0)
+  })
+})

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -140,6 +140,8 @@ let preserveNextEditorPointerAfterTable = false
 
 const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES = 72
 const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS = 1_120
+const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES = 4
+const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS = 64
 const EDITOR_POINTER_SCROLL_PRESERVE_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
 const EDITOR_POINTER_SCROLL_CONTROL_SELECTOR =
   "button, input, textarea, select, summary, [role='button'], [contenteditable='false']"
@@ -156,24 +158,45 @@ const EDITOR_POINTER_SCROLL_RICH_BLOCK_SELECTOR = [
   ".aq-mermaid-stage",
 ].join(", ")
 
-export const preserveWindowScrollForEditorPointerFocus = (target: EventTarget | null, tableSelectionActive: boolean) => {
+export const preserveWindowScrollForEditorPointerFocus = (
+  target: EventTarget | null,
+  tableSelectionActive: boolean,
+  blockSelectionActive = false
+) => {
   const targetElement = target instanceof Element ? target : target instanceof Node ? target.parentElement : null
   const tablePointerTarget = Boolean(targetElement?.closest(".aq-table-shell, .tableWrapper, table"))
   const editorPointerTarget = Boolean(targetElement?.closest(EDITOR_POINTER_SCROLL_PRESERVE_SELECTOR))
   const editorControlTarget = Boolean(targetElement?.closest(EDITOR_POINTER_SCROLL_CONTROL_SELECTOR))
   const editorRichBlockTarget = Boolean(targetElement?.closest(EDITOR_POINTER_SCROLL_RICH_BLOCK_SELECTOR))
-  const shouldPreserveEditorPointer = editorPointerTarget && (editorRichBlockTarget || !editorControlTarget)
+  const shouldPreserveRichEditorPointer = editorPointerTarget && editorRichBlockTarget
+  const shouldPreserveBlockSelectionPointer = editorPointerTarget && blockSelectionActive && !editorControlTarget
+  const shouldPreserveGeneralEditorPointer =
+    editorPointerTarget && !editorRichBlockTarget && !editorControlTarget && !blockSelectionActive
   const shouldPreserveFollowUp = !tablePointerTarget && preserveNextEditorPointerAfterTable
   if (tablePointerTarget) {
     preserveNextEditorPointerAfterTable = true
   } else if (shouldPreserveFollowUp) {
     preserveNextEditorPointerAfterTable = false
   }
-  if (shouldPreserveEditorPointer || tablePointerTarget || tableSelectionActive || shouldPreserveFollowUp) {
+  if (
+    shouldPreserveRichEditorPointer ||
+    shouldPreserveBlockSelectionPointer ||
+    tablePointerTarget ||
+    tableSelectionActive ||
+    shouldPreserveFollowUp
+  ) {
     preserveWindowScrollAcrossFrames(
       EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES,
       4,
       EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS
+    )
+    return
+  }
+  if (shouldPreserveGeneralEditorPointer) {
+    preserveWindowScrollAcrossFrames(
+      EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES,
+      4,
+      EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS
     )
   }
 }

--- a/front/src/components/editor/useBlockEditorEngineBlockSelectionUi.ts
+++ b/front/src/components/editor/useBlockEditorEngineBlockSelectionUi.ts
@@ -473,7 +473,15 @@ export const useBlockEditorEngineBlockSelectionUi = ({
         findTopLevelBlockIndexFromTarget(event.target) ??
         findTopLevelBlockIndexByClientPosition(event.clientX, event.clientY)
       const currentEditor = editorRef.current ?? editor
-      if (currentEditor) preserveWindowScrollForEditorPointerFocus(event.target, isTableSelectionActive(currentEditor))
+      if (currentEditor) {
+        preserveWindowScrollForEditorPointerFocus(
+          event.target,
+          isTableSelectionActive(currentEditor),
+          selectedBlockNodeIndex !== null ||
+            selectedBlockNodeIndexRef.current !== null ||
+            keyboardBlockSelectionStickyRef.current
+        )
+      }
       if (
         currentEditor &&
         isOuterListItemSelectionGesture(event, targetListItemContext) &&
@@ -543,6 +551,7 @@ export const useBlockEditorEngineBlockSelectionUi = ({
       keyboardBlockSelectionStickyRef,
       promoteTopLevelBlockSelection,
       selectedBlockNodeIndex,
+      selectedBlockNodeIndexRef,
       setClickedBlockIndex,
       setSelectedBlockNodeIndex,
       setSelectedListItemContext,


### PR DESCRIPTION
## 관련 이슈

close #453

## 작업 배경

- `/editor/[id]` 글 수정 화면에서 일반 본문 클릭까지 1.12초 scroll restore loop가 걸려 화면이 깜빡이거나 순간 이동할 수 있던 회귀를 복구합니다.
- 일반 본문은 짧은 immediate stale-selection 보호만 유지하고, code/table/Mermaid 같은 rich block에는 기존 장시간 지연 focus reveal 보호를 유지합니다.

## 작업 내용

- editor pointer scroll preserve 조건을 일반 본문, 기존 block selection, rich block/table 경로로 분리했습니다.
- 일반 본문 클릭의 delayed reveal scroll이 restore loop로 되돌아가지 않는 E2E 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - RED: `yarn --cwd front playwright test e2e/editor-authoring-route-body-click-flicker.spec.ts --workers=1` 실패 확인
  - GREEN: `yarn --cwd front playwright test e2e/editor-authoring-route-body-click-flicker.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-body-click-flicker.spec.ts e2e/editor-authoring-route-scroll-selection.spec.ts e2e/editor-authoring-route-rich-focus.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring` (89 passed)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: scroll preserve window 조건을 분리했기 때문에 editor focus/selection edge case가 영향을 받을 수 있습니다. 관련 body/table/rich block authoring 회귀를 함께 통과시켰습니다.
- 롤백 방법: 이 PR의 단일 커밋 `bbbbdfc5`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
