### PR TITLE
[Fix] 7x3 table selection 회귀 복구

### DIFF
--- a/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "@playwright/test"
+import { getTableAffordances } from "./helpers/editorAuthoringFlow"
+import { mockEditorRouteWithSevenByThreeTable } from "./helpers/editorTableFixtures"
+
+const SELECT_ALL_SHORTCUT = process.platform === "darwin" ? "Meta+a" : "Control+a"
+
+test.describe("editor authoring route table axis after select all", () => {
+  test("실제 /editor/[id] 7x3 table은 table-wide Cmd/Ctrl+A 직후 row/column grip으로 축 선택을 연다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 920 })
+    const { editor } = await mockEditorRouteWithSevenByThreeTable(page, {
+      postId: 991,
+      title: "7x3 table axis after select-all route 글",
+    })
+    const { columnHandle, rowHandle } = getTableAffordances(page)
+
+    const table = editor.locator("table").first()
+    const targetCell = editor.locator("td", { hasText: "Access Token" }).first()
+    const selectWholeTableText = async () => {
+      await targetCell.click({ position: { x: 36, y: 16 } })
+      await targetCell.dblclick({ position: { x: 36, y: 16 } })
+      await page.keyboard.press(SELECT_ALL_SHORTCUT)
+      await expect.poll(async () => page.evaluate(() => window.getSelection()?.toString() || "")).toContain("영역")
+      await expect.poll(async () => page.evaluate(() => window.getSelection()?.toString() || "")).toContain("Access Token")
+      await expect.poll(async () => page.evaluate(() => window.getSelection()?.toString() || "")).toContain("구현되어 있는가")
+    }
+
+    const moveToRowGripHotzone = async () => {
+      const tableBox = await table.boundingBox()
+      const cellBox = await targetCell.boundingBox()
+      if (!tableBox || !cellBox) {
+        throw new Error("7x3 route row grip metrics are missing after table-wide select-all")
+      }
+      const points = [
+        { x: tableBox.x + 4, y: cellBox.y + cellBox.height / 2 },
+        { x: tableBox.x + 8, y: cellBox.y + cellBox.height / 2 },
+        { x: tableBox.x + 4, y: tableBox.y + tableBox.height / 2 },
+      ]
+      for (const point of points) {
+        await page.mouse.move(cellBox.x + cellBox.width / 2, cellBox.y + cellBox.height / 2)
+        await page.mouse.move(point.x, point.y, { steps: 4 })
+        await page.waitForTimeout(80)
+        if (await rowHandle.isVisible().catch(() => false)) return
+      }
+    }
+
+    const moveToColumnGripHotzone = async () => {
+      const tableBox = await table.boundingBox()
+      const cellBox = await targetCell.boundingBox()
+      if (!tableBox || !cellBox) {
+        throw new Error("7x3 route column grip metrics are missing after table-wide select-all")
+      }
+      const points = [
+        { x: cellBox.x + cellBox.width / 2, y: tableBox.y + 4 },
+        { x: cellBox.x + cellBox.width / 2, y: tableBox.y + 8 },
+        { x: tableBox.x + tableBox.width / 2, y: tableBox.y + 4 },
+      ]
+      for (const point of points) {
+        await page.mouse.move(cellBox.x + cellBox.width / 2, cellBox.y + cellBox.height / 2)
+        await page.mouse.move(point.x, point.y, { steps: 4 })
+        await page.waitForTimeout(80)
+        if (await columnHandle.isVisible().catch(() => false)) return
+      }
+    }
+
+    await selectWholeTableText()
+    await moveToRowGripHotzone()
+    await expect(rowHandle).toBeVisible()
+    await rowHandle.click()
+    await expect(page.getByTestId("table-row-selection-outline")).toBeVisible()
+    await expect(page.getByTestId("table-row-menu")).toBeVisible()
+    await expect(editor.locator(".selectedCell")).toHaveCount(3)
+    await expect.poll(async () => page.evaluate(() => window.getSelection()?.toString() || "")).toBe("")
+    await expect
+      .poll(async () =>
+        page.evaluate(() =>
+          Boolean(
+            document.documentElement.getAttribute("data-table-drag-selection-text")?.trim() ||
+              document.querySelector("[data-table-drag-selection-text]")
+          )
+        )
+      )
+      .toBe(false)
+
+    await page.keyboard.press("Escape")
+    await selectWholeTableText()
+    await moveToColumnGripHotzone()
+    await expect(columnHandle).toBeVisible()
+    await columnHandle.click()
+    await expect(page.getByTestId("table-column-selection-outline")).toBeVisible()
+    await expect(page.getByTestId("table-column-menu")).toBeVisible()
+    await expect(editor.locator(".selectedCell")).toHaveCount(7)
+    await expect.poll(async () => page.evaluate(() => window.getSelection()?.toString() || "")).toBe("")
+  })
+})

--- a/front/e2e/editor-authoring-route-table-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-select-all.spec.ts
@@ -1,29 +1,9 @@
 import { expect, test, type Page } from "@playwright/test"
 import { expectEditorToContainLoadedText } from "./helpers/editorAuthoringFlow"
+import { editorSevenByThreeTableMarkdown } from "./helpers/editorTableFixtures"
 
 const SELECT_ALL_SHORTCUT = process.platform === "darwin" ? "Meta+a" : "Control+a"
-const TABLE_SELECT_ALL_EXAMPLE = [
-  '<!-- aq-table {"overflowMode":"normal","columnWidths":[160,220,220]} -->',
-  "| **영역** | **점검 항목** | **확인 기준** |",
-  "| --- | --- | --- |",
-  "| 개념 이해 | Stateless 의미 | 요청만으로 처리 가능한가 |",
-  "| 토큰 구조 | Access Token | 역할 명확 |",
-  "| 흐름 | 재발급 로직 | 구현되어 있는가 |",
-  "| 예외 | 동시 요청 | 처리 안정성 확인 |",
-  "| 정책 | 재시도 정책 | idempotent 검토 여부 |",
-  "| UI | 행 선택 | 접근성 경로 검증 |",
-].join("\n")
-const TABLE_SELECT_ALL_REPEAT_EXAMPLE = [
-  '<!-- aq-table {"overflowMode":"normal","columnWidths":[160,220,220]} -->',
-  "| 영역 | 점검 항목 | 확인 기준 |",
-  "| --- | --- | --- |",
-  "| A | B | C |",
-  "| D | E | F |",
-  "| G | H | I |",
-  "| J | K | L |",
-  "| M | N | O |",
-  "| P | Q | R |",
-].join("\n")
+const TABLE_SELECT_ALL_EXAMPLE = editorSevenByThreeTableMarkdown
 
 const adminMember = {
   id: 1,
@@ -31,20 +11,6 @@ const adminMember = {
   nickname: "aquila",
   isAdmin: true,
 }
-const focusTableCellByKeyboard = async (page: Page, maxAttempts = 12) => {
-  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-    const inTableCell = await page.evaluate(
-      () => Boolean(document.activeElement?.closest("th, td"))
-    )
-    if (inTableCell) {
-      return true
-    }
-    await page.keyboard.press("Tab")
-    await page.waitForTimeout(50)
-  }
-  return false
-}
-
 const blurTableCellByKeyboard = async (page: Page, maxAttempts = 28) => {
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     await page.keyboard.press("Tab")
@@ -82,6 +48,12 @@ const expectNativeSelectionAnchoredInParagraph = async (
       }, paragraphText)
     )
     .toBe(true)
+}
+
+const expectSevenByThreeTableShape = async (page: Page) => {
+  const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+  await expect(editor.locator("table tr")).toHaveCount(7)
+  await expect(editor.locator("table tr").first().locator("th, td")).toHaveCount(3)
 }
 
 test.describe("editor authoring route table select all", () => {
@@ -122,6 +94,7 @@ test.describe("editor authoring route table select all", () => {
     const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
     await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("table select all live route 글")
     await expectEditorToContainLoadedText(editor, "Access Token")
+    await expectSevenByThreeTableShape(page)
 
     const targetCell = editor.locator("td", { hasText: "Access Token" }).first()
     await targetCell.click({
@@ -148,10 +121,9 @@ test.describe("editor authoring route table select all", () => {
   test("table select all 반복 호출 시에도 table scope만 유지된다", async ({
     page,
   }) => {
-    const selectAllReRunMarkdown = TABLE_SELECT_ALL_REPEAT_EXAMPLE
     const content = [
       "table select all repeat lead paragraph",
-      selectAllReRunMarkdown,
+      TABLE_SELECT_ALL_EXAMPLE,
       "table select all repeat trailing paragraph",
     ].join("\n\n")
 
@@ -181,8 +153,9 @@ test.describe("editor authoring route table select all", () => {
     await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
       "table select all repeat route 글"
     )
+    await expectSevenByThreeTableShape(page)
 
-    const targetCell = editor.locator("td", { hasText: "D" }).first()
+    const targetCell = editor.locator("td", { hasText: "Access Token" }).first()
     await targetCell.click({
       position: { x: 40, y: 16 },
     })
@@ -243,6 +216,7 @@ test.describe("editor authoring route table select all", () => {
       "table select all row handle route 글"
     )
     await expectEditorToContainLoadedText(editor, "Access Token")
+    await expectSevenByThreeTableShape(page)
 
     const targetCell = editor.locator("td", { hasText: "Access Token" }).first()
     await targetCell.click({
@@ -326,6 +300,7 @@ test.describe("editor authoring route table select all", () => {
     await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
       "table select all keyboard focus escape route 글"
     )
+    await expectSevenByThreeTableShape(page)
 
     const targetCell = editor.locator("td", { hasText: "Access Token" }).first()
     await targetCell.click({
@@ -334,14 +309,7 @@ test.describe("editor authoring route table select all", () => {
     await targetCell.dblclick({ position: { x: 40, y: 16 } })
     await page.keyboard.press(SELECT_ALL_SHORTCUT)
     await page.waitForTimeout(240)
-    let firstSelectionText = await page.evaluate(() => window.getSelection()?.toString() ?? "")
-    if (!firstSelectionText.trim()) {
-      await targetCell.click({ position: { x: 40, y: 16 } })
-      await targetCell.dblclick({ position: { x: 40, y: 16 } })
-      await page.keyboard.press(SELECT_ALL_SHORTCUT)
-      await page.waitForTimeout(240)
-      firstSelectionText = await page.evaluate(() => window.getSelection()?.toString() ?? "")
-    }
+    const firstSelectionText = await page.evaluate(() => window.getSelection()?.toString() ?? "")
 
     expect(firstSelectionText).toContain("영역")
     expect(firstSelectionText).toContain("확인 기준")
@@ -380,14 +348,7 @@ test.describe("editor authoring route table select all", () => {
 
     await page.keyboard.press(SELECT_ALL_SHORTCUT)
     await page.waitForTimeout(240)
-    let secondSelectionText = await page.evaluate(() => window.getSelection()?.toString() ?? "")
-    if (!secondSelectionText.trim()) {
-      await targetCell.click({ position: { x: 40, y: 16 } })
-      await targetCell.dblclick({ position: { x: 40, y: 16 } })
-      await page.keyboard.press(SELECT_ALL_SHORTCUT)
-      await page.waitForTimeout(240)
-      secondSelectionText = await page.evaluate(() => window.getSelection()?.toString() ?? "")
-    }
+    const secondSelectionText = await page.evaluate(() => window.getSelection()?.toString() ?? "")
 
     expect(secondSelectionText).toContain("영역")
     expect(secondSelectionText).toContain("확인 기준")

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -46,7 +46,13 @@ let shouldClearActiveTableTextSelectionOnBlur = false
 let lastTableSelectionRoot: HTMLElement | null = null
 let lastTableSelectionExitTarget: Element | null = null
 const RECENT_TABLE_TEXT_SELECTION_CONTEXT_ATTR = "data-table-recent-text-selection-context"
+const TABLE_DRAG_SELECTION_TEXT_ATTR = "data-table-drag-selection-text"
+const TABLE_DRAG_SELECTION_TEXT_SELECTOR = `[${TABLE_DRAG_SELECTION_TEXT_ATTR}]`
 const TABLE_TEXT_HIGHLIGHT_NAME = "aq-table-text-selection"
+const clearTableDragSelectionTextAttributes = () => {
+  document.querySelectorAll(TABLE_DRAG_SELECTION_TEXT_SELECTOR).forEach((element) => element.removeAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR))
+  document.documentElement.removeAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR)
+}
 const clearTableTextRangeHighlight = (options: { markBlur?: boolean } = {}) => {
   const shouldClearTableSelection =
     hasActiveTableTextSelection ||
@@ -55,8 +61,7 @@ const clearTableTextRangeHighlight = (options: { markBlur?: boolean } = {}) => {
     shouldClearActiveTableTextSelectionOnBlur = true
   }
   hasActiveTableTextSelection = false
-  document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => element.removeAttribute("data-table-drag-selection-text"))
-  document.documentElement.removeAttribute("data-table-drag-selection-text")
+  clearTableDragSelectionTextAttributes()
   ;(CSS as typeof CSS & { highlights?: { delete: (name: string) => void } }).highlights?.delete(TABLE_TEXT_HIGHLIGHT_NAME)
 }
 const paintTableTextRangeHighlight = (range: Range) => { const HighlightCtor = (window as typeof window & { Highlight?: new (range: Range) => unknown }).Highlight, highlights = (CSS as typeof CSS & { highlights?: { set: (name: string, highlight: unknown) => void } }).highlights; if (!HighlightCtor || !highlights) return; if (!document.getElementById("aq-table-text-highlight-style")) { const style = document.createElement("style"); style.id = "aq-table-text-highlight-style"; style.textContent = `::highlight(${TABLE_TEXT_HIGHLIGHT_NAME}){background:#0a5b9d;color:white}`; document.head.append(style) } highlights.set(TABLE_TEXT_HIGHLIGHT_NAME, new HighlightCtor(range.cloneRange())) }
@@ -263,8 +268,8 @@ export const selectTableCellTextRange = (
   if (typeof selection.setBaseAndExtent === "function") selection.setBaseAndExtent(startBoundary.node, startBoundary.offset, endBoundary.node, endBoundary.offset)
   else selection.addRange(range)
   const selectedText = selection.toString() || range.toString()
-  resolvedCells.startedCell.setAttribute("data-table-drag-selection-text", selectedText || normalizeCellText(resolvedCells.startedCell))
-  document.documentElement.setAttribute("data-table-drag-selection-text", selectedText || normalizeCellText(resolvedCells.startedCell))
+  resolvedCells.startedCell.setAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR, selectedText || normalizeCellText(resolvedCells.startedCell))
+  document.documentElement.setAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR, selectedText || normalizeCellText(resolvedCells.startedCell))
   paintTableTextRangeHighlight(range)
   return selectedText
 }
@@ -301,8 +306,6 @@ let lastActiveTableCell: HTMLElement | null = null
 let lastActiveTableCellPath: ActiveTableCellPath | null = null
 const activeTableCellScrollPreserveCancels = new Set<() => void>()
 const activeTableCellSelectionPreserveCancels = new Set<() => void>()
-const TABLE_DRAG_SELECTION_TEXT_ATTR = "data-table-drag-selection-text"
-const TABLE_DRAG_SELECTION_TEXT_SELECTOR = `[${TABLE_DRAG_SELECTION_TEXT_ATTR}]`
 const TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES = 48
 const TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS = 800
 
@@ -495,7 +498,7 @@ const hasOwnedTableCellTextSelection = (
 ) => {
   const currentCell = resolveConnectedTableCell(editor, startedCell)
   if (!currentCell) return false
-  if (currentCell.getAttribute("data-table-drag-selection-text")?.trim()) {
+  if (currentCell.getAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR)?.trim()) {
     return true
   }
 
@@ -508,9 +511,8 @@ const clearOwnedTableCellDragSelectionText = (
   editor: TiptapEditor,
   startedCell: HTMLElement
 ) => {
-  resolveConnectedTableCell(editor, startedCell)?.removeAttribute(
-    "data-table-drag-selection-text"
-  )
+  resolveConnectedTableCell(editor, startedCell)?.removeAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR)
+  clearTableDragSelectionTextAttributes()
 }
 
 export const rememberActiveTableCellFromTarget = (
@@ -741,7 +743,7 @@ export const restoreTableCellTextSelectionIfEscaped = (
       (anchorElement && currentCell.contains(anchorElement)) ||
       (focusElement && currentCell.contains(focusElement)))
   ) {
-    currentCell.setAttribute("data-table-drag-selection-text", selection.toString())
+    currentCell.setAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR, selection.toString())
     clearNextEditorPointerAfterTable()
     if (!forceStartedCellSelection || !rangeEndCell || rangeEndCell === currentCell) {
       return true
@@ -759,7 +761,7 @@ export const restoreTableCellTextSelectionIfEscaped = (
     selection.addRange(range)
   }
   currentCell.setAttribute(
-    "data-table-drag-selection-text",
+    TABLE_DRAG_SELECTION_TEXT_ATTR,
     restoredRangeText || selection.toString() || normalizeCellText(currentCell)
   )
   clearNextEditorPointerAfterTable()

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -46,8 +46,8 @@ let shouldClearActiveTableTextSelectionOnBlur = false
 let lastTableSelectionRoot: HTMLElement | null = null
 let lastTableSelectionExitTarget: Element | null = null
 const RECENT_TABLE_TEXT_SELECTION_CONTEXT_ATTR = "data-table-recent-text-selection-context"
-const TABLE_DRAG_SELECTION_TEXT_ATTR = "data-table-drag-selection-text"
-const TABLE_DRAG_SELECTION_TEXT_SELECTOR = `[${TABLE_DRAG_SELECTION_TEXT_ATTR}]`
+export const TABLE_DRAG_SELECTION_TEXT_ATTR = "data-table-drag-selection-text"
+export const TABLE_DRAG_SELECTION_TEXT_SELECTOR = `[${TABLE_DRAG_SELECTION_TEXT_ATTR}]`
 const TABLE_TEXT_HIGHLIGHT_NAME = "aq-table-text-selection"
 const clearTableDragSelectionTextAttributes = () => {
   document.querySelectorAll(TABLE_DRAG_SELECTION_TEXT_SELECTOR).forEach((element) => element.removeAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR))

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -5,7 +5,7 @@ import { cancelTablePointerScrollPreserves, clearNextEditorPointerAfterTable, ma
 import { resolveMultiCellTableDomSelectionBubbleState, resolvePersistedTableTextSelectionBubbleState } from "./floatingBubbleDomRangeModel"
 import { collapseTableCellTextSelectionToPoint } from "./tableTextCaretModel"
 import { isTableSelectionActive } from "./tableStructureModel"
-import { cancelActiveTableCellTextSelectionPreserves, collapseStaleTableEditorSelection, preserveTableCellTextSelectionAcrossFrames, resolveTableTextCellAtPoint, resolveTableTextSelectionRangeCells, restoreTableCellTextSelectionIfEscaped, selectTableCellTextRange, watchTableCellTextSelectionExternalClear } from "./tableTextSelectionModel"
+import { TABLE_DRAG_SELECTION_TEXT_ATTR, TABLE_DRAG_SELECTION_TEXT_SELECTOR, cancelActiveTableCellTextSelectionPreserves, collapseStaleTableEditorSelection, preserveTableCellTextSelectionAcrossFrames, resolveTableTextCellAtPoint, resolveTableTextSelectionRangeCells, restoreTableCellTextSelectionIfEscaped, selectTableCellTextRange, watchTableCellTextSelectionExternalClear } from "./tableTextSelectionModel"
 import { areFloatingBubbleStatesEqual, hasNativeEditorTextSelection, hideFloatingBubbleState, resolveFloatingBubbleStateFromCoords, resolveHeadingSelectionBubbleState, type FloatingBubbleState } from "./useFloatingBubbleState"
 const CODE_BLOCK_EDITOR_CONTENT_SELECTOR = ".aq-code-editor-content"
 const BLOCK_EDITOR_ROOT_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
@@ -60,7 +60,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     let codeDragSelectionPreserveGeneration = 0
     const cancelTableTextDragPreserves = () => { cleanupTableDragScrollPreserve?.(); cleanupTableDragScrollPreserve = null; cleanupTableDragSelectionPreserve?.(); cleanupTableDragSelectionPreserve = null; cancelActiveTableCellTextSelectionPreserves(); cancelTablePointerScrollPreserves(); clearNextEditorPointerAfterTable(); tableTextSelectionExternalClearWatcher?.reset() }
     const handleTableTextSelectionExternalClear = () => { cancelTableTextDragPreserves(); const activeEditor = editorRef.current ?? currentEditor, toolbarActive = Boolean(bubbleToolbarHoveredRef.current || document.querySelector("[data-testid='editor-text-bubble-toolbar']:hover, [data-testid='editor-text-bubble-toolbar'] details[open]")); if (activeEditor && !toolbarActive) collapseStaleTableEditorSelection(activeEditor) }
-    const clearWindowTextSelectionOnly = () => { window.getSelection()?.removeAllRanges(); document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => element.removeAttribute("data-table-drag-selection-text")); document.documentElement.removeAttribute("data-table-drag-selection-text") }
+    const clearWindowTextSelectionOnly = () => { window.getSelection()?.removeAllRanges(); document.querySelectorAll(TABLE_DRAG_SELECTION_TEXT_SELECTOR).forEach((element) => element.removeAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR)); document.documentElement.removeAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR) }
     const clearImmediateWindowTextSelection = () => { cancelTableTextDragPreserves(); clearWindowTextSelectionOnly() }
     const cancelCodeDragSelectionPreserve = () => {
       codeDragSelectionPreserveGeneration += 1

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -60,7 +60,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     let codeDragSelectionPreserveGeneration = 0
     const cancelTableTextDragPreserves = () => { cleanupTableDragScrollPreserve?.(); cleanupTableDragScrollPreserve = null; cleanupTableDragSelectionPreserve?.(); cleanupTableDragSelectionPreserve = null; cancelActiveTableCellTextSelectionPreserves(); cancelTablePointerScrollPreserves(); clearNextEditorPointerAfterTable(); tableTextSelectionExternalClearWatcher?.reset() }
     const handleTableTextSelectionExternalClear = () => { cancelTableTextDragPreserves(); const activeEditor = editorRef.current ?? currentEditor, toolbarActive = Boolean(bubbleToolbarHoveredRef.current || document.querySelector("[data-testid='editor-text-bubble-toolbar']:hover, [data-testid='editor-text-bubble-toolbar'] details[open]")); if (activeEditor && !toolbarActive) collapseStaleTableEditorSelection(activeEditor) }
-    const clearWindowTextSelectionOnly = () => { window.getSelection()?.removeAllRanges(); document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => element.removeAttribute("data-table-drag-selection-text")) }
+    const clearWindowTextSelectionOnly = () => { window.getSelection()?.removeAllRanges(); document.querySelectorAll("[data-table-drag-selection-text]").forEach((element) => element.removeAttribute("data-table-drag-selection-text")); document.documentElement.removeAttribute("data-table-drag-selection-text") }
     const clearImmediateWindowTextSelection = () => { cancelTableTextDragPreserves(); clearWindowTextSelectionOnly() }
     const cancelCodeDragSelectionPreserve = () => {
       codeDragSelectionPreserveGeneration += 1
@@ -301,7 +301,6 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
 
       if (multiCellTableBubbleState && canShowMultiCellTableTextToolbar) {
         cancelBubbleHide()
-        hideTableQuickRailImmediately()
         setBubbleState((prev) => areFloatingBubbleStatesEqual(prev, multiCellTableBubbleState) ? prev : multiCellTableBubbleState)
         return
       }

--- a/front/src/components/editor/useBlockEditorTableOverlayControllerCommands.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayControllerCommands.ts
@@ -147,9 +147,14 @@ export const useBlockEditorTableOverlayControllerCommands = ({
     )
     const hoveredCellFromPoint: HTMLTableCellElement | null = hasHoverPoint
       ? (() => {
-          const pointElement = document.elementFromPoint(hoverClientX as number, hoverClientY as number)
-          const pointCell = pointElement?.closest("th, td")
-          if (pointCell instanceof HTMLTableCellElement) return pointCell
+          const pointElements = document.elementsFromPoint(hoverClientX as number, hoverClientY as number)
+          const pointCell = pointElements
+            .map((pointElement) => pointElement.closest("th, td"))
+            .find(
+              (cell): cell is HTMLTableCellElement =>
+                cell instanceof HTMLTableCellElement && tableElement.contains(cell)
+            )
+          if (pointCell) return pointCell
 
           const cells = Array.from(tableElement.querySelectorAll("th, td")).filter(
             (cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement

--- a/front/src/components/editor/useBlockEditorTableOverlayControllerCommands.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayControllerCommands.ts
@@ -26,6 +26,14 @@ import {
 } from "./useBlockEditorTableOverlayControllerState"
 import { resolveTableAxisIndexFromPointer } from "./tableAxisDragModel"
 
+const resolveElementsFromPoint = (clientX: number, clientY: number) => {
+  if (typeof document.elementsFromPoint === "function") {
+    return document.elementsFromPoint(clientX, clientY)
+  }
+  const pointElement = document.elementFromPoint(clientX, clientY)
+  return pointElement ? [pointElement] : []
+}
+
 type UseBlockEditorTableOverlayControllerCommandsArgs = {
   activeTableElementRef: MutableRefObject<HTMLTableElement | null>
   cancelTableQuickRailHide: () => void
@@ -147,7 +155,7 @@ export const useBlockEditorTableOverlayControllerCommands = ({
     )
     const hoveredCellFromPoint: HTMLTableCellElement | null = hasHoverPoint
       ? (() => {
-          const pointElements = document.elementsFromPoint(hoverClientX as number, hoverClientY as number)
+          const pointElements = resolveElementsFromPoint(hoverClientX as number, hoverClientY as number)
           const pointCell = pointElements
             .map((pointElement) => pointElement.closest("th, td"))
             .find(

--- a/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
@@ -9,6 +9,14 @@ import type { TableAffordanceGeometry } from "./tableAffordanceModel"
 import { findActiveRenderedTable, resolveTableScopedSelectedCell } from "./tableRenderedDomModel"
 import { isTableSelectionActive } from "./tableStructureModel"
 
+const resolveElementsFromPoint = (clientX: number, clientY: number) => {
+  if (typeof document.elementsFromPoint === "function") {
+    return document.elementsFromPoint(clientX, clientY)
+  }
+  const pointElement = document.elementFromPoint(clientX, clientY)
+  return pointElement ? [pointElement] : []
+}
+
 type UseBlockEditorTableOverlayDomAdapterArgs = {
   activeTableElementRef: MutableRefObject<HTMLTableElement | null>
   editorRef: MutableRefObject<TiptapEditor | null>
@@ -83,7 +91,7 @@ export const useBlockEditorTableOverlayDomAdapter = ({
       if (targetCell) return targetCell
       if (typeof document === "undefined") return null
 
-      const pointElements = document.elementsFromPoint(clientX, clientY)
+      const pointElements = resolveElementsFromPoint(clientX, clientY)
       const pointCell = pointElements
         .map((element) => element.closest("td, th"))
         .find((cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement)

--- a/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
@@ -83,15 +83,19 @@ export const useBlockEditorTableOverlayDomAdapter = ({
       if (targetCell) return targetCell
       if (typeof document === "undefined") return null
 
-      const pointElement = document.elementFromPoint(clientX, clientY)
-      const pointCell = pointElement?.closest("td, th")
-      if (pointCell instanceof HTMLTableCellElement) return pointCell
+      const pointElements = document.elementsFromPoint(clientX, clientY)
+      const pointCell = pointElements
+        .map((element) => element.closest("td, th"))
+        .find((cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement)
+      if (pointCell) return pointCell
 
       const normalizedTarget =
         target instanceof Element ? target : target instanceof Node ? target.parentElement : null
       const tableSurfaceElement =
         normalizedTarget?.closest(".aq-table-shell, .tableWrapper, table") ??
-        pointElement?.closest(".aq-table-shell, .tableWrapper, table") ??
+        pointElements
+          .map((element) => element.closest(".aq-table-shell, .tableWrapper, table"))
+          .find((surface): surface is Element => surface instanceof Element) ??
         null
       const tableElement =
         tableSurfaceElement instanceof HTMLTableElement


### PR DESCRIPTION
## 관련 이슈

close #467
close #551
close #561
close #562

## 작업 배경

- 글수정 `/editor/[id]` 7x3 테이블에서 Cmd/Ctrl+A 직후 table text bubble이 row/column quick rail을 숨기는 회귀를 복구합니다.
- 테이블 선택 hit-test를 `elementsFromPoint()` 기반으로 보강해 text bubble overlay 아래의 row/column grip 전환을 안정화합니다.

## 작업 내용

- table-wide text selection bubble 상태에서도 table quick rail을 강제로 숨기지 않도록 조정했습니다.
- table axis hover hit-test가 toolbar/overlay 아래의 실제 table cell을 찾도록 보강했습니다.
- `data-table-drag-selection-text` cleanup을 공통화하고 documentElement 잔여 상태를 명시적으로 정리했습니다.
- 7x3 route fixture 기준 Cmd/Ctrl+A 직후 row/column grip 전환 회귀 테스트를 추가하고 select-all 테스트의 inline fixture/retry fallback을 제거했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-select-all.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts e2e/editor-authoring-route-table-select-all.spec.ts e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-affordances.spec.ts e2e/editor-authoring-table-operations.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke`
  - `git diff --cached --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table text selection toolbar와 table quick rail이 동시에 유지되는 구간에서 overlay z-index/hover 경쟁이 재발할 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋 `036add1b`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
