### PR TITLE
[Fix] Live admin protected route smoke isolation

### DIFF
--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -486,6 +486,47 @@ const loginThroughUi = async (
   throw new Error(`UI login failed after retries. last=${lastFailure}`)
 }
 
+const authenticateLiveAdmin = async (page: Page, apiBaseUrl: string) => {
+  if (hasUiLoginCredentials) {
+    await loginThroughUi(page, apiBaseUrl, adminEmail, adminLegacyLoginId, adminPassword)
+    return
+  }
+
+  await loginWithRetry(page, apiBaseUrl, adminEmail, adminLegacyLoginId, adminPassword)
+}
+
+const isVisibleLoginPage = async (page: Page) => {
+  if (/\/login(\/|$|\?)/.test(page.url())) return true
+  return page.getByRole("heading", { name: "로그인" }).isVisible().catch(() => false)
+}
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
+const expectLiveAdminRoute = async (
+  page: Page,
+  apiBaseUrl: string,
+  path: string,
+  headingPattern: RegExp,
+  label: string
+) => {
+  const routePattern = new RegExp(`${escapeRegExp(path)}(?:/?(?:$|[?#]))`)
+
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    await page.goto(path)
+
+    if (await isVisibleLoginPage(page)) {
+      await authenticateLiveAdmin(page, apiBaseUrl)
+      continue
+    }
+
+    await expect(page, `${label} route url`).toHaveURL(routePattern, { timeout: 20_000 })
+    await expect(page.getByRole("heading", { name: headingPattern }), `${label} heading`).toBeVisible()
+    return
+  }
+
+  throw new Error(`${label} route redirected to login after re-authentication: ${page.url()}`)
+}
+
 test.describe("live critical error filter", () => {
   test("WebKit Next data prefetch access-control noise는 critical error에서 제외한다", () => {
     expect(
@@ -552,18 +593,11 @@ test.describe("live production e2e", () => {
 
     const apiBaseUrl = resolveApiBaseUrl(page.url())
     await waitForApiReachability(page, apiBaseUrl)
-    if (hasUiLoginCredentials) {
-      await loginThroughUi(page, apiBaseUrl, adminEmail, adminLegacyLoginId, adminPassword)
-    } else {
-      await loginWithRetry(page, apiBaseUrl, adminEmail, adminLegacyLoginId, adminPassword)
-    }
+    await authenticateLiveAdmin(page, apiBaseUrl)
 
-    await page.goto("/admin")
-    await expect(page).toHaveURL(/\/admin(\/|$)/, { timeout: 20_000 })
-    await expect(page.getByRole("heading", { name: adminLandingHeadingPattern })).toBeVisible()
+    await expectLiveAdminRoute(page, apiBaseUrl, "/admin", adminLandingHeadingPattern, "admin landing")
 
-    await page.goto("/admin/profile")
-    await expect(page.getByRole("heading", { name: adminProfileHeadingPattern })).toBeVisible()
+    await expectLiveAdminRoute(page, apiBaseUrl, "/admin/profile", adminProfileHeadingPattern, "admin profile")
     const profileImage = page.locator("main img").first()
     await expect(profileImage).toBeVisible()
     await expect
@@ -575,26 +609,22 @@ test.describe("live production e2e", () => {
       })
       .toBeTruthy()
 
-    await page.goto("/admin/dashboard")
-    await expect(page.getByRole("heading", { name: adminDashboardHeadingPattern })).toBeVisible()
+    await expectLiveAdminRoute(page, apiBaseUrl, "/admin/dashboard", adminDashboardHeadingPattern, "admin dashboard")
     const dashboardKpiRail = page.locator('[data-ui="monitoring-service-rail"]')
     await expect(dashboardKpiRail).toBeVisible()
     await expect(dashboardKpiRail.getByText("서비스 상태")).toBeVisible()
     await expect(page.getByRole("heading", { name: "우선 점검 항목" })).toBeVisible()
 
-    await page.goto("/admin/cloud")
-    await expect(page.getByRole("heading", { name: adminCloudHeadingPattern })).toBeVisible()
+    await expectLiveAdminRoute(page, apiBaseUrl, "/admin/cloud", adminCloudHeadingPattern, "admin cloud")
     const visibleCloudUploadButtons = page
       .getByRole("button", { name: /^(파일 업로드|업로드 중)$/ })
       .filter({ visible: true })
     await expect(visibleCloudUploadButtons.first()).toBeVisible()
 
-    await page.goto("/admin/tools")
-    await expect(page.getByRole("heading", { name: adminToolsHeadingPattern })).toBeVisible()
+    await expectLiveAdminRoute(page, apiBaseUrl, "/admin/tools", adminToolsHeadingPattern, "admin tools")
     await expect(page.getByRole("tab", { name: /^작업 큐 진단/ })).toBeVisible()
 
-    await page.goto("/admin/posts")
-    await expect(page.getByRole("heading", { name: adminPostsHeadingPattern })).toBeVisible()
+    await expectLiveAdminRoute(page, apiBaseUrl, "/admin/posts", adminPostsHeadingPattern, "admin posts")
     const titleInput = page.locator("#post-title").first()
     const legacyTitleInput = page.getByPlaceholder("제목을 입력하세요").first()
     await openAdminNewPostEntry(page)


### PR DESCRIPTION
## 관련 이슈

close #717

## 작업 배경

- Deploy run 27487552182에서 `/admin/profile` 이후 `/admin/dashboard`가 `/login?next=%2Fadmin%2Fdashboard`로 리다이렉트되어 live smoke가 실패했습니다.
- live admin smoke를 보호 라우트별 인증 확인 helper로 분리해, 각 route가 로그인으로 튕길 때 한 번 재인증하고 그래도 실패하면 해당 route 이름으로 실패하도록 했습니다.

## 작업 내용

- `/admin`, `/admin/profile`, `/admin/dashboard`, `/admin/cloud`, `/admin/tools`, `/admin/posts` 진입을 공통 helper로 통합했습니다.
- 보호 라우트 진입 후 로그인 화면이 보이면 UI/API 로그인 경로를 재사용해 한 번 재인증한 뒤 route별 heading을 확인합니다.
- 긴 admin smoke 안에서 세션 상태 실패가 다음 검증으로 번지지 않고 route 단위로 드러나도록 했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright:preflight`
  - `git diff --check`
  - Deploy failure evidence: `Deploy to Home Server` run `27487552182`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: live smoke가 보호 라우트별로 재인증을 수행하면서 실제 인증/쿠키 문제가 더 명확히 실패로 드러날 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 기존 live smoke 흐름으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
