### PR TITLE
[Fix] table caret wheel scroll jump preservation regression test

### DIFF
--- a/front/e2e/editor-authoring-route-table-scroll-preserve.spec.ts
+++ b/front/e2e/editor-authoring-route-table-scroll-preserve.spec.ts
@@ -119,4 +119,105 @@ test.describe("editor authoring route table scroll preserve", () => {
     expect(selectionText).toContain("Access Token")
     expect(selectionText).toContain("구현되어 있는가")
   })
+
+  test("테이블 caret 포커스 후 wheel scroll은 캐럿 위치를 보존하며 점프하지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+
+    const leadParagraphs = Array.from({ length: 60 }, (_, index) =>
+      `table scroll preserve lead paragraph ${index + 1}. 캐럿 고정 점검용 시나리오입니다.`
+    )
+    const tableMarkdown = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[119,192,210]} -->',
+      "| **영역** | **점검 항목** | **확인 기준** |",
+      "| --- | --- | --- |",
+      "| 시작 | 캐럿 | 유지 |",
+      "| 중간 | 스크롤 | 점검 |",
+      "| 끝 | 반응성 | 확인 |",
+    ].join("\n")
+    const trailingParagraphs = Array.from({ length: 20 }, (_, index) =>
+      `table scroll preserve trailing paragraph ${index + 1}. 스크롤 이동 후에도 캐럿 anchor는 유지되어야 합니다.`
+    )
+    const content = [
+      ...leadParagraphs,
+      tableMarkdown,
+      ...trailingParagraphs,
+    ].join("\n\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/994", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 994,
+          version: 2,
+          title: "table caret scroll jump regress test",
+          content,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/994")
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+      "table caret scroll jump regress test"
+    )
+
+    const targetCell = editor.locator("td", { hasText: "캐럿" }).first()
+    await targetCell.scrollIntoViewIfNeeded()
+    await page.waitForTimeout(120)
+
+    const cellBox = await targetCell.boundingBox()
+    if (!cellBox) {
+      throw new Error("table caret scroll jump test target cell box is not available")
+    }
+
+    await page.mouse.move(cellBox.x + 24, cellBox.y + 16)
+    await page.mouse.down()
+    await page.mouse.up()
+    const caretStateAfterClick = await page.evaluate(() => {
+      const selection = window.getSelection()
+      return {
+        isCollapsed: selection?.isCollapsed ?? false,
+        text: selection?.toString() ?? "",
+      }
+    })
+    expect(caretStateAfterClick).toMatchObject({
+      isCollapsed: true,
+      text: "",
+    })
+
+    const beforeScrollTop = await readScrollTop(page)
+    await page.mouse.wheel(0, 240)
+    await page.waitForTimeout(220)
+    const afterFirstWheel = await readScrollTop(page)
+    expect(afterFirstWheel - beforeScrollTop).toBeGreaterThan(120)
+
+    await page.mouse.wheel(0, -240)
+    await page.waitForTimeout(220)
+    const afterSecondWheel = await readScrollTop(page)
+    expect(afterSecondWheel).toBeLessThan(beforeScrollTop + 140)
+    expect(Math.abs(afterSecondWheel - afterFirstWheel)).toBeGreaterThan(60)
+
+    const caretStateAfterScroll = await page.evaluate(() => {
+      const selection = window.getSelection()
+      return {
+        isCollapsed: selection?.isCollapsed ?? false,
+        text: selection?.toString() ?? "",
+      }
+    })
+    expect(caretStateAfterScroll).toMatchObject({
+      isCollapsed: true,
+      text: "",
+    })
+  })
 })


### PR DESCRIPTION
## 관련 이슈

close #537

## 작업 배경

- 테이블 내부 caret를 둔 상태에서 wheel scroll 발생 시 선택 범위가 튀거나 스크롤이 비정상 점프하지 않도록 회귀 시나리오를 추가했습니다.

## 작업 내용

- `front/e2e/editor-authoring-route-table-scroll-preserve.spec.ts`에 캐럿 `isCollapsed` 상태를 확인하면서 wheel scroll 전후에 스크롤 점프 및 caret 유지 여부를 검증하는 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright test e2e/editor-authoring-route-table-scroll-preserve.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring --grep "table"` (관련 외부 resize-guide 스펙 2건 플레이크 재현 및 재실행)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: wheel 기반 상호작용 시나리오로 테스트 실행 변동성 소폭 증가
- 롤백 방법: 해당 케이스 제거 및 이전 커밋으로 되돌림

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
