### PR TITLE
[Fix] 수정 화면 focused code fence 복구

### DIFF
--- a/front/e2e/editor-load-sync-guard.spec.ts
+++ b/front/e2e/editor-load-sync-guard.spec.ts
@@ -134,4 +134,44 @@ test.describe("editor load sync guard", () => {
 
     expect(afterUserEdit.changed).toBe(false)
   })
+
+  test("초기 focused synthetic code fence 손실은 사용자 편집으로 보지 않고 expected body로 복구한다", () => {
+    const nowMs = 5_000
+    const expectedBody = [
+      "초기 focused 복구 대상입니다.",
+      "",
+      "```ts",
+      "const token = createAccessToken(user)",
+      "console.log(token)",
+      "```",
+    ].join("\n")
+    const staleUpdate = [
+      "초기 focused 복구 대상입니다.",
+      "",
+      "```ts",
+      "```",
+    ].join("\n")
+    const guard = createBlockEditorLoadGuardState(expectedBody, nowMs, 1_200)
+
+    const restored = restoreBlockEditorCodeLossUpdate({
+      nextMarkdown: staleUpdate,
+      currentMarkdown: expectedBody,
+      guardState: guard,
+      editorFocused: true,
+      nowMs: nowMs + 300,
+    })
+
+    expect(restored.changed).toBe(true)
+    expect(restored.markdown).toContain("createAccessToken(user)")
+
+    const focusedUserEditAfterHold = restoreBlockEditorCodeLossUpdate({
+      nextMarkdown: staleUpdate,
+      currentMarkdown: expectedBody,
+      guardState: guard,
+      editorFocused: true,
+      nowMs: nowMs + 3_000,
+    })
+
+    expect(focusedUserEditAfterHold.changed).toBe(false)
+  })
 })

--- a/front/src/routes/Admin/editorLoadSyncGuard.ts
+++ b/front/src/routes/Admin/editorLoadSyncGuard.ts
@@ -85,11 +85,21 @@ export const restoreBlockEditorCodeLossUpdate = ({
   editorFocused?: boolean
   nowMs?: number
 }) => {
-  if (editorFocused || !guardState.expectedBody) {
+  if (!guardState.expectedBody) {
     return { markdown: nextMarkdown, changed: false }
   }
 
   const normalizedCurrent = normalizeEditorMarkdown(currentMarkdown ?? guardState.expectedBody)
+  const isInitialFocusedSyntheticUpdate =
+    editorFocused &&
+    !guardState.ignoredInitialEmpty &&
+    nowMs <= guardState.ignoreUntilMs &&
+    normalizedCurrent === guardState.expectedBody
+
+  if (editorFocused && !isInitialFocusedSyntheticUpdate) {
+    return { markdown: nextMarkdown, changed: false }
+  }
+
   if (nowMs > guardState.ignoreUntilMs && normalizedCurrent !== guardState.expectedBody) {
     return { markdown: nextMarkdown, changed: false }
   }


### PR DESCRIPTION
## 관련 이슈

close #552

## 작업 배경

- `/editor/[id]` 초기 로드 중 focused synthetic update가 빈 fenced code block을 보내도 서버 baseline의 코드 본문을 유지하도록 load guard를 보강했습니다.
- 실제 focused user edit는 hold window 밖에서 계속 복구 대상에서 제외해 사용자 편집을 덮지 않습니다.

## 작업 내용

- `restoreBlockEditorCodeLossUpdate`에서 `editorFocused=true`를 무조건 복구 제외하지 않고, guard hold window 안에서 current markdown이 baseline과 같은 초기 synthetic update만 복구합니다.
- focused 초기 code-loss regression 테스트를 추가해 기존 조기 반환 회귀를 RED/GREEN으로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-load-sync-guard.spec.ts --workers=1` (RED 확인 후 GREEN)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-code-recovery.spec.ts --workers=1`
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front test:e2e:perf`
  - `yarn --cwd front test:e2e:a11y`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 초기 로드 guard hold window 안에서만 복구 조건이 넓어지므로, guard window 안의 특수한 focused 이벤트 분류에 영향을 줄 수 있습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert하면 기존 `editorFocused=true` 조기 반환 동작으로 복귀합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
