### PR TITLE
[Feat] OAuth PKCE OIDC 로그인 계약 추가

### DIFF
--- a/back/src/main/kotlin/com/back/global/security/config/SecurityConfig.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/SecurityConfig.kt
@@ -8,6 +8,7 @@ import com.back.global.rsData.RsData
 import com.back.global.security.config.oauth2.CustomOAuth2AuthorizationRequestResolver
 import com.back.global.security.config.oauth2.CustomOAuth2LoginSuccessHandler
 import com.back.global.security.config.oauth2.CustomOAuth2UserService
+import com.back.global.security.config.oauth2.CustomOidcUserService
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -35,6 +36,7 @@ class SecurityConfig(
     private val customOAuth2LoginSuccessHandler: CustomOAuth2LoginSuccessHandler,
     private val customOAuth2AuthorizationRequestResolver: CustomOAuth2AuthorizationRequestResolver,
     private val customOAuth2UserService: CustomOAuth2UserService,
+    private val customOidcUserService: CustomOidcUserService,
     private val authSecurityConfigurer: AuthSecurityConfigurer,
     private val memberSecurityConfigurer: MemberSecurityConfigurer,
     private val postSecurityConfigurer: PostSecurityConfigurer,
@@ -107,6 +109,7 @@ class SecurityConfig(
 
                 userInfoEndpoint {
                     userService = customOAuth2UserService
+                    oidcUserService = customOidcUserService
                 }
             }
 

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2AuthorizationRequestResolver.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2AuthorizationRequestResolver.kt
@@ -4,6 +4,7 @@ import com.back.global.security.config.oauth2.application.OAuth2State
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestCustomizers
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
@@ -22,7 +23,9 @@ class CustomOAuth2AuthorizationRequestResolver(
         DefaultOAuth2AuthorizationRequestResolver(
             clientRegistrationRepository,
             OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI,
-        )
+        ).apply {
+            setAuthorizationRequestCustomizer(OAuth2AuthorizationRequestCustomizers.withPkce())
+        }
 
     override fun resolve(request: HttpServletRequest): OAuth2AuthorizationRequest? =
         delegate.resolve(request)?.let { customizeState(it, request) }

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserService.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserService.kt
@@ -42,7 +42,8 @@ private enum class OAuth2Provider {
 @Service
 class CustomOAuth2UserService(
     private val memberUseCase: MemberUseCase,
-) : DefaultOAuth2UserService() {
+) : OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    internal var delegate: OAuth2UserService<OAuth2UserRequest, OAuth2User> = DefaultOAuth2UserService()
     private val logger = LoggerFactory.getLogger(javaClass)
 
     /**
@@ -51,7 +52,7 @@ class CustomOAuth2UserService(
      */
     @Transactional
     override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
-        val oAuth2User = super.loadUser(userRequest)
+        val oAuth2User = delegate.loadUser(userRequest)
         val provider = OAuth2Provider.from(userRequest.clientRegistration.registrationId)
         val profilePayload =
             when (provider) {
@@ -66,7 +67,7 @@ class CustomOAuth2UserService(
 class CustomOidcUserService(
     private val memberUseCase: MemberUseCase,
 ) : OAuth2UserService<OidcUserRequest, OidcUser> {
-    private val delegate = OidcUserService()
+    internal var delegate: OAuth2UserService<OidcUserRequest, OidcUser> = OidcUserService()
     private val logger = LoggerFactory.getLogger(javaClass)
 
     @Transactional

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserService.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserService.kt
@@ -1,11 +1,20 @@
 package com.back.global.security.config.oauth2
 
 import com.back.boundedContexts.member.application.port.input.MemberUseCase
+import com.back.boundedContexts.member.domain.shared.Member
 import com.back.global.security.domain.SecurityUser
 import com.back.global.security.domain.toGrantedAuthorities
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
+import org.springframework.security.oauth2.core.oidc.OidcIdToken
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -44,40 +53,106 @@ class CustomOAuth2UserService(
     override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
         val oAuth2User = super.loadUser(userRequest)
         val provider = OAuth2Provider.from(userRequest.clientRegistration.registrationId)
-
         val profilePayload =
             when (provider) {
                 OAuth2Provider.KAKAO -> OAuth2ProfileExtractor.extractKakao(oAuth2User.attributes, oAuth2User.name)
             }
 
-        if (profilePayload.nickname == OAuth2ProfileExtractor.DEFAULT_KAKAO_NICKNAME) {
-            logger.warn(
-                "oauth2_kakao_profile_fallback_used provider={} oauthUserId={}",
-                provider.name.lowercase(),
-                profilePayload.oauthUserId,
-            )
-        }
+        return upsertMember(provider, profilePayload, memberUseCase, logger).toSecurityUser()
+    }
+}
 
-        val username = "${provider.name}__${profilePayload.oauthUserId}"
-        val password = ""
+@Service
+class CustomOidcUserService(
+    private val memberUseCase: MemberUseCase,
+) : OAuth2UserService<OidcUserRequest, OidcUser> {
+    private val delegate = OidcUserService()
+    private val logger = LoggerFactory.getLogger(javaClass)
 
-        val member =
-            memberUseCase
-                .modifyOrJoin(
-                    username,
-                    password,
-                    profilePayload.nickname,
-                    profilePayload.profileImgUrl,
-                ).data
+    @Transactional
+    override fun loadUser(userRequest: OidcUserRequest): OidcUser {
+        val oidcUser = delegate.loadUser(userRequest)
+        val provider = OAuth2Provider.from(userRequest.clientRegistration.registrationId)
+        val profilePayload =
+            when (provider) {
+                OAuth2Provider.KAKAO -> OAuth2ProfileExtractor.extractKakao(oidcUser.claims, oidcUser.name)
+            }
+        val member = upsertMember(provider, profilePayload, memberUseCase, logger)
 
-        return SecurityUser(
-            member.id,
-            member.username,
-            member.password ?: "",
-            member.name,
-            member.toGrantedAuthorities(),
+        return member.toSecurityOidcUser(oidcUser)
+    }
+}
+
+private fun upsertMember(
+    provider: OAuth2Provider,
+    profilePayload: OAuth2ProfilePayload,
+    memberUseCase: MemberUseCase,
+    logger: Logger,
+): Member {
+    if (profilePayload.nickname == OAuth2ProfileExtractor.DEFAULT_KAKAO_NICKNAME) {
+        logger.warn(
+            "oauth2_kakao_profile_fallback_used provider={} oauthUserId={}",
+            provider.name.lowercase(),
+            profilePayload.oauthUserId,
         )
     }
+
+    val username = "${provider.name}__${profilePayload.oauthUserId}"
+    val password = ""
+
+    return memberUseCase
+        .modifyOrJoin(
+            username,
+            password,
+            profilePayload.nickname,
+            profilePayload.profileImgUrl,
+        ).data
+}
+
+private fun Member.toSecurityUser(): SecurityUser =
+    SecurityUser(
+        id,
+        username,
+        password ?: "",
+        name,
+        toGrantedAuthorities(),
+    )
+
+private fun Member.toSecurityOidcUser(oidcUser: OidcUser): SecurityOidcUser =
+    SecurityOidcUser(
+        id,
+        username,
+        password ?: "",
+        name,
+        toGrantedAuthorities(),
+        oidcUser.idToken,
+        oidcUser.userInfo,
+    )
+
+private class SecurityOidcUser(
+    id: Long,
+    username: String,
+    password: String,
+    nickname: String,
+    authorities: Collection<GrantedAuthority>,
+    private val idToken: OidcIdToken,
+    userInfo: OidcUserInfo?,
+) : SecurityUser(id, username, password, nickname, authorities),
+    OidcUser {
+    private val userInfo = userInfo ?: OidcUserInfo(idToken.claims)
+    private val oidcClaims: Map<String, Any> =
+        buildMap {
+            putAll(this@SecurityOidcUser.userInfo.claims)
+            putAll(idToken.claims)
+        }
+
+    override fun getAttributes(): Map<String, Any> = oidcClaims
+
+    override fun getClaims(): Map<String, Any> = oidcClaims
+
+    override fun getUserInfo(): OidcUserInfo = userInfo
+
+    override fun getIdToken(): OidcIdToken = idToken
 }
 
 internal data class OAuth2ProfilePayload(
@@ -100,6 +175,7 @@ internal object OAuth2ProfileExtractor {
         val oauthUserId =
             firstNonBlank(
                 attributes["id"],
+                attributes["sub"],
                 fallbackName,
                 "unknown",
             )
@@ -108,6 +184,8 @@ internal object OAuth2ProfileExtractor {
                 properties?.get("nickname"),
                 accountProfile?.get("nickname"),
                 kakaoAccount?.get("name"),
+                attributes["nickname"],
+                attributes["name"],
                 DEFAULT_KAKAO_NICKNAME,
             )
         val profileImgUrl =
@@ -115,6 +193,7 @@ internal object OAuth2ProfileExtractor {
                 properties?.get("profile_image"),
                 accountProfile?.get("profile_image_url"),
                 accountProfile?.get("thumbnail_image_url"),
+                attributes["picture"],
             )
 
         return OAuth2ProfilePayload(

--- a/back/src/main/kotlin/com/back/global/security/domain/SecurityUser.kt
+++ b/back/src/main/kotlin/com/back/global/security/domain/SecurityUser.kt
@@ -8,7 +8,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User
  * SecurityUser는 글로벌 모듈 도메인 상태와 규칙을 표현하는 모델입니다.
  * 불변조건을 유지하며 상태 전이를 메서드 단위로 캡슐화합니다.
  */
-class SecurityUser(
+open class SecurityUser(
     val id: Long,
     username: String,
     password: String,
@@ -16,7 +16,7 @@ class SecurityUser(
     authorities: Collection<GrantedAuthority>,
 ) : User(username, password, authorities),
     OAuth2User {
-    override fun getAttributes(): Map<String, Any> = emptyMap()
+    open override fun getAttributes(): Map<String, Any> = emptyMap()
 
-    override fun getName(): String = username
+    open override fun getName(): String = username
 }

--- a/back/src/main/resources/application.yaml
+++ b/back/src/main/resources/application.yaml
@@ -25,16 +25,18 @@ spring:
         registration:
           kakao:
             client-id: ${SPRING__SECURITY__OAUTH2__CLIENT__REGISTRATION__KAKAO__CLIENT_ID:}
-            scope: profile_nickname, profile_image
+            scope: openid, profile_nickname, profile_image
             client-name: Kakao
             authorization-grant-type: authorization_code
             redirect-uri: '${custom.site.backUrl}/login/oauth2/code/{registrationId}'
         provider:
           kakao:
+            issuer-uri: https://kauth.kakao.com
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
-            user-info-uri: https://kapi.kakao.com/v2/user/me
-            user-name-attribute: id
+            jwk-set-uri: https://kauth.kakao.com/.well-known/jwks.json
+            user-info-uri: https://kapi.kakao.com/v1/oidc/userinfo
+            user-name-attribute: sub
   mail:
     host: ${SPRING__MAIL__HOST:}
     port: ${SPRING__MAIL__PORT:587}

--- a/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserServiceTest.kt
@@ -1,0 +1,204 @@
+package com.back.global.security.config.oauth2
+
+import com.back.boundedContexts.member.application.port.input.MemberUseCase
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.global.rsData.RsData
+import com.back.global.security.domain.SecurityUser
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
+import org.springframework.security.oauth2.client.registration.ClientRegistration
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
+import org.springframework.security.oauth2.core.AuthorizationGrantType
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod
+import org.springframework.security.oauth2.core.OAuth2AccessToken
+import org.springframework.security.oauth2.core.oidc.OidcIdToken
+import org.springframework.security.oauth2.core.oidc.OidcScopes
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User
+import org.springframework.security.oauth2.core.user.OAuth2User
+import java.lang.reflect.Proxy
+import java.time.Instant
+
+@DisplayName("CustomOAuth2UserService 테스트")
+class CustomOAuth2UserServiceTest {
+    @Test
+    fun `OAuth2 사용자 정보는 내부 SecurityUser로 매핑하고 기본 닉네임 fallback을 기록한다`() {
+        val memberUseCase = RecordingMemberUseCase()
+        val service =
+            CustomOAuth2UserService(memberUseCase.proxy).apply {
+                delegate =
+                    OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+                        DefaultOAuth2User(emptyList(), mapOf("id" to "oauth-user-id"), "id")
+                    }
+            }
+
+        val principal =
+            service.loadUser(
+                OAuth2UserRequest(kakaoClientRegistration(userNameAttributeName = "id"), accessToken()),
+            ) as SecurityUser
+
+        assertThat(memberUseCase.lastRequest)
+            .isEqualTo(
+                ModifyOrJoinRequest(
+                    username = "KAKAO__oauth-user-id",
+                    password = "",
+                    nickname = OAuth2ProfileExtractor.DEFAULT_KAKAO_NICKNAME,
+                    profileImgUrl = null,
+                ),
+            )
+        assertThat(principal.username).isEqualTo("KAKAO__oauth-user-id")
+        assertThat(principal.nickname).isEqualTo(OAuth2ProfileExtractor.DEFAULT_KAKAO_NICKNAME)
+        assertThat(principal.authorities.map { it.authority }).containsExactly("ROLE_MEMBER")
+    }
+
+    @Test
+    fun `OIDC claims는 SecurityUser이자 OidcUser인 principal로 매핑한다`() {
+        val memberUseCase = RecordingMemberUseCase()
+        val idToken =
+            OidcIdToken(
+                "id-token",
+                Instant.EPOCH,
+                Instant.EPOCH.plusSeconds(60),
+                mapOf(
+                    "sub" to "oidc-user-id",
+                    "nickname" to "OIDC닉네임",
+                    "picture" to "https://kakao.cdn/oidc.png",
+                ),
+            )
+        val userInfo =
+            OidcUserInfo(
+                mapOf(
+                    "sub" to "oidc-user-id",
+                    "nickname" to "userinfo-nickname",
+                ),
+            )
+        val service =
+            CustomOidcUserService(memberUseCase.proxy).apply {
+                delegate =
+                    OAuth2UserService<OidcUserRequest, OidcUser> {
+                        DefaultOidcUser(emptyList(), idToken, userInfo, "sub")
+                    }
+            }
+
+        val principal =
+            service.loadUser(
+                OidcUserRequest(kakaoClientRegistration(userNameAttributeName = "sub"), accessToken(), idToken),
+            )
+        val securityUser = principal as SecurityUser
+
+        assertThat(memberUseCase.lastRequest)
+            .isEqualTo(
+                ModifyOrJoinRequest(
+                    username = "KAKAO__oidc-user-id",
+                    password = "",
+                    nickname = "OIDC닉네임",
+                    profileImgUrl = "https://kakao.cdn/oidc.png",
+                ),
+            )
+        assertThat(securityUser.username).isEqualTo("KAKAO__oidc-user-id")
+        assertThat(securityUser.nickname).isEqualTo("OIDC닉네임")
+        assertThat(principal.attributes["sub"]).isEqualTo("oidc-user-id")
+        assertThat(principal.claims["nickname"]).isEqualTo("OIDC닉네임")
+        assertThat(principal.idToken).isSameAs(idToken)
+        assertThat(principal.userInfo.subject).isEqualTo("oidc-user-id")
+    }
+
+    @Test
+    fun `지원하지 않는 provider는 명시적으로 거부한다`() {
+        val service =
+            CustomOAuth2UserService(RecordingMemberUseCase().proxy).apply {
+                delegate =
+                    OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+                        DefaultOAuth2User(emptyList(), mapOf("id" to "oauth-user-id"), "id")
+                    }
+            }
+
+        assertThatThrownBy {
+            service.loadUser(
+                OAuth2UserRequest(
+                    kakaoClientRegistration(registrationId = "google", userNameAttributeName = "id"),
+                    accessToken(),
+                ),
+            )
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("Unsupported provider: google")
+    }
+
+    private fun kakaoClientRegistration(
+        registrationId: String = "kakao",
+        userNameAttributeName: String,
+    ): ClientRegistration =
+        ClientRegistration
+            .withRegistrationId(registrationId)
+            .clientId("kakao-client-id")
+            .clientSecret("kakao-client-secret")
+            .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+            .scope(OidcScopes.OPENID, "profile_nickname", "profile_image")
+            .authorizationUri("https://kauth.kakao.com/oauth/authorize")
+            .tokenUri("https://kauth.kakao.com/oauth/token")
+            .issuerUri("https://kauth.kakao.com")
+            .jwkSetUri("https://kauth.kakao.com/.well-known/jwks.json")
+            .userInfoUri("https://kapi.kakao.com/v1/oidc/userinfo")
+            .userNameAttributeName(userNameAttributeName)
+            .clientName("Kakao")
+            .build()
+
+    private fun accessToken(): OAuth2AccessToken =
+        OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            "access-token",
+            Instant.EPOCH,
+            Instant.EPOCH.plusSeconds(60),
+        )
+}
+
+private data class ModifyOrJoinRequest(
+    val username: String,
+    val password: String,
+    val nickname: String,
+    val profileImgUrl: String?,
+)
+
+private class RecordingMemberUseCase {
+    lateinit var lastRequest: ModifyOrJoinRequest
+        private set
+
+    val proxy: MemberUseCase =
+        Proxy
+            .newProxyInstance(
+                MemberUseCase::class.java.classLoader,
+                arrayOf(MemberUseCase::class.java),
+            ) { _, method, args ->
+                when (method.name) {
+                    "modifyOrJoin" -> {
+                        val request =
+                            ModifyOrJoinRequest(
+                                username = args?.get(0) as String,
+                                password = args[1] as String,
+                                nickname = args[2] as String,
+                                profileImgUrl = args[3] as String?,
+                            )
+                        lastRequest = request
+
+                        RsData.ok(
+                            Member(
+                                id = 1,
+                                username = request.username,
+                                password = request.password,
+                                nickname = request.nickname,
+                            ),
+                        )
+                    }
+                    "toString" -> "RecordingMemberUseCase"
+                    else -> error("Unexpected MemberUseCase method: ${method.name}")
+                }
+            } as MemberUseCase
+}

--- a/back/src/test/kotlin/com/back/global/security/config/oauth2/OAuth2AuthorizationRequestResolverTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/oauth2/OAuth2AuthorizationRequestResolverTest.kt
@@ -1,0 +1,80 @@
+package com.back.global.security.config.oauth2
+
+import com.back.global.security.config.oauth2.application.OAuth2State
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.security.oauth2.client.registration.ClientRegistration
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository
+import org.springframework.security.oauth2.core.AuthorizationGrantType
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod
+import org.springframework.security.oauth2.core.endpoint.PkceParameterNames
+import org.springframework.security.oauth2.core.oidc.OidcScopes
+import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames
+
+@DisplayName("CustomOAuth2AuthorizationRequestResolver 테스트")
+class OAuth2AuthorizationRequestResolverTest {
+    @Test
+    fun `카카오 authorization request는 PKCE S256과 OIDC nonce를 포함한다`() {
+        val resolver =
+            CustomOAuth2AuthorizationRequestResolver(
+                InMemoryClientRegistrationRepository(kakaoClientRegistration()),
+            )
+        val request =
+            MockHttpServletRequest("GET", "/oauth2/authorization/kakao").apply {
+                scheme = "https"
+                serverName = "api.example.com"
+                serverPort = 443
+                servletPath = "/oauth2/authorization/kakao"
+                setParameter("redirectUrl", "/admin")
+            }
+
+        val authorizationRequest = resolver.resolve(request)
+
+        assertThat(authorizationRequest).isNotNull
+        authorizationRequest!!
+        assertThat(authorizationRequest.scopes).containsExactlyInAnyOrder(
+            OidcScopes.OPENID,
+            "profile_nickname",
+            "profile_image",
+        )
+        assertThat(authorizationRequest.additionalParameters[PkceParameterNames.CODE_CHALLENGE_METHOD])
+            .isEqualTo("S256")
+        assertThat(authorizationRequest.additionalParameters[PkceParameterNames.CODE_CHALLENGE] as String)
+            .isNotBlank()
+        assertThat(authorizationRequest.attributes[PkceParameterNames.CODE_VERIFIER] as String)
+            .isNotBlank()
+        assertThat(authorizationRequest.additionalParameters[OidcParameterNames.NONCE] as String)
+            .isNotBlank()
+        assertThat(authorizationRequest.attributes[OidcParameterNames.NONCE] as String)
+            .isNotBlank()
+        assertThat(OAuth2State.decode(authorizationRequest.state).redirectUrl).isEqualTo("/admin")
+    }
+
+    private fun kakaoClientRegistration(): ClientRegistration {
+        val clientSettings =
+            ClientRegistration.ClientSettings
+                .builder()
+                .requireProofKey(false)
+                .build()
+
+        return ClientRegistration
+            .withRegistrationId("kakao")
+            .clientId("kakao-client-id")
+            .clientSecret("kakao-client-secret")
+            .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+            .clientSettings(clientSettings)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+            .scope(OidcScopes.OPENID, "profile_nickname", "profile_image")
+            .authorizationUri("https://kauth.kakao.com/oauth/authorize")
+            .tokenUri("https://kauth.kakao.com/oauth/token")
+            .issuerUri("https://kauth.kakao.com")
+            .jwkSetUri("https://kauth.kakao.com/.well-known/jwks.json")
+            .userInfoUri("https://kapi.kakao.com/v1/oidc/userinfo")
+            .userNameAttributeName("sub")
+            .clientName("Kakao")
+            .build()
+    }
+}

--- a/back/src/test/kotlin/com/back/global/security/config/oauth2/OAuth2ProfileExtractorTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/oauth2/OAuth2ProfileExtractorTest.kt
@@ -48,6 +48,22 @@ class OAuth2ProfileExtractorTest {
     }
 
     @Test
+    fun `OIDC 표준 claims가 있으면 sub nickname picture로 매핑한다`() {
+        val attributes =
+            mapOf(
+                "sub" to "oidc-kakao-user-id",
+                "nickname" to "OIDC닉네임",
+                "picture" to "https://kakao.cdn/oidc-picture.png",
+            )
+
+        val payload = OAuth2ProfileExtractor.extractKakao(attributes, fallbackName = "fallback-name")
+
+        assertThat(payload.oauthUserId).isEqualTo("oidc-kakao-user-id")
+        assertThat(payload.nickname).isEqualTo("OIDC닉네임")
+        assertThat(payload.profileImgUrl).isEqualTo("https://kakao.cdn/oidc-picture.png")
+    }
+
+    @Test
     fun `nickname 필드가 모두 없으면 기본 닉네임으로 fallback한다`() {
         val attributes = mapOf<String, Any>()
 


### PR DESCRIPTION
## 관련 이슈

close #496

## 작업 배경

- Kakao OAuth 로그인을 OAuth 2.0 authorization code + PKCE(S256) + OIDC(openid, nonce) 계약으로 고정합니다.
- OIDC `id_token`/userinfo claim이 기존 member session 발급 흐름으로 이어지도록 `OidcUserService` 경로를 추가했습니다.

## 작업 내용

- Kakao OAuth registration에 `openid`, issuer, JWKS, OIDC userinfo, `sub` name attribute를 설정했습니다.
- authorization request resolver가 client 설정과 무관하게 PKCE S256 파라미터를 보장하도록 했습니다.
- OIDC `sub/nickname/picture` claim fallback과 PKCE/OIDC nonce 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd back && ./gradlew test --tests com.back.global.security.config.oauth2.OAuth2AuthorizationRequestResolverTest --tests com.back.global.security.config.oauth2.OAuth2ProfileExtractorTest`
  - `cd back && ./gradlew ktlintCheck`
  - `cd back && ./gradlew test`
  - `cd back && ./gradlew test --rerun-tasks`
  - `cd back && ./gradlew ciFastCheck --rerun-tasks` (2회 연속 통과)
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: Kakao Developers 콘솔에서 OpenID Connect가 활성화되어 있지 않으면 `id_token`이 발급되지 않아 로그인 콜백이 실패할 수 있습니다.
- 롤백 방법: 이 PR의 두 커밋 `95737802`, `375bd334`를 revert하면 기존 OAuth2 userinfo 기반 흐름으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
