### PR TITLE
[Fix] live code loss guard 복구

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -233,6 +233,7 @@ test.describe("editor authoring route live drag sequence", () => {
     await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
     await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforeImmediateCodeSelectAll + 24)
     await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforeImmediateCodeSelectAll - 24)
+    await page.mouse.wheel(0, 1).then(() => page.waitForTimeout(40))
 
     const followUpBody = editor.locator("li", { hasText: "Access Token 은 요청마다" }).first()
     await followUpBody.evaluate((element) => {

--- a/front/e2e/editor-load-sync-guard.spec.ts
+++ b/front/e2e/editor-load-sync-guard.spec.ts
@@ -3,6 +3,7 @@ import {
   consumeGuardOnExpectedUpdate,
   createBlockEditorLoadGuardState,
   markGuardEmptyUpdateIgnored,
+  restoreBlockEditorCodeLossUpdate,
   shouldIgnoreBlockEditorEmptyUpdate,
 } from "src/routes/Admin/editorLoadSyncGuard"
 
@@ -83,5 +84,54 @@ test.describe("editor load sync guard", () => {
         nowMs: nowMs + 150,
       })
     ).toBe(false)
+  })
+
+  test("focus 없는 지연 code fence 손실은 hold 시간이 지나도 expected body로 복구한다", () => {
+    const nowMs = 4_000
+    const expectedBody = [
+      "코드 지연 복구 대상입니다.",
+      "",
+      "```java",
+      "public Token login(User user) {",
+      "    return createAccessToken(user);",
+      "}",
+      "```",
+    ].join("\n")
+    const staleUpdate = [
+      "코드 지연 복구 대상입니다.",
+      "",
+      "```java",
+      "```",
+    ].join("\n")
+    const guard = createBlockEditorLoadGuardState(expectedBody, nowMs, 1_200)
+
+    const restored = restoreBlockEditorCodeLossUpdate({
+      nextMarkdown: staleUpdate,
+      currentMarkdown: expectedBody,
+      guardState: guard,
+      nowMs: nowMs + 3_000,
+    })
+
+    expect(restored.changed).toBe(true)
+    expect(restored.markdown).toContain("createAccessToken(user)")
+
+    const focusedEdit = restoreBlockEditorCodeLossUpdate({
+      nextMarkdown: staleUpdate,
+      currentMarkdown: expectedBody,
+      guardState: guard,
+      editorFocused: true,
+      nowMs: nowMs + 3_000,
+    })
+
+    expect(focusedEdit.changed).toBe(false)
+
+    const afterUserEdit = restoreBlockEditorCodeLossUpdate({
+      nextMarkdown: staleUpdate,
+      currentMarkdown: expectedBody.replace("코드 지연 복구 대상입니다.", "사용자 수정 본문입니다."),
+      guardState: guard,
+      nowMs: nowMs + 3_000,
+    })
+
+    expect(afterUserEdit.changed).toBe(false)
   })
 })

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -72,11 +72,12 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
   const [draftLanguage, setDraftLanguage] = useState(normalizeCodeLanguage(String(node.attrs?.language || "")))
   const [isLanguageMenuOpen, setIsLanguageMenuOpen] = useState(false)
   const [languageSearch, setLanguageSearch] = useState("")
-  const initialCodeSource = node.textContent || ""
-  const [liveCodeSource, setLiveCodeSource] = useState(initialCodeSource)
+  const nodeCodeSource = node.textContent || ""
+  const nodeCodeSourceRef = useRef(nodeCodeSource)
+  const [liveCodeSource, setLiveCodeSource] = useState(nodeCodeSource)
   const [highlightedCodeHtml, setHighlightedCodeHtml] = useState(() =>
     renderImmediateCodeToHtml({
-      source: initialCodeSource,
+      source: nodeCodeSource,
       language: normalizeCodeLanguage(String(node.attrs?.language || "")),
     }).html
   )
@@ -135,7 +136,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
         const contentBaseOffset = highlightText ? Math.max(0, contentText.indexOf(highlightText)) : 0
         return Math.min(contentText.length, contentBaseOffset + highlightOffset)
       }
-
       if (contentRoot && caretNode && typeof caretOffset === "number" && contentRoot.contains(caretNode)) {
         try {
           pointerPos = editor.view.posAtDOM(caretNode, caretOffset)
@@ -143,7 +143,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
           pointerPos = null
         }
       }
-
       if (pointerPos === null && caretNode && typeof caretOffset === "number") {
         const highlightTextOffset = resolveHighlightTextOffset(caretNode, caretOffset)
         const contentPosition =
@@ -158,12 +157,10 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
           }
         }
       }
-
       if (pointerPos === null) {
         const coords = editor.view.posAtCoords({ left: clientX, top: clientY })
         pointerPos = coords?.pos ?? null
       }
-
       if (pointerPos === null) return
       return Math.min(Math.max(pointerPos, from), to)
     },
@@ -332,8 +329,9 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
   }, [node.attrs?.language])
 
   useEffect(() => {
-    setLiveCodeSource(node.textContent || "")
-  }, [node.textContent])
+    nodeCodeSourceRef.current = nodeCodeSource
+    setLiveCodeSource(nodeCodeSource)
+  }, [nodeCodeSource])
 
   useEffect(() => {
     const shell = shellRef.current
@@ -346,12 +344,13 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     let frameId: number | null = null
 
     const syncLiveCodeSource = () => {
-      const nextValue = resolveEditorContent()?.textContent || ""
+      const contentText = resolveEditorContent()?.textContent || ""
+      const sourceFromNode = nodeCodeSourceRef.current
+      const nextValue = contentText.trim() || !sourceFromNode.trim() ? contentText : sourceFromNode
       setLiveCodeSource((current) => (current === nextValue ? current : nextValue))
     }
 
     syncLiveCodeSource()
-
     const handleDocumentPointerDown = (event: PointerEvent) => {
       const target = event.target
       if (!(target instanceof Node)) return

--- a/front/src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx
+++ b/front/src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx
@@ -206,6 +206,7 @@ export const EditorStudioWorkspaceController = ({ initialMember }: AdminPageProp
 
     const restoredCodeLossUpdate = restoreBlockEditorCodeLossUpdate({
       nextMarkdown,
+      currentMarkdown: previousMarkdown,
       guardState: nextGuardState,
       editorFocused: meta?.editorFocused === true,
     })

--- a/front/src/routes/Admin/editorLoadSyncGuard.ts
+++ b/front/src/routes/Admin/editorLoadSyncGuard.ts
@@ -74,16 +74,23 @@ export const markGuardEmptyUpdateIgnored = (
 
 export const restoreBlockEditorCodeLossUpdate = ({
   nextMarkdown,
+  currentMarkdown,
   guardState,
   editorFocused = false,
   nowMs = Date.now(),
 }: {
   nextMarkdown: string
+  currentMarkdown?: string
   guardState: BlockEditorLoadGuardState
   editorFocused?: boolean
   nowMs?: number
 }) => {
-  if (editorFocused || nowMs > guardState.ignoreUntilMs || !guardState.expectedBody) {
+  if (editorFocused || !guardState.expectedBody) {
+    return { markdown: nextMarkdown, changed: false }
+  }
+
+  const normalizedCurrent = normalizeEditorMarkdown(currentMarkdown ?? guardState.expectedBody)
+  if (nowMs > guardState.ignoreUntilMs && normalizedCurrent !== guardState.expectedBody) {
     return { markdown: nextMarkdown, changed: false }
   }
 


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 배포본 /editor/507에서 최신 build SHA임에도 일반 code block 본문과 highlight DOM이 빈 값으로 재손실되는 문제를 막습니다.
- focus 없는 자동 editor commit이 빈 code fence를 올리면 expected body 기준으로 복구하고, NodeView highlight source도 빈 DOM 타이밍에 덮이지 않게 했습니다.

## 작업 내용

- editor load guard가 hold 시간 이후에도 focus 없는 code-loss update를 expected body로 복구하도록 보강했습니다.
- CodeBlock NodeView가 content DOM이 일시적으로 비어도 node text source를 유지해 highlight가 빈 값으로 고정되지 않게 했습니다.
- CodeRabbit 지적에 따라 node source는 ref로 읽고 document listener/MutationObserver effect dependency churn을 제거했습니다.
- 지연 code fence 손실 복구 단위 테스트를 추가했습니다.
- live drag sequence spec은 code select-all 직후 실제 wheel cancel을 넣어 CI의 programmatic scrollIntoView/selection reveal 경쟁 flake를 막았습니다.

## 검증

- 실행한 명령과 결과:
  - git diff --check
  - CURRENT_TASK_SLUG=editor-rich-block-interaction-regression bash tools/guards/current-task-preflight.sh
  - yarn --cwd front playwright:preflight
  - yarn --cwd front check:refactor-boundaries
  - yarn --cwd front playwright test e2e/editor-load-sync-guard.spec.ts --workers=1
  - yarn --cwd front playwright test e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1
  - yarn --cwd front test:e2e:authoring (2회 연속 통과, 96 passed x2)
  - yarn --cwd front playwright test e2e/editor-load-sync-guard.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1 (최종 code diff 기준 11 passed)
  - yarn --cwd front build
  - yarn --cwd front check:bundle-size
  - yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1 (flake 보강 후 2회 연속 통과)
  - yarn --cwd front test:e2e:authoring (flake 보강 후 96 passed)
  - yarn --cwd front playwright test e2e/editor-load-sync-guard.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1 (CodeRabbit 대응 후 11 passed)
  - yarn --cwd front test:e2e:authoring (CodeRabbit 대응 후 96 passed)
  - yarn --cwd front build (CodeRabbit 대응 후)
  - yarn --cwd front check:bundle-size (CodeRabbit 대응 후)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: focus 없는 자동 동기화에서만 code fence 복구가 개입하므로 실제 사용자가 focus 상태에서 코드를 비우는 편집은 복구하지 않습니다.
- 롤백 방법: 이 PR의 squash commit을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
