### PR TITLE
[Fix] 테이블 멀티셀 dragover 선택 복구

### DIFF
--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -88,16 +88,20 @@ export const finalizeTableTextSelectionFromPoint = (clientX: number, clientY: nu
 
 const rememberExplicitTableTextDragStart = (event: MouseEvent | PointerEvent) => { if (event.button !== 0 || ("pointerType" in event && event.pointerType && event.pointerType !== "mouse")) return; const startCell = resolveTableTextCellAtPoint(event.clientX, event.clientY, event.target); explicitTableTextDragStart = startCell instanceof HTMLElement ? { cell: startCell, x: event.clientX, y: event.clientY } : null }
 if (typeof window !== "undefined" && typeof document !== "undefined") {
-  const tableSelectionWindow = window as typeof window & { __aqTableTextSelectionFinalizerInstalled?: boolean }
-  if (!tableSelectionWindow.__aqTableTextSelectionFinalizerInstalled) {
-    tableSelectionWindow.__aqTableTextSelectionFinalizerInstalled = true
-    window.addEventListener("pointerdown", rememberExplicitTableTextDragStart, true); window.addEventListener("mousedown", rememberExplicitTableTextDragStart, true)
-    window.addEventListener("pointermove", preserveExplicitTableTextSelectionFromMoveEvent, true); window.addEventListener("mousemove", preserveExplicitTableTextSelectionFromMoveEvent, true)
-    window.addEventListener("dragover", (event) => { if (preserveExplicitTableTextSelectionFromPoint(event.clientX, event.clientY, event.target)) event.preventDefault() }, true)
-    window.addEventListener("dragenter", (event) => { if (preserveExplicitTableTextSelectionFromPoint(event.clientX, event.clientY, event.target)) event.preventDefault() }, true)
-    window.addEventListener("pointerup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("mouseup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("dragend", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true); window.addEventListener("drop", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
+    const tableSelectionWindow = window as typeof window & { __aqTableTextSelectionFinalizerInstalled?: boolean }
+    if (!tableSelectionWindow.__aqTableTextSelectionFinalizerInstalled) {
+      tableSelectionWindow.__aqTableTextSelectionFinalizerInstalled = true
+      window.addEventListener("pointerdown", rememberExplicitTableTextDragStart, true); window.addEventListener("mousedown", rememberExplicitTableTextDragStart, true)
+      window.addEventListener("pointermove", preserveExplicitTableTextSelectionFromMoveEvent, true); window.addEventListener("mousemove", preserveExplicitTableTextSelectionFromMoveEvent, true)
+      window.addEventListener("dragover", (event) => { if (preserveExplicitTableTextSelectionFromPoint(event.clientX, event.clientY, event.target)) event.preventDefault() }, true)
+      window.addEventListener("dragenter", (event) => { if (preserveExplicitTableTextSelectionFromPoint(event.clientX, event.clientY, event.target)) event.preventDefault() }, true)
+      window.addEventListener("pointerup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
+      window.addEventListener("pointercancel", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
+      window.addEventListener("mouseup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
+      window.addEventListener("dragend", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
+      window.addEventListener("drop", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
+    }
   }
-}
 
 const normalizeCellText = (cell: Element | null | undefined) => cell?.textContent?.replace(/\s+/g, " ").trim() ?? ""
 


### PR DESCRIPTION
## 관련 이슈

close #515

## 작업 배경

- table multi-cell drag 시 dragover 이후 pointercancel에서 시작 셀~끝 셀 텍스트 선택이 사라지던 경로를 보완합니다.
- explicit table drag finalizer가 포인터 취소 경로에서도 동작하도록 하여 텍스트 마커 선택을 복구합니다.

## 작업 내용

- front/src/components/editor/tableTextSelectionModel.ts: pointercancel 이벤트에서 table 텍스트 selection finalizer를 호출하도록 추가해 명시적 range 상태를 정리합니다.

## 검증

- 실행한 명령과 결과:
  - yarn --cwd front test:e2e:authoring --grep "multi-cell" (환경 제약으로 PLAYWRIGHT 서버 시작 실패: EPERM 127.0.0.1:3100)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 특이사항 없음

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
