### PR TITLE
[Fix] 테이블 셀 선택 scroll 좌표 보존 복구

### DIFF
--- a/front/e2e/editor-authoring-route-table-scroll-preserve.spec.ts
+++ b/front/e2e/editor-authoring-route-table-scroll-preserve.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test, type Page } from "@playwright/test"
+import { expectEditorToContainLoadedText } from "./helpers/editorAuthoringFlow"
+
+const SELECT_ALL_SHORTCUT = process.platform === "darwin" ? "Meta+a" : "Control+a"
+
+const adminMember = {
+  id: 1,
+  username: "qa-admin",
+  nickname: "aquila",
+  isAdmin: true,
+}
+
+const readScrollTop = (page: Page) =>
+  page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+
+test.describe("editor authoring route table scroll preserve", () => {
+  test("실제 /editor/[id] table cell 클릭/텍스트 선택/Cmd+A 중 scrollTop이 튀지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+
+    const leadParagraphs = Array.from({ length: 72 }, (_, index) =>
+      `table scroll preserve lead paragraph ${index + 1}. table 상호작용 중 scroll coordinate 보존을 확인합니다.`
+    )
+    const tableMarkdown = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[119,192,210]} -->',
+      "| **영역** | **점검 항목** | **확인 기준** |",
+      "| --- | --- | --- |",
+      "| 개념 이해 | Stateless 의미 | 요청만으로 처리 가능한가 |",
+      "| 토큰 구조 | Access Token | 역할 명확 |",
+      "| 흐름 | 재발급 로직 | 구현되어 있는가 |",
+    ].join("\n")
+    const content = [
+      "table scroll preserve route 글입니다.",
+      ...leadParagraphs,
+      tableMarkdown,
+      "table scroll preserve trailing paragraph. 상호작용 후에도 viewport가 유지되어야 합니다.",
+    ].join("\n\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/993", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 993,
+          version: 2,
+          title: "table scroll preserve live route 글",
+          content,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/993")
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+      "table scroll preserve live route 글"
+    )
+    await expectEditorToContainLoadedText(editor, "Access Token")
+
+    const targetCell = editor.locator("td", { hasText: "Access Token" }).first()
+    await targetCell.scrollIntoViewIfNeeded()
+    await page.waitForTimeout(120)
+
+    const beforeClickScrollTop = await readScrollTop(page)
+    await targetCell.click({ position: { x: 28, y: 16 } })
+    await page.waitForTimeout(180)
+    const afterClickScrollTop = await readScrollTop(page)
+    expect(Math.abs(afterClickScrollTop - beforeClickScrollTop)).toBeLessThanOrEqual(24)
+
+    const dragMetrics = await targetCell.evaluate((element) => {
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+      while (walker.nextNode()) {
+        const textNode = walker.currentNode as Text
+        const startOffset = textNode.data.indexOf("Access Token")
+        if (startOffset < 0) continue
+        const range = document.createRange()
+        range.setStart(textNode, startOffset)
+        range.setEnd(textNode, startOffset + "Access Token".length)
+        const rect = Array.from(range.getClientRects()).find((candidate) => candidate.width > 2 && candidate.height > 2) ?? range.getBoundingClientRect()
+        if (rect.width <= 2 || rect.height <= 2) {
+          throw new Error("table scroll preserve text rect is too small")
+        }
+        return {
+          endX: rect.right - 2,
+          startX: rect.left + 2,
+          y: rect.top + rect.height / 2,
+        }
+      }
+      throw new Error("table scroll preserve text node is missing")
+    })
+
+    const beforeDragScrollTop = await readScrollTop(page)
+    await page.mouse.move(dragMetrics.startX, dragMetrics.y)
+    await page.mouse.down()
+    await page.mouse.move(dragMetrics.endX, dragMetrics.y, { steps: 16 })
+    await page.mouse.up()
+    await page.waitForTimeout(220)
+    const afterDragScrollTop = await readScrollTop(page)
+    expect(Math.abs(afterDragScrollTop - beforeDragScrollTop)).toBeLessThanOrEqual(24)
+
+    const beforeSelectAllScrollTop = await readScrollTop(page)
+    await page.keyboard.press(SELECT_ALL_SHORTCUT)
+    await page.waitForTimeout(320)
+    const afterSelectAllScrollTop = await readScrollTop(page)
+    expect(Math.abs(afterSelectAllScrollTop - beforeSelectAllScrollTop)).toBeLessThanOrEqual(24)
+
+    const selectionText = await page.evaluate(() => window.getSelection()?.toString() ?? "")
+    expect(selectionText).toContain("영역")
+    expect(selectionText).toContain("점검 항목")
+    expect(selectionText).toContain("확인 기준")
+    expect(selectionText).toContain("Access Token")
+    expect(selectionText).toContain("구현되어 있는가")
+  })
+})


### PR DESCRIPTION
## 관련 이슈

close #517

## 작업 배경

- `/editor/[id]` 실경로에서 table cell 상호작용(클릭 → 텍스트 선택 → Cmd/Ctrl+A) 중 scrollTop이 튀지 않는지 검증하는 회귀 테스트를 추가했습니다.
- 기존 하단 본문 클릭 스크롤 보존 테스트와 함께 table 선택 흐름의 scroll coordinate 계약을 명시적으로 고정합니다.

## 작업 내용

- `front/e2e/editor-authoring-route-table-scroll-preserve.spec.ts`
  - table cell 클릭/드래그 선택/Cmd+Crtl+A 단계별 scrollTop delta를 계측해 jump 여부를 검증합니다.
  - 같은 흐름에서 table 전체 선택 텍스트가 유지되는지 함께 확인합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:authoring --grep "table cell 클릭/텍스트 선택/Cmd\\+A 중 scrollTop이 튀지 않는다"` (2회 연속 통과)
  - `yarn --cwd front test:e2e:authoring --grep "테이블 클릭 후 하단 본문 클릭|table cell 클릭/텍스트 선택/Cmd\\+A"` (2회 연속 통과)
  - `yarn --cwd front build`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 브라우저별 selection 이벤트 타이밍 차이로 scroll delta 기준이 경계값에서 흔들릴 수 있음
- 롤백 방법: PR revert로 신규 scroll preserve spec만 제거하면 됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
