### PR TITLE
[Fix] 관리자 프로필 이미지 fallback 복구

### DIFF
--- a/front/e2e/admin-profile-state.spec.ts
+++ b/front/e2e/admin-profile-state.spec.ts
@@ -67,6 +67,35 @@ test.describe("admin profile state contract", () => {
     expect(layoutSource).not.toContain("export const LinkRowCard = styled.div")
   })
 
+  test("프로필 이미지는 저장된 URL 로드 실패 시 기본 이미지를 한 번만 fallback 한다", () => {
+    const profileImageSource = readFileSync(
+      path.resolve(__dirname, "../src/components/ProfileImage.tsx"),
+      "utf8"
+    )
+    const identitySource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/AdminProfileWorkspaceIdentitySection.tsx"),
+      "utf8"
+    )
+    const previewSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/AdminProfilePreviewRail.tsx"),
+      "utf8"
+    )
+
+    expect(profileImageSource).not.toContain('import { CONFIG } from "site.config"')
+    expect(profileImageSource).toContain("fallbackSrc,")
+    expect(profileImageSource).toContain("const requestedSrc = src || fallbackSrc")
+    expect(profileImageSource).toContain("const [resolvedSrc, setResolvedSrc] = React.useState(requestedSrc)")
+    expect(profileImageSource).toContain("const fallbackAttemptSourceRef = React.useRef<string | undefined>(undefined)")
+    expect(profileImageSource).toContain("fallbackAttemptSourceRef.current = undefined")
+    expect(profileImageSource).toContain("setResolvedSrc(requestedSrc)")
+    expect(profileImageSource).toContain("}, [requestedSrc])")
+    expect(profileImageSource).toContain("fallbackAttemptSourceRef.current === requestedSrc")
+    expect(profileImageSource).toContain("fallbackAttemptSourceRef.current = requestedSrc")
+    expect(profileImageSource).toContain("setResolvedSrc(fallbackSrc)")
+    expect(identitySource).toContain("fallbackSrc={CONFIG.profile.image}")
+    expect(previewSource).toContain("fallbackSrc={CONFIG.profile.image}")
+  })
+
   test("profile 작업공간은 공통 section nav/action dock primitive 위에서 반응형 분기를 유지한다", () => {
     const sectionSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/AdminProfileWorkspaceSections.tsx"),

--- a/front/e2e/admin-profile-state.spec.ts
+++ b/front/e2e/admin-profile-state.spec.ts
@@ -92,8 +92,12 @@ test.describe("admin profile state contract", () => {
     expect(profileImageSource).toContain("fallbackAttemptSourceRef.current === requestedSrc")
     expect(profileImageSource).toContain("fallbackAttemptSourceRef.current = requestedSrc")
     expect(profileImageSource).toContain("setResolvedSrc(fallbackSrc)")
+    expect(identitySource).toContain("src={draft.profileImageUrl || undefined}")
     expect(identitySource).toContain("fallbackSrc={CONFIG.profile.image}")
+    expect(identitySource).not.toContain("<AvatarFallback>")
+    expect(previewSource).toContain("src={previewContent.profileImageUrl || undefined}")
     expect(previewSource).toContain("fallbackSrc={CONFIG.profile.image}")
+    expect(previewSource).not.toContain("<AvatarFallback>")
   })
 
   test("profile 작업공간은 공통 section nav/action dock primitive 위에서 반응형 분기를 유지한다", () => {

--- a/front/src/components/ProfileImage.tsx
+++ b/front/src/components/ProfileImage.tsx
@@ -2,25 +2,50 @@
 import React from "react"
 
 type Props = React.ImgHTMLAttributes<HTMLImageElement> & {
+  fallbackSrc?: string
   fillContainer?: boolean
   priority?: boolean
 }
 
 const ProfileImage: React.FC<Props> = ({
+  fallbackSrc,
   fillContainer = false,
   priority = false,
   loading,
   alt,
+  onError,
+  src,
   style,
   ...props
 }) => {
+  const requestedSrc = src || fallbackSrc
+  const [resolvedSrc, setResolvedSrc] = React.useState(requestedSrc)
+  const fallbackAttemptSourceRef = React.useRef<string | undefined>(undefined)
+
+  React.useEffect(() => {
+    fallbackAttemptSourceRef.current = undefined
+    setResolvedSrc(requestedSrc)
+  }, [requestedSrc])
+
+  const handleImageError: React.ReactEventHandler<HTMLImageElement> = (event) => {
+    onError?.(event)
+
+    if (!fallbackSrc || fallbackAttemptSourceRef.current === requestedSrc) return
+
+    // Keep persisted broken profile URLs from leaving the UI with alt text only.
+    fallbackAttemptSourceRef.current = requestedSrc
+    setResolvedSrc(fallbackSrc)
+  }
+
   return (
     <img
       alt={alt}
+      src={resolvedSrc}
       loading={loading || (priority ? "eager" : "lazy")}
       {...({ fetchpriority: priority ? "high" : "auto" } as Record<string, string>)}
       decoding={priority ? "sync" : "async"}
       draggable={false}
+      onError={handleImageError}
       style={{
         display: "block",
         objectFit: "cover",

--- a/front/src/routes/Admin/AdminProfilePreviewRail.tsx
+++ b/front/src/routes/Admin/AdminProfilePreviewRail.tsx
@@ -3,7 +3,6 @@ import ProfileImage from "src/components/ProfileImage"
 import { CONFIG } from "site.config"
 import type { ProfileWorkspaceContent } from "src/libs/profileWorkspace"
 import {
-  AvatarFallback,
   PreviewAboutCard,
   PreviewBody,
   PreviewCardShell,
@@ -24,7 +23,6 @@ export type AdminProfilePreviewRailProps = {
   activeSection: WorkspaceSectionId
   activeSectionLabel: string
   displayName: string
-  displayNameInitial: string
   hasMissingExposureItems: boolean
   isPreviewExpanded: boolean
   onPreviewModeChange: (mode: PreviewMode) => void
@@ -37,7 +35,6 @@ export default function AdminProfilePreviewRail({
   activeSection,
   activeSectionLabel,
   displayName,
-  displayNameInitial,
   hasMissingExposureItems,
   isPreviewExpanded,
   onPreviewModeChange,
@@ -81,18 +78,14 @@ export default function AdminProfilePreviewRail({
               <PreviewProfileCard>
                 <div className="identityRow">
                   <div className="avatar">
-                    {previewContent.profileImageUrl ? (
-                      <ProfileImage
-                        src={previewContent.profileImageUrl}
-                        fallbackSrc={CONFIG.profile.image}
-                        alt={displayName}
-                        width={72}
-                        height={72}
-                        priority
-                      />
-                    ) : (
-                      <AvatarFallback>{displayNameInitial}</AvatarFallback>
-                    )}
+                    <ProfileImage
+                      src={previewContent.profileImageUrl || undefined}
+                      fallbackSrc={CONFIG.profile.image}
+                      alt={displayName}
+                      width={72}
+                      height={72}
+                      priority
+                    />
                   </div>
                   <div className="identityCopy">
                     <strong>{displayName}</strong>

--- a/front/src/routes/Admin/AdminProfilePreviewRail.tsx
+++ b/front/src/routes/Admin/AdminProfilePreviewRail.tsx
@@ -1,5 +1,6 @@
 import AppIcon from "src/components/icons/AppIcon"
 import ProfileImage from "src/components/ProfileImage"
+import { CONFIG } from "site.config"
 import type { ProfileWorkspaceContent } from "src/libs/profileWorkspace"
 import {
   AvatarFallback,
@@ -83,6 +84,7 @@ export default function AdminProfilePreviewRail({
                     {previewContent.profileImageUrl ? (
                       <ProfileImage
                         src={previewContent.profileImageUrl}
+                        fallbackSrc={CONFIG.profile.image}
                         alt={displayName}
                         width={72}
                         height={72}

--- a/front/src/routes/Admin/AdminProfileWorkspaceIdentitySection.tsx
+++ b/front/src/routes/Admin/AdminProfileWorkspaceIdentitySection.tsx
@@ -1,4 +1,5 @@
 import ProfileImage from "src/components/ProfileImage"
+import { CONFIG } from "site.config"
 import type { ProfileWorkspaceContent } from "src/libs/profileWorkspace"
 import {
   AvatarFallback,
@@ -32,7 +33,14 @@ export const renderAdminProfileIdentitySection = (props: Record<string, any>) =>
       <AvatarWorkspaceCard>
         <div className="avatarPreview">
           {draft.profileImageUrl ? (
-            <ProfileImage src={draft.profileImageUrl} alt={displayName} width={88} height={88} priority />
+            <ProfileImage
+              src={draft.profileImageUrl}
+              fallbackSrc={CONFIG.profile.image}
+              alt={displayName}
+              width={88}
+              height={88}
+              priority
+            />
           ) : (
             <AvatarFallback>{displayNameInitial}</AvatarFallback>
           )}

--- a/front/src/routes/Admin/AdminProfileWorkspaceIdentitySection.tsx
+++ b/front/src/routes/Admin/AdminProfileWorkspaceIdentitySection.tsx
@@ -2,7 +2,6 @@ import ProfileImage from "src/components/ProfileImage"
 import { CONFIG } from "site.config"
 import type { ProfileWorkspaceContent } from "src/libs/profileWorkspace"
 import {
-  AvatarFallback,
   AvatarWorkspaceCard,
   FieldBox,
   FieldGrid,
@@ -26,24 +25,19 @@ export const renderAdminProfileIdentitySection = (props: Record<string, any>) =>
     updateDraft,
   } = props as Record<string, any> & { draft: ProfileWorkspaceContent }
   const displayName = displayNameInput.trim() || sessionMember?.nickname || sessionMember?.username || "관리자"
-  const displayNameInitial = displayName.slice(0, 2).toUpperCase()
 
   return (
     <SectionStack>
       <AvatarWorkspaceCard>
         <div className="avatarPreview">
-          {draft.profileImageUrl ? (
-            <ProfileImage
-              src={draft.profileImageUrl}
-              fallbackSrc={CONFIG.profile.image}
-              alt={displayName}
-              width={88}
-              height={88}
-              priority
-            />
-          ) : (
-            <AvatarFallback>{displayNameInitial}</AvatarFallback>
-          )}
+          <ProfileImage
+            src={draft.profileImageUrl || undefined}
+            fallbackSrc={CONFIG.profile.image}
+            alt={displayName}
+            width={88}
+            height={88}
+            priority
+          />
         </div>
         <div className="avatarMeta">
           <strong>{displayName}</strong>

--- a/front/src/routes/Admin/AdminProfileWorkspaceSections.tsx
+++ b/front/src/routes/Admin/AdminProfileWorkspaceSections.tsx
@@ -73,7 +73,6 @@ export const AdminProfileWorkspaceSections = (props: Record<string, any>) => {
     publishedSnapshot: ProfileWorkspaceContent
   }
   const displayName = displayNameInput.trim() || sessionMember.nickname || sessionMember.username || "관리자"
-  const displayNameInitial = displayName.slice(0, 2).toUpperCase()
   const previewContent = previewMode === "published" ? publishedSnapshot : draft
   const missingExposureItems: string[] = []
   if (!displayNameInput.trim()) missingExposureItems.push("계정 이름")
@@ -158,7 +157,6 @@ export const AdminProfileWorkspaceSections = (props: Record<string, any>) => {
           activeSection={activeSection}
           activeSectionLabel={activeSectionMeta.label}
           displayName={displayName}
-          displayNameInitial={displayNameInitial}
           hasMissingExposureItems={hasMissingExposureItems}
           isPreviewExpanded={isPreviewExpanded}
           onPreviewModeChange={setPreviewMode}


### PR DESCRIPTION
## 관련 이슈

close #722

## 작업 배경

- Home Server CD live E2E가 `/admin/profile`에서 깨진 저장 프로필 이미지 때문에 실패하던 문제를 복구합니다.
- 공통 `ProfileImage`에 opt-in fallback을 추가하고, 관리자 프로필 편집/미리보기 영역만 기본 프로필 이미지로 대체되도록 연결했습니다.
- CodeRabbit 지적을 반영해 빈 프로필 이미지 URL도 동일한 `ProfileImage` fallback 경로를 타도록 정리했습니다.

## 작업 내용

- `ProfileImage`가 `fallbackSrc`를 받은 경우에만 이미지 로드 실패 시 fallback 이미지를 한 번 시도합니다.
- 관리자 프로필 identity 편집 카드와 preview rail에서 `CONFIG.profile.image`를 fallback으로 사용합니다.
- 빈 URL 분기에서도 initials fallback으로 우회하지 않고 `src={... || undefined}`로 기본 이미지 fallback을 렌더링합니다.
- 게시글 썸네일 등 다른 이미지 사용처에 기본 프로필 이미지가 섞이지 않도록 전역 fallback은 적용하지 않았습니다.
- 한글 display name의 Playwright 계약 테스트로 fallback 구조를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`
  - `yarn --cwd front lint`
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front playwright test e2e/admin-profile-state.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `coderabbit review --agent --base origin/main`
  - `codex review --base origin/main --title "[Fix] 관리자 프로필 이미지 fallback 복구"`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: fallback 대상이 관리자 프로필 이미지 영역으로 제한되어 있어 영향 범위는 낮습니다. 기본 fallback SVG까지 깨진 경우에는 기존처럼 이미지 로드 실패가 남습니다.
- 롤백 방법: 이 PR의 merge commit을 revert하면 기존 `ProfileImage` 동작과 관리자 프로필 렌더링으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
