### PR TITLE
[Fix] Live admin profile SSR session gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -607,6 +607,13 @@ jobs:
           remove_env_key "SPRING_SQL_INIT_CONTINUE_ON_ERROR" "deploy/homeserver/.env.prod"
           upsert_env_key "SPRING_SQL_INIT_MODE" "never" "deploy/homeserver/.env.prod"
 
+          # Live auth cookies must cover both www.aquilaxk.site and api.aquilaxk.site.
+          # HOME_SERVER_ENV can lag behind custom-domain changes, so pin the deployed
+          # prod site scope immediately before rollout.
+          upsert_env_key "CUSTOM_PROD_COOKIEDOMAIN" "aquilaxk.site" "deploy/homeserver/.env.prod"
+          upsert_env_key "CUSTOM_PROD_FRONTURL" "https://www.aquilaxk.site" "deploy/homeserver/.env.prod"
+          upsert_env_key "CUSTOM_PROD_BACKURL" "https://api.aquilaxk.site" "deploy/homeserver/.env.prod"
+
           if [ -z "${HOME_BACK_IMAGE:-}" ]; then
             echo "HOME_BACK_IMAGE is empty. abort deploy to avoid stale image rollout." >&2
             exit 1

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -272,6 +272,18 @@ test("deploy workflow validates HOME_SERVER_ENV before SSH deployment", () => {
   assert(workflow.lastIndexOf("rm -f deploy/homeserver/.external-minio-migration-stopped") < workflow.indexOf('DEPLOY_COMPLETED="true"'))
 })
 
+test("deploy workflow pins production site cookie scope to the live custom domain before rollout", () => {
+  const workflow = readFileSync(workflowPath, "utf8")
+
+  assert.match(workflow, /upsert_env_key "CUSTOM_PROD_COOKIEDOMAIN" "aquilaxk\.site" "deploy\/homeserver\/\.env\.prod"/)
+  assert.match(workflow, /upsert_env_key "CUSTOM_PROD_FRONTURL" "https:\/\/www\.aquilaxk\.site" "deploy\/homeserver\/\.env\.prod"/)
+  assert.match(workflow, /upsert_env_key "CUSTOM_PROD_BACKURL" "https:\/\/api\.aquilaxk\.site" "deploy\/homeserver\/\.env\.prod"/)
+  assert(
+    workflow.indexOf('upsert_env_key "CUSTOM_PROD_COOKIEDOMAIN"') <
+      workflow.indexOf('require_nonempty_env_key "CF_TUNNEL_TOKEN"'),
+  )
+})
+
 test("required secret check does not inject multi-line HOME_SERVER_ENV into shell", () => {
   const workflow = readFileSync(workflowPath, "utf8")
 


### PR DESCRIPTION
## 관련 이슈

close #715

## 작업 배경

- Deploy to Home Server live E2E에서 Markdown editor canary 3개는 통과했지만, 후속 live smoke가 /admin/profile에서 로그인 페이지로 리다이렉트되어 실패했습니다.
- 실패 run: https://github.com/AquilaXk/aquila-blog/actions/runs/27487063649

## 작업 내용

- 배포 직전 .env.prod에 live custom domain 쿠키 스코프를 고정합니다.
- HOME_SERVER_ENV가 과거 도메인 값을 들고 있어도 CUSTOM_PROD_COOKIEDOMAIN/FRONTURL/BACKURL을 aquilaxk.site 실서비스 도메인으로 보정합니다.
- env contract 테스트로 재발을 막습니다.

## 검증

- 실행한 명령과 결과:
  - node --test tools/test/env-contract.test.mjs
  - bash tools/test/verify-deploy-workflow-classification.sh
  - yarn --cwd front lint
  - yarn --cwd front build

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 특이사항 없음

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
