### PR TITLE
[Fix] 관리자 클라우드 ZIP 업로드 400 오류 수정

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -420,6 +420,9 @@ class CloudFileService(
         if (filename.substringAfterLast(".", "").lowercase(Locale.ROOT) == "hwpx" && isHwpxPackage(bytes)) {
             return DetectedContent(HWPX_CONTENT_TYPE, CloudFileMediaKind.DOCUMENT)
         }
+        if (filename.substringAfterLast(".", "").lowercase(Locale.ROOT) == "zip" && isZipSignature(bytes)) {
+            return DetectedContent(ZIP_CONTENT_TYPE, CloudFileMediaKind.DOCUMENT)
+        }
 
         return null
     }
@@ -515,6 +518,7 @@ class CloudFileService(
         private const val MAX_FILENAME_CODE_POINTS = 255L
         private const val MAX_FILENAME_METADATA_ENCODED_BYTES = 1024
         private const val HWPX_CONTENT_TYPE = "application/haansofthwpx"
+        private const val ZIP_CONTENT_TYPE = "application/zip"
         private const val HWPX_MANIFEST_ENTRY = "Contents/content.hpf"
         private const val ZIP_EOCD_MIN_SIZE = 22
         private const val ZIP_EOCD_MAX_SEARCH_LENGTH = ZIP_EOCD_MIN_SIZE + 0xFFFF
@@ -548,11 +552,13 @@ class CloudFileService(
                 "image/x-png" to "image/png",
                 "image/x-webp" to "image/webp",
                 "application/x-hwpx" to HWPX_CONTENT_TYPE,
+                "application/x-zip-compressed" to ZIP_CONTENT_TYPE,
             )
         private val KNOWN_CONTENT_TYPES =
             setOf(
                 "application/pdf",
                 HWPX_CONTENT_TYPE,
+                ZIP_CONTENT_TYPE,
                 "image/jpeg",
                 "image/png",
                 "image/gif",

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -427,7 +427,7 @@ class CloudFileService(
         if (filename.substringAfterLast(".", "").lowercase(Locale.ROOT) == "hwpx" && isHwpxPackage(bytes)) {
             return DetectedContent(HWPX_CONTENT_TYPE, CloudFileMediaKind.DOCUMENT)
         }
-        if (filename.substringAfterLast(".", "").lowercase(Locale.ROOT) == "zip" && isZipSignature(bytes)) {
+        if (filename.substringAfterLast(".", "").lowercase(Locale.ROOT) == "zip" && isValidZipArchive(bytes)) {
             return DetectedContent(ZIP_CONTENT_TYPE, CloudFileMediaKind.DOCUMENT)
         }
 
@@ -446,15 +446,19 @@ class CloudFileService(
         return HWPX_MANIFEST_ENTRY in entries && entries.any { it in HWPX_DOCUMENT_ENTRIES }
     }
 
-    private fun readZipCentralDirectoryEntryNames(bytes: ByteArray): Set<String> {
-        val endRecordOffset = findZipEndOfCentralDirectoryOffset(bytes) ?: return emptySet()
+    private fun isValidZipArchive(bytes: ByteArray): Boolean = isZipSignature(bytes) && parseZipCentralDirectoryEntryNames(bytes) != null
+
+    private fun readZipCentralDirectoryEntryNames(bytes: ByteArray): Set<String> = parseZipCentralDirectoryEntryNames(bytes).orEmpty()
+
+    private fun parseZipCentralDirectoryEntryNames(bytes: ByteArray): Set<String>? {
+        val endRecordOffset = findZipEndOfCentralDirectoryOffset(bytes) ?: return null
         val entryCount = readUInt16Le(bytes, endRecordOffset + ZIP_EOCD_TOTAL_ENTRY_COUNT_OFFSET)
         val centralDirectorySize = readUInt32Le(bytes, endRecordOffset + ZIP_EOCD_DIRECTORY_SIZE_OFFSET)
         val centralDirectoryOffset = readUInt32Le(bytes, endRecordOffset + ZIP_EOCD_DIRECTORY_OFFSET)
-        if (centralDirectorySize > bytes.size || centralDirectoryOffset > bytes.size) return emptySet()
+        if (centralDirectorySize > bytes.size || centralDirectoryOffset > bytes.size) return null
 
         val directoryStart = centralDirectoryOffset.toInt()
-        val directoryEnd = (centralDirectoryOffset + centralDirectorySize).takeIf { it <= bytes.size }?.toInt() ?: return emptySet()
+        val directoryEnd = (centralDirectoryOffset + centralDirectorySize).takeIf { it <= bytes.size }?.toInt() ?: return null
         val names = mutableSetOf<String>()
         var offset = directoryStart
         var scannedCount = 0
@@ -463,21 +467,21 @@ class CloudFileService(
             offset + ZIP_CENTRAL_DIRECTORY_HEADER_SIZE <= directoryEnd &&
             scannedCount < entryCount
         ) {
-            if (!hasSignature(bytes, offset, ZIP_CENTRAL_DIRECTORY_FILE_HEADER_SIGNATURE)) break
+            if (!hasSignature(bytes, offset, ZIP_CENTRAL_DIRECTORY_FILE_HEADER_SIGNATURE)) return null
 
             val nameLength = readUInt16Le(bytes, offset + ZIP_CENTRAL_DIRECTORY_NAME_LENGTH_OFFSET)
             val extraLength = readUInt16Le(bytes, offset + ZIP_CENTRAL_DIRECTORY_EXTRA_LENGTH_OFFSET)
             val commentLength = readUInt16Le(bytes, offset + ZIP_CENTRAL_DIRECTORY_COMMENT_LENGTH_OFFSET)
             val nameOffset = offset + ZIP_CENTRAL_DIRECTORY_HEADER_SIZE
             val nextOffset = nameOffset + nameLength + extraLength + commentLength
-            if (nameOffset + nameLength > directoryEnd || nextOffset > directoryEnd) break
+            if (nameOffset + nameLength > directoryEnd || nextOffset > directoryEnd) return null
 
             names += String(bytes, nameOffset, nameLength, StandardCharsets.UTF_8).replace('\\', '/')
-            if (HWPX_MANIFEST_ENTRY in names && names.any { it in HWPX_DOCUMENT_ENTRIES }) break
-
             offset = nextOffset
             scannedCount++
         }
+
+        if (scannedCount != entryCount || offset != directoryEnd) return null
 
         return names
     }

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -349,13 +349,20 @@ class CloudFileService(
         if (
             normalizedDeclared != null &&
             normalizedDeclared in KNOWN_CONTENT_TYPES &&
-            normalizedDeclared != detected.contentType
+            !isDeclaredContentTypeCompatible(normalizedDeclared, detected.contentType)
         ) {
             throw AppException("400-1", "파일 내용과 콘텐츠 타입이 일치하지 않습니다.")
         }
 
         return detected
     }
+
+    private fun isDeclaredContentTypeCompatible(
+        declaredContentType: String,
+        detectedContentType: String,
+    ): Boolean =
+        declaredContentType == detectedContentType ||
+            (detectedContentType == HWPX_CONTENT_TYPE && declaredContentType == ZIP_CONTENT_TYPE)
 
     private fun normalizeContentType(raw: String?): String? {
         val normalized =

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -303,6 +303,28 @@ class CloudFileServiceTest {
     }
 
     @Test
+    @DisplayName("업로드 시 한글 파일명의 일반 ZIP 파일은 문서로 저장한다")
+    fun `upload는 한글 파일명의 일반 ZIP 파일을 문서로 저장한다`() {
+        val nfcName = "3._(별첨2)_직무시험_관련_국민건강보험법_및_노인장기요양법.zip"
+        val nfdName = Normalizer.normalize(nfcName, Normalizer.Form.NFD)
+
+        val result =
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = nfdName,
+                clientOriginalFilename = nfdName,
+                contentType = "application/zip",
+                bytes = genericZipBytes(),
+                folderPath = null,
+            )
+
+        assertThat(result.originalFilename).isEqualTo(nfcName)
+        assertThat(result.mediaKind).isEqualTo(CloudFileMediaKind.DOCUMENT)
+        assertThat(result.contentType).isEqualTo("application/zip")
+        assertThat(storage.uploaded.single().originalFilename).isEqualTo(nfcName)
+    }
+
+    @Test
     @DisplayName("업로드 시 mojibake로 들어온 한글 파일명은 원본 기호까지 UTF-8 기준으로 복구한다")
     fun `upload는 mojibake 한글 파일명을 UTF-8 기준으로 복구한다`() {
         val originalName = "★2026년 제3회 식약처 공무원(일반직) 경력경쟁채용시험 공고문_게시.pdf"

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -342,6 +342,24 @@ class CloudFileServiceTest {
     }
 
     @Test
+    @DisplayName("업로드 시 중앙 디렉터리가 없는 ZIP 조각은 일반 ZIP 문서로 저장하지 않는다")
+    fun `upload는 중앙 디렉터리가 없는 ZIP 조각을 일반 ZIP 문서로 저장하지 않는다`() {
+        assertThatThrownBy {
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "truncated.zip",
+                contentType = "application/zip",
+                bytes = truncatedZipBytes(),
+                folderPath = null,
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("지원하지 않는 클라우드 파일 형식")
+
+        assertThat(storage.uploaded).isEmpty()
+        assertThat(repository.savedFiles).isEmpty()
+    }
+
+    @Test
     @DisplayName("업로드 시 mojibake로 들어온 한글 파일명은 원본 기호까지 UTF-8 기준으로 복구한다")
     fun `upload는 mojibake 한글 파일명을 UTF-8 기준으로 복구한다`() {
         val originalName = "★2026년 제3회 식약처 공무원(일반직) 경력경쟁채용시험 공고문_게시.pdf"

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -249,6 +249,23 @@ class CloudFileServiceTest {
     }
 
     @Test
+    @DisplayName("업로드 시 ZIP MIME으로 선언된 HWPX 파일도 HWPX 문서로 저장한다")
+    fun `upload는 zip mime으로 선언된 hwpx 파일도 hwpx 문서로 저장한다`() {
+        val result =
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "제출서류_총괄표.hwpx",
+                contentType = "application/x-zip-compressed",
+                bytes = zipBytes(),
+                folderPath = null,
+            )
+
+        assertThat(result.mediaKind).isEqualTo(CloudFileMediaKind.DOCUMENT)
+        assertThat(result.contentType).isEqualTo("application/haansofthwpx")
+        assertThat(result.originalFilename).isEqualTo("제출서류_총괄표.hwpx")
+    }
+
+    @Test
     @DisplayName("업로드 시 잘못된 ZIP 헤더 조합은 HWPX 문서로 저장하지 않는다")
     fun `upload는 잘못된 ZIP 헤더 조합을 HWPX 문서로 저장하지 않는다`() {
         assertThatThrownBy {

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -930,6 +930,44 @@ export const PdfCanvas = styled.canvas`
   object-fit: contain;
 `
 
+export const DocumentFallbackBox = styled.div`
+  display: grid;
+  gap: 0.65rem;
+  place-items: center;
+  min-height: 12rem;
+  padding: 1.25rem;
+  border: 1px solid ${border};
+  border-radius: 8px;
+  background: ${surfaceRaised};
+  color: ${textSecondary};
+  text-align: center;
+
+  strong {
+    color: ${textPrimary};
+    font-size: 0.95rem;
+    font-weight: 850;
+  }
+
+  p {
+    margin: 0;
+    max-width: 18rem;
+    font-size: 0.78rem;
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+  }
+
+  a {
+    border: 1px solid ${borderStrong};
+    border-radius: 999px;
+    padding: 0.45rem 0.7rem;
+    background: ${surfaceMuted};
+    color: ${textPrimary};
+    font-size: 0.78rem;
+    font-weight: 850;
+    text-decoration: none;
+  }
+`
+
 export const PhotoFrame = styled.div`
   position: relative;
   display: grid;

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -48,6 +48,7 @@ import {
   DetailSummary,
   DetailTab,
   DetailTabs,
+  DocumentFallbackBox,
   EmptyState,
   EmptyTableState,
   FavoriteButton,
@@ -142,6 +143,8 @@ const preferClientFilenameForUploadedFile = (uploaded: CloudFile, clientFilename
 
 const isAbortLikeError = (error: unknown) =>
   error instanceof DOMException && (error.name === "AbortError" || error.name === "TimeoutError")
+
+const isPdfDocumentFile = (file: CloudFile) => file.contentType.toLowerCase() === "application/pdf"
 
 const resolveCloudErrorMessage = (error: unknown) => {
   if (error instanceof Error && error.message.trim()) return error.message.trim()
@@ -303,6 +306,26 @@ const PdfPreview = ({ file, contentUrl }: PdfPreviewProps) => {
   )
 }
 
+type DocumentFallbackPreviewProps = {
+  file: CloudFile
+  contentUrl: string
+}
+
+const DocumentFallbackPreview = ({ file, contentUrl }: DocumentFallbackPreviewProps) => (
+  <PreviewStage>
+    <PreviewHeader>
+      <h3>문서 파일</h3>
+    </PreviewHeader>
+    <DocumentFallbackBox>
+      <strong>{getCloudKindBadge(file)} 파일</strong>
+      <p>{file.originalFilename}</p>
+      <a href={contentUrl} download={file.originalFilename}>
+        다운로드
+      </a>
+    </DocumentFallbackBox>
+  </PreviewStage>
+)
+
 type PhotoPreviewProps = {
   file: CloudFile
   contentUrl: string
@@ -411,7 +434,8 @@ const PreviewDrawer = ({ file }: PreviewDrawerProps) => {
   }
 
   const contentUrl = getCloudFileContentUrl(file.id)
-  if (file.mediaKind === "DOCUMENT") return <PdfPreview file={file} contentUrl={contentUrl} />
+  if (file.mediaKind === "DOCUMENT" && isPdfDocumentFile(file)) return <PdfPreview file={file} contentUrl={contentUrl} />
+  if (file.mediaKind === "DOCUMENT") return <DocumentFallbackPreview file={file} contentUrl={contentUrl} />
   if (file.mediaKind === "PHOTO") return <PhotoPreview file={file} contentUrl={contentUrl} />
   return <VideoPreview file={file} contentUrl={contentUrl} />
 }


### PR DESCRIPTION
## 관련 이슈

close #810

## 작업 배경

- 관리자 클라우드에서 한글/괄호 파일명을 가진 ZIP 파일 업로드 시 `POST /system/api/v1/adm/cloud/files`가 400으로 실패했습니다.
- 원인은 `CloudFileService`가 ZIP 시그니처를 HWPX 판별에만 사용하고, 일반 `.zip`은 지원 파일 형식으로 분류하지 않아 `detectContent`가 실패한 것입니다.
- 일반 ZIP 허용 과정에서 HWPX MIME 호환, 손상 ZIP 거부, non-PDF 문서 미리보기 경로도 함께 회귀 가능성이 있어 같은 PR에서 보강했습니다.

## 작업 내용

- `.zip` 확장자와 유효한 ZIP 중앙 디렉터리가 함께 확인되는 파일을 `application/zip` 문서 파일로 저장하도록 허용했습니다.
- `application/x-zip-compressed` 선언 MIME은 `application/zip`으로 정규화했습니다.
- 브라우저/OS가 HWPX를 ZIP MIME으로 선언해도 HWPX 감지 결과와 호환되도록 검증 계약을 조정했습니다.
- 중앙 디렉터리가 없는 ZIP 조각은 일반 ZIP 문서로 저장하지 않도록 검증을 강화했습니다.
- ZIP/HWPX 등 PDF가 아닌 문서는 PDF.js 대신 다운로드 가능한 문서 fallback 미리보기를 표시하도록 분기했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests 'com.back.boundedContexts.cloud.application.service.CloudFileServiceTest'` RED: 신규 ZIP 테스트 1건 실패 확인
  - `back/gradlew -p back test --tests 'com.back.boundedContexts.cloud.application.service.CloudFileServiceTest'` GREEN 성공
  - `back/gradlew -p back test --tests 'com.back.boundedContexts.cloud.*'` 성공
  - `back/gradlew -p back ktlintCheck` 성공
  - `yarn --cwd front build` 성공
  - `git diff --check` 성공
  - GitHub Actions: backend-ci, frontend-ci, Security/CodeQL 성공
  - Vercel Preview 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `CloudFileService.detectFromSignature`에서 HWPX 판별 뒤 일반 ZIP을 별도 허용하는 순서
  - `isDeclaredContentTypeCompatible`의 HWPX + ZIP MIME 호환 계약
  - ZIP 문서가 PDF.js 경로로 들어가지 않고 fallback preview로 분기되는지

## 리스크

- ZIP 내부 파일 내용은 백신/콘텐츠 검사 대상이 아닙니다. 관리자 전용 개인 클라우드에 저장 가능한 문서 컨테이너로만 분류하며, public URL은 만들지 않는 기존 권한 모델을 유지합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
