### PR TITLE
[Test] editor 507 live canary 마지막 참고 선택 보강

### DIFF
--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -17,6 +17,7 @@ import {
   sleep,
   waitForApiReachability,
 } from "./helpers/liveAuth"
+import { expectPost507FinalReferenceTextSelectionStable } from "./helpers/post507Fixtures"
 
 const uiLoginId = adminEmail || adminLegacyLoginId
 const hasUiLoginCredentials = Boolean(uiLoginId && adminPassword)
@@ -994,6 +995,7 @@ test.describe("editor live visual regression", () => {
     expect(Math.abs(listTextDrag.afterScrollTop - listTextDrag.beforeScrollTop)).toBeLessThanOrEqual(24)
     await expectNoSelectionResidue(page, "live 507 list text after code select all")
 
+    await expectPost507FinalReferenceTextSelectionStable(page, editor)
     await expectFinalTableOverlayFollowsScroll(page, finalTable)
   })
 })


### PR DESCRIPTION
## 관련 이슈

close #677

## 작업 배경

- PR #684로 고친 507 하단 selection owner 회귀가 배포 live canary에서도 마지막 참고 URL까지 직접 검증되도록 보강합니다.
- 기존 live 507 canary는 table/body/code/list 흐름은 확인했지만, #677의 마지막 참고 리스트 URL selection owner helper를 직접 호출하지 않았습니다.

## 작업 내용

- 실제 /editor/507 live visual canary 마지막 단계에 expectPost507FinalReferenceTextSelectionStable 호출을 추가했습니다.
- 이 helper는 마지막 참고 URL 선택 텍스트, caret owner, scrollTop delta, block/drop indicator, selectedCell, table/code fallback marker를 함께 검사합니다.

## 검증

- 실행한 명령과 결과:
  - yarn --cwd front playwright:preflight
  - yarn --cwd front playwright test e2e/editor-live-visual.spec.ts --grep "실제 /editor/507 하단 선택과 table block overlay" --workers=1
  - yarn --cwd front playwright test e2e/editor-authoring-route-real-507-lower-gate.spec.ts --workers=1
  - yarn --cwd front test:e2e:authoring
  - yarn --cwd front build

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: live canary 시간이 약간 늘어날 수 있습니다. production 런타임 코드는 변경하지 않습니다.
- 롤백 방법: 이 PR의 test-only 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
