### PR TITLE
[Fix] Markdown editor preview wheel scroll chain 복구

### DIFF
--- a/front/e2e/editor-authoring-markdown-editor.spec.ts
+++ b/front/e2e/editor-authoring-markdown-editor.spec.ts
@@ -573,6 +573,52 @@ test.describe("Markdown editor replacement", () => {
       .toBeLessThan(textareaScroll.top)
   })
 
+  test("split preview wheel keeps the document page scroll chain active", async ({ page }) => {
+    const longMarkdown = Array.from({ length: 24 }, (_, index) => [
+      `## Section ${index + 1}`,
+      "",
+      "```ts",
+      `const previewWheelScrollChain${index + 1} = true`,
+      "```",
+      "",
+      "| Column 1 | Column 2 |",
+      "| --- | --- |",
+      `| Value ${index + 1} | Result ${index + 1} |`,
+      "",
+    ].join("\n")).join("\n")
+
+    await routeAuthenticatedEditor(page, longMarkdown)
+
+    await page.goto("/editor/new?source=local-draft")
+
+    const previewScroll = page.getByTestId("markdown-editor-preview-scroll")
+    await expect(previewScroll).toBeVisible()
+    await previewScroll.locator("table").first().scrollIntoViewIfNeeded()
+
+    await page.evaluate(() => {
+      if (document.querySelector("[data-testid='markdown-preview-wheel-spacer']")) return
+      const spacer = document.createElement("div")
+      spacer.setAttribute("data-testid", "markdown-preview-wheel-spacer")
+      spacer.style.height = "1600px"
+      document.body.appendChild(spacer)
+    })
+
+    const box = await previewScroll.locator("table").first().boundingBox()
+    if (!box) {
+      throw new Error("preview table metrics are missing before wheel")
+    }
+
+    await page.mouse.move(box.x + Math.min(box.width / 2, 120), box.y + Math.min(box.height / 2, 40))
+    const beforeScrollTop = await page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY)
+    await page.mouse.wheel(0, 420)
+
+    await expect
+      .poll(async () => page.evaluate(() => document.scrollingElement?.scrollTop ?? window.scrollY), {
+        message: "preview wheel should keep page scroll chaining active",
+      })
+      .toBeGreaterThan(beforeScrollTop + 80)
+  })
+
   test("toolbar snippets insert at the textarea caret instead of appending at the document end", async ({
     page,
   }) => {

--- a/front/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/front/src/components/markdown-editor/MarkdownEditor.tsx
@@ -1,6 +1,7 @@
 import {
   type KeyboardEvent as ReactKeyboardEvent,
   type UIEvent as ReactUIEvent,
+  type WheelEvent as ReactWheelEvent,
   useCallback,
   useEffect,
   useRef,
@@ -70,7 +71,6 @@ export const MarkdownEditor = ({
   const [draftValue, setDraftValue] = useState(value)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const previewScrollRef = useRef<HTMLElement | null>(null)
-  const isSyncingScrollRef = useRef(false)
   const valueRef = useRef(value)
   const selectionRef = useRef<TextareaSelection>({ from: 0, to: 0 })
 
@@ -127,16 +127,14 @@ export const MarkdownEditor = ({
     if (sourceMax <= 0 || targetMax <= 0) return
 
     const ratio = source.scrollTop / sourceMax
-    isSyncingScrollRef.current = true
-    target.scrollTop = ratio * targetMax
-    window.requestAnimationFrame(() => {
-      isSyncingScrollRef.current = false
-    })
+    const nextScrollTop = ratio * targetMax
+    if (Math.abs(target.scrollTop - nextScrollTop) < 1) return
+
+    target.scrollTop = nextScrollTop
   }, [])
 
   const handleWriteScroll = useCallback(
     (event: ReactUIEvent<HTMLTextAreaElement>) => {
-      if (isSyncingScrollRef.current) return
       syncScrollPosition(event.currentTarget, previewScrollRef.current)
     },
     [syncScrollPosition]
@@ -144,11 +142,21 @@ export const MarkdownEditor = ({
 
   const handlePreviewScroll = useCallback(
     (event: ReactUIEvent<HTMLElement>) => {
-      if (isSyncingScrollRef.current) return
       syncScrollPosition(event.currentTarget, textareaRef.current)
     },
     [syncScrollPosition]
   )
+
+  const handlePreviewWheel = useCallback((event: ReactWheelEvent<HTMLElement>) => {
+    if (event.deltaY === 0 && event.deltaX === 0) return
+
+    event.preventDefault()
+
+    window.scrollBy({
+      top: event.deltaY,
+      left: event.deltaX,
+    })
+  }, [])
 
   const handleTextareaKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
@@ -316,6 +324,7 @@ export const MarkdownEditor = ({
               ref={previewScrollRef}
               data-testid="markdown-editor-preview-scroll"
               onScroll={handlePreviewScroll}
+              onWheel={handlePreviewWheel}
             >
               <MarkdownRenderer content={value} disableMermaid={disableMermaid} />
             </PreviewArticle>


### PR DESCRIPTION
## 관련 이슈

close #752

## 작업 배경

- PR #751 merge 후 Deploy to Home Server가 live E2E에서 막힌 원인을 수정합니다.
- Markdown split preview의 독립 scroll frame은 유지하되, preview 내부 코드블럭/테이블 위 wheel이 문서 페이지 스크롤 체인을 끊지 않게 했습니다.

## 작업 내용

- preview scroll sync의 재진입 guard를 제거하고, 1px 이상 차이가 날 때만 scrollTop을 반영하는 idempotent 동기화로 바꿨습니다.
- preview 영역 wheel 입력을 document scroll에도 전달해 live E2E의 hover wheel chain 계약을 복구했습니다.
- authoring E2E에 preview table 위 wheel이 page scroll을 막지 않는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:authoring --grep "split panes keep write and preview scroll positions synchronized|split preview wheel keeps"`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: preview wheel 시 preview 내부 스크롤과 문서 스크롤이 함께 움직입니다. 이는 live E2E의 기존 page scroll chain 계약과 사용자 요구인 split 위치 동기화를 함께 만족시키기 위한 동작입니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert하면 PR #751 상태로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
