### PR TITLE
[Fix] 관리자 클라우드 표면 정리

### DIFF
--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -282,6 +282,7 @@ test.describe("관리자 클라우드", () => {
 
     const uploadPanel = page.getByLabel("업로드 중인 파일")
     await expect(uploadPanel).toHaveCSS("position", "fixed")
+    await expect(uploadPanel).toHaveCSS("z-index", "160")
     await expect(uploadPanel.getByRole("heading", { name: /항목 .* 업로드/ })).toBeVisible()
     await expect(uploadPanel.getByText("신규 운영 문서.pdf")).toBeVisible()
     await expect(uploadPanel.getByText("배포 캡처.png")).toBeVisible()
@@ -393,6 +394,7 @@ test.describe("관리자 클라우드", () => {
 
     const uploadPanel = page.getByLabel("업로드 중인 파일")
     await expect(uploadPanel.getByText("실패할 운영 문서.pdf")).toBeVisible()
+    await expect(uploadPanel.getByRole("heading", { name: "항목 1개 업로드 실패/취소" })).toBeVisible()
     await expect(uploadPanel.getByText(/서버 오류가 발생했습니다/)).toBeVisible()
     await expect(uploadPanel.getByRole("button", { name: "실패할 운영 문서.pdf 업로드 다시 시도" })).toBeVisible()
   })

--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -282,7 +282,7 @@ test.describe("관리자 클라우드", () => {
 
     const uploadPanel = page.getByLabel("업로드 중인 파일")
     await expect(uploadPanel).toHaveCSS("position", "fixed")
-    await expect(uploadPanel).toHaveCSS("z-index", "35")
+    await expect(uploadPanel).toHaveCSS("z-index", "29")
     await expect(uploadPanel.getByRole("heading", { name: /항목 .* 업로드/ })).toBeVisible()
     await expect(uploadPanel.getByText("신규 운영 문서.pdf")).toBeVisible()
     await expect(uploadPanel.getByText("배포 캡처.png")).toBeVisible()

--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -282,7 +282,7 @@ test.describe("관리자 클라우드", () => {
 
     const uploadPanel = page.getByLabel("업로드 중인 파일")
     await expect(uploadPanel).toHaveCSS("position", "fixed")
-    await expect(uploadPanel).toHaveCSS("z-index", "160")
+    await expect(uploadPanel).toHaveCSS("z-index", "35")
     await expect(uploadPanel.getByRole("heading", { name: /항목 .* 업로드/ })).toBeVisible()
     await expect(uploadPanel.getByText("신규 운영 문서.pdf")).toBeVisible()
     await expect(uploadPanel.getByText("배포 캡처.png")).toBeVisible()

--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -281,7 +281,8 @@ test.describe("관리자 클라우드", () => {
     ])
 
     const uploadPanel = page.getByLabel("업로드 중인 파일")
-    await expect(uploadPanel.getByRole("heading", { name: "업로드 관리" })).toBeVisible()
+    await expect(uploadPanel).toHaveCSS("position", "fixed")
+    await expect(uploadPanel.getByRole("heading", { name: /항목 .* 업로드/ })).toBeVisible()
     await expect(uploadPanel.getByText("신규 운영 문서.pdf")).toBeVisible()
     await expect(uploadPanel.getByText("배포 캡처.png")).toBeVisible()
     await expect.poll(() => mocks.uploadedNames).toEqual(
@@ -300,7 +301,7 @@ test.describe("관리자 클라우드", () => {
     await uploadPanel.getByRole("button", { name: "취소할 영상.mp4 업로드 취소" }).click()
     await expect(uploadPanel.getByText("취소됨")).toBeVisible()
     await expect(page.getByRole("row", { name: /취소할 영상\.mp4/ })).toHaveCount(0)
-    await uploadPanel.getByRole("button", { name: "종료된 항목 지우기" }).click()
+    await uploadPanel.getByRole("button", { name: "종료된 업로드 항목 지우기" }).click()
     await expect(page.getByLabel("업로드 중인 파일")).toHaveCount(0)
 
     await page.getByRole("button", { name: "운영 점검 리포트.pdf 미리보기" }).click()
@@ -356,7 +357,8 @@ test.describe("관리자 클라우드", () => {
     })
 
     const uploadPanel = page.getByLabel("업로드 중인 파일")
-    await expect(uploadPanel.getByRole("heading", { name: "업로드 관리" })).toBeVisible()
+    await expect(uploadPanel).toHaveCSS("position", "fixed")
+    await expect(uploadPanel.getByRole("heading", { name: /항목 .* 업로드/ })).toBeVisible()
     await expect(uploadPanel.getByText("취소할 영상.mp4")).toBeVisible()
     await expect(page.getByText("표시할 파일이 없습니다.")).toHaveCount(0)
     await expect(page.getByText("업로드 중인 파일이 있습니다.")).toBeVisible()

--- a/front/e2e/admin-hub-state.spec.ts
+++ b/front/e2e/admin-hub-state.spec.ts
@@ -32,7 +32,7 @@ test.describe("admin hub state contract", () => {
     expect(source).toContain("supportRailGroups={supportRailGroups}")
   })
 
-  test("관리자 허브는 범용 관리 문구 대신 경계선형 작업 구조를 사용한다", () => {
+  test("관리자 허브는 범용 관리 문구 대신 저선형 작업 구조를 사용한다", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminHubSurface.tsx"), "utf8")
     const sectionSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminHubSurface.sections.tsx"), "utf8")
     const styleSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminHubSurface.styles.ts"), "utf8")
@@ -47,8 +47,9 @@ test.describe("admin hub state contract", () => {
     expect(styleSource).toContain("export const BorderlessSection = styled.section`")
     expect(styleSource).toContain("export const BorderlessPanelLink = styled.a`")
     expect(styleSource).toContain("export const BorderlessSupportSection = styled.section`")
-    expect(styleSource).toContain("border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};")
-    expect(styleSource).toContain("border-radius: 0;")
+    expect(styleSource).not.toContain("border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};")
+    expect(styleSource).toContain("border-radius: 8px;")
+    expect(styleSource).toContain("background: ${({ theme }) => adminRaisedSurface(theme)};")
     expect(styleSource).not.toContain("transform: translateY")
     expect(source).toContain("priorityActions: AdminHubNextAction[]")
     expect(source).toContain("handoffActions: AdminHubNextAction[]")

--- a/front/e2e/admin-surface-primitives.spec.ts
+++ b/front/e2e/admin-surface-primitives.spec.ts
@@ -60,6 +60,8 @@ test.describe("관리자 표면 공통 계약", () => {
     expect(shellSource).not.toContain("width: 100vw;")
     expect(shellSource).toContain("background: ${adminAppBackground};")
     expect(shellSource).not.toContain("border-radius: 14px;")
+    expect(shellSource).toContain("border-radius: 999px;")
+    expect(shellSource).toContain("border-radius: inherit;")
 
     expect(utilitySource).toContain("border-bottom: 1px solid ${adminBorder};")
     expect(utilitySource).not.toContain("backdrop-filter")
@@ -72,6 +74,10 @@ test.describe("관리자 표면 공통 계약", () => {
 
     expect(primitiveSource).toContain("adminPlainSurface(theme)")
     expect(primitiveSource).not.toContain("linear-gradient")
+    expect(primitiveSource).toContain("background: ${({ theme }) => adminMutedSurface(theme)};")
+    expect(primitiveSource).not.toContain("box-shadow: 0 0 0 1px ${({ theme }) => adminCardBorder(theme)} inset;")
+    expect(primitiveSource).toContain("& + & {")
+    expect(primitiveSource).toContain("margin-top: 0.4rem;")
     expect(hubStyleSource).not.toContain("transform: translateY")
   })
 
@@ -106,6 +112,9 @@ test.describe("관리자 표면 공통 계약", () => {
     expect(source).toContain("export const AdminTextActionButton = styled.button`")
     expect(source).toContain("export const AdminTextActionLink = styled.a`")
     expect(source).toContain("export const AdminActionCardButton = styled.button`")
+    expect(source).toContain("export const AdminInlineActionRow = styled.div`")
+    expect(source).toContain("background: ${({ theme }) => adminMutedSurface(theme)};")
+    expect(source).toContain("border-bottom: 0;")
     const actionButtonBlock = source.match(/export const AdminActionCardButton = styled\.button`[\s\S]*?`\n/)?.[0] ?? ""
     expect(actionButtonBlock).toContain("background: ${({ theme }) => adminRaisedSurface(theme)};")
     expect(actionButtonBlock).toContain("background: ${({ theme }) => adminAccentSurface(theme)};")

--- a/front/e2e/perf-layout.spec.ts
+++ b/front/e2e/perf-layout.spec.ts
@@ -454,7 +454,7 @@ test.describe("성능 레이아웃과 표면 예산", () => {
     const fingerprint = await getThemeSurfaceFingerprint(page)
 
     expect(fingerprint.route).toBe(scenario.route)
-    expect(fingerprint.themeToggleLabel).toBeNull()
+    expect(fingerprint.themeToggleLabel).toBe("다크 모드로 전환")
     expect(fingerprint.bodyBg).toBe("rgb(243, 245, 248)")
     expect(fingerprint.headerBg).not.toBeNull()
     expect(fingerprint.headerBg).not.toBe(fingerprint.bodyBg)

--- a/front/e2e/smoke-public-shell.spec.ts
+++ b/front/e2e/smoke-public-shell.spec.ts
@@ -54,6 +54,8 @@ test.describe("core smoke public shell", () => {
   expect(appSource).toContain("initialAdminProfileShouldRefetch")
   expect(rootLayoutSource).toContain('pathname[1] !== "_"')
   expect(rootLayoutSource).toContain('const effectiveBlogDesign = "legacy"')
+  expect(rootLayoutSource).toContain('showThemeToggle={effectiveBlogDesign === "legacy"}')
+  expect(rootLayoutSource).not.toContain('showThemeToggle={effectiveBlogDesign === "legacy" && !isPublicBlogRoute}')
   expect(rootLayoutSource).toContain("refetchOnMount: isDesignAwareRoute")
   expect(rootLayoutSource).toContain("staleTimeMs: isDesignAwareRoute ? 0 : undefined")
   expect(rootLayoutSource).toContain('pathname[1] !== "_"')

--- a/front/src/layouts/RootLayout/index.tsx
+++ b/front/src/layouts/RootLayout/index.tsx
@@ -188,7 +188,7 @@ const RootLayout = ({
       <Scripts />
       {/* // TODO: replace react query */}
       {/* {metaConfig.type !== "Paper" && <Header />} */}
-      <Header fullWidth={false} showThemeToggle={effectiveBlogDesign === "legacy" && !isPublicBlogRoute} blogTitle={headerBlogTitle} />
+      <Header fullWidth={false} showThemeToggle={effectiveBlogDesign === "legacy"} blogTitle={headerBlogTitle} />
       <RouteProgress data-busy={isNavigating} aria-hidden="true" />
       <StyledMain $fullBleed={isFullBleedRoute}>{children}</StyledMain>
     </ThemeProvider>

--- a/front/src/routes/Admin/AdminCloudUploadQueue.tsx
+++ b/front/src/routes/Admin/AdminCloudUploadQueue.tsx
@@ -34,13 +34,15 @@ const AdminCloudUploadQueue = ({
 }: AdminCloudUploadQueueProps) => {
   if (uploadQueue.length === 0) return null
 
-  const finishedCount = uploadQueue.length - activeUploadCount
+  const failedOrCancelledCount = uploadQueue.filter(
+    (item) => item.status === "failed" || item.status === "cancelled"
+  ).length
   const title =
     activeUploadCount > 0
       ? `항목 ${activeUploadCount}개 업로드 중`
       : completedUploadCount === uploadQueue.length
         ? `항목 ${completedUploadCount}개 업로드 완료`
-        : `항목 ${finishedCount}개 업로드 종료`
+        : `항목 ${failedOrCancelledCount}개 업로드 실패/취소`
 
   // The queue is fixed like Drive's transfer panel, while the upload state machine stays in this page.
   return (

--- a/front/src/routes/Admin/AdminCloudUploadQueue.tsx
+++ b/front/src/routes/Admin/AdminCloudUploadQueue.tsx
@@ -34,22 +34,31 @@ const AdminCloudUploadQueue = ({
 }: AdminCloudUploadQueueProps) => {
   if (uploadQueue.length === 0) return null
 
-  // Keep upload state in the file workspace flow so it reads as file management, not a toast.
+  const finishedCount = uploadQueue.length - activeUploadCount
+  const title =
+    activeUploadCount > 0
+      ? `항목 ${activeUploadCount}개 업로드 중`
+      : completedUploadCount === uploadQueue.length
+        ? `항목 ${completedUploadCount}개 업로드 완료`
+        : `항목 ${finishedCount}개 업로드 종료`
+
+  // The queue is fixed like Drive's transfer panel, while the upload state machine stays in this page.
   return (
     <QueuePanel aria-label="업로드 중인 파일">
       <QueueHeader>
         <div>
-          <h2>업로드 관리</h2>
+          <h2>{title}</h2>
           <p>
             진행 중 {activeUploadCount}개 · 완료 {completedUploadCount}개
           </p>
         </div>
         <GhostButton
           type="button"
+          aria-label="종료된 업로드 항목 지우기"
           disabled={uploadQueue.every((item) => isUploadActive(item.status))}
           onClick={onClearFinishedUploads}
         >
-          종료된 항목 지우기
+          ×
         </GhostButton>
       </QueueHeader>
       <QueueList>

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -663,16 +663,26 @@ export const InlineList = styled.div`
 `
 
 export const QueuePanel = styled.section`
+  position: fixed;
+  right: max(1rem, env(safe-area-inset-right));
+  bottom: max(1rem, env(safe-area-inset-bottom));
+  z-index: 40;
   display: grid;
   gap: 0.55rem;
-  padding: 0.72rem 1.25rem 0.86rem;
-  border-bottom: 1px solid ${border};
-  border-radius: 0;
-  background: ${surface};
-  box-shadow: none;
+  width: min(25rem, calc(100vw - 2rem));
+  max-height: min(24rem, calc(100vh - var(--app-header-height, 73px) - 2rem));
+  padding: 0.78rem;
+  border: 1px solid ${borderStrong};
+  border-radius: 8px;
+  background: ${surfaceRaised};
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.2);
 
   @media (max-width: 760px) {
-    padding: 0.7rem 0.9rem 0.82rem;
+    right: 0.72rem;
+    bottom: 0.72rem;
+    width: calc(100vw - 1.44rem);
+    max-height: min(22rem, calc(100vh - var(--app-header-height, 73px) - 1.44rem));
+    padding: 0.68rem;
   }
 `
 
@@ -699,13 +709,12 @@ export const QueueHeader = styled.div`
 
 export const QueueList = styled.ul`
   display: grid;
-  gap: 0;
+  gap: 0.25rem;
   max-height: 15rem;
   overflow: auto;
   margin: 0;
   padding: 0;
   list-style: none;
-  border-top: 1px solid ${border};
 `
 
 export const QueueItem = styled.li`
@@ -714,11 +723,10 @@ export const QueueItem = styled.li`
   gap: 0.5rem 0.75rem;
   align-items: center;
   min-width: 0;
-  padding: 0.58rem 0;
+  padding: 0.54rem 0.58rem;
   border: 0;
-  border-bottom: 1px solid ${border};
-  border-radius: 2px;
-  background: transparent;
+  border-radius: 6px;
+  background: ${surface};
 
   strong {
     color: ${textPrimary};

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -666,7 +666,7 @@ export const QueuePanel = styled.section`
   position: fixed;
   right: max(1rem, env(safe-area-inset-right));
   bottom: max(1rem, env(safe-area-inset-bottom));
-  z-index: 40;
+  z-index: 160;
   display: grid;
   gap: 0.55rem;
   width: min(25rem, calc(100vw - 2rem));

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -667,7 +667,7 @@ export const QueuePanel = styled.section`
   position: fixed;
   right: max(1rem, env(safe-area-inset-right));
   bottom: max(1rem, env(safe-area-inset-bottom));
-  z-index: ${zIndexes.dropdownMenu - 1};
+  z-index: ${zIndexes.header - 1};
   display: grid;
   gap: 0.55rem;
   width: min(25rem, calc(100vw - 2rem));

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -14,6 +14,7 @@ import {
   adminTextPrimary as textPrimary,
   adminTextSecondary as textSecondary,
 } from "src/routes/Admin/adminColorTokens"
+import { zIndexes } from "src/styles/zIndexes"
 
 export const CloudMain = styled.main`
   display: grid;
@@ -666,7 +667,7 @@ export const QueuePanel = styled.section`
   position: fixed;
   right: max(1rem, env(safe-area-inset-right));
   bottom: max(1rem, env(safe-area-inset-bottom));
-  z-index: 160;
+  z-index: ${zIndexes.dropdownMenu - 1};
   display: grid;
   gap: 0.55rem;
   width: min(25rem, calc(100vw - 2rem));

--- a/front/src/routes/Admin/AdminHubSurface.styles.ts
+++ b/front/src/routes/Admin/AdminHubSurface.styles.ts
@@ -195,10 +195,22 @@ export const BorderlessPanel = styled.div`
 
   &[data-tone="good"] {
     background: ${({ theme }) => theme.colors.statusSuccessSurface};
+    color: ${({ theme }) => theme.colors.statusSuccessText};
+
+    span,
+    strong {
+      color: ${({ theme }) => theme.colors.statusSuccessText};
+    }
   }
 
   &[data-tone="warn"] {
     background: ${({ theme }) => theme.colors.orange2};
+    color: ${({ theme }) => theme.colors.orange10};
+
+    span,
+    strong {
+      color: ${({ theme }) => theme.colors.orange10};
+    }
   }
 
   span {
@@ -241,10 +253,24 @@ export const BorderlessPanelLink = styled.a`
 
   &[data-tone="good"] {
     background: ${({ theme }) => theme.colors.statusSuccessSurface};
+    color: ${({ theme }) => theme.colors.statusSuccessText};
+
+    small,
+    span,
+    strong {
+      color: ${({ theme }) => theme.colors.statusSuccessText};
+    }
   }
 
   &[data-tone="warn"] {
     background: ${({ theme }) => theme.colors.orange2};
+    color: ${({ theme }) => theme.colors.orange10};
+
+    small,
+    span,
+    strong {
+      color: ${({ theme }) => theme.colors.orange10};
+    }
   }
 
   &:hover {
@@ -326,10 +352,22 @@ export const BorderlessMetricRow = styled.div`
 
   &[data-tone="good"] {
     background: ${({ theme }) => theme.colors.statusSuccessSurface};
+    color: ${({ theme }) => theme.colors.statusSuccessText};
+
+    span,
+    strong {
+      color: ${({ theme }) => theme.colors.statusSuccessText};
+    }
   }
 
   &[data-tone="warn"] {
     background: ${({ theme }) => theme.colors.orange2};
+    color: ${({ theme }) => theme.colors.orange10};
+
+    span,
+    strong {
+      color: ${({ theme }) => theme.colors.orange10};
+    }
   }
 
   span {

--- a/front/src/routes/Admin/AdminHubSurface.styles.ts
+++ b/front/src/routes/Admin/AdminHubSurface.styles.ts
@@ -34,7 +34,7 @@ export const HeroPanel = styled.section`
   display: grid;
   gap: 0.5rem;
   padding: 0 0 0.6rem;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  border-bottom: 0;
 `
 
 export const HeroHeader = styled.div`
@@ -146,8 +146,8 @@ export const BorderlessSupportSection = styled.section`
   display: grid;
   gap: 0.66rem;
   min-width: 0;
-  padding: 0 0 0.92rem;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  padding: 0 0 0.72rem;
+  border-bottom: 0;
 
   &:last-of-type {
     padding-bottom: 0;
@@ -174,8 +174,8 @@ export const BorderlessSection = styled.section`
   display: grid;
   min-width: 0;
   gap: 0.82rem;
-  padding: 0 0 1rem;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  padding: 0 0 0.86rem;
+  border-bottom: 0;
 
   &[data-variant="subtle"] {
     padding-bottom: 0;
@@ -187,18 +187,18 @@ export const BorderlessPanel = styled.div`
   display: grid;
   gap: 0.24rem;
   min-width: 0;
-  padding: 0.72rem 0.2rem;
+  padding: 0.72rem 0.82rem;
   border: 0;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
-  border-radius: 0;
-  background: transparent;
+  border-bottom: 0;
+  border-radius: 8px;
+  background: ${({ theme }) => adminRaisedSurface(theme)};
 
   &[data-tone="good"] {
-    border-color: ${({ theme }) => theme.colors.green7};
+    background: ${({ theme }) => theme.colors.statusSuccessSurface};
   }
 
   &[data-tone="warn"] {
-    border-color: ${({ theme }) => theme.colors.orange7};
+    background: ${({ theme }) => theme.colors.orange2};
   }
 
   span {
@@ -223,15 +223,14 @@ export const BorderlessPanelLink = styled.a`
   align-items: center;
   min-width: 0;
   min-height: 3.75rem;
-  padding: 0.72rem 0.2rem;
+  padding: 0.72rem 0.82rem;
   border: 0;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
-  border-radius: 0;
+  border-bottom: 0;
+  border-radius: 8px;
   background: transparent;
   color: inherit;
   text-decoration: none;
   transition:
-    border-color 0.16s ease,
     background 0.16s ease;
 
   &[data-featured="true"] {
@@ -241,11 +240,11 @@ export const BorderlessPanelLink = styled.a`
   }
 
   &[data-tone="good"] {
-    border-color: ${({ theme }) => theme.colors.green7};
+    background: ${({ theme }) => theme.colors.statusSuccessSurface};
   }
 
   &[data-tone="warn"] {
-    border-color: ${({ theme }) => theme.colors.orange7};
+    background: ${({ theme }) => theme.colors.orange2};
   }
 
   &:hover {
@@ -319,18 +318,18 @@ export const BorderlessMetricRow = styled.div`
   display: grid;
   gap: 0.24rem;
   min-width: 0;
-  padding: 0.72rem 0.2rem;
+  padding: 0.72rem 0.82rem;
   border: 0;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
-  border-radius: 0;
-  background: transparent;
+  border-bottom: 0;
+  border-radius: 8px;
+  background: ${({ theme }) => adminRaisedSurface(theme)};
 
   &[data-tone="good"] {
-    border-color: ${({ theme }) => theme.colors.green7};
+    background: ${({ theme }) => theme.colors.statusSuccessSurface};
   }
 
   &[data-tone="warn"] {
-    border-color: ${({ theme }) => theme.colors.orange7};
+    background: ${({ theme }) => theme.colors.orange2};
   }
 
   span {

--- a/front/src/routes/Admin/AdminShell.tsx
+++ b/front/src/routes/Admin/AdminShell.tsx
@@ -231,7 +231,7 @@ const BrandBlock = styled.div`
 const BrandMark = styled.div`
   width: 2.95rem;
   height: 2.95rem;
-  border-radius: 2px;
+  border-radius: 999px;
   display: grid;
   place-items: center;
   position: relative;
@@ -244,6 +244,10 @@ const BrandMark = styled.div`
     font-size: 0.9rem;
     font-weight: 800;
     letter-spacing: -0.04em;
+  }
+
+  img {
+    border-radius: inherit;
   }
 `
 

--- a/front/src/routes/Admin/AdminSurfacePrimitives.tsx
+++ b/front/src/routes/Admin/AdminSurfacePrimitives.tsx
@@ -29,7 +29,7 @@ export const adminInteractiveFocusRing = (theme: Theme) =>
 export const AdminElevatedCard = styled.section`
   border-radius: 0;
   border: 0;
-  border-bottom: 1px solid ${({ theme }) => adminElevatedBorder(theme)};
+  border-bottom: 0;
   background: transparent;
   box-shadow: ${({ theme }) => adminElevatedShadow(theme)};
 `
@@ -37,14 +37,14 @@ export const AdminElevatedCard = styled.section`
 export const AdminPlainCard = styled.section`
   border-radius: 0;
   border: 0;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  border-bottom: 0;
   background: transparent;
 `
 
 export const AdminSubtleCard = styled.section`
   border-radius: 0;
   border: 0;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  border-bottom: 0;
   background: transparent;
 `
 
@@ -100,7 +100,7 @@ export const AdminPaneHeader = styled.div`
   display: grid;
   gap: 0.22rem;
   padding-bottom: 0.95rem;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  border-bottom: 0;
 
   h2 {
     margin: 0;
@@ -128,7 +128,7 @@ export const AdminWorkspaceHero = styled.section`
   display: grid;
   gap: 0.4rem;
   padding: 0 0 0.56rem;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  border-bottom: 0;
 `
 
 export const AdminWorkspaceHeroLabel = styled.span`
@@ -210,10 +210,11 @@ export const AdminWorkspaceSectionNav = styled(AdminStickyRail)`
 
 export const AdminWorkspaceSectionNavStatus = styled(AdminRailCard)`
   gap: 0.22rem;
-  padding: 0.72rem 0;
-  border-radius: 0;
+  padding: 0.72rem 0.78rem;
+  border-radius: 8px;
   border: 0;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  border-bottom: 0;
+  background: ${({ theme }) => adminMutedSurface(theme)};
 
   small {
     color: ${({ theme }) => adminMutedText(theme)};
@@ -334,11 +335,11 @@ export const AdminWorkspaceActionDockInner = styled.div`
   align-items: center;
   justify-content: flex-end;
   gap: 0.65rem;
-  padding: 0.7rem 0;
-  border-radius: 0;
+  padding: 0.62rem 0.7rem;
+  border-radius: 8px;
   border: 0;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
-  background: transparent;
+  border-bottom: 0;
+  background: ${({ theme }) => adminMutedSurface(theme)};
 
   @media (max-width: 760px) {
     justify-content: space-between;
@@ -355,10 +356,10 @@ export const AdminInfoLinkCard = styled.a<{ $withIcon?: boolean }>`
   grid-template-columns: ${({ $withIcon = true }) => ($withIcon ? "auto minmax(0, 1fr)" : "minmax(0, 1fr)")};
   gap: ${({ $withIcon = true }) => ($withIcon ? "0.7rem" : "0.18rem")};
   align-items: center;
-  padding: 0.78rem 0;
-  border-radius: 0;
+  padding: 0.78rem 0.82rem;
+  border-radius: 8px;
   border: 0;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
+  border-bottom: 0;
   background: transparent;
   color: inherit;
   text-decoration: none;
@@ -370,8 +371,11 @@ export const AdminInfoLinkCard = styled.a<{ $withIcon?: boolean }>`
 
   &:focus-visible {
     outline: none;
-    border-color: ${({ theme }) => adminStrongBorder(theme)};
     box-shadow: ${({ theme }) => adminInteractiveFocusRing(theme)};
+  }
+
+  &:hover {
+    background: ${({ theme }) => adminMutedSurface(theme)};
   }
 
   .iconWrap {
@@ -417,18 +421,18 @@ export const AdminInfoStatusItem = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 0.72rem;
-  padding: 0.74rem 0;
-  border-radius: 0;
+  padding: 0.74rem 0.82rem;
+  border-radius: 8px;
   border: 0;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
-  background: transparent;
+  border-bottom: 0;
+  background: ${({ theme }) => adminMutedSurface(theme)};
 
   &[data-tone="good"] {
-    border-color: ${({ theme }) => theme.colors.green7};
+    background: ${({ theme }) => theme.colors.statusSuccessSurface};
   }
 
   &[data-tone="warn"] {
-    border-color: ${({ theme }) => theme.colors.orange7};
+    background: ${({ theme }) => theme.colors.orange2};
   }
 
   span {
@@ -448,11 +452,11 @@ export const AdminInfoStatusItem = styled.div`
 export const AdminInfoPanelCard = styled.div`
   display: grid;
   gap: 0.68rem;
-  padding: 0.92rem 0;
-  border-radius: 0;
+  padding: 0.92rem 0.98rem;
+  border-radius: 8px;
   border: 0;
-  border-bottom: 1px solid ${({ theme }) => adminCardBorder(theme)};
-  background: transparent;
+  border-bottom: 0;
+  background: ${({ theme }) => adminMutedSurface(theme)};
 `
 
 export const AdminStatusPill = styled.span<{ $size?: "sm" | "md" }>`
@@ -505,6 +509,15 @@ export const AdminInlineActionRow = styled.div`
   gap: 0.55rem;
   align-items: center;
   flex-wrap: wrap;
+  width: fit-content;
+  max-width: 100%;
+  padding: 0.42rem 0.48rem;
+  border-radius: 6px;
+  background: ${({ theme }) => adminMutedSurface(theme)};
+
+  & + & {
+    margin-top: 0.4rem;
+  }
 `
 
 export const AdminTextActionButton = styled.button`

--- a/front/src/routes/Admin/AdminSurfacePrimitives.tsx
+++ b/front/src/routes/Admin/AdminSurfacePrimitives.tsx
@@ -429,10 +429,22 @@ export const AdminInfoStatusItem = styled.div`
 
   &[data-tone="good"] {
     background: ${({ theme }) => theme.colors.statusSuccessSurface};
+    color: ${({ theme }) => theme.colors.statusSuccessText};
+
+    span,
+    strong {
+      color: ${({ theme }) => theme.colors.statusSuccessText};
+    }
   }
 
   &[data-tone="warn"] {
     background: ${({ theme }) => theme.colors.orange2};
+    color: ${({ theme }) => theme.colors.orange10};
+
+    span,
+    strong {
+      color: ${({ theme }) => theme.colors.orange10};
+    }
   }
 
   span {


### PR DESCRIPTION
## 관련 이슈

close #758

## 작업 배경

- 관리자 페이지의 이중선처럼 보이는 행/액션 표면을 GDrive/MYBOX형 저선형 구조로 정리했습니다.
- 관리자 프로필 이미지를 원형으로 고정하고, legacy 디자인의 상단 light/dark 토글을 메인/관리자에서 일관되게 노출합니다.
- 클라우드 업로드 큐는 본문 목록을 밀지 않는 우측 하단 고정 패널로 옮겼고 다중 업로드/취소/재시도 동작은 유지했습니다.

## 작업 내용

- `AdminSurfacePrimitives`와 `AdminHubSurface`의 반복 border-bottom 기반 구분을 옅은 surface 중심으로 조정했습니다.
- 관리자 shell profile mark와 내부 img radius를 원형으로 맞췄습니다.
- `RootLayout`의 theme toggle 조건에서 public route 제외 조건을 제거했습니다.
- `AdminCloudUploadQueue`를 Drive형 fixed transfer panel로 바꾸고 완료/종료 제목과 접근성 라벨을 정리했습니다.
- 관련 e2e/source contract를 한국어 display name으로 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_FILE_PATH=.codex/tasks/admin-double-divider.local bash tools/guards/current-task-preflight.sh`
  - `yarn --cwd front playwright test e2e/admin-cloud.spec.ts --grep "업로드" --workers=1`
  - `yarn --cwd front playwright test e2e/admin-cloud.spec.ts --workers=1`
  - `yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts e2e/admin-hub-state.spec.ts --grep "관리자" --workers=1`
  - `yarn --cwd front playwright test e2e/smoke-public-shell.spec.ts --grep "public blog appearance" --workers=1`
  - `yarn --cwd front playwright test e2e/perf-layout.spec.ts --grep "공개와 인증 핵심 화면은 system light legacy 표면 계층을 유지한다" --workers=1`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front build`
  - `yarn --cwd front check:bundle-size`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: 관리자 공통 surface primitive 변경으로 일부 관리자 섹션의 여백 밀도가 달라질 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋 `7bb83cbb`를 revert하면 이전 관리자 표면/업로드 큐 렌더링으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
