### PR TITLE
[Fix] live code drag post-CmdA 보존

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -228,12 +228,65 @@ test.describe("editor authoring route live drag sequence", () => {
     await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
     await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforeCodeSelectAll + 24)
     await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforeCodeSelectAll - 24)
+    await codeContent.evaluate((element, metrics) => {
+      const rect = element.getBoundingClientRect()
+      const clientX = rect.left + 80
+      const clientY = rect.top + metrics.y
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      const range = document.createRange()
+      range.selectNodeContents(element)
+      selection?.addRange(range)
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, buttons: 1, cancelable: true, clientX, clientY, pointerType: "mouse" }))
+      window.getSelection()?.removeAllRanges()
+      element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0, buttons: 1, cancelable: true, clientX, clientY }))
+    }, codeDragMetrics)
+    await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
+    await codeContent.evaluate((element, metrics) => {
+      const rect = element.getBoundingClientRect()
+      const clientX = rect.left + 80
+      const clientY = rect.top + metrics.y
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, button: 0, buttons: 0, cancelable: true, clientX, clientY, pointerType: "mouse" }))
+      element.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 0, buttons: 0, cancelable: true, clientX, clientY }))
+    }, codeDragMetrics)
     const codeDragStartBox = await codeContent.boundingBox()
     if (!codeDragStartBox) throw new Error("code drag start metrics are missing")
+    await page.evaluate(() => {
+      ;(window as typeof window & { __qaCodeDragEvents?: unknown[] }).__qaCodeDragEvents = []
+      const record = (event: Event) => {
+        const pointerEvent = event instanceof MouseEvent || event instanceof PointerEvent ? event : null
+        const target = event.target instanceof Element ? event.target : event.target?.parentElement
+        const selection = window.getSelection()
+        ;(window as typeof window & { __qaCodeDragEvents?: unknown[] }).__qaCodeDragEvents?.push({
+          type: event.type,
+          buttons: pointerEvent?.buttons,
+          button: pointerEvent?.button,
+          x: pointerEvent?.clientX,
+          y: pointerEvent?.clientY,
+          targetClass: String(target?.className ?? ""),
+          selectionText: selection?.toString() ?? "",
+          persisted: Array.from(document.querySelectorAll("[data-code-drag-selection-text]")).map((element) => element.getAttribute("data-code-drag-selection-text")),
+        })
+        if (((window as typeof window & { __qaCodeDragEvents?: unknown[] }).__qaCodeDragEvents?.length ?? 0) > 40) {
+          ;(window as typeof window & { __qaCodeDragEvents?: unknown[] }).__qaCodeDragEvents?.shift()
+        }
+      }
+      for (const type of ["pointerdown", "mousedown", "selectionchange"] as const) {
+        document.addEventListener(type, record, { capture: true, once: type !== "selectionchange" })
+      }
+    })
     await page.mouse.move(codeDragStartBox.x + 80, codeDragStartBox.y + codeDragMetrics.y)
     await page.mouse.down()
     await page.waitForTimeout(120)
-    await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
+    const codeSelectionAfterMouseDown = await readSelectionText(page)
+    if (!codeSelectionAfterMouseDown.includes("createAccessToken")) {
+      const diagnostics = await page.evaluate(() => ({
+        selectionText: window.getSelection()?.toString() ?? "",
+        persisted: Array.from(document.querySelectorAll("[data-code-drag-selection-text]")).map((element) => element.getAttribute("data-code-drag-selection-text")),
+        events: (window as typeof window & { __qaCodeDragEvents?: unknown[] }).__qaCodeDragEvents ?? [],
+      }))
+      throw new Error(`code mousedown cleared selection: ${JSON.stringify(diagnostics)}`)
+    }
     await page.mouse.up()
     const codeDrag = await dragLocatorText(page, codeContent, "token login code drag", {
       endX: codeDragMetrics.endX,

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -185,7 +185,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         window.removeEventListener("pointerdown", cancelPreservedSelection, true)
         window.removeEventListener("mousedown", cancelPreservedSelection, true)
       }
-      const cancelPreservedSelection = () => cancelCodeDragSelectionPreserve()
+      const isCurrentCodeDragEvent = (event: Event) => { const codeTextDragStart = codeTextDragStartRef.current; const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null; const codeShell = root.closest(".aq-code-shell"); return Boolean(targetElement && (root.contains(targetElement) || codeShell?.contains(targetElement)) && ((codeTextDragStart?.scrollPreserveStarted && codeTextDragStart.root === root) || codeShell?.getAttribute("data-code-drag-selection-text")?.trim())) }, cancelPreservedSelection = (event: Event) => { if (!isCurrentCodeDragEvent(event)) cancelCodeDragSelectionPreserve() }
       const restore = () => {
         if (!root.isConnected) {
           codeDragSelectionPreserveRafId = null
@@ -400,7 +400,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const targetElement = eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
       const pointElements = document.elementsFromPoint(event.clientX, event.clientY)
       const codeShellTarget = findCodeShellTarget(targetElement, pointElements)
-      const existingSelectionText = window.getSelection()?.toString().trim() ?? ""
+      const existingSelectionText = window.getSelection()?.toString().trim() ?? "", existingCodeSelectionText = existingSelectionText || codeShellTarget?.getAttribute("data-code-drag-selection-text")?.trim() || ""
       const allowTableControlCellFallback = Boolean(existingSelectionText) && !isTableSelectionActive(activeEditor)
       const targetTableControl = targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR)
       const pointInsideEditor = !targetElement?.closest("[data-table-menu-root='true']") && (!targetTableControl || allowTableControlCellFallback) && pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR)))
@@ -410,7 +410,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       if (codeShellTarget) {
         cancelCodeDragSelectionPreserve()
         const codeTextDragStart = rememberCodeTextDragStart(codeShellTarget, event)
-        if (codeTextDragStart && existingSelectionText) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root) } else clearImmediateWindowTextSelection()
+        if (codeTextDragStart && existingCodeSelectionText) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root) } else clearImmediateWindowTextSelection()
       } else {
         codeTextDragStartRef.current = null
         if (insideEditorDom) {
@@ -456,7 +456,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const insideEditorDom = eventTarget instanceof Node && (activeEditor.view.dom.contains(eventTarget) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor)
       if (!insideEditorDom && !codeShellTarget) return; if (codeTextDragStartRef.current && !codeShellTarget) codeTextDragStartRef.current = null
       if (codeShellTarget) {
-        if (codeTextDragStartRef.current?.root.isConnected && isSelectionInsideCodeDragRoot(codeTextDragStartRef.current.root)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStartRef.current.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStartRef.current.root); return }
+        if (codeTextDragStartRef.current?.root.isConnected && (codeTextDragStartRef.current.scrollPreserveStarted || isSelectionInsideCodeDragRoot(codeTextDragStartRef.current.root))) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStartRef.current.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStartRef.current.root); return }
         cancelCodeDragSelectionPreserve()
         rememberCodeTextDragStart(codeShellTarget, event)
         clearImmediateWindowTextSelection()


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 실제 배포본 `/editor/507`에서 code Cmd+A 직후 direct drag가 selection/dataset을 비우는 회귀를 후속 수정합니다.
- code Cmd+A preserve가 DOM selection 대신 `data-code-drag-selection-text`만 남긴 상태에서도 다음 code pointerdown이 기존 code selection을 re-arm하도록 보강했습니다.

## 작업 내용

- 같은 code root 안에서 dataset이 남아 있는 pointerdown/mousedown은 preserve cancel 입력으로 처리하지 않습니다.
- code pointerdown re-arm이 DOM selection과 dataset 보존 텍스트를 모두 기존 code selection으로 인정합니다.
- live drag sequence E2E에 Cmd+A 직후 selection이 dataset-only가 되는 경로와 실제 mouse down 경로를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `yarn --cwd front check:refactor-boundaries`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1` -> 1/1 pass
  - `yarn --cwd front test:e2e:authoring` -> 96/96 pass (2회 연속)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: code block 선택 보존 시간이 남아 있는 동안 같은 code root 내부 클릭이 selection re-arm으로 유지될 수 있습니다.
- 롤백 방법: 이 PR을 revert하면 PR #480 배포본 동작으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
