### PR TITLE
[Fix] 테마 전환 color-scheme 동기화

### DIFF
--- a/front/e2e/theme-color-scheme.spec.ts
+++ b/front/e2e/theme-color-scheme.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test"
+import { addPublicAboutSnapshotCookie, mockAvatarAsset, mockFeedEndpoints } from "./helpers/smokeFixtures"
+
+test.describe("theme color-scheme", () => {
+  test("헤더 테마 토글은 루트와 form control color-scheme을 함께 전환한다", async ({ page }) => {
+    await mockAvatarAsset(page)
+    await mockFeedEndpoints(page)
+    await addPublicAboutSnapshotCookie(page)
+    await page.context().addCookies([
+      {
+        name: "scheme",
+        value: "dark",
+        url: "http://127.0.0.1:3000",
+      },
+    ])
+
+    await page.goto("/")
+    await expect(page.getByRole("button", { name: "라이트 모드로 전환" })).toBeVisible()
+
+    const initialScheme = await page.evaluate(() => {
+      const input = document.createElement("input")
+      document.body.append(input)
+      const result = {
+        body: window.getComputedStyle(document.body).colorScheme,
+        html: window.getComputedStyle(document.documentElement).colorScheme,
+        input: window.getComputedStyle(input).colorScheme,
+      }
+      input.remove()
+      return result
+    })
+
+    expect(initialScheme).toEqual({
+      body: "dark",
+      html: "dark",
+      input: "dark",
+    })
+
+    await page.getByRole("button", { name: "라이트 모드로 전환" }).click()
+    await expect(page.getByRole("button", { name: "다크 모드로 전환" })).toBeVisible()
+
+    const nextScheme = await page.evaluate(() => {
+      const input = document.createElement("input")
+      document.body.append(input)
+      const result = {
+        bootstrapScheme: document.documentElement.getAttribute("data-aquila-scheme-bootstrap"),
+        bootstrapStyleCount: document.querySelectorAll('style[data-aquila-scheme-bootstrap-style="true"]').length,
+        datasetScheme: document.documentElement.dataset.aquilaScheme,
+        body: window.getComputedStyle(document.body).colorScheme,
+        html: window.getComputedStyle(document.documentElement).colorScheme,
+        inlineHtmlColorScheme: document.documentElement.style.colorScheme,
+        input: window.getComputedStyle(input).colorScheme,
+      }
+      input.remove()
+      return result
+    })
+
+    expect(nextScheme).toEqual({
+      bootstrapScheme: null,
+      bootstrapStyleCount: 0,
+      datasetScheme: "light",
+      body: "light",
+      html: "light",
+      inlineHtmlColorScheme: "",
+      input: "light",
+    })
+  })
+})

--- a/front/src/hooks/useScheme.ts
+++ b/front/src/hooks/useScheme.ts
@@ -19,14 +19,21 @@ const resolveCachedScheme = (): SchemeType | null => {
   return isScheme(cachedScheme) ? cachedScheme : null
 }
 
-const clearSchemeBootstrapStyle = () => {
-  document.documentElement.removeAttribute("data-aquila-scheme-bootstrap")
+const clearSchemeBootstrapStyle = (scheme?: SchemeType) => {
+  const root = document.documentElement
+  if (scheme) {
+    root.dataset.aquilaScheme = scheme
+  }
+  root.removeAttribute("data-aquila-scheme-bootstrap")
+  root.removeAttribute("data-aquila-scheme-bootstrap-source")
+  root.style.removeProperty("color-scheme")
+  root.style.removeProperty("background-color")
   document.querySelector('style[data-aquila-scheme-bootstrap-style="true"]')?.remove()
 }
 
-const clearSchemeBootstrapAfterHydration = () => {
+const clearSchemeBootstrapAfterHydration = (scheme: SchemeType) => {
   requestAnimationFrame(() => {
-    requestAnimationFrame(clearSchemeBootstrapStyle)
+    requestAnimationFrame(() => clearSchemeBootstrapStyle(scheme))
   })
 }
 
@@ -47,6 +54,7 @@ const useScheme = (): [SchemeType, SetScheme] => {
   const setScheme = useCallback((scheme: SchemeType) => {
     setCookie("scheme", scheme, { path: "/", sameSite: "lax" })
     queryClient.setQueryData(queryKey.scheme(), scheme)
+    clearSchemeBootstrapStyle(scheme)
   }, [queryClient])
 
   useEffect(() => {
@@ -58,7 +66,7 @@ const useScheme = (): [SchemeType, SetScheme] => {
       queryClient.setQueryData(queryKey.scheme(), bootstrapScheme)
       return
     }
-    clearSchemeBootstrapAfterHydration()
+    clearSchemeBootstrapAfterHydration(data)
   }, [data, followsSystemTheme, queryClient])
 
   return [data, setScheme]

--- a/front/src/layouts/RootLayout/ThemeProvider/Global/index.tsx
+++ b/front/src/layouts/RootLayout/ThemeProvider/Global/index.tsx
@@ -12,6 +12,7 @@ export const Global = () => {
       styles={css`
         html {
           min-height: 100%;
+          color-scheme: ${theme.scheme};
           -webkit-text-size-adjust: 100%;
           text-size-adjust: 100%;
           overflow-x: visible;


### PR DESCRIPTION
## 관련 이슈

close #811

## 작업 배경

- 라이트/다크 토글 클릭 시 body/header 색상은 바뀌지만 `_document` bootstrap이 남긴 html inline `color-scheme` 때문에 루트 computed scheme이 이전 값으로 남았습니다.
- 이 상태에서는 브라우저 기본 UI와 form control 렌더링이 현재 테마와 어긋날 수 있습니다.

## 작업 내용

- 전역 Global style에서 `html`에도 현재 theme의 `color-scheme`을 명시했습니다.
- `useScheme`의 bootstrap 정리 로직이 `data-aquila-scheme-bootstrap`, bootstrap style tag, bootstrap source attribute, html inline `color-scheme/background-color`를 함께 제거하도록 수정했습니다.
- 헤더 테마 토글 후 `html/body/input`의 computed `color-scheme`과 bootstrap 잔여물을 검증하는 Playwright 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight` 통과
  - `yarn --cwd front playwright test e2e/theme-color-scheme.spec.ts --workers=1` 최초 실패로 기존 결함 재현 후 수정 뒤 통과
  - `yarn --cwd front playwright test e2e/smoke-public-shell.spec.ts e2e/theme-color-scheme.spec.ts --workers=1` 9 passed
  - `yarn --cwd front build` 통과
  - GitHub Actions: frontend-ci, backend-ci, Security/CodeQL 모두 통과
  - PR review threads: unresolved 0개

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `front/src/hooks/useScheme.ts`의 bootstrap 정리 범위입니다.
- `_document`의 dark pre-hydration guard 자체는 유지하고, hydration 이후 또는 사용자 직접 전환 시 잔여 inline/style만 제거합니다.
- CodeRabbit은 rate limit으로 실제 리뷰가 시작되지 않아 Codex CLI fallback review를 PR review로 남겼고, actionable 0건입니다.

## 리스크

- 첫 페인트 dark guard를 건드리지 않았으므로 초기 깜빡임 방지 계약은 유지됩니다.
- 테마 전환 직후 루트 inline style이 제거되어 Global theme style이 source of truth가 됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
