### PR TITLE
[Fix] live table drag mousedown 보존

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -139,6 +139,24 @@ test.describe("editor authoring route live drag sequence", () => {
       const rect = element.getBoundingClientRect()
       return { y: rect.height / 2, endX: Math.min(rect.width - 8, 128) }
     })
+    await accessTokenCell.evaluate((element, metrics) => {
+      const rect = element.getBoundingClientRect()
+      const clientX = rect.left + 10
+      const clientY = rect.top + metrics.y
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      const range = document.createRange()
+      range.selectNodeContents(element)
+      selection?.addRange(range)
+      element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0, buttons: 1, cancelable: true, clientX, clientY }))
+    }, accessTokenBox)
+    expect(await readSelectionText(page)).toContain("Access Token")
+    await accessTokenCell.evaluate((element, metrics) => {
+      const rect = element.getBoundingClientRect()
+      const clientX = rect.left + 10
+      const clientY = rect.top + metrics.y
+      element.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 0, buttons: 0, cancelable: true, clientX, clientY }))
+    }, accessTokenBox)
     await page.evaluate(() => {
       ;(window as typeof window & { __qaTableDragEvents?: unknown[] }).__qaTableDragEvents = []
       const record = (event: MouseEvent | PointerEvent) => {

--- a/front/src/components/editor/BlockEditorEngine.tableStyles.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tableStyles.tsx
@@ -300,6 +300,10 @@ export const TableQuickRailButton = styled.button`
     inset: -0.5rem;
   }
 
+  &[data-axis="row"]::after {
+    inset: -0.5rem 0 -0.5rem -0.5rem;
+  }
+
   &:hover,
   &:focus-visible {
     background: ${({ theme }) =>

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -49,7 +49,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
   tableMenuState,
   tryStartTableColumnResizeFromDomHandle,
 }: UseBlockEditorEngineSelectionBubbleEffectsArgs) => {
-  const tableTextDragStartRef = useRef<{ cell: HTMLElement; scrollPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null)
+  const tableTextDragStartRef = useRef<{ cell: HTMLElement; coveredControlFallback: boolean; scrollPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null)
   const codeTextDragStartRef = useRef<{ root: HTMLElement; scrollPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null)
 
   useEffect(() => {
@@ -107,13 +107,14 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const pointElement = pointElements.find((element) => Boolean(element.closest("th, td"))) ?? document.elementFromPoint(event.clientX, event.clientY)
       const tableTextCell = pointElement?.closest("th, td") ?? targetElement?.closest("th, td")
       const tableControlTarget = targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR) ?? pointElements[0]?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR)
-      if (tableControlTarget && (!allowTableControlCellFallback || !(tableTextCell instanceof HTMLElement))) { tableTextDragStartRef.current = null; return null }
+      const tableCellRect = tableTextCell instanceof HTMLElement ? tableTextCell.getBoundingClientRect() : null, coveredControlFallback = Boolean(tableCellRect && tableControlTarget?.getAttribute("data-table-affordance") === "row-handle" && event.clientX >= tableCellRect.left && event.clientX <= tableCellRect.right && event.clientY >= tableCellRect.top && event.clientY <= tableCellRect.bottom)
+      if (tableControlTarget && (!(allowTableControlCellFallback || coveredControlFallback) || !(tableTextCell instanceof HTMLElement))) { tableTextDragStartRef.current = null; return null }
       const scrollAnchor = { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }
       if (tableTextCell instanceof HTMLElement) {
         tableTextCell.removeAttribute("data-table-drag-selection-text")
         markNextEditorPointerAfterTable()
       }
-      tableTextDragStartRef.current = tableTextCell instanceof HTMLElement ? { cell: tableTextCell, scrollPreserveStarted: false, scrollAnchor, x: event.clientX, y: event.clientY } : null
+      tableTextDragStartRef.current = tableTextCell instanceof HTMLElement ? { cell: tableTextCell, coveredControlFallback, scrollPreserveStarted: false, scrollAnchor, x: event.clientX, y: event.clientY } : null
       return tableTextDragStartRef.current
     }
 
@@ -419,11 +420,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         }
       }
       if (insideEditorDom) {
-        if (tableTextDragStart && existingSelectionText) {
-          event.preventDefault()
-          event.stopPropagation()
-          restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true)
-        }
+        if (tableTextDragStart && (existingSelectionText || tableTextDragStart.coveredControlFallback)) { event.preventDefault(); event.stopPropagation(); if (tableTextDragStart.coveredControlFallback) event.stopImmediatePropagation?.(); restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); if (tableTextDragStart.coveredControlFallback) { preserveTableCellTextSelectionAcrossFrames(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor); preserveActiveTableTextDragScroll() } }
         const blockSelectionActive = Boolean(document.querySelector("[data-testid='keyboard-block-selection-overlay']"))
         preserveWindowScrollForEditorPointerFocus(event.target, isTableSelectionActive(activeEditor), blockSelectionActive)
       }
@@ -450,9 +447,9 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       if (!activeEditor) return
       const eventTarget = event.target
       const targetElement = eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
-      const pointElements = document.elementsFromPoint(event.clientX, event.clientY), codeShellTarget = findCodeShellTarget(targetElement, pointElements), existingCodeSelectionText = (window.getSelection()?.toString().trim() || codeShellTarget?.getAttribute("data-code-drag-selection-text")?.trim() || "")
-      const pointInsideEditor = !targetElement?.closest("[data-table-menu-root='true']") && !targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR) && pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR)))
-      const insideEditorDom = eventTarget instanceof Node && (activeEditor.view.dom.contains(eventTarget) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor)
+      const pointElements = document.elementsFromPoint(event.clientX, event.clientY), codeShellTarget = findCodeShellTarget(targetElement, pointElements), existingSelectionText = window.getSelection()?.toString().trim() ?? "", existingCodeSelectionText = existingSelectionText || codeShellTarget?.getAttribute("data-code-drag-selection-text")?.trim() || ""
+      const allowTableControlCellFallback = Boolean(existingSelectionText) && !isTableSelectionActive(activeEditor), targetTableControl = targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR)
+      const pointInsideEditor = !targetElement?.closest("[data-table-menu-root='true']") && (!targetTableControl || allowTableControlCellFallback) && pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR))), insideEditorDom = eventTarget instanceof Node && (activeEditor.view.dom.contains(eventTarget) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor), columnResizeTarget = targetElement?.closest(".column-resize-handle"), tableTextDragStart = insideEditorDom && !codeShellTarget ? tableTextDragStartRef.current ?? rememberTableTextDragStart(event, allowTableControlCellFallback) : null
       if (!insideEditorDom && !codeShellTarget) return; if (codeTextDragStartRef.current && !codeShellTarget) codeTextDragStartRef.current = null
       if (codeShellTarget) {
         if (codeTextDragStartRef.current?.root.isConnected && (codeTextDragStartRef.current.scrollPreserveStarted || isSelectionInsideCodeDragRoot(codeTextDragStartRef.current.root))) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStartRef.current.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStartRef.current.root); return }
@@ -461,13 +458,12 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         if (codeTextDragStart && existingCodeSelectionText) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root); return }
         clearImmediateWindowTextSelection()
       } else if (insideEditorDom) {
-        codeTextDragStartRef.current = null
-        cancelCodeDragSelectionPreserve()
-        clearImmediateWindowTextSelection()
+        codeTextDragStartRef.current = null; cancelCodeDragSelectionPreserve()
+        if (tableTextDragStart && tableTextDragStart.coveredControlFallback && !columnResizeTarget) { event.preventDefault(); event.stopPropagation(); event.stopImmediatePropagation?.(); restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); preserveTableCellTextSelectionAcrossFrames(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor); preserveActiveTableTextDragScroll() } else if (tableTextDragStart && existingSelectionText) restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); else if (!tableTextDragStart || !existingSelectionText) clearImmediateWindowTextSelection()
       }
       if (!insideEditorDom) return
-      if (!tableTextDragStartRef.current) rememberTableTextDragStart(event)
-      if (!targetElement?.closest(".column-resize-handle")) return
+      if (!tableTextDragStartRef.current) rememberTableTextDragStart(event, allowTableControlCellFallback)
+      if (!columnResizeTarget) return
       event.preventDefault()
       event.stopPropagation()
       event.stopImmediatePropagation?.()
@@ -527,7 +523,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
           preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root)
         }
       }
-      if (activeEditor && tableTextDragStart && tableTextDragMoved && restoreActiveTableTextDragSelection(true, true)) {
+      if (activeEditor && tableTextDragStart && (tableTextDragMoved || tableTextDragStart.coveredControlFallback) && restoreActiveTableTextDragSelection(true, true)) {
         event.preventDefault()
         event.stopPropagation()
         preserveActiveTableTextDragScroll()


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 실제 Chrome /editor/507에서 table row handle hit-area가 셀 본문을 덮어 Access Token drag가 옆 셀로 탈출하는 회귀를 복구합니다.
- table mousedown fallback은 covered row-handle 입력에서 started cell selection/scroll preserve를 즉시 재무장합니다.

## 작업 내용

- table row grip pseudo hit-area가 셀 본문 쪽으로 확장되지 않도록 제한했습니다.
- table drag start가 row-handle overlay에 가려져도 underlying cell selection을 보존하도록 fallback을 보강했습니다.
- live drag sequence E2E에 table mousedown-only selection 보존 회귀를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front check:refactor-boundaries`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-selection-drag.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring` (96/96, 2회 연속)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: row handle hit-area 축소로 row grip 클릭 가능 영역이 오른쪽 셀 본문 방향으로만 줄어듭니다. 기존 row/column/table affordance E2E는 통과했습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
