### PR TITLE
[Fix] 7x3 select-all column rail 회귀 복구

### DIFF
--- a/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
@@ -5,6 +5,91 @@ import { mockEditorRouteWithSevenByThreeTable } from "./helpers/editorTableFixtu
 const SELECT_ALL_SHORTCUT = process.platform === "darwin" ? "Meta+a" : "Control+a"
 
 test.describe("editor authoring route table axis after select all", () => {
+  test("실제 /editor/[id] 7x3 table은 table-wide Cmd/Ctrl+A 직후 column grip을 첫 축 선택으로 연다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1580, height: 900 })
+    const { editor } = await mockEditorRouteWithSevenByThreeTable(page, {
+      postId: 993,
+      title: "7x3 table select-all column route 글",
+      lead: "table live lead paragraph",
+      tail: "table live trailing paragraph",
+    })
+    const { columnHandle } = getTableAffordances(page)
+
+    const table = editor.locator("table").first()
+    const targetCell = editor.locator("td", { hasText: "Access Token" }).first()
+    await targetCell.click({ position: { x: 40, y: 16 } })
+    await targetCell.dblclick({ position: { x: 40, y: 16 } })
+    await page.keyboard.press(SELECT_ALL_SHORTCUT)
+    await expect.poll(async () => page.evaluate(() => window.getSelection()?.toString() || "")).toContain("영역")
+    await expect.poll(async () => page.evaluate(() => window.getSelection()?.toString() || "")).toContain("구현되어 있는가")
+
+    const tableBox = await table.boundingBox()
+    const cellBox = await targetCell.boundingBox()
+    if (!tableBox || !cellBox) {
+      throw new Error("7x3 route column grip metrics are missing after table-wide select-all")
+    }
+    await page.mouse.move(cellBox.x + cellBox.width / 2, cellBox.y + cellBox.height / 2)
+    await page.evaluate(
+      ({ left, top, width }) => {
+        const doc = document as Document & {
+          __aqOriginalElementFromPoint?: typeof document.elementFromPoint
+          __aqOriginalElementsFromPoint?: typeof document.elementsFromPoint
+        }
+        const cover = document.createElement("div")
+        cover.setAttribute("data-testid", "table-hotzone-cover")
+        Object.assign(cover.style, {
+          background: "transparent",
+          height: "24px",
+          left: `${left}px`,
+          pointerEvents: "auto",
+          position: "fixed",
+          top: `${top}px`,
+          width: `${width}px`,
+          zIndex: "2147483647",
+        })
+        document.querySelector("[data-testid='block-editor-viewport']")?.appendChild(cover)
+        doc.__aqOriginalElementsFromPoint = document.elementsFromPoint.bind(document)
+        doc.__aqOriginalElementFromPoint = document.elementFromPoint.bind(document)
+        document.elementsFromPoint = ((clientX: number, clientY: number) => {
+          const rect = cover.getBoundingClientRect()
+          if (clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom) {
+            return [cover]
+          }
+          return doc.__aqOriginalElementsFromPoint?.(clientX, clientY) ?? []
+        }) as typeof document.elementsFromPoint
+        document.elementFromPoint = ((clientX: number, clientY: number) => {
+          const rect = cover.getBoundingClientRect()
+          if (clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom) {
+            return cover
+          }
+          return doc.__aqOriginalElementFromPoint?.(clientX, clientY) ?? null
+        }) as typeof document.elementFromPoint
+      },
+      { left: tableBox.x, top: tableBox.y, width: tableBox.width }
+    )
+    await page.mouse.move(cellBox.x + cellBox.width / 2, tableBox.y + 3)
+    await page.waitForTimeout(180)
+
+    await expect(columnHandle).toBeVisible()
+    await page.getByTestId("table-hotzone-cover").evaluate((element) => {
+      const doc = document as Document & {
+        __aqOriginalElementFromPoint?: typeof document.elementFromPoint
+        __aqOriginalElementsFromPoint?: typeof document.elementsFromPoint
+      }
+      if (doc.__aqOriginalElementsFromPoint) document.elementsFromPoint = doc.__aqOriginalElementsFromPoint
+      if (doc.__aqOriginalElementFromPoint) document.elementFromPoint = doc.__aqOriginalElementFromPoint
+      delete doc.__aqOriginalElementsFromPoint
+      delete doc.__aqOriginalElementFromPoint
+      element.remove()
+    })
+    await columnHandle.click()
+    await expect(page.getByTestId("table-column-selection-outline")).toBeVisible()
+    await expect(page.getByTestId("table-column-menu")).toBeVisible()
+    await expect(editor.locator(".selectedCell")).toHaveCount(7)
+  })
+
   test("실제 /editor/[id] 7x3 table은 table-wide Cmd/Ctrl+A 직후 row/column grip으로 축 선택을 연다", async ({
     page,
   }) => {

--- a/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
@@ -108,7 +108,21 @@ export const useBlockEditorTableOverlayDomAdapter = ({
       const tableElement =
         tableSurfaceElement instanceof HTMLTableElement
           ? tableSurfaceElement
-          : (tableSurfaceElement?.querySelector("table") as HTMLTableElement | null)
+          : (tableSurfaceElement?.querySelector("table") as HTMLTableElement | null) ??
+            (() => {
+              const activeTable =
+                activeTableElementRef.current ??
+                findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
+              if (!activeTable?.isConnected) return null
+              const rect = activeTable.getBoundingClientRect()
+              const hitTestMargin = 32
+              const isInsideActiveTableSurface =
+                clientX >= rect.left - hitTestMargin &&
+                clientX <= rect.right + hitTestMargin &&
+                clientY >= rect.top - hitTestMargin &&
+                clientY <= rect.bottom + hitTestMargin
+              return isInsideActiveTableSurface ? activeTable : null
+            })()
       if (!tableElement) return null
 
       const cells = Array.from(tableElement.querySelectorAll("th, td")).filter(
@@ -121,7 +135,7 @@ export const useBlockEditorTableOverlayDomAdapter = ({
         }) ?? null
       )
     },
-    [getTableCellFromTarget]
+    [activeTableElementRef, getTableCellFromTarget, tableAffordanceGeometryRef, viewportRef]
   )
 
   const getActiveTableRectFromDom = useCallback((activeEditor?: TiptapEditor | null) => {


### PR DESCRIPTION
## 관련 이슈

close #561
close #562

## 작업 배경

- `/editor/[id]` 7x3 table에서 table-wide Cmd/Ctrl+A 직후 column hotzone이 overlay에 가려지면 column rail 대신 cell menu만 남던 회귀를 복구합니다.
- point hit-test가 table cell을 직접 반환하지 못해도 현재 활성/렌더링 table rect로 fallback해 column grip을 열 수 있게 했습니다.

## 작업 내용

- table overlay DOM adapter의 `getTableCellFromClientPoint`에 active/rendered table geometry fallback을 추가했습니다.
- 7x3 route E2E에 `elementsFromPoint`가 overlay만 반환하는 조건을 추가해 live 실패 조건을 회귀 테스트로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts --workers=1`
  - RED 확인: runtime fallback 제거 상태에서 위 axis spec 1건 실패
  - GREEN 확인: runtime fallback 복구 후 위 axis spec 2건 통과
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-select-all.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts e2e/editor-authoring-route-table-select-all.spec.ts e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-affordances.spec.ts e2e/editor-authoring-table-operations.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke`
  - `git diff --check`
  - `git diff --cached --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table hover hit-test fallback이 활성 table 근처 32px 영역에서만 동작하므로 범위는 작지만, table overlay가 여러 개일 때 잘못된 table을 잡는지 CI와 live로 확인합니다.
- 롤백 방법: 이 PR의 단일 commit `697fdad7`을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
