### PR TITLE
[Fix] 관리자 클라우드 live e2e 업로드 selector 보강

### DIFF
--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -586,7 +586,7 @@ test.describe("live production e2e", () => {
 
     await page.goto("/admin/cloud")
     await expect(page.getByRole("heading", { name: adminCloudHeadingPattern })).toBeVisible()
-    await expect(page.getByRole("button", { name: /파일 업로드|업로드 중/ })).toBeVisible()
+    await expect(page.getByRole("button", { name: /^(파일 업로드|업로드 중)$/ })).toBeVisible()
 
     await page.goto("/admin/tools")
     await expect(page.getByRole("heading", { name: adminToolsHeadingPattern })).toBeVisible()


### PR DESCRIPTION
## 관련 이슈

close #670

## 작업 배경

- main merge 후 `Deploy to Home Server` live e2e가 `/admin/cloud` 업로드 버튼 확인에서 Playwright strict mode violation으로 실패하던 문제를 수정했습니다.
- 원인은 `파일 업로드|업로드 중` 부분 매칭이 file input의 `클라우드 파일 업로드` aria-label과 실제 visible button을 동시에 잡은 것입니다.
- selector를 실제 버튼 텍스트와 정확히 일치하도록 제한해 live smoke가 의도한 요소 1개만 확인하게 했습니다.

## 작업 내용

- `front/e2e/live.spec.ts`의 `/admin/cloud` 업로드 버튼 확인 selector를 `/^(파일 업로드|업로드 중)$/`로 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - RED: `Deploy to Home Server` run `27452642108` attempt 2, job `81151326727`에서 `e2e/live.spec.ts:589` strict mode violation 확인
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 PLAYWRIGHT_USE_WEBSERVER=true yarn --cwd front playwright test e2e/admin-cloud.spec.ts --workers=1`
  - `PLAYWRIGHT_BASE_URL=https://www.aquilaxk.site PLAYWRIGHT_USE_WEBSERVER=false E2E_EXPECTED_FRONT_COMMIT_SHA=b17a3a0a0cbd86b80dcb6d99f9a7fb49125beb5d yarn --cwd front playwright test e2e/live.spec.ts --grep "관리자 로그인 후 핵심 운영 경로" --workers=1` (로컬 live secret 없음으로 1 skipped)
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: selector 정밀화로 실제 버튼 문구가 바뀌면 live smoke가 다시 실패할 수 있습니다. 버튼의 현재 제품 문구는 `파일 업로드`/`업로드 중`입니다.
- 롤백 방법: 이 PR의 단일 commit `29a8bd82`를 revert하면 기존 selector로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
