### PR TITLE
[Fix] table drop release 선택 유지

### DIFF
--- a/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
+++ b/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
@@ -32,7 +32,7 @@ const dragBetweenTextRanges = async (
   endTarget: Locator,
   label: string,
   texts: { end: string; start: string },
-  options: { cancelAtStart?: boolean; cancelBeforeMouseup?: boolean; skipSyntheticMoves?: boolean; syntheticWithoutNativeSelection?: boolean } = {}
+  options: { cancelAtStart?: boolean; cancelBeforeMouseup?: boolean; dropInsteadOfMouseup?: boolean; skipSyntheticMoves?: boolean; syntheticWithoutNativeSelection?: boolean } = {}
 ) => {
   await startTarget.count()
   await endTarget.count()
@@ -88,7 +88,7 @@ const dragBetweenTextRanges = async (
   const beforeScrollTop = await readScrollTop(page)
 
   if (options.syntheticWithoutNativeSelection) {
-    await page.evaluate(({ cancelAtStart, cancelBeforeMouseup, end, skipSyntheticMoves, start }) => {
+    await page.evaluate(({ cancelAtStart, cancelBeforeMouseup, dropInsteadOfMouseup, end, skipSyntheticMoves, start }) => {
       window.getSelection()?.removeAllRanges()
       document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => {
         element.removeAttribute("data-table-drag-selection-text")
@@ -125,8 +125,9 @@ const dragBetweenTextRanges = async (
       }
       if (cancelBeforeMouseup) dispatch("pointercancel", cancelAtStart ? start : end, 0)
       else dispatch("pointerup", end, 0)
-      dispatch("mouseup", end, 0)
-    }, { ...metrics, cancelAtStart: options.cancelAtStart ?? false, cancelBeforeMouseup: options.cancelBeforeMouseup ?? false, skipSyntheticMoves: options.skipSyntheticMoves ?? false })
+      if (dropInsteadOfMouseup) dispatch("drop", end, 0)
+      else dispatch("mouseup", end, 0)
+    }, { ...metrics, cancelAtStart: options.cancelAtStart ?? false, cancelBeforeMouseup: options.cancelBeforeMouseup ?? false, dropInsteadOfMouseup: options.dropInsteadOfMouseup ?? false, skipSyntheticMoves: options.skipSyntheticMoves ?? false })
     await page.waitForTimeout(1_000)
     return { beforeScrollTop, afterScrollTop: await readScrollTop(page), selectionText: await readSelectionText(page) }
   }
@@ -335,6 +336,32 @@ test("live 507 형태의 table multi-cell drag는 여러 셀 텍스트를 연속
   expect(pointerCancelBeforeMouseupDrag.selectionText).toContain("점검 항목")
   expect(pointerCancelBeforeMouseupDrag.selectionText).toContain("확인 기준")
   expect(pointerCancelBeforeMouseupDrag.selectionText).toContain("구현되어 있는가")
+  expect(await editor.locator(".selectedCell").count()).toBe(0)
+
+  await page.evaluate(() => {
+    window.getSelection()?.removeAllRanges()
+    document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => {
+      element.removeAttribute("data-table-drag-selection-text")
+    })
+    document.documentElement.removeAttribute("data-table-drag-selection-text")
+  })
+
+  const dropReleaseDrag = await dragBetweenTextRanges(
+    page,
+    startCell,
+    endCell,
+    "live 507 table multi-cell drag with drop release",
+    {
+      end: "구현되어 있는가",
+      start: "영역",
+    },
+    { cancelAtStart: true, cancelBeforeMouseup: true, dropInsteadOfMouseup: true, skipSyntheticMoves: true, syntheticWithoutNativeSelection: true }
+  )
+
+  expect(dropReleaseDrag.selectionText).toContain("영역")
+  expect(dropReleaseDrag.selectionText).toContain("점검 항목")
+  expect(dropReleaseDrag.selectionText).toContain("확인 기준")
+  expect(dropReleaseDrag.selectionText).toContain("구현되어 있는가")
   expect(await editor.locator(".selectedCell").count()).toBe(0)
 
   await page.evaluate((selectionText) => {

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -93,7 +93,7 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
     window.addEventListener("pointerdown", rememberExplicitTableTextDragStart, true); window.addEventListener("mousedown", rememberExplicitTableTextDragStart, true)
     window.addEventListener("pointermove", (event) => { pendingTableTextSelectionRangeCells = event.buttons === 1 ? resolveTableTextSelectionRangeCells(event.clientX, event.clientY, event.target) ?? pendingTableTextSelectionRangeCells : null }, true)
     window.addEventListener("mousemove", (event) => { pendingTableTextSelectionRangeCells = event.buttons === 1 ? resolveTableTextSelectionRangeCells(event.clientX, event.clientY, event.target) ?? pendingTableTextSelectionRangeCells : null }, true)
-    window.addEventListener("pointerup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("mouseup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("dragend", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
+    window.addEventListener("pointerup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("mouseup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("dragend", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("drop", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 실제 Chrome에서 운영 체크리스트 표의 대각선 drag release가 `drop`으로 끝날 때 table text finalizer가 종료 좌표를 받지 못해 다중 셀 선택이 빈 값으로 끝나는 follow-up입니다.
- `drop` release도 table text selection 확정 경로에 연결하고, `pointercancel -> drop` 회귀 테스트를 추가했습니다.

## 작업 내용

- table text selection global finalizer가 `pointerup`/`mouseup`/`dragend`뿐 아니라 `drop`에서도 시작/종료 셀 range를 확정합니다.
- live 507 형태 multi-cell table drag E2E에 `pointercancel(start) -> drop(end)` 경로를 추가해 셀 블록 선택 없이 여러 셀 텍스트가 유지되는지 확인합니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-bottom-block-selection-regression bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-multicell-selection.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-affordances.spec.ts e2e/editor-authoring-table-structure.spec.ts e2e/editor-authoring-table-operations.spec.ts e2e/detail-table-rendering.spec.ts e2e/smoke-detail-rendering.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring` (2회 연속)
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front test:e2e e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table drop 종료 이벤트가 구조적 table drag/drop과 충돌할 수 있으나, 기존 finalizer가 cell text drag start/range를 요구하므로 텍스트 선택 경로에 한정됩니다.
- 롤백 방법: 이 PR의 squash commit을 revert하면 이전 table release 처리로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
