### PR TITLE
[Fix] table workflow 선택 이동 복구

### DIFF
--- a/front/e2e/editor-authoring-block-selection.spec.ts
+++ b/front/e2e/editor-authoring-block-selection.spec.ts
@@ -307,6 +307,59 @@ test.describe("editor authoring block selection and drag", () => {
     await page.mouse.up()
   })
 
+  test("table block handle drag는 표 전체 block을 이동한다", async ({ page }) => {
+    const tableMarkdown = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[180,180]} -->',
+      "| 구분 | 값 |",
+      "| --- | --- |",
+      "| table-block-marker | 이동 대상 |",
+    ].join("\n")
+    await page.goto(QA_WRITER_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.click()
+    await editor.evaluate((element, markdown) => {
+      const data = new DataTransfer()
+      data.setData("text/plain", markdown)
+      const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true })
+      Object.defineProperty(event, "clipboardData", { value: data })
+      element.dispatchEvent(event)
+    }, ["테이블 위 문단", tableMarkdown, "테이블 아래 문단"].join("\n\n"))
+    await expect(editor).toContainText("table-block-marker")
+
+    const table = editor.locator(".tableWrapper table").first()
+    const trailingParagraph = editor.locator(":scope > p", { hasText: "테이블 아래 문단" }).first()
+    const tableBox = await table.boundingBox()
+    const trailingBox = await trailingParagraph.boundingBox()
+    if (!tableBox || !trailingBox) {
+      throw new Error("table block drag 좌표를 계산할 수 없습니다.")
+    }
+
+    await page.mouse.move(tableBox.x + 24, tableBox.y + 24)
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    const handleBox = await dragHandle.boundingBox()
+    if (!handleBox) {
+      throw new Error("table block drag handle 좌표를 계산할 수 없습니다.")
+    }
+
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(trailingBox.x + 24, trailingBox.y + trailingBox.height + 18, { steps: 10 })
+    await expect(page.getByTestId("block-drag-ghost")).toBeVisible()
+    await page.mouse.up()
+
+    const blockOrder = await editor.evaluate((element) =>
+      Array.from(element.children).map((child) => child.textContent?.replace(/\s+/g, " ").trim() ?? "")
+    )
+    const topIndex = blockOrder.findIndex((text) => text.includes("테이블 위 문단"))
+    const trailingIndex = blockOrder.findIndex((text) => text.includes("테이블 아래 문단"))
+    const tableIndex = blockOrder.findIndex((text) => text.includes("table-block-marker"))
+    expect(topIndex).toBeGreaterThanOrEqual(0)
+    expect(trailingIndex).toBeGreaterThan(topIndex)
+    expect(tableIndex).toBeGreaterThan(trailingIndex)
+  })
+
   test("구분선 block handle은 다음 문단이 아니라 divider 중심에 맞춰 뜬다", async ({ page }) => {
     await page.goto(QA_ENGINE_ROUTE)
 

--- a/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
+++ b/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
@@ -309,6 +309,19 @@ test("live 507 형태의 table multi-cell drag는 여러 셀 텍스트를 연속
     { syntheticWithoutNativeSelection: true }
   )
 
+  if (!emptyNativeMouseupDrag.selectionText.includes("영역")) {
+    const diagnostics = await page.evaluate(() => ({
+      events: ((window as typeof window & { __qaMultiCellDragEvents?: unknown[] }).__qaMultiCellDragEvents ?? []).slice(-80),
+      htmlPersisted: document.documentElement.getAttribute("data-table-drag-selection-text"),
+      persisted: Array.from(document.querySelectorAll("[data-table-drag-selection-text]")).map((element) => ({
+        tagName: element.tagName,
+        text: element.textContent?.replace(/\s+/g, " ").trim().slice(0, 120),
+        value: element.getAttribute("data-table-drag-selection-text"),
+      })),
+      selectionText: window.getSelection()?.toString() ?? "",
+    }))
+    throw new Error(`empty native mouseup multi-cell drag lost selection: ${JSON.stringify({ diagnostics, emptyNativeMouseupDrag })}`)
+  }
   expect(emptyNativeMouseupDrag.selectionText).toContain("영역")
   expect(emptyNativeMouseupDrag.selectionText).toContain("점검 항목")
   expect(emptyNativeMouseupDrag.selectionText).toContain("확인 기준")

--- a/front/e2e/editor-authoring-selection-drag.spec.ts
+++ b/front/e2e/editor-authoring-selection-drag.spec.ts
@@ -119,6 +119,29 @@ const expectSelectionScopedToWord = async (page: Page, word: string, unrelatedWo
     .toBe(true)
 }
 
+const expectSelectionContainsOnly = async (page: Page, includedWords: string[], excludedWords: string[]) => {
+  await expect
+    .poll(
+      async () => {
+        const selectionText = await page.evaluate(() => {
+          const text =
+            window.getSelection()?.toString() ||
+            document.documentElement.getAttribute("data-table-drag-selection-text") ||
+            document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text") ||
+            document.querySelector("[data-code-drag-selection-text]")?.getAttribute("data-code-drag-selection-text") ||
+            ""
+          return text.replace(/\s+/g, " ").trim()
+        })
+        return (
+          includedWords.every((includedWord) => selectionText.includes(includedWord)) &&
+          excludedWords.every((excludedWord) => !selectionText.includes(excludedWord))
+        )
+      },
+      { timeout: 2_000 }
+    )
+    .toBe(true)
+}
+
 const expectCodeHighlightLayerAligned = async (page: Page, word: string) => {
   const metrics = await page.evaluate((targetWord) => {
     const content = Array.from(document.querySelectorAll<HTMLElement>(".aq-code-editor-content")).find((element) =>
@@ -225,7 +248,7 @@ test.describe("editor authoring route text selection drag", () => {
     const tableCellPoints = await getWordDragPoints(tableCell, tableLabel)
     await page.mouse.click(tableCellPoints.startX, tableCellPoints.startY)
     await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A")
-    await expectSelectionScopedToWord(page, tableLabel, [bodyLabel, codeLabel])
+    await expectSelectionContainsOnly(page, ["구분", "값", tableLabel], [bodyLabel, codeLabel])
 
     await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
     expect(runtimeErrors).toEqual([])

--- a/front/e2e/editor-authoring-selection-drag.spec.ts
+++ b/front/e2e/editor-authoring-selection-drag.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Locator, type Page } from "@playwright/test"
 import {
+  QA_WRITER_ROUTE,
   expectEditorToContainLoadedText,
   getWordDragPoints,
   selectWordInEditable,
@@ -169,6 +170,57 @@ const expectCodeHighlightLayerAligned = async (page: Page, word: string) => {
 }
 
 test.describe("editor authoring route text selection drag", () => {
+  test("writer table cell 기존 텍스트 선택 후 단순 클릭은 caret만 남긴다", async ({ page }) => {
+    await page.goto(QA_WRITER_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.click()
+    await page.getByRole("button", { name: "테이블", exact: true }).first().click()
+
+    const firstCell = page.locator("table th, table td").first()
+    await firstCell.click()
+    await page.keyboard.type("셀 커서 테스트")
+
+    await selectWordInEditable(page, firstCell, "커서")
+    await expect
+      .poll(async () => page.evaluate(() => window.getSelection()?.toString().replace(/\s+/g, " ").trim() ?? ""))
+      .toContain("커서")
+
+    const points = await getWordDragPoints(firstCell, "테스트")
+    await page.mouse.click(points.startX, points.startY)
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() => {
+          const selection = window.getSelection()
+          const anchorElement =
+            selection?.anchorNode instanceof Element
+              ? selection.anchorNode
+              : selection?.anchorNode?.parentElement ?? null
+          const focusElement =
+            selection?.focusNode instanceof Element
+              ? selection.focusNode
+              : selection?.focusNode?.parentElement ?? null
+          return {
+            blockOverlayCount: document.querySelectorAll("[data-testid='keyboard-block-selection-overlay']").length,
+            inCell: Boolean(anchorElement?.closest("th, td") && focusElement?.closest("th, td")),
+            persistedText: document.documentElement.getAttribute("data-table-drag-selection-text") || "",
+            selectedCellCount: document.querySelectorAll(".selectedCell").length,
+            selectionCollapsed: selection?.isCollapsed ?? false,
+            selectionText: selection?.toString().replace(/\s+/g, " ").trim() ?? "",
+          }
+        })
+      )
+      .toEqual({
+        blockOverlayCount: 0,
+        inCell: true,
+        persistedText: "",
+        selectedCellCount: 0,
+        selectionCollapsed: true,
+        selectionText: "",
+      })
+  })
+
   test("실제 /editor/[id] 텍스트 드래그 선택은 code/table/body에서 에러 없이 유지된다", async ({
     page,
   }) => {

--- a/front/e2e/editor-authoring-selection-drag.spec.ts
+++ b/front/e2e/editor-authoring-selection-drag.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Locator, type Page } from "@playwright/test"
 import {
   expectEditorToContainLoadedText,
   getWordDragPoints,
+  selectWordInEditable,
 } from "./helpers/editorAuthoringFlow"
 
 const adminMember = {
@@ -337,5 +338,144 @@ test.describe("editor authoring route text selection drag", () => {
     await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
     const afterScrollTop = await page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
     expect(Math.abs(afterScrollTop - points.scrollTop)).toBeLessThanOrEqual(24)
+  })
+
+  test("table multi-cell 선택 toolbar는 이전 본문 selection anchor로 순간이동하지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    const staleAnchorLabel = "이전 글 선택 anchor"
+    const filler = Array.from({ length: 54 }, (_, index) =>
+      index === 4
+        ? `${staleAnchorLabel} ${index + 1}. table 선택 전 이전 본문 selection anchor가 남아 있습니다.`
+        : `toolbar stale anchor filler ${index + 1}. 글 선택 toolbar 위치 회귀를 재현하기 위한 긴 본문입니다.`
+    )
+    const tableMarkdown = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[160,220,240]} -->',
+      "| 영역 | 점검 항목 | 확인 기준 |",
+      "| --- | --- | --- |",
+      "| 개념 이해 | Stateless 의미 | 요청만으로 처리 가능한가 |",
+      "| 토큰 구조 | Access/Refresh 구분 | 역할 명확 |",
+      "| 보안 | HTTPS 사용 | 필수 |",
+      "| 저장소 | Refresh 저장 | DB/Redis |",
+      "| 만료 | Access 짧게 | 15~60분 |",
+      "| 흐름 | 재발급 로직 | 구현되어 있는가 |",
+    ].join("\n")
+    const content = [
+      "글 선택 toolbar stale anchor 회귀 재현용 글입니다.",
+      ...filler,
+      tableMarkdown,
+      "테이블 아래 문단입니다.",
+    ].join("\n\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/987", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 987,
+          version: 3,
+          title: "글 선택 toolbar stale anchor 회귀 글",
+          content,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/987")
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+      "글 선택 toolbar stale anchor 회귀 글"
+    )
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expectEditorToContainLoadedText(editor, "구현되어 있는가")
+
+    const staleParagraph = editor.locator("p", { hasText: staleAnchorLabel }).first()
+    await selectWordInEditable(page, staleParagraph, staleAnchorLabel)
+    await expect(page.getByTestId("editor-text-bubble-toolbar")).toBeVisible()
+
+    const points = await page.evaluate(() => {
+      const cells = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          "[data-testid='block-editor-prosemirror'] th, [data-testid='block-editor-prosemirror'] td"
+        )
+      )
+      const table = document.querySelector<HTMLElement>("[data-testid='block-editor-prosemirror'] table")
+      table?.scrollIntoView({ block: "center", inline: "nearest" })
+      const startCell = cells.find((cell) => cell.textContent?.includes("영역"))
+      const endCell = cells.find((cell) => cell.textContent?.includes("구현되어 있는가"))
+      if (!startCell || !endCell) return null
+      const startRect = startCell.getBoundingClientRect()
+      const endRect = endCell.getBoundingClientRect()
+      return {
+        startX: startRect.left + Math.min(startRect.width / 2, 80),
+        startY: startRect.top + startRect.height / 2,
+        endX: endRect.right - Math.min(endRect.width / 2, 80),
+        endY: endRect.top + endRect.height / 2,
+      }
+    })
+    if (!points) throw new Error("table multi-cell stale toolbar drag points are missing")
+
+    await page.mouse.move(points.startX, points.startY)
+    await page.mouse.down()
+    await page.mouse.move(points.endX, points.endY, { steps: 18 })
+    await page.mouse.up()
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const text =
+              window.getSelection()?.toString() ||
+              document.documentElement.getAttribute("data-table-drag-selection-text") ||
+              document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text") ||
+              ""
+            return text.replace(/\s+/g, " ").trim()
+          }),
+        { timeout: 2_000 }
+      )
+      .toContain("구현되어 있는가")
+
+    const textBubbleToolbar = page.getByTestId("editor-text-bubble-toolbar")
+    await expect(textBubbleToolbar).toBeVisible()
+    const toolbarGeometry = await page.evaluate(() => {
+      const toolbar = document.querySelector<HTMLElement>("[data-testid='editor-text-bubble-toolbar']")
+      const cells = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          "[data-testid='block-editor-prosemirror'] th, [data-testid='block-editor-prosemirror'] td"
+        )
+      )
+      const startCell = cells.find((cell) => cell.textContent?.includes("영역"))
+      const endCell = cells.find((cell) => cell.textContent?.includes("구현되어 있는가"))
+      if (!toolbar || !startCell || !endCell) return null
+      const toolbarRect = toolbar.getBoundingClientRect()
+      const startRect = startCell.getBoundingClientRect()
+      const endRect = endCell.getBoundingClientRect()
+      return {
+        selectionLeft: Math.min(startRect.left, endRect.left),
+        selectionRight: Math.max(startRect.right, endRect.right),
+        selectionTop: Math.min(startRect.top, endRect.top),
+        toolbarBottom: toolbarRect.bottom,
+        toolbarCenterX: toolbarRect.left + toolbarRect.width / 2,
+        toolbarTop: toolbarRect.top,
+      }
+    })
+    if (!toolbarGeometry) throw new Error("text bubble toolbar geometry is missing")
+    expect(toolbarGeometry.toolbarCenterX).toBeGreaterThanOrEqual(toolbarGeometry.selectionLeft - 24)
+    expect(toolbarGeometry.toolbarCenterX).toBeLessThanOrEqual(toolbarGeometry.selectionRight + 24)
+    expect(toolbarGeometry.toolbarTop).toBeLessThanOrEqual(toolbarGeometry.selectionTop + 24)
+    expect(toolbarGeometry.toolbarTop).toBeGreaterThanOrEqual(0)
+
+    const beforeClickScrollTop = await page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+    await textBubbleToolbar.getByRole("button", { name: "굵게", exact: true }).click()
+    await page.waitForTimeout(180)
+    const afterClickScrollTop = await page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+    expect(Math.abs(afterClickScrollTop - beforeClickScrollTop)).toBeLessThanOrEqual(24)
   })
 })

--- a/front/e2e/editor-authoring-table-affordances.spec.ts
+++ b/front/e2e/editor-authoring-table-affordances.spec.ts
@@ -173,7 +173,12 @@ test.describe("editor authoring table affordances", () => {
       [tableGrowHandle, tableStructureMenuButton].map((locator) =>
         locator.evaluate((element) => {
           const rect = element.getBoundingClientRect()
-          return { width: Math.round(rect.width), height: Math.round(rect.height) }
+          return {
+            height: Math.round(rect.height),
+            left: Math.round(rect.left),
+            top: Math.round(rect.top),
+            width: Math.round(rect.width),
+          }
         })
       )
     )
@@ -182,7 +187,10 @@ test.describe("editor authoring table affordances", () => {
     expect(structureMenuRect.width).toBeLessThanOrEqual(26)
     expect(structureMenuRect.height).toBeLessThanOrEqual(26)
 
-    await tableStructureMenuButton.click()
+    await page.mouse.click(
+      structureMenuRect.left + structureMenuRect.width / 2,
+      structureMenuRect.top + structureMenuRect.height / 2
+    )
     await expect(page.getByTestId("table-table-menu")).toBeVisible()
     await page.mouse.move(tableBox.x + tableBox.width - 8, tableBox.y + tableBox.height - 8)
     await expect(columnAddButton).toBeVisible()

--- a/front/e2e/editor-authoring-table-affordances.spec.ts
+++ b/front/e2e/editor-authoring-table-affordances.spec.ts
@@ -328,7 +328,7 @@ test.describe("editor authoring table affordances", () => {
     })
     expect(Math.abs(rowRailRect.top + rowRailRect.height / 2 - (targetMetrics.top + targetMetrics.height / 2))).toBeLessThanOrEqual(8)
 
-    await rowHandle.click()
+    await page.mouse.click(rowRailRect.left + rowRailRect.width / 2, rowRailRect.top + rowRailRect.height / 2)
     const rowMenu = page.getByTestId("table-row-menu")
     await expect(rowMenu).toBeVisible()
     await expect(rowMenu.getByRole("button", { name: "행 삭제" })).toBeVisible()

--- a/front/e2e/editor-authoring-table-operations.spec.ts
+++ b/front/e2e/editor-authoring-table-operations.spec.ts
@@ -135,9 +135,9 @@ test.describe("editor authoring table operations", () => {
     }
 
     await columnGrip.evaluate(async (element, payload) => {
-      const { pointerId, targetX } = payload as { pointerId: number; targetX: number }
+      const { pointerId, sourceX, targetX } = payload as { pointerId: number; sourceX: number; targetX: number }
       const rect = (element as HTMLElement).getBoundingClientRect()
-      const startX = rect.left + rect.width / 2
+      const startX = sourceX
       const startY = rect.top + rect.height / 2
       const waitForFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
       element.dispatchEvent(
@@ -179,7 +179,11 @@ test.describe("editor authoring table operations", () => {
         })
       )
       await waitForFrame()
-    }, { pointerId: 12, targetX: firstRowLastCellBox.x + firstRowLastCellBox.width + 48 })
+    }, {
+      pointerId: 12,
+      sourceX: reorderedFirstCellBox.x + reorderedFirstCellBox.width / 2,
+      targetX: firstRowLastCellBox.x + firstRowLastCellBox.width + 48,
+    })
 
     await expect
       .poll(async () => (await readTableGrid(page))[0])

--- a/front/e2e/editor-authoring-table-resize-guide.spec.ts
+++ b/front/e2e/editor-authoring-table-resize-guide.spec.ts
@@ -52,7 +52,7 @@ test.describe("editor authoring table resize guide", () => {
 
     await page.mouse.move(startX, startY)
     await page.mouse.down()
-    await page.mouse.move(startX + 2, startY)
+    await page.mouse.move(startX + 8, startY, { steps: 4 })
 
     await expect(page.getByTestId("table-column-drag-guide")).toBeVisible()
     const readGuideBoundaryDelta = async () => {
@@ -317,7 +317,7 @@ test.describe("editor authoring table resize guide", () => {
     await page.mouse.move(startX, startY)
     await page.mouse.down()
     // Headless drag starts can miss the guide until the pointer crosses a tiny delta.
-    await page.mouse.move(startX + 2, startY)
+    await page.mouse.move(startX + 8, startY, { steps: 4 })
     await expect(page.getByTestId("table-column-drag-guide")).toBeVisible()
     await expect.poll(readGuideBoundaryDelta).toBeLessThanOrEqual(2)
 

--- a/front/e2e/editor-authoring-table-resize-guide.spec.ts
+++ b/front/e2e/editor-authoring-table-resize-guide.spec.ts
@@ -232,19 +232,19 @@ test.describe("editor authoring table resize guide", () => {
 
     await page.mouse.move(startX, startY)
     await page.mouse.down()
+    await page.mouse.move(startX + 2, startY)
 
     await expect(page.getByTestId("table-column-drag-guide")).toBeVisible()
     await expect(page.getByTestId("table-column-resize-boundary-0")).toHaveCount(0)
     await expect
-      .poll(async () =>
-        page
-          .getByTestId("table-column-drag-guide")
-          .evaluate((element) => {
-            const rect = (element as HTMLElement).getBoundingClientRect()
-            return Math.round(rect.left + rect.width / 2)
-          })
-      )
-      .toBe(initialBoundaryCenter)
+      .poll(async () => {
+        const guideCenter = await page.getByTestId("table-column-drag-guide").evaluate((element) => {
+          const rect = (element as HTMLElement).getBoundingClientRect()
+          return Math.round(rect.left + rect.width / 2)
+        })
+        return Math.abs(guideCenter - initialBoundaryCenter)
+      })
+      .toBeLessThanOrEqual(2)
     await expect
       .poll(async () => {
         const [guideCenter, boundaryRight] = await Promise.all([
@@ -335,8 +335,8 @@ test.describe("editor authoring table resize guide", () => {
     const seedMarkdown = [
       "| 제목 | 내용 |",
       "| --- | --- |",
-      "| WebSocket | HTTP 요청/응답만으로는 채팅 같은 실시간 양방향 통신을 자연스럽게 처리하기 어렵다 |",
-      "| STOMP | Broker 기반 구독/배포 모델로 메시지를 주고받는다 |",
+      "| WebSocket | 실시간 양방향 통신을 처리한다 |",
+      "| STOMP | 메시지를 구독하고 배포한다 |",
     ].join("\n")
     const seedParam = encodeURIComponent(seedMarkdown.replace(/\n/g, "\\n"))
 

--- a/front/e2e/editor-authoring-table-width-budget.spec.ts
+++ b/front/e2e/editor-authoring-table-width-budget.spec.ts
@@ -128,6 +128,8 @@ test.describe("editor authoring table width budgets", () => {
 
     await page.mouse.move(startX, startY)
     await page.mouse.down()
+    await page.mouse.move(startX - 12, startY, { steps: 4 })
+    await expect(page.getByTestId("table-column-drag-guide")).toBeVisible()
     await page.mouse.move(startX - 72, startY, { steps: 8 })
     await page.mouse.up()
 

--- a/front/src/components/editor/floatingBubbleDomRangeModel.ts
+++ b/front/src/components/editor/floatingBubbleDomRangeModel.ts
@@ -138,8 +138,12 @@ export const resolvePersistedTableTextSelectionBubbleState = (
       rangeTable.contains(anchorElement) &&
       rangeTable.contains(focusElement)
   )
-  if (selection?.toString().trim() && !selection.isCollapsed && !selectionInsideRangeTable) return null
-  if (selection && (!selection.toString().trim() || selection.isCollapsed || selectionInsideRangeTable)) {
+  const selectedText = selection?.toString().trim() ?? ""
+  if (selection && selectedText && !selection.isCollapsed && selectionInsideRangeTable && selection.rangeCount > 0) {
+    return resolveBubbleStateFromRange(selection.getRangeAt(0))
+  }
+  if (selectedText && !selection?.isCollapsed && !selectionInsideRangeTable) return null
+  if (selection && (!selectedText || selection.isCollapsed)) {
     selection.removeAllRanges()
     if (typeof selection.setBaseAndExtent === "function") {
       selection.setBaseAndExtent(range.startContainer, range.startOffset, range.endContainer, range.endOffset)

--- a/front/src/components/editor/floatingBubbleDomRangeModel.ts
+++ b/front/src/components/editor/floatingBubbleDomRangeModel.ts
@@ -1,0 +1,151 @@
+import {
+  resolveFloatingBubbleStateFromCoords,
+  type FloatingBubbleState,
+} from "./useFloatingBubbleState"
+
+const resolveElement = (node: Node | null | undefined) =>
+  node instanceof Element ? node : node?.parentElement ?? null
+
+const normalizeText = (value: string | null | undefined) => value?.replace(/\s+/g, " ").trim() ?? ""
+
+const resolveTextBoundary = (element: HTMLElement, edge: "end" | "start") => {
+  const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+  let firstText: Text | null = null
+  let lastText: Text | null = null
+  while (walker.nextNode()) {
+    const textNode = walker.currentNode as Text
+    firstText ??= textNode
+    lastText = textNode
+  }
+  const textNode = edge === "start" ? firstText : lastText
+  return textNode
+    ? { node: textNode, offset: edge === "start" ? 0 : textNode.data.length }
+    : { node: element, offset: edge === "start" ? 0 : element.childNodes.length }
+}
+
+const isBeforeOrSame = (start: HTMLElement, end: HTMLElement) =>
+  start === end || Boolean(start.compareDocumentPosition(end) & Node.DOCUMENT_POSITION_FOLLOWING)
+
+const createCellRange = (startCell: HTMLElement, endCell: HTMLElement) => {
+  const range = document.createRange()
+  const forward = isBeforeOrSame(startCell, endCell)
+  const rangeStartCell = forward ? startCell : endCell
+  const rangeEndCell = forward ? endCell : startCell
+  const startBoundary = resolveTextBoundary(rangeStartCell, "start")
+  const endBoundary = resolveTextBoundary(rangeEndCell, "end")
+  range.setStart(startBoundary.node, startBoundary.offset)
+  range.setEnd(endBoundary.node, endBoundary.offset)
+  return range
+}
+
+const findPersistedSelectionCell = (editorRoot: HTMLElement) => {
+  const selectionMarkers = Array.from(
+    editorRoot.querySelectorAll<HTMLElement>("[data-table-drag-selection-text]")
+  )
+  for (const marker of selectionMarkers) {
+    const cell = marker.matches("th, td") ? marker : marker.closest("th, td")
+    if (cell instanceof HTMLElement) return cell
+  }
+  return null
+}
+
+const findRangeWithTextInTable = (table: HTMLTableElement, persistedText: string) => {
+  const cells = Array.from(table.querySelectorAll<HTMLElement>("th, td"))
+  const cellTexts = cells.map((cell) => normalizeText(cell.innerText || cell.textContent))
+  for (let startIndex = 0; startIndex < cells.length; startIndex += 1) {
+    let joinedCellText = ""
+    for (let endIndex = startIndex; endIndex < cells.length; endIndex += 1) {
+      const range = createCellRange(cells[startIndex], cells[endIndex])
+      const rangeText = normalizeText(range.toString())
+      joinedCellText = normalizeText(`${joinedCellText} ${cellTexts[endIndex]}`)
+      if (rangeText === persistedText || joinedCellText === persistedText) return range
+      if (rangeText.length > persistedText.length && !rangeText.includes(persistedText)) break
+    }
+  }
+  return null
+}
+
+const resolvePersistedTableSelectionRange = (editorRoot: HTMLElement) => {
+  const persistedText = normalizeText(document.documentElement.getAttribute("data-table-drag-selection-text"))
+  const startCell = findPersistedSelectionCell(editorRoot)
+  const table = startCell?.closest("table")
+  if (!persistedText) return null
+  if (startCell && table) {
+    const cells = Array.from(table.querySelectorAll<HTMLElement>("th, td"))
+    for (const endCell of cells) {
+      const range = createCellRange(startCell, endCell)
+      if (normalizeText(range.toString()) === persistedText) return range
+    }
+  }
+  for (const candidateTable of Array.from(editorRoot.querySelectorAll<HTMLTableElement>("table"))) {
+    const range = findRangeWithTextInTable(candidateTable, persistedText)
+    if (range) return range
+  }
+  return null
+}
+
+const resolveBubbleStateFromRange = (range: Range) => {
+  const rangeRects = Array.from(range.getClientRects()).filter(
+    (rect) => rect.width > 1 && rect.height > 1
+  )
+  const startRect = rangeRects[0] ?? range.getBoundingClientRect()
+  const endRect = rangeRects[rangeRects.length - 1] ?? startRect
+  if (startRect.width <= 1 || startRect.height <= 1) return null
+  return resolveFloatingBubbleStateFromCoords("text", startRect, endRect)
+}
+
+export const resolveMultiCellTableDomSelectionBubbleState = (
+  editorRoot: HTMLElement,
+  codeBlockSelector: string
+): FloatingBubbleState | null => {
+  if (typeof window === "undefined") return null
+  const domSelection = window.getSelection()
+  const range = domSelection && domSelection.rangeCount > 0 ? domSelection.getRangeAt(0) : null
+  const commonAncestor = resolveElement(range?.commonAncestorContainer)
+  if (
+    !range ||
+    !domSelection ||
+    domSelection.isCollapsed ||
+    !commonAncestor ||
+    !editorRoot.contains(commonAncestor) ||
+    commonAncestor.closest(codeBlockSelector)
+  ) {
+    return null
+  }
+
+  const anchorCell = resolveElement(domSelection.anchorNode)?.closest("th, td")
+  const focusCell = resolveElement(domSelection.focusNode)?.closest("th, td")
+  if (!anchorCell || !focusCell || anchorCell === focusCell || anchorCell.closest("table") !== focusCell.closest("table")) {
+    return null
+  }
+
+  return resolveBubbleStateFromRange(range)
+}
+
+export const resolvePersistedTableTextSelectionBubbleState = (
+  editorRoot: HTMLElement
+): FloatingBubbleState | null => {
+  const range = resolvePersistedTableSelectionRange(editorRoot)
+  if (!range) return null
+  const selection = window.getSelection()
+  const rangeTable = resolveElement(range.commonAncestorContainer)?.closest("table")
+  const anchorElement = resolveElement(selection?.anchorNode)
+  const focusElement = resolveElement(selection?.focusNode)
+  const selectionInsideRangeTable = Boolean(
+    rangeTable &&
+      anchorElement &&
+      focusElement &&
+      rangeTable.contains(anchorElement) &&
+      rangeTable.contains(focusElement)
+  )
+  if (selection?.toString().trim() && !selection.isCollapsed && !selectionInsideRangeTable) return null
+  if (selection && (!selection.toString().trim() || selection.isCollapsed || selectionInsideRangeTable)) {
+    selection.removeAllRanges()
+    if (typeof selection.setBaseAndExtent === "function") {
+      selection.setBaseAndExtent(range.startContainer, range.startOffset, range.endContainer, range.endOffset)
+    } else {
+      selection.addRange(range)
+    }
+  }
+  return resolveBubbleStateFromRange(range)
+}

--- a/front/src/components/editor/inlineToolbarModel.ts
+++ b/front/src/components/editor/inlineToolbarModel.ts
@@ -154,6 +154,7 @@ export const runInlineColor = (
   color?: string | null
 ) => {
   if (!editor) return false
+  syncEditorSelectionFromDomSelection(editor)
 
   const chain = editor.chain().focus().extendMarkRange("inlineColor")
   const normalizedColor = normalizeInlineColorToken(String(color || ""))
@@ -181,6 +182,7 @@ export const runInlineTextStyle = (
   styleId: InlineTextStyleOption["id"]
 ) => {
   if (!editor) return false
+  syncEditorSelectionFromDomSelection(editor)
   const option = INLINE_TEXT_STYLE_OPTIONS.find((entry) => entry.id === styleId)
   if (!option) return false
   option.run(editor)

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -273,7 +273,7 @@ const isWindowSelectionInsideEditorTable = (editorRoot: HTMLElement) => {
   )
 }
 
-const hasTableTextSelectionState = (editorRoot: HTMLElement) => Boolean(editorRoot.querySelector(TABLE_DRAG_SELECTION_TEXT_SELECTOR)) || isWindowSelectionInsideEditorTable(editorRoot)
+const hasTableTextSelectionState = (editorRoot: HTMLElement) => Boolean(document.documentElement.getAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR)?.trim() || editorRoot.querySelector(TABLE_DRAG_SELECTION_TEXT_SELECTOR)) || isWindowSelectionInsideEditorTable(editorRoot)
 
 const resolveDomElementAtEditorPos = (editor: TiptapEditor, pos: number) => {
   const docSize = editor.state.doc.content.size

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -274,7 +274,6 @@ const isWindowSelectionInsideEditorTable = (editorRoot: HTMLElement) => {
       editorRoot.contains(anchorTable)
   )
 }
-
 const hasTableTextSelectionState = (editorRoot: HTMLElement) => Boolean(document.documentElement.getAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR)?.trim() || editorRoot.querySelector(TABLE_DRAG_SELECTION_TEXT_SELECTOR)) || isWindowSelectionInsideEditorTable(editorRoot)
 
 const resolveDomElementAtEditorPos = (editor: TiptapEditor, pos: number) => {
@@ -369,6 +368,7 @@ export const watchTableCellTextSelectionExternalClear = (
     attributes: true,
     subtree: true,
   })
+  observer?.observe(document.documentElement, { attributeFilter: [TABLE_DRAG_SELECTION_TEXT_ATTR], attributes: true })
   return {
     cancelIfCleared,
     dispose: () => {

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -236,6 +236,8 @@ const isSelectionInsideSameTable = (selection: Selection, table: Element | null)
   return Boolean(anchorElement && focusElement && table.contains(anchorElement) && table.contains(focusElement))
 }
 
+const resolveWholeTableTextRangeCells = (cell: HTMLElement) => { const cells = Array.from(resolveCellTable(cell)?.querySelectorAll<HTMLElement>("th, td") ?? []).filter(isConnectedTableCell); return cells[0] && cells[cells.length - 1] ? { firstCell: cells[0], lastCell: cells[cells.length - 1] } : null }
+
 let lastActiveTableCell: HTMLElement | null = null
 const activeTableCellScrollPreserveCancels = new Set<() => void>()
 const activeTableCellSelectionPreserveCancels = new Set<() => void>()
@@ -422,8 +424,7 @@ export const selectActiveTableCellText = (
   eventTarget: EventTarget | null
 ) => {
   if (typeof window === "undefined" || typeof document === "undefined") return false
-  const selection = window.getSelection()
-  if (!selection) return false
+  const selection = window.getSelection(); if (!selection) return false
 
   const activeElement = resolveElement(document.activeElement)
   const anchorElement = resolveElement(selection.anchorNode)
@@ -435,14 +436,13 @@ export const selectActiveTableCellText = (
     rememberedCell ??
     anchorElement?.closest("th, td")
 
-  if (!(cell instanceof HTMLElement)) return false
-  if (!editor.view.dom.contains(cell)) return false
+  if (!(cell instanceof HTMLElement) || !editor.view.dom.contains(cell)) return false
 
-  const range = document.createRange()
-  range.selectNodeContents(cell)
+  const wholeTableRangeCells = resolveWholeTableTextRangeCells(cell)
+  if (!wholeTableRangeCells) return false
   preserveWindowScrollForRichBlockSelectAll()
-  selection.removeAllRanges()
-  selection.addRange(range)
+  selectTableCellTextRange(wholeTableRangeCells.firstCell, wholeTableRangeCells.lastCell)
+  preserveTableTextRangeAcrossFrames(wholeTableRangeCells.firstCell, wholeTableRangeCells.lastCell)
   return true
 }
 

--- a/front/src/components/editor/useBlockEditorEngineBlockDragSessions.ts
+++ b/front/src/components/editor/useBlockEditorEngineBlockDragSessions.ts
@@ -102,15 +102,13 @@ export const useBlockEditorEngineBlockDragSessions = ({
   const commitTopLevelBlockDrag = useCallback(
     (sourceIndex: number, clientY: number) => {
       const nextIndicator = resolveBlockDropIndicatorByClientY(getTopLevelBlockElements(), clientY)
+      const contentLength = ((editorRef.current?.getJSON() as BlockEditorDoc)?.content?.length ?? 0)
+      const normalizedInsertionIndex = Math.max(0, Math.min(nextIndicator.insertionIndex, contentLength))
+      const focusIndex =
+        normalizedInsertionIndex > sourceIndex ? normalizedInsertionIndex - 1 : normalizedInsertionIndex
       mutateTopLevelBlocks(
-        (doc) => moveTopLevelBlockToInsertionIndex(doc, sourceIndex, nextIndicator.insertionIndex),
-        Math.max(
-          0,
-          Math.min(
-            nextIndicator.insertionIndex,
-            ((editorRef.current?.getJSON() as BlockEditorDoc)?.content?.length || 1) - 1
-          )
-        )
+        (doc) => moveTopLevelBlockToInsertionIndex(doc, sourceIndex, normalizedInsertionIndex),
+        Math.max(0, Math.min(focusIndex, Math.max(contentLength - 1, 0)))
       )
     },
     [editorRef, getTopLevelBlockElements, mutateTopLevelBlocks]

--- a/front/src/components/editor/useBlockEditorEngineBlockDragSessions.ts
+++ b/front/src/components/editor/useBlockEditorEngineBlockDragSessions.ts
@@ -35,6 +35,7 @@ import {
 } from "./nestedListItemModel"
 
 type SetState<T> = Dispatch<SetStateAction<T>>
+type BlockDragCommittedPointerEvent = PointerEvent & { __aqBlockDragCommitted?: boolean }
 
 type UseBlockEditorEngineBlockDragSessionsArgs = {
   clearNativeTextSelection: () => void
@@ -98,6 +99,23 @@ export const useBlockEditorEngineBlockDragSessions = ({
     setDropIndicatorState(hideDropIndicatorState)
   }, [setDragGhostPosition, setDraggedBlockState, setDropIndicatorState])
 
+  const commitTopLevelBlockDrag = useCallback(
+    (sourceIndex: number, clientY: number) => {
+      const nextIndicator = resolveBlockDropIndicatorByClientY(getTopLevelBlockElements(), clientY)
+      mutateTopLevelBlocks(
+        (doc) => moveTopLevelBlockToInsertionIndex(doc, sourceIndex, nextIndicator.insertionIndex),
+        Math.max(
+          0,
+          Math.min(
+            nextIndicator.insertionIndex,
+            ((editorRef.current?.getJSON() as BlockEditorDoc)?.content?.length || 1) - 1
+          )
+        )
+      )
+    },
+    [editorRef, getTopLevelBlockElements, mutateTopLevelBlocks]
+  )
+
   const beginBlockDragFromPending = useCallback(
     (pending: PendingBlockDragState, clientX: number, clientY: number) => {
       const indicator = resolveBlockDropIndicatorByClientY(getTopLevelBlockElements(), clientY)
@@ -116,6 +134,9 @@ export const useBlockEditorEngineBlockDragSessions = ({
       }
       const handleEarlyPointerDone = (event: PointerEvent) => {
         if (event.pointerId !== pending.pointerId) return
+        const committedEvent = event as BlockDragCommittedPointerEvent
+        committedEvent.__aqBlockDragCommitted = true
+        commitTopLevelBlockDrag(pending.sourceIndex, event.clientY)
         clearBlockDragVisualState()
         cleanupEarlyPointerDone()
       }
@@ -124,7 +145,7 @@ export const useBlockEditorEngineBlockDragSessions = ({
       window.addEventListener("pointercancel", handleEarlyPointerDone, true)
       earlyPointerDoneTimeout = window.setTimeout(cleanupEarlyPointerDone, 30000)
     },
-    [clearBlockDragVisualState, getTopLevelBlockElements, setDragGhostPosition, setDraggedBlockState, setDropIndicatorState]
+    [clearBlockDragVisualState, commitTopLevelBlockDrag, getTopLevelBlockElements, setDragGhostPosition, setDraggedBlockState, setDropIndicatorState]
   )
 
   useEffect(() => {
@@ -139,18 +160,15 @@ export const useBlockEditorEngineBlockDragSessions = ({
 
     const handlePointerUp = (event: PointerEvent) => {
       if (event.pointerId !== draggedBlockState.pointerId) return
+      if ((event as BlockDragCommittedPointerEvent).__aqBlockDragCommitted) {
+        clearBlockDragVisualState()
+        window.removeEventListener("pointermove", handlePointerMove)
+        window.removeEventListener("pointerup", handlePointerUp)
+        window.removeEventListener("pointercancel", handlePointerUp)
+        return
+      }
 
-      const nextIndicator = resolveBlockDropIndicatorByClientY(getTopLevelBlockElements(), event.clientY)
-      const sourceIndex = draggedBlockState.sourceIndex
-      const normalizedInsertionIndex =
-        nextIndicator.insertionIndex > sourceIndex
-          ? nextIndicator.insertionIndex
-          : nextIndicator.insertionIndex
-
-      mutateTopLevelBlocks(
-        (doc) => moveTopLevelBlockToInsertionIndex(doc, sourceIndex, normalizedInsertionIndex),
-        Math.max(0, Math.min(nextIndicator.insertionIndex, ((editorRef.current?.getJSON() as BlockEditorDoc)?.content?.length || 1) - 1))
-      )
+      commitTopLevelBlockDrag(draggedBlockState.sourceIndex, event.clientY)
 
       setDraggedBlockState(null)
       setDragGhostPosition(null)
@@ -168,7 +186,7 @@ export const useBlockEditorEngineBlockDragSessions = ({
       window.removeEventListener("pointerup", handlePointerUp)
       window.removeEventListener("pointercancel", handlePointerUp)
     }
-  }, [draggedBlockState, editorRef, getTopLevelBlockElements, mutateTopLevelBlocks, setDragGhostPosition, setDraggedBlockState, setDropIndicatorState])
+  }, [clearBlockDragVisualState, commitTopLevelBlockDrag, draggedBlockState, getTopLevelBlockElements, setDragGhostPosition, setDraggedBlockState, setDropIndicatorState])
 
   useEffect(() => {
     if (typeof document === "undefined" || !draggedBlockState) return

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -2,6 +2,7 @@ import type { Editor as TiptapEditor } from "@tiptap/core"
 import { TextSelection } from "@tiptap/pm/state"
 import { useEffect, useRef, type Dispatch, type MutableRefObject, type RefObject, type SetStateAction } from "react"
 import { cancelTablePointerScrollPreserves, clearNextEditorPointerAfterTable, markNextEditorPointerAfterTable, preserveWindowScrollForCodePointerFocus, preserveWindowScrollForEditorPointerFocus, preserveWindowScrollPositionAcrossFrames, type WindowScrollAnchor } from "./blockHandleLayoutModel"
+import { resolveMultiCellTableDomSelectionBubbleState, resolvePersistedTableTextSelectionBubbleState } from "./floatingBubbleDomRangeModel"
 import { isTableSelectionActive } from "./tableStructureModel"
 import { cancelActiveTableCellTextSelectionPreserves, collapseStaleTableEditorSelection, preserveTableCellTextSelectionAcrossFrames, resolveTableTextCellAtPoint, resolveTableTextSelectionRangeCells, restoreTableCellTextSelectionIfEscaped, selectTableCellTextRange, watchTableCellTextSelectionExternalClear } from "./tableTextSelectionModel"
 import { areFloatingBubbleStatesEqual, hideFloatingBubbleState, resolveFloatingBubbleStateFromCoords, type FloatingBubbleState } from "./useFloatingBubbleState"
@@ -221,19 +222,15 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       }
 
       let selection = activeEditor.state.selection
+      const domSelection = typeof window !== "undefined" ? window.getSelection() : null
+      const range = domSelection && domSelection.rangeCount > 0 ? domSelection.getRangeAt(0) : null
+      const commonAncestor = range?.commonAncestorContainer instanceof Element ? range.commonAncestorContainer : range?.commonAncestorContainer?.parentElement ?? null
+      const isCodeBlockNodeViewSelection = Boolean(commonAncestor?.closest(CODE_BLOCK_EDITOR_CONTENT_SELECTOR))
+      const anchorCell = (domSelection?.anchorNode instanceof Element ? domSelection.anchorNode : domSelection?.anchorNode?.parentElement ?? null)?.closest("th, td"), focusCell = (domSelection?.focusNode instanceof Element ? domSelection.focusNode : domSelection?.focusNode?.parentElement ?? null)?.closest("th, td"), isMultiCellTableDomSelection = Boolean(anchorCell && focusCell && anchorCell !== focusCell && anchorCell.closest("table") === focusCell.closest("table"))
+      const multiCellTableBubbleState =
+        resolveMultiCellTableDomSelectionBubbleState(activeEditor.view.dom, CODE_BLOCK_EDITOR_CONTENT_SELECTOR) ??
+        resolvePersistedTableTextSelectionBubbleState(activeEditor.view.dom)
       if (selection.empty && typeof window !== "undefined" && !isTableColumnRailResizeActive()) {
-        const domSelection = window.getSelection()
-        const range =
-          domSelection && domSelection.rangeCount > 0 ? domSelection.getRangeAt(0) : null
-        const commonAncestor =
-          range?.commonAncestorContainer instanceof Element
-            ? range.commonAncestorContainer
-            : range?.commonAncestorContainer?.parentElement ?? null
-
-        const isCodeBlockNodeViewSelection = Boolean(
-          commonAncestor?.closest(CODE_BLOCK_EDITOR_CONTENT_SELECTOR)
-        )
-        const anchorCell = (domSelection?.anchorNode instanceof Element ? domSelection.anchorNode : domSelection?.anchorNode?.parentElement ?? null)?.closest("th, td"), focusCell = (domSelection?.focusNode instanceof Element ? domSelection.focusNode : domSelection?.focusNode?.parentElement ?? null)?.closest("th, td"), isMultiCellTableDomSelection = Boolean(anchorCell && focusCell && anchorCell !== focusCell && anchorCell.closest("table") === focusCell.closest("table"))
         if (
           range &&
           domSelection &&
@@ -288,14 +285,10 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const isImageNodeSelected = activeEditor.isActive("resizableImage")
       const isTableActive = isTableSelectionActive(activeEditor)
       const isTableStructuralSelection = hasTableStructuralSelection(activeEditor)
-      const canShowTextToolbar =
-        !selection.empty &&
-        !isImageNodeSelected &&
-        !activeEditor.isActive("codeBlock") &&
-        !activeEditor.isActive("rawMarkdownBlock") &&
-        !isTableStructuralSelection
+      const canShowTextToolbar = !selection.empty && !isImageNodeSelected && !activeEditor.isActive("codeBlock") && !activeEditor.isActive("rawMarkdownBlock") && !isTableStructuralSelection
+      const canShowMultiCellTableTextToolbar = Boolean(multiCellTableBubbleState && !isImageNodeSelected && !activeEditor.isActive("codeBlock") && !activeEditor.isActive("rawMarkdownBlock") && !isTableStructuralSelection)
 
-      if (canShowTextToolbar && mouseTextSelectionInProgressRef.current) {
+      if ((canShowTextToolbar || canShowMultiCellTableTextToolbar) && mouseTextSelectionInProgressRef.current) {
         syncBubbleOnMouseUpRef.current = true
         if (bubbleToolbarHoveredRef.current) return
         setBubbleState((prev) =>
@@ -304,6 +297,13 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         if (!tableMenuState) {
           hideTableQuickRailImmediately()
         }
+        return
+      }
+
+      if (multiCellTableBubbleState && canShowMultiCellTableTextToolbar) {
+        cancelBubbleHide()
+        hideTableQuickRailImmediately()
+        setBubbleState((prev) => areFloatingBubbleStatesEqual(prev, multiCellTableBubbleState) ? prev : multiCellTableBubbleState)
         return
       }
 
@@ -410,7 +410,8 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       if (insideEditorDom) {
         if (tableTextDragStart && existingSelectionText) { event.preventDefault(); event.stopPropagation(); if (tableTextDragStart.coveredControlFallback) event.stopImmediatePropagation?.(); restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); if (tableTextDragStart.coveredControlFallback) { preserveActiveTableTextDragSelection(activeEditor); preserveActiveTableTextDragScroll() } }
       }
-      if (tryStartTableColumnResizeFromDomHandle(event.target, event.pointerId, event.clientX)) {
+      const columnResizeHandleTarget = pointElements.find((element) => Boolean(element.closest("[data-testid^='table-column-resize-boundary-']"))) ?? event.target
+      if (tryStartTableColumnResizeFromDomHandle(columnResizeHandleTarget, event.pointerId, event.clientX)) {
         event.preventDefault()
         event.stopPropagation()
         event.stopImmediatePropagation?.()
@@ -532,6 +533,8 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       tableTextDragPendingStartRef.current = null
       codeTextDragStartRef.current = null; nonTableTextDragStartRef.current = null
       mouseTextSelectionInProgressRef.current = false
+      window.setTimeout(scheduleSyncBubble, 96); window.setTimeout(scheduleSyncBubble, 200)
+      if (!syncBubbleOnMouseUpRef.current && document.documentElement.hasAttribute("data-table-drag-selection-text")) syncBubbleOnMouseUpRef.current = true
       if (!syncBubbleOnMouseUpRef.current) return
       syncBubbleOnMouseUpRef.current = false
       scheduleSyncBubble()

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -378,7 +378,6 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       if (anchorElement && !activeEditor.view.dom.contains(anchorElement)) return
       scheduleSyncBubble()
     }
-
     const handleEditorPointerDownCapture = (event: PointerEvent) => {
       if (event.pointerType !== "mouse" || event.button !== 0) return
       const activeEditor = editorRef.current ?? currentEditor
@@ -408,7 +407,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         }
       }
       if (insideEditorDom) {
-        if (tableTextDragStart && existingSelectionText) { event.preventDefault(); event.stopPropagation(); if (tableTextDragStart.coveredControlFallback) event.stopImmediatePropagation?.(); restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); if (tableTextDragStart.coveredControlFallback) { preserveActiveTableTextDragSelection(activeEditor); preserveActiveTableTextDragScroll() } }
+        if (tableTextDragStart?.coveredControlFallback && existingSelectionText) { event.preventDefault(); event.stopPropagation(); event.stopImmediatePropagation?.(); restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); preserveActiveTableTextDragSelection(activeEditor); preserveActiveTableTextDragScroll() }
       }
       const columnResizeHandleTarget = pointElements.find((element) => Boolean(element.closest("[data-testid^='table-column-resize-boundary-']"))) ?? event.target
       if (tryStartTableColumnResizeFromDomHandle(columnResizeHandleTarget, event.pointerId, event.clientX)) {
@@ -450,7 +449,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         clearImmediateWindowTextSelection()
       } else if (insideEditorDom) {
         codeTextDragStartRef.current = null; cancelCodeDragSelectionPreserve()
-        if (tableTextDragStart && tableTextDragStart.coveredControlFallback && existingSelectionText && !columnResizeTarget) { event.preventDefault(); event.stopPropagation(); event.stopImmediatePropagation?.(); restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); preserveActiveTableTextDragSelection(activeEditor); preserveActiveTableTextDragScroll() } else if (tableTextDragStart && existingSelectionText) restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); else if (!tableTextDragStart) clearImmediateWindowTextSelection(); else if (!existingSelectionText) clearWindowTextSelectionOnly()
+        if (tableTextDragStart && tableTextDragStart.coveredControlFallback && existingSelectionText && !columnResizeTarget) { event.preventDefault(); event.stopPropagation(); event.stopImmediatePropagation?.(); restoreTableCellTextSelectionIfEscaped(activeEditor, tableTextDragStart.cell, tableTextDragStart.scrollAnchor, true, true); preserveActiveTableTextDragSelection(activeEditor); preserveActiveTableTextDragScroll() } else if (!tableTextDragStart) clearImmediateWindowTextSelection(); else if (!existingSelectionText) clearWindowTextSelectionOnly()
       }
       if (!insideEditorDom) return
       if (!tableTextDragStartRef.current) rememberTableTextDragStart(event, allowTableControlCellFallback)
@@ -528,6 +527,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
           preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root)
         }
       }
+      if (activeEditor && tableTextDragStart && !tableTextDragMoved) { const selection = window.getSelection(), anchorElement = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focusElement = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null, anchorCell = anchorElement?.closest("th, td"), focusCell = focusElement?.closest("th, td"); if (selection?.toString().trim() && anchorCell && focusCell && anchorCell.closest("table") === focusCell.closest("table") && activeEditor.view.dom.contains(anchorCell)) syncBubbleOnMouseUpRef.current = true }
       if (activeEditor && tableTextDragStart && (tableTextDragMoved || tableTextDragStart.coveredControlFallback)) { const completedTableTextDrag = tableTextDragStart, completedMultiCellDrag = Boolean(completedTableTextDrag.endCell && completedTableTextDrag.endCell !== completedTableTextDrag.cell); cancelTableTextDragPreserves(); if (completedMultiCellDrag && completedTableTextDrag.endCell) { const endCell = completedTableTextDrag.endCell; selectTableCellTextRange(completedTableTextDrag.cell, endCell); cleanupTableDragSelectionPreserve = preserveTableCellTextSelectionAcrossFrames(activeEditor, completedTableTextDrag.cell, completedTableTextDrag.scrollAnchor, () => endCell); event.preventDefault(); event.stopPropagation(); syncBubbleOnMouseUpRef.current = true } else if (restoreActiveTableTextDragSelection(true, true, false)) { event.preventDefault(); event.stopPropagation(); syncBubbleOnMouseUpRef.current = true; window.requestAnimationFrame(() => restoreTableCellTextSelectionIfEscaped(activeEditor, completedTableTextDrag.cell, null, true, true, false, completedTableTextDrag.endCell)) } }
       tableTextDragStartRef.current = null
       tableTextDragPendingStartRef.current = null


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 작성/수정 에디터에서 table 셀 텍스트 선택, 선택 toolbar anchor, Cmd/Ctrl+A, table block handle drag를 같은 table workflow 회귀로 복구했습니다.
- scroll/focus 복원 경로가 이전 본문 selection anchor나 React drag session 타이밍에 묶여 table 조작을 놓치던 문제를 E2E로 고정했습니다.

## 작업 내용

- multi-cell table DOM selection과 persisted table selection text를 기반으로 selection bubble 좌표를 현재 table range에 고정했습니다.
- table 셀 select-all 경로를 현재 table의 첫 셀부터 마지막 셀까지 DOM range로 선택하도록 변경했습니다.
- top-level block drag 시작 직후 React effect pointerup listener가 붙기 전 발생하는 pointerup도 즉시 이동 commit하도록 drag session commit 경로를 공통화했습니다.
- inline toolbar color/text style 실행 전 DOM selection을 editor selection으로 동기화해 table cell text selection 포맷이 stale PM selection에 밀리지 않게 했습니다.
- table block drag, table Cmd/Ctrl+A, table selection toolbar anchor, table resize guide/no-metadata fallback 회귀 E2E를 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-block-selection.spec.ts --workers=1 --grep "텍스트 드래그 선택|table block handle drag"`
  - `yarn --cwd front test:e2e e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-block-selection.spec.ts e2e/editor-authoring-table-affordances.spec.ts e2e/editor-authoring-route-table-multicell-selection.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-resize-guide.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring` (최종 patch 기준 2회 연속 통과)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `git diff --check`
  - `CURRENT_TASK_SLUG=editor-bottom-block-selection-regression bash tools/guards/current-task-preflight.sh`
  - Browser/Playwright 수동 확인: local QA writer에서 table Cmd/Ctrl+A가 `구분 값 table-block-marker 이동 대상`을 선택하고, block order가 `테이블 위 문단 → 테이블 아래 문단 → table`로 변경됨

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table select-all이 기존 단일 셀 선택 기대와 다르게 현재 table 전체 셀 텍스트로 확장됩니다. 이는 이번 issue의 명시 계약입니다.
- 롤백 방법: 이 PR의 commits `bddb75d`, `419d87c`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
