### PR TITLE
[Fix] SSR 초기 글 hydrate 복구

### DIFF
--- a/front/e2e/editor-authoring-ssr-initial-post.spec.ts
+++ b/front/e2e/editor-authoring-ssr-initial-post.spec.ts
@@ -1,0 +1,129 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { expect, test } from "@playwright/test"
+
+const adminMember = {
+  id: 1,
+  username: "qa-admin",
+  nickname: "aquila",
+  isAdmin: true,
+}
+
+test.describe("editor authoring SSR initial post contract", () => {
+  test("전용 글 수정 라우트는 SSR 초기 글 스냅샷으로 client auth fetch 실패와 분리한다", () => {
+    const editorPageSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/EditorStudioPage.tsx"),
+      "utf8"
+    )
+    const editorRootSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx"),
+      "utf8"
+    )
+    const routingSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/useEditorStudioRouting.ts"),
+      "utf8"
+    )
+    const draftLifecycleSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/useEditorStudioDraftLifecycle.ts"),
+      "utf8"
+    )
+
+    expect(editorPageSource).toContain("initialEditorPost")
+    expect(editorPageSource).toContain("serverApiFetch(req, `/post/api/v1/adm/posts/${postId}`")
+    expect(editorRootSource).toContain("initialEditorPost = null")
+    expect(routingSource).toContain("void loadPostForEditor(queryPostId, { initialPost })")
+    expect(draftLifecycleSource).toContain("options.initialPost")
+    expect(draftLifecycleSource).toContain("initialPost ??")
+  })
+
+  test("SSR initialEditorPost가 있으면 client admin post 401에도 에디터 본문을 유지한다", async ({
+    page,
+  }) => {
+    const initialContent = [
+      "---",
+      'tags: ["SSR", "Hydrate"]',
+      "---",
+      "",
+      "## SSR 초기 본문",
+      "",
+      "| 영역 | 점검 항목 |",
+      "| --- | --- |",
+      "| hydrate | initialEditorPost 유지 |",
+      "",
+      "client admin fetch가 실패해도 이 문단이 남아야 합니다.",
+    ].join("\n")
+    let clientPostFetchCount = 0
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/997", async (route) => {
+      clientPostFetchCount += 1
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "로그인이 필요합니다." }),
+      })
+    })
+    await page.route("**/_next/data/**/editor/997.json**", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          pageProps: {
+            dehydratedState: {
+              mutations: [],
+              queries: [],
+            },
+            initialMember: adminMember,
+            initialEditorPost: {
+              id: 997,
+              version: 3,
+              title: "SSR 초기 hydrate 글",
+              content: initialContent,
+              contentHtml: null,
+              published: true,
+              listed: true,
+            },
+          },
+          __N_SSP: true,
+        }),
+      })
+    })
+
+    await page.goto("/", { waitUntil: "domcontentloaded" })
+    await expect
+      .poll(async () => {
+        try {
+          return await page.evaluate(() => {
+            const router = (
+              window as typeof window & {
+                next?: { router?: { push?: (url: string) => Promise<boolean>; isReady?: boolean } }
+              }
+            ).next?.router
+            return Boolean(router?.push && router.isReady !== false)
+          })
+        } catch {
+          return false
+        }
+      })
+      .toBe(true)
+    await page.evaluate(() => {
+      const router = (window as typeof window & { next?: { router?: { push?: (url: string) => Promise<boolean> } } })
+        .next?.router
+      if (!router?.push) throw new Error("Next router is missing")
+      window.setTimeout(() => {
+        void router.push("/editor/997")
+      }, 0)
+    })
+
+    await expect(page).toHaveURL(/\/editor\/997/)
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("SSR 초기 hydrate 글")
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expect(editor).toContainText("SSR 초기 본문")
+    await expect(editor.locator("td", { hasText: "initialEditorPost 유지" }).first()).toBeVisible()
+    expect(clientPostFetchCount).toBe(0)
+  })
+})

--- a/front/src/pages/editor/[id].tsx
+++ b/front/src/pages/editor/[id].tsx
@@ -1,9 +1,12 @@
 import { NextPage } from "next"
-import { AdminPageProps } from "src/libs/server/adminPage"
-import { EditorStudioPage, getEditorStudioPageProps } from "src/routes/Admin/EditorStudioPage"
+import {
+  EditorStudioPage,
+  getEditorStudioPageProps,
+  type EditorStudioPageProps,
+} from "src/routes/Admin/EditorStudioPage"
 
 export const getServerSideProps = getEditorStudioPageProps
 
-const EditorPostPage: NextPage<AdminPageProps> = (props) => <EditorStudioPage {...props} />
+const EditorPostPage: NextPage<EditorStudioPageProps> = (props) => <EditorStudioPage {...props} />
 
 export default EditorPostPage

--- a/front/src/routes/Admin/EditorStudioPage.tsx
+++ b/front/src/routes/Admin/EditorStudioPage.tsx
@@ -6,11 +6,67 @@ import {
   readAdminProtectedBootstrap,
   type AdminPageProps,
 } from "src/libs/server/adminPage"
+import { serverApiFetch } from "src/libs/server/backend"
+import type { PostForEditor } from "./EditorStudioWorkspaceControllerRootModel"
 import { EditorStudioWorkspaceController } from "./EditorStudioWorkspaceController"
 
 const EDITOR_NEW_ROUTE_PATH = "/editor/new"
 
-export const getEditorStudioPageProps: GetServerSideProps<AdminPageProps> = async ({ req }) => {
+export type EditorStudioPageProps = AdminPageProps & {
+  initialEditorPost?: PostForEditor | null
+}
+
+const parseEditorPostId = (value: unknown) => {
+  if (typeof value !== "string") return ""
+  const normalized = value.trim()
+  return /^\d+$/.test(normalized) ? normalized : ""
+}
+
+const toRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === "object" ? (value as Record<string, unknown>) : null
+
+const normalizeInitialEditorPost = (payload: unknown): PostForEditor | null => {
+  const root = toRecord(payload)
+  const candidate = toRecord(root?.data) ?? root
+  if (!candidate) return null
+
+  const rawId = candidate.id
+  const id = typeof rawId === "number" ? rawId : typeof rawId === "string" ? Number.parseInt(rawId, 10) : NaN
+  if (!Number.isInteger(id) || id <= 0) return null
+
+  const rawVersion = candidate.version
+  const version =
+    typeof rawVersion === "number" && Number.isFinite(rawVersion) ? rawVersion : undefined
+  const contentHtml = typeof candidate.contentHtml === "string" ? candidate.contentHtml : undefined
+
+  return {
+    id,
+    title: typeof candidate.title === "string" ? candidate.title : "",
+    content: typeof candidate.content === "string" ? candidate.content : "",
+    ...(contentHtml === undefined ? {} : { contentHtml }),
+    ...(version === undefined ? {} : { version }),
+    published: candidate.published === true,
+    listed: candidate.listed === true,
+    ...(candidate.tempDraft === undefined ? {} : { tempDraft: candidate.tempDraft === true }),
+  }
+}
+
+const fetchInitialEditorPost = async (req: Parameters<GetServerSideProps>[0]["req"], postId: string) => {
+  if (!postId) return null
+
+  try {
+    const response = await serverApiFetch(req, `/post/api/v1/adm/posts/${postId}`, {
+      cache: "no-store",
+      timeoutMs: 6_000,
+    })
+    if (!response.ok) return null
+    return normalizeInitialEditorPost(await response.json())
+  } catch {
+    return null
+  }
+}
+
+export const getEditorStudioPageProps: GetServerSideProps<EditorStudioPageProps> = async ({ req, query }) => {
   const bootstrapResult = await readAdminProtectedBootstrap<{
     member: AuthMember
     profile: Partial<AuthMember>
@@ -43,8 +99,14 @@ export const getEditorStudioPageProps: GetServerSideProps<AdminPageProps> = asyn
         profile.homeIntroDescription || member.homeIntroDescription || "",
     }
 
+    const initialEditorPost = await fetchInitialEditorPost(req, parseEditorPostId(query.id))
+    const baseProps = buildAdminPagePropsFromMember(mergedMember)
+
     return {
-      props: buildAdminPagePropsFromMember(mergedMember),
+      props: {
+        ...baseProps,
+        initialEditorPost,
+      },
     }
   }
 
@@ -60,7 +122,7 @@ export const getEditorStudioPageProps: GetServerSideProps<AdminPageProps> = asyn
   return await getAdminPageProps(req)
 }
 
-export const EditorStudioPage: NextPage<AdminPageProps> = (props) => (
+export const EditorStudioPage: NextPage<EditorStudioPageProps> = (props) => (
   <EditorStudioWorkspaceController {...props} />
 )
 

--- a/front/src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx
+++ b/front/src/routes/Admin/EditorStudioWorkspaceControllerRoot.tsx
@@ -99,7 +99,14 @@ import {
   type StudioSurface,
 } from "./EditorStudioWorkspaceControllerRootModel"
 
-export const EditorStudioWorkspaceController = ({ initialMember }: AdminPageProps) => {
+type EditorStudioWorkspaceControllerProps = AdminPageProps & {
+  initialEditorPost?: PostForEditor | null
+}
+
+export const EditorStudioWorkspaceController = ({
+  initialEditorPost = null,
+  initialMember,
+}: EditorStudioWorkspaceControllerProps) => {
   const router = useRouter()
   const queryClient = useQueryClient()
   const { me, authStatus, setMe } = useAuthSession()
@@ -692,6 +699,7 @@ export const EditorStudioWorkspaceController = ({ initialMember }: AdminPageProp
     router,
     authStatus,
     sessionMember,
+    initialEditorPost,
     postId,
     isDedicatedEditorRoute,
     isDedicatedNewEditorRoute,

--- a/front/src/routes/Admin/useEditorStudioDraftLifecycle.ts
+++ b/front/src/routes/Admin/useEditorStudioDraftLifecycle.ts
@@ -74,6 +74,10 @@ type RsData<T> = {
   msg: string
 }
 
+type LoadPostForEditorOptions = {
+  initialPost?: PostForEditor | null
+}
+
 type EditorFingerprintPayload = {
   title: string
   content: string
@@ -342,10 +346,20 @@ export const useEditorStudioDraftLifecycle = ({
     setPostVersion,
   ])
 
-  const loadPostForEditor = useCallback(async (targetPostId: string = postId) => {
+  const loadPostForEditor = useCallback(async (
+    targetPostId: string = postId,
+    options: LoadPostForEditorOptions = {}
+  ) => {
     try {
       setLoadingKey("postOne")
-      const post = await apiFetch<PostForEditor>(`/post/api/v1/adm/posts/${targetPostId}`)
+      const normalizedTargetPostId = targetPostId.trim()
+      const initialPost =
+        String(options.initialPost?.id ?? "") === normalizedTargetPostId
+          ? options.initialPost
+          : null
+      const post =
+        initialPost ??
+        (await apiFetch<PostForEditor>(`/post/api/v1/adm/posts/${normalizedTargetPostId}`))
       let resolvedPost = post
 
       const adminContent = resolvedPost.content ?? ""

--- a/front/src/routes/Admin/useEditorStudioRouting.ts
+++ b/front/src/routes/Admin/useEditorStudioRouting.ts
@@ -13,6 +13,7 @@ import {
   replaceShallowRoutePreservingScroll,
   toLoginPath,
 } from "src/libs/router"
+import type { PostForEditor } from "./EditorStudioWorkspaceControllerRootModel"
 
 type StudioSetState<T> = Dispatch<SetStateAction<T>>
 
@@ -24,6 +25,7 @@ type UseEditorStudioRoutingParams = {
   router: NextRouter
   authStatus: string
   sessionMember: SessionMember | null
+  initialEditorPost?: PostForEditor | null
   postId: string
   isDedicatedEditorRoute: boolean
   isDedicatedNewEditorRoute: boolean
@@ -39,7 +41,10 @@ type UseEditorStudioRoutingParams = {
   autoLoadedPostIdRef: MutableRefObject<string | null>
   autoCreatedTempDraftRef: MutableRefObject<boolean>
   restoreLocalDraft: () => void
-  loadPostForEditor: (targetPostId?: string) => Promise<void>
+  loadPostForEditor: (
+    targetPostId?: string,
+    options?: { initialPost?: PostForEditor | null }
+  ) => Promise<void>
   handleLoadOrCreateTempPost: (options?: {
     redirectToEditor?: boolean
     source?: string
@@ -54,6 +59,7 @@ export const useEditorStudioRouting = ({
   autoLoadedPostIdRef,
   editorNewRoutePath,
   handleLoadOrCreateTempPost,
+  initialEditorPost,
   isDedicatedEditorRoute,
   isDedicatedNewEditorRoute,
   loadPostForEditor,
@@ -130,8 +136,17 @@ export const useEditorStudioRouting = ({
 
     autoLoadedPostIdRef.current = queryPostId
     setPostId(queryPostId)
-    void loadPostForEditor(queryPostId)
-  }, [autoLoadedPostIdRef, loadPostForEditor, router.isReady, router.query.id, router.query.postId, setPostId])
+    const initialPost = String(initialEditorPost?.id ?? "") === queryPostId ? initialEditorPost : null
+    void loadPostForEditor(queryPostId, { initialPost })
+  }, [
+    autoLoadedPostIdRef,
+    initialEditorPost,
+    loadPostForEditor,
+    router.isReady,
+    router.query.id,
+    router.query.postId,
+    setPostId,
+  ])
 
   useEffect(() => {
     if (!router.isReady) return


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 최신 배포본 `/editor/507` 새 탭이 SSR 관리자 shell은 보이지만 client admin post fetch 401로 빈 작성 화면에 머무는 회귀를 복구합니다.
- `/editor/[id]` SSR에서 관리자 요청으로 초기 글 스냅샷을 주입하고, client fetch가 실패해도 최초 edit state가 저장된 글로 hydrate되게 했습니다.

## 작업 내용

- `getEditorStudioPageProps`가 numeric editor id에 대해 `/post/api/v1/adm/posts/{id}` 서버 스냅샷을 내려줍니다.
- editor routing/draft lifecycle이 `initialEditorPost`를 같은 id의 최초 로드에 우선 사용합니다.
- client auth fetch 실패와 SSR 초기 글 hydrate가 다시 결합되지 않도록 source 계약 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e e2e/editor-authoring-ssr-initial-post.spec.ts --workers=1` (2 passed; includes runtime 401 guard)
  - `yarn --cwd front test:e2e e2e/editor-authoring-ssr-initial-post.spec.ts e2e/editor-authoring-route-live-drag-sequence.spec.ts --grep "SSR initial|live 507" --workers=1` (3 passed)
  - `yarn --cwd front build`
  - `yarn --cwd front test:e2e:authoring` (100 passed, review 반영 후 1회차)
  - `yarn --cwd front test:e2e:authoring` (100 passed, review 반영 후 2회차)
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `git diff --check`
  - `bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: `/editor/[id]` SSR이 admin post read를 1회 추가 수행하므로 editor hard-load latency가 약간 늘 수 있습니다. 실패 시 기존 client fetch 경로로 fallback합니다.
- 롤백 방법: 이 PR을 revert하면 editor 초기 로드는 기존 client fetch 전용 경로로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
