### PR TITLE
[Fix] 관리자 클라우드 NFD 파일명 업로드 400 수정

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -426,10 +426,7 @@ class CloudFileService(
 
     private fun isZipSignature(bytes: ByteArray): Boolean =
         bytes.size >= 4 &&
-            bytes[0] == 0x50.toByte() &&
-            bytes[1] == 0x4B.toByte() &&
-            bytes[2] in ZIP_THIRD_BYTES &&
-            bytes[3] in ZIP_FOURTH_BYTES
+            bytes.copyOfRange(0, 4).toList() in ZIP_SIGNATURES
 
     private data class DetectedContent(
         val contentType: String,
@@ -441,8 +438,12 @@ class CloudFileService(
         private const val MAX_FILENAME_CODE_POINTS = 255L
         private const val MAX_FILENAME_METADATA_ENCODED_BYTES = 1024
         private const val HWPX_CONTENT_TYPE = "application/haansofthwpx"
-        private val ZIP_THIRD_BYTES = setOf(0x03.toByte(), 0x05.toByte(), 0x07.toByte())
-        private val ZIP_FOURTH_BYTES = setOf(0x04.toByte(), 0x06.toByte(), 0x08.toByte())
+        private val ZIP_SIGNATURES =
+            setOf(
+                listOf(0x50.toByte(), 0x4B.toByte(), 0x03.toByte(), 0x04.toByte()),
+                listOf(0x50.toByte(), 0x4B.toByte(), 0x05.toByte(), 0x06.toByte()),
+                listOf(0x50.toByte(), 0x4B.toByte(), 0x07.toByte(), 0x08.toByte()),
+            )
         private val CONTENT_TYPE_ALIASES =
             mapOf(
                 "image/jpg" to "image/jpeg",

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -451,8 +451,7 @@ class CloudFileService(
 
         while (
             offset + ZIP_CENTRAL_DIRECTORY_HEADER_SIZE <= directoryEnd &&
-            scannedCount < entryCount &&
-            scannedCount < MAX_HWPX_ENTRY_SCAN_COUNT
+            scannedCount < entryCount
         ) {
             if (!hasSignature(bytes, offset, ZIP_CENTRAL_DIRECTORY_FILE_HEADER_SIGNATURE)) break
 
@@ -517,7 +516,6 @@ class CloudFileService(
         private const val MAX_FILENAME_METADATA_ENCODED_BYTES = 1024
         private const val HWPX_CONTENT_TYPE = "application/haansofthwpx"
         private const val HWPX_MANIFEST_ENTRY = "Contents/content.hpf"
-        private const val MAX_HWPX_ENTRY_SCAN_COUNT = 512
         private const val ZIP_EOCD_MIN_SIZE = 22
         private const val ZIP_EOCD_MAX_SEARCH_LENGTH = ZIP_EOCD_MIN_SIZE + 0xFFFF
         private const val ZIP_EOCD_TOTAL_ENTRY_COUNT_OFFSET = 10

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionSynchronization
 import org.springframework.transaction.support.TransactionSynchronizationManager
-import java.io.ByteArrayInputStream
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.text.Normalizer
@@ -21,7 +20,6 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import java.util.UUID
-import java.util.zip.ZipInputStream
 
 data class CloudFileDto(
     val id: Long,
@@ -433,21 +431,80 @@ class CloudFileService(
     private fun isHwpxPackage(bytes: ByteArray): Boolean {
         if (!isZipSignature(bytes)) return false
 
-        val entries =
-            runCatching {
-                ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
-                    buildSet {
-                        while (size < MAX_HWPX_ENTRY_SCAN_COUNT) {
-                            val entry = zip.nextEntry ?: break
-                            add(entry.name.replace('\\', '/'))
-                            zip.closeEntry()
-                        }
-                    }
-                }
-            }.getOrDefault(emptySet())
+        val entries = readZipCentralDirectoryEntryNames(bytes)
 
         return HWPX_MANIFEST_ENTRY in entries && entries.any { it in HWPX_DOCUMENT_ENTRIES }
     }
+
+    private fun readZipCentralDirectoryEntryNames(bytes: ByteArray): Set<String> {
+        val endRecordOffset = findZipEndOfCentralDirectoryOffset(bytes) ?: return emptySet()
+        val entryCount = readUInt16Le(bytes, endRecordOffset + ZIP_EOCD_TOTAL_ENTRY_COUNT_OFFSET)
+        val centralDirectorySize = readUInt32Le(bytes, endRecordOffset + ZIP_EOCD_DIRECTORY_SIZE_OFFSET)
+        val centralDirectoryOffset = readUInt32Le(bytes, endRecordOffset + ZIP_EOCD_DIRECTORY_OFFSET)
+        if (centralDirectorySize > bytes.size || centralDirectoryOffset > bytes.size) return emptySet()
+
+        val directoryStart = centralDirectoryOffset.toInt()
+        val directoryEnd = (centralDirectoryOffset + centralDirectorySize).takeIf { it <= bytes.size }?.toInt() ?: return emptySet()
+        val names = mutableSetOf<String>()
+        var offset = directoryStart
+        var scannedCount = 0
+
+        while (
+            offset + ZIP_CENTRAL_DIRECTORY_HEADER_SIZE <= directoryEnd &&
+            scannedCount < entryCount &&
+            scannedCount < MAX_HWPX_ENTRY_SCAN_COUNT
+        ) {
+            if (!hasSignature(bytes, offset, ZIP_CENTRAL_DIRECTORY_FILE_HEADER_SIGNATURE)) break
+
+            val nameLength = readUInt16Le(bytes, offset + ZIP_CENTRAL_DIRECTORY_NAME_LENGTH_OFFSET)
+            val extraLength = readUInt16Le(bytes, offset + ZIP_CENTRAL_DIRECTORY_EXTRA_LENGTH_OFFSET)
+            val commentLength = readUInt16Le(bytes, offset + ZIP_CENTRAL_DIRECTORY_COMMENT_LENGTH_OFFSET)
+            val nameOffset = offset + ZIP_CENTRAL_DIRECTORY_HEADER_SIZE
+            val nextOffset = nameOffset + nameLength + extraLength + commentLength
+            if (nameOffset + nameLength > directoryEnd || nextOffset > directoryEnd) break
+
+            names += String(bytes, nameOffset, nameLength, StandardCharsets.UTF_8).replace('\\', '/')
+            if (HWPX_MANIFEST_ENTRY in names && names.any { it in HWPX_DOCUMENT_ENTRIES }) break
+
+            offset = nextOffset
+            scannedCount++
+        }
+
+        return names
+    }
+
+    private fun findZipEndOfCentralDirectoryOffset(bytes: ByteArray): Int? {
+        val firstSearchOffset = maxOf(0, bytes.size - ZIP_EOCD_MAX_SEARCH_LENGTH)
+        for (offset in bytes.size - ZIP_EOCD_MIN_SIZE downTo firstSearchOffset) {
+            if (hasSignature(bytes, offset, ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE)) return offset
+        }
+        return null
+    }
+
+    private fun hasSignature(
+        bytes: ByteArray,
+        offset: Int,
+        signature: ByteArray,
+    ): Boolean {
+        if (offset < 0 || offset + signature.size > bytes.size) return false
+        return signature.indices.all { index -> bytes[offset + index] == signature[index] }
+    }
+
+    private fun readUInt16Le(
+        bytes: ByteArray,
+        offset: Int,
+    ): Int =
+        (bytes[offset].toInt() and 0xFF) or
+            ((bytes[offset + 1].toInt() and 0xFF) shl 8)
+
+    private fun readUInt32Le(
+        bytes: ByteArray,
+        offset: Int,
+    ): Long =
+        (bytes[offset].toLong() and 0xFF) or
+            ((bytes[offset + 1].toLong() and 0xFF) shl 8) or
+            ((bytes[offset + 2].toLong() and 0xFF) shl 16) or
+            ((bytes[offset + 3].toLong() and 0xFF) shl 24)
 
     private data class DetectedContent(
         val contentType: String,
@@ -461,12 +518,25 @@ class CloudFileService(
         private const val HWPX_CONTENT_TYPE = "application/haansofthwpx"
         private const val HWPX_MANIFEST_ENTRY = "Contents/content.hpf"
         private const val MAX_HWPX_ENTRY_SCAN_COUNT = 512
+        private const val ZIP_EOCD_MIN_SIZE = 22
+        private const val ZIP_EOCD_MAX_SEARCH_LENGTH = ZIP_EOCD_MIN_SIZE + 0xFFFF
+        private const val ZIP_EOCD_TOTAL_ENTRY_COUNT_OFFSET = 10
+        private const val ZIP_EOCD_DIRECTORY_SIZE_OFFSET = 12
+        private const val ZIP_EOCD_DIRECTORY_OFFSET = 16
+        private const val ZIP_CENTRAL_DIRECTORY_HEADER_SIZE = 46
+        private const val ZIP_CENTRAL_DIRECTORY_NAME_LENGTH_OFFSET = 28
+        private const val ZIP_CENTRAL_DIRECTORY_EXTRA_LENGTH_OFFSET = 30
+        private const val ZIP_CENTRAL_DIRECTORY_COMMENT_LENGTH_OFFSET = 32
         private val HWPX_DOCUMENT_ENTRIES =
             setOf(
                 "Contents/header.xml",
                 "Contents/section0.xml",
                 "META-INF/container.xml",
             )
+        private val ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE =
+            byteArrayOf(0x50.toByte(), 0x4B.toByte(), 0x05.toByte(), 0x06.toByte())
+        private val ZIP_CENTRAL_DIRECTORY_FILE_HEADER_SIGNATURE =
+            byteArrayOf(0x50.toByte(), 0x4B.toByte(), 0x01.toByte(), 0x02.toByte())
         private val ZIP_SIGNATURES =
             setOf(
                 listOf(0x50.toByte(), 0x4B.toByte(), 0x03.toByte(), 0x04.toByte()),

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionSynchronization
 import org.springframework.transaction.support.TransactionSynchronizationManager
+import java.io.ByteArrayInputStream
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.text.Normalizer
@@ -20,6 +21,7 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import java.util.UUID
+import java.util.zip.ZipInputStream
 
 data class CloudFileDto(
     val id: Long,
@@ -417,7 +419,7 @@ class CloudFileService(
         ) {
             return DetectedContent("video/webm", CloudFileMediaKind.VIDEO)
         }
-        if (isZipSignature(bytes) && filename.substringAfterLast(".", "").lowercase(Locale.ROOT) == "hwpx") {
+        if (filename.substringAfterLast(".", "").lowercase(Locale.ROOT) == "hwpx" && isHwpxPackage(bytes)) {
             return DetectedContent(HWPX_CONTENT_TYPE, CloudFileMediaKind.DOCUMENT)
         }
 
@@ -427,6 +429,25 @@ class CloudFileService(
     private fun isZipSignature(bytes: ByteArray): Boolean =
         bytes.size >= 4 &&
             bytes.copyOfRange(0, 4).toList() in ZIP_SIGNATURES
+
+    private fun isHwpxPackage(bytes: ByteArray): Boolean {
+        if (!isZipSignature(bytes)) return false
+
+        val entries =
+            runCatching {
+                ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
+                    buildSet {
+                        while (size < MAX_HWPX_ENTRY_SCAN_COUNT) {
+                            val entry = zip.nextEntry ?: break
+                            add(entry.name.replace('\\', '/'))
+                            zip.closeEntry()
+                        }
+                    }
+                }
+            }.getOrDefault(emptySet())
+
+        return HWPX_MANIFEST_ENTRY in entries && entries.any { it in HWPX_DOCUMENT_ENTRIES }
+    }
 
     private data class DetectedContent(
         val contentType: String,
@@ -438,6 +459,14 @@ class CloudFileService(
         private const val MAX_FILENAME_CODE_POINTS = 255L
         private const val MAX_FILENAME_METADATA_ENCODED_BYTES = 1024
         private const val HWPX_CONTENT_TYPE = "application/haansofthwpx"
+        private const val HWPX_MANIFEST_ENTRY = "Contents/content.hpf"
+        private const val MAX_HWPX_ENTRY_SCAN_COUNT = 512
+        private val HWPX_DOCUMENT_ENTRIES =
+            setOf(
+                "Contents/header.xml",
+                "Contents/section0.xml",
+                "META-INF/container.xml",
+            )
         private val ZIP_SIGNATURES =
             setOf(
                 listOf(0x50.toByte(), 0x4B.toByte(), 0x03.toByte(), 0x04.toByte()),

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -13,6 +13,7 @@ import org.springframework.transaction.support.TransactionSynchronization
 import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import java.text.Normalizer
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
@@ -65,7 +66,7 @@ class CloudFileService(
 
         val normalizedFolderPath = normalizeFolderPath(folderPath)
         val safeFilename = normalizeFilename(clientOriginalFilename?.takeIf(String::isNotBlank) ?: originalFilename)
-        val detected = detectContent(bytes, contentType)
+        val detected = detectContent(bytes, contentType, safeFilename)
         val objectKey =
             buildObjectKey(
                 ownerMemberId = ownerMemberId,
@@ -229,7 +230,8 @@ class CloudFileService(
                 .orEmpty()
         val decoded = recoverUtf8MojibakeFilename(raw)
         val cleaned =
-            decoded
+            Normalizer
+                .normalize(decoded, Normalizer.Form.NFC)
                 .ifBlank { fallback }
                 .replace(Regex("[\\r\\n\\t]"), " ")
                 .replace(Regex("[/\\\\]"), "_")
@@ -337,10 +339,11 @@ class CloudFileService(
     private fun detectContent(
         bytes: ByteArray,
         declaredContentType: String?,
+        filename: String,
     ): DetectedContent {
         val normalizedDeclared = normalizeContentType(declaredContentType)
         val detected =
-            detectFromSignature(bytes)
+            detectFromSignature(bytes, filename)
                 ?: throw AppException("400-1", "지원하지 않는 클라우드 파일 형식입니다.")
 
         if (
@@ -365,7 +368,10 @@ class CloudFileService(
         return CONTENT_TYPE_ALIASES[normalized] ?: normalized
     }
 
-    private fun detectFromSignature(bytes: ByteArray): DetectedContent? {
+    private fun detectFromSignature(
+        bytes: ByteArray,
+        filename: String,
+    ): DetectedContent? {
         if (bytes.size >= 5 && bytes.copyOfRange(0, 5).toString(Charsets.US_ASCII) == "%PDF-") {
             return DetectedContent("application/pdf", CloudFileMediaKind.DOCUMENT)
         }
@@ -411,9 +417,19 @@ class CloudFileService(
         ) {
             return DetectedContent("video/webm", CloudFileMediaKind.VIDEO)
         }
+        if (isZipSignature(bytes) && filename.substringAfterLast(".", "").lowercase(Locale.ROOT) == "hwpx") {
+            return DetectedContent(HWPX_CONTENT_TYPE, CloudFileMediaKind.DOCUMENT)
+        }
 
         return null
     }
+
+    private fun isZipSignature(bytes: ByteArray): Boolean =
+        bytes.size >= 4 &&
+            bytes[0] == 0x50.toByte() &&
+            bytes[1] == 0x4B.toByte() &&
+            bytes[2] in ZIP_THIRD_BYTES &&
+            bytes[3] in ZIP_FOURTH_BYTES
 
     private data class DetectedContent(
         val contentType: String,
@@ -424,16 +440,21 @@ class CloudFileService(
         private val DATE_PATH_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd")
         private const val MAX_FILENAME_CODE_POINTS = 255L
         private const val MAX_FILENAME_METADATA_ENCODED_BYTES = 1024
+        private const val HWPX_CONTENT_TYPE = "application/haansofthwpx"
+        private val ZIP_THIRD_BYTES = setOf(0x03.toByte(), 0x05.toByte(), 0x07.toByte())
+        private val ZIP_FOURTH_BYTES = setOf(0x04.toByte(), 0x06.toByte(), 0x08.toByte())
         private val CONTENT_TYPE_ALIASES =
             mapOf(
                 "image/jpg" to "image/jpeg",
                 "image/pjpeg" to "image/jpeg",
                 "image/x-png" to "image/png",
                 "image/x-webp" to "image/webp",
+                "application/x-hwpx" to HWPX_CONTENT_TYPE,
             )
         private val KNOWN_CONTENT_TYPES =
             setOf(
                 "application/pdf",
+                HWPX_CONTENT_TYPE,
                 "image/jpeg",
                 "image/png",
                 "image/gif",

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -212,6 +212,24 @@ class CloudFileServiceTest {
     }
 
     @Test
+    @DisplayName("업로드 시 잘못된 ZIP 헤더 조합은 HWPX 문서로 저장하지 않는다")
+    fun `upload는 잘못된 ZIP 헤더 조합을 HWPX 문서로 저장하지 않는다`() {
+        assertThatThrownBy {
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "invalid.hwpx",
+                contentType = "application/octet-stream",
+                bytes = invalidZipBytes(),
+                folderPath = null,
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("지원하지 않는 클라우드 파일 형식")
+
+        assertThat(storage.uploaded).isEmpty()
+        assertThat(repository.savedFiles).isEmpty()
+    }
+
+    @Test
     @DisplayName("업로드 시 mojibake로 들어온 한글 파일명은 원본 기호까지 UTF-8 기준으로 복구한다")
     fun `upload는 mojibake 한글 파일명을 UTF-8 기준으로 복구한다`() {
         val originalName = "★2026년 제3회 식약처 공무원(일반직) 경력경쟁채용시험 공고문_게시.pdf"
@@ -736,6 +754,18 @@ class CloudFileServiceTest {
                 0x4B,
                 0x03,
                 0x04,
+                0x14,
+                0x00,
+                0x00,
+                0x00,
+            )
+
+        private fun invalidZipBytes(): ByteArray =
+            byteArrayOf(
+                0x50,
+                0x4B,
+                0x03,
+                0x06,
                 0x14,
                 0x00,
                 0x00,

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -14,6 +14,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.io.ByteArrayInputStream
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import java.text.Normalizer
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
@@ -186,6 +187,28 @@ class CloudFileServiceTest {
         assertThat(result.originalFilename).isEqualTo("cloud-file")
         assertThat(result.folderPath).isEmpty()
         assertThat(repository.savedFiles.single().objectKey).startsWith("cloud/7/2026/06/12/")
+    }
+
+    @Test
+    @DisplayName("업로드 시 NFD 한글 HWPX 문서는 NFC 파일명으로 저장한다")
+    fun `upload는 NFD 한글 HWPX 문서를 NFC 파일명으로 저장한다`() {
+        val nfcName = "★2026년 제3회 식약처 공무원(일반직) 경력경쟁채용시험 공고문_게시.hwpx"
+        val nfdName = Normalizer.normalize(nfcName, Normalizer.Form.NFD)
+
+        val result =
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = nfdName,
+                clientOriginalFilename = nfdName,
+                contentType = "application/octet-stream",
+                bytes = zipBytes(),
+                folderPath = null,
+            )
+
+        assertThat(result.originalFilename).isEqualTo(nfcName)
+        assertThat(result.mediaKind).isEqualTo(CloudFileMediaKind.DOCUMENT)
+        assertThat(result.contentType).isEqualTo("application/haansofthwpx")
+        assertThat(storage.uploaded.single().originalFilename).isEqualTo(nfcName)
     }
 
     @Test
@@ -705,6 +728,18 @@ class CloudFileServiceTest {
                 0x0A,
                 0x1A,
                 0x0A,
+            )
+
+        private fun zipBytes(): ByteArray =
+            byteArrayOf(
+                0x50,
+                0x4B,
+                0x03,
+                0x04,
+                0x14,
+                0x00,
+                0x00,
+                0x00,
             )
 
         private fun cloudFile(

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -12,12 +12,15 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.text.Normalizer
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 @DisplayName("관리자 클라우드 파일 서비스 테스트")
 class CloudFileServiceTest {
@@ -220,6 +223,24 @@ class CloudFileServiceTest {
                 originalFilename = "invalid.hwpx",
                 contentType = "application/octet-stream",
                 bytes = invalidZipBytes(),
+                folderPath = null,
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("지원하지 않는 클라우드 파일 형식")
+
+        assertThat(storage.uploaded).isEmpty()
+        assertThat(repository.savedFiles).isEmpty()
+    }
+
+    @Test
+    @DisplayName("업로드 시 일반 ZIP 파일은 HWPX 확장자로 바꿔도 저장하지 않는다")
+    fun `upload는 일반 ZIP 파일을 HWPX 문서로 저장하지 않는다`() {
+        assertThatThrownBy {
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "renamed.hwpx",
+                contentType = "application/octet-stream",
+                bytes = genericZipBytes(),
                 folderPath = null,
             )
         }.isInstanceOf(AppException::class.java)
@@ -749,15 +770,9 @@ class CloudFileServiceTest {
             )
 
         private fun zipBytes(): ByteArray =
-            byteArrayOf(
-                0x50,
-                0x4B,
-                0x03,
-                0x04,
-                0x14,
-                0x00,
-                0x00,
-                0x00,
+            zip(
+                "Contents/content.hpf" to "<package />",
+                "Contents/header.xml" to "<header />",
             )
 
         private fun invalidZipBytes(): ByteArray =
@@ -771,6 +786,23 @@ class CloudFileServiceTest {
                 0x00,
                 0x00,
             )
+
+        private fun genericZipBytes(): ByteArray =
+            zip(
+                "readme.txt" to "not an hwpx package",
+            )
+
+        private fun zip(vararg entries: Pair<String, String>): ByteArray {
+            val output = ByteArrayOutputStream()
+            ZipOutputStream(output).use { zip ->
+                entries.forEach { (name, content) ->
+                    zip.putNextEntry(ZipEntry(name))
+                    zip.write(content.toByteArray(StandardCharsets.UTF_8))
+                    zip.closeEntry()
+                }
+            }
+            return output.toByteArray()
+        }
 
         private fun cloudFile(
             ownerMemberId: Long,

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -250,6 +250,24 @@ class CloudFileServiceTest {
     }
 
     @Test
+    @DisplayName("업로드 시 중앙 디렉터리가 없는 ZIP 조각은 HWPX 문서로 저장하지 않는다")
+    fun `upload는 중앙 디렉터리가 없는 ZIP 조각을 HWPX 문서로 저장하지 않는다`() {
+        assertThatThrownBy {
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "truncated.hwpx",
+                contentType = "application/octet-stream",
+                bytes = truncatedZipBytes(),
+                folderPath = null,
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("지원하지 않는 클라우드 파일 형식")
+
+        assertThat(storage.uploaded).isEmpty()
+        assertThat(repository.savedFiles).isEmpty()
+    }
+
+    @Test
     @DisplayName("업로드 시 일반 ZIP 파일은 HWPX 확장자로 바꿔도 저장하지 않는다")
     fun `upload는 일반 ZIP 파일을 HWPX 문서로 저장하지 않는다`() {
         assertThatThrownBy {
@@ -805,6 +823,18 @@ class CloudFileServiceTest {
                 0x4B,
                 0x03,
                 0x06,
+                0x14,
+                0x00,
+                0x00,
+                0x00,
+            )
+
+        private fun truncatedZipBytes(): ByteArray =
+            byteArrayOf(
+                0x50,
+                0x4B,
+                0x03,
+                0x04,
                 0x14,
                 0x00,
                 0x00,

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -232,6 +232,23 @@ class CloudFileServiceTest {
     }
 
     @Test
+    @DisplayName("업로드 시 HWPX 필수 항목이 중앙 디렉터리 뒤쪽에 있어도 문서로 저장한다")
+    fun `upload는 HWPX 필수 항목이 중앙 디렉터리 뒤쪽에 있어도 문서로 저장한다`() {
+        val result =
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "첨부자료_많은리소스.hwpx",
+                contentType = "application/octet-stream",
+                bytes = zipBytesWithLateHwpxEntries(),
+                folderPath = null,
+            )
+
+        assertThat(result.mediaKind).isEqualTo(CloudFileMediaKind.DOCUMENT)
+        assertThat(result.contentType).isEqualTo("application/haansofthwpx")
+        assertThat(result.originalFilename).isEqualTo("첨부자료_많은리소스.hwpx")
+    }
+
+    @Test
     @DisplayName("업로드 시 잘못된 ZIP 헤더 조합은 HWPX 문서로 저장하지 않는다")
     fun `upload는 잘못된 ZIP 헤더 조합을 HWPX 문서로 저장하지 않는다`() {
         assertThatThrownBy {
@@ -816,6 +833,21 @@ class CloudFileServiceTest {
                 "Contents/content.hpf" to "<package />",
                 "Contents/header.xml" to "<header />",
             )
+
+        private fun zipBytesWithLateHwpxEntries(): ByteArray {
+            val fillerEntries =
+                (0 until 600).map { index ->
+                    "Contents/resources/resource-$index.bin" to "x"
+                }
+            val hwpxEntries =
+                listOf(
+                    "Contents/content.hpf" to "<package />",
+                    "Contents/header.xml" to "<header />",
+                )
+            return zip(
+                *(fillerEntries + hwpxEntries).toTypedArray(),
+            )
+        }
 
         private fun invalidZipBytes(): ByteArray =
             byteArrayOf(

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -215,6 +215,23 @@ class CloudFileServiceTest {
     }
 
     @Test
+    @DisplayName("업로드 시 HWPX 판별은 압축 본문을 풀지 않고 중앙 디렉터리 이름만 확인한다")
+    fun `upload는 HWPX 판별 시 중앙 디렉터리 이름만 확인한다`() {
+        val result =
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "제출서류_총괄표.hwpx",
+                contentType = "application/octet-stream",
+                bytes = zipBytesWithLargeLeadingEntry(),
+                folderPath = null,
+            )
+
+        assertThat(result.mediaKind).isEqualTo(CloudFileMediaKind.DOCUMENT)
+        assertThat(result.contentType).isEqualTo("application/haansofthwpx")
+        assertThat(result.originalFilename).isEqualTo("제출서류_총괄표.hwpx")
+    }
+
+    @Test
     @DisplayName("업로드 시 잘못된 ZIP 헤더 조합은 HWPX 문서로 저장하지 않는다")
     fun `upload는 잘못된 ZIP 헤더 조합을 HWPX 문서로 저장하지 않는다`() {
         assertThatThrownBy {
@@ -771,6 +788,13 @@ class CloudFileServiceTest {
 
         private fun zipBytes(): ByteArray =
             zip(
+                "Contents/content.hpf" to "<package />",
+                "Contents/header.xml" to "<header />",
+            )
+
+        private fun zipBytesWithLargeLeadingEntry(): ByteArray =
+            zip(
+                "filler.bin" to "0".repeat(1024 * 1024),
                 "Contents/content.hpf" to "<package />",
                 "Contents/header.xml" to "<header />",
             )


### PR DESCRIPTION
## 관련 이슈

close #802

## 작업 배경

- 관리자 클라우드에서 macOS가 만든 NFD 한글 파일명 HWPX 문서를 업로드하면 백엔드 파일 형식 검증에서 ZIP 기반 문서를 지원하지 않아 400 Bad Request가 발생했습니다.
- 같은 흐름에서 NFD 파일명이 NFC로 정규화되지 않으면 저장 후 파일명 표시가 계속 깨질 수 있어 업로드 저장 계약을 같이 보강했습니다.

## 작업 내용

- 클라우드 업로드 파일명 정규화 단계에서 NFD 한글 파일명을 NFC로 정규화하도록 수정했습니다.
- HWPX를 ZIP 시그니처 기반 문서 형식으로 허용하고 `application/haansofthwpx` 문서로 저장하도록 추가했습니다.
- `application/x-hwpx` content-type alias를 표준 HWPX content-type으로 매핑했습니다.
- NFD 한글 HWPX 업로드가 NFC 파일명과 DOCUMENT mediaKind로 저장되는 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --rerun-tasks --tests com.back.boundedContexts.cloud.application.service.CloudFileServiceTest` 성공
  - `back/gradlew -p back ktlintCheck` 성공
  - `back/gradlew -p back test` 성공
  - `back/gradlew -p back test --tests com.back.boundedContexts.cloud.adapter.web.ApiV1AdmCloudControllerWebMvcTest` 성공
  - pre-commit hook `OpenApiContractExportTest` 및 `yarn contracts:check` 성공
  - PR CI: backend-ci, frontend-ci, Security, Vercel 성공
  - main merge 후 CD: Deploy to Home Server 및 live e2e 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `CloudFileService.detectFromSignature`에서 HWPX를 확장자와 ZIP 시그니처 조합으로만 허용하는 부분
  - `normalizeFilename`에서 NFC 정규화가 기존 mojibake 복구, 제어문자 제거, 길이 제한 흐름을 깨지 않는지

## 리스크

- ZIP 기반 문서 중 현재는 HWPX만 허용합니다. DOCX/XLSX/PPTX까지 넓히지 않아 기존 업로드 허용 범위를 불필요하게 확대하지 않습니다.
- 파일 내용은 여전히 시그니처 기반 검증을 통과해야 하므로 확장자만 HWPX인 임의 텍스트 파일은 거절됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 상태를 확인했다. (rate limit으로 실제 리뷰 미생성)
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * HWPX(한글 오피스) 파일 형식 지원 추가
  
* **개선 사항**
  * 한글 파일명 유니코드 정규화 처리 강화
  * 파일 형식 검증 로직 개선으로 위변조 파일 감지 능력 향상

* **테스트**
  * HWPX 파일 정규화, 형식 검증 관련 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
