### PR TITLE
[Fix] 507 live Markdown selection assertion

### DIFF
--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -447,11 +447,6 @@ test.describe("editor live visual regression", () => {
     await expect(tokenCodeBlock).toContainText(post507CodeText)
     await expect(preview.getByText(post507ListText)).toBeVisible()
 
-    await focusMarkdownEditor(page)
-    await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A")
-    await expect.poll(() => readEditorSelection(page)).toContain(post507FinalTableTargetCell)
-    await expect.poll(() => readEditorSelection(page)).toContain(post507CodeText)
-    await expect.poll(() => readEditorSelection(page)).toContain(post507ListText)
     await expect(page.locator("[data-table-affordance]")).toHaveCount(0)
   })
 })


### PR DESCRIPTION
## 관련 이슈

close #709

## 작업 배경

- #712 배포 후 live /editor/507 canary가 긴 CodeMirror 문서의 전체 선택 텍스트를 `window.getSelection()`으로 읽어 실패했습니다.
- 긴 문서에서는 viewport에 렌더된 상단 텍스트만 반환될 수 있으므로, 507 canary는 preview 하단 content와 legacy affordance 부재만 검증하도록 조정했습니다.

## 작업 내용

- `front/e2e/editor-live-visual.spec.ts`의 /editor/507 canary에서 긴 문서 전체 선택 polling assert를 제거했습니다.
- Cmd+A selection 검증은 작은 저장글 `/editor/[id]` 케이스에 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-live-visual.spec.ts --workers=1` (local secrets 없음으로 3 skipped, spec load 검증)
  - `yarn --cwd front lint`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: live secret 환경에서만 /editor/507 canary를 실제로 검증할 수 있습니다.
- 롤백 방법: 이 PR의 단일 commit을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
