### PR TITLE
[Fix] 7x3 stale active table ref 복구

### DIFF
--- a/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
@@ -111,6 +111,56 @@ test.describe("editor authoring route table axis after select all", () => {
     await expect(editor.locator(".selectedCell")).toHaveCount(7)
   })
 
+  test("실제 /editor/[id] 7x3 table은 stale active DOM ref가 끊겨도 현재 rendered table로 column hotzone을 복구한다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1580, height: 900 })
+    const { editor } = await mockEditorRouteWithSevenByThreeTable(page, {
+      postId: 996,
+      title: "7x3 table disconnected ref stale hotzone route 글",
+      lead: "table live lead paragraph",
+      tail: "table live trailing paragraph",
+    })
+    const { columnHandle } = getTableAffordances(page)
+
+    const table = editor.locator("table").first()
+    const targetCell = editor.locator("td", { hasText: "Access Token" }).first()
+    await targetCell.click({ position: { x: 40, y: 16 } })
+    await targetCell.dblclick({ position: { x: 40, y: 16 } })
+
+    const staleTableBox = await table.boundingBox()
+    const staleCellBox = await targetCell.boundingBox()
+    if (!staleTableBox || !staleCellBox) {
+      throw new Error("7x3 route disconnected ref metrics are missing")
+    }
+
+    await page.mouse.move(staleCellBox.x + staleCellBox.width / 2, staleCellBox.y + staleCellBox.height / 2)
+    await page.waitForTimeout(140)
+    await page.evaluate(() => {
+      const tableElement = document.querySelector("[data-testid='block-editor-prosemirror'] table")
+      const tableShell = tableElement?.closest(".aq-table-shell, .tableWrapper, table")
+      if (!tableShell) throw new Error("table shell is missing")
+      const clone = tableShell.cloneNode(true) as HTMLElement
+      const spacer = document.createElement("div")
+      spacer.setAttribute("data-testid", "stale-active-table-ref-shift-spacer")
+      spacer.style.height = "96px"
+      spacer.style.pointerEvents = "none"
+      tableShell.before(spacer)
+      tableShell.replaceWith(clone)
+    })
+    await page.waitForTimeout(50)
+
+    const shiftedTableBox = await table.boundingBox()
+    if (!shiftedTableBox || shiftedTableBox.y - staleTableBox.y < 48) {
+      throw new Error("7x3 route disconnected ref shift is missing")
+    }
+
+    await page.mouse.move(staleCellBox.x + staleCellBox.width / 2, staleTableBox.y + 3)
+    await page.waitForTimeout(180)
+
+    await expect(columnHandle).toBeVisible()
+  })
+
   test("실제 /editor/[id] 7x3 table은 table-wide Cmd/Ctrl+A 직후 column grip을 첫 축 선택으로 연다", async ({
     page,
   }) => {

--- a/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts
@@ -112,9 +112,11 @@ export const useBlockEditorTableOverlayDomAdapter = ({
           ? tableSurfaceElement
           : (tableSurfaceElement?.querySelector("table") as HTMLTableElement | null) ??
             (() => {
-              const activeTable =
-                activeTableElementRef.current ??
-                findActiveRenderedTable(viewportRef.current, tableAffordanceGeometryRef.current)
+              const activeTable = findActiveRenderedTable(
+                viewportRef.current,
+                tableAffordanceGeometryRef.current,
+                activeTableElementRef.current
+              )
               if (!activeTable?.isConnected) return null
               const rect = activeTable.getBoundingClientRect()
               const hitTestMargin = 32


### PR DESCRIPTION
## 관련 이슈

close #561
close #562

## 작업 배경

- PR #571 배포본에서 남은 `row_reset_column_direct_stale_metrics` 실패를 follow-up으로 막습니다.
- row reset 뒤 이전 table DOM ref가 끊겨도 현재 rendered table fallback으로 column hotzone을 복구합니다.

## 작업 내용

- `getTableCellFromClientPoint`의 active table fallback이 disconnected ref에 막히지 않도록 `findActiveRenderedTable`로 preferred ref 검증을 일원화했습니다.
- `/editor/[id]` 7x3 table E2E에 stale active DOM ref가 끊긴 상태의 column hotzone 복구 케이스를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-table-7x3-selection bash tools/guards/current-task-preflight.sh`
  - `git diff --check`
  - `rg "__aqTable|console\\.log|debugger" front/src/components/editor/useBlockEditorTableOverlayDomAdapter.ts front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts` (no matches; exit 1)
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-select-all.spec.ts e2e/editor-authoring-route-table-axis-after-select-all.spec.ts e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-affordances.spec.ts e2e/editor-authoring-table-operations.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front test:e2e:authoring` failed in pre-existing code block route test: `e2e/editor-authoring-route-live-drag-sequence.spec.ts` expected `createAccessToken(getUser` after code block Cmd+A but selection text was empty. The same failure reproduced after temporarily reverting this PR's DOM adapter change, so it is tracked as a separate code block follow-up, not this table patch.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: stale hover fallback이 table top hotzone을 더 오래 인정하므로, 인접 rich block pointer path와 충돌할 수 있습니다. Existing table/code drag smoke와 table interaction E2E로 확인했습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
