### PR TITLE
[Fix] table 셀 caret 선택 복구

### DIFF
--- a/front/e2e/editor-authoring-selection-drag.spec.ts
+++ b/front/e2e/editor-authoring-selection-drag.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Locator, type Page } from "@playwright/test"
 import {
   QA_WRITER_ROUTE,
   expectEditorToContainLoadedText,
+  expectVisibleBox,
   getWordDragPoints,
   selectWordInEditable,
 } from "./helpers/editorAuthoringFlow"
@@ -186,8 +187,42 @@ test.describe("editor authoring route text selection drag", () => {
       .poll(async () => page.evaluate(() => window.getSelection()?.toString().replace(/\s+/g, " ").trim() ?? ""))
       .toContain("커서")
 
-    const points = await getWordDragPoints(firstCell, "테스트")
-    await page.mouse.click(points.startX, points.startY)
+    const points = await getWordDragPoints(firstCell, "커서")
+    await firstCell.evaluate(
+      (element, point) => {
+        const target = document.elementFromPoint(point.x, point.y) ?? element
+        const init = {
+          bubbles: true,
+          button: 0,
+          cancelable: true,
+          clientX: point.x,
+          clientY: point.y,
+        }
+        target.dispatchEvent(
+          new PointerEvent("pointerdown", {
+            ...init,
+            buttons: 1,
+            pointerId: 1,
+            pointerType: "mouse",
+          })
+        )
+        target.dispatchEvent(new MouseEvent("mousedown", { ...init, buttons: 1 }))
+        target.dispatchEvent(
+          new PointerEvent("pointerup", {
+            ...init,
+            buttons: 0,
+            pointerId: 1,
+            pointerType: "mouse",
+          })
+        )
+        target.dispatchEvent(new MouseEvent("mouseup", { ...init, buttons: 0 }))
+        target.dispatchEvent(new MouseEvent("click", { ...init, buttons: 0 }))
+      },
+      {
+        x: Math.round((points.startX + points.endX) / 2),
+        y: points.startY,
+      }
+    )
 
     await expect
       .poll(async () =>
@@ -217,6 +252,141 @@ test.describe("editor authoring route text selection drag", () => {
         persistedText: "",
         selectedCellCount: 0,
         selectionCollapsed: true,
+        selectionText: "",
+      })
+  })
+
+  test("실제 /editor/[id] table cell 클릭은 이전 block selection 대신 caret으로 진입한다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const previousSelectionLabel = "table caret previous block anchor"
+    const marker = "route-table-caret-marker"
+    const content = [
+      "table caret route 재현 문서",
+      ...Array.from({ length: 28 }, (_, index) =>
+        index === 8
+          ? `${previousSelectionLabel} ${index + 1}. 테이블 클릭 전 이전 block selection을 남깁니다.`
+          : `table caret lead paragraph ${index + 1}. 실제 수정 페이지에서 table caret 진입을 검증합니다.`
+      ),
+      [
+        '<!-- aq-table {"overflowMode":"normal","columnWidths":[180,240,220]} -->',
+        "| 영역 | 점검 항목 | 확인 기준 |",
+        "| --- | --- | --- |",
+        `| caret | ${marker} alpha | 클릭 후 caret |`,
+        "| result | beta | 선택 없음 |",
+      ].join("\n"),
+      "table caret trailing paragraph. 테이블 이후 본문입니다.",
+    ].join("\n\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/989", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          content,
+          contentHtml: null,
+          id: 989,
+          listed: true,
+          published: true,
+          title: "table caret route 회귀 글",
+          version: 3,
+        }),
+      })
+    })
+
+    await page.goto("/editor/989")
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+      "table caret route 회귀 글"
+    )
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expectEditorToContainLoadedText(editor, marker)
+
+    const previousSelectionParagraph = editor.locator("p", { hasText: previousSelectionLabel }).first()
+    await previousSelectionParagraph.scrollIntoViewIfNeeded()
+    const previousSelectionBox = await expectVisibleBox(
+      previousSelectionParagraph,
+      "table caret previous selection paragraph metrics are missing"
+    )
+    await page.mouse.move(
+      previousSelectionBox.x + Math.min(previousSelectionBox.width / 2, 240),
+      previousSelectionBox.y + Math.min(previousSelectionBox.height / 2, 18)
+    )
+    await previousSelectionParagraph.hover()
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    await dragHandle.click()
+    await expect(page.getByTestId("keyboard-block-selection-overlay")).toBeVisible()
+
+    const targetCell = editor.locator("table th, table td", { hasText: marker }).first()
+    await targetCell.scrollIntoViewIfNeeded()
+    const clickPoint = await targetCell.evaluate((element, text) => {
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+      while (walker.nextNode()) {
+        const textNode = walker.currentNode as Text
+        const index = textNode.data.indexOf(text)
+        if (index < 0) continue
+
+        const range = document.createRange()
+        range.setStart(textNode, index + 3)
+        range.setEnd(textNode, index + 4)
+        const rect = range.getBoundingClientRect()
+        if (rect.width <= 0 || rect.height <= 0) break
+        return {
+          x: rect.left + rect.width / 2,
+          y: rect.top + rect.height / 2,
+        }
+      }
+      return null
+    }, marker)
+
+    if (!clickPoint) {
+      throw new Error("route table caret click point is missing")
+    }
+
+    await page.mouse.click(clickPoint.x, clickPoint.y)
+    await page.waitForTimeout(260)
+
+    await expect
+      .poll(async () =>
+        page.evaluate((text) => {
+          const selection = window.getSelection()
+          const anchorElement =
+            selection?.anchorNode instanceof Element
+              ? selection.anchorNode
+              : selection?.anchorNode?.parentElement ?? null
+          const focusElement =
+            selection?.focusNode instanceof Element
+              ? selection.focusNode
+              : selection?.focusNode?.parentElement ?? null
+          return {
+            anchorInsideTargetCell: Boolean(anchorElement?.closest("th, td")?.textContent?.includes(text)),
+            blockOverlayCount: document.querySelectorAll("[data-testid='keyboard-block-selection-overlay']").length,
+            collapsed: selection?.isCollapsed ?? false,
+            focusInsideTargetCell: Boolean(focusElement?.closest("th, td")?.textContent?.includes(text)),
+            persistedText:
+              document.documentElement.getAttribute("data-table-drag-selection-text") ||
+              document
+                .querySelector("[data-table-drag-selection-text]")
+                ?.getAttribute("data-table-drag-selection-text") ||
+              "",
+            selectedCellCount: document.querySelectorAll(".selectedCell").length,
+            selectionText: selection?.toString().replace(/\s+/g, " ").trim() ?? "",
+          }
+        }, marker)
+      )
+      .toEqual({
+        anchorInsideTargetCell: true,
+        blockOverlayCount: 0,
+        collapsed: true,
+        focusInsideTargetCell: true,
+        persistedText: "",
+        selectedCellCount: 0,
         selectionText: "",
       })
   })

--- a/front/src/components/editor/tableTextCaretModel.ts
+++ b/front/src/components/editor/tableTextCaretModel.ts
@@ -1,0 +1,115 @@
+import type { Editor as TiptapEditor } from "@tiptap/core"
+import { TextSelection } from "@tiptap/pm/state"
+import { clearNextEditorPointerAfterTable } from "./blockHandleLayoutModel"
+import {
+  cancelActiveTableCellTextSelectionPreserves,
+  resolveTableTextCellAtPoint,
+} from "./tableTextSelectionModel"
+
+const TABLE_DRAG_SELECTION_TEXT_ATTR = "data-table-drag-selection-text"
+const TABLE_DRAG_SELECTION_TEXT_SELECTOR = `[${TABLE_DRAG_SELECTION_TEXT_ATTR}]`
+
+const resolveElement = (target: EventTarget | Node | null | undefined) => {
+  if (target instanceof Element) return target
+  if (target instanceof Node) return target.parentElement
+  return null
+}
+
+const resolveCaretRangeFromPoint = (clientX: number, clientY: number) => {
+  const caretDocument = document as Document & {
+    caretPositionFromPoint?: (
+      x: number,
+      y: number
+    ) => { offset: number; offsetNode: Node } | null
+    caretRangeFromPoint?: (x: number, y: number) => Range | null
+  }
+  const position = caretDocument.caretPositionFromPoint?.(clientX, clientY)
+  if (position) {
+    const range = document.createRange()
+    range.setStart(position.offsetNode, position.offset)
+    range.collapse(true)
+    return range
+  }
+  const range = caretDocument.caretRangeFromPoint?.(clientX, clientY)
+  range?.collapse(true)
+  return range ?? null
+}
+
+const isWindowSelectionInsideTable = (selection: Selection, table: Element | null) => {
+  if (!table) return false
+  const anchorElement = resolveElement(selection.anchorNode)
+  const focusElement = resolveElement(selection.focusNode)
+  return Boolean(anchorElement && focusElement && table.contains(anchorElement) && table.contains(focusElement))
+}
+
+const isEditorSelectionInsideTable = (editor: TiptapEditor) => {
+  const { selection } = editor.state
+  if (selection.empty) return false
+  const resolveDomElementAtPos = (pos: number) => {
+    const safePos = Math.max(0, Math.min(editor.state.doc.content.size, pos))
+    try {
+      return resolveElement(editor.view.domAtPos(safePos).node)
+    } catch {
+      return null
+    }
+  }
+  const fromElement = resolveDomElementAtPos(selection.from)
+  const toElement = resolveDomElementAtPos(Math.max(selection.from, selection.to - 1))
+  return Boolean(fromElement?.closest("th, td") || toElement?.closest("th, td"))
+}
+
+const clearTableDragSelectionMarkers = () => {
+  document
+    .querySelectorAll(TABLE_DRAG_SELECTION_TEXT_SELECTOR)
+    .forEach((element) => element.removeAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR))
+  document.documentElement.removeAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR)
+}
+
+export const collapseTableCellTextSelectionToPoint = (
+  editor: TiptapEditor,
+  clientX: number,
+  clientY: number,
+  target?: EventTarget | Node | null
+) => {
+  const cell = resolveTableTextCellAtPoint(clientX, clientY, target)
+  if (!(cell instanceof HTMLElement) || !editor.view.dom.contains(cell)) return false
+  const selection = window.getSelection()
+  if (!selection) return false
+
+  const table = cell.closest("table")
+  const hasOwnedWindowSelection = Boolean(
+    selection.toString().trim() && isWindowSelectionInsideTable(selection, table)
+  )
+  const hasPersistedTableSelection = Boolean(
+    document.documentElement.getAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR)?.trim() ||
+      cell.getAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR)?.trim() ||
+      cell.querySelector(TABLE_DRAG_SELECTION_TEXT_SELECTOR)
+  )
+  if (!hasOwnedWindowSelection && !hasPersistedTableSelection && !isEditorSelectionInsideTable(editor)) {
+    return false
+  }
+
+  const caretRange = resolveCaretRangeFromPoint(clientX, clientY)
+  const caretElement = resolveElement(caretRange?.startContainer)
+  if (!caretRange || !caretElement || !cell.contains(caretElement)) return false
+
+  cancelActiveTableCellTextSelectionPreserves()
+  clearTableDragSelectionMarkers()
+  if (editor.view.dom instanceof HTMLElement) {
+    editor.view.dom.focus({ preventScroll: true })
+  }
+
+  const pointPos = editor.view.posAtCoords({ left: clientX, top: clientY })?.pos
+  if (typeof pointPos === "number") {
+    const safePos = Math.max(0, Math.min(editor.state.doc.content.size, pointPos))
+    try {
+      editor.view.dispatch(editor.state.tr.setSelection(TextSelection.near(editor.state.doc.resolve(safePos))))
+    } catch {
+      // The DOM caret range below is still enough to leave native text selection collapsed.
+    }
+  }
+  selection.removeAllRanges()
+  selection.addRange(caretRange)
+  clearNextEditorPointerAfterTable()
+  return true
+}

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -3,10 +3,11 @@ import { TextSelection } from "@tiptap/pm/state"
 import { useEffect, useRef, type Dispatch, type MutableRefObject, type RefObject, type SetStateAction } from "react"
 import { cancelTablePointerScrollPreserves, clearNextEditorPointerAfterTable, markNextEditorPointerAfterTable, preserveWindowScrollForCodePointerFocus, preserveWindowScrollForEditorPointerFocus, preserveWindowScrollPositionAcrossFrames, type WindowScrollAnchor } from "./blockHandleLayoutModel"
 import { resolveMultiCellTableDomSelectionBubbleState, resolvePersistedTableTextSelectionBubbleState } from "./floatingBubbleDomRangeModel"
+import { TABLE_COLUMN_RESIZE_GUARD_PX } from "./tableResizeInteractionModel"
+import { collapseTableCellTextSelectionToPoint } from "./tableTextCaretModel"
 import { isTableSelectionActive } from "./tableStructureModel"
 import { cancelActiveTableCellTextSelectionPreserves, collapseStaleTableEditorSelection, preserveTableCellTextSelectionAcrossFrames, resolveTableTextCellAtPoint, resolveTableTextSelectionRangeCells, restoreTableCellTextSelectionIfEscaped, selectTableCellTextRange, watchTableCellTextSelectionExternalClear } from "./tableTextSelectionModel"
 import { areFloatingBubbleStatesEqual, hideFloatingBubbleState, resolveFloatingBubbleStateFromCoords, type FloatingBubbleState } from "./useFloatingBubbleState"
-type SetState<T> = Dispatch<SetStateAction<T>>
 const CODE_BLOCK_EDITOR_CONTENT_SELECTOR = ".aq-code-editor-content"
 const BLOCK_EDITOR_ROOT_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
 const TABLE_TEXT_DRAG_CONTROL_SELECTOR = "[data-table-axis-rail='true'], [data-table-affordance], [data-table-menu-root='true'], [data-table-menu-trigger='true'], [data-testid^='table-column-resize-boundary-'], [data-testid='table-structure-menu-button'], [data-testid='table-corner-handle'], [data-testid='table-corner-grow-handle'], .column-resize-handle"
@@ -22,7 +23,7 @@ type UseBlockEditorEngineSelectionBubbleEffectsArgs = {
   mouseTextSelectionInProgressRef: MutableRefObject<boolean>
   scheduleBubbleHide: () => void
   scheduleTableQuickRailHide: () => void
-  setBubbleState: SetState<FloatingBubbleState>
+  setBubbleState: Dispatch<SetStateAction<FloatingBubbleState>>
   syncBubbleOnMouseUpRef: MutableRefObject<boolean>
   syncTableQuickRailFromElement: (element: Element, clientX?: number, clientY?: number) => void
   tableMenuState: unknown
@@ -47,7 +48,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
   tableMenuState,
   tryStartTableColumnResizeFromDomHandle,
 }: UseBlockEditorEngineSelectionBubbleEffectsArgs) => {
-  const tableTextDragStartRef = useRef<{ cell: HTMLElement; coveredControlFallback: boolean; endCell: HTMLElement | null; scrollPreserveStarted: boolean; selectionPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null)
+  const tableTextDragStartRef = useRef<{ cell: HTMLElement; coveredControlFallback: boolean; endCell: HTMLElement | null; scrollPreserveStarted: boolean; selectionPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null), tableTextDragInitialSelectionTextRef = useRef("")
   const tableTextDragPendingStartRef = useRef<{ cell: HTMLElement; coveredControlFallback: boolean; endCell: HTMLElement | null; scrollPreserveStarted: boolean; selectionPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null)
   const codeTextDragStartRef = useRef<{ root: HTMLElement; scrollPreserveStarted: boolean; scrollAnchor: WindowScrollAnchor; x: number; y: number } | null>(null), nonTableTextDragStartRef = useRef<{ x: number; y: number } | null>(null)
   useEffect(() => {
@@ -101,12 +102,12 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const pointInsideEditor = pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR)))
       const tableTextCell = resolveTableTextCellAtPoint(event.clientX, event.clientY, event.target, { allowControlFallback: true })
       const tableControlTarget = targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR) ?? pointElements[0]?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR)
-      const tableCellRect = tableTextCell instanceof HTMLElement ? tableTextCell.getBoundingClientRect() : null, coveredControlFallback = Boolean(tableCellRect && tableControlTarget?.getAttribute("data-table-affordance") === "row-handle" && event.clientX >= tableCellRect.left && event.clientX <= tableCellRect.right && event.clientY >= tableCellRect.top && event.clientY <= tableCellRect.bottom)
+      const tableCellRect = tableTextCell instanceof HTMLElement ? tableTextCell.getBoundingClientRect() : null, tableControlAffordance = tableControlTarget?.getAttribute("data-table-affordance") ?? "", coveredControlFallback = Boolean(tableCellRect && (tableControlAffordance === "row-handle" || (!tableControlAffordance && tableControlTarget?.getAttribute("data-testid") === "table-row-rail" && event.clientX <= tableCellRect.right - TABLE_COLUMN_RESIZE_GUARD_PX)) && event.clientX >= tableCellRect.left && event.clientX <= tableCellRect.right && event.clientY >= tableCellRect.top && event.clientY <= tableCellRect.bottom)
       if (!(event.target instanceof Node) || (!activeEditor.view.dom.contains(event.target) && !targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR) && !pointInsideEditor && !(allowOutsideCoveredControlFallback && coveredControlFallback))) { tableTextDragStartRef.current = null; return null }
       if (tableControlTarget && (!coveredControlFallback || !(tableTextCell instanceof HTMLElement))) { tableTextDragStartRef.current = null; return null }
       const scrollAnchor = { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }
       if (tableTextCell instanceof HTMLElement) {
-        nonTableTextDragStartRef.current = null; cancelTableTextDragPreserves()
+        nonTableTextDragStartRef.current = null; cancelTableTextDragPreserves(); tableTextDragInitialSelectionTextRef.current = window.getSelection()?.toString().trim() ?? ""
         tableTextCell.removeAttribute("data-table-drag-selection-text")
         markNextEditorPointerAfterTable()
       }
@@ -210,7 +211,6 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const codeTextDragStart = codeTextDragStartRef.current
       return Boolean(codeTextDragStart && (Math.abs(event.clientX - codeTextDragStart.x) > 4 || Math.abs(event.clientY - codeTextDragStart.y) > 4))
     }
-
     const syncBubble = () => {
       const activeEditor = editorRef.current ?? currentEditor
       if (!activeEditor) {
@@ -527,9 +527,9 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
           preserveCodeDragRootSelectionAcrossFrames(codeTextDragStart.root)
         }
       }
-      if (activeEditor && tableTextDragStart && !tableTextDragMoved) { const selection = window.getSelection(), anchorElement = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focusElement = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null, anchorCell = anchorElement?.closest("th, td"), focusCell = focusElement?.closest("th, td"); if (selection?.toString().trim() && anchorCell && focusCell && anchorCell.closest("table") === focusCell.closest("table") && activeEditor.view.dom.contains(anchorCell)) syncBubbleOnMouseUpRef.current = true }
+      if (activeEditor && tableTextDragStart && !tableTextDragMoved) { const selection = window.getSelection(), currentSelectionText = selection?.toString().trim() ?? "", collapsedTableCaret = event.type === "pointerup" && currentSelectionText === tableTextDragInitialSelectionTextRef.current && collapseTableCellTextSelectionToPoint(activeEditor, event.clientX, event.clientY, event.target); if (!collapsedTableCaret) { const anchorElement = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focusElement = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null, anchorCell = anchorElement?.closest("th, td"), focusCell = focusElement?.closest("th, td"); if (currentSelectionText && anchorCell && focusCell && anchorCell.closest("table") === focusCell.closest("table") && activeEditor.view.dom.contains(anchorCell)) syncBubbleOnMouseUpRef.current = true } }
       if (activeEditor && tableTextDragStart && (tableTextDragMoved || tableTextDragStart.coveredControlFallback)) { const completedTableTextDrag = tableTextDragStart, completedMultiCellDrag = Boolean(completedTableTextDrag.endCell && completedTableTextDrag.endCell !== completedTableTextDrag.cell); cancelTableTextDragPreserves(); if (completedMultiCellDrag && completedTableTextDrag.endCell) { const endCell = completedTableTextDrag.endCell; selectTableCellTextRange(completedTableTextDrag.cell, endCell); cleanupTableDragSelectionPreserve = preserveTableCellTextSelectionAcrossFrames(activeEditor, completedTableTextDrag.cell, completedTableTextDrag.scrollAnchor, () => endCell); event.preventDefault(); event.stopPropagation(); syncBubbleOnMouseUpRef.current = true } else if (restoreActiveTableTextDragSelection(true, true, false)) { event.preventDefault(); event.stopPropagation(); syncBubbleOnMouseUpRef.current = true; window.requestAnimationFrame(() => restoreTableCellTextSelectionIfEscaped(activeEditor, completedTableTextDrag.cell, null, true, true, false, completedTableTextDrag.endCell)) } }
-      tableTextDragStartRef.current = null
+      tableTextDragStartRef.current = null; tableTextDragInitialSelectionTextRef.current = ""
       tableTextDragPendingStartRef.current = null
       codeTextDragStartRef.current = null; nonTableTextDragStartRef.current = null
       mouseTextSelectionInProgressRef.current = false


### PR DESCRIPTION
## 관련 이슈

close #514

## 작업 배경

- 테이블 셀 내부 기존 텍스트 선택 상태에서 단순 클릭이 native caret collapse에만 의존하던 경로를 보강했습니다.
- non-drag table click 종료 시 클릭 좌표로 caret을 직접 복구해 글자 블록 선택이 남지 않게 합니다.

## 작업 내용

- table caret collapse 전용 모델을 추가해 table selection preserve marker와 window selection을 정리합니다.
- table text drag 종료 경로에서 움직임 없는 클릭만 caret collapse로 처리하고, drag/multi-cell selection 경로는 기존 로직을 유지합니다.
- 기존 table cell 선택 테스트를 실제 이벤트 경로 기반 RED 회귀로 강화하고 `/editor/[id]` stale block selection 진입 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:authoring --grep "writer table cell 기존 텍스트 선택 후 단순 클릭"`
  - `yarn --cwd front test:e2e:authoring --grep "table cell|table caret"`
  - `yarn --cwd front build`
  - 참고: `yarn --cwd front test:e2e:authoring --grep "multi-cell"`는 #515 범위의 `dragOverCancelDrag.selectionText=""` 기존 실패로 분리했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 셀 텍스트 선택 직후 단순 클릭과 드래그 시작 판정이 겹치는 경계에서 caret 복구가 과하게 동작할 수 있습니다. 4px 이상 이동한 table drag 경로는 기존 multi-cell 분기로 유지했습니다.
- 롤백 방법: 이 PR을 revert하면 table caret collapse helper와 관련 테스트만 되돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
