### PR TITLE
[Fix] 글수정 코드블록 언어 버튼 capture 복구

### DIFF
--- a/front/e2e/editor-authoring-code-mermaid.spec.ts
+++ b/front/e2e/editor-authoring-code-mermaid.spec.ts
@@ -212,7 +212,52 @@ test.describe("editor authoring code and mermaid blocks", () => {
       )
       .toContain("selectedLanguage")
 
+    await page.evaluate(() => {
+      const originalElementsFromPoint = document.elementsFromPoint.bind(document)
+      Object.defineProperty(document, "elementsFromPoint", {
+        configurable: true,
+        value: (x: number, y: number) => {
+          const elements = originalElementsFromPoint(x, y)
+          const topElement = elements[0]
+          const languageButton =
+            topElement instanceof Element ? topElement.closest("[data-code-block-header='true'] button[aria-haspopup='dialog']") : null
+          const codeShell = languageButton
+            ?.closest("[data-code-block-wrapper='true']")
+            ?.querySelector<HTMLElement>(".aq-code-shell")
+          if (!codeShell || elements.includes(codeShell)) return elements
+          return [topElement, codeShell, ...elements.filter((element) => element !== topElement)].filter(
+            Boolean
+          ) as Element[]
+        },
+      })
+      const diagnosticsWindow = window as typeof window & {
+        __aqCodeLanguagePointerDiagnostics?: Array<{ defaultPrevented: boolean; type: string }>
+      }
+      diagnosticsWindow.__aqCodeLanguagePointerDiagnostics = []
+      const recordLanguageControlPointer = (event: Event) => {
+        const target = event.target instanceof Element ? event.target : null
+        if (!target?.closest("[data-code-block-header='true'] button[aria-haspopup='dialog']")) return
+        diagnosticsWindow.__aqCodeLanguagePointerDiagnostics?.push({
+          defaultPrevented: event.defaultPrevented,
+          type: event.type,
+        })
+      }
+      document.addEventListener("pointerdown", recordLanguageControlPointer, true)
+      document.addEventListener("mousedown", recordLanguageControlPointer, true)
+    })
+
     await codeBlock.getByRole("button", { name: /TypeScript/i }).click()
+
+    const pointerDiagnostics = await page.evaluate(
+      () =>
+        (
+          window as typeof window & {
+            __aqCodeLanguagePointerDiagnostics?: Array<{ defaultPrevented: boolean; type: string }>
+          }
+        ).__aqCodeLanguagePointerDiagnostics ?? []
+    )
+    expect(pointerDiagnostics.map((event) => event.type)).toEqual(["pointerdown", "mousedown"])
+    expect(pointerDiagnostics.some((event) => event.defaultPrevented)).toBe(false)
 
     const languageDialog = page.getByRole("dialog", { name: "코드 언어 선택" })
     await expect(languageDialog).toBeVisible()

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -528,7 +528,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
           <span data-tone="yellow" />
           <span data-tone="green" />
         </CodeWindowDots>
-        <CodeLanguagePicker ref={menuRef}>
+        <CodeLanguagePicker ref={menuRef} data-code-language-control="true">
           <CodeLanguageButton
             type="button"
             aria-haspopup="dialog"

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -7,7 +7,7 @@ import { collapseTableCellTextSelectionToPoint } from "./tableTextCaretModel"
 import { isTableSelectionActive } from "./tableStructureModel"
 import { TABLE_DRAG_SELECTION_TEXT_ATTR, TABLE_DRAG_SELECTION_TEXT_SELECTOR, cancelActiveTableCellTextSelectionPreserves, collapseStaleTableEditorSelection, preserveTableCellTextSelectionAcrossFrames, resolveTableTextCellAtPoint, resolveTableTextSelectionRangeCells, restoreTableCellTextSelectionIfEscaped, selectTableCellTextRange, watchTableCellTextSelectionExternalClear } from "./tableTextSelectionModel"
 import { areFloatingBubbleStatesEqual, hasNativeEditorTextSelection, hideFloatingBubbleState, resolveFloatingBubbleStateFromCoords, resolveHeadingSelectionBubbleState, type FloatingBubbleState } from "./useFloatingBubbleState"
-const CODE_BLOCK_EDITOR_CONTENT_SELECTOR = ".aq-code-editor-content"
+const CODE_BLOCK_EDITOR_CONTENT_SELECTOR = ".aq-code-editor-content", CODE_BLOCK_INTERACTIVE_CONTROL_SELECTOR = "[data-code-language-control='true']"
 const BLOCK_EDITOR_ROOT_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
 const TABLE_TEXT_DRAG_CONTROL_SELECTOR = "[data-table-axis-rail='true'], [data-table-affordance], [data-table-menu-root='true'], [data-table-menu-trigger='true'], [data-testid^='table-column-resize-boundary-'], [data-testid='table-structure-menu-button'], [data-testid='table-corner-handle'], [data-testid='table-corner-grow-handle'], .column-resize-handle"
 type UseBlockEditorEngineSelectionBubbleEffectsArgs = {
@@ -382,6 +382,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       if (!activeEditor) return
       const eventTarget = event.target
       const targetElement = eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
+      if (targetElement?.closest(CODE_BLOCK_INTERACTIVE_CONTROL_SELECTOR)) { codeTextDragStartRef.current = null; nonTableTextDragStartRef.current = null; cancelCodeDragSelectionPreserve(); return }
       const pointElements = document.elementsFromPoint(event.clientX, event.clientY)
       const codeShellTarget = findCodeShellTarget(targetElement, pointElements)
       const existingSelectionText = window.getSelection()?.toString().trim() ?? "", existingCodeSelectionText = resolveCurrentCodeSelectionText(codeShellTarget)
@@ -432,6 +433,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       if (!activeEditor) return
       const eventTarget = event.target
       const targetElement = eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null
+      if (targetElement?.closest(CODE_BLOCK_INTERACTIVE_CONTROL_SELECTOR)) { codeTextDragStartRef.current = null; nonTableTextDragStartRef.current = null; cancelCodeDragSelectionPreserve(); return }
       const pointElements = document.elementsFromPoint(event.clientX, event.clientY), codeShellTarget = findCodeShellTarget(targetElement, pointElements), existingSelectionText = window.getSelection()?.toString().trim() ?? "", existingCodeSelectionText = resolveCurrentCodeSelectionText(codeShellTarget)
       const allowTableControlCellFallback = Boolean(existingSelectionText) && !isTableSelectionActive(activeEditor), targetTableControl = targetElement?.closest(TABLE_TEXT_DRAG_CONTROL_SELECTOR)
       const pointInsideEditor = !targetElement?.closest("[data-table-menu-root='true']") && (!targetTableControl || allowTableControlCellFallback) && pointElements.some((element) => Boolean(element.closest(BLOCK_EDITOR_ROOT_SELECTOR))), insideEditorDom = eventTarget instanceof Node && (activeEditor.view.dom.contains(eventTarget) || Boolean(targetElement?.closest(BLOCK_EDITOR_ROOT_SELECTOR)) || pointInsideEditor), columnResizeTarget = targetElement?.closest(".column-resize-handle"), tableTextDragStart = insideEditorDom && !codeShellTarget ? tableTextDragStartRef.current ?? rememberTableTextDragStart(event, allowTableControlCellFallback) : null


### PR DESCRIPTION
## 관련 이슈

close #565

## 작업 배경

- `/editor/[id]` 코드 블록 언어 버튼 클릭이 전역 code-drag capture에 삼켜지는 조건을 수정합니다.
- `document.elementsFromPoint()`가 언어 버튼 아래 `.aq-code-shell`을 함께 반환하는 실제 브라우저 hit-test 조건을 E2E 회귀로 고정했습니다.

## 작업 내용

- 코드 블록 언어 선택 wrapper에 `data-code-language-control` 식별자를 추가했습니다.
- document-level pointer/mousedown capture가 언어 선택 컨트롤을 code shell drag surface로 오판하지 않도록 예외 처리했습니다.
- 실제 수정 route 언어 선택 테스트에 pointer/mousedown 전파 진단과 `elementsFromPoint()` shell overlap 재현 조건을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-code-mermaid.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front test:e2e:perf`
  - `yarn --cwd front test:e2e:a11y`
  - `yarn --cwd front test:e2e:authoring`은 2회 모두 서로 다른 단일 테스트 flake로 실패했습니다. 실패한 두 테스트는 각각 동일 워커/동일 Playwright 설정의 격리 실행에서 PASS했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 전역 selection/drag capture 경계 변경으로 코드 블록 드래그/테이블 선택 상호작용에 간접 영향이 있을 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 기존 capture 동작으로 복구됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
