### PR TITLE
[Fix] live code drag mousedown 보존

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -232,6 +232,14 @@ test.describe("editor authoring route live drag sequence", () => {
       const rect = element.getBoundingClientRect()
       const clientX = rect.left + 80
       const clientY = rect.top + metrics.y
+      element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0, buttons: 1, cancelable: true, clientX, clientY }))
+      element.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 0, buttons: 0, cancelable: true, clientX, clientY }))
+    }, codeDragMetrics)
+    await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
+    await codeContent.evaluate((element, metrics) => {
+      const rect = element.getBoundingClientRect()
+      const clientX = rect.left + 80
+      const clientY = rect.top + metrics.y
       const selection = window.getSelection()
       selection?.removeAllRanges()
       const range = document.createRange()

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -450,15 +450,15 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       if (!activeEditor) return
       const eventTarget = event.target
       const targetElement = eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
-      const pointElements = document.elementsFromPoint(event.clientX, event.clientY)
-      const codeShellTarget = findCodeShellTarget(targetElement, pointElements)
+      const pointElements = document.elementsFromPoint(event.clientX, event.clientY), codeShellTarget = findCodeShellTarget(targetElement, pointElements), existingCodeSelectionText = (window.getSelection()?.toString().trim() || codeShellTarget?.getAttribute("data-code-drag-selection-text")?.trim() || "")
       const pointInsideEditor = !targetElement?.closest("[data-table-menu-root='true']") && !targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR) && pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR)))
       const insideEditorDom = eventTarget instanceof Node && (activeEditor.view.dom.contains(eventTarget) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor)
       if (!insideEditorDom && !codeShellTarget) return; if (codeTextDragStartRef.current && !codeShellTarget) codeTextDragStartRef.current = null
       if (codeShellTarget) {
         if (codeTextDragStartRef.current?.root.isConnected && (codeTextDragStartRef.current.scrollPreserveStarted || isSelectionInsideCodeDragRoot(codeTextDragStartRef.current.root))) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStartRef.current.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStartRef.current.root); return }
         cancelCodeDragSelectionPreserve()
-        rememberCodeTextDragStart(codeShellTarget, event)
+        const codeTextDragStart = rememberCodeTextDragStart(codeShellTarget, event)
+        if (codeTextDragStart && existingCodeSelectionText) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root); return }
         clearImmediateWindowTextSelection()
       } else if (insideEditorDom) {
         codeTextDragStartRef.current = null


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 실제 배포본 `/editor/507`에서 code Cmd+A 직후 code direct drag가 selection/dataset을 비우는 follow-up 회귀를 수정합니다.
- pointerdown 재보존을 놓치고 mousedown capture로 들어오는 실제 Chrome/CUA 경로에서도 기존 code selection을 인정해 root selection과 scroll preserve를 다시 무장합니다.

## 작업 내용

- code block mousedown fallback이 기존 code selection 또는 `data-code-drag-selection-text`를 감지하면 selection clear 대신 code root selection preserve를 실행합니다.
- live drag sequence E2E에 mousedown-only 회귀를 추가해 실제 Chrome 이벤트 순서 차이를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `yarn --cwd front check:refactor-boundaries`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring` (첫 실행은 기존 3100 포트 점유 환경 실패, 잔여 Next test server 정리 후 재실행)
  - `yarn --cwd front test:e2e:authoring` (2회 연속 통과)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: code block 내부 select-all 이후 단일 클릭도 기존 selection preserve 경로를 탈 수 있습니다. 기존 pointerdown 경로와 같은 동작이며 drag selection 보존을 우선합니다.
- 롤백 방법: 이 PR을 revert하면 PR #481 상태로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
