### PR TITLE
[Fix] post-code body selectionchange scroll 보존

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -514,14 +514,20 @@ test.describe("editor authoring route live drag sequence", () => {
     const beforePostCodeBodyClick = await readScrollTop(page)
     const postCodeLowerBodyBox = await lowerBodyAnchor.boundingBox()
     if (!postCodeLowerBodyBox) throw new Error("post-code lower body metrics are missing")
-    await page.evaluate(() => {
-      window.setTimeout(() => document.dispatchEvent(new Event("selectionchange")), 16)
-      window.setTimeout(() => window.scrollBy(0, 476), 72)
-    })
-    await page.mouse.click(
+    await page.mouse.move(
       postCodeLowerBodyBox.x + Math.min(postCodeLowerBodyBox.width / 2, 96),
       postCodeLowerBodyBox.y + 12
     )
+    await page.mouse.down()
+    const afterSelectionChangeBodyClickScroll = await page.evaluate(() => {
+      document.dispatchEvent(new Event("selectionchange"))
+      window.scrollBy(0, 476)
+      return document.scrollingElement?.scrollTop ?? window.scrollY
+    })
+    expect(afterSelectionChangeBodyClickScroll).toBeGreaterThan(beforePostCodeBodyClick + 120)
+    await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforePostCodeBodyClick + 24)
+    await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforePostCodeBodyClick - 24)
+    await page.mouse.up()
     await page.waitForTimeout(1_000)
     await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforePostCodeBodyClick + 24)
     await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforePostCodeBodyClick - 24)

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -40,7 +40,7 @@ import {
   resolveCodeBlockPasteRange,
   resolveCodeBlockCopyText,
   selectCodeBlockText,
-  selectDomTextContents,
+  selectCodeDomTextContents, selectDomTextContents,
   selectDomTextOffsetRange,
 } from "./codeBlockNodeViewSelectionModel"
 import { focusElementWithoutScroll } from "./blockEditorEngineDocumentModel"
@@ -312,7 +312,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       const selectedText = window.getSelection()?.toString() || ""
       if (selectedText.trim()) return
       if (!(contentRoot.textContent || "").trim()) return
-      selectDomTextContents(contentRoot)
+      selectCodeDomTextContents(contentRoot)
     })
   }, [])
   useEffect(() => {
@@ -375,7 +375,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
         ensureCodeDomTextSelection(contentRoot)
         return
       }
-      selectDomTextContents(contentRoot)
+      selectCodeDomTextContents(contentRoot)
     }
 
     const observer = new MutationObserver(() => {
@@ -505,7 +505,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       ensureCodeDomTextSelection(contentRoot)
       return
     }
-    if (selectDomTextContents(contentRoot)) return
+    if (selectCodeDomTextContents(contentRoot)) return
 
     if (typeof getPos !== "function") return
     const codeBlockPos = getPos()

--- a/front/src/components/editor/codeBlockNodeViewSelectionModel.ts
+++ b/front/src/components/editor/codeBlockNodeViewSelectionModel.ts
@@ -32,6 +32,15 @@ export const selectDomTextContents = (root: HTMLElement | null) => {
   return true
 }
 
+export const selectCodeDomTextContents = (root: HTMLElement | null) => {
+  const selected = selectDomTextContents(root)
+  if (selected) {
+    markNextEditorPointerAfterCodeSelection()
+    preserveWindowScrollForRichBlockSelectAll()
+  }
+  return selected
+}
+
 export const selectDomTextOffsetRange = (
   root: HTMLElement | null,
   fromOffset: number,


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- PR #495 배포본에서 하단 code Cmd+A 이후 하단 본문 클릭 중 `selectionchange`와 reveal scroll이 겹치면 `/editor/507` viewport가 운영 체크리스트/table 위치로 이동하던 live 회귀를 복구합니다.
- code DOM select-all fallback이 후속 editor pointer 마커와 rich-block select-all scroll 보존을 남기도록 좁혀, 다음 body click/drag가 일반 preserve 조기 취소 경로로 빠지지 않게 했습니다.

## 작업 내용

- code block DOM 텍스트 전체 선택 fallback을 `selectCodeDomTextContents`로 분리해 code-selection 이후 editor pointer와 viewport 보존 상태를 함께 남깁니다.
- code block NodeView의 DOM select-all fallback 호출부를 새 code 전용 helper로 교체했습니다.
- live drag sequence E2E에서 body click 중 `selectionchange`와 scroll injection을 mouse-down 상태에서 deterministic하게 재현하고 restore를 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-body-click-flicker.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-rich-focus.spec.ts e2e/editor-authoring-route-rich-select-all.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-affordances.spec.ts:547 e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-smoke.spec.ts:9 --workers=1`
  - `yarn --cwd front test:e2e:authoring` (2회 연속)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: code DOM select-all fallback이 추가 scroll preserve를 남기므로 code Cmd+A 직후 다른 블럭 클릭/drag 타이밍에 영향을 줄 수 있습니다. 관련 route set과 full authoring을 함께 통과시켜 회귀 범위를 확인했습니다.
- 롤백 방법: 이 PR을 revert하면 이전 PR #495 상태로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
