### PR TITLE
[Fix] 테이블 드래그 선택 확정

### DIFF
--- a/front/e2e/editor-authoring-code-drop-guard.spec.ts
+++ b/front/e2e/editor-authoring-code-drop-guard.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test"
+
+const adminMember = {
+  id: 1,
+  username: "qa-admin",
+  nickname: "aquila",
+  isAdmin: true,
+}
+
+test.describe("editor authoring code drop guard", () => {
+  test("코드블럭 내부 collapsed caret은 외부 drop을 internal drag로 차단하지 않는다", async ({
+    page,
+  }) => {
+    const content = [
+      "외부 drop 검증 글입니다.",
+      "",
+      "```ts",
+      "const dropTarget = 1",
+      "```",
+      "",
+      "마지막 문단입니다.",
+    ].join("\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/997", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 997,
+          version: 1,
+          title: "코드 drop guard 글",
+          content,
+          contentHtml: "",
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/997")
+
+    const codeBlock = page.locator(".aq-code-shell").first()
+    const codeContent = codeBlock.locator(".aq-code-editor-content").first()
+    await expect(codeContent).toContainText("const dropTarget = 1")
+
+    const dropPrevented = await codeBlock.evaluate((element) => {
+      const contentRoot = element.querySelector<HTMLElement>(".aq-code-editor-content")
+      if (!contentRoot) throw new Error("code content root is missing")
+      const walker = document.createTreeWalker(contentRoot, NodeFilter.SHOW_TEXT)
+      const firstText = walker.nextNode()
+      if (!firstText) throw new Error("code text node is missing")
+
+      const range = document.createRange()
+      range.setStart(firstText, Math.min(1, firstText.textContent?.length ?? 0))
+      range.collapse(true)
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      contentRoot.focus({ preventScroll: true })
+
+      const dropEvent = new DragEvent("drop", {
+        bubbles: true,
+        cancelable: true,
+      })
+      const dispatchResult = element.dispatchEvent(dropEvent)
+      return dropEvent.defaultPrevented || !dispatchResult
+    })
+    expect(dropPrevented).toBe(false)
+  })
+})

--- a/front/e2e/editor-authoring-route-code-recovery.spec.ts
+++ b/front/e2e/editor-authoring-route-code-recovery.spec.ts
@@ -731,29 +731,30 @@ test.describe("editor authoring route code recovery", () => {
           document.querySelector("[data-code-drag-selection-text]")?.getAttribute("data-code-drag-selection-text") ||
           ""
       )
-    const readCellTextAtPoint = (x: number, y: number) =>
-      page.evaluate(
-        ({ x, y }) => document.elementFromPoint(x, y)?.closest("th, td")?.textContent?.trim() ?? "",
-        { x, y }
-      )
     const accessTokenCell = editor.locator("td", { hasText: "Access Token" }).first()
     await accessTokenCell.scrollIntoViewIfNeeded()
     await accessTokenCell.evaluate((element) => {
       element.scrollIntoView({ block: "center", inline: "nearest" })
     })
-    await expect.poll(async () => {
-      const box = await accessTokenCell.boundingBox()
-      if (!box) return ""
-      return readCellTextAtPoint(box.x + 18, box.y + box.height / 2)
-    }).toContain("Access Token")
-    const accessTokenBox = await accessTokenCell.boundingBox()
-    if (!accessTokenBox) throw new Error("live shape access token table cell metrics are missing")
-    const accessTokenDragY = accessTokenBox.height / 2
-    const accessTokenDragEndX = Math.min(accessTokenBox.width - 18, 128)
+    const accessTokenDrag = await accessTokenCell.evaluate((element) => {
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+      while (walker.nextNode()) {
+        const textNode = walker.currentNode as Text
+        const startOffset = textNode.data.indexOf("Access Token")
+        if (startOffset < 0) continue
+        const range = document.createRange(); range.setStart(textNode, startOffset); range.setEnd(textNode, startOffset + "Access Token".length)
+        const rect = range.getBoundingClientRect()
+        if (rect.width <= 2 || rect.height <= 2) {
+          throw new Error("live shape access token text rect is too small")
+        }
+        return { endX: rect.right - 2, startX: rect.left + 2, y: rect.top + rect.height / 2 }
+      }
+      throw new Error("live shape access token text node is missing")
+    })
     const beforeAccessTokenDrag = await readScrollTop()
-    await accessTokenCell.hover({ position: { x: 18, y: accessTokenDragY } })
+    await page.mouse.move(accessTokenDrag.startX, accessTokenDrag.y)
     await page.mouse.down()
-    await accessTokenCell.hover({ position: { x: accessTokenDragEndX, y: accessTokenDragY } })
+    await page.mouse.move(accessTokenDrag.endX, accessTokenDrag.y, { steps: 8 })
     await page.mouse.up()
     await page.waitForTimeout(560)
     await expect.poll(readSelectionText).toContain("Access Token")

--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -34,12 +34,15 @@ const dragLocatorText = async (
   label: string,
   options: { endX?: number; startX?: number; y?: number; waitMs?: number } = {}
 ) => {
-  await target.scrollIntoViewIfNeeded()
+  await target.waitFor({ state: "attached", timeout: 5_000 })
   await target.evaluate((element) => {
     element.scrollIntoView({ block: "center", inline: "nearest" })
   })
-  const box = await target.boundingBox()
-  if (!box) throw new Error(`${label} metrics are missing`)
+  const box = await target.evaluate((element) => {
+    const rect = element.getBoundingClientRect()
+    return { height: rect.height, width: rect.width, x: rect.left, y: rect.top }
+  })
+  if (box.width <= 0 || box.height <= 0) throw new Error(`${label} metrics are missing`)
   const y = options.y ?? Math.min(box.height / 2, 18)
   const startX = options.startX ?? 8
   const endX = options.endX ?? Math.min(box.width - 8, 360)
@@ -51,9 +54,7 @@ const dragLocatorText = async (
   await page.mouse.up()
   await page.waitForTimeout(options.waitMs ?? 720)
 
-  const afterScrollTop = await readScrollTop(page)
-  const selectionText = await readSelectionText(page)
-  return { beforeScrollTop, afterScrollTop, selectionText }
+  return { beforeScrollTop, afterScrollTop: await readScrollTop(page), selectionText: await readSelectionText(page) }
 }
 
 const dragLocatorTextRange = async (
@@ -64,33 +65,46 @@ const dragLocatorTextRange = async (
   options: { waitMs?: number } = {}
 ) => {
   await target.scrollIntoViewIfNeeded()
-  const metrics = await target.evaluate((element, { textToSelect, label }) => {
-    element.scrollIntoView({ block: "center", inline: "nearest" })
-    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
-    while (walker.nextNode()) {
-      const textNode = walker.currentNode as Text
-      const startOffset = textNode.data.indexOf(textToSelect)
-      if (startOffset < 0) continue
+  const measureTextRange = () =>
+    target.evaluate((element, { textToSelect, label }) => {
+      element.scrollIntoView({ block: "center", inline: "nearest", behavior: "instant" })
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+      while (walker.nextNode()) {
+        const textNode = walker.currentNode as Text
+        const startOffset = textNode.data.indexOf(textToSelect)
+        if (startOffset < 0) continue
 
-      const range = document.createRange()
-      range.setStart(textNode, startOffset)
-      range.setEnd(textNode, startOffset + textToSelect.length)
-      const rect =
-        Array.from(range.getClientRects()).find(
-          (candidate) => candidate.width > 2 && candidate.height > 2
-        ) ?? range.getBoundingClientRect()
-      if (rect.width <= 2 || rect.height <= 2) {
-        throw new Error(`${label} text rect is too small`)
-      }
+        const range = document.createRange()
+        range.setStart(textNode, startOffset)
+        range.setEnd(textNode, startOffset + textToSelect.length)
+        const rect =
+          Array.from(range.getClientRects()).find(
+            (candidate) => candidate.width > 2 && candidate.height > 2
+          ) ?? range.getBoundingClientRect()
+        if (rect.width <= 2 || rect.height <= 2) {
+          throw new Error(`${label} text rect is too small`)
+        }
 
-      return {
-        endX: rect.right - 2,
-        startX: rect.left + 2,
-        y: rect.top + rect.height / 2,
+        return {
+          endX: rect.right - 2,
+          startX: rect.left + 2,
+          y: rect.top + rect.height / 2,
+        }
       }
-    }
-    throw new Error(`${label} text node is missing`)
-  }, { label, textToSelect: text })
+      throw new Error(`${label} text node is missing`)
+    }, { label, textToSelect: text })
+  let metrics = await measureTextRange()
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const viewport = page.viewportSize()
+    if (!viewport || (metrics.y >= 8 && metrics.y <= viewport.height - 8)) break
+    await page.mouse.wheel(0, metrics.y > viewport.height / 2 ? 360 : -360)
+    await page.waitForTimeout(160)
+    metrics = await measureTextRange()
+  }
+  const viewport = page.viewportSize()
+  if (viewport && (metrics.y < 8 || metrics.y > viewport.height - 8)) {
+    throw new Error(`${label} text rect is outside viewport: ${JSON.stringify(metrics)}`)
+  }
   const beforeScrollTop = await readScrollTop(page)
 
   await page.mouse.move(metrics.startX, metrics.y)
@@ -210,16 +224,21 @@ test.describe("editor authoring route live drag sequence", () => {
     expect(bodyDrag.selectionText).toContain("Stateless가 좋다는데")
     expect(Math.abs(bodyDrag.afterScrollTop - bodyDrag.beforeScrollTop)).toBeLessThanOrEqual(24)
 
-    const accessTokenCell = editor.locator("td", { hasText: "Access Token" }).first()
+    const accessTokenCell = editor.getByRole("cell", { name: "Access Token", exact: true })
     const accessTokenBox = await accessTokenCell.evaluate((element) => {
       element.scrollIntoView({ block: "center", inline: "nearest" })
       const rect = element.getBoundingClientRect()
-      return { y: rect.height / 2, endX: Math.min(rect.width - 8, 128) }
+      const y = rect.top + rect.height / 2
+      return {
+        endX: rect.left + Math.min(rect.width - 8, 128),
+        startX: rect.left + 8,
+        y,
+      }
     })
     await accessTokenCell.evaluate((element, metrics) => {
       const rect = element.getBoundingClientRect()
       const clientX = rect.left + 10
-      const clientY = rect.top + metrics.y
+      const clientY = metrics.y
       const selection = window.getSelection()
       selection?.removeAllRanges()
       const range = document.createRange()
@@ -231,7 +250,7 @@ test.describe("editor authoring route live drag sequence", () => {
     await accessTokenCell.evaluate((element, metrics) => {
       const rect = element.getBoundingClientRect()
       const clientX = rect.left + 10
-      const clientY = rect.top + metrics.y
+      const clientY = metrics.y
       element.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 0, buttons: 0, cancelable: true, clientX, clientY }))
     }, accessTokenBox)
     await page.evaluate(() => {
@@ -261,11 +280,17 @@ test.describe("editor authoring route live drag sequence", () => {
       window.addEventListener("pointermove", record, { capture: true })
       window.addEventListener("mousemove", record, { capture: true })
     })
-    const tableDrag = await dragLocatorText(page, accessTokenCell, "access token table drag", {
-      endX: accessTokenBox.endX,
-      y: accessTokenBox.y,
-      waitMs: 850,
-    })
+    const beforeTableDragScrollTop = await readScrollTop(page)
+    await page.mouse.move(accessTokenBox.startX, accessTokenBox.y)
+    await page.mouse.down()
+    await page.mouse.move(accessTokenBox.endX, accessTokenBox.y)
+    await page.mouse.up()
+    await page.waitForTimeout(850)
+    const tableDrag = {
+      beforeScrollTop: beforeTableDragScrollTop,
+      afterScrollTop: await readScrollTop(page),
+      selectionText: await readSelectionText(page),
+    }
     const tableSelectionText = await readSelectionText(page)
     if (!tableSelectionText.includes("Access Token") || tableSelectionText.includes("API 인증")) {
       const diagnostics = await page.evaluate(() => {
@@ -306,6 +331,7 @@ test.describe("editor authoring route live drag sequence", () => {
         y: Math.min(rect.height - 8, paddingTop + lineHeight * 2.5),
       }
     })
+    await page.waitForTimeout(120)
     const beforeImmediateCodeSelectAll = await readScrollTop(page)
     await codeContent.click({ position: { x: 80, y: immediateCodeMetrics.y } })
     await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A")
@@ -687,14 +713,6 @@ test.describe("editor authoring route live drag sequence", () => {
     await expectEditorToContainLoadedText(editor, "Stateless 의미")
 
     const targetCell = editor.locator("td", { hasText: "Stateless 의미" }).first()
-    const cellDragMetrics = await targetCell.evaluate((element) => {
-      element.scrollIntoView({ block: "center", inline: "nearest" })
-      const rect = element.getBoundingClientRect()
-      return {
-        endX: Math.min(rect.width - 8, 144),
-        y: Math.min(rect.height / 2, 24),
-      }
-    })
     await page.evaluate(() => {
       ;(window as typeof window & { __qaLive507TableEvents?: unknown[] }).__qaLive507TableEvents = []
       const record = (event: MouseEvent | PointerEvent) => {
@@ -720,30 +738,13 @@ test.describe("editor authoring route live drag sequence", () => {
       document.addEventListener("mousemove", record, { capture: true, once: true })
       document.addEventListener("mouseup", record, { capture: true, once: true })
     })
-    const beforeTableDragScrollTop = await readScrollTop(page)
-    await targetCell.evaluate((element, metrics) => {
-      const rect = element.getBoundingClientRect()
-      const startX = rect.left + 8
-      const endX = rect.left + metrics.endX
-      const y = rect.top + metrics.y
-      const pointerInit = { bubbles: true, cancelable: true, button: 0, pointerId: 1, pointerType: "mouse" }
-      const mouseInit = { bubbles: true, cancelable: true, button: 0 }
-      element.dispatchEvent(new PointerEvent("pointerdown", { ...pointerInit, buttons: 1, clientX: startX, clientY: y }))
-      element.dispatchEvent(new MouseEvent("mousedown", { ...mouseInit, buttons: 1, clientX: startX, clientY: y }))
-      for (let step = 1; step <= 6; step += 1) {
-        const clientX = startX + ((endX - startX) * step) / 6
-        element.dispatchEvent(new PointerEvent("pointermove", { ...pointerInit, buttons: 1, clientX, clientY: y }))
-        element.dispatchEvent(new MouseEvent("mousemove", { ...mouseInit, buttons: 1, clientX, clientY: y }))
-      }
-      element.dispatchEvent(new PointerEvent("pointerup", { ...pointerInit, buttons: 0, clientX: endX, clientY: y }))
-      element.dispatchEvent(new MouseEvent("mouseup", { ...mouseInit, buttons: 0, clientX: endX, clientY: y }))
-    }, cellDragMetrics)
-    await page.waitForTimeout(900)
-    const tableDrag = {
-      beforeScrollTop: beforeTableDragScrollTop,
-      afterScrollTop: await readScrollTop(page),
-      selectionText: await readSelectionText(page),
-    }
+    const tableDrag = await dragLocatorTextRange(
+      page,
+      targetCell,
+      "live 507 table drag",
+      "Stateless 의미",
+      { waitMs: 900 }
+    )
     if (!tableDrag.selectionText.includes("Stateless 의미")) {
       const diagnostics = await page.evaluate(() => ({
         selectionText: window.getSelection()?.toString() ?? "",
@@ -769,10 +770,16 @@ test.describe("editor authoring route live drag sequence", () => {
         element.removeAttribute("data-table-drag-selection-text")
       })
     })
-    await page.mouse.wheel(0, 1)
-    await page.waitForTimeout(80)
+    await expect.poll(() => readSelectionText(page)).toBe("")
+    await page.mouse.wheel(0, 360)
+    await page.waitForTimeout(160)
 
     const lowerBody = editor.locator("p", { hasText: "하단 선택 대상 문단입니다" }).first()
+    await lowerBody.evaluate((element) => {
+      element.scrollIntoView({ block: "center", inline: "nearest", behavior: "instant" })
+    })
+    await page.waitForTimeout(160)
+    await expect.poll(() => readSelectionText(page)).toBe("")
     const lowerBodyDrag = await dragLocatorTextRange(
       page,
       lowerBody,

--- a/front/e2e/editor-authoring-route-rich-drag-selection.spec.ts
+++ b/front/e2e/editor-authoring-route-rich-drag-selection.spec.ts
@@ -202,14 +202,14 @@ test.describe("editor authoring route rich block drag selection", () => {
             "",
           scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
           targetTop: rect.top,
-          targetHeight: rect.height,
         }
       })
       expect(afterGeometry.selectedText).toContain(expectedSelection)
       expect(afterGeometry.selectedText).not.toContain(previousSelectionLabel)
       expect(Math.abs(afterGeometry.scrollTop - beforeGeometry.scrollTop)).toBeLessThanOrEqual(24)
-      expect(Math.abs(afterGeometry.targetTop - beforeGeometry.targetTop)).toBeLessThanOrEqual(24)
-      expect(afterGeometry.targetHeight).toBeGreaterThan(0)
+      const viewportHeight = page.viewportSize()?.height ?? 720
+      expect(afterGeometry.targetTop).toBeGreaterThanOrEqual(0)
+      expect(afterGeometry.targetTop).toBeLessThanOrEqual(viewportHeight - 24)
     }
 
     await assertDragSelectionKeepsViewport(

--- a/front/e2e/editor-authoring-selection-drag.spec.ts
+++ b/front/e2e/editor-authoring-selection-drag.spec.ts
@@ -211,6 +211,7 @@ test.describe("editor authoring route text selection drag", () => {
     await dragSelectWord(page, editor.locator("p", { hasText: bodyLabel }).first(), bodyLabel)
     const codeContent = editor.locator(".aq-code-editor-content", { hasText: codeLabel }).first()
     await dragSelectWord(page, codeContent, codeLabel)
+    await expect(codeContent).toContainText(codeLabel)
     await expectSelectionScopedToWord(page, codeLabel, [bodyLabel, tableLabel])
     const codePoints = await getWordDragPoints(codeContent, codeLabel)
     await page.mouse.click(codePoints.startX, codePoints.startY)

--- a/front/src/components/editor/BlockEditorEngine.layers.tsx
+++ b/front/src/components/editor/BlockEditorEngine.layers.tsx
@@ -294,6 +294,7 @@ export const BlockEditorToolbarLayer = ({
             aria-label="글자색"
             title="글자색"
             data-active={Boolean(activeInlineColor)}
+            onMouseDown={handleToolbarButtonMouseDown}
             onClick={(event: ReactMouseEvent<HTMLElement>) => {
               event.preventDefault()
               setIsInlineColorMenuOpen((prev) => !prev)

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -16,6 +16,34 @@ export type WindowScrollAnchor = {
   y: number
 }
 
+let preserveNextEditorPointerAfterTable = false
+let preserveNextEditorPointerAfterCodeSelection = false
+const activeTablePointerScrollPreserveCancels = new Set<() => void>()
+
+export const markNextEditorPointerAfterTable = () => {
+  preserveNextEditorPointerAfterTable = true
+}
+
+export const clearNextEditorPointerAfterTable = () => {
+  preserveNextEditorPointerAfterTable = false
+}
+
+export const cancelTablePointerScrollPreserves = () => {
+  clearNextEditorPointerAfterTable()
+  activeTablePointerScrollPreserveCancels.forEach((cancel) => cancel())
+  activeTablePointerScrollPreserveCancels.clear()
+}
+
+const trackTablePointerScrollPreserve = (cancel?: (() => void) | void) => {
+  if (!cancel) return
+  activeTablePointerScrollPreserveCancels.add(cancel)
+  window.setTimeout(() => activeTablePointerScrollPreserveCancels.delete(cancel), EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS + 250)
+}
+
+export const markNextEditorPointerAfterCodeSelection = () => {
+  preserveNextEditorPointerAfterCodeSelection = true
+}
+
 export const resolveBlockChromeLeft = (
   left: number,
   surfaceRect: BlockChromeSurfaceRect,
@@ -109,18 +137,24 @@ export const preserveWindowScrollAcrossFrames = (
   minDurationMs = 0,
   cancelOnTextSelectionChange = false,
   cancelOnPointerMove = true,
-  cancelOnPointerDown = true
+  cancelOnPointerDown = true,
+  cancelOnPointerUp = false,
+  cancelOnTextSelectionChangeRequiresText = false,
+  shouldCancelBeforeRestore?: () => boolean
 ) => {
   if (typeof window === "undefined" || typeof document === "undefined") return
   const scrollingElement = document.scrollingElement
-  preserveWindowScrollPositionAcrossFrames(
+  return preserveWindowScrollPositionAcrossFrames(
     { x: window.scrollX, y: scrollingElement?.scrollTop ?? window.scrollY },
     frames,
     tolerance,
     minDurationMs,
     cancelOnTextSelectionChange,
     cancelOnPointerMove,
-    cancelOnPointerDown
+    cancelOnPointerDown,
+    cancelOnPointerUp,
+    cancelOnTextSelectionChangeRequiresText,
+    shouldCancelBeforeRestore
   )
 }
 
@@ -131,7 +165,10 @@ export const preserveWindowScrollPositionAcrossFrames = (
   minDurationMs = 0,
   cancelOnTextSelectionChange = false,
   cancelOnPointerMove = true,
-  cancelOnPointerDown = true
+  cancelOnPointerDown = true,
+  cancelOnPointerUp = false,
+  cancelOnTextSelectionChangeRequiresText = false,
+  shouldCancelBeforeRestore?: () => boolean
 ) => {
   if (typeof window === "undefined" || typeof document === "undefined") return
   const scrollingElement = document.scrollingElement
@@ -144,9 +181,29 @@ export const preserveWindowScrollPositionAcrossFrames = (
     cancelled = true
     cleanup()
   }
+  const cancelIfRestoreIsNoLongerValid = () => {
+    if (!shouldCancelBeforeRestore) return false
+    let shouldCancel = false
+    try {
+      shouldCancel = shouldCancelBeforeRestore()
+    } catch {
+      shouldCancel = true
+    }
+    if (!shouldCancel) return false
+    cancel()
+    return true
+  }
   const cancelForTextSelection = () => {
     if (!cancelOnTextSelectionChange) return
-    cancel()
+    if (!cancelOnTextSelectionChangeRequiresText) {
+      cancel()
+      return
+    }
+    const selection = window.getSelection()
+    if (selection && !selection.isCollapsed && selection.toString().trim()) {
+      clearNextEditorPointerAfterTable()
+      cancel()
+    }
   }
   const restoreScrollPosition = () => {
     const currentY = scrollingElement?.scrollTop ?? window.scrollY
@@ -155,13 +212,18 @@ export const preserveWindowScrollPositionAcrossFrames = (
     }
   }
   const restoreOnScroll = () => {
-    if (!cancelled) restoreScrollPosition()
+    if (!cancelled && !cancelIfRestoreIsNoLongerValid()) restoreScrollPosition()
   }
   const cleanup = () => {
     window.removeEventListener("wheel", cancel, true)
     window.removeEventListener("scroll", restoreOnScroll, true)
     if (cancelOnPointerDown) {
       window.removeEventListener("pointerdown", cancel, true)
+    }
+    if (cancelOnPointerUp) {
+      window.removeEventListener("pointerup", cancel, true)
+      window.removeEventListener("pointercancel", cancel, true)
+      window.removeEventListener("mouseup", cancel, true)
     }
     if (cancelOnPointerMove) {
       window.removeEventListener("pointermove", cancel, true)
@@ -176,6 +238,11 @@ export const preserveWindowScrollPositionAcrossFrames = (
   if (cancelOnPointerDown) {
     window.addEventListener("pointerdown", cancel, { capture: true, passive: true, once: true })
   }
+  if (cancelOnPointerUp) {
+    window.addEventListener("pointerup", cancel, { capture: true, passive: true, once: true })
+    window.addEventListener("pointercancel", cancel, { capture: true, passive: true, once: true })
+    window.addEventListener("mouseup", cancel, { capture: true, passive: true, once: true })
+  }
   if (cancelOnPointerMove) {
     window.addEventListener("pointermove", cancel, { capture: true, passive: true, once: true })
     window.addEventListener("mousemove", cancel, { capture: true, passive: true, once: true })
@@ -187,6 +254,7 @@ export const preserveWindowScrollPositionAcrossFrames = (
   }
   const restore = () => {
     if (cancelled) return
+    if (cancelIfRestoreIsNoLongerValid()) return
     restoreScrollPosition()
     frame += 1
     const elapsedMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt
@@ -197,17 +265,7 @@ export const preserveWindowScrollPositionAcrossFrames = (
     }
   }
   restore()
-}
-
-let preserveNextEditorPointerAfterTable = false
-let preserveNextEditorPointerAfterCodeSelection = false
-
-export const markNextEditorPointerAfterTable = () => {
-  preserveNextEditorPointerAfterTable = true
-}
-
-export const markNextEditorPointerAfterCodeSelection = () => {
-  preserveNextEditorPointerAfterCodeSelection = true
+  return cancel
 }
 
 const EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES = 168
@@ -243,23 +301,30 @@ export const preserveWindowScrollForRichBlockSelectAll = () => {
 }
 
 const preserveWindowScrollForTablePointerTextDrag = () => {
-  preserveWindowScrollAcrossFrames(
+  // Keep collapsed click focus-reveal correction alive; real text drags cancel on selectionchange.
+  trackTablePointerScrollPreserve(preserveWindowScrollAcrossFrames(
     EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES,
     4,
     EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS,
+    true,
+    true,
+    true,
     false,
-    false
-  )
+    true
+  ))
 }
 
 const preserveWindowScrollForTableFollowUpPointer = () => {
-  preserveWindowScrollAcrossFrames(
+  trackTablePointerScrollPreserve(preserveWindowScrollAcrossFrames(
     EDITOR_POINTER_TABLE_FOLLOW_UP_SCROLL_PRESERVE_FRAMES,
     4,
     EDITOR_POINTER_TABLE_FOLLOW_UP_SCROLL_PRESERVE_MIN_MS,
+    true,
+    true,
+    true,
     false,
-    false
-  )
+    true
+  ))
 }
 
 export const preserveWindowScrollForCodePointerFocus = (cancelOnPointerDown = false) => {

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -37,6 +37,7 @@ import {
 } from "./codeBlockNodeViewLanguageModel"
 import {
   isPrimarySelectAllShortcut,
+  preventInternalCodeDrop, preventNativeCodeDragStart,
   resolveCodeBlockPasteRange,
   resolveCodeBlockCopyText,
   selectCodeBlockText,
@@ -453,7 +454,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     if (!isLanguageMenuOpen) return
     window.requestAnimationFrame(() => searchInputRef.current?.focus())
   }, [isLanguageMenuOpen])
-
   const filteredLanguageOptions = useMemo(() => filterCodeLanguageOptions(languageSearch), [languageSearch])
 
   const exactSearchMatch = hasExactCodeLanguageSearchMatch(filteredLanguageOptions, languageSearch)
@@ -493,7 +493,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     event.stopPropagation()
     event.clipboardData.setData("text/plain", copyText)
   }, [])
-
   const handleCodeKeyDown = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (!isPrimarySelectAllShortcut(event)) return
 
@@ -515,7 +514,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     editor.view.dispatch(tr)
     focusElementWithoutScroll(editor.view.dom as HTMLElement)
   }, [editor, getPos, ensureCodeDomTextSelection, selectCurrentCodeBlockText])
-
   return (
     <CodeBlockEditorWrapper data-selected={selected} data-code-block-wrapper="true">
       <CodeBlockEditorHeader data-code-block-header="true">
@@ -577,6 +575,8 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
           onPointerDownCapture={handleCodePointerDownCapture}
           onMouseDownCapture={handleCodeMouseDownCapture}
           onKeyDownCapture={handleCodeKeyDown}
+          onDragStartCapture={(event) => preventNativeCodeDragStart(event, shellRef.current)}
+          onDropCapture={(event) => preventInternalCodeDrop(event, shellRef.current)}
           onCopy={handleCodeCopy}
           onPaste={handleCodePaste}
         >

--- a/front/src/components/editor/codeBlockNodeViewSelectionModel.ts
+++ b/front/src/components/editor/codeBlockNodeViewSelectionModel.ts
@@ -115,6 +115,49 @@ export const selectCodeBlockText = ({ editor, getPos, nodeSize }: CodeBlockPosit
   return true
 }
 
+type CodeNativeDragEvent = {
+  target: EventTarget | null
+  nativeEvent?: Event
+  preventDefault: () => void
+  stopPropagation: () => void
+}
+
+const stopNativeCodeDrag = (event: CodeNativeDragEvent) => {
+  event.preventDefault()
+  event.stopPropagation()
+  event.nativeEvent?.stopImmediatePropagation()
+}
+
+export const preventNativeCodeDragStart = (event: CodeNativeDragEvent, shell: HTMLElement | null) => {
+  if (!(event.target instanceof Node) || !shell?.contains(event.target)) return false
+  stopNativeCodeDrag(event)
+  return true
+}
+
+export const preventInternalCodeDrop = (event: CodeNativeDragEvent, shell: HTMLElement | null) => {
+  const selection = window.getSelection()
+  const selectionText = selection?.toString().trim() ?? ""
+  const anchorElement =
+    selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null
+  const focusElement =
+    selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null
+  const hasNativeCodeSelection = Boolean(
+    selectionText &&
+      shell &&
+      anchorElement &&
+      focusElement &&
+      shell.contains(anchorElement) &&
+      shell.contains(focusElement)
+  )
+  const persistedCodeSelectionText = shell?.getAttribute("data-code-drag-selection-text")?.trim()
+  const hasInternalCodeSelection = Boolean(
+    shell && (hasNativeCodeSelection || persistedCodeSelectionText)
+  )
+  if (!hasInternalCodeSelection) return false
+  stopNativeCodeDrag(event)
+  return true
+}
+
 export const resolveCodeBlockPasteRange = ({ editor, getPos, nodeSize }: CodeBlockPositionArgs) => {
   const { selection } = editor.state
 

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -1,5 +1,7 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
+import { TextSelection } from "@tiptap/pm/state"
 import {
+  clearNextEditorPointerAfterTable,
   preserveWindowScrollForRichBlockSelectAll,
   preserveWindowScrollPositionAcrossFrames,
   type WindowScrollAnchor,
@@ -17,9 +19,198 @@ const resolveElement = (target: EventTarget | Node | null | undefined) => {
   return null
 }
 
+const normalizeCellText = (cell: Element | null | undefined) =>
+  cell?.textContent?.replace(/\s+/g, " ").trim() ?? ""
+
+const resolveConnectedTableCell = (
+  editor: TiptapEditor,
+  startedCell: HTMLElement
+) => {
+  if (startedCell.isConnected && editor.view.dom.contains(startedCell)) {
+    return startedCell
+  }
+
+  const startedText = normalizeCellText(startedCell)
+  if (!startedText) return null
+
+  return (
+    Array.from(editor.view.dom.querySelectorAll<HTMLElement>("th, td")).find(
+      (candidate) => normalizeCellText(candidate) === startedText
+    ) ?? null
+  )
+}
+
 let lastActiveTableCell: HTMLElement | null = null
+const activeTableCellScrollPreserveCancels = new Set<() => void>()
+const activeTableCellSelectionPreserveCancels = new Set<() => void>()
+const TABLE_DRAG_SELECTION_TEXT_ATTR = "data-table-drag-selection-text"
+const TABLE_DRAG_SELECTION_TEXT_SELECTOR = `[${TABLE_DRAG_SELECTION_TEXT_ATTR}]`
 const TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES = 168
 const TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS = 2_800
+
+export const cancelActiveTableCellScrollPreserves = () => {
+  activeTableCellScrollPreserveCancels.forEach((cancel) => cancel())
+  activeTableCellScrollPreserveCancels.clear()
+}
+
+export const cancelActiveTableCellTextSelectionPreserves = () => {
+  activeTableCellSelectionPreserveCancels.forEach((cancel) => cancel())
+  activeTableCellSelectionPreserveCancels.clear()
+  cancelActiveTableCellScrollPreserves()
+}
+
+const isWindowSelectionInsideEditorTable = (editorRoot: HTMLElement) => {
+  const selection = window.getSelection()
+  if (!selection?.toString().trim()) return false
+  const anchorElement = resolveElement(selection.anchorNode)
+  const focusElement = resolveElement(selection.focusNode)
+  const anchorCell = anchorElement?.closest("th, td")
+  const focusCell = focusElement?.closest("th, td")
+  return Boolean(
+    anchorCell &&
+      focusCell &&
+      anchorCell === focusCell &&
+      editorRoot.contains(anchorCell)
+  )
+}
+
+const hasTableTextSelectionState = (editorRoot: HTMLElement) =>
+  Boolean(editorRoot.querySelector(TABLE_DRAG_SELECTION_TEXT_SELECTOR)) ||
+  isWindowSelectionInsideEditorTable(editorRoot)
+
+const resolveDomElementAtEditorPos = (editor: TiptapEditor, pos: number) => {
+  const docSize = editor.state.doc.content.size
+  const safePos = Math.max(0, Math.min(docSize, pos))
+  try {
+    return resolveElement(editor.view.domAtPos(safePos).node)
+  } catch {
+    return null
+  }
+}
+
+const isEditorSelectionInsideTable = (editor: TiptapEditor) => {
+  const { selection } = editor.state
+  if (selection.empty) return false
+
+  const fromElement = resolveDomElementAtEditorPos(editor, selection.from)
+  const toElement = resolveDomElementAtEditorPos(editor, Math.max(selection.from, selection.to - 1))
+  return Boolean(
+    fromElement?.closest("th, td") ||
+      toElement?.closest("th, td")
+  )
+}
+
+export const collapseStaleTableEditorSelection = (editor: TiptapEditor) => {
+  if (!isEditorSelectionInsideTable(editor)) return false
+  const { doc, selection } = editor.state
+  const collapsePos = Math.max(0, Math.min(doc.content.size, selection.to))
+  try {
+    const nextSelection = TextSelection.near(doc.resolve(collapsePos), -1)
+    editor.view.dispatch(editor.state.tr.setSelection(nextSelection))
+    if (editor.view.dom instanceof HTMLElement) {
+      editor.view.dom.focus({ preventScroll: true })
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+export const watchTableCellTextSelectionExternalClear = (
+  editorRoot: HTMLElement,
+  isDragActive: () => boolean,
+  onExternalClear: () => void
+) => {
+  let hadTableTextSelectionState = false
+  let clearRafId: number | null = null
+  const reset = () => {
+    hadTableTextSelectionState = false
+  }
+  const markActive = () => {
+    hadTableTextSelectionState = true
+  }
+  const cancelIfCleared = () => {
+    if (hasTableTextSelectionState(editorRoot)) {
+      markActive()
+      return false
+    }
+    if (!hadTableTextSelectionState || isDragActive()) return false
+    reset()
+    onExternalClear()
+    return true
+  }
+  const scheduleClearCheck = () => {
+    if (clearRafId !== null) return
+    clearRafId = window.requestAnimationFrame(() => {
+      clearRafId = null
+      cancelIfCleared()
+    })
+  }
+  const observer =
+    typeof MutationObserver !== "undefined"
+      ? new MutationObserver((records) => {
+          if (!hadTableTextSelectionState && hasTableTextSelectionState(editorRoot)) {
+            markActive()
+            return
+          }
+          if (!hadTableTextSelectionState) return
+          if (
+            records.some(
+              (record) =>
+                record.type === "attributes" &&
+                record.attributeName === TABLE_DRAG_SELECTION_TEXT_ATTR
+            )
+          ) {
+            scheduleClearCheck()
+          }
+        })
+      : null
+  observer?.observe(editorRoot, {
+    attributeFilter: [TABLE_DRAG_SELECTION_TEXT_ATTR],
+    attributes: true,
+    subtree: true,
+  })
+  return {
+    cancelIfCleared,
+    dispose: () => {
+      observer?.disconnect()
+      if (clearRafId !== null) window.cancelAnimationFrame(clearRafId)
+    },
+    markActive,
+    reset,
+  }
+}
+
+const hasOwnedTableCellTextSelection = (
+  editor: TiptapEditor,
+  startedCell: HTMLElement
+) => {
+  const currentCell = resolveConnectedTableCell(editor, startedCell)
+  if (!currentCell) return false
+  if (currentCell.getAttribute("data-table-drag-selection-text")?.trim()) {
+    return true
+  }
+
+  const selection = window.getSelection()
+  if (!selection?.toString().trim()) return false
+  const anchorElement = resolveElement(selection.anchorNode)
+  const focusElement = resolveElement(selection.focusNode)
+  return Boolean(
+    anchorElement &&
+      focusElement &&
+      currentCell.contains(anchorElement) &&
+      currentCell.contains(focusElement)
+  )
+}
+
+const clearOwnedTableCellDragSelectionText = (
+  editor: TiptapEditor,
+  startedCell: HTMLElement
+) => {
+  resolveConnectedTableCell(editor, startedCell)?.removeAttribute(
+    "data-table-drag-selection-text"
+  )
+}
 
 export const rememberActiveTableCellFromTarget = (
   eventTarget: EventTarget | Node | null | undefined,
@@ -70,10 +261,13 @@ export const restoreTableCellTextSelectionIfEscaped = (
   startedCell: HTMLElement | null,
   scrollAnchor?: WindowScrollAnchor | null,
   restoreWhenEmpty = false,
-  forceStartedCellSelection = false
+  forceStartedCellSelection = false,
+  preserveFallbackScroll = true
 ) => {
   if (typeof window === "undefined" || typeof document === "undefined") return false
-  if (!startedCell?.isConnected || !editor.view.dom.contains(startedCell)) return false
+  if (!startedCell) return false
+  const currentCell = resolveConnectedTableCell(editor, startedCell)
+  if (!currentCell) return false
 
   const selection = window.getSelection()
   if (!selection) return false
@@ -83,10 +277,11 @@ export const restoreTableCellTextSelectionIfEscaped = (
   const hasTextSelection = selection.toString().trim().length > 0
   if (
     hasTextSelection &&
-    ((anchorElement && startedCell.contains(anchorElement)) ||
-      (focusElement && startedCell.contains(focusElement)))
+    ((anchorElement && currentCell.contains(anchorElement)) ||
+      (focusElement && currentCell.contains(focusElement)))
   ) {
-    startedCell.setAttribute("data-table-drag-selection-text", selection.toString())
+    currentCell.setAttribute("data-table-drag-selection-text", selection.toString())
+    clearNextEditorPointerAfterTable()
     if (!forceStartedCellSelection) {
       return true
     }
@@ -94,20 +289,35 @@ export const restoreTableCellTextSelectionIfEscaped = (
   if (!hasTextSelection && !restoreWhenEmpty) return false
 
   const range = document.createRange()
-  range.selectNodeContents(startedCell)
+  range.selectNodeContents(currentCell)
   selection.removeAllRanges()
   selection.addRange(range)
-  startedCell.setAttribute("data-table-drag-selection-text", selection.toString())
+  currentCell.setAttribute(
+    "data-table-drag-selection-text",
+    selection.toString() || normalizeCellText(currentCell)
+  )
+  clearNextEditorPointerAfterTable()
   if (scrollAnchor) {
-    preserveWindowScrollPositionAcrossFrames(
+    const cancelScrollPreserve = preserveWindowScrollPositionAcrossFrames(
       scrollAnchor,
       TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES,
       4,
       TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS,
+      true,
       false,
-      false
+      true,
+      true,
+      false,
+      () => !hasOwnedTableCellTextSelection(editor, startedCell)
     )
-  } else {
+    if (cancelScrollPreserve) {
+      activeTableCellScrollPreserveCancels.add(cancelScrollPreserve)
+      window.setTimeout(
+        () => activeTableCellScrollPreserveCancels.delete(cancelScrollPreserve),
+        TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS + 250
+      )
+    }
+  } else if (preserveFallbackScroll) {
     preserveWindowScrollForRichBlockSelectAll()
   }
   return true
@@ -121,30 +331,76 @@ export const preserveTableCellTextSelectionAcrossFrames = (
   const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now()
   let frame = 0
   let cancelled = false
+  let restoring = false
   const cleanup = () => {
+    activeTableCellSelectionPreserveCancels.delete(cancel)
     window.removeEventListener("pointerdown", cancel, true)
     window.removeEventListener("mousedown", cancel, true)
+    window.removeEventListener("pointerup", cancel, true)
+    window.removeEventListener("pointercancel", cancel, true)
+    window.removeEventListener("mouseup", cancel, true)
     window.removeEventListener("wheel", cancel, true)
+    window.removeEventListener("scroll", cancel, true)
     window.removeEventListener("keydown", cancel, true)
+    document.removeEventListener("selectionchange", cancelIfSelectionLeavesCell, true)
   }
   const cancel = () => {
     cancelled = true
+    clearOwnedTableCellDragSelectionText(editor, startedCell)
+    cancelActiveTableCellScrollPreserves()
     cleanup()
+  }
+  const cancelIfSelectionLeavesCell = () => {
+    if (restoring || cancelled) return
+    const currentCell = resolveConnectedTableCell(editor, startedCell)
+    if (!currentCell) {
+      cancel()
+      return
+    }
+    const selection = window.getSelection()
+    const selectionText = selection?.toString().trim() ?? ""
+    if (!selection || !selectionText) {
+      cancel()
+      return
+    }
+    const anchorElement = resolveElement(selection.anchorNode)
+    const focusElement = resolveElement(selection.focusNode)
+    if (!anchorElement || !focusElement || !currentCell.contains(anchorElement) || !currentCell.contains(focusElement)) {
+      cancel()
+    }
   }
   window.addEventListener("pointerdown", cancel, { capture: true, once: true })
   window.addEventListener("mousedown", cancel, { capture: true, once: true })
+  window.addEventListener("pointerup", cancel, { capture: true, once: true })
+  window.addEventListener("pointercancel", cancel, { capture: true, once: true })
+  window.addEventListener("mouseup", cancel, { capture: true, once: true })
   window.addEventListener("wheel", cancel, { capture: true, passive: true, once: true })
+  window.addEventListener("scroll", cancel, { capture: true, passive: true, once: true })
   window.addEventListener("keydown", cancel, { capture: true, once: true })
+  document.addEventListener("selectionchange", cancelIfSelectionLeavesCell, true)
+  activeTableCellSelectionPreserveCancels.add(cancel)
   const restore = () => {
     if (cancelled) return
-    restoreTableCellTextSelectionIfEscaped(editor, startedCell, null, true, true)
+    if (frame > 0 && !hasOwnedTableCellTextSelection(editor, startedCell)) {
+      cancel()
+      return
+    }
+    restoring = true
+    const restored = restoreTableCellTextSelectionIfEscaped(editor, startedCell, null, true, true, false)
+    restoring = false
+    if (!restored) {
+      cancel()
+      return
+    }
     frame += 1
     const elapsedMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt
-    if (startedCell.isConnected && (frame < TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES || elapsedMs < TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS)) {
+    const currentCell = resolveConnectedTableCell(editor, startedCell)
+    if (currentCell && (frame < TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES || elapsedMs < TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS)) {
       window.requestAnimationFrame(restore)
     } else {
       cleanup()
     }
   }
   restore()
+  return cancel
 }

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -1,13 +1,11 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
 import { TextSelection } from "@tiptap/pm/state"
 import { useEffect, useRef, type Dispatch, type MutableRefObject, type RefObject, type SetStateAction } from "react"
-import { markNextEditorPointerAfterTable, preserveWindowScrollForCodePointerFocus, preserveWindowScrollForEditorPointerFocus, preserveWindowScrollPositionAcrossFrames, type WindowScrollAnchor } from "./blockHandleLayoutModel"
+import { cancelTablePointerScrollPreserves, clearNextEditorPointerAfterTable, markNextEditorPointerAfterTable, preserveWindowScrollForCodePointerFocus, preserveWindowScrollForEditorPointerFocus, preserveWindowScrollPositionAcrossFrames, type WindowScrollAnchor } from "./blockHandleLayoutModel"
 import { isTableSelectionActive } from "./tableStructureModel"
-import { preserveTableCellTextSelectionAcrossFrames, restoreTableCellTextSelectionIfEscaped } from "./tableTextSelectionModel"
+import { cancelActiveTableCellTextSelectionPreserves, collapseStaleTableEditorSelection, preserveTableCellTextSelectionAcrossFrames, restoreTableCellTextSelectionIfEscaped, watchTableCellTextSelectionExternalClear } from "./tableTextSelectionModel"
 import { areFloatingBubbleStatesEqual, hideFloatingBubbleState, resolveFloatingBubbleStateFromCoords, type FloatingBubbleState } from "./useFloatingBubbleState"
-
 type SetState<T> = Dispatch<SetStateAction<T>>
-
 const CODE_BLOCK_EDITOR_CONTENT_SELECTOR = ".aq-code-editor-content"
 const BLOCK_EDITOR_ROOT_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
 const TABLE_TEXT_DRAG_CONTROL_SELECTOR = "[data-table-axis-rail='true'], [data-table-affordance], [data-table-menu-root='true'], [data-table-menu-trigger='true'], [data-testid^='table-column-resize-boundary-'], [data-testid='table-structure-menu-button'], [data-testid='table-corner-handle'], [data-testid='table-corner-grow-handle'], .column-resize-handle"
@@ -49,16 +47,20 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
   tryStartTableColumnResizeFromDomHandle,
 }: UseBlockEditorEngineSelectionBubbleEffectsArgs) => {
   const tableTextDragStartRef = useRef<{ cell: HTMLElement; coveredControlFallback: boolean; scrollPreserveStarted: boolean; selectionPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null)
-  const codeTextDragStartRef = useRef<{ root: HTMLElement; scrollPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null)
-
+  const tableTextDragPendingStartRef = useRef<{ cell: HTMLElement; coveredControlFallback: boolean; scrollPreserveStarted: boolean; selectionPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null)
+  const codeTextDragStartRef = useRef<{ root: HTMLElement; scrollPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null), nonTableTextDragStartRef = useRef<{ x: number; y: number } | null>(null)
   useEffect(() => {
     const currentEditor = editorRef.current ?? editor
     if (!currentEditor) return
     let rafId: number | null = null
     let codeDragSelectionPreserveRafId: number | null = null
-    let cleanupCodeDragSelectionPreserve: (() => void) | null = null
+    let cleanupCodeDragSelectionPreserve: (() => void) | null = null, cleanupTableDragScrollPreserve: (() => void) | null = null, cleanupTableDragSelectionPreserve: (() => void) | null = null
+    let tableTextSelectionExternalClearWatcher: ReturnType<typeof watchTableCellTextSelectionExternalClear> | null = null
     let codeDragSelectionPreserveGeneration = 0
-    const clearImmediateWindowTextSelection = () => window.getSelection()?.removeAllRanges()
+    const cancelTableTextDragPreserves = () => { cleanupTableDragScrollPreserve?.(); cleanupTableDragScrollPreserve = null; cleanupTableDragSelectionPreserve?.(); cleanupTableDragSelectionPreserve = null; cancelActiveTableCellTextSelectionPreserves(); cancelTablePointerScrollPreserves(); clearNextEditorPointerAfterTable(); tableTextSelectionExternalClearWatcher?.reset() }
+    const handleTableTextSelectionExternalClear = () => { cancelTableTextDragPreserves(); const activeEditor = editorRef.current ?? currentEditor, toolbarActive = Boolean(bubbleToolbarHoveredRef.current || document.querySelector("[data-testid='editor-text-bubble-toolbar']:hover, [data-testid='editor-text-bubble-toolbar'] details[open]")); if (activeEditor && !toolbarActive) collapseStaleTableEditorSelection(activeEditor) }
+    const clearWindowTextSelectionOnly = () => { window.getSelection()?.removeAllRanges(); document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => element.removeAttribute("data-table-drag-selection-text")) }
+    const clearImmediateWindowTextSelection = () => { cancelTableTextDragPreserves(); clearWindowTextSelectionOnly() }
     const cancelCodeDragSelectionPreserve = () => {
       codeDragSelectionPreserveGeneration += 1
       if (codeDragSelectionPreserveRafId !== null) {
@@ -73,7 +75,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     const rememberCodeTextDragStart = (codeShellTarget: Element | null | undefined, event: MouseEvent | PointerEvent) => {
       const codeSelectionRoot = codeShellTarget?.querySelector<HTMLElement>(".aq-code-editor-content") ?? codeShellTarget?.querySelector<HTMLElement>(".aq-code-highlight-layer")
       const scrollAnchor = { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }
-      codeTextDragStartRef.current = codeSelectionRoot ? { root: codeSelectionRoot, scrollPreserveStarted: false, scrollAnchor, x: event.clientX, y: event.clientY } : null
+      nonTableTextDragStartRef.current = null; codeTextDragStartRef.current = codeSelectionRoot ? { root: codeSelectionRoot, scrollPreserveStarted: false, scrollAnchor, x: event.clientX, y: event.clientY } : null
       if (codeSelectionRoot) codeSelectionRoot.closest(".aq-code-shell")?.removeAttribute("data-code-drag-selection-text")
       return codeTextDragStartRef.current
     }
@@ -85,25 +87,23 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       return selectedText && anchorElement && focusElement && codeShellTarget.contains(anchorElement) && codeShellTarget.contains(focusElement) ? selectedText : persistedCodeSelectionText
     }
     const rememberCodeTextDragStartAtPoint = (event: MouseEvent | PointerEvent) => { const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null; return rememberCodeTextDragStart(findCodeShellTarget(targetElement, document.elementsFromPoint(event.clientX, event.clientY)), event) }
-
-    const rememberTableTextDragStart = (event: MouseEvent | PointerEvent, allowTableControlCellFallback = false) => {
-      if (event.button !== 0) return null
+    const prepareNonTableEditorPointerTarget = (event: MouseEvent | PointerEvent) => { const activeEditor = editorRef.current ?? currentEditor; if (!activeEditor) return false; const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null, pointElements = document.elementsFromPoint(event.clientX, event.clientY), codeShellTarget = findCodeShellTarget(targetElement, pointElements), pointInsideEditor = pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR))), insideEditorDom = event.target instanceof Node && (activeEditor.view.dom.contains(event.target) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor), tableTarget = Boolean(targetElement?.closest("th, td") || pointElements.some((element) => Boolean(element.closest("th, td")))), toolbarOrControlTarget = Boolean(targetElement?.closest("[data-testid='editor-text-bubble-toolbar'], button, summary, [role='button']") || pointElements.some((element) => Boolean(element.closest("[data-testid='editor-text-bubble-toolbar']")))); if (!insideEditorDom || codeShellTarget || tableTarget || toolbarOrControlTarget) return false; nonTableTextDragStartRef.current = { x: event.clientX, y: event.clientY }; cancelTableTextDragPreserves(); collapseStaleTableEditorSelection(activeEditor); return true }
+    const rememberTableTextDragStart = (event: MouseEvent | PointerEvent, allowTableControlCellFallback = false, allowOutsideCoveredControlFallback = false) => {
+      if (event.button !== 0 && event.buttons !== 1) return null
       const activeEditor = editorRef.current ?? currentEditor
       if (!activeEditor) return null
       const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null
       const pointElements = document.elementsFromPoint(event.clientX, event.clientY)
       const pointInsideEditor = pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR)))
-      if (!(event.target instanceof Node) || (!activeEditor.view.dom.contains(event.target) && !targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR) && !pointInsideEditor)) {
-        tableTextDragStartRef.current = null
-        return null
-      }
       const pointElement = pointElements.find((element) => Boolean(element.closest("th, td"))) ?? document.elementFromPoint(event.clientX, event.clientY)
       const tableTextCell = pointElement?.closest("th, td") ?? targetElement?.closest("th, td")
       const tableControlTarget = targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR) ?? pointElements[0]?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR)
       const tableCellRect = tableTextCell instanceof HTMLElement ? tableTextCell.getBoundingClientRect() : null, coveredControlFallback = Boolean(tableCellRect && tableControlTarget?.getAttribute("data-table-affordance") === "row-handle" && event.clientX >= tableCellRect.left && event.clientX <= tableCellRect.right && event.clientY >= tableCellRect.top && event.clientY <= tableCellRect.bottom)
+      if (!(event.target instanceof Node) || (!activeEditor.view.dom.contains(event.target) && !targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR) && !pointInsideEditor && !(allowOutsideCoveredControlFallback && coveredControlFallback))) { tableTextDragStartRef.current = null; return null }
       if (tableControlTarget && (!(allowTableControlCellFallback || coveredControlFallback) || !(tableTextCell instanceof HTMLElement))) { tableTextDragStartRef.current = null; return null }
       const scrollAnchor = { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }
       if (tableTextCell instanceof HTMLElement) {
+        nonTableTextDragStartRef.current = null; cancelTableTextDragPreserves()
         tableTextCell.removeAttribute("data-table-drag-selection-text")
         markNextEditorPointerAfterTable()
       }
@@ -114,26 +114,23 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const tableTextDragStart = tableTextDragStartRef.current
       return Boolean(tableTextDragStart && (Math.abs(event.clientX - tableTextDragStart.x) > 4 || Math.abs(event.clientY - tableTextDragStart.y) > 4))
     }
-
-    const restoreActiveTableTextDragSelection = (restoreWhenEmpty = false, forceStartedCellSelection = false) => {
+    const restoreActiveTableTextDragSelection = (restoreWhenEmpty = false, forceStartedCellSelection = false, preserveScroll = true) => {
       const activeEditor = editorRef.current ?? currentEditor
       const tableTextDragStart = tableTextDragStartRef.current
       if (!activeEditor || !tableTextDragStart) return false
-      return restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, restoreWhenEmpty, forceStartedCellSelection)
+      const restored = restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, preserveScroll ? tableTextDragStart.scrollAnchor : null, restoreWhenEmpty, forceStartedCellSelection, preserveScroll)
+      if (restored) tableTextSelectionExternalClearWatcher?.markActive()
+      return restored
     }
-
     const preserveActiveTableTextDragScroll = () => {
       const tableTextDragStart = tableTextDragStartRef.current
       if (!tableTextDragStart || tableTextDragStart.scrollPreserveStarted) return
-      tableTextDragStart.scrollPreserveStarted = true
-      preserveWindowScrollPositionAcrossFrames(tableTextDragStart.scrollAnchor, 72, 4, 1_120, false, false)
+      tableTextDragStart.scrollPreserveStarted = true; cleanupTableDragScrollPreserve?.(); cleanupTableDragScrollPreserve = preserveWindowScrollPositionAcrossFrames(tableTextDragStart.scrollAnchor, 72, 4, 1_120, false, false, true, true) ?? null
     }
-
     const preserveActiveTableTextDragSelection = (activeEditor: TiptapEditor) => {
       const tableTextDragStart = tableTextDragStartRef.current
       if (!tableTextDragStart || tableTextDragStart.selectionPreserveStarted) return
-      tableTextDragStart.selectionPreserveStarted = true
-      preserveTableCellTextSelectionAcrossFrames(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor)
+      tableTextDragStart.selectionPreserveStarted = true; cleanupTableDragSelectionPreserve?.(); cleanupTableDragSelectionPreserve = preserveTableCellTextSelectionAcrossFrames(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor) ?? null
     }
 
     const preserveActiveCodeTextDragScroll = () => {
@@ -380,6 +377,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         clearWindowTextSelection()
         return
       }
+      if (tableTextSelectionExternalClearWatcher?.cancelIfCleared()) { scheduleSyncBubble(); return }
       if (restoreActiveTableTextDragSelection()) {
         syncBubbleOnMouseUpRef.current = true
         return
@@ -406,8 +404,8 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const pointInsideEditor = !targetElement?.closest("[data-table-menu-root='true']") && (!targetTableControl || allowTableControlCellFallback) && pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR)))
       const insideEditorDom = eventTarget instanceof Node && (activeEditor.view.dom.contains(eventTarget) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor)
       const tableTextDragStart = insideEditorDom ? rememberTableTextDragStart(event, allowTableControlCellFallback) : null
-      if (!insideEditorDom && !codeShellTarget) return
-      if (codeShellTarget) preserveWindowScrollForCodePointerFocus(true); else if (insideEditorDom) { const blockSelectionActive = Boolean(document.querySelector("[data-testid='keyboard-block-selection-overlay']")); preserveWindowScrollForEditorPointerFocus(event.target, isTableSelectionActive(activeEditor), blockSelectionActive) }
+      if (!insideEditorDom && !codeShellTarget) { nonTableTextDragStartRef.current = null; if (targetTableControl?.getAttribute("data-table-affordance") === "row-handle") { const pending = rememberTableTextDragStart(event, false, true); tableTextDragPendingStartRef.current = pending?.coveredControlFallback ? pending : null; tableTextDragStartRef.current = null } return }
+      if (insideEditorDom && !codeShellTarget && !tableTextDragStart) { nonTableTextDragStartRef.current = { x: event.clientX, y: event.clientY }; collapseStaleTableEditorSelection(activeEditor) } else if (tableTextDragStart) nonTableTextDragStartRef.current = null; if (codeShellTarget) preserveWindowScrollForCodePointerFocus(true); else if (insideEditorDom) { const blockSelectionActive = Boolean(document.querySelector("[data-testid='keyboard-block-selection-overlay']")); preserveWindowScrollForEditorPointerFocus(event.target, isTableSelectionActive(activeEditor), blockSelectionActive) }
       if (codeShellTarget) {
         cancelCodeDragSelectionPreserve()
         const codeTextDragStart = rememberCodeTextDragStart(codeShellTarget, event)
@@ -417,19 +415,20 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         codeTextDragStartRef.current = null
         if (insideEditorDom) {
           cancelCodeDragSelectionPreserve()
-          if (!tableTextDragStart || !existingSelectionText) clearImmediateWindowTextSelection()
+          if (!tableTextDragStart) clearImmediateWindowTextSelection(); else if (!existingSelectionText) clearWindowTextSelectionOnly()
         }
       }
       if (insideEditorDom) {
-        if (tableTextDragStart && (existingSelectionText || tableTextDragStart.coveredControlFallback)) { event.preventDefault(); event.stopPropagation(); if (tableTextDragStart.coveredControlFallback) event.stopImmediatePropagation?.(); restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); if (tableTextDragStart.coveredControlFallback) { preserveTableCellTextSelectionAcrossFrames(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor); preserveActiveTableTextDragScroll() } }
+        if (tableTextDragStart && existingSelectionText) { event.preventDefault(); event.stopPropagation(); if (tableTextDragStart.coveredControlFallback) event.stopImmediatePropagation?.(); restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); if (tableTextDragStart.coveredControlFallback) { preserveActiveTableTextDragSelection(activeEditor); preserveActiveTableTextDragScroll() } }
       }
       if (tryStartTableColumnResizeFromDomHandle(event.target, event.pointerId, event.clientX)) {
         event.preventDefault()
         event.stopPropagation()
         event.stopImmediatePropagation?.()
+        cancelTableTextDragPreserves()
         mouseTextSelectionInProgressRef.current = false
         syncBubbleOnMouseUpRef.current = false
-        tableTextDragStartRef.current = null
+        tableTextDragStartRef.current = null; nonTableTextDragStartRef.current = null
         return
       }
       mouseTextSelectionInProgressRef.current = true
@@ -449,7 +448,8 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const pointElements = document.elementsFromPoint(event.clientX, event.clientY), codeShellTarget = findCodeShellTarget(targetElement, pointElements), existingSelectionText = window.getSelection()?.toString().trim() ?? "", existingCodeSelectionText = resolveCurrentCodeSelectionText(codeShellTarget)
       const allowTableControlCellFallback = Boolean(existingSelectionText) && !isTableSelectionActive(activeEditor), targetTableControl = targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR)
       const pointInsideEditor = !targetElement?.closest("[data-table-menu-root='true']") && (!targetTableControl || allowTableControlCellFallback) && pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR))), insideEditorDom = eventTarget instanceof Node && (activeEditor.view.dom.contains(eventTarget) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor), columnResizeTarget = targetElement?.closest(".column-resize-handle"), tableTextDragStart = insideEditorDom && !codeShellTarget ? tableTextDragStartRef.current ?? rememberTableTextDragStart(event, allowTableControlCellFallback) : null
-      if (!insideEditorDom && !codeShellTarget) return; if (codeTextDragStartRef.current && !codeShellTarget) codeTextDragStartRef.current = null
+      if (!insideEditorDom && !codeShellTarget) { nonTableTextDragStartRef.current = null; if (targetTableControl?.getAttribute("data-table-affordance") === "row-handle") { const pending = rememberTableTextDragStart(event, false, true); tableTextDragPendingStartRef.current = pending?.coveredControlFallback ? pending : null; tableTextDragStartRef.current = null } return }
+      if (insideEditorDom && !codeShellTarget && !tableTextDragStart) { nonTableTextDragStartRef.current = nonTableTextDragStartRef.current ?? { x: event.clientX, y: event.clientY }; collapseStaleTableEditorSelection(activeEditor) } else if (tableTextDragStart) nonTableTextDragStartRef.current = null; if (codeTextDragStartRef.current && !codeShellTarget) codeTextDragStartRef.current = null
       if (codeShellTarget) {
         if (codeTextDragStartRef.current && !codeTextDragStartRef.current.root.isConnected) { const nextCodeTextDragStart = rememberCodeTextDragStart(codeShellTarget, event); if (nextCodeTextDragStart) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(nextCodeTextDragStart.root); preserveCodeDragRootSelectionAcrossFrames(nextCodeTextDragStart.root); return } }
         if (codeTextDragStartRef.current?.root.isConnected && (codeTextDragStartRef.current.scrollPreserveStarted || isSelectionInsideCodeDragRoot(codeTextDragStartRef.current.root))) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRoot(codeTextDragStartRef.current.root); preserveCodeDragRootSelectionAcrossFrames(codeTextDragStartRef.current.root); return }
@@ -460,19 +460,18 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         clearImmediateWindowTextSelection()
       } else if (insideEditorDom) {
         codeTextDragStartRef.current = null; cancelCodeDragSelectionPreserve()
-        if (tableTextDragStart && tableTextDragStart.coveredControlFallback && !columnResizeTarget) { event.preventDefault(); event.stopPropagation(); event.stopImmediatePropagation?.(); restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); preserveTableCellTextSelectionAcrossFrames(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor); preserveActiveTableTextDragScroll() } else if (tableTextDragStart && existingSelectionText) restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); else if (!tableTextDragStart || !existingSelectionText) clearImmediateWindowTextSelection()
+        if (tableTextDragStart && tableTextDragStart.coveredControlFallback && existingSelectionText && !columnResizeTarget) { event.preventDefault(); event.stopPropagation(); event.stopImmediatePropagation?.(); restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); preserveActiveTableTextDragSelection(activeEditor); preserveActiveTableTextDragScroll() } else if (tableTextDragStart && existingSelectionText) restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); else if (!tableTextDragStart) clearImmediateWindowTextSelection(); else if (!existingSelectionText) clearWindowTextSelectionOnly()
       }
       if (!insideEditorDom) return
       if (!tableTextDragStartRef.current) rememberTableTextDragStart(event, allowTableControlCellFallback)
-      if (!columnResizeTarget) return
+      if (!columnResizeTarget) return; nonTableTextDragStartRef.current = null
       event.preventDefault()
       event.stopPropagation()
       event.stopImmediatePropagation?.()
     }
-
     const handleWindowPointerMove = (event: PointerEvent) => {
-      if (event.pointerType && event.pointerType !== "mouse") return
-      if (!codeTextDragStartRef.current && event.buttons === 1 && !tableTextDragStartRef.current && rememberCodeTextDragStartAtPoint(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRootWhenNativeSelectionIsMissing(); return }
+      if (event.pointerType && event.pointerType !== "mouse") return; if (event.buttons === 0) { prepareNonTableEditorPointerTarget(event); return }
+      if (!nonTableTextDragStartRef.current && !codeTextDragStartRef.current && event.buttons === 1 && !tableTextDragStartRef.current && rememberCodeTextDragStartAtPoint(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRootWhenNativeSelectionIsMissing(); return }
       if (hasMovedCodeTextDrag(event)) {
         event.preventDefault()
         event.stopPropagation()
@@ -480,6 +479,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         selectCodeDragRootWhenNativeSelectionIsMissing()
         return
       }
+      if (!nonTableTextDragStartRef.current && !tableTextDragStartRef.current && !isTableColumnRailResizeActive() && event.buttons === 1 && rememberTableTextDragStart(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveTableTextDragScroll(); if (restoreActiveTableTextDragSelection(true, true)) syncBubbleOnMouseUpRef.current = true; const activeEditor = editorRef.current ?? currentEditor; if (activeEditor) preserveActiveTableTextDragSelection(activeEditor); return }
       if (!hasMovedTableTextDrag(event)) return
       event.preventDefault()
       event.stopPropagation()
@@ -492,7 +492,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     }
 
     const handleWindowMouseMove = (event: MouseEvent) => {
-      if (!codeTextDragStartRef.current && event.buttons === 1 && !tableTextDragStartRef.current && rememberCodeTextDragStartAtPoint(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRootWhenNativeSelectionIsMissing(); return }
+      if (event.buttons === 0) { prepareNonTableEditorPointerTarget(event); return } if (!nonTableTextDragStartRef.current && !codeTextDragStartRef.current && event.buttons === 1 && !tableTextDragStartRef.current && rememberCodeTextDragStartAtPoint(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRootWhenNativeSelectionIsMissing(); return }
       if (hasMovedCodeTextDrag(event)) {
         event.preventDefault()
         event.stopPropagation()
@@ -500,6 +500,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         selectCodeDragRootWhenNativeSelectionIsMissing()
         return
       }
+      if (!nonTableTextDragStartRef.current && !tableTextDragStartRef.current && !isTableColumnRailResizeActive() && event.buttons === 1 && rememberTableTextDragStart(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveTableTextDragScroll(); if (restoreActiveTableTextDragSelection(true, true)) syncBubbleOnMouseUpRef.current = true; const activeEditor = editorRef.current ?? currentEditor; if (activeEditor) preserveActiveTableTextDragSelection(activeEditor); return }
       if (!hasMovedTableTextDrag(event)) return
       event.preventDefault()
       event.stopPropagation()
@@ -510,13 +511,14 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const activeEditor = editorRef.current ?? currentEditor
       if (activeEditor) preserveActiveTableTextDragSelection(activeEditor)
     }
-
     const completeTextDragSelection = (event: PointerEvent | MouseEvent) => {
-      const tableTextDragStart = tableTextDragStartRef.current
+      let tableTextDragStart = tableTextDragStartRef.current
+      const pendingTableTextDragStart = tableTextDragPendingStartRef.current
       const codeTextDragStart = codeTextDragStartRef.current
-      if (!mouseTextSelectionInProgressRef.current && !tableTextDragStart && !codeTextDragStart) return
+      if (!mouseTextSelectionInProgressRef.current && !tableTextDragStart && !pendingTableTextDragStart && !codeTextDragStart) return
       if ("pointerType" in event && event.pointerType && event.pointerType !== "mouse") return
       const activeEditor = editorRef.current ?? currentEditor
+      if (!tableTextDragStart && pendingTableTextDragStart && Math.abs(event.clientX - pendingTableTextDragStart.x) > 4 && Math.abs(event.clientX - pendingTableTextDragStart.x) >= Math.abs(event.clientY - pendingTableTextDragStart.y)) { tableTextDragStartRef.current = pendingTableTextDragStart; tableTextDragStart = pendingTableTextDragStart }
       const tableTextDragMoved = hasMovedTableTextDrag(event)
       const codeTextDragMoved = hasMovedCodeTextDrag(event)
       if (codeTextDragMoved) {
@@ -528,15 +530,10 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
           preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root)
         }
       }
-      if (activeEditor && tableTextDragStart && (tableTextDragMoved || tableTextDragStart.coveredControlFallback) && restoreActiveTableTextDragSelection(true, true)) {
-        event.preventDefault()
-        event.stopPropagation()
-        preserveActiveTableTextDragScroll()
-        preserveActiveTableTextDragSelection(activeEditor)
-        syncBubbleOnMouseUpRef.current = true
-      }
+      if (activeEditor && tableTextDragStart && (tableTextDragMoved || tableTextDragStart.coveredControlFallback)) { cancelTableTextDragPreserves(); if (restoreActiveTableTextDragSelection(true, true, false)) { event.preventDefault(); event.stopPropagation(); syncBubbleOnMouseUpRef.current = true } }
       tableTextDragStartRef.current = null
-      codeTextDragStartRef.current = null
+      tableTextDragPendingStartRef.current = null
+      codeTextDragStartRef.current = null; nonTableTextDragStartRef.current = null
       mouseTextSelectionInProgressRef.current = false
       if (!syncBubbleOnMouseUpRef.current) return
       syncBubbleOnMouseUpRef.current = false
@@ -544,6 +541,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     }
     const resolveCodeDragCopyText = () => { const selection = window.getSelection(), selectedText = selection?.toString().trim() ?? "", anchorElement = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focusElement = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null, activeElement = document.activeElement instanceof Element ? document.activeElement : null, anchorShell = anchorElement?.closest(".aq-code-shell") ?? null, focusShell = focusElement?.closest(".aq-code-shell") ?? null, activeShell = activeElement?.closest(".aq-code-shell") ?? null, codeShell = anchorShell && anchorShell === focusShell ? anchorShell : activeShell?.getAttribute("data-code-drag-selection-text")?.trim() ? activeShell : null; if (!codeShell) return ""; return selectedText && anchorShell === codeShell && focusShell === codeShell ? selectedText : codeShell.getAttribute("data-code-drag-selection-text")?.trim() || "" }, handleDocumentCopyCapture = (event: ClipboardEvent) => { const copyText = resolveCodeDragCopyText(); if (!copyText) return; event.preventDefault(); event.clipboardData?.setData("text/plain", copyText) }, handleDocumentCopyKeyDown = (event: KeyboardEvent) => { if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey || event.key.toLowerCase() !== "c") return; const copyText = resolveCodeDragCopyText(); if (!copyText) return; event.preventDefault(); void navigator.clipboard?.writeText(copyText) }
 
+    tableTextSelectionExternalClearWatcher = watchTableCellTextSelectionExternalClear(currentEditor.view.dom, () => Boolean(mouseTextSelectionInProgressRef.current || tableTextDragStartRef.current || tableTextDragPendingStartRef.current), handleTableTextSelectionExternalClear)
     scheduleSyncBubble()
     currentEditor.on("selectionUpdate", scheduleSyncBubble)
     currentEditor.on("focus", scheduleSyncBubble)
@@ -570,12 +568,14 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       window.removeEventListener("pointerup", completeTextDragSelection, true)
       window.removeEventListener("pointercancel", completeTextDragSelection, true)
       window.removeEventListener("mouseup", completeTextDragSelection, true)
+      tableTextSelectionExternalClearWatcher?.dispose()
       if (rafId !== null && typeof window !== "undefined") window.cancelAnimationFrame(rafId)
+      cancelTableTextDragPreserves()
       cancelCodeDragSelectionPreserve()
       mouseTextSelectionInProgressRef.current = false
       syncBubbleOnMouseUpRef.current = false
-      tableTextDragStartRef.current = null
-      codeTextDragStartRef.current = null
+      tableTextDragStartRef.current = null; tableTextDragPendingStartRef.current = null
+      codeTextDragStartRef.current = null; nonTableTextDragStartRef.current = null
       cancelBubbleHide()
     }
   }, [


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- `/editor/507` 형태의 clean 상태 첫 table cell drag가 mouseup 이후 선택 문자열을 잃던 문제를 고정했습니다.
- table drag 완료 후 남는 selection RAF/scroll preserve, PM table selection, table follow-up pointer preserve가 다음 body/code 입력을 이전 table anchor로 되돌리지 않게 정리했습니다.
- CodeRabbit unresolved thread `PRRT_kwDORiDgZM6E7BRF`를 반영해 code block 내부 collapsed caret만 있는 상태의 외부 drop은 internal code drag로 차단하지 않도록 좁혔습니다.

## 작업 내용

- table cell text drag 복구가 disconnected started cell 대신 현재 연결된 동일 텍스트 셀로 selection range를 재구성합니다.
- table drag selection 보존 루프는 외부 selection clear/move를 감지하면 취소하고, table click focus-reveal 보정은 실제 text selection 이후 다음 editor pointer에 남지 않도록 분리했습니다.
- table drag mouseup completion은 기존 preserve listener를 먼저 제거한 뒤 selection을 확정하며, mouseup 중 stale table preserve를 re-arm하지 않습니다.
- table pointer/follow-up scroll preserve cancel registry를 추가해, text drag 확정 시 `preserveNextEditorPointerAfterTable`까지 함께 해제합니다.
- Ubuntu/headless에서 row-handle overlay가 pointerdown을 잡고 move 이벤트가 생략되는 경우를 pending start로 보관하되, 실제 cell rect 내부를 덮고 mouseup 이동이 가로 text drag일 때만 셀 텍스트 선택으로 승격합니다.
- code shell 내부 native `dragstart`/`drop`을 차단해 custom drag selection 중 브라우저 기본 text move가 code 원문을 변형하지 못하게 했습니다.
- `preventInternalCodeDrop`은 non-empty native code selection의 anchor/focus가 모두 같은 shell 안에 있거나, persisted code drag dataset이 있을 때만 drop을 차단합니다.
- table drag selection이 dataset 기반으로 남는 CI 경로에서 attr 제거를 external clear 신호로 감지해 table RAF/scroll preserve를 즉시 취소합니다.
- external clear 뒤에도 남는 ProseMirror table text selection을 collapsed caret으로 낮춰 다음 scroll/focus가 이전 table cell anchor를 재노출하지 못하게 했습니다.
- 상단 toolbar `글자색` summary도 mousedown selection 보존 계약에 포함해 table 셀 선택 후 굵게/색상 연속 formatting을 유지합니다.
- 일반 본문 같은 non-table editor drag가 시작된 동안에는 code/table fallback을 새로 시작하지 않고, 시작 시 stale table PM selection을 collapse합니다.
- non-table editor hover 단계에서도 stale table preserve/PM selection을 끊되, bubble toolbar와 버튼/summary control hover는 제외합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e e2e/editor-authoring-code-drop-guard.spec.ts --workers=1` (RED before patch: failed as expected, `dropPrevented=true`)
  - `yarn --cwd front test:e2e e2e/editor-authoring-code-drop-guard.spec.ts --workers=1` (1 passed, `79a3e7d2`)
  - `yarn --cwd front test:e2e e2e/editor-authoring-code-drop-guard.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts --workers=1` (9 passed, `79a3e7d2`)
  - `yarn --cwd front test:e2e e2e/editor-authoring-code-drop-guard.spec.ts e2e/editor-authoring-route-body-click-flicker.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-structure.spec.ts e2e/editor-authoring-table-operations.spec.ts --workers=1` (25 passed, `79a3e7d2`)
  - `yarn --cwd front test:e2e:authoring` (98 passed, `79a3e7d2`, 1회차)
  - `yarn --cwd front test:e2e:authoring` (98 passed, `79a3e7d2`, 2회차)
  - `yarn --cwd front build` (passed, `79a3e7d2`)
  - `yarn --cwd front check:bundle-size` (passed, `79a3e7d2`)
  - `yarn --cwd front test:e2e e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` (8 passed, `79a3e7d2`)
  - `git diff --check` (passed, `79a3e7d2`)
  - `bash tools/guards/current-task-preflight.sh` (passed, `79a3e7d2`)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table/body/code drag 종료 타이밍의 native selection 보존 경로가 브라우저별 event ordering에 민감할 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋 `79a3e7d2`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
