### PR TITLE
[Fix] post-code body drag scroll 보존

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -338,6 +338,11 @@ test.describe("editor authoring route live drag sequence", () => {
       throw new Error(`code shell drag did not select code text: ${JSON.stringify(shellDispatchDiagnostics)}`)
     }
     await expect.poll(() => readSelectionText(page)).toContain("createAccessToken")
+    await page.mouse.wheel(0, 1).then(() => page.waitForTimeout(40))
+    await codeContent.evaluate((element) => {
+      element.scrollIntoView({ block: "center", inline: "nearest" })
+    })
+    await page.waitForTimeout(120)
     const beforeCodeSelectAll = await readScrollTop(page)
     await codeContent.click({ position: { x: 80, y: 28 } })
     await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A")
@@ -485,7 +490,9 @@ test.describe("editor authoring route live drag sequence", () => {
     })
     await page.waitForTimeout(120)
     const beforeLowerCodeClick = await readScrollTop(page)
-    await reissueCodeContent.click({ position: { x: 80, y: reissueClickMetrics.y } })
+    const reissueCodeBox = await reissueCodeContent.boundingBox()
+    if (!reissueCodeBox) throw new Error("reissue code metrics are missing")
+    await page.mouse.click(reissueCodeBox.x + 80, reissueCodeBox.y + reissueClickMetrics.y)
     await page.waitForTimeout(2_600)
     await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforeLowerCodeClick + 24)
     await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforeLowerCodeClick - 24)
@@ -522,6 +529,14 @@ test.describe("editor authoring route live drag sequence", () => {
     if (!postCodeCurrentLowerBodyBox) throw new Error("post-code current lower body metrics are missing")
     await page.mouse.move(postCodeCurrentLowerBodyBox.x + 8, postCodeCurrentLowerBodyBox.y + postCodeCurrentLowerBodyBox.height / 2)
     await page.mouse.down()
+    const beforeInjectedBodyDragScroll = await readScrollTop(page)
+    const afterInjectedBodyDragScroll = await page.evaluate(() => {
+      window.scrollBy(0, 476)
+      return document.scrollingElement?.scrollTop ?? window.scrollY
+    })
+    expect(afterInjectedBodyDragScroll).toBeGreaterThan(beforeInjectedBodyDragScroll + 120)
+    await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforeInjectedBodyDragScroll + 24)
+    await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforeInjectedBodyDragScroll - 24)
     await page.mouse.move(
       postCodeCurrentLowerBodyBox.x + Math.max(24, postCodeCurrentLowerBodyBox.width - 8),
       postCodeCurrentLowerBodyBox.y + postCodeCurrentLowerBodyBox.height / 2,
@@ -532,6 +547,8 @@ test.describe("editor authoring route live drag sequence", () => {
     const postCodeBodySelection = await readSelectionText(page)
     expect(postCodeBodySelection).toContain("TTL")
     expect(postCodeBodySelection).not.toContain("createAccessToken")
+    await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforePostCodeBodyClick + 24)
+    await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforePostCodeBodyClick - 24)
     await page.mouse.wheel(0, 1).then(() => page.waitForTimeout(40))
     await codeContent.evaluate((element) => {
       element.scrollIntoView({ block: "center", inline: "nearest" })

--- a/front/e2e/editor-authoring-route-rich-focus.spec.ts
+++ b/front/e2e/editor-authoring-route-rich-focus.spec.ts
@@ -101,6 +101,8 @@ test.describe("editor authoring route rich block focus", () => {
       label: string,
       clickOffset = { x: 40, y: 24 }
     ) => {
+      await page.mouse.wheel(0, 1)
+      await page.waitForTimeout(40)
       await target.scrollIntoViewIfNeeded()
       await target.evaluate((element) => {
         element.scrollIntoView({ block: "center", inline: "nearest" })

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -108,7 +108,8 @@ export const preserveWindowScrollAcrossFrames = (
   tolerance = 4,
   minDurationMs = 0,
   cancelOnTextSelectionChange = false,
-  cancelOnPointerMove = true
+  cancelOnPointerMove = true,
+  cancelOnPointerDown = true
 ) => {
   if (typeof window === "undefined" || typeof document === "undefined") return
   const scrollingElement = document.scrollingElement
@@ -118,7 +119,8 @@ export const preserveWindowScrollAcrossFrames = (
     tolerance,
     minDurationMs,
     cancelOnTextSelectionChange,
-    cancelOnPointerMove
+    cancelOnPointerMove,
+    cancelOnPointerDown
   )
 }
 
@@ -128,7 +130,8 @@ export const preserveWindowScrollPositionAcrossFrames = (
   tolerance = 4,
   minDurationMs = 0,
   cancelOnTextSelectionChange = false,
-  cancelOnPointerMove = true
+  cancelOnPointerMove = true,
+  cancelOnPointerDown = true
 ) => {
   if (typeof window === "undefined" || typeof document === "undefined") return
   const scrollingElement = document.scrollingElement
@@ -145,9 +148,21 @@ export const preserveWindowScrollPositionAcrossFrames = (
     if (!cancelOnTextSelectionChange) return
     cancel()
   }
+  const restoreScrollPosition = () => {
+    const currentY = scrollingElement?.scrollTop ?? window.scrollY
+    if (Math.abs(window.scrollX - startX) > tolerance || Math.abs(currentY - startY) > tolerance) {
+      window.scrollTo(startX, startY)
+    }
+  }
+  const restoreOnScroll = () => {
+    if (!cancelled) restoreScrollPosition()
+  }
   const cleanup = () => {
     window.removeEventListener("wheel", cancel, true)
-    window.removeEventListener("pointerdown", cancel, true)
+    window.removeEventListener("scroll", restoreOnScroll, true)
+    if (cancelOnPointerDown) {
+      window.removeEventListener("pointerdown", cancel, true)
+    }
     if (cancelOnPointerMove) {
       window.removeEventListener("pointermove", cancel, true)
       window.removeEventListener("mousemove", cancel, true)
@@ -157,7 +172,10 @@ export const preserveWindowScrollPositionAcrossFrames = (
     document.removeEventListener("selectionchange", cancelForTextSelection, true)
   }
   window.addEventListener("wheel", cancel, { capture: true, passive: true, once: true })
-  window.addEventListener("pointerdown", cancel, { capture: true, passive: true, once: true })
+  window.addEventListener("scroll", restoreOnScroll, { capture: true, passive: true })
+  if (cancelOnPointerDown) {
+    window.addEventListener("pointerdown", cancel, { capture: true, passive: true, once: true })
+  }
   if (cancelOnPointerMove) {
     window.addEventListener("pointermove", cancel, { capture: true, passive: true, once: true })
     window.addEventListener("mousemove", cancel, { capture: true, passive: true, once: true })
@@ -169,10 +187,7 @@ export const preserveWindowScrollPositionAcrossFrames = (
   }
   const restore = () => {
     if (cancelled) return
-    const currentY = scrollingElement?.scrollTop ?? window.scrollY
-    if (Math.abs(window.scrollX - startX) > tolerance || Math.abs(currentY - startY) > tolerance) {
-      window.scrollTo(startX, startY)
-    }
+    restoreScrollPosition()
     frame += 1
     const elapsedMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt
     if (frame < frames || elapsedMs < minDurationMs) {
@@ -195,12 +210,14 @@ export const markNextEditorPointerAfterCodeSelection = () => {
   preserveNextEditorPointerAfterCodeSelection = true
 }
 
-const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES = 72
-const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS = 1_120
+const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES = 168
+const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS = 2_800
+const EDITOR_POINTER_CODE_FOLLOW_UP_SCROLL_PRESERVE_FRAMES = 192
+const EDITOR_POINTER_CODE_FOLLOW_UP_SCROLL_PRESERVE_MIN_MS = 3_200
 const EDITOR_POINTER_TABLE_FOLLOW_UP_SCROLL_PRESERVE_FRAMES = 144
 const EDITOR_POINTER_TABLE_FOLLOW_UP_SCROLL_PRESERVE_MIN_MS = 2_400
-const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES = EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES
-const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS = EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS
+const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES = 72
+const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS = 1_120
 const EDITOR_POINTER_SCROLL_PRESERVE_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
 const EDITOR_POINTER_SCROLL_CONTROL_SELECTOR =
   "button, input, textarea, select, summary, [role='button'], [contenteditable='false']"
@@ -241,6 +258,17 @@ const preserveWindowScrollForTableFollowUpPointer = () => {
   )
 }
 
+export const preserveWindowScrollForCodePointerFocus = (cancelOnPointerDown = false) => {
+  preserveWindowScrollAcrossFrames(
+    EDITOR_POINTER_CODE_FOLLOW_UP_SCROLL_PRESERVE_FRAMES,
+    4,
+    EDITOR_POINTER_CODE_FOLLOW_UP_SCROLL_PRESERVE_MIN_MS,
+    false,
+    false,
+    cancelOnPointerDown
+  )
+}
+
 export const preserveWindowScrollForEditorPointerFocus = (
   target: EventTarget | null,
   tableSelectionActive: boolean,
@@ -267,6 +295,10 @@ export const preserveWindowScrollForEditorPointerFocus = (
   } else if (shouldPreserveFollowUp) {
     preserveNextEditorPointerAfterTable = false
   }
+  if (shouldPreserveCodeSelectionFollowUp && !tablePointerTarget) {
+    preserveWindowScrollForCodePointerFocus()
+    return
+  }
   if (shouldPreserveFollowUp) {
     preserveWindowScrollForTableFollowUpPointer()
     return
@@ -289,7 +321,7 @@ export const preserveWindowScrollForEditorPointerFocus = (
       EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES,
       4,
       EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS,
-      !shouldPreserveCodeSelectionFollowUp
+      true
     )
   }
 }

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -167,9 +167,10 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now(), preserveGeneration = ++codeDomTextRangePreserveGeneration
       let frame = 0, cancelled = false, cancelArmed = false
       const shell = contentRoot?.closest(".aq-code-shell")
-      const cleanupCancel = () => { window.removeEventListener("pointerdown", cancel, true); window.removeEventListener("mousedown", cancel, true); document.removeEventListener("selectionchange", cancelOnSelectionChange, true) }
+      const cleanupCancel = () => { window.removeEventListener("pointerdown", cancel, true); window.removeEventListener("mousedown", cancel, true); window.removeEventListener("keydown", cancelForKeydown, true); window.removeEventListener("wheel", cancelForKeydown, true); document.removeEventListener("selectionchange", cancelOnSelectionChange, true) }
       const cancelPreserve = () => { cancelled = true; codeDomTextRangePreserveGeneration += 1; shell?.removeAttribute("data-code-drag-selection-text"); cleanupCancel() }
       const cancel = (event: Event) => { if (!cancelArmed) return; if (!(event.target instanceof Node) || !shell?.contains(event.target)) cancelPreserve() }
+      const cancelForKeydown = () => { if (cancelArmed) cancelPreserve() }
       const cancelOnSelectionChange = () => { if (!cancelArmed) return; const selection = window.getSelection(), anchor = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focus = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null; if (selection?.toString().trim() && (!anchor || !focus || !shell?.contains(anchor) || !shell.contains(focus))) cancelPreserve() }
       const selectRange = () => { if (!selectCodeDomTextRange(contentRoot, anchorPos, headPos)) selectDomTextContents(contentRoot)
         shell?.setAttribute("data-code-drag-selection-text", window.getSelection()?.toString() || contentRoot?.textContent || "")
@@ -183,8 +184,10 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       }
       window.addEventListener("pointerdown", cancel, { capture: true, passive: true })
       window.addEventListener("mousedown", cancel, { capture: true, passive: true })
+      window.addEventListener("keydown", cancelForKeydown, true)
+      window.addEventListener("wheel", cancelForKeydown, { capture: true, passive: true })
       document.addEventListener("selectionchange", cancelOnSelectionChange, true)
-      preserveWindowScrollPositionAcrossFrames(scrollAnchor, 168, 4, 2_800, false, false)
+      preserveWindowScrollPositionAcrossFrames(scrollAnchor, 192, 4, 3_200, false, false, true)
       window.requestAnimationFrame(() => { cancelArmed = true })
       restore()
     },
@@ -194,7 +197,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     (event: ReactMouseEvent<HTMLDivElement> | ReactPointerEvent<HTMLDivElement>) => {
       const shell = shellRef.current
       const contentRoot = shell?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
-      if (event.button !== 0 || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return
+      if (event.button !== 0 || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey || event.defaultPrevented || (event.nativeEvent as Event & { __aqCodePointerHandled?: boolean }).__aqCodePointerHandled) return
       if (!shell || !contentRoot || !(event.target instanceof Node) || !shell.contains(event.target)) return
       const targetElement = event.target instanceof Element ? event.target : event.target.parentElement
       const contentRect = contentRoot.getBoundingClientRect()
@@ -219,7 +222,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       } else {
         selection?.removeAllRanges()
       }
-      preserveWindowScrollPositionAcrossFrames({ x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }, 168, 4, 2_800, false, false)
+      preserveWindowScrollPositionAcrossFrames({ x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }, 192, 4, 3_200, false, false, true)
       codeDragSelectionRef.current = {
         active: false,
         anchorPos,

--- a/front/src/components/editor/useBlockEditorEngineBlockSelectionUi.ts
+++ b/front/src/components/editor/useBlockEditorEngineBlockSelectionUi.ts
@@ -408,7 +408,7 @@ export const useBlockEditorEngineBlockSelectionUi = ({
         return
       }
 
-      if (event.defaultPrevented) return
+      if (event.defaultPrevented || (event.nativeEvent as Event & { __aqCodePointerHandled?: boolean }).__aqCodePointerHandled) return
       if (event.key !== "Tab" || event.metaKey || event.ctrlKey || event.altKey) return
       if (slashMenuState) return
       const activeListItemInteraction = resolveActiveListItemInteraction(currentEditor)
@@ -468,6 +468,7 @@ export const useBlockEditorEngineBlockSelectionUi = ({
         skipNextPointerDownSelectionClearRef.current = false
         return
       }
+      if (event.defaultPrevented) return
       const targetListItemContext = findNestedListItemContextFromTarget(event.target)
       const targetBlockIndex =
         findTopLevelBlockIndexFromTarget(event.target) ??

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -1,8 +1,7 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
 import { TextSelection } from "@tiptap/pm/state"
-import { useEffect, useRef } from "react"
-import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from "react"
-import { markNextEditorPointerAfterTable, preserveWindowScrollForEditorPointerFocus, preserveWindowScrollPositionAcrossFrames, type WindowScrollAnchor } from "./blockHandleLayoutModel"
+import { useEffect, useRef, type Dispatch, type MutableRefObject, type RefObject, type SetStateAction } from "react"
+import { markNextEditorPointerAfterTable, preserveWindowScrollForCodePointerFocus, preserveWindowScrollForEditorPointerFocus, preserveWindowScrollPositionAcrossFrames, type WindowScrollAnchor } from "./blockHandleLayoutModel"
 import { isTableSelectionActive } from "./tableStructureModel"
 import { preserveTableCellTextSelectionAcrossFrames, restoreTableCellTextSelectionIfEscaped } from "./tableTextSelectionModel"
 import { areFloatingBubbleStatesEqual, hideFloatingBubbleState, resolveFloatingBubbleStateFromCoords, type FloatingBubbleState } from "./useFloatingBubbleState"
@@ -90,10 +89,12 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     }
     const findCodeShellTarget = (targetElement: Element | null | undefined, pointElements: Element[]) =>
       targetElement?.closest(".aq-code-shell") ?? pointElements.find((element) => Boolean(element.closest(".aq-code-shell")))?.closest(".aq-code-shell")
-    const rememberCodeTextDragStartAtPoint = (event: MouseEvent | PointerEvent) => {
-      const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null
-      return rememberCodeTextDragStart(findCodeShellTarget(targetElement, document.elementsFromPoint(event.clientX, event.clientY)), event)
+    const resolveCurrentCodeSelectionText = (codeShellTarget: Element | null | undefined) => {
+      if (!codeShellTarget) return ""
+      const persistedCodeSelectionText = codeShellTarget.getAttribute("data-code-drag-selection-text")?.trim() || codeShellTarget.querySelector("[data-code-drag-selection-text]")?.getAttribute("data-code-drag-selection-text")?.trim() || "", selection = window.getSelection(), selectedText = selection?.toString().trim() ?? "", anchorElement = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focusElement = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null
+      return selectedText && anchorElement && focusElement && codeShellTarget.contains(anchorElement) && codeShellTarget.contains(focusElement) ? selectedText : persistedCodeSelectionText
     }
+    const rememberCodeTextDragStartAtPoint = (event: MouseEvent | PointerEvent) => { const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null; return rememberCodeTextDragStart(findCodeShellTarget(targetElement, document.elementsFromPoint(event.clientX, event.clientY)), event) }
 
     const rememberTableTextDragStart = (event: MouseEvent | PointerEvent, allowTableControlCellFallback = false) => {
       if (event.button !== 0) return null
@@ -143,7 +144,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const codeTextDragStart = codeTextDragStartRef.current
       if (!codeTextDragStart || codeTextDragStart.scrollPreserveStarted) return
       codeTextDragStart.scrollPreserveStarted = true
-      preserveWindowScrollPositionAcrossFrames(codeTextDragStart.scrollAnchor, 168, 4, 2_800, false, false)
+      preserveWindowScrollPositionAcrossFrames(codeTextDragStart.scrollAnchor, 192, 4, 3_200, false, false, true)
     }
     const isSelectionInsideCodeDragRoot = (root: HTMLElement) => {
       const selection = window.getSelection()
@@ -187,8 +188,9 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         return true
       }
       const handlePreservedSelectionChange = () => { if (restoring || !isCurrentPreserveGeneration()) return; const currentRoot = resolveCurrentRoot(), selection = window.getSelection(), anchor = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focus = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null; if (selection?.toString().trim() && (!anchor || !focus || !currentRoot.contains(anchor) || !currentRoot.contains(focus))) { cancelCodeDragSelectionPreserve(); return }; restoreIfMissing() }
-      const cleanupPreservedSelection = () => { document.removeEventListener("selectionchange", handlePreservedSelectionChange, true); window.removeEventListener("pointerdown", cancelPreservedSelection, true); window.removeEventListener("mousedown", cancelPreservedSelection, true) }
+      const cleanupPreservedSelection = () => { document.removeEventListener("selectionchange", handlePreservedSelectionChange, true); window.removeEventListener("pointerdown", cancelPreservedSelection, true); window.removeEventListener("mousedown", cancelPreservedSelection, true); window.removeEventListener("keydown", cancelPreservedSelectionForKeydown, true); window.removeEventListener("wheel", cancelPreservedSelectionForKeydown, true) }
       const isCurrentCodeDragEvent = (event: Event) => { const codeTextDragStart = codeTextDragStartRef.current; const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null; const currentRoot = resolveCurrentRoot(), currentShell = currentRoot.closest(".aq-code-shell") ?? codeShell; return Boolean(targetElement && (currentRoot.contains(targetElement) || currentShell?.contains(targetElement)) && ((codeTextDragStart?.scrollPreserveStarted && codeTextDragStart.root === currentRoot) || currentShell?.getAttribute("data-code-drag-selection-text")?.trim())) }, cancelPreservedSelection = (event: Event) => { if (!isCurrentPreserveGeneration()) return; if (!isCurrentCodeDragEvent(event)) cancelCodeDragSelectionPreserve() }
+      const cancelPreservedSelectionForKeydown = () => { if (isCurrentPreserveGeneration()) cancelCodeDragSelectionPreserve() }
       const restore = () => {
         if (!isCurrentPreserveGeneration()) { cleanupPreservedSelection(); return }; if (!resolveCurrentRoot().isConnected) { codeDragSelectionPreserveRafId = null; codeDragSelectionPreserveGeneration += 1; cleanupPreservedSelection(); return }
         restoreIfMissing()
@@ -205,6 +207,8 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       document.addEventListener("selectionchange", handlePreservedSelectionChange, true)
       window.addEventListener("pointerdown", cancelPreservedSelection, { capture: true, passive: true })
       window.addEventListener("mousedown", cancelPreservedSelection, { capture: true, passive: true })
+      window.addEventListener("keydown", cancelPreservedSelectionForKeydown, true)
+      window.addEventListener("wheel", cancelPreservedSelectionForKeydown, { capture: true, passive: true })
       cleanupCodeDragSelectionPreserve = cleanupPreservedSelection
       restore()
     }
@@ -400,18 +404,19 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const targetElement = eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
       const pointElements = document.elementsFromPoint(event.clientX, event.clientY)
       const codeShellTarget = findCodeShellTarget(targetElement, pointElements)
-      const existingSelectionText = window.getSelection()?.toString().trim() ?? "", existingCodeSelectionText = existingSelectionText || codeShellTarget?.getAttribute("data-code-drag-selection-text")?.trim() || ""
+      const existingSelectionText = window.getSelection()?.toString().trim() ?? "", existingCodeSelectionText = resolveCurrentCodeSelectionText(codeShellTarget)
       const allowTableControlCellFallback = Boolean(existingSelectionText) && !isTableSelectionActive(activeEditor)
       const targetTableControl = targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR)
       const pointInsideEditor = !targetElement?.closest("[data-table-menu-root='true']") && (!targetTableControl || allowTableControlCellFallback) && pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR)))
       const insideEditorDom = eventTarget instanceof Node && (activeEditor.view.dom.contains(eventTarget) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor)
       const tableTextDragStart = insideEditorDom ? rememberTableTextDragStart(event, allowTableControlCellFallback) : null
       if (!insideEditorDom && !codeShellTarget) return
+      if (codeShellTarget) preserveWindowScrollForCodePointerFocus(true); else if (insideEditorDom) { const blockSelectionActive = Boolean(document.querySelector("[data-testid='keyboard-block-selection-overlay']")); preserveWindowScrollForEditorPointerFocus(event.target, isTableSelectionActive(activeEditor), blockSelectionActive) }
       if (codeShellTarget) {
         cancelCodeDragSelectionPreserve()
         const codeTextDragStart = rememberCodeTextDragStart(codeShellTarget, event)
         const shellSurfaceTarget = codeTextDragStart && !targetElement?.closest(CODE_BLOCK_EDITOR_CONTENT_SELECTOR)
-        if (codeTextDragStart && (existingCodeSelectionText || shellSurfaceTarget)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root) } else clearImmediateWindowTextSelection()
+        if (codeTextDragStart && (existingCodeSelectionText || shellSurfaceTarget)) { (event as MouseEvent & { __aqCodePointerHandled?: boolean }).__aqCodePointerHandled = true; event.preventDefault(); event.stopPropagation(); event.stopImmediatePropagation?.(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root) } else clearImmediateWindowTextSelection()
       } else {
         codeTextDragStartRef.current = null
         if (insideEditorDom) {
@@ -421,8 +426,6 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       }
       if (insideEditorDom) {
         if (tableTextDragStart && (existingSelectionText || tableTextDragStart.coveredControlFallback)) { event.preventDefault(); event.stopPropagation(); if (tableTextDragStart.coveredControlFallback) event.stopImmediatePropagation?.(); restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); if (tableTextDragStart.coveredControlFallback) { preserveTableCellTextSelectionAcrossFrames(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor); preserveActiveTableTextDragScroll() } }
-        const blockSelectionActive = Boolean(document.querySelector("[data-testid='keyboard-block-selection-overlay']"))
-        preserveWindowScrollForEditorPointerFocus(event.target, isTableSelectionActive(activeEditor), blockSelectionActive)
       }
       if (tryStartTableColumnResizeFromDomHandle(event.target, event.pointerId, event.clientX)) {
         event.preventDefault()
@@ -447,7 +450,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       if (!activeEditor) return
       const eventTarget = event.target
       const targetElement = eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
-      const pointElements = document.elementsFromPoint(event.clientX, event.clientY), codeShellTarget = findCodeShellTarget(targetElement, pointElements), existingSelectionText = window.getSelection()?.toString().trim() ?? "", existingCodeSelectionText = existingSelectionText || codeShellTarget?.getAttribute("data-code-drag-selection-text")?.trim() || ""
+      const pointElements = document.elementsFromPoint(event.clientX, event.clientY), codeShellTarget = findCodeShellTarget(targetElement, pointElements), existingSelectionText = window.getSelection()?.toString().trim() ?? "", existingCodeSelectionText = resolveCurrentCodeSelectionText(codeShellTarget)
       const allowTableControlCellFallback = Boolean(existingSelectionText) && !isTableSelectionActive(activeEditor), targetTableControl = targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR)
       const pointInsideEditor = !targetElement?.closest("[data-table-menu-root='true']") && (!targetTableControl || allowTableControlCellFallback) && pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR))), insideEditorDom = eventTarget instanceof Node && (activeEditor.view.dom.contains(eventTarget) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor), columnResizeTarget = targetElement?.closest(".column-resize-handle"), tableTextDragStart = insideEditorDom && !codeShellTarget ? tableTextDragStartRef.current ?? rememberTableTextDragStart(event, allowTableControlCellFallback) : null
       if (!insideEditorDom && !codeShellTarget) return; if (codeTextDragStartRef.current && !codeShellTarget) codeTextDragStartRef.current = null
@@ -457,7 +460,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         cancelCodeDragSelectionPreserve()
         const codeTextDragStart = rememberCodeTextDragStart(codeShellTarget, event)
         const shellSurfaceTarget = codeTextDragStart && !targetElement?.closest(CODE_BLOCK_EDITOR_CONTENT_SELECTOR)
-        if (codeTextDragStart && (existingCodeSelectionText || shellSurfaceTarget)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root); return }
+        if (codeTextDragStart && (existingCodeSelectionText || shellSurfaceTarget)) { (event as MouseEvent & { __aqCodePointerHandled?: boolean }).__aqCodePointerHandled = true; event.preventDefault(); event.stopPropagation(); event.stopImmediatePropagation?.(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root); return }
         clearImmediateWindowTextSelection()
       } else if (insideEditorDom) {
         codeTextDragStartRef.current = null; cancelCodeDragSelectionPreserve()
@@ -539,13 +542,14 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       syncBubbleOnMouseUpRef.current = false
       scheduleSyncBubble()
     }
+    const resolveCodeDragCopyText = () => { const selection = window.getSelection(), selectedText = selection?.toString().trim() ?? "", anchorElement = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focusElement = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null, activeElement = document.activeElement instanceof Element ? document.activeElement : null, anchorShell = anchorElement?.closest(".aq-code-shell") ?? null, focusShell = focusElement?.closest(".aq-code-shell") ?? null, activeShell = activeElement?.closest(".aq-code-shell") ?? null, codeShell = anchorShell && anchorShell === focusShell ? anchorShell : activeShell?.getAttribute("data-code-drag-selection-text")?.trim() ? activeShell : null; if (!codeShell) return ""; return selectedText && anchorShell === codeShell && focusShell === codeShell ? selectedText : codeShell.getAttribute("data-code-drag-selection-text")?.trim() || "" }, handleDocumentCopyCapture = (event: ClipboardEvent) => { const copyText = resolveCodeDragCopyText(); if (!copyText) return; event.preventDefault(); event.clipboardData?.setData("text/plain", copyText) }, handleDocumentCopyKeyDown = (event: KeyboardEvent) => { if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey || event.key.toLowerCase() !== "c") return; const copyText = resolveCodeDragCopyText(); if (!copyText) return; event.preventDefault(); void navigator.clipboard?.writeText(copyText) }
 
     scheduleSyncBubble()
     currentEditor.on("selectionUpdate", scheduleSyncBubble)
     currentEditor.on("focus", scheduleSyncBubble)
     document.addEventListener("selectionchange", handleDocumentSelectionChange)
     document.addEventListener("pointerdown", handleEditorPointerDownCapture, true)
-    document.addEventListener("mousedown", handleEditorMouseDownCapture, true)
+    document.addEventListener("mousedown", handleEditorMouseDownCapture, true); document.addEventListener("copy", handleDocumentCopyCapture, true); window.addEventListener("keydown", handleDocumentCopyKeyDown, true)
     window.addEventListener("scroll", scheduleSyncBubble, { capture: true, passive: true })
     window.addEventListener("resize", scheduleSyncBubble, { passive: true })
     window.addEventListener("pointermove", handleWindowPointerMove, true)
@@ -558,7 +562,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       currentEditor.off("focus", scheduleSyncBubble)
       document.removeEventListener("selectionchange", handleDocumentSelectionChange)
       document.removeEventListener("pointerdown", handleEditorPointerDownCapture, true)
-      document.removeEventListener("mousedown", handleEditorMouseDownCapture, true)
+      document.removeEventListener("mousedown", handleEditorMouseDownCapture, true); document.removeEventListener("copy", handleDocumentCopyCapture, true); window.removeEventListener("keydown", handleDocumentCopyKeyDown, true)
       window.removeEventListener("scroll", scheduleSyncBubble, true)
       window.removeEventListener("resize", scheduleSyncBubble)
       window.removeEventListener("pointermove", handleWindowPointerMove, true)
@@ -566,9 +570,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       window.removeEventListener("pointerup", completeTextDragSelection, true)
       window.removeEventListener("pointercancel", completeTextDragSelection, true)
       window.removeEventListener("mouseup", completeTextDragSelection, true)
-      if (rafId !== null && typeof window !== "undefined") {
-        window.cancelAnimationFrame(rafId)
-      }
+      if (rafId !== null && typeof window !== "undefined") window.cancelAnimationFrame(rafId)
       cancelCodeDragSelectionPreserve()
       mouseTextSelectionInProgressRef.current = false
       syncBubbleOnMouseUpRef.current = false


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 하단 code Cmd+A 이후 body click/drag가 이전 code/body selection anchor에 끌려 viewport가 순간이동하는 회귀를 복구합니다.
- code handler가 현재 code shell 내부 selection/dataset만 code selection으로 인정하도록 좁히고, direct code click/drag preserve는 다음 pointerdown에서 취소되도록 분리했습니다.

## 작업 내용

- code scroll preserve에 scroll-event 즉시 복구와 pointerdown 취소 옵션을 추가했습니다.
- body selection을 code selection으로 오인하지 않도록 current code shell 기준으로 selection 판정을 제한했습니다.
- live-shape route E2E에 post-code body click/drag delayed scroll 회귀와 rich focus programmatic scroll 준비 계약을 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-rich-focus.spec.ts:9 e2e/editor-authoring-route-rich-drag-selection.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-body-click-flicker.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-rich-focus.spec.ts e2e/editor-authoring-route-rich-select-all.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-affordances.spec.ts:547 e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-smoke.spec.ts:9 --workers=1`
  - `yarn --cwd front test:e2e:authoring` (96 passed, 2회 연속; 최종 test 변경 후 96 passed 1회 추가)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: editor scroll preserve 기간/취소 조건 변경으로 code/table/body 선택 경로에 타이밍 회귀가 생길 수 있습니다.
- 롤백 방법: 이 PR 커밋을 revert하면 이전 editor pointer preserve 동작으로 되돌릴 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
