### PR TITLE
[Test] post-code body drag 회귀 보강

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -518,6 +518,20 @@ test.describe("editor authoring route live drag sequence", () => {
     await page.waitForTimeout(1_000)
     await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforePostCodeBodyClick + 24)
     await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforePostCodeBodyClick - 24)
+    const postCodeCurrentLowerBodyBox = await lowerBodyAnchor.boundingBox()
+    if (!postCodeCurrentLowerBodyBox) throw new Error("post-code current lower body metrics are missing")
+    await page.mouse.move(postCodeCurrentLowerBodyBox.x + 8, postCodeCurrentLowerBodyBox.y + postCodeCurrentLowerBodyBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(
+      postCodeCurrentLowerBodyBox.x + Math.max(24, postCodeCurrentLowerBodyBox.width - 8),
+      postCodeCurrentLowerBodyBox.y + postCodeCurrentLowerBodyBox.height / 2,
+      { steps: 12 }
+    )
+    await page.mouse.up()
+    await page.waitForTimeout(720)
+    const postCodeBodySelection = await readSelectionText(page)
+    expect(postCodeBodySelection).toContain("TTL")
+    expect(postCodeBodySelection).not.toContain("createAccessToken")
     await page.mouse.wheel(0, 1).then(() => page.waitForTimeout(40))
     await codeContent.evaluate((element) => {
       element.scrollIntoView({ block: "center", inline: "nearest" })


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- PR #493 배포본에서 `/editor/507` 하단 code `Cmd+A` 이후 하단 본문 click/drag는 실제 live 검증으로 통과했습니다.
- 같은 조건이 다시 빠지지 않도록 route E2E에 `code Cmd+A -> lower body click -> lower body drag selection` 계약을 추가했습니다.

## 작업 내용

- `editor-authoring-route-live-drag-sequence`에서 post-code lower body click의 scroll 보존 직후 같은 본문 블럭을 실제 mouse drag로 선택합니다.
- 선택 텍스트가 `TTL`을 포함하고 이전 code selection인 `createAccessToken`을 포함하지 않는지 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `PLAYWRIGHT_BASE_URL=https://www.aquilaxk.site PLAYWRIGHT_LIVE_MULTI_BROWSER=false E2E_EXPECTED_FRONT_COMMIT_SHA=a36330273bc228c50f57810a0a82e56a14577a98 yarn --cwd front test:e2e:live -- e2e/editor-authoring-live-507-regression.spec.ts --grep "editor 507 lower block"` (1 passed)
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring` (96 passed, 2회 연속)
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: test-only 변경으로 제품 런타임 영향은 없습니다. CI 시간이 약간 늘 수 있습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 기존 route E2E 범위로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
