### PR TITLE
[Chore] CodeRabbit PR 리뷰 설정

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: ko-KR
+tone_instructions: "간결하고 직접적으로 작성하되, 차단급 문제와 개선 제안을 명확히 구분한다."
+enable_free_tier: true
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  review_details: true
+  commit_status: true
+  fail_commit_status: false
+  collapse_walkthrough: true
+  changed_files_summary: true
+  sequence_diagrams: false
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: false
+  auto_assign_reviewers: false
+  in_progress_fortune: false
+  poem: false
+  enable_prompt_for_ai_agents: false
+  abort_on_close: true
+
+  path_filters:
+    - "!**/node_modules/**"
+    - "!**/.next/**"
+    - "!**/dist/**"
+    - "!**/build/**"
+    - "!**/coverage/**"
+    - "!**/test-results/**"
+    - "!**/playwright-report/**"
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 5
+    ignore_title_keywords:
+      - "[WIP]"
+      - "WIP:"
+    drafts: false
+    ignore_usernames:
+      - "dependabot[bot]"
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
+
+  path_instructions:
+    - path: "front/**"
+      instructions: |
+        React/Next.js 변경은 사용자에게 보이는 회귀, hydration 불일치, bundle-size 증가, 접근성, 모바일 레이아웃 깨짐, editor/content rendering 회귀를 우선 검토한다.
+        단순 취향성 스타일 변경이나 사소한 네이밍 지적은 실제 유지보수 리스크가 있을 때만 남긴다.
+    - path: "back/**"
+      instructions: |
+        Kotlin/Spring 변경은 API 계약, 트랜잭션 경계, 인증/인가, N+1 쿼리, 동시성, 마이그레이션 호환성, 테스트 누락을 우선 검토한다.
+        ktlint나 포맷팅처럼 자동 도구가 잡는 문제는 동작 리스크가 없으면 낮은 우선순위로 다룬다.
+    - path: ".github/**"
+      instructions: |
+        GitHub Actions 변경은 권한 최소화, secret 노출, pull_request_target 안전성, cache key 안정성, required check drift, 배포 조건 누락을 우선 검토한다.
+    - path: "deploy/**"
+      instructions: |
+        배포 변경은 rollback 가능성, secret/env drift, health check, live verification, 홈서버 배포 경로와 main merge 후 자동 배포 계약을 우선 검토한다.
+    - path: "tools/**"
+      instructions: |
+        로컬/CI guard 스크립트는 실패 시그니처가 명확한지, macOS/Linux 양쪽에서 실행 가능한지, destructive command를 안전하게 막는지 우선 검토한다.


### PR DESCRIPTION
## 관련 이슈

close #457

## 작업 배경

- public OSS repository 기준으로 CodeRabbit 자동 PR 리뷰 설정을 추가합니다.
- GitHub App 설치는 repository 관리자 권한이 필요한 외부 설정이지만, 이 PR에서 CodeRabbit이 설정 파일을 읽고 리뷰를 시작한 것을 확인했습니다.

## 작업 내용

- repository root에 .coderabbit.yaml을 추가했습니다.
- 자동 리뷰와 incremental review를 켜고 draft PR, WIP 제목, dependabot 작성 PR은 제외했습니다.
- 리뷰 기준을 버그, 보안, 회귀, 테스트 누락, 유지보수성 중심으로 제한했습니다.
- 자동 코드 생성류 finishing touches는 꺼서 PR 리뷰 목적에 집중하도록 했습니다.
- front/back/.github/deploy/tools 경로별 리뷰 지침을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `ruby -e 'require "yaml"; YAML.load_file(".coderabbit.yaml"); puts "ok"'`
  - `git diff --cached --check`
  - `tools/guards/check-forbidden-tracked-files.sh --staged`
  - PR #459에서 CodeRabbit status/comment 생성 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: CodeRabbit GitHub App의 repository access가 해제되면 설정 파일만으로는 리뷰가 실행되지 않습니다.
- 롤백 방법: .coderabbit.yaml을 제거하거나 CodeRabbit GitHub App의 repository access를 해제합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
