### PR TITLE
[Fix] table select-all scope isolation regression test

### DIFF
--- a/front/e2e/editor-authoring-route-table-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-select-all.spec.ts
@@ -77,4 +77,70 @@ test.describe("editor authoring route table select all", () => {
     expect(selectionText).not.toContain("table select all trailing paragraph")
     await expect(editor.locator(".selectedCell")).toHaveCount(0)
   })
+
+  test("table select all 반복 호출 시에도 table scope만 유지된다", async ({
+    page,
+  }) => {
+    const selectAllReRunMarkdown = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[119,192,210]} -->',
+      "| 영역 | 점검 항목 | 확인 기준 |",
+      "| --- | --- | --- |",
+      "| A | B | C |",
+      "| D | E | F |",
+    ].join("\n")
+    const content = [
+      "table select all repeat lead paragraph",
+      selectAllReRunMarkdown,
+      "table select all repeat trailing paragraph",
+    ].join("\n\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/996", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 996,
+          version: 1,
+          title: "table select all repeat route 글",
+          content,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/996")
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("table select all repeat route 글")
+
+    const targetCell = editor.locator("td", { hasText: "D" }).first()
+    await targetCell.click({
+      position: { x: 24, y: 16 },
+    })
+    await page.keyboard.press(SELECT_ALL_SHORTCUT)
+    await page.waitForTimeout(280)
+    const firstSelectionText = await page.evaluate(() => window.getSelection()?.toString() ?? "")
+    expect(firstSelectionText).toContain("영역")
+    expect(firstSelectionText).toContain("점검 항목")
+    expect(firstSelectionText).toContain("확인 기준")
+
+    await targetCell.dblclick({
+      position: { x: 24, y: 16 },
+    })
+    await page.keyboard.press(SELECT_ALL_SHORTCUT)
+    await page.waitForTimeout(280)
+    const secondSelectionText = await page.evaluate(() => window.getSelection()?.toString() ?? "")
+    expect(secondSelectionText).toContain("영역")
+    expect(secondSelectionText).toContain("점검 항목")
+    expect(secondSelectionText).toContain("확인 기준")
+    expect(secondSelectionText).not.toContain("repeat lead paragraph")
+    expect(secondSelectionText).not.toContain("repeat trailing paragraph")
+    await expect(editor.locator(".selectedCell")).toHaveCount(0)
+  })
 })


### PR DESCRIPTION
## 관련 이슈

close #536

## 작업 배경

- table에서 Cmd/Ctrl+A를 반복 호출했을 때 selection scope가 본문 밖으로 누수되지 않도록 회귀 테스트를 추가했습니다.

## 작업 내용

- `front/e2e/editor-authoring-route-table-select-all.spec.ts`에 기존 select-all 후 텍스트 재호출 시에도 table 영역만 선택되는지 확인하는 시나리오를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright test e2e/editor-authoring-route-table-select-all.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring --grep "table"` (관련 외부 resize-guide 스펙 2건 플레이크 재현 및 재실행)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: select-all 경로 테스트 시간 증가
- 롤백 방법: 해당 검증 시나리오 제거

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
