### PR TITLE
[Test] editor 507 live selection canary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1225,6 +1225,7 @@ jobs:
         env:
           PLAYWRIGHT_LIVE_FAIL_FAST: "true"
           PLAYWRIGHT_LIVE_MULTI_BROWSER: "false"
+          E2E_LIVE_EDITOR_507_CANARY: "true"
         shell: bash
         run: |
           set -euo pipefail
@@ -1243,7 +1244,7 @@ jobs:
           }
           trap cleanup EXIT
 
-          npx playwright test e2e/live.spec.ts \
+          npx playwright test e2e/live.spec.ts e2e/editor-live-visual.spec.ts \
             --workers=1 \
             --reporter=line \
             --max-failures=1

--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test"
+import { expect, test, type Locator, type Page } from "@playwright/test"
 import {
   adminEmail,
   adminLegacyLoginId,
@@ -18,13 +18,27 @@ import {
   waitForApiReachability,
 } from "./helpers/liveAuth"
 
-const hasUiLoginCredentials = Boolean(adminEmail && adminPassword)
+const uiLoginId = adminEmail || adminLegacyLoginId
+const hasUiLoginCredentials = Boolean(uiLoginId && adminPassword)
 const editorOrAdminUrlPattern = /\/(admin|editor)(\/|$|\?)/
 const editorUrlPattern = /\/editor(\/|$|\?)/
+const expectedFrontendCommitSha = process.env.E2E_EXPECTED_FRONT_COMMIT_SHA?.trim() || ""
+const liveEditor507CanaryEnabled = process.env.E2E_LIVE_EDITOR_507_CANARY === "true"
+const liveEditor507SeededHosts = new Set(
+  (process.env.E2E_LIVE_EDITOR_507_HOSTS || "www.aquilaxk.site")
+    .split(",")
+    .map((host) => host.trim().toLowerCase())
+    .filter(Boolean)
+)
+const post507FinalTableTargetCell = "Stateless 의미"
+const post507FinalTableSelectAllNeedle = "구현되어 있는가"
+const post507LowerBodyText = "서버가 아무것도 안 하는 구조"
+const post507CodeText = "createAccessToken(user)"
+const post507ListText = "세션이랑 JWT"
 
 
 
-const tryEnterEditorRoute = async (page: Parameters<typeof test>[0]["page"], timeoutMs: number) => {
+const tryEnterEditorRoute = async (page: Page, timeoutMs: number) => {
   const tries = 3
   const perTryTimeout = Math.max(4_000, Math.floor(timeoutMs / tries))
 
@@ -48,7 +62,7 @@ const tryEnterEditorRoute = async (page: Parameters<typeof test>[0]["page"], tim
   return false
 }
 
-const gotoLoginForEditor = async (page: Parameters<typeof test>[0]["page"], timeoutMs: number) => {
+const gotoLoginForEditor = async (page: Page, timeoutMs: number) => {
   try {
     await page.goto("/login?next=%2Feditor%2Fnew")
   } catch (error) {
@@ -75,7 +89,7 @@ type UiLoginOutcome =
   | { kind: "error"; message: string }
   | { kind: "timeout" }
 
-const getVisibleUiLoginError = async (page: Parameters<typeof test>[0]["page"]) => {
+const getVisibleUiLoginError = async (page: Page) => {
   const loginError = page
     .locator("main")
     .getByText(/로그인에 실패|이메일 또는 비밀번호|로그인 시도가 너무 많습니다|서버 오류/i)
@@ -85,7 +99,7 @@ const getVisibleUiLoginError = async (page: Parameters<typeof test>[0]["page"]) 
   return (await loginError.textContent())?.trim() || "unknown error"
 }
 
-const getTableAffordances = (page: Parameters<typeof test>[0]["page"]) => ({
+const getTableAffordances = (page: Page) => ({
   rowHandle: page.locator("[data-table-affordance='row-handle']").first(),
   columnHandle: page.locator("[data-table-affordance='column-handle']").first(),
   rowAddButton: page.locator("[data-table-affordance='row-add']").first(),
@@ -96,7 +110,7 @@ const getTableAffordances = (page: Parameters<typeof test>[0]["page"]) => ({
 })
 
 const waitForUiLoginOutcome = async (
-  page: Parameters<typeof test>[0]["page"],
+  page: Page,
   getObservedLoginResponse: () => { status: number; bodyPreview: string } | null,
   timeoutMs: number
 ): Promise<UiLoginOutcome> => {
@@ -127,7 +141,7 @@ const waitForUiLoginOutcome = async (
 
 
 
-const loginWithRetry = async (page: Parameters<typeof test>[0]["page"], apiBaseUrl: string) => {
+const loginWithRetry = async (page: Page, apiBaseUrl: string) => {
   const payloadCandidates = buildLoginPayloadCandidates(adminEmail, adminLegacyLoginId, adminPassword)
   if (payloadCandidates.length === 0) {
     throw new Error("Login credentials are missing. Provide E2E_ADMIN_EMAIL or E2E_ADMIN_USERNAME.")
@@ -178,7 +192,7 @@ const loginWithRetry = async (page: Parameters<typeof test>[0]["page"], apiBaseU
   throw new Error(`Login API failed after retries. base=${apiBaseUrl} last=${lastFailure}`)
 }
 
-const loginThroughUi = async (page: Parameters<typeof test>[0]["page"]) => {
+const loginThroughUi = async (page: Page) => {
   const route = await gotoLoginForEditor(page, liveUiRedirectTimeoutMs)
   if (route === "editor") return
 
@@ -189,7 +203,7 @@ const loginThroughUi = async (page: Parameters<typeof test>[0]["page"]) => {
 
   for (let attempt = 1; attempt <= liveLoginAttempts; attempt += 1) {
     await expect(page.getByRole("heading", { name: "로그인" })).toBeVisible()
-    await page.getByLabel("이메일").fill(adminEmail)
+    await page.getByLabel("이메일").fill(uiLoginId)
     await page.locator("#password").fill(adminPassword)
 
     let observedLoginResponse: { status: number; bodyPreview: string } | null = null
@@ -276,7 +290,7 @@ type LiveWriteResponse = {
 }
 
 const createHiddenEditorPost = async (
-  page: Parameters<typeof test>[0]["page"],
+  page: Page,
   title: string,
   content: string
 ) => {
@@ -300,7 +314,7 @@ const createHiddenEditorPost = async (
   return postId
 }
 
-const deleteHiddenEditorPost = async (page: Parameters<typeof test>[0]["page"], postId: number) => {
+const deleteHiddenEditorPost = async (page: Page, postId: number) => {
   const apiBaseUrl = resolveApiBaseUrl(page.url())
   const response = await page.request.delete(`${apiBaseUrl}/post/api/v1/posts/${postId}`, {
     headers: {
@@ -313,8 +327,334 @@ const deleteHiddenEditorPost = async (page: Parameters<typeof test>[0]["page"], 
   }
 }
 
+const pressSelectAll = async (page: Page) => page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A")
+
+const readScrollTop = (page: Page) =>
+  page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+
+const readSelectionText = (page: Page) =>
+  page.evaluate(() => {
+    const candidates = [
+      window.getSelection()?.toString() ?? "",
+      document.documentElement.getAttribute("data-table-drag-selection-text") ?? "",
+      document
+        .querySelector("[data-table-drag-selection-text]")
+        ?.getAttribute("data-table-drag-selection-text") ?? "",
+      document.documentElement.getAttribute("data-code-drag-selection-text") ?? "",
+      document
+        .querySelector("[data-code-drag-selection-text]")
+        ?.getAttribute("data-code-drag-selection-text") ?? "",
+    ].filter((value) => value.trim().length > 0)
+    return candidates.sort((left, right) => right.length - left.length)[0] ?? ""
+  })
+
+const clearSelectionResidue = (page: Page) =>
+  page.evaluate(() => {
+    window.getSelection()?.removeAllRanges()
+    document.documentElement.removeAttribute("data-table-drag-selection-text")
+    document.documentElement.removeAttribute("data-code-drag-selection-text")
+    document
+      .querySelectorAll<HTMLElement>("[data-table-drag-selection-text], [data-code-drag-selection-text]")
+      .forEach((element) => {
+        element.removeAttribute("data-table-drag-selection-text")
+        element.removeAttribute("data-code-drag-selection-text")
+      })
+    document.dispatchEvent(new Event("selectionchange"))
+  })
+
+const readSelectionResidueState = (page: Page) =>
+  page.evaluate(() => {
+    const editor = document.querySelector<HTMLElement>("[data-testid='block-editor-prosemirror']")
+    const tableDragText =
+      document.documentElement.getAttribute("data-table-drag-selection-text") ||
+      document.querySelector("[data-table-drag-selection-text]")?.getAttribute("data-table-drag-selection-text") ||
+      ""
+    return {
+      activePreserveOwner: document.documentElement.getAttribute("data-editor-scroll-preserve-owner"),
+      blockOverlayCount: document.querySelectorAll("[data-testid='keyboard-block-selection-overlay']").length,
+      keyboardBlockSelection: editor?.getAttribute("data-keyboard-block-selection") ?? null,
+      selectedCellCount: document.querySelectorAll(".selectedCell").length,
+      tableDragText,
+    }
+  })
+
+const expectNoSelectionResidue = async (page: Page, label: string) => {
+  const state = await readSelectionResidueState(page)
+  expect(state.blockOverlayCount, `${label}: block selection overlay should not remain`).toBe(0)
+  expect(state.keyboardBlockSelection, `${label}: keyboard block selection should not remain`).not.toBe("true")
+  expect(state.selectedCellCount, `${label}: selectedCell should not remain`).toBe(0)
+  expect(state.activePreserveOwner, `${label}: table scroll preserve should not remain`).not.toBe("table")
+  expect(state.tableDragText, `${label}: stale table drag text should not remain`).not.toContain(
+    post507FinalTableTargetCell
+  )
+}
+
+const dragTextRange = async (
+  page: Page,
+  target: Locator,
+  label: string,
+  text: string,
+  options: {
+    endInsetPx?: number
+    paced?: boolean
+    retryWhenEmpty?: boolean
+    startInsetPx?: number
+    waitMs?: number
+  } = {}
+) => {
+  const isRetryable = (error: unknown) =>
+    error instanceof Error &&
+    /not attached to the DOM|Element is not attached|text rect is too small|text range is not hit-testable/i.test(
+      error.message
+    )
+
+  const runDrag = async () => {
+    const measureTextRange = async () => {
+      await target.evaluate((element) => {
+        element.scrollIntoView({ block: "center", inline: "nearest", behavior: "instant" })
+      })
+      await page.waitForTimeout(80)
+      return target.evaluate(
+        (element, { endInsetPx, label, startInsetPx, textToSelect }) => {
+          const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+          while (walker.nextNode()) {
+            const textNode = walker.currentNode as Text
+            const startOffset = textNode.data.indexOf(textToSelect)
+            if (startOffset < 0) continue
+            const range = document.createRange()
+            range.setStart(textNode, startOffset)
+            range.setEnd(textNode, startOffset + textToSelect.length)
+            const rects = Array.from(range.getClientRects())
+              .filter((candidate) => candidate.width > 2 && candidate.height > 2)
+              .sort((a, b) => a.top - b.top || a.left - b.left)
+            const startRect = rects[0] ?? range.getBoundingClientRect()
+            const endRect = rects[rects.length - 1] ?? startRect
+            if (startRect.width <= 2 || startRect.height <= 2 || endRect.width <= 2 || endRect.height <= 2) {
+              throw new Error(`${label} text rect is too small`)
+            }
+            const resolvedStartInsetPx = Math.min(startRect.width / 2, Math.max(2, startInsetPx ?? 2))
+            const resolvedEndInsetPx = Math.min(endRect.width / 2, Math.max(2, endInsetPx ?? 2))
+            return {
+              endX: endRect.right - resolvedEndInsetPx,
+              endY: endRect.top + endRect.height / 2,
+              startX: startRect.left + resolvedStartInsetPx,
+              startY: startRect.top + startRect.height / 2,
+            }
+          }
+          throw new Error(`${label} text node is missing`)
+        },
+        {
+          endInsetPx: options.endInsetPx,
+          label,
+          startInsetPx: options.startInsetPx,
+          textToSelect: text,
+        }
+      )
+    }
+
+    const pointHitsTargetText = (metrics: Awaited<ReturnType<typeof measureTextRange>>) =>
+      page.evaluate(
+        ({ endX, endY, startX, startY, textToSelect }) => {
+          const hitsText = (x: number, y: number) =>
+            Boolean(document.elementFromPoint(x, y)?.textContent?.includes(textToSelect))
+          return hitsText(startX, startY) && hitsText(endX, endY)
+        },
+        {
+          endX: metrics.endX,
+          endY: metrics.endY,
+          startX: metrics.startX,
+          startY: metrics.startY,
+          textToSelect: text,
+        }
+      )
+
+    let metrics = await measureTextRange()
+    const viewport = page.viewportSize()
+    for (let attempt = 0; viewport && attempt < 3; attempt += 1) {
+      const withinViewport =
+        metrics.startY >= 8 &&
+        metrics.endY >= 8 &&
+        metrics.startY <= viewport.height - 8 &&
+        metrics.endY <= viewport.height - 8
+      if (withinViewport) break
+      await page.mouse.wheel(0, Math.max(metrics.startY, metrics.endY) > viewport.height / 2 ? 360 : -360)
+      await page.waitForTimeout(160)
+      metrics = await measureTextRange()
+    }
+
+    let pointHit = await pointHitsTargetText(metrics)
+    for (let attempt = 0; !pointHit && attempt < 4; attempt += 1) {
+      await page.waitForTimeout(120 + attempt * 80)
+      metrics = await measureTextRange()
+      pointHit = await pointHitsTargetText(metrics)
+    }
+    if (!pointHit) throw new Error(`${label} text range is not hit-testable`)
+
+    const beforeScrollTop = await readScrollTop(page)
+    await page.mouse.move(metrics.startX, metrics.startY)
+    if (options.paced) await page.waitForTimeout(80)
+    await page.mouse.down()
+    if (options.paced) {
+      for (let index = 1; index <= 28; index += 1) {
+        const ratio = index / 28
+        await page.mouse.move(
+          metrics.startX + (metrics.endX - metrics.startX) * ratio,
+          metrics.startY + (metrics.endY - metrics.startY) * ratio
+        )
+        await page.waitForTimeout(index === 1 ? 16 : 4)
+      }
+      await page.waitForTimeout(40)
+    } else {
+      await page.mouse.move(metrics.endX, metrics.endY, { steps: 18 })
+    }
+    await page.mouse.up()
+    await page.waitForTimeout(options.waitMs ?? 720)
+    return {
+      afterScrollTop: await readScrollTop(page),
+      beforeScrollTop,
+      selectionText: await readSelectionText(page),
+    }
+  }
+
+  let result: Awaited<ReturnType<typeof runDrag>> | null = null
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      result = await runDrag()
+      break
+    } catch (error) {
+      if (!isRetryable(error) || attempt === 2) throw error
+      await page.waitForTimeout(160)
+    }
+  }
+  if (!result) throw new Error(`${label} drag did not start`)
+
+  for (let attempt = 1; options.retryWhenEmpty && !result.selectionText.includes(text) && attempt < 5; attempt += 1) {
+    await clearSelectionResidue(page)
+    await page.waitForTimeout(120 + attempt * 80)
+    try {
+      result = await runDrag()
+    } catch (error) {
+      if (!isRetryable(error) || attempt === 4) throw error
+      await page.waitForTimeout(160)
+    }
+  }
+
+  if (options.retryWhenEmpty && !result.selectionText.includes(text)) {
+    const residueState = await readSelectionResidueState(page)
+    throw new Error(
+      `${label} drag did not select expected text after retries: ${JSON.stringify(
+        { residueState, selectionText: result.selectionText },
+        null,
+        2
+      )}`
+    )
+  }
+
+  return result
+}
+
+const readFinalTableOverlayMetrics = (page: Page) =>
+  page.evaluate((targetCellText) => {
+    const table =
+      Array.from(document.querySelectorAll<HTMLElement>("table")).find((candidate) =>
+        candidate.textContent?.includes(targetCellText)
+      ) ?? null
+    const block = (table?.closest(".tableWrapper") as HTMLElement | null) ?? table
+    const overlay = document.querySelector<HTMLElement>("[data-testid='keyboard-block-selection-overlay']")
+    if (!block || !overlay) return null
+    const blockRect = block.getBoundingClientRect()
+    const overlayRect = overlay.getBoundingClientRect()
+    return {
+      blockLeft: blockRect.left,
+      blockTop: blockRect.top,
+      blockWidth: blockRect.width,
+      gapLeft: overlayRect.left - blockRect.left,
+      gapTop: overlayRect.top - blockRect.top,
+      overlayLeft: overlayRect.left,
+      overlayTop: overlayRect.top,
+      overlayWidth: overlayRect.width,
+      scrollTop: document.scrollingElement?.scrollTop ?? window.scrollY,
+    }
+  }, post507FinalTableTargetCell)
+
+const expectFinalTableOverlayFollowsScroll = async (page: Page, finalTable: Locator) => {
+  await finalTable.evaluate((element) => {
+    element.scrollIntoView({ block: "center", inline: "nearest", behavior: "instant" })
+  })
+  await page.waitForTimeout(160)
+  await page.keyboard.press("Escape")
+  await clearSelectionResidue(page)
+  const tableBox = await finalTable.boundingBox()
+  if (!tableBox) throw new Error("live 507 final table metrics are missing")
+
+  const blockHandle = page.getByTestId("block-drag-handle")
+  for (const point of [
+    { x: 24, y: 24 },
+    { x: 18, y: 18 },
+    { x: 32, y: 28 },
+    { x: -24, y: 24 },
+    { x: -36, y: 32 },
+  ]) {
+    const currentTableBox = await finalTable.boundingBox()
+    if (!currentTableBox) break
+    await page.mouse.move(
+      currentTableBox.x + currentTableBox.width / 2,
+      currentTableBox.y + currentTableBox.height / 2
+    )
+    await page.mouse.move(currentTableBox.x + point.x, currentTableBox.y + point.y, { steps: 4 })
+    await page.waitForTimeout(80)
+    if (await blockHandle.isVisible().catch(() => false)) break
+  }
+  await expect(blockHandle).toBeVisible()
+  await blockHandle.click()
+  await expect(page.getByTestId("keyboard-block-selection-overlay")).toBeVisible()
+
+  const before = await readFinalTableOverlayMetrics(page)
+  if (!before) throw new Error("live 507 final table overlay metrics are missing before scroll")
+  expect(Math.abs(before.gapTop + 4)).toBeLessThanOrEqual(8)
+  expect(Math.abs(before.overlayWidth - (before.blockWidth + 12))).toBeLessThanOrEqual(8)
+
+  const scrollState = await page.evaluate(() => {
+    const scroller = document.scrollingElement ?? document.documentElement
+    const scrollTop = scroller.scrollTop || window.scrollY
+    const scrollHeight = scroller.scrollHeight || document.documentElement.scrollHeight
+    return { maxScrollTop: scrollHeight - window.innerHeight, scrollTop }
+  })
+  const scrollDeltas =
+    scrollState.scrollTop < scrollState.maxScrollTop - 240 ? [180, 360] : [-180, -360]
+  let scrolled = false
+  for (const scrollDelta of scrollDeltas) {
+    const currentTableBox = await finalTable.boundingBox()
+    if (currentTableBox) {
+      await page.mouse.move(
+        currentTableBox.x + Math.min(Math.max(currentTableBox.width / 2, 12), currentTableBox.width - 12),
+        currentTableBox.y + Math.min(Math.max(currentTableBox.height / 2, 12), currentTableBox.height - 12)
+      )
+    }
+    await page.mouse.wheel(0, scrollDelta)
+    await page.waitForTimeout(160)
+    const current = await readFinalTableOverlayMetrics(page)
+    if (current && Math.abs(current.scrollTop - before.scrollTop) > 40) {
+      scrolled = true
+      break
+    }
+  }
+  if (!scrolled) {
+    const current = await readFinalTableOverlayMetrics(page)
+    throw new Error(
+      `live 507 final table overlay scroll did not move: ${JSON.stringify({ before, current, scrollState }, null, 2)}`
+    )
+  }
+  const after = await readFinalTableOverlayMetrics(page)
+  if (!after) throw new Error("live 507 final table overlay metrics are missing after scroll")
+  expect(Math.abs(after.gapTop - before.gapTop)).toBeLessThanOrEqual(3)
+  expect(Math.abs(after.gapLeft - before.gapLeft)).toBeLessThanOrEqual(3)
+  expect(Math.abs(after.blockTop - before.blockTop - (after.overlayTop - before.overlayTop))).toBeLessThanOrEqual(3)
+  expect(Math.abs(after.blockLeft - before.blockLeft - (after.overlayLeft - before.overlayLeft))).toBeLessThanOrEqual(3)
+}
+
 test.describe("editor live visual regression", () => {
-  test.skip(!hasUiLoginCredentials, "E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD가 필요합니다.")
+  test.skip(!hasUiLoginCredentials, "E2E_ADMIN_EMAIL 또는 E2E_ADMIN_USERNAME / E2E_ADMIN_PASSWORD가 필요합니다.")
 
   test("실제 /editor/new는 제품 셸 기준으로 제목/본문 정렬을 유지하고 QA affordance를 노출하지 않는다", async ({
     page,
@@ -565,5 +905,95 @@ test.describe("editor live visual regression", () => {
     } finally {
       await deleteHiddenEditorPost(page, postId)
     }
+  })
+
+  test("실제 /editor/507 하단 선택과 table block overlay는 배포본에서 stale table 상태를 남기지 않는다", async ({
+    page,
+  }) => {
+    test.skip(!liveEditor507CanaryEnabled, "E2E_LIVE_EDITOR_507_CANARY=true일 때만 실제 507 seeded live canary를 실행합니다.")
+    test.slow()
+    await page.setViewportSize({ width: 1580, height: 900 })
+    await loginThroughUi(page)
+    test.skip(
+      !liveEditor507SeededHosts.has(new URL(page.url()).hostname.toLowerCase()),
+      "실제 507 seeded content가 있는 live host에서만 canary를 실행합니다."
+    )
+
+    await page.goto("/editor/507")
+    await page.waitForURL(/\/editor\/507(\?|$)/, { timeout: 30_000 })
+    await expect(page.getByPlaceholder("제목을 입력하세요").first()).toBeVisible()
+
+    const buildSha = await page.evaluate(() =>
+      document.querySelector('meta[name="aquila-build-sha"]')?.getAttribute("content") ?? null
+    )
+    if (expectedFrontendCommitSha) {
+      expect(buildSha).toBe(expectedFrontendCommitSha)
+    }
+
+    const editor = page.getByTestId("block-editor-prosemirror").first()
+    await expect(editor.getByText(post507FinalTableTargetCell).first()).toBeVisible({ timeout: 30_000 })
+
+    const finalTable = editor.locator("table", { hasText: post507FinalTableTargetCell }).last()
+    const targetCell = finalTable.locator("td", { hasText: post507FinalTableTargetCell }).first()
+    await expect(targetCell).toBeVisible()
+
+    const tableDrag = await dragTextRange(
+      page,
+      targetCell,
+      "live /editor/507 final table drag",
+      post507FinalTableTargetCell,
+      { paced: true, retryWhenEmpty: true, waitMs: 900 }
+    )
+    expect(tableDrag.selectionText).toContain(post507FinalTableTargetCell)
+
+    await pressSelectAll(page)
+    await expect.poll(() => readSelectionText(page)).toContain(post507FinalTableSelectAllNeedle)
+    const tableSelectAllText = await readSelectionText(page)
+    expect(tableSelectAllText).toContain(post507FinalTableTargetCell)
+    expect(tableSelectAllText).not.toContain(post507ListText)
+
+    const lowerBody = editor.locator("p", { hasText: post507LowerBodyText }).first()
+    const bodyDrag = await dragTextRange(page, lowerBody, "live /editor/507 lower body drag", post507LowerBodyText, {
+      paced: true,
+      waitMs: 1_000,
+    })
+    expect(bodyDrag.selectionText).toContain(post507LowerBodyText)
+    expect(bodyDrag.selectionText).not.toContain(post507FinalTableTargetCell)
+    expect(bodyDrag.selectionText).not.toContain(post507FinalTableSelectAllNeedle)
+    expect(Math.abs(bodyDrag.afterScrollTop - bodyDrag.beforeScrollTop)).toBeLessThanOrEqual(24)
+    await expectNoSelectionResidue(page, "live 507 lower body after table select all")
+
+    const codeContent = editor.locator(".aq-code-editor-content", { hasText: post507CodeText }).first()
+    const codeDrag = await dragTextRange(page, codeContent, "live /editor/507 code drag", post507CodeText, {
+      paced: true,
+      retryWhenEmpty: true,
+      waitMs: 1_000,
+    })
+    expect(codeDrag.selectionText).toContain(post507CodeText)
+    expect(codeDrag.selectionText).not.toContain(post507FinalTableTargetCell)
+    expect(codeDrag.selectionText).not.toContain(post507LowerBodyText)
+    expect(Math.abs(codeDrag.afterScrollTop - codeDrag.beforeScrollTop)).toBeLessThanOrEqual(24)
+    await expectNoSelectionResidue(page, "live 507 code after body drag")
+
+    await pressSelectAll(page)
+    await expect.poll(() => readSelectionText(page)).toContain("return new Token")
+    const codeSelectAllText = await readSelectionText(page)
+    expect(codeSelectAllText).toContain(post507CodeText)
+    expect(codeSelectAllText).not.toContain(post507FinalTableTargetCell)
+
+    const listTextDrag = await dragTextRange(
+      page,
+      editor.locator("li", { hasText: post507ListText }).first(),
+      "live /editor/507 list text drag",
+      post507ListText,
+      { paced: true, retryWhenEmpty: true, waitMs: 1_000 }
+    )
+    expect(listTextDrag.selectionText).toContain(post507ListText)
+    expect(listTextDrag.selectionText).not.toContain(post507FinalTableTargetCell)
+    expect(listTextDrag.selectionText).not.toContain(post507LowerBodyText)
+    expect(Math.abs(listTextDrag.afterScrollTop - listTextDrag.beforeScrollTop)).toBeLessThanOrEqual(24)
+    await expectNoSelectionResidue(page, "live 507 list text after code select all")
+
+    await expectFinalTableOverlayFollowsScroll(page, finalTable)
   })
 })


### PR DESCRIPTION
## 관련 이슈

close #653

## 작업 배경

- 배포 workflow의 live E2E가 실제 /editor/507 수정 화면까지 secrets 인증으로 검증하도록 확장합니다.
- canary는 저장 없이 하단 final table drag, Cmd/Ctrl+A, 하단 body/code/list drag, table block-selection overlay scroll follow를 확인합니다.

## 작업 내용

- editor-live visual spec에 실제 /editor/507 하단 선택 canary를 추가했습니다.
- deploy frontLiveE2E 실행 대상에 editor-live-visual spec을 포함했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_FILE_PATH=.codex/tasks/editor-507-long-table-selection.local bash tools/guards/check-current-task-state.sh`
  - `CURRENT_TASK_FILE_PATH=.codex/tasks/editor-507-long-table-selection.local bash tools/guards/check-current-task-scope.sh --worktree`
  - `git diff --check`
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=https://www.aquilaxk.site PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/editor-live-visual.spec.ts --workers=1` (로컬에는 live credentials가 없어 4 skipped, 파일 로드/설정 검증)
  - `yarn --cwd front lint`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: deploy live E2E 시간이 늘어나며, 실제 507 콘텐츠가 변경되면 canary target text를 함께 갱신해야 합니다.
- 롤백 방법: 이 PR의 workflow/spec 변경을 revert하면 기존 live E2E 범위로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
