### PR TITLE
[CI] editor cell menu E2E flake 안정화

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -563,19 +563,22 @@ test.describe("editor authoring route live drag sequence", () => {
       throw new Error(`lower body selection restored stale code text: ${JSON.stringify(diagnostics)}\n${error instanceof Error ? error.message : String(error)}`)
     }
     const reissueCodeContent = editor.locator(".aq-code-editor-content", { hasText: "createAccessToken(getUser(refreshToken))" }).first()
-    const reissueClickMetrics = await reissueCodeContent.evaluate((element) => {
+    await reissueCodeContent.evaluate((element) => {
       element.scrollIntoView({ block: "center", inline: "nearest" })
+    })
+    await page.waitForTimeout(120)
+    const reissueClickPoint = await reissueCodeContent.evaluate((element) => {
       const rect = element.getBoundingClientRect()
       const style = window.getComputedStyle(element)
       const lineHeight = Number.parseFloat(style.lineHeight || "22") || 22
       const paddingTop = Number.parseFloat(style.paddingTop || "0") || 0
       return {
-        y: Math.min(rect.height - 8, paddingTop + lineHeight * 5.5),
+        x: rect.left + 80,
+        y: rect.top + Math.min(rect.height - 8, paddingTop + lineHeight * 5.5),
       }
     })
-    await page.waitForTimeout(120)
     const beforeLowerCodeClick = await readScrollTop(page)
-    await reissueCodeContent.click({ position: { x: 80, y: reissueClickMetrics.y } })
+    await page.mouse.click(reissueClickPoint.x, reissueClickPoint.y)
     await page.waitForTimeout(2_600)
     await expect.poll(() => readScrollTop(page)).toBeLessThanOrEqual(beforeLowerCodeClick + 24)
     await expect.poll(() => readScrollTop(page)).toBeGreaterThanOrEqual(beforeLowerCodeClick - 24)

--- a/front/e2e/editor-authoring-table-structure.spec.ts
+++ b/front/e2e/editor-authoring-table-structure.spec.ts
@@ -24,6 +24,28 @@ const openCellMenuForCell = async (page: Page, cell: Locator) => {
   throw new Error("table cell menu did not open for active cell")
 }
 
+const clickStableCellMenuButton = async (page: Page, cell: Locator, name: string) => {
+  const cellMenu = page.getByTestId("table-cell-menu")
+
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const menu =
+      attempt === 0 && (await cellMenu.isVisible().catch(() => false))
+        ? cellMenu
+        : await openCellMenuForCell(page, cell)
+    const button = menu.getByRole("button", { name })
+    try {
+      await expect(button).toBeVisible({ timeout: 1_000 })
+      await expect(button).toBeEnabled({ timeout: 1_000 })
+      await button.click({ timeout: 1_000 })
+      return
+    } catch (error) {
+      if (attempt === 3) throw error
+      await page.keyboard.press("Escape").catch(() => {})
+      await cellMenu.waitFor({ state: "hidden", timeout: 500 }).catch(() => {})
+    }
+  }
+}
+
 test.describe("editor authoring table structure and styles", () => {
   test("모바일 뷰포트에서는 표만 wrapper 내부 가로 스크롤을 사용하고 페이지 전체 overflow는 생기지 않는다", async ({
     page,
@@ -540,18 +562,12 @@ test.describe("editor authoring table structure and styles", () => {
     await expect(cellMenu.getByRole("button", { name: "제목 행" })).toHaveCount(0)
     await expect(cellMenu.getByRole("button", { name: "표 삭제" })).toHaveCount(0)
 
-    await cellMenu.getByRole("button", { name: "가운데" }).click()
+    await clickStableCellMenuButton(page, firstTableCell, "가운데")
     await expect
       .poll(async () => (await page.getByTestId("qa-markdown-output").textContent()) || "")
       .toContain('"align":"center"')
 
-    const refreshedCellMenu = page.getByTestId("table-cell-menu")
-    if (!(await refreshedCellMenu.isVisible().catch(() => false))) {
-      await openCellMenuForCell(page, firstTableCell)
-    }
-    const yellowBackgroundButton = page.getByTestId("table-cell-menu").getByRole("button", { name: "노랑 배경" })
-    await expect(yellowBackgroundButton).toBeVisible()
-    await yellowBackgroundButton.click()
+    await clickStableCellMenuButton(page, firstTableCell, "노랑 배경")
     await expect
       .poll(async () => (await page.getByTestId("qa-markdown-output").textContent()) || "")
       .toContain('"backgroundColor":"#fef3c7"')


### PR DESCRIPTION
## 관련 이슈

close #618

## 작업 배경

- main CI run `26850106758`은 success 결론이지만 authoring annotation에 `editor-authoring-table-structure.spec.ts`의 retry-only flake가 남았습니다.
- PR #621 첫 CI run `26850779152`도 단순 button click retry로는 같은 stale/partial cell menu snapshot을 회복하지 못해 동일 annotation을 남겼습니다.
- PR #621 두 번째 CI run `26851423430`은 success 결론이지만 `editor-authoring-route-live-drag-sequence.spec.ts`의 lower code 재클릭 scrollTop guard가 retry-only flake annotation을 남겼습니다.
- E2E pass를 제품 정상 증거로 보지 않고, CI annotation을 남기는 비동기 판정 경계를 좁게 안정화합니다. `main` merge 후 Home Server CD는 기존 자동 배포 경로로 확인합니다.

## 작업 내용

- `front/e2e/editor-authoring-table-structure.spec.ts`의 cell menu action helper가 stale/partial menu snapshot을 재사용하지 않도록 cell 기준으로 menu를 재오픈/재획득합니다.
- `front/e2e/editor-authoring-route-live-drag-sequence.spec.ts`의 lower code 재클릭 guard가 Playwright locator click의 auto-scroll side effect를 섞지 않도록 viewport 좌표 기반 mouse click으로 검증합니다.
- production editor 코드, workflow, 배포/인프라는 변경하지 않았습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=ci-editor-grow-handle-flake bash tools/guards/current-task-preflight.sh`
  - `CURRENT_TASK_SLUG=ci-editor-grow-handle-flake yarn --cwd front playwright:preflight`
  - `CURRENT_TASK_SLUG=ci-editor-grow-handle-flake yarn --cwd front build`
  - `CURRENT_TASK_SLUG=ci-editor-grow-handle-flake yarn --cwd front lint`
  - 로컬 Playwright webServer 검증은 sandbox의 `127.0.0.1:3000` bind `EPERM` 제한이 재현된 상태라, PR CI의 authoring step과 check annotations로 동일 시그니처 소거 여부를 확인합니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 실제 cell menu button 렌더 또는 live drag scroll restoration이 깨지면 bounded retry 뒤 CI annotation/failure로 남습니다. 동일 stale locator 또는 locator auto-scroll side effect를 무한 재사용하지 않습니다.
- 롤백 방법: commits `5fb8dc48`, `bbf19472` revert.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
