### PR TITLE
[Fix] code block live 본문 복구

### DIFF
--- a/front/e2e/editor-authoring-route-code-public-fallback.spec.ts
+++ b/front/e2e/editor-authoring-route-code-public-fallback.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "@playwright/test"
+import { expectEditorToContainLoadedText } from "./helpers/editorAuthoringFlow"
+
+test.describe("editor authoring route code public fallback", () => {
+  test("실제 /editor/[id] 수정 진입은 admin 코드 fence가 비었으면 공개 markdown 코드 본문으로 복구한다", async ({
+    page,
+  }) => {
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const adminContentWithEmptyCode = [
+      "공개 markdown 복구 대상입니다.",
+      "",
+      "```text",
+      "```",
+      "",
+      "```java",
+      "```",
+      "",
+      "복구 뒤 문단입니다.",
+    ].join("\n")
+    const publicContentWithCode = [
+      "공개 markdown 복구 대상입니다.",
+      "",
+      "```text",
+      "로그인 -> 세션 생성 -> 이후 요청에서 세션 확인",
+      "```",
+      "",
+      "```java",
+      "public Token login(User user) {",
+      "    return new Token(access, refresh);",
+      "}",
+      "```",
+      "",
+      "복구 뒤 문단입니다.",
+    ].join("\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/997", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 997,
+          version: 13,
+          title: "공개 markdown 코드 복구 글",
+          content: adminContentWithEmptyCode,
+          contentHtml: "",
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+    await page.route("**/post/api/v1/posts/997", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          content: publicContentWithCode,
+          contentHtml: "",
+        }),
+      })
+    })
+
+    await page.goto("/editor/997")
+
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("공개 markdown 코드 복구 글")
+    await expectEditorToContainLoadedText(
+      page.locator("[data-testid='block-editor-prosemirror']").first(),
+      "복구 뒤 문단입니다."
+    )
+
+    const codeBlocks = page.locator(".aq-code-shell")
+    await expect(codeBlocks).toHaveCount(2)
+    await expect(codeBlocks.nth(0).locator(".aq-code-highlight-layer")).toContainText(
+      "로그인 -> 세션 생성 -> 이후 요청에서 세션 확인"
+    )
+    await expect(codeBlocks.nth(1).locator(".aq-code-highlight-layer")).toContainText("public Token login")
+    await expect(codeBlocks.nth(1).locator(".aq-code-highlight-layer")).toContainText(
+      "return new Token(access, refresh);"
+    )
+  })
+})

--- a/front/src/routes/Admin/editorCodeFenceRecovery.ts
+++ b/front/src/routes/Admin/editorCodeFenceRecovery.ts
@@ -74,3 +74,8 @@ export const restoreEmptyFencedCodeBlocks = (content: string, recoveredContent: 
 
   return lines.join("\n")
 }
+
+export const hasEmptyFencedCodeBlockBody = (content: string) =>
+  parseFencedCodeBlocks(content.replace(/\r\n?/g, "\n")).some((block) =>
+    isCodeFenceBodyVisiblyEmpty(block.body)
+  )

--- a/front/src/routes/Admin/useEditorStudioDraftLifecycle.ts
+++ b/front/src/routes/Admin/useEditorStudioDraftLifecycle.ts
@@ -7,6 +7,7 @@ import {
 } from "react"
 import { apiFetch } from "src/apis/backend/client"
 import { replaceRoute } from "src/libs/router"
+import { hasEmptyFencedCodeBlockBody, restoreEmptyFencedCodeBlocks } from "./editorCodeFenceRecovery"
 import { isServerTempDraftPost } from "./editorTempDraft"
 import { useEditorStudioLocalDraftLifecycle } from "./useEditorStudioDraftLifecycleModel"
 
@@ -347,15 +348,25 @@ export const useEditorStudioDraftLifecycle = ({
       const post = await apiFetch<PostForEditor>(`/post/api/v1/adm/posts/${targetPostId}`)
       let resolvedPost = post
 
-      if ((resolvedPost.content ?? "").trim().length === 0 && resolvedPost.contentHtml) {
+      const adminContent = resolvedPost.content ?? ""
+      const shouldFetchPublicPostFallback =
+        (adminContent.trim().length === 0 && resolvedPost.contentHtml) ||
+        hasEmptyFencedCodeBlockBody(adminContent)
+
+      if (shouldFetchPublicPostFallback) {
         try {
           const publicPost = await apiFetch<Pick<PostForEditor, "content" | "contentHtml">>(
             `/post/api/v1/posts/${targetPostId}`
           )
           if ((publicPost.content ?? "").trim().length > 0 || publicPost.contentHtml) {
+            const publicContent = publicPost.content ?? ""
+            const restoredContent =
+              adminContent.trim().length > 0 && publicContent.trim().length > 0
+                ? restoreEmptyFencedCodeBlocks(adminContent, publicContent)
+                : publicContent || post.content
             resolvedPost = {
               ...post,
-              content: publicPost.content ?? post.content,
+              content: restoredContent,
               contentHtml: publicPost.contentHtml ?? post.contentHtml,
             }
           }


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- PR #469 배포 후 실제 `/editor/507`에서 일반 `text/java` 코드블럭 본문이 빈 DOM으로 렌더링되는 live 회귀를 복구합니다.
- admin payload의 일부 code fence body만 빈 경우에도 공개 markdown fallback을 조회해 빈 fence 본문만 채웁니다.

## 작업 내용

- 수정 진입 시 content 전체가 비어 있지 않아도 빈 fenced code body가 있으면 public post markdown fallback을 조회합니다.
- public markdown의 code body로 admin content의 빈 fence만 복구하고 나머지 본문/메타는 유지합니다.
- live 회귀를 별도 authoring route E2E로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - RED: `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-code-public-fallback.spec.ts --workers=1` failed before patch with empty highlight text.
  - GREEN: `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-code-public-fallback.spec.ts --workers=1` -> 1 passed.
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-code-public-fallback.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts --workers=1` -> 7 passed.
  - `yarn --cwd front test:e2e:authoring` -> 95 passed.
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `git diff --check`
  - 배포 전 실제 Chrome 검증: PR #469 배포본 `/editor/507`에서 일반 codeBlock blank 재현. 이 PR merge/CD 후 같은 URL에서 재검증 예정.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 공개 글 본문을 fallback으로 조회할 수 없는 비공개/삭제 글은 기존 admin payload만 사용하므로 복구가 제한될 수 있습니다.
- 롤백 방법: 이 PR revert.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
