### PR TITLE
[Fix] editor live canary 배포 게이트 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: true
         type: boolean
+      force_editor_live_canary:
+        description: "Run the seeded /editor/507 live canary during frontend live verification."
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: homeserver-deploy-main
@@ -55,6 +60,7 @@ jobs:
       deploy_sha: ${{ steps.meta.outputs.deploy_sha }}
       backend_deploy: ${{ steps.meta.outputs.backend_deploy }}
       front_live_verify: ${{ steps.meta.outputs.front_live_verify }}
+      editor_live_canary: ${{ steps.meta.outputs.editor_live_canary }}
 
     steps:
       - name: Checkout
@@ -69,6 +75,7 @@ jobs:
           DEPLOY_SHA_INPUT: ${{ github.event.workflow_run.head_sha || github.sha }}
           FORCE_BACKEND_DEPLOY_INPUT: ${{ github.event.inputs.force_backend_deploy || 'false' }}
           FORCE_FRONT_LIVE_VERIFY_INPUT: ${{ github.event.inputs.force_front_live_verify || 'false' }}
+          FORCE_EDITOR_LIVE_CANARY_INPUT: ${{ github.event.inputs.force_editor_live_canary || 'false' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -88,9 +95,11 @@ jobs:
           IMAGE_LATEST_REF="${IMAGE_NAME}:latest"
           BACKEND_DEPLOY="false"
           FRONT_LIVE_VERIFY="false"
+          EDITOR_LIVE_CANARY="false"
           CHANGE_SOURCE="first-parent-diff"
           BACKEND_DEPLOY_PATHS_PATTERN='^(back/|deploy/homeserver/|\.github/workflows/deploy\.yml|\.github/workflows/ci\.yml|\.github/workflows/reusable-backend-quality\.yml)'
           FRONT_LIVE_VERIFY_PATHS_PATTERN='^(front/|\.github/workflows/deploy\.yml|\.github/workflows/ci\.yml|\.github/workflows/frontend-ci\.yml|\.github/workflows/reusable-frontend-verify\.yml)'
+          EDITOR_LIVE_CANARY_PATHS_PATTERN='^(front/src/components/editor/|front/src/pages/editor/|front/src/routes/Admin/(Editor|WriterEditor|QaEditor|editor)|front/e2e/editor-|front/e2e/helpers/(authoringPlaywright|post507Fixtures)\.ts)'
           CHANGED_FILES=""
           CHANGED_FILES="$(git diff --name-only "${DEPLOY_SHA}^1" "${DEPLOY_SHA}" 2>/dev/null || true)"
           if [ -z "${CHANGED_FILES}" ]; then
@@ -100,6 +109,7 @@ jobs:
           if [ -z "${CHANGED_FILES}" ]; then
             BACKEND_DEPLOY="true"
             FRONT_LIVE_VERIFY="true"
+            EDITOR_LIVE_CANARY="false"
             CHANGE_SOURCE="fail-open:no-changed-files"
           else
             if echo "${CHANGED_FILES}" | grep -Eq "${BACKEND_DEPLOY_PATHS_PATTERN}"; then
@@ -108,6 +118,9 @@ jobs:
             fi
             if echo "${CHANGED_FILES}" | grep -Eq "${FRONT_LIVE_VERIFY_PATHS_PATTERN}"; then
               FRONT_LIVE_VERIFY="true"
+            fi
+            if echo "${CHANGED_FILES}" | grep -Eq "${EDITOR_LIVE_CANARY_PATHS_PATTERN}"; then
+              EDITOR_LIVE_CANARY="true"
             fi
           fi
 
@@ -119,6 +132,11 @@ jobs:
             FRONT_LIVE_VERIFY="true"
             CHANGE_SOURCE="${CHANGE_SOURCE}+manual-force-front-live-verify"
           fi
+          if [ "${FORCE_EDITOR_LIVE_CANARY_INPUT}" = "true" ]; then
+            FRONT_LIVE_VERIFY="true"
+            EDITOR_LIVE_CANARY="true"
+            CHANGE_SOURCE="${CHANGE_SOURCE}+manual-force-editor-live-canary"
+          fi
 
           echo "deploy_target_source=${CHANGE_SOURCE}"
 
@@ -128,6 +146,7 @@ jobs:
           echo "deploy_sha=${DEPLOY_SHA}" >> "$GITHUB_OUTPUT"
           echo "backend_deploy=${BACKEND_DEPLOY}" >> "$GITHUB_OUTPUT"
           echo "front_live_verify=${FRONT_LIVE_VERIFY}" >> "$GITHUB_OUTPUT"
+          echo "editor_live_canary=${EDITOR_LIVE_CANARY}" >> "$GITHUB_OUTPUT"
 
           {
             echo "## Deploy Boundary"
@@ -143,6 +162,7 @@ jobs:
             fi
             if [ "${FRONT_LIVE_VERIFY}" = "true" ]; then
               echo "- frontend result: live frontend verification will run"
+              echo "- editor live canary: ${EDITOR_LIVE_CANARY}"
             else
               echo "- frontend result: live frontend verification skipped because frontend/backend deploy paths did not change"
             fi
@@ -935,6 +955,7 @@ jobs:
       E2E_ADMIN_USERNAME: ${{ secrets.E2E_ADMIN_USERNAME || '' }}
       E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD || '' }}
       E2E_EXPECTED_FRONT_COMMIT_SHA: ${{ needs.calculateTag.outputs.deploy_sha }}
+      E2E_LIVE_EDITOR_507_CANARY: ${{ needs.calculateTag.outputs.editor_live_canary }}
 
     steps:
       - name: Checkout
@@ -1287,7 +1308,6 @@ jobs:
         env:
           PLAYWRIGHT_LIVE_FAIL_FAST: "true"
           PLAYWRIGHT_LIVE_MULTI_BROWSER: "false"
-          E2E_LIVE_EDITOR_507_CANARY: "true"
         shell: bash
         run: |
           set -euo pipefail

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -280,6 +280,17 @@ test("required secret check does not inject multi-line HOME_SERVER_ENV into shel
   assert.match(workflow, /value="\$\{!key:-\}"/)
 })
 
+test("deploy workflow는 editor live canary를 editor 변경 또는 명시적 force로 제한한다", () => {
+  const workflow = readFileSync(workflowPath, "utf8")
+
+  assert.match(workflow, /editor_live_canary: \$\{\{ steps\.meta\.outputs\.editor_live_canary \}\}/)
+  assert.match(workflow, /EDITOR_LIVE_CANARY_PATHS_PATTERN=.*front\/src\/components\/editor\//)
+  assert.match(workflow, /EDITOR_LIVE_CANARY_PATHS_PATTERN=.*front\/src\/pages\/editor\//)
+  assert.match(workflow, /force_editor_live_canary:\s*\n/)
+  assert.match(workflow, /E2E_LIVE_EDITOR_507_CANARY: \$\{\{ needs\.calculateTag\.outputs\.editor_live_canary \}\}/)
+  assert.doesNotMatch(workflow, /E2E_LIVE_EDITOR_507_CANARY:\s*['"]?true['"]?/)
+})
+
 test("runtime contract accounts for every compose env interpolation", async () => {
   const { loadContract } = await import("../env/validate-env.mjs")
   const contractKeys = new Set(targetKeyNames(loadContract(contractPath), "home-server-runtime"))

--- a/tools/test/verify-deploy-workflow-classification.sh
+++ b/tools/test/verify-deploy-workflow-classification.sh
@@ -33,11 +33,17 @@ reject_pattern 'cancel-in-progress:[[:space:]]*true' "homeserver deploy must not
 
 require_pattern 'backend_deploy:' "workflow must expose a backend_deploy output"
 require_pattern 'front_live_verify:' "workflow must expose a front_live_verify output"
+require_pattern 'editor_live_canary:' "workflow must expose an editor_live_canary output"
 require_pattern 'git diff-tree --no-commit-id --name-only -r -m "\$\{DEPLOY_SHA\}"' "merge commit changed-file detection must use -m fallback"
 reject_pattern 'git diff-tree --no-commit-id --name-only -r "\$\{DEPLOY_SHA\}"' "single-parent diff-tree form can return empty changed files for merge commits"
 
 require_pattern 'needs\.calculateTag\.outputs\.backend_deploy' "backend jobs must be gated by backend_deploy"
 require_pattern 'needs\.calculateTag\.outputs\.front_live_verify' "frontend live verification must be gated by front_live_verify"
+require_pattern 'needs\.calculateTag\.outputs\.editor_live_canary' "editor seeded live canary must be gated by editor_live_canary"
+require_pattern 'EDITOR_LIVE_CANARY_PATHS_PATTERN=.*front/src/components/editor/' "editor canary path classification must include editor component changes"
+require_pattern 'EDITOR_LIVE_CANARY_PATHS_PATTERN=.*front/src/pages/editor/' "editor canary path classification must include editor page changes"
+require_pattern 'force_editor_live_canary:[[:space:]]*$' "workflow_dispatch must expose force_editor_live_canary input key"
+reject_pattern "E2E_LIVE_EDITOR_507_CANARY:[[:space:]]*['\"]?true['\"]?" "editor seeded live canary must not be hardcoded true"
 require_pattern 'always\(\)[[:space:]]*&&' "frontLiveE2E must handle skipped backend deploy dependencies explicitly"
 require_pattern 'create_external_backup\.sh' "homeserver deploy must create an external storage backup before rollout mutation"
 require_pattern 'prune_external_backups\.sh' "homeserver deploy must prune external backups around backup creation"


### PR DESCRIPTION
## 관련 이슈

close #692

## 작업 배경

- editor live canary 배포 게이트 분리

## 작업 내용

- editor live canary 배포 게이트 분리

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `tools/test/verify-deploy-workflow-classification.sh`
  - `node --test tools/test/env-contract.test.mjs`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - CodeRabbit/Codex CLI로 PR diff를 확인했습니다. Codex CLI는 usage limit로 완료되지 않았고, CodeRabbit CLI 재검토를 완료했습니다.

## 리스크

- 특이사항 없음

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
