### PR TITLE
[Fix] 글수정 선택 시 화면 깜빡임 및 위치 점프 복구

### DIFF
--- a/front/e2e/editor-authoring-route-body-click-flicker.spec.ts
+++ b/front/e2e/editor-authoring-route-body-click-flicker.spec.ts
@@ -2,9 +2,159 @@ import { expect, test } from "@playwright/test"
 import {
   expectEditorToContainLoadedText,
   expectVisibleBox,
+  getWordDragPoints,
 } from "./helpers/editorAuthoringFlow"
 
 test.describe("editor authoring route body click flicker", () => {
+  test("실제 /editor/[id] 본문 선택 드래그는 빠른 focus reveal 이후 이전 scrollTop으로 되돌아가지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const targetLabel = "본문선택스크롤점프대상"
+    const paragraphs = Array.from({ length: 82 }, (_, index) =>
+      index === 51
+        ? `본문 선택 회귀 ${targetLabel} ${index + 1}. 드래그 선택 중 이전 scrollTop으로 되돌아가면 안 됩니다.`
+        : `body selection scroll jump paragraph ${index + 1}. 글수정 본문 선택 위치 점프 회귀를 확인합니다.`
+    )
+    const content = paragraphs.join("\n\n")
+    const contentHtml = paragraphs.map((paragraph) => `<p>${paragraph}</p>`).join("")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/991", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 991,
+          version: 5,
+          title: "본문 선택 scroll jump 회귀 글",
+          content,
+          contentHtml,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/991")
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+      "본문 선택 scroll jump 회귀 글"
+    )
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expectEditorToContainLoadedText(editor, targetLabel)
+
+    const targetParagraph = editor.locator("p", { hasText: targetLabel }).first()
+    await targetParagraph.scrollIntoViewIfNeeded()
+    const dragPoints = await getWordDragPoints(targetParagraph, targetLabel)
+    const beforeGeometry = await page.evaluate((label) => {
+      const paragraph =
+        Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] p")).find(
+          (element) => element.textContent?.includes(label)
+        ) ?? null
+      if (!paragraph) return null
+      const rect = paragraph.getBoundingClientRect()
+      return {
+        scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+        paragraphTop: rect.top,
+        visible: rect.bottom > 0 && rect.top < window.innerHeight,
+      }
+    }, targetLabel)
+    if (!beforeGeometry) {
+      throw new Error("body selection scroll jump geometry is missing before drag")
+    }
+    expect(beforeGeometry.visible).toBe(true)
+
+    await page.evaluate(
+      ({ label, beforeScrollTop }) => {
+        const win = window as Window & {
+          __bodySelectionScrollCalls?: Array<{ targetY: number; elapsedMs: number }>
+          __restoreBodySelectionScrollTo?: () => void
+        }
+        const root = document.querySelector<HTMLElement>("[data-testid='block-editor-prosemirror']")
+        const originalScrollTo = window.scrollTo.bind(window)
+        const startedAt = performance.now()
+        win.__bodySelectionScrollCalls = []
+        win.__restoreBodySelectionScrollTo = () => {
+          window.scrollTo = originalScrollTo
+        }
+        window.scrollTo = ((xOrOptions?: number | ScrollToOptions, y?: number) => {
+          const targetY =
+            typeof xOrOptions === "object"
+              ? Number(xOrOptions.top ?? window.scrollY)
+              : Number(y ?? window.scrollY)
+          win.__bodySelectionScrollCalls?.push({
+            targetY,
+            elapsedMs: performance.now() - startedAt,
+          })
+          return originalScrollTo(xOrOptions as never, y as never)
+        }) as typeof window.scrollTo
+        root?.addEventListener(
+          "pointerdown",
+          (event) => {
+            if (!(event.target instanceof Element)) return
+            const paragraph = event.target.closest("p")
+            if (!paragraph?.textContent?.includes(label)) return
+            window.setTimeout(() => {
+              const textNode =
+                Array.from(paragraph.childNodes).find((node) => node.nodeType === Node.TEXT_NODE) ?? null
+              if (textNode?.textContent) {
+                const start = textNode.textContent.indexOf(label)
+                if (start >= 0) {
+                  const range = document.createRange()
+                  range.setStart(textNode, start)
+                  range.setEnd(textNode, start + label.length)
+                  const selection = window.getSelection()
+                  selection?.removeAllRanges()
+                  selection?.addRange(range)
+                  document.dispatchEvent(new Event("selectionchange", { bubbles: true }))
+                }
+              }
+              window.scrollTo(0, beforeScrollTop + 96)
+            }, 24)
+          },
+          { capture: true, once: true }
+        )
+      },
+      { label: targetLabel, beforeScrollTop: beforeGeometry.scrollTop }
+    )
+
+    await page.mouse.move(dragPoints.startX, dragPoints.startY)
+    await page.mouse.down()
+    await page.waitForTimeout(72)
+    await page.mouse.move(dragPoints.endX, dragPoints.endY, { steps: 8 })
+    await page.mouse.up()
+    await page.waitForTimeout(240)
+
+    const afterGeometry = await page.evaluate(() => {
+      const win = window as Window & {
+        __bodySelectionScrollCalls?: Array<{ targetY: number; elapsedMs: number }>
+        __restoreBodySelectionScrollTo?: () => void
+      }
+      const scrollCalls = win.__bodySelectionScrollCalls ?? []
+      win.__restoreBodySelectionScrollTo?.()
+      return {
+        scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+        scrollCalls,
+      }
+    })
+    const staleRestoreCalls = afterGeometry.scrollCalls.filter(
+      (call) => call.elapsedMs > 24 && Math.abs(call.targetY - beforeGeometry.scrollTop) <= 4
+    )
+
+    expect(afterGeometry.scrollTop).toBeGreaterThan(beforeGeometry.scrollTop + 60)
+    expect(staleRestoreCalls).toHaveLength(0)
+  })
+
   test("실제 /editor/[id] 일반 본문 클릭은 지연 reveal scroll을 restore loop로 되돌리지 않는다", async ({
     page,
   }) => {

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -99,7 +99,12 @@ export const resolveBlockHandleRailLayoutForSurface = (
   }
 }
 
-export const preserveWindowScrollAcrossFrames = (frames = 6, tolerance = 4, minDurationMs = 0) => {
+export const preserveWindowScrollAcrossFrames = (
+  frames = 6,
+  tolerance = 4,
+  minDurationMs = 0,
+  cancelOnTextSelectionChange = false
+) => {
   if (typeof window === "undefined" || typeof document === "undefined") return
   const scrollingElement = document.scrollingElement
   const startX = window.scrollX
@@ -111,18 +116,26 @@ export const preserveWindowScrollAcrossFrames = (frames = 6, tolerance = 4, minD
     cancelled = true
     cleanup()
   }
+  const cancelForTextSelection = () => {
+    if (!cancelOnTextSelectionChange) return
+    cancel()
+  }
   const cleanup = () => {
     window.removeEventListener("wheel", cancel, true)
     window.removeEventListener("pointermove", cancel, true)
     window.removeEventListener("mousemove", cancel, true)
     window.removeEventListener("touchmove", cancel, true)
     window.removeEventListener("keydown", cancel, true)
+    document.removeEventListener("selectionchange", cancelForTextSelection, true)
   }
   window.addEventListener("wheel", cancel, { capture: true, passive: true, once: true })
   window.addEventListener("pointermove", cancel, { capture: true, passive: true, once: true })
   window.addEventListener("mousemove", cancel, { capture: true, passive: true, once: true })
   window.addEventListener("touchmove", cancel, { capture: true, passive: true, once: true })
   window.addEventListener("keydown", cancel, { capture: true, once: true })
+  if (cancelOnTextSelectionChange) {
+    document.addEventListener("selectionchange", cancelForTextSelection, true)
+  }
   const restore = () => {
     if (cancelled) return
     const currentY = scrollingElement?.scrollTop ?? window.scrollY
@@ -200,7 +213,8 @@ export const preserveWindowScrollForEditorPointerFocus = (
     preserveWindowScrollAcrossFrames(
       EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES,
       4,
-      EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS
+      EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS,
+      true
     )
   }
 }


### PR DESCRIPTION
## 관련 이슈

close #461

## 작업 배경

- 글수정 페이지에서 본문 텍스트 선택 중 focus reveal scroll이 이전 위치로 되돌아가 화면이 깜빡이던 회귀를 복구했습니다.
- 실제 `/editor/[id]` route에서 본문, 코드블럭, 테이블 내부 텍스트 드래그 선택이 유지되는지 E2E로 고정했습니다.

## 작업 내용

- 일반 본문 pointer focus용 scroll-preserve를 실제 텍스트 selection 변경 시 취소하도록 제한했습니다.
- `/editor/[id]` 본문 선택 중 빠른 focus reveal 이후 stale scroll restore가 발생하지 않는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-body-click-flicker.spec.ts e2e/editor-authoring-selection-drag.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-body-click-flicker.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-route-rich-focus.spec.ts e2e/editor-authoring-route-scroll-selection.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-table-structure.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-table-resize-guide.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front lint`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 일반 본문 클릭 보호의 scroll-preserve 취소 시점이 selectionchange에 묶여 있어, 본문 클릭만 수행하는 경로는 기존 회귀 테스트로 보호합니다.
- 롤백 방법: 이 PR의 단일 커밋 `fix(editor): selection scroll 점프 복구`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
