### PR TITLE
[Fix] 507 테이블 외곽선 깜빡임 방지

### DIFF
--- a/front/e2e/editor-authoring-route-table-outline-churn.spec.ts
+++ b/front/e2e/editor-authoring-route-table-outline-churn.spec.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "fs"
+import { expect, test } from "@playwright/test"
+import {
+  POST_507_FINAL_TABLE_TARGET_CELL,
+  mockEditorRouteWithPost507,
+} from "./helpers/post507Fixtures"
+
+const TABLE_CHROME_TRANSITION_RE = /\b(?:border-color|box-shadow|background(?:-color)?)\b/
+
+test.describe("editor authoring route table outline churn", () => {
+  test("table wrapper source contract는 caret-only click chrome transition을 두지 않는다", () => {
+    const source = readFileSync("src/components/editor/BlockEditorEngine.editorSurfaceStyles.tsx", "utf8")
+    const tableWrapperBlock = source.match(/\.aq-block-editor__content \.tableWrapper \{[\s\S]*?\n  \}/)?.[0] ?? ""
+    const transitionDeclaration = tableWrapperBlock.match(/transition:\s*([\s\S]*?);/)?.[1] ?? ""
+    expect(transitionDeclaration).not.toMatch(TABLE_CHROME_TRANSITION_RE)
+  })
+
+  test("실제 /editor/[id] 507 table wrapper는 border/shadow/background transition 대상이 아니다", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1580, height: 900 })
+    const { finalTable } = await mockEditorRouteWithPost507(page, {
+      postId: 997,
+      title: "live 507 table outline churn 글",
+      version: 1,
+    })
+    const targetCell = finalTable.locator("td", { hasText: POST_507_FINAL_TABLE_TARGET_CELL }).first()
+    await targetCell.scrollIntoViewIfNeeded()
+    await targetCell.click()
+
+    const tableChrome = await page.evaluate((tableText) => {
+      const table = Array.from(document.querySelectorAll("table")).find((candidate) =>
+        candidate.textContent?.includes(tableText)
+      )
+      const wrapper = table?.closest(".tableWrapper")
+      if (!(wrapper instanceof HTMLElement)) throw new Error("post 507 table wrapper is missing")
+      const style = window.getComputedStyle(wrapper)
+      return {
+        borderColor: style.borderColor,
+        boxShadow: style.boxShadow,
+        transitionDuration: style.transitionDuration,
+        transitionProperty: style.transitionProperty,
+      }
+    }, POST_507_FINAL_TABLE_TARGET_CELL)
+
+    expect(tableChrome.transitionProperty).not.toMatch(TABLE_CHROME_TRANSITION_RE)
+  })
+})

--- a/front/src/components/editor/BlockEditorEngine.editorSurfaceStyles.tsx
+++ b/front/src/components/editor/BlockEditorEngine.editorSurfaceStyles.tsx
@@ -302,10 +302,7 @@ export const EditorViewport = styled.div`
     overscroll-behavior-x: contain;
     overscroll-behavior-y: auto;
     touch-action: pan-x pan-y;
-    transition:
-      border-color 140ms ease,
-      box-shadow 140ms ease,
-      background 140ms ease;
+    transition: none;
       `
     }}
   }


### PR DESCRIPTION
## 관련 이슈

close #612

## 작업 배경

- 507 `/editor/[id]` 테이블 내부 caret-only click 때 wrapper 외곽선이 transition으로 깜빡이던 경로를 끊었습니다.
- E2E는 보조 가드로만 두고, source/runtime contract에서 `.tableWrapper`가 border/shadow/background transition 대상이 되지 않도록 고정했습니다.

## 작업 내용

- `.tableWrapper`에 `transition: none`을 명시해 공통 block transition(`.aq-block-editor__content > *`)과 자체 chrome transition이 table wrapper에 적용되지 않게 했습니다.
- hover border/ring 자체는 유지해 hover enter/leave와 structural selection 시각 상태는 기존 의미를 유지합니다.
- 507 fixture 기반 source/runtime guard를 추가해 table wrapper computed `transitionProperty`가 `border-color`, `box-shadow`, `background`를 포함하지 않도록 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=issue-612-table-outline-churn bash tools/guards/current-task-preflight.sh`
  - RED: `CURRENT_TASK_SLUG=issue-612-table-outline-churn yarn --cwd front playwright test e2e/editor-authoring-route-table-outline-churn.spec.ts --workers=1`
  - GREEN: `CURRENT_TASK_SLUG=issue-612-table-outline-churn yarn --cwd front playwright test e2e/editor-authoring-route-table-outline-churn.spec.ts --workers=1`
  - `CURRENT_TASK_SLUG=issue-612-table-outline-churn yarn --cwd front test:e2e:authoring`
  - `CURRENT_TASK_SLUG=issue-612-table-outline-churn yarn --cwd front build`
  - `CURRENT_TASK_SLUG=issue-612-table-outline-churn yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table wrapper hover chrome은 즉시 상태 전환으로 유지되며, wrapper border/shadow/background 애니메이션은 제거됩니다.
- 롤백 방법: `fix(editor): 507 table outline churn 방지` 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
