### PR TITLE
[Fix] 홈서버 외부 백업 전 compose 이미지 env 보정

### DIFF
--- a/deploy/homeserver/create_external_backup.sh
+++ b/deploy/homeserver/create_external_backup.sh
@@ -9,6 +9,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 ENV_FILE="${SCRIPT_DIR}/.env.prod"
 COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.prod.yml"
+COMPOSE_ENV_FILE="${ENV_FILE}"
+COMPOSE_ENV_FILE_TMP=""
 MIGRATION_STOPPED_FILE="${SCRIPT_DIR}/.external-minio-migration-stopped"
 DEFAULT_EXTERNAL_STORAGE_ROOT="/mnt/aquila-blog-data"
 TIMESTAMP="${AQUILA_BACKUP_TIMESTAMP:-$(date +%Y%m%d-%H%M%S)}"
@@ -18,6 +20,7 @@ STOPPED_BACKUP_MINIO_CONTAINERS=()
 LEGACY_MINIO_STOPPED_FOR_MIGRATION="false"
 MINIO_STOPPED_FOR_BACKUP="false"
 MIGRATED_MINIO_DIR_THIS_RUN=""
+COMPOSE_IMAGE_ENV_PREFLIGHT_DONE="false"
 
 read_key_from_text() {
   local key="$1"
@@ -82,6 +85,112 @@ env_value_from_current_file() {
     return 0
   fi
   printf '%s' "${default_value}"
+}
+
+trim_quotes() {
+  local value="$1"
+  value="${value#\"}"
+  value="${value%\"}"
+  value="${value#\'}"
+  value="${value%\'}"
+  printf '%s' "${value}"
+}
+
+require_digest_image_value() {
+  local key="$1"
+  local value="$2"
+  if [[ "${value}" == *":latest" || "${value}" == *":latest@"* ]]; then
+    fail "latest tag is not allowed for image env key before backup compose evaluation: ${key}=${value}"
+  fi
+  if [[ ! "${value}" =~ @sha256:[a-fA-F0-9]{64}$ ]]; then
+    fail "image env key must include sha256 digest before backup compose evaluation: ${key}=${value}"
+  fi
+}
+
+ensure_compose_env_work_file() {
+  if [[ -n "${COMPOSE_ENV_FILE_TMP}" ]]; then
+    return 0
+  fi
+
+  COMPOSE_ENV_FILE_TMP="$(mktemp "${TMPDIR:-/tmp}/aquila-compose-env.XXXXXX")"
+  if [[ -f "${ENV_FILE}" ]]; then
+    cp "${ENV_FILE}" "${COMPOSE_ENV_FILE_TMP}"
+  else
+    : > "${COMPOSE_ENV_FILE_TMP}"
+  fi
+  COMPOSE_ENV_FILE="${COMPOSE_ENV_FILE_TMP}"
+}
+
+upsert_env_key() {
+  local key="$1"
+  local value="$2"
+  local target="${3:-${COMPOSE_ENV_FILE}}"
+  local status
+  [[ -n "${value}" ]] || return 0
+  touch "${target}"
+
+  if grep -qE "^${key}=" "${target}"; then
+    set +e
+    grep -vE "^${key}=" "${target}" > "${target}.tmp"
+    status=$?
+    set -e
+    [[ "${status}" -eq 0 || "${status}" -eq 1 ]] || fail "failed to filter ${key} from ${target}"
+    printf '%s=%s\n' "${key}" "${value}" >> "${target}.tmp"
+    mv "${target}.tmp" "${target}"
+  else
+    printf '%s=%s\n' "${key}" "${value}" >> "${target}"
+  fi
+}
+
+resolve_local_repo_digest() {
+  local image_ref="$1"
+  docker image inspect --format '{{index .RepoDigests 0}}' "${image_ref}" 2>/dev/null | head -n 1 | tr -d '\r'
+}
+
+ensure_image_env_key_from_local_digest() {
+  local key="$1"
+  local fallback_image="$2"
+  local value
+  value="$(trim_quotes "$(env_value "${key}")")"
+  if [[ -n "${value}" ]]; then
+    require_digest_image_value "${key}" "${value}"
+    local file_value
+    file_value="$(trim_quotes "$(read_key_from_file "${key}" "${ENV_FILE}")")"
+    if [[ "${value}" != "${file_value}" ]]; then
+      # Keep the deploy snapshot truthful: stage HOME_SERVER_ENV or shell
+      # overrides in a temporary compose env file instead of mutating .env.prod.
+      ensure_compose_env_work_file
+      upsert_env_key "${key}" "${value}"
+    fi
+    return 0
+  fi
+
+  local digest
+  digest="$(resolve_local_repo_digest "${fallback_image}" || true)"
+  if [[ -n "${digest}" ]]; then
+    require_digest_image_value "${key}" "${digest}"
+    ensure_compose_env_work_file
+    upsert_env_key "${key}" "${digest}"
+    log "auto-filled ${key} from local digest (${fallback_image} -> ${digest})"
+    return 0
+  fi
+
+  fail "required image env key is missing and local digest lookup failed: ${key} (fallback=${fallback_image})"
+}
+
+ensure_compose_image_env_defaults() {
+  ensure_image_env_key_from_local_digest "CLOUDFLARED_IMAGE" "cloudflare/cloudflared:latest"
+  ensure_image_env_key_from_local_digest "AUTOHEAL_IMAGE" "willfarrell/autoheal:1.2.0"
+  ensure_image_env_key_from_local_digest "CADDY_IMAGE" "caddy:2.8-alpine"
+  ensure_image_env_key_from_local_digest "UPTIME_KUMA_IMAGE" "louislam/uptime-kuma:1"
+  ensure_image_env_key_from_local_digest "PROMETHEUS_IMAGE" "prom/prometheus:v2.54.1"
+  ensure_image_env_key_from_local_digest "GRAFANA_IMAGE" "grafana/grafana:11.2.2"
+  ensure_image_env_key_from_local_digest "LOKI_IMAGE" "grafana/loki:3.0.0"
+  ensure_image_env_key_from_local_digest "PROMTAIL_IMAGE" "grafana/promtail:3.0.0"
+  ensure_image_env_key_from_local_digest "NODE_RUNTIME_IMAGE" "node:20-alpine"
+  ensure_image_env_key_from_local_digest "DB_IMAGE" "jangka512/pgj:latest"
+  ensure_image_env_key_from_local_digest "REDIS_IMAGE" "redis:7-alpine"
+  ensure_image_env_key_from_local_digest "MINIO_IMAGE" "minio/minio:latest"
 }
 
 log() {
@@ -163,7 +272,29 @@ check_free_space() {
 }
 
 compose() {
-  docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" "$@"
+  docker compose --env-file "${COMPOSE_ENV_FILE}" -f "${COMPOSE_FILE}" "$@"
+}
+
+validate_compose_config_after_env_autofill() {
+  compose config --quiet >/dev/null || fail "compose config validation failed after image env auto-fill"
+}
+
+ensure_backup_compose_ready() {
+  if [[ "${COMPOSE_IMAGE_ENV_PREFLIGHT_DONE}" == "true" ]]; then
+    return 0
+  fi
+  ensure_compose_image_env_defaults
+  validate_compose_config_after_env_autofill
+  COMPOSE_IMAGE_ENV_PREFLIGHT_DONE="true"
+}
+
+prepare_postgres_backup_compose_if_needed() {
+  if [[ "${AQUILA_BACKUP_SKIP_POSTGRES:-false}" == "true" ]]; then
+    return 0
+  fi
+
+  command -v docker >/dev/null 2>&1 || fail "docker is required for PostgreSQL backup"
+  ensure_backup_compose_ready
 }
 
 backup_classes() {
@@ -219,6 +350,9 @@ copy_deploy_config() {
       cp "${SCRIPT_DIR}/${file}" "${target_dir}/${file}"
     fi
   done
+  if [[ "${COMPOSE_ENV_FILE}" != "${ENV_FILE}" && -f "${COMPOSE_ENV_FILE}" ]]; then
+    cp "${COMPOSE_ENV_FILE}" "${target_dir}/.env.prod.compose"
+  fi
 
   write_metadata "${class}" "${target_dir}"
 }
@@ -234,7 +368,7 @@ backup_postgres() {
     return 0
   fi
 
-  command -v docker >/dev/null 2>&1 || fail "docker is required for PostgreSQL backup"
+  prepare_postgres_backup_compose_if_needed
   compose exec -T db_1 pg_dump -U postgres -d "${POSTGRES_DB_NAME}" > "${target_dir}/dump.sql"
   write_metadata "${class}" "${target_dir}"
 }
@@ -343,6 +477,9 @@ write_stopped_legacy_minio_marker() {
 
 cleanup_on_exit() {
   local status=$?
+  if [[ -n "${COMPOSE_ENV_FILE_TMP}" ]]; then
+    rm -f -- "${COMPOSE_ENV_FILE_TMP}" "${COMPOSE_ENV_FILE_TMP}.tmp"
+  fi
   if [[ "${status}" -ne 0 ]]; then
     if [[ "${MINIO_STOPPED_FOR_BACKUP}" == "true" ]]; then
       restart_minio_after_consistent_backup || true
@@ -446,6 +583,7 @@ done < <(backup_classes)
 log "backup start id=${TIMESTAMP} root=${BACKUP_ROOT} classes=${classes[*]}"
 
 for class in "${classes[@]}"; do
+  prepare_postgres_backup_compose_if_needed
   copy_deploy_config "${class}"
   backup_postgres "${class}"
   backup_minio "${class}"

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -172,6 +172,117 @@ test("runtime service images are env-backed in compose and digest-validated by c
   assert(tagOnlyResult.errors.some((error) => error.key === "CADDY_IMAGE"))
 })
 
+test("외부 백업은 compose 평가 전에 누락된 runtime image env를 보정한다", () => {
+  const externalBackupScript = readFileSync(externalBackupScriptPath, "utf8")
+  const runtimeImageDefaults = [
+    ["CLOUDFLARED_IMAGE", "cloudflare/cloudflared:latest"],
+    ["AUTOHEAL_IMAGE", "willfarrell/autoheal:1.2.0"],
+    ["CADDY_IMAGE", "caddy:2.8-alpine"],
+    ["UPTIME_KUMA_IMAGE", "louislam/uptime-kuma:1"],
+    ["PROMETHEUS_IMAGE", "prom/prometheus:v2.54.1"],
+    ["GRAFANA_IMAGE", "grafana/grafana:11.2.2"],
+    ["LOKI_IMAGE", "grafana/loki:3.0.0"],
+    ["PROMTAIL_IMAGE", "grafana/promtail:3.0.0"],
+    ["NODE_RUNTIME_IMAGE", "node:20-alpine"],
+    ["DB_IMAGE", "jangka512/pgj:latest"],
+    ["REDIS_IMAGE", "redis:7-alpine"],
+    ["MINIO_IMAGE", "minio/minio:latest"],
+  ]
+
+  for (const [key, image] of runtimeImageDefaults) {
+    const escapedImage = image.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    assert.match(
+      externalBackupScript,
+      new RegExp(`ensure_image_env_key_from_local_digest "${key}" "${escapedImage}"`),
+    )
+  }
+
+  const imageGuardBody = externalBackupScript.slice(
+    externalBackupScript.indexOf("ensure_image_env_key_from_local_digest() {"),
+    externalBackupScript.indexOf("ensure_compose_image_env_defaults() {"),
+  )
+  assert.match(imageGuardBody, /value="\$\(trim_quotes "\$\(env_value "\$\{key\}"\)"\)"/)
+  assert.match(
+    externalBackupScript,
+    /if \[\[ "\$\{value\}" == \*":latest" \|\| "\$\{value\}" == \*":latest@"\* \]\]/,
+  )
+  assert.match(imageGuardBody, /require_digest_image_value "\$\{key\}" "\$\{value\}"/)
+  assert.match(imageGuardBody, /file_value="\$\(trim_quotes "\$\(read_key_from_file "\$\{key\}" "\$\{ENV_FILE\}"\)"\)"/)
+  assert.match(imageGuardBody, /ensure_compose_env_work_file\n\s+upsert_env_key "\$\{key\}" "\$\{value\}"/)
+  assert.match(imageGuardBody, /upsert_env_key "\$\{key\}" "\$\{value\}"/)
+  assert.match(
+    imageGuardBody,
+    /require_digest_image_value "\$\{key\}" "\$\{digest\}"/,
+  )
+  assert.match(imageGuardBody, /ensure_compose_env_work_file\n\s+upsert_env_key "\$\{key\}" "\$\{digest\}"/)
+  assert.match(
+    externalBackupScript,
+    /set \+e\n\s+grep -vE "\^\$\{key\}=" "\$\{target\}" > "\$\{target\}\.tmp"\n\s+status=\$\?\n\s+set -e\n\s+\[\[ "\$\{status\}" -eq 0 \|\| "\$\{status\}" -eq 1 \]\] \|\| fail "failed to filter \$\{key\} from \$\{target\}"/,
+  )
+  assert.match(
+    externalBackupScript,
+    /COMPOSE_ENV_FILE="\$\{ENV_FILE\}"/,
+  )
+  assert.match(
+    externalBackupScript,
+    /docker compose --env-file "\$\{COMPOSE_ENV_FILE\}" -f "\$\{COMPOSE_FILE\}" "\$@"/,
+  )
+  assert.match(
+    externalBackupScript,
+    /rm -f -- "\$\{COMPOSE_ENV_FILE_TMP\}" "\$\{COMPOSE_ENV_FILE_TMP\}\.tmp"/,
+  )
+  assert(
+    imageGuardBody.indexOf("ensure_compose_env_work_file") < imageGuardBody.indexOf('upsert_env_key "${key}" "${value}"') &&
+    imageGuardBody.indexOf('upsert_env_key "${key}" "${value}"') < imageGuardBody.indexOf("return 0"),
+    "HOME_SERVER_ENV image values must be staged before compose reads the env file",
+  )
+
+  const composeReadyBody = externalBackupScript.slice(
+    externalBackupScript.indexOf("ensure_backup_compose_ready() {"),
+    externalBackupScript.indexOf("backup_classes() {"),
+  )
+  const copyDeployConfigBody = externalBackupScript.slice(
+    externalBackupScript.indexOf("copy_deploy_config() {"),
+    externalBackupScript.indexOf("backup_postgres() {"),
+  )
+  const preparePostgresBody = externalBackupScript.slice(
+    externalBackupScript.indexOf("prepare_postgres_backup_compose_if_needed() {"),
+    externalBackupScript.indexOf("backup_classes() {"),
+  )
+  const backupPostgresBody = externalBackupScript.slice(
+    externalBackupScript.indexOf("backup_postgres() {"),
+    externalBackupScript.indexOf("is_dir_empty() {"),
+  )
+  const backupLoopBody = externalBackupScript.slice(
+    externalBackupScript.indexOf('for class in "${classes[@]}"; do'),
+    externalBackupScript.indexOf('log "backup complete id=${TIMESTAMP}"'),
+  )
+  const ensureCallIndex = composeReadyBody.indexOf("\n  ensure_compose_image_env_defaults\n")
+  const validateComposeIndex = composeReadyBody.indexOf("\n  validate_compose_config_after_env_autofill\n")
+  const skipMarkerIndex = preparePostgresBody.indexOf('if [[ "${AQUILA_BACKUP_SKIP_POSTGRES:-false}" == "true" ]]')
+  const prepareComposeReadyCallIndex = preparePostgresBody.indexOf("\n  ensure_backup_compose_ready\n")
+  const prepareCallIndex = backupPostgresBody.indexOf("\n  prepare_postgres_backup_compose_if_needed\n")
+  const composeExecIndex = backupPostgresBody.indexOf("\n  compose exec -T db_1")
+  const loopPrepareIndex = backupLoopBody.indexOf("\n  prepare_postgres_backup_compose_if_needed\n")
+  const loopCopyIndex = backupLoopBody.indexOf("\n  copy_deploy_config")
+  assert(ensureCallIndex > -1, "create_external_backup.sh must call image env auto-fill")
+  assert(validateComposeIndex > -1, "create_external_backup.sh must validate compose after image env auto-fill")
+  assert(skipMarkerIndex > -1, "PostgreSQL backup skip path must remain explicit")
+  assert(prepareComposeReadyCallIndex > -1, "PostgreSQL compose preparation must call compose preflight")
+  assert(prepareCallIndex > -1, "PostgreSQL backup must prepare compose before compose exec")
+  assert(composeExecIndex > -1, "PostgreSQL backup must keep compose exec")
+  assert(loopPrepareIndex > -1, "backup loop must prepare compose before copying deploy config")
+  assert(loopCopyIndex > -1, "backup loop must copy deploy config")
+  assert(ensureCallIndex < validateComposeIndex, "compose validation must run after image env auto-fill")
+  assert(skipMarkerIndex < prepareComposeReadyCallIndex, "compose preflight must not run before skipped PostgreSQL backups")
+  assert(prepareCallIndex < composeExecIndex, "compose preflight must run before backup compose calls")
+  assert(loopPrepareIndex < loopCopyIndex, "compose env failures must be detected before copying deploy config")
+  assert.match(
+    copyDeployConfigBody,
+    /cp "\$\{COMPOSE_ENV_FILE\}" "\$\{target_dir\}\/\.env\.prod\.compose"/,
+  )
+})
+
 test("home-server runtime contract covers external storage backup keys", async () => {
   const { loadContract } = await import("../env/validate-env.mjs")
   const keys = new Set(targetKeyNames(loadContract(contractPath), "home-server-runtime"))


### PR DESCRIPTION
## 관련 이슈

close #829

## 작업 배경

- PR #828 merge 후 홈서버 CD run `27666855662`가 `create_external_backup.sh` 단계에서 rollback됐습니다.
- 원인은 외부 백업 스크립트가 `blue_green_deploy.sh`의 runtime image digest 보정 전에 `docker compose`를 평가하면서, 운영 env에 없던 `PROMETHEUS_IMAGE` 필수값을 요구한 것입니다.

## 작업 내용

- `create_external_backup.sh`에 compose 평가 전 runtime image env auto-fill을 추가했습니다.
- 기존 `blue_green_deploy.sh`와 동일한 fallback image 목록을 사용해 local repo digest가 있으면 `.env.prod`에 누락 key를 보강합니다.
- `PROMETHEUS_IMAGE`를 포함한 runtime image 보정이 백업 loop보다 먼저 실행되는지 env contract 테스트로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `bash -n deploy/homeserver/create_external_backup.sh` 성공
  - `node --test --test-name-pattern "외부 백업은 compose 평가 전에 누락된 runtime image env를 보정한다" tools/test/env-contract.test.mjs` 성공
  - `node --test tools/test/env-contract.test.mjs` 성공, 25개 테스트 통과

## 리뷰어 메모

- 먼저 볼 지점: `create_external_backup.sh`의 `ensure_compose_image_env_defaults` 호출 위치입니다. `backup_postgres`/`backup_minio`가 compose를 호출하기 전에 실행되어야 합니다.

## 리스크

- local image digest가 없는 완전 초기 서버에서는 기존처럼 명확한 실패 메시지로 중단됩니다.
- `.env.prod`에 누락된 runtime image key만 추가/갱신하며 secret 값은 건드리지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 외부 백업 생성 스크립트의 안정성을 개선하여 Docker Compose 평가 전에 이미지 설정을 자동으로 검증하고 보정하도록 강화했습니다.

* **Tests**
  * 백업 프로세스의 이미지 설정 보정 및 구성 검증을 확인하는 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->