### PR TITLE
[Fix] front live build drift guard 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -872,6 +872,7 @@ jobs:
       E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL || '' }}
       E2E_ADMIN_USERNAME: ${{ secrets.E2E_ADMIN_USERNAME || '' }}
       E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD || '' }}
+      E2E_EXPECTED_FRONT_COMMIT_SHA: ${{ needs.calculateTag.outputs.deploy_sha }}
 
     steps:
       - name: Checkout
@@ -1067,6 +1068,8 @@ jobs:
           PREFLIGHT_SLEEP_SECONDS="${E2E_PREFLIGHT_SLEEP_SECONDS:-3}"
           PREFLIGHT_CURL_RETRY="${E2E_PREFLIGHT_CURL_RETRY:-2}"
           PREFLIGHT_FORCE_IPV4="${E2E_PREFLIGHT_FORCE_IPV4:-true}"
+          FRONT_BUILD_METADATA_ATTEMPTS="${E2E_FRONT_BUILD_METADATA_ATTEMPTS:-20}"
+          FRONT_BUILD_METADATA_SLEEP_SECONDS="${E2E_FRONT_BUILD_METADATA_SLEEP_SECONDS:-6}"
 
           curl_args=(
             -sS
@@ -1129,6 +1132,32 @@ jobs:
           if [ "${front_ok}" -ne 1 ]; then
             echo "preflight failed for front-login: ${front_base}/login" >&2
             exit 1
+          fi
+
+          if [ -n "${E2E_EXPECTED_FRONT_COMMIT_SHA:-}" ]; then
+            front_build_ok=0
+            for attempt in $(seq 1 "${FRONT_BUILD_METADATA_ATTEMPTS}"); do
+              front_html="$(
+                curl "${curl_args[@]}" \
+                  -L \
+                  "${front_base}/login?next=%2Fadmin&frontBuildCheck=${E2E_EXPECTED_FRONT_COMMIT_SHA}" || true
+              )"
+              front_build_sha="$(
+                printf '%s' "${front_html}" |
+                  sed -nE 's/.*<meta name="aquila-build-sha" content="([^"]*)".*/\1/p' |
+                  head -n 1
+              )"
+              echo "[preflight] front-build-sha attempt=${attempt} expected=${E2E_EXPECTED_FRONT_COMMIT_SHA} actual=${front_build_sha:-missing}"
+              if [ "${front_build_sha}" = "${E2E_EXPECTED_FRONT_COMMIT_SHA}" ]; then
+                front_build_ok=1
+                break
+              fi
+              sleep "${FRONT_BUILD_METADATA_SLEEP_SECONDS}"
+            done
+            if [ "${front_build_ok}" -ne 1 ]; then
+              echo "preflight failed: live frontend build metadata does not match deploy sha" >&2
+              exit 1
+            fi
           fi
 
           api_ok=0

--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -20,6 +20,7 @@ import {
 
 const hasLiveCredentials = Boolean((adminEmail || adminLegacyLoginId) && adminPassword)
 const hasUiLoginCredentials = Boolean(adminEmail && adminPassword)
+const expectedFrontendCommitSha = process.env.E2E_EXPECTED_FRONT_COMMIT_SHA?.trim() || ""
 const adminLandingHeadingPattern = /(?:오늘 블로그 운영은 이 흐름으로 정리됩니다|관리자 (?:작업 공간|작업 진입점|운영 허브|허브))/
 const adminDashboardHeadingPattern = /(?:지금 확인해야 할 운영 상태|운영 대시보드)/
 const adminProfileHeadingPattern =
@@ -502,6 +503,19 @@ test.describe("live critical error filter", () => {
     expect(
       isWebKitCorsAccessControlNoise("https://cdn.example.com/widget.js due to access control checks.")
     ).toBe(false)
+  })
+})
+
+test.describe("live frontend build metadata", () => {
+  test("custom domain이 배포 대상 commit의 front build를 서빙한다", async ({ page }) => {
+    test.skip(!expectedFrontendCommitSha, "E2E_EXPECTED_FRONT_COMMIT_SHA is required")
+
+    await page.goto("/login?next=%2Fadmin")
+
+    const buildSha = await page.evaluate(() =>
+      document.querySelector('meta[name="aquila-build-sha"]')?.getAttribute("content") ?? null
+    )
+    expect(buildSha).toBe(expectedFrontendCommitSha)
   })
 })
 

--- a/front/src/pages/_document.tsx
+++ b/front/src/pages/_document.tsx
@@ -91,6 +91,13 @@ const CLIENT_RUNTIME_RECOVERY_SCRIPT = `
 })();
 `
 
+const AQUILA_BUILD_SHA =
+  process.env.AQUILA_BUILD_SHA ||
+  process.env.NEXT_PUBLIC_AQUILA_BUILD_SHA ||
+  process.env.VERCEL_GIT_COMMIT_SHA ||
+  process.env.GITHUB_SHA ||
+  "unknown"
+
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
     const originalRenderPage = ctx.renderPage
@@ -137,6 +144,7 @@ class MyDocument extends Document {
             title="RSS 2.0"
             href="/feed"
           ></link>
+          <meta name="aquila-build-sha" content={AQUILA_BUILD_SHA} />
           {/* google search console */}
           {CONFIG.googleSearchConsole.enable === true && (
             <>


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- Vercel production deployment가 success여도 custom domain이 이전 front build를 계속 서빙하면 live e2e가 통과하던 운영 결함을 막습니다.
- 배포 대상 commit SHA를 HTML metadata로 노출하고, live preflight/e2e가 custom domain HTML의 build metadata와 deploy SHA 일치를 검증합니다.

## 작업 내용

- `aquila-build-sha` meta tag를 `_document`에서 렌더링해 배포본 HTML이 어떤 commit build인지 확인할 수 있게 했습니다.
- `live.spec.ts`에 `E2E_EXPECTED_FRONT_COMMIT_SHA` 기반 custom domain build metadata 검증을 추가했습니다.
- `Deploy to Home Server` live preflight가 Playwright 실행 전에 custom domain HTML의 front build SHA 불일치를 fail-fast로 잡도록 했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `AQUILA_BUILD_SHA=2b87075273d78d42bfb043783d6280fee6e447c3 yarn --cwd front build`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front check:bundle-size`
  - `E2E_EXPECTED_FRONT_COMMIT_SHA=2b87075273d78d42bfb043783d6280fee6e447c3 PLAYWRIGHT_USE_WEBSERVER=false PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/live.spec.ts --grep 'custom domain이 배포 대상 commit의 front build를 서빙한다' --workers=1` (2회 연속 통과)
  - RED 확인: 같은 live metadata test를 `https://www.aquilaxk.site`와 PR #471 merge SHA 조건으로 실행했을 때 기존 배포본은 `buildSha=null`로 실패했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: custom domain propagation이 지연되면 live preflight가 실패해 stale front build 배포를 중단합니다.
- 롤백 방법: 이 PR revert 후 기존 live e2e 경로로 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
