### PR TITLE
[Fix] Live editor navigation abort retry

### DIFF
--- a/front/e2e/helpers/liveAuth.ts
+++ b/front/e2e/helpers/liveAuth.ts
@@ -53,7 +53,7 @@ export const hasAuthCookie = async (page: Page) => {
 
 export const isNavigationInterruptedError = (error: unknown) => {
   const message = error instanceof Error ? error.message : String(error)
-  return /interrupted by another navigation/i.test(message)
+  return /(interrupted by another navigation|net::ERR_ABORTED)/i.test(message)
 }
 
 export const waitForApiReachability = async (page: Page, apiBaseUrl: string) => {

--- a/front/e2e/live-auth-helper.spec.ts
+++ b/front/e2e/live-auth-helper.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test"
+
+import { isNavigationInterruptedError } from "./helpers/liveAuth"
+
+test.describe("live auth navigation helper", () => {
+  test("treats Playwright net ERR_ABORTED as a retriable navigation interruption", () => {
+    const error = new Error(
+      [
+        "page.goto: net::ERR_ABORTED at https://www.aquilaxk.site/editor/new",
+        "Call log:",
+        '  - navigating to "https://www.aquilaxk.site/editor/new", waiting until "load"',
+      ].join("\n")
+    )
+
+    expect(isNavigationInterruptedError(error)).toBe(true)
+  })
+
+  test("does not hide unrelated navigation failures", () => {
+    const error = new Error("page.goto: net::ERR_NAME_NOT_RESOLVED at https://www.aquilaxk.site/editor/new")
+
+    expect(isNavigationInterruptedError(error)).toBe(false)
+  })
+})


### PR DESCRIPTION
## 관련 이슈

close #687

## 작업 배경

- Deploy live e2e가 `/editor/507` canary에 도달하기 전에 `/editor/new` 재진입 중 `page.goto: net::ERR_ABORTED`로 중단되는 문제를 수정합니다.
- `net::ERR_ABORTED`를 live login/editor navigation retry 대상으로 분류하되, DNS 같은 unrelated navigation failure는 계속 숨기지 않습니다.

## 작업 내용

- `front/e2e/helpers/liveAuth.ts`의 navigation interruption classifier에 Playwright `net::ERR_ABORTED` 시그니처를 추가했습니다.
- `front/e2e/live-auth-helper.spec.ts`를 추가해 abort는 retry 대상으로, unrelated failure는 비대상으로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - RED: `yarn --cwd front playwright test e2e/live-auth-helper.spec.ts --workers=1` 실패 확인 (`Expected true, Received false`)
  - GREEN: `yarn --cwd front playwright test e2e/live-auth-helper.spec.ts --workers=1` -> 2 passed
  - `PLAYWRIGHT_BASE_URL=https://www.aquilaxk.site PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/editor-live-visual.spec.ts --grep "table affordance" --workers=1` -> 1 skipped (local live credentials 없음)
  - `yarn --cwd front test:e2e:authoring` -> 175 passed
  - `yarn --cwd front build` -> success

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: `net::ERR_ABORTED`가 실제 fatal navigation abort인 경우도 retry될 수 있지만, live login/editor route 진입 helper 내부에서만 사용되는 classifier라 영향 범위는 live e2e 재시도 로직으로 제한됩니다.
- 롤백 방법: 이 PR을 revert하면 기존 classifier 동작으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
