### PR TITLE
[Fix] 글수정 rich block drag 선택 회귀 복구

### DIFF
--- a/front/e2e/editor-authoring-list-affordances.spec.ts
+++ b/front/e2e/editor-authoring-list-affordances.spec.ts
@@ -12,20 +12,8 @@ test.describe("editor authoring list affordances", () => {
 
     const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
     const blockSelectionOverlay = page.getByTestId("keyboard-block-selection-overlay")
-    await editor.click()
-    await page.getByRole("button", { name: "목록" }).first().click()
-    await page.keyboard.type("1단계")
-    await page.keyboard.press("Enter")
-    await page.keyboard.type("2단계")
-    await page.keyboard.press("Enter")
-    await page.keyboard.type("3단계")
-
-    await editor.locator("li", { hasText: /^2단계$/ }).locator("p").first().click()
-    await page.keyboard.press("Tab")
-    await editor.locator("li", { hasText: /^3단계$/ }).locator("p").first().click()
-    await page.keyboard.press("Tab")
-    await page.keyboard.press("Tab")
-    await expect(blockSelectionOverlay).toHaveCount(0)
+    const clickListItemParagraph = (label: string) =>
+      editor.locator("li > p", { hasText: new RegExp(`^${label}$`) }).last().click()
     const countOwnLabel = (label: string) =>
       page.evaluate((targetLabel) => {
         const readOwnLabel = (item: HTMLElement) =>
@@ -39,11 +27,49 @@ test.describe("editor authoring list affordances", () => {
           document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
         ).filter((item) => readOwnLabel(item) === targetLabel).length
       }, label)
+    const hasNestedChild = (parentLabel: string, childLabel: string) =>
+      page.evaluate(
+        ({ childLabel: expectedChildLabel, parentLabel: expectedParentLabel }) => {
+          const readOwnLabel = (item: HTMLElement) =>
+            Array.from(item.childNodes)
+              .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+              .map((node) => node.textContent || "")
+              .join(" ")
+              .replace(/\s+/g, " ")
+              .trim()
+          return Array.from(
+            document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+          ).some(
+            (item) =>
+              readOwnLabel(item) === expectedParentLabel &&
+              Array.from(item.querySelectorAll<HTMLElement>("li")).some(
+                (child) => readOwnLabel(child) === expectedChildLabel
+              )
+          )
+        },
+        { childLabel, parentLabel }
+      )
+    await editor.click()
+    await page.getByRole("button", { name: "목록" }).first().click()
+    await page.keyboard.type("1단계")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("2단계")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("3단계")
+
+    await clickListItemParagraph("2단계")
+    await page.keyboard.press("Tab")
+    await clickListItemParagraph("3단계")
+    await page.keyboard.press("Tab")
+    await expect.poll(() => countOwnLabel("3단계")).toBe(1)
+    await page.keyboard.press("Tab")
+    await expect.poll(() => hasNestedChild("2단계", "3단계")).toBe(true)
+    await expect(blockSelectionOverlay).toHaveCount(0)
     await expect.poll(() => countOwnLabel("1단계")).toBe(1)
     await expect.poll(() => countOwnLabel("2단계")).toBe(1)
     await expect.poll(() => countOwnLabel("3단계")).toBe(1)
 
-    await editor.locator("li", { hasText: /^3단계$/ }).locator("p").first().click()
+    await clickListItemParagraph("3단계")
     await page.keyboard.press("Shift+Tab")
     await expect(blockSelectionOverlay).toHaveCount(0)
     await expect.poll(() => countOwnLabel("3단계")).toBe(1)
@@ -54,20 +80,8 @@ test.describe("editor authoring list affordances", () => {
 
     const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
     const blockSelectionOverlay = page.getByTestId("keyboard-block-selection-overlay")
-    await editor.click()
-    await page.getByRole("button", { name: "목록" }).first().click()
-    await page.keyboard.type("1단계")
-    await page.keyboard.press("Enter")
-    await page.keyboard.type("2단계")
-    await page.keyboard.press("Enter")
-    await page.keyboard.type("3단계")
-
-    await editor.locator("li", { hasText: /^2단계$/ }).locator("p").first().click()
-    await page.keyboard.press("Tab")
-    await editor.locator("li", { hasText: /^3단계$/ }).locator("p").first().click()
-    await page.keyboard.press("Tab")
-    await page.keyboard.press("Tab")
-    await expect(blockSelectionOverlay).toHaveCount(0)
+    const clickListItemParagraph = (label: string) =>
+      editor.locator("li > p", { hasText: new RegExp(`^${label}$`) }).last().click()
     const countOwnLabel = (label: string) =>
       page.evaluate((targetLabel) => {
         const readOwnLabel = (item: HTMLElement) =>
@@ -81,11 +95,49 @@ test.describe("editor authoring list affordances", () => {
           document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
         ).filter((item) => readOwnLabel(item) === targetLabel).length
       }, label)
+    const hasNestedChild = (parentLabel: string, childLabel: string) =>
+      page.evaluate(
+        ({ childLabel: expectedChildLabel, parentLabel: expectedParentLabel }) => {
+          const readOwnLabel = (item: HTMLElement) =>
+            Array.from(item.childNodes)
+              .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+              .map((node) => node.textContent || "")
+              .join(" ")
+              .replace(/\s+/g, " ")
+              .trim()
+          return Array.from(
+            document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+          ).some(
+            (item) =>
+              readOwnLabel(item) === expectedParentLabel &&
+              Array.from(item.querySelectorAll<HTMLElement>("li")).some(
+                (child) => readOwnLabel(child) === expectedChildLabel
+              )
+          )
+        },
+        { childLabel, parentLabel }
+      )
+    await editor.click()
+    await page.getByRole("button", { name: "목록" }).first().click()
+    await page.keyboard.type("1단계")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("2단계")
+    await page.keyboard.press("Enter")
+    await page.keyboard.type("3단계")
+
+    await clickListItemParagraph("2단계")
+    await page.keyboard.press("Tab")
+    await clickListItemParagraph("3단계")
+    await page.keyboard.press("Tab")
+    await expect.poll(() => countOwnLabel("3단계")).toBe(1)
+    await page.keyboard.press("Tab")
+    await expect.poll(() => hasNestedChild("2단계", "3단계")).toBe(true)
+    await expect(blockSelectionOverlay).toHaveCount(0)
     await expect.poll(() => countOwnLabel("1단계")).toBe(1)
     await expect.poll(() => countOwnLabel("2단계")).toBe(1)
     await expect.poll(() => countOwnLabel("3단계")).toBe(1)
 
-    await editor.locator("li", { hasText: /^3단계$/ }).locator("p").first().click()
+    await clickListItemParagraph("3단계")
     await page.keyboard.press("Shift+Tab")
     await expect(blockSelectionOverlay).toHaveCount(0)
     await expect.poll(() => countOwnLabel("3단계")).toBe(1)

--- a/front/e2e/editor-authoring-route-rich-drag-selection.spec.ts
+++ b/front/e2e/editor-authoring-route-rich-drag-selection.spec.ts
@@ -1,0 +1,207 @@
+import { expect, test, type Locator } from "@playwright/test"
+import {
+  expectEditorToContainLoadedText,
+  expectVisibleBox,
+} from "./helpers/editorAuthoringFlow"
+
+type DragTargetMetrics = {
+  startX: number
+  endX: number
+  y: number
+  scrollTop: number
+  targetTop: number
+  targetBottom: number
+}
+
+const readDragTargetMetrics = async (target: Locator, label: string): Promise<DragTargetMetrics> => {
+  const metrics = await target.evaluate((element, expectedText) => {
+    const findTextNode = (root: Node): Text | null => {
+      const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+      let current = walker.nextNode()
+      while (current) {
+        if ((current.textContent ?? "").includes(expectedText)) return current as Text
+        current = walker.nextNode()
+      }
+      return null
+    }
+
+    const textNode = findTextNode(element)
+    const targetRect = element.getBoundingClientRect()
+    const range = document.createRange()
+    if (textNode) {
+      const text = textNode.textContent ?? ""
+      const startOffset = text.indexOf(expectedText)
+      if (startOffset >= 0) {
+        range.setStart(textNode, startOffset)
+        range.setEnd(textNode, startOffset + expectedText.length)
+      } else {
+        range.selectNodeContents(textNode)
+      }
+    } else {
+      range.selectNodeContents(element)
+    }
+    const rangeRect = range.getBoundingClientRect()
+    const rect =
+      rangeRect.width > 0 && rangeRect.height > 0
+        ? rangeRect
+        : targetRect
+    return {
+      startX: Math.max(targetRect.left + 4, rect.left + 3),
+      endX: Math.min(targetRect.right - 4, rect.right - 3),
+      y: Math.min(targetRect.bottom - 4, Math.max(targetRect.top + 4, rect.top + rect.height / 2)),
+      scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+      targetTop: targetRect.top,
+      targetBottom: targetRect.bottom,
+    }
+  }, label)
+
+  if (!Number.isFinite(metrics.startX) || !Number.isFinite(metrics.endX) || metrics.endX <= metrics.startX) {
+    throw new Error(`${label} drag target metrics are invalid`)
+  }
+  return metrics
+}
+
+test.describe("editor authoring route rich block drag selection", () => {
+  test("실제 /editor/[id] rich block drag selection은 block selection anchor와 viewport를 되돌리지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const previousSelectionLabel = "drag selection previous block anchor"
+    const bodyLabel = "drag selection body target"
+    const tableLabel = "Drag selection table target"
+    const codeLabel = "drag selection code target"
+    const bodySelectionNeedle = "drag selection body"
+    const tableSelectionNeedle = "Drag selection table"
+    const codeSelectionNeedle = "drag selection code"
+    const leadParagraphs = Array.from({ length: 46 }, (_, index) =>
+      index === 20
+        ? `${previousSelectionLabel} ${index + 1}. drag 선택 전 이전 block selection anchor가 남아 있는 본문입니다.`
+        : `drag selection lead paragraph ${index + 1}. rich block drag selection 회귀를 확인합니다.`
+    )
+    const trailingParagraphs = Array.from({ length: 20 }, (_, index) =>
+      index === 3
+        ? `${bodyLabel} ${index + 1}. 표를 지난 뒤 일반 본문 drag selection도 같은 viewport에 남아야 합니다.`
+        : `drag selection trailing paragraph ${index + 1}. drag 이후 scrollTop이 되돌아가면 안 됩니다.`
+    )
+    const tableMarkdown = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[140,260,260]} -->',
+      "| 영역 | 점검 항목 | 확인 기준 |",
+      "| --- | --- | --- |",
+      "| 개념 이해 | Stateless 의미 | 요청만으로 처리 가능한가 |",
+      `| 토큰 구조 | ${tableLabel} | 역할 명확 |`,
+      "| 보안 | HTTPS 사용 | 필수 |",
+    ].join("\n")
+    const content = [
+      "# rich block drag selection 재현",
+      ...leadParagraphs,
+      tableMarkdown,
+      "```ts",
+      `const marker = "${codeLabel}";`,
+      "console.log(marker);",
+      "```",
+      ...trailingParagraphs,
+    ].join("\n\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/998", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 998,
+          version: 7,
+          title: "rich block drag selection 회귀 글",
+          content,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/998")
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+      "rich block drag selection 회귀 글"
+    )
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expectEditorToContainLoadedText(editor, tableLabel)
+
+    const previousSelectionParagraph = editor.locator("p", { hasText: previousSelectionLabel }).first()
+    const dragHandle = page.getByTestId("block-drag-handle")
+    const selectPreviousBlockAnchor = async () => {
+      await previousSelectionParagraph.scrollIntoViewIfNeeded()
+      const previousSelectionBox = await expectVisibleBox(
+        previousSelectionParagraph,
+        "drag selection stale paragraph metrics are missing"
+      )
+      await page.mouse.move(
+        previousSelectionBox.x + Math.min(previousSelectionBox.width / 2, 240),
+        previousSelectionBox.y + Math.min(previousSelectionBox.height / 2, 18)
+      )
+      await previousSelectionParagraph.hover()
+      await expect(dragHandle).toBeVisible()
+      await dragHandle.click()
+      await expect(page.getByTestId("keyboard-block-selection-overlay")).toBeVisible()
+    }
+
+    const assertDragSelectionKeepsViewport = async (
+      target: Locator,
+      expectedSelection: string,
+      label: string
+    ) => {
+      await selectPreviousBlockAnchor()
+      await target.scrollIntoViewIfNeeded()
+      await target.evaluate((element) => {
+        element.scrollIntoView({ block: "center", inline: "nearest" })
+      })
+      const beforeGeometry = await readDragTargetMetrics(target, label)
+
+      await page.mouse.move(beforeGeometry.startX, beforeGeometry.y)
+      await page.mouse.down()
+      await page.mouse.move(beforeGeometry.endX, beforeGeometry.y, { steps: 18 })
+      await page.mouse.up()
+      await page.waitForTimeout(360)
+
+      const afterGeometry = await target.evaluate((element) => {
+        const rect = element.getBoundingClientRect()
+        return {
+          selectedText: window.getSelection()?.toString() ?? "",
+          scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+          targetTop: rect.top,
+          targetBottom: rect.bottom,
+        }
+      })
+      expect(afterGeometry.selectedText).toContain(expectedSelection)
+      expect(afterGeometry.selectedText).not.toContain(previousSelectionLabel)
+      expect(Math.abs(afterGeometry.scrollTop - beforeGeometry.scrollTop)).toBeLessThanOrEqual(24)
+      expect(Math.abs(afterGeometry.targetTop - beforeGeometry.targetTop)).toBeLessThanOrEqual(24)
+      expect(Math.abs(afterGeometry.targetBottom - beforeGeometry.targetBottom)).toBeLessThanOrEqual(24)
+    }
+
+    await assertDragSelectionKeepsViewport(
+      editor.locator("table th, table td", { hasText: tableLabel }).first(),
+      tableSelectionNeedle,
+      tableLabel
+    )
+    await assertDragSelectionKeepsViewport(
+      editor.locator(".aq-code-editor-content", { hasText: codeLabel }).first(),
+      codeSelectionNeedle,
+      codeLabel
+    )
+    await assertDragSelectionKeepsViewport(
+      editor.locator("p", { hasText: bodyLabel }).first(),
+      bodySelectionNeedle,
+      bodyLabel
+    )
+  })
+})

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -1,9 +1,11 @@
 import CodeBlock from "@tiptap/extension-code-block"
-import { NodeSelection } from "@tiptap/pm/state"
+import { NodeSelection, TextSelection } from "@tiptap/pm/state"
 import { NodeViewContent, type NodeViewProps, ReactNodeViewRenderer } from "@tiptap/react"
 import {
   ClipboardEvent as ReactClipboardEvent,
   KeyboardEvent as ReactKeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+  PointerEvent as ReactPointerEvent,
   useCallback,
   useEffect,
   useId,
@@ -50,11 +52,19 @@ export { CodeBlockEditorStyles } from "./codeBlockNodeViewStyles"
 
 let lastActiveCodeBlockContentRoot: HTMLElement | null = null
 
+type CodeDragSelectionSession = {
+  active: boolean
+  anchorPos: number
+  startX: number
+  startY: number
+}
+
 export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos }: NodeViewProps) => {
   const menuId = useId()
   const menuRef = useRef<HTMLDivElement>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
   const shellRef = useRef<HTMLDivElement>(null)
+  const codeDragSelectionRef = useRef<CodeDragSelectionSession | null>(null)
   const [draftLanguage, setDraftLanguage] = useState(normalizeCodeLanguage(String(node.attrs?.language || "")))
   const [isLanguageMenuOpen, setIsLanguageMenuOpen] = useState(false)
   const [languageSearch, setLanguageSearch] = useState("")
@@ -71,6 +81,170 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     () => selectCodeBlockText({ editor, getPos, nodeSize: node.nodeSize }),
     [editor, getPos, node.nodeSize]
   )
+
+  const resolveCodeTextPosFromPointer = useCallback(
+    (clientX: number, clientY: number, contentRoot: HTMLElement | null) => {
+      if (typeof getPos !== "function") return
+      const codeBlockPos = getPos()
+      if (typeof codeBlockPos !== "number") return
+      const from = codeBlockPos + 1
+      const to = codeBlockPos + Math.max(1, node.nodeSize - 1)
+      let pointerPos: number | null = null
+      const ownerDocument = editor.view.dom.ownerDocument as Document & {
+        caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null
+        caretRangeFromPoint?: (x: number, y: number) => Range | null
+      }
+      const caretPosition = ownerDocument.caretPositionFromPoint?.(clientX, clientY)
+      const caretRange = caretPosition ? null : ownerDocument.caretRangeFromPoint?.(clientX, clientY)
+      const caretNode = caretPosition?.offsetNode ?? caretRange?.startContainer ?? null
+      const caretOffset = caretPosition?.offset ?? caretRange?.startOffset ?? null
+      const measureTextOffset = (root: Node, node: Node, offset: number) => {
+        const range = ownerDocument.createRange()
+        range.setStart(root, 0)
+        range.setEnd(node, offset)
+        return range.toString().length
+      }
+      const resolveContentTextDomPosition = (offset: number) => {
+        if (!contentRoot) return null
+        const walker = ownerDocument.createTreeWalker(contentRoot, NodeFilter.SHOW_TEXT)
+        let remaining = offset
+        let current = walker.nextNode()
+        while (current) {
+          const textLength = current.textContent?.length ?? 0
+          if (remaining <= textLength) {
+            return { node: current, offset: remaining }
+          }
+          remaining -= textLength
+          current = walker.nextNode()
+        }
+        return null
+      }
+      const resolveHighlightTextOffset = (node: Node, offset: number) => {
+        if (!contentRoot) return null
+        const highlightRoot = contentRoot
+          .closest(".aq-code-shell")
+          ?.querySelector<HTMLElement>(".aq-code-highlight-layer")
+        if (!highlightRoot?.contains(node)) return null
+        const highlightOffset = measureTextOffset(highlightRoot, node, offset)
+        const contentText = contentRoot.textContent ?? ""
+        const highlightText = highlightRoot.textContent ?? ""
+        const contentBaseOffset = highlightText ? Math.max(0, contentText.indexOf(highlightText)) : 0
+        return Math.min(contentText.length, contentBaseOffset + highlightOffset)
+      }
+
+      if (contentRoot && caretNode && typeof caretOffset === "number" && contentRoot.contains(caretNode)) {
+        try {
+          pointerPos = editor.view.posAtDOM(caretNode, caretOffset)
+        } catch {
+          pointerPos = null
+        }
+      }
+
+      if (pointerPos === null && caretNode && typeof caretOffset === "number") {
+        const highlightTextOffset = resolveHighlightTextOffset(caretNode, caretOffset)
+        const contentPosition =
+          typeof highlightTextOffset === "number"
+            ? resolveContentTextDomPosition(highlightTextOffset)
+            : null
+        if (contentPosition) {
+          try {
+            pointerPos = editor.view.posAtDOM(contentPosition.node, contentPosition.offset)
+          } catch {
+            pointerPos = null
+          }
+        }
+      }
+
+      if (pointerPos === null) {
+        const coords = editor.view.posAtCoords({ left: clientX, top: clientY })
+        pointerPos = coords?.pos ?? null
+      }
+
+      if (pointerPos === null) return
+      return Math.min(Math.max(pointerPos, from), to)
+    },
+    [editor, getPos, node.nodeSize]
+  )
+
+  const applyCodeTextSelection = useCallback(
+    (anchorPos: number, headPos: number) => {
+      const nextSelection = TextSelection.create(
+        editor.state.doc,
+        Math.min(anchorPos, headPos),
+        Math.max(anchorPos, headPos)
+      )
+      if (nextSelection.eq(editor.state.selection)) return
+      editor.view.dispatch(editor.state.tr.setSelection(nextSelection))
+    },
+    [editor]
+  )
+
+  const handleCodePointerDownCapture = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const contentRoot =
+        shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
+      lastActiveCodeBlockContentRoot = contentRoot
+    },
+    []
+  )
+
+  const handleCodeMouseDownCapture = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      const contentRoot =
+        shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
+      if (event.button !== 0 || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return
+      if (!contentRoot || !(event.target instanceof Node) || !contentRoot.contains(event.target)) return
+      const anchorPos = resolveCodeTextPosFromPointer(event.clientX, event.clientY, contentRoot)
+      if (typeof anchorPos !== "number") return
+      event.preventDefault()
+      event.stopPropagation()
+      lastActiveCodeBlockContentRoot = contentRoot
+      codeDragSelectionRef.current = {
+        active: false,
+        anchorPos,
+        startX: event.clientX,
+        startY: event.clientY,
+      }
+      applyCodeTextSelection(anchorPos, anchorPos)
+      focusElementWithoutScroll(editor.view.dom as HTMLElement)
+    },
+    [applyCodeTextSelection, editor.view.dom, resolveCodeTextPosFromPointer]
+  )
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const handleWindowMouseMove = (event: MouseEvent) => {
+      const session = codeDragSelectionRef.current
+      if (!session) return
+      const contentRoot =
+        shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
+      const headPos = resolveCodeTextPosFromPointer(event.clientX, event.clientY, contentRoot)
+      if (typeof headPos !== "number") return
+      const distance = Math.hypot(event.clientX - session.startX, event.clientY - session.startY)
+      if (!session.active && distance < 3) return
+      session.active = true
+      event.preventDefault()
+      event.stopPropagation()
+      applyCodeTextSelection(session.anchorPos, headPos)
+    }
+
+    const handleWindowMouseUp = (event: MouseEvent) => {
+      const session = codeDragSelectionRef.current
+      if (!session) return
+      codeDragSelectionRef.current = null
+      if (!session.active) return
+      event.preventDefault()
+      event.stopPropagation()
+    }
+
+    window.addEventListener("mousemove", handleWindowMouseMove, true)
+    window.addEventListener("mouseup", handleWindowMouseUp, true)
+    return () => {
+      window.removeEventListener("mousemove", handleWindowMouseMove, true)
+      window.removeEventListener("mouseup", handleWindowMouseUp, true)
+    }
+  }, [applyCodeTextSelection, resolveCodeTextPosFromPointer])
 
   const ensureCodeDomTextSelection = useCallback((contentRoot: HTMLElement | null) => {
     if (!contentRoot || typeof window === "undefined") return
@@ -330,10 +504,8 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
         <div
           ref={shellRef}
           className="aq-code-shell"
-          onPointerDownCapture={() => {
-            lastActiveCodeBlockContentRoot =
-              shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
-          }}
+          onPointerDownCapture={handleCodePointerDownCapture}
+          onMouseDownCapture={handleCodeMouseDownCapture}
           onKeyDownCapture={handleCodeKeyDown}
           onPaste={handleCodePaste}
         >


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- `/editor/[id]` code block 내부 drag selection이 직전 block selection에 빼앗겨 빈 선택/앞쪽 선택으로 끝나는 회귀를 복구했습니다.
- table/body/code rich block drag selection을 한 시나리오로 고정하는 route E2E를 추가했고, authoring full run에서 발견된 중첩 list 테스트 타깃 flake도 함께 안정화했습니다.

## 작업 내용

- Code block content mousedown에서 native/PM 기본 선택을 막고, caret range를 실제 code content text offset으로 매핑해 `TextSelection`을 직접 확장합니다.
- `/editor/[id]` rich block drag selection E2E를 추가해 stale block selection anchor가 남아도 table/code/body 선택 텍스트와 viewport가 같은 블럭에 남는지 검증합니다.
- 중첩 list Tab/Shift+Tab 검증은 부모 `li` 텍스트 매칭 대신 직계 `li > p` 라벨 클릭과 nesting poll을 사용해 full authoring run flake를 막습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-body-click-flicker.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-rich-focus.spec.ts e2e/editor-authoring-route-rich-select-all.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-list-affordances.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: code block 내부 mousedown을 직접 처리하므로 code block click/drag/edit interaction에 영향이 있을 수 있습니다. 관련 code recovery, code/mermaid, rich focus/select-all, authoring full run으로 회귀를 확인했습니다.
- 롤백 방법: 이 PR의 merge commit을 revert하면 이전 code block selection 경로로 복구됩니다. 단, live 배포 후 `/editor/507`에서 동일 drag selection 시나리오를 재확인해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
