### PR TITLE
[Fix] live code drag visible selection 복구

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -258,6 +258,33 @@ test.describe("editor authoring route live drag sequence", () => {
         endX: Math.min(rect.width - 8, 390),
       }
     })
+    const codeDragDefaultAllowed = await codeContent.evaluate((element, metrics) => {
+      const rect = element.getBoundingClientRect()
+      const clientX = rect.left + 80
+      const clientY = rect.top + metrics.y
+      const pointerDefaultAllowed = element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, buttons: 1, cancelable: true, clientX, clientY, pointerType: "mouse" }))
+      const mouseDefaultAllowed = element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0, buttons: 1, cancelable: true, clientX, clientY }))
+      window.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, button: 0, buttons: 0, cancelable: true, clientX, clientY, pointerType: "mouse" }))
+      window.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 0, buttons: 0, cancelable: true, clientX, clientY }))
+      return { mouseDefaultAllowed, pointerDefaultAllowed }
+    }, codeDragMetrics)
+    expect(codeDragDefaultAllowed.pointerDefaultAllowed).toBe(true)
+    expect(codeDragDefaultAllowed.mouseDefaultAllowed).toBe(true)
+    const codeShell = editor.locator(".aq-code-shell", { hasText: "createAccessToken(user)" }).first()
+    await codeShell.evaluate((shell, metrics) => {
+      const contentRoot = shell.querySelector<HTMLElement>(".aq-code-editor-content")
+      if (!contentRoot) throw new Error("code shell content root is missing")
+      const rect = contentRoot.getBoundingClientRect()
+      const startX = rect.left + 80
+      const endX = rect.left + metrics.endX
+      const clientY = rect.top + metrics.y
+      window.getSelection()?.removeAllRanges()
+      shell.removeAttribute("data-code-drag-selection-text")
+      shell.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, buttons: 1, cancelable: true, clientX: startX, clientY, pointerType: "mouse" }))
+      window.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, button: 0, buttons: 1, cancelable: true, clientX: endX, clientY, pointerType: "mouse" }))
+      window.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, button: 0, buttons: 0, cancelable: true, clientX: endX, clientY, pointerType: "mouse" }))
+    }, codeDragMetrics)
+    await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
     const beforeCodeSelectAll = await readScrollTop(page)
     await codeContent.click({ position: { x: 80, y: 28 } })
     await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A")

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -223,7 +223,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       if (!isCodeTextSurfaceTarget) return
       const anchorPos = resolveCodeTextPosFromPointer(event.clientX, event.clientY, contentRoot)
       if (typeof anchorPos !== "number") return
-      event.preventDefault()
       event.stopPropagation()
       lastActiveCodeBlockContentRoot = contentRoot
       window.getSelection()?.removeAllRanges()
@@ -253,7 +252,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
   const handleCodeMouseDownCapture = useCallback(
     (event: ReactMouseEvent<HTMLDivElement>) => {
       if (codeDragSelectionRef.current) {
-        event.preventDefault()
         event.stopPropagation()
         return
       }
@@ -281,7 +279,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       const headPos = typeof resolvedHeadPos === "number" ? resolvedHeadPos : resolveFallbackHeadPos(session.anchorPos)
       session.active = true
       session.lastHeadPos = headPos
-      event.preventDefault()
       event.stopPropagation()
       applyCodeTextSelection(session.anchorPos, headPos)
       preserveCodeDomTextRange(contentRoot, session.anchorPos, headPos)
@@ -296,7 +293,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       const resolvedHeadPos = resolveCodeTextPosFromPointer(event.clientX, event.clientY, contentRoot)
       const headPos = typeof resolvedHeadPos === "number" ? resolvedHeadPos : session.lastHeadPos ?? resolveFallbackHeadPos(session.anchorPos)
       preserveCodeDomTextRange(contentRoot, session.anchorPos, headPos)
-      event.preventDefault()
       event.stopPropagation()
     }
     window.addEventListener("mousemove", handleWindowMouseMove, true)


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- PR #487 배포본에서도 실제 Chrome code direct drag가 selected text/시각 하이라이트 없이 끝나는 회귀를 follow-up으로 복구합니다.
- 코드 드래그 시작/이동/종료 경로에서 native text selection 기본 동작을 살리고, 기존 custom range/scroll preserve는 보조로 유지합니다.

## 작업 내용

- code block NodeView의 drag start/move/up handler에서 preventDefault를 제거해 실제 Chrome drag가 native selection/copy를 만들 수 있게 했습니다.
- live drag route E2E에 code drag pointer/mousedown default 허용 계약과 shell-target selection preserve 계약을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - git diff --check
  - RED: yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1 failed on pointerDefaultAllowed=false
  - GREEN: yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1
  - yarn --cwd front playwright:preflight
  - yarn --cwd front playwright test e2e/editor-load-sync-guard.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1
  - yarn --cwd front check:refactor-boundaries
  - yarn --cwd front test:e2e:authoring
  - yarn --cwd front build
  - yarn --cwd front check:bundle-size

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: code drag 중 native selection과 custom preserve가 동시에 동작해 이전 scroll preserve 회귀가 재발할 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하고 PR #487 상태로 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
