### PR TITLE
[Fix] editor 507 row axis scroll flicker 안정화

### DIFF
--- a/front/e2e/editor-authoring-route-selection-scroll-owner.spec.ts
+++ b/front/e2e/editor-authoring-route-selection-scroll-owner.spec.ts
@@ -126,12 +126,20 @@ test.describe("editor authoring route 507 selection scroll owner", () => {
       source.match(
         /const preserveCodePointerFocusScroll = useCallback\([\s\S]*?\n  \}, \[\]\)/
       )?.[0] ?? ""
+    const sharedHelper =
+      source.match(
+        /const preserveCodeScrollAcrossFrames = \([\s\S]*?\n\) => \{[\s\S]*?\n\}/
+      )?.[0] ?? ""
 
+    expect(sharedHelper).toContain("replaceActivePreserve = false")
+    expect(sharedHelper).toContain("CODE_SCROLL_PRESERVE_MIN_MS")
+    expect(sharedHelper).toContain("shouldCancelCodeScrollPreserve(scrollAnchor)")
+    expect(sharedHelper).toContain("replaceActivePreserve")
     expect(helper).toContain(
-      "CODE_SCROLL_PRESERVE_MIN_MS, false, false, true, false, false, shouldCancelCodeScrollPreserve(scrollAnchor), true"
+      "preserveCodeScrollAcrossFrames(scrollAnchor, true)"
     )
     expect(helper).toContain(
-      "CODE_SCROLL_PRESERVE_MIN_MS, false, false, true, false, false, shouldCancelCodeScrollPreserve(scrollAnchor))"
+      "preserveCodeScrollAcrossFrames(scrollAnchor)"
     )
   })
 

--- a/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
+++ b/front/e2e/editor-authoring-route-table-axis-after-select-all.spec.ts
@@ -11,10 +11,11 @@ import {
 
 const SELECT_ALL_SHORTCUT = process.platform === "darwin" ? "Meta+a" : "Control+a"
 
-const clickVisibleOverlayControl = async (_page: Page, locator: Locator) => {
-  void _page
+const clickVisibleOverlayControl = async (page: Page, locator: Locator) => {
   await expect(locator).toBeVisible({ timeout: 900 })
-  await locator.click({ force: true, timeout: 900 })
+  const box = await locator.boundingBox()
+  if (!box) throw new Error("visible overlay control has no bounding box")
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2)
 }
 
 const moveToPost507RowGripHotzone = async (page: Page, rowHandle: Locator) => {
@@ -68,8 +69,24 @@ const readPost507AxisAttemptDebug = async (page: Page) =>
     const editor = document.querySelector<HTMLElement>("[data-testid='block-editor-prosemirror']")
     const count = (selector: string) => document.querySelectorAll(selector).length
     const visibleCount = (selector: string) =>
-      Array.from(document.querySelectorAll<HTMLElement>(selector)).filter((element) => { const rect = element.getBoundingClientRect(); return rect.width > 0 && rect.height > 0 }).length
-    return { columnMenuCount: count("[data-testid='table-column-menu']"), columnOutlineCount: count("[data-testid='table-column-selection-outline']"), columnRailVisibleCount: visibleCount("[data-testid='table-column-rail']"), dragAttributeCount: count("[data-table-drag-selection-text]"), rootDragText: document.documentElement.getAttribute("data-table-drag-selection-text")?.trim() ?? "", rowMenuCount: count("[data-testid='table-row-menu']"), rowOutlineCount: count("[data-testid='table-row-selection-outline']"), rowRailVisibleCount: visibleCount("[data-testid='table-row-rail']"), scrollTop: Math.round(document.scrollingElement?.scrollTop ?? window.scrollY), selectedCellCount: editor?.querySelectorAll(".selectedCell").length ?? 0, selectionText: window.getSelection()?.toString().trim() ?? "" }
+      Array.from(document.querySelectorAll<HTMLElement>(selector)).filter((element) => {
+        const rect = element.getBoundingClientRect()
+        return rect.width > 0 && rect.height > 0
+      }).length
+
+    return {
+      columnMenuCount: count("[data-testid='table-column-menu']"),
+      columnOutlineCount: count("[data-testid='table-column-selection-outline']"),
+      columnRailVisibleCount: visibleCount("[data-testid='table-column-rail']"),
+      dragAttributeCount: count("[data-table-drag-selection-text]"),
+      rootDragText: document.documentElement.getAttribute("data-table-drag-selection-text")?.trim() ?? "",
+      rowMenuCount: count("[data-testid='table-row-menu']"),
+      rowOutlineCount: count("[data-testid='table-row-selection-outline']"),
+      rowRailVisibleCount: visibleCount("[data-testid='table-row-rail']"),
+      scrollTop: Math.round(document.scrollingElement?.scrollTop ?? window.scrollY),
+      selectedCellCount: editor?.querySelectorAll(".selectedCell").length ?? 0,
+      selectionText: window.getSelection()?.toString().trim() ?? "",
+    }
   })
 
 const clickPost507AxisHandleUntilSelected = async (
@@ -161,6 +178,45 @@ const expectPost507FinalTableSelectionOnPage = async (page: Page) => {
       }
     })
     .toBe(true)
+}
+
+const readPost507FinalTableViewportSample = (page: Page) =>
+  page.evaluate((targetCellText) => {
+    const editor = document.querySelector<HTMLElement>("[data-testid='block-editor-prosemirror']")
+    const table = Array.from(editor?.querySelectorAll<HTMLElement>("table") ?? [])
+      .filter((candidate) => {
+        const text = candidate.textContent ?? ""
+        return text.includes(targetCellText) && text.includes("재발급 로직")
+      })
+      .at(-1)
+    const rect = table?.getBoundingClientRect()
+    const scrollTop = Math.round(document.scrollingElement?.scrollTop ?? window.scrollY)
+    const tableTop = rect ? Math.round(rect.top) : null
+    return {
+      scrollTop,
+      tableDocumentTop: tableTop === null ? null : scrollTop + tableTop,
+      tableTop,
+    }
+  }, POST_507_FINAL_TABLE_TARGET_CELL)
+
+const waitForPost507FinalTableViewportStable = async (page: Page) => {
+  let lastSamples: Awaited<ReturnType<typeof readPost507FinalTableViewportSample>>[] = []
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const samples = []
+    for (let index = 0; index < 5; index += 1) {
+      samples.push(await readPost507FinalTableViewportSample(page))
+      await page.waitForTimeout(50)
+    }
+    const documentTops = samples
+      .map((sample) => sample.tableDocumentTop)
+      .filter((value): value is number => typeof value === "number")
+    const stable =
+      documentTops.length === samples.length &&
+      Math.max(...documentTops) - Math.min(...documentTops) <= 8
+    if (stable) return
+    lastSamples = samples
+  }
+  throw new Error(`post 507 final table viewport did not stabilize: ${JSON.stringify(lastSamples)}`)
 }
 
 const expectNoTableTextSelectionState = async (page: Page, label: string) => {
@@ -355,6 +411,76 @@ const expectAxisSelectionStable = async (
       selectedCellCount: expectedSelectedCellCount,
     }))
   )
+}
+
+const expectAxisSelectionViewportStableImmediately = async (
+  page: Page,
+  expectedSelectedCellCount: number,
+  overlayTestId: "table-column-selection-outline" | "table-row-selection-outline"
+) => {
+  const samples = []
+  for (let index = 0; index < 24; index += 1) {
+    samples.push(
+      await page.evaluate(
+        ({ overlayTestId }) => {
+          const editor = document.querySelector<HTMLElement>("[data-testid='block-editor-prosemirror']")
+          const selectedCells = Array.from(editor?.querySelectorAll<HTMLElement>(".selectedCell") ?? [])
+          const table = selectedCells[0]?.closest("table") ?? null
+          const mermaidHeights = Array.from(
+            editor?.querySelectorAll<HTMLElement>(".node-mermaidBlock") ?? []
+          ).map((element, mermaidIndex) => ({
+            height: Math.round(element.getBoundingClientRect().height),
+            index: mermaidIndex,
+            offsetTop: element.offsetTop,
+          }))
+          const rect = table?.getBoundingClientRect()
+          const scrollTop = Math.round(document.scrollingElement?.scrollTop ?? window.scrollY)
+          const tableTop = rect ? Math.round(rect.top) : null
+
+          return {
+            documentScrollHeight: document.scrollingElement?.scrollHeight ?? null,
+            mermaidHeights,
+            overlayCount: document.querySelectorAll(`[data-testid='${overlayTestId}']`).length,
+            scrollPreserveOwner: document.documentElement.getAttribute("data-editor-scroll-preserve-owner"),
+            scrollTop,
+            selectedCellCount: selectedCells.length,
+            selectionTextLength: window.getSelection()?.toString().trim().length ?? 0,
+            tableDocumentTop: tableTop === null ? null : scrollTop + tableTop,
+            tableTop,
+          }
+        },
+        {
+          overlayTestId,
+        }
+      )
+    )
+    await page.waitForTimeout(50)
+  }
+
+  const first = samples[0]
+  expect(first?.tableTop, "first axis viewport sample should include the final table").not.toBeNull()
+  for (const sample of samples) {
+    expect(sample.overlayCount).toBe(1)
+    expect(sample.selectedCellCount).toBe(expectedSelectedCellCount)
+    expect(sample.selectionTextLength).toBe(0)
+    expect(sample.tableDocumentTop).not.toBeNull()
+  }
+  const scrollTops = samples.map((sample) => sample.scrollTop)
+  const tableTops = samples.map((sample) => sample.tableTop ?? Number.NaN)
+  const documentScrollHeights = samples.map((sample) => sample.documentScrollHeight ?? Number.NaN)
+  const tableDocumentTops = samples.map((sample) => sample.tableDocumentTop ?? Number.NaN)
+  const maxScrollDelta = Math.max(...scrollTops) - Math.min(...scrollTops)
+  const maxTableTopDelta = Math.max(...tableTops) - Math.min(...tableTops)
+  const maxDocumentScrollHeightDelta =
+    Math.max(...documentScrollHeights) - Math.min(...documentScrollHeights)
+  const maxTableDocumentTopDelta = Math.max(...tableDocumentTops) - Math.min(...tableDocumentTops)
+  expect(maxScrollDelta, `axis viewport scroll samples: ${JSON.stringify(samples)}`).toBeLessThanOrEqual(16)
+  expect(maxTableTopDelta, `axis viewport table samples: ${JSON.stringify(samples)}`).toBeLessThanOrEqual(32)
+  expect(
+    maxDocumentScrollHeightDelta,
+    `axis document height samples: ${JSON.stringify(samples)}`
+  ).toBeLessThanOrEqual(32)
+  expect(maxTableDocumentTopDelta, `axis document table samples: ${JSON.stringify(samples)}`).toBeLessThanOrEqual(32)
 }
 
 const countMenuCloseTransitions = (menuCounts: number[]) => {
@@ -745,12 +871,14 @@ test.describe("editor authoring route post 507 final table axis after cell text 
     }
 
     await selectCurrentCellText()
+    await waitForPost507FinalTableViewportStable(page)
     await moveToPost507RowGripHotzone(page, rowHandle)
     await expect(rowHandle).toBeVisible()
     await clickVisibleOverlayControl(page, rowHandle)
     await expect(page.getByTestId("table-row-selection-outline")).toBeVisible()
     await expect(page.getByTestId("table-row-menu")).toBeVisible()
     await expect(editor.locator(".selectedCell")).toHaveCount(3)
+    await expectAxisSelectionViewportStableImmediately(page, 3, "table-row-selection-outline")
     await expect
       .poll(async () =>
         page.evaluate(() =>

--- a/front/e2e/editor-authoring-table-operations.spec.ts
+++ b/front/e2e/editor-authoring-table-operations.spec.ts
@@ -35,6 +35,48 @@ test.describe("editor authoring table operations", () => {
     await expect(page.locator("table tr")).toHaveCount(3)
   })
 
+  test("multi-table 상태의 QA fallback 열 선택은 첫 표를 임의 선택하지 않는다", async ({
+    page,
+  }) => {
+    await page.goto(QA_ENGINE_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.click()
+    const twoTableMarkdown = [
+      "| 첫 표 A | 첫 표 B |",
+      "| --- | --- |",
+      "| first-1 | first-2 |",
+      "",
+      "중간 문단",
+      "",
+      "| 둘째 표 A | 둘째 표 B |",
+      "| --- | --- |",
+      "| second-1 | second-2 |",
+    ].join("\n")
+
+    await editor.evaluate((element, markdown) => {
+      const data = new DataTransfer()
+      data.setData("text/plain", markdown)
+      const event = new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+      })
+      Object.defineProperty(event, "clipboardData", { value: data })
+      element.dispatchEvent(event)
+    }, twoTableMarkdown)
+
+    const tables = page.locator(".aq-block-editor__content .tableWrapper table")
+    await expect(tables).toHaveCount(2)
+    await expect(tables.first().locator("tr")).toHaveCount(2)
+    await expect(tables.nth(1).locator("tr")).toHaveCount(2)
+
+    await page.evaluate(() => window.scrollBy(0, 80))
+    await page.getByRole("button", { name: "QA fallback 열 선택" }).click()
+
+    await expect(page.locator("table .selectedCell")).toHaveCount(0)
+    await expect(page.getByTestId("table-column-menu")).toHaveCount(0)
+  })
+
   test("table row/column grip drag는 축을 재정렬하고 seed 재진입 후에도 순서를 유지한다", async ({ page }) => {
     await page.goto(QA_ENGINE_ROUTE)
     const { rowHandle: rowGrip, columnHandle: columnGrip } = getTableAffordances(page)

--- a/front/e2e/editor-authoring-table-operations.spec.ts
+++ b/front/e2e/editor-authoring-table-operations.spec.ts
@@ -77,6 +77,66 @@ test.describe("editor authoring table operations", () => {
     await expect(page.getByTestId("table-column-menu")).toHaveCount(0)
   })
 
+  test("multi-table affordance는 stale selection보다 hovered table을 우선한다", async ({
+    page,
+  }) => {
+    await page.goto(QA_ENGINE_ROUTE)
+
+    const editor = page.locator("[data-testid='block-editor-prosemirror']").first()
+    await editor.click()
+    const twoTableMarkdown = [
+      "| 첫 표 A | 첫 표 B |",
+      "| --- | --- |",
+      "| first-1 | first-2 |",
+      "",
+      "중간 문단",
+      "",
+      "| 둘째 표 A | 둘째 표 B |",
+      "| --- | --- |",
+      "| second-1 | second-2 |",
+    ].join("\n")
+
+    await editor.evaluate((element, markdown) => {
+      const data = new DataTransfer()
+      data.setData("text/plain", markdown)
+      const event = new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+      })
+      Object.defineProperty(event, "clipboardData", { value: data })
+      element.dispatchEvent(event)
+    }, twoTableMarkdown)
+
+    const tables = page.locator(".aq-block-editor__content .tableWrapper table")
+    await expect(tables).toHaveCount(2)
+    const { growHandle } = getTableAffordances(page)
+    const secondTable = tables.nth(1)
+    await tables.first().locator("th, td").first().click()
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const secondTableBox = await secondTable.boundingBox()
+      if (!secondTableBox) {
+        throw new Error("second table box is missing before grow handle hover")
+      }
+      await secondTable.hover({
+        position: {
+          x: Math.max(2, Math.round(secondTableBox.width) - 4),
+          y: 6,
+        },
+      })
+      await page.waitForTimeout(120)
+      if (await growHandle.isVisible().catch(() => false)) break
+    }
+
+    await expect(growHandle).toBeVisible()
+    await growHandle.click()
+
+    await expect(tables.first().locator("tr")).toHaveCount(2)
+    await expect(tables.first().locator("tr").first().locator("th, td")).toHaveCount(2)
+    await expect(secondTable.locator("tr")).toHaveCount(3)
+    await expect(secondTable.locator("tr").first().locator("th, td")).toHaveCount(3)
+  })
+
   test("table row/column grip drag는 축을 재정렬하고 seed 재진입 후에도 순서를 유지한다", async ({ page }) => {
     await page.goto(QA_ENGINE_ROUTE)
     const { rowHandle: rowGrip, columnHandle: columnGrip } = getTableAffordances(page)

--- a/front/e2e/editor-authoring-table-resize-guide.spec.ts
+++ b/front/e2e/editor-authoring-table-resize-guide.spec.ts
@@ -26,10 +26,13 @@ test.describe("editor authoring table resize guide", () => {
       )
       .not.toBe(beforeMarkdown)
 
-    const afterWidth = await firstHeaderCell.evaluate((element) =>
-      Math.round((element as HTMLElement).getBoundingClientRect().width)
-    )
-    expect(afterWidth).toBeGreaterThanOrEqual(beforeWidth)
+    await expect
+      .poll(async () =>
+        firstHeaderCell.evaluate((element) =>
+          Math.round((element as HTMLElement).getBoundingClientRect().width)
+        )
+      )
+      .toBeGreaterThanOrEqual(beforeWidth)
     await expect(markdownOutput).toContainText('"columnWidths"')
   })
 

--- a/front/e2e/editor-authoring-table-structure.spec.ts
+++ b/front/e2e/editor-authoring-table-structure.spec.ts
@@ -14,12 +14,19 @@ const openCellMenuForCell = async (page: Page, cell: Locator) => {
   const cellMenu = page.getByTestId("table-cell-menu")
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
-    await cell.click()
-    await cell.hover()
-    await expect(cellMenuButton).toBeVisible()
-    await cellMenuButton.click()
-    await page.waitForTimeout(80)
-    if (await cellMenu.isVisible().catch(() => false)) return cellMenu
+    try {
+      await cell.click()
+      await page.mouse.move(16, 16)
+      await cell.hover()
+      await expect(cellMenuButton).toBeVisible({ timeout: 1_500 })
+      await cellMenuButton.click()
+      await page.waitForTimeout(80)
+      if (await cellMenu.isVisible().catch(() => false)) return cellMenu
+    } catch (error) {
+      if (attempt === 2) throw error
+      await page.keyboard.press("Escape").catch(() => {})
+      await cellMenu.waitFor({ state: "hidden", timeout: 500 }).catch(() => {})
+    }
   }
 
   throw new Error("table cell menu did not open for active cell")

--- a/front/e2e/helpers/post507Fixtures.ts
+++ b/front/e2e/helpers/post507Fixtures.ts
@@ -175,7 +175,11 @@ export type Post507InteractionTelemetrySnapshot = {
     row: boolean
     structure: boolean
   }
-  scrollToCalls: Array<{ elapsedMs: number; targetX: number; targetY: number }>
+  scrollToCalls: Array<{
+    elapsedMs: number
+    targetX: number
+    targetY: number
+  }>
   scrollTopTimeline: Array<{ elapsedMs: number; label: string; scrollTop: number }>
   selectionTimeline: Array<{
     label: string
@@ -475,7 +479,11 @@ export const installPost507InteractionTelemetry = async (page: Page) =>
     window.scrollTo = ((xOrOptions?: number | ScrollToOptions, y?: number) => {
       const targetX = typeof xOrOptions === "object" ? Number(xOrOptions.left ?? window.scrollX) : Number(xOrOptions ?? window.scrollX)
       const targetY = typeof xOrOptions === "object" ? Number(xOrOptions.top ?? window.scrollY) : Number(y ?? window.scrollY)
-      telemetry.scrollToCalls.push({ elapsedMs: elapsedMs(), targetX: Math.round(targetX), targetY: Math.round(targetY) })
+      telemetry.scrollToCalls.push({
+        elapsedMs: elapsedMs(),
+        targetX: Math.round(targetX),
+        targetY: Math.round(targetY),
+      })
       trim(telemetry.scrollToCalls)
       if (typeof xOrOptions === "object") return originalScrollTo(xOrOptions)
       return originalScrollTo(xOrOptions ?? window.scrollX, y ?? window.scrollY)
@@ -1279,13 +1287,19 @@ const resolvePost507FinalTableColumnMetrics = async (page: Page) => {
         headerCells.find((candidate) => candidate.textContent?.includes("점검 항목")) ?? headerCells[1] ?? headerCells[0]
       if (!headerCell) return null
       const headerRect = headerCell.getBoundingClientRect()
+      if (headerRect.bottom <= 8 || headerRect.top >= window.innerHeight - 8) {
+        headerCell.scrollIntoView({
+          block: "center",
+          inline: "nearest",
+          behavior: "instant",
+        })
+        return null
+      }
       if (
         tableRect.width <= 0 ||
         tableRect.height <= 0 ||
         headerRect.width <= 0 ||
-        headerRect.height <= 0 ||
-        headerRect.bottom <= 8 ||
-        headerRect.top >= window.innerHeight - 8
+        headerRect.height <= 0
       ) {
         return null
       }

--- a/front/src/components/editor/codeBlockNodeView.tsx
+++ b/front/src/components/editor/codeBlockNodeView.tsx
@@ -31,12 +31,14 @@ import {
 } from "./codeBlockNodeViewLanguageModel"
 import {
   isPrimarySelectAllShortcut,
-  preventInternalCodeDrop, preventNativeCodeDragStart,
+  preventInternalCodeDrop,
+  preventNativeCodeDragStart,
   resolveCodeBlockPasteRange,
   resolveCodeBlockCopyText,
   resolveVisibleCodeRootForSelectAll,
   selectCodeBlockText,
-  selectCodeDomTextContents, selectDomTextContents,
+  selectCodeDomTextContents,
+  selectDomTextContents,
   selectDomTextOffsetRange,
 } from "./codeBlockNodeViewSelectionModel"
 import { focusElementWithoutScroll } from "./blockEditorEngineDocumentModel"
@@ -55,12 +57,59 @@ let lastCodePointerClientX = 0
 let lastCodePointerClientY = 0
 let lastCodePointerAt = 0
 let activeCodeSelectionOwnerRoot: HTMLElement | null = null
-let lastCodeDragSelectionCompletedAt = 0, lastCodeDragSelectionCompletedX = 0, lastCodeDragSelectionCompletedY = 0
+let lastCodeDragSelectionCompletedAt = 0
+let lastCodeDragSelectionCompletedX = 0
+let lastCodeDragSelectionCompletedY = 0
 const CODE_SCROLL_PRESERVE_MIN_MS = 4_800
 const CODE_SCROLL_PRESERVE_CANCEL_DISTANCE_PX = 3_200
 const CODE_SELECT_ALL_ACTIVE_GRACE_MS = 4_000
-const shouldCancelCodeScrollPreserve = (scrollAnchor: WindowScrollAnchor) => () => Math.abs(window.scrollX - scrollAnchor.x) > CODE_SCROLL_PRESERVE_CANCEL_DISTANCE_PX || Math.abs((document.scrollingElement?.scrollTop ?? window.scrollY) - scrollAnchor.y) > CODE_SCROLL_PRESERVE_CANCEL_DISTANCE_PX
-const isSyntheticClickAfterCodeDragRelease = (clientX: number, clientY: number) => { const now = typeof performance !== "undefined" ? performance.now() : Date.now(), completedAt = lastCodeDragSelectionCompletedAt, matches = now - completedAt < 600 && Math.hypot(clientX - lastCodeDragSelectionCompletedX, clientY - lastCodeDragSelectionCompletedY) <= 8; if (matches) window.setTimeout(() => { if (lastCodeDragSelectionCompletedAt === completedAt) lastCodeDragSelectionCompletedAt = 0 }, 0); return matches }
+const shouldCancelCodeScrollPreserve =
+  (scrollAnchor: WindowScrollAnchor) => () =>
+    Math.abs(window.scrollX - scrollAnchor.x) >
+      CODE_SCROLL_PRESERVE_CANCEL_DISTANCE_PX ||
+    Math.abs(
+      (document.scrollingElement?.scrollTop ?? window.scrollY) - scrollAnchor.y
+    ) > CODE_SCROLL_PRESERVE_CANCEL_DISTANCE_PX
+const isSyntheticClickAfterCodeDragRelease = (
+  clientX: number,
+  clientY: number
+) => {
+  const now =
+    typeof performance !== "undefined" ? performance.now() : Date.now()
+  const completedAt = lastCodeDragSelectionCompletedAt
+  const matches =
+    now - completedAt < 600 &&
+    Math.hypot(
+      clientX - lastCodeDragSelectionCompletedX,
+      clientY - lastCodeDragSelectionCompletedY
+    ) <= 8
+  if (matches) {
+    window.setTimeout(() => {
+      if (lastCodeDragSelectionCompletedAt === completedAt) {
+        lastCodeDragSelectionCompletedAt = 0
+      }
+    }, 0)
+  }
+  return matches
+}
+const preserveCodeScrollAcrossFrames = (
+  scrollAnchor: WindowScrollAnchor,
+  replaceActivePreserve = false
+) => {
+  preserveWindowScrollPositionAcrossFrames(
+    scrollAnchor,
+    240,
+    4,
+    CODE_SCROLL_PRESERVE_MIN_MS,
+    false,
+    false,
+    true,
+    false,
+    false,
+    shouldCancelCodeScrollPreserve(scrollAnchor),
+    replaceActivePreserve
+  )
+}
 type CodeDragSelectionSession = {
   active: boolean
   anchorPos: number
@@ -109,12 +158,12 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
   const preserveCodeSelectAllScroll = useCallback(() => {
     lastCodeDragSelectionCompletedAt = 0
     const scrollAnchor = { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }
-    preserveWindowScrollPositionAcrossFrames(scrollAnchor, 240, 4, CODE_SCROLL_PRESERVE_MIN_MS, false, false, true, false, false, shouldCancelCodeScrollPreserve(scrollAnchor), true)
+    preserveCodeScrollAcrossFrames(scrollAnchor, true)
     return scrollAnchor
   }, [])
   const preserveCodePointerFocusScroll = useCallback((scrollAnchor: { x: number; y: number }) => {
-    preserveWindowScrollPositionAcrossFrames(scrollAnchor, 240, 4, CODE_SCROLL_PRESERVE_MIN_MS, false, false, true, false, false, shouldCancelCodeScrollPreserve(scrollAnchor), true)
-    preserveWindowScrollPositionAcrossFrames(scrollAnchor, 240, 4, CODE_SCROLL_PRESERVE_MIN_MS, false, false, true, false, false, shouldCancelCodeScrollPreserve(scrollAnchor))
+    preserveCodeScrollAcrossFrames(scrollAnchor, true)
+    preserveCodeScrollAcrossFrames(scrollAnchor)
   }, [])
   const resolveCodeTextPosFromPointer = useCallback(
     (clientX: number, clientY: number, contentRoot: HTMLElement | null) => {
@@ -232,28 +281,87 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
   const preserveCodeDomTextRange = useCallback(
     (contentRoot: HTMLElement | null, anchorPos: number, headPos: number) => {
       const scrollAnchor = { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }
-      const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now(), preserveGeneration = ++codeDomTextRangePreserveGeneration
-      let frame = 0, cancelled = false, cancelArmed = false
+      const startedAt =
+        typeof performance !== "undefined" ? performance.now() : Date.now()
+      const preserveGeneration = ++codeDomTextRangePreserveGeneration
+      let frame = 0
+      let cancelled = false
+      let cancelArmed = false
       const shell = contentRoot?.closest(".aq-code-shell")
-      const rootTextSnapshot = (contentRoot?.innerText || contentRoot?.textContent || "").replace(/\s+/g, " ").trim()
+      const rootTextSnapshot = (
+        contentRoot?.innerText ||
+        contentRoot?.textContent ||
+        ""
+      ).replace(/\s+/g, " ").trim()
       const resolveCurrentRoot = () => {
         if (shell?.isConnected) return shell.querySelector<HTMLElement>(".aq-code-editor-content") ?? contentRoot
         const textProbe = rootTextSnapshot.slice(0, 48)
-        return Array.from(document.querySelectorAll<HTMLElement>(".aq-code-editor-content")).find((candidate) => (candidate.innerText || candidate.textContent || "").replace(/\s+/g, " ").trim().includes(textProbe)) ?? contentRoot
+        return Array.from(
+          document.querySelectorAll<HTMLElement>(".aq-code-editor-content")
+        ).find((candidate) =>
+          (candidate.innerText || candidate.textContent || "")
+            .replace(/\s+/g, " ")
+            .trim()
+            .includes(textProbe)
+        ) ?? contentRoot
       }
       const resolveCurrentShell = () => resolveCurrentRoot()?.closest(".aq-code-shell") ?? shell
-      const cleanupCancel = () => { window.removeEventListener("pointerdown", cancel, true); window.removeEventListener("mousedown", cancel, true); window.removeEventListener("keydown", cancelForKeydown, true); window.removeEventListener("wheel", cancelForKeydown, true); document.removeEventListener("selectionchange", cancelOnSelectionChange, true) }
-      const cancelPreserve = () => { cancelled = true; codeDomTextRangePreserveGeneration += 1; resolveCurrentShell()?.removeAttribute("data-code-drag-selection-text"); cleanupCancel() }
-      const cancel = (event: Event) => { if (!cancelArmed) return; const currentShell = resolveCurrentShell(); if (!(event.target instanceof Node) || !currentShell?.contains(event.target)) cancelPreserve() }
+      const cleanupCancel = () => {
+        window.removeEventListener("pointerdown", cancel, true)
+        window.removeEventListener("mousedown", cancel, true)
+        window.removeEventListener("keydown", cancelForKeydown, true)
+        window.removeEventListener("wheel", cancelForKeydown, true)
+        document.removeEventListener("selectionchange", cancelOnSelectionChange, true)
+      }
+      const cancelPreserve = () => {
+        cancelled = true
+        codeDomTextRangePreserveGeneration += 1
+        resolveCurrentShell()?.removeAttribute("data-code-drag-selection-text")
+        cleanupCancel()
+      }
+      const cancel = (event: Event) => {
+        if (!cancelArmed) return
+        const currentShell = resolveCurrentShell()
+        if (!(event.target instanceof Node) || !currentShell?.contains(event.target)) {
+          cancelPreserve()
+        }
+      }
       const cancelForKeydown = () => { if (cancelArmed) cancelPreserve() }
-      const cancelOnSelectionChange = () => { if (!cancelArmed) return; const selection = window.getSelection(), anchor = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focus = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null, currentShell = resolveCurrentShell(); if (selection?.toString().trim() && (!anchor || !focus || !currentShell?.contains(anchor) || !currentShell.contains(focus))) cancelPreserve() }
-      const selectRange = () => { const currentRoot = resolveCurrentRoot(); if (!currentRoot?.isConnected) return; if (!selectCodeDomTextRange(currentRoot, anchorPos, headPos) && anchorPos !== headPos) selectDomTextContents(currentRoot)
+      const cancelOnSelectionChange = () => {
+        if (!cancelArmed) return
+        const selection = window.getSelection()
+        const anchor =
+          selection?.anchorNode instanceof Element
+            ? selection.anchorNode
+            : selection?.anchorNode?.parentElement ?? null
+        const focus =
+          selection?.focusNode instanceof Element
+            ? selection.focusNode
+            : selection?.focusNode?.parentElement ?? null
+        const currentShell = resolveCurrentShell()
+        const selectionLeftCode =
+          selection?.toString().trim() &&
+          (!anchor ||
+            !focus ||
+            !currentShell?.contains(anchor) ||
+            !currentShell.contains(focus))
+        if (selectionLeftCode) cancelPreserve()
+      }
+      const selectRange = () => {
+        const currentRoot = resolveCurrentRoot()
+        if (!currentRoot?.isConnected) return
+        if (!selectCodeDomTextRange(currentRoot, anchorPos, headPos) && anchorPos !== headPos) {
+          selectDomTextContents(currentRoot)
+        }
         persistCodeSelectionText(currentRoot, { allowContentFallback: true })
       }
       const restore = () => {
         if (cancelled || preserveGeneration !== codeDomTextRangePreserveGeneration) return
-        selectRange(); frame += 1
-        const elapsedMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt
+        selectRange()
+        frame += 1
+        const elapsedMs =
+          (typeof performance !== "undefined" ? performance.now() : Date.now()) -
+          startedAt
         if (frame < 168 || elapsedMs < CODE_SCROLL_PRESERVE_MIN_MS) window.requestAnimationFrame(restore)
         else { codeDomTextRangePreserveGeneration += 1; cleanupCancel() }
       }
@@ -272,11 +380,27 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     (event: ReactMouseEvent<HTMLDivElement> | ReactPointerEvent<HTMLDivElement>) => {
       const shell = shellRef.current
       const contentRoot = shell?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
-      if (event.button !== 0 || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey || event.defaultPrevented || (event.nativeEvent as Event & { __aqCodePointerHandled?: boolean }).__aqCodePointerHandled) return
+      const codePointerHandled = (
+        event.nativeEvent as Event & { __aqCodePointerHandled?: boolean }
+      ).__aqCodePointerHandled
+      if (
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.altKey ||
+        event.shiftKey ||
+        event.defaultPrevented ||
+        codePointerHandled
+      )
+        return
       if (!shell || !contentRoot || !(event.target instanceof Node) || !shell.contains(event.target)) return
       const targetElement = event.target instanceof Element ? event.target : event.target.parentElement
       const contentRect = contentRoot.getBoundingClientRect()
-      const isInsideContentBox = event.clientX >= contentRect.left && event.clientX <= contentRect.right && event.clientY >= contentRect.top && event.clientY <= contentRect.bottom
+      const isInsideContentBox =
+        event.clientX >= contentRect.left &&
+        event.clientX <= contentRect.right &&
+        event.clientY >= contentRect.top &&
+        event.clientY <= contentRect.bottom
       const isCodeTextSurfaceTarget =
         contentRoot.contains(event.target) ||
         Boolean(targetElement?.closest(".aq-code-highlight-layer")) ||
@@ -287,11 +411,29 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       event.stopPropagation()
       const scrollAnchor = { x: window.scrollX, y: document.scrollingElement?.scrollTop ?? window.scrollY }
       preserveCodePointerFocusScroll(scrollAnchor)
-      const selection = window.getSelection(), persistedCodeSelectionText = shell.getAttribute("data-code-drag-selection-text")?.trim() || ""
-      const anchorElement = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null, focusElement = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null
-      const selectedText = selection?.toString().trim() || "", contentText = contentRoot.textContent?.trim() || ""
+      const selection = window.getSelection()
+      const persistedCodeSelectionText =
+        shell.getAttribute("data-code-drag-selection-text")?.trim() || ""
+      const anchorElement =
+        selection?.anchorNode instanceof Element
+          ? selection.anchorNode
+          : selection?.anchorNode?.parentElement ?? null
+      const focusElement =
+        selection?.focusNode instanceof Element
+          ? selection.focusNode
+          : selection?.focusNode?.parentElement ?? null
+      const selectedText = selection?.toString().trim() || ""
+      const contentText = contentRoot.textContent?.trim() || ""
       const existingCodeSelectionText = selectedText || persistedCodeSelectionText
-      const hasExistingCodeSelection = Boolean((selectedText && anchorElement && focusElement && contentRoot.contains(anchorElement) && contentRoot.contains(focusElement)) || (persistedCodeSelectionText && contentText.includes(persistedCodeSelectionText.slice(0, 48))))
+      const hasExistingCodeSelection = Boolean(
+        (selectedText &&
+          anchorElement &&
+          focusElement &&
+          contentRoot.contains(anchorElement) &&
+          contentRoot.contains(focusElement)) ||
+          (persistedCodeSelectionText &&
+            contentText.includes(persistedCodeSelectionText.slice(0, 48)))
+      )
       if (hasExistingCodeSelection) {
         codeDomTextRangePreserveGeneration += 1
         selection?.removeAllRanges()
@@ -302,7 +444,7 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       } else {
         if (!selectCodeDomTextRange(contentRoot, anchorPos, anchorPos)) selection?.removeAllRanges()
       }
-      preserveWindowScrollPositionAcrossFrames(scrollAnchor, 240, 4, CODE_SCROLL_PRESERVE_MIN_MS, false, false, true, false, false, shouldCancelCodeScrollPreserve(scrollAnchor), true)
+      preserveCodeScrollAcrossFrames(scrollAnchor, true)
       codeDragSelectionRef.current = {
         active: false,
         anchorPos,
@@ -473,17 +615,33 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       window.removeEventListener("pointercancel", handleWindowMouseUp, true)
     }
   }, [focusCodeTextPosition, getPos, node.nodeSize, preserveCodeDomTextRange, preserveCodePointerFocusScroll, resolveCodeTextPosFromPointer])
-  const ensureCodeDomTextSelection = useCallback((contentRoot: HTMLElement | null, scrollAnchor?: { x: number; y: number }) => {
+  const ensureCodeDomTextSelection = useCallback((
+    contentRoot: HTMLElement | null,
+    scrollAnchor?: { x: number; y: number }
+  ) => {
     if (!contentRoot || typeof window === "undefined") return
-    if (scrollAnchor) preserveWindowScrollPositionAcrossFrames(scrollAnchor, 240, 4, CODE_SCROLL_PRESERVE_MIN_MS, false, false, true, false, false, shouldCancelCodeScrollPreserve(scrollAnchor), true)
+    if (scrollAnchor) preserveCodeScrollAcrossFrames(scrollAnchor, true)
     const codeShell = contentRoot.closest(".aq-code-shell")
-    const rootTextSnapshot = (contentRoot.innerText || contentRoot.textContent || "").replace(/\s+/g, " ").trim()
+    const rootTextSnapshot = (
+      contentRoot.innerText ||
+      contentRoot.textContent ||
+      ""
+    ).replace(/\s+/g, " ").trim()
     const resolveCurrentRoot = () => {
       if (codeShell?.isConnected) return codeShell.querySelector<HTMLElement>(".aq-code-editor-content") ?? contentRoot
       const textProbe = rootTextSnapshot.slice(0, 48)
-      return Array.from(document.querySelectorAll<HTMLElement>(".aq-code-editor-content")).find((candidate) => (candidate.innerText || candidate.textContent || "").replace(/\s+/g, " ").trim().includes(textProbe)) ?? contentRoot
+      return Array.from(
+        document.querySelectorAll<HTMLElement>(".aq-code-editor-content")
+      ).find((candidate) =>
+        (candidate.innerText || candidate.textContent || "")
+          .replace(/\s+/g, " ")
+          .trim()
+          .includes(textProbe)
+      ) ?? contentRoot
     }
-    const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now(), preserveGeneration = ++codeDomTextRangePreserveGeneration
+    const startedAt =
+      typeof performance !== "undefined" ? performance.now() : Date.now()
+    const preserveGeneration = ++codeDomTextRangePreserveGeneration
     let cancelled = false
     let frameId: number | null = null
     let armed = false
@@ -498,7 +656,11 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
     }
     const cancel = (event?: Event) => {
       if (!armed) return
-      if (event?.type === "pointerdown" || event?.type === "mousedown" || event?.type === "click") {
+      if (
+        event?.type === "pointerdown" ||
+        event?.type === "mousedown" ||
+        event?.type === "click"
+      ) {
         const currentRoot = resolveCurrentRoot()
         currentRoot?.closest(".aq-code-shell")?.removeAttribute("data-code-drag-selection-text")
         window.getSelection()?.removeAllRanges()
@@ -506,24 +668,37 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
         lastActiveCodeSelectionAt = 0
         activeCodeSelectionOwnerRoot = null
       }
-      cancelled = true; codeDomTextRangePreserveGeneration += 1
+      cancelled = true
+      codeDomTextRangePreserveGeneration += 1
       cleanup()
     }
     const restore = () => {
       if (cancelled) return
       const currentRoot = resolveCurrentRoot()
-      if (!currentRoot.isConnected || preserveGeneration !== codeDomTextRangePreserveGeneration) { cleanup(); return }
+      if (
+        !currentRoot.isConnected ||
+        preserveGeneration !== codeDomTextRangePreserveGeneration
+      ) {
+        cleanup()
+        return
+      }
       const selection = window.getSelection()
       const anchorElement = selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null
       const focusElement = selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null
-      const selectionInsideCode = Boolean(selection?.toString().trim() && anchorElement && focusElement && currentRoot.contains(anchorElement) && currentRoot.contains(focusElement))
+      const selectionInsideCode = Boolean(
+        selection?.toString().trim() &&
+          anchorElement &&
+          focusElement &&
+          currentRoot.contains(anchorElement) &&
+          currentRoot.contains(focusElement)
+      )
       if (selectionInsideCode) {
         persistCodeSelectionText(currentRoot)
       } else if (persistCodeSelectionText(currentRoot, { allowContentFallback: true }).trim()) {
         selectCodeDomTextContents(currentRoot)
         persistCodeSelectionText(currentRoot)
       }
-      if (scrollAnchor) preserveWindowScrollPositionAcrossFrames(scrollAnchor, 240, 4, CODE_SCROLL_PRESERVE_MIN_MS, false, false, true, false, false, shouldCancelCodeScrollPreserve(scrollAnchor), true)
+      if (scrollAnchor) preserveCodeScrollAcrossFrames(scrollAnchor, true)
       const elapsedMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt
       if (elapsedMs < 240) {
         frameId = window.requestAnimationFrame(restore)
@@ -532,8 +707,14 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
       }
     }
     armed = true
-    window.addEventListener("pointerdown", cancel, true); window.addEventListener("mousedown", cancel, true); window.addEventListener("click", cancel, true); window.addEventListener("wheel", cancel, { capture: true, passive: true })
-    frameId = window.requestAnimationFrame(() => { window.addEventListener("keydown", cancel, true); restore() })
+    window.addEventListener("pointerdown", cancel, true)
+    window.addEventListener("mousedown", cancel, true)
+    window.addEventListener("click", cancel, true)
+    window.addEventListener("wheel", cancel, { capture: true, passive: true })
+    frameId = window.requestAnimationFrame(() => {
+      window.addEventListener("keydown", cancel, true)
+      restore()
+    })
   }, [persistCodeSelectionText])
   useEffect(() => {
     setDraftLanguage(normalizeCodeLanguage(String(node.attrs?.language || "")))
@@ -608,12 +789,38 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
           event.clientY >= shellRect.top &&
           event.clientY <= shellRect.bottom
       )
-      const isInsideCodePointer = contentRoot.contains(target) || Boolean(codeShell?.contains(target)) || Boolean(pointTarget && (contentRoot.contains(pointTarget) || codeShell?.contains(pointTarget))) || isInsideContentPoint || isInsideShellPoint
-      if (event.type !== "click" && !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey && isInsideCodePointer && (window.getSelection()?.toString().trim() || codeShell?.getAttribute("data-code-drag-selection-text")?.trim())) {
-        codeDomTextRangePreserveGeneration += 1; window.getSelection()?.removeAllRanges(); codeShell?.removeAttribute("data-code-drag-selection-text")
-        lastActiveCodeSelectionText = ""; lastActiveCodeSelectionAt = 0; activeCodeSelectionOwnerRoot = null
+      const isInsideCodePointer =
+        contentRoot.contains(target) ||
+        Boolean(codeShell?.contains(target)) ||
+        Boolean(
+          pointTarget &&
+            (contentRoot.contains(pointTarget) || codeShell?.contains(pointTarget))
+        ) ||
+        isInsideContentPoint ||
+        isInsideShellPoint
+      const hasCodeTextSelection =
+        window.getSelection()?.toString().trim() ||
+        codeShell?.getAttribute("data-code-drag-selection-text")?.trim()
+      if (
+        event.type !== "click" &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.shiftKey &&
+        isInsideCodePointer &&
+        hasCodeTextSelection
+      ) {
+        codeDomTextRangePreserveGeneration += 1
+        window.getSelection()?.removeAllRanges()
+        codeShell?.removeAttribute("data-code-drag-selection-text")
+        lastActiveCodeSelectionText = ""
+        lastActiveCodeSelectionAt = 0
+        activeCodeSelectionOwnerRoot = null
       }
       if (isInsideCodePointer) {
+        if (event.type === "pointerdown" || event.type === "mousedown") {
+          markNextEditorPointerAfterCodeSelection()
+        }
         rememberActiveCodeContentRoot()
       } else if (isActiveCodeBlockRef.current && ownsActiveCodeSelection) {
         isActiveCodeBlockRef.current = false
@@ -649,15 +856,30 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
           ? selection.anchorNode
           : selection?.anchorNode?.parentElement ?? null
       const codeShell = contentRoot.closest(".aq-code-shell")
-      const isProseMirrorRootFocused = activeElement instanceof HTMLElement && activeElement.classList.contains("ProseMirror")
+      const isProseMirrorRootFocused =
+        activeElement instanceof HTMLElement &&
+        activeElement.classList.contains("ProseMirror")
       const anchorTableCell = anchorElement?.closest("th, td")
-      const hasTableDragSelectionText = document.documentElement.hasAttribute("data-table-drag-selection-text")
-      if ((activeElement instanceof Element && activeElement.closest("th, td")) || (hasTableDragSelectionText && !isProseMirrorRootFocused) || (anchorTableCell && !isProseMirrorRootFocused)) return
+      const hasTableDragSelectionText = document.documentElement.hasAttribute(
+        "data-table-drag-selection-text"
+      )
+      if (
+        (activeElement instanceof Element && activeElement.closest("th, td")) ||
+        (hasTableDragSelectionText && !isProseMirrorRootFocused) ||
+        (anchorTableCell && !isProseMirrorRootFocused)
+      )
+        return
       if (isProseMirrorRootFocused) {
-        const visibleCodeRoot = resolveVisibleCodeRootForSelectAll({ ignoreTableAnchor: true, ignoreTableDragSelectionText: true })
+        const visibleCodeRoot = resolveVisibleCodeRootForSelectAll({
+          ignoreTableAnchor: true,
+          ignoreTableDragSelectionText: true,
+        })
         if (!visibleCodeRoot) return
         const now = typeof performance !== "undefined" ? performance.now() : Date.now()
-        const visibleCodeRect = (visibleCodeRoot.closest<HTMLElement>(".aq-code-shell") ?? visibleCodeRoot).getBoundingClientRect()
+        const visibleCodeRect = (
+          visibleCodeRoot.closest<HTMLElement>(".aq-code-shell") ??
+          visibleCodeRoot
+        ).getBoundingClientRect()
         const recentCodePointerInsideVisibleRoot =
           now - lastCodePointerAt <= CODE_SELECT_ALL_ACTIVE_GRACE_MS &&
           lastCodePointerClientX >= visibleCodeRect.left &&
@@ -670,7 +892,8 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
         event.preventDefault()
         event.stopPropagation()
         event.stopImmediatePropagation()
-        const preserveAfterSelectAll = () => preserveWindowScrollPositionAcrossFrames(scrollAnchor, 240, 4, CODE_SCROLL_PRESERVE_MIN_MS, false, false, true, false, false, shouldCancelCodeScrollPreserve(scrollAnchor), true)
+        const preserveAfterSelectAll = () =>
+          preserveCodeScrollAcrossFrames(scrollAnchor, true)
         if (selectCodeDomTextContents(visibleCodeRoot)) {
           persistCodeSelectionText(visibleCodeRoot, { allowContentFallback: true })
           preserveAfterSelectAll()
@@ -722,10 +945,12 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
         isRootFocusedWhileCodeHovered
       if (!isInsideCodeBlock) return
       const scrollAnchor = preserveCodeSelectAllScroll()
+      markNextEditorPointerAfterCodeSelection()
       event.preventDefault()
       event.stopPropagation()
       event.stopImmediatePropagation()
-      const preserveAfterSelectAll = () => preserveWindowScrollPositionAcrossFrames(scrollAnchor, 240, 4, CODE_SCROLL_PRESERVE_MIN_MS, false, false, true, false, false, shouldCancelCodeScrollPreserve(scrollAnchor), true)
+      const preserveAfterSelectAll = () =>
+        preserveCodeScrollAcrossFrames(scrollAnchor, true)
       if (selectCodeDomTextContents(contentRoot)) {
         persistCodeSelectionText(contentRoot, { allowContentFallback: true })
         preserveAfterSelectAll()
@@ -911,7 +1136,8 @@ export const CodeBlockView = ({ node, updateAttributes, selected, editor, getPos
 
     const contentRoot = shellRef.current?.querySelector<HTMLElement>(".aq-code-editor-content") ?? null
     const scrollAnchor = preserveCodeSelectAllScroll()
-    const preserveAfterSelectAll = () => preserveWindowScrollPositionAcrossFrames(scrollAnchor, 240, 4, CODE_SCROLL_PRESERVE_MIN_MS, false, false, true, false, false, shouldCancelCodeScrollPreserve(scrollAnchor), true)
+    const preserveAfterSelectAll = () =>
+      preserveCodeScrollAcrossFrames(scrollAnchor, true)
     if (selectCodeDomTextContents(contentRoot)) {
       persistCodeSelectionText(contentRoot, { allowContentFallback: true })
       preserveAfterSelectAll()

--- a/front/src/components/editor/codePointerFollowUpModel.ts
+++ b/front/src/components/editor/codePointerFollowUpModel.ts
@@ -1,0 +1,84 @@
+import type { MutableRefObject } from "react"
+import { markNextEditorPointerAfterCodeSelection } from "./blockHandleLayoutModel"
+
+const CODE_POINTER_FOLLOW_UP_RECENT_MS = 8_000
+const CODE_POINTER_SCROLL_PRESERVE_MS = 3_200
+const CODE_POINTER_SCROLL_TOLERANCE_PX = 4
+
+const getCodePointerFollowUpNow = () =>
+  typeof performance !== "undefined" ? performance.now() : Date.now()
+
+export const markRecentCodePointerFollowUp = (
+  recentCodePointerUntilRef: MutableRefObject<number>
+) => {
+  recentCodePointerUntilRef.current =
+    getCodePointerFollowUpNow() + CODE_POINTER_FOLLOW_UP_RECENT_MS
+  markNextEditorPointerAfterCodeSelection()
+}
+
+export const promoteRecentCodePointerFollowUp = (
+  recentCodePointerUntilRef: MutableRefObject<number>
+) => {
+  if (getCodePointerFollowUpNow() > recentCodePointerUntilRef.current) {
+    return false
+  }
+  markNextEditorPointerAfterCodeSelection()
+  preserveRecentCodePointerScroll()
+  return true
+}
+
+export const preserveRecentCodePointerScroll = () => {
+  if (typeof window === "undefined" || typeof document === "undefined") return
+  const scrollingElement = document.scrollingElement
+  const startY = Math.round(scrollingElement?.scrollTop ?? window.scrollY)
+  const startedAt = getCodePointerFollowUpNow()
+  let cancelled = false
+  let intervalId: number | null = null
+  let rafId: number | null = null
+
+  const restore = () => {
+    const currentY = Math.round(scrollingElement?.scrollTop ?? window.scrollY)
+    if (Math.abs(currentY - startY) <= CODE_POINTER_SCROLL_TOLERANCE_PX) return
+    if (Math.abs(currentY - startY) > 3_200) {
+      cleanup()
+      return
+    }
+    if (scrollingElement) scrollingElement.scrollTop = startY
+    else document.documentElement.scrollTop = startY
+  }
+  const cleanup = () => {
+    cancelled = true
+    window.removeEventListener("scroll", restoreOnScroll, true)
+    window.removeEventListener("wheel", cleanup, true)
+    window.removeEventListener("pointerdown", cleanup, true)
+    window.removeEventListener("keydown", cleanup, true)
+    if (intervalId !== null) window.clearInterval(intervalId)
+    if (rafId !== null) window.cancelAnimationFrame(rafId)
+  }
+  const tick = () => {
+    if (cancelled) return
+    if (getCodePointerFollowUpNow() - startedAt > CODE_POINTER_SCROLL_PRESERVE_MS) {
+      cleanup()
+      return
+    }
+    restore()
+    rafId = window.requestAnimationFrame(tick)
+  }
+  const restoreOnScroll = () => {
+    if (!cancelled) restore()
+  }
+
+  window.addEventListener("scroll", restoreOnScroll, {
+    capture: true,
+    passive: true,
+  })
+  window.addEventListener("wheel", cleanup, {
+    capture: true,
+    passive: true,
+    once: true,
+  })
+  window.addEventListener("pointerdown", cleanup, { capture: true, once: true })
+  window.addEventListener("keydown", cleanup, { capture: true, once: true })
+  intervalId = window.setInterval(restore, 8)
+  rafId = window.requestAnimationFrame(tick)
+}

--- a/front/src/components/editor/mermaidNodeView.tsx
+++ b/front/src/components/editor/mermaidNodeView.tsx
@@ -4,7 +4,14 @@ import { type NodeViewProps, NodeViewWrapper, ReactNodeViewRenderer } from "@tip
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import useMermaidEffect from "src/libs/markdown/hooks/useMermaidEffect"
 import { extractNormalizedMermaidSource } from "src/libs/markdown/mermaid"
-import { MERMAID_TEMPLATE, MERMAID_VIEW_MODE_OPTIONS, type MermaidEditorViewMode, renderMermaidHighlightedSource, useAutosizeTextarea, useDebouncedAttributeCommit } from "./mermaidNodeViewModel"
+import {
+  MERMAID_TEMPLATE,
+  MERMAID_VIEW_MODE_OPTIONS,
+  type MermaidEditorViewMode,
+  renderMermaidHighlightedSource,
+  useAutosizeTextarea,
+  useDebouncedAttributeCommit,
+} from "./mermaidNodeViewModel"
 
 export const MermaidBlockView = ({ node, updateAttributes, selected }: NodeViewProps) => {
   const [draftSource, setDraftSource] = useState(String(node.attrs?.source || MERMAID_TEMPLATE))
@@ -126,7 +133,7 @@ export const MermaidBlockView = ({ node, updateAttributes, selected }: NodeViewP
         {showCodePane ? (
           <MermaidCodePane>
             <MermaidPaneLabel>Mermaid 코드</MermaidPaneLabel>
-            <MermaidCodeEditorShell>
+            <MermaidCodeEditorShell data-view-mode={viewMode}>
               <MermaidCodeHighlight
                 className="aq-mermaid-code-highlight"
                 ref={codeHighlightRef}
@@ -168,7 +175,7 @@ export const MermaidBlockView = ({ node, updateAttributes, selected }: NodeViewP
         {showPreviewPane ? (
           <MermaidPreviewPane ref={previewRootRef}>
             <MermaidPaneLabel>Mermaid 결과</MermaidPaneLabel>
-            <MermaidPreviewCard>
+            <MermaidPreviewCard data-view-mode={viewMode}>
               {normalizedSource ? (
                 <pre
                   className="aq-mermaid"
@@ -235,15 +242,23 @@ const MermaidBlockTextarea = styled.textarea<{ rows?: number }>`
 `
 
 const MermaidPreviewCard = styled.div`
+  height: clamp(14rem, 38vh, 22rem);
   min-height: 12rem;
   border: 1px solid ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray6 : "rgba(255, 255, 255, 0.06)")};
   border-radius: 0.95rem;
   background: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray1 : "rgba(10, 12, 16, 0.98)")};
+  overflow: auto;
+  overscroll-behavior: contain;
   padding: 0.95rem 1rem;
+  scrollbar-width: thin;
+
+  &[data-view-mode="preview"] {
+    height: clamp(20rem, 62vh, 36rem);
+  }
 
   .aq-mermaid {
     margin: 0;
-    min-height: 8rem;
+    min-height: 100%;
   }
 
   .aq-mermaid-stage > svg foreignObject,
@@ -419,11 +434,17 @@ const MermaidCodePane = styled.div`
 
 const MermaidCodeEditorShell = styled.div`
   position: relative;
+  height: 13rem;
   min-height: 13rem;
   border-radius: 0.95rem;
   border: 1px solid ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray6 : "rgba(255, 255, 255, 0.06)")};
   background: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray1 : "rgba(10, 12, 16, 0.98)")};
   overflow: hidden;
+
+  &[data-view-mode="code"] {
+    height: 22rem;
+    min-height: 22rem;
+  }
 `
 
 const MermaidCodeHighlight = styled.pre`
@@ -467,6 +488,7 @@ const MermaidCodeHighlight = styled.pre`
 const MermaidCodeTextarea = styled(MermaidBlockTextarea)`
   position: relative;
   z-index: 1;
+  height: 100% !important;
   min-height: 13rem;
   overflow: auto;
   border: 0;
@@ -486,6 +508,7 @@ const MermaidCodeTextarea = styled(MermaidBlockTextarea)`
   -webkit-text-fill-color: transparent !important;
 
   &[data-view-mode="code"] {
+    height: 22rem !important;
     min-height: 22rem;
   }
 

--- a/front/src/components/editor/tableRenderedDomModel.ts
+++ b/front/src/components/editor/tableRenderedDomModel.ts
@@ -4,7 +4,51 @@ import type { TableAffordanceGeometry } from "./tableAffordanceModel"
 export const RENDERED_TABLE_SELECTOR =
   ".aq-block-editor__content .tableWrapper table, .aq-block-editor__content table"
 const FIRST_ROW_CELL_SELECTOR =
-  "thead tr:first-of-type > th, thead tr:first-of-type > td, tbody tr:first-of-type > th, tbody tr:first-of-type > td, tr:first-of-type > th, tr:first-of-type > td"
+  [
+    "thead tr:first-of-type > th",
+    "thead tr:first-of-type > td",
+    "tbody tr:first-of-type > th",
+    "tbody tr:first-of-type > td",
+    "tr:first-of-type > th",
+    "tr:first-of-type > td",
+  ].join(", ")
+
+const getRenderedTables = (viewport: HTMLElement | null) =>
+  viewport
+    ? Array.from(
+        viewport.querySelectorAll<HTMLTableElement>(RENDERED_TABLE_SELECTOR)
+      )
+    : []
+
+export const findRenderedTableMatchingGeometry = (
+  viewport: HTMLElement | null,
+  quickRailGeometry: TableAffordanceGeometry | null
+) => {
+  if (!quickRailGeometry) return null
+
+  const renderedTables = getRenderedTables(viewport)
+  if (!renderedTables.length) return null
+
+  const withinHorizontalTolerance = (left: number, right: number) =>
+    Math.abs(left - quickRailGeometry.tableLeft) <= 6 &&
+    Math.abs(right - (quickRailGeometry.tableLeft + quickRailGeometry.width)) <=
+      6
+  const withinFullTolerance = (rect: DOMRect) =>
+    withinHorizontalTolerance(rect.left, rect.right) &&
+    Math.abs(rect.top - quickRailGeometry.tableTop) <= 6
+
+  const fullMatch = renderedTables.find((table) => {
+    const rect = table.getBoundingClientRect()
+    return withinFullTolerance(rect)
+  })
+  if (fullMatch) return fullMatch
+
+  const horizontalMatches = renderedTables.filter((table) => {
+    const rect = table.getBoundingClientRect()
+    return withinHorizontalTolerance(rect.left, rect.right)
+  })
+  return horizontalMatches.length === 1 ? horizontalMatches[0] ?? null : null
+}
 
 export const findActiveRenderedTable = (
   viewport: HTMLElement | null,
@@ -13,27 +57,20 @@ export const findActiveRenderedTable = (
 ) => {
   if (!viewport) return null
 
-  const renderedTables = Array.from(viewport.querySelectorAll<HTMLTableElement>(RENDERED_TABLE_SELECTOR))
+  const renderedTables = getRenderedTables(viewport)
   if (!renderedTables.length) return null
   const connectedPreferredTable =
-    preferredTable?.isConnected && viewport.contains(preferredTable) ? preferredTable : null
-  if (!quickRailGeometry) return connectedPreferredTable ?? renderedTables[0] ?? null
-
-  const withinHorizontalTolerance = (left: number, right: number) =>
-    Math.abs(left - quickRailGeometry.tableLeft) <= 6 &&
-    Math.abs(right - (quickRailGeometry.tableLeft + quickRailGeometry.width)) <= 6
-  const withinFullTolerance = (rect: DOMRect) =>
-    withinHorizontalTolerance(rect.left, rect.right) && Math.abs(rect.top - quickRailGeometry.tableTop) <= 6
+    preferredTable?.isConnected && viewport.contains(preferredTable)
+      ? preferredTable
+      : null
+  if (!quickRailGeometry)
+    return connectedPreferredTable ?? renderedTables[0] ?? null
 
   return (
-    renderedTables.find((table) => {
-      const rect = table.getBoundingClientRect()
-      return withinFullTolerance(rect)
-    }) ??
-    renderedTables.find((table) => {
-      const rect = table.getBoundingClientRect()
-      return withinHorizontalTolerance(rect.left, rect.right)
-    }) ?? connectedPreferredTable ?? renderedTables[0] ?? null
+    findRenderedTableMatchingGeometry(viewport, quickRailGeometry) ??
+    connectedPreferredTable ??
+    renderedTables[0] ??
+    null
   )
 }
 
@@ -51,7 +88,12 @@ export const resolveActiveRenderedTableForFloatingUi = (
 export const readRenderedColumnWidths = (tableElement: HTMLElement | null) => {
   if (!tableElement) return []
 
-  return Array.from(tableElement.querySelectorAll<HTMLElement>(FIRST_ROW_CELL_SELECTOR)).map((cell) =>
-    Math.max(TABLE_MIN_COLUMN_WIDTH_PX, Math.round(cell.getBoundingClientRect().width))
+  return Array.from(
+    tableElement.querySelectorAll<HTMLElement>(FIRST_ROW_CELL_SELECTOR)
+  ).map((cell) =>
+    Math.max(
+      TABLE_MIN_COLUMN_WIDTH_PX,
+      Math.round(cell.getBoundingClientRect().width)
+    )
   )
 }

--- a/front/src/components/editor/tableTextSelectionModel.ts
+++ b/front/src/components/editor/tableTextSelectionModel.ts
@@ -1591,7 +1591,7 @@ export const clearTableTextSelectionForStructuralSelection = (
   hasRecentTableTextSelectionContext = false
   cancelActiveTableCellTextSelectionPreserves()
   suppressSingleCellNativeTextSelectionPreserve(1_200)
-  cancelActiveWindowScrollPreserve()
+  cancelAllWindowScrollPreserves()
   cancelTablePointerScrollPreserves()
   shouldClearActiveTableTextSelectionOnBlur = false
   lastTableSelectionExitTarget = null

--- a/front/src/components/editor/useBlockEditorEngineQaActions.ts
+++ b/front/src/components/editor/useBlockEditorEngineQaActions.ts
@@ -1,6 +1,7 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
 import { tableEditingKey } from "@tiptap/pm/tables"
-import { useEffect } from "react"
+import { TextSelection } from "@tiptap/pm/state"
+import { useEffect, useRef } from "react"
 import type { RefObject } from "react"
 import type { BlockEditorQaActions } from "./blockEditorContract"
 import type { BlockEditorDoc } from "./serialization"
@@ -45,6 +46,11 @@ export const useBlockEditorEngineQaActions = ({
   updateActiveTableCellAttrs,
   withTrailingParagraph,
 }: UseBlockEditorEngineQaActionsArgs) => {
+  const lastQaTableAxisTargetRef = useRef<{
+    axis: "row" | "column"
+    index: number | null
+  } | null>(null)
+
   useEffect(() => {
     if (!onQaActionsReady) return
     const runTableStructureAction = (
@@ -63,6 +69,37 @@ export const useBlockEditorEngineQaActions = ({
         if (!retryEditor) return
         if (!selectCurrentTableAxis(axis)) return
         command(retryEditor)
+      })
+    }
+    const runTableCellAttrsAction = (attrs: Record<string, unknown>) => {
+      const applyAttrs = () => {
+        const currentEditor = editorRef.current ?? editor
+        if (!currentEditor) return false
+        const previousDoc = currentEditor.state.doc
+        updateActiveTableCellAttrs(attrs)
+        return currentEditor.state.doc !== previousDoc
+      }
+      const restoreLastQaTableAxisSelection = () => {
+        const lastTarget = lastQaTableAxisTargetRef.current
+        if (!lastTarget) return false
+        if (
+          lastTarget.axis === "column" &&
+          typeof lastTarget.index === "number"
+        ) {
+          return Boolean(selectTableColumnByIndex(lastTarget.index))
+        }
+        return selectCurrentTableAxis(lastTarget.axis)
+      }
+
+      if (applyAttrs()) return
+      if (restoreLastQaTableAxisSelection() && applyAttrs()) return
+      updateActiveTableCellAttrs(attrs)
+      if (typeof window === "undefined") return
+      window.requestAnimationFrame(() => {
+        if (applyAttrs()) return
+        if (restoreLastQaTableAxisSelection()) {
+          applyAttrs()
+        }
       })
     }
 
@@ -90,19 +127,33 @@ export const useBlockEditorEngineQaActions = ({
         selectTopLevelBlockNode(currentEditor, blockIndex)
       },
       selectTableAxis: (axis) => {
-        selectCurrentTableAxis(axis)
+        if (selectCurrentTableAxis(axis)) {
+          lastQaTableAxisTargetRef.current = {
+            axis,
+            index: null,
+          }
+        }
       },
       selectTableColumnViaDomFallback: (columnIndex) => {
         const currentEditor = editorRef.current ?? editor
         if (!currentEditor) return
-        currentEditor.chain().focus("end").run()
-        selectTableColumnByIndex(columnIndex)
+        currentEditor.view.dispatch(
+          currentEditor.state.tr
+            .setSelection(TextSelection.atEnd(currentEditor.state.doc))
+            .setMeta("addToHistory", false)
+        )
+        if (selectTableColumnByIndex(columnIndex)) {
+          lastQaTableAxisTargetRef.current = {
+            axis: "column",
+            index: columnIndex,
+          }
+        }
       },
       setActiveTableCellAlign: (align) => {
-        updateActiveTableCellAttrs({ textAlign: align })
+        runTableCellAttrsAction({ textAlign: align })
       },
       setActiveTableCellBackground: (color) => {
-        updateActiveTableCellAttrs({ backgroundColor: color })
+        runTableCellAttrsAction({ backgroundColor: color })
       },
       addTableRowAfter: () => {
         runTableStructureAction("row", (activeEditor) =>

--- a/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
+++ b/front/src/components/editor/useBlockEditorEngineSelectionBubbleEffects.ts
@@ -60,6 +60,7 @@ import {
   resolveOcclusionAwareTextBubbleState,
   type FloatingBubbleState,
 } from "./useFloatingBubbleState"
+import { markRecentCodePointerFollowUp, promoteRecentCodePointerFollowUp } from "./codePointerFollowUpModel"
 const CODE_BLOCK_EDITOR_CONTENT_SELECTOR = ".aq-code-editor-content"
 const CODE_BLOCK_TEXT_SURFACE_SELECTOR = [
   CODE_BLOCK_EDITOR_CONTENT_SELECTOR,
@@ -180,6 +181,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       x: number
       y: number
     } | null>(null),
+    recentCodePointerUntilRef = useRef(0),
     nonTableTextDragStartRef = useRef<{ x: number; y: number } | null>(null)
   useEffect(() => {
     const currentEditor = editorRef.current ?? editor
@@ -1376,6 +1378,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       }
       if (insideEditorDom && !codeShellTarget && !tableTextDragStart) {
         markCodeSelectionFollowUpIfActive()
+        promoteRecentCodePointerFollowUp(recentCodePointerUntilRef)
         nonTableTextDragStartRef.current = {
           x: event.clientX,
           y: event.clientY,
@@ -1389,8 +1392,10 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         nonTableTextDragStartRef.current = null
         preserveActiveTableTextDragScroll()
       }
-      if (codeShellTarget) preserveWindowScrollForCodePointerFocus(true)
-      else if (insideEditorDom && !tableTextDragStart) {
+      if (codeShellTarget) {
+        markRecentCodePointerFollowUp(recentCodePointerUntilRef)
+        preserveWindowScrollForCodePointerFocus(true)
+      } else if (insideEditorDom && !tableTextDragStart) {
         const blockSelectionActive = Boolean(
           document.querySelector(
             "[data-testid='keyboard-block-selection-overlay']"
@@ -1588,6 +1593,20 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
         return
       }
       if (insideEditorDom && !codeShellTarget && !tableTextDragStart) {
+        markCodeSelectionFollowUpIfActive()
+        promoteRecentCodePointerFollowUp(recentCodePointerUntilRef)
+        const blockSelectionActive = Boolean(
+          document.querySelector(
+            "[data-testid='keyboard-block-selection-overlay']"
+          )
+        )
+        preserveWindowScrollForEditorPointerFocus(
+          event.target,
+          isTableSelectionActive(activeEditor),
+          blockSelectionActive,
+          true,
+          true
+        )
         nonTableTextDragStartRef.current = nonTableTextDragStartRef.current ?? {
           x: event.clientX,
           y: event.clientY,
@@ -1604,6 +1623,7 @@ export const useBlockEditorEngineSelectionBubbleEffects = ({
       if (codeTextDragStartRef.current && !codeShellTarget)
         codeTextDragStartRef.current = null
       if (codeShellTarget) {
+        markRecentCodePointerFollowUp(recentCodePointerUntilRef)
         cancelTableTextDragPreserves()
         const codeTextSurfaceTarget = findCodeTextSurfaceTarget(
           targetElement,

--- a/front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts
@@ -33,6 +33,7 @@ import {
 import type { TableMenuState } from "./tableFloatingUiModel"
 import {
   findActiveRenderedTable,
+  findRenderedTableMatchingGeometry,
   RENDERED_TABLE_SELECTOR,
 } from "./tableRenderedDomModel"
 import { dispatchEditorSelectionSafely } from "./tableSelectionDispatchModel"
@@ -66,6 +67,10 @@ const TABLE_AXIS_FOCUS_SCROLL_TOLERANCE_PX = 4
 
 type SelectTableAxisOptions = { clearNativeText?: boolean }
 type ClearNativeTableTextSelectionOptions = { restoreCellSelection?: boolean }
+type RenderedTableSelectionTarget = {
+  renderedTable: HTMLTableElement
+  selectionRect: TableOverlaySelectionRect
+}
 
 const resolveTableAxisSelectionSink = () => {
   let selectionSink = document.getElementById(TABLE_AXIS_SELECTION_SINK_ID)
@@ -266,49 +271,66 @@ export const useBlockEditorTableOverlayAxisDrag = ({
     },
     []
   )
-  const resolveAxisPointerTableRect = useCallback(
+  const resolveRenderedTableSelectionTarget = useCallback(
+    (
+      activeEditor: TiptapEditor,
+      tableElement: HTMLTableElement | null
+    ): RenderedTableSelectionTarget | null => {
+      if (!tableElement) return null
+      const selectionRect = resolveRenderedTableSelectionRect(
+        activeEditor,
+        tableElement
+      )
+      return selectionRect
+        ? { renderedTable: tableElement, selectionRect }
+        : null
+    },
+    [resolveRenderedTableSelectionRect]
+  )
+  const resolveAxisPointerTableTarget = useCallback(
     (
       activeEditor: TiptapEditor,
       axis: TableAxis,
       clientX: number,
       clientY: number
-    ) => {
+    ): RenderedTableSelectionTarget | null => {
       const viewport = viewportRef.current
       if (!viewport) return null
 
       const renderedTables = Array.from(
         viewport.querySelectorAll<HTMLTableElement>(RENDERED_TABLE_SELECTOR)
       )
-      const pointerTable =
-        renderedTables.find((table) => {
-          const rect = table.getBoundingClientRect()
-          if (rect.width <= 0 || rect.height <= 0) return false
+      const pointerTable = renderedTables.find((table) => {
+        const rect = table.getBoundingClientRect()
+        if (rect.width <= 0 || rect.height <= 0) return false
 
-          if (axis === "row") {
-            return (
-              clientY >= rect.top - TABLE_AXIS_POINTER_TABLE_EDGE_TOLERANCE_PX &&
-              clientY <= rect.bottom + TABLE_AXIS_POINTER_TABLE_EDGE_TOLERANCE_PX &&
-              clientX >= rect.left - TABLE_AXIS_POINTER_TABLE_MATCH_MARGIN_PX &&
-              clientX <= rect.left + TABLE_AXIS_POINTER_TABLE_MATCH_MARGIN_PX
-            )
-          }
-
+        if (axis === "row") {
           return (
-            clientX >= rect.left - TABLE_AXIS_POINTER_TABLE_EDGE_TOLERANCE_PX &&
-            clientX <= rect.right + TABLE_AXIS_POINTER_TABLE_EDGE_TOLERANCE_PX &&
-            clientY >= rect.top - TABLE_AXIS_POINTER_TABLE_MATCH_MARGIN_PX &&
-            clientY <= rect.top + TABLE_AXIS_POINTER_TABLE_MATCH_MARGIN_PX
+            clientY >= rect.top - TABLE_AXIS_POINTER_TABLE_EDGE_TOLERANCE_PX &&
+            clientY <= rect.bottom + TABLE_AXIS_POINTER_TABLE_EDGE_TOLERANCE_PX &&
+            clientX >= rect.left - TABLE_AXIS_POINTER_TABLE_MATCH_MARGIN_PX &&
+            clientX <= rect.left + TABLE_AXIS_POINTER_TABLE_MATCH_MARGIN_PX
           )
-        }) ??
-        findActiveRenderedTable(
-          viewport,
-          tableAffordanceGeometryRef.current
-        )
+        }
 
-      return resolveRenderedTableSelectionRect(activeEditor, pointerTable)
+        return (
+          clientX >= rect.left - TABLE_AXIS_POINTER_TABLE_EDGE_TOLERANCE_PX &&
+          clientX <= rect.right + TABLE_AXIS_POINTER_TABLE_EDGE_TOLERANCE_PX &&
+          clientY >= rect.top - TABLE_AXIS_POINTER_TABLE_MATCH_MARGIN_PX &&
+          clientY <= rect.top + TABLE_AXIS_POINTER_TABLE_MATCH_MARGIN_PX
+        )
+      })
+      const activeGeometryTable = findRenderedTableMatchingGeometry(
+        viewport,
+        tableAffordanceGeometryRef.current
+      )
+      return resolveRenderedTableSelectionTarget(
+        activeEditor,
+        pointerTable ?? activeGeometryTable
+      )
     },
     [
-      resolveRenderedTableSelectionRect,
+      resolveRenderedTableSelectionTarget,
       tableAffordanceGeometryRef,
       viewportRef,
     ]
@@ -318,7 +340,7 @@ export const useBlockEditorTableOverlayAxisDrag = ({
       const viewport = viewportRef.current
       if (!viewport) return null
 
-      const activeRenderedTable = findActiveRenderedTable(
+      const activeRenderedTable = findRenderedTableMatchingGeometry(
         viewport,
         tableAffordanceGeometryRef.current
       )
@@ -828,18 +850,20 @@ export const useBlockEditorTableOverlayAxisDrag = ({
       const currentEditor = editorRef.current
       if (!currentEditor) return
 
+      const pointerTarget = resolveAxisPointerTableTarget(
+        currentEditor,
+        axis,
+        clientX,
+        clientY
+      )
       const tableRect =
-        resolveAxisPointerTableRect(currentEditor, axis, clientX, clientY) ??
+        pointerTarget?.selectionRect ??
         getCurrentSelectedTableRect(currentEditor)
       const tablePos = tableRect ? Math.max(0, tableRect.tableStart - 1) : null
       if (!tableRect || tablePos === null) return
-      const renderedTable = findActiveRenderedTable(
-        viewportRef.current,
-        tableAffordanceGeometryRef.current
-      )
       const resolvedSourceIndex =
         resolveTableAxisIndexFromPointer(
-          renderedTable,
+          pointerTarget?.renderedTable ?? null,
           axis,
           clientX,
           clientY
@@ -853,6 +877,19 @@ export const useBlockEditorTableOverlayAxisDrag = ({
             resolvedSourceIndex < tableRect.map.width
       if (!withinBounds) return
 
+      const sourceGeometry = pointerTarget?.renderedTable
+        ? resolveSyncedTableAxisGeometryFromDom(
+            tableAffordanceGeometryRef.current,
+            pointerTarget.renderedTable,
+            { axis, index: resolvedSourceIndex }
+          ) ?? tableAffordanceGeometryRef.current
+        : tableAffordanceGeometryRef.current
+
+      if (sourceGeometry !== tableAffordanceGeometryRef.current) {
+        tableAffordanceGeometryRef.current = sourceGeometry
+        setTableAffordanceGeometry(sourceGeometry)
+      }
+
       clearStructuralSelectionNativeText()
       markTableStructuralSelectionOwner(1_200)
       clearPendingTableAxisDrag()
@@ -865,7 +902,7 @@ export const useBlockEditorTableOverlayAxisDrag = ({
         tablePos,
         clientX,
         clientY,
-        tableAffordanceGeometryRef.current
+        sourceGeometry
       )
       tableAxisMenuStabilizationTokenRef.current += 1
       tableAxisMenuSuppressUntilRef.current = 0
@@ -1029,8 +1066,9 @@ export const useBlockEditorTableOverlayAxisDrag = ({
       editorRef,
       getCurrentSelectedTableRect,
       reorderTableAxisAtPosition,
-      resolveAxisPointerTableRect,
+      resolveAxisPointerTableTarget,
       selectTableAxisAtIndex,
+      setTableAffordanceGeometry,
       setSelectionTick,
       setTableMenuState,
       tableAffordanceGeometryRef,

--- a/front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts
@@ -31,7 +31,10 @@ import {
   resolveTableAxisReorderIndicator,
 } from "./tableAxisDragModel"
 import type { TableMenuState } from "./tableFloatingUiModel"
-import { findActiveRenderedTable } from "./tableRenderedDomModel"
+import {
+  findActiveRenderedTable,
+  RENDERED_TABLE_SELECTOR,
+} from "./tableRenderedDomModel"
 import { dispatchEditorSelectionSafely } from "./tableSelectionDispatchModel"
 import {
   buildReorderedSimpleTableNode,
@@ -55,7 +58,95 @@ import {
 const getTableAxisMenuNow = () =>
   typeof performance !== "undefined" ? performance.now() : Date.now()
 
+const TABLE_AXIS_POINTER_TABLE_MATCH_MARGIN_PX = 96
+const TABLE_AXIS_POINTER_TABLE_EDGE_TOLERANCE_PX = 12
+const TABLE_AXIS_SELECTION_SINK_ID = "aq-table-axis-selection-sink"
+const TABLE_AXIS_FOCUS_SCROLL_PRESERVE_MS = 240
+const TABLE_AXIS_FOCUS_SCROLL_TOLERANCE_PX = 4
+
 type SelectTableAxisOptions = { clearNativeText?: boolean }
+type ClearNativeTableTextSelectionOptions = { restoreCellSelection?: boolean }
+
+const resolveTableAxisSelectionSink = () => {
+  let selectionSink = document.getElementById(TABLE_AXIS_SELECTION_SINK_ID)
+  if (selectionSink) return selectionSink
+
+  selectionSink = document.createElement("span")
+  selectionSink.id = TABLE_AXIS_SELECTION_SINK_ID
+  selectionSink.setAttribute("aria-hidden", "true")
+  selectionSink.style.cssText = [
+    "position:fixed",
+    "width:0",
+    "height:0",
+    "overflow:hidden",
+    "left:0",
+    "top:0",
+  ].join(";")
+  document.body.append(selectionSink)
+  return selectionSink
+}
+
+const preserveTableAxisFocusScrollBriefly = () => {
+  if (typeof window === "undefined") return
+  const scrollingElement = document.scrollingElement
+  const startX = window.scrollX
+  const startY = Math.round(scrollingElement?.scrollTop ?? window.scrollY)
+  const startedAt = getTableAxisMenuNow()
+  let cancelled = false
+  let intervalId: number | null = null
+  let rafId: number | null = null
+
+  const restoreScrollPosition = () => {
+    const currentY = Math.round(scrollingElement?.scrollTop ?? window.scrollY)
+    if (Math.abs(currentY - startY) <= TABLE_AXIS_FOCUS_SCROLL_TOLERANCE_PX)
+      return
+    if (scrollingElement) {
+      scrollingElement.scrollTop = startY
+    } else {
+      document.documentElement.scrollTop = startY
+      document.body.scrollTop = startY
+    }
+    if (Math.abs(window.scrollX - startX) > TABLE_AXIS_FOCUS_SCROLL_TOLERANCE_PX) {
+      document.documentElement.scrollLeft = startX
+      document.body.scrollLeft = startX
+    }
+  }
+  const cleanup = () => {
+    cancelled = true
+    window.removeEventListener("scroll", restoreOnScroll, true)
+    window.removeEventListener("wheel", cleanup, true)
+    window.removeEventListener("pointerdown", cleanup, true)
+    window.removeEventListener("keydown", cleanup, true)
+    if (intervalId !== null) window.clearInterval(intervalId)
+    if (rafId !== null) window.cancelAnimationFrame(rafId)
+  }
+  const tick = () => {
+    if (cancelled) return
+    if (getTableAxisMenuNow() - startedAt > TABLE_AXIS_FOCUS_SCROLL_PRESERVE_MS) {
+      cleanup()
+      return
+    }
+    restoreScrollPosition()
+    rafId = window.requestAnimationFrame(tick)
+  }
+  const restoreOnScroll = () => {
+    if (!cancelled) restoreScrollPosition()
+  }
+
+  window.addEventListener("scroll", restoreOnScroll, {
+    capture: true,
+    passive: true,
+  })
+  window.addEventListener("wheel", cleanup, {
+    capture: true,
+    passive: true,
+    once: true,
+  })
+  window.addEventListener("pointerdown", cleanup, { capture: true, once: true })
+  window.addEventListener("keydown", cleanup, { capture: true, once: true })
+  intervalId = window.setInterval(restoreScrollPosition, 8)
+  rafId = window.requestAnimationFrame(tick)
+}
 
 type UseBlockEditorTableOverlayAxisDragArgs = {
   cancelTableQuickRailHide: () => void
@@ -136,8 +227,132 @@ export const useBlockEditorTableOverlayAxisDrag = ({
     },
     []
   )
+  const resolveRenderedTableSelectionRect = useCallback(
+    (activeEditor: TiptapEditor, tableElement: HTMLTableElement | null) => {
+      const firstCellSelector = [
+        "thead tr:first-of-type > th",
+        "thead tr:first-of-type > td",
+        "tbody tr:first-of-type > th",
+        "tbody tr:first-of-type > td",
+        "tr:first-of-type > th",
+        "tr:first-of-type > td",
+        "th",
+        "td",
+      ].join(", ")
+      const firstCell = tableElement?.querySelector<HTMLElement>(firstCellSelector)
+      if (!firstCell) return null
+
+      let domPosition = 0
+      try {
+        domPosition = activeEditor.view.posAtDOM(firstCell, 0)
+      } catch {
+        return null
+      }
+
+      const resolvedPosition = resolveDocPosSafe(activeEditor, domPosition)
+      if (!resolvedPosition) return null
+
+      for (let depth = resolvedPosition.depth; depth > 0; depth -= 1) {
+        const tableNode = resolvedPosition.node(depth)
+        if (tableNode.type.name !== "table") continue
+        return {
+          map: TableMap.get(tableNode),
+          table: tableNode,
+          tableStart: resolvedPosition.start(depth),
+        }
+      }
+
+      return null
+    },
+    []
+  )
+  const resolveAxisPointerTableRect = useCallback(
+    (
+      activeEditor: TiptapEditor,
+      axis: TableAxis,
+      clientX: number,
+      clientY: number
+    ) => {
+      const viewport = viewportRef.current
+      if (!viewport) return null
+
+      const renderedTables = Array.from(
+        viewport.querySelectorAll<HTMLTableElement>(RENDERED_TABLE_SELECTOR)
+      )
+      const pointerTable =
+        renderedTables.find((table) => {
+          const rect = table.getBoundingClientRect()
+          if (rect.width <= 0 || rect.height <= 0) return false
+
+          if (axis === "row") {
+            return (
+              clientY >= rect.top - TABLE_AXIS_POINTER_TABLE_EDGE_TOLERANCE_PX &&
+              clientY <= rect.bottom + TABLE_AXIS_POINTER_TABLE_EDGE_TOLERANCE_PX &&
+              clientX >= rect.left - TABLE_AXIS_POINTER_TABLE_MATCH_MARGIN_PX &&
+              clientX <= rect.left + TABLE_AXIS_POINTER_TABLE_MATCH_MARGIN_PX
+            )
+          }
+
+          return (
+            clientX >= rect.left - TABLE_AXIS_POINTER_TABLE_EDGE_TOLERANCE_PX &&
+            clientX <= rect.right + TABLE_AXIS_POINTER_TABLE_EDGE_TOLERANCE_PX &&
+            clientY >= rect.top - TABLE_AXIS_POINTER_TABLE_MATCH_MARGIN_PX &&
+            clientY <= rect.top + TABLE_AXIS_POINTER_TABLE_MATCH_MARGIN_PX
+          )
+        }) ??
+        findActiveRenderedTable(
+          viewport,
+          tableAffordanceGeometryRef.current
+        )
+
+      return resolveRenderedTableSelectionRect(activeEditor, pointerTable)
+    },
+    [
+      resolveRenderedTableSelectionRect,
+      tableAffordanceGeometryRef,
+      viewportRef,
+    ]
+  )
+  const resolveVisibleRenderedTableSelectionRect = useCallback(
+    (activeEditor: TiptapEditor) => {
+      const viewport = viewportRef.current
+      if (!viewport) return null
+
+      const activeRenderedTable = findActiveRenderedTable(
+        viewport,
+        tableAffordanceGeometryRef.current
+      )
+      if (activeRenderedTable) {
+        return resolveRenderedTableSelectionRect(
+          activeEditor,
+          activeRenderedTable
+        )
+      }
+
+      const visibleRenderedTables = Array.from(
+        viewport.querySelectorAll<HTMLTableElement>(RENDERED_TABLE_SELECTOR)
+      ).filter((table) => {
+        const rect = table.getBoundingClientRect()
+        return rect.width > 0 && rect.height > 0
+      })
+
+      if (visibleRenderedTables.length !== 1) return null
+      return resolveRenderedTableSelectionRect(
+        activeEditor,
+        visibleRenderedTables[0] ?? null
+      )
+    },
+    [
+      resolveRenderedTableSelectionRect,
+      tableAffordanceGeometryRef,
+      viewportRef,
+    ]
+  )
   const clearNativeTableTextSelectionOnly = useCallback(
-    (activeEditor?: TiptapEditor | null) => {
+    (
+      activeEditor?: TiptapEditor | null,
+      options: ClearNativeTableTextSelectionOptions = {}
+    ) => {
       const preservedCellSelection =
         activeEditor?.state.selection instanceof CellSelection
           ? activeEditor.state.selection
@@ -155,17 +370,7 @@ export const useBlockEditorTableOverlayAxisDrag = ({
         | undefined
       const domObserver = viewWithDomObserver?.domObserver
       const clearDomSelection = () => {
-        let selectionSink = document.getElementById(
-          "aq-table-axis-selection-sink"
-        )
-        if (!selectionSink) {
-          selectionSink = document.createElement("span")
-          selectionSink.id = "aq-table-axis-selection-sink"
-          selectionSink.setAttribute("aria-hidden", "true")
-          selectionSink.style.cssText =
-            "position:fixed;width:0;height:0;overflow:hidden;left:0;top:0;"
-          document.body.append(selectionSink)
-        }
+        const selectionSink = resolveTableAxisSelectionSink()
         domObserver?.stop?.()
         try {
           const selection = window.getSelection()
@@ -186,12 +391,26 @@ export const useBlockEditorTableOverlayAxisDrag = ({
         document.documentElement.removeAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR)
       }
       clearDomSelection()
-      if (
-        !activeEditor ||
-        !preservedCellSelection ||
-        typeof window === "undefined"
-      )
+      if (!activeEditor || typeof window === "undefined")
         return
+      const clearStartedAt = getTableAxisMenuNow()
+      const keepDomSelectionCleared = () => {
+        if (
+          !activeEditor.view.dom.isConnected ||
+          !isActiveTableAxisSelection(activeEditor) ||
+          getTableAxisMenuNow() - clearStartedAt > 1_200
+        )
+          return
+        clearDomSelection()
+        window.requestAnimationFrame(keepDomSelectionCleared)
+      }
+      if (
+        !preservedCellSelection ||
+        options.restoreCellSelection === false
+      ) {
+        window.requestAnimationFrame(keepDomSelectionCleared)
+        return
+      }
       const restoreCellSelection = () => {
         if (!activeEditor.view.dom.isConnected) return
         if (tableAxisMenuStabilizationTokenRef.current !== restoreToken) return
@@ -208,17 +427,6 @@ export const useBlockEditorTableOverlayAxisDrag = ({
         clearDomSelection()
         setSelectionTick((prev) => prev + 1)
       }
-      const clearStartedAt = getTableAxisMenuNow(),
-        keepDomSelectionCleared = () => {
-          if (
-            !activeEditor.view.dom.isConnected ||
-            !isActiveTableAxisSelection(activeEditor) ||
-            getTableAxisMenuNow() - clearStartedAt > 1_200
-          )
-            return
-          clearDomSelection()
-          window.requestAnimationFrame(keepDomSelectionCleared)
-        }
       window.requestAnimationFrame(restoreCellSelection)
       window.setTimeout(restoreCellSelection, 0)
       window.setTimeout(restoreCellSelection, 40)
@@ -354,12 +562,12 @@ export const useBlockEditorTableOverlayAxisDrag = ({
       const anchorResolved = resolveDocPosSafe(activeEditor, anchorCellPos)
       const headResolved = resolveDocPosSafe(activeEditor, headCellPos)
       if (!anchorResolved || !headResolved) return false
-
       clearStickyTopLevelBlockSelection()
       clearTableTextSelectionForStructuralSelection()
       focusElementWithoutScroll(activeEditor.view.dom)
       clearEditorMouseDownSelectionSyncDeferral(activeEditor)
       tableAxisMenuStabilizationTokenRef.current += 1
+      preserveTableAxisFocusScrollBriefly()
       activeEditor.view.dispatch(
         activeEditor.state.tr
           .setSelection(
@@ -369,6 +577,7 @@ export const useBlockEditorTableOverlayAxisDrag = ({
           )
           .setMeta(tableEditingKey, anchorResolved.pos)
       )
+      activeEditor.view.dom.blur()
       setTableAffordanceGeometry((prev) =>
         isColumn
           ? { ...prev, columnIndex: axisIndex }
@@ -376,12 +585,14 @@ export const useBlockEditorTableOverlayAxisDrag = ({
       )
       setSelectionTick((prev) => prev + 1)
       if (options.clearNativeText !== false)
-        clearStructuralSelectionNativeText()
+        clearNativeTableTextSelectionOnly(activeEditor, {
+          restoreCellSelection: false,
+        })
       return true
     },
     [
+      clearNativeTableTextSelectionOnly,
       clearStickyTopLevelBlockSelection,
-      clearStructuralSelectionNativeText,
       setSelectionTick,
       setTableAffordanceGeometry,
     ]
@@ -445,7 +656,9 @@ export const useBlockEditorTableOverlayAxisDrag = ({
     (columnIndex: number, options: SelectTableAxisOptions = {}) => {
       const currentEditor = editorRef.current
       if (!currentEditor) return false
-      const rect = getCurrentSelectedTableRect(currentEditor)
+      const rect =
+        getCurrentSelectedTableRect(currentEditor) ??
+        resolveVisibleRenderedTableSelectionRect(currentEditor)
       if (!rect || columnIndex < 0 || columnIndex >= rect.map.width)
         return false
 
@@ -460,14 +673,21 @@ export const useBlockEditorTableOverlayAxisDrag = ({
         ? { axis: "column" as const, index: columnIndex, tablePos }
         : false
     },
-    [editorRef, getCurrentSelectedTableRect, selectTableAxisAtIndex]
+    [
+      editorRef,
+      getCurrentSelectedTableRect,
+      resolveVisibleRenderedTableSelectionRect,
+      selectTableAxisAtIndex,
+    ]
   )
 
   const selectTableRowByIndex = useCallback(
     (rowIndex: number, options: SelectTableAxisOptions = {}) => {
       const currentEditor = editorRef.current
       if (!currentEditor) return false
-      const rect = getCurrentSelectedTableRect(currentEditor)
+      const rect =
+        getCurrentSelectedTableRect(currentEditor) ??
+        resolveVisibleRenderedTableSelectionRect(currentEditor)
       if (!rect || rowIndex < 0 || rowIndex >= rect.map.height) return false
 
       const tablePos = rect.tableStart - 1
@@ -481,7 +701,12 @@ export const useBlockEditorTableOverlayAxisDrag = ({
         ? { axis: "row" as const, index: rowIndex, tablePos }
         : false
     },
-    [editorRef, getCurrentSelectedTableRect, selectTableAxisAtIndex]
+    [
+      editorRef,
+      getCurrentSelectedTableRect,
+      resolveVisibleRenderedTableSelectionRect,
+      selectTableAxisAtIndex,
+    ]
   )
 
   const reorderTableAxisAtPosition = useCallback(
@@ -603,7 +828,9 @@ export const useBlockEditorTableOverlayAxisDrag = ({
       const currentEditor = editorRef.current
       if (!currentEditor) return
 
-      const tableRect = getCurrentSelectedTableRect(currentEditor)
+      const tableRect =
+        resolveAxisPointerTableRect(currentEditor, axis, clientX, clientY) ??
+        getCurrentSelectedTableRect(currentEditor)
       const tablePos = tableRect ? Math.max(0, tableRect.tableStart - 1) : null
       if (!tableRect || tablePos === null) return
       const renderedTable = findActiveRenderedTable(
@@ -648,7 +875,6 @@ export const useBlockEditorTableOverlayAxisDrag = ({
         tablePos,
       }
       selectTableAxisAtIndex(currentEditor, tablePos, axis, resolvedSourceIndex)
-      clearNativeTableTextSelectionOnly(currentEditor)
 
       const DRAG_THRESHOLD_PX = 5
       let activeDragState: Exclude<DraggedTableAxisState, null> | null = null
@@ -741,7 +967,6 @@ export const useBlockEditorTableOverlayAxisDrag = ({
         const completedClick = completeClickWithoutDrag?.() ?? false
         if (completedClick) {
           markTableStructuralSelectionOwner(1_200)
-          clearTableTextSelectionForStructuralSelection()
           const stabilizationToken = tableAxisMenuStabilizationTokenRef.current
           const stabilizationGeneration =
             getTableAxisSelectionRestoreGeneration()
@@ -799,12 +1024,12 @@ export const useBlockEditorTableOverlayAxisDrag = ({
     },
     [
       beginTableAxisDragFromPending,
-      clearNativeTableTextSelectionOnly,
       clearPendingTableAxisDrag,
       clearStructuralSelectionNativeText,
       editorRef,
       getCurrentSelectedTableRect,
       reorderTableAxisAtPosition,
+      resolveAxisPointerTableRect,
       selectTableAxisAtIndex,
       setSelectionTick,
       setTableMenuState,

--- a/front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts
@@ -415,8 +415,8 @@ export const useBlockEditorTableOverlayAxisDrag = ({
   )
   const resolveTableAxisSelectionRect = useCallback(
     (activeEditor: TiptapEditor) =>
-      resolveTableSelectionRectFromEditorContext(activeEditor) ??
-      resolveVisibleRenderedTableSelectionRect(activeEditor),
+      resolveVisibleRenderedTableSelectionRect(activeEditor) ??
+      resolveTableSelectionRectFromEditorContext(activeEditor),
     [
       resolveTableSelectionRectFromEditorContext,
       resolveVisibleRenderedTableSelectionRect,

--- a/front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts
@@ -1,4 +1,5 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
+import type { ResolvedPos } from "@tiptap/pm/model"
 import {
   CellSelection,
   selectedRect,
@@ -287,6 +288,48 @@ export const useBlockEditorTableOverlayAxisDrag = ({
     },
     [resolveRenderedTableSelectionRect]
   )
+  const resolveTableSelectionRectFromResolvedPosition = useCallback(
+    (resolvedPosition: ResolvedPos): TableOverlaySelectionRect | null => {
+      for (let depth = resolvedPosition.depth; depth > 0; depth -= 1) {
+        const tableNode = resolvedPosition.node(depth)
+        if (tableNode.type.name !== "table") continue
+        return {
+          map: TableMap.get(tableNode),
+          table: tableNode,
+          tableStart: resolvedPosition.start(depth),
+        }
+      }
+
+      return null
+    },
+    []
+  )
+  const resolveTableSelectionRectFromEditorContext = useCallback(
+    (activeEditor: TiptapEditor): TableOverlaySelectionRect | null => {
+      const { selection } = activeEditor.state
+      if (selection instanceof CellSelection) {
+        try {
+          return selectedRect(activeEditor.state)
+        } catch {
+          return null
+        }
+      }
+
+      if (selection instanceof NodeSelection && selection.node.type.name === "table") {
+        return {
+          map: TableMap.get(selection.node),
+          table: selection.node,
+          tableStart: selection.from + 1,
+        }
+      }
+
+      return (
+        resolveTableSelectionRectFromResolvedPosition(selection.$from) ??
+        resolveTableSelectionRectFromResolvedPosition(selection.$to)
+      )
+    },
+    [resolveTableSelectionRectFromResolvedPosition]
+  )
   const resolveAxisPointerTableTarget = useCallback(
     (
       activeEditor: TiptapEditor,
@@ -368,6 +411,15 @@ export const useBlockEditorTableOverlayAxisDrag = ({
       resolveRenderedTableSelectionRect,
       tableAffordanceGeometryRef,
       viewportRef,
+    ]
+  )
+  const resolveTableAxisSelectionRect = useCallback(
+    (activeEditor: TiptapEditor) =>
+      resolveTableSelectionRectFromEditorContext(activeEditor) ??
+      resolveVisibleRenderedTableSelectionRect(activeEditor),
+    [
+      resolveTableSelectionRectFromEditorContext,
+      resolveVisibleRenderedTableSelectionRect,
     ]
   )
   const clearNativeTableTextSelectionOnly = useCallback(
@@ -678,9 +730,7 @@ export const useBlockEditorTableOverlayAxisDrag = ({
     (columnIndex: number, options: SelectTableAxisOptions = {}) => {
       const currentEditor = editorRef.current
       if (!currentEditor) return false
-      const rect =
-        getCurrentSelectedTableRect(currentEditor) ??
-        resolveVisibleRenderedTableSelectionRect(currentEditor)
+      const rect = resolveTableAxisSelectionRect(currentEditor)
       if (!rect || columnIndex < 0 || columnIndex >= rect.map.width)
         return false
 
@@ -697,8 +747,7 @@ export const useBlockEditorTableOverlayAxisDrag = ({
     },
     [
       editorRef,
-      getCurrentSelectedTableRect,
-      resolveVisibleRenderedTableSelectionRect,
+      resolveTableAxisSelectionRect,
       selectTableAxisAtIndex,
     ]
   )
@@ -707,9 +756,7 @@ export const useBlockEditorTableOverlayAxisDrag = ({
     (rowIndex: number, options: SelectTableAxisOptions = {}) => {
       const currentEditor = editorRef.current
       if (!currentEditor) return false
-      const rect =
-        getCurrentSelectedTableRect(currentEditor) ??
-        resolveVisibleRenderedTableSelectionRect(currentEditor)
+      const rect = resolveTableAxisSelectionRect(currentEditor)
       if (!rect || rowIndex < 0 || rowIndex >= rect.map.height) return false
 
       const tablePos = rect.tableStart - 1
@@ -725,8 +772,7 @@ export const useBlockEditorTableOverlayAxisDrag = ({
     },
     [
       editorRef,
-      getCurrentSelectedTableRect,
-      resolveVisibleRenderedTableSelectionRect,
+      resolveTableAxisSelectionRect,
       selectTableAxisAtIndex,
     ]
   )

--- a/front/src/routes/Admin/QaEditorHarness.tsx
+++ b/front/src/routes/Admin/QaEditorHarness.tsx
@@ -1,5 +1,5 @@
 import dynamic from "next/dynamic"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState, type MouseEvent } from "react"
 import type { BlockEditorQaActions } from "src/components/editor/blockEditorContract"
 
 const LazyBlockEditorShell = dynamic(() => import("src/components/editor/BlockEditorShell"), {
@@ -22,6 +22,12 @@ const LazyBlockEditorShell = dynamic(() => import("src/components/editor/BlockEd
 const QA_IMAGE_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlH0WkAAAAASUVORK5CYII="
 const QA_EXTERNAL_POST_MARKDOWN = "# 선택 글 제목\n\n선택 글 본문\n\n선택 글 둘째 문단"
+
+const preserveEditorSelectionOnButtonMouseDown = (
+  event: MouseEvent<HTMLButtonElement>
+) => {
+  event.preventDefault()
+}
 
 type QaEditorHarnessProps = {
   seedMarkdown: string
@@ -91,34 +97,74 @@ export const QaEditorHarness = ({ seedMarkdown }: QaEditorHarnessProps) => {
           gap: "0.65rem",
         }}
       >
-        <button type="button" onClick={() => qaActionsRef.current?.selectTableAxis("column")}>
+        <button
+          type="button"
+          onMouseDown={preserveEditorSelectionOnButtonMouseDown}
+          onClick={() => qaActionsRef.current?.selectTableAxis("column")}
+        >
           QA 열 선택
         </button>
-        <button type="button" onClick={() => qaActionsRef.current?.selectTableColumnViaDomFallback(0)}>
+        <button
+          type="button"
+          onMouseDown={preserveEditorSelectionOnButtonMouseDown}
+          onClick={() => qaActionsRef.current?.selectTableColumnViaDomFallback(0)}
+        >
           QA fallback 열 선택
         </button>
-        <button type="button" onClick={() => qaActionsRef.current?.setActiveTableCellAlign("center")}>
+        <button
+          type="button"
+          onMouseDown={preserveEditorSelectionOnButtonMouseDown}
+          onClick={() => qaActionsRef.current?.setActiveTableCellAlign("center")}
+        >
           QA 가운데
         </button>
-        <button type="button" onClick={() => qaActionsRef.current?.setActiveTableCellBackground("#fef3c7")}>
+        <button
+          type="button"
+          onMouseDown={preserveEditorSelectionOnButtonMouseDown}
+          onClick={() => qaActionsRef.current?.setActiveTableCellBackground("#fef3c7")}
+        >
           QA 노랑 배경
         </button>
-        <button type="button" onClick={() => qaActionsRef.current?.addTableRowAfter()}>
+        <button
+          type="button"
+          onMouseDown={preserveEditorSelectionOnButtonMouseDown}
+          onClick={() => qaActionsRef.current?.addTableRowAfter()}
+        >
           QA 행 추가
         </button>
-        <button type="button" onClick={() => qaActionsRef.current?.addTableColumnAfter()}>
+        <button
+          type="button"
+          onMouseDown={preserveEditorSelectionOnButtonMouseDown}
+          onClick={() => qaActionsRef.current?.addTableColumnAfter()}
+        >
           QA 열 추가
         </button>
-        <button type="button" onClick={() => qaActionsRef.current?.deleteSelectedTableRow()}>
+        <button
+          type="button"
+          onMouseDown={preserveEditorSelectionOnButtonMouseDown}
+          onClick={() => qaActionsRef.current?.deleteSelectedTableRow()}
+        >
           QA 행 삭제
         </button>
-        <button type="button" onClick={() => qaActionsRef.current?.deleteSelectedTableColumn()}>
+        <button
+          type="button"
+          onMouseDown={preserveEditorSelectionOnButtonMouseDown}
+          onClick={() => qaActionsRef.current?.deleteSelectedTableColumn()}
+        >
           QA 열 삭제
         </button>
-        <button type="button" onClick={() => qaActionsRef.current?.resizeFirstTableRow(28)}>
+        <button
+          type="button"
+          onMouseDown={preserveEditorSelectionOnButtonMouseDown}
+          onClick={() => qaActionsRef.current?.resizeFirstTableRow(28)}
+        >
           QA 행 리사이즈
         </button>
-        <button type="button" onClick={() => qaActionsRef.current?.resizeFirstTableColumn(28)}>
+        <button
+          type="button"
+          onMouseDown={preserveEditorSelectionOnButtonMouseDown}
+          onClick={() => qaActionsRef.current?.resizeFirstTableColumn(28)}
+        >
           QA 열 리사이즈
         </button>
         <button type="button" onClick={() => qaActionsRef.current?.focusDocumentEnd()}>


### PR DESCRIPTION
## 관련 이슈

close #634

## 작업 배경

- `/editor/507` 하단 7x3 table row/column 구조 선택 직후 scroll/table rect/native selection이 프레임 단위로 토글되는 잔여 flicker를 안정화했습니다.
- 긴 본문 하단에서 code/table/body 전환 시 selection owner와 scroll preserve가 서로 되돌리는 경로를 보강하고, 실제 507 하단 사용자 플로우 E2E를 강화했습니다.

## 작업 내용

- editor 전용 Mermaid/code block 높이 재측정이 하단 table 위치를 흔들지 않도록 내부 스크롤/고정 높이 계약을 정리했습니다.
- table row/column axis 선택 시 native table text selection과 stale restore가 다시 살아나지 않도록 focus/scroll/native selection preserve 순서를 보강했습니다.
- code select-all 뒤 일반 본문 pointer follow-up에서 code 전용 direct scroll preserve를 시작해 긴 본문 하단 forced scroll 회귀를 막았습니다.
- 실제 507 하단 code/table/body workflow, table-wide Cmd/Ctrl+A 뒤 row grip, row/column 구조 선택 sampling, source contract 검증을 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:authoring --grep "body selection 뒤 table/code drag는 이전 selection anchor" --repeat-each=5` -> 5 passed
  - `yarn --cwd front test:e2e:authoring --grep "사용자 507 하단 본문/table 드래그 플로우|실제 507 하단 code/table/body workflow|body selection 뒤 table/code drag는 이전 selection anchor|table structural selection 해제는 table 밖 safe text selection|table-wide Cmd/Ctrl\\+A 직후 row grip" --repeat-each=5` -> 25 passed
  - `yarn --cwd front test:e2e:authoring` -> 160 passed
  - `yarn --cwd front test:e2e:authoring` -> 160 passed, 동일 조건 2회 연속 통과
  - `git diff --check` -> passed
  - 변경 editor/e2e 파일 160자 초과 라인 검사 -> 0건
  - debug marker 검사 -> no match
  - `yarn --cwd front lint` -> passed, ESLint warnings 0
  - `yarn --cwd front check:refactor-boundaries` -> passed with advisory warnings only
  - `yarn --cwd front build` -> passed
  - `node front/scripts/check-bundle-size.mjs` -> monitored routes OK
  - `yarn --cwd front test:e2e:smoke` -> 57 passed

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: selection/focus/scroll owner 변경이 editor의 table/code/rich block pointer 흐름에 영향을 줄 수 있습니다. 관련 authoring 전체 2회와 smoke/build/bundle로 회귀를 확인했습니다.
- 롤백 방법: 이 PR 커밋을 revert하고 이전 PR #647 배포 상태로 되돌립니다.
- 리뷰 상태: 로컬 CodeRabbit CLI는 10분 이상 `connecting_to_review_service`에서 멈춰 종료했고, CodexReview CLI는 사용량 한도(`2026-06-14 10:39` 재시도 가능)로 실행되지 못했습니다. PR 생성 후 GitHub CodeRabbit/review thread 상태를 다시 확인합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
