### PR TITLE
[Fix] 507 하단 에디터 선택 CI 안정화

### DIFF
--- a/front/e2e/editor-authoring-block-selection.spec.ts
+++ b/front/e2e/editor-authoring-block-selection.spec.ts
@@ -715,7 +715,7 @@ test.describe("editor authoring block selection and drag", () => {
       expect(metrics.rail.right).toBeLessThanOrEqual(metrics.viewport.width - metrics.viewport.padding + viewportTolerancePx)
       expect(metrics.rail.bottom).toBeLessThanOrEqual(metrics.viewport.height - metrics.viewport.padding + viewportTolerancePx)
       expect(metrics.targetRailGap).toBeGreaterThanOrEqual(8)
-      expect(metrics.targetRailGap).toBeLessThanOrEqual(24)
+      expect(metrics.targetRailGap).toBeLessThanOrEqual(28)
       expect(metrics.targetTextGap ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(72)
       expect({ collisions: metrics.collisions, metrics, targetText }).toMatchObject({
         collisions: [],

--- a/front/src/components/editor/blockHandleLayoutModel.ts
+++ b/front/src/components/editor/blockHandleLayoutModel.ts
@@ -1,7 +1,7 @@
 import type { BlockEditorDoc } from "./serialization"
 
 export const BLOCK_HANDLE_VIEWPORT_PADDING_PX = 12
-export const BLOCK_HANDLE_GUTTER_GAP_PX = 20.7
+export const BLOCK_HANDLE_GUTTER_GAP_PX = 22.75
 export const BLOCK_HANDLE_STACKED_GAP_PX = 8
 
 export type BlockHandleRailLayout = {
@@ -866,13 +866,10 @@ export const preserveWindowScrollForEditorPointerFocus = (
   const shouldPreserveCodeSelectionFollowUp =
     editorPointerTarget &&
     !editorControlTarget &&
-    codePointerTarget &&
+    !tablePointerTarget &&
     (preserveNextEditorPointerAfterCodeSelection ||
       codeSelectionFollowUpReentryActive ||
       codeSelectionFollowUpRecent)
-  if (editorPointerTarget && !codePointerTarget && codeSelectionFollowUpRecent) {
-    clearNextEditorPointerAfterCodeSelection()
-  }
   const shouldPreserveFollowUp =
     !tablePointerTarget && preserveNextEditorPointerAfterTable
   if (codeSelectionFollowUpOnly && !shouldPreserveCodeSelectionFollowUp) return

--- a/front/src/components/editor/useBlockEditorEngineBlockSelectionLayout.ts
+++ b/front/src/components/editor/useBlockEditorEngineBlockSelectionLayout.ts
@@ -211,10 +211,7 @@ export const useBlockEditorEngineBlockSelectionLayout = ({
       hideBlockHandle()
       return
     }
-    const contentRoot =
-      !isCoarsePointer && textSelectionBlockIndex !== null
-        ? getContentRoot()
-        : null
+    const contentRoot = !isCoarsePointer ? getContentRoot() : null
     const nativeTextSelectionActive = Boolean(
       contentRoot && hasNativeEditorTextSelection(contentRoot)
     )

--- a/front/src/components/editor/useBlockEditorEngineBlockSelectionUi.ts
+++ b/front/src/components/editor/useBlockEditorEngineBlockSelectionUi.ts
@@ -1,5 +1,5 @@
 import type { Editor as TiptapEditor } from "@tiptap/core"
-import { useCallback } from "react"
+import { useCallback, useRef } from "react"
 import type {
   Dispatch,
   KeyboardEvent as ReactKeyboardEvent,
@@ -243,6 +243,8 @@ export const useBlockEditorEngineBlockSelectionUi = ({
   textSelectionBlockIndex,
   viewportRef,
 }: UseBlockEditorEngineBlockSelectionUiArgs) => {
+  const blockHandleRailHoverBlockIndexRef = useRef<number | null>(null)
+
   useBlockEditorEngineBlockSelectionLayout({
     blockHandleRailMetricsRef,
     blockHandleGutterHoverBlockIndex,
@@ -291,7 +293,12 @@ export const useBlockEditorEngineBlockSelectionUi = ({
   }, [clearNativeTextSelection])
 
   const syncViewportHoverState = useCallback(
-    (targetEvent: EventTarget | null, clientX: number, clientY: number) => {
+    (
+      targetEvent: EventTarget | null,
+      clientX: number,
+      clientY: number,
+      buttons = 0
+    ) => {
       cancelHoveredBlockClear()
       const rowResizeState = isTableRowResizeActive()
       const columnResizeState = isTableColumnRailResizeActive()
@@ -343,8 +350,31 @@ export const useBlockEditorEngineBlockSelectionUi = ({
             clientX < targetBlockRect.left
           )
       )
+      const hasBlockHandleRailHover = Boolean(
+        target?.closest("[data-block-handle-rail='true']") ||
+          target?.closest("[data-block-menu-root='true']")
+      )
+      const isPrimaryPointerButtonDown = (buttons & 1) === 1
+      if (
+        blockHandleRailHoverBlockIndexRef.current !== null &&
+        blockHandleRailHoverBlockIndexRef.current !== targetBlockIndex &&
+        !hasBlockHandleRailHover
+      ) {
+        blockHandleRailHoverBlockIndexRef.current = null
+      }
+      const shouldKeepCurrentBlockHandleHover =
+        !isBlockHandleGutterHover &&
+        blockHandleRailHoverBlockIndexRef.current === targetBlockIndex &&
+        blockHandleState.visible &&
+        blockHandleState.blockIndex === targetBlockIndex
+      const shouldUseBlockHandleGutterHover =
+        isBlockHandleGutterHover &&
+        (!isPrimaryPointerButtonDown ||
+          blockHandleRailHoverBlockIndexRef.current === targetBlockIndex)
       setBlockHandleGutterHoverBlockIndex(
-        isBlockHandleGutterHover ? targetBlockIndex : null
+        shouldUseBlockHandleGutterHover || shouldKeepCurrentBlockHandleHover
+          ? targetBlockIndex
+          : null
       )
       const isFarLeftTableBlockGutter = Boolean(
         targetBlockElement?.querySelector(
@@ -426,6 +456,7 @@ export const useBlockEditorEngineBlockSelectionUi = ({
         target?.closest("[data-block-menu-root='true']")
       ) {
         if (blockHandleState.visible) {
+          blockHandleRailHoverBlockIndexRef.current = blockHandleState.blockIndex
           setBlockHandleGutterHoverBlockIndex(blockHandleState.blockIndex)
           if (blockHandleState.kind === "list-item" && hoveredListItemContext) {
             setHoveredListItemContext(hoveredListItemContext)
@@ -491,14 +522,24 @@ export const useBlockEditorEngineBlockSelectionUi = ({
 
   const handleViewportPointerMove = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
-      syncViewportHoverState(event.target, event.clientX, event.clientY)
+      syncViewportHoverState(
+        event.target,
+        event.clientX,
+        event.clientY,
+        event.buttons
+      )
     },
     [syncViewportHoverState]
   )
 
   const handleViewportMouseMove = useCallback(
     (event: ReactMouseEvent<HTMLDivElement>) => {
-      syncViewportHoverState(event.target, event.clientX, event.clientY)
+      syncViewportHoverState(
+        event.target,
+        event.clientX,
+        event.clientY,
+        event.buttons
+      )
     },
     [syncViewportHoverState]
   )
@@ -630,6 +671,22 @@ export const useBlockEditorEngineBlockSelectionUi = ({
       const targetBlockIndex =
         findTopLevelBlockIndexFromTarget(event.target) ??
         findTopLevelBlockIndexByClientPosition(event.clientX, event.clientY)
+      const targetElement =
+        event.target instanceof Element
+          ? event.target
+          : event.target instanceof Node
+          ? event.target.parentElement
+          : null
+      const hasBlockHandleRailPointerTarget = Boolean(
+        targetElement?.closest("[data-block-handle-rail='true']") ||
+          targetElement?.closest("[data-block-menu-root='true']")
+      )
+      if (
+        !hasBlockHandleRailPointerTarget &&
+        blockHandleRailHoverBlockIndexRef.current !== targetBlockIndex
+      ) {
+        setBlockHandleGutterHoverBlockIndex(null)
+      }
       const currentEditor = editorRef.current ?? editor
       const hasActiveBlockSelection =
         selectedBlockNodeIndex !== null ||
@@ -751,6 +808,7 @@ export const useBlockEditorEngineBlockSelectionUi = ({
       selectedBlockNodeIndex,
       selectedBlockNodeIndexRef,
       setClickedBlockIndex,
+      setBlockHandleGutterHoverBlockIndex,
       setSelectedBlockNodeIndex,
       setSelectedListItemContext,
       setTableQuickRailHovered,


### PR DESCRIPTION
## 관련 이슈

close #662

## 작업 배경

- Stabilize 507 lower editor selection CI after #673 by widening the list/block handle gutter margin for CI subpixel marker safety.
- Preserve code-selection follow-up scroll handling for non-table editor pointers so code -> lower body selection does not jump back to stale anchors.
- Keep block handles visible only for explicit rail-hover text selection, while hiding handles during ordinary native text selection and still allowing lower-body block drag after selection.

## 작업 내용

- Stabilize 507 lower editor selection CI after #673 by widening the list/block handle gutter margin for CI subpixel marker safety.
- Preserve code-selection follow-up scroll handling for non-table editor pointers so code -> lower body selection does not jump back to stale anchors.
- Keep block handles visible only for explicit rail-hover text selection, while hiding handles during ordinary native text selection and still allowing lower-body block drag after selection.

## 검증

- 실행한 명령과 결과:
  - CodeRabbit CLI review (uncommitted): 0 issues
  - CodeRabbit CLI review (committed, base 74ff3b8): 0 issues
  - env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn playwright test e2e/editor-authoring-block-selection.spec.ts:188 e2e/editor-authoring-route-scroll-selection.spec.ts:8 e2e/editor-authoring-route-scroll-selection.spec.ts:103 e2e/editor-authoring-selection-bubble-occlusion.spec.ts:77 e2e/editor-authoring-selection-bubble-occlusion.spec.ts:195 e2e/editor-authoring-route-real-507-lower-gate.spec.ts --workers=1: 6 passed
  - env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn playwright test e2e/editor-authoring-block-selection.spec.ts e2e/editor-authoring-list-affordances.spec.ts e2e/editor-authoring-route-live-drag-sequence.spec.ts e2e/editor-authoring-route-scroll-selection.spec.ts e2e/editor-authoring-selection-bubble-occlusion.spec.ts --workers=1: 39 passed
  - env -u NO_COLOR yarn test:e2e:authoring: 175 passed, 2 consecutive runs
  - env -u NO_COLOR yarn build: passed

  Refs #662
  Follow-up to #673

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 특이사항 없음

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
