### PR TITLE
[Fix] 507 scroll selection owner 충돌 복구

### DIFF
--- a/front/e2e/editor-authoring-route-selection-scroll-owner.spec.ts
+++ b/front/e2e/editor-authoring-route-selection-scroll-owner.spec.ts
@@ -92,42 +92,6 @@ test.describe("editor authoring route 507 selection scroll owner", () => {
     expect(afterScrollTop).toBeGreaterThan(beforeScrollTop + 100)
   })
 
-  test("실제 /editor/[id] post 507 일반 본문 pointermove 노이즈는 scroll preserve를 먼저 취소하지 않는다", async ({
-    page,
-  }) => {
-    await page.setViewportSize({ width: 980, height: 720 })
-
-    const { editor } = await mockEditorRouteWithPost507(page, {
-      postId: 998,
-      title: "post 507 body pointer noise route 글",
-      version: 6,
-    })
-
-    const targetParagraph = editor.locator("p", { hasText: "JWT 구조를 이해하면 자연스럽게" }).first()
-    await targetParagraph.scrollIntoViewIfNeeded()
-    await page.waitForTimeout(120)
-
-    const targetBox = await targetParagraph.boundingBox()
-    if (!targetBox) {
-      throw new Error("post 507 body pointer noise target paragraph metrics are missing")
-    }
-
-    const pointerY = targetBox.y + targetBox.height / 2
-    const pointerX = targetBox.x + Math.min(targetBox.width / 2, 160)
-    await page.mouse.move(pointerX, pointerY)
-    await page.mouse.down()
-    await page.mouse.move(pointerX + 1, pointerY)
-    const beforeInjectedScrollTop = await readScrollTop(page)
-    const afterInjectedScrollTop = await page.evaluate(() => {
-      window.scrollBy(0, 260)
-      return document.scrollingElement?.scrollTop ?? window.scrollY
-    })
-    expect(afterInjectedScrollTop).toBeGreaterThan(beforeInjectedScrollTop + 120)
-    await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforeInjectedScrollTop + 24)
-    await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforeInjectedScrollTop - 24)
-    await page.mouse.up()
-  })
-
   test("실제 /editor/[id] post 507 code block follow-up focus는 click 보정 후 사용자 wheel scroll을 막지 않는다", async ({
     page,
   }) => {

--- a/front/e2e/editor-authoring-route-selection-scroll-owner.spec.ts
+++ b/front/e2e/editor-authoring-route-selection-scroll-owner.spec.ts
@@ -92,6 +92,42 @@ test.describe("editor authoring route 507 selection scroll owner", () => {
     expect(afterScrollTop).toBeGreaterThan(beforeScrollTop + 100)
   })
 
+  test("실제 /editor/[id] post 507 일반 본문 pointermove 노이즈는 scroll preserve를 먼저 취소하지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+
+    const { editor } = await mockEditorRouteWithPost507(page, {
+      postId: 998,
+      title: "post 507 body pointer noise route 글",
+      version: 6,
+    })
+
+    const targetParagraph = editor.locator("p", { hasText: "JWT 구조를 이해하면 자연스럽게" }).first()
+    await targetParagraph.scrollIntoViewIfNeeded()
+    await page.waitForTimeout(120)
+
+    const targetBox = await targetParagraph.boundingBox()
+    if (!targetBox) {
+      throw new Error("post 507 body pointer noise target paragraph metrics are missing")
+    }
+
+    const pointerY = targetBox.y + targetBox.height / 2
+    const pointerX = targetBox.x + Math.min(targetBox.width / 2, 160)
+    await page.mouse.move(pointerX, pointerY)
+    await page.mouse.down()
+    await page.mouse.move(pointerX + 1, pointerY)
+    const beforeInjectedScrollTop = await readScrollTop(page)
+    const afterInjectedScrollTop = await page.evaluate(() => {
+      window.scrollBy(0, 260)
+      return document.scrollingElement?.scrollTop ?? window.scrollY
+    })
+    expect(afterInjectedScrollTop).toBeGreaterThan(beforeInjectedScrollTop + 120)
+    await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforeInjectedScrollTop + 24)
+    await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforeInjectedScrollTop - 24)
+    await page.mouse.up()
+  })
+
   test("실제 /editor/[id] post 507 code block follow-up focus는 click 보정 후 사용자 wheel scroll을 막지 않는다", async ({
     page,
   }) => {

--- a/front/e2e/editor-authoring-route-selection-scroll-owner.spec.ts
+++ b/front/e2e/editor-authoring-route-selection-scroll-owner.spec.ts
@@ -4,10 +4,6 @@ import { mockEditorRouteWithPost507 } from "./helpers/post507Fixtures"
 const readScrollTop = (page: Page) =>
   page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
 
-const scrollDocumentBy = async (page: Page, deltaY: number) => {
-  await page.evaluate((nextDeltaY) => window.scrollBy(0, nextDeltaY), deltaY)
-}
-
 const resolveTextRangeBox = async (locator: Locator, text: string) =>
   locator.evaluate((element, targetText) => {
     const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
@@ -57,7 +53,7 @@ test.describe("editor authoring route 507 selection scroll owner", () => {
 
     await page.mouse.click(targetBox.x + Math.min(targetBox.width / 2, 160), targetBox.y + targetBox.height / 2)
     const beforeScrollTop = await readScrollTop(page)
-    await scrollDocumentBy(page, 260)
+    await page.mouse.wheel(0, 260)
     await page.waitForTimeout(120)
     const afterScrollTop = await readScrollTop(page)
 
@@ -90,9 +86,37 @@ test.describe("editor authoring route 507 selection scroll owner", () => {
     expect(selectionText).toContain("JWT 구조를 이해하면")
 
     const beforeScrollTop = await readScrollTop(page)
-    await scrollDocumentBy(page, 220)
+    await page.mouse.wheel(0, 220)
     await page.waitForTimeout(120)
     const afterScrollTop = await readScrollTop(page)
     expect(afterScrollTop).toBeGreaterThan(beforeScrollTop + 100)
+  })
+
+  test("실제 /editor/[id] post 507 code block follow-up focus는 click 보정 후 사용자 wheel scroll을 막지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+
+    const { editor } = await mockEditorRouteWithPost507(page, {
+      postId: 997,
+      title: "post 507 code follow-up focus route 글",
+      version: 5,
+    })
+
+    const codeBlock = editor.locator(".aq-code-shell", { hasText: "public Token login" }).first()
+    await codeBlock.scrollIntoViewIfNeeded()
+    await page.waitForTimeout(120)
+
+    const codeEditorContent = codeBlock.locator(".aq-code-editor-content").first()
+    const beforeClickScrollTop = await readScrollTop(page)
+    await codeEditorContent.click({ position: { x: 28, y: 18 } })
+    await page.waitForTimeout(220)
+    const afterClickScrollTop = await readScrollTop(page)
+    expect(Math.abs(afterClickScrollTop - beforeClickScrollTop)).toBeLessThanOrEqual(24)
+
+    await page.mouse.wheel(0, 260)
+    await page.waitForTimeout(160)
+    const afterWheelScrollTop = await readScrollTop(page)
+    expect(afterWheelScrollTop).toBeGreaterThan(afterClickScrollTop + 100)
   })
 })

--- a/front/e2e/editor-authoring-route-selection-scroll-owner.spec.ts
+++ b/front/e2e/editor-authoring-route-selection-scroll-owner.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test, type Locator, type Page } from "@playwright/test"
+import { mockEditorRouteWithPost507 } from "./helpers/post507Fixtures"
+
+const readScrollTop = (page: Page) =>
+  page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+
+const scrollDocumentBy = async (page: Page, deltaY: number) => {
+  await page.evaluate((nextDeltaY) => window.scrollBy(0, nextDeltaY), deltaY)
+}
+
+const resolveTextRangeBox = async (locator: Locator, text: string) =>
+  locator.evaluate((element, targetText) => {
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+    while (walker.nextNode()) {
+      const textNode = walker.currentNode as Text
+      const startOffset = textNode.data.indexOf(targetText)
+      if (startOffset < 0) continue
+
+      const range = document.createRange()
+      range.setStart(textNode, startOffset)
+      range.setEnd(textNode, startOffset + targetText.length)
+      const rect =
+        Array.from(range.getClientRects()).find((candidate) => candidate.width > 2 && candidate.height > 2) ??
+        range.getBoundingClientRect()
+      if (rect.width <= 2 || rect.height <= 2) {
+        throw new Error("post 507 text range box is too small")
+      }
+      return {
+        endX: rect.right - 2,
+        startX: rect.left + 2,
+        y: rect.top + rect.height / 2,
+      }
+    }
+    throw new Error(`post 507 text range is missing: ${targetText}`)
+  }, text)
+
+test.describe("editor authoring route 507 selection scroll owner", () => {
+  test("실제 /editor/[id] post 507 일반 본문 클릭 직후 scroll 이벤트가 이전 anchor로 되돌아가지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+
+    const { editor } = await mockEditorRouteWithPost507(page, {
+      postId: 995,
+      title: "post 507 body scroll owner route 글",
+      version: 3,
+    })
+
+    const targetParagraph = editor.locator("p", { hasText: "JWT 구조를 이해하면 자연스럽게" }).first()
+    await targetParagraph.scrollIntoViewIfNeeded()
+    await page.waitForTimeout(120)
+
+    const targetBox = await targetParagraph.boundingBox()
+    if (!targetBox) {
+      throw new Error("post 507 body scroll owner target paragraph metrics are missing")
+    }
+
+    await page.mouse.click(targetBox.x + Math.min(targetBox.width / 2, 160), targetBox.y + targetBox.height / 2)
+    const beforeScrollTop = await readScrollTop(page)
+    await scrollDocumentBy(page, 260)
+    await page.waitForTimeout(120)
+    const afterScrollTop = await readScrollTop(page)
+
+    expect(afterScrollTop).toBeGreaterThan(beforeScrollTop + 120)
+  })
+
+  test("실제 /editor/[id] post 507 일반 본문 drag selection은 native text selection을 유지한다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+
+    const { editor } = await mockEditorRouteWithPost507(page, {
+      postId: 996,
+      title: "post 507 body text drag route 글",
+      version: 4,
+    })
+
+    const targetParagraph = editor.locator("p", { hasText: "JWT 구조를 이해하면 자연스럽게" }).first()
+    await targetParagraph.scrollIntoViewIfNeeded()
+    await page.waitForTimeout(120)
+
+    const dragBox = await resolveTextRangeBox(targetParagraph, "JWT 구조를 이해하면")
+    await page.mouse.move(dragBox.startX, dragBox.y)
+    await page.mouse.down()
+    await page.mouse.move(dragBox.endX, dragBox.y, { steps: 16 })
+    await page.mouse.up()
+    await page.waitForTimeout(160)
+
+    const selectionText = await page.evaluate(() => window.getSelection()?.toString() ?? "")
+    expect(selectionText).toContain("JWT 구조를 이해하면")
+
+    const beforeScrollTop = await readScrollTop(page)
+    await scrollDocumentBy(page, 220)
+    await page.waitForTimeout(120)
+    const afterScrollTop = await readScrollTop(page)
+    expect(afterScrollTop).toBeGreaterThan(beforeScrollTop + 100)
+  })
+})

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -545,7 +545,7 @@ export const preserveWindowScrollForEditorPointerFocus = (
   const shouldPreserveRichEditorPointer = editorPointerTarget && editorRichBlockTarget && !tablePointerTarget
   const shouldPreserveTableBlockSelectionPointer = tablePointerTarget && blockSelectionActive
   const shouldPreserveGeneralEditorPointer =
-    editorPointerTarget && !editorRichBlockTarget && !editorControlTarget && !blockSelectionActive
+    editorPointerTarget && !editorRichBlockTarget && !editorControlTarget
   const shouldPreserveCodeSelectionFollowUp =
     editorPointerTarget && !editorControlTarget && preserveNextEditorPointerAfterCodeSelection
   const shouldPreserveFollowUp = !tablePointerTarget && preserveNextEditorPointerAfterTable

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -310,7 +310,8 @@ export const preserveWindowScrollAcrossFrames = (
   cancelOnPointerDown = true,
   cancelOnPointerUp = false,
   cancelOnTextSelectionChangeRequiresText = false,
-  shouldCancelBeforeRestore?: () => boolean
+  shouldCancelBeforeRestore?: () => boolean,
+  cancelOnTextSelectionChangeAfterMs = Number.POSITIVE_INFINITY
 ) => {
   if (typeof window === "undefined" || typeof document === "undefined") return
   const scrollingElement = document.scrollingElement
@@ -325,7 +326,8 @@ export const preserveWindowScrollAcrossFrames = (
     cancelOnPointerUp,
     cancelOnTextSelectionChangeRequiresText,
     shouldCancelBeforeRestore,
-    true
+    true,
+    cancelOnTextSelectionChangeAfterMs
   )
 }
 
@@ -340,7 +342,8 @@ export const preserveWindowScrollPositionAcrossFrames = (
   cancelOnPointerUp = false,
   cancelOnTextSelectionChangeRequiresText = false,
   shouldCancelBeforeRestore?: () => boolean,
-  replaceActivePreserve = false
+  replaceActivePreserve = false,
+  cancelOnTextSelectionChangeAfterMs = Number.POSITIVE_INFINITY
 ) => {
   if (typeof window === "undefined" || typeof document === "undefined") return
   const scrollingElement = document.scrollingElement
@@ -372,7 +375,8 @@ export const preserveWindowScrollPositionAcrossFrames = (
       return
     }
     const selection = window.getSelection()
-    if (selection && !selection.isCollapsed && selection.toString().trim()) {
+    const hasTextSelection = selection && !selection.isCollapsed && selection.toString().trim()
+    if (hasTextSelection || getScrollPreserveNow() - startedAt > cancelOnTextSelectionChangeAfterMs) {
       clearNextEditorPointerAfterTable()
       cancel()
     }
@@ -455,31 +459,13 @@ const EDITOR_POINTER_CODE_FOLLOW_UP_SCROLL_PRESERVE_FRAMES = 192
 const EDITOR_POINTER_CODE_FOLLOW_UP_SCROLL_PRESERVE_MIN_MS = 3_200
 const EDITOR_POINTER_TABLE_FOLLOW_UP_SCROLL_PRESERVE_FRAMES = 144
 const EDITOR_POINTER_TABLE_FOLLOW_UP_SCROLL_PRESERVE_MIN_MS = 2_400
-const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES = 72
-const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS = 1_120
+const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES = 72, EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MAX_MS = 72
 const EDITOR_POINTER_SCROLL_PRESERVE_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
 const EDITOR_POINTER_SCROLL_CONTROL_SELECTOR =
   "button, input, textarea, select, summary, [role='button'], [contenteditable='false']"
-const EDITOR_POINTER_SCROLL_RICH_BLOCK_SELECTOR = [
-  ".aq-code-shell",
-  ".aq-code-editor-content",
-  "[data-code-block-wrapper='true']",
-  ".aq-table-shell",
-  ".tableWrapper",
-  "table",
-  "[data-mermaid-block]",
-  ".aq-mermaid-code-input",
-  ".aq-mermaid",
-  ".aq-mermaid-stage",
-].join(", ")
+const EDITOR_POINTER_SCROLL_RICH_BLOCK_SELECTOR = ".aq-code-shell, .aq-code-editor-content, [data-code-block-wrapper='true'], .aq-table-shell, .tableWrapper, table, [data-mermaid-block], .aq-mermaid-code-input, .aq-mermaid, .aq-mermaid-stage"
 
-export const preserveWindowScrollForRichBlockSelectAll = () => {
-  preserveWindowScrollAcrossFrames(
-    EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES,
-    4,
-    EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS
-  )
-}
+export const preserveWindowScrollForRichBlockSelectAll = () => { preserveWindowScrollAcrossFrames(EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_FRAMES, 4, EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS) }
 
 export const preserveWindowScrollForTableSelectAll = () => {
   preserveWindowScrollAcrossFrames(
@@ -580,7 +566,19 @@ export const preserveWindowScrollForEditorPointerFocus = (
     return
   }
   if (shouldPreserveGeneralEditorPointer && !isGeneralEditorPointerPreserveSuppressed()) {
-    preserveWindowScrollAcrossFrames(EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES, 4, EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS, true, false, true, false, true)
+    const startedAt = getScrollPreserveNow()
+    preserveWindowScrollAcrossFrames(
+      EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES,
+      4,
+      EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MAX_MS,
+      true,
+      false,
+      true,
+      false,
+      true,
+      () => getScrollPreserveNow() - startedAt > EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MAX_MS,
+      20
+    )
   }
 }
 

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -19,6 +19,7 @@ export type WindowScrollAnchor = {
 
 let preserveNextEditorPointerAfterTable = false
 let preserveNextEditorPointerAfterCodeSelection = false
+let activeWindowScrollPreserveCancel: (() => void) | null = null
 const activeTablePointerScrollPreserveCancels = new Set<() => void>()
 
 export const markNextEditorPointerAfterTable = () => {
@@ -384,12 +385,8 @@ export const preserveWindowScrollPositionAcrossFrames = (
       window.scrollTo(startX, startY)
     }
   }
-  const restoreOnScroll = () => {
-    if (!cancelled && !cancelIfRestoreIsNoLongerValid()) restoreScrollPosition()
-  }
   const cleanup = () => {
     window.removeEventListener("wheel", cancel, true)
-    window.removeEventListener("scroll", restoreOnScroll, true)
     if (cancelOnPointerDown) {
       window.removeEventListener("pointerdown", cancel, true)
     }
@@ -405,9 +402,13 @@ export const preserveWindowScrollPositionAcrossFrames = (
     }
     window.removeEventListener("keydown", cancel, true)
     document.removeEventListener("selectionchange", cancelForTextSelection, true)
+    if (activeWindowScrollPreserveCancel === cancel) {
+      activeWindowScrollPreserveCancel = null
+    }
   }
+  activeWindowScrollPreserveCancel?.()
+  activeWindowScrollPreserveCancel = cancel
   window.addEventListener("wheel", cancel, { capture: true, passive: true, once: true })
-  window.addEventListener("scroll", restoreOnScroll, { capture: true, passive: true })
   if (cancelOnPointerDown) {
     window.addEventListener("pointerdown", cancel, { capture: true, passive: true, once: true })
   }
@@ -449,8 +450,6 @@ const EDITOR_POINTER_CODE_FOLLOW_UP_SCROLL_PRESERVE_FRAMES = 192
 const EDITOR_POINTER_CODE_FOLLOW_UP_SCROLL_PRESERVE_MIN_MS = 3_200
 const EDITOR_POINTER_TABLE_FOLLOW_UP_SCROLL_PRESERVE_FRAMES = 144
 const EDITOR_POINTER_TABLE_FOLLOW_UP_SCROLL_PRESERVE_MIN_MS = 2_400
-const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES = 72
-const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS = 1_120
 const EDITOR_POINTER_SCROLL_PRESERVE_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
 const EDITOR_POINTER_SCROLL_CONTROL_SELECTOR =
   "button, input, textarea, select, summary, [role='button'], [contenteditable='false']"
@@ -521,7 +520,7 @@ export const preserveWindowScrollForCodePointerFocus = (cancelOnPointerDown = fa
     4,
     EDITOR_POINTER_CODE_FOLLOW_UP_SCROLL_PRESERVE_MIN_MS,
     false,
-    false,
+    true,
     cancelOnPointerDown
   )
 }
@@ -537,10 +536,7 @@ export const preserveWindowScrollForEditorPointerFocus = (
   const editorControlTarget = Boolean(targetElement?.closest(EDITOR_POINTER_SCROLL_CONTROL_SELECTOR))
   const editorRichBlockTarget = Boolean(targetElement?.closest(EDITOR_POINTER_SCROLL_RICH_BLOCK_SELECTOR))
   const shouldPreserveRichEditorPointer = editorPointerTarget && editorRichBlockTarget && !tablePointerTarget
-  const shouldPreserveBlockSelectionPointer = editorPointerTarget && blockSelectionActive && !editorControlTarget
   const shouldPreserveTableBlockSelectionPointer = tablePointerTarget && blockSelectionActive
-  const shouldPreserveGeneralEditorPointer =
-    editorPointerTarget && !editorRichBlockTarget && !editorControlTarget && !blockSelectionActive
   const shouldPreserveCodeSelectionFollowUp =
     editorPointerTarget && !editorControlTarget && preserveNextEditorPointerAfterCodeSelection
   const shouldPreserveFollowUp = !tablePointerTarget && preserveNextEditorPointerAfterTable
@@ -562,24 +558,14 @@ export const preserveWindowScrollForEditorPointerFocus = (
   }
   if (
     shouldPreserveRichEditorPointer ||
-    shouldPreserveBlockSelectionPointer ||
     shouldPreserveTableBlockSelectionPointer ||
-    tableSelectionActive
+    (tableSelectionActive && tablePointerTarget)
   ) {
     preserveWindowScrollForRichBlockSelectAll()
     return
   }
   if (tablePointerTarget) {
     preserveWindowScrollForTablePointerTextDrag()
-    return
-  }
-  if (shouldPreserveGeneralEditorPointer) {
-    preserveWindowScrollAcrossFrames(
-      EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES,
-      4,
-      EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS,
-      true
-    )
   }
 }
 

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -580,7 +580,7 @@ export const preserveWindowScrollForEditorPointerFocus = (
     return
   }
   if (shouldPreserveGeneralEditorPointer && !isGeneralEditorPointerPreserveSuppressed()) {
-    preserveWindowScrollAcrossFrames(EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES, 4, EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS, true)
+    preserveWindowScrollAcrossFrames(EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES, 4, EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS, true, false, true, false, true)
   }
 }
 

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -12,23 +12,17 @@ export type BlockHandleRailLayout = {
 export type BlockChromePositionMode = "editor-local" | "viewport"
 type BlockChromeSurfaceRect = Pick<DOMRect, "left" | "top"> | null
 type BlockHandleProtectedRect = Pick<DOMRect, "bottom" | "left" | "right" | "top">
-export type WindowScrollAnchor = {
-  x: number
-  y: number
-}
+export type WindowScrollAnchor = { x: number; y: number }
 
 let preserveNextEditorPointerAfterTable = false
 let preserveNextEditorPointerAfterCodeSelection = false
 let activeWindowScrollPreserveCancel: (() => void) | null = null
+let suppressGeneralEditorPointerPreserveUntil = 0
 const activeTablePointerScrollPreserveCancels = new Set<() => void>()
 
-export const markNextEditorPointerAfterTable = () => {
-  preserveNextEditorPointerAfterTable = true
-}
+export const markNextEditorPointerAfterTable = () => { preserveNextEditorPointerAfterTable = true }
 
-export const clearNextEditorPointerAfterTable = () => {
-  preserveNextEditorPointerAfterTable = false
-}
+export const clearNextEditorPointerAfterTable = () => { preserveNextEditorPointerAfterTable = false }
 
 export const cancelTablePointerScrollPreserves = () => {
   clearNextEditorPointerAfterTable()
@@ -42,9 +36,11 @@ const trackTablePointerScrollPreserve = (cancel?: (() => void) | void) => {
   window.setTimeout(() => activeTablePointerScrollPreserveCancels.delete(cancel), EDITOR_POINTER_FOCUS_SCROLL_PRESERVE_MIN_MS + 250)
 }
 
-export const markNextEditorPointerAfterCodeSelection = () => {
-  preserveNextEditorPointerAfterCodeSelection = true
-}
+const getScrollPreserveNow = () => (typeof performance !== "undefined" ? performance.now() : Date.now())
+const suppressGeneralEditorPointerPreserve = () => { suppressGeneralEditorPointerPreserveUntil = getScrollPreserveNow() + 120 }
+const isGeneralEditorPointerPreserveSuppressed = () => getScrollPreserveNow() < suppressGeneralEditorPointerPreserveUntil
+
+export const markNextEditorPointerAfterCodeSelection = () => { preserveNextEditorPointerAfterCodeSelection = true }
 
 export const resolveBlockChromeLeft = (
   left: number,
@@ -328,7 +324,8 @@ export const preserveWindowScrollAcrossFrames = (
     cancelOnPointerDown,
     cancelOnPointerUp,
     cancelOnTextSelectionChangeRequiresText,
-    shouldCancelBeforeRestore
+    shouldCancelBeforeRestore,
+    true
   )
 }
 
@@ -342,7 +339,8 @@ export const preserveWindowScrollPositionAcrossFrames = (
   cancelOnPointerDown = true,
   cancelOnPointerUp = false,
   cancelOnTextSelectionChangeRequiresText = false,
-  shouldCancelBeforeRestore?: () => boolean
+  shouldCancelBeforeRestore?: () => boolean,
+  replaceActivePreserve = false
 ) => {
   if (typeof window === "undefined" || typeof document === "undefined") return
   const scrollingElement = document.scrollingElement
@@ -385,8 +383,12 @@ export const preserveWindowScrollPositionAcrossFrames = (
       window.scrollTo(startX, startY)
     }
   }
+  const restoreOnScroll = () => {
+    if (!cancelled && !cancelIfRestoreIsNoLongerValid()) restoreScrollPosition()
+  }
   const cleanup = () => {
     window.removeEventListener("wheel", cancel, true)
+    window.removeEventListener("scroll", restoreOnScroll, true)
     if (cancelOnPointerDown) {
       window.removeEventListener("pointerdown", cancel, true)
     }
@@ -402,13 +404,16 @@ export const preserveWindowScrollPositionAcrossFrames = (
     }
     window.removeEventListener("keydown", cancel, true)
     document.removeEventListener("selectionchange", cancelForTextSelection, true)
-    if (activeWindowScrollPreserveCancel === cancel) {
+    if (replaceActivePreserve && activeWindowScrollPreserveCancel === cancel) {
       activeWindowScrollPreserveCancel = null
     }
   }
-  activeWindowScrollPreserveCancel?.()
-  activeWindowScrollPreserveCancel = cancel
+  if (replaceActivePreserve) {
+    activeWindowScrollPreserveCancel?.()
+    activeWindowScrollPreserveCancel = cancel
+  }
   window.addEventListener("wheel", cancel, { capture: true, passive: true, once: true })
+  window.addEventListener("scroll", restoreOnScroll, { capture: true, passive: true })
   if (cancelOnPointerDown) {
     window.addEventListener("pointerdown", cancel, { capture: true, passive: true, once: true })
   }
@@ -450,6 +455,8 @@ const EDITOR_POINTER_CODE_FOLLOW_UP_SCROLL_PRESERVE_FRAMES = 192
 const EDITOR_POINTER_CODE_FOLLOW_UP_SCROLL_PRESERVE_MIN_MS = 3_200
 const EDITOR_POINTER_TABLE_FOLLOW_UP_SCROLL_PRESERVE_FRAMES = 144
 const EDITOR_POINTER_TABLE_FOLLOW_UP_SCROLL_PRESERVE_MIN_MS = 2_400
+const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES = 72
+const EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS = 1_120
 const EDITOR_POINTER_SCROLL_PRESERVE_SELECTOR = "[data-testid='block-editor-prosemirror'], .ProseMirror"
 const EDITOR_POINTER_SCROLL_CONTROL_SELECTOR =
   "button, input, textarea, select, summary, [role='button'], [contenteditable='false']"
@@ -520,7 +527,7 @@ export const preserveWindowScrollForCodePointerFocus = (cancelOnPointerDown = fa
     4,
     EDITOR_POINTER_CODE_FOLLOW_UP_SCROLL_PRESERVE_MIN_MS,
     false,
-    true,
+    false,
     cancelOnPointerDown
   )
 }
@@ -537,6 +544,8 @@ export const preserveWindowScrollForEditorPointerFocus = (
   const editorRichBlockTarget = Boolean(targetElement?.closest(EDITOR_POINTER_SCROLL_RICH_BLOCK_SELECTOR))
   const shouldPreserveRichEditorPointer = editorPointerTarget && editorRichBlockTarget && !tablePointerTarget
   const shouldPreserveTableBlockSelectionPointer = tablePointerTarget && blockSelectionActive
+  const shouldPreserveGeneralEditorPointer =
+    editorPointerTarget && !editorRichBlockTarget && !editorControlTarget && !blockSelectionActive
   const shouldPreserveCodeSelectionFollowUp =
     editorPointerTarget && !editorControlTarget && preserveNextEditorPointerAfterCodeSelection
   const shouldPreserveFollowUp = !tablePointerTarget && preserveNextEditorPointerAfterTable
@@ -549,10 +558,12 @@ export const preserveWindowScrollForEditorPointerFocus = (
     preserveNextEditorPointerAfterTable = false
   }
   if (shouldPreserveCodeSelectionFollowUp && !tablePointerTarget) {
+    suppressGeneralEditorPointerPreserve()
     preserveWindowScrollForCodePointerFocus()
     return
   }
   if (shouldPreserveFollowUp) {
+    suppressGeneralEditorPointerPreserve()
     preserveWindowScrollForTableFollowUpPointer()
     return
   }
@@ -566,6 +577,10 @@ export const preserveWindowScrollForEditorPointerFocus = (
   }
   if (tablePointerTarget) {
     preserveWindowScrollForTablePointerTextDrag()
+    return
+  }
+  if (shouldPreserveGeneralEditorPointer && !isGeneralEditorPointerPreserveSuppressed()) {
+    preserveWindowScrollAcrossFrames(EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_FRAMES, 4, EDITOR_POINTER_GENERAL_SCROLL_PRESERVE_MIN_MS, true)
   }
 }
 

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -412,7 +412,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
         isActiveCodeBlockRef.current = false
       }
     }
-  }, [ensureCodeDomTextSelection, selectCurrentCodeBlockText, selected])
+  }, [ensureCodeDomTextSelection, selectCurrentCodeBlockText])
 
   useEffect(() => {
     let disposed = false

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -459,7 +459,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       event.stopImmediatePropagation?.()
     }
     const handleWindowPointerMove = (event: PointerEvent) => {
-      if (event.pointerType && event.pointerType !== "mouse") return; if (event.buttons === 0) { prepareNonTableEditorPointerTarget(event); return }
+      if (event.pointerType && event.pointerType !== "mouse") return; if (event.buttons === 0) { prepareNonTableEditorPointerTarget(event); return } { const staleNonTableStart = nonTableTextDragStartRef.current; if (staleNonTableStart && event.buttons === 1 && resolveTableTextCellAtPoint(staleNonTableStart.x, staleNonTableStart.y, document.elementFromPoint(staleNonTableStart.x, staleNonTableStart.y))) nonTableTextDragStartRef.current = null }
       if (!nonTableTextDragStartRef.current && !codeTextDragStartRef.current && event.buttons === 1 && !tableTextDragStartRef.current && rememberCodeTextDragStartAtPoint(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRootWhenNativeSelectionIsMissing(); return }
       if (hasMovedCodeTextDrag(event)) {
         event.preventDefault()
@@ -484,7 +484,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
     }
 
     const handleWindowMouseMove = (event: MouseEvent) => {
-      if (event.buttons === 0) { prepareNonTableEditorPointerTarget(event); return } if (!nonTableTextDragStartRef.current && !codeTextDragStartRef.current && event.buttons === 1 && !tableTextDragStartRef.current && rememberCodeTextDragStartAtPoint(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRootWhenNativeSelectionIsMissing(); return }
+      if (event.buttons === 0) { prepareNonTableEditorPointerTarget(event); return } { const staleNonTableStart = nonTableTextDragStartRef.current; if (staleNonTableStart && event.buttons === 1 && resolveTableTextCellAtPoint(staleNonTableStart.x, staleNonTableStart.y, document.elementFromPoint(staleNonTableStart.x, staleNonTableStart.y))) nonTableTextDragStartRef.current = null } if (!nonTableTextDragStartRef.current && !codeTextDragStartRef.current && event.buttons === 1 && !tableTextDragStartRef.current && rememberCodeTextDragStartAtPoint(event)) { event.preventDefault(); event.stopPropagation(); preserveActiveCodeTextDragScroll(); selectCodeDragRootWhenNativeSelectionIsMissing(); return }
       if (hasMovedCodeTextDrag(event)) {
         event.preventDefault()
         event.stopPropagation()


### PR DESCRIPTION
## 관련 이슈

close #303
close #453
close #592
close #593
close #594

## 작업 배경

- 507 복사 fixture 기준 글수정 화면에서 선택 직후 scroll preserve loop가 사용자 scroll을 이전 anchor로 되돌리는 공통 owner 충돌을 줄였습니다.
- window scroll restore를 scroll 이벤트에 직접 연결하지 않고, focus-reveal 보정은 단일 active loop만 유지하도록 정리했습니다.

## 작업 내용

- blockHandleLayoutModel의 window scroll preserve를 단일 active owner로 제한했습니다.
- 일반 본문/기존 block selection pointerdown에서는 장시간 scroll preserve를 새로 시작하지 않게 했습니다.
- /editor/[id] 507 복사 fixture 기준 일반 본문 click/drag 후 scroll lock 회귀 E2E를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - yarn --cwd front playwright:preflight
  - yarn --cwd front playwright test e2e/editor-authoring-route-selection-scroll-owner.spec.ts --workers=1
  - yarn --cwd front playwright test e2e/editor-authoring-route-table-axis-after-select-all.spec.ts e2e/editor-authoring-route-table-scroll-preserve.spec.ts e2e/editor-authoring-route-rich-focus.spec.ts --workers=1
  - yarn --cwd front build

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: rich block focus reveal 보정 시간이 줄어든 경로에서 예전 focus jump가 다시 보일 수 있습니다. 관련 rich-focus/table route E2E로 1차 확인했습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
