### PR TITLE
[Fix] 테이블 셀 Cmd+A 전체 셀 텍스트 선택 복구

### DIFF
--- a/front/e2e/editor-authoring-route-table-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-select-all.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "@playwright/test"
+import { expectEditorToContainLoadedText } from "./helpers/editorAuthoringFlow"
+
+const SELECT_ALL_SHORTCUT = process.platform === "darwin" ? "Meta+a" : "Control+a"
+
+const adminMember = {
+  id: 1,
+  username: "qa-admin",
+  nickname: "aquila",
+  isAdmin: true,
+}
+
+test.describe("editor authoring route table select all", () => {
+  test("실제 /editor/[id] table cell에서 첫 Cmd/Ctrl+A는 현재 테이블 전체 셀 텍스트를 선택한다", async ({
+    page,
+  }) => {
+    const leadLabel = "table select all lead paragraph"
+    const tailLabel = "table select all trailing paragraph"
+    const tableContent = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[119,192,210]} -->',
+      "| **영역** | **점검 항목** | **확인 기준** |",
+      "| --- | --- | --- |",
+      "| 개념 이해 | Stateless 의미 | 요청만으로 처리 가능한가 |",
+      "| 토큰 구조 | Access Token | 역할 명확 |",
+      "| 흐름 | 재발급 로직 | 구현되어 있는가 |",
+    ].join("\n")
+    const content = [
+      `${leadLabel}. 첫 Cmd/Ctrl+A에서 editor 전체가 아니라 table 범위만 선택되어야 합니다.`,
+      tableContent,
+      `${tailLabel}. table 바깥 본문은 첫 Cmd/Ctrl+A 선택 범위에 포함되면 안 됩니다.`,
+    ].join("\n\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/994", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 994,
+          version: 3,
+          title: "table select all live route 글",
+          content,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/994")
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("table select all live route 글")
+    await expectEditorToContainLoadedText(editor, "Access Token")
+
+    const targetCell = editor.locator("td", { hasText: "Access Token" }).first()
+    await targetCell.click({
+      position: { x: 24, y: 16 },
+    })
+    await targetCell.dblclick({
+      position: { x: 40, y: 16 },
+    })
+
+    await page.keyboard.press(SELECT_ALL_SHORTCUT)
+    await page.waitForTimeout(360)
+
+    const selectionText = await page.evaluate(() => window.getSelection()?.toString() ?? "")
+    expect(selectionText).toContain("영역")
+    expect(selectionText).toContain("점검 항목")
+    expect(selectionText).toContain("확인 기준")
+    expect(selectionText).toContain("Access Token")
+    expect(selectionText).toContain("구현되어 있는가")
+    expect(selectionText).not.toContain("table select all lead paragraph")
+    expect(selectionText).not.toContain("table select all trailing paragraph")
+    await expect(editor.locator(".selectedCell")).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## 관련 이슈

close #516

## 작업 배경

- `/editor/[id]` 실경로에서 table cell 내부 선택 상태에서 첫 Cmd/Ctrl+A가 현재 테이블 전체 셀 텍스트 범위로 확장되는지 검증하는 회귀 테스트를 추가했습니다.
- table 바깥 본문이 첫 select-all 범위에 섞이지 않는 계약을 명시해 keymap 회귀를 재발 방지합니다.

## 작업 내용

- `front/e2e/editor-authoring-route-table-select-all.spec.ts`
  - table cell 클릭/부분 선택 후 첫 Cmd/Ctrl+A가 헤더+다중 셀 텍스트를 모두 포함하는지 검증합니다.
  - 같은 동작에서 table 바깥 문단이 선택에 포함되지 않는지 확인합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:authoring --grep "table cell에서 첫 Cmd/Ctrl\\+A"` (2회 연속 통과)
  - `yarn --cwd front test:e2e:authoring --grep "select all|Cmd/Ctrl\\+A"` (2회 연속 통과)
  - `yarn --cwd front build`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: OS별 단축키 차이로 입력 이벤트 처리 순서가 달라질 수 있음
- 롤백 방법: PR revert로 신규 table select-all route spec만 제거하면 됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
