### PR TITLE
[Fix] 관리자 런타임 회귀 수정

### DIFF
--- a/front/e2e/admin-runtime-regressions.spec.ts
+++ b/front/e2e/admin-runtime-regressions.spec.ts
@@ -1,0 +1,48 @@
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { expect, test } from "@playwright/test"
+
+const readFrontSource = (relativePath: string) =>
+  readFileSync(path.resolve(__dirname, "../src", relativePath), "utf8")
+
+test.describe("관리자 런타임 회귀 계약", () => {
+  test("운영 브라우저 API는 로그인과 관리자 요청을 same-origin 백엔드 프록시로 보낸다", () => {
+    const clientSource = readFrontSource("apis/backend/client.ts")
+    const proxySourcePath = path.resolve(__dirname, "../src/pages/api/backend/[...path].ts")
+
+    expect(clientSource).toContain('const BROWSER_BACKEND_PROXY_PREFIX = "/api/backend"')
+    expect(clientSource).toContain("const shouldUseBrowserBackendProxy = (safePath: string) =>")
+    expect(clientSource).toContain('process.env.NODE_ENV === "production"')
+    expect(clientSource).toContain("safePath.startsWith(\"/member/api/v1/auth/\")")
+    expect(clientSource).toContain("safePath.startsWith(\"/system/api/v1/adm/\")")
+    expect(clientSource).toContain("return `${BROWSER_BACKEND_PROXY_PREFIX}${safePath}`")
+
+    expect(existsSync(proxySourcePath)).toBe(true)
+    const proxySource = readFileSync(proxySourcePath, "utf8")
+    expect(proxySource).toContain("bodyParser: false")
+    expect(proxySource).toContain("normalizeApiRequestPath")
+    expect(proxySource).toContain("resolveServerApiBaseUrl")
+    expect(proxySource).toContain('headers.set("X-Forwarded-Host"')
+    expect(proxySource).toContain('duplex: "half"')
+  })
+
+  test("클라우드 목록과 업로드는 프록시 가능한 URL 생성기를 공유한다", () => {
+    const cloudSource = readFrontSource("apis/backend/cloud.ts")
+
+    expect(cloudSource).toContain('import { apiFetch, getApiRequestUrl } from "./client"')
+    expect(cloudSource).toContain("getApiRequestUrl(`/system/api/v1/adm/cloud/files/${fileId}/content`)")
+    expect(cloudSource).not.toContain("getApiBaseUrl")
+  })
+
+  test("새로고침 전 첫 페인트는 저장된 테마나 시스템 다크 모드를 먼저 적용한다", () => {
+    const documentSource = readFrontSource("pages/_document.tsx")
+    const schemeSource = readFrontSource("hooks/useScheme.ts")
+
+    expect(documentSource).toContain("AQUILA_SCHEME_BOOTSTRAP_SCRIPT")
+    expect(documentSource).toContain('document.documentElement.dataset.aquilaScheme = nextScheme')
+    expect(documentSource).toContain("prefers-color-scheme: dark")
+    expect(documentSource).toContain("colorScheme = nextScheme")
+    expect(schemeSource).toContain("resolveInitialBrowserScheme")
+    expect(schemeSource).toContain('window.matchMedia?.("(prefers-color-scheme: dark)")?.matches')
+  })
+})

--- a/front/e2e/admin-runtime-regressions.spec.ts
+++ b/front/e2e/admin-runtime-regressions.spec.ts
@@ -23,7 +23,18 @@ test.describe("관리자 런타임 회귀 계약", () => {
     expect(proxySource).toContain("normalizeApiRequestPath")
     expect(proxySource).toContain("resolveServerApiBaseUrl")
     expect(proxySource).toContain('headers.set("X-Forwarded-Host"')
+    expect(proxySource).toContain('headers.set("X-Forwarded-Proto", firstHeaderValue(req.headers["x-forwarded-proto"]) || "https")')
+    expect(proxySource).toContain('headers.set("X-Forwarded-For", clientIp)')
+    expect(proxySource).toContain("const BACKEND_PROXY_TIMEOUT_MS = 120_000")
+    expect(proxySource).toContain("const controller = new AbortController()")
+    expect(proxySource).toContain("const timeoutId = setTimeout(() => controller.abort(), BACKEND_PROXY_TIMEOUT_MS)")
+    expect(proxySource).toContain("signal: controller.signal")
+    expect(proxySource).toContain("clearTimeout(timeoutId)")
     expect(proxySource).toContain('duplex: "half"')
+    expect(proxySource).toContain('normalizedKey === "host"')
+    expect(proxySource).toContain('normalizedKey === "accept-encoding"')
+    expect(proxySource).toContain('const DECODED_RESPONSE_HEADERS = new Set(["content-encoding", "content-length"])')
+    expect(proxySource).toContain("DECODED_RESPONSE_HEADERS.has(normalizedKey)")
   })
 
   test("클라우드 목록과 업로드는 프록시 가능한 URL 생성기를 공유한다", () => {
@@ -40,9 +51,26 @@ test.describe("관리자 런타임 회귀 계약", () => {
 
     expect(documentSource).toContain("AQUILA_SCHEME_BOOTSTRAP_SCRIPT")
     expect(documentSource).toContain('document.documentElement.dataset.aquilaScheme = nextScheme')
+    expect(documentSource).toContain('document.documentElement.setAttribute("data-aquila-scheme-bootstrap", nextScheme)')
     expect(documentSource).toContain("prefers-color-scheme: dark")
     expect(documentSource).toContain("colorScheme = nextScheme")
-    expect(schemeSource).toContain("resolveInitialBrowserScheme")
+    expect(documentSource).toContain('nextScheme === "dark" ? "#121212" : "#f3f5f8"')
+    expect(documentSource).not.toContain("#111318")
+    expect(documentSource).toContain("html[data-aquila-scheme-bootstrap] body")
+    expect(schemeSource).toContain("initialData: fallbackScheme")
+    expect(schemeSource).toContain("clearSchemeBootstrapAfterHydration")
+    expect(schemeSource).toContain('style[data-aquila-scheme-bootstrap-style="true"]')
     expect(schemeSource).toContain('window.matchMedia?.("(prefers-color-scheme: dark)")?.matches')
+    expect(schemeSource).not.toContain("resolveInitialBrowserScheme")
+  })
+})
+
+test.describe("공개 피드 접근성 회귀 계약", () => {
+  test("홈 피드 활성 태그는 밝은 배경에서 충분한 대비의 텍스트 색을 사용한다", () => {
+    const tagListSource = readFrontSource("routes/Feed/TagList.tsx")
+
+    expect(tagListSource).toContain("--feed-tag-accent-text")
+    expect(tagListSource).toContain('theme.scheme === "light" ? theme.colors.blue11 : theme.colors.blue10')
+    expect(tagListSource).toContain("color: var(--feed-tag-accent-text);")
   })
 })

--- a/front/e2e/admin-surface-primitives.spec.ts
+++ b/front/e2e/admin-surface-primitives.spec.ts
@@ -106,6 +106,10 @@ test.describe("관리자 표면 공통 계약", () => {
     expect(source).toContain("export const AdminTextActionButton = styled.button`")
     expect(source).toContain("export const AdminTextActionLink = styled.a`")
     expect(source).toContain("export const AdminActionCardButton = styled.button`")
+    const actionButtonBlock = source.match(/export const AdminActionCardButton = styled\.button`[\s\S]*?`\n/)?.[0] ?? ""
+    expect(actionButtonBlock).toContain("background: ${({ theme }) => adminRaisedSurface(theme)};")
+    expect(actionButtonBlock).toContain("background: ${({ theme }) => adminAccentSurface(theme)};")
+    expect(actionButtonBlock).not.toContain("background: transparent;")
     expect(source).toContain("export const AdminWorkspaceHero = styled.section`")
   })
 

--- a/front/src/apis/backend/client.ts
+++ b/front/src/apis/backend/client.ts
@@ -1,6 +1,7 @@
 import { normalizeApiRequestPath } from "src/libs/backend/requestPath"
 
 const DEFAULT_API_BASE_URL = "http://localhost:8080"
+const BROWSER_BACKEND_PROXY_PREFIX = "/api/backend"
 const DEFAULT_API_FETCH_TIMEOUT_MS = 12_000
 const DEFAULT_REVALIDATE_CACHE_TTL_MS = 15_000
 const REVALIDATE_CACHE_MAX_TTL_MS = 300_000
@@ -341,9 +342,31 @@ export const getApiBaseUrl = () => {
   return DEFAULT_API_BASE_URL
 }
 
+const shouldUseBrowserBackendProxy = (safePath: string) => {
+  if (isServer) return false
+  if (process.env.NODE_ENV !== "production") return false
+
+  return (
+    safePath.startsWith("/member/api/v1/auth/") ||
+    safePath.startsWith("/member/api/v1/adm/") ||
+    safePath.startsWith("/post/api/v1/adm/") ||
+    safePath.startsWith("/system/api/v1/adm/") ||
+    safePath.startsWith("/signup")
+  )
+}
+
+export const getApiRequestUrl = (path: string) => {
+  const safePath = normalizeApiRequestPath(path)
+  if (shouldUseBrowserBackendProxy(safePath)) {
+    return `${BROWSER_BACKEND_PROXY_PREFIX}${safePath}`
+  }
+
+  return `${getApiBaseUrl()}${safePath}`
+}
+
 export const apiFetch = async <T>(path: string, init: ApiFetchOptions = {}): Promise<T> => {
   const safePath = normalizeApiRequestPath(path)
-  const url = `${getApiBaseUrl()}${safePath}`
+  const url = getApiRequestUrl(safePath)
   const { timeoutMs: _timeoutMs, ...requestInit } = init
   const headers = new Headers(requestInit.headers || {})
   const hasBody = requestInit.body !== undefined && requestInit.body !== null

--- a/front/src/apis/backend/cloud.ts
+++ b/front/src/apis/backend/cloud.ts
@@ -1,5 +1,5 @@
 import type { components } from "@shared/contracts"
-import { apiFetch, getApiBaseUrl } from "./client"
+import { apiFetch, getApiRequestUrl } from "./client"
 
 export type CloudFileDto = components["schemas"]["CloudFileDto"]
 export type CloudMediaKind = NonNullable<CloudFileDto["mediaKind"]>
@@ -44,7 +44,7 @@ const appendQuery = (path: string, params: Record<string, string | undefined>) =
 }
 
 export const getCloudFileContentUrl = (fileId: number) =>
-  `${getApiBaseUrl()}/system/api/v1/adm/cloud/files/${fileId}/content`
+  getApiRequestUrl(`/system/api/v1/adm/cloud/files/${fileId}/content`)
 
 export const listCloudFiles = async ({
   folderPath = "",

--- a/front/src/hooks/useScheme.ts
+++ b/front/src/hooks/useScheme.ts
@@ -9,34 +9,28 @@ type SetScheme = (scheme: SchemeType) => void
 
 const isScheme = (value: unknown): value is SchemeType => value === "light" || value === "dark"
 
-const resolveInitialBrowserScheme = (
-  fallbackScheme: SchemeType,
-  followsSystemTheme: boolean
-): SchemeType => {
-  if (typeof window === "undefined") return fallbackScheme
+const clearSchemeBootstrapStyle = () => {
+  document.documentElement.removeAttribute("data-aquila-scheme-bootstrap")
+  document.querySelector('style[data-aquila-scheme-bootstrap-style="true"]')?.remove()
+}
 
-  const cachedScheme = getCookie("scheme")
-  if (isScheme(cachedScheme)) return cachedScheme
-
-  if (followsSystemTheme && window.matchMedia?.("(prefers-color-scheme: dark)")?.matches) {
-    return "dark"
-  }
-
-  return fallbackScheme
+const clearSchemeBootstrapAfterHydration = () => {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(clearSchemeBootstrapStyle)
+  })
 }
 
 const useScheme = (): [SchemeType, SetScheme] => {
   const queryClient = useQueryClient()
   const followsSystemTheme = CONFIG.blog.scheme === "system"
   const fallbackScheme = (CONFIG.blog.scheme === "system" ? "light" : CONFIG.blog.scheme) as SchemeType
-  const initialScheme = resolveInitialBrowserScheme(fallbackScheme, followsSystemTheme)
 
   const { data } = useQuery<SchemeType>({
     queryKey: queryKey.scheme(),
-    queryFn: () => initialScheme,
+    queryFn: () => fallbackScheme,
     enabled: false,
     staleTime: Infinity,
-    initialData: initialScheme,
+    initialData: fallbackScheme,
   })
 
   const setScheme = useCallback((scheme: SchemeType) => {
@@ -47,16 +41,19 @@ const useScheme = (): [SchemeType, SetScheme] => {
   useEffect(() => {
     if (typeof window === "undefined") return
 
-    const cachedScheme = getCookie("scheme") as SchemeType
+    const cachedScheme = getCookie("scheme")
     const defaultScheme = followsSystemTheme
       ? window.matchMedia?.("(prefers-color-scheme: dark)")?.matches
         ? "dark"
         : "light"
       : data
-    const nextScheme = cachedScheme || defaultScheme
+    const nextScheme = isScheme(cachedScheme) ? cachedScheme : defaultScheme
     if (nextScheme !== data) {
       setScheme(nextScheme)
+      clearSchemeBootstrapAfterHydration()
+      return
     }
+    clearSchemeBootstrapAfterHydration()
   }, [data, followsSystemTheme, setScheme])
 
   return [data, setScheme]

--- a/front/src/hooks/useScheme.ts
+++ b/front/src/hooks/useScheme.ts
@@ -7,18 +7,36 @@ import { SchemeType } from "src/types"
 
 type SetScheme = (scheme: SchemeType) => void
 
+const isScheme = (value: unknown): value is SchemeType => value === "light" || value === "dark"
+
+const resolveInitialBrowserScheme = (
+  fallbackScheme: SchemeType,
+  followsSystemTheme: boolean
+): SchemeType => {
+  if (typeof window === "undefined") return fallbackScheme
+
+  const cachedScheme = getCookie("scheme")
+  if (isScheme(cachedScheme)) return cachedScheme
+
+  if (followsSystemTheme && window.matchMedia?.("(prefers-color-scheme: dark)")?.matches) {
+    return "dark"
+  }
+
+  return fallbackScheme
+}
+
 const useScheme = (): [SchemeType, SetScheme] => {
   const queryClient = useQueryClient()
   const followsSystemTheme = CONFIG.blog.scheme === "system"
   const fallbackScheme = (CONFIG.blog.scheme === "system" ? "light" : CONFIG.blog.scheme) as SchemeType
+  const initialScheme = resolveInitialBrowserScheme(fallbackScheme, followsSystemTheme)
 
   const { data } = useQuery<SchemeType>({
     queryKey: queryKey.scheme(),
-    queryFn: () => fallbackScheme,
+    queryFn: () => initialScheme,
     enabled: false,
     staleTime: Infinity,
-    // SSR/CSR 첫 렌더를 동일하게 맞춰 새로고침 시 하이드레이션 흔들림을 줄인다.
-    initialData: fallbackScheme,
+    initialData: initialScheme,
   })
 
   const setScheme = useCallback((scheme: SchemeType) => {

--- a/front/src/pages/_document.tsx
+++ b/front/src/pages/_document.tsx
@@ -23,14 +23,15 @@ const AQUILA_SCHEME_BOOTSTRAP_SCRIPT = `
     systemDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
   } catch (_) {}
   var nextScheme = cachedScheme || (systemDark ? "dark" : "light");
-  var background = nextScheme === "dark" ? "#111318" : "#f7f9fc";
+  var background = nextScheme === "dark" ? "#121212" : "#f3f5f8";
   var foreground = nextScheme === "dark" ? "#f4f6fb" : "#101214";
   document.documentElement.dataset.aquilaScheme = nextScheme;
+  document.documentElement.setAttribute("data-aquila-scheme-bootstrap", nextScheme);
   document.documentElement.style.colorScheme = nextScheme;
   document.documentElement.style.backgroundColor = background;
   var style = document.createElement("style");
-  style.setAttribute("data-aquila-scheme-bootstrap", nextScheme);
-  style.textContent = "html,body{background:" + background + ";color:" + foreground + ";color-scheme:" + nextScheme + ";}";
+  style.setAttribute("data-aquila-scheme-bootstrap-style", "true");
+  style.textContent = "html[data-aquila-scheme-bootstrap]{background:" + background + ";color-scheme:" + nextScheme + ";}html[data-aquila-scheme-bootstrap] body{background:" + background + ";color:" + foreground + ";color-scheme:" + nextScheme + ";}";
   document.head.appendChild(style);
 })();
 `

--- a/front/src/pages/_document.tsx
+++ b/front/src/pages/_document.tsx
@@ -13,6 +13,28 @@ import { pretendard } from "src/assets"
 import createEmotionCache from "src/libs/emotion/createEmotionCache"
 import { HEADER_AUTH_SHELL_BOOTSTRAP_SCRIPT } from "src/libs/headerAuthShell"
 
+const AQUILA_SCHEME_BOOTSTRAP_SCRIPT = `
+(function () {
+  if (typeof document === "undefined") return;
+  var cookieMatch = document.cookie.match(/(?:^|; )scheme=(light|dark)(?:;|$)/);
+  var cachedScheme = cookieMatch ? cookieMatch[1] : "";
+  var systemDark = false;
+  try {
+    systemDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+  } catch (_) {}
+  var nextScheme = cachedScheme || (systemDark ? "dark" : "light");
+  var background = nextScheme === "dark" ? "#111318" : "#f7f9fc";
+  var foreground = nextScheme === "dark" ? "#f4f6fb" : "#101214";
+  document.documentElement.dataset.aquilaScheme = nextScheme;
+  document.documentElement.style.colorScheme = nextScheme;
+  document.documentElement.style.backgroundColor = background;
+  var style = document.createElement("style");
+  style.setAttribute("data-aquila-scheme-bootstrap", nextScheme);
+  style.textContent = "html,body{background:" + background + ";color:" + foreground + ";color-scheme:" + nextScheme + ";}";
+  document.head.appendChild(style);
+})();
+`
+
 const CLIENT_RUNTIME_RECOVERY_SCRIPT = `
 (function () {
   if (typeof window === "undefined" || typeof document === "undefined") return;
@@ -132,6 +154,7 @@ class MyDocument extends Document {
     return (
       <Html lang={CONFIG.lang} data-header-auth-shell="anonymous" data-header-auth-admin="false">
         <Head>
+          <script dangerouslySetInnerHTML={{ __html: AQUILA_SCHEME_BOOTSTRAP_SCRIPT }} />
           <link rel="icon" href="/favicon.ico" />
           <link
             rel="apple-touch-icon"

--- a/front/src/pages/api/backend/[...path].ts
+++ b/front/src/pages/api/backend/[...path].ts
@@ -1,0 +1,112 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+import { normalizeApiRequestPath } from "src/libs/backend/requestPath"
+import { resolveServerApiBaseUrl } from "src/libs/server/backend"
+
+export const config = {
+  api: {
+    bodyParser: false,
+    externalResolver: true,
+  },
+}
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+])
+
+const BODYLESS_METHODS = new Set(["GET", "HEAD"])
+
+const getSetCookieHeaders = (headers: Headers): string[] => {
+  const withCookieList = headers as Headers & { getSetCookie?: () => string[] }
+  const cookieList = withCookieList.getSetCookie?.()
+  if (cookieList?.length) return cookieList
+
+  const cookie = headers.get("set-cookie")
+  return cookie ? [cookie] : []
+}
+
+const appendIncomingHeader = (headers: Headers, key: string, value: string | string[] | undefined) => {
+  if (value === undefined) return
+  if (HOP_BY_HOP_HEADERS.has(key.toLowerCase())) return
+
+  if (Array.isArray(value)) {
+    value.forEach((entry) => headers.append(key, entry))
+    return
+  }
+
+  headers.set(key, value)
+}
+
+const resolveProxyPath = (req: NextApiRequest): string => {
+  const segments = Array.isArray(req.query.path) ? req.query.path : [String(req.query.path || "")]
+  const pathname = `/${segments.filter(Boolean).join("/")}`
+  const queryIndex = req.url?.indexOf("?") ?? -1
+  const query = queryIndex >= 0 ? req.url?.slice(queryIndex) : ""
+  return normalizeApiRequestPath(`${pathname}${query || ""}`)
+}
+
+const pipeWebStreamToResponse = async (stream: ReadableStream<Uint8Array>, res: NextApiResponse) => {
+  const reader = stream.getReader()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (value) res.write(Buffer.from(value))
+    }
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  let safePath: string
+  try {
+    safePath = resolveProxyPath(req)
+  } catch {
+    res.status(400).json({ message: "Invalid backend proxy path." })
+    return
+  }
+
+  const method = (req.method || "GET").toUpperCase()
+  const headers = new Headers()
+  Object.entries(req.headers).forEach(([key, value]) => appendIncomingHeader(headers, key, value))
+  headers.set("X-Forwarded-Host", req.headers.host || "")
+  headers.set("X-Forwarded-Proto", "https")
+
+  try {
+    const upstreamResponse = await fetch(`${resolveServerApiBaseUrl(req)}${safePath}`, {
+      method,
+      headers,
+      body: BODYLESS_METHODS.has(method) ? undefined : (req as unknown as BodyInit),
+      duplex: "half",
+      redirect: "manual",
+    } as RequestInit & { duplex: "half" })
+
+    res.status(upstreamResponse.status)
+    upstreamResponse.headers.forEach((value, key) => {
+      if (HOP_BY_HOP_HEADERS.has(key.toLowerCase())) return
+      if (key.toLowerCase() === "set-cookie") return
+      res.setHeader(key, value)
+    })
+    const setCookieHeaders = getSetCookieHeaders(upstreamResponse.headers)
+    if (setCookieHeaders.length > 0) {
+      res.setHeader("Set-Cookie", setCookieHeaders)
+    }
+
+    if (!upstreamResponse.body) {
+      res.end()
+      return
+    }
+
+    await pipeWebStreamToResponse(upstreamResponse.body, res)
+    res.end()
+  } catch {
+    res.status(502).json({ message: "Backend proxy request failed." })
+  }
+}

--- a/front/src/pages/api/backend/[...path].ts
+++ b/front/src/pages/api/backend/[...path].ts
@@ -20,7 +20,14 @@ const HOP_BY_HOP_HEADERS = new Set([
   "upgrade",
 ])
 
+const DECODED_RESPONSE_HEADERS = new Set(["content-encoding", "content-length"])
 const BODYLESS_METHODS = new Set(["GET", "HEAD"])
+const BACKEND_PROXY_TIMEOUT_MS = 120_000
+
+const firstHeaderValue = (value: string | string[] | undefined): string => {
+  if (Array.isArray(value)) return value[0] || ""
+  return value || ""
+}
 
 const getSetCookieHeaders = (headers: Headers): string[] => {
   const withCookieList = headers as Headers & { getSetCookie?: () => string[] }
@@ -32,8 +39,11 @@ const getSetCookieHeaders = (headers: Headers): string[] => {
 }
 
 const appendIncomingHeader = (headers: Headers, key: string, value: string | string[] | undefined) => {
+  const normalizedKey = key.toLowerCase()
   if (value === undefined) return
-  if (HOP_BY_HOP_HEADERS.has(key.toLowerCase())) return
+  if (HOP_BY_HOP_HEADERS.has(normalizedKey)) return
+  if (normalizedKey === "host") return
+  if (normalizedKey === "accept-encoding") return
 
   if (Array.isArray(value)) {
     value.forEach((entry) => headers.append(key, entry))
@@ -77,7 +87,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const headers = new Headers()
   Object.entries(req.headers).forEach(([key, value]) => appendIncomingHeader(headers, key, value))
   headers.set("X-Forwarded-Host", req.headers.host || "")
-  headers.set("X-Forwarded-Proto", "https")
+  headers.set("X-Forwarded-Proto", firstHeaderValue(req.headers["x-forwarded-proto"]) || "https")
+  const clientIp = firstHeaderValue(req.headers["x-forwarded-for"]) || req.socket?.remoteAddress || ""
+  if (clientIp) headers.set("X-Forwarded-For", clientIp)
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), BACKEND_PROXY_TIMEOUT_MS)
 
   try {
     const upstreamResponse = await fetch(`${resolveServerApiBaseUrl(req)}${safePath}`, {
@@ -86,12 +101,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       body: BODYLESS_METHODS.has(method) ? undefined : (req as unknown as BodyInit),
       duplex: "half",
       redirect: "manual",
+      signal: controller.signal,
     } as RequestInit & { duplex: "half" })
 
     res.status(upstreamResponse.status)
     upstreamResponse.headers.forEach((value, key) => {
-      if (HOP_BY_HOP_HEADERS.has(key.toLowerCase())) return
-      if (key.toLowerCase() === "set-cookie") return
+      const normalizedKey = key.toLowerCase()
+      if (HOP_BY_HOP_HEADERS.has(normalizedKey)) return
+      if (DECODED_RESPONSE_HEADERS.has(normalizedKey)) return
+      if (normalizedKey === "set-cookie") return
       res.setHeader(key, value)
     })
     const setCookieHeaders = getSetCookieHeaders(upstreamResponse.headers)
@@ -108,5 +126,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     res.end()
   } catch {
     res.status(502).json({ message: "Backend proxy request failed." })
+  } finally {
+    clearTimeout(timeoutId)
   }
 }

--- a/front/src/routes/Admin/AdminSurfacePrimitives.tsx
+++ b/front/src/routes/Admin/AdminSurfacePrimitives.tsx
@@ -576,7 +576,7 @@ export const AdminActionCardButton = styled.button`
   padding: 0.82rem 0.88rem;
   border-radius: 2px;
   border: 1px solid ${({ theme }) => adminCardBorder(theme)};
-  background: transparent;
+  background: ${({ theme }) => adminRaisedSurface(theme)};
   color: ${({ theme }) => adminPrimaryText(theme)};
   cursor: pointer;
   transition:
@@ -588,6 +588,10 @@ export const AdminActionCardButton = styled.button`
     outline: none;
     border-color: ${({ theme }) => adminStrongBorder(theme)};
     box-shadow: ${({ theme }) => adminInteractiveFocusRing(theme)};
+  }
+
+  &:hover:not(:disabled) {
+    background: ${({ theme }) => adminAccentSurface(theme)};
   }
 
   &:disabled {

--- a/front/src/routes/Feed/TagList.tsx
+++ b/front/src/routes/Feed/TagList.tsx
@@ -207,6 +207,8 @@ const StyledWrapper = styled.div`
   --feed-tag-surface: ${({ theme }) => theme.publicDesign.surface};
   --feed-tag-surface-elevated: ${({ theme }) => theme.publicDesign.surfaceElevated};
   --feed-tag-accent: ${({ theme }) => theme.publicDesign.accent};
+  --feed-tag-accent-text: ${({ theme }) =>
+    theme.scheme === "light" ? theme.colors.blue11 : theme.colors.blue10};
   --feed-tag-accent-muted: ${({ theme }) => theme.publicDesign.accentMuted};
 
   .desktopPanel {
@@ -340,7 +342,7 @@ const StyledWrapper = styled.div`
   }
 
   .desktopList button[data-active="true"] .name {
-    color: var(--feed-tag-accent);
+    color: var(--feed-tag-accent-text);
     font-weight: 700;
     text-decoration: none;
   }
@@ -353,7 +355,7 @@ const StyledWrapper = styled.div`
   }
 
   .desktopList button[data-active="true"] .count {
-    color: var(--feed-tag-accent);
+    color: var(--feed-tag-accent-text);
   }
 
   .chipRail {
@@ -427,7 +429,7 @@ const StyledWrapper = styled.div`
     }
 
     &[data-active="true"] {
-      color: var(--feed-tag-accent);
+      color: var(--feed-tag-accent-text);
 
       &::after {
         border-color: var(--feed-tag-border-strong);
@@ -457,7 +459,7 @@ const StyledWrapper = styled.div`
   }
 
   .chipRail button[data-active="true"] .count {
-    color: var(--feed-tag-accent);
+    color: var(--feed-tag-accent-text);
   }
 
   .chipRail .chipToggle {


### PR DESCRIPTION
## 관련 이슈

close #736
close #737
close #738
close #739
close #740

## 작업 배경

- 관리자 런타임 회귀 5건을 한 번에 정리했습니다.
- 운영 브라우저 API 호출을 same-origin proxy로 접어 cloud 목록/업로드와 auth 재검증의 CORS·쿠키 경계를 줄이고, 새로고침 테마 first paint와 공통 액션 버튼 대비를 보강했습니다.

## 작업 내용

- production 브라우저의 로그인/관리자 API 요청을 `/api/backend/**` Next proxy로 전달하고, proxy는 쿠키·multipart body·Set-Cookie를 보존합니다.
- cloud content URL도 동일한 URL 생성기를 사용해 문서/사진/동영상 preview가 API origin drift에 묶이지 않도록 했습니다.
- document pre-paint scheme bootstrap과 `useScheme` 초기값을 맞춰 새로고침 시 white flash를 줄였습니다.
- 관리자 공통 action card button에 raised/accent surface 배경을 적용해 경계선만 두 줄로 보이는 상태를 제거했습니다.

## 검증

- 실행한 명령과 결과:
  - `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/admin-runtime-regressions.spec.ts e2e/admin-surface-primitives.spec.ts --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front playwright:preflight`
  - In-app Browser, `http://localhost:3100/admin/cloud`: loading 고착 없이 `파일 목록을 불러오지 못했습니다.` + 재시도 표시 확인
  - In-app Browser, `http://localhost:3100/admin/dashboard`: 로그인 화면으로 튕기지 않고 관리자 대시보드 유지 확인
  - In-app Browser, `http://localhost:3100/admin/tools`: action button computed background가 transparent가 아닌 실제 surface 색상임을 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: production 브라우저 API가 Next proxy를 경유하므로 proxy route의 server runtime env(`BACKEND_INTERNAL_URL`)가 비어 있으면 502로 실패합니다.
- 롤백 방법: 이 PR을 revert하면 브라우저 API 호출은 기존 `NEXT_PUBLIC_BACKEND_URL` 직접 호출 방식으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
