### PR TITLE
[Fix] live admin dashboard 인증 fallback

### DIFF
--- a/front/e2e/admin-bootstrap-state.spec.ts
+++ b/front/e2e/admin-bootstrap-state.spec.ts
@@ -14,7 +14,7 @@ test.describe("admin bootstrap state contract", () => {
 
   test("관리자 글 작업공간은 auth/session 선조회 대신 protected bootstrap으로 first paint를 구성한다", () => {
     const adminPageSource = readFileSync(path.resolve(__dirname, "../src/libs/server/adminPage.ts"), "utf8")
-    const postsSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspacePage.tsx"), "utf8")
+    const postsSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspacePageCommands.ts"), "utf8")
 
     expect(adminPageSource).toContain("export const buildAdminPagePropsFromMember = (")
     expect(adminPageSource).toContain("member: AuthMember,")
@@ -30,8 +30,20 @@ test.describe("admin bootstrap state contract", () => {
     expect(postsSource).toContain('source: "bootstrap"')
   })
 
+  test("protected bootstrap redirect는 auth cookie가 있으면 fallback guard로 검증을 넘긴다", () => {
+    const adminPageSource = readFileSync(path.resolve(__dirname, "../src/libs/server/adminPage.ts"), "utf8")
+
+    expect(adminPageSource).toContain('import { hasServerAuthCookie } from "./authSession"')
+    expect(adminPageSource).toContain("const shouldDeferRedirectToFallback = hasServerAuthCookie(req)")
+    expect(adminPageSource).toMatch(
+      /destination:\s*shouldDeferRedirectToFallback\s*\?\s*null\s*:\s*toLoginPath\(normalizeNextPath\(req\.url, fallbackPath\), fallbackPath\)/
+    )
+    expect(adminPageSource).toMatch(/destination:\s*shouldDeferRedirectToFallback\s*\?\s*null\s*:\s*"\/"/)
+  })
+
   test("운영 진단은 auth/session 선조회 대신 protected bootstrap으로 health summary를 first paint에 주입한다", () => {
     const toolsSource = readFileSync(path.resolve(__dirname, "../src/pages/admin/tools.tsx"), "utf8")
+    const toolsWorkspaceSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminToolsWorkspacePage.tsx"), "utf8")
     const toolsModelSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminToolsWorkspaceModel.ts"), "utf8")
 
     expect(toolsSource).toContain('"/system/api/v1/adm/bootstrap"')
@@ -39,14 +51,14 @@ test.describe("admin bootstrap state contract", () => {
     expect(toolsSource).toContain("baseProps = buildAdminPagePropsFromMember(bootstrapResult.value.value.member)")
     expect(toolsSource).toContain("systemHealth: bootstrapResult.value.value.health")
     expect(toolsSource).toContain('source: "bootstrap"')
-    expect(toolsSource).toContain("const [systemHealthCheckedAt, setSystemHealthCheckedAt] = useState<string | null>(initialSnapshot.systemHealthFetchedAt)")
+    expect(toolsWorkspaceSource).toContain("const [systemHealthCheckedAt, setSystemHealthCheckedAt] = useState<string | null>(initialSnapshot.systemHealthFetchedAt)")
     expect(toolsSource).toContain("formatInstant,")
     expect(toolsSource).toContain("getFreshnessMeta,")
     expect(toolsModelSource).toContain('export const ADMIN_TOOLS_DISPLAY_TIME_ZONE = "Asia/Seoul"')
     expect(toolsModelSource).toContain("timeZone: ADMIN_TOOLS_DISPLAY_TIME_ZONE")
-    expect(toolsSource).toContain("const [freshnessClock, setFreshnessClock] = useState<number | null>(null)")
-    expect(toolsSource).toContain("const systemHealthFreshness = getFreshnessMeta(systemHealthCheckedAt, freshnessClock)")
-    expect(toolsSource).toContain("const systemHealthFetchedAt = systemHealthCheckedAt ? formatInstant(systemHealthCheckedAt) : \"-\"")
+    expect(toolsWorkspaceSource).toContain("const [freshnessClock, setFreshnessClock] = useState<number | null>(null)")
+    expect(toolsWorkspaceSource).toContain("const systemHealthFreshness = getFreshnessMeta(systemHealthCheckedAt, freshnessClock)")
+    expect(toolsWorkspaceSource).toContain("const systemHealthFetchedAt = systemHealthCheckedAt ? formatInstant(systemHealthCheckedAt) : \"-\"")
   })
 
   test("운영 대시보드는 auth/session 선조회 대신 protected bootstrap으로 health summary를 first paint에 주입한다", () => {

--- a/front/src/libs/server/adminPage.ts
+++ b/front/src/libs/server/adminPage.ts
@@ -8,6 +8,7 @@ import { createQueryClient } from "src/libs/react-query"
 import { normalizeNextPath, toLoginPath } from "src/libs/router"
 import { serverApiFetch } from "./backend"
 import { guardAdminRequest } from "./adminGuard"
+import { hasServerAuthCookie } from "./authSession"
 import {
   buildStaticAdminProfileSnapshot,
   fetchServerAdminProfile,
@@ -80,16 +81,19 @@ export const readAdminProtectedBootstrap = async <T>(
 ): Promise<AdminProtectedBootstrapResult<T>> => {
   try {
     const response = await serverApiFetch(req, path)
+    const shouldDeferRedirectToFallback = hasServerAuthCookie(req)
     if (response.status === 401) {
       return {
         ok: false,
-        destination: toLoginPath(normalizeNextPath(req.url, fallbackPath), fallbackPath),
+        destination: shouldDeferRedirectToFallback
+          ? null
+          : toLoginPath(normalizeNextPath(req.url, fallbackPath), fallbackPath),
       }
     }
     if (response.status === 403) {
       return {
         ok: false,
-        destination: "/",
+        destination: shouldDeferRedirectToFallback ? null : "/",
       }
     }
     if (!response.ok) {


### PR DESCRIPTION
## 관련 이슈

close #655

## 작업 배경

- main deploy run `27366135878`에서 backend `blueGreenDeploy`와 live `/editor/507` canary는 통과했지만, live admin flow가 `/admin/dashboard`에서 login redirect로 실패했습니다.
- auth cookie가 있는 SSR protected bootstrap 401/403은 즉시 redirect로 확정하지 않고 `getAdminPageProps` fallback guard가 최종 인증/권한을 판정하도록 보강했습니다.

## 작업 내용

- `readAdminProtectedBootstrap`이 auth cookie가 있는 요청에서는 bootstrap 401/403 redirect를 defer해 dashboard/tools/posts/editor 등 admin SSR fallback이 동작할 수 있게 했습니다.
- `admin-bootstrap-state` 계약 테스트에 fallback guard 위임 계약을 추가했고, 실제 SSR command/workspace 파일 경로에 맞게 기존 source contract를 정리했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_USE_WEBSERVER=false PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-bootstrap-state.spec.ts` (RED 확인 후 GREEN 2회 통과)
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front test:e2e:smoke`
  - `CURRENT_TASK_FILE_PATH=.codex/tasks/deploy-back-green-autoheal.local bash tools/guards/check-current-task-state.sh`
  - `CURRENT_TASK_FILE_PATH=.codex/tasks/deploy-back-green-autoheal.local bash tools/guards/check-current-task-scope.sh --worktree`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: bootstrap endpoint가 실제 권한 실패를 반환해도 fallback guard가 한 번 더 `/member/api/v1/auth/session`을 확인하므로 SSR 요청이 1회 늘 수 있습니다.
- 롤백 방법: 이 PR의 commit을 revert하면 protected bootstrap 401/403 즉시 redirect 동작으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
