### PR TITLE
[Refactor] grid 디자인 분기 제거

### DIFF
--- a/front/e2e/admin-profile-state.spec.ts
+++ b/front/e2e/admin-profile-state.spec.ts
@@ -332,7 +332,7 @@ test.describe("admin profile state contract", () => {
       blogTitle: "AquilaLog",
       homeIntroTitle: "비밀스러운 IT 공작소",
       homeIntroDescription: "비밀스러운 지식들을 탐구하는데 목적을 두고 있습니다",
-      blogDesign: "grid",
+      blogDesign: "grid" as never,
       legacyBlogScheme: "light",
       serviceLinks: [],
       contactLinks: [],

--- a/front/e2e/mobile-layout.spec.ts
+++ b/front/e2e/mobile-layout.spec.ts
@@ -14,11 +14,11 @@ test.describe("모바일 레이아웃 소스 경계", () => {
       "src/routes/Feed/ProfileCard.tsx",
       "src/routes/Feed/ServiceCard.tsx",
       "src/routes/Feed/ContactCard.tsx",
-      "src/routes/About/AboutPage.styles.ts",
       "src/routes/Detail/PostDetail/PostDetail.styles.ts",
       "src/routes/Detail/PostDetail/PostDetailSection.styles.ts",
       "src/routes/Detail/PostDetail/PostHeader.styles.ts",
     ].map((sourcePath) => [sourcePath, readSourceFile(sourcePath)] as const)
+    const aboutSource = readSourceFile("src/routes/About/AboutPage.styles.ts")
     const themeSource = readSourceFile("src/styles/theme.ts")
     const articleSurfaceSource = [
       readSourceFile("src/routes/Detail/PostDetail/PostDetail.styles.ts"),
@@ -77,14 +77,20 @@ test.describe("모바일 레이아웃 소스 경계", () => {
     expect(adminToolsSource).toContain("adminSurface")
     expect(adminToolsSource).toContain("adminSurfaceRaised")
     expect(adminDashboardSource).toContain("adminSurface")
-    expect(authShellSource).toContain("theme.publicDesign.readableSurface")
-    expect(errorSource).toContain("theme.publicDesign.readableSurface")
-    expect(editorComposeSource).toContain("theme.publicDesign.readableSurface")
-    expect(editorDedicatedSource).toContain("theme.publicDesign.readableSurface")
-    expect(editorPreviewSource).toContain("theme.publicDesign.readableSurface")
-    for (const [sourcePath, source] of publicSurfaceSources) {
-      expect(source, sourcePath).toContain("theme.publicDesign")
+    expect(authShellSource).toContain("theme.colors.gray1")
+    expect(errorSource).toContain("theme.colors.gray1")
+    expect(editorComposeSource).toContain("theme.colors.gray2")
+    expect(editorDedicatedSource).toContain("theme.colors.gray2")
+    expect(editorPreviewSource).toContain("theme.colors.gray1")
+    for (const source of [authShellSource, errorSource, editorComposeSource, editorDedicatedSource, editorPreviewSource]) {
+      expect(source).not.toContain("theme.blogDesign")
     }
+    for (const [sourcePath, source] of publicSurfaceSources) {
+      expect(source, sourcePath).not.toContain("theme.blogDesign")
+    }
+    expect(publicSurfaceSources.map(([, source]) => source).join("\n")).toContain("theme.publicDesign")
+    expect(aboutSource).toContain("theme.colors.gray1")
+    expect(aboutSource).not.toContain("theme.blogDesign")
     expect(articleSurfaceSource).toContain("theme.publicDesign.readableSurface")
     expect(articleSurfaceSource).toContain("article::before")
     expect(articleSurfaceSource).not.toContain("font-size: ${({ theme }) =>")

--- a/front/e2e/smoke-public-shell.spec.ts
+++ b/front/e2e/smoke-public-shell.spec.ts
@@ -73,7 +73,7 @@ test.describe("core smoke public shell", () => {
     name: "aquila",
     nickname: "aquila",
     profileImageUrl: "/avatar.png",
-    blogDesign: "grid" as const,
+    blogDesign: "grid" as never,
     legacyBlogScheme: "light" as const,
   }
 

--- a/front/src/components/auth/AuthShell.tsx
+++ b/front/src/components/auth/AuthShell.tsx
@@ -1,39 +1,26 @@
-import styled from "@emotion/styled"
-import Link from "next/link"
-import { ReactNode } from "react"
-
+import styled from "@emotion/styled";
+import Link from "next/link";
+import { ReactNode } from "react";
 type AuthShellProps = {
-  activeTab: "login" | "signup"
-  title: string
-  subtitle?: string
-  eyebrow: string
-  heroTitle: string
-  heroDescription?: string
-  statItems?: {
-    label: string
-    value: string
-  }[]
-  tips?: string[]
-  footer: ReactNode
-  children: ReactNode
-  loginHref?: string
-  signupHref?: string
-  hideTabs?: boolean
-}
-
-const AuthShell = ({
-  activeTab,
-  title,
-  subtitle,
-  eyebrow,
-  footer,
-  children,
-  loginHref = "/login",
-  signupHref = "/signup",
-  hideTabs = false,
-}: AuthShellProps) => {
-  return (
-    <Main>
+    activeTab: "login" | "signup";
+    title: string;
+    subtitle?: string;
+    eyebrow: string;
+    heroTitle: string;
+    heroDescription?: string;
+    statItems?: {
+        label: string;
+        value: string;
+    }[];
+    tips?: string[];
+    footer: ReactNode;
+    children: ReactNode;
+    loginHref?: string;
+    signupHref?: string;
+    hideTabs?: boolean;
+};
+const AuthShell = ({ activeTab, title, subtitle, eyebrow, footer, children, loginHref = "/login", signupHref = "/signup", hideTabs = false, }: AuthShellProps) => {
+    return (<Main>
       <Backdrop />
       <Shell data-auth-shell="true">
         <FormPanel>
@@ -43,68 +30,50 @@ const AuthShell = ({
             {subtitle ? <SubTitle>{subtitle}</SubTitle> : null}
           </Top>
 
-          {hideTabs ? null : (
-            <Tabs>
-              {activeTab === "login" ? (
-                <>
+          {hideTabs ? null : (<Tabs>
+              {activeTab === "login" ? (<>
                   <ActiveTab>로그인</ActiveTab>
                   <PassiveTab href={signupHref}>회원가입</PassiveTab>
-                </>
-              ) : (
-                <>
+                </>) : (<>
                   <PassiveTab href={loginHref}>로그인</PassiveTab>
                   <ActiveTab>회원가입</ActiveTab>
-                </>
-              )}
-            </Tabs>
-          )}
+                </>)}
+            </Tabs>)}
 
           <Body>{children}</Body>
           <Footer>{footer}</Footer>
         </FormPanel>
       </Shell>
-    </Main>
-  )
-}
-
-export default AuthShell
-
-const Main = styled.main`
+    </Main>);
+};
+export default AuthShell;
+const Main = styled.main `
   position: relative;
   min-height: calc(100vh - 4rem);
   min-height: calc(100dvh - 4rem);
   padding: 1.8rem 1rem;
   display: grid;
   place-items: center;
-`
-
-const Backdrop = styled.div`
+`;
+const Backdrop = styled.div `
   position: absolute;
   inset: 0;
   background:
-    ${({ theme }) =>
-      theme.blogDesign === "grid"
-        ? `linear-gradient(180deg, color-mix(in srgb, ${theme.publicDesign.surfaceElevated} 72%, transparent), ${theme.publicDesign.pageBackgroundColor}), ${theme.publicDesign.pageBackgroundImage}`
-        : theme.colors.gray1};
-`
-
-const Shell = styled.section`
+    ${({ theme }) => theme.colors.gray1};
+`;
+const Shell = styled.section `
   position: relative;
   z-index: 1;
   width: min(520px, 100%);
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray5)};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "22px")};
+  border: 1px solid ${({ theme }) => (theme.colors.gray5)};
+  border-radius: ${({ theme }) => ("22px")};
   overflow: hidden;
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : theme.colors.gray1)};
-  box-shadow: ${({ theme }) =>
-    theme.blogDesign === "grid"
-      ? theme.publicDesign.shadow
-      : theme.scheme === "light"
-      ? "0 18px 40px rgba(15, 23, 42, 0.08)"
-      : "0 18px 40px rgba(0, 0, 0, 0.3)"};
-`
-
-const FormPanel = styled.section`
+  background: ${({ theme }) => (theme.colors.gray1)};
+  box-shadow: ${({ theme }) => theme.scheme === "light"
+    ? "0 18px 40px rgba(15, 23, 42, 0.08)"
+    : "0 18px 40px rgba(0, 0, 0, 0.3)"};
+`;
+const FormPanel = styled.section `
   padding: 1.6rem 1.35rem 1.28rem;
   background: transparent;
   display: grid;
@@ -113,84 +82,71 @@ const FormPanel = styled.section`
   @media (max-width: 720px) {
     padding: 1.2rem 0.9rem 1rem;
   }
-`
-
-const Top = styled.div`
+`;
+const Top = styled.div `
   margin-bottom: 1.04rem;
-`
-
-const Eyebrow = styled.span`
+`;
+const Eyebrow = styled.span `
   display: inline-flex;
   align-items: center;
   margin-bottom: 0.38rem;
-  color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray10)};
+  color: ${({ theme }) => (theme.colors.gray10)};
   font-size: 0.74rem;
   font-weight: 760;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-`
-
-const Title = styled.h1`
+`;
+const Title = styled.h1 `
   margin: 0;
   font-size: 1.48rem;
   letter-spacing: -0.025em;
   color: ${({ theme }) => theme.colors.gray12};
-`
-
-const SubTitle = styled.p`
+`;
+const SubTitle = styled.p `
   margin: 0.45rem 0 0;
   color: ${({ theme }) => theme.colors.gray11};
   line-height: 1.6;
-`
-
-const Tabs = styled.div`
+`;
+const Tabs = styled.div `
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 0.42rem;
   margin-bottom: 1.08rem;
-`
-
-const ActiveTab = styled.div`
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "4px" : "11px")};
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray6)};
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid"
-      ? theme.publicDesign.accentMuted
-      : theme.scheme === "light"
-        ? theme.colors.gray2
-        : theme.colors.gray3};
+`;
+const ActiveTab = styled.div `
+  border-radius: ${({ theme }) => ("11px")};
+  border: 1px solid ${({ theme }) => (theme.colors.gray6)};
+  background: ${({ theme }) => theme.scheme === "light"
+    ? theme.colors.gray2
+    : theme.colors.gray3};
   color: ${({ theme }) => theme.colors.gray12};
   padding: 0.66rem 0.76rem;
   text-align: center;
   font-weight: 700;
-`
-
-const PassiveTab = styled(Link)`
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "4px" : "11px")};
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.scheme === "light" ? "#f8fafc" : theme.colors.gray1};
+`;
+const PassiveTab = styled(Link) `
+  border-radius: ${({ theme }) => ("11px")};
+  border: 1px solid ${({ theme }) => (theme.colors.gray5)};
+  background: ${({ theme }) => theme.scheme === "light" ? "#f8fafc" : theme.colors.gray1};
   color: ${({ theme }) => theme.colors.gray11};
   padding: 0.66rem 0.76rem;
   text-align: center;
   text-decoration: none;
   font-weight: 600;
-`
-
-const Body = styled.div`
+`;
+const Body = styled.div `
   form {
     display: grid;
     gap: 0.85rem;
   }
-`
-
-const Footer = styled.div`
+`;
+const Footer = styled.div `
   margin-top: 1rem;
   color: ${({ theme }) => theme.colors.gray11};
 
   a {
-    color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.accentLink)};
+    color: ${({ theme }) => (theme.colors.accentLink)};
     text-decoration: underline;
     text-underline-offset: 3px;
   }
-`
+`;

--- a/front/src/routes/About/AboutPage.styles.ts
+++ b/front/src/routes/About/AboutPage.styles.ts
@@ -1,6 +1,5 @@
-import styled from "@emotion/styled"
-
-export const StyledWrapper = styled.div`
+import styled from "@emotion/styled";
+export const StyledWrapper = styled.div `
   max-width: 62rem;
   margin: 0 auto;
   padding: 2.25rem 0 3rem;
@@ -15,8 +14,7 @@ export const StyledWrapper = styled.div`
     grid-template-columns: minmax(0, 1.6fr) minmax(220px, 0.9fr);
     gap: 2.25rem;
     padding-bottom: 2rem;
-    border-bottom: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
   }
 
   .hero-copy {
@@ -83,11 +81,9 @@ export const StyledWrapper = styled.div`
     width: 148px;
     border-radius: 999px;
     overflow: hidden;
-    border: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray1)};
-    box-shadow: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.shadow : "0 18px 38px rgba(0, 0, 0, 0.18)"};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => (theme.colors.gray1)};
+    box-shadow: ${({ theme }) => "0 18px 38px rgba(0, 0, 0, 0.18)"};
 
     &::after {
       content: "";
@@ -109,9 +105,8 @@ export const StyledWrapper = styled.div`
       min-height: 40px;
       padding: 0.68rem 0.92rem;
       border-radius: 999px;
-      border: 1px solid ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
-      background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray1)};
+      border: 1px solid ${({ theme }) => theme.colors.gray6};
+      background: ${({ theme }) => (theme.colors.gray1)};
       color: ${({ theme }) => theme.colors.gray12};
       font-size: 0.94rem;
       font-weight: 700;
@@ -119,10 +114,8 @@ export const StyledWrapper = styled.div`
       transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 
       &:hover {
-        background: ${({ theme }) =>
-          theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray2};
-        border-color: ${({ theme }) =>
-          theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray10};
+        background: ${({ theme }) => theme.colors.gray2};
+        border-color: ${({ theme }) => theme.colors.gray10};
         transform: translateY(-1px);
       }
     }
@@ -159,10 +152,9 @@ export const StyledWrapper = styled.div`
       grid-template-columns: minmax(0, 1fr) minmax(10rem, 15rem);
       gap: 1.1rem;
       padding: 1rem 1.1rem;
-      border: 1px solid ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+      border: 1px solid ${({ theme }) => theme.colors.gray6};
       border-radius: 16px;
-      background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray1)};
+      background: ${({ theme }) => (theme.colors.gray1)};
     }
   }
 
@@ -207,8 +199,7 @@ export const StyledWrapper = styled.div`
       align-items: center;
       min-height: 30px;
       padding: 0.42rem 0.7rem;
-      border: 1px solid ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+      border: 1px solid ${({ theme }) => theme.colors.gray6};
       border-radius: 999px;
       color: ${({ theme }) => theme.colors.gray12};
       font-size: 0.86rem;
@@ -216,8 +207,7 @@ export const StyledWrapper = styled.div`
       font-weight: 650;
 
       &:hover {
-        border-color: ${({ theme }) =>
-          theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray10};
+        border-color: ${({ theme }) => theme.colors.gray10};
         text-decoration: none;
       }
     }
@@ -253,8 +243,7 @@ export const StyledWrapper = styled.div`
 
   .supplemental-section[data-has-divider="true"] {
     padding-top: 1.2rem;
-    border-top: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+    border-top: 1px solid ${({ theme }) => theme.colors.gray6};
   }
 
   .supplemental-list {
@@ -276,12 +265,10 @@ export const StyledWrapper = styled.div`
 
   .compact-link-list {
     background: transparent;
-    border-bottom: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
 
     li + li {
-      border-top: 1px solid ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+      border-top: 1px solid ${({ theme }) => theme.colors.gray6};
     }
 
     a {
@@ -408,4 +395,4 @@ export const StyledWrapper = styled.div`
       font-size: 0.94rem;
     }
   }
-`
+`;

--- a/front/src/routes/Admin/EditorActualPreviewPage.tsx
+++ b/front/src/routes/Admin/EditorActualPreviewPage.tsx
@@ -1,84 +1,71 @@
-import styled from "@emotion/styled"
-import dynamic from "next/dynamic"
-import { NextPage } from "next"
-import { useRouter } from "next/router"
-import { useEffect, useMemo, useState } from "react"
-import AppIcon from "src/components/icons/AppIcon"
-import { AdminPageProps } from "src/libs/server/adminPage"
-import type { TPost } from "src/types"
-import PostHeader from "src/routes/Detail/PostDetail/PostHeader"
-import {
-  readEditorActualPreviewSnapshot,
-  toEditorActualPreviewRoute,
-  toPreviewPostStatus,
-  type EditorActualPreviewSnapshot,
-} from "./editorActualPreview"
-
+import styled from "@emotion/styled";
+import dynamic from "next/dynamic";
+import { NextPage } from "next";
+import { useRouter } from "next/router";
+import { useEffect, useMemo, useState } from "react";
+import AppIcon from "src/components/icons/AppIcon";
+import { AdminPageProps } from "src/libs/server/adminPage";
+import type { TPost } from "src/types";
+import PostHeader from "src/routes/Detail/PostDetail/PostHeader";
+import { readEditorActualPreviewSnapshot, toEditorActualPreviewRoute, toPreviewPostStatus, type EditorActualPreviewSnapshot, } from "./editorActualPreview";
 const LazyMarkdownRenderer = dynamic(() => import("src/routes/Detail/components/MarkdownRenderer"), {
-  ssr: false,
-  loading: () => <div style={{ padding: "1rem 1.1rem", color: "var(--color-gray10)" }}>실제 보기 준비 중...</div>,
-})
-
+    ssr: false,
+    loading: () => <div style={{ padding: "1rem 1.1rem", color: "var(--color-gray10)" }}>실제 보기 준비 중...</div>,
+});
 export const EditorActualPreviewPage: NextPage<AdminPageProps> = ({ initialMember }) => {
-  const router = useRouter()
-  const previewId = typeof router.query.id === "string" ? router.query.id : ""
-  const [snapshot, setSnapshot] = useState<EditorActualPreviewSnapshot | null>(null)
-
-  useEffect(() => {
-    if (!previewId) return
-
-    const sync = () => {
-      setSnapshot(readEditorActualPreviewSnapshot(previewId))
-    }
-
-    sync()
-
-    const handleStorage = (event: StorageEvent) => {
-      if (!event.key || !event.key.endsWith(previewId)) return
-      sync()
-    }
-
-    window.addEventListener("storage", handleStorage)
-    return () => window.removeEventListener("storage", handleStorage)
-  }, [previewId])
-
-  const previewPost = useMemo<TPost | null>(() => {
-    if (!snapshot) return null
-
-    return {
-      id: snapshot.id,
-      slug: snapshot.id,
-      type: ["Post"],
-      title: snapshot.title.trim() || "제목을 입력하세요",
-      summary: snapshot.summary.trim() || undefined,
-      tags: snapshot.tags,
-      author: [
-        {
-          id: String(initialMember.id),
-          name: snapshot.authorName || initialMember.nickname || initialMember.username || "관리자",
-          profile_photo: snapshot.authorImageUrl || undefined,
-        },
-      ],
-      date: { start_date: snapshot.createdAt },
-      createdTime: snapshot.createdAt,
-      modifiedTime: snapshot.createdAt,
-      status: toPreviewPostStatus(snapshot.visibility),
-      fullWidth: false,
-      thumbnail: snapshot.thumbnailUrl || undefined,
-      likesCount: 0,
-      commentsCount: 0,
-      hitCount: 0,
-      actorHasLiked: false,
-      actorCanModify: false,
-      actorCanDelete: false,
-    }
-  }, [initialMember.id, initialMember.nickname, initialMember.username, snapshot])
-
-  return (
-    <PreviewRoot>
+    const router = useRouter();
+    const previewId = typeof router.query.id === "string" ? router.query.id : "";
+    const [snapshot, setSnapshot] = useState<EditorActualPreviewSnapshot | null>(null);
+    useEffect(() => {
+        if (!previewId)
+            return;
+        const sync = () => {
+            setSnapshot(readEditorActualPreviewSnapshot(previewId));
+        };
+        sync();
+        const handleStorage = (event: StorageEvent) => {
+            if (!event.key || !event.key.endsWith(previewId))
+                return;
+            sync();
+        };
+        window.addEventListener("storage", handleStorage);
+        return () => window.removeEventListener("storage", handleStorage);
+    }, [previewId]);
+    const previewPost = useMemo<TPost | null>(() => {
+        if (!snapshot)
+            return null;
+        return {
+            id: snapshot.id,
+            slug: snapshot.id,
+            type: ["Post"],
+            title: snapshot.title.trim() || "제목을 입력하세요",
+            summary: snapshot.summary.trim() || undefined,
+            tags: snapshot.tags,
+            author: [
+                {
+                    id: String(initialMember.id),
+                    name: snapshot.authorName || initialMember.nickname || initialMember.username || "관리자",
+                    profile_photo: snapshot.authorImageUrl || undefined,
+                },
+            ],
+            date: { start_date: snapshot.createdAt },
+            createdTime: snapshot.createdAt,
+            modifiedTime: snapshot.createdAt,
+            status: toPreviewPostStatus(snapshot.visibility),
+            fullWidth: false,
+            thumbnail: snapshot.thumbnailUrl || undefined,
+            likesCount: 0,
+            commentsCount: 0,
+            hitCount: 0,
+            actorHasLiked: false,
+            actorCanModify: false,
+            actorCanDelete: false,
+        };
+    }, [initialMember.id, initialMember.nickname, initialMember.username, snapshot]);
+    return (<PreviewRoot>
       <PreviewTopBar>
         <button type="button" onClick={() => void router.push(toEditorActualPreviewRoute(previewId).replace("/preview/", "/"))}>
-          <AppIcon name="edit" />
+          <AppIcon name="edit"/>
           <span>편집기로 돌아가기</span>
         </button>
         <div>
@@ -87,36 +74,26 @@ export const EditorActualPreviewPage: NextPage<AdminPageProps> = ({ initialMembe
         </div>
       </PreviewTopBar>
 
-      {previewPost && snapshot ? (
-        <PreviewLayout>
+      {previewPost && snapshot ? (<PreviewLayout>
           <PreviewArticle>
-            <PostHeader data={previewPost} interactiveTags={false} showEngagement={false} />
+            <PostHeader data={previewPost} interactiveTags={false} showEngagement={false}/>
             <PreviewBody>
-              <LazyMarkdownRenderer content={snapshot.content} />
+              <LazyMarkdownRenderer content={snapshot.content}/>
             </PreviewBody>
           </PreviewArticle>
-        </PreviewLayout>
-      ) : (
-        <PreviewEmptyState>
+        </PreviewLayout>) : (<PreviewEmptyState>
           <strong>실제 보기 데이터를 찾을 수 없습니다.</strong>
           <span>편집 화면에서 다시 열어 주세요.</span>
-        </PreviewEmptyState>
-      )}
-    </PreviewRoot>
-  )
-}
-
-const PreviewRoot = styled.div`
+        </PreviewEmptyState>)}
+    </PreviewRoot>);
+};
+const PreviewRoot = styled.div `
   min-height: 100vh;
   padding: calc(var(--app-header-height, 64px) + 1.5rem) 1.5rem 3rem;
   background:
-    ${({ theme }) =>
-      theme.blogDesign === "grid"
-        ? `linear-gradient(180deg, color-mix(in srgb, ${theme.publicDesign.surfaceElevated} 52%, transparent), transparent 18rem), ${theme.publicDesign.pageBackgroundImage}`
-        : theme.colors.gray1};
-`
-
-const PreviewTopBar = styled.div`
+    ${({ theme }) => theme.colors.gray1};
+`;
+const PreviewTopBar = styled.div `
   width: min(100%, calc(var(--article-readable-width, 48rem) + 6rem));
   margin: 0 auto 1.6rem;
   display: flex;
@@ -130,7 +107,7 @@ const PreviewTopBar = styled.div`
     gap: 0.5rem;
     border: 0;
     background: transparent;
-    color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray12)};
+    color: ${({ theme }) => (theme.colors.gray12)};
     font-size: 0.95rem;
     font-weight: 700;
     cursor: pointer;
@@ -161,40 +138,36 @@ const PreviewTopBar = styled.div`
       justify-items: start;
     }
   }
-`
-
-const PreviewLayout = styled.div`
+`;
+const PreviewLayout = styled.div `
   width: min(100%, 74rem);
   margin: 0 auto;
   min-width: 0;
-`
-
-const PreviewArticle = styled.article`
+`;
+const PreviewArticle = styled.article `
   width: min(100%, var(--article-readable-width, 48rem));
   margin: 0 auto;
   display: grid;
   gap: 1.15rem;
   min-width: 0;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
-  padding: ${({ theme }) => (theme.blogDesign === "grid" ? "1rem" : "0")};
-  box-shadow: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.shadow : "none")};
-`
-
-const PreviewBody = styled.section`
+  border: 1px solid ${({ theme }) => ("transparent")};
+  border-radius: ${({ theme }) => ("0")};
+  background: ${({ theme }) => ("transparent")};
+  padding: ${({ theme }) => ("0")};
+  box-shadow: ${({ theme }) => ("none")};
+`;
+const PreviewBody = styled.section `
   min-width: 0;
-`
-
-const PreviewEmptyState = styled.div`
+`;
+const PreviewEmptyState = styled.div `
   width: min(100%, var(--article-readable-width, 48rem));
   margin: 4rem auto 0;
   display: grid;
   gap: 0.5rem;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
-  padding: ${({ theme }) => (theme.blogDesign === "grid" ? "1rem" : "0")};
+  border: 1px solid ${({ theme }) => ("transparent")};
+  border-radius: ${({ theme }) => ("0")};
+  background: ${({ theme }) => ("transparent")};
+  padding: ${({ theme }) => ("0")};
 
   strong {
     color: ${({ theme }) => theme.colors.gray12};
@@ -205,4 +178,4 @@ const PreviewEmptyState = styled.div`
     color: ${({ theme }) => theme.colors.gray10};
     font-size: 0.9rem;
   }
-`
+`;

--- a/front/src/routes/Admin/EditorStudioComposeWorkspace.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeWorkspace.tsx
@@ -1,309 +1,124 @@
-import styled from "@emotion/styled"
-import type {
-  ChangeEventHandler,
-  CSSProperties,
-  KeyboardEventHandler,
-  ReactNode,
-  Ref,
-} from "react"
-import type { PostVisibility } from "./editorStudioState"
-import { EditorStudioComposeAssistantPanel } from "./EditorStudioComposeAssistantPanel"
-import {
-  EditorStudioComposeMobileChrome,
-  type EditorStudioComposeMobileStatus,
-} from "./EditorStudioComposeMobileChrome"
-import { EditorStudioComposeWritingSurface } from "./EditorStudioComposeWritingSurface"
-import { EditorStudioMetadataAssistantPanel } from "./EditorStudioMetadataAssistantPanel"
-
-type NoticeTone = "idle" | "loading" | "success" | "error"
-type PreviewViewportMode = "desktop" | "tablet" | "mobile"
-
+import styled from "@emotion/styled";
+import type { ChangeEventHandler, CSSProperties, KeyboardEventHandler, ReactNode, Ref, } from "react";
+import type { PostVisibility } from "./editorStudioState";
+import { EditorStudioComposeAssistantPanel } from "./EditorStudioComposeAssistantPanel";
+import { EditorStudioComposeMobileChrome, type EditorStudioComposeMobileStatus, } from "./EditorStudioComposeMobileChrome";
+import { EditorStudioComposeWritingSurface } from "./EditorStudioComposeWritingSurface";
+import { EditorStudioMetadataAssistantPanel } from "./EditorStudioMetadataAssistantPanel";
+type NoticeTone = "idle" | "loading" | "success" | "error";
+type PreviewViewportMode = "desktop" | "tablet" | "mobile";
 type VisibilityOption = {
-  value: PostVisibility
-  label: string
-  description: string
-}
-
+    value: PostVisibility;
+    label: string;
+    description: string;
+};
 type PreviewViewportOption = {
-  value: PreviewViewportMode
-  label: string
-}
-
+    value: PreviewViewportMode;
+    label: string;
+};
 type ComposeStatusEntry = {
-  key: string
-  label: string
-  text: string
-  tone: NoticeTone
-}
-
+    key: string;
+    label: string;
+    text: string;
+    tone: NoticeTone;
+};
 type EditorStudioComposeWorkspaceProps = {
-  isCompactMobileLayout: boolean
-  isPublishModalOpen: boolean
-  mobilePrimaryStatus: EditorStudioComposeMobileStatus
-  mobileSecondaryStatusText?: string | null
-  mobilePrimaryActionLabel: string
-  composeCallToActionLabel: string
-  mobilePrimaryActionDisabled: boolean
-  onPrimaryAction: () => void
-  currentVisibilityText: string
-  editorModeLabel: string
-  composePageTitle: string
-  composeSurfaceSubtitle: string
-  composeStatusText: string
-  composeStatusTone: string
-  postSummary: string
-  postSummaryMaxLength: number
-  onPostSummaryChange: (value: string) => void
-  isFillSummaryFromBodyDisabled: boolean
-  onFillSummaryFromBody: () => void
-  postTags: string[]
-  tagDraft: string
-  onTagDraftChange: (value: string) => void
-  onAddTags: (values: string[]) => void
-  onAddTag: (value: string) => void
-  onRemoveTag: (value: string) => void
-  titleInputRef: (node: HTMLTextAreaElement | null) => void
-  postTitle: string
-  onPostTitleChange: ChangeEventHandler<HTMLTextAreaElement>
-  onPostTitleKeyDown: KeyboardEventHandler<HTMLTextAreaElement>
-  thumbnailImageFileInputRef: Ref<HTMLInputElement>
-  onThumbnailImageFileChange: ChangeEventHandler<HTMLInputElement>
-  contentLength: number
-  lineCount: number
-  imageCount: number
-  editorCanvas: ReactNode
-  tagSummaryText: string
-  isSaveDraftDisabled: boolean
-  onSaveLocalDraft: () => void
-  composeHeroSummary: string[]
-  isRecommendTagsDisabled: boolean
-  isRecommendTagsLoading: boolean
-  onRecommendTags: () => void
-  composeStatusEntries: ComposeStatusEntry[]
-  activeVisibility: PostVisibility
-  visibilityOptions: VisibilityOption[]
-  onVisibilityChange: (visibility: PostVisibility) => void
-  previewViewport: PreviewViewportMode
-  previewViewportLabel: string
-  previewViewportOptions: PreviewViewportOption[]
-  onPreviewViewportChange: (viewport: PreviewViewportMode) => void
-  previewFrameStyle?: CSSProperties
-  previewThumbnailSrc: string
-  postThumbnailFocusX: number
-  postThumbnailFocusY: number
-  postThumbnailZoom: number
-  onPreviewThumbnailError: () => void
-  previewVisibilityLabel: string
-  summaryPreview: string
-  previewDateText: string
-  previewAuthorAvatarSrc: string
-  displayNameInitial: string
-  displayName: string
-  summaryLengthLabel: string
-  isComposeAssistOpen: boolean
-  onToggleComposeAssist: () => void
-  thumbnailEditorPanel: ReactNode
-  previewMetaEditorPanel: ReactNode
-  isTagPanelOpen: boolean
-  onToggleTagPanel: () => void
-  isUtilityPanelOpen: boolean
-  onToggleUtilityPanel: () => void
-  metaNotice: {
-    tone: NoticeTone
-    text: string
-  }
-  knownTags: string[]
-  tagUsageMap: Record<string, number>
-  onToggleKnownTag: (tag: string) => void
-  onDeleteKnownTag: (tag: string) => void
-  onRestoreLocalDraft: () => void
-  onClearLocalDraft: () => void
-  isClearLocalDraftDisabled: boolean
-}
-
-export const EditorStudioComposeWorkspace = ({
-  isCompactMobileLayout,
-  isPublishModalOpen,
-  mobilePrimaryStatus,
-  mobileSecondaryStatusText,
-  mobilePrimaryActionLabel,
-  composeCallToActionLabel,
-  mobilePrimaryActionDisabled,
-  onPrimaryAction,
-  currentVisibilityText,
-  editorModeLabel,
-  composePageTitle,
-  composeSurfaceSubtitle,
-  composeStatusText,
-  composeStatusTone,
-  postSummary,
-  postSummaryMaxLength,
-  onPostSummaryChange,
-  isFillSummaryFromBodyDisabled,
-  onFillSummaryFromBody,
-  postTags,
-  tagDraft,
-  onTagDraftChange,
-  onAddTags,
-  onAddTag,
-  onRemoveTag,
-  titleInputRef,
-  postTitle,
-  onPostTitleChange,
-  onPostTitleKeyDown,
-  thumbnailImageFileInputRef,
-  onThumbnailImageFileChange,
-  contentLength,
-  lineCount,
-  imageCount,
-  editorCanvas,
-  tagSummaryText,
-  isSaveDraftDisabled,
-  onSaveLocalDraft,
-  composeHeroSummary,
-  isRecommendTagsDisabled,
-  isRecommendTagsLoading,
-  onRecommendTags,
-  composeStatusEntries,
-  activeVisibility,
-  visibilityOptions,
-  onVisibilityChange,
-  previewViewport,
-  previewViewportLabel,
-  previewViewportOptions,
-  onPreviewViewportChange,
-  previewFrameStyle,
-  previewThumbnailSrc,
-  postThumbnailFocusX,
-  postThumbnailFocusY,
-  postThumbnailZoom,
-  onPreviewThumbnailError,
-  previewVisibilityLabel,
-  summaryPreview,
-  previewDateText,
-  previewAuthorAvatarSrc,
-  displayNameInitial,
-  displayName,
-  summaryLengthLabel,
-  isComposeAssistOpen,
-  onToggleComposeAssist,
-  thumbnailEditorPanel,
-  previewMetaEditorPanel,
-  isTagPanelOpen,
-  onToggleTagPanel,
-  isUtilityPanelOpen,
-  onToggleUtilityPanel,
-  metaNotice,
-  knownTags,
-  tagUsageMap,
-  onToggleKnownTag,
-  onDeleteKnownTag,
-  onRestoreLocalDraft,
-  onClearLocalDraft,
-  isClearLocalDraftDisabled,
-}: EditorStudioComposeWorkspaceProps) => (
-  <ComposeSurfaceSection>
+    isCompactMobileLayout: boolean;
+    isPublishModalOpen: boolean;
+    mobilePrimaryStatus: EditorStudioComposeMobileStatus;
+    mobileSecondaryStatusText?: string | null;
+    mobilePrimaryActionLabel: string;
+    composeCallToActionLabel: string;
+    mobilePrimaryActionDisabled: boolean;
+    onPrimaryAction: () => void;
+    currentVisibilityText: string;
+    editorModeLabel: string;
+    composePageTitle: string;
+    composeSurfaceSubtitle: string;
+    composeStatusText: string;
+    composeStatusTone: string;
+    postSummary: string;
+    postSummaryMaxLength: number;
+    onPostSummaryChange: (value: string) => void;
+    isFillSummaryFromBodyDisabled: boolean;
+    onFillSummaryFromBody: () => void;
+    postTags: string[];
+    tagDraft: string;
+    onTagDraftChange: (value: string) => void;
+    onAddTags: (values: string[]) => void;
+    onAddTag: (value: string) => void;
+    onRemoveTag: (value: string) => void;
+    titleInputRef: (node: HTMLTextAreaElement | null) => void;
+    postTitle: string;
+    onPostTitleChange: ChangeEventHandler<HTMLTextAreaElement>;
+    onPostTitleKeyDown: KeyboardEventHandler<HTMLTextAreaElement>;
+    thumbnailImageFileInputRef: Ref<HTMLInputElement>;
+    onThumbnailImageFileChange: ChangeEventHandler<HTMLInputElement>;
+    contentLength: number;
+    lineCount: number;
+    imageCount: number;
+    editorCanvas: ReactNode;
+    tagSummaryText: string;
+    isSaveDraftDisabled: boolean;
+    onSaveLocalDraft: () => void;
+    composeHeroSummary: string[];
+    isRecommendTagsDisabled: boolean;
+    isRecommendTagsLoading: boolean;
+    onRecommendTags: () => void;
+    composeStatusEntries: ComposeStatusEntry[];
+    activeVisibility: PostVisibility;
+    visibilityOptions: VisibilityOption[];
+    onVisibilityChange: (visibility: PostVisibility) => void;
+    previewViewport: PreviewViewportMode;
+    previewViewportLabel: string;
+    previewViewportOptions: PreviewViewportOption[];
+    onPreviewViewportChange: (viewport: PreviewViewportMode) => void;
+    previewFrameStyle?: CSSProperties;
+    previewThumbnailSrc: string;
+    postThumbnailFocusX: number;
+    postThumbnailFocusY: number;
+    postThumbnailZoom: number;
+    onPreviewThumbnailError: () => void;
+    previewVisibilityLabel: string;
+    summaryPreview: string;
+    previewDateText: string;
+    previewAuthorAvatarSrc: string;
+    displayNameInitial: string;
+    displayName: string;
+    summaryLengthLabel: string;
+    isComposeAssistOpen: boolean;
+    onToggleComposeAssist: () => void;
+    thumbnailEditorPanel: ReactNode;
+    previewMetaEditorPanel: ReactNode;
+    isTagPanelOpen: boolean;
+    onToggleTagPanel: () => void;
+    isUtilityPanelOpen: boolean;
+    onToggleUtilityPanel: () => void;
+    metaNotice: {
+        tone: NoticeTone;
+        text: string;
+    };
+    knownTags: string[];
+    tagUsageMap: Record<string, number>;
+    onToggleKnownTag: (tag: string) => void;
+    onDeleteKnownTag: (tag: string) => void;
+    onRestoreLocalDraft: () => void;
+    onClearLocalDraft: () => void;
+    isClearLocalDraftDisabled: boolean;
+};
+export const EditorStudioComposeWorkspace = ({ isCompactMobileLayout, isPublishModalOpen, mobilePrimaryStatus, mobileSecondaryStatusText, mobilePrimaryActionLabel, composeCallToActionLabel, mobilePrimaryActionDisabled, onPrimaryAction, currentVisibilityText, editorModeLabel, composePageTitle, composeSurfaceSubtitle, composeStatusText, composeStatusTone, postSummary, postSummaryMaxLength, onPostSummaryChange, isFillSummaryFromBodyDisabled, onFillSummaryFromBody, postTags, tagDraft, onTagDraftChange, onAddTags, onAddTag, onRemoveTag, titleInputRef, postTitle, onPostTitleChange, onPostTitleKeyDown, thumbnailImageFileInputRef, onThumbnailImageFileChange, contentLength, lineCount, imageCount, editorCanvas, tagSummaryText, isSaveDraftDisabled, onSaveLocalDraft, composeHeroSummary, isRecommendTagsDisabled, isRecommendTagsLoading, onRecommendTags, composeStatusEntries, activeVisibility, visibilityOptions, onVisibilityChange, previewViewport, previewViewportLabel, previewViewportOptions, onPreviewViewportChange, previewFrameStyle, previewThumbnailSrc, postThumbnailFocusX, postThumbnailFocusY, postThumbnailZoom, onPreviewThumbnailError, previewVisibilityLabel, summaryPreview, previewDateText, previewAuthorAvatarSrc, displayNameInitial, displayName, summaryLengthLabel, isComposeAssistOpen, onToggleComposeAssist, thumbnailEditorPanel, previewMetaEditorPanel, isTagPanelOpen, onToggleTagPanel, isUtilityPanelOpen, onToggleUtilityPanel, metaNotice, knownTags, tagUsageMap, onToggleKnownTag, onDeleteKnownTag, onRestoreLocalDraft, onClearLocalDraft, isClearLocalDraftDisabled, }: EditorStudioComposeWorkspaceProps) => (<ComposeSurfaceSection>
     <EditorSection>
-      <EditorStudioComposeMobileChrome
-        showStatus={isCompactMobileLayout}
-        showAction={isCompactMobileLayout && !isPublishModalOpen}
-        primaryStatus={mobilePrimaryStatus}
-        visibilityText={currentVisibilityText}
-        secondaryStatusText={mobileSecondaryStatusText}
-        primaryActionLabel={mobilePrimaryActionLabel}
-        primaryActionDisabled={mobilePrimaryActionDisabled}
-        onPrimaryAction={onPrimaryAction}
-      />
+      <EditorStudioComposeMobileChrome showStatus={isCompactMobileLayout} showAction={isCompactMobileLayout && !isPublishModalOpen} primaryStatus={mobilePrimaryStatus} visibilityText={currentVisibilityText} secondaryStatusText={mobileSecondaryStatusText} primaryActionLabel={mobilePrimaryActionLabel} primaryActionDisabled={mobilePrimaryActionDisabled} onPrimaryAction={onPrimaryAction}/>
       <ComposeStudioLayout>
-        <EditorStudioComposeWritingSurface
-          editorModeLabel={editorModeLabel}
-          composePageTitle={composePageTitle}
-          composeSurfaceSubtitle={composeSurfaceSubtitle}
-          composeStatusText={composeStatusText}
-          composeStatusTone={composeStatusTone}
-          currentVisibilityText={currentVisibilityText}
-          postSummary={postSummary}
-          postSummaryMaxLength={postSummaryMaxLength}
-          onPostSummaryChange={onPostSummaryChange}
-          isFillSummaryFromBodyDisabled={isFillSummaryFromBodyDisabled}
-          onFillSummaryFromBody={onFillSummaryFromBody}
-          postTags={postTags}
-          tagDraft={tagDraft}
-          onTagDraftChange={onTagDraftChange}
-          onAddTags={onAddTags}
-          onAddTag={onAddTag}
-          onRemoveTag={onRemoveTag}
-          titleInputRef={titleInputRef}
-          postTitle={postTitle}
-          onPostTitleChange={onPostTitleChange}
-          onPostTitleKeyDown={onPostTitleKeyDown}
-          thumbnailImageFileInputRef={thumbnailImageFileInputRef}
-          onThumbnailImageFileChange={onThumbnailImageFileChange}
-          contentLength={contentLength}
-          lineCount={lineCount}
-          imageCount={imageCount}
-          editorCanvas={editorCanvas}
-          tagSummaryText={tagSummaryText}
-          isSaveDraftDisabled={isSaveDraftDisabled}
-          onSaveDraft={onSaveLocalDraft}
-          primaryActionDisabled={mobilePrimaryActionDisabled}
-          primaryActionLabel={composeCallToActionLabel}
-          onPrimaryAction={onPrimaryAction}
-        />
+        <EditorStudioComposeWritingSurface editorModeLabel={editorModeLabel} composePageTitle={composePageTitle} composeSurfaceSubtitle={composeSurfaceSubtitle} composeStatusText={composeStatusText} composeStatusTone={composeStatusTone} currentVisibilityText={currentVisibilityText} postSummary={postSummary} postSummaryMaxLength={postSummaryMaxLength} onPostSummaryChange={onPostSummaryChange} isFillSummaryFromBodyDisabled={isFillSummaryFromBodyDisabled} onFillSummaryFromBody={onFillSummaryFromBody} postTags={postTags} tagDraft={tagDraft} onTagDraftChange={onTagDraftChange} onAddTags={onAddTags} onAddTag={onAddTag} onRemoveTag={onRemoveTag} titleInputRef={titleInputRef} postTitle={postTitle} onPostTitleChange={onPostTitleChange} onPostTitleKeyDown={onPostTitleKeyDown} thumbnailImageFileInputRef={thumbnailImageFileInputRef} onThumbnailImageFileChange={onThumbnailImageFileChange} contentLength={contentLength} lineCount={lineCount} imageCount={imageCount} editorCanvas={editorCanvas} tagSummaryText={tagSummaryText} isSaveDraftDisabled={isSaveDraftDisabled} onSaveDraft={onSaveLocalDraft} primaryActionDisabled={mobilePrimaryActionDisabled} primaryActionLabel={composeCallToActionLabel} onPrimaryAction={onPrimaryAction}/>
 
         <ComposeAssistantColumn>
-          <EditorStudioComposeAssistantPanel
-            composeHeroSummary={composeHeroSummary}
-            publishAction={
-              <PrimaryButton type="button" disabled={mobilePrimaryActionDisabled} onClick={onPrimaryAction}>
+          <EditorStudioComposeAssistantPanel composeHeroSummary={composeHeroSummary} publishAction={<PrimaryButton type="button" disabled={mobilePrimaryActionDisabled} onClick={onPrimaryAction}>
                 {composeCallToActionLabel}
-              </PrimaryButton>
-            }
-            tagRecommendationAction={
-              <Button type="button" disabled={isRecommendTagsDisabled} onClick={onRecommendTags}>
+              </PrimaryButton>} tagRecommendationAction={<Button type="button" disabled={isRecommendTagsDisabled} onClick={onRecommendTags}>
                 {isRecommendTagsLoading ? "태그 제안 중..." : "태그 제안"}
-              </Button>
-            }
-            composeStatusEntries={composeStatusEntries}
-            activeVisibility={activeVisibility}
-            visibilityOptions={visibilityOptions}
-            onVisibilityChange={onVisibilityChange}
-            previewViewport={previewViewport}
-            previewViewportLabel={previewViewportLabel}
-            previewViewportOptions={previewViewportOptions}
-            onPreviewViewportChange={onPreviewViewportChange}
-            previewFrameStyle={previewFrameStyle}
-            previewThumbnailSrc={previewThumbnailSrc}
-            postThumbnailFocusX={postThumbnailFocusX}
-            postThumbnailFocusY={postThumbnailFocusY}
-            postThumbnailZoom={postThumbnailZoom}
-            onPreviewThumbnailError={onPreviewThumbnailError}
-            previewVisibilityLabel={previewVisibilityLabel}
-            postTitle={postTitle}
-            summaryPreview={summaryPreview}
-            previewDateText={previewDateText}
-            previewAuthorAvatarSrc={previewAuthorAvatarSrc}
-            displayNameInitial={displayNameInitial}
-            displayName={displayName}
-            summaryLengthLabel={summaryLengthLabel}
-            isComposeAssistOpen={isComposeAssistOpen}
-            onToggleComposeAssist={onToggleComposeAssist}
-            thumbnailEditorPanel={thumbnailEditorPanel}
-            previewMetaEditorPanel={previewMetaEditorPanel}
-          >
-            <EditorStudioMetadataAssistantPanel
-              isTagPanelOpen={isTagPanelOpen}
-              onToggleTagPanel={onToggleTagPanel}
-              isUtilityPanelOpen={isUtilityPanelOpen}
-              onToggleUtilityPanel={onToggleUtilityPanel}
-              metaNotice={metaNotice}
-              knownTags={knownTags}
-              selectedTags={postTags}
-              tagUsageMap={tagUsageMap}
-              onToggleTag={onToggleKnownTag}
-              onDeleteTag={onDeleteKnownTag}
-              utilityActions={
-                <SubActionRow>
+              </Button>} composeStatusEntries={composeStatusEntries} activeVisibility={activeVisibility} visibilityOptions={visibilityOptions} onVisibilityChange={onVisibilityChange} previewViewport={previewViewport} previewViewportLabel={previewViewportLabel} previewViewportOptions={previewViewportOptions} onPreviewViewportChange={onPreviewViewportChange} previewFrameStyle={previewFrameStyle} previewThumbnailSrc={previewThumbnailSrc} postThumbnailFocusX={postThumbnailFocusX} postThumbnailFocusY={postThumbnailFocusY} postThumbnailZoom={postThumbnailZoom} onPreviewThumbnailError={onPreviewThumbnailError} previewVisibilityLabel={previewVisibilityLabel} postTitle={postTitle} summaryPreview={summaryPreview} previewDateText={previewDateText} previewAuthorAvatarSrc={previewAuthorAvatarSrc} displayNameInitial={displayNameInitial} displayName={displayName} summaryLengthLabel={summaryLengthLabel} isComposeAssistOpen={isComposeAssistOpen} onToggleComposeAssist={onToggleComposeAssist} thumbnailEditorPanel={thumbnailEditorPanel} previewMetaEditorPanel={previewMetaEditorPanel}>
+            <EditorStudioMetadataAssistantPanel isTagPanelOpen={isTagPanelOpen} onToggleTagPanel={onToggleTagPanel} isUtilityPanelOpen={isUtilityPanelOpen} onToggleUtilityPanel={onToggleUtilityPanel} metaNotice={metaNotice} knownTags={knownTags} selectedTags={postTags} tagUsageMap={tagUsageMap} onToggleTag={onToggleKnownTag} onDeleteTag={onDeleteKnownTag} utilityActions={<SubActionRow>
                   <Button type="button" disabled={isSaveDraftDisabled} onClick={onSaveLocalDraft}>
                     브라우저 임시저장
                   </Button>
@@ -313,29 +128,22 @@ export const EditorStudioComposeWorkspace = ({
                   <Button type="button" disabled={isClearLocalDraftDisabled} onClick={onClearLocalDraft}>
                     임시저장 삭제
                   </Button>
-                </SubActionRow>
-              }
-            />
+                </SubActionRow>}/>
           </EditorStudioComposeAssistantPanel>
         </ComposeAssistantColumn>
       </ComposeStudioLayout>
     </EditorSection>
-  </ComposeSurfaceSection>
-)
-
-const ComposeSurfaceSection = styled.section`
+  </ComposeSurfaceSection>);
+const ComposeSurfaceSection = styled.section `
   display: grid;
   gap: 1.2rem;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray4)};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "14px")};
+  border: 1px solid ${({ theme }) => (theme.colors.gray4)};
+  border-radius: ${({ theme }) => ("14px")};
   padding: 1.1rem 1.1rem 1.3rem;
   margin-bottom: 1.2rem;
   background:
-    ${({ theme }) =>
-      theme.blogDesign === "grid"
-        ? `linear-gradient(180deg, ${theme.publicDesign.operationSurfaceElevated}, ${theme.publicDesign.operationSurface})`
-        : `radial-gradient(circle at top left, rgba(96, 165, 250, 0.04), transparent 24%), ${theme.colors.gray1}`};
-  box-shadow: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.shadow : "none")};
+    ${({ theme }) => `radial-gradient(circle at top left, rgba(96, 165, 250, 0.04), transparent 24%), ${theme.colors.gray1}`};
+  box-shadow: ${({ theme }) => ("none")};
 
   h2 {
     margin: 0;
@@ -349,9 +157,8 @@ const ComposeSurfaceSection = styled.section`
     padding: 0.82rem 0.82rem 1rem;
     margin-bottom: 0.95rem;
   }
-`
-
-const EditorSection = styled.div`
+`;
+const EditorSection = styled.div `
   margin: 1.12rem 0 0.25rem;
   border: none;
   border-radius: 0;
@@ -362,9 +169,8 @@ const EditorSection = styled.div`
     padding: 0;
     margin-top: 0.92rem;
   }
-`
-
-const ComposeStudioLayout = styled.div`
+`;
+const ComposeStudioLayout = styled.div `
   display: grid;
   gap: 1.4rem;
   align-items: start;
@@ -376,19 +182,17 @@ const ComposeStudioLayout = styled.div`
   @media (max-width: 720px) {
     gap: 1rem;
   }
-`
-
-const ComposeAssistantColumn = styled.aside`
+`;
+const ComposeAssistantColumn = styled.aside `
   min-width: 0;
-`
-
-const SubActionRow = styled.div`
+`;
+const SubActionRow = styled.div `
   display: flex;
   flex-wrap: wrap;
   gap: 0.45rem;
   margin-top: 0.65rem;
   padding-top: 0.65rem;
-  border-top: 1px dashed ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
+  border-top: 1px dashed ${({ theme }) => (theme.colors.gray6)};
 
   > button {
     border-style: dashed;
@@ -403,14 +207,13 @@ const SubActionRow = styled.div`
       justify-content: center;
     }
   }
-`
-
-const Button = styled.button`
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
+`;
+const Button = styled.button `
+  border: 1px solid ${({ theme }) => (theme.colors.gray6)};
   border-radius: 8px;
   padding: 0.62rem 0.92rem;
   min-height: 44px;
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : "transparent")};
+  background: ${({ theme }) => ("transparent")};
   color: ${({ theme }) => theme.colors.gray10};
   cursor: pointer;
   font-size: 0.84rem;
@@ -422,34 +225,33 @@ const Button = styled.button`
     box-shadow 0.18s ease;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray8)};
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3)};
+    border-color: ${({ theme }) => (theme.colors.gray8)};
+    background: ${({ theme }) => (theme.colors.gray3)};
     color: ${({ theme }) => theme.colors.gray12};
   }
 
   &:focus-visible {
     outline: none;
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue8)};
-    box-shadow: 0 0 0 3px ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.blue4)};
+    border-color: ${({ theme }) => (theme.colors.blue8)};
+    box-shadow: 0 0 0 3px ${({ theme }) => (theme.colors.blue4)};
   }
 
   &:disabled {
     opacity: 0.45;
     cursor: not-allowed;
   }
-`
-
-const PrimaryButton = styled(Button)`
+`;
+const PrimaryButton = styled(Button) `
   border-radius: 8px;
   padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue9)};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue9)};
-  color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.pageBackgroundColor : theme.colors.gray1)};
+  border-color: ${({ theme }) => (theme.colors.blue9)};
+  background: ${({ theme }) => (theme.colors.blue9)};
+  color: ${({ theme }) => (theme.colors.gray1)};
   font-weight: 700;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.blue10)};
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.blue10)};
-    color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.pageBackgroundColor : theme.colors.gray1)};
+    border-color: ${({ theme }) => (theme.colors.blue10)};
+    background: ${({ theme }) => (theme.colors.blue10)};
+    color: ${({ theme }) => (theme.colors.gray1)};
   }
-`
+`;

--- a/front/src/routes/Admin/EditorStudioComposeWritingSurfaceParts.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeWritingSurfaceParts.tsx
@@ -1,13 +1,11 @@
-import styled from "@emotion/styled"
-import { articleTypographyScale } from "src/libs/markdown/contentTypography"
-
-export const EditorStudioComposeMainColumn = styled.div`
+import styled from "@emotion/styled";
+import { articleTypographyScale } from "src/libs/markdown/contentTypography";
+export const EditorStudioComposeMainColumn = styled.div `
   display: grid;
   gap: 1.1rem;
   min-width: 0;
-`
-
-export const EditorStudioComposeHeaderSection = styled.div`
+`;
+export const EditorStudioComposeHeaderSection = styled.div `
   display: grid;
   gap: 0.9rem;
 
@@ -15,9 +13,8 @@ export const EditorStudioComposeHeaderSection = styled.div`
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: start;
   }
-`
-
-export const ComposeStudioHeaderCopy = styled.div`
+`;
+export const ComposeStudioHeaderCopy = styled.div `
   display: grid;
   gap: 0.28rem;
   min-width: 0;
@@ -38,20 +35,18 @@ export const ComposeStudioHeaderCopy = styled.div`
     line-height: 1.58;
     max-width: 34rem;
   }
-`
-
-export const ComposeStudioKicker = styled.span`
+`;
+export const ComposeStudioKicker = styled.span `
   display: inline-flex;
   align-items: center;
   width: fit-content;
-  color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray10)};
+  color: ${({ theme }) => (theme.colors.gray10)};
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0;
   text-transform: uppercase;
-`
-
-export const ComposeStudioContextBar = styled.div`
+`;
+export const ComposeStudioContextBar = styled.div `
   display: flex;
   flex-wrap: wrap;
   gap: 0.45rem;
@@ -60,16 +55,15 @@ export const ComposeStudioContextBar = styled.div`
   @media (min-width: 960px) {
     justify-content: flex-end;
   }
-`
-
-export const ComposeStudioContextItem = styled.div`
+`;
+export const ComposeStudioContextItem = styled.div `
   display: grid;
   gap: 0.08rem;
   min-width: 7rem;
   padding: 0.5rem 0.68rem;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "4px" : "12px")};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2)};
+  border: 1px solid ${({ theme }) => (theme.colors.gray5)};
+  border-radius: ${({ theme }) => ("12px")};
+  background: ${({ theme }) => (theme.colors.gray2)};
 
   span {
     color: ${({ theme }) => theme.colors.gray10};
@@ -95,9 +89,8 @@ export const ComposeStudioContextItem = styled.div`
   &[data-tone="error"] strong {
     color: ${({ theme }) => theme.colors.red11};
   }
-`
-
-export const WriterHeader = styled.div`
+`;
+export const WriterHeader = styled.div `
   display: grid;
   grid-template-columns: 1fr;
   gap: 1rem;
@@ -108,16 +101,14 @@ export const WriterHeader = styled.div`
     gap: 1rem;
     min-width: 0;
   }
-`
-
-export const WriterAccent = styled.div`
+`;
+export const WriterAccent = styled.div `
   width: 5rem;
   height: 0.42rem;
   border-radius: 999px;
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray8)};
-`
-
-export const TitleInput = styled.textarea`
+  background: ${({ theme }) => (theme.colors.gray8)};
+`;
+export const TitleInput = styled.textarea `
   width: 100%;
   min-width: 0;
   border: 0;
@@ -149,39 +140,35 @@ export const TitleInput = styled.textarea`
     font-size: ${articleTypographyScale.postTitleFontSizeMobile};
     line-height: ${articleTypographyScale.postTitleLineHeightMobile};
   }
-`
-
-export const EditorStudioComposeMetadataSection = styled.div`
+`;
+export const EditorStudioComposeMetadataSection = styled.div `
   width: 100%;
   max-width: var(--article-readable-width, 48rem);
   min-width: 0;
   margin-inline: auto;
   display: grid;
   gap: 1rem;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
-  padding: ${({ theme }) => (theme.blogDesign === "grid" ? "1rem" : "0")};
-`
-
-export const ComposeSummaryField = styled.div`
+  border: 1px solid ${({ theme }) => ("transparent")};
+  border-radius: ${({ theme }) => ("0")};
+  background: ${({ theme }) => ("transparent")};
+  padding: ${({ theme }) => ("0")};
+`;
+export const ComposeSummaryField = styled.div `
   display: grid;
   gap: 0.45rem;
-`
-
-export const FieldLabel = styled.label`
+`;
+export const FieldLabel = styled.label `
   font-size: 0.8rem;
   font-weight: 650;
   color: ${({ theme }) => theme.colors.gray11};
-`
-
-export const ComposeSummaryInput = styled.textarea`
+`;
+export const ComposeSummaryInput = styled.textarea `
   width: 100%;
   min-height: 5.6rem;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "4px" : "16px")};
+  border: 1px solid ${({ theme }) => (theme.colors.gray5)};
+  border-radius: ${({ theme }) => ("16px")};
   padding: 0.95rem 1rem;
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray2)};
+  background: ${({ theme }) => (theme.colors.gray2)};
   color: ${({ theme }) => theme.colors.gray12};
   font-size: 1rem;
   line-height: 1.7;
@@ -193,27 +180,24 @@ export const ComposeSummaryInput = styled.textarea`
 
   &:focus-visible {
     outline: none;
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray7)};
-    box-shadow: 0 0 0 3px ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.blue4)};
+    border-color: ${({ theme }) => (theme.colors.gray7)};
+    box-shadow: 0 0 0 3px ${({ theme }) => (theme.colors.blue4)};
   }
-`
-
-export const ComposeSummaryMeta = styled.div`
+`;
+export const ComposeSummaryMeta = styled.div `
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.7rem;
   flex-wrap: wrap;
-`
-
-export const SummaryCounter = styled.span`
+`;
+export const SummaryCounter = styled.span `
   justify-self: end;
   color: ${({ theme }) => theme.colors.gray10};
   font-size: 0.74rem;
   line-height: 1;
-`
-
-export const InlineTagComposer = styled.div`
+`;
+export const InlineTagComposer = styled.div `
   display: grid;
   gap: 0.55rem;
   min-width: 0;
@@ -237,9 +221,8 @@ export const InlineTagComposer = styled.div`
     font-size: 0.78rem;
     font-weight: 600;
   }
-`
-
-export const InlineTagList = styled.div`
+`;
+export const InlineTagList = styled.div `
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
@@ -249,9 +232,8 @@ export const InlineTagList = styled.div`
   border: none;
   background: transparent;
   padding: 0;
-`
-
-export const InlineMetaInput = styled.input`
+`;
+export const InlineMetaInput = styled.input `
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
@@ -277,9 +259,8 @@ export const InlineMetaInput = styled.input`
     border-color: ${({ theme }) => theme.colors.blue8};
     box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
   }
-`
-
-export const SelectedTagChip = styled.span`
+`;
+export const SelectedTagChip = styled.span `
   display: inline-flex;
   align-items: stretch;
   gap: 0;
@@ -287,8 +268,8 @@ export const SelectedTagChip = styled.span`
   max-width: 100%;
   min-height: 32px;
   border-radius: 999px;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3)};
+  border: 1px solid ${({ theme }) => (theme.colors.gray6)};
+  background: ${({ theme }) => (theme.colors.gray3)};
   overflow: hidden;
   transition:
     border-color 0.18s ease,
@@ -321,8 +302,8 @@ export const SelectedTagChip = styled.span`
     min-width: 1.92rem;
     padding: 0 0.52rem;
     border: 0;
-    border-left: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray2)};
+    border-left: 1px solid ${({ theme }) => (theme.colors.gray6)};
+    background: ${({ theme }) => (theme.colors.gray2)};
     color: ${({ theme }) => theme.colors.gray10};
     cursor: pointer;
     flex: 0 0 auto;
@@ -339,14 +320,12 @@ export const SelectedTagChip = styled.span`
       color: ${({ theme }) => theme.colors.gray12};
     }
   }
-`
-
-export const EditorStudioComposeBodySection = styled.section`
+`;
+export const EditorStudioComposeBodySection = styled.section `
   display: grid;
   gap: 0.82rem;
-`
-
-export const ComposeBodyHeader = styled.div`
+`;
+export const ComposeBodyHeader = styled.div `
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
@@ -361,9 +340,8 @@ export const ComposeBodyHeader = styled.div`
     flex-direction: column;
     align-items: flex-start;
   }
-`
-
-export const ComposeBodyTitleGroup = styled.div`
+`;
+export const ComposeBodyTitleGroup = styled.div `
   display: grid;
   gap: 0.14rem;
 
@@ -374,9 +352,8 @@ export const ComposeBodyTitleGroup = styled.div`
     font-weight: 760;
     line-height: 1.3;
   }
-`
-
-export const ComposeBodyMetrics = styled.div`
+`;
+export const ComposeBodyMetrics = styled.div `
   display: flex;
   align-items: center;
   gap: 0.55rem;
@@ -384,9 +361,8 @@ export const ComposeBodyMetrics = styled.div`
   color: ${({ theme }) => theme.colors.gray10};
   font-size: 0.76rem;
   line-height: 1.4;
-`
-
-export const EditorStudioComposeFooterBar = styled.div`
+`;
+export const EditorStudioComposeFooterBar = styled.div `
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -395,18 +371,16 @@ export const EditorStudioComposeFooterBar = styled.div`
   margin-top: 0.84rem;
   padding-top: 0.72rem;
   border-top: 1px solid ${({ theme }) => theme.colors.gray6};
-`
-
-export const WriterFooterSummary = styled.div`
+`;
+export const WriterFooterSummary = styled.div `
   display: flex;
   flex-wrap: wrap;
   gap: 0.52rem 0.72rem;
   color: ${({ theme }) => theme.colors.gray11};
   font-size: 0.76rem;
   line-height: 1.45;
-`
-
-export const WriterFooterControls = styled.div`
+`;
+export const WriterFooterControls = styled.div `
   display: grid;
   gap: 0.52rem;
   justify-items: stretch;
@@ -420,9 +394,8 @@ export const WriterFooterControls = styled.div`
     width: 100%;
     min-width: 100%;
   }
-`
-
-export const WriterFooterActions = styled.div`
+`;
+export const WriterFooterActions = styled.div `
   display: flex;
   flex-wrap: wrap;
   gap: 0.55rem;
@@ -432,9 +405,8 @@ export const WriterFooterActions = styled.div`
   @media (max-width: 720px) {
     display: none;
   }
-`
-
-export const Button = styled.button`
+`;
+export const Button = styled.button `
   border: 1px solid ${({ theme }) => theme.colors.gray6};
   border-radius: 8px;
   padding: 0.62rem 0.92rem;
@@ -466,9 +438,8 @@ export const Button = styled.button`
     opacity: 0.45;
     cursor: not-allowed;
   }
-`
-
-export const PrimaryButton = styled(Button)`
+`;
+export const PrimaryButton = styled(Button) `
   border-radius: 8px;
   padding: 0.6rem 0.88rem;
   border-color: ${({ theme }) => theme.colors.blue9};
@@ -481,4 +452,4 @@ export const PrimaryButton = styled(Button)`
     background: ${({ theme }) => theme.colors.blue10};
     color: ${({ theme }) => theme.colors.gray1};
   }
-`
+`;

--- a/front/src/routes/Admin/EditorStudioContentWorkspace.tsx
+++ b/front/src/routes/Admin/EditorStudioContentWorkspace.tsx
@@ -1,337 +1,139 @@
-import styled from "@emotion/styled"
-import type { ChangeEvent } from "react"
-import type { EditorMode, PostVisibility } from "./editorStudioState"
-import { EditorStudioMobileStepNavigator } from "./EditorStudioMobileStepNavigator"
-import { EditorStudioPostListPanel } from "./EditorStudioPostListPanel"
-import type { EditorStudioPostListItem } from "./EditorStudioPostListPanel"
-import { EditorStudioPostQueryPanel } from "./EditorStudioPostQueryPanel"
-import { EditorStudioSelectedPostPanel } from "./EditorStudioSelectedPostPanel"
-import { EditorStudioSelectedPostToolsPanel } from "./EditorStudioSelectedPostToolsPanel"
-import { EditorStudioUndoToast } from "./EditorStudioUndoToast"
-
-type NoticeTone = "idle" | "loading" | "success" | "error"
-type ManageMobileStudioStep = "query" | "list"
-type MobileStudioStep = "query" | "list" | "edit" | "publish"
-type PostListScope = "active" | "deleted"
-type ListQuickPreset = "none" | "today" | "temp"
-
+import styled from "@emotion/styled";
+import type { ChangeEvent } from "react";
+import type { EditorMode, PostVisibility } from "./editorStudioState";
+import { EditorStudioMobileStepNavigator } from "./EditorStudioMobileStepNavigator";
+import { EditorStudioPostListPanel } from "./EditorStudioPostListPanel";
+import type { EditorStudioPostListItem } from "./EditorStudioPostListPanel";
+import { EditorStudioPostQueryPanel } from "./EditorStudioPostQueryPanel";
+import { EditorStudioSelectedPostPanel } from "./EditorStudioSelectedPostPanel";
+import { EditorStudioSelectedPostToolsPanel } from "./EditorStudioSelectedPostToolsPanel";
+import { EditorStudioUndoToast } from "./EditorStudioUndoToast";
+type NoticeTone = "idle" | "loading" | "success" | "error";
+type ManageMobileStudioStep = "query" | "list";
+type MobileStudioStep = "query" | "list" | "edit" | "publish";
+type PostListScope = "active" | "deleted";
+type ListQuickPreset = "none" | "today" | "temp";
 type NoticeState = {
-  tone: NoticeTone
-  text: string
-}
-
+    tone: NoticeTone;
+    text: string;
+};
 type ListSortOption = {
-  value: string
-  label: string
-}
-
+    value: string;
+    label: string;
+};
 type EditorStudioContentWorkspaceProps = {
-  shouldShowGlobalNotice: boolean
-  globalNotice: NoticeState
-  mobileStudioSurfaceSteps: readonly MobileStudioStep[]
-  activeMobileStudioStep: MobileStudioStep
-  mobileStudioStepLabels: Record<MobileStudioStep, string>
-  mobileStudioStepDescriptions: Record<MobileStudioStep, string>
-  mobileStudioPrevStep: MobileStudioStep | null
-  mobileStudioNextStep: MobileStudioStep | null
-  mobileStudioPrevStepLabel: string
-  mobileStudioNextStepLabel: string
-  isCompactMobileLayout: boolean
-  onMobileStepChange: (step: MobileStudioStep) => void
-  listScope: PostListScope
-  listKeyword: string
-  listQuickPreset: ListQuickPreset
-  hasListFiltersApplied: boolean
-  isListAdvancedOpen: boolean
-  listPage: string
-  listPageSize: string
-  listSort: string
-  listSortOptions: readonly ListSortOption[]
-  isListRefreshDisabled: boolean
-  isTempPostDisabled: boolean
-  onListScopeChange: (scope: PostListScope) => void
-  onListKeywordChange: (value: string) => void
-  onRefreshList: () => void
-  onLoadOrCreateTempPost: () => void
-  onApplyQuickPreset: (preset: Exclude<ListQuickPreset, "none">) => void
-  onResetFilters: () => void
-  onToggleListAdvanced: () => void
-  onListPageChange: (event: ChangeEvent<HTMLInputElement>) => void
-  onListPageSizeChange: (event: ChangeEvent<HTMLInputElement>) => void
-  onListSortChange: (event: ChangeEvent<HTMLSelectElement>) => void
-  selectedPostIds: readonly number[]
-  adminPostTotal: number
-  adminPostRows: readonly EditorStudioPostListItem[]
-  adminPostViewRows: readonly EditorStudioPostListItem[]
-  isAllVisiblePostsSelected: boolean
-  selectedPostIdSet: ReadonlySet<number>
-  editorMode: EditorMode
-  postId: string
-  loadingKey: string
-  modifiedSortOrder: "desc" | "asc"
-  deletedListNotice: NoticeState
-  onToggleSelectAllVisiblePosts: () => void
-  onClearSelection: () => void
-  onRequestDeletePosts: (ids: number[], headline?: string) => void
-  onTogglePostSelection: (id: number) => void
-  onToggleModifiedSortOrder: () => void
-  onEditPost: (row: EditorStudioPostListItem) => void
-  onOpenPostDetail: (id: number) => void
-  onCopyPostDetailLink: (id: number, title: string) => void
-  onRestoreDeletedPost: (row: EditorStudioPostListItem) => void
-  onHardDeletePost: (row: EditorStudioPostListItem) => void
-  showSelectedPanelInManageSurface: boolean
-  hasSelectedManagedPost: boolean
-  editorModeLabel: string
-  selectedPostLabel: string
-  postTitle: string
-  postVersion: number | null
-  isTempDraftMode: boolean
-  postVisibility: PostVisibility
-  currentVisibilityText: string
-  isContinueEditingDisabled: boolean
-  isCreateNewPostDisabled: boolean
-  isDeletePostDisabled: boolean
-  onContinueEditing: () => void
-  onCreateNewPost: () => void
-  onDeletePost: () => void
-  isDirectLoadOpen: boolean
-  onToggleDirectLoad: () => void
-  isSelectedToolsOpen: boolean
-  onToggleSelectedTools: () => void
-  onPostIdChange: (postId: string) => void
-  isLoadPostDisabled: boolean
-  onLoadPost: () => void
-  isHitPostDisabled: boolean
-  onRunHitPost: () => void
-  isLikePostDisabled: boolean
-  onRunLikePost: () => void
-  softDeleteUndoMessage: string
-  isSoftDeleteUndoVisible: boolean
-  isUndoDisabled: boolean
-  onUndoSoftDelete: () => void
-}
-
-export const EditorStudioContentWorkspace = ({
-  shouldShowGlobalNotice,
-  globalNotice,
-  mobileStudioSurfaceSteps,
-  activeMobileStudioStep,
-  mobileStudioStepLabels,
-  mobileStudioStepDescriptions,
-  mobileStudioPrevStep,
-  mobileStudioNextStep,
-  mobileStudioPrevStepLabel,
-  mobileStudioNextStepLabel,
-  isCompactMobileLayout,
-  onMobileStepChange,
-  listScope,
-  listKeyword,
-  listQuickPreset,
-  hasListFiltersApplied,
-  isListAdvancedOpen,
-  listPage,
-  listPageSize,
-  listSort,
-  listSortOptions,
-  isListRefreshDisabled,
-  isTempPostDisabled,
-  onListScopeChange,
-  onListKeywordChange,
-  onRefreshList,
-  onLoadOrCreateTempPost,
-  onApplyQuickPreset,
-  onResetFilters,
-  onToggleListAdvanced,
-  onListPageChange,
-  onListPageSizeChange,
-  onListSortChange,
-  selectedPostIds,
-  adminPostTotal,
-  adminPostRows,
-  adminPostViewRows,
-  isAllVisiblePostsSelected,
-  selectedPostIdSet,
-  editorMode,
-  postId,
-  loadingKey,
-  modifiedSortOrder,
-  deletedListNotice,
-  onToggleSelectAllVisiblePosts,
-  onClearSelection,
-  onRequestDeletePosts,
-  onTogglePostSelection,
-  onToggleModifiedSortOrder,
-  onEditPost,
-  onOpenPostDetail,
-  onCopyPostDetailLink,
-  onRestoreDeletedPost,
-  onHardDeletePost,
-  showSelectedPanelInManageSurface,
-  hasSelectedManagedPost,
-  editorModeLabel,
-  selectedPostLabel,
-  postTitle,
-  postVersion,
-  isTempDraftMode,
-  postVisibility,
-  currentVisibilityText,
-  isContinueEditingDisabled,
-  isCreateNewPostDisabled,
-  isDeletePostDisabled,
-  onContinueEditing,
-  onCreateNewPost,
-  onDeletePost,
-  isDirectLoadOpen,
-  onToggleDirectLoad,
-  isSelectedToolsOpen,
-  onToggleSelectedTools,
-  onPostIdChange,
-  isLoadPostDisabled,
-  onLoadPost,
-  isHitPostDisabled,
-  onRunHitPost,
-  isLikePostDisabled,
-  onRunLikePost,
-  softDeleteUndoMessage,
-  isSoftDeleteUndoVisible,
-  isUndoDisabled,
-  onUndoSoftDelete,
-}: EditorStudioContentWorkspaceProps) => (
-  <Section id="content-studio">
+    shouldShowGlobalNotice: boolean;
+    globalNotice: NoticeState;
+    mobileStudioSurfaceSteps: readonly MobileStudioStep[];
+    activeMobileStudioStep: MobileStudioStep;
+    mobileStudioStepLabels: Record<MobileStudioStep, string>;
+    mobileStudioStepDescriptions: Record<MobileStudioStep, string>;
+    mobileStudioPrevStep: MobileStudioStep | null;
+    mobileStudioNextStep: MobileStudioStep | null;
+    mobileStudioPrevStepLabel: string;
+    mobileStudioNextStepLabel: string;
+    isCompactMobileLayout: boolean;
+    onMobileStepChange: (step: MobileStudioStep) => void;
+    listScope: PostListScope;
+    listKeyword: string;
+    listQuickPreset: ListQuickPreset;
+    hasListFiltersApplied: boolean;
+    isListAdvancedOpen: boolean;
+    listPage: string;
+    listPageSize: string;
+    listSort: string;
+    listSortOptions: readonly ListSortOption[];
+    isListRefreshDisabled: boolean;
+    isTempPostDisabled: boolean;
+    onListScopeChange: (scope: PostListScope) => void;
+    onListKeywordChange: (value: string) => void;
+    onRefreshList: () => void;
+    onLoadOrCreateTempPost: () => void;
+    onApplyQuickPreset: (preset: Exclude<ListQuickPreset, "none">) => void;
+    onResetFilters: () => void;
+    onToggleListAdvanced: () => void;
+    onListPageChange: (event: ChangeEvent<HTMLInputElement>) => void;
+    onListPageSizeChange: (event: ChangeEvent<HTMLInputElement>) => void;
+    onListSortChange: (event: ChangeEvent<HTMLSelectElement>) => void;
+    selectedPostIds: readonly number[];
+    adminPostTotal: number;
+    adminPostRows: readonly EditorStudioPostListItem[];
+    adminPostViewRows: readonly EditorStudioPostListItem[];
+    isAllVisiblePostsSelected: boolean;
+    selectedPostIdSet: ReadonlySet<number>;
+    editorMode: EditorMode;
+    postId: string;
+    loadingKey: string;
+    modifiedSortOrder: "desc" | "asc";
+    deletedListNotice: NoticeState;
+    onToggleSelectAllVisiblePosts: () => void;
+    onClearSelection: () => void;
+    onRequestDeletePosts: (ids: number[], headline?: string) => void;
+    onTogglePostSelection: (id: number) => void;
+    onToggleModifiedSortOrder: () => void;
+    onEditPost: (row: EditorStudioPostListItem) => void;
+    onOpenPostDetail: (id: number) => void;
+    onCopyPostDetailLink: (id: number, title: string) => void;
+    onRestoreDeletedPost: (row: EditorStudioPostListItem) => void;
+    onHardDeletePost: (row: EditorStudioPostListItem) => void;
+    showSelectedPanelInManageSurface: boolean;
+    hasSelectedManagedPost: boolean;
+    editorModeLabel: string;
+    selectedPostLabel: string;
+    postTitle: string;
+    postVersion: number | null;
+    isTempDraftMode: boolean;
+    postVisibility: PostVisibility;
+    currentVisibilityText: string;
+    isContinueEditingDisabled: boolean;
+    isCreateNewPostDisabled: boolean;
+    isDeletePostDisabled: boolean;
+    onContinueEditing: () => void;
+    onCreateNewPost: () => void;
+    onDeletePost: () => void;
+    isDirectLoadOpen: boolean;
+    onToggleDirectLoad: () => void;
+    isSelectedToolsOpen: boolean;
+    onToggleSelectedTools: () => void;
+    onPostIdChange: (postId: string) => void;
+    isLoadPostDisabled: boolean;
+    onLoadPost: () => void;
+    isHitPostDisabled: boolean;
+    onRunHitPost: () => void;
+    isLikePostDisabled: boolean;
+    onRunLikePost: () => void;
+    softDeleteUndoMessage: string;
+    isSoftDeleteUndoVisible: boolean;
+    isUndoDisabled: boolean;
+    onUndoSoftDelete: () => void;
+};
+export const EditorStudioContentWorkspace = ({ shouldShowGlobalNotice, globalNotice, mobileStudioSurfaceSteps, activeMobileStudioStep, mobileStudioStepLabels, mobileStudioStepDescriptions, mobileStudioPrevStep, mobileStudioNextStep, mobileStudioPrevStepLabel, mobileStudioNextStepLabel, isCompactMobileLayout, onMobileStepChange, listScope, listKeyword, listQuickPreset, hasListFiltersApplied, isListAdvancedOpen, listPage, listPageSize, listSort, listSortOptions, isListRefreshDisabled, isTempPostDisabled, onListScopeChange, onListKeywordChange, onRefreshList, onLoadOrCreateTempPost, onApplyQuickPreset, onResetFilters, onToggleListAdvanced, onListPageChange, onListPageSizeChange, onListSortChange, selectedPostIds, adminPostTotal, adminPostRows, adminPostViewRows, isAllVisiblePostsSelected, selectedPostIdSet, editorMode, postId, loadingKey, modifiedSortOrder, deletedListNotice, onToggleSelectAllVisiblePosts, onClearSelection, onRequestDeletePosts, onTogglePostSelection, onToggleModifiedSortOrder, onEditPost, onOpenPostDetail, onCopyPostDetailLink, onRestoreDeletedPost, onHardDeletePost, showSelectedPanelInManageSurface, hasSelectedManagedPost, editorModeLabel, selectedPostLabel, postTitle, postVersion, isTempDraftMode, postVisibility, currentVisibilityText, isContinueEditingDisabled, isCreateNewPostDisabled, isDeletePostDisabled, onContinueEditing, onCreateNewPost, onDeletePost, isDirectLoadOpen, onToggleDirectLoad, isSelectedToolsOpen, onToggleSelectedTools, onPostIdChange, isLoadPostDisabled, onLoadPost, isHitPostDisabled, onRunHitPost, isLikePostDisabled, onRunLikePost, softDeleteUndoMessage, isSoftDeleteUndoVisible, isUndoDisabled, onUndoSoftDelete, }: EditorStudioContentWorkspaceProps) => (<Section id="content-studio">
     <SectionTop>
       <div>
         <h2>글 목록 관리</h2>
         <SectionDescription>조회·선택·편집만 남겨 정리에 집중합니다.</SectionDescription>
       </div>
     </SectionTop>
-    {shouldShowGlobalNotice ? (
-      <GlobalNoticeBar data-tone={globalNotice.tone}>{globalNotice.text}</GlobalNoticeBar>
-    ) : null}
-    <EditorStudioMobileStepNavigator
-      steps={mobileStudioSurfaceSteps}
-      activeStep={activeMobileStudioStep}
-      stepLabels={mobileStudioStepLabels}
-      stepDescriptions={mobileStudioStepDescriptions}
-      prevStep={mobileStudioPrevStep}
-      nextStep={mobileStudioNextStep}
-      prevStepLabel={mobileStudioPrevStepLabel}
-      nextStepLabel={mobileStudioNextStepLabel}
-      isCompactMobileLayout={isCompactMobileLayout}
-      onStepChange={onMobileStepChange}
-    />
+    {shouldShowGlobalNotice ? (<GlobalNoticeBar data-tone={globalNotice.tone}>{globalNotice.text}</GlobalNoticeBar>) : null}
+    <EditorStudioMobileStepNavigator steps={mobileStudioSurfaceSteps} activeStep={activeMobileStudioStep} stepLabels={mobileStudioStepLabels} stepDescriptions={mobileStudioStepDescriptions} prevStep={mobileStudioPrevStep} nextStep={mobileStudioNextStep} prevStepLabel={mobileStudioPrevStepLabel} nextStepLabel={mobileStudioNextStepLabel} isCompactMobileLayout={isCompactMobileLayout} onStepChange={onMobileStepChange}/>
     <ContentStudioGrid>
-      <ContentStudioLeft
-        data-mobile-visible={!isCompactMobileLayout || activeMobileStudioStep === "query" || activeMobileStudioStep === "list"}
-      >
-        <EditorStudioPostQueryPanel
-          activeMobileStep={activeMobileStudioStep as ManageMobileStudioStep}
-          isCompactMobileLayout={isCompactMobileLayout}
-          listScope={listScope}
-          listKeyword={listKeyword}
-          listQuickPreset={listQuickPreset}
-          hasListFiltersApplied={hasListFiltersApplied}
-          isAdvancedOpen={isListAdvancedOpen}
-          listPage={listPage}
-          listPageSize={listPageSize}
-          listSort={listSort}
-          listSortOptions={listSortOptions}
-          isRefreshDisabled={isListRefreshDisabled}
-          isTempPostDisabled={isTempPostDisabled}
-          onListScopeChange={onListScopeChange}
-          onListKeywordChange={onListKeywordChange}
-          onRefreshList={onRefreshList}
-          onLoadOrCreateTempPost={onLoadOrCreateTempPost}
-          onApplyQuickPreset={onApplyQuickPreset}
-          onResetFilters={onResetFilters}
-          onToggleAdvanced={onToggleListAdvanced}
-          onListPageChange={onListPageChange}
-          onListPageSizeChange={onListPageSizeChange}
-          onListSortChange={onListSortChange}
-        />
-        <EditorStudioPostListPanel
-          mobileVisible={!isCompactMobileLayout || activeMobileStudioStep === "list"}
-          listScope={listScope}
-          selectedPostIds={selectedPostIds}
-          adminPostTotal={adminPostTotal}
-          adminPostRows={adminPostRows}
-          adminPostViewRows={adminPostViewRows}
-          isAllVisiblePostsSelected={isAllVisiblePostsSelected}
-          selectedPostIdSet={selectedPostIdSet}
-          editorMode={editorMode}
-          postId={postId}
-          loadingKey={loadingKey}
-          modifiedSortOrder={modifiedSortOrder}
-          deletedListNotice={deletedListNotice}
-          isRefreshDisabled={isListRefreshDisabled}
-          onToggleSelectAllVisiblePosts={onToggleSelectAllVisiblePosts}
-          onClearSelection={onClearSelection}
-          onRequestDeletePosts={onRequestDeletePosts}
-          onRefreshList={onRefreshList}
-          onTogglePostSelection={onTogglePostSelection}
-          onToggleModifiedSortOrder={onToggleModifiedSortOrder}
-          onEditPost={onEditPost}
-          onOpenPostDetail={onOpenPostDetail}
-          onCopyPostDetailLink={onCopyPostDetailLink}
-          onRestoreDeletedPost={onRestoreDeletedPost}
-          onHardDeletePost={onHardDeletePost}
-        />
+      <ContentStudioLeft data-mobile-visible={!isCompactMobileLayout || activeMobileStudioStep === "query" || activeMobileStudioStep === "list"}>
+        <EditorStudioPostQueryPanel activeMobileStep={activeMobileStudioStep as ManageMobileStudioStep} isCompactMobileLayout={isCompactMobileLayout} listScope={listScope} listKeyword={listKeyword} listQuickPreset={listQuickPreset} hasListFiltersApplied={hasListFiltersApplied} isAdvancedOpen={isListAdvancedOpen} listPage={listPage} listPageSize={listPageSize} listSort={listSort} listSortOptions={listSortOptions} isRefreshDisabled={isListRefreshDisabled} isTempPostDisabled={isTempPostDisabled} onListScopeChange={onListScopeChange} onListKeywordChange={onListKeywordChange} onRefreshList={onRefreshList} onLoadOrCreateTempPost={onLoadOrCreateTempPost} onApplyQuickPreset={onApplyQuickPreset} onResetFilters={onResetFilters} onToggleAdvanced={onToggleListAdvanced} onListPageChange={onListPageChange} onListPageSizeChange={onListPageSizeChange} onListSortChange={onListSortChange}/>
+        <EditorStudioPostListPanel mobileVisible={!isCompactMobileLayout || activeMobileStudioStep === "list"} listScope={listScope} selectedPostIds={selectedPostIds} adminPostTotal={adminPostTotal} adminPostRows={adminPostRows} adminPostViewRows={adminPostViewRows} isAllVisiblePostsSelected={isAllVisiblePostsSelected} selectedPostIdSet={selectedPostIdSet} editorMode={editorMode} postId={postId} loadingKey={loadingKey} modifiedSortOrder={modifiedSortOrder} deletedListNotice={deletedListNotice} isRefreshDisabled={isListRefreshDisabled} onToggleSelectAllVisiblePosts={onToggleSelectAllVisiblePosts} onClearSelection={onClearSelection} onRequestDeletePosts={onRequestDeletePosts} onRefreshList={onRefreshList} onTogglePostSelection={onTogglePostSelection} onToggleModifiedSortOrder={onToggleModifiedSortOrder} onEditPost={onEditPost} onOpenPostDetail={onOpenPostDetail} onCopyPostDetailLink={onCopyPostDetailLink} onRestoreDeletedPost={onRestoreDeletedPost} onHardDeletePost={onHardDeletePost}/>
       </ContentStudioLeft>
 
-      <EditorStudioSelectedPostPanel
-        mobileVisible={showSelectedPanelInManageSurface}
-        hasSelectedManagedPost={hasSelectedManagedPost}
-        editorModeLabel={editorModeLabel}
-        selectedPostLabel={selectedPostLabel}
-        postTitle={postTitle}
-        postId={postId}
-        postVersion={postVersion}
-        isTempDraftMode={isTempDraftMode}
-        postVisibility={postVisibility}
-        currentVisibilityText={currentVisibilityText}
-        isContinueEditingDisabled={isContinueEditingDisabled}
-        isCreateNewPostDisabled={isCreateNewPostDisabled}
-        isDeletePostDisabled={isDeletePostDisabled}
-        onContinueEditing={onContinueEditing}
-        onCreateNewPost={onCreateNewPost}
-        onDeletePost={onDeletePost}
-        toolsPanel={
-          <EditorStudioSelectedPostToolsPanel
-            hasSelectedManagedPost={hasSelectedManagedPost}
-            isDirectLoadOpen={isDirectLoadOpen}
-            onToggleDirectLoad={onToggleDirectLoad}
-            isSelectedToolsOpen={isSelectedToolsOpen}
-            onToggleSelectedTools={onToggleSelectedTools}
-            postId={postId}
-            onPostIdChange={onPostIdChange}
-            isLoadPostDisabled={isLoadPostDisabled}
-            onLoadPost={onLoadPost}
-            isHitPostDisabled={isHitPostDisabled}
-            onRunHitPost={onRunHitPost}
-            isLikePostDisabled={isLikePostDisabled}
-            onRunLikePost={onRunLikePost}
-          />
-        }
-      />
+      <EditorStudioSelectedPostPanel mobileVisible={showSelectedPanelInManageSurface} hasSelectedManagedPost={hasSelectedManagedPost} editorModeLabel={editorModeLabel} selectedPostLabel={selectedPostLabel} postTitle={postTitle} postId={postId} postVersion={postVersion} isTempDraftMode={isTempDraftMode} postVisibility={postVisibility} currentVisibilityText={currentVisibilityText} isContinueEditingDisabled={isContinueEditingDisabled} isCreateNewPostDisabled={isCreateNewPostDisabled} isDeletePostDisabled={isDeletePostDisabled} onContinueEditing={onContinueEditing} onCreateNewPost={onCreateNewPost} onDeletePost={onDeletePost} toolsPanel={<EditorStudioSelectedPostToolsPanel hasSelectedManagedPost={hasSelectedManagedPost} isDirectLoadOpen={isDirectLoadOpen} onToggleDirectLoad={onToggleDirectLoad} isSelectedToolsOpen={isSelectedToolsOpen} onToggleSelectedTools={onToggleSelectedTools} postId={postId} onPostIdChange={onPostIdChange} isLoadPostDisabled={isLoadPostDisabled} onLoadPost={onLoadPost} isHitPostDisabled={isHitPostDisabled} onRunHitPost={onRunHitPost} isLikePostDisabled={isLikePostDisabled} onRunLikePost={onRunLikePost}/>}/>
     </ContentStudioGrid>
 
-    <EditorStudioUndoToast
-      isVisible={isSoftDeleteUndoVisible}
-      message={softDeleteUndoMessage}
-      isUndoDisabled={isUndoDisabled}
-      onUndo={onUndoSoftDelete}
-    />
-  </Section>
-)
-
-const Section = styled.section`
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "14px")};
+    <EditorStudioUndoToast isVisible={isSoftDeleteUndoVisible} message={softDeleteUndoMessage} isUndoDisabled={isUndoDisabled} onUndo={onUndoSoftDelete}/>
+  </Section>);
+const Section = styled.section `
+  border: 1px solid ${({ theme }) => (theme.colors.gray5)};
+  border-radius: ${({ theme }) => ("14px")};
   padding: 0.96rem;
   margin-bottom: 1.05rem;
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray2};
-  box-shadow: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.shadow : "none")};
+  background: ${({ theme }) => theme.colors.gray2};
+  box-shadow: ${({ theme }) => ("none")};
 
   h2 {
     margin: 0;
@@ -344,35 +146,32 @@ const Section = styled.section`
     padding: 0.74rem;
     margin-bottom: 0.95rem;
   }
-`
-
-const SectionTop = styled.div`
+`;
+const SectionTop = styled.div `
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
   margin-bottom: 0.95rem;
-`
-
-const SectionDescription = styled.p`
+`;
+const SectionDescription = styled.p `
   margin: 0.22rem 0 0;
   color: ${({ theme }) => theme.colors.gray10};
   font-size: 0.82rem;
   line-height: 1.5;
-`
-
-const GlobalNoticeBar = styled.div`
+`;
+const GlobalNoticeBar = styled.div `
   margin-bottom: 0.9rem;
   padding: 0.66rem 0.78rem;
   border-radius: 10px;
   font-size: 0.84rem;
   line-height: 1.5;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
+  border: 1px solid ${({ theme }) => (theme.colors.gray6)};
 
   &[data-tone="idle"] {
     color: ${({ theme }) => theme.colors.gray10};
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurfaceElevated : theme.colors.gray2)};
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
+    background: ${({ theme }) => (theme.colors.gray2)};
+    border-color: ${({ theme }) => (theme.colors.gray6)};
   }
 
   &[data-tone="loading"] {
@@ -398,9 +197,8 @@ const GlobalNoticeBar = styled.div`
     padding: 0.58rem 0.62rem;
     font-size: 0.8rem;
   }
-`
-
-const ContentStudioGrid = styled.div`
+`;
+const ContentStudioGrid = styled.div `
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: 1rem;
@@ -413,15 +211,14 @@ const ContentStudioGrid = styled.div`
   @media (max-width: 720px) {
     gap: 0.76rem;
   }
-`
-
-const ContentStudioLeft = styled.div`
+`;
+const ContentStudioLeft = styled.div `
   display: grid;
   gap: 0.95rem;
   min-width: 0;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray5)};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "6px" : "12px")};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : theme.colors.gray1)};
+  border: 1px solid ${({ theme }) => (theme.colors.gray5)};
+  border-radius: ${({ theme }) => ("12px")};
+  background: ${({ theme }) => (theme.colors.gray1)};
   padding: 0.9rem;
   box-shadow: none;
   overflow: hidden;
@@ -436,4 +233,4 @@ const ContentStudioLeft = styled.div`
       display: none;
     }
   }
-`
+`;

--- a/front/src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx
+++ b/front/src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx
@@ -1,7 +1,6 @@
-import styled from "@emotion/styled"
-import { articleTypographyScale } from "src/libs/markdown/contentTypography"
-
-export const EditorStudioRoot = styled.main`
+import styled from "@emotion/styled";
+import { articleTypographyScale } from "src/libs/markdown/contentTypography";
+export const EditorStudioRoot = styled.main `
   box-sizing: border-box;
   width: 100vw;
   margin-left: calc(50% - 50vw);
@@ -10,10 +9,7 @@ export const EditorStudioRoot = styled.main`
   display: grid;
   gap: 1.2rem;
   overflow-x: clip;
-  background: ${({ theme }) =>
-    theme.blogDesign === "grid"
-      ? `linear-gradient(180deg, color-mix(in srgb, ${theme.publicDesign.surfaceElevated} 44%, transparent), transparent 18rem)`
-      : "transparent"};
+  background: ${({ theme }) => "transparent"};
 
   @media (max-width: 1024px) {
     padding: 1rem 1rem 1.4rem;
@@ -25,9 +21,8 @@ export const EditorStudioRoot = styled.main`
     padding-left: max(0.82rem, env(safe-area-inset-left, 0px));
     padding-right: max(0.82rem, env(safe-area-inset-right, 0px));
   }
-`
-
-export const EditorStudioLoadingState = styled.div`
+`;
+export const EditorStudioLoadingState = styled.div `
   min-height: calc(100vh - 10rem);
   display: grid;
   place-content: center;
@@ -43,9 +38,8 @@ export const EditorStudioLoadingState = styled.div`
     color: ${({ theme }) => theme.colors.gray10};
     font-size: 0.9rem;
   }
-`
-
-export const EditorStudioDedicatedTopBar = styled.div`
+`;
+export const EditorStudioDedicatedTopBar = styled.div `
   width: min(100%, 1600px);
   margin: 0 auto;
   display: flex;
@@ -67,9 +61,8 @@ export const EditorStudioDedicatedTopBar = styled.div`
     flex-direction: column;
     gap: 0.7rem;
   }
-`
-
-export const EditorExitAction = styled.button`
+`;
+export const EditorExitAction = styled.button `
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -89,20 +82,19 @@ export const EditorExitAction = styled.button`
     color 0.18s ease;
 
   &:hover {
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3)};
+    background: ${({ theme }) => (theme.colors.gray3)};
   }
 
   &:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 3px ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.blue4)};
+    box-shadow: 0 0 0 3px ${({ theme }) => (theme.colors.blue4)};
   }
 
   @media (max-width: 1200px) {
     justify-content: flex-start;
   }
-`
-
-export const EditorStudioTopBarActions = styled.div`
+`;
+export const EditorStudioTopBarActions = styled.div `
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -122,9 +114,8 @@ export const EditorStudioTopBarActions = styled.div`
     justify-content: flex-end;
     flex-wrap: wrap;
   }
-`
-
-export const EditorStudioSaveState = styled.span`
+`;
+export const EditorStudioSaveState = styled.span `
   color: ${({ theme }) => theme.colors.gray10};
   font-size: 0.84rem;
   font-weight: 600;
@@ -146,14 +137,13 @@ export const EditorStudioSaveState = styled.span`
   @media (max-width: 680px) {
     width: 100%;
   }
-`
-
-const Button = styled.button`
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6)};
+`;
+const Button = styled.button `
+  border: 1px solid ${({ theme }) => (theme.colors.gray6)};
   border-radius: 8px;
   padding: 0.62rem 0.92rem;
   min-height: 44px;
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : "transparent")};
+  background: ${({ theme }) => ("transparent")};
   color: ${({ theme }) => theme.colors.gray10};
   cursor: pointer;
   font-size: 0.84rem;
@@ -165,39 +155,37 @@ const Button = styled.button`
     box-shadow 0.18s ease;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray8)};
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3)};
+    border-color: ${({ theme }) => (theme.colors.gray8)};
+    background: ${({ theme }) => (theme.colors.gray3)};
     color: ${({ theme }) => theme.colors.gray12};
   }
 
   &:focus-visible {
     outline: none;
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue8)};
-    box-shadow: 0 0 0 3px ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.blue4)};
+    border-color: ${({ theme }) => (theme.colors.blue8)};
+    box-shadow: 0 0 0 3px ${({ theme }) => (theme.colors.blue4)};
   }
 
   &:disabled {
     opacity: 0.45;
     cursor: not-allowed;
   }
-`
-
-export const PrimaryButton = styled(Button)`
+`;
+export const PrimaryButton = styled(Button) `
   border-radius: 8px;
   padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue9)};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.blue9)};
-  color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.pageBackgroundColor : theme.colors.gray1)};
+  border-color: ${({ theme }) => (theme.colors.blue9)};
+  background: ${({ theme }) => (theme.colors.blue9)};
+  color: ${({ theme }) => (theme.colors.gray1)};
   font-weight: 700;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.blue10)};
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.blue10)};
-    color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.pageBackgroundColor : theme.colors.gray1)};
+    border-color: ${({ theme }) => (theme.colors.blue10)};
+    background: ${({ theme }) => (theme.colors.blue10)};
+    color: ${({ theme }) => (theme.colors.gray1)};
   }
-`
-
-export const EditorStudioFrame = styled.div`
+`;
+export const EditorStudioFrame = styled.div `
   width: min(100%, 1600px);
   margin: 0 auto;
   display: grid;
@@ -211,37 +199,39 @@ export const EditorStudioFrame = styled.div`
     grid-template-columns: minmax(0, 1fr);
     gap: 1.4rem;
   }
-`
-
-export const EditorStudioWritingColumn = styled.section<{ $compact?: boolean }>`
+`;
+export const EditorStudioWritingColumn = styled.section<{
+    $compact?: boolean;
+}> `
   display: grid;
   min-width: 0;
   gap: ${({ $compact }) => ($compact ? "0.88rem" : "1rem")};
   overflow-x: visible;
-`
-
-export const EditorStudioDedicatedMetaSection = styled.section<{ $compact?: boolean }>`
+`;
+export const EditorStudioDedicatedMetaSection = styled.section<{
+    $compact?: boolean;
+}> `
   width: 100%;
   max-width: var(--article-readable-width, 48rem);
   min-width: 0;
   margin-inline: auto;
   display: grid;
   gap: ${({ $compact }) => ($compact ? "0.72rem" : "0.9rem")};
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
-  padding: ${({ theme, $compact }) => (theme.blogDesign === "grid" ? ($compact ? "0.8rem" : "1rem") : "0")};
-`
-
-export const EditorTagRow = styled.div<{ $compact?: boolean }>`
+  border: 1px solid ${({ theme }) => ("transparent")};
+  border-radius: ${({ theme }) => ("0")};
+  background: ${({ theme }) => ("transparent")};
+  padding: ${({ theme, $compact }) => ("0")};
+`;
+export const EditorTagRow = styled.div<{
+    $compact?: boolean;
+}> `
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: ${({ $compact }) => ($compact ? "0.44rem" : "0.55rem")};
   min-height: 32px;
-`
-
-export const SelectedTagChip = styled.span`
+`;
+export const SelectedTagChip = styled.span `
   display: inline-flex;
   align-items: stretch;
   gap: 0;
@@ -301,9 +291,8 @@ export const SelectedTagChip = styled.span`
       color: ${({ theme }) => theme.colors.gray12};
     }
   }
-`
-
-export const InlineMetaInput = styled.input`
+`;
+export const InlineMetaInput = styled.input `
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
@@ -329,9 +318,10 @@ export const InlineMetaInput = styled.input`
     border-color: ${({ theme }) => theme.colors.blue8};
     box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
   }
-`
-
-export const TitleInput = styled.textarea<{ $compact?: boolean }>`
+`;
+export const TitleInput = styled.textarea<{
+    $compact?: boolean;
+}> `
   width: 100%;
   min-width: 0;
   border: 0;
@@ -363,34 +353,32 @@ export const TitleInput = styled.textarea<{ $compact?: boolean }>`
     font-size: ${articleTypographyScale.postTitleFontSizeMobile};
     line-height: ${articleTypographyScale.postTitleLineHeightMobile};
   }
-`
-
-export const EditorHeaderMetaRow = styled.div`
+`;
+export const EditorHeaderMetaRow = styled.div `
   display: flex;
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 0.85rem;
   min-width: 0;
-`
-
-export const EditorHeaderMetaActions = styled.div`
+`;
+export const EditorHeaderMetaActions = styled.div `
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
   flex-wrap: wrap;
   gap: 0.45rem;
   min-width: 0;
-`
-
-export const EditorHeaderAuthor = styled.div`
+`;
+export const EditorHeaderAuthor = styled.div `
   display: inline-flex;
   align-items: center;
   gap: 0.85rem;
   min-width: 0;
-`
-
-export const EditorHeaderAvatar = styled.div<{ $compact?: boolean }>`
+`;
+export const EditorHeaderAvatar = styled.div<{
+    $compact?: boolean;
+}> `
   position: relative;
   width: ${({ $compact }) => ($compact ? "40px" : "48px")};
   height: ${({ $compact }) => ($compact ? "40px" : "48px")};
@@ -410,9 +398,10 @@ export const EditorHeaderAvatar = styled.div<{ $compact?: boolean }>`
     font-weight: 800;
     letter-spacing: 0.04em;
   }
-`
-
-export const EditorHeaderAuthorText = styled.div<{ $compact?: boolean }>`
+`;
+export const EditorHeaderAuthorText = styled.div<{
+    $compact?: boolean;
+}> `
   display: grid;
   gap: ${({ $compact }) => ($compact ? "0.12rem" : "0.18rem")};
   min-width: 0;
@@ -429,9 +418,10 @@ export const EditorHeaderAuthorText = styled.div<{ $compact?: boolean }>`
     font-size: ${({ $compact }) => ($compact ? "0.82rem" : "0.9rem")};
     font-weight: 500;
   }
-`
-
-export const EditorHeaderMetaPill = styled.span<{ $compact?: boolean }>`
+`;
+export const EditorHeaderMetaPill = styled.span<{
+    $compact?: boolean;
+}> `
   display: inline-flex;
   align-items: center;
   min-height: ${({ $compact }) => ($compact ? "30px" : "34px")};
@@ -443,16 +433,14 @@ export const EditorHeaderMetaPill = styled.span<{ $compact?: boolean }>`
   font-size: ${({ $compact }) => ($compact ? "0.74rem" : "0.82rem")};
   font-weight: 650;
   line-height: 1;
-`
-
-export const EditorHeaderActionButton = styled(Button)`
+`;
+export const EditorHeaderActionButton = styled(Button) `
   min-height: 34px;
   padding: 0.45rem 0.7rem;
   border-radius: 999px;
   font-size: 0.78rem;
-`
-
-export const EditorStudioDedicatedCanvasSection = styled.section`
+`;
+export const EditorStudioDedicatedCanvasSection = styled.section `
   --compose-pane-readable-width: var(--article-readable-width, 48rem);
   width: 100%;
   max-width: var(--article-readable-width, 48rem);
@@ -462,14 +450,13 @@ export const EditorStudioDedicatedCanvasSection = styled.section`
   display: grid;
   gap: 0.72rem;
   overflow-x: visible;
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "0")};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
-  padding: ${({ theme }) => (theme.blogDesign === "grid" ? "1rem" : "0")};
-  box-shadow: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.shadow : "none")};
-`
-
-export const PublishNotice = styled.div`
+  border: 1px solid ${({ theme }) => ("transparent")};
+  border-radius: ${({ theme }) => ("0")};
+  background: ${({ theme }) => ("transparent")};
+  padding: ${({ theme }) => ("0")};
+  box-shadow: ${({ theme }) => ("none")};
+`;
+export const PublishNotice = styled.div `
   margin: 0;
   padding: 0.55rem 0.7rem;
   border-radius: 10px;
@@ -505,4 +492,4 @@ export const PublishNotice = styled.div`
   @media (max-width: 720px) {
     width: 100%;
   }
-`
+`;

--- a/front/src/routes/Detail/PostDetail/PostDetail.styles.ts
+++ b/front/src/routes/Detail/PostDetail/PostDetail.styles.ts
@@ -1,6 +1,5 @@
-import styled from "@emotion/styled"
-
-export const StyledWrapper = styled.div`
+import styled from "@emotion/styled";
+export const StyledWrapper = styled.div `
   width: 100%;
   max-width: none;
   box-sizing: border-box;
@@ -32,7 +31,7 @@ export const StyledWrapper = styled.div`
 
   article::before {
     content: "";
-    display: ${({ theme }) => (theme.blogDesign === "grid" ? "block" : "none")};
+    display: ${({ theme }) => ("none")};
     position: absolute;
     inset: -1.4rem -1.5rem;
     z-index: -1;
@@ -97,18 +96,12 @@ export const StyledWrapper = styled.div`
     justify-content: center;
     padding: 0;
     border-radius: 999px;
-    border: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid"
-        ? theme.publicDesign.border
-        : theme.scheme === "dark"
-          ? "rgba(148, 163, 184, 0.28)"
-          : theme.colors.gray6};
-    background: ${({ theme }) =>
-      theme.blogDesign === "grid"
-        ? theme.publicDesign.surface
-        : theme.scheme === "dark"
-          ? "rgba(15, 23, 42, 0.32)"
-          : "rgba(255, 255, 255, 0.92)"};
+    border: 1px solid ${({ theme }) => theme.scheme === "dark"
+    ? "rgba(148, 163, 184, 0.28)"
+    : theme.colors.gray6};
+    background: ${({ theme }) => theme.scheme === "dark"
+    ? "rgba(15, 23, 42, 0.32)"
+    : "rgba(255, 255, 255, 0.92)"};
     color: ${({ theme }) => theme.colors.gray12};
     cursor: pointer;
     transition: border-color 0.18s ease, background-color 0.18s ease, color 0.18s ease, transform 0.18s ease;
@@ -121,18 +114,12 @@ export const StyledWrapper = styled.div`
 
     &:hover {
       transform: translateY(-1px);
-      border-color: ${({ theme }) =>
-        theme.blogDesign === "grid"
-          ? theme.publicDesign.borderStrong
-          : theme.scheme === "dark"
-            ? "rgba(148, 163, 184, 0.62)"
-            : theme.colors.gray8};
-      background: ${({ theme }) =>
-        theme.blogDesign === "grid"
-          ? theme.publicDesign.surfaceElevated
-          : theme.scheme === "dark"
-            ? "rgba(17, 24, 39, 0.62)"
-            : "#ffffff"};
+      border-color: ${({ theme }) => theme.scheme === "dark"
+    ? "rgba(148, 163, 184, 0.62)"
+    : theme.colors.gray8};
+      background: ${({ theme }) => theme.scheme === "dark"
+    ? "rgba(17, 24, 39, 0.62)"
+    : "#ffffff"};
     }
 
     &:disabled {
@@ -156,10 +143,8 @@ export const StyledWrapper = styled.div`
       white-space: nowrap;
       padding: 0.3rem 0.48rem;
       border-radius: 8px;
-      border: 1px solid ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
-      background: ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray2};
+      border: 1px solid ${({ theme }) => theme.colors.gray6};
+      background: ${({ theme }) => theme.colors.gray2};
       color: ${({ theme }) => theme.colors.gray11};
       font-size: 0.68rem;
       line-height: 1;
@@ -221,12 +206,9 @@ export const StyledWrapper = styled.div`
   }
 
   .rightRailInner {
-    border-left: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid"
-        ? theme.publicDesign.border
-        : theme.scheme === "dark"
-          ? "rgba(148, 163, 184, 0.26)"
-          : theme.colors.gray6};
+    border-left: 1px solid ${({ theme }) => theme.scheme === "dark"
+    ? "rgba(148, 163, 184, 0.26)"
+    : theme.colors.gray6};
     padding: 0.2rem 0 0.2rem 1.4rem;
     background: transparent;
 
@@ -261,11 +243,9 @@ export const StyledWrapper = styled.div`
     }
 
     .tocDepthToggle {
-      border: 1px solid ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+      border: 1px solid ${({ theme }) => theme.colors.gray6};
       border-radius: 999px;
-      background: ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray2};
+      background: ${({ theme }) => theme.colors.gray2};
       color: ${({ theme }) => theme.colors.gray10};
       font-size: 0.71rem;
       font-weight: 700;
@@ -276,8 +256,7 @@ export const StyledWrapper = styled.div`
 
       &:hover {
         color: ${({ theme }) => theme.colors.gray12};
-        border-color: ${({ theme }) =>
-          theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray8};
+        border-color: ${({ theme }) => theme.colors.gray8};
       }
     }
 
@@ -330,8 +309,7 @@ export const StyledWrapper = styled.div`
 
     button:hover {
       color: ${({ theme }) => theme.colors.gray11};
-      background: ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray2};
+      background: ${({ theme }) => theme.colors.gray2};
     }
 
     button::before {
@@ -342,15 +320,14 @@ export const StyledWrapper = styled.div`
       bottom: 0.18rem;
       width: 1px;
       opacity: 0;
-      background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.accentBorder)};
+      background: ${({ theme }) => (theme.colors.accentBorder)};
       transition: opacity 0.15s ease;
     }
 
     button[data-active="true"] {
       color: ${({ theme }) => theme.colors.gray12};
       font-weight: 700;
-      background: ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.accentSurfaceSubtle};
+      background: ${({ theme }) => theme.colors.accentSurfaceSubtle};
     }
 
     button[data-active="true"]::before {
@@ -410,13 +387,11 @@ export const StyledWrapper = styled.div`
       max-width: 50rem;
     }
   }
-`
-
-export const BodySection = styled.div`
+`;
+export const BodySection = styled.div `
   margin-top: 0.8rem;
   padding-top: 1.05rem;
-  border-top: 1px solid ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+  border-top: 1px solid ${({ theme }) => theme.colors.gray6};
   width: 100%;
   min-width: 0;
 
@@ -424,6 +399,5 @@ export const BodySection = styled.div`
     margin-top: 0.55rem;
     padding-top: 0.85rem;
   }
-`
-
-export { CompactTocSection, MobileSummaryBar, RelatedSection, RelatedSkeletonItem } from "./PostDetailSection.styles"
+`;
+export { CompactTocSection, MobileSummaryBar, RelatedSection, RelatedSkeletonItem } from "./PostDetailSection.styles";

--- a/front/src/routes/Detail/PostDetail/PostDetailSection.styles.ts
+++ b/front/src/routes/Detail/PostDetail/PostDetailSection.styles.ts
@@ -1,12 +1,10 @@
-import styled from "@emotion/styled"
-
-export const CompactTocSection = styled.section`
+import styled from "@emotion/styled";
+export const CompactTocSection = styled.section `
   display: none;
   margin-top: 0.2rem;
-  border: 1px solid ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
   border-radius: 14px;
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray2)};
+  background: ${({ theme }) => (theme.colors.gray2)};
   overflow: hidden;
 
   details {
@@ -53,8 +51,7 @@ export const CompactTocSection = styled.section`
     width: 2rem;
     height: 2rem;
     border-radius: 999px;
-    border: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
     color: ${({ theme }) => theme.colors.gray10};
     flex-shrink: 0;
     transition: transform 0.16s ease;
@@ -109,14 +106,12 @@ export const CompactTocSection = styled.section`
   }
 
   button:hover {
-    background: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray3};
+    background: ${({ theme }) => theme.colors.gray3};
     color: ${({ theme }) => theme.colors.gray12};
   }
 
   button[data-active="true"] {
-    background: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray3};
+    background: ${({ theme }) => theme.colors.gray3};
     color: ${({ theme }) => theme.colors.gray12};
     font-weight: 700;
   }
@@ -124,9 +119,8 @@ export const CompactTocSection = styled.section`
   @media (max-width: 1365px) {
     display: block;
   }
-`
-
-export const MobileSummaryBar = styled.div`
+`;
+export const MobileSummaryBar = styled.div `
   display: none;
 
   @media (max-width: 1023px) {
@@ -147,12 +141,8 @@ export const MobileSummaryBar = styled.div`
       gap: 0.36rem;
       padding: 0 0.55rem;
       border-radius: 999px;
-      border: 1px solid ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
-      background: ${({ theme }) =>
-        theme.blogDesign === "grid"
-          ? `color-mix(in srgb, ${theme.publicDesign.surface} 88%, transparent)`
-          : `color-mix(in srgb, ${theme.colors.gray1} 88%, transparent)`};
+      border: 1px solid ${({ theme }) => theme.colors.gray6};
+      background: ${({ theme }) => `color-mix(in srgb, ${theme.colors.gray1} 88%, transparent)`};
       color: ${({ theme }) => theme.colors.gray11};
       box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
       backdrop-filter: blur(12px);
@@ -163,11 +153,9 @@ export const MobileSummaryBar = styled.div`
     }
 
     button[data-active="true"] {
-      border-color: ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.accentBorder};
-      background: ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.accentSurfaceSubtle};
-      color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.accentLink)};
+      border-color: ${({ theme }) => theme.colors.accentBorder};
+      background: ${({ theme }) => theme.colors.accentSurfaceSubtle};
+      color: ${({ theme }) => (theme.colors.accentLink)};
     }
 
     button[data-active="true"][data-tone="danger"] {
@@ -186,13 +174,11 @@ export const MobileSummaryBar = styled.div`
       font-size: 0.74rem;
     }
   }
-`
-
-export const RelatedSection = styled.section`
+`;
+export const RelatedSection = styled.section `
   margin-top: 0.52rem;
   padding-top: 0.88rem;
-  border-top: 1px solid ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+  border-top: 1px solid ${({ theme }) => theme.colors.gray6};
   display: grid;
   gap: 0.72rem;
   content-visibility: auto;
@@ -258,23 +244,17 @@ export const RelatedSection = styled.section`
     min-width: 0;
     padding: 0.68rem 0.74rem;
     border-radius: 10px;
-    border: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray1)};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => (theme.colors.gray1)};
     text-decoration: none;
     transition: border-color 0.14s ease-in, background-color 0.14s ease-in, box-shadow 0.14s ease-in;
 
     &:hover {
-      border-color: ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray8};
-      background: ${({ theme }) =>
-        theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray2};
-      box-shadow: ${({ theme }) =>
-        theme.blogDesign === "grid"
-          ? "0 12px 26px rgba(0, 0, 0, 0.28)"
-          : theme.scheme === "light"
-            ? "0 10px 24px rgba(15, 23, 42, 0.05)"
-            : "none"};
+      border-color: ${({ theme }) => theme.colors.gray8};
+      background: ${({ theme }) => theme.colors.gray2};
+      box-shadow: ${({ theme }) => theme.scheme === "light"
+    ? "0 10px 24px rgba(15, 23, 42, 0.05)"
+    : "none"};
     }
   }
 
@@ -285,10 +265,8 @@ export const RelatedSection = styled.section`
     min-height: 24px;
     padding: 0 0.52rem;
     border-radius: 999px;
-    border: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
-    background: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray2};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => theme.colors.gray2};
     color: ${({ theme }) => theme.colors.gray11};
     font-size: 0.7rem;
     font-weight: 800;
@@ -334,25 +312,22 @@ export const RelatedSection = styled.section`
       align-items: stretch;
     }
   }
-`
-
-export const RelatedSkeletonItem = styled.li`
+`;
+export const RelatedSkeletonItem = styled.li `
   display: grid;
   gap: 0.34rem;
   min-width: 0;
   padding: 0.68rem 0.74rem;
   border-radius: 10px;
-  border: 1px solid ${({ theme }) =>
-    theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray1)};
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => (theme.colors.gray1)};
 
   .titleLine,
   .summaryLine,
   .metaLine {
     display: block;
     border-radius: 999px;
-    background: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray3};
+    background: ${({ theme }) => theme.colors.gray3};
     animation: related-skeleton-pulse 1.18s ease-in-out infinite;
   }
 
@@ -389,4 +364,4 @@ export const RelatedSkeletonItem = styled.li`
       opacity: 0.7;
     }
   }
-`
+`;

--- a/front/src/routes/Detail/PostDetail/PostHeader.styles.ts
+++ b/front/src/routes/Detail/PostDetail/PostHeader.styles.ts
@@ -1,8 +1,7 @@
-import styled from "@emotion/styled"
-import { HEADER_AUTH_ADMIN_ATTR } from "src/libs/headerAuthShell"
-import { articleTypographyScale } from "src/libs/markdown/contentTypography"
-
-export const StyledWrapper = styled.header`
+import styled from "@emotion/styled";
+import { HEADER_AUTH_ADMIN_ATTR } from "src/libs/headerAuthShell";
+import { articleTypographyScale } from "src/libs/markdown/contentTypography";
+export const StyledWrapper = styled.header `
   .taxonomyRow {
     display: flex;
     align-items: center;
@@ -30,14 +29,12 @@ export const StyledWrapper = styled.header`
     min-height: 32px;
     padding: 0.38rem 0.78rem;
     border-radius: 999px;
-    border: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
     font-size: 0.86rem;
     line-height: 1.2;
     font-weight: 600;
     color: ${({ theme }) => theme.colors.gray11};
-    background-color: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray3};
+    background-color: ${({ theme }) => theme.colors.gray3};
   }
 
   .title {
@@ -74,8 +71,7 @@ export const StyledWrapper = styled.header`
     height: 48px;
     border-radius: 50%;
     overflow: hidden;
-    background: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray3};
+    background: ${({ theme }) => theme.colors.gray3};
 
     img {
       object-fit: cover;
@@ -150,9 +146,8 @@ export const StyledWrapper = styled.header`
     min-height: 34px;
     padding: 0 0.78rem;
     border-radius: 999px;
-    border: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray2)};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => (theme.colors.gray2)};
     color: ${({ theme }) => theme.colors.gray11};
     font-size: 0.82rem;
     font-weight: 650;
@@ -166,9 +161,8 @@ export const StyledWrapper = styled.header`
     min-height: 34px;
     padding: 0 0.76rem;
     border-radius: 999px;
-    border: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.surface : theme.colors.gray2)};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => (theme.colors.gray2)};
     color: ${({ theme }) => theme.colors.gray12};
     font-size: 0.82rem;
     font-weight: 700;
@@ -227,8 +221,7 @@ export const StyledWrapper = styled.header`
     min-height: 40px;
     padding: 0 0.9rem;
     border-radius: 8px;
-    border: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
     background: transparent;
     color: ${({ theme }) => theme.colors.gray12};
     font-size: 0.9rem;
@@ -266,8 +259,7 @@ export const StyledWrapper = styled.header`
     min-height: 40px;
     padding: 0 0.9rem;
     border-radius: 8px;
-    border: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
     background: transparent;
     color: ${({ theme }) => theme.colors.gray12};
     font-size: 0.9rem;
@@ -287,7 +279,7 @@ export const StyledWrapper = styled.header`
     width: 0.22rem;
     height: 0.22rem;
     border-radius: 50%;
-    background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray8)};
+    background: ${({ theme }) => (theme.colors.gray8)};
   }
 
   .statChip {
@@ -297,8 +289,7 @@ export const StyledWrapper = styled.header`
     min-height: 40px;
     padding: 0 0.82rem;
     border-radius: 8px;
-    border: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
     background: transparent;
     color: ${({ theme }) => theme.colors.gray11};
     font-size: 0.9rem;
@@ -334,10 +325,8 @@ export const StyledWrapper = styled.header`
     margin-top: 2rem;
     border-radius: 10px;
     width: 100%;
-    border: 1px solid ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.border : theme.colors.gray6};
-    background-color: ${({ theme }) =>
-      theme.blogDesign === "grid" ? theme.publicDesign.surfaceElevated : theme.colors.gray3};
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background-color: ${({ theme }) => theme.colors.gray3};
     padding-bottom: 52%;
   }
 
@@ -385,4 +374,4 @@ export const StyledWrapper = styled.header`
       display: none;
     }
   }
-`
+`;

--- a/front/src/routes/Error/index.tsx
+++ b/front/src/routes/Error/index.tsx
@@ -1,17 +1,14 @@
-import styled from "@emotion/styled"
-import Link from "next/link"
-import React from "react"
-import AppIcon from "src/components/icons/AppIcon"
-
-type Props = {}
-
+import styled from "@emotion/styled";
+import Link from "next/link";
+import React from "react";
+import AppIcon from "src/components/icons/AppIcon";
+type Props = {};
 const CustomError: React.FC<Props> = () => {
-  return (
-    <StyledWrapper>
+    return (<StyledWrapper>
       <div className="wrapper">
         <div className="top">
           <div>4</div>
-          <AppIcon name="question" className="questionIcon" />
+          <AppIcon name="question" className="questionIcon"/>
           <div>4</div>
         </div>
         <div className="copy">
@@ -23,23 +20,20 @@ const CustomError: React.FC<Props> = () => {
           <Link href="/about">블로그 소개</Link>
         </div>
       </div>
-    </StyledWrapper>
-  )
-}
-
-export default CustomError
-
-const StyledWrapper = styled.div`
+    </StyledWrapper>);
+};
+export default CustomError;
+const StyledWrapper = styled.div `
   margin: 0 auto;
   padding-left: 1.5rem;
   padding-right: 1.5rem;
   padding-top: 3rem;
   padding-bottom: 3rem;
-  border-radius: ${({ theme }) => (theme.blogDesign === "grid" ? "8px" : "1.5rem")};
+  border-radius: ${({ theme }) => ("1.5rem")};
   max-width: 56rem;
-  background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.readableSurface : "transparent")};
-  border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.border : "transparent")};
-  box-shadow: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.shadow : "none")};
+  background: ${({ theme }) => ("transparent")};
+  border: 1px solid ${({ theme }) => ("transparent")};
+  box-shadow: ${({ theme }) => ("none")};
   .wrapper {
     display: flex;
     padding-top: 5rem;
@@ -57,7 +51,7 @@ const StyledWrapper = styled.div`
       .questionIcon {
         font-size: 3.1rem;
         flex: 0 0 auto;
-        color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : "inherit")};
+        color: ${({ theme }) => ("inherit")};
       }
     }
     > .copy {
@@ -94,8 +88,8 @@ const StyledWrapper = styled.div`
       min-height: 44px;
       padding: 0 1rem;
       border-radius: 999px;
-      border: 1px solid ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.borderStrong : theme.colors.gray6)};
-      background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.operationSurface : theme.colors.gray1)};
+      border: 1px solid ${({ theme }) => (theme.colors.gray6)};
+      background: ${({ theme }) => (theme.colors.gray1)};
       color: ${({ theme }) => theme.colors.gray12};
       text-decoration: none;
       font-size: 0.92rem;
@@ -108,8 +102,8 @@ const StyledWrapper = styled.div`
 
     > .actions a:hover {
       transform: translateY(-1px);
-      border-color: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accent : theme.colors.gray8)};
-      background: ${({ theme }) => (theme.blogDesign === "grid" ? theme.publicDesign.accentMuted : theme.colors.gray2)};
+      border-color: ${({ theme }) => (theme.colors.gray8)};
+      background: ${({ theme }) => (theme.colors.gray2)};
     }
   }
-`
+`;

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -97,5 +97,5 @@ export type TCategories = {
 }
 
 export type SchemeType = "light" | "dark"
-export type BlogDesignType = "legacy" | "grid"
+export type BlogDesignType = "legacy"
 export type LegacyBlogScheme = "light" | "dark"


### PR DESCRIPTION
## 관련 이슈

close #730

## 작업 배경

- `front/src/**`에 남아 있던 `theme.blogDesign === "grid"` 기반 스타일 분기를 제거했습니다.
- 공개/인증/about/editor/admin preview 표면을 legacy light/dark 토큰만 사용하도록 정리했습니다.
- `BlogDesignType`을 `legacy` 단일 값으로 좁히고, 과거 `grid` 저장값은 계속 `legacy`로 정규화되도록 테스트를 유지했습니다.

## 작업 내용

- auth, error, about, detail, editor/admin preview 스타일에서 grid 전용 publicDesign 분기를 legacy colors/scheme 표현으로 치환했습니다.
- `front/src/types/index.ts`의 `BlogDesignType`을 `"legacy"`로 고정했습니다.
- e2e 소스 경계 테스트를 grid 제거 이후의 legacy-only 계약으로 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`
  - `yarn --cwd front build`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-profile-state.spec.ts e2e/admin-surface-primitives.spec.ts e2e/smoke-public-shell.spec.ts e2e/mobile-layout.spec.ts e2e/perf-layout.spec.ts --workers=1`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/mobile-layout.spec.ts --workers=1`
  - commit hook: `node scripts/check-bundle-size.mjs`
  - commit hook: `yarn test:e2e:smoke`
  - `git grep -n 'blogDesign === "grid"\|blogDesign !== "grid"\|theme\.blogDesign' -- front/src` 결과 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 과거 grid 전용 스타일에 의존하던 화면이 legacy colors 기준으로만 렌더됩니다. 현재 런타임은 이미 legacy로 고정되어 있어 동작 변화는 dead branch 제거에 가깝습니다.
- 롤백 방법: 이 PR의 단일 커밋 `d701981c`를 revert하면 grid 분기 제거 전 상태로 되돌릴 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
