### PR TITLE
[Fix] 507 live Markdown table locator

### DIFF
--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -440,9 +440,11 @@ test.describe("editor live visual regression", () => {
 
     await expectMarkdownEditorShell(page)
     const preview = page.getByTestId("github-markdown-preview-pane")
-    await expect(preview.locator("table")).toContainText(post507FinalTableTargetCell, { timeout: 30_000 })
-    await expect(preview.locator("table")).toContainText(post507FinalTableSelectAllNeedle)
-    await expect(preview.locator("pre")).toContainText(post507CodeText)
+    const finalReferenceTable = preview.locator("table").filter({ hasText: post507FinalTableTargetCell }).first()
+    const tokenCodeBlock = preview.locator("pre").filter({ hasText: post507CodeText }).first()
+    await expect(finalReferenceTable).toContainText(post507FinalTableTargetCell, { timeout: 30_000 })
+    await expect(finalReferenceTable).toContainText(post507FinalTableSelectAllNeedle)
+    await expect(tokenCodeBlock).toContainText(post507CodeText)
     await expect(preview.getByText(post507ListText)).toBeVisible()
 
     await focusMarkdownEditor(page)


### PR DESCRIPTION
## 관련 이슈

close #709

## 작업 배경

- #710 배포 후 live E2E에서 /editor/507 preview table locator가 3개 table을 동시에 잡아 strict mode로 실패했습니다.
- 507 canary의 최종 reference table/code block을 target text로 필터링해 실제 Markdown editor 검증만 남깁니다.

## 작업 내용

- `front/e2e/editor-live-visual.spec.ts`의 /editor/507 canary에서 `preview.locator("table")` 광범위 locator를 target text 기반 locator로 좁혔습니다.
- code block도 `post507CodeText` 기준으로 필터링해 다중 `pre` 문서에서도 안정적으로 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-live-visual.spec.ts --workers=1` (local secrets 없음으로 3 skipped, spec load 검증)
  - `yarn --cwd front lint`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: live secret 환경에서만 507 canary 본문 전체를 검증할 수 있습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
