### PR TITLE
[Fix] main ci scroll 보존 복구

### DIFF
--- a/front/e2e/editor-authoring-route-rich-focus.spec.ts
+++ b/front/e2e/editor-authoring-route-rich-focus.spec.ts
@@ -107,31 +107,15 @@ test.describe("editor authoring route rich block focus", () => {
       })
       const targetBox = await expectVisibleBox(target, `${label} metrics are missing before click`)
 
-      const beforeGeometry = await page.evaluate(
-        ({ selector, text }) => {
-          const candidates = Array.from(document.querySelectorAll<HTMLElement>(selector))
-          const target =
-            candidates.find((element) => {
-              const elementText =
-                element instanceof HTMLTextAreaElement ? element.value : element.textContent ?? ""
-              return elementText.includes(text)
-            }) ??
-            candidates[0] ??
-            null
-          if (!target) return null
-          const rect = target.getBoundingClientRect()
-          return {
-            scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
-            targetTop: rect.top,
-            targetBottom: rect.bottom,
-            visible: rect.bottom > 0 && rect.top < window.innerHeight,
-          }
-        },
-        { selector: label === mermaidLabel ? ".aq-mermaid-code-input" : "[data-testid='block-editor-prosemirror'] *", text: label }
-      )
-      if (!beforeGeometry) {
-        throw new Error(`${label} geometry is missing before click`)
-      }
+      const beforeGeometry = await target.evaluate((element) => {
+        const rect = element.getBoundingClientRect()
+        return {
+          scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+          targetTop: rect.top,
+          targetBottom: rect.bottom,
+          visible: rect.bottom > 0 && rect.top < window.innerHeight,
+        }
+      })
       expect(beforeGeometry.visible).toBe(true)
       await page.evaluate(
         ({ staleScrollTop }) => {
@@ -157,30 +141,14 @@ test.describe("editor authoring route rich block focus", () => {
       )
       await page.waitForTimeout(1_000)
 
-      const afterGeometry = await page.evaluate(
-        ({ selector, text }) => {
-          const candidates = Array.from(document.querySelectorAll<HTMLElement>(selector))
-          const target =
-            candidates.find((element) => {
-              const elementText =
-                element instanceof HTMLTextAreaElement ? element.value : element.textContent ?? ""
-              return elementText.includes(text)
-            }) ??
-            candidates[0] ??
-            null
-          if (!target) return null
-          const rect = target.getBoundingClientRect()
-          return {
-            scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
-            targetTop: rect.top,
-            targetBottom: rect.bottom,
-          }
-        },
-        { selector: label === mermaidLabel ? ".aq-mermaid-code-input" : "[data-testid='block-editor-prosemirror'] *", text: label }
-      )
-      if (!afterGeometry) {
-        throw new Error(`${label} geometry is missing after click`)
-      }
+      const afterGeometry = await target.evaluate((element) => {
+        const rect = element.getBoundingClientRect()
+        return {
+          scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+          targetTop: rect.top,
+          targetBottom: rect.bottom,
+        }
+      })
 
       expect(Math.abs(afterGeometry.scrollTop - beforeGeometry.scrollTop)).toBeLessThanOrEqual(24)
       expect(Math.abs(afterGeometry.targetTop - beforeGeometry.targetTop)).toBeLessThanOrEqual(24)

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -192,6 +192,8 @@ export const markNextEditorPointerAfterTable = () => {
 
 const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES = 72
 const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS = 1_120
+const EDITOR_POINTER_TABLE_FOLLOW_UP_SCROLL_PRESERVE_FRAMES = 144
+const EDITOR_POINTER_TABLE_FOLLOW_UP_SCROLL_PRESERVE_MIN_MS = 2_400
 const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES = 4
 const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS = 64
 const EDITOR_POINTER_SCROLL_PRESERVE_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
@@ -226,6 +228,14 @@ const preserveWindowScrollForTablePointerTextDrag = () => {
   )
 }
 
+const preserveWindowScrollForTableFollowUpPointer = () => {
+  preserveWindowScrollAcrossFrames(
+    EDITOR_POINTER_TABLE_FOLLOW_UP_SCROLL_PRESERVE_FRAMES,
+    4,
+    EDITOR_POINTER_TABLE_FOLLOW_UP_SCROLL_PRESERVE_MIN_MS
+  )
+}
+
 export const preserveWindowScrollForEditorPointerFocus = (
   target: EventTarget | null,
   tableSelectionActive: boolean,
@@ -247,12 +257,15 @@ export const preserveWindowScrollForEditorPointerFocus = (
   } else if (shouldPreserveFollowUp) {
     preserveNextEditorPointerAfterTable = false
   }
+  if (shouldPreserveFollowUp) {
+    preserveWindowScrollForTableFollowUpPointer()
+    return
+  }
   if (
     shouldPreserveRichEditorPointer ||
     shouldPreserveBlockSelectionPointer ||
     shouldPreserveTableBlockSelectionPointer ||
-    tableSelectionActive ||
-    shouldPreserveFollowUp
+    tableSelectionActive
   ) {
     preserveWindowScrollForRichBlockSelectAll()
     return


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- PR #473 merge 후 main CI에서 `editor-authoring-route-code-recovery.spec.ts:277`이 table drag 뒤 하단 본문 클릭 시 scrollTop이 이전 anchor로 되돌아가 실패했습니다.
- table 이후 첫 non-table pointer에만 긴 scroll preserve를 적용하고, rich-focus E2E는 실제 locator 기준 geometry를 읽도록 고정해 숨은 후보를 집는 flake를 제거했습니다.

## 작업 내용

- table text drag 뒤 첫 후속 pointer에 전용 2.4s scroll preserve를 적용합니다.
- 일반 rich block 클릭 preserve 시간은 기존 1.12s로 유지해 다음 target scrollIntoView를 방해하지 않게 했습니다.
- rich-focus E2E geometry 측정을 broad selector 대신 이미 visible 검증된 locator 기준으로 바꿨습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright test e2e/editor-authoring-route-code-recovery.spec.ts:277 e2e/editor-authoring-route-rich-drag-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts --workers=1` (3 passed)
  - `yarn --cwd front playwright test e2e/editor-authoring-route-rich-focus.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts:277 e2e/editor-authoring-route-rich-drag-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts --workers=1` (초기 flake 확인 후 패치, 최종 7 passed)
  - `yarn --cwd front test:e2e:authoring` (초기 flake 확인 후 패치, 최종 95 passed)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table 이후 후속 클릭의 scroll preserve 시간이 늘어나므로, 직후 프로그램matic scroll과 경쟁할 수 있습니다. pointer/wheel/key 입력은 기존 cancel 경로를 유지합니다.
- 롤백 방법: 이 PR commit을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
