### PR TITLE
[Fix] editor table 행/열 오버레이 좌표 추론 보정

### DIFF
--- a/front/src/components/editor/useBlockEditorTableOverlayControllerCommands.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayControllerCommands.ts
@@ -24,6 +24,7 @@ import {
   TABLE_ROW_GRIP_WIDTH_PX,
   TABLE_TRAILING_ADD_EDGE_HOTZONE_PX,
 } from "./useBlockEditorTableOverlayControllerState"
+import { resolveTableAxisIndexFromPointer } from "./tableAxisDragModel"
 
 type UseBlockEditorTableOverlayControllerCommandsArgs = {
   activeTableElementRef: MutableRefObject<HTMLTableElement | null>
@@ -141,11 +142,59 @@ export const useBlockEditorTableOverlayControllerCommands = ({
           : Date.now()) + 280
     }
     cancelTableQuickRailHide()
-    const hoveredCell = element?.closest("th, td") as HTMLElement | null
+    const tableRows = Array.from(tableElement.querySelectorAll("tr")).filter(
+      (row): row is HTMLTableRowElement => row instanceof HTMLTableRowElement && row.cells.length > 0
+    )
+    const hoveredCellFromPoint: HTMLTableCellElement | null = hasHoverPoint
+      ? (() => {
+          const pointElement = document.elementFromPoint(hoverClientX as number, hoverClientY as number)
+          const pointCell = pointElement?.closest("th, td")
+          if (pointCell instanceof HTMLTableCellElement) return pointCell
+
+          const cells = Array.from(tableElement.querySelectorAll("th, td")).filter(
+            (cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement
+          )
+          return (
+            cells.find((cell) => {
+              const cellRect = cell.getBoundingClientRect()
+              return (
+                hoverClientX >= cellRect.left &&
+                hoverClientX <= cellRect.right &&
+                hoverClientY >= cellRect.top &&
+                hoverClientY <= cellRect.bottom
+              )
+            }) ?? null
+          )
+        })()
+      : null
+    const hoveredCell = element?.closest("th, td") as HTMLTableCellElement | null
+    const hoveredColumnIndex = hasHoverPoint
+      ? resolveTableAxisIndexFromPointer(tableElement, "column", hoverClientX as number, hoverClientY as number)
+      : null
+    const hoveredRowIndex = hasHoverPoint
+      ? resolveTableAxisIndexFromPointer(tableElement, "row", hoverClientX as number, hoverClientY as number)
+      : null
+    const hoveredCellFromSelectedRect: HTMLTableCellElement | null = hasHoverPoint && hoveredRowIndex !== null
+      ? tableRows[hoveredRowIndex]?.querySelector("th, td") ?? null
+      : null
     const selectedCell = resolveTableScopedSelectedCell(tableElement)
-    const activeCell = hoveredCell || selectedCell || (tableElement.querySelector("th, td") as HTMLElement | null)
+    const selectedRow = selectedCell?.closest("tr")
+    const fallbackRow = tableRows[hoveredRowIndex ?? 0] ?? tableRows[0] ?? selectedRow ?? null
+    const activeCellFromColumnIndex =
+      typeof hoveredColumnIndex === "number" && fallbackRow
+        ? Array.from(fallbackRow.children).find((cell, index): cell is HTMLTableCellElement => index === hoveredColumnIndex && cell instanceof HTMLTableCellElement)
+        : null
+    const activeCell: HTMLTableCellElement | null = hoveredCell ??
+      hoveredCellFromPoint ??
+      activeCellFromColumnIndex ??
+      hoveredCellFromSelectedRect ??
+      (selectedCell as HTMLTableCellElement | null) ??
+      (tableElement.querySelector("th, td") as HTMLTableCellElement | null)
     const activeCellRect = activeCell?.getBoundingClientRect()
-    const activeRow = activeCell?.closest("tr") as HTMLTableRowElement | null
+    const activeRow =
+      activeCell?.closest("tr") ??
+      tableRows[hoveredRowIndex ?? 0] ??
+      (selectedRow instanceof HTMLTableRowElement ? selectedRow : null)
     const activeRowRect = activeRow?.getBoundingClientRect()
     const activeColumnLeft = activeCellRect?.left ?? tableRect.left
     const activeColumnRight = activeCellRect?.right ?? tableRect.right
@@ -199,10 +248,14 @@ export const useBlockEditorTableOverlayControllerCommands = ({
       !showColumnAddBar &&
       !showRowAddBar &&
       !showCornerControls
-    const activeRowIndex = activeRow
+    const activeRowIndex = typeof hoveredRowIndex === "number"
+      ? hoveredRowIndex
+      : activeRow
       ? Array.from(tableElement.querySelectorAll("tr")).findIndex((row) => row === activeRow)
       : 0
-    const activeColumnIndex = activeCell?.parentElement
+    const activeColumnIndex = typeof hoveredColumnIndex === "number"
+      ? hoveredColumnIndex
+      : activeCell?.parentElement
       ? Array.from(activeCell.parentElement.children).findIndex((child) => child === activeCell)
       : 0
     if (hasHoverPoint) syncHoveredTableCellMenuLayout(tableElement, activeCell)


### PR DESCRIPTION
## 관련 이슈

close #547

## 작업 배경

- `/editor/[id]`에서 테이블 호버/레이스오버가 셀/행 영역 밖에서도 이전 선택 셀에 고착되는 현상을 완화했습니다.
- 마우스 포인터 기반으로 행/열 인덱스를 다시 계산해 행 핸들/열 핸들 앵커가 올바른 대상에 붙도록 보정했습니다.
- 기존 셀 선택/scroll 점프 회귀 스위트를 유지 상태로 통과했습니다.

## 작업 내용

- `front/src/components/editor/useBlockEditorTableOverlayControllerCommands.ts`: hover pointer 좌표에서 행/열 인덱스를 추론해 `activeCell`, `activeRowIndex`, `activeColumnIndex`를 재결정하도록 변경했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front test:e2e:authoring --grep "table"`
  - `yarn --cwd front test:e2e:authoring --grep "table"`
  - `yarn --cwd front build`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 포인터 좌표 변환 기준이 예외 테이블 구조(병합/비정형 행)에서 오작동할 수 있음.
- 롤백 방법: `front/src/components/editor/useBlockEditorTableOverlayControllerCommands.ts`의 포인터 기반 fallback 로직만 revert.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
