### PR TITLE
[Fix] code selection follow-up scroll 보존

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -507,6 +507,10 @@ test.describe("editor authoring route live drag sequence", () => {
     const beforePostCodeBodyClick = await readScrollTop(page)
     const postCodeLowerBodyBox = await lowerBodyAnchor.boundingBox()
     if (!postCodeLowerBodyBox) throw new Error("post-code lower body metrics are missing")
+    await page.evaluate(() => {
+      window.setTimeout(() => document.dispatchEvent(new Event("selectionchange")), 16)
+      window.setTimeout(() => window.scrollBy(0, 476), 72)
+    })
     await page.mouse.click(
       postCodeLowerBodyBox.x + Math.min(postCodeLowerBodyBox.width / 2, 96),
       postCodeLowerBodyBox.y + 12

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -185,9 +185,14 @@ export const preserveWindowScrollPositionAcrossFrames = (
 }
 
 let preserveNextEditorPointerAfterTable = false
+let preserveNextEditorPointerAfterCodeSelection = false
 
 export const markNextEditorPointerAfterTable = () => {
   preserveNextEditorPointerAfterTable = true
+}
+
+export const markNextEditorPointerAfterCodeSelection = () => {
+  preserveNextEditorPointerAfterCodeSelection = true
 }
 
 const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES = 72
@@ -251,7 +256,12 @@ export const preserveWindowScrollForEditorPointerFocus = (
   const shouldPreserveTableBlockSelectionPointer = tablePointerTarget && blockSelectionActive
   const shouldPreserveGeneralEditorPointer =
     editorPointerTarget && !editorRichBlockTarget && !editorControlTarget && !blockSelectionActive
+  const shouldPreserveCodeSelectionFollowUp =
+    editorPointerTarget && !editorControlTarget && preserveNextEditorPointerAfterCodeSelection
   const shouldPreserveFollowUp = !tablePointerTarget && preserveNextEditorPointerAfterTable
+  if (shouldPreserveCodeSelectionFollowUp) {
+    preserveNextEditorPointerAfterCodeSelection = false
+  }
   if (tablePointerTarget) {
     markNextEditorPointerAfterTable()
   } else if (shouldPreserveFollowUp) {
@@ -279,7 +289,7 @@ export const preserveWindowScrollForEditorPointerFocus = (
       EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES,
       4,
       EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS,
-      true
+      !shouldPreserveCodeSelectionFollowUp
     )
   }
 }

--- a/front/src/components/editor/codeBlockNodeViewSelectionModel.ts
+++ b/front/src/components/editor/codeBlockNodeViewSelectionModel.ts
@@ -2,7 +2,10 @@ import type { Editor } from "@tiptap/core"
 import { NodeSelection, TextSelection } from "@tiptap/pm/state"
 import type { KeyboardEvent as ReactKeyboardEvent } from "react"
 import { focusElementWithoutScroll } from "./blockEditorEngineDocumentModel"
-import { preserveWindowScrollForRichBlockSelectAll } from "./blockHandleLayoutModel"
+import {
+  markNextEditorPointerAfterCodeSelection,
+  preserveWindowScrollForRichBlockSelectAll,
+} from "./blockHandleLayoutModel"
 
 type CodeBlockPositionArgs = {
   editor: Editor
@@ -96,6 +99,7 @@ export const selectCodeBlockText = ({ editor, getPos, nodeSize }: CodeBlockPosit
   const from = codeBlockPos + 1
   const to = codeBlockPos + Math.max(1, nodeSize - 1)
   const nextSelection = TextSelection.create(editor.state.doc, from, to)
+  markNextEditorPointerAfterCodeSelection()
   preserveWindowScrollForRichBlockSelectAll()
   editor.view.dispatch(editor.state.tr.setSelection(nextSelection))
   focusElementWithoutScroll(editor.view.dom as HTMLElement)


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- PR #492 배포본에서도 `/editor/507` 하단 code `Cmd+A` 이후 하단 본문 클릭이 `scrollTop +476` 이동하는 live 회귀가 남아 있었습니다.
- code block selection 직후의 다음 editor pointer만 selectionchange cancel을 무시하도록 좁혀, 일반 본문 클릭/드래그 scroll-chain 계약은 유지하면서 post-code delayed reveal jump를 막습니다.

## 작업 내용

- code block select-all 성공 시 다음 editor pointer를 code-selection follow-up으로 표시합니다.
- general editor pointer preserve는 기본적으로 selectionchange에서 cancel되지만, code-selection follow-up 1회에 한해서 selectionchange cancel을 비활성화합니다.
- route E2E에 `code Cmd+A -> selectionchange -> delayed scroll reveal -> lower body click` 계약을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `PLAYWRIGHT_BASE_URL=https://www.aquilaxk.site PLAYWRIGHT_LIVE_MULTI_BROWSER=false E2E_EXPECTED_FRONT_COMMIT_SHA=034249b5a3c60881c730e52a77472171c7d1efdd yarn --cwd front test:e2e:live -- e2e/editor-authoring-live-507-regression.spec.ts --grep "editor 507 lower block"` (RED: lower body click `scrollTop +476`)
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-body-click-flicker.spec.ts e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-body-click-flicker.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-rich-focus.spec.ts e2e/editor-authoring-route-rich-select-all.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-affordances.spec.ts:547 e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-smoke.spec.ts:9 --workers=1`
  - `yarn --cwd front test:e2e:authoring` (96 passed, 2회 연속)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: code select-all 직후의 첫 editor pointer에 한해 scroll preserve가 selectionchange로 취소되지 않습니다. 적용 범위는 1회성 flag로 제한했고 일반 본문 click/drag 회귀 테스트를 함께 통과했습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 PR #492 상태로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
