### PR TITLE
[Feat] 관리자 전용 클라우드 백엔드

### DIFF
--- a/back/config/jacoco-coverage-baseline-excludes.txt
+++ b/back/config/jacoco-coverage-baseline-excludes.txt
@@ -175,6 +175,7 @@ com/back/global/security/domain/SecurityUser.class
 com/back/global/security/model/AuthSecurityEvent.class
 com/back/global/storage/application/UploadedFileRetentionService.class
 com/back/global/storage/application/UploadedFileUrlCodec.class
+com/back/global/storage/adapter/CloudStorageAdapter.class
 com/back/global/storage/model/UploadedFile.class
 com/back/global/system/adapter/web/ApiV1AdmSystemController$SearchEngineMirrorForceDisableRequest.class
 com/back/global/system/adapter/web/ApiV1AdmSystemController$SearchPipelineForceControlRequest.class

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/persistence/CloudFileRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/persistence/CloudFileRepository.kt
@@ -1,0 +1,51 @@
+package com.back.boundedContexts.cloud.adapter.persistence
+
+import com.back.boundedContexts.cloud.application.port.output.CloudFileRepositoryPort
+import com.back.boundedContexts.cloud.model.CloudFile
+import com.back.boundedContexts.cloud.model.CloudFileMediaKind
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface CloudFileRepository :
+    JpaRepository<CloudFile, Long>,
+    CloudFileRepositoryPort {
+    @Query(
+        """
+        SELECT f
+        FROM CloudFile f
+        WHERE f.ownerMemberId = :ownerMemberId
+          AND f.deletedAt IS NULL
+          AND (:folderPath IS NULL OR f.folderPath = :folderPath)
+          AND (:keyword IS NULL OR LOWER(f.originalFilename) LIKE LOWER(CONCAT('%', :keyword, '%')))
+          AND (:mediaKind IS NULL OR f.mediaKind = :mediaKind)
+        ORDER BY f.createdAt DESC, f.id DESC
+        """,
+    )
+    override fun findActiveByOwner(
+        @Param("ownerMemberId")
+        ownerMemberId: Long,
+        @Param("folderPath")
+        folderPath: String?,
+        @Param("keyword")
+        keyword: String?,
+        @Param("mediaKind")
+        mediaKind: CloudFileMediaKind?,
+    ): List<CloudFile>
+
+    @Query(
+        """
+        SELECT f
+        FROM CloudFile f
+        WHERE f.id = :id
+          AND f.ownerMemberId = :ownerMemberId
+          AND f.deletedAt IS NULL
+        """,
+    )
+    override fun findActiveByIdAndOwner(
+        @Param("id")
+        id: Long,
+        @Param("ownerMemberId")
+        ownerMemberId: Long,
+    ): CloudFile?
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudController.kt
@@ -6,6 +6,7 @@ import com.back.boundedContexts.cloud.model.CloudFileMediaKind
 import com.back.global.exception.application.AppException
 import com.back.global.rsData.RsData
 import com.back.global.security.domain.SecurityUser
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.constraints.Positive
 import org.springframework.core.io.InputStreamResource
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import java.io.EOFException
@@ -63,6 +65,8 @@ class ApiV1AdmCloudController(
         )
 
     @PostMapping("/files", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @ApiResponse(responseCode = "201", description = "Created")
+    @ResponseStatus(HttpStatus.CREATED)
     fun upload(
         @AuthenticationPrincipal securityUser: SecurityUser,
         @RequestPart("file") file: MultipartFile,
@@ -117,7 +121,7 @@ class ApiV1AdmCloudController(
         // 동영상 seek 호환을 위해 단일 byte range만 허용하고 multi-range는 거절한다.
         if (!rangeHeader.isNullOrBlank()) {
             if (totalLength <= 0) {
-                storedObject.inputStream.close()
+                storedObject.close()
                 return noStoreHeaders(
                     ResponseEntity
                         .status(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
@@ -127,7 +131,7 @@ class ApiV1AdmCloudController(
 
             val range = parseSingleRange(rangeHeader, totalLength)
             if (range == null) {
-                storedObject.inputStream.close()
+                storedObject.close()
                 return noStoreHeaders(
                     ResponseEntity
                         .status(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE)

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudController.kt
@@ -1,0 +1,290 @@
+package com.back.boundedContexts.cloud.adapter.web
+
+import com.back.boundedContexts.cloud.application.service.CloudFileDto
+import com.back.boundedContexts.cloud.application.service.CloudFileService
+import com.back.boundedContexts.cloud.model.CloudFileMediaKind
+import com.back.global.exception.application.AppException
+import com.back.global.rsData.RsData
+import com.back.global.security.domain.SecurityUser
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.constraints.Positive
+import org.springframework.core.io.InputStreamResource
+import org.springframework.core.io.Resource
+import org.springframework.http.ContentDisposition
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+import java.io.EOFException
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
+
+@Validated
+@RestController
+@RequestMapping("/system/api/v1/adm/cloud")
+class ApiV1AdmCloudController(
+    private val cloudFileService: CloudFileService,
+) {
+    data class CloudFileListResBody(
+        val files: List<CloudFileDto>,
+    )
+
+    @GetMapping("/files")
+    @Transactional(readOnly = true)
+    fun listFiles(
+        @AuthenticationPrincipal securityUser: SecurityUser,
+        @RequestParam(defaultValue = "")
+        folderPath: String,
+        @RequestParam(defaultValue = "")
+        kw: String,
+        @RequestParam(required = false)
+        mediaKind: CloudFileMediaKind?,
+    ): CloudFileListResBody =
+        CloudFileListResBody(
+            files =
+                cloudFileService.listFiles(
+                    ownerMemberId = securityUser.id,
+                    folderPath = folderPath.trim().takeIf(String::isNotBlank),
+                    keyword = kw,
+                    mediaKind = mediaKind,
+                ),
+        )
+
+    @PostMapping("/files", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    fun upload(
+        @AuthenticationPrincipal securityUser: SecurityUser,
+        @RequestPart("file") file: MultipartFile,
+        @RequestParam(defaultValue = "")
+        folderPath: String,
+    ): ResponseEntity<RsData<CloudFileDto>> {
+        val uploaded =
+            cloudFileService.upload(
+                ownerMemberId = securityUser.id,
+                originalFilename = file.originalFilename,
+                contentType = file.contentType,
+                bytes = file.bytes,
+                folderPath = folderPath,
+            )
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(RsData("201-1", "클라우드 파일이 업로드되었습니다.", uploaded))
+    }
+
+    @GetMapping("/files/{id}")
+    @Transactional(readOnly = true)
+    fun getFile(
+        @AuthenticationPrincipal securityUser: SecurityUser,
+        @PathVariable
+        @Positive
+        id: Long,
+    ): CloudFileDto =
+        cloudFileService.get(
+            ownerMemberId = securityUser.id,
+            fileId = id,
+        )
+
+    @GetMapping("/files/{id}/content")
+    @Transactional(readOnly = true)
+    fun content(
+        @AuthenticationPrincipal securityUser: SecurityUser,
+        @PathVariable
+        @Positive
+        id: Long,
+        request: HttpServletRequest,
+    ): ResponseEntity<Resource> {
+        val content =
+            cloudFileService.openContent(
+                ownerMemberId = securityUser.id,
+                fileId = id,
+            )
+        val storedObject = content.storedObject
+        val totalLength = storedObject.contentLength ?: -1
+        val rangeHeader = request.getHeader(HttpHeaders.RANGE)
+
+        // 동영상 seek 호환을 위해 단일 byte range만 허용하고 multi-range는 거절한다.
+        if (!rangeHeader.isNullOrBlank()) {
+            if (totalLength <= 0) {
+                storedObject.inputStream.close()
+                return noStoreHeaders(
+                    ResponseEntity
+                        .status(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
+                        .header(HttpHeaders.CONTENT_RANGE, "bytes */*"),
+                ).build()
+            }
+
+            val range = parseSingleRange(rangeHeader, totalLength)
+            if (range == null) {
+                storedObject.inputStream.close()
+                return noStoreHeaders(
+                    ResponseEntity
+                        .status(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
+                        .header(HttpHeaders.CONTENT_RANGE, "bytes */$totalLength"),
+                ).build()
+            }
+
+            return noStoreHeaders(
+                ResponseEntity
+                    .status(HttpStatus.PARTIAL_CONTENT)
+                    .contentType(safeMediaType(storedObject.contentType))
+                    .header(HttpHeaders.ACCEPT_RANGES, "bytes")
+                    .header(HttpHeaders.CONTENT_RANGE, "bytes ${range.first}-${range.last}/$totalLength")
+                    .header(HttpHeaders.CONTENT_DISPOSITION, inlineDisposition(content.file.originalFilename))
+                    .contentLength(range.last - range.first + 1),
+            ).body(InputStreamResource(sliceStream(storedObject.inputStream, range)))
+        }
+
+        val responseBuilder =
+            noStoreHeaders(
+                ResponseEntity
+                    .ok()
+                    .contentType(safeMediaType(storedObject.contentType))
+                    .header(HttpHeaders.ACCEPT_RANGES, "bytes")
+                    .header(HttpHeaders.CONTENT_DISPOSITION, inlineDisposition(content.file.originalFilename)),
+            )
+        val finalizedBuilder =
+            totalLength
+                .takeIf { it >= 0 }
+                ?.let(responseBuilder::contentLength)
+                ?: responseBuilder
+
+        return finalizedBuilder.body(InputStreamResource(storedObject.inputStream))
+    }
+
+    @DeleteMapping("/files/{id}")
+    fun delete(
+        @AuthenticationPrincipal securityUser: SecurityUser,
+        @PathVariable
+        @Positive
+        id: Long,
+    ): RsData<Void> {
+        cloudFileService.delete(
+            ownerMemberId = securityUser.id,
+            fileId = id,
+        )
+
+        return RsData("200-1", "클라우드 파일이 삭제되었습니다.")
+    }
+
+    private fun inlineDisposition(filename: String): String =
+        ContentDisposition
+            .inline()
+            .filename(filename, StandardCharsets.UTF_8)
+            .build()
+            .toString()
+
+    private fun safeMediaType(contentType: String): MediaType =
+        runCatching { MediaType.parseMediaType(contentType) }
+            .getOrElse { throw AppException("500-1", "클라우드 파일 콘텐츠 타입이 올바르지 않습니다.") }
+
+    private fun <T : ResponseEntity.BodyBuilder> noStoreHeaders(builder: T): T {
+        builder.header(HttpHeaders.CACHE_CONTROL, "private, no-store, max-age=0")
+        builder.header(HttpHeaders.PRAGMA, "no-cache")
+        builder.header(HttpHeaders.EXPIRES, "0")
+        builder.header("X-Content-Type-Options", "nosniff")
+        return builder
+    }
+
+    private fun parseSingleRange(
+        rangeHeader: String,
+        totalLength: Long,
+    ): LongRange? {
+        if (!rangeHeader.startsWith("bytes=")) return null
+        if (totalLength <= 0) return null
+
+        val spec = rangeHeader.removePrefix("bytes=").trim()
+        if (spec.contains(",")) return null
+
+        val (rawStart, rawEnd) =
+            spec.split("-", limit = 2).let {
+                if (it.size != 2) return null
+                it[0].trim() to it[1].trim()
+            }
+
+        if (rawStart.isEmpty()) {
+            val suffixLength = rawEnd.toLongOrNull() ?: return null
+            if (suffixLength <= 0) return null
+            val actualLength = minOf(suffixLength, totalLength)
+            val start = totalLength - actualLength
+            return start..(totalLength - 1)
+        }
+
+        val start = rawStart.toLongOrNull() ?: return null
+        if (start < 0 || start >= totalLength) return null
+
+        val end =
+            if (rawEnd.isEmpty()) {
+                totalLength - 1
+            } else {
+                val parsedEnd = rawEnd.toLongOrNull() ?: return null
+                if (parsedEnd < start) return null
+                minOf(parsedEnd, totalLength - 1)
+            }
+
+        return start..end
+    }
+
+    private fun skipFully(
+        input: InputStream,
+        count: Long,
+    ) {
+        var remaining = count
+        while (remaining > 0) {
+            val skipped = input.skip(remaining)
+            if (skipped > 0) {
+                remaining -= skipped
+                continue
+            }
+
+            if (input.read() == -1) {
+                throw EOFException("Unexpected EOF while skipping stream")
+            }
+            remaining -= 1
+        }
+    }
+
+    private fun sliceStream(
+        source: InputStream,
+        range: LongRange,
+    ): InputStream {
+        skipFully(source, range.first)
+        return object : InputStream() {
+            private var remaining = range.last - range.first + 1
+
+            override fun read(): Int {
+                if (remaining <= 0) return -1
+                val value = source.read()
+                if (value >= 0) remaining -= 1
+                return value
+            }
+
+            override fun read(
+                b: ByteArray,
+                off: Int,
+                len: Int,
+            ): Int {
+                if (remaining <= 0) return -1
+                val allowed = minOf(remaining, len.toLong()).toInt()
+                val read = source.read(b, off, allowed)
+                if (read > 0) remaining -= read.toLong()
+                return read
+            }
+
+            override fun close() {
+                source.close()
+            }
+        }
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/port/output/CloudFileRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/port/output/CloudFileRepositoryPort.kt
@@ -1,0 +1,20 @@
+package com.back.boundedContexts.cloud.application.port.output
+
+import com.back.boundedContexts.cloud.model.CloudFile
+import com.back.boundedContexts.cloud.model.CloudFileMediaKind
+
+interface CloudFileRepositoryPort {
+    fun save(file: CloudFile): CloudFile
+
+    fun findActiveByOwner(
+        ownerMemberId: Long,
+        folderPath: String?,
+        keyword: String?,
+        mediaKind: CloudFileMediaKind?,
+    ): List<CloudFile>
+
+    fun findActiveByIdAndOwner(
+        id: Long,
+        ownerMemberId: Long,
+    ): CloudFile?
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -213,7 +213,6 @@ class CloudFileService(
                     segment.replace(Regex("[^A-Za-z0-9._ -]"), "_").take(80)
                 }.take(500)
 
-        if (cleaned.isBlank()) throw AppException("400-1", "유효하지 않은 폴더 경로입니다.")
         return cleaned
     }
 

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -1,0 +1,331 @@
+package com.back.boundedContexts.cloud.application.service
+
+import com.back.boundedContexts.cloud.application.port.output.CloudFileRepositoryPort
+import com.back.boundedContexts.cloud.model.CloudFile
+import com.back.boundedContexts.cloud.model.CloudFileMediaKind
+import com.back.global.exception.application.AppException
+import com.back.global.storage.application.port.output.CloudStoragePort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import java.util.UUID
+
+data class CloudFileDto(
+    val id: Long,
+    val ownerMemberId: Long,
+    val originalFilename: String,
+    val contentType: String,
+    val byteSize: Long,
+    val mediaKind: CloudFileMediaKind,
+    val folderPath: String,
+    val createdAt: Instant,
+    val modifiedAt: Instant,
+)
+
+data class CloudFileContent(
+    val file: CloudFileDto,
+    val storedObject: CloudStoragePort.StoredObject,
+)
+
+@Service
+class CloudFileService(
+    private val cloudFileRepository: CloudFileRepositoryPort,
+    private val cloudStoragePort: CloudStoragePort,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    @Transactional
+    fun upload(
+        ownerMemberId: Long,
+        originalFilename: String?,
+        contentType: String?,
+        bytes: ByteArray,
+        folderPath: String?,
+    ): CloudFileDto {
+        if (bytes.isEmpty()) throw AppException("400-1", "클라우드 파일이 비어 있습니다.")
+
+        val normalizedFolderPath = normalizeFolderPath(folderPath)
+        val safeFilename = normalizeFilename(originalFilename)
+        val detected = detectContent(bytes, contentType)
+        val objectKey =
+            buildObjectKey(
+                ownerMemberId = ownerMemberId,
+                folderPath = normalizedFolderPath,
+                originalFilename = safeFilename,
+            )
+
+        // 선언 MIME만 믿지 않고 파일 시그니처로 media kind를 확정해 preview spoofing을 막는다.
+        val uploadResult =
+            cloudStoragePort.upload(
+                CloudStoragePort.UploadRequest(
+                    objectKey = objectKey,
+                    bytes = bytes,
+                    contentType = detected.contentType,
+                    originalFilename = safeFilename,
+                ),
+            )
+
+        val saved =
+            cloudFileRepository.save(
+                CloudFile.create(
+                    ownerMemberId = ownerMemberId,
+                    objectKey = uploadResult.objectKey,
+                    originalFilename = safeFilename,
+                    contentType = detected.contentType,
+                    byteSize = bytes.size.toLong(),
+                    mediaKind = detected.mediaKind,
+                    folderPath = normalizedFolderPath,
+                    checksumSha256 = uploadResult.checksumSha256,
+                ),
+            )
+
+        return saved.toDto()
+    }
+
+    @Transactional(readOnly = true)
+    fun listFiles(
+        ownerMemberId: Long,
+        folderPath: String?,
+        keyword: String?,
+        mediaKind: CloudFileMediaKind?,
+    ): List<CloudFileDto> =
+        cloudFileRepository
+            .findActiveByOwner(
+                ownerMemberId = ownerMemberId,
+                folderPath = normalizeOptionalFolderPath(folderPath),
+                keyword = keyword?.trim()?.takeIf(String::isNotBlank),
+                mediaKind = mediaKind,
+            ).map { it.toDto() }
+
+    @Transactional(readOnly = true)
+    fun get(
+        ownerMemberId: Long,
+        fileId: Long,
+    ): CloudFileDto =
+        cloudFileRepository
+            .findActiveByIdAndOwner(fileId, ownerMemberId)
+            ?.toDto()
+            ?: throw AppException("404-1", "클라우드 파일을 찾을 수 없습니다.")
+
+    @Transactional(readOnly = true)
+    fun openContent(
+        ownerMemberId: Long,
+        fileId: Long,
+    ): CloudFileContent {
+        // owner check가 storage open보다 먼저 실행되어야 비소유자가 object 존재 여부를 추론할 수 없다.
+        val file =
+            cloudFileRepository.findActiveByIdAndOwner(fileId, ownerMemberId)
+                ?: throw AppException("404-1", "클라우드 파일을 찾을 수 없습니다.")
+        val storedObject =
+            cloudStoragePort.open(file.objectKey)
+                ?: throw AppException("404-1", "클라우드 파일을 찾을 수 없습니다.")
+
+        return CloudFileContent(
+            file = file.toDto(),
+            storedObject = storedObject,
+        )
+    }
+
+    @Transactional
+    fun delete(
+        ownerMemberId: Long,
+        fileId: Long,
+    ) {
+        val file =
+            cloudFileRepository.findActiveByIdAndOwner(fileId, ownerMemberId)
+                ?: throw AppException("404-1", "클라우드 파일을 찾을 수 없습니다.")
+
+        cloudStoragePort.delete(file.objectKey)
+        file.markDeleted(clock.instant())
+        cloudFileRepository.save(file)
+    }
+
+    private fun CloudFile.toDto(): CloudFileDto =
+        CloudFileDto(
+            id = id,
+            ownerMemberId = ownerMemberId,
+            originalFilename = originalFilename,
+            contentType = contentType,
+            byteSize = byteSize,
+            mediaKind = mediaKind,
+            folderPath = folderPath,
+            createdAt = runCatching { createdAt }.getOrDefault(clock.instant()),
+            modifiedAt = runCatching { modifiedAt }.getOrDefault(clock.instant()),
+        )
+
+    private fun normalizeOptionalFolderPath(folderPath: String?): String? = normalizeFolderPath(folderPath).takeIf(String::isNotBlank)
+
+    private fun normalizeFolderPath(folderPath: String?): String {
+        val raw = folderPath?.trim()?.trim('/').orEmpty()
+        if (raw.isBlank()) return ""
+        if (
+            raw.contains("..") ||
+            raw.contains("//") ||
+            raw.startsWith("/") ||
+            raw.split('/').any { it.isBlank() || it == "." || it == ".." }
+        ) {
+            throw AppException("400-1", "유효하지 않은 폴더 경로입니다.")
+        }
+
+        val cleaned =
+            raw
+                .split('/')
+                .joinToString("/") { segment ->
+                    segment.replace(Regex("[^A-Za-z0-9._ -]"), "_").take(80)
+                }.take(500)
+
+        if (cleaned.isBlank()) throw AppException("400-1", "유효하지 않은 폴더 경로입니다.")
+        return cleaned
+    }
+
+    private fun normalizeFilename(originalFilename: String?): String {
+        val fallback = "cloud-file"
+        val raw =
+            originalFilename
+                ?.substringAfterLast('/')
+                ?.substringAfterLast('\\')
+                ?.trim()
+                .orEmpty()
+        val cleaned =
+            raw
+                .ifBlank { fallback }
+                .replace(Regex("[\\r\\n\\t]"), " ")
+                .replace(Regex("[^A-Za-z0-9가-힣._()\\[\\] -]"), "_")
+                .take(255)
+                .trim()
+
+        return cleaned.ifBlank { fallback }
+    }
+
+    private fun buildObjectKey(
+        ownerMemberId: Long,
+        folderPath: String,
+        originalFilename: String,
+    ): String {
+        val ext = extractExtension(originalFilename)
+        val datePath = DATE_PATH_FORMATTER.format(clock.instant().atZone(ZoneOffset.UTC))
+        val folderSegment = folderPath.takeIf(String::isNotBlank)?.let { "$it/" }.orEmpty()
+        return "cloud/$ownerMemberId/$folderSegment$datePath/${UUID.randomUUID()}$ext"
+    }
+
+    private fun extractExtension(filename: String): String {
+        if (!filename.contains(".")) return ""
+        val ext =
+            filename
+                .substringAfterLast(".")
+                .lowercase(Locale.ROOT)
+                .replace(Regex("[^a-z0-9]"), "")
+                .take(10)
+        return if (ext.isBlank()) "" else ".$ext"
+    }
+
+    private fun detectContent(
+        bytes: ByteArray,
+        declaredContentType: String?,
+    ): DetectedContent {
+        val normalizedDeclared = normalizeContentType(declaredContentType)
+        val detected =
+            detectFromSignature(bytes)
+                ?: throw AppException("400-1", "지원하지 않는 클라우드 파일 형식입니다.")
+
+        if (
+            normalizedDeclared != null &&
+            normalizedDeclared in KNOWN_CONTENT_TYPES &&
+            normalizedDeclared != detected.contentType
+        ) {
+            throw AppException("400-1", "파일 내용과 콘텐츠 타입이 일치하지 않습니다.")
+        }
+
+        return detected
+    }
+
+    private fun normalizeContentType(raw: String?): String? {
+        val normalized =
+            raw
+                ?.substringBefore(";")
+                ?.trim()
+                ?.lowercase(Locale.ROOT)
+                .orEmpty()
+        if (normalized.isBlank()) return null
+        return CONTENT_TYPE_ALIASES[normalized] ?: normalized
+    }
+
+    private fun detectFromSignature(bytes: ByteArray): DetectedContent? {
+        if (bytes.size >= 5 && bytes.copyOfRange(0, 5).toString(Charsets.US_ASCII) == "%PDF-") {
+            return DetectedContent("application/pdf", CloudFileMediaKind.DOCUMENT)
+        }
+        if (
+            bytes.size >= 3 &&
+            bytes[0] == 0xFF.toByte() &&
+            bytes[1] == 0xD8.toByte() &&
+            bytes[2] == 0xFF.toByte()
+        ) {
+            return DetectedContent("image/jpeg", CloudFileMediaKind.PHOTO)
+        }
+        if (
+            bytes.size >= 8 &&
+            bytes[0] == 0x89.toByte() &&
+            bytes[1] == 0x50.toByte() &&
+            bytes[2] == 0x4E.toByte() &&
+            bytes[3] == 0x47.toByte() &&
+            bytes[4] == 0x0D.toByte() &&
+            bytes[5] == 0x0A.toByte() &&
+            bytes[6] == 0x1A.toByte() &&
+            bytes[7] == 0x0A.toByte()
+        ) {
+            return DetectedContent("image/png", CloudFileMediaKind.PHOTO)
+        }
+        if (bytes.size >= 6) {
+            val header = bytes.copyOfRange(0, 6).toString(Charsets.US_ASCII)
+            if (header == "GIF87a" || header == "GIF89a") return DetectedContent("image/gif", CloudFileMediaKind.PHOTO)
+        }
+        if (bytes.size >= 12) {
+            val riff = bytes.copyOfRange(0, 4).toString(Charsets.US_ASCII)
+            val webp = bytes.copyOfRange(8, 12).toString(Charsets.US_ASCII)
+            if (riff == "RIFF" && webp == "WEBP") return DetectedContent("image/webp", CloudFileMediaKind.PHOTO)
+        }
+        if (bytes.size >= 12 && bytes.copyOfRange(4, 8).toString(Charsets.US_ASCII) == "ftyp") {
+            return DetectedContent("video/mp4", CloudFileMediaKind.VIDEO)
+        }
+        if (
+            bytes.size >= 4 &&
+            bytes[0] == 0x1A.toByte() &&
+            bytes[1] == 0x45.toByte() &&
+            bytes[2] == 0xDF.toByte() &&
+            bytes[3] == 0xA3.toByte()
+        ) {
+            return DetectedContent("video/webm", CloudFileMediaKind.VIDEO)
+        }
+
+        return null
+    }
+
+    private data class DetectedContent(
+        val contentType: String,
+        val mediaKind: CloudFileMediaKind,
+    )
+
+    companion object {
+        private val DATE_PATH_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd")
+        private val CONTENT_TYPE_ALIASES =
+            mapOf(
+                "image/jpg" to "image/jpeg",
+                "image/pjpeg" to "image/jpeg",
+                "image/x-png" to "image/png",
+                "image/x-webp" to "image/webp",
+            )
+        private val KNOWN_CONTENT_TYPES =
+            setOf(
+                "application/pdf",
+                "image/jpeg",
+                "image/png",
+                "image/gif",
+                "image/webp",
+                "video/mp4",
+                "video/webm",
+            )
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -5,8 +5,12 @@ import com.back.boundedContexts.cloud.model.CloudFile
 import com.back.boundedContexts.cloud.model.CloudFileMediaKind
 import com.back.global.exception.application.AppException
 import com.back.global.storage.application.port.output.CloudStoragePort
+import com.back.global.storage.config.CloudStorageProperties
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
@@ -35,8 +39,11 @@ data class CloudFileContent(
 class CloudFileService(
     private val cloudFileRepository: CloudFileRepositoryPort,
     private val cloudStoragePort: CloudStoragePort,
+    private val cloudStorageProperties: CloudStorageProperties = CloudStorageProperties(),
     private val clock: Clock = Clock.systemUTC(),
 ) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     @Transactional
     fun upload(
         ownerMemberId: Long,
@@ -46,6 +53,12 @@ class CloudFileService(
         folderPath: String?,
     ): CloudFileDto {
         if (bytes.isEmpty()) throw AppException("400-1", "클라우드 파일이 비어 있습니다.")
+        if (bytes.size.toLong() > cloudStorageProperties.maxFileSizeBytes) {
+            throw AppException(
+                "413-1",
+                "클라우드 파일은 ${formatFileSizeLimit(cloudStorageProperties.maxFileSizeBytes)} 이하여야 합니다.",
+            )
+        }
 
         val normalizedFolderPath = normalizeFolderPath(folderPath)
         val safeFilename = normalizeFilename(originalFilename)
@@ -138,9 +151,32 @@ class CloudFileService(
             cloudFileRepository.findActiveByIdAndOwner(fileId, ownerMemberId)
                 ?: throw AppException("404-1", "클라우드 파일을 찾을 수 없습니다.")
 
-        cloudStoragePort.delete(file.objectKey)
+        val objectKey = file.objectKey
         file.markDeleted(clock.instant())
         cloudFileRepository.save(file)
+        deleteObjectAfterCommit(objectKey)
+    }
+
+    private fun deleteObjectAfterCommit(objectKey: String) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            cloudStoragePort.delete(objectKey)
+            return
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() {
+                    runCatching { cloudStoragePort.delete(objectKey) }
+                        .onFailure {
+                            logger.error(
+                                "Cloud file object delete failed after metadata commit (objectKey={})",
+                                objectKey,
+                                it,
+                            )
+                        }
+                }
+            },
+        )
     }
 
     private fun CloudFile.toDto(): CloudFileDto =
@@ -198,6 +234,11 @@ class CloudFileService(
                 .trim()
 
         return cleaned.ifBlank { fallback }
+    }
+
+    private fun formatFileSizeLimit(maxFileSizeBytes: Long): String {
+        val limitMb = (maxFileSizeBytes + (1024 * 1024) - 1) / (1024 * 1024)
+        return "${limitMb}MB"
     }
 
     private fun buildObjectKey(

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/model/CloudFile.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/model/CloudFile.kt
@@ -28,6 +28,13 @@ enum class CloudFileMediaKind {
     WHERE deleted_at IS NULL
     """,
 )
+@AfterDDL(
+    """
+    CREATE INDEX IF NOT EXISTS cloud_file_idx_owner_media_created_active
+    ON cloud_file (owner_member_id, media_kind, created_at DESC, id DESC)
+    WHERE deleted_at IS NULL
+    """,
+)
 class CloudFile(
     @field:Id
     @field:SequenceGenerator(name = "cloud_file_seq_gen", sequenceName = "cloud_file_seq", allocationSize = 1)

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/model/CloudFile.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/model/CloudFile.kt
@@ -1,0 +1,84 @@
+package com.back.boundedContexts.cloud.model
+
+import com.back.global.jpa.domain.AfterDDL
+import com.back.global.jpa.domain.BaseTime
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType.SEQUENCE
+import jakarta.persistence.Id
+import jakarta.persistence.SequenceGenerator
+import org.hibernate.annotations.DynamicUpdate
+import java.time.Instant
+
+enum class CloudFileMediaKind {
+    DOCUMENT,
+    PHOTO,
+    VIDEO,
+}
+
+@Entity
+@DynamicUpdate
+@AfterDDL(
+    """
+    CREATE INDEX IF NOT EXISTS cloud_file_idx_owner_folder_created_active
+    ON cloud_file (owner_member_id, folder_path, created_at DESC, id DESC)
+    WHERE deleted_at IS NULL
+    """,
+)
+class CloudFile(
+    @field:Id
+    @field:SequenceGenerator(name = "cloud_file_seq_gen", sequenceName = "cloud_file_seq", allocationSize = 1)
+    @field:GeneratedValue(strategy = SEQUENCE, generator = "cloud_file_seq_gen")
+    override val id: Long = 0,
+    @field:Column(nullable = false)
+    val ownerMemberId: Long,
+    @field:Column(nullable = false, unique = true, length = 1000)
+    val objectKey: String,
+    @field:Column(nullable = false, length = 255)
+    val originalFilename: String,
+    @field:Column(nullable = false, length = 120)
+    val contentType: String,
+    @field:Column(nullable = false)
+    val byteSize: Long,
+    @field:Enumerated(EnumType.STRING)
+    @field:Column(nullable = false, length = 40)
+    val mediaKind: CloudFileMediaKind,
+    @field:Column(nullable = false, length = 500)
+    val folderPath: String = "",
+    @field:Column(length = 128)
+    val checksumSha256: String? = null,
+    @field:Column
+    var deletedAt: Instant? = null,
+) : BaseTime(id) {
+    fun markDeleted(now: Instant) {
+        deletedAt = now
+    }
+
+    companion object {
+        fun create(
+            id: Long = 0,
+            ownerMemberId: Long,
+            objectKey: String,
+            originalFilename: String,
+            contentType: String,
+            byteSize: Long,
+            mediaKind: CloudFileMediaKind,
+            folderPath: String,
+            checksumSha256: String?,
+        ): CloudFile =
+            CloudFile(
+                id = id,
+                ownerMemberId = ownerMemberId,
+                objectKey = objectKey,
+                originalFilename = originalFilename,
+                contentType = contentType,
+                byteSize = byteSize,
+                mediaKind = mediaKind,
+                folderPath = folderPath,
+                checksumSha256 = checksumSha256,
+            )
+    }
+}

--- a/back/src/main/kotlin/com/back/global/storage/adapter/CloudStorageAdapter.kt
+++ b/back/src/main/kotlin/com/back/global/storage/adapter/CloudStorageAdapter.kt
@@ -1,0 +1,255 @@
+package com.back.global.storage.adapter
+
+import com.back.global.exception.application.AppException
+import com.back.global.storage.application.port.output.CloudStoragePort
+import com.back.global.storage.config.CloudStorageProperties
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.model.S3Exception
+import java.net.URI
+import java.net.URLDecoder
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+@Service
+class CloudStorageAdapter(
+    private val properties: CloudStorageProperties,
+) : CloudStoragePort {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val initLock = Any()
+
+    @Volatile
+    private var s3Client: S3Client? = null
+
+    @Volatile
+    private var initErrorMessage: String? = null
+
+    @PostConstruct
+    fun initializeBucket() {
+        initializeStorage(forceRetry = true)
+    }
+
+    override fun upload(request: CloudStoragePort.UploadRequest): CloudStoragePort.UploadResult {
+        val client = requireClient()
+        validateObjectKey(request.objectKey)
+
+        try {
+            client.putObject(
+                PutObjectRequest
+                    .builder()
+                    .bucket(properties.bucket)
+                    .key(request.objectKey)
+                    .contentType(request.contentType)
+                    .metadata(
+                        mapOf(
+                            "original-filename" to
+                                URLEncoder
+                                    .encode(request.originalFilename, StandardCharsets.UTF_8)
+                                    .replace("+", "%20"),
+                        ),
+                    ).build(),
+                RequestBody.fromBytes(request.bytes),
+            )
+        } catch (e: Exception) {
+            logger.error("Cloud file upload failed (objectKey={})", request.objectKey, e)
+            throw AppException("500-1", "클라우드 파일 업로드에 실패했습니다.")
+        }
+
+        return CloudStoragePort.UploadResult(
+            objectKey = request.objectKey,
+            checksumSha256 = sha256Hex(request.bytes),
+        )
+    }
+
+    override fun open(objectKey: String): CloudStoragePort.StoredObject? {
+        val client = requireClient()
+        validateObjectKey(objectKey)
+
+        return try {
+            val response =
+                client.getObject(
+                    GetObjectRequest
+                        .builder()
+                        .bucket(properties.bucket)
+                        .key(objectKey)
+                        .build(),
+                )
+            CloudStoragePort.StoredObject(
+                inputStream = response,
+                contentType = response.response().contentType() ?: "application/octet-stream",
+                contentLength = response.response().contentLength(),
+                originalFilename = decodeStoredOriginalFilename(response.response().metadata()["original-filename"]),
+            )
+        } catch (_: NoSuchKeyException) {
+            null
+        } catch (e: S3Exception) {
+            if (e.statusCode() == 404) return null
+            logger.error("Cloud file download failed (objectKey={})", objectKey, e)
+            throw AppException("500-1", "클라우드 파일을 불러오지 못했습니다.")
+        }
+    }
+
+    override fun delete(objectKey: String) {
+        val client = requireClient()
+        validateObjectKey(objectKey)
+
+        try {
+            client.deleteObject(
+                DeleteObjectRequest
+                    .builder()
+                    .bucket(properties.bucket)
+                    .key(objectKey)
+                    .build(),
+            )
+        } catch (e: S3Exception) {
+            if (e.statusCode() == 404) return
+            logger.error("Cloud file delete failed (objectKey={})", objectKey, e)
+            throw AppException("500-1", "클라우드 파일 삭제에 실패했습니다.")
+        }
+    }
+
+    private fun initializeStorage(forceRetry: Boolean) {
+        if (!properties.enabled) return
+
+        synchronized(initLock) {
+            if (!forceRetry && s3Client != null && initErrorMessage == null) return
+
+            val client =
+                try {
+                    s3Client ?: buildClient()
+                } catch (e: Exception) {
+                    initErrorMessage = "클라우드 스토리지 설정 오류: ${e.message ?: "알 수 없는 오류"}"
+                    logger.error("Cloud storage client initialization failed", e)
+                    return
+                }
+            s3Client = client
+
+            try {
+                client.headBucket(
+                    HeadBucketRequest
+                        .builder()
+                        .bucket(properties.bucket)
+                        .build(),
+                )
+                initErrorMessage = null
+            } catch (headError: Exception) {
+                try {
+                    client.createBucket(
+                        CreateBucketRequest
+                            .builder()
+                            .bucket(properties.bucket)
+                            .build(),
+                    )
+                    initErrorMessage = null
+                } catch (createError: Exception) {
+                    initErrorMessage = "클라우드 스토리지 버킷 초기화 실패: ${createError.message ?: headError.message ?: "알 수 없는 오류"}"
+                    logger.error("Cloud storage bucket initialization failed", createError)
+                }
+            }
+        }
+    }
+
+    private fun requireClient(): S3Client {
+        if (!properties.enabled) throw AppException("503-1", "클라우드 스토리지가 비활성화되어 있습니다.")
+
+        if (s3Client == null || initErrorMessage != null) {
+            initializeStorage(forceRetry = true)
+        }
+
+        initErrorMessage?.let { throw AppException("503-1", it) }
+
+        return s3Client ?: throw AppException("503-1", "클라우드 스토리지가 아직 준비되지 않았습니다.")
+    }
+
+    private fun buildClient(): S3Client {
+        val accessKey = resolveProperty(properties.accessKey, "CUSTOM_STORAGE_ACCESSKEY", "MINIO_ROOT_USER")
+        val secretKey = resolveProperty(properties.secretKey, "CUSTOM_STORAGE_SECRETKEY", "MINIO_ROOT_PASSWORD")
+        if (accessKey.isBlank() || secretKey.isBlank()) {
+            throw IllegalArgumentException("스토리지 계정 정보가 비어 있습니다.")
+        }
+
+        val endpoint = resolveProperty(properties.endpoint, "CUSTOM_STORAGE_ENDPOINT", null)
+        if (!endpoint.startsWith("http://") && !endpoint.startsWith("https://")) {
+            throw IllegalArgumentException("CUSTOM_STORAGE_ENDPOINT 형식이 올바르지 않습니다. (현재: $endpoint)")
+        }
+
+        return S3Client
+            .builder()
+            .endpointOverride(URI.create(endpoint))
+            .region(Region.of(properties.region))
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+            .forcePathStyle(properties.pathStyleAccess)
+            .build()
+    }
+
+    private fun resolveProperty(
+        rawValue: String,
+        envKeyName: String,
+        fallbackEnvKeyName: String?,
+    ): String {
+        val trimmed = rawValue.trim()
+        val resolved =
+            resolveEnvReference(trimmed)
+                ?: trimmed.ifBlank { fallbackEnvKeyName?.let { System.getenv(it)?.trim().orEmpty() } ?: "" }
+
+        if (resolved.contains("\${")) {
+            throw IllegalArgumentException("${envKeyName}에 미해결 placeholder가 포함되어 있습니다. (현재: $resolved)")
+        }
+
+        return resolved
+    }
+
+    private fun resolveEnvReference(value: String): String? {
+        val match = ENV_REFERENCE_REGEX.matchEntire(value) ?: return null
+        val envName = match.groupValues[1]
+        val defaultValue = match.groupValues.getOrNull(2).orEmpty()
+        val envValue = System.getenv(envName)?.trim().orEmpty()
+        return if (envValue.isNotBlank()) envValue else defaultValue
+    }
+
+    private fun validateObjectKey(objectKey: String) {
+        val prefix =
+            properties.cloudKeyPrefix
+                .trim()
+                .trim('/')
+                .ifBlank { "cloud" }
+        // service 계층의 정규화가 우회되어도 cloud prefix 밖 object 접근은 어댑터에서 차단한다.
+        if (
+            objectKey.isBlank() ||
+            objectKey.contains("..") ||
+            objectKey.startsWith("/") ||
+            !objectKey.startsWith("$prefix/")
+        ) {
+            throw AppException("400-1", "유효하지 않은 클라우드 파일 경로입니다.")
+        }
+    }
+
+    private fun decodeStoredOriginalFilename(value: String?): String? {
+        val encoded = value?.trim().orEmpty()
+        if (encoded.isBlank()) return null
+        return runCatching { URLDecoder.decode(encoded, StandardCharsets.UTF_8) }.getOrNull()
+    }
+
+    private fun sha256Hex(bytes: ByteArray): String =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(bytes)
+            .joinToString("") { "%02x".format(it) }
+
+    companion object {
+        private val ENV_REFERENCE_REGEX = Regex("^\\$\\{([A-Za-z_][A-Za-z0-9_]*)(?::-(.*))?}$")
+    }
+}

--- a/back/src/main/kotlin/com/back/global/storage/application/port/output/CloudStoragePort.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/port/output/CloudStoragePort.kt
@@ -3,24 +3,58 @@ package com.back.global.storage.application.port.output
 import java.io.InputStream
 
 interface CloudStoragePort {
-    data class UploadRequest(
+    class UploadRequest(
         val objectKey: String,
         val bytes: ByteArray,
         val contentType: String,
         val originalFilename: String,
-    )
+    ) {
+        override fun equals(other: Any?): Boolean =
+            this === other ||
+                (
+                    other is UploadRequest &&
+                        objectKey == other.objectKey &&
+                        bytes.contentEquals(other.bytes) &&
+                        contentType == other.contentType &&
+                        originalFilename == other.originalFilename
+                )
+
+        override fun hashCode(): Int {
+            var result = objectKey.hashCode()
+            result = 31 * result + bytes.contentHashCode()
+            result = 31 * result + contentType.hashCode()
+            result = 31 * result + originalFilename.hashCode()
+            return result
+        }
+
+        override fun toString(): String =
+            "UploadRequest(" +
+                "objectKey=$objectKey, " +
+                "bytes=${bytes.size} bytes, " +
+                "contentType=$contentType, " +
+                "originalFilename=$originalFilename" +
+                ")"
+    }
 
     data class UploadResult(
         val objectKey: String,
-        val checksumSha256: String?,
+        val checksumSha256: String,
     )
 
+    /**
+     * S3 호환 클라이언트가 반환한 네트워크 스트림을 감싼다.
+     * 응답을 반환하거나 복사한 호출자는 연결 풀이 고갈되지 않도록 반드시 닫아야 한다.
+     */
     data class StoredObject(
         val inputStream: InputStream,
         val contentType: String,
         val contentLength: Long?,
         val originalFilename: String?,
-    )
+    ) : AutoCloseable {
+        override fun close() {
+            inputStream.close()
+        }
+    }
 
     fun upload(request: UploadRequest): UploadResult
 

--- a/back/src/main/kotlin/com/back/global/storage/application/port/output/CloudStoragePort.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/port/output/CloudStoragePort.kt
@@ -1,0 +1,30 @@
+package com.back.global.storage.application.port.output
+
+import java.io.InputStream
+
+interface CloudStoragePort {
+    data class UploadRequest(
+        val objectKey: String,
+        val bytes: ByteArray,
+        val contentType: String,
+        val originalFilename: String,
+    )
+
+    data class UploadResult(
+        val objectKey: String,
+        val checksumSha256: String?,
+    )
+
+    data class StoredObject(
+        val inputStream: InputStream,
+        val contentType: String,
+        val contentLength: Long?,
+        val originalFilename: String?,
+    )
+
+    fun upload(request: UploadRequest): UploadResult
+
+    fun open(objectKey: String): StoredObject?
+
+    fun delete(objectKey: String)
+}

--- a/back/src/main/kotlin/com/back/global/storage/config/CloudStorageConfig.kt
+++ b/back/src/main/kotlin/com/back/global/storage/config/CloudStorageConfig.kt
@@ -1,0 +1,8 @@
+package com.back.global.storage.config
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(CloudStorageProperties::class)
+class CloudStorageConfig

--- a/back/src/main/kotlin/com/back/global/storage/config/CloudStorageProperties.kt
+++ b/back/src/main/kotlin/com/back/global/storage/config/CloudStorageProperties.kt
@@ -12,4 +12,5 @@ data class CloudStorageProperties(
     val secretKey: String = "",
     val pathStyleAccess: Boolean = true,
     val cloudKeyPrefix: String = "cloud",
+    val maxFileSizeBytes: Long = 10 * 1024 * 1024,
 )

--- a/back/src/main/kotlin/com/back/global/storage/config/CloudStorageProperties.kt
+++ b/back/src/main/kotlin/com/back/global/storage/config/CloudStorageProperties.kt
@@ -1,0 +1,15 @@
+package com.back.global.storage.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("custom.storage")
+data class CloudStorageProperties(
+    val enabled: Boolean = false,
+    val endpoint: String = "http://localhost:9000",
+    val region: String = "us-east-1",
+    val bucket: String = "blog-images",
+    val accessKey: String = "",
+    val secretKey: String = "",
+    val pathStyleAccess: Boolean = true,
+    val cloudKeyPrefix: String = "cloud",
+)

--- a/back/src/main/resources/db/migration-test/V20260319_01__baseline_schema.sql
+++ b/back/src/main/resources/db/migration-test/V20260319_01__baseline_schema.sql
@@ -11,6 +11,7 @@ CREATE SEQUENCE IF NOT EXISTS post_comment_seq INCREMENT BY 50 START WITH 1 MINV
 CREATE SEQUENCE IF NOT EXISTS post_like_seq INCREMENT BY 50 START WITH 1 MINVALUE 1;
 CREATE SEQUENCE IF NOT EXISTS post_write_request_idempotency_seq INCREMENT BY 50 START WITH 1 MINVALUE 1;
 CREATE SEQUENCE IF NOT EXISTS uploaded_file_seq INCREMENT BY 1 START WITH 1 MINVALUE 1;
+CREATE SEQUENCE IF NOT EXISTS cloud_file_seq INCREMENT BY 1 START WITH 1 MINVALUE 1;
 CREATE SEQUENCE IF NOT EXISTS task_seq INCREMENT BY 50 START WITH 1 MINVALUE 1;
 
 CREATE TABLE IF NOT EXISTS member (
@@ -195,6 +196,24 @@ CREATE TABLE IF NOT EXISTS uploaded_file (
     CONSTRAINT uk_uploaded_file_object_key UNIQUE (object_key)
 );
 
+CREATE TABLE IF NOT EXISTS cloud_file (
+    id BIGINT NOT NULL DEFAULT nextval('cloud_file_seq'),
+    owner_member_id BIGINT NOT NULL,
+    object_key VARCHAR(1000) NOT NULL,
+    original_filename VARCHAR(255) NOT NULL,
+    content_type VARCHAR(120) NOT NULL,
+    byte_size BIGINT NOT NULL,
+    media_kind VARCHAR(40) NOT NULL,
+    folder_path VARCHAR(500) NOT NULL DEFAULT '',
+    checksum_sha256 VARCHAR(128),
+    deleted_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_cloud_file PRIMARY KEY (id),
+    CONSTRAINT uk_cloud_file_object_key UNIQUE (object_key),
+    CONSTRAINT fk_cloud_file_owner FOREIGN KEY (owner_member_id) REFERENCES member (id)
+);
+
 CREATE TABLE IF NOT EXISTS task (
     id BIGINT NOT NULL DEFAULT nextval('task_seq'),
     uid UUID UNIQUE,
@@ -271,3 +290,11 @@ CREATE INDEX IF NOT EXISTS task_idx_status_next_retry_at
 
 CREATE INDEX IF NOT EXISTS uploaded_file_idx_status_purge_after
     ON uploaded_file (status, purge_after ASC);
+
+CREATE INDEX IF NOT EXISTS cloud_file_idx_owner_folder_created_active
+    ON cloud_file (owner_member_id, folder_path, created_at DESC, id DESC)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS cloud_file_idx_owner_media_created_active
+    ON cloud_file (owner_member_id, media_kind, created_at DESC, id DESC)
+    WHERE deleted_at IS NULL;

--- a/back/src/main/resources/db/migration/V20260612_01__create_cloud_file.sql
+++ b/back/src/main/resources/db/migration/V20260612_01__create_cloud_file.sql
@@ -1,0 +1,27 @@
+CREATE SEQUENCE IF NOT EXISTS cloud_file_seq INCREMENT BY 1 START WITH 1 MINVALUE 1;
+
+CREATE TABLE IF NOT EXISTS cloud_file (
+    id BIGINT NOT NULL DEFAULT nextval('cloud_file_seq'),
+    owner_member_id BIGINT NOT NULL,
+    object_key VARCHAR(1000) NOT NULL,
+    original_filename VARCHAR(255) NOT NULL,
+    content_type VARCHAR(120) NOT NULL,
+    byte_size BIGINT NOT NULL,
+    media_kind VARCHAR(40) NOT NULL,
+    folder_path VARCHAR(500) NOT NULL DEFAULT '',
+    checksum_sha256 VARCHAR(128),
+    deleted_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_cloud_file PRIMARY KEY (id),
+    CONSTRAINT uk_cloud_file_object_key UNIQUE (object_key),
+    CONSTRAINT fk_cloud_file_owner FOREIGN KEY (owner_member_id) REFERENCES member (id)
+);
+
+CREATE INDEX IF NOT EXISTS cloud_file_idx_owner_folder_created_active
+    ON cloud_file (owner_member_id, folder_path, created_at DESC, id DESC)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS cloud_file_idx_owner_media_created_active
+    ON cloud_file (owner_member_id, media_kind, created_at DESC, id DESC)
+    WHERE deleted_at IS NULL;

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudControllerWebMvcTest.kt
@@ -2,24 +2,31 @@ package com.back.boundedContexts.cloud.adapter.web
 
 import com.back.boundedContexts.cloud.application.service.CloudFileContent
 import com.back.boundedContexts.cloud.application.service.CloudFileDto
+import com.back.boundedContexts.cloud.application.service.CloudFileService
 import com.back.boundedContexts.cloud.model.CloudFileMediaKind
 import com.back.global.security.domain.SecurityUser
 import com.back.global.storage.application.port.output.CloudStoragePort
 import com.back.support.BaseAdmCloudControllerWebMvcTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
+import org.mockito.Mockito.mock
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.test.util.ReflectionTestUtils
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.multipart
 import java.io.ByteArrayInputStream
+import java.io.EOFException
+import java.io.InputStream
 import java.time.Instant
 
 @DisplayName("관리자 클라우드 WebMvc 테스트")
@@ -68,6 +75,27 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
     }
 
     @Test
+    @DisplayName("관리자는 folder keyword mediaKind 조건으로 cloud 목록을 조회한다")
+    fun `관리자는 folder keyword mediaKind 조건으로 cloud 목록을 조회한다`() {
+        val admin = adminUser(id = 7L)
+        given(cloudFileService.listFiles(7L, folderPath = "docs", keyword = "manual", mediaKind = CloudFileMediaKind.DOCUMENT))
+            .willReturn(emptyList())
+
+        mvc
+            .get("/system/api/v1/adm/cloud/files") {
+                param("folderPath", " docs ")
+                param("kw", "manual")
+                param("mediaKind", "DOCUMENT")
+                with(user(admin))
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.files.length()") { value(0) }
+            }
+
+        then(cloudFileService).should().listFiles(7L, "docs", "manual", CloudFileMediaKind.DOCUMENT)
+    }
+
+    @Test
     @DisplayName("관리자 upload는 자신의 owner id로 service에 위임한다")
     fun `관리자 upload는 자신의 owner id로 service에 위임한다`() {
         val admin = adminUser(id = 7L)
@@ -97,31 +125,71 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
     }
 
     @Test
+    @DisplayName("관리자는 자신의 cloud 파일 단건 metadata를 조회한다")
+    fun `관리자는 자신의 cloud 파일 단건 metadata를 조회한다`() {
+        val admin = adminUser(id = 7L)
+        given(cloudFileService.get(ownerMemberId = 7L, fileId = 12L))
+            .willReturn(sampleDto(id = 12L, ownerMemberId = 7L, originalFilename = "manual.pdf"))
+
+        mvc
+            .get("/system/api/v1/adm/cloud/files/12") {
+                with(user(admin))
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.id") { value(12) }
+                jsonPath("$.ownerMemberId") { value(7) }
+                jsonPath("$.originalFilename") { value("manual.pdf") }
+            }
+    }
+
+    @Test
+    @DisplayName("content 일반 요청은 private full response를 반환한다")
+    fun `content 일반 요청은 private full response를 반환한다`() {
+        val admin = adminUser(id = 7L)
+        givenContent(
+            ownerMemberId = 7L,
+            fileId = 12L,
+            bytes = "0123456789".toByteArray(),
+            contentLength = 10L,
+        )
+
+        mvc
+            .get("/system/api/v1/adm/cloud/files/12/content") {
+                with(user(admin))
+            }.andExpect {
+                status { isOk() }
+                header { string(HttpHeaders.ACCEPT_RANGES, "bytes") }
+                header { string(HttpHeaders.CACHE_CONTROL, "private, no-store, max-age=0") }
+                header { string("X-Content-Type-Options", "nosniff") }
+                content { bytes("0123456789".toByteArray()) }
+            }
+    }
+
+    @Test
+    @DisplayName("content 일반 요청은 길이를 모르는 stream도 반환한다")
+    fun `content 일반 요청은 길이를 모르는 stream도 반환한다`() {
+        val admin = adminUser(id = 7L)
+        givenContent(
+            ownerMemberId = 7L,
+            fileId = 12L,
+            bytes = "abc".toByteArray(),
+            contentLength = null,
+        )
+
+        mvc
+            .get("/system/api/v1/adm/cloud/files/12/content") {
+                with(user(admin))
+            }.andExpect {
+                status { isOk() }
+                content { bytes("abc".toByteArray()) }
+            }
+    }
+
+    @Test
     @DisplayName("content Range 요청은 private partial response를 반환한다")
     fun `content Range 요청은 private partial response를 반환한다`() {
         val admin = adminUser(id = 7L)
-        val file =
-            sampleDto(
-                id = 12L,
-                ownerMemberId = 7L,
-                originalFilename = "demo.mp4",
-                contentType = "video/mp4",
-                byteSize = 10L,
-                mediaKind = CloudFileMediaKind.VIDEO,
-            )
-        given(cloudFileService.openContent(ownerMemberId = 7L, fileId = 12L))
-            .willReturn(
-                CloudFileContent(
-                    file = file,
-                    storedObject =
-                        CloudStoragePort.StoredObject(
-                            inputStream = ByteArrayInputStream("0123456789".toByteArray()),
-                            contentType = "video/mp4",
-                            contentLength = 10L,
-                            originalFilename = "demo.mp4",
-                        ),
-                ),
-            )
+        givenContent(ownerMemberId = 7L, fileId = 12L, bytes = "0123456789".toByteArray(), contentLength = 10L)
 
         mvc
             .get("/system/api/v1/adm/cloud/files/12/content") {
@@ -138,6 +206,159 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
     }
 
     @Test
+    @DisplayName("content suffix Range 요청은 마지막 byte 구간을 반환한다")
+    fun `content suffix Range 요청은 마지막 byte 구간을 반환한다`() {
+        val admin = adminUser(id = 7L)
+        givenContent(ownerMemberId = 7L, fileId = 12L, bytes = "0123456789".toByteArray(), contentLength = 10L)
+
+        mvc
+            .get("/system/api/v1/adm/cloud/files/12/content") {
+                header(HttpHeaders.RANGE, "bytes=-4")
+                with(user(admin))
+            }.andExpect {
+                status { isPartialContent() }
+                header { string(HttpHeaders.CONTENT_RANGE, "bytes 6-9/10") }
+                content { bytes("6789".toByteArray()) }
+            }
+    }
+
+    @Test
+    @DisplayName("content open-ended Range 요청은 끝까지 반환한다")
+    fun `content open-ended Range 요청은 끝까지 반환한다`() {
+        val admin = adminUser(id = 7L)
+        givenContent(ownerMemberId = 7L, fileId = 12L, bytes = "0123456789".toByteArray(), contentLength = 10L)
+
+        mvc
+            .get("/system/api/v1/adm/cloud/files/12/content") {
+                header(HttpHeaders.RANGE, "bytes=7-")
+                with(user(admin))
+            }.andExpect {
+                status { isPartialContent() }
+                header { string(HttpHeaders.CONTENT_RANGE, "bytes 7-9/10") }
+                content { bytes("789".toByteArray()) }
+            }
+    }
+
+    @Test
+    @DisplayName("content Range 요청은 stream 길이를 모르면 416을 반환하고 stream을 닫는다")
+    fun `content Range 요청은 stream 길이를 모르면 416을 반환하고 stream을 닫는다`() {
+        val admin = adminUser(id = 7L)
+        val inputStream =
+            givenContent(
+                ownerMemberId = 7L,
+                fileId = 12L,
+                bytes = "0123456789".toByteArray(),
+                contentLength = null,
+            )
+
+        mvc
+            .get("/system/api/v1/adm/cloud/files/12/content") {
+                header(HttpHeaders.RANGE, "bytes=0-1")
+                with(user(admin))
+            }.andExpect {
+                status { isRequestedRangeNotSatisfiable() }
+                header { string(HttpHeaders.CONTENT_RANGE, "bytes */*") }
+            }
+
+        assertThat(inputStream.closed).isTrue()
+    }
+
+    @Test
+    @DisplayName("content Range 요청은 multi-range를 거절하고 stream을 닫는다")
+    fun `content Range 요청은 multi-range를 거절하고 stream을 닫는다`() {
+        val admin = adminUser(id = 7L)
+        val inputStream =
+            givenContent(
+                ownerMemberId = 7L,
+                fileId = 12L,
+                bytes = "0123456789".toByteArray(),
+                contentLength = 10L,
+            )
+
+        mvc
+            .get("/system/api/v1/adm/cloud/files/12/content") {
+                header(HttpHeaders.RANGE, "bytes=0-1,3-4")
+                with(user(admin))
+            }.andExpect {
+                status { isRequestedRangeNotSatisfiable() }
+                header { string(HttpHeaders.CONTENT_RANGE, "bytes */10") }
+            }
+
+        assertThat(inputStream.closed).isTrue()
+    }
+
+    @Test
+    @DisplayName("content 요청은 저장된 content type이 올바르지 않으면 500을 반환한다")
+    fun `content 요청은 저장된 content type이 올바르지 않으면 500을 반환한다`() {
+        val admin = adminUser(id = 7L)
+        givenContent(
+            ownerMemberId = 7L,
+            fileId = 12L,
+            bytes = "body".toByteArray(),
+            contentLength = 4L,
+            contentType = "bad type",
+        )
+
+        mvc
+            .get("/system/api/v1/adm/cloud/files/12/content") {
+                with(user(admin))
+            }.andExpect {
+                status { isInternalServerError() }
+                jsonPath("$.resultCode") { value("500-1") }
+            }
+    }
+
+    @Test
+    @DisplayName("slice stream은 단일 byte read에서도 지정된 구간만 반환한다")
+    fun `slice stream은 단일 byte read에서도 지정된 구간만 반환한다`() {
+        val controller = ApiV1AdmCloudController(mock(CloudFileService::class.java))
+        val stream =
+            ReflectionTestUtils.invokeMethod<InputStream>(
+                controller,
+                "sliceStream",
+                ByteArrayInputStream("0123456789".toByteArray()),
+                2L..4L,
+            )!!
+
+        val values = generateSequence { stream.read().takeIf { it >= 0 } }.toList()
+        stream.close()
+
+        assertThat(values).containsExactly('2'.code, '3'.code, '4'.code)
+    }
+
+    @Test
+    @DisplayName("slice stream은 시작 위치까지 건너뛰지 못하면 EOF로 실패한다")
+    fun `slice stream은 시작 위치까지 건너뛰지 못하면 EOF로 실패한다`() {
+        val controller = ApiV1AdmCloudController(mock(CloudFileService::class.java))
+
+        assertThatThrownBy {
+            ReflectionTestUtils.invokeMethod<InputStream>(
+                controller,
+                "sliceStream",
+                ByteArrayInputStream("abc".toByteArray()),
+                5L..6L,
+            )
+        }.rootCause()
+            .isInstanceOf(EOFException::class.java)
+    }
+
+    @Test
+    @DisplayName("slice stream은 skip이 0이면 read로 건너뛰기를 이어간다")
+    fun `slice stream은 skip이 0이면 read로 건너뛰기를 이어간다`() {
+        val controller = ApiV1AdmCloudController(mock(CloudFileService::class.java))
+        val stream =
+            ReflectionTestUtils.invokeMethod<InputStream>(
+                controller,
+                "sliceStream",
+                ZeroSkipInputStream("abc".toByteArray()),
+                2L..2L,
+            )!!
+
+        assertThat(stream.read()).isEqualTo('c'.code)
+        assertThat(stream.read()).isEqualTo(-1)
+    }
+
+    @Test
     @DisplayName("delete는 자신의 owner id로 service에 위임한다")
     fun `delete는 자신의 owner id로 service에 위임한다`() {
         val admin = adminUser(id = 7L)
@@ -151,6 +372,39 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
             }
 
         then(cloudFileService).should().delete(ownerMemberId = 7L, fileId = 12L)
+    }
+
+    private fun givenContent(
+        ownerMemberId: Long,
+        fileId: Long,
+        bytes: ByteArray,
+        contentLength: Long?,
+        contentType: String = "video/mp4",
+    ): CloseAwareInputStream {
+        val inputStream = CloseAwareInputStream(bytes)
+        val file =
+            sampleDto(
+                id = fileId,
+                ownerMemberId = ownerMemberId,
+                originalFilename = "demo.mp4",
+                contentType = contentType,
+                byteSize = bytes.size.toLong(),
+                mediaKind = CloudFileMediaKind.VIDEO,
+            )
+        given(cloudFileService.openContent(ownerMemberId = ownerMemberId, fileId = fileId))
+            .willReturn(
+                CloudFileContent(
+                    file = file,
+                    storedObject =
+                        CloudStoragePort.StoredObject(
+                            inputStream = inputStream,
+                            contentType = contentType,
+                            contentLength = contentLength,
+                            originalFilename = "demo.mp4",
+                        ),
+                ),
+            )
+        return inputStream
     }
 
     private fun adminUser(id: Long): SecurityUser =
@@ -181,4 +435,21 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
             createdAt = Instant.parse("2026-06-12T00:00:00Z"),
             modifiedAt = Instant.parse("2026-06-12T00:00:00Z"),
         )
+
+    private class CloseAwareInputStream(
+        bytes: ByteArray,
+    ) : ByteArrayInputStream(bytes) {
+        var closed: Boolean = false
+
+        override fun close() {
+            closed = true
+            super.close()
+        }
+    }
+
+    private class ZeroSkipInputStream(
+        bytes: ByteArray,
+    ) : ByteArrayInputStream(bytes) {
+        override fun skip(n: Long): Long = 0
+    }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudControllerWebMvcTest.kt
@@ -1,0 +1,184 @@
+package com.back.boundedContexts.cloud.adapter.web
+
+import com.back.boundedContexts.cloud.application.service.CloudFileContent
+import com.back.boundedContexts.cloud.application.service.CloudFileDto
+import com.back.boundedContexts.cloud.model.CloudFileMediaKind
+import com.back.global.security.domain.SecurityUser
+import com.back.global.storage.application.port.output.CloudStoragePort
+import com.back.support.BaseAdmCloudControllerWebMvcTest
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.then
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.multipart
+import java.io.ByteArrayInputStream
+import java.time.Instant
+
+@DisplayName("관리자 클라우드 WebMvc 테스트")
+class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
+    @Test
+    @DisplayName("비로그인 사용자는 cloud 목록을 조회할 수 없다")
+    fun `비로그인 사용자는 cloud 목록을 조회할 수 없다`() {
+        mvc.get("/system/api/v1/adm/cloud/files").andExpect {
+            status { isUnauthorized() }
+            jsonPath("$.resultCode") { value("401-1") }
+            jsonPath("$.msg") { value("로그인 후 이용해주세요.") }
+        }
+    }
+
+    @Test
+    @WithMockUser(roles = ["USER"])
+    @DisplayName("일반 사용자는 cloud 목록을 조회할 수 없다")
+    fun `일반 사용자는 cloud 목록을 조회할 수 없다`() {
+        mvc.get("/system/api/v1/adm/cloud/files").andExpect {
+            status { isForbidden() }
+            jsonPath("$.resultCode") { value("403-1") }
+            jsonPath("$.msg") { value("권한이 없습니다.") }
+        }
+    }
+
+    @Test
+    @DisplayName("관리자는 자신의 cloud 파일 목록을 조회한다")
+    fun `관리자는 자신의 cloud 파일 목록을 조회한다`() {
+        val admin = adminUser(id = 7L)
+        val item = sampleDto(id = 10L, ownerMemberId = 7L, originalFilename = "manual.pdf")
+        given(cloudFileService.listFiles(7L, folderPath = null, keyword = "", mediaKind = null))
+            .willReturn(listOf(item))
+
+        mvc
+            .get("/system/api/v1/adm/cloud/files") {
+                with(user(admin))
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.files.length()") { value(1) }
+                jsonPath("$.files[0].id") { value(10) }
+                jsonPath("$.files[0].ownerMemberId") { value(7) }
+                jsonPath("$.files[0].originalFilename") { value("manual.pdf") }
+            }
+
+        then(cloudFileService).should().listFiles(7L, null, "", null)
+    }
+
+    @Test
+    @DisplayName("관리자 upload는 자신의 owner id로 service에 위임한다")
+    fun `관리자 upload는 자신의 owner id로 service에 위임한다`() {
+        val admin = adminUser(id = 7L)
+        val item = sampleDto(id = 11L, ownerMemberId = 7L, originalFilename = "photo.png", mediaKind = CloudFileMediaKind.PHOTO)
+        val uploadBytes = "png".toByteArray()
+        given(
+            cloudFileService.upload(
+                ownerMemberId = 7L,
+                originalFilename = "photo.png",
+                contentType = "image/png",
+                bytes = uploadBytes,
+                folderPath = "photos",
+            ),
+        ).willReturn(item)
+
+        mvc
+            .multipart("/system/api/v1/adm/cloud/files") {
+                file(MockMultipartFile("file", "photo.png", MediaType.IMAGE_PNG_VALUE, uploadBytes))
+                param("folderPath", "photos")
+                with(user(admin))
+            }.andExpect {
+                status { isCreated() }
+                jsonPath("$.resultCode") { value("201-1") }
+                jsonPath("$.data.id") { value(11) }
+                jsonPath("$.data.ownerMemberId") { value(7) }
+            }
+    }
+
+    @Test
+    @DisplayName("content Range 요청은 private partial response를 반환한다")
+    fun `content Range 요청은 private partial response를 반환한다`() {
+        val admin = adminUser(id = 7L)
+        val file =
+            sampleDto(
+                id = 12L,
+                ownerMemberId = 7L,
+                originalFilename = "demo.mp4",
+                contentType = "video/mp4",
+                byteSize = 10L,
+                mediaKind = CloudFileMediaKind.VIDEO,
+            )
+        given(cloudFileService.openContent(ownerMemberId = 7L, fileId = 12L))
+            .willReturn(
+                CloudFileContent(
+                    file = file,
+                    storedObject =
+                        CloudStoragePort.StoredObject(
+                            inputStream = ByteArrayInputStream("0123456789".toByteArray()),
+                            contentType = "video/mp4",
+                            contentLength = 10L,
+                            originalFilename = "demo.mp4",
+                        ),
+                ),
+            )
+
+        mvc
+            .get("/system/api/v1/adm/cloud/files/12/content") {
+                header(HttpHeaders.RANGE, "bytes=2-5")
+                with(user(admin))
+            }.andExpect {
+                status { isPartialContent() }
+                header { string(HttpHeaders.ACCEPT_RANGES, "bytes") }
+                header { string(HttpHeaders.CONTENT_RANGE, "bytes 2-5/10") }
+                header { string(HttpHeaders.CACHE_CONTROL, "private, no-store, max-age=0") }
+                content { contentType("video/mp4") }
+                content { bytes("2345".toByteArray()) }
+            }
+    }
+
+    @Test
+    @DisplayName("delete는 자신의 owner id로 service에 위임한다")
+    fun `delete는 자신의 owner id로 service에 위임한다`() {
+        val admin = adminUser(id = 7L)
+
+        mvc
+            .delete("/system/api/v1/adm/cloud/files/12") {
+                with(user(admin))
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.resultCode") { value("200-1") }
+            }
+
+        then(cloudFileService).should().delete(ownerMemberId = 7L, fileId = 12L)
+    }
+
+    private fun adminUser(id: Long): SecurityUser =
+        SecurityUser(
+            id = id,
+            username = "admin$id@example.com",
+            password = "",
+            nickname = "관리자$id",
+            authorities = listOf(SimpleGrantedAuthority("ROLE_ADMIN")),
+        )
+
+    private fun sampleDto(
+        id: Long,
+        ownerMemberId: Long,
+        originalFilename: String,
+        contentType: String = "application/pdf",
+        byteSize: Long = 9L,
+        mediaKind: CloudFileMediaKind = CloudFileMediaKind.DOCUMENT,
+    ): CloudFileDto =
+        CloudFileDto(
+            id = id,
+            ownerMemberId = ownerMemberId,
+            originalFilename = originalFilename,
+            contentType = contentType,
+            byteSize = byteSize,
+            mediaKind = mediaKind,
+            folderPath = "",
+            createdAt = Instant.parse("2026-06-12T00:00:00Z"),
+            modifiedAt = Instant.parse("2026-06-12T00:00:00Z"),
+        )
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -5,6 +5,7 @@ import com.back.boundedContexts.cloud.model.CloudFile
 import com.back.boundedContexts.cloud.model.CloudFileMediaKind
 import com.back.global.exception.application.AppException
 import com.back.global.storage.application.port.output.CloudStoragePort
+import com.back.global.storage.config.CloudStorageProperties
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
@@ -82,6 +83,32 @@ class CloudFileServiceTest {
     }
 
     @Test
+    @DisplayName("업로드 시 설정된 최대 크기를 넘으면 storage에 저장하지 않는다")
+    fun `upload는 설정된 최대 크기를 넘으면 storage에 저장하지 않는다`() {
+        val limitedService =
+            CloudFileService(
+                cloudFileRepository = repository,
+                cloudStoragePort = storage,
+                cloudStorageProperties = CloudStorageProperties(maxFileSizeBytes = 5),
+                clock = Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneOffset.UTC),
+            )
+
+        assertThatThrownBy {
+            limitedService.upload(
+                ownerMemberId = 7L,
+                originalFilename = "large.pdf",
+                contentType = "application/pdf",
+                bytes = "%PDF-1.7".toByteArray(),
+                folderPath = "docs",
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("클라우드 파일은")
+
+        assertThat(storage.uploaded).isEmpty()
+        assertThat(repository.savedFiles).isEmpty()
+    }
+
+    @Test
     @DisplayName("content 조회 시 owner match 없이는 저장소 stream을 열지 않는다")
     fun `content 조회는 owner match 없이는 저장소를 열지 않는다`() {
         val saved =
@@ -138,6 +165,33 @@ class CloudFileServiceTest {
     }
 
     @Test
+    @DisplayName("delete 시 metadata 삭제 표시 저장 후 object를 삭제한다")
+    fun `delete는 metadata 삭제 표시 저장 후 object를 삭제한다`() {
+        val saved =
+            repository.save(
+                CloudFile.create(
+                    ownerMemberId = 7L,
+                    objectKey = "cloud/7/docs/file.pdf",
+                    originalFilename = "file.pdf",
+                    contentType = "application/pdf",
+                    byteSize = 9L,
+                    mediaKind = CloudFileMediaKind.DOCUMENT,
+                    folderPath = "docs",
+                    checksumSha256 = null,
+                ),
+            )
+        repository.onSave = { file ->
+            assertThat(file.deletedAt).isNotNull()
+            assertThat(storage.deletedObjectKeys).isEmpty()
+        }
+
+        service.delete(ownerMemberId = 7L, fileId = saved.id)
+
+        assertThat(repository.findActiveByIdAndOwner(saved.id, 7L)).isNull()
+        assertThat(storage.deletedObjectKeys).containsExactly(saved.objectKey)
+    }
+
+    @Test
     @DisplayName("delete 시 owner mismatch이면 metadata와 object를 삭제하지 않는다")
     fun `delete는 owner mismatch에서 metadata와 object를 삭제하지 않는다`() {
         val saved =
@@ -163,8 +217,31 @@ class CloudFileServiceTest {
         assertThat(storage.deletedObjectKeys).isEmpty()
     }
 
+    @Test
+    @DisplayName("UploadRequest는 bytes 내용을 기준으로 동일성을 비교한다")
+    fun `UploadRequest는 bytes 내용을 기준으로 동일성을 비교한다`() {
+        val first =
+            CloudStoragePort.UploadRequest(
+                objectKey = "cloud/7/docs/file.pdf",
+                bytes = "%PDF-1.7".toByteArray(),
+                contentType = "application/pdf",
+                originalFilename = "file.pdf",
+            )
+        val second =
+            CloudStoragePort.UploadRequest(
+                objectKey = "cloud/7/docs/file.pdf",
+                bytes = "%PDF-1.7".toByteArray(),
+                contentType = "application/pdf",
+                originalFilename = "file.pdf",
+            )
+
+        assertThat(first).isEqualTo(second)
+        assertThat(first.hashCode()).isEqualTo(second.hashCode())
+    }
+
     private class FakeCloudFileRepository : CloudFileRepositoryPort {
         val savedFiles = mutableListOf<CloudFile>()
+        var onSave: ((CloudFile) -> Unit)? = null
         private var nextId = 1L
 
         override fun save(file: CloudFile): CloudFile {
@@ -184,6 +261,7 @@ class CloudFileServiceTest {
                 } else {
                     file
                 }
+            onSave?.invoke(stored)
             savedFiles.removeIf { it.id == stored.id }
             savedFiles += stored
             return stored

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.io.ByteArrayInputStream
 import java.time.Clock
 import java.time.Instant
@@ -109,6 +110,126 @@ class CloudFileServiceTest {
     }
 
     @Test
+    @DisplayName("업로드 시 빈 파일과 미지원 파일 형식을 storage 저장 전에 차단한다")
+    fun `upload는 빈 파일과 미지원 파일 형식을 storage 저장 전에 차단한다`() {
+        assertThatThrownBy {
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "empty.pdf",
+                contentType = "application/pdf",
+                bytes = byteArrayOf(),
+                folderPath = "docs",
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("비어 있습니다")
+
+        assertThatThrownBy {
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "unknown.bin",
+                contentType = "application/octet-stream",
+                bytes = "plain".toByteArray(),
+                folderPath = "docs",
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("지원하지 않는 클라우드 파일 형식")
+
+        assertThat(storage.uploaded).isEmpty()
+        assertThat(repository.savedFiles).isEmpty()
+    }
+
+    @Test
+    @DisplayName("업로드 시 지원하는 문서 사진 동영상 시그니처를 mediaKind로 분류한다")
+    fun `upload는 지원하는 문서 사진 동영상 시그니처를 mediaKind로 분류한다`() {
+        val cases =
+            listOf(
+                SignatureCase("alias.jpg", "image/jpg", byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte()), CloudFileMediaKind.PHOTO),
+                SignatureCase("photo.png", "image/x-png", PNG_BYTES, CloudFileMediaKind.PHOTO),
+                SignatureCase("anim.gif", "image/gif", "GIF89a".toByteArray(), CloudFileMediaKind.PHOTO),
+                SignatureCase("asset.webp", "image/x-webp", "RIFFxxxxWEBP".toByteArray(), CloudFileMediaKind.PHOTO),
+                SignatureCase("movie.mp4", null, byteArrayOf(0, 0, 0, 0, 0x66, 0x74, 0x79, 0x70, 0, 0, 0, 0), CloudFileMediaKind.VIDEO),
+                SignatureCase("clip.webm", "video/webm", byteArrayOf(0x1A, 0x45, 0xDF.toByte(), 0xA3.toByte()), CloudFileMediaKind.VIDEO),
+            )
+
+        cases.forEachIndexed { index, case ->
+            val result =
+                service.upload(
+                    ownerMemberId = 7L,
+                    originalFilename = "unsafe/${case.filename}\n",
+                    contentType = case.contentType,
+                    bytes = case.bytes,
+                    folderPath = "/media $index/",
+                )
+
+            assertThat(result.mediaKind).isEqualTo(case.mediaKind)
+            assertThat(result.folderPath).isEqualTo("media $index")
+            assertThat(result.originalFilename).doesNotContain("/")
+        }
+
+        assertThat(storage.uploaded).hasSize(cases.size)
+    }
+
+    @Test
+    @DisplayName("업로드 시 파일명이 없으면 기본 파일명과 root folder를 사용한다")
+    fun `upload는 파일명이 없으면 기본 파일명과 root folder를 사용한다`() {
+        val result =
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = null,
+                contentType = "application/pdf",
+                bytes = "%PDF-1.7".toByteArray(),
+                folderPath = null,
+            )
+
+        assertThat(result.originalFilename).isEqualTo("cloud-file")
+        assertThat(result.folderPath).isEmpty()
+        assertThat(repository.savedFiles.single().objectKey).startsWith("cloud/7/2026/06/12/")
+    }
+
+    @Test
+    @DisplayName("목록과 단건 조회는 owner folder keyword mediaKind 조건을 적용한다")
+    fun `목록과 단건 조회는 owner folder keyword mediaKind 조건을 적용한다`() {
+        repository.assignAuditTimestamps = true
+        val manual =
+            repository.save(
+                cloudFile(
+                    ownerMemberId = 7L,
+                    objectKey = "cloud/7/docs/manual.pdf",
+                    originalFilename = "Manual.pdf",
+                    mediaKind = CloudFileMediaKind.DOCUMENT,
+                    folderPath = "docs",
+                ),
+            )
+        repository.save(
+            cloudFile(
+                ownerMemberId = 7L,
+                objectKey = "cloud/7/photos/photo.png",
+                originalFilename = "photo.png",
+                mediaKind = CloudFileMediaKind.PHOTO,
+                folderPath = "photos",
+            ),
+        )
+
+        val files =
+            service.listFiles(
+                ownerMemberId = 7L,
+                folderPath = " docs ",
+                keyword = "manual",
+                mediaKind = CloudFileMediaKind.DOCUMENT,
+            )
+        val dto = service.get(ownerMemberId = 7L, fileId = manual.id)
+        val allFiles = service.listFiles(ownerMemberId = 7L, folderPath = "", keyword = " ", mediaKind = null)
+
+        assertThat(files).extracting("id").containsExactly(manual.id)
+        assertThat(dto.createdAt).isEqualTo(Instant.parse("2026-06-12T00:00:00Z"))
+        assertThat(allFiles).hasSize(2)
+        assertThatThrownBy {
+            service.get(ownerMemberId = 8L, fileId = manual.id)
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("파일을 찾을 수 없습니다")
+    }
+
+    @Test
     @DisplayName("content 조회 시 owner match 없이는 저장소 stream을 열지 않는다")
     fun `content 조회는 owner match 없이는 저장소를 열지 않는다`() {
         val saved =
@@ -131,6 +252,28 @@ class CloudFileServiceTest {
             .hasMessageContaining("파일을 찾을 수 없습니다")
 
         assertThat(storage.openedObjectKeys).isEmpty()
+    }
+
+    @Test
+    @DisplayName("content 조회 시 metadata는 있지만 object가 없으면 404로 실패한다")
+    fun `content 조회는 metadata는 있지만 object가 없으면 실패한다`() {
+        val saved =
+            repository.save(
+                cloudFile(
+                    ownerMemberId = 7L,
+                    objectKey = "cloud/7/docs/missing.pdf",
+                    originalFilename = "missing.pdf",
+                    mediaKind = CloudFileMediaKind.DOCUMENT,
+                    folderPath = "docs",
+                ),
+            )
+
+        assertThatThrownBy {
+            service.openContent(ownerMemberId = 7L, fileId = saved.id)
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("파일을 찾을 수 없습니다")
+
+        assertThat(storage.openedObjectKeys).containsExactly(saved.objectKey)
     }
 
     @Test
@@ -192,6 +335,63 @@ class CloudFileServiceTest {
     }
 
     @Test
+    @DisplayName("delete 시 transaction commit 이후 object 삭제를 실행한다")
+    fun `delete는 transaction commit 이후 object 삭제를 실행한다`() {
+        val saved =
+            repository.save(
+                cloudFile(
+                    ownerMemberId = 7L,
+                    objectKey = "cloud/7/docs/tx.pdf",
+                    originalFilename = "tx.pdf",
+                    mediaKind = CloudFileMediaKind.DOCUMENT,
+                    folderPath = "docs",
+                ),
+            )
+
+        TransactionSynchronizationManager.initSynchronization()
+        try {
+            service.delete(ownerMemberId = 7L, fileId = saved.id)
+            val synchronizations = TransactionSynchronizationManager.getSynchronizations()
+
+            assertThat(storage.deletedObjectKeys).isEmpty()
+            synchronizations.single().afterCommit()
+            assertThat(storage.deletedObjectKeys).containsExactly(saved.objectKey)
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization()
+        }
+    }
+
+    @Test
+    @DisplayName("delete 후 commit 이후 object 삭제 실패는 요청 성공 이후 로그로만 남긴다")
+    fun `delete 후 commit 이후 object 삭제 실패는 요청 성공 이후 로그로만 남긴다`() {
+        val saved =
+            repository.save(
+                cloudFile(
+                    ownerMemberId = 7L,
+                    objectKey = "cloud/7/docs/delete-fail.pdf",
+                    originalFilename = "delete-fail.pdf",
+                    mediaKind = CloudFileMediaKind.DOCUMENT,
+                    folderPath = "docs",
+                ),
+            )
+        storage.deleteFailure = IllegalStateException("delete failed")
+
+        TransactionSynchronizationManager.initSynchronization()
+        try {
+            service.delete(ownerMemberId = 7L, fileId = saved.id)
+            val synchronization = TransactionSynchronizationManager.getSynchronizations().single()
+
+            synchronization.afterCommit()
+
+            assertThat(repository.findActiveByIdAndOwner(saved.id, 7L)).isNull()
+            assertThat(storage.deletedObjectKeys).containsExactly(saved.objectKey)
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization()
+            storage.deleteFailure = null
+        }
+    }
+
+    @Test
     @DisplayName("delete 시 owner mismatch이면 metadata와 object를 삭제하지 않는다")
     fun `delete는 owner mismatch에서 metadata와 object를 삭제하지 않는다`() {
         val saved =
@@ -218,6 +418,18 @@ class CloudFileServiceTest {
     }
 
     @Test
+    @DisplayName("delete 시 파일이 없으면 metadata와 object를 삭제하지 않는다")
+    fun `delete는 파일이 없으면 metadata와 object를 삭제하지 않는다`() {
+        assertThatThrownBy {
+            service.delete(ownerMemberId = 7L, fileId = 404L)
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("파일을 찾을 수 없습니다")
+
+        assertThat(repository.savedFiles).isEmpty()
+        assertThat(storage.deletedObjectKeys).isEmpty()
+    }
+
+    @Test
     @DisplayName("UploadRequest는 bytes 내용을 기준으로 동일성을 비교한다")
     fun `UploadRequest는 bytes 내용을 기준으로 동일성을 비교한다`() {
         val first =
@@ -237,11 +449,50 @@ class CloudFileServiceTest {
 
         assertThat(first).isEqualTo(second)
         assertThat(first.hashCode()).isEqualTo(second.hashCode())
+        assertThat(first.objectKey).isEqualTo("cloud/7/docs/file.pdf")
+        assertThat(first.bytes).containsExactly(*"%PDF-1.7".toByteArray())
+        assertThat(first.contentType).isEqualTo("application/pdf")
+        assertThat(first.originalFilename).isEqualTo("file.pdf")
+        assertThat(first).isNotEqualTo(
+            CloudStoragePort.UploadRequest(
+                objectKey = "cloud/7/docs/other.pdf",
+                bytes = "%PDF-1.7".toByteArray(),
+                contentType = "application/pdf",
+                originalFilename = "file.pdf",
+            ),
+        )
+        assertThat(first.toString()).contains("bytes=8 bytes")
     }
+
+    @Test
+    @DisplayName("StoredObject close는 내부 inputStream을 닫는다")
+    fun `StoredObject close는 내부 inputStream을 닫는다`() {
+        val inputStream = CloseAwareInputStream("stream".toByteArray())
+        val storedObject =
+            CloudStoragePort.StoredObject(
+                inputStream = inputStream,
+                contentType = "application/pdf",
+                contentLength = 6L,
+                originalFilename = "stream.pdf",
+            )
+
+        storedObject.close()
+
+        assertThat(inputStream.closed).isTrue()
+        assertThat(storedObject.originalFilename).isEqualTo("stream.pdf")
+    }
+
+    private data class SignatureCase(
+        val filename: String,
+        val contentType: String?,
+        val bytes: ByteArray,
+        val mediaKind: CloudFileMediaKind,
+    )
 
     private class FakeCloudFileRepository : CloudFileRepositoryPort {
         val savedFiles = mutableListOf<CloudFile>()
         var onSave: ((CloudFile) -> Unit)? = null
+        var assignAuditTimestamps: Boolean = false
         private var nextId = 1L
 
         override fun save(file: CloudFile): CloudFile {
@@ -261,6 +512,10 @@ class CloudFileServiceTest {
                 } else {
                     file
                 }
+            if (assignAuditTimestamps) {
+                stored.createdAt = Instant.parse("2026-06-12T00:00:00Z")
+                stored.modifiedAt = Instant.parse("2026-06-12T00:00:00Z")
+            }
             onSave?.invoke(stored)
             savedFiles.removeIf { it.id == stored.id }
             savedFiles += stored
@@ -297,6 +552,7 @@ class CloudFileServiceTest {
         val openedObjectKeys = mutableListOf<String>()
         val deletedObjectKeys = mutableListOf<String>()
         val objects = mutableMapOf<String, CloudStoragePort.StoredObject>()
+        var deleteFailure: RuntimeException? = null
 
         override fun upload(request: CloudStoragePort.UploadRequest): CloudStoragePort.UploadResult {
             uploaded += request
@@ -313,6 +569,55 @@ class CloudFileServiceTest {
 
         override fun delete(objectKey: String) {
             deletedObjectKeys += objectKey
+            deleteFailure?.let { throw it }
         }
+    }
+
+    private class CloseAwareInputStream(
+        bytes: ByteArray,
+    ) : ByteArrayInputStream(bytes) {
+        var closed: Boolean = false
+
+        override fun close() {
+            closed = true
+            super.close()
+        }
+    }
+
+    companion object {
+        private val PNG_BYTES =
+            byteArrayOf(
+                0x89.toByte(),
+                0x50,
+                0x4E,
+                0x47,
+                0x0D,
+                0x0A,
+                0x1A,
+                0x0A,
+            )
+
+        private fun cloudFile(
+            ownerMemberId: Long,
+            objectKey: String,
+            originalFilename: String,
+            mediaKind: CloudFileMediaKind,
+            folderPath: String,
+        ): CloudFile =
+            CloudFile.create(
+                ownerMemberId = ownerMemberId,
+                objectKey = objectKey,
+                originalFilename = originalFilename,
+                contentType =
+                    when (mediaKind) {
+                        CloudFileMediaKind.DOCUMENT -> "application/pdf"
+                        CloudFileMediaKind.PHOTO -> "image/png"
+                        CloudFileMediaKind.VIDEO -> "video/mp4"
+                    },
+                byteSize = 9L,
+                mediaKind = mediaKind,
+                folderPath = folderPath,
+                checksumSha256 = null,
+            )
     }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -1,0 +1,240 @@
+package com.back.boundedContexts.cloud.application.service
+
+import com.back.boundedContexts.cloud.application.port.output.CloudFileRepositoryPort
+import com.back.boundedContexts.cloud.model.CloudFile
+import com.back.boundedContexts.cloud.model.CloudFileMediaKind
+import com.back.global.exception.application.AppException
+import com.back.global.storage.application.port.output.CloudStoragePort
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+@DisplayName("관리자 클라우드 파일 서비스 테스트")
+class CloudFileServiceTest {
+    private val repository = FakeCloudFileRepository()
+    private val storage = FakeCloudStoragePort()
+    private val service =
+        CloudFileService(
+            cloudFileRepository = repository,
+            cloudStoragePort = storage,
+            clock = Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneOffset.UTC),
+        )
+
+    @Test
+    @DisplayName("업로드 시 ownerMemberId와 cloud prefix를 metadata에 고정한다")
+    fun `upload는 ownerMemberId와 cloud prefix를 metadata에 고정한다`() {
+        val result =
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "manual.pdf",
+                contentType = "application/pdf",
+                bytes = "%PDF-1.7".toByteArray(),
+                folderPath = "docs",
+            )
+
+        assertThat(result.ownerMemberId).isEqualTo(7L)
+        assertThat(result.originalFilename).isEqualTo("manual.pdf")
+        assertThat(result.mediaKind).isEqualTo(CloudFileMediaKind.DOCUMENT)
+        assertThat(result.folderPath).isEqualTo("docs")
+        assertThat(repository.savedFiles.single().objectKey).startsWith("cloud/7/docs/")
+        assertThat(storage.uploaded.single().objectKey).isEqualTo(repository.savedFiles.single().objectKey)
+    }
+
+    @Test
+    @DisplayName("업로드 시 folder path traversal을 차단한다")
+    fun `upload는 folder path traversal을 차단한다`() {
+        assertThatThrownBy {
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "secret.pdf",
+                contentType = "application/pdf",
+                bytes = "%PDF-1.7".toByteArray(),
+                folderPath = "../private",
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("유효하지 않은 폴더 경로")
+
+        assertThat(storage.uploaded).isEmpty()
+        assertThat(repository.savedFiles).isEmpty()
+    }
+
+    @Test
+    @DisplayName("업로드 시 파일 내용과 선언 content type이 다르면 차단한다")
+    fun `upload는 content type spoofing을 차단한다`() {
+        assertThatThrownBy {
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "fake.png",
+                contentType = "image/png",
+                bytes = "%PDF-1.7".toByteArray(),
+                folderPath = "docs",
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("콘텐츠 타입이 일치하지 않습니다")
+
+        assertThat(storage.uploaded).isEmpty()
+        assertThat(repository.savedFiles).isEmpty()
+    }
+
+    @Test
+    @DisplayName("content 조회 시 owner match 없이는 저장소 stream을 열지 않는다")
+    fun `content 조회는 owner match 없이는 저장소를 열지 않는다`() {
+        val saved =
+            repository.save(
+                CloudFile.create(
+                    ownerMemberId = 7L,
+                    objectKey = "cloud/7/docs/file.pdf",
+                    originalFilename = "file.pdf",
+                    contentType = "application/pdf",
+                    byteSize = 9L,
+                    mediaKind = CloudFileMediaKind.DOCUMENT,
+                    folderPath = "docs",
+                    checksumSha256 = null,
+                ),
+            )
+
+        assertThatThrownBy {
+            service.openContent(ownerMemberId = 8L, fileId = saved.id)
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("파일을 찾을 수 없습니다")
+
+        assertThat(storage.openedObjectKeys).isEmpty()
+    }
+
+    @Test
+    @DisplayName("Range content 조회는 owner match 뒤에만 저장소 stream을 반환한다")
+    fun `Range content 조회는 owner match 뒤에만 저장소 stream을 반환한다`() {
+        val saved =
+            repository.save(
+                CloudFile.create(
+                    ownerMemberId = 7L,
+                    objectKey = "cloud/7/video/demo.mp4",
+                    originalFilename = "demo.mp4",
+                    contentType = "video/mp4",
+                    byteSize = 10L,
+                    mediaKind = CloudFileMediaKind.VIDEO,
+                    folderPath = "video",
+                    checksumSha256 = "abc",
+                ),
+            )
+        storage.objects[saved.objectKey] =
+            CloudStoragePort.StoredObject(
+                inputStream = ByteArrayInputStream("0123456789".toByteArray()),
+                contentType = "video/mp4",
+                contentLength = 10L,
+                originalFilename = "demo.mp4",
+            )
+
+        val content = service.openContent(ownerMemberId = 7L, fileId = saved.id)
+
+        assertThat(content.file.id).isEqualTo(saved.id)
+        assertThat(content.storedObject.contentType).isEqualTo("video/mp4")
+        assertThat(storage.openedObjectKeys).containsExactly(saved.objectKey)
+    }
+
+    @Test
+    @DisplayName("delete 시 owner mismatch이면 metadata와 object를 삭제하지 않는다")
+    fun `delete는 owner mismatch에서 metadata와 object를 삭제하지 않는다`() {
+        val saved =
+            repository.save(
+                CloudFile.create(
+                    ownerMemberId = 7L,
+                    objectKey = "cloud/7/docs/file.pdf",
+                    originalFilename = "file.pdf",
+                    contentType = "application/pdf",
+                    byteSize = 9L,
+                    mediaKind = CloudFileMediaKind.DOCUMENT,
+                    folderPath = "docs",
+                    checksumSha256 = null,
+                ),
+            )
+
+        assertThatThrownBy {
+            service.delete(ownerMemberId = 8L, fileId = saved.id)
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("파일을 찾을 수 없습니다")
+
+        assertThat(repository.findActiveByIdAndOwner(saved.id, 7L)).isNotNull
+        assertThat(storage.deletedObjectKeys).isEmpty()
+    }
+
+    private class FakeCloudFileRepository : CloudFileRepositoryPort {
+        val savedFiles = mutableListOf<CloudFile>()
+        private var nextId = 1L
+
+        override fun save(file: CloudFile): CloudFile {
+            val stored =
+                if (file.id == 0L) {
+                    CloudFile.create(
+                        id = nextId++,
+                        ownerMemberId = file.ownerMemberId,
+                        objectKey = file.objectKey,
+                        originalFilename = file.originalFilename,
+                        contentType = file.contentType,
+                        byteSize = file.byteSize,
+                        mediaKind = file.mediaKind,
+                        folderPath = file.folderPath,
+                        checksumSha256 = file.checksumSha256,
+                    )
+                } else {
+                    file
+                }
+            savedFiles.removeIf { it.id == stored.id }
+            savedFiles += stored
+            return stored
+        }
+
+        override fun findActiveByOwner(
+            ownerMemberId: Long,
+            folderPath: String?,
+            keyword: String?,
+            mediaKind: CloudFileMediaKind?,
+        ): List<CloudFile> =
+            savedFiles.filter {
+                it.ownerMemberId == ownerMemberId &&
+                    it.deletedAt == null &&
+                    (folderPath == null || it.folderPath == folderPath) &&
+                    (keyword.isNullOrBlank() || it.originalFilename.contains(keyword, ignoreCase = true)) &&
+                    (mediaKind == null || it.mediaKind == mediaKind)
+            }
+
+        override fun findActiveByIdAndOwner(
+            id: Long,
+            ownerMemberId: Long,
+        ): CloudFile? =
+            savedFiles.firstOrNull {
+                it.id == id &&
+                    it.ownerMemberId == ownerMemberId &&
+                    it.deletedAt == null
+            }
+    }
+
+    private class FakeCloudStoragePort : CloudStoragePort {
+        val uploaded = mutableListOf<CloudStoragePort.UploadRequest>()
+        val openedObjectKeys = mutableListOf<String>()
+        val deletedObjectKeys = mutableListOf<String>()
+        val objects = mutableMapOf<String, CloudStoragePort.StoredObject>()
+
+        override fun upload(request: CloudStoragePort.UploadRequest): CloudStoragePort.UploadResult {
+            uploaded += request
+            return CloudStoragePort.UploadResult(
+                objectKey = request.objectKey,
+                checksumSha256 = "test-checksum",
+            )
+        }
+
+        override fun open(objectKey: String): CloudStoragePort.StoredObject? {
+            openedObjectKeys += objectKey
+            return objects[objectKey]
+        }
+
+        override fun delete(objectKey: String) {
+            deletedObjectKeys += objectKey
+        }
+    }
+}

--- a/back/src/test/kotlin/com/back/support/BaseAdmCloudControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseAdmCloudControllerWebMvcTest.kt
@@ -1,0 +1,85 @@
+package com.back.support
+
+import com.back.boundedContexts.cloud.adapter.web.ApiV1AdmCloudController
+import com.back.boundedContexts.cloud.application.service.CloudFileService
+import com.back.global.security.config.CustomAuthenticationFilter
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.context.annotation.Import
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+
+@WebMvcTest(
+    ApiV1AdmCloudController::class,
+    excludeFilters = [
+        ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = [CustomAuthenticationFilter::class],
+        ),
+    ],
+)
+@Import(BaseAdmCloudControllerWebMvcTest.TestSecurityConfig::class)
+abstract class BaseAdmCloudControllerWebMvcTest : BaseIntegrationTest() {
+    @Autowired
+    protected lateinit var mvc: MockMvc
+
+    @MockitoBean
+    protected lateinit var cloudFileService: CloudFileService
+
+    @MockitoBean(name = "jpaMappingContext")
+    protected lateinit var jpaMappingContext: JpaMetamodelMappingContext
+
+    @TestConfiguration
+    class TestSecurityConfig {
+        @Bean
+        fun testSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+            http {
+                csrf { disable() }
+                formLogin { disable() }
+                logout { disable() }
+                httpBasic { disable() }
+                sessionManagement {
+                    sessionCreationPolicy = SessionCreationPolicy.STATELESS
+                }
+                authorizeHttpRequests {
+                    authorize("/system/api/v1/adm/cloud/**", hasRole("ADMIN"))
+                    authorize(anyRequest, permitAll)
+                }
+                exceptionHandling {
+                    authenticationEntryPoint = jsonAuthenticationEntryPoint()
+                    accessDeniedHandler = jsonAccessDeniedHandler()
+                }
+            }
+
+            return http.build()
+        }
+
+        @Bean
+        fun jsonAuthenticationEntryPoint(): AuthenticationEntryPoint =
+            AuthenticationEntryPoint { _, response, _ ->
+                response.status = 401
+                response.contentType = "$APPLICATION_JSON_VALUE;charset=UTF-8"
+                response.writer.write("""{"resultCode":"401-1","msg":"로그인 후 이용해주세요."}""")
+            }
+
+        @Bean
+        fun jsonAccessDeniedHandler(): AccessDeniedHandler =
+            AccessDeniedHandler { _, response, _ ->
+                response.status = 403
+                response.contentType = "$APPLICATION_JSON_VALUE;charset=UTF-8"
+                response.writer.write("""{"resultCode":"403-1","msg":"권한이 없습니다."}""")
+            }
+    }
+}

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -422,6 +422,90 @@
         }
       }
     },
+    "/system/api/v1/adm/cloud/files" : {
+      "get" : {
+        "tags" : [ "api-v-1-adm-cloud-controller" ],
+        "operationId" : "listFiles",
+        "parameters" : [ {
+          "name" : "folderPath",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : ""
+          }
+        }, {
+          "name" : "kw",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : ""
+          }
+        }, {
+          "name" : "mediaKind",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "DOCUMENT", "PHOTO", "VIDEO" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CloudFileListResBody"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "api-v-1-adm-cloud-controller" ],
+        "operationId" : "upload",
+        "parameters" : [ {
+          "name" : "folderPath",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : ""
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "multipart/form-data" : {
+              "schema" : {
+                "type" : "object",
+                "properties" : {
+                  "file" : {
+                    "type" : "string",
+                    "format" : "binary"
+                  }
+                },
+                "required" : [ "file" ]
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RsDataCloudFileDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/post/api/v1/posts" : {
       "get" : {
         "tags" : [ "api-v-1-post-controller" ],
@@ -1253,6 +1337,89 @@
               "*/*" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/AdminDashboardSnapshot"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/system/api/v1/adm/cloud/files/{id}" : {
+      "get" : {
+        "tags" : [ "api-v-1-adm-cloud-controller" ],
+        "operationId" : "getFile",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CloudFileDto"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "api-v-1-adm-cloud-controller" ],
+        "operationId" : "delete_2",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RsDataVoid"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/system/api/v1/adm/cloud/files/{id}/content" : {
+      "get" : {
+        "tags" : [ "api-v-1-adm-cloud-controller" ],
+        "operationId" : "content",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string",
+                  "format" : "binary"
                 }
               }
             }
@@ -2985,6 +3152,58 @@
           }
         }
       },
+      "CloudFileDto" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "ownerMemberId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "originalFilename" : {
+            "type" : "string"
+          },
+          "contentType" : {
+            "type" : "string"
+          },
+          "byteSize" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "mediaKind" : {
+            "type" : "string",
+            "enum" : [ "DOCUMENT", "PHOTO", "VIDEO" ]
+          },
+          "folderPath" : {
+            "type" : "string"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "modifiedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }
+      },
+      "RsDataCloudFileDto" : {
+        "type" : "object",
+        "properties" : {
+          "resultCode" : {
+            "type" : "string"
+          },
+          "msg" : {
+            "type" : "string"
+          },
+          "data" : {
+            "$ref" : "#/components/schemas/CloudFileDto"
+          }
+        }
+      },
       "PostWriteRequest" : {
         "type" : "object",
         "properties" : {
@@ -4335,6 +4554,17 @@
           },
           "latestFailureMessage" : {
             "type" : "string"
+          }
+        }
+      },
+      "CloudFileListResBody" : {
+        "type" : "object",
+        "properties" : {
+          "files" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CloudFileDto"
+            }
           }
         }
       },

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -493,8 +493,8 @@
           }
         },
         "responses" : {
-          "200" : {
-            "description" : "OK",
+          "201" : {
+            "description" : "Created",
             "content" : {
               "*/*" : {
                 "schema" : {

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -2465,8 +2465,8 @@ export interface operations {
             };
         };
         responses: {
-            /** @description OK */
-            200: {
+            /** @description Created */
+            201: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -132,6 +132,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/system/api/v1/adm/cloud/files": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["listFiles"];
+        put?: never;
+        post: operations["upload"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/post/api/v1/posts": {
         parameters: {
             query?: never;
@@ -558,6 +574,38 @@ export interface paths {
             cookie?: never;
         };
         get: operations["dashboardSnapshot"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/system/api/v1/adm/cloud/files/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getFile"];
+        put?: never;
+        post?: never;
+        delete: operations["delete_2"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/system/api/v1/adm/cloud/files/{id}/content": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["content"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1348,6 +1396,28 @@ export interface components {
                 [key: string]: string;
             };
         };
+        CloudFileDto: {
+            /** Format: int64 */
+            id?: number;
+            /** Format: int64 */
+            ownerMemberId?: number;
+            originalFilename?: string;
+            contentType?: string;
+            /** Format: int64 */
+            byteSize?: number;
+            /** @enum {string} */
+            mediaKind?: "DOCUMENT" | "PHOTO" | "VIDEO";
+            folderPath?: string;
+            /** Format: date-time */
+            createdAt?: string;
+            /** Format: date-time */
+            modifiedAt?: string;
+        };
+        RsDataCloudFileDto: {
+            resultCode?: string;
+            msg?: string;
+            data?: components["schemas"]["CloudFileDto"];
+        };
         PostWriteRequest: {
             title: string;
             content: string;
@@ -1853,6 +1923,9 @@ export interface components {
             latestFailureAt?: string;
             latestFailureMessage?: string;
         };
+        CloudFileListResBody: {
+            files?: components["schemas"]["CloudFileDto"][];
+        };
         AdminSystemBootstrapResBody: {
             member?: components["schemas"]["AuthSessionMemberDto"];
             health?: components["schemas"]["HealthResBody"];
@@ -2346,6 +2419,59 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["RsDataMapStringString"];
+                };
+            };
+        };
+    };
+    listFiles: {
+        parameters: {
+            query?: {
+                folderPath?: string;
+                kw?: string;
+                mediaKind?: "DOCUMENT" | "PHOTO" | "VIDEO";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["CloudFileListResBody"];
+                };
+            };
+        };
+    };
+    upload: {
+        parameters: {
+            query?: {
+                folderPath?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "multipart/form-data": {
+                    /** Format: binary */
+                    file: string;
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RsDataCloudFileDto"];
                 };
             };
         };
@@ -3018,6 +3144,72 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["AdminDashboardSnapshot"];
+                };
+            };
+        };
+    };
+    getFile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["CloudFileDto"];
+                };
+            };
+        };
+    };
+    delete_2: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    content: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": string;
                 };
             };
         };


### PR DESCRIPTION
## 관련 이슈

close #664

## 작업 배경

- 관리자 전용 cloud 파일 metadata, owner-scoped API, private content streaming을 backend에 추가했습니다.
- 모든 파일 접근은 admin session의 `SecurityUser.id`와 `ownerMemberId`가 일치할 때만 storage object를 열도록 구성했습니다.
- OpenAPI snapshot과 generated shared contract도 backend API 변경에 맞춰 갱신했습니다.

## 작업 내용

- `/system/api/v1/adm/cloud/**` upload/list/detail/content/delete API 추가
- `cloud_file` schema/domain/repository와 owner-scoped query 추가
- MinIO/S3 호환 cloud storage adapter와 `cloud/{owner}/...` object key 검증 추가
- 파일 시그니처 기반 content type 판별, folder/object key traversal 차단, private Range streaming 추가
- 한글 `@DisplayName` backend 테스트와 support WebMvc base 추가

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back ktlintCheck`
  - `back/gradlew -p back test --tests 'com.back.boundedContexts.cloud.*'`
  - `back/gradlew -p back test`
  - `back/gradlew -p back cleanTest test`
  - `yarn --cwd front contracts:generate`
  - `yarn --cwd front contracts:check`
  - pre-commit hook: `OpenApiContractExportTest` + `contracts:check` 통과
  - Codex Security diff scan: `/tmp/codex-security-scans/aquila-blog/local-patch-admin-cloud-backend-20260613T0318/report.html` (reportable finding 0)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 새 `cloud_file` migration과 storage 설정이 live 환경에서 적용되어야 하며, `custom.storage.enabled=false`이면 cloud API는 503으로 실패합니다.
- 롤백 방법: PR merge commit revert 후 자동 배포를 재실행합니다. 생성된 `cloud_file` 테이블은 롤백 후 사용되지 않으며, 데이터 보존이 필요하면 DB 백업 기준으로 별도 처리합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
