### PR TITLE
[Fix] 수정 화면 코드블록 빈 렌더 복구

### DIFF
--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -259,6 +259,40 @@ test.describe("editor studio state", () => {
     expect(restored.doc.content?.[1]?.content?.[0]?.text).toBe("로그인 -> 세션 생성 -> 이후 요청에서 세션 확인")
   })
 
+  test("source/current 코드블럭 매핑이 어긋나면 빈 NodeView를 잘못한 source 본문으로 복구하지 않는다", () => {
+    const sourceMarkdown = [
+      "코드 본문 구조 이동 방지 대상입니다.",
+      "",
+      "```ts",
+      "const access = createAccessToken(user)",
+      "```",
+      "",
+      "```java",
+      "public Token login(User user) {",
+      "    return new Token(access, refresh);",
+      "}",
+      "```",
+    ].join("\n")
+    const staleDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "코드 본문 구조 이동 방지 대상입니다." }],
+        },
+        { type: "codeBlock", attrs: { language: "java" }, content: [] },
+        { type: "codeBlock", attrs: { language: "ts" }, content: [] },
+      ],
+    }
+
+    const restored = restoreEditorDocCodeBlocksFromMarkdown(sourceMarkdown, staleDoc)
+
+    expect(restored.changed).toBe(false)
+    expect(restored.doc).toBe(staleDoc)
+    expect(restored.doc.content?.[1]?.content || []).toHaveLength(0)
+    expect(restored.doc.content?.[2]?.content || []).toHaveLength(0)
+  })
+
   test("초기 로드 guard는 서버 baseline보다 빈 code fence가 들어온 editor update를 복구한다", () => {
     const expectedBody = [
       "코드 손실 방지 대상입니다.",

--- a/front/src/components/editor/serializationLegacyRepair.ts
+++ b/front/src/components/editor/serializationLegacyRepair.ts
@@ -13,13 +13,21 @@ const readPlainTextFromEditorNode = (node: JSONContent): string => {
 const hasVisibleCodeText = (value: string) =>
   value.replace(INVISIBLE_CODE_PLACEHOLDER_REGEX, "").trim().length > 0
 
+const readCodeLanguage = (node: JSONContent): string | null => {
+  const language = typeof node.attrs?.language === "string" ? node.attrs.language.trim() : ""
+  return language || null
+}
+
+const areCodeLanguagesCompatible = (currentLanguage: string | null, sourceLanguage: string | null) =>
+  !currentLanguage || !sourceLanguage || currentLanguage.toLowerCase() === sourceLanguage.toLowerCase()
+
 const collectCodeBlockSnapshots = (doc: JSONContent) => {
   const blocks: Array<{ language: string | null; text: string }> = []
 
   const visit = (node: JSONContent) => {
     if (node.type === "codeBlock") {
       blocks.push({
-        language: typeof node.attrs?.language === "string" ? node.attrs.language : null,
+        language: readCodeLanguage(node),
         text: readPlainTextFromEditorNode(node),
       })
       return
@@ -37,6 +45,8 @@ export const restoreEditorDocCodeBlocksFromMarkdown = (
   doc: BlockEditorDoc
 ): { doc: BlockEditorDoc; changed: boolean } => {
   const sourceBlocks = collectCodeBlockSnapshots(parseMarkdownToEditorDoc(sourceMarkdown))
+  const currentBlocks = collectCodeBlockSnapshots(doc)
+  if (sourceBlocks.length !== currentBlocks.length) return { doc, changed: false }
 
   let codeBlockIndex = 0
   let changed = false
@@ -48,10 +58,11 @@ export const restoreEditorDocCodeBlocksFromMarkdown = (
 
       const currentText = readPlainTextFromEditorNode(node)
       const sourceText = sourceBlock?.text || ""
+      const currentLanguage = readCodeLanguage(node)
+      if (!areCodeLanguagesCompatible(currentLanguage, sourceBlock?.language || null)) return node
       if (hasVisibleCodeText(currentText) || !hasVisibleCodeText(sourceText)) return node
 
       changed = true
-      const currentLanguage = typeof node.attrs?.language === "string" ? node.attrs.language : null
       return {
         ...node,
         attrs: {


### PR DESCRIPTION
## 관련 이슈

close #552

## 작업 배경

- `/editor/[id]` 진입/동기화 중 빈 codeBlock NodeView를 source markdown으로 복구할 때, source/current 매핑이 어긋난 상태에서 잘못한 코드 본문을 주입하지 않도록 제한했습니다.
- 정상적인 초기 빈 코드블럭 복구는 유지하고, codeBlock 개수 또는 언어가 맞지 않는 구조 이동 상태에서는 복구를 건너뛰도록 회귀 테스트를 추가했습니다.

## 작업 내용

- `restoreEditorDocCodeBlocksFromMarkdown`가 source/current codeBlock 개수 일치를 확인한 뒤 복구합니다.
- 빈 NodeView 복구 시 current/source 언어가 모두 있으면 같은 언어일 때만 source 본문을 적용합니다.
- source/current 순번이 어긋난 상태에서는 잘못한 source 본문으로 복구하지 않는 source-level 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-code-recovery.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: source/current codeBlock 개수가 이미 어긋난 손상 문서는 자동 복구를 건너뛰므로, 잘못한 코드 주입 대신 빈 상태가 유지될 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋 `fix(editor): codeblock empty render 복구`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
