### PR TITLE
[Fix] 관리자 클라우드 파일 뷰어와 업로드 UX 개선

### DIFF
--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -54,6 +54,17 @@ const CLOUD_FILES: CloudFileFixture[] = [
     createdAt: "2026-06-12T11:00:00Z",
     modifiedAt: "2026-06-12T11:00:00Z",
   },
+  {
+    id: 104,
+    ownerMemberId: 1,
+    originalFilename: "[첨부1] NCS기반 채용 직무설명자료_2026년 제3회 식약처 공무원(일반직) 경력경쟁채용시험 공고문_게시.pdf",
+    contentType: "application/pdf",
+    byteSize: 1_004_544,
+    mediaKind: "DOCUMENT",
+    folderPath: "/",
+    createdAt: "2026-06-13T02:20:00Z",
+    modifiedAt: "2026-06-13T02:20:00Z",
+  },
 ]
 
 const pixelPng = Buffer.from(
@@ -90,11 +101,23 @@ const getUploadFileMetadata = (name: string) => {
 
 const normalizeFolderPathParam = (value: string) => value.trim().replace(/^\/+|\/+$/g, "")
 
+const expectPdfPreviewFitsDetailPanel = async (page: Page, previewName: string | RegExp) => {
+  await expect
+    .poll(async () => {
+      const detailPanelBox = await page.getByLabel("클라우드 상세정보").boundingBox()
+      const pdfCanvasBox = await page.getByLabel(previewName).boundingBox()
+      if (!detailPanelBox || !pdfCanvasBox) return false
+      return pdfCanvasBox.width <= detailPanelBox.width
+    })
+    .toBe(true)
+}
+
 const setupAdminCloudMocks = async (
   page: Page,
   options: {
     failDeleteIds?: string[]
     failList?: boolean
+    failUploadOnceNames?: string[]
     failUploadNames?: string[]
     initialFiles?: CloudFileFixture[]
   } = {}
@@ -106,6 +129,7 @@ const setupAdminCloudMocks = async (
   const uploadedFiles: CloudFileFixture[] = []
   const failedDeleteIds = new Set(options.failDeleteIds ?? [])
   const failedUploadNames = new Set(options.failUploadNames ?? [])
+  const failUploadOnceNames = new Set(options.failUploadOnceNames ?? [])
   const initialFiles = options.initialFiles ?? CLOUD_FILES
   let nextUploadId = 204
 
@@ -155,7 +179,8 @@ const setupAdminCloudMocks = async (
       const uploadedName = getUploadName(route)
       const metadata = getUploadFileMetadata(uploadedName)
 
-      if (failedUploadNames.has(uploadedName)) {
+      if (failedUploadNames.has(uploadedName) || failUploadOnceNames.has(uploadedName)) {
+        failUploadOnceNames.delete(uploadedName)
         await fulfillJson(route, { resultCode: "500-1", msg: "외장 스토리지 저장에 실패했습니다." }, 500)
         return
       }
@@ -253,6 +278,8 @@ test.describe("관리자 클라우드", () => {
     await expect(page.getByText("표시할 파일이 없습니다.")).toHaveCount(0)
     await expect(page.getByText("계정 소유주만 볼 수 있음").first()).toBeVisible()
     await expect(page.getByRole("button", { name: "운영 점검 리포트.pdf 즐겨찾기 (준비 중)" })).toBeDisabled()
+    await expect(page.getByText("문", { exact: true })).toHaveCount(0)
+    await expect(page.getByText("PDF").first()).toBeVisible()
 
     const searchInput = page.getByLabel("클라우드 파일 검색")
     await searchInput.fill("/photos")
@@ -298,6 +325,7 @@ test.describe("관리자 클라우드", () => {
       expect.arrayContaining(["신규 운영 문서.pdf", "배포 캡처.png"])
     )
     await expect(uploadPanel.getByText("완료").first()).toBeVisible()
+    await expect(page.getByText("신규 운영 문서.pdf 업로드 완료")).toHaveCount(0)
     await expect(page.getByRole("row", { name: /신규 운영 문서\.pdf/ })).toBeVisible()
     await expect(page.getByRole("row", { name: /배포 캡처\.png/ })).toBeVisible()
 
@@ -316,6 +344,7 @@ test.describe("관리자 클라우드", () => {
     await page.getByRole("button", { name: "운영 점검 리포트.pdf 미리보기" }).click()
     await expect(page.getByRole("heading", { name: "문서 뷰어" })).toBeVisible()
     await expect(page.getByText("PDF.js canvas 렌더링")).toBeVisible()
+    await expectPdfPreviewFitsDetailPanel(page, "운영 점검 리포트.pdf PDF 미리보기")
     await page.getByRole("button", { name: "상세 패널 닫기" }).click()
     await expect(page.getByLabel("클라우드 상세정보").getByText("파일 선택")).toBeVisible()
     await page.getByRole("button", { name: "상세 패널 보기" }).click()
@@ -336,6 +365,39 @@ test.describe("관리자 클라우드", () => {
 
     await page.getByRole("button", { name: "deploy-walkthrough.mp4 삭제" }).click()
     await expect.poll(() => mocks.deletedIds).toContain("103")
+  })
+
+  test("긴 파일명과 업로드 완료 상태는 목록과 하단 업로드 패널에서 겹치지 않는다", async ({ page }) => {
+    await setupAdminCloudMocks(page, { initialFiles: CLOUD_FILES })
+
+    await page.goto("/admin/cloud")
+
+    const longFileRow = page.getByRole("row", { name: /NCS기반 채용 직무설명자료.*게시\.pdf/ })
+    await expect(longFileRow).toBeVisible()
+    const longFileName = longFileRow.locator('button[title$="게시.pdf"]')
+    await expect(longFileName).toHaveAttribute("title", /게시\.pdf$/)
+    await expect(longFileRow.getByLabel("문서")).toHaveText("PDF")
+
+    await longFileRow.getByRole("button", { name: /미리보기/ }).click()
+    await expect(page.getByRole("heading", { name: "문서 뷰어" })).toBeVisible()
+    await expectPdfPreviewFitsDetailPanel(page, /NCS기반 채용 직무설명자료.*PDF 미리보기/)
+
+    await page.getByLabel("클라우드 파일 업로드").setInputFiles({
+      name: "★2026년 제3회 식약처 공무원(일반직) 경력경쟁채용시험 공고문_게시_긴파일명_상태겹침방지.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4 long upload"),
+    })
+
+    const uploadPanel = page.getByLabel("업로드 중인 파일")
+    await expect(uploadPanel.getByText(/상태겹침방지\.pdf/)).toBeVisible()
+    const donePill = uploadPanel.getByText("완료", { exact: true })
+    await expect(donePill).toBeVisible()
+    await expect(page.getByText(/상태겹침방지\.pdf 업로드 완료/)).toHaveCount(0)
+    const queueItemBox = await uploadPanel.getByText(/상태겹침방지\.pdf/).boundingBox()
+    const donePillBox = await donePill.boundingBox()
+    expect(queueItemBox).not.toBeNull()
+    expect(donePillBox).not.toBeNull()
+    expect(queueItemBox!.x + queueItemBox!.width).toBeLessThanOrEqual(donePillBox!.x + 2)
   })
 
   test("선택 삭제 일부 실패 시 성공 항목만 목록에서 제거하고 실패 알림을 유지한다", async ({ page }) => {
@@ -407,5 +469,29 @@ test.describe("관리자 클라우드", () => {
     await expect(uploadPanel.getByRole("heading", { name: "항목 1개 업로드 실패/취소" })).toBeVisible()
     await expect(uploadPanel.getByText(/서버 오류가 발생했습니다/)).toBeVisible()
     await expect(uploadPanel.getByRole("button", { name: "실패할 운영 문서.pdf 업로드 다시 시도" })).toBeVisible()
+  })
+
+  test("업로드 재시도 성공 시 이전 실패 알림은 작업 영역에 남지 않는다", async ({ page }) => {
+    await setupAdminCloudMocks(page, {
+      failUploadOnceNames: ["재시도 성공 문서.pdf"],
+      initialFiles: [],
+    })
+
+    await page.goto("/admin/cloud")
+
+    await page.getByLabel("클라우드 파일 업로드").setInputFiles({
+      name: "재시도 성공 문서.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4 retry upload"),
+    })
+
+    const uploadPanel = page.getByLabel("업로드 중인 파일")
+    await expect(page.getByText(/재시도 성공 문서\.pdf 업로드 실패/)).toBeVisible()
+    await uploadPanel.getByRole("button", { name: "재시도 성공 문서.pdf 업로드 다시 시도" }).click()
+
+    await expect(uploadPanel.getByText("완료", { exact: true })).toBeVisible()
+    await expect(page.getByText(/재시도 성공 문서\.pdf 업로드 실패/)).toHaveCount(0)
+    await expect(page.getByText("재시도 성공 문서.pdf 업로드 완료")).toHaveCount(0)
+    await expect(page.getByRole("row", { name: /재시도 성공 문서\.pdf/ })).toBeVisible()
   })
 })

--- a/front/src/routes/Admin/AdminCloudUploadQueue.tsx
+++ b/front/src/routes/Admin/AdminCloudUploadQueue.tsx
@@ -66,7 +66,7 @@ const AdminCloudUploadQueue = ({
       <QueueList>
         {uploadQueue.map((item) => (
           <QueueItem key={item.id}>
-            <div>
+            <div title={item.name}>
               <strong>{item.name}</strong>
               <p>
                 {formatCloudFileSize(item.byteSize)} · {item.message}

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -218,8 +218,9 @@ export const SearchDetail = styled.span`
 `
 
 export const ActionBar = styled.div`
-  display: flex;
-  align-items: center;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
   justify-content: space-between;
   gap: 0.8rem;
   min-width: 0;
@@ -227,8 +228,7 @@ export const ActionBar = styled.div`
   border-bottom: 1px solid ${border};
 
   @media (max-width: 760px) {
-    align-items: stretch;
-    flex-direction: column;
+    grid-template-columns: minmax(0, 1fr);
   }
 `
 
@@ -238,6 +238,16 @@ export const ActionGroup = styled.div`
   gap: 0.45rem;
   min-width: 0;
   flex-wrap: wrap;
+
+  &[data-align="end"] {
+    justify-content: flex-end;
+  }
+
+  @media (max-width: 760px) {
+    &[data-align="end"] {
+      justify-content: flex-start;
+    }
+  }
 `
 
 export const UploadInput = styled.input`
@@ -362,8 +372,9 @@ export const FileTableScroll = styled.div`
 
 export const FileTable = styled.table`
   width: 100%;
-  min-width: 46rem;
+  min-width: 50rem;
   border-collapse: collapse;
+  table-layout: fixed;
   color: ${textPrimary};
 
   th,
@@ -397,6 +408,33 @@ export const FileTable = styled.table`
   tbody tr:hover {
     background: ${surfaceMuted};
   }
+
+  th:nth-of-type(1),
+  th:nth-of-type(2),
+  td:nth-of-type(1),
+  td:nth-of-type(2) {
+    width: 2.65rem;
+  }
+
+  th:nth-of-type(3),
+  td:nth-of-type(3) {
+    width: 4.2rem;
+  }
+
+  th:nth-of-type(5),
+  td:nth-of-type(5) {
+    width: 5.6rem;
+  }
+
+  th:nth-of-type(6),
+  td:nth-of-type(6) {
+    width: 8.9rem;
+  }
+
+  th:nth-of-type(7),
+  td:nth-of-type(7) {
+    width: 5.8rem;
+  }
 `
 
 export const SelectBoxCell = styled.td`
@@ -420,15 +458,17 @@ export const FavoriteButton = styled.button`
 `
 
 export const FileTypeIcon = styled.span`
-  width: 1.45rem;
-  height: 1.2rem;
-  display: inline-grid;
-  place-items: center;
+  min-width: 2.25rem;
+  height: 1.38rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 4px;
   background: ${surfaceAccent};
   color: ${accentGold};
-  font-size: 0.63rem;
+  font-size: 0.66rem;
   font-weight: 900;
+  letter-spacing: 0;
 `
 
 export const FileNameButton = styled.button`
@@ -436,7 +476,6 @@ export const FileNameButton = styled.button`
   padding: 0;
   display: inline-flex;
   align-items: center;
-  gap: 0.52rem;
   min-width: 0;
   max-width: 100%;
   background: transparent;
@@ -447,8 +486,20 @@ export const FileNameButton = styled.button`
   text-align: left;
 
   strong {
+    display: inline-flex;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  [data-filename-stem] {
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  [data-filename-extension] {
+    flex: 0 0 auto;
     white-space: nowrap;
   }
 `
@@ -532,11 +583,11 @@ export const DetailTab = styled.button`
 
 export const DetailPreviewBox = styled.div`
   display: grid;
-  place-items: center;
+  align-items: start;
   min-height: 12.5rem;
   border-radius: 2px;
   background: ${surfaceMuted};
-  overflow: hidden;
+  overflow: auto;
 `
 
 export const DetailMetaList = styled.dl`
@@ -586,14 +637,19 @@ export const PreviewStage = styled.div`
   width: 100%;
   min-height: 12rem;
   align-content: start;
+  min-width: 0;
 `
 
 export const PdfCanvas = styled.canvas`
   width: 100%;
-  max-height: 18rem;
+  height: auto;
+  max-width: 100%;
+  max-height: min(52vh, 34rem);
+  display: block;
   border: 1px solid ${border};
   border-radius: 8px;
   background: ${surfaceRaised};
+  object-fit: contain;
 `
 
 export const PhotoFrame = styled.div`
@@ -720,7 +776,7 @@ export const QueueList = styled.ul`
 
 export const QueueItem = styled.li`
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-columns: minmax(0, 1fr) minmax(3.7rem, auto) auto;
   gap: 0.5rem 0.75rem;
   align-items: center;
   min-width: 0;
@@ -730,6 +786,7 @@ export const QueueItem = styled.li`
   background: ${surface};
 
   strong {
+    display: block;
     color: ${textPrimary};
     font-size: 0.8rem;
     font-weight: 820;
@@ -757,14 +814,16 @@ export const QueueItem = styled.li`
 
 export const StatusPill = styled.span`
   justify-self: end;
-  min-width: 4.2rem;
+  min-width: 3.55rem;
+  max-width: 5.6rem;
   border-radius: 999px;
-  padding: 0.22rem 0.48rem;
+  padding: 0.22rem 0.45rem;
   background: ${surfaceAccent};
   color: ${accentGold};
   font-size: 0.7rem;
   font-weight: 850;
   text-align: center;
+  white-space: nowrap;
 
   &[data-status="failed"] {
     background: ${({ theme }) => theme.colors.statusDangerSurface};

--- a/front/src/routes/Admin/AdminCloudWorkspaceModel.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspaceModel.ts
@@ -48,15 +48,34 @@ export const getCloudKindLabel = (kind: CloudMediaFilter) => {
 }
 
 export const getCloudKindBadge = (file: CloudFile) => {
-  if (file.mediaKind === "DOCUMENT") return "PDF"
+  const extension = getCloudFileExtension(file.originalFilename)
+  if (file.mediaKind === "DOCUMENT") return extension || "DOC"
   if (file.mediaKind === "PHOTO") return "IMG"
   return "MP4"
 }
 
 export const getCloudKindIconLabel = (file: CloudFile) => {
-  if (file.mediaKind === "DOCUMENT") return "문"
-  if (file.mediaKind === "PHOTO") return "사"
-  return "동"
+  return getCloudKindBadge(file)
+}
+
+export const getCloudFileExtension = (filename: string) => {
+  const trimmed = filename.trim()
+  const extension = trimmed.includes(".") ? trimmed.split(".").pop() : ""
+  const normalized = extension?.replace(/[^A-Za-z0-9]+/g, "").toUpperCase() ?? ""
+  return normalized.slice(0, 4)
+}
+
+export const getCloudFilenameParts = (filename: string) => {
+  const trimmed = filename.trim()
+  const dotIndex = trimmed.lastIndexOf(".")
+  if (dotIndex <= 0 || dotIndex === trimmed.length - 1) {
+    return { stem: trimmed || "이름 없는 파일", extension: "" }
+  }
+
+  return {
+    stem: trimmed.slice(0, dotIndex),
+    extension: trimmed.slice(dotIndex),
+  }
 }
 
 export const formatCloudFileSize = (bytes: number) => {

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -19,6 +19,7 @@ import {
   doesCloudFileMatchFilters,
   formatCloudDate,
   formatCloudFileSize,
+  getCloudFilenameParts,
   getCloudKindBadge,
   getCloudKindIconLabel,
   getCloudKindLabel,
@@ -105,14 +106,29 @@ const resolveCloudErrorMessage = (error: unknown) => {
   return "요청 처리 중 오류가 발생했습니다."
 }
 
+const suppressPdfWorkerTerminationRejection = () => {
+  const handleCleanupRejection = (event: PromiseRejectionEvent) => {
+    if (!(event.reason instanceof Error)) return
+    if (!event.reason.message.includes("Worker was terminated")) return
+
+    event.preventDefault()
+  }
+
+  window.addEventListener("unhandledrejection", handleCleanupRejection)
+  window.setTimeout(() => {
+    window.removeEventListener("unhandledrejection", handleCleanupRejection)
+  }, 1000)
+}
+
 const ignorePdfPreviewTeardownRejection = (task: PDFDocumentLoadingTask | null) => {
   if (!task) return
 
   void task.promise.catch(() => {
-    // 미리보기 cleanup에서 PDF.js worker를 의도적으로 종료하면 reject가 발생할 수 있다.
+    // 미리보기 전환 중 PDF 로딩이 늦게 실패할 수 있으므로 cleanup 경로에서 reject를 소비한다.
   })
+  suppressPdfWorkerTerminationRejection()
   void task.destroy().catch(() => {
-    // 미리보기 cleanup에서 PDF.js worker를 의도적으로 종료하면 reject가 발생할 수 있다.
+    // cleanup에서 PDF.js worker/download를 종료할 때 발생하는 reject도 사용자에게 노출하지 않는다.
   })
 }
 
@@ -155,13 +171,16 @@ const PdfPreview = ({ file, contentUrl }: PdfPreviewProps) => {
         const outputScale = window.devicePixelRatio || 1
         canvas.width = Math.floor(viewport.width * outputScale)
         canvas.height = Math.floor(viewport.height * outputScale)
-        canvas.style.width = `${Math.floor(viewport.width)}px`
-        canvas.style.height = `${Math.floor(viewport.height)}px`
+        canvas.style.width = "100%"
+        canvas.style.height = "auto"
         renderTask = page.render({
           canvas,
           canvasContext: context,
           viewport,
           transform: outputScale !== 1 ? [outputScale, 0, 0, outputScale, 0, 0] : undefined,
+        })
+        void renderTask.promise.catch(() => {
+          // 파일 전환/패널 닫기 중 render task 취소가 pageerror로 번지는 것을 막는다.
         })
         await renderTask.promise
         if (!cancelled) setRenderState("PDF.js canvas 렌더링")
@@ -379,7 +398,9 @@ const AdminCloudWorkspacePage = () => {
         })
         setIsDetailPanelOpen(true)
         setSelectedFileId(uploaded.id)
-        setNotice(`${uploaded.originalFilename} 업로드 완료`)
+        setNotice((current) =>
+          current.includes(nextUpload.name) && /업로드 (실패|취소)/.test(current) ? "" : current
+        )
         setUploadQueue((current) =>
           current.map((item) =>
             item.id === nextUpload.id && item.status !== "cancelled"
@@ -423,7 +444,6 @@ const AdminCloudWorkspacePage = () => {
     if (selectedFiles.length === 0) return
 
     setUploadQueue((current) => [...current, ...selectedFiles.map(createUploadQueueItem)])
-    setNotice(`${selectedFiles.length}개 파일을 업로드 큐에 추가했습니다.`)
     event.currentTarget.value = ""
   }
 
@@ -597,7 +617,7 @@ const AdminCloudWorkspacePage = () => {
               </SecondaryButton>
             </ActionGroup>
 
-            <ActionGroup>
+            <ActionGroup data-align="end">
               {notice ? <Notice>{notice}</Notice> : null}
               <FilterGroup aria-label="파일 종류 필터">
                 {CLOUD_FILTERS.map((item) => (
@@ -674,6 +694,7 @@ const AdminCloudWorkspacePage = () => {
                   {files.map((file) => {
                     const checked = checkedFileIds.includes(file.id)
                     const selected = selectedFile?.id === file.id
+                    const filenameParts = getCloudFilenameParts(file.originalFilename)
                     return (
                       <tr key={file.id} data-selected={selected ? "true" : "false"}>
                         <SelectBoxCell>
@@ -699,8 +720,15 @@ const AdminCloudWorkspacePage = () => {
                           </FileTypeIcon>
                         </td>
                         <td>
-                          <FileNameButton type="button" onClick={() => handlePreviewFile(file.id)}>
-                            <strong>{file.originalFilename}</strong>
+                          <FileNameButton
+                            type="button"
+                            title={file.originalFilename}
+                            onClick={() => handlePreviewFile(file.id)}
+                          >
+                            <strong>
+                              <span data-filename-stem>{filenameParts.stem}</span>
+                              <span data-filename-extension>{filenameParts.extension}</span>
+                            </strong>
                           </FileNameButton>
                         </td>
                         <td>{formatCloudFileSize(file.byteSize)}</td>


### PR DESCRIPTION
## 관련 이슈

close #788

## 변경 요약

- 관리자 클라우드 파일 목록에서 긴 파일명을 stem/extension으로 분리해 확장자는 보존하고 본문만 자연스럽게 말줄임 처리했습니다.
- 문서 종류 배지를 실제 확장자(PDF/DOC/HWP 등) 기준으로 표시해 `문`처럼 잘린 라벨이 보이지 않도록 정리했습니다.
- PDF 미리보기 canvas를 우측 상세 패널 너비 안에서 `contain` 렌더링하도록 바꿔 이미지가 잘리는 문제를 줄였습니다.
- 툴바를 좌측 작업 그룹과 우측 필터/보기 그룹으로 나눠 MYBOX/GDrive에 가까운 배치로 정렬했습니다.
- 업로드 완료 메시지는 하단 업로드 패널에만 남기고 중앙 상태 문구에서는 제거했습니다.
- 업로드 패널의 긴 파일명이 `완료` 상태 배지를 덮지 않도록 grid 컬럼을 고정했습니다.

## 검증

- `yarn --cwd front playwright:preflight`
- `yarn --cwd front playwright test e2e/admin-cloud.spec.ts --workers=1`
- `yarn --cwd front build`
- `git diff --check`

## 화면 확인

- Browser로 `http://127.0.0.1:3000/admin/cloud` 진입과 콘솔 상태를 확인했습니다.
- 파일 데이터가 필요한 긴 파일명/PDF/업로드 패널 상태는 `front/e2e/admin-cloud.spec.ts`의 mock-data 시나리오로 검증했습니다.

## 리스크

- 클라우드 파일 API 계약은 변경하지 않았고, 프론트 표시/레이아웃/미리보기 렌더링만 수정했습니다.
- PDF.js worker 종료 시점의 비동기 rejection은 preview 전환 중 사용자에게 노출되지 않도록 처리했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 파일명에 마우스를 올렸을 때 전체 파일명을 툴팁으로 표시
  * 파일 확장자를 더욱 명확하게 표시

* **Bug Fixes**
  * PDF 미리보기 렌더링 개선
  * 긴 파일명으로 인한 UI 요소 겹침 방지

* **Style**
  * 클라우드 파일 목록 레이아웃 및 테이블 너비 최적화
  * 모바일 기기에서의 반응형 디자인 개선

* **Tests**
  * 관리자 클라우드 화면 검증 강화
  * 긴 파일명 및 레이아웃 상호작용 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->