### PR TITLE
[Fix] Markdown 코드블럭 언어 라벨 복구

### DIFF
--- a/front/e2e/editor-authoring-markdown-editor.spec.ts
+++ b/front/e2e/editor-authoring-markdown-editor.spec.ts
@@ -911,4 +911,54 @@ test.describe("Markdown editor replacement", () => {
       .poll(() => page.evaluate(() => Boolean((window as unknown as { __markdownPreviewScript?: boolean }).__markdownPreviewScript)))
       .toBe(false)
   })
+
+  test("code block language labels keep common fenced language aliases out of TXT fallback", async ({
+    page,
+  }) => {
+    const languageCases = [
+      ["java", "public Token login(User user) {\n  return new Token(access, refresh);\n}", "Java"],
+      ["js", "const value = 1", "JavaScript"],
+      ["javascript", "const value = 1", "JavaScript"],
+      ["ts", "const value: string = 'ok'", "TypeScript"],
+      ["typescript", "const value: string = 'ok'", "TypeScript"],
+      ["tsx", "export const View = () => <div />", "TSX"],
+      ["jsx", "export const View = () => <div />", "JSX"],
+      ["kotlin", "fun login(): Token = token", "Kotlin"],
+      ["kt", "val token = Token()", "Kotlin"],
+      ["python", "def login():\n    return token", "Python"],
+      ["py", "def login():\n    return token", "Python"],
+      ["bash", "echo hello", "Bash"],
+      ["sh", "echo hello", "Shell"],
+      ["shell", "echo hello", "Shell"],
+      ["sql", "SELECT * FROM users", "SQL"],
+      ["yaml", "name: aquila", "YAML"],
+      ["yml", "name: aquila", "YAML"],
+      ["json", "{\"ok\": true}", "JSON"],
+      ["html", "<main>hello</main>", "HTML"],
+      ["xml", "<root>hello</root>", "XML"],
+      ["css", ".login { color: red; }", "CSS"],
+      ["scss", "$color: red;\n.login { color: $color; }", "SCSS"],
+      ["markdown", "# Heading", "Markdown"],
+      ["md", "# Heading", "Markdown"],
+      ["go", "func main() {}", "Go"],
+      ["rust", "fn main() {}", "Rust"],
+      ["rs", "fn main() {}", "Rust"],
+    ] as const
+
+    await routeAuthenticatedEditor(
+      page,
+      languageCases
+        .map(([language, source]) => ["```" + language, source, "```"].join("\n"))
+        .join("\n\n")
+    )
+
+    await page.goto("/editor/new?source=local-draft")
+
+    const labels = await page
+      .getByTestId("markdown-editor-preview-pane")
+      .locator(".aq-code-language")
+      .allTextContents()
+    expect(labels).toEqual(languageCases.map(([, , label]) => label))
+    expect(labels).not.toContain("TXT")
+  })
 })

--- a/front/e2e/smoke-detail-rendering.spec.ts
+++ b/front/e2e/smoke-detail-rendering.spec.ts
@@ -327,6 +327,88 @@ test.describe("core smoke detail rendering", () => {
   expect(colors.string).not.toBe(colors.code)
 })
 
+  test("상세 코드블럭은 fenced language alias 라벨을 TXT로 떨어뜨리지 않는다", async ({ page }) => {
+  const languageCases = [
+    ["java", "public Token login(User user) {\n  return new Token(access, refresh);\n}", "Java"],
+    ["js", "const value = 1", "JavaScript"],
+    ["javascript", "const value = 1", "JavaScript"],
+    ["ts", "const value: string = 'ok'", "TypeScript"],
+    ["typescript", "const value: string = 'ok'", "TypeScript"],
+    ["tsx", "export const View = () => <div />", "TSX"],
+    ["jsx", "export const View = () => <div />", "JSX"],
+    ["kotlin", "fun login(): Token = token", "Kotlin"],
+    ["kt", "val token = Token()", "Kotlin"],
+    ["python", "def login():\n    return token", "Python"],
+    ["py", "def login():\n    return token", "Python"],
+    ["bash", "echo hello", "Bash"],
+    ["sh", "echo hello", "Shell"],
+    ["shell", "echo hello", "Shell"],
+    ["sql", "SELECT * FROM users", "SQL"],
+    ["yaml", "name: aquila", "YAML"],
+    ["yml", "name: aquila", "YAML"],
+    ["json", "{\"ok\": true}", "JSON"],
+    ["html", "<main>hello</main>", "HTML"],
+    ["xml", "<root>hello</root>", "XML"],
+    ["css", ".login { color: red; }", "CSS"],
+    ["scss", "$color: red;\n.login { color: $color; }", "SCSS"],
+    ["markdown", "# Heading", "Markdown"],
+    ["md", "# Heading", "Markdown"],
+    ["go", "func main() {}", "Go"],
+    ["rust", "fn main() {}", "Rust"],
+    ["rs", "fn main() {}", "Rust"],
+  ] as const
+
+  await page.route("**/post/api/v1/posts/114", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: 114,
+        createdAt: "2026-06-15T00:00:00Z",
+        modifiedAt: "2026-06-15T00:00:00Z",
+        authorId: 1,
+        authorName: "관리자",
+        authorUsername: "aquila",
+        authorProfileImageDirectUrl: "/avatar.png",
+        title: "코드 언어 라벨 회귀 방지",
+        content: languageCases
+          .map(([language, source]) => ["```" + language, source, "```"].join("\n"))
+          .join("\n\n"),
+        tags: ["테스트태그"],
+        category: [],
+        published: true,
+        listed: true,
+        likesCount: 0,
+        commentsCount: 0,
+        hitCount: 0,
+        actorHasLiked: false,
+        actorCanModify: false,
+        actorCanDelete: false,
+      }),
+    })
+  })
+
+  await page.route("**/post/api/v1/posts/114/hit", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "200-1",
+        msg: "ok",
+        data: { hitCount: 1 },
+      }),
+    })
+  })
+
+  await page.goto("/posts/114")
+
+  const languageLabels = page.locator(".aq-code-language")
+  await expect(languageLabels).toHaveCount(languageCases.length)
+  const labels = await languageLabels.allTextContents()
+  expect(labels).toEqual(languageCases.map(([, , label]) => label))
+  expect(labels).not.toContain("TXT")
+})
+
   test("code-heavy 상세 페이지는 markdown AST prop 누수 없이 hydration 된다", async ({ page }) => {
   const runtimeErrors: string[] = []
   const isHydrationRuntimeSignal = (value: string) =>

--- a/front/src/libs/markdown/MarkdownRenderer.tsx
+++ b/front/src/libs/markdown/MarkdownRenderer.tsx
@@ -170,8 +170,8 @@ const MarkdownRendererComponent: FC<MarkdownRendererProps> = ({
             </code>
           )
         },
-        pre({ node: _node, children, className: _className, ...props }) {
-          const { language, rawCode } = extractCodeMetaFromPreChildren(children)
+        pre({ node, children, className: _className, ...props }) {
+          const { language, rawCode } = extractCodeMetaFromPreChildren(children, node)
           const mermaidSource = extractNormalizedMermaidSource(rawCode)
           const shouldRenderMermaid = language === "mermaid" || isMermaidSource(rawCode)
 

--- a/front/src/libs/markdown/renderingCodeModel.ts
+++ b/front/src/libs/markdown/renderingCodeModel.ts
@@ -39,6 +39,38 @@ const extractTextFromNode = (node: ReactNode): string => {
   return extractTextFromNode((node.props as { children?: ReactNode }).children)
 }
 
+const readAstProperties = (node: unknown): Record<string, unknown> => {
+  if (!node || typeof node !== "object") return {}
+  const properties = (node as { properties?: unknown }).properties
+  return properties && typeof properties === "object" ? properties as Record<string, unknown> : {}
+}
+
+const findCodeAstNode = (node: unknown): unknown => {
+  if (!node || typeof node !== "object") return null
+  if (String((node as { tagName?: unknown }).tagName || "").toLowerCase() === "code") return node
+  const children = (node as { children?: unknown }).children
+  if (!Array.isArray(children)) return null
+  return children.find((child) => String((child as { tagName?: unknown })?.tagName || "").toLowerCase() === "code") || null
+}
+
+const readClassName = (...values: unknown[]): string =>
+  values
+    .flatMap((value) => {
+      if (typeof value === "string") return [value]
+      if (!Array.isArray(value)) return []
+      return value.filter((item): item is string => typeof item === "string")
+    })
+    .join(" ")
+
+const readLanguageAttribute = (...values: unknown[]): string => {
+  for (const value of values) {
+    if (typeof value !== "string") continue
+    const normalized = value.trim().toLowerCase()
+    if (normalized) return normalized
+  }
+  return ""
+}
+
 export const extractTextFromCodeAst = (node: unknown): string => {
   if (!node || typeof node !== "object") return ""
 
@@ -52,15 +84,16 @@ export const extractTextFromCodeAst = (node: unknown): string => {
   return children.map(extractTextFromCodeAst).join("")
 }
 
-export const extractCodeMetaFromPreChildren = (children: ReactNode) => {
+export const extractCodeMetaFromPreChildren = (children: ReactNode, preNode?: unknown) => {
   const list = Array.isArray(children) ? children : [children]
   const codeElement = list.find(
     (child): child is ReactElement<Record<string, unknown>> =>
       isValidElement(child) && typeof child.type === "string" && child.type.toLowerCase() === "code"
   )
+  const codeAstNode = codeElement?.props.node || findCodeAstNode(preNode)
+  const astProperties = readAstProperties(codeAstNode)
 
-  const codeClassName =
-    typeof codeElement?.props.className === "string" ? codeElement.props.className : ""
+  const codeClassName = readClassName(codeElement?.props.className, astProperties.className)
   const classLanguage =
     codeClassName
       .split(" ")
@@ -69,10 +102,11 @@ export const extractCodeMetaFromPreChildren = (children: ReactNode) => {
       ?.replace("language-", "")
       .toLowerCase() || ""
 
-  const dataLanguage =
-    typeof codeElement?.props["data-language"] === "string"
-      ? String(codeElement.props["data-language"]).toLowerCase()
-      : ""
+  const dataLanguage = readLanguageAttribute(
+    codeElement?.props["data-language"],
+    astProperties["data-language"],
+    astProperties.dataLanguage
+  )
   const dataRawCode =
     typeof codeElement?.props["data-raw-code"] === "string"
       ? String(codeElement.props["data-raw-code"])
@@ -80,7 +114,7 @@ export const extractCodeMetaFromPreChildren = (children: ReactNode) => {
 
   const codeChildren = (codeElement?.props.children as ReactNode | undefined) ?? children
   const rawCodeFromChildren = extractTextFromNode(codeChildren)
-  const rawCodeFromAst = extractTextFromCodeAst(codeElement?.props.node)
+  const rawCodeFromAst = extractTextFromCodeAst(codeAstNode)
   const rawCode = (dataRawCode || rawCodeFromChildren || rawCodeFromAst).replace(/\n$/, "")
 
   return {


### PR DESCRIPTION
## 관련 이슈

close #763

## 작업 배경

- Markdown fenced code block의 명시 언어가 preview/detail 렌더 단계에서 `TXT` fallback으로 떨어지는 문제를 수정했습니다.
- `java`뿐 아니라 주요 언어 alias가 editor preview와 public detail에서 같은 label 경로로 표시되도록 회귀 테스트를 추가했습니다.

## 작업 내용

- `pre` 렌더러가 React child props뿐 아니라 Markdown AST의 child `code.properties.className`도 읽도록 보강했습니다.
- Java, JavaScript, TypeScript, TSX, JSX, Kotlin, Python, Bash, Shell, SQL, YAML, JSON, HTML, XML, CSS, SCSS, Markdown, Go, Rust alias가 `TXT`로 떨어지지 않는 authoring/detail E2E를 추가했습니다.
- unknown/plain text code block은 기존처럼 `TXT` fallback을 유지합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:authoring --grep "code block language labels"`
  - `yarn --cwd front test:e2e:smoke --grep "fenced language alias"`
  - `yarn --cwd front test:e2e:authoring`
  - `yarn --cwd front test:e2e:smoke`
  - `yarn --cwd front build`
  - `node front/scripts/check-bundle-size.mjs`
  - `yarn --cwd front playwright:preflight`
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`
  - `yarn --cwd front test:e2e:perf`
  - `git diff --check`
  - 커밋 훅 재검증: `yarn build`, `node scripts/check-bundle-size.mjs`, `yarn test:e2e:smoke`
  - Browser 수동 확인: 로컬 `/posts/507`에서 명시 Java code block label이 `Java`로 표시됨을 확인했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 특이사항 없음

## 리스크

- 예상 리스크: Markdown AST 구조가 바뀌는 라이브러리 업데이트 시 language class 추출 경로가 다시 달라질 수 있습니다.
- 롤백 방법: 이 PR의 단일 커밋 `99f4d9f7`을 revert합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
