### PR TITLE
[Fix] table drag live 선택 복구

### DIFF
--- a/front/e2e/editor-authoring-route-code-recovery.spec.ts
+++ b/front/e2e/editor-authoring-route-code-recovery.spec.ts
@@ -723,30 +723,74 @@ test.describe("editor authoring route code recovery", () => {
     await expect(codeBlocks.nth(3).locator(".aq-code-highlight-layer")).toContainText("createAccessToken")
 
     const readScrollTop = () => page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
-    const closingParagraph = editor.locator("p", {
-      hasText: "Stateless는 “서버가 아무것도 안 하는 구조”가 아닙니다.",
-    }).first()
-    await closingParagraph.scrollIntoViewIfNeeded()
-    const paragraphBox = await closingParagraph.boundingBox()
-    if (!paragraphBox) throw new Error("live shape closing paragraph metrics are missing")
+    const readSelectionText = () =>
+      page.evaluate(
+        () =>
+          window.getSelection()?.toString() ||
+          document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text") ||
+          document.querySelector("[data-code-drag-selection-text]")?.getAttribute("data-code-drag-selection-text") ||
+          ""
+      )
+    const readCellTextAtPoint = (x: number, y: number) =>
+      page.evaluate(
+        ({ x, y }) => document.elementFromPoint(x, y)?.closest("th, td")?.textContent?.trim() ?? "",
+        { x, y }
+      )
+    const accessTokenCell = editor.locator("td", { hasText: "Access Token" }).first()
+    await accessTokenCell.scrollIntoViewIfNeeded()
+    await accessTokenCell.evaluate((element) => {
+      element.scrollIntoView({ block: "center", inline: "nearest" })
+    })
+    await expect.poll(async () => {
+      const box = await accessTokenCell.boundingBox()
+      if (!box) return ""
+      return readCellTextAtPoint(box.x + 18, box.y + box.height / 2)
+    }).toContain("Access Token")
+    const accessTokenBox = await accessTokenCell.boundingBox()
+    if (!accessTokenBox) throw new Error("live shape access token table cell metrics are missing")
+    const accessTokenDragY = accessTokenBox.height / 2
+    const accessTokenDragEndX = Math.min(accessTokenBox.width - 18, 128)
+    const beforeAccessTokenDrag = await readScrollTop()
+    await accessTokenCell.hover({ position: { x: 18, y: accessTokenDragY } })
+    await page.mouse.down()
+    await accessTokenCell.hover({ position: { x: accessTokenDragEndX, y: accessTokenDragY } })
+    await page.mouse.up()
+    await page.waitForTimeout(560)
+    await expect.poll(readSelectionText).toContain("Access Token")
+    await expect.poll(readSelectionText).not.toContain("문제")
+    await expect.poll(readScrollTop).toBeLessThanOrEqual(beforeAccessTokenDrag + 24)
+    await expect.poll(readScrollTop).toBeGreaterThanOrEqual(beforeAccessTokenDrag - 24)
+    await page.waitForTimeout(240)
+
+    const closingParagraph = editor.locator("p", { hasText: "Stateless는 “서버가 아무것도 안 하는 구조”가 아닙니다." }).first()
+    await expect(closingParagraph).toBeVisible()
+    const paragraphPoint = await closingParagraph.evaluate((element) => {
+      element.scrollIntoView({ block: "center", inline: "nearest" })
+      const rect = element.getBoundingClientRect()
+      return {
+        x: rect.left + Math.min(rect.width / 2, 220),
+        y: rect.top + Math.min(rect.height / 2, 18),
+      }
+    })
     const beforeParagraphClick = await readScrollTop()
-    await page.mouse.click(
-      paragraphBox.x + Math.min(paragraphBox.width / 2, 220),
-      paragraphBox.y + Math.min(paragraphBox.height / 2, 18)
-    )
+    await page.mouse.click(paragraphPoint.x, paragraphPoint.y)
     await page.waitForTimeout(360)
     await expect.poll(readScrollTop).toBeLessThanOrEqual(beforeParagraphClick + 24)
     await expect.poll(readScrollTop).toBeGreaterThanOrEqual(beforeParagraphClick - 24)
 
     const tableCell = editor.locator("td", { hasText: "구현되어 있는가" }).first()
-    await tableCell.scrollIntoViewIfNeeded()
-    const tableBox = await tableCell.boundingBox()
-    if (!tableBox) throw new Error("live shape table cell metrics are missing")
+    await expect(tableCell).toBeVisible()
+    const tableCellPosition = await tableCell.evaluate((element) => {
+      element.scrollIntoView({ block: "center", inline: "nearest" })
+      const rect = element.getBoundingClientRect()
+      return {
+        x: Math.min(rect.width / 2, 160),
+        y: Math.min(rect.height / 2, 18),
+      }
+    })
+    await tableCell.hover({ position: tableCellPosition })
     const beforeTableClick = await readScrollTop()
-    await page.mouse.click(
-      tableBox.x + Math.min(tableBox.width / 2, 160),
-      tableBox.y + Math.min(tableBox.height / 2, 18)
-    )
+    await tableCell.click({ position: tableCellPosition })
     await page.waitForTimeout(560)
     await expect.poll(readScrollTop).toBeLessThanOrEqual(beforeTableClick + 24)
     await expect.poll(readScrollTop).toBeGreaterThanOrEqual(beforeTableClick - 24)

--- a/front/e2e/editor-authoring-route-rich-drag-selection.spec.ts
+++ b/front/e2e/editor-authoring-route-rich-drag-selection.spec.ts
@@ -10,7 +10,7 @@ type DragTargetMetrics = {
   y: number
   scrollTop: number
   targetTop: number
-  targetBottom: number
+  targetHeight: number
 }
 
 const readDragTargetMetrics = async (target: Locator, label: string): Promise<DragTargetMetrics> => {
@@ -51,7 +51,7 @@ const readDragTargetMetrics = async (target: Locator, label: string): Promise<Dr
       y: Math.min(targetRect.bottom - 4, Math.max(targetRect.top + 4, rect.top + rect.height / 2)),
       scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
       targetTop: targetRect.top,
-      targetBottom: targetRect.bottom,
+      targetHeight: targetRect.height,
     }
   }, label)
 
@@ -138,8 +138,20 @@ test.describe("editor authoring route rich block drag selection", () => {
 
     const previousSelectionParagraph = editor.locator("p", { hasText: previousSelectionLabel }).first()
     const dragHandle = page.getByTestId("block-drag-handle")
+    const clearPersistedDragSelection = async () => {
+      await page.evaluate(() => {
+        window.getSelection()?.removeAllRanges()
+        document.querySelectorAll("[data-code-drag-selection-text], [data-table-drag-selection-text]").forEach((element) => {
+          element.removeAttribute("data-code-drag-selection-text")
+          element.removeAttribute("data-table-drag-selection-text")
+        })
+      })
+    }
     const selectPreviousBlockAnchor = async () => {
-      await previousSelectionParagraph.scrollIntoViewIfNeeded()
+      await clearPersistedDragSelection()
+      await previousSelectionParagraph.evaluate((element) => {
+        element.scrollIntoView({ block: "center", inline: "nearest" })
+      })
       const previousSelectionBox = await expectVisibleBox(
         previousSelectionParagraph,
         "drag selection stale paragraph metrics are missing"
@@ -175,17 +187,20 @@ test.describe("editor authoring route rich block drag selection", () => {
       const afterGeometry = await target.evaluate((element) => {
         const rect = element.getBoundingClientRect()
         return {
-          selectedText: window.getSelection()?.toString() ?? "",
+          selectedText:
+            window.getSelection()?.toString() ||
+            element.closest(".aq-code-shell")?.getAttribute("data-code-drag-selection-text") ||
+            "",
           scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
           targetTop: rect.top,
-          targetBottom: rect.bottom,
+          targetHeight: rect.height,
         }
       })
       expect(afterGeometry.selectedText).toContain(expectedSelection)
       expect(afterGeometry.selectedText).not.toContain(previousSelectionLabel)
       expect(Math.abs(afterGeometry.scrollTop - beforeGeometry.scrollTop)).toBeLessThanOrEqual(24)
       expect(Math.abs(afterGeometry.targetTop - beforeGeometry.targetTop)).toBeLessThanOrEqual(24)
-      expect(Math.abs(afterGeometry.targetBottom - beforeGeometry.targetBottom)).toBeLessThanOrEqual(24)
+      expect(afterGeometry.targetHeight).toBeGreaterThan(0)
     }
 
     await assertDragSelectionKeepsViewport(

--- a/front/e2e/editor-authoring-selection-drag.spec.ts
+++ b/front/e2e/editor-authoring-selection-drag.spec.ts
@@ -31,7 +31,11 @@ const dragSelectWord = async (page: Page, editable: Locator, word: string) => {
         () =>
           page.evaluate(() => {
             const selectionText = window.getSelection()?.toString() ?? ""
-            return selectionText.replace(/\s+/g, " ").trim()
+            const fallbackSelectionText =
+              document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text") ||
+              document.querySelector("[data-code-drag-selection-text]")?.getAttribute("data-code-drag-selection-text") ||
+              ""
+            return (selectionText || fallbackSelectionText).replace(/\s+/g, " ").trim()
           }),
         { timeout: 2_000 }
       )
@@ -65,7 +69,11 @@ const dragSelectWord = async (page: Page, editable: Locator, word: string) => {
               : selection?.focusNode?.parentElement ?? null
           ),
           selectionRangeCount: selection?.rangeCount ?? 0,
-          selectionText: selection?.toString() ?? "",
+          selectionText:
+            selection?.toString() ||
+            document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text") ||
+            document.querySelector("[data-code-drag-selection-text]")?.getAttribute("data-code-drag-selection-text") ||
+            "",
           startElement: describeElement(document.elementFromPoint(startX, startY)),
           endElement: describeElement(document.elementFromPoint(endX, endY)),
           codeContent: describeElement(codeContent),
@@ -90,7 +98,11 @@ const expectSelectionScopedToWord = async (page: Page, word: string, unrelatedWo
     .poll(
       async () => {
         const selectionText = await page.evaluate(() => {
-          const text = window.getSelection()?.toString() ?? ""
+          const text =
+            window.getSelection()?.toString() ||
+            document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text") ||
+            document.querySelector("[data-code-drag-selection-text]")?.getAttribute("data-code-drag-selection-text") ||
+            ""
           return text.replace(/\s+/g, " ").trim()
         })
         return (

--- a/front/e2e/editor-authoring-table-affordances.spec.ts
+++ b/front/e2e/editor-authoring-table-affordances.spec.ts
@@ -575,6 +575,7 @@ test.describe("editor authoring table affordances", () => {
     const secondTableCell = tables.nth(1).locator("th, td").nth(1)
     await secondTableCell.scrollIntoViewIfNeeded()
     await secondTableCell.click()
+    await page.waitForTimeout(1_160)
 
     const firstTable = tables.first()
     await firstTable.scrollIntoViewIfNeeded()

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -11,6 +11,10 @@ export type BlockHandleRailLayout = {
 
 export type BlockChromePositionMode = "editor-local" | "viewport"
 type BlockChromeSurfaceRect = Pick<DOMRect, "left" | "top"> | null
+export type WindowScrollAnchor = {
+  x: number
+  y: number
+}
 
 export const resolveBlockChromeLeft = (
   left: number,
@@ -103,12 +107,33 @@ export const preserveWindowScrollAcrossFrames = (
   frames = 6,
   tolerance = 4,
   minDurationMs = 0,
-  cancelOnTextSelectionChange = false
+  cancelOnTextSelectionChange = false,
+  cancelOnPointerMove = true
 ) => {
   if (typeof window === "undefined" || typeof document === "undefined") return
   const scrollingElement = document.scrollingElement
-  const startX = window.scrollX
-  const startY = scrollingElement?.scrollTop ?? window.scrollY
+  preserveWindowScrollPositionAcrossFrames(
+    { x: window.scrollX, y: scrollingElement?.scrollTop ?? window.scrollY },
+    frames,
+    tolerance,
+    minDurationMs,
+    cancelOnTextSelectionChange,
+    cancelOnPointerMove
+  )
+}
+
+export const preserveWindowScrollPositionAcrossFrames = (
+  anchor: WindowScrollAnchor,
+  frames = 6,
+  tolerance = 4,
+  minDurationMs = 0,
+  cancelOnTextSelectionChange = false,
+  cancelOnPointerMove = true
+) => {
+  if (typeof window === "undefined" || typeof document === "undefined") return
+  const scrollingElement = document.scrollingElement
+  const startX = anchor.x
+  const startY = anchor.y
   const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now()
   let cancelled = false
   let frame = 0
@@ -122,16 +147,22 @@ export const preserveWindowScrollAcrossFrames = (
   }
   const cleanup = () => {
     window.removeEventListener("wheel", cancel, true)
-    window.removeEventListener("pointermove", cancel, true)
-    window.removeEventListener("mousemove", cancel, true)
-    window.removeEventListener("touchmove", cancel, true)
+    window.removeEventListener("pointerdown", cancel, true)
+    if (cancelOnPointerMove) {
+      window.removeEventListener("pointermove", cancel, true)
+      window.removeEventListener("mousemove", cancel, true)
+      window.removeEventListener("touchmove", cancel, true)
+    }
     window.removeEventListener("keydown", cancel, true)
     document.removeEventListener("selectionchange", cancelForTextSelection, true)
   }
   window.addEventListener("wheel", cancel, { capture: true, passive: true, once: true })
-  window.addEventListener("pointermove", cancel, { capture: true, passive: true, once: true })
-  window.addEventListener("mousemove", cancel, { capture: true, passive: true, once: true })
-  window.addEventListener("touchmove", cancel, { capture: true, passive: true, once: true })
+  window.addEventListener("pointerdown", cancel, { capture: true, passive: true, once: true })
+  if (cancelOnPointerMove) {
+    window.addEventListener("pointermove", cancel, { capture: true, passive: true, once: true })
+    window.addEventListener("mousemove", cancel, { capture: true, passive: true, once: true })
+    window.addEventListener("touchmove", cancel, { capture: true, passive: true, once: true })
+  }
   window.addEventListener("keydown", cancel, { capture: true, once: true })
   if (cancelOnTextSelectionChange) {
     document.addEventListener("selectionchange", cancelForTextSelection, true)
@@ -150,10 +181,14 @@ export const preserveWindowScrollAcrossFrames = (
       cleanup()
     }
   }
-  window.requestAnimationFrame(restore)
+  restore()
 }
 
 let preserveNextEditorPointerAfterTable = false
+
+export const markNextEditorPointerAfterTable = () => {
+  preserveNextEditorPointerAfterTable = true
+}
 
 const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES = 72
 const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS = 1_120
@@ -183,6 +218,14 @@ export const preserveWindowScrollForRichBlockSelectAll = () => {
   )
 }
 
+const preserveWindowScrollForTablePointerTextDrag = () => {
+  preserveWindowScrollAcrossFrames(
+    EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES,
+    4,
+    EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS
+  )
+}
+
 export const preserveWindowScrollForEditorPointerFocus = (
   target: EventTarget | null,
   tableSelectionActive: boolean,
@@ -193,24 +236,29 @@ export const preserveWindowScrollForEditorPointerFocus = (
   const editorPointerTarget = Boolean(targetElement?.closest(EDITOR_POINTER_SCROLL_PRESERVE_SELECTOR))
   const editorControlTarget = Boolean(targetElement?.closest(EDITOR_POINTER_SCROLL_CONTROL_SELECTOR))
   const editorRichBlockTarget = Boolean(targetElement?.closest(EDITOR_POINTER_SCROLL_RICH_BLOCK_SELECTOR))
-  const shouldPreserveRichEditorPointer = editorPointerTarget && editorRichBlockTarget
+  const shouldPreserveRichEditorPointer = editorPointerTarget && editorRichBlockTarget && !tablePointerTarget
   const shouldPreserveBlockSelectionPointer = editorPointerTarget && blockSelectionActive && !editorControlTarget
+  const shouldPreserveTableBlockSelectionPointer = tablePointerTarget && blockSelectionActive
   const shouldPreserveGeneralEditorPointer =
     editorPointerTarget && !editorRichBlockTarget && !editorControlTarget && !blockSelectionActive
   const shouldPreserveFollowUp = !tablePointerTarget && preserveNextEditorPointerAfterTable
   if (tablePointerTarget) {
-    preserveNextEditorPointerAfterTable = true
+    markNextEditorPointerAfterTable()
   } else if (shouldPreserveFollowUp) {
     preserveNextEditorPointerAfterTable = false
   }
   if (
     shouldPreserveRichEditorPointer ||
     shouldPreserveBlockSelectionPointer ||
-    tablePointerTarget ||
+    shouldPreserveTableBlockSelectionPointer ||
     tableSelectionActive ||
     shouldPreserveFollowUp
   ) {
     preserveWindowScrollForRichBlockSelectAll()
+    return
+  }
+  if (tablePointerTarget) {
+    preserveWindowScrollForTablePointerTextDrag()
     return
   }
   if (shouldPreserveGeneralEditorPointer) {

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -43,6 +43,7 @@ import {
   resolveCodeBlockPasteRange,
   selectCodeBlockText,
   selectDomTextContents,
+  selectDomTextOffsetRange,
 } from "./codeBlockNodeViewSelectionModel"
 import { focusElementWithoutScroll } from "./blockEditorEngineDocumentModel"
 import { preserveWindowScrollForRichBlockSelectAll } from "./blockHandleLayoutModel"
@@ -179,26 +180,47 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     [editor]
   )
 
-  const handleCodePointerDownCapture = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
-      const contentRoot =
-        shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
-      lastActiveCodeBlockContentRoot = contentRoot
+  const selectCodeDomTextRange = useCallback(
+    (contentRoot: HTMLElement | null, anchorPos: number, headPos: number) => {
+      if (typeof getPos !== "function" || !contentRoot) return false
+      const codeBlockPos = getPos()
+      if (typeof codeBlockPos !== "number") return false
+      const from = codeBlockPos + 1
+      return selectDomTextOffsetRange(contentRoot, anchorPos - from, headPos - from)
     },
-    []
+    [getPos]
   )
 
-  const handleCodeMouseDownCapture = useCallback(
-    (event: ReactMouseEvent<HTMLDivElement>) => {
+  const preserveCodeDomTextRange = useCallback(
+    (contentRoot: HTMLElement | null, anchorPos: number, headPos: number) => {
+      const selectRange = () => {
+        if (!selectCodeDomTextRange(contentRoot, anchorPos, headPos)) {
+          selectDomTextContents(contentRoot)
+        }
+      }
+      selectRange()
+      window.requestAnimationFrame(selectRange)
+    },
+    [selectCodeDomTextRange]
+  )
+
+  const startCodeDragSelection = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement> | ReactPointerEvent<HTMLDivElement>) => {
+      const shell = shellRef.current
       const contentRoot =
-        shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
+        shell?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
       if (event.button !== 0 || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return
-      if (!contentRoot || !(event.target instanceof Node) || !contentRoot.contains(event.target)) return
+      if (!shell || !contentRoot || !(event.target instanceof Node) || !shell.contains(event.target)) return
+      const targetElement = event.target instanceof Element ? event.target : event.target.parentElement
+      const isCodeTextSurfaceTarget =
+        contentRoot.contains(event.target) || Boolean(targetElement?.closest(".aq-code-highlight-layer"))
+      if (!isCodeTextSurfaceTarget) return
       const anchorPos = resolveCodeTextPosFromPointer(event.clientX, event.clientY, contentRoot)
       if (typeof anchorPos !== "number") return
       event.preventDefault()
       event.stopPropagation()
       lastActiveCodeBlockContentRoot = contentRoot
+      window.getSelection()?.removeAllRanges()
       codeDragSelectionRef.current = {
         active: false,
         anchorPos,
@@ -209,6 +231,29 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       focusElementWithoutScroll(editor.view.dom as HTMLElement)
     },
     [applyCodeTextSelection, editor.view.dom, resolveCodeTextPosFromPointer]
+  )
+
+  const handleCodePointerDownCapture = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const contentRoot =
+        shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
+      lastActiveCodeBlockContentRoot = contentRoot
+      if (event.pointerType && event.pointerType !== "mouse") return
+      startCodeDragSelection(event)
+    },
+    [startCodeDragSelection]
+  )
+
+  const handleCodeMouseDownCapture = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      if (codeDragSelectionRef.current) {
+        event.preventDefault()
+        event.stopPropagation()
+        return
+      }
+      startCodeDragSelection(event)
+    },
+    [startCodeDragSelection]
   )
 
   useEffect(() => {
@@ -227,6 +272,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       event.preventDefault()
       event.stopPropagation()
       applyCodeTextSelection(session.anchorPos, headPos)
+      preserveCodeDomTextRange(contentRoot, session.anchorPos, headPos)
     }
 
     const handleWindowMouseUp = (event: MouseEvent) => {
@@ -234,6 +280,12 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       if (!session) return
       codeDragSelectionRef.current = null
       if (!session.active) return
+      const contentRoot =
+        shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
+      const headPos = resolveCodeTextPosFromPointer(event.clientX, event.clientY, contentRoot)
+      if (typeof headPos === "number") {
+        preserveCodeDomTextRange(contentRoot, session.anchorPos, headPos)
+      }
       event.preventDefault()
       event.stopPropagation()
     }
@@ -244,7 +296,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       window.removeEventListener("mousemove", handleWindowMouseMove, true)
       window.removeEventListener("mouseup", handleWindowMouseUp, true)
     }
-  }, [applyCodeTextSelection, resolveCodeTextPosFromPointer])
+  }, [applyCodeTextSelection, preserveCodeDomTextRange, resolveCodeTextPosFromPointer])
 
   const ensureCodeDomTextSelection = useCallback((contentRoot: HTMLElement | null) => {
     if (!contentRoot || typeof window === "undefined") return

--- a/front/src/components/editor/codeBlockNodeViewSelectionModel.ts
+++ b/front/src/components/editor/codeBlockNodeViewSelectionModel.ts
@@ -29,6 +29,48 @@ export const selectDomTextContents = (root: HTMLElement | null) => {
   return true
 }
 
+export const selectDomTextOffsetRange = (
+  root: HTMLElement | null,
+  fromOffset: number,
+  toOffset: number
+) => {
+  if (!root) return false
+  const selection = window.getSelection()
+  if (!selection) return false
+
+  const textLength = root.textContent?.length ?? 0
+  const startOffset = Math.max(0, Math.min(textLength, Math.min(fromOffset, toOffset)))
+  const endOffset = Math.max(0, Math.min(textLength, Math.max(fromOffset, toOffset)))
+  if (startOffset === endOffset) return false
+
+  const resolveTextPosition = (offset: number) => {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+    let remaining = offset
+    let current = walker.nextNode()
+    while (current) {
+      const currentLength = current.textContent?.length ?? 0
+      if (remaining <= currentLength) {
+        return { node: current, offset: remaining }
+      }
+      remaining -= currentLength
+      current = walker.nextNode()
+    }
+    return null
+  }
+
+  const start = resolveTextPosition(startOffset)
+  const end = resolveTextPosition(endOffset)
+  if (!start || !end) return false
+
+  const range = document.createRange()
+  range.setStart(start.node, start.offset)
+  range.setEnd(end.node, end.offset)
+  selection.removeAllRanges()
+  selection.addRange(range)
+  root.focus()
+  return true
+}
+
 export const selectCodeBlockText = ({ editor, getPos, nodeSize }: CodeBlockPositionArgs) => {
   if (typeof getPos !== "function") return false
   const codeBlockPos = getPos()

--- a/front/src/components/editor/codeBlockNodeViewStyles.tsx
+++ b/front/src/components/editor/codeBlockNodeViewStyles.tsx
@@ -215,8 +215,8 @@ export const CodeBlockEditorSurface = styled.div`
 
   .aq-code-highlight-layer {
     pointer-events: none;
-    user-select: none;
-    -webkit-user-select: none;
+    user-select: text;
+    -webkit-user-select: text;
     background: transparent;
     color: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray11 : "#a9b7c6")};
 

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -1,5 +1,9 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
-import { preserveWindowScrollForRichBlockSelectAll } from "./blockHandleLayoutModel"
+import {
+  preserveWindowScrollForRichBlockSelectAll,
+  preserveWindowScrollPositionAcrossFrames,
+  type WindowScrollAnchor,
+} from "./blockHandleLayoutModel"
 
 export const isPrimarySelectAllKeyboardEvent = (event: KeyboardEvent) => {
   if (event.defaultPrevented || event.altKey || event.shiftKey) return false
@@ -14,6 +18,8 @@ const resolveElement = (target: EventTarget | Node | null | undefined) => {
 }
 
 let lastActiveTableCell: HTMLElement | null = null
+const TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES = 24
+const TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS = 720
 
 export const rememberActiveTableCellFromTarget = (
   eventTarget: EventTarget | Node | null | undefined,
@@ -56,5 +62,66 @@ export const selectActiveTableCellText = (
   preserveWindowScrollForRichBlockSelectAll()
   selection.removeAllRanges()
   selection.addRange(range)
+  return true
+}
+
+export const restoreTableCellTextSelectionIfEscaped = (
+  editor: TiptapEditor,
+  startedCell: HTMLElement | null,
+  scrollAnchor?: WindowScrollAnchor | null,
+  restoreWhenEmpty = false,
+  forceStartedCellSelection = false
+) => {
+  if (typeof window === "undefined" || typeof document === "undefined") return false
+  if (!startedCell?.isConnected || !editor.view.dom.contains(startedCell)) return false
+
+  const selection = window.getSelection()
+  if (!selection) return false
+
+  const anchorElement = resolveElement(selection.anchorNode)
+  const focusElement = resolveElement(selection.focusNode)
+  const hasTextSelection = selection.toString().trim().length > 0
+  if (
+    hasTextSelection &&
+    ((anchorElement && startedCell.contains(anchorElement)) ||
+      (focusElement && startedCell.contains(focusElement)))
+  ) {
+    startedCell.setAttribute("data-table-drag-selection-text", selection.toString())
+    if (!forceStartedCellSelection) {
+      return true
+    }
+  }
+  if (!hasTextSelection && !restoreWhenEmpty) return false
+
+  const anchorCell = anchorElement?.closest("th, td")
+  const focusCell = focusElement?.closest("th, td")
+  const startedTable = startedCell.closest("table")
+  if (
+    hasTextSelection &&
+    !forceStartedCellSelection &&
+    startedTable &&
+    ((anchorCell && startedTable.contains(anchorCell)) ||
+      (focusCell && startedTable.contains(focusCell)))
+  ) {
+    return false
+  }
+
+  const range = document.createRange()
+  range.selectNodeContents(startedCell)
+  selection.removeAllRanges()
+  selection.addRange(range)
+  startedCell.setAttribute("data-table-drag-selection-text", selection.toString())
+  if (scrollAnchor) {
+    preserveWindowScrollPositionAcrossFrames(
+      scrollAnchor,
+      TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES,
+      4,
+      TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS,
+      false,
+      false
+    )
+  } else {
+    preserveWindowScrollForRichBlockSelectAll()
+  }
   return true
 }

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -1,9 +1,15 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
 import { TextSelection } from "@tiptap/pm/state"
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from "react"
-import { preserveWindowScrollForEditorPointerFocus } from "./blockHandleLayoutModel"
+import {
+  markNextEditorPointerAfterTable,
+  preserveWindowScrollForEditorPointerFocus,
+  preserveWindowScrollPositionAcrossFrames,
+  type WindowScrollAnchor,
+} from "./blockHandleLayoutModel"
 import { isTableSelectionActive } from "./tableStructureModel"
+import { restoreTableCellTextSelectionIfEscaped } from "./tableTextSelectionModel"
 import {
   areFloatingBubbleStatesEqual,
   hideFloatingBubbleState,
@@ -52,10 +58,171 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
   tableMenuState,
   tryStartTableColumnResizeFromDomHandle,
 }: UseBlockEditorEngineSelectionBubbleEffectsArgs) => {
+  const tableTextDragStartRef = useRef<{
+    cell: HTMLElement; scrollPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number
+  } | null>(null)
+  const codeTextDragStartRef = useRef<{ root: HTMLElement; x: number; y: number } | null>(null)
+
   useEffect(() => {
     const currentEditor = editorRef.current ?? editor
     if (!currentEditor) return
     let rafId: number | null = null
+    let codeDragSelectionPreserveRafId: number | null = null
+
+    const rememberTableTextDragStart = (event: MouseEvent | PointerEvent) => {
+      if (event.button !== 0) return null
+      const activeEditor = editorRef.current ?? currentEditor
+      if (!activeEditor) return null
+      if (!(event.target instanceof Node) || !activeEditor.view.dom.contains(event.target)) {
+        tableTextDragStartRef.current = null
+        return null
+      }
+      const targetElement = event.target instanceof Element ? event.target : event.target.parentElement
+      const tableTextCell = targetElement?.closest("th, td")
+      const scrollAnchor = {
+        x: window.scrollX,
+        y: document.scrollingElement?.scrollTop ?? window.scrollY,
+      }
+      if (tableTextCell instanceof HTMLElement) {
+        tableTextCell.removeAttribute("data-table-drag-selection-text")
+        markNextEditorPointerAfterTable()
+      }
+      tableTextDragStartRef.current =
+        tableTextCell instanceof HTMLElement
+          ? { cell: tableTextCell, scrollPreserveStarted: false, scrollAnchor, x: event.clientX, y: event.clientY }
+          : null
+      return tableTextDragStartRef.current
+    }
+
+    const hasMovedTableTextDrag = (event: MouseEvent | PointerEvent) => {
+      const tableTextDragStart = tableTextDragStartRef.current
+      return Boolean(
+        tableTextDragStart &&
+          (Math.abs(event.clientX - tableTextDragStart.x) > 4 ||
+            Math.abs(event.clientY - tableTextDragStart.y) > 4)
+      )
+    }
+
+    const restoreActiveTableTextDragSelection = (
+      restoreWhenEmpty = false,
+      forceStartedCellSelection = false
+    ) => {
+      const activeEditor = editorRef.current ?? currentEditor
+      const tableTextDragStart = tableTextDragStartRef.current
+      if (!activeEditor || !tableTextDragStart) return false
+      return restoreTableCellTextSelectionIfEscaped(
+        activeEditor,
+        tableTextDragStart.cell,
+        tableTextDragStart.scrollAnchor,
+        restoreWhenEmpty,
+        forceStartedCellSelection
+      )
+    }
+
+    const preserveActiveTableTextDragScroll = () => {
+      const tableTextDragStart = tableTextDragStartRef.current
+      if (!tableTextDragStart || tableTextDragStart.scrollPreserveStarted) return
+      tableTextDragStart.scrollPreserveStarted = true
+      preserveWindowScrollPositionAcrossFrames(tableTextDragStart.scrollAnchor, 24, 4, 720, false, false)
+    }
+
+    const isSelectionInsideCodeDragRoot = (root: HTMLElement) => {
+      const selection = window.getSelection()
+      if (!selection) return false
+      const anchorElement =
+        selection.anchorNode instanceof Element
+          ? selection.anchorNode
+          : selection.anchorNode?.parentElement ?? null
+      const focusElement =
+        selection.focusNode instanceof Element
+          ? selection.focusNode
+          : selection.focusNode?.parentElement ?? null
+      const selectionInsideCodeRoot =
+        Boolean(anchorElement && root.contains(anchorElement)) ||
+        Boolean(focusElement && root.contains(focusElement))
+      return Boolean(selection.toString().trim() && selectionInsideCodeRoot)
+    }
+
+    const selectCodeDragRoot = (root: HTMLElement) => {
+      const selection = window.getSelection()
+      if (!selection) return false
+      root.focus({ preventScroll: true })
+      const range = document.createRange()
+      range.selectNodeContents(root)
+      selection.removeAllRanges()
+      selection.addRange(range)
+      root.closest(".aq-code-shell")?.setAttribute("data-code-drag-selection-text", selection.toString())
+      return true
+    }
+
+    const preserveCodeDragRootSelectionAcrossFrames = (root: HTMLElement) => {
+      if (codeDragSelectionPreserveRafId !== null) return
+      const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now()
+      let frame = 0
+      let restoring = false
+      const restoreIfMissing = () => {
+        if (!root.isConnected) return false
+        if (isSelectionInsideCodeDragRoot(root)) return true
+        restoring = true
+        selectCodeDragRoot(root)
+        restoring = false
+        return true
+      }
+      const handlePreservedSelectionChange = () => {
+        if (restoring) return
+        restoreIfMissing()
+      }
+      const cleanupPreservedSelection = () => {
+        document.removeEventListener("selectionchange", handlePreservedSelectionChange, true)
+        window.removeEventListener("pointerdown", cancelPreservedSelection, true)
+      }
+      const cancelPreservedSelection = () => {
+        if (codeDragSelectionPreserveRafId !== null) {
+          window.cancelAnimationFrame(codeDragSelectionPreserveRafId)
+        }
+        codeDragSelectionPreserveRafId = null
+        cleanupPreservedSelection()
+      }
+      const restore = () => {
+        if (!root.isConnected) {
+          codeDragSelectionPreserveRafId = null
+          cleanupPreservedSelection()
+          return
+        }
+        restoreIfMissing()
+        frame += 1
+        const elapsedMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt
+        if (frame < 72 || elapsedMs < 1_120) {
+          codeDragSelectionPreserveRafId = window.requestAnimationFrame(restore)
+        } else {
+          codeDragSelectionPreserveRafId = null
+          cleanupPreservedSelection()
+        }
+      }
+      document.addEventListener("selectionchange", handlePreservedSelectionChange, true)
+      window.addEventListener("pointerdown", cancelPreservedSelection, { capture: true, passive: true, once: true })
+      restore()
+    }
+
+    const selectCodeDragRootWhenNativeSelectionIsMissing = () => {
+      const codeTextDragStart = codeTextDragStartRef.current
+      if (!codeTextDragStart?.root.isConnected) return false
+      if (isSelectionInsideCodeDragRoot(codeTextDragStart.root)) return false
+      const selected = selectCodeDragRoot(codeTextDragStart.root)
+      if (selected) {
+        preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root)
+      }
+      return selected
+    }
+
+    const hasMovedCodeTextDrag = (event: MouseEvent | PointerEvent) => {
+      const codeTextDragStart = codeTextDragStartRef.current
+      return Boolean(
+        codeTextDragStart &&
+          (Math.abs(event.clientX - codeTextDragStart.x) > 4 ||
+            Math.abs(event.clientY - codeTextDragStart.y) > 4)
+      )
+    }
 
     const syncBubble = () => {
       const activeEditor = editorRef.current ?? currentEditor
@@ -212,6 +379,10 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         clearWindowTextSelection()
         return
       }
+      if (restoreActiveTableTextDragSelection()) {
+        syncBubbleOnMouseUpRef.current = true
+        return
+      }
       const selection = window.getSelection()
       const anchorNode = selection?.anchorNode ?? null
       const anchorElement =
@@ -224,14 +395,48 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       if (event.pointerType !== "mouse" || event.button !== 0) return
       const activeEditor = editorRef.current ?? currentEditor
       if (!activeEditor) return
-      if (!(event.target instanceof Node) || !activeEditor.view.dom.contains(event.target)) return
-      preserveWindowScrollForEditorPointerFocus(event.target, isTableSelectionActive(activeEditor))
+      const eventTarget = event.target
+      const targetElement =
+        eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
+      const codeShellTarget = targetElement?.closest(".aq-code-shell")
+      const insideEditorDom = eventTarget instanceof Node && activeEditor.view.dom.contains(eventTarget)
+      if (!insideEditorDom && !codeShellTarget) return
+      if (codeShellTarget) {
+        const codeContentRoot = codeShellTarget.querySelector<HTMLElement>(".aq-code-editor-content")
+        const codeSelectionRoot =
+          codeShellTarget.querySelector<HTMLElement>(".aq-code-highlight-layer") ?? codeContentRoot
+        codeShellTarget.removeAttribute("data-code-drag-selection-text")
+        codeTextDragStartRef.current = codeSelectionRoot
+          ? {
+              root: codeSelectionRoot,
+              x: event.clientX,
+              y: event.clientY,
+            }
+          : null
+        clearWindowTextSelection()
+        event.preventDefault()
+        event.stopPropagation()
+      } else {
+        codeTextDragStartRef.current = null
+      }
+      if (insideEditorDom) {
+        rememberTableTextDragStart(event)
+        const blockSelectionActive = Boolean(
+          document.querySelector("[data-testid='keyboard-block-selection-overlay']")
+        )
+        preserveWindowScrollForEditorPointerFocus(
+          event.target,
+          isTableSelectionActive(activeEditor),
+          blockSelectionActive
+        )
+      }
       if (tryStartTableColumnResizeFromDomHandle(event.target, event.pointerId, event.clientX)) {
         event.preventDefault()
         event.stopPropagation()
         event.stopImmediatePropagation?.()
         mouseTextSelectionInProgressRef.current = false
         syncBubbleOnMouseUpRef.current = false
+        tableTextDragStartRef.current = null
         return
       }
       mouseTextSelectionInProgressRef.current = true
@@ -245,16 +450,83 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     const handleEditorMouseDownCapture = (event: MouseEvent) => {
       const activeEditor = editorRef.current ?? currentEditor
       if (!activeEditor) return
-      if (!(event.target instanceof Node) || !activeEditor.view.dom.contains(event.target)) return
-      if (!(event.target instanceof Element) || !event.target.closest(".column-resize-handle")) return
+      const eventTarget = event.target
+      const targetElement =
+        eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
+      const codeShellTarget = targetElement?.closest(".aq-code-shell")
+      const insideEditorDom = eventTarget instanceof Node && activeEditor.view.dom.contains(eventTarget)
+      if (!insideEditorDom && !codeShellTarget) return
+      if (codeTextDragStartRef.current && !codeShellTarget) {
+        event.preventDefault()
+        event.stopPropagation()
+        event.stopImmediatePropagation?.()
+        return
+      }
+      if (codeShellTarget) {
+        const codeContentRoot = codeShellTarget.querySelector<HTMLElement>(".aq-code-editor-content")
+        const codeSelectionRoot =
+          codeShellTarget.querySelector<HTMLElement>(".aq-code-highlight-layer") ?? codeContentRoot
+        codeShellTarget.removeAttribute("data-code-drag-selection-text")
+        codeTextDragStartRef.current = codeSelectionRoot
+          ? {
+              root: codeSelectionRoot,
+              x: event.clientX,
+              y: event.clientY,
+            }
+          : null
+        clearWindowTextSelection()
+      }
+      if (!insideEditorDom) return
+      rememberTableTextDragStart(event)
+      if (!targetElement?.closest(".column-resize-handle")) return
       event.preventDefault()
       event.stopPropagation()
       event.stopImmediatePropagation?.()
     }
 
-    const handleWindowPointerUp = (event: PointerEvent) => {
-      if (!mouseTextSelectionInProgressRef.current) return
+    const handleWindowPointerMove = (event: PointerEvent) => {
       if (event.pointerType && event.pointerType !== "mouse") return
+      if (hasMovedCodeTextDrag(event)) {
+        selectCodeDragRootWhenNativeSelectionIsMissing()
+      }
+      if (!hasMovedTableTextDrag(event)) return
+      preserveActiveTableTextDragScroll()
+      if (restoreActiveTableTextDragSelection(true)) {
+        syncBubbleOnMouseUpRef.current = true
+      }
+    }
+
+    const handleWindowMouseMove = (event: MouseEvent) => {
+      if (hasMovedCodeTextDrag(event)) {
+        selectCodeDragRootWhenNativeSelectionIsMissing()
+      }
+      if (!hasMovedTableTextDrag(event)) return
+      preserveActiveTableTextDragScroll()
+      if (restoreActiveTableTextDragSelection(true)) {
+        syncBubbleOnMouseUpRef.current = true
+      }
+    }
+
+    const handleWindowPointerUp = (event: PointerEvent) => {
+      const tableTextDragStart = tableTextDragStartRef.current
+      const codeTextDragStart = codeTextDragStartRef.current
+      if (!mouseTextSelectionInProgressRef.current && !tableTextDragStart && !codeTextDragStart) return
+      if (event.pointerType && event.pointerType !== "mouse") return
+      const activeEditor = editorRef.current ?? currentEditor
+      const tableTextDragMoved = hasMovedTableTextDrag(event)
+      if (hasMovedCodeTextDrag(event)) {
+        selectCodeDragRootWhenNativeSelectionIsMissing()
+      }
+      if (
+        activeEditor &&
+          tableTextDragMoved &&
+          restoreActiveTableTextDragSelection(true, true)
+      ) {
+        preserveActiveTableTextDragScroll()
+        syncBubbleOnMouseUpRef.current = true
+      }
+      tableTextDragStartRef.current = null
+      codeTextDragStartRef.current = null
       mouseTextSelectionInProgressRef.current = false
       if (!syncBubbleOnMouseUpRef.current) return
       syncBubbleOnMouseUpRef.current = false
@@ -269,6 +541,8 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     document.addEventListener("mousedown", handleEditorMouseDownCapture, true)
     window.addEventListener("scroll", scheduleSyncBubble, { capture: true, passive: true })
     window.addEventListener("resize", scheduleSyncBubble, { passive: true })
+    window.addEventListener("pointermove", handleWindowPointerMove, true)
+    window.addEventListener("mousemove", handleWindowMouseMove, true)
     window.addEventListener("pointerup", handleWindowPointerUp, true)
     window.addEventListener("pointercancel", handleWindowPointerUp, true)
     return () => {
@@ -279,13 +553,20 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       document.removeEventListener("mousedown", handleEditorMouseDownCapture, true)
       window.removeEventListener("scroll", scheduleSyncBubble, true)
       window.removeEventListener("resize", scheduleSyncBubble)
+      window.removeEventListener("pointermove", handleWindowPointerMove, true)
+      window.removeEventListener("mousemove", handleWindowMouseMove, true)
       window.removeEventListener("pointerup", handleWindowPointerUp, true)
       window.removeEventListener("pointercancel", handleWindowPointerUp, true)
       if (rafId !== null && typeof window !== "undefined") {
         window.cancelAnimationFrame(rafId)
       }
+      if (codeDragSelectionPreserveRafId !== null && typeof window !== "undefined") {
+        window.cancelAnimationFrame(codeDragSelectionPreserveRafId)
+      }
       mouseTextSelectionInProgressRef.current = false
       syncBubbleOnMouseUpRef.current = false
+      tableTextDragStartRef.current = null
+      codeTextDragStartRef.current = null
       cancelBubbleHide()
     }
   }, [


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- `/editor/507` 배포본에서 table cell drag selection이 다른 table/cell anchor로 튀는 live 회귀를 복구합니다.
- Table drag scroll anchor 보존과 code highlight-layer drag selection fallback을 보강해 body/table/code drag selection이 같은 블럭에 머물도록 합니다.

## 작업 내용

- Table cell pointerdown scroll anchor를 drag selection restore 경로와 묶어 viewport가 시작 cell 위치를 벗어나지 않도록 했습니다.
- Table click preserve와 table 이후 editor pointer marker를 분리해 stale block-selection reveal과 다음 drag anchor drift를 동시에 막았습니다.
- Code block drag selection은 highlight layer 기준 fallback selection 상태를 유지하고, 관련 E2E가 fallback attr까지 읽도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-body-click-flicker.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-rich-focus.spec.ts e2e/editor-authoring-route-rich-select-all.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-affordances.spec.ts:547 --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front test:e2e:authoring`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: Editor pointer/selection preserve 경로가 겹치는 table/code drag interaction 회귀
- 롤백 방법: 이 PR의 `fix(editor): table drag live 선택 복구` 커밋을 revert

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
