### PR TITLE
[Fix] live code drag mouseup dataset 복구

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -344,6 +344,10 @@ test.describe("editor authoring route live drag sequence", () => {
       throw new Error(`code mousedown cleared selection: ${JSON.stringify(diagnostics)}`)
     }
     await page.mouse.up()
+    await codeContent.evaluate((element) => {
+      window.getSelection()?.removeAllRanges()
+      element.closest(".aq-code-shell")?.removeAttribute("data-code-drag-selection-text")
+    })
     const codeDrag = await dragLocatorText(page, codeContent, "token login code drag", {
       endX: codeDragMetrics.endX,
       startX: 80,

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -50,19 +50,16 @@ import {
   preserveWindowScrollForRichBlockSelectAll,
   preserveWindowScrollPositionAcrossFrames,
 } from "./blockHandleLayoutModel"
-
 export { getPreferredCodeLanguage, normalizeCodeLanguage } from "./codeBlockNodeViewLanguageModel"
 export { CodeBlockEditorStyles } from "./codeBlockNodeViewStyles"
-
 let lastActiveCodeBlockContentRoot: HTMLElement | null = null
-
 type CodeDragSelectionSession = {
   active: boolean
   anchorPos: number
+  lastHeadPos?: number
   startX: number
   startY: number
 }
-
 export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos }: NodeViewProps) => {
   const menuId = useId()
   const menuRef = useRef<HTMLDivElement>(null)
@@ -81,12 +78,10 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       language: normalizeCodeLanguage(String(node.attrs?.language || "")),
     }).html
   )
-
   const selectCurrentCodeBlockText = useCallback(
     () => selectCodeBlockText({ editor, getPos, nodeSize: node.nodeSize }),
     [editor, getPos, node.nodeSize]
   )
-
   const resolveCodeTextPosFromPointer = useCallback(
     (clientX: number, clientY: number, contentRoot: HTMLElement | null) => {
       if (typeof getPos !== "function") return
@@ -166,7 +161,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     },
     [editor, getPos, node.nodeSize]
   )
-
   const applyCodeTextSelection = useCallback(
     (anchorPos: number, headPos: number) => {
       const nextSelection = TextSelection.create(editor.state.doc, Math.min(anchorPos, headPos), Math.max(anchorPos, headPos))
@@ -175,7 +169,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     },
     [editor]
   )
-
   const selectCodeDomTextRange = useCallback(
     (contentRoot: HTMLElement | null, anchorPos: number, headPos: number) => {
       if (typeof getPos !== "function" || !contentRoot) return false
@@ -186,7 +179,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     },
     [getPos]
   )
-
   const preserveCodeDomTextRange = useCallback(
     (contentRoot: HTMLElement | null, anchorPos: number, headPos: number) => {
       const scrollAnchor = { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }
@@ -219,7 +211,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     },
     [selectCodeDomTextRange]
   )
-
   const startCodeDragSelection = useCallback(
     (event: ReactMouseEvent<HTMLDivElement> | ReactPointerEvent<HTMLDivElement>) => {
       const shell = shellRef.current
@@ -273,16 +264,23 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
 
   useEffect(() => {
     if (typeof window === "undefined") return
+    const resolveFallbackHeadPos = (anchorPos: number) => {
+      const codeBlockPos = typeof getPos === "function" ? getPos() : undefined
+      if (typeof codeBlockPos !== "number") return anchorPos
+      const from = codeBlockPos + 1, to = codeBlockPos + Math.max(1, node.nodeSize - 1)
+      return anchorPos <= (from + to) / 2 ? to : from
+    }
     const handleWindowMouseMove = (event: MouseEvent | PointerEvent) => {
       const session = codeDragSelectionRef.current
       if (!session) return
       const contentRoot =
         shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
-      const headPos = resolveCodeTextPosFromPointer(event.clientX, event.clientY, contentRoot)
-      if (typeof headPos !== "number") return
       const distance = Math.hypot(event.clientX - session.startX, event.clientY - session.startY)
       if (!session.active && distance < 3) return
+      const resolvedHeadPos = resolveCodeTextPosFromPointer(event.clientX, event.clientY, contentRoot)
+      const headPos = typeof resolvedHeadPos === "number" ? resolvedHeadPos : resolveFallbackHeadPos(session.anchorPos)
       session.active = true
+      session.lastHeadPos = headPos
       event.preventDefault()
       event.stopPropagation()
       applyCodeTextSelection(session.anchorPos, headPos)
@@ -295,10 +293,9 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       if (!session.active) return
       const contentRoot =
         shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
-      const headPos = resolveCodeTextPosFromPointer(event.clientX, event.clientY, contentRoot)
-      if (typeof headPos === "number") {
-        preserveCodeDomTextRange(contentRoot, session.anchorPos, headPos)
-      }
+      const resolvedHeadPos = resolveCodeTextPosFromPointer(event.clientX, event.clientY, contentRoot)
+      const headPos = typeof resolvedHeadPos === "number" ? resolvedHeadPos : session.lastHeadPos ?? resolveFallbackHeadPos(session.anchorPos)
+      preserveCodeDomTextRange(contentRoot, session.anchorPos, headPos)
       event.preventDefault()
       event.stopPropagation()
     }
@@ -314,7 +311,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       window.removeEventListener("pointerup", handleWindowMouseUp, true)
       window.removeEventListener("pointercancel", handleWindowMouseUp, true)
     }
-  }, [applyCodeTextSelection, preserveCodeDomTextRange, resolveCodeTextPosFromPointer])
+  }, [applyCodeTextSelection, getPos, node.nodeSize, preserveCodeDomTextRange, resolveCodeTextPosFromPointer])
   const ensureCodeDomTextSelection = useCallback((contentRoot: HTMLElement | null) => {
     if (!contentRoot || typeof window === "undefined") return
     window.requestAnimationFrame(() => {


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 배포본 /editor/507에서 body/table drag, code visibility, code Cmd+A, scroll 보존은 통과했지만 실제 Chrome code direct drag가 mouseup 후 빈 선택으로 끝나는 회귀를 고정합니다.
- code drag move 좌표를 못 푸는 실제 입력 경로에서도 drag session을 활성화하고, mouseup에서 fallback head position으로 DOM selection/dataset을 최종 확정합니다.

## 작업 내용

- CodeBlock NodeView의 drag session에 마지막 head position fallback을 저장하고, 좌표 해석 실패 시 code block 경계까지 선택을 확정하도록 보강했습니다.
- live-drag E2E가 실제 code drag 직전 stale dataset을 지워 빈 선택 false-positive를 막도록 수정했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-rich-block-interaction-regression bash tools/guards/current-task-preflight.sh`
  - `git diff --check`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `yarn --cwd front check:refactor-boundaries`
  - `yarn --cwd front playwright test e2e/editor-load-sync-guard.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - 배포본 PR #486 merge commit `ff46f057327e7133a449f5de67156eeb298bda20` 실제 Chrome /editor/507 재현: code direct drag selection empty, data-code-drag-selection-text empty, scrollDelta=0 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 좌표 해석 실패 시 code block 경계까지 fallback selection을 잡아, 극단적인 drag에서 실제 드래그 범위보다 넓게 선택될 수 있습니다. code block 내부 drag에만 한정되고 scroll 보존은 기존 루프를 재사용합니다.
- 롤백 방법: 이 PR revert.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
