### PR TITLE
[Test] 글수정 codeblock 언어 선택 회귀 보강

### DIFF
--- a/front/e2e/editor-authoring-code-mermaid.spec.ts
+++ b/front/e2e/editor-authoring-code-mermaid.spec.ts
@@ -218,8 +218,12 @@ test.describe("editor authoring code and mermaid blocks", () => {
     await expect(languageDialog).toBeVisible()
     await languageDialog.getByRole("button", { name: "Python", exact: true }).click()
 
-    await expect(codeBlock.getByRole("button", { name: /Python/i })).toBeVisible()
-    await expect(page.getByRole("dialog", { name: "코드 언어 선택" })).toHaveCount(0)
+    await expect(languageDialog).toHaveCount(0)
+    await expect(
+      codeBlock
+        .locator("[data-code-block-header='true']")
+        .getByRole("button", { name: "Python", exact: true })
+    ).toBeVisible()
   })
 
   test("머메이드 블록 코드를 바꾸면 preview가 이전 템플릿이 아니라 최신 source로 즉시 다시 렌더된다", async ({ page }) => {

--- a/front/e2e/editor-authoring-code-mermaid.spec.ts
+++ b/front/e2e/editor-authoring-code-mermaid.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test"
 import {
+  expectEditorToContainLoadedText,
   QA_ENGINE_ROUTE,
   QA_WRITER_ROUTE,
 } from "./helpers/editorAuthoringFlow"
@@ -120,6 +121,105 @@ test.describe("editor authoring code and mermaid blocks", () => {
         return optionRect.y - headerRect.y - headerRect.height
       })
       .toBeGreaterThanOrEqual(8)
+  })
+
+  test("실제 /editor/[id] 수정 route 코드 언어 선택은 dialog를 열고 언어를 갱신한다", async ({
+    page,
+  }) => {
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const content = [
+      "코드 언어 선택 회귀 대상입니다.",
+      "",
+      "```ts",
+      "const selectedLanguage = true",
+      "```",
+      "",
+      "언어 선택 뒤 문단입니다.",
+    ].join("\n")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/998", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 998,
+          version: 3,
+          title: "코드 언어 선택 회귀 글",
+          content,
+          contentHtml: "",
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/998")
+
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("코드 언어 선택 회귀 글")
+    await expectEditorToContainLoadedText(
+      page.locator("[data-testid='block-editor-prosemirror']").first(),
+      "언어 선택 뒤 문단입니다."
+    )
+
+    const codeBlock = page.locator("[data-code-block-wrapper='true']").first()
+    await expect(codeBlock).toBeVisible({ timeout: 15_000 })
+    await expect(codeBlock.locator(".aq-code-highlight-layer")).toContainText("const selectedLanguage")
+
+    const codeContent = codeBlock.locator(".aq-code-editor-content").first()
+    const dragPoints = await codeContent.evaluate((element) => {
+      const targetText = "selectedLanguage"
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+      while (walker.nextNode()) {
+        const current = walker.currentNode as Text
+        const startOffset = current.data.indexOf(targetText)
+        if (startOffset < 0) continue
+        const range = document.createRange()
+        range.setStart(current, startOffset)
+        range.setEnd(current, startOffset + targetText.length)
+        const rect = range.getBoundingClientRect()
+        if (rect.width <= 2 || rect.height <= 2) break
+        return {
+          endX: rect.right - 1,
+          startX: rect.left + 1,
+          y: rect.top + rect.height / 2,
+        }
+      }
+      throw new Error("code language regression selection target is missing")
+    })
+    await page.mouse.move(dragPoints.startX, dragPoints.y)
+    await page.mouse.down()
+    await page.mouse.move(dragPoints.endX, dragPoints.y, { steps: 12 })
+    await page.mouse.up()
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const selectionText = window.getSelection()?.toString() ?? ""
+          const persistedCodeSelectionText =
+            document.querySelector("[data-code-drag-selection-text]")?.getAttribute("data-code-drag-selection-text") ??
+            ""
+          return (selectionText || persistedCodeSelectionText).replace(/\s+/g, " ").trim()
+        })
+      )
+      .toContain("selectedLanguage")
+
+    await codeBlock.getByRole("button", { name: /TypeScript/i }).click()
+
+    const languageDialog = page.getByRole("dialog", { name: "코드 언어 선택" })
+    await expect(languageDialog).toBeVisible()
+    await languageDialog.getByRole("button", { name: "Python", exact: true }).click()
+
+    await expect(codeBlock.getByRole("button", { name: /Python/i })).toBeVisible()
+    await expect(page.getByRole("dialog", { name: "코드 언어 선택" })).toHaveCount(0)
   })
 
   test("머메이드 블록 코드를 바꾸면 preview가 이전 템플릿이 아니라 최신 source로 즉시 다시 렌더된다", async ({ page }) => {


### PR DESCRIPTION
## 관련 이슈

close #565

## 작업 배경

- `/editor/[id]` 실제 글수정 route에서 저장된 코드 블록의 언어 선택 버튼이 dialog를 열고 언어 label을 갱신하는 E2E 회귀 테스트를 추가했습니다.
- 현재 로컬 main 기준 단순 클릭과 코드 텍스트 선택 후 클릭 모두 동작이 재현 통과되어, production 코드는 건드리지 않고 누락된 실제 수정 route 커버리지만 고정했습니다.

## 작업 내용

- `/editor/998` stub 응답으로 코드 블록 포함 글을 로드한 뒤 기존 코드 블록의 TypeScript 언어 버튼을 클릭합니다.
- `코드 언어 선택` dialog에서 Python을 선택하고 코드 블록 언어 label이 Python으로 바뀌는지 검증합니다.
- 코드 텍스트 드래그 선택 이후에도 언어 선택 dialog가 정상 동작하는지 같은 시나리오 안에서 확인합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-code-mermaid.spec.ts -g "실제 /editor/\\[id\\] 수정 route 코드 언어 선택"`
  - `yarn --cwd front playwright test e2e/editor-authoring-code-mermaid.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front test:e2e:perf`
  - `yarn --cwd front test:e2e:a11y`
  - Review fix 이후:
    - `yarn --cwd front playwright:preflight`
    - `yarn --cwd front playwright test e2e/editor-authoring-code-mermaid.spec.ts -g "실제 /editor/\\[id\\] 수정 route 코드 언어 선택"`
    - `yarn --cwd front playwright test e2e/editor-authoring-code-mermaid.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts`

  참고: `yarn --cwd front test:e2e` 전체 1회는 #565 변경 파일 밖의 pre-existing 정적/소스 계약 20건 실패로 분류했습니다. CI 대상 묶음인 smoke/authoring/perf/a11y는 로컬에서 통과했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: production 코드 변경이 없어서 런타임 리스크는 낮지만, 테스트가 실제 수정 route와 코드 텍스트 선택 상태를 함께 검증하므로 기존 에디터 선택 동작 회귀를 드러낼 수 있습니다.
- 롤백 방법: 이 PR의 커밋 `85faf027`, `c480e375`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
