### PR TITLE
[Fix] live chrome drag 선택 복구

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -1,0 +1,235 @@
+import { expect, test, type Locator, type Page } from "@playwright/test"
+import { expectEditorToContainLoadedText } from "./helpers/editorAuthoringFlow"
+
+const adminMember = {
+  id: 1,
+  username: "qa-admin",
+  nickname: "aquila",
+  isAdmin: true,
+}
+
+const readScrollTop = (page: Page) =>
+  page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+
+const readSelectionText = (page: Page) =>
+  page.evaluate(
+    () =>
+      window.getSelection()?.toString() ||
+      document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text") ||
+      document.querySelector("[data-code-drag-selection-text]")?.getAttribute("data-code-drag-selection-text") ||
+      ""
+  )
+
+const dragLocatorText = async (
+  page: Page,
+  target: Locator,
+  label: string,
+  options: { endX?: number; startX?: number; y?: number; waitMs?: number } = {}
+) => {
+  await target.scrollIntoViewIfNeeded()
+  await target.evaluate((element) => {
+    element.scrollIntoView({ block: "center", inline: "nearest" })
+  })
+  const box = await target.boundingBox()
+  if (!box) throw new Error(`${label} metrics are missing`)
+  const y = options.y ?? Math.min(box.height / 2, 18)
+  const startX = options.startX ?? 8
+  const endX = options.endX ?? Math.min(box.width - 8, 360)
+  const beforeScrollTop = await readScrollTop(page)
+
+  await target.hover({ position: { x: startX, y } })
+  await page.mouse.down()
+  await target.hover({ position: { x: endX, y } })
+  await page.mouse.up()
+  await page.waitForTimeout(options.waitMs ?? 720)
+
+  const afterScrollTop = await readScrollTop(page)
+  const selectionText = await readSelectionText(page)
+  return { beforeScrollTop, afterScrollTop, selectionText }
+}
+
+const filler = (label: string, count: number) =>
+  Array.from({ length: count }, (_, index) => [
+    `${label} ${index + 1}: 인증 흐름을 설명하는 긴 문단입니다.`,
+    "",
+  ]).flat()
+
+test.describe("editor authoring route live drag sequence", () => {
+  test("body selection 뒤 table/code drag는 이전 selection anchor와 scroll 위치로 튀지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+
+    const liveDragContent = [
+      "---",
+      'tags: ["Stateless", "인증", "JWT", "Refresh Token"]',
+      "---",
+      "",
+      "## 시작하며",
+      "",
+      "- “Stateless가 좋다는데, 왜 좋은 거지?”",
+      "- “세션이랑 JWT는 뭐가 다른 거야?”",
+      "",
+      ...filler("table 이전 본문", 72),
+      "",
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[146,139]} -->',
+      "| **토큰** | **역할** |",
+      "| --- | --- |",
+      "| Access Token | API 인증 |",
+      "| Refresh Token | Access 재발급 |",
+      "",
+      "- Access Token 은 요청마다 서버로 보내어지기 때문에 탈취위험이 매우 높다",
+      "",
+      ...filler("code 이전 본문", 24),
+      "",
+      "```java",
+      "public Token login(User user) {",
+      "",
+      "    String access = createAccessToken(user);   // 짧게",
+      "    String refresh = createRefreshToken(user); // 길게",
+      "",
+      "    saveRefreshToken(user.getId(), refresh);",
+      "",
+      "    return new Token(access, refresh);",
+      "}",
+      "```",
+      "",
+      ...filler("code 이후 본문", 8),
+    ].join("\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/997", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 997,
+          version: 12,
+          title: "live drag sequence 글",
+          content: liveDragContent,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/997")
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("live drag sequence 글")
+    await expectEditorToContainLoadedText(editor, "createAccessToken")
+
+    const bodyDrag = await dragLocatorText(
+      page,
+      editor.locator("li", { hasText: "Stateless가 좋다는데" }).first(),
+      "stale body selection",
+      { waitMs: 720 }
+    )
+    expect(bodyDrag.selectionText).toContain("Stateless가 좋다는데")
+    expect(Math.abs(bodyDrag.afterScrollTop - bodyDrag.beforeScrollTop)).toBeLessThanOrEqual(24)
+
+    const accessTokenCell = editor.locator("td", { hasText: "Access Token" }).first()
+    const accessTokenBox = await accessTokenCell.evaluate((element) => {
+      element.scrollIntoView({ block: "center", inline: "nearest" })
+      const rect = element.getBoundingClientRect()
+      return { y: rect.height / 2, endX: Math.min(rect.width - 8, 128) }
+    })
+    await page.evaluate(() => {
+      ;(window as typeof window & { __qaTableDragEvents?: unknown[] }).__qaTableDragEvents = []
+      const record = (event: MouseEvent | PointerEvent) => {
+        const cell = document.elementFromPoint(event.clientX, event.clientY)?.closest("th, td")
+        const stack = document.elementsFromPoint(event.clientX, event.clientY).map((element) => ({
+          tagName: element.tagName,
+          testId: element.getAttribute("data-testid"),
+          affordance: element.getAttribute("data-table-affordance"),
+          cellText: element.closest("th, td")?.textContent?.replace(/\s+/g, " ").trim() ?? null,
+        }))
+        ;(window as typeof window & { __qaTableDragEvents?: unknown[] }).__qaTableDragEvents?.push({
+          type: event.type,
+          x: event.clientX,
+          y: event.clientY,
+          cellText: cell?.textContent?.replace(/\s+/g, " ").trim() ?? null,
+          stack,
+        })
+      }
+      document.addEventListener("pointerdown", record, { capture: true, once: true })
+      document.addEventListener("pointermove", record, { capture: true, once: true })
+      document.addEventListener("pointerup", record, { capture: true, once: true })
+      document.addEventListener("mousedown", record, { capture: true, once: true })
+      document.addEventListener("mousemove", record, { capture: true, once: true })
+      document.addEventListener("mouseup", record, { capture: true, once: true })
+    })
+    const tableDrag = await dragLocatorText(page, accessTokenCell, "access token table drag", {
+      endX: accessTokenBox.endX,
+      y: accessTokenBox.y,
+      waitMs: 2_800,
+    })
+    const tableSelectionText = await readSelectionText(page)
+    if (!tableSelectionText.includes("Access Token") || tableSelectionText.includes("API 인증")) {
+      const diagnostics = await page.evaluate(() => {
+        const selection = window.getSelection()
+        const describeNode = (node: Node | null | undefined) => {
+          const element = node instanceof Element ? node : node?.parentElement ?? null
+          const cell = element?.closest("th, td")
+          return {
+            tagName: element?.tagName ?? null,
+            text: element?.textContent?.replace(/\s+/g, " ").trim().slice(0, 80) ?? null,
+            cellText: cell?.textContent?.replace(/\s+/g, " ").trim() ?? null,
+          }
+        }
+        return {
+          selectionText: selection?.toString() ?? "",
+          anchor: describeNode(selection?.anchorNode),
+          focus: describeNode(selection?.focusNode),
+          persisted: Array.from(document.querySelectorAll("[data-table-drag-selection-text]")).map((element) => ({
+            text: element.textContent?.replace(/\s+/g, " ").trim(),
+            attr: element.getAttribute("data-table-drag-selection-text"),
+          })),
+          events: (window as typeof window & { __qaTableDragEvents?: unknown[] }).__qaTableDragEvents ?? [],
+        }
+      })
+      throw new Error(`table drag escaped started cell: ${JSON.stringify(diagnostics)}`)
+    }
+    expect(tableDrag.afterScrollTop).toBeLessThanOrEqual(tableDrag.beforeScrollTop + 24)
+    expect(tableDrag.afterScrollTop).toBeGreaterThanOrEqual(tableDrag.beforeScrollTop - 24)
+
+    const followUpBody = editor.locator("li", { hasText: "Access Token 은 요청마다" }).first()
+    await followUpBody.evaluate((element) => {
+      element.scrollIntoView({ block: "center", inline: "nearest" })
+    })
+    const followUpBox = await followUpBody.boundingBox()
+    if (!followUpBox) throw new Error("follow-up body metrics are missing")
+    const beforeFollowUpClick = await readScrollTop(page)
+    await page.mouse.click(followUpBox.x + Math.min(followUpBox.width / 2, 220), followUpBox.y + 18)
+    await page.waitForTimeout(2_600)
+    await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforeFollowUpClick + 24)
+    await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforeFollowUpClick - 24)
+
+    const codeContent = editor.locator(".aq-code-editor-content", { hasText: "createAccessToken(user)" }).first()
+    const codeDragMetrics = await codeContent.evaluate((element) => {
+      element.scrollIntoView({ block: "center", inline: "nearest" })
+      const rect = element.getBoundingClientRect()
+      const style = window.getComputedStyle(element)
+      const lineHeight = Number.parseFloat(style.lineHeight || "22") || 22
+      const paddingTop = Number.parseFloat(style.paddingTop || "0") || 0
+      return {
+        y: Math.min(rect.height - 8, paddingTop + lineHeight * 2.5),
+        endX: Math.min(rect.width - 8, 390),
+      }
+    })
+    const codeDrag = await dragLocatorText(page, codeContent, "token login code drag", {
+      endX: codeDragMetrics.endX,
+      y: codeDragMetrics.y,
+      waitMs: 1_600,
+    })
+    await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
+    expect(codeDrag.selectionText).not.toContain("Access Token")
+    expect(codeDrag.afterScrollTop).toBeLessThanOrEqual(codeDrag.beforeScrollTop + 24)
+    expect(codeDrag.afterScrollTop).toBeGreaterThanOrEqual(codeDrag.beforeScrollTop - 24)
+  })
+})

--- a/front/e2e/editor-authoring-route-rich-drag-selection.spec.ts
+++ b/front/e2e/editor-authoring-route-rich-drag-selection.spec.ts
@@ -184,6 +184,15 @@ test.describe("editor authoring route rich block drag selection", () => {
       await page.mouse.up()
       await page.waitForTimeout(360)
 
+      await expect
+        .poll(async () =>
+          target.evaluate((element) =>
+            window.getSelection()?.toString() ||
+            element.closest(".aq-code-shell")?.getAttribute("data-code-drag-selection-text") ||
+            ""
+          )
+        )
+        .toContain(expectedSelection)
       const afterGeometry = await target.evaluate((element) => {
         const rect = element.getBoundingClientRect()
         return {

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -46,7 +46,10 @@ import {
   selectDomTextOffsetRange,
 } from "./codeBlockNodeViewSelectionModel"
 import { focusElementWithoutScroll } from "./blockEditorEngineDocumentModel"
-import { preserveWindowScrollForRichBlockSelectAll } from "./blockHandleLayoutModel"
+import {
+  preserveWindowScrollForRichBlockSelectAll,
+  preserveWindowScrollPositionAcrossFrames,
+} from "./blockHandleLayoutModel"
 
 export { getPreferredCodeLanguage, normalizeCodeLanguage } from "./codeBlockNodeViewLanguageModel"
 export { CodeBlockEditorStyles } from "./codeBlockNodeViewStyles"
@@ -169,11 +172,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
 
   const applyCodeTextSelection = useCallback(
     (anchorPos: number, headPos: number) => {
-      const nextSelection = TextSelection.create(
-        editor.state.doc,
-        Math.min(anchorPos, headPos),
-        Math.max(anchorPos, headPos)
-      )
+      const nextSelection = TextSelection.create(editor.state.doc, Math.min(anchorPos, headPos), Math.max(anchorPos, headPos))
       if (nextSelection.eq(editor.state.selection)) return
       editor.view.dispatch(editor.state.tr.setSelection(nextSelection))
     },
@@ -193,13 +192,33 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
 
   const preserveCodeDomTextRange = useCallback(
     (contentRoot: HTMLElement | null, anchorPos: number, headPos: number) => {
+      const scrollAnchor = { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }
+      const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now()
+      let frame = 0
+      let cancelled = false
+      let cancelArmed = false
+      const shell = contentRoot?.closest(".aq-code-shell")
+      const cancel = (event: Event) => { if (cancelArmed && (!(event.target instanceof Node) || !shell?.contains(event.target))) cancelled = true }
       const selectRange = () => {
         if (!selectCodeDomTextRange(contentRoot, anchorPos, headPos)) {
           selectDomTextContents(contentRoot)
         }
+        shell?.setAttribute("data-code-drag-selection-text", window.getSelection()?.toString() || contentRoot?.textContent || "")
       }
-      selectRange()
-      window.requestAnimationFrame(selectRange)
+      const restore = () => {
+        if (cancelled) return
+        selectRange()
+        frame += 1
+        const elapsedMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt
+        if (frame < 168 || elapsedMs < 2_800) {
+          window.requestAnimationFrame(restore)
+        }
+      }
+      window.addEventListener("pointerdown", cancel, { capture: true, once: true })
+      window.addEventListener("mousedown", cancel, { capture: true, once: true })
+      preserveWindowScrollPositionAcrossFrames(scrollAnchor, 168, 4, 2_800, false, false)
+      window.requestAnimationFrame(() => { cancelArmed = true })
+      restore()
     },
     [selectCodeDomTextRange]
   )
@@ -207,8 +226,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
   const startCodeDragSelection = useCallback(
     (event: ReactMouseEvent<HTMLDivElement> | ReactPointerEvent<HTMLDivElement>) => {
       const shell = shellRef.current
-      const contentRoot =
-        shell?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
+      const contentRoot = shell?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
       if (event.button !== 0 || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return
       if (!shell || !contentRoot || !(event.target instanceof Node) || !shell.contains(event.target)) return
       const targetElement = event.target instanceof Element ? event.target : event.target.parentElement

--- a/front/src/components/editor/codeBlockNodeViewSelectionModel.ts
+++ b/front/src/components/editor/codeBlockNodeViewSelectionModel.ts
@@ -25,7 +25,7 @@ export const selectDomTextContents = (root: HTMLElement | null) => {
   range.selectNodeContents(root)
   selection.removeAllRanges()
   selection.addRange(range)
-  root.focus()
+  root.focus({ preventScroll: true })
   return true
 }
 
@@ -67,7 +67,7 @@ export const selectDomTextOffsetRange = (
   range.setEnd(end.node, end.offset)
   selection.removeAllRanges()
   selection.addRange(range)
-  root.focus()
+  root.focus({ preventScroll: true })
   return true
 }
 

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -18,8 +18,8 @@ const resolveElement = (target: EventTarget | Node | null | undefined) => {
 }
 
 let lastActiveTableCell: HTMLElement | null = null
-const TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES = 72
-const TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS = 1_120
+const TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES = 168
+const TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS = 2_800
 
 export const rememberActiveTableCellFromTarget = (
   eventTarget: EventTarget | Node | null | undefined,
@@ -93,19 +93,6 @@ export const restoreTableCellTextSelectionIfEscaped = (
   }
   if (!hasTextSelection && !restoreWhenEmpty) return false
 
-  const anchorCell = anchorElement?.closest("th, td")
-  const focusCell = focusElement?.closest("th, td")
-  const startedTable = startedCell.closest("table")
-  if (
-    hasTextSelection &&
-    !forceStartedCellSelection &&
-    startedTable &&
-    ((anchorCell && startedTable.contains(anchorCell)) ||
-      (focusCell && startedTable.contains(focusCell)))
-  ) {
-    return false
-  }
-
   const range = document.createRange()
   range.selectNodeContents(startedCell)
   selection.removeAllRanges()
@@ -124,4 +111,27 @@ export const restoreTableCellTextSelectionIfEscaped = (
     preserveWindowScrollForRichBlockSelectAll()
   }
   return true
+}
+
+export const preserveTableCellTextSelectionAcrossFrames = (
+  editor: TiptapEditor,
+  startedCell: HTMLElement,
+  scrollAnchor: WindowScrollAnchor
+) => {
+  const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now()
+  let frame = 0
+  let cancelled = false
+  const cancel = () => { cancelled = true }
+  window.addEventListener("pointerdown", cancel, { capture: true, once: true })
+  window.addEventListener("mousedown", cancel, { capture: true, once: true })
+  const restore = () => {
+    if (cancelled) return
+    restoreTableCellTextSelectionIfEscaped(editor, startedCell, scrollAnchor, true, true)
+    frame += 1
+    const elapsedMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt
+    if (startedCell.isConnected && (frame < TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES || elapsedMs < TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS)) {
+      window.requestAnimationFrame(restore)
+    }
+  }
+  restore()
 }

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -9,7 +9,7 @@ import {
   type WindowScrollAnchor,
 } from "./blockHandleLayoutModel"
 import { isTableSelectionActive } from "./tableStructureModel"
-import { restoreTableCellTextSelectionIfEscaped } from "./tableTextSelectionModel"
+import { preserveTableCellTextSelectionAcrossFrames, restoreTableCellTextSelectionIfEscaped } from "./tableTextSelectionModel"
 import {
   areFloatingBubbleStatesEqual,
   hideFloatingBubbleState,
@@ -20,6 +20,8 @@ import {
 type SetState<T> = Dispatch<SetStateAction<T>>
 
 const CODE_BLOCK_EDITOR_CONTENT_SELECTOR = ".aq-code-editor-content"
+const BLOCK_EDITOR_ROOT_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
+const TABLE_TEXT_DRAG_CONTROL_SELECTOR = "[data-table-axis-rail='true'], [data-table-affordance], [data-table-menu-root='true'], [data-table-menu-trigger='true'], [data-testid^='table-column-resize-boundary-'], [data-testid='table-structure-menu-button'], [data-testid='table-corner-handle'], [data-testid='table-corner-grow-handle'], .column-resize-handle"
 
 type UseBlockEditorEngineSelectionBubbleEffectsArgs = {
   bubbleToolbarHoveredRef: RefObject<boolean>
@@ -58,9 +60,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
   tableMenuState,
   tryStartTableColumnResizeFromDomHandle,
 }: UseBlockEditorEngineSelectionBubbleEffectsArgs) => {
-  const tableTextDragStartRef = useRef<{
-    cell: HTMLElement; scrollPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number
-  } | null>(null)
+  const tableTextDragStartRef = useRef<{ cell: HTMLElement; scrollPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null)
   const codeTextDragStartRef = useRef<{ root: HTMLElement; x: number; y: number } | null>(null)
 
   useEffect(() => {
@@ -80,28 +80,27 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       document.querySelectorAll("[data-code-drag-selection-text]").forEach((element) => element.removeAttribute("data-code-drag-selection-text"))
     }
 
-    const rememberTableTextDragStart = (event: MouseEvent | PointerEvent) => {
+    const rememberTableTextDragStart = (event: MouseEvent | PointerEvent, allowTableControlCellFallback = false) => {
       if (event.button !== 0) return null
       const activeEditor = editorRef.current ?? currentEditor
       if (!activeEditor) return null
-      if (!(event.target instanceof Node) || !activeEditor.view.dom.contains(event.target)) {
+      const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null
+      const pointElements = document.elementsFromPoint(event.clientX, event.clientY)
+      const pointInsideEditor = pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR)))
+      if (!(event.target instanceof Node) || (!activeEditor.view.dom.contains(event.target) && !targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR) && !pointInsideEditor)) {
         tableTextDragStartRef.current = null
         return null
       }
-      const targetElement = event.target instanceof Element ? event.target : event.target.parentElement
-      const tableTextCell = targetElement?.closest("th, td")
-      const scrollAnchor = {
-        x: window.scrollX,
-        y: document.scrollingElement?.scrollTop ?? window.scrollY,
-      }
+      const pointElement = pointElements.find((element) => Boolean(element.closest("th, td"))) ?? document.elementFromPoint(event.clientX, event.clientY)
+      const tableTextCell = pointElement?.closest("th, td") ?? targetElement?.closest("th, td")
+      const tableControlTarget = targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR) ?? pointElements[0]?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR)
+      if (tableControlTarget && (!allowTableControlCellFallback || !(tableTextCell instanceof HTMLElement))) { tableTextDragStartRef.current = null; return null }
+      const scrollAnchor = { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }
       if (tableTextCell instanceof HTMLElement) {
         tableTextCell.removeAttribute("data-table-drag-selection-text")
         markNextEditorPointerAfterTable()
       }
-      tableTextDragStartRef.current =
-        tableTextCell instanceof HTMLElement
-          ? { cell: tableTextCell, scrollPreserveStarted: false, scrollAnchor, x: event.clientX, y: event.clientY }
-          : null
+      tableTextDragStartRef.current = tableTextCell instanceof HTMLElement ? { cell: tableTextCell, scrollPreserveStarted: false, scrollAnchor, x: event.clientX, y: event.clientY } : null
       return tableTextDragStartRef.current
     }
 
@@ -403,16 +402,18 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const activeEditor = editorRef.current ?? currentEditor
       if (!activeEditor) return
       const eventTarget = event.target
-      const targetElement =
-        eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
+      const targetElement = eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
       const codeShellTarget = targetElement?.closest(".aq-code-shell")
-      const insideEditorDom = eventTarget instanceof Node && activeEditor.view.dom.contains(eventTarget)
+      const existingSelectionText = window.getSelection()?.toString().trim() ?? ""
+      const allowTableControlCellFallback = Boolean(existingSelectionText) && !isTableSelectionActive(activeEditor)
+      const targetTableControl = targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR)
+      const pointInsideEditor = !targetElement?.closest("[data-table-menu-root='true']") && (!targetTableControl || allowTableControlCellFallback) && document.elementsFromPoint(event.clientX, event.clientY).some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR)))
+      const insideEditorDom = eventTarget instanceof Node && (activeEditor.view.dom.contains(eventTarget) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor)
+      const tableTextDragStart = insideEditorDom ? rememberTableTextDragStart(event, allowTableControlCellFallback) : null
       if (!insideEditorDom && !codeShellTarget) return
       if (codeShellTarget) {
         cancelCodeDragSelectionPreserve()
-        const codeSelectionRoot =
-          codeShellTarget.querySelector<HTMLElement>(".aq-code-editor-content") ??
-          codeShellTarget.querySelector<HTMLElement>(".aq-code-highlight-layer")
+        const codeSelectionRoot = codeShellTarget.querySelector<HTMLElement>(".aq-code-editor-content") ?? codeShellTarget.querySelector<HTMLElement>(".aq-code-highlight-layer")
         codeTextDragStartRef.current = codeSelectionRoot
           ? {
               root: codeSelectionRoot,
@@ -425,19 +426,17 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         codeTextDragStartRef.current = null
         if (insideEditorDom) {
           cancelCodeDragSelectionPreserve()
-          clearImmediateWindowTextSelection()
+          if (!tableTextDragStart || !existingSelectionText) clearImmediateWindowTextSelection()
         }
       }
       if (insideEditorDom) {
-        rememberTableTextDragStart(event)
-        const blockSelectionActive = Boolean(
-          document.querySelector("[data-testid='keyboard-block-selection-overlay']")
-        )
-        preserveWindowScrollForEditorPointerFocus(
-          event.target,
-          isTableSelectionActive(activeEditor),
-          blockSelectionActive
-        )
+        if (tableTextDragStart && existingSelectionText) {
+          event.preventDefault()
+          event.stopPropagation()
+          restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true)
+        }
+        const blockSelectionActive = Boolean(document.querySelector("[data-testid='keyboard-block-selection-overlay']"))
+        preserveWindowScrollForEditorPointerFocus(event.target, isTableSelectionActive(activeEditor), blockSelectionActive)
       }
       if (tryStartTableColumnResizeFromDomHandle(event.target, event.pointerId, event.clientX)) {
         event.preventDefault()
@@ -460,17 +459,15 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const activeEditor = editorRef.current ?? currentEditor
       if (!activeEditor) return
       const eventTarget = event.target
-      const targetElement =
-        eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
+      const targetElement = eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
       const codeShellTarget = targetElement?.closest(".aq-code-shell")
-      const insideEditorDom = eventTarget instanceof Node && activeEditor.view.dom.contains(eventTarget)
+      const pointInsideEditor = !targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR) && document.elementsFromPoint(event.clientX, event.clientY).some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR)))
+      const insideEditorDom = eventTarget instanceof Node && (activeEditor.view.dom.contains(eventTarget) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor)
       if (!insideEditorDom && !codeShellTarget) return
       if (codeTextDragStartRef.current && !codeShellTarget) codeTextDragStartRef.current = null
       if (codeShellTarget) {
         cancelCodeDragSelectionPreserve()
-        const codeSelectionRoot =
-          codeShellTarget.querySelector<HTMLElement>(".aq-code-editor-content") ??
-          codeShellTarget.querySelector<HTMLElement>(".aq-code-highlight-layer")
+        const codeSelectionRoot = codeShellTarget.querySelector<HTMLElement>(".aq-code-editor-content") ?? codeShellTarget.querySelector<HTMLElement>(".aq-code-highlight-layer")
         codeTextDragStartRef.current = codeSelectionRoot
           ? {
               root: codeSelectionRoot,
@@ -485,7 +482,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         clearImmediateWindowTextSelection()
       }
       if (!insideEditorDom) return
-      rememberTableTextDragStart(event)
+      if (!tableTextDragStartRef.current) rememberTableTextDragStart(event)
       if (!targetElement?.closest(".column-resize-handle")) return
       event.preventDefault()
       event.stopPropagation()
@@ -498,6 +495,8 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         selectCodeDragRootWhenNativeSelectionIsMissing()
       }
       if (!hasMovedTableTextDrag(event)) return
+      event.preventDefault()
+      event.stopPropagation()
       preserveActiveTableTextDragScroll()
       if (restoreActiveTableTextDragSelection(true, true)) {
         syncBubbleOnMouseUpRef.current = true
@@ -509,6 +508,8 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         selectCodeDragRootWhenNativeSelectionIsMissing()
       }
       if (!hasMovedTableTextDrag(event)) return
+      event.preventDefault()
+      event.stopPropagation()
       preserveActiveTableTextDragScroll()
       if (restoreActiveTableTextDragSelection(true, true)) {
         syncBubbleOnMouseUpRef.current = true
@@ -525,12 +526,11 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       if (hasMovedCodeTextDrag(event)) {
         selectCodeDragRootWhenNativeSelectionIsMissing()
       }
-      if (
-        activeEditor &&
-          tableTextDragMoved &&
-          restoreActiveTableTextDragSelection(true, true)
-      ) {
+      if (activeEditor && tableTextDragStart && tableTextDragMoved && restoreActiveTableTextDragSelection(true, true)) {
+        event.preventDefault()
+        event.stopPropagation()
         preserveActiveTableTextDragScroll()
+        preserveTableCellTextSelectionAcrossFrames(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor)
         syncBubbleOnMouseUpRef.current = true
       }
       tableTextDragStartRef.current = null


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 실제 배포본 `/editor/507`에서 body selection 이후 table/code drag가 이전 selection anchor와 scroll 위치로 튀는 follow-up 회귀를 복구합니다.
- table row-handle overlay가 셀을 덮는 경우에도 일반 텍스트 selection 상태에서는 underlying cell을 started cell로 잡고, table 구조 control과 code drag는 서로의 preserve loop를 빼앗지 않게 분리했습니다.

## 작업 내용

- body -> table -> code 순서의 route E2E를 추가해 table `Access Token`, code `createAccessToken`, scroll 보존을 함께 검증합니다.
- table text drag restore를 completion 이후에도 유지하되 다음 pointer 입력과 table menu/resize/grip/structural selection에서는 빠지게 했습니다.
- code drag selection은 DOM range와 shell attribute를 함께 보존하고 `focus({ preventScroll: true })`로 scroll jump를 막습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts e2e/editor-authoring-table-affordances.spec.ts:380 e2e/editor-authoring-table-operations.spec.ts:38 e2e/editor-authoring-table-resize-guide.spec.ts:36 e2e/editor-authoring-table-resize-guide.spec.ts:86 --workers=1`
  - `yarn --cwd front test:e2e:authoring` (96 passed, 2회 연속)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table text drag preserve가 table 구조 조작과 충돌할 수 있어 resize/grip/menu E2E를 같이 고정했습니다.
- 롤백 방법: 이 PR의 commit을 revert하면 PR #474 상태로 되돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
