### PR TITLE
[Fix] front dependency security alert 정리

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -109,7 +109,9 @@
     "prismjs": "1.30.0",
     "readdirp/picomatch": "2.3.2",
     "rimraf/glob/minimatch": "3.1.5",
+    "qs": "6.15.2",
     "tinyglobby/picomatch": "4.0.4",
+    "uuid": "11.1.1",
     "yaml": "1.10.3"
   },
   "devDependencies": {

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -8822,10 +8822,10 @@ punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-qs@^6.12.3:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.0.tgz#db8fd5d1b1d2d6b5b33adaf87429805f1909e7b3"
-  integrity sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==
+qs@6.15.2, qs@^6.12.3:
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 
@@ -10440,15 +10440,10 @@ utila@~0.4:
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==
 
-uuid@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
-  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
-
-"uuid@^9.0.0 || ^10 || ^11.1.0 || ^12 || ^13 || ^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
-  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
+uuid@11.1.1, uuid@^9.0.0, "uuid@^9.0.0 || ^10 || ^11.1.0 || ^12 || ^13 || ^14.0.0":
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 uvu@^0.5.0:
   version "0.5.6"


### PR DESCRIPTION
## 관련 이슈

close #465

## 작업 배경

- GitHub Security and quality에 열린 Dependabot alert 2건(`uuid`, `qs`)을 patched lock version으로 정리합니다.
- `front/package.json` resolutions로 transitive dependency를 고정하고 `front/yarn.lock`을 `uuid@11.1.1`, `qs@6.15.2`로 갱신했습니다.
- `main` merge 후 Security/Dependabot 재스캔과 자동 CI/CD 배포 경로가 이어집니다.

## 작업 내용

- `uuid` transitive lock entry를 `11.1.1`로 고정했습니다.
- `qs` transitive lock entry를 `6.15.2`로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front install --frozen-lockfile` 2회 통과
  - `yarn --cwd front build` 2회 통과
  - `yarn --cwd front check:bundle-size` 2회 통과
  - `gh api graphql ... vulnerabilityAlerts(states: OPEN)` 확인: PR merge 전 default branch 기준이라 #87/#88은 아직 OPEN
  - `git diff --check` 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: `uuid@11.1.1` resolution이 `@storybook/addon-actions`의 `^9.0.0` 요청과 semver 경고를 냅니다. 빌드와 bundle-size는 같은 조건에서 2회 통과했습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 기존 dependency resolution으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
