### PR TITLE
[Fix] live code drag anchor 보존

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -94,6 +94,11 @@ test.describe("editor authoring route live drag sequence", () => {
       "}",
       "```",
       "",
+      "## 운영에서 가장 먼저 터지는 문제들",
+      "",
+      "- 짧은 TTL",
+      "- Refresh 관리",
+      "",
       ...filler("code 이후 본문", 8),
     ].join("\n")
 
@@ -271,19 +276,43 @@ test.describe("editor authoring route live drag sequence", () => {
     expect(codeDragDefaultAllowed.pointerDefaultAllowed).toBe(true)
     expect(codeDragDefaultAllowed.mouseDefaultAllowed).toBe(true)
     const codeShell = editor.locator(".aq-code-shell", { hasText: "createAccessToken(user)" }).first()
-    await codeShell.evaluate((shell, metrics) => {
+    const shellDispatchDiagnostics = await codeShell.evaluate(async (shell, metrics) => {
       const contentRoot = shell.querySelector<HTMLElement>(".aq-code-editor-content")
       if (!contentRoot) throw new Error("code shell content root is missing")
       const rect = contentRoot.getBoundingClientRect()
       const startX = rect.left + 80
       const endX = rect.left + metrics.endX
       const clientY = rect.top + metrics.y
+      const events: Array<{ type: string; selection: string; dataset: string | null }> = []
+      const record = (event: Event) => {
+        events.push({
+          type: event.type,
+          selection: window.getSelection()?.toString() ?? "",
+          dataset: shell.getAttribute("data-code-drag-selection-text"),
+        })
+      }
+      for (const type of ["pointerdown", "pointermove", "pointerup", "selectionchange"] as const) {
+        document.addEventListener(type, record, { capture: true })
+      }
       window.getSelection()?.removeAllRanges()
       shell.removeAttribute("data-code-drag-selection-text")
       shell.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, buttons: 1, cancelable: true, clientX: startX, clientY, pointerType: "mouse" }))
       window.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, button: 0, buttons: 1, cancelable: true, clientX: endX, clientY, pointerType: "mouse" }))
       window.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, button: 0, buttons: 0, cancelable: true, clientX: endX, clientY, pointerType: "mouse" }))
+      await new Promise((resolve) => setTimeout(resolve, 220))
+      for (const type of ["pointerdown", "pointermove", "pointerup", "selectionchange"] as const) {
+        document.removeEventListener(type, record, true)
+      }
+      return {
+        events,
+        selection: window.getSelection()?.toString() ?? "",
+        dataset: shell.getAttribute("data-code-drag-selection-text"),
+        text: contentRoot.textContent,
+      }
     }, codeDragMetrics)
+    if (!(shellDispatchDiagnostics.selection || shellDispatchDiagnostics.dataset || "").includes("createAccessToken")) {
+      throw new Error(`code shell drag did not select code text: ${JSON.stringify(shellDispatchDiagnostics)}`)
+    }
     await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
     const beforeCodeSelectAll = await readScrollTop(page)
     await codeContent.click({ position: { x: 80, y: 28 } })
@@ -375,6 +404,31 @@ test.describe("editor authoring route live drag sequence", () => {
       window.getSelection()?.removeAllRanges()
       element.closest(".aq-code-shell")?.removeAttribute("data-code-drag-selection-text")
     })
+    const lowerBodyAnchor = editor.getByText("짧은 TTL", { exact: true }).first()
+    await lowerBodyAnchor.evaluate((element) => {
+      element.scrollIntoView({ block: "center", inline: "nearest" })
+    })
+    const lowerBodyBox = await lowerBodyAnchor.boundingBox()
+    if (!lowerBodyBox) throw new Error("lower body anchor metrics are missing")
+    await page.mouse.click(lowerBodyBox.x + Math.min(lowerBodyBox.width / 2, 96), lowerBodyBox.y + 12)
+    await page.waitForTimeout(40)
+    await lowerBodyAnchor.evaluate((element) => {
+      const selection = window.getSelection()
+      const textNode = Array.from(element.childNodes).find((node) => node.nodeType === Node.TEXT_NODE)
+      if (!selection || !textNode?.textContent) throw new Error("lower body anchor text node is missing")
+      const start = textNode.textContent.indexOf("TTL")
+      if (start < 0) throw new Error("TTL text is missing")
+      const range = document.createRange()
+      range.setStart(textNode, start)
+      range.setEnd(textNode, start + "TTL".length)
+      selection.removeAllRanges()
+      selection.addRange(range)
+    })
+    await expect.poll(() => readSelectionText(page)).toContain("TTL")
+    await codeContent.evaluate((element) => {
+      element.scrollIntoView({ block: "center", inline: "nearest" })
+      element.closest(".aq-code-shell")?.removeAttribute("data-code-drag-selection-text")
+    })
     const codeDrag = await dragLocatorText(page, codeContent, "token login code drag", {
       endX: codeDragMetrics.endX,
       startX: 80,
@@ -382,6 +436,7 @@ test.describe("editor authoring route live drag sequence", () => {
       waitMs: 1_600,
     })
     await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
+    expect(codeDrag.selectionText).not.toContain("TTL")
     expect(codeDrag.selectionText).not.toContain("Access Token")
     expect(codeDrag.afterScrollTop).toBeLessThanOrEqual(codeDrag.beforeScrollTop + 24)
     expect(codeDrag.afterScrollTop).toBeGreaterThanOrEqual(codeDrag.beforeScrollTop - 24)

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -1,5 +1,5 @@
 import CodeBlock from "@tiptap/extension-code-block"
-import { NodeSelection, TextSelection } from "@tiptap/pm/state"
+import { NodeSelection } from "@tiptap/pm/state"
 import { NodeViewContent, type NodeViewProps, ReactNodeViewRenderer } from "@tiptap/react"
 import {
   ClipboardEvent as ReactClipboardEvent,
@@ -161,14 +161,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     },
     [editor, getPos, node.nodeSize]
   )
-  const applyCodeTextSelection = useCallback(
-    (anchorPos: number, headPos: number) => {
-      const nextSelection = TextSelection.create(editor.state.doc, Math.min(anchorPos, headPos), Math.max(anchorPos, headPos))
-      if (nextSelection.eq(editor.state.selection)) return
-      editor.view.dispatch(editor.state.tr.setSelection(nextSelection))
-    },
-    [editor]
-  )
   const selectCodeDomTextRange = useCallback(
     (contentRoot: HTMLElement | null, anchorPos: number, headPos: number) => {
       if (typeof getPos !== "function" || !contentRoot) return false
@@ -218,24 +210,38 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       if (event.button !== 0 || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return
       if (!shell || !contentRoot || !(event.target instanceof Node) || !shell.contains(event.target)) return
       const targetElement = event.target instanceof Element ? event.target : event.target.parentElement
+      const contentRect = contentRoot.getBoundingClientRect()
+      const isInsideContentBox = event.clientX >= contentRect.left && event.clientX <= contentRect.right && event.clientY >= contentRect.top && event.clientY <= contentRect.bottom
       const isCodeTextSurfaceTarget =
-        contentRoot.contains(event.target) || Boolean(targetElement?.closest(".aq-code-highlight-layer"))
+        contentRoot.contains(event.target) ||
+        Boolean(targetElement?.closest(".aq-code-highlight-layer")) ||
+        (targetElement === shell && isInsideContentBox)
       if (!isCodeTextSurfaceTarget) return
       const anchorPos = resolveCodeTextPosFromPointer(event.clientX, event.clientY, contentRoot)
       if (typeof anchorPos !== "number") return
       event.stopPropagation()
       lastActiveCodeBlockContentRoot = contentRoot
-      window.getSelection()?.removeAllRanges()
+      const selection = window.getSelection(), persistedCodeSelectionText = shell.getAttribute("data-code-drag-selection-text")?.trim() || ""
+      const anchorElement = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focusElement = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null
+      const selectedText = selection?.toString().trim() || "", contentText = contentRoot.textContent?.trim() || ""
+      const existingCodeSelectionText = selectedText || persistedCodeSelectionText
+      const hasExistingCodeSelection = Boolean((selectedText && anchorElement && focusElement && contentRoot.contains(anchorElement) && contentRoot.contains(focusElement)) || (persistedCodeSelectionText && contentText.includes(persistedCodeSelectionText.slice(0, 48))))
+      if (hasExistingCodeSelection) {
+        shell.setAttribute("data-code-drag-selection-text", existingCodeSelectionText)
+        preserveCodeDomTextRange(contentRoot, anchorPos, anchorPos)
+      } else {
+        selection?.removeAllRanges()
+      }
+      preserveWindowScrollPositionAcrossFrames({ x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }, 168, 4, 2_800, false, false)
       codeDragSelectionRef.current = {
         active: false,
         anchorPos,
         startX: event.clientX,
         startY: event.clientY,
       }
-      applyCodeTextSelection(anchorPos, anchorPos)
-      focusElementWithoutScroll(editor.view.dom as HTMLElement)
+      focusElementWithoutScroll(contentRoot)
     },
-    [applyCodeTextSelection, editor.view.dom, resolveCodeTextPosFromPointer]
+    [preserveCodeDomTextRange, resolveCodeTextPosFromPointer]
   )
 
   const handleCodePointerDownCapture = useCallback(
@@ -279,8 +285,8 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       const headPos = typeof resolvedHeadPos === "number" ? resolvedHeadPos : resolveFallbackHeadPos(session.anchorPos)
       session.active = true
       session.lastHeadPos = headPos
+      event.preventDefault()
       event.stopPropagation()
-      applyCodeTextSelection(session.anchorPos, headPos)
       preserveCodeDomTextRange(contentRoot, session.anchorPos, headPos)
     }
     const handleWindowMouseUp = (event: MouseEvent | PointerEvent) => {
@@ -292,6 +298,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
         shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
       const resolvedHeadPos = resolveCodeTextPosFromPointer(event.clientX, event.clientY, contentRoot)
       const headPos = typeof resolvedHeadPos === "number" ? resolvedHeadPos : session.lastHeadPos ?? resolveFallbackHeadPos(session.anchorPos)
+      event.preventDefault()
       preserveCodeDomTextRange(contentRoot, session.anchorPos, headPos)
       event.stopPropagation()
     }
@@ -307,7 +314,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       window.removeEventListener("pointerup", handleWindowMouseUp, true)
       window.removeEventListener("pointercancel", handleWindowMouseUp, true)
     }
-  }, [applyCodeTextSelection, getPos, node.nodeSize, preserveCodeDomTextRange, resolveCodeTextPosFromPointer])
+  }, [getPos, node.nodeSize, preserveCodeDomTextRange, resolveCodeTextPosFromPointer])
   const ensureCodeDomTextSelection = useCallback((contentRoot: HTMLElement | null) => {
     if (!contentRoot || typeof window === "undefined") return
     window.requestAnimationFrame(() => {

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -165,34 +165,32 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     }
 
     const preserveCodeDragRootSelectionAcrossFrames = (root: HTMLElement) => {
-      if (codeDragSelectionPreserveRafId !== null) return
+      if (codeDragSelectionPreserveRafId !== null) {
+        window.cancelAnimationFrame(codeDragSelectionPreserveRafId); codeDragSelectionPreserveRafId = null; cleanupCodeDragSelectionPreserve?.(); cleanupCodeDragSelectionPreserve = null
+      }
+      const codeShell = root.closest(".aq-code-shell"), rootTextSnapshot = (root.innerText || root.textContent || "").trim(), resolveCurrentRoot = () => codeShell?.isConnected ? codeShell.querySelector<HTMLElement>(CODE_BLOCK_EDITOR_CONTENT_SELECTOR) ?? root : Array.from(document.querySelectorAll<HTMLElement>(CODE_BLOCK_EDITOR_CONTENT_SELECTOR)).find((candidate) => (candidate.innerText || candidate.textContent || "").includes(rootTextSnapshot.slice(0, 48))) ?? root
       const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now()
       let frame = 0
       let restoring = false
+      const persistSelectionText = (currentRoot: HTMLElement) => currentRoot.closest(".aq-code-shell")?.setAttribute("data-code-drag-selection-text", window.getSelection()?.toString() || currentRoot.innerText || currentRoot.textContent || "")
       const restoreIfMissing = () => {
-        if (!root.isConnected) return false
-        if (isSelectionInsideCodeDragRoot(root) && window.getSelection()?.toString() === (root.innerText || root.textContent || "")) return true
+        const currentRoot = resolveCurrentRoot()
+        persistSelectionText(currentRoot)
+        if (!currentRoot.isConnected) return false; if (isSelectionInsideCodeDragRoot(currentRoot) && window.getSelection()?.toString() === (currentRoot.innerText || currentRoot.textContent || "")) return true
         restoring = true
-        selectCodeDragRoot(root)
+        selectCodeDragRoot(currentRoot)
         restoring = false
+        persistSelectionText(currentRoot)
         return true
       }
       const handlePreservedSelectionChange = () => {
         if (restoring) return
         restoreIfMissing()
       }
-      const cleanupPreservedSelection = () => {
-        document.removeEventListener("selectionchange", handlePreservedSelectionChange, true)
-        window.removeEventListener("pointerdown", cancelPreservedSelection, true)
-        window.removeEventListener("mousedown", cancelPreservedSelection, true)
-      }
-      const isCurrentCodeDragEvent = (event: Event) => { const codeTextDragStart = codeTextDragStartRef.current; const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null; const codeShell = root.closest(".aq-code-shell"); return Boolean(targetElement && (root.contains(targetElement) || codeShell?.contains(targetElement)) && ((codeTextDragStart?.scrollPreserveStarted && codeTextDragStart.root === root) || codeShell?.getAttribute("data-code-drag-selection-text")?.trim())) }, cancelPreservedSelection = (event: Event) => { if (!isCurrentCodeDragEvent(event)) cancelCodeDragSelectionPreserve() }
+      const cleanupPreservedSelection = () => { document.removeEventListener("selectionchange", handlePreservedSelectionChange, true); window.removeEventListener("pointerdown", cancelPreservedSelection, true); window.removeEventListener("mousedown", cancelPreservedSelection, true) }
+      const isCurrentCodeDragEvent = (event: Event) => { const codeTextDragStart = codeTextDragStartRef.current; const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null; const currentRoot = resolveCurrentRoot(), currentShell = currentRoot.closest(".aq-code-shell") ?? codeShell; return Boolean(targetElement && (currentRoot.contains(targetElement) || currentShell?.contains(targetElement)) && ((codeTextDragStart?.scrollPreserveStarted && codeTextDragStart.root === currentRoot) || currentShell?.getAttribute("data-code-drag-selection-text")?.trim())) }, cancelPreservedSelection = (event: Event) => { if (!isCurrentCodeDragEvent(event)) cancelCodeDragSelectionPreserve() }
       const restore = () => {
-        if (!root.isConnected) {
-          codeDragSelectionPreserveRafId = null
-          cleanupPreservedSelection()
-          return
-        }
+        if (!resolveCurrentRoot().isConnected) { codeDragSelectionPreserveRafId = null; cleanupPreservedSelection(); return }
         restoreIfMissing()
         frame += 1
         const elapsedMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt
@@ -411,7 +409,8 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       if (codeShellTarget) {
         cancelCodeDragSelectionPreserve()
         const codeTextDragStart = rememberCodeTextDragStart(codeShellTarget, event)
-        if (codeTextDragStart && existingCodeSelectionText) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root) } else clearImmediateWindowTextSelection()
+        const shellSurfaceTarget = codeTextDragStart && !targetElement?.closest(CODE_BLOCK_EDITOR_CONTENT_SELECTOR)
+        if (codeTextDragStart && (existingCodeSelectionText || shellSurfaceTarget)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root) } else clearImmediateWindowTextSelection()
       } else {
         codeTextDragStartRef.current = null
         if (insideEditorDom) {
@@ -452,10 +451,12 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const pointInsideEditor = !targetElement?.closest("[data-table-menu-root='true']") && (!targetTableControl || allowTableControlCellFallback) && pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR))), insideEditorDom = eventTarget instanceof Node && (activeEditor.view.dom.contains(eventTarget) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor), columnResizeTarget = targetElement?.closest(".column-resize-handle"), tableTextDragStart = insideEditorDom && !codeShellTarget ? tableTextDragStartRef.current ?? rememberTableTextDragStart(event, allowTableControlCellFallback) : null
       if (!insideEditorDom && !codeShellTarget) return; if (codeTextDragStartRef.current && !codeShellTarget) codeTextDragStartRef.current = null
       if (codeShellTarget) {
+        if (codeTextDragStartRef.current && !codeTextDragStartRef.current.root.isConnected) { const nextCodeTextDragStart = rememberCodeTextDragStart(codeShellTarget, event); if (nextCodeTextDragStart) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(nextCodeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(nextCodeTextDragStart.root); return } }
         if (codeTextDragStartRef.current?.root.isConnected && (codeTextDragStartRef.current.scrollPreserveStarted || isSelectionInsideCodeDragRoot(codeTextDragStartRef.current.root))) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStartRef.current.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStartRef.current.root); return }
         cancelCodeDragSelectionPreserve()
         const codeTextDragStart = rememberCodeTextDragStart(codeShellTarget, event)
-        if (codeTextDragStart && existingCodeSelectionText) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root); return }
+        const shellSurfaceTarget = codeTextDragStart && !targetElement?.closest(CODE_BLOCK_EDITOR_CONTENT_SELECTOR)
+        if (codeTextDragStart && (existingCodeSelectionText || shellSurfaceTarget)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root); return }
         clearImmediateWindowTextSelection()
       } else if (insideEditorDom) {
         codeTextDragStartRef.current = null; cancelCodeDragSelectionPreserve()


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- PR #488 배포본에서 `/editor/507` code direct drag가 하단 본문 `TTL` anchor로 튀는 live 회귀를 복구합니다.
- code preserve cancel이 DOM 교체 뒤 현재 code root 입력을 외부 입력으로 오판하지 않게 하고, NodeView drag 시작이 기존 code selection/dataset을 지우지 않게 했습니다.

## 작업 내용

- code drag preserve 루프가 현재 code root를 다시 resolve해서 현재 pointerdown/mousedown은 보존 취소 대상에서 제외합니다.
- code block drag 시작 시 기존 code selection/dataset을 즉시 재보존하고, code content에 focus를 유지해 Cmd/Ctrl+A 내부 선택도 유지합니다.
- live drag route E2E에 하단 `TTL` stale selection 재현을 추가해 code drag가 본문 anchor로 튀지 않는지 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-load-sync-guard.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-route-rich-select-all.spec.ts --workers=1`
  - `yarn --cwd front check:refactor-boundaries`
  - `yarn --cwd front test:e2e:authoring` (96 passed, 2회 연속)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: code drag preserve가 다른 code/table/body selection 취소 타이밍과 충돌할 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋 `fix(editor): live code drag anchor 보존`을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
