### PR TITLE
[Fix] Live editor write smoke Markdown contract

### DIFF
--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -166,102 +166,39 @@ const openAdminNewPostEntry = async (page: Page) => {
   throw new Error("관리자 글 작업 공간에서 '새 글 작성' CTA를 찾지 못했습니다.")
 }
 
-const appendTextToBlockEditor = async (page: Page, text: string) => {
-  const blockEditor = page.locator(".aq-block-editor__content[contenteditable='true']").first()
-  await expect(blockEditor).toBeVisible()
-  await expect(blockEditor).toHaveAttribute("contenteditable", "true")
-  await blockEditor.click({ position: { x: 24, y: 24 } })
-  await expect
-    .poll(async () => {
-      return blockEditor.evaluate((node) => {
-        if (!(node instanceof HTMLElement)) return false
-        const active = document.activeElement
-        return active === node || !!active?.closest(".aq-block-editor__content[contenteditable='true']")
-      })
-    })
-    .toBe(true)
-
-  await blockEditor.evaluate((node) => {
-    if (!(node instanceof HTMLElement)) return
-    node.focus()
-    const selection = window.getSelection()
-    if (!selection) return
-    const range = document.createRange()
-
-    const textWalker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT)
-    let lastTextNode: Text | null = null
-    while (textWalker.nextNode()) {
-      const candidate = textWalker.currentNode
-      if (candidate instanceof Text) {
-        lastTextNode = candidate
-      }
-    }
-
-    if (lastTextNode) {
-      range.setStart(lastTextNode, lastTextNode.textContent?.length ?? 0)
-    } else {
-      const fallbackBlock = node.querySelector("p, li, h1, h2, h3, h4, blockquote, pre") ?? node
-      range.selectNodeContents(fallbackBlock)
-    }
-    range.collapse(false)
-    selection.removeAllRanges()
-    selection.addRange(range)
-  })
-
-  await page.keyboard.type(text)
-  await expect
-    .poll(async () => {
-      return blockEditor.evaluate((node) => {
-        if (!(node instanceof HTMLElement)) return ""
-        return (node.textContent || "").trim()
-      })
-    })
-    .toContain(text)
-
-  return blockEditor
-}
-
-const liveHoverWheelTableMarkdown = [
+const liveEditorSmokeMarkdown = [
+  "라이브 E2E 편집 확인",
+  "",
+  "```ts",
+  "const liveHoverWheel = true",
+  "```",
+  "",
   "| A | B | C | D | E | F | G |",
   "| --- | --- | --- | --- | --- | --- | --- |",
   "| 1 | 2 | 3 | 4 | 5 | 6 | 7 |",
   "| aa | bb | cc | dd | ee | ff | gg |",
 ].join("\n")
 
-const pasteMarkdownIntoBlockEditor = async (blockEditor: Locator, markdown: string) => {
-  await blockEditor.evaluate((element, payload) => {
-    const data = new DataTransfer()
-    data.setData("text/plain", payload)
-    const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true })
-    Object.defineProperty(event, "clipboardData", { value: data })
-    element.dispatchEvent(event)
-  }, markdown)
-}
+const appendMarkdownToGitHubEditor = async (page: Page, markdown: string) => {
+  const editorRoot = page.getByTestId("github-markdown-editor")
+  const writePane = page.getByTestId("github-markdown-write-pane")
+  const previewPane = page.getByTestId("github-markdown-preview-pane")
+  const editorContent = writePane.locator(".cm-content").first()
 
-const ensureLiveHoverWheelFixture = async (page: Page, blockEditor: Locator) => {
-  await blockEditor.click({ position: { x: 24, y: 24 } })
-  await page.keyboard.press("Enter")
+  await expect(editorRoot).toBeVisible()
+  await expect(writePane).toBeVisible()
+  await expect(previewPane).toBeVisible()
+  await expect(editorContent).toBeVisible()
 
-  const codeButton = page.getByRole("button", { name: "코드", exact: true }).first()
-  if (await codeButton.isVisible().catch(() => false)) {
-    await codeButton.click()
-  } else {
-    await page.keyboard.type("/코드")
-    await page.keyboard.press("Enter")
-  }
+  await editorContent.click()
+  await page.keyboard.press(process.platform === "darwin" ? "Meta+End" : "Control+End")
+  await page.keyboard.insertText(`\n\n${markdown}`)
 
-  await expect(page.locator("[data-code-block-wrapper='true']").first()).toBeVisible()
-  await expect(page.locator(".aq-code-shell").first()).toBeVisible()
-  await page.keyboard.type("const liveHoverWheel = true")
+  await expect(editorContent).toContainText("라이브 E2E 편집 확인")
+  await expect(previewPane.locator("pre").first()).toContainText("const liveHoverWheel = true")
+  await expect(previewPane.locator("table").first()).toContainText("aa")
 
-  const tableButton = page.getByRole("button", { name: "테이블", exact: true }).first()
-  if (await tableButton.isVisible().catch(() => false)) {
-    await tableButton.click()
-  } else {
-    await pasteMarkdownIntoBlockEditor(blockEditor, liveHoverWheelTableMarkdown)
-  }
-
-  await expect(page.locator(".aq-block-editor__content .tableWrapper").first()).toBeVisible()
+  return previewPane
 }
 
 const readDocumentScrollTop = (page: Page) =>
@@ -300,18 +237,13 @@ const expectHoverWheelChainsToPageScroll = async (page: Page, target: Locator, l
   await expect.poll(() => readDocumentScrollTop(page)).toBeGreaterThan(beforeScrollTop + 80)
 }
 
-const expectLiveEditorHoverWheelScrollChain = async (page: Page, blockEditor: Locator) => {
-  await ensureLiveHoverWheelFixture(page, blockEditor)
+const expectLiveEditorHoverWheelScrollChain = async (page: Page, previewPane: Locator) => {
   await expectHoverWheelChainsToPageScroll(
     page,
-    page.locator("[data-code-block-wrapper='true']").first(),
+    previewPane.locator("pre").first(),
     "live code block"
   )
-  await expectHoverWheelChainsToPageScroll(
-    page,
-    page.locator(".aq-block-editor__content .tableWrapper").first(),
-    "live table wrapper"
-  )
+  await expectHoverWheelChainsToPageScroll(page, previewPane.locator("table").first(), "live table")
 }
 
 
@@ -635,8 +567,8 @@ test.describe("live production e2e", () => {
     } else {
       await expect(legacyTitleInput).toBeVisible()
     }
-    const blockEditor = await appendTextToBlockEditor(page, "라이브 E2E 편집 확인")
-    await expectLiveEditorHoverWheelScrollChain(page, blockEditor)
+    const previewPane = await appendMarkdownToGitHubEditor(page, liveEditorSmokeMarkdown)
+    await expectLiveEditorHoverWheelScrollChain(page, previewPane)
 
     await page.getByRole("button", { name: "Logout", exact: true }).click()
     await expect(page).toHaveURL(/\/login/)


### PR DESCRIPTION
## 관련 이슈

close #720

## 작업 배경

- Deploy run `27489311658`에서 `/editor/507` canary는 통과했지만, live 새 글 작성 smoke가 제거된 legacy block editor selector를 기다리며 실패했습니다.
- live smoke helper를 현재 GitHub Markdown editor 계약으로 전환해 CodeMirror write pane에 Markdown을 입력하고 split preview의 code/table 렌더링을 검증하게 했습니다.

## 작업 내용

- `.aq-block-editor__content`, `data-code-block-wrapper`, `.tableWrapper` 기반 live helper를 제거했습니다.
- `github-markdown-write-pane`의 CodeMirror `.cm-content`에 일반 문장, fenced code, Markdown table을 입력합니다.
- wheel-chain 검증 대상도 legacy block editor DOM이 아니라 Markdown preview의 `pre`/`table` 렌더 결과로 전환했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright:preflight`
  - `git diff --check`
  - Deploy failure evidence: `Deploy to Home Server` run `27489311658`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: live smoke가 현재 Markdown editor 계약에 더 정확히 맞춰져, 실제 editor regression이 있으면 즉시 배포를 차단합니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 이전 live smoke로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
