### PR TITLE
[Fix] live code drag final selection 복구

### DIFF
--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -159,7 +159,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       range.selectNodeContents(root)
       selection.removeAllRanges()
       selection.addRange(range)
-      root.closest(".aq-code-shell")?.setAttribute("data-code-drag-selection-text", selection.toString())
+      root.closest(".aq-code-shell")?.setAttribute("data-code-drag-selection-text", selection.toString() || root.innerText || root.textContent || "")
       return true
     }
 


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- PR #477 배포본에서도 실제 Chrome `/editor/507` 코드 블럭 direct drag 후 `window.getSelection()`과 `data-code-drag-selection-text`가 모두 비어 있었다.
- 코드 drag fallback이 native selection 문자열을 얻지 못해도 실제 코드 DOM 텍스트를 shell dataset에 남기도록 보강했다.

## 작업 내용

- 코드 블럭 drag selection fallback에서 `selection.toString()`이 빈 값이면 `.aq-code-editor-content`의 `innerText/textContent`를 `data-code-drag-selection-text`에 저장한다.
- 기존 scroll preserve, table drag, code Cmd+A 경로는 그대로 유지한다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts e2e/editor-authoring-table-affordances.spec.ts:380 e2e/editor-authoring-table-operations.spec.ts:38 e2e/editor-authoring-table-resize-guide.spec.ts:36 e2e/editor-authoring-table-resize-guide.spec.ts:86 --workers=1`
  - `yarn --cwd front test:e2e:authoring` - 96 passed
  - `yarn --cwd front test:e2e:authoring` - 1 unrelated table cell menu polling failure, then `yarn --cwd front playwright test e2e/editor-authoring-table-structure.spec.ts:499 --workers=1` passed
  - `yarn --cwd front test:e2e:authoring` - 96 passed
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: code drag fallback이 native selection이 비어 있는 경우 전체 code block text를 persisted selection text로 사용한다.
- 롤백 방법: 이 PR commit을 revert하면 PR #477 상태로 되돌아간다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
