### PR TITLE
[Fix] 7x3 row reset column rail 회귀 복구

### DIFF
--- a/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
@@ -5,6 +5,54 @@ import { mockEditorRouteWithSevenByThreeTable } from "./helpers/editorTableFixtu
 const SELECT_ALL_SHORTCUT = process.platform === "darwin" ? "Meta+a" : "Control+a"
 
 test.describe("editor authoring route table axis after select all", () => {
+  test("실제 /editor/[id] 7x3 table은 row 선택 해제 직후 column hotzone direct hover로 열 선택을 연다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1580, height: 900 })
+    const { editor } = await mockEditorRouteWithSevenByThreeTable(page, {
+      postId: 994,
+      title: "7x3 table row reset column route 글",
+      lead: "table live lead paragraph",
+      tail: "table live trailing paragraph",
+    })
+    const { columnHandle, rowHandle } = getTableAffordances(page)
+
+    const table = editor.locator("table").first()
+    const targetCell = editor.locator("td", { hasText: "Access Token" }).first()
+    await targetCell.click({ position: { x: 40, y: 16 } })
+    await targetCell.dblclick({ position: { x: 40, y: 16 } })
+
+    const tableBox = await table.boundingBox()
+    const cellBox = await targetCell.boundingBox()
+    if (!tableBox || !cellBox) {
+      throw new Error("7x3 route row reset metrics are missing")
+    }
+
+    await page.mouse.move(tableBox.x + 3, cellBox.y + cellBox.height / 2)
+    await page.waitForTimeout(140)
+    await expect(rowHandle).toBeVisible()
+    await rowHandle.click()
+    await expect(page.getByTestId("table-row-selection-outline")).toBeVisible()
+    await expect(page.getByTestId("table-row-menu")).toBeVisible()
+    await expect(editor.locator(".selectedCell")).toHaveCount(3)
+
+    await page.keyboard.press("Escape")
+    await targetCell.click({ position: { x: 40, y: 16 } })
+    const tableBoxAfterReset = await table.boundingBox()
+    const cellBoxAfterReset = await targetCell.boundingBox()
+    if (!tableBoxAfterReset || !cellBoxAfterReset) {
+      throw new Error("7x3 route row reset column metrics are missing")
+    }
+    await page.mouse.move(cellBoxAfterReset.x + cellBoxAfterReset.width / 2, tableBoxAfterReset.y + 3)
+    await page.waitForTimeout(180)
+
+    await expect(columnHandle).toBeVisible()
+    await columnHandle.click()
+    await expect(page.getByTestId("table-column-selection-outline")).toBeVisible()
+    await expect(page.getByTestId("table-column-menu")).toBeVisible()
+    await expect(editor.locator(".selectedCell")).toHaveCount(7)
+  })
+
   test("실제 /editor/[id] 7x3 table은 table-wide Cmd/Ctrl+A 직후 column grip을 첫 축 선택으로 연다", async ({
     page,
   }) => {

--- a/front/src/components/editor/useBlockEditorTableOverlayController.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayController.ts
@@ -56,6 +56,7 @@ export const useBlockEditorTableOverlayController = ({
     tableAffordanceGeometryRef,
     tableAffordanceVisibility,
     tableAffordanceVisibilityRef,
+    tableAxisHoverLockUntilRef,
     tableHoverAnchorLockUntilRef,
     tableMenuState,
   } = useBlockEditorTableOverlayControllerState({ viewportRef })
@@ -95,6 +96,7 @@ export const useBlockEditorTableOverlayController = ({
     isNarrowTableViewport,
     setTableAffordanceVisibility,
     tableAffordanceGeometryRef,
+    tableAxisHoverLockUntilRef,
     viewportRef,
   })
   const {
@@ -139,6 +141,7 @@ export const useBlockEditorTableOverlayController = ({
     setSelectionTick,
     setTableAffordanceGeometry,
     setTableAffordanceVisibility,
+    tableAxisHoverLockUntilRef,
     tableHoverAnchorLockUntilRef,
     viewportRef,
   })

--- a/front/src/components/editor/useBlockEditorTableOverlayControllerCommands.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayControllerCommands.ts
@@ -34,6 +34,8 @@ const resolveElementsFromPoint = (clientX: number, clientY: number) => {
   return pointElement ? [pointElement] : []
 }
 
+const TABLE_AXIS_HOVER_LOCK_MS = 280
+
 type UseBlockEditorTableOverlayControllerCommandsArgs = {
   activeTableElementRef: MutableRefObject<HTMLTableElement | null>
   cancelTableQuickRailHide: () => void
@@ -53,6 +55,7 @@ type UseBlockEditorTableOverlayControllerCommandsArgs = {
     showCornerControls: boolean
     showCellMenu: boolean
   }>>
+  tableAxisHoverLockUntilRef: MutableRefObject<number>
   tableHoverAnchorLockUntilRef: MutableRefObject<number>
   viewportRef: RefObject<HTMLDivElement>
 }
@@ -68,6 +71,7 @@ export const useBlockEditorTableOverlayControllerCommands = ({
   setSelectionTick,
   setTableAffordanceGeometry,
   setTableAffordanceVisibility,
+  tableAxisHoverLockUntilRef,
   tableHoverAnchorLockUntilRef,
 }: UseBlockEditorTableOverlayControllerCommandsArgs) => {
   const clearWindowTextSelection = useCallback(() => {
@@ -136,18 +140,24 @@ export const useBlockEditorTableOverlayControllerCommands = ({
     if (!tableElement || !tableRect) {
       activeTableElementRef.current = null
       hoveredTableElementRef.current = null
+      tableAxisHoverLockUntilRef.current = 0
       tableHoverAnchorLockUntilRef.current = 0
       setHoveredTableCellMenuLayout(null)
       hideTableQuickRailImmediately()
       return
     }
     activeTableElementRef.current = tableElement
+    const now =
+      typeof window !== "undefined" && typeof window.performance !== "undefined"
+        ? window.performance.now()
+        : Date.now()
+    const isRecentHoverAnchorSync =
+      !hasHoverPoint &&
+      hoveredTableElementRef.current === tableElement &&
+      now <= tableHoverAnchorLockUntilRef.current
     if (hasHoverPoint) {
       hoveredTableElementRef.current = tableElement
-      tableHoverAnchorLockUntilRef.current =
-        (typeof window !== "undefined" && typeof window.performance !== "undefined"
-          ? window.performance.now()
-          : Date.now()) + 280
+      tableHoverAnchorLockUntilRef.current = now + TABLE_AXIS_HOVER_LOCK_MS
     }
     cancelTableQuickRailHide()
     const tableRows = Array.from(tableElement.querySelectorAll("tr")).filter(
@@ -264,6 +274,12 @@ export const useBlockEditorTableOverlayControllerCommands = ({
       !showColumnAddBar &&
       !showRowAddBar &&
       !showCornerControls
+    if (hasHoverPoint) {
+      tableAxisHoverLockUntilRef.current =
+        showColumnRail || showRowRail || showColumnAddBar || showRowAddBar || showCornerControls
+          ? now + TABLE_AXIS_HOVER_LOCK_MS
+          : 0
+    }
     const activeRowIndex = typeof hoveredRowIndex === "number"
       ? hoveredRowIndex
       : activeRow
@@ -387,15 +403,17 @@ export const useBlockEditorTableOverlayControllerCommands = ({
       cellMenuAnchor,
       columnSegments: firstRowCells,
     })
-    setTableAffordanceVisibility((prev) => ({
-      visible: true,
-      showColumnRail: hasHoverPoint ? showColumnRail : prev.showColumnRail,
-      showRowRail: hasHoverPoint ? showRowRail : prev.showRowRail,
-      showColumnAddBar: hasHoverPoint ? showColumnAddBar : prev.showColumnAddBar,
-      showRowAddBar: hasHoverPoint ? showRowAddBar : prev.showRowAddBar,
-      showCornerControls: hasHoverPoint ? showCornerControls : prev.showCornerControls,
-      showCellMenu: hasHoverPoint ? showCellMenu : prev.showCellMenu,
-    }))
+    if (!isRecentHoverAnchorSync) {
+      setTableAffordanceVisibility((prev) => ({
+        visible: true,
+        showColumnRail: hasHoverPoint ? showColumnRail : prev.showColumnRail,
+        showRowRail: hasHoverPoint ? showRowRail : prev.showRowRail,
+        showColumnAddBar: hasHoverPoint ? showColumnAddBar : prev.showColumnAddBar,
+        showRowAddBar: hasHoverPoint ? showRowAddBar : prev.showRowAddBar,
+        showCornerControls: hasHoverPoint ? showCornerControls : prev.showCornerControls,
+        showCellMenu: hasHoverPoint ? showCellMenu : prev.showCellMenu,
+      }))
+    }
   }, [
     activeTableElementRef,
     cancelTableQuickRailHide,
@@ -406,6 +424,7 @@ export const useBlockEditorTableOverlayControllerCommands = ({
     setTableAffordanceVisibility,
     syncHoveredTableCellMenuLayout,
     tableHoverAnchorLockUntilRef,
+    tableAxisHoverLockUntilRef,
   ])
 
   const stabilizeTableSelectionSurface = useCallback((nextEditor?: TiptapEditor | null) => {

--- a/front/src/components/editor/useBlockEditorTableOverlayControllerState.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayControllerState.ts
@@ -32,6 +32,7 @@ export const useBlockEditorTableOverlayControllerState = ({
 }: UseBlockEditorTableOverlayControllerStateArgs) => {
   const activeTableElementRef = useRef<HTMLTableElement | null>(null)
   const hoveredTableElementRef = useRef<HTMLTableElement | null>(null)
+  const tableAxisHoverLockUntilRef = useRef(0)
   const tableHoverAnchorLockUntilRef = useRef(0)
   const [isNarrowTableViewport, setIsNarrowTableViewport] = useState(false)
   const [tableAffordanceGeometry, setTableAffordanceGeometry] = useState<TableAffordanceGeometry>(
@@ -92,6 +93,7 @@ export const useBlockEditorTableOverlayControllerState = ({
     tableAffordanceGeometryRef,
     tableAffordanceVisibility,
     tableAffordanceVisibilityRef,
+    tableAxisHoverLockUntilRef,
     tableHoverAnchorLockUntilRef,
     tableMenuState,
   }

--- a/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
@@ -17,6 +17,8 @@ const resolveElementsFromPoint = (clientX: number, clientY: number) => {
   return pointElement ? [pointElement] : []
 }
 
+const TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX = 32
+
 type UseBlockEditorTableOverlayDomAdapterArgs = {
   activeTableElementRef: MutableRefObject<HTMLTableElement | null>
   editorRef: MutableRefObject<TiptapEditor | null>
@@ -128,11 +130,46 @@ export const useBlockEditorTableOverlayDomAdapter = ({
       const cells = Array.from(tableElement.querySelectorAll("th, td")).filter(
         (cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement
       )
+      const strictCell = cells.find((cell) => {
+        const rect = cell.getBoundingClientRect()
+        return clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom
+      })
+      if (strictCell) return strictCell
+
+      const tableRect = tableElement.getBoundingClientRect()
+      const isNearTableSurface =
+        clientX >= tableRect.left - TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX &&
+        clientX <= tableRect.right + TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX &&
+        clientY >= tableRect.top - TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX &&
+        clientY <= tableRect.bottom + TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX
+      if (!isNearTableSurface) return null
+
+      const rows = Array.from(tableElement.querySelectorAll("tr")).filter(
+        (row): row is HTMLTableRowElement => row instanceof HTMLTableRowElement && row.cells.length > 0
+      )
+      const firstRowCells = Array.from(rows[0]?.cells ?? []).filter(
+        (cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement
+      )
+      const topAxisCell =
+        clientY <= tableRect.top + TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX
+          ? firstRowCells.find((cell) => {
+              const rect = cell.getBoundingClientRect()
+              return clientX >= rect.left && clientX <= rect.right
+            }) ?? firstRowCells[0] ?? null
+          : null
+      if (topAxisCell) return topAxisCell
+
+      const leftAxisRow =
+        clientX <= tableRect.left + TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX
+          ? rows.find((row) => {
+              const rect = row.getBoundingClientRect()
+              return clientY >= rect.top && clientY <= rect.bottom
+            }) ?? rows[0] ?? null
+          : null
       return (
-        cells.find((cell) => {
-          const rect = cell.getBoundingClientRect()
-          return clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom
-        }) ?? null
+        Array.from(leftAxisRow?.cells ?? []).find(
+          (cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement
+        ) ?? null
       )
     },
     [activeTableElementRef, getTableCellFromTarget, tableAffordanceGeometryRef, viewportRef]

--- a/front/src/components/editor/useBlockEditorTableOverlayUiTimers.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayUiTimers.ts
@@ -1,6 +1,10 @@
 import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from "react"
 import { useCallback, useEffect, useRef, useState } from "react"
-import type { TableAffordanceGeometry, TableAffordanceVisibility } from "./tableAffordanceModel"
+import {
+  INITIAL_TABLE_AFFORDANCE_VISIBILITY,
+  type TableAffordanceGeometry,
+  type TableAffordanceVisibility,
+} from "./tableAffordanceModel"
 import { resolveActiveRenderedTableForFloatingUi } from "./tableRenderedDomModel"
 import {
   TABLE_OVERFLOW_COACHMARK_DISMISS_MS,
@@ -16,6 +20,7 @@ type UseBlockEditorTableOverlayUiTimersArgs = {
   isNarrowTableViewport: boolean
   setTableAffordanceVisibility: Dispatch<SetStateAction<TableAffordanceVisibility>>
   tableAffordanceGeometryRef: MutableRefObject<TableAffordanceGeometry>
+  tableAxisHoverLockUntilRef: MutableRefObject<number>
   viewportRef: RefObject<HTMLDivElement>
 }
 
@@ -27,6 +32,7 @@ export const useBlockEditorTableOverlayUiTimers = ({
   isNarrowTableViewport,
   setTableAffordanceVisibility,
   tableAffordanceGeometryRef,
+  tableAxisHoverLockUntilRef,
   viewportRef,
 }: UseBlockEditorTableOverlayUiTimersArgs) => {
   const tableQuickRailHideTimerRef = useRef<number | null>(null)
@@ -80,12 +86,18 @@ export const useBlockEditorTableOverlayUiTimers = ({
     scheduleTableOverflowCoachmarkHide()
   }, [cornerButtonSize, isCoarsePointer, isNarrowTableViewport, scheduleTableOverflowCoachmarkHide, tableAffordanceGeometryRef, viewportRef])
 
-  const hideTableQuickRailImmediately = useCallback(() => {
-    if (tableQuickRailHideTimerRef.current !== null && typeof window !== "undefined") {
-      window.clearTimeout(tableQuickRailHideTimerRef.current)
-      tableQuickRailHideTimerRef.current = null
-    }
-    setTableAffordanceVisibility((prev) => (prev.visible ? { ...prev, visible: false } : prev))
+  const clearTableQuickRailVisibility = useCallback(() => {
+    setTableAffordanceVisibility((prev) =>
+      prev.visible ||
+      prev.showColumnRail ||
+      prev.showRowRail ||
+      prev.showColumnAddBar ||
+      prev.showRowAddBar ||
+      prev.showCornerControls ||
+      prev.showCellMenu
+        ? INITIAL_TABLE_AFFORDANCE_VISIBILITY
+        : prev
+    )
   }, [setTableAffordanceVisibility])
 
   const cancelTableQuickRailHide = useCallback(() => {
@@ -98,11 +110,40 @@ export const useBlockEditorTableOverlayUiTimers = ({
   const scheduleTableQuickRailHide = useCallback((delayMs = TABLE_QUICK_RAIL_HIDE_DELAY_MS) => {
     cancelTableQuickRailHide()
     if (typeof window === "undefined") return
-    tableQuickRailHideTimerRef.current = window.setTimeout(() => {
-      setTableAffordanceVisibility((prev) => (prev.visible ? { ...prev, visible: false } : prev))
+    const runHide = () => {
+      const now =
+        typeof window.performance !== "undefined"
+          ? window.performance.now()
+          : Date.now()
+      const remainingAxisHoverLockMs = tableAxisHoverLockUntilRef.current - now
+      if (remainingAxisHoverLockMs > 0) {
+        tableQuickRailHideTimerRef.current = window.setTimeout(runHide, remainingAxisHoverLockMs + 16)
+        return
+      }
       tableQuickRailHideTimerRef.current = null
-    }, delayMs)
-  }, [cancelTableQuickRailHide, setTableAffordanceVisibility])
+      clearTableQuickRailVisibility()
+    }
+    tableQuickRailHideTimerRef.current = window.setTimeout(runHide, delayMs)
+  }, [cancelTableQuickRailHide, clearTableQuickRailVisibility, tableAxisHoverLockUntilRef])
+
+  const hideTableQuickRailImmediately = useCallback(() => {
+    const now =
+      typeof window !== "undefined" && typeof window.performance !== "undefined"
+        ? window.performance.now()
+        : Date.now()
+    const remainingAxisHoverLockMs = tableAxisHoverLockUntilRef.current - now
+    if (remainingAxisHoverLockMs > 0) {
+      scheduleTableQuickRailHide(remainingAxisHoverLockMs + 16)
+      return
+    }
+    cancelTableQuickRailHide()
+    clearTableQuickRailVisibility()
+  }, [
+    cancelTableQuickRailHide,
+    clearTableQuickRailVisibility,
+    scheduleTableQuickRailHide,
+    tableAxisHoverLockUntilRef,
+  ])
 
   return {
     cancelTableOverflowCoachmarkHide,


### PR DESCRIPTION
## 관련 이슈

close #561
close #562

## 작업 배경

- `/editor/[id]` 7x3 table에서 row 선택 해제 직후 column hotzone으로 바로 이동하면 column rail이 즉시 사라지는 live 회귀를 복구합니다.
- no-coordinate layout sync와 immediate hide가 table control hover 상태를 덮는 경로를 막고, row/column/add/corner control hover를 짧게 lock해 직접 hover에서도 rail/menu/outline이 남도록 했습니다.

## 작업 내용

- row selection 해제 직후 direct column hotzone hover를 재현하는 7x3 route E2E를 추가했습니다.
- table control hover 중 no-coordinate sync가 visibility를 덮지 않도록 hover anchor/axis lock을 분리했습니다.
- top/left axis hotzone의 cell fallback을 보강해 셀 중심을 경유하지 않는 edge hover에서도 대상 cell을 안정적으로 찾습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts --workers=1 --grep "row 선택 해제"`
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-operations.spec.ts --workers=1 --grep "table row/column grip drag"`
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-affordances.spec.ts --workers=1 --grep "table hover에서도 block selection|desktop table handle"`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts e2e/editor-authoring-route-table-select-all.spec.ts e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-affordances.spec.ts e2e/editor-authoring-table-operations.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke`
  - `git diff --check`
  - `git diff --cached --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table hover hide 타이밍 변경으로 row/column/add/corner control이 이전보다 약 280ms 더 유지될 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋 `fix(editor): 7x3 row-reset column rail 회귀 복구`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
