### PR TITLE
[Fix] 알림 snapshot polling 연결 종료 완화

### DIFF
--- a/front/e2e/admin-runtime-regressions.spec.ts
+++ b/front/e2e/admin-runtime-regressions.spec.ts
@@ -6,16 +6,19 @@ const readFrontSource = (relativePath: string) =>
   readFileSync(path.resolve(__dirname, "../src", relativePath), "utf8")
 
 test.describe("관리자 런타임 회귀 계약", () => {
-  test("운영 브라우저 API는 로그인과 관리자 요청을 same-origin 백엔드 프록시로 보낸다", () => {
+  test("운영 브라우저 API는 로그인과 관리자 요청, 알림 snapshot을 same-origin 백엔드 프록시로 보낸다", () => {
     const clientSource = readFrontSource("apis/backend/client.ts")
+    const notificationsSource = readFrontSource("apis/backend/notifications.ts")
     const proxySourcePath = path.resolve(__dirname, "../src/pages/api/backend/[...path].ts")
 
     expect(clientSource).toContain('const BROWSER_BACKEND_PROXY_PREFIX = "/api/backend"')
     expect(clientSource).toContain("const shouldUseBrowserBackendProxy = (safePath: string) =>")
     expect(clientSource).toContain('process.env.NODE_ENV === "production"')
     expect(clientSource).toContain("safePath.startsWith(\"/member/api/v1/auth/\")")
+    expect(clientSource).toContain("safePath.startsWith(\"/member/api/v1/notifications/snapshot\")")
     expect(clientSource).toContain("safePath.startsWith(\"/system/api/v1/adm/\")")
     expect(clientSource).toContain("return `${BROWSER_BACKEND_PROXY_PREFIX}${safePath}`")
+    expect(notificationsSource).toContain("return new URL(NOTIFICATIONS_STREAM_API_PATH, `${apiBaseUrl}/`).toString()")
 
     expect(existsSync(proxySourcePath)).toBe(true)
     const proxySource = readFileSync(proxySourcePath, "utf8")

--- a/front/src/apis/backend/client.ts
+++ b/front/src/apis/backend/client.ts
@@ -348,6 +348,7 @@ const shouldUseBrowserBackendProxy = (safePath: string) => {
 
   return (
     safePath.startsWith("/member/api/v1/auth/") ||
+    safePath.startsWith("/member/api/v1/notifications/snapshot") ||
     safePath.startsWith("/member/api/v1/adm/") ||
     safePath.startsWith("/post/api/v1/adm/") ||
     safePath.startsWith("/system/api/v1/adm/") ||


### PR DESCRIPTION
## 관련 이슈

close #783

## 작업 배경

- 운영 브라우저에서 알림 snapshot polling이 `https://api.aquilaxk.site/member/api/v1/notifications/snapshot`을 직접 호출하며 `net::ERR_CONNECTION_CLOSED`가 주기적으로 노출되었습니다.
- 직접 확인 시 같은 snapshot 경로에서 Cloudflare 502와 정상 401 JSON이 간헐적으로 섞였고, health/post/unread-count API는 같은 시점에 정상 응답했습니다.
- SSE stream은 별도 `/member/api/v1/notifications/stream` 경로이므로, stream 직접 연결 계약은 유지하고 짧은 snapshot GET만 same-origin backend proxy로 이동합니다.

## 작업 내용

- production browser runtime에서 `/member/api/v1/notifications/snapshot`을 `/api/backend/...` same-origin proxy allowlist에 추가했습니다.
- notification stream URL은 기존처럼 `NEXT_PUBLIC_BACKEND_URL` 기반 절대 API 오리진으로 조립되는 계약을 테스트에 고정했습니다.
- 관리자 런타임 회귀 테스트에 notification snapshot proxy 계약을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front install --frozen-lockfile` 통과
  - `yarn --cwd front playwright:preflight` 통과
  - RED 확인: `yarn --cwd front playwright test e2e/admin-runtime-regressions.spec.ts --workers=1` 실패 확인 (`notifications/snapshot` proxy allowlist 누락)
  - GREEN 확인: `yarn --cwd front playwright test e2e/admin-runtime-regressions.spec.ts --workers=1` 통과, 6 passed
  - `yarn --cwd front test:e2e:smoke` 통과, 59 passed
  - `yarn --cwd front build` 통과
  - `yarn --cwd front check:bundle-size` 통과
  - `git diff --check` 통과
  - PR checks 통과: backend-ci, frontend-ci, Security(CodeQL/dependency-check), Vercel preview
  - CodeRabbit: rate limit으로 실제 리뷰 미실행 확인
  - CodexReview fallback: `Actionable comments posted: 0` PR review 게시 완료

## 리뷰어 메모

- `front/src/apis/backend/client.ts`의 production browser proxy allowlist에 snapshot만 추가했습니다.
- `front/src/apis/backend/notifications.ts`는 수정하지 않았고, stream direct 연결 계약은 테스트로만 고정했습니다.

## 리스크

- snapshot 요청 URL이 same-origin `/api/backend`로 바뀌어 브라우저 콘솔의 직접 API 오리진 연결 종료 노출은 줄어듭니다.
- backend proxy 자체가 upstream 장애를 받으면 JSON 502/504로 정리되며, 기존 stale-if-error/backoff 흐름은 유지됩니다.
- 배포 후 실제 페이지 Network에서 snapshot URL과 stream URL을 다시 확인해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
