### PR TITLE
[Fix] 507 drag session cleanup 강화

### DIFF
--- a/front/e2e/editor-authoring-route-drag-cancel.spec.ts
+++ b/front/e2e/editor-authoring-route-drag-cancel.spec.ts
@@ -1,0 +1,254 @@
+import { expect, test, type Page } from "@playwright/test"
+import {
+  expectEditorToContainLoadedText,
+  expectListItemHandleReady,
+  hoverListItemGutter,
+} from "./helpers/editorAuthoringFlow"
+import { post507Markdown } from "./helpers/post507Fixtures"
+
+const adminMember = {
+  id: 1,
+  username: "qa-admin",
+  nickname: "aquila",
+  isAdmin: true,
+}
+
+const routePost507Editor = async (page: Page) => {
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(adminMember),
+    })
+  })
+  await page.route("**/post/api/v1/adm/posts/995", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: 995,
+        version: 5,
+        title: "live 507 drag cancel cleanup 글",
+        content: post507Markdown,
+        contentHtml: null,
+        published: true,
+        listed: true,
+      }),
+    })
+  })
+
+  await page.goto("/editor/995")
+  const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+  await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(
+    "live 507 drag cancel cleanup 글"
+  )
+  await expectEditorToContainLoadedText(editor, "Stateless 의미")
+  return editor
+}
+
+const readDragResidue = (page: Page) =>
+  page.evaluate(() => ({
+    cursor: document.body.style.cursor,
+    ghostCount: document.querySelectorAll("[data-testid='block-drag-ghost']").length,
+    indicatorCount: document.querySelectorAll("[data-testid='block-drop-indicator']").length,
+    scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+    userSelect: document.body.style.userSelect,
+  }))
+
+const readListItemDraggable = (page: Page, label: string) =>
+  page.evaluate((targetLabel) => {
+    const readOwnLabel = (item: HTMLElement) =>
+      Array.from(item.childNodes)
+        .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+        .map((node) => node.textContent || "")
+        .join(" ")
+        .replace(/\s+/g, " ")
+        .trim()
+    const targetItem = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")
+    ).find((item) => readOwnLabel(item) === targetLabel)
+    return targetItem?.getAttribute("draggable") ?? null
+  }, label)
+
+test.describe("editor authoring route drag cancel cleanup", () => {
+  test("live 507 block/list drag cancel은 stale ghost와 scroll lock을 남기지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const editor = await routePost507Editor(page)
+
+    const sourceParagraph = editor.locator("p", { hasText: "백엔드 인증을 처음 배우면" }).first()
+    const destinationParagraph = editor.locator("p", { hasText: "이 구조는 아주 직관적" }).first()
+    await sourceParagraph.scrollIntoViewIfNeeded()
+    await sourceParagraph.hover()
+    const dragHandle = page.getByTestId("block-drag-handle")
+    await expect(dragHandle).toBeVisible()
+    const [handleBox, destinationBox] = await Promise.all([
+      dragHandle.boundingBox(),
+      destinationParagraph.boundingBox(),
+    ])
+    if (!handleBox || !destinationBox) {
+      throw new Error("live 507 top-level drag cancel 좌표를 계산할 수 없습니다.")
+    }
+
+    const pointerId = 5951
+    await dragHandle.dispatchEvent("pointerdown", {
+      pointerId,
+      pointerType: "mouse",
+      button: 0,
+      buttons: 1,
+      clientX: handleBox.x + handleBox.width / 2,
+      clientY: handleBox.y + handleBox.height / 2,
+      bubbles: true,
+      cancelable: true,
+    })
+    await page.evaluate(
+      ({ endX, endY, pointerId: nextPointerId }) => {
+        window.dispatchEvent(
+          new PointerEvent("pointermove", {
+            pointerId: nextPointerId,
+            pointerType: "mouse",
+            button: 0,
+            buttons: 1,
+            clientX: endX,
+            clientY: endY,
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+      },
+      {
+        endX: destinationBox.x + Math.min(24, destinationBox.width / 3),
+        endY: destinationBox.y + destinationBox.height / 2,
+        pointerId,
+      }
+    )
+    await expect(page.getByTestId("block-drag-ghost")).toBeVisible()
+
+    await page.evaluate(() => window.dispatchEvent(new Event("blur")))
+    await expect.poll(() => readDragResidue(page)).toMatchObject({
+      cursor: "",
+      ghostCount: 0,
+      indicatorCount: 0,
+      userSelect: "",
+    })
+
+    const scrollBeforeTopLevelCancel = (await readDragResidue(page)).scrollTop
+    await page.mouse.wheel(0, 320)
+    await expect.poll(async () => (await readDragResidue(page)).scrollTop).toBeGreaterThan(
+      scrollBeforeTopLevelCancel + 80
+    )
+
+    const firstListItem = "“Stateless가 좋다는데, 왜 좋은 거지?”"
+    await editor.locator("li", { hasText: firstListItem }).first().scrollIntoViewIfNeeded()
+
+    await hoverListItemGutter(page, firstListItem)
+    const { handleBox: listHandleBox } = await expectListItemHandleReady(
+      page,
+      firstListItem,
+      "목록 항목 이동"
+    )
+    const listEscapeEnd = {
+      x: listHandleBox.x + listHandleBox.width / 2 + 12,
+      y: listHandleBox.y + listHandleBox.height / 2 + 48,
+    }
+
+    await page.mouse.move(listHandleBox.x + listHandleBox.width / 2, listHandleBox.y + listHandleBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(listEscapeEnd.x, listEscapeEnd.y, { steps: 12 })
+    await expect(page.getByTestId("block-drag-ghost")).toBeVisible()
+
+    await page.keyboard.press("Escape")
+    await expect.poll(() => readDragResidue(page)).toMatchObject({
+      cursor: "",
+      ghostCount: 0,
+      indicatorCount: 0,
+      userSelect: "",
+    })
+
+    await hoverListItemGutter(page, firstListItem)
+    const { handleBox: pointerCancelHandleBox } = await expectListItemHandleReady(
+      page,
+      firstListItem,
+      "목록 항목 이동"
+    )
+    const pointerCancelEnd = {
+      x: pointerCancelHandleBox.x + pointerCancelHandleBox.width / 2 + 12,
+      y: pointerCancelHandleBox.y + pointerCancelHandleBox.height / 2 + 48,
+    }
+
+    await page.mouse.move(
+      pointerCancelHandleBox.x + pointerCancelHandleBox.width / 2,
+      pointerCancelHandleBox.y + pointerCancelHandleBox.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(pointerCancelEnd.x, pointerCancelEnd.y, { steps: 12 })
+    await expect(page.getByTestId("block-drag-ghost")).toBeVisible()
+
+    await page.evaluate(
+      ({ endX, endY, pointerId: nextPointerId }) => {
+        window.dispatchEvent(
+          new PointerEvent("pointercancel", {
+            pointerId: nextPointerId,
+            pointerType: "mouse",
+            button: 0,
+            buttons: 0,
+            clientX: endX,
+            clientY: endY,
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+      },
+      {
+        endX: pointerCancelEnd.x,
+        endY: pointerCancelEnd.y,
+        pointerId: 1,
+      }
+    )
+    await page.mouse.up()
+    await expect.poll(() => readDragResidue(page)).toMatchObject({
+      cursor: "",
+      ghostCount: 0,
+      indicatorCount: 0,
+      userSelect: "",
+    })
+
+    const scrollBeforeListCancel = (await readDragResidue(page)).scrollTop
+    await page.mouse.wheel(0, 320)
+    await expect.poll(async () => (await readDragResidue(page)).scrollTop).toBeGreaterThan(
+      scrollBeforeListCancel + 80
+    )
+  })
+
+  test("live 507 list pending drag cancel은 draggable을 복구한다", async ({ page }) => {
+    await page.setViewportSize({ width: 980, height: 720 })
+    const editor = await routePost507Editor(page)
+    const firstListItem = "“Stateless가 좋다는데, 왜 좋은 거지?”"
+    await editor.locator("li", { hasText: firstListItem }).first().scrollIntoViewIfNeeded()
+
+    await hoverListItemGutter(page, firstListItem)
+    const { handleBox: pendingHandleBox } = await expectListItemHandleReady(
+      page,
+      firstListItem,
+      "목록 항목 이동"
+    )
+    await page.getByRole("button", { name: "목록 항목 이동" }).dispatchEvent("pointerdown", {
+      pointerId: 5950,
+      pointerType: "mouse",
+      button: 0,
+      buttons: 1,
+      clientX: pendingHandleBox.x + pendingHandleBox.width / 2,
+      clientY: pendingHandleBox.y + pendingHandleBox.height / 2,
+      bubbles: true,
+      cancelable: true,
+    })
+    await page.keyboard.press("Escape")
+
+    await expect.poll(() => readListItemDraggable(page, firstListItem)).toBe("true")
+    await expect.poll(() => readDragResidue(page)).toMatchObject({
+      cursor: "",
+      ghostCount: 0,
+      indicatorCount: 0,
+      userSelect: "",
+    })
+  })
+})

--- a/front/src/components/editor/useBlockEditorEngineBlockDragSessions.ts
+++ b/front/src/components/editor/useBlockEditorEngineBlockDragSessions.ts
@@ -1,5 +1,5 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
-import { useCallback, useEffect } from "react"
+import { useCallback, useEffect, useRef } from "react"
 import type { Dispatch, DragEvent as ReactDragEvent, MutableRefObject, RefObject, SetStateAction } from "react"
 import {
   moveNestedListItemToInsertionIndex,
@@ -93,11 +93,20 @@ export const useBlockEditorEngineBlockDragSessions = ({
   setNestedListItemDropIndicatorState,
   setSelectedListItemContext,
 }: UseBlockEditorEngineBlockDragSessionsArgs) => {
+  const topLevelBlockEarlyPointerDoneCleanupRef = useRef<(() => void) | null>(null)
+
   const clearBlockDragVisualState = useCallback(() => {
     setDraggedBlockState(null)
     setDragGhostPosition(null)
     setDropIndicatorState(hideDropIndicatorState)
   }, [setDragGhostPosition, setDraggedBlockState, setDropIndicatorState])
+
+  const cleanupTopLevelBlockEarlyPointerDone = useCallback(() => {
+    const cleanup = topLevelBlockEarlyPointerDoneCleanupRef.current
+    if (!cleanup) return
+    topLevelBlockEarlyPointerDoneCleanupRef.current = null
+    cleanup()
+  }, [])
 
   const commitTopLevelBlockDrag = useCallback(
     (sourceIndex: number, clientY: number) => {
@@ -116,6 +125,7 @@ export const useBlockEditorEngineBlockDragSessions = ({
 
   const beginBlockDragFromPending = useCallback(
     (pending: PendingBlockDragState, clientX: number, clientY: number) => {
+      cleanupTopLevelBlockEarlyPointerDone()
       const indicator = resolveBlockDropIndicatorByClientY(getTopLevelBlockElements(), clientY)
       setDraggedBlockState(createDraggedBlockState(pending))
       setDragGhostPosition({ x: clientX, y: clientY })
@@ -129,9 +139,17 @@ export const useBlockEditorEngineBlockDragSessions = ({
           window.clearTimeout(earlyPointerDoneTimeout)
           earlyPointerDoneTimeout = null
         }
+        if (topLevelBlockEarlyPointerDoneCleanupRef.current === cleanupEarlyPointerDone) {
+          topLevelBlockEarlyPointerDoneCleanupRef.current = null
+        }
       }
       const handleEarlyPointerDone = (event: PointerEvent) => {
         if (event.pointerId !== pending.pointerId) return
+        if (event.type === "pointercancel") {
+          clearBlockDragVisualState()
+          cleanupEarlyPointerDone()
+          return
+        }
         const committedEvent = event as BlockDragCommittedPointerEvent
         committedEvent.__aqBlockDragCommitted = true
         commitTopLevelBlockDrag(pending.sourceIndex, event.clientY)
@@ -141,50 +159,103 @@ export const useBlockEditorEngineBlockDragSessions = ({
 
       window.addEventListener("pointerup", handleEarlyPointerDone, true)
       window.addEventListener("pointercancel", handleEarlyPointerDone, true)
-      earlyPointerDoneTimeout = window.setTimeout(cleanupEarlyPointerDone, 30000)
+      topLevelBlockEarlyPointerDoneCleanupRef.current = cleanupEarlyPointerDone
+      earlyPointerDoneTimeout = window.setTimeout(cleanupEarlyPointerDone, 1500)
     },
-    [clearBlockDragVisualState, commitTopLevelBlockDrag, getTopLevelBlockElements, setDragGhostPosition, setDraggedBlockState, setDropIndicatorState]
+    [
+      cleanupTopLevelBlockEarlyPointerDone,
+      clearBlockDragVisualState,
+      commitTopLevelBlockDrag,
+      getTopLevelBlockElements,
+      setDragGhostPosition,
+      setDraggedBlockState,
+      setDropIndicatorState,
+    ]
   )
 
   useEffect(() => {
     if (typeof window === "undefined" || !draggedBlockState) return
+    const activeDraggedBlockState = draggedBlockState
 
-    const handlePointerMove = (event: PointerEvent) => {
-      if (event.pointerId !== draggedBlockState.pointerId) return
+    let cleanedUp = false
+    let scheduledBlurCancelTimeout: number | null = null
+    function cleanupListeners() {
+      if (cleanedUp) return
+      cleanedUp = true
+      cleanupTopLevelBlockEarlyPointerDone()
+      clearScheduledBlurCancel()
+      window.removeEventListener("pointermove", handlePointerMove)
+      window.removeEventListener("pointerup", handlePointerUp)
+      window.removeEventListener("pointercancel", handlePointerCancel)
+      window.removeEventListener("blur", handleBlurCancelDragSession, true)
+      window.removeEventListener("keydown", handleKeyDown, true)
+      window.removeEventListener("wheel", cancelDragSession, true)
+      document.removeEventListener("visibilitychange", handleVisibilityChange, true)
+    }
+
+    function cancelDragSession() {
+      clearBlockDragVisualState()
+      cleanupListeners()
+    }
+    function clearScheduledBlurCancel() {
+      if (scheduledBlurCancelTimeout === null) return
+      window.clearTimeout(scheduledBlurCancelTimeout)
+      scheduledBlurCancelTimeout = null
+    }
+    function scheduleBlurCancel() {
+      clearScheduledBlurCancel()
+      scheduledBlurCancelTimeout = window.setTimeout(() => {
+        scheduledBlurCancelTimeout = null
+        cancelDragSession()
+      }, 1500)
+    }
+    function handlePointerMove(event: PointerEvent) {
+      if (event.pointerId !== activeDraggedBlockState.pointerId) return
+      clearScheduledBlurCancel()
       const nextIndicator = resolveBlockDropIndicatorByClientY(getTopLevelBlockElements(), event.clientY)
       setDropIndicatorState(createDropIndicatorState(nextIndicator))
       setDragGhostPosition({ x: event.clientX, y: event.clientY })
     }
-
-    const handlePointerUp = (event: PointerEvent) => {
-      if (event.pointerId !== draggedBlockState.pointerId) return
+    function handlePointerUp(event: PointerEvent) {
+      if (event.pointerId !== activeDraggedBlockState.pointerId) return
+      clearScheduledBlurCancel()
       if ((event as BlockDragCommittedPointerEvent).__aqBlockDragCommitted) {
         clearBlockDragVisualState()
-        window.removeEventListener("pointermove", handlePointerMove)
-        window.removeEventListener("pointerup", handlePointerUp)
-        window.removeEventListener("pointercancel", handlePointerUp)
+        cleanupListeners()
         return
       }
 
-      commitTopLevelBlockDrag(draggedBlockState.sourceIndex, event.clientY)
+      commitTopLevelBlockDrag(activeDraggedBlockState.sourceIndex, event.clientY)
 
-      setDraggedBlockState(null)
-      setDragGhostPosition(null)
-      setDropIndicatorState(hideDropIndicatorState)
-      window.removeEventListener("pointermove", handlePointerMove)
-      window.removeEventListener("pointerup", handlePointerUp)
-      window.removeEventListener("pointercancel", handlePointerUp)
+      clearBlockDragVisualState()
+      cleanupListeners()
+    }
+    function handlePointerCancel(event: PointerEvent) {
+      if (event.pointerId !== activeDraggedBlockState.pointerId) return
+      cancelDragSession()
+    }
+    function handleBlurCancelDragSession() {
+      scheduleBlurCancel()
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return
+      cancelDragSession()
+    }
+    function handleVisibilityChange() {
+      if (document.visibilityState === "hidden") cancelDragSession()
     }
 
     window.addEventListener("pointermove", handlePointerMove)
     window.addEventListener("pointerup", handlePointerUp)
-    window.addEventListener("pointercancel", handlePointerUp)
+    window.addEventListener("pointercancel", handlePointerCancel)
+    window.addEventListener("blur", handleBlurCancelDragSession, true)
+    window.addEventListener("keydown", handleKeyDown, true)
+    window.addEventListener("wheel", cancelDragSession, { capture: true, passive: true })
+    document.addEventListener("visibilitychange", handleVisibilityChange, true)
     return () => {
-      window.removeEventListener("pointermove", handlePointerMove)
-      window.removeEventListener("pointerup", handlePointerUp)
-      window.removeEventListener("pointercancel", handlePointerUp)
+      cleanupListeners()
     }
-  }, [clearBlockDragVisualState, commitTopLevelBlockDrag, draggedBlockState, getTopLevelBlockElements, setDragGhostPosition, setDraggedBlockState, setDropIndicatorState])
+  }, [cleanupTopLevelBlockEarlyPointerDone, clearBlockDragVisualState, commitTopLevelBlockDrag, draggedBlockState, getTopLevelBlockElements, setDragGhostPosition, setDropIndicatorState])
 
   useEffect(() => {
     if (typeof document === "undefined" || !draggedBlockState) return
@@ -265,22 +336,60 @@ export const useBlockEditorEngineBlockDragSessions = ({
     setNestedListItemDropIndicatorState(hideNestedListItemDropIndicatorState)
   }, [setDragGhostPosition, setDraggedNestedListItemState, setNestedListItemDropIndicatorState])
 
+  const cancelNestedListItemDragSession = useCallback(() => {
+    const pending = pendingNestedListItemHandleDragRef.current
+    if (pending?.context.listItemElement.isConnected) pending.context.listItemElement.setAttribute("draggable", "true")
+    clearNestedListItemDragState()
+    clearPendingNestedListItemHandleDrag()
+  }, [clearNestedListItemDragState, clearPendingNestedListItemHandleDrag, pendingNestedListItemHandleDragRef])
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !draggedNestedListItemState) return
+    let scheduledBlurCancelTimeout: number | null = null
+
+    const clearScheduledBlurCancel = () => {
+      if (scheduledBlurCancelTimeout === null) return
+      window.clearTimeout(scheduledBlurCancelTimeout)
+      scheduledBlurCancelTimeout = null
+    }
+    const handleBlurCancelDragSession = () => {
+      clearScheduledBlurCancel()
+      scheduledBlurCancelTimeout = window.setTimeout(() => {
+        scheduledBlurCancelTimeout = null
+        cancelNestedListItemDragSession()
+      }, 1500)
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return
+      clearScheduledBlurCancel()
+      cancelNestedListItemDragSession()
+    }
+    const handleVisibilityChange = () => {
+      clearScheduledBlurCancel()
+      if (document.visibilityState === "hidden") cancelNestedListItemDragSession()
+    }
+
+    window.addEventListener("blur", handleBlurCancelDragSession, true)
+    window.addEventListener("keydown", handleKeyDown, true)
+    window.addEventListener("wheel", cancelNestedListItemDragSession, { capture: true, passive: true })
+    document.addEventListener("visibilitychange", handleVisibilityChange, true)
+    return () => {
+      clearScheduledBlurCancel()
+      window.removeEventListener("blur", handleBlurCancelDragSession, true)
+      window.removeEventListener("keydown", handleKeyDown, true)
+      window.removeEventListener("wheel", cancelNestedListItemDragSession, true)
+      document.removeEventListener("visibilitychange", handleVisibilityChange, true)
+    }
+  }, [cancelNestedListItemDragSession, draggedNestedListItemState])
+
   const beginPendingNestedListItemHandleDrag = useCallback(
     (pointerId: number, startX: number, startY: number, context: NestedListItemContext) => {
       clearPendingNestedListItemHandleDrag()
       flushPendingMarkdownCommit()
       const sourceElement = context.listItemElement
-      if (sourceElement.isConnected) {
-        sourceElement.setAttribute("draggable", "false")
-      }
+      if (sourceElement.isConnected) sourceElement.setAttribute("draggable", "false")
       const preview = createNestedListItemDragPreview(sourceElement, window.innerWidth)
-      pendingNestedListItemHandleDragRef.current = createPendingNestedListItemHandleDragState(
-        pointerId,
-        startX,
-        startY,
-        context,
-        preview
-      )
+      pendingNestedListItemHandleDragRef.current = createPendingNestedListItemHandleDragState(pointerId, startX, startY, context, preview)
       clearStickyTopLevelBlockSelection()
       const currentEditor = editorRef.current ?? editor
       if (currentEditor) {
@@ -288,9 +397,16 @@ export const useBlockEditorEngineBlockDragSessions = ({
         clearNativeTextSelection()
       }
 
+      let scheduledPendingBlurCancelTimeout: number | null = null
+      const clearScheduledPendingBlurCancel = () => {
+        if (scheduledPendingBlurCancelTimeout === null) return
+        window.clearTimeout(scheduledPendingBlurCancelTimeout)
+        scheduledPendingBlurCancelTimeout = null
+      }
       const handlePointerMove = (moveEvent: PointerEvent) => {
         const pending = pendingNestedListItemHandleDragRef.current
         if (!pending || moveEvent.pointerId !== pending.pointerId) return
+        clearScheduledPendingBlurCancel()
         const distance = Math.hypot(moveEvent.clientX - pending.startX, moveEvent.clientY - pending.startY)
         if (!pending.started) {
           if (distance < 5) return
@@ -328,6 +444,8 @@ export const useBlockEditorEngineBlockDragSessions = ({
       const handlePointerDone = (doneEvent: PointerEvent) => {
         const pending = pendingNestedListItemHandleDragRef.current
         if (!pending || doneEvent.pointerId !== pending.pointerId) return
+        clearScheduledPendingBlurCancel()
+        if (doneEvent.type === "pointercancel") return cancelNestedListItemDragSession()
         if (!pending.started) {
           if (pending.context.listItemElement.isConnected) {
             pending.context.listItemElement.setAttribute("draggable", "true")
@@ -371,18 +489,45 @@ export const useBlockEditorEngineBlockDragSessions = ({
         clearNestedListItemDragState()
         clearPendingNestedListItemHandleDrag()
       }
+      const handleCancelPendingDragSession = () => {
+        clearScheduledPendingBlurCancel()
+        cancelNestedListItemDragSession()
+      }
+      const handlePendingBlurCancel = () => {
+        clearScheduledPendingBlurCancel()
+        scheduledPendingBlurCancelTimeout = window.setTimeout(() => {
+          scheduledPendingBlurCancelTimeout = null
+          cancelNestedListItemDragSession()
+        }, 1500)
+      }
+      const handlePendingKeyDown = (event: KeyboardEvent) => {
+        if (event.key === "Escape") handleCancelPendingDragSession()
+      }
+      const handlePendingVisibilityChange = () => {
+        if (document.visibilityState === "hidden") handleCancelPendingDragSession()
+      }
 
       window.addEventListener("pointermove", handlePointerMove)
       window.addEventListener("pointerup", handlePointerDone)
       window.addEventListener("pointercancel", handlePointerDone)
+      window.addEventListener("blur", handlePendingBlurCancel, true)
+      window.addEventListener("keydown", handlePendingKeyDown, true)
+      window.addEventListener("wheel", handleCancelPendingDragSession, { capture: true, passive: true })
+      document.addEventListener("visibilitychange", handlePendingVisibilityChange, true)
 
       pendingNestedListItemHandleDragCleanupRef.current = () => {
+        clearScheduledPendingBlurCancel()
         window.removeEventListener("pointermove", handlePointerMove)
         window.removeEventListener("pointerup", handlePointerDone)
         window.removeEventListener("pointercancel", handlePointerDone)
+        window.removeEventListener("blur", handlePendingBlurCancel, true)
+        window.removeEventListener("keydown", handlePendingKeyDown, true)
+        window.removeEventListener("wheel", handleCancelPendingDragSession, true)
+        document.removeEventListener("visibilitychange", handlePendingVisibilityChange, true)
       }
     },
     [
+      cancelNestedListItemDragSession,
       clearNativeTextSelection,
       clearNestedListItemDragState,
       clearPendingNestedListItemHandleDrag,
@@ -435,8 +580,8 @@ export const useBlockEditorEngineBlockDragSessions = ({
   )
 
   const handleViewportDragEnd = useCallback(() => {
-    clearNestedListItemDragState()
-  }, [clearNestedListItemDragState])
+    cancelNestedListItemDragSession()
+  }, [cancelNestedListItemDragSession])
 
   return {
     beginBlockDragFromPending,


### PR DESCRIPTION
## 관련 이슈

close #595

## 작업 배경

- `/editor/[id]` 507 copy route에서 block/list drag cancel 후 stale ghost/drop indicator와 `body.userSelect=none`이 남는 회귀를 수정했습니다.
- pointerup/drop 정상 경로 외 `pointercancel`, window blur, visibilitychange, Escape, wheel intent에서도 drag session을 정리합니다.

## 작업 내용

- top-level block drag의 early pointer cleanup을 명시 ref로 관리하고 cancel 이벤트에서는 commit이 아닌 cancel cleanup을 수행합니다.
- block/list drag session에 blur/visibility/Escape/wheel cleanup 경로를 추가해 scroll/selection lock 잔상을 제거합니다.
- 507 fixture 기반 `/editor/995` 회귀 spec을 추가해 block drag blur cancel, list drag Escape cancel, 이후 wheel scroll 회복을 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-507-drag-session-cleanup bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-drag-cancel.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-block-selection.spec.ts -g "table block handle drag" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-block-selection.spec.ts e2e/editor-authoring-list-affordances.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `git diff --check`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front test:e2e:perf`
  - `yarn --cwd front test:e2e:a11y`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: drag cancel 이벤트가 너무 적극적으로 동작하면 정상 drag commit을 취소할 수 있습니다. 이를 막기 위해 기존 table block handle drag와 live drag sequence를 함께 검증했습니다.
- 롤백 방법: 이 PR의 merge commit을 revert하면 이전 drag session 동작으로 복구됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
