### PR TITLE
[Fix] editor 507 bottom selection owner

### DIFF
--- a/front/e2e/editor-authoring-route-real-507-lower-gate.spec.ts
+++ b/front/e2e/editor-authoring-route-real-507-lower-gate.spec.ts
@@ -1,6 +1,7 @@
 import { test } from "./helpers/authoringPlaywright"
 import {
   expectPost507CodeGateSatisfied,
+  expectPost507FinalReferenceTextSelectionStable,
   expectPost507LowerGateTelemetryStable,
   installPost507InteractionTelemetry,
   mockEditorRouteWithPost507,
@@ -22,8 +23,9 @@ test.describe("editor authoring route post 507 lower real workflow gate", () => 
 
     await installPost507InteractionTelemetry(page)
 
-    // cell text drag -> code block internal Cmd/Ctrl+A -> row axis selection -> column axis selection -> lower body text selection -> lower body block drag
+    // cell text drag -> code block internal Cmd/Ctrl+A -> row axis selection -> column axis selection -> lower body text selection -> lower body block drag -> final reference text selection
     await runPost507LowerRealWorkflowGate(page, { editor, finalTable })
+    await expectPost507FinalReferenceTextSelectionStable(page, editor)
     await expectPost507LowerGateTelemetryStable(page, "post-507-lower-real-workflow")
     await expectPost507CodeGateSatisfied(page, modifyCapture)
   })

--- a/front/e2e/helpers/post507Fixtures.ts
+++ b/front/e2e/helpers/post507Fixtures.ts
@@ -5,6 +5,7 @@ export const POST_507_TITLE = "Stateless란 무엇인가?"
 export const POST_507_FINAL_TABLE_TARGET_CELL = "Stateless 의미"
 export const POST_507_FINAL_TABLE_END_CELL = "구현되어 있는가"
 export const POST_507_FINAL_TABLE_HEADER_CELL = "영역"
+export const POST_507_FINAL_REFERENCE_TEXT = "https://datatracker.ietf.org/doc/html/rfc7519"
 export const POST_507_FINAL_TABLE_REQUIRED_TEXTS = [
   POST_507_FINAL_TABLE_HEADER_CELL,
   "점검 항목",
@@ -126,7 +127,9 @@ export type Post507EditorDiagnosticSnapshot = {
   activePreserveOwner: string | null
   domSnapshot: {
     blockOverlayCount: number
+    blockGhostCount: number
     codeBlockCount: number
+    dropIndicatorCount: number
     editorTextSample: string
     selectedCellCount: number
     tableCount: number
@@ -219,7 +222,8 @@ export const readPost507EditorDiagnostics = async (
       "[data-testid='keyboard-block-selection-overlay']",
       "[data-testid='table-column-selection-outline']",
       "[data-testid='table-row-selection-outline']",
-      "[data-testid='block-drag-drop-indicator']",
+      "[data-testid='block-drop-indicator']",
+      "[data-testid='block-drag-ghost']",
       "[data-block-drag-ghost='true']",
       "[data-table-affordance]",
     ]
@@ -319,7 +323,9 @@ export const readPost507EditorDiagnostics = async (
         null,
       domSnapshot: {
         blockOverlayCount: document.querySelectorAll("[data-testid='keyboard-block-selection-overlay']").length,
+        blockGhostCount: document.querySelectorAll("[data-testid='block-drag-ghost'], [data-block-drag-ghost='true']").length,
         codeBlockCount: document.querySelectorAll("[data-code-block-wrapper='true'], .aq-code-shell").length,
+        dropIndicatorCount: document.querySelectorAll("[data-testid='block-drop-indicator']").length,
         editorTextSample: (editor?.textContent || "").replace(/\s+/g, " ").trim().slice(0, 240),
         selectedCellCount: document.querySelectorAll(".selectedCell").length,
         tableCount: document.querySelectorAll("table").length,
@@ -1230,6 +1236,72 @@ export const dragPost507TextRange = async (page: Page, target: Locator, label: s
   }
 }
 
+type Post507SelectionArtifactSample = {
+  blockGhostCount: number
+  blockOverlayCount: number
+  dropIndicatorCount: number
+  label: string
+  selectedCellCount: number
+}
+
+const readPost507SelectionArtifactSample = (page: Page, label: string) =>
+  page.evaluate((sampleLabel) => {
+    const countUnique = (selectors: string[]) => {
+      const elements = new Set<Element>()
+      for (const selector of selectors) {
+        document.querySelectorAll(selector).forEach((element) => elements.add(element))
+      }
+      return elements.size
+    }
+    return {
+      blockGhostCount: countUnique(["[data-testid='block-drag-ghost']", "[data-block-drag-ghost='true']"]),
+      blockOverlayCount: document.querySelectorAll("[data-testid='keyboard-block-selection-overlay']").length,
+      dropIndicatorCount: document.querySelectorAll("[data-testid='block-drop-indicator']").length,
+      label: sampleLabel,
+      selectedCellCount: document.querySelectorAll(".selectedCell").length,
+    }
+  }, label)
+
+const dragPost507TextRangeWithArtifactSamples = async (
+  page: Page,
+  target: Locator,
+  label: string,
+  text: string,
+  options: { endPaddingPx?: number } = {}
+) => {
+  const metrics = await resolvePost507TextDragMetrics(target, label, text)
+  const beforeScrollTop = await readPost507ScrollTop(page)
+  const artifactSamples: Post507SelectionArtifactSample[] = []
+  const sample = async (sampleLabel: string) => {
+    artifactSamples.push(await readPost507SelectionArtifactSample(page, `${label}:${sampleLabel}`))
+  }
+
+  await page.mouse.move(metrics.startX, metrics.y)
+  await sample("before-down")
+  await page.mouse.down()
+  await sample("after-down")
+  for (let step = 1; step <= 18; step += 1) {
+    const progress = step / 18
+    const targetEndX = metrics.endX + (options.endPaddingPx ?? 0)
+    const x = metrics.startX + (targetEndX - metrics.startX) * progress
+    await page.mouse.move(x, metrics.y)
+    if (step === 1 || step === 6 || step === 12 || step === 18) {
+      await sample(`move-${step}`)
+    }
+  }
+  await page.mouse.up()
+  await sample("after-up")
+  await page.waitForTimeout(900)
+  await sample("settled")
+
+  return {
+    afterScrollTop: await readPost507ScrollTop(page),
+    artifactSamples,
+    beforeScrollTop,
+    selectionText: await readPost507SelectionText(page),
+  }
+}
+
 const resolvePost507FinalTableRowMetrics = async (page: Page) => {
   for (let attempt = 0; attempt < 12; attempt += 1) {
     const metrics = await page.evaluate((targetCellText) => {
@@ -1754,6 +1826,84 @@ const expectPost507LowerBodyTextSelectionAfterTableAxes = async (page: Page, edi
   await expect(page.getByTestId("editor-text-bubble-toolbar")).toBeVisible({ timeout: 2_000 })
   await expect(editor.locator(".selectedCell")).toHaveCount(0)
   await expect(page.getByTestId("keyboard-block-selection-overlay")).toHaveCount(0)
+}
+
+export const expectPost507FinalReferenceTextSelectionStable = async (page: Page, editor: Locator) => {
+  const finalReference = editor.locator("li", { hasText: POST_507_FINAL_REFERENCE_TEXT }).last()
+  await expect(finalReference).toBeVisible({ timeout: 5_000 })
+  const referenceDrag = await dragPost507TextRangeWithArtifactSamples(
+    page,
+    finalReference,
+    "post 507 final reference text selection",
+    POST_507_FINAL_REFERENCE_TEXT,
+    { endPaddingPx: 24 }
+  )
+  const diagnostics = await readPost507EditorDiagnostics(page, "final-reference-text-selection")
+  const artifactLeaks = referenceDrag.artifactSamples.filter(
+    (sample) =>
+      sample.blockGhostCount > 0 ||
+      sample.blockOverlayCount > 0 ||
+      sample.dropIndicatorCount > 0 ||
+      sample.selectedCellCount > 0
+  )
+  const fallbackTail = diagnostics.interactionTelemetry.fallbackTimeline.slice(-8).filter(
+    (sample) =>
+      sample.codeFallbackCount > 0 ||
+      sample.tableFallbackCount > 0 ||
+      Boolean(sample.codeFallbackText.trim()) ||
+      Boolean(sample.tableFallbackText.trim())
+  )
+  const ownerState = await page.evaluate((targetText) => {
+    const readOwnLabel = (item: HTMLElement) =>
+      Array.from(item.childNodes)
+        .filter((node) => !(node instanceof HTMLElement && ["UL", "OL"].includes(node.tagName)))
+        .map((node) => node.textContent || "")
+        .join(" ")
+        .replace(/\s+/g, " ")
+        .trim()
+    const targetItem =
+      Array.from(document.querySelectorAll<HTMLElement>("[data-testid='block-editor-prosemirror'] li")).find(
+        (item) => readOwnLabel(item) === targetText
+      ) ?? null
+    const selection = window.getSelection()
+    const anchorElement =
+      selection?.anchorNode instanceof Element ? selection.anchorNode : selection?.anchorNode?.parentElement ?? null
+    const focusElement =
+      selection?.focusNode instanceof Element ? selection.focusNode : selection?.focusNode?.parentElement ?? null
+    return {
+      anchorInTarget: Boolean(targetItem && anchorElement && targetItem.contains(anchorElement)),
+      focusInTarget: Boolean(targetItem && focusElement && targetItem.contains(focusElement)),
+      selectionText: selection?.toString().replace(/\s+/g, " ").trim() ?? "",
+      targetFound: Boolean(targetItem),
+    }
+  }, POST_507_FINAL_REFERENCE_TEXT)
+
+  if (!referenceDrag.selectionText.includes("rfc7519")) {
+    throw new Error(
+      `post 507 final reference text selection lost: ${JSON.stringify({
+        diagnostics,
+        ownerState,
+        referenceDrag,
+      })}`
+    )
+  }
+  if (!ownerState.targetFound || !ownerState.anchorInTarget || !ownerState.focusInTarget) {
+    throw new Error(
+      `post 507 final reference caret owner escaped target item: ${JSON.stringify({
+        diagnostics,
+        ownerState,
+        referenceDrag,
+      })}`
+    )
+  }
+  expect(Math.abs(referenceDrag.afterScrollTop - referenceDrag.beforeScrollTop)).toBeLessThanOrEqual(24)
+  expect(artifactLeaks, "final reference text drag should not show block/table artifacts").toEqual([])
+  expect(fallbackTail, "final reference text drag should leave no table/code fallback markers").toEqual([])
+  expect(diagnostics.domSnapshot.dropIndicatorCount).toBe(0)
+  expect(diagnostics.domSnapshot.blockGhostCount).toBe(0)
+  expect(diagnostics.domSnapshot.blockOverlayCount).toBe(0)
+  expect(diagnostics.domSnapshot.selectedCellCount).toBe(0)
+  expect(diagnostics.selectionDebug.owner).toBe("body")
 }
 
 export const runPost507LowerRealWorkflowGate = async (

--- a/front/src/components/editor/BlockEditorEngine.editorSurfaceStyles.tsx
+++ b/front/src/components/editor/BlockEditorEngine.editorSurfaceStyles.tsx
@@ -168,6 +168,11 @@ export const EditorViewport = styled.div`
     background: rgba(59, 130, 246, 0.24);
   }
 
+  .aq-block-editor__content a {
+    user-select: text;
+    -webkit-user-drag: none;
+  }
+
   .aq-block-editor__content[data-keyboard-block-selection="true"] ::selection {
     background: transparent;
     color: inherit;

--- a/front/src/components/editor/useBlockEditorEngineBlockDragSessions.ts
+++ b/front/src/components/editor/useBlockEditorEngineBlockDragSessions.ts
@@ -277,14 +277,28 @@ export const useBlockEditorEngineBlockDragSessions = ({
     (event: ReactDragEvent<HTMLDivElement>) => {
       const listItemContext = findNestedListItemContextFromTarget(event.target)
       if (!listItemContext) return
-
+      const targetElement = event.target instanceof Element ? event.target : null
       const currentEditor = editorRef.current ?? editor
+      const selectedListItemContext = currentEditor
+        ? resolveEffectiveSelectedListItemContext(currentEditor)
+        : null
+      const dragStartsFromSelectedListItem = Boolean(
+        selectedListItemContext &&
+          isSameNestedListItemContext(selectedListItemContext, listItemContext) &&
+          listItemContext.listItemElement.getAttribute("data-block-selected") === "true"
+      )
+      const dragStartsFromHandle = Boolean(targetElement?.closest("[data-block-handle-rail='true']"))
+      if (!dragStartsFromHandle && !dragStartsFromSelectedListItem) {
+        event.preventDefault()
+        event.stopPropagation()
+        return
+      }
+
       if (currentEditor) {
-        const currentSelectedListItemContext = resolveEffectiveSelectedListItemContext(currentEditor)
         setSelectedListItemContext(listItemContext)
         if (
-          !currentSelectedListItemContext ||
-          !isSameNestedListItemContext(currentSelectedListItemContext, listItemContext)
+          !selectedListItemContext ||
+          !isSameNestedListItemContext(selectedListItemContext, listItemContext)
         ) {
           selectNestedListItemNode(currentEditor, listItemContext)
           clearNativeTextSelection()

--- a/front/src/components/editor/writerEditorPreset.ts
+++ b/front/src/components/editor/writerEditorPreset.ts
@@ -98,6 +98,9 @@ export const createWriterEditorExtensions = ({
     openOnClick: false,
     autolink: false,
     linkOnPaste: true,
+    HTMLAttributes: {
+      draggable: "false",
+    },
   }),
   InlineColorMark,
   Placeholder.configure({


### PR DESCRIPTION
## 관련 이슈

close #677

## 작업 배경

- 507 긴 본문 하단에서 table/code/list 복합 행동 이후 마지막 참고 URL 텍스트 선택이 비거나 caret/drop indicator가 다른 owner로 새는 문제를 방지합니다.
- 마지막 참고 리스트 URL 전체 drag를 실제 507 lower workflow 뒤에 검증하고, text selection 중 block/table/code artifact가 끼어들지 않도록 list item native drag handoff와 link drag 속성을 안정화했습니다.

## 작업 내용

- 507 lower E2E gate에 마지막 참고 URL native text selection, caret owner, scroll delta, stale overlay/drop/ghost/selectedCell/table-code fallback 검사를 추가했습니다.
- editor diagnostics가 실제 block drop indicator와 drag ghost를 집계하도록 보강했습니다.
- list item 내부 text/link drag가 block move drag로 승격되지 않도록 handle 또는 이미 선택된 list item에서 시작한 drag만 block drag로 처리합니다.
- editor link mark와 style에 text selection/user-drag 안정화 속성을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - yarn --cwd front playwright:preflight
  - yarn --cwd front playwright test e2e/editor-authoring-route-real-507-lower-gate.spec.ts --workers=1 (red 확인 후 patch, 이후 2회 연속 pass)
  - yarn --cwd front playwright test e2e/editor-authoring-route-real-507-lower-gate.spec.ts e2e/editor-authoring-block-selection.spec.ts e2e/editor-authoring-selection-bubble-occlusion.spec.ts --workers=1
  - yarn --cwd front test:e2e:authoring
  - yarn --cwd front build

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: list item block drag 시작 조건이 좁아져 handle이 아닌 텍스트 영역에서의 block move 오인이 줄어드는 대신, 기존에 텍스트를 끌어 block move처럼 쓰던 비표준 흐름은 동작하지 않을 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋 d239d26a를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
