### PR TITLE
[Fix] 글수정 rich block 클릭/선택 회귀 복구

### DIFF
--- a/front/e2e/editor-authoring-route-rich-focus.spec.ts
+++ b/front/e2e/editor-authoring-route-rich-focus.spec.ts
@@ -102,6 +102,9 @@ test.describe("editor authoring route rich block focus", () => {
       clickOffset = { x: 40, y: 24 }
     ) => {
       await target.scrollIntoViewIfNeeded()
+      await target.evaluate((element) => {
+        element.scrollIntoView({ block: "center", inline: "nearest" })
+      })
       const targetBox = await expectVisibleBox(target, `${label} metrics are missing before click`)
 
       const beforeGeometry = await page.evaluate(
@@ -256,6 +259,9 @@ test.describe("editor authoring route rich block focus", () => {
     const assertSelectionRevealKeepsViewport = async (target: Locator, label: string) => {
       await selectPreviousBlockAnchor()
       await target.scrollIntoViewIfNeeded()
+      await target.evaluate((element) => {
+        element.scrollIntoView({ block: "center", inline: "nearest" })
+      })
       const beforeGeometry = await target.evaluate((element) => {
         const rect = element.getBoundingClientRect()
         return {
@@ -403,6 +409,9 @@ test.describe("editor authoring route rich block focus", () => {
     ) => {
       await selectPreviousBlockAnchor()
       await target.scrollIntoViewIfNeeded()
+      await target.evaluate((element) => {
+        element.scrollIntoView({ block: "center", inline: "nearest" })
+      })
       const targetBox = await expectVisibleBox(target, `${label} metrics are missing before click`)
       const beforeGeometry = await target.evaluate((element) => {
         const rect = element.getBoundingClientRect()

--- a/front/e2e/editor-authoring-route-rich-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-rich-select-all.spec.ts
@@ -1,0 +1,163 @@
+import { expect, test, type Locator } from "@playwright/test"
+import {
+  expectEditorToContainLoadedText,
+  expectVisibleBox,
+} from "./helpers/editorAuthoringFlow"
+
+const SELECT_ALL_SHORTCUT = process.platform === "darwin" ? "Meta+a" : "Control+a"
+
+test.describe("editor authoring route rich block select all", () => {
+  test("실제 /editor/[id] rich block Cmd/Ctrl+A는 내부 텍스트 선택 중 viewport를 유지한다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const previousSelectionLabel = "select all previous block anchor"
+    const codeLabel = "select all code viewport target"
+    const tableLabel = "Select all table viewport target"
+    const leadParagraphs = Array.from({ length: 54 }, (_, index) =>
+      index === 18
+        ? `${previousSelectionLabel} ${index + 1}. Cmd+A 전에 이전 block selection anchor를 남깁니다.`
+        : `select all lead paragraph ${index + 1}. rich block 내부 선택 중 viewport 유지 회귀를 확인합니다.`
+    )
+    const tableMarkdown = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[180,260]} -->',
+      "| 영역 | 점검 항목 |",
+      "| --- | --- |",
+      `| 테이블 | ${tableLabel} |`,
+      "| 결과 | viewport 유지 |",
+    ].join("\n")
+    const content = [
+      "# rich block select all viewport 재현",
+      ...leadParagraphs,
+      "```ts",
+      `const marker = "${codeLabel}";`,
+      "console.log(marker);",
+      "```",
+      tableMarkdown,
+      "select all trailing paragraph. 내부 선택 이후에도 위치가 유지되어야 합니다.",
+    ].join("\n\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/999", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 999,
+          version: 5,
+          title: "rich block select all viewport 회귀 글",
+          content,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/999")
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+      "rich block select all viewport 회귀 글"
+    )
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expectEditorToContainLoadedText(editor, tableLabel)
+
+    const previousSelectionParagraph = editor.locator("p", { hasText: previousSelectionLabel }).first()
+    const dragHandle = page.getByTestId("block-drag-handle")
+    const selectPreviousBlockAnchor = async () => {
+      await previousSelectionParagraph.scrollIntoViewIfNeeded()
+      const previousSelectionBox = await expectVisibleBox(
+        previousSelectionParagraph,
+        "select all stale selection paragraph metrics are missing"
+      )
+      await page.mouse.move(
+        previousSelectionBox.x + Math.min(previousSelectionBox.width / 2, 260),
+        previousSelectionBox.y + Math.min(previousSelectionBox.height / 2, 18)
+      )
+      await previousSelectionParagraph.hover()
+      await expect(dragHandle).toBeVisible()
+      await dragHandle.click()
+      await expect(page.getByTestId("keyboard-block-selection-overlay")).toBeVisible()
+      return page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+    }
+
+    const assertSelectAllKeepsViewport = async (
+      target: Locator,
+      expectedSelection: string,
+      label: string,
+      clickOffset = { x: 32, y: 20 }
+    ) => {
+      const staleSelectionScrollTop = await selectPreviousBlockAnchor()
+      await target.scrollIntoViewIfNeeded()
+      const targetBox = await expectVisibleBox(target, `${label} metrics are missing before select all`)
+      const beforeGeometry = await target.evaluate((element) => {
+        const rect = element.getBoundingClientRect()
+        return {
+          scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+          targetTop: rect.top,
+          targetBottom: rect.bottom,
+        }
+      })
+      await page.evaluate(
+        ({ staleScrollTop }) => {
+          document.addEventListener(
+            "selectionchange",
+            () => {
+              window.setTimeout(() => {
+                window.scrollTo(0, staleScrollTop)
+              }, 32)
+            },
+            { capture: true, once: true }
+          )
+        },
+        { staleScrollTop: staleSelectionScrollTop }
+      )
+
+      await page.mouse.click(
+        targetBox.x + Math.min(clickOffset.x, Math.max(8, targetBox.width - 8)),
+        targetBox.y + Math.min(clickOffset.y, Math.max(8, targetBox.height - 8))
+      )
+      await page.keyboard.press(SELECT_ALL_SHORTCUT)
+      await page.waitForTimeout(560)
+
+      const afterGeometry = await target.evaluate((element) => {
+        const rect = element.getBoundingClientRect()
+        const selection = window.getSelection()
+        return {
+          selectedText: selection?.toString() ?? "",
+          scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+          targetTop: rect.top,
+          targetBottom: rect.bottom,
+        }
+      })
+
+      expect(afterGeometry.selectedText).toContain(expectedSelection)
+      expect(afterGeometry.selectedText).not.toContain("AquilaLog")
+      expect(afterGeometry.selectedText).not.toContain("select all lead paragraph 1")
+      expect(Math.abs(afterGeometry.scrollTop - beforeGeometry.scrollTop)).toBeLessThanOrEqual(24)
+      expect(Math.abs(afterGeometry.targetTop - beforeGeometry.targetTop)).toBeLessThanOrEqual(24)
+      expect(Math.abs(afterGeometry.targetBottom - beforeGeometry.targetBottom)).toBeLessThanOrEqual(24)
+    }
+
+    await assertSelectAllKeepsViewport(
+      editor.locator(".aq-code-editor-content", { hasText: codeLabel }).first(),
+      codeLabel,
+      codeLabel
+    )
+    await assertSelectAllKeepsViewport(
+      editor.locator("table th, table td", { hasText: tableLabel }).first(),
+      tableLabel,
+      tableLabel,
+      { x: 24, y: 16 }
+    )
+  })
+})

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -175,6 +175,14 @@ const EDITOR_POINTER_SCROLL_RICH_BLOCK_SELECTOR = [
   ".aq-mermaid-stage",
 ].join(", ")
 
+export const preserveWindowScrollForRichBlockSelectAll = () => {
+  preserveWindowScrollAcrossFrames(
+    EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES,
+    4,
+    EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS
+  )
+}
+
 export const preserveWindowScrollForEditorPointerFocus = (
   target: EventTarget | null,
   tableSelectionActive: boolean,
@@ -202,11 +210,7 @@ export const preserveWindowScrollForEditorPointerFocus = (
     tableSelectionActive ||
     shouldPreserveFollowUp
   ) {
-    preserveWindowScrollAcrossFrames(
-      EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES,
-      4,
-      EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS
-    )
+    preserveWindowScrollForRichBlockSelectAll()
     return
   }
   if (shouldPreserveGeneralEditorPointer) {

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -42,9 +42,13 @@ import {
   selectCodeBlockText,
   selectDomTextContents,
 } from "./codeBlockNodeViewSelectionModel"
+import { focusElementWithoutScroll } from "./blockEditorEngineDocumentModel"
+import { preserveWindowScrollForRichBlockSelectAll } from "./blockHandleLayoutModel"
 
 export { getPreferredCodeLanguage, normalizeCodeLanguage } from "./codeBlockNodeViewLanguageModel"
 export { CodeBlockEditorStyles } from "./codeBlockNodeViewStyles"
+
+let lastActiveCodeBlockContentRoot: HTMLElement | null = null
 
 export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos }: NodeViewProps) => {
   const menuId = useId()
@@ -67,6 +71,17 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     () => selectCodeBlockText({ editor, getPos, nodeSize: node.nodeSize }),
     [editor, getPos, node.nodeSize]
   )
+
+  const ensureCodeDomTextSelection = useCallback((contentRoot: HTMLElement | null) => {
+    if (!contentRoot || typeof window === "undefined") return
+    window.requestAnimationFrame(() => {
+      if (!contentRoot.isConnected) return
+      const selectedText = window.getSelection()?.toString() || ""
+      if (selectedText.trim()) return
+      if (!(contentRoot.textContent || "").trim()) return
+      selectDomTextContents(contentRoot)
+    })
+  }, [])
 
   useEffect(() => {
     setDraftLanguage(normalizeCodeLanguage(String(node.attrs?.language || "")))
@@ -93,6 +108,16 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
 
     syncLiveCodeSource()
 
+    const handleDocumentPointerDown = (event: PointerEvent) => {
+      const target = event.target
+      if (!(target instanceof Node)) return
+      if (contentRoot.contains(target)) {
+        lastActiveCodeBlockContentRoot = contentRoot
+      } else if (lastActiveCodeBlockContentRoot === contentRoot) {
+        lastActiveCodeBlockContentRoot = null
+      }
+    }
+
     const handleDocumentSelectAll = (event: KeyboardEvent) => {
       if (event.altKey || event.shiftKey) return
       if (!(event.metaKey || event.ctrlKey)) return
@@ -105,12 +130,16 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
           : selection?.anchorNode?.parentElement ?? null
       const isInsideCodeBlock =
         (activeElement instanceof Element && contentRoot.contains(activeElement)) ||
-        (anchorElement instanceof Element && contentRoot.contains(anchorElement))
+        (anchorElement instanceof Element && contentRoot.contains(anchorElement)) ||
+        (lastActiveCodeBlockContentRoot === contentRoot && contentRoot.isConnected)
       if (!isInsideCodeBlock) return
       event.preventDefault()
       event.stopPropagation()
       event.stopImmediatePropagation()
-      if (selectCurrentCodeBlockText()) return
+      if (selectCurrentCodeBlockText()) {
+        ensureCodeDomTextSelection(contentRoot)
+        return
+      }
       selectDomTextContents(contentRoot)
     }
 
@@ -122,6 +151,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       })
     })
 
+    document.addEventListener("pointerdown", handleDocumentPointerDown, true)
     document.addEventListener("keydown", handleDocumentSelectAll, true)
     observer.observe(contentRoot, {
       childList: true,
@@ -130,13 +160,17 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     })
 
     return () => {
+      document.removeEventListener("pointerdown", handleDocumentPointerDown, true)
       document.removeEventListener("keydown", handleDocumentSelectAll, true)
       observer.disconnect()
       if (frameId !== null) {
         window.cancelAnimationFrame(frameId)
       }
+      if (lastActiveCodeBlockContentRoot === contentRoot) {
+        lastActiveCodeBlockContentRoot = null
+      }
     }
-  }, [selectCurrentCodeBlockText, selected])
+  }, [ensureCodeDomTextSelection, selectCurrentCodeBlockText, selected])
 
   useEffect(() => {
     let disposed = false
@@ -222,18 +256,21 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     event.preventDefault()
     event.stopPropagation()
 
-    if (selectCurrentCodeBlockText()) return
-
     const contentRoot = shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
+    if (selectCurrentCodeBlockText()) {
+      ensureCodeDomTextSelection(contentRoot)
+      return
+    }
     if (selectDomTextContents(contentRoot)) return
 
     if (typeof getPos !== "function") return
     const codeBlockPos = getPos()
     if (typeof codeBlockPos !== "number") return
     const tr = editor.state.tr.setSelection(NodeSelection.create(editor.state.doc, Math.max(0, codeBlockPos)))
-    editor.view.dispatch(tr.scrollIntoView())
-    editor.view.focus()
-  }, [editor, getPos, selectCurrentCodeBlockText])
+    preserveWindowScrollForRichBlockSelectAll()
+    editor.view.dispatch(tr)
+    focusElementWithoutScroll(editor.view.dom as HTMLElement)
+  }, [editor, getPos, ensureCodeDomTextSelection, selectCurrentCodeBlockText])
 
   return (
     <CodeBlockEditorWrapper data-selected={selected} data-code-block-wrapper="true">
@@ -290,7 +327,16 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
         </CodeLanguagePicker>
       </CodeBlockEditorHeader>
       <CodeBlockEditorSurface>
-        <div ref={shellRef} className="aq-code-shell" onKeyDownCapture={handleCodeKeyDown} onPaste={handleCodePaste}>
+        <div
+          ref={shellRef}
+          className="aq-code-shell"
+          onPointerDownCapture={() => {
+            lastActiveCodeBlockContentRoot =
+              shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
+          }}
+          onKeyDownCapture={handleCodeKeyDown}
+          onPaste={handleCodePaste}
+        >
           <pre
             className="aq-code-highlight-layer"
             aria-hidden="true"

--- a/front/src/components/editor/codeBlockNodeViewSelectionModel.ts
+++ b/front/src/components/editor/codeBlockNodeViewSelectionModel.ts
@@ -1,6 +1,8 @@
 import type { Editor } from "@tiptap/core"
 import { NodeSelection, TextSelection } from "@tiptap/pm/state"
 import type { KeyboardEvent as ReactKeyboardEvent } from "react"
+import { focusElementWithoutScroll } from "./blockEditorEngineDocumentModel"
+import { preserveWindowScrollForRichBlockSelectAll } from "./blockHandleLayoutModel"
 
 type CodeBlockPositionArgs = {
   editor: Editor
@@ -34,8 +36,9 @@ export const selectCodeBlockText = ({ editor, getPos, nodeSize }: CodeBlockPosit
   const from = codeBlockPos + 1
   const to = codeBlockPos + Math.max(1, nodeSize - 1)
   const nextSelection = TextSelection.create(editor.state.doc, from, to)
-  editor.view.dispatch(editor.state.tr.setSelection(nextSelection).scrollIntoView())
-  editor.view.focus()
+  preserveWindowScrollForRichBlockSelectAll()
+  editor.view.dispatch(editor.state.tr.setSelection(nextSelection))
+  focusElementWithoutScroll(editor.view.dom as HTMLElement)
   return true
 }
 

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -1,4 +1,5 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
+import { preserveWindowScrollForRichBlockSelectAll } from "./blockHandleLayoutModel"
 
 export const isPrimarySelectAllKeyboardEvent = (event: KeyboardEvent) => {
   if (event.defaultPrevented || event.altKey || event.shiftKey) return false
@@ -12,6 +13,23 @@ const resolveElement = (target: EventTarget | Node | null | undefined) => {
   return null
 }
 
+let lastActiveTableCell: HTMLElement | null = null
+
+export const rememberActiveTableCellFromTarget = (
+  eventTarget: EventTarget | Node | null | undefined,
+  editorRoot?: HTMLElement | null
+) => {
+  const targetElement = resolveElement(eventTarget)
+  const cell = targetElement?.closest("th, td")
+  if (cell instanceof HTMLElement && (!editorRoot || editorRoot.contains(cell))) {
+    lastActiveTableCell = cell
+    return
+  }
+  if (editorRoot && targetElement && editorRoot.contains(targetElement)) {
+    lastActiveTableCell = null
+  }
+}
+
 export const selectActiveTableCellText = (
   editor: TiptapEditor,
   eventTarget: EventTarget | null
@@ -23,16 +41,19 @@ export const selectActiveTableCellText = (
   const activeElement = resolveElement(document.activeElement)
   const anchorElement = resolveElement(selection.anchorNode)
   const targetElement = resolveElement(eventTarget)
+  const rememberedCell = lastActiveTableCell?.isConnected ? lastActiveTableCell : null
   const cell =
-    anchorElement?.closest("th, td") ??
+    targetElement?.closest("th, td") ??
     activeElement?.closest("th, td") ??
-    targetElement?.closest("th, td")
+    rememberedCell ??
+    anchorElement?.closest("th, td")
 
   if (!(cell instanceof HTMLElement)) return false
   if (!editor.view.dom.contains(cell)) return false
 
   const range = document.createRange()
   range.selectNodeContents(cell)
+  preserveWindowScrollForRichBlockSelectAll()
   selection.removeAllRanges()
   selection.addRange(range)
   return true

--- a/front/src/components/editor/useBlockEditorEngineSelectionEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionEffects.ts
@@ -19,6 +19,7 @@ import {
 import { isTableSelectionActive } from "./tableStructureModel"
 import {
   isPrimarySelectAllKeyboardEvent,
+  rememberActiveTableCellFromTarget,
   selectActiveTableCellText,
 } from "./tableTextSelectionModel"
 import {
@@ -231,6 +232,7 @@ export const useBlockEditorEngineSelectionEffects = ({
     if (!editor) return
 
     const handleEditorMouseDownCapture = (event: MouseEvent) => {
+      rememberActiveTableCellFromTarget(event.target, editor.view.dom as HTMLElement)
       const targetListItemContext = findNestedListItemContextFromTarget(event.target)
       const targetBlockIndex =
         findTopLevelBlockIndexFromTarget(event.target) ??


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 글 수정 페이지에서 rich block 클릭/선택이 이전 selection anchor로 되돌아가며 깜빡이거나 점프하던 회귀를 복구했습니다.
- 코드/테이블 Cmd/Ctrl+A는 마지막으로 클릭한 내부 rich block root/cell을 우선 사용하고, 선택 중 viewport를 보존합니다.

## 작업 내용

- 코드블럭 select-all에서 `scrollIntoView()`를 제거하고 viewport preserve + no-scroll focus로 전환했습니다.
- 코드블럭/테이블 내부의 마지막 active root/cell을 기록해 stale selection anchor가 남아도 내부 선택으로 제한되게 했습니다.
- rich block Cmd/Ctrl+A와 focus scroll 회귀를 route E2E로 고정하고, offscreen target flake를 분리했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-body-click-flicker.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-rich-focus.spec.ts e2e/editor-authoring-route-rich-select-all.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `git diff --cached --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: editor focus/selection/scroll 보존 경로가 겹쳐 있어 특정 rich block 조합에서 viewport preserve timing이 다시 흔들릴 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋 `99add6ee`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
