### PR TITLE
[Fix] 글수정 말머리 handle overlap 복구

### DIFF
--- a/front/e2e/editor-authoring-block-selection.spec.ts
+++ b/front/e2e/editor-authoring-block-selection.spec.ts
@@ -578,6 +578,8 @@ test.describe("editor authoring block selection and drag", () => {
             right: railRect.right,
             top: railRect.top,
           }
+          const blockHandleGutterGapPx = 10
+          const blockHandleViewportPaddingPx = 12
           const resolveProtectedRects = (element: HTMLElement) => {
             const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
             let textNode: Text | null = null
@@ -599,7 +601,7 @@ test.describe("editor authoring block selection and drag", () => {
             range.setEnd(textNode, textOffset + Math.min(label.length, 6))
             const elementRect = element.getBoundingClientRect()
             const textRect = range.getBoundingClientRect()
-            const prefixLeft = Math.min(elementRect.left, textRect.left - 56)
+            const prefixLeft = Math.min(elementRect.left, textRect.left - (railRect.width + blockHandleGutterGapPx))
             return [
               {
                 bottom: textRect.bottom,
@@ -631,7 +633,16 @@ test.describe("editor authoring block selection and drag", () => {
               railBox.top < entry.bottom &&
               railBox.bottom > entry.top
           )
-          return { collisions, protectedRects, rail: railBox }
+          return {
+            collisions,
+            protectedRects,
+            rail: railBox,
+            viewport: {
+              height: window.innerHeight,
+              padding: blockHandleViewportPaddingPx,
+              width: window.innerWidth,
+            },
+          }
         },
         { selector: targetSelector, text: targetText }
       )
@@ -640,6 +651,11 @@ test.describe("editor authoring block selection and drag", () => {
         throw new Error(`말머리 overlap 좌표를 계산할 수 없습니다: ${targetText}`)
       }
 
+      const viewportTolerancePx = 1
+      expect(metrics.rail.left).toBeGreaterThanOrEqual(metrics.viewport.padding - viewportTolerancePx)
+      expect(metrics.rail.top).toBeGreaterThanOrEqual(metrics.viewport.padding - viewportTolerancePx)
+      expect(metrics.rail.right).toBeLessThanOrEqual(metrics.viewport.width - metrics.viewport.padding + viewportTolerancePx)
+      expect(metrics.rail.bottom).toBeLessThanOrEqual(metrics.viewport.height - metrics.viewport.padding + viewportTolerancePx)
       expect({ collisions: metrics.collisions, metrics, targetText }).toMatchObject({
         collisions: [],
       })

--- a/front/e2e/editor-authoring-block-selection.spec.ts
+++ b/front/e2e/editor-authoring-block-selection.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test"
 import {
   QA_ENGINE_ROUTE,
   QA_WRITER_ROUTE,
+  expectEditorToContainLoadedText,
   expectVisibleBox,
 } from "./helpers/editorAuthoringFlow"
 
@@ -512,5 +513,139 @@ test.describe("editor authoring block selection and drag", () => {
       railBox.y + railBox.height > paragraphBox.y
 
     expect(overlapsParagraph).toBe(false)
+  })
+
+  test("실제 /editor/[id] 수정 route block handle rail은 list/quote 말머리를 덮지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 760, height: 760 })
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 1,
+          username: "qa-admin",
+          nickname: "aquila",
+          isAdmin: true,
+        }),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/997", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 997,
+          version: 2,
+          title: "말머리 handle overlap 회귀 글",
+          content: [
+            "- JWT 쓰면 로그인 상태가 유지되는 거야?",
+            "- Refresh Token은 왜 또 따로 있어?",
+            "",
+            "> 세션 = 서버 저장",
+          ].join("\n"),
+          contentHtml: "",
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+
+    await page.goto("/editor/997")
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await expectEditorToContainLoadedText(editor, "Refresh Token은 왜 또 따로 있어?")
+
+    const assertRailDoesNotCoverPrefix = async (targetSelector: string, targetText: string) => {
+      const target = editor.locator(targetSelector, { hasText: targetText }).first()
+      await expect(target).toBeVisible()
+      await target.hover()
+
+      const handleRail = page.locator("[data-block-handle-rail='true'][data-visible='true']").first()
+      await expect(handleRail).toBeVisible()
+
+      const metrics = await page.evaluate(
+        ({ selector, text }) => {
+          const targetElement = Array.from(document.querySelectorAll<HTMLElement>(selector)).find((element) =>
+            element.textContent?.includes(text)
+          )
+          const rail = document.querySelector<HTMLElement>("[data-block-handle-rail='true'][data-visible='true']")
+          if (!targetElement || !rail) return null
+
+          const railRect = rail.getBoundingClientRect()
+          const railBox = {
+            bottom: railRect.bottom,
+            left: railRect.left,
+            right: railRect.right,
+            top: railRect.top,
+          }
+          const resolveProtectedRects = (element: HTMLElement) => {
+            const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+            let textNode: Text | null = null
+            let textOffset = -1
+            let label = ""
+            while (walker.nextNode()) {
+              const current = walker.currentNode as Text
+              const trimmed = current.data.trim()
+              if (!trimmed) continue
+              textNode = current
+              textOffset = current.data.indexOf(trimmed)
+              label = trimmed
+              break
+            }
+            if (!textNode || textOffset < 0) return []
+
+            const range = document.createRange()
+            range.setStart(textNode, textOffset)
+            range.setEnd(textNode, textOffset + Math.min(label.length, 6))
+            const elementRect = element.getBoundingClientRect()
+            const textRect = range.getBoundingClientRect()
+            const prefixLeft = Math.min(elementRect.left, textRect.left - 56)
+            return [
+              {
+                bottom: textRect.bottom,
+                kind: "prefix",
+                label,
+                left: prefixLeft,
+                right: textRect.left,
+                top: textRect.top,
+              },
+              {
+                bottom: textRect.bottom,
+                kind: "text",
+                label,
+                left: textRect.left,
+                right: textRect.right,
+                top: textRect.top,
+              },
+            ]
+          }
+          const protectedRects = Array.from(
+            document.querySelectorAll<HTMLElement>(
+              "[data-testid='block-editor-prosemirror'] li, [data-testid='block-editor-prosemirror'] blockquote"
+            )
+          ).flatMap(resolveProtectedRects)
+          const collisions = protectedRects.filter(
+            (entry) =>
+              railBox.left < entry.right &&
+              railBox.right > entry.left &&
+              railBox.top < entry.bottom &&
+              railBox.bottom > entry.top
+          )
+          return { collisions, protectedRects, rail: railBox }
+        },
+        { selector: targetSelector, text: targetText }
+      )
+
+      if (!metrics || metrics.protectedRects.length === 0) {
+        throw new Error(`말머리 overlap 좌표를 계산할 수 없습니다: ${targetText}`)
+      }
+
+      expect({ collisions: metrics.collisions, metrics, targetText }).toMatchObject({
+        collisions: [],
+      })
+    }
+
+    await assertRailDoesNotCoverPrefix("li", "Refresh Token은 왜 또 따로 있어?")
+    await assertRailDoesNotCoverPrefix("blockquote", "세션 = 서버 저장")
   })
 })

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -118,7 +118,10 @@ export const resolveBlockHandleRailLayout = (
   }
 }
 
-const resolveBlockHandleGutterBoundaryLeft = (blockElement?: HTMLElement | null) => {
+const resolveBlockHandleGutterBoundaryLeft = (
+  blockElement: HTMLElement | null | undefined,
+  railWidth: number
+) => {
   if (!blockElement || typeof document === "undefined" || typeof NodeFilter === "undefined") return null
   if (!blockElement.matches("li, blockquote")) return null
 
@@ -136,17 +139,70 @@ const resolveBlockHandleGutterBoundaryLeft = (blockElement?: HTMLElement | null)
     if (textRect.width <= 0 || textRect.height <= 0) return null
 
     const elementRect = blockElement.getBoundingClientRect()
-    return Math.min(elementRect.left, textRect.left - 56)
+    return Math.min(elementRect.left, textRect.left - (railWidth + BLOCK_HANDLE_GUTTER_GAP_PX))
   }
 
   return null
 }
 
-const collectBlockHandleProtectedRects = (protectedRoot?: HTMLElement | null): BlockHandleProtectedRect[] => {
-  if (!protectedRoot || typeof document === "undefined" || typeof NodeFilter === "undefined") return []
+const BLOCK_HANDLE_PROTECTED_SIBLING_WINDOW = 2
 
-  return Array.from(protectedRoot.querySelectorAll<HTMLElement>("li, blockquote")).flatMap((element) => {
-    const boundaryLeft = resolveBlockHandleGutterBoundaryLeft(element)
+const isBlockHandleProtectedElement = (element: Element | null): element is HTMLElement =>
+  typeof HTMLElement !== "undefined" && element instanceof HTMLElement && element.matches("li, blockquote")
+
+const collectBlockHandleProtectedElements = (protectedAnchor?: HTMLElement | null) => {
+  if (!protectedAnchor) return []
+
+  const elements: HTMLElement[] = []
+  const seen = new Set<HTMLElement>()
+  const push = (element: Element | null) => {
+    if (!isBlockHandleProtectedElement(element) || seen.has(element)) return
+    seen.add(element)
+    elements.push(element)
+  }
+  const pushDescendants = (element: Element | null, edge: "all" | "end" | "start") => {
+    if (!(element instanceof HTMLElement) || element.matches("li, blockquote")) return
+
+    const descendants = Array.from(element.children).flatMap((child) => {
+      if (isBlockHandleProtectedElement(child)) return [child]
+      if (!(child instanceof HTMLElement) || !child.matches("ul, ol")) return []
+      return Array.from(child.children).filter(isBlockHandleProtectedElement)
+    })
+    const boundedDescendants =
+      edge === "end"
+        ? descendants.slice(-BLOCK_HANDLE_PROTECTED_SIBLING_WINDOW)
+        : edge === "start"
+          ? descendants.slice(0, BLOCK_HANDLE_PROTECTED_SIBLING_WINDOW)
+          : descendants.slice(0, BLOCK_HANDLE_PROTECTED_SIBLING_WINDOW * 2 + 1)
+    boundedDescendants.forEach(push)
+  }
+  const pushCandidate = (element: Element | null, edge: "all" | "end" | "start" = "all") => {
+    push(element)
+    pushDescendants(element, edge)
+  }
+
+  pushCandidate(protectedAnchor)
+
+  let previousSibling = protectedAnchor.previousElementSibling
+  let nextSibling = protectedAnchor.nextElementSibling
+  for (let index = 0; index < BLOCK_HANDLE_PROTECTED_SIBLING_WINDOW; index += 1) {
+    pushCandidate(previousSibling, "end")
+    pushCandidate(nextSibling, "start")
+    previousSibling = previousSibling?.previousElementSibling ?? null
+    nextSibling = nextSibling?.nextElementSibling ?? null
+  }
+
+  return elements
+}
+
+const collectBlockHandleProtectedRects = (
+  protectedAnchor: HTMLElement | null | undefined,
+  railWidth: number
+): BlockHandleProtectedRect[] => {
+  if (!protectedAnchor || typeof document === "undefined" || typeof NodeFilter === "undefined") return []
+
+  return collectBlockHandleProtectedElements(protectedAnchor).flatMap((element) => {
+    const boundaryLeft = resolveBlockHandleGutterBoundaryLeft(element, railWidth)
     if (boundaryLeft === null) return []
 
     const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
@@ -190,7 +246,7 @@ const resolvePrefixSafeBlockHandleRailLayout = (
 ): BlockHandleRailLayout => {
   if (typeof window === "undefined") return railLayout
 
-  const protectedRects = collectBlockHandleProtectedRects(protectedRoot).filter(
+  const protectedRects = collectBlockHandleProtectedRects(protectedRoot, railWidth).filter(
     (protectedRect) =>
       protectedRect.bottom >= -railHeight &&
       protectedRect.top <= window.innerHeight + railHeight &&
@@ -238,11 +294,11 @@ export const resolveBlockHandleRailLayoutForSurface = (
       railWidth,
       railHeight,
       anchoredTop,
-      resolveBlockHandleGutterBoundaryLeft(gutterBoundaryElement) ?? rect.left
+      resolveBlockHandleGutterBoundaryLeft(gutterBoundaryElement, railWidth) ?? rect.left
     ),
     railWidth,
     railHeight,
-    gutterBoundaryElement?.closest(".aq-block-editor__content") as HTMLElement | null
+    gutterBoundaryElement
   )
   return {
     left: resolveBlockChromeLeft(railLayout.left, surfaceRect, mode),

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -11,6 +11,7 @@ export type BlockHandleRailLayout = {
 
 export type BlockChromePositionMode = "editor-local" | "viewport"
 type BlockChromeSurfaceRect = Pick<DOMRect, "left" | "top"> | null
+type BlockHandleProtectedRect = Pick<DOMRect, "bottom" | "left" | "right" | "top">
 export type WindowScrollAnchor = {
   x: number
   y: number
@@ -95,9 +96,10 @@ export const resolveBlockHandleRailLayout = (
   rect: DOMRect,
   railWidth: number,
   railHeight: number,
-  anchoredTop: number
+  anchoredTop: number,
+  gutterBoundaryLeft = rect.left
 ): BlockHandleRailLayout => {
-  const gutterLeft = rect.left - railWidth - BLOCK_HANDLE_GUTTER_GAP_PX
+  const gutterLeft = gutterBoundaryLeft - railWidth - BLOCK_HANDLE_GUTTER_GAP_PX
   if (gutterLeft >= BLOCK_HANDLE_VIEWPORT_PADDING_PX || typeof window === "undefined") {
     return {
       left: Math.max(BLOCK_HANDLE_VIEWPORT_PADDING_PX, gutterLeft),
@@ -116,15 +118,132 @@ export const resolveBlockHandleRailLayout = (
   }
 }
 
+const resolveBlockHandleGutterBoundaryLeft = (blockElement?: HTMLElement | null) => {
+  if (!blockElement || typeof document === "undefined" || typeof NodeFilter === "undefined") return null
+  if (!blockElement.matches("li, blockquote")) return null
+
+  const walker = document.createTreeWalker(blockElement, NodeFilter.SHOW_TEXT)
+  while (walker.nextNode()) {
+    const textNode = walker.currentNode as Text
+    const trimmed = textNode.data.trim()
+    if (!trimmed) continue
+
+    const textOffset = textNode.data.indexOf(trimmed)
+    const range = document.createRange()
+    range.setStart(textNode, textOffset)
+    range.setEnd(textNode, textOffset + Math.min(trimmed.length, 6))
+    const textRect = range.getBoundingClientRect()
+    if (textRect.width <= 0 || textRect.height <= 0) return null
+
+    const elementRect = blockElement.getBoundingClientRect()
+    return Math.min(elementRect.left, textRect.left - 56)
+  }
+
+  return null
+}
+
+const collectBlockHandleProtectedRects = (protectedRoot?: HTMLElement | null): BlockHandleProtectedRect[] => {
+  if (!protectedRoot || typeof document === "undefined" || typeof NodeFilter === "undefined") return []
+
+  return Array.from(protectedRoot.querySelectorAll<HTMLElement>("li, blockquote")).flatMap((element) => {
+    const boundaryLeft = resolveBlockHandleGutterBoundaryLeft(element)
+    if (boundaryLeft === null) return []
+
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+    while (walker.nextNode()) {
+      const textNode = walker.currentNode as Text
+      const trimmed = textNode.data.trim()
+      if (!trimmed) continue
+
+      const textOffset = textNode.data.indexOf(trimmed)
+      const range = document.createRange()
+      range.setStart(textNode, textOffset)
+      range.setEnd(textNode, textOffset + Math.min(trimmed.length, 6))
+      const textRect = range.getBoundingClientRect()
+      if (textRect.width <= 0 || textRect.height <= 0) return []
+
+      return [
+        {
+          bottom: textRect.bottom,
+          left: boundaryLeft,
+          right: textRect.left,
+          top: textRect.top,
+        },
+        {
+          bottom: textRect.bottom,
+          left: textRect.left,
+          right: textRect.right,
+          top: textRect.top,
+        },
+      ]
+    }
+
+    return []
+  })
+}
+
+const resolvePrefixSafeBlockHandleRailLayout = (
+  railLayout: BlockHandleRailLayout,
+  railWidth: number,
+  railHeight: number,
+  protectedRoot?: HTMLElement | null
+): BlockHandleRailLayout => {
+  if (typeof window === "undefined") return railLayout
+
+  const protectedRects = collectBlockHandleProtectedRects(protectedRoot).filter(
+    (protectedRect) =>
+      protectedRect.bottom >= -railHeight &&
+      protectedRect.top <= window.innerHeight + railHeight &&
+      railLayout.left < protectedRect.right &&
+      railLayout.left + railWidth > protectedRect.left
+  )
+  if (!protectedRects.length) return railLayout
+
+  const hasCollision = (top: number) =>
+    protectedRects.some(
+      (protectedRect) =>
+        top < protectedRect.bottom &&
+        top + railHeight > protectedRect.top
+    )
+  if (!hasCollision(railLayout.top)) return railLayout
+
+  const minTop = BLOCK_HANDLE_VIEWPORT_PADDING_PX
+  const maxTop = Math.max(minTop, window.innerHeight - railHeight - BLOCK_HANDLE_VIEWPORT_PADDING_PX)
+  const clampTop = (top: number) => Math.min(Math.max(minTop, top), maxTop)
+  const candidates = new Set<number>()
+  protectedRects.forEach((protectedRect) => {
+    candidates.add(clampTop(protectedRect.top - railHeight - BLOCK_HANDLE_STACKED_GAP_PX))
+    candidates.add(clampTop(protectedRect.bottom + BLOCK_HANDLE_STACKED_GAP_PX))
+  })
+
+  const safeTop = Array.from(candidates)
+    .sort((a, b) => Math.abs(a - railLayout.top) - Math.abs(b - railLayout.top) || a - b)
+    .find((top) => !hasCollision(top))
+
+  return typeof safeTop === "number" ? { ...railLayout, top: safeTop } : railLayout
+}
+
 export const resolveBlockHandleRailLayoutForSurface = (
   rect: DOMRect,
   railWidth: number,
   railHeight: number,
   anchoredTop: number,
   surfaceRect: BlockChromeSurfaceRect,
-  mode: BlockChromePositionMode
+  mode: BlockChromePositionMode,
+  gutterBoundaryElement?: HTMLElement | null
 ): BlockHandleRailLayout => {
-  const railLayout = resolveBlockHandleRailLayout(rect, railWidth, railHeight, anchoredTop)
+  const railLayout = resolvePrefixSafeBlockHandleRailLayout(
+    resolveBlockHandleRailLayout(
+      rect,
+      railWidth,
+      railHeight,
+      anchoredTop,
+      resolveBlockHandleGutterBoundaryLeft(gutterBoundaryElement) ?? rect.left
+    ),
+    railWidth,
+    railHeight,
+    gutterBoundaryElement?.closest(".aq-block-editor__content") as HTMLElement | null
+  )
   return {
     left: resolveBlockChromeLeft(railLayout.left, surfaceRect, mode),
     top: resolveBlockChromeTop(railLayout.top, surfaceRect, mode),

--- a/front/src/components/editor/useBlockEditorEngineBlockSelectionLayout.ts
+++ b/front/src/components/editor/useBlockEditorEngineBlockSelectionLayout.ts
@@ -166,7 +166,8 @@ export const useBlockEditorEngineBlockSelectionLayout = ({
         railHeight,
         resolveBlockHandleAnchorTop(activeListItemContext.listItemElement, railHeight),
         viewportRect,
-        handlePositionMode
+        handlePositionMode,
+        activeListItemContext.listItemElement
       )
       const nextState: TopLevelBlockHandleState = {
         visible: true,
@@ -208,7 +209,8 @@ export const useBlockEditorEngineBlockSelectionLayout = ({
       railHeight,
       anchoredTop,
       viewportRect,
-      handlePositionMode
+      handlePositionMode,
+      blockElement
     )
     const nextState: TopLevelBlockHandleState = {
       visible: true,


### PR DESCRIPTION
## 관련 이슈

close #564

## 작업 배경

- `/editor/[id]`에서 list/blockquote 말머리가 block handle rail에 가려지는 회귀를 복구합니다.
- rail 계산을 실제 rail 폭과 gutter gap 기준으로 맞추고, hover 경로의 보호 영역 수집을 현재 block/인접 sibling 범위로 제한했습니다.
- 실제 수정 route E2E에 말머리 collision 및 viewport clipping 검증을 추가했습니다.

## 작업 내용

- `li`/`blockquote`의 첫 텍스트 기준으로 marker/prefix boundary를 계산해 gutter 배치를 보정합니다.
- gutter가 부족해 fallback 배치가 주변 말머리/텍스트와 충돌하면 안전한 세로 후보로 이동합니다.
- protected rect 수집을 editor 전체 scan 대신 현재 block, 인접 sibling, direct child list 범위로 제한했습니다.
- `/editor/[id]` 760px route에서 list/blockquote 보호 영역과 rail collision, viewport clipping이 없는지 E2E로 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - RED: `/editor/[id]` 말머리 overlap 단일 회귀 테스트가 기존 코드에서 첫 list prefix/text 충돌로 실패
  - `yarn --cwd front playwright test e2e/editor-authoring-block-selection.spec.ts -g "실제 /editor/\\[id\\] 수정 route block handle rail은 list/quote 말머리를 덮지 않는다"` (1 passed)
  - `yarn --cwd front playwright test e2e/editor-authoring-block-selection.spec.ts e2e/editor-authoring-list-affordances.spec.ts e2e/editor-authoring-route-rich-drag-selection.spec.ts` (21 passed)
  - `yarn --cwd front build` (passed)
  - `node front/scripts/check-bundle-size.mjs` (passed)
  - `yarn --cwd front test:e2e:authoring` (119 passed)
  - `yarn --cwd front test:e2e:smoke` (57 passed)
  - `yarn --cwd front test:e2e:perf` (14 passed)
  - `yarn --cwd front test:e2e:a11y` (2 passed)
  - `yarn --cwd front test:e2e` (최종 355 passed, 7 skipped, 22 failed; 실패는 기존 admin/source-boundary/mermaid/security/slash/public-profile 정적 계약 20건과 full 병렬에서만 실패한 table mobile/slash interaction 2건으로 분류. 추가 2건은 단일 재실행 1 passed씩 확인)
  - `git diff --check` (passed)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 좁은 viewport에서 fallback rail 위치가 기존보다 위/아래로 이동할 수 있습니다. 기존 list item handle 세로 정렬 회귀는 관련 E2E로 확인했습니다.
- 롤백 방법: 이 PR의 commit `26877dd7`, `d403143b`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
