### PR TITLE
[Fix] 첨부 파일 업로드 권한 경계 강화

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/config/PostSecurityConfigurer.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/config/PostSecurityConfigurer.kt
@@ -44,6 +44,7 @@ class PostSecurityConfigurer : PublicApiRouteContributor {
         authorize.apply {
             authorize(HttpMethod.POST, "/post/api/*/posts", hasRole("ADMIN"))
             authorize(HttpMethod.POST, "/post/api/*/posts/images", hasRole("ADMIN"))
+            authorize(HttpMethod.POST, "/post/api/*/posts/files", hasRole("ADMIN"))
             authorize(HttpMethod.PUT, "/post/api/*/posts/{id:\\d+}", hasRole("ADMIN"))
             authorize(HttpMethod.DELETE, "/post/api/*/posts/{id:\\d+}", hasRole("ADMIN"))
             authorize(HttpMethod.GET, "/post/api/*/posts/mine", hasRole("ADMIN"))

--- a/back/src/test/kotlin/com/back/support/SecurityConfigEndpointExposureWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/support/SecurityConfigEndpointExposureWebMvcTest.kt
@@ -36,6 +36,7 @@ import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 import tools.jackson.databind.ObjectMapper
@@ -47,6 +48,7 @@ import tools.jackson.databind.ObjectMapper
 )
 @TestPropertySource(
     properties = [
+        "custom.security.apiRateLimit.enabled=false",
         "spring.security.oauth2.client.registration.kakao.client-id=test-kakao-client-id",
     ],
 )
@@ -180,6 +182,24 @@ class SecurityConfigProdEndpointExposureWebMvcTest : SecurityConfigEndpointExpos
             mvc.get(path).andExpect {
                 status { isInternalServerError() }
             }
+        }
+    }
+
+    @Test
+    @DisplayName("prod에서 일반 사용자는 첨부 파일 업로드 보안 체인을 통과하지 못한다")
+    @WithMockUser(roles = ["USER"])
+    fun `prod protects post file upload from non admin access`() {
+        mvc.post("/post/api/v1/posts/files").andExpect {
+            status { isForbidden() }
+        }
+    }
+
+    @Test
+    @DisplayName("prod에서 관리자는 첨부 파일 업로드 보안 체인을 통과해 handler 계층까지 도달한다")
+    @WithMockUser(roles = ["ADMIN"])
+    fun `prod lets admin pass post file upload security checks to application handler layer`() {
+        mvc.post("/post/api/v1/posts/files").andExpect {
+            status { isInternalServerError() }
         }
     }
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #778
- audit follow-up of #777

## 📝 Summary
- `POST /post/api/v1/posts/files`가 글 작성/이미지 업로드 권한 경계와 다르게 인증 사용자 전체에 열려 있던 문제를 막습니다.
- 첨부 파일 업로드를 admin 전용으로 맞추고 SecurityConfig WebMvc 회귀 테스트를 추가했습니다.

## 🛠 Changes
- `PostSecurityConfigurer`에 `POST /post/api/*/posts/files` admin 권한 규칙을 추가했습니다.
- prod security WebMvc 테스트에 non-admin 403, admin handler-layer 통과 케이스를 추가했습니다.
- 테스트 slice에서 AuthZ만 검증하도록 Redis rate-limit backstop을 비활성화했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [ ] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `back/gradlew -p back test --tests com.back.support.SecurityConfigProdEndpointExposureWebMvcTest`
- `back/gradlew -p back ktlintCheck`
- `git diff --check`
- pre-commit: `OpenApiContractExportTest`, `yarn contracts:check`

## 📸 Screenshot / API Example
- API 권한 변경이며 UI 변경 없음.
- 기대 동작: 일반 사용자 `POST /post/api/v1/posts/files`는 403, admin은 보안 체인을 통과합니다.

## ⚠️ Risk & Rollback
- 예상 리스크: 일반 인증 사용자에게 첨부 파일 업로드를 허용하는 숨은 사용처가 있었다면 차단됩니다. 현재 글 작성과 이미지 업로드가 admin 전용이므로 권한 경계 정합성이 더 중요합니다.
- 롤백 방법: 이 PR의 단일 커밋을 revert합니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?