### PR TITLE
[Fix] 507 하단 테이블 scroll selection 안정화

### DIFF
--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -873,7 +873,7 @@ export const preserveTableCellTextSelectionAcrossFrames = (
     TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES,
     4,
     TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS,
-    true,
+    false,
     false,
     true,
     false,

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -361,8 +361,8 @@ let lastActiveTableCell: HTMLElement | null = null
 let lastActiveTableCellPath: ActiveTableCellPath | null = null
 const activeTableCellScrollPreserveCancels = new Set<() => void>()
 const activeTableCellSelectionPreserveCancels = new Set<() => void>()
-const TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES = 48
-const TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS = 800
+const TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES = 72
+const TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS = 1_200
 
 export const cancelActiveTableCellScrollPreserves = () => {
   activeTableCellScrollPreserveCancels.forEach((cancel) => cancel())
@@ -859,7 +859,7 @@ export const restoreTableCellTextSelectionIfEscaped = (
 export const preserveTableCellTextSelectionAcrossFrames = (
   editor: TiptapEditor,
   startedCell: HTMLElement,
-  _scrollAnchor: WindowScrollAnchor,
+  scrollAnchor: WindowScrollAnchor,
   resolveEndCell?: () => HTMLElement | null
 ) => {
   if (isTableStructuralSelectionOwnerActive()) return null
@@ -868,8 +868,27 @@ export const preserveTableCellTextSelectionAcrossFrames = (
   let frame = 0
   let cancelled = false
   let restoring = false
+  const cancelScrollPreserve = preserveWindowScrollPositionAcrossFrames(
+    scrollAnchor,
+    TABLE_TEXT_DRAG_SCROLL_PRESERVE_FRAMES,
+    4,
+    TABLE_TEXT_DRAG_SCROLL_PRESERVE_MIN_MS,
+    true,
+    false,
+    true,
+    false,
+    false,
+    () => !hasOwnedTableCellTextSelection(editor, startedCell)
+  )
+  if (cancelScrollPreserve) {
+    activeTableCellScrollPreserveCancels.add(cancelScrollPreserve)
+  }
   const cleanup = () => {
     activeTableCellSelectionPreserveCancels.delete(cancel)
+    if (cancelScrollPreserve) {
+      activeTableCellScrollPreserveCancels.delete(cancelScrollPreserve)
+      cancelScrollPreserve()
+    }
     window.removeEventListener("pointerdown", cancel, true)
     window.removeEventListener("mousedown", cancel, true)
     window.removeEventListener("wheel", cancel, true)


### PR DESCRIPTION
## 관련 이슈

close #627

## 작업 배경

- #629 merge 이후 main CI #26894621291에서 `/editor/507` 하단 table/code drag sequence가 selection empty와 scroll jump로 실패한 문제를 고칩니다.
- table text drag release 이후 selection 복구 루프가 scroll anchor를 잃지 않도록 보강해, 늦게 들어오는 browser auto-scroll과 selection restore 경합을 줄였습니다.

## 작업 내용

- `preserveTableCellTextSelectionAcrossFrames`가 pointerup 이후에도 기존 scroll anchor를 일정 프레임 유지하도록 연결했습니다.
- post-release scroll preserve cancel을 기존 active cancel set에 등록해 wheel/new pointer/selection owner loss 시 정상 해제되도록 했습니다.
- table drag scroll preserve window를 48 frames/800ms에서 72 frames/1200ms로 늘려 CI에서 보인 늦은 auto-scroll을 흡수합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --grep "body selection 뒤 table/code drag" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-table-multicell-selection.spec.ts --grep "단일 셀 내부 drag" --workers=1 --repeat-each=5`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-route-table-multicell-selection.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-code-initial-render.spec.ts e2e/editor-authoring-route-code-duplicate-raw.spec.ts e2e/editor-authoring-route-code-recovery.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-route-table-multicell-selection.spec.ts --workers=1 --repeat-each=2`
  - main CI failure artifact 확인: run #26894621291, lower code Ctrl+A selection empty 및 table scroll jump failure screenshot 확인
  - in-app Browser 직접 route mock은 현재 Browser API가 `page.route`를 제공하지 않아 대체하지 않고, 동일 Chromium 기반 Playwright 실제 조작으로 검증했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table text selection 직후 짧은 시간 동안 scroll preserve가 유지되어 의도적 wheel 직후 체감이 늦을 수 있습니다. cancel 조건은 wheel/pointer/selection owner loss에 연결했습니다.
- 롤백 방법: 이 PR의 단일 커밋 `fix(editor): 507 table scroll selection 안정화`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
