### PR TITLE
[Fix] Markdown editor focus blue outline 제거

### DIFF
--- a/front/e2e/editor-authoring-markdown-editor.spec.ts
+++ b/front/e2e/editor-authoring-markdown-editor.spec.ts
@@ -400,6 +400,39 @@ test.describe("Markdown editor replacement", () => {
     expect(styles.textarea.color).toBe("rgb(15, 23, 36)")
   })
 
+  test("write pane focus does not render the global blue textarea outline", async ({ page }) => {
+    await routeAuthenticatedEditor(
+      page,
+      [
+        "### Stateful",
+        "",
+        "Markdown textarea focus should keep the writing surface visually stable.",
+      ].join("\n")
+    )
+
+    await page.goto("/editor/new?source=local-draft")
+
+    const textarea = page.getByTestId("markdown-editor-write-pane").locator("textarea")
+    await expect(textarea).toBeVisible()
+    await textarea.click()
+    await textarea.pressSequentially("\n\n추가 입력")
+
+    const focusContract = await textarea.evaluate((element) => {
+      const style = window.getComputedStyle(element)
+      return {
+        active: document.activeElement === element,
+        outlineColor: style.outlineColor,
+        outlineStyle: style.outlineStyle,
+        outlineWidth: style.outlineWidth,
+      }
+    })
+
+    expect(focusContract.active).toBe(true)
+    expect(focusContract.outlineStyle).toBe("none")
+    expect(focusContract.outlineWidth).toBe("0px")
+    expect(focusContract.outlineColor).not.toBe("rgb(63, 81, 181)")
+  })
+
   test("write pane supports native mouse drag text selection", async ({ page }) => {
     await routeAuthenticatedEditor(
       page,

--- a/front/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/front/src/components/markdown-editor/MarkdownEditor.tsx
@@ -512,6 +512,12 @@ const MarkdownTextarea = styled.textarea`
     background: ${({ theme }) => (theme.scheme === "dark" ? "rgba(56, 139, 253, 0.45)" : "rgba(9, 105, 218, 0.24)")};
   }
 
+  &:focus,
+  &:focus-visible {
+    outline: 0;
+    box-shadow: none;
+  }
+
   &:disabled {
     cursor: not-allowed;
     opacity: 0.7;


### PR DESCRIPTION
## 관련 이슈

close #756

## 작업 배경

- Markdown 작성 textarea에 전역 `textarea:focus-visible` outline이 새어 들어가던 문제를 제거합니다.
- focus 중에도 작성 영역 상단/하단에 파란 선이 생기지 않도록 회귀 E2E를 추가했습니다.

## 작업 내용

- Markdown textarea focus/focus-visible 상태에서 global blue outline과 box-shadow를 명시적으로 차단했습니다.
- authoring E2E에 focused textarea의 outline contract를 검증하는 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:authoring --grep "write pane focus"`: 구현 전 실패, 수정 후 통과
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - 로컬 production `http://127.0.0.1:3100/editor/new`에서 focused textarea `outlineStyle=none`, `outlineWidth=0px`, `boxShadow=none` 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: Markdown textarea의 visual focus ring은 제거되지만 caret과 기존 editor shell 경계는 유지됩니다.
- 롤백 방법: 이 PR의 커밋을 revert하면 전역 focus outline 적용 상태로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
