### PR TITLE
[Fix] 507 codeblock 언어 선택과 내부 chrome 복구

### DIFF
--- a/front/e2e/editor-authoring-code-mermaid.spec.ts
+++ b/front/e2e/editor-authoring-code-mermaid.spec.ts
@@ -1,9 +1,42 @@
-import { expect, test } from "@playwright/test"
-import {
-  expectEditorToContainLoadedText,
-  QA_ENGINE_ROUTE,
-  QA_WRITER_ROUTE,
-} from "./helpers/editorAuthoringFlow"
+import { expect, test, type Locator } from "@playwright/test"
+import { QA_ENGINE_ROUTE, QA_WRITER_ROUTE } from "./helpers/editorAuthoringFlow"
+import { mockEditorRouteWithPost507 } from "./helpers/post507Fixtures"
+
+const expectCodeBlockInnerChromeHidden = async (codeBlock: Locator) => {
+  const chrome = await codeBlock.evaluate((element) => {
+    const readChrome = (selector: string) => {
+      const node = element.querySelector<HTMLElement>(selector)
+      if (!node) throw new Error(`${selector} is missing`)
+      const style = window.getComputedStyle(node)
+      return {
+        backgroundColor: style.backgroundColor,
+        borderBottomWidth: style.borderBottomWidth,
+        borderLeftWidth: style.borderLeftWidth,
+        borderRadius: style.borderTopLeftRadius,
+        borderRightWidth: style.borderRightWidth,
+        borderTopWidth: style.borderTopWidth,
+        boxShadow: style.boxShadow,
+      }
+    }
+
+    return {
+      content: readChrome(".aq-code-editor-content"),
+      highlight: readChrome(".aq-code-highlight-layer"),
+    }
+  })
+
+  for (const layer of [chrome.highlight, chrome.content]) {
+    expect([
+      layer.borderTopWidth,
+      layer.borderRightWidth,
+      layer.borderBottomWidth,
+      layer.borderLeftWidth,
+    ]).toEqual(["0px", "0px", "0px", "0px"])
+    expect(layer.borderRadius).toBe("0px")
+    expect(layer.boxShadow).toBe("none")
+    expect(layer.backgroundColor).toBe("rgba(0, 0, 0, 0)")
+  }
+}
 
 test.describe("editor authoring code and mermaid blocks", () => {
   test("코드 블록은 작성 surface에서도 Prism 하이라이트 토큰을 렌더한다", async ({ page }) => {
@@ -105,6 +138,7 @@ test.describe("editor authoring code and mermaid blocks", () => {
 
     const codeBlock = page.locator("[data-code-block-wrapper='true']").first()
     await expect(codeBlock).toBeVisible()
+    await expectCodeBlockInnerChromeHidden(codeBlock)
 
     await codeBlock.locator("button[aria-haspopup='dialog']").click()
 
@@ -126,91 +160,15 @@ test.describe("editor authoring code and mermaid blocks", () => {
   test("실제 /editor/[id] 수정 route 코드 언어 선택은 dialog를 열고 언어를 갱신한다", async ({
     page,
   }) => {
-    const adminMember = {
-      id: 1,
-      username: "qa-admin",
-      nickname: "aquila",
-      isAdmin: true,
-    }
-    const content = [
-      "코드 언어 선택 회귀 대상입니다.",
-      "",
-      "```ts",
-      "const selectedLanguage = true",
-      "```",
-      "",
-      "언어 선택 뒤 문단입니다.",
-    ].join("\n")
-
-    await page.route("**/member/api/v1/auth/me", async (route) => {
-      await route.fulfill({
-        contentType: "application/json",
-        body: JSON.stringify(adminMember),
-      })
+    await mockEditorRouteWithPost507(page, {
+      postId: 565,
+      title: "post 507 code language route 글",
     })
-    await page.route("**/post/api/v1/adm/posts/998", async (route) => {
-      await route.fulfill({
-        contentType: "application/json",
-        body: JSON.stringify({
-          id: 998,
-          version: 3,
-          title: "코드 언어 선택 회귀 글",
-          content,
-          contentHtml: "",
-          published: true,
-          listed: true,
-        }),
-      })
-    })
-
-    await page.goto("/editor/998")
-
-    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("코드 언어 선택 회귀 글")
-    await expectEditorToContainLoadedText(
-      page.locator("[data-testid='block-editor-prosemirror']").first(),
-      "언어 선택 뒤 문단입니다."
-    )
 
     const codeBlock = page.locator("[data-code-block-wrapper='true']").first()
     await expect(codeBlock).toBeVisible({ timeout: 15_000 })
-    await expect(codeBlock.locator(".aq-code-highlight-layer")).toContainText("const selectedLanguage")
-
-    const codeContent = codeBlock.locator(".aq-code-editor-content").first()
-    const dragPoints = await codeContent.evaluate((element) => {
-      const targetText = "selectedLanguage"
-      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
-      while (walker.nextNode()) {
-        const current = walker.currentNode as Text
-        const startOffset = current.data.indexOf(targetText)
-        if (startOffset < 0) continue
-        const range = document.createRange()
-        range.setStart(current, startOffset)
-        range.setEnd(current, startOffset + targetText.length)
-        const rect = range.getBoundingClientRect()
-        if (rect.width <= 2 || rect.height <= 2) break
-        return {
-          endX: rect.right - 1,
-          startX: rect.left + 1,
-          y: rect.top + rect.height / 2,
-        }
-      }
-      throw new Error("code language regression selection target is missing")
-    })
-    await page.mouse.move(dragPoints.startX, dragPoints.y)
-    await page.mouse.down()
-    await page.mouse.move(dragPoints.endX, dragPoints.y, { steps: 12 })
-    await page.mouse.up()
-    await expect
-      .poll(() =>
-        page.evaluate(() => {
-          const selectionText = window.getSelection()?.toString() ?? ""
-          const persistedCodeSelectionText =
-            document.querySelector("[data-code-drag-selection-text]")?.getAttribute("data-code-drag-selection-text") ??
-            ""
-          return (selectionText || persistedCodeSelectionText).replace(/\s+/g, " ").trim()
-        })
-      )
-      .toContain("selectedLanguage")
+    await expect(codeBlock.locator(".aq-code-highlight-layer")).toContainText("로그인 -> 세션 생성")
+    await expectCodeBlockInnerChromeHidden(codeBlock)
 
     await page.evaluate(() => {
       const diagnosticsWindow = window as typeof window & {
@@ -227,12 +185,15 @@ test.describe("editor authoring code and mermaid blocks", () => {
       }
       document.addEventListener("pointerdown", recordLanguageControlPointer, true)
       document.addEventListener("mousedown", recordLanguageControlPointer, true)
+      document.addEventListener("click", recordLanguageControlPointer, true)
     })
 
-    const languageButton = codeBlock
-      .locator("[data-code-block-header='true']")
-      .getByRole("button", { name: /TypeScript/i })
-    const languageLabelBox = await languageButton.locator("span", { hasText: "TypeScript" }).boundingBox()
+    const languageButton = codeBlock.locator("[data-code-block-header='true'] button[aria-haspopup='dialog']").first()
+    await languageButton.scrollIntoViewIfNeeded()
+    const beforeLanguageClickScrollTop = await page.evaluate(
+      () => document.scrollingElement?.scrollTop ?? window.scrollY
+    )
+    const languageLabelBox = await languageButton.locator("span", { hasText: "TXT" }).boundingBox()
     if (!languageLabelBox) {
       throw new Error("code language label hit-test box is missing")
     }
@@ -240,6 +201,12 @@ test.describe("editor authoring code and mermaid blocks", () => {
       languageLabelBox.x + languageLabelBox.width / 2,
       languageLabelBox.y + languageLabelBox.height / 2
     )
+    await expect
+      .poll(async () => {
+        const scrollTop = await page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+        return Math.abs(scrollTop - beforeLanguageClickScrollTop)
+      })
+      .toBeLessThanOrEqual(24)
 
     const pointerDiagnostics = await page.evaluate(
       () =>
@@ -249,34 +216,15 @@ test.describe("editor authoring code and mermaid blocks", () => {
           }
         ).__aqCodeLanguagePointerDiagnostics ?? []
     )
-    expect(pointerDiagnostics.map((event) => event.type)).toEqual(["pointerdown", "mousedown"])
+    expect(pointerDiagnostics.map((event) => event.type)).toEqual(["pointerdown", "mousedown", "click"])
     expect(pointerDiagnostics.some((event) => event.defaultPrevented)).toBe(false)
+    await expect(languageButton).toHaveAttribute("aria-expanded", "true")
 
     const languageDialog = page.getByRole("dialog", { name: "코드 언어 선택" })
     await expect(languageDialog).toBeVisible()
-    const txtOption = languageDialog.getByRole("button", { name: "TXT", exact: true })
-    const txtOptionLabelBox = await txtOption.locator("span", { hasText: "TXT" }).boundingBox()
-    if (!txtOptionLabelBox) {
-      throw new Error("TXT language option hit-test box is missing")
-    }
-    await page.mouse.click(
-      txtOptionLabelBox.x + txtOptionLabelBox.width / 2,
-      txtOptionLabelBox.y + txtOptionLabelBox.height / 2
-    )
+    const pythonOption = languageDialog.getByRole("button", { name: "Python", exact: true })
+    await pythonOption.click()
 
-    await expect(languageDialog).toHaveCount(0)
-    await expect(
-      codeBlock
-        .locator("[data-code-block-header='true']")
-        .getByRole("button", { name: "TXT", exact: true })
-    ).toBeVisible()
-
-    await codeBlock
-      .locator("[data-code-block-header='true']")
-      .getByRole("button", { name: "TXT", exact: true })
-      .click()
-    await expect(languageDialog).toBeVisible()
-    await languageDialog.getByRole("button", { name: "Python", exact: true }).click()
     await expect(languageDialog).toHaveCount(0)
     await expect(
       codeBlock

--- a/front/src/components/editor/CodeLanguageControl.tsx
+++ b/front/src/components/editor/CodeLanguageControl.tsx
@@ -1,0 +1,137 @@
+import {
+  MouseEvent as ReactMouseEvent,
+  PointerEvent as ReactPointerEvent,
+  useCallback,
+  useRef,
+} from "react"
+import type { RefObject } from "react"
+import AppIcon from "src/components/icons/AppIcon"
+import { toLanguageLabel } from "src/libs/markdown/rendering"
+import {
+  CodeLanguageButton,
+  CodeLanguageOptionButton,
+  CodeLanguageOptionList,
+  CodeLanguagePicker,
+  CodeLanguagePopover,
+  CodeLanguageSearchInput,
+} from "./codeBlockNodeViewStyles"
+import type { CodeLanguageOption } from "./codeBlockNodeViewLanguageModel"
+
+type CodeLanguageControlProps = {
+  applyLanguage: (value: string) => void
+  draftLanguage: string
+  exactSearchMatch: boolean
+  filteredLanguageOptions: CodeLanguageOption[]
+  isLanguageMenuOpen: boolean
+  languageSearch: string
+  menuId: string
+  menuRef: RefObject<HTMLDivElement>
+  searchInputRef: RefObject<HTMLInputElement>
+  setLanguageSearch: (value: string) => void
+  toggleLanguageMenu: () => void
+}
+
+const CODE_LANGUAGE_OPTION_SELECTOR = "[data-code-language-option]"
+
+export const CodeLanguageControl = ({
+  applyLanguage,
+  draftLanguage,
+  exactSearchMatch,
+  filteredLanguageOptions,
+  isLanguageMenuOpen,
+  languageSearch,
+  menuId,
+  menuRef,
+  searchInputRef,
+  setLanguageSearch,
+  toggleLanguageMenu,
+}: CodeLanguageControlProps) => {
+  const pointerTogglePendingRef = useRef(false)
+
+  const handleButtonPointerDownCapture = useCallback((event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (event.pointerType && event.pointerType !== "mouse") return
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return
+    pointerTogglePendingRef.current = true
+    event.stopPropagation()
+    toggleLanguageMenu()
+  }, [toggleLanguageMenu])
+
+  const handleButtonClickCapture = useCallback((event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation()
+    if (pointerTogglePendingRef.current) {
+      pointerTogglePendingRef.current = false
+      return
+    }
+    toggleLanguageMenu()
+  }, [toggleLanguageMenu])
+
+  const handleOptionPointerDownCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const target = event.target instanceof Element ? event.target : null
+    if (!target?.closest(CODE_LANGUAGE_OPTION_SELECTOR)) return
+    event.stopPropagation()
+  }, [])
+
+  const handleOptionClickCapture = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
+    const target = event.target instanceof Element ? event.target : null
+    const optionButton = target?.closest<HTMLElement>(CODE_LANGUAGE_OPTION_SELECTOR)
+    if (!optionButton) return
+    event.stopPropagation()
+    applyLanguage(optionButton.dataset.codeLanguageOption || "")
+  }, [applyLanguage])
+
+  return (
+    <CodeLanguagePicker
+      ref={menuRef}
+      data-code-language-control="true"
+      contentEditable={false}
+      onPointerDownCapture={handleOptionPointerDownCapture}
+      onClickCapture={handleOptionClickCapture}
+    >
+      <CodeLanguageButton
+        type="button"
+        contentEditable={false}
+        aria-haspopup="dialog"
+        aria-expanded={isLanguageMenuOpen}
+        aria-controls={`${menuId}-language-menu`}
+        onPointerDownCapture={handleButtonPointerDownCapture}
+        onClickCapture={handleButtonClickCapture}
+      >
+        <span>{toLanguageLabel(draftLanguage)}</span>
+        <AppIcon name="chevron-down" aria-hidden="true" />
+      </CodeLanguageButton>
+      {isLanguageMenuOpen ? (
+        <CodeLanguagePopover id={`${menuId}-language-menu`} role="dialog" aria-label="코드 언어 선택">
+          <CodeLanguageSearchInput
+            ref={searchInputRef}
+            value={languageSearch}
+            placeholder="언어를 검색하세요"
+            aria-label="언어 검색"
+            onChange={(event) => setLanguageSearch(event.target.value)}
+          />
+          <CodeLanguageOptionList>
+            {filteredLanguageOptions.map((option) => (
+              <CodeLanguageOptionButton
+                key={option.value}
+                type="button"
+                data-active={draftLanguage === option.value}
+                data-code-language-option={option.value}
+              >
+                <span>{option.label}</span>
+                {draftLanguage === option.value ? <AppIcon name="check-circle" aria-hidden="true" /> : null}
+              </CodeLanguageOptionButton>
+            ))}
+            {languageSearch.trim() && !exactSearchMatch ? (
+              <CodeLanguageOptionButton
+                type="button"
+                data-code-language-option={languageSearch.trim()}
+              >
+                <span>{languageSearch.trim()}</span>
+                <small>직접 입력</small>
+              </CodeLanguageOptionButton>
+            ) : null}
+          </CodeLanguageOptionList>
+        </CodeLanguagePopover>
+      ) : null}
+    </CodeLanguagePicker>
+  )
+}

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -13,22 +13,15 @@ import {
   useRef,
   useState,
 } from "react"
-import AppIcon from "src/components/icons/AppIcon"
 import { extractPlainTextFromHtml } from "src/libs/markdown/htmlToMarkdown"
 import { highlightCodeToHtml, renderImmediateCodeToHtml } from "src/libs/markdown/prismRuntime"
-import { toLanguageLabel } from "src/libs/markdown/rendering"
 import {
   CodeBlockEditorHeader,
   CodeBlockEditorSurface,
   CodeBlockEditorWrapper,
-  CodeLanguageButton,
-  CodeLanguageOptionButton,
-  CodeLanguageOptionList,
-  CodeLanguagePicker,
-  CodeLanguagePopover,
-  CodeLanguageSearchInput,
   CodeWindowDots,
 } from "./codeBlockNodeViewStyles"
+import { CodeLanguageControl } from "./CodeLanguageControl"
 import {
   filterCodeLanguageOptions,
   hasExactCodeLanguageSearchMatch,
@@ -464,14 +457,19 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
 
   const exactSearchMatch = hasExactCodeLanguageSearchMatch(filteredLanguageOptions, languageSearch)
 
-  const applyLanguage = (value: string) => {
+  const toggleLanguageMenu = useCallback(() => {
+    setIsLanguageMenuOpen((prev) => !prev)
+    setLanguageSearch("")
+  }, [])
+
+  const applyLanguage = useCallback((value: string) => {
     const normalizedLanguage = normalizeCodeLanguage(value)
     setDraftLanguage(normalizedLanguage)
     rememberPreferredCodeLanguage(normalizedLanguage)
     updateAttributes({ language: normalizedLanguage || null })
     setIsLanguageMenuOpen(false)
     setLanguageSearch("")
-  }
+  }, [updateAttributes])
 
   const handleCodePaste = useCallback((event: ReactClipboardEvent<HTMLDivElement>) => {
     const plainText = event.clipboardData.getData("text/plain") || ""
@@ -528,51 +526,19 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
           <span data-tone="yellow" />
           <span data-tone="green" />
         </CodeWindowDots>
-        <CodeLanguagePicker ref={menuRef} data-code-language-control="true">
-          <CodeLanguageButton
-            type="button"
-            aria-haspopup="dialog"
-            aria-expanded={isLanguageMenuOpen}
-            aria-controls={`${menuId}-language-menu`}
-            onClick={() => {
-              setIsLanguageMenuOpen((prev) => !prev)
-              setLanguageSearch("")
-            }}
-          >
-            <span>{toLanguageLabel(draftLanguage)}</span>
-            <AppIcon name="chevron-down" aria-hidden="true" />
-          </CodeLanguageButton>
-          {isLanguageMenuOpen ? (
-            <CodeLanguagePopover id={`${menuId}-language-menu`} role="dialog" aria-label="코드 언어 선택">
-              <CodeLanguageSearchInput
-                ref={searchInputRef}
-                value={languageSearch}
-                placeholder="언어를 검색하세요"
-                aria-label="언어 검색"
-                onChange={(event) => setLanguageSearch(event.target.value)}
-              />
-              <CodeLanguageOptionList>
-                {filteredLanguageOptions.map((option) => (
-                  <CodeLanguageOptionButton
-                    key={option.value}
-                    type="button"
-                    data-active={draftLanguage === option.value}
-                    onClick={() => applyLanguage(option.value)}
-                  >
-                    <span>{option.label}</span>
-                    {draftLanguage === option.value ? <AppIcon name="check-circle" aria-hidden="true" /> : null}
-                  </CodeLanguageOptionButton>
-                ))}
-                {languageSearch.trim() && !exactSearchMatch ? (
-                  <CodeLanguageOptionButton type="button" onClick={() => applyLanguage(languageSearch)}>
-                    <span>{languageSearch.trim()}</span>
-                    <small>직접 입력</small>
-                  </CodeLanguageOptionButton>
-                ) : null}
-              </CodeLanguageOptionList>
-            </CodeLanguagePopover>
-          ) : null}
-        </CodeLanguagePicker>
+        <CodeLanguageControl
+          applyLanguage={applyLanguage}
+          draftLanguage={draftLanguage}
+          exactSearchMatch={exactSearchMatch}
+          filteredLanguageOptions={filteredLanguageOptions}
+          isLanguageMenuOpen={isLanguageMenuOpen}
+          languageSearch={languageSearch}
+          menuId={menuId}
+          menuRef={menuRef}
+          searchInputRef={searchInputRef}
+          setLanguageSearch={setLanguageSearch}
+          toggleLanguageMenu={toggleLanguageMenu}
+        />
       </CodeBlockEditorHeader>
       <CodeBlockEditorSurface>
         <div

--- a/front/src/components/editor/codeBlockNodeViewStyles.tsx
+++ b/front/src/components/editor/codeBlockNodeViewStyles.tsx
@@ -204,6 +204,10 @@ export const CodeBlockEditorSurface = styled.div`
     max-width: none;
     grid-area: 1 / 1;
     margin: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
     overflow: visible;
     padding: 1.05rem 1.18rem 1.6rem;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
@@ -211,6 +215,14 @@ export const CodeBlockEditorSurface = styled.div`
     font-size: 0.85rem;
     line-height: 1.5;
     white-space: pre;
+  }
+
+  .aq-code-shell > pre.aq-code-highlight-layer,
+  .aq-code-shell > .aq-code-editor-content {
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
   }
 
   .aq-code-highlight-layer {


### PR DESCRIPTION
## 관련 이슈

close #565

## 작업 배경

- `/editor/[id]` 507 복사 fixture 기준으로 기존 글 코드블럭 언어 버튼 첫 클릭이 dialog를 열고 옵션 선택 후 라벨을 갱신하도록 복구했습니다.
- 코드블럭 내부 highlight/content layer에 전역 `pre` chrome이 누수되어 안쪽 글쓰기 박스처럼 보이던 border/radius/background를 제거했습니다.

## 작업 내용

- `CodeLanguageControl`을 분리하고 `contentEditable={false}` + capture 단계 pointer/click handler로 ProseMirror selection 경계와 언어 선택 UI를 분리했습니다.
- 코드블럭 highlight/content layer에 높은 specificity의 chrome reset을 추가했습니다.
- 기존 998 mock route 테스트를 507 복사 fixture 기반 `/editor/[id]` 회귀 테스트로 바꾸고, dialog open/옵션 선택/scroll stability/내부 chrome 제거를 함께 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright test e2e/editor-authoring-code-mermaid.spec.ts -g "실제 /editor/\\[id\\] 수정 route 코드 언어 선택" --workers=4`
  - `yarn --cwd front playwright test e2e/source-boundary-editor-studio.spec.ts -g "NodeView import pipeline" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-code-mermaid.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front test:e2e:perf`
  - `yarn --cwd front test:e2e:a11y`
  - 참고 실패: `yarn --cwd front test:e2e`는 이번 범위 밖 기존 admin/source/selection 계약 26개 실패로 실패했습니다. 이 PR 범위 항목인 507 언어 선택과 NodeView budget은 이후 별도 재검증에서 통과했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 언어 선택 버튼 이벤트를 capture 단계에서 처리하므로 code block header 내부 pointer 흐름에만 영향이 있습니다. 본문 code drag/copy/paste 경로는 유지됩니다.
- 롤백 방법: 이 PR revert.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
