### PR TITLE
[Fix] table dragover 선택 유지

### DIFF
--- a/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
+++ b/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
@@ -32,7 +32,7 @@ const dragBetweenTextRanges = async (
   endTarget: Locator,
   label: string,
   texts: { end: string; start: string },
-  options: { cancelAtStart?: boolean; cancelBeforeMouseup?: boolean; dropInsteadOfMouseup?: boolean; skipSyntheticMoves?: boolean; syntheticWithoutNativeSelection?: boolean } = {}
+  options: { cancelAtStart?: boolean; cancelBeforeMouseup?: boolean; dragOverBeforeRelease?: boolean; dropInsteadOfMouseup?: boolean; skipRelease?: boolean; skipSyntheticMoves?: boolean; syntheticWithoutNativeSelection?: boolean } = {}
 ) => {
   await startTarget.count()
   await endTarget.count()
@@ -88,7 +88,7 @@ const dragBetweenTextRanges = async (
   const beforeScrollTop = await readScrollTop(page)
 
   if (options.syntheticWithoutNativeSelection) {
-    await page.evaluate(({ cancelAtStart, cancelBeforeMouseup, dropInsteadOfMouseup, end, skipSyntheticMoves, start }) => {
+    await page.evaluate(({ cancelAtStart, cancelBeforeMouseup, dragOverBeforeRelease, dropInsteadOfMouseup, end, skipRelease, skipSyntheticMoves, start }) => {
       window.getSelection()?.removeAllRanges()
       document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => {
         element.removeAttribute("data-table-drag-selection-text")
@@ -123,11 +123,14 @@ const dragBetweenTextRanges = async (
           dispatch("mousemove", point, 1)
         }
       }
+      if (dragOverBeforeRelease) dispatch("dragover", end, 1)
       if (cancelBeforeMouseup) dispatch("pointercancel", cancelAtStart ? start : end, 0)
       else dispatch("pointerup", end, 0)
-      if (dropInsteadOfMouseup) dispatch("drop", end, 0)
-      else dispatch("mouseup", end, 0)
-    }, { ...metrics, cancelAtStart: options.cancelAtStart ?? false, cancelBeforeMouseup: options.cancelBeforeMouseup ?? false, dropInsteadOfMouseup: options.dropInsteadOfMouseup ?? false, skipSyntheticMoves: options.skipSyntheticMoves ?? false })
+      if (!skipRelease) {
+        if (dropInsteadOfMouseup) dispatch("drop", end, 0)
+        else dispatch("mouseup", end, 0)
+      }
+    }, { ...metrics, cancelAtStart: options.cancelAtStart ?? false, cancelBeforeMouseup: options.cancelBeforeMouseup ?? false, dragOverBeforeRelease: options.dragOverBeforeRelease ?? false, dropInsteadOfMouseup: options.dropInsteadOfMouseup ?? false, skipRelease: options.skipRelease ?? false, skipSyntheticMoves: options.skipSyntheticMoves ?? false })
     await page.waitForTimeout(1_000)
     return { beforeScrollTop, afterScrollTop: await readScrollTop(page), selectionText: await readSelectionText(page) }
   }
@@ -362,6 +365,32 @@ test("live 507 형태의 table multi-cell drag는 여러 셀 텍스트를 연속
   expect(dropReleaseDrag.selectionText).toContain("점검 항목")
   expect(dropReleaseDrag.selectionText).toContain("확인 기준")
   expect(dropReleaseDrag.selectionText).toContain("구현되어 있는가")
+  expect(await editor.locator(".selectedCell").count()).toBe(0)
+
+  await page.evaluate(() => {
+    window.getSelection()?.removeAllRanges()
+    document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => {
+      element.removeAttribute("data-table-drag-selection-text")
+    })
+    document.documentElement.removeAttribute("data-table-drag-selection-text")
+  })
+
+  const dragOverCancelDrag = await dragBetweenTextRanges(
+    page,
+    startCell,
+    endCell,
+    "live 507 table multi-cell drag with dragover before pointercancel",
+    {
+      end: "구현되어 있는가",
+      start: "영역",
+    },
+    { cancelAtStart: true, cancelBeforeMouseup: true, dragOverBeforeRelease: true, skipRelease: true, skipSyntheticMoves: true, syntheticWithoutNativeSelection: true }
+  )
+
+  expect(dragOverCancelDrag.selectionText).toContain("영역")
+  expect(dragOverCancelDrag.selectionText).toContain("점검 항목")
+  expect(dragOverCancelDrag.selectionText).toContain("확인 기준")
+  expect(dragOverCancelDrag.selectionText).toContain("구현되어 있는가")
   expect(await editor.locator(".selectedCell").count()).toBe(0)
 
   await page.evaluate((selectionText) => {

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -35,9 +35,7 @@ export const resolveTableTextSelectionRangeCells = (clientX: number, clientY: nu
     const cellText = normalizeCellText(cell)
     return cellText === selectedText || cellText.includes(selectedText) || selectedText.includes(cellText)
   })
-  return pointCell instanceof HTMLElement && anchorCell instanceof HTMLElement && selectedText && pointTable === anchorCell.closest("table")
-    ? { anchorCell, pointCell }
-    : null
+  return pointCell instanceof HTMLElement && anchorCell instanceof HTMLElement && selectedText && pointTable === anchorCell.closest("table") ? { anchorCell, pointCell } : null
 }
 
 let pendingTableTextSelectionRangeCells: { anchorCell: HTMLElement; pointCell: HTMLElement } | null = null, explicitTableTextDragStart: { cell: HTMLElement; x: number; y: number } | null = null
@@ -45,6 +43,8 @@ let activeTableTextRangePreserveCancel: (() => void) | null = null
 const TABLE_TEXT_HIGHLIGHT_NAME = "aq-table-text-selection"
 const clearTableTextRangeHighlight = () => { document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => element.removeAttribute("data-table-drag-selection-text")); document.documentElement.removeAttribute("data-table-drag-selection-text"); (CSS as typeof CSS & { highlights?: { delete: (name: string) => void } }).highlights?.delete(TABLE_TEXT_HIGHLIGHT_NAME) }
 const paintTableTextRangeHighlight = (range: Range) => { const HighlightCtor = (window as typeof window & { Highlight?: new (range: Range) => unknown }).Highlight, highlights = (CSS as typeof CSS & { highlights?: { set: (name: string, highlight: unknown) => void } }).highlights; if (!HighlightCtor || !highlights) return; if (!document.getElementById("aq-table-text-highlight-style")) { const style = document.createElement("style"); style.id = "aq-table-text-highlight-style"; style.textContent = `::highlight(${TABLE_TEXT_HIGHLIGHT_NAME}){background:#0a5b9d;color:white}`; document.head.append(style) } highlights.set(TABLE_TEXT_HIGHLIGHT_NAME, new HighlightCtor(range.cloneRange())) }
+const resolveExplicitTableTextSelectionRangeCells = (clientX: number, clientY: number, target?: EventTarget | Node | null, explicitDragStart = explicitTableTextDragStart) => { const pointCell = resolveTableTextCellAtPoint(clientX, clientY, target); return explicitDragStart && pointCell instanceof HTMLElement && pointCell.closest("table") === explicitDragStart.cell.closest("table") && (Math.abs(clientX - explicitDragStart.x) > 4 || Math.abs(clientY - explicitDragStart.y) > 4) ? { anchorCell: explicitDragStart.cell, pointCell } : null }
+const preserveExplicitTableTextSelectionFromPoint = (clientX: number, clientY: number, target?: EventTarget | Node | null) => { const rangeCells = resolveExplicitTableTextSelectionRangeCells(clientX, clientY, target); if (!rangeCells || rangeCells.anchorCell === rangeCells.pointCell) return false; pendingTableTextSelectionRangeCells = rangeCells; selectTableCellTextRange(rangeCells.anchorCell, rangeCells.pointCell); preserveTableTextRangeAcrossFrames(rangeCells.anchorCell, rangeCells.pointCell); return true }
 
 const preserveTableTextRangeAcrossFrames = (anchorCell: HTMLElement, pointCell: HTMLElement) => {
   activeTableTextRangePreserveCancel?.()
@@ -75,7 +75,7 @@ const preserveTableTextRangeAcrossFrames = (anchorCell: HTMLElement, pointCell: 
 export const finalizeTableTextSelectionFromPoint = (clientX: number, clientY: number, target?: EventTarget | Node | null) => {
   const explicitDragStart = explicitTableTextDragStart
   explicitTableTextDragStart = null
-  const pointCell = resolveTableTextCellAtPoint(clientX, clientY, target), explicitRangeCells = explicitDragStart && pointCell instanceof HTMLElement && pointCell.closest("table") === explicitDragStart.cell.closest("table") && (Math.abs(clientX - explicitDragStart.x) > 4 || Math.abs(clientY - explicitDragStart.y) > 4) ? { anchorCell: explicitDragStart.cell, pointCell } : null, rangeCells = resolveTableTextSelectionRangeCells(clientX, clientY, target) ?? (pointCell ? pendingTableTextSelectionRangeCells : null) ?? explicitRangeCells
+  const pointCell = resolveTableTextCellAtPoint(clientX, clientY, target), explicitRangeCells = resolveExplicitTableTextSelectionRangeCells(clientX, clientY, target, explicitDragStart), rangeCells = resolveTableTextSelectionRangeCells(clientX, clientY, target) ?? (pointCell ? pendingTableTextSelectionRangeCells : null) ?? explicitRangeCells
   pendingTableTextSelectionRangeCells = null
   if (!rangeCells || rangeCells.anchorCell === rangeCells.pointCell) return false
   cancelActiveTableCellTextSelectionPreserves()
@@ -93,6 +93,8 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
     window.addEventListener("pointerdown", rememberExplicitTableTextDragStart, true); window.addEventListener("mousedown", rememberExplicitTableTextDragStart, true)
     window.addEventListener("pointermove", (event) => { pendingTableTextSelectionRangeCells = event.buttons === 1 ? resolveTableTextSelectionRangeCells(event.clientX, event.clientY, event.target) ?? pendingTableTextSelectionRangeCells : null }, true)
     window.addEventListener("mousemove", (event) => { pendingTableTextSelectionRangeCells = event.buttons === 1 ? resolveTableTextSelectionRangeCells(event.clientX, event.clientY, event.target) ?? pendingTableTextSelectionRangeCells : null }, true)
+    window.addEventListener("dragover", (event) => { if (preserveExplicitTableTextSelectionFromPoint(event.clientX, event.clientY, event.target)) event.preventDefault() }, true)
+    window.addEventListener("dragenter", (event) => { if (preserveExplicitTableTextSelectionFromPoint(event.clientX, event.clientY, event.target)) event.preventDefault() }, true)
     window.addEventListener("pointerup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("mouseup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("dragend", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("drop", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
   }
 }
@@ -100,9 +102,7 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
 const normalizeCellText = (cell: Element | null | undefined) => cell?.textContent?.replace(/\s+/g, " ").trim() ?? ""
 
 const resolveCellTable = (cell: HTMLElement | null | undefined) => cell?.closest("table") ?? null
-
-const isConnectedTableCell = (cell: HTMLElement) =>
-  cell.isConnected && document.documentElement.contains(cell)
+const isConnectedTableCell = (cell: HTMLElement) => cell.isConnected && document.documentElement.contains(cell)
 
 const resolveCurrentTableTextRangeCells = (
   startedCell: HTMLElement,


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- PR #508 배포본에서도 실제 Chrome table multi-cell drag가 `selectionText=""`로 끝나, release 이벤트 이전 native dragover/cancel 경로에서 range가 비는 문제가 남았습니다.
- table text drag가 native `dragover`에 들어간 시점에 시작 셀부터 현재 셀까지 range를 먼저 확정하고, release가 없어도 선택 텍스트가 유지되도록 보강했습니다.

## 작업 내용

- explicit table text drag start가 살아 있는 동안 `dragover`/`dragenter` 좌표가 같은 table의 다른 셀로 이동하면 multi-cell text range를 즉시 선택/보존합니다.
- `dragover -> pointercancel -> release 없음` 회귀 테스트를 추가해 실제 Chrome native drag 전환 경로를 고정했습니다.
- `tableTextSelectionModel.ts`는 refactor-boundaries 600라인 제한 안에 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-bottom-block-selection-regression bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-multicell-selection.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-affordances.spec.ts e2e/editor-authoring-table-structure.spec.ts e2e/editor-authoring-table-operations.spec.ts e2e/detail-table-rendering.spec.ts e2e/smoke-detail-rendering.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring` (2회 연속)
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front test:e2e e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table 구조 drag와 충돌 가능성이 있으나 explicit text drag start와 같은 table의 다른 cell 이동 조건에만 작동합니다.
- 롤백 방법: 이 PR의 squash commit을 revert하면 PR #508 상태로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
