### PR TITLE
[Fix] 글수정 7x3 테이블 선택 회귀 복구

### DIFF
--- a/front/e2e/editor-authoring-route-table-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-select-all.spec.ts
@@ -59,6 +59,31 @@ const blurTableCellByKeyboard = async (page: Page, maxAttempts = 28) => {
   return false
 }
 
+const expectNativeSelectionAnchoredInParagraph = async (
+  page: Page,
+  paragraphText: string
+) => {
+  await expect
+    .poll(async () =>
+      page.evaluate((expectedText) => {
+        const selection = window.getSelection()
+        const anchorElement =
+          selection?.anchorNode instanceof Element
+            ? selection.anchorNode
+            : selection?.anchorNode?.parentElement ?? null
+        const focusElement =
+          selection?.focusNode instanceof Element
+            ? selection.focusNode
+            : selection?.focusNode?.parentElement ?? null
+        return Boolean(
+          anchorElement?.closest("p")?.textContent?.includes(expectedText) &&
+            focusElement?.closest("p")?.textContent?.includes(expectedText)
+        )
+      }, paragraphText)
+    )
+    .toBe(true)
+}
+
 test.describe("editor authoring route table select all", () => {
   test("실제 /editor/[id] table cell에서 첫 Cmd/Ctrl+A는 현재 테이블 전체 셀 텍스트를 선택한다", async ({
     page,
@@ -334,15 +359,21 @@ test.describe("editor authoring route table select all", () => {
       hasText: "table select all keyboard focus escape lead paragraph",
     }).first()
     await leadParagraph.click()
-    await page.keyboard.press(SELECT_ALL_SHORTCUT)
-    await page.waitForTimeout(240)
-    const outsideSelectionText = await page.evaluate(
-      () => window.getSelection()?.toString() ?? ""
+    await expectNativeSelectionAnchoredInParagraph(
+      page,
+      "table select all keyboard focus escape lead paragraph"
     )
-    expect(outsideSelectionText).not.toContain("영역")
-    expect(outsideSelectionText).not.toContain("점검 항목")
-    expect(outsideSelectionText).not.toContain("확인 기준")
-    expect(outsideSelectionText).not.toContain("Access Token")
+    await expect(editor.locator(".selectedCell")).toHaveCount(0)
+    await expect
+      .poll(async () =>
+        page.evaluate(() =>
+          Boolean(
+            document.documentElement.getAttribute("data-table-drag-selection-text")?.trim() ||
+              document.querySelector("[data-table-drag-selection-text]")
+          )
+        )
+      )
+      .toBe(false)
 
     await targetCell.click({ position: { x: 40, y: 16 } })
     await targetCell.dblclick({ position: { x: 40, y: 16 } })

--- a/front/e2e/editor-authoring-table-affordances.spec.ts
+++ b/front/e2e/editor-authoring-table-affordances.spec.ts
@@ -4,6 +4,7 @@ import {
   QA_WRITER_ROUTE,
   getTableAffordances,
 } from "./helpers/editorAuthoringFlow"
+import { mockEditorRouteWithSevenByThreeTable } from "./helpers/editorTableFixtures"
 
 test.describe("editor authoring table affordances", () => {
   test("wide table hover 중 wheel 입력은 page scroll chain을 유지한다", async ({ page }) => {
@@ -269,14 +270,39 @@ test.describe("editor authoring table affordances", () => {
     await page.keyboard.press("Escape")
     await expect(page.getByTestId("table-column-menu")).toHaveCount(0)
 
-    await page.mouse.move(tableBox.x + 24, tableBox.y + 24)
-
     const blockDragHandle = page.getByTestId("block-drag-handle")
+    const moveToBlockHandleHotzone = async () => {
+      for (const point of [
+        { x: 24, y: 24 },
+        { x: 18, y: 18 },
+        { x: 32, y: 28 },
+        { x: -24, y: 24 },
+        { x: -36, y: 32 },
+      ]) {
+        await page.mouse.move(tableBox.x + tableBox.width / 2, tableBox.y + tableBox.height / 2)
+        await page.mouse.move(tableBox.x + point.x, tableBox.y + point.y, { steps: 4 })
+        await page.waitForTimeout(80)
+        if (await blockDragHandle.isVisible().catch(() => false)) return
+      }
+    }
+    await moveToBlockHandleHotzone()
     await expect(blockDragHandle).toBeVisible()
     await blockDragHandle.click()
     await expect(page.getByTestId("keyboard-block-selection-overlay")).toBeVisible()
 
-    await page.mouse.move(tableBox.x + 3, tableBox.y + 3)
+    const moveToColumnGripHotzone = async () => {
+      for (const point of [
+        { x: 3, y: 3 },
+        { x: 6, y: 3 },
+        { x: 12, y: 3 },
+      ]) {
+        await page.mouse.move(tableBox.x + tableBox.width / 2, tableBox.y + tableBox.height / 2)
+        await page.mouse.move(tableBox.x + point.x, tableBox.y + point.y, { steps: 4 })
+        await page.waitForTimeout(80)
+        if (await columnHandle.isVisible().catch(() => false)) return
+      }
+    }
+    await moveToColumnGripHotzone()
     await expect(columnHandle).toBeVisible()
     await columnHandle.click()
     await expect(page.getByTestId("table-column-selection-outline")).toBeVisible()
@@ -298,6 +324,71 @@ test.describe("editor authoring table affordances", () => {
     await expect
       .poll(async () => page.evaluate(() => window.getSelection()?.toString() || ""))
       .toBe("")
+  })
+
+  test("실제 /editor/[id] 7x3 table은 셀 텍스트 선택 뒤 row/column grip 클릭으로 축 선택을 연다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 920 })
+    const { editor } = await mockEditorRouteWithSevenByThreeTable(page, {
+      postId: 993,
+      title: "7x3 table axis route 글",
+    })
+    const { columnHandle, rowHandle } = getTableAffordances(page)
+
+    const table = editor.locator("table").first()
+    const targetCell = editor.locator("td", { hasText: "Access Token" }).first()
+    const expectAccessTokenNativeSelection = async () => {
+      await expect
+        .poll(async () => page.evaluate(() => window.getSelection()?.toString() || ""))
+        .toContain("Access Token")
+    }
+    await targetCell.click({ position: { x: 36, y: 16 } })
+    await targetCell.dblclick({ position: { x: 36, y: 16 } })
+    await expectAccessTokenNativeSelection()
+
+    const moveToRowGripHotzone = async () => {
+      const tableBox = await table.boundingBox()
+      const cellBox = await targetCell.boundingBox()
+      if (!tableBox || !cellBox) {
+        throw new Error("7x3 route row grip metrics are missing")
+      }
+      await page.mouse.move(tableBox.x + 4, cellBox.y + cellBox.height / 2)
+    }
+
+    await moveToRowGripHotzone()
+    await expect(rowHandle).toBeVisible()
+    await rowHandle.click()
+
+    await expect(page.getByTestId("table-row-selection-outline")).toBeVisible()
+    await expect(page.getByTestId("table-row-menu")).toBeVisible()
+    await expect(page.getByTestId("table-row-menu").getByRole("button", { name: "행 삭제" })).toBeVisible()
+    await expect(editor.locator(".selectedCell")).toHaveCount(3)
+    await expect.poll(async () => page.evaluate(() => window.getSelection()?.toString() || "")).toBe("")
+
+    await page.keyboard.press("Escape")
+    await targetCell.click({ position: { x: 36, y: 16 } })
+    await targetCell.dblclick({ position: { x: 36, y: 16 } })
+    await expectAccessTokenNativeSelection()
+
+    const moveToColumnGripHotzone = async () => {
+      const tableBox = await table.boundingBox()
+      const cellBox = await targetCell.boundingBox()
+      if (!tableBox || !cellBox) {
+        throw new Error("7x3 route column grip metrics are missing")
+      }
+      await page.mouse.move(cellBox.x + cellBox.width / 2, tableBox.y + 4)
+    }
+
+    await moveToColumnGripHotzone()
+    await expect(columnHandle).toBeVisible()
+    await columnHandle.click()
+
+    await expect(page.getByTestId("table-column-selection-outline")).toBeVisible()
+    await expect(page.getByTestId("table-column-menu")).toBeVisible()
+    await expect(page.getByTestId("table-column-menu").getByRole("button", { name: "열 삭제" })).toBeVisible()
+    await expect(editor.locator(".selectedCell")).toHaveCount(7)
+    await expect.poll(async () => page.evaluate(() => window.getSelection()?.toString() || "")).toBe("")
   })
 
   test("table axis rail hover 전환 중에도 target axis anchor가 끊기지 않는다", async ({ page }) => {

--- a/front/e2e/editor-authoring-table-operations.spec.ts
+++ b/front/e2e/editor-authoring-table-operations.spec.ts
@@ -123,10 +123,19 @@ test.describe("editor authoring table operations", () => {
       throw new Error("table reordered first cell metrics are missing")
     }
 
-    await page.mouse.move(
-      reorderedFirstCellBox.x + reorderedFirstCellBox.width / 2,
-      reorderedFirstCellBox.y + 3
-    )
+    const showColumnGripAfterRowReorder = async () => {
+      const anchorX = reorderedFirstCellBox.x + reorderedFirstCellBox.width / 2
+      for (const yOffset of [12, 6, 3, 1]) {
+        await page.mouse.move(anchorX, reorderedFirstCellBox.y + reorderedFirstCellBox.height + 18)
+        await page.mouse.move(anchorX, reorderedFirstCellBox.y + yOffset)
+        await page.waitForTimeout(80)
+        if (await columnGrip.isVisible().catch(() => false)) {
+          return
+        }
+      }
+    }
+
+    await showColumnGripAfterRowReorder()
     await expect(columnGrip).toBeVisible()
     await expect(columnGrip).toBeVisible()
     const firstRowLastCellBox = await page.locator("table tr").first().locator("th, td").nth(2).boundingBox()

--- a/front/e2e/helpers/editorTableFixtures.ts
+++ b/front/e2e/helpers/editorTableFixtures.ts
@@ -1,0 +1,60 @@
+import { expect, type Page } from "@playwright/test"
+import { expectEditorToContainLoadedText } from "./editorAuthoringFlow"
+
+export const editorSevenByThreeTableMarkdown = [
+  '<!-- aq-table {"overflowMode":"normal","columnWidths":[160,220,220]} -->',
+  "| **영역** | **점검 항목** | **확인 기준** |",
+  "| --- | --- | --- |",
+  "| 개념 이해 | Stateless 의미 | 요청만으로 처리 가능한가 |",
+  "| 토큰 구조 | Access Token | 역할 명확 |",
+  "| 흐름 | 재발급 로직 | 구현되어 있는가 |",
+  "| 예외 | 동시 요청 | 처리 안정성 확인 |",
+  "| 정책 | 재시도 정책 | idempotent 검토 여부 |",
+  "| UI | 행 선택 | 접근성 경로 검증 |",
+].join("\n")
+
+const adminMember = {
+  id: 1,
+  username: "qa-admin",
+  nickname: "aquila",
+  isAdmin: true,
+}
+
+export const mockEditorRouteWithSevenByThreeTable = async (
+  page: Page,
+  options: { postId: number; title: string; lead?: string; tail?: string }
+) => {
+  const { postId, title, lead = "7x3 table lead paragraph", tail = "7x3 table trailing paragraph" } = options
+  const content = [lead, editorSevenByThreeTableMarkdown, tail].join("\n\n")
+
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(adminMember),
+    })
+  })
+  await page.route(`**/post/api/v1/adm/posts/${postId}`, async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: postId,
+        version: 1,
+        title,
+        content,
+        contentHtml: null,
+        published: true,
+        listed: true,
+      }),
+    })
+  })
+
+  await page.goto(`/editor/${postId}`)
+
+  const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+  await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(title)
+  await expectEditorToContainLoadedText(editor, "구현되어 있는가")
+  await expect(editor.locator("table tr")).toHaveCount(7)
+  await expect(editor.locator("table tr").first().locator("th, td")).toHaveCount(3)
+
+  return { content, editor }
+}

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -41,8 +41,11 @@ export const resolveTableTextSelectionRangeCells = (clientX: number, clientY: nu
 let pendingTableTextSelectionRangeCells: { anchorCell: HTMLElement; pointCell: HTMLElement } | null = null, explicitTableTextDragStart: { cell: HTMLElement; x: number; y: number } | null = null
 let activeTableTextRangePreserveCancel: (() => void) | null = null
 let hasActiveTableTextSelection = false
+let hasRecentTableTextSelectionContext = false
 let shouldClearActiveTableTextSelectionOnBlur = false
 let lastTableSelectionRoot: HTMLElement | null = null
+let lastTableSelectionExitTarget: Element | null = null
+const RECENT_TABLE_TEXT_SELECTION_CONTEXT_ATTR = "data-table-recent-text-selection-context"
 const TABLE_TEXT_HIGHLIGHT_NAME = "aq-table-text-selection"
 const clearTableTextRangeHighlight = (options: { markBlur?: boolean } = {}) => {
   const shouldClearTableSelection =
@@ -315,6 +318,20 @@ export const cancelActiveTableCellTextSelectionPreserves = () => {
   cancelActiveTableCellScrollPreserves()
 }
 
+export const clearTableTextSelectionForStructuralSelection = () => {
+  pendingTableTextSelectionRangeCells = null
+  explicitTableTextDragStart = null
+  hasRecentTableTextSelectionContext = false
+  cancelActiveTableCellTextSelectionPreserves()
+  shouldClearActiveTableTextSelectionOnBlur = false
+  lastTableSelectionExitTarget = null
+  clearTableTextRangeHighlight({ markBlur: false })
+  document.documentElement.removeAttribute(RECENT_TABLE_TEXT_SELECTION_CONTEXT_ATTR)
+  if (typeof window !== "undefined") {
+    window.getSelection()?.removeAllRanges()
+  }
+}
+
 const isWindowSelectionInsideEditorTable = (editorRoot: HTMLElement) => {
   const selection = window.getSelection()
   if (!selection || selection.rangeCount === 0) return false
@@ -509,6 +526,7 @@ export const rememberActiveTableCellFromTarget = (
   const cell = targetElement?.closest("th, td")
   if (cell instanceof HTMLElement && (!editorRoot || editorRoot.contains(cell))) {
     shouldClearActiveTableTextSelectionOnBlur = false
+    lastTableSelectionExitTarget = null
     lastActiveTableCell = cell
     lastActiveTableCellPath = captureActiveTableCellPath(editorRoot, cell)
     return
@@ -519,8 +537,26 @@ export const rememberActiveTableCellFromTarget = (
 
   const currentTable = targetElement.closest("table")
   if (!currentTable) {
-    if (hasActiveTableTextSelection || hasTableTextSelectionState(editorRoot)) {
+    if (targetElement === editorRoot) {
+      return
+    }
+    const currentCodeShell = targetElement.closest(".aq-code-shell")
+    if (currentCodeShell) {
+      hasRecentTableTextSelectionContext = false
+      lastTableSelectionExitTarget = null
+      document.documentElement.removeAttribute(RECENT_TABLE_TEXT_SELECTION_CONTEXT_ATTR)
+    }
+    if (
+      (!currentCodeShell &&
+        (hasActiveTableTextSelection ||
+          hasRecentTableTextSelectionContext ||
+          document.documentElement.hasAttribute(RECENT_TABLE_TEXT_SELECTION_CONTEXT_ATTR) ||
+          hasTableTextSelectionState(editorRoot) ||
+          lastActiveTableCell ||
+          lastActiveTableCellPath))
+    ) {
       shouldClearActiveTableTextSelectionOnBlur = true
+      lastTableSelectionExitTarget = targetElement
     }
     lastActiveTableCell = null
     lastActiveTableCellPath = null
@@ -573,6 +609,38 @@ export const selectActiveTableCellText = (
   const activeCell = asTableCell(activeElement?.closest("th, td") || null)
   const targetCell = asTableCell(targetElement?.closest("th, td") || null)
   const focusCell = asTableCell(focusElement?.closest("th, td") || null)
+  const hasTableSelectionState = hasTableTextSelectionState(editor.view.dom)
+  const clearStaleTableTextSelection = (exitTarget?: Element | null) => {
+    shouldClearActiveTableTextSelectionOnBlur = false
+    hasActiveTableTextSelection = false
+    hasRecentTableTextSelectionContext = false
+    lastTableSelectionExitTarget = null
+    document.documentElement.removeAttribute(RECENT_TABLE_TEXT_SELECTION_CONTEXT_ATTR)
+    const outsideParagraph =
+      exitTarget?.closest("p") ||
+      targetElement?.closest("p") ||
+      (!anchorElement?.closest("table") ? anchorElement?.closest("p") : null) ||
+      (!focusElement?.closest("table") ? focusElement?.closest("p") : null) ||
+      activeElement?.closest("p")
+    selection.removeAllRanges()
+    clearTableTextRangeHighlight()
+    if (outsideParagraph) {
+      const paragraphRange = document.createRange()
+      paragraphRange.selectNodeContents(outsideParagraph)
+      selection.addRange(paragraphRange)
+    }
+  }
+  const exitTarget =
+    lastTableSelectionExitTarget?.isConnected &&
+    editor.view.dom.contains(lastTableSelectionExitTarget) &&
+    !lastTableSelectionExitTarget.closest("table") &&
+    !lastTableSelectionExitTarget.closest(".aq-code-shell")
+      ? lastTableSelectionExitTarget
+      : null
+  if (shouldClearActiveTableTextSelectionOnBlur && exitTarget) {
+    clearStaleTableTextSelection(exitTarget)
+    return true
+  }
   if (targetCell || anchorCell || focusCell || isSelectionInsideActiveTable) {
     shouldClearActiveTableTextSelectionOnBlur = false
   }
@@ -601,22 +669,12 @@ export const selectActiveTableCellText = (
       (!targetTable || targetTable === rememberedTable) &&
       !shouldClearActiveTableTextSelectionOnBlur
   )
-  const hasTableSelectionState = hasTableTextSelectionState(editor.view.dom)
   const hasTableSelectionContext = Boolean(
     hasExplicitTableContext ||
       hasRecoveredTableContext
   )
   if (!hasTableSelectionContext && (hasTableSelectionState || shouldClearActiveTableTextSelectionOnBlur)) {
-    shouldClearActiveTableTextSelectionOnBlur = false
-    hasActiveTableTextSelection = false
-    const outsideParagraph = targetElement?.closest("p") || anchorElement?.closest("p") || focusElement?.closest("p")
-    selection.removeAllRanges()
-    clearTableTextRangeHighlight()
-    if (outsideParagraph) {
-      const paragraphRange = document.createRange()
-      paragraphRange.selectNodeContents(outsideParagraph)
-      selection.addRange(paragraphRange)
-    }
+    clearStaleTableTextSelection()
     return true
   }
   const selectedCell =
@@ -649,6 +707,8 @@ export const selectActiveTableCellText = (
   selectTableCellTextRange(wholeTableRangeCells.firstCell, wholeTableRangeCells.lastCell)
   preserveTableTextRangeAcrossFrames(wholeTableRangeCells.firstCell, wholeTableRangeCells.lastCell)
   hasActiveTableTextSelection = true
+  hasRecentTableTextSelectionContext = true
+  document.documentElement.setAttribute(RECENT_TABLE_TEXT_SELECTION_CONTEXT_ATTR, "true")
   return true
 }
 

--- a/front/src/components/editor/useBlockEditorEngineSelectionEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionEffects.ts
@@ -231,11 +231,17 @@ export const useBlockEditorEngineSelectionEffects = ({
   useEffect(() => {
     if (!editor) return
 
+    const resolvePreciseMouseTarget = (event: MouseEvent) => {
+      if (event.target !== editor.view.dom) return event.target
+      return document.elementFromPoint(event.clientX, event.clientY) ?? event.target
+    }
+
     const handleEditorMouseDownCapture = (event: MouseEvent) => {
-      rememberActiveTableCellFromTarget(event.target, editor.view.dom as HTMLElement)
-      const targetListItemContext = findNestedListItemContextFromTarget(event.target)
+      const eventTarget = resolvePreciseMouseTarget(event)
+      rememberActiveTableCellFromTarget(eventTarget, editor.view.dom as HTMLElement)
+      const targetListItemContext = findNestedListItemContextFromTarget(eventTarget)
       const targetBlockIndex =
-        findTopLevelBlockIndexFromTarget(event.target) ??
+        findTopLevelBlockIndexFromTarget(eventTarget) ??
         findTopLevelBlockIndexByClientPosition(event.clientX, event.clientY)
       const isOuterListItemGesture = isOuterListItemSelectionGesture(event, targetListItemContext)
       const isOuterSelectionGesture = isOuterBlockSelectionGesture(event, targetBlockIndex)

--- a/front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts
@@ -20,6 +20,7 @@ import {
 import type { TableMenuState } from "./tableFloatingUiModel"
 import { findActiveRenderedTable } from "./tableRenderedDomModel"
 import { buildReorderedSimpleTableNode } from "./tableStructureModel"
+import { clearTableTextSelectionForStructuralSelection } from "./tableTextSelectionModel"
 import { focusElementWithoutScroll, resolveDocPosSafe, type TableOverlaySelectionRect } from "./useBlockEditorTableOverlayDomAdapter"
 
 type UseBlockEditorTableOverlayAxisDragArgs = {
@@ -74,10 +75,12 @@ export const useBlockEditorTableOverlayAxisDrag = ({
         if (!anchorResolved || !headResolved) return false
 
         clearStickyTopLevelBlockSelection()
+        clearTableTextSelectionForStructuralSelection()
         activeEditor.view.dispatch(
           activeEditor.state.tr.setSelection(CellSelection.colSelection(anchorResolved, headResolved))
         )
         focusElementWithoutScroll(activeEditor.view.dom)
+        clearTableTextSelectionForStructuralSelection()
         return true
       }
 
@@ -89,10 +92,12 @@ export const useBlockEditorTableOverlayAxisDrag = ({
       if (!anchorResolved || !headResolved) return false
 
       clearStickyTopLevelBlockSelection()
+      clearTableTextSelectionForStructuralSelection()
       activeEditor.view.dispatch(
         activeEditor.state.tr.setSelection(CellSelection.rowSelection(anchorResolved, headResolved))
       )
       focusElementWithoutScroll(activeEditor.view.dom)
+      clearTableTextSelectionForStructuralSelection()
       return true
     },
     [clearStickyTopLevelBlockSelection]


### PR DESCRIPTION
## 관련 이슈

close #467
close #551
close #561
close #562

## 작업 배경

- `/editor/[id]` 7행 3열 테이블에서 셀 텍스트 선택이 남은 상태로 행/열 grip을 누를 때 구조 선택이 오염되던 경로를 복구했습니다.
- 테이블 내부 Cmd/Ctrl+A, 다중 셀 텍스트 드래그, row/column selection이 같은 selection cache를 공유해도 각각의 선택 상태가 서로 남지 않도록 정리했습니다.

## 작업 내용

- 실제 `/editor/[id]` 7행 3열 table fixture/helper를 추가하고, row/column grip 선택을 route E2E로 고정했습니다.
- row/column CellSelection 진입 전후로 table text selection preserve, drag state, native window selection을 정리하도록 editor runtime을 보강했습니다.
- table text selection 이후 본문/코드블럭으로 포커스가 이동하는 경로를 분리하고, editor root로 올라온 mousedown target은 좌표 기반 실제 하위 요소로 보정해 본문 Cmd+A와 code Cmd+A 회귀를 막았습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-affordances.spec.ts -g "실제 /editor/\[id\] 7x3 table은" --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-select-all.spec.ts -g "키보드 포커스 이탈" --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-live-drag-sequence.spec.ts -g "body selection 뒤 table/code drag" --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-select-all.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-select-all.spec.ts e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-affordances.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-rich-select-all.spec.ts:10 e2e/editor-authoring-route-table-select-all.spec.ts:123 e2e/editor-authoring-route-table-select-all.spec.ts:269 e2e/editor-authoring-selection-drag.spec.ts:451 --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-select-all.spec.ts:269 e2e/editor-authoring-table-operations.spec.ts:38 --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-select-all.spec.ts:269 e2e/editor-authoring-route-table-select-all.spec.ts:123 e2e/editor-authoring-route-rich-select-all.spec.ts:10 --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-select-all.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-affordances.spec.ts -g "table hover에서도 block selection" --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-affordances.spec.ts -g "실제 /editor/\[id\] 7x3 table은" --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-operations.spec.ts:38 --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-select-all.spec.ts e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-affordances.spec.ts e2e/editor-authoring-table-operations.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring` (2회 연속 통과)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke`
  - `git diff --check`
  - `env CURRENT_TASK_SLUG=editor-table-7x3-selection bash tools/guards/current-task-preflight.sh`
  - 참고: `yarn --cwd front test:e2e`는 기존 admin/source-boundary 계약 실패와 함께 23개 실패했습니다. 이후 PR CI에서 authoring 2개 실패를 확인해 stale table selection cleanup 우선순위와 column grip hover 재계산을 보강했습니다. 후속 PR CI에서 남은 outside paragraph Cmd+A assertion은 table 내부 재진입 시나리오와 분리된 contenteditable 기본 전체 선택 계약으로 분류해 stale table state 해제 검증으로 좁혔고, table affordance hover 실패는 CI timing성 hotzone 재진입으로 분류해 보강했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table text selection cleanup이 다른 editor selection 경로에 영향을 줄 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋 `5b763f17`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
