### PR TITLE
[Style] 관리자 클라우드 파일 관리 밀도 개선

### DIFF
--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -597,6 +597,18 @@ test.describe("관리자 클라우드", () => {
     expect(Math.abs(tableBoxAfter!.width - tableBoxBefore!.width)).toBeLessThanOrEqual(2)
   })
 
+  test("작은 화면 첫 진입은 상세정보 드로어로 파일 목록을 가리지 않는다", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await setupAdminCloudMocks(page, { initialFiles: CLOUD_FILES.slice(0, 2) })
+
+    await page.goto("/admin/cloud")
+
+    await expect(page.getByRole("row", { name: /운영 점검 리포트\.pdf/ })).toBeVisible()
+    await expect(page.getByLabel("클라우드 상세정보")).toHaveCount(0)
+    await page.locator('button[title="운영 점검 리포트.pdf"]').click()
+    await expect(page.getByLabel("클라우드 상세정보")).toHaveCSS("position", "fixed")
+  })
+
   test("관리자 클라우드 진입만으로 알림 snapshot 백그라운드 요청을 시작하지 않는다", async ({ page }) => {
     let snapshotRequestCount = 0
     await page.addInitScript(() => {

--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -144,20 +144,6 @@ const expectPdfPreviewFitsDetailPanel = async (page: Page, previewName: string |
     .toBe(true)
 }
 
-const expectElementCenterAligned = async (container: ReturnType<Page["locator"]>, item: ReturnType<Page["locator"]>) => {
-  await expect
-    .poll(async () => {
-      const containerBox = await container.boundingBox()
-      const itemBox = await item.boundingBox()
-      if (!containerBox || !itemBox) return false
-
-      const containerCenterX = containerBox.x + containerBox.width / 2
-      const itemCenterX = itemBox.x + itemBox.width / 2
-      return Math.abs(containerCenterX - itemCenterX) <= 3
-    })
-    .toBe(true)
-}
-
 const setupAdminCloudMocks = async (
   page: Page,
   options: {
@@ -414,7 +400,7 @@ test.describe("관리자 클라우드", () => {
     await expect(page.getByText("미리보기 완료")).toBeVisible()
     await expectPdfPreviewFitsDetailPanel(page, "운영 점검 리포트.pdf PDF 미리보기")
     await page.getByRole("button", { name: "상세 패널 닫기" }).click()
-    await expect(page.getByLabel("클라우드 상세정보").getByText("파일 선택")).toBeVisible()
+    await expect(page.getByLabel("클라우드 상세정보")).toHaveCount(0)
     await page.getByRole("button", { name: "상세 패널 보기" }).click()
     await expect(page.getByRole("heading", { name: "문서 뷰어" })).toBeVisible()
     await page.waitForTimeout(100)
@@ -550,24 +536,28 @@ test.describe("관리자 클라우드", () => {
     expect(queueItemBox!.x + queueItemBox!.width).toBeLessThanOrEqual(donePillBox!.x + 2)
   })
 
-  test("선택된 긴 PDF 행은 종류 배지와 파일명 포커스가 명확하고 개별 삭제를 노출하지 않는다", async ({ page }) => {
+  test("선택된 긴 PDF 행은 이름 셀 안의 종류 배지와 파일명 포커스가 명확하다", async ({ page }) => {
     await setupAdminCloudMocks(page, { initialFiles: CLOUD_FILES })
 
     await page.goto("/admin/cloud")
 
     const selectedRow = page.getByRole("row", { name: /운영 점검 리포트\.pdf/ })
     await expect(selectedRow).toBeVisible()
-    const typeCell = selectedRow.locator("td").nth(2)
+    const nameCell = selectedRow.locator("td").nth(2)
     const typeBadge = selectedRow.getByLabel("문서")
     await expect(typeBadge).toHaveText("PDF")
-    await expectElementCenterAligned(typeCell, typeBadge)
+    await expect(nameCell.getByLabel("문서")).toBeVisible()
 
     const badgeBox = await typeBadge.boundingBox()
+    const thumbnailBox = await selectedRow.locator('[data-kind="DOCUMENT"]').first().boundingBox()
     const selectedRowBox = await selectedRow.boundingBox()
     expect(badgeBox).not.toBeNull()
+    expect(thumbnailBox).not.toBeNull()
     expect(selectedRowBox).not.toBeNull()
-    expect(badgeBox!.width).toBeGreaterThan(34)
-    expect(badgeBox!.height).toBeGreaterThan(22)
+    expect(badgeBox!.width).toBeGreaterThan(30)
+    expect(badgeBox!.height).toBeGreaterThan(18)
+    expect(thumbnailBox!.width).toBeGreaterThan(40)
+    expect(thumbnailBox!.x).toBeGreaterThan(selectedRowBox!.x)
 
     const nameButton = selectedRow.locator('button[title="운영 점검 리포트.pdf"]')
     await nameButton.focus()
@@ -576,6 +566,35 @@ test.describe("관리자 클라우드", () => {
 
     await expect(selectedRow.getByRole("button", { name: /미리보기/ })).toHaveCount(0)
     await expect(selectedRow.getByRole("button", { name: "운영 점검 리포트.pdf 삭제" })).toHaveCount(0)
+  })
+
+  test("파일이 많은 목록은 상세정보를 드로어로 열어 목록 폭을 유지한다", async ({ page }) => {
+    const manyFiles = Array.from({ length: 9 }, (_, index): CloudFileFixture => ({
+      id: 300 + index,
+      ownerMemberId: 1,
+      originalFilename: `density-${index + 1}.png`,
+      contentType: "image/png",
+      byteSize: 32_768 + index,
+      mediaKind: "PHOTO",
+      folderPath: "/photos",
+      createdAt: "2026-06-12T10:00:00Z",
+      modifiedAt: "2026-06-12T10:00:00Z",
+    }))
+    await setupAdminCloudMocks(page, { initialFiles: manyFiles })
+
+    await page.goto("/admin/cloud")
+
+    const tableBoxBefore = await page.getByRole("table").boundingBox()
+    await expect(page.getByLabel("클라우드 상세정보")).toHaveCount(0)
+    await page.locator('button[title="density-1.png"]').click()
+
+    const detailPanel = page.getByLabel("클라우드 상세정보")
+    await expect(detailPanel).toBeVisible()
+    await expect(detailPanel).toHaveCSS("position", "fixed")
+    const tableBoxAfter = await page.getByRole("table").boundingBox()
+    expect(tableBoxBefore).not.toBeNull()
+    expect(tableBoxAfter).not.toBeNull()
+    expect(Math.abs(tableBoxAfter!.width - tableBoxBefore!.width)).toBeLessThanOrEqual(2)
   })
 
   test("관리자 클라우드 진입만으로 알림 snapshot 백그라운드 요청을 시작하지 않는다", async ({ page }) => {

--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -603,10 +603,28 @@ test.describe("관리자 클라우드", () => {
 
     await page.goto("/admin/cloud")
 
-    await expect(page.getByRole("row", { name: /운영 점검 리포트\.pdf/ })).toBeVisible()
+    const firstRow = page.getByRole("row", { name: /운영 점검 리포트\.pdf/ })
+    await expect(firstRow).toBeVisible()
+    await expect(firstRow).not.toHaveAttribute("data-selected", "true")
     await expect(page.getByLabel("클라우드 상세정보")).toHaveCount(0)
     await page.locator('button[title="운영 점검 리포트.pdf"]').click()
     await expect(page.getByLabel("클라우드 상세정보")).toHaveCSS("position", "fixed")
+  })
+
+  test("작은 화면 빈 목록의 첫 업로드는 열린 상세정보를 유지한다", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await setupAdminCloudMocks(page, { initialFiles: [] })
+
+    await page.goto("/admin/cloud")
+    await page.getByLabel("클라우드 파일 업로드").setInputFiles({
+      name: "모바일 첫 업로드.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4 first mobile upload"),
+    })
+
+    await expect(page.getByRole("row", { name: /모바일 첫 업로드\.pdf/ })).toBeVisible()
+    await expect(page.getByLabel("클라우드 상세정보")).toHaveCSS("position", "fixed")
+    await expect(page.getByLabel("클라우드 상세정보").getByText("모바일 첫 업로드.pdf")).toBeVisible()
   })
 
   test("관리자 클라우드 진입만으로 알림 snapshot 백그라운드 요청을 시작하지 않는다", async ({ page }) => {

--- a/front/e2e/admin-runtime-regressions.spec.ts
+++ b/front/e2e/admin-runtime-regressions.spec.ts
@@ -111,7 +111,7 @@ test.describe("관리자 런타임 회귀 계약", () => {
     expect(documentSource).toContain('document.documentElement.setAttribute("data-aquila-scheme-bootstrap-source", bootstrapSource)')
     expect(documentSource).toContain("prefers-color-scheme: dark")
     expect(documentSource).toContain("colorScheme = nextScheme")
-    expect(documentSource).toContain('nextScheme === "dark" ? "#121212" : "#f3f5f8"')
+    expect(documentSource).toContain('nextScheme === "dark" ? "#0d1117" : "#f3f5f8"')
     expect(documentSource).toContain('var darkPreHydrationGuard = nextScheme === "dark"')
     expect(documentSource).toContain('html[data-aquila-scheme-bootstrap="dark"] *{color-scheme:dark!important;}')
     expect(documentSource).toContain('background-color:transparent!important;background-image:none!important;box-shadow:none!important;')

--- a/front/e2e/admin-surface-primitives.spec.ts
+++ b/front/e2e/admin-surface-primitives.spec.ts
@@ -68,7 +68,10 @@ test.describe("관리자 표면 공통 계약", () => {
     expect(utilitySource).not.toContain("border-radius: 14px;")
 
     expect(cloudStyleSource).toContain("background: ${surface};")
-    expect(cloudStyleSource).toContain("grid-template-columns: minmax(0, 1fr) minmax(18rem, 21rem);")
+    expect(cloudStyleSource).toContain("grid-template-columns: minmax(0, 1fr);")
+    expect(cloudStyleSource).toContain('data-detail-open="true"')
+    expect(cloudStyleSource).toContain('data-detail-mode="inline"')
+    expect(cloudStyleSource).toContain("grid-template-columns: minmax(0, 3fr) minmax(22rem, 2fr);")
     expect(cloudPageSource).toContain('선택한 조건에 맞는 파일이 없습니다.')
     expect(cloudPageSource).not.toContain("아직 올린 파일이 없습니다.")
 

--- a/front/e2e/mobile-layout.spec.ts
+++ b/front/e2e/mobile-layout.spec.ts
@@ -70,7 +70,7 @@ test.describe("모바일 레이아웃 소스 경계", () => {
     expect(adminColorTokenSource).toContain("export const adminSystemThemeVariables = (theme: Theme) =>")
     expect(adminColorTokenSource).toContain('theme.scheme === "dark" ? adminDarkThemeVariables : adminLightThemeVariables')
     expect(adminColorTokenSource).toContain("--admin-app-bg: #ffffff;")
-    expect(adminColorTokenSource).toContain("--admin-app-bg: #121212;")
+    expect(adminColorTokenSource).toContain("--admin-app-bg: #0d1117;")
     expect(adminSurfaceSource).toContain("adminPlainSurface(theme)")
     expect(adminShellSource).toContain("adminSystemThemeVariables(theme)")
     expect(adminShellSource).toContain("background: ${adminAppBackground};")

--- a/front/src/pages/_document.tsx
+++ b/front/src/pages/_document.tsx
@@ -29,7 +29,7 @@ const AQUILA_SCHEME_BOOTSTRAP_SCRIPT = `
   var defaultScheme = configuredScheme === "system" ? (systemDark ? "dark" : "light") : configuredScheme;
   var nextScheme = cachedScheme || defaultScheme;
   var bootstrapSource = cachedScheme ? "cookie" : "system";
-  var background = nextScheme === "dark" ? "#121212" : "#f3f5f8";
+  var background = nextScheme === "dark" ? "#0d1117" : "#f3f5f8";
   var foreground = nextScheme === "dark" ? "#f4f6fb" : "#101214";
   var darkPreHydrationGuard = nextScheme === "dark"
     ? [

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -28,16 +28,23 @@ export const CloudMain = styled.main`
 `
 
 export const CloudWorkspace = styled.section`
+  position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(18rem, 21rem);
+  grid-template-columns: minmax(0, 1fr);
   min-height: calc(100vh - var(--app-header-height, 73px) - 3.95rem);
 
-  @media (max-width: 1260px) {
-    grid-template-columns: minmax(0, 1fr) minmax(17rem, 19rem);
+  &[data-detail-open="true"][data-detail-mode="inline"] {
+    grid-template-columns: minmax(0, 3fr) minmax(22rem, 2fr);
   }
 
-  @media (max-width: 980px) {
+  &[data-detail-open="true"][data-detail-mode="drawer"] {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  @media (max-width: 1080px) {
+    &[data-detail-open="true"][data-detail-mode] {
+      grid-template-columns: minmax(0, 1fr);
+    }
   }
 `
 
@@ -147,7 +154,7 @@ export const CloudContent = styled.div`
 
 export const CloudTitleBar = styled.header`
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(18rem, 26rem);
+  grid-template-columns: minmax(0, 1fr) minmax(20rem, 32rem);
   gap: 1rem;
   align-items: center;
   padding: 1rem 1.25rem 0.72rem;
@@ -220,7 +227,7 @@ export const SearchDetail = styled.span`
 export const ActionBar = styled.div`
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  align-items: start;
+  align-items: center;
   justify-content: space-between;
   gap: 0.8rem;
   min-width: 0;
@@ -324,6 +331,40 @@ export const IconButton = styled.button`
     border-color: ${borderStrong};
     background: ${surfaceAccent};
   }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.58;
+  }
+`
+
+export const ViewModeButton = styled.button`
+  min-height: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  flex-shrink: 0;
+  border: 1px solid ${border};
+  border-radius: 5px;
+  padding: 0 0.64rem;
+  background: ${surface};
+  color: ${textSecondary};
+  font-size: 0.8rem;
+  font-weight: 820;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &[data-active="true"] {
+    color: ${accentGold};
+    border-color: ${borderStrong};
+    background: ${surfaceAccent};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.58;
+  }
 `
 
 export const FilterGroup = styled.div`
@@ -379,7 +420,7 @@ export const FileTableScroll = styled.div`
 
 export const FileTable = styled.table`
   width: 100%;
-  min-width: 50rem;
+  min-width: 48rem;
   border-collapse: collapse;
   table-layout: fixed;
   color: ${textPrimary};
@@ -392,7 +433,7 @@ export const FileTable = styled.table`
   }
 
   th {
-    height: 2.25rem;
+    height: 2.4rem;
     padding: 0 0.7rem;
     color: ${textMuted};
     background: ${surfaceRaised};
@@ -401,7 +442,7 @@ export const FileTable = styled.table`
   }
 
   td {
-    height: 3.1rem;
+    height: 4.15rem;
     padding: 0 0.7rem;
     color: ${textSecondary};
     font-size: 0.82rem;
@@ -425,17 +466,16 @@ export const FileTable = styled.table`
 
   th:nth-of-type(3),
   td:nth-of-type(3) {
-    width: 4.2rem;
-    text-align: center;
+    width: auto;
+  }
+
+  th:nth-of-type(4),
+  td:nth-of-type(4) {
+    width: 5.8rem;
   }
 
   th:nth-of-type(5),
   td:nth-of-type(5) {
-    width: 5.6rem;
-  }
-
-  th:nth-of-type(6),
-  td:nth-of-type(6) {
     width: 8.9rem;
   }
 `
@@ -461,13 +501,14 @@ export const FavoriteButton = styled.button`
 `
 
 export const FileTypeIcon = styled.span`
-  min-width: 2.65rem;
+  min-width: 2.45rem;
+  flex: 0 0 2.65rem;
   height: 1.58rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border-radius: 4px;
-  background: ${({ theme }) => theme.colors.gray3};
+  background: ${surfaceRaised};
   color: ${accentGold};
   border: 1px solid ${border};
   font-size: 0.68rem;
@@ -475,9 +516,74 @@ export const FileTypeIcon = styled.span`
   letter-spacing: 0;
 
   &[data-selected="true"] {
-    background: ${({ theme }) => theme.colors.gray2};
+    background: ${surfaceMuted};
     border-color: ${borderStrong};
-    color: ${({ theme }) => theme.colors.gray12};
+    color: ${textPrimary};
+  }
+`
+
+export const FileIdentity = styled.div`
+  display: grid;
+  grid-template-columns: 3rem minmax(0, 1fr);
+  gap: 0.72rem;
+  align-items: center;
+  min-width: 0;
+`
+
+export const FileThumbnailFrame = styled.span`
+  width: 3rem;
+  height: 2.4rem;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid ${border};
+  border-radius: 6px;
+  background: ${surfaceRaised};
+  color: ${accentGold};
+  font-size: 0.68rem;
+  font-weight: 900;
+
+  &[data-kind="DOCUMENT"] {
+    background: var(--admin-surface-accent, #edf3ff);
+  }
+
+  &[data-kind="VIDEO"] {
+    background: ${surfaceMuted};
+  }
+
+  &[data-selected="true"] {
+    border-color: ${borderStrong};
+    box-shadow: inset 0 0 0 1px ${borderStrong};
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    background: ${surfaceMuted};
+  }
+`
+
+export const FileNameStack = styled.div`
+  display: grid;
+  gap: 0.18rem;
+  min-width: 0;
+`
+
+export const FileMetaLine = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 0.38rem;
+  min-width: 0;
+  color: ${textMuted};
+  font-size: 0.74rem;
+  font-weight: 760;
+
+  > span:not([data-file-kind-badge]) {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 `
 
@@ -524,9 +630,6 @@ export const FileNameButton = styled.button`
 
   &:focus-visible {
     outline: none;
-    text-decoration: underline;
-    text-decoration-thickness: 2px;
-    text-underline-offset: 0.22rem;
     color: ${accentGold};
   }
 `
@@ -564,14 +667,54 @@ export const DetailPanel = styled.aside`
   border-left: 1px solid ${border};
   background: ${surface};
 
-  @media (max-width: 1260px) {
+  &[data-mode="inline"] {
     grid-column: 2;
   }
 
-  @media (max-width: 980px) {
-    grid-column: 1;
-    border-left: 0;
-    border-top: 1px solid ${border};
+  &[data-mode="drawer"] {
+    position: fixed;
+    top: var(--app-header-height, 73px);
+    right: 0;
+    bottom: 0;
+    z-index: ${zIndexes.dialog};
+    width: min(29rem, calc(100vw - 2rem));
+    overflow: auto;
+    box-shadow: -18px 0 48px rgba(0, 0, 0, 0.32);
+  }
+
+  @media (max-width: 1080px) {
+    position: fixed;
+    top: var(--app-header-height, 73px);
+    right: 0;
+    bottom: 0;
+    z-index: ${zIndexes.dialog};
+    width: min(29rem, calc(100vw - 2rem));
+    overflow: auto;
+    box-shadow: -18px 0 48px rgba(0, 0, 0, 0.32);
+  }
+`
+
+export const DetailScrim = styled.button`
+  display: none;
+
+  &[data-mode="drawer"] {
+    position: fixed;
+    inset: var(--app-header-height, 73px) 0 0;
+    z-index: ${zIndexes.dialog - 1};
+    display: block;
+    border: 0;
+    padding: 0;
+    background: rgba(0, 0, 0, 0.38);
+  }
+
+  @media (max-width: 1080px) {
+    position: fixed;
+    inset: var(--app-header-height, 73px) 0 0;
+    z-index: ${zIndexes.dialog - 1};
+    display: block;
+    border: 0;
+    padding: 0;
+    background: rgba(0, 0, 0, 0.38);
   }
 `
 
@@ -619,6 +762,31 @@ export const DetailPreviewBox = styled.div`
   overflow: auto;
 `
 
+export const DetailSummary = styled.div`
+  display: grid;
+  grid-template-columns: 3.2rem minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: center;
+  min-width: 0;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid ${border};
+
+  strong {
+    display: block;
+    color: ${textPrimary};
+    font-size: 0.94rem;
+    font-weight: 860;
+    overflow-wrap: anywhere;
+  }
+
+  p {
+    margin: 0.22rem 0 0;
+    color: ${textMuted};
+    font-size: 0.78rem;
+    font-weight: 760;
+  }
+`
+
 export const DetailMetaList = styled.dl`
   display: grid;
   grid-template-columns: 5rem minmax(0, 1fr);
@@ -626,9 +794,18 @@ export const DetailMetaList = styled.dl`
   margin: 0;
 
   dt {
+    display: flex;
+    align-items: center;
+    gap: 0.38rem;
     color: ${textMuted};
     font-size: 0.8rem;
     font-weight: 800;
+  }
+
+  dt span {
+    width: 1rem;
+    color: ${accentGold};
+    text-align: center;
   }
 
   dd {

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -370,6 +370,11 @@ export const ViewModeButton = styled.button`
     cursor: not-allowed;
     opacity: 0.58;
   }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--admin-focus-ring, rgba(111, 149, 255, 0.22));
+  }
 `
 
 export const FilterGroup = styled.div`

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -336,6 +336,11 @@ export const IconButton = styled.button`
     cursor: not-allowed;
     opacity: 0.58;
   }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--admin-focus-ring, rgba(111, 149, 255, 0.22));
+  }
 `
 
 export const ViewModeButton = styled.button`
@@ -514,6 +519,9 @@ export const FileTypeIcon = styled.span`
   font-size: 0.68rem;
   font-weight: 900;
   letter-spacing: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   &[data-selected="true"] {
     background: ${surfaceMuted};

--- a/front/src/routes/Admin/AdminCloudWorkspaceModel.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspaceModel.ts
@@ -50,8 +50,8 @@ export const getCloudKindLabel = (kind: CloudMediaFilter) => {
 export const getCloudKindBadge = (file: CloudFile) => {
   const extension = getCloudFileExtension(file.originalFilename)
   if (file.mediaKind === "DOCUMENT") return extension || "DOC"
-  if (file.mediaKind === "PHOTO") return "IMG"
-  return "MP4"
+  if (file.mediaKind === "PHOTO") return extension || "IMG"
+  return extension || "MP4"
 }
 
 export const getCloudKindIconLabel = (file: CloudFile) => {

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -87,6 +87,7 @@ const CLOUD_QUERY_KEY = "admin-cloud-files"
 const EMPTY_CLOUD_FILES: CloudFile[] = []
 const PDF_STANDARD_FONT_DATA_URL = "/pdfjs/standard_fonts/"
 const PDF_LOADED_TASK_DESTROY_DELAY_MS = 3000
+const DETAIL_INLINE_MEDIA_QUERY = "(min-width: 1081px)"
 
 const mediaKindFromFilter = (filter: CloudMediaFilter): CloudMediaKind | undefined =>
   filter === "ALL" ? undefined : filter
@@ -512,7 +513,8 @@ const AdminCloudWorkspacePage = () => {
   useEffect(() => {
     if (didInitializeDetailModeRef.current || files.length === 0) return
     didInitializeDetailModeRef.current = true
-    setIsDetailPanelOpen(files.length <= 8)
+    const canUseInlineDetail = window.matchMedia(DETAIL_INLINE_MEDIA_QUERY).matches
+    setIsDetailPanelOpen(canUseInlineDetail && files.length <= 8)
   }, [files.length])
 
   useEffect(() => {

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -511,11 +511,12 @@ const AdminCloudWorkspacePage = () => {
   }, [files, selectedFileId])
 
   useEffect(() => {
-    if (didInitializeDetailModeRef.current || files.length === 0) return
+    if (didInitializeDetailModeRef.current || filesQuery.isLoading) return
     didInitializeDetailModeRef.current = true
+    if (files.length === 0 || isDetailPanelOpen) return
     const canUseInlineDetail = window.matchMedia(DETAIL_INLINE_MEDIA_QUERY).matches
     setIsDetailPanelOpen(canUseInlineDetail && files.length <= 8)
-  }, [files.length])
+  }, [files.length, filesQuery.isLoading, isDetailPanelOpen])
 
   useEffect(() => {
     setCheckedFileIds((current) => current.filter((id) => files.some((file) => file.id === id)))
@@ -939,7 +940,7 @@ const AdminCloudWorkspacePage = () => {
                 <tbody>
                   {files.map((file) => {
                     const checked = checkedFileIds.includes(file.id)
-                    const selected = selectedFile?.id === file.id
+                    const selected = shouldShowDetailPanel && selectedFile?.id === file.id
                     const filenameParts = getCloudFilenameParts(file.originalFilename)
                     return (
                       <tr key={file.id} data-selected={selected ? "true" : "false"}>

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -421,14 +421,6 @@ type FileThumbnailProps = {
 const FileThumbnail = ({ file, selected }: FileThumbnailProps) => {
   const badge = getCloudKindBadge(file)
 
-  if (file.mediaKind === "PHOTO") {
-    return (
-      <FileThumbnailFrame data-kind={file.mediaKind} data-selected={selected ? "true" : "false"}>
-        <img src={getCloudFileContentUrl(file.id)} alt="" loading="lazy" decoding="async" />
-      </FileThumbnailFrame>
-    )
-  }
-
   return (
     <FileThumbnailFrame
       aria-hidden="true"

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -44,14 +44,20 @@ import {
   DetailMetaList,
   DetailPanel,
   DetailPreviewBox,
+  DetailScrim,
+  DetailSummary,
   DetailTab,
   DetailTabs,
   EmptyState,
   EmptyTableState,
   FavoriteButton,
+  FileIdentity,
+  FileMetaLine,
   FileNameButton,
+  FileNameStack,
   FileTable,
   FileTableScroll,
+  FileThumbnailFrame,
   FileTypeIcon,
   FilterGroup,
   GhostButton,
@@ -73,13 +79,13 @@ import {
   ToastViewport,
   Timeline,
   UploadInput,
+  ViewModeButton,
   VideoFrame,
 } from "./AdminCloudWorkspace.styles"
 
 const CLOUD_QUERY_KEY = "admin-cloud-files"
 const EMPTY_CLOUD_FILES: CloudFile[] = []
 const PDF_STANDARD_FONT_DATA_URL = "/pdfjs/standard_fonts/"
-const PDF_LOADED_TASK_DESTROY_DELAY_MS = 3000
 
 const mediaKindFromFilter = (filter: CloudMediaFilter): CloudMediaKind | undefined =>
   filter === "ALL" ? undefined : filter
@@ -184,11 +190,6 @@ const ignorePdfPreviewTeardownRejection = (
       await pdfDocument.cleanup().catch(() => {
         // 이미 해제된 문서 리소스 정리는 사용자에게 노출하지 않는다.
       })
-      window.setTimeout(() => {
-        void loadingTask?.destroy().catch(() => {
-          // worker 종료 reject는 teardown 내부에서 소비한다.
-        })
-      }, PDF_LOADED_TASK_DESTROY_DELAY_MS)
     })
     return
   }
@@ -281,7 +282,6 @@ const PdfPreview = ({ file, contentUrl }: PdfPreviewProps) => {
     <PreviewStage>
       <PreviewHeader>
         <h3>문서 뷰어</h3>
-        <p>{file.originalFilename}</p>
       </PreviewHeader>
       <PdfCanvas ref={canvasRef} aria-label={`${file.originalFilename} PDF 미리보기`} />
       <InlineList aria-label="PDF 문서 제어">
@@ -314,7 +314,6 @@ const PhotoPreview = ({ file, contentUrl }: PhotoPreviewProps) => {
     <PreviewStage>
       <PreviewHeader>
         <h3>사진 보기</h3>
-        <p>{file.originalFilename}</p>
       </PreviewHeader>
       <PhotoFrame aria-busy={isImageReady ? "false" : "true"}>
         {!isImageReady ? <span role="status">사진을 불러오는 중입니다.</span> : null}
@@ -345,7 +344,6 @@ const VideoPreview = ({ file, contentUrl }: VideoPreviewProps) => {
     <PreviewStage>
       <PreviewHeader>
         <h3>동영상 플레이어</h3>
-        <p>{file.originalFilename}</p>
       </PreviewHeader>
       <VideoFrame>
         <video src={contentUrl} controls preload="metadata" />
@@ -408,6 +406,33 @@ const PreviewDrawer = ({ file }: PreviewDrawerProps) => {
   return <VideoPreview file={file} contentUrl={contentUrl} />
 }
 
+type FileThumbnailProps = {
+  file: CloudFile
+  selected: boolean
+}
+
+const FileThumbnail = ({ file, selected }: FileThumbnailProps) => {
+  const badge = getCloudKindBadge(file)
+
+  if (file.mediaKind === "PHOTO") {
+    return (
+      <FileThumbnailFrame data-kind={file.mediaKind} data-selected={selected ? "true" : "false"}>
+        <img src={getCloudFileContentUrl(file.id)} alt="" loading="lazy" decoding="async" />
+      </FileThumbnailFrame>
+    )
+  }
+
+  return (
+    <FileThumbnailFrame
+      aria-hidden="true"
+      data-kind={file.mediaKind}
+      data-selected={selected ? "true" : "false"}
+    >
+      {badge}
+    </FileThumbnailFrame>
+  )
+}
+
 type DeleteConfirmState = {
   files: CloudFile[]
 }
@@ -424,7 +449,6 @@ const FileTableHead = () => (
     <tr>
       <th aria-label="선택" />
       <th aria-label="즐겨찾기" />
-      <th>종류</th>
       <th>이름</th>
       <th>크기</th>
       <th>수정한 날짜</th>
@@ -436,6 +460,7 @@ const AdminCloudWorkspacePage = () => {
   const queryClient = useQueryClient()
   const uploadInputRef = useRef<HTMLInputElement>(null)
   const uploadControllersRef = useRef<Map<string, AbortController>>(new Map())
+  const didInitializeDetailModeRef = useRef(false)
   const [filter, setFilter] = useState<CloudMediaFilter>("ALL")
   const [keyword, setKeyword] = useState("")
   const [selectedFileId, setSelectedFileId] = useState<number | null>(null)
@@ -470,9 +495,9 @@ const AdminCloudWorkspacePage = () => {
     () => mergeCloudFiles(visibleOptimisticFiles, serverFiles),
     [serverFiles, visibleOptimisticFiles]
   )
-  const selectedFile = isDetailPanelOpen
-    ? files.find((file) => file.id === selectedFileId) || files[0] || null
-    : null
+  const selectedFile = files.find((file) => file.id === selectedFileId) || files[0] || null
+  const isDetailDrawerMode = files.length > 8
+  const shouldShowDetailPanel = isDetailPanelOpen && selectedFile !== null
   const activeUploadCount = uploadQueue.filter((item) => isUploadActive(item.status)).length
   const completedUploadCount = uploadQueue.filter((item) => item.status === "done").length
   const allVisibleChecked = files.length > 0 && files.every((file) => checkedFileIds.includes(file.id))
@@ -481,10 +506,15 @@ const AdminCloudWorkspacePage = () => {
   const previousFocusRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
-    if (!isDetailPanelOpen) return
     if (selectedFileId && files.some((file) => file.id === selectedFileId)) return
     setSelectedFileId(files[0]?.id ?? null)
-  }, [files, isDetailPanelOpen, selectedFileId])
+  }, [files, selectedFileId])
+
+  useEffect(() => {
+    if (didInitializeDetailModeRef.current || files.length === 0) return
+    didInitializeDetailModeRef.current = true
+    setIsDetailPanelOpen(files.length <= 8)
+  }, [files.length])
 
   useEffect(() => {
     setCheckedFileIds((current) => current.filter((id) => files.some((file) => file.id === id)))
@@ -773,7 +803,10 @@ const AdminCloudWorkspacePage = () => {
 
   return (
     <CloudMain>
-      <CloudWorkspace>
+      <CloudWorkspace
+        data-detail-open={shouldShowDetailPanel ? "true" : "false"}
+        data-detail-mode={isDetailDrawerMode ? "drawer" : "inline"}
+      >
         <CloudContent>
           <CloudTitleBar>
             <div>
@@ -783,11 +816,11 @@ const AdminCloudWorkspacePage = () => {
               <AppIcon name="search" />
               <SearchInput
                 aria-label="클라우드 파일 검색"
-                placeholder="파일명 또는 /폴더 경로 검색"
+                placeholder="클라우드 파일 검색"
                 value={keyword}
                 onChange={(event) => setKeyword(event.target.value)}
               />
-              <SearchDetail aria-hidden="true">상세</SearchDetail>
+              <SearchDetail aria-hidden="true">파일</SearchDetail>
             </CloudSearchField>
           </CloudTitleBar>
 
@@ -816,7 +849,7 @@ const AdminCloudWorkspacePage = () => {
                 ⤴ 올리기
               </PrimaryButton>
               <SecondaryButton type="button" disabled>
-                새로 만들기
+                새 폴더
               </SecondaryButton>
               <SecondaryButton type="button" disabled={checkedFileIds.length === 0} onClick={handleDeleteSelected}>
                 선택 삭제
@@ -837,20 +870,23 @@ const AdminCloudWorkspacePage = () => {
                   </GhostButton>
                 ))}
               </FilterGroup>
-              <IconButton type="button" aria-label="리스트 보기" data-active="true">
-                ☷
-              </IconButton>
-              <IconButton
+              <ViewModeButton type="button" aria-label="리스트 보기" data-active="true">
+                ☰ 리스트
+              </ViewModeButton>
+              <ViewModeButton type="button" aria-label="그리드 보기" disabled>
+                ⊞ 그리드
+              </ViewModeButton>
+              <ViewModeButton
                 type="button"
                 aria-label="상세 패널 보기"
-                data-active={selectedFile ? "true" : "false"}
+                data-active={shouldShowDetailPanel ? "true" : "false"}
                 onClick={() => {
-                  setIsDetailPanelOpen(true)
+                  setIsDetailPanelOpen((current) => !current)
                   setSelectedFileId((current) => current ?? files[0]?.id ?? null)
                 }}
               >
-                ⓘ
-              </IconButton>
+                ⓘ 정보
+              </ViewModeButton>
             </ActionGroup>
           </ActionBar>
 
@@ -869,7 +905,7 @@ const AdminCloudWorkspacePage = () => {
                 <FileTableHead />
                 <tbody>
                   <tr>
-                    <td colSpan={6}>
+                    <td colSpan={5}>
                       <LoadingTableStatus role="status" aria-label="파일 목록 로딩">
                         파일 목록 로딩
                       </LoadingTableStatus>
@@ -924,24 +960,31 @@ const AdminCloudWorkspacePage = () => {
                           </FavoriteButton>
                         </td>
                         <td>
-                          <FileTypeIcon
-                            aria-label={getCloudKindLabel(file.mediaKind)}
-                            data-selected={selected ? "true" : "false"}
-                          >
-                            {getCloudKindIconLabel(file)}
-                          </FileTypeIcon>
-                        </td>
-                        <td>
-                          <FileNameButton
-                            type="button"
-                            title={file.originalFilename}
-                            onClick={() => handlePreviewFile(file.id)}
-                          >
-                            <strong>
-                              <span data-filename-stem>{filenameParts.stem}</span>
-                              <span data-filename-extension>{filenameParts.extension}</span>
-                            </strong>
-                          </FileNameButton>
+                          <FileIdentity>
+                            <FileThumbnail file={file} selected={selected} />
+                            <FileNameStack>
+                              <FileNameButton
+                                type="button"
+                                title={file.originalFilename}
+                                onClick={() => handlePreviewFile(file.id)}
+                              >
+                                <strong>
+                                  <span data-filename-stem>{filenameParts.stem}</span>
+                                  <span data-filename-extension>{filenameParts.extension}</span>
+                                </strong>
+                              </FileNameButton>
+                              <FileMetaLine>
+                                <FileTypeIcon
+                                  aria-label={getCloudKindLabel(file.mediaKind)}
+                                  data-file-kind-badge="true"
+                                  data-selected={selected ? "true" : "false"}
+                                >
+                                  {getCloudKindIconLabel(file)}
+                                </FileTypeIcon>
+                                <span>{getCloudKindLabel(file.mediaKind)}</span>
+                              </FileMetaLine>
+                            </FileNameStack>
+                          </FileIdentity>
                         </td>
                         <td>{formatCloudFileSize(file.byteSize)}</td>
                         <td>{formatCloudDate(file.modifiedAt || file.createdAt)}</td>
@@ -954,46 +997,82 @@ const AdminCloudWorkspacePage = () => {
           </FileTableScroll>
         </CloudContent>
 
-        <DetailPanel aria-label="클라우드 상세정보">
-          <DetailHeader>
-            <h2>파일 정보</h2>
-            <IconButton
+        {shouldShowDetailPanel ? (
+          <>
+            <DetailScrim
               type="button"
               aria-label="상세 패널 닫기"
-              onClick={() => {
-                setIsDetailPanelOpen(false)
-              }}
-            >
-              ×
-            </IconButton>
-          </DetailHeader>
-          <DetailTabs>
-            <DetailTab type="button" data-active="true">
-              상세정보
-            </DetailTab>
-          </DetailTabs>
-          <DetailPreviewBox>
-            <PreviewDrawer file={selectedFile} />
-          </DetailPreviewBox>
-          {selectedFile ? (
-            <DetailMetaList>
-              <dt>종류</dt>
-              <dd>
-                {getCloudKindBadge(selectedFile)} · {getCloudKindLabel(selectedFile.mediaKind)}
-              </dd>
-              <dt>위치</dt>
-              <dd>{selectedFile.folderPath || "/"}</dd>
-              <dt>올린 날짜</dt>
-              <dd>{formatCloudDate(selectedFile.createdAt)}</dd>
-              <dt>수정한 날짜</dt>
-              <dd>{formatCloudDate(selectedFile.modifiedAt || selectedFile.createdAt)}</dd>
-              <dt>크기</dt>
-              <dd>{formatCloudFileSize(selectedFile.byteSize)}</dd>
-              <dt>권한</dt>
-              <dd>계정 소유주만 볼 수 있음</dd>
-            </DetailMetaList>
-          ) : null}
-        </DetailPanel>
+              data-mode={isDetailDrawerMode ? "drawer" : "inline"}
+              onClick={() => setIsDetailPanelOpen(false)}
+            />
+            <DetailPanel aria-label="클라우드 상세정보" data-mode={isDetailDrawerMode ? "drawer" : "inline"}>
+              <DetailHeader>
+                <h2>파일 정보</h2>
+                <IconButton
+                  type="button"
+                  aria-label="상세 패널 닫기"
+                  onClick={() => {
+                    setIsDetailPanelOpen(false)
+                  }}
+                >
+                  ×
+                </IconButton>
+              </DetailHeader>
+              <DetailTabs>
+                <DetailTab type="button" data-active="true">
+                  상세정보
+                </DetailTab>
+              </DetailTabs>
+              <DetailPreviewBox>
+                <PreviewDrawer file={selectedFile} />
+              </DetailPreviewBox>
+              <DetailSummary>
+                <FileThumbnail file={selectedFile} selected />
+                <div>
+                  <strong>{selectedFile.originalFilename}</strong>
+                  <p>
+                    {getCloudKindBadge(selectedFile)} · {getCloudKindLabel(selectedFile.mediaKind)} ·{" "}
+                    {formatCloudFileSize(selectedFile.byteSize)}
+                  </p>
+                </div>
+              </DetailSummary>
+              <DetailMetaList>
+                <dt>
+                  <span aria-hidden="true">T</span>
+                  종류
+                </dt>
+                <dd>
+                  {getCloudKindBadge(selectedFile)} · {getCloudKindLabel(selectedFile.mediaKind)}
+                </dd>
+                <dt>
+                  <span aria-hidden="true">P</span>
+                  위치
+                </dt>
+                <dd>{selectedFile.folderPath || "/"}</dd>
+                <dt>
+                  <span aria-hidden="true">U</span>
+                  올린 날짜
+                </dt>
+                <dd>{formatCloudDate(selectedFile.createdAt)}</dd>
+                <dt>
+                  <span aria-hidden="true">M</span>
+                  수정한 날짜
+                </dt>
+                <dd>{formatCloudDate(selectedFile.modifiedAt || selectedFile.createdAt)}</dd>
+                <dt>
+                  <span aria-hidden="true">S</span>
+                  크기
+                </dt>
+                <dd>{formatCloudFileSize(selectedFile.byteSize)}</dd>
+                <dt>
+                  <span aria-hidden="true">L</span>
+                  권한
+                </dt>
+                <dd>계정 소유주만 볼 수 있음</dd>
+              </DetailMetaList>
+            </DetailPanel>
+          </>
+        ) : null}
       </CloudWorkspace>
       {toast ? (
         <ToastViewport data-tone={toast.tone} role="status" aria-live="polite">

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -86,6 +86,7 @@ import {
 const CLOUD_QUERY_KEY = "admin-cloud-files"
 const EMPTY_CLOUD_FILES: CloudFile[] = []
 const PDF_STANDARD_FONT_DATA_URL = "/pdfjs/standard_fonts/"
+const PDF_LOADED_TASK_DESTROY_DELAY_MS = 3000
 
 const mediaKindFromFilter = (filter: CloudMediaFilter): CloudMediaKind | undefined =>
   filter === "ALL" ? undefined : filter
@@ -190,6 +191,12 @@ const ignorePdfPreviewTeardownRejection = (
       await pdfDocument.cleanup().catch(() => {
         // 이미 해제된 문서 리소스 정리는 사용자에게 노출하지 않는다.
       })
+
+      window.setTimeout(() => {
+        void loadingTask?.destroy().catch(() => {
+          // 로드 완료 후 worker 종료 reject도 미리보기 teardown 결과로 흡수한다.
+        })
+      }, PDF_LOADED_TASK_DESTROY_DELAY_MS)
     })
     return
   }
@@ -469,7 +476,7 @@ const AdminCloudWorkspacePage = () => {
   const [toast, setToast] = useState<CloudToastState>(null)
   const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([])
   const [optimisticFiles, setOptimisticFiles] = useState<CloudFile[]>([])
-  const [isDetailPanelOpen, setIsDetailPanelOpen] = useState(true)
+  const [isDetailPanelOpen, setIsDetailPanelOpen] = useState(false)
   const [deleteConfirm, setDeleteConfirm] = useState<DeleteConfirmState | null>(null)
   const [isDeletePending, setIsDeletePending] = useState(false)
 

--- a/front/src/routes/Admin/AdminUtilityBar.tsx
+++ b/front/src/routes/Admin/AdminUtilityBar.tsx
@@ -115,8 +115,8 @@ const AdminUtilityBar = ({ navItems, currentLabel }: Props) => {
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             onKeyDown={handleSearchKeyDown}
-            placeholder="페이지 검색"
-            aria-label="관리자 검색"
+            placeholder="관리자 메뉴 검색"
+            aria-label="관리자 메뉴 검색"
           />
         </SearchField>
       </SearchForm>

--- a/front/src/routes/Admin/AdminUtilityBar.tsx
+++ b/front/src/routes/Admin/AdminUtilityBar.tsx
@@ -116,7 +116,7 @@ const AdminUtilityBar = ({ navItems, currentLabel }: Props) => {
             onChange={(event) => setQuery(event.target.value)}
             onKeyDown={handleSearchKeyDown}
             placeholder="관리자 메뉴 검색"
-            aria-label="관리자 메뉴 검색"
+            aria-label="관리자 검색"
           />
         </SearchField>
       </SearchForm>

--- a/front/src/routes/Admin/adminColorTokens.ts
+++ b/front/src/routes/Admin/adminColorTokens.ts
@@ -27,15 +27,15 @@ const adminLightThemeVariables = `
 
 const adminDarkThemeVariables = `
   color-scheme: dark;
-  --admin-app-bg: #121212;
-  --admin-sidebar-bg: #181818;
-  --admin-surface: #121212;
-  --admin-surface-raised: #1b1b1b;
-  --admin-surface-muted: #222222;
-  --admin-surface-accent: #172033;
-  --admin-elevated-top: #181818;
-  --admin-border: #2f333a;
-  --admin-border-strong: #4a5464;
+  --admin-app-bg: #0d1117;
+  --admin-sidebar-bg: #0d1117;
+  --admin-surface: #0d1117;
+  --admin-surface-raised: #161b22;
+  --admin-surface-muted: #21262d;
+  --admin-surface-accent: #1f2a44;
+  --admin-elevated-top: #161b22;
+  --admin-border: #30363d;
+  --admin-border-strong: #4b5567;
   --admin-text-primary: #f5f6f8;
   --admin-text-secondary: #c8ced7;
   --admin-text-muted: #8f99a7;


### PR DESCRIPTION
## 관련 이슈

close #804

## 작업 배경

- 관리자 클라우드가 파일 수가 적을 때 빈 공간이 과하고, 파일 타입/썸네일/상세 정보 밀도가 낮아 전문 파일 관리 UI처럼 보이지 않았습니다.
- 클라우드 내부 파일 검색과 관리자 메뉴 검색의 역할도 화면상 헷갈릴 수 있었습니다.

## 작업 내용

- 파일명 셀 안에 썸네일 placeholder, 확장자 배지, 파일 종류 메타를 통합했습니다.
- 파일 수가 적으면 목록/상세정보를 60/40에 가깝게 배치하고, 파일이 많거나 좁은 화면에서는 상세정보를 우측 drawer로 열도록 변경했습니다.
- 상세 패널에 파일 요약 영역을 추가하고, 중복 파일명 노출과 PDF worker teardown 오류 노출을 줄였습니다.
- 관리자 다크 테마를 GitHub dark 계열 색상으로 조정하고, 상단 검색 placeholder를 관리자 메뉴 검색과 클라우드 파일 검색으로 분리했습니다.
- admin-cloud/admin-surface e2e에 썸네일/배지, drawer 전환, 파일명 fallback, 업로드/삭제 회귀 검증을 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front lint` 통과
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-cloud.spec.ts e2e/admin-surface-primitives.spec.ts --workers=1` 통과 (32 passed)
  - `yarn --cwd front build` 통과
  - `git diff --check` 통과
  - PR CI 통과: frontend-ci, backend-ci, backend-dependency-check, CodeQL java-kotlin, CodeQL javascript-typescript, Vercel Preview, CodeRabbit
  - main CI 통과: backend-ci, frontend-ci
  - main Security 통과: backend-dependency-check, CodeQL java-kotlin, CodeQL javascript-typescript
  - Deploy to Home Server #27599171173 통과: frontend live e2e 성공, backend blue/green은 backend/deploy path 변경이 없어 조건상 skip

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `AdminCloudWorkspacePage.tsx`의 detail panel inline/drawer 전환 조건
  - `AdminCloudWorkspace.styles.ts`의 파일 행 썸네일/메타 밀도와 dark token 적용
  - `front/e2e/admin-cloud.spec.ts`의 drawer/배지/업로드/삭제 회귀 테스트

## 리스크

- 클라우드 파일 목록 UI 구조가 바뀌므로 행 높이와 상세 패널 폭 체감이 달라집니다.
- API 계약과 업로드/삭제 동작은 변경하지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
