### PR TITLE
[Fix] 발행 모달과 GFM 렌더링 계약 정리

### DIFF
--- a/front/e2e/editor-authoring-markdown-editor.spec.ts
+++ b/front/e2e/editor-authoring-markdown-editor.spec.ts
@@ -112,6 +112,59 @@ test.describe("GitHub Markdown editor replacement", () => {
     expect(composeRootSource).not.toContain("handleBlockEditorChange")
   })
 
+  test("publish confirmation modal follows the admin neutral dialog contract", async ({ page }) => {
+    await routeAuthenticatedEditor(page)
+
+    await page.goto("/editor/new?source=local-draft")
+    await page.getByRole("button", { name: /^(발행|새 글 작성|수정 반영)$/ }).first().click()
+
+    const dialog = page.getByRole("dialog", { name: /^(발행 설정|새 글 작성|수정 설정)$/ })
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByRole("button", { name: "닫기" })).toBeVisible()
+    await expect(dialog.getByRole("button", { name: /^(발행하기|새 글 작성|변경 반영)$/ })).toBeVisible()
+
+    const dialogContract = await dialog.evaluate((element) => {
+      const style = window.getComputedStyle(element)
+      return {
+        borderRadius: Number.parseFloat(style.borderTopLeftRadius),
+        width: element.getBoundingClientRect().width,
+        backgroundImage: style.backgroundImage,
+      }
+    })
+
+    expect(dialogContract.borderRadius).toBeLessThanOrEqual(16)
+    expect(dialogContract.width).toBeLessThanOrEqual(960)
+    expect(dialogContract.backgroundImage).toBe("none")
+  })
+
+  test("publish modal shell styles stay in the modal style primitive file", () => {
+    const publishModalSource = readFileSync(
+      sourcePath("routes/Admin/EditorStudioPublishModal.tsx"),
+      "utf8"
+    )
+    const publishModalStylesSource = readFileSync(
+      sourcePath("routes/Admin/EditorStudioPublishModalStyles.tsx"),
+      "utf8"
+    )
+    const publishModalShellStylesSource = readFileSync(
+      sourcePath("routes/Admin/EditorStudioPublishModalShellStyles.tsx"),
+      "utf8"
+    )
+
+    expect(publishModalSource).not.toContain("const PublishModalBackdrop = styled.")
+    expect(publishModalSource).not.toContain("const PublishDialog = styled.")
+    expect(publishModalSource).not.toContain("const PublishModalHeader = styled.")
+    expect(publishModalSource).not.toContain("const PublishModalBody = styled.")
+    expect(publishModalSource).not.toContain("const PublishModalFooter = styled.")
+    expect(publishModalSource).toContain('from "./EditorStudioPublishModalStyles"')
+    expect(publishModalStylesSource).toContain('from "./EditorStudioPublishModalShellStyles"')
+    expect(publishModalShellStylesSource).toContain("export const PublishModalBackdrop")
+    expect(publishModalShellStylesSource).toContain("export const PublishDialog")
+    expect(publishModalShellStylesSource).toContain("export const PublishModalHeader")
+    expect(publishModalShellStylesSource).toContain("export const PublishModalBody")
+    expect(publishModalShellStylesSource).toContain("export const PublishModalFooter")
+  })
+
   test("/editor/new renders GitHub Markdown write and preview panes for 507-style bottom content", async ({
     page,
   }) => {
@@ -133,6 +186,101 @@ test.describe("GitHub Markdown editor replacement", () => {
     await expect(preview.locator("pre")).toContainText("console.log(\"507-code\")")
     await expect(preview.locator("input[type='checkbox']")).toHaveCount(2)
     await expect(preview.getByText("quote at the bottom")).toBeVisible()
+  })
+
+  test("preview matches GitHub table markdown for alignment, escaped pipes, and inline cell formatting", async ({
+    page,
+  }) => {
+    await routeAuthenticatedEditor(
+      page,
+      [
+        "# GitHub table parity",
+        "",
+        "```md",
+        "| example | only |",
+        "| --- | --- |",
+        "| this is code | not a rendered table |",
+        "```",
+        "",
+        "    | indented | code |",
+        "    | --- | --- |",
+        "",
+        "escaped \\| pipe is plain text",
+        "--- | ---",
+        "",
+        "Mismatch | Header | Count",
+        "--- | ---",
+        "one | two",
+        "",
+        "Inline | `pipe|code`",
+        "--- | ---",
+        "",
+        "Two dash A | Two dash B",
+        "-- | --",
+        "one | two",
+        "",
+        "Left | Center | Right",
+        ":--- | :---: | ---:",
+        "**strong** and *em* | `code` and [link](https://github.com) | escaped \\| pipe",
+        "",
+        '<!-- aq-table {"overflowMode":"wide","columnWidths":[320,360,420]} -->',
+        "| Wide A | Wide B | Wide C |",
+        "| --- | --- | --- |",
+        "| " + "wide content ".repeat(10) + " | beta | gamma |",
+      ].join("\n")
+    )
+
+    await page.goto("/editor/new?source=local-draft")
+
+    const preview = page.getByTestId("github-markdown-preview-pane")
+    await expect(preview.locator("pre").filter({ hasText: "| example | only |" })).toBeVisible()
+    await expect(preview.locator("pre").filter({ hasText: "| indented | code |" })).toBeVisible()
+    await expect(preview.getByText("escaped | pipe is plain text")).toBeVisible()
+    await expect(preview.getByText("Mismatch | Header | Count")).toBeVisible()
+    await expect(preview.getByText("Inline | pipe|code")).toBeVisible()
+    await expect(preview.locator("table")).toHaveCount(3)
+
+    const table = preview.locator("table").filter({ hasText: "strong" }).first()
+    await expect(table).toBeVisible()
+    await expect(table.locator("th")).toHaveCount(3)
+    await expect(table.locator("td")).toHaveCount(3)
+    await expect(table.locator("td").nth(0).locator("strong")).toHaveText("strong")
+    await expect(table.locator("td").nth(0).locator("em")).toHaveText("em")
+    await expect(table.locator("td").nth(1).locator("code")).toHaveText("code")
+    await expect(table.locator("td").nth(1).locator("a")).toHaveAttribute("href", "https://github.com")
+    await expect(table.locator("td").nth(2)).toHaveText("escaped | pipe")
+
+    const tableContract = await table.evaluate((element) => {
+      const cells = Array.from(element.querySelectorAll<HTMLElement>("th"))
+      const shell = element.closest(".aq-table-shell")
+      const scroll = element.closest(".aq-table-scroll")
+      return {
+        alignments: cells.map((cell) => window.getComputedStyle(cell).textAlign),
+        shellWidth: shell?.getBoundingClientRect().width ?? 0,
+        tableWidth: element.getBoundingClientRect().width,
+        scrollWidth: scroll?.scrollWidth ?? 0,
+        clientWidth: scroll?.clientWidth ?? 0,
+      }
+    })
+
+    expect(tableContract.alignments).toEqual(["left", "center", "right"])
+    expect(tableContract.tableWidth).toBeLessThanOrEqual(tableContract.shellWidth + 1)
+
+    const wideTableContract = await preview
+      .locator("table")
+      .filter({ hasText: "wide content" })
+      .first()
+      .evaluate((element) => {
+        const scroll = element.closest(".aq-table-scroll")
+        return {
+          mode: element.getAttribute("data-overflow-mode"),
+          scrollWidth: scroll?.scrollWidth ?? 0,
+          clientWidth: scroll?.clientWidth ?? 0,
+        }
+      })
+
+    expect(wideTableContract.mode).toBe("wide")
+    expect(wideTableContract.scrollWidth).toBeGreaterThan(wideTableContract.clientWidth)
   })
 
   test("write pane keeps every CodeMirror surface on the dark editor surface", async ({ page }) => {

--- a/front/package.json
+++ b/front/package.json
@@ -48,6 +48,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.11.0",
+    "@lezer/highlight": "^1.2.3",
     "@next/env": "15.5.18",
     "@radix-ui/colors": "^1.0.0",
     "@shared/contracts": "file:packages/shared-contracts",

--- a/front/src/libs/markdown/MarkdownRenderer.tsx
+++ b/front/src/libs/markdown/MarkdownRenderer.tsx
@@ -33,6 +33,21 @@ import type { MarkdownRendererProps } from "src/libs/markdown/MarkdownRenderer.t
 
 export { markdownGuide } from "src/libs/markdown/rendering"
 
+const resolveMarkdownTableCellAlignment = (node: unknown, propAlignment: unknown, style: unknown) => {
+  const nodeProperties = (node as { properties?: { align?: unknown; style?: unknown } } | null)?.properties
+  const nodeAlignment = nodeProperties?.align
+  const styleAlignment =
+    typeof style === "object" && style && "textAlign" in style
+      ? (style as { textAlign?: unknown }).textAlign
+      : undefined
+  const serializedStyle = typeof nodeProperties?.style === "string" ? nodeProperties.style : ""
+  const serializedStyleAlignment = serializedStyle
+    .match(/text-align:\s*(left|center|right)/i)?.[1]
+    ?.toLowerCase()
+  const alignment = propAlignment || nodeAlignment || styleAlignment || serializedStyleAlignment
+  return typeof alignment === "string" ? alignment : undefined
+}
+
 const MarkdownRendererComponent: FC<MarkdownRendererProps> = ({
   content,
   contentHtml,
@@ -89,16 +104,24 @@ const MarkdownRendererComponent: FC<MarkdownRendererProps> = ({
         tr({ children, ...props }) {
           return <MarkdownTableRowRenderer {...props}>{children}</MarkdownTableRowRenderer>
         },
-        th({ children, ...props }) {
+        th({ children, node, ...props }) {
           return (
-            <MarkdownTableCellRenderer as="th" className={props.className}>
+            <MarkdownTableCellRenderer
+              as="th"
+              alignment={resolveMarkdownTableCellAlignment(node, props.align, props.style)}
+              className={props.className}
+            >
               {children}
             </MarkdownTableCellRenderer>
           )
         },
-        td({ children, ...props }) {
+        td({ children, node, ...props }) {
           return (
-            <MarkdownTableCellRenderer as="td" className={props.className}>
+            <MarkdownTableCellRenderer
+              as="td"
+              alignment={resolveMarkdownTableCellAlignment(node, props.align, props.style)}
+              className={props.className}
+            >
               {children}
             </MarkdownTableCellRenderer>
           )

--- a/front/src/libs/markdown/MarkdownRendererTable.tsx
+++ b/front/src/libs/markdown/MarkdownRendererTable.tsx
@@ -184,10 +184,12 @@ export const MarkdownTableRowRenderer = ({
 }
 
 export const MarkdownTableCellRenderer = ({
+  alignment,
   as: Component,
   children,
   className,
 }: {
+  alignment?: string
   as: "td" | "th"
   children?: ReactNode
   className?: string
@@ -204,6 +206,8 @@ export const MarkdownTableCellRenderer = ({
   const columnIndex = cellIndexRef.current ?? 0
   const cellLayout = tableContext?.cellLayouts[rowIndex]?.[columnIndex] || null
   const columnAlignment = tableContext?.columnAlignments[columnIndex] || null
+  const markdownAlignment: MarkdownTableCellAlignment | null =
+    alignment === "left" || alignment === "center" || alignment === "right" ? alignment : null
 
   if (cellLayout?.hidden) {
     return null
@@ -211,7 +215,7 @@ export const MarkdownTableCellRenderer = ({
 
   const rowSpan = cellLayout?.rowspan && cellLayout.rowspan > 1 ? cellLayout.rowspan : undefined
   const colSpan = cellLayout?.colspan && cellLayout.colspan > 1 ? cellLayout.colspan : undefined
-  const textAlign = cellLayout?.align || columnAlignment || undefined
+  const textAlign = cellLayout?.align || columnAlignment || markdownAlignment || undefined
   const backgroundColor = cellLayout?.backgroundColor || undefined
   const style = textAlign || backgroundColor
     ? ({

--- a/front/src/libs/markdown/components/MarkdownRendererRootTableToggleStyles.ts
+++ b/front/src/libs/markdown/components/MarkdownRendererRootTableToggleStyles.ts
@@ -131,7 +131,7 @@ export const markdownRendererRootTableToggleStyles = (theme: Theme) => css`
     ${(() => {
       const tableChrome = getTableChromePalette(theme)
       return `
-    text-align: left !important;
+    text-align: left;
     background: ${tableChrome.headerBackground};
     font-weight: 700;
     line-height: 1.52;

--- a/front/src/libs/markdown/renderingTypes.ts
+++ b/front/src/libs/markdown/renderingTypes.ts
@@ -48,7 +48,7 @@ export type MarkdownRenderModel = {
   resolvedContentHtml: string
   renderKey: string
   segments: MarkdownSegment[]
-  tableLayouts: MarkdownTableLayout[]
+  tableLayouts: Array<MarkdownTableLayout | null>
 }
 
 export const markdownGuide = `### 작성 가이드

--- a/front/src/libs/markdown/tableMetadata.ts
+++ b/front/src/libs/markdown/tableMetadata.ts
@@ -221,16 +221,55 @@ export const serializeMarkdownTableLayoutComment = (
 
 type ExtractedTableLayouts = {
   cleanedMarkdown: string
-  layouts: MarkdownTableLayout[]
+  layouts: Array<MarkdownTableLayout | null>
+}
+
+const isIndentedCodeLine = (line: string) => /^(?: {4}|\t)/.test(line)
+
+const countUnescapedPipeDelimiters = (line: string) => {
+  let count = 0
+
+  for (let index = 0; index < line.length; index += 1) {
+    if (isUnescapedPipeAt(line, index)) count += 1
+  }
+
+  return count
+}
+
+const isUnescapedPipeAt = (line: string, index: number) => {
+  if (line[index] !== "|") return false
+
+  let slashCount = 0
+  for (let slashIndex = index - 1; slashIndex >= 0 && line[slashIndex] === "\\"; slashIndex -= 1) {
+    slashCount += 1
+  }
+
+  return slashCount % 2 === 0
+}
+
+const countGfmTableCells = (line: string) => {
+  const trimmed = line.trim()
+  const delimiterCount = countUnescapedPipeDelimiters(trimmed)
+  if (delimiterCount < 1) return 0
+
+  const hasLeadingPipe = isUnescapedPipeAt(trimmed, 0)
+  const hasTrailingPipe = isUnescapedPipeAt(trimmed, trimmed.length - 1)
+  return delimiterCount + 1 - (hasLeadingPipe ? 1 : 0) - (hasTrailingPipe ? 1 : 0)
 }
 
 const isTableSeparatorLine = (line: string) =>
-  /^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$/.test(line)
+  !isIndentedCodeLine(line) &&
+  /^\s*\|?(?:\s*:?-{2,}:?\s*\|)+\s*:?-{2,}:?\s*\|?\s*$/.test(line)
 
 const isLikelyTableRow = (line: string) => {
+  if (isIndentedCodeLine(line) || countGfmTableCells(line) < 2) return false
   const trimmed = line.trim()
-  if (!trimmed.includes("|")) return false
   return /^\|?.+\|.+\|?$/.test(trimmed)
+}
+
+const isLikelyGfmTable = (headerLine: string, separatorLine: string) => {
+  if (!isLikelyTableRow(headerLine) || !isTableSeparatorLine(separatorLine)) return false
+  return countGfmTableCells(headerLine) === countGfmTableCells(separatorLine)
 }
 
 export const extractMarkdownTableLayouts = (
@@ -238,21 +277,44 @@ export const extractMarkdownTableLayouts = (
 ): ExtractedTableLayouts => {
   const lines = markdown.replace(/\r\n?/g, "\n").split("\n")
   const cleanedLines: string[] = []
-  const layouts: MarkdownTableLayout[] = []
+  const layouts: Array<MarkdownTableLayout | null> = []
+  const tableHeaderLinesWithExplicitLayout = new Set<number>()
+  let inFencedCodeBlock = false
 
   for (let index = 0; index < lines.length; index += 1) {
-    const layout = parseMarkdownTableLayoutComment(lines[index] || "")
+    const line = lines[index] || ""
+    const trimmedLine = line.trim()
 
-    if (
-      layout &&
-      isLikelyTableRow(lines[index + 1] || "") &&
-      isTableSeparatorLine(lines[index + 2] || "")
-    ) {
-      layouts.push(layout)
+    if (/^(```|~~~)/.test(trimmedLine)) {
+      inFencedCodeBlock = !inFencedCodeBlock
+      cleanedLines.push(line)
       continue
     }
 
-    cleanedLines.push(lines[index])
+    if (inFencedCodeBlock) {
+      cleanedLines.push(line)
+      continue
+    }
+
+    const layout = parseMarkdownTableLayoutComment(line)
+
+    if (
+      layout &&
+      isLikelyGfmTable(lines[index + 1] || "", lines[index + 2] || "")
+    ) {
+      layouts.push(layout)
+      tableHeaderLinesWithExplicitLayout.add(index + 1)
+      continue
+    }
+
+    if (
+      !tableHeaderLinesWithExplicitLayout.has(index) &&
+      isLikelyGfmTable(line, lines[index + 1] || "")
+    ) {
+      layouts.push(null)
+    }
+
+    cleanedLines.push(line)
   }
 
   return {

--- a/front/src/routes/Admin/EditorStudioPublishModal.tsx
+++ b/front/src/routes/Admin/EditorStudioPublishModal.tsx
@@ -1,17 +1,23 @@
-import styled from "@emotion/styled"
 import type { CSSProperties, ReactNode } from "react"
 import type { PostVisibility } from "./editorStudioState"
 import {
   EditorStudioPublishCardSettings,
   EditorStudioPublishPreviewCard,
   EditorStudioPublishVisibilitySection,
-  PublishButton,
-  PublishModalNotice,
-  PublishOverviewGrid,
-  PublishPrimaryButton,
   type EditorStudioPreviewViewportOption,
   type EditorStudioPublishVisibilityOption,
 } from "./EditorStudioPublishModalParts"
+import {
+  PublishButton,
+  PublishDialog,
+  PublishModalBackdrop,
+  PublishModalBody,
+  PublishModalFooter,
+  PublishModalHeader,
+  PublishModalNotice,
+  PublishOverviewGrid,
+  PublishPrimaryButton,
+} from "./EditorStudioPublishModalStyles"
 
 type NoticeTone = "idle" | "loading" | "success" | "error"
 
@@ -113,7 +119,13 @@ export const EditorStudioPublishModal = <TViewport extends string,>({
 
   return (
     <PublishModalBackdrop data-variant={variant} onClick={onClose}>
-      <PublishDialog data-variant={variant} onClick={(event) => event.stopPropagation()}>
+      <PublishDialog
+        role="dialog"
+        aria-modal="true"
+        aria-label={publishActionTitle}
+        data-variant={variant}
+        onClick={(event) => event.stopPropagation()}
+      >
         <PublishModalHeader>
           <div>
             <h4>{publishActionTitle}</h4>
@@ -176,91 +188,3 @@ export const EditorStudioPublishModal = <TViewport extends string,>({
     </PublishModalBackdrop>
   )
 }
-
-const PublishModalBackdrop = styled.div`
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.42);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 120;
-  padding: 1rem;
-
-  &[data-variant="drawer"] {
-    justify-content: flex-end;
-    padding: 0;
-  }
-`
-
-const PublishDialog = styled.div`
-  width: min(1120px, calc(100vw - 2rem));
-  max-height: min(86vh, 920px);
-  overflow: auto;
-  border-radius: 18px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
-  padding: 1rem 1rem 0;
-  display: grid;
-  gap: 0.8rem;
-
-  &[data-variant="drawer"] {
-    width: min(560px, 100vw);
-    max-height: 100vh;
-    height: 100vh;
-    border-radius: 0;
-    border-left: 1px solid ${({ theme }) => theme.colors.gray6};
-    border-right: 0;
-    border-top: 0;
-    border-bottom: 0;
-    padding-top: max(1rem, env(safe-area-inset-top, 0px));
-    padding-bottom: 0;
-  }
-
-  @media (max-width: 720px) {
-    width: min(100%, 34rem);
-    max-height: min(92vh, 980px);
-    padding: 0.82rem 0.82rem 0;
-    gap: 0.78rem;
-  }
-`
-
-const PublishModalHeader = styled.div`
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-
-  h4 {
-    margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 1.04rem;
-    font-weight: 750;
-  }
-`
-
-const PublishModalBody = styled.div`
-  display: grid;
-  gap: 0.86rem;
-  padding-bottom: 0.95rem;
-`
-
-const PublishModalFooter = styled.div`
-  position: sticky;
-  bottom: 0;
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.52rem;
-  padding: 0.78rem 0;
-  border-top: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
-
-  @media (max-width: 480px) {
-    flex-direction: column-reverse;
-
-    > button {
-      width: 100%;
-      justify-content: center;
-    }
-  }
-`

--- a/front/src/routes/Admin/EditorStudioPublishModalParts.tsx
+++ b/front/src/routes/Admin/EditorStudioPublishModalParts.tsx
@@ -19,6 +19,10 @@ import {
   VisibilityCard,
   VisibilityOptionButton,
   VisibilityOptionGrid,
+  PublishButton,
+  PublishModalNotice,
+  PublishOverviewGrid,
+  PublishPrimaryButton,
 } from "./EditorStudioPublishModalStyles"
 import AppIcon from "src/components/icons/AppIcon"
 import type { PostVisibility } from "./editorStudioState"
@@ -255,6 +259,4 @@ export const EditorStudioPublishCardSettings = ({
     )}
   </PostPreviewSetup>
 )
-
-export { PublishButton, PublishModalNotice, PublishOverviewGrid, PublishPrimaryButton } from "./EditorStudioPublishModalStyles"
 

--- a/front/src/routes/Admin/EditorStudioPublishModalShellStyles.tsx
+++ b/front/src/routes/Admin/EditorStudioPublishModalShellStyles.tsx
@@ -1,0 +1,91 @@
+import styled from "@emotion/styled"
+
+export const PublishModalBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.42);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 120;
+  padding: 1rem;
+
+  &[data-variant="drawer"] {
+    justify-content: flex-end;
+    padding: 0;
+  }
+`
+
+export const PublishDialog = styled.div`
+  width: min(920px, calc(100vw - 2rem));
+  max-height: min(86vh, 920px);
+  overflow: auto;
+  border-radius: 16px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray2};
+  padding: 1rem 1rem 0;
+  display: grid;
+  gap: 0.8rem;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.34);
+
+  &[data-variant="drawer"] {
+    width: min(560px, 100vw);
+    max-height: 100vh;
+    height: 100vh;
+    border-radius: 0;
+    border-left: 1px solid ${({ theme }) => theme.colors.gray6};
+    border-right: 0;
+    border-top: 0;
+    border-bottom: 0;
+    padding-top: max(1rem, env(safe-area-inset-top, 0px));
+    padding-bottom: 0;
+    box-shadow: -18px 0 44px rgba(0, 0, 0, 0.28);
+  }
+
+  @media (max-width: 720px) {
+    width: min(100%, 34rem);
+    max-height: min(92vh, 980px);
+    padding: 0.82rem 0.82rem 0;
+    gap: 0.78rem;
+  }
+`
+
+export const PublishModalHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+
+  h4 {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 1.04rem;
+    font-weight: 750;
+  }
+`
+
+export const PublishModalBody = styled.div`
+  display: grid;
+  gap: 0.86rem;
+  padding-bottom: 0.95rem;
+`
+
+export const PublishModalFooter = styled.div`
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.52rem;
+  padding: 0.78rem 0;
+  border-top: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray2};
+
+  @media (max-width: 480px) {
+    flex-direction: column-reverse;
+
+    > button {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+`

--- a/front/src/routes/Admin/EditorStudioPublishModalStyles.tsx
+++ b/front/src/routes/Admin/EditorStudioPublishModalStyles.tsx
@@ -1,5 +1,13 @@
 import styled from "@emotion/styled"
 
+export {
+  PublishDialog,
+  PublishModalBackdrop,
+  PublishModalBody,
+  PublishModalFooter,
+  PublishModalHeader,
+} from "./EditorStudioPublishModalShellStyles"
+
 export const PublishOverviewGrid = styled.div`
   display: grid;
   gap: 0.8rem;
@@ -16,9 +24,7 @@ export const VisibilityCard = styled.section`
   align-content: start;
   border: 1px solid ${({ theme }) => theme.colors.gray6};
   border-radius: 14px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0)),
-    ${({ theme }) => theme.colors.gray1};
+  background: ${({ theme }) => theme.colors.gray1};
   padding: 0.9rem;
 
   > strong {
@@ -102,9 +108,7 @@ export const PreviewResultPanel = styled.div`
   overflow: hidden;
   border: 1px solid ${({ theme }) => theme.colors.gray6};
   border-radius: 14px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0)),
-    ${({ theme }) => theme.colors.gray1};
+  background: ${({ theme }) => theme.colors.gray1};
   padding: 0.9rem;
 `
 
@@ -212,9 +216,7 @@ export const PreviewResultCard = styled.article`
     position: relative;
     aspect-ratio: 1.94 / 1;
     overflow: hidden;
-    background:
-      radial-gradient(circle at top left, rgba(96, 165, 250, 0.08), transparent 48%),
-      ${({ theme }) => theme.colors.gray3};
+    background: ${({ theme }) => theme.colors.gray3};
     border-bottom: 1px solid ${({ theme }) => theme.colors.gray4};
   }
 

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -1739,7 +1739,7 @@
     "@lezer/highlight" "^1.0.0"
     "@lezer/lr" "^1.3.0"
 
-"@lezer/highlight@^1.0.0", "@lezer/highlight@^1.1.3":
+"@lezer/highlight@^1.0.0", "@lezer/highlight@^1.1.3", "@lezer/highlight@^1.2.3":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.2.3.tgz#a20f324b71148a2ea9ba6ff42e58bbfaec702857"
   integrity sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==


### PR DESCRIPTION
## 관련 이슈

close #726

## 작업 배경

- 글 작성/수정 반영 확인 모달을 관리자 화면의 neutral dialog 톤으로 정리했습니다.
- GitHub 공식 문서 기준 GFM table 렌더링 계약을 작성 미리보기와 상세 렌더러에 맞춰 보강했습니다.
- 특히 table의 optional outer pipe, alignment colon, escaped pipe, 2-hyphen delimiter, 셀 내부 strong/em/link/code, wide overflow, `aq-table` 메타데이터 독립성을 E2E로 고정했습니다.

## 작업 내용

- 발행/수정 모달 shell 스타일을 `EditorStudioPublishModalShellStyles.tsx`로 분리하고, root 컴포넌트는 조립과 접근성 role만 맡도록 정리했습니다.
- 모달 카드/미리보기 패널의 장식 gradient를 제거하고 어드민/블로그 본 화면과 맞는 중립 surface로 낮췄습니다.
- GFM table 셀 정렬 값을 `react-markdown` node/style/prop 경로에서 복구해 커스텀 table cell renderer에 전달합니다.
- plain GitHub table이 뒤따르는 `aq-table` wide 메타데이터를 잘못 상속하지 않도록 table layout 추출 순서를 보정했습니다.
- CodeMirror Markdown editor가 사용하는 `@lezer/highlight` 직접 의존성을 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=editor-publish-modal-gfm-parity bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front test:e2e:authoring --grep "preview matches GitHub table"`
  - `yarn --cwd front test:e2e:authoring --grep "publish confirmation modal|publish modal shell|preview matches GitHub table"`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front playwright test e2e/block-editor-serialization.spec.ts --workers=1 --grep "렌더 모델은 테이블 메타"`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - pre-commit hook: `yarn build`, `node scripts/check-bundle-size.mjs`, `yarn test:e2e:smoke` 재통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 기존 `aq-table` 메타데이터와 plain GFM table이 섞인 문서에서 table layout indexing이 영향을 받을 수 있습니다.
- 대응: plain table과 `aq-table` wide table이 연속으로 있는 케이스를 E2E로 추가했고, 기존 table metadata serialization 회귀 테스트를 함께 통과시켰습니다.
- 롤백 방법: 이 PR의 단일 커밋 `4bab1e7e`를 revert하면 됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
