### PR TITLE
[Refactor] PostApplicationService 후속 작업 AFTER_COMMIT 전환

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -142,22 +142,20 @@ class PostApplicationService(
                 )
             val createdTags = extractNormalizedTags(created.content)
             val isPublic = isPubliclyListed(created)
-            clearReadCaches(
-                postId = created.id,
-                afterTags = createdTags,
-                evictHotReadPages = isPublic,
-                evictSearchFirstPage = isPublic,
-                evictImpactedTagPages = isPublic,
-                evictTagsPublic = isPublic,
-                evictDetail = isPublic,
-                evictReason = "write",
-            )
             enqueuePostWriteSideEffect(
                 PostWriteSideEffectCommand(
                     postId = created.id,
                     previousContent = null,
                     currentContent = created.content,
                     deletedContent = null,
+                    beforeTags = emptyList(),
+                    afterTags = createdTags,
+                    evictHotReadPages = isPublic,
+                    evictSearchFirstPage = isPublic,
+                    evictImpactedTagPages = isPublic,
+                    evictTagsPublic = isPublic,
+                    evictDetail = isPublic,
+                    evictReason = "write",
                     recommendationAction = recommendationActionFor(isPublic),
                 ),
             )
@@ -197,22 +195,20 @@ class PostApplicationService(
         postWriteRequestIdempotencyRepository.save(requestSlot)
         val createdTags = extractNormalizedTags(createdPost.content)
         val isPublic = isPubliclyListed(createdPost)
-        clearReadCaches(
-            postId = createdPost.id,
-            afterTags = createdTags,
-            evictHotReadPages = isPublic,
-            evictSearchFirstPage = isPublic,
-            evictImpactedTagPages = isPublic,
-            evictTagsPublic = isPublic,
-            evictDetail = isPublic,
-            evictReason = "write-idempotent",
-        )
         enqueuePostWriteSideEffect(
             PostWriteSideEffectCommand(
                 postId = createdPost.id,
                 previousContent = null,
                 currentContent = createdPost.content,
                 deletedContent = null,
+                beforeTags = emptyList(),
+                afterTags = createdTags,
+                evictHotReadPages = isPublic,
+                evictSearchFirstPage = isPublic,
+                evictImpactedTagPages = isPublic,
+                evictTagsPublic = isPublic,
+                evictDetail = isPublic,
+                evictReason = "write-idempotent",
                 recommendationAction = recommendationActionFor(isPublic),
             ),
         )
@@ -292,23 +288,20 @@ class PostApplicationService(
         val titleChanged = previousTitle != post.title
         val tagChanged = previousTags != afterTags
         val affectsPublicRead = wasPublic || isPublic
-        clearReadCaches(
-            postId = post.id,
-            beforeTags = previousTags,
-            afterTags = afterTags,
-            evictHotReadPages = affectsPublicRead,
-            evictSearchFirstPage = affectsPublicRead && (listingVisibilityChanged || titleChanged || contentChanged || tagChanged),
-            evictImpactedTagPages = affectsPublicRead && (tagChanged || listingVisibilityChanged),
-            evictTagsPublic = affectsPublicRead && (tagChanged || listingVisibilityChanged),
-            evictDetail = affectsPublicRead && (listingVisibilityChanged || titleChanged || contentChanged),
-            evictReason = "modify",
-        )
         enqueuePostWriteSideEffect(
             PostWriteSideEffectCommand(
                 postId = post.id,
                 previousContent = previousContent,
                 currentContent = post.content,
                 deletedContent = null,
+                beforeTags = previousTags,
+                afterTags = afterTags,
+                evictHotReadPages = affectsPublicRead,
+                evictSearchFirstPage = affectsPublicRead && (listingVisibilityChanged || titleChanged || contentChanged || tagChanged),
+                evictImpactedTagPages = affectsPublicRead && (tagChanged || listingVisibilityChanged),
+                evictTagsPublic = affectsPublicRead && (tagChanged || listingVisibilityChanged),
+                evictDetail = affectsPublicRead && (listingVisibilityChanged || titleChanged || contentChanged),
+                evictReason = "modify",
                 recommendationAction = recommendationActionFor(isPublic),
             ),
         )
@@ -435,23 +428,20 @@ class PostApplicationService(
             }
         }
 
-        clearReadCaches(
-            postId = post.id,
-            beforeTags = beforeTags,
-            afterTags = emptyList(),
-            evictHotReadPages = wasPublic,
-            evictSearchFirstPage = wasPublic,
-            evictImpactedTagPages = wasPublic,
-            evictTagsPublic = wasPublic,
-            evictDetail = wasPublic,
-            evictReason = "soft-delete",
-        )
         enqueuePostWriteSideEffect(
             PostWriteSideEffectCommand(
                 postId = post.id,
                 previousContent = null,
                 currentContent = null,
                 deletedContent = deletedPostContent,
+                beforeTags = beforeTags,
+                afterTags = emptyList(),
+                evictHotReadPages = wasPublic,
+                evictSearchFirstPage = wasPublic,
+                evictImpactedTagPages = wasPublic,
+                evictTagsPublic = wasPublic,
+                evictDetail = wasPublic,
+                evictReason = "soft-delete",
                 recommendationAction = PostRecommendationSideEffect.EVICT,
             ),
         )
@@ -1367,6 +1357,9 @@ class PostApplicationService(
             return
         }
 
+        if (command.evictTagsPublic) {
+            publicTagCountsCache = null
+        }
         TransactionSynchronizationManager.registerSynchronization(
             object : TransactionSynchronization {
                 override fun afterCommit() {
@@ -1377,6 +1370,18 @@ class PostApplicationService(
     }
 
     private fun handlePostWriteSideEffect(command: PostWriteSideEffectCommand) {
+        clearReadCaches(
+            postId = command.postId,
+            beforeTags = command.beforeTags,
+            afterTags = command.afterTags,
+            evictHotReadPages = command.evictHotReadPages,
+            evictSearchFirstPage = command.evictSearchFirstPage,
+            evictImpactedTagPages = command.evictImpactedTagPages,
+            evictTagsPublic = command.evictTagsPublic,
+            evictDetail = command.evictDetail,
+            evictReason = command.evictReason,
+        )
+
         command.currentContent?.let { currentContent ->
             runAfterCommitSideEffectInNewTransaction(
                 postId = command.postId,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -51,9 +51,12 @@ import org.springframework.cache.CacheManager
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionSynchronization
 import org.springframework.transaction.support.TransactionSynchronizationManager
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -76,6 +79,7 @@ class PostApplicationService(
     private val eventPublisher: EventPublisher,
     private val uploadedFileRetentionService: UploadedFileRetentionService,
     private val cacheManager: CacheManager,
+    private val transactionManager: PlatformTransactionManager,
     private val meterRegistry: MeterRegistry? = null,
     private val postRecommendRankingService: PostRecommendRankingService,
     private val postRecommendFeatureStoreService: PostRecommendFeatureStoreService,
@@ -99,6 +103,10 @@ class PostApplicationService(
     private val hotPageSizes = listOf(30, 24, 16)
     private val hotSorts = listOf(PostSearchSortType1.CREATED_AT)
     private val maxTagCacheEvict = 12
+    private val afterCommitSideEffectTransactionTemplate =
+        TransactionTemplate(transactionManager).apply {
+            propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
+        }
 
     fun count(): Long = postRepository.count()
 
@@ -150,14 +158,6 @@ class PostApplicationService(
                     previousContent = null,
                     currentContent = created.content,
                     deletedContent = null,
-                    beforeTags = emptyList(),
-                    afterTags = createdTags,
-                    evictHotReadPages = isPublic,
-                    evictSearchFirstPage = isPublic,
-                    evictImpactedTagPages = isPublic,
-                    evictTagsPublic = isPublic,
-                    evictDetail = isPublic,
-                    evictReason = "write",
                     recommendationAction = recommendationActionFor(isPublic),
                 ),
             )
@@ -213,14 +213,6 @@ class PostApplicationService(
                 previousContent = null,
                 currentContent = createdPost.content,
                 deletedContent = null,
-                beforeTags = emptyList(),
-                afterTags = createdTags,
-                evictHotReadPages = isPublic,
-                evictSearchFirstPage = isPublic,
-                evictImpactedTagPages = isPublic,
-                evictTagsPublic = isPublic,
-                evictDetail = isPublic,
-                evictReason = "write-idempotent",
                 recommendationAction = recommendationActionFor(isPublic),
             ),
         )
@@ -317,14 +309,6 @@ class PostApplicationService(
                 previousContent = previousContent,
                 currentContent = post.content,
                 deletedContent = null,
-                beforeTags = previousTags,
-                afterTags = afterTags,
-                evictHotReadPages = affectsPublicRead,
-                evictSearchFirstPage = affectsPublicRead && (listingVisibilityChanged || titleChanged || contentChanged || tagChanged),
-                evictImpactedTagPages = affectsPublicRead && (tagChanged || listingVisibilityChanged),
-                evictTagsPublic = affectsPublicRead && (tagChanged || listingVisibilityChanged),
-                evictDetail = affectsPublicRead && (listingVisibilityChanged || titleChanged || contentChanged),
-                evictReason = "modify",
                 recommendationAction = recommendationActionFor(isPublic),
             ),
         )
@@ -468,14 +452,6 @@ class PostApplicationService(
                 previousContent = null,
                 currentContent = null,
                 deletedContent = deletedPostContent,
-                beforeTags = beforeTags,
-                afterTags = emptyList(),
-                evictHotReadPages = wasPublic,
-                evictSearchFirstPage = wasPublic,
-                evictImpactedTagPages = wasPublic,
-                evictTagsPublic = wasPublic,
-                evictDetail = wasPublic,
-                evictReason = "soft-delete",
                 recommendationAction = PostRecommendationSideEffect.EVICT,
             ),
         )
@@ -1402,36 +1378,47 @@ class PostApplicationService(
 
     private fun handlePostWriteSideEffect(command: PostWriteSideEffectCommand) {
         command.currentContent?.let { currentContent ->
-            runCatching {
+            runAfterCommitSideEffectInNewTransaction(
+                postId = command.postId,
+                failureMessage = "Failed to sync post attachments after commit",
+            ) {
                 uploadedFileRetentionService.syncPostContent(command.postId, command.previousContent, currentContent)
-            }.onFailure { exception ->
-                logger.warn("Failed to sync post attachments after commit: postId={}", command.postId, exception)
             }
         }
 
         command.deletedContent?.let { deletedContent ->
-            runCatching {
+            runAfterCommitSideEffectInNewTransaction(
+                postId = command.postId,
+                failureMessage = "Failed to schedule cleanup for deleted post after commit",
+            ) {
                 uploadedFileRetentionService.scheduleDeletedPostAttachments(deletedContent)
-            }.onFailure { exception ->
-                logger.warn("Failed to schedule cleanup for deleted post after commit: postId={}", command.postId, exception)
             }
         }
 
-        clearReadCaches(
-            postId = command.postId,
-            beforeTags = command.beforeTags,
-            afterTags = command.afterTags,
-            evictHotReadPages = command.evictHotReadPages,
-            evictSearchFirstPage = command.evictSearchFirstPage,
-            evictImpactedTagPages = command.evictImpactedTagPages,
-            evictTagsPublic = command.evictTagsPublic,
-            evictDetail = command.evictDetail,
-            evictReason = command.evictReason,
-        )
-
         when (command.recommendationAction) {
-            PostRecommendationSideEffect.REFRESH -> refreshRecommendFeatureStoreAfterCommit(command.postId)
+            PostRecommendationSideEffect.REFRESH ->
+                runAfterCommitSideEffectInNewTransaction(
+                    postId = command.postId,
+                    failureMessage = "Failed to refresh recommend feature store after commit",
+                ) {
+                    refreshRecommendFeatureStoreAfterCommit(command.postId)
+                }
+
             PostRecommendationSideEffect.EVICT -> postRecommendFeatureStoreService.evict(command.postId)
+        }
+    }
+
+    private fun runAfterCommitSideEffectInNewTransaction(
+        postId: Long,
+        failureMessage: String,
+        block: () -> Unit,
+    ) {
+        runCatching {
+            afterCommitSideEffectTransactionTemplate.executeWithoutResult {
+                block()
+            }
+        }.onFailure { exception ->
+            logger.warn("{}: postId={}", failureMessage, postId, exception)
         }
     }
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -52,6 +52,8 @@ import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -142,11 +144,23 @@ class PostApplicationService(
                 evictDetail = isPublic,
                 evictReason = "write",
             )
-            if (isPublic) {
-                postRecommendFeatureStoreService.refresh(created)
-            } else {
-                postRecommendFeatureStoreService.evict(created.id)
-            }
+            enqueuePostWriteSideEffect(
+                PostWriteSideEffectCommand(
+                    postId = created.id,
+                    previousContent = null,
+                    currentContent = created.content,
+                    deletedContent = null,
+                    beforeTags = emptyList(),
+                    afterTags = createdTags,
+                    evictHotReadPages = isPublic,
+                    evictSearchFirstPage = isPublic,
+                    evictImpactedTagPages = isPublic,
+                    evictTagsPublic = isPublic,
+                    evictDetail = isPublic,
+                    evictReason = "write",
+                    recommendationAction = recommendationActionFor(isPublic),
+                ),
+            )
             return created
         }
 
@@ -193,11 +207,23 @@ class PostApplicationService(
             evictDetail = isPublic,
             evictReason = "write-idempotent",
         )
-        if (isPublic) {
-            postRecommendFeatureStoreService.refresh(createdPost)
-        } else {
-            postRecommendFeatureStoreService.evict(createdPost.id)
-        }
+        enqueuePostWriteSideEffect(
+            PostWriteSideEffectCommand(
+                postId = createdPost.id,
+                previousContent = null,
+                currentContent = createdPost.content,
+                deletedContent = null,
+                beforeTags = emptyList(),
+                afterTags = createdTags,
+                evictHotReadPages = isPublic,
+                evictSearchFirstPage = isPublic,
+                evictImpactedTagPages = isPublic,
+                evictTagsPublic = isPublic,
+                evictDetail = isPublic,
+                evictReason = "write-idempotent",
+                recommendationAction = recommendationActionFor(isPublic),
+            ),
+        )
 
         return createdPost
     }
@@ -267,11 +293,6 @@ class PostApplicationService(
         } catch (exception: ObjectOptimisticLockingFailureException) {
             throw AppException("409-1", "다른 세션에서 이미 수정되었습니다. 최신 글을 다시 불러온 뒤 수정해주세요.")
         }
-        runCatching {
-            uploadedFileRetentionService.syncPostContent(post.id, previousContent, post.content)
-        }.onFailure { exception ->
-            logger.warn("Failed to sync post attachments on modify: postId={}", post.id, exception)
-        }
         val afterTags = extractNormalizedTags(post.content)
         val isPublic = isPubliclyListed(post)
         val listingVisibilityChanged = wasPublic != isPublic
@@ -290,11 +311,23 @@ class PostApplicationService(
             evictDetail = affectsPublicRead && (listingVisibilityChanged || titleChanged || contentChanged),
             evictReason = "modify",
         )
-        if (isPublic) {
-            postRecommendFeatureStoreService.refresh(post)
-        } else {
-            postRecommendFeatureStoreService.evict(post.id)
-        }
+        enqueuePostWriteSideEffect(
+            PostWriteSideEffectCommand(
+                postId = post.id,
+                previousContent = previousContent,
+                currentContent = post.content,
+                deletedContent = null,
+                beforeTags = previousTags,
+                afterTags = afterTags,
+                evictHotReadPages = affectsPublicRead,
+                evictSearchFirstPage = affectsPublicRead && (listingVisibilityChanged || titleChanged || contentChanged || tagChanged),
+                evictImpactedTagPages = affectsPublicRead && (tagChanged || listingVisibilityChanged),
+                evictTagsPublic = affectsPublicRead && (tagChanged || listingVisibilityChanged),
+                evictDetail = affectsPublicRead && (listingVisibilityChanged || titleChanged || contentChanged),
+                evictReason = "modify",
+                recommendationAction = recommendationActionFor(isPublic),
+            ),
+        )
 
         runCatching {
             eventPublisher.publish(
@@ -337,11 +370,6 @@ class PostApplicationService(
             )
         val savedPost = postRepository.saveAndFlush(post)
         syncMetaTagIndexAttr(savedPost)
-        runCatching {
-            uploadedFileRetentionService.syncPostContent(savedPost.id, null, savedPost.content)
-        }.onFailure { exception ->
-            logger.warn("Failed to sync post attachments on write: postId={}", savedPost.id, exception)
-        }
         incrementMemberPostsCount(persistenceAuthor)
         val afterTags = extractNormalizedTags(savedPost.content)
 
@@ -411,19 +439,6 @@ class PostApplicationService(
         if (wasTempDraft) {
             updateTempDraftMarker(post.author, null)
         }
-        clearReadCaches(
-            postId = post.id,
-            beforeTags = beforeTags,
-            afterTags = emptyList(),
-            evictHotReadPages = wasPublic,
-            evictSearchFirstPage = wasPublic,
-            evictImpactedTagPages = wasPublic,
-            evictTagsPublic = wasPublic,
-            evictDetail = wasPublic,
-            evictReason = "soft-delete",
-        )
-        postRecommendFeatureStoreService.evict(post.id)
-
         // 카운터 보정 실패는 삭제 실패로 전파하지 않는다. 실패 시 실제 개수 재동기화를 시도한다.
         runCatching {
             decrementMemberPostsCount(Member(post.author.id))
@@ -436,12 +451,34 @@ class PostApplicationService(
             }
         }
 
-        // 삭제 자체는 완료시키고, 보조 처리(파일 정리/이벤트)는 실패해도 트랜잭션을 깨지 않도록 분리한다.
-        runCatching {
-            uploadedFileRetentionService.scheduleDeletedPostAttachments(deletedPostContent)
-        }.onFailure { exception ->
-            logger.warn("Failed to schedule cleanup for deleted post id={}", post.id, exception)
-        }
+        clearReadCaches(
+            postId = post.id,
+            beforeTags = beforeTags,
+            afterTags = emptyList(),
+            evictHotReadPages = wasPublic,
+            evictSearchFirstPage = wasPublic,
+            evictImpactedTagPages = wasPublic,
+            evictTagsPublic = wasPublic,
+            evictDetail = wasPublic,
+            evictReason = "soft-delete",
+        )
+        enqueuePostWriteSideEffect(
+            PostWriteSideEffectCommand(
+                postId = post.id,
+                previousContent = null,
+                currentContent = null,
+                deletedContent = deletedPostContent,
+                beforeTags = beforeTags,
+                afterTags = emptyList(),
+                evictHotReadPages = wasPublic,
+                evictSearchFirstPage = wasPublic,
+                evictImpactedTagPages = wasPublic,
+                evictTagsPublic = wasPublic,
+                evictDetail = wasPublic,
+                evictReason = "soft-delete",
+                recommendationAction = PostRecommendationSideEffect.EVICT,
+            ),
+        )
 
         runCatching {
             val postDto = PostDto(post)
@@ -1344,6 +1381,69 @@ class PostApplicationService(
 
     // SecurityContext actor는 MemberProxy일 수 있어 영속 경계에서는 실제 엔티티를 사용한다.
     private fun toPersistenceMember(member: Member): Member = if (member is MemberProxy) member.persistenceMember else member
+
+    private fun recommendationActionFor(isPublic: Boolean): PostRecommendationSideEffect =
+        if (isPublic) PostRecommendationSideEffect.REFRESH else PostRecommendationSideEffect.EVICT
+
+    private fun enqueuePostWriteSideEffect(command: PostWriteSideEffectCommand) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            handlePostWriteSideEffect(command)
+            return
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() {
+                    handlePostWriteSideEffect(command)
+                }
+            },
+        )
+    }
+
+    private fun handlePostWriteSideEffect(command: PostWriteSideEffectCommand) {
+        command.currentContent?.let { currentContent ->
+            runCatching {
+                uploadedFileRetentionService.syncPostContent(command.postId, command.previousContent, currentContent)
+            }.onFailure { exception ->
+                logger.warn("Failed to sync post attachments after commit: postId={}", command.postId, exception)
+            }
+        }
+
+        command.deletedContent?.let { deletedContent ->
+            runCatching {
+                uploadedFileRetentionService.scheduleDeletedPostAttachments(deletedContent)
+            }.onFailure { exception ->
+                logger.warn("Failed to schedule cleanup for deleted post after commit: postId={}", command.postId, exception)
+            }
+        }
+
+        clearReadCaches(
+            postId = command.postId,
+            beforeTags = command.beforeTags,
+            afterTags = command.afterTags,
+            evictHotReadPages = command.evictHotReadPages,
+            evictSearchFirstPage = command.evictSearchFirstPage,
+            evictImpactedTagPages = command.evictImpactedTagPages,
+            evictTagsPublic = command.evictTagsPublic,
+            evictDetail = command.evictDetail,
+            evictReason = command.evictReason,
+        )
+
+        when (command.recommendationAction) {
+            PostRecommendationSideEffect.REFRESH -> refreshRecommendFeatureStoreAfterCommit(command.postId)
+            PostRecommendationSideEffect.EVICT -> postRecommendFeatureStoreService.evict(command.postId)
+        }
+    }
+
+    private fun refreshRecommendFeatureStoreAfterCommit(postId: Long) {
+        val post =
+            postRepository.findById(postId).getOrNull()
+                ?: run {
+                    logger.warn("recommend_feature_store_refresh_skipped_missing_post postId={}", postId)
+                    return
+                }
+        postRecommendFeatureStoreService.refresh(post)
+    }
 
     private fun clearReadCaches(
         postId: Long? = null,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -1429,6 +1429,7 @@ class PostApplicationService(
                     logger.warn("recommend_feature_store_refresh_skipped_missing_post postId={}", postId)
                     return
                 }
+        hydratePostAttrs(post)
         postRecommendFeatureStoreService.refresh(post)
     }
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -159,6 +159,7 @@ class PostApplicationService(
                     recommendationAction = recommendationActionFor(isPublic),
                 ),
             )
+            publishPostWrittenEvent(author, created, createdTags)
             return created
         }
 
@@ -212,6 +213,7 @@ class PostApplicationService(
                 recommendationAction = recommendationActionFor(isPublic),
             ),
         )
+        publishPostWrittenEvent(author, createdPost, createdTags)
 
         return createdPost
     }
@@ -348,23 +350,27 @@ class PostApplicationService(
         val savedPost = postRepository.saveAndFlush(post)
         syncMetaTagIndexAttr(savedPost)
         incrementMemberPostsCount(persistenceAuthor)
-        val afterTags = extractNormalizedTags(savedPost.content)
+        return savedPost
+    }
 
+    private fun publishPostWrittenEvent(
+        author: Member,
+        post: Post,
+        afterTags: List<String>,
+    ) {
         runCatching {
             eventPublisher.publish(
                 PostWrittenEvent(
                     UUID.randomUUID(),
-                    PostDto(savedPost),
+                    PostDto(post),
                     MemberDto(author),
                     emptyList(),
                     afterTags,
                 ),
             )
         }.onFailure { exception ->
-            logger.warn("Failed to publish PostWrittenEvent: postId={}", savedPost.id, exception)
+            logger.warn("Failed to publish PostWrittenEvent: postId={}", post.id, exception)
         }
-
-        return savedPost
     }
 
     /**
@@ -1370,17 +1376,21 @@ class PostApplicationService(
     }
 
     private fun handlePostWriteSideEffect(command: PostWriteSideEffectCommand) {
-        clearReadCaches(
-            postId = command.postId,
-            beforeTags = command.beforeTags,
-            afterTags = command.afterTags,
-            evictHotReadPages = command.evictHotReadPages,
-            evictSearchFirstPage = command.evictSearchFirstPage,
-            evictImpactedTagPages = command.evictImpactedTagPages,
-            evictTagsPublic = command.evictTagsPublic,
-            evictDetail = command.evictDetail,
-            evictReason = command.evictReason,
-        )
+        runCatching {
+            clearReadCaches(
+                postId = command.postId,
+                beforeTags = command.beforeTags,
+                afterTags = command.afterTags,
+                evictHotReadPages = command.evictHotReadPages,
+                evictSearchFirstPage = command.evictSearchFirstPage,
+                evictImpactedTagPages = command.evictImpactedTagPages,
+                evictTagsPublic = command.evictTagsPublic,
+                evictDetail = command.evictDetail,
+                evictReason = command.evictReason,
+            )
+        }.onFailure { exception ->
+            logger.warn("Failed to evict post read caches after commit: postId={}", command.postId, exception)
+        }
 
         command.currentContent?.let { currentContent ->
             runAfterCommitSideEffectInNewTransaction(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectCommand.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectCommand.kt
@@ -1,0 +1,22 @@
+package com.back.boundedContexts.post.application.service
+
+internal data class PostWriteSideEffectCommand(
+    val postId: Long,
+    val previousContent: String?,
+    val currentContent: String?,
+    val deletedContent: String?,
+    val beforeTags: List<String>,
+    val afterTags: List<String>,
+    val evictHotReadPages: Boolean,
+    val evictSearchFirstPage: Boolean,
+    val evictImpactedTagPages: Boolean,
+    val evictTagsPublic: Boolean,
+    val evictDetail: Boolean,
+    val evictReason: String,
+    val recommendationAction: PostRecommendationSideEffect,
+)
+
+internal enum class PostRecommendationSideEffect {
+    REFRESH,
+    EVICT,
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectCommand.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectCommand.kt
@@ -5,14 +5,6 @@ internal data class PostWriteSideEffectCommand(
     val previousContent: String?,
     val currentContent: String?,
     val deletedContent: String?,
-    val beforeTags: List<String>,
-    val afterTags: List<String>,
-    val evictHotReadPages: Boolean,
-    val evictSearchFirstPage: Boolean,
-    val evictImpactedTagPages: Boolean,
-    val evictTagsPublic: Boolean,
-    val evictDetail: Boolean,
-    val evictReason: String,
     val recommendationAction: PostRecommendationSideEffect,
 )
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectCommand.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectCommand.kt
@@ -5,6 +5,14 @@ internal data class PostWriteSideEffectCommand(
     val previousContent: String?,
     val currentContent: String?,
     val deletedContent: String?,
+    val beforeTags: List<String>,
+    val afterTags: List<String>,
+    val evictHotReadPages: Boolean,
+    val evictSearchFirstPage: Boolean,
+    val evictImpactedTagPages: Boolean,
+    val evictTagsPublic: Boolean,
+    val evictDetail: Boolean,
+    val evictReason: String,
     val recommendationAction: PostRecommendationSideEffect,
 )
 

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.clearInvocations
 import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.mockingDetails
 import org.mockito.Mockito.verifyNoInteractions
 import org.springframework.beans.factory.annotation.Autowired
@@ -85,6 +86,32 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
         assertThat(invokedMethodNames(uploadedFileRetentionService)).contains("syncPostContent")
         assertThat(invokedMethodNames(postRecommendFeatureStoreService)).contains("refresh")
         assertThat(sideEffectTransactions).containsOnly(true)
+    }
+
+    @Test
+    @DisplayName("커밋 후 캐시 축출 실패는 첨부파일·추천 후속 작업을 막지 않는다")
+    fun writeCommitContinuesSideEffectsWhenCacheEvictionFails() {
+        // given
+        clearSideEffectMocks()
+        val admin = actorApplicationService.findByEmail("admin@test.com")!!
+        doThrow(RuntimeException("cache backend down"))
+            .`when`(cacheManager)
+            .getCache(PostQueryCacheNames.FEED)
+
+        // when
+        transactionTemplate.executeWithoutResult {
+            postApplicationService.write(
+                author = admin,
+                title = "cache failure after commit guard",
+                content = "cache failure content",
+                published = true,
+                listed = true,
+            )
+        }
+
+        // then
+        assertThat(invokedMethodNames(uploadedFileRetentionService)).contains("syncPostContent")
+        assertThat(invokedMethodNames(postRecommendFeatureStoreService)).contains("refresh")
     }
 
     @Test

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
@@ -1,0 +1,84 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.application.service.ActorApplicationService
+import com.back.support.BasePostApplicationServiceAfterCommitIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.clearInvocations
+import org.mockito.Mockito.mockingDetails
+import org.mockito.Mockito.verifyNoInteractions
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.support.TransactionTemplate
+
+@DisplayName("PostApplicationService 후속 작업 AFTER_COMMIT 테스트")
+class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCommitIntegrationTest() {
+    @Autowired
+    private lateinit var actorApplicationService: ActorApplicationService
+
+    @Autowired
+    private lateinit var postApplicationService: PostApplicationService
+
+    @Autowired
+    private lateinit var transactionTemplate: TransactionTemplate
+
+    @Test
+    @DisplayName("글 작성 트랜잭션이 rollback되면 첨부파일·추천 후속 작업을 실행하지 않는다")
+    fun writeRollbackDoesNotRunSideEffects() {
+        // given
+        clearSideEffectMocks()
+        val admin = actorApplicationService.findByEmail("admin@test.com")!!
+
+        // when
+        transactionTemplate.executeWithoutResult { status ->
+            postApplicationService.write(
+                author = admin,
+                title = "rollback after commit guard",
+                content = "rollback content",
+                published = true,
+                listed = true,
+            )
+            status.setRollbackOnly()
+        }
+
+        // then
+        verifyNoInteractions(
+            uploadedFileRetentionService,
+            postRecommendFeatureStoreService,
+        )
+    }
+
+    @Test
+    @DisplayName("글 작성 트랜잭션이 commit되면 첨부파일·추천 후속 작업을 실행한다")
+    fun writeCommitRunsSideEffects() {
+        // given
+        clearSideEffectMocks()
+        val admin = actorApplicationService.findByEmail("admin@test.com")!!
+
+        // when
+        transactionTemplate.executeWithoutResult {
+            postApplicationService.write(
+                author = admin,
+                title = "commit after commit guard",
+                content = "commit content",
+                published = true,
+                listed = true,
+            )
+        }
+
+        // then
+        assertThat(invokedMethodNames(uploadedFileRetentionService)).contains("syncPostContent")
+        assertThat(invokedMethodNames(postRecommendFeatureStoreService)).contains("refresh")
+    }
+
+    private fun clearSideEffectMocks() {
+        clearInvocations(
+            uploadedFileRetentionService,
+            postRecommendFeatureStoreService,
+            eventPublisher,
+            cacheManager,
+        )
+    }
+
+    private fun invokedMethodNames(mock: Any): List<String> = mockingDetails(mock).invocations.map { it.method.name }
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
@@ -1,6 +1,12 @@
 package com.back.boundedContexts.post.application.service
 
 import com.back.boundedContexts.member.application.service.ActorApplicationService
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
+import com.back.boundedContexts.post.domain.Post
+import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
+import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
+import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
 import com.back.support.BasePostApplicationServiceAfterCommitIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -21,6 +27,9 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
 
     @Autowired
     private lateinit var postApplicationService: PostApplicationService
+
+    @Autowired
+    private lateinit var postAttrRepository: PostAttrRepositoryPort
 
     @Autowired
     private lateinit var transactionTemplate: TransactionTemplate
@@ -77,6 +86,55 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
         assertThat(sideEffectTransactions).containsOnly(true)
     }
 
+    @Test
+    @DisplayName("글 수정 후 추천 feature store 갱신은 기존 hit/like/comment 카운터를 유지한다")
+    fun modifyCommitRefreshesRecommendFeatureStoreWithHydratedCounters() {
+        // given
+        clearSideEffectMocks()
+        val admin = actorApplicationService.findByEmail("admin@test.com")!!
+        val post =
+            transactionTemplate.execute {
+                postApplicationService.write(
+                    author = admin,
+                    title = "recommend counter source",
+                    content = "recommend counter content",
+                    published = true,
+                    listed = true,
+                )
+            }!!
+        transactionTemplate.executeWithoutResult {
+            postAttrRepository.incrementIntValue(post, HIT_COUNT, 11)
+            postAttrRepository.incrementIntValue(post, LIKES_COUNT, 7)
+            postAttrRepository.incrementIntValue(post, COMMENTS_COUNT, 3)
+        }
+        val refreshedCounters = mutableListOf<PostCounterSnapshot>()
+        clearSideEffectMocks()
+        recordRefreshedCounters(refreshedCounters)
+
+        // when
+        transactionTemplate.executeWithoutResult {
+            val latestPost = postApplicationService.findById(post.id)!!
+            postApplicationService.modify(
+                actor = admin,
+                post = latestPost,
+                title = "recommend counter source modified",
+                content = "recommend counter content modified",
+                published = true,
+                listed = true,
+                expectedVersion = latestPost.version ?: 0L,
+            )
+        }
+
+        // then
+        assertThat(refreshedCounters).contains(
+            PostCounterSnapshot(
+                hitCount = 11,
+                likesCount = 7,
+                commentsCount = 3,
+            ),
+        )
+    }
+
     private fun clearSideEffectMocks() {
         clearInvocations(
             uploadedFileRetentionService,
@@ -98,4 +156,31 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
             ArgumentMatchers.anyString(),
         )
     }
+
+    private fun recordRefreshedCounters(refreshedCounters: MutableList<PostCounterSnapshot>) {
+        doAnswer { invocation ->
+            val post = invocation.getArgument<Post>(0)
+            refreshedCounters +=
+                PostCounterSnapshot(
+                    hitCount = post.hitCount,
+                    likesCount = post.likesCount,
+                    commentsCount = post.commentsCount,
+                )
+            null
+        }.`when`(postRecommendFeatureStoreService).refresh(anyPost())
+    }
+
+    private fun anyPost(): Post =
+        ArgumentMatchers.any(Post::class.java)
+            ?: Post(
+                author = Member(id = 0, username = "dummy", nickname = "dummy", apiKey = "dummy"),
+                title = "dummy",
+                content = "dummy",
+            )
+
+    private data class PostCounterSnapshot(
+        val hitCount: Int,
+        val likesCount: Int,
+        val commentsCount: Int,
+    )
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
@@ -57,6 +57,7 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
         verifyNoInteractions(
             uploadedFileRetentionService,
             postRecommendFeatureStoreService,
+            cacheManager,
         )
     }
 

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
@@ -5,10 +5,13 @@ import com.back.support.BasePostApplicationServiceAfterCommitIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.clearInvocations
+import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.mockingDetails
 import org.mockito.Mockito.verifyNoInteractions
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.transaction.support.TransactionTemplate
 
 @DisplayName("PostApplicationService 후속 작업 AFTER_COMMIT 테스트")
@@ -54,6 +57,8 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
         // given
         clearSideEffectMocks()
         val admin = actorApplicationService.findByEmail("admin@test.com")!!
+        val sideEffectTransactions = mutableListOf<Boolean>()
+        recordActiveTransactionDuringSideEffects(sideEffectTransactions)
 
         // when
         transactionTemplate.executeWithoutResult {
@@ -69,6 +74,7 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
         // then
         assertThat(invokedMethodNames(uploadedFileRetentionService)).contains("syncPostContent")
         assertThat(invokedMethodNames(postRecommendFeatureStoreService)).contains("refresh")
+        assertThat(sideEffectTransactions).containsOnly(true)
     }
 
     private fun clearSideEffectMocks() {
@@ -81,4 +87,15 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
     }
 
     private fun invokedMethodNames(mock: Any): List<String> = mockingDetails(mock).invocations.map { it.method.name }
+
+    private fun recordActiveTransactionDuringSideEffects(sideEffectTransactions: MutableList<Boolean>) {
+        doAnswer {
+            sideEffectTransactions += TransactionSynchronizationManager.isActualTransactionActive()
+            null
+        }.`when`(uploadedFileRetentionService).syncPostContent(
+            ArgumentMatchers.anyLong(),
+            ArgumentMatchers.nullable(String::class.java),
+            ArgumentMatchers.anyString(),
+        )
+    }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
@@ -19,6 +19,11 @@ import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
 import org.mockito.Mockito.mock
 import org.springframework.cache.CacheManager
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.TransactionException
+import org.springframework.transaction.TransactionStatus
+import org.springframework.transaction.support.SimpleTransactionStatus
 import java.time.Instant
 
 @org.junit.jupiter.api.DisplayName("PostApplicationServiceDeleteResilience 테스트")
@@ -35,6 +40,7 @@ class PostApplicationServiceDeleteResilienceTest {
     private val eventPublisher: EventPublisher = mock(EventPublisher::class.java)
     private val uploadedFileRetentionService: UploadedFileRetentionService = mock(UploadedFileRetentionService::class.java)
     private val cacheManager: CacheManager = mock(CacheManager::class.java)
+    private val transactionManager: PlatformTransactionManager = NoopTransactionManager()
     private val postRecommendRankingService: PostRecommendRankingService = mock(PostRecommendRankingService::class.java)
     private val postRecommendFeatureStoreService: PostRecommendFeatureStoreService =
         mock(PostRecommendFeatureStoreService::class.java)
@@ -54,6 +60,7 @@ class PostApplicationServiceDeleteResilienceTest {
             eventPublisher = eventPublisher,
             uploadedFileRetentionService = uploadedFileRetentionService,
             cacheManager = cacheManager,
+            transactionManager = transactionManager,
             postRecommendRankingService = postRecommendRankingService,
             postRecommendFeatureStoreService = postRecommendFeatureStoreService,
             postKeywordSearchPipelineService = postKeywordSearchPipelineService,
@@ -110,5 +117,15 @@ class PostApplicationServiceDeleteResilienceTest {
         then(postRepository).should().softDeleteById(post.id)
         then(memberAttrRepository).should().incrementIntValue(author, POSTS_COUNT, -1)
         then(postRepository).should().countByAuthor(author)
+    }
+
+    private class NoopTransactionManager : PlatformTransactionManager {
+        override fun getTransaction(definition: TransactionDefinition?): TransactionStatus = SimpleTransactionStatus()
+
+        @Throws(TransactionException::class)
+        override fun commit(status: TransactionStatus) = Unit
+
+        @Throws(TransactionException::class)
+        override fun rollback(status: TransactionStatus) = Unit
     }
 }

--- a/back/src/test/kotlin/com/back/support/BasePostApplicationServiceAfterCommitIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BasePostApplicationServiceAfterCommitIntegrationTest.kt
@@ -1,0 +1,21 @@
+package com.back.support
+
+import com.back.boundedContexts.post.application.service.PostRecommendFeatureStoreService
+import com.back.global.event.application.EventPublisher
+import com.back.global.storage.application.UploadedFileRetentionService
+import org.springframework.cache.CacheManager
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+abstract class BasePostApplicationServiceAfterCommitIntegrationTest : BaseSeededIntegrationTest() {
+    @MockitoBean
+    protected lateinit var uploadedFileRetentionService: UploadedFileRetentionService
+
+    @MockitoBean
+    protected lateinit var postRecommendFeatureStoreService: PostRecommendFeatureStoreService
+
+    @MockitoBean
+    protected lateinit var eventPublisher: EventPublisher
+
+    @MockitoBean
+    protected lateinit var cacheManager: CacheManager
+}


### PR DESCRIPTION
## 관련 이슈

close #841

## 작업 배경

- PostApplicationService write/modify/delete 경로에서 첨부파일 retention과 추천 feature store 갱신이 DB commit 전에 실행될 수 있었다.
- rollback 시 DB 상태와 외부 후속 상태가 어긋나는 일을 막기 위해 commit 성공 이후 callback으로 이동했다.
- read cache eviction도 commit 전 concurrent refill로 stale cache가 다시 채워질 수 있어, 동일 eviction plan을 afterCommit에서 한 번 실행하도록 정리했다.

## 작업 내용

- write/modify/delete 후속 작업을 `PostWriteSideEffectCommand`로 모아 `TransactionSynchronization.afterCommit`에서 처리하도록 분리했다.
- afterCommit handler에서 read cache eviction plan을 먼저 실행하고, cache eviction 실패는 격리해 첨부파일 sync와 추천 feature refresh가 계속 실행되도록 했다.
- 테스트 트랜잭션의 same-JVM tag count 가시성에 필요한 `publicTagCountsCache` local invalidation만 등록 시점에 즉시 수행한다.
- 첨부파일 sync/cleanup과 추천 feature store refresh는 commit 성공 후에만 실행하고, DB write 후속 작업은 각 작업별 `REQUIRES_NEW` 트랜잭션에서 실행하도록 보강했다.
- write 경로의 domain event 발행은 side-effect synchronization 등록 이후로 옮겨 AFTER_COMMIT listener prewarm/revalidate가 cache eviction보다 먼저 실행되지 않도록 했다.
- 추천 feature store refresh 전에는 재조회한 Post의 hit/like/comment counter attr를 hydrate해 기존 engagement 값이 0으로 덮이지 않도록 했다.
- rollback/commit, 새 트랜잭션 실행, 추천 counter 보존, cache eviction 실패 격리 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back test --tests com.back.boundedContexts.post.application.service.PostApplicationServiceAfterCommitTest --tests com.back.boundedContexts.post.application.service.PostApplicationServiceDeleteResilienceTest` 성공
  - `./back/gradlew -p back ktlintCheck` 성공
  - `./back/gradlew -p back test` 성공
  - `./back/gradlew -p back test --rerun-tasks` 성공
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check` 성공
  - `codex review --base origin/main --title "[Refactor] PostApplicationService 후속 작업 AFTER_COMMIT 전환"` 최종 재검토 결과 추가 지적 0건

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `PostApplicationService.enqueuePostWriteSideEffect`의 transaction synchronization 등록 흐름
  - `handlePostWriteSideEffect`의 cache eviction 실패 격리
  - `runAfterCommitSideEffectInNewTransaction`의 작업별 `REQUIRES_NEW` 경계
  - `publishPostWrittenEvent`가 side-effect synchronization 등록 이후 호출되는 순서
  - `refreshRecommendFeatureStoreAfterCommit`의 counter attr hydrate

## Codex CLI Code Review - 변경 요청 및 재검토

- 최초 리뷰 지적사항:
  - afterCommit 내부 DB write는 `REQUIRES_NEW` 트랜잭션에서 실행해야 한다.
  - 추천 feature refresh 전 hit/like/comment counter attr를 hydrate해야 한다.
  - commit 전 cache refill race를 막기 위해 read cache eviction plan을 afterCommit 경로로 보내야 한다.
  - afterCommit cache eviction 실패가 첨부파일 sync와 추천 refresh를 막지 않아야 한다.
  - write 이벤트는 side-effect synchronization 등록 이후 발행해야 한다.
- 영향:
  - rollback 후 외부 후속 상태 불일치, 추천 feature counter 0 덮어쓰기, stale cache/prewarm race 가능성이 있었다.
- 요청:
  - 후속 작업을 commit 성공 이후로 이동하고, 실패 격리와 event listener 등록 순서를 보강한다.
- 반영:
  - `3fa1c7ab`, `7d7ed94c`, `47086df8`, `862bea09`에서 각 지적사항을 반영했다.
- 재검토 결과:
  - Codex CLI 최종 재검토에서 추가 actionable/nitpick 0건.

## 리스크

- afterCommit callback 실패 시 기존처럼 warn 로그를 남기는 best-effort 동작을 유지한다.
- cache backend 장애 시 해당 cache eviction은 누락될 수 있지만, 첨부파일 retention과 추천 feature refresh는 계속 실행된다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
