### PR TITLE
[Test] editor 507 실제 기능 E2E 계약 고정

### DIFF
--- a/front/e2e/editor-authoring-507-contract.spec.ts
+++ b/front/e2e/editor-authoring-507-contract.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import {
+  mockEditorRouteWithPost507,
+  POST_507_REAL_FEATURE_CONTRACT,
+  readPost507EditorDiagnostics,
+} from "./helpers/post507Fixtures"
+
+const e2eRoot = path.resolve(process.cwd(), "e2e")
+const helperSource = (relativePath: string) => readFileSync(path.join(e2eRoot, relativePath), "utf8")
+
+test.describe("editor 507 real feature E2E contract", () => {
+  test("사용자 체감 editor close gate는 507 copy route coverage manifest로 고정된다", () => {
+    expect(POST_507_REAL_FEATURE_CONTRACT.editorRoute).toBe("/editor/[id]")
+    expect(POST_507_REAL_FEATURE_CONTRACT.fixtureName).toBe("post507Markdown")
+    expect(POST_507_REAL_FEATURE_CONTRACT.auxiliaryRouteBoundary).toContain("auxiliary")
+
+    const requiredIds = [
+      "code-block-initial-render",
+      "code-block-language-picker",
+      "table-axis-selection",
+      "table-cmd-a",
+      "table-text-drag",
+      "list-item-block-selection",
+      "body-text-selection",
+      "block-selection",
+      "scroll-jump-lock",
+    ]
+    expect(POST_507_REAL_FEATURE_CONTRACT.requiredCoverage.map((entry) => entry.id)).toEqual(requiredIds)
+
+    for (const coverage of POST_507_REAL_FEATURE_CONTRACT.requiredCoverage) {
+      const source = helperSource(coverage.specFile)
+      for (const fragment of coverage.requiredSourceFragments) {
+        expect(source, `${coverage.id} must contain ${fragment}`).toContain(fragment)
+      }
+      expect(source, `${coverage.id} must exercise an editor route`).toMatch(/\/editor\/|mockEditorRouteWithPost507/)
+
+      const usesSyntheticPostId = /adm\/posts\/(?:584|585|988|994|996|997|998|999)|\/editor\/(?:584|585|988|994|996|997|998|999)/.test(source)
+      if (usesSyntheticPostId) {
+        expect(
+          /post507|POST_507|507/.test(source),
+          `${coverage.specFile} uses a synthetic id and must explicitly bind it to the 507 copy/source`
+        ).toBe(true)
+      }
+    }
+  })
+
+  test("QA route constants are explicitly auxiliary, not real bug close gates", () => {
+    const source = helperSource("helpers/editorAuthoringFlow.ts")
+    expect(source).toContain("QA_ROUTE_PURPOSE")
+    expect(source).toContain("auxiliary-only")
+    expect(source).toContain("not editor user-bug close gates")
+  })
+
+  test("507 diagnostics snapshot includes selection, scroll, focus, overlay, preserve owner, and DOM summary", async ({
+    page,
+  }) => {
+    await mockEditorRouteWithPost507(page, {
+      postId: 589,
+      title: "post 507 real feature diagnostics contract 글",
+    })
+
+    const diagnostics = await readPost507EditorDiagnostics(page, "loaded-507")
+
+    expect(diagnostics.url).toBe("/editor/589")
+    expect(diagnostics.scrollTopTimeline).toEqual([
+      expect.objectContaining({ label: "loaded-507", scrollTop: expect.any(Number) }),
+    ])
+    expect(diagnostics.domSnapshot.editorTextSample).toContain("Stateless")
+    expect(diagnostics.domSnapshot.codeBlockCount).toBeGreaterThanOrEqual(1)
+    expect(diagnostics.domSnapshot.tableCount).toBeGreaterThanOrEqual(1)
+    expect(diagnostics).toEqual(
+      expect.objectContaining({
+        activeElement: expect.any(String),
+        domSnapshot: expect.any(Object),
+        overlayRects: expect.any(Array),
+        preserveAttributes: expect.any(Array),
+        selectionText: expect.any(String),
+      })
+    )
+    expect(Object.hasOwn(diagnostics, "focusedElement")).toBe(true)
+    expect(diagnostics.focusedElement === null || typeof diagnostics.focusedElement === "string").toBe(true)
+  })
+})

--- a/front/e2e/helpers/editorAuthoringFlow.ts
+++ b/front/e2e/helpers/editorAuthoringFlow.ts
@@ -3,6 +3,8 @@ import type { Locator, Page } from "@playwright/test"
 
 export const QA_ENGINE_ROUTE = "/_qa/block-editor-slash?surface=engine"
 export const QA_WRITER_ROUTE = "/_qa/block-editor-slash?surface=writer"
+export const QA_ROUTE_PURPOSE =
+  "auxiliary-only: QA routes are for isolated helper/unit smoke coverage, not editor user-bug close gates"
 export const UNDO_SHORTCUT = process.platform === "darwin" ? "Meta+z" : "Control+z"
 
 export const expectVisibleBox = async (locator: Locator, errorMessage: string) => {

--- a/front/e2e/helpers/post507Fixtures.ts
+++ b/front/e2e/helpers/post507Fixtures.ts
@@ -21,6 +21,190 @@ export const POST_507_FINAL_TABLE_FORBIDDEN_TEXTS = [
   "Access 길게 보안 위험",
 ] as const
 
+export const POST_507_REAL_FEATURE_CONTRACT = {
+  auxiliaryRouteBoundary:
+    "QA routes and synthetic documents are auxiliary/unit contracts; editor user-bug close gates must use post 507 copied content on /editor/[id].",
+  editorRoute: "/editor/[id]",
+  fixtureFile: "front/e2e/helpers/post507Fixtures.ts",
+  fixtureName: "post507Markdown",
+  requiredCoverage: [
+    {
+      id: "code-block-initial-render",
+      issueSymptom: "code block body appears late or empty on first render",
+      requiredSourceFragments: ["507 contentHtml 코드블럭", "POST_507_TITLE", "/editor/584"],
+      routeContract: "507-contentHtml-copy",
+      specFile: "editor-authoring-route-code-initial-render.spec.ts",
+    },
+    {
+      id: "code-block-language-picker",
+      issueSymptom: "code language picker dead-clicks or scrolls instead of opening",
+      requiredSourceFragments: ["mockEditorRouteWithPost507", "userId", "코드 언어 선택"],
+      routeContract: "507-copy-route",
+      specFile: "editor-authoring-code-mermaid.spec.ts",
+    },
+    {
+      id: "table-axis-selection",
+      issueSymptom: "row/column structural selection flickers or leaves stale overlays",
+      requiredSourceFragments: [
+        "mockEditorRouteWithPost507",
+        "table-column-selection-outline",
+        "table-row-selection-outline",
+      ],
+      routeContract: "507-copy-route",
+      specFile: "editor-authoring-route-table-axis-after-select-all.spec.ts",
+    },
+    {
+      id: "table-cmd-a",
+      issueSymptom: "Cmd/Ctrl+A in a table cell fails to select the current table text",
+      requiredSourceFragments: ["mockEditorRouteWithPost507", "expectPost507FinalTableTextSelected", "SELECT_ALL_SHORTCUT"],
+      routeContract: "507-copy-route",
+      specFile: "editor-authoring-route-table-select-all.spec.ts",
+    },
+    {
+      id: "table-text-drag",
+      issueSymptom: "mouse drag inside table cells does not leave native text selection",
+      requiredSourceFragments: ["post507Markdown", "single-cell native drag", "multi-cell"],
+      routeContract: "507-copy-route",
+      specFile: "editor-authoring-route-table-multicell-selection.spec.ts",
+    },
+    {
+      id: "list-item-block-selection",
+      issueSymptom: "list item block selection paints inside the bullet/content instead of the item overlay",
+      requiredSourceFragments: ["mockEditorRouteWithPost507", "실제 /editor/[id] 507 리스트 항목"],
+      routeContract: "507-copy-route",
+      specFile: "editor-authoring-list-affordances.spec.ts",
+    },
+    {
+      id: "body-text-selection",
+      issueSymptom: "body text drag selection jumps scroll or leaves block overlay state behind",
+      requiredSourceFragments: ["post507Markdown", "Stateless가 좋다는데", "bodyDrag.selectionText"],
+      routeContract: "507-copy-route",
+      specFile: "editor-authoring-route-live-drag-sequence.spec.ts",
+    },
+    {
+      id: "block-selection",
+      issueSymptom: "top-level block selection competes with code/list/table text selection",
+      requiredSourceFragments: ["mockEditorRouteWithPost507", "코드블럭 block handle", "keyboard-block-selection-overlay"],
+      routeContract: "507-copy-route",
+      specFile: "editor-authoring-code-mermaid.spec.ts",
+    },
+    {
+      id: "scroll-jump-lock",
+      issueSymptom: "selection or drag leaves scrollTop jumped or locked",
+      requiredSourceFragments: ["post507Markdown", "live 507", "scrollTop"],
+      routeContract: "507-copy-route",
+      specFile: "editor-authoring-route-live-drag-sequence.spec.ts",
+    },
+  ],
+} as const
+
+export type Post507EditorDiagnosticSnapshot = {
+  activeElement: string | null
+  activePreserveOwner: string | null
+  domSnapshot: {
+    blockOverlayCount: number
+    codeBlockCount: number
+    editorTextSample: string
+    selectedCellCount: number
+    tableCount: number
+  }
+  focusedElement: string | null
+  overlayRects: Array<{
+    bottom: number
+    height: number
+    left: number
+    selector: string
+    testId: string | null
+    top: number
+    width: number
+  }>
+  preserveAttributes: Array<{ element: string; name: string; value: string }>
+  scrollTopTimeline: Array<{ label: string; scrollTop: number }>
+  selectionText: string
+  url: string
+}
+
+export const readPost507EditorDiagnostics = async (
+  page: Page,
+  label = "snapshot"
+): Promise<Post507EditorDiagnosticSnapshot> =>
+  page.evaluate((snapshotLabel) => {
+    const describeElement = (element: Element | null) => {
+      if (!element) return null
+      const id = element.id ? `#${element.id}` : ""
+      const testId = element.getAttribute("data-testid")
+      const testIdSuffix = testId ? `[data-testid="${testId}"]` : ""
+      const className = typeof element.className === "string" ? element.className.trim().replace(/\s+/g, ".") : ""
+      return `${element.tagName.toLowerCase()}${id}${className ? `.${className}` : ""}${testIdSuffix}`
+    }
+    const toRect = (element: Element, selector: string) => {
+      const rect = element.getBoundingClientRect()
+      return {
+        bottom: Math.round(rect.bottom),
+        height: Math.round(rect.height),
+        left: Math.round(rect.left),
+        selector,
+        testId: element.getAttribute("data-testid"),
+        top: Math.round(rect.top),
+        width: Math.round(rect.width),
+      }
+    }
+    const overlaySelectors = [
+      "[data-testid='keyboard-block-selection-overlay']",
+      "[data-testid='table-column-selection-outline']",
+      "[data-testid='table-row-selection-outline']",
+      "[data-testid='block-drag-drop-indicator']",
+      "[data-block-drag-ghost='true']",
+      "[data-table-affordance]",
+    ]
+    const overlayRects = overlaySelectors.flatMap((selector) =>
+      Array.from(document.querySelectorAll(selector)).map((element) => toRect(element, selector))
+    )
+    const preserveAttributes = Array.from(document.querySelectorAll<HTMLElement>("*"))
+      .flatMap((element) =>
+        Array.from(element.attributes)
+          .filter((attribute) => /preserve|scroll|selection/i.test(attribute.name))
+          .map((attribute) => ({
+            element: describeElement(element) || element.tagName.toLowerCase(),
+            name: attribute.name,
+            value: attribute.value.slice(0, 160),
+          }))
+      )
+      .slice(0, 40)
+    const editor = document.querySelector<HTMLElement>("[data-testid='block-editor-prosemirror']")
+    const selectionText =
+      window.getSelection()?.toString() ||
+      document.documentElement.getAttribute("data-table-drag-selection-text") ||
+      document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text") ||
+      ""
+
+    return {
+      activeElement: describeElement(document.activeElement),
+      activePreserveOwner:
+        document.documentElement.getAttribute("data-editor-scroll-preserve-owner") ||
+        document.documentElement.getAttribute("data-editor-active-preserve-owner") ||
+        null,
+      domSnapshot: {
+        blockOverlayCount: document.querySelectorAll("[data-testid='keyboard-block-selection-overlay']").length,
+        codeBlockCount: document.querySelectorAll("[data-code-block-wrapper='true'], .aq-code-shell").length,
+        editorTextSample: (editor?.textContent || "").replace(/\s+/g, " ").trim().slice(0, 240),
+        selectedCellCount: document.querySelectorAll(".selectedCell").length,
+        tableCount: document.querySelectorAll("table").length,
+      },
+      focusedElement: describeElement(document.querySelector(":focus")),
+      overlayRects,
+      preserveAttributes,
+      scrollTopTimeline: [
+        {
+          label: snapshotLabel,
+          scrollTop: Math.round(document.scrollingElement?.scrollTop ?? window.scrollY),
+        },
+      ],
+      selectionText,
+      url: `${window.location.pathname}${window.location.search}`,
+    }
+  }, label)
+
 export const expectPost507FinalTableTextSelected = (selectionText: string) => {
   const normalizedSelectionText = selectionText.replace(/\s+/g, " ").trim()
   for (const requiredText of POST_507_FINAL_TABLE_REQUIRED_TEXTS) {


### PR DESCRIPTION
## 관련 이슈

close #589

## 작업 배경

- editor 실제 기능 E2E close gate를 507 copy `/editor/[id]` workflow 기준으로 고정합니다.
- QA route와 synthetic content는 보조/단위 계약으로 분리하고, code/language/table/list/body/block/scroll 증상이 507 fixture coverage manifest에 묶이도록 했습니다.

## 작업 내용

- `POST_507_REAL_FEATURE_CONTRACT` manifest로 사용자 체감 editor close gate 9개를 507 route workflow와 매핑했습니다.
- 507 diagnostics helper가 selection text, scrollTop, focus/active element, overlay rect, preserve owner, DOM summary를 한 번에 수집합니다.
- QA route helper에 auxiliary-only 목적을 명시하고, static contract spec이 507 fixture 기준을 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-507-real-feature-e2e-contract bash tools/guards/current-task-preflight.sh`
  - `git diff --check`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-507-contract.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front test:e2e:a11y`
  - `yarn --cwd front test:e2e:perf`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 새 static contract가 실제 spec 파일명/핵심 fragment 변경 시 의도적으로 실패할 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 기존 E2E 계약으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
