### PR TITLE
[Test] 507 테이블 Cmd+A 안정화 검증

### DIFF
--- a/front/e2e/editor-authoring-route-table-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-select-all.spec.ts
@@ -7,6 +7,40 @@ import {
 
 const SELECT_ALL_SHORTCUT = process.platform === "darwin" ? "Meta+a" : "Control+a"
 
+const readPageScrollState = (page: Page) =>
+  page.evaluate(() => ({
+    scrollHeight: document.scrollingElement?.scrollHeight ?? document.body.scrollHeight,
+    scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+    viewportHeight: window.innerHeight,
+  }))
+
+const expectPost507FinalTableSelectionStable = async (page: Page) => {
+  for (let sample = 0; sample < 5; sample += 1) {
+    await page.waitForTimeout(120)
+    expectPost507FinalTableTextSelected(
+      await page.evaluate(() => window.getSelection()?.toString() ?? "")
+    )
+  }
+}
+
+const expectWheelScrollRemainsUsable = async (page: Page) => {
+  const before = await readPageScrollState(page)
+  const scrollDelta =
+    before.scrollTop + before.viewportHeight >= before.scrollHeight - 320 ? -260 : 260
+
+  await page.mouse.wheel(0, scrollDelta)
+
+  if (scrollDelta > 0) {
+    await expect
+      .poll(async () => (await readPageScrollState(page)).scrollTop)
+      .toBeGreaterThan(before.scrollTop + 80)
+  } else {
+    await expect
+      .poll(async () => (await readPageScrollState(page)).scrollTop)
+      .toBeLessThan(before.scrollTop - 80)
+  }
+}
+
 const blurTableCellByKeyboard = async (page: Page, maxAttempts = 28) => {
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     await page.keyboard.press("Tab")
@@ -66,10 +100,12 @@ test.describe("editor authoring route post 507 final table select all", () => {
     await targetCell.click({ position: { x: 40, y: 16 } })
     await targetCell.dblclick({ position: { x: 40, y: 16 } })
     await page.keyboard.press(SELECT_ALL_SHORTCUT)
-    await page.waitForTimeout(360)
 
-    const selectionText = await page.evaluate(() => window.getSelection()?.toString() ?? "")
-    expectPost507FinalTableTextSelected(selectionText)
+    await expectPost507FinalTableSelectionStable(page)
+    await expectWheelScrollRemainsUsable(page)
+    expectPost507FinalTableTextSelected(
+      await page.evaluate(() => window.getSelection()?.toString() ?? "")
+    )
     await expect(editor.locator(".selectedCell")).toHaveCount(0)
   })
 

--- a/front/e2e/editor-authoring-route-table-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-select-all.spec.ts
@@ -25,8 +25,8 @@ const expectPost507FinalTableSelectionStable = async (page: Page) => {
 
 const expectWheelScrollRemainsUsable = async (page: Page) => {
   const before = await readPageScrollState(page)
-  const scrollDelta =
-    before.scrollTop + before.viewportHeight >= before.scrollHeight - 320 ? -260 : 260
+  const nearBottom = before.scrollTop + before.viewportHeight >= before.scrollHeight - 320
+  const scrollDelta = nearBottom && before.scrollTop >= 320 ? -260 : 260
 
   await page.mouse.wheel(0, scrollDelta)
 


### PR DESCRIPTION
## 관련 이슈

close #582

## 작업 배경

- 507 복사 fixture 마지막 테이블에서 셀 내부 Cmd/Ctrl+A가 현재 테이블 전체 셀 텍스트를 안정적으로 선택하는지 CI가 직접 검증하도록 보강합니다.
- Cmd/Ctrl+A 직후 selection 안정 샘플과 wheel scroll 가능 상태까지 확인해, 재오픈된 #582 계약을 실제 페이지 기준으로 닫습니다.

## 작업 내용

- editor-authoring-route-table-select-all E2E에 5회 안정 샘플 검증을 추가했습니다.
- table-wide selection 직후 wheel 입력으로 페이지 스크롤이 계속 사용 가능한지 검증합니다.
- CodeRabbit 리뷰에 따라 위쪽 wheel 검증 분기도 실제 위쪽 여유 공간이 있을 때만 사용하도록 보강했습니다.
- 기존 selectedCell 잔상 없음 확인은 유지합니다.

## 검증

- 실행한 명령과 결과:
  - yarn --cwd front test:e2e e2e/editor-authoring-route-table-select-all.spec.ts --workers=1
  - yarn --cwd front test:e2e e2e/editor-authoring-route-table-scroll-preserve.spec.ts --workers=1
  - yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts --workers=1
  - yarn --cwd front test:e2e e2e/editor-authoring-selection-drag.spec.ts --workers=1
  - yarn --cwd front test:e2e e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1
  - yarn --cwd front test:e2e e2e/editor-authoring-table-affordances.spec.ts --workers=1
  - yarn --cwd front test:e2e e2e/editor-authoring-table-structure.spec.ts --workers=1
  - yarn --cwd front test:e2e e2e/editor-authoring-code-mermaid.spec.ts --workers=1
  - yarn --cwd front test:e2e e2e/editor-authoring-route-table-multicell-selection.spec.ts --workers=1
  - yarn --cwd front test:e2e:authoring (초기 1회 live-drag timing flake 후 단독 재실행 통과, 이후 동일 조건 2회 연속 통과)
  - yarn --cwd front build
  - yarn --cwd front check:bundle-size
  - yarn --cwd front test:e2e:smoke
  - PR #605 backend-ci, frontend-ci, Vercel, CodeRabbit check 통과
  - PR #605 reviewThreads unresolved 없음 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 테스트 대기 시간이 507 table select-all 케이스에서 약간 증가합니다.
- 롤백 방법: 이 PR의 커밋을 revert하면 기존 테스트 계약으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
