### PR TITLE
[Fix] live bottom block click 보존

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -102,6 +102,19 @@ test.describe("editor authoring route live drag sequence", () => {
       "}",
       "```",
       "",
+      "## 재발급",
+      "",
+      "```java",
+      "public String reissue(String refreshToken) {",
+      "",
+      "    if (!isValid(refreshToken)) {",
+      "        throw new UnauthorizedException();",
+      "    }",
+      "",
+      "    return createAccessToken(getUser(refreshToken));",
+      "}",
+      "```",
+      "",
       "## 운영에서 가장 먼저 터지는 문제들",
       "",
       "- 짧은 TTL",
@@ -435,7 +448,51 @@ test.describe("editor authoring route live drag sequence", () => {
       selection.removeAllRanges()
       selection.addRange(range)
     })
-    await expect.poll(() => readSelectionText(page)).toContain("TTL")
+    try {
+      await expect.poll(() => readSelectionText(page)).toContain("TTL")
+    } catch (error) {
+      const diagnostics = await page.evaluate(() => {
+        const selection = window.getSelection()
+        const describeNode = (node: Node | null | undefined) => {
+          const element = node instanceof Element ? node : node?.parentElement ?? null
+          return {
+            className: String(element?.className ?? ""),
+            codeText: element?.closest(".aq-code-shell")?.textContent?.replace(/\s+/g, " ").trim().slice(0, 120) ?? null,
+            text: element?.textContent?.replace(/\s+/g, " ").trim().slice(0, 120) ?? null,
+          }
+        }
+        return {
+          selectionText: selection?.toString() ?? "",
+          anchor: describeNode(selection?.anchorNode),
+          focus: describeNode(selection?.focusNode),
+          codePersisted: Array.from(document.querySelectorAll("[data-code-drag-selection-text]")).map((element) => element.getAttribute("data-code-drag-selection-text")),
+          tablePersisted: Array.from(document.querySelectorAll("[data-table-drag-selection-text]")).map((element) => element.getAttribute("data-table-drag-selection-text")),
+          activeElement: String(document.activeElement?.className ?? ""),
+        }
+      })
+      throw new Error(`lower body selection restored stale code text: ${JSON.stringify(diagnostics)}\n${error instanceof Error ? error.message : String(error)}`)
+    }
+    const reissueCodeContent = editor.locator(".aq-code-editor-content", { hasText: "createAccessToken(getUser(refreshToken))" }).first()
+    const reissueClickMetrics = await reissueCodeContent.evaluate((element) => {
+      element.scrollIntoView({ block: "center", inline: "nearest" })
+      const rect = element.getBoundingClientRect()
+      const style = window.getComputedStyle(element)
+      const lineHeight = Number.parseFloat(style.lineHeight || "22") || 22
+      const paddingTop = Number.parseFloat(style.paddingTop || "0") || 0
+      return {
+        y: Math.min(rect.height - 8, paddingTop + lineHeight * 5.5),
+      }
+    })
+    const beforeLowerCodeClick = await readScrollTop(page)
+    await reissueCodeContent.click({ position: { x: 80, y: reissueClickMetrics.y } })
+    await page.waitForTimeout(2_600)
+    await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforeLowerCodeClick + 24)
+    await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforeLowerCodeClick - 24)
+    await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A")
+    await expect.poll(() => readSelectionText(page)).toContain("createAccessToken(getUser")
+    await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforeLowerCodeClick + 24)
+    await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforeLowerCodeClick - 24)
+    await page.mouse.wheel(0, 1).then(() => page.waitForTimeout(40))
     await codeContent.evaluate((element) => {
       element.scrollIntoView({ block: "center", inline: "nearest" })
       element.closest(".aq-code-shell")?.removeAttribute("data-code-drag-selection-text")

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -50,7 +50,7 @@ import {
 } from "./blockHandleLayoutModel"
 export { getPreferredCodeLanguage, normalizeCodeLanguage } from "./codeBlockNodeViewLanguageModel"
 export { CodeBlockEditorStyles } from "./codeBlockNodeViewStyles"
-let lastActiveCodeBlockContentRoot: HTMLElement | null = null
+let lastActiveCodeBlockContentRoot: HTMLElement | null = null, codeDomTextRangePreserveGeneration = 0
 type CodeDragSelectionSession = { active: boolean; anchorPos: number; lastHeadPos?: number; startX: number; startY: number }
 export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos }: NodeViewProps) => {
   const menuId = useId()
@@ -164,29 +164,26 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
   const preserveCodeDomTextRange = useCallback(
     (contentRoot: HTMLElement | null, anchorPos: number, headPos: number) => {
       const scrollAnchor = { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }
-      const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now()
-      let frame = 0
-      let cancelled = false
-      let cancelArmed = false
+      const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now(), preserveGeneration = ++codeDomTextRangePreserveGeneration
+      let frame = 0, cancelled = false, cancelArmed = false
       const shell = contentRoot?.closest(".aq-code-shell")
-      const cancel = (event: Event) => { if (cancelArmed && (!(event.target instanceof Node) || !shell?.contains(event.target))) cancelled = true }
-      const selectRange = () => {
-        if (!selectCodeDomTextRange(contentRoot, anchorPos, headPos)) {
-          selectDomTextContents(contentRoot)
-        }
+      const cleanupCancel = () => { window.removeEventListener("pointerdown", cancel, true); window.removeEventListener("mousedown", cancel, true); document.removeEventListener("selectionchange", cancelOnSelectionChange, true) }
+      const cancelPreserve = () => { cancelled = true; codeDomTextRangePreserveGeneration += 1; shell?.removeAttribute("data-code-drag-selection-text"); cleanupCancel() }
+      const cancel = (event: Event) => { if (!cancelArmed) return; if (!(event.target instanceof Node) || !shell?.contains(event.target)) cancelPreserve() }
+      const cancelOnSelectionChange = () => { if (!cancelArmed) return; const selection = window.getSelection(), anchor = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focus = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null; if (selection?.toString().trim() && (!anchor || !focus || !shell?.contains(anchor) || !shell.contains(focus))) cancelPreserve() }
+      const selectRange = () => { if (!selectCodeDomTextRange(contentRoot, anchorPos, headPos)) selectDomTextContents(contentRoot)
         shell?.setAttribute("data-code-drag-selection-text", window.getSelection()?.toString() || contentRoot?.textContent || "")
       }
       const restore = () => {
-        if (cancelled) return
-        selectRange()
-        frame += 1
+        if (cancelled || preserveGeneration !== codeDomTextRangePreserveGeneration) return
+        selectRange(); frame += 1
         const elapsedMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt
-        if (frame < 168 || elapsedMs < 2_800) {
-          window.requestAnimationFrame(restore)
-        }
+        if (frame < 168 || elapsedMs < 2_800) window.requestAnimationFrame(restore)
+        else { codeDomTextRangePreserveGeneration += 1; cleanupCancel() }
       }
-      window.addEventListener("pointerdown", cancel, { capture: true, once: true })
-      window.addEventListener("mousedown", cancel, { capture: true, once: true })
+      window.addEventListener("pointerdown", cancel, { capture: true, passive: true })
+      window.addEventListener("mousedown", cancel, { capture: true, passive: true })
+      document.addEventListener("selectionchange", cancelOnSelectionChange, true)
       preserveWindowScrollPositionAcrossFrames(scrollAnchor, 168, 4, 2_800, false, false)
       window.requestAnimationFrame(() => { cancelArmed = true })
       restore()

--- a/front/src/components/editor/inlineToolbarModel.ts
+++ b/front/src/components/editor/inlineToolbarModel.ts
@@ -1,4 +1,5 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
+import { TextSelection } from "@tiptap/pm/state"
 import { normalizeInlineColorToken } from "src/libs/markdown/inlineColor"
 
 export type InlineTextStyleOption = {
@@ -111,11 +112,35 @@ export const isInlineCodeMarkActive = (
   editor: TiptapEditor | null | undefined
 ) => isInlineMarkCommandActive(editor, "code")
 
+const syncEditorSelectionFromDomSelection = (editor: TiptapEditor) => {
+  if (typeof window === "undefined") return
+  const domSelection = window.getSelection()
+  const range = domSelection && domSelection.rangeCount > 0 ? domSelection.getRangeAt(0) : null
+  const commonAncestor =
+    range?.commonAncestorContainer instanceof Element
+      ? range.commonAncestorContainer
+      : range?.commonAncestorContainer?.parentElement ?? null
+  if (!range || !domSelection || domSelection.isCollapsed || !commonAncestor || !editor.view.dom.contains(commonAncestor) || commonAncestor.closest(".aq-code-editor-content")) return
+
+  try {
+    const from = editor.view.posAtDOM(range.startContainer, range.startOffset)
+    const to = editor.view.posAtDOM(range.endContainer, range.endOffset)
+    if (!Number.isFinite(from) || !Number.isFinite(to) || from === to) return
+    const nextSelection = TextSelection.create(editor.state.doc, Math.min(from, to), Math.max(from, to))
+    if (!nextSelection.eq(editor.state.selection)) {
+      editor.view.dispatch(editor.state.tr.setSelection(nextSelection))
+    }
+  } catch {
+    // NodeView internals that do not map to the editor document keep the current PM selection.
+  }
+}
+
 export const runInlineMarkCommand = (
   editor: TiptapEditor | null | undefined,
   commandId: InlineMarkCommandId
 ) => {
   if (!editor) return false
+  syncEditorSelectionFromDomSelection(editor)
   INLINE_MARK_COMMANDS[commandId].run(editor)
   return true
 }

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -58,8 +58,10 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     let rafId: number | null = null
     let codeDragSelectionPreserveRafId: number | null = null
     let cleanupCodeDragSelectionPreserve: (() => void) | null = null
+    let codeDragSelectionPreserveGeneration = 0
     const clearImmediateWindowTextSelection = () => window.getSelection()?.removeAllRanges()
     const cancelCodeDragSelectionPreserve = () => {
+      codeDragSelectionPreserveGeneration += 1
       if (codeDragSelectionPreserveRafId !== null) {
         window.cancelAnimationFrame(codeDragSelectionPreserveRafId)
         codeDragSelectionPreserveRafId = null
@@ -165,6 +167,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     }
 
     const preserveCodeDragRootSelectionAcrossFrames = (root: HTMLElement) => {
+      const preserveGeneration = ++codeDragSelectionPreserveGeneration, isCurrentPreserveGeneration = () => preserveGeneration === codeDragSelectionPreserveGeneration
       if (codeDragSelectionPreserveRafId !== null) {
         window.cancelAnimationFrame(codeDragSelectionPreserveRafId); codeDragSelectionPreserveRafId = null; cleanupCodeDragSelectionPreserve?.(); cleanupCodeDragSelectionPreserve = null
       }
@@ -172,9 +175,9 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now()
       let frame = 0
       let restoring = false
-      const persistSelectionText = (currentRoot: HTMLElement) => currentRoot.closest(".aq-code-shell")?.setAttribute("data-code-drag-selection-text", window.getSelection()?.toString() || currentRoot.innerText || currentRoot.textContent || "")
+      const persistSelectionText = (currentRoot: HTMLElement) => { if (isCurrentPreserveGeneration()) currentRoot.closest(".aq-code-shell")?.setAttribute("data-code-drag-selection-text", window.getSelection()?.toString() || currentRoot.innerText || currentRoot.textContent || "") }
       const restoreIfMissing = () => {
-        const currentRoot = resolveCurrentRoot()
+        if (!isCurrentPreserveGeneration()) return false; const currentRoot = resolveCurrentRoot()
         persistSelectionText(currentRoot)
         if (!currentRoot.isConnected) return false; if (isSelectionInsideCodeDragRoot(currentRoot) && window.getSelection()?.toString() === (currentRoot.innerText || currentRoot.textContent || "")) return true
         restoring = true
@@ -183,14 +186,11 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         persistSelectionText(currentRoot)
         return true
       }
-      const handlePreservedSelectionChange = () => {
-        if (restoring) return
-        restoreIfMissing()
-      }
+      const handlePreservedSelectionChange = () => { if (restoring || !isCurrentPreserveGeneration()) return; const currentRoot = resolveCurrentRoot(), selection = window.getSelection(), anchor = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focus = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null; if (selection?.toString().trim() && (!anchor || !focus || !currentRoot.contains(anchor) || !currentRoot.contains(focus))) { cancelCodeDragSelectionPreserve(); return }; restoreIfMissing() }
       const cleanupPreservedSelection = () => { document.removeEventListener("selectionchange", handlePreservedSelectionChange, true); window.removeEventListener("pointerdown", cancelPreservedSelection, true); window.removeEventListener("mousedown", cancelPreservedSelection, true) }
-      const isCurrentCodeDragEvent = (event: Event) => { const codeTextDragStart = codeTextDragStartRef.current; const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null; const currentRoot = resolveCurrentRoot(), currentShell = currentRoot.closest(".aq-code-shell") ?? codeShell; return Boolean(targetElement && (currentRoot.contains(targetElement) || currentShell?.contains(targetElement)) && ((codeTextDragStart?.scrollPreserveStarted && codeTextDragStart.root === currentRoot) || currentShell?.getAttribute("data-code-drag-selection-text")?.trim())) }, cancelPreservedSelection = (event: Event) => { if (!isCurrentCodeDragEvent(event)) cancelCodeDragSelectionPreserve() }
+      const isCurrentCodeDragEvent = (event: Event) => { const codeTextDragStart = codeTextDragStartRef.current; const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null; const currentRoot = resolveCurrentRoot(), currentShell = currentRoot.closest(".aq-code-shell") ?? codeShell; return Boolean(targetElement && (currentRoot.contains(targetElement) || currentShell?.contains(targetElement)) && ((codeTextDragStart?.scrollPreserveStarted && codeTextDragStart.root === currentRoot) || currentShell?.getAttribute("data-code-drag-selection-text")?.trim())) }, cancelPreservedSelection = (event: Event) => { if (!isCurrentPreserveGeneration()) return; if (!isCurrentCodeDragEvent(event)) cancelCodeDragSelectionPreserve() }
       const restore = () => {
-        if (!resolveCurrentRoot().isConnected) { codeDragSelectionPreserveRafId = null; cleanupPreservedSelection(); return }
+        if (!isCurrentPreserveGeneration()) { cleanupPreservedSelection(); return }; if (!resolveCurrentRoot().isConnected) { codeDragSelectionPreserveRafId = null; codeDragSelectionPreserveGeneration += 1; cleanupPreservedSelection(); return }
         restoreIfMissing()
         frame += 1
         const elapsedMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt
@@ -198,12 +198,13 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
           codeDragSelectionPreserveRafId = window.requestAnimationFrame(restore)
         } else {
           codeDragSelectionPreserveRafId = null
+          codeDragSelectionPreserveGeneration += 1
           cleanupPreservedSelection()
         }
       }
       document.addEventListener("selectionchange", handlePreservedSelectionChange, true)
-      window.addEventListener("pointerdown", cancelPreservedSelection, { capture: true, passive: true, once: true })
-      window.addEventListener("mousedown", cancelPreservedSelection, { capture: true, passive: true, once: true })
+      window.addEventListener("pointerdown", cancelPreservedSelection, { capture: true, passive: true })
+      window.addEventListener("mousedown", cancelPreservedSelection, { capture: true, passive: true })
       cleanupCodeDragSelectionPreserve = cleanupPreservedSelection
       restore()
     }


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- PR #490 배포본에서 하단 `재발급` 코드블럭/본문 클릭이 이전 코드 selection anchor로 되돌아가며 viewport가 순간이동하는 회귀를 복구합니다.
- code drag preserve가 non-code selectionchange를 restore로 처리하지 않도록 취소 조건과 세대값을 추가했고, callout/table 같은 NodeView 내부 inline toolbar selection 동기화 누락도 함께 고정했습니다.

## 작업 내용

- code drag preserve RAF/selectionchange 루프를 세대값으로 무효화하고, 코드 밖 pointer/selection 입력에서는 stale `data-code-drag-selection-text`를 제거합니다.
- inline toolbar mark command 실행 전 DOM selection을 ProseMirror selection으로 동기화해 callout 내부 inline code 적용 누락을 막습니다.
- live drag sequence E2E에 하단 code block 클릭/Cmd+A 계약과 stale code dataset 진단을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-body-click-flicker.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-rich-focus.spec.ts e2e/editor-authoring-route-rich-select-all.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-affordances.spec.ts:547 e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-smoke.spec.ts:9 --workers=1`
  - `yarn --cwd front test:e2e:authoring` (96개, 2회 연속 통과)
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-smoke.spec.ts:9 --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: code drag selection preserve의 취소 타이밍 변경이 code drag copy 보존에 영향을 줄 수 있습니다. 관련 live sequence와 full authoring 회귀로 code drag copy, Cmd+A, 하단 code click을 같이 검증했습니다.
- 롤백 방법: 이 PR의 단일 commit `fix(editor): live bottom block click 보존`을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
