### PR TITLE
[Fix] table release preserve 유지

### DIFF
--- a/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
+++ b/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
@@ -299,4 +299,30 @@ test("live 507 형태의 table multi-cell drag는 여러 셀 텍스트를 연속
   expect(emptyNativeMouseupDrag.selectionText).toContain("확인 기준")
   expect(emptyNativeMouseupDrag.selectionText).toContain("구현되어 있는가")
   expect(await editor.locator(".selectedCell").count()).toBe(0)
+
+  await page.evaluate((selectionText) => {
+    window.getSelection()?.removeAllRanges()
+    document.documentElement.setAttribute("data-table-drag-selection-text", selectionText)
+    const table = Array.from(document.querySelectorAll("table")).find((candidate) =>
+      candidate.textContent?.includes("구현되어 있는가")
+    )
+    const startCell = Array.from(table?.querySelectorAll("th, td") ?? []).find((cell) =>
+      cell.textContent?.replace(/\s+/g, " ").trim().includes("영역")
+    )
+    startCell?.setAttribute("data-table-drag-selection-text", selectionText)
+    window.dispatchEvent(
+      new MouseEvent("mouseup", {
+        bubbles: true,
+        button: 0,
+        buttons: 0,
+        cancelable: true,
+        clientX: 0,
+        clientY: 0,
+      })
+    )
+  }, emptyNativeMouseupDrag.selectionText)
+  await page.waitForTimeout(100)
+  const afterTrailingMouseup = await readSelectionText(page)
+  expect(afterTrailingMouseup).toContain("영역")
+  expect(afterTrailingMouseup).toContain("구현되어 있는가")
 })

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -40,7 +40,7 @@ export const resolveTableTextSelectionRangeCells = (clientX: number, clientY: nu
     : null
 }
 
-let pendingTableTextSelectionRangeCells: { anchorCell: HTMLElement; pointCell: HTMLElement } | null = null
+let pendingTableTextSelectionRangeCells: { anchorCell: HTMLElement; pointCell: HTMLElement } | null = null, explicitTableTextDragStart: { cell: HTMLElement; x: number; y: number } | null = null
 let activeTableTextRangePreserveCancel: (() => void) | null = null
 const TABLE_TEXT_HIGHLIGHT_NAME = "aq-table-text-selection"
 const clearTableTextRangeHighlight = () => { document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => element.removeAttribute("data-table-drag-selection-text")); document.documentElement.removeAttribute("data-table-drag-selection-text"); (CSS as typeof CSS & { highlights?: { delete: (name: string) => void } }).highlights?.delete(TABLE_TEXT_HIGHLIGHT_NAME) }
@@ -73,7 +73,10 @@ const preserveTableTextRangeAcrossFrames = (anchorCell: HTMLElement, pointCell: 
 }
 
 export const finalizeTableTextSelectionFromPoint = (clientX: number, clientY: number, target?: EventTarget | Node | null) => {
-  const pointCell = resolveTableTextCellAtPoint(clientX, clientY, target), rangeCells = resolveTableTextSelectionRangeCells(clientX, clientY, target) ?? (pointCell ? pendingTableTextSelectionRangeCells : null); pendingTableTextSelectionRangeCells = null
+  const explicitDragStart = explicitTableTextDragStart
+  explicitTableTextDragStart = null
+  const pointCell = resolveTableTextCellAtPoint(clientX, clientY, target), explicitRangeCells = explicitDragStart && pointCell instanceof HTMLElement && pointCell.closest("table") === explicitDragStart.cell.closest("table") && (Math.abs(clientX - explicitDragStart.x) > 4 || Math.abs(clientY - explicitDragStart.y) > 4) ? { anchorCell: explicitDragStart.cell, pointCell } : null, rangeCells = resolveTableTextSelectionRangeCells(clientX, clientY, target) ?? (pointCell ? pendingTableTextSelectionRangeCells : null) ?? explicitRangeCells
+  pendingTableTextSelectionRangeCells = null
   if (!rangeCells || rangeCells.anchorCell === rangeCells.pointCell) return false
   cancelActiveTableCellTextSelectionPreserves()
   const restore = () => selectTableCellTextRange(rangeCells.anchorCell, rangeCells.pointCell)
@@ -82,12 +85,15 @@ export const finalizeTableTextSelectionFromPoint = (clientX: number, clientY: nu
   return true
 }
 
+const rememberExplicitTableTextDragStart = (event: MouseEvent | PointerEvent) => { if (event.button !== 0 || ("pointerType" in event && event.pointerType && event.pointerType !== "mouse")) return; const startCell = resolveTableTextCellAtPoint(event.clientX, event.clientY, event.target); explicitTableTextDragStart = startCell instanceof HTMLElement ? { cell: startCell, x: event.clientX, y: event.clientY } : null }
 if (typeof window !== "undefined" && typeof document !== "undefined") {
   const tableSelectionWindow = window as typeof window & { __aqTableTextSelectionFinalizerInstalled?: boolean }
   if (!tableSelectionWindow.__aqTableTextSelectionFinalizerInstalled) {
     tableSelectionWindow.__aqTableTextSelectionFinalizerInstalled = true
+    window.addEventListener("pointerdown", rememberExplicitTableTextDragStart, true); window.addEventListener("mousedown", rememberExplicitTableTextDragStart, true)
+    window.addEventListener("pointermove", (event) => { pendingTableTextSelectionRangeCells = event.buttons === 1 ? resolveTableTextSelectionRangeCells(event.clientX, event.clientY, event.target) ?? pendingTableTextSelectionRangeCells : null }, true)
     window.addEventListener("mousemove", (event) => { pendingTableTextSelectionRangeCells = event.buttons === 1 ? resolveTableTextSelectionRangeCells(event.clientX, event.clientY, event.target) ?? pendingTableTextSelectionRangeCells : null }, true)
-    window.addEventListener("mouseup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
+    window.addEventListener("pointerup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("pointercancel", () => { explicitTableTextDragStart = null }, true); window.addEventListener("mouseup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
   }
 }
 
@@ -531,9 +537,6 @@ export const preserveTableCellTextSelectionAcrossFrames = (
     activeTableCellSelectionPreserveCancels.delete(cancel)
     window.removeEventListener("pointerdown", cancel, true)
     window.removeEventListener("mousedown", cancel, true)
-    window.removeEventListener("pointerup", cancel, true)
-    window.removeEventListener("pointercancel", cancel, true)
-    window.removeEventListener("mouseup", cancel, true)
     window.removeEventListener("wheel", cancel, true)
     window.removeEventListener("scroll", cancel, true)
     window.removeEventListener("keydown", cancel, true)
@@ -564,9 +567,6 @@ export const preserveTableCellTextSelectionAcrossFrames = (
   }
   window.addEventListener("pointerdown", cancel, { capture: true, once: true })
   window.addEventListener("mousedown", cancel, { capture: true, once: true })
-  window.addEventListener("pointerup", cancel, { capture: true, once: true })
-  window.addEventListener("pointercancel", cancel, { capture: true, once: true })
-  window.addEventListener("mouseup", cancel, { capture: true, once: true })
   window.addEventListener("wheel", cancel, { capture: true, passive: true, once: true })
   window.addEventListener("scroll", cancel, { capture: true, passive: true, once: true })
   window.addEventListener("keydown", cancel, { capture: true, once: true })


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 실제 Chrome 배포본에서 table multi-cell drag가 pointerup 직후 trailing mouseup에 의해 selection/data attr가 비워지는 회귀를 다시 고정합니다.
- native selection이 비어도 mousedown 시작 셀과 mouseup 종료 셀로 table text range를 확정해 사진처럼 여러 셀 텍스트 선택이 남도록 합니다.

## 작업 내용

- table text drag start cell을 전역 finalizer에서 별도로 보존해 native selection fallback이 비어도 multi-cell range를 확정합니다.
- table text selection preserve가 같은 제스처의 release 이벤트를 다음 입력으로 오인해 즉시 취소하지 않도록 release cancel을 제거했습니다.
- multi-cell E2E에 trailing mouseup 이후 persisted selection 유지 검증을 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - 실제 Chrome `https://www.aquilaxk.site/editor/507`: buildSha `86a621d64b3f9c04760f017ac88c8e37bd110168`에서 multi-cell drag가 `selectionText=""`, `.selectedCell=0`, scrollDelta 0으로 재현됨
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-multicell-selection.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-affordances.spec.ts e2e/editor-authoring-table-structure.spec.ts e2e/editor-authoring-table-operations.spec.ts e2e/detail-table-rendering.spec.ts e2e/smoke-detail-rendering.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring` (2회 연속, 각 101 passed)
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front test:e2e e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `git diff --check`
  - `CURRENT_TASK_SLUG=editor-bottom-block-selection-regression bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table 구조 조작 drag와 table text drag의 구분 회귀.
- 롤백 방법: 이 PR의 squash commit을 revert하면 기존 table selection preserve 계약으로 되돌릴 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
