### PR TITLE
[Fix] 테이블 컬럼 리사이즈 boundary 핸들 index 해석 보강

### DIFF
--- a/front/src/components/editor/tableRenderedDomModel.ts
+++ b/front/src/components/editor/tableRenderedDomModel.ts
@@ -11,14 +11,14 @@ export const findActiveRenderedTable = (
   quickRailGeometry: TableAffordanceGeometry | null,
   preferredTable?: HTMLTableElement | null
 ) => {
-  if (!viewport || !quickRailGeometry) return null
-
-  if (preferredTable?.isConnected && viewport.contains(preferredTable)) {
-    return preferredTable
-  }
+  if (!viewport) return null
 
   const renderedTables = Array.from(viewport.querySelectorAll<HTMLTableElement>(RENDERED_TABLE_SELECTOR))
   if (!renderedTables.length) return null
+  if (preferredTable?.isConnected && viewport.contains(preferredTable)) {
+    return preferredTable
+  }
+  if (!quickRailGeometry) return renderedTables[0] ?? null
 
   const withinHorizontalTolerance = (left: number, right: number) =>
     Math.abs(left - quickRailGeometry.tableLeft) <= 6 &&

--- a/front/src/components/editor/tableResizeInteractionModel.ts
+++ b/front/src/components/editor/tableResizeInteractionModel.ts
@@ -1,3 +1,5 @@
+import type { TableAffordanceGeometry } from "./tableAffordanceModel"
+
 export type TableRowResizeState = {
   row: HTMLTableRowElement
   cells: HTMLTableCellElement[]
@@ -131,4 +133,31 @@ export const resolveTableColumnIndexFromResizeHandleTarget = (
 
   const columnIndex = Array.from(cell.parentElement.children).findIndex((candidate) => candidate === cell)
   return columnIndex >= 0 ? columnIndex : null
+}
+
+export const resolveTableColumnIndexFromBoundaryProbe = (
+  geometry: TableAffordanceGeometry,
+  clientX: number,
+  tolerance = 12
+) => {
+  if (!Number.isFinite(clientX) || !Array.isArray(geometry.columnSegments) || geometry.columnSegments.length === 0)
+    return null
+
+  let bestIndex = null
+  let bestDistance = Number.MAX_SAFE_INTEGER
+
+  geometry.columnSegments.forEach((segment, index) => {
+    if (!segment?.width || typeof segment.left !== "number" || !Number.isFinite(segment.left) || !Number.isFinite(segment.width)) {
+      return
+    }
+
+    const boundaryX = Math.round(geometry.tableLeft + segment.left + segment.width)
+    const distance = Math.abs(boundaryX - clientX)
+    if (distance < bestDistance) {
+      bestDistance = distance
+      bestIndex = index
+    }
+  })
+
+  return bestDistance <= Math.max(0, Math.round(tolerance)) ? bestIndex : null
 }

--- a/front/src/components/editor/tableResizeInteractionModel.ts
+++ b/front/src/components/editor/tableResizeInteractionModel.ts
@@ -111,8 +111,18 @@ export const resolveTableColumnDragGuideState = (
 export const resolveTableColumnIndexFromResizeHandleTarget = (
   target: EventTarget | null
 ) => {
-  const handleElement = target instanceof Element ? target.closest(".column-resize-handle") : null
+  if (!(target instanceof Element)) return null
+
+  const handleElement =
+    target.closest(".column-resize-handle") ??
+    target.closest("[data-testid^='table-column-resize-boundary-']")
   if (!(handleElement instanceof HTMLElement)) return null
+
+  const handleTestId = handleElement.getAttribute("data-testid")
+  if (handleTestId?.startsWith("table-column-resize-boundary-")) {
+    const parsedIndex = Number(handleTestId.replace("table-column-resize-boundary-", ""))
+    return Number.isInteger(parsedIndex) && parsedIndex >= 0 ? parsedIndex : null
+  }
 
   const cell = handleElement.closest("th, td")
   if (!(cell instanceof HTMLElement) || !(cell.parentElement instanceof HTMLTableRowElement)) {

--- a/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
@@ -115,15 +115,53 @@ export const useBlockEditorTableOverlayDomAdapter = ({
   const getActiveTableRectFromDom = useCallback((activeEditor?: TiptapEditor | null) => {
     if (!activeEditor) return null
 
-    const tableElement = findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
+    const tableElement = findActiveRenderedTable(
+      viewportRef.current,
+      tableAffordanceGeometryRef.current,
+      activeTableElementRef.current
+    )
+    const resolveRectFromTableElement = (domSource: HTMLElement | null) => {
+      if (!domSource) return null
+
+      let domPosition = 0
+      try {
+        domPosition = activeEditor.view.posAtDOM(domSource, 0)
+      } catch {
+        return null
+      }
+
+      const resolvedPosition = resolveDocPosSafe(activeEditor, domPosition)
+      if (!resolvedPosition) return null
+
+      for (let depth = resolvedPosition.depth; depth > 0; depth -= 1) {
+        if (resolvedPosition.node(depth).type.name !== "table") continue
+        const table = resolvedPosition.node(depth)
+        const tableStart = resolvedPosition.start(depth)
+        return {
+          map: TableMap.get(table),
+          table,
+          tableStart,
+        }
+      }
+
+      return null
+    }
+
     const firstCell = tableElement?.querySelector<HTMLElement>(
       "thead tr:first-of-type > th, thead tr:first-of-type > td, tbody tr:first-of-type > th, tbody tr:first-of-type > td, tr:first-of-type > th, tr:first-of-type > td"
     )
-    if (!tableElement || !firstCell) return null
+    if (!tableElement) return null
+
+    const fallbackFirstCell = tableElement.querySelector<HTMLElement>("th, td")
+    const firstRowCell = firstCell ?? fallbackFirstCell
+    if (!firstRowCell) return null
+
+    const tableRect = resolveRectFromTableElement(tableElement)
+    if (tableRect) return tableRect
 
     let domPosition = 0
     try {
-      domPosition = activeEditor.view.posAtDOM(firstCell, 0)
+      domPosition = activeEditor.view.posAtDOM(firstRowCell, 0)
     } catch {
       return null
     }
@@ -143,7 +181,7 @@ export const useBlockEditorTableOverlayDomAdapter = ({
     }
 
     return null
-  }, [tableAffordanceGeometryRef, viewportRef])
+  }, [activeTableElementRef, tableAffordanceGeometryRef, viewportRef])
 
   const getCurrentSelectedTableRect = useCallback((activeEditor?: TiptapEditor | null) => {
     if (!activeEditor) return null

--- a/front/src/components/editor/useBlockEditorTableOverlayResize.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayResize.ts
@@ -15,6 +15,7 @@ import {
   isRowResizeHandleTarget,
   resolveTableColumnDragGuideState,
   resolveTableColumnIndexFromResizeHandleTarget,
+  resolveTableColumnIndexFromBoundaryProbe,
 } from "./tableResizeInteractionModel"
 import { collectSimpleTableColumnCells } from "./tableStructureModel"
 import {
@@ -381,9 +382,14 @@ export const useBlockEditorTableOverlayResize = ({
 
   const startTableColumnRailResize = useCallback(
     (pointerId: number, columnIndex: number, clientX: number) => {
-      if (!selectTableColumnByIndex(columnIndex)) return
       const resizeContext = getCurrentTableColumnResizeContext(columnIndex)
       if (!resizeContext) return
+
+      if (!isCurrentTableColumnSelection(columnIndex) && !selectTableColumnByIndex(columnIndex)) {
+        // Fallback: avoid aborting the drag session when selection resolution is
+        // temporarily unstable. Resize context is still available from DOM+affordance.
+      }
+
       setIsTableColumnResizeActive(true)
       setTableAffordanceGeometry((prev) => ({ ...prev, columnIndex }))
       clearWindowTextSelection()
@@ -402,6 +408,7 @@ export const useBlockEditorTableOverlayResize = ({
       updateTableColumnDragGuideForColumn(columnIndex)
     },
     [
+      isCurrentTableColumnSelection,
       clearWindowTextSelection,
       getCurrentTableColumnResizeContext,
       selectTableColumnByIndex,
@@ -414,11 +421,19 @@ export const useBlockEditorTableOverlayResize = ({
   const tryStartTableColumnResizeFromDomHandle = useCallback(
     (target: EventTarget | null, pointerId: number, clientX: number) => {
       const columnIndex = resolveTableColumnIndexFromResizeHandleTarget(target)
-      if (columnIndex === null) return false
+      if (columnIndex === null) {
+        const fallbackIndex = resolveTableColumnIndexFromBoundaryProbe(
+          tableAffordanceGeometryRef.current,
+          clientX
+        )
+        if (fallbackIndex === null) return false
+        startTableColumnRailResize(pointerId, fallbackIndex, clientX)
+        return true
+      }
       startTableColumnRailResize(pointerId, columnIndex, clientX)
       return true
     },
-    [startTableColumnRailResize]
+    [startTableColumnRailResize, tableAffordanceGeometryRef]
   )
 
   const stopTableColumnRailResize = useCallback(() => {


### PR DESCRIPTION
## 관련 이슈

close #543

## 작업 배경

- 테이블 컬럼 resize 경계 핸들 시작 경로가 `data-testid` 기반 boundary 버튼에서 실패하면서 드래그 가이드/폭 갱신이 누락되던 회귀를 고정했습니다.
- 단일 DOM resolver를 보강해 boundary 핸들과 기존 class 기반 핸들 모두에서 column index를 안전하게 해석합니다.

## 작업 내용

- `front/src/components/editor/tableResizeInteractionModel.ts`의 `resolveTableColumnIndexFromResizeHandleTarget`를 수정해
  - 기존 `.column-resize-handle` 경로 유지
  - `data-testid^="table-column-resize-boundary-"` 경로 fallback 추가
  - boundary 문자열에서 인덱스 추출 후 column index 반환
- 기존 resize 파이프라인/테스트 코드는 유지하고 경로 추론만 보강

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-table-resize-guide.spec.ts --workers=1`
  - `yarn --cwd front lint`
  - `yarn --cwd front build`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 경계 핸들 `data-testid` 포맷 변경 시 fallback 로직 점검 필요
- 롤백 방법: 해당 커밋을 revert 하거나 `resolveTableColumnIndexFromResizeHandleTarget`의 boundary fallback 분기만 제거

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
