### PR TITLE
[Fix] 글선택 버블 스케줄 안정화

### DIFF
--- a/front/e2e/editor-authoring-callout-inline.spec.ts
+++ b/front/e2e/editor-authoring-callout-inline.spec.ts
@@ -269,6 +269,44 @@ test.describe("editor authoring callout and inline formatting", () => {
       .toBe(0)
   })
 
+  test("writer heading 시작부 선택 bubble은 block rail 영역으로 밀리지 않는다", async ({ page }) => {
+    await page.goto(QA_WRITER_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.click()
+    await page.keyboard.type("버블헤딩 오버랩 회피")
+    await selectWordInEditable(page, editor, "버블헤딩")
+    await page.getByRole("button", { name: "제목 2" }).first().click()
+    await expect(editor.locator("h2", { hasText: "버블헤딩" }).first()).toBeVisible()
+
+    const heading = editor.locator("h2", { hasText: "버블헤딩" }).first()
+    await selectWordInEditable(page, heading, "버블헤딩")
+    const textBubbleToolbar = page.getByTestId("editor-text-bubble-toolbar")
+    await expect(textBubbleToolbar).toBeVisible()
+
+    const metrics = await page.evaluate(() => {
+      const toolbar = document.querySelector<HTMLElement>("[data-testid='editor-text-bubble-toolbar']")
+      const bubbleRoot = toolbar?.parentElement
+      const heading = Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] h2"))
+        .find((element) => element.textContent?.includes("버블헤딩"))
+      if (!toolbar || !bubbleRoot || !heading) return null
+      const toolbarRect = toolbar.getBoundingClientRect()
+      const headingRect = heading.getBoundingClientRect()
+      return {
+        anchor: bubbleRoot.getAttribute("data-anchor"),
+        headingLeft: headingRect.left,
+        headingTop: headingRect.top,
+        toolbarBottom: toolbarRect.bottom,
+        toolbarLeft: toolbarRect.left,
+      }
+    })
+
+    if (!metrics) throw new Error("heading bubble metrics are missing")
+    expect(metrics.anchor).toBe("left")
+    expect(metrics.toolbarLeft).toBeGreaterThanOrEqual(metrics.headingLeft - 4)
+    expect(metrics.toolbarBottom).toBeLessThanOrEqual(metrics.headingTop - 4)
+  })
+
   test("writer surface에서는 마우스 드래그 선택 중 버블을 숨기고 mouseup 이후에만 노출한다", async ({
     page,
   }) => {

--- a/front/e2e/editor-authoring-selection-drag.spec.ts
+++ b/front/e2e/editor-authoring-selection-drag.spec.ts
@@ -195,15 +195,30 @@ const expectCodeHighlightLayerAligned = async (page: Page, word: string) => {
 
 test.describe("editor authoring route text selection drag", () => {
   test("writer table cell 기존 텍스트 선택 후 단순 클릭은 caret만 남긴다", async ({ page }) => {
+    const tableMarkdown = [
+      '<!-- aq-table {"overflowMode":"normal","columnWidths":[160,220,240]} -->',
+      "| 영역 | 점검 항목 | 확인 기준 |",
+      "| --- | --- | --- |",
+      "| caret | 셀 커서 테스트 | 단순 클릭 |",
+      "| drag | 기존 선택 | 유지 |",
+      "| focus | caret 복귀 | 확인 |",
+      "| scroll | viewport | 안정 |",
+      "| bubble | toolbar | 닫힘 |",
+      "| result | selection | 정리 |",
+    ].join("\n")
     await page.goto(QA_WRITER_ROUTE)
-
     const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
     await editor.click()
-    await page.getByRole("button", { name: "테이블", exact: true }).first().click()
+    await editor.evaluate((element, markdown) => {
+      const data = new DataTransfer()
+      data.setData("text/plain", markdown)
+      const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true })
+      Object.defineProperty(event, "clipboardData", { value: data })
+      element.dispatchEvent(event)
+    }, tableMarkdown)
 
-    const firstCell = page.locator("table th, table td").first()
+    const firstCell = page.locator("table th, table td", { hasText: "셀 커서 테스트" }).first()
     await firstCell.click()
-    await page.keyboard.type("셀 커서 테스트")
 
     await selectWordInEditable(page, firstCell, "커서")
     await expect
@@ -298,6 +313,10 @@ test.describe("editor authoring route text selection drag", () => {
         "| --- | --- | --- |",
         `| caret | ${marker} alpha | 클릭 후 caret |`,
         "| result | beta | 선택 없음 |",
+        "| focus | gamma | 캐럿 유지 |",
+        "| scroll | delta | viewport 안정 |",
+        "| bubble | epsilon | toolbar 정리 |",
+        "| final | zeta | block overlay 없음 |",
       ].join("\n"),
       "table caret trailing paragraph. 테이블 이후 본문입니다.",
     ].join("\n\n")

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -300,8 +300,8 @@ const activeTableCellScrollPreserveCancels = new Set<() => void>()
 const activeTableCellSelectionPreserveCancels = new Set<() => void>()
 const TABLE_DRAG_SELECTION_TEXT_ATTR = "data-table-drag-selection-text"
 const TABLE_DRAG_SELECTION_TEXT_SELECTOR = `[${TABLE_DRAG_SELECTION_TEXT_ATTR}]`
-const TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES = 168
-const TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS = 2_800
+const TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES = 48
+const TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS = 800
 
 export const cancelActiveTableCellScrollPreserves = () => {
   activeTableCellScrollPreserveCancels.forEach((cancel) => cancel())

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -6,7 +6,7 @@ import { resolveMultiCellTableDomSelectionBubbleState, resolvePersistedTableText
 import { collapseTableCellTextSelectionToPoint } from "./tableTextCaretModel"
 import { isTableSelectionActive } from "./tableStructureModel"
 import { cancelActiveTableCellTextSelectionPreserves, collapseStaleTableEditorSelection, preserveTableCellTextSelectionAcrossFrames, resolveTableTextCellAtPoint, resolveTableTextSelectionRangeCells, restoreTableCellTextSelectionIfEscaped, selectTableCellTextRange, watchTableCellTextSelectionExternalClear } from "./tableTextSelectionModel"
-import { areFloatingBubbleStatesEqual, hideFloatingBubbleState, resolveFloatingBubbleStateFromCoords, type FloatingBubbleState } from "./useFloatingBubbleState"
+import { areFloatingBubbleStatesEqual, hasNativeEditorTextSelection, hideFloatingBubbleState, resolveFloatingBubbleStateFromCoords, resolveHeadingSelectionBubbleState, type FloatingBubbleState } from "./useFloatingBubbleState"
 const CODE_BLOCK_EDITOR_CONTENT_SELECTOR = ".aq-code-editor-content"
 const BLOCK_EDITOR_ROOT_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
 const TABLE_TEXT_DRAG_CONTROL_SELECTOR = "[data-table-axis-rail='true'], [data-table-affordance], [data-table-menu-root='true'], [data-table-menu-trigger='true'], [data-testid^='table-column-resize-boundary-'], [data-testid='table-structure-menu-button'], [data-testid='table-corner-handle'], [data-testid='table-corner-grow-handle'], .column-resize-handle"
@@ -53,7 +53,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
   useEffect(() => {
     const currentEditor = editorRef.current ?? editor
     if (!currentEditor) return
-    let rafId: number | null = null
+    let rafId: number | null = null, bubbleSettleTimeoutId: number | null = null
     let codeDragSelectionPreserveRafId: number | null = null
     let cleanupCodeDragSelectionPreserve: (() => void) | null = null, cleanupTableDragScrollPreserve: (() => void) | null = null, cleanupTableDragSelectionPreserve: (() => void) | null = null
     let tableTextSelectionExternalClearWatcher: ReturnType<typeof watchTableCellTextSelectionExternalClear> | null = null
@@ -336,11 +336,12 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
 
       const startCoords = activeEditor.view.coordsAtPos(selection.from)
       const endCoords = activeEditor.view.coordsAtPos(isImageNodeSelected ? selection.from : selection.to)
-      const nextBubbleState = resolveFloatingBubbleStateFromCoords(
+      const baseBubbleState = resolveFloatingBubbleStateFromCoords(
         isImageNodeSelected ? "image" : "text",
         startCoords,
         endCoords
       )
+      const nextBubbleState = resolveHeadingSelectionBubbleState(baseBubbleState, activeEditor.view.dom)
       setBubbleState((prev) =>
         areFloatingBubbleStatesEqual(prev, nextBubbleState) ? prev : nextBubbleState
       )
@@ -357,7 +358,6 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         syncBubble()
       })
     }
-
     const handleDocumentSelectionChange = () => {
       const activeEditor = editorRef.current ?? currentEditor
       if (!activeEditor) return
@@ -532,11 +532,11 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       tableTextDragPendingStartRef.current = null
       codeTextDragStartRef.current = null; nonTableTextDragStartRef.current = null
       mouseTextSelectionInProgressRef.current = false
-      window.setTimeout(scheduleSyncBubble, 96); window.setTimeout(scheduleSyncBubble, 200)
+      if (!syncBubbleOnMouseUpRef.current && activeEditor && hasNativeEditorTextSelection(activeEditor.view.dom)) syncBubbleOnMouseUpRef.current = true
       if (!syncBubbleOnMouseUpRef.current && document.documentElement.hasAttribute("data-table-drag-selection-text")) syncBubbleOnMouseUpRef.current = true
       if (!syncBubbleOnMouseUpRef.current) return
       syncBubbleOnMouseUpRef.current = false
-      scheduleSyncBubble()
+      scheduleSyncBubble(); if (bubbleSettleTimeoutId === null) bubbleSettleTimeoutId = window.setTimeout(() => { bubbleSettleTimeoutId = null; scheduleSyncBubble() }, 96)
     }
     const resolveCodeDragCopyText = () => { const selection = window.getSelection(), selectedText = selection?.toString().trim() ?? "", anchorElement = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focusElement = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null, activeElement = document.activeElement instanceof Element ? document.activeElement : null, anchorShell = anchorElement?.closest(".aq-code-shell") ?? null, focusShell = focusElement?.closest(".aq-code-shell") ?? null, activeShell = activeElement?.closest(".aq-code-shell") ?? null, codeShell = anchorShell && anchorShell === focusShell ? anchorShell : activeShell?.getAttribute("data-code-drag-selection-text")?.trim() ? activeShell : null; if (!codeShell) return ""; return selectedText && anchorShell === codeShell && focusShell === codeShell ? selectedText : codeShell.getAttribute("data-code-drag-selection-text")?.trim() || "" }, handleDocumentCopyCapture = (event: ClipboardEvent) => { const copyText = resolveCodeDragCopyText(); if (!copyText) return; event.preventDefault(); event.clipboardData?.setData("text/plain", copyText) }, handleDocumentCopyKeyDown = (event: KeyboardEvent) => { if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey || event.key.toLowerCase() !== "c") return; const copyText = resolveCodeDragCopyText(); if (!copyText) return; event.preventDefault(); void navigator.clipboard?.writeText(copyText) }
 
@@ -568,7 +568,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       window.removeEventListener("pointercancel", completeTextDragSelection, true)
       window.removeEventListener("mouseup", completeTextDragSelection, true)
       tableTextSelectionExternalClearWatcher?.dispose()
-      if (rafId !== null && typeof window !== "undefined") window.cancelAnimationFrame(rafId)
+      if (rafId !== null && typeof window !== "undefined") window.cancelAnimationFrame(rafId); if (bubbleSettleTimeoutId !== null && typeof window !== "undefined") window.clearTimeout(bubbleSettleTimeoutId)
       cancelTableTextDragPreserves()
       cancelCodeDragSelectionPreserve()
       mouseTextSelectionInProgressRef.current = false

--- a/front/src/components/editor/useFloatingBubbleState.ts
+++ b/front/src/components/editor/useFloatingBubbleState.ts
@@ -49,6 +49,28 @@ export const areFloatingBubbleStatesEqual = (
 export const hideFloatingBubbleState = (state: FloatingBubbleState) =>
   state.visible ? { ...state, visible: false } : state
 
+const HEADING_SELECTION_SELECTOR = "h1, h2, h3, h4, h5, h6"
+const resolveSelectionElement = (node: Node | null | undefined) => node instanceof Element ? node : node?.parentElement ?? null
+
+export const hasNativeEditorTextSelection = (editorRoot: HTMLElement) => {
+  const selection = typeof window !== "undefined" ? window.getSelection() : null
+  const anchorElement = resolveSelectionElement(selection?.anchorNode)
+  const focusElement = resolveSelectionElement(selection?.focusNode)
+  return Boolean(selection?.toString().trim() && anchorElement && focusElement && editorRoot.contains(anchorElement) && editorRoot.contains(focusElement))
+}
+
+export const resolveHeadingSelectionBubbleState = (state: FloatingBubbleState, editorRoot: HTMLElement) => {
+  if (state.mode !== "text") return state
+  const selection = typeof window !== "undefined" ? window.getSelection() : null
+  if (!selection || selection.isCollapsed || !selection.toString().trim()) return state
+  const anchorHeading = resolveSelectionElement(selection.anchorNode)?.closest<HTMLElement>(HEADING_SELECTION_SELECTOR)
+  const focusHeading = resolveSelectionElement(selection.focusNode)?.closest<HTMLElement>(HEADING_SELECTION_SELECTOR)
+  if (!anchorHeading || anchorHeading !== focusHeading || !editorRoot.contains(anchorHeading)) return state
+  const headingRect = anchorHeading.getBoundingClientRect()
+  if (!Number.isFinite(headingRect.left) || headingRect.width <= 0) return state
+  return { ...state, anchor: "left" as const, left: Math.max(12, Math.round(headingRect.left)) }
+}
+
 export const useFloatingBubbleState = () => {
   const [bubbleState, setBubbleState] = useState<FloatingBubbleState>(
     INITIAL_FLOATING_BUBBLE_STATE


### PR DESCRIPTION
## 관련 이슈

close #555

## 작업 배경

- `/editor/[id]` 글선택 버블이 selectionchange/mouseup 경로에서 중복 동기화되며 버벅이던 회귀를 줄였습니다.
- heading 시작부 선택 시 bubble anchor를 block header/rail과 겹치지 않는 위치로 보정하고, #555 table selection 회귀 seed를 7행 3열 기준으로 맞췄습니다.

## 작업 내용

- selection bubble 동기화를 immediate RAF + 96ms settle 1회로 정리해 mouseup 이후 불필요한 중복 예약을 줄였습니다.
- heading 텍스트 선택 bubble은 heading 좌측 기준 anchor를 사용해 block header 영역 오버랩을 피합니다.
- table text drag 보존 루프는 table 범위만 48 frame / 800ms로 축소하고, code block drag 보존 계약은 기존 긴 보존 시간으로 유지했습니다.
- writer/table 관련 e2e seed를 7행 3열 표 기준으로 보강했습니다. 새 테이블 기본 3x3 계약은 변경하지 않았습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-route-rich-select-all.spec.ts e2e/editor-authoring-route-table-select-all.spec.ts e2e/editor-authoring-callout-inline.spec.ts --workers=1` → 21 passed
  - `yarn --cwd front test:e2e:authoring` → 116 passed
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke` → 57 passed
  - Browser plugin으로 `http://127.0.0.1:3100/_qa/block-editor-slash?surface=writer` writer heading 화면을 확인했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 선택 복원 타이밍 조정으로 특정 브라우저에서 bubble 표시 시점이 달라질 수 있습니다.
- 롤백 방법: 이 PR의 `fix(editor): selection bubble schedule 안정화` 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
