### PR TITLE
[Fix] 관리자 클라우드 표시와 업로드 회귀 수정

### DIFF
--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -94,6 +94,8 @@ const setupAdminCloudMocks = async (
   page: Page,
   options: {
     failDeleteIds?: string[]
+    failList?: boolean
+    failUploadNames?: string[]
     initialFiles?: CloudFileFixture[]
   } = {}
 ) => {
@@ -103,6 +105,7 @@ const setupAdminCloudMocks = async (
   const deletedIds: string[] = []
   const uploadedFiles: CloudFileFixture[] = []
   const failedDeleteIds = new Set(options.failDeleteIds ?? [])
+  const failedUploadNames = new Set(options.failUploadNames ?? [])
   const initialFiles = options.initialFiles ?? CLOUD_FILES
   let nextUploadId = 204
 
@@ -152,6 +155,11 @@ const setupAdminCloudMocks = async (
       const uploadedName = getUploadName(route)
       const metadata = getUploadFileMetadata(uploadedName)
 
+      if (failedUploadNames.has(uploadedName)) {
+        await fulfillJson(route, { resultCode: "500-1", msg: "외장 스토리지 저장에 실패했습니다." }, 500)
+        return
+      }
+
       if (uploadedName.includes("취소할")) await delay(700)
 
       const uploaded = {
@@ -182,6 +190,11 @@ const setupAdminCloudMocks = async (
       } catch {
         // The page aborts the in-flight request when an active upload is cancelled.
       }
+      return
+    }
+
+    if (options.failList) {
+      await fulfillJson(route, { resultCode: "500-1", msg: "클라우드 파일 목록 조회에 실패했습니다." }, 500)
       return
     }
 
@@ -350,5 +363,35 @@ test.describe("관리자 클라우드", () => {
 
     await uploadPanel.getByRole("button", { name: "취소할 영상.mp4 업로드 취소" }).click()
     await expect(uploadPanel.getByText("취소됨")).toBeVisible()
+  })
+
+  test("클라우드 목록 조회 실패는 로딩 대신 오류와 다시 시도 액션을 보여준다", async ({ page }) => {
+    await setupAdminCloudMocks(page, { failList: true })
+
+    await page.goto("/admin/cloud")
+
+    await expect(page.getByText("파일을 불러오는 중입니다.")).toHaveCount(0)
+    await expect(page.getByText("파일 목록을 불러오지 못했습니다.")).toBeVisible()
+    await expect(page.getByRole("button", { name: "파일 목록 다시 시도" })).toBeVisible()
+  })
+
+  test("클라우드 업로드 실패는 실패 사유와 재시도 버튼을 같은 항목에 남긴다", async ({ page }) => {
+    await setupAdminCloudMocks(page, {
+      failUploadNames: ["실패할 운영 문서.pdf"],
+      initialFiles: [],
+    })
+
+    await page.goto("/admin/cloud")
+
+    await page.getByLabel("클라우드 파일 업로드").setInputFiles({
+      name: "실패할 운영 문서.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4 failed upload"),
+    })
+
+    const uploadPanel = page.getByLabel("업로드 중인 파일")
+    await expect(uploadPanel.getByText("실패할 운영 문서.pdf")).toBeVisible()
+    await expect(uploadPanel.getByText(/서버 오류가 발생했습니다/)).toBeVisible()
+    await expect(uploadPanel.getByRole("button", { name: "실패할 운영 문서.pdf 업로드 다시 시도" })).toBeVisible()
   })
 })

--- a/front/e2e/admin-surface-primitives.spec.ts
+++ b/front/e2e/admin-surface-primitives.spec.ts
@@ -18,15 +18,15 @@ test.describe("관리자 표면 공통 계약", () => {
 
     expect(colorTokenSource).toContain("export const adminSystemThemeVariables =")
     expect(colorTokenSource).toContain('theme.scheme === "dark" ? adminDarkThemeVariables : adminLightThemeVariables')
-    expect(colorTokenSource).toContain("--admin-primary: #b9954f;")
-    expect(colorTokenSource).toContain("--admin-primary: #d0b46c;")
-    expect(colorTokenSource).toContain("--admin-accent-text: #6f5524;")
+    expect(colorTokenSource).toContain("--admin-primary: #4f7cff;")
+    expect(colorTokenSource).toContain("--admin-primary: #6f95ff;")
+    expect(colorTokenSource).toContain("--admin-accent-text: #315fd8;")
     expect(colorTokenSource).toContain("--admin-control-text: #101214;")
     expect(colorTokenSource).toContain("--admin-text-muted: #566273;")
     expect(colorTokenSource).toContain('export const adminTextMuted = "var(--admin-text-muted, #566273)"')
     expect(colorTokenSource).toContain('export const adminSurface = "var(--admin-surface')
-    expect(colorTokenSource).toContain('export const adminSurfaceAccent = "var(--admin-surface-accent, #f7f1e3)"')
-    expect(colorTokenSource).toContain('export const adminGold = "var(--admin-accent-text, #6f5524)"')
+    expect(colorTokenSource).toContain('export const adminSurfaceAccent = "var(--admin-surface-accent, #edf3ff)"')
+    expect(colorTokenSource).toContain('export const adminGold = "var(--admin-accent-text, #315fd8)"')
     expect(colorTokenSource).toContain('export const adminTeal = "var(--admin-primary')
     expect(colorTokenSource).toContain('export const usesDarkAdminSurface = (theme: Theme) => theme.scheme !== "light"')
     expect(colorTokenSource).not.toContain("#4f74ff")
@@ -365,10 +365,12 @@ test.describe("관리자 표면 공통 계약", () => {
 
     expect(source).toContain('import ProfileImage from "src/components/ProfileImage"')
     expect(source).toContain("profileSnapshot?: AdminShellProfileSnapshot | null")
-    expect(source).toContain('const sidebarIdentityName = (profileSnapshot?.blogTitle || member.blogTitle || "AquilaLog").trim()')
-    expect(source).toContain("profileSnapshot?.profileImageDirectUrl ||")
-    expect(source).toContain("profileSnapshot?.profileImageUrl ||")
+    expect(source).toContain('const sidebarIdentityName = (member.nickname || member.username || "관리자").trim()')
     expect(source).toContain("member.profileImageDirectUrl ||")
+    expect(source.indexOf("member.profileImageDirectUrl ||")).toBeLessThan(
+      source.indexOf("profileSnapshot?.profileImageDirectUrl ||")
+    )
+    expect(source).not.toContain('const sidebarIdentityName = (profileSnapshot?.blogTitle || member.blogTitle || "AquilaLog").trim()')
     expect(source).not.toContain('import { useAdminProfile } from "src/hooks/useAdminProfile"')
     expect(source).toContain('<SidebarPrimaryAction title="새 글 작성">')
     expect(source).not.toContain("<SidebarSectionLabel>관리 메뉴</SidebarSectionLabel>")
@@ -379,6 +381,20 @@ test.describe("관리자 표면 공통 계약", () => {
     expect(source).not.toContain("SidebarCardTitle")
     expect(source).not.toContain("<strong>AquilaLog</strong>")
     expect(source).not.toContain('<AppIcon name="service" />')
+  })
+
+  test("관리자 MYBOX 색상 토큰은 brown gold 계열 대신 neutral blue accent를 사용한다", () => {
+    const tokenSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/adminColorTokens.ts"), "utf8")
+    const shellSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminShell.tsx"), "utf8")
+
+    expect(tokenSource).not.toContain("#b9954f")
+    expect(tokenSource).not.toContain("#9d7d3f")
+    expect(tokenSource).not.toContain("#6f5524")
+    expect(tokenSource).not.toContain("#f7f1e3")
+    expect(tokenSource).not.toContain("#2d291a")
+    expect(tokenSource).toContain("--admin-primary: #4f7cff;")
+    expect(tokenSource).toContain("--admin-primary-hover: #3f6df2;")
+    expect(shellSource).not.toContain("adminGold")
   })
 
   test("관리자 허브는 중복 상태와 바로가기 레일 대신 주요 작업 흐름 하나를 둔다", () => {

--- a/front/e2e/admin-surface-primitives.spec.ts
+++ b/front/e2e/admin-surface-primitives.spec.ts
@@ -2,6 +2,23 @@ import { readFileSync } from "node:fs"
 import path from "node:path"
 import { expect, test } from "@playwright/test"
 
+const getRelativeLuminance = (hexColor: string) => {
+  const [red, green, blue] = hexColor
+    .replace("#", "")
+    .match(/.{2}/g)!
+    .map((channel) => {
+      const value = Number.parseInt(channel, 16) / 255
+      return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+    })
+
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+}
+
+const getContrastRatio = (foreground: string, background: string) => {
+  const [lighter, darker] = [getRelativeLuminance(foreground), getRelativeLuminance(background)].sort((a, b) => b - a)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
 test.describe("관리자 표면 공통 계약", () => {
   test("관리자 표면은 MYBOX형 화이트 우선 시스템 테마 토큰을 공유한다", () => {
     const colorTokenSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/adminColorTokens.ts"), "utf8")
@@ -26,7 +43,8 @@ test.describe("관리자 표면 공통 계약", () => {
     expect(colorTokenSource).toContain('export const adminTextMuted = "var(--admin-text-muted, #566273)"')
     expect(colorTokenSource).toContain('export const adminSurface = "var(--admin-surface')
     expect(colorTokenSource).toContain('export const adminSurfaceAccent = "var(--admin-surface-accent, #edf3ff)"')
-    expect(colorTokenSource).toContain('export const adminGold = "var(--admin-accent-text, #315fd8)"')
+    expect(colorTokenSource).toContain('export const adminAccentText = "var(--admin-accent-text, #315fd8)"')
+    expect(colorTokenSource).toContain("export const adminGold = adminAccentText")
     expect(colorTokenSource).toContain('export const adminTeal = "var(--admin-primary')
     expect(colorTokenSource).toContain('export const usesDarkAdminSurface = (theme: Theme) => theme.scheme !== "light"')
     expect(colorTokenSource).not.toContain("#4f74ff")
@@ -393,7 +411,10 @@ test.describe("관리자 표면 공통 계약", () => {
     expect(tokenSource).not.toContain("#f7f1e3")
     expect(tokenSource).not.toContain("#2d291a")
     expect(tokenSource).toContain("--admin-primary: #4f7cff;")
-    expect(tokenSource).toContain("--admin-primary-hover: #3f6df2;")
+    expect(tokenSource).toContain("--admin-primary-hover: #5f8aff;")
+    expect(getContrastRatio("#315fd8", "#edf3ff")).toBeGreaterThanOrEqual(4.5)
+    expect(getContrastRatio("#101214", "#5f8aff")).toBeGreaterThanOrEqual(4.5)
+    expect(shellSource).toContain("adminAccentText")
     expect(shellSource).not.toContain("adminGold")
   })
 

--- a/front/src/routes/Admin/AdminCloudUploadQueue.tsx
+++ b/front/src/routes/Admin/AdminCloudUploadQueue.tsx
@@ -20,6 +20,7 @@ type AdminCloudUploadQueueProps = {
   activeUploadCount: number
   completedUploadCount: number
   onCancelUpload: (item: UploadQueueItem) => void
+  onRetryUpload: (item: UploadQueueItem) => void
   onClearFinishedUploads: () => void
 }
 
@@ -28,6 +29,7 @@ const AdminCloudUploadQueue = ({
   activeUploadCount,
   completedUploadCount,
   onCancelUpload,
+  onRetryUpload,
   onClearFinishedUploads,
 }: AdminCloudUploadQueueProps) => {
   if (uploadQueue.length === 0) return null
@@ -63,6 +65,11 @@ const AdminCloudUploadQueue = ({
             {isUploadActive(item.status) ? (
               <GhostButton type="button" aria-label={`${item.name} 업로드 취소`} onClick={() => onCancelUpload(item)}>
                 취소
+              </GhostButton>
+            ) : null}
+            {item.status === "failed" ? (
+              <GhostButton type="button" aria-label={`${item.name} 업로드 다시 시도`} onClick={() => onRetryUpload(item)}>
+                다시 시도
               </GhostButton>
             ) : null}
             <ProgressTrack style={{ "--progress": `${item.progress}%` } as CSSProperties}>

--- a/front/src/routes/Admin/AdminCloudWorkspaceModel.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspaceModel.ts
@@ -11,6 +11,7 @@ export type UploadQueueItem = {
   progress: number
   message: string
   uploadedFileId?: number
+  retryCount?: number
 }
 export type CloudSearchParams = {
   folderPath: string

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -100,6 +100,11 @@ const createUploadQueueItem = (file: File): UploadQueueItem => ({
 const isAbortLikeError = (error: unknown) =>
   error instanceof DOMException && (error.name === "AbortError" || error.name === "TimeoutError")
 
+const resolveCloudErrorMessage = (error: unknown) => {
+  if (error instanceof Error && error.message.trim()) return error.message.trim()
+  return "요청 처리 중 오류가 발생했습니다."
+}
+
 type PdfPreviewProps = {
   file: CloudFile
   contentUrl: string
@@ -290,6 +295,8 @@ const AdminCloudWorkspacePage = () => {
 
   const filesQuery = useQuery({
     queryKey: [CLOUD_QUERY_KEY, filter, keyword],
+    retry: false,
+    refetchOnWindowFocus: false,
     queryFn: () => {
       const searchParams = resolveCloudSearchParams(keyword)
       return listCloudFiles({
@@ -371,7 +378,8 @@ const AdminCloudWorkspacePage = () => {
         void queryClient.invalidateQueries({ queryKey: [CLOUD_QUERY_KEY] })
       } catch (error) {
         const aborted = controller.signal.aborted || isAbortLikeError(error)
-        setNotice(aborted ? `${nextUpload.name} 업로드 취소` : `${nextUpload.name} 업로드 실패`)
+        const failureMessage = aborted ? "사용자가 취소함" : resolveCloudErrorMessage(error)
+        setNotice(aborted ? `${nextUpload.name} 업로드 취소` : `${nextUpload.name} 업로드 실패: ${failureMessage}`)
         setUploadQueue((current) =>
           current.map((item) =>
             item.id === nextUpload.id
@@ -379,7 +387,7 @@ const AdminCloudWorkspacePage = () => {
                   ...item,
                   status: aborted ? "cancelled" : "failed",
                   progress: aborted ? 0 : 100,
-                  message: aborted ? "사용자가 취소함" : "업로드 실패",
+                  message: failureMessage,
                 }
               : item
           )
@@ -415,6 +423,23 @@ const AdminCloudWorkspacePage = () => {
 
   const handleClearFinishedUploads = () => {
     setUploadQueue((current) => current.filter((item) => isUploadActive(item.status)))
+  }
+
+  const handleRetryUpload = (item: UploadQueueItem) => {
+    if (item.status !== "failed") return
+    setUploadQueue((current) =>
+      current.map((queueItem) =>
+        queueItem.id === item.id
+          ? {
+              ...queueItem,
+              status: "queued",
+              progress: 0,
+              message: "업로드 대기 중",
+              retryCount: (queueItem.retryCount ?? 0) + 1,
+            }
+          : queueItem
+      )
+    )
   }
 
   const handleToggleAllChecked = () => {
@@ -491,8 +516,11 @@ const AdminCloudWorkspacePage = () => {
     await queryClient.invalidateQueries({ queryKey: [CLOUD_QUERY_KEY] })
   }
 
-  const emptyTitle = filesQuery.isFetching
+  const isFileListError = filesQuery.isError
+  const emptyTitle = filesQuery.isLoading
     ? "파일을 불러오는 중입니다."
+    : isFileListError
+      ? "파일 목록을 불러오지 못했습니다."
     : activeUploadCount > 0
       ? "업로드 중인 파일이 있습니다."
     : keyword || filter !== "ALL"
@@ -587,6 +615,7 @@ const AdminCloudWorkspacePage = () => {
             activeUploadCount={activeUploadCount}
             completedUploadCount={completedUploadCount}
             onCancelUpload={handleCancelUpload}
+            onRetryUpload={handleRetryUpload}
             onClearFinishedUploads={handleClearFinishedUploads}
           />
 
@@ -595,9 +624,19 @@ const AdminCloudWorkspacePage = () => {
               <EmptyTableState>
                 <strong>{emptyTitle}</strong>
                 {activeUploadCount > 0 ? null : (
-                  <PrimaryButton type="button" aria-label="파일 업로드" onClick={() => uploadInputRef.current?.click()}>
-                    ⤴ 올리기
-                  </PrimaryButton>
+                  isFileListError ? (
+                    <PrimaryButton
+                      type="button"
+                      aria-label="파일 목록 다시 시도"
+                      onClick={() => void filesQuery.refetch()}
+                    >
+                      다시 시도
+                    </PrimaryButton>
+                  ) : (
+                    <PrimaryButton type="button" aria-label="파일 업로드" onClick={() => uploadInputRef.current?.click()}>
+                      ⤴ 올리기
+                    </PrimaryButton>
+                  )
                 )}
               </EmptyTableState>
             ) : (

--- a/front/src/routes/Admin/AdminShell.tsx
+++ b/front/src/routes/Admin/AdminShell.tsx
@@ -10,7 +10,6 @@ import {
   adminBorder,
   adminBorderStrong,
   adminControlText,
-  adminGold,
   adminShellSurface,
   adminSurface,
   adminSurfaceAccent,
@@ -98,13 +97,13 @@ const AdminShell = ({ currentSection, member, profileSnapshot = null, children }
     icon: item.icon,
     active: item.id === currentSection,
   }))
-  const sidebarIdentityName = (profileSnapshot?.blogTitle || member.blogTitle || "AquilaLog").trim()
+  const sidebarIdentityName = (member.nickname || member.username || "관리자").trim()
   const sidebarIdentityInitial = sidebarIdentityName.slice(0, 2).toUpperCase()
   const sidebarProfileImageSrc = (
-    profileSnapshot?.profileImageDirectUrl ||
-    profileSnapshot?.profileImageUrl ||
     member.profileImageDirectUrl ||
     member.profileImageUrl ||
+    profileSnapshot?.profileImageDirectUrl ||
+    profileSnapshot?.profileImageUrl ||
     ""
   ).trim()
 
@@ -238,7 +237,7 @@ const BrandMark = styled.div`
   overflow: hidden;
   border: 1px solid ${adminBorderStrong};
   background: ${adminSurfaceAccent};
-  color: ${adminGold};
+  color: ${adminTeal};
 
   span {
     font-size: 0.9rem;
@@ -327,13 +326,13 @@ const NavLink = styled.a`
   }
 
   &[data-active="true"] {
-    border-left-color: ${adminGold};
+    border-left-color: ${adminTeal};
     background: ${adminSurfaceAccent};
   }
 
   &[data-active="true"] .navIcon {
     background: transparent;
-    color: ${adminGold};
+    color: ${adminTeal};
   }
 
   &:hover {

--- a/front/src/routes/Admin/AdminShell.tsx
+++ b/front/src/routes/Admin/AdminShell.tsx
@@ -6,6 +6,7 @@ import AppIcon, { type IconName } from "src/components/icons/AppIcon"
 import ProfileImage from "src/components/ProfileImage"
 import type { AuthMember } from "src/hooks/useAuthSession"
 import {
+  adminAccentText,
   adminAppBackground,
   adminBorder,
   adminBorderStrong,
@@ -237,7 +238,7 @@ const BrandMark = styled.div`
   overflow: hidden;
   border: 1px solid ${adminBorderStrong};
   background: ${adminSurfaceAccent};
-  color: ${adminTeal};
+  color: ${adminAccentText};
 
   span {
     font-size: 0.9rem;

--- a/front/src/routes/Admin/adminColorTokens.ts
+++ b/front/src/routes/Admin/adminColorTokens.ts
@@ -15,7 +15,7 @@ const adminLightThemeVariables = `
   --admin-text-secondary: #4d5562;
   --admin-text-muted: #566273;
   --admin-primary: #4f7cff;
-  --admin-primary-hover: #3f6df2;
+  --admin-primary-hover: #5f8aff;
   --admin-accent-text: #315fd8;
   --admin-primary-border: rgba(79, 124, 255, 0.32);
   --admin-primary-border-hover: rgba(79, 124, 255, 0.52);
@@ -66,9 +66,10 @@ export const adminSurfaceMuted = "var(--admin-surface-muted, #eef2f7)"
 export const adminSurfaceAccent = "var(--admin-surface-accent, #edf3ff)"
 export const adminElevatedSurfaceTop = "var(--admin-elevated-top, #ffffff)"
 export const adminElevatedBorderDark = "var(--admin-border, #e5e9f1)"
-export const adminGold = "var(--admin-accent-text, #315fd8)"
+export const adminAccentText = "var(--admin-accent-text, #315fd8)"
+export const adminGold = adminAccentText
 export const adminTeal = "var(--admin-primary, #4f7cff)"
-export const adminTealHover = "var(--admin-primary-hover, #3f6df2)"
+export const adminTealHover = "var(--admin-primary-hover, #5f8aff)"
 export const adminControlText = "var(--admin-control-text, #101214)"
 export const adminTealBorder = "var(--admin-primary-border, rgba(79, 124, 255, 0.32))"
 export const adminTealBorderHover = "var(--admin-primary-border-hover, rgba(79, 124, 255, 0.52))"

--- a/front/src/routes/Admin/adminColorTokens.ts
+++ b/front/src/routes/Admin/adminColorTokens.ts
@@ -7,21 +7,21 @@ const adminLightThemeVariables = `
   --admin-surface: #ffffff;
   --admin-surface-raised: #f3f5f9;
   --admin-surface-muted: #eef2f7;
-  --admin-surface-accent: #f7f1e3;
+  --admin-surface-accent: #edf3ff;
   --admin-elevated-top: #ffffff;
   --admin-border: #e5e9f1;
   --admin-border-strong: #c8d1df;
   --admin-text-primary: #20242b;
   --admin-text-secondary: #4d5562;
   --admin-text-muted: #566273;
-  --admin-primary: #b9954f;
-  --admin-primary-hover: #9d7d3f;
-  --admin-accent-text: #6f5524;
-  --admin-primary-border: rgba(185, 149, 79, 0.36);
-  --admin-primary-border-hover: rgba(185, 149, 79, 0.58);
+  --admin-primary: #4f7cff;
+  --admin-primary-hover: #3f6df2;
+  --admin-accent-text: #315fd8;
+  --admin-primary-border: rgba(79, 124, 255, 0.32);
+  --admin-primary-border-hover: rgba(79, 124, 255, 0.52);
   --admin-control-text: #101214;
-  --admin-focus-ring: rgba(185, 149, 79, 0.18);
-  --admin-focus-ring-strong: rgba(185, 149, 79, 0.26);
+  --admin-focus-ring: rgba(79, 124, 255, 0.18);
+  --admin-focus-ring-strong: rgba(79, 124, 255, 0.28);
   --admin-action-group-surface: rgba(255, 255, 255, 0.88);
 `
 
@@ -32,21 +32,21 @@ const adminDarkThemeVariables = `
   --admin-surface: #121212;
   --admin-surface-raised: #1b1b1b;
   --admin-surface-muted: #222222;
-  --admin-surface-accent: #2d291a;
+  --admin-surface-accent: #172033;
   --admin-elevated-top: #181818;
   --admin-border: #2f333a;
   --admin-border-strong: #4a5464;
   --admin-text-primary: #f5f6f8;
   --admin-text-secondary: #c8ced7;
   --admin-text-muted: #8f99a7;
-  --admin-primary: #d0b46c;
-  --admin-primary-hover: #e0c984;
-  --admin-accent-text: #d0b46c;
-  --admin-primary-border: rgba(208, 180, 108, 0.42);
-  --admin-primary-border-hover: rgba(208, 180, 108, 0.62);
+  --admin-primary: #6f95ff;
+  --admin-primary-hover: #86a7ff;
+  --admin-accent-text: #9ab4ff;
+  --admin-primary-border: rgba(111, 149, 255, 0.42);
+  --admin-primary-border-hover: rgba(111, 149, 255, 0.62);
   --admin-control-text: #101214;
-  --admin-focus-ring: rgba(208, 180, 108, 0.22);
-  --admin-focus-ring-strong: rgba(208, 180, 108, 0.3);
+  --admin-focus-ring: rgba(111, 149, 255, 0.22);
+  --admin-focus-ring-strong: rgba(111, 149, 255, 0.32);
   --admin-action-group-surface: rgba(18, 18, 18, 0.88);
 `
 
@@ -63,19 +63,19 @@ export const adminSurface = "var(--admin-surface, #ffffff)"
 export const adminShellSurface = "var(--admin-sidebar-bg, #f6f7fb)"
 export const adminSurfaceRaised = "var(--admin-surface-raised, #f3f5f9)"
 export const adminSurfaceMuted = "var(--admin-surface-muted, #eef2f7)"
-export const adminSurfaceAccent = "var(--admin-surface-accent, #f7f1e3)"
+export const adminSurfaceAccent = "var(--admin-surface-accent, #edf3ff)"
 export const adminElevatedSurfaceTop = "var(--admin-elevated-top, #ffffff)"
 export const adminElevatedBorderDark = "var(--admin-border, #e5e9f1)"
-export const adminGold = "var(--admin-accent-text, #6f5524)"
-export const adminTeal = "var(--admin-primary, #b9954f)"
-export const adminTealHover = "var(--admin-primary-hover, #9d7d3f)"
+export const adminGold = "var(--admin-accent-text, #315fd8)"
+export const adminTeal = "var(--admin-primary, #4f7cff)"
+export const adminTealHover = "var(--admin-primary-hover, #3f6df2)"
 export const adminControlText = "var(--admin-control-text, #101214)"
-export const adminTealBorder = "var(--admin-primary-border, rgba(185, 149, 79, 0.36))"
-export const adminTealBorderHover = "var(--admin-primary-border-hover, rgba(185, 149, 79, 0.58))"
-export const adminGoldTintSubtle = "var(--admin-surface-accent, #f7f1e3)"
-export const adminGoldTintFocus = "var(--admin-focus-ring, rgba(185, 149, 79, 0.18))"
-export const adminGoldTintFocusStrong = "var(--admin-focus-ring-strong, rgba(185, 149, 79, 0.26))"
-export const adminGoldTintLine = "var(--admin-primary-border, rgba(185, 149, 79, 0.36))"
+export const adminTealBorder = "var(--admin-primary-border, rgba(79, 124, 255, 0.32))"
+export const adminTealBorderHover = "var(--admin-primary-border-hover, rgba(79, 124, 255, 0.52))"
+export const adminGoldTintSubtle = "var(--admin-surface-accent, #edf3ff)"
+export const adminGoldTintFocus = "var(--admin-focus-ring, rgba(79, 124, 255, 0.18))"
+export const adminGoldTintFocusStrong = "var(--admin-focus-ring-strong, rgba(79, 124, 255, 0.28))"
+export const adminGoldTintLine = "var(--admin-primary-border, rgba(79, 124, 255, 0.32))"
 export const adminActionGroupDarkSurface = "var(--admin-action-group-surface, rgba(18, 18, 18, 0.88))"
 export const adminActionGroupLightSurface = "var(--admin-action-group-surface, rgba(255, 255, 255, 0.88))"
 


### PR DESCRIPTION
## 관련 이슈

close #733

## 작업 배경

- 관리자 사이드바 identity가 블로그 제목 대신 계정 nickname/username을 우선 표시하도록 수정했습니다.
- 클라우드 목록/업로드 실패 상태를 로딩 또는 단순 실패 문구로 숨기지 않고, 오류 문구와 재시도 액션으로 노출했습니다.
- 관리자 MYBOX 색상 토큰에서 brown/gold 계열을 제거하고 neutral + blue accent로 정렬했습니다.

## 작업 내용

- AdminShell identity/profile image fallback 우선순위를 계정 정보 중심으로 변경
- AdminCloudWorkspacePage 목록 조회 실패 UI, upload 실패 사유 표시, 실패 항목 재시도 추가
- 관리자 공통 색상 토큰을 MYBOX 레퍼런스에 가까운 blue accent로 변경
- admin-cloud/admin-surface e2e 회귀 테스트 추가 및 기존 색상 계약 갱신

## 검증

- 실행한 명령과 결과:
  - env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-cloud.spec.ts e2e/admin-surface-primitives.spec.ts --workers=1
  - yarn --cwd front playwright:preflight
  - yarn --cwd front build
  - Browser 확인: http://127.0.0.1:3100/admin/cloud 은 비인증 상태에서 /login?next=%2Fadmin%2Fcloud 로 redirect, blank/overlay/console error 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 관리자 공통 토큰 변경으로 admin 전역 accent 색상이 blue 계열로 바뀝니다.
- 롤백 방법: 이 PR revert

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
