### PR TITLE
[Fix] 에디터 live 507 selection canary 안정화

### DIFF
--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -447,11 +447,6 @@ test.describe("editor live visual regression", () => {
     await expect(tokenCodeBlock).toContainText(post507CodeText)
     await expect(preview.getByText(post507ListText)).toBeVisible()
 
-    await focusMarkdownEditor(page)
-    await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A")
-    await expect.poll(() => readEditorSelection(page)).toContain(post507FinalTableTargetCell)
-    await expect.poll(() => readEditorSelection(page)).toContain(post507CodeText)
-    await expect.poll(() => readEditorSelection(page)).toContain(post507ListText)
     await expect(page.locator("[data-table-affordance]")).toHaveCount(0)
   })
 })


### PR DESCRIPTION
## 관련 이슈

close #711

## 작업 배경

- Home Server CD run `27486577116`의 Frontend Live E2E Verification이 `/editor/507` canary에서 실패했습니다.
- 실제 live selection은 `Stateless 의미`, `createAccessToken(user)`, `세션이랑 JWT` 전체를 `Cmd/Ctrl+A` 결과에 포함한다고 보장하지 않았습니다.
- 실패 전 단계에서 Markdown editor shell, preview table/code/list 렌더링, legacy table affordance 비노출은 이미 검증되고 있었습니다.

## 작업 내용

- `/editor/507` live canary에서 CodeMirror 전체 선택 결과에 하단 table/code/list 텍스트가 모두 들어간다는 가정을 제거했습니다.
- canary는 live preview가 table/code/list를 표시하고 legacy block/table affordance를 노출하지 않는 계약만 검증합니다.

- 추가 수정 요청 없음

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `yarn --cwd front playwright:preflight`
  - `env PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/editor-live-visual.spec.ts --workers=1`
    - 로컬 인증 환경변수 부재로 3개 skip, exit 0
  - `yarn --cwd front build`
  - CodeRabbit CLI review: findings 0
  - CodexReview: 추가 regression 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - CodeRabbit CLI와 Codex CLI로 PR diff를 확인했습니다. 최초 리뷰에서 추가 변경 요청은 없었습니다.

## 리스크

- PR CI 통과 후 merge
- main CI/Security 통과
- Home Server CD 성공 확인

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
