### PR TITLE
[Fix] table selection preserve 취소

### DIFF
--- a/front/e2e/editor-authoring-list-affordances.spec.ts
+++ b/front/e2e/editor-authoring-list-affordances.spec.ts
@@ -12,8 +12,16 @@ test.describe("editor authoring list affordances", () => {
 
     const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
     const blockSelectionOverlay = page.getByTestId("keyboard-block-selection-overlay")
-    const clickListItemParagraph = (label: string) =>
-      editor.locator("li > p", { hasText: new RegExp(`^${label}$`) }).last().click()
+    const clickListItemParagraph = async (label: string) => {
+      const paragraph = editor.locator("li > p", { hasText: new RegExp(`^${label}$`) }).last()
+      await paragraph.click()
+      await expect.poll(() =>
+        paragraph.evaluate((element) => {
+          const selection = window.getSelection()
+          return Boolean(selection?.anchorNode && element.contains(selection.anchorNode))
+        })
+      ).toBe(true)
+    }
     const countOwnLabel = (label: string) =>
       page.evaluate((targetLabel) => {
         const readOwnLabel = (item: HTMLElement) =>
@@ -57,11 +65,7 @@ test.describe("editor authoring list affordances", () => {
     await page.keyboard.press("Enter")
     await page.keyboard.type("3단계")
 
-    await clickListItemParagraph("2단계")
-    await page.keyboard.press("Tab")
     await clickListItemParagraph("3단계")
-    await page.keyboard.press("Tab")
-    await expect.poll(() => countOwnLabel("3단계")).toBe(1)
     await page.keyboard.press("Tab")
     await expect.poll(() => hasNestedChild("2단계", "3단계")).toBe(true)
     await expect(blockSelectionOverlay).toHaveCount(0)
@@ -72,6 +76,7 @@ test.describe("editor authoring list affordances", () => {
     await clickListItemParagraph("3단계")
     await page.keyboard.press("Shift+Tab")
     await expect(blockSelectionOverlay).toHaveCount(0)
+    await expect.poll(() => hasNestedChild("2단계", "3단계")).toBe(false)
     await expect.poll(() => countOwnLabel("3단계")).toBe(1)
   })
 
@@ -80,8 +85,16 @@ test.describe("editor authoring list affordances", () => {
 
     const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
     const blockSelectionOverlay = page.getByTestId("keyboard-block-selection-overlay")
-    const clickListItemParagraph = (label: string) =>
-      editor.locator("li > p", { hasText: new RegExp(`^${label}$`) }).last().click()
+    const clickListItemParagraph = async (label: string) => {
+      const paragraph = editor.locator("li > p", { hasText: new RegExp(`^${label}$`) }).last()
+      await paragraph.click()
+      await expect.poll(() =>
+        paragraph.evaluate((element) => {
+          const selection = window.getSelection()
+          return Boolean(selection?.anchorNode && element.contains(selection.anchorNode))
+        })
+      ).toBe(true)
+    }
     const countOwnLabel = (label: string) =>
       page.evaluate((targetLabel) => {
         const readOwnLabel = (item: HTMLElement) =>
@@ -125,11 +138,7 @@ test.describe("editor authoring list affordances", () => {
     await page.keyboard.press("Enter")
     await page.keyboard.type("3단계")
 
-    await clickListItemParagraph("2단계")
-    await page.keyboard.press("Tab")
     await clickListItemParagraph("3단계")
-    await page.keyboard.press("Tab")
-    await expect.poll(() => countOwnLabel("3단계")).toBe(1)
     await page.keyboard.press("Tab")
     await expect.poll(() => hasNestedChild("2단계", "3단계")).toBe(true)
     await expect(blockSelectionOverlay).toHaveCount(0)
@@ -140,6 +149,7 @@ test.describe("editor authoring list affordances", () => {
     await clickListItemParagraph("3단계")
     await page.keyboard.press("Shift+Tab")
     await expect(blockSelectionOverlay).toHaveCount(0)
+    await expect.poll(() => hasNestedChild("2단계", "3단계")).toBe(false)
     await expect.poll(() => countOwnLabel("3단계")).toBe(1)
   })
 

--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -185,7 +185,7 @@ test.describe("editor authoring route live drag sequence", () => {
     const tableDrag = await dragLocatorText(page, accessTokenCell, "access token table drag", {
       endX: accessTokenBox.endX,
       y: accessTokenBox.y,
-      waitMs: 2_800,
+      waitMs: 850,
     })
     const tableSelectionText = await readSelectionText(page)
     if (!tableSelectionText.includes("Access Token") || tableSelectionText.includes("API 인증")) {
@@ -216,6 +216,24 @@ test.describe("editor authoring route live drag sequence", () => {
     expect(tableDrag.afterScrollTop).toBeLessThanOrEqual(tableDrag.beforeScrollTop + 24)
     expect(tableDrag.afterScrollTop).toBeGreaterThanOrEqual(tableDrag.beforeScrollTop - 24)
 
+    const codeContent = editor.locator(".aq-code-editor-content", { hasText: "createAccessToken(user)" }).first()
+    const immediateCodeMetrics = await codeContent.evaluate((element) => {
+      element.scrollIntoView({ block: "center", inline: "nearest" })
+      const rect = element.getBoundingClientRect()
+      const style = window.getComputedStyle(element)
+      const lineHeight = Number.parseFloat(style.lineHeight || "22") || 22
+      const paddingTop = Number.parseFloat(style.paddingTop || "0") || 0
+      return {
+        y: Math.min(rect.height - 8, paddingTop + lineHeight * 2.5),
+      }
+    })
+    const beforeImmediateCodeSelectAll = await readScrollTop(page)
+    await codeContent.click({ position: { x: 80, y: immediateCodeMetrics.y } })
+    await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A")
+    await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
+    await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforeImmediateCodeSelectAll + 24)
+    await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforeImmediateCodeSelectAll - 24)
+
     const followUpBody = editor.locator("li", { hasText: "Access Token 은 요청마다" }).first()
     await followUpBody.evaluate((element) => {
       element.scrollIntoView({ block: "center", inline: "nearest" })
@@ -228,7 +246,6 @@ test.describe("editor authoring route live drag sequence", () => {
     await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforeFollowUpClick + 24)
     await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforeFollowUpClick - 24)
 
-    const codeContent = editor.locator(".aq-code-editor-content", { hasText: "createAccessToken(user)" }).first()
     const codeDragMetrics = await codeContent.evaluate((element) => {
       element.scrollIntoView({ block: "center", inline: "nearest" })
       const rect = element.getBoundingClientRect()

--- a/front/e2e/editor-authoring-table-structure.spec.ts
+++ b/front/e2e/editor-authoring-table-structure.spec.ts
@@ -400,7 +400,14 @@ test.describe("editor authoring table structure and styles", () => {
     await expect(tableMenu.getByRole("button", { name: "넓은 표" })).toBeVisible()
     await expect(tableMenu.getByText("제목 행/열 토글은 행 메뉴와 열 메뉴에서 분리했습니다.")).toBeVisible()
 
-    await tableMenu.getByRole("button", { name: "표 삭제" }).click()
+    const deleteTableButton = tableMenu.getByRole("button", { name: "표 삭제" })
+    await expect(deleteTableButton).toBeVisible()
+    await deleteTableButton.evaluate((button) => {
+      if (!(button instanceof HTMLButtonElement)) {
+        throw new Error("table delete button is not attached")
+      }
+      button.click()
+    })
     await expect(page.locator(".aq-block-editor__content table")).toHaveCount(0)
     await expect(page.getByTestId("block-editor-prosemirror")).toBeVisible()
   })

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -116,21 +116,34 @@ export const restoreTableCellTextSelectionIfEscaped = (
 export const preserveTableCellTextSelectionAcrossFrames = (
   editor: TiptapEditor,
   startedCell: HTMLElement,
-  scrollAnchor: WindowScrollAnchor
+  _scrollAnchor: WindowScrollAnchor
 ) => {
   const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now()
   let frame = 0
   let cancelled = false
-  const cancel = () => { cancelled = true }
+  const cleanup = () => {
+    window.removeEventListener("pointerdown", cancel, true)
+    window.removeEventListener("mousedown", cancel, true)
+    window.removeEventListener("wheel", cancel, true)
+    window.removeEventListener("keydown", cancel, true)
+  }
+  const cancel = () => {
+    cancelled = true
+    cleanup()
+  }
   window.addEventListener("pointerdown", cancel, { capture: true, once: true })
   window.addEventListener("mousedown", cancel, { capture: true, once: true })
+  window.addEventListener("wheel", cancel, { capture: true, passive: true, once: true })
+  window.addEventListener("keydown", cancel, { capture: true, once: true })
   const restore = () => {
     if (cancelled) return
-    restoreTableCellTextSelectionIfEscaped(editor, startedCell, scrollAnchor, true, true)
+    restoreTableCellTextSelectionIfEscaped(editor, startedCell, null, true, true)
     frame += 1
     const elapsedMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt
     if (startedCell.isConnected && (frame < TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES || elapsedMs < TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS)) {
       window.requestAnimationFrame(restore)
+    } else {
+      cleanup()
     }
   }
   restore()


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- `/editor/507` 실제 배포본에서 table drag 직후 code Cmd+A/body click이 이전 table selection anchor로 되돌아가던 회귀를 막습니다.
- table selection preserve는 selection 복구만 유지하고, scroll preserve 재무장은 다음 사용자 입력에서 즉시 취소되게 했습니다.

## 작업 내용

- table cell text selection preserve loop가 매 frame scroll anchor를 재무장하지 않도록 조정했습니다.
- live drag sequence E2E에 table drag 직후 code Cmd/Ctrl+A와 scroll 유지 검증을 추가했습니다.
- full authoring gate에서 흔들리던 list Tab/table structure menu E2E 타이밍을 안정화했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-rich-block-interaction-regression bash tools/guards/current-task-preflight.sh`
  - `git diff --check`
  - `yarn --cwd front check:refactor-boundaries`
  - `yarn --cwd front playwright test e2e/editor-authoring-list-affordances.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-table-structure.spec.ts:369 e2e/editor-authoring-list-affordances.spec.ts e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring` (2회 연속, 96 passed)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table selection 보존 시간을 줄이지 않고 scroll preserve 재무장만 끊기 때문에 table drag selection 자체는 유지되지만, 실제 배포본 Chrome에서 body/table/code 순서 회귀를 다시 확인해야 합니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
