### PR TITLE
[Fix] 507 코드블럭 초기 코드 표시 지연 제거

### DIFF
--- a/front/e2e/editor-authoring-route-code-initial-render.spec.ts
+++ b/front/e2e/editor-authoring-route-code-initial-render.spec.ts
@@ -1,0 +1,325 @@
+import { expect, test, type Page } from "@playwright/test"
+import { mockAvatarAsset } from "./helpers/smokeFixtures"
+import { POST_507_TITLE } from "./helpers/post507Fixtures"
+import { resolveMarkdownRenderModel } from "src/libs/markdown/rendering"
+
+type InitialCodeSnapshot = {
+  stage: string
+  elapsedMs: number
+  codeText: string
+  lineCount: number
+  shellText: string
+}
+
+const javaLoginCode = [
+  "public Token login(User user) {",
+  "",
+  "    String access = createAccessToken(user);   // 짧게",
+  "    String refresh = createRefreshToken(user); // 길게",
+  "",
+  "    saveRefreshToken(user.getId(), refresh);",
+  "",
+  "    return new Token(access, refresh);",
+  "}",
+].join("\n")
+
+const mermaidSequenceCode = [
+  "sequenceDiagram",
+  "    participant Client",
+  "    participant Server",
+  "    Client->>Server: 로그인",
+].join("\n")
+
+const escapeHtmlAttribute = (value: string) =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("\n", "&#10;")
+
+const buildPost507CopiedCodeHtml = () => {
+  const rawCodeAttribute = escapeHtmlAttribute(javaLoginCode)
+  const emptyLines = javaLoginCode
+    .split("\n")
+    .map(() => '<span data-line class="line"></span>')
+    .join("")
+
+  return [
+    "<h2>구현 예시</h2>",
+    "<h3>로그인</h3>",
+    '<div class="aq-code-block">',
+    '<div class="aq-code-toolbar"><span class="aq-code-language">JAVA</span></div>',
+    '<div class="aq-code-body"><div class="aq-code-shell">',
+    '<pre class="aq-code aq-pretty-pre">',
+    `<code class="language-java" data-language="java" data-prism-language="java" data-prism-source="${rawCodeAttribute}" data-raw-code="${rawCodeAttribute}">${emptyLines}</code>`,
+    "</pre>",
+    "</div></div>",
+    "</div>",
+  ].join("")
+}
+
+const buildPost507WrapperRawCodeHtml = () => {
+  const rawCodeAttribute = escapeHtmlAttribute(javaLoginCode)
+  const emptyLines = javaLoginCode
+    .split("\n")
+    .map(() => '<span data-line class="line"></span>')
+    .join("")
+
+  return [
+    "<h2>구현 예시</h2>",
+    "<h3>로그인</h3>",
+    `<div class="aq-code-block" data-language="java" data-raw-code="${rawCodeAttribute}">`,
+    '<div class="aq-code-toolbar"><span class="aq-code-language">JAVA</span></div>',
+    '<div class="aq-code-body"><div class="aq-code-shell">',
+    '<pre class="aq-code aq-pretty-pre">',
+    `<code class="language-java">${emptyLines}</code>`,
+    "</pre>",
+    "</div></div>",
+    "</div>",
+  ].join("")
+}
+
+const buildWrapperRawMermaidHtml = () => {
+  const rawCodeAttribute = escapeHtmlAttribute(mermaidSequenceCode)
+  const emptyLines = mermaidSequenceCode
+    .split("\n")
+    .map(() => '<span data-line class="line"></span>')
+    .join("")
+
+  return [
+    `<div class="aq-code-block" data-language="mermaid" data-raw-code="${rawCodeAttribute}">`,
+    '<div class="aq-code-body"><div class="aq-code-shell">',
+    '<pre class="aq-code aq-pretty-pre">',
+    `<code class="language-mermaid">${emptyLines}</code>`,
+    "</pre>",
+    "</div></div>",
+    "</div>",
+  ].join("")
+}
+
+const extractVisibleHtmlText = (html: string) =>
+  html
+    .replace(/<[^>]*>/g, "")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, "\"")
+    .replace(/&#39;/g, "'")
+    .replace(/&#10;/g, "\n")
+
+const emptyJavaFenceContent = [
+  "## **구현 예시 **",
+  "",
+  "### **로그인**",
+  "",
+  "```java",
+  "```",
+].join("\n")
+
+const installInitialCodeSnapshotProbe = async (page: Page) => {
+  await page.addInitScript(() => {
+    const windowWithSnapshots = window as typeof window & {
+      __aqInitialCodeSnapshots?: InitialCodeSnapshot[]
+    }
+    const startedAt = performance.now()
+    windowWithSnapshots.__aqInitialCodeSnapshots = []
+
+    const capture = (stage: string) => {
+      const shell = document.querySelector<HTMLElement>(".aq-code-shell")
+      if (!shell) return
+
+      const detailCode = shell.querySelector<HTMLElement>("pre > code")
+      const editorHighlight = shell.querySelector<HTMLElement>(".aq-code-highlight-layer")
+      const editorContent = shell.querySelector<HTMLElement>(".aq-code-editor-content")
+      const codeText = detailCode?.textContent || editorHighlight?.textContent || editorContent?.textContent || ""
+      const lineCount =
+        detailCode?.querySelectorAll("[data-line]").length ||
+        editorHighlight?.querySelectorAll("[data-line]").length ||
+        shell.querySelectorAll("[data-line]").length
+
+      windowWithSnapshots.__aqInitialCodeSnapshots?.push({
+        stage,
+        elapsedMs: Math.round(performance.now() - startedAt),
+        shellText: shell.textContent || "",
+        codeText,
+        lineCount,
+      })
+    }
+
+    let frameCount = 0
+    const captureFrame = () => {
+      capture(`raf:${frameCount}`)
+      frameCount += 1
+      if (frameCount < 30) window.requestAnimationFrame(captureFrame)
+    }
+    window.requestAnimationFrame(captureFrame)
+
+    const interval = window.setInterval(() => capture("interval"), 8)
+    const observer = new MutationObserver(() => capture("mutation"))
+    const startObserver = () => {
+      const root = document.documentElement || document.body
+      if (!root) return
+      observer.observe(root, { childList: true, subtree: true })
+    }
+    if (document.documentElement || document.body) {
+      startObserver()
+    } else {
+      document.addEventListener("DOMContentLoaded", startObserver, { once: true })
+    }
+    window.setTimeout(() => {
+      observer.disconnect()
+      window.clearInterval(interval)
+    }, 3_000)
+  })
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockAvatarAsset(page)
+})
+
+test.describe("editor authoring route code initial render", () => {
+  test("contentHtml-only 렌더 모델은 data-raw-code만 있는 507 코드블럭도 visible text로 채운다", () => {
+    const renderModel = resolveMarkdownRenderModel({
+      content: "",
+      contentHtml: buildPost507CopiedCodeHtml(),
+    })
+    const visibleText = extractVisibleHtmlText(renderModel.resolvedContentHtml)
+
+    expect(visibleText).toContain("public Token login(User user)")
+    expect(visibleText).toContain("createAccessToken(user)")
+    expect(visibleText).toContain("return new Token(access, refresh);")
+  })
+
+  test("contentHtml-only 렌더 모델은 wrapper data-raw-code도 visible text로 채운다", () => {
+    const renderModel = resolveMarkdownRenderModel({
+      content: "",
+      contentHtml: buildPost507WrapperRawCodeHtml(),
+    })
+    const visibleText = extractVisibleHtmlText(renderModel.resolvedContentHtml)
+
+    expect(visibleText).toContain("public Token login(User user)")
+    expect(visibleText).toContain("createAccessToken(user)")
+    expect(visibleText).toContain("return new Token(access, refresh);")
+  })
+
+  test("contentHtml-only 렌더 모델은 wrapper data-raw-code mermaid를 초기 mermaid block으로 채운다", () => {
+    const renderModel = resolveMarkdownRenderModel({
+      content: "",
+      contentHtml: buildWrapperRawMermaidHtml(),
+    })
+    const visibleText = extractVisibleHtmlText(renderModel.resolvedContentHtml)
+
+    expect(renderModel.resolvedContentHtml).toContain('data-aq-mermaid="true"')
+    expect(visibleText).toContain("sequenceDiagram")
+    expect(visibleText).toContain("Client->>Server: 로그인")
+  })
+
+  test("browser contentHtml 코드블럭은 escaped numeric entity literal을 tag text로 재해석하지 않는다", async ({
+    page,
+  }) => {
+    const escapedNumericLiteralHtml =
+      '<pre class="aq-code aq-pretty-pre"><code class="language-text">&amp;#60;not-tag&amp;#62;</code></pre>'
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 1,
+          username: "qa-admin",
+          nickname: "aquila",
+          isAdmin: true,
+        }),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/585", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 585,
+          version: 1,
+          title: POST_507_TITLE,
+          content: "",
+          contentHtml: escapedNumericLiteralHtml,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+    await page.route("**/post/api/v1/posts/585", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          content: "",
+          contentHtml: escapedNumericLiteralHtml,
+        }),
+      })
+    })
+
+    await page.goto("/editor/585")
+    await expect(page.locator(".aq-code-shell").first()).toContainText("&#60;not-tag&#62;")
+    await expect(page.locator(".aq-code-shell").first()).not.toContainText("<not-tag>")
+  })
+
+  test("507 contentHtml 코드블럭은 첫 DOM snapshot부터 raw code text를 표시한다", async ({
+    page,
+  }) => {
+    await installInitialCodeSnapshotProbe(page)
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 1,
+          username: "qa-admin",
+          nickname: "aquila",
+          isAdmin: true,
+        }),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/584", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 584,
+          version: 1,
+          title: POST_507_TITLE,
+          content: emptyJavaFenceContent,
+          contentHtml: buildPost507CopiedCodeHtml(),
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+    await page.route("**/post/api/v1/posts/584", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          content: emptyJavaFenceContent,
+          contentHtml: buildPost507CopiedCodeHtml(),
+        }),
+      })
+    })
+
+    await page.goto("/editor/584")
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(POST_507_TITLE)
+    await expect(page.locator(".aq-code-shell").first()).toBeVisible()
+
+    const snapshots = await page.evaluate(() => {
+      const windowWithSnapshots = window as typeof window & {
+        __aqInitialCodeSnapshots?: InitialCodeSnapshot[]
+      }
+      return windowWithSnapshots.__aqInitialCodeSnapshots || []
+    })
+    const firstCodeSnapshot = snapshots.find((snapshot) => snapshot.lineCount > 0)
+
+    expect(firstCodeSnapshot, JSON.stringify(snapshots.slice(0, 8), null, 2)).toBeTruthy()
+    expect(firstCodeSnapshot?.codeText).toContain("createAccessToken(user)")
+    expect(firstCodeSnapshot?.shellText).toContain("return new Token(access, refresh);")
+  })
+})

--- a/front/src/libs/markdown/renderingHtmlModel.ts
+++ b/front/src/libs/markdown/renderingHtmlModel.ts
@@ -2,6 +2,7 @@ import {
   extractNormalizedMermaidSource,
   normalizeEscapedMermaidFences,
 } from "src/libs/markdown/mermaid"
+import { renderImmediateCodeToHtml } from "src/libs/markdown/prismRuntime"
 
 const MERMAID_SOURCE_PATTERN =
   /^(%%\{|\s*(?:info|flowchart|graph|sequenceDiagram|classDiagram|stateDiagram(?:-v2)?|erDiagram|journey|gantt|pie|mindmap|timeline|gitGraph|quadrantChart|requirementDiagram|c4Context|C4Context|xychart-beta)\b)/
@@ -15,6 +16,10 @@ const HTML_ENTITY_MAP: Record<string, string> = {
   "#x27": "'",
   apos: "'",
 }
+
+const HTML_ATTRIBUTE_REGEX = /([^\s=\/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g
+const HTML_CODE_BLOCK_REGEX = /<pre\b([^>]*)>\s*<code\b([^>]*)>([\s\S]*?)<\/code>\s*<\/pre>/gi
+const HTML_CODE_CONTAINER_OPEN_REGEX = /<(div|section|figure)\b([^>]*)>/gi
 
 const HAS_FENCED_CODE_BLOCK_REGEX = /(^|\n)\s*[`~]{3,}[\w-]*[\t ]*\n[\s\S]*?\n[`~]{3,}(?=\n|$)/
 const HAS_MERMAID_BLOCK_REGEX = /(^|\n)\s*[`~]{3,}\s*mermaid\b[\t ]*\n[\s\S]*?\n[`~]{3,}(?=\n|$)/i
@@ -50,10 +55,19 @@ const hasMermaidConnectorOrKeyword = (source: string) => {
   return connectorTokens.some((token) => containsTokenByCharCodes(normalized, token))
 }
 
+const decodeHtmlEntitiesOnce = (raw: string) =>
+  raw.replace(/&(lt|gt|amp|quot|#39|#x27|apos|#\d+|#x[0-9a-f]+);/gi, (entity, key: string) => {
+    const normalizedKey = key.toLowerCase()
+    if (normalizedKey.startsWith("#x")) {
+      const codePoint = Number.parseInt(normalizedKey.slice(2), 16)
+      return decodeHtmlCodePoint(entity, codePoint)
+    }
+    if (normalizedKey.startsWith("#")) {
+      const codePoint = Number.parseInt(normalizedKey.slice(1), 10)
+      return decodeHtmlCodePoint(entity, codePoint)
+    }
 
-const decodeBasicHtmlEntities = (raw: string) =>
-  raw.replace(/&(lt|gt|amp|quot|#39|#x27|apos);/gi, (entity, key: string) => {
-    const decoded = HTML_ENTITY_MAP[key.toLowerCase()]
+    const decoded = HTML_ENTITY_MAP[normalizedKey]
     return decoded ?? entity
   })
 
@@ -66,6 +80,14 @@ const escapeHtml = (raw: string) =>
     .replaceAll("'", "&#39;")
 
 const escapeHtmlAttribute = (raw: string) => escapeHtml(raw).replaceAll("\n", "&#10;")
+
+const renderMermaidPre = (source: string) =>
+  `<pre class="aq-mermaid" data-aq-mermaid="true" data-mermaid-rendered="pending" data-mermaid-source="${escapeHtmlAttribute(source)}"><code class="language-mermaid">${escapeHtml(source)}</code></pre>`
+
+const decodeHtmlCodePoint = (entity: string, codePoint: number) =>
+  Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+    ? String.fromCodePoint(codePoint)
+    : entity
 
 const BLOCK_BREAK_TAGS = new Set(["p", "div", "li", "tr", "h1", "h2", "h3", "h4", "h5", "h6"])
 
@@ -132,7 +154,7 @@ const extractPlainTextByHtmlScanner = (rawHtml: string) => {
 
 const extractPlainTextFromHtml = (rawHtml: string) => {
   if (!rawHtml) return ""
-  if (!rawHtml.includes("<")) return decodeBasicHtmlEntities(rawHtml)
+  if (!rawHtml.includes("<")) return decodeHtmlEntitiesOnce(rawHtml)
 
   if (typeof window !== "undefined" && typeof window.DOMParser !== "undefined") {
     const parser = new window.DOMParser()
@@ -141,10 +163,10 @@ const extractPlainTextFromHtml = (rawHtml: string) => {
     doc.querySelectorAll("br").forEach((br) => br.replaceWith("\n"))
     doc.querySelectorAll("p,div,li,tr,h1,h2,h3,h4,h5,h6").forEach((el) => el.append("\n"))
 
-    return decodeBasicHtmlEntities(doc.body.textContent || "")
+    return doc.body.textContent || ""
   }
 
-  return decodeBasicHtmlEntities(extractPlainTextByHtmlScanner(rawHtml))
+  return decodeHtmlEntitiesOnce(extractPlainTextByHtmlScanner(rawHtml))
 }
 
 const extractMermaidSource = (rawCode: string) => {
@@ -168,7 +190,7 @@ const normalizeMermaidCodeBlocksInHtml = (html: string) =>
     if (!hasMermaidClass && !looksLikeMermaid) return full
     if (!source) return full
 
-    return `<pre class="aq-mermaid" data-aq-mermaid="true" data-mermaid-rendered="pending" data-mermaid-source="${escapeHtmlAttribute(source)}"><code class="language-mermaid">${escapeHtml(source)}</code></pre>`
+    return renderMermaidPre(source)
   })
 
 const normalizeMermaidParagraphsInHtml = (html: string) =>
@@ -185,7 +207,7 @@ const normalizeMermaidParagraphsInHtml = (html: string) =>
     if (!hasMermaidFence && !looksLikeMermaid) return full
     if (!source) return full
 
-    return `<pre class="aq-mermaid" data-aq-mermaid="true" data-mermaid-rendered="pending" data-mermaid-source="${escapeHtmlAttribute(source)}"><code class="language-mermaid">${escapeHtml(source)}</code></pre>`
+    return renderMermaidPre(source)
   })
 
 const normalizeStandaloneMermaidPreBlocksInHtml = (html: string) =>
@@ -206,13 +228,148 @@ const normalizeStandaloneMermaidPreBlocksInHtml = (html: string) =>
     if (!hasMermaidHint && !looksLikeMermaid) return full
     if (!source) return full
 
-    return `<pre class="aq-mermaid" data-aq-mermaid="true" data-mermaid-rendered="pending" data-mermaid-source="${escapeHtmlAttribute(source)}"><code class="language-mermaid">${escapeHtml(source)}</code></pre>`
+    return renderMermaidPre(source)
+  })
+
+const readHtmlAttribute = (rawAttrs: string, name: string) => {
+  const normalizedName = name.toLowerCase()
+  HTML_ATTRIBUTE_REGEX.lastIndex = 0
+
+  let match: RegExpExecArray | null
+  while ((match = HTML_ATTRIBUTE_REGEX.exec(rawAttrs))) {
+    if (match[1]?.toLowerCase() !== normalizedName) continue
+    return decodeHtmlEntitiesOnce(match[2] ?? match[3] ?? match[4] ?? "")
+  }
+
+  return ""
+}
+
+const stripHtmlAttributes = (rawAttrs: string, names: Set<string>) => {
+  HTML_ATTRIBUTE_REGEX.lastIndex = 0
+  return rawAttrs
+    .replace(HTML_ATTRIBUTE_REGEX, (full, rawName: string) => (names.has(rawName.toLowerCase()) ? "" : full))
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+const mergeClassNames = (...classNames: string[]) => {
+  const tokens = new Set<string>()
+  for (const className of classNames) {
+    className
+      .split(/\s+/)
+      .map((token) => token.trim())
+      .filter(Boolean)
+      .forEach((token) => tokens.add(token))
+  }
+  return Array.from(tokens).join(" ")
+}
+
+const countHtmlTags = (source: string, tagName: string, closing: boolean) => {
+  const pattern = new RegExp(closing ? `</${tagName}\\s*>` : `<${tagName}\\b`, "gi")
+  return source.match(pattern)?.length ?? 0
+}
+
+const extractNearestCodeContainerAttrs = (html: string, preOffset: number) => {
+  const prefix = html.slice(0, preOffset)
+  const candidates: Array<{ attrs: string; index: number; tagName: string }> = []
+  HTML_CODE_CONTAINER_OPEN_REGEX.lastIndex = 0
+
+  let match: RegExpExecArray | null
+  while ((match = HTML_CODE_CONTAINER_OPEN_REGEX.exec(prefix))) {
+    candidates.push({
+      attrs: match[2] || "",
+      index: match.index,
+      tagName: (match[1] || "").toLowerCase(),
+    })
+  }
+
+  for (let index = candidates.length - 1; index >= 0; index -= 1) {
+    const candidate = candidates[index]
+    if (
+      !readHtmlAttribute(candidate.attrs, "data-raw-code") &&
+      !readHtmlAttribute(candidate.attrs, "data-prism-source")
+    ) {
+      continue
+    }
+
+    const segment = prefix.slice(candidate.index)
+    const openCount = countHtmlTags(segment, candidate.tagName, false)
+    const closeCount = countHtmlTags(segment, candidate.tagName, true)
+    if (openCount > closeCount) return candidate.attrs
+  }
+
+  return ""
+}
+
+const extractCodeLanguageFromAttrs = (rawPreAttrs: string, rawCodeAttrs: string, rawContainerAttrs: string) => {
+  const explicitLanguage =
+    readHtmlAttribute(rawCodeAttrs, "data-language") ||
+    readHtmlAttribute(rawCodeAttrs, "data-prism-language") ||
+    readHtmlAttribute(rawPreAttrs, "data-language") ||
+    readHtmlAttribute(rawPreAttrs, "data-prism-language") ||
+    readHtmlAttribute(rawContainerAttrs, "data-language") ||
+    readHtmlAttribute(rawContainerAttrs, "data-prism-language")
+  if (explicitLanguage) return explicitLanguage
+
+  const className = `${readHtmlAttribute(rawCodeAttrs, "class")} ${readHtmlAttribute(rawPreAttrs, "class")} ${readHtmlAttribute(rawContainerAttrs, "class")}`
+  return className.match(/(?:^|\s)language-([\w-]+)/)?.[1] || "text"
+}
+
+const extractCodeSourceFromHtmlBlock = (rawPreAttrs: string, rawCodeAttrs: string, rawContainerAttrs: string, rawCodeBody: string) =>
+  readHtmlAttribute(rawCodeAttrs, "data-raw-code") ||
+  readHtmlAttribute(rawCodeAttrs, "data-prism-source") ||
+  readHtmlAttribute(rawPreAttrs, "data-raw-code") ||
+  readHtmlAttribute(rawPreAttrs, "data-prism-source") ||
+  readHtmlAttribute(rawContainerAttrs, "data-raw-code") ||
+  readHtmlAttribute(rawContainerAttrs, "data-prism-source") ||
+  extractPlainTextFromHtml(rawCodeBody)
+
+const normalizeContentHtmlCodeBlocks = (html: string) =>
+  html.replace(HTML_CODE_BLOCK_REGEX, (full, rawPreAttrs, rawCodeAttrs, rawCodeBody, offset) => {
+    const preAttrs = String(rawPreAttrs || "")
+    const codeAttrs = String(rawCodeAttrs || "")
+    const containerAttrs = extractNearestCodeContainerAttrs(html, Number(offset) || 0)
+    const source = extractCodeSourceFromHtmlBlock(preAttrs, codeAttrs, containerAttrs, String(rawCodeBody || ""))
+    if (!source) return full
+
+    const language = extractCodeLanguageFromAttrs(preAttrs, codeAttrs, containerAttrs)
+    const codeClassName = readHtmlAttribute(codeAttrs, "class")
+    const hasMermaidHint =
+      language.toLowerCase() === "mermaid" ||
+      codeClassName.toLowerCase().includes("language-mermaid") ||
+      readHtmlAttribute(preAttrs, "class").toLowerCase().includes("aq-mermaid") ||
+      readHtmlAttribute(containerAttrs, "class").toLowerCase().includes("aq-mermaid")
+    if (hasMermaidHint || isMermaidSource(source)) {
+      const mermaidSource = extractMermaidSource(source)
+      return mermaidSource ? renderMermaidPre(mermaidSource) : full
+    }
+
+    const presentation = renderImmediateCodeToHtml({ source, language })
+    const retainedCodeAttrs = stripHtmlAttributes(
+      codeAttrs,
+      new Set(["class", "data-language", "data-prism-language", "data-prism-source", "data-raw-code"])
+    )
+    const normalizedClassName = mergeClassNames(codeClassName, `language-${presentation.language}`)
+    const normalizedCodeAttrs = [
+      retainedCodeAttrs,
+      `class="${escapeHtmlAttribute(normalizedClassName)}"`,
+      `data-language="${escapeHtmlAttribute(presentation.language)}"`,
+      `data-prism-language="${escapeHtmlAttribute(presentation.language)}"`,
+      `data-prism-source="${escapeHtmlAttribute(source)}"`,
+      `data-raw-code="${escapeHtmlAttribute(source)}"`,
+    ]
+      .filter(Boolean)
+      .join(" ")
+
+    return `<pre${preAttrs}><code ${normalizedCodeAttrs}>${presentation.html}</code></pre>`
   })
 
 export const normalizeContentHtmlForMermaid = (rawHtml: string): string =>
   rawHtml
-    ? normalizeStandaloneMermaidPreBlocksInHtml(
-      normalizeMermaidParagraphsInHtml(normalizeMermaidCodeBlocksInHtml(rawHtml))
+    ? normalizeContentHtmlCodeBlocks(
+      normalizeStandaloneMermaidPreBlocksInHtml(
+        normalizeMermaidParagraphsInHtml(normalizeMermaidCodeBlocksInHtml(rawHtml))
+      )
     )
     : ""
 


### PR DESCRIPTION
## 관련 이슈

close #584

## 작업 배경

- 507 코드블럭에서 `contentHtml` 코드 body가 비어 있고 raw source가 attribute에만 남은 경우에도 첫 렌더 HTML의 visible text를 즉시 채웁니다.
- Prism/Shiki highlight는 decoration으로 남기고, raw code 가시성은 idle hydration schedule에 의존하지 않도록 분리했습니다.
- CodeRabbit 지적 반영으로 숫자 HTML entity는 1회만 해석하고, wrapper raw mermaid source도 초기 `data-aq-mermaid` block으로 승격합니다.

## 작업 내용

- `contentHtml` 정규화 단계에서 `<pre><code>`의 `data-raw-code`/`data-prism-source`를 읽어 즉시 line-wrapped Prism fallback HTML을 주입합니다.
- nearest wrapper의 raw source도 읽어 507 카피 계열 legacy code block을 복구합니다.
- DOMParser `textContent` 결과에는 숫자 entity를 다시 적용하지 않아 escaped numeric literal이 tag text로 변환되지 않게 했습니다.
- raw source가 mermaid인 경우 Prism fallback 대신 `data-aq-mermaid` block을 즉시 구성합니다.
- 507 코드 예시 기반 초기 렌더 회귀 테스트에 `<code>` 직접 raw source, wrapper raw source, wrapper mermaid source, escaped numeric literal, `/editor/[id]` 첫 code snapshot 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-code-initial-render.spec.ts --workers=1` (RED 확인: wrapper raw mermaid 미승격, GREEN 5 passed)
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-code-recovery.spec.ts --workers=1` (5 passed)
  - `yarn --cwd front test:e2e e2e/smoke-detail-rendering.spec.ts --workers=1` (8 passed)
  - `yarn --cwd front test:e2e e2e/perf.spec.ts --workers=1` (1 passed)
  - `yarn --cwd front test:e2e:authoring` (128 passed)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke` (57 passed)
  - pre-commit hook에서 `yarn --cwd front build`, `node scripts/check-bundle-size.mjs`, `yarn --cwd front test:e2e:smoke` 재실행
  - CodexReview fallback 수행 후 CodeRabbit review completed. CodeRabbit actionable 2건은 commit `0bd3522a`에서 반영하고 review thread resolve 완료

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: legacy `contentHtml` 코드블럭 HTML을 정규화하면서 일부 custom code attribute 순서가 바뀔 수 있습니다. `class`, language, raw source, line wrapper는 유지/재생성합니다.
- 롤백 방법: 이 PR의 merge commit을 revert하면 이전 `contentHtml` 코드블럭 처리로 복구됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
