### PR TITLE
[Fix] table multicell selection resilience after pointercancel

### DIFF
--- a/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
+++ b/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
@@ -432,3 +432,61 @@ test("live 507 형태의 table multi-cell drag는 여러 셀 텍스트를 연속
   expect(afterTrailingMouseup).toContain("영역")
   expect(afterTrailingMouseup).toContain("구현되어 있는가")
 })
+
+test("pointercancel 이전후에도 table multi-cell drag 선택 텍스트가 비지 않는다", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1580, height: 900 })
+
+  const content = [
+    "## 멀티셀 보정",
+    ...filler("table multicell recovery", 40),
+    '',
+    '<!-- aq-table {"overflowMode":"normal","columnWidths":[119,192,210]} -->',
+    "| **영역** | **점검 항목** | **확인 기준** |",
+    "| --- | --- | --- |",
+    "| 시작 | A | B |",
+    "| 중간 | C | D |",
+    "| 끝 | E | F |",
+    '',
+    ...filler("table multicell recovery after", 10),
+  ].join("\n")
+
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(adminMember),
+    })
+  })
+  await page.route("**/post/api/v1/adm/posts/998", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: 998,
+        version: 1,
+        title: "table multicell recover route 글",
+        content,
+        contentHtml: null,
+        published: true,
+        listed: true,
+      }),
+    })
+  })
+
+  await page.goto("/editor/998")
+  const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+  await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("table multicell recover route 글")
+  await expectEditorToContainLoadedText(editor, "점검 항목")
+
+  const startCell = editor.locator("th", { hasText: "시작" }).first()
+  const endCell = editor.locator("td", { hasText: "끝" }).first()
+  const tableDrag = await dragBetweenTextRanges(page, startCell, endCell, "live 507 table multi-cell drag restore", {
+    end: "끝",
+    start: "시작",
+  }, { cancelAtStart: true, cancelBeforeMouseup: true, skipSyntheticMoves: true, syntheticWithoutNativeSelection: true })
+
+  expect(tableDrag.selectionText).toContain("시작")
+  expect(tableDrag.selectionText).toContain("끝")
+  expect(await editor.locator(".selectedCell").count()).toBe(0)
+  expect(Math.abs(tableDrag.afterScrollTop - tableDrag.beforeScrollTop)).toBeLessThanOrEqual(24)
+})


### PR DESCRIPTION
## 관련 이슈

close #535

## 작업 배경

- table multi-cell 드래그 후 pointercancel/중간 취소 경로에서 텍스트 선택이 비는 문제를 고정하기 위한 회귀 테스트를 추가했습니다.

## 작업 내용

- `front/e2e/editor-authoring-route-table-multicell-selection.spec.ts`에 `pointercancel` 이후에도 선택 텍스트가 유지되는 시나리오를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright test e2e/editor-authoring-route-table-multicell-selection.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring --grep "table"` (관련 외부 resize-guide 스펙 2건 플레이크 재현 및 재실행)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 시나리오 기반 테스트 유지 비용 증가
- 롤백 방법: 이 테스트만 제거 후 이전 코드로 되돌림

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
