### PR TITLE
[Test] editor 507 live table overlay retarget 보강

### DIFF
--- a/front/e2e/editor-authoring-route-drag-cancel.spec.ts
+++ b/front/e2e/editor-authoring-route-drag-cancel.spec.ts
@@ -83,9 +83,17 @@ test.describe("editor authoring route drag cancel cleanup", () => {
     await expect(dragHandle).toBeVisible()
     const [handleBox, destinationBox] = await Promise.all([
       dragHandle.boundingBox(),
-      destinationParagraph.boundingBox(),
+      destinationParagraph.evaluate((element) => {
+        const rect = element.getBoundingClientRect()
+        return {
+          height: rect.height,
+          width: rect.width,
+          x: rect.left,
+          y: rect.top,
+        }
+      }),
     ])
-    if (!handleBox || !destinationBox) {
+    if (!handleBox || destinationBox.width <= 0 || destinationBox.height <= 0) {
       throw new Error("live 507 top-level drag cancel 좌표를 계산할 수 없습니다.")
     }
 

--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -578,6 +578,56 @@ const readFinalTableOverlayMetrics = (page: Page) =>
     }
   }, post507FinalTableTargetCell)
 
+const readFinalTableHandleMetrics = (page: Page) =>
+  page.evaluate((targetCellText) => {
+    const table =
+      Array.from(document.querySelectorAll<HTMLElement>("table")).find((candidate) =>
+        candidate.textContent?.includes(targetCellText)
+      ) ?? null
+    const block = (table?.closest(".tableWrapper") as HTMLElement | null) ?? table
+    const handle = document.querySelector<HTMLElement>("[data-testid='block-drag-handle']")
+    if (!block || !handle) return null
+
+    const blockRect = block.getBoundingClientRect()
+    const handleRect = handle.getBoundingClientRect()
+    const handleCenterX = handleRect.left + handleRect.width / 2
+    const handleCenterY = handleRect.top + handleRect.height / 2
+    const style = window.getComputedStyle(handle)
+    const handleVisible =
+      handleRect.width > 0 &&
+      handleRect.height > 0 &&
+      style.display !== "none" &&
+      style.visibility !== "hidden" &&
+      Number(style.opacity || "1") > 0
+
+    return {
+      blockBottom: blockRect.bottom,
+      blockLeft: blockRect.left,
+      blockTop: blockRect.top,
+      handleCenterX,
+      handleCenterY,
+      handleRight: handleRect.right,
+      handleVisible,
+      verticalDistanceToBlock:
+        handleCenterY < blockRect.top
+          ? blockRect.top - handleCenterY
+          : handleCenterY > blockRect.bottom
+            ? handleCenterY - blockRect.bottom
+            : 0,
+    }
+  }, post507FinalTableTargetCell)
+
+const finalTableHandleIsRetargeted = (
+  metrics: Awaited<ReturnType<typeof readFinalTableHandleMetrics>>
+) =>
+  Boolean(
+    metrics &&
+      metrics.handleVisible &&
+      metrics.verticalDistanceToBlock <= 24 &&
+      metrics.handleCenterX < metrics.blockLeft + 32 &&
+      metrics.handleRight > metrics.blockLeft - 96
+  )
+
 const expectFinalTableOverlayFollowsScroll = async (page: Page, finalTable: Locator) => {
   await finalTable.evaluate((element) => {
     element.scrollIntoView({ block: "center", inline: "nearest", behavior: "instant" })
@@ -589,6 +639,7 @@ const expectFinalTableOverlayFollowsScroll = async (page: Page, finalTable: Loca
   if (!tableBox) throw new Error("live 507 final table metrics are missing")
 
   const blockHandle = page.getByTestId("block-drag-handle")
+  let lastHandleMetrics: Awaited<ReturnType<typeof readFinalTableHandleMetrics>> = null
   for (const point of [
     { x: 24, y: 24 },
     { x: 18, y: 18 },
@@ -604,9 +655,15 @@ const expectFinalTableOverlayFollowsScroll = async (page: Page, finalTable: Loca
     )
     await page.mouse.move(currentTableBox.x + point.x, currentTableBox.y + point.y, { steps: 4 })
     await page.waitForTimeout(80)
-    if (await blockHandle.isVisible().catch(() => false)) break
+    lastHandleMetrics = await readFinalTableHandleMetrics(page)
+    if (finalTableHandleIsRetargeted(lastHandleMetrics)) break
   }
-  await expect(blockHandle).toBeVisible()
+  await expect
+    .poll(async () => {
+      lastHandleMetrics = await readFinalTableHandleMetrics(page)
+      return finalTableHandleIsRetargeted(lastHandleMetrics)
+    }, { timeout: 2_500 })
+    .toBe(true)
   await blockHandle.click()
   await expect(page.getByTestId("keyboard-block-selection-overlay")).toBeVisible()
 

--- a/front/e2e/helpers/post507Fixtures.ts
+++ b/front/e2e/helpers/post507Fixtures.ts
@@ -1110,6 +1110,11 @@ export const clearPost507SelectionState = (page: Page) =>
     })
   })
 
+const cancelPost507ScrollPreserveBeforeProgrammaticScroll = async (page: Page) => {
+  await page.mouse.wheel(0, 1)
+  await page.waitForTimeout(80)
+}
+
 const readPost507CodeGateState = (page: Page) =>
   page.evaluate((requiredTexts) => {
     const codeShells = Array.from(document.querySelectorAll<HTMLElement>(".aq-code-shell"))
@@ -1831,6 +1836,7 @@ const expectPost507LowerBodyTextSelectionAfterTableAxes = async (page: Page, edi
 export const expectPost507FinalReferenceTextSelectionStable = async (page: Page, editor: Locator) => {
   const finalReference = editor.locator("li", { hasText: POST_507_FINAL_REFERENCE_TEXT }).last()
   await expect(finalReference).toBeVisible({ timeout: 5_000 })
+  await cancelPost507ScrollPreserveBeforeProgrammaticScroll(page)
   const referenceDrag = await dragPost507TextRangeWithArtifactSamples(
     page,
     finalReference,


### PR DESCRIPTION
## 관련 이슈

close #677

## 작업 배경

- Deploy run 27466246005에서 live /editor/507 canary가 마지막 참고 URL 선택 직후 stale list handle을 다시 클릭해 final table overlay 검증을 오판한 문제를 보강합니다.
- live canary는 이제 최하단 table handle이 실제 table 위치로 retarget된 것을 확인한 뒤 block selection overlay scroll sync를 검증합니다.
- 전체 authoring 회귀 중 발견된 drag-cancel test 좌표 산출 결함도 offscreen DOM rect 기반으로 안정화했습니다.

## 작업 내용

- live visual canary에 final table handle geometry 검사를 추가해 table block handle로 재타겟된 상태만 overlay 검증 시작 조건으로 인정합니다.
- 507 drag-cancel cleanup spec에서 화면 밖 destination paragraph도 DOM rect로 좌표를 계산해 false negative를 막습니다.

## 검증

- 실행한 명령과 결과:
  - yarn --cwd front playwright:preflight
  - yarn --cwd front playwright test e2e/editor-live-visual.spec.ts --grep 실제 /editor/507 하단 선택과 table block overlay --workers=1 (local credential 없음으로 1 skipped, compile gate 확인)
  - yarn --cwd front playwright test e2e/editor-authoring-route-real-507-lower-gate.spec.ts --workers=1
  - yarn --cwd front test:e2e:authoring (첫 실행 174 passed / 1 failed: offscreen destination boundingBox null)
  - yarn --cwd front playwright test e2e/editor-authoring-route-drag-cancel.spec.ts --workers=1
  - yarn --cwd front test:e2e:authoring (재실행 175 passed)
  - yarn --cwd front build

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: live canary가 table handle geometry를 더 엄격하게 보므로 실제 handle 위치 회귀를 더 빨리 실패시킬 수 있습니다.
- 롤백 방법: 이 PR의 두 테스트 커밋을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
