### PR TITLE
[Fix] 에디터 live table affordance 검증 안정화

### DIFF
--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -860,14 +860,16 @@ test.describe("editor live visual regression", () => {
 
     await page.keyboard.press("Escape")
     await expect(tableMenu).toBeHidden()
-    await page.mouse.move(tableBox.x + tableBox.width - 3, tableBox.y + tableBox.height - 3)
 
+    await page.mouse.move(tableBox.x + tableBox.width - 3, tableBox.y + tableBox.height / 2)
     await expect(columnAddButton).toBeVisible()
+    const columnAddBarBox = await columnAddButton.boundingBox()
+
+    await page.mouse.move(tableBox.x + tableBox.width / 2, tableBox.y + tableBox.height - 3)
     await expect(rowAddButton).toBeVisible()
+    const rowAddBarBox = await rowAddButton.boundingBox()
 
     const viewport = page.viewportSize()
-    const addBarBoxes = await Promise.all([columnAddButton.boundingBox(), rowAddButton.boundingBox()])
-    const [columnAddBarBox, rowAddBarBox] = addBarBoxes
     expect(viewport).not.toBeNull()
     expect(columnAddBarBox).not.toBeNull()
     expect(rowAddBarBox).not.toBeNull()


### PR DESCRIPTION
## 관련 이슈

close #703

## 작업 배경

- Home Server CD run `27484538301`의 `/editor/new` live visual E2E가 table add affordance를 우하단 한 좌표에서 동시에 기대해 실패한 문제를 수정합니다.
- column add와 row add는 서로 다른 edge hover 조건에서 렌더링되므로, 테스트도 right edge와 bottom edge를 각각 hover한 직후 clipping bounds를 확인하도록 정렬했습니다.

## 작업 내용

- `column-add` affordance는 table 오른쪽 edge 중앙 hover 직후 visible과 bounding box를 확인합니다.
- `row-add` affordance는 table 아래 edge 중앙 hover 직후 visible과 bounding box를 확인합니다.
- 제품 코드, 백엔드, 배포 워크플로우는 변경하지 않았습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `yarn --cwd front playwright:preflight`
  - `env PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-live-visual.spec.ts --workers=1` (로컬 live 조건 없음으로 4 skipped)
  - `yarn --cwd front build`
  - `codex review --base origin/main --title "[Fix] 에디터 live table affordance 검증 안정화"`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: table add affordance가 동시에 보이는지를 더 이상 한 좌표에서 검증하지 않습니다. 대신 각 edge hover 조건에서 visible과 viewport clipping을 검증합니다.
- 롤백 방법: `front/e2e/editor-live-visual.spec.ts`의 add affordance hover 검증을 이전 우하단 단일 좌표 방식으로 되돌립니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
