### PR TITLE
[Fix] 관리자 클라우드 PDF 콘솔 에러 정리

### DIFF
--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -234,6 +234,14 @@ const setupAdminCloudMocks = async (
 test.describe("관리자 클라우드", () => {
   test("MYBOX형 파일 목록, 다중 업로드 큐, 취소, 삭제와 owner 전용 preview drawer가 동작한다", async ({ page }) => {
     const mocks = await setupAdminCloudMocks(page)
+    const browserErrors: string[] = []
+
+    page.on("pageerror", (error) => {
+      browserErrors.push(error.message)
+    })
+    page.on("console", (message) => {
+      if (message.type() === "error") browserErrors.push(message.text())
+    })
 
     await page.goto("/admin/cloud")
 
@@ -312,6 +320,8 @@ test.describe("관리자 클라우드", () => {
     await expect(page.getByLabel("클라우드 상세정보").getByText("파일 선택")).toBeVisible()
     await page.getByRole("button", { name: "상세 패널 보기" }).click()
     await expect(page.getByRole("heading", { name: "문서 뷰어" })).toBeVisible()
+    await page.waitForTimeout(100)
+    expect(browserErrors.filter((message) => message.includes("Worker was terminated"))).toEqual([])
 
     await page.getByRole("button", { name: "home-server-rack.png 미리보기" }).click()
     await expect(page.getByRole("heading", { name: "사진 보기" })).toBeVisible()

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -105,6 +105,17 @@ const resolveCloudErrorMessage = (error: unknown) => {
   return "요청 처리 중 오류가 발생했습니다."
 }
 
+const ignorePdfPreviewTeardownRejection = (task: PDFDocumentLoadingTask | null) => {
+  if (!task) return
+
+  void task.promise.catch(() => {
+    // 미리보기 cleanup에서 PDF.js worker를 의도적으로 종료하면 reject가 발생할 수 있다.
+  })
+  void task.destroy().catch(() => {
+    // 미리보기 cleanup에서 PDF.js worker를 의도적으로 종료하면 reject가 발생할 수 있다.
+  })
+}
+
 type PdfPreviewProps = {
   file: CloudFile
   contentUrl: string
@@ -128,6 +139,9 @@ const PdfPreview = ({ file, contentUrl }: PdfPreviewProps) => {
         loadingTask = pdfjs.getDocument({
           url: contentUrl,
           withCredentials: true,
+        })
+        void loadingTask.promise.catch(() => {
+          // cleanup이 먼저 실행된 경우 await 경로 밖에서도 worker 종료 reject를 소비한다.
         })
         const pdf = await loadingTask.promise
         if (cancelled) return
@@ -160,8 +174,12 @@ const PdfPreview = ({ file, contentUrl }: PdfPreviewProps) => {
 
     return () => {
       cancelled = true
-      renderTask?.cancel()
-      void loadingTask?.destroy()
+      try {
+        renderTask?.cancel()
+      } catch {
+        // loading task 종료가 먼저 끝난 경우 render task도 이미 취소 상태일 수 있다.
+      }
+      ignorePdfPreviewTeardownRejection(loadingTask)
     }
   }, [contentUrl, file.mediaKind])
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #779

## 📝 Summary
- 관리자 클라우드 PDF 미리보기 전환/닫기 중 PDF.js worker 종료가 브라우저 콘솔의 unhandled error로 남는 문제를 정리했습니다.
- 비로그인 auth/me 401은 기존 세션 probe 회귀 테스트로 앱 오류/로그아웃 루프가 아님을 함께 확인했습니다.

## 🛠 Changes
- PDF 미리보기 cleanup에서 loading task promise와 destroy promise의 예상 가능한 종료 rejection을 소비합니다.
- render task가 이미 종료된 상태에서도 cleanup이 예외를 다시 만들지 않도록 처리했습니다.
- 관리자 클라우드 e2e에서 PDF preview drawer 닫기/재열기 후 `Worker was terminated` 콘솔 에러가 남지 않도록 회귀를 고정했습니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Editor / Content Rendering
- [x] Admin / Dashboard
- [x] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [ ] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `yarn --cwd front playwright:preflight`
- `yarn --cwd front playwright test e2e/admin-cloud.spec.ts e2e/header-refresh-auth.spec.ts` (1차: 기존 Worker was terminated 재현 후 실패)
- `yarn --cwd front playwright test e2e/admin-cloud.spec.ts e2e/header-refresh-auth.spec.ts` (수정 후 10 passed)
- `yarn --cwd front build`
- `yarn --cwd front playwright test e2e/admin-cloud.spec.ts e2e/header-refresh-auth.spec.ts` (2회 연속 통과 확인, 10 passed)

## 📸 Screenshot / API Example
- UI 변경 없음. 브라우저 콘솔 cleanup 오류만 제거하는 런타임 패치입니다.

## ⚠️ Risk & Rollback
- 예상 리스크: PDF.js cleanup 중 실제 예외와 정상 종료 rejection이 같은 경로를 공유하므로, 미리보기 종료 시점의 일부 내부 종료 오류는 사용자에게 노출하지 않습니다.
- 롤백 방법: `f04fe3d0` revert 후 배포하면 기존 cleanup 동작으로 돌아갑니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
