### PR TITLE
[Fix] Markdown editor 이미지 업로드 실패 복구

### DIFF
--- a/front/e2e/editor-authoring-markdown-editor.spec.ts
+++ b/front/e2e/editor-authoring-markdown-editor.spec.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer"
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
 import { resolve } from "node:path"
 import type { Page, Route } from "./helpers/authoringPlaywright"
@@ -7,6 +8,10 @@ const sourcePath = (...segments: string[]) => resolve(__dirname, "../src", ...se
 const frontPath = (...segments: string[]) => resolve(__dirname, "..", ...segments)
 const joinParts = (...parts: string[]) => parts.join("")
 const localDraftStorageKey = "admin.editor.localDraft.v1"
+const onePixelPng = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64"
+)
 const adminMember = {
   id: 1,
   username: "qa-admin",
@@ -830,6 +835,53 @@ test.describe("Markdown editor replacement", () => {
     const editorText = await writePane.locator("textarea").inputValue()
     expect(editorText.indexOf("| Column 1 | Column 2 | Column 3 |")).toBeLessThan(editorText.indexOf("omega"))
     await expect(page.getByTestId("markdown-editor-preview-pane").locator("table")).toContainText("Column 1")
+  })
+
+  test("image upload inserts a url-only upload response at the textarea caret", async ({ page }) => {
+    await routeAuthenticatedEditor(page, ["alpha", "omega"].join("\n"))
+    let uploadCalled = false
+    await page.route("**/post/api/v1/posts/images", async (route) => {
+      uploadCalled = true
+      await fulfillJson(route, {
+        resultCode: "201-1",
+        msg: "이미지가 업로드되었습니다.",
+        data: {
+          key: "post-images/body-image.png",
+          url: "https://cdn.example.test/post-images/body-image.png",
+        },
+      })
+    })
+
+    await page.goto("/editor/new?source=local-draft")
+
+    const writePane = page.getByTestId("markdown-editor-write-pane")
+    const textarea = writePane.locator("textarea")
+    await expect(textarea).toBeVisible()
+    await textarea.click()
+    await page.keyboard.press(process.platform === "darwin" ? "Meta+Home" : "Control+Home")
+    await page.keyboard.press("ArrowRight")
+
+    await page
+      .getByTestId("markdown-editor")
+      .locator("input[type='file'][accept='image/*']")
+      .setInputFiles({
+        name: "본문 이미지.png",
+        mimeType: "image/png",
+        buffer: onePixelPng,
+      })
+
+    await expect.poll(() => uploadCalled, { message: "post image upload request should be sent" }).toBe(true)
+    await expect(page.getByText("이미지 업로드에 실패했습니다.")).toHaveCount(0)
+    await expect(page.getByText(/이미지 업로드 실패:/)).toHaveCount(0)
+
+    const editorText = await textarea.inputValue()
+    const imageMarkdown = "![본문 이미지.png](https://cdn.example.test/post-images/body-image.png)"
+    expect(editorText).toContain(imageMarkdown)
+    expect(editorText.indexOf(imageMarkdown)).toBeLessThan(editorText.indexOf("omega"))
+    await expect(page.getByTestId("markdown-editor-preview-pane").locator("img")).toHaveAttribute(
+      "src",
+      "https://cdn.example.test/post-images/body-image.png"
+    )
   })
 
   test("preview keeps raw HTML script and javascript URLs out of the rendered DOM", async ({

--- a/front/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/front/src/components/markdown-editor/MarkdownEditor.tsx
@@ -247,9 +247,11 @@ export const MarkdownEditor = ({
         return
       }
       const alt = uploaded.alt || uploaded.title || file.name
-      commitMarkdown(`${valueRef.current}\n\n![${alt}](${src})\n`, true)
+      const imageMarkdown = `\n\n![${alt}](${src})\n`
+      if (insertMarkdownAtEditorSelection(imageMarkdown)) return
+      commitMarkdown(`${valueRef.current}${imageMarkdown}`, true)
     },
-    [commitMarkdown, onUploadImage]
+    [commitMarkdown, insertMarkdownAtEditorSelection, onUploadImage]
   )
 
   return (

--- a/front/src/routes/Admin/useEditorStudioPersistenceModel.ts
+++ b/front/src/routes/Admin/useEditorStudioPersistenceModel.ts
@@ -117,11 +117,14 @@ export const useEditorStudioPersistenceUploads = ({
 
     try {
       const uploaded = await uploadPostImageFile(file)
-      const markdown = uploaded.uploaded.data?.markdown
-      if (!markdown) throw new Error("업로드 응답 형식이 올바르지 않습니다.")
+      const markdown = uploaded.uploaded.data?.markdown?.trim()
+      const uploadedUrl = uploaded.uploaded.data?.url?.trim()
+      if (!markdown && !uploadedUrl) throw new Error("업로드 응답 형식이 올바르지 않습니다.")
 
-      const parsed = parseStandaloneMarkdownImageLine(markdown)
-      if (!parsed) throw new Error("이미지 markdown 메타데이터를 해석하지 못했습니다.")
+      const parsed = markdown ? parseStandaloneMarkdownImageLine(markdown) : null
+      if (markdown && !parsed && !uploadedUrl) throw new Error("이미지 markdown 메타데이터를 해석하지 못했습니다.")
+      const safeUploadedUrl = normalizeSafeImageUrl(parsed?.src || uploadedUrl || "")
+      if (!safeUploadedUrl) throw new Error("허용되지 않은 이미지 URL 형식입니다.")
 
       setPublishStatus({
         tone: "success",
@@ -129,11 +132,11 @@ export const useEditorStudioPersistenceUploads = ({
       })
 
       return {
-        src: parsed.src,
-        alt: parsed.alt,
-        title: parsed.title,
-        widthPx: parsed.widthPx,
-        align: parsed.align || "center",
+        src: safeUploadedUrl,
+        alt: parsed?.alt || file.name,
+        title: parsed?.title,
+        widthPx: parsed?.widthPx,
+        align: parsed?.align || "center",
       }
     } catch (error) {
       const message = normalizeProfileImageUploadError(error)
@@ -143,7 +146,7 @@ export const useEditorStudioPersistenceUploads = ({
       })
       throw error
     }
-  }, [setPublishStatus, uploadPostImageFile])
+  }, [normalizeSafeImageUrl, setPublishStatus, uploadPostImageFile])
 
   const uploadPostAttachmentFile = useCallback(async (file: File): Promise<UploadPostFileResponse> => {
     const formData = new FormData()


### PR DESCRIPTION
## 관련 이슈

close #759

## 작업 배경

- Markdown editor 본문 이미지 업로드가 성공 응답을 받고도 `이미지 업로드에 실패했습니다.`로 떨어지는 경로를 복구했습니다.
- 업로드 응답은 `markdown`을 우선 사용하되, 기존/구계약 `url` 응답도 안전 URL 정규화를 거쳐 본문 caret 위치에 Markdown 이미지로 삽입합니다.

## 작업 내용

- 본문 이미지 업로드 핸들러가 `data.markdown`만 요구하던 계약을 `data.url` fallback까지 허용하도록 수정했습니다.
- 업로드 결과 이미지 Markdown을 문서 끝이 아니라 현재 textarea caret 위치에 삽입하도록 변경했습니다.
- URL-only 이미지 업로드 응답이 실패 UI 없이 preview 이미지로 렌더되는 authoring E2E를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:authoring --grep "image upload inserts"` (RED 확인 후 수정 뒤 통과)
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front build`
  - `yarn --cwd front test:e2e:smoke`
  - `git diff --check`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: URL-only 응답을 허용하면서 안전하지 않은 이미지 URL이 본문에 삽입될 수 있는지 확인이 필요합니다. 이 PR은 기존 `normalizeSafeImageUrl`을 그대로 통과시켜 `javascript:` 등 비허용 URL을 차단합니다.
- 롤백 방법: 이 PR을 revert하면 이전 Markdown-only 업로드 응답 파싱으로 돌아갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
