### PR TITLE
[Fix] 글작성/수정 선택 버벅임 및 에러 복구

### DIFF
--- a/front/e2e/editor-authoring-selection-drag.spec.ts
+++ b/front/e2e/editor-authoring-selection-drag.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test, type Locator, type Page } from "@playwright/test"
+import {
+  expectEditorToContainLoadedText,
+  getWordDragPoints,
+} from "./helpers/editorAuthoringFlow"
+
+const adminMember = {
+  id: 1,
+  username: "qa-admin",
+  nickname: "aquila",
+  isAdmin: true,
+}
+
+const isLocalResourceConsoleNoise = (text: string) =>
+  text.startsWith("Failed to load resource:") ||
+  text.includes("/_vercel/speed-insights/script.js") ||
+  text.includes("/_vercel/insights/script.js")
+
+const dragSelectWord = async (page: Page, editable: Locator, word: string) => {
+  await editable.scrollIntoViewIfNeeded()
+  const points = await getWordDragPoints(editable, word)
+
+  await page.mouse.move(points.startX, points.startY)
+  await page.mouse.down()
+  await page.mouse.move(points.endX, points.endY, { steps: 8 })
+  await page.mouse.up()
+
+  try {
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const selectionText = window.getSelection()?.toString() ?? ""
+            return selectionText.replace(/\s+/g, " ").trim()
+          }),
+        { timeout: 2_000 }
+      )
+      .toContain(word)
+  } catch {
+    const diagnostics = await page.evaluate(
+      ({ startX, startY, endX, endY }) => {
+        const describeElement = (element: Element | null) => {
+          if (!element) return null
+          return {
+            tagName: element.tagName.toLowerCase(),
+            className: element.getAttribute("class"),
+            testId: element.getAttribute("data-testid"),
+            contentEditable: (element as HTMLElement).contentEditable,
+            text: (element.textContent || "").replace(/\s+/g, " ").trim().slice(0, 120),
+          }
+        }
+        const selection = window.getSelection()
+        const activeElement = document.activeElement
+        const codeContent = document.querySelector<HTMLElement>(".aq-code-editor-content")
+        return {
+          activeElement: describeElement(activeElement instanceof Element ? activeElement : null),
+          anchorElement: describeElement(
+            selection?.anchorNode instanceof Element
+              ? selection.anchorNode
+              : selection?.anchorNode?.parentElement ?? null
+          ),
+          focusElement: describeElement(
+            selection?.focusNode instanceof Element
+              ? selection.focusNode
+              : selection?.focusNode?.parentElement ?? null
+          ),
+          selectionRangeCount: selection?.rangeCount ?? 0,
+          selectionText: selection?.toString() ?? "",
+          startElement: describeElement(document.elementFromPoint(startX, startY)),
+          endElement: describeElement(document.elementFromPoint(endX, endY)),
+          codeContent: describeElement(codeContent),
+          codeContentStyle: codeContent
+            ? {
+                userSelect: window.getComputedStyle(codeContent).userSelect,
+                pointerEvents: window.getComputedStyle(codeContent).pointerEvents,
+                color: window.getComputedStyle(codeContent).color,
+                webkitTextFillColor: window.getComputedStyle(codeContent).webkitTextFillColor,
+              }
+            : null,
+        }
+      },
+      points
+    )
+    throw new Error(`drag selection did not include "${word}": ${JSON.stringify(diagnostics)}`)
+  }
+}
+
+test.describe("editor authoring route text selection drag", () => {
+  test("실제 /editor/[id] 텍스트 드래그 선택은 code/table/body에서 에러 없이 유지된다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const runtimeErrors: string[] = []
+    const bodyLabel = "본문드래그선택대상"
+    const codeLabel = "코드드래그선택대상"
+    const tableLabel = "테이블드래그선택대상"
+    const codeMarkdown = ["```ts", `const marker = "${codeLabel}";`, "console.log(marker);", "```"].join("\n")
+    const tableMarkdown = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[180,220]} -->',
+      "| 구분 | 값 |",
+      "| --- | --- |",
+      `| inline code | \`${tableLabel}\` |`,
+    ].join("\n")
+    const content = [
+      "드래그 선택 회귀 재현용 글입니다.",
+      `일반 본문 ${bodyLabel} 문장을 마우스로 선택해도 에러가 없어야 합니다.`,
+      codeMarkdown,
+      tableMarkdown,
+    ].join("\n\n")
+
+    page.on("pageerror", (error) => {
+      runtimeErrors.push(error.message)
+    })
+    page.on("console", (message) => {
+      if (message.type() === "error" && !isLocalResourceConsoleNoise(message.text())) {
+        runtimeErrors.push(message.text())
+      }
+    })
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/989", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 989,
+          version: 4,
+          title: "드래그 선택 버벅임 회귀 글",
+          content,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/989")
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+      "드래그 선택 버벅임 회귀 글"
+    )
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expectEditorToContainLoadedText(editor, tableLabel)
+
+    await dragSelectWord(page, editor.locator("p", { hasText: bodyLabel }).first(), bodyLabel)
+    await dragSelectWord(page, editor.locator(".aq-code-editor-content", { hasText: codeLabel }).first(), codeLabel)
+    await dragSelectWord(page, editor.locator("table th, table td", { hasText: tableLabel }).first(), tableLabel)
+
+    await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
+    expect(runtimeErrors).toEqual([])
+  })
+})

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -113,10 +113,14 @@ export const preserveWindowScrollAcrossFrames = (frames = 6, tolerance = 4, minD
   }
   const cleanup = () => {
     window.removeEventListener("wheel", cancel, true)
+    window.removeEventListener("pointermove", cancel, true)
+    window.removeEventListener("mousemove", cancel, true)
     window.removeEventListener("touchmove", cancel, true)
     window.removeEventListener("keydown", cancel, true)
   }
   window.addEventListener("wheel", cancel, { capture: true, passive: true, once: true })
+  window.addEventListener("pointermove", cancel, { capture: true, passive: true, once: true })
+  window.addEventListener("mousemove", cancel, { capture: true, passive: true, once: true })
   window.addEventListener("touchmove", cancel, { capture: true, passive: true, once: true })
   window.addEventListener("keydown", cancel, { capture: true, once: true })
   const restore = () => {

--- a/front/src/components/editor/codeBlockNodeViewStyles.tsx
+++ b/front/src/components/editor/codeBlockNodeViewStyles.tsx
@@ -291,8 +291,11 @@ export const CodeBlockEditorSurface = styled.div`
     z-index: 1;
     background: transparent;
     color: transparent !important;
+    cursor: text;
     caret-color: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray12 : "#f8fafc")};
     text-shadow: none;
+    user-select: text;
+    -webkit-user-select: text;
     -webkit-text-fill-color: transparent !important;
   }
 
@@ -311,6 +314,8 @@ export const CodeBlockEditorSurface = styled.div`
     overflow-wrap: normal;
     word-break: normal;
     color: transparent !important;
+    user-select: text;
+    -webkit-user-select: text;
     -webkit-text-fill-color: transparent !important;
   }
 

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -13,6 +13,8 @@ import {
 
 type SetState<T> = Dispatch<SetStateAction<T>>
 
+const CODE_BLOCK_EDITOR_CONTENT_SELECTOR = ".aq-code-editor-content"
+
 type UseBlockEditorEngineSelectionBubbleEffectsArgs = {
   bubbleToolbarHoveredRef: RefObject<boolean>
   cancelBubbleHide: () => void
@@ -75,7 +77,18 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
             ? range.commonAncestorContainer
             : range?.commonAncestorContainer?.parentElement ?? null
 
-        if (range && domSelection && !domSelection.isCollapsed && commonAncestor && activeEditor.view.dom.contains(commonAncestor)) {
+        const isCodeBlockNodeViewSelection = Boolean(
+          commonAncestor?.closest(CODE_BLOCK_EDITOR_CONTENT_SELECTOR)
+        )
+
+        if (
+          range &&
+          domSelection &&
+          !domSelection.isCollapsed &&
+          commonAncestor &&
+          activeEditor.view.dom.contains(commonAncestor) &&
+          !isCodeBlockNodeViewSelection
+        ) {
           const syncPmSelectionFromRange = (from: number, to: number) => {
             if (!Number.isFinite(from) || !Number.isFinite(to) || from === to) return false
             const nextSelection = TextSelection.create(


### PR DESCRIPTION
## 관련 이슈

close #458

## 작업 배경

- 글작성/수정 화면에서 본문, 코드블럭, 테이블 셀 내부 코드를 드래그 선택할 때 viewport restore loop가 선택 좌표를 되돌리던 문제를 복구했습니다.
- code block editable layer의 text selection surface 계약을 명시하고, 실제 `/editor/[id]` 선택 드래그 E2E로 회귀를 고정했습니다.

## 작업 내용

- rich block pointer focus scroll preserve를 pointer/mouse move에서 즉시 취소해 drag selection 중 stale scroll restore가 돌지 않게 했습니다.
- 코드블럭 hidden editable layer에 cursor/user-select text 계약을 명시했습니다.
- 코드블럭 NodeView 내부 native selection은 text bubble용 DOM-to-PM fallback sync 대상에서 제외했습니다.
- `/editor/[id]`에서 body -> code -> table 순서의 실제 마우스 드래그 선택 회귀 spec을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-selection-drag.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-flow.spec.ts e2e/editor-studio-state.spec.ts e2e/slash-menu-interaction.spec.ts --workers=1` (2회 연속 통과)
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front lint`
  - in-app browser QA route 로드 확인. 해당 Browser CUA drag API는 body/code/table 모두 native selection을 만들지 못해 선택 판정은 Playwright E2E 결과를 기준으로 삼았습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: rich block 클릭 시 viewport 보정이 drag 시작과 구분되어야 합니다. 기존 rich block click/scroll 회귀를 포함한 authoring 전체 회귀를 통과했습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 이전 selection/scroll 보정 동작으로 되돌아갑니다.
- 배포 경로: 작업 브랜치 -> PR to `main` -> `main` merge -> 홈서버 자동 배포 workflow.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
