### PR TITLE
[Fix] SecurityConfig 기본 보안 헤더 비활성화 범위 축소

### DIFF
--- a/back/src/main/kotlin/com/back/global/security/config/SecurityConfig.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/SecurityConfig.kt
@@ -57,6 +57,8 @@ class SecurityConfig(
         http: HttpSecurity,
         apiMutationCsrfGuardFilter: ApiMutationCsrfGuardFilter,
     ): SecurityFilterChain {
+        val isProd = environment.matchesProfiles("prod")
+
         http {
             authorizeHttpRequests {
                 authorize(HttpMethod.OPTIONS, "/**", permitAll)
@@ -68,7 +70,6 @@ class SecurityConfig(
                 authorize("/*/api/*/**", authenticated)
                 authorize("/oauth2/**", permitAll)
                 authorize("/login/oauth2/**", permitAll)
-                val isProd = environment.matchesProfiles("prod")
                 val endpointExposurePolicy = SecurityEndpointExposurePolicy(isProd)
                 if (isProd) {
                     // 프로덕션에서는 k8s/lb health probe 외 actuator 공개를 차단한다.
@@ -97,12 +98,13 @@ class SecurityConfig(
             cors { }
 
             headers {
-                // Caddy is the single source of response security headers in prod;
-                // disable Spring Security defaults that would otherwise duplicate them.
-                cacheControl { disable() }
-                contentTypeOptions { disable() }
-                frameOptions { disable() }
-                httpStrictTransportSecurity { disable() }
+                if (isProd) {
+                    // Caddy is the single source of response security headers in prod.
+                    cacheControl { disable() }
+                    contentTypeOptions { disable() }
+                    frameOptions { disable() }
+                    httpStrictTransportSecurity { disable() }
+                }
             }
 
             csrf { disable() }

--- a/back/src/test/kotlin/com/back/support/SecurityConfigEndpointExposureWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/support/SecurityConfigEndpointExposureWebMvcTest.kt
@@ -19,6 +19,7 @@ import com.back.global.security.config.oauth2.CustomOidcUserService
 import com.back.global.web.application.AuthCookieService
 import com.back.global.web.application.ClientIpResolver
 import com.back.global.web.application.Rq
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -30,6 +31,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.core.env.Environment
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
+import org.springframework.http.HttpHeaders
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
@@ -40,6 +42,8 @@ import org.springframework.test.web.servlet.post
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 import tools.jackson.databind.ObjectMapper
+
+private const val STRICT_TRANSPORT_SECURITY_HEADER = "Strict-Transport-Security"
 
 @WebMvcTest(controllers = [SecurityConfigEndpointExposureWebMvcTestSupport.ProbeController::class])
 @Import(
@@ -124,6 +128,23 @@ abstract class SecurityConfigEndpointExposureWebMvcTestSupport {
 @ActiveProfiles("prod")
 @DisplayName("SecurityConfig prod endpoint exposure 테스트")
 class SecurityConfigProdEndpointExposureWebMvcTest : SecurityConfigEndpointExposureWebMvcTestSupport() {
+    @Test
+    @DisplayName("prod에서는 edge proxy가 보안 헤더를 단일 책임으로 내려주도록 Spring 기본 헤더를 위임한다")
+    fun `prod delegates default response security headers to edge proxy`() {
+        val response =
+            mvc
+                .get("/actuator/health/liveness")
+                .andExpect {
+                    status { isInternalServerError() }
+                }.andReturn()
+                .response
+
+        assertThat(response.getHeader("X-Content-Type-Options")).isNull()
+        assertThat(response.getHeader("X-Frame-Options")).isNull()
+        assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL)).isNull()
+        assertThat(response.getHeader(STRICT_TRANSPORT_SECURITY_HEADER)).isNull()
+    }
+
     @Test
     @DisplayName("prod에서 public Swagger와 OpenAPI는 익명 접근을 401로 막는다")
     fun `prod protects public api docs from anonymous access`() {
@@ -215,6 +236,28 @@ class SecurityConfigProdEndpointExposureWebMvcTest : SecurityConfigEndpointExpos
 @ActiveProfiles("test")
 @DisplayName("SecurityConfig non-prod endpoint exposure 테스트")
 class SecurityConfigNonProdEndpointExposureWebMvcTest : SecurityConfigEndpointExposureWebMvcTestSupport() {
+    @Test
+    @DisplayName("non-prod에서는 proxy 보강 없이도 Spring 기본 보안 헤더를 유지한다")
+    fun `non prod keeps spring security default response headers`() {
+        val response =
+            mvc
+                .get("/actuator/info") {
+                    secure = true
+                }.andExpect {
+                    status { isInternalServerError() }
+                }.andReturn()
+                .response
+
+        assertThat(response.getHeader("X-Content-Type-Options")).isEqualTo("nosniff")
+        assertThat(response.getHeader("X-Frame-Options")).isEqualTo("DENY")
+        assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL))
+            .isEqualTo("no-cache, no-store, max-age=0, must-revalidate")
+        assertThat(response.getHeader(HttpHeaders.PRAGMA)).isEqualTo("no-cache")
+        assertThat(response.getHeader(HttpHeaders.EXPIRES)).isEqualTo("0")
+        assertThat(response.getHeader(STRICT_TRANSPORT_SECURITY_HEADER))
+            .isEqualTo("max-age=31536000 ; includeSubDomains")
+    }
+
     @Test
     @DisplayName("non-prod에서는 Prometheus, Swagger, OpenAPI 개발 경로의 익명 접근을 유지한다")
     fun `non prod keeps diagnostics and api docs public`() {


### PR DESCRIPTION
## 관련 이슈

close #835

## 작업 배경

- `SecurityConfig`가 Spring Security 기본 보안 헤더를 모든 profile에서 비활성화하고 있어, Caddy/edge proxy가 헤더를 보강하지 않는 local·staging·우회 경로에서 기본 방어 헤더가 빠질 수 있었습니다.
- prod에서는 Caddy가 response security header의 단일 책임을 갖도록 유지하되, non-prod/default에서는 Spring Security 기본 헤더를 유지해 설정 누락을 조기에 드러내도록 합니다.

## 작업 내용

- `SecurityConfig.filterChain`에서 `prod` profile 여부를 한 번 계산해 endpoint 노출 정책과 header 정책에 함께 사용하도록 정리했습니다.
- `cacheControl`, `contentTypeOptions`, `frameOptions`, `httpStrictTransportSecurity` disable을 prod profile 블록 안으로 제한했습니다.
- non-prod WebMvc 테스트에 `X-Content-Type-Options`, `X-Frame-Options`, `Cache-Control`, `Pragma`, `Expires`, `Strict-Transport-Security` 기본 헤더 회귀 테스트를 추가했습니다.
- prod WebMvc 테스트에는 Spring 기본 보안 헤더가 Caddy로 위임되어 중복 생성되지 않는 계약을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back test --tests com.back.support.SecurityConfigNonProdEndpointExposureWebMvcTest --tests com.back.support.SecurityConfigProdEndpointExposureWebMvcTest` RED: non-prod `X-Content-Type-Options` 누락으로 실패 확인
  - `./back/gradlew -p back test --tests com.back.support.SecurityConfigNonProdEndpointExposureWebMvcTest --tests com.back.support.SecurityConfigProdEndpointExposureWebMvcTest` GREEN: 통과
  - `./back/gradlew -p back ktlintCheck` 통과
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check` 통과

## 리뷰어 메모

- prod의 edge proxy 위임 정책은 유지하고, non-prod/default만 Spring Security 기본 header writer를 복구하는 최소 변경입니다.
- `coderabbit` CLI/스킬과 `codex review` fallback은 사용자 금지 조건에 따라 실행하지 않습니다.

## 리스크

- non-prod/default 응답에 Spring Security 기본 cache header가 추가됩니다. 운영 prod는 기존 Caddy 위임 정책을 유지하므로 prod cache/header 중복 리스크는 낮습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. (GitHub 앱 자동 체크만 확인, CLI/스킬 미실행)
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (사용자 금지 조건 때문에 미사용)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (`Deploy to Home Server` 및 live e2e 통과)
