### PR TITLE
[Chore] 홈서버 DDoS 방어 레이어 강화

### DIFF
--- a/back/src/main/kotlin/com/back/global/security/config/ApiRateLimitBackstopFilter.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/ApiRateLimitBackstopFilter.kt
@@ -1,0 +1,221 @@
+package com.back.global.security.config
+
+import com.back.global.cache.application.port.output.RedisKeyValuePort
+import com.back.global.web.application.ClientIpResolver
+import io.micrometer.core.instrument.MeterRegistry
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.core.env.Environment
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.time.Duration
+import java.time.Instant
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 20)
+class ApiRateLimitBackstopFilter(
+    private val redisKeyValuePortProvider: ObjectProvider<RedisKeyValuePort>,
+    private val clientIpResolverProvider: ObjectProvider<ClientIpResolver>,
+    private val meterRegistryProvider: ObjectProvider<MeterRegistry>,
+    private val environment: Environment,
+    @param:Value("\${custom.security.apiRateLimit.enabled:true}")
+    private val enabled: Boolean = true,
+    @param:Value("\${custom.security.apiRateLimit.requireRedisInProd:true}")
+    private val requireRedisInProd: Boolean = true,
+    @param:Value("\${custom.security.apiRateLimit.publicReadLimitPerMinute:120}")
+    private val publicReadLimitPerMinute: Int = 120,
+    @param:Value("\${custom.security.apiRateLimit.mutationLimitPerMinute:60}")
+    private val mutationLimitPerMinute: Int = 60,
+    @param:Value("\${custom.security.apiRateLimit.authLimitPerMinute:20}")
+    private val authLimitPerMinute: Int = 20,
+    @param:Value("\${custom.security.apiRateLimit.sseLimitPerMinute:30}")
+    private val sseLimitPerMinute: Int = 30,
+) : OncePerRequestFilter() {
+    init {
+        require(publicReadLimitPerMinute > 0) { "publicReadLimitPerMinute must be > 0" }
+        require(mutationLimitPerMinute > 0) { "mutationLimitPerMinute must be > 0" }
+        require(authLimitPerMinute > 0) { "authLimitPerMinute must be > 0" }
+        require(sseLimitPerMinute > 0) { "sseLimitPerMinute must be > 0" }
+    }
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        if (!enabled) return true
+        val path = requestPath(request)
+        if (path.startsWith("/actuator/")) return true
+        return bucketFor(request.method, path) == null
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val path = requestPath(request)
+        val bucket = bucketFor(request.method, path) ?: error("ApiRateLimitBackstopFilter invoked without a rate-limit bucket.")
+
+        val redisKeyValuePort = redisKeyValuePortProvider.getIfAvailable()
+        if (redisKeyValuePort == null || !redisKeyValuePort.isAvailable()) {
+            if (shouldFailClosedWithoutRedis()) {
+                writeUnavailable(response)
+                record(bucket.name, "redis-unavailable")
+                return
+            }
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        val clientIp = (clientIpResolverProvider.getIfAvailable() ?: ClientIpResolver()).resolve(request).ifBlank { "unknown" }
+        val key = redisKey(bucket.name, clientIp)
+        val count = redisKeyValuePort.increment(key)
+        if (count == null) {
+            if (shouldFailClosedWithoutRedis()) {
+                writeUnavailable(response)
+                record(bucket.name, "redis-unavailable")
+                return
+            }
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        if (count == 1L) {
+            val ttlApplied = redisKeyValuePort.expire(key, WINDOW)
+            if (!ttlApplied) {
+                if (shouldFailClosedWithoutRedis()) {
+                    writeUnavailable(response)
+                    record(bucket.name, "redis-unavailable")
+                    return
+                }
+                redisKeyValuePort.delete(listOf(key))
+                filterChain.doFilter(request, response)
+                return
+            }
+        }
+
+        if (count > bucket.limit.toLong()) {
+            writeTooManyRequests(response, bucket.name)
+            record(bucket.name, "rejected")
+            meterRegistryProvider.getIfAvailable()?.counter("api_rate_limit_rejected_total", "bucket", bucket.name)?.increment()
+            return
+        }
+
+        record(bucket.name, "accepted")
+        filterChain.doFilter(request, response)
+    }
+
+    private fun bucketFor(
+        rawMethod: String,
+        path: String,
+    ): Bucket? {
+        val method = rawMethod.uppercase()
+        if (method == "OPTIONS") return null
+        if (method == "GET" && path == "/member/api/v1/notifications/stream") {
+            return Bucket("sse-open", sseLimitPerMinute)
+        }
+        if (isAuthPath(path)) {
+            return Bucket("auth", authLimitPerMinute)
+        }
+        if (method in SAFE_METHODS && isPublicReadPath(path)) {
+            return Bucket("public-read", publicReadLimitPerMinute)
+        }
+        if (method !in SAFE_METHODS && API_PATH_REGEX.matches(path)) {
+            return Bucket("mutation", mutationLimitPerMinute)
+        }
+        return null
+    }
+
+    private fun isAuthPath(path: String): Boolean =
+        AUTH_PATHS.any { it.matches(path) } ||
+            path.startsWith("/oauth2/") ||
+            path.startsWith("/login/oauth2/")
+
+    private fun isPublicReadPath(path: String): Boolean = PUBLIC_READ_PATHS.any { it.matches(path) } || PUBLIC_DETAIL_PATH.matches(path)
+
+    private fun shouldFailClosedWithoutRedis(): Boolean = environment.matchesProfiles("prod") && requireRedisInProd
+
+    private fun requestPath(request: HttpServletRequest): String {
+        val contextPath = request.contextPath.orEmpty()
+        val uri = request.requestURI.orEmpty()
+        return if (contextPath.isNotBlank() && uri.startsWith(contextPath)) {
+            uri.removePrefix(contextPath)
+        } else {
+            uri
+        }
+    }
+
+    private fun redisKey(
+        bucket: String,
+        clientIp: String,
+    ): String {
+        val minuteBucket = Instant.now().epochSecond / WINDOW.seconds
+        return "security:api-rate-limit:$bucket:${sanitizeKeyToken(clientIp)}:$minuteBucket"
+    }
+
+    private fun sanitizeKeyToken(raw: String): String = raw.replace(Regex("[^A-Za-z0-9:._-]"), "_").take(96)
+
+    private fun writeTooManyRequests(
+        response: HttpServletResponse,
+        bucket: String,
+    ) {
+        response.status = 429
+        response.setHeader(HttpHeaders.RETRY_AFTER, WINDOW.seconds.toString())
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = Charsets.UTF_8.name()
+        response.writer.write("""{"resultCode":"429-10","msg":"요청이 너무 많습니다.","bucket":"$bucket"}""")
+    }
+
+    private fun writeUnavailable(response: HttpServletResponse) {
+        response.status = HttpServletResponse.SC_SERVICE_UNAVAILABLE
+        response.setHeader(HttpHeaders.RETRY_AFTER, "5")
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = Charsets.UTF_8.name()
+        response.writer.write("""{"resultCode":"503-4","msg":"API 보호 시스템이 준비되지 않았습니다."}""")
+    }
+
+    private fun record(
+        bucket: String,
+        result: String,
+    ) {
+        meterRegistryProvider.getIfAvailable()?.counter("api_rate_limit_result_total", "bucket", bucket, "result", result)?.increment()
+    }
+
+    private data class Bucket(
+        val name: String,
+        val limit: Int,
+    )
+
+    companion object {
+        private val WINDOW = Duration.ofMinutes(1)
+        private val SAFE_METHODS = setOf("GET", "HEAD")
+        private val API_PATH_REGEX = Regex("^/[^/]+/api/.*")
+        private val AUTH_PATHS =
+            listOf(
+                Regex("^/member/api/v\\d+/auth/login$"),
+                Regex("^/member/api/v\\d+/signup/email/start$"),
+                Regex("^/member/api/v\\d+/signup/email/verify$"),
+                Regex("^/member/api/v\\d+/signup/complete$"),
+            )
+        private val PUBLIC_READ_PATHS =
+            listOf(
+                Regex("^/post/api/v\\d+/posts$"),
+                Regex("^/post/api/v\\d+/posts/feed$"),
+                Regex("^/post/api/v\\d+/posts/feed/cursor$"),
+                Regex("^/post/api/v\\d+/posts/bootstrap$"),
+                Regex("^/post/api/v\\d+/posts/explore$"),
+                Regex("^/post/api/v\\d+/posts/explore/cursor$"),
+                Regex("^/post/api/v\\d+/posts/search$"),
+                Regex("^/post/api/v\\d+/posts/tags$"),
+                Regex("^/post/api/v\\d+/posts/related/author$"),
+                Regex("^/post/api/v\\d+/posts/\\d+/comments$"),
+                Regex("^/post/api/v\\d+/posts/\\d+/comments/\\d+$"),
+                Regex("^/post/api/v\\d+/images/.*"),
+            )
+        private val PUBLIC_DETAIL_PATH = Regex("^/post/api/v\\d+/posts/\\d+$")
+    }
+}

--- a/back/src/main/resources/application.yaml
+++ b/back/src/main/resources/application.yaml
@@ -207,6 +207,14 @@ custom:
     password: "${CUSTOM__ADMIN__PASSWORD:}"
     bootstrap:
       rotatePasswordOnStartup: ${CUSTOM__ADMIN__BOOTSTRAP__ROTATE_PASSWORD_ON_STARTUP:false}
+  security:
+    apiRateLimit:
+      enabled: ${CUSTOM__SECURITY__API_RATE_LIMIT__ENABLED:true}
+      requireRedisInProd: ${CUSTOM__SECURITY__API_RATE_LIMIT__REQUIRE_REDIS_IN_PROD:true}
+      publicReadLimitPerMinute: ${CUSTOM__SECURITY__API_RATE_LIMIT__PUBLIC_READ_LIMIT_PER_MINUTE:120}
+      mutationLimitPerMinute: ${CUSTOM__SECURITY__API_RATE_LIMIT__MUTATION_LIMIT_PER_MINUTE:60}
+      authLimitPerMinute: ${CUSTOM__SECURITY__API_RATE_LIMIT__AUTH_LIMIT_PER_MINUTE:20}
+      sseLimitPerMinute: ${CUSTOM__SECURITY__API_RATE_LIMIT__SSE_LIMIT_PER_MINUTE:30}
   auth:
     cookie:
       apiKeyMaxAgeSeconds: ${CUSTOM__AUTH__COOKIE__API_KEY_MAX_AGE_SECONDS:604800}

--- a/back/src/test/kotlin/com/back/global/security/config/ApiRateLimitBackstopFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/ApiRateLimitBackstopFilterTest.kt
@@ -1,0 +1,397 @@
+package com.back.global.security.config
+
+import com.back.global.cache.application.port.output.RedisKeyValuePort
+import com.back.global.web.application.ClientIpResolver
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import jakarta.servlet.http.HttpServlet
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.mock.env.MockEnvironment
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+
+@DisplayName("ApiRateLimitBackstopFilter 테스트")
+class ApiRateLimitBackstopFilterTest {
+    @Test
+    @DisplayName("기본 설정은 public read 기본 한도를 적용한다")
+    fun `default configuration applies public read limit`() {
+        val redis = InMemoryRedisKeyValuePort()
+        val filter =
+            ApiRateLimitBackstopFilter(
+                redisKeyValuePortProvider = objectProvider(redis, RedisKeyValuePort::class.java),
+                clientIpResolverProvider = objectProvider(ClientIpResolver(), ClientIpResolver::class.java),
+                meterRegistryProvider = objectProvider(SimpleMeterRegistry(), MeterRegistry::class.java),
+                environment = MockEnvironment().apply { setActiveProfiles("test") },
+            )
+
+        repeat(120) {
+            assertThat(runFilter(filter, "GET", "/post/api/v1/posts/feed").status).isEqualTo(HttpServletResponse.SC_OK)
+        }
+
+        assertThat(runFilter(filter, "GET", "/post/api/v1/posts/feed").status).isEqualTo(429)
+    }
+
+    @Test
+    @DisplayName("public read API가 분당 제한을 넘으면 429와 Retry-After를 반환한다")
+    fun `public read api is rate limited by client ip`() {
+        val redis = InMemoryRedisKeyValuePort()
+        val meterRegistry = SimpleMeterRegistry()
+        val filter = createFilter(redis = redis, meterRegistry = meterRegistry, publicReadLimitPerMinute = 2)
+
+        assertThat(runFilter(filter, "GET", "/post/api/v1/posts/feed").status).isEqualTo(HttpServletResponse.SC_OK)
+        assertThat(runFilter(filter, "GET", "/post/api/v1/posts/feed").status).isEqualTo(HttpServletResponse.SC_OK)
+
+        val limited = runFilter(filter, "GET", "/post/api/v1/posts/feed")
+
+        assertThat(limited.status).isEqualTo(429)
+        assertThat(limited.getHeader("Retry-After")).isEqualTo("60")
+        assertThat(limited.contentAsString).contains("\"resultCode\":\"429-10\"")
+        assertThat(redis.expiredKeys()).anyMatch { it.contains("public-read") && it.contains("203.0.113.10") }
+        assertThat(
+            meterRegistry
+                .find("api_rate_limit_rejected_total")
+                .tag("bucket", "public-read")
+                .counter()
+                ?.count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    @DisplayName("비활성화, actuator, OPTIONS 요청은 rate limit을 건너뛴다")
+    fun `disabled actuator and options requests bypass filter`() {
+        val disabled = createFilter(redis = InMemoryRedisKeyValuePort(), enabled = false, publicReadLimitPerMinute = 1)
+        val enabled = createFilter(redis = InMemoryRedisKeyValuePort(), publicReadLimitPerMinute = 1)
+
+        assertThat(runFilter(disabled, "GET", "/post/api/v1/posts/feed").status).isEqualTo(HttpServletResponse.SC_OK)
+        assertThat(runFilter(enabled, "GET", "/actuator/health/readiness").status).isEqualTo(HttpServletResponse.SC_OK)
+        assertThat(runFilter(enabled, "OPTIONS", "/post/api/v1/posts/feed").status).isEqualTo(HttpServletResponse.SC_OK)
+    }
+
+    @Test
+    @DisplayName("rate limit 한도값은 0 이하로 설정할 수 없다")
+    fun `rate limit thresholds must be positive`() {
+        assertThatThrownBy {
+            createFilter(redis = InMemoryRedisKeyValuePort(), publicReadLimitPerMinute = 0)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("publicReadLimitPerMinute must be > 0")
+    }
+
+    @Test
+    @DisplayName("SSE 신규 연결은 public read와 별도 bucket으로 제한한다")
+    fun `sse stream open is rate limited separately`() {
+        val filter = createFilter(redis = InMemoryRedisKeyValuePort(), sseLimitPerMinute = 1)
+
+        assertThat(runFilter(filter, "GET", "/member/api/v1/notifications/stream").status).isEqualTo(HttpServletResponse.SC_OK)
+
+        val limited = runFilter(filter, "GET", "/member/api/v1/notifications/stream")
+
+        assertThat(limited.status).isEqualTo(429)
+        assertThat(limited.contentAsString).contains("sse-open")
+    }
+
+    @Test
+    @DisplayName("OAuth와 signup/auth 요청은 auth bucket으로 제한한다")
+    fun `oauth and signup auth paths use auth bucket`() {
+        val filter = createFilter(redis = InMemoryRedisKeyValuePort(), authLimitPerMinute = 1)
+
+        assertThat(runFilter(filter, "GET", "/login/oauth2/code/github").status).isEqualTo(HttpServletResponse.SC_OK)
+
+        val limited = runFilter(filter, "POST", "/member/api/v1/signup/email/start")
+
+        assertThat(limited.status).isEqualTo(429)
+        assertThat(limited.contentAsString).contains("auth")
+    }
+
+    @Test
+    @DisplayName("mutating API는 mutation bucket으로 제한한다")
+    fun `mutating api uses mutation bucket`() {
+        val filter = createFilter(redis = InMemoryRedisKeyValuePort(), mutationLimitPerMinute = 1)
+
+        assertThat(runFilter(filter, "POST", "/post/api/v1/posts/1/hit").status).isEqualTo(HttpServletResponse.SC_OK)
+
+        val limited = runFilter(filter, "DELETE", "/post/api/v1/posts/1")
+
+        assertThat(limited.status).isEqualTo(429)
+        assertThat(limited.contentAsString).contains("mutation")
+    }
+
+    @Test
+    @DisplayName("context path가 있으면 제거한 API path로 bucket을 계산한다")
+    fun `context path is removed before bucket matching`() {
+        val filter = createFilter(redis = InMemoryRedisKeyValuePort(), publicReadLimitPerMinute = 1)
+
+        assertThat(
+            runFilter(
+                filter,
+                "GET",
+                "/ctx/post/api/v1/posts/feed",
+                contextPath = "/ctx",
+            ).status,
+        ).isEqualTo(HttpServletResponse.SC_OK)
+
+        val limited = runFilter(filter, "GET", "/ctx/post/api/v1/posts/feed", contextPath = "/ctx")
+
+        assertThat(limited.status).isEqualTo(429)
+    }
+
+    @Test
+    @DisplayName("Redis가 unavailable이면 non-prod에서는 fail-open으로 통과한다")
+    fun `non prod with unavailable redis fails open`() {
+        val filter =
+            createFilter(
+                redis = InMemoryRedisKeyValuePort(available = false),
+                requireRedisInProd = false,
+                publicReadLimitPerMinute = 1,
+            )
+
+        assertThat(runFilter(filter, "GET", "/post/api/v1/posts/feed").status).isEqualTo(HttpServletResponse.SC_OK)
+        assertThat(runFilter(filter, "GET", "/post/api/v1/posts/feed").status).isEqualTo(HttpServletResponse.SC_OK)
+    }
+
+    @Test
+    @DisplayName("Redis increment가 null이면 non-prod에서는 fail-open으로 통과한다")
+    fun `non prod with null redis increment fails open`() {
+        val filter =
+            createFilter(
+                redis = InMemoryRedisKeyValuePort(incrementAvailable = false),
+                requireRedisInProd = false,
+                publicReadLimitPerMinute = 1,
+            )
+
+        assertThat(runFilter(filter, "GET", "/post/api/v1/posts/feed").status).isEqualTo(HttpServletResponse.SC_OK)
+        assertThat(runFilter(filter, "GET", "/post/api/v1/posts/feed").status).isEqualTo(HttpServletResponse.SC_OK)
+    }
+
+    @Test
+    @DisplayName("Redis TTL 설정 실패는 non-prod에서 fail-open하고 카운터를 제거한다")
+    fun `non prod with redis ttl failure fails open and deletes counter`() {
+        val redis = InMemoryRedisKeyValuePort(expireAvailable = false)
+        val filter =
+            createFilter(
+                redis = redis,
+                requireRedisInProd = false,
+                publicReadLimitPerMinute = 1,
+            )
+
+        assertThat(runFilter(filter, "GET", "/post/api/v1/posts/feed").status).isEqualTo(HttpServletResponse.SC_OK)
+        assertThat(redis.keys("security:api-rate-limit:")).isEmpty()
+    }
+
+    @Test
+    @DisplayName("Redis bean이 없으면 non-prod에서는 fail-open으로 통과한다")
+    fun `non prod without redis bean fails open`() {
+        val filter =
+            createFilter(
+                redis = null,
+                requireRedisInProd = false,
+                publicReadLimitPerMinute = 1,
+            )
+
+        assertThat(runFilter(filter, "GET", "/post/api/v1/posts/feed").status).isEqualTo(HttpServletResponse.SC_OK)
+        assertThat(runFilter(filter, "GET", "/post/api/v1/posts/feed").status).isEqualTo(HttpServletResponse.SC_OK)
+    }
+
+    @Test
+    @DisplayName("prod에서 Redis bean이 없고 필수이면 fail-closed로 503을 반환한다")
+    fun `prod without redis bean fails closed`() {
+        val filter =
+            createFilter(
+                redis = null,
+                requireRedisInProd = true,
+                prodRuntime = true,
+            )
+
+        val response = runFilter(filter, "GET", "/post/api/v1/posts/feed")
+
+        assertThat(response.status).isEqualTo(HttpServletResponse.SC_SERVICE_UNAVAILABLE)
+        assertThat(response.contentAsString).contains("\"resultCode\":\"503-4\"")
+    }
+
+    @Test
+    @DisplayName("Redis increment가 null이고 prod이면 fail-closed로 503을 반환한다")
+    fun `prod with null redis increment fails closed`() {
+        val filter =
+            createFilter(
+                redis = InMemoryRedisKeyValuePort(incrementAvailable = false),
+                requireRedisInProd = true,
+                prodRuntime = true,
+            )
+
+        val response = runFilter(filter, "GET", "/post/api/v1/posts/feed")
+
+        assertThat(response.status).isEqualTo(HttpServletResponse.SC_SERVICE_UNAVAILABLE)
+        assertThat(response.contentAsString).contains("\"resultCode\":\"503-4\"")
+    }
+
+    @Test
+    @DisplayName("Redis TTL 설정 실패는 prod에서 fail-closed로 503을 반환한다")
+    fun `prod with redis ttl failure fails closed`() {
+        val filter =
+            createFilter(
+                redis = InMemoryRedisKeyValuePort(expireAvailable = false),
+                requireRedisInProd = true,
+                prodRuntime = true,
+            )
+
+        val response = runFilter(filter, "GET", "/post/api/v1/posts/feed")
+
+        assertThat(response.status).isEqualTo(HttpServletResponse.SC_SERVICE_UNAVAILABLE)
+        assertThat(response.contentAsString).contains("\"resultCode\":\"503-4\"")
+    }
+
+    @Test
+    @DisplayName("Redis가 필수인데 없으면 fail-closed로 503을 반환한다")
+    fun `required redis unavailable fails closed`() {
+        val filter =
+            createFilter(
+                redis = InMemoryRedisKeyValuePort(available = false),
+                requireRedisInProd = true,
+                prodRuntime = true,
+            )
+
+        val response = runFilter(filter, "POST", "/post/api/v1/posts/1/hit")
+
+        assertThat(response.status).isEqualTo(HttpServletResponse.SC_SERVICE_UNAVAILABLE)
+        assertThat(response.contentAsString).contains("\"resultCode\":\"503-4\"")
+    }
+
+    @Test
+    @DisplayName("clientIpResolver와 meterRegistry provider가 비어도 요청은 처리된다")
+    fun `empty optional providers fall back without metrics`() {
+        val redis = InMemoryRedisKeyValuePort()
+        val filter =
+            createFilter(
+                redis = redis,
+                clientIpResolver = null,
+                meterRegistry = null,
+                publicReadLimitPerMinute = 1,
+            )
+
+        assertThat(runFilter(filter, "GET", "/post/api/v1/posts/feed").status).isEqualTo(HttpServletResponse.SC_OK)
+
+        val limited = runFilter(filter, "GET", "/post/api/v1/posts/feed")
+
+        assertThat(limited.status).isEqualTo(429)
+        assertThat(redis.expiredKeys()).anyMatch { it.contains("public-read") }
+    }
+
+    private fun createFilter(
+        redis: RedisKeyValuePort?,
+        clientIpResolver: ClientIpResolver? = ClientIpResolver(),
+        meterRegistry: SimpleMeterRegistry? = SimpleMeterRegistry(),
+        enabled: Boolean = true,
+        requireRedisInProd: Boolean = false,
+        publicReadLimitPerMinute: Int = 120,
+        mutationLimitPerMinute: Int = 60,
+        authLimitPerMinute: Int = 20,
+        sseLimitPerMinute: Int = 30,
+        prodRuntime: Boolean = false,
+    ) = ApiRateLimitBackstopFilter(
+        redisKeyValuePortProvider = objectProvider(redis, RedisKeyValuePort::class.java),
+        clientIpResolverProvider = objectProvider(clientIpResolver, ClientIpResolver::class.java),
+        meterRegistryProvider = objectProvider(meterRegistry, MeterRegistry::class.java),
+        environment =
+            MockEnvironment().apply {
+                setActiveProfiles(if (prodRuntime) "prod" else "test")
+            },
+        enabled = enabled,
+        requireRedisInProd = requireRedisInProd,
+        publicReadLimitPerMinute = publicReadLimitPerMinute,
+        mutationLimitPerMinute = mutationLimitPerMinute,
+        authLimitPerMinute = authLimitPerMinute,
+        sseLimitPerMinute = sseLimitPerMinute,
+    )
+
+    private fun <T : Any> objectProvider(
+        value: T?,
+        type: Class<T>,
+    ): ObjectProvider<T> =
+        object : ObjectProvider<T> {
+            override fun getObject(): T = value ?: throw NoSuchBeanDefinitionException(type)
+
+            override fun getIfAvailable(): T? = value
+        }
+
+    private fun runFilter(
+        filter: ApiRateLimitBackstopFilter,
+        method: String,
+        path: String,
+        contextPath: String = "",
+    ): MockHttpServletResponse {
+        val request = MockHttpServletRequest(method, path)
+        request.contextPath = contextPath
+        request.remoteAddr = "172.19.0.2"
+        request.addHeader("CF-Connecting-IP", "203.0.113.10")
+        val response = MockHttpServletResponse()
+        val chain =
+            MockFilterChain(
+                object : HttpServlet() {
+                    override fun service(
+                        req: HttpServletRequest,
+                        res: HttpServletResponse,
+                    ) {
+                        res.status = HttpServletResponse.SC_OK
+                    }
+                },
+            )
+
+        filter.doFilter(request, response, chain)
+        return response
+    }
+
+    private class InMemoryRedisKeyValuePort(
+        private val available: Boolean = true,
+        private val incrementAvailable: Boolean = true,
+        private val expireAvailable: Boolean = true,
+    ) : RedisKeyValuePort {
+        private val values = ConcurrentHashMap<String, String>()
+        private val expirations = ConcurrentHashMap.newKeySet<String>()
+
+        override fun isAvailable(): Boolean = available
+
+        override fun get(key: String): String? = values[key]
+
+        override fun set(
+            key: String,
+            value: String,
+            ttl: Duration?,
+        ) {
+            values[key] = value
+            if (ttl != null) expirations += key
+        }
+
+        override fun increment(key: String): Long? {
+            if (!available || !incrementAvailable) return null
+            return values.compute(key) { _, current -> ((current?.toLongOrNull() ?: 0L) + 1L).toString() }?.toLong()
+        }
+
+        override fun expire(
+            key: String,
+            ttl: Duration,
+        ): Boolean {
+            if (!available || !expireAvailable) return false
+            expirations += key
+            return true
+        }
+
+        override fun delete(keys: Collection<String>): Long {
+            val removed = keys.count { values.remove(it) != null }
+            expirations.removeAll(keys.toSet())
+            return removed.toLong()
+        }
+
+        override fun keys(pattern: String): Set<String> = values.keys.filter { it.startsWith(pattern.removeSuffix("*")) }.toSet()
+
+        fun expiredKeys(): Set<String> = expirations.toSet()
+    }
+}

--- a/deploy/homeserver/HARDENING.md
+++ b/deploy/homeserver/HARDENING.md
@@ -10,6 +10,7 @@
 1. 현재 SSH 키 접속이 되는지 확인
 2. 서버 콘솔(물리 접근 또는 원격 콘솔) 준비
 3. GitHub `HOME_SSH_PORT` 변경 필요 여부 확인
+4. Cloudflare Tunnel public hostname이 API/Grafana/monitoring 도메인을 Caddy origin으로 라우팅하는지 확인
 
 ## 실행
 
@@ -25,7 +26,8 @@ sudo ./deploy/homeserver/hardening/setup_hardening.sh 22 <your_linux_user>
 
 - SSH: root 로그인 차단, 비밀번호 로그인 차단, 키 로그인만 허용
 - SSH: `AllowUsers <your_linux_user>` 제한
-- UFW: 인바운드 `SSH`, `80`, `443`만 허용
+- UFW: 인바운드 `SSH`만 허용하고, public `80/443` ingress는 열지 않음
+- HTTP(S): `cloudflared egress`가 Docker 네트워크의 Caddy로 접근하며, host `80/443`은 compose에서 loopback 바인딩으로만 노출
 - fail2ban: sshd 브루트포스 차단
 
 ## 변경 파일(서버)
@@ -39,6 +41,9 @@ sudo ./deploy/homeserver/hardening/setup_hardening.sh 22 <your_linux_user>
 sudo ufw status verbose
 sudo fail2ban-client status sshd
 sudo sshd -t
+docker compose --env-file deploy/homeserver/.env.prod -f deploy/homeserver/docker-compose.prod.yml ps caddy cloudflared
+ss -tulpen | grep -E '127\.0\.0\.1:(80|443)\b'
+curl -sS -o /dev/null -w '%{http_code}\n' https://<api_domain>/actuator/health
 ```
 
 ## 롤백

--- a/deploy/homeserver/docker-compose.prod.yml
+++ b/deploy/homeserver/docker-compose.prod.yml
@@ -138,6 +138,29 @@ services:
       retries: 5
       start_period: 20s
 
+  docker_runtime_probe:
+    image: node:20-alpine
+    restart: unless-stopped
+    working_dir: /app
+    command:
+      - "node"
+      - "/app/docker-runtime-probe.mjs"
+      - "--serve-port"
+      - "9920"
+      - "--project"
+      - "blog_home"
+      - "--services"
+      - "cloudflared,back_blue,back_green,back_read,back_admin,back_worker,redis_1"
+    volumes:
+      - ./monitoring/docker-runtime-probe.mjs:/app/docker-runtime-probe.mjs:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -T 3 -O /dev/null http://127.0.0.1:9920/healthz || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+
   back_blue:
     image: ${BACK_IMAGE:?BACK_IMAGE is required (sha-pinned; latest forbidden)}
     restart: unless-stopped

--- a/deploy/homeserver/docker-compose.prod.yml
+++ b/deploy/homeserver/docker-compose.prod.yml
@@ -24,8 +24,10 @@ services:
     restart: unless-stopped
     command: caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
     ports:
-      - "80:80"
-      - "443:443"
+      # Public ingress must terminate at Cloudflare Tunnel. Keep host binds on
+      # loopback only so direct internet traffic cannot bypass Cloudflare WAF/rate limits.
+      - "127.0.0.1:80:80"
+      - "127.0.0.1:443:443"
     volumes:
       - ./caddy:/etc/caddy:ro
       - caddy_data:/data

--- a/deploy/homeserver/hardening/setup_hardening.sh
+++ b/deploy/homeserver/hardening/setup_hardening.sh
@@ -43,8 +43,8 @@ ufw --force reset
 ufw default deny incoming
 ufw default allow outgoing
 ufw allow "${SSH_PORT}/tcp"
-ufw allow 80/tcp
-ufw allow 443/tcp
+# Cloudflare Tunnel is the public ingress. Do not open 80/443 on the host;
+# Caddy is bound to loopback and cloudflared reaches it through Docker networking.
 ufw --force enable
 
 echo "[4/6] Configure fail2ban"

--- a/deploy/homeserver/monitoring/docker-runtime-probe.mjs
+++ b/deploy/homeserver/monitoring/docker-runtime-probe.mjs
@@ -1,0 +1,142 @@
+import http from "node:http"
+
+const args = process.argv.slice(2)
+const optionValue = (name, fallback) => {
+  const index = args.indexOf(name)
+  if (index === -1 || index + 1 >= args.length) return fallback
+  return args[index + 1]
+}
+
+const servePort = Number(optionValue("--serve-port", "9920"))
+const composeProject = optionValue("--project", "blog_home")
+const services = optionValue(
+  "--services",
+  "cloudflared,back_blue,back_green,back_read,back_admin,back_worker,redis_1",
+)
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean)
+
+const dockerSocketPath = optionValue("--docker-socket", "/var/run/docker.sock")
+
+const escapeLabel = (value) => value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n")
+
+const metricLine = (name, labels, value) => {
+  const labelText = Object.entries(labels)
+    .map(([key, labelValue]) => `${key}="${escapeLabel(String(labelValue))}"`)
+    .join(",")
+  return `${name}{${labelText}} ${Number.isFinite(value) ? value : 0}`
+}
+
+const matchingContainerForService = (containers, service) =>
+  containers
+    .filter((candidate) => {
+      const labels = candidate.Labels || {}
+      return labels["com.docker.compose.project"] === composeProject && labels["com.docker.compose.service"] === service
+    })
+    .sort((left, right) => {
+      const leftRunning = String(left.State || "").toLowerCase() === "running" ? 1 : 0
+      const rightRunning = String(right.State || "").toLowerCase() === "running" ? 1 : 0
+      if (leftRunning !== rightRunning) return rightRunning - leftRunning
+      return (right.Created || 0) - (left.Created || 0)
+    })[0]
+
+const dockerGet = (path) =>
+  new Promise((resolve, reject) => {
+    const chunks = []
+
+    const request = http.request({ method: "GET", path, socketPath: dockerSocketPath, timeout: 5000 }, (response) => {
+      response.on("data", (chunk) => chunks.push(chunk))
+      response.on("end", () => {
+        const status = response.statusCode || 0
+        if (status < 200 || status >= 300) {
+          reject(new Error(`docker ${path} returned ${status}`))
+          return
+        }
+        const body = Buffer.concat(chunks).toString("utf8")
+        resolve(JSON.parse(body || "null"))
+      })
+    })
+
+    request.on("timeout", () => {
+      request.destroy(new Error(`docker request timed out: ${path}`))
+    })
+    request.on("error", reject)
+    request.end()
+  })
+
+const collectServiceMetrics = async (containers, service) => {
+  const container = matchingContainerForService(containers, service)
+
+  if (!container) {
+    return [
+      metricLine("docker_container_restart_count", { service }, 0),
+      metricLine("docker_container_running", { service }, 0),
+      metricLine("docker_container_memory_usage_bytes", { service }, 0),
+      metricLine("docker_container_memory_limit_bytes", { service }, 0),
+    ]
+  }
+
+  const inspect = await dockerGet(`/containers/${container.Id}/json`)
+  const stats = inspect.State?.Running ? await dockerGet(`/containers/${container.Id}/stats?stream=false`) : null
+  const memoryUsage = stats?.memory_stats?.usage || 0
+  const memoryLimit = stats?.memory_stats?.limit || 0
+  const restartCount = inspect.RestartCount || 0
+
+  return [
+    metricLine("docker_container_restart_count", { service }, restartCount),
+    metricLine("docker_container_running", { service }, inspect.State?.Running ? 1 : 0),
+    metricLine("docker_container_memory_usage_bytes", { service }, memoryUsage),
+    metricLine("docker_container_memory_limit_bytes", { service }, memoryLimit),
+  ]
+}
+
+const collectMetrics = async () => {
+  const containers = await dockerGet("/containers/json?all=1")
+  const lines = [
+    "# HELP docker_runtime_probe_up Docker runtime probe success.",
+    "# TYPE docker_runtime_probe_up gauge",
+    "docker_runtime_probe_up 1",
+    "# HELP docker_container_restart_count Docker restart count by compose service.",
+    "# TYPE docker_container_restart_count gauge",
+    "# HELP docker_container_running Docker running state by compose service.",
+    "# TYPE docker_container_running gauge",
+    "# HELP docker_container_memory_usage_bytes Docker container memory usage by compose service.",
+    "# TYPE docker_container_memory_usage_bytes gauge",
+    "# HELP docker_container_memory_limit_bytes Docker container memory limit by compose service.",
+    "# TYPE docker_container_memory_limit_bytes gauge",
+  ]
+
+  const serviceMetricLines = await Promise.all(services.map((service) => collectServiceMetrics(containers, service)))
+  lines.push(...serviceMetricLines.flat())
+
+  return `${lines.join("\n")}\n`
+}
+
+const server = http.createServer(async (request, response) => {
+  if (request.url === "/healthz") {
+    response.writeHead(200, { "content-type": "text/plain; charset=utf-8" })
+    response.end("ok\n")
+    return
+  }
+
+  if (request.url !== "/metrics") {
+    response.writeHead(404, { "content-type": "text/plain; charset=utf-8" })
+    response.end("not found\n")
+    return
+  }
+
+  try {
+    const metrics = await collectMetrics()
+    response.writeHead(200, { "content-type": "text/plain; version=0.0.4; charset=utf-8" })
+    response.end(metrics)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    response.writeHead(200, { "content-type": "text/plain; version=0.0.4; charset=utf-8" })
+    response.end(`docker_runtime_probe_up 0\ndocker_runtime_probe_error{message="${escapeLabel(message).slice(0, 160)}"} 1\n`)
+  }
+})
+
+server.listen(servePort, "0.0.0.0", () => {
+  console.log(`docker-runtime-probe listening on :${servePort}`)
+})

--- a/deploy/homeserver/monitoring/prometheus.yml
+++ b/deploy/homeserver/monitoring/prometheus.yml
@@ -41,3 +41,11 @@ scrape_configs:
       - targets: ["public_edge_probe:9915"]
         labels:
           service: aquila-public-edge-probe
+
+  - job_name: docker_runtime_probe
+    honor_labels: true
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["docker_runtime_probe:9920"]
+        labels:
+          service: aquila-docker-runtime-probe

--- a/deploy/homeserver/monitoring/rules/task-alerts.yml
+++ b/deploy/homeserver/monitoring/rules/task-alerts.yml
@@ -199,6 +199,132 @@ groups:
           summary: "Search index async sync lag p95 is high"
           description: "post.search_index.task.lag p95 > 120s for 10m."
 
+  - name: aquila-ddos-defense
+    rules:
+      - alert: AquilaDockerRuntimeProbeScrapeDown
+        expr: min(up{job="docker_runtime_probe",service="aquila-docker-runtime-probe"}) < 1
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "docker runtime probe scrape is down"
+          description: "Prometheus cannot scrape docker_runtime_probe for 3m. Check probe container health and docker socket access."
+
+      - alert: AquilaApiRateLimitRejectedHigh
+        expr: sum(rate(api_rate_limit_rejected_total{job="back",service="aquila-back"}[5m])) > 0.5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "API rate-limit rejections are high"
+          description: "Backend Redis rate-limit backstop is rejecting more than 0.5 req/s for 5m. Check Cloudflare WAF/rate limit events and attack source distribution."
+
+      - alert: AquilaApi429RatioHigh
+        expr: |
+          (
+            sum(rate({__name__=~"http_server_requests_seconds_count|http_server_request_duration_seconds_count",job="back",service="aquila-back",status="429"}[5m]))
+            /
+            clamp_min(
+              sum(rate({__name__=~"http_server_requests_seconds_count|http_server_request_duration_seconds_count",job="back",service="aquila-back"}[5m])),
+              0.001
+            )
+          ) > 0.10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "API 429 ratio is high"
+          description: "More than 10% of backend API responses are 429 for 5m. Verify Cloudflare edge limits and backend Redis backstop thresholds."
+
+      - alert: AquilaPublicReadRpsHigh
+        expr: |
+          sum(
+            rate(
+              {__name__=~"http_server_requests_seconds_count|http_server_request_duration_seconds_count",job="back",service="aquila-back",uri=~"/post/api/v1/posts(/feed|/feed/cursor|/explore|/explore/cursor|/search|/tags|/[0-9]+)?"}[5m]
+            )
+          ) > 50
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Public read API RPS is high"
+          description: "Public read endpoints exceeded 50 req/s for 10m. Check Cloudflare Security Events and edge cache hit behavior."
+
+      - alert: AquilaApiOrigin5xxRatioHigh
+        expr: |
+          (
+            sum(rate({__name__=~"http_server_requests_seconds_count|http_server_request_duration_seconds_count",job="back",service="aquila-back",status=~"5.."}[5m]))
+            /
+            clamp_min(
+              sum(rate({__name__=~"http_server_requests_seconds_count|http_server_request_duration_seconds_count",job="back",service="aquila-back"}[5m])),
+              0.001
+            )
+          ) > 0.02
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "API origin 5xx ratio is high"
+          description: "Backend 5xx ratio exceeded 2% for 5m. Check whether DDoS pressure reached origin and consider Cloudflare emergency rules."
+
+      - alert: AquilaApiP99LatencyHigh
+        expr: |
+          (
+            histogram_quantile(
+              0.99,
+              sum by (le) (
+                rate({__name__=~"http_server_requests_seconds_bucket|http_server_request_duration_seconds_bucket",job="back",service="aquila-back",uri!~"/actuator.*"}[5m])
+              )
+            )
+            and on() (
+              sum(rate({__name__=~"http_server_requests_seconds_count|http_server_request_duration_seconds_count",job="back",service="aquila-back",uri!~"/actuator.*"}[5m])) > bool 0.2
+            )
+          ) > 2
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "API p99 latency is high"
+          description: "API p99 latency stayed above 2s for 10m. Check origin saturation, Redis latency, and Cloudflare edge mitigation."
+
+      - alert: AquilaCloudflaredRestartCountHigh
+        expr: increase(docker_container_restart_count{job="docker_runtime_probe",service="cloudflared"}[15m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "cloudflared restarted recently"
+          description: "cloudflared restart_count increased in the last 15m. Check Tunnel health, Cloudflare edge connectivity, and host pressure."
+
+      - alert: AquilaBackendContainerMemoryHigh
+        expr: |
+          (
+            docker_container_memory_usage_bytes{job="docker_runtime_probe",service=~"back_.+"}
+            /
+            clamp_min(docker_container_memory_limit_bytes{job="docker_runtime_probe",service=~"back_.+"}, 1)
+          ) > 0.85
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Backend container memory usage is high"
+          description: "A backend container is using more than 85% of its Docker memory limit for 10m. Check DDoS pressure and runtime split sizing."
+
+      - alert: AquilaRedisCommandLatencyHigh
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (
+              rate({__name__=~"redis_commands_duration_seconds_bucket|lettuce_command_completion_seconds_bucket|lettuce_command_duration_seconds_bucket",job="back",service="aquila-back"}[5m])
+            )
+          ) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Redis command latency is high"
+          description: "redis command latency p95 exceeded 50ms for 10m. Check API rate-limit pressure and Redis saturation."
+
   - name: aquila-notification-sse
     rules:
       - alert: AquilaNotificationSseEmitterSaturated

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -12,6 +12,8 @@ const applicationProdPath = path.join(repoRoot, "back/src/main/resources/applica
 const deployScriptPath = path.join(repoRoot, "deploy/homeserver/blue_green_deploy.sh")
 const hardeningScriptPath = path.join(repoRoot, "deploy/homeserver/hardening/setup_hardening.sh")
 const hardeningDocPath = path.join(repoRoot, "deploy/homeserver/HARDENING.md")
+const prometheusPath = path.join(repoRoot, "deploy/homeserver/monitoring/prometheus.yml")
+const taskAlertsPath = path.join(repoRoot, "deploy/homeserver/monitoring/rules/task-alerts.yml")
 
 const targetKeyNames = (contract, targetName) => {
   const target = contract.targets[targetName]
@@ -202,4 +204,24 @@ test("homeserver origin ingress is private behind Cloudflare Tunnel", () => {
   assert.match(hardeningScript, /Cloudflare Tunnel/)
   assert.match(hardeningDoc, /cloudflared egress/)
   assert.match(hardeningDoc, /80\/443.*loopback/)
+})
+
+test("ddos defense monitoring covers rate limit, docker runtime, redis, and memory pressure", () => {
+  const compose = readFileSync(composePath, "utf8")
+  const prometheus = readFileSync(prometheusPath, "utf8")
+  const taskAlerts = readFileSync(taskAlertsPath, "utf8")
+
+  assert.match(compose, /docker_runtime_probe:/)
+  assert.match(compose, /monitoring\/docker-runtime-probe\.mjs:\/app\/docker-runtime-probe\.mjs:ro/)
+  assert.match(compose, /\/var\/run\/docker\.sock:\/var\/run\/docker\.sock:ro/)
+  assert.match(prometheus, /job_name: docker_runtime_probe/)
+  assert.match(prometheus, /honor_labels:\s*true/)
+  assert.match(prometheus, /docker_runtime_probe:9920/)
+
+  assert.match(taskAlerts, /api_rate_limit_rejected_total/)
+  assert.match(taskAlerts, /status="429"/)
+  assert.match(taskAlerts, /AquilaDockerRuntimeProbeScrapeDown/)
+  assert.match(taskAlerts, /docker_container_restart_count\{[^}]*service="cloudflared"/)
+  assert.match(taskAlerts, /docker_container_memory_usage_bytes\{[^}]*service=~"back_.+"/)
+  assert.match(taskAlerts, /redis.*latency|lettuce.*duration|redis_commands_duration_seconds/i)
 })

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -10,6 +10,8 @@ const workflowPath = path.join(repoRoot, ".github/workflows/deploy.yml")
 const composePath = path.join(repoRoot, "deploy/homeserver/docker-compose.prod.yml")
 const applicationProdPath = path.join(repoRoot, "back/src/main/resources/application-prod.yaml")
 const deployScriptPath = path.join(repoRoot, "deploy/homeserver/blue_green_deploy.sh")
+const hardeningScriptPath = path.join(repoRoot, "deploy/homeserver/hardening/setup_hardening.sh")
+const hardeningDocPath = path.join(repoRoot, "deploy/homeserver/HARDENING.md")
 
 const targetKeyNames = (contract, targetName) => {
   const target = contract.targets[targetName]
@@ -183,4 +185,21 @@ test("prod datasource uses a non-superuser runtime role contract", () => {
   assert(!deployScript.includes("ALTER ROLE"))
   assert(!deployScript.includes("OWNER TO"))
   assert(!deployScript.includes("GRANT SELECT"))
+})
+
+test("homeserver origin ingress is private behind Cloudflare Tunnel", () => {
+  const compose = readFileSync(composePath, "utf8")
+  const hardeningScript = readFileSync(hardeningScriptPath, "utf8")
+  const hardeningDoc = readFileSync(hardeningDocPath, "utf8")
+
+  assert(!/^\s*-\s*['"]?80:80['"]?\s*$/m.test(compose))
+  assert(!/^\s*-\s*['"]?443:443['"]?\s*$/m.test(compose))
+  assert.match(compose, /^\s*-\s*['"]?127\.0\.0\.1:80:80['"]?\s*$/m)
+  assert.match(compose, /^\s*-\s*['"]?127\.0\.0\.1:443:443['"]?\s*$/m)
+
+  assert(!hardeningScript.includes("ufw allow 80/tcp"))
+  assert(!hardeningScript.includes("ufw allow 443/tcp"))
+  assert.match(hardeningScript, /Cloudflare Tunnel/)
+  assert.match(hardeningDoc, /cloudflared egress/)
+  assert.match(hardeningDoc, /80\/443.*loopback/)
 })


### PR DESCRIPTION
## 관련 이슈

close #501

## 작업 배경

- 홈서버 API 진입 경로를 Cloudflare Tunnel 중심으로 고정하고, origin 공개 포트와 UFW public 80/443 ingress를 닫는 운영 계약을 반영했습니다.
- Spring 요청 초기에 Redis 기반 API rate-limit backstop을 추가하고, DDoS 상황에서 볼 429/RPS/5xx/latency/cloudflared restart/Redis latency/backend memory 알림을 추가했습니다.

## 작업 내용

- Caddy host 80/443 바인딩을 loopback으로 축소하고, homeserver hardening 문서와 UFW 스크립트에서 public 80/443 허용을 제거했습니다.
- public read/auth/SSE/mutating API bucket별 Redis fixed-window rate limit과 429/503 응답, Micrometer counter를 추가했습니다.
- Docker runtime probe를 추가해 cloudflared restart_count와 backend container memory를 Prometheus에서 수집하고 DDoS 관련 alert group을 추가했습니다.
- env-contract 테스트로 origin 비공개화와 DDoS 관측 계약이 회귀하지 않도록 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back test --tests com.back.global.security.config.ApiRateLimitBackstopFilterTest`
  - `./back/gradlew -p back test --tests com.back.global.security.config.ApiRateLimitBackstopFilterTest --tests com.back.boundedContexts.member.adapter.web.ApiV1AdmMemberControllerWebMvcTest`
  - `./back/gradlew -p back ktlintCheck`
  - `./back/gradlew -p back ciFastCheck --rerun-tasks`
  - `./back/gradlew -p back test`
  - `./back/gradlew -p back test --rerun-tasks`
  - `node --check deploy/homeserver/monitoring/docker-runtime-probe.mjs`
  - `node --test tools/test/env-contract.test.mjs`
  - `bash tools/test/verify-deploy-workflow-classification.sh`
  - `node tools/env/validate-env.mjs --target home-server-runtime --file deploy/homeserver/.env.prod` 실행 결과: 로컬 secret 파일 부재로 `ENOENT: deploy/homeserver/.env.prod`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: rate-limit threshold가 실제 트래픽보다 낮으면 일부 API에서 429가 늘 수 있습니다. Cloudflare edge rule과 backend property 값을 함께 조정해야 합니다.
- 롤백 방법: 이 PR revert 후 homeserver compose를 재배포합니다. 긴급 완화는 `custom.security.apiRateLimit.enabled=false`로 backend backstop을 비활성화할 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
