### PR TITLE
[Refactor] 관리자 전체 라이트/다크 MYBOX 구조 정리

### DIFF
--- a/front/e2e/admin-hub-state.spec.ts
+++ b/front/e2e/admin-hub-state.spec.ts
@@ -32,7 +32,7 @@ test.describe("admin hub state contract", () => {
     expect(source).toContain("supportRailGroups={supportRailGroups}")
   })
 
-  test("admin hub uses backstage landing copy instead of generic management labels", () => {
+  test("관리자 허브는 범용 관리 문구 대신 경계선형 작업 구조를 사용한다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminHubSurface.tsx"), "utf8")
     const sectionSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminHubSurface.sections.tsx"), "utf8")
     const styleSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminHubSurface.styles.ts"), "utf8")
@@ -47,7 +47,9 @@ test.describe("admin hub state contract", () => {
     expect(styleSource).toContain("export const BorderlessSection = styled.section`")
     expect(styleSource).toContain("export const BorderlessPanelLink = styled.a`")
     expect(styleSource).toContain("export const BorderlessSupportSection = styled.section`")
-    expect(styleSource).toContain("border-radius: 2px;")
+    expect(styleSource).toContain("border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};")
+    expect(styleSource).toContain("border-radius: 0;")
+    expect(styleSource).not.toContain("transform: translateY")
     expect(source).toContain("priorityActions: AdminHubNextAction[]")
     expect(source).toContain("handoffActions: AdminHubNextAction[]")
     expect(source).not.toContain("새 글 작성, 최근 초안 복귀, 프로필 점검, 운영 상태 확인까지 지금 필요한 흐름만 먼저 보여줍니다.")
@@ -61,7 +63,7 @@ test.describe("admin hub state contract", () => {
     expect(source).not.toContain("requestIdleCallback")
   })
 
-  test("dashboard first fold uses main-like priority copy and explicit rail labels", () => {
+  test("대시보드 first fold는 우선순위 문구와 명시적 레일 라벨을 사용한다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminDashboardWorkspaceView.tsx"), "utf8")
     const styleSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/AdminDashboardWorkspace.styles.layout.ts"),

--- a/front/e2e/admin-surface-primitives.spec.ts
+++ b/front/e2e/admin-surface-primitives.spec.ts
@@ -3,6 +3,61 @@ import path from "node:path"
 import { expect, test } from "@playwright/test"
 
 test.describe("admin surface primitives contract", () => {
+  test("관리자 표면은 MYBOX형 화이트 우선 시스템 테마 토큰을 공유한다", () => {
+    const colorTokenSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/adminColorTokens.ts"), "utf8")
+    const shellSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminShell.tsx"), "utf8")
+    const utilitySource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminUtilityBar.tsx"), "utf8")
+    const cloudStyleSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminCloudWorkspace.styles.ts"), "utf8")
+    const cloudPageSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminCloudWorkspacePage.tsx"), "utf8")
+    const primitiveSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/AdminSurfacePrimitives.tsx"),
+      "utf8",
+    )
+    const hubStyleSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminHubSurface.styles.ts"), "utf8")
+
+    expect(colorTokenSource).toContain("export const adminSystemThemeVariables =")
+    expect(colorTokenSource).toContain("@media (prefers-color-scheme: dark)")
+    expect(colorTokenSource).toContain("--admin-primary: #b9954f;")
+    expect(colorTokenSource).toContain("--admin-primary: #d0b46c;")
+    expect(colorTokenSource).toContain('export const adminSurface = "var(--admin-surface')
+    expect(colorTokenSource).toContain('export const adminTeal = "var(--admin-primary')
+    expect(colorTokenSource).toContain('export const usesDarkAdminSurface = (theme: Theme) => theme.scheme !== "light"')
+    expect(colorTokenSource).not.toContain("#4f74ff")
+
+    expect(shellSource).toContain("${adminSystemThemeVariables}")
+    expect(shellSource).toContain("grid-template-columns: 17.5rem minmax(0, 1fr);")
+    expect(shellSource).toContain("background: ${adminAppBackground};")
+    expect(shellSource).not.toContain("border-radius: 14px;")
+
+    expect(utilitySource).toContain("border-bottom: 1px solid ${adminBorder};")
+    expect(utilitySource).not.toContain("backdrop-filter")
+    expect(utilitySource).not.toContain("border-radius: 14px;")
+
+    expect(cloudStyleSource).toContain("background: ${surface};")
+    expect(cloudStyleSource).toContain("grid-template-columns: minmax(0, 1fr) minmax(18rem, 21rem);")
+    expect(cloudPageSource).toContain('선택한 조건에 맞는 파일이 없습니다.')
+    expect(cloudPageSource).not.toContain("아직 올린 파일이 없습니다.")
+
+    expect(primitiveSource).toContain("adminPlainSurface(theme)")
+    expect(primitiveSource).not.toContain("linear-gradient")
+    expect(hubStyleSource).not.toContain("transform: translateY")
+  })
+
+  test("관리자 프로필은 대표 heading과 내부 섹션 heading 텍스트를 중복하지 않는다", () => {
+    const profileSectionSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/AdminProfileWorkspaceSections.tsx"),
+      "utf8",
+    )
+    const profileModelSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/AdminProfileWorkspaceModel.ts"),
+      "utf8",
+    )
+
+    expect(profileSectionSource).toContain("<h1>프로필</h1>")
+    expect(profileModelSource).toContain('label: "기본 정보"')
+    expect(profileModelSource).not.toContain('label: "프로필"')
+  })
+
   test("shared admin primitives own focus-visible and mobile snap contracts", () => {
     const source = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/AdminSurfacePrimitives.tsx"),

--- a/front/e2e/admin-surface-primitives.spec.ts
+++ b/front/e2e/admin-surface-primitives.spec.ts
@@ -2,10 +2,11 @@ import { readFileSync } from "node:fs"
 import path from "node:path"
 import { expect, test } from "@playwright/test"
 
-test.describe("admin surface primitives contract", () => {
+test.describe("관리자 표면 공통 계약", () => {
   test("관리자 표면은 MYBOX형 화이트 우선 시스템 테마 토큰을 공유한다", () => {
     const colorTokenSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/adminColorTokens.ts"), "utf8")
     const shellSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminShell.tsx"), "utf8")
+    const rootLayoutSource = readFileSync(path.resolve(__dirname, "../src/layouts/RootLayout/index.tsx"), "utf8")
     const utilitySource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminUtilityBar.tsx"), "utf8")
     const cloudStyleSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminCloudWorkspace.styles.ts"), "utf8")
     const cloudPageSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminCloudWorkspacePage.tsx"), "utf8")
@@ -16,16 +17,27 @@ test.describe("admin surface primitives contract", () => {
     const hubStyleSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminHubSurface.styles.ts"), "utf8")
 
     expect(colorTokenSource).toContain("export const adminSystemThemeVariables =")
-    expect(colorTokenSource).toContain("@media (prefers-color-scheme: dark)")
+    expect(colorTokenSource).toContain('theme.scheme === "dark" ? adminDarkThemeVariables : adminLightThemeVariables')
     expect(colorTokenSource).toContain("--admin-primary: #b9954f;")
     expect(colorTokenSource).toContain("--admin-primary: #d0b46c;")
+    expect(colorTokenSource).toContain("--admin-accent-text: #6f5524;")
+    expect(colorTokenSource).toContain("--admin-control-text: #101214;")
+    expect(colorTokenSource).toContain("--admin-text-muted: #566273;")
+    expect(colorTokenSource).toContain('export const adminTextMuted = "var(--admin-text-muted, #566273)"')
     expect(colorTokenSource).toContain('export const adminSurface = "var(--admin-surface')
+    expect(colorTokenSource).toContain('export const adminSurfaceAccent = "var(--admin-surface-accent, #f7f1e3)"')
+    expect(colorTokenSource).toContain('export const adminGold = "var(--admin-accent-text, #6f5524)"')
     expect(colorTokenSource).toContain('export const adminTeal = "var(--admin-primary')
     expect(colorTokenSource).toContain('export const usesDarkAdminSurface = (theme: Theme) => theme.scheme !== "light"')
     expect(colorTokenSource).not.toContain("#4f74ff")
 
-    expect(shellSource).toContain("${adminSystemThemeVariables}")
+    expect(rootLayoutSource).toContain('const isAdminRoute = pathname === "/admin" || pathname.startsWith("/admin/")')
+    expect(rootLayoutSource).toContain('const isDesignAwareRoute = !isAdminRoute && pathname[1] !== "_" && pathname !== "/sitemap.xml"')
+    expect(rootLayoutSource).toContain("const effectiveScheme = isDesignAwareRoute ? publicAppearance.scheme : scheme")
+    expect(shellSource).toContain("${({ theme }) => adminSystemThemeVariables(theme)}")
     expect(shellSource).toContain("grid-template-columns: 17.5rem minmax(0, 1fr);")
+    expect(shellSource).toContain("width: 100%;")
+    expect(shellSource).not.toContain("width: 100vw;")
     expect(shellSource).toContain("background: ${adminAppBackground};")
     expect(shellSource).not.toContain("border-radius: 14px;")
 
@@ -43,7 +55,7 @@ test.describe("admin surface primitives contract", () => {
     expect(hubStyleSource).not.toContain("transform: translateY")
   })
 
-  test("관리자 프로필은 대표 heading과 내부 섹션 heading 텍스트를 중복하지 않는다", () => {
+  test("관리자 프로필은 대표 제목과 내부 섹션 제목 텍스트를 중복하지 않는다", () => {
     const profileSectionSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/AdminProfileWorkspaceSections.tsx"),
       "utf8",
@@ -58,7 +70,7 @@ test.describe("admin surface primitives contract", () => {
     expect(profileModelSource).not.toContain('label: "프로필"')
   })
 
-  test("shared admin primitives own focus-visible and mobile snap contracts", () => {
+  test("관리자 공통 프리미티브는 포커스 표시와 모바일 스냅 계약을 가진다", () => {
     const source = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/AdminSurfacePrimitives.tsx"),
       "utf8",
@@ -77,7 +89,7 @@ test.describe("admin surface primitives contract", () => {
     expect(source).toContain("export const AdminWorkspaceHero = styled.section`")
   })
 
-  test("dashboard context rail yields priority earlier on tablet widths", () => {
+  test("대시보드 컨텍스트 레일은 태블릿 폭에서 우선 영역을 먼저 노출한다", () => {
     const workspaceSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/AdminDashboardWorkspacePage.tsx"),
       "utf8",
@@ -117,7 +129,7 @@ test.describe("admin surface primitives contract", () => {
     expect(`${layoutStyleSource}\n${priorityStyleSource}`).not.toContain("${AdminInfoLinkCard}")
   })
 
-  test("posts/tools reuse shared badge and action primitives", () => {
+  test("글 관리와 운영 도구는 공통 배지와 액션 프리미티브를 재사용한다", () => {
     const postsListSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspaceList.tsx"), "utf8")
     const postsListStyleSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspaceList.styles.ts"),
@@ -154,7 +166,7 @@ test.describe("admin surface primitives contract", () => {
     expect(`${toolsTokenStyleSource}\n${toolsLayoutStyleSource}`).not.toContain("const SectionNavButton = styled(AdminWorkspaceSectionNavButton)``")
   })
 
-  test("large admin pages move style-heavy surface definitions out of orchestration pages", () => {
+  test("큰 관리자 페이지는 스타일 정의를 오케스트레이션 페이지 밖으로 분리한다", () => {
     const profileSource = readFileSync(path.resolve(__dirname, "../src/pages/admin/profile.tsx"), "utf8")
     const profileSectionSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/AdminProfileWorkspaceSections.tsx"),
@@ -213,7 +225,7 @@ test.describe("admin surface primitives contract", () => {
     expect(dashboardSource.split("\n").length).toBeLessThan(1050)
   })
 
-  test("posts workspace splits repeated UI regions out of the orchestration page", () => {
+  test("글 관리 작업공간은 반복 UI 영역을 페이지에서 분리한다", () => {
     const postsSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspacePageView.tsx"), "utf8")
     const controllerSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspacePage.tsx"), "utf8")
     const recentWorkSource = readFileSync(
@@ -253,7 +265,7 @@ test.describe("admin surface primitives contract", () => {
     expect(feedbackSource).toContain("export const AdminPostsWorkspaceFeedbackLayer")
   })
 
-  test("remaining admin pages avoid oversized slab card radii", () => {
+  test("나머지 관리자 페이지는 과도한 카드 반경을 쓰지 않는다", () => {
     const dashboardSource = readFileSync(path.resolve(__dirname, "../src/pages/admin/dashboard.tsx"), "utf8")
     const profileSource = readFileSync(path.resolve(__dirname, "../src/pages/admin/profile.tsx"), "utf8")
     const toolsSource = readFileSync(path.resolve(__dirname, "../src/pages/admin/tools.tsx"), "utf8")
@@ -277,7 +289,7 @@ test.describe("admin surface primitives contract", () => {
     }
   })
 
-  test("tools workspace uses detail-like hero copy and ops rail labels", () => {
+  test("운영 도구 작업공간은 상세형 대표 문구와 작업 레일 라벨을 사용한다", () => {
     const toolsPageSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminToolsWorkspacePage.tsx"), "utf8")
     const toolsSectionsSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/AdminToolsWorkspaceSections.tsx"),
@@ -334,7 +346,7 @@ test.describe("admin surface primitives contract", () => {
     expect(toolsLayoutStyleSource).toContain("box-shadow: ${({ theme }) => adminInteractiveFocusRing(theme)};")
   })
 
-  test("admin utility bar keeps explicit current-view context and tablet compact nav without extra account CTA", () => {
+  test("관리자 상단 바는 현재 화면 맥락과 태블릿 축약 내비게이션만 유지한다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminUtilityBar.tsx"), "utf8")
 
     expect(source).toContain("<CurrentViewChip aria-label=\"현재 화면\">")
@@ -346,7 +358,7 @@ test.describe("admin surface primitives contract", () => {
     expect(source).not.toContain('<AppIcon name="camera" />')
   })
 
-  test("admin shell sidebar uses member profile identity before current task and nav", () => {
+  test("관리자 사이드바는 현재 작업보다 사용자 정체성을 먼저 보여준다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminShell.tsx"), "utf8")
 
     expect(source).toContain('import ProfileImage from "src/components/ProfileImage"')
@@ -367,7 +379,7 @@ test.describe("admin surface primitives contract", () => {
     expect(source).not.toContain('<AppIcon name="service" />')
   })
 
-  test("admin hub removes duplicated status and shortcut rails in favor of a single primary workflow", () => {
+  test("관리자 허브는 중복 상태와 바로가기 레일 대신 주요 작업 흐름 하나를 둔다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminHubSurface.tsx"), "utf8")
     const sectionSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminHubSurface.sections.tsx"), "utf8")
     const styleSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminHubSurface.styles.ts"), "utf8")
@@ -385,7 +397,7 @@ test.describe("admin surface primitives contract", () => {
     expect(styleSource).not.toContain("border-radius: 24px;")
   })
 
-  test("shared admin landing primitives expose a dedicated lead sentence style", () => {
+  test("공통 관리자 랜딩 프리미티브는 전용 리드 문장 스타일을 제공한다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminSurfacePrimitives.tsx"), "utf8")
 
     expect(source).toContain("export const AdminLandingSectionLead = styled.p`")

--- a/front/e2e/mobile-layout-admin.spec.ts
+++ b/front/e2e/mobile-layout-admin.spec.ts
@@ -17,8 +17,8 @@ test.beforeEach(async ({ page }) => {
   await mockAnonymousSession(page)
 })
 
-test.describe("mobile layout admin", () => {
-  test("모바일 어드민 유틸리티는 검색을 접어 first fold를 보존한다", async ({ page }) => {
+test.describe("모바일 관리자 레이아웃", () => {
+  test("모바일 어드민 유틸리티는 검색을 접어 첫 화면을 보존한다", async ({ page }) => {
   await page.goto("/admin/tools")
 
   await expect(page.getByRole("heading", { name: "운영 도구" })).toBeVisible()
@@ -57,7 +57,7 @@ test.describe("mobile layout admin", () => {
   await expect(page).toHaveURL(/\/admin\/posts(?:$|\?)/)
 })
 
-  test("어드민 글 목록 first fold는 목록 본문을 보조 패널보다 먼저 노출한다", async ({ page }) => {
+  test("어드민 글 목록 첫 화면은 목록 본문을 보조 패널보다 먼저 노출한다", async ({ page }) => {
   await mockAdminPostsWorkspaceEndpoints(page)
 
   await page.goto("/admin/posts")

--- a/front/e2e/mobile-layout.spec.ts
+++ b/front/e2e/mobile-layout.spec.ts
@@ -4,8 +4,8 @@ import { expect, test } from "@playwright/test"
 
 const readSourceFile = (sourcePath: string) => readFileSync(path.resolve(__dirname, "..", sourcePath), "utf8")
 
-test.describe("mobile layout source boundaries", () => {
-  test("grid design은 전 사용자-facing 화면 토큰을 사용하고 article typography를 변경하지 않는다", () => {
+test.describe("모바일 레이아웃 소스 경계", () => {
+  test("그리드 디자인은 공개 화면 토큰과 관리자 MYBOX 토큰을 분리하고 본문 타이포그래피를 변경하지 않는다", () => {
   const publicSurfaceSources = [
     "src/layouts/RootLayout/Header/index.tsx",
     "src/layouts/RootLayout/Header/Logo.tsx",
@@ -28,6 +28,7 @@ test.describe("mobile layout source boundaries", () => {
     readSourceFile("src/routes/Detail/PostDetail/PostHeader.styles.ts"),
   ].join("\n")
   const rootLayoutSource = readSourceFile("src/layouts/RootLayout/index.tsx")
+  const adminColorTokenSource = readSourceFile("src/routes/Admin/adminColorTokens.ts")
   const adminSurfaceSource = readSourceFile("src/routes/Admin/AdminSurfacePrimitives.tsx")
   const adminShellSource = readSourceFile("src/routes/Admin/AdminShell.tsx")
   const adminToolsSource = [
@@ -61,15 +62,22 @@ test.describe("mobile layout source boundaries", () => {
   expect(themeSource).toContain("readableSurface")
   expect(themeSource).toContain("operationSurface")
   expect(themeSource).toContain("operationSurfaceElevated")
-  expect(rootLayoutSource).toContain("isDesignAwareRoute")
-  expect(rootLayoutSource).toContain('pathname[1] !== "_"')
+  expect(rootLayoutSource).toContain('const isDesignAwareRoute = !isAdminRoute && pathname[1] !== "_" && pathname !== "/sitemap.xml"')
   expect(rootLayoutSource).toContain('effectiveBlogDesign === "legacy" && !isPublicBlogRoute')
+  expect(rootLayoutSource).toContain('const isAdminRoute = pathname === "/admin" || pathname.startsWith("/admin/")')
+  expect(rootLayoutSource).toContain("const isFullBleedRoute = isDedicatedEditorRoute || isAdminRoute")
+  expect(rootLayoutSource).toContain("<StyledMain $fullBleed={isFullBleedRoute}>")
   expect(rootLayoutSource).toContain("resolvePublicBlogAppearance(isDesignAwareRoute ? adminProfile : null)")
-  expect(adminSurfaceSource).toContain("theme.publicDesign.operationSurface")
-  expect(adminSurfaceSource).toContain("theme.publicDesign.operationSurfaceElevated")
-  expect(adminShellSource).toContain("theme.publicDesign.operationSurface")
-  expect(adminToolsSource).toContain("theme.publicDesign.operationSurface")
-  expect(adminDashboardSource).toContain("theme.publicDesign.operationSurface")
+  expect(adminColorTokenSource).toContain("export const adminSystemThemeVariables = (theme: Theme) =>")
+  expect(adminColorTokenSource).toContain('theme.scheme === "dark" ? adminDarkThemeVariables : adminLightThemeVariables')
+  expect(adminColorTokenSource).toContain("--admin-app-bg: #ffffff;")
+  expect(adminColorTokenSource).toContain("--admin-app-bg: #121212;")
+  expect(adminSurfaceSource).toContain("adminPlainSurface(theme)")
+  expect(adminShellSource).toContain("adminSystemThemeVariables(theme)")
+  expect(adminShellSource).toContain("background: ${adminAppBackground};")
+  expect(adminToolsSource).toContain("adminSurface")
+  expect(adminToolsSource).toContain("adminSurfaceRaised")
+  expect(adminDashboardSource).toContain("adminSurface")
   expect(authShellSource).toContain("theme.publicDesign.readableSurface")
   expect(errorSource).toContain("theme.publicDesign.readableSurface")
   expect(editorComposeSource).toContain("theme.publicDesign.readableSurface")

--- a/front/e2e/perf-layout.spec.ts
+++ b/front/e2e/perf-layout.spec.ts
@@ -16,8 +16,8 @@ import {
   waitForHomeTagRailReady,
 } from "./helpers/perfFixtures"
 
-test.describe("perf layout and surface budgets", () => {
-  test("메인 레이아웃은 velog형 width tier(1728/1376/1024/100%)를 유지한다", async ({ page }) => {
+test.describe("성능 레이아웃과 표면 예산", () => {
+  test("메인 레이아웃은 velog형 폭 단계(1728/1376/1024/100%)를 유지한다", async ({ page }) => {
   await mockFeedEndpoints(page)
 
   await page.setViewportSize({ width: 2000, height: 900 })
@@ -64,7 +64,7 @@ test.describe("perf layout and surface budgets", () => {
   await expect(page.locator(".rt")).toBeHidden()
 })
 
-  test("피드 카드 hover lift는 content-visibility clipping 없이 상단을 그릴 수 있다", async ({ page }) => {
+  test("피드 카드 호버 상승은 콘텐츠 표시 잘림 없이 상단을 그릴 수 있다", async ({ page }) => {
   await mockFeedEndpoints(page)
   await page.setViewportSize({ width: 1440, height: 900 })
   await gotoForPerf(page, "/")
@@ -147,7 +147,7 @@ test.describe("perf layout and surface budgets", () => {
   expect(firstCardLeft).toBeGreaterThanOrEqual(railRight + 8)
 })
 
-  test("상세 좌/우 레일 sticky는 스크롤 전후 좌표를 안정적으로 유지한다", async ({ page }) => {
+  test("상세 좌/우 고정 레일은 스크롤 전후 좌표를 안정적으로 유지한다", async ({ page }) => {
   const postId = 991
   await mockFeedEndpoints(page)
   await mockDetailRailEndpoint(page, postId)
@@ -181,7 +181,7 @@ test.describe("perf layout and surface budgets", () => {
   expect(Math.abs((midSnapshot.rightRail?.left ?? 0) - (deepSnapshot.rightRail?.left ?? 0))).toBeLessThanOrEqual(2)
 })
 
-  test("핵심 화면 레이아웃 스냅샷(desktop/iPhone15/iPad mini)을 유지한다", async ({ page }) => {
+  test("핵심 화면 레이아웃 스냅샷(데스크톱/iPhone15/iPad mini)을 유지한다", async ({ page }) => {
   await mockFeedEndpoints(page)
   await mockDetailRailEndpoint(page, 991)
   await mockAdminMonitoringEndpoints(page)
@@ -394,14 +394,15 @@ test.describe("perf layout and surface budgets", () => {
       const htmlScrollWidth = snapshot.scrollWidth?.html ?? 0
       const bodyScrollWidth = snapshot.scrollWidth?.body ?? 0
 
-      // 헤드리스/스크롤바 폭 편차로 iPad mini 768 환경에서 2~3px 오차가 발생할 수 있다.
-      expect(serviceRailWidth).toBeGreaterThanOrEqual(716)
+      // MYBOX형 관리자 first fold는 iPad mini 768 환경에서 우선 점검 영역을 350px 전후로 당긴다.
+      // 관리자 route는 full-bleed 작업 공간이므로 콘텐츠 폭은 742px 안팎으로 고정한다.
+      expect(serviceRailWidth).toBeGreaterThanOrEqual(738)
       expect(serviceRailWidth).toBeLessThanOrEqual(744)
-      expect(prioritySectionY).toBeGreaterThanOrEqual(360)
-      expect(prioritySectionY).toBeLessThanOrEqual(470)
-      expect(panelGridWidth).toBeGreaterThanOrEqual(716)
+      expect(prioritySectionY).toBeGreaterThanOrEqual(340)
+      expect(prioritySectionY).toBeLessThanOrEqual(370)
+      expect(panelGridWidth).toBeGreaterThanOrEqual(738)
       expect(panelGridWidth).toBeLessThanOrEqual(744)
-      expect(firstPanelWidth).toBeGreaterThanOrEqual(716)
+      expect(firstPanelWidth).toBeGreaterThanOrEqual(738)
       expect(firstPanelWidth).toBeLessThanOrEqual(744)
       expect(firstPanelY).toBeGreaterThanOrEqual(prioritySectionBottom)
       expect(firstPanelY).toBeLessThanOrEqual(650)
@@ -414,7 +415,7 @@ test.describe("perf layout and surface budgets", () => {
   }
 })
 
-  test("public/auth 핵심 화면은 adminProfile grid 서피스 계층을 유지한다", async ({ page }) => {
+  test("공개와 인증 핵심 화면은 관리자 프로필 그리드 표면 계층을 유지한다", async ({ page }) => {
   test.setTimeout(60_000)
   await mockFeedEndpoints(page, {
     adminProfile: {

--- a/front/src/layouts/RootLayout/index.tsx
+++ b/front/src/layouts/RootLayout/index.tsx
@@ -77,7 +77,9 @@ const RootLayout = ({
   const { events, pathname } = useRouter()
   const isPublicBlogRoute = pathname === "/" || pathname === "/about" || pathname === "/posts/[id]"
   const isDedicatedEditorRoute = pathname === "/editor/[id]" || pathname === "/editor/new"
-  const isDesignAwareRoute = pathname[1] !== "_" && pathname !== "/sitemap.xml"
+  const isAdminRoute = pathname === "/admin" || pathname.startsWith("/admin/")
+  const isFullBleedRoute = isDedicatedEditorRoute || isAdminRoute
+  const isDesignAwareRoute = !isAdminRoute && pathname[1] !== "_" && pathname !== "/sitemap.xml"
   const adminProfile = usePublicAdminProfile(initialAdminProfile, {
     enabled: isDesignAwareRoute || initialAdminProfileShouldRefetch,
     refetchOnMount: isDesignAwareRoute,
@@ -190,7 +192,7 @@ const RootLayout = ({
       {/* {metaConfig.type !== "Paper" && <Header />} */}
       <Header fullWidth={false} showThemeToggle={effectiveBlogDesign === "legacy" && !isPublicBlogRoute} blogTitle={headerBlogTitle} />
       <RouteProgress data-busy={isNavigating} aria-hidden="true" />
-      <StyledMain $fullBleed={isDedicatedEditorRoute}>{children}</StyledMain>
+      <StyledMain $fullBleed={isFullBleedRoute}>{children}</StyledMain>
     </ThemeProvider>
   )
 }

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -753,8 +753,8 @@ export const StatusPill = styled.span`
   }
 
   &[data-status="cancelled"] {
-    background: ${surfaceMuted};
-    color: ${textMuted};
+    background: ${({ theme }) => theme.colors.gray3};
+    color: ${({ theme }) => theme.colors.gray10};
   }
 
   &[data-status="done"] {

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -1,7 +1,9 @@
 import styled from "@emotion/styled"
 import {
+  adminAppBackground as appBackground,
   adminBorder as border,
   adminBorderStrong as borderStrong,
+  adminControlText as controlText,
   adminGold as accentGold,
   adminSurface as surface,
   adminSurfaceAccent as surfaceAccent,
@@ -17,7 +19,7 @@ export const CloudMain = styled.main`
   display: grid;
   min-width: 0;
   color: ${textPrimary};
-  background: ${surface};
+  background: ${appBackground};
   border: 0;
   border-radius: 0;
   overflow: hidden;
@@ -27,7 +29,7 @@ export const CloudMain = styled.main`
 export const CloudWorkspace = styled.section`
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(18rem, 21rem);
-  min-height: calc(100vh - var(--app-header-height, 73px) - 3.2rem);
+  min-height: calc(100vh - var(--app-header-height, 73px) - 3.95rem);
 
   @media (max-width: 1260px) {
     grid-template-columns: minmax(0, 1fr) minmax(17rem, 19rem);
@@ -45,7 +47,7 @@ export const CloudNavigationRail = styled.aside`
   min-width: 0;
   padding: 1.25rem 1rem;
   border-right: 1px solid ${border};
-  background: #141514;
+  background: ${surfaceRaised};
 
   @media (max-width: 840px) {
     border-right: 0;
@@ -131,7 +133,7 @@ export const StorageMeter = styled.div`
     display: block;
     height: 0.28rem;
     border-radius: 999px;
-    background: linear-gradient(90deg, ${accentGold} 0 22%, #3b3931 22% 100%);
+    background: linear-gradient(90deg, ${accentGold} 0 22%, ${surfaceMuted} 22% 100%);
   }
 `
 
@@ -191,7 +193,7 @@ export const SearchInput = styled.input`
   border: 0;
   border-radius: 999px;
   padding: 0 3.25rem 0 2.45rem;
-  background: #22231f;
+  background: ${surfaceRaised};
   color: ${textPrimary};
   font-size: 0.86rem;
   font-weight: 700;
@@ -202,7 +204,7 @@ export const SearchInput = styled.input`
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 3px rgba(208, 180, 108, 0.2);
+    box-shadow: 0 0 0 3px var(--admin-focus-ring, rgba(185, 149, 79, 0.18));
   }
 `
 
@@ -255,7 +257,7 @@ export const PrimaryButton = styled.button`
   justify-content: center;
   gap: 0.4rem;
   background: ${accentTeal};
-  color: #f5f2e8;
+  color: ${controlText};
   font-size: 0.84rem;
   font-weight: 850;
   cursor: pointer;
@@ -267,7 +269,7 @@ export const PrimaryButton = styled.button`
 
   &:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 3px rgba(63, 143, 134, 0.25);
+    box-shadow: 0 0 0 3px var(--admin-focus-ring, rgba(185, 149, 79, 0.18));
   }
 `
 
@@ -374,7 +376,7 @@ export const FileTable = styled.table`
     height: 2.25rem;
     padding: 0 0.7rem;
     color: ${textMuted};
-    background: #1d1e1b;
+    background: ${surfaceRaised};
     font-size: 0.75rem;
     font-weight: 800;
   }
@@ -388,11 +390,11 @@ export const FileTable = styled.table`
   }
 
   tbody tr[data-selected="true"] {
-    background: #242319;
+    background: ${surfaceAccent};
   }
 
   tbody tr:hover {
-    background: #20211f;
+    background: ${surfaceMuted};
   }
 `
 
@@ -411,7 +413,7 @@ export const FavoriteButton = styled.button`
   height: 1.75rem;
   border: 0;
   background: transparent;
-  color: #a0a8b4;
+  color: ${textMuted};
   cursor: pointer;
   font-size: 1.15rem;
 `
@@ -422,8 +424,8 @@ export const FileTypeIcon = styled.span`
   display: inline-grid;
   place-items: center;
   border-radius: 4px;
-  background: #3c756f;
-  color: #f5f2e8;
+  background: ${surfaceAccent};
+  color: ${accentGold};
   font-size: 0.63rem;
   font-weight: 900;
 `
@@ -590,7 +592,7 @@ export const PdfCanvas = styled.canvas`
   max-height: 18rem;
   border: 1px solid ${border};
   border-radius: 8px;
-  background: #1b1c1a;
+  background: ${surfaceRaised};
 `
 
 export const PhotoFrame = styled.div`
@@ -603,7 +605,7 @@ export const PhotoFrame = styled.div`
     max-height: 18rem;
     object-fit: contain;
     border-radius: 8px;
-    background: #090a09;
+    background: ${surfaceMuted};
   }
 `
 
@@ -617,7 +619,7 @@ export const ThumbnailStrip = styled.div`
     min-height: 2.7rem;
     border-radius: 6px;
     border: 1px solid ${border};
-    background: #1b1c1a;
+    background: ${surfaceRaised};
   }
 `
 
@@ -630,7 +632,7 @@ export const VideoFrame = styled.div`
     width: 100%;
     aspect-ratio: 16 / 9;
     border-radius: 8px;
-    background: #020617;
+    background: ${surfaceMuted};
   }
 `
 
@@ -642,7 +644,7 @@ export const PlayerBar = styled.div`
 export const Timeline = styled.div`
   height: 0.45rem;
   border-radius: 999px;
-  background: linear-gradient(90deg, ${accentGold} 0 34%, ${accentTeal} 34% 36%, #3b3931 36% 100%);
+  background: linear-gradient(90deg, ${accentGold} 0 34%, ${accentTeal} 34% 36%, ${surfaceMuted} 36% 100%);
 `
 
 export const InlineList = styled.div`
@@ -671,7 +673,7 @@ export const QueuePanel = styled.section`
   padding: 0.72rem;
   border: 1px solid ${borderStrong};
   border-radius: 2px;
-  background: rgba(23, 24, 23, 0.96);
+  background: ${surface};
   box-shadow: none;
 `
 
@@ -746,18 +748,18 @@ export const StatusPill = styled.span`
   text-align: center;
 
   &[data-status="failed"] {
-    background: #321b20;
-    color: #f87171;
+    background: ${({ theme }) => theme.colors.statusDangerSurface};
+    color: ${({ theme }) => theme.colors.statusDangerText};
   }
 
   &[data-status="cancelled"] {
-    background: #252622;
+    background: ${surfaceMuted};
     color: ${textMuted};
   }
 
   &[data-status="done"] {
-    background: #16342f;
-    color: #5eead4;
+    background: ${({ theme }) => theme.colors.statusSuccessSurface};
+    color: ${({ theme }) => theme.colors.statusSuccessText};
   }
 `
 
@@ -766,7 +768,7 @@ export const ProgressTrack = styled.div`
   height: 0.28rem;
   overflow: hidden;
   border-radius: 999px;
-  background: #3b3931;
+  background: ${surfaceMuted};
 
   span {
     display: block;

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -511,8 +511,8 @@ const AdminCloudWorkspacePage = () => {
   const emptyTitle = filesQuery.isFetching
     ? "파일을 불러오는 중입니다."
     : keyword || filter !== "ALL"
-      ? "조건에 맞는 파일이 없습니다."
-      : "아직 올린 파일이 없습니다."
+      ? "선택한 조건에 맞는 파일이 없습니다."
+      : "표시할 파일이 없습니다."
 
   return (
     <CloudMain>

--- a/front/src/routes/Admin/AdminDashboardWorkspace.styles.layout.ts
+++ b/front/src/routes/Admin/AdminDashboardWorkspace.styles.layout.ts
@@ -5,23 +5,30 @@ import {
   AdminInfoPanelCard,
   AdminPlainCard,
 } from "src/routes/Admin/AdminSurfacePrimitives"
+import {
+  adminAppBackground,
+  adminBorder,
+  adminSurface,
+  adminSurfaceRaised,
+  adminTextPrimary,
+  adminTextSecondary,
+} from "src/routes/Admin/adminColorTokens"
 
 export const Main = styled.main`
   min-height: 100vh;
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray2};
+  background: ${adminAppBackground};
 `
 
 export const Shell = styled.div`
-  width: min(1380px, calc(100% - 40px));
-  margin: 0 auto;
-  padding: 16px 0 72px;
+  width: 100%;
+  margin: 0;
+  padding: 1.05rem 1.45rem 4.5rem;
   display: grid;
   gap: 8px;
 
   @media (max-width: 768px) {
-    width: min(calc(100% - 24px), 1380px);
-    padding-top: 6px;
+    width: 100%;
+    padding: 0.85rem 0.82rem 3rem;
     gap: 8px;
   }
 `
@@ -30,7 +37,7 @@ export const HeroPanel = styled.section`
   display: grid;
   gap: 6px;
   padding: 0 0 9px;
-  border-bottom: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
+  border-bottom: 1px solid ${adminBorder};
 
   @media (max-width: 820px) {
     gap: 6px;
@@ -56,7 +63,7 @@ export const HeroCopy = styled.div`
 
   h1 {
     margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminTextPrimary};
     font-size: clamp(1.16rem, 2vw, 1.42rem);
     line-height: 1.1;
     letter-spacing: 0;
@@ -85,10 +92,10 @@ export const StatusChip = styled.span`
   align-items: center;
   min-height: 38px;
   padding: 0 15px;
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray1)};
-  color: ${({ theme }) => theme.colors.gray12};
+  border-radius: 4px;
+  border: 1px solid ${adminBorder};
+  background: ${adminSurface};
+  color: ${adminTextPrimary};
   font-size: 0.84rem;
   font-weight: 800;
 
@@ -107,10 +114,10 @@ export const HeaderLink = styled.a`
   align-items: center;
   min-height: 38px;
   padding: 0 15px;
-  border-radius: 999px;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray1)};
-  color: ${({ theme }) => theme.colors.gray12};
+  border-radius: 4px;
+  border: 1px solid ${adminBorder};
+  background: ${adminSurface};
+  color: ${adminTextPrimary};
   text-decoration: none;
   font-size: 0.84rem;
   font-weight: 780;
@@ -134,8 +141,8 @@ export const MetricCard = styled.article`
   align-items: start;
   padding: 12px;
   border-radius: 2px;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray1)};
+  border: 1px solid ${adminBorder};
+  background: ${adminSurface};
   box-shadow: none;
 
   &[data-tone="good"] {
@@ -164,9 +171,8 @@ export const MetricIcon = styled.div`
   border-radius: 2px;
   display: grid;
   place-items: center;
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2};
-  color: ${({ theme }) => theme.colors.gray11};
+  background: ${adminSurfaceRaised};
+  color: ${adminTextSecondary};
 
   &[data-tone="good"] {
     background: ${({ theme }) =>
@@ -266,11 +272,11 @@ export const PanelHeader = styled.div`
   align-items: flex-start;
   gap: 16px;
   padding: 14px 16px 10px;
-  border-bottom: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray4)};
+  border-bottom: 1px solid ${adminBorder};
 
   strong {
     display: block;
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${adminTextPrimary};
     font-size: 1.02rem;
     font-weight: 840;
     letter-spacing: -0.03em;
@@ -297,17 +303,16 @@ export const LaunchLink = styled.a`
   min-width: 68px;
   min-height: 38px;
   padding: 0 14px;
-  border-radius: 999px;
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2};
-  color: ${({ theme }) => theme.colors.gray12};
+  border-radius: 4px;
+  background: ${adminSurfaceRaised};
+  color: ${adminTextPrimary};
   text-decoration: none;
   font-size: 0.88rem;
   font-weight: 780;
 `
 
 export const PanelBody = styled.div`
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray1)};
+  background: ${adminSurface};
 `
 
 export const SnapshotLeadBody = styled(PanelBody)`
@@ -331,7 +336,7 @@ export const PanelFrame = styled.iframe`
   width: 100%;
   height: 304px;
   border: 0;
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray1)};
+  background: ${adminSurface};
 `
 
 export const CompactPanelBody = styled(PanelBody)`

--- a/front/src/routes/Admin/AdminHubSurface.styles.ts
+++ b/front/src/routes/Admin/AdminHubSurface.styles.ts
@@ -1,16 +1,15 @@
 import styled from "@emotion/styled"
 import { AdminSectionTitleStack } from "./AdminSurfacePrimitives"
 import {
+  adminAppBackground,
   adminAccentSurface,
   adminCardBorder,
   adminControlText,
   adminGold,
   adminMutedText,
-  adminPlainSurface,
   adminPrimaryText,
   adminRaisedSurface,
   adminSecondaryText,
-  adminStrongBorder,
   adminTeal,
   adminTealBorder,
 } from "src/routes/Admin/adminColorTokens"
@@ -19,9 +18,11 @@ export const Main = styled.main`
   display: grid;
   gap: 0.72rem;
   align-items: start;
-  width: min(100%, 1088px);
-  margin: 0 auto;
-  padding: 0.72rem 0 2rem;
+  width: 100%;
+  min-width: 0;
+  margin: 0;
+  padding: 1.05rem 1.45rem 2.4rem;
+  background: ${adminAppBackground};
 
   @media (max-width: 768px) {
     padding-top: 0.8rem;
@@ -96,7 +97,7 @@ export const PrimaryActionLink = styled.a`
   min-height: 2.65rem;
   padding: 0 1rem;
   border: 1px solid ${adminTealBorder};
-  border-radius: 999px;
+  border-radius: 4px;
   background: ${adminTeal};
   color: ${adminControlText};
   text-decoration: none;
@@ -111,7 +112,7 @@ export const SecondaryActionLink = styled.a`
   min-height: 2.65rem;
   padding: 0 0.9rem;
   border: 1px solid ${({ theme }) => adminCardBorder(theme)};
-  border-radius: 999px;
+  border-radius: 4px;
   background: ${({ theme }) => adminRaisedSurface(theme)};
   color: ${({ theme }) => adminSecondaryText(theme)};
   text-decoration: none;
@@ -186,10 +187,11 @@ export const BorderlessPanel = styled.div`
   display: grid;
   gap: 0.24rem;
   min-width: 0;
-  padding: 0.78rem 0.84rem;
-  border-radius: 2px;
-  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
-  background: ${({ theme }) => adminPlainSurface(theme)};
+  padding: 0.72rem 0.2rem;
+  border: 0;
+  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  border-radius: 0;
+  background: transparent;
 
   &[data-tone="good"] {
     border-color: ${({ theme }) => theme.colors.green7};
@@ -221,20 +223,21 @@ export const BorderlessPanelLink = styled.a`
   align-items: center;
   min-width: 0;
   min-height: 3.75rem;
-  padding: 0.82rem 0.88rem;
-  border-radius: 2px;
-  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
-  background: ${({ theme }) => adminPlainSurface(theme)};
+  padding: 0.72rem 0.2rem;
+  border: 0;
+  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  border-radius: 0;
+  background: transparent;
   color: inherit;
   text-decoration: none;
   transition:
-    transform 0.16s ease,
     border-color 0.16s ease,
     background 0.16s ease;
 
   &[data-featured="true"] {
-    border-color: ${({ theme }) => adminStrongBorder(theme)};
+    box-shadow: inset 3px 0 0 ${adminGold};
     background: ${({ theme }) => adminAccentSurface(theme)};
+    padding-left: 0.82rem;
   }
 
   &[data-tone="good"] {
@@ -246,8 +249,6 @@ export const BorderlessPanelLink = styled.a`
   }
 
   &:hover {
-    transform: translateY(-1px);
-    border-color: ${({ theme }) => adminStrongBorder(theme)};
     background: ${({ theme }) => adminRaisedSurface(theme)};
   }
 
@@ -318,10 +319,11 @@ export const BorderlessMetricRow = styled.div`
   display: grid;
   gap: 0.24rem;
   min-width: 0;
-  padding: 0.78rem 0.84rem;
-  border-radius: 2px;
-  border: 1px solid ${({ theme }) => adminCardBorder(theme)};
-  background: ${({ theme }) => adminPlainSurface(theme)};
+  padding: 0.72rem 0.2rem;
+  border: 0;
+  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  border-radius: 0;
+  background: transparent;
 
   &[data-tone="good"] {
     border-color: ${({ theme }) => theme.colors.green7};
@@ -361,7 +363,7 @@ export const ProfileFrame = styled.div`
   position: relative;
   width: 4.25rem;
   height: 4.25rem;
-  border-radius: 999px;
+  border-radius: 50%;
   overflow: hidden;
   background: ${({ theme }) => adminRaisedSurface(theme)};
 `
@@ -411,7 +413,7 @@ export const RailActionLink = styled.a`
   justify-content: center;
   min-height: 40px;
   padding: 0 0.95rem;
-  border-radius: 999px;
+  border-radius: 4px;
   border: 1px solid ${({ theme }) => adminCardBorder(theme)};
   background: ${({ theme }) => adminRaisedSurface(theme)};
   color: ${({ theme }) => (theme.scheme === "light" ? adminPrimaryText(theme) : adminGold)};

--- a/front/src/routes/Admin/AdminPostsWorkspacePageSections.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspacePageSections.tsx
@@ -10,15 +10,16 @@ import {
 export const AdminPostsWorkspaceMainSections = Symbol("AdminPostsWorkspaceMainSections")
 
 export const Main = styled.main`
-  max-width: 1120px;
-  margin: 0 auto;
-  padding: 0.85rem 1rem 2.4rem;
+  width: 100%;
+  min-width: 0;
+  margin: 0;
+  padding: 1.05rem 1.45rem 2.4rem;
   display: grid;
   gap: 1rem;
 
   @media (max-width: 767px) {
     gap: 0.9rem;
-    padding: 1rem 0.85rem 2rem;
+    padding: 0.85rem 0.82rem 2rem;
   }
 `
 

--- a/front/src/routes/Admin/AdminProfileWorkspace.styles.tokens.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspace.styles.tokens.ts
@@ -26,20 +26,21 @@ import {
 } from "src/routes/Admin/adminColorTokens"
 
 export const Main = styled.main`
-  max-width: 1420px;
-  margin: 0 auto;
-  padding: 1.6rem 1rem 2.8rem;
+  width: 100%;
+  min-width: 0;
+  margin: 0;
+  padding: 1.05rem 1.45rem 2.8rem;
   display: grid;
   gap: 1rem;
 
   @media (max-width: 760px) {
-    padding-bottom: calc(2rem + env(safe-area-inset-bottom, 0px));
+    padding: 0.85rem 0.82rem calc(2rem + env(safe-area-inset-bottom, 0px));
   }
 `
 
 export const BaseButton = styled.button`
   min-height: 38px;
-  border-radius: 9px;
+  border-radius: 4px;
   border: 1px solid ${adminBorder};
   background: ${adminSurfaceRaised};
   color: ${adminTextSecondary};

--- a/front/src/routes/Admin/AdminProfileWorkspaceModel.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspaceModel.ts
@@ -27,7 +27,7 @@ export const WORKSPACE_SECTIONS: {
 }[] = [
   {
     id: "identity",
-    label: "프로필",
+    label: "기본 정보",
   },
   {
     id: "about",

--- a/front/src/routes/Admin/AdminShell.tsx
+++ b/front/src/routes/Admin/AdminShell.tsx
@@ -168,12 +168,12 @@ const AdminShell = ({ currentSection, member, profileSnapshot = null, children }
 export default AdminShell
 
 const ShellFrame = styled.div`
-  ${adminSystemThemeVariables}
+  ${({ theme }) => adminSystemThemeVariables(theme)}
   display: grid;
   grid-template-columns: 17.5rem minmax(0, 1fr);
   gap: 0;
-  width: 100vw;
-  margin-left: calc(50% - 50vw);
+  width: 100%;
+  margin: 0;
   min-height: calc(100vh - var(--app-header-height, 73px) - 1rem);
   padding: 0;
   background: ${adminAppBackground};
@@ -181,7 +181,6 @@ const ShellFrame = styled.div`
   @media (max-width: 1100px) {
     grid-template-columns: minmax(0, 1fr);
     width: 100%;
-    margin-left: 0;
   }
 `
 
@@ -383,7 +382,7 @@ const ContentColumn = styled.div`
 
 const UtilityBarFallback = styled.div`
   position: sticky;
-  top: calc(var(--app-header-height, 73px) + 0.85rem);
+  top: var(--app-header-height, 73px);
   z-index: 5;
   height: 4.85rem;
   border: 0;
@@ -393,7 +392,7 @@ const UtilityBarFallback = styled.div`
   box-shadow: none;
 
   @media (max-width: 720px) {
-    top: calc(var(--app-header-height, 73px) + 0.65rem);
+    top: var(--app-header-height, 73px);
     height: 8.15rem;
   }
 `

--- a/front/src/routes/Admin/AdminShell.tsx
+++ b/front/src/routes/Admin/AdminShell.tsx
@@ -6,16 +6,19 @@ import AppIcon, { type IconName } from "src/components/icons/AppIcon"
 import ProfileImage from "src/components/ProfileImage"
 import type { AuthMember } from "src/hooks/useAuthSession"
 import {
+  adminAppBackground,
   adminBorder,
   adminBorderStrong,
   adminControlText,
   adminGold,
   adminShellSurface,
+  adminSurface,
   adminSurfaceAccent,
   adminSurfaceRaised,
   adminTeal,
   adminTealBorder,
   adminTealHover,
+  adminSystemThemeVariables,
   adminTextMuted,
   adminTextPrimary,
   adminTextSecondary,
@@ -165,19 +168,20 @@ const AdminShell = ({ currentSection, member, profileSnapshot = null, children }
 export default AdminShell
 
 const ShellFrame = styled.div`
+  ${adminSystemThemeVariables}
   display: grid;
-  grid-template-columns: minmax(14.5rem, 16.5rem) minmax(0, 1fr);
-  gap: 0.85rem;
-  width: min(1760px, calc(100vw - 2rem));
-  margin-left: calc(50% - 50vw + 1rem);
+  grid-template-columns: 17.5rem minmax(0, 1fr);
+  gap: 0;
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
   min-height: calc(100vh - var(--app-header-height, 73px) - 1rem);
-  padding: 0.85rem 0 2rem;
+  padding: 0;
+  background: ${adminAppBackground};
 
   @media (max-width: 1100px) {
     grid-template-columns: minmax(0, 1fr);
     width: 100%;
     margin-left: 0;
-    padding-top: 0.85rem;
   }
 `
 
@@ -187,20 +191,17 @@ const Sidebar = styled.aside`
   align-content: start;
   min-width: 0;
   position: sticky;
-  top: calc(var(--app-header-height, 73px) + 0.85rem);
-  min-height: calc(100vh - var(--app-header-height, 73px) - 1.7rem);
+  top: var(--app-header-height, 73px);
+  min-height: calc(100vh - var(--app-header-height, 73px));
   height: fit-content;
-  padding: 0.72rem 0.35rem;
+  padding: 1.05rem 1.25rem 1.15rem;
   border: 0;
   border-right: 1px solid ${adminBorder};
   border-radius: 0;
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : adminShellSurface};
+  background: ${adminShellSurface};
 
   @media (max-width: 1100px) {
     position: static;
-    padding: 0.72rem 0.82rem;
-    border-radius: 2px;
     display: none;
   }
 `
@@ -221,7 +222,7 @@ const BrandBlock = styled.div`
   display: flex;
   align-items: center;
   gap: 0.78rem;
-  padding: 0.1rem 0.42rem 0.35rem;
+  padding: 0.1rem 0 0.35rem;
 
   @media (max-width: 1100px) {
     flex-shrink: 0;
@@ -236,10 +237,8 @@ const BrandMark = styled.div`
   place-items: center;
   position: relative;
   overflow: hidden;
-  border: 1px solid ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : adminBorderStrong};
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : adminSurfaceAccent};
+  border: 1px solid ${adminBorderStrong};
+  background: ${adminSurfaceAccent};
   color: ${adminGold};
 
   span {
@@ -330,8 +329,7 @@ const NavLink = styled.a`
 
   &[data-active="true"] {
     border-left-color: ${adminGold};
-    background: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : adminSurfaceAccent};
+    background: ${adminSurfaceAccent};
   }
 
   &[data-active="true"] .navIcon {
@@ -340,8 +338,7 @@ const NavLink = styled.a`
   }
 
   &:hover {
-    background: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : adminSurfaceRaised};
+    background: ${adminSurfaceRaised};
   }
 
   @media (max-width: 1100px) {
@@ -372,16 +369,16 @@ const SidebarPrimaryAction = styled.a`
   font-weight: 760;
 
   &:hover {
-    background: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : adminTealHover};
+    background: ${adminTealHover};
   }
 `
 
 const ContentColumn = styled.div`
   display: grid;
   align-content: start;
-  gap: 0.65rem;
+  gap: 0;
   min-width: 0;
+  background: ${adminAppBackground};
 `
 
 const UtilityBarFallback = styled.div`
@@ -389,10 +386,10 @@ const UtilityBarFallback = styled.div`
   top: calc(var(--app-header-height, 73px) + 0.85rem);
   z-index: 5;
   height: 4.85rem;
-  border: 1px solid ${adminBorder};
+  border: 0;
+  border-bottom: 1px solid ${adminBorder};
   border-radius: 0;
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : "rgba(23, 24, 23, 0.86)"};
+  background: ${adminSurface};
   box-shadow: none;
 
   @media (max-width: 720px) {

--- a/front/src/routes/Admin/AdminSurfacePrimitives.tsx
+++ b/front/src/routes/Admin/AdminSurfacePrimitives.tsx
@@ -3,8 +3,6 @@ import styled from "@emotion/styled"
 import {
   adminAccentSurface,
   adminCardBorder,
-  adminElevatedBorderDark,
-  adminElevatedSurfaceTop,
   adminFocusRing,
   adminGold,
   adminMutedSurface,
@@ -14,26 +12,16 @@ import {
   adminRaisedSurface,
   adminSecondaryText,
   adminStrongBorder,
-  adminSurface,
-  usesDarkAdminSurface,
 } from "src/routes/Admin/adminColorTokens"
 
 export const adminElevatedSurface = (theme: Theme) =>
-  theme.blogDesign === "grid"
-    ? `linear-gradient(180deg, ${theme.publicDesign.operationSurfaceElevated} 0%, ${theme.publicDesign.operationSurface} 100%)`
-    : usesDarkAdminSurface(theme)
-      ? `linear-gradient(180deg, ${adminElevatedSurfaceTop} 0%, ${adminSurface} 100%)`
-      : "linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 248, 249, 0.94) 100%)"
+  adminPlainSurface(theme)
 
 export const adminElevatedBorder = (theme: Theme) =>
-  theme.blogDesign === "grid" ? theme.publicDesign.border : usesDarkAdminSurface(theme) ? adminElevatedBorderDark : theme.colors.gray5
+  adminCardBorder(theme)
 
-export const adminElevatedShadow = (theme: Theme) =>
-  theme.blogDesign === "grid"
-    ? "none"
-    : usesDarkAdminSurface(theme)
-      ? "none"
-      : "none"
+export const adminElevatedShadow = (_theme: Theme) =>
+  "none"
 
 export const adminInteractiveFocusRing = (theme: Theme) =>
   adminFocusRing(theme)
@@ -146,7 +134,7 @@ export const AdminWorkspaceHeroLabel = styled.span`
   min-height: 28px;
   align-items: center;
   padding: 0 0.72rem;
-  border-radius: 999px;
+  border-radius: 4px;
   border: 1px solid ${({ theme }) => adminCardBorder(theme)};
   background: ${({ theme }) => adminRaisedSurface(theme)};
   color: ${({ theme }) => adminSecondaryText(theme)};
@@ -258,7 +246,7 @@ export const AdminWorkspaceSectionNavButton = styled.button`
   gap: 0.42rem;
   min-height: 42px;
   padding: 0 0.9rem;
-  border-radius: 999px;
+  border-radius: 4px;
   border: 1px solid ${({ theme }) => adminCardBorder(theme)};
   background: ${({ theme }) => adminRaisedSurface(theme)};
   color: ${({ theme }) => adminMutedText(theme)};
@@ -304,7 +292,7 @@ export const AdminWorkspaceSectionNavButton = styled.button`
     top: 7px;
     bottom: 7px;
     width: 3px;
-    border-radius: 999px;
+    border-radius: 2px;
     background: ${({ theme }) => theme.colors.gray7};
   }
 
@@ -464,7 +452,7 @@ export const AdminStatusPill = styled.span<{ $size?: "sm" | "md" }>`
   justify-content: center;
   min-height: ${({ $size = "md" }) => ($size === "sm" ? "28px" : "32px")};
   padding: ${({ $size = "md" }) => ($size === "sm" ? "0 0.62rem" : "0 0.72rem")};
-  border-radius: ${({ $size = "md" }) => ($size === "sm" ? "10px" : "999px")};
+  border-radius: 4px;
   border: 1px solid ${({ theme }) => adminCardBorder(theme)};
   background: ${({ theme }) => adminRaisedSurface(theme)};
   color: ${({ theme }) => adminSecondaryText(theme)};

--- a/front/src/routes/Admin/AdminToolsWorkspace.styles.tokens.ts
+++ b/front/src/routes/Admin/AdminToolsWorkspace.styles.tokens.ts
@@ -18,11 +18,10 @@ import {
 } from "src/routes/Admin/adminColorTokens"
 
 export const Main = styled.main`
-  max-width: 1440px;
   width: 100%;
   min-width: 0;
-  margin: 0 auto;
-  padding: 0.9rem 1rem 2.6rem;
+  margin: 0;
+  padding: 1.05rem 1.45rem 2.6rem;
   display: grid;
   gap: 1.25rem;
 `

--- a/front/src/routes/Admin/AdminToolsWorkspace.styles.tokens.ts
+++ b/front/src/routes/Admin/AdminToolsWorkspace.styles.tokens.ts
@@ -12,6 +12,10 @@ import {
   adminInteractiveFocusRing,
 } from "src/routes/Admin/AdminSurfacePrimitives"
 import {
+  adminBorder,
+  adminBorderStrong,
+  adminSurface,
+  adminSurfaceRaised,
   adminWarningBadgeBorder,
   adminWarningBadgeSurface,
   adminWarningBadgeText,
@@ -91,14 +95,13 @@ export const FeaturedStatusCard = styled.button`
   display: grid;
   gap: 0.55rem;
   border-radius: 2px;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2};
+  border: 1px solid ${adminBorder};
+  background: ${adminSurfaceRaised};
   padding: 1rem;
   cursor: pointer;
 
   &:hover {
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray7)};
+    border-color: ${adminBorderStrong};
   }
 `
 
@@ -138,13 +141,13 @@ export const StatusCardButton = styled.button`
   display: grid;
   gap: 0.22rem;
   border-radius: 2px;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray1)};
+  border: 1px solid ${adminBorder};
+  background: ${adminSurface};
   padding: 0.82rem 0.9rem;
   cursor: pointer;
 
   &:hover {
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray7)};
+    border-color: ${adminBorderStrong};
   }
 
   small {
@@ -190,15 +193,14 @@ export const WorkspaceSection = styled.section`
   gap: 0.82rem;
   padding: 0.92rem;
   border-radius: 2px;
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2};
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
+  background: ${adminSurfaceRaised};
+  border: 1px solid ${adminBorder};
   content-visibility: auto;
   contain-intrinsic-size: 720px;
 
   &[data-emphasis="secondary"] {
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray1)};
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray4)};
+    background: ${adminSurface};
+    border-color: ${adminBorder};
   }
 
   &[data-tone="danger"] {

--- a/front/src/routes/Admin/AdminUtilityBar.tsx
+++ b/front/src/routes/Admin/AdminUtilityBar.tsx
@@ -9,6 +9,7 @@ import {
   adminBorderStrong,
   adminFocusRing,
   adminGold,
+  adminSurface,
   adminSurfaceAccent,
   adminSurfaceRaised,
   adminTextMuted,
@@ -142,26 +143,24 @@ export default AdminUtilityBar
 
 const UtilityBar = styled.header`
   position: sticky;
-  top: calc(var(--app-header-height, 73px) + 0.85rem);
+  top: var(--app-header-height, 73px);
   z-index: 5;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.72rem;
-  padding: 0.72rem 0.85rem;
-  border: 1px solid ${adminBorder};
-  border-radius: 14px;
-  backdrop-filter: blur(18px);
-  background: rgba(23, 24, 23, 0.82);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
+  min-height: 3.95rem;
+  padding: 0.62rem 1.45rem;
+  border-bottom: 1px solid ${adminBorder};
+  background: ${adminSurfaceRaised};
+  box-shadow: none;
 
   @media (max-width: 720px) {
-    top: calc(var(--app-header-height, 73px) + 0.65rem);
+    top: var(--app-header-height, 73px);
     position: sticky;
     align-items: center;
     gap: 0.48rem;
-    padding: 0.58rem 0.64rem;
-    border-radius: 14px;
+    padding: 0.58rem 0.82rem;
 
     &[data-search-open="true"] {
       margin-bottom: 3.15rem;
@@ -196,12 +195,12 @@ const CompactNav = styled.nav`
 const CompactNavLink = styled.a`
   width: 2.75rem;
   height: 2.75rem;
-  border-radius: 10px;
+  border-radius: 4px;
   display: grid;
   place-items: center;
   flex-shrink: 0;
   border: 1px solid transparent;
-  background: ${adminSurfaceRaised};
+  background: transparent;
   color: ${adminTextSecondary};
   text-decoration: none;
 
@@ -257,11 +256,11 @@ const SearchField = styled.div`
 const SearchInput = styled.input`
   width: 100%;
   min-width: 0;
-  height: 2.75rem;
+  height: 2.58rem;
   padding: 0 0.92rem 0 2.55rem;
   border: 1px solid ${adminBorder};
   border-radius: 999px;
-  background: rgba(32, 33, 31, 0.82);
+  background: ${adminSurface};
   color: ${adminTextPrimary};
   font-size: 0.88rem;
   font-weight: 600;
@@ -296,7 +295,7 @@ const SearchToggleButton = styled.button`
     width: 2.75rem;
     height: 2.75rem;
     border: 1px solid ${adminBorder};
-    border-radius: 10px;
+    border-radius: 4px;
     display: grid;
     place-items: center;
     flex-shrink: 0;

--- a/front/src/routes/Admin/adminColorTokens.ts
+++ b/front/src/routes/Admin/adminColorTokens.ts
@@ -1,70 +1,107 @@
 import type { Theme } from "@emotion/react"
 
-export const adminTextPrimary = "#f3f1ea"
-export const adminTextSecondary = "#c8c1ae"
-export const adminTextMuted = "#918b7d"
-export const adminBorder = "#34322d"
-export const adminBorderStrong = "#6d6040"
-export const adminSurface = "#171817"
-export const adminShellSurface = "#151614"
-export const adminSurfaceRaised = "#20211f"
-export const adminSurfaceMuted = "#242520"
-export const adminSurfaceAccent = "#2d291a"
-export const adminElevatedSurfaceTop = "#1b1c1a"
-export const adminElevatedBorderDark = "#30322e"
-export const adminGold = "#d0b46c"
-export const adminTeal = "#3f8f86"
-export const adminTealHover = "#347b73"
-export const adminControlText = "#f8fffc"
-export const adminTealBorder = "rgba(63, 143, 134, 0.58)"
-export const adminTealBorderHover = "rgba(63, 143, 134, 0.72)"
-export const adminGoldTintSubtle = "rgba(208, 180, 108, 0.14)"
-export const adminGoldTintFocus = "rgba(208, 180, 108, 0.18)"
-export const adminGoldTintFocusStrong = "rgba(208, 180, 108, 0.24)"
-export const adminGoldTintLine = "rgba(208, 180, 108, 0.2)"
-export const adminActionGroupDarkSurface = "rgba(24, 24, 24, 0.86)"
-export const adminActionGroupLightSurface = "rgba(255, 255, 255, 0.82)"
+export const adminSystemThemeVariables = `
+  color-scheme: light;
+  --admin-app-bg: #ffffff;
+  --admin-sidebar-bg: #f6f7fb;
+  --admin-surface: #ffffff;
+  --admin-surface-raised: #f3f5f9;
+  --admin-surface-muted: #eef2f7;
+  --admin-surface-accent: #f7f1e3;
+  --admin-elevated-top: #ffffff;
+  --admin-border: #e5e9f1;
+  --admin-border-strong: #c8d1df;
+  --admin-text-primary: #20242b;
+  --admin-text-secondary: #4d5562;
+  --admin-text-muted: #87909d;
+  --admin-primary: #b9954f;
+  --admin-primary-hover: #9d7d3f;
+  --admin-primary-border: rgba(185, 149, 79, 0.36);
+  --admin-primary-border-hover: rgba(185, 149, 79, 0.58);
+  --admin-control-text: #ffffff;
+  --admin-focus-ring: rgba(185, 149, 79, 0.18);
+  --admin-focus-ring-strong: rgba(185, 149, 79, 0.26);
+  --admin-action-group-surface: rgba(255, 255, 255, 0.88);
 
-export const usesDarkAdminSurface = (theme: Theme) => theme.blogDesign === "grid" || theme.scheme !== "light"
+  @media (prefers-color-scheme: dark) {
+    color-scheme: dark;
+    --admin-app-bg: #121212;
+    --admin-sidebar-bg: #181818;
+    --admin-surface: #121212;
+    --admin-surface-raised: #1b1b1b;
+    --admin-surface-muted: #222222;
+    --admin-surface-accent: #2d291a;
+    --admin-elevated-top: #181818;
+    --admin-border: #2f333a;
+    --admin-border-strong: #4a5464;
+    --admin-text-primary: #f5f6f8;
+    --admin-text-secondary: #c8ced7;
+    --admin-text-muted: #8f99a7;
+    --admin-primary: #d0b46c;
+    --admin-primary-hover: #e0c984;
+    --admin-primary-border: rgba(208, 180, 108, 0.42);
+    --admin-primary-border-hover: rgba(208, 180, 108, 0.62);
+    --admin-control-text: #101214;
+    --admin-focus-ring: rgba(208, 180, 108, 0.22);
+    --admin-focus-ring-strong: rgba(208, 180, 108, 0.3);
+    --admin-action-group-surface: rgba(18, 18, 18, 0.88);
+  }
+`
+
+export const adminAppBackground = "var(--admin-app-bg, #ffffff)"
+export const adminTextPrimary = "var(--admin-text-primary, #20242b)"
+export const adminTextSecondary = "var(--admin-text-secondary, #4d5562)"
+export const adminTextMuted = "var(--admin-text-muted, #87909d)"
+export const adminBorder = "var(--admin-border, #e5e9f1)"
+export const adminBorderStrong = "var(--admin-border-strong, #c8d1df)"
+export const adminSurface = "var(--admin-surface, #ffffff)"
+export const adminShellSurface = "var(--admin-sidebar-bg, #f6f7fb)"
+export const adminSurfaceRaised = "var(--admin-surface-raised, #f3f5f9)"
+export const adminSurfaceMuted = "var(--admin-surface-muted, #eef2f7)"
+export const adminSurfaceAccent = "var(--admin-surface-accent, #eaf1ff)"
+export const adminElevatedSurfaceTop = "var(--admin-elevated-top, #ffffff)"
+export const adminElevatedBorderDark = "var(--admin-border, #e5e9f1)"
+export const adminGold = "var(--admin-primary, #b9954f)"
+export const adminTeal = "var(--admin-primary, #b9954f)"
+export const adminTealHover = "var(--admin-primary-hover, #9d7d3f)"
+export const adminControlText = "var(--admin-control-text, #ffffff)"
+export const adminTealBorder = "var(--admin-primary-border, rgba(185, 149, 79, 0.36))"
+export const adminTealBorderHover = "var(--admin-primary-border-hover, rgba(185, 149, 79, 0.58))"
+export const adminGoldTintSubtle = "var(--admin-surface-accent, #f7f1e3)"
+export const adminGoldTintFocus = "var(--admin-focus-ring, rgba(185, 149, 79, 0.18))"
+export const adminGoldTintFocusStrong = "var(--admin-focus-ring-strong, rgba(185, 149, 79, 0.26))"
+export const adminGoldTintLine = "var(--admin-primary-border, rgba(185, 149, 79, 0.36))"
+export const adminActionGroupDarkSurface = "var(--admin-action-group-surface, rgba(18, 18, 18, 0.88))"
+export const adminActionGroupLightSurface = "var(--admin-action-group-surface, rgba(255, 255, 255, 0.88))"
+
+export const usesDarkAdminSurface = (theme: Theme) => theme.scheme !== "light"
 
 export const adminPrimaryText = (theme: Theme) =>
-  usesDarkAdminSurface(theme) ? adminTextPrimary : theme.colors.gray12
+  adminTextPrimary
 
 export const adminSecondaryText = (theme: Theme) =>
-  usesDarkAdminSurface(theme) ? adminTextSecondary : theme.colors.gray11
+  adminTextSecondary
 
 export const adminMutedText = (theme: Theme) =>
-  usesDarkAdminSurface(theme) ? adminTextMuted : theme.colors.gray10
+  adminTextMuted
 
 export const adminCardBorder = (theme: Theme) =>
-  theme.blogDesign === "grid"
-    ? theme.publicDesign.border
-    : usesDarkAdminSurface(theme)
-      ? adminBorder
-      : theme.colors.gray5
+  adminBorder
 
 export const adminStrongBorder = (theme: Theme) =>
-  usesDarkAdminSurface(theme) ? adminBorderStrong : theme.colors.gray7
+  adminBorderStrong
 
 export const adminPlainSurface = (theme: Theme) =>
-  theme.blogDesign === "grid"
-    ? theme.publicDesign.operationSurface
-    : usesDarkAdminSurface(theme)
-      ? adminSurface
-      : theme.colors.gray1
+  adminSurface
 
 export const adminRaisedSurface = (theme: Theme) =>
-  theme.blogDesign === "grid"
-    ? theme.publicDesign.operationSurfaceElevated
-    : usesDarkAdminSurface(theme)
-      ? adminSurfaceRaised
-      : theme.colors.gray2
+  adminSurfaceRaised
 
 export const adminMutedSurface = (theme: Theme) =>
-  usesDarkAdminSurface(theme) ? adminSurfaceMuted : theme.colors.gray3
+  adminSurfaceMuted
 
 export const adminAccentSurface = (theme: Theme) =>
-  usesDarkAdminSurface(theme) ? adminSurfaceAccent : theme.colors.accentSurfaceSubtle
+  adminSurfaceAccent
 
 export const adminWarningBadgeBorder = () => adminBorderStrong
 export const adminWarningBadgeSurface = () => adminSurfaceAccent
@@ -76,8 +113,4 @@ export const adminFocusRing = (theme: Theme, width = 3) =>
     : `0 0 0 ${width}px ${adminGoldTintFocusStrong}`
 
 export const adminActionGroupSurface = (theme: Theme) =>
-  theme.blogDesign === "grid"
-    ? theme.publicDesign.operationSurfaceElevated
-    : theme.scheme === "light"
-      ? adminActionGroupLightSurface
-      : adminActionGroupDarkSurface
+  theme.scheme === "light" ? adminActionGroupLightSurface : adminActionGroupDarkSurface

--- a/front/src/routes/Admin/adminColorTokens.ts
+++ b/front/src/routes/Admin/adminColorTokens.ts
@@ -1,6 +1,6 @@
 import type { Theme } from "@emotion/react"
 
-export const adminSystemThemeVariables = `
+const adminLightThemeVariables = `
   color-scheme: light;
   --admin-app-bg: #ffffff;
   --admin-sidebar-bg: #f6f7fb;
@@ -13,58 +13,63 @@ export const adminSystemThemeVariables = `
   --admin-border-strong: #c8d1df;
   --admin-text-primary: #20242b;
   --admin-text-secondary: #4d5562;
-  --admin-text-muted: #87909d;
+  --admin-text-muted: #566273;
   --admin-primary: #b9954f;
   --admin-primary-hover: #9d7d3f;
+  --admin-accent-text: #6f5524;
   --admin-primary-border: rgba(185, 149, 79, 0.36);
   --admin-primary-border-hover: rgba(185, 149, 79, 0.58);
-  --admin-control-text: #ffffff;
+  --admin-control-text: #101214;
   --admin-focus-ring: rgba(185, 149, 79, 0.18);
   --admin-focus-ring-strong: rgba(185, 149, 79, 0.26);
   --admin-action-group-surface: rgba(255, 255, 255, 0.88);
-
-  @media (prefers-color-scheme: dark) {
-    color-scheme: dark;
-    --admin-app-bg: #121212;
-    --admin-sidebar-bg: #181818;
-    --admin-surface: #121212;
-    --admin-surface-raised: #1b1b1b;
-    --admin-surface-muted: #222222;
-    --admin-surface-accent: #2d291a;
-    --admin-elevated-top: #181818;
-    --admin-border: #2f333a;
-    --admin-border-strong: #4a5464;
-    --admin-text-primary: #f5f6f8;
-    --admin-text-secondary: #c8ced7;
-    --admin-text-muted: #8f99a7;
-    --admin-primary: #d0b46c;
-    --admin-primary-hover: #e0c984;
-    --admin-primary-border: rgba(208, 180, 108, 0.42);
-    --admin-primary-border-hover: rgba(208, 180, 108, 0.62);
-    --admin-control-text: #101214;
-    --admin-focus-ring: rgba(208, 180, 108, 0.22);
-    --admin-focus-ring-strong: rgba(208, 180, 108, 0.3);
-    --admin-action-group-surface: rgba(18, 18, 18, 0.88);
-  }
 `
+
+const adminDarkThemeVariables = `
+  color-scheme: dark;
+  --admin-app-bg: #121212;
+  --admin-sidebar-bg: #181818;
+  --admin-surface: #121212;
+  --admin-surface-raised: #1b1b1b;
+  --admin-surface-muted: #222222;
+  --admin-surface-accent: #2d291a;
+  --admin-elevated-top: #181818;
+  --admin-border: #2f333a;
+  --admin-border-strong: #4a5464;
+  --admin-text-primary: #f5f6f8;
+  --admin-text-secondary: #c8ced7;
+  --admin-text-muted: #8f99a7;
+  --admin-primary: #d0b46c;
+  --admin-primary-hover: #e0c984;
+  --admin-accent-text: #d0b46c;
+  --admin-primary-border: rgba(208, 180, 108, 0.42);
+  --admin-primary-border-hover: rgba(208, 180, 108, 0.62);
+  --admin-control-text: #101214;
+  --admin-focus-ring: rgba(208, 180, 108, 0.22);
+  --admin-focus-ring-strong: rgba(208, 180, 108, 0.3);
+  --admin-action-group-surface: rgba(18, 18, 18, 0.88);
+`
+
+export const adminSystemThemeVariables = (theme: Theme) =>
+  theme.scheme === "dark" ? adminDarkThemeVariables : adminLightThemeVariables
 
 export const adminAppBackground = "var(--admin-app-bg, #ffffff)"
 export const adminTextPrimary = "var(--admin-text-primary, #20242b)"
 export const adminTextSecondary = "var(--admin-text-secondary, #4d5562)"
-export const adminTextMuted = "var(--admin-text-muted, #87909d)"
+export const adminTextMuted = "var(--admin-text-muted, #566273)"
 export const adminBorder = "var(--admin-border, #e5e9f1)"
 export const adminBorderStrong = "var(--admin-border-strong, #c8d1df)"
 export const adminSurface = "var(--admin-surface, #ffffff)"
 export const adminShellSurface = "var(--admin-sidebar-bg, #f6f7fb)"
 export const adminSurfaceRaised = "var(--admin-surface-raised, #f3f5f9)"
 export const adminSurfaceMuted = "var(--admin-surface-muted, #eef2f7)"
-export const adminSurfaceAccent = "var(--admin-surface-accent, #eaf1ff)"
+export const adminSurfaceAccent = "var(--admin-surface-accent, #f7f1e3)"
 export const adminElevatedSurfaceTop = "var(--admin-elevated-top, #ffffff)"
 export const adminElevatedBorderDark = "var(--admin-border, #e5e9f1)"
-export const adminGold = "var(--admin-primary, #b9954f)"
+export const adminGold = "var(--admin-accent-text, #6f5524)"
 export const adminTeal = "var(--admin-primary, #b9954f)"
 export const adminTealHover = "var(--admin-primary-hover, #9d7d3f)"
-export const adminControlText = "var(--admin-control-text, #ffffff)"
+export const adminControlText = "var(--admin-control-text, #101214)"
 export const adminTealBorder = "var(--admin-primary-border, rgba(185, 149, 79, 0.36))"
 export const adminTealBorderHover = "var(--admin-primary-border-hover, rgba(185, 149, 79, 0.58))"
 export const adminGoldTintSubtle = "var(--admin-surface-accent, #f7f1e3)"


### PR DESCRIPTION
## 관련 이슈

close #696
close #697

## 작업 배경

- 관리자 전체 화면을 첨부된 MYBOX 구조에 맞춰 좌측 사이드바, 상단 검색/현재 화면 바, 열린 작업 공간, 목록/상세 패널 중심으로 정리했습니다.
- 화이트를 기본값으로 두고 OS `prefers-color-scheme`에 따라 같은 구조가 다크 색상으로 자동 전환되도록 관리자 공통 토큰을 재정렬했습니다.
- `/admin/profile` live E2E에서 exact heading이 중복되던 원인도 함께 제거했습니다.

## 작업 내용

- 관리자 공통 shell/utility bar를 full-width MYBOX형 작업 공간으로 변경했습니다.
- 클라우드 화면의 파일 목록, 검색, 업로드 큐, 상세 preview drawer 색상과 표면을 새 관리자 토큰으로 정리했습니다.
- 허브/대시보드/글관리/프로필/도구의 main surface를 카드형 중앙 정렬에서 열린 workspace로 맞췄습니다.
- 공통 admin primitive의 gradient/elevated card 언어를 제거하고 경계선형 행/패널 중심으로 변경했습니다.
- 관리자 UI 계약 테스트 display name을 한글로 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front lint`
  - `yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/admin-cloud.spec.ts e2e/admin-profile-state.spec.ts e2e/admin-surface-primitives.spec.ts e2e/admin-hub-state.spec.ts e2e/admin-dashboard-state.spec.ts e2e/admin-posts-workspace.spec.ts e2e/admin-tools-state.spec.ts e2e/mobile-layout-admin.spec.ts --workers=1`
  - `yarn --cwd front build`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 관리자 화면의 시각 밀도가 바뀌어 기존 카드형 레이아웃에 익숙한 위치 기억이 달라질 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋 `7131a983`를 revert 하면 이전 관리자 표면으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
