### PR TITLE
[Fix] live code drag selection 복구

### DIFF
--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -86,6 +86,12 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       }
       return codeTextDragStartRef.current
     }
+    const findCodeShellTarget = (targetElement: Element | null | undefined, pointElements: Element[]) =>
+      targetElement?.closest(".aq-code-shell") ?? pointElements.find((element) => Boolean(element.closest(".aq-code-shell")))?.closest(".aq-code-shell")
+    const rememberCodeTextDragStartAtPoint = (event: MouseEvent | PointerEvent) => {
+      const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null
+      return rememberCodeTextDragStart(findCodeShellTarget(targetElement, document.elementsFromPoint(event.clientX, event.clientY)), event)
+    }
 
     const rememberTableTextDragStart = (event: MouseEvent | PointerEvent, allowTableControlCellFallback = false) => {
       if (event.button !== 0) return null
@@ -113,11 +119,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
 
     const hasMovedTableTextDrag = (event: MouseEvent | PointerEvent) => {
       const tableTextDragStart = tableTextDragStartRef.current
-      return Boolean(
-        tableTextDragStart &&
-          (Math.abs(event.clientX - tableTextDragStart.x) > 4 ||
-            Math.abs(event.clientY - tableTextDragStart.y) > 4)
-      )
+      return Boolean(tableTextDragStart && (Math.abs(event.clientX - tableTextDragStart.x) > 4 || Math.abs(event.clientY - tableTextDragStart.y) > 4))
     }
 
     const restoreActiveTableTextDragSelection = (restoreWhenEmpty = false, forceStartedCellSelection = false) => {
@@ -220,11 +222,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
 
     const hasMovedCodeTextDrag = (event: MouseEvent | PointerEvent) => {
       const codeTextDragStart = codeTextDragStartRef.current
-      return Boolean(
-        codeTextDragStart &&
-          (Math.abs(event.clientX - codeTextDragStart.x) > 4 ||
-            Math.abs(event.clientY - codeTextDragStart.y) > 4)
-      )
+      return Boolean(codeTextDragStart && (Math.abs(event.clientX - codeTextDragStart.x) > 4 || Math.abs(event.clientY - codeTextDragStart.y) > 4))
     }
 
     const syncBubble = () => {
@@ -401,7 +399,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const eventTarget = event.target
       const targetElement = eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
       const pointElements = document.elementsFromPoint(event.clientX, event.clientY)
-      const codeShellTarget = targetElement?.closest(".aq-code-shell") ?? pointElements.find((element) => Boolean(element.closest(".aq-code-shell")))?.closest(".aq-code-shell")
+      const codeShellTarget = findCodeShellTarget(targetElement, pointElements)
       const existingSelectionText = window.getSelection()?.toString().trim() ?? ""
       const allowTableControlCellFallback = Boolean(existingSelectionText) && !isTableSelectionActive(activeEditor)
       const targetTableControl = targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR)
@@ -453,7 +451,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const eventTarget = event.target
       const targetElement = eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
       const pointElements = document.elementsFromPoint(event.clientX, event.clientY)
-      const codeShellTarget = targetElement?.closest(".aq-code-shell") ?? pointElements.find((element) => Boolean(element.closest(".aq-code-shell")))?.closest(".aq-code-shell")
+      const codeShellTarget = findCodeShellTarget(targetElement, pointElements)
       const pointInsideEditor = !targetElement?.closest("[data-table-menu-root='true']") && !targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR) && pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR)))
       const insideEditorDom = eventTarget instanceof Node && (activeEditor.view.dom.contains(eventTarget) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor)
       if (!insideEditorDom && !codeShellTarget) return
@@ -477,6 +475,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
 
     const handleWindowPointerMove = (event: PointerEvent) => {
       if (event.pointerType && event.pointerType !== "mouse") return
+      if (!codeTextDragStartRef.current && event.buttons === 1 && !tableTextDragStartRef.current && rememberCodeTextDragStartAtPoint(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRootWhenNativeSelectionIsMissing(); return }
       if (hasMovedCodeTextDrag(event)) {
         event.preventDefault()
         event.stopPropagation()
@@ -494,6 +493,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     }
 
     const handleWindowMouseMove = (event: MouseEvent) => {
+      if (!codeTextDragStartRef.current && event.buttons === 1 && !tableTextDragStartRef.current && rememberCodeTextDragStartAtPoint(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRootWhenNativeSelectionIsMissing(); return }
       if (hasMovedCodeTextDrag(event)) {
         event.preventDefault()
         event.stopPropagation()


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- PR #476 배포본 실제 Chrome `/editor/507`에서 body drag, table drag, code Cmd+A는 통과했지만 code direct drag selection이 빈 값으로 남는 후속 회귀를 복구합니다.
- code drag가 pointerdown/mousedown 시작점을 놓친 경우에도 좌버튼 move 중 code shell을 재식별해 selection fallback을 즉시 arm합니다.

## 작업 내용

- code shell hit-test를 공통 helper로 정리했습니다.
- move 이벤트에서 좌버튼 drag가 code shell 위에 들어오면 code root selection과 scroll preserve를 바로 적용합니다.
- refactor boundary 600줄 제한은 599줄로 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts e2e/editor-authoring-table-affordances.spec.ts:380 e2e/editor-authoring-table-operations.spec.ts:38 e2e/editor-authoring-table-resize-guide.spec.ts:36 e2e/editor-authoring-table-resize-guide.spec.ts:86 --workers=1`
  - `yarn --cwd front test:e2e:authoring` (96 passed, 1회차)
  - `yarn --cwd front test:e2e:authoring` (96 passed, 2회차)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: code drag move fallback이 일반 table/body drag를 가로채는 회귀.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 PR #476 상태로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
