### PR TITLE
[Fix] CORS allowedHeaders 운영 허용 목록 구체화

### DIFF
--- a/back/src/main/kotlin/com/back/global/security/config/ApiCorsPolicy.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/ApiCorsPolicy.kt
@@ -28,7 +28,7 @@ class ApiCorsPolicy(
         CorsConfiguration().apply {
             allowedOriginPatterns = buildAllowedOriginPatterns()
             allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
-            allowedHeaders = ALLOWED_REQUEST_HEADERS
+            allowedHeaders = buildAllowedRequestHeaders()
             allowCredentials = true
             maxAge = 1800
         }
@@ -84,6 +84,19 @@ class ApiCorsPolicy(
             .distinct()
     }
 
+    private fun buildAllowedRequestHeaders(): List<String> =
+        listOf(
+            HttpHeaders.ACCEPT,
+            HttpHeaders.AUTHORIZATION,
+            HttpHeaders.CONTENT_TYPE,
+            HttpHeaders.IF_NONE_MATCH,
+            "Idempotency-Key",
+            "Last-Event-ID",
+            HttpHeaders.RANGE,
+            ApiMutationCsrfGuardFilter.CSRF_PREFLIGHT_HEADER,
+            "X-Request-ID",
+        )
+
     private fun normalizeOriginPattern(raw: String?): String? {
         if (raw.isNullOrBlank()) return null
         val trimmed = raw.trim()
@@ -121,20 +134,5 @@ class ApiCorsPolicy(
         if (tokens.add(token)) {
             response.setHeader(HttpHeaders.VARY, tokens.joinToString(", "))
         }
-    }
-
-    private companion object {
-        val ALLOWED_REQUEST_HEADERS =
-            listOf(
-                HttpHeaders.ACCEPT,
-                HttpHeaders.AUTHORIZATION,
-                HttpHeaders.CONTENT_TYPE,
-                HttpHeaders.IF_NONE_MATCH,
-                "Idempotency-Key",
-                "Last-Event-ID",
-                HttpHeaders.RANGE,
-                ApiMutationCsrfGuardFilter.CSRF_PREFLIGHT_HEADER,
-                "X-Request-ID",
-            )
     }
 }

--- a/back/src/main/kotlin/com/back/global/security/config/ApiCorsPolicy.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/ApiCorsPolicy.kt
@@ -28,7 +28,7 @@ class ApiCorsPolicy(
         CorsConfiguration().apply {
             allowedOriginPatterns = buildAllowedOriginPatterns()
             allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
-            allowedHeaders = listOf("*")
+            allowedHeaders = ALLOWED_REQUEST_HEADERS
             allowCredentials = true
             maxAge = 1800
         }
@@ -121,5 +121,20 @@ class ApiCorsPolicy(
         if (tokens.add(token)) {
             response.setHeader(HttpHeaders.VARY, tokens.joinToString(", "))
         }
+    }
+
+    private companion object {
+        val ALLOWED_REQUEST_HEADERS =
+            listOf(
+                HttpHeaders.ACCEPT,
+                HttpHeaders.AUTHORIZATION,
+                HttpHeaders.CONTENT_TYPE,
+                HttpHeaders.IF_NONE_MATCH,
+                "Idempotency-Key",
+                "Last-Event-ID",
+                HttpHeaders.RANGE,
+                ApiMutationCsrfGuardFilter.CSRF_PREFLIGHT_HEADER,
+                "X-Request-ID",
+            )
     }
 }

--- a/back/src/test/kotlin/com/back/global/security/config/ApiCorsPolicyTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/ApiCorsPolicyTest.kt
@@ -49,4 +49,38 @@ class ApiCorsPolicyTest {
 
         assertThat(patterns).isEmpty()
     }
+
+    @Test
+    @DisplayName("credential CORS 요청 헤더는 운영에 필요한 명시 목록만 허용한다")
+    fun `cors allowed headers use explicit production allowlist`() {
+        val environment = MockEnvironment().withProperty("spring.profiles.active", "prod")
+        val policy =
+            ApiCorsPolicy(
+                environment = environment,
+                siteFrontUrl = "https://www.aquilaxk.site",
+                siteBackUrl = "https://api.aquilaxk.site",
+                siteCookieDomain = "aquilaxk.site",
+            )
+
+        val allowedHeaders = policy.corsConfiguration().allowedHeaders.orEmpty()
+
+        assertThat(allowedHeaders).containsExactlyInAnyOrder(
+            "Accept",
+            "Authorization",
+            "Content-Type",
+            "If-None-Match",
+            "Idempotency-Key",
+            "Last-Event-ID",
+            "Range",
+            "X-Aquila-CSRF",
+            "X-Request-ID",
+        )
+        assertThat(allowedHeaders).doesNotContain(
+            "*",
+            "X-Forwarded-For",
+            "X-Real-IP",
+            "CF-Connecting-IP",
+            "True-Client-IP",
+        )
+    }
 }


### PR DESCRIPTION
## 관련 이슈

close #837

## 작업 배경

- `ApiCorsPolicy`가 credential CORS에서 `allowedHeaders="*"`를 사용해 브라우저가 preflight로 승인받을 수 있는 요청 헤더 범위가 운영 필요보다 넓었습니다.
- 실제 프론트/백엔드 사용 경로에 필요한 인증, CSRF, idempotency, cache validation, range streaming, SSE reconnect, request correlation 헤더만 명시적으로 허용합니다.

## 작업 내용

- CORS allowed request headers를 명시 목록으로 변경했습니다.
- 허용 목록에 `Accept`, `Authorization`, `Content-Type`, `If-None-Match`, `Idempotency-Key`, `Last-Event-ID`, `Range`, `X-Aquila-CSRF`, `X-Request-ID`를 포함했습니다.
- `*`, `X-Forwarded-For`, `X-Real-IP`, `CF-Connecting-IP`, `True-Client-IP`가 CORS 허용 요청 헤더에 포함되지 않도록 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back test --tests com.back.global.security.config.ApiCorsPolicyTest` RED: `allowedHeaders="*"`로 명시 목록 검증 실패 확인
  - `./back/gradlew -p back test --tests com.back.global.security.config.ApiCorsPolicyTest` GREEN: 통과
  - `./back/gradlew -p back ktlintCheck` 통과
  - `./back/gradlew -p back ciFastCheck` GREEN: 통과
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check` 통과
  - PR CI: backend-ci, frontend-ci, Security, CodeQL, Vercel 통과
  - PR review threads: unresolved thread 없음
  - main CI/Security: merge commit `0c23e2285de7cf5985ff404d25e931adf7d30800` 기준 통과
  - CD: `Deploy to Home Server` run `27677129266` 통과, live e2e 통과

## 리뷰어 메모

- 브라우저 CORS 허용 목록에 proxy/client IP 전달 헤더를 넣지 않는 것이 핵심입니다.
- `coderabbit` CLI/스킬과 `codex review` fallback은 사용자 금지 조건에 따라 실행하지 않았습니다.
- GitHub PR 상 CodeRabbit 리뷰/체크는 생성되지 않았고, unresolved review thread도 없습니다.

## 리스크

- 새 브라우저 클라이언트가 목록 밖 커스텀 헤더를 추가하면 preflight에서 차단될 수 있습니다. 필요한 경우 해당 헤더를 테스트와 함께 명시적으로 추가해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. (GitHub 리뷰/체크 없음, CLI/스킬 미실행)
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (사용자 금지 조건 때문에 미사용)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
