### PR TITLE
[Fix] live code drag dataset 복구

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -293,6 +293,18 @@ test.describe("editor authoring route live drag sequence", () => {
       element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, button: 0, buttons: 0, cancelable: true, clientX, clientY, pointerType: "mouse" }))
       element.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 0, buttons: 0, cancelable: true, clientX, clientY }))
     }, codeDragMetrics)
+    await codeContent.evaluate((element, metrics) => {
+      const rect = element.getBoundingClientRect()
+      const startX = rect.left + 80
+      const clientY = rect.top + metrics.y
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      element.closest(".aq-code-shell")?.removeAttribute("data-code-drag-selection-text")
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, buttons: 1, cancelable: true, clientX: startX, clientY, pointerType: "mouse" }))
+      element.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, button: 0, buttons: 1, cancelable: true, clientX: rect.left + metrics.endX, clientY, pointerType: "mouse" }))
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, button: 0, buttons: 0, cancelable: true, clientX: rect.left + metrics.endX, clientY, pointerType: "mouse" }))
+    }, codeDragMetrics)
+    await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
     const codeDragStartBox = await codeContent.boundingBox()
     if (!codeDragStartBox) throw new Error("code drag start metrics are missing")
     await page.evaluate(() => {

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -273,8 +273,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
 
   useEffect(() => {
     if (typeof window === "undefined") return
-
-    const handleWindowMouseMove = (event: MouseEvent) => {
+    const handleWindowMouseMove = (event: MouseEvent | PointerEvent) => {
       const session = codeDragSelectionRef.current
       if (!session) return
       const contentRoot =
@@ -289,8 +288,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       applyCodeTextSelection(session.anchorPos, headPos)
       preserveCodeDomTextRange(contentRoot, session.anchorPos, headPos)
     }
-
-    const handleWindowMouseUp = (event: MouseEvent) => {
+    const handleWindowMouseUp = (event: MouseEvent | PointerEvent) => {
       const session = codeDragSelectionRef.current
       if (!session) return
       codeDragSelectionRef.current = null
@@ -304,15 +302,19 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       event.preventDefault()
       event.stopPropagation()
     }
-
     window.addEventListener("mousemove", handleWindowMouseMove, true)
+    window.addEventListener("pointermove", handleWindowMouseMove, true)
     window.addEventListener("mouseup", handleWindowMouseUp, true)
+    window.addEventListener("pointerup", handleWindowMouseUp, true)
+    window.addEventListener("pointercancel", handleWindowMouseUp, true)
     return () => {
       window.removeEventListener("mousemove", handleWindowMouseMove, true)
+      window.removeEventListener("pointermove", handleWindowMouseMove, true)
       window.removeEventListener("mouseup", handleWindowMouseUp, true)
+      window.removeEventListener("pointerup", handleWindowMouseUp, true)
+      window.removeEventListener("pointercancel", handleWindowMouseUp, true)
     }
   }, [applyCodeTextSelection, preserveCodeDomTextRange, resolveCodeTextPosFromPointer])
-
   const ensureCodeDomTextSelection = useCallback((contentRoot: HTMLElement | null) => {
     if (!contentRoot || typeof window === "undefined") return
     window.requestAnimationFrame(() => {
@@ -323,7 +325,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       selectDomTextContents(contentRoot)
     })
   }, [])
-
   useEffect(() => {
     setDraftLanguage(normalizeCodeLanguage(String(node.attrs?.language || "")))
   }, [node.attrs?.language])


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 배포본 /editor/507에서 code block 텍스트와 Cmd+A는 복구됐지만, 실제 Chrome code direct drag가 빈 선택으로 끝나는 회귀를 고정합니다.
- code drag 세션을 mouse 이벤트뿐 아니라 pointermove/pointerup에서도 완료 처리해 CUA/실제 Chrome 입력 경로에서 선택 텍스트 dataset을 남깁니다.

## 작업 내용

- CodeBlock NodeView의 drag session 보존 로직이 pointermove/pointerup 입력도 처리하도록 확장했습니다.
- live-drag E2E에 pointer-only code drag 회귀 케이스를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `CURRENT_TASK_SLUG=editor-rich-block-interaction-regression bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front check:refactor-boundaries`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-load-sync-guard.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - 배포본 PR #485 merge commit에서 실제 Chrome /editor/507 재현: code direct drag selection empty 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: code drag listener가 pointer/mouse 중복 이벤트를 받을 수 있으나 session null 처리로 중복 종료를 방지합니다.
- 롤백 방법: 이 PR revert.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
