### PR TITLE
[Fix] 507 테이블 텍스트 드래그 경계 보존

### DIFF
--- a/front/e2e/editor-authoring-route-table-text-boundary.spec.ts
+++ b/front/e2e/editor-authoring-route-table-text-boundary.spec.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from "fs"
+import { expect, test } from "@playwright/test"
+import {
+  POST_507_FINAL_TABLE_FORBIDDEN_TEXTS,
+  POST_507_FINAL_TABLE_TARGET_CELL,
+  mockEditorRouteWithPost507,
+} from "./helpers/post507Fixtures"
+
+test.describe("editor authoring route table text drag boundary", () => {
+  test("table text restore source contract는 한쪽 endpoint만 table 안인 native selection을 owned로 인정하지 않는다", () => {
+    const source = readFileSync("src/components/editor/tableTextSelectionModel.ts", "utf8")
+    expect(source).toContain("isTableCellEndpointSelection")
+    expect(source).not.toContain("(anchorElement && currentCell.contains(anchorElement)) ||")
+    expect(source).not.toContain("(focusElement && currentCell.contains(focusElement)))")
+  })
+
+  test("실제 /editor/[id] 507 table text drag는 table 밖 body selection을 owner로 인정하지 않는다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1580, height: 900 })
+    const { finalTable } = await mockEditorRouteWithPost507(page, {
+      postId: 996,
+      title: "live 507 table text boundary 글",
+      version: 1,
+    })
+    await finalTable.locator("td", { hasText: POST_507_FINAL_TABLE_TARGET_CELL }).first().scrollIntoViewIfNeeded()
+
+    const forbiddenText = POST_507_FINAL_TABLE_FORBIDDEN_TEXTS[0]
+    await page.evaluate(
+      ({ forbiddenText, tableText }) => {
+        const table = Array.from(document.querySelectorAll("table")).find((candidate) =>
+          candidate.textContent?.includes(tableText)
+        )
+        const startCell = Array.from(table?.querySelectorAll<HTMLElement>("th, td") ?? []).find((cell) =>
+          cell.textContent?.includes(tableText)
+        )
+        const textNodeFor = (root: Node, text: string) => {
+          const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+          while (walker.nextNode()) {
+            const node = walker.currentNode as Text
+            if (node.data.includes(text)) return node
+          }
+          return null
+        }
+        const outsideNode = textNodeFor(document.body, forbiddenText)
+        const startNode = startCell ? textNodeFor(startCell, tableText) : null
+        if (!startCell || !startNode || !outsideNode || startCell.contains(outsideNode.parentElement)) {
+          throw new Error("table boundary fixture nodes are missing")
+        }
+        const pointFor = (node: Text, text: string, edge: "end" | "start") => {
+          const offset = node.data.indexOf(text)
+          const range = document.createRange()
+          range.setStart(node, offset)
+          range.setEnd(node, offset + text.length)
+          const rect = Array.from(range.getClientRects()).find((candidate) => candidate.width > 2 && candidate.height > 2) ?? range.getBoundingClientRect()
+          return { x: edge === "start" ? rect.left + 2 : rect.right - 2, y: rect.top + rect.height / 2 }
+        }
+        const start = pointFor(startNode, tableText, "start")
+        const outside = pointFor(outsideNode, forbiddenText, "end")
+        const dispatch = (type: string, point: { x: number; y: number }, buttons: number) => {
+          const target = document.elementFromPoint(point.x, point.y) ?? document
+          const init = { bubbles: true, button: 0, buttons, cancelable: true, clientX: point.x, clientY: point.y, composed: true }
+          if (type.startsWith("pointer")) target.dispatchEvent(new PointerEvent(type, { ...init, isPrimary: true, pointerId: 1, pointerType: "mouse" }))
+          else target.dispatchEvent(new MouseEvent(type, init))
+        }
+        dispatch("pointerdown", start, 1)
+        dispatch("mousedown", start, 1)
+        const leakedRange = document.createRange()
+        leakedRange.setStart(startNode, startNode.data.indexOf(tableText))
+        leakedRange.setEnd(outsideNode, outsideNode.data.indexOf(forbiddenText) + forbiddenText.length)
+        const selection = window.getSelection()
+        selection?.removeAllRanges()
+        selection?.addRange(leakedRange)
+        dispatch("pointermove", outside, 1)
+        dispatch("mousemove", outside, 1)
+        dispatch("pointerup", outside, 0)
+        dispatch("mouseup", outside, 0)
+      },
+      { forbiddenText, tableText: POST_507_FINAL_TABLE_TARGET_CELL }
+    )
+    await page.waitForTimeout(260)
+
+    const selectionState = await page.evaluate(() => {
+      const selection = window.getSelection()
+      const closestCellText = (node: Node | null | undefined) => {
+        const element = node instanceof Element ? node : node?.parentElement
+        return element?.closest("th, td")?.textContent?.replace(/\s+/g, " ").trim() ?? ""
+      }
+      return {
+        anchorCellText: closestCellText(selection?.anchorNode),
+        focusCellText: closestCellText(selection?.focusNode),
+        nativeText: selection?.toString().replace(/\s+/g, " ").trim() ?? "",
+        persistedText: document.documentElement.getAttribute("data-table-drag-selection-text") ?? "",
+      }
+    })
+    expect(selectionState.nativeText).toContain(POST_507_FINAL_TABLE_TARGET_CELL)
+    expect(selectionState.nativeText).not.toContain(forbiddenText)
+    expect(selectionState.anchorCellText || selectionState.focusCellText).toContain(POST_507_FINAL_TABLE_TARGET_CELL)
+    expect(selectionState.persistedText).not.toContain(forbiddenText)
+  })
+})

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -96,7 +96,15 @@ const resolveExplicitTableTextSelectionRangeCells = (
   options: { allowControlFallback?: boolean } = {}
 ) => { const pointCell = resolveTableTextCellAtPoint(clientX, clientY, target, options); return explicitDragStart && pointCell instanceof HTMLElement && pointCell.closest("table") === explicitDragStart.cell.closest("table") && (Math.abs(clientX - explicitDragStart.x) > 4 || Math.abs(clientY - explicitDragStart.y) > 4) ? { anchorCell: explicitDragStart.cell, pointCell } : null }
 const preserveExplicitTableTextSelectionFromPoint = (clientX: number, clientY: number, target?: EventTarget | Node | null) => { const rangeCells = resolveExplicitTableTextSelectionRangeCells(clientX, clientY, target, explicitTableTextDragStart, { allowControlFallback: Boolean(explicitTableTextDragStart) }); if (!rangeCells || rangeCells.anchorCell === rangeCells.pointCell) return false; pendingTableTextSelectionRangeCells = rangeCells; selectTableCellTextRange(rangeCells.anchorCell, rangeCells.pointCell); preserveTableTextRangeAcrossFrames(rangeCells.anchorCell, rangeCells.pointCell); return true }
-const preserveExplicitTableTextSelectionFromMoveEvent = (event: MouseEvent | PointerEvent) => { if (event.buttons !== 1) { pendingTableTextSelectionRangeCells = null; return } if (preserveExplicitTableTextSelectionFromPoint(event.clientX, event.clientY, event.target)) { event.preventDefault(); event.stopPropagation(); event.stopImmediatePropagation(); return } pendingTableTextSelectionRangeCells = resolveTableTextSelectionRangeCells(event.clientX, event.clientY, event.target) ?? pendingTableTextSelectionRangeCells }
+const preserveExplicitTableTextSelectionFromMoveEvent = (event: MouseEvent | PointerEvent) => {
+  if (event.buttons !== 1) { pendingTableTextSelectionRangeCells = null; return }
+  const rangeCells = resolveExplicitTableTextSelectionRangeCells(event.clientX, event.clientY, event.target, explicitTableTextDragStart, { allowControlFallback: Boolean(explicitTableTextDragStart) }) ?? resolveTableTextSelectionRangeCells(event.clientX, event.clientY, event.target, { allowControlFallback: Boolean(explicitTableTextDragStart) })
+  if (rangeCells && rangeCells.anchorCell !== rangeCells.pointCell) {
+    pendingTableTextSelectionRangeCells = rangeCells; selectTableCellTextRange(rangeCells.anchorCell, rangeCells.pointCell); preserveTableTextRangeAcrossFrames(rangeCells.anchorCell, rangeCells.pointCell)
+    event.preventDefault(); event.stopPropagation(); event.stopImmediatePropagation(); return
+  }
+  pendingTableTextSelectionRangeCells = rangeCells ?? pendingTableTextSelectionRangeCells
+}
 
 const preserveTableTextRangeAcrossFrames = (anchorCell: HTMLElement, pointCell: HTMLElement) => {
   activeTableTextRangePreserveCancel?.()
@@ -144,7 +152,7 @@ export const finalizeTableTextSelectionFromPoint = (clientX: number, clientY: nu
   const explicitDragStart = explicitTableTextDragStart
   explicitTableTextDragStart = null
   const allowControlFallback = Boolean(explicitDragStart || pendingTableTextSelectionRangeCells)
-  const pointCell = resolveTableTextCellAtPoint(clientX, clientY, target, { allowControlFallback }), explicitRangeCells = resolveExplicitTableTextSelectionRangeCells(clientX, clientY, target, explicitDragStart, { allowControlFallback }), rangeCells = resolveTableTextSelectionRangeCells(clientX, clientY, target, { allowControlFallback }) ?? (pointCell ? pendingTableTextSelectionRangeCells : null) ?? explicitRangeCells
+  const explicitRangeCells = resolveExplicitTableTextSelectionRangeCells(clientX, clientY, target, explicitDragStart, { allowControlFallback }), rangeCells = resolveTableTextSelectionRangeCells(clientX, clientY, target, { allowControlFallback }) ?? pendingTableTextSelectionRangeCells ?? explicitRangeCells
   pendingTableTextSelectionRangeCells = null
   if (!rangeCells || rangeCells.anchorCell === rangeCells.pointCell) return false
   cancelActiveTableCellTextSelectionPreserves()
@@ -333,6 +341,11 @@ const isSelectionInsideSameTable = (selection: Selection, table: Element | null)
   const anchorElement = resolveElement(selection.anchorNode)
   const focusElement = resolveElement(selection.focusNode)
   return Boolean(anchorElement && focusElement && table.contains(anchorElement) && table.contains(focusElement))
+}
+const isTableCellEndpointSelection = (selection: Selection, cell: HTMLElement) => {
+  const anchorElement = resolveElement(selection.anchorNode)
+  const focusElement = resolveElement(selection.focusNode)
+  return Boolean(anchorElement && focusElement && cell.contains(anchorElement) && cell.contains(focusElement))
 }
 
 const asTableCell = (element: Element | null) =>
@@ -788,16 +801,12 @@ export const restoreTableCellTextSelectionIfEscaped = (
   const selection = window.getSelection()
   if (!selection) return false
 
-  const anchorElement = resolveElement(selection.anchorNode)
-  const focusElement = resolveElement(selection.focusNode)
   const hasTextSelection = selection.toString().trim().length > 0
   const table = resolveCellTable(currentCell)
   const isOwnedTableSelection = isSelectionInsideSameTable(selection, table)
   if (
     hasTextSelection &&
-    (isOwnedTableSelection ||
-      (anchorElement && currentCell.contains(anchorElement)) ||
-      (focusElement && currentCell.contains(focusElement)))
+    (isOwnedTableSelection || isTableCellEndpointSelection(selection, currentCell))
   ) {
     currentCell.setAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR, selection.toString())
     clearNextEditorPointerAfterTable()


### PR DESCRIPTION
## 관련 이슈

close #611

## 작업 배경

- 507 `/editor/[id]` 테이블 텍스트 드래그가 table 밖 본문 선택을 owned selection으로 받아들이던 경계를 막았습니다.
- E2E는 회귀 가드로만 두고, source contract에서 한쪽 endpoint만 셀 안인 native selection을 더 이상 정상 owned 상태로 인정하지 않도록 고정했습니다.

## 작업 내용

- `restoreTableCellTextSelectionIfEscaped`가 같은 table 또는 같은 cell endpoint selection만 보존하도록 owner 조건을 좁혔습니다.
- global table text move listener가 explicit pointerdown start를 놓친 same-table drag도 즉시 table text range로 선택하고 이벤트를 차단하도록 보강했습니다.
- pointerup/mouseup 지점이 cell로 해석되지 않아도 pending last-valid table range를 사용해 body selection 유입을 끊었습니다.
- 507 fixture 기반 source/runtime guard를 추가해 table 밖 본문 텍스트가 native/persisted selection에 남지 않는지 확인합니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=issue-611-table-text-drag-boundary bash tools/guards/current-task-preflight.sh`
  - RED: `CURRENT_TASK_SLUG=issue-611-table-text-drag-boundary yarn --cwd front playwright test e2e/editor-authoring-route-table-text-boundary.spec.ts -g "source contract" --workers=1`
  - GREEN: `CURRENT_TASK_SLUG=issue-611-table-text-drag-boundary yarn --cwd front playwright test e2e/editor-authoring-route-table-text-boundary.spec.ts e2e/editor-authoring-route-table-multicell-selection.spec.ts e2e/editor-authoring-selection-drag.spec.ts -g "table text drag는 table 밖|source contract|multi-cell drag|테이블 다중 셀 텍스트 드래그|pointercancel" --workers=1`
  - `CURRENT_TASK_SLUG=issue-611-table-text-drag-boundary yarn --cwd front playwright test e2e/editor-authoring-route-table-axis-after-select-all.spec.ts -g "column structural selection" --workers=1`
  - `CURRENT_TASK_SLUG=issue-611-table-text-drag-boundary yarn --cwd front test:e2e:authoring`
  - `CURRENT_TASK_SLUG=issue-611-table-text-drag-boundary yarn --cwd front build`
  - `CURRENT_TASK_SLUG=issue-611-table-text-drag-boundary yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 테이블 텍스트 선택 보존 경계가 좁아져, table 밖으로 의도적으로 이어지는 native selection은 table 내부 마지막 valid range로 복구됩니다.
- 롤백 방법: `fix(editor): 507 table text drag 경계 보존` 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
