### PR TITLE
[Fix] 테이블 블록 드래그 이동 복구

### DIFF
--- a/front/e2e/editor-authoring-route-table-block-drag.spec.ts
+++ b/front/e2e/editor-authoring-route-table-block-drag.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test"
+import { expectEditorToContainLoadedText } from "./helpers/editorAuthoringFlow"
+
+const adminMember = {
+  id: 1,
+  username: "qa-admin",
+  nickname: "aquila",
+  isAdmin: true,
+}
+
+test.describe("editor authoring route table block drag", () => {
+  test("실제 /editor/[id] table block handle drag는 표 전체 block을 하단으로 이동한다", async ({
+    page,
+  }) => {
+    const tableMarkdown = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[180,180]} -->',
+      "| 구분 | 값 |",
+      "| --- | --- |",
+      "| table-block-marker | 이동 대상 |",
+    ].join("\n")
+    const content = [
+      "테이블 위 문단",
+      tableMarkdown,
+      "테이블 아래 문단",
+    ].join("\n\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/996", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 996,
+          version: 2,
+          title: "table block drag live route 글",
+          content,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/996")
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("table block drag live route 글")
+    await expectEditorToContainLoadedText(editor, "table-block-marker")
+
+    const table = editor.locator(".tableWrapper table").first()
+    const trailingParagraph = editor.locator(":scope > p", { hasText: "테이블 아래 문단" }).first()
+    const tableBox = await table.boundingBox()
+    const trailingBox = await trailingParagraph.boundingBox()
+    if (!tableBox || !trailingBox) {
+      throw new Error("table block drag live route 좌표를 계산할 수 없습니다.")
+    }
+
+    await page.mouse.move(tableBox.x + 24, tableBox.y + 24)
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    const handleBox = await dragHandle.boundingBox()
+    if (!handleBox) {
+      throw new Error("table block drag live route handle 좌표를 계산할 수 없습니다.")
+    }
+
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(trailingBox.x + 24, trailingBox.y + trailingBox.height + 18, { steps: 10 })
+    await expect(page.getByTestId("block-drag-ghost")).toBeVisible()
+    await page.mouse.up()
+
+    const blockOrder = await editor.evaluate((element) =>
+      Array.from(element.children).map((child) => child.textContent?.replace(/\s+/g, " ").trim() ?? "")
+    )
+    const topIndex = blockOrder.findIndex((text) => text.includes("테이블 위 문단"))
+    const trailingIndex = blockOrder.findIndex((text) => text.includes("테이블 아래 문단"))
+    const tableIndex = blockOrder.findIndex((text) => text.includes("table-block-marker"))
+    expect(topIndex).toBeGreaterThanOrEqual(0)
+    expect(trailingIndex).toBeGreaterThan(topIndex)
+    expect(tableIndex).toBeGreaterThan(trailingIndex)
+  })
+})


### PR DESCRIPTION
## 관련 이슈

close #513

## 작업 배경

- `/editor/[id]` 실경로에서 table block handle drag가 표 전체 블록 이동으로 이어지는지 검증하는 회귀 테스트를 추가했습니다.
- 기존 QA writer 경로 테스트와 함께 실경로 회귀를 이중으로 고정해 overlay/handle 충돌 재발을 차단합니다.

## 작업 내용

- `front/e2e/editor-authoring-route-table-block-drag.spec.ts`
  - 실제 `/editor/[id]` 환경에서 table block drag 후 블록 순서가 하단으로 이동하는지 검증하는 e2e를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:authoring --grep "실제 /editor/\[id\] table block handle drag"`
  - `yarn --cwd front test:e2e:authoring --grep "table block handle drag"` (2회 연속 통과)
  - `yarn --cwd front build`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: route fixture(`post 996`) 기반 테스트 데이터가 editor parsing 계약 변경에 민감할 수 있음
- 롤백 방법: PR revert로 신규 spec 파일만 제거하면 기존 동작 코드는 영향 없이 복구됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
