### PR TITLE
[Fix] editor block overlay scroll sync

### DIFF
--- a/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
+++ b/front/e2e/editor-authoring-route-live-drag-sequence.spec.ts
@@ -295,11 +295,55 @@ const readPost507FinalTableBlockOverlayMetrics = (page: Page) =>
     }
   }, POST_507_FINAL_TABLE_TARGET_CELL)
 
+const readPost507FinalTableHoverTarget = (finalTable: Locator) =>
+  finalTable.evaluate((tableElement, targetCellText) => {
+    const table = tableElement as HTMLElement
+    const block = (table.closest(".tableWrapper") as HTMLElement | null) ?? table
+
+    const targetCell =
+      Array.from(table.querySelectorAll<HTMLElement>("td, th")).find((candidate) =>
+        candidate.textContent?.includes(targetCellText)
+      ) ?? null
+    const blockRect = block.getBoundingClientRect()
+    const cellRect = targetCell?.getBoundingClientRect() ?? null
+    const clamp = (value: number, min: number, max: number) =>
+      Math.min(Math.max(value, min), max)
+    const minInteractiveY = Math.min(96, Math.max(8, window.innerHeight - 24))
+    const maxInteractiveY = Math.max(minInteractiveY, window.innerHeight - 24)
+    const visibleTop = Math.max(blockRect.top, cellRect?.top ?? blockRect.top, minInteractiveY)
+    const visibleBottom = Math.min(
+      blockRect.bottom,
+      cellRect?.bottom ?? blockRect.bottom,
+      maxInteractiveY
+    )
+    const preferredY = cellRect
+      ? cellRect.top + cellRect.height / 2
+      : blockRect.top + Math.min(Math.max(blockRect.height / 2, 16), blockRect.height - 16)
+    const hoverY =
+      visibleBottom > visibleTop
+        ? visibleTop + (visibleBottom - visibleTop) / 2
+        : clamp(preferredY, minInteractiveY, maxInteractiveY)
+    const clampX = (value: number) => clamp(value, 4, window.innerWidth - 4)
+    const contentX = blockRect.left + Math.min(Math.max(blockRect.width / 2, 12), blockRect.width - 12)
+
+    return {
+      anchor: {
+        x: clampX(contentX),
+        y: hoverY,
+      },
+      points: [24, 18, 32, -24, -36].map((offsetX) => ({
+        x: clampX(blockRect.left + offsetX),
+        y: hoverY,
+      })),
+    }
+  }, POST_507_FINAL_TABLE_TARGET_CELL)
+
 const expectPost507FinalTableBlockOverlayFollowsScroll = async (
   page: Page,
   finalTable: Locator
 ) => {
-  await finalTable.evaluate((element) => {
+  const targetCell = finalTable.locator("td, th", { hasText: POST_507_FINAL_TABLE_TARGET_CELL }).first()
+  await targetCell.evaluate((element) => {
     element.scrollIntoView({ block: "center", inline: "nearest", behavior: "instant" })
   })
   await page.waitForTimeout(160)
@@ -318,17 +362,11 @@ const expectPost507FinalTableBlockOverlayFollowsScroll = async (
   if (!tableBox) throw new Error("post 507 final table block metrics are missing")
 
   const blockHandle = page.getByTestId("block-drag-handle")
-  for (const point of [
-    { x: 24, y: 24 },
-    { x: 18, y: 18 },
-    { x: 32, y: 28 },
-    { x: -24, y: 24 },
-    { x: -36, y: 32 },
-  ]) {
-    const currentTableBox = await finalTable.boundingBox()
-    if (!currentTableBox) break
-    await page.mouse.move(currentTableBox.x + currentTableBox.width / 2, currentTableBox.y + currentTableBox.height / 2)
-    await page.mouse.move(currentTableBox.x + point.x, currentTableBox.y + point.y, { steps: 4 })
+  const hoverTarget = await readPost507FinalTableHoverTarget(finalTable)
+  if (!hoverTarget) throw new Error("post 507 final table hover target metrics are missing")
+  for (const point of hoverTarget.points) {
+    await page.mouse.move(hoverTarget.anchor.x, hoverTarget.anchor.y)
+    await page.mouse.move(point.x, point.y, { steps: 4 })
     await page.waitForTimeout(80)
     if (await blockHandle.isVisible().catch(() => false)) break
   }

--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -578,6 +578,49 @@ const readFinalTableOverlayMetrics = (page: Page) =>
     }
   }, post507FinalTableTargetCell)
 
+const readFinalTableHoverTarget = (finalTable: Locator) =>
+  finalTable.evaluate((tableElement, targetCellText) => {
+    const table = tableElement as HTMLElement
+    const block = (table.closest(".tableWrapper") as HTMLElement | null) ?? table
+
+    const targetCell =
+      Array.from(table.querySelectorAll<HTMLElement>("td, th")).find((candidate) =>
+        candidate.textContent?.includes(targetCellText)
+      ) ?? null
+    const blockRect = block.getBoundingClientRect()
+    const cellRect = targetCell?.getBoundingClientRect() ?? null
+    const clamp = (value: number, min: number, max: number) =>
+      Math.min(Math.max(value, min), max)
+    const minInteractiveY = Math.min(96, Math.max(8, window.innerHeight - 24))
+    const maxInteractiveY = Math.max(minInteractiveY, window.innerHeight - 24)
+    const visibleTop = Math.max(blockRect.top, cellRect?.top ?? blockRect.top, minInteractiveY)
+    const visibleBottom = Math.min(
+      blockRect.bottom,
+      cellRect?.bottom ?? blockRect.bottom,
+      maxInteractiveY
+    )
+    const preferredY = cellRect
+      ? cellRect.top + cellRect.height / 2
+      : blockRect.top + Math.min(Math.max(blockRect.height / 2, 16), blockRect.height - 16)
+    const hoverY =
+      visibleBottom > visibleTop
+        ? visibleTop + (visibleBottom - visibleTop) / 2
+        : clamp(preferredY, minInteractiveY, maxInteractiveY)
+    const clampX = (value: number) => clamp(value, 4, window.innerWidth - 4)
+    const contentX = blockRect.left + Math.min(Math.max(blockRect.width / 2, 12), blockRect.width - 12)
+
+    return {
+      anchor: {
+        x: clampX(contentX),
+        y: hoverY,
+      },
+      points: [24, 18, 32, -24, -36].map((offsetX) => ({
+        x: clampX(blockRect.left + offsetX),
+        y: hoverY,
+      })),
+    }
+  }, post507FinalTableTargetCell)
+
 const readFinalTableHandleMetrics = (page: Page) =>
   page.evaluate((targetCellText) => {
     const table =
@@ -629,7 +672,8 @@ const finalTableHandleIsRetargeted = (
   )
 
 const expectFinalTableOverlayFollowsScroll = async (page: Page, finalTable: Locator) => {
-  await finalTable.evaluate((element) => {
+  const targetCell = finalTable.locator("td, th", { hasText: post507FinalTableTargetCell }).first()
+  await targetCell.evaluate((element) => {
     element.scrollIntoView({ block: "center", inline: "nearest", behavior: "instant" })
   })
   await page.waitForTimeout(160)
@@ -640,20 +684,11 @@ const expectFinalTableOverlayFollowsScroll = async (page: Page, finalTable: Loca
 
   const blockHandle = page.getByTestId("block-drag-handle")
   let lastHandleMetrics: Awaited<ReturnType<typeof readFinalTableHandleMetrics>> = null
-  for (const point of [
-    { x: 24, y: 24 },
-    { x: 18, y: 18 },
-    { x: 32, y: 28 },
-    { x: -24, y: 24 },
-    { x: -36, y: 32 },
-  ]) {
-    const currentTableBox = await finalTable.boundingBox()
-    if (!currentTableBox) break
-    await page.mouse.move(
-      currentTableBox.x + currentTableBox.width / 2,
-      currentTableBox.y + currentTableBox.height / 2
-    )
-    await page.mouse.move(currentTableBox.x + point.x, currentTableBox.y + point.y, { steps: 4 })
+  const hoverTarget = await readFinalTableHoverTarget(finalTable)
+  if (!hoverTarget) throw new Error("live 507 final table hover target metrics are missing")
+  for (const point of hoverTarget.points) {
+    await page.mouse.move(hoverTarget.anchor.x, hoverTarget.anchor.y)
+    await page.mouse.move(point.x, point.y, { steps: 4 })
     await page.waitForTimeout(80)
     lastHandleMetrics = await readFinalTableHandleMetrics(page)
     if (finalTableHandleIsRetargeted(lastHandleMetrics)) break


### PR DESCRIPTION
## 관련 이슈

close #678

## 작업 배경

- `/editor/507` 하단의 큰 table block overlay canary가 tall table top 기준 좌표로 hover해 final table handle을 못 찾던 문제를 수정합니다.
- final table target cell을 먼저 실제 viewport 중앙에 보이게 한 뒤, 보이는 table/cell 영역에서 hover 좌표를 계산해 block overlay scroll sync를 검증합니다.

## 작업 내용

- live `/editor/507` canary가 table top이 아니라 visible final table 영역 기준으로 block drag handle을 retarget합니다.
- local 507 복합 route spec도 같은 visible hover 계약을 사용해 false pass 위험을 줄였습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/editor-authoring-route-live-drag-sequence.spec.ts --grep "실제 507 하단 table Cmd\+A" --workers=1`
  - `PLAYWRIGHT_BASE_URL=https://www.aquilaxk.site PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/editor-live-visual.spec.ts --grep "실제 /editor/507 하단 선택과 table block overlay" --workers=1` (local credentials 부재로 1 skipped, compile gate 확인)
  - `yarn --cwd front test:e2e:authoring` (175 passed)
  - `yarn --cwd front build`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: live viewport에서 fixed header 높이가 달라져 hover safe area가 부족하면 canary가 다시 실패할 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 이전 canary 동작으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
