### PR TITLE
[Fix] live code drag copy 보존

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -20,6 +20,14 @@ const readSelectionText = (page: Page) =>
       ""
   )
 
+const readClipboardText = (page: Page) =>
+  page.evaluate(async () => navigator.clipboard?.readText?.() ?? "")
+
+const writeClipboardText = (page: Page, text: string) =>
+  page.evaluate(async (nextText) => {
+    await navigator.clipboard?.writeText?.(nextText)
+  }, text)
+
 const dragLocatorText = async (
   page: Page,
   target: Locator,
@@ -124,6 +132,9 @@ test.describe("editor authoring route live drag sequence", () => {
     })
 
     await page.goto("/editor/997")
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin: new URL(page.url()).origin,
+    })
 
     const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
     await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("live drag sequence 글")
@@ -436,6 +447,9 @@ test.describe("editor authoring route live drag sequence", () => {
       waitMs: 1_600,
     })
     await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
+    await writeClipboardText(page, "__AQUILA_SENTINEL__")
+    await page.keyboard.press(process.platform === "darwin" ? "Meta+C" : "Control+C")
+    await expect.poll(() => readClipboardText(page)).toContain("createAccessToken")
     expect(codeDrag.selectionText).not.toContain("TTL")
     expect(codeDrag.selectionText).not.toContain("Access Token")
     expect(codeDrag.afterScrollTop).toBeLessThanOrEqual(codeDrag.beforeScrollTop + 24)

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -15,10 +15,7 @@ import {
 } from "react"
 import AppIcon from "src/components/icons/AppIcon"
 import { extractPlainTextFromHtml } from "src/libs/markdown/htmlToMarkdown"
-import {
-  highlightCodeToHtml,
-  renderImmediateCodeToHtml,
-} from "src/libs/markdown/prismRuntime"
+import { highlightCodeToHtml, renderImmediateCodeToHtml } from "src/libs/markdown/prismRuntime"
 import { toLanguageLabel } from "src/libs/markdown/rendering"
 import {
   CodeBlockEditorHeader,
@@ -41,6 +38,7 @@ import {
 import {
   isPrimarySelectAllShortcut,
   resolveCodeBlockPasteRange,
+  resolveCodeBlockCopyText,
   selectCodeBlockText,
   selectDomTextContents,
   selectDomTextOffsetRange,
@@ -53,13 +51,7 @@ import {
 export { getPreferredCodeLanguage, normalizeCodeLanguage } from "./codeBlockNodeViewLanguageModel"
 export { CodeBlockEditorStyles } from "./codeBlockNodeViewStyles"
 let lastActiveCodeBlockContentRoot: HTMLElement | null = null
-type CodeDragSelectionSession = {
-  active: boolean
-  anchorPos: number
-  lastHeadPos?: number
-  startX: number
-  startY: number
-}
+type CodeDragSelectionSession = { active: boolean; anchorPos: number; lastHeadPos?: number; startX: number; startY: number }
 export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos }: NodeViewProps) => {
   const menuId = useId()
   const menuRef = useRef<HTMLDivElement>(null)
@@ -72,12 +64,10 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
   const nodeCodeSource = node.textContent || ""
   const nodeCodeSourceRef = useRef(nodeCodeSource)
   const [liveCodeSource, setLiveCodeSource] = useState(nodeCodeSource)
-  const [highlightedCodeHtml, setHighlightedCodeHtml] = useState(() =>
-    renderImmediateCodeToHtml({
-      source: nodeCodeSource,
-      language: normalizeCodeLanguage(String(node.attrs?.language || "")),
-    }).html
-  )
+  const [highlightedCodeHtml, setHighlightedCodeHtml] = useState(() => renderImmediateCodeToHtml({
+    source: nodeCodeSource,
+    language: normalizeCodeLanguage(String(node.attrs?.language || "")),
+  }).html)
   const selectCurrentCodeBlockText = useCallback(
     () => selectCodeBlockText({ editor, getPos, nodeSize: node.nodeSize }),
     [editor, getPos, node.nodeSize]
@@ -495,6 +485,15 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     editor.view.focus()
   }, [editor, getPos, node.nodeSize])
 
+  const handleCodeCopy = useCallback((event: ReactClipboardEvent<HTMLDivElement>) => {
+    const copyText = resolveCodeBlockCopyText(shellRef.current)
+    if (!copyText.trim()) return
+
+    event.preventDefault()
+    event.stopPropagation()
+    event.clipboardData.setData("text/plain", copyText)
+  }, [])
+
   const handleCodeKeyDown = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (!isPrimarySelectAllShortcut(event)) return
 
@@ -578,6 +577,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
           onPointerDownCapture={handleCodePointerDownCapture}
           onMouseDownCapture={handleCodeMouseDownCapture}
           onKeyDownCapture={handleCodeKeyDown}
+          onCopy={handleCodeCopy}
           onPaste={handleCodePaste}
         >
           <pre

--- a/front/src/components/editor/codeBlockNodeViewSelectionModel.ts
+++ b/front/src/components/editor/codeBlockNodeViewSelectionModel.ts
@@ -71,6 +71,24 @@ export const selectDomTextOffsetRange = (
   return true
 }
 
+export const resolveCodeBlockCopyText = (shell: HTMLElement | null) => {
+  const contentRoot = shell?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
+  const selection = window.getSelection()
+  const anchorElement = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null
+  const focusElement = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null
+  const selectionText = selection?.toString() || ""
+  const selectionInsideCode = Boolean(
+    selectionText &&
+    contentRoot &&
+    anchorElement &&
+    focusElement &&
+    contentRoot.contains(anchorElement) &&
+    contentRoot.contains(focusElement)
+  )
+  const fallbackText = shell?.getAttribute("data-code-drag-selection-text") || ""
+  return selectionInsideCode ? selectionText : fallbackText
+}
+
 export const selectCodeBlockText = ({ editor, getPos, nodeSize }: CodeBlockPositionArgs) => {
   if (typeof getPos !== "function") return false
   const codeBlockPos = getPos()


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 실제 Chrome 배포본에서 code direct drag 후 Cmd+C가 sentinel 그대로 남던 회귀를 복구합니다.
- code drag가 DOM selection 대신 `data-code-drag-selection-text` fallback으로만 끝나도 code shell copy handler가 같은 텍스트를 clipboard로 내보내도록 했습니다.

## 작업 내용

- 코드블럭 copy 경로가 실제 DOM selection과 code drag fallback text를 함께 해석합니다.
- live drag sequence E2E가 code direct drag 후 실제 clipboard에 `createAccessToken`이 들어가는지 검증합니다.

## 검증

- 실행한 명령과 결과:
  - RED: `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1` failed with clipboard `__AQUILA_SENTINEL__`.
  - GREEN: same command passed, `1 passed`.
  - `yarn --cwd front test:e2e:authoring` passed `96 passed` twice consecutively after classifying one intermediate long-smoke selection timing flake and confirming the smoke spec alone passed.
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: code drag fallback clipboard가 code shell 내부 copy에만 적용되어 일반 editor/body/table copy에는 영향을 주지 않습니다.
- 롤백 방법: `fix(editor): live code drag copy 보존` 커밋 revert.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
