### PR TITLE
[Fix] 507 수정 페이지 코드블럭 본문 복구

### DIFF
--- a/front/e2e/editor-authoring-route-code-duplicate-raw.spec.ts
+++ b/front/e2e/editor-authoring-route-code-duplicate-raw.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "@playwright/test"
+
+const escapeHtmlAttribute = (value: string) =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("\n", "&#10;")
+
+const buildDuplicatedRawCodeBlockHtml = (language: string, code: string) => {
+  const rawCodeAttribute = escapeHtmlAttribute(code)
+  return [
+    `<div class="aq-code-block" data-language="${language}" data-raw-code="${rawCodeAttribute}">`,
+    '<pre class="aq-code aq-pretty-pre">',
+    `<code class="language-${language}" data-raw-code="${rawCodeAttribute}">`,
+    "</code>",
+    "</pre>",
+    "</div>",
+  ].join("")
+}
+
+test.describe("editor authoring route duplicate raw code recovery", () => {
+  test("실제 /editor/[id] 수정 진입은 wrapper/code 중복 raw attribute 여러 코드블럭도 순서대로 복구한다", async ({
+    page,
+  }) => {
+    const adminMember = {
+      id: 1,
+      username: "qa-admin",
+      nickname: "aquila",
+      isAdmin: true,
+    }
+    const firstCode = "firstUniqueLine();"
+    const secondCode = "secondUniqueLine();"
+    const staleContent = [
+      "첫 번째 코드입니다.",
+      "",
+      "```java",
+      "```",
+      "",
+      "두 번째 코드입니다.",
+      "",
+      "```ts",
+      "```",
+    ].join("\n")
+    const prettyCodeHtml = [
+      "<p>첫 번째 코드입니다.</p>",
+      buildDuplicatedRawCodeBlockHtml("java", firstCode),
+      "<p>두 번째 코드입니다.</p>",
+      buildDuplicatedRawCodeBlockHtml("ts", secondCode),
+    ].join("")
+
+    await page.route("**/member/api/v1/auth/me", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(adminMember),
+      })
+    })
+    await page.route("**/post/api/v1/adm/posts/992", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 992,
+          version: 4,
+          title: "코드 중복 raw 복구 글",
+          content: staleContent,
+          contentHtml: prettyCodeHtml,
+          published: true,
+          listed: true,
+        }),
+      })
+    })
+    await page.route("**/post/api/v1/posts/992", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          content: staleContent,
+          contentHtml: prettyCodeHtml,
+        }),
+      })
+    })
+
+    await page.goto("/editor/992")
+
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue("코드 중복 raw 복구 글")
+    const codeBlocks = page.locator(".aq-code-shell")
+    await expect(codeBlocks).toHaveCount(2, { timeout: 15_000 })
+    await expect(codeBlocks.nth(0).locator(".aq-code-highlight-layer")).toContainText(firstCode)
+    await expect(codeBlocks.nth(0).locator(".aq-code-highlight-layer")).not.toContainText(secondCode)
+    await expect(codeBlocks.nth(1).locator(".aq-code-highlight-layer")).toContainText(secondCode)
+    await expect(codeBlocks.nth(1).locator(".aq-code-highlight-layer")).not.toContainText(firstCode)
+  })
+})

--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -200,6 +200,43 @@ test.describe("editor studio state", () => {
     )
   })
 
+  test("contentHtml fallback은 wrapper/code 중복 raw attribute가 있어도 여러 빈 코드블럭을 순서대로 복구한다", () => {
+    const staleContent = [
+      "첫 번째 코드입니다.",
+      "",
+      "```java",
+      "",
+      "```",
+      "",
+      "두 번째 코드입니다.",
+      "",
+      "```ts",
+      "",
+      "```",
+    ].join("\n")
+    const prettyCodeHtml = [
+      '<div class="aq-code-block" data-language="java" data-raw-code="firstUniqueLine();">',
+      '<pre class="aq-code aq-pretty-pre">',
+      '<code class="language-java" data-raw-code="firstUniqueLine();">',
+      '</code>',
+      '</pre>',
+      '</div>',
+      '<div class="aq-code-block" data-language="ts" data-raw-code="secondUniqueLine();">',
+      '<pre class="aq-code aq-pretty-pre">',
+      '<code class="language-ts" data-raw-code="secondUniqueLine();">',
+      '</code>',
+      '</pre>',
+      '</div>',
+    ].join("")
+
+    const body = resolveEditorMetaSnapshot(staleContent, prettyCodeHtml).body
+
+    expect(body).toContain(["```java", "firstUniqueLine();", "```"].join("\n"))
+    expect(body).toContain(["```ts", "secondUniqueLine();", "```"].join("\n"))
+    expect(body.match(/firstUniqueLine/g)?.length).toBe(1)
+    expect(body.match(/secondUniqueLine/g)?.length).toBe(1)
+  })
+
   test("초기 editor doc의 빈 코드블럭은 source markdown의 non-empty fence로 복구한다", () => {
     const sourceMarkdown = [
       "코드 본문 보존 대상입니다.",

--- a/front/e2e/editor-studio-state.spec.ts
+++ b/front/e2e/editor-studio-state.spec.ts
@@ -235,6 +235,32 @@ test.describe("editor studio state", () => {
     expect(body).toContain(["```ts", "secondUniqueLine();", "```"].join("\n"))
     expect(body.match(/firstUniqueLine/g)?.length).toBe(1)
     expect(body.match(/secondUniqueLine/g)?.length).toBe(1)
+    expect(body.indexOf(["```java", "firstUniqueLine();", "```"].join("\n"))).toBeLessThan(
+      body.indexOf(["```ts", "secondUniqueLine();", "```"].join("\n"))
+    )
+  })
+
+  test("contentHtml fallback은 wrapper-only raw와 child code language를 같은 fence로 복구한다", () => {
+    const staleContent = [
+      "언어 보강 대상입니다.",
+      "",
+      "```ts",
+      "",
+      "```",
+    ].join("\n")
+    const prettyCodeHtml = [
+      '<div class="aq-code-block" data-raw-code="childLanguageOnly();">',
+      '<pre class="aq-code aq-pretty-pre">',
+      '<code class="language-ts">',
+      '</code>',
+      '</pre>',
+      '</div>',
+    ].join("")
+
+    const body = resolveEditorMetaSnapshot(staleContent, prettyCodeHtml).body
+
+    expect(body).toContain(["```ts", "childLanguageOnly();", "```"].join("\n"))
+    expect(body).not.toContain(["```", "childLanguageOnly();", "```"].join("\n"))
   })
 
   test("초기 editor doc의 빈 코드블럭은 source markdown의 non-empty fence로 복구한다", () => {

--- a/front/src/routes/Admin/editorStudioMetaModel.ts
+++ b/front/src/routes/Admin/editorStudioMetaModel.ts
@@ -65,22 +65,7 @@ const EDITOR_BODY_PLACEHOLDER = "내용을 입력하세요."
 const EDITOR_TOGGLE_TITLE_PLACEHOLDER = "토글 제목"
 const HTML_TAG_REGEX = /<\/?([a-z][a-z0-9:-]*)\b([^>]*)>/gi
 const HTML_ATTRIBUTE_REGEX = /\s([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>`]+)))?/g
-const HTML_VOID_TAG_NAMES = new Set([
-  "area",
-  "base",
-  "br",
-  "col",
-  "embed",
-  "hr",
-  "img",
-  "input",
-  "link",
-  "meta",
-  "param",
-  "source",
-  "track",
-  "wbr",
-])
+const HTML_VOID_TAG_NAMES = new Set("area base br col embed hr img input link meta param source track wbr".split(" "))
 export const PREVIEW_SUMMARY_MAX_LENGTH = 150
 export const PREVIEW_SUMMARY_MAX_CONTENT_LENGTH = 50_000
 
@@ -348,6 +333,21 @@ const resolveCodeLanguageFromHtmlAttributes = (attributes: Map<string, string>) 
   return (className.match(/(?:^|\s)language-([a-zA-Z0-9_-]+)/)?.[1] || "").trim()
 }
 
+const backfillLatestRawCodeBlockLanguage = (
+  blocks: Array<{ codeSource: string; language: string }>,
+  codeSource: string,
+  language: string
+) => {
+  if (!language) return
+
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    const previousBlock = blocks[index]
+    if (previousBlock.codeSource !== codeSource) continue
+    if (!previousBlock.language) previousBlock.language = language
+    break
+  }
+}
+
 const extractRawCodeFencedBlocksFromHtml = (contentHtml?: string | null) => {
   if (!contentHtml?.trim()) return ""
 
@@ -364,6 +364,7 @@ const extractRawCodeFencedBlocksFromHtml = (contentHtml?: string | null) => {
     }
 
     const attributes = readHtmlAttributes(String(rawAttributes))
+    const language = resolveCodeLanguageFromHtmlAttributes(attributes)
     const codeSource = (
       attributes.get("data-raw-code") ||
       attributes.get("data-prism-source") ||
@@ -372,21 +373,20 @@ const extractRawCodeFencedBlocksFromHtml = (contentHtml?: string | null) => {
     const isSelfClosing = /\/\s*>$/.test(String(_match)) || HTML_VOID_TAG_NAMES.has(tagName)
     const stackEntry: { rawCodeSource?: string; tagName: string } = { tagName }
     if (codeSource.trim()) {
-      const language = resolveCodeLanguageFromHtmlAttributes(attributes)
       const hasSameRawCodeAncestor = elementStack.some((entry) => entry.rawCodeSource === codeSource)
       if (hasSameRawCodeAncestor) {
-        if (language) {
-          for (let index = blocks.length - 1; index >= 0; index -= 1) {
-            const previousBlock = blocks[index]
-            if (previousBlock.codeSource !== codeSource) continue
-            if (!previousBlock.language) previousBlock.language = language
-            break
-          }
-        }
+        backfillLatestRawCodeBlockLanguage(blocks, codeSource, language)
       } else {
         blocks.push({ codeSource, language })
       }
       stackEntry.rawCodeSource = codeSource
+    } else if (language) {
+      for (let index = elementStack.length - 1; index >= 0; index -= 1) {
+        const ancestorSource = elementStack[index]?.rawCodeSource
+        if (!ancestorSource) continue
+        backfillLatestRawCodeBlockLanguage(blocks, ancestorSource, language)
+        break
+      }
     }
     if (!isSelfClosing) elementStack.push(stackEntry)
     return _match

--- a/front/src/routes/Admin/editorStudioMetaModel.ts
+++ b/front/src/routes/Admin/editorStudioMetaModel.ts
@@ -63,9 +63,24 @@ const LEADING_EDITOR_METADATA_LINE_REGEX =
   /^\s*(tags?|categories?|summary|thumbnail|thumb|cover|coverimage|cover_image)\s*:\s*(.+)\s*$/i
 const EDITOR_BODY_PLACEHOLDER = "내용을 입력하세요."
 const EDITOR_TOGGLE_TITLE_PLACEHOLDER = "토글 제목"
-const HTML_CODE_RAW_ATTRIBUTE_TAG_REGEX =
-  /<([a-z][a-z0-9:-]*)\b([^>]*(?:data-raw-code|data-prism-source)[^>]*)>/gi
+const HTML_TAG_REGEX = /<\/?([a-z][a-z0-9:-]*)\b([^>]*)>/gi
 const HTML_ATTRIBUTE_REGEX = /\s([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>`]+)))?/g
+const HTML_VOID_TAG_NAMES = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+])
 export const PREVIEW_SUMMARY_MAX_LENGTH = 150
 export const PREVIEW_SUMMARY_MAX_CONTENT_LENGTH = 50_000
 
@@ -336,22 +351,50 @@ const resolveCodeLanguageFromHtmlAttributes = (attributes: Map<string, string>) 
 const extractRawCodeFencedBlocksFromHtml = (contentHtml?: string | null) => {
   if (!contentHtml?.trim()) return ""
 
-  const blocks: string[] = []
-  contentHtml.replace(HTML_CODE_RAW_ATTRIBUTE_TAG_REGEX, (_match, _tagName, rawAttributes) => {
+  const blocks: Array<{ codeSource: string; language: string }> = []
+  const elementStack: Array<{ rawCodeSource?: string; tagName: string }> = []
+  contentHtml.replace(HTML_TAG_REGEX, (_match, rawTagName, rawAttributes) => {
+    const tagName = String(rawTagName).toLowerCase()
+    if (String(_match).startsWith("</")) {
+      for (let index = elementStack.length - 1; index >= 0; index -= 1) {
+        const current = elementStack.pop()
+        if (current?.tagName === tagName) break
+      }
+      return _match
+    }
+
     const attributes = readHtmlAttributes(String(rawAttributes))
     const codeSource = (
       attributes.get("data-raw-code") ||
       attributes.get("data-prism-source") ||
       ""
     ).trimEnd()
-    if (!codeSource.trim()) return _match
-
-    const language = resolveCodeLanguageFromHtmlAttributes(attributes)
-    blocks.push(`\`\`\`${language}\n${codeSource}\n\`\`\``)
+    const isSelfClosing = /\/\s*>$/.test(String(_match)) || HTML_VOID_TAG_NAMES.has(tagName)
+    const stackEntry: { rawCodeSource?: string; tagName: string } = { tagName }
+    if (codeSource.trim()) {
+      const language = resolveCodeLanguageFromHtmlAttributes(attributes)
+      const hasSameRawCodeAncestor = elementStack.some((entry) => entry.rawCodeSource === codeSource)
+      if (hasSameRawCodeAncestor) {
+        if (language) {
+          for (let index = blocks.length - 1; index >= 0; index -= 1) {
+            const previousBlock = blocks[index]
+            if (previousBlock.codeSource !== codeSource) continue
+            if (!previousBlock.language) previousBlock.language = language
+            break
+          }
+        }
+      } else {
+        blocks.push({ codeSource, language })
+      }
+      stackEntry.rawCodeSource = codeSource
+    }
+    if (!isSelfClosing) elementStack.push(stackEntry)
     return _match
   })
 
-  return blocks.join("\n\n")
+  return blocks
+    .map(({ codeSource, language }) => `\`\`\`${language}\n${codeSource}\n\`\`\``)
+    .join("\n\n")
 }
 
 export const resolveEditorMetaSnapshot = (content: string, contentHtml?: string | null): ResolvedEditorMetaSnapshot => {


### PR DESCRIPTION
## 관련 이슈

close #626

## 작업 배경

- 507 수정 진입에서 pretty-code `contentHtml`의 wrapper와 inner `code`가 같은 raw source를 동시에 갖는 경우, 빈 fenced code 복구 순서가 밀려 뒤쪽 코드블럭 본문이 잘못 채워지는 문제를 수정했습니다.
- raw-code 추출을 태그 스택 기반으로 바꿔 부모 wrapper와 자식 code의 중복 raw source를 한 코드블럭으로 취급하고, 상태 모델과 실제 editor route 회귀 테스트를 추가했습니다.

## 작업 내용

- `contentHtml` raw-code fallback 추출이 중복 wrapper/code raw attribute를 별도 fence로 세지 않도록 보강했습니다.
- 저장 기준 editor body를 만드는 상태 모델 테스트에 다중 빈 fence 순서 복구 케이스를 추가했습니다.
- 실제 `/editor/[id]` 진입 route 테스트를 새 spec으로 분리해 코드블럭 2개의 highlight layer가 각각 원래 raw code를 표시하는지 확인합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight` (2회 통과)
  - `yarn --cwd front playwright test e2e/editor-authoring-route-code-initial-render.spec.ts e2e/editor-authoring-route-code-duplicate-raw.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts --workers=1` (동일 조건 2회 연속 통과, 11 passed)
  - `yarn --cwd front playwright test e2e/editor-studio-state.spec.ts --workers=1` (동일 조건 2회 연속 통과, 13 passed)
  - `yarn --cwd front build` (동일 조건 2회 연속 통과)
  - Browser 수동 확인: mock 507-equivalent `/editor/507` payload에서 `.aq-code-shell` 2개, highlight text `firstUniqueLine();` / `secondUniqueLine();`, console error/warn 0건 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: malformed HTML에서 태그 스택이 예상보다 넓게 유지되면 raw-code de-duplication 범위가 달라질 수 있습니다. 기존 단일 raw attribute, wrapper-only raw attribute, placeholder 복구 테스트를 함께 통과시켜 회귀 범위를 확인했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `e0bf6a44`를 revert하면 이전 raw-code 추출 방식과 테스트 구성으로 되돌릴 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
