### PR TITLE
[Fix] 글수정 rich block 선택 범위 복구

### DIFF
--- a/front/e2e/editor-authoring-selection-drag.spec.ts
+++ b/front/e2e/editor-authoring-selection-drag.spec.ts
@@ -88,23 +88,19 @@ const dragSelectWord = async (page: Page, editable: Locator, word: string) => {
 const expectSelectionScopedToWord = async (page: Page, word: string, unrelatedWords: string[]) => {
   await expect
     .poll(
-      () =>
-        page.evaluate(() => {
-          const selectionText = window.getSelection()?.toString() ?? ""
-          return selectionText.replace(/\s+/g, " ").trim()
-        }),
+      async () => {
+        const selectionText = await page.evaluate(() => {
+          const text = window.getSelection()?.toString() ?? ""
+          return text.replace(/\s+/g, " ").trim()
+        })
+        return (
+          selectionText.includes(word) &&
+          unrelatedWords.every((unrelatedWord) => !selectionText.includes(unrelatedWord))
+        )
+      },
       { timeout: 2_000 }
     )
-    .toContain(word)
-
-  const selectionText = await page.evaluate(() => {
-    const text = window.getSelection()?.toString() ?? ""
-    return text.replace(/\s+/g, " ").trim()
-  })
-
-  for (const unrelatedWord of unrelatedWords) {
-    expect(selectionText).not.toContain(unrelatedWord)
-  }
+    .toBe(true)
 }
 
 const expectCodeHighlightLayerAligned = async (page: Page, word: string) => {

--- a/front/e2e/editor-authoring-selection-drag.spec.ts
+++ b/front/e2e/editor-authoring-selection-drag.spec.ts
@@ -192,8 +192,12 @@ test.describe("editor authoring route text selection drag", () => {
     const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
     await expectEditorToContainLoadedText(editor, tableLabel)
 
-    await dragSelectWord(page, editor.locator("p", { hasText: bodyLabel }).first(), bodyLabel)
     await expectCodeHighlightLayerAligned(page, codeLabel)
+    await page.setViewportSize({ width: 390, height: 720 })
+    await expectCodeHighlightLayerAligned(page, codeLabel)
+    await page.setViewportSize({ width: 980, height: 720 })
+
+    await dragSelectWord(page, editor.locator("p", { hasText: bodyLabel }).first(), bodyLabel)
     await dragSelectWord(page, editor.locator(".aq-code-editor-content", { hasText: codeLabel }).first(), codeLabel)
     await expectSelectionScopedToWord(page, codeLabel, [bodyLabel, tableLabel])
     await dragSelectWord(page, editor.locator("table th, table td", { hasText: tableLabel }).first(), tableLabel)

--- a/front/e2e/editor-authoring-selection-drag.spec.ts
+++ b/front/e2e/editor-authoring-selection-drag.spec.ts
@@ -85,6 +85,54 @@ const dragSelectWord = async (page: Page, editable: Locator, word: string) => {
   }
 }
 
+const expectSelectionScopedToWord = async (page: Page, word: string, unrelatedWords: string[]) => {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const selectionText = window.getSelection()?.toString() ?? ""
+          return selectionText.replace(/\s+/g, " ").trim()
+        }),
+      { timeout: 2_000 }
+    )
+    .toContain(word)
+
+  const selectionText = await page.evaluate(() => {
+    const text = window.getSelection()?.toString() ?? ""
+    return text.replace(/\s+/g, " ").trim()
+  })
+
+  for (const unrelatedWord of unrelatedWords) {
+    expect(selectionText).not.toContain(unrelatedWord)
+  }
+}
+
+const expectCodeHighlightLayerAligned = async (page: Page, word: string) => {
+  const metrics = await page.evaluate((targetWord) => {
+    const content = Array.from(document.querySelectorAll<HTMLElement>(".aq-code-editor-content")).find((element) =>
+      element.textContent?.includes(targetWord)
+    )
+    const shell = content?.closest(".aq-code-shell")
+    const highlightLine = shell?.querySelector<HTMLElement>(".aq-code-highlight-layer .line")
+    if (!content || !highlightLine) return null
+    const contentStyle = window.getComputedStyle(content)
+    const highlightLineStyle = window.getComputedStyle(highlightLine)
+    return {
+      contentLineHeight: Number.parseFloat(contentStyle.lineHeight || "0"),
+      highlightLineMinHeight: Number.parseFloat(highlightLineStyle.minHeight || "0"),
+    }
+  }, word)
+
+  if (!metrics) {
+    throw new Error(`code highlight metrics are missing for "${word}"`)
+  }
+
+  expect(
+    Math.abs(metrics.contentLineHeight - metrics.highlightLineMinHeight),
+    JSON.stringify(metrics)
+  ).toBeLessThanOrEqual(1)
+}
+
 test.describe("editor authoring route text selection drag", () => {
   test("실제 /editor/[id] 텍스트 드래그 선택은 code/table/body에서 에러 없이 유지된다", async ({
     page,
@@ -145,8 +193,17 @@ test.describe("editor authoring route text selection drag", () => {
     await expectEditorToContainLoadedText(editor, tableLabel)
 
     await dragSelectWord(page, editor.locator("p", { hasText: bodyLabel }).first(), bodyLabel)
+    await expectCodeHighlightLayerAligned(page, codeLabel)
     await dragSelectWord(page, editor.locator(".aq-code-editor-content", { hasText: codeLabel }).first(), codeLabel)
+    await expectSelectionScopedToWord(page, codeLabel, [bodyLabel, tableLabel])
     await dragSelectWord(page, editor.locator("table th, table td", { hasText: tableLabel }).first(), tableLabel)
+    await expectSelectionScopedToWord(page, tableLabel, [bodyLabel, codeLabel])
+
+    const tableCell = editor.locator("table th, table td", { hasText: tableLabel }).first()
+    const tableCellPoints = await getWordDragPoints(tableCell, tableLabel)
+    await page.mouse.click(tableCellPoints.startX, tableCellPoints.startY)
+    await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A")
+    await expectSelectionScopedToWord(page, tableLabel, [bodyLabel, codeLabel])
 
     await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
     expect(runtimeErrors).toEqual([])

--- a/front/src/components/editor/codeBlockNodeViewStyles.tsx
+++ b/front/src/components/editor/codeBlockNodeViewStyles.tsx
@@ -345,6 +345,16 @@ export const CodeBlockEditorSurface = styled.div`
       line-height: 1.54;
       padding: 0.86rem 0.74rem 1.1rem;
     }
+
+    .aq-code-shell .aq-code-highlight-layer,
+    .aq-code-shell .aq-code-highlight-layer code {
+      font-size: 0.86rem;
+      line-height: 1.54;
+    }
+
+    .aq-code-shell .aq-code-highlight-layer .line {
+      min-height: 1.54em;
+    }
   }
 `
 

--- a/front/src/components/editor/codeBlockNodeViewStyles.tsx
+++ b/front/src/components/editor/codeBlockNodeViewStyles.tsx
@@ -222,7 +222,7 @@ export const CodeBlockEditorSurface = styled.div`
 
     .line {
       display: block;
-      min-height: calc(0.88rem * 1.65);
+      min-height: 1.5em;
     }
 
     .token.comment,
@@ -284,6 +284,12 @@ export const CodeBlockEditorSurface = styled.div`
     .token.important {
       color: ${({ theme }) => (theme.scheme === "dark" ? "#bbb529" : "#92400e")};
     }
+  }
+
+  .aq-code-shell .aq-code-highlight-layer,
+  .aq-code-shell .aq-code-highlight-layer code {
+    font-size: 0.85rem;
+    line-height: 1.5;
   }
 
   .aq-code-editor-content {

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -3,7 +3,7 @@ import type { Editor as TiptapEditor } from "@tiptap/core"
 export const isPrimarySelectAllKeyboardEvent = (event: KeyboardEvent) => {
   if (event.defaultPrevented || event.altKey || event.shiftKey) return false
   if (!(event.metaKey || event.ctrlKey)) return false
-  return event.key.toLowerCase() === "a"
+  return event.code === "KeyA" || event.key.toLowerCase() === "a"
 }
 
 const resolveElement = (target: EventTarget | Node | null | undefined) => {

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -1,0 +1,39 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+
+export const isPrimarySelectAllKeyboardEvent = (event: KeyboardEvent) => {
+  if (event.defaultPrevented || event.altKey || event.shiftKey) return false
+  if (!(event.metaKey || event.ctrlKey)) return false
+  return event.key.toLowerCase() === "a"
+}
+
+const resolveElement = (target: EventTarget | Node | null | undefined) => {
+  if (target instanceof Element) return target
+  if (target instanceof Node) return target.parentElement
+  return null
+}
+
+export const selectActiveTableCellText = (
+  editor: TiptapEditor,
+  eventTarget: EventTarget | null
+) => {
+  if (typeof window === "undefined" || typeof document === "undefined") return false
+  const selection = window.getSelection()
+  if (!selection) return false
+
+  const activeElement = resolveElement(document.activeElement)
+  const anchorElement = resolveElement(selection.anchorNode)
+  const targetElement = resolveElement(eventTarget)
+  const cell =
+    anchorElement?.closest("th, td") ??
+    activeElement?.closest("th, td") ??
+    targetElement?.closest("th, td")
+
+  if (!(cell instanceof HTMLElement)) return false
+  if (!editor.view.dom.contains(cell)) return false
+
+  const range = document.createRange()
+  range.selectNodeContents(cell)
+  selection.removeAllRanges()
+  selection.addRange(range)
+  return true
+}

--- a/front/src/components/editor/useBlockEditorEngineSelectionEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionEffects.ts
@@ -18,6 +18,10 @@ import {
 } from "./nestedListItemModel"
 import { isTableSelectionActive } from "./tableStructureModel"
 import {
+  isPrimarySelectAllKeyboardEvent,
+  selectActiveTableCellText,
+} from "./tableTextSelectionModel"
+import {
   type FloatingBubbleState,
 } from "./useFloatingBubbleState"
 import type { BlockEditorSlashMenuState } from "./BlockEditorEngine.layers"
@@ -298,6 +302,19 @@ export const useBlockEditorEngineSelectionEffects = ({
 
     const handleKeyDownCapture = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return
+      if (isPrimarySelectAllKeyboardEvent(event)) {
+        const currentEditor = editorRef.current
+        if (currentEditor && selectActiveTableCellText(currentEditor, event.target)) {
+          event.preventDefault()
+          event.stopPropagation()
+          event.stopImmediatePropagation?.()
+          clearStickyTopLevelBlockSelection()
+          setSelectedBlockNodeIndex(null)
+          syncSelectedBlockNodeSurface(null)
+          setSelectionTick((prev) => prev + 1)
+          return
+        }
+      }
       if (event.key !== "Tab" || event.metaKey || event.ctrlKey || event.altKey) return
       if (slashMenuState) return
 
@@ -364,9 +381,11 @@ export const useBlockEditorEngineSelectionEffects = ({
     findTopLevelBlockIndexFromTarget,
     hoveredBlockIndex,
     promoteTopLevelBlockSelection,
+    setSelectedBlockNodeIndex,
     resolveActiveListItemInteraction,
     setSelectionTick,
     slashMenuState,
+    syncSelectedBlockNodeSurface,
   ])
 
   useBlockEditorEngineSelectionBubbleEffects({


### PR DESCRIPTION
## 관련 이슈

close #463

## 작업 배경

- 글수정 페이지의 rich block 텍스트 선택 회귀를 복구합니다.
- 코드블럭 selection highlight line box를 editable layer와 맞추고, 테이블 셀 내부 Cmd/Ctrl+A가 editor 전체 선택으로 승격되지 않도록 제한합니다.

## 작업 내용

- 코드블럭 Prism highlight layer와 실제 편집 text layer의 font-size/line-height 계약을 맞췄습니다.
- 테이블 셀 내부 Cmd/Ctrl+A를 현재 셀 native text selection으로 처리하는 guard를 추가했습니다.
- `/editor/[id]` E2E에 body/code/table 드래그 선택, 코드 highlight metric, table cell Cmd/Ctrl+A 범위 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-selection-drag.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-code-mermaid.spec.ts e2e/editor-authoring-table-structure.spec.ts e2e/editor-authoring-route-rich-focus.spec.ts e2e/editor-authoring-route-scroll-selection.spec.ts e2e/editor-authoring-route-body-click-flicker.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring` (92/92 통과, 2회 연속)
  - `yarn --cwd front lint`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 테이블 셀 내부 Cmd/Ctrl+A 동작이 셀 단위 native selection으로 고정되어, 기존 editor-wide select-all에 의존하던 단축키 흐름이 달라질 수 있습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 기존 selection keydown 처리와 코드블럭 highlight CSS로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
