### PR TITLE
[Fix] 507 수정 페이지 코드블럭 내부 빈 body 복구

### DIFF
--- a/front/e2e/editor-authoring-code-mermaid.spec.ts
+++ b/front/e2e/editor-authoring-code-mermaid.spec.ts
@@ -4,9 +4,7 @@ import { mockEditorRouteWithPost507 } from "./helpers/post507Fixtures"
 
 const expectCodeBlockInnerChromeHidden = async (codeBlock: Locator) => {
   const chrome = await codeBlock.evaluate((element) => {
-    const readChrome = (selector: string) => {
-      const node = element.querySelector<HTMLElement>(selector)
-      if (!node) throw new Error(`${selector} is missing`)
+    const readNodeChrome = (node: HTMLElement, selector: string) => {
       const style = window.getComputedStyle(node)
       return {
         backgroundColor: style.backgroundColor,
@@ -16,25 +14,44 @@ const expectCodeBlockInnerChromeHidden = async (codeBlock: Locator) => {
         borderRightWidth: style.borderRightWidth,
         borderTopWidth: style.borderTopWidth,
         boxShadow: style.boxShadow,
+        selector,
+        tagName: node.tagName,
       }
     }
+    const readChrome = (selector: string) => {
+      const node = element.querySelector<HTMLElement>(selector)
+      if (!node) throw new Error(`${selector} is missing`)
+      return readNodeChrome(node, selector)
+    }
+    const readAllChrome = (selector: string) =>
+      Array.from(element.querySelectorAll<HTMLElement>(selector)).map((node) =>
+        readNodeChrome(node, selector)
+      )
 
     return {
       content: readChrome(".aq-code-editor-content"),
+      contentDescendants: [
+        ...readAllChrome(".aq-code-editor-content > *"),
+        ...readAllChrome(".aq-code-editor-content pre"),
+        ...readAllChrome(".aq-code-editor-content code"),
+        ...readAllChrome(".aq-code-highlight-layer code"),
+      ],
       highlight: readChrome(".aq-code-highlight-layer"),
     }
   })
 
-  for (const layer of [chrome.highlight, chrome.content]) {
+  for (const layer of [chrome.highlight, chrome.content, ...chrome.contentDescendants]) {
     expect([
       layer.borderTopWidth,
       layer.borderRightWidth,
       layer.borderBottomWidth,
       layer.borderLeftWidth,
-    ]).toEqual(["0px", "0px", "0px", "0px"])
-    expect(layer.borderRadius).toBe("0px")
-    expect(layer.boxShadow).toBe("none")
-    expect(layer.backgroundColor).toBe("rgba(0, 0, 0, 0)")
+    ], `${layer.selector} ${layer.tagName} border should be reset`).toEqual(["0px", "0px", "0px", "0px"])
+    expect(layer.borderRadius, `${layer.selector} ${layer.tagName} radius should be reset`).toBe("0px")
+    expect(layer.boxShadow, `${layer.selector} ${layer.tagName} shadow should be reset`).toBe("none")
+    expect(layer.backgroundColor, `${layer.selector} ${layer.tagName} background should be reset`).toBe(
+      "rgba(0, 0, 0, 0)"
+    )
   }
 }
 
@@ -169,6 +186,11 @@ test.describe("editor authoring code and mermaid blocks", () => {
     await expect(codeBlock).toBeVisible({ timeout: 15_000 })
     await expect(codeBlock.locator(".aq-code-highlight-layer")).toContainText("로그인 -> 세션 생성")
     await expectCodeBlockInnerChromeHidden(codeBlock)
+
+    const jwtCodeBlock = page.locator("[data-code-block-wrapper='true']").filter({ hasText: "\"userId\": 123" })
+    await expect(jwtCodeBlock).toHaveCount(1)
+    await expect(jwtCodeBlock.locator(".aq-code-highlight-layer")).toContainText("\"role\": \"USER\"")
+    await expectCodeBlockInnerChromeHidden(jwtCodeBlock)
 
     await page.evaluate(() => {
       const diagnosticsWindow = window as typeof window & {

--- a/front/e2e/editor-authoring-ssr-initial-post.spec.ts
+++ b/front/e2e/editor-authoring-ssr-initial-post.spec.ts
@@ -1,12 +1,40 @@
 import { readFileSync } from "node:fs"
 import path from "node:path"
-import { expect, test } from "@playwright/test"
+import { expect, test, type Page } from "@playwright/test"
 
 const adminMember = {
   id: 1,
   username: "qa-admin",
   nickname: "aquila",
   isAdmin: true,
+}
+
+const pushEditorRoute = async (page: Page, postId: number) => {
+  await page.goto("/", { waitUntil: "domcontentloaded" })
+  await expect
+    .poll(async () => {
+      try {
+        return await page.evaluate(() => {
+          const router = (
+            window as typeof window & {
+              next?: { router?: { push?: (url: string) => Promise<boolean>; isReady?: boolean } }
+            }
+          ).next?.router
+          return Boolean(router?.push && router.isReady !== false)
+        })
+      } catch {
+        return false
+      }
+    })
+    .toBe(true)
+  await page.evaluate((nextPostId) => {
+    const router = (window as typeof window & { next?: { router?: { push?: (url: string) => Promise<boolean> } } })
+      .next?.router
+    if (!router?.push) throw new Error("Next router is missing")
+    window.setTimeout(() => {
+      void router.push(`/editor/${nextPostId}`)
+    }, 0)
+  }, postId)
 }
 
 test.describe("editor authoring SSR initial post contract", () => {
@@ -34,6 +62,8 @@ test.describe("editor authoring SSR initial post contract", () => {
     expect(routingSource).toContain("void loadPostForEditor(queryPostId, { initialPost })")
     expect(draftLifecycleSource).toContain("options.initialPost")
     expect(draftLifecycleSource).toContain("initialPost ??")
+    expect(draftLifecycleSource).toContain("const freshPost = await")
+    expect(draftLifecycleSource).toContain("post = freshPost")
   })
 
   test("SSR initialEditorPost가 있으면 client admin post 401에도 에디터 본문을 유지한다", async ({
@@ -93,37 +123,85 @@ test.describe("editor authoring SSR initial post contract", () => {
       })
     })
 
-    await page.goto("/", { waitUntil: "domcontentloaded" })
-    await expect
-      .poll(async () => {
-        try {
-          return await page.evaluate(() => {
-            const router = (
-              window as typeof window & {
-                next?: { router?: { push?: (url: string) => Promise<boolean>; isReady?: boolean } }
-              }
-            ).next?.router
-            return Boolean(router?.push && router.isReady !== false)
-          })
-        } catch {
-          return false
-        }
-      })
-      .toBe(true)
-    await page.evaluate(() => {
-      const router = (window as typeof window & { next?: { router?: { push?: (url: string) => Promise<boolean> } } })
-        .next?.router
-      if (!router?.push) throw new Error("Next router is missing")
-      window.setTimeout(() => {
-        void router.push("/editor/997")
-      }, 0)
-    })
+    await pushEditorRoute(page, 997)
 
     await expect(page).toHaveURL(/\/editor\/997/)
     await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("SSR 초기 hydrate 글")
     const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
     await expect(editor).toContainText("SSR 초기 본문")
     await expect(editor.locator("td", { hasText: "initialEditorPost 유지" }).first()).toBeVisible()
-    expect(clientPostFetchCount).toBe(0)
+    expect(clientPostFetchCount).toBe(1)
+  })
+
+  test("SSR initialEditorPost의 빈 코드블럭은 client admin content로 복구한다", async ({
+    page,
+  }) => {
+    const staleContent = ["## JWT 내부 예시", "", "```", "```"].join("\n")
+    const freshContent = [
+      "## JWT 내부 예시",
+      "",
+      "```",
+      "{",
+      "  \"userId\": 123,",
+      "  \"role\": \"USER\"",
+      "}",
+      "```",
+    ].join("\n")
+    let clientPostFetchCount = 0
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/996", async (route) => {
+      clientPostFetchCount += 1
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 996,
+          version: 4,
+          title: "SSR stale code hydrate 글",
+          content: freshContent,
+          contentHtml: null,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+    await page.route("**/_next/data/**/editor/996.json**", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          pageProps: {
+            dehydratedState: {
+              mutations: [],
+              queries: [],
+            },
+            initialMember: adminMember,
+            initialEditorPost: {
+              id: 996,
+              version: 3,
+              title: "SSR stale code hydrate 글",
+              content: staleContent,
+              contentHtml: null,
+              published: true,
+              listed: true,
+            },
+          },
+          __N_SSP: true,
+        }),
+      })
+    })
+
+    await pushEditorRoute(page, 996)
+
+    await expect(page).toHaveURL(/\/editor\/996/)
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("SSR stale code hydrate 글")
+    const codeBlock = page.locator("[data-code-block-wrapper='true']").filter({ hasText: "\"userId\": 123" })
+    await expect(codeBlock).toHaveCount(1)
+    await expect(codeBlock.locator(".aq-code-highlight-layer")).toContainText("\"role\": \"USER\"")
+    expect(clientPostFetchCount).toBe(1)
   })
 })

--- a/front/src/routes/Admin/useEditorStudioDraftLifecycle.ts
+++ b/front/src/routes/Admin/useEditorStudioDraftLifecycle.ts
@@ -357,9 +357,19 @@ export const useEditorStudioDraftLifecycle = ({
         String(options.initialPost?.id ?? "") === normalizedTargetPostId
           ? options.initialPost
           : null
-      const post =
+      let post =
         initialPost ??
         (await apiFetch<PostForEditor>(`/post/api/v1/adm/posts/${normalizedTargetPostId}`))
+      if (initialPost) {
+        try {
+          const freshPost = await apiFetch<PostForEditor>(`/post/api/v1/adm/posts/${normalizedTargetPostId}`)
+          if ((freshPost.content ?? "").trim().length > 0 || freshPost.contentHtml) {
+            post = freshPost
+          }
+        } catch {
+          // SSR initialPost is still a valid fallback when the client-side refresh fails.
+        }
+      }
       let resolvedPost = post
 
       const adminContent = resolvedPost.content ?? ""


### PR DESCRIPTION
## 관련 이슈

close #565

## 작업 배경

- 507 복사본 `/editor/[id]`에서 코드블럭 body가 비어 보이는 원인을 SSR `initialPost` 우선 load 경로로 고정하고, client admin `content`를 fresh reconcile하도록 수정했습니다.
- client admin fetch 실패 시에는 기존 SSR snapshot fallback을 유지해 수정 페이지 진입 안정성은 보존합니다.

## 작업 내용

- `/editor/[id]` load 시 SSR `initialPost`가 있어도 client admin post payload를 한 번 재조회해 raw markdown 코드 본문을 우선 사용합니다.
- SSR initialPost regression spec에 fresh code body 복구 케이스를 추가했습니다.
- 507 route code block E2E에서 `JWT 내부 예시` 본문과 inner highlight/content layer chrome reset을 함께 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-codeblock-inner-chrome-followup bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-code-mermaid.spec.ts -g "실제 /editor/\\[id\\] 수정 route 코드 언어 선택" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-ssr-initial-post.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-ssr-initial-post.spec.ts e2e/editor-authoring-code-mermaid.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front test:e2e:perf`
  - `yarn --cwd front test:e2e:a11y`

  Note: 첫 `test:e2e:authoring` 실행에서 `editor-authoring-route-live-drag-sequence.spec.ts` scrollTop timing assertion 1건이 실패했고, 동일 단일 테스트 재실행 및 전체 authoring 재실행은 통과했습니다. 코드블럭 body 빈 화면과는 다른 flaky timing으로 분류했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: `/editor/[id]` 초기 진입 시 client admin post 조회가 1회 추가됩니다. 해당 fetch가 실패하면 기존 SSR `initialPost` fallback을 유지합니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 SSR `initialPost` 우선 load 경로로 되돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
