### PR TITLE
[Fix] 에디터 serializer review edge case 보강

### DIFF
--- a/front/e2e/block-editor-serialization.spec.ts
+++ b/front/e2e/block-editor-serialization.spec.ts
@@ -492,6 +492,48 @@ test.describe("block editor serialization", () => {
     expect(reparsed.content?.[0]?.content).toEqual([{ type: "text", text: "15~60분" }])
   })
 
+  test("escaped block marker 문단은 저장 후에도 block 으로 재해석되지 않는다", () => {
+    const markdown = [
+      String.raw`\# not a heading`,
+      String.raw`\- not a bullet`,
+      String.raw`\+ not a bullet`,
+      String.raw`1\. not ordered`,
+      String.raw`1234567890\. not ordered`,
+      String.raw`\> not quote`,
+      String.raw`\>todo`,
+    ].join("\n\n")
+
+    const doc = parseMarkdownToEditorDoc(markdown)
+    const serialized = serializeEditorDocToMarkdown(doc)
+    const reparsed = parseMarkdownToEditorDoc(serialized)
+
+    expect(serialized).toContain(String.raw`\# not a heading`)
+    expect(serialized).toContain(String.raw`\- not a bullet`)
+    expect(serialized).toContain(String.raw`\+ not a bullet`)
+    expect(serialized).toContain(String.raw`1\. not ordered`)
+    expect(serialized).toContain(String.raw`1234567890\. not ordered`)
+    expect(serialized).toContain(String.raw`\> not quote`)
+    expect(serialized).toContain(String.raw`\>todo`)
+    expect(reparsed.content?.map((node) => node.type)).toEqual([
+      "paragraph",
+      "paragraph",
+      "paragraph",
+      "paragraph",
+      "paragraph",
+      "paragraph",
+      "paragraph",
+    ])
+    expect(reparsed.content?.map((node) => node.content?.[0]?.text)).toEqual([
+      "# not a heading",
+      "- not a bullet",
+      "+ not a bullet",
+      "1. not ordered",
+      "1234567890. not ordered",
+      "> not quote",
+      ">todo",
+    ])
+  })
+
   test("mark 내부 escaped inline text 는 reload 후 원문 text 로 복구된다", () => {
     const doc = {
       type: "doc",
@@ -723,6 +765,23 @@ test.describe("block editor serialization", () => {
     const reparsedCellNode = reparsedTableRow?.content?.[1]?.content?.[0]?.content?.[0]
 
     expect(reparsedCellNode).toEqual({ type: "text", text: String.raw`\* and \$` })
+  })
+
+  test("compact GFM 테이블은 짝수 backslash 뒤 pipe 를 셀 구분자로 처리한다", () => {
+    const markdown = [String.raw`| 항목 | 값 |`, String.raw`| --- | --- |`, String.raw`| 경로 \\| next |`].join("\n")
+
+    const doc = parseMarkdownToEditorDoc(markdown)
+    const tableRow = doc.content?.[0]?.content?.[1]
+    const firstCellText = tableRow?.content?.[0]?.content?.[0]?.content?.[0]?.text
+    const secondCellText = tableRow?.content?.[1]?.content?.[0]?.content?.[0]?.text
+    const serialized = serializeEditorDocToMarkdown(doc)
+    const reparsed = parseMarkdownToEditorDoc(serialized)
+    const reparsedRow = reparsed.content?.[0]?.content?.[1]
+
+    expect(firstCellText).toBe("경로 \\")
+    expect(secondCellText).toBe("next")
+    expect(reparsedRow?.content?.[0]?.content?.[0]?.content?.[0]?.text).toBe("경로 \\")
+    expect(reparsedRow?.content?.[1]?.content?.[0]?.content?.[0]?.text).toBe("next")
   })
 
   test("정렬 지정 GFM 테이블은 table block 으로 승격되고 정렬 메타를 유지한다", () => {

--- a/front/e2e/editor-authoring-selection-drag.spec.ts
+++ b/front/e2e/editor-authoring-selection-drag.spec.ts
@@ -630,11 +630,25 @@ test.describe("editor authoring route text selection drag", () => {
     await finalTable.scrollIntoViewIfNeeded()
     const startPoints = await getWordDragPoints(startCell, "영역")
     const endPoints = await getWordDragPoints(endCell, "구현되어 있는가")
+    const endCellBox = await expectVisibleBox(endCell, "table multi-cell drag end cell metrics are missing")
+    const endDragX = Math.min(
+      endCellBox.x + endCellBox.width - 10,
+      Math.max(endPoints.endX, endCellBox.x + endCellBox.width * 0.82)
+    )
+    const endDragY = Math.min(
+      endCellBox.y + endCellBox.height - 8,
+      Math.max(endPoints.endY, endCellBox.y + endCellBox.height * 0.62)
+    )
     const beforeScrollTop = await page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
 
     await page.mouse.move(startPoints.startX, startPoints.startY)
     await page.mouse.down()
-    await page.mouse.move(endPoints.endX, endPoints.endY, { steps: 36 })
+    await page.mouse.move(
+      (startPoints.startX + endDragX) / 2,
+      (startPoints.startY + endDragY) / 2,
+      { steps: 18 }
+    )
+    await page.mouse.move(endDragX, endDragY, { steps: 36 })
     await page.mouse.up()
 
     await expect

--- a/front/e2e/helpers/editorAuthoringFlow.ts
+++ b/front/e2e/helpers/editorAuthoringFlow.ts
@@ -7,9 +7,14 @@ export const QA_ROUTE_PURPOSE =
   "auxiliary-only: QA routes are for isolated helper/unit smoke coverage, not editor user-bug close gates"
 export const UNDO_SHORTCUT = process.platform === "darwin" ? "Meta+z" : "Control+z"
 
-export const expectVisibleBox = async (locator: Locator, errorMessage: string) => {
+type VisibleBoundingBox = NonNullable<Awaited<ReturnType<Locator["boundingBox"]>>>
+
+export const expectVisibleBox = async (
+  locator: Locator,
+  errorMessage: string
+): Promise<VisibleBoundingBox> => {
   await expect(locator).toBeVisible({ timeout: 15_000 })
-  let visibleBox: Awaited<ReturnType<Locator["boundingBox"]>> | null = null
+  let visibleBox: VisibleBoundingBox | null = null
   await expect
     .poll(
       async () => {

--- a/front/src/components/editor/serializationInlineNormalization.ts
+++ b/front/src/components/editor/serializationInlineNormalization.ts
@@ -26,6 +26,8 @@ const MARKDOWN_ESCAPABLE_INLINE_CHARS = new Set([
 const INLINE_PATTERN_PREFIXES = ["{{", "[", "**", "~~", "`", "$", "*"]
 const MARKDOWN_ESCAPE_PATTERN = /[\\`*_{}\[\]()!$]/g
 const MARKDOWN_TILDE_RUN_PATTERN = /~{2,}/g
+const MARKDOWN_ORDERED_BLOCK_START_PATTERN = /^( {0,3})(\d+)(\.)(?=\s|$)/
+const MARKDOWN_DIVIDER_BLOCK_START_PATTERN = /^( {0,3})(-)(?:\s*-){2,}\s*$/
 
 const isEscapedMarkdownCharacter = (character: string | undefined) =>
   Boolean(character && MARKDOWN_ESCAPABLE_INLINE_CHARS.has(character))
@@ -39,6 +41,31 @@ export const escapeMarkdownInlineText = (text: string) =>
 
 export const unescapeMarkdownInlineText = (text: string) =>
   text.replace(/\\([\\`*_{}\[\]()!$~>#+\-.])/g, "$1")
+
+const escapeMarkdownBlockStartLine = (line: string) => {
+  if (MARKDOWN_DIVIDER_BLOCK_START_PATTERN.test(line)) {
+    return line.replace(/^( {0,3})(-)/, "$1\\$2")
+  }
+  if (/^( {0,3})(#{1,6})(?=\s|$)/.test(line)) {
+    return line.replace(/^( {0,3})(#)/, "$1\\$2")
+  }
+  if (/^( {0,3})([-+])(?=\s|$)/.test(line)) {
+    return line.replace(/^( {0,3})([-+])/, "$1\\$2")
+  }
+  if (MARKDOWN_ORDERED_BLOCK_START_PATTERN.test(line)) {
+    return line.replace(
+      MARKDOWN_ORDERED_BLOCK_START_PATTERN,
+      "$1$2\\$3"
+    )
+  }
+  if (/^(\s*)(>)/.test(line)) {
+    return line.replace(/^(\s*)(>)/, "$1\\$2")
+  }
+  return line
+}
+
+const escapeMarkdownBlockStartText = (text: string) =>
+  text.split("\n").map(escapeMarkdownBlockStartLine).join("\n")
 
 const getMaxBacktickRun = (text: string) =>
   (text.match(/`+/g) || []).reduce(
@@ -336,5 +363,5 @@ export const serializeInlineContent = (content?: JSONContent[]) =>
 
 export const serializeParagraphLikeNode = (node: JSONContent) => {
   if (!node.content || node.content.length === 0) return ""
-  return serializeInlineContent(node.content)
+  return escapeMarkdownBlockStartText(serializeInlineContent(node.content))
 }

--- a/front/src/components/editor/serializationTableMetadata.ts
+++ b/front/src/components/editor/serializationTableMetadata.ts
@@ -35,15 +35,22 @@ export const splitTableCells = (line: string) => {
 
   for (let index = 0; index < trimmed.length; index += 1) {
     const character = trimmed[index]
-    const nextCharacter = trimmed[index + 1]
-
-    if (character === "\\" && nextCharacter === "|") {
-      current += "|"
-      index += 1
-      continue
-    }
 
     if (character === "|") {
+      let backslashRunLength = 0
+      for (
+        let cursor = current.length - 1;
+        cursor >= 0 && current[cursor] === "\\";
+        cursor -= 1
+      ) {
+        backslashRunLength += 1
+      }
+
+      if (backslashRunLength % 2 === 1) {
+        current = `${current.slice(0, -1)}|`
+        continue
+      }
+
       cells.push(current.trim())
       current = ""
       continue

--- a/front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts
+++ b/front/src/components/editor/useBlockEditorTableOverlayAxisDrag.ts
@@ -15,6 +15,7 @@ import type {
 } from "react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { BLOCK_SELECTION_CONTROL_SELECTOR } from "./blockSelectionModel"
+import { preserveWindowScrollPositionAcrossFrames } from "./blockHandleLayoutModel"
 import type { TableAffordanceGeometry } from "./tableAffordanceModel"
 import {
   type DraggedTableAxisState,
@@ -64,9 +65,15 @@ const TABLE_AXIS_POINTER_TABLE_MATCH_MARGIN_PX = 96
 const TABLE_AXIS_POINTER_TABLE_EDGE_TOLERANCE_PX = 12
 const TABLE_AXIS_SELECTION_SINK_ID = "aq-table-axis-selection-sink"
 const TABLE_AXIS_FOCUS_SCROLL_PRESERVE_MS = 240
+const TABLE_AXIS_TEXT_SELECTION_SCROLL_PRESERVE_MS = 1_400
 const TABLE_AXIS_FOCUS_SCROLL_TOLERANCE_PX = 4
+const TABLE_AXIS_TEXT_SELECTION_SCROLL_PRESERVE_FRAMES = 96
+type TableAxisFocusScrollPreserveMode = "brief" | "text-selection"
 
-type SelectTableAxisOptions = { clearNativeText?: boolean }
+type SelectTableAxisOptions = {
+  clearNativeText?: boolean
+  scrollPreserveMode?: TableAxisFocusScrollPreserveMode
+}
 type ClearNativeTableTextSelectionOptions = { restoreCellSelection?: boolean }
 type RenderedTableSelectionTarget = {
   renderedTable: HTMLTableElement
@@ -92,7 +99,9 @@ const resolveTableAxisSelectionSink = () => {
   return selectionSink
 }
 
-const preserveTableAxisFocusScrollBriefly = () => {
+const preserveTableAxisFocusScrollBriefly = (
+  mode: TableAxisFocusScrollPreserveMode = "brief"
+) => {
   if (typeof window === "undefined") return
   const scrollingElement = document.scrollingElement
   const startX = window.scrollX
@@ -101,18 +110,52 @@ const preserveTableAxisFocusScrollBriefly = () => {
   let cancelled = false
   let intervalId: number | null = null
   let rafId: number | null = null
+  const cancelActiveScrollPreserve =
+    mode === "text-selection"
+      ? preserveWindowScrollPositionAcrossFrames(
+          { x: startX, y: startY },
+          TABLE_AXIS_TEXT_SELECTION_SCROLL_PRESERVE_FRAMES,
+          TABLE_AXIS_FOCUS_SCROLL_TOLERANCE_PX,
+          TABLE_AXIS_TEXT_SELECTION_SCROLL_PRESERVE_MS,
+          false,
+          false,
+          false,
+          false,
+          false,
+          undefined,
+          true,
+          Number.POSITIVE_INFINITY,
+          "table-axis"
+        )
+      : undefined
 
   const restoreScrollPosition = () => {
     const currentY = Math.round(scrollingElement?.scrollTop ?? window.scrollY)
-    if (Math.abs(currentY - startY) <= TABLE_AXIS_FOCUS_SCROLL_TOLERANCE_PX)
+    const shouldRestoreX =
+      Math.abs(window.scrollX - startX) > TABLE_AXIS_FOCUS_SCROLL_TOLERANCE_PX
+    const shouldRestoreY =
+      Math.abs(currentY - startY) > TABLE_AXIS_FOCUS_SCROLL_TOLERANCE_PX
+    if (!shouldRestoreX && !shouldRestoreY)
       return
+    if (mode === "text-selection") {
+      try {
+        window.scrollTo({
+          behavior: "instant" as ScrollBehavior,
+          left: startX,
+          top: startY,
+        })
+      } catch {
+        window.scrollTo(startX, startY)
+      }
+    }
     if (scrollingElement) {
       scrollingElement.scrollTop = startY
+      scrollingElement.scrollLeft = startX
     } else {
       document.documentElement.scrollTop = startY
       document.body.scrollTop = startY
     }
-    if (Math.abs(window.scrollX - startX) > TABLE_AXIS_FOCUS_SCROLL_TOLERANCE_PX) {
+    if (shouldRestoreX) {
       document.documentElement.scrollLeft = startX
       document.body.scrollLeft = startX
     }
@@ -125,10 +168,15 @@ const preserveTableAxisFocusScrollBriefly = () => {
     window.removeEventListener("keydown", cleanup, true)
     if (intervalId !== null) window.clearInterval(intervalId)
     if (rafId !== null) window.cancelAnimationFrame(rafId)
+    cancelActiveScrollPreserve?.()
   }
   const tick = () => {
     if (cancelled) return
-    if (getTableAxisMenuNow() - startedAt > TABLE_AXIS_FOCUS_SCROLL_PRESERVE_MS) {
+    const preserveMs =
+      mode === "text-selection"
+        ? TABLE_AXIS_TEXT_SELECTION_SCROLL_PRESERVE_MS
+        : TABLE_AXIS_FOCUS_SCROLL_PRESERVE_MS
+    if (getTableAxisMenuNow() - startedAt > preserveMs) {
       cleanup()
       return
     }
@@ -150,9 +198,51 @@ const preserveTableAxisFocusScrollBriefly = () => {
   })
   window.addEventListener("pointerdown", cleanup, { capture: true, once: true })
   window.addEventListener("keydown", cleanup, { capture: true, once: true })
-  intervalId = window.setInterval(restoreScrollPosition, 8)
+  intervalId = window.setInterval(
+    restoreScrollPosition,
+    mode === "text-selection" ? 4 : 8
+  )
   rafId = window.requestAnimationFrame(tick)
+  return restoreScrollPosition
 }
+
+const hasActiveTableTextSelectionForAxisDrag = () => {
+  if (typeof document === "undefined" || typeof window === "undefined")
+    return false
+  if (
+    document.documentElement
+      .getAttribute(TABLE_DRAG_SELECTION_TEXT_ATTR)
+      ?.trim()
+  )
+    return true
+  if (document.querySelector(TABLE_DRAG_SELECTION_TEXT_SELECTOR)) return true
+  return Boolean(window.getSelection()?.toString().trim())
+}
+
+const isCurrentCellSelectionSingleAxis = (editor: TiptapEditor) => {
+  if (!(editor.state.selection instanceof CellSelection)) return false
+  try {
+    const rect = selectedRect(editor.state)
+    const isRowAxis =
+      rect.left === 0 &&
+      rect.right === rect.map.width &&
+      rect.bottom === rect.top + 1
+    const isColumnAxis =
+      rect.top === 0 &&
+      rect.bottom === rect.map.height &&
+      rect.right === rect.left + 1
+    return isRowAxis || isColumnAxis
+  } catch {
+    return false
+  }
+}
+
+const shouldPreserveTableAxisTextSelectionScroll = (
+  editor: TiptapEditor
+) =>
+  hasActiveTableTextSelectionForAxisDrag() ||
+  (editor.state.selection instanceof CellSelection &&
+    !isCurrentCellSelectionSingleAxis(editor))
 
 type UseBlockEditorTableOverlayAxisDragArgs = {
   cancelTableQuickRailHide: () => void
@@ -636,12 +726,19 @@ export const useBlockEditorTableOverlayAxisDrag = ({
       const anchorResolved = resolveDocPosSafe(activeEditor, anchorCellPos)
       const headResolved = resolveDocPosSafe(activeEditor, headCellPos)
       if (!anchorResolved || !headResolved) return false
+      const scrollPreserveMode =
+        options.scrollPreserveMode ??
+        (shouldPreserveTableAxisTextSelectionScroll(activeEditor)
+          ? "text-selection"
+          : "brief")
       clearStickyTopLevelBlockSelection()
       clearTableTextSelectionForStructuralSelection()
       focusElementWithoutScroll(activeEditor.view.dom)
       clearEditorMouseDownSelectionSyncDeferral(activeEditor)
       tableAxisMenuStabilizationTokenRef.current += 1
-      preserveTableAxisFocusScrollBriefly()
+      const restoreAxisFocusScroll = preserveTableAxisFocusScrollBriefly(
+        scrollPreserveMode
+      )
       activeEditor.view.dispatch(
         activeEditor.state.tr
           .setSelection(
@@ -652,6 +749,7 @@ export const useBlockEditorTableOverlayAxisDrag = ({
           .setMeta(tableEditingKey, anchorResolved.pos)
       )
       activeEditor.view.dom.blur()
+      restoreAxisFocusScroll?.()
       setTableAffordanceGeometry((prev) =>
         isColumn
           ? { ...prev, columnIndex: axisIndex }
@@ -936,6 +1034,10 @@ export const useBlockEditorTableOverlayAxisDrag = ({
         setTableAffordanceGeometry(sourceGeometry)
       }
 
+      const scrollPreserveMode: TableAxisFocusScrollPreserveMode =
+        shouldPreserveTableAxisTextSelectionScroll(currentEditor)
+          ? "text-selection"
+          : "brief"
       clearStructuralSelectionNativeText()
       markTableStructuralSelectionOwner(1_200)
       clearPendingTableAxisDrag()
@@ -957,7 +1059,15 @@ export const useBlockEditorTableOverlayAxisDrag = ({
         index: resolvedSourceIndex,
         tablePos,
       }
-      selectTableAxisAtIndex(currentEditor, tablePos, axis, resolvedSourceIndex)
+      selectTableAxisAtIndex(
+        currentEditor,
+        tablePos,
+        axis,
+        resolvedSourceIndex,
+        {
+          scrollPreserveMode,
+        }
+      )
 
       const DRAG_THRESHOLD_PX = 5
       let activeDragState: Exclude<DraggedTableAxisState, null> | null = null
@@ -1049,6 +1159,11 @@ export const useBlockEditorTableOverlayAxisDrag = ({
         }
         const completedClick = completeClickWithoutDrag?.() ?? false
         if (completedClick) {
+          const restoreCompletedAxisScroll =
+            scrollPreserveMode === "text-selection"
+              ? preserveTableAxisFocusScrollBriefly("text-selection")
+              : undefined
+          restoreCompletedAxisScroll?.()
           markTableStructuralSelectionOwner(1_200)
           const stabilizationToken = tableAxisMenuStabilizationTokenRef.current
           const stabilizationGeneration =


### PR DESCRIPTION
## 관련 이슈

close #660

## 작업 배경

- CodexReview follow-up에서 확인된 escaped block marker 저장 손실, compact GFM table backslash parity 오류, `/editor/507` 하단 table-wide Cmd/Ctrl+A 이후 row grip scroll jump를 수정합니다.
- 공백 없는 `\>todo` 같은 literal blockquote marker도 paragraph로 round-trip 되고, table 축 선택은 긴 본문 하단에서도 scroll anchor를 유지합니다.

## 작업 내용

- paragraph serializer가 parser block-start 규칙과 맞게 `#`, list marker, 긴 ordered marker, 공백 없는 `>` marker를 다시 escape합니다.
- table splitter가 pipe 직전 backslash run parity를 판정해 escaped pipe와 실제 delimiter를 구분합니다.
- `/editor/507` table-wide Cmd/Ctrl+A 후 row/column grip 축 선택에서 `CellSelection` 상태와 click completion 재선택 모두 strong scroll preserve owner를 유지합니다.
- multi-cell drag hit-point와 `expectVisibleBox` helper 타입 계약을 보강해 긴 본문 하단 선택 회귀 테스트를 안정화했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/block-editor-serialization.spec.ts --grep "escaped block marker" --workers=1` → 1 passed
  - `yarn --cwd front playwright test e2e/block-editor-serialization.spec.ts --workers=1` → 43 passed
  - `yarn --cwd front playwright test e2e/editor-authoring-route-table-axis-after-select-all.spec.ts --grep "table-wide Cmd/Ctrl\\+A 직후 row grip" --workers=1` → 1 passed
  - `yarn --cwd front playwright test e2e/editor-authoring-route-table-axis-after-select-all.spec.ts --workers=1` → 6 passed
  - `yarn --cwd front playwright test e2e/editor-audit-open-issues-status.spec.ts e2e/editor-source-flush-contract.spec.ts e2e/block-editor-serialization.spec.ts e2e/editor-authoring-route-table-axis-after-select-all.spec.ts e2e/editor-authoring-selection-drag.spec.ts --workers=1` → 60 passed
  - `yarn --cwd front test:e2e:authoring` → 170 passed, 2회 연속
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `yarn --cwd front test:e2e:smoke` → 57 passed, 2회 연속
  - `yarn --cwd front tsc --noEmit --pretty false` → 기존 e2e 타입 부채로 실패, 새 `expectVisibleBox` `never` 오류는 재현되지 않음
  - `codex review --commit HEAD` → actionable correctness issue 0건, PR review comment로 기록
  - PR checks → `frontend-ci`, `backend-ci`, Vercel preview 통과 (`CodeRabbit`은 usage limit으로 review skipped)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: line-start markdown escape가 추가되어 저장 markdown에 backslash가 보강될 수 있습니다. 렌더/재파싱 결과는 기존 사용자 텍스트 보존 방향입니다.
- 롤백 방법: 이 PR의 단일 커밋 `c464dbed`를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
