### PR TITLE
[Fix] 7x3 row reset stale hover 회귀 복구

### DIFF
--- a/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
@@ -53,6 +53,64 @@ test.describe("editor authoring route table axis after select all", () => {
     await expect(editor.locator(".selectedCell")).toHaveCount(7)
   })
 
+  test("실제 /editor/[id] 7x3 table은 row reset 뒤 scroll 보정으로 stale column hotzone에 남아도 열 선택을 연다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1580, height: 900 })
+    const { editor } = await mockEditorRouteWithSevenByThreeTable(page, {
+      postId: 995,
+      title: "7x3 table stale row reset column route 글",
+      lead: "table live lead paragraph",
+      tail: "table live trailing paragraph",
+    })
+    const { columnHandle, rowHandle } = getTableAffordances(page)
+
+    const table = editor.locator("table").first()
+    const targetCell = editor.locator("td", { hasText: "Access Token" }).first()
+    await targetCell.click({ position: { x: 40, y: 16 } })
+    await targetCell.dblclick({ position: { x: 40, y: 16 } })
+    await page.evaluate(() => window.scrollBy(0, 120))
+    await page.waitForTimeout(50)
+
+    const staleTableBox = await table.boundingBox()
+    const staleCellBox = await targetCell.boundingBox()
+    if (!staleTableBox || !staleCellBox) {
+      throw new Error("7x3 route stale row reset metrics are missing")
+    }
+
+    await page.mouse.move(staleTableBox.x + 3, staleCellBox.y + staleCellBox.height / 2)
+    await page.waitForTimeout(140)
+    await expect(rowHandle).toBeVisible()
+    await rowHandle.click()
+    await expect(page.getByTestId("table-row-selection-outline")).toBeVisible()
+    await expect(editor.locator(".selectedCell")).toHaveCount(3)
+
+    await page.keyboard.press("Escape")
+    await targetCell.click({ position: { x: 40, y: 16 } })
+    await page.evaluate(() => {
+      const tableElement = document.querySelector("[data-testid='block-editor-prosemirror'] table")
+      const tableShell = tableElement?.closest(".aq-table-shell, .tableWrapper, table")
+      const spacer = document.createElement("div")
+      spacer.setAttribute("data-testid", "stale-table-shift-spacer")
+      spacer.style.height = "96px"
+      spacer.style.pointerEvents = "none"
+      tableShell?.before(spacer)
+    })
+    await page.waitForTimeout(50)
+    const shiftedTableBox = await table.boundingBox()
+    if (!shiftedTableBox || shiftedTableBox.y - staleTableBox.y < 48) {
+      throw new Error("7x3 route stale row reset scroll shift is missing")
+    }
+    await page.mouse.move(staleCellBox.x + staleCellBox.width / 2, staleTableBox.y + 3)
+    await page.waitForTimeout(180)
+
+    await expect(columnHandle).toBeVisible()
+    await columnHandle.click()
+    await expect(page.getByTestId("table-column-selection-outline")).toBeVisible()
+    await expect(page.getByTestId("table-column-menu")).toBeVisible()
+    await expect(editor.locator(".selectedCell")).toHaveCount(7)
+  })
+
   test("실제 /editor/[id] 7x3 table은 table-wide Cmd/Ctrl+A 직후 column grip을 첫 축 선택으로 연다", async ({
     page,
   }) => {

--- a/front/src/components/editor/tableAffordanceModel.ts
+++ b/front/src/components/editor/tableAffordanceModel.ts
@@ -1,6 +1,7 @@
 export const TABLE_ADD_BAR_VIEWPORT_PADDING_PX = 8
 export const TABLE_EDGE_ADD_BUTTON_SIZE_PX = 24
 export const TABLE_CELL_MENU_BUTTON_SIZE_PX = 22
+export const TABLE_STALE_AXIS_HOTZONE_TOP_MARGIN_PX = 128
 
 export type TableOverlayAnchor = {
   left: number

--- a/front/src/components/editor/useBlockEditorTableOverlayControllerCommands.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayControllerCommands.ts
@@ -35,6 +35,7 @@ const resolveElementsFromPoint = (clientX: number, clientY: number) => {
 }
 
 const TABLE_AXIS_HOVER_LOCK_MS = 280
+const TABLE_STALE_AXIS_HOTZONE_TOP_MARGIN_PX = 128
 
 type UseBlockEditorTableOverlayControllerCommandsArgs = {
   activeTableElementRef: MutableRefObject<HTMLTableElement | null>
@@ -249,7 +250,7 @@ export const useBlockEditorTableOverlayControllerCommands = ({
       hasHoverPoint &&
       Boolean(activeCellRect) &&
       !showCornerControls &&
-      hoverClientY >= visibleTop - TABLE_COLUMN_GRIP_HEIGHT_PX &&
+      hoverClientY >= visibleTop - TABLE_STALE_AXIS_HOTZONE_TOP_MARGIN_PX &&
       hoverClientY <= visibleTop + TABLE_AXIS_RAIL_EDGE_HOTZONE_PX &&
       hoverClientX >= activeColumnLeft &&
       hoverClientX <= activeColumnRight

--- a/front/src/components/editor/useBlockEditorTableOverlayControllerCommands.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayControllerCommands.ts
@@ -5,6 +5,7 @@ import {
   TABLE_ADD_BAR_VIEWPORT_PADDING_PX,
   TABLE_CELL_MENU_BUTTON_SIZE_PX,
   TABLE_EDGE_ADD_BUTTON_SIZE_PX,
+  TABLE_STALE_AXIS_HOTZONE_TOP_MARGIN_PX,
   clampViewportPosition,
   type TableAffordanceGeometry,
 } from "./tableAffordanceModel"
@@ -35,7 +36,6 @@ const resolveElementsFromPoint = (clientX: number, clientY: number) => {
 }
 
 const TABLE_AXIS_HOVER_LOCK_MS = 280
-const TABLE_STALE_AXIS_HOTZONE_TOP_MARGIN_PX = 128
 
 type UseBlockEditorTableOverlayControllerCommandsArgs = {
   activeTableElementRef: MutableRefObject<HTMLTableElement | null>

--- a/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
@@ -18,6 +18,7 @@ const resolveElementsFromPoint = (clientX: number, clientY: number) => {
 }
 
 const TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX = 32
+const TABLE_STALE_AXIS_HOTZONE_CELL_FALLBACK_TOP_MARGIN_PX = 128
 
 type UseBlockEditorTableOverlayDomAdapterArgs = {
   activeTableElementRef: MutableRefObject<HTMLTableElement | null>
@@ -119,9 +120,9 @@ export const useBlockEditorTableOverlayDomAdapter = ({
               const rect = activeTable.getBoundingClientRect()
               const hitTestMargin = 32
               const isInsideActiveTableSurface =
-                clientX >= rect.left - hitTestMargin &&
-                clientX <= rect.right + hitTestMargin &&
-                clientY >= rect.top - hitTestMargin &&
+                clientX >= rect.left &&
+                clientX <= rect.right &&
+                clientY >= rect.top - TABLE_STALE_AXIS_HOTZONE_CELL_FALLBACK_TOP_MARGIN_PX &&
                 clientY <= rect.bottom + hitTestMargin
               return isInsideActiveTableSurface ? activeTable : null
             })()
@@ -140,7 +141,7 @@ export const useBlockEditorTableOverlayDomAdapter = ({
       const isNearTableSurface =
         clientX >= tableRect.left - TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX &&
         clientX <= tableRect.right + TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX &&
-        clientY >= tableRect.top - TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX &&
+        clientY >= tableRect.top - TABLE_STALE_AXIS_HOTZONE_CELL_FALLBACK_TOP_MARGIN_PX &&
         clientY <= tableRect.bottom + TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX
       if (!isNearTableSurface) return null
 

--- a/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
@@ -5,7 +5,7 @@ import { CellSelection, selectedRect, TableMap } from "@tiptap/pm/tables"
 import type { MutableRefObject, RefObject } from "react"
 import { useCallback } from "react"
 import { getFirstEditableTextPositionInNode } from "./blockSelectionModel"
-import type { TableAffordanceGeometry } from "./tableAffordanceModel"
+import { TABLE_STALE_AXIS_HOTZONE_TOP_MARGIN_PX, type TableAffordanceGeometry } from "./tableAffordanceModel"
 import { findActiveRenderedTable, resolveTableScopedSelectedCell } from "./tableRenderedDomModel"
 import { isTableSelectionActive } from "./tableStructureModel"
 
@@ -18,7 +18,6 @@ const resolveElementsFromPoint = (clientX: number, clientY: number) => {
 }
 
 const TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX = 32
-const TABLE_STALE_AXIS_HOTZONE_CELL_FALLBACK_TOP_MARGIN_PX = 128
 
 type UseBlockEditorTableOverlayDomAdapterArgs = {
   activeTableElementRef: MutableRefObject<HTMLTableElement | null>
@@ -122,7 +121,7 @@ export const useBlockEditorTableOverlayDomAdapter = ({
               const isInsideActiveTableSurface =
                 clientX >= rect.left &&
                 clientX <= rect.right &&
-                clientY >= rect.top - TABLE_STALE_AXIS_HOTZONE_CELL_FALLBACK_TOP_MARGIN_PX &&
+                clientY >= rect.top - TABLE_STALE_AXIS_HOTZONE_TOP_MARGIN_PX &&
                 clientY <= rect.bottom + hitTestMargin
               return isInsideActiveTableSurface ? activeTable : null
             })()
@@ -141,7 +140,7 @@ export const useBlockEditorTableOverlayDomAdapter = ({
       const isNearTableSurface =
         clientX >= tableRect.left - TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX &&
         clientX <= tableRect.right + TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX &&
-        clientY >= tableRect.top - TABLE_STALE_AXIS_HOTZONE_CELL_FALLBACK_TOP_MARGIN_PX &&
+        clientY >= tableRect.top - TABLE_STALE_AXIS_HOTZONE_TOP_MARGIN_PX &&
         clientY <= tableRect.bottom + TABLE_AXIS_HOTZONE_CELL_FALLBACK_MARGIN_PX
       if (!isNearTableSurface) return null
 


### PR DESCRIPTION
## 관련 이슈

close #561
close #562

## 작업 배경

- PR #570 merge 후 배포본 2회차 verifier에서 row reset 이후 stale table/cell 좌표 기반 column hotzone이 `column handle did not appear`로 재발한 문제를 복구합니다.
- `/editor/[id]` 7행 3열 route fixture에 row reset 뒤 table 위치가 바뀐 stale hotzone 재현 E2E를 추가하고, table overlay hit-test가 stale top band를 active table의 column axis 후보로 유지하도록 조정했습니다.

## 작업 내용

- row reset 뒤 focus reveal/selection cleanup으로 table 위치가 아래로 밀려도, 이전 column hotzone 좌표에서 column rail/outline/menu가 열리도록 top fallback margin을 확장했습니다.
- active table fallback의 x축은 table 폭 내부로 제한해 table block handle hotzone을 다시 가리지 않도록 했습니다.
- `editor-authoring-route-table-axis-after-select-all`에 7x3 stale row-reset column hotzone 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - RED: `yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts --workers=1 --grep "scroll 보정"` 실패 (`columnHandle.toBeVisible()`)
  - GREEN: `yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts --workers=1 --grep "scroll 보정"`
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-affordances.spec.ts --workers=1 --grep "table hover에서도 block selection"`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts e2e/editor-authoring-route-table-select-all.spec.ts e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-affordances.spec.ts e2e/editor-authoring-table-operations.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke` (57 passed)
  - `yarn --cwd front test:e2e:authoring` 1차: 1 failed / 122 passed, `editor-authoring-route-live-drag-sequence`의 lower code Cmd+A selection empty. 변경 파일과 직접 연결되지 않은 full-suite 타이밍성으로 분류.
  - 재분류: `yarn --cwd front test:e2e e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1 --grep "body selection 뒤 table/code drag"` (1 passed)
  - 재검증: `yarn --cwd front test:e2e:authoring` (123 passed)
  - `git diff --check`
  - `git diff --cached --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: stale top hotzone margin 확대로 table 주변 hover 판정이 넓어질 수 있습니다. x축 fallback을 table 내부로 제한해 block handle hotzone 회귀를 별도 E2E로 막았습니다.
- 롤백 방법: 이 PR의 단일 커밋 `fix(editor): 7x3 row-reset stale hover 회귀 복구`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
