### PR TITLE
[Fix] 테이블 셀 단순 클릭 caret 선택 복구

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -229,15 +229,15 @@ test.describe("editor authoring route live drag sequence", () => {
       element.scrollIntoView({ block: "center", inline: "nearest" })
       const rect = element.getBoundingClientRect()
       const y = rect.top + rect.height / 2
+      const startX = rect.left + Math.min(rect.width - 18, 24)
       return {
         endX: rect.left + Math.min(rect.width - 8, 128),
-        startX: rect.left + 8,
+        startX,
         y,
       }
     })
     await accessTokenCell.evaluate((element, metrics) => {
-      const rect = element.getBoundingClientRect()
-      const clientX = rect.left + 10
+      const clientX = metrics.startX + 2
       const clientY = metrics.y
       const selection = window.getSelection()
       selection?.removeAllRanges()
@@ -248,8 +248,7 @@ test.describe("editor authoring route live drag sequence", () => {
     }, accessTokenBox)
     expect(await readSelectionText(page)).toContain("Access Token")
     await accessTokenCell.evaluate((element, metrics) => {
-      const rect = element.getBoundingClientRect()
-      const clientX = rect.left + 10
+      const clientX = metrics.startX + 2
       const clientY = metrics.y
       element.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 0, buttons: 0, cancelable: true, clientX, clientY }))
     }, accessTokenBox)

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -3,7 +3,6 @@ import { TextSelection } from "@tiptap/pm/state"
 import { useEffect, useRef, type Dispatch, type MutableRefObject, type RefObject, type SetStateAction } from "react"
 import { cancelTablePointerScrollPreserves, clearNextEditorPointerAfterTable, markNextEditorPointerAfterTable, preserveWindowScrollForCodePointerFocus, preserveWindowScrollForEditorPointerFocus, preserveWindowScrollPositionAcrossFrames, type WindowScrollAnchor } from "./blockHandleLayoutModel"
 import { resolveMultiCellTableDomSelectionBubbleState, resolvePersistedTableTextSelectionBubbleState } from "./floatingBubbleDomRangeModel"
-import { TABLE_COLUMN_RESIZE_GUARD_PX } from "./tableResizeInteractionModel"
 import { collapseTableCellTextSelectionToPoint } from "./tableTextCaretModel"
 import { isTableSelectionActive } from "./tableStructureModel"
 import { cancelActiveTableCellTextSelectionPreserves, collapseStaleTableEditorSelection, preserveTableCellTextSelectionAcrossFrames, resolveTableTextCellAtPoint, resolveTableTextSelectionRangeCells, restoreTableCellTextSelectionIfEscaped, selectTableCellTextRange, watchTableCellTextSelectionExternalClear } from "./tableTextSelectionModel"
@@ -102,7 +101,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       const pointInsideEditor = pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR)))
       const tableTextCell = resolveTableTextCellAtPoint(event.clientX, event.clientY, event.target, { allowControlFallback: true })
       const tableControlTarget = targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR) ?? pointElements[0]?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR)
-      const tableCellRect = tableTextCell instanceof HTMLElement ? tableTextCell.getBoundingClientRect() : null, tableControlAffordance = tableControlTarget?.getAttribute("data-table-affordance") ?? "", coveredControlFallback = Boolean(tableCellRect && (tableControlAffordance === "row-handle" || (!tableControlAffordance && tableControlTarget?.getAttribute("data-testid") === "table-row-rail" && event.clientX <= tableCellRect.right - TABLE_COLUMN_RESIZE_GUARD_PX)) && event.clientX >= tableCellRect.left && event.clientX <= tableCellRect.right && event.clientY >= tableCellRect.top && event.clientY <= tableCellRect.bottom)
+      const tableCellRect = tableTextCell instanceof HTMLElement ? tableTextCell.getBoundingClientRect() : null, coveredControlFallback = Boolean(tableCellRect && tableControlTarget?.getAttribute("data-table-affordance") === "row-handle" && event.clientX >= tableCellRect.left && event.clientX <= tableCellRect.right && event.clientY >= tableCellRect.top && event.clientY <= tableCellRect.bottom)
       if (!(event.target instanceof Node) || (!activeEditor.view.dom.contains(event.target) && !targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR) && !pointInsideEditor && !(allowOutsideCoveredControlFallback && coveredControlFallback))) { tableTextDragStartRef.current = null; return null }
       if (tableControlTarget && (!coveredControlFallback || !(tableTextCell instanceof HTMLElement))) { tableTextDragStartRef.current = null; return null }
       const scrollAnchor = { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }


### PR DESCRIPTION
## 관련 이슈

close #514

## 작업 배경

- 테이블 셀 내부에서 단순 클릭/드래그 시작 시 블록 단위 선택이 생기던 회귀를 수정합니다.
- table row rail 시작 경로에서 셀 텍스트 drag 처리 범위를 row-handle 폴백 경로로 제한해 caret 동작을 복구합니다.

## 작업 내용

- front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts: row-handle 기반 fallback 판정으로 table 텍스트 drag start 경로를 제한했습니다.
- front/e2e/editor-authoring-route-live-drag-sequence.spec.ts: 회귀 케이스 재현 좌표를 안정적으로 산출하도록 수정했습니다.

## 검증

- 실행한 명령과 결과:
  - yarn --cwd front test:e2e:authoring --grep "table cell|table caret" (3 passed)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 특이사항 없음

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
