### PR TITLE
[Fix] back_green autoheal readiness loop

### DIFF
--- a/deploy/homeserver/blue_green_deploy.sh
+++ b/deploy/homeserver/blue_green_deploy.sh
@@ -35,6 +35,7 @@ AUTO_MEMORY_TUNER_SYSTEM_RESERVE_MB="${AUTO_MEMORY_TUNER_SYSTEM_RESERVE_MB:-2048
 AUTO_MEMORY_TUNER_MIN_BUDGET_MB="${AUTO_MEMORY_TUNER_MIN_BUDGET_MB:-1280}"
 LAST_COMPOSE_UP_SERVICES=""
 LAST_COMPOSE_UP_OUTPUT=""
+AUTOHEAL_PAUSED="false"
 
 run_diagnostic_command() {
   local timeout_seconds="${DIAGNOSTIC_TIMEOUT_SECONDS:-15}"
@@ -161,6 +162,32 @@ acquire_deploy_lock() {
 
 release_deploy_lock() {
   rm -rf "${DEPLOY_LOCK_DIR}" 2>/dev/null || true
+}
+
+is_compose_service_running() {
+  local service="$1"
+  compose ps --status running --services 2>/dev/null | grep -qx "${service}"
+}
+
+pause_autoheal_for_blue_green() {
+  if ! is_compose_service_running "autoheal"; then
+    echo "autoheal is not running; skip blue/green autoheal pause"
+    return 0
+  fi
+
+  echo "pausing autoheal during blue/green candidate readiness"
+  compose stop autoheal
+  AUTOHEAL_PAUSED="true"
+}
+
+resume_autoheal_if_paused() {
+  if [[ "${AUTOHEAL_PAUSED}" != "true" ]]; then
+    return 0
+  fi
+
+  echo "resuming autoheal after blue/green candidate readiness"
+  compose up -d autoheal || true
+  AUTOHEAL_PAUSED="false"
 }
 
 require_supported_docker_engine() {
@@ -1812,7 +1839,7 @@ fi
 if ! acquire_deploy_lock; then
   exit 1
 fi
-trap 'release_deploy_lock' EXIT INT TERM
+trap 'resume_autoheal_if_paused; release_deploy_lock' EXIT INT TERM
 
 require_supported_docker_engine
 validate_storage_env
@@ -1855,6 +1882,7 @@ warn_grafana_embed_public_route
 validate_db_runtime_role_env
 provision_db_runtime_role
 ensure_db_runtime_guards || true
+pause_autoheal_for_blue_green
 compose pull "${next_backend}"
 if ! compose_up_force_recreate_with_retry "${next_backend}"; then
   emit_backend_diagnostics "${next_backend}" >&2 || true

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -196,6 +196,24 @@ test("prod datasource uses a non-superuser runtime role contract", () => {
   assert.match(deployScript, /GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public/)
 })
 
+test("blue-green deploy pauses autoheal while staging a candidate backend", () => {
+  const deployScript = readFileSync(deployScriptPath, "utf8")
+  const pauseCallIndex = deployScript.indexOf("\npause_autoheal_for_blue_green\n")
+  const candidateRecreateIndex = deployScript.indexOf('compose_up_force_recreate_with_retry "${next_backend}"')
+
+  assert.match(deployScript, /pause_autoheal_for_blue_green\(\)/)
+  assert.match(deployScript, /resume_autoheal_if_paused\(\)/)
+  assert.match(deployScript, /trap 'resume_autoheal_if_paused; release_deploy_lock' EXIT INT TERM/)
+  assert.match(deployScript, /compose stop autoheal/)
+  assert.match(deployScript, /compose up -d autoheal/)
+  assert(pauseCallIndex > 0, "deploy script must call pause_autoheal_for_blue_green before staging")
+  assert(candidateRecreateIndex > 0, "deploy script must recreate the candidate backend")
+  assert(
+    pauseCallIndex < candidateRecreateIndex,
+    "autoheal must be paused before candidate backend force-recreate",
+  )
+})
+
 test("homeserver origin ingress is private behind Cloudflare Tunnel", () => {
   const compose = readFileSync(composePath, "utf8")
   const hardeningScript = readFileSync(hardeningScriptPath, "utf8")


### PR DESCRIPTION
## 관련 이슈

close #655

## 작업 배경

- main deploy run `27359571305`에서 `back_green` candidate가 readiness 도달 전 10~15초 간격으로 재시작되어 CD가 막힌 문제를 수정합니다.
- blue/green candidate backend를 staging하는 동안 autoheal을 잠시 중지하고, deploy script 종료 시 항상 복구해 readiness 대기 중 재시작 간섭을 제거합니다.

## 작업 내용

- `deploy/homeserver/blue_green_deploy.sh`에서 candidate backend force recreate 전에 autoheal을 pause합니다.
- `EXIT/INT/TERM` trap에서 autoheal을 resume하도록 복구 경로를 추가했습니다.
- deploy env contract test에 autoheal pause/resume 순서 회귀 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/test/env-contract.test.mjs`
  - `bash tools/test/verify-deploy-workflow-classification.sh`
  - `bash -n deploy/homeserver/blue_green_deploy.sh`
  - `git diff --check`
  - `CURRENT_TASK_FILE_PATH=.codex/tasks/deploy-back-green-autoheal.local bash tools/guards/check-current-task-state.sh`
  - `CURRENT_TASK_FILE_PATH=.codex/tasks/deploy-back-green-autoheal.local bash tools/guards/check-current-task-scope.sh --worktree`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: blue/green deploy가 진행되는 짧은 구간에는 autoheal이 멈추므로 해당 구간의 자동 재시작이 지연됩니다. deploy script 자체 healthcheck와 rollback은 계속 동작합니다.
- 롤백 방법: 이 PR을 revert하면 기존 autoheal 상시 동작 방식으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
