### PR TITLE
[Fix] 관리자 클라우드 로딩과 삭제 확인 UI 회귀 수정

### DIFF
--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -161,11 +161,13 @@ const expectElementCenterAligned = async (container: ReturnType<Page["locator"]>
 const setupAdminCloudMocks = async (
   page: Page,
   options: {
+    contentDelayMs?: number
     failDeleteIds?: string[]
     failList?: boolean
     failUploadOnceNames?: string[]
     failUploadNames?: string[]
     initialFiles?: CloudFileFixture[]
+    listDelayMs?: number
   } = {}
 ) => {
   const requestedKinds: string[] = []
@@ -173,6 +175,7 @@ const setupAdminCloudMocks = async (
   const uploadedNames: string[] = []
   const uploadedClientFilenames: string[] = []
   const deletedIds: string[] = []
+  const requestedContentIds: string[] = []
   const uploadedFiles: CloudFileFixture[] = []
   const failedDeleteIds = new Set(options.failDeleteIds ?? [])
   const failedUploadNames = new Set(options.failUploadNames ?? [])
@@ -268,10 +271,12 @@ const setupAdminCloudMocks = async (
     }
 
     if (options.failList) {
+      if (options.listDelayMs) await delay(options.listDelayMs)
       await fulfillJson(route, { resultCode: "500-1", msg: "클라우드 파일 목록 조회에 실패했습니다." }, 500)
       return
     }
 
+    if (options.listDelayMs) await delay(options.listDelayMs)
     requestedKinds.push(mediaKind)
     requestedFolderPaths.push(folderPath)
     const keyword = (url.searchParams.get("kw") || "").toLowerCase()
@@ -288,6 +293,7 @@ const setupAdminCloudMocks = async (
   await page.route("**/system/api/v1/adm/cloud/files/*/content", async (route) => {
     const url = new URL(route.request().url())
     const id = url.pathname.match(/\/files\/(\d+)\/content/)?.[1] ?? ""
+    requestedContentIds.push(id)
     const file = [...uploadedFiles, ...initialFiles].find((item) => String(item.id) === id)
     const contentType = file?.contentType ?? "application/octet-stream"
     const body = contentType === "application/pdf"
@@ -296,6 +302,7 @@ const setupAdminCloudMocks = async (
         ? pixelPng
         : Buffer.from("mock-private-cloud-content")
 
+    if (options.contentDelayMs) await delay(options.contentDelayMs)
     await route.fulfill({
       status: 200,
       contentType,
@@ -307,7 +314,7 @@ const setupAdminCloudMocks = async (
     })
   })
 
-  return { requestedKinds, requestedFolderPaths, uploadedNames, uploadedClientFilenames, deletedIds }
+  return { requestedKinds, requestedFolderPaths, uploadedNames, uploadedClientFilenames, deletedIds, requestedContentIds }
 }
 
 test.describe("관리자 클라우드", () => {
@@ -427,7 +434,67 @@ test.describe("관리자 클라우드", () => {
     await expect(page.getByText("재생 기록 00:00")).toBeVisible()
 
     await page.getByRole("button", { name: "deploy-walkthrough.mp4 삭제" }).click()
+    await expect(page.getByRole("dialog", { name: "파일 삭제" })).toBeVisible()
+    expect(mocks.deletedIds).toEqual([])
+    await page.getByRole("dialog", { name: "파일 삭제" }).getByRole("button", { name: "삭제" }).click()
     await expect.poll(() => mocks.deletedIds).toContain("103")
+  })
+
+  test("목록 로딩 중에도 클라우드 작업공간과 툴바를 유지한다", async ({ page }) => {
+    await setupAdminCloudMocks(page, { listDelayMs: 450 })
+
+    await page.goto("/admin/cloud")
+
+    await expect(page.getByRole("heading", { name: "내 파일" })).toBeVisible()
+    await expect(page.locator('button[aria-label="파일 업로드"]').first()).toBeVisible()
+    await expect(page.getByRole("status", { name: "파일 목록 로딩" })).toBeVisible()
+    await expect(page.getByText("파일을 불러오는 중입니다.")).toHaveCount(0)
+    await expect(page.getByRole("row", { name: /운영 점검 리포트\.pdf/ })).toBeVisible()
+    await expect(page.getByRole("status", { name: "파일 목록 로딩" })).toHaveCount(0)
+  })
+
+  test("사진 선택 시 상세 패널은 이미지 요청과 로딩 상태를 즉시 보여준다", async ({ page }) => {
+    const mocks = await setupAdminCloudMocks(page, { contentDelayMs: 450 })
+
+    await page.goto("/admin/cloud")
+    await page.locator('button[title="home-server-rack.png"]').click()
+
+    await expect(page.getByRole("heading", { name: "사진 보기" })).toBeVisible()
+    await expect(page.getByText("사진을 불러오는 중입니다.")).toBeVisible()
+    await expect.poll(() => mocks.requestedContentIds).toContain("102")
+    await expect(page.getByAltText("home-server-rack.png")).toBeVisible()
+    await expect(page.getByText("사진을 불러오는 중입니다.")).toHaveCount(0)
+  })
+
+  test("삭제 확인 모달은 확인 전 API 호출을 막고 툴바 레이아웃을 유지한다", async ({ page }) => {
+    const mocks = await setupAdminCloudMocks(page, { initialFiles: CLOUD_FILES })
+
+    await page.goto("/admin/cloud")
+
+    const longFileRow = page.getByRole("row", { name: /NCS기반 채용 직무설명자료.*게시\.pdf/ })
+    await expect(longFileRow).toBeVisible()
+    await longFileRow.getByRole("button", { name: /삭제/ }).click()
+
+    const dialog = page.getByRole("dialog", { name: "파일 삭제" })
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByText(/NCS기반 채용 직무설명자료.*게시\.pdf/)).toBeVisible()
+    expect(mocks.deletedIds).toEqual([])
+
+    const uploadButton = page.locator('button[aria-label="파일 업로드"]').first()
+    await expect(uploadButton).toHaveCSS("white-space", "nowrap")
+    const uploadButtonBox = await uploadButton.boundingBox()
+    expect(uploadButtonBox).not.toBeNull()
+    expect(uploadButtonBox!.height).toBeLessThanOrEqual(38)
+
+    await dialog.getByRole("button", { name: "취소" }).click()
+    await expect(dialog).toHaveCount(0)
+    expect(mocks.deletedIds).toEqual([])
+
+    await longFileRow.getByRole("button", { name: /삭제/ }).click()
+    await page.getByRole("dialog", { name: "파일 삭제" }).getByRole("button", { name: "삭제" }).click()
+    await expect.poll(() => mocks.deletedIds).toContain("104")
+    await expect(page.getByRole("status").filter({ hasText: /삭제 완료/ })).toBeVisible()
+    await expect(page.getByRole("row", { name: /NCS기반 채용 직무설명자료.*게시\.pdf/ })).toHaveCount(0)
   })
 
   test("긴 파일명과 업로드 완료 상태는 목록과 하단 업로드 패널에서 겹치지 않는다", async ({ page }) => {
@@ -534,9 +601,12 @@ test.describe("관리자 클라우드", () => {
     await page.getByRole("checkbox", { name: "운영 점검 리포트.pdf 선택" }).check()
     await page.getByRole("checkbox", { name: "home-server-rack.png 선택" }).check()
     await page.getByRole("button", { name: "선택 삭제" }).click()
+    await expect(page.getByRole("dialog", { name: "파일 삭제" })).toBeVisible()
+    expect(mocks.deletedIds).toEqual([])
+    await page.getByRole("dialog", { name: "파일 삭제" }).getByRole("button", { name: "삭제" }).click()
 
     await expect.poll(() => mocks.deletedIds).toContain("101")
-    await expect(page.getByText("1개 삭제 완료, 1개 실패")).toBeVisible()
+    await expect(page.getByRole("status").filter({ hasText: "1개 삭제 완료, 1개 실패" })).toBeVisible()
     await expect(page.getByRole("row", { name: /운영 점검 리포트\.pdf/ })).toHaveCount(0)
     await expect(page.getByRole("row", { name: /home-server-rack\.png/ })).toBeVisible()
     await expect(page.getByRole("checkbox", { name: "home-server-rack.png 선택" })).toBeChecked()

--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -478,6 +478,11 @@ test.describe("관리자 클라우드", () => {
     const dialog = page.getByRole("dialog", { name: "파일 삭제" })
     await expect(dialog).toBeVisible()
     await expect(dialog.getByText(/NCS기반 채용 직무설명자료.*게시\.pdf/)).toBeVisible()
+    await expect(dialog.getByRole("button", { name: "취소" })).toBeFocused()
+    await page.keyboard.press("Tab")
+    await expect(dialog.getByRole("button", { name: "삭제" })).toBeFocused()
+    await page.keyboard.press("Tab")
+    await expect(dialog.getByRole("button", { name: "취소" })).toBeFocused()
     expect(mocks.deletedIds).toEqual([])
 
     const uploadButton = page.locator('button[aria-label="파일 업로드"]').first()
@@ -488,6 +493,12 @@ test.describe("관리자 클라우드", () => {
 
     await dialog.getByRole("button", { name: "취소" }).click()
     await expect(dialog).toHaveCount(0)
+    expect(mocks.deletedIds).toEqual([])
+
+    await longFileRow.getByRole("button", { name: /삭제/ }).click()
+    await expect(page.getByRole("dialog", { name: "파일 삭제" })).toBeVisible()
+    await page.keyboard.press("Escape")
+    await expect(page.getByRole("dialog", { name: "파일 삭제" })).toHaveCount(0)
     expect(mocks.deletedIds).toEqual([])
 
     await longFileRow.getByRole("button", { name: /삭제/ }).click()

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -271,6 +271,7 @@ export const PrimaryButton = styled.button`
   color: ${controlText};
   font-size: 0.84rem;
   font-weight: 850;
+  white-space: nowrap;
   cursor: pointer;
 
   &:disabled {
@@ -297,6 +298,7 @@ export const SecondaryButton = styled.button`
   color: ${textPrimary};
   font-size: 0.83rem;
   font-weight: 820;
+  white-space: nowrap;
   cursor: pointer;
 
   &:disabled {
@@ -361,6 +363,10 @@ export const GhostButton = styled.button`
 
 export const Notice = styled.p`
   margin: 0;
+  max-width: 10rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: ${accentGold};
   font-size: 0.82rem;
   font-weight: 780;
@@ -556,6 +562,15 @@ export const EmptyTableState = styled.div`
   }
 `
 
+export const LoadingTableStatus = styled.div`
+  display: grid;
+  place-items: center;
+  min-height: 12rem;
+  color: ${textMuted};
+  font-size: 0.86rem;
+  font-weight: 800;
+`
+
 export const DetailPanel = styled.aside`
   display: grid;
   align-content: start;
@@ -683,8 +698,22 @@ export const PdfCanvas = styled.canvas`
 `
 
 export const PhotoFrame = styled.div`
+  position: relative;
   display: grid;
+  place-items: center;
   width: 100%;
+  min-height: 12rem;
+
+  > span {
+    position: absolute;
+    z-index: 1;
+    border-radius: 999px;
+    padding: 0.34rem 0.62rem;
+    background: ${surfaceRaised};
+    color: ${textSecondary};
+    font-size: 0.76rem;
+    font-weight: 780;
+  }
 
   img {
     width: 100%;
@@ -692,6 +721,102 @@ export const PhotoFrame = styled.div`
     object-fit: contain;
     border-radius: 8px;
     background: ${surfaceMuted};
+  }
+`
+
+export const ToastViewport = styled.div<{ "data-tone": "success" | "error" }>`
+  position: fixed;
+  right: max(1rem, env(safe-area-inset-right));
+  bottom: max(1rem, env(safe-area-inset-bottom));
+  z-index: ${zIndexes.dialogHoverCard};
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.28rem 0.7rem;
+  align-items: center;
+  width: min(24rem, calc(100vw - 2rem));
+  padding: 0.78rem 0.9rem;
+  border: 1px solid
+    ${({ theme, "data-tone": tone }) =>
+      tone === "error" ? theme.colors.statusDangerBorder : theme.colors.statusSuccessBorder};
+  border-radius: 8px;
+  background: ${surfaceRaised};
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.22);
+
+  strong {
+    color: ${textPrimary};
+    font-size: 0.86rem;
+    font-weight: 850;
+  }
+
+  span {
+    grid-column: 1 / 2;
+    min-width: 0;
+    overflow: hidden;
+    color: ${textMuted};
+    font-size: 0.76rem;
+    font-weight: 720;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  button {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+    border: 0;
+    background: transparent;
+    color: ${textSecondary};
+    font-size: 0.78rem;
+    font-weight: 800;
+    cursor: pointer;
+  }
+`
+
+export const ConfirmBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: ${zIndexes.dialog};
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.46);
+`
+
+export const ConfirmDialog = styled.div`
+  display: grid;
+  gap: 0.95rem;
+  width: min(26rem, 100%);
+  padding: 1.15rem;
+  border: 1px solid ${borderStrong};
+  border-radius: 8px;
+  background: ${surfaceRaised};
+  box-shadow: 0 22px 54px rgba(0, 0, 0, 0.24);
+
+  > strong {
+    color: ${textPrimary};
+    font-size: 1rem;
+    font-weight: 880;
+  }
+
+  p {
+    display: grid;
+    gap: 0.42rem;
+    margin: 0;
+    color: ${textMuted};
+    font-size: 0.82rem;
+    line-height: 1.55;
+    font-weight: 720;
+  }
+
+  p span {
+    color: ${textPrimary};
+    font-weight: 850;
+    overflow-wrap: anywhere;
+  }
+
+  > div {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.45rem;
   }
 `
 

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element -- private cloud content needs browser-owned auth cookies. */
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import type { PDFDocumentLoadingTask, RenderTask } from "pdfjs-dist"
-import { type ChangeEvent, useEffect, useMemo, useRef, useState } from "react"
+import { type ChangeEvent, type KeyboardEvent as ReactKeyboardEvent, useEffect, useMemo, useRef, useState } from "react"
 import {
   deleteCloudFile,
   getCloudFileContentUrl,
@@ -253,10 +253,15 @@ type PhotoPreviewProps = {
 }
 
 const PhotoPreview = ({ file, contentUrl }: PhotoPreviewProps) => {
-  const [isImageReady, setIsImageReady] = useState(false)
+  const imageRef = useRef<HTMLImageElement | null>(null)
+  const [loadedContentUrl, setLoadedContentUrl] = useState<string | null>(null)
+  const isImageReady = loadedContentUrl === contentUrl
 
   useEffect(() => {
-    setIsImageReady(false)
+    const image = imageRef.current
+    if (image?.complete && image.naturalWidth > 0) {
+      setLoadedContentUrl(contentUrl)
+    }
   }, [contentUrl])
 
   return (
@@ -268,12 +273,13 @@ const PhotoPreview = ({ file, contentUrl }: PhotoPreviewProps) => {
       <PhotoFrame aria-busy={isImageReady ? "false" : "true"}>
         {!isImageReady ? <span role="status">사진을 불러오는 중입니다.</span> : null}
         <img
+          ref={imageRef}
           src={contentUrl}
           alt={file.originalFilename}
           decoding="async"
           loading="eager"
-          onLoad={() => setIsImageReady(true)}
-          onError={() => setIsImageReady(true)}
+          onLoad={() => setLoadedContentUrl(contentUrl)}
+          onError={() => setLoadedContentUrl(contentUrl)}
         />
       </PhotoFrame>
     </PreviewStage>
@@ -425,6 +431,9 @@ const AdminCloudWorkspacePage = () => {
   const activeUploadCount = uploadQueue.filter((item) => isUploadActive(item.status)).length
   const completedUploadCount = uploadQueue.filter((item) => item.status === "done").length
   const allVisibleChecked = files.length > 0 && files.every((file) => checkedFileIds.includes(file.id))
+  const deleteDialogRef = useRef<HTMLDivElement | null>(null)
+  const deleteCancelButtonRef = useRef<HTMLButtonElement | null>(null)
+  const previousFocusRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
     if (!isDetailPanelOpen) return
@@ -435,6 +444,36 @@ const AdminCloudWorkspacePage = () => {
   useEffect(() => {
     setCheckedFileIds((current) => current.filter((id) => files.some((file) => file.id === id)))
   }, [files])
+
+  useEffect(() => {
+    if (!deleteConfirm) return
+
+    previousFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const focusFrame = window.requestAnimationFrame(() => {
+      deleteCancelButtonRef.current?.focus()
+    })
+
+    return () => {
+      window.cancelAnimationFrame(focusFrame)
+      previousFocusRef.current?.focus()
+      previousFocusRef.current = null
+    }
+  }, [deleteConfirm])
+
+  useEffect(() => {
+    if (!deleteConfirm) return
+
+    const handleDocumentKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "Escape" || isDeletePending) return
+      event.preventDefault()
+      setDeleteConfirm(null)
+    }
+
+    document.addEventListener("keydown", handleDocumentKeyDown)
+    return () => {
+      document.removeEventListener("keydown", handleDocumentKeyDown)
+    }
+  }, [deleteConfirm, isDeletePending])
 
   useEffect(() => {
     const hasActiveUpload = uploadQueue.some((item) => item.status === "uploading")
@@ -574,6 +613,41 @@ const AdminCloudWorkspacePage = () => {
 
   const handleDelete = (file: CloudFile) => {
     setDeleteConfirm({ files: [file] })
+  }
+
+  const closeDeleteConfirm = () => {
+    if (isDeletePending) return
+    setDeleteConfirm(null)
+  }
+
+  const handleDeleteDialogKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault()
+      closeDeleteConfirm()
+      return
+    }
+
+    if (event.key !== "Tab") return
+
+    const dialog = deleteDialogRef.current
+    if (!dialog) return
+    const focusableElements = Array.from(dialog.querySelectorAll<HTMLElement>("button:not(:disabled)"))
+    if (focusableElements.length === 0) {
+      event.preventDefault()
+      return
+    }
+
+    const firstElement = focusableElements[0]
+    const lastElement = focusableElements[focusableElements.length - 1]
+    if (event.shiftKey && document.activeElement === firstElement) {
+      event.preventDefault()
+      lastElement.focus()
+      return
+    }
+    if (!event.shiftKey && document.activeElement === lastElement) {
+      event.preventDefault()
+      firstElement.focus()
+    }
   }
 
   const performSingleDelete = async (file: CloudFile) => {
@@ -901,13 +975,16 @@ const AdminCloudWorkspacePage = () => {
         </ToastViewport>
       ) : null}
       {deleteConfirm ? (
-        <ConfirmBackdrop role="presentation" onClick={() => (isDeletePending ? undefined : setDeleteConfirm(null))}>
+        <ConfirmBackdrop role="presentation" onClick={closeDeleteConfirm}>
           <ConfirmDialog
+            ref={deleteDialogRef}
             role="dialog"
             aria-modal="true"
             aria-labelledby="cloud-delete-confirm-title"
             aria-describedby="cloud-delete-confirm-description"
+            tabIndex={-1}
             onClick={(event) => event.stopPropagation()}
+            onKeyDown={handleDeleteDialogKeyDown}
           >
             <strong id="cloud-delete-confirm-title">파일 삭제</strong>
             <p id="cloud-delete-confirm-description">
@@ -919,7 +996,12 @@ const AdminCloudWorkspacePage = () => {
               삭제한 파일은 관리자 클라우드 목록에서 제거됩니다.
             </p>
             <div>
-              <SecondaryButton type="button" disabled={isDeletePending} onClick={() => setDeleteConfirm(null)}>
+              <SecondaryButton
+                ref={deleteCancelButtonRef}
+                type="button"
+                disabled={isDeletePending}
+                onClick={closeDeleteConfirm}
+              >
                 취소
               </SecondaryButton>
               <PrimaryButton type="button" disabled={isDeletePending} onClick={() => void handleConfirmDelete()}>

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -38,6 +38,8 @@ import {
   CloudSearchField,
   CloudTitleBar,
   CloudWorkspace,
+  ConfirmBackdrop,
+  ConfirmDialog,
   DetailHeader,
   DetailMetaList,
   DetailPanel,
@@ -55,6 +57,7 @@ import {
   GhostButton,
   IconButton,
   InlineList,
+  LoadingTableStatus,
   Notice,
   PdfCanvas,
   PhotoFrame,
@@ -68,6 +71,7 @@ import {
   SearchInput,
   SecondaryButton,
   SelectBoxCell,
+  ToastViewport,
   Timeline,
   UploadInput,
   VideoFrame,
@@ -248,17 +252,33 @@ type PhotoPreviewProps = {
   contentUrl: string
 }
 
-const PhotoPreview = ({ file, contentUrl }: PhotoPreviewProps) => (
-  <PreviewStage>
-    <PreviewHeader>
-      <h3>사진 보기</h3>
-      <p>{file.originalFilename}</p>
-    </PreviewHeader>
-    <PhotoFrame>
-      <img src={contentUrl} alt={file.originalFilename} />
-    </PhotoFrame>
-  </PreviewStage>
-)
+const PhotoPreview = ({ file, contentUrl }: PhotoPreviewProps) => {
+  const [isImageReady, setIsImageReady] = useState(false)
+
+  useEffect(() => {
+    setIsImageReady(false)
+  }, [contentUrl])
+
+  return (
+    <PreviewStage>
+      <PreviewHeader>
+        <h3>사진 보기</h3>
+        <p>{file.originalFilename}</p>
+      </PreviewHeader>
+      <PhotoFrame aria-busy={isImageReady ? "false" : "true"}>
+        {!isImageReady ? <span role="status">사진을 불러오는 중입니다.</span> : null}
+        <img
+          src={contentUrl}
+          alt={file.originalFilename}
+          decoding="async"
+          loading="eager"
+          onLoad={() => setIsImageReady(true)}
+          onError={() => setIsImageReady(true)}
+        />
+      </PhotoFrame>
+    </PreviewStage>
+  )
+}
 
 type VideoPreviewProps = {
   file: CloudFile
@@ -336,6 +356,31 @@ const PreviewDrawer = ({ file }: PreviewDrawerProps) => {
   return <VideoPreview file={file} contentUrl={contentUrl} />
 }
 
+type DeleteConfirmState = {
+  files: CloudFile[]
+}
+
+type CloudToastState =
+  | {
+      tone: "success" | "error"
+      text: string
+    }
+  | null
+
+const FileTableHead = () => (
+  <thead>
+    <tr>
+      <th aria-label="선택" />
+      <th aria-label="즐겨찾기" />
+      <th>종류</th>
+      <th>이름</th>
+      <th>크기</th>
+      <th>수정한 날짜</th>
+      <th aria-label="작업" />
+    </tr>
+  </thead>
+)
+
 const AdminCloudWorkspacePage = () => {
   const queryClient = useQueryClient()
   const uploadInputRef = useRef<HTMLInputElement>(null)
@@ -345,9 +390,12 @@ const AdminCloudWorkspacePage = () => {
   const [selectedFileId, setSelectedFileId] = useState<number | null>(null)
   const [checkedFileIds, setCheckedFileIds] = useState<number[]>([])
   const [notice, setNotice] = useState("")
+  const [toast, setToast] = useState<CloudToastState>(null)
   const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([])
   const [optimisticFiles, setOptimisticFiles] = useState<CloudFile[]>([])
   const [isDetailPanelOpen, setIsDetailPanelOpen] = useState(true)
+  const [deleteConfirm, setDeleteConfirm] = useState<DeleteConfirmState | null>(null)
+  const [isDeletePending, setIsDeletePending] = useState(false)
 
   const filesQuery = useQuery({
     queryKey: [CLOUD_QUERY_KEY, filter, keyword],
@@ -524,26 +572,27 @@ const AdminCloudWorkspacePage = () => {
     })
   }
 
-  const handleDelete = async (file: CloudFile) => {
+  const handleDelete = (file: CloudFile) => {
+    setDeleteConfirm({ files: [file] })
+  }
+
+  const performSingleDelete = async (file: CloudFile) => {
     try {
       await deleteCloudFile(file.id)
       const deletedIds = new Set([file.id])
-      setNotice(`${file.originalFilename} 삭제 완료`)
+      setToast({ tone: "success", text: `${file.originalFilename} 삭제 완료` })
       setOptimisticFiles((current) => current.filter((item) => item.id !== file.id))
       setCheckedFileIds((current) => current.filter((id) => id !== file.id))
       removeDeletedFilesFromCloudCaches(deletedIds)
       if (selectedFileId === file.id) setSelectedFileId(null)
     } catch {
-      setNotice(`${file.originalFilename} 삭제 실패`)
+      setToast({ tone: "error", text: `${file.originalFilename} 삭제 실패` })
     } finally {
       await queryClient.invalidateQueries({ queryKey: [CLOUD_QUERY_KEY] })
     }
   }
 
-  const handleDeleteSelected = async () => {
-    const targets = files.filter((file) => checkedFileIds.includes(file.id))
-    if (targets.length === 0) return
-
+  const performBulkDelete = async (targets: CloudFile[]) => {
     const results = await Promise.allSettled(
       targets.map(async (file) => {
         await deleteCloudFile(file.id)
@@ -562,15 +611,37 @@ const AdminCloudWorkspacePage = () => {
     }
 
     if (failedCount > 0) {
-      setNotice(
-        deletedIds.size > 0
-          ? `${deletedIds.size}개 삭제 완료, ${failedCount}개 실패`
-          : `${failedCount}개 파일 삭제 실패`
-      )
+      const failureText =
+        deletedIds.size > 0 ? `${deletedIds.size}개 삭제 완료, ${failedCount}개 실패` : `${failedCount}개 파일 삭제 실패`
+      setToast({ tone: "error", text: failureText })
     } else {
-      setNotice(`${deletedIds.size}개 파일 삭제 완료`)
+      const successText = `${deletedIds.size}개 파일 삭제 완료`
+      setToast({ tone: "success", text: successText })
     }
     await queryClient.invalidateQueries({ queryKey: [CLOUD_QUERY_KEY] })
+  }
+
+  const handleDeleteSelected = () => {
+    const targets = files.filter((file) => checkedFileIds.includes(file.id))
+    if (targets.length === 0) return
+
+    setDeleteConfirm({ files: targets })
+  }
+
+  const handleConfirmDelete = async () => {
+    if (!deleteConfirm || isDeletePending) return
+
+    setIsDeletePending(true)
+    try {
+      if (deleteConfirm.files.length === 1) {
+        await performSingleDelete(deleteConfirm.files[0])
+      } else {
+        await performBulkDelete(deleteConfirm.files)
+      }
+      setDeleteConfirm(null)
+    } finally {
+      setIsDeletePending(false)
+    }
   }
 
   const isFileListError = filesQuery.isError
@@ -631,7 +702,7 @@ const AdminCloudWorkspacePage = () => {
               <SecondaryButton type="button" disabled>
                 새로 만들기
               </SecondaryButton>
-              <SecondaryButton type="button" disabled={checkedFileIds.length === 0} onClick={() => void handleDeleteSelected()}>
+              <SecondaryButton type="button" disabled={checkedFileIds.length === 0} onClick={handleDeleteSelected}>
                 선택 삭제
               </SecondaryButton>
             </ActionGroup>
@@ -677,7 +748,20 @@ const AdminCloudWorkspacePage = () => {
           />
 
           <FileTableScroll>
-            {files.length === 0 ? (
+            {files.length === 0 && filesQuery.isLoading ? (
+              <FileTable aria-busy="true">
+                <FileTableHead />
+                <tbody>
+                  <tr>
+                    <td colSpan={7}>
+                      <LoadingTableStatus role="status" aria-label="파일 목록 로딩">
+                        파일 목록 로딩
+                      </LoadingTableStatus>
+                    </td>
+                  </tr>
+                </tbody>
+              </FileTable>
+            ) : files.length === 0 ? (
               <EmptyTableState>
                 <strong>{emptyTitle}</strong>
                 {activeUploadCount > 0 ? null : (
@@ -698,17 +782,7 @@ const AdminCloudWorkspacePage = () => {
               </EmptyTableState>
             ) : (
               <FileTable aria-busy={filesQuery.isFetching ? "true" : "false"}>
-                <thead>
-                  <tr>
-                    <th aria-label="선택" />
-                    <th aria-label="즐겨찾기" />
-                    <th>종류</th>
-                    <th>이름</th>
-                    <th>크기</th>
-                    <th>수정한 날짜</th>
-                    <th aria-label="작업" />
-                  </tr>
-                </thead>
+                <FileTableHead />
                 <tbody>
                   {files.map((file) => {
                     const checked = checkedFileIds.includes(file.id)
@@ -760,7 +834,7 @@ const AdminCloudWorkspacePage = () => {
                             <GhostButton
                               type="button"
                               aria-label={`${file.originalFilename} 삭제`}
-                              onClick={() => void handleDelete(file)}
+                              onClick={() => handleDelete(file)}
                             >
                               <AppIcon name="trash" />
                               삭제
@@ -817,6 +891,44 @@ const AdminCloudWorkspacePage = () => {
           ) : null}
         </DetailPanel>
       </CloudWorkspace>
+      {toast ? (
+        <ToastViewport data-tone={toast.tone} role="status" aria-live="polite">
+          <strong>{toast.tone === "error" ? "작업 실패" : "작업 완료"}</strong>
+          <span>{toast.text}</span>
+          <button type="button" onClick={() => setToast(null)}>
+            닫기
+          </button>
+        </ToastViewport>
+      ) : null}
+      {deleteConfirm ? (
+        <ConfirmBackdrop role="presentation" onClick={() => (isDeletePending ? undefined : setDeleteConfirm(null))}>
+          <ConfirmDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="cloud-delete-confirm-title"
+            aria-describedby="cloud-delete-confirm-description"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <strong id="cloud-delete-confirm-title">파일 삭제</strong>
+            <p id="cloud-delete-confirm-description">
+              <span>
+                {deleteConfirm.files.length === 1
+                  ? deleteConfirm.files[0].originalFilename
+                  : `${deleteConfirm.files.length}개 파일`}
+              </span>
+              삭제한 파일은 관리자 클라우드 목록에서 제거됩니다.
+            </p>
+            <div>
+              <SecondaryButton type="button" disabled={isDeletePending} onClick={() => setDeleteConfirm(null)}>
+                취소
+              </SecondaryButton>
+              <PrimaryButton type="button" disabled={isDeletePending} onClick={() => void handleConfirmDelete()}>
+                삭제
+              </PrimaryButton>
+            </div>
+          </ConfirmDialog>
+        </ConfirmBackdrop>
+      ) : null}
     </CloudMain>
   )
 }


### PR DESCRIPTION
## 관련 이슈

close #796

## 작업 배경

- 관리자 클라우드에서 목록 로딩이 빈 화면처럼 보이고, 사진 선택 직후 상세 패널이 늦게 반응하는 문제가 있었다.
- 긴 파일명 삭제 완료 문구가 툴바 normal flow에 들어가면서 올리기/필터 버튼이 세로로 깨졌다.
- 삭제 확인 UX를 MYBOX/GDrive 계열처럼 중앙 모달 confirm 흐름으로 분리해야 했다.

## 작업 내용

- 파일 목록 로딩 중에는 빈 상태 문구 대신 테이블 구조와 `파일 목록 로딩` status row를 유지한다.
- 사진 preview에 즉시 표시되는 로딩 상태와 eager image load 처리를 추가했다.
- 단일/선택 삭제를 중앙 `파일 삭제` 확인 모달로 전환하고, 확인 전에는 delete API를 호출하지 않게 했다.
- 삭제 결과는 툴바 notice에서 제거하고 하단 toast로 분리해 긴 파일명이 toolbar layout을 깨지 않게 했다.
- Playwright e2e에 로딩/사진 preview/삭제 모달 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight` 통과
  - `yarn --cwd front playwright test e2e/admin-cloud.spec.ts --grep "삭제 확인|사진 선택|목록 로딩"` RED 후 GREEN 통과
  - `yarn --cwd front playwright test e2e/admin-cloud.spec.ts` 12개 통과, 2회 연속 통과
  - `yarn --cwd front build` 통과
  - `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1` 통과
  - Browser plugin 로컬 QA는 in-app Browser의 localhost 접근 정책으로 차단되어 상호작용 검증은 Playwright mock e2e로 대체

## 리뷰어 메모

- `front/src/routes/Admin/AdminCloudWorkspacePage.tsx`의 삭제 confirm 상태 흐름을 먼저 확인하면 된다.
- 삭제 결과 toast는 파일 소유권/권한 계약을 바꾸지 않고 기존 관리자 cloud delete API만 확인 후 호출한다.
- `front/e2e/admin-cloud.spec.ts`의 새 테스트 3개가 이번 회귀를 고정한다.

## 리스크

- 실제 파일 content 응답 자체가 느린 경우 네트워크 시간은 남지만, 사진 선택 직후 요청과 로딩 상태는 즉시 표시된다.
- Browser plugin은 mock routing을 제공하지 않아 실제 UI 검증은 Playwright e2e가 기준이다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 클라우드 워크스페이스 업데이트

* **새 기능**
  * 파일 삭제 시 확인 모달 추가로 실수로 인한 삭제 방지
  * 이미지 미리보기에 로딩 상태 표시 추가
  * 파일 삭제 결과를 토스트 알림으로 안내

* **UI 개선**
  * 버튼 텍스트 줄 바꿈 방지로 레이아웃 안정성 개선
  * 알림창 텍스트 가독성 향상
  * 파일 목록 로딩 중 로딩 상태 시각 표시 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->