### PR TITLE
[Fix] 관리자 클라우드 PDF 파일명 및 미리보기 개선

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionSynchronization
 import org.springframework.transaction.support.TransactionSynchronizationManager
+import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Clock
 import java.time.Instant
@@ -231,12 +232,64 @@ class CloudFileService(
             decoded
                 .ifBlank { fallback }
                 .replace(Regex("[\\r\\n\\t]"), " ")
-                .replace(Regex("[^A-Za-z0-9가-힣._()\\[\\] -]"), "_")
-                .take(255)
+                .replace(Regex("[/\\\\]"), "_")
+                .replace(Regex("[\\p{Cc}\\p{Cf}\\p{Cs}]"), "")
+                .replace(Regex("\\s+"), " ")
+                .takeFilenameLimits()
                 .trim()
 
         return cleaned.ifBlank { fallback }
     }
+
+    private fun String.takeFilenameLimits(): String {
+        val originalExtensionIndex = lastIndexOf(".").takeIf { it > 0 && it < lastIndex }
+        val originalExtension =
+            originalExtensionIndex
+                ?.let(::substring)
+                .orEmpty()
+                .takeCodePoints(MAX_FILENAME_CODE_POINTS - 1)
+        val originalStem = originalExtensionIndex?.let { substring(0, it) } ?: this
+        val maxStemCodePoints =
+            MAX_FILENAME_CODE_POINTS - originalExtension.codePointCount(0, originalExtension.length).toLong()
+        val codePointLimited = originalStem.takeCodePoints(maxStemCodePoints.coerceAtLeast(0)) + originalExtension
+        if (metadataEncodedLength(codePointLimited) <= MAX_FILENAME_METADATA_ENCODED_BYTES) return codePointLimited
+
+        val extensionIndex = codePointLimited.lastIndexOf(".").takeIf { it > 0 && it < codePointLimited.lastIndex }
+        val extension =
+            extensionIndex
+                ?.let(codePointLimited::substring)
+                .orEmpty()
+                .takeMetadataEncodedBytes(MAX_FILENAME_METADATA_ENCODED_BYTES)
+        val stem = extensionIndex?.let { codePointLimited.substring(0, it) } ?: codePointLimited
+        val maxStemBytes = MAX_FILENAME_METADATA_ENCODED_BYTES - metadataEncodedLength(extension)
+        val safeStem = stem.takeMetadataEncodedBytes(maxStemBytes.coerceAtLeast(0))
+        return (safeStem + extension).ifBlank { takeMetadataEncodedBytes(MAX_FILENAME_METADATA_ENCODED_BYTES) }
+    }
+
+    private fun String.takeCodePoints(maxCodePoints: Long): String {
+        val codePoints = codePoints().limit(maxCodePoints).toArray()
+        return String(codePoints, 0, codePoints.size)
+    }
+
+    private fun String.takeMetadataEncodedBytes(maxEncodedBytes: Int): String {
+        val builder = StringBuilder()
+        val iterator = codePoints().iterator()
+        while (iterator.hasNext()) {
+            val next = iterator.nextInt()
+            val candidate = StringBuilder(builder).appendCodePoint(next).toString()
+            if (metadataEncodedLength(candidate) > maxEncodedBytes) break
+            builder.appendCodePoint(next)
+        }
+
+        return builder.toString()
+    }
+
+    private fun metadataEncodedLength(value: String): Int =
+        URLEncoder
+            .encode(value, StandardCharsets.UTF_8)
+            .replace("+", "%20")
+            .toByteArray(StandardCharsets.US_ASCII)
+            .size
 
     private fun recoverUtf8MojibakeFilename(raw: String): String {
         if (raw.isBlank()) return raw
@@ -369,6 +422,8 @@ class CloudFileService(
 
     companion object {
         private val DATE_PATH_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd")
+        private const val MAX_FILENAME_CODE_POINTS = 255L
+        private const val MAX_FILENAME_METADATA_ENCODED_BYTES = 1024
         private val CONTENT_TYPE_ALIASES =
             mapOf(
                 "image/jpg" to "image/jpeg",

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.io.ByteArrayInputStream
+import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Clock
 import java.time.Instant
@@ -188,7 +189,7 @@ class CloudFileServiceTest {
     }
 
     @Test
-    @DisplayName("업로드 시 mojibake로 들어온 한글 파일명을 UTF-8 기준으로 복구한다")
+    @DisplayName("업로드 시 mojibake로 들어온 한글 파일명은 원본 기호까지 UTF-8 기준으로 복구한다")
     fun `upload는 mojibake 한글 파일명을 UTF-8 기준으로 복구한다`() {
         val originalName = "★2026년 제3회 식약처 공무원(일반직) 경력경쟁채용시험 공고문_게시.pdf"
         val mojibakeName = String(originalName.toByteArray(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1)
@@ -202,7 +203,7 @@ class CloudFileServiceTest {
                 folderPath = null,
             )
 
-        assertThat(result.originalFilename).isEqualTo("_2026년 제3회 식약처 공무원(일반직) 경력경쟁채용시험 공고문_게시.pdf")
+        assertThat(result.originalFilename).isEqualTo(originalName)
     }
 
     @Test
@@ -221,6 +222,55 @@ class CloudFileServiceTest {
             )
 
         assertThat(result.originalFilename).isEqualTo(clientName)
+    }
+
+    @Test
+    @DisplayName("업로드 시 보이지 않는 Unicode 제어 서식 문자는 파일명에서 제거한다")
+    fun `upload는 보이지 않는 unicode 제어 서식 문자를 제거한다`() {
+        val result =
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "계약서\u202Ecod.exe\u0080.pdf",
+                contentType = "application/pdf",
+                bytes = "%PDF-1.7".toByteArray(),
+                folderPath = null,
+            )
+
+        assertThat(result.originalFilename).isEqualTo("계약서cod.exe.pdf")
+    }
+
+    @Test
+    @DisplayName("업로드 시 긴 non-BMP 파일명은 metadata 안전 길이로 자른다")
+    fun `upload는 긴 non-BMP 파일명을 metadata 안전 길이로 자른다`() {
+        val result =
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "😀".repeat(300) + ".pdf",
+                contentType = "application/pdf",
+                bytes = "%PDF-1.7".toByteArray(),
+                folderPath = null,
+            )
+
+        assertThat(metadataEncodedLength(result.originalFilename)).isLessThanOrEqualTo(1024)
+        assertThat(result.originalFilename).endsWith(".pdf")
+        assertThat(hasUnpairedSurrogate(result.originalFilename)).isFalse()
+    }
+
+    @Test
+    @DisplayName("업로드 시 과도하게 긴 확장자는 DB 컬럼 길이 안으로 자른다")
+    fun `upload는 과도하게 긴 확장자를 db 컬럼 길이 안으로 자른다`() {
+        val result =
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "a." + "x".repeat(300),
+                contentType = "application/pdf",
+                bytes = "%PDF-1.7".toByteArray(),
+                folderPath = null,
+            )
+
+        assertThat(result.originalFilename).hasSizeLessThanOrEqualTo(255)
+        assertThat(metadataEncodedLength(result.originalFilename)).isLessThanOrEqualTo(1024)
+        assertThat(result.originalFilename).startsWith("a.")
     }
 
     @Test
@@ -620,6 +670,29 @@ class CloudFileServiceTest {
             super.close()
         }
     }
+
+    private fun hasUnpairedSurrogate(value: String): Boolean {
+        var index = 0
+        while (index < value.length) {
+            val current = value[index]
+            if (Character.isHighSurrogate(current)) {
+                if (index + 1 >= value.length || !Character.isLowSurrogate(value[index + 1])) return true
+                index += 2
+                continue
+            }
+            if (Character.isLowSurrogate(current)) return true
+            index += 1
+        }
+
+        return false
+    }
+
+    private fun metadataEncodedLength(value: String): Int =
+        URLEncoder
+            .encode(value, StandardCharsets.UTF_8)
+            .replace("+", "%20")
+            .toByteArray(StandardCharsets.US_ASCII)
+            .size
 
     companion object {
         private val PNG_BYTES =

--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -168,6 +168,7 @@ const setupAdminCloudMocks = async (
     failUploadNames?: string[]
     initialFiles?: CloudFileFixture[]
     listDelayMs?: number
+    uploadResponseFilenames?: Record<string, string>
   } = {}
 ) => {
   const requestedKinds: string[] = []
@@ -241,7 +242,7 @@ const setupAdminCloudMocks = async (
       const uploaded = {
         id: nextUploadId++,
         ownerMemberId: 1,
-        originalFilename: uploadedName,
+        originalFilename: options.uploadResponseFilenames?.[uploadedName] ?? uploadedName,
         contentType: metadata.contentType,
         byteSize: route.request().postDataBuffer()?.byteLength ?? 0,
         mediaKind: metadata.mediaKind,
@@ -410,7 +411,7 @@ test.describe("관리자 클라우드", () => {
 
     await page.locator('button[title="운영 점검 리포트.pdf"]').click()
     await expect(page.getByRole("heading", { name: "문서 뷰어" })).toBeVisible()
-    await expect(page.getByText("PDF.js canvas 렌더링")).toBeVisible()
+    await expect(page.getByText("미리보기 완료")).toBeVisible()
     await expectPdfPreviewFitsDetailPanel(page, "운영 점검 리포트.pdf PDF 미리보기")
     await page.getByRole("button", { name: "상세 패널 닫기" }).click()
     await expect(page.getByLabel("클라우드 상세정보").getByText("파일 선택")).toBeVisible()
@@ -699,5 +700,75 @@ test.describe("관리자 클라우드", () => {
     await expect(page.getByText(/재시도 성공 문서\.pdf 업로드 실패/)).toHaveCount(0)
     await expect(page.getByText("재시도 성공 문서.pdf 업로드 완료")).toHaveCount(0)
     await expect(page.getByRole("row", { name: /재시도 성공 문서\.pdf/ })).toBeVisible()
+  })
+
+  test("PDF 파일명은 업로드 직후 클라이언트 원본명으로 보이고 렌더링 지연 문구를 노출하지 않는다", async ({ page }) => {
+    const sourceName = "★2026년 제3회 식약처 공무원(일반직) 경력경쟁채용시험 공고문_게시.pdf"
+    const damagedServerName = "_2026__ __3__ ___________________.pdf"
+    await setupAdminCloudMocks(page, {
+      initialFiles: [],
+      uploadResponseFilenames: {
+        [sourceName]: damagedServerName,
+      },
+    })
+
+    await page.goto("/admin/cloud")
+    await page.getByLabel("클라우드 파일 업로드").setInputFiles({
+      name: sourceName,
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4 filename fallback"),
+    })
+
+    await expect(page.getByLabel("업로드 중인 파일").getByText(sourceName)).toBeVisible()
+    const escapedSourceName = sourceName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    await expect(page.getByRole("row", { name: new RegExp(escapedSourceName) })).toBeVisible()
+    await expect(page.getByRole("row", { name: /___________________\.pdf/ })).toHaveCount(0)
+    await expect(page.getByRole("heading", { name: "문서 뷰어" })).toBeVisible()
+    await expect(page.getByLabel("클라우드 상세정보").getByText(sourceName)).toBeVisible()
+    await expect(page.getByText(/렌더링 중|렌더링 대기|렌더링 준비|미리보기 준비|미리보기 대기/)).toHaveCount(0)
+  })
+
+  test("서버가 정상 정규화한 업로드 파일명은 클라이언트 원본명으로 덮어쓰지 않는다", async ({ page }) => {
+    const clientName = "서버 정규화    문서.pdf"
+    const serverName = "서버 정규화 문서.pdf"
+    await setupAdminCloudMocks(page, {
+      initialFiles: [],
+      uploadResponseFilenames: {
+        [clientName]: serverName,
+      },
+    })
+
+    await page.goto("/admin/cloud")
+    await page.getByLabel("클라우드 파일 업로드").setInputFiles({
+      name: clientName,
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4 normalized filename"),
+    })
+
+    await expect(page.getByRole("row", { name: new RegExp(serverName) })).toBeVisible()
+    await expect(page.getByRole("row", { name: /서버 정규화 {4}문서\.pdf/ })).toHaveCount(0)
+    await expect(page.getByLabel("클라우드 상세정보").getByText(serverName)).toBeVisible()
+  })
+
+  test("손상된 서버 응답의 클라이언트 파일명 fallback은 보이지 않는 제어문자를 제거한다", async ({ page }) => {
+    const clientName = "보고서\u202Ecod.exe.pdf"
+    const displayName = "보고서cod.exe.pdf"
+    await setupAdminCloudMocks(page, {
+      initialFiles: [],
+      uploadResponseFilenames: {
+        [clientName]: "______.pdf",
+      },
+    })
+
+    await page.goto("/admin/cloud")
+    await page.getByLabel("클라우드 파일 업로드").setInputFiles({
+      name: clientName,
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4 sanitized fallback filename"),
+    })
+
+    await expect(page.getByRole("row", { name: new RegExp(displayName) })).toBeVisible()
+    await expect(page.getByRole("row", { name: /보고서.*cod\.exe\.pdf/ })).toHaveCount(1)
+    await expect(page.getByLabel("클라우드 상세정보").getByText(displayName)).toBeVisible()
   })
 })

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -102,6 +102,34 @@ const createUploadQueueItem = (file: File): UploadQueueItem => ({
   message: "업로드 대기 중",
 })
 
+const sanitizeClientFilenameForDisplayFallback = (filename: string) => {
+  const normalized = filename
+    .replace(/[\r\n\t]/g, " ")
+    .replace(/[\\/]/g, "_")
+    .replace(/[\p{Cc}\p{Cf}\p{Cs}]/gu, "")
+    .replace(/\s+/g, " ")
+    .trim()
+
+  return Array.from(normalized).slice(0, 255).join("")
+}
+
+const preferClientFilenameForUploadedFile = (uploaded: CloudFile, clientFilename: string): CloudFile => {
+  const normalizedClientFilename = sanitizeClientFilenameForDisplayFallback(clientFilename)
+  if (!normalizedClientFilename) return uploaded
+  const serverFilename = uploaded.originalFilename.trim()
+  if (normalizedClientFilename === serverFilename) return uploaded
+
+  const clientHasReadableUnicode = /[^\x00-\x7F]/u.test(normalizedClientFilename)
+  const serverLostReadableUnicode = !/[^\x00-\x7F]/u.test(serverFilename)
+  const serverLooksLikePlaceholder = /_{4,}/.test(serverFilename)
+  if (!clientHasReadableUnicode || !serverLostReadableUnicode || !serverLooksLikePlaceholder) return uploaded
+
+  return {
+    ...uploaded,
+    originalFilename: normalizedClientFilename,
+  }
+}
+
 const isAbortLikeError = (error: unknown) =>
   error instanceof DOMException && (error.name === "AbortError" || error.name === "TimeoutError")
 
@@ -182,7 +210,7 @@ type PdfPreviewProps = {
 const PdfPreview = ({ file, contentUrl }: PdfPreviewProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [pageCount, setPageCount] = useState(0)
-  const [renderState, setRenderState] = useState("PDF.js canvas 렌더링 준비")
+  const [renderState, setRenderState] = useState("미리보기 준비")
 
   useEffect(() => {
     if (file.mediaKind !== "DOCUMENT") return
@@ -229,9 +257,9 @@ const PdfPreview = ({ file, contentUrl }: PdfPreviewProps) => {
           // 파일 전환/패널 닫기 중 render task 취소가 pageerror로 번지는 것을 막는다.
         })
         await renderTask.promise
-        if (!cancelled) setRenderState("PDF.js canvas 렌더링")
+        if (!cancelled) setRenderState("미리보기 완료")
       } catch {
-        if (!cancelled) setRenderState("PDF.js canvas 렌더링 대기")
+        if (!cancelled) setRenderState("미리보기 대기")
       }
     }
 
@@ -511,16 +539,17 @@ const AdminCloudWorkspacePage = () => {
       try {
         const uploaded = await uploadCloudFile(nextUpload.file, "", controller.signal)
         if (controller.signal.aborted) throw new DOMException("Upload aborted", "AbortError")
+        const displayUploaded = preferClientFilenameForUploadedFile(uploaded, nextUpload.name)
 
-        setOptimisticFiles((current) => mergeCloudFiles([uploaded], current))
+        setOptimisticFiles((current) => mergeCloudFiles([displayUploaded], current))
         queryClient.getQueriesData<CloudFile[]>({ queryKey: [CLOUD_QUERY_KEY] }).forEach(([queryKey, current]) => {
           if (!Array.isArray(current)) return
           const cachedFilters = getCachedCloudQueryFilters(queryKey)
-          if (!doesCloudFileMatchFilters(uploaded, cachedFilters.filter, cachedFilters.keyword)) return
-          queryClient.setQueryData(queryKey, mergeCloudFiles([uploaded], current))
+          if (!doesCloudFileMatchFilters(displayUploaded, cachedFilters.filter, cachedFilters.keyword)) return
+          queryClient.setQueryData(queryKey, mergeCloudFiles([displayUploaded], current))
         })
         setIsDetailPanelOpen(true)
-        setSelectedFileId(uploaded.id)
+        setSelectedFileId(displayUploaded.id)
         setNotice((current) =>
           current.includes(nextUpload.name) && /업로드 (실패|취소)/.test(current) ? "" : current
         )
@@ -532,7 +561,7 @@ const AdminCloudWorkspacePage = () => {
                   status: "done",
                   progress: 100,
                   message: "업로드 완료",
-                  uploadedFileId: uploaded.id,
+                  uploadedFileId: displayUploaded.id,
                 }
               : item
           )


### PR DESCRIPTION
## 관련 이슈

close #800

## 작업 배경

- 관리자 클라우드에서 한글/기호가 포함된 PDF 파일명이 `_` 위주로 표시되어 문서 식별이 어려웠습니다.
- PDF 상세 패널의 상태 문구가 렌더링 지연을 직접 노출해 체감 UX가 나빴습니다.

## 작업 내용

- 클라우드 파일 업로드 저장명 정규화가 원본 표시명을 과하게 손상하지 않도록 경로 구분자와 제어/서식/surrogate 문자만 정리하도록 수정했습니다.
- 파일명 길이 제한을 Unicode code point와 URL-encoded metadata byte 기준으로 함께 제한해 DB/MinIO metadata 저장 실패를 막았습니다.
- 업로드 직후 optimistic 파일 목록은 서버 응답이 Unicode 손실 placeholder처럼 손상된 경우에만 클라이언트 원본 파일명을 표시 fallback으로 사용하도록 보강했습니다.
- PDF 상세 패널 상태 문구를 `미리보기 준비/완료/대기`로 바꿔 렌더링 내부 표현을 노출하지 않도록 정리했습니다.
- 한국어 display name이 있는 백엔드/Playwright 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests com.back.boundedContexts.cloud.application.service.CloudFileServiceTest` 통과
  - `yarn --cwd front playwright test e2e/admin-cloud.spec.ts --grep "PDF 파일명" --workers=1` RED/GREEN 확인 후 통과
  - `back/gradlew -p back ktlintCheck` 통과
  - `yarn --cwd front playwright:preflight` 통과
  - `yarn --cwd front playwright test e2e/admin-cloud.spec.ts --workers=1` 15 passed
  - `yarn --cwd front build` 통과
  - `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1` 1 passed
  - GitHub PR CI 전체 통과
  - Codex CLI review 재검토 결과 추가 수정 필요 없음

## 리뷰어 메모

- `CloudFileService.normalizeFilename`은 DB에 저장되는 표시명을 보존하고, object key 확장자 정리는 기존 `extractExtension` 경로가 계속 담당합니다.
- 업로드 직후 화면은 서버 응답이 손상된 경우에만 `clientFilename` 기반 표시 fallback을 쓰고, 서버가 정상 정규화한 파일명은 그대로 표시합니다.
- CodeRabbit 리뷰가 신뢰 가능한 상세 지적을 생성하지 못하는 상황을 대비해 Codex CLI Review를 단일 PR Review로 게시했고, 지적 7건을 모두 반영한 뒤 재검토했습니다.

## 리스크

- 기존에 이미 DB에 `_` 위주로 저장된 과거 파일명은 원본명 정보를 잃은 상태라 자동 복구할 수 없습니다. 이번 수정은 신규 업로드와 업로드 직후 표시 회귀를 막습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
