### PR TITLE
[Fix] 관리자 클라우드 live E2E 업로드 버튼 선택자 안정화

### DIFF
--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -585,7 +585,7 @@ test.describe("live production e2e", () => {
     await page.goto("/admin/cloud")
     await expect(page.getByRole("heading", { name: adminCloudHeadingPattern })).toBeVisible()
     const visibleCloudUploadButton = page
-      .locator('button[aria-label="파일 업로드"], button[aria-label="업로드 중"]')
+      .getByRole("button", { name: /^(파일 업로드|업로드 중)$/ })
       .filter({ visible: true })
     await expect(visibleCloudUploadButton).toHaveCount(1)
     await expect(visibleCloudUploadButton).toBeVisible()

--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -584,7 +584,11 @@ test.describe("live production e2e", () => {
 
     await page.goto("/admin/cloud")
     await expect(page.getByRole("heading", { name: adminCloudHeadingPattern })).toBeVisible()
-    await expect(page.getByRole("button", { name: /^(파일 업로드|업로드 중)$/ })).toBeVisible()
+    const visibleCloudUploadButton = page
+      .locator('button[aria-label="파일 업로드"], button[aria-label="업로드 중"]')
+      .filter({ visible: true })
+    await expect(visibleCloudUploadButton).toHaveCount(1)
+    await expect(visibleCloudUploadButton).toBeVisible()
 
     await page.goto("/admin/tools")
     await expect(page.getByRole("heading", { name: adminToolsHeadingPattern })).toBeVisible()


### PR DESCRIPTION
## 관련 이슈

close #699

## 작업 배경

- Home Server CD live E2E가 `/admin/cloud`에서 업로드 버튼 2개를 동시에 매칭해 strict mode violation으로 실패했습니다.
- 제품 UI는 그대로 두고, live E2E가 현재 viewport에서 실제로 보이는 업로드 버튼 1개만 확인하도록 선택자를 좁혔습니다.

## 작업 내용

- `/admin/cloud` live E2E의 업로드 버튼 확인을 `aria-label` 후보 + `visible` 필터로 변경했습니다.
- responsive desktop/mobile 버튼이 동시에 DOM에 존재해도 visible 버튼 1개만 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `yarn --cwd front playwright:preflight`
  - `env PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/live.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `codex review --base origin/main --title "[Fix] 관리자 클라우드 live E2E 업로드 버튼 선택자 안정화"`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: live E2E가 확인하는 버튼 범위가 visible 업로드 버튼으로 좁아집니다. 실제 UI 동작은 변경하지 않습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 기존 선택자 검증으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
