### PR TITLE
[Fix] 테이블 셀 텍스트 범위 선택 복구

### DIFF
--- a/front/scripts/check-refactor-boundaries.mjs
+++ b/front/scripts/check-refactor-boundaries.mjs
@@ -37,6 +37,11 @@ const productionSoftAllowlist = {
     reason: "table style module is a style-only companion and remains below the 1,000 line style budget",
     expires: "split when table chrome tokens are promoted to shared primitives",
   },
+  "src/components/editor/tableTextSelectionModel.ts": {
+    issue: "#515",
+    reason: "table text-range drag recovery remains centralized while multi-cell regressions are stabilized",
+    expires: "split below 600 after explicit drag tracking and frame-preserve logic move into dedicated helpers",
+  },
 }
 
 const e2eRootAllowlist = {

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -87,6 +87,11 @@ export const finalizeTableTextSelectionFromPoint = (clientX: number, clientY: nu
 }
 
 const rememberExplicitTableTextDragStart = (event: MouseEvent | PointerEvent) => { if (event.button !== 0 || ("pointerType" in event && event.pointerType && event.pointerType !== "mouse")) return; const startCell = resolveTableTextCellAtPoint(event.clientX, event.clientY, event.target); explicitTableTextDragStart = startCell instanceof HTMLElement ? { cell: startCell, x: event.clientX, y: event.clientY } : null }
+const finalizeTableTextSelectionFromPointerCancel = (event: PointerEvent) => {
+  const explicitDragStart = explicitTableTextDragStart
+  if (finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target)) return
+  if (explicitDragStart) explicitTableTextDragStart = explicitDragStart
+}
 if (typeof window !== "undefined" && typeof document !== "undefined") {
     const tableSelectionWindow = window as typeof window & { __aqTableTextSelectionFinalizerInstalled?: boolean }
     if (!tableSelectionWindow.__aqTableTextSelectionFinalizerInstalled) {
@@ -96,7 +101,7 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
       window.addEventListener("dragover", (event) => { if (preserveExplicitTableTextSelectionFromPoint(event.clientX, event.clientY, event.target)) event.preventDefault() }, true)
       window.addEventListener("dragenter", (event) => { if (preserveExplicitTableTextSelectionFromPoint(event.clientX, event.clientY, event.target)) event.preventDefault() }, true)
       window.addEventListener("pointerup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
-      window.addEventListener("pointercancel", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
+      window.addEventListener("pointercancel", finalizeTableTextSelectionFromPointerCancel, true)
       window.addEventListener("mouseup", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
       window.addEventListener("dragend", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)
       window.addEventListener("drop", (event) => finalizeTableTextSelectionFromPoint(event.clientX, event.clientY, event.target), true)


### PR DESCRIPTION
## 관련 이슈

close #515

## 작업 배경

- table multi-cell drag에서 `pointercancel`이 먼저 발생하면 selection range가 빈 문자열로 사라지던 회귀를 복구했습니다.
- pointercancel 시점에 selection finalize가 실패한 경우 drag start를 유지해 이후 `mouseup/drop`에서 정상적으로 범위 선택을 복원합니다.

## 작업 내용

- `front/src/components/editor/tableTextSelectionModel.ts`
  - pointercancel 전용 finalize 경로를 추가해 release 이벤트 체인에서 시작 셀 정보 유실을 방지했습니다.
- `front/scripts/check-refactor-boundaries.mjs`
  - `tableTextSelectionModel.ts`(600+ lines) soft allowlist를 #515 근거로 동기화해 CI/webServer prebuild 실패를 제거했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:authoring --grep "multi-cell"` (2회 연속 통과)
  - `yarn --cwd front test:e2e:authoring --grep "table cell|table caret"` (2회 연속 통과)
  - `yarn --cwd front build`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table text selection 경로가 pointercancel 이후 mouseup/drop에 의존하는 브라우저별 이벤트 순서 차이
- 롤백 방법: PR revert로 `tableTextSelectionModel.ts` pointercancel 복구 경로와 allowlist 엔트리를 함께 되돌린다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
