### PR TITLE
[Fix] 공개 페이지 초기 다크 테마 플래시 제거

### DIFF
--- a/front/e2e/smoke-public-shell.spec.ts
+++ b/front/e2e/smoke-public-shell.spec.ts
@@ -13,6 +13,17 @@ test.beforeEach(async ({ page }) => {
 })
 
 test.describe("core smoke public shell", () => {
+  test("system dark 공개 페이지는 hydration 첫 렌더에서 light scheme으로 되돌아가지 않는다", async () => {
+    const useSchemeSource = readFileSync(path.resolve(__dirname, "../src/hooks/useScheme.ts"), "utf8")
+
+    expect(useSchemeSource).toContain('CONFIG.blog.scheme === "system" ? "light" : CONFIG.blog.scheme')
+    expect(useSchemeSource).toContain("const bootstrapScheme = resolveCachedScheme() ?? defaultScheme")
+    expect(useSchemeSource).toContain("if (bootstrapScheme !== data)")
+    expect(useSchemeSource).toContain("queryClient.setQueryData(queryKey.scheme(), bootstrapScheme)")
+    expect(useSchemeSource).not.toContain("setScheme(bootstrapScheme)")
+    expect(useSchemeSource).not.toMatch(/setScheme\(nextScheme\)\s*clearSchemeBootstrapAfterHydration\(\)/)
+  })
+
   test("public blog appearance는 전역 theme와 legacy 디자인으로 고정된다", async () => {
   const resolverSource = readFileSync(path.resolve(__dirname, "../src/libs/blogAppearance.ts"), "utf8")
   const rootLayoutSource = readFileSync(path.resolve(__dirname, "../src/layouts/RootLayout/index.tsx"), "utf8")

--- a/front/src/hooks/useScheme.ts
+++ b/front/src/hooks/useScheme.ts
@@ -53,14 +53,13 @@ const useScheme = (): [SchemeType, SetScheme] => {
     if (typeof window === "undefined") return
 
     const defaultScheme = followsSystemTheme ? resolveSystemScheme() : data
-    const nextScheme = resolveCachedScheme() ?? defaultScheme
-    if (nextScheme !== data) {
-      setScheme(nextScheme)
-      clearSchemeBootstrapAfterHydration()
+    const bootstrapScheme = resolveCachedScheme() ?? defaultScheme
+    if (bootstrapScheme !== data) {
+      queryClient.setQueryData(queryKey.scheme(), bootstrapScheme)
       return
     }
     clearSchemeBootstrapAfterHydration()
-  }, [data, followsSystemTheme, setScheme])
+  }, [data, followsSystemTheme, queryClient])
 
   return [data, setScheme]
 }


### PR DESCRIPTION
## 관련 이슈

close #762

## 작업 배경

- OS/browser dark 설정에서 공개 메인과 글 상세를 직접 진입하거나 새로고침할 때 라이트 배경이 잠깐 노출되는 초기 theme flash를 줄입니다.
- 서버/클라이언트 첫 hydration은 기존 light fallback과 맞추고, system dark 전환이 반영되기 전에는 _document bootstrap mask를 제거하지 않도록 정리했습니다.

## 작업 내용

- system theme 자동 동기화 시 cookie를 새로 쓰지 않고 React Query state만 갱신해 OS 설정을 계속 따르게 했습니다.
- dark bootstrap style 제거는 현재 scheme과 bootstrap/system 판정이 일치한 뒤에만 실행되도록 변경했습니다.
- 공개 shell 회귀 테스트에 system dark hydration 첫 렌더 계약을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - yarn --cwd front playwright:preflight
  - yarn --cwd front playwright test e2e/smoke-public-shell.spec.ts --grep "system dark" --workers=1 (RED 확인 후 GREEN)
  - yarn --cwd front playwright test e2e/smoke-public-shell.spec.ts --workers=1
  - yarn --cwd front playwright test e2e/perf-layout.spec.ts --grep "공개와 인증 핵심 화면" --workers=1
  - yarn --cwd front build
  - node front/scripts/check-bundle-size.mjs

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: theme bootstrap style 제거 타이밍 변경으로 첫 렌더 직후 bootstrap attribute가 기존보다 한 render 늦게 제거됩니다.
- 롤백 방법: 이 PR의 front/src/hooks/useScheme.ts 변경과 smoke-public-shell 테스트 추가를 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
