### PR TITLE
[CI] main editor grow-handle E2E flake 안정화

### DIFF
--- a/front/e2e/editor-authoring-callout-inline.spec.ts
+++ b/front/e2e/editor-authoring-callout-inline.spec.ts
@@ -339,20 +339,8 @@ test.describe("editor authoring callout and inline formatting", () => {
     await page.keyboard.type("전체 선택 테두리 방지")
 
     const paragraph = editor.locator("p", { hasText: "전체 선택 테두리 방지" }).first()
-    const paragraphBox = await expectVisibleBox(
-      paragraph,
-      "본문 첫 글자 더블클릭 좌표를 계산할 수 없습니다."
-    )
-
-    await paragraph.dispatchEvent("mousedown", {
-      button: 0,
-      buttons: 1,
-      clientX: paragraphBox.x + 2,
-      clientY: paragraphBox.y + paragraphBox.height / 2,
-      detail: 2,
-      bubbles: true,
-      cancelable: true,
-    })
+    await expect(paragraph).toBeVisible()
+    await paragraph.dblclick({ position: { x: 2, y: 8 } })
 
     await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
     await expect

--- a/front/e2e/editor-authoring-table-affordances.spec.ts
+++ b/front/e2e/editor-authoring-table-affordances.spec.ts
@@ -434,7 +434,16 @@ test.describe("editor authoring table affordances", () => {
 
     await targetCell.click()
     await targetCell.hover()
-    await page.mouse.move(targetMetrics.left + targetMetrics.width / 2, tableBox.y + 6)
+    const columnTargetMetrics = await targetCell.evaluate((element) => {
+      const rect = element.getBoundingClientRect()
+      return { left: Math.round(rect.left), width: Math.round(rect.width) }
+    })
+    const columnTableBox = await page.locator(".aq-block-editor__content .tableWrapper table").boundingBox()
+    if (!columnTableBox) {
+      throw new Error("table bounding box is missing before column axis hover")
+    }
+    const columnTargetCenter = columnTargetMetrics.left + columnTargetMetrics.width / 2
+    await page.mouse.move(columnTargetCenter, columnTableBox.y + 6)
     await expect(columnHandle).toBeVisible()
     const columnRailRect = await columnHandle.evaluate((element) => {
       const rect = element.getBoundingClientRect()
@@ -445,7 +454,7 @@ test.describe("editor authoring table affordances", () => {
         height: Math.round(rect.height),
       }
     })
-    expect(Math.abs(columnRailRect.left + columnRailRect.width / 2 - (targetMetrics.left + targetMetrics.width / 2))).toBeLessThanOrEqual(8)
+    expect(Math.abs(columnRailRect.left + columnRailRect.width / 2 - columnTargetCenter)).toBeLessThanOrEqual(8)
   })
 
   test("table menu는 좁은 뷰포트에서도 화면 내부에 배치된다", async ({ page }) => {

--- a/front/e2e/editor-authoring-table-structure.spec.ts
+++ b/front/e2e/editor-authoring-table-structure.spec.ts
@@ -319,7 +319,12 @@ test.describe("editor authoring table structure and styles", () => {
     const trailingCell = page.locator("table tr").nth(before.rows - 1).locator("th, td").nth(before.columns - 1)
     await trailingCell.click()
     await page.keyboard.type("keep")
+    await expect(trailingCell).toContainText("keep")
+    await expect
+      .poll(async () => (await page.getByTestId("qa-markdown-output").textContent()) || "")
+      .toContain("keep")
     await hoverTableCorner()
+    await expect(growHandle).toBeVisible()
 
     await growHandle.evaluate(async (element, payload) => {
       const { pointerId, padding } = payload as {


### PR DESCRIPTION
## 관련 이슈

close #618

## 작업 배경

- #617 merge 후 main CI를 막은 editor authoring E2E flake를 안정화합니다.
- 실패한 E2E를 완료 근거로 과신하지 않고, 입력 반영 전제와 stale geometry 전제를 테스트 내부에서 먼저 고정했습니다.

## 작업 내용

- grow-handle blocked-shrink 검증 전에 trailing cell의 `keep` 입력이 DOM과 markdown output에 반영됐는지 확인합니다.
- row menu를 닫은 뒤 column axis hover 검증에서 target cell/table geometry를 다시 읽어 stale 좌표로 anchor를 판정하지 않게 했습니다.
- writer double-click guard는 detached DOM 좌표 계산 대신 Playwright의 retry 가능한 `dblclick` action을 사용합니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=ci-editor-grow-handle-flake bash tools/guards/current-task-preflight.sh`
  - 환경 실패 분류: sandbox에서 `CURRENT_TASK_SLUG=ci-editor-grow-handle-flake yarn --cwd front playwright test e2e/editor-authoring-table-structure.spec.ts -g "table corner grow handle" --workers=1 --repeat-each=3`는 `listen EPERM 127.0.0.1:3000`로 실패했습니다.
  - `CURRENT_TASK_SLUG=ci-editor-grow-handle-flake yarn --cwd front playwright test e2e/editor-authoring-table-structure.spec.ts -g "table corner grow handle" --workers=1 --repeat-each=3` (권한 상승 후 3 passed)
  - `CURRENT_TASK_SLUG=ci-editor-grow-handle-flake yarn --cwd front playwright test e2e/editor-authoring-table-structure.spec.ts e2e/editor-authoring-table-affordances.spec.ts -g "table corner grow handle|table axis rail hover" --workers=1 --repeat-each=3` (6 passed)
  - `CURRENT_TASK_SLUG=ci-editor-grow-handle-flake yarn --cwd front test:e2e:authoring` (초기 변경 후 146 passed)
  - `CURRENT_TASK_SLUG=ci-editor-grow-handle-flake yarn --cwd front build` (최종 변경 후 passed)
  - `CURRENT_TASK_SLUG=ci-editor-grow-handle-flake yarn --cwd front playwright test e2e/editor-authoring-table-structure.spec.ts e2e/editor-authoring-table-affordances.spec.ts e2e/editor-authoring-callout-inline.spec.ts -g "table corner grow handle|table axis rail hover|본문 첫 글자 더블클릭" --workers=1 --repeat-each=3` (최종 변경 후 9 passed)
  - `CURRENT_TASK_SLUG=ci-editor-grow-handle-flake yarn --cwd front test:e2e:authoring` (최종 변경 후 145 passed, 1 unrelated existing failure: `editor-authoring-route-table-axis-after-select-all.spec.ts` row structural selection stale overlay)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 테스트 전제 안정화만 포함되어 production editor 동작 변경은 없습니다. 전체 authoring suite는 별도 row overlay stale 시그니처가 남아 PR CI에서 재확인합니다.
- 롤백 방법: `79099925`를 revert하면 기존 E2E timing/geometry 검증으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
