### PR TITLE
[Test] 507 list click CI 안정화

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -105,7 +105,9 @@ const hasNestedListChild = (page: Page, parentLabel: string, childLabel: string)
 
 const isDetachedElementError = (error: unknown) =>
   error instanceof Error &&
-  /not attached to the DOM|Element is not attached/i.test(error.message)
+  /not attached to the DOM|Element is not attached|list paragraph click metrics are missing/i.test(
+    error.message
+  )
 
 const retryDetachedLocatorAction = async <T>(
   page: Page,
@@ -134,8 +136,8 @@ const clickListItemParagraph = async (
 ) => {
   const resolveParagraph = () => editor.locator("li > p", { hasText: label }).first()
   const clickPoint = await retryDetachedLocatorAction(page, resolveParagraph, async (paragraph) => {
-    await paragraph.scrollIntoViewIfNeeded()
     return paragraph.evaluate((element, needle) => {
+      element.scrollIntoView({ block: "center", inline: "nearest", behavior: "instant" })
       const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
       while (walker.nextNode()) {
         const textNode = walker.currentNode as Text
@@ -176,21 +178,27 @@ const clickListItemParagraph = async (
     }, caretNeedle ?? null)
   })
   await retryDetachedLocatorAction(page, resolveParagraph, async (paragraph) => {
-    const box = await paragraph.boundingBox()
-    if (!box) throw new Error("list paragraph click metrics are missing")
-    const clickX = box.x + clickPoint.relativeX
-    const clickY = box.y + clickPoint.relativeY
+    const clickMetrics = await paragraph.evaluate((element, point) => {
+      element.scrollIntoView({ block: "center", inline: "nearest", behavior: "instant" })
+      const rect = element.getBoundingClientRect()
+      if (rect.width <= 0 || rect.height <= 0) return null
+      return {
+        x: rect.left + Math.min(Math.max(point.relativeX, 1), Math.max(rect.width - 1, 1)),
+        y: rect.top + Math.min(Math.max(point.relativeY, 1), Math.max(rect.height - 1, 1)),
+      }
+    }, clickPoint)
+    if (!clickMetrics) throw new Error("list paragraph click metrics are missing")
     await expect
       .poll(() =>
         page.evaluate(
           ({ expectedLabel, x, y }) =>
             document.elementFromPoint(x, y)?.textContent?.includes(expectedLabel) ??
             false,
-          { expectedLabel: label, x: clickX, y: clickY }
+          { expectedLabel: label, x: clickMetrics.x, y: clickMetrics.y }
         )
       )
       .toBe(true)
-    await page.mouse.click(clickX, clickY)
+    await page.mouse.click(clickMetrics.x, clickMetrics.y)
   })
   const readCaretState = () =>
     resolveParagraph().evaluate(

--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -342,20 +342,40 @@ const expectPost507FinalTableBlockOverlayFollowsScroll = async (
   expect(Math.abs(before.overlayWidth - (before.blockWidth + 12))).toBeLessThanOrEqual(8)
 
   const scrollState = await page.evaluate(() => {
-    const scrollTop = document.scrollingElement?.scrollTop ?? window.scrollY
-    const scrollHeight = document.scrollingElement?.scrollHeight ?? document.documentElement.scrollHeight
+    const scroller = document.scrollingElement ?? document.documentElement
+    const scrollTop = scroller.scrollTop || window.scrollY
+    const scrollHeight = scroller.scrollHeight || document.documentElement.scrollHeight
     return { maxScrollTop: scrollHeight - window.innerHeight, scrollTop }
   })
-  const scrollDelta = scrollState.scrollTop < scrollState.maxScrollTop - 240 ? 180 : -180
-  await page.evaluate((deltaY) => {
-    window.scrollBy(0, deltaY)
-  }, scrollDelta)
-  await expect
-    .poll(async () => {
-      const current = await readPost507FinalTableBlockOverlayMetrics(page)
-      return current ? Math.abs(current.scrollTop - before.scrollTop) : 0
-    })
-    .toBeGreaterThan(40)
+  const scrollDeltas =
+    scrollState.scrollTop < scrollState.maxScrollTop - 240 ? [180, 360] : [-180, -360]
+  let scrolled = false
+  for (const scrollDelta of scrollDeltas) {
+    const currentTableBox = await finalTable.boundingBox()
+    if (currentTableBox) {
+      await page.mouse.move(
+        currentTableBox.x + Math.min(Math.max(currentTableBox.width / 2, 12), currentTableBox.width - 12),
+        currentTableBox.y + Math.min(Math.max(currentTableBox.height / 2, 12), currentTableBox.height - 12)
+      )
+    }
+    await page.mouse.wheel(0, scrollDelta)
+    await page.waitForTimeout(160)
+    const current = await readPost507FinalTableBlockOverlayMetrics(page)
+    if (current && Math.abs(current.scrollTop - before.scrollTop) > 40) {
+      scrolled = true
+      break
+    }
+  }
+  if (!scrolled) {
+    const current = await readPost507FinalTableBlockOverlayMetrics(page)
+    throw new Error(
+      `post 507 final table overlay scroll did not move: ${JSON.stringify(
+        { before, current, scrollState },
+        null,
+        2
+      )}`
+    )
+  }
   const after = await readPost507FinalTableBlockOverlayMetrics(page)
   if (!after) throw new Error("post 507 final table overlay metrics are missing after scroll")
   expect(Math.abs(after.gapTop - before.gapTop)).toBeLessThanOrEqual(3)
@@ -416,12 +436,14 @@ const dragLocatorTextRange = async (
 ) => {
   const isDetachedError = (error: unknown) =>
     error instanceof Error &&
-    /not attached to the DOM|Element is not attached/i.test(error.message)
+    /not attached to the DOM|Element is not attached|text rect is too small|text range is not hit-testable/i.test(error.message)
   const runDrag = async () => {
-    await target.scrollIntoViewIfNeeded()
-    const measureTextRange = () =>
-      target.evaluate((element, { endInsetPx, label, startInsetPx, textToSelect }) => {
+    const measureTextRange = async () => {
+      await target.evaluate((element) => {
         element.scrollIntoView({ block: "center", inline: "nearest", behavior: "instant" })
+      })
+      await page.waitForTimeout(80)
+      return target.evaluate((element, { endInsetPx, label, startInsetPx, textToSelect }) => {
         const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
         while (walker.nextNode()) {
           const textNode = walker.currentNode as Text
@@ -458,6 +480,24 @@ const dragLocatorTextRange = async (
         startInsetPx: options.startInsetPx,
         textToSelect: text,
       })
+    }
+    const pointHitsTargetText = (metrics: Awaited<ReturnType<typeof measureTextRange>>) =>
+      page.evaluate(
+        ({ endX, endY, startX, startY, textToSelect }) => {
+          const isExpectedPoint = (x: number, y: number) => {
+            const element = document.elementFromPoint(x, y)
+            return Boolean(element?.textContent?.includes(textToSelect))
+          }
+          return isExpectedPoint(startX, startY) && isExpectedPoint(endX, endY)
+        },
+        {
+          endX: metrics.endX,
+          endY: metrics.endY,
+          startX: metrics.startX,
+          startY: metrics.startY,
+          textToSelect: text,
+        }
+      )
     let metrics = await measureTextRange()
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const viewport = page.viewportSize()
@@ -466,6 +506,13 @@ const dragLocatorTextRange = async (
       await page.waitForTimeout(160)
       metrics = await measureTextRange()
     }
+    let pointHit = await pointHitsTargetText(metrics)
+    for (let attempt = 0; !pointHit && attempt < 4; attempt += 1) {
+      await page.waitForTimeout(120 + attempt * 80)
+      metrics = await measureTextRange()
+      pointHit = await pointHitsTargetText(metrics)
+    }
+    if (!pointHit) throw new Error(`${label} text range is not hit-testable`)
     const viewport = page.viewportSize()
     if (viewport && (metrics.startY < 8 || metrics.endY < 8 || metrics.startY > viewport.height - 8 || metrics.endY > viewport.height - 8)) {
       throw new Error(`${label} text rect is outside viewport: ${JSON.stringify(metrics)}`)


### PR DESCRIPTION
## 관련 이슈

close #634

## 작업 배경

- #651 merge 후 main CI에서 507 chain E2E의 list paragraph click helper가 GitHub runner에서 unstable scroll/bounding box로 실패한 문제를 안정화합니다.
- 제품 동작 변경 없이 테스트 helper가 DOM scrollIntoView와 좌표 polling을 사용하도록 조정했습니다.

## 작업 내용

- Playwright `scrollIntoViewIfNeeded()` 대기 대신 DOM `scrollIntoView({ block: "center", behavior: "instant" })`로 list paragraph를 즉시 중앙 정렬합니다.
- `boundingBox()` null 상태를 retry 가능한 helper 오류로 분류하고, DOM rect 기반 click 좌표를 산출합니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --grep "실제 507 하단 table" --workers=1`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --workers=1`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: test helper 변경만 있어 제품 런타임 영향은 없습니다. helper 좌표 계산이 과도하게 보수적이면 해당 E2E만 실패할 수 있습니다.
- 롤백 방법: 이 PR 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
