### PR TITLE
[Fix] Markdown 에디터 작성/미리보기 시각 회귀

### DIFF
--- a/front/e2e/editor-authoring-markdown-editor.spec.ts
+++ b/front/e2e/editor-authoring-markdown-editor.spec.ts
@@ -135,6 +135,65 @@ test.describe("GitHub Markdown editor replacement", () => {
     await expect(preview.getByText("quote at the bottom")).toBeVisible()
   })
 
+  test("write pane keeps every CodeMirror surface on the dark editor surface", async ({ page }) => {
+    await routeAuthenticatedEditor(page)
+
+    await page.goto("/editor/new?source=local-draft")
+
+    const styles = await page.getByTestId("github-markdown-write-pane").evaluate((pane) => {
+      const readStyle = (selector: string) => {
+        const element = pane.querySelector(selector)
+        if (!element) throw new Error(`${selector} not found`)
+        const style = window.getComputedStyle(element)
+        return {
+          backgroundColor: style.backgroundColor,
+          color: style.color,
+        }
+      }
+
+      return {
+        editor: readStyle(".cm-editor"),
+        scroller: readStyle(".cm-scroller"),
+        content: readStyle(".cm-content"),
+        line: readStyle(".cm-line"),
+        gutters: readStyle(".cm-gutters"),
+      }
+    })
+
+    expect(styles.editor.backgroundColor).toBe("rgb(13, 17, 23)")
+    expect(styles.scroller.backgroundColor).toBe("rgb(13, 17, 23)")
+    expect(styles.content.backgroundColor).toBe("rgb(13, 17, 23)")
+    expect(styles.gutters.backgroundColor).toBe("rgb(13, 17, 23)")
+    expect(styles.line.color).toBe("rgb(230, 237, 243)")
+  })
+
+  test("split preview uses the same readable width and typography contract as post detail", async ({
+    page,
+  }) => {
+    await routeAuthenticatedEditor(page)
+
+    await page.goto("/editor/new?source=local-draft")
+
+    const previewContract = await page
+      .getByTestId("github-markdown-preview-pane")
+      .locator(".aq-markdown")
+      .evaluate((markdownRoot) => {
+        const style = window.getComputedStyle(markdownRoot)
+        const rect = markdownRoot.getBoundingClientRect()
+        return {
+          maxWidth: style.maxWidth,
+          fontSize: style.fontSize,
+          lineHeight: style.lineHeight,
+          renderedWidth: rect.width,
+        }
+      })
+
+    expect(previewContract.maxWidth).toBe("768px")
+    expect(previewContract.fontSize).toBe("17px")
+    expect(previewContract.lineHeight).toBe("28px")
+    expect(previewContract.renderedWidth).toBeLessThanOrEqual(768)
+  })
+
   test("toolbar snippets insert at the CodeMirror caret instead of appending at the document end", async ({
     page,
   }) => {

--- a/front/e2e/editor-authoring-markdown-editor.spec.ts
+++ b/front/e2e/editor-authoring-markdown-editor.spec.ts
@@ -136,7 +136,16 @@ test.describe("GitHub Markdown editor replacement", () => {
   })
 
   test("write pane keeps every CodeMirror surface on the dark editor surface", async ({ page }) => {
-    await routeAuthenticatedEditor(page)
+    await routeAuthenticatedEditor(
+      page,
+      [
+        "# Token Highlight",
+        "",
+        "[link](https://example.com) and `inline code`",
+        "",
+        "> quoted text",
+      ].join("\n")
+    )
 
     await page.goto("/editor/new?source=local-draft")
 
@@ -156,6 +165,9 @@ test.describe("GitHub Markdown editor replacement", () => {
         scroller: readStyle(".cm-scroller"),
         content: readStyle(".cm-content"),
         line: readStyle(".cm-line"),
+        tokenColors: Array.from(pane.querySelectorAll(".cm-line span"))
+          .map((span) => window.getComputedStyle(span).color)
+          .filter((color, index, colors) => colors.indexOf(color) === index),
         gutters: readStyle(".cm-gutters"),
       }
     })
@@ -165,6 +177,8 @@ test.describe("GitHub Markdown editor replacement", () => {
     expect(styles.content.backgroundColor).toBe("rgb(13, 17, 23)")
     expect(styles.gutters.backgroundColor).toBe("rgb(13, 17, 23)")
     expect(styles.line.color).toBe("rgb(230, 237, 243)")
+    expect(styles.tokenColors).toContain("rgb(121, 192, 255)")
+    expect(styles.tokenColors).not.toEqual(["rgb(230, 237, 243)"])
   })
 
   test("split preview uses the same readable width and typography contract as post detail", async ({
@@ -176,11 +190,16 @@ test.describe("GitHub Markdown editor replacement", () => {
 
     const previewContract = await page
       .getByTestId("github-markdown-preview-pane")
-      .locator(".aq-markdown")
-      .evaluate((markdownRoot) => {
+      .locator("article")
+      .evaluate((article) => {
+        const markdownRoot = article.querySelector(".aq-markdown")
+        if (!(markdownRoot instanceof HTMLElement)) throw new Error("preview markdown root not found")
+        const articleStyle = window.getComputedStyle(article)
         const style = window.getComputedStyle(markdownRoot)
         const rect = markdownRoot.getBoundingClientRect()
         return {
+          paddingLeft: articleStyle.paddingLeft,
+          paddingRight: articleStyle.paddingRight,
           maxWidth: style.maxWidth,
           fontSize: style.fontSize,
           lineHeight: style.lineHeight,
@@ -188,6 +207,8 @@ test.describe("GitHub Markdown editor replacement", () => {
         }
       })
 
+    expect(previewContract.paddingLeft).toBe("16px")
+    expect(previewContract.paddingRight).toBe("16px")
     expect(previewContract.maxWidth).toBe("768px")
     expect(previewContract.fontSize).toBe("17px")
     expect(previewContract.lineHeight).toBe("28px")

--- a/front/e2e/editor-authoring-markdown-editor.spec.ts
+++ b/front/e2e/editor-authoring-markdown-editor.spec.ts
@@ -194,6 +194,37 @@ test.describe("GitHub Markdown editor replacement", () => {
     expect(previewContract.renderedWidth).toBeLessThanOrEqual(768)
   })
 
+  test("narrow split mode keeps the write pane primary and shows detail preview through the Preview tab", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 760, height: 900 })
+    await routeAuthenticatedEditor(page)
+
+    await page.goto("/editor/new?source=local-draft")
+
+    const writePane = page.getByTestId("github-markdown-write-pane")
+    const previewPane = page.getByTestId("github-markdown-preview-pane")
+
+    await expect(writePane).toBeVisible()
+    await expect(previewPane).toBeHidden()
+
+    await page.getByRole("tab", { name: "Preview" }).click()
+
+    await expect(writePane).toHaveCount(0)
+    await expect(previewPane).toBeVisible()
+    const previewContract = await previewPane.locator(".aq-markdown").evaluate((markdownRoot) => {
+      const style = window.getComputedStyle(markdownRoot)
+      const rect = markdownRoot.getBoundingClientRect()
+      return {
+        maxWidth: style.maxWidth,
+        renderedWidth: rect.width,
+      }
+    })
+
+    expect(previewContract.maxWidth).toBe("768px")
+    expect(previewContract.renderedWidth).toBeLessThanOrEqual(728)
+  })
+
   test("toolbar snippets insert at the CodeMirror caret instead of appending at the document end", async ({
     page,
   }) => {

--- a/front/src/components/markdown-editor/GitHubMarkdownEditor.tsx
+++ b/front/src/components/markdown-editor/GitHubMarkdownEditor.tsx
@@ -51,41 +51,61 @@ const tableSnippet = [
 
 const codeBlockSnippet = ["", "```", "", "```", ""].join("\n")
 
-const markdownEditorTheme: Extension = EditorView.theme({
-  "&": {
-    minHeight: "100%",
-    backgroundColor: "#0d1117",
-    color: "#e6edf3",
-    fontSize: "14px",
+const markdownEditorTheme: Extension = EditorView.theme(
+  {
+    "&.cm-editor": {
+      minHeight: "100%",
+      backgroundColor: "#0d1117",
+      color: "#e6edf3",
+      fontSize: "14px",
+    },
+    ".cm-scroller": {
+      backgroundColor: "#0d1117",
+      color: "#e6edf3",
+      fontFamily:
+        "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+      lineHeight: "1.55",
+    },
+    ".cm-content": {
+      minHeight: "560px",
+      padding: "16px",
+      backgroundColor: "#0d1117",
+      color: "#e6edf3",
+      caretColor: "#e6edf3",
+    },
+    ".cm-line, .cm-line span": {
+      color: "#e6edf3",
+    },
+    ".cm-gutters": {
+      backgroundColor: "#0d1117",
+      borderRight: "1px solid #30363d",
+      color: "#7d8590",
+    },
+    ".cm-gutter": {
+      backgroundColor: "#0d1117",
+      color: "#7d8590",
+    },
+    ".cm-activeLine": {
+      backgroundColor: "rgba(110, 118, 129, 0.12)",
+    },
+    ".cm-activeLineGutter": {
+      backgroundColor: "rgba(110, 118, 129, 0.12)",
+    },
+    "&.cm-focused": {
+      outline: "none",
+    },
+    ".cm-cursor": {
+      borderLeftColor: "#e6edf3",
+    },
+    ".cm-placeholder": {
+      color: "#7d8590",
+    },
+    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
+      backgroundColor: "rgba(56, 139, 253, 0.45)",
+    },
   },
-  ".cm-scroller": {
-    fontFamily:
-      "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-    lineHeight: "1.55",
-  },
-  ".cm-content": {
-    minHeight: "560px",
-    padding: "16px",
-    caretColor: "#e6edf3",
-  },
-  ".cm-gutters": {
-    backgroundColor: "#0d1117",
-    borderRight: "1px solid #30363d",
-    color: "#7d8590",
-  },
-  ".cm-activeLine": {
-    backgroundColor: "rgba(110, 118, 129, 0.12)",
-  },
-  ".cm-activeLineGutter": {
-    backgroundColor: "rgba(110, 118, 129, 0.12)",
-  },
-  "&.cm-focused": {
-    outline: "none",
-  },
-  "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
-    backgroundColor: "rgba(56, 139, 253, 0.45)",
-  },
-})
+  { dark: true }
+)
 
 export const GitHubMarkdownEditor = ({
   value,
@@ -106,7 +126,6 @@ export const GitHubMarkdownEditor = ({
       markdown({ base: markdownLanguage }),
       EditorView.lineWrapping,
       EditorState.tabSize.of(2),
-      markdownEditorTheme,
       EditorView.editable.of(!disabled),
     ],
     [disabled]
@@ -254,6 +273,7 @@ export const GitHubMarkdownEditor = ({
                 highlightActiveLine: true,
                 highlightSelectionMatches: false,
               }}
+              theme={markdownEditorTheme}
               extensions={extensions}
               onCreateEditor={(editorView) => {
                 editorViewRef.current = editorView
@@ -432,10 +452,17 @@ const PreviewHeader = styled.div`
 `
 
 const PreviewArticle = styled.article`
-  padding: 1.25rem 1.4rem 2rem;
+  padding: 1.25rem 0 2rem;
   background: #0d1117;
 
   .aq-markdown {
+    width: min(100%, var(--article-readable-width, 48rem));
+    max-width: var(--article-readable-width, 48rem);
+    margin-inline: auto;
     color: #e6edf3;
+  }
+
+  @media (max-width: 980px) {
+    padding-inline: 1rem;
   }
 `

--- a/front/src/components/markdown-editor/GitHubMarkdownEditor.tsx
+++ b/front/src/components/markdown-editor/GitHubMarkdownEditor.tsx
@@ -264,7 +264,7 @@ export const GitHubMarkdownEditor = ({
       {uploadError ? <ToolbarError role="alert">{uploadError}</ToolbarError> : null}
       <EditorBody data-mode={mode}>
         {mode !== "preview" ? (
-          <WritePane data-testid="github-markdown-write-pane">
+          <WritePane data-pane="write" data-testid="github-markdown-write-pane">
             <CodeMirror
               value={value}
               height="100%"
@@ -283,7 +283,7 @@ export const GitHubMarkdownEditor = ({
           </WritePane>
         ) : null}
         {mode !== "write" ? (
-          <PreviewPane data-testid="github-markdown-preview-pane">
+          <PreviewPane data-pane="preview" data-testid="github-markdown-preview-pane">
             <PreviewHeader>Preview</PreviewHeader>
             <PreviewArticle>
               <MarkdownRenderer content={value} disableMermaid={disableMermaid} />
@@ -420,6 +420,16 @@ const EditorBody = styled.div`
 
   @media (max-width: 980px) {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  @media (max-width: 768px) {
+    &[data-mode="split"] [data-pane="preview"] {
+      display: none;
+    }
+
+    &[data-mode="split"] [data-pane="write"] {
+      border-bottom: 0;
+    }
   }
 `
 

--- a/front/src/components/markdown-editor/GitHubMarkdownEditor.tsx
+++ b/front/src/components/markdown-editor/GitHubMarkdownEditor.tsx
@@ -1,9 +1,11 @@
 import CodeMirror from "@uiw/react-codemirror"
 import { markdown } from "@codemirror/lang-markdown"
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands"
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language"
 import { markdownLanguage } from "@codemirror/lang-markdown"
 import { EditorState, type Extension } from "@codemirror/state"
 import { EditorView, keymap } from "@codemirror/view"
+import { tags } from "@lezer/highlight"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import styled from "@emotion/styled"
 import MarkdownRenderer from "src/libs/markdown/MarkdownRenderer"
@@ -51,6 +53,18 @@ const tableSnippet = [
 
 const codeBlockSnippet = ["", "```", "", "```", ""].join("\n")
 
+const markdownHighlightStyle = HighlightStyle.define([
+  { tag: tags.heading, color: "#79c0ff", fontWeight: "700" },
+  { tag: tags.strong, color: "#ffa657", fontWeight: "700" },
+  { tag: tags.emphasis, color: "#d2a8ff", fontStyle: "italic" },
+  { tag: tags.link, color: "#58a6ff", textDecoration: "underline" },
+  { tag: tags.url, color: "#a5d6ff" },
+  { tag: tags.monospace, color: "#a5d6ff" },
+  { tag: tags.quote, color: "#8b949e", fontStyle: "italic" },
+  { tag: tags.meta, color: "#7d8590" },
+  { tag: tags.punctuation, color: "#8b949e" },
+])
+
 const markdownEditorTheme: Extension = EditorView.theme(
   {
     "&.cm-editor": {
@@ -73,7 +87,7 @@ const markdownEditorTheme: Extension = EditorView.theme(
       color: "#e6edf3",
       caretColor: "#e6edf3",
     },
-    ".cm-line, .cm-line span": {
+    ".cm-line": {
       color: "#e6edf3",
     },
     ".cm-gutters": {
@@ -124,6 +138,7 @@ export const GitHubMarkdownEditor = ({
       history(),
       keymap.of([...defaultKeymap, ...historyKeymap]),
       markdown({ base: markdownLanguage }),
+      syntaxHighlighting(markdownHighlightStyle),
       EditorView.lineWrapping,
       EditorState.tabSize.of(2),
       EditorView.editable.of(!disabled),
@@ -462,7 +477,7 @@ const PreviewHeader = styled.div`
 `
 
 const PreviewArticle = styled.article`
-  padding: 1.25rem 0 2rem;
+  padding: 1.25rem 1rem 2rem;
   background: #0d1117;
 
   .aq-markdown {


### PR DESCRIPTION
## 관련 이슈

close #723

## 작업 배경

- Markdown 에디터 write pane의 CodeMirror 기본 light surface가 노출되어 흰 배경/저대비 텍스트로 보이던 회귀를 수정했습니다.
- Split preview가 상세 페이지 본문과 같은 48rem readable width와 Markdown typography 계약을 쓰도록 맞췄습니다.
- 768px 이하 좁은 화면에서는 Velog처럼 split preview pane을 접고, Preview 탭에서만 상세형 preview를 보여주도록 정리했습니다.

## 작업 내용

- `@uiw/react-codemirror` custom dark theme를 `theme` prop으로 적용하고, editor/scroller/content/gutter/caret/selection 색상 계약을 명시했습니다.
- preview 내부 `.aq-markdown`에 상세 페이지와 같은 `--article-readable-width` 기반 폭 계약을 적용했습니다.
- 좁은 화면 split mode에서는 write pane을 우선 표시하고 preview pane은 숨겨 가로폭이 무너지는 상황을 막았습니다.
- 507-style 긴 본문 작성 E2E에 CodeMirror surface contrast와 preview/detail typography parity 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - RED 확인: `yarn --cwd front playwright test e2e/editor-authoring-markdown-editor.spec.ts --grep "write pane keeps|split preview uses" --workers=1`
  - GREEN 확인: `yarn --cwd front playwright test e2e/editor-authoring-markdown-editor.spec.ts --grep "write pane keeps|split preview uses" --workers=1`
  - `yarn --cwd front playwright test e2e/editor-authoring-markdown-editor.spec.ts --workers=1`
  - RED/GREEN 확인: `yarn --cwd front playwright test e2e/editor-authoring-markdown-editor.spec.ts --grep "narrow split mode" --workers=1`
  - `yarn --cwd front lint`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - Browser rendered check: `http://localhost:3000/editor/new`에서 CodeMirror editor/scroller/content/gutter dark surface와 preview `max-width: 768px`, `font-size: 17px`, `line-height: 28px` 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: CodeMirror Markdown token 색상을 단일 고대비 색으로 고정해 syntax 색상 다양성이 줄어들 수 있습니다.
- 롤백 방법: 이 PR 커밋을 revert하면 이전 Markdown editor theme/preview wrapper로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
