### PR TITLE
[Fix] table cell click caret collapse regression test

### DIFF
--- a/front/e2e/editor-authoring-selection-drag.spec.ts
+++ b/front/e2e/editor-authoring-selection-drag.spec.ts
@@ -389,6 +389,21 @@ test.describe("editor authoring route text selection drag", () => {
         selectedCellCount: 0,
         selectionText: "",
       })
+
+    await page.mouse.click(clickPoint.x, clickPoint.y)
+    await page.waitForTimeout(120)
+    const postClickState = await page.evaluate(() => ({
+      blockOverlayCount: document.querySelectorAll("[data-testid='keyboard-block-selection-overlay']").length,
+      selectedCellCount: document.querySelectorAll(".selectedCell").length,
+      selectionText: window.getSelection()?.toString().replace(/\s+/g, " ").trim() ?? "",
+      selectionCollapsed: window.getSelection()?.isCollapsed ?? true,
+    }))
+    expect(postClickState).toMatchObject({
+      blockOverlayCount: 0,
+      selectedCellCount: 0,
+      selectionText: "",
+      selectionCollapsed: true,
+    })
   })
 
   test("실제 /editor/[id] 텍스트 드래그 선택은 code/table/body에서 에러 없이 유지된다", async ({


### PR DESCRIPTION
## 관련 이슈

close #534

## 작업 배경

- 테이블 셀 단일 클릭 후 기존 block selection overlay가 남아 caret 동작이 깨지는 회귀를 재현하고 방지하는 테스트를 추가했습니다.

## 작업 내용

- `front/e2e/editor-authoring-selection-drag.spec.ts`에서 기존 `table cell 클릭` 시나리오에 단일 클릭 후 overlay/selection 상태를 `isCollapsed`와 카운트 기반으로 명시 검증하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright test e2e/editor-authoring-selection-drag.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring --grep "table"` (관련 외부 resize-guide 스펙 2건 플레이크 재현 및 재실행)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 테스트 실행 시간이 소폭 증가
- 롤백 방법: 해당 검증 블록을 제거하고 이전 커밋으로 되돌림

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
