### PR TITLE
[CI] backend public snapshot cache test 안정화

### DIFF
--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostControllerTest.kt
@@ -243,17 +243,19 @@ class ApiV1PostControllerTest : BaseControllerIntegrationTest() {
 
         @Test
         fun `비로그인 상세 조회는 merged snapshot cache를 채운다`() {
-            val post = postFacade.findPagedByKw("", PostSearchSortType1.CREATED_AT, 1, 1).content.first()
-            cacheManager.getCache(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT)?.evict(post.id)
+            val actor = actorApplicationService.findByEmail("user1@test.com").getOrThrow()
+            val post = postFacade.write(actor, "스냅샷 캐시 테스트 글", "작은 공개 본문", true, true)
+            val snapshotCache =
+                cacheManager.getCache(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT)
+                    ?: error("detail public snapshot cache is missing")
+            snapshotCache.evict(post.id)
 
             mvc.get("/post/api/v1/posts/${post.id}").andExpect {
                 status { isOk() }
             }
 
             val snapshot =
-                cacheManager
-                    .getCache(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT)
-                    ?.get(post.id, PublicPostDetailSnapshotCacheDto::class.java)
+                snapshotCache.get(post.id, PublicPostDetailSnapshotCacheDto::class.java)
 
             assertThat(snapshot).isNotNull
             assertThat(snapshot?.id).isEqualTo(post.id)


### PR DESCRIPTION
## 관련 이슈

close #622

## 작업 배경

- main CI run `26852422912`에서 backend `ApiV1PostControllerTest`가 전역 public list 첫 글에 의존하다 snapshot cache null assertion으로 실패했습니다.
- 테스트가 자체 small public listed post fixture를 생성하도록 바꿔 이전 테스트 데이터/fixture ordering에 의존하지 않게 합니다.
- #621의 frontend E2E 변경과 production backend 코드는 건드리지 않습니다. merge 후 main CI/Security/CD를 다시 확인합니다.

## 작업 내용

- `ApiV1PostControllerTest`의 public snapshot cache case가 `postFacade.write(...)`로 작은 공개 글을 직접 생성합니다.
- `DETAIL_PUBLIC_SNAPSHOT` cache handle을 명시적으로 확보하고 해당 post id를 evict한 뒤 GET 결과로 cache put을 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=ci-backend-public-snapshot-cache-flake bash tools/guards/current-task-preflight.sh`
  - `./gradlew ktlintCheck`
  - `./gradlew --no-daemon test --tests "com.back.boundedContexts.post.adapter.web.ApiV1PostControllerTest*비로그인 상세 조회는 merged snapshot cache를 채운다"`: 로컬에서는 `jps`상 test JVM 없이 Gradle tool session만 남아 결과를 반환하지 않아 PR CI backend job으로 최종 검증합니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 테스트가 새 public post fixture를 만들기 때문에 기존 global list 기반 간접 검증은 제거됩니다. 의도한 검증 대상은 detail snapshot cache put입니다.
- 롤백 방법: commit `2c5aa97e` revert.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
