### PR TITLE
[Fix] 507 리스트 항목 selection overlay 복구

### DIFF
--- a/front/e2e/editor-authoring-list-affordances.spec.ts
+++ b/front/e2e/editor-authoring-list-affordances.spec.ts
@@ -1,12 +1,85 @@
-import { expect, test } from "@playwright/test"
+import { expect, test, type Page } from "@playwright/test"
 import {
   QA_ENGINE_ROUTE,
   QA_WRITER_ROUTE,
   expectListItemHandleReady,
   hoverListItemGutter,
 } from "./helpers/editorAuthoringFlow"
+import { mockEditorRouteWithPost507 } from "./helpers/post507Fixtures"
+
+const POST_507_FIRST_LIST_ITEM = "“Stateless가 좋다는데, 왜 좋은 거지?”"
+
+const readListItemSelectionOverlayMetrics = async (page: Page, label: string) =>
+  page.evaluate((targetLabel) => {
+    const readOwnLabel = (item: HTMLElement) =>
+      Array.from(item.childNodes)
+        .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+        .map((node) => node.textContent || "")
+        .join(" ")
+        .replace(/\s+/g, " ")
+        .trim()
+
+    const targetItem =
+      Array.from(
+        document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+      ).find((item) => readOwnLabel(item) === targetLabel) ?? null
+    const overlay = document.querySelector<HTMLElement>("[data-testid='keyboard-block-selection-overlay']")
+    if (!targetItem || !overlay) return null
+
+    const itemRect = targetItem.getBoundingClientRect()
+    const overlayRect = overlay.getBoundingClientRect()
+    const listRect = targetItem.closest("ul, ol")?.getBoundingClientRect() ?? itemRect
+    const itemStyle = window.getComputedStyle(targetItem)
+    return {
+      itemBackgroundColor: itemStyle.backgroundColor,
+      itemBoxShadow: itemStyle.boxShadow,
+      itemHeight: itemRect.height,
+      itemRight: itemRect.right,
+      itemTop: itemRect.top,
+      markerAwareLeft: Math.min(itemRect.left, listRect.left),
+      markerAwareRight: Math.max(itemRect.right, listRect.right),
+      overlayHeight: overlayRect.height,
+      overlayLeft: overlayRect.left,
+      overlayRight: overlayRect.right,
+      overlayTop: overlayRect.top,
+    }
+  }, label)
 
 test.describe("editor authoring list affordances", () => {
+  test("실제 /editor/[id] 507 리스트 항목 block selection은 글머리 안쪽 paint가 아니라 fixed overlay로 표시된다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+
+    const { editor } = await mockEditorRouteWithPost507(page, {
+      postId: 590,
+      title: "post 507 list item selection route 글",
+      version: 2,
+    })
+
+    const targetItem = editor.locator("li", { hasText: "Stateless가 좋다는데" }).first()
+    await expect(targetItem).toBeVisible()
+    await targetItem.scrollIntoViewIfNeeded()
+    await hoverListItemGutter(page, POST_507_FIRST_LIST_ITEM)
+
+    const { handleBox } = await expectListItemHandleReady(page, POST_507_FIRST_LIST_ITEM, "목록 항목 이동")
+    await page.mouse.click(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2)
+
+    const blockSelectionOverlay = page.getByTestId("keyboard-block-selection-overlay")
+    await expect(blockSelectionOverlay).toBeVisible()
+    const metrics = await readListItemSelectionOverlayMetrics(page, POST_507_FIRST_LIST_ITEM)
+    if (!metrics) {
+      throw new Error("post 507 list item selection overlay metrics are missing")
+    }
+
+    expect(Math.abs(metrics.overlayTop - metrics.itemTop)).toBeLessThanOrEqual(8)
+    expect(Math.abs(metrics.overlayHeight - metrics.itemHeight)).toBeLessThanOrEqual(12)
+    expect(metrics.overlayLeft).toBeLessThanOrEqual(metrics.markerAwareLeft + 4)
+    expect(metrics.overlayRight).toBeGreaterThanOrEqual(metrics.markerAwareRight - 4)
+    expect(metrics.itemBoxShadow).toBe("none")
+    expect(metrics.itemBackgroundColor).toBe("rgba(0, 0, 0, 0)")
+  })
+
   test("리스트 항목 안의 Tab/Shift+Tab은 Notion처럼 단계 승강으로 동작한다", async ({ page }) => {
     await page.goto(QA_ENGINE_ROUTE)
 
@@ -313,7 +386,7 @@ test.describe("editor authoring list affordances", () => {
     await expectListItemHandleReady(page, "Retry", "목록 항목 이동")
   })
 
-  test("writer surface의 선택된 리스트 항목 affordance는 파란 rail 없이 말머리 바깥에 유지된다", async ({
+  test("writer surface의 선택된 리스트 항목 affordance는 내부 paint 없이 fixed overlay로 표시된다", async ({
     page,
   }) => {
     await page.goto(QA_WRITER_ROUTE)
@@ -331,13 +404,22 @@ test.describe("editor authoring list affordances", () => {
 
     const { handleBox: dragHandleBox } = await expectListItemHandleReady(page, "Retry", "목록 항목 이동")
     await page.mouse.click(dragHandleBox.x + dragHandleBox.width / 2, dragHandleBox.y + dragHandleBox.height / 2)
-    await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
+    await expect(page.getByTestId("keyboard-block-selection-overlay")).toBeVisible()
     const selectedDragHandle = page.getByRole("button", { name: "목록 항목 이동" })
     await expect(selectedDragHandle).toBeVisible()
     const selectedMetrics = await expectListItemHandleReady(page, "Retry", "목록 항목 이동")
+    const overlayMetrics = await readListItemSelectionOverlayMetrics(page, "Retry")
+    if (!overlayMetrics) {
+      throw new Error("writer list item selection overlay metrics are missing")
+    }
     const selectedHandleBox = selectedMetrics.handleBox
 
+    expect(Math.abs(overlayMetrics.overlayTop - overlayMetrics.itemTop)).toBeLessThanOrEqual(8)
+    expect(Math.abs(overlayMetrics.overlayHeight - overlayMetrics.itemHeight)).toBeLessThanOrEqual(12)
+    expect(overlayMetrics.overlayLeft).toBeLessThanOrEqual(overlayMetrics.markerAwareLeft + 4)
+    expect(overlayMetrics.overlayRight).toBeGreaterThanOrEqual(overlayMetrics.markerAwareRight - 4)
     expect(selectedMetrics.boxShadow).toBe("none")
+    expect(overlayMetrics.itemBackgroundColor).toBe("rgba(0, 0, 0, 0)")
     expect(selectedMetrics.textLeft).not.toBeNull()
     expect(selectedHandleBox.x + selectedHandleBox.width + 6).toBeLessThanOrEqual(
       selectedMetrics.itemLeft
@@ -547,6 +629,6 @@ test.describe("editor authoring list affordances", () => {
         })
       )
       .toEqual(["Retry", "Access", "Refresh"])
-    await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
+    await expect(page.getByTestId("keyboard-block-selection-overlay")).toBeVisible()
   })
 })

--- a/front/src/components/editor/BlockEditorEngine.editorSurfaceStyles.tsx
+++ b/front/src/components/editor/BlockEditorEngine.editorSurfaceStyles.tsx
@@ -118,10 +118,9 @@ export const EditorViewport = styled.div`
 
   .aq-block-editor__content li[data-list-item="true"][data-block-selected="true"],
   .aq-block-editor__content li[data-task-item="true"][data-block-selected="true"] {
-    background: ${({ theme }) =>
-      theme.scheme === "dark" ? "rgba(59, 130, 246, 0.12)" : "rgba(59, 130, 246, 0.1)"};
-    box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.2);
-    border-radius: 10px;
+    background: transparent;
+    box-shadow: none;
+    border-radius: 0;
   }
 
   .aq-block-editor__content > *[data-block-dragging="true"] {

--- a/front/src/components/editor/BlockEditorEngine.tsx
+++ b/front/src/components/editor/BlockEditorEngine.tsx
@@ -153,7 +153,6 @@ const BlockEditorEngine = (props: BlockEditorEngineProps) => {
         runItalicAction={controller.runItalicAction}
         runStrikeAction={controller.runStrikeAction}
         scheduleBubbleHide={controller.scheduleBubbleHide}
-        selectedListItemContext={controller.selectedListItemContext}
         setIsBubbleInlineColorMenuOpen={controller.setIsBubbleInlineColorMenuOpen}
         setIsBubbleTextStyleMenuOpen={controller.setIsBubbleTextStyleMenuOpen}
         viewportRef={controller.viewportRef}

--- a/front/src/components/editor/BlockEditorEngine.viewportLayer.tsx
+++ b/front/src/components/editor/BlockEditorEngine.viewportLayer.tsx
@@ -406,7 +406,6 @@ export const BlockEditorViewportLayer = ({
   runItalicAction,
   runStrikeAction,
   scheduleBubbleHide,
-  selectedListItemContext,
   setIsBubbleInlineColorMenuOpen,
   setIsBubbleTextStyleMenuOpen,
   viewportRef,
@@ -469,7 +468,6 @@ export const BlockEditorViewportLayer = ({
   runItalicAction: () => void
   runStrikeAction: () => void
   scheduleBubbleHide: () => void
-  selectedListItemContext: unknown
   setIsBubbleInlineColorMenuOpen: Dispatch<SetStateAction<boolean>>
   setIsBubbleTextStyleMenuOpen: Dispatch<SetStateAction<boolean>>
   viewportRef: RefObject<HTMLDivElement | null>
@@ -552,10 +550,7 @@ export const BlockEditorViewportLayer = ({
         </DraggedBlockGhost>
       )
     })()}
-    {blockSelectionOverlayState.visible &&
-    !draggedBlockState &&
-    !draggedNestedListItemState &&
-    !selectedListItemContext ? (
+    {blockSelectionOverlayState.visible && !draggedBlockState && !draggedNestedListItemState ? (
       <BlockSelectionOverlay
         aria-hidden="true"
         data-testid="keyboard-block-selection-overlay"

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -55,7 +55,7 @@ export const resolveBlockChromeTop = (
 ) => (mode === "editor-local" ? top - (surfaceRect?.top ?? 0) : top)
 
 export const resolveBlockSelectionOverlayLayout = (
-  rect: DOMRect,
+  rect: Pick<DOMRect, "height" | "left" | "top" | "width">,
   surfaceRect: BlockChromeSurfaceRect
 ) => ({
   visible: true,

--- a/front/src/components/editor/useBlockEditorEngineBlockSelectionLayout.ts
+++ b/front/src/components/editor/useBlockEditorEngineBlockSelectionLayout.ts
@@ -56,6 +56,23 @@ type UseBlockEditorEngineBlockSelectionLayoutArgs = {
 
 const useBlockSelectionLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect
 
+const resolveNestedListItemSelectionRect = (
+  listItemElement: HTMLElement
+): Pick<DOMRect, "height" | "left" | "top" | "width"> => {
+  const itemRect = listItemElement.getBoundingClientRect()
+  const listRect = listItemElement.closest("ul, ol")?.getBoundingClientRect()
+  if (!listRect) return itemRect
+
+  const left = Math.min(itemRect.left, listRect.left)
+  const right = Math.max(itemRect.right, listRect.right)
+  return {
+    height: itemRect.height,
+    left,
+    top: itemRect.top,
+    width: Math.max(0, right - left),
+  }
+}
+
 export const useBlockEditorEngineBlockSelectionLayout = ({
   blockHandleRailMetricsRef,
   blockSelectionLayoutRectCacheRef,
@@ -100,7 +117,7 @@ export const useBlockEditorEngineBlockSelectionLayout = ({
       return next
     }
     if (selectedNestedListItemContext?.listItemElement?.isConnected) {
-      const rect = selectedNestedListItemContext.listItemElement.getBoundingClientRect()
+      const rect = resolveNestedListItemSelectionRect(selectedNestedListItemContext.listItemElement)
       const nextOverlayState: BlockSelectionOverlayState = resolveBlockSelectionOverlayLayout(rect, viewportRect)
       setBlockSelectionOverlayState((prev) =>
         isStableBlockSelectionOverlayState(prev, nextOverlayState) ? prev : nextOverlayState


### PR DESCRIPTION
## 관련 이슈

close #590

## 작업 배경

- 실제 `/editor/[id]` 507 copy route에서 리스트 항목 선택 표시가 글머리/내용 안쪽 `<li>` paint로 남던 회귀를 fixed overlay 기준으로 복구합니다.
- 선택된 리스트 항목은 marker/gutter-aware overlay로 표시하고, `<li>` 내부 background/box-shadow 선택 paint는 남기지 않습니다.

## 작업 내용

- selected list item 상태에서도 block selection overlay를 렌더하도록 viewport layer 조건을 정리했습니다.
- list item selection rect를 가까운 list root 좌우 경계까지 확장해 marker/gutter 포함 영역으로 계산합니다.
- selected `<li>` 내부 background/box-shadow paint를 제거했습니다.
- 507 copy `/editor/[id]` route 기반 E2E를 추가하고 기존 writer list affordance 기대값을 새 overlay 계약으로 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-507-list-item-selection-overlay bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front playwright:preflight`
  - `git diff --check`
  - RED 확인: `yarn --cwd front playwright test e2e/editor-authoring-list-affordances.spec.ts -g "실제 /editor/\\[id\\] 507 리스트 항목" --workers=1` (패치 전 overlay 미렌더로 실패)
  - `yarn --cwd front playwright test e2e/editor-authoring-list-affordances.spec.ts -g "실제 /editor/\\[id\\] 507 리스트 항목" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-list-affordances.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/source-boundary-editor-studio.spec.ts -g "NodeView import pipeline" --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front test:e2e:perf`
  - `yarn --cwd front test:e2e:a11y`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 리스트 항목 선택 overlay가 이전보다 넓게 보일 수 있습니다. 의도된 변경이며 `<li>` 내부 선택 블록보다 operation range가 명확해집니다.
- 롤백 방법: 이 PR의 단일 커밋 `4b16d9f7`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
