### PR TITLE
[Fix] table multi-cell text 선택 복구

### DIFF
--- a/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
+++ b/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
@@ -1,0 +1,233 @@
+import { expect, test, type Locator, type Page } from "@playwright/test"
+import { expectEditorToContainLoadedText } from "./helpers/editorAuthoringFlow"
+
+const adminMember = {
+  id: 1,
+  username: "qa-admin",
+  nickname: "aquila",
+  isAdmin: true,
+}
+
+const readScrollTop = (page: Page) =>
+  page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+
+const readSelectionText = (page: Page) =>
+  page.evaluate(
+    () =>
+      window.getSelection()?.toString() ||
+      document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text") ||
+      ""
+  )
+
+const filler = (label: string, count: number) =>
+  Array.from({ length: count }, (_, index) => [
+    `${label} ${index + 1}: 인증 흐름을 설명하는 긴 문단입니다.`,
+    "",
+  ]).flat()
+
+const dragBetweenTextRanges = async (
+  page: Page,
+  startTarget: Locator,
+  endTarget: Locator,
+  label: string,
+  texts: { end: string; start: string }
+) => {
+  await startTarget.scrollIntoViewIfNeeded()
+  await endTarget.waitFor({ state: "attached", timeout: 5_000 })
+  const metrics = await startTarget.evaluate(
+    (startElement, { endText, label, startText }) => {
+      const table = startElement.closest("table")
+      const endElement = Array.from(table?.querySelectorAll("th, td") ?? []).find((candidate) =>
+        candidate.textContent?.replace(/\s+/g, " ").trim().includes(endText)
+      )
+      if (!endElement) throw new Error(`${label} end cell is missing`)
+      table?.scrollIntoView({ block: "center", inline: "nearest", behavior: "instant" })
+
+      const measureText = (element: Element, textToSelect: string, edge: "end" | "start") => {
+        const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+        while (walker.nextNode()) {
+          const textNode = walker.currentNode as Text
+          const startOffset = textNode.data.indexOf(textToSelect)
+          if (startOffset < 0) continue
+
+          const range = document.createRange()
+          range.setStart(textNode, startOffset)
+          range.setEnd(textNode, startOffset + textToSelect.length)
+          const rect =
+            Array.from(range.getClientRects()).find(
+              (candidate) => candidate.width > 2 && candidate.height > 2
+            ) ?? range.getBoundingClientRect()
+          if (rect.width <= 2 || rect.height <= 2) {
+            throw new Error(`${label} ${edge} text rect is too small`)
+          }
+          return {
+            x: edge === "start" ? rect.left + 2 : rect.right - 2,
+            y: rect.top + rect.height / 2,
+          }
+        }
+        throw new Error(`${label} ${edge} text node is missing`)
+      }
+
+      return {
+        end: measureText(endElement, endText, "end"),
+        start: measureText(startElement, startText, "start"),
+      }
+    },
+    { endText: texts.end, label, startText: texts.start }
+  )
+  const beforeScrollTop = await readScrollTop(page)
+
+  await page.mouse.move(metrics.start.x, metrics.start.y)
+  await page.mouse.down()
+  await page.mouse.move(metrics.end.x, metrics.end.y, { steps: 36 })
+  await page.mouse.up()
+  await page.waitForTimeout(1_000)
+
+  return { beforeScrollTop, afterScrollTop: await readScrollTop(page), selectionText: await readSelectionText(page) }
+}
+
+test("live 507 형태의 table multi-cell drag는 여러 셀 텍스트를 연속 선택한다", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1580, height: 900 })
+
+  const live507TableContent = [
+    "---",
+    'tags: ["Stateless", "인증", "JWT", "Refresh Token"]',
+    "---",
+    "",
+    "## 시작하며",
+    "",
+    ...filler("table 이전 본문", 96),
+    "",
+    '<!-- aq-table {"overflowMode":"normal","columnWidths":[119,192,210]} -->',
+    "| **영역** | **점검 항목** | **확인 기준** |",
+    "| --- | --- | --- |",
+    "| 개념 이해 | Stateless 의미 | 요청만으로 처리 가능한가 |",
+    "| 토큰 구조 | Access/Refresh 구분 | 역할 명확 |",
+    "| 보안 | HTTPS 사용 | 필수 |",
+    "| 저장소 | Refresh 저장 | DB/Redis |",
+    "| 만료 | Access 짧게 | 15~60분 |",
+    "| 흐름 | 재발급 로직 | 구현되어 있는가 |",
+    "",
+    ...filler("table 이후 본문", 12),
+  ].join("\n")
+
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(adminMember),
+    })
+  })
+  await page.route("**/post/api/v1/adm/posts/999", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: 999,
+        version: 1,
+        title: "live 507 table multi cell selection 글",
+        content: live507TableContent,
+        contentHtml: null,
+        published: true,
+        listed: true,
+      }),
+    })
+  })
+
+  await page.goto("/editor/999")
+  const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+  await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+    "live 507 table multi cell selection 글"
+  )
+  await expectEditorToContainLoadedText(editor, "구현되어 있는가")
+
+  const startCell = editor.locator("th", { hasText: "영역" }).first()
+  const endCell = editor.locator("td", { hasText: "구현되어 있는가" }).first()
+  await page.evaluate(() => {
+    window.getSelection()?.removeAllRanges()
+    document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => {
+      element.removeAttribute("data-table-drag-selection-text")
+    })
+    ;(window as typeof window & { __qaMultiCellDragEvents?: unknown[] }).__qaMultiCellDragEvents = []
+    const record = (event: MouseEvent | PointerEvent) => {
+      const cell = document.elementsFromPoint(event.clientX, event.clientY)
+        .find((element) => Boolean(element.closest("th, td")))
+        ?.closest("th, td")
+      ;(window as typeof window & { __qaMultiCellDragEvents?: unknown[] }).__qaMultiCellDragEvents?.push({
+        buttons: event.buttons,
+        cellText: cell?.textContent?.replace(/\s+/g, " ").trim() ?? null,
+        selectionText: window.getSelection()?.toString() ?? "",
+        type: event.type,
+        x: Math.round(event.clientX),
+        y: Math.round(event.clientY),
+      })
+    }
+    for (const type of ["pointerdown", "pointermove", "pointerup", "mousedown", "mousemove", "mouseup"] as const) {
+      window.addEventListener(type, record, { capture: true })
+    }
+  })
+
+  const tableDrag = await dragBetweenTextRanges(page, startCell, endCell, "live 507 table multi-cell drag", {
+    end: "구현되어 있는가",
+    start: "영역",
+  })
+  const selectedCellCount = await editor.locator(".selectedCell").count()
+  if (!tableDrag.selectionText.includes("점검 항목") || !tableDrag.selectionText.includes("구현되어 있는가")) {
+    const diagnostics = await startCell.evaluate(() => {
+      const table = document.querySelector("table")
+      const startCell = Array.from(table?.querySelectorAll("th, td") ?? []).find((cell) =>
+        cell.textContent?.replace(/\s+/g, " ").trim().includes("영역")
+      )
+      const endCell = Array.from(table?.querySelectorAll("th, td") ?? []).find((cell) =>
+        cell.textContent?.replace(/\s+/g, " ").trim().includes("구현되어 있는가")
+      )
+      const measureRangeText = () => {
+        if (!startCell || !endCell) return ""
+        const boundary = (element: Element, edge: "end" | "start") => {
+          const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+          let first: Text | null = null
+          let last: Text | null = null
+          while (walker.nextNode()) {
+            const textNode = walker.currentNode as Text
+            first ??= textNode
+            last = textNode
+          }
+          const textNode = edge === "start" ? first : last
+          return textNode
+            ? { node: textNode, offset: edge === "start" ? 0 : textNode.data.length }
+            : { node: element, offset: edge === "start" ? 0 : element.childNodes.length }
+        }
+        const range = document.createRange()
+        const start = boundary(startCell, "start")
+        const end = boundary(endCell, "end")
+        range.setStart(start.node, start.offset)
+        range.setEnd(end.node, end.offset)
+        const selection = window.getSelection()
+        selection?.removeAllRanges()
+        selection?.addRange(range)
+        return selection?.toString() ?? ""
+      }
+      const selection = window.getSelection()
+      return {
+        anchorText: selection?.anchorNode?.textContent ?? null,
+        focusText: selection?.focusNode?.textContent ?? null,
+        finalizerInstalled: (window as typeof window & { __aqTableTextSelectionFinalizerInstalled?: boolean }).__aqTableTextSelectionFinalizerInstalled ?? false,
+        events: ((window as typeof window & { __qaMultiCellDragEvents?: unknown[] }).__qaMultiCellDragEvents ?? []).slice(-120),
+        manualRangeText: measureRangeText(),
+        persisted: Array.from(document.querySelectorAll("[data-table-drag-selection-text]")).map(
+          (element) => element.getAttribute("data-table-drag-selection-text")
+        ),
+      }
+    })
+    throw new Error(`multi-cell table drag stayed in one cell: ${JSON.stringify({ diagnostics, tableDrag })}`)
+  }
+
+  expect(tableDrag.selectionText).toContain("영역")
+  expect(tableDrag.selectionText).toContain("점검 항목")
+  expect(tableDrag.selectionText).toContain("확인 기준")
+  expect(tableDrag.selectionText).toContain("Stateless 의미")
+  expect(tableDrag.selectionText).toContain("구현되어 있는가")
+  expect(selectedCellCount).toBe(0)
+  expect(tableDrag.afterScrollTop).toBeLessThanOrEqual(tableDrag.beforeScrollTop + 24)
+  expect(tableDrag.afterScrollTop).toBeGreaterThanOrEqual(tableDrag.beforeScrollTop - 24)
+})

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -8,6 +8,7 @@ import {
 } from "./BlockEditorEngine.layers"
 import { BlockEditorTableOverlayLayer } from "./BlockEditorEngine.tableOverlayLayer"
 import { Shell } from "./BlockEditorEngine.styles"
+import "./tableTextNativeDragGuard"
 import { useBlockEditorEngineController } from "./useBlockEditorEngineController"
 
 const BlockEditorEngine = (props: BlockEditorEngineProps) => {

--- a/front/src/components/editor/tableTextNativeDragGuard.ts
+++ b/front/src/components/editor/tableTextNativeDragGuard.ts
@@ -1,0 +1,43 @@
+const TABLE_TEXT_NATIVE_DRAG_CONTROL_SELECTOR =
+  "[data-table-axis-rail='true'], [data-table-affordance], [data-table-menu-root='true'], [data-table-menu-trigger='true'], [data-testid^='table-column-resize-boundary-'], [data-testid='table-structure-menu-button'], [data-testid='table-corner-handle'], [data-testid='table-corner-grow-handle'], .column-resize-handle"
+
+const resolveElement = (target: EventTarget | Node | null | undefined) => {
+  if (target instanceof Element) return target
+  if (target instanceof Node) return target.parentElement
+  return null
+}
+
+const isInternalTableTextDrag = (event: DragEvent) => {
+  const targetElement = resolveElement(event.target)
+  const table = targetElement?.closest("table")
+  if (!targetElement || !table || targetElement.closest(TABLE_TEXT_NATIVE_DRAG_CONTROL_SELECTOR)) return false
+
+  const selection = window.getSelection()
+  const anchorElement = resolveElement(selection?.anchorNode)
+  const focusElement = resolveElement(selection?.focusNode)
+  const selectedText =
+    selection?.toString().trim() ||
+    document.documentElement.getAttribute("data-table-drag-selection-text")?.trim() ||
+    document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text")?.trim() ||
+    ""
+
+  return Boolean(selectedText && anchorElement && focusElement && table.contains(anchorElement) && table.contains(focusElement))
+}
+
+const stopInternalTableTextDrag = (event: DragEvent) => {
+  if (!isInternalTableTextDrag(event)) return
+  event.preventDefault()
+  event.stopPropagation()
+  event.stopImmediatePropagation()
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  const tableDragWindow = window as typeof window & { __aqTableTextNativeDragGuardInstalled?: boolean }
+  if (!tableDragWindow.__aqTableTextNativeDragGuardInstalled) {
+    tableDragWindow.__aqTableTextNativeDragGuardInstalled = true
+    window.addEventListener("dragstart", stopInternalTableTextDrag, true)
+    window.addEventListener("drop", stopInternalTableTextDrag, true)
+  }
+}
+
+export {}

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -19,8 +19,127 @@ const resolveElement = (target: EventTarget | Node | null | undefined) => {
   return null
 }
 
-const normalizeCellText = (cell: Element | null | undefined) =>
-  cell?.textContent?.replace(/\s+/g, " ").trim() ?? ""
+const TABLE_TEXT_SELECTION_CONTROL_SELECTOR = "[data-table-axis-rail='true'], [data-table-affordance], [data-table-menu-root='true'], [data-table-menu-trigger='true'], [data-testid^='table-column-resize-boundary-'], [data-testid='table-structure-menu-button'], [data-testid='table-corner-handle'], [data-testid='table-corner-grow-handle'], .column-resize-handle"
+export const resolveTableTextCellAtPoint = (clientX: number, clientY: number, target?: EventTarget | Node | null, options: { allowControlFallback?: boolean } = {}) => {
+  const pointElements = document.elementsFromPoint(clientX, clientY), targetElement = resolveElement(target)
+  return !options.allowControlFallback && (targetElement?.closest(TABLE_TEXT_SELECTION_CONTROL_SELECTOR) || pointElements[0]?.closest(TABLE_TEXT_SELECTION_CONTROL_SELECTOR)) ? null : pointElements.find((element) => Boolean(element.closest("th, td")))?.closest("th, td") ?? targetElement?.closest("th, td")
+}
+
+export const resolveTableTextSelectionRangeCells = (clientX: number, clientY: number, target?: EventTarget | Node | null) => {
+  const pointCell = resolveTableTextCellAtPoint(clientX, clientY, target)
+  const selection = window.getSelection()
+  const anchorElement = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null
+  const selectedText = selection?.toString().trim() ?? ""
+  const pointTable = pointCell?.closest("table")
+  const anchorCell = anchorElement?.closest("th, td") ?? Array.from(pointTable?.querySelectorAll<HTMLElement>("th, td") ?? []).find((cell) => {
+    const cellText = normalizeCellText(cell)
+    return cellText === selectedText || cellText.includes(selectedText) || selectedText.includes(cellText)
+  })
+  return pointCell instanceof HTMLElement && anchorCell instanceof HTMLElement && selectedText && pointTable === anchorCell.closest("table")
+    ? { anchorCell, pointCell }
+    : null
+}
+
+let pendingTableTextSelectionRangeCells: { anchorCell: HTMLElement; pointCell: HTMLElement } | null = null
+let activeTableTextRangePreserveCancel: (() => void) | null = null
+const TABLE_TEXT_HIGHLIGHT_NAME = "aq-table-text-selection"
+const clearTableTextRangeHighlight = () => { document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => element.removeAttribute("data-table-drag-selection-text")); document.documentElement.removeAttribute("data-table-drag-selection-text"); (CSS as typeof CSS & { highlights?: { delete: (name: string) => void } }).highlights?.delete(TABLE_TEXT_HIGHLIGHT_NAME) }
+const paintTableTextRangeHighlight = (range: Range) => { const HighlightCtor = (window as typeof window & { Highlight?: new (range: Range) => unknown }).Highlight, highlights = (CSS as typeof CSS & { highlights?: { set: (name: string, highlight: unknown) => void } }).highlights; if (!HighlightCtor || !highlights) return; if (!document.getElementById("aq-table-text-highlight-style")) { const style = document.createElement("style"); style.id = "aq-table-text-highlight-style"; style.textContent = `::highlight(${TABLE_TEXT_HIGHLIGHT_NAME}){background:#0a5b9d;color:white}`; document.head.append(style) } highlights.set(TABLE_TEXT_HIGHLIGHT_NAME, new HighlightCtor(range.cloneRange())) }
+
+const preserveTableTextRangeAcrossFrames = (anchorCell: HTMLElement, pointCell: HTMLElement) => {
+  activeTableTextRangePreserveCancel?.()
+  let cancelled = false, frame = 0
+  const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now()
+  const cleanup = () => {
+    window.removeEventListener("pointerdown", cancel, true); window.removeEventListener("mousedown", cancel, true); window.removeEventListener("wheel", cancel, true); window.removeEventListener("scroll", cancel, true); window.removeEventListener("keydown", cancel, true)
+    if (activeTableTextRangePreserveCancel === cancel) activeTableTextRangePreserveCancel = null
+  }
+  const cancel = () => { cancelled = true; clearTableTextRangeHighlight(); cleanup() }
+  const restore = () => {
+    if (cancelled) return
+    selectTableCellTextRange(anchorCell, pointCell)
+    frame += 1
+    const elapsedMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt
+    if (frame < 96 || elapsedMs < 1_600) {
+      window.requestAnimationFrame(restore)
+    }
+  }
+  activeTableTextRangePreserveCancel = cancel
+  window.addEventListener("pointerdown", cancel, { capture: true, once: true }); window.addEventListener("mousedown", cancel, { capture: true, once: true })
+  window.addEventListener("wheel", cancel, { capture: true, passive: true, once: true }); window.addEventListener("scroll", cancel, { capture: true, passive: true, once: true })
+  window.addEventListener("keydown", cancel, { capture: true, once: true })
+  window.requestAnimationFrame(restore)
+  return cancel
+}
+
+export const finalizeTableTextSelectionFromPoint = (clientX: number, clientY: number, target?: EventTarget | Node | null) => {
+  const pointCell = resolveTableTextCellAtPoint(clientX, clientY, target), rangeCells = resolveTableTextSelectionRangeCells(clientX, clientY, target) ?? (pointCell ? pendingTableTextSelectionRangeCells : null); pendingTableTextSelectionRangeCells = null
+  if (!rangeCells || rangeCells.anchorCell === rangeCells.pointCell) return false
+  cancelActiveTableCellTextSelectionPreserves()
+  const restore = () => selectTableCellTextRange(rangeCells.anchorCell, rangeCells.pointCell)
+  window.requestAnimationFrame(restore); window.setTimeout(restore, 80); window.setTimeout(restore, 180)
+  preserveTableTextRangeAcrossFrames(rangeCells.anchorCell, rangeCells.pointCell)
+  return true
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  const tableSelectionWindow = window as typeof window & { __aqTableTextSelectionFinalizerInstalled?: boolean }
+  if (!tableSelectionWindow.__aqTableTextSelectionFinalizerInstalled) {
+    tableSelectionWindow.__aqTableTextSelectionFinalizerInstalled = true
+    window.addEventListener("mousemove", (event) => { pendingTableTextSelectionRangeCells = event.buttons === 1 ? resolveTableTextSelectionRangeCells(event.clientX, event.clientY, event.target) ?? pendingTableTextSelectionRangeCells : null }, true)
+    window.addEventListener("mouseup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
+  }
+}
+
+const normalizeCellText = (cell: Element | null | undefined) => cell?.textContent?.replace(/\s+/g, " ").trim() ?? ""
+
+const resolveCellTable = (cell: HTMLElement | null | undefined) => cell?.closest("table") ?? null
+
+const isConnectedTableCell = (cell: HTMLElement) =>
+  cell.isConnected && document.documentElement.contains(cell)
+
+const resolveCurrentTableTextRangeCells = (
+  startedCell: HTMLElement,
+  endCell: HTMLElement
+) => {
+  const startedTable = resolveCellTable(startedCell)
+  if (
+    isConnectedTableCell(startedCell) &&
+    isConnectedTableCell(endCell) &&
+    startedTable &&
+    resolveCellTable(endCell) === startedTable
+  ) {
+    return { endCell, startedCell }
+  }
+
+  const startedText = normalizeCellText(startedCell)
+  const endText = normalizeCellText(endCell)
+  if (!startedText || !endText) return null
+  const originalCells = startedTable ? Array.from(startedTable.querySelectorAll<HTMLElement>("th, td")) : []
+  const startedIndex = originalCells.indexOf(startedCell)
+  const endIndex = originalCells.indexOf(endCell)
+
+  for (const table of Array.from(document.querySelectorAll("table"))) {
+    const cells = Array.from(table.querySelectorAll<HTMLElement>("th, td"))
+    const indexedStartedCell = startedIndex >= 0 ? cells[startedIndex] : null
+    const indexedEndCell = endIndex >= 0 ? cells[endIndex] : null
+    if (
+      indexedStartedCell &&
+      indexedEndCell &&
+      normalizeCellText(indexedStartedCell) === startedText &&
+      normalizeCellText(indexedEndCell) === endText
+    ) {
+      return { endCell: indexedEndCell, startedCell: indexedStartedCell }
+    }
+
+    const textStartedCell = cells.find((cell) => normalizeCellText(cell) === startedText)
+    const textEndCell = cells.find((cell) => normalizeCellText(cell) === endText)
+    if (textStartedCell && textEndCell) {
+      return { endCell: textEndCell, startedCell: textStartedCell }
+    }
+  }
+  return null
+}
 
 const resolveConnectedTableCell = (
   editor: TiptapEditor,
@@ -40,6 +159,77 @@ const resolveConnectedTableCell = (
   )
 }
 
+const resolveOwnedTableRangeEndCell = (
+  editor: TiptapEditor,
+  startedCell: HTMLElement,
+  endCell: HTMLElement | null | undefined
+) => {
+  if (!endCell) return null
+  const currentCell = resolveConnectedTableCell(editor, endCell)
+  const startedTable = resolveCellTable(startedCell)
+  if (!currentCell || !startedTable || resolveCellTable(currentCell) !== startedTable) {
+    return null
+  }
+  return currentCell
+}
+
+const resolveTextBoundary = (element: HTMLElement, edge: "end" | "start") => {
+  const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+  let firstText: Text | null = null
+  let lastText: Text | null = null
+  while (walker.nextNode()) {
+    const textNode = walker.currentNode as Text
+    if (!firstText) firstText = textNode
+    lastText = textNode
+  }
+  const textNode = edge === "start" ? firstText : lastText
+  if (textNode) {
+    return {
+      node: textNode,
+      offset: edge === "start" ? 0 : textNode.data.length,
+    }
+  }
+  return {
+    node: element,
+    offset: edge === "start" ? 0 : element.childNodes.length,
+  }
+}
+
+const isElementBeforeOrSame = (start: HTMLElement, end: HTMLElement) =>
+  start === end || Boolean(start.compareDocumentPosition(end) & Node.DOCUMENT_POSITION_FOLLOWING)
+
+export const selectTableCellTextRange = (
+  startedCell: HTMLElement,
+  endCell: HTMLElement
+) => {
+  const selection = window.getSelection()
+  if (!selection) return ""
+  const resolvedCells = resolveCurrentTableTextRangeCells(startedCell, endCell)
+  if (!resolvedCells) return ""
+  const range = document.createRange()
+  const forward = isElementBeforeOrSame(resolvedCells.startedCell, resolvedCells.endCell)
+  const rangeStartCell = forward ? resolvedCells.startedCell : resolvedCells.endCell, rangeEndCell = forward ? resolvedCells.endCell : resolvedCells.startedCell
+  const startBoundary = resolveTextBoundary(rangeStartCell, "start")
+  const endBoundary = resolveTextBoundary(rangeEndCell, "end")
+  range.setStart(startBoundary.node, startBoundary.offset)
+  range.setEnd(endBoundary.node, endBoundary.offset)
+  selection.removeAllRanges()
+  if (typeof selection.setBaseAndExtent === "function") selection.setBaseAndExtent(startBoundary.node, startBoundary.offset, endBoundary.node, endBoundary.offset)
+  else selection.addRange(range)
+  const selectedText = selection.toString() || range.toString()
+  resolvedCells.startedCell.setAttribute("data-table-drag-selection-text", selectedText || normalizeCellText(resolvedCells.startedCell))
+  document.documentElement.setAttribute("data-table-drag-selection-text", selectedText || normalizeCellText(resolvedCells.startedCell))
+  paintTableTextRangeHighlight(range)
+  return selectedText
+}
+
+const isSelectionInsideSameTable = (selection: Selection, table: Element | null) => {
+  if (!table) return false
+  const anchorElement = resolveElement(selection.anchorNode)
+  const focusElement = resolveElement(selection.focusNode)
+  return Boolean(anchorElement && focusElement && table.contains(anchorElement) && table.contains(focusElement))
+}
+
 let lastActiveTableCell: HTMLElement | null = null
 const activeTableCellScrollPreserveCancels = new Set<() => void>()
 const activeTableCellSelectionPreserveCancels = new Set<() => void>()
@@ -56,6 +246,7 @@ export const cancelActiveTableCellScrollPreserves = () => {
 export const cancelActiveTableCellTextSelectionPreserves = () => {
   activeTableCellSelectionPreserveCancels.forEach((cancel) => cancel())
   activeTableCellSelectionPreserveCancels.clear()
+  activeTableTextRangePreserveCancel?.(); clearTableTextRangeHighlight()
   cancelActiveTableCellScrollPreserves()
 }
 
@@ -66,17 +257,17 @@ const isWindowSelectionInsideEditorTable = (editorRoot: HTMLElement) => {
   const focusElement = resolveElement(selection.focusNode)
   const anchorCell = anchorElement?.closest("th, td")
   const focusCell = focusElement?.closest("th, td")
+  const anchorTable = anchorCell?.closest("table")
   return Boolean(
     anchorCell &&
       focusCell &&
-      anchorCell === focusCell &&
-      editorRoot.contains(anchorCell)
+      anchorTable &&
+      focusCell.closest("table") === anchorTable &&
+      editorRoot.contains(anchorTable)
   )
 }
 
-const hasTableTextSelectionState = (editorRoot: HTMLElement) =>
-  Boolean(editorRoot.querySelector(TABLE_DRAG_SELECTION_TEXT_SELECTOR)) ||
-  isWindowSelectionInsideEditorTable(editorRoot)
+const hasTableTextSelectionState = (editorRoot: HTMLElement) => Boolean(editorRoot.querySelector(TABLE_DRAG_SELECTION_TEXT_SELECTOR)) || isWindowSelectionInsideEditorTable(editorRoot)
 
 const resolveDomElementAtEditorPos = (editor: TiptapEditor, pos: number) => {
   const docSize = editor.state.doc.content.size
@@ -193,14 +384,7 @@ const hasOwnedTableCellTextSelection = (
 
   const selection = window.getSelection()
   if (!selection?.toString().trim()) return false
-  const anchorElement = resolveElement(selection.anchorNode)
-  const focusElement = resolveElement(selection.focusNode)
-  return Boolean(
-    anchorElement &&
-      focusElement &&
-      currentCell.contains(anchorElement) &&
-      currentCell.contains(focusElement)
-  )
+  return isSelectionInsideSameTable(selection, resolveCellTable(currentCell))
 }
 
 const clearOwnedTableCellDragSelectionText = (
@@ -262,12 +446,14 @@ export const restoreTableCellTextSelectionIfEscaped = (
   scrollAnchor?: WindowScrollAnchor | null,
   restoreWhenEmpty = false,
   forceStartedCellSelection = false,
-  preserveFallbackScroll = true
+  preserveFallbackScroll = true,
+  endCell: HTMLElement | null = null
 ) => {
   if (typeof window === "undefined" || typeof document === "undefined") return false
   if (!startedCell) return false
   const currentCell = resolveConnectedTableCell(editor, startedCell)
   if (!currentCell) return false
+  const rangeEndCell = resolveOwnedTableRangeEndCell(editor, currentCell, endCell)
 
   const selection = window.getSelection()
   if (!selection) return false
@@ -275,26 +461,34 @@ export const restoreTableCellTextSelectionIfEscaped = (
   const anchorElement = resolveElement(selection.anchorNode)
   const focusElement = resolveElement(selection.focusNode)
   const hasTextSelection = selection.toString().trim().length > 0
+  const table = resolveCellTable(currentCell)
+  const isOwnedTableSelection = isSelectionInsideSameTable(selection, table)
   if (
     hasTextSelection &&
-    ((anchorElement && currentCell.contains(anchorElement)) ||
+    (isOwnedTableSelection ||
+      (anchorElement && currentCell.contains(anchorElement)) ||
       (focusElement && currentCell.contains(focusElement)))
   ) {
     currentCell.setAttribute("data-table-drag-selection-text", selection.toString())
     clearNextEditorPointerAfterTable()
-    if (!forceStartedCellSelection) {
+    if (!forceStartedCellSelection || !rangeEndCell || rangeEndCell === currentCell) {
       return true
     }
   }
   if (!hasTextSelection && !restoreWhenEmpty) return false
 
-  const range = document.createRange()
-  range.selectNodeContents(currentCell)
-  selection.removeAllRanges()
-  selection.addRange(range)
+  let restoredRangeText = ""
+  if (rangeEndCell && rangeEndCell !== currentCell) {
+    restoredRangeText = selectTableCellTextRange(currentCell, rangeEndCell)
+  } else {
+    const range = document.createRange()
+    range.selectNodeContents(currentCell)
+    selection.removeAllRanges()
+    selection.addRange(range)
+  }
   currentCell.setAttribute(
     "data-table-drag-selection-text",
-    selection.toString() || normalizeCellText(currentCell)
+    restoredRangeText || selection.toString() || normalizeCellText(currentCell)
   )
   clearNextEditorPointerAfterTable()
   if (scrollAnchor) {
@@ -326,7 +520,8 @@ export const restoreTableCellTextSelectionIfEscaped = (
 export const preserveTableCellTextSelectionAcrossFrames = (
   editor: TiptapEditor,
   startedCell: HTMLElement,
-  _scrollAnchor: WindowScrollAnchor
+  _scrollAnchor: WindowScrollAnchor,
+  resolveEndCell?: () => HTMLElement | null
 ) => {
   const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now()
   let frame = 0
@@ -363,9 +558,7 @@ export const preserveTableCellTextSelectionAcrossFrames = (
       cancel()
       return
     }
-    const anchorElement = resolveElement(selection.anchorNode)
-    const focusElement = resolveElement(selection.focusNode)
-    if (!anchorElement || !focusElement || !currentCell.contains(anchorElement) || !currentCell.contains(focusElement)) {
+    if (!isSelectionInsideSameTable(selection, resolveCellTable(currentCell))) {
       cancel()
     }
   }
@@ -386,7 +579,7 @@ export const preserveTableCellTextSelectionAcrossFrames = (
       return
     }
     restoring = true
-    const restored = restoreTableCellTextSelectionIfEscaped(editor, startedCell, null, true, true, false)
+    const restored = restoreTableCellTextSelectionIfEscaped(editor, startedCell, null, true, true, false, resolveEndCell?.() ?? null)
     restoring = false
     if (!restored) {
       cancel()

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -3,7 +3,7 @@ import { TextSelection } from "@tiptap/pm/state"
 import { useEffect, useRef, type Dispatch, type MutableRefObject, type RefObject, type SetStateAction } from "react"
 import { cancelTablePointerScrollPreserves, clearNextEditorPointerAfterTable, markNextEditorPointerAfterTable, preserveWindowScrollForCodePointerFocus, preserveWindowScrollForEditorPointerFocus, preserveWindowScrollPositionAcrossFrames, type WindowScrollAnchor } from "./blockHandleLayoutModel"
 import { isTableSelectionActive } from "./tableStructureModel"
-import { cancelActiveTableCellTextSelectionPreserves, collapseStaleTableEditorSelection, preserveTableCellTextSelectionAcrossFrames, restoreTableCellTextSelectionIfEscaped, watchTableCellTextSelectionExternalClear } from "./tableTextSelectionModel"
+import { cancelActiveTableCellTextSelectionPreserves, collapseStaleTableEditorSelection, preserveTableCellTextSelectionAcrossFrames, resolveTableTextCellAtPoint, resolveTableTextSelectionRangeCells, restoreTableCellTextSelectionIfEscaped, selectTableCellTextRange, watchTableCellTextSelectionExternalClear } from "./tableTextSelectionModel"
 import { areFloatingBubbleStatesEqual, hideFloatingBubbleState, resolveFloatingBubbleStateFromCoords, type FloatingBubbleState } from "./useFloatingBubbleState"
 type SetState<T> = Dispatch<SetStateAction<T>>
 const CODE_BLOCK_EDITOR_CONTENT_SELECTOR = ".aq-code-editor-content"
@@ -46,8 +46,8 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
   tableMenuState,
   tryStartTableColumnResizeFromDomHandle,
 }: UseBlockEditorEngineSelectionBubbleEffectsArgs) => {
-  const tableTextDragStartRef = useRef<{ cell: HTMLElement; coveredControlFallback: boolean; scrollPreserveStarted: boolean; selectionPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null)
-  const tableTextDragPendingStartRef = useRef<{ cell: HTMLElement; coveredControlFallback: boolean; scrollPreserveStarted: boolean; selectionPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null)
+  const tableTextDragStartRef = useRef<{ cell: HTMLElement; coveredControlFallback: boolean; endCell: HTMLElement | null; scrollPreserveStarted: boolean; selectionPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null)
+  const tableTextDragPendingStartRef = useRef<{ cell: HTMLElement; coveredControlFallback: boolean; endCell: HTMLElement | null; scrollPreserveStarted: boolean; selectionPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null)
   const codeTextDragStartRef = useRef<{ root: HTMLElement; scrollPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null), nonTableTextDragStartRef = useRef<{ x: number; y: number } | null>(null)
   useEffect(() => {
     const currentEditor = editorRef.current ?? editor
@@ -88,40 +88,33 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     }
     const rememberCodeTextDragStartAtPoint = (event: MouseEvent | PointerEvent) => { const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null; return rememberCodeTextDragStart(findCodeShellTarget(targetElement, document.elementsFromPoint(event.clientX, event.clientY)), event) }
     const prepareNonTableEditorPointerTarget = (event: MouseEvent | PointerEvent) => { const activeEditor = editorRef.current ?? currentEditor; if (!activeEditor) return false; const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null, pointElements = document.elementsFromPoint(event.clientX, event.clientY), codeShellTarget = findCodeShellTarget(targetElement, pointElements), pointInsideEditor = pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR))), insideEditorDom = event.target instanceof Node && (activeEditor.view.dom.contains(event.target) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor), tableTarget = Boolean(targetElement?.closest("th, td") || pointElements.some((element) => Boolean(element.closest("th, td")))), toolbarOrControlTarget = Boolean(targetElement?.closest("[data-testid='editor-text-bubble-toolbar'], button, summary, [role='button']") || pointElements.some((element) => Boolean(element.closest("[data-testid='editor-text-bubble-toolbar']")))); if (!insideEditorDom || codeShellTarget || tableTarget || toolbarOrControlTarget) return false; nonTableTextDragStartRef.current = { x: event.clientX, y: event.clientY }; cancelTableTextDragPreserves(); collapseStaleTableEditorSelection(activeEditor); return true }
-    const rememberTableTextDragStart = (event: MouseEvent | PointerEvent, allowTableControlCellFallback = false, allowOutsideCoveredControlFallback = false) => {
+    const updateTableTextDragEndCellFromPoint = (event: MouseEvent | PointerEvent) => { const tableTextDragStart = tableTextDragStartRef.current, pointCell = resolveTableTextCellAtPoint(event.clientX, event.clientY, event.target); if (tableTextDragStart && pointCell instanceof HTMLElement && pointCell.closest("table") === tableTextDragStart.cell.closest("table")) tableTextDragStart.endCell = pointCell }
+    const letNativeMultiCellTableTextDrag = (event: MouseEvent | PointerEvent) => { const tableTextDragStart = tableTextDragStartRef.current, pointCell = resolveTableTextCellAtPoint(event.clientX, event.clientY, event.target); if (!(pointCell instanceof HTMLElement) || !tableTextDragStart || pointCell === tableTextDragStart.cell || pointCell.closest("table") !== tableTextDragStart.cell.closest("table")) return false; tableTextDragStart.endCell = pointCell; preserveActiveTableTextDragScroll(); syncBubbleOnMouseUpRef.current = true; return true }
+    const rememberTableTextDragStartFromSelection = (event: MouseEvent | PointerEvent) => { const activeEditor = editorRef.current ?? currentEditor, pointCell = resolveTableTextCellAtPoint(event.clientX, event.clientY, event.target), selection = window.getSelection(), anchorElement = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, anchorCell = anchorElement?.closest("th, td"); if (!activeEditor || !(pointCell instanceof HTMLElement) || !(anchorCell instanceof HTMLElement) || !selection?.toString().trim() || pointCell.closest("table") !== anchorCell.closest("table") || !activeEditor.view.dom.contains(anchorCell)) return null; const scrollAnchor = { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }; nonTableTextDragStartRef.current = null; cancelTableTextDragPreserves(); markNextEditorPointerAfterTable(); tableTextDragStartRef.current = { cell: anchorCell, coveredControlFallback: false, endCell: pointCell, scrollPreserveStarted: false, selectionPreserveStarted: false, scrollAnchor, x: event.clientX, y: event.clientY }; return tableTextDragStartRef.current }
+    const restoreTableTextDragSelectionFromNativeRange = (event: MouseEvent | PointerEvent) => { const activeEditor = editorRef.current ?? currentEditor, rangeCells = resolveTableTextSelectionRangeCells(event.clientX, event.clientY, event.target); if (!activeEditor || !rangeCells || rangeCells.anchorCell !== rangeCells.pointCell || !activeEditor.view.dom.contains(rangeCells.anchorCell)) return false; nonTableTextDragStartRef.current = null; tableTextDragStartRef.current = { cell: rangeCells.anchorCell, coveredControlFallback: false, endCell: rangeCells.pointCell, scrollPreserveStarted: true, selectionPreserveStarted: false, scrollAnchor: { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }, x: event.clientX, y: event.clientY }; const restored = restoreTableCellTextSelectionIfEscaped(activeEditor, rangeCells.anchorCell, null, true, true, false, rangeCells.pointCell); if (restored) tableTextSelectionExternalClearWatcher?.markActive(); return restored }
+    const rememberTableTextDragStart = (event: MouseEvent | PointerEvent, _allowTableControlCellFallback = false, allowOutsideCoveredControlFallback = false) => {
       if (event.button !== 0 && event.buttons !== 1) return null
       const activeEditor = editorRef.current ?? currentEditor
       if (!activeEditor) return null
       const targetElement = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : null
       const pointElements = document.elementsFromPoint(event.clientX, event.clientY)
       const pointInsideEditor = pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR)))
-      const pointElement = pointElements.find((element) => Boolean(element.closest("th, td"))) ?? document.elementFromPoint(event.clientX, event.clientY)
-      const tableTextCell = pointElement?.closest("th, td") ?? targetElement?.closest("th, td")
+      const tableTextCell = resolveTableTextCellAtPoint(event.clientX, event.clientY, event.target, { allowControlFallback: true })
       const tableControlTarget = targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR) ?? pointElements[0]?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR)
       const tableCellRect = tableTextCell instanceof HTMLElement ? tableTextCell.getBoundingClientRect() : null, coveredControlFallback = Boolean(tableCellRect && tableControlTarget?.getAttribute("data-table-affordance") === "row-handle" && event.clientX >= tableCellRect.left && event.clientX <= tableCellRect.right && event.clientY >= tableCellRect.top && event.clientY <= tableCellRect.bottom)
       if (!(event.target instanceof Node) || (!activeEditor.view.dom.contains(event.target) && !targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR) && !pointInsideEditor && !(allowOutsideCoveredControlFallback && coveredControlFallback))) { tableTextDragStartRef.current = null; return null }
-      if (tableControlTarget && (!(allowTableControlCellFallback || coveredControlFallback) || !(tableTextCell instanceof HTMLElement))) { tableTextDragStartRef.current = null; return null }
+      if (tableControlTarget && (!coveredControlFallback || !(tableTextCell instanceof HTMLElement))) { tableTextDragStartRef.current = null; return null }
       const scrollAnchor = { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }
       if (tableTextCell instanceof HTMLElement) {
         nonTableTextDragStartRef.current = null; cancelTableTextDragPreserves()
         tableTextCell.removeAttribute("data-table-drag-selection-text")
         markNextEditorPointerAfterTable()
       }
-      tableTextDragStartRef.current = tableTextCell instanceof HTMLElement ? { cell: tableTextCell, coveredControlFallback, scrollPreserveStarted: false, selectionPreserveStarted: false, scrollAnchor, x: event.clientX, y: event.clientY } : null
+      tableTextDragStartRef.current = tableTextCell instanceof HTMLElement ? { cell: tableTextCell, coveredControlFallback, endCell: tableTextCell, scrollPreserveStarted: false, selectionPreserveStarted: false, scrollAnchor, x: event.clientX, y: event.clientY } : null
       return tableTextDragStartRef.current
     }
-    const hasMovedTableTextDrag = (event: MouseEvent | PointerEvent) => {
-      const tableTextDragStart = tableTextDragStartRef.current
-      return Boolean(tableTextDragStart && (Math.abs(event.clientX - tableTextDragStart.x) > 4 || Math.abs(event.clientY - tableTextDragStart.y) > 4))
-    }
-    const restoreActiveTableTextDragSelection = (restoreWhenEmpty = false, forceStartedCellSelection = false, preserveScroll = true) => {
-      const activeEditor = editorRef.current ?? currentEditor
-      const tableTextDragStart = tableTextDragStartRef.current
-      if (!activeEditor || !tableTextDragStart) return false
-      const restored = restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, preserveScroll ? tableTextDragStart.scrollAnchor : null, restoreWhenEmpty, forceStartedCellSelection, preserveScroll)
-      if (restored) tableTextSelectionExternalClearWatcher?.markActive()
-      return restored
-    }
+    const hasMovedTableTextDrag = (event: MouseEvent | PointerEvent) => { const tableTextDragStart = tableTextDragStartRef.current; return Boolean(tableTextDragStart && (Math.abs(event.clientX - tableTextDragStart.x) > 4 || Math.abs(event.clientY - tableTextDragStart.y) > 4)) }
+    const restoreActiveTableTextDragSelection = (restoreWhenEmpty = false, forceStartedCellSelection = false, preserveScroll = true) => { const activeEditor = editorRef.current ?? currentEditor, tableTextDragStart = tableTextDragStartRef.current; if (!activeEditor || !tableTextDragStart) return false; const restored = restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, preserveScroll ? tableTextDragStart.scrollAnchor : null, restoreWhenEmpty, forceStartedCellSelection, preserveScroll, tableTextDragStart.endCell); if (restored) tableTextSelectionExternalClearWatcher?.markActive(); return restored }
     const preserveActiveTableTextDragScroll = () => {
       const tableTextDragStart = tableTextDragStartRef.current
       if (!tableTextDragStart || tableTextDragStart.scrollPreserveStarted) return
@@ -130,9 +123,8 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     const preserveActiveTableTextDragSelection = (activeEditor: TiptapEditor) => {
       const tableTextDragStart = tableTextDragStartRef.current
       if (!tableTextDragStart || tableTextDragStart.selectionPreserveStarted) return
-      tableTextDragStart.selectionPreserveStarted = true; cleanupTableDragSelectionPreserve?.(); cleanupTableDragSelectionPreserve = preserveTableCellTextSelectionAcrossFrames(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor) ?? null
+      tableTextDragStart.selectionPreserveStarted = true; cleanupTableDragSelectionPreserve?.(); cleanupTableDragSelectionPreserve = preserveTableCellTextSelectionAcrossFrames(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, () => tableTextDragStartRef.current?.endCell ?? null) ?? null
     }
-
     const preserveActiveCodeTextDragScroll = () => {
       const codeTextDragStart = codeTextDragStartRef.current
       if (!codeTextDragStart || codeTextDragStart.scrollPreserveStarted) return
@@ -159,7 +151,6 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       root.closest(".aq-code-shell")?.setAttribute("data-code-drag-selection-text", selection.toString() || root.innerText || root.textContent || "")
       return true
     }
-
     const preserveCodeDragRootSelectionAcrossFrames = (root: HTMLElement) => {
       const preserveGeneration = ++codeDragSelectionPreserveGeneration, isCurrentPreserveGeneration = () => preserveGeneration === codeDragSelectionPreserveGeneration
       if (codeDragSelectionPreserveRafId !== null) {
@@ -205,7 +196,6 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       cleanupCodeDragSelectionPreserve = cleanupPreservedSelection
       restore()
     }
-
     const selectCodeDragRootWhenNativeSelectionIsMissing = () => {
       const codeTextDragStart = codeTextDragStartRef.current
       if (!codeTextDragStart?.root.isConnected) return false
@@ -216,7 +206,6 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       }
       return selected
     }
-
     const hasMovedCodeTextDrag = (event: MouseEvent | PointerEvent) => {
       const codeTextDragStart = codeTextDragStartRef.current
       return Boolean(codeTextDragStart && (Math.abs(event.clientX - codeTextDragStart.x) > 4 || Math.abs(event.clientY - codeTextDragStart.y) > 4))
@@ -245,14 +234,15 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         const isCodeBlockNodeViewSelection = Boolean(
           commonAncestor?.closest(CODE_BLOCK_EDITOR_CONTENT_SELECTOR)
         )
-
+        const anchorCell = (domSelection?.anchorNode instanceof Element ? domSelection.anchorNode : domSelection?.anchorNode?.parentElement ?? null)?.closest("th, td"), focusCell = (domSelection?.focusNode instanceof Element ? domSelection.focusNode : domSelection?.focusNode?.parentElement ?? null)?.closest("th, td"), isMultiCellTableDomSelection = Boolean(anchorCell && focusCell && anchorCell !== focusCell && anchorCell.closest("table") === focusCell.closest("table"))
         if (
           range &&
           domSelection &&
           !domSelection.isCollapsed &&
           commonAncestor &&
           activeEditor.view.dom.contains(commonAncestor) &&
-          !isCodeBlockNodeViewSelection
+          !isCodeBlockNodeViewSelection &&
+          !isMultiCellTableDomSelection
         ) {
           const syncPmSelectionFromRange = (from: number, to: number) => {
             if (!Number.isFinite(from) || !Number.isFinite(to) || from === to) return false
@@ -479,8 +469,12 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         selectCodeDragRootWhenNativeSelectionIsMissing()
         return
       }
-      if (!nonTableTextDragStartRef.current && !tableTextDragStartRef.current && !isTableColumnRailResizeActive() && event.buttons === 1 && rememberTableTextDragStart(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveTableTextDragScroll(); if (restoreActiveTableTextDragSelection(true, true)) syncBubbleOnMouseUpRef.current = true; const activeEditor = editorRef.current ?? currentEditor; if (activeEditor) preserveActiveTableTextDragSelection(activeEditor); return }
+      if (letNativeMultiCellTableTextDrag(event)) return
+      if (event.buttons === 1 && restoreTableTextDragSelectionFromNativeRange(event)) { event.preventDefault(); event.stopPropagation(); syncBubbleOnMouseUpRef.current = true; return }
+      if (!tableTextDragStartRef.current && !isTableColumnRailResizeActive() && event.buttons === 1 && rememberTableTextDragStartFromSelection(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveTableTextDragScroll(); if (restoreActiveTableTextDragSelection(true, true)) syncBubbleOnMouseUpRef.current = true; const activeEditor = editorRef.current ?? currentEditor; if (activeEditor) preserveActiveTableTextDragSelection(activeEditor); return }
+      if (!nonTableTextDragStartRef.current && !tableTextDragStartRef.current && !isTableColumnRailResizeActive() && event.buttons === 1 && rememberTableTextDragStart(event)) { updateTableTextDragEndCellFromPoint(event); event.preventDefault(); event.stopPropagation(); preserveActiveTableTextDragScroll(); if (restoreActiveTableTextDragSelection(true, true)) syncBubbleOnMouseUpRef.current = true; const activeEditor = editorRef.current ?? currentEditor; if (activeEditor) preserveActiveTableTextDragSelection(activeEditor); return }
       if (!hasMovedTableTextDrag(event)) return
+      updateTableTextDragEndCellFromPoint(event)
       event.preventDefault()
       event.stopPropagation()
       preserveActiveTableTextDragScroll()
@@ -500,8 +494,12 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         selectCodeDragRootWhenNativeSelectionIsMissing()
         return
       }
-      if (!nonTableTextDragStartRef.current && !tableTextDragStartRef.current && !isTableColumnRailResizeActive() && event.buttons === 1 && rememberTableTextDragStart(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveTableTextDragScroll(); if (restoreActiveTableTextDragSelection(true, true)) syncBubbleOnMouseUpRef.current = true; const activeEditor = editorRef.current ?? currentEditor; if (activeEditor) preserveActiveTableTextDragSelection(activeEditor); return }
+      if (letNativeMultiCellTableTextDrag(event)) return
+      if (event.buttons === 1 && restoreTableTextDragSelectionFromNativeRange(event)) { event.preventDefault(); event.stopPropagation(); syncBubbleOnMouseUpRef.current = true; return }
+      if (!tableTextDragStartRef.current && !isTableColumnRailResizeActive() && event.buttons === 1 && rememberTableTextDragStartFromSelection(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveTableTextDragScroll(); if (restoreActiveTableTextDragSelection(true, true)) syncBubbleOnMouseUpRef.current = true; const activeEditor = editorRef.current ?? currentEditor; if (activeEditor) preserveActiveTableTextDragSelection(activeEditor); return }
+      if (!nonTableTextDragStartRef.current && !tableTextDragStartRef.current && !isTableColumnRailResizeActive() && event.buttons === 1 && rememberTableTextDragStart(event)) { updateTableTextDragEndCellFromPoint(event); event.preventDefault(); event.stopPropagation(); preserveActiveTableTextDragScroll(); if (restoreActiveTableTextDragSelection(true, true)) syncBubbleOnMouseUpRef.current = true; const activeEditor = editorRef.current ?? currentEditor; if (activeEditor) preserveActiveTableTextDragSelection(activeEditor); return }
       if (!hasMovedTableTextDrag(event)) return
+      updateTableTextDragEndCellFromPoint(event)
       event.preventDefault()
       event.stopPropagation()
       preserveActiveTableTextDragScroll()
@@ -515,10 +513,12 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       let tableTextDragStart = tableTextDragStartRef.current
       const pendingTableTextDragStart = tableTextDragPendingStartRef.current
       const codeTextDragStart = codeTextDragStartRef.current
-      if (!mouseTextSelectionInProgressRef.current && !tableTextDragStart && !pendingTableTextDragStart && !codeTextDragStart) return
+      const activeEditor = editorRef.current ?? currentEditor, rawNativeTableRangeSnapshot = activeEditor ? resolveTableTextSelectionRangeCells(event.clientX, event.clientY, event.target) : null, nativeTableRangeSnapshot = rawNativeTableRangeSnapshot?.anchorCell !== rawNativeTableRangeSnapshot?.pointCell ? rawNativeTableRangeSnapshot : null
+      if (!mouseTextSelectionInProgressRef.current && !tableTextDragStart && !pendingTableTextDragStart && !codeTextDragStart && !nativeTableRangeSnapshot) return
       if ("pointerType" in event && event.pointerType && event.pointerType !== "mouse") return
-      const activeEditor = editorRef.current ?? currentEditor
       if (!tableTextDragStart && pendingTableTextDragStart && Math.abs(event.clientX - pendingTableTextDragStart.x) > 4 && Math.abs(event.clientX - pendingTableTextDragStart.x) >= Math.abs(event.clientY - pendingTableTextDragStart.y)) { tableTextDragStartRef.current = pendingTableTextDragStart; tableTextDragStart = pendingTableTextDragStart }
+      if (activeEditor && nativeTableRangeSnapshot) { restoreTableCellTextSelectionIfEscaped(activeEditor, nativeTableRangeSnapshot.anchorCell, null, true, true, false, nativeTableRangeSnapshot.pointCell); window.requestAnimationFrame(() => { restoreTableCellTextSelectionIfEscaped(activeEditor, nativeTableRangeSnapshot.anchorCell, null, true, true, false, nativeTableRangeSnapshot.pointCell) }); window.setTimeout(() => { const text = selectTableCellTextRange(nativeTableRangeSnapshot.anchorCell, nativeTableRangeSnapshot.pointCell); nativeTableRangeSnapshot.anchorCell.setAttribute("data-table-drag-selection-text", text || nativeTableRangeSnapshot.anchorCell.textContent?.replace(/\s+/g, " ").trim() || "") }, 80) }
+      updateTableTextDragEndCellFromPoint(event)
       const tableTextDragMoved = hasMovedTableTextDrag(event)
       const codeTextDragMoved = hasMovedCodeTextDrag(event)
       if (codeTextDragMoved) {
@@ -530,7 +530,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
           preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root)
         }
       }
-      if (activeEditor && tableTextDragStart && (tableTextDragMoved || tableTextDragStart.coveredControlFallback)) { cancelTableTextDragPreserves(); if (restoreActiveTableTextDragSelection(true, true, false)) { event.preventDefault(); event.stopPropagation(); syncBubbleOnMouseUpRef.current = true } }
+      if (activeEditor && tableTextDragStart && (tableTextDragMoved || tableTextDragStart.coveredControlFallback)) { const completedTableTextDrag = tableTextDragStart, completedMultiCellDrag = Boolean(completedTableTextDrag.endCell && completedTableTextDrag.endCell !== completedTableTextDrag.cell); cancelTableTextDragPreserves(); if (completedMultiCellDrag) syncBubbleOnMouseUpRef.current = true; else if (restoreActiveTableTextDragSelection(true, true, false)) { event.preventDefault(); event.stopPropagation(); syncBubbleOnMouseUpRef.current = true; window.requestAnimationFrame(() => restoreTableCellTextSelectionIfEscaped(activeEditor, completedTableTextDrag.cell, null, true, true, false, completedTableTextDrag.endCell)) } }
       tableTextDragStartRef.current = null
       tableTextDragPendingStartRef.current = null
       codeTextDragStartRef.current = null; nonTableTextDragStartRef.current = null


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- `/editor/507` 형태의 table에서 헤더부터 하단 셀까지 드래그해도 시작 셀 한 칸만 선택되던 회귀를 복구합니다.
- ProseMirror가 cross-cell DOM selection을 접는 경로를 CSS Highlight/root attr fallback으로 보강하고, Ubuntu/Chromium native drag/drop이 table 텍스트를 셀 이동으로 바꾸는 경로도 차단했습니다.

## 작업 내용

- table multi-cell text range를 현재 셀 기준으로 재해결하고, 여러 셀 텍스트 선택 상태를 유지합니다.
- table 구조 메뉴/rail/resize control mouseup은 fallback 대상에서 제외해 row/column menu가 흔들리지 않게 했습니다.
- table 셀 내부 텍스트 drag/drop은 문서 편집이 아니라 선택만 남도록 internal table text native drag guard를 추가했습니다.
- `/editor/507` 운영 체크리스트 형태의 multi-cell drag 회귀 E2E를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-affordances.spec.ts:611 --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-affordances.spec.ts e2e/editor-authoring-table-structure.spec.ts e2e/editor-authoring-table-operations.spec.ts e2e/detail-table-rendering.spec.ts e2e/smoke-detail-rendering.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring` (guard 추가 후 2회 연속)
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front test:e2e e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `git diff --check`
  - `CURRENT_TASK_SLUG=editor-bottom-block-selection-regression bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table text selection fallback이 table 구조 조작 또는 native contenteditable drop과 충돌할 수 있습니다. 구조 메뉴/rail/resize, code drop, full authoring E2E로 회귀를 확인했습니다.
- 롤백 방법: 이 PR의 squash commit을 revert하면 이전 table selection 경로로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
