### PR TITLE
[Fix] 관리자 클라우드 개별 삭제 제거

### DIFF
--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -433,7 +433,9 @@ test.describe("관리자 클라우드", () => {
     await expect(page.getByRole("button", { name: "자막" })).toBeVisible()
     await expect(page.getByText("재생 기록 00:00")).toBeVisible()
 
-    await page.getByRole("button", { name: "deploy-walkthrough.mp4 삭제" }).click()
+    await expect(page.getByRole("button", { name: "deploy-walkthrough.mp4 삭제" })).toHaveCount(0)
+    await page.getByRole("checkbox", { name: "deploy-walkthrough.mp4 선택" }).check()
+    await page.getByRole("button", { name: "선택 삭제" }).click()
     await expect(page.getByRole("dialog", { name: "파일 삭제" })).toBeVisible()
     expect(mocks.deletedIds).toEqual([])
     await page.getByRole("dialog", { name: "파일 삭제" }).getByRole("button", { name: "삭제" }).click()
@@ -466,14 +468,16 @@ test.describe("관리자 클라우드", () => {
     await expect(page.getByText("사진을 불러오는 중입니다.")).toHaveCount(0)
   })
 
-  test("삭제 확인 모달은 확인 전 API 호출을 막고 툴바 레이아웃을 유지한다", async ({ page }) => {
+  test("개별 삭제 없이 선택 삭제 모달은 확인 전 API 호출을 막고 툴바 레이아웃을 유지한다", async ({ page }) => {
     const mocks = await setupAdminCloudMocks(page, { initialFiles: CLOUD_FILES })
 
     await page.goto("/admin/cloud")
 
     const longFileRow = page.getByRole("row", { name: /NCS기반 채용 직무설명자료.*게시\.pdf/ })
     await expect(longFileRow).toBeVisible()
-    await longFileRow.getByRole("button", { name: /삭제/ }).click()
+    await expect(longFileRow.getByRole("button", { name: /삭제/ })).toHaveCount(0)
+    await longFileRow.getByRole("checkbox", { name: /NCS기반 채용 직무설명자료.*게시\.pdf 선택/ }).check()
+    await page.getByRole("button", { name: "선택 삭제" }).click()
 
     const dialog = page.getByRole("dialog", { name: "파일 삭제" })
     await expect(dialog).toBeVisible()
@@ -495,13 +499,13 @@ test.describe("관리자 클라우드", () => {
     await expect(dialog).toHaveCount(0)
     expect(mocks.deletedIds).toEqual([])
 
-    await longFileRow.getByRole("button", { name: /삭제/ }).click()
+    await page.getByRole("button", { name: "선택 삭제" }).click()
     await expect(page.getByRole("dialog", { name: "파일 삭제" })).toBeVisible()
     await page.keyboard.press("Escape")
     await expect(page.getByRole("dialog", { name: "파일 삭제" })).toHaveCount(0)
     expect(mocks.deletedIds).toEqual([])
 
-    await longFileRow.getByRole("button", { name: /삭제/ }).click()
+    await page.getByRole("button", { name: "선택 삭제" }).click()
     await page.getByRole("dialog", { name: "파일 삭제" }).getByRole("button", { name: "삭제" }).click()
     await expect.poll(() => mocks.deletedIds).toContain("104")
     await expect(page.getByRole("status").filter({ hasText: /삭제 완료/ })).toBeVisible()
@@ -545,7 +549,7 @@ test.describe("관리자 클라우드", () => {
     expect(queueItemBox!.x + queueItemBox!.width).toBeLessThanOrEqual(donePillBox!.x + 2)
   })
 
-  test("선택된 긴 PDF 행은 종류 배지, 파일명 포커스, 삭제 액션이 명확하게 보인다", async ({ page }) => {
+  test("선택된 긴 PDF 행은 종류 배지와 파일명 포커스가 명확하고 개별 삭제를 노출하지 않는다", async ({ page }) => {
     await setupAdminCloudMocks(page, { initialFiles: CLOUD_FILES })
 
     await page.goto("/admin/cloud")
@@ -570,12 +574,7 @@ test.describe("관리자 클라우드", () => {
     await expect(nameButton).toHaveCSS("border-radius", "0px")
 
     await expect(selectedRow.getByRole("button", { name: /미리보기/ })).toHaveCount(0)
-    const deleteButton = selectedRow.getByRole("button", { name: "운영 점검 리포트.pdf 삭제" })
-    await expect(deleteButton).toBeVisible()
-    await expect(deleteButton).toHaveCSS("white-space", "nowrap")
-    const deleteButtonBox = await deleteButton.boundingBox()
-    expect(deleteButtonBox).not.toBeNull()
-    expect(deleteButtonBox!.height).toBeLessThanOrEqual(38)
+    await expect(selectedRow.getByRole("button", { name: "운영 점검 리포트.pdf 삭제" })).toHaveCount(0)
   })
 
   test("관리자 클라우드 진입만으로 알림 snapshot 백그라운드 요청을 시작하지 않는다", async ({ page }) => {

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -438,11 +438,6 @@ export const FileTable = styled.table`
   td:nth-of-type(6) {
     width: 8.9rem;
   }
-
-  th:nth-of-type(7),
-  td:nth-of-type(7) {
-    width: 5.6rem;
-  }
 `
 
 export const SelectBoxCell = styled.td`
@@ -533,17 +528,6 @@ export const FileNameButton = styled.button`
     text-decoration-thickness: 2px;
     text-underline-offset: 0.22rem;
     color: ${accentGold};
-  }
-`
-
-export const RowActions = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.3rem;
-
-  button {
-    min-width: 4.2rem;
-    padding-inline: 0.55rem;
   }
 `
 

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element -- private cloud content needs browser-owned auth cookies. */
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import type { PDFDocumentLoadingTask, RenderTask } from "pdfjs-dist"
+import type { PDFDocumentLoadingTask, PDFDocumentProxy, RenderTask } from "pdfjs-dist"
 import { type ChangeEvent, type KeyboardEvent as ReactKeyboardEvent, useEffect, useMemo, useRef, useState } from "react"
 import {
   deleteCloudFile,
@@ -65,7 +65,6 @@ import {
   PreviewHeader,
   PreviewStage,
   PrimaryButton,
-  RowActions,
   RowCheckbox,
   SearchDetail,
   SearchInput,
@@ -80,6 +79,7 @@ import {
 const CLOUD_QUERY_KEY = "admin-cloud-files"
 const EMPTY_CLOUD_FILES: CloudFile[] = []
 const PDF_STANDARD_FONT_DATA_URL = "/pdfjs/standard_fonts/"
+const PDF_LOADED_TASK_DESTROY_DELAY_MS = 3000
 
 const mediaKindFromFilter = (filter: CloudMediaFilter): CloudMediaKind | undefined =>
   filter === "ALL" ? undefined : filter
@@ -142,15 +142,31 @@ const installPdfWorkerTerminationRejectionHandler = () => {
 
 const ignorePdfPreviewTeardownRejection = (
   loadingTask: PDFDocumentLoadingTask | null,
+  pdfDocument: PDFDocumentProxy | null,
   renderTask: RenderTask | null
 ) => {
-  if (!loadingTask) return
+  const renderSettled = renderTask?.promise.catch(() => undefined) ?? Promise.resolve()
 
-  void loadingTask.promise.catch(() => {
-    // 미리보기 전환 중 PDF 로딩이 늦게 실패할 수 있으므로 cleanup 경로에서 reject를 소비한다.
+  void loadingTask?.promise.catch(() => {
+    // teardown 중 늦게 도착한 loading reject도 pageerror로 노출하지 않는다.
   })
 
-  const renderSettled = renderTask?.promise.catch(() => undefined) ?? Promise.resolve()
+  if (pdfDocument) {
+    void renderSettled.then(async () => {
+      await pdfDocument.cleanup().catch(() => {
+        // 이미 해제된 문서 리소스 정리는 사용자에게 노출하지 않는다.
+      })
+      window.setTimeout(() => {
+        void loadingTask?.destroy().catch(() => {
+          // worker 종료 reject는 teardown 내부에서 소비한다.
+        })
+      }, PDF_LOADED_TASK_DESTROY_DELAY_MS)
+    })
+    return
+  }
+
+  if (!loadingTask) return
+
   void renderSettled.finally(() => {
     void loadingTask.destroy().catch(() => {
       // cleanup에서 PDF.js worker/download를 종료할 때 발생하는 reject도 사용자에게 노출하지 않는다.
@@ -172,6 +188,7 @@ const PdfPreview = ({ file, contentUrl }: PdfPreviewProps) => {
     if (file.mediaKind !== "DOCUMENT") return
     let cancelled = false
     let loadingTask: PDFDocumentLoadingTask | null = null
+    let pdfDocument: PDFDocumentProxy | null = null
     let renderTask: RenderTask | null = null
     const releasePdfWorkerTerminationHandler = installPdfWorkerTerminationRejectionHandler()
 
@@ -188,6 +205,7 @@ const PdfPreview = ({ file, contentUrl }: PdfPreviewProps) => {
           // cleanup이 먼저 실행된 경우 await 경로 밖에서도 worker 종료 reject를 소비한다.
         })
         const pdf = await loadingTask.promise
+        pdfDocument = pdf
         if (cancelled) return
         setPageCount(pdf.numPages)
         const page = await pdf.getPage(1)
@@ -226,7 +244,7 @@ const PdfPreview = ({ file, contentUrl }: PdfPreviewProps) => {
       } catch {
         // loading task 종료가 먼저 끝난 경우 render task도 이미 취소 상태일 수 있다.
       }
-      ignorePdfPreviewTeardownRejection(loadingTask, renderTask)
+      ignorePdfPreviewTeardownRejection(loadingTask, pdfDocument, renderTask)
       releasePdfWorkerTerminationHandler(10000)
     }
   }, [contentUrl, file.mediaKind])
@@ -382,7 +400,6 @@ const FileTableHead = () => (
       <th>이름</th>
       <th>크기</th>
       <th>수정한 날짜</th>
-      <th aria-label="작업" />
     </tr>
   </thead>
 )
@@ -611,10 +628,6 @@ const AdminCloudWorkspacePage = () => {
     })
   }
 
-  const handleDelete = (file: CloudFile) => {
-    setDeleteConfirm({ files: [file] })
-  }
-
   const closeDeleteConfirm = () => {
     if (isDeletePending) return
     setDeleteConfirm(null)
@@ -827,7 +840,7 @@ const AdminCloudWorkspacePage = () => {
                 <FileTableHead />
                 <tbody>
                   <tr>
-                    <td colSpan={7}>
+                    <td colSpan={6}>
                       <LoadingTableStatus role="status" aria-label="파일 목록 로딩">
                         파일 목록 로딩
                       </LoadingTableStatus>
@@ -903,18 +916,6 @@ const AdminCloudWorkspacePage = () => {
                         </td>
                         <td>{formatCloudFileSize(file.byteSize)}</td>
                         <td>{formatCloudDate(file.modifiedAt || file.createdAt)}</td>
-                        <td>
-                          <RowActions>
-                            <GhostButton
-                              type="button"
-                              aria-label={`${file.originalFilename} 삭제`}
-                              onClick={() => handleDelete(file)}
-                            >
-                              <AppIcon name="trash" />
-                              삭제
-                            </GhostButton>
-                          </RowActions>
-                        </td>
                       </tr>
                     )
                   })}


### PR DESCRIPTION
## 관련 이슈

close #798

## 작업 배경

- 관리자 클라우드 파일 목록의 행 단위 삭제 버튼이 `선택 삭제`와 중복되어 목록 UI가 복잡했습니다.
- 삭제 동작을 MYBOX/GDrive형 흐름처럼 체크박스 선택 후 상단 액션으로 통합합니다.

## 작업 내용

- 파일 목록 table에서 행별 `삭제` 버튼과 작업 컬럼을 제거했습니다.
- 로딩 행 `colSpan`과 table column 폭을 6개 컬럼 기준으로 정리했습니다.
- 한글 display name E2E를 선택 삭제 기준으로 갱신했습니다.
- 반복 E2E 중 기존 PDF.js worker 종료 경고가 재현되어, 로드 완료 PDF는 cleanup 이후 지연 destroy로 정리하도록 안정화했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright test e2e/admin-cloud.spec.ts --grep "개별 삭제" --workers=1`
    - RED: 개별 삭제 버튼이 남아 있어 2건 실패 확인
    - GREEN: 2 passed
  - `yarn --cwd front playwright:preflight`
    - passed
  - `yarn --cwd front playwright test e2e/admin-cloud.spec.ts --workers=1`
    - 12 passed
  - `yarn --cwd front playwright test e2e/admin-cloud.spec.ts --workers=1`
    - 12 passed
  - `yarn --cwd front build`
    - passed
  - `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`
    - 1 passed

## 리뷰어 메모

- `AdminCloudWorkspacePage.tsx`의 table row에서 작업 컬럼이 완전히 제거됐는지 먼저 봐주세요.
- CodeRabbit은 rate limit으로 실제 리뷰가 시작되지 않아 Codex CLI review를 대체 리뷰로 남겼습니다. 최초 P2 지적 1건은 반영했고 재검토에서 추가 이슈 0건을 확인했습니다.

## 리스크

- 단일 파일 삭제도 체크박스 선택 후 `선택 삭제`를 눌러야 하므로 클릭 수가 늘어납니다. 대신 삭제 경로가 하나로 고정됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.