### PR TITLE
[Test] 507 테이블 native 드래그 선택 검증

### DIFF
--- a/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
+++ b/front/e2e/editor-authoring-route-table-multicell-selection.spec.ts
@@ -22,13 +22,30 @@ const readSelectionText = (page: Page) =>
   )
 
 const readNativeSelectionState = (page: Page) =>
-  page.evaluate(() => ({
-    nativeText: window.getSelection()?.toString() ?? "",
-    persistedText:
-      document.documentElement.getAttribute("data-table-drag-selection-text") ||
-      document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text") ||
-      "",
-  }))
+  page.evaluate(() => {
+    const selection = window.getSelection()
+    const range = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null
+    const visibleRects = range
+      ? Array.from(range.getClientRects()).filter((rect) => rect.width > 1 && rect.height > 1)
+      : []
+    const closestCellText = (node: Node | null | undefined) => {
+      const element = node instanceof Element ? node : node?.parentElement
+      return element?.closest("th, td")?.textContent?.replace(/\s+/g, " ").trim() ?? ""
+    }
+
+    return {
+      anchorCellText: closestCellText(selection?.anchorNode),
+      focusCellText: closestCellText(selection?.focusNode),
+      isCollapsed: selection?.isCollapsed ?? true,
+      nativeText: selection?.toString() ?? "",
+      persistedText:
+        document.documentElement.getAttribute("data-table-drag-selection-text") ||
+        document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text") ||
+        "",
+      rangeCount: selection?.rangeCount ?? 0,
+      visibleRectCount: visibleRects.length,
+    }
+  })
 
 const filler = (label: string, count: number) =>
   Array.from({ length: count }, (_, index) => [
@@ -244,6 +261,11 @@ test("live 507 형태의 table 단일 셀 내부 drag는 native 텍스트 선택
   }
   expect(selectionState.nativeText.replace(/\s+/g, " ").trim()).toContain("Stateless 의미")
   expect(selectionState.persistedText).toBe("")
+  expect(selectionState.isCollapsed).toBe(false)
+  expect(selectionState.rangeCount).toBeGreaterThan(0)
+  expect(selectionState.visibleRectCount).toBeGreaterThan(0)
+  expect(selectionState.anchorCellText).toContain("Stateless 의미")
+  expect(selectionState.focusCellText).toContain("Stateless 의미")
   expect(tableDrag.afterScrollTop).toBeLessThanOrEqual(tableDrag.beforeScrollTop + 24)
   expect(tableDrag.afterScrollTop).toBeGreaterThanOrEqual(tableDrag.beforeScrollTop - 24)
   expect(await editor.locator(".selectedCell").count()).toBe(0)


### PR DESCRIPTION
## 관련 이슈

close #583

## 작업 배경

- 507 복제 fixture의 table 단일 셀 드래그 선택 테스트가 fallback 저장값만으로 통과하지 못하도록 강화했습니다.
- mouse drag 후 실제 native selection이 non-collapsed range와 visible rect를 남기고, anchor/focus가 같은 target cell에 있는지 검증합니다.

## 작업 내용

- table 단일 셀 drag 검증에서 `window.getSelection()` range 상태, visible rect 개수, anchor/focus cell text를 함께 수집합니다.
- `data-table-drag-selection-text` fallback attr가 비어 있어야 한다는 기존 계약을 유지하면서 native visible text selection을 별도로 증명합니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-multicell-selection.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-selection-drag.spec.ts --workers=1`
  - `yarn --cwd front test:e2e e2e/editor-authoring-route-table-axis-after-select-all.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: E2E assertion 강화만 포함되어 런타임 영향은 없습니다. 브라우저 selection rect 계산이 실제 visible selection을 더 엄격하게 요구합니다.
- 롤백 방법: 이 PR의 단일 테스트 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
