### PR TITLE
[Fix] back_green deploy 메모리 재시작 차단

### DIFF
--- a/back/src/main/kotlin/com/back/global/jpa/application/ProdSequenceGuardService.kt
+++ b/back/src/main/kotlin/com/back/global/jpa/application/ProdSequenceGuardService.kt
@@ -46,7 +46,7 @@ class ProdSequenceGuardService(
 
     fun repairAllKnownSequences() {
         sequenceTargetsByConstraint.values.distinctBy { it.table }.forEach { target ->
-            repairSequence(target)
+            repairSequenceBySetvalOnly(target)
         }
     }
 
@@ -83,8 +83,17 @@ class ProdSequenceGuardService(
                 )
             }.getOrElse { false }
 
-        if (fullRepairSucceeded || !allowSetvalOnlyFallback) return fullRepairSucceeded
-        return repairSequenceBySetvalOnly(target)
+        if (fullRepairSucceeded) return true
+        return repairSequenceBySetvalOnly(target).also { fallbackSucceeded ->
+            if (!fallbackSucceeded && allowSetvalOnlyFallback) {
+                log.warn(
+                    "setval-only fallback did not repair sequence drift: table={}, sequence={}, allocationSize={}",
+                    target.table,
+                    target.sequence,
+                    target.allocationSize,
+                )
+            }
+        }
     }
 
     private fun repairSequenceBySetvalOnly(target: SequenceTarget): Boolean =

--- a/back/src/test/kotlin/com/back/global/jpa/application/ProdSequenceGuardServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/jpa/application/ProdSequenceGuardServiceTest.kt
@@ -5,12 +5,27 @@ import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.contains
 import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
+import org.springframework.boot.ApplicationArguments
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.jdbc.core.JdbcTemplate
 
 class ProdSequenceGuardServiceTest {
+    @Test
+    fun `startup guard는 owner 권한이 필요한 ALTER 없이 setval만 수행한다`() {
+        val jdbcTemplate = mock(JdbcTemplate::class.java)
+        val service = ProdSequenceGuardService(jdbcTemplate, sequenceGuardOnStartup = true)
+
+        service.run(mock(ApplicationArguments::class.java))
+
+        verify(jdbcTemplate, never()).execute(contains("ALTER SEQUENCE"))
+        verify(jdbcTemplate).execute(
+            "SELECT setval('public.post_seq', COALESCE((SELECT MAX(id) FROM public.post), 0) + 50, false)",
+        )
+    }
+
     @Test
     fun `post_pkey 충돌이면 allocation 정렬 setval로 보정한다`() {
         val jdbcTemplate = mock(JdbcTemplate::class.java)
@@ -78,6 +93,26 @@ class ProdSequenceGuardServiceTest {
         verify(jdbcTemplate).execute("ALTER SEQUENCE IF EXISTS public.uploaded_file_seq INCREMENT BY 1")
         verify(jdbcTemplate).execute(
             "SELECT setval('public.uploaded_file_seq', COALESCE((SELECT MAX(id) FROM public.uploaded_file), 0) + 1, false)",
+        )
+    }
+
+    @Test
+    fun `일반 시퀀스 보정도 ALTER 권한 실패 시 setval-only fallback으로 복구한다`() {
+        val jdbcTemplate = mock(JdbcTemplate::class.java)
+        doThrow(RuntimeException("must be owner of sequence post_seq"))
+            .`when`(jdbcTemplate)
+            .execute(contains("ALTER SEQUENCE IF EXISTS public.post_seq"))
+        val service = ProdSequenceGuardService(jdbcTemplate, sequenceGuardOnStartup = false)
+
+        val repaired =
+            service.repairIfSequenceDrift(
+                DataIntegrityViolationException("duplicate key value violates unique constraint \"post_pkey\""),
+            )
+
+        assertThat(repaired).isTrue()
+        verify(jdbcTemplate).execute("ALTER SEQUENCE IF EXISTS public.post_seq INCREMENT BY 50")
+        verify(jdbcTemplate).execute(
+            "SELECT setval('public.post_seq', COALESCE((SELECT MAX(id) FROM public.post), 0) + 50, false)",
         )
     }
 

--- a/deploy/homeserver/.env.prod.example
+++ b/deploy/homeserver/.env.prod.example
@@ -42,8 +42,8 @@ GRAFANA_ROOT_URL=https://grafana.example.com
 # 배포 시점 자동 메모리 튜너(가드 포함, HOME_SERVER_ENV로 제어 가능)
 # true면 host MemTotal 기준으로 BACK_*_MEM_{LIMIT,RESERVATION}를 자동 산출한다.
 # AUTO_MEMORY_TUNER_ENABLED=true
-# 전체 백엔드 컨테이너 예산 상한(MB). 기본 2816(2.8GB)
-# AUTO_MEMORY_TUNER_MAX_BUDGET_MB=2816
+# 전체 백엔드 컨테이너 예산 상한(MB). 기본 4096(4GB)
+# AUTO_MEMORY_TUNER_MAX_BUDGET_MB=4096
 # 호스트 시스템 예약 메모리(MB). 기본 2048
 # AUTO_MEMORY_TUNER_SYSTEM_RESERVE_MB=2048
 # 자동 산출 최소 예산(MB). 기본 1280 (runtime-split에서는 내부 최소 2048 가드 적용)

--- a/deploy/homeserver/blue_green_deploy.sh
+++ b/deploy/homeserver/blue_green_deploy.sh
@@ -30,7 +30,7 @@ STREAM_DRAIN_SECONDS="${STREAM_DRAIN_SECONDS:-15}"
 RUNTIME_SPLIT_ENABLED="${RUNTIME_SPLIT_ENABLED:-false}"
 RUNTIME_SPLIT_STAGE="${RUNTIME_SPLIT_STAGE:-A}"
 AUTO_MEMORY_TUNER_ENABLED="${AUTO_MEMORY_TUNER_ENABLED:-true}"
-AUTO_MEMORY_TUNER_MAX_BUDGET_MB="${AUTO_MEMORY_TUNER_MAX_BUDGET_MB:-2816}"
+AUTO_MEMORY_TUNER_MAX_BUDGET_MB="${AUTO_MEMORY_TUNER_MAX_BUDGET_MB:-4096}"
 AUTO_MEMORY_TUNER_SYSTEM_RESERVE_MB="${AUTO_MEMORY_TUNER_SYSTEM_RESERVE_MB:-2048}"
 AUTO_MEMORY_TUNER_MIN_BUDGET_MB="${AUTO_MEMORY_TUNER_MIN_BUDGET_MB:-1280}"
 LAST_COMPOSE_UP_SERVICES=""
@@ -107,7 +107,7 @@ RUNTIME_SPLIT_ENABLED="$(normalize_bool "${RUNTIME_SPLIT_ENABLED}")"
 RUNTIME_SPLIT_STAGE="$(normalize_runtime_split_stage "${RUNTIME_SPLIT_STAGE}")"
 STREAM_DRAIN_SECONDS="$(normalize_non_negative_int "${STREAM_DRAIN_SECONDS}" "15")"
 AUTO_MEMORY_TUNER_ENABLED="$(normalize_bool "${AUTO_MEMORY_TUNER_ENABLED}")"
-AUTO_MEMORY_TUNER_MAX_BUDGET_MB="$(normalize_positive_int "${AUTO_MEMORY_TUNER_MAX_BUDGET_MB}" "2816")"
+AUTO_MEMORY_TUNER_MAX_BUDGET_MB="$(normalize_positive_int "${AUTO_MEMORY_TUNER_MAX_BUDGET_MB}" "4096")"
 AUTO_MEMORY_TUNER_SYSTEM_RESERVE_MB="$(normalize_positive_int "${AUTO_MEMORY_TUNER_SYSTEM_RESERVE_MB}" "2048")"
 AUTO_MEMORY_TUNER_MIN_BUDGET_MB="$(normalize_positive_int "${AUTO_MEMORY_TUNER_MIN_BUDGET_MB}" "1280")"
 
@@ -723,7 +723,7 @@ scaled_limit_mb() {
 
 allocate_runtime_split_memory_limits() {
   local budget_mb="$1"
-  local blue_min=384
+  local blue_min=640
   local read_min=512
   local admin_min=512
   local worker_min=512
@@ -827,7 +827,7 @@ apply_auto_memory_tuner() {
   local mode_min_budget_mb=1280
   if [[ "${RUNTIME_SPLIT_ENABLED}" == "true" ]]; then
     mode="runtime-split"
-    mode_min_budget_mb=2304
+    mode_min_budget_mb=3200
   fi
 
   if (( AUTO_MEMORY_TUNER_MAX_BUDGET_MB < mode_min_budget_mb )); then

--- a/deploy/homeserver/blue_green_deploy.sh
+++ b/deploy/homeserver/blue_green_deploy.sh
@@ -733,6 +733,7 @@ allocate_runtime_split_memory_limits() {
   local worker
   local total
 
+  # 2816 is the original runtime-split scaling reference; the active cap is AUTO_MEMORY_TUNER_MAX_BUDGET_MB.
   blue="$(scaled_limit_mb 512 "${budget_mb}" 2816 "${blue_min}")"
   read="$(scaled_limit_mb 640 "${budget_mb}" 2816 "${read_min}")"
   admin="$(scaled_limit_mb 512 "${budget_mb}" 2816 "${admin_min}")"

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -214,6 +214,22 @@ test("blue-green deploy pauses autoheal while staging a candidate backend", () =
   )
 })
 
+test("runtime-split memory tuner keeps backend color startup headroom", () => {
+  const deployScript = readFileSync(deployScriptPath, "utf8")
+  const splitAllocator = deployScript.slice(
+    deployScript.indexOf("allocate_runtime_split_memory_limits()"),
+    deployScript.indexOf("allocate_single_runtime_memory_limits()"),
+  )
+
+  assert.match(
+    deployScript,
+    /AUTO_MEMORY_TUNER_MAX_BUDGET_MB="\$\{AUTO_MEMORY_TUNER_MAX_BUDGET_MB:-4096\}"/,
+  )
+  assert.match(splitAllocator, /local blue_min=640/)
+  assert.match(deployScript, /mode_min_budget_mb=3200/)
+  assert(!splitAllocator.includes("local blue_min=384"))
+})
+
 test("homeserver origin ingress is private behind Cloudflare Tunnel", () => {
   const compose = readFileSync(composePath, "utf8")
   const hardeningScript = readFileSync(hardeningScriptPath, "utf8")


### PR DESCRIPTION
## 관련 이슈

close #655

## 작업 배경

- `back_green` deploy가 runtime-split `448m` backend memory budget에서 `Restarting (137)`로 readiness 전에 죽는 문제를 막습니다.
- 기존 prod 로그의 sequence owner 오류도 startup `ALTER SEQUENCE` 없이 setval-only repair/fallback으로 정리합니다.
- main merge 후 홈서버 자동 CD와 live `/editor/507` canary로 최종 확인합니다.

## 작업 내용

- runtime-split auto-memory tuner의 기본 max budget을 `4096m`로 올리고 backend color별 최소 startup headroom을 `640m`로 고정했습니다.
- env contract test에 runtime-split memory budget 회귀 가드를 추가했습니다.
- `ProdSequenceGuardService` startup repair를 setval-only로 바꾸고, duplicate-key repair에서도 `ALTER SEQUENCE` 권한 실패 시 setval fallback을 수행하게 했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/test/env-contract.test.mjs`
  - `bash -n deploy/homeserver/blue_green_deploy.sh`
  - `./back/gradlew -p back test --tests com.back.global.jpa.application.ProdSequenceGuardServiceTest -PtestInfraMode=none`
  - `./back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back test --tests "com.back.global.springDoc.OpenApiContractExportTest" --no-daemon`
  - `./back/gradlew -p back test`

  초기 `./back/gradlew -p back test`와 commit hook은 로컬 Docker daemon 미기동 및 `docker compose` CLI plugin 미노출로 실패했습니다. Docker Desktop 기동 후 동일 backend 전체 테스트와 hook의 OpenAPI export/contracts check가 통과했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: runtime-split 환경에서 backend/read/admin/worker 컨테이너의 총 memory reservation이 증가합니다. 홈서버 로그 기준 host memory는 runtime-split budget을 감당할 수 있어 `Restarting (137)` 재발 위험을 낮추는 쪽이 우선입니다.
- 롤백 방법: 이 PR revert 후 기존 blue/green deploy script로 되돌립니다. 배포 실패 시 workflow의 기존 rollback 경로가 active backend를 복구합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
