### PR TITLE
[Feat] 관리자 클라우드와 admin surface UX 재설계

### DIFF
--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -88,6 +88,8 @@ const getUploadFileMetadata = (name: string) => {
   return { contentType: "application/pdf", mediaKind: "DOCUMENT" as const }
 }
 
+const normalizeFolderPathParam = (value: string) => value.trim().replace(/^\/+|\/+$/g, "")
+
 const setupAdminCloudMocks = async (
   page: Page,
   options: {
@@ -95,6 +97,7 @@ const setupAdminCloudMocks = async (
   } = {}
 ) => {
   const requestedKinds: string[] = []
+  const requestedFolderPaths: string[] = []
   const uploadedNames: string[] = []
   const deletedIds: string[] = []
   const uploadedFiles: CloudFileFixture[] = []
@@ -131,6 +134,7 @@ const setupAdminCloudMocks = async (
     const url = new URL(request.url())
     const id = url.pathname.match(/\/files\/(\d+)$/)?.[1] ?? ""
     const mediaKind = url.searchParams.get("mediaKind") || "ALL"
+    const folderPath = normalizeFolderPathParam(url.searchParams.get("folderPath") || "")
 
     if (request.method() === "DELETE" && id) {
       if (failedDeleteIds.has(id)) {
@@ -180,12 +184,14 @@ const setupAdminCloudMocks = async (
     }
 
     requestedKinds.push(mediaKind)
+    requestedFolderPaths.push(folderPath)
     const keyword = (url.searchParams.get("kw") || "").toLowerCase()
     const files = [...uploadedFiles, ...CLOUD_FILES].filter((file) => {
       const isDeleted = deletedIds.includes(String(file.id))
       const kindMatches = mediaKind === "ALL" || file.mediaKind === mediaKind
+      const folderMatches = !folderPath || normalizeFolderPathParam(file.folderPath) === folderPath
       const keywordMatches = !keyword || file.originalFilename.toLowerCase().includes(keyword)
-      return !isDeleted && kindMatches && keywordMatches
+      return !isDeleted && kindMatches && folderMatches && keywordMatches
     })
     await fulfillJson(route, { files })
   })
@@ -207,7 +213,7 @@ const setupAdminCloudMocks = async (
     })
   })
 
-  return { requestedKinds, uploadedNames, deletedIds }
+  return { requestedKinds, requestedFolderPaths, uploadedNames, deletedIds }
 }
 
 test.describe("관리자 클라우드", () => {
@@ -226,6 +232,11 @@ test.describe("관리자 클라우드", () => {
     await expect(page.getByRole("button", { name: "운영 점검 리포트.pdf 즐겨찾기 기능 준비 중" })).toBeDisabled()
 
     const searchInput = page.getByLabel("클라우드 파일 검색")
+    await searchInput.fill("/photos")
+    await expect.poll(() => mocks.requestedFolderPaths).toContain("photos")
+    await expect(page.getByRole("row", { name: /home-server-rack\.png/ })).toBeVisible()
+    await expect(page.getByRole("row", { name: /운영 점검 리포트\.pdf/ })).toHaveCount(0)
+
     await searchInput.fill("deploy")
     await expect(page.getByRole("row", { name: /deploy-walkthrough\.mp4/ })).toBeVisible()
 

--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -8,7 +8,19 @@ const ADMIN_MEMBER = {
   blogTitle: "AquilaLog",
 }
 
-const CLOUD_FILES = [
+type CloudFileFixture = {
+  id: number
+  ownerMemberId: number
+  originalFilename: string
+  contentType: string
+  byteSize: number
+  mediaKind: "DOCUMENT" | "PHOTO" | "VIDEO"
+  folderPath: string
+  createdAt: string
+  modifiedAt: string
+}
+
+const CLOUD_FILES: CloudFileFixture[] = [
   {
     id: 101,
     ownerMemberId: 1,
@@ -49,6 +61,8 @@ const pixelPng = Buffer.from(
   "base64"
 )
 
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
 const fulfillJson = async (route: Route, body: unknown, status = 200) => {
   await route.fulfill({
     status,
@@ -57,10 +71,29 @@ const fulfillJson = async (route: Route, body: unknown, status = 200) => {
   })
 }
 
+const getUploadName = (route: Route) => {
+  const body = route.request().postDataBuffer()
+  const bodyText = body?.toString("utf8") ?? ""
+  return bodyText.match(/filename="([^"]+)"/)?.[1] ?? "uploaded.pdf"
+}
+
+const getUploadFileMetadata = (name: string) => {
+  const lowerName = name.toLowerCase()
+  if (lowerName.endsWith(".png") || lowerName.endsWith(".jpg") || lowerName.endsWith(".jpeg")) {
+    return { contentType: "image/png", mediaKind: "PHOTO" as const }
+  }
+  if (lowerName.endsWith(".mp4") || lowerName.endsWith(".mov")) {
+    return { contentType: "video/mp4", mediaKind: "VIDEO" as const }
+  }
+  return { contentType: "application/pdf", mediaKind: "DOCUMENT" as const }
+}
+
 const setupAdminCloudMocks = async (page: Page) => {
   const requestedKinds: string[] = []
   const uploadedNames: string[] = []
   const deletedIds: string[] = []
+  const uploadedFiles: CloudFileFixture[] = []
+  let nextUploadId = 204
 
   await page.route("**/_next/image**", async (route) => {
     await route.fulfill({ status: 200, contentType: "image/png", body: pixelPng })
@@ -96,28 +129,45 @@ const setupAdminCloudMocks = async (page: Page) => {
     }
 
     if (request.method() === "POST") {
-      uploadedNames.push("신규 운영 문서.pdf")
-      await fulfillJson(
-        route,
-        {
-          resultCode: "201-1",
-          msg: "클라우드 파일이 업로드되었습니다.",
-          data: {
-            ...CLOUD_FILES[0],
-            id: 204,
-            originalFilename: uploadedNames.at(-1) || "uploaded.pdf",
-            createdAt: "2026-06-12T12:00:00Z",
-            modifiedAt: "2026-06-12T12:00:00Z",
+      const uploadedName = getUploadName(route)
+      const metadata = getUploadFileMetadata(uploadedName)
+
+      if (uploadedName.includes("취소할")) await delay(700)
+
+      const uploaded = {
+        id: nextUploadId++,
+        ownerMemberId: 1,
+        originalFilename: uploadedName,
+        contentType: metadata.contentType,
+        byteSize: route.request().postDataBuffer()?.byteLength ?? 0,
+        mediaKind: metadata.mediaKind,
+        folderPath: "/",
+        createdAt: "2026-06-12T12:00:00Z",
+        modifiedAt: "2026-06-12T12:00:00Z",
+      }
+
+      uploadedNames.push(uploadedName)
+      if (!uploadedName.includes("취소할")) uploadedFiles.unshift(uploaded)
+
+      try {
+        await fulfillJson(
+          route,
+          {
+            resultCode: "201-1",
+            msg: "클라우드 파일이 업로드되었습니다.",
+            data: uploaded,
           },
-        },
-        201
-      )
+          201
+        )
+      } catch {
+        // The page aborts the in-flight request when an active upload is cancelled.
+      }
       return
     }
 
     requestedKinds.push(mediaKind)
     const keyword = (url.searchParams.get("kw") || "").toLowerCase()
-    const files = CLOUD_FILES.filter((file) => {
+    const files = [...uploadedFiles, ...CLOUD_FILES].filter((file) => {
       const kindMatches = mediaKind === "ALL" || file.mediaKind === mediaKind
       const keywordMatches = !keyword || file.originalFilename.toLowerCase().includes(keyword)
       return kindMatches && keywordMatches
@@ -128,7 +178,7 @@ const setupAdminCloudMocks = async (page: Page) => {
   await page.route("**/system/api/v1/adm/cloud/files/*/content", async (route) => {
     const url = new URL(route.request().url())
     const id = url.pathname.match(/\/files\/(\d+)\/content/)?.[1] ?? ""
-    const file = CLOUD_FILES.find((item) => String(item.id) === id)
+    const file = [...uploadedFiles, ...CLOUD_FILES].find((item) => String(item.id) === id)
     const contentType = file?.contentType ?? "application/octet-stream"
 
     await route.fulfill({
@@ -146,35 +196,62 @@ const setupAdminCloudMocks = async (page: Page) => {
 }
 
 test.describe("관리자 클라우드", () => {
-  test("파일 목록, 업로드, 삭제와 owner 전용 preview drawer가 동작한다", async ({ page }) => {
+  test("MYBOX형 파일 목록, 다중 업로드 큐, 취소, 삭제와 owner 전용 preview drawer가 동작한다", async ({ page }) => {
     const mocks = await setupAdminCloudMocks(page)
 
     await page.goto("/admin/cloud")
 
     await expect(page.getByRole("heading", { name: "관리자 클라우드" })).toBeVisible()
-    await expect(page.getByRole("link", { name: "클라우드" })).toHaveAttribute("href", "/admin/cloud")
-    await expect(page.locator("article").filter({ hasText: "운영 점검 리포트.pdf" })).toBeVisible()
-    await expect(page.locator("article").filter({ hasText: "home-server-rack.png" })).toBeVisible()
-    await expect(page.locator("article").filter({ hasText: "deploy-walkthrough.mp4" })).toBeVisible()
+    await expect(page.getByRole("link", { name: "클라우드" }).first()).toHaveAttribute("href", "/admin/cloud")
+    await expect(page.getByRole("row", { name: /운영 점검 리포트\.pdf/ })).toBeVisible()
+    await expect(page.getByRole("row", { name: /home-server-rack\.png/ })).toBeVisible()
+    await expect(page.getByRole("row", { name: /deploy-walkthrough\.mp4/ })).toBeVisible()
+    await expect(page.getByText("표시할 파일이 없습니다.")).toHaveCount(0)
     await expect(page.getByText("계정 소유주만 볼 수 있음").first()).toBeVisible()
 
-    await page.getByPlaceholder("파일명 검색").fill("deploy")
-    await expect(page.locator("article").filter({ hasText: "deploy-walkthrough.mp4" })).toBeVisible()
+    await page.getByPlaceholder("파일, 확장자, 폴더 경로 검색").fill("deploy")
+    await expect(page.getByRole("row", { name: /deploy-walkthrough\.mp4/ })).toBeVisible()
 
-    await page.getByRole("button", { name: "동영상" }).click()
+    await page.getByLabel("파일 종류 필터").getByRole("button", { name: "동영상" }).click()
     await expect.poll(() => mocks.requestedKinds).toContain("VIDEO")
 
-    await page.getByLabel("클라우드 파일 업로드").setInputFiles({
-      name: "신규 운영 문서.pdf",
-      mimeType: "application/pdf",
-      buffer: Buffer.from("%PDF-1.4 mock upload"),
-    })
-    await expect.poll(() => mocks.uploadedNames).toContain("신규 운영 문서.pdf")
-    await expect(page.getByText("업로드 완료")).toBeVisible()
+    await page.getByLabel("파일 종류 필터").getByRole("button", { name: "전체" }).click()
+    await page.getByPlaceholder("파일, 확장자, 폴더 경로 검색").fill("")
+    await page.getByLabel("클라우드 파일 업로드").setInputFiles([
+      {
+        name: "신규 운영 문서.pdf",
+        mimeType: "application/pdf",
+        buffer: Buffer.from("%PDF-1.4 mock upload"),
+      },
+      {
+        name: "배포 캡처.png",
+        mimeType: "image/png",
+        buffer: pixelPng,
+      },
+    ])
 
-    await page.getByRole("button", { name: "전체" }).click()
-    await page.getByPlaceholder("파일명 검색").fill("")
-    await expect(page.locator("article").filter({ hasText: "운영 점검 리포트.pdf" })).toBeVisible()
+    const uploadPanel = page.getByLabel("업로드 중인 파일")
+    await expect(uploadPanel.getByRole("heading", { name: "업로드 관리" })).toBeVisible()
+    await expect(uploadPanel.getByText("신규 운영 문서.pdf")).toBeVisible()
+    await expect(uploadPanel.getByText("배포 캡처.png")).toBeVisible()
+    await expect.poll(() => mocks.uploadedNames).toEqual(
+      expect.arrayContaining(["신규 운영 문서.pdf", "배포 캡처.png"])
+    )
+    await expect(uploadPanel.getByText("완료").first()).toBeVisible()
+    await expect(page.getByRole("row", { name: /신규 운영 문서\.pdf/ })).toBeVisible()
+    await expect(page.getByRole("row", { name: /배포 캡처\.png/ })).toBeVisible()
+
+    await page.getByLabel("클라우드 파일 업로드").setInputFiles({
+      name: "취소할 영상.mp4",
+      mimeType: "video/mp4",
+      buffer: Buffer.from("cancel this upload"),
+    })
+    await expect(uploadPanel.getByText("취소할 영상.mp4")).toBeVisible()
+    await uploadPanel.getByRole("button", { name: "취소할 영상.mp4 업로드 취소" }).click()
+    await expect(uploadPanel.getByText("취소됨")).toBeVisible()
+    await expect(page.getByRole("row", { name: /취소할 영상\.mp4/ })).toHaveCount(0)
+    await uploadPanel.getByRole("button", { name: "완료 항목 지우기" }).click()
+    await expect(page.getByLabel("업로드 중인 파일")).toHaveCount(0)
 
     await page.getByRole("button", { name: "운영 점검 리포트.pdf 미리보기" }).click()
     await expect(page.getByRole("heading", { name: "문서 뷰어" })).toBeVisible()

--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -208,8 +208,10 @@ test.describe("관리자 클라우드", () => {
     await expect(page.getByRole("row", { name: /deploy-walkthrough\.mp4/ })).toBeVisible()
     await expect(page.getByText("표시할 파일이 없습니다.")).toHaveCount(0)
     await expect(page.getByText("계정 소유주만 볼 수 있음").first()).toBeVisible()
+    await expect(page.getByRole("button", { name: "운영 점검 리포트.pdf 즐겨찾기 기능 준비 중" })).toBeDisabled()
 
-    await page.getByPlaceholder("파일, 확장자, 폴더 경로 검색").fill("deploy")
+    const searchInput = page.getByLabel("클라우드 파일 검색")
+    await searchInput.fill("deploy")
     await expect(page.getByRole("row", { name: /deploy-walkthrough\.mp4/ })).toBeVisible()
 
     await page.getByLabel("파일 종류 필터").getByRole("button", { name: "동영상" }).click()
@@ -223,7 +225,7 @@ test.describe("관리자 클라우드", () => {
     await expect(page.getByRole("row", { name: /필터 제외 문서\.pdf/ })).toHaveCount(0)
 
     await page.getByLabel("파일 종류 필터").getByRole("button", { name: "전체" }).click()
-    await page.getByPlaceholder("파일, 확장자, 폴더 경로 검색").fill("")
+    await searchInput.fill("")
     await page.getByLabel("클라우드 파일 업로드").setInputFiles([
       {
         name: "신규 운영 문서.pdf",
@@ -265,6 +267,8 @@ test.describe("관리자 클라우드", () => {
     await expect(page.getByText("PDF.js canvas 렌더링")).toBeVisible()
     await page.getByRole("button", { name: "상세 패널 닫기" }).click()
     await expect(page.getByText("미리 볼 파일을 선택하세요.")).toBeVisible()
+    await page.getByRole("button", { name: "상세 패널 보기" }).click()
+    await expect(page.getByRole("heading", { name: "문서 뷰어" })).toBeVisible()
 
     await page.getByRole("button", { name: "home-server-rack.png 미리보기" }).click()
     await expect(page.getByRole("heading", { name: "사진 보기" })).toBeVisible()

--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -88,11 +88,17 @@ const getUploadFileMetadata = (name: string) => {
   return { contentType: "application/pdf", mediaKind: "DOCUMENT" as const }
 }
 
-const setupAdminCloudMocks = async (page: Page) => {
+const setupAdminCloudMocks = async (
+  page: Page,
+  options: {
+    failDeleteIds?: string[]
+  } = {}
+) => {
   const requestedKinds: string[] = []
   const uploadedNames: string[] = []
   const deletedIds: string[] = []
   const uploadedFiles: CloudFileFixture[] = []
+  const failedDeleteIds = new Set(options.failDeleteIds ?? [])
   let nextUploadId = 204
 
   await page.route("**/_next/image**", async (route) => {
@@ -108,6 +114,10 @@ const setupAdminCloudMocks = async (page: Page) => {
     const id = url.pathname.match(/\/files\/(\d+)$/)?.[1] ?? ""
 
     if (method === "DELETE" && id) {
+      if (failedDeleteIds.has(id)) {
+        await fulfillJson(route, { resultCode: "500-1", msg: "클라우드 파일 삭제에 실패했습니다." }, 500)
+        return
+      }
       deletedIds.push(id)
       await fulfillJson(route, { resultCode: "200-1", msg: "클라우드 파일이 삭제되었습니다." })
       return
@@ -123,6 +133,10 @@ const setupAdminCloudMocks = async (page: Page) => {
     const mediaKind = url.searchParams.get("mediaKind") || "ALL"
 
     if (request.method() === "DELETE" && id) {
+      if (failedDeleteIds.has(id)) {
+        await fulfillJson(route, { resultCode: "500-1", msg: "클라우드 파일 삭제에 실패했습니다." }, 500)
+        return
+      }
       deletedIds.push(id)
       await fulfillJson(route, { resultCode: "200-1", msg: "클라우드 파일이 삭제되었습니다." })
       return
@@ -168,9 +182,10 @@ const setupAdminCloudMocks = async (page: Page) => {
     requestedKinds.push(mediaKind)
     const keyword = (url.searchParams.get("kw") || "").toLowerCase()
     const files = [...uploadedFiles, ...CLOUD_FILES].filter((file) => {
+      const isDeleted = deletedIds.includes(String(file.id))
       const kindMatches = mediaKind === "ALL" || file.mediaKind === mediaKind
       const keywordMatches = !keyword || file.originalFilename.toLowerCase().includes(keyword)
-      return kindMatches && keywordMatches
+      return !isDeleted && kindMatches && keywordMatches
     })
     await fulfillJson(route, { files })
   })
@@ -283,5 +298,21 @@ test.describe("관리자 클라우드", () => {
 
     await page.getByRole("button", { name: "deploy-walkthrough.mp4 삭제" }).click()
     await expect.poll(() => mocks.deletedIds).toContain("103")
+  })
+
+  test("선택 삭제 일부 실패 시 성공 항목만 목록에서 제거하고 실패 알림을 유지한다", async ({ page }) => {
+    const mocks = await setupAdminCloudMocks(page, { failDeleteIds: ["102"] })
+
+    await page.goto("/admin/cloud")
+
+    await page.getByRole("checkbox", { name: "운영 점검 리포트.pdf 선택" }).check()
+    await page.getByRole("checkbox", { name: "home-server-rack.png 선택" }).check()
+    await page.getByRole("button", { name: "선택 삭제" }).click()
+
+    await expect.poll(() => mocks.deletedIds).toContain("101")
+    await expect(page.getByText("1개 삭제 완료, 1개 실패")).toBeVisible()
+    await expect(page.getByRole("row", { name: /운영 점검 리포트\.pdf/ })).toHaveCount(0)
+    await expect(page.getByRole("row", { name: /home-server-rack\.png/ })).toBeVisible()
+    await expect(page.getByRole("checkbox", { name: "home-server-rack.png 선택" })).toBeChecked()
   })
 })

--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -214,6 +214,13 @@ test.describe("관리자 클라우드", () => {
 
     await page.getByLabel("파일 종류 필터").getByRole("button", { name: "동영상" }).click()
     await expect.poll(() => mocks.requestedKinds).toContain("VIDEO")
+    await page.getByLabel("클라우드 파일 업로드").setInputFiles({
+      name: "필터 제외 문서.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4 filtered cache guard"),
+    })
+    await expect.poll(() => mocks.uploadedNames).toContain("필터 제외 문서.pdf")
+    await expect(page.getByRole("row", { name: /필터 제외 문서\.pdf/ })).toHaveCount(0)
 
     await page.getByLabel("파일 종류 필터").getByRole("button", { name: "전체" }).click()
     await page.getByPlaceholder("파일, 확장자, 폴더 경로 검색").fill("")
@@ -256,6 +263,8 @@ test.describe("관리자 클라우드", () => {
     await page.getByRole("button", { name: "운영 점검 리포트.pdf 미리보기" }).click()
     await expect(page.getByRole("heading", { name: "문서 뷰어" })).toBeVisible()
     await expect(page.getByText("PDF.js canvas 렌더링")).toBeVisible()
+    await page.getByRole("button", { name: "상세 패널 닫기" }).click()
+    await expect(page.getByText("미리 볼 파일을 선택하세요.")).toBeVisible()
 
     await page.getByRole("button", { name: "home-server-rack.png 미리보기" }).click()
     await expect(page.getByRole("heading", { name: "사진 보기" })).toBeVisible()

--- a/front/src/apis/backend/cloud.ts
+++ b/front/src/apis/backend/cloud.ts
@@ -61,7 +61,11 @@ export const listCloudFiles = async ({
   return (response.files || []).map(normalizeCloudFile).filter((file) => file.id > 0)
 }
 
-export const uploadCloudFile = async (file: File, folderPath = ""): Promise<CloudFile> => {
+export const uploadCloudFile = async (
+  file: File,
+  folderPath = "",
+  signal?: AbortSignal,
+): Promise<CloudFile> => {
   const formData = new FormData()
   formData.append("file", file)
   const response = await apiFetch<RsDataCloudFileDto>(
@@ -69,6 +73,7 @@ export const uploadCloudFile = async (file: File, folderPath = ""): Promise<Clou
     {
       method: "POST",
       body: formData,
+      signal,
     }
   )
   return normalizeCloudFile(response.data || {})

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -1,16 +1,17 @@
 import styled from "@emotion/styled"
-
-const textPrimary = "#f3f1ea"
-const textSecondary = "#c8c1ae"
-const textMuted = "#918b7d"
-const border = "#34322d"
-const borderStrong = "#6d6040"
-const surface = "#171817"
-const surfaceRaised = "#20211f"
-const surfaceMuted = "#242520"
-const surfaceAccent = "#2d291a"
-const accentGold = "#d0b46c"
-const accentTeal = "#3f8f86"
+import {
+  adminBorder as border,
+  adminBorderStrong as borderStrong,
+  adminGold as accentGold,
+  adminSurface as surface,
+  adminSurfaceAccent as surfaceAccent,
+  adminSurfaceMuted as surfaceMuted,
+  adminSurfaceRaised as surfaceRaised,
+  adminTeal as accentTeal,
+  adminTextMuted as textMuted,
+  adminTextPrimary as textPrimary,
+  adminTextSecondary as textSecondary,
+} from "src/routes/Admin/adminColorTokens"
 
 export const CloudMain = styled.main`
   display: grid;

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -1,53 +1,262 @@
 import styled from "@emotion/styled"
 
+const textPrimary = "#f3f1ea"
+const textSecondary = "#c8c1ae"
+const textMuted = "#918b7d"
+const border = "#34322d"
+const borderStrong = "#6d6040"
+const surface = "#171817"
+const surfaceRaised = "#20211f"
+const surfaceMuted = "#242520"
+const surfaceAccent = "#2d291a"
+const accentGold = "#d0b46c"
+const accentTeal = "#3f8f86"
+
 export const CloudMain = styled.main`
   display: grid;
-  gap: 1rem;
   min-width: 0;
+  color: ${textPrimary};
+  background: ${surface};
+  border: 1px solid ${border};
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.28);
 `
 
-export const CloudHeader = styled.section`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 1rem;
-  align-items: end;
-  padding: 1.35rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray4};
-  border-radius: 22px;
-  background: ${({ theme }) => theme.colors.gray1};
+export const CloudNoticeBar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  min-height: 2.8rem;
+  padding: 0.55rem 1rem;
+  border-bottom: 1px solid ${border};
+  background: #1d1e1b;
+  color: ${textSecondary};
+  font-size: 0.86rem;
+  font-weight: 700;
+
+  strong {
+    color: ${accentGold};
+    font-weight: 850;
+  }
 
   @media (max-width: 760px) {
+    justify-content: flex-start;
+    text-align: left;
+  }
+`
+
+export const CloudWorkspace = styled.section`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 21rem);
+  min-height: calc(100vh - var(--app-header-height, 73px) - 7rem);
+
+  @media (max-width: 1260px) {
+    grid-template-columns: minmax(0, 1fr) minmax(17rem, 19rem);
+  }
+
+  @media (max-width: 980px) {
     grid-template-columns: minmax(0, 1fr);
   }
 `
 
-export const HeaderCopy = styled.div`
+export const CloudNavigationRail = styled.aside`
   display: grid;
-  gap: 0.45rem;
+  align-content: start;
+  gap: 1.25rem;
+  min-width: 0;
+  padding: 1.25rem 1rem;
+  border-right: 1px solid ${border};
+  background: #141514;
 
-  h1 {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: clamp(1.65rem, 3vw, 2.35rem);
-    line-height: 1.08;
-    letter-spacing: 0;
+  @media (max-width: 840px) {
+    border-right: 0;
+    border-bottom: 1px solid ${border};
+    padding: 0.9rem;
+  }
+`
+
+export const CloudNavGroup = styled.div`
+  display: grid;
+  gap: 0.18rem;
+  min-width: 0;
+`
+
+export const CloudNavDivider = styled.hr`
+  width: 100%;
+  border: 0;
+  border-top: 1px solid ${border};
+  margin: 0.25rem 0;
+`
+
+export const CloudNavButton = styled.button`
+  width: 100%;
+  min-height: 2.3rem;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  border: 0;
+  border-radius: 8px;
+  padding: 0.35rem 0.45rem;
+  background: transparent;
+  color: ${textPrimary};
+  font-size: 0.9rem;
+  font-weight: 760;
+  text-align: left;
+  cursor: pointer;
+
+  span:first-of-type {
+    width: 1.35rem;
+    display: inline-grid;
+    place-items: center;
+    color: ${textMuted};
+    font-size: 0.86rem;
+  }
+
+  small {
+    color: ${accentGold};
+    font-size: 0.76rem;
+    font-weight: 850;
+  }
+
+  &[data-active="true"] {
+    color: ${accentGold};
+    background: ${surfaceAccent};
+  }
+
+  &:hover {
+    background: ${surfaceMuted};
+  }
+`
+
+export const StorageMeter = styled.div`
+  display: grid;
+  gap: 0.5rem;
+  margin-top: auto;
+  min-width: 0;
+  padding-top: 0.75rem;
+
+  strong {
+    color: ${accentGold};
+    font-size: 0.86rem;
+    font-weight: 850;
   }
 
   p {
     margin: 0;
-    max-width: 48rem;
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.98rem;
-    line-height: 1.65;
+    color: ${textSecondary};
+    font-size: 0.78rem;
+    font-weight: 700;
+  }
+
+  span {
+    display: block;
+    height: 0.28rem;
+    border-radius: 999px;
+    background: linear-gradient(90deg, ${accentGold} 0 22%, #3b3931 22% 100%);
   }
 `
 
-export const HeaderActions = styled.div`
-  display: flex;
-  gap: 0.55rem;
+export const CloudContent = styled.div`
+  display: grid;
+  align-content: start;
+  min-width: 0;
+  background: ${surface};
+`
+
+export const CloudTitleBar = styled.header`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 26rem);
+  gap: 1rem;
   align-items: center;
+  padding: 1.35rem 1.5rem 0.95rem;
+
+  h1 {
+    margin: 0;
+    color: ${textPrimary};
+    font-size: 1.32rem;
+    line-height: 1.2;
+    font-weight: 850;
+    letter-spacing: 0;
+  }
+
+  p {
+    margin: 0.22rem 0 0;
+    color: ${textMuted};
+    font-size: 0.82rem;
+    line-height: 1.45;
+  }
+
+  @media (max-width: 980px) {
+    grid-template-columns: minmax(0, 1fr);
+  }
+`
+
+export const CloudSearchField = styled.label`
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+
+  svg {
+    position: absolute;
+    left: 0.86rem;
+    color: ${textMuted};
+    pointer-events: none;
+  }
+`
+
+export const SearchInput = styled.input`
+  width: 100%;
+  min-height: 2.42rem;
+  border: 0;
+  border-radius: 999px;
+  padding: 0 3.25rem 0 2.45rem;
+  background: #22231f;
+  color: ${textPrimary};
+  font-size: 0.86rem;
+  font-weight: 700;
+
+  &::placeholder {
+    color: ${textMuted};
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(208, 180, 108, 0.2);
+  }
+`
+
+export const SearchDetail = styled.span`
+  position: absolute;
+  right: 0.85rem;
+  color: ${textMuted};
+  font-size: 0.75rem;
+  font-weight: 750;
+`
+
+export const ActionBar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  min-width: 0;
+  padding: 0.55rem 1.5rem 1rem;
+  border-bottom: 1px solid ${border};
+
+  @media (max-width: 760px) {
+    align-items: stretch;
+    flex-direction: column;
+  }
+`
+
+export const ActionGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
   flex-wrap: wrap;
-  justify-content: flex-end;
 `
 
 export const UploadInput = styled.input`
@@ -60,216 +269,321 @@ export const UploadInput = styled.input`
 
 export const PrimaryButton = styled.button`
   border: 0;
-  border-radius: 10px;
-  min-height: 2.65rem;
-  padding: 0 1rem;
+  border-radius: 5px;
+  min-height: 2.25rem;
+  padding: 0 0.82rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.45rem;
-  background: #0f766e;
-  color: white;
-  font-size: 0.92rem;
-  font-weight: 800;
+  gap: 0.4rem;
+  background: ${accentTeal};
+  color: #f5f2e8;
+  font-size: 0.84rem;
+  font-weight: 850;
   cursor: pointer;
 
   &:disabled {
     cursor: not-allowed;
-    opacity: 0.6;
+    opacity: 0.62;
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(63, 143, 134, 0.25);
   }
 `
 
-export const GhostButton = styled.button`
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  border-radius: 10px;
-  min-height: 2.35rem;
-  padding: 0 0.75rem;
+export const SecondaryButton = styled.button`
+  border: 0;
+  border-radius: 5px;
+  min-height: 2.25rem;
+  padding: 0 0.82rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.35rem;
-  background: ${({ theme }) => theme.colors.gray1};
-  color: ${({ theme }) => theme.colors.gray11};
-  font-size: 0.86rem;
-  font-weight: 750;
+  gap: 0.38rem;
+  background: ${surfaceMuted};
+  color: ${textPrimary};
+  font-size: 0.83rem;
+  font-weight: 820;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+    color: ${textMuted};
+  }
+`
+
+export const IconButton = styled.button`
+  width: 2.25rem;
+  height: 2.25rem;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  border: 1px solid ${border};
+  border-radius: 5px;
+  background: ${surface};
+  color: ${textSecondary};
   cursor: pointer;
 
   &[data-active="true"] {
-    border-color: #0f766e;
-    background: #ecfdf5;
-    color: #115e59;
-  }
-`
-
-export const CloudMetrics = styled.dl`
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.75rem;
-  margin: 0;
-
-  @media (max-width: 900px) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-`
-
-export const MetricItem = styled.div`
-  display: grid;
-  gap: 0.28rem;
-  min-width: 0;
-  padding: 0.9rem 1rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray4};
-  border-radius: 16px;
-  background: ${({ theme }) => theme.colors.gray1};
-
-  dt {
-    color: ${({ theme }) => theme.colors.gray9};
-    font-size: 0.76rem;
-    font-weight: 750;
-  }
-
-  dd {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 1.15rem;
-    font-weight: 850;
-  }
-`
-
-export const WorkspaceGrid = styled.section`
-  display: grid;
-  grid-template-columns: minmax(0, 1.12fr) minmax(21rem, 0.88fr);
-  gap: 1rem;
-  align-items: start;
-
-  @media (max-width: 1120px) {
-    grid-template-columns: minmax(0, 1fr);
-  }
-`
-
-export const FileBrowserPanel = styled.div`
-  display: grid;
-  gap: 0.9rem;
-  min-width: 0;
-  padding: 1rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray4};
-  border-radius: 18px;
-  background: ${({ theme }) => theme.colors.gray1};
-`
-
-export const Toolbar = styled.div`
-  display: grid;
-  grid-template-columns: minmax(12rem, 1fr) auto;
-  gap: 0.75rem;
-  align-items: center;
-
-  @media (max-width: 760px) {
-    grid-template-columns: minmax(0, 1fr);
-  }
-`
-
-export const SearchInput = styled.input`
-  width: 100%;
-  min-height: 2.55rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  border-radius: 10px;
-  padding: 0 0.85rem;
-  background: white;
-  color: ${({ theme }) => theme.colors.gray12};
-  font-size: 0.94rem;
-
-  &:focus {
-    outline: 2px solid rgba(15, 118, 110, 0.22);
-    border-color: #0f766e;
+    color: ${accentGold};
+    border-color: ${borderStrong};
+    background: ${surfaceAccent};
   }
 `
 
 export const FilterGroup = styled.div`
   display: flex;
-  gap: 0.42rem;
+  gap: 0.32rem;
   align-items: center;
   flex-wrap: wrap;
 `
 
-export const FileList = styled.div`
-  display: grid;
-  gap: 0.55rem;
-`
-
-export const FileRow = styled.article`
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: 0.75rem;
+export const GhostButton = styled.button`
+  border: 1px solid transparent;
+  border-radius: 5px;
+  min-height: 2.25rem;
+  padding: 0 0.7rem;
+  display: inline-flex;
   align-items: center;
-  min-width: 0;
-  padding: 0.78rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray4};
-  border-radius: 14px;
-  background: white;
+  justify-content: center;
+  gap: 0.35rem;
+  background: ${surfaceMuted};
+  color: ${textSecondary};
+  font-size: 0.82rem;
+  font-weight: 820;
+  cursor: pointer;
 
-  &[data-selected="true"] {
-    border-color: #0f766e;
-    box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.1);
+  &[data-active="true"] {
+    border-color: ${borderStrong};
+    background: ${surfaceAccent};
+    color: ${accentGold};
   }
 
-  @media (max-width: 680px) {
-    grid-template-columns: auto minmax(0, 1fr);
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.54;
   }
 `
 
-export const KindBadge = styled.span`
-  width: 2.65rem;
-  height: 2.65rem;
-  border-radius: 12px;
-  display: grid;
+export const Notice = styled.p`
+  margin: 0;
+  color: ${accentGold};
+  font-size: 0.82rem;
+  font-weight: 780;
+`
+
+export const FileTableScroll = styled.div`
+  min-width: 0;
+  overflow-x: auto;
+`
+
+export const FileTable = styled.table`
+  width: 100%;
+  min-width: 46rem;
+  border-collapse: collapse;
+  color: ${textPrimary};
+
+  th,
+  td {
+    border-bottom: 1px solid ${border};
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  th {
+    height: 2.25rem;
+    padding: 0 0.7rem;
+    color: ${textMuted};
+    background: #1d1e1b;
+    font-size: 0.75rem;
+    font-weight: 800;
+  }
+
+  td {
+    height: 3.1rem;
+    padding: 0 0.7rem;
+    color: ${textSecondary};
+    font-size: 0.82rem;
+    font-weight: 700;
+  }
+
+  tbody tr[data-selected="true"] {
+    background: #242319;
+  }
+
+  tbody tr:hover {
+    background: #20211f;
+  }
+`
+
+export const SelectBoxCell = styled.td`
+  width: 2.75rem;
+`
+
+export const RowCheckbox = styled.input`
+  width: 1rem;
+  height: 1rem;
+  accent-color: ${accentGold};
+`
+
+export const FavoriteButton = styled.button`
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 0;
+  background: transparent;
+  color: #a0a8b4;
+  cursor: pointer;
+  font-size: 1.15rem;
+`
+
+export const FileTypeIcon = styled.span`
+  width: 1.45rem;
+  height: 1.2rem;
+  display: inline-grid;
   place-items: center;
-  background: #f1f5f9;
-  color: #0f172a;
-  font-size: 0.74rem;
+  border-radius: 4px;
+  background: #3c756f;
+  color: #f5f2e8;
+  font-size: 0.63rem;
   font-weight: 900;
 `
 
-export const FileCopy = styled.div`
+export const FileNameButton = styled.button`
+  border: 0;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.52rem;
   min-width: 0;
-  display: grid;
-  gap: 0.22rem;
+  max-width: 100%;
+  background: transparent;
+  color: ${textPrimary};
+  cursor: pointer;
+  font-size: 0.88rem;
+  font-weight: 800;
+  text-align: left;
 
   strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 0.94rem;
-    overflow-wrap: anywhere;
-  }
-
-  span {
-    color: ${({ theme }) => theme.colors.gray9};
-    font-size: 0.78rem;
-    line-height: 1.45;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 `
 
 export const RowActions = styled.div`
   display: flex;
-  gap: 0.4rem;
   justify-content: flex-end;
+  gap: 0.3rem;
+`
 
-  @media (max-width: 680px) {
-    grid-column: 1 / -1;
-    justify-content: flex-start;
+export const EmptyTableState = styled.div`
+  display: grid;
+  place-items: center;
+  gap: 0.7rem;
+  min-height: 20rem;
+  padding: 2rem;
+  color: ${textMuted};
+  text-align: center;
+
+  strong {
+    color: ${textPrimary};
+    font-size: 1rem;
+  }
+
+  p {
+    margin: 0;
+    max-width: 26rem;
+    color: ${textMuted};
+    font-size: 0.84rem;
+    line-height: 1.55;
   }
 `
 
-export const PreviewPanel = styled.aside`
+export const DetailPanel = styled.aside`
   display: grid;
-  gap: 0.9rem;
+  align-content: start;
+  gap: 1rem;
   min-width: 0;
-  position: sticky;
-  top: calc(var(--app-header-height, 73px) + 1rem);
-  padding: 1rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray4};
-  border-radius: 18px;
-  background: white;
+  padding: 1.35rem 1.25rem;
+  border-left: 1px solid ${border};
+  background: ${surface};
 
-  @media (max-width: 1120px) {
-    position: static;
+  @media (max-width: 1260px) {
+    grid-column: 2;
+  }
+
+  @media (max-width: 980px) {
+    grid-column: 1;
+    border-left: 0;
+    border-top: 1px solid ${border};
+  }
+`
+
+export const DetailHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+
+  h2 {
+    margin: 0;
+    color: ${textPrimary};
+    font-size: 1.08rem;
+    font-weight: 860;
+  }
+`
+
+export const DetailTabs = styled.div`
+  display: flex;
+  gap: 0.35rem;
+  border-bottom: 1px solid ${border};
+`
+
+export const DetailTab = styled.button`
+  border: 0;
+  border-bottom: 2px solid transparent;
+  padding: 0 0.15rem 0.45rem;
+  background: transparent;
+  color: ${textMuted};
+  font-size: 0.84rem;
+  font-weight: 850;
+  cursor: pointer;
+
+  &[data-active="true"] {
+    color: ${accentGold};
+    border-bottom-color: ${accentGold};
+  }
+`
+
+export const DetailPreviewBox = styled.div`
+  display: grid;
+  place-items: center;
+  min-height: 12.5rem;
+  border-radius: 2px;
+  background: ${surfaceMuted};
+  overflow: hidden;
+`
+
+export const DetailMetaList = styled.dl`
+  display: grid;
+  grid-template-columns: 5rem minmax(0, 1fr);
+  gap: 0.68rem 0.8rem;
+  margin: 0;
+
+  dt {
+    color: ${textMuted};
+    font-size: 0.8rem;
+    font-weight: 800;
+  }
+
+  dd {
+    margin: 0;
+    color: ${textPrimary};
+    font-size: 0.82rem;
+    font-weight: 780;
+    overflow-wrap: anywhere;
   }
 `
 
@@ -277,17 +591,17 @@ export const PreviewHeader = styled.div`
   display: grid;
   gap: 0.35rem;
 
-  h2 {
+  h3 {
     margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 1.15rem;
-    letter-spacing: 0;
+    color: ${textPrimary};
+    font-size: 0.96rem;
+    font-weight: 850;
   }
 
   p {
     margin: 0;
-    color: ${({ theme }) => theme.colors.gray9};
-    font-size: 0.82rem;
+    color: ${textMuted};
+    font-size: 0.78rem;
     line-height: 1.5;
     overflow-wrap: anywhere;
   }
@@ -296,28 +610,30 @@ export const PreviewHeader = styled.div`
 export const PreviewStage = styled.div`
   display: grid;
   gap: 0.75rem;
-  min-height: 18rem;
+  width: 100%;
+  min-height: 12rem;
   align-content: start;
 `
 
 export const PdfCanvas = styled.canvas`
   width: 100%;
-  max-height: 22rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray4};
-  border-radius: 12px;
-  background: #f8fafc;
+  max-height: 18rem;
+  border: 1px solid ${border};
+  border-radius: 8px;
+  background: #1b1c1a;
 `
 
 export const PhotoFrame = styled.div`
   display: grid;
   gap: 0.65rem;
+  width: 100%;
 
   img {
     width: 100%;
-    max-height: 25rem;
+    max-height: 18rem;
     object-fit: contain;
-    border-radius: 12px;
-    background: #0f172a;
+    border-radius: 8px;
+    background: #090a09;
   }
 `
 
@@ -328,21 +644,22 @@ export const ThumbnailStrip = styled.div`
 
   span {
     display: block;
-    min-height: 3.4rem;
-    border-radius: 10px;
-    border: 1px solid ${({ theme }) => theme.colors.gray4};
-    background: #f8fafc;
+    min-height: 2.7rem;
+    border-radius: 6px;
+    border: 1px solid ${border};
+    background: #1b1c1a;
   }
 `
 
 export const VideoFrame = styled.div`
   display: grid;
   gap: 0.7rem;
+  width: 100%;
 
   video {
     width: 100%;
     aspect-ratio: 16 / 9;
-    border-radius: 12px;
+    border-radius: 8px;
     background: #020617;
   }
 `
@@ -353,40 +670,162 @@ export const PlayerBar = styled.div`
 `
 
 export const Timeline = styled.div`
-  height: 0.55rem;
+  height: 0.45rem;
   border-radius: 999px;
-  background: linear-gradient(90deg, #0f766e 0 34%, #f59e0b 34% 36%, #e2e8f0 36% 100%);
+  background: linear-gradient(90deg, ${accentGold} 0 34%, ${accentTeal} 34% 36%, #3b3931 36% 100%);
 `
 
 export const InlineList = styled.div`
   display: flex;
-  gap: 0.45rem;
+  gap: 0.4rem;
   flex-wrap: wrap;
 
   span {
-    border: 1px solid ${({ theme }) => theme.colors.gray4};
+    border: 1px solid ${border};
     border-radius: 999px;
-    padding: 0.32rem 0.55rem;
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.76rem;
-    font-weight: 750;
+    padding: 0.25rem 0.48rem;
+    color: ${textSecondary};
+    font-size: 0.72rem;
+    font-weight: 760;
   }
 `
 
-export const Notice = styled.p`
+export const QueuePanel = styled.section`
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  z-index: 30;
+  width: min(26rem, calc(100vw - 2rem));
+  display: grid;
+  gap: 0.72rem;
+  padding: 0.9rem;
+  border: 1px solid ${borderStrong};
+  border-radius: 12px;
+  background: rgba(23, 24, 23, 0.96);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.34);
+`
+
+export const QueueHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+
+  h2 {
+    margin: 0;
+    color: ${textPrimary};
+    font-size: 0.95rem;
+    font-weight: 880;
+  }
+
+  p {
+    margin: 0.16rem 0 0;
+    color: ${textMuted};
+    font-size: 0.74rem;
+    font-weight: 700;
+  }
+`
+
+export const QueueList = styled.ul`
+  display: grid;
+  gap: 0.48rem;
+  max-height: 18rem;
+  overflow: auto;
   margin: 0;
-  color: #115e59;
-  font-size: 0.84rem;
-  font-weight: 750;
+  padding: 0;
+  list-style: none;
+`
+
+export const QueueItem = styled.li`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem 0.75rem;
+  align-items: center;
+  min-width: 0;
+  padding: 0.62rem;
+  border: 1px solid ${border};
+  border-radius: 9px;
+  background: ${surfaceRaised};
+
+  strong {
+    color: ${textPrimary};
+    font-size: 0.8rem;
+    font-weight: 820;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  p {
+    margin: 0.16rem 0 0;
+    color: ${textMuted};
+    font-size: 0.72rem;
+    font-weight: 700;
+  }
+`
+
+export const StatusPill = styled.span`
+  justify-self: end;
+  min-width: 4.2rem;
+  border-radius: 999px;
+  padding: 0.22rem 0.48rem;
+  background: ${surfaceAccent};
+  color: ${accentGold};
+  font-size: 0.7rem;
+  font-weight: 850;
+  text-align: center;
+
+  &[data-status="failed"] {
+    background: #321b20;
+    color: #f87171;
+  }
+
+  &[data-status="cancelled"] {
+    background: #252622;
+    color: ${textMuted};
+  }
+
+  &[data-status="done"] {
+    background: #16342f;
+    color: #5eead4;
+  }
+`
+
+export const ProgressTrack = styled.div`
+  grid-column: 1 / -1;
+  height: 0.28rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #3b3931;
+
+  span {
+    display: block;
+    height: 100%;
+    width: var(--progress, 0%);
+    border-radius: inherit;
+    background: linear-gradient(90deg, ${accentGold}, ${accentTeal});
+    transition: width 180ms ease;
+  }
 `
 
 export const EmptyState = styled.div`
-  min-height: 16rem;
   display: grid;
   place-items: center;
+  gap: 0.45rem;
+  min-height: 10rem;
+  padding: 1.4rem;
   text-align: center;
-  color: ${({ theme }) => theme.colors.gray9};
-  border: 1px dashed ${({ theme }) => theme.colors.gray5};
-  border-radius: 14px;
-  background: #f8fafc;
+  color: ${textMuted};
+
+  strong {
+    color: ${textPrimary};
+    font-size: 0.94rem;
+  }
+
+  p {
+    margin: 0;
+    color: ${textMuted};
+    font-size: 0.8rem;
+    line-height: 1.5;
+  }
 `

--- a/front/src/routes/Admin/AdminCloudWorkspaceModel.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspaceModel.ts
@@ -1,6 +1,7 @@
 import type { CloudFile, CloudMediaKind } from "src/apis/backend/cloud"
 
 export type CloudMediaFilter = "ALL" | CloudMediaKind
+export type UploadQueueStatus = "queued" | "uploading" | "done" | "failed" | "cancelled"
 
 export const CLOUD_FILTERS: Array<{ value: CloudMediaFilter; label: string }> = [
   { value: "ALL", label: "전체" },
@@ -37,6 +38,12 @@ export const getCloudKindBadge = (file: CloudFile) => {
   return "MP4"
 }
 
+export const getCloudKindIconLabel = (file: CloudFile) => {
+  if (file.mediaKind === "DOCUMENT") return "문"
+  if (file.mediaKind === "PHOTO") return "사"
+  return "동"
+}
+
 export const formatCloudFileSize = (bytes: number) => {
   if (!Number.isFinite(bytes) || bytes <= 0) return "0 B"
   const units = ["B", "KB", "MB", "GB"] as const
@@ -54,11 +61,49 @@ export const formatCloudDate = (value?: string) => {
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return "날짜 없음"
   return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
     month: "2-digit",
     day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
   }).format(date)
+}
+
+export const getUploadStatusLabel = (status: UploadQueueStatus) => {
+  if (status === "queued") return "대기"
+  if (status === "uploading") return "업로드 중"
+  if (status === "done") return "완료"
+  if (status === "failed") return "실패"
+  return "취소됨"
+}
+
+export const isUploadActive = (status: UploadQueueStatus) => status === "queued" || status === "uploading"
+
+export const doesCloudFileMatchFilters = (
+  file: CloudFile,
+  filter: CloudMediaFilter,
+  keyword: string,
+) => {
+  const normalizedKeyword = keyword.trim().toLowerCase()
+  const matchesKind = filter === "ALL" || file.mediaKind === filter
+  const matchesKeyword =
+    !normalizedKeyword ||
+    file.originalFilename.toLowerCase().includes(normalizedKeyword) ||
+    file.folderPath.toLowerCase().includes(normalizedKeyword)
+  return matchesKind && matchesKeyword
+}
+
+export const mergeCloudFiles = (primary: CloudFile[], secondary: CloudFile[]) => {
+  const seen = new Set<number>()
+  const merged: CloudFile[] = []
+
+  ;[...primary, ...secondary].forEach((file) => {
+    if (seen.has(file.id)) return
+    seen.add(file.id)
+    merged.push(file)
+  })
+
+  return merged
 }
 
 export const getCloudSummary = (files: CloudFile[]) => {

--- a/front/src/routes/Admin/AdminCloudWorkspaceModel.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspaceModel.ts
@@ -2,6 +2,10 @@ import type { CloudFile, CloudMediaKind } from "src/apis/backend/cloud"
 
 export type CloudMediaFilter = "ALL" | CloudMediaKind
 export type UploadQueueStatus = "queued" | "uploading" | "done" | "failed" | "cancelled"
+export type CloudSearchParams = {
+  folderPath: string
+  keyword: string
+}
 
 export const CLOUD_FILTERS: Array<{ value: CloudMediaFilter; label: string }> = [
   { value: "ALL", label: "전체" },
@@ -79,18 +83,31 @@ export const getUploadStatusLabel = (status: UploadQueueStatus) => {
 
 export const isUploadActive = (status: UploadQueueStatus) => status === "queued" || status === "uploading"
 
+export const normalizeCloudFolderPathSearch = (value: string) => value.trim().replace(/^\/+|\/+$/g, "")
+
+export const resolveCloudSearchParams = (value: string): CloudSearchParams => {
+  const normalized = value.trim()
+  if (!normalized.startsWith("/")) return { folderPath: "", keyword: normalized }
+
+  return {
+    folderPath: normalizeCloudFolderPathSearch(normalized),
+    keyword: "",
+  }
+}
+
 export const doesCloudFileMatchFilters = (
   file: CloudFile,
   filter: CloudMediaFilter,
-  keyword: string,
+  searchText: string,
 ) => {
-  const normalizedKeyword = keyword.trim().toLowerCase()
+  const searchParams = resolveCloudSearchParams(searchText)
+  const normalizedKeyword = searchParams.keyword.toLowerCase()
   const matchesKind = filter === "ALL" || file.mediaKind === filter
-  const matchesKeyword =
-    !normalizedKeyword ||
-    file.originalFilename.toLowerCase().includes(normalizedKeyword) ||
-    file.folderPath.toLowerCase().includes(normalizedKeyword)
-  return matchesKind && matchesKeyword
+  const matchesFolderPath =
+    !searchParams.folderPath ||
+    normalizeCloudFolderPathSearch(file.folderPath) === searchParams.folderPath
+  const matchesKeyword = !normalizedKeyword || file.originalFilename.toLowerCase().includes(normalizedKeyword)
+  return matchesKind && matchesFolderPath && matchesKeyword
 }
 
 export const mergeCloudFiles = (primary: CloudFile[], secondary: CloudFile[]) => {

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -447,25 +447,62 @@ const AdminCloudWorkspacePage = () => {
     setSelectedFileId(fileId)
   }
 
+  const removeDeletedFilesFromCloudCaches = (deletedIds: Set<number>) => {
+    queryClient.getQueriesData<CloudFile[]>({ queryKey: [CLOUD_QUERY_KEY] }).forEach(([queryKey, current]) => {
+      if (!Array.isArray(current)) return
+      queryClient.setQueryData(
+        queryKey,
+        current.filter((file) => !deletedIds.has(file.id))
+      )
+    })
+  }
+
   const handleDelete = async (file: CloudFile) => {
-    await deleteCloudFile(file.id)
-    setNotice(`${file.originalFilename} 삭제 완료`)
-    setOptimisticFiles((current) => current.filter((item) => item.id !== file.id))
-    setCheckedFileIds((current) => current.filter((id) => id !== file.id))
-    if (selectedFileId === file.id) setSelectedFileId(null)
-    await queryClient.invalidateQueries({ queryKey: [CLOUD_QUERY_KEY] })
+    try {
+      await deleteCloudFile(file.id)
+      const deletedIds = new Set([file.id])
+      setNotice(`${file.originalFilename} 삭제 완료`)
+      setOptimisticFiles((current) => current.filter((item) => item.id !== file.id))
+      setCheckedFileIds((current) => current.filter((id) => id !== file.id))
+      removeDeletedFilesFromCloudCaches(deletedIds)
+      if (selectedFileId === file.id) setSelectedFileId(null)
+    } catch {
+      setNotice(`${file.originalFilename} 삭제 실패`)
+    } finally {
+      await queryClient.invalidateQueries({ queryKey: [CLOUD_QUERY_KEY] })
+    }
   }
 
   const handleDeleteSelected = async () => {
     const targets = files.filter((file) => checkedFileIds.includes(file.id))
     if (targets.length === 0) return
 
-    await Promise.all(targets.map((file) => deleteCloudFile(file.id)))
-    const deletedIds = new Set(targets.map((file) => file.id))
-    setOptimisticFiles((current) => current.filter((file) => !deletedIds.has(file.id)))
-    setCheckedFileIds([])
-    if (selectedFileId && deletedIds.has(selectedFileId)) setSelectedFileId(null)
-    setNotice(`${targets.length}개 파일 삭제 완료`)
+    const results = await Promise.allSettled(
+      targets.map(async (file) => {
+        await deleteCloudFile(file.id)
+        return file
+      })
+    )
+    const deletedFiles = results.flatMap((result) => (result.status === "fulfilled" ? [result.value] : []))
+    const deletedIds = new Set(deletedFiles.map((file) => file.id))
+    const failedCount = targets.length - deletedIds.size
+
+    if (deletedIds.size > 0) {
+      setOptimisticFiles((current) => current.filter((file) => !deletedIds.has(file.id)))
+      setCheckedFileIds((current) => current.filter((id) => !deletedIds.has(id)))
+      removeDeletedFilesFromCloudCaches(deletedIds)
+      if (selectedFileId && deletedIds.has(selectedFileId)) setSelectedFileId(null)
+    }
+
+    if (failedCount > 0) {
+      setNotice(
+        deletedIds.size > 0
+          ? `${deletedIds.size}개 삭제 완료, ${failedCount}개 실패`
+          : `${failedCount}개 파일 삭제 실패`
+      )
+    } else {
+      setNotice(`${deletedIds.size}개 파일 삭제 완료`)
+    }
     await queryClient.invalidateQueries({ queryKey: [CLOUD_QUERY_KEY] })
   }
 

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -25,6 +25,7 @@ import {
   getUploadStatusLabel,
   isUploadActive,
   mergeCloudFiles,
+  resolveCloudSearchParams,
   type CloudMediaFilter,
   type UploadQueueStatus,
 } from "./AdminCloudWorkspaceModel"
@@ -308,11 +309,14 @@ const AdminCloudWorkspacePage = () => {
 
   const filesQuery = useQuery({
     queryKey: [CLOUD_QUERY_KEY, filter, keyword],
-    queryFn: () =>
-      listCloudFiles({
-        keyword,
+    queryFn: () => {
+      const searchParams = resolveCloudSearchParams(keyword)
+      return listCloudFiles({
+        folderPath: searchParams.folderPath,
+        keyword: searchParams.keyword,
         mediaKind: mediaKindFromFilter(filter),
-      }),
+      })
+    },
   })
   const serverFiles = filesQuery.data ?? EMPTY_CLOUD_FILES
   const visibleOptimisticFiles = useMemo(
@@ -534,7 +538,7 @@ const AdminCloudWorkspacePage = () => {
               <AppIcon name="search" />
               <SearchInput
                 aria-label="클라우드 파일 검색"
-                placeholder="파일, 확장자, 폴더 경로 검색"
+                placeholder="파일명 또는 /폴더 경로 검색"
                 value={keyword}
                 onChange={(event) => setKeyword(event.target.value)}
               />

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element -- private cloud content needs browser-owned auth cookies. */
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import type { PDFDocumentLoadingTask, RenderTask } from "pdfjs-dist"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { type ChangeEvent, type CSSProperties, useEffect, useMemo, useRef, useState } from "react"
 import {
   deleteCloudFile,
   getCloudFileContentUrl,
@@ -10,57 +10,104 @@ import {
   type CloudFile,
   type CloudMediaKind,
 } from "src/apis/backend/cloud"
+import AppIcon from "src/components/icons/AppIcon"
 import {
   CLOUD_FILTERS,
   IINA_CHAPTERS,
   IINA_SHORTCUTS,
   PLAYBACK_SPEEDS,
+  doesCloudFileMatchFilters,
   formatCloudDate,
   formatCloudFileSize,
   getCloudKindBadge,
+  getCloudKindIconLabel,
   getCloudKindLabel,
-  getCloudSummary,
+  getUploadStatusLabel,
+  isUploadActive,
+  mergeCloudFiles,
   type CloudMediaFilter,
+  type UploadQueueStatus,
 } from "./AdminCloudWorkspaceModel"
 import {
-  CloudHeader,
+  ActionBar,
+  ActionGroup,
+  CloudContent,
   CloudMain,
-  CloudMetrics,
+  CloudNoticeBar,
+  CloudSearchField,
+  CloudTitleBar,
+  CloudWorkspace,
+  DetailHeader,
+  DetailMetaList,
+  DetailPanel,
+  DetailPreviewBox,
+  DetailTab,
+  DetailTabs,
   EmptyState,
-  FileBrowserPanel,
-  FileCopy,
-  FileList,
-  FileRow,
+  EmptyTableState,
+  FavoriteButton,
+  FileNameButton,
+  FileTable,
+  FileTableScroll,
+  FileTypeIcon,
   FilterGroup,
   GhostButton,
-  HeaderActions,
-  HeaderCopy,
+  IconButton,
   InlineList,
-  KindBadge,
-  MetricItem,
   Notice,
   PdfCanvas,
   PhotoFrame,
   PlayerBar,
   PreviewHeader,
-  PreviewPanel,
   PreviewStage,
   PrimaryButton,
+  ProgressTrack,
+  QueueHeader,
+  QueueItem,
+  QueueList,
+  QueuePanel,
   RowActions,
+  RowCheckbox,
+  SearchDetail,
   SearchInput,
+  SecondaryButton,
+  SelectBoxCell,
+  StatusPill,
   ThumbnailStrip,
   Timeline,
-  Toolbar,
   UploadInput,
   VideoFrame,
-  WorkspaceGrid,
 } from "./AdminCloudWorkspace.styles"
 
 const CLOUD_QUERY_KEY = "admin-cloud-files"
 const EMPTY_CLOUD_FILES: CloudFile[] = []
 
+type UploadQueueItem = {
+  id: string
+  file: File
+  name: string
+  byteSize: number
+  status: UploadQueueStatus
+  progress: number
+  message: string
+  uploadedFileId?: number
+}
+
 const mediaKindFromFilter = (filter: CloudMediaFilter): CloudMediaKind | undefined =>
   filter === "ALL" ? undefined : filter
+
+const createUploadQueueItem = (file: File): UploadQueueItem => ({
+  id: `${Date.now()}-${file.name}-${file.size}-${Math.random().toString(36).slice(2)}`,
+  file,
+  name: file.name,
+  byteSize: file.size,
+  status: "queued",
+  progress: 0,
+  message: "업로드 대기 중",
+})
+
+const isAbortLikeError = (error: unknown) =>
+  error instanceof DOMException && (error.name === "AbortError" || error.name === "TimeoutError")
 
 type PdfPreviewProps = {
   file: CloudFile
@@ -81,7 +128,6 @@ const PdfPreview = ({ file, contentUrl }: PdfPreviewProps) => {
     const render = async () => {
       try {
         const pdfjs = await import("pdfjs-dist")
-        // 관리자 전용 파일 preview가 외부 CDN worker를 신뢰하지 않도록 같은-origin worker를 사용한다.
         pdfjs.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs"
         loadingTask = pdfjs.getDocument({
           url: contentUrl,
@@ -126,7 +172,7 @@ const PdfPreview = ({ file, contentUrl }: PdfPreviewProps) => {
   return (
     <PreviewStage>
       <PreviewHeader>
-        <h2>문서 뷰어</h2>
+        <h3>문서 뷰어</h3>
         <p>{file.originalFilename}</p>
       </PreviewHeader>
       <PdfCanvas ref={canvasRef} aria-label={`${file.originalFilename} PDF 미리보기`} />
@@ -147,12 +193,12 @@ type PhotoPreviewProps = {
 const PhotoPreview = ({ file, contentUrl }: PhotoPreviewProps) => (
   <PreviewStage>
     <PreviewHeader>
-      <h2>사진 보기</h2>
+      <h3>사진 보기</h3>
       <p>{file.originalFilename}</p>
     </PreviewHeader>
     <PhotoFrame>
       <img src={contentUrl} alt={file.originalFilename} />
-      <ThumbnailStrip aria-label="Immich 스타일 사진 썸네일">
+      <ThumbnailStrip aria-label="사진 썸네일">
         <span />
         <span />
         <span />
@@ -174,7 +220,7 @@ const VideoPreview = ({ file, contentUrl }: VideoPreviewProps) => {
   return (
     <PreviewStage>
       <PreviewHeader>
-        <h2>동영상 플레이어</h2>
+        <h3>동영상 플레이어</h3>
         <p>{file.originalFilename}</p>
       </PreviewHeader>
       <VideoFrame>
@@ -225,7 +271,12 @@ type PreviewDrawerProps = {
 
 const PreviewDrawer = ({ file }: PreviewDrawerProps) => {
   if (!file) {
-    return <EmptyState>미리 볼 파일을 선택하세요.</EmptyState>
+    return (
+      <EmptyState>
+        <strong>미리 볼 파일을 선택하세요.</strong>
+        <p>파일명을 누르면 문서, 사진, 동영상 미리보기가 이 영역에 표시됩니다.</p>
+      </EmptyState>
+    )
   }
 
   const contentUrl = getCloudFileContentUrl(file.id)
@@ -237,11 +288,14 @@ const PreviewDrawer = ({ file }: PreviewDrawerProps) => {
 const AdminCloudWorkspacePage = () => {
   const queryClient = useQueryClient()
   const uploadInputRef = useRef<HTMLInputElement>(null)
+  const uploadControllersRef = useRef<Map<string, AbortController>>(new Map())
   const [filter, setFilter] = useState<CloudMediaFilter>("ALL")
   const [keyword, setKeyword] = useState("")
   const [selectedFileId, setSelectedFileId] = useState<number | null>(null)
+  const [checkedFileIds, setCheckedFileIds] = useState<number[]>([])
   const [notice, setNotice] = useState("")
-  const [isUploading, setIsUploading] = useState(false)
+  const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([])
+  const [optimisticFiles, setOptimisticFiles] = useState<CloudFile[]>([])
 
   const filesQuery = useQuery({
     queryKey: [CLOUD_QUERY_KEY, filter, keyword],
@@ -251,147 +305,390 @@ const AdminCloudWorkspacePage = () => {
         mediaKind: mediaKindFromFilter(filter),
       }),
   })
-  const files = filesQuery.data ?? EMPTY_CLOUD_FILES
+  const serverFiles = filesQuery.data ?? EMPTY_CLOUD_FILES
+  const visibleOptimisticFiles = useMemo(
+    () => optimisticFiles.filter((file) => doesCloudFileMatchFilters(file, filter, keyword)),
+    [filter, keyword, optimisticFiles]
+  )
+  const files = useMemo(
+    () => mergeCloudFiles(visibleOptimisticFiles, serverFiles),
+    [serverFiles, visibleOptimisticFiles]
+  )
   const selectedFile = files.find((file) => file.id === selectedFileId) || files[0] || null
-  const summary = useMemo(() => getCloudSummary(files), [files])
+  const activeUploadCount = uploadQueue.filter((item) => isUploadActive(item.status)).length
+  const completedUploadCount = uploadQueue.filter((item) => item.status === "done").length
+  const allVisibleChecked = files.length > 0 && files.every((file) => checkedFileIds.includes(file.id))
 
   useEffect(() => {
     if (selectedFileId && files.some((file) => file.id === selectedFileId)) return
     setSelectedFileId(files[0]?.id ?? null)
   }, [files, selectedFileId])
 
-  const refreshFiles = () => queryClient.invalidateQueries({ queryKey: [CLOUD_QUERY_KEY] })
+  useEffect(() => {
+    setCheckedFileIds((current) => current.filter((id) => files.some((file) => file.id === id)))
+  }, [files])
 
-  const handleUpload = async (file: File | undefined) => {
-    if (!file) return
-    setIsUploading(true)
-    setNotice("")
-    try {
-      const uploaded = await uploadCloudFile(file)
-      setSelectedFileId(uploaded.id)
-      setNotice("업로드 완료")
-      await refreshFiles()
-    } catch {
-      setNotice("업로드 실패")
-    } finally {
-      setIsUploading(false)
-      if (uploadInputRef.current) uploadInputRef.current.value = ""
+  useEffect(() => {
+    const hasActiveUpload = uploadQueue.some((item) => item.status === "uploading")
+    const nextUpload = uploadQueue.find((item) => item.status === "queued")
+    if (hasActiveUpload || !nextUpload) return
+
+    const controller = new AbortController()
+    uploadControllersRef.current.set(nextUpload.id, controller)
+    setUploadQueue((current) =>
+      current.map((item) =>
+        item.id === nextUpload.id
+          ? { ...item, status: "uploading", progress: 36, message: "서버로 업로드 중" }
+          : item
+      )
+    )
+
+    const run = async () => {
+      try {
+        const uploaded = await uploadCloudFile(nextUpload.file, "", controller.signal)
+        if (controller.signal.aborted) throw new DOMException("Upload aborted", "AbortError")
+
+        setOptimisticFiles((current) => mergeCloudFiles([uploaded], current))
+        queryClient.setQueriesData<CloudFile[]>({ queryKey: [CLOUD_QUERY_KEY] }, (current) => {
+          if (!Array.isArray(current)) return current
+          return mergeCloudFiles([uploaded], current)
+        })
+        setSelectedFileId(uploaded.id)
+        setNotice(`${uploaded.originalFilename} 업로드 완료`)
+        setUploadQueue((current) =>
+          current.map((item) =>
+            item.id === nextUpload.id && item.status !== "cancelled"
+              ? {
+                  ...item,
+                  status: "done",
+                  progress: 100,
+                  message: "업로드 완료",
+                  uploadedFileId: uploaded.id,
+                }
+              : item
+          )
+        )
+        void queryClient.invalidateQueries({ queryKey: [CLOUD_QUERY_KEY] })
+      } catch (error) {
+        const aborted = controller.signal.aborted || isAbortLikeError(error)
+        setNotice(aborted ? `${nextUpload.name} 업로드 취소` : `${nextUpload.name} 업로드 실패`)
+        setUploadQueue((current) =>
+          current.map((item) =>
+            item.id === nextUpload.id
+              ? {
+                  ...item,
+                  status: aborted ? "cancelled" : "failed",
+                  progress: aborted ? 0 : 100,
+                  message: aborted ? "사용자가 취소함" : "업로드 실패",
+                }
+              : item
+          )
+        )
+      } finally {
+        uploadControllersRef.current.delete(nextUpload.id)
+      }
     }
+
+    void run()
+  }, [queryClient, uploadQueue])
+
+  const handleUploadSelect = (event: ChangeEvent<HTMLInputElement>) => {
+    const selectedFiles = Array.from(event.currentTarget.files || [])
+    if (selectedFiles.length === 0) return
+
+    setUploadQueue((current) => [...current, ...selectedFiles.map(createUploadQueueItem)])
+    setNotice(`${selectedFiles.length}개 파일을 업로드 큐에 추가했습니다.`)
+    event.currentTarget.value = ""
+  }
+
+  const handleCancelUpload = (item: UploadQueueItem) => {
+    if (!isUploadActive(item.status)) return
+    uploadControllersRef.current.get(item.id)?.abort()
+    setUploadQueue((current) =>
+      current.map((queueItem) =>
+        queueItem.id === item.id
+          ? { ...queueItem, status: "cancelled", progress: 0, message: "사용자가 취소함" }
+          : queueItem
+      )
+    )
+  }
+
+  const handleClearFinishedUploads = () => {
+    setUploadQueue((current) => current.filter((item) => isUploadActive(item.status)))
+  }
+
+  const handleToggleAllChecked = () => {
+    setCheckedFileIds(allVisibleChecked ? [] : files.map((file) => file.id))
+  }
+
+  const handleToggleChecked = (fileId: number) => {
+    setCheckedFileIds((current) =>
+      current.includes(fileId) ? current.filter((id) => id !== fileId) : [...current, fileId]
+    )
   }
 
   const handleDelete = async (file: CloudFile) => {
     await deleteCloudFile(file.id)
-    setNotice("삭제 완료")
+    setNotice(`${file.originalFilename} 삭제 완료`)
+    setOptimisticFiles((current) => current.filter((item) => item.id !== file.id))
+    setCheckedFileIds((current) => current.filter((id) => id !== file.id))
     if (selectedFileId === file.id) setSelectedFileId(null)
-    await refreshFiles()
+    await queryClient.invalidateQueries({ queryKey: [CLOUD_QUERY_KEY] })
   }
+
+  const handleDeleteSelected = async () => {
+    const targets = files.filter((file) => checkedFileIds.includes(file.id))
+    if (targets.length === 0) return
+
+    await Promise.all(targets.map((file) => deleteCloudFile(file.id)))
+    const deletedIds = new Set(targets.map((file) => file.id))
+    setOptimisticFiles((current) => current.filter((file) => !deletedIds.has(file.id)))
+    setCheckedFileIds([])
+    if (selectedFileId && deletedIds.has(selectedFileId)) setSelectedFileId(null)
+    setNotice(`${targets.length}개 파일 삭제 완료`)
+    await queryClient.invalidateQueries({ queryKey: [CLOUD_QUERY_KEY] })
+  }
+
+  const emptyTitle = filesQuery.isFetching
+    ? "파일을 불러오는 중입니다."
+    : keyword || filter !== "ALL"
+      ? "조건에 맞는 파일이 없습니다."
+      : "아직 올린 파일이 없습니다."
+  const emptyDescription =
+    activeUploadCount > 0
+      ? "업로드가 끝나면 이 목록에 자동으로 표시됩니다."
+      : "상단의 올리기 버튼으로 문서, 사진, 동영상을 여러 개 선택해 업로드하세요."
 
   return (
     <CloudMain>
-      <CloudHeader>
-        <HeaderCopy>
-          <h1>관리자 클라우드</h1>
-          <p>
-            서버 백업 외장 스토리지와 분리된 관리자 전용 파일 작업 공간입니다. 모든 파일은 계정 소유주만 볼 수 있음
-            상태로 다루고 public URL은 만들지 않습니다.
-          </p>
-        </HeaderCopy>
-        <HeaderActions>
-          <UploadInput
-            ref={uploadInputRef}
-            aria-label="클라우드 파일 업로드"
-            type="file"
-            onChange={(event) => void handleUpload(event.currentTarget.files?.[0])}
-          />
-          <PrimaryButton type="button" disabled={isUploading} onClick={() => uploadInputRef.current?.click()}>
-            {isUploading ? "업로드 중" : "파일 업로드"}
-          </PrimaryButton>
-        </HeaderActions>
-      </CloudHeader>
+      <CloudNoticeBar>
+        <span>관리자 클라우드는 public URL을 만들지 않습니다.</span>
+        <strong>계정 소유주만 접근</strong>
+      </CloudNoticeBar>
 
-      <CloudMetrics>
-        <MetricItem>
-          <dt>전체 파일</dt>
-          <dd>{summary.totalCount}개</dd>
-        </MetricItem>
-        <MetricItem>
-          <dt>사용량</dt>
-          <dd>{summary.totalSize}</dd>
-        </MetricItem>
-        <MetricItem>
-          <dt>사진</dt>
-          <dd>{summary.photoCount}개</dd>
-        </MetricItem>
-        <MetricItem>
-          <dt>동영상</dt>
-          <dd>{summary.videoCount}개</dd>
-        </MetricItem>
-      </CloudMetrics>
+      <CloudWorkspace>
+        <CloudContent>
+          <CloudTitleBar>
+            <div>
+              <h1>관리자 클라우드</h1>
+              <p>MYBOX형 파일 관리자 화면입니다. 문서, 사진, 동영상은 모두 관리자 계정 소유주만 볼 수 있습니다.</p>
+            </div>
+            <CloudSearchField>
+              <AppIcon name="search" />
+              <SearchInput
+                placeholder="파일, 확장자, 폴더 경로 검색"
+                value={keyword}
+                onChange={(event) => setKeyword(event.target.value)}
+              />
+              <SearchDetail>상세</SearchDetail>
+            </CloudSearchField>
+          </CloudTitleBar>
 
-      {notice ? <Notice>{notice}</Notice> : null}
+          <ActionBar>
+            <ActionGroup>
+              <IconButton
+                type="button"
+                aria-label={allVisibleChecked ? "전체 선택 해제" : "전체 선택"}
+                data-active={allVisibleChecked ? "true" : "false"}
+                onClick={handleToggleAllChecked}
+              >
+                ✓
+              </IconButton>
+              <UploadInput
+                ref={uploadInputRef}
+                aria-label="클라우드 파일 업로드"
+                type="file"
+                multiple
+                onChange={handleUploadSelect}
+              />
+              <PrimaryButton
+                type="button"
+                aria-label={activeUploadCount > 0 ? "업로드 중" : "파일 업로드"}
+                onClick={() => uploadInputRef.current?.click()}
+              >
+                ⤴ 올리기
+              </PrimaryButton>
+              <SecondaryButton type="button" disabled>
+                새로 만들기
+              </SecondaryButton>
+              <SecondaryButton type="button" disabled={checkedFileIds.length === 0} onClick={() => void handleDeleteSelected()}>
+                선택 삭제
+              </SecondaryButton>
+            </ActionGroup>
 
-      <WorkspaceGrid>
-        <FileBrowserPanel>
-          <Toolbar>
-            <SearchInput
-              placeholder="파일명 검색"
-              value={keyword}
-              onChange={(event) => setKeyword(event.target.value)}
-            />
-            <FilterGroup aria-label="파일 종류 필터">
-              {CLOUD_FILTERS.map((item) => (
-                <GhostButton
-                  key={item.value}
-                  type="button"
-                  data-active={filter === item.value ? "true" : "false"}
-                  onClick={() => setFilter(item.value)}
-                >
-                  {item.label}
-                </GhostButton>
-              ))}
-            </FilterGroup>
-          </Toolbar>
+            <ActionGroup>
+              {notice ? <Notice>{notice}</Notice> : null}
+              <FilterGroup aria-label="파일 종류 필터">
+                {CLOUD_FILTERS.map((item) => (
+                  <GhostButton
+                    key={item.value}
+                    type="button"
+                    data-active={filter === item.value ? "true" : "false"}
+                    onClick={() => setFilter(item.value)}
+                  >
+                    {item.label}
+                  </GhostButton>
+                ))}
+              </FilterGroup>
+              <IconButton type="button" aria-label="리스트 보기" data-active="true">
+                ☷
+              </IconButton>
+              <IconButton type="button" aria-label="상세 패널 보기" data-active={selectedFile ? "true" : "false"}>
+                ⓘ
+              </IconButton>
+            </ActionGroup>
+          </ActionBar>
 
-          <FileList aria-busy={filesQuery.isFetching ? "true" : "false"}>
+          <FileTableScroll>
             {files.length === 0 ? (
-              <EmptyState>{filesQuery.isFetching ? "파일을 불러오는 중입니다." : "표시할 파일이 없습니다."}</EmptyState>
+              <EmptyTableState>
+                <strong>{emptyTitle}</strong>
+                <p>{emptyDescription}</p>
+                <PrimaryButton type="button" aria-label="파일 업로드" onClick={() => uploadInputRef.current?.click()}>
+                  ⤴ 올리기
+                </PrimaryButton>
+              </EmptyTableState>
             ) : (
-              files.map((file) => (
-                <FileRow key={file.id} data-selected={selectedFile?.id === file.id ? "true" : "false"}>
-                  <KindBadge>{getCloudKindBadge(file)}</KindBadge>
-                  <FileCopy>
-                    <strong>{file.originalFilename}</strong>
-                    <span>
-                      {getCloudKindLabel(file.mediaKind)} · {formatCloudFileSize(file.byteSize)} ·{" "}
-                      {formatCloudDate(file.modifiedAt || file.createdAt)} · 계정 소유주만 볼 수 있음
-                    </span>
-                  </FileCopy>
-                  <RowActions>
-                    <GhostButton
-                      type="button"
-                      aria-label={`${file.originalFilename} 미리보기`}
-                      onClick={() => setSelectedFileId(file.id)}
-                    >
-                      미리보기
-                    </GhostButton>
-                    <GhostButton
-                      type="button"
-                      aria-label={`${file.originalFilename} 삭제`}
-                      onClick={() => void handleDelete(file)}
-                    >
-                      삭제
-                    </GhostButton>
-                  </RowActions>
-                </FileRow>
-              ))
+              <FileTable aria-busy={filesQuery.isFetching ? "true" : "false"}>
+                <thead>
+                  <tr>
+                    <th aria-label="선택" />
+                    <th aria-label="즐겨찾기" />
+                    <th>종류</th>
+                    <th>이름</th>
+                    <th>크기</th>
+                    <th>수정한 날짜</th>
+                    <th aria-label="작업" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {files.map((file) => {
+                    const checked = checkedFileIds.includes(file.id)
+                    const selected = selectedFile?.id === file.id
+                    return (
+                      <tr key={file.id} data-selected={selected ? "true" : "false"}>
+                        <SelectBoxCell>
+                          <RowCheckbox
+                            type="checkbox"
+                            aria-label={`${file.originalFilename} 선택`}
+                            checked={checked}
+                            onChange={() => handleToggleChecked(file.id)}
+                          />
+                        </SelectBoxCell>
+                        <td>
+                          <FavoriteButton type="button" aria-label={`${file.originalFilename} 즐겨찾기`}>
+                            ☆
+                          </FavoriteButton>
+                        </td>
+                        <td>
+                          <FileTypeIcon aria-label={getCloudKindLabel(file.mediaKind)}>
+                            {getCloudKindIconLabel(file)}
+                          </FileTypeIcon>
+                        </td>
+                        <td>
+                          <FileNameButton type="button" onClick={() => setSelectedFileId(file.id)}>
+                            <strong>{file.originalFilename}</strong>
+                          </FileNameButton>
+                        </td>
+                        <td>{formatCloudFileSize(file.byteSize)}</td>
+                        <td>{formatCloudDate(file.modifiedAt || file.createdAt)}</td>
+                        <td>
+                          <RowActions>
+                            <GhostButton
+                              type="button"
+                              aria-label={`${file.originalFilename} 미리보기`}
+                              onClick={() => setSelectedFileId(file.id)}
+                            >
+                              <AppIcon name="eye" />
+                            </GhostButton>
+                            <GhostButton
+                              type="button"
+                              aria-label={`${file.originalFilename} 삭제`}
+                              onClick={() => void handleDelete(file)}
+                            >
+                              <AppIcon name="trash" />
+                            </GhostButton>
+                          </RowActions>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </FileTable>
             )}
-          </FileList>
-        </FileBrowserPanel>
+          </FileTableScroll>
+        </CloudContent>
 
-        <PreviewPanel aria-label="클라우드 미리보기">
-          <PreviewDrawer file={selectedFile} />
-        </PreviewPanel>
-      </WorkspaceGrid>
+        <DetailPanel aria-label="클라우드 상세정보">
+          <DetailHeader>
+            <h2>내 파일</h2>
+            <IconButton type="button" aria-label="상세 패널 닫기">×</IconButton>
+          </DetailHeader>
+          <DetailTabs>
+            <DetailTab type="button" data-active="true">
+              상세정보
+            </DetailTab>
+          </DetailTabs>
+          <DetailPreviewBox>
+            <PreviewDrawer file={selectedFile} />
+          </DetailPreviewBox>
+          {selectedFile ? (
+            <DetailMetaList>
+              <dt>종류</dt>
+              <dd>
+                {getCloudKindBadge(selectedFile)} · {getCloudKindLabel(selectedFile.mediaKind)}
+              </dd>
+              <dt>위치</dt>
+              <dd>{selectedFile.folderPath || "/"}</dd>
+              <dt>올린 날짜</dt>
+              <dd>{formatCloudDate(selectedFile.createdAt)}</dd>
+              <dt>수정한 날짜</dt>
+              <dd>{formatCloudDate(selectedFile.modifiedAt || selectedFile.createdAt)}</dd>
+              <dt>크기</dt>
+              <dd>{formatCloudFileSize(selectedFile.byteSize)}</dd>
+              <dt>권한</dt>
+              <dd>계정 소유주만 볼 수 있음</dd>
+            </DetailMetaList>
+          ) : null}
+        </DetailPanel>
+      </CloudWorkspace>
+
+      {uploadQueue.length > 0 ? (
+        <QueuePanel aria-label="업로드 중인 파일">
+          <QueueHeader>
+            <div>
+              <h2>업로드 관리</h2>
+              <p>
+                진행 중 {activeUploadCount}개 · 완료 {completedUploadCount}개
+              </p>
+            </div>
+            <GhostButton type="button" disabled={uploadQueue.every((item) => isUploadActive(item.status))} onClick={handleClearFinishedUploads}>
+              완료 항목 지우기
+            </GhostButton>
+          </QueueHeader>
+          <QueueList>
+            {uploadQueue.map((item) => (
+              <QueueItem key={item.id}>
+                <div>
+                  <strong>{item.name}</strong>
+                  <p>
+                    {formatCloudFileSize(item.byteSize)} · {item.message}
+                  </p>
+                </div>
+                <StatusPill data-status={item.status}>{getUploadStatusLabel(item.status)}</StatusPill>
+                <ProgressTrack style={{ "--progress": `${item.progress}%` } as CSSProperties}>
+                  <span />
+                </ProgressTrack>
+                {isUploadActive(item.status) ? (
+                  <GhostButton type="button" aria-label={`${item.name} 업로드 취소`} onClick={() => handleCancelUpload(item)}>
+                    취소
+                  </GhostButton>
+                ) : null}
+              </QueueItem>
+            ))}
+          </QueueList>
+        </QueuePanel>
+      ) : null}
     </CloudMain>
   )
 }

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -96,6 +96,14 @@ type UploadQueueItem = {
 const mediaKindFromFilter = (filter: CloudMediaFilter): CloudMediaKind | undefined =>
   filter === "ALL" ? undefined : filter
 
+const isCloudMediaFilter = (value: unknown): value is CloudMediaFilter =>
+  CLOUD_FILTERS.some((item) => item.value === value)
+
+const getCachedCloudQueryFilters = (queryKey: readonly unknown[]) => ({
+  filter: isCloudMediaFilter(queryKey[1]) ? queryKey[1] : ("ALL" as CloudMediaFilter),
+  keyword: typeof queryKey[2] === "string" ? queryKey[2] : "",
+})
+
 const createUploadQueueItem = (file: File): UploadQueueItem => ({
   id: `${Date.now()}-${file.name}-${file.size}-${Math.random().toString(36).slice(2)}`,
   file,
@@ -296,6 +304,7 @@ const AdminCloudWorkspacePage = () => {
   const [notice, setNotice] = useState("")
   const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([])
   const [optimisticFiles, setOptimisticFiles] = useState<CloudFile[]>([])
+  const [isDetailPanelOpen, setIsDetailPanelOpen] = useState(true)
 
   const filesQuery = useQuery({
     queryKey: [CLOUD_QUERY_KEY, filter, keyword],
@@ -314,15 +323,18 @@ const AdminCloudWorkspacePage = () => {
     () => mergeCloudFiles(visibleOptimisticFiles, serverFiles),
     [serverFiles, visibleOptimisticFiles]
   )
-  const selectedFile = files.find((file) => file.id === selectedFileId) || files[0] || null
+  const selectedFile = isDetailPanelOpen
+    ? files.find((file) => file.id === selectedFileId) || files[0] || null
+    : null
   const activeUploadCount = uploadQueue.filter((item) => isUploadActive(item.status)).length
   const completedUploadCount = uploadQueue.filter((item) => item.status === "done").length
   const allVisibleChecked = files.length > 0 && files.every((file) => checkedFileIds.includes(file.id))
 
   useEffect(() => {
+    if (!isDetailPanelOpen) return
     if (selectedFileId && files.some((file) => file.id === selectedFileId)) return
     setSelectedFileId(files[0]?.id ?? null)
-  }, [files, selectedFileId])
+  }, [files, isDetailPanelOpen, selectedFileId])
 
   useEffect(() => {
     setCheckedFileIds((current) => current.filter((id) => files.some((file) => file.id === id)))
@@ -349,10 +361,13 @@ const AdminCloudWorkspacePage = () => {
         if (controller.signal.aborted) throw new DOMException("Upload aborted", "AbortError")
 
         setOptimisticFiles((current) => mergeCloudFiles([uploaded], current))
-        queryClient.setQueriesData<CloudFile[]>({ queryKey: [CLOUD_QUERY_KEY] }, (current) => {
-          if (!Array.isArray(current)) return current
-          return mergeCloudFiles([uploaded], current)
+        queryClient.getQueriesData<CloudFile[]>({ queryKey: [CLOUD_QUERY_KEY] }).forEach(([queryKey, current]) => {
+          if (!Array.isArray(current)) return
+          const cachedFilters = getCachedCloudQueryFilters(queryKey)
+          if (!doesCloudFileMatchFilters(uploaded, cachedFilters.filter, cachedFilters.keyword)) return
+          queryClient.setQueryData(queryKey, mergeCloudFiles([uploaded], current))
         })
+        setIsDetailPanelOpen(true)
         setSelectedFileId(uploaded.id)
         setNotice(`${uploaded.originalFilename} 업로드 완료`)
         setUploadQueue((current) =>
@@ -425,6 +440,11 @@ const AdminCloudWorkspacePage = () => {
     setCheckedFileIds((current) =>
       current.includes(fileId) ? current.filter((id) => id !== fileId) : [...current, fileId]
     )
+  }
+
+  const handlePreviewFile = (fileId: number) => {
+    setIsDetailPanelOpen(true)
+    setSelectedFileId(fileId)
   }
 
   const handleDelete = async (file: CloudFile) => {
@@ -586,7 +606,7 @@ const AdminCloudWorkspacePage = () => {
                           </FileTypeIcon>
                         </td>
                         <td>
-                          <FileNameButton type="button" onClick={() => setSelectedFileId(file.id)}>
+                          <FileNameButton type="button" onClick={() => handlePreviewFile(file.id)}>
                             <strong>{file.originalFilename}</strong>
                           </FileNameButton>
                         </td>
@@ -597,7 +617,7 @@ const AdminCloudWorkspacePage = () => {
                             <GhostButton
                               type="button"
                               aria-label={`${file.originalFilename} 미리보기`}
-                              onClick={() => setSelectedFileId(file.id)}
+                              onClick={() => handlePreviewFile(file.id)}
                             >
                               <AppIcon name="eye" />
                             </GhostButton>
@@ -622,7 +642,16 @@ const AdminCloudWorkspacePage = () => {
         <DetailPanel aria-label="클라우드 상세정보">
           <DetailHeader>
             <h2>내 파일</h2>
-            <IconButton type="button" aria-label="상세 패널 닫기">×</IconButton>
+            <IconButton
+              type="button"
+              aria-label="상세 패널 닫기"
+              onClick={() => {
+                setIsDetailPanelOpen(false)
+                setSelectedFileId(null)
+              }}
+            >
+              ×
+            </IconButton>
           </DetailHeader>
           <DetailTabs>
             <DetailTab type="button" data-active="true">

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -496,11 +496,12 @@ const AdminCloudWorkspacePage = () => {
             <CloudSearchField>
               <AppIcon name="search" />
               <SearchInput
+                aria-label="클라우드 파일 검색"
                 placeholder="파일, 확장자, 폴더 경로 검색"
                 value={keyword}
                 onChange={(event) => setKeyword(event.target.value)}
               />
-              <SearchDetail>상세</SearchDetail>
+              <SearchDetail aria-hidden="true">상세</SearchDetail>
             </CloudSearchField>
           </CloudTitleBar>
 
@@ -553,7 +554,15 @@ const AdminCloudWorkspacePage = () => {
               <IconButton type="button" aria-label="리스트 보기" data-active="true">
                 ☷
               </IconButton>
-              <IconButton type="button" aria-label="상세 패널 보기" data-active={selectedFile ? "true" : "false"}>
+              <IconButton
+                type="button"
+                aria-label="상세 패널 보기"
+                data-active={selectedFile ? "true" : "false"}
+                onClick={() => {
+                  setIsDetailPanelOpen(true)
+                  setSelectedFileId((current) => current ?? files[0]?.id ?? null)
+                }}
+              >
                 ⓘ
               </IconButton>
             </ActionGroup>
@@ -596,7 +605,11 @@ const AdminCloudWorkspacePage = () => {
                           />
                         </SelectBoxCell>
                         <td>
-                          <FavoriteButton type="button" aria-label={`${file.originalFilename} 즐겨찾기`}>
+                          <FavoriteButton
+                            type="button"
+                            aria-label={`${file.originalFilename} 즐겨찾기 기능 준비 중`}
+                            disabled
+                          >
                             ☆
                           </FavoriteButton>
                         </td>
@@ -647,7 +660,6 @@ const AdminCloudWorkspacePage = () => {
               aria-label="상세 패널 닫기"
               onClick={() => {
                 setIsDetailPanelOpen(false)
-                setSelectedFileId(null)
               }}
             >
               ×

--- a/front/src/routes/Admin/AdminDashboardWorkspace.styles.layout.ts
+++ b/front/src/routes/Admin/AdminDashboardWorkspace.styles.layout.ts
@@ -141,7 +141,7 @@ export const MetricCard = styled.article`
   grid-template-columns: auto minmax(0, 1fr);
   align-items: start;
   padding: 12px;
-  border-radius: 22px;
+  border-radius: 12px;
   border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
   background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray1)};
   box-shadow: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.shadow : "0 14px 30px rgba(15, 23, 42, 0.05)")};

--- a/front/src/routes/Admin/AdminDashboardWorkspace.styles.priority.ts
+++ b/front/src/routes/Admin/AdminDashboardWorkspace.styles.priority.ts
@@ -39,7 +39,7 @@ export const ContextSection = styled(AdminPlainCard)`
   display: grid;
   gap: 12px;
   padding: 16px 18px;
-  border-radius: 24px;
+  border-radius: 12px;
 `
 
 export const ContextLinkGrid = styled(AdminInfoList)`
@@ -72,7 +72,7 @@ export const ContextMonitoringLinkCard = styled(AdminInfoLinkCard)`
 
 export const AdditionalPanelsSection = styled(AdminPlainCard)`
   padding: 14px 16px;
-  border-radius: 24px;
+  border-radius: 12px;
 `
 
 export const AdditionalPanelsDisclosure = styled.details`

--- a/front/src/routes/Admin/AdminHubSurface.styles.ts
+++ b/front/src/routes/Admin/AdminHubSurface.styles.ts
@@ -1,6 +1,17 @@
 import styled from "@emotion/styled"
 import { AdminSectionTitleStack } from "./AdminSurfacePrimitives"
 
+const adminTextPrimary = "#f3f1ea"
+const adminTextSecondary = "#c8c1ae"
+const adminTextMuted = "#918b7d"
+const adminBorder = "#34322d"
+const adminBorderStrong = "#6d6040"
+const adminSurface = "#171817"
+const adminSurfaceRaised = "#20211f"
+const adminSurfaceAccent = "#2d291a"
+const adminGold = "#d0b46c"
+const adminTeal = "#3f8f86"
+
 export const Main = styled.main`
   display: grid;
   gap: 1.1rem;
@@ -19,7 +30,7 @@ export const HeroPanel = styled.section`
   display: grid;
   gap: 0.82rem;
   padding: 0 0 0.96rem;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray5};
+  border-bottom: 1px solid ${adminBorder};
 `
 
 export const HeroHeader = styled.div`
@@ -46,7 +57,7 @@ export const HeroCopy = styled.div`
 export const HeroHeading = styled.h1`
   margin: 0;
   min-width: 0;
-  color: ${({ theme }) => theme.colors.gray12};
+  color: ${adminTextPrimary};
   font-size: clamp(1.56rem, 2.6vw, 2.1rem);
   line-height: 1.1;
   font-weight: 800;
@@ -81,11 +92,10 @@ export const PrimaryActionLink = styled.a`
   min-width: 6rem;
   min-height: 2.65rem;
   padding: 0 1rem;
-  border: 1px solid ${({ theme }) => theme.colors.blue8};
+  border: 1px solid rgba(63, 143, 134, 0.58);
   border-radius: 999px;
-  background: ${({ theme }) =>
-    theme.scheme === "light" ? "rgba(59, 130, 246, 0.12)" : "rgba(37, 99, 235, 0.22)"};
-  color: ${({ theme }) => theme.colors.blue9};
+  background: ${adminTeal};
+  color: #f8fffc;
   text-decoration: none;
   font-size: 0.94rem;
   font-weight: 800;
@@ -97,10 +107,10 @@ export const SecondaryActionLink = styled.a`
   justify-content: center;
   min-height: 2.65rem;
   padding: 0 0.9rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border: 1px solid ${adminBorder};
   border-radius: 999px;
-  background: ${({ theme }) => theme.colors.gray1};
-  color: ${({ theme }) => theme.colors.gray11};
+  background: ${adminSurfaceRaised};
+  color: ${adminTextSecondary};
   text-decoration: none;
   font-size: 0.88rem;
   font-weight: 760;
@@ -133,7 +143,7 @@ export const BorderlessSupportSection = styled.section`
   gap: 0.66rem;
   min-width: 0;
   padding: 0 0 0.92rem;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray5};
+  border-bottom: 1px solid ${adminBorder};
 
   &:last-of-type {
     padding-bottom: 0;
@@ -161,7 +171,7 @@ export const BorderlessSection = styled.section`
   min-width: 0;
   gap: 0.82rem;
   padding: 0 0 1rem;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray5};
+  border-bottom: 1px solid ${adminBorder};
 
   &[data-variant="subtle"] {
     padding-bottom: 0;
@@ -175,9 +185,8 @@ export const BorderlessPanel = styled.div`
   min-width: 0;
   padding: 0.78rem 0.84rem;
   border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) =>
-    theme.scheme === "light" ? "rgba(255, 255, 255, 0.6)" : "rgba(255, 255, 255, 0.025)"};
+  border: 1px solid ${adminBorder};
+  background: ${adminSurface};
 
   &[data-tone="good"] {
     border-color: ${({ theme }) => theme.colors.green7};
@@ -188,14 +197,14 @@ export const BorderlessPanel = styled.div`
   }
 
   span {
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     font-size: 0.75rem;
     font-weight: 700;
   }
 
   strong {
     min-width: 0;
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminTextPrimary};
     font-size: 0.9rem;
     font-weight: 800;
     line-height: 1.36;
@@ -211,9 +220,8 @@ export const BorderlessPanelLink = styled.a`
   min-height: 3.75rem;
   padding: 0.82rem 0.88rem;
   border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) =>
-    theme.scheme === "light" ? "rgba(255, 255, 255, 0.64)" : "rgba(255, 255, 255, 0.035)"};
+  border: 1px solid ${adminBorder};
+  background: ${adminSurface};
   color: inherit;
   text-decoration: none;
   transition:
@@ -222,7 +230,8 @@ export const BorderlessPanelLink = styled.a`
     background 0.16s ease;
 
   &[data-featured="true"] {
-    border-color: ${({ theme }) => theme.colors.blue7};
+    border-color: ${adminBorderStrong};
+    background: ${adminSurfaceAccent};
   }
 
   &[data-tone="good"] {
@@ -235,9 +244,8 @@ export const BorderlessPanelLink = styled.a`
 
   &:hover {
     transform: translateY(-1px);
-    border-color: ${({ theme }) => theme.colors.blue7};
-    background: ${({ theme }) =>
-      theme.scheme === "light" ? "rgba(255, 255, 255, 0.82)" : "rgba(255, 255, 255, 0.055)"};
+    border-color: ${adminBorderStrong};
+    background: ${adminSurfaceRaised};
   }
 
   .copy {
@@ -248,7 +256,7 @@ export const BorderlessPanelLink = styled.a`
 
   small,
   span {
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     font-size: 0.72rem;
     font-weight: 800;
     letter-spacing: 0.04em;
@@ -256,7 +264,7 @@ export const BorderlessPanelLink = styled.a`
 
   strong {
     min-width: 0;
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminTextPrimary};
     font-size: 0.92rem;
     font-weight: 800;
     line-height: 1.36;
@@ -309,9 +317,8 @@ export const BorderlessMetricRow = styled.div`
   min-width: 0;
   padding: 0.78rem 0.84rem;
   border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) =>
-    theme.scheme === "light" ? "rgba(255, 255, 255, 0.6)" : "rgba(255, 255, 255, 0.025)"};
+  border: 1px solid ${adminBorder};
+  background: ${adminSurface};
 
   &[data-tone="good"] {
     border-color: ${({ theme }) => theme.colors.green7};
@@ -322,13 +329,13 @@ export const BorderlessMetricRow = styled.div`
   }
 
   span {
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     font-size: 0.75rem;
     font-weight: 700;
   }
 
   strong {
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminTextPrimary};
     font-size: 0.9rem;
     font-weight: 800;
     line-height: 1.35;
@@ -353,7 +360,7 @@ export const ProfileFrame = styled.div`
   height: 4.25rem;
   border-radius: 999px;
   overflow: hidden;
-  background: ${({ theme }) => theme.colors.gray4};
+  background: ${adminSurfaceRaised};
 `
 
 export const ProfileFallback = styled.div`
@@ -361,7 +368,7 @@ export const ProfileFallback = styled.div`
   height: 100%;
   display: grid;
   place-items: center;
-  color: ${({ theme }) => theme.colors.gray12};
+  color: ${adminTextPrimary};
   font-size: 1rem;
   font-weight: 800;
 `
@@ -372,20 +379,20 @@ export const ProfileCopy = styled.div`
   gap: 0.14rem;
 
   strong {
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminTextPrimary};
     font-size: 1rem;
     font-weight: 800;
   }
 
   span {
-    color: ${({ theme }) => theme.colors.gray11};
+    color: ${adminTextSecondary};
     font-size: 0.82rem;
     font-weight: 700;
   }
 
   p {
     margin: 0;
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     font-size: 0.8rem;
     line-height: 1.5;
     display: -webkit-box;
@@ -402,10 +409,9 @@ export const RailActionLink = styled.a`
   min-height: 40px;
   padding: 0 0.95rem;
   border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) =>
-    theme.scheme === "light" ? "rgba(255, 255, 255, 0.86)" : "rgba(31, 31, 31, 0.88)"};
-  color: ${({ theme }) => theme.colors.gray12};
+  border: 1px solid ${adminBorder};
+  background: ${adminSurfaceRaised};
+  color: ${adminGold};
   text-decoration: none;
   font-size: 0.84rem;
   font-weight: 760;

--- a/front/src/routes/Admin/AdminHubSurface.styles.ts
+++ b/front/src/routes/Admin/AdminHubSurface.styles.ts
@@ -1,16 +1,19 @@
 import styled from "@emotion/styled"
 import { AdminSectionTitleStack } from "./AdminSurfacePrimitives"
-
-const adminTextPrimary = "#f3f1ea"
-const adminTextSecondary = "#c8c1ae"
-const adminTextMuted = "#918b7d"
-const adminBorder = "#34322d"
-const adminBorderStrong = "#6d6040"
-const adminSurface = "#171817"
-const adminSurfaceRaised = "#20211f"
-const adminSurfaceAccent = "#2d291a"
-const adminGold = "#d0b46c"
-const adminTeal = "#3f8f86"
+import {
+  adminBorder,
+  adminBorderStrong,
+  adminControlText,
+  adminGold,
+  adminSurface,
+  adminSurfaceAccent,
+  adminSurfaceRaised,
+  adminTeal,
+  adminTealBorder,
+  adminTextMuted,
+  adminTextPrimary,
+  adminTextSecondary,
+} from "src/routes/Admin/adminColorTokens"
 
 export const Main = styled.main`
   display: grid;
@@ -92,10 +95,10 @@ export const PrimaryActionLink = styled.a`
   min-width: 6rem;
   min-height: 2.65rem;
   padding: 0 1rem;
-  border: 1px solid rgba(63, 143, 134, 0.58);
+  border: 1px solid ${adminTealBorder};
   border-radius: 999px;
   background: ${adminTeal};
-  color: #f8fffc;
+  color: ${adminControlText};
   text-decoration: none;
   font-size: 0.94rem;
   font-weight: 800;

--- a/front/src/routes/Admin/AdminHubSurface.styles.ts
+++ b/front/src/routes/Admin/AdminHubSurface.styles.ts
@@ -1,18 +1,18 @@
 import styled from "@emotion/styled"
 import { AdminSectionTitleStack } from "./AdminSurfacePrimitives"
 import {
-  adminBorder,
-  adminBorderStrong,
+  adminAccentSurface,
+  adminCardBorder,
   adminControlText,
   adminGold,
-  adminSurface,
-  adminSurfaceAccent,
-  adminSurfaceRaised,
+  adminMutedText,
+  adminPlainSurface,
+  adminPrimaryText,
+  adminRaisedSurface,
+  adminSecondaryText,
+  adminStrongBorder,
   adminTeal,
   adminTealBorder,
-  adminTextMuted,
-  adminTextPrimary,
-  adminTextSecondary,
 } from "src/routes/Admin/adminColorTokens"
 
 export const Main = styled.main`
@@ -33,7 +33,7 @@ export const HeroPanel = styled.section`
   display: grid;
   gap: 0.82rem;
   padding: 0 0 0.96rem;
-  border-bottom: 1px solid ${adminBorder};
+  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
 `
 
 export const HeroHeader = styled.div`
@@ -60,11 +60,11 @@ export const HeroCopy = styled.div`
 export const HeroHeading = styled.h1`
   margin: 0;
   min-width: 0;
-  color: ${adminTextPrimary};
+  color: ${({ theme }) => adminPrimaryText(theme)};
   font-size: clamp(1.56rem, 2.6vw, 2.1rem);
   line-height: 1.1;
   font-weight: 800;
-  letter-spacing: -0.03em;
+  letter-spacing: 0;
   word-break: keep-all;
 
   @media (max-width: 768px) {
@@ -110,10 +110,10 @@ export const SecondaryActionLink = styled.a`
   justify-content: center;
   min-height: 2.65rem;
   padding: 0 0.9rem;
-  border: 1px solid ${adminBorder};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
   border-radius: 999px;
-  background: ${adminSurfaceRaised};
-  color: ${adminTextSecondary};
+  background: ${({ theme }) => adminRaisedSurface(theme)};
+  color: ${({ theme }) => adminSecondaryText(theme)};
   text-decoration: none;
   font-size: 0.88rem;
   font-weight: 760;
@@ -146,7 +146,7 @@ export const BorderlessSupportSection = styled.section`
   gap: 0.66rem;
   min-width: 0;
   padding: 0 0 0.92rem;
-  border-bottom: 1px solid ${adminBorder};
+  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
 
   &:last-of-type {
     padding-bottom: 0;
@@ -157,7 +157,7 @@ export const BorderlessSupportSection = styled.section`
 export const SupportHeader = styled.div`
   h3 {
     margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${({ theme }) => adminPrimaryText(theme)};
     font-size: 0.96rem;
     font-weight: 800;
     line-height: 1.35;
@@ -174,7 +174,7 @@ export const BorderlessSection = styled.section`
   min-width: 0;
   gap: 0.82rem;
   padding: 0 0 1rem;
-  border-bottom: 1px solid ${adminBorder};
+  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
 
   &[data-variant="subtle"] {
     padding-bottom: 0;
@@ -188,8 +188,8 @@ export const BorderlessPanel = styled.div`
   min-width: 0;
   padding: 0.78rem 0.84rem;
   border-radius: 12px;
-  border: 1px solid ${adminBorder};
-  background: ${adminSurface};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  background: ${({ theme }) => adminPlainSurface(theme)};
 
   &[data-tone="good"] {
     border-color: ${({ theme }) => theme.colors.green7};
@@ -200,14 +200,14 @@ export const BorderlessPanel = styled.div`
   }
 
   span {
-    color: ${adminTextMuted};
+    color: ${({ theme }) => adminMutedText(theme)};
     font-size: 0.75rem;
     font-weight: 700;
   }
 
   strong {
     min-width: 0;
-    color: ${adminTextPrimary};
+    color: ${({ theme }) => adminPrimaryText(theme)};
     font-size: 0.9rem;
     font-weight: 800;
     line-height: 1.36;
@@ -223,8 +223,8 @@ export const BorderlessPanelLink = styled.a`
   min-height: 3.75rem;
   padding: 0.82rem 0.88rem;
   border-radius: 12px;
-  border: 1px solid ${adminBorder};
-  background: ${adminSurface};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  background: ${({ theme }) => adminPlainSurface(theme)};
   color: inherit;
   text-decoration: none;
   transition:
@@ -233,8 +233,8 @@ export const BorderlessPanelLink = styled.a`
     background 0.16s ease;
 
   &[data-featured="true"] {
-    border-color: ${adminBorderStrong};
-    background: ${adminSurfaceAccent};
+    border-color: ${({ theme }) => adminStrongBorder(theme)};
+    background: ${({ theme }) => adminAccentSurface(theme)};
   }
 
   &[data-tone="good"] {
@@ -247,8 +247,8 @@ export const BorderlessPanelLink = styled.a`
 
   &:hover {
     transform: translateY(-1px);
-    border-color: ${adminBorderStrong};
-    background: ${adminSurfaceRaised};
+    border-color: ${({ theme }) => adminStrongBorder(theme)};
+    background: ${({ theme }) => adminRaisedSurface(theme)};
   }
 
   .copy {
@@ -259,7 +259,7 @@ export const BorderlessPanelLink = styled.a`
 
   small,
   span {
-    color: ${adminTextMuted};
+    color: ${({ theme }) => adminMutedText(theme)};
     font-size: 0.72rem;
     font-weight: 800;
     letter-spacing: 0.04em;
@@ -267,7 +267,7 @@ export const BorderlessPanelLink = styled.a`
 
   strong {
     min-width: 0;
-    color: ${adminTextPrimary};
+    color: ${({ theme }) => adminPrimaryText(theme)};
     font-size: 0.92rem;
     font-weight: 800;
     line-height: 1.36;
@@ -301,7 +301,7 @@ export const RecentWorkSummary = styled.div`
   gap: 0;
 
   strong {
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${({ theme }) => adminPrimaryText(theme)};
     font-size: 0.96rem;
     font-weight: 820;
     line-height: 1.35;
@@ -320,8 +320,8 @@ export const BorderlessMetricRow = styled.div`
   min-width: 0;
   padding: 0.78rem 0.84rem;
   border-radius: 12px;
-  border: 1px solid ${adminBorder};
-  background: ${adminSurface};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  background: ${({ theme }) => adminPlainSurface(theme)};
 
   &[data-tone="good"] {
     border-color: ${({ theme }) => theme.colors.green7};
@@ -332,13 +332,13 @@ export const BorderlessMetricRow = styled.div`
   }
 
   span {
-    color: ${adminTextMuted};
+    color: ${({ theme }) => adminMutedText(theme)};
     font-size: 0.75rem;
     font-weight: 700;
   }
 
   strong {
-    color: ${adminTextPrimary};
+    color: ${({ theme }) => adminPrimaryText(theme)};
     font-size: 0.9rem;
     font-weight: 800;
     line-height: 1.35;
@@ -363,7 +363,7 @@ export const ProfileFrame = styled.div`
   height: 4.25rem;
   border-radius: 999px;
   overflow: hidden;
-  background: ${adminSurfaceRaised};
+  background: ${({ theme }) => adminRaisedSurface(theme)};
 `
 
 export const ProfileFallback = styled.div`
@@ -371,7 +371,7 @@ export const ProfileFallback = styled.div`
   height: 100%;
   display: grid;
   place-items: center;
-  color: ${adminTextPrimary};
+  color: ${({ theme }) => adminPrimaryText(theme)};
   font-size: 1rem;
   font-weight: 800;
 `
@@ -382,20 +382,20 @@ export const ProfileCopy = styled.div`
   gap: 0.14rem;
 
   strong {
-    color: ${adminTextPrimary};
+    color: ${({ theme }) => adminPrimaryText(theme)};
     font-size: 1rem;
     font-weight: 800;
   }
 
   span {
-    color: ${adminTextSecondary};
+    color: ${({ theme }) => adminSecondaryText(theme)};
     font-size: 0.82rem;
     font-weight: 700;
   }
 
   p {
     margin: 0;
-    color: ${adminTextMuted};
+    color: ${({ theme }) => adminMutedText(theme)};
     font-size: 0.8rem;
     line-height: 1.5;
     display: -webkit-box;
@@ -412,9 +412,9 @@ export const RailActionLink = styled.a`
   min-height: 40px;
   padding: 0 0.95rem;
   border-radius: 999px;
-  border: 1px solid ${adminBorder};
-  background: ${adminSurfaceRaised};
-  color: ${adminGold};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  background: ${({ theme }) => adminRaisedSurface(theme)};
+  color: ${({ theme }) => (theme.scheme === "light" ? adminPrimaryText(theme) : adminGold)};
   text-decoration: none;
   font-size: 0.84rem;
   font-weight: 760;

--- a/front/src/routes/Admin/AdminProfileWorkspace.styles.layout.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspace.styles.layout.ts
@@ -10,6 +10,12 @@ import {
   AdminWorkspaceSectionNav,
   AdminWorkspaceSectionNavButton,
 } from "src/routes/Admin/AdminSurfacePrimitives"
+import {
+  adminFocusRing,
+  adminWarningBadgeBorder,
+  adminWarningBadgeSurface,
+  adminWarningBadgeText,
+} from "src/routes/Admin/adminColorTokens"
 
 
 export const WorkspaceHero = styled(AdminWorkspaceHero)``
@@ -108,9 +114,9 @@ export const SectionStateBadge = styled.span`
   }
 
   &[data-tone="published"] {
-    border-color: #6d6040;
-    color: #d0b46c;
-    background: #2d291a;
+    border-color: ${adminWarningBadgeBorder()};
+    color: ${adminWarningBadgeText()};
+    background: ${adminWarningBadgeSurface()};
   }
 
   &[data-tone="synced"] {
@@ -252,7 +258,7 @@ export const Input = styled.input`
   &:focus-visible {
     outline: none;
     border-color: ${({ theme }) => theme.colors.accentBorder};
-    box-shadow: 0 0 0 3px rgba(208, 180, 108, 0.18);
+    box-shadow: ${({ theme }) => adminFocusRing(theme)};
   }
 `
 
@@ -275,7 +281,7 @@ export const TextArea = styled.textarea`
   &:focus-visible {
     outline: none;
     border-color: ${({ theme }) => theme.colors.accentBorder};
-    box-shadow: 0 0 0 3px rgba(208, 180, 108, 0.18);
+    box-shadow: ${({ theme }) => adminFocusRing(theme)};
   }
 `
 

--- a/front/src/routes/Admin/AdminProfileWorkspace.styles.layout.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspace.styles.layout.ts
@@ -108,9 +108,9 @@ export const SectionStateBadge = styled.span`
   }
 
   &[data-tone="published"] {
-    border-color: ${({ theme }) => theme.colors.blue7};
-    color: ${({ theme }) => theme.colors.blue10};
-    background: ${({ theme }) => theme.colors.blue2};
+    border-color: #6d6040;
+    color: #d0b46c;
+    background: #2d291a;
   }
 
   &[data-tone="synced"] {
@@ -172,7 +172,7 @@ export const FieldSectionCard = styled.div`
   display: grid;
   gap: 0.82rem;
   padding: 1rem;
-  border-radius: 22px;
+  border-radius: 12px;
   border: 1px solid ${({ theme }) => theme.colors.gray5};
   background: ${({ theme }) => theme.colors.gray1};
 
@@ -252,7 +252,7 @@ export const Input = styled.input`
   &:focus-visible {
     outline: none;
     border-color: ${({ theme }) => theme.colors.accentBorder};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+    box-shadow: 0 0 0 3px rgba(208, 180, 108, 0.18);
   }
 `
 
@@ -275,7 +275,7 @@ export const TextArea = styled.textarea`
   &:focus-visible {
     outline: none;
     border-color: ${({ theme }) => theme.colors.accentBorder};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.blue4};
+    box-shadow: 0 0 0 3px rgba(208, 180, 108, 0.18);
   }
 `
 

--- a/front/src/routes/Admin/AdminProfileWorkspace.styles.links.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspace.styles.links.ts
@@ -1,4 +1,10 @@
 import styled from "@emotion/styled"
+import {
+  adminGold,
+  adminGoldTintLine,
+  adminWarningBadgeBorder,
+  adminWarningBadgeSurface,
+} from "src/routes/Admin/adminColorTokens"
 
 export const LinkManagerHeader = styled.div`
   display: flex;
@@ -49,8 +55,8 @@ export const LinkRowCard = styled.div`
   }
 
   &[data-drop-target="true"] {
-    border-color: #6d6040;
-    background: #2d291a;
+    border-color: ${adminWarningBadgeBorder()};
+    background: ${adminWarningBadgeSurface()};
   }
 
   &[data-drop-target="true"]::before {
@@ -60,8 +66,8 @@ export const LinkRowCard = styled.div`
     right: 0.72rem;
     height: 3px;
     border-radius: 999px;
-    background: #d0b46c;
-    box-shadow: 0 0 0 1px rgba(208, 180, 108, 0.2);
+    background: ${adminGold};
+    box-shadow: 0 0 0 1px ${adminGoldTintLine};
   }
 
   &[data-drop-target="true"][data-drop-position="before"]::before {
@@ -207,8 +213,8 @@ export const IconOptionButton = styled.button`
   align-items: center;
 
   &[data-selected="true"] {
-    border-color: #6d6040;
-    background: #2d291a;
+    border-color: ${adminWarningBadgeBorder()};
+    background: ${adminWarningBadgeSurface()};
   }
 `
 

--- a/front/src/routes/Admin/AdminProfileWorkspace.styles.links.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspace.styles.links.ts
@@ -49,8 +49,8 @@ export const LinkRowCard = styled.div`
   }
 
   &[data-drop-target="true"] {
-    border-color: ${({ theme }) => theme.colors.blue8};
-    background: ${({ theme }) => theme.colors.accentSurfaceSubtle};
+    border-color: #6d6040;
+    background: #2d291a;
   }
 
   &[data-drop-target="true"]::before {
@@ -60,8 +60,8 @@ export const LinkRowCard = styled.div`
     right: 0.72rem;
     height: 3px;
     border-radius: 999px;
-    background: ${({ theme }) => theme.colors.blue8};
-    box-shadow: 0 0 0 1px rgba(96, 165, 250, 0.2);
+    background: #d0b46c;
+    box-shadow: 0 0 0 1px rgba(208, 180, 108, 0.2);
   }
 
   &[data-drop-target="true"][data-drop-position="before"]::before {
@@ -207,8 +207,8 @@ export const IconOptionButton = styled.button`
   align-items: center;
 
   &[data-selected="true"] {
-    border-color: ${({ theme }) => theme.colors.blue8};
-    background: ${({ theme }) => theme.colors.blue3};
+    border-color: #6d6040;
+    background: #2d291a;
   }
 `
 
@@ -242,4 +242,3 @@ export const LinkInputs = styled.div`
     grid-template-columns: 1fr;
   }
 `
-

--- a/front/src/routes/Admin/AdminProfileWorkspace.styles.sections.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspace.styles.sections.ts
@@ -288,9 +288,9 @@ export const ToastCard = styled.div`
   }
 
   &[data-tone="loading"] {
-    border-color: ${({ theme }) => theme.colors.blue8};
-    background: ${({ theme }) => theme.colors.blue3};
-    color: ${({ theme }) => theme.colors.blue11};
+    border-color: #6d6040;
+    background: #2d291a;
+    color: #d0b46c;
   }
 `
 
@@ -324,7 +324,7 @@ export const ModalCard = styled.section`
   width: min(640px, 100%);
   max-height: min(92vh, 860px);
   overflow: auto;
-  border-radius: 20px;
+  border-radius: 12px;
   border: 1px solid ${({ theme }) => theme.colors.gray6};
   background: ${({ theme }) => theme.colors.gray2};
   box-shadow: 0 24px 64px rgba(0, 0, 0, 0.42);

--- a/front/src/routes/Admin/AdminProfileWorkspace.styles.sections.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspace.styles.sections.ts
@@ -10,6 +10,11 @@ import {
   AdminWorkspaceSectionNav,
   AdminWorkspaceSectionNavButton,
 } from "src/routes/Admin/AdminSurfacePrimitives"
+import {
+  adminWarningBadgeBorder,
+  adminWarningBadgeSurface,
+  adminWarningBadgeText,
+} from "src/routes/Admin/adminColorTokens"
 import { BaseButton, PublishButton } from "./AdminProfileWorkspace.styles.tokens"
 
 
@@ -288,9 +293,9 @@ export const ToastCard = styled.div`
   }
 
   &[data-tone="loading"] {
-    border-color: #6d6040;
-    background: #2d291a;
-    color: #d0b46c;
+    border-color: ${adminWarningBadgeBorder()};
+    background: ${adminWarningBadgeSurface()};
+    color: ${adminWarningBadgeText()};
   }
 `
 

--- a/front/src/routes/Admin/AdminProfileWorkspace.styles.tokens.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspace.styles.tokens.ts
@@ -10,14 +10,20 @@ import {
   AdminWorkspaceSectionNav,
   AdminWorkspaceSectionNavButton,
 } from "src/routes/Admin/AdminSurfacePrimitives"
-
-const adminTextPrimary = "#f3f1ea"
-const adminTextSecondary = "#c8c1ae"
-const adminBorder = "#34322d"
-const adminBorderStrong = "#6d6040"
-const adminSurfaceRaised = "#20211f"
-const adminGold = "#d0b46c"
-const adminTeal = "#3f8f86"
+import {
+  adminBorder,
+  adminBorderStrong,
+  adminControlText,
+  adminGold,
+  adminSurfaceMuted,
+  adminSurfaceRaised,
+  adminTeal,
+  adminTealBorder,
+  adminTealBorderHover,
+  adminTealHover,
+  adminTextPrimary,
+  adminTextSecondary,
+} from "src/routes/Admin/adminColorTokens"
 
 export const Main = styled.main`
   max-width: 1420px;
@@ -49,7 +55,7 @@ export const BaseButton = styled.button`
 
   &:hover:not(:disabled) {
     border-color: ${adminBorderStrong};
-    background: #242520;
+    background: ${adminSurfaceMuted};
     color: ${adminTextPrimary};
     transform: translateY(-1px);
   }
@@ -78,14 +84,14 @@ export const GhostButton = styled(BaseButton)`
 `
 
 export const PrimaryButton = styled(BaseButton)`
-  border-color: rgba(63, 143, 134, 0.58);
+  border-color: ${adminTealBorder};
   background: ${adminTeal};
-  color: #f8fffc;
+  color: ${adminControlText};
 
   &:hover:not(:disabled) {
-    border-color: rgba(63, 143, 134, 0.72);
-    background: #347b73;
-    color: #f8fffc;
+    border-color: ${adminTealBorderHover};
+    background: ${adminTealHover};
+    color: ${adminControlText};
   }
 `
 

--- a/front/src/routes/Admin/AdminProfileWorkspace.styles.tokens.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspace.styles.tokens.ts
@@ -11,6 +11,13 @@ import {
   AdminWorkspaceSectionNavButton,
 } from "src/routes/Admin/AdminSurfacePrimitives"
 
+const adminTextPrimary = "#f3f1ea"
+const adminTextSecondary = "#c8c1ae"
+const adminBorder = "#34322d"
+const adminBorderStrong = "#6d6040"
+const adminSurfaceRaised = "#20211f"
+const adminGold = "#d0b46c"
+const adminTeal = "#3f8f86"
 
 export const Main = styled.main`
   max-width: 1420px;
@@ -26,10 +33,10 @@ export const Main = styled.main`
 
 export const BaseButton = styled.button`
   min-height: 38px;
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray1};
-  color: ${({ theme }) => theme.colors.gray11};
+  border-radius: 9px;
+  border: 1px solid ${adminBorder};
+  background: ${adminSurfaceRaised};
+  color: ${adminTextSecondary};
   padding: 0.7rem 0.96rem;
   font-size: 0.92rem;
   font-weight: 700;
@@ -41,9 +48,9 @@ export const BaseButton = styled.button`
     transform 0.18s ease;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.gray8};
-    background: ${({ theme }) => theme.colors.gray3};
-    color: ${({ theme }) => theme.colors.gray12};
+    border-color: ${adminBorderStrong};
+    background: #242520;
+    color: ${adminTextPrimary};
     transform: translateY(-1px);
   }
 
@@ -71,14 +78,14 @@ export const GhostButton = styled(BaseButton)`
 `
 
 export const PrimaryButton = styled(BaseButton)`
-  border-color: ${({ theme }) => theme.colors.blue8};
-  background: ${({ theme }) => theme.colors.blue3};
-  color: ${({ theme }) => theme.colors.blue11};
+  border-color: rgba(63, 143, 134, 0.58);
+  background: ${adminTeal};
+  color: #f8fffc;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.blue9};
-    background: ${({ theme }) => theme.colors.blue4};
-    color: ${({ theme }) => theme.colors.blue12};
+    border-color: rgba(63, 143, 134, 0.72);
+    background: #347b73;
+    color: #f8fffc;
   }
 `
 
@@ -128,9 +135,8 @@ export const PreviewAnchor = styled.a`
   padding: 0;
   border: 0;
   background: transparent;
-  color: ${({ theme }) => theme.colors.blue9};
+  color: ${adminGold};
   font-size: 0.8rem;
   font-weight: 700;
   text-decoration: none;
 `
-

--- a/front/src/routes/Admin/AdminShell.tsx
+++ b/front/src/routes/Admin/AdminShell.tsx
@@ -71,6 +71,17 @@ const AdminUtilityBar = dynamic(() => import("./AdminUtilityBar"), {
   loading: () => <UtilityBarFallback aria-hidden="true" />,
 })
 
+const adminTextPrimary = "#f3f1ea"
+const adminTextSecondary = "#c8c1ae"
+const adminTextMuted = "#918b7d"
+const adminBorder = "#34322d"
+const adminBorderStrong = "#6d6040"
+const adminSurface = "#151614"
+const adminSurfaceRaised = "#20211f"
+const adminSurfaceAccent = "#2d291a"
+const adminGold = "#d0b46c"
+const adminTeal = "#3f8f86"
+
 const AdminShell = ({ currentSection, member, profileSnapshot = null, children }: AdminShellProps) => {
   const currentNav = NAV_ITEMS.find((item) => item.id === currentSection) ?? NAV_ITEMS[0]
   const utilityNavItems = NAV_ITEMS.map((item) => ({
@@ -152,13 +163,17 @@ export default AdminShell
 
 const ShellFrame = styled.div`
   display: grid;
-  grid-template-columns: minmax(14.5rem, 16rem) minmax(0, 1fr);
-  gap: 1rem;
+  grid-template-columns: minmax(14.5rem, 16.5rem) minmax(0, 1fr);
+  gap: 0.85rem;
+  width: min(1760px, calc(100vw - 2rem));
+  margin-left: calc(50% - 50vw + 1rem);
   min-height: calc(100vh - var(--app-header-height, 73px) - 1rem);
-  padding: 1rem 0 2rem;
+  padding: 0.85rem 0 2rem;
 
   @media (max-width: 1100px) {
     grid-template-columns: minmax(0, 1fr);
+    width: 100%;
+    margin-left: 0;
     padding-top: 0.85rem;
   }
 `
@@ -170,19 +185,19 @@ const Sidebar = styled.aside`
   min-width: 0;
   position: sticky;
   top: calc(var(--app-header-height, 73px) + 0.85rem);
+  min-height: calc(100vh - var(--app-header-height, 73px) - 1.7rem);
   height: fit-content;
-  padding: 1.05rem;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray4)};
-  border-radius: 24px;
+  padding: 0.85rem 0.72rem;
+  border: 0;
+  border-right: 1px solid ${adminBorder};
+  border-radius: 0;
   background: ${({ theme }) =>
-    theme.blogDesign === "grid"
-      ? `linear-gradient(180deg, ${theme.publicDesign.operationSurfaceElevated} 0%, ${theme.publicDesign.operationSurface} 100%)`
-      : theme.colors.gray1};
+    theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : adminSurface};
 
   @media (max-width: 1100px) {
     position: static;
     padding: 0.72rem 0.82rem;
-    border-radius: 22px;
+    border-radius: 14px;
     display: none;
   }
 `
@@ -203,7 +218,7 @@ const BrandBlock = styled.div`
   display: flex;
   align-items: center;
   gap: 0.78rem;
-  padding: 0.1rem 0.1rem 0;
+  padding: 0.1rem 0.2rem 0.35rem;
 
   @media (max-width: 1100px) {
     flex-shrink: 0;
@@ -211,17 +226,18 @@ const BrandBlock = styled.div`
 `
 
 const BrandMark = styled.div`
-  width: 3.25rem;
-  height: 3.25rem;
-  border-radius: 16px;
+  width: 2.95rem;
+  height: 2.95rem;
+  border-radius: 11px;
   display: grid;
   place-items: center;
   position: relative;
   overflow: hidden;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray6)};
+  border: 1px solid ${({ theme }) =>
+    theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : adminBorderStrong};
   background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2};
-  color: ${({ theme }) => theme.colors.gray12};
+    theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : adminSurfaceAccent};
+  color: ${adminGold};
 
   span {
     font-size: 0.9rem;
@@ -235,14 +251,14 @@ const BrandCopy = styled.div`
   gap: 0.16rem;
 
   strong {
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminTextPrimary};
     font-size: 1.18rem;
     font-weight: 800;
     letter-spacing: -0.03em;
   }
 
   span {
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     font-size: 0.8rem;
     font-weight: 700;
   }
@@ -254,16 +270,16 @@ const BrandCopy = styled.div`
 
 const SidebarNavSection = styled.section`
   display: grid;
-  gap: 0.7rem;
-  padding-top: 0.25rem;
+  gap: 0.68rem;
+  padding-top: 0.35rem;
 `
 
 const SidebarSectionLabel = styled.small`
-  color: ${({ theme }) => theme.colors.gray10};
+  color: ${adminTextMuted};
   font-size: 0.74rem;
   font-weight: 700;
   letter-spacing: 0.02em;
-  padding: 0 0.22rem;
+  padding: 0 0.35rem;
 `
 
 const SidebarNav = styled.nav`
@@ -289,9 +305,10 @@ const NavLink = styled.a`
   align-items: center;
   gap: 0.82rem;
   min-width: 0;
-  padding: 0.78rem 0.84rem;
-  border-radius: 16px;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray3)};
+  min-height: 2.65rem;
+  padding: 0.5rem 0.62rem;
+  border-radius: 8px;
+  border: 1px solid transparent;
   color: inherit;
   text-decoration: none;
   transition: border-color 140ms ease, background 140ms ease;
@@ -299,17 +316,17 @@ const NavLink = styled.a`
   .navIcon {
     width: 2.3rem;
     height: 2.3rem;
-    border-radius: 13px;
+    border-radius: 7px;
     display: grid;
     place-items: center;
     flex-shrink: 0;
-    color: ${({ theme }) => theme.colors.gray11};
+    color: ${adminTextSecondary};
     background: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2};
+      theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : adminSurfaceRaised};
   }
 
   .navLabel {
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminTextPrimary};
     font-size: 0.92rem;
     font-weight: 760;
     letter-spacing: -0.02em;
@@ -317,21 +334,21 @@ const NavLink = styled.a`
   }
 
   &[data-active="true"] {
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray6)};
+    border-color: ${({ theme }) =>
+      theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : adminBorderStrong};
     background: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2};
+      theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : adminSurfaceAccent};
   }
 
   &[data-active="true"] .navIcon {
-    background: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3};
-    color: ${({ theme }) => theme.colors.gray12};
+    background: rgba(208, 180, 108, 0.14);
+    color: ${adminGold};
   }
 
   &:hover {
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray6)};
+    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : adminBorder)};
     background: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2};
+      theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : adminSurfaceRaised};
   }
 
   @media (max-width: 1100px) {
@@ -352,19 +369,18 @@ const SidebarPrimaryAction = styled.a`
   gap: 0.46rem;
   width: 100%;
   min-height: 2.9rem;
-  padding: 0.78rem 0.9rem;
-  border-radius: 14px;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray6)};
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray2};
-  color: ${({ theme }) => theme.colors.gray12};
+  padding: 0.7rem 0.9rem;
+  border-radius: 8px;
+  border: 1px solid rgba(63, 143, 134, 0.58);
+  background: ${adminTeal};
+  color: #f8fffc;
   text-decoration: none;
   font-size: 0.88rem;
   font-weight: 760;
 
   &:hover {
     background: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray3};
+      theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : "#347b73"};
   }
 `
 
@@ -380,14 +396,11 @@ const UtilityBarFallback = styled.div`
   top: calc(var(--app-header-height, 73px) + 0.85rem);
   z-index: 5;
   height: 4.85rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray5};
-  border-radius: 24px;
+  border: 1px solid ${adminBorder};
+  border-radius: 14px;
   background: ${({ theme }) =>
-    theme.scheme === "light" ? "rgba(255, 255, 255, 0.84)" : "rgba(18, 18, 18, 0.84)"};
-  box-shadow: ${({ theme }) =>
-    theme.scheme === "light"
-      ? "0 16px 36px rgba(15, 23, 42, 0.06)"
-      : "0 18px 36px rgba(0, 0, 0, 0.2)"};
+    theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : "rgba(23, 24, 23, 0.86)"};
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.2);
 
   @media (max-width: 720px) {
     top: calc(var(--app-header-height, 73px) + 0.65rem);

--- a/front/src/routes/Admin/AdminShell.tsx
+++ b/front/src/routes/Admin/AdminShell.tsx
@@ -5,6 +5,22 @@ import { type ReactNode } from "react"
 import AppIcon, { type IconName } from "src/components/icons/AppIcon"
 import ProfileImage from "src/components/ProfileImage"
 import type { AuthMember } from "src/hooks/useAuthSession"
+import {
+  adminBorder,
+  adminBorderStrong,
+  adminControlText,
+  adminGold,
+  adminGoldTintSubtle,
+  adminShellSurface,
+  adminSurfaceAccent,
+  adminSurfaceRaised,
+  adminTeal,
+  adminTealBorder,
+  adminTealHover,
+  adminTextMuted,
+  adminTextPrimary,
+  adminTextSecondary,
+} from "src/routes/Admin/adminColorTokens"
 
 type AdminShellProfileSnapshot = Pick<
   AuthMember,
@@ -70,17 +86,6 @@ const AdminUtilityBar = dynamic(() => import("./AdminUtilityBar"), {
   ssr: false,
   loading: () => <UtilityBarFallback aria-hidden="true" />,
 })
-
-const adminTextPrimary = "#f3f1ea"
-const adminTextSecondary = "#c8c1ae"
-const adminTextMuted = "#918b7d"
-const adminBorder = "#34322d"
-const adminBorderStrong = "#6d6040"
-const adminSurface = "#151614"
-const adminSurfaceRaised = "#20211f"
-const adminSurfaceAccent = "#2d291a"
-const adminGold = "#d0b46c"
-const adminTeal = "#3f8f86"
 
 const AdminShell = ({ currentSection, member, profileSnapshot = null, children }: AdminShellProps) => {
   const currentNav = NAV_ITEMS.find((item) => item.id === currentSection) ?? NAV_ITEMS[0]
@@ -192,7 +197,7 @@ const Sidebar = styled.aside`
   border-right: 1px solid ${adminBorder};
   border-radius: 0;
   background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : adminSurface};
+    theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : adminShellSurface};
 
   @media (max-width: 1100px) {
     position: static;
@@ -341,7 +346,7 @@ const NavLink = styled.a`
   }
 
   &[data-active="true"] .navIcon {
-    background: rgba(208, 180, 108, 0.14);
+    background: ${adminGoldTintSubtle};
     color: ${adminGold};
   }
 
@@ -371,16 +376,16 @@ const SidebarPrimaryAction = styled.a`
   min-height: 2.9rem;
   padding: 0.7rem 0.9rem;
   border-radius: 8px;
-  border: 1px solid rgba(63, 143, 134, 0.58);
+  border: 1px solid ${adminTealBorder};
   background: ${adminTeal};
-  color: #f8fffc;
+  color: ${adminControlText};
   text-decoration: none;
   font-size: 0.88rem;
   font-weight: 760;
 
   &:hover {
     background: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : "#347b73"};
+      theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : adminTealHover};
   }
 `
 

--- a/front/src/routes/Admin/AdminSurfacePrimitives.tsx
+++ b/front/src/routes/Admin/AdminSurfacePrimitives.tsx
@@ -1,44 +1,51 @@
 import type { Theme } from "@emotion/react"
 import styled from "@emotion/styled"
 
+const adminTextPrimary = "#f3f1ea"
+const adminTextSecondary = "#c8c1ae"
+const adminTextMuted = "#918b7d"
+const adminBorder = "#34322d"
+const adminBorderStrong = "#6d6040"
+const adminSurface = "#171817"
+const adminSurfaceRaised = "#20211f"
+const adminSurfaceMuted = "#242520"
+const adminSurfaceAccent = "#2d291a"
+const adminGold = "#d0b46c"
+
 export const adminElevatedSurface = (theme: Theme) =>
   theme.blogDesign === "grid"
     ? `linear-gradient(180deg, ${theme.publicDesign.operationSurfaceElevated} 0%, ${theme.publicDesign.operationSurface} 100%)`
-    : theme.scheme === "light"
-      ? "linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 248, 249, 0.94) 100%)"
-      : "linear-gradient(180deg, rgba(23, 23, 24, 0.96) 0%, rgba(17, 17, 18, 0.94) 100%)"
+    : `linear-gradient(180deg, #1b1c1a 0%, ${adminSurface} 100%)`
 
 export const adminElevatedBorder = (theme: Theme) =>
-  theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5
+  theme.blogDesign === "grid" ? theme.publicDesign.border : "#30322e"
 
 export const adminElevatedShadow = (theme: Theme) =>
   theme.blogDesign === "grid"
     ? theme.publicDesign.shadow
-    : theme.scheme === "light"
-      ? "0 18px 42px rgba(15, 23, 42, 0.06)"
-      : "0 20px 44px rgba(0, 0, 0, 0.2)"
+    : "0 20px 44px rgba(0, 0, 0, 0.2)"
 
 export const adminInteractiveFocusRing = (theme: Theme) =>
-  theme.scheme === "light" ? "0 0 0 3px rgba(59, 130, 246, 0.18)" : "0 0 0 3px rgba(96, 165, 250, 0.28)"
+  theme.scheme === "light" ? "0 0 0 3px rgba(208, 180, 108, 0.18)" : "0 0 0 3px rgba(208, 180, 108, 0.24)"
 
 export const AdminElevatedCard = styled.section`
-  border-radius: 24px;
+  border-radius: 14px;
   border: 1px solid ${({ theme }) => adminElevatedBorder(theme)};
   background: ${({ theme }) => adminElevatedSurface(theme)};
   box-shadow: ${({ theme }) => adminElevatedShadow(theme)};
 `
 
 export const AdminPlainCard = styled.section`
-  border-radius: 20px;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray1)};
+  border-radius: 12px;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : adminBorder)};
+  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : adminSurface)};
 `
 
 export const AdminSubtleCard = styled.section`
-  border-radius: 20px;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
+  border-radius: 12px;
+  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : adminBorder)};
   background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2};
+    theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : adminSurfaceRaised};
 `
 
 export const AdminRailCard = styled(AdminSubtleCard)`
@@ -75,7 +82,7 @@ export const AdminSectionTitleStack = styled.div`
   h2,
   h3 {
     margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminTextPrimary};
     font-size: 1.05rem;
     font-weight: 800;
     letter-spacing: -0.02em;
@@ -83,7 +90,7 @@ export const AdminSectionTitleStack = styled.div`
 
   p {
     margin: 0;
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     font-size: 0.84rem;
     line-height: 1.55;
   }
@@ -93,18 +100,18 @@ export const AdminPaneHeader = styled.div`
   display: grid;
   gap: 0.22rem;
   padding-bottom: 0.95rem;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray5};
+  border-bottom: 1px solid ${adminBorder};
 
   h2 {
     margin: 0;
     font-size: clamp(1.24rem, 2vw, 1.5rem);
     line-height: 1.2;
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminTextPrimary};
   }
 
   p {
     margin: 0;
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     font-size: 0.86rem;
     line-height: 1.55;
   }
@@ -112,7 +119,7 @@ export const AdminPaneHeader = styled.div`
 
 export const AdminLandingSectionLead = styled.p`
   margin: 0;
-  color: ${({ theme }) => theme.colors.gray10};
+  color: ${adminTextMuted};
   font-size: 0.86rem;
   line-height: 1.58;
 `
@@ -121,7 +128,7 @@ export const AdminWorkspaceHero = styled.section`
   display: grid;
   gap: 0.72rem;
   padding: 0 0 0.92rem;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray5};
+  border-bottom: 1px solid ${adminBorder};
 `
 
 export const AdminWorkspaceHeroLabel = styled.span`
@@ -131,9 +138,9 @@ export const AdminWorkspaceHeroLabel = styled.span`
   align-items: center;
   padding: 0 0.72rem;
   border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
-  color: ${({ theme }) => theme.colors.gray11};
+  border: 1px solid ${adminBorder};
+  background: ${adminSurfaceRaised};
+  color: ${adminTextSecondary};
   font-size: 0.74rem;
   font-weight: 800;
 `
@@ -158,13 +165,13 @@ export const AdminWorkspaceHeroCopy = styled.div`
     font-size: clamp(1.42rem, 2.5vw, 1.86rem);
     line-height: 1.1;
     letter-spacing: -0.03em;
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminTextPrimary};
   }
 
   p {
     margin: 0;
     max-width: 36rem;
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     font-size: 0.88rem;
     line-height: 1.58;
   }
@@ -204,26 +211,26 @@ export const AdminWorkspaceSectionNav = styled(AdminStickyRail)`
 export const AdminWorkspaceSectionNavStatus = styled(AdminRailCard)`
   gap: 0.22rem;
   padding: 0.88rem 0.96rem;
-  border-radius: 16px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 10px;
+  border: 1px solid ${adminBorder};
 
   small {
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     font-size: 0.72rem;
     font-weight: 800;
     letter-spacing: 0.03em;
   }
 
   strong {
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminTextPrimary};
     font-size: 0.92rem;
     font-weight: 780;
     letter-spacing: -0.02em;
   }
 
   &[data-jumping="true"] {
-    border-color: ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray1};
+    border-color: ${adminBorderStrong};
+    background: ${adminSurfaceAccent};
   }
 
   @media (max-width: 1180px) {
@@ -243,9 +250,9 @@ export const AdminWorkspaceSectionNavButton = styled.button`
   min-height: 42px;
   padding: 0 0.9rem;
   border-radius: 999px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
-  color: ${({ theme }) => theme.colors.gray10};
+  border: 1px solid ${adminBorder};
+  background: ${adminSurfaceRaised};
+  color: ${adminTextMuted};
   font-size: 0.84rem;
   font-weight: 700;
   text-align: left;
@@ -259,14 +266,14 @@ export const AdminWorkspaceSectionNavButton = styled.button`
 
   &:focus-visible {
     outline: none;
-    border-color: ${({ theme }) => theme.colors.blue8};
+    border-color: ${adminBorderStrong};
     box-shadow: ${({ theme }) => adminInteractiveFocusRing(theme)};
   }
 
   &[data-active="true"] {
-    color: ${({ theme }) => theme.colors.gray12};
-    border-color: ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray1};
+    color: ${adminGold};
+    border-color: ${adminBorderStrong};
+    background: ${adminSurfaceAccent};
   }
 
   &[data-freshness="fresh"] {
@@ -326,9 +333,9 @@ export const AdminWorkspaceActionDockInner = styled.div`
   justify-content: flex-end;
   gap: 0.65rem;
   padding: 0.7rem 0.9rem;
-  border-radius: 20px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
+  border-radius: 12px;
+  border: 1px solid ${adminBorder};
+  background: ${adminSurfaceRaised};
 
   @media (max-width: 760px) {
     justify-content: space-between;
@@ -346,10 +353,9 @@ export const AdminInfoLinkCard = styled.a<{ $withIcon?: boolean }>`
   gap: ${({ $withIcon = true }) => ($withIcon ? "0.7rem" : "0.18rem")};
   align-items: center;
   padding: 0.82rem 0.88rem;
-  border-radius: 18px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) =>
-    theme.scheme === "light" ? "rgba(255, 255, 255, 0.84)" : "rgba(31, 31, 31, 0.88)"};
+  border-radius: 10px;
+  border: 1px solid ${adminBorder};
+  background: ${adminSurfaceRaised};
   color: inherit;
   text-decoration: none;
   min-width: 0;
@@ -360,7 +366,7 @@ export const AdminInfoLinkCard = styled.a<{ $withIcon?: boolean }>`
 
   &:focus-visible {
     outline: none;
-    border-color: ${({ theme }) => theme.colors.blue8};
+    border-color: ${adminBorderStrong};
     box-shadow: ${({ theme }) => adminInteractiveFocusRing(theme)};
   }
 
@@ -368,10 +374,10 @@ export const AdminInfoLinkCard = styled.a<{ $withIcon?: boolean }>`
     display: ${({ $withIcon = true }) => ($withIcon ? "grid" : "none")};
     width: 2.35rem;
     height: 2.35rem;
-    border-radius: 14px;
+    border-radius: 8px;
     place-items: center;
-    background: ${({ theme }) => theme.colors.gray2};
-    color: ${({ theme }) => theme.colors.gray11};
+    background: ${adminSurfaceMuted};
+    color: ${adminTextSecondary};
   }
 
   .copy {
@@ -382,7 +388,7 @@ export const AdminInfoLinkCard = styled.a<{ $withIcon?: boolean }>`
 
   .copy strong,
   > strong {
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminTextPrimary};
     font-size: 0.86rem;
     font-weight: 780;
     overflow-wrap: anywhere;
@@ -390,7 +396,7 @@ export const AdminInfoLinkCard = styled.a<{ $withIcon?: boolean }>`
 
   .copy span,
   > span {
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     font-size: 0.75rem;
     font-weight: 700;
     overflow-wrap: anywhere;
@@ -408,10 +414,9 @@ export const AdminInfoStatusItem = styled.div`
   justify-content: space-between;
   gap: 0.72rem;
   padding: 0.74rem 0.82rem;
-  border-radius: 16px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) =>
-    theme.scheme === "light" ? "rgba(255, 255, 255, 0.82)" : "rgba(31, 31, 31, 0.88)"};
+  border-radius: 10px;
+  border: 1px solid ${adminBorder};
+  background: ${adminSurfaceRaised};
 
   &[data-tone="good"] {
     border-color: ${({ theme }) => theme.colors.green7};
@@ -422,13 +427,13 @@ export const AdminInfoStatusItem = styled.div`
   }
 
   span {
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     font-size: 0.76rem;
     font-weight: 700;
   }
 
   strong {
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminTextPrimary};
     font-size: 0.82rem;
     font-weight: 780;
     text-align: right;
@@ -439,9 +444,9 @@ export const AdminInfoPanelCard = styled.div`
   display: grid;
   gap: 0.68rem;
   padding: 0.92rem;
-  border-radius: 18px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray1};
+  border-radius: 10px;
+  border: 1px solid ${adminBorder};
+  background: ${adminSurface};
 `
 
 export const AdminStatusPill = styled.span<{ $size?: "sm" | "md" }>`
@@ -451,23 +456,23 @@ export const AdminStatusPill = styled.span<{ $size?: "sm" | "md" }>`
   min-height: ${({ $size = "md" }) => ($size === "sm" ? "28px" : "32px")};
   padding: ${({ $size = "md" }) => ($size === "sm" ? "0 0.62rem" : "0 0.72rem")};
   border-radius: ${({ $size = "md" }) => ($size === "sm" ? "10px" : "999px")};
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
-  color: ${({ theme }) => theme.colors.gray11};
+  border: 1px solid ${adminBorder};
+  background: ${adminSurfaceRaised};
+  color: ${adminTextSecondary};
   font-size: ${({ $size = "md" }) => ($size === "sm" ? "0.76rem" : "0.78rem")};
   font-weight: 800;
   line-height: 1;
 
   &[data-tone="neutral"] {
-    border-color: ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray2};
-    color: ${({ theme }) => theme.colors.gray10};
+    border-color: ${adminBorder};
+    background: ${adminSurfaceRaised};
+    color: ${adminTextMuted};
   }
 
   &[data-tone="accent"] {
-    border-color: ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray1};
-    color: ${({ theme }) => theme.colors.gray12};
+    border-color: ${adminBorderStrong};
+    background: ${adminSurfaceAccent};
+    color: ${adminGold};
   }
 
   &[data-tone="success"] {
@@ -502,7 +507,7 @@ export const AdminTextActionButton = styled.button`
   border: 0;
   border-radius: 0.36rem;
   background: transparent;
-  color: ${({ theme }) => theme.colors.gray11};
+  color: ${adminTextSecondary};
   font-size: 0.84rem;
   font-weight: 700;
   cursor: pointer;
@@ -521,7 +526,7 @@ export const AdminTextActionButton = styled.button`
   }
 
   &[data-tone="primary"] {
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminGold};
     font-weight: 800;
   }
 
@@ -535,7 +540,7 @@ export const AdminTextActionLink = styled.a`
   align-items: center;
   min-height: 0;
   border-radius: 0.36rem;
-  color: ${({ theme }) => theme.colors.gray11};
+  color: ${adminTextSecondary};
   font-size: 0.84rem;
   font-weight: 700;
   text-decoration: none;
@@ -549,7 +554,7 @@ export const AdminTextActionLink = styled.a`
   }
 
   &[data-tone="primary"] {
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminGold};
     font-weight: 800;
   }
 
@@ -563,10 +568,10 @@ export const AdminActionCardButton = styled.button`
   display: grid;
   gap: 0.16rem;
   padding: 0.82rem 0.88rem;
-  border-radius: 14px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 10px;
+  border: 1px solid ${adminBorder};
   background: transparent;
-  color: ${({ theme }) => theme.colors.gray12};
+  color: ${adminTextPrimary};
   cursor: pointer;
   transition:
     border-color 0.18s ease,
@@ -575,7 +580,7 @@ export const AdminActionCardButton = styled.button`
 
   &:focus-visible {
     outline: none;
-    border-color: ${({ theme }) => theme.colors.blue8};
+    border-color: ${adminBorderStrong};
     box-shadow: ${({ theme }) => adminInteractiveFocusRing(theme)};
   }
 
@@ -590,7 +595,7 @@ export const AdminActionCardButton = styled.button`
   }
 
   small {
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     line-height: 1.55;
   }
 `

--- a/front/src/routes/Admin/AdminSurfacePrimitives.tsx
+++ b/front/src/routes/Admin/AdminSurfacePrimitives.tsx
@@ -12,18 +12,40 @@ const adminSurfaceMuted = "#242520"
 const adminSurfaceAccent = "#2d291a"
 const adminGold = "#d0b46c"
 
+const usesDarkAdminSurface = (theme: Theme) => theme.blogDesign === "grid" || theme.scheme !== "light"
+const adminPrimaryText = (theme: Theme) => usesDarkAdminSurface(theme) ? adminTextPrimary : theme.colors.gray12
+const adminSecondaryText = (theme: Theme) => usesDarkAdminSurface(theme) ? adminTextSecondary : theme.colors.gray11
+const adminMutedText = (theme: Theme) => usesDarkAdminSurface(theme) ? adminTextMuted : theme.colors.gray10
+const adminCardBorder = (theme: Theme) => theme.blogDesign === "grid" ? theme.publicDesign.border : usesDarkAdminSurface(theme) ? adminBorder : theme.colors.gray5
+const adminStrongBorder = (theme: Theme) => usesDarkAdminSurface(theme) ? adminBorderStrong : theme.colors.gray7
+const adminPlainSurface = (theme: Theme) =>
+  theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : usesDarkAdminSurface(theme) ? adminSurface : theme.colors.gray1
+const adminRaisedSurface = (theme: Theme) =>
+  theme.blogDesign === "grid"
+    ? theme.publicDesign.operationSurfaceElevated
+    : usesDarkAdminSurface(theme)
+      ? adminSurfaceRaised
+      : theme.colors.gray2
+const adminMutedSurface = (theme: Theme) => usesDarkAdminSurface(theme) ? adminSurfaceMuted : theme.colors.gray3
+const adminAccentSurface = (theme: Theme) =>
+  usesDarkAdminSurface(theme) ? adminSurfaceAccent : theme.colors.accentSurfaceSubtle
+
 export const adminElevatedSurface = (theme: Theme) =>
   theme.blogDesign === "grid"
     ? `linear-gradient(180deg, ${theme.publicDesign.operationSurfaceElevated} 0%, ${theme.publicDesign.operationSurface} 100%)`
-    : `linear-gradient(180deg, #1b1c1a 0%, ${adminSurface} 100%)`
+    : usesDarkAdminSurface(theme)
+      ? `linear-gradient(180deg, #1b1c1a 0%, ${adminSurface} 100%)`
+      : "linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 248, 249, 0.94) 100%)"
 
 export const adminElevatedBorder = (theme: Theme) =>
-  theme.blogDesign === "grid" ? theme.publicDesign.border : "#30322e"
+  theme.blogDesign === "grid" ? theme.publicDesign.border : usesDarkAdminSurface(theme) ? "#30322e" : theme.colors.gray5
 
 export const adminElevatedShadow = (theme: Theme) =>
   theme.blogDesign === "grid"
     ? theme.publicDesign.shadow
-    : "0 20px 44px rgba(0, 0, 0, 0.2)"
+    : usesDarkAdminSurface(theme)
+      ? "0 20px 44px rgba(0, 0, 0, 0.2)"
+      : "0 18px 42px rgba(15, 23, 42, 0.06)"
 
 export const adminInteractiveFocusRing = (theme: Theme) =>
   theme.scheme === "light" ? "0 0 0 3px rgba(208, 180, 108, 0.18)" : "0 0 0 3px rgba(208, 180, 108, 0.24)"
@@ -37,15 +59,14 @@ export const AdminElevatedCard = styled.section`
 
 export const AdminPlainCard = styled.section`
   border-radius: 12px;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : adminBorder)};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : adminSurface)};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  background: ${({ theme }) => adminPlainSurface(theme)};
 `
 
 export const AdminSubtleCard = styled.section`
   border-radius: 12px;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : adminBorder)};
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : adminSurfaceRaised};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  background: ${({ theme }) => adminRaisedSurface(theme)};
 `
 
 export const AdminRailCard = styled(AdminSubtleCard)`
@@ -82,7 +103,7 @@ export const AdminSectionTitleStack = styled.div`
   h2,
   h3 {
     margin: 0;
-    color: ${adminTextPrimary};
+    color: ${({ theme }) => adminPrimaryText(theme)};
     font-size: 1.05rem;
     font-weight: 800;
     letter-spacing: -0.02em;
@@ -90,7 +111,7 @@ export const AdminSectionTitleStack = styled.div`
 
   p {
     margin: 0;
-    color: ${adminTextMuted};
+    color: ${({ theme }) => adminMutedText(theme)};
     font-size: 0.84rem;
     line-height: 1.55;
   }
@@ -100,18 +121,18 @@ export const AdminPaneHeader = styled.div`
   display: grid;
   gap: 0.22rem;
   padding-bottom: 0.95rem;
-  border-bottom: 1px solid ${adminBorder};
+  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
 
   h2 {
     margin: 0;
     font-size: clamp(1.24rem, 2vw, 1.5rem);
     line-height: 1.2;
-    color: ${adminTextPrimary};
+    color: ${({ theme }) => adminPrimaryText(theme)};
   }
 
   p {
     margin: 0;
-    color: ${adminTextMuted};
+    color: ${({ theme }) => adminMutedText(theme)};
     font-size: 0.86rem;
     line-height: 1.55;
   }
@@ -119,7 +140,7 @@ export const AdminPaneHeader = styled.div`
 
 export const AdminLandingSectionLead = styled.p`
   margin: 0;
-  color: ${adminTextMuted};
+  color: ${({ theme }) => adminMutedText(theme)};
   font-size: 0.86rem;
   line-height: 1.58;
 `
@@ -128,7 +149,7 @@ export const AdminWorkspaceHero = styled.section`
   display: grid;
   gap: 0.72rem;
   padding: 0 0 0.92rem;
-  border-bottom: 1px solid ${adminBorder};
+  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
 `
 
 export const AdminWorkspaceHeroLabel = styled.span`
@@ -138,9 +159,9 @@ export const AdminWorkspaceHeroLabel = styled.span`
   align-items: center;
   padding: 0 0.72rem;
   border-radius: 999px;
-  border: 1px solid ${adminBorder};
-  background: ${adminSurfaceRaised};
-  color: ${adminTextSecondary};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  background: ${({ theme }) => adminRaisedSurface(theme)};
+  color: ${({ theme }) => adminSecondaryText(theme)};
   font-size: 0.74rem;
   font-weight: 800;
 `
@@ -165,13 +186,13 @@ export const AdminWorkspaceHeroCopy = styled.div`
     font-size: clamp(1.42rem, 2.5vw, 1.86rem);
     line-height: 1.1;
     letter-spacing: -0.03em;
-    color: ${adminTextPrimary};
+    color: ${({ theme }) => adminPrimaryText(theme)};
   }
 
   p {
     margin: 0;
     max-width: 36rem;
-    color: ${adminTextMuted};
+    color: ${({ theme }) => adminMutedText(theme)};
     font-size: 0.88rem;
     line-height: 1.58;
   }
@@ -212,25 +233,25 @@ export const AdminWorkspaceSectionNavStatus = styled(AdminRailCard)`
   gap: 0.22rem;
   padding: 0.88rem 0.96rem;
   border-radius: 10px;
-  border: 1px solid ${adminBorder};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
 
   small {
-    color: ${adminTextMuted};
+    color: ${({ theme }) => adminMutedText(theme)};
     font-size: 0.72rem;
     font-weight: 800;
     letter-spacing: 0.03em;
   }
 
   strong {
-    color: ${adminTextPrimary};
+    color: ${({ theme }) => adminPrimaryText(theme)};
     font-size: 0.92rem;
     font-weight: 780;
     letter-spacing: -0.02em;
   }
 
   &[data-jumping="true"] {
-    border-color: ${adminBorderStrong};
-    background: ${adminSurfaceAccent};
+    border-color: ${({ theme }) => adminStrongBorder(theme)};
+    background: ${({ theme }) => adminAccentSurface(theme)};
   }
 
   @media (max-width: 1180px) {
@@ -250,9 +271,9 @@ export const AdminWorkspaceSectionNavButton = styled.button`
   min-height: 42px;
   padding: 0 0.9rem;
   border-radius: 999px;
-  border: 1px solid ${adminBorder};
-  background: ${adminSurfaceRaised};
-  color: ${adminTextMuted};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  background: ${({ theme }) => adminRaisedSurface(theme)};
+  color: ${({ theme }) => adminMutedText(theme)};
   font-size: 0.84rem;
   font-weight: 700;
   text-align: left;
@@ -266,14 +287,14 @@ export const AdminWorkspaceSectionNavButton = styled.button`
 
   &:focus-visible {
     outline: none;
-    border-color: ${adminBorderStrong};
+    border-color: ${({ theme }) => adminStrongBorder(theme)};
     box-shadow: ${({ theme }) => adminInteractiveFocusRing(theme)};
   }
 
   &[data-active="true"] {
     color: ${adminGold};
-    border-color: ${adminBorderStrong};
-    background: ${adminSurfaceAccent};
+    border-color: ${({ theme }) => adminStrongBorder(theme)};
+    background: ${({ theme }) => adminAccentSurface(theme)};
   }
 
   &[data-freshness="fresh"] {
@@ -334,8 +355,8 @@ export const AdminWorkspaceActionDockInner = styled.div`
   gap: 0.65rem;
   padding: 0.7rem 0.9rem;
   border-radius: 12px;
-  border: 1px solid ${adminBorder};
-  background: ${adminSurfaceRaised};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  background: ${({ theme }) => adminRaisedSurface(theme)};
 
   @media (max-width: 760px) {
     justify-content: space-between;
@@ -354,8 +375,8 @@ export const AdminInfoLinkCard = styled.a<{ $withIcon?: boolean }>`
   align-items: center;
   padding: 0.82rem 0.88rem;
   border-radius: 10px;
-  border: 1px solid ${adminBorder};
-  background: ${adminSurfaceRaised};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  background: ${({ theme }) => adminRaisedSurface(theme)};
   color: inherit;
   text-decoration: none;
   min-width: 0;
@@ -366,7 +387,7 @@ export const AdminInfoLinkCard = styled.a<{ $withIcon?: boolean }>`
 
   &:focus-visible {
     outline: none;
-    border-color: ${adminBorderStrong};
+    border-color: ${({ theme }) => adminStrongBorder(theme)};
     box-shadow: ${({ theme }) => adminInteractiveFocusRing(theme)};
   }
 
@@ -376,8 +397,8 @@ export const AdminInfoLinkCard = styled.a<{ $withIcon?: boolean }>`
     height: 2.35rem;
     border-radius: 8px;
     place-items: center;
-    background: ${adminSurfaceMuted};
-    color: ${adminTextSecondary};
+    background: ${({ theme }) => adminMutedSurface(theme)};
+    color: ${({ theme }) => adminSecondaryText(theme)};
   }
 
   .copy {
@@ -388,7 +409,7 @@ export const AdminInfoLinkCard = styled.a<{ $withIcon?: boolean }>`
 
   .copy strong,
   > strong {
-    color: ${adminTextPrimary};
+    color: ${({ theme }) => adminPrimaryText(theme)};
     font-size: 0.86rem;
     font-weight: 780;
     overflow-wrap: anywhere;
@@ -396,7 +417,7 @@ export const AdminInfoLinkCard = styled.a<{ $withIcon?: boolean }>`
 
   .copy span,
   > span {
-    color: ${adminTextMuted};
+    color: ${({ theme }) => adminMutedText(theme)};
     font-size: 0.75rem;
     font-weight: 700;
     overflow-wrap: anywhere;
@@ -415,8 +436,8 @@ export const AdminInfoStatusItem = styled.div`
   gap: 0.72rem;
   padding: 0.74rem 0.82rem;
   border-radius: 10px;
-  border: 1px solid ${adminBorder};
-  background: ${adminSurfaceRaised};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  background: ${({ theme }) => adminRaisedSurface(theme)};
 
   &[data-tone="good"] {
     border-color: ${({ theme }) => theme.colors.green7};
@@ -427,13 +448,13 @@ export const AdminInfoStatusItem = styled.div`
   }
 
   span {
-    color: ${adminTextMuted};
+    color: ${({ theme }) => adminMutedText(theme)};
     font-size: 0.76rem;
     font-weight: 700;
   }
 
   strong {
-    color: ${adminTextPrimary};
+    color: ${({ theme }) => adminPrimaryText(theme)};
     font-size: 0.82rem;
     font-weight: 780;
     text-align: right;
@@ -445,8 +466,8 @@ export const AdminInfoPanelCard = styled.div`
   gap: 0.68rem;
   padding: 0.92rem;
   border-radius: 10px;
-  border: 1px solid ${adminBorder};
-  background: ${adminSurface};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  background: ${({ theme }) => adminPlainSurface(theme)};
 `
 
 export const AdminStatusPill = styled.span<{ $size?: "sm" | "md" }>`
@@ -456,22 +477,22 @@ export const AdminStatusPill = styled.span<{ $size?: "sm" | "md" }>`
   min-height: ${({ $size = "md" }) => ($size === "sm" ? "28px" : "32px")};
   padding: ${({ $size = "md" }) => ($size === "sm" ? "0 0.62rem" : "0 0.72rem")};
   border-radius: ${({ $size = "md" }) => ($size === "sm" ? "10px" : "999px")};
-  border: 1px solid ${adminBorder};
-  background: ${adminSurfaceRaised};
-  color: ${adminTextSecondary};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  background: ${({ theme }) => adminRaisedSurface(theme)};
+  color: ${({ theme }) => adminSecondaryText(theme)};
   font-size: ${({ $size = "md" }) => ($size === "sm" ? "0.76rem" : "0.78rem")};
   font-weight: 800;
   line-height: 1;
 
   &[data-tone="neutral"] {
-    border-color: ${adminBorder};
-    background: ${adminSurfaceRaised};
-    color: ${adminTextMuted};
+    border-color: ${({ theme }) => adminCardBorder(theme)};
+    background: ${({ theme }) => adminRaisedSurface(theme)};
+    color: ${({ theme }) => adminMutedText(theme)};
   }
 
   &[data-tone="accent"] {
-    border-color: ${adminBorderStrong};
-    background: ${adminSurfaceAccent};
+    border-color: ${({ theme }) => adminStrongBorder(theme)};
+    background: ${({ theme }) => adminAccentSurface(theme)};
     color: ${adminGold};
   }
 
@@ -507,7 +528,7 @@ export const AdminTextActionButton = styled.button`
   border: 0;
   border-radius: 0.36rem;
   background: transparent;
-  color: ${adminTextSecondary};
+  color: ${({ theme }) => adminSecondaryText(theme)};
   font-size: 0.84rem;
   font-weight: 700;
   cursor: pointer;
@@ -540,7 +561,7 @@ export const AdminTextActionLink = styled.a`
   align-items: center;
   min-height: 0;
   border-radius: 0.36rem;
-  color: ${adminTextSecondary};
+  color: ${({ theme }) => adminSecondaryText(theme)};
   font-size: 0.84rem;
   font-weight: 700;
   text-decoration: none;
@@ -569,9 +590,9 @@ export const AdminActionCardButton = styled.button`
   gap: 0.16rem;
   padding: 0.82rem 0.88rem;
   border-radius: 10px;
-  border: 1px solid ${adminBorder};
+  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
   background: transparent;
-  color: ${adminTextPrimary};
+  color: ${({ theme }) => adminPrimaryText(theme)};
   cursor: pointer;
   transition:
     border-color 0.18s ease,
@@ -580,7 +601,7 @@ export const AdminActionCardButton = styled.button`
 
   &:focus-visible {
     outline: none;
-    border-color: ${adminBorderStrong};
+    border-color: ${({ theme }) => adminStrongBorder(theme)};
     box-shadow: ${({ theme }) => adminInteractiveFocusRing(theme)};
   }
 
@@ -595,7 +616,7 @@ export const AdminActionCardButton = styled.button`
   }
 
   small {
-    color: ${adminTextMuted};
+    color: ${({ theme }) => adminMutedText(theme)};
     line-height: 1.55;
   }
 `

--- a/front/src/routes/Admin/AdminSurfacePrimitives.tsx
+++ b/front/src/routes/Admin/AdminSurfacePrimitives.tsx
@@ -1,44 +1,32 @@
 import type { Theme } from "@emotion/react"
 import styled from "@emotion/styled"
-
-const adminTextPrimary = "#f3f1ea"
-const adminTextSecondary = "#c8c1ae"
-const adminTextMuted = "#918b7d"
-const adminBorder = "#34322d"
-const adminBorderStrong = "#6d6040"
-const adminSurface = "#171817"
-const adminSurfaceRaised = "#20211f"
-const adminSurfaceMuted = "#242520"
-const adminSurfaceAccent = "#2d291a"
-const adminGold = "#d0b46c"
-
-const usesDarkAdminSurface = (theme: Theme) => theme.blogDesign === "grid" || theme.scheme !== "light"
-const adminPrimaryText = (theme: Theme) => usesDarkAdminSurface(theme) ? adminTextPrimary : theme.colors.gray12
-const adminSecondaryText = (theme: Theme) => usesDarkAdminSurface(theme) ? adminTextSecondary : theme.colors.gray11
-const adminMutedText = (theme: Theme) => usesDarkAdminSurface(theme) ? adminTextMuted : theme.colors.gray10
-const adminCardBorder = (theme: Theme) => theme.blogDesign === "grid" ? theme.publicDesign.border : usesDarkAdminSurface(theme) ? adminBorder : theme.colors.gray5
-const adminStrongBorder = (theme: Theme) => usesDarkAdminSurface(theme) ? adminBorderStrong : theme.colors.gray7
-const adminPlainSurface = (theme: Theme) =>
-  theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : usesDarkAdminSurface(theme) ? adminSurface : theme.colors.gray1
-const adminRaisedSurface = (theme: Theme) =>
-  theme.blogDesign === "grid"
-    ? theme.publicDesign.operationSurfaceElevated
-    : usesDarkAdminSurface(theme)
-      ? adminSurfaceRaised
-      : theme.colors.gray2
-const adminMutedSurface = (theme: Theme) => usesDarkAdminSurface(theme) ? adminSurfaceMuted : theme.colors.gray3
-const adminAccentSurface = (theme: Theme) =>
-  usesDarkAdminSurface(theme) ? adminSurfaceAccent : theme.colors.accentSurfaceSubtle
+import {
+  adminAccentSurface,
+  adminCardBorder,
+  adminElevatedBorderDark,
+  adminElevatedSurfaceTop,
+  adminFocusRing,
+  adminGold,
+  adminMutedSurface,
+  adminMutedText,
+  adminPlainSurface,
+  adminPrimaryText,
+  adminRaisedSurface,
+  adminSecondaryText,
+  adminStrongBorder,
+  adminSurface,
+  usesDarkAdminSurface,
+} from "src/routes/Admin/adminColorTokens"
 
 export const adminElevatedSurface = (theme: Theme) =>
   theme.blogDesign === "grid"
     ? `linear-gradient(180deg, ${theme.publicDesign.operationSurfaceElevated} 0%, ${theme.publicDesign.operationSurface} 100%)`
     : usesDarkAdminSurface(theme)
-      ? `linear-gradient(180deg, #1b1c1a 0%, ${adminSurface} 100%)`
+      ? `linear-gradient(180deg, ${adminElevatedSurfaceTop} 0%, ${adminSurface} 100%)`
       : "linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 248, 249, 0.94) 100%)"
 
 export const adminElevatedBorder = (theme: Theme) =>
-  theme.blogDesign === "grid" ? theme.publicDesign.border : usesDarkAdminSurface(theme) ? "#30322e" : theme.colors.gray5
+  theme.blogDesign === "grid" ? theme.publicDesign.border : usesDarkAdminSurface(theme) ? adminElevatedBorderDark : theme.colors.gray5
 
 export const adminElevatedShadow = (theme: Theme) =>
   theme.blogDesign === "grid"
@@ -48,7 +36,7 @@ export const adminElevatedShadow = (theme: Theme) =>
       : "0 18px 42px rgba(15, 23, 42, 0.06)"
 
 export const adminInteractiveFocusRing = (theme: Theme) =>
-  theme.scheme === "light" ? "0 0 0 3px rgba(208, 180, 108, 0.18)" : "0 0 0 3px rgba(208, 180, 108, 0.24)"
+  adminFocusRing(theme)
 
 export const AdminElevatedCard = styled.section`
   border-radius: 14px;

--- a/front/src/routes/Admin/AdminToolsWorkspace.styles.layout.ts
+++ b/front/src/routes/Admin/AdminToolsWorkspace.styles.layout.ts
@@ -23,9 +23,9 @@ export const InlineNotice = styled.p`
   line-height: 1.6;
 
   &[data-tone="warning"] {
-    border-color: ${({ theme }) => theme.colors.indigo8};
-    background: ${({ theme }) => theme.colors.indigo3};
-    color: ${({ theme }) => theme.colors.indigo11};
+    border-color: #6d6040;
+    background: #2d291a;
+    color: #d0b46c;
   }
 
   &[data-tone="danger"] {
@@ -147,8 +147,7 @@ export const ActionGroupCard = styled(AdminRailCard)`
   gap: 0.8rem;
   border-radius: 18px;
   border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) =>
-    theme.scheme === "light" ? "rgba(255, 255, 255, 0.82)" : "rgba(24, 24, 24, 0.86)"};
+  background: rgba(24, 24, 24, 0.86);
 `
 
 export const CardSectionHeading = styled.div`
@@ -511,4 +510,3 @@ export const EmptyResultState = styled.p`
   color: ${({ theme }) => theme.colors.gray10};
   line-height: 1.6;
 `
-

--- a/front/src/routes/Admin/AdminToolsWorkspace.styles.layout.ts
+++ b/front/src/routes/Admin/AdminToolsWorkspace.styles.layout.ts
@@ -11,7 +11,12 @@ import {
   AdminWorkspaceHero,
   adminInteractiveFocusRing,
 } from "src/routes/Admin/AdminSurfacePrimitives"
-
+import {
+  adminActionGroupSurface,
+  adminWarningBadgeBorder,
+  adminWarningBadgeSurface,
+  adminWarningBadgeText,
+} from "src/routes/Admin/adminColorTokens"
 
 export const InlineNotice = styled.p`
   margin: 0;
@@ -23,9 +28,9 @@ export const InlineNotice = styled.p`
   line-height: 1.6;
 
   &[data-tone="warning"] {
-    border-color: #6d6040;
-    background: #2d291a;
-    color: #d0b46c;
+    border-color: ${adminWarningBadgeBorder()};
+    background: ${adminWarningBadgeSurface()};
+    color: ${adminWarningBadgeText()};
   }
 
   &[data-tone="danger"] {
@@ -147,7 +152,7 @@ export const ActionGroupCard = styled(AdminRailCard)`
   gap: 0.8rem;
   border-radius: 18px;
   border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: rgba(24, 24, 24, 0.86);
+  background: ${({ theme }) => adminActionGroupSurface(theme)};
 `
 
 export const CardSectionHeading = styled.div`

--- a/front/src/routes/Admin/AdminToolsWorkspace.styles.tokens.ts
+++ b/front/src/routes/Admin/AdminToolsWorkspace.styles.tokens.ts
@@ -186,7 +186,7 @@ export const WorkspaceSection = styled.section`
   display: grid;
   gap: 0.82rem;
   padding: 0.92rem;
-  border-radius: 20px;
+  border-radius: 12px;
   background: ${({ theme }) =>
     theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2};
   border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
@@ -211,9 +211,9 @@ export const SectionHeading = styled(AdminSectionHeading)`
 export const StatusBadge = styled(AdminStatusPill)`
   min-height: 34px;
   padding: 0 0.78rem;
-  border-color: ${({ theme }) => theme.colors.indigo8};
-  background: ${({ theme }) => theme.colors.indigo3};
-  color: ${({ theme }) => theme.colors.indigo11};
+  border-color: #6d6040;
+  background: #2d291a;
+  color: #d0b46c;
 
   &[data-tone="success"] {
     border-color: ${({ theme }) => theme.colors.statusSuccessBorder};
@@ -407,4 +407,3 @@ export const MetricCard = styled.div`
     overflow-wrap: anywhere;
   }
 `
-

--- a/front/src/routes/Admin/AdminToolsWorkspace.styles.tokens.ts
+++ b/front/src/routes/Admin/AdminToolsWorkspace.styles.tokens.ts
@@ -11,7 +11,11 @@ import {
   AdminWorkspaceHero,
   adminInteractiveFocusRing,
 } from "src/routes/Admin/AdminSurfacePrimitives"
-
+import {
+  adminWarningBadgeBorder,
+  adminWarningBadgeSurface,
+  adminWarningBadgeText,
+} from "src/routes/Admin/adminColorTokens"
 
 export const Main = styled.main`
   max-width: 1440px;
@@ -211,9 +215,9 @@ export const SectionHeading = styled(AdminSectionHeading)`
 export const StatusBadge = styled(AdminStatusPill)`
   min-height: 34px;
   padding: 0 0.78rem;
-  border-color: #6d6040;
-  background: #2d291a;
-  color: #d0b46c;
+  border-color: ${adminWarningBadgeBorder()};
+  background: ${adminWarningBadgeSurface()};
+  color: ${adminWarningBadgeText()};
 
   &[data-tone="success"] {
     border-color: ${({ theme }) => theme.colors.statusSuccessBorder};

--- a/front/src/routes/Admin/AdminUtilityBar.tsx
+++ b/front/src/routes/Admin/AdminUtilityBar.tsx
@@ -24,6 +24,15 @@ type ShortcutItem = {
   icon: IconName
 }
 
+const adminTextPrimary = "#f3f1ea"
+const adminTextSecondary = "#c8c1ae"
+const adminTextMuted = "#918b7d"
+const adminBorder = "#34322d"
+const adminBorderStrong = "#6d6040"
+const adminSurfaceRaised = "#20211f"
+const adminSurfaceAccent = "#2d291a"
+const adminGold = "#d0b46c"
+
 const normalize = (value: string) => value.trim().toLowerCase()
 
 const matchesShortcut = (item: ShortcutItem, query: string) => {
@@ -138,15 +147,11 @@ const UtilityBar = styled.header`
   justify-content: space-between;
   gap: 0.72rem;
   padding: 0.72rem 0.85rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray4};
-  border-radius: 20px;
+  border: 1px solid ${adminBorder};
+  border-radius: 14px;
   backdrop-filter: blur(18px);
-  background: ${({ theme }) =>
-    theme.scheme === "light" ? "rgba(255, 255, 255, 0.78)" : "rgba(18, 18, 18, 0.76)"};
-  box-shadow: ${({ theme }) =>
-    theme.scheme === "light"
-      ? "0 10px 24px rgba(15, 23, 42, 0.05)"
-      : "0 12px 28px rgba(0, 0, 0, 0.18)"};
+  background: rgba(23, 24, 23, 0.82);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
 
   @media (max-width: 720px) {
     top: calc(var(--app-header-height, 73px) + 0.65rem);
@@ -154,7 +159,7 @@ const UtilityBar = styled.header`
     align-items: center;
     gap: 0.48rem;
     padding: 0.58rem 0.64rem;
-    border-radius: 18px;
+    border-radius: 14px;
 
     &[data-search-open="true"] {
       margin-bottom: 3.15rem;
@@ -189,20 +194,19 @@ const CompactNav = styled.nav`
 const CompactNavLink = styled.a`
   width: 2.75rem;
   height: 2.75rem;
-  border-radius: 15px;
+  border-radius: 10px;
   display: grid;
   place-items: center;
   flex-shrink: 0;
   border: 1px solid transparent;
-  background: ${({ theme }) =>
-    theme.scheme === "light" ? "rgba(243, 246, 250, 0.92)" : "rgba(31, 31, 31, 0.92)"};
-  color: ${({ theme }) => theme.colors.gray11};
+  background: ${adminSurfaceRaised};
+  color: ${adminTextSecondary};
   text-decoration: none;
 
   &[data-active="true"] {
-    border-color: ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray1};
-    color: ${({ theme }) => theme.colors.gray12};
+    border-color: ${adminBorderStrong};
+    background: ${adminSurfaceAccent};
+    color: ${adminGold};
   }
 `
 
@@ -232,7 +236,7 @@ const SearchField = styled.div`
   .searchIcon {
     position: absolute;
     left: 0.9rem;
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -253,22 +257,21 @@ const SearchInput = styled.input`
   min-width: 0;
   height: 2.75rem;
   padding: 0 0.92rem 0 2.55rem;
-  border: 1px solid ${({ theme }) => theme.colors.gray4};
+  border: 1px solid ${adminBorder};
   border-radius: 999px;
-  background: ${({ theme }) =>
-    theme.scheme === "light" ? "rgba(243, 246, 250, 0.82)" : "rgba(24, 24, 24, 0.82)"};
-  color: ${({ theme }) => theme.colors.gray12};
+  background: rgba(32, 33, 31, 0.82);
+  color: ${adminTextPrimary};
   font-size: 0.88rem;
   font-weight: 600;
 
   &::placeholder {
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
   }
 
   &:focus {
     outline: none;
-    border-color: ${({ theme }) => theme.colors.gray6};
-    box-shadow: 0 0 0 4px rgba(148, 163, 184, 0.16);
+    border-color: ${adminBorderStrong};
+    box-shadow: 0 0 0 4px rgba(208, 180, 108, 0.14);
   }
 `
 
@@ -290,25 +293,24 @@ const SearchToggleButton = styled.button`
   @media (max-width: 720px) {
     width: 2.75rem;
     height: 2.75rem;
-    border: 1px solid ${({ theme }) => theme.colors.gray4};
-    border-radius: 15px;
+    border: 1px solid ${adminBorder};
+    border-radius: 10px;
     display: grid;
     place-items: center;
     flex-shrink: 0;
-    background: ${({ theme }) =>
-      theme.scheme === "light" ? "rgba(243, 246, 250, 0.92)" : "rgba(31, 31, 31, 0.92)"};
-    color: ${({ theme }) => theme.colors.gray11};
+    background: ${adminSurfaceRaised};
+    color: ${adminTextSecondary};
     cursor: pointer;
 
     &[aria-expanded="true"] {
-      border-color: ${({ theme }) => theme.colors.gray6};
-      background: ${({ theme }) => theme.colors.gray1};
-      color: ${({ theme }) => theme.colors.gray12};
+      border-color: ${adminBorderStrong};
+      background: ${adminSurfaceAccent};
+      color: ${adminGold};
     }
 
     &:focus-visible {
       outline: none;
-      box-shadow: 0 0 0 4px rgba(148, 163, 184, 0.16);
+      box-shadow: 0 0 0 4px rgba(208, 180, 108, 0.14);
     }
   }
 `
@@ -322,18 +324,18 @@ const CurrentViewChip = styled.div`
   border-radius: 999px;
   border: none;
   background: transparent;
-  color: ${({ theme }) => theme.colors.gray10};
+  color: ${adminTextMuted};
   text-decoration: none;
 
   span {
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     font-size: 0.7rem;
     font-weight: 700;
     white-space: nowrap;
   }
 
   strong {
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${adminTextMuted};
     font-size: 0.78rem;
     font-weight: 740;
     white-space: nowrap;

--- a/front/src/routes/Admin/AdminUtilityBar.tsx
+++ b/front/src/routes/Admin/AdminUtilityBar.tsx
@@ -4,6 +4,17 @@ import { useRouter } from "next/router"
 import { type FormEvent, type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react"
 import AppIcon, { type IconName } from "src/components/icons/AppIcon"
 import { pushRoute } from "src/libs/router"
+import {
+  adminBorder,
+  adminBorderStrong,
+  adminFocusRing,
+  adminGold,
+  adminSurfaceAccent,
+  adminSurfaceRaised,
+  adminTextMuted,
+  adminTextPrimary,
+  adminTextSecondary,
+} from "src/routes/Admin/adminColorTokens"
 
 type UtilityNavItem = {
   key: string
@@ -23,15 +34,6 @@ type ShortcutItem = {
   label: string
   icon: IconName
 }
-
-const adminTextPrimary = "#f3f1ea"
-const adminTextSecondary = "#c8c1ae"
-const adminTextMuted = "#918b7d"
-const adminBorder = "#34322d"
-const adminBorderStrong = "#6d6040"
-const adminSurfaceRaised = "#20211f"
-const adminSurfaceAccent = "#2d291a"
-const adminGold = "#d0b46c"
 
 const normalize = (value: string) => value.trim().toLowerCase()
 
@@ -271,7 +273,7 @@ const SearchInput = styled.input`
   &:focus {
     outline: none;
     border-color: ${adminBorderStrong};
-    box-shadow: 0 0 0 4px rgba(208, 180, 108, 0.14);
+    box-shadow: ${({ theme }) => adminFocusRing(theme, 4)};
   }
 `
 
@@ -310,7 +312,7 @@ const SearchToggleButton = styled.button`
 
     &:focus-visible {
       outline: none;
-      box-shadow: 0 0 0 4px rgba(208, 180, 108, 0.14);
+      box-shadow: ${({ theme }) => adminFocusRing(theme, 4)};
     }
   }
 `

--- a/front/src/routes/Admin/adminColorTokens.ts
+++ b/front/src/routes/Admin/adminColorTokens.ts
@@ -1,0 +1,83 @@
+import type { Theme } from "@emotion/react"
+
+export const adminTextPrimary = "#f3f1ea"
+export const adminTextSecondary = "#c8c1ae"
+export const adminTextMuted = "#918b7d"
+export const adminBorder = "#34322d"
+export const adminBorderStrong = "#6d6040"
+export const adminSurface = "#171817"
+export const adminShellSurface = "#151614"
+export const adminSurfaceRaised = "#20211f"
+export const adminSurfaceMuted = "#242520"
+export const adminSurfaceAccent = "#2d291a"
+export const adminElevatedSurfaceTop = "#1b1c1a"
+export const adminElevatedBorderDark = "#30322e"
+export const adminGold = "#d0b46c"
+export const adminTeal = "#3f8f86"
+export const adminTealHover = "#347b73"
+export const adminControlText = "#f8fffc"
+export const adminTealBorder = "rgba(63, 143, 134, 0.58)"
+export const adminTealBorderHover = "rgba(63, 143, 134, 0.72)"
+export const adminGoldTintSubtle = "rgba(208, 180, 108, 0.14)"
+export const adminGoldTintFocus = "rgba(208, 180, 108, 0.18)"
+export const adminGoldTintFocusStrong = "rgba(208, 180, 108, 0.24)"
+export const adminGoldTintLine = "rgba(208, 180, 108, 0.2)"
+export const adminActionGroupDarkSurface = "rgba(24, 24, 24, 0.86)"
+export const adminActionGroupLightSurface = "rgba(255, 255, 255, 0.82)"
+
+export const usesDarkAdminSurface = (theme: Theme) => theme.blogDesign === "grid" || theme.scheme !== "light"
+
+export const adminPrimaryText = (theme: Theme) =>
+  usesDarkAdminSurface(theme) ? adminTextPrimary : theme.colors.gray12
+
+export const adminSecondaryText = (theme: Theme) =>
+  usesDarkAdminSurface(theme) ? adminTextSecondary : theme.colors.gray11
+
+export const adminMutedText = (theme: Theme) =>
+  usesDarkAdminSurface(theme) ? adminTextMuted : theme.colors.gray10
+
+export const adminCardBorder = (theme: Theme) =>
+  theme.blogDesign === "grid"
+    ? theme.publicDesign.border
+    : usesDarkAdminSurface(theme)
+      ? adminBorder
+      : theme.colors.gray5
+
+export const adminStrongBorder = (theme: Theme) =>
+  usesDarkAdminSurface(theme) ? adminBorderStrong : theme.colors.gray7
+
+export const adminPlainSurface = (theme: Theme) =>
+  theme.blogDesign === "grid"
+    ? theme.publicDesign.operationSurface
+    : usesDarkAdminSurface(theme)
+      ? adminSurface
+      : theme.colors.gray1
+
+export const adminRaisedSurface = (theme: Theme) =>
+  theme.blogDesign === "grid"
+    ? theme.publicDesign.operationSurfaceElevated
+    : usesDarkAdminSurface(theme)
+      ? adminSurfaceRaised
+      : theme.colors.gray2
+
+export const adminMutedSurface = (theme: Theme) =>
+  usesDarkAdminSurface(theme) ? adminSurfaceMuted : theme.colors.gray3
+
+export const adminAccentSurface = (theme: Theme) =>
+  usesDarkAdminSurface(theme) ? adminSurfaceAccent : theme.colors.accentSurfaceSubtle
+
+export const adminWarningBadgeBorder = () => adminBorderStrong
+export const adminWarningBadgeSurface = () => adminSurfaceAccent
+export const adminWarningBadgeText = () => adminGold
+
+export const adminFocusRing = (theme: Theme, width = 3) =>
+  theme.scheme === "light"
+    ? `0 0 0 ${width}px ${adminGoldTintFocus}`
+    : `0 0 0 ${width}px ${adminGoldTintFocusStrong}`
+
+export const adminActionGroupSurface = (theme: Theme) =>
+  theme.blogDesign === "grid"
+    ? theme.publicDesign.operationSurfaceElevated
+    : theme.scheme === "light"
+      ? adminActionGroupLightSurface
+      : adminActionGroupDarkSurface


### PR DESCRIPTION
## 관련 이슈

close #672

## 작업 배경

- 관리자 클라우드를 MYBOX형 파일 관리자 구조로 재설계하고 AquilaLog near-black/gold/teal 운영 콘솔 톤으로 변형했습니다.
- 다중 업로드 큐, 업로드 취소, 완료 후 목록 유지, 문서/사진/동영상 미리보기와 owner-only 문구를 같은 화면에서 관리하도록 정리했습니다.
- `/admin`, `/admin/dashboard`, `/admin/posts`, `/admin/profile`, `/admin/tools`, `/admin/cloud`가 같은 admin shell/sidebar/utility/surface 언어를 공유하도록 맞췄습니다.

## 작업 내용

- `/admin/cloud`를 중앙 파일 테이블, 상단 작업 바, 우측 상세 패널, 업로드 큐 기반으로 재구성했습니다.
- 파일 input에 `multiple`을 적용하고 큐 상태(`대기`, `업로드 중`, `완료`, `실패`, `취소됨`)와 개별 취소를 추가했습니다.
- 서버 refetch가 늦어도 업로드 완료 파일이 목록에서 사라지지 않도록 optimistic merge를 적용했습니다.
- admin sidebar, utility bar, 공통 card/button/panel surface를 MYBOX형 정보 밀도와 AquilaLog 색감에 맞게 정리했습니다.
- admin cloud e2e를 한글 display name으로 보강해 다중 업로드, 취소, preview, 삭제, 빈 상태 회귀를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `env PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-cloud.spec.ts --workers=1` 2회 연속 통과
  - `env PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/mobile-layout.spec.ts --workers=1` 2회 연속 통과
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`
  - Browser visual QA: `/admin/cloud`, `/admin`, `/admin/dashboard`, `/admin/posts`, `/admin/profile`, `/admin/tools`
  - Codex Security diff scan: reportable findings 0건
    - Markdown: `/tmp/codex-security-scans/aquila-blog/localpatch_20260613_admin_cloud_mybox/report.md`
    - HTML: `/tmp/codex-security-scans/aquila-blog/localpatch_20260613_admin_cloud_mybox/report.html`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: admin UI 구조 변경 폭이 커서 일부 좁은 viewport에서 정보 밀도나 텍스트 줄바꿈이 어색할 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋 `b29231bc`를 revert하면 기존 admin cloud/admin surface로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
