### PR TITLE
[Feat] 홈 피드 제품형 브랜드 리디자인

### DIFF
--- a/front/e2e/helpers/perfFixtures.ts
+++ b/front/e2e/helpers/perfFixtures.ts
@@ -561,21 +561,6 @@ export const getDesktopTagRailMetrics = async (page: Page) =>
   })
 
 export const waitForHomeTagRailReady = async (page: Page, viewportWidth: number) => {
-  if (viewportWidth > 1200) {
-    await expect
-      .poll(
-        async () =>
-          page.evaluate(() => {
-            const list = document.querySelector(".desktopList")
-            if (!list) return 0
-            return list.querySelectorAll("li").length
-          }),
-        { timeout: 5000 }
-      )
-      .toBeGreaterThanOrEqual(4)
-    return
-  }
-
   await expect
     .poll(
       async () =>

--- a/front/e2e/home-feed-redesign.spec.ts
+++ b/front/e2e/home-feed-redesign.spec.ts
@@ -1,0 +1,296 @@
+import { expect, test, type Page } from "@playwright/test"
+import { readFileSync } from "fs"
+import path from "path"
+import {
+  addPublicAboutSnapshotCookie,
+  createExplorePost,
+  mockAvatarAsset,
+} from "./helpers/smokeFixtures"
+
+const TAGS = [
+  "JWT",
+  "Spring",
+  "Security",
+  "Kafka",
+  "Architecture",
+  "Infrastructure",
+  "Performance",
+  "Realtime",
+].map((tag, index) => ({ tag, count: 20 - index }))
+
+const POSTS = Array.from({ length: 9 }, (_, index) =>
+  createExplorePost({
+    id: 7000 + index,
+    title: index === 0 ? "JWT VS Session" : `AquilaLog 아키텍처 노트 ${index + 1}`,
+    summary:
+      index === 0
+        ? "JWT가 Stateless하다고 해서 무조건 좋은 것은 아니라는 점을 운영 관점에서 정리합니다."
+        : "Spring, Infrastructure, Security를 제품 수준의 글 카드에서 읽기 쉽게 정리합니다.",
+    tags: index === 0 ? [] : [TAGS[index % TAGS.length].tag],
+    category: [index === 0 ? "Security" : TAGS[index % TAGS.length].tag],
+    thumbnail: index % 3 === 0 ? "" : `/mock-cover-${index}.png`,
+    hitCount: 1200 + index * 137,
+    commentsCount: index,
+    likesCount: index + 1,
+    createdAt: `2026-06-${String(10 + index).padStart(2, "0")}T00:00:00Z`,
+    modifiedAt: `2026-06-${String(10 + index).padStart(2, "0")}T00:00:00Z`,
+  })
+)
+
+const createPageResponse = (posts = POSTS) => ({
+  content: posts,
+  pageable: {
+    pageNumber: 0,
+    pageSize: 30,
+    totalElements: posts.length,
+    totalPages: 1,
+  },
+})
+
+const mockHomeFeedRedesignEndpoints = async (page: Page, posts = POSTS) => {
+  await mockAvatarAsset(page)
+  await addPublicAboutSnapshotCookie(page)
+
+  await page.route("**/mock-cover-*.png", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "image/png",
+      body: Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlH0WkAAAAASUVORK5CYII=",
+        "base64"
+      ),
+    })
+  })
+
+  await page.route("**/post/api/v1/posts/feed**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(createPageResponse(posts)),
+    })
+  })
+
+  await page.route("**/post/api/v1/posts/search**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(createPageResponse(posts)),
+    })
+  })
+
+  await page.route("**/post/api/v1/posts/explore**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(createPageResponse(posts)),
+    })
+  })
+
+  await page.route("**/post/api/v1/posts/tags", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(TAGS),
+    })
+  })
+}
+
+const addEmptyProfileLinksCookie = async (page: Page) => {
+  const profile = {
+    username: "aquila",
+    name: "aquila",
+    nickname: "aquila",
+    modifiedAt: new Date().toISOString(),
+    profileImageUrl: "/avatar.png",
+    profileImageDirectUrl: "/avatar.png",
+    profileRole: "Backend Developer",
+    contactLinks: [],
+    serviceLinks: [],
+  }
+
+  await page.route("**/member/api/v1/members/adminProfile", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(profile),
+    })
+  })
+
+  await page.context().addCookies([
+    {
+      name: "admin_profile_snapshot_v1",
+      value: encodeURIComponent(JSON.stringify(profile)),
+      url: "http://127.0.0.1:3000",
+    },
+  ])
+}
+
+test.describe("home feed product redesign", () => {
+  test("1440px 이상 홈은 포스트 중심 3열과 compact profile/tag chip 구조를 사용한다", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await mockHomeFeedRedesignEndpoints(page)
+
+    await page.goto("/")
+
+    await expect(page.locator('[data-ui="feed-home-product-shell"]')).toBeVisible()
+    await expect(page.locator('[data-ui="feed-profile-summary"]')).toBeVisible()
+    await expect(page.locator('[data-ui="feed-tag-chip-rail"]')).toBeVisible()
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute("content", "AquilaLog")
+    await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute("content", "AquilaLog")
+    await expect(page.locator(".desktopPanel")).toBeHidden()
+    await expect(page.locator(".rt")).toBeHidden()
+    await expect(page.locator('[data-ui="feed-profile-summary"]')).not.toContainText("Posts-")
+
+    const cardRects = await page.locator('[data-ui="feed-post-card"]').evaluateAll((cards) =>
+      cards.slice(0, 6).map((card) => {
+        const rect = card.getBoundingClientRect()
+        return { left: Math.round(rect.left), top: Math.round(rect.top), width: Math.round(rect.width) }
+      })
+    )
+    const firstRowTop = cardRects[0]?.top
+    const firstRow = cardRects.filter((rect) => rect.top === firstRowTop)
+    const secondRow = cardRects.filter((rect) => rect.top !== firstRowTop)
+
+    expect(firstRow).toHaveLength(3)
+    expect(secondRow.length).toBeGreaterThanOrEqual(3)
+    expect(Math.min(...firstRow.map((rect) => rect.width))).toBeGreaterThanOrEqual(300)
+  })
+
+  test("1440px 미만 데스크톱은 포스트 카드를 2열로 유지한다", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await mockHomeFeedRedesignEndpoints(page)
+
+    await page.goto("/")
+    await expect(page.locator('[data-ui="feed-post-card"]').nth(3)).toBeVisible()
+
+    const cardRects = await page.locator('[data-ui="feed-post-card"]').evaluateAll((cards) =>
+      cards.slice(0, 4).map((card) => {
+        const rect = card.getBoundingClientRect()
+        return { left: Math.round(rect.left), top: Math.round(rect.top), width: Math.round(rect.width) }
+      })
+    )
+    const firstRowTop = cardRects[0]?.top
+    const firstRow = cardRects.filter((rect) => rect.top === firstRowTop)
+
+    expect(firstRow).toHaveLength(2)
+    expect(Math.min(...firstRow.map((rect) => rect.width))).toBeGreaterThanOrEqual(360)
+  })
+
+  test("브랜드 cover fallback은 썸네일 없는 글도 통일된 기술 블로그 카드로 보여준다", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await mockHomeFeedRedesignEndpoints(page)
+
+    await page.goto("/")
+
+    const fallbackCover = page.locator('[data-ui="feed-card-brand-cover"]').filter({
+      hasText: "JWT VS Session",
+    })
+    await expect(fallbackCover).toBeVisible()
+    await expect(fallbackCover.getByText("Security", { exact: true })).toBeVisible()
+  })
+
+  test("저장용 category prefix는 카드와 cover 라벨에 노출하지 않는다", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    const categorizedPosts = [
+      createExplorePost({
+        id: 8110,
+        title: "Spring 운영 패턴",
+        summary: "저장용 카테고리 prefix 대신 사용자에게 보이는 라벨만 보여줘야 합니다.",
+        tags: [],
+        category: ["monitor::Spring"],
+        thumbnail: "",
+      }),
+    ]
+    await mockHomeFeedRedesignEndpoints(page, categorizedPosts)
+
+    await page.goto("/")
+
+    const categorizedCard = page.locator('[data-ui="feed-post-card"]').filter({
+      hasText: "Spring 운영 패턴",
+    })
+    await expect(categorizedCard).toBeVisible()
+    await expect(categorizedCard.getByText("Spring", { exact: true })).toHaveCount(2)
+    await expect(categorizedCard.getByText("monitor::Spring", { exact: true })).toHaveCount(0)
+  })
+
+  test("pinned 내부 태그는 카드 category 라벨로 노출하지 않는다", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    const pinnedPosts = [
+      createExplorePost({
+        id: 8101,
+        title: "Pinned SSE 운영 노트",
+        summary: "Pinned 내부 태그 대신 실제 주제 태그를 카드 라벨로 보여줘야 합니다.",
+        tags: ["Pinned", "SSE"],
+        category: [],
+        thumbnail: "",
+      }),
+    ]
+    await mockHomeFeedRedesignEndpoints(page, pinnedPosts)
+
+    await page.goto("/")
+
+    const pinnedCover = page.locator('[data-ui="feed-card-brand-cover"]').filter({
+      hasText: "Pinned SSE 운영 노트",
+    })
+    await expect(pinnedCover).toBeVisible()
+    await expect(pinnedCover.getByText("SSE", { exact: true })).toBeVisible()
+    await expect(pinnedCover.getByText("Pinned", { exact: true })).toHaveCount(0)
+  })
+
+  test("명시적으로 비운 profile 링크는 기본 링크로 되살리지 않는다", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await mockHomeFeedRedesignEndpoints(page)
+    await addEmptyProfileLinksCookie(page)
+
+    await page.goto("/")
+
+    const profileSummary = page.locator('[data-ui="feed-profile-summary"]')
+    await expect(profileSummary).toBeVisible()
+    await expect(profileSummary.locator(".links a")).toHaveCount(0)
+  })
+
+  test("category-only 글은 restore snapshot과 memo guard에서도 stale fallback으로 떨어지지 않는다", () => {
+    const feedRoot = path.resolve(__dirname, "../src/routes/Feed")
+    const restoreSource = readFileSync(path.join(feedRoot, "FeedExplorerRestoreModel.ts"), "utf8")
+    const postListSource = readFileSync(path.join(feedRoot, "PostList/index.tsx"), "utf8")
+    const postCardSource = readFileSync(path.join(feedRoot, "PostList/PostCard.tsx"), "utf8")
+
+    expect(restoreSource).toContain("category?: string[]")
+    expect(restoreSource.match(/post\.category\?\.length \? \{ category: post\.category \}/g)).toHaveLength(2)
+    expect(postListSource).toContain("areStringArraysEqual(prevPost.tags, nextPost.tags)")
+    expect(postListSource).toContain("areStringArraysEqual(prevPost.category, nextPost.category)")
+    expect(postCardSource).toContain("areStringArraysEqual(prev.data.tags, next.data.tags)")
+    expect(postCardSource).toContain("areStringArraysEqual(prev.data.category, next.data.category)")
+    expect(postCardSource).toContain("INTERNAL_CATEGORY_TAGS")
+    expect(readFileSync(path.join(feedRoot, "ProfileSummaryCard.tsx"), "utf8")).not.toContain("resolveContactLinks(null)")
+  })
+
+  test("모바일 홈은 태그 칩과 카드 1열을 유지하고 가로 overflow를 만들지 않는다", async ({ page }) => {
+    await page.setViewportSize({ width: 393, height: 852 })
+    await mockHomeFeedRedesignEndpoints(page)
+
+    await page.goto("/")
+
+    await expect(page.locator('[data-ui="feed-tag-chip-rail"]')).toBeVisible()
+    await expect(page.locator('[data-ui="feed-profile-summary"]')).toBeHidden()
+    await expect(page.locator(".desktopPanel")).toBeHidden()
+    await expect(page.locator('[data-ui="feed-post-card"]').nth(2)).toBeVisible()
+
+    const layout = await page.evaluate(() => {
+      const cards = Array.from(document.querySelectorAll<HTMLElement>('[data-ui="feed-post-card"]')).slice(0, 3)
+      const rects = cards.map((card) => {
+        const rect = card.getBoundingClientRect()
+        return { left: Math.round(rect.left), top: Math.round(rect.top), width: Math.round(rect.width) }
+      })
+
+      return {
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+        rects,
+      }
+    })
+
+    expect(layout.scrollWidth).toBeLessThanOrEqual(layout.clientWidth + 1)
+    expect(new Set(layout.rects.map((rect) => rect.left)).size).toBe(1)
+  })
+})

--- a/front/e2e/perf-layout.spec.ts
+++ b/front/e2e/perf-layout.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from "@playwright/test"
 import {
   allowAdminDashboardLoginFallback,
   applySchemePreference,
-  getDesktopTagRailMetrics,
   getRailStickySnapshot,
   getThemeSurfaceFingerprint,
   getVisualLayoutFingerprint,
@@ -26,7 +25,7 @@ test.describe("성능 레이아웃과 표면 예산", () => {
   const ultraWideSnapshot = await getWidthLockSnapshot(page)
   expect(ultraWideSnapshot.mainWidth).toBeCloseTo(1728, 0)
   expect(ultraWideSnapshot.headerWidth).toBeCloseTo(1728, 0)
-  await expect(page.locator(".rt")).toBeVisible()
+  await expect(page.locator(".rt")).toBeHidden()
 
   await page.setViewportSize({ width: 1600, height: 900 })
   await reloadForPerf(page)
@@ -34,7 +33,7 @@ test.describe("성능 레이아웃과 표면 예산", () => {
   const wideSnapshot = await getWidthLockSnapshot(page)
   expect(wideSnapshot.mainWidth).toBeCloseTo(1376, 0)
   expect(wideSnapshot.headerWidth).toBeCloseTo(1376, 0)
-  await expect(page.locator(".rt")).toBeVisible()
+  await expect(page.locator(".rt")).toBeHidden()
 
   const checkpoints = [
     { viewport: 1300, expectedLocked: 1024 },
@@ -113,7 +112,7 @@ test.describe("성능 레이아웃과 표면 예산", () => {
   expect(hoverMetrics.articleTop).toBeLessThan(hoverMetrics.cardTop)
 })
 
-  test("메인 태그 레일은 1200/1201 전환과 넓은 데스크톱에서 안전하게 전환된다", async ({ page }) => {
+  test("메인 태그 칩 레일은 1200/1201 전환과 넓은 데스크톱에서 안전하게 유지된다", async ({ page }) => {
   await mockFeedEndpoints(page)
 
   await page.setViewportSize({ width: 1200, height: 900 })
@@ -123,28 +122,29 @@ test.describe("성능 레이아웃과 표면 예산", () => {
 
   await page.setViewportSize({ width: 1201, height: 900 })
   await reloadForPerf(page)
-  await expect(page.locator(".chipRail")).toBeHidden()
-  await expect(page.locator(".desktopPanel")).toBeVisible()
+  await expect(page.locator(".chipRail")).toBeVisible()
+  await expect(page.locator(".desktopPanel")).toBeHidden()
   await expect
     .poll(async () => {
-      const rect = await page.locator(".desktopPanel").boundingBox()
+      const rect = await page.locator(".chipRail").boundingBox()
       return rect?.x ?? -999
     })
     .toBeGreaterThanOrEqual(0)
 
   await page.setViewportSize({ width: 1680, height: 900 })
   await reloadForPerf(page)
-  await expect(page.locator(".desktopPanel")).toBeVisible()
+  await expect(page.locator(".chipRail")).toBeVisible()
+  await expect(page.locator(".desktopPanel")).toBeHidden()
 
-  const railRect = await page.locator(".desktopPanel").boundingBox()
+  const railRect = await page.locator(".chipRail").boundingBox()
   expect(railRect).not.toBeNull()
   expect((railRect?.x ?? -1)).toBeGreaterThanOrEqual(0)
 
   const firstCardRect = await page.locator(".postColumn article").first().boundingBox()
   expect(firstCardRect).not.toBeNull()
-  const railRight = (railRect?.x ?? 0) + (railRect?.width ?? 0)
-  const firstCardLeft = firstCardRect?.x ?? 0
-  expect(firstCardLeft).toBeGreaterThanOrEqual(railRight + 8)
+  const railBottom = (railRect?.y ?? 0) + (railRect?.height ?? 0)
+  const firstCardTop = firstCardRect?.y ?? 0
+  expect(firstCardTop).toBeGreaterThanOrEqual(railBottom + 8)
 })
 
   test("상세 좌/우 고정 레일은 스크롤 전후 좌표를 안정적으로 유지한다", async ({ page }) => {
@@ -213,38 +213,30 @@ test.describe("성능 레이아웃과 표면 예산", () => {
       expect(snapshot.route).toBe("/")
       expect(snapshot.viewport.width).toBe(1440)
       expect(snapshot.viewport.height).toBe(900)
-      expect(snapshot.rails.desktopTag).toBe(true)
+      expect(snapshot.rails.chip).toBe(true)
+      expect(snapshot.rails.desktopTag).toBe(false)
       expect(snapshot.rails.leftReaction).toBe(false)
       expect(snapshot.rails.rightToc).toBe(false)
 
       expect(snapshot.searchRect).not.toBeNull()
       expect(snapshot.firstCardRect).not.toBeNull()
-      const desktopTagRailMetrics = await getDesktopTagRailMetrics(page)
-      expect(desktopTagRailMetrics).not.toBeNull()
 
       const searchWidth = snapshot.searchRect?.width ?? 0
       const searchHeight = snapshot.searchRect?.height ?? 0
       const firstCardWidth = snapshot.firstCardRect?.width ?? 0
       const firstCardHeight = snapshot.firstCardRect?.height ?? 0
-      const railWidth = snapshot.desktopTagRailRect?.width ?? 0
-      const railHeight = desktopTagRailMetrics?.height ?? 0
-      const railScrollHeight = desktopTagRailMetrics?.scrollHeight ?? 0
-      const railPanelBottom = desktopTagRailMetrics?.panelBottom ?? 0
       const htmlScrollWidth = snapshot.scrollWidth?.html ?? 0
       const bodyScrollWidth = snapshot.scrollWidth?.body ?? 0
 
-      expect(searchWidth).toBeGreaterThanOrEqual(600)
-      expect(searchWidth).toBeLessThanOrEqual(680)
+      expect(searchWidth).toBeGreaterThanOrEqual(860)
+      expect(searchWidth).toBeLessThanOrEqual(1280)
       expect(searchHeight).toBe(36)
-      expect(firstCardWidth).toBeGreaterThanOrEqual(340)
-      expect(firstCardWidth).toBeLessThanOrEqual(380)
+      expect(firstCardWidth).toBeGreaterThanOrEqual(280)
+      expect(firstCardWidth).toBeLessThanOrEqual(420)
       expect(firstCardHeight).toBeGreaterThanOrEqual(360)
-      expect(firstCardHeight).toBeLessThanOrEqual(400)
-      expect(railWidth).toBe(184)
-      expect(railHeight).toBeGreaterThanOrEqual(84)
-      expect(railHeight).toBeLessThanOrEqual(560)
-      expect(railScrollHeight).toBeGreaterThanOrEqual(railHeight)
-      expect(railPanelBottom).toBeLessThanOrEqual(snapshot.viewport.height)
+      expect(firstCardHeight).toBeLessThanOrEqual(430)
+      expect(snapshot.desktopTagRailRect?.width ?? 0).toBe(0)
+      expect(snapshot.desktopTagRailRect?.height ?? 0).toBe(0)
       expect(htmlScrollWidth).toBeLessThanOrEqual(1440)
       expect(htmlScrollWidth).toBeGreaterThanOrEqual(1420)
       expect(bodyScrollWidth).toBeLessThanOrEqual(1440)
@@ -272,14 +264,14 @@ test.describe("성능 레이아웃과 표면 예산", () => {
       expect(searchWidth).toBeGreaterThanOrEqual(320)
       expect(searchWidth).toBeLessThanOrEqual(336)
       expect(searchHeight).toBe(34)
-      expect(searchY).toBeGreaterThanOrEqual(156)
-      expect(searchY).toBeLessThanOrEqual(188)
+      expect(searchY).toBeGreaterThanOrEqual(190)
+      expect(searchY).toBeLessThanOrEqual(230)
       expect(firstCardWidth).toBeGreaterThanOrEqual(360)
       expect(firstCardWidth).toBeLessThanOrEqual(370)
       expect(firstCardHeight).toBeGreaterThanOrEqual(388)
-      expect(firstCardHeight).toBeLessThanOrEqual(404)
+      expect(firstCardHeight).toBeLessThanOrEqual(430)
       expect(firstCardY).toBeGreaterThanOrEqual(298)
-      expect(firstCardY).toBeLessThanOrEqual(360)
+      expect(firstCardY).toBeLessThanOrEqual(410)
       continue
     }
 
@@ -303,14 +295,14 @@ test.describe("성능 레이아웃과 표면 예산", () => {
       expect(searchWidth).toBeGreaterThanOrEqual(692)
       expect(searchWidth).toBeLessThanOrEqual(710)
       expect(searchHeight).toBe(34)
-      expect(searchY).toBeGreaterThanOrEqual(156)
-      expect(searchY).toBeLessThanOrEqual(190)
+      expect(searchY).toBeGreaterThanOrEqual(190)
+      expect(searchY).toBeLessThanOrEqual(230)
       expect(firstCardWidth).toBeGreaterThanOrEqual(348)
       expect(firstCardWidth).toBeLessThanOrEqual(360)
       expect(firstCardHeight).toBeGreaterThanOrEqual(384)
-      expect(firstCardHeight).toBeLessThanOrEqual(398)
+      expect(firstCardHeight).toBeLessThanOrEqual(430)
       expect(firstCardY).toBeGreaterThanOrEqual(300)
-      expect(firstCardY).toBeLessThanOrEqual(334)
+      expect(firstCardY).toBeLessThanOrEqual(380)
       continue
     }
 
@@ -460,10 +452,10 @@ test.describe("성능 레이아웃과 표면 예산", () => {
     expect(fingerprint.headerBg).not.toBe(fingerprint.bodyBg)
 
     if (scenario.route === "/") {
-      expect(fingerprint.searchBg).toBe("rgb(255, 255, 255)")
-      expect(fingerprint.searchBorder).toBe("rgb(200, 210, 222)")
-      expect(fingerprint.cardBg).toBe("rgb(255, 255, 255)")
-      expect(fingerprint.cardBorder).toBe("rgb(200, 210, 222)")
+      expect(fingerprint.searchBg).toBe("rgb(22, 27, 34)")
+      expect(fingerprint.searchBorder).toBe("rgb(48, 54, 61)")
+      expect(fingerprint.cardBg).toBe("rgb(22, 27, 34)")
+      expect(fingerprint.cardBorder).toBe("rgb(48, 54, 61)")
     }
 
     if (scenario.route === "/posts/991") {

--- a/front/e2e/smoke-feed-search.spec.ts
+++ b/front/e2e/smoke-feed-search.spec.ts
@@ -18,47 +18,49 @@ test.describe("core smoke feed and search", () => {
   await page.goto("/")
   await expect(page.getByLabel("Search posts by keyword")).toBeVisible()
   await expect(page.getByRole("button", { name: "전체보기" })).toBeVisible()
-  await expect(page.locator('[data-ui="feed-service-section"]')).toBeVisible()
-  await expect(page.locator('[data-ui="feed-contact-section"]')).toBeVisible()
-  await expect(page.locator('[data-ui="feed-service-section"]').getByText("aquila-blog", { exact: true })).toBeVisible()
-  await expect(
-    page.locator('[data-ui="feed-contact-section"]').getByRole("link", { name: /github github\.com\/aquilaxk/i })
-  ).toBeVisible()
+  await expect(page.locator('[data-ui="feed-home-product-shell"]')).toBeVisible()
+  await expect(page.locator('[data-ui="feed-profile-summary"]')).toBeVisible()
+  await expect(page.locator('[data-ui="feed-tag-chip-rail"]')).toBeVisible()
+  await expect(page.locator(".rt")).toBeHidden()
 
-  const sidebarStyles = await page.evaluate(() => {
+  const homeStyles = await page.evaluate(() => {
     const read = (selector: string) => {
       const element = document.querySelector(selector) as HTMLElement | null
       if (!element) return null
       const styles = window.getComputedStyle(element)
       return {
         backgroundColor: styles.backgroundColor,
-        borderBottomWidth: styles.borderBottomWidth,
+        borderWidth: styles.borderWidth,
       }
     }
 
     return {
-      service: read('[data-ui="feed-service-links"]'),
-      contact: read('[data-ui="feed-contact-links"]'),
+      profileSummary: read('[data-ui="feed-profile-summary"]'),
+      firstCard: read('[data-ui="feed-post-card"] article'),
     }
   })
 
-  expect(sidebarStyles.service?.backgroundColor).toBe("rgba(0, 0, 0, 0)")
-  expect(sidebarStyles.service?.borderBottomWidth).toBe("1px")
-  expect(sidebarStyles.contact?.backgroundColor).toBe("rgba(0, 0, 0, 0)")
-  expect(sidebarStyles.contact?.borderBottomWidth).toBe("1px")
+  expect(homeStyles.profileSummary?.backgroundColor).not.toBe("rgba(0, 0, 0, 0)")
+  expect(homeStyles.profileSummary?.borderWidth).toBe("1px")
+  expect(homeStyles.firstCard?.backgroundColor).not.toBe("rgba(0, 0, 0, 0)")
+  expect(homeStyles.firstCard?.borderWidth).toBe("1px")
 })
 
-  test("홈 새로고침 이후에도 레거시 기본 문구로 되돌아가지 않는다", async ({ page }) => {
+  test("홈 새로고침 이후에도 제품형 브랜드 문구를 유지한다", async ({ page }) => {
   await mockFeedEndpoints(page)
 
   await page.goto("/")
-  await expect(page.getByRole("heading", { level: 1, name: "비밀스러운 IT 공작소" })).toBeVisible()
+  await expect(page.getByRole("heading", { level: 1, name: "AquilaLog" })).toBeVisible()
+  await expect(page.locator('[data-ui="feed-brand-role"]')).toBeVisible()
   await expect(page.getByText("비밀스러운 지식들을 탐구하는데 목적을 두고 있습니다")).toBeVisible()
+  await expect(page.getByText("비밀스러운 IT 공작소")).toHaveCount(0)
   await expect(page.getByText("aquilaXk's Blog")).toHaveCount(0)
 
   await page.reload()
-  await expect(page.getByRole("heading", { level: 1, name: "비밀스러운 IT 공작소" })).toBeVisible()
+  await expect(page.getByRole("heading", { level: 1, name: "AquilaLog" })).toBeVisible()
+  await expect(page.locator('[data-ui="feed-brand-role"]')).toBeVisible()
   await expect(page.getByText("비밀스러운 지식들을 탐구하는데 목적을 두고 있습니다")).toBeVisible()
+  await expect(page.getByText("비밀스러운 IT 공작소")).toHaveCount(0)
   await expect(page.getByText("aquilaXk's Blog")).toHaveCount(0)
 })
 
@@ -110,7 +112,7 @@ test.describe("core smoke feed and search", () => {
   await searchInput.fill("alpha")
 
   await expect.poll(() => capturedKw.some((value) => value === "alpha")).toBeTruthy()
-  await expect(page.getByText("검색:alpha")).toBeVisible()
+  await expect(page.locator("a[href^='/posts/'] h2").filter({ hasText: "검색:alpha" })).toBeVisible()
 })
 
   test("검색 모드는 백엔드가 반환한 순서를 그대로 유지한다", async ({ page }) => {
@@ -184,7 +186,7 @@ test.describe("core smoke feed and search", () => {
   await searchInput.fill("alpha beta")
 
   await expect.poll(() => capturedKw.some((value) => value === "alpha beta")).toBeTruthy()
-  await expect(page.getByText("본문 exact phrase 매치")).toBeVisible()
+  await expect(page.locator("a[href^='/posts/'] h2").filter({ hasText: "본문 exact phrase 매치" })).toBeVisible()
   const titles = await page.locator("a[href^='/posts/'] h2").evaluateAll((elements) =>
     elements.map((element) => element.textContent?.trim() || "").filter(Boolean)
   )
@@ -214,7 +216,7 @@ test.describe("core smoke feed and search", () => {
   await page.goto("/?tag=%ED%85%8C%EC%8A%A4%ED%8A%B8%ED%83%9C%EA%B7%B8")
 
   await expect.poll(() => capturedTag.some((value) => value === "테스트태그")).toBeTruthy()
-  await expect(page.getByText("태그:테스트태그")).toBeVisible()
+  await expect(page.locator("a[href^='/posts/'] h2").filter({ hasText: "태그:테스트태그" })).toBeVisible()
 })
 
   test("메인 피드 탐색 요청은 최신순 정렬(sort=CREATED_AT)로 고정된다", async ({ page }) => {
@@ -244,7 +246,7 @@ test.describe("core smoke feed and search", () => {
   await expect(page.getByRole("button", { name: "전체보기" })).toBeVisible()
 
   await expect.poll(() => capturedSort.some((value) => value === "CREATED_AT")).toBeTruthy()
-  await expect(page.getByText("정렬:CREATED_AT")).toBeVisible()
+  await expect(page.locator("a[href^='/posts/'] h2").filter({ hasText: "정렬:CREATED_AT" })).toBeVisible()
 })
 
   test("피드 카드 hover는 fallback 상세 _next/data prefetch를 만들지 않는다", async ({ page }) => {

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -132,10 +132,9 @@ type FeedPageProps = {
 
 const FeedPage: NextPageWithLayout<FeedPageProps> = ({ initialAdminProfile }) => {
   const feedTitle =
-    initialAdminProfile?.homeIntroTitle ||
     initialAdminProfile?.blogTitle ||
-    CONFIG.blog.homeIntroTitle ||
-    CONFIG.blog.title
+    CONFIG.blog.title ||
+    "AquilaLog"
   const feedDescription = initialAdminProfile?.homeIntroDescription || CONFIG.blog.homeIntroDescription || CONFIG.blog.description
 
   const meta = {

--- a/front/src/routes/Feed/FeedExplorer.styles.ts
+++ b/front/src/routes/Feed/FeedExplorer.styles.ts
@@ -1,15 +1,10 @@
 import styled from "@emotion/styled"
-import { FEED_TAG_RAIL_DESKTOP_MIN_PX, FEED_TAG_RAIL_WIDTH_PX } from "./feedUiTokens"
-
-const FEED_TAG_RAIL_GAP_PX = 32
-const FEED_POST_COLUMN_MAX_WIDTH_REM = 52
+const FEED_POST_COLUMN_MAX_WIDTH_REM = 92
 
 export const ExplorerCard = styled.section`
-  --feed-tag-rail-width: ${FEED_TAG_RAIL_WIDTH_PX}px;
-  --feed-tag-rail-gap: ${FEED_TAG_RAIL_GAP_PX}px;
   --feed-post-column-max-width: ${FEED_POST_COLUMN_MAX_WIDTH_REM}rem;
   display: grid;
-  gap: 0;
+  gap: 0.8rem;
   padding: 0;
   min-width: 0;
   min-height: 0;
@@ -23,57 +18,29 @@ export const ExplorerCard = styled.section`
     margin-inline: auto;
   }
 
-  @media (min-width: ${FEED_TAG_RAIL_DESKTOP_MIN_PX}px) {
-    grid-template-columns: var(--feed-tag-rail-width) minmax(0, var(--feed-post-column-max-width));
-    column-gap: var(--feed-tag-rail-gap);
-    justify-content: center;
-    align-items: start;
-
-    .searchSlot {
-      width: 100%;
-      margin-inline: 0;
-      grid-column: 2;
-    }
-  }
-
   @media (max-width: 768px) {
     margin-bottom: 0.38rem;
   }
 `
 
 export const FeedBody = styled.section`
-  --feed-tag-rail-width: ${FEED_TAG_RAIL_WIDTH_PX}px;
-  --feed-tag-rail-gap: ${FEED_TAG_RAIL_GAP_PX}px;
   --feed-post-column-max-width: ${FEED_POST_COLUMN_MAX_WIDTH_REM}rem;
+  display: grid;
+  gap: 0.85rem;
   min-width: 0;
   overflow: visible;
 
   .tagColumn {
     min-width: 0;
     display: block;
+    width: min(100%, var(--feed-post-column-max-width));
+    margin-inline: auto;
   }
 
   .postColumn {
     min-width: 0;
     width: min(100%, var(--feed-post-column-max-width));
     margin-inline: auto;
-  }
-
-  @media (min-width: ${FEED_TAG_RAIL_DESKTOP_MIN_PX}px) {
-    display: grid;
-    grid-template-columns: var(--feed-tag-rail-width) minmax(0, var(--feed-post-column-max-width));
-    column-gap: var(--feed-tag-rail-gap);
-    justify-content: center;
-    align-items: start;
-
-    .tagColumn {
-      min-width: 0;
-    }
-
-    .postColumn {
-      width: 100%;
-      margin-inline: 0;
-    }
   }
 `
 
@@ -84,7 +51,7 @@ export const FilterContextBar = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
-  color: ${({ theme }) => theme.colors.gray10};
+  color: #8b949e;
 
   .contextMain {
     min-width: 0;
@@ -103,13 +70,13 @@ export const FilterContextBar = styled.div`
 
   .contextCount {
     font-size: 0.88rem;
-    color: ${({ theme }) => theme.colors.gray11};
+    color: #f0f6fc;
     font-weight: 740;
     letter-spacing: -0.015em;
   }
 
   .filterSummary {
-    color: ${({ theme }) => theme.colors.gray9};
+    color: #8b949e;
     font-size: 0.74rem;
     line-height: 1.35;
     font-weight: 600;
@@ -126,9 +93,9 @@ export const FilterContextBar = styled.div`
     min-height: 1.7rem;
     padding: 0 0.58rem;
     border-radius: 999px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray2};
-    color: ${({ theme }) => theme.colors.gray11};
+    border: 1px solid #30363d;
+    background: #161b22;
+    color: #c9d1d9;
     font-size: 0.72rem;
     font-weight: 700;
     white-space: nowrap;
@@ -139,18 +106,18 @@ export const FilterContextBar = styled.div`
     min-height: 1.7rem;
     padding: 0 0.52rem;
     border-radius: 999px;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    border: 1px solid #30363d;
     background: transparent;
-    color: ${({ theme }) => theme.colors.gray10};
+    color: #8b949e;
     font-size: 0.72rem;
     font-weight: 700;
     cursor: pointer;
     transition: border-color 0.125s ease-in, color 0.125s ease-in, background-color 0.125s ease-in;
 
     &:hover {
-      border-color: ${({ theme }) => theme.colors.gray7};
-      background: ${({ theme }) => theme.colors.gray2};
-      color: ${({ theme }) => theme.colors.gray12};
+      border-color: #58a6ff;
+      background: rgba(88, 166, 255, 0.12);
+      color: #f0f6fc;
     }
   }
 

--- a/front/src/routes/Feed/FeedExplorerRestoreModel.ts
+++ b/front/src/routes/Feed/FeedExplorerRestoreModel.ts
@@ -38,6 +38,7 @@ export type FeedExplorerSnapshotPost = {
   summary?: string
   thumbnail?: string
   tags?: string[]
+  category?: string[]
   author?: {
     id: string
     name: string
@@ -45,6 +46,7 @@ export type FeedExplorerSnapshotPost = {
   }[]
   likesCount?: number
   commentsCount?: number
+  hitCount?: number
 }
 
 export type FeedExplorerSnapshotPage = {
@@ -110,6 +112,7 @@ export const toSnapshotPost = (post: TPost): FeedExplorerSnapshotPost => {
     ...(post.summary ? { summary: post.summary } : {}),
     ...(post.thumbnail ? { thumbnail: post.thumbnail } : {}),
     ...(post.tags?.length ? { tags: post.tags } : {}),
+    ...(post.category?.length ? { category: post.category } : {}),
     ...(firstAuthor
       ? {
           author: [
@@ -123,6 +126,7 @@ export const toSnapshotPost = (post: TPost): FeedExplorerSnapshotPost => {
       : {}),
     ...(typeof post.likesCount === "number" ? { likesCount: post.likesCount } : {}),
     ...(typeof post.commentsCount === "number" ? { commentsCount: post.commentsCount } : {}),
+    ...(typeof post.hitCount === "number" ? { hitCount: post.hitCount } : {}),
   }
 }
 
@@ -153,9 +157,11 @@ export const toRestoredPost = (post: FeedExplorerSnapshotPost): TPost => {
     ...(post.summary ? { summary: post.summary } : {}),
     ...(post.thumbnail ? { thumbnail: post.thumbnail } : {}),
     ...(post.tags?.length ? { tags: post.tags } : {}),
+    ...(post.category?.length ? { category: post.category } : {}),
     ...(post.author?.length ? { author: post.author } : {}),
     ...(typeof post.likesCount === "number" ? { likesCount: post.likesCount } : {}),
     ...(typeof post.commentsCount === "number" ? { commentsCount: post.commentsCount } : {}),
+    ...(typeof post.hitCount === "number" ? { hitCount: post.hitCount } : {}),
   }
 }
 

--- a/front/src/routes/Feed/PostList/PinnedPosts.tsx
+++ b/front/src/routes/Feed/PostList/PinnedPosts.tsx
@@ -33,8 +33,22 @@ const arePinnedPostsEqual = (prev: Props, next: Props) => {
     if (prevPost.modifiedTime !== nextPost.modifiedTime) return false
     if (prevPost.likesCount !== nextPost.likesCount) return false
     if (prevPost.commentsCount !== nextPost.commentsCount) return false
+    if (prevPost.hitCount !== nextPost.hitCount) return false
+    if (prevPost.title !== nextPost.title) return false
+    if (prevPost.summary !== nextPost.summary) return false
+    if (prevPost.thumbnail !== nextPost.thumbnail) return false
+    if (!areStringArraysEqual(prevPost.tags, nextPost.tags)) return false
+    if (!areStringArraysEqual(prevPost.category, nextPost.category)) return false
   }
   return true
+}
+
+const areStringArraysEqual = (prevValues?: string[], nextValues?: string[]) => {
+  if (prevValues === nextValues) return true
+  if (!prevValues || !nextValues) return !prevValues?.length && !nextValues?.length
+  if (prevValues.length !== nextValues.length) return false
+
+  return prevValues.every((value, index) => value === nextValues[index])
 }
 
 export default memo(PinnedPosts, arePinnedPostsEqual)

--- a/front/src/routes/Feed/PostList/PostCard.tsx
+++ b/front/src/routes/Feed/PostList/PostCard.tsx
@@ -1,5 +1,5 @@
 import { CONFIG } from "site.config"
-import { formatDate } from "src/libs/utils"
+import { formatDate, splitCategoryDisplay } from "src/libs/utils"
 import { TPost } from "../../../types"
 import styled from "@emotion/styled"
 import { uiTokens } from "@shared/ui-tokens"
@@ -25,7 +25,17 @@ const FEED_CARD_META_FONT_SIZE_REM = uiTokens.feed.card.metaFontSizeRem
 const FEED_CARD_SUMMARY_LINES = uiTokens.feed.card.summaryLines
 const FEED_CARD_SUMMARY_LINE_HEIGHT = uiTokens.feed.card.summaryLineHeight
 const FEED_CARD_TITLE_LINE_HEIGHT = uiTokens.feed.card.titleLineHeight
-const FEED_CARD_RADIUS_PX = 4
+const FEED_CARD_RADIUS_PX = 14
+const INTERNAL_CATEGORY_TAGS = new Set(["Pinned"])
+
+const toDisplayCategoryLabel = (post: TPost) => {
+  const rawLabel =
+    post.category?.[0] ||
+    post.tags?.find((tag) => !INTERNAL_CATEGORY_TAGS.has(tag)) ||
+    "Engineering"
+  return splitCategoryDisplay(rawLabel).label
+}
+
 const PostCard: React.FC<Props> = ({ data, layout = "regular" }) => {
   const author = data.author?.[0]
   const postPath = toCanonicalPostPath(data.id)
@@ -36,6 +46,11 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular" }) => {
   const summary = normalizeCardSummary(data.summary)
   const commentsCount = data.commentsCount ?? 0
   const likesCount = data.likesCount ?? 0
+  const categoryLabel = toDisplayCategoryLabel(data)
+  const readMinutes = Math.max(4, Math.ceil(((data.title?.length || 0) + (summary?.length || 0)) / 120))
+  const viewsCount = data.hitCount ?? 0
+  const viewsText =
+    viewsCount >= 1000 ? `${(viewsCount / 1000).toFixed(viewsCount >= 10000 ? 0 : 1)}k views` : `${viewsCount} views`
   const { thumbnailSrc, thumbnailFocusX, thumbnailFocusY, thumbnailZoom } = useMemo(() => {
     const rawThumbnail = data.thumbnail || ""
     return {
@@ -66,7 +81,7 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular" }) => {
   )
 
   return (
-    <StyledWrapper href={postPath} data-layout={layout} onClick={handleNavigate}>
+    <StyledWrapper href={postPath} data-layout={layout} data-ui="feed-post-card" onClick={handleNavigate}>
       <article>
         {thumbnailSrc && (
           <div className="thumbnail">
@@ -86,8 +101,15 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular" }) => {
             />
           </div>
         )}
-        {!thumbnailSrc && <div className="thumbnail placeholder" aria-hidden="true" />}
+        {!thumbnailSrc && (
+          <div className="thumbnail brandCover" data-ui="feed-card-brand-cover" aria-label={`${data.title} cover`}>
+            <span className="coverCategory">{categoryLabel}</span>
+            <strong>{data.title}</strong>
+            <span className="coverBrand">AquilaLog</span>
+          </div>
+        )}
         <div className="content">
+          <div className="category">{categoryLabel}</div>
           <header>
             <h2>{data.title}</h2>
           </header>
@@ -96,6 +118,10 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular" }) => {
           </div>
           <div className="meta">
             <span>{createdAtText}</span>
+            <span className="dot">·</span>
+            <span>{readMinutes} min read</span>
+            <span className="dot">·</span>
+            <span>{viewsText}</span>
             <span className="dot">·</span>
             <span className="comment">
               <AppIcon name="message" />
@@ -147,9 +173,20 @@ const arePostCardPropsEqual = (prev: Props, next: Props) => {
     prev.data.createdTime === next.data.createdTime &&
     prev.data.commentsCount === next.data.commentsCount &&
     prev.data.likesCount === next.data.likesCount &&
+    prev.data.hitCount === next.data.hitCount &&
+    areStringArraysEqual(prev.data.tags, next.data.tags) &&
+    areStringArraysEqual(prev.data.category, next.data.category) &&
     prevAuthor?.name === nextAuthor?.name &&
     prevAuthor?.profile_photo === nextAuthor?.profile_photo
   )
+}
+
+const areStringArraysEqual = (prevValues?: string[], nextValues?: string[]) => {
+  if (prevValues === nextValues) return true
+  if (!prevValues || !nextValues) return !prevValues?.length && !nextValues?.length
+  if (prevValues.length !== nextValues.length) return false
+
+  return prevValues.every((value, index) => value === nextValues[index])
 }
 
 export default memo(PostCard, arePostCardPropsEqual)
@@ -161,12 +198,12 @@ const StyledWrapper = styled.a`
   min-width: 0;
   text-decoration: none;
   --post-card-translate-y: -8px;
-  --post-card-border-color: ${({ theme }) => theme.publicDesign.border};
-  --post-card-border-strong: ${({ theme }) => theme.publicDesign.borderStrong};
-  --post-card-surface: ${({ theme }) => theme.publicDesign.surface};
-  --post-card-surface-elevated: ${({ theme }) => theme.publicDesign.surfaceElevated};
-  --post-card-shadow-current: ${({ theme }) => theme.publicDesign.shadow};
-  --post-card-shadow-hover-current: ${({ theme }) => theme.publicDesign.shadow};
+  --post-card-border-color: #30363d;
+  --post-card-border-strong: #58a6ff;
+  --post-card-surface: #161b22;
+  --post-card-surface-elevated: #21262d;
+  --post-card-shadow-current: 0 12px 34px rgba(1, 4, 9, 0.26);
+  --post-card-shadow-hover-current: 0 20px 52px rgba(1, 4, 9, 0.36);
 
   &:focus-visible {
     outline: 0;
@@ -183,7 +220,9 @@ const StyledWrapper = styled.a`
     flex-direction: column;
     border-radius: ${FEED_CARD_RADIUS_PX}px;
     border: ${({ theme }) => `${theme.variables.ui.card.borderWidth}px solid var(--post-card-border-color)`};
-    background: var(--post-card-surface);
+    background:
+      linear-gradient(180deg, rgba(33, 38, 45, 0.34), rgba(22, 27, 34, 0.98)),
+      var(--post-card-surface);
     box-shadow: var(--post-card-shadow-current);
 
     > .thumbnail {
@@ -201,6 +240,49 @@ const StyledWrapper = styled.a`
 
       &.placeholder {
         background: var(--post-card-surface-elevated);
+      }
+
+      &.brandCover {
+        min-height: 0;
+        aspect-ratio: 1.92 / 1;
+        display: grid;
+        align-content: end;
+        gap: 0.36rem;
+        padding: 1rem;
+        background:
+          radial-gradient(circle at 82% 18%, rgba(88, 166, 255, 0.28), transparent 34%),
+          linear-gradient(135deg, rgba(88, 166, 255, 0.2), rgba(126, 231, 135, 0.08)),
+          #111722;
+        color: #f0f6fc;
+
+        .coverCategory {
+          width: fit-content;
+          border-radius: 999px;
+          border: 1px solid rgba(88, 166, 255, 0.42);
+          background: rgba(88, 166, 255, 0.1);
+          color: #c9e7ff;
+          padding: 0.22rem 0.5rem;
+          font-size: 0.64rem;
+          line-height: 1.2;
+          font-weight: 860;
+        }
+
+        strong {
+          max-width: 12ch;
+          color: #f0f6fc;
+          font-size: clamp(1.35rem, 2.5vw, 2rem);
+          line-height: 0.94;
+          letter-spacing: -0.07em;
+          font-weight: 920;
+          text-transform: uppercase;
+        }
+
+        .coverBrand {
+          color: #8b949e;
+          font-size: 0.7rem;
+          font-weight: 820;
+          letter-spacing: 0.02em;
+        }
       }
 
       &::after {
@@ -221,14 +303,25 @@ const StyledWrapper = styled.a`
       padding: ${({ theme }) => `${theme.variables.ui.card.padding}px`};
       gap: 0;
 
+      > .category {
+        width: fit-content;
+        margin-bottom: 0.42rem;
+        color: #58a6ff;
+        font-size: 0.7rem;
+        line-height: 1.2;
+        font-weight: 860;
+        letter-spacing: 0.035em;
+        text-transform: uppercase;
+      }
+
       > header {
         h2 {
           margin: 0;
-          color: ${({ theme }) => theme.colors.gray12};
-          font-size: 1.02rem;
+          color: #f0f6fc;
+          font-size: 1.12rem;
           line-height: ${FEED_CARD_TITLE_LINE_HEIGHT};
-          font-weight: 760;
-          letter-spacing: -0.01em;
+          font-weight: 840;
+          letter-spacing: -0.035em;
           word-break: keep-all;
           overflow-wrap: anywhere;
           display: -webkit-box;
@@ -244,7 +337,7 @@ const StyledWrapper = styled.a`
 
         p {
           margin: 0;
-          color: ${({ theme }) => theme.colors.gray10};
+          color: #8b949e;
           font-size: 0.85rem;
           line-height: ${FEED_CARD_SUMMARY_LINE_HEIGHT};
           letter-spacing: -0.01em;
@@ -264,7 +357,7 @@ const StyledWrapper = styled.a`
         align-items: center;
         margin-top: 0.6rem;
         padding-bottom: 0.88rem;
-        color: ${({ theme }) => theme.colors.gray10};
+        color: #8b949e;
         font-size: ${FEED_CARD_META_FONT_SIZE_REM}rem;
         line-height: 1.45;
         letter-spacing: -0.01em;
@@ -317,17 +410,17 @@ const StyledWrapper = styled.a`
             .initial {
               font-size: 0.72rem;
               font-weight: 800;
-              color: ${({ theme }) => theme.colors.gray11};
+              color: #0d1117;
             }
           }
 
           .by {
-            color: ${({ theme }) => theme.colors.gray10};
+            color: #8b949e;
             font-size: 0.72rem;
           }
 
           strong {
-            color: ${({ theme }) => theme.colors.gray12};
+            color: #f0f6fc;
             font-size: 0.76rem;
             font-weight: 760;
             line-height: 1.2;
@@ -342,14 +435,14 @@ const StyledWrapper = styled.a`
           display: inline-flex;
           align-items: center;
           gap: 0.42rem;
-          color: ${({ theme }) => theme.colors.gray11};
+          color: #8b949e;
           font-size: 0.75rem;
           font-weight: 700;
 
           svg {
             width: 0.75rem;
             height: 0.75rem;
-            color: ${({ theme }) => theme.colors.red10};
+            color: #ff7b72;
           }
         }
       }

--- a/front/src/routes/Feed/PostList/index.tsx
+++ b/front/src/routes/Feed/PostList/index.tsx
@@ -243,12 +243,23 @@ const arePostsEqual = (prevPosts: TPost[], nextPosts: TPost[]) => {
     if (prevPost.modifiedTime !== nextPost.modifiedTime) return false
     if (prevPost.likesCount !== nextPost.likesCount) return false
     if (prevPost.commentsCount !== nextPost.commentsCount) return false
+    if (prevPost.hitCount !== nextPost.hitCount) return false
     if (prevPost.title !== nextPost.title) return false
     if (prevPost.summary !== nextPost.summary) return false
     if (prevPost.thumbnail !== nextPost.thumbnail) return false
+    if (!areStringArraysEqual(prevPost.tags, nextPost.tags)) return false
+    if (!areStringArraysEqual(prevPost.category, nextPost.category)) return false
   }
 
   return true
+}
+
+const areStringArraysEqual = (prevValues?: string[], nextValues?: string[]) => {
+  if (prevValues === nextValues) return true
+  if (!prevValues || !nextValues) return !prevValues?.length && !nextValues?.length
+  if (prevValues.length !== nextValues.length) return false
+
+  return prevValues.every((value, index) => value === nextValues[index])
 }
 
 const arePostListPropsEqual = (prev: Props, next: Props) => {
@@ -276,6 +287,11 @@ const StyledWrapper = styled.div`
 
   @media (min-width: 768px) {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 2rem;
+  }
+
+  @media (min-width: 1440px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 2rem;
   }
 
@@ -471,6 +487,11 @@ const StyledWrapper = styled.div`
 
     @media (min-width: 768px) {
       grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 2rem;
+    }
+
+    @media (min-width: 1440px) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 2rem;
     }
   }

--- a/front/src/routes/Feed/ProfileSummaryCard.tsx
+++ b/front/src/routes/Feed/ProfileSummaryCard.tsx
@@ -1,0 +1,183 @@
+import styled from "@emotion/styled"
+import { CONFIG } from "site.config"
+import ProfileImage from "src/components/ProfileImage"
+import { AdminProfile, useAdminProfile } from "src/hooks/useAdminProfile"
+import { usePostsTotalCountQuery } from "src/hooks/usePostsTotalCountQuery"
+import { useTagsQuery } from "src/hooks/useTagsQuery"
+import { resolveContactLinks, resolveServiceLinks } from "src/libs/utils/profileCardLinks"
+
+type Props = {
+  initialAdminProfile?: AdminProfile | null
+}
+
+const resolveSummaryLinks = (adminProfile: AdminProfile | null | undefined) => {
+  const contactLinks = resolveContactLinks(adminProfile)
+  const serviceLinks = resolveServiceLinks(adminProfile)
+
+  return [...contactLinks.slice(0, 1), ...serviceLinks.slice(0, 1)]
+}
+
+const ProfileSummaryCard: React.FC<Props> = ({ initialAdminProfile = null }) => {
+  const adminProfile = useAdminProfile(initialAdminProfile)
+  const totalPostCount = usePostsTotalCountQuery()
+  const { tagEntries } = useTagsQuery()
+  const imageSrc =
+    adminProfile?.profileImageDirectUrl || adminProfile?.profileImageUrl || CONFIG.profile.image
+  const displayName = adminProfile?.nickname || adminProfile?.name || CONFIG.profile.name
+  const displayRole = adminProfile?.profileRole || CONFIG.profile.role
+  const summaryLinks = resolveSummaryLinks(adminProfile)
+  const statItems = [
+    ...(typeof totalPostCount === "number" ? [{ label: "Posts", value: String(totalPostCount) }] : []),
+    { label: "Tags", value: tagEntries.length ? String(tagEntries.length) : "-" },
+    { label: "Focus", value: "Backend" },
+  ]
+
+  return (
+    <StyledWrapper data-ui="feed-profile-summary" aria-label="AquilaLog profile summary">
+      <div className="identity">
+        <span className="avatar" aria-hidden="true">
+          <ProfileImage src={imageSrc} width={48} height={48} alt="" fillContainer />
+        </span>
+        <div className="copy">
+          <strong>{displayName}</strong>
+          <span>{displayRole}</span>
+        </div>
+      </div>
+      <dl className="stats" aria-label="블로그 통계">
+        {statItems.map((item) => (
+          <div key={item.label}>
+            <dt>{item.label}</dt>
+            <dd>{item.value}</dd>
+          </div>
+        ))}
+      </dl>
+      <div className="links">
+        {summaryLinks.map((link) => (
+          <a key={`${link.label}:${link.href}`} href={link.href} target="_blank" rel="noopener noreferrer">
+            {link.label}
+          </a>
+        ))}
+      </div>
+    </StyledWrapper>
+  )
+}
+
+export default ProfileSummaryCard
+
+const StyledWrapper = styled.aside`
+  width: 100%;
+  min-width: 0;
+  border: 1px solid rgba(48, 54, 61, 0.92);
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(33, 38, 45, 0.72), rgba(22, 27, 34, 0.94)),
+    #161b22;
+  box-shadow: 0 18px 44px rgba(1, 4, 9, 0.34);
+  padding: 1rem;
+  color: #f0f6fc;
+
+  .identity {
+    display: flex;
+    align-items: center;
+    gap: 0.78rem;
+    min-width: 0;
+  }
+
+  .avatar {
+    position: relative;
+    width: 48px;
+    height: 48px;
+    border-radius: 999px;
+    overflow: hidden;
+    flex: 0 0 auto;
+    border: 1px solid rgba(240, 246, 252, 0.14);
+    background: #21262d;
+
+    img {
+      object-fit: cover;
+      object-position: center 38%;
+    }
+  }
+
+  .copy {
+    min-width: 0;
+    display: grid;
+    gap: 0.14rem;
+
+    strong {
+      color: #f0f6fc;
+      font-size: 1.02rem;
+      line-height: 1.2;
+      font-weight: 850;
+      letter-spacing: -0.03em;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    span {
+      color: #8b949e;
+      font-size: 0.78rem;
+      line-height: 1.35;
+      font-weight: 720;
+    }
+  }
+
+  .stats {
+    margin: 1rem 0 0;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.48rem;
+  }
+
+  .stats div {
+    min-width: 0;
+    border: 1px solid rgba(48, 54, 61, 0.78);
+    border-radius: 12px;
+    background: rgba(13, 17, 23, 0.58);
+    padding: 0.64rem 0.62rem;
+  }
+
+  dt {
+    margin: 0;
+    color: #6e7681;
+    font-size: 0.64rem;
+    line-height: 1.2;
+    font-weight: 850;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  dd {
+    margin: 0.18rem 0 0;
+    color: #f0f6fc;
+    font-size: 1.05rem;
+    line-height: 1.1;
+    font-weight: 860;
+    letter-spacing: -0.035em;
+  }
+
+  .links {
+    margin-top: 0.82rem;
+    min-height: 32px;
+    display: flex;
+    align-items: center;
+    gap: 0.48rem;
+    flex-wrap: wrap;
+  }
+
+  .links a {
+    min-height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    padding: 0 0.76rem;
+    border: 1px solid rgba(88, 166, 255, 0.42);
+    background: rgba(88, 166, 255, 0.1);
+    color: #c9e7ff;
+    text-decoration: none;
+    font-size: 0.75rem;
+    font-weight: 820;
+  }
+`

--- a/front/src/routes/Feed/SearchInput.tsx
+++ b/front/src/routes/Feed/SearchInput.tsx
@@ -52,11 +52,11 @@ export default SearchInput
 
 const StyledWrapper = styled.div`
   min-width: 0;
-  --feed-search-border: ${({ theme }) => theme.publicDesign.border};
-  --feed-search-border-strong: ${({ theme }) => theme.publicDesign.borderStrong};
-  --feed-search-surface: ${({ theme }) => theme.publicDesign.surface};
-  --feed-search-surface-elevated: ${({ theme }) => theme.publicDesign.surfaceElevated};
-  --feed-search-accent-muted: ${({ theme }) => theme.publicDesign.accentMuted};
+  --feed-search-border: #30363d;
+  --feed-search-border-strong: #58a6ff;
+  --feed-search-surface: #161b22;
+  --feed-search-surface-elevated: #21262d;
+  --feed-search-accent-muted: rgba(88, 166, 255, 0.16);
 
   > .field {
     display: flex;
@@ -76,7 +76,7 @@ const StyledWrapper = styled.div`
       align-items: center;
       justify-content: center;
       flex: 0 0 auto;
-      color: ${({ theme }) => theme.colors.gray10};
+      color: #8b949e;
       width: 15px;
       height: 15px;
       transition: color 0.125s ease-in;
@@ -98,7 +98,7 @@ const StyledWrapper = styled.div`
       border-radius: ${({ theme }) => `${theme.variables.ui.button.radiusPill}px`};
       border: 1px solid var(--feed-search-border);
       background: transparent;
-      color: ${({ theme }) => theme.colors.gray10};
+      color: #8b949e;
       font-size: 0.74rem;
       font-weight: 700;
       letter-spacing: 0;
@@ -107,7 +107,7 @@ const StyledWrapper = styled.div`
       transition: all 0.125s ease-in;
 
       &:hover {
-        color: ${({ theme }) => theme.colors.gray12};
+        color: #f0f6fc;
         border-color: var(--feed-search-border-strong);
         background: var(--feed-search-accent-muted);
       }
@@ -126,8 +126,8 @@ const StyledWrapper = styled.div`
     font-size: 0.84rem;
     font-weight: 560;
     line-height: 1.4;
-    color: ${({ theme }) => theme.colors.gray12};
-    caret-color: ${({ theme }) => theme.colors.gray12};
+    color: #f0f6fc;
+    caret-color: #f0f6fc;
     border: 0;
     outline: none;
     box-shadow: none;
@@ -137,7 +137,7 @@ const StyledWrapper = styled.div`
     transition: all 0.125s ease-in;
 
     &::placeholder {
-      color: ${({ theme }) => theme.colors.gray10};
+      color: #8b949e;
       opacity: 1;
       transition: opacity 0.12s ease-in;
     }
@@ -160,7 +160,7 @@ const StyledWrapper = styled.div`
     box-shadow: 0 0 0 1px var(--feed-search-accent-muted);
 
     .searchIcon {
-      color: ${({ theme }) => theme.colors.gray11};
+      color: #c9d1d9;
     }
   }
 

--- a/front/src/routes/Feed/TagList.tsx
+++ b/front/src/routes/Feed/TagList.tsx
@@ -106,6 +106,7 @@ const TagList: React.FC = () => {
       <section
         className="desktopPanel"
         aria-label="태그 목록"
+        aria-hidden="true"
       >
         <h2 className="panelTitle">
           <span className="panelEmoji" aria-hidden="true">🏷️</span>
@@ -154,6 +155,7 @@ const TagList: React.FC = () => {
 
       <div
         className="chipRail"
+        data-ui="feed-tag-chip-rail"
         role="group"
         aria-label="태그 선택"
       >
@@ -201,15 +203,14 @@ export default memo(TagList)
 
 const StyledWrapper = styled.div`
   min-width: 0;
-  --feed-tag-border: ${({ theme }) => theme.publicDesign.border};
-  --feed-tag-border-strong: ${({ theme }) => theme.publicDesign.borderStrong};
-  --feed-tag-hover-border: ${({ theme }) => theme.publicDesign.borderStrong};
-  --feed-tag-surface: ${({ theme }) => theme.publicDesign.surface};
-  --feed-tag-surface-elevated: ${({ theme }) => theme.publicDesign.surfaceElevated};
-  --feed-tag-accent: ${({ theme }) => theme.publicDesign.accent};
-  --feed-tag-accent-text: ${({ theme }) =>
-    theme.scheme === "light" ? theme.colors.blue11 : theme.colors.blue10};
-  --feed-tag-accent-muted: ${({ theme }) => theme.publicDesign.accentMuted};
+  --feed-tag-border: #30363d;
+  --feed-tag-border-strong: #58a6ff;
+  --feed-tag-hover-border: #8b949e;
+  --feed-tag-surface: #161b22;
+  --feed-tag-surface-elevated: #21262d;
+  --feed-tag-accent: #58a6ff;
+  --feed-tag-accent-text: #58a6ff;
+  --feed-tag-accent-muted: rgba(88, 166, 255, 0.14);
 
   .desktopPanel {
     display: none;
@@ -219,10 +220,6 @@ const StyledWrapper = styled.div`
     max-height: calc(100vh - var(--app-header-height, 56px) - 1.8rem);
     max-height: calc(100dvh - var(--app-header-height, 56px) - 1.8rem);
     overflow: hidden;
-
-    @media (min-width: ${FEED_TAG_RAIL_DESKTOP_MIN_PX}px) {
-      display: block;
-    }
   }
 
   .panelTitle {
@@ -387,7 +384,10 @@ const StyledWrapper = styled.div`
     }
 
     @media (min-width: ${FEED_TAG_RAIL_DESKTOP_MIN_PX}px) {
-      display: none;
+      justify-content: center;
+      flex-wrap: wrap;
+      overflow-x: visible;
+      padding-bottom: 0;
     }
   }
 
@@ -403,7 +403,7 @@ const StyledWrapper = styled.div`
     border: 0;
     background: transparent;
     padding: 0.34rem 0.82rem;
-    color: ${({ theme }) => theme.colors.gray11};
+    color: #c9d1d9;
     flex-shrink: 0;
     scroll-snap-align: start;
     cursor: pointer;
@@ -455,7 +455,7 @@ const StyledWrapper = styled.div`
 
   .chipRail button .count {
     font-size: 0.72rem;
-    color: ${({ theme }) => theme.colors.gray8};
+    color: #8b949e;
   }
 
   .chipRail button[data-active="true"] .count {

--- a/front/src/routes/Feed/index.tsx
+++ b/front/src/routes/Feed/index.tsx
@@ -1,15 +1,9 @@
 import Footer from "./Footer"
 import styled from "@emotion/styled"
-import MobileProfileCard from "./MobileProfileCard"
-import ProfileCard from "./ProfileCard"
-import ServiceCard from "./ServiceCard"
-import ContactCard from "./ContactCard"
 import { AdminProfile, useAdminProfile } from "src/hooks/useAdminProfile"
 import { CONFIG } from "site.config"
 import FeedExplorer from "./FeedExplorer"
-import {
-  WIDE_SIDEBAR_LAYOUT_MIN_PX,
-} from "src/layouts/RootLayout/layoutTiers"
+import ProfileSummaryCard from "./ProfileSummaryCard"
 
 type Props = {
   initialAdminProfile?: AdminProfile | null
@@ -18,28 +12,29 @@ type Props = {
 const Feed: React.FC<Props> = ({ initialAdminProfile = null }) => {
   const adminProfile = useAdminProfile(initialAdminProfile)
   const introTitle =
-    adminProfile?.homeIntroTitle || adminProfile?.blogTitle || CONFIG.blog.homeIntroTitle || CONFIG.blog.title
+    adminProfile?.blogTitle || CONFIG.blog.title || "AquilaLog"
+  const introRole = adminProfile?.profileRole || CONFIG.profile.role || "Backend Engineering"
   const introDescription = adminProfile?.homeIntroDescription || CONFIG.blog.homeIntroDescription || CONFIG.blog.description
 
   return (
-    <StyledWrapper>
+    <StyledWrapper data-ui="feed-home-product-shell">
       <div className="mid">
         <IntroCard>
-          <h1>{introTitle}</h1>
-          <p>{introDescription}</p>
+          <div className="introCopy">
+            <span className="brandLabel" data-ui="feed-brand-role">
+              {introRole}
+            </span>
+            <h1>{introTitle}</h1>
+            <p>{introDescription}</p>
+            <div className="topicRail" aria-label="AquilaLog topics">
+              <span>Spring</span>
+              <span>Architecture</span>
+              <span>Infrastructure</span>
+            </div>
+          </div>
+          <ProfileSummaryCard initialAdminProfile={initialAdminProfile} />
         </IntroCard>
         <FeedExplorer />
-        <div className="mobileProfileCard">
-          <MobileProfileCard initialAdminProfile={initialAdminProfile} />
-        </div>
-        <div className="footer">
-          <Footer />
-        </div>
-      </div>
-      <div className="rt">
-        <ProfileCard initialAdminProfile={initialAdminProfile} />
-        <ServiceCard initialAdminProfile={initialAdminProfile} />
-        <ContactCard initialAdminProfile={initialAdminProfile} />
         <div className="footer">
           <Footer />
         </div>
@@ -50,103 +45,135 @@ const Feed: React.FC<Props> = ({ initialAdminProfile = null }) => {
 
 export default Feed
 
-const FEED_SIDEBAR_WIDTH_REM = 20
-
 const StyledWrapper = styled.div`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 1.25rem;
-  align-items: start;
-  padding: 1rem 0 1.9rem;
+  --feed-product-bg: #0d1117;
+  --feed-product-panel: #161b22;
+  --feed-product-panel-hover: #21262d;
+  --feed-product-border: #30363d;
+  --feed-product-text: #f0f6fc;
+  --feed-product-muted: #8b949e;
+  --feed-product-accent: #58a6ff;
+  display: block;
+  position: relative;
+  z-index: 0;
+  isolation: isolate;
+  padding: 1.2rem 0 2.4rem;
+  color: var(--feed-product-text);
 
-  @media (min-width: ${WIDE_SIDEBAR_LAYOUT_MIN_PX}px) {
-    grid-template-columns: minmax(0, 1fr) minmax(18rem, ${FEED_SIDEBAR_WIDTH_REM}rem);
-    column-gap: clamp(1.5rem, 2.2vw, 2.5rem);
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    z-index: -1;
+    width: 100vw;
+    transform: translateX(-50%);
+    background:
+      radial-gradient(circle at 78% 0%, rgba(88, 166, 255, 0.1), transparent 28rem),
+      var(--feed-product-bg);
   }
 
   @media (max-width: 768px) {
-    padding: 0.28rem 0 0.96rem;
+    padding: 0.5rem 0 1.1rem;
   }
 
   > .mid {
     display: grid;
     min-width: 0;
-    gap: 1rem;
+    gap: 1.35rem;
 
     @media (max-width: 768px) {
       gap: 0.82rem;
     }
 
-    .mobileProfileCard {
-      @media (min-width: ${WIDE_SIDEBAR_LAYOUT_MIN_PX}px) {
-        display: none;
-      }
-    }
-
     > .footer {
       padding-bottom: 2rem;
-      @media (min-width: ${WIDE_SIDEBAR_LAYOUT_MIN_PX}px) {
-        display: none;
-      }
-    }
-  }
-
-  > .rt {
-    display: none;
-    min-width: 0;
-    overflow: auto;
-    overscroll-behavior: contain;
-    position: sticky;
-    top: calc(var(--app-header-height, 73px) + 0.65rem);
-    height: calc(100vh - var(--app-header-height, 73px) - 0.65rem);
-    height: calc(100dvh - var(--app-header-height, 73px) - 0.65rem);
-    gap: 1rem;
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-
-    &::-webkit-scrollbar {
-      display: none;
-    }
-
-    @media (min-width: ${WIDE_SIDEBAR_LAYOUT_MIN_PX}px) {
-      display: grid;
-    }
-
-    .footer {
-      padding-top: 1rem;
     }
   }
 `
 
 const IntroCard = styled.section`
-  border-bottom: 1px solid ${({ theme }) => theme.publicDesign.border};
-  padding: 0.28rem 0 0.96rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(17rem, 20rem);
+  align-items: end;
+  gap: clamp(1.2rem, 3vw, 2.4rem);
+  border-bottom: 1px solid rgba(48, 54, 61, 0.82);
+  padding: 0.2rem 0 1.3rem;
+
+  .introCopy {
+    min-width: 0;
+  }
+
+  .brandLabel {
+    display: block;
+    margin-bottom: 0.52rem;
+    color: #58a6ff;
+    font-size: 0.78rem;
+    line-height: 1.2;
+    font-weight: 860;
+    letter-spacing: 0.02em;
+  }
 
   h1 {
     margin: 0;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: clamp(2.1rem, 4.2vw, 2.95rem);
-    letter-spacing: -0.04em;
-    line-height: 1.08;
-    font-weight: 760;
-    max-width: 13ch;
+    color: #f0f6fc;
+    font-size: clamp(2.6rem, 5vw, 4rem);
+    letter-spacing: -0.075em;
+    line-height: 0.96;
+    font-weight: 880;
+    max-width: 12ch;
   }
 
   p {
-    margin: 0.78rem 0 0;
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: clamp(1rem, 1.55vw, 1.18rem);
+    margin: 0.82rem 0 0;
+    color: #8b949e;
+    font-size: clamp(0.98rem, 1.3vw, 1.08rem);
     line-height: 1.55;
-    letter-spacing: -0.022em;
-    max-width: 34rem;
+    letter-spacing: -0.018em;
+    max-width: 40rem;
+  }
+
+  .topicRail {
+    margin-top: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.48rem;
+    flex-wrap: wrap;
+  }
+
+  .topicRail span {
+    display: inline-flex;
+    align-items: center;
+    min-height: 30px;
+    border-radius: 999px;
+    border: 1px solid rgba(48, 54, 61, 0.86);
+    background: rgba(22, 27, 34, 0.68);
+    color: #8b949e;
+    padding: 0 0.72rem;
+    font-size: 0.76rem;
+    font-weight: 780;
+  }
+
+  @media (max-width: 1024px) {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
   }
 
   @media (max-width: 768px) {
-    padding-bottom: 1.12rem;
+    padding-bottom: 1rem;
+
+    [data-ui="feed-profile-summary"] {
+      display: none;
+    }
+
+    .topicRail {
+      display: none;
+    }
 
     h1 {
       max-width: none;
-      font-size: clamp(1.85rem, 10vw, 2.55rem);
+      font-size: clamp(2rem, 11vw, 2.55rem);
       line-height: 1.1;
     }
 


### PR DESCRIPTION
## 관련 이슈

close #805

## 작업 배경

- 홈 피드가 좌측 세로 태그 레일과 우측 대형 프로필 레일에 공간을 많이 쓰면서 포스트 중심성이 약했습니다.
- 1440px 이상에서도 포스트 카드가 2열 중심으로 보이고, light scheme에서 새 제품형 카드가 섞이면 표면 계층이 깨질 위험이 있었습니다.
- 썸네일, 카테고리, 태그, 프로필 링크처럼 카드에 노출되는 데이터가 많아지면서 저장용 값이 사용자-facing UI에 새는 회귀를 막을 필요가 있었습니다.

## 작업 내용

- 홈 피드를 중앙 포스트 중심 레이아웃으로 재구성하고 1440px 이상 3열 카드 그리드를 적용했습니다.
- 세로 태그 레일과 우측 프로필 레일을 제거하고 검색 아래 수평 태그 칩과 compact profile summary로 전환했습니다.
- GitHub Dark 계열 surface, border, text token을 홈 피드 product surface에 고정했습니다.
- 썸네일 없는 글도 통일된 브랜드 cover fallback으로 보이도록 카드 UI를 재설계했습니다.
- 카드 category 라벨은 저장용 prefix(`monitor::Spring` 등)를 노출하지 않고 공용 category parser의 표시 라벨만 사용합니다.
- 모바일에서는 프로필 요약과 topic rail을 접어 검색과 포스트 진입을 앞당겼습니다.
- 홈 리디자인, 검색 smoke, perf layout, category-prefix 회귀 테스트를 새 계약에 맞게 추가/갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight` 통과
  - `yarn --cwd front playwright test e2e/home-feed-redesign.spec.ts --workers=1` 통과, 8 passed
  - `yarn --cwd front playwright test e2e/home-feed-redesign.spec.ts e2e/smoke-feed-search.spec.ts e2e/perf-layout.spec.ts e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1` 통과, 30 passed
  - `yarn --cwd front playwright test e2e/perf-runtime.spec.ts --workers=1` 통과, 4 passed
  - `yarn --cwd front build` 통과, `/` First Load JS 160 kB
  - `node front/scripts/check-bundle-size.mjs` 통과, `/`, `/posts/[id]`, `/admin` raw/gzip/brotli 모두 budget OK
  - `git diff --check` 통과
  - CodexReview 지적 반영: category 저장 prefix가 카드/cover에 노출될 수 있는 문제 수정
  - CodeRabbit 최신 리뷰 통과: 3열 브레이크포인트가 1200px부터 적용되던 지적을 `ed4a1496`에서 1440px로 수정하고 1280px 2열 회귀 테스트 추가
  - security diff check: 변경 범위 내 신규 `dangerouslySetInnerHTML`/`innerHTML`/`eval` sink 없음, 외부 profile summary 링크는 정규화 helper와 `rel="noopener noreferrer"` 적용, 포스트 링크는 내부 canonical path만 사용

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `front/src/routes/Feed/index.tsx`: 홈 상단 구조와 full-width dark product surface
  - `front/src/routes/Feed/PostList/PostCard.tsx`: 브랜드 cover fallback, category 표시 라벨, 카드 meta 구조
  - `front/src/routes/Feed/ProfileSummaryCard.tsx`: compact profile summary와 외부 링크 정규화 경로
  - `front/e2e/home-feed-redesign.spec.ts`: 3열/1열/태그칩/브랜드 cover/category prefix 회귀 테스트

## 리스크

- 홈 피드의 light scheme 표면 계약을 의도적으로 dark product surface로 바꿨습니다. 상세/인증 화면의 light legacy 계약은 유지합니다.
- 기존 `ProfileCard`, `ServiceCard`, `ContactCard`, `MobileProfileCard` 파일은 다른 참조 가능성을 고려해 삭제하지 않고 홈 렌더 경로에서만 제거했습니다.
- `front` 전체 `tsc --noEmit`은 기존 e2e 타입 오류가 남아 있어 리뷰 참고 신호로만 기록했습니다. PR 대상 검증은 `next build`, Playwright, bundle guard 기준으로 통과했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 프로필 요약 카드를 홈 피드에 추가하여 포스트/태그/관심사 통계 표시
  * 썸네일이 없는 포스트에 브랜드 커버 폴백 UI 적용
  * 포스트 카드에 조회수 및 예상 읽기 시간 표시

* **Improvements**
  * 홈 피드 레이아웃을 단순화하고 반응형 디자인 개선
  * 태그 칩 레일 표시 방식 업데이트
  * 포스트 카테고리 라벨 표시 로직 개선
  * UI 색상 팔레트 일관성 강화

* **Tests**
  * 홈 피드 리디자인 E2E 시나리오 추가
  * 성능/레이아웃 회귀 테스트 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
