### PR TITLE
[Fix] editor table 셀 선택/코드블럭 회귀 보정

### DIFF
--- a/front/e2e/editor-authoring-route-table-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-select-all.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test"
-import { expectEditorToContainLoadedText } from "./helpers/editorAuthoringFlow"
+import { expectEditorToContainLoadedText, getTableAffordances } from "./helpers/editorAuthoringFlow"
 
 const SELECT_ALL_SHORTCUT = process.platform === "darwin" ? "Meta+a" : "Control+a"
 
@@ -76,5 +76,92 @@ test.describe("editor authoring route table select all", () => {
     expect(selectionText).not.toContain("table select all lead paragraph")
     expect(selectionText).not.toContain("table select all trailing paragraph")
     await expect(editor.locator(".selectedCell")).toHaveCount(0)
+  })
+
+  test("실제 /editor/[id] table 행 핸들을 클릭하면 행 overlay/menu가 표시되어야 한다", async ({
+    page,
+  }) => {
+    const leadLabel = "table row handle lead paragraph"
+    const tailLabel = "table row handle trailing paragraph"
+    const tableContent = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[119,192,210]} -->',
+      "| **영역** | **점검 항목** | **확인 기준** |",
+      "| --- | --- | --- |",
+      "| 개념 이해 | Stateless 의미 | 요청만으로 처리 가능한가 |",
+      "| 토큰 구조 | Access Token | 역할 명확 |",
+      "| 흐름 | 재발급 로직 | 구현되어 있는가 |",
+    ].join("\n")
+    const content = [
+      `${leadLabel}. 행 핸들이 행 선택으로 이어져야 합니다.`,
+      tableContent,
+      `${tailLabel}. 행 선택 핸들 동작 실패 여부를 확인합니다.`,
+    ].join("\n\n")
+    const rowId = 996
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route(`**/post/api/v1/adm/posts/${rowId}`, async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: rowId,
+          version: 3,
+          title: "table row handle live route 글",
+          content,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto(`/editor/${rowId}`)
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("table row handle live route 글")
+    await expectEditorToContainLoadedText(editor, "Access Token")
+
+    const rowAffordances = getTableAffordances(page)
+    const rowHandle = rowAffordances.rowHandle
+
+    const firstTableCell = editor.locator("table th, table td").first()
+    await firstTableCell.click({ position: { x: 24, y: 16 } })
+    const table = editor.locator("table").first()
+    const tableRect = await table.boundingBox()
+    const firstCellRect = await firstTableCell.boundingBox()
+    if (!tableRect || !firstCellRect) {
+      throw new Error("table row handle target metrics are missing")
+    }
+
+    await page.mouse.move(tableRect.x + 2, firstCellRect.y + firstCellRect.height / 2)
+    await expect(rowHandle).toBeVisible({ timeout: 10_000 })
+    const rowHandleRect = await rowHandle.boundingBox()
+    if (!rowHandleRect || rowHandleRect.width <= 0 || rowHandleRect.height <= 0) {
+      throw new Error("row handle metrics are invalid")
+    }
+
+    await page.mouse.click(
+      rowHandleRect.x + rowHandleRect.width / 2,
+      rowHandleRect.y + rowHandleRect.height / 2
+    )
+    await expect(page.getByTestId("table-row-selection-outline")).toBeVisible()
+    const rowMenu = page.getByTestId("table-row-menu")
+    await expect(rowMenu).toBeVisible()
+    await expect(rowMenu.getByRole("button", { name: "행 삭제" })).toBeVisible()
+    await page.keyboard.press("Escape")
+    await expect(rowMenu).toHaveCount(0)
+
+    const targetCell = editor.locator("td", { hasText: "Access Token" }).first()
+    await targetCell.click({ position: { x: 24, y: 16 } })
+    await page.keyboard.press(process.platform === "darwin" ? "Meta+a" : "Control+a")
+    await page.waitForTimeout(260)
+    const selectionText = await page.evaluate(() => window.getSelection()?.toString() ?? "")
+    expect(selectionText).toContain("개념 이해")
+    expect(selectionText).toContain("Access Token")
+    expect(selectionText).not.toContain(leadLabel)
+    expect(selectionText).not.toContain(tailLabel)
   })
 })

--- a/front/scripts/check-refactor-boundaries.mjs
+++ b/front/scripts/check-refactor-boundaries.mjs
@@ -42,6 +42,11 @@ const productionSoftAllowlist = {
     reason: "table text-range drag recovery remains centralized while multi-cell regressions are stabilized",
     expires: "split below 600 after explicit drag tracking and frame-preserve logic move into dedicated helpers",
   },
+  "src/components/editor/codeBlockNodeView.tsx": {
+    issue: "#545",
+    reason: "editor table/cell selection and code-block selection interception regressions are fixed in-place without functional split yet",
+    expires: "split below 600 when code-block selection, drag-preserve, and scroll-jump fixes are extracted into dedicated helpers",
+  },
 }
 
 const e2eRootAllowlist = {

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -51,7 +51,7 @@ import {
 } from "./blockHandleLayoutModel"
 export { getPreferredCodeLanguage, normalizeCodeLanguage } from "./codeBlockNodeViewLanguageModel"
 export { CodeBlockEditorStyles } from "./codeBlockNodeViewStyles"
-let lastActiveCodeBlockContentRoot: HTMLElement | null = null, codeDomTextRangePreserveGeneration = 0
+let codeDomTextRangePreserveGeneration = 0
 type CodeDragSelectionSession = { active: boolean; anchorPos: number; lastHeadPos?: number; startX: number; startY: number }
 export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos }: NodeViewProps) => {
   const menuId = useId()
@@ -59,6 +59,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
   const searchInputRef = useRef<HTMLInputElement>(null)
   const shellRef = useRef<HTMLDivElement>(null)
   const codeDragSelectionRef = useRef<CodeDragSelectionSession | null>(null)
+  const isActiveCodeBlockRef = useRef(false)
   const [draftLanguage, setDraftLanguage] = useState(normalizeCodeLanguage(String(node.attrs?.language || "")))
   const [isLanguageMenuOpen, setIsLanguageMenuOpen] = useState(false)
   const [languageSearch, setLanguageSearch] = useState("")
@@ -211,7 +212,6 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       const anchorPos = resolveCodeTextPosFromPointer(event.clientX, event.clientY, contentRoot)
       if (typeof anchorPos !== "number") return
       event.stopPropagation()
-      lastActiveCodeBlockContentRoot = contentRoot
       const selection = window.getSelection(), persistedCodeSelectionText = shell.getAttribute("data-code-drag-selection-text")?.trim() || ""
       const anchorElement = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focusElement = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null
       const selectedText = selection?.toString().trim() || "", contentText = contentRoot.textContent?.trim() || ""
@@ -239,7 +239,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     (event: ReactPointerEvent<HTMLDivElement>) => {
       const contentRoot =
         shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
-      lastActiveCodeBlockContentRoot = contentRoot
+      isActiveCodeBlockRef.current = contentRoot?.isConnected ?? false
       if (event.pointerType && event.pointerType !== "mouse") return
       startCodeDragSelection(event)
     },
@@ -347,9 +347,9 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       const target = event.target
       if (!(target instanceof Node)) return
       if (contentRoot.contains(target)) {
-        lastActiveCodeBlockContentRoot = contentRoot
-      } else if (lastActiveCodeBlockContentRoot === contentRoot) {
-        lastActiveCodeBlockContentRoot = null
+        isActiveCodeBlockRef.current = contentRoot.isConnected
+      } else if (isActiveCodeBlockRef.current) {
+        isActiveCodeBlockRef.current = false
       }
       if (!contentRoot.contains(target)) codeDragSelectionRef.current = null
     }
@@ -364,10 +364,16 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
         selection?.anchorNode instanceof Element
           ? selection.anchorNode
           : selection?.anchorNode?.parentElement ?? null
+      const codeShell = contentRoot.closest(".aq-code-shell")
+      const isActiveShellMatch =
+        isActiveCodeBlockRef.current &&
+        codeShell?.isConnected &&
+        activeElement instanceof Element &&
+        codeShell.contains(activeElement)
       const isInsideCodeBlock =
         (activeElement instanceof Element && contentRoot.contains(activeElement)) ||
         (anchorElement instanceof Element && contentRoot.contains(anchorElement)) ||
-        (lastActiveCodeBlockContentRoot === contentRoot && contentRoot.isConnected)
+        (isActiveShellMatch && contentRoot.isConnected)
       if (!isInsideCodeBlock) return
       event.preventDefault()
       event.stopPropagation()
@@ -402,8 +408,8 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       if (frameId !== null) {
         window.cancelAnimationFrame(frameId)
       }
-      if (lastActiveCodeBlockContentRoot === contentRoot) {
-        lastActiveCodeBlockContentRoot = null
+      if (isActiveCodeBlockRef.current) {
+        isActiveCodeBlockRef.current = false
       }
     }
   }, [ensureCodeDomTextSelection, selectCurrentCodeBlockText, selected])

--- a/front/src/components/editor/serializationLegacyRepair.ts
+++ b/front/src/components/editor/serializationLegacyRepair.ts
@@ -37,9 +37,6 @@ export const restoreEditorDocCodeBlocksFromMarkdown = (
   doc: BlockEditorDoc
 ): { doc: BlockEditorDoc; changed: boolean } => {
   const sourceBlocks = collectCodeBlockSnapshots(parseMarkdownToEditorDoc(sourceMarkdown))
-  if (sourceBlocks.every((block) => !hasVisibleCodeText(block.text))) {
-    return { doc, changed: false }
-  }
 
   let codeBlockIndex = 0
   let changed = false

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -245,7 +245,17 @@ const isSelectionInsideSameTable = (selection: Selection, table: Element | null)
   return Boolean(anchorElement && focusElement && table.contains(anchorElement) && table.contains(focusElement))
 }
 
-const resolveWholeTableTextRangeCells = (cell: HTMLElement) => { const cells = Array.from(resolveCellTable(cell)?.querySelectorAll<HTMLElement>("th, td") ?? []).filter(isConnectedTableCell); return cells[0] && cells[cells.length - 1] ? { firstCell: cells[0], lastCell: cells[cells.length - 1] } : null }
+const resolveWholeTableTextRangeCells = (cell: HTMLElement) => {
+  const table = resolveCellTable(cell)
+  if (!table) return null
+
+  const rows = Array.from(table.rows)
+  const cells = rows.flatMap((row) => Array.from(row.cells)).filter(isConnectedTableCell)
+
+  return cells[0] && cells[cells.length - 1]
+    ? { firstCell: cells[0], lastCell: cells[cells.length - 1] }
+    : null
+}
 
 let lastActiveTableCell: HTMLElement | null = null
 const activeTableCellScrollPreserveCancels = new Set<() => void>()
@@ -438,6 +448,9 @@ export const selectActiveTableCellText = (
   const activeElement = resolveElement(document.activeElement)
   const anchorElement = resolveElement(selection.anchorNode)
   const targetElement = resolveElement(eventTarget)
+  if (targetElement?.closest(".aq-code-shell") || activeElement?.closest(".aq-code-shell") || anchorElement?.closest(".aq-code-shell")) {
+    return false
+  }
   const rememberedCell = lastActiveTableCell?.isConnected ? lastActiveTableCell : null
   const cell =
     targetElement?.closest("th, td") ??
@@ -449,6 +462,7 @@ export const selectActiveTableCellText = (
 
   const wholeTableRangeCells = resolveWholeTableTextRangeCells(cell)
   if (!wholeTableRangeCells) return false
+  clearNextEditorPointerAfterTable()
   preserveWindowScrollForRichBlockSelectAll()
   selectTableCellTextRange(wholeTableRangeCells.firstCell, wholeTableRangeCells.lastCell)
   preserveTableTextRangeAcrossFrames(wholeTableRangeCells.firstCell, wholeTableRangeCells.lastCell)


### PR DESCRIPTION
## 관련 이슈

close #545

## 작업 배경

- `/editor/[id]`에서 테이블 셀 전체 선택 경로가 코드블럭 컨텍스트와 충돌하지 않도록 분리했습니다.
- 코드블럭 복구 로직의 조기 조기 return을 제거해 실제 코드 본문이 보존되어야 하는 경우도 복구되도록 했습니다.
- 관련 e2e를 추가해 행 핸들/행 메뉴 오버레이와 셀 범위 선택 회귀를 확인하도록 했습니다.

## 작업 내용

- `front/src/components/editor/tableTextSelectionModel.ts`: 테이블 전체 선택의 시작/종료 셀 계산을 `table.rows` 기반으로 안정화하고, 코드블럭 내부에서는 table select-all 분기를 차단.
- `front/src/components/editor/codeBlockNodeView.tsx`: 코드블럭 활성 상태 추적을 전역 변수에서 셸 ref 기반 상태로 바꿔 멀티 블록/재진입 시 select-all 오버랩을 줄임.
- `front/src/components/editor/serializationLegacyRepair.ts`: placeholder 공백 판정 기준을 완화해 빈 문자열처럼 보이는 소스 코드블럭도 안전하게 복구.
- `front/e2e/editor-authoring-route-table-select-all.spec.ts`: 테이블 행 핸들 클릭 시 row outline/menu 표시 및 닫힘 동작을 추가.
- `front/scripts/check-refactor-boundaries.mjs`: 해당 코드 변경 파일에 대해 이슈 트래커 연동 allowlist 갱신.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_USE_WEBSERVER=false PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-table-select-all.spec.ts --workers=1` (실행 실패: 브라우저 런처 `browserType.launch: Target page, context or browser has been closed`, EPERM kill)
  - `PLAYWRIGHT_USE_WEBSERVER=false PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-table-scroll-preserve.spec.ts --workers=1` (실행 실패: 동일 브라우저 런처 오류)
  - `PLAYWRIGHT_USE_WEBSERVER=false PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-code-recovery.spec.ts --workers=1` (실행 실패: 동일 브라우저 런처 오류)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front eslint e2e/editor-authoring-route-table-select-all.spec.ts src/components/editor/tableTextSelectionModel.ts src/components/editor/codeBlockNodeView.tsx src/components/editor/serializationLegacyRepair.ts scripts/check-refactor-boundaries.mjs`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 테스트 자동화가 브라우저 런처 이슈로 차단되어 회귀 미통과 상태에서 머지될 위험이 있으나, 코드 변경은 국소적이며 기존 테이블/코드블럭 모듈 내.
- 롤백 방법: 해당 커밋을 revert 하거나 `front/src/components/editor/tableTextSelectionModel.ts`의 수정 영역(`resolveWholeTableTextRangeCells`, `selectActiveTableCellText`) 또는 `codeBlockNodeView.tsx` 관련 블록만 cherry-pick 취소.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
