### PR TITLE
[Fix] live code drag existing selection 복구

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -222,8 +222,15 @@ test.describe("editor authoring route live drag sequence", () => {
         endX: Math.min(rect.width - 8, 390),
       }
     })
+    const beforeCodeSelectAll = await readScrollTop(page)
+    await codeContent.click({ position: { x: 80, y: 28 } })
+    await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A")
+    await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
+    await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforeCodeSelectAll + 24)
+    await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforeCodeSelectAll - 24)
     const codeDrag = await dragLocatorText(page, codeContent, "token login code drag", {
       endX: codeDragMetrics.endX,
+      startX: 80,
       y: codeDragMetrics.y,
       waitMs: 1_600,
     })

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -170,7 +170,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       let restoring = false
       const restoreIfMissing = () => {
         if (!root.isConnected) return false
-        if (isSelectionInsideCodeDragRoot(root)) return true
+        if (isSelectionInsideCodeDragRoot(root) && window.getSelection()?.toString() === (root.innerText || root.textContent || "")) return true
         restoring = true
         selectCodeDragRoot(root)
         restoring = false
@@ -212,7 +212,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     const selectCodeDragRootWhenNativeSelectionIsMissing = () => {
       const codeTextDragStart = codeTextDragStartRef.current
       if (!codeTextDragStart?.root.isConnected) return false
-      if (isSelectionInsideCodeDragRoot(codeTextDragStart.root)) return false
+      if (isSelectionInsideCodeDragRoot(codeTextDragStart.root)) { const rootText = codeTextDragStart.root.innerText || codeTextDragStart.root.textContent || ""; const selectionText = window.getSelection()?.toString() || ""; if (rootText && selectionText !== rootText) return selectCodeDragRoot(codeTextDragStart.root); codeTextDragStart.root.closest(".aq-code-shell")?.setAttribute("data-code-drag-selection-text", selectionText || rootText); return false }
       const selected = selectCodeDragRoot(codeTextDragStart.root)
       if (selected) {
         preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root)


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- PR #478 배포본에서 code Cmd+A 이후 code direct drag를 시작하면 기존 code root selection이 부분 native selection으로 밀려 `createAccessToken` 포함 선택 완료조건을 잃던 회귀를 복구합니다.
- code selection preserve 루프가 root 내부 partial selection을 정상으로 간주하지 않도록 바꾸고, live drag sequence E2E에 Cmd+A 이후 code drag 순서를 고정했습니다.

## 작업 내용

- code drag preserve가 code root 전체 텍스트와 일치하지 않는 partial native selection을 다시 root selection으로 복구합니다.
- live drag sequence E2E에서 code Cmd+A 직후 code drag가 코드 텍스트와 scroll 위치를 유지하는지 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `wc -l front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts` -> 599 lines
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts e2e/editor-authoring-table-affordances.spec.ts:380 e2e/editor-authoring-table-operations.spec.ts:38 e2e/editor-authoring-table-resize-guide.spec.ts:36 e2e/editor-authoring-table-resize-guide.spec.ts:86 --workers=1`
  - `yarn --cwd front test:e2e:authoring` -> 96/96 passed
  - `yarn --cwd front test:e2e:authoring` -> 96/96 passed
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: code block drag 중 partial text selection 대신 code root 전체 선택을 더 강하게 보존하므로, code block 안에서 아주 짧은 부분 drag 선택의 UX가 기존보다 root selection 쪽으로 수렴할 수 있습니다.
- 롤백 방법: 이 PR의 squash commit을 revert하면 PR #478 상태로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
