### PR TITLE
[Fix] live code drag rearm 유지

### DIFF
--- a/front/e2e/editor-authoring-route-code-recovery.spec.ts
+++ b/front/e2e/editor-authoring-route-code-recovery.spec.ts
@@ -761,7 +761,7 @@ test.describe("editor authoring route code recovery", () => {
     await expect.poll(readScrollTop).toBeLessThanOrEqual(beforeAccessTokenDrag + 24)
     await expect.poll(readScrollTop).toBeGreaterThanOrEqual(beforeAccessTokenDrag - 24)
     await page.waitForTimeout(240)
-
+    await page.mouse.wheel(0, 1).then(() => page.waitForTimeout(40))
     const closingParagraph = editor.locator("p", { hasText: "Stateless는 “서버가 아무것도 안 하는 구조”가 아닙니다." }).first()
     await expect(closingParagraph).toBeVisible()
     const paragraphPoint = await closingParagraph.evaluate((element) => {
@@ -777,7 +777,7 @@ test.describe("editor authoring route code recovery", () => {
     await page.waitForTimeout(360)
     await expect.poll(readScrollTop).toBeLessThanOrEqual(beforeParagraphClick + 24)
     await expect.poll(readScrollTop).toBeGreaterThanOrEqual(beforeParagraphClick - 24)
-
+    await page.mouse.wheel(0, 1).then(() => page.waitForTimeout(40))
     const tableCell = editor.locator("td", { hasText: "구현되어 있는가" }).first()
     await expect(tableCell).toBeVisible()
     const tableCellPosition = await tableCell.evaluate((element) => {

--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -228,6 +228,13 @@ test.describe("editor authoring route live drag sequence", () => {
     await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
     await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforeCodeSelectAll + 24)
     await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforeCodeSelectAll - 24)
+    const codeDragStartBox = await codeContent.boundingBox()
+    if (!codeDragStartBox) throw new Error("code drag start metrics are missing")
+    await page.mouse.move(codeDragStartBox.x + 80, codeDragStartBox.y + codeDragMetrics.y)
+    await page.mouse.down()
+    await page.waitForTimeout(120)
+    await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
+    await page.mouse.up()
     const codeDrag = await dragLocatorText(page, codeContent, "token login code drag", {
       endX: codeDragMetrics.endX,
       startX: 80,

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -409,8 +409,8 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       if (!insideEditorDom && !codeShellTarget) return
       if (codeShellTarget) {
         cancelCodeDragSelectionPreserve()
-        rememberCodeTextDragStart(codeShellTarget, event)
-        clearImmediateWindowTextSelection()
+        const codeTextDragStart = rememberCodeTextDragStart(codeShellTarget, event)
+        if (codeTextDragStart && existingSelectionText) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root) } else clearImmediateWindowTextSelection()
       } else {
         codeTextDragStartRef.current = null
         if (insideEditorDom) {
@@ -454,9 +454,9 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const codeShellTarget = findCodeShellTarget(targetElement, pointElements)
       const pointInsideEditor = !targetElement?.closest("[data-table-menu-root='true']") && !targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR) && pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR)))
       const insideEditorDom = eventTarget instanceof Node && (activeEditor.view.dom.contains(eventTarget) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor)
-      if (!insideEditorDom && !codeShellTarget) return
-      if (codeTextDragStartRef.current && !codeShellTarget) codeTextDragStartRef.current = null
+      if (!insideEditorDom && !codeShellTarget) return; if (codeTextDragStartRef.current && !codeShellTarget) codeTextDragStartRef.current = null
       if (codeShellTarget) {
+        if (codeTextDragStartRef.current?.root.isConnected && isSelectionInsideCodeDragRoot(codeTextDragStartRef.current.root)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStartRef.current.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStartRef.current.root); return }
         cancelCodeDragSelectionPreserve()
         rememberCodeTextDragStart(codeShellTarget, event)
         clearImmediateWindowTextSelection()


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- PR #479 배포본의 실제 Chrome `/editor/507`에서 code Cmd+A 이후 code direct drag가 selection을 비우는 follow-up 회귀를 고정합니다.
- code pointerdown이 기존 code root selection을 re-arm한 뒤 이어지는 mousedown capture가 preserve를 취소하지 않도록 보존 경로를 유지했습니다.

## 작업 내용

- code block 내부 기존 selection이 있는 상태에서 pointerdown/mousedown 순서가 이어져도 code root selection과 scroll preserve를 유지합니다.
- live drag sequence E2E에 Cmd+A 직후 mousedown 단계에서 selection이 사라지지 않는 회귀 검증을 추가했습니다.
- live-shape code recovery E2E의 offscreen 대상 이동은 사용자 wheel cancel 경로를 거치게 해 scroll-preserve loop와 programmatic scroll flake를 분리했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front check:refactor-boundaries`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-code-recovery.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring` (2회 연속, 각 96/96)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: editor pointer/mousedown capture 경로 변경으로 code block drag selection 경계에서 추가 이벤트 순서 차이가 있을 수 있습니다.
- 롤백 방법: 이 PR을 revert하면 PR #479 상태로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
