### PR TITLE
[Fix] table cancel release 선택 유지

### DIFF
--- a/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
+++ b/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
@@ -32,16 +32,24 @@ const dragBetweenTextRanges = async (
   endTarget: Locator,
   label: string,
   texts: { end: string; start: string },
-  options: { syntheticWithoutNativeSelection?: boolean } = {}
+  options: { cancelAtStart?: boolean; cancelBeforeMouseup?: boolean; skipSyntheticMoves?: boolean; syntheticWithoutNativeSelection?: boolean } = {}
 ) => {
-  await startTarget.scrollIntoViewIfNeeded()
-  await endTarget.waitFor({ state: "attached", timeout: 5_000 })
-  const metrics = await startTarget.evaluate(
-    (startElement, { endText, label, startText }) => {
-      const table = startElement.closest("table")
-      const endElement = Array.from(table?.querySelectorAll("th, td") ?? []).find((candidate) =>
+  await startTarget.count()
+  await endTarget.count()
+  const metrics = await page.evaluate(
+    ({ endText, label, startText }) => {
+      const table = Array.from(document.querySelectorAll("table")).find((candidate) => {
+        const text = candidate.textContent?.replace(/\s+/g, " ").trim() ?? ""
+        return text.includes(startText) && text.includes(endText)
+      })
+      const cells = Array.from(table?.querySelectorAll("th, td") ?? [])
+      const startElement = cells.find((candidate) =>
+        candidate.textContent?.replace(/\s+/g, " ").trim().includes(startText)
+      )
+      const endElement = cells.find((candidate) =>
         candidate.textContent?.replace(/\s+/g, " ").trim().includes(endText)
       )
+      if (!startElement) throw new Error(`${label} start cell is missing`)
       if (!endElement) throw new Error(`${label} end cell is missing`)
       table?.scrollIntoView({ block: "center", inline: "nearest", behavior: "instant" })
 
@@ -80,7 +88,7 @@ const dragBetweenTextRanges = async (
   const beforeScrollTop = await readScrollTop(page)
 
   if (options.syntheticWithoutNativeSelection) {
-    await page.evaluate(({ end, start }) => {
+    await page.evaluate(({ cancelAtStart, cancelBeforeMouseup, end, skipSyntheticMoves, start }) => {
       window.getSelection()?.removeAllRanges()
       document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => {
         element.removeAttribute("data-table-drag-selection-text")
@@ -104,18 +112,21 @@ const dragBetweenTextRanges = async (
       }
       dispatch("pointerdown", start, 1)
       dispatch("mousedown", start, 1)
-      for (let index = 1; index <= 36; index += 1) {
-        const ratio = index / 36
-        const point = {
-          x: start.x + (end.x - start.x) * ratio,
-          y: start.y + (end.y - start.y) * ratio,
+      if (!skipSyntheticMoves) {
+        for (let index = 1; index <= 36; index += 1) {
+          const ratio = index / 36
+          const point = {
+            x: start.x + (end.x - start.x) * ratio,
+            y: start.y + (end.y - start.y) * ratio,
+          }
+          dispatch("pointermove", point, 1)
+          dispatch("mousemove", point, 1)
         }
-        dispatch("pointermove", point, 1)
-        dispatch("mousemove", point, 1)
       }
-      dispatch("pointerup", end, 0)
+      if (cancelBeforeMouseup) dispatch("pointercancel", cancelAtStart ? start : end, 0)
+      else dispatch("pointerup", end, 0)
       dispatch("mouseup", end, 0)
-    }, metrics)
+    }, { ...metrics, cancelAtStart: options.cancelAtStart ?? false, cancelBeforeMouseup: options.cancelBeforeMouseup ?? false, skipSyntheticMoves: options.skipSyntheticMoves ?? false })
     await page.waitForTimeout(1_000)
     return { beforeScrollTop, afterScrollTop: await readScrollTop(page), selectionText: await readSelectionText(page) }
   }
@@ -298,6 +309,32 @@ test("live 507 형태의 table multi-cell drag는 여러 셀 텍스트를 연속
   expect(emptyNativeMouseupDrag.selectionText).toContain("점검 항목")
   expect(emptyNativeMouseupDrag.selectionText).toContain("확인 기준")
   expect(emptyNativeMouseupDrag.selectionText).toContain("구현되어 있는가")
+  expect(await editor.locator(".selectedCell").count()).toBe(0)
+
+  await page.evaluate(() => {
+    window.getSelection()?.removeAllRanges()
+    document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => {
+      element.removeAttribute("data-table-drag-selection-text")
+    })
+    document.documentElement.removeAttribute("data-table-drag-selection-text")
+  })
+
+  const pointerCancelBeforeMouseupDrag = await dragBetweenTextRanges(
+    page,
+    startCell,
+    endCell,
+    "live 507 table multi-cell drag with pointercancel before mouseup",
+    {
+      end: "구현되어 있는가",
+      start: "영역",
+    },
+    { cancelAtStart: true, cancelBeforeMouseup: true, skipSyntheticMoves: true, syntheticWithoutNativeSelection: true }
+  )
+
+  expect(pointerCancelBeforeMouseupDrag.selectionText).toContain("영역")
+  expect(pointerCancelBeforeMouseupDrag.selectionText).toContain("점검 항목")
+  expect(pointerCancelBeforeMouseupDrag.selectionText).toContain("확인 기준")
+  expect(pointerCancelBeforeMouseupDrag.selectionText).toContain("구현되어 있는가")
   expect(await editor.locator(".selectedCell").count()).toBe(0)
 
   await page.evaluate((selectionText) => {

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -93,7 +93,7 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
     window.addEventListener("pointerdown", rememberExplicitTableTextDragStart, true); window.addEventListener("mousedown", rememberExplicitTableTextDragStart, true)
     window.addEventListener("pointermove", (event) => { pendingTableTextSelectionRangeCells = event.buttons === 1 ? resolveTableTextSelectionRangeCells(event.clientX, event.clientY, event.target) ?? pendingTableTextSelectionRangeCells : null }, true)
     window.addEventListener("mousemove", (event) => { pendingTableTextSelectionRangeCells = event.buttons === 1 ? resolveTableTextSelectionRangeCells(event.clientX, event.clientY, event.target) ?? pendingTableTextSelectionRangeCells : null }, true)
-    window.addEventListener("pointerup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("pointercancel", () => { explicitTableTextDragStart = null }, true); window.addEventListener("mouseup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
+    window.addEventListener("pointerup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("mouseup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("dragend", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 실제 Chrome `/editor/507`에서 table multi-cell drag가 시작 좌표 `pointercancel` 이후 release 좌표 `mouseup/dragend`를 잃어 선택 텍스트가 비는 회귀를 막습니다.
- `영역`에서 `구현되어 있는가`까지 사진처럼 여러 셀 텍스트가 연속 선택되는 경로를 regression으로 고정했습니다.

## 작업 내용

- table text global finalizer가 `pointercancel`에서 explicit drag start를 지우지 않고, `dragend`에서도 release 좌표를 finalizer로 처리합니다.
- live 507 형태 multi-cell table drag E2E에 `pointercancel`이 시작 좌표에서 먼저 오는 synthetic regression을 추가했습니다.
- table 좌표 측정 helper가 re-render된 table DOM에도 현재 셀 텍스트 기준으로 다시 측정하게 보강됐습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-multicell-selection.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-affordances.spec.ts e2e/editor-authoring-table-structure.spec.ts e2e/editor-authoring-table-operations.spec.ts e2e/detail-table-rendering.spec.ts e2e/smoke-detail-rendering.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring` 2회 연속
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front test:e2e e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `git diff --check`
  - `CURRENT_TASK_SLUG=editor-bottom-block-selection-regression bash tools/guards/current-task-preflight.sh`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table drag release 이벤트 순서 차이를 보존하는 변경이라 table 구조 drag/resize와의 이벤트 경계가 중요합니다. 관련 table affordance/structure/operation 회귀 31개와 authoring 전체 101개 2회로 확인했습니다.
- 롤백 방법: 이 PR의 squash commit을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
