### PR TITLE
[Test] HtmlContentSanitizer XSS 회귀 테스트 추가

### DIFF
--- a/back/src/main/kotlin/com/back/global/security/application/HtmlContentSanitizer.kt
+++ b/back/src/main/kotlin/com/back/global/security/application/HtmlContentSanitizer.kt
@@ -3,8 +3,10 @@ package com.back.global.security.application
 import org.jsoup.Jsoup
 
 /**
- * HtmlContentSanitizer는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
+ * 게시글 contentHtml 렌더링 전 XSS 위험을 줄이기 위한 HTML 정제 유틸입니다.
+ *
+ * 허용 태그만 유지하고, 이벤트/style/srcdoc 속성과 위험 URI 프로토콜을 제거합니다.
+ * target="_blank" 링크에는 opener 참조를 막기 위한 rel 값을 보강합니다.
  */
 object HtmlContentSanitizer {
     private val allowedTags =
@@ -51,10 +53,6 @@ object HtmlContentSanitizer {
     private val blockedProtocols = listOf("javascript:", "vbscript:", "data:")
     private val uriAttributes = setOf("href", "src")
 
-    /**
-     * 입력 HTML을 정제해 렌더링/XSS 위험을 줄입니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     fun sanitizeRichHtmlOrNull(rawHtml: String?): String? {
         if (rawHtml.isNullOrBlank()) return null
 
@@ -79,7 +77,7 @@ object HtmlContentSanitizer {
                 }
 
                 if (key in uriAttributes) {
-                    val normalized = value.lowercase()
+                    val normalized = normalizeUriForProtocolCheck(value)
                     if (blockedProtocols.any { normalized.startsWith(it) }) {
                         element.removeAttr(attr.key)
                     }
@@ -103,4 +101,9 @@ object HtmlContentSanitizer {
         val sanitized = body.html().trim()
         return sanitized.ifBlank { null }
     }
+
+    private fun normalizeUriForProtocolCheck(value: String): String =
+        value
+            .filterNot { it.isWhitespace() || it.isISOControl() }
+            .lowercase()
 }

--- a/back/src/test/kotlin/com/back/global/security/application/HtmlContentSanitizerTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/application/HtmlContentSanitizerTest.kt
@@ -1,0 +1,76 @@
+package com.back.global.security.application
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("HtmlContentSanitizer XSS 회귀 테스트")
+class HtmlContentSanitizerTest {
+    @Test
+    @DisplayName("이벤트 속성, srcdoc, 비허용 active content 태그를 제거한다")
+    fun removesExecutableHtmlPayloads() {
+        // given
+        val rawHtml =
+            """
+            <p>safe</p>
+            <img src="https://cdn.example.com/a.png" onerror="alert(1)" style="background:url(javascript:alert(1))">
+            <svg onload="alert(1)"><script>alert(2)</script><a href="javascript:alert(3)">x</a></svg>
+            <iframe srcdoc="<script>alert(4)</script>"></iframe>
+            """.trimIndent()
+
+        // when
+        val sanitized = HtmlContentSanitizer.sanitizeRichHtmlOrNull(rawHtml)
+
+        // then
+        assertThat(sanitized).contains("<p>safe</p>")
+        assertThat(sanitized).contains("<img src=\"https://cdn.example.com/a.png\">")
+        assertThat(sanitized).doesNotContain("onerror")
+        assertThat(sanitized).doesNotContain("style=")
+        assertThat(sanitized).doesNotContain("srcdoc")
+        assertThat(sanitized).doesNotContain("<svg")
+        assertThat(sanitized).doesNotContain("<script")
+        assertThat(sanitized).doesNotContain("<iframe")
+        assertThat(sanitized).doesNotContain("javascript:")
+    }
+
+    @Test
+    @DisplayName("href/src 위험 프로토콜과 protocol 내부 제어문자 우회 payload를 제거한다")
+    fun removesDangerousUriProtocols() {
+        // given
+        val rawHtml =
+            """
+            <a href="javascript:alert(1)">javascript</a>
+            <a href="java&#x09;script:alert(2)">tab-obfuscated</a>
+            <a href="vbscript:alert(3)">vbscript</a>
+            <img src="data:text/html,<script>alert(4)</script>">
+            """.trimIndent()
+
+        // when
+        val sanitized = HtmlContentSanitizer.sanitizeRichHtmlOrNull(rawHtml)
+
+        // then
+        assertThat(sanitized).contains("<a>javascript</a>")
+        assertThat(sanitized).contains("<a>tab-obfuscated</a>")
+        assertThat(sanitized).contains("<a>vbscript</a>")
+        assertThat(sanitized).contains("<img>")
+        assertThat(sanitized).doesNotContain("href=")
+        assertThat(sanitized).doesNotContain("src=")
+        assertThat(sanitized).doesNotContain("javascript:")
+        assertThat(sanitized).doesNotContain("vbscript:")
+        assertThat(sanitized).doesNotContain("data:")
+    }
+
+    @Test
+    @DisplayName("target blank 링크에는 opener 참조 차단 rel을 보강한다")
+    fun addsNoopenerNoreferrerToBlankTargets() {
+        // given
+        val rawHtml = """<a target="_blank" rel="nofollow" href="https://example.com">external</a>"""
+
+        // when
+        val sanitized = HtmlContentSanitizer.sanitizeRichHtmlOrNull(rawHtml)
+
+        // then
+        assertThat(sanitized)
+            .isEqualTo("""<a target="_blank" rel="nofollow noopener noreferrer" href="https://example.com">external</a>""")
+    }
+}


### PR DESCRIPTION
## 관련 이슈

close #833

## 작업 배경

- `HtmlContentSanitizer`가 XSS 위험 payload를 정제하는 계약을 갖고 있지만, 명시적인 회귀 테스트가 없어 sanitizer 변경 시 방어 수준이 낮아질 수 있습니다.
- 리뷰에서 지적된 자동 생성식 주석도 실제 sanitizer 역할에 맞게 정리합니다.

## 작업 내용

- `img onerror`, `style`, `svg onload`, `script`, `iframe srcdoc`, `javascript:`, `vbscript:`, `data:` payload 회귀 테스트를 추가했습니다.
- `java&#x09;script:`처럼 protocol 내부 제어문자를 이용한 우회 payload를 위험 프로토콜로 판정하도록 보강했습니다.
- `target="_blank"` 링크가 `rel="noopener noreferrer"`를 유지/보강하는 계약을 테스트로 고정했습니다.
- `HtmlContentSanitizer` KDoc을 실제 XSS sanitizer 역할 중심으로 수정했습니다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back test --tests com.back.global.security.application.HtmlContentSanitizerTest` RED: `java&#x09;script:` href 잔존으로 실패 확인
  - `./back/gradlew -p back test --tests com.back.global.security.application.HtmlContentSanitizerTest` GREEN: 통과
  - `./back/gradlew -p back ktlintCheck` 통과
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check` 통과

## 리뷰어 메모

- URI 값 자체를 재작성하지 않고, 위험 프로토콜 판정용 문자열에서 whitespace/control character만 제거해 `javascript:` 계열 우회만 차단합니다.
- `coderabbit` CLI/스킬은 사용자 요청에 따라 실행하지 않습니다.

## 리스크

- 매우 보수적으로 `java script:`처럼 공백이 들어간 protocol-like 값도 위험 프로토콜로 판정합니다. 정상 URL에서 scheme 내부 공백은 유효하지 않으므로 호환성 영향은 낮습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. (GitHub 앱 자동 체크만 확인, CLI/스킬 미실행)
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (사용자 금지 조건 때문에 미사용)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (`Deploy to Home Server` 및 live e2e 통과)
