### PR TITLE
[Fix] live chrome table code 선택 복구

### DIFF
--- a/front/e2e/editor-authoring-selection-drag.spec.ts
+++ b/front/e2e/editor-authoring-selection-drag.spec.ts
@@ -19,6 +19,7 @@ const isLocalResourceConsoleNoise = (text: string) =>
 const dragSelectWord = async (page: Page, editable: Locator, word: string) => {
   await editable.scrollIntoViewIfNeeded()
   const points = await getWordDragPoints(editable, word)
+  const beforeScrollTop = await page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
 
   await page.mouse.move(points.startX, points.startY)
   await page.mouse.down()
@@ -91,6 +92,8 @@ const dragSelectWord = async (page: Page, editable: Locator, word: string) => {
     )
     throw new Error(`drag selection did not include "${word}": ${JSON.stringify(diagnostics)}`)
   }
+  const afterScrollTop = await page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+  expect(Math.abs(afterScrollTop - beforeScrollTop), `${word} drag 이후 scrollTop이 유지되어야 합니다`).toBeLessThanOrEqual(24)
 }
 
 const expectSelectionScopedToWord = async (page: Page, word: string, unrelatedWords: string[]) => {
@@ -206,7 +209,12 @@ test.describe("editor authoring route text selection drag", () => {
     await page.setViewportSize({ width: 980, height: 720 })
 
     await dragSelectWord(page, editor.locator("p", { hasText: bodyLabel }).first(), bodyLabel)
-    await dragSelectWord(page, editor.locator(".aq-code-editor-content", { hasText: codeLabel }).first(), codeLabel)
+    const codeContent = editor.locator(".aq-code-editor-content", { hasText: codeLabel }).first()
+    await dragSelectWord(page, codeContent, codeLabel)
+    await expectSelectionScopedToWord(page, codeLabel, [bodyLabel, tableLabel])
+    const codePoints = await getWordDragPoints(codeContent, codeLabel)
+    await page.mouse.click(codePoints.startX, codePoints.startY)
+    await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A")
     await expectSelectionScopedToWord(page, codeLabel, [bodyLabel, tableLabel])
     await dragSelectWord(page, editor.locator("table th, table td", { hasText: tableLabel }).first(), tableLabel)
     await expectSelectionScopedToWord(page, tableLabel, [bodyLabel, codeLabel])

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -342,6 +342,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       } else if (lastActiveCodeBlockContentRoot === contentRoot) {
         lastActiveCodeBlockContentRoot = null
       }
+      if (!contentRoot.contains(target)) codeDragSelectionRef.current = null
     }
 
     const handleDocumentSelectAll = (event: KeyboardEvent) => {

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -18,8 +18,8 @@ const resolveElement = (target: EventTarget | Node | null | undefined) => {
 }
 
 let lastActiveTableCell: HTMLElement | null = null
-const TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES = 24
-const TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS = 720
+const TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES = 72
+const TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS = 1_120
 
 export const rememberActiveTableCellFromTarget = (
   eventTarget: EventTarget | Node | null | undefined,

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -68,6 +68,17 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     if (!currentEditor) return
     let rafId: number | null = null
     let codeDragSelectionPreserveRafId: number | null = null
+    let cleanupCodeDragSelectionPreserve: (() => void) | null = null
+    const clearImmediateWindowTextSelection = () => window.getSelection()?.removeAllRanges()
+    const cancelCodeDragSelectionPreserve = () => {
+      if (codeDragSelectionPreserveRafId !== null) {
+        window.cancelAnimationFrame(codeDragSelectionPreserveRafId)
+        codeDragSelectionPreserveRafId = null
+      }
+      cleanupCodeDragSelectionPreserve?.()
+      cleanupCodeDragSelectionPreserve = null
+      document.querySelectorAll("[data-code-drag-selection-text]").forEach((element) => element.removeAttribute("data-code-drag-selection-text"))
+    }
 
     const rememberTableTextDragStart = (event: MouseEvent | PointerEvent) => {
       if (event.button !== 0) return null
@@ -123,9 +134,8 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const tableTextDragStart = tableTextDragStartRef.current
       if (!tableTextDragStart || tableTextDragStart.scrollPreserveStarted) return
       tableTextDragStart.scrollPreserveStarted = true
-      preserveWindowScrollPositionAcrossFrames(tableTextDragStart.scrollAnchor, 24, 4, 720, false, false)
+      preserveWindowScrollPositionAcrossFrames(tableTextDragStart.scrollAnchor, 72, 4, 1_120, false, false)
     }
-
     const isSelectionInsideCodeDragRoot = (root: HTMLElement) => {
       const selection = window.getSelection()
       if (!selection) return false
@@ -175,14 +185,9 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const cleanupPreservedSelection = () => {
         document.removeEventListener("selectionchange", handlePreservedSelectionChange, true)
         window.removeEventListener("pointerdown", cancelPreservedSelection, true)
+        window.removeEventListener("mousedown", cancelPreservedSelection, true)
       }
-      const cancelPreservedSelection = () => {
-        if (codeDragSelectionPreserveRafId !== null) {
-          window.cancelAnimationFrame(codeDragSelectionPreserveRafId)
-        }
-        codeDragSelectionPreserveRafId = null
-        cleanupPreservedSelection()
-      }
+      const cancelPreservedSelection = () => cancelCodeDragSelectionPreserve()
       const restore = () => {
         if (!root.isConnected) {
           codeDragSelectionPreserveRafId = null
@@ -201,6 +206,8 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       }
       document.addEventListener("selectionchange", handlePreservedSelectionChange, true)
       window.addEventListener("pointerdown", cancelPreservedSelection, { capture: true, passive: true, once: true })
+      window.addEventListener("mousedown", cancelPreservedSelection, { capture: true, passive: true, once: true })
+      cleanupCodeDragSelectionPreserve = cleanupPreservedSelection
       restore()
     }
 
@@ -402,10 +409,10 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const insideEditorDom = eventTarget instanceof Node && activeEditor.view.dom.contains(eventTarget)
       if (!insideEditorDom && !codeShellTarget) return
       if (codeShellTarget) {
-        const codeContentRoot = codeShellTarget.querySelector<HTMLElement>(".aq-code-editor-content")
+        cancelCodeDragSelectionPreserve()
         const codeSelectionRoot =
-          codeShellTarget.querySelector<HTMLElement>(".aq-code-highlight-layer") ?? codeContentRoot
-        codeShellTarget.removeAttribute("data-code-drag-selection-text")
+          codeShellTarget.querySelector<HTMLElement>(".aq-code-editor-content") ??
+          codeShellTarget.querySelector<HTMLElement>(".aq-code-highlight-layer")
         codeTextDragStartRef.current = codeSelectionRoot
           ? {
               root: codeSelectionRoot,
@@ -413,11 +420,13 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
               y: event.clientY,
             }
           : null
-        clearWindowTextSelection()
-        event.preventDefault()
-        event.stopPropagation()
+        clearImmediateWindowTextSelection()
       } else {
         codeTextDragStartRef.current = null
+        if (insideEditorDom) {
+          cancelCodeDragSelectionPreserve()
+          clearImmediateWindowTextSelection()
+        }
       }
       if (insideEditorDom) {
         rememberTableTextDragStart(event)
@@ -456,17 +465,12 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const codeShellTarget = targetElement?.closest(".aq-code-shell")
       const insideEditorDom = eventTarget instanceof Node && activeEditor.view.dom.contains(eventTarget)
       if (!insideEditorDom && !codeShellTarget) return
-      if (codeTextDragStartRef.current && !codeShellTarget) {
-        event.preventDefault()
-        event.stopPropagation()
-        event.stopImmediatePropagation?.()
-        return
-      }
+      if (codeTextDragStartRef.current && !codeShellTarget) codeTextDragStartRef.current = null
       if (codeShellTarget) {
-        const codeContentRoot = codeShellTarget.querySelector<HTMLElement>(".aq-code-editor-content")
+        cancelCodeDragSelectionPreserve()
         const codeSelectionRoot =
-          codeShellTarget.querySelector<HTMLElement>(".aq-code-highlight-layer") ?? codeContentRoot
-        codeShellTarget.removeAttribute("data-code-drag-selection-text")
+          codeShellTarget.querySelector<HTMLElement>(".aq-code-editor-content") ??
+          codeShellTarget.querySelector<HTMLElement>(".aq-code-highlight-layer")
         codeTextDragStartRef.current = codeSelectionRoot
           ? {
               root: codeSelectionRoot,
@@ -474,7 +478,11 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
               y: event.clientY,
             }
           : null
-        clearWindowTextSelection()
+        clearImmediateWindowTextSelection()
+      } else if (insideEditorDom) {
+        codeTextDragStartRef.current = null
+        cancelCodeDragSelectionPreserve()
+        clearImmediateWindowTextSelection()
       }
       if (!insideEditorDom) return
       rememberTableTextDragStart(event)
@@ -491,7 +499,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       }
       if (!hasMovedTableTextDrag(event)) return
       preserveActiveTableTextDragScroll()
-      if (restoreActiveTableTextDragSelection(true)) {
+      if (restoreActiveTableTextDragSelection(true, true)) {
         syncBubbleOnMouseUpRef.current = true
       }
     }
@@ -502,16 +510,16 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       }
       if (!hasMovedTableTextDrag(event)) return
       preserveActiveTableTextDragScroll()
-      if (restoreActiveTableTextDragSelection(true)) {
+      if (restoreActiveTableTextDragSelection(true, true)) {
         syncBubbleOnMouseUpRef.current = true
       }
     }
 
-    const handleWindowPointerUp = (event: PointerEvent) => {
+    const completeTextDragSelection = (event: PointerEvent | MouseEvent) => {
       const tableTextDragStart = tableTextDragStartRef.current
       const codeTextDragStart = codeTextDragStartRef.current
       if (!mouseTextSelectionInProgressRef.current && !tableTextDragStart && !codeTextDragStart) return
-      if (event.pointerType && event.pointerType !== "mouse") return
+      if ("pointerType" in event && event.pointerType && event.pointerType !== "mouse") return
       const activeEditor = editorRef.current ?? currentEditor
       const tableTextDragMoved = hasMovedTableTextDrag(event)
       if (hasMovedCodeTextDrag(event)) {
@@ -543,8 +551,9 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     window.addEventListener("resize", scheduleSyncBubble, { passive: true })
     window.addEventListener("pointermove", handleWindowPointerMove, true)
     window.addEventListener("mousemove", handleWindowMouseMove, true)
-    window.addEventListener("pointerup", handleWindowPointerUp, true)
-    window.addEventListener("pointercancel", handleWindowPointerUp, true)
+    window.addEventListener("pointerup", completeTextDragSelection, true)
+    window.addEventListener("pointercancel", completeTextDragSelection, true)
+    window.addEventListener("mouseup", completeTextDragSelection, true)
     return () => {
       currentEditor.off("selectionUpdate", scheduleSyncBubble)
       currentEditor.off("focus", scheduleSyncBubble)
@@ -555,14 +564,13 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       window.removeEventListener("resize", scheduleSyncBubble)
       window.removeEventListener("pointermove", handleWindowPointerMove, true)
       window.removeEventListener("mousemove", handleWindowMouseMove, true)
-      window.removeEventListener("pointerup", handleWindowPointerUp, true)
-      window.removeEventListener("pointercancel", handleWindowPointerUp, true)
+      window.removeEventListener("pointerup", completeTextDragSelection, true)
+      window.removeEventListener("pointercancel", completeTextDragSelection, true)
+      window.removeEventListener("mouseup", completeTextDragSelection, true)
       if (rafId !== null && typeof window !== "undefined") {
         window.cancelAnimationFrame(rafId)
       }
-      if (codeDragSelectionPreserveRafId !== null && typeof window !== "undefined") {
-        window.cancelAnimationFrame(codeDragSelectionPreserveRafId)
-      }
+      cancelCodeDragSelectionPreserve()
       mouseTextSelectionInProgressRef.current = false
       syncBubbleOnMouseUpRef.current = false
       tableTextDragStartRef.current = null


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 최신 custom domain 배포본에서도 `/editor/507`의 table/code drag와 code Cmd+A가 깨지는 follow-up을 복구합니다.
- code selection preserve와 CodeBlock NodeView drag session이 다음 table/body drag로 새는 경로를 끊고, table drag scroll 보존을 강화했습니다.

## 작업 내용

- CodeBlock NodeView가 외부 pointerdown에서 stale drag session을 종료하도록 했습니다.
- editor selection bubble이 code preserve RAF를 명시 취소하고, 비동기 clear 대신 drag 시작 시점의 동기 selection clear만 수행하도록 조정했습니다.
- code drag selection root를 highlight layer가 아니라 실제 editable content root로 맞췄습니다.
- table text drag started-cell restore와 scroll preserve 시간을 강화하고, E2E에서 scrollTop/code Cmd+A 회귀를 함께 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts --workers=1` (초기 실패 확인 후 패치, 최종 2회 통과)
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-body-click-flicker.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-rich-focus.spec.ts e2e/editor-authoring-route-rich-select-all.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-affordances.spec.ts:547 --workers=1` (15 passed)
  - `yarn --cwd front test:e2e:authoring` (1회 실패 후 code selection root 보정, 재실행 95 passed)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: editor selection capture/preserve 경로를 조정하므로 code/table/body drag selection 주변 회귀 가능성이 있습니다.
- 롤백 방법: 이 PR commit을 revert하고 #467 이전 배포 상태로 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
