### PR TITLE
[Fix] 관리자 클라우드 사진 preview 로딩 문구 제거

### DIFF
--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -480,6 +480,7 @@ test.describe("관리자 클라우드", () => {
     await expect(page.getByText("사진을 불러오는 중입니다.")).toHaveCount(0)
     await expect.poll(() => mocks.requestedContentIds).toContain("102")
     await expect(page.getByAltText("home-server-rack.png")).toBeVisible()
+    await expect(page.getByLabel("home-server-rack.png 사진 미리보기")).toHaveAttribute("aria-busy", "false")
     await expect.poll(() => page.evaluate(() => Boolean((window as any).__adminCloudPhotoLoadingTextSeen))).toBe(false)
     await expect(page.getByText("사진을 불러오는 중입니다.")).toHaveCount(0)
   })

--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -445,16 +445,42 @@ test.describe("관리자 클라우드", () => {
     await expect(page.getByRole("status", { name: "파일 목록 로딩" })).toHaveCount(0)
   })
 
-  test("사진 선택 시 상세 패널은 이미지 요청과 로딩 상태를 즉시 보여준다", async ({ page }) => {
+  test("사진 선택 시 상세 패널은 이미지 요청을 즉시 시작하고 텍스트 로딩 상태를 숨긴다", async ({ page }) => {
     const mocks = await setupAdminCloudMocks(page, { contentDelayMs: 450 })
+
+    await page.addInitScript(() => {
+      Object.assign(window, { __adminCloudPhotoLoadingTextSeen: false })
+
+      const markIfLoadingTextExists = () => {
+        if (document.body?.textContent?.includes("사진을 불러오는 중입니다.")) {
+          Object.assign(window, { __adminCloudPhotoLoadingTextSeen: true })
+        }
+      }
+
+      const startObserver = () => {
+        markIfLoadingTextExists()
+        new MutationObserver(markIfLoadingTextExists).observe(document.documentElement, {
+          characterData: true,
+          childList: true,
+          subtree: true,
+        })
+      }
+
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", startObserver, { once: true })
+      } else {
+        startObserver()
+      }
+    })
 
     await page.goto("/admin/cloud")
     await page.locator('button[title="home-server-rack.png"]').click()
 
     await expect(page.getByRole("heading", { name: "사진 보기" })).toBeVisible()
-    await expect(page.getByText("사진을 불러오는 중입니다.")).toBeVisible()
+    await expect(page.getByText("사진을 불러오는 중입니다.")).toHaveCount(0)
     await expect.poll(() => mocks.requestedContentIds).toContain("102")
     await expect(page.getByAltText("home-server-rack.png")).toBeVisible()
+    await expect.poll(() => page.evaluate(() => Boolean((window as any).__adminCloudPhotoLoadingTextSeen))).toBe(false)
     await expect(page.getByText("사진을 불러오는 중입니다.")).toHaveCount(0)
   })
 

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -986,6 +986,17 @@ export const PhotoFrame = styled.div`
   }
 `
 
+export const PhotoFallback = styled.div`
+  display: grid;
+  place-items: center;
+  min-height: 12rem;
+  padding: 1rem;
+  color: ${textSecondary};
+  font-size: 0.82rem;
+  font-weight: 780;
+  text-align: center;
+`
+
 export const ToastViewport = styled.div<{ "data-tone": "success" | "error" }>`
   position: fixed;
   right: max(1rem, env(safe-area-inset-right));

--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -974,24 +974,15 @@ export const PhotoFrame = styled.div`
   place-items: center;
   width: 100%;
   min-height: 12rem;
-
-  > span {
-    position: absolute;
-    z-index: 1;
-    border-radius: 999px;
-    padding: 0.34rem 0.62rem;
-    background: ${surfaceRaised};
-    color: ${textSecondary};
-    font-size: 0.76rem;
-    font-weight: 780;
-  }
+  overflow: hidden;
+  border-radius: 8px;
+  background: ${surfaceMuted};
 
   img {
     width: 100%;
     max-height: 18rem;
     object-fit: contain;
-    border-radius: 8px;
-    background: ${surfaceMuted};
+    background: transparent;
   }
 `
 

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -67,6 +67,7 @@ import {
   LoadingTableStatus,
   Notice,
   PdfCanvas,
+  PhotoFallback,
   PhotoFrame,
   PlayerBar,
   PreviewHeader,
@@ -332,13 +333,31 @@ type PhotoPreviewProps = {
 }
 
 const PhotoPreview = ({ file, contentUrl }: PhotoPreviewProps) => {
+  const [imageState, setImageState] = useState<"loading" | "ready" | "error">("loading")
+
+  useEffect(() => {
+    setImageState("loading")
+  }, [contentUrl])
+
   return (
     <PreviewStage>
       <PreviewHeader>
         <h3>사진 보기</h3>
       </PreviewHeader>
-      <PhotoFrame>
-        <img src={contentUrl} alt={file.originalFilename} decoding="async" loading="eager" />
+      <PhotoFrame
+        aria-label={`${file.originalFilename} 사진 미리보기`}
+        aria-busy={imageState === "loading" ? "true" : "false"}
+      >
+        {imageState === "error" ? <PhotoFallback role="alert">이미지를 불러올 수 없습니다.</PhotoFallback> : null}
+        <img
+          src={contentUrl}
+          alt={file.originalFilename}
+          decoding="async"
+          loading="eager"
+          hidden={imageState === "error"}
+          onLoad={() => setImageState("ready")}
+          onError={() => setImageState("error")}
+        />
       </PhotoFrame>
     </PreviewStage>
   )

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -332,33 +332,13 @@ type PhotoPreviewProps = {
 }
 
 const PhotoPreview = ({ file, contentUrl }: PhotoPreviewProps) => {
-  const imageRef = useRef<HTMLImageElement | null>(null)
-  const [loadedContentUrl, setLoadedContentUrl] = useState<string | null>(null)
-  const isImageReady = loadedContentUrl === contentUrl
-
-  useEffect(() => {
-    const image = imageRef.current
-    if (image?.complete && image.naturalWidth > 0) {
-      setLoadedContentUrl(contentUrl)
-    }
-  }, [contentUrl])
-
   return (
     <PreviewStage>
       <PreviewHeader>
         <h3>사진 보기</h3>
       </PreviewHeader>
-      <PhotoFrame aria-busy={isImageReady ? "false" : "true"}>
-        {!isImageReady ? <span role="status">사진을 불러오는 중입니다.</span> : null}
-        <img
-          ref={imageRef}
-          src={contentUrl}
-          alt={file.originalFilename}
-          decoding="async"
-          loading="eager"
-          onLoad={() => setLoadedContentUrl(contentUrl)}
-          onError={() => setLoadedContentUrl(contentUrl)}
-        />
+      <PhotoFrame>
+        <img src={contentUrl} alt={file.originalFilename} decoding="async" loading="eager" />
       </PhotoFrame>
     </PreviewStage>
   )


### PR DESCRIPTION
## 관련 이슈

close #815

## 작업 배경

- 관리자 클라우드에서 사진 파일 선택 시 `사진을 불러오는 중입니다.` 텍스트가 순간 노출되어 GDrive/MYBOX형 preview UX와 맞지 않았습니다.
- 사용자는 메타 정보와 별도 텍스트 로딩 상태를 먼저 보여주기보다, 안정적인 preview frame 안에서 사진이 자연스럽게 표시되는 동작을 요청했습니다.

## 작업 내용

- `PhotoPreview`의 별도 이미지 로딩 상태와 status 텍스트 렌더링을 제거했습니다.
- 사진 preview frame은 텍스트 placeholder 없이 고정 배경과 clipping만 유지하도록 정리했습니다.
- e2e 테스트는 DOM mutation 기록으로 `사진을 불러오는 중입니다.` 문구가 한 번이라도 노출되면 실패하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight` 통과
  - `yarn --cwd front playwright test e2e/admin-cloud.spec.ts -g "사진 선택 시 상세 패널은 이미지 요청을 즉시 시작하고 텍스트 로딩 상태를 숨긴다" --workers=1` RED 확인 후 수정 뒤 통과
  - `yarn --cwd front playwright test e2e/admin-cloud.spec.ts --workers=1` 통과, 18 passed
  - `yarn --cwd front build` 통과
  - `git diff --check` 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `PhotoPreview`가 더 이상 사진 로딩 텍스트를 렌더링하지 않는지
  - 테스트가 transient 텍스트 노출까지 잡도록 충분한지

## 리스크

- 사진 preview 자체만 변경했으며 업로드/삭제 API와 backend storage contract는 변경하지 않았습니다.
- 이미지 fetch가 늦을 때도 텍스트 상태가 없으므로, frame만 먼저 보이는 UX가 의도된 동작입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
