### PR TITLE
[Fix] 7x3 stale metrics column rail 복구

### DIFF
--- a/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
@@ -88,13 +88,12 @@ test.describe("editor authoring route table axis after select all", () => {
     await page.keyboard.press("Escape")
     await targetCell.click({ position: { x: 40, y: 16 } })
     await page.evaluate(() => {
-      const tableElement = document.querySelector("[data-testid='block-editor-prosemirror'] table")
-      const tableShell = tableElement?.closest(".aq-table-shell, .tableWrapper, table")
+      const viewport = document.querySelector("[data-testid='block-editor-viewport']")
       const spacer = document.createElement("div")
       spacer.setAttribute("data-testid", "stale-table-shift-spacer")
       spacer.style.height = "96px"
       spacer.style.pointerEvents = "none"
-      tableShell?.before(spacer)
+      viewport?.before(spacer)
     })
     await page.waitForTimeout(50)
     const shiftedTableBox = await table.boundingBox()

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -8,14 +8,55 @@ import {
 } from "./BlockEditorEngine.layers"
 import { BlockEditorTableOverlayLayer } from "./BlockEditorEngine.tableOverlayLayer"
 import { Shell } from "./BlockEditorEngine.styles"
+import { TABLE_STALE_AXIS_HOTZONE_TOP_MARGIN_PX } from "./tableAffordanceModel"
 import "./tableTextNativeDragGuard"
 import { useBlockEditorEngineController } from "./useBlockEditorEngineController"
 
+const SHELL_TABLE_STALE_AXIS_HOTZONE_BOTTOM_PX = 32
+const RENDERED_TABLE_SELECTOR =
+  ".aq-block-editor__content .tableWrapper table, .aq-block-editor__content table"
+
 const BlockEditorEngine = (props: BlockEditorEngineProps) => {
   const controller = useBlockEditorEngineController(props)
+  const isViewportEventTarget = (target: EventTarget | null) =>
+    target instanceof Element && Boolean(target.closest("[data-testid='block-editor-viewport']"))
+  const isShellStaleTableHotzone = (shell: HTMLElement, clientX: number, clientY: number) => {
+    const viewportRect = shell
+      .querySelector<HTMLElement>("[data-testid='block-editor-viewport']")
+      ?.getBoundingClientRect()
+    if (viewportRect && clientY >= viewportRect.top && clientY <= viewportRect.bottom) return false
+
+    return Array.from(shell.querySelectorAll<HTMLTableElement>(RENDERED_TABLE_SELECTOR)).some((table) => {
+      const rect = table.getBoundingClientRect()
+      return (
+        clientX >= rect.left &&
+        clientX <= rect.right &&
+        clientY >= rect.top - TABLE_STALE_AXIS_HOTZONE_TOP_MARGIN_PX &&
+        clientY <= rect.top + SHELL_TABLE_STALE_AXIS_HOTZONE_BOTTOM_PX
+      )
+    })
+  }
 
   return (
-    <Shell className={props.className}>
+    <Shell
+      className={props.className}
+      onMouseMove={(event) => {
+        if (
+          !isViewportEventTarget(event.target) &&
+          isShellStaleTableHotzone(event.currentTarget, event.clientX, event.clientY)
+        ) {
+          controller.handleViewportMouseMove(event)
+        }
+      }}
+      onPointerMove={(event) => {
+        if (
+          !isViewportEventTarget(event.target) &&
+          isShellStaleTableHotzone(event.currentTarget, event.clientX, event.clientY)
+        ) {
+          controller.handleViewportPointerMove(event)
+        }
+      }}
+    >
       <BlockEditorToolbarLayer
         activeInlineColor={controller.activeInlineColor}
         applyInlineColor={controller.applyInlineColor}


### PR DESCRIPTION
## 관련 이슈

close #561
close #562

## 작업 배경

- `/editor/[id]` 7x3 table에서 row reset 뒤 reset 전 column hotzone 좌표가 ProseMirror viewport 위 Shell 영역에 남으면 column rail hover가 시작되지 않는 회귀를 복구합니다.
- Shell 영역의 stale top-axis hotzone만 기존 viewport hover resolver로 전달해 row/column selection, Cmd/Ctrl+A, table drag 회귀를 함께 유지합니다.

## 작업 내용

- editor Shell의 pointer/mouse move에서 현재 table의 stale top-axis band만 table hover resolver로 전달합니다.
- block handle gutter와 viewport 내부 hover는 기존 경로를 유지하도록 Shell 전달 범위를 제한했습니다.
- 7x3 route E2E의 stale shift 재현을 viewport 밖 Shell 영역으로 이동해 PR #572 배포 실패 조건을 잡도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `CURRENT_TASK_SLUG=editor-table-7x3-selection bash tools/guards/current-task-preflight.sh`
  - RED 확인: `yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts --workers=1` (stale Shell hotzone 보강 후 패치 전 실패)
  - GREEN 확인: `yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-table-affordances.spec.ts -g "table hover에서도 block selection affordance" --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-select-all.spec.ts e2e/editor-authoring-route-table-axis-after-select-all.spec.ts e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts e2e/editor-authoring-table-affordances.spec.ts e2e/editor-authoring-table-operations.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front test:e2e:authoring`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: Shell 영역 hover 전달이 넓으면 block handle/table rail hover가 서로 간섭할 수 있습니다. 전달 범위를 viewport 밖 + 현재 table의 stale top-axis band로 제한했고 관련 affordance 회귀를 통과시켰습니다.
- 롤백 방법: 이 PR의 단일 커밋 `fix(editor): 7x3 stale metrics column rail 복구`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
