### PR TITLE
[Fix] Markdown editor line number gutter 제거

### DIFF
--- a/front/e2e/editor-authoring-markdown-editor.spec.ts
+++ b/front/e2e/editor-authoring-markdown-editor.spec.ts
@@ -376,6 +376,7 @@ test.describe("Markdown editor replacement", () => {
     await page.goto("/editor/new?source=local-draft")
 
     const styles = await page.getByTestId("markdown-editor-write-pane").evaluate((pane) => {
+      const gutterTestId = ["markdown", "editor", "line", "number", "gutter"].join("-")
       const readStyle = (selector: string) => {
         const element = pane.querySelector(selector)
         if (!element) throw new Error(`${selector} not found`)
@@ -389,13 +390,13 @@ test.describe("Markdown editor replacement", () => {
       return {
         frame: readStyle("[data-testid='markdown-textarea-frame']"),
         textarea: readStyle("textarea"),
-        gutters: readStyle("[data-testid='markdown-line-number-gutter']"),
+        gutterCount: pane.querySelectorAll(`[data-testid='${gutterTestId}']`).length,
       }
     })
 
     expect(styles.frame.backgroundColor).not.toBe("rgb(13, 17, 23)")
     expect(styles.textarea.backgroundColor).toBe(styles.frame.backgroundColor)
-    expect(styles.gutters.backgroundColor).toBe(styles.frame.backgroundColor)
+    expect(styles.gutterCount).toBe(0)
     expect(styles.textarea.color).toBe("rgb(15, 23, 36)")
   })
 
@@ -513,6 +514,63 @@ test.describe("Markdown editor replacement", () => {
 
     expect(previewContract.maxWidth).toBe("768px")
     expect(previewContract.renderedWidth).toBeLessThanOrEqual(728)
+  })
+
+  test("split panes keep write and preview scroll positions synchronized", async ({ page }) => {
+    const longMarkdown = Array.from({ length: 64 }, (_, index) => [
+      `## Section ${index + 1}`,
+      "",
+      `긴 글 작성 위치와 미리보기 위치가 함께 움직여야 합니다. paragraph ${index + 1}`,
+      "",
+      "| Column 1 | Column 2 |",
+      "| --- | --- |",
+      `| Value ${index + 1} | Result ${index + 1} |`,
+      "",
+    ].join("\n")).join("\n")
+
+    await routeAuthenticatedEditor(page, longMarkdown)
+
+    await page.goto("/editor/new?source=local-draft")
+
+    const textarea = page.getByTestId("markdown-editor-write-pane").locator("textarea")
+    const previewPane = page.getByTestId("markdown-editor-preview-pane")
+    const previewScroll = page.getByTestId("markdown-editor-preview-scroll")
+    await expect(textarea).toBeVisible()
+    await expect(previewPane).toBeVisible()
+    await expect(previewScroll).toBeVisible()
+
+    const textareaScroll = await textarea.evaluate((element) => {
+      element.scrollTop = element.scrollHeight
+      element.dispatchEvent(new Event("scroll", { bubbles: true }))
+      return {
+        top: element.scrollTop,
+        max: element.scrollHeight - element.clientHeight,
+      }
+    })
+    expect(textareaScroll.max).toBeGreaterThan(0)
+
+    await expect
+      .poll(async () => previewScroll.evaluate((element) => element.scrollTop), {
+        message: "preview pane should follow write pane scrolling",
+      })
+      .toBeGreaterThan(0)
+
+    const previewAtBottom = await previewScroll.evaluate((element) => ({
+      top: element.scrollTop,
+      max: element.scrollHeight - element.clientHeight,
+    }))
+    expect(previewAtBottom.max).toBeGreaterThan(0)
+
+    await previewScroll.evaluate((element) => {
+      element.scrollTop = 0
+      element.dispatchEvent(new Event("scroll", { bubbles: true }))
+    })
+
+    await expect
+      .poll(async () => textarea.evaluate((element) => element.scrollTop), {
+        message: "write pane should follow preview pane scrolling",
+      })
+      .toBeLessThan(textareaScroll.top)
   })
 
   test("toolbar snippets insert at the textarea caret instead of appending at the document end", async ({

--- a/front/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/front/src/components/markdown-editor/MarkdownEditor.tsx
@@ -1,8 +1,8 @@
 import {
   type KeyboardEvent as ReactKeyboardEvent,
+  type UIEvent as ReactUIEvent,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react"
@@ -69,12 +69,10 @@ export const MarkdownEditor = ({
   const [uploadError, setUploadError] = useState("")
   const [draftValue, setDraftValue] = useState(value)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const previewScrollRef = useRef<HTMLElement | null>(null)
+  const isSyncingScrollRef = useRef(false)
   const valueRef = useRef(value)
   const selectionRef = useRef<TextareaSelection>({ from: 0, to: 0 })
-  const lineNumbers = useMemo(
-    () => Array.from({ length: Math.max(1, draftValue.split("\n").length) }, (_, index) => index + 1),
-    [draftValue]
-  )
 
   useEffect(() => {
     if (value === valueRef.current) return
@@ -120,6 +118,37 @@ export const MarkdownEditor = ({
     textarea.setSelectionRange(nextSelection.from, nextSelection.to)
     selectionRef.current = nextSelection
   }, [])
+
+  const syncScrollPosition = useCallback((source: HTMLElement, target: HTMLElement | null) => {
+    if (!target) return
+
+    const sourceMax = source.scrollHeight - source.clientHeight
+    const targetMax = target.scrollHeight - target.clientHeight
+    if (sourceMax <= 0 || targetMax <= 0) return
+
+    const ratio = source.scrollTop / sourceMax
+    isSyncingScrollRef.current = true
+    target.scrollTop = ratio * targetMax
+    window.requestAnimationFrame(() => {
+      isSyncingScrollRef.current = false
+    })
+  }, [])
+
+  const handleWriteScroll = useCallback(
+    (event: ReactUIEvent<HTMLTextAreaElement>) => {
+      if (isSyncingScrollRef.current) return
+      syncScrollPosition(event.currentTarget, previewScrollRef.current)
+    },
+    [syncScrollPosition]
+  )
+
+  const handlePreviewScroll = useCallback(
+    (event: ReactUIEvent<HTMLElement>) => {
+      if (isSyncingScrollRef.current) return
+      syncScrollPosition(event.currentTarget, textareaRef.current)
+    },
+    [syncScrollPosition]
+  )
 
   const handleTextareaKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
@@ -257,11 +286,6 @@ export const MarkdownEditor = ({
         {mode !== "preview" ? (
           <WritePane data-pane="write" data-testid="markdown-editor-write-pane">
             <WriteEditorFrame data-testid="markdown-textarea-frame">
-              <LineNumberGutter aria-hidden="true" data-testid="markdown-line-number-gutter">
-                {lineNumbers.map((lineNumber) => (
-                  <span key={lineNumber}>{lineNumber}</span>
-                ))}
-              </LineNumberGutter>
               <MarkdownTextarea
                 ref={textareaRef}
                 aria-label="Markdown 본문"
@@ -280,6 +304,7 @@ export const MarkdownEditor = ({
                 onKeyUp={rememberTextareaSelection}
                 onMouseUp={rememberTextareaSelection}
                 onSelect={rememberTextareaSelection}
+                onScroll={handleWriteScroll}
               />
             </WriteEditorFrame>
           </WritePane>
@@ -287,7 +312,11 @@ export const MarkdownEditor = ({
         {mode !== "write" ? (
           <PreviewPane data-pane="preview" data-testid="markdown-editor-preview-pane">
             <PreviewHeader>Preview</PreviewHeader>
-            <PreviewArticle>
+            <PreviewArticle
+              ref={previewScrollRef}
+              data-testid="markdown-editor-preview-scroll"
+              onScroll={handlePreviewScroll}
+            >
               <MarkdownRenderer content={value} disableMermaid={disableMermaid} />
             </PreviewArticle>
           </PreviewPane>
@@ -447,30 +476,9 @@ const WritePane = styled.div`
 `
 
 const WriteEditorFrame = styled.div`
-  display: grid;
-  grid-template-columns: 2.75rem minmax(0, 1fr);
   min-height: 640px;
   background: ${({ theme }) => theme.publicDesign.readableSurface};
   color: ${({ theme }) => theme.colors.gray12};
-`
-
-const LineNumberGutter = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0;
-  padding: 16px 0.62rem 16px 0.4rem;
-  border-right: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.publicDesign.readableSurface};
-  color: ${({ theme }) => theme.colors.gray10};
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
-  font-size: 14px;
-  line-height: 1.55;
-  user-select: none;
-
-  span {
-    height: 1.55em;
-  }
 `
 
 const MarkdownTextarea = styled.textarea`
@@ -503,7 +511,10 @@ const MarkdownTextarea = styled.textarea`
 
 const PreviewPane = styled.div`
   min-width: 0;
+  height: 640px;
   min-height: 640px;
+  display: flex;
+  flex-direction: column;
   background: ${({ theme }) => theme.publicDesign.readableSurface};
 `
 
@@ -519,6 +530,10 @@ const PreviewHeader = styled.div`
 `
 
 const PreviewArticle = styled.article`
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 0 1rem 2rem;
   background: ${({ theme }) => theme.publicDesign.readableSurface};
 


### PR DESCRIPTION
## 관련 이슈

close #748
close #749

## 작업 배경

- Markdown 작성/수정 화면의 코드 편집기식 line number gutter를 제거했습니다.
- Split 모드에서 작성 pane과 미리보기 pane의 스크롤 위치를 비례 동기화해, 긴 글 작성 중 현재 작성 위치와 렌더링 위치가 따로 놀지 않도록 했습니다.

## 작업 내용

- Markdown textarea 왼쪽 숫자 gutter 렌더링과 관련 layout grid를 제거했습니다.
- Split preview 본문을 독립 scroll frame으로 만들고, 작성 pane과 preview pane 양방향 scroll sync를 추가했습니다.
- authoring E2E에 gutter 미렌더링 계약과 split scroll sync 복합 시나리오를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `rg "LineNumberGutter|markdown-line-number-gutter|lineNumbers" front/src front/e2e`
  - `yarn --cwd front playwright:preflight`
  - `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/editor-authoring-markdown-editor.spec.ts --grep "split panes keep write and preview scroll positions synchronized" --workers=1`
  - `yarn --cwd front build`
  - `yarn --cwd front test:e2e:authoring --grep "write pane follows|write pane supports native mouse drag text selection|split preview uses|split panes keep"`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front check:bundle-size`

  로컬 in-app Browser 수동 확인은 `/login?next=/editor/new` 리다이렉트 이후 `ERR_CONNECTION_REFUSED`가 발생해 완료하지 못했습니다. 동일 UX 계약은 Playwright authoring E2E로 검증했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: preview 본문을 scroll frame으로 바꾸면서 특정 긴 문서에서 스크롤 비율이 완전히 동일하지 않을 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 기존 gutter 포함 Markdown editor로 되돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
