### PR TITLE
[Test] cell menu CI flake 고정

### DIFF
--- a/front/e2e/editor-authoring-table-structure.spec.ts
+++ b/front/e2e/editor-authoring-table-structure.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test"
+import type { Locator, Page } from "@playwright/test"
 import {
   QA_ENGINE_ROUTE,
   getTableAffordances,
@@ -6,6 +7,22 @@ import {
   selectWordInEditable,
   setWordSelectionInEditable,
 } from "./helpers/editorAuthoringFlow"
+
+const openCellMenuForCell = async (page: Page, cell: Locator) => {
+  const { cellMenuButton } = getTableAffordances(page)
+  const cellMenu = page.getByTestId("table-cell-menu")
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await cell.click()
+    await cell.hover()
+    await expect(cellMenuButton).toBeVisible()
+    await cellMenuButton.click()
+    await page.waitForTimeout(80)
+    if (await cellMenu.isVisible().catch(() => false)) return cellMenu
+  }
+
+  throw new Error("table cell menu did not open for active cell")
+}
 
 test.describe("editor authoring table structure and styles", () => {
   test("모바일 뷰포트에서는 표만 wrapper 내부 가로 스크롤을 사용하고 페이지 전체 overflow는 생기지 않는다", async ({
@@ -505,16 +522,10 @@ test.describe("editor authoring table structure and styles", () => {
 
   test("table cell menu는 셀 스타일만 포함하고 구조 액션 없이 정렬/배경을 저장한다", async ({ page }) => {
     await page.goto(QA_ENGINE_ROUTE)
-    const { cellMenuButton } = getTableAffordances(page)
 
     await page.getByRole("button", { name: "테이블" }).click()
     const firstTableCell = page.locator("table th, table td").first()
-    await firstTableCell.click()
-    await firstTableCell.hover()
-
-    await cellMenuButton.click()
-
-    const cellMenu = page.getByTestId("table-cell-menu")
+    const cellMenu = await openCellMenuForCell(page, firstTableCell)
     await expect(cellMenu).toBeVisible()
     await expect(cellMenu.getByRole("button", { name: "좌측" })).toBeVisible()
     await expect(cellMenu.getByRole("button", { name: "가운데" })).toBeVisible()
@@ -525,11 +536,17 @@ test.describe("editor authoring table structure and styles", () => {
     await expect(cellMenu.getByRole("button", { name: "표 삭제" })).toHaveCount(0)
 
     await cellMenu.getByRole("button", { name: "가운데" }).click()
-    await cellMenu.getByRole("button", { name: "노랑 배경" }).click()
-
     await expect
       .poll(async () => (await page.getByTestId("qa-markdown-output").textContent()) || "")
       .toContain('"align":"center"')
+
+    const refreshedCellMenu = page.getByTestId("table-cell-menu")
+    if (!(await refreshedCellMenu.isVisible().catch(() => false))) {
+      await openCellMenuForCell(page, firstTableCell)
+    }
+    const yellowBackgroundButton = page.getByTestId("table-cell-menu").getByRole("button", { name: "노랑 배경" })
+    await expect(yellowBackgroundButton).toBeVisible()
+    await yellowBackgroundButton.click()
     await expect
       .poll(async () => (await page.getByTestId("qa-markdown-output").textContent()) || "")
       .toContain('"backgroundColor":"#fef3c7"')


### PR DESCRIPTION
## 관련 이슈

close #577

## 작업 배경

- PR #578 merge 후 main CI에서 실패한 `table-cell-menu` authoring flake를 후속으로 고정했습니다.
- cell menu open을 active cell hover/click 기준으로 재시도하고, 정렬 클릭 뒤 메뉴 re-render가 끝난 다음 배경 swatch를 새 locator로 클릭하도록 테스트를 안정화했습니다.

## 작업 내용

- `editor-authoring-table-structure.spec.ts`에 `openCellMenuForCell` helper를 추가했습니다.
- cell style menu 테스트에서 align 적용 후 markdown 반영을 기다린 뒤 background 버튼을 다시 조회하도록 바꿨습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-table-structure.spec.ts --workers=1 -g "table cell menu는 셀 스타일만" --repeat-each=10`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-table-structure.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: production 코드는 변경하지 않았고, 테스트의 메뉴 열기/클릭 안정화만 포함합니다.
- 롤백 방법: 이 PR의 단일 커밋 `test(editor): cell menu ci flake 고정`을 revert합니다.
- 배포 경로: `main` merge 후 기존 홈서버 CD workflow가 자동 실행됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
