### PR TITLE
[Fix] 507 axis selection scroll rollback 방지

### DIFF
--- a/front/e2e/editor-authoring-507-contract.spec.ts
+++ b/front/e2e/editor-authoring-507-contract.spec.ts
@@ -81,5 +81,16 @@ test.describe("editor 507 real feature E2E contract", () => {
     )
     expect(Object.hasOwn(diagnostics, "focusedElement")).toBe(true)
     expect(diagnostics.focusedElement === null || typeof diagnostics.focusedElement === "string").toBe(true)
+    expect(
+      (diagnostics as unknown as { interactionTelemetry?: unknown }).interactionTelemetry,
+      "507 diagnostics must expose interaction telemetry so tests can fail on timeline churn"
+    ).toEqual(
+      expect.objectContaining({
+        fallbackTimeline: expect.any(Array),
+        menuTimeline: expect.any(Array),
+        scrollToCalls: expect.any(Array),
+        selectionTimeline: expect.any(Array),
+      })
+    )
   })
 })

--- a/front/e2e/editor-authoring-507-contract.spec.ts
+++ b/front/e2e/editor-authoring-507-contract.spec.ts
@@ -88,6 +88,7 @@ test.describe("editor 507 real feature E2E contract", () => {
       expect.objectContaining({
         fallbackTimeline: expect.any(Array),
         menuTimeline: expect.any(Array),
+        scrollTopTimeline: expect.any(Array),
         scrollToCalls: expect.any(Array),
         selectionTimeline: expect.any(Array),
       })

--- a/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
@@ -2,8 +2,11 @@ import { expect, test, type Locator, type Page } from "@playwright/test"
 import { getTableAffordances } from "./helpers/editorAuthoringFlow"
 import {
   POST_507_FINAL_TABLE_TARGET_CELL,
+  clearPost507InteractionTelemetry,
   expectPost507FinalTableTextSelected,
+  installPost507InteractionTelemetry,
   mockEditorRouteWithPost507,
+  readPost507InteractionTelemetry,
 } from "./helpers/post507Fixtures"
 
 const SELECT_ALL_SHORTCUT = process.platform === "darwin" ? "Meta+a" : "Control+a"
@@ -71,6 +74,7 @@ const clickPost507AxisHandleUntilSelected = async (
       await page.waitForTimeout(140)
       if (!(await handle.isVisible().catch(() => false))) continue
       try {
+        await installPost507InteractionTelemetry(page)
         await clickVisibleOverlayControl(page, handle)
       } catch {
         continue
@@ -314,6 +318,52 @@ const expectAxisSelectionStable = async (
   )
 }
 
+const countMenuCloseTransitions = (menuCounts: number[]) => {
+  let sawOpen = false
+  let closeCount = 0
+  for (let index = 0; index < menuCounts.length; index += 1) {
+    const count = menuCounts[index] ?? 0
+    const previousCount = index > 0 ? menuCounts[index - 1] ?? 0 : 0
+    if (count > 0) sawOpen = true
+    if (sawOpen && previousCount > 0 && count === 0) closeCount += 1
+  }
+  return closeCount
+}
+
+const countMenuReopenTransitions = (menuCounts: number[]) => {
+  let sawCloseAfterOpen = false
+  let reopenCount = 0
+  for (let index = 0; index < menuCounts.length; index += 1) {
+    const count = menuCounts[index] ?? 0
+    const previousCount = index > 0 ? menuCounts[index - 1] ?? 0 : 0
+    if (previousCount > 0 && count === 0) sawCloseAfterOpen = true
+    if (sawCloseAfterOpen && previousCount === 0 && count > 0) reopenCount += 1
+  }
+  return reopenCount
+}
+
+const expectNoPost507MenuChurn = (
+  telemetry: Awaited<ReturnType<typeof readPost507InteractionTelemetry>>,
+  axis: "column" | "row",
+  label: string
+) => {
+  const menuCounts = telemetry.menuTimeline.map((sample) =>
+    axis === "row" ? sample.rowMenuCount : sample.columnMenuCount
+  )
+  const fallbackSamples = telemetry.fallbackTimeline.filter(
+    (sample) =>
+      sample.codeFallbackCount > 0 ||
+      sample.tableFallbackCount > 0 ||
+      Boolean(sample.codeFallbackText) ||
+      Boolean(sample.tableFallbackText)
+  )
+  expect(menuCounts.some((count) => count > 0), `${label} should record an opened ${axis} menu`).toBe(true)
+  expect(countMenuCloseTransitions(menuCounts), `${label} should not close the ${axis} menu after opening`).toBe(0)
+  expect(countMenuReopenTransitions(menuCounts), `${label} should not reopen the ${axis} menu after closing`).toBe(0)
+  expect(telemetry.scrollToCalls, `${label} should not preserve-scroll rollback during stable axis selection`).toEqual([])
+  expect(fallbackSamples, `${label} should not leave code/table text fallback selection markers`).toEqual([])
+}
+
 const readPost507AxisOverlayScrollSnapshot = async (
   page: Page,
   overlayTestId: "table-column-selection-outline" | "table-row-selection-outline",
@@ -454,15 +504,15 @@ test.describe("editor authoring route post 507 final table axis after cell text 
     await expect(editor.locator(".selectedCell")).toHaveCount(7)
   })
 
-  test("실제 /editor/[id] post 507 row/column structural selection은 깜빡이지 않고 scroll 중 stale overlay를 남기지 않는다", async ({
+  test("실제 /editor/[id] post 507 row structural selection은 깜빡이지 않고 scroll 중 stale overlay를 남기지 않는다", async ({
     page,
   }) => {
     await page.setViewportSize({ width: 1280, height: 760 })
     const { editor, finalTable } = await mockEditorRouteWithPost507(page, {
       postId: 997,
-      title: "post 507 table axis overlay stability route 글",
+      title: "post 507 table row axis overlay stability route 글",
     })
-    const { columnHandle, rowHandle } = getTableAffordances(page)
+    const { rowHandle } = getTableAffordances(page)
 
     const targetCell = finalTable.locator("td", { hasText: POST_507_FINAL_TABLE_TARGET_CELL }).first()
     await page.evaluate((targetCellText) => {
@@ -485,13 +535,25 @@ test.describe("editor authoring route post 507 final table axis after cell text 
     await expect(page.getByTestId("table-row-menu")).toBeVisible()
     await expect(editor.locator(".selectedCell")).toHaveCount(3)
     await expectAxisSelectionStable(page, 3, "table-row-selection-outline", "table-row-menu")
+    expectNoPost507MenuChurn(await readPost507InteractionTelemetry(page, "row-axis-stable"), "row", "post 507 row axis")
+    await clearPost507InteractionTelemetry(page)
     await expectAxisOverlayFollowsScrollOrCloses(
       page,
       await readPost507AxisOverlayScrollSnapshot(page, "table-row-selection-outline", "table-row-menu"),
       "table-row-selection-outline",
       "table-row-menu"
     )
+  })
 
+  test("실제 /editor/[id] post 507 column structural selection은 깜빡이지 않고 scroll 중 stale overlay를 남기지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 760 })
+    const { editor } = await mockEditorRouteWithPost507(page, {
+      postId: 998,
+      title: "post 507 table column axis overlay stability route 글",
+    })
+    const { columnHandle } = getTableAffordances(page)
     await page.evaluate((targetCellText) => {
       const editor = document.querySelector<HTMLElement>("[data-testid='block-editor-prosemirror']")
       const table = Array.from(editor?.querySelectorAll<HTMLElement>("table") ?? [])
@@ -513,6 +575,12 @@ test.describe("editor authoring route post 507 final table axis after cell text 
     await expect(page.getByTestId("table-column-menu")).toBeVisible()
     await expect(editor.locator(".selectedCell")).toHaveCount(7)
     await expectAxisSelectionStable(page, 7, "table-column-selection-outline", "table-column-menu")
+    expectNoPost507MenuChurn(
+      await readPost507InteractionTelemetry(page, "column-axis-stable"),
+      "column",
+      "post 507 column axis"
+    )
+    await clearPost507InteractionTelemetry(page)
     await expectAxisOverlayFollowsScrollOrCloses(
       page,
       await readPost507AxisOverlayScrollSnapshot(page, "table-column-selection-outline", "table-column-menu"),

--- a/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
@@ -348,7 +348,7 @@ const expectNoPost507MenuChurn = (
   label: string
 ) => {
   const menuCounts = telemetry.menuTimeline.map((sample) =>
-    axis === "row" ? sample.rowMenuCount : sample.columnMenuCount
+    axis === "row" ? sample.rowMenuVisibleCount : sample.columnMenuVisibleCount
   )
   const fallbackSamples = telemetry.fallbackTimeline.filter(
     (sample) =>

--- a/front/e2e/helpers/post507Fixtures.ts
+++ b/front/e2e/helpers/post507Fixtures.ts
@@ -137,9 +137,12 @@ export type Post507InteractionTelemetrySnapshot = {
   }>
   menuTimeline: Array<{
     columnMenuCount: number
+    columnMenuVisibleCount: number
     label: string
     rowMenuCount: number
+    rowMenuVisibleCount: number
     structureMenuCount: number
+    structureMenuVisibleCount: number
   }>
   scrollToCalls: Array<{ elapsedMs: number; targetX: number; targetY: number }>
   scrollTopTimeline: Array<{ elapsedMs: number; label: string; scrollTop: number }>
@@ -220,11 +223,27 @@ export const readPost507EditorDiagnostics = async (
         tableFallbackText: tableFallbackText.slice(0, 160),
       }
     }
+    const isElementVisible = (element: Element) => {
+      const className = typeof element.className === "string" ? element.className.toLowerCase() : ""
+      const style = (element.getAttribute("style") || "").toLowerCase()
+      return (
+        element.getAttribute("aria-hidden") !== "true" &&
+        element.getAttribute("data-state") !== "closed" &&
+        !element.hasAttribute("hidden") &&
+        !/\b(hidden|invisible|opacity-0)\b/.test(className) &&
+        !/(display\s*:\s*none|visibility\s*:\s*hidden|opacity\s*:\s*0(?:[;\s]|$))/.test(style)
+      )
+    }
+    const countVisibleElements = (selector: string) =>
+      Array.from(document.querySelectorAll(selector)).filter(isElementVisible).length
     const readMenuSample = (sampleLabel: string) => ({
       columnMenuCount: document.querySelectorAll("[data-testid='table-column-menu']").length,
+      columnMenuVisibleCount: countVisibleElements("[data-testid='table-column-menu']"),
       label: sampleLabel,
       rowMenuCount: document.querySelectorAll("[data-testid='table-row-menu']").length,
+      rowMenuVisibleCount: countVisibleElements("[data-testid='table-row-menu']"),
       structureMenuCount: document.querySelectorAll("[data-testid='table-structure-menu'], [data-table-menu-root='true']").length,
+      structureMenuVisibleCount: countVisibleElements("[data-testid='table-structure-menu'], [data-table-menu-root='true']"),
     })
     const resolveSelectionOwner = (): Post507InteractionTelemetrySnapshot["selectionTimeline"][number]["owner"] => {
       const selection = window.getSelection()
@@ -338,11 +357,27 @@ export const installPost507InteractionTelemetry = async (page: Page) =>
         tableFallbackText: tableFallbackText.slice(0, 160),
       }
     }
+    const isElementVisible = (element: Element) => {
+      const className = typeof element.className === "string" ? element.className.toLowerCase() : ""
+      const style = (element.getAttribute("style") || "").toLowerCase()
+      return (
+        element.getAttribute("aria-hidden") !== "true" &&
+        element.getAttribute("data-state") !== "closed" &&
+        !element.hasAttribute("hidden") &&
+        !/\b(hidden|invisible|opacity-0)\b/.test(className) &&
+        !/(display\s*:\s*none|visibility\s*:\s*hidden|opacity\s*:\s*0(?:[;\s]|$))/.test(style)
+      )
+    }
+    const countVisibleElements = (selector: string) =>
+      Array.from(document.querySelectorAll(selector)).filter(isElementVisible).length
     const readMenuSample = (label: string) => ({
       columnMenuCount: document.querySelectorAll("[data-testid='table-column-menu']").length,
+      columnMenuVisibleCount: countVisibleElements("[data-testid='table-column-menu']"),
       label,
       rowMenuCount: document.querySelectorAll("[data-testid='table-row-menu']").length,
+      rowMenuVisibleCount: countVisibleElements("[data-testid='table-row-menu']"),
       structureMenuCount: document.querySelectorAll("[data-testid='table-structure-menu'], [data-table-menu-root='true']").length,
+      structureMenuVisibleCount: countVisibleElements("[data-testid='table-structure-menu'], [data-table-menu-root='true']"),
     })
     const resolveSelectionOwner = (): Post507InteractionTelemetrySnapshot["selectionTimeline"][number]["owner"] => {
       const selection = window.getSelection()

--- a/front/e2e/helpers/post507Fixtures.ts
+++ b/front/e2e/helpers/post507Fixtures.ts
@@ -46,7 +46,9 @@ export const POST_507_REAL_FEATURE_CONTRACT = {
       id: "table-axis-selection",
       issueSymptom: "row/column structural selection flickers or leaves stale overlays",
       requiredSourceFragments: [
+        "installPost507InteractionTelemetry",
         "mockEditorRouteWithPost507",
+        "expectNoPost507MenuChurn",
         "table-column-selection-outline",
         "table-row-selection-outline",
       ],
@@ -109,6 +111,7 @@ export type Post507EditorDiagnosticSnapshot = {
     tableCount: number
   }
   focusedElement: string | null
+  interactionTelemetry: Post507InteractionTelemetrySnapshot
   overlayRects: Array<{
     bottom: number
     height: number
@@ -122,6 +125,30 @@ export type Post507EditorDiagnosticSnapshot = {
   scrollTopTimeline: Array<{ label: string; scrollTop: number }>
   selectionText: string
   url: string
+}
+
+export type Post507InteractionTelemetrySnapshot = {
+  fallbackTimeline: Array<{
+    codeFallbackCount: number
+    codeFallbackText: string
+    label: string
+    tableFallbackCount: number
+    tableFallbackText: string
+  }>
+  menuTimeline: Array<{
+    columnMenuCount: number
+    label: string
+    rowMenuCount: number
+    structureMenuCount: number
+  }>
+  scrollToCalls: Array<{ elapsedMs: number; targetX: number; targetY: number }>
+  scrollTopTimeline: Array<{ elapsedMs: number; label: string; scrollTop: number }>
+  selectionTimeline: Array<{
+    label: string
+    owner: "block" | "body" | "code" | "none" | "table"
+    textLength: number
+    textSample: string
+  }>
 }
 
 export const readPost507EditorDiagnostics = async (
@@ -177,6 +204,57 @@ export const readPost507EditorDiagnostics = async (
       document.documentElement.getAttribute("data-table-drag-selection-text") ||
       document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text") ||
       ""
+    const readFallbackSample = (sampleLabel: string) => {
+      const codeFallbackText =
+        document.querySelector("[data-code-drag-selection-text]")?.getAttribute("data-code-drag-selection-text")?.trim() ||
+        ""
+      const tableFallbackText =
+        document.documentElement.getAttribute("data-table-drag-selection-text")?.trim() ||
+        document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text")?.trim() ||
+        ""
+      return {
+        codeFallbackCount: document.querySelectorAll("[data-code-drag-selection-text]").length,
+        codeFallbackText: codeFallbackText.slice(0, 160),
+        label: sampleLabel,
+        tableFallbackCount: document.querySelectorAll("[data-table-drag-selection-text]").length,
+        tableFallbackText: tableFallbackText.slice(0, 160),
+      }
+    }
+    const readMenuSample = (sampleLabel: string) => ({
+      columnMenuCount: document.querySelectorAll("[data-testid='table-column-menu']").length,
+      label: sampleLabel,
+      rowMenuCount: document.querySelectorAll("[data-testid='table-row-menu']").length,
+      structureMenuCount: document.querySelectorAll("[data-testid='table-structure-menu'], [data-table-menu-root='true']").length,
+    })
+    const resolveSelectionOwner = (): Post507InteractionTelemetrySnapshot["selectionTimeline"][number]["owner"] => {
+      const selection = window.getSelection()
+      const elements = [selection?.anchorNode, selection?.focusNode]
+        .map((node) => (node instanceof Element ? node : node?.parentElement ?? null))
+        .filter((element): element is Element => Boolean(element))
+      if (elements.some((element) => element.closest(".aq-code-shell, .aq-code-editor-content"))) return "code"
+      if (elements.some((element) => element.closest("td, th, .tableWrapper"))) return "table"
+      if (document.querySelector("[data-testid='keyboard-block-selection-overlay']")) return "block"
+      if (selection?.toString().trim()) return "body"
+      return "none"
+    }
+    const readSelectionSample = (sampleLabel: string) => {
+      const text = window.getSelection()?.toString() || ""
+      return {
+        label: sampleLabel,
+        owner: resolveSelectionOwner(),
+        textLength: text.length,
+        textSample: text.replace(/\s+/g, " ").trim().slice(0, 160),
+      }
+    }
+    const readScrollTopSample = (sampleLabel: string) => ({
+      elapsedMs: 0,
+      label: sampleLabel,
+      scrollTop: Math.round(document.scrollingElement?.scrollTop ?? window.scrollY),
+    })
+    const telemetryWindow = window as typeof window & {
+      __aqPost507InteractionTelemetry?: Post507InteractionTelemetrySnapshot
+    }
+    const recordedTelemetry = telemetryWindow.__aqPost507InteractionTelemetry
 
     return {
       activeElement: describeElement(document.activeElement),
@@ -192,6 +270,21 @@ export const readPost507EditorDiagnostics = async (
         tableCount: document.querySelectorAll("table").length,
       },
       focusedElement: describeElement(document.querySelector(":focus")),
+      interactionTelemetry: recordedTelemetry
+        ? {
+            fallbackTimeline: recordedTelemetry.fallbackTimeline.slice(-120),
+            menuTimeline: recordedTelemetry.menuTimeline.slice(-120),
+            scrollToCalls: recordedTelemetry.scrollToCalls.slice(-120),
+            scrollTopTimeline: recordedTelemetry.scrollTopTimeline.slice(-120),
+            selectionTimeline: recordedTelemetry.selectionTimeline.slice(-120),
+          }
+        : {
+            fallbackTimeline: [readFallbackSample(snapshotLabel)],
+            menuTimeline: [readMenuSample(snapshotLabel)],
+            scrollToCalls: [],
+            scrollTopTimeline: [readScrollTopSample(snapshotLabel)],
+            selectionTimeline: [readSelectionSample(snapshotLabel)],
+          },
       overlayRects,
       preserveAttributes,
       scrollTopTimeline: [
@@ -204,6 +297,149 @@ export const readPost507EditorDiagnostics = async (
       url: `${window.location.pathname}${window.location.search}`,
     }
   }, label)
+
+export const installPost507InteractionTelemetry = async (page: Page) =>
+  page.evaluate(() => {
+    type TelemetryWindow = typeof window & {
+      __aqPost507InteractionTelemetry?: Post507InteractionTelemetrySnapshot
+      __aqPost507InteractionTelemetryCleanup?: () => void
+      __aqPost507OriginalScrollTo?: typeof window.scrollTo
+    }
+    const telemetryWindow = window as TelemetryWindow
+    telemetryWindow.__aqPost507InteractionTelemetryCleanup?.()
+
+    const startedAt = performance.now()
+    const elapsedMs = () => Math.round(performance.now() - startedAt)
+    const limit = 120
+    const trim = <T>(items: T[]) => {
+      if (items.length > limit) items.splice(0, items.length - limit)
+    }
+    const telemetry: Post507InteractionTelemetrySnapshot = {
+      fallbackTimeline: [],
+      menuTimeline: [],
+      scrollToCalls: [],
+      scrollTopTimeline: [],
+      selectionTimeline: [],
+    }
+
+    const readFallbackSample = (label: string) => {
+      const codeFallbackText =
+        document.querySelector("[data-code-drag-selection-text]")?.getAttribute("data-code-drag-selection-text")?.trim() ||
+        ""
+      const tableFallbackText =
+        document.documentElement.getAttribute("data-table-drag-selection-text")?.trim() ||
+        document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text")?.trim() ||
+        ""
+      return {
+        codeFallbackCount: document.querySelectorAll("[data-code-drag-selection-text]").length,
+        codeFallbackText: codeFallbackText.slice(0, 160),
+        label,
+        tableFallbackCount: document.querySelectorAll("[data-table-drag-selection-text]").length,
+        tableFallbackText: tableFallbackText.slice(0, 160),
+      }
+    }
+    const readMenuSample = (label: string) => ({
+      columnMenuCount: document.querySelectorAll("[data-testid='table-column-menu']").length,
+      label,
+      rowMenuCount: document.querySelectorAll("[data-testid='table-row-menu']").length,
+      structureMenuCount: document.querySelectorAll("[data-testid='table-structure-menu'], [data-table-menu-root='true']").length,
+    })
+    const resolveSelectionOwner = (): Post507InteractionTelemetrySnapshot["selectionTimeline"][number]["owner"] => {
+      const selection = window.getSelection()
+      const elements = [selection?.anchorNode, selection?.focusNode]
+        .map((node) => (node instanceof Element ? node : node?.parentElement ?? null))
+        .filter((element): element is Element => Boolean(element))
+      if (elements.some((element) => element.closest(".aq-code-shell, .aq-code-editor-content"))) return "code"
+      if (elements.some((element) => element.closest("td, th, .tableWrapper"))) return "table"
+      if (document.querySelector("[data-testid='keyboard-block-selection-overlay']")) return "block"
+      if (selection?.toString().trim()) return "body"
+      return "none"
+    }
+    const readSelectionSample = (label: string) => {
+      const text = window.getSelection()?.toString() || ""
+      return {
+        label,
+        owner: resolveSelectionOwner(),
+        textLength: text.length,
+        textSample: text.replace(/\s+/g, " ").trim().slice(0, 160),
+      }
+    }
+    const readScrollTopSample = (label: string) => ({
+      elapsedMs: elapsedMs(),
+      label,
+      scrollTop: Math.round(document.scrollingElement?.scrollTop ?? window.scrollY),
+    })
+    const recordSnapshot = (label: string) => {
+      telemetry.fallbackTimeline.push(readFallbackSample(label))
+      telemetry.menuTimeline.push(readMenuSample(label))
+      telemetry.selectionTimeline.push(readSelectionSample(label))
+      trim(telemetry.fallbackTimeline)
+      trim(telemetry.menuTimeline)
+      trim(telemetry.selectionTimeline)
+    }
+    const recordScrollTop = (label: string) => {
+      telemetry.scrollTopTimeline.push(readScrollTopSample(label))
+      trim(telemetry.scrollTopTimeline)
+    }
+
+    const originalScrollTo =
+      telemetryWindow.__aqPost507OriginalScrollTo ?? (window.scrollTo.bind(window) as typeof window.scrollTo)
+    telemetryWindow.__aqPost507OriginalScrollTo = originalScrollTo
+    window.scrollTo = ((xOrOptions?: number | ScrollToOptions, y?: number) => {
+      const targetX = typeof xOrOptions === "object" ? Number(xOrOptions.left ?? window.scrollX) : Number(xOrOptions ?? window.scrollX)
+      const targetY = typeof xOrOptions === "object" ? Number(xOrOptions.top ?? window.scrollY) : Number(y ?? window.scrollY)
+      telemetry.scrollToCalls.push({ elapsedMs: elapsedMs(), targetX: Math.round(targetX), targetY: Math.round(targetY) })
+      trim(telemetry.scrollToCalls)
+      if (typeof xOrOptions === "object") return originalScrollTo(xOrOptions)
+      return originalScrollTo(xOrOptions ?? window.scrollX, y ?? window.scrollY)
+    }) as typeof window.scrollTo
+
+    const mutationObserver = new MutationObserver(() => recordSnapshot("mutation"))
+    mutationObserver.observe(document.documentElement, {
+      attributeFilter: [
+        "aria-expanded",
+        "class",
+        "data-code-drag-selection-text",
+        "data-table-drag-selection-text",
+        "data-testid",
+        "style",
+      ],
+      attributes: true,
+      childList: true,
+      subtree: true,
+    })
+    const handleSelectionChange = () => {
+      telemetry.selectionTimeline.push(readSelectionSample("selectionchange"))
+      trim(telemetry.selectionTimeline)
+    }
+    const handleScroll = () => recordScrollTop("scroll")
+    document.addEventListener("selectionchange", handleSelectionChange)
+    window.addEventListener("scroll", handleScroll, true)
+    recordSnapshot("installed")
+    recordScrollTop("installed")
+
+    telemetryWindow.__aqPost507InteractionTelemetry = telemetry
+    telemetryWindow.__aqPost507InteractionTelemetryCleanup = () => {
+      window.scrollTo = originalScrollTo
+      mutationObserver.disconnect()
+      document.removeEventListener("selectionchange", handleSelectionChange)
+      window.removeEventListener("scroll", handleScroll, true)
+      delete telemetryWindow.__aqPost507InteractionTelemetryCleanup
+    }
+  })
+
+export const readPost507InteractionTelemetry = async (page: Page, label = "interaction") =>
+  (await readPost507EditorDiagnostics(page, label)).interactionTelemetry
+
+export const clearPost507InteractionTelemetry = async (page: Page) =>
+  page.evaluate(() => {
+    const telemetryWindow = window as typeof window & {
+      __aqPost507InteractionTelemetry?: Post507InteractionTelemetrySnapshot
+      __aqPost507InteractionTelemetryCleanup?: () => void
+    }
+    telemetryWindow.__aqPost507InteractionTelemetryCleanup?.()
+    delete telemetryWindow.__aqPost507InteractionTelemetry
+  })
 
 export const expectPost507FinalTableTextSelected = (selectionText: string) => {
   const normalizedSelectionText = selectionText.replace(/\s+/g, " ").trim()

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -24,6 +24,8 @@ export const markNextEditorPointerAfterTable = () => { preserveNextEditorPointer
 
 export const clearNextEditorPointerAfterTable = () => { preserveNextEditorPointerAfterTable = false }
 
+export const cancelActiveWindowScrollPreserve = () => { activeWindowScrollPreserveCancel?.(); activeWindowScrollPreserveCancel = null }
+
 export const cancelTablePointerScrollPreserves = () => {
   clearNextEditorPointerAfterTable()
   activeTablePointerScrollPreserveCancels.forEach((cancel) => cancel())

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -1,6 +1,7 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
 import { TextSelection } from "@tiptap/pm/state"
 import {
+  cancelActiveWindowScrollPreserve,
   cancelTablePointerScrollPreserves,
   clearNextEditorPointerAfterTable,
   preserveWindowScrollForRichBlockSelectAll,
@@ -363,6 +364,7 @@ export const clearTableTextSelectionForStructuralSelection = (
   explicitTableTextDragStart = null
   hasRecentTableTextSelectionContext = false
   cancelActiveTableCellTextSelectionPreserves()
+  cancelActiveWindowScrollPreserve()
   cancelTablePointerScrollPreserves()
   shouldClearActiveTableTextSelectionOnBlur = false
   lastTableSelectionExitTarget = null


### PR DESCRIPTION
## 관련 이슈

close #608
close #610

## 작업 배경

- 507 editor route의 selection/menu/scroll/fallback timeline을 계측해, 최종 DOM 상태만 보는 E2E가 놓치던 중간 churn을 실패 조건으로 올렸습니다.
- 새 telemetry가 노출한 row/column axis selection 중 stale `window.scrollTo` rollback 원인을 제거했습니다.

## 작업 내용

- 507 diagnostics에 interaction telemetry를 추가해 `window.scrollTo`, row/column menu churn, selection owner, code/table fallback marker를 기록합니다.
- table axis structural selection 테스트를 row/column fresh-page 시나리오로 분리하고, menu close/reopen과 fallback marker 잔존을 명시적으로 실패시킵니다.
- table structural selection cleanup에서 active global scroll preserve까지 취소해 stale preserve loop가 viewport를 되돌리지 않게 했습니다.

## 검증

- 실행한 명령과 결과:
  - `env CURRENT_TASK_SLUG=issue-608-editor-telemetry bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-507-contract.spec.ts e2e/editor-authoring-code-mermaid.spec.ts e2e/editor-authoring-route-table-axis-after-select-all.spec.ts --workers=1` (17 passed)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:authoring` 2회 연속 (각 141 passed)
  - 수동 diff 리뷰: E2E 통과만 완료 근거로 쓰지 않고, `clearTableTextSelectionForStructuralSelection`의 active global preserve 취소와 telemetry cleanup 경로를 확인했습니다.
  - CodeRabbit CLI: `coderabbit review --agent -t uncommitted --base main -c AGENTS.md`가 연결 이후 findings 없이 멈춰 수동 리뷰로 대체했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 테스트 전용 telemetry가 long authoring suite에서 부하를 늘릴 수 있습니다. assertion 직후 cleanup을 호출하고 row/column 시나리오를 분리해 부하를 제한했습니다.
- 롤백 방법: 이 PR의 두 commit을 revert하면 telemetry assertion과 scroll preserve 취소 변경이 함께 제거됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
