### PR TITLE
[Fix] 글작성 진입 화면 정렬과 temp draft 403 복구

### DIFF
--- a/front/e2e/admin-runtime-regressions.spec.ts
+++ b/front/e2e/admin-runtime-regressions.spec.ts
@@ -6,9 +6,10 @@ const readFrontSource = (relativePath: string) =>
   readFileSync(path.resolve(__dirname, "../src", relativePath), "utf8")
 
 test.describe("관리자 런타임 회귀 계약", () => {
-  test("운영 브라우저 API는 로그인과 관리자 요청, 알림 snapshot을 same-origin 백엔드 프록시로 보낸다", () => {
+  test("운영 브라우저 API는 로그인과 관리자 요청, 알림 snapshot, 작성 temp draft를 same-origin 백엔드 프록시로 보낸다", () => {
     const clientSource = readFrontSource("apis/backend/client.ts")
     const notificationsSource = readFrontSource("apis/backend/notifications.ts")
+    const editorRootModelSource = readFrontSource("routes/Admin/EditorStudioWorkspaceControllerRootModel.ts")
     const proxySourcePath = path.resolve(__dirname, "../src/pages/api/backend/[...path].ts")
 
     expect(clientSource).toContain('const BROWSER_BACKEND_PROXY_PREFIX = "/api/backend"')
@@ -16,9 +17,14 @@ test.describe("관리자 런타임 회귀 계약", () => {
     expect(clientSource).toContain('process.env.NODE_ENV === "production"')
     expect(clientSource).toContain("safePath.startsWith(\"/member/api/v1/auth/\")")
     expect(clientSource).toContain("safePath.startsWith(\"/member/api/v1/notifications/snapshot\")")
+    expect(clientSource).toContain("safePath.startsWith(\"/post/api/v1/posts/temp\")")
     expect(clientSource).toContain("safePath.startsWith(\"/system/api/v1/adm/\")")
     expect(clientSource).toContain("return `${BROWSER_BACKEND_PROXY_PREFIX}${safePath}`")
     expect(notificationsSource).toContain("return new URL(NOTIFICATIONS_STREAM_API_PATH, `${apiBaseUrl}/`).toString()")
+    expect(editorRootModelSource).toContain('import { getApiRequestUrl } from "src/apis/backend/client"')
+    expect(editorRootModelSource).toContain('fetch(getApiRequestUrl("/post/api/v1/posts/temp"), {')
+    expect(editorRootModelSource).toContain('"X-Aquila-CSRF": "1"')
+    expect(editorRootModelSource).not.toContain('fetch(`${getApiBaseUrl()}/post/api/v1/posts/temp`, {')
 
     expect(existsSync(proxySourcePath)).toBe(true)
     const proxySource = readFileSync(proxySourcePath, "utf8")

--- a/front/e2e/editor-authoring-markdown-editor.spec.ts
+++ b/front/e2e/editor-authoring-markdown-editor.spec.ts
@@ -271,6 +271,67 @@ test.describe("Markdown editor replacement", () => {
     await expect(preview.getByText("quote at the bottom")).toBeVisible()
   })
 
+  test("split write and preview panes start body text from the same pane-relative point", async ({ page }) => {
+    await page.setViewportSize({ width: 1920, height: 1080 })
+    await routeAuthenticatedEditor(page, "ㄷㄷㄷ")
+
+    await page.goto("/editor/new?source=local-draft")
+
+    await expect(page.getByTestId("markdown-editor-write-pane").locator("textarea")).toBeVisible()
+    await expect(page.getByTestId("markdown-editor-preview-pane").getByText("ㄷㄷㄷ")).toBeVisible()
+
+    const startPointContract = await page.evaluate(() => {
+      const writePane = document.querySelector<HTMLElement>("[data-testid='markdown-editor-write-pane']")
+      const previewPane = document.querySelector<HTMLElement>("[data-testid='markdown-editor-preview-pane']")
+      const textarea = writePane?.querySelector<HTMLTextAreaElement>("textarea")
+      const firstPreviewBlock = previewPane?.querySelector<HTMLElement>(".aq-markdown > :first-child")
+      if (!writePane || !previewPane || !textarea || !firstPreviewBlock) {
+        throw new Error("markdown split pane elements not found")
+      }
+
+      const writePaneRect = writePane.getBoundingClientRect()
+      const previewPaneRect = previewPane.getBoundingClientRect()
+      const textareaRect = textarea.getBoundingClientRect()
+      const textareaStyle = window.getComputedStyle(textarea)
+      const firstPreviewBlockRect = firstPreviewBlock.getBoundingClientRect()
+
+      return {
+        writeStartLeft: textareaRect.left + Number.parseFloat(textareaStyle.paddingLeft) - writePaneRect.left,
+        writeStartTop: textareaRect.top + Number.parseFloat(textareaStyle.paddingTop) - writePaneRect.top,
+        previewStartLeft: firstPreviewBlockRect.left - previewPaneRect.left,
+        previewStartTop: firstPreviewBlockRect.top - previewPaneRect.top,
+      }
+    })
+
+    expect(Math.abs(startPointContract.writeStartLeft - startPointContract.previewStartLeft)).toBeLessThanOrEqual(2)
+    expect(Math.abs(startPointContract.writeStartTop - startPointContract.previewStartTop)).toBeLessThanOrEqual(2)
+  })
+
+  test("dedicated editor top actions stay inside the editor content rail", async ({ page }) => {
+    await page.setViewportSize({ width: 2048, height: 1152 })
+    await routeAuthenticatedEditor(page, "본문이 없습니다.")
+
+    await page.goto("/editor/new?source=local-draft")
+
+    const editor = page.getByTestId("markdown-editor")
+    const exitButton = page.getByRole("button", { name: "← 나가기" })
+    const publishButton = page.getByRole("button", { name: "발행" }).first()
+    await expect(editor).toBeVisible()
+    await expect(exitButton).toBeVisible()
+    await expect(publishButton).toBeVisible()
+
+    const editorBox = await editor.boundingBox()
+    const exitBox = await exitButton.boundingBox()
+    const publishBox = await publishButton.boundingBox()
+    expect(editorBox).not.toBeNull()
+    expect(exitBox).not.toBeNull()
+    expect(publishBox).not.toBeNull()
+    if (!editorBox || !exitBox || !publishBox) return
+
+    expect(exitBox.x).toBeGreaterThanOrEqual(editorBox.x - 2)
+    expect(publishBox.x + publishBox.width).toBeLessThanOrEqual(editorBox.x + editorBox.width + 2)
+  })
+
   test("preview matches supported table markdown for alignment, escaped pipes, and inline cell formatting", async ({
     page,
   }) => {
@@ -485,7 +546,7 @@ test.describe("Markdown editor replacement", () => {
     expect(selectionState.activeInsideWritePane).toBe(true)
   })
 
-  test("split preview uses the same readable width and typography contract as post detail", async ({
+  test("split preview keeps readable width and typography while matching the write start", async ({
     page,
   }) => {
     await routeAuthenticatedEditor(page)
@@ -516,7 +577,7 @@ test.describe("Markdown editor replacement", () => {
     expect(previewContract.articleBackground).not.toBe("rgb(13, 17, 23)")
     expect(previewContract.paddingLeft).toBe("16px")
     expect(previewContract.paddingRight).toBe("16px")
-    expect(previewContract.marginTop).toBe("26.4px")
+    expect(previewContract.marginTop).toBe("0px")
     expect(previewContract.maxWidth).toBe("768px")
     expect(previewContract.fontSize).toBe("17px")
     expect(previewContract.lineHeight).toBe("28px")

--- a/front/src/apis/backend/client.ts
+++ b/front/src/apis/backend/client.ts
@@ -350,6 +350,7 @@ const shouldUseBrowserBackendProxy = (safePath: string) => {
     safePath.startsWith("/member/api/v1/auth/") ||
     safePath.startsWith("/member/api/v1/notifications/snapshot") ||
     safePath.startsWith("/member/api/v1/adm/") ||
+    safePath.startsWith("/post/api/v1/posts/temp") ||
     safePath.startsWith("/post/api/v1/adm/") ||
     safePath.startsWith("/system/api/v1/adm/") ||
     safePath.startsWith("/signup")

--- a/front/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/front/src/components/markdown-editor/MarkdownEditor.tsx
@@ -345,7 +345,6 @@ export const MarkdownEditor = ({
         ) : null}
         {mode !== "write" ? (
           <PreviewPane data-pane="preview" data-testid="markdown-editor-preview-pane">
-            <PreviewHeader>Preview</PreviewHeader>
             <PreviewArticle
               ref={previewScrollRef}
               data-testid="markdown-editor-preview-scroll"
@@ -559,30 +558,24 @@ const PreviewPane = styled.div`
   background: ${({ theme }) => theme.publicDesign.readableSurface};
 `
 
-const PreviewHeader = styled.div`
-  height: 42px;
-  display: flex;
-  align-items: center;
-  padding: 0 1rem;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
-  color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.8rem;
-  font-weight: 700;
-`
-
 const PreviewArticle = styled.article`
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding: 0 1rem 2rem;
+  padding: 16px 1rem 2rem;
   background: ${({ theme }) => theme.publicDesign.readableSurface};
 
   .aq-markdown {
     width: min(100%, var(--article-readable-width, 48rem));
     max-width: var(--article-readable-width, 48rem);
+    margin-top: 0;
     margin-inline: auto;
     color: ${({ theme }) => theme.colors.gray12};
+  }
+
+  .aq-markdown > :first-child {
+    margin-top: 0;
   }
 
   @media (max-width: 980px) {

--- a/front/src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx
+++ b/front/src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx
@@ -40,7 +40,7 @@ export const EditorStudioLoadingState = styled.div `
   }
 `;
 export const EditorStudioDedicatedTopBar = styled.div `
-  width: min(100%, 1600px);
+  width: min(100%, var(--article-readable-width, 48rem));
   margin: 0 auto;
   display: flex;
   align-items: center;
@@ -68,7 +68,7 @@ export const EditorExitAction = styled.button `
   justify-content: center;
   min-height: 42px;
   padding: 0.2rem 0.32rem;
-  margin: -0.2rem -0.32rem;
+  margin: 0;
   border: 0;
   border-radius: 10px;
   background: transparent;

--- a/front/src/routes/Admin/EditorStudioWorkspaceControllerRootModel.ts
+++ b/front/src/routes/Admin/EditorStudioWorkspaceControllerRootModel.ts
@@ -1,5 +1,5 @@
 import type { KeyboardEvent as ReactKeyboardEvent } from "react"
-import { getApiBaseUrl } from "src/apis/backend/client"
+import { getApiRequestUrl } from "src/apis/backend/client"
 import { toCanonicalPostPath } from "src/libs/utils/postPath"
 import {
   applyThumbnailTransformToUrl,
@@ -260,9 +260,12 @@ export const requestTempPostWithConflictRetry = async (
   let lastConflictBody = ""
 
   for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
-    const response = await fetch(`${getApiBaseUrl()}/post/api/v1/posts/temp`, {
+    const response = await fetch(getApiRequestUrl("/post/api/v1/posts/temp"), {
       method: "POST",
       credentials: "include",
+      headers: {
+        "X-Aquila-CSRF": "1",
+      },
     })
 
     if (response.status !== 409) {


### PR DESCRIPTION
## 관련 이슈

close #792

## 작업 배경

- `/editor/new` 진입 화면에서 작성 pane과 미리보기 pane의 본문 시작점이 어긋나 사용자가 같은 줄을 보고 작성하기 어려웠습니다.
- 상단 `나가기`/`발행` 액션이 editor 본문 rail이 아니라 viewport 양끝에 붙어 넓은 화면에서 조작 위치가 과하게 벌어졌습니다.
- temp draft 생성 POST가 운영 브라우저 프록시와 CSRF preflight 헤더를 우회해 `/post/api/v1/posts/temp`에서 403이 날 수 있었습니다.

## 작업 내용

- Markdown split preview의 별도 `Preview` 헤더와 첫 문단 상단 margin을 제거해 작성/미리보기 본문 시작점을 같은 pane-relative 좌표로 맞췄습니다.
- dedicated editor top bar 폭을 article readable rail 기준으로 제한하고, `나가기` 버튼의 음수 margin을 제거했습니다.
- temp draft POST를 `getApiRequestUrl("/post/api/v1/posts/temp")` 경유로 바꾸고 `X-Aquila-CSRF: 1` 헤더를 명시했습니다.
- editor entry 회귀 e2e와 운영 프록시 계약 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright test e2e/editor-authoring-markdown-editor.spec.ts e2e/admin-runtime-regressions.spec.ts --workers=1` 실패 확인: temp proxy, 시작점, top action rail, preview margin 회귀 재현
  - `yarn --cwd front playwright:preflight` 통과
  - `yarn --cwd front playwright test e2e/editor-authoring-markdown-editor.spec.ts e2e/admin-runtime-regressions.spec.ts --workers=1` 31 passed
  - 동일 targeted e2e 재실행 31 passed
  - `yarn --cwd front test:e2e:smoke` 60 passed
  - `yarn --cwd front build` 통과
  - `yarn --cwd front check:bundle-size` OK
  - Browser local check: `http://localhost:3100/editor/new?source=local-draft`는 인증 필요로 `/login` 리다이렉트, console error/warn 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `front/src/components/markdown-editor/MarkdownEditor.tsx`의 preview header 제거와 `.aq-markdown > :first-child` margin override가 editor preview 범위에만 적용되는지
  - `front/src/routes/Admin/EditorStudioWorkspaceControllerRootModel.ts`의 temp draft POST가 409 conflict recovery 흐름은 유지하면서 proxy/CSRF 계약을 만족하는지
  - `front/e2e/editor-authoring-markdown-editor.spec.ts`의 새 좌표 기반 회귀 테스트가 사용자가 신고한 넓은 화면 진입 UI를 방어하는지

## 리스크

- Preview pane 내부에서 별도 `Preview` 라벨이 사라지지만 상단 tab으로 mode는 계속 구분됩니다.
- Browser 직접 검증은 인증 화면에서 막혀 e2e mock 기반 검증으로 editor 본 화면을 확인했습니다. 배포 후 실제 계정 세션에서 `/editor/new`를 다시 확인해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
