### PR TITLE
[Fix] 관리자 클라우드 live E2E 업로드 진입점 존재 검증

### DIFF
--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -584,11 +584,10 @@ test.describe("live production e2e", () => {
 
     await page.goto("/admin/cloud")
     await expect(page.getByRole("heading", { name: adminCloudHeadingPattern })).toBeVisible()
-    const visibleCloudUploadButton = page
+    const visibleCloudUploadButtons = page
       .getByRole("button", { name: /^(파일 업로드|업로드 중)$/ })
       .filter({ visible: true })
-    await expect(visibleCloudUploadButton).toHaveCount(1)
-    await expect(visibleCloudUploadButton).toBeVisible()
+    await expect(visibleCloudUploadButtons.first()).toBeVisible()
 
     await page.goto("/admin/tools")
     await expect(page.getByRole("heading", { name: adminToolsHeadingPattern })).toBeVisible()


### PR DESCRIPTION
## 관련 이슈

close #701

## 작업 배경

- Home Server CD live E2E가 `/admin/cloud`에서 visible 업로드 버튼을 정확히 1개로 기대해 실패한 문제를 수정합니다.
- 실제 관리자 클라우드 화면에는 상단 툴바와 빈 상태 영역의 업로드 진입점이 함께 보일 수 있으므로, 테스트는 업로드 진입점 존재 여부만 검증하도록 정렬했습니다.

## 작업 내용

- `/admin/cloud` live E2E에서 visible 업로드 버튼 `toHaveCount(1)` 기대를 제거했습니다.
- `파일 업로드` 또는 `업로드 중` 버튼 중 첫 visible 진입점이 보이는지만 확인해 UI 구조와 테스트 계약을 맞췄습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `yarn --cwd front playwright:preflight`
  - `env PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/live.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `codex review --base origin/main --title "[Fix] 관리자 클라우드 live E2E 업로드 진입점 존재 검증"`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 업로드 버튼이 여러 개 보이는 정상 화면을 허용하므로 테스트가 특정 버튼 개수 회귀를 잡지 않습니다. 이 PR의 목적은 live 업로드 진입점 존재 검증입니다.
- 롤백 방법: `front/e2e/live.spec.ts`의 업로드 버튼 검증을 이전 `toHaveCount(1)` 방식으로 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
