### PR TITLE
[Refactor] ApiV1PostController 캐시 ETag 응답 조립 분리

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostController.kt
@@ -30,17 +30,12 @@ import jakarta.validation.constraints.Size
 import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.dao.OptimisticLockingFailureException
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.*
-import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
 import java.sql.SQLException
-import java.time.Instant
-import java.util.Locale
 
 /**
  * ApiV1PostController는 웹 계층에서 HTTP 요청/응답을 처리하는 클래스입니다.
@@ -52,6 +47,7 @@ class ApiV1PostController(
     private val postUseCase: PostUseCase,
     private val postHitDedupUseCase: PostHitDedupUseCase,
     private val postPublicReadQueryUseCase: PostPublicReadQueryUseCase,
+    private val postPublicReadResponseFactory: PostPublicReadResponseFactory,
     private val rq: Rq,
 ) {
     private val logger = LoggerFactory.getLogger(ApiV1PostController::class.java)
@@ -60,288 +56,6 @@ class ApiV1PostController(
         val keyword: String,
         val tag: String,
     )
-
-    private fun applyPublicReadCacheHeaders(
-        response: HttpServletResponse,
-        policy: PublicReadCachePolicy,
-        surrogateKeys: Set<String>,
-    ) {
-        val safeMaxAge = policy.maxAgeSeconds.coerceAtLeast(0)
-        val safeSharedMaxAge = policy.sharedMaxAgeSeconds.coerceAtLeast(safeMaxAge)
-        val safeSWR = policy.staleWhileRevalidateSeconds.coerceAtLeast(0)
-        val staleIfError = (safeSharedMaxAge + safeSWR).coerceAtLeast(safeSWR)
-        response.setHeader(
-            "Cache-Control",
-            "public, max-age=$safeMaxAge, s-maxage=$safeSharedMaxAge, stale-while-revalidate=$safeSWR, stale-if-error=$staleIfError",
-        )
-        response.setHeader("X-Cache-Policy", policy.name)
-        applySurrogateKeyHeaders(response, surrogateKeys)
-        appendServerTiming(response, "cache-policy;desc=\"${policy.name}\"")
-    }
-
-    private fun applyPrivateNoStoreHeaders(response: HttpServletResponse) {
-        response.setHeader("Cache-Control", "private, no-store, max-age=0")
-    }
-
-    private fun applySurrogateKeyHeaders(
-        response: HttpServletResponse,
-        surrogateKeys: Set<String>,
-    ) {
-        val normalized =
-            surrogateKeys
-                .asSequence()
-                .map(::normalizeCacheTagToken)
-                .filter { it.isNotBlank() }
-                .distinct()
-                .toList()
-        if (normalized.isEmpty()) return
-        response.setHeader("Surrogate-Key", normalized.joinToString(" "))
-        response.setHeader("Cache-Tag", normalized.joinToString(","))
-    }
-
-    private fun normalizeCacheTagToken(raw: String): String =
-        raw
-            .trim()
-            .lowercase()
-            .replace(Regex("[^a-z0-9:_-]"), "-")
-            .replace(Regex("-+"), "-")
-            .trim('-')
-            .take(MAX_CACHE_TAG_LENGTH)
-
-    private fun appendServerTiming(
-        response: HttpServletResponse,
-        metric: String,
-    ) {
-        val current = response.getHeader("Server-Timing")
-        if (current.isNullOrBlank()) {
-            response.setHeader("Server-Timing", metric)
-            return
-        }
-        response.setHeader("Server-Timing", "$current, $metric")
-    }
-
-    private fun appendOriginTiming(
-        response: HttpServletResponse,
-        startedAtNanos: Long,
-        description: String,
-    ) {
-        val elapsedMs = ((System.nanoTime() - startedAtNanos).coerceAtLeast(0L)).toDouble() / 1_000_000.0
-        val durationToken = String.format(Locale.US, "%.1f", elapsedMs)
-        appendServerTiming(response, "origin;dur=$durationToken;desc=\"$description\"")
-    }
-
-    private fun normalizeEtagToken(raw: String): String = raw.trim().removePrefix("W/").removePrefix("w/")
-
-    private fun toWeakEtag(seed: String): String {
-        val digest =
-            MessageDigest
-                .getInstance("SHA-256")
-                .digest(seed.toByteArray(StandardCharsets.UTF_8))
-                .joinToString("") { each -> "%02x".format(each) }
-                .take(32)
-        return "W/\"$digest\""
-    }
-
-    private fun isNotModified(
-        request: HttpServletRequest,
-        etag: String,
-    ): Boolean {
-        val ifNoneMatch = request.getHeader(HttpHeaders.IF_NONE_MATCH)?.trim().orEmpty()
-        if (ifNoneMatch.isBlank()) return false
-        if (ifNoneMatch == "*") return true
-
-        val expected = normalizeEtagToken(etag)
-        return ifNoneMatch
-            .split(",")
-            .asSequence()
-            .map { normalizeEtagToken(it) }
-            .any { it == expected }
-    }
-
-    private fun <T : Any> respondPublicWithEtag(
-        request: HttpServletRequest,
-        response: HttpServletResponse,
-        cachePolicy: PublicReadCachePolicy,
-        surrogateKeys: Set<String>,
-        etagSeed: String,
-        startedAtNanos: Long,
-        body: T,
-    ): ResponseEntity<T> {
-        applyPublicReadCacheHeaders(
-            response,
-            policy = cachePolicy,
-            surrogateKeys = surrogateKeys,
-        )
-        val etag = toWeakEtag(etagSeed)
-        response.setHeader(HttpHeaders.ETAG, etag)
-        if (isNotModified(request, etag)) {
-            appendServerTiming(response, "cache;desc=\"etag-304\"")
-            appendOriginTiming(response, startedAtNanos, "etag-304")
-            response.status = HttpServletResponse.SC_NOT_MODIFIED
-            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build<T>()
-        }
-        appendOriginTiming(response, startedAtNanos, "etag-200")
-        return ResponseEntity.ok(body)
-    }
-
-    private fun resolveSearchReadCachePolicy(keyword: String): PublicReadCachePolicy {
-        val normalized = keyword.trim()
-        if (normalized.isBlank()) {
-            return SEARCH_DEFAULT_CACHE_POLICY
-        }
-        if (isHighEntropyKeyword(normalized)) {
-            return SEARCH_NO_STORE_CACHE_POLICY
-        }
-        if (normalized.length >= SEARCH_SHORT_TTL_KEYWORD_LENGTH) {
-            return SEARCH_SHORT_CACHE_POLICY
-        }
-        return SEARCH_DEFAULT_CACHE_POLICY
-    }
-
-    private fun isHighEntropyKeyword(keyword: String): Boolean {
-        if (keyword.length >= SEARCH_NO_STORE_KEYWORD_LENGTH) return true
-
-        val tokens = keyword.split(Regex("\\s+")).filter { it.isNotBlank() }
-        if (tokens.size >= SEARCH_NO_STORE_TOKEN_COUNT) return true
-
-        val alphaNumeric = keyword.filter { it.isLetterOrDigit() }
-        if (alphaNumeric.length < SEARCH_HIGH_ENTROPY_MIN_LENGTH) return false
-
-        val uniqueRatio =
-            alphaNumeric
-                .lowercase()
-                .toSet()
-                .size
-                .toDouble() / alphaNumeric.length
-        return uniqueRatio >= SEARCH_HIGH_ENTROPY_UNIQUE_RATIO_THRESHOLD
-    }
-
-    private fun toEpochMillis(instant: Instant): Long = instant.toEpochMilli()
-
-    private fun buildFeedPageEtagSeed(
-        source: String,
-        page: Int,
-        pageSize: Int,
-        sort: PostSearchSortType1,
-        kw: String = "",
-        tag: String = "",
-        data: PageDto<FeedPostDto>,
-    ): String {
-        val itemsToken =
-            data.content.joinToString(separator = "|") {
-                "${it.id}:${toEpochMillis(it.modifiedAt)}:${it.likesCount}:${it.commentsCount}:${it.hitCount}"
-            }
-        return buildString {
-            append(source)
-            append("|page=")
-            append(page)
-            append("|size=")
-            append(pageSize)
-            append("|sort=")
-            append(sort.name)
-            append("|kw=")
-            append(kw.trim())
-            append("|tag=")
-            append(tag.trim())
-            append("|total=")
-            append(data.pageable.totalElements)
-            append("|pages=")
-            append(data.pageable.totalPages)
-            append("|items=")
-            append(itemsToken)
-        }
-    }
-
-    private fun buildCursorFeedEtagSeed(
-        source: String,
-        pageSize: Int,
-        sort: PostSearchSortType1,
-        cursor: String?,
-        tag: String = "",
-        data: CursorFeedPageDto,
-    ): String {
-        val itemsToken =
-            data.content.joinToString(separator = "|") {
-                "${it.id}:${toEpochMillis(it.modifiedAt)}:${it.likesCount}:${it.commentsCount}:${it.hitCount}"
-            }
-        return buildString {
-            append(source)
-            append("|size=")
-            append(pageSize)
-            append("|sort=")
-            append(sort.name)
-            append("|cursor=")
-            append(cursor?.trim().orEmpty())
-            append("|tag=")
-            append(tag.trim())
-            append("|hasNext=")
-            append(data.hasNext)
-            append("|nextCursor=")
-            append(data.nextCursor.orEmpty())
-            append("|items=")
-            append(itemsToken)
-        }
-    }
-
-    private fun buildPublicDetailEtagSeed(data: PostWithContentDto): String =
-        buildString {
-            append(data.id)
-            append("|")
-            append(toEpochMillis(data.modifiedAt))
-            append("|")
-            append(data.version)
-            append("|")
-            append(data.likesCount)
-            append("|")
-            append(data.commentsCount)
-            append("|")
-            append(data.hitCount)
-        }
-
-    private fun buildTagsEtagSeed(tags: List<TagCountDto>): String = tags.joinToString(separator = "|") { "${it.tag}:${it.count}" }
-
-    private fun buildRelatedAuthorEtagSeed(
-        authorId: Long,
-        excludePostId: Long?,
-        limit: Int,
-        posts: List<FeedPostDto>,
-    ): String {
-        val itemsToken =
-            posts.joinToString(separator = "|") {
-                "${it.id}:${toEpochMillis(it.modifiedAt)}:${it.likesCount}:${it.commentsCount}:${it.hitCount}"
-            }
-        return buildString {
-            append("related-author")
-            append("|authorId=")
-            append(authorId)
-            append("|excludePostId=")
-            append(excludePostId ?: 0L)
-            append("|limit=")
-            append(limit)
-            append("|items=")
-            append(itemsToken)
-        }
-    }
-
-    private fun buildBootstrapEtagSeed(
-        pageSize: Int,
-        sort: PostSearchSortType1,
-        tag: String,
-        feed: CursorFeedPageDto,
-        tags: List<TagCountDto>,
-    ): String {
-        val feedSeed =
-            buildCursorFeedEtagSeed(
-                source = if (tag.isBlank()) "bootstrap-feed-cursor" else "bootstrap-explore-cursor",
-                pageSize = pageSize,
-                sort = sort,
-                cursor = null,
-                tag = tag,
-                data = feed,
-            )
-        val tagSeed = buildTagsEtagSeed(tags)
-        return "$feedSeed|tags=$tagSeed"
-    }
 
     /**
      * makePostDtoPage 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
@@ -384,11 +98,11 @@ class ApiV1PostController(
         val validPage = normalizePublicPage(page)
         val validPageSize = pageSize.coerceIn(1, 30)
         val data = postPublicReadQueryUseCase.getPublicFeed(validPage, validPageSize, sort)
-        val etagSeed = buildFeedPageEtagSeed("feed", validPage, validPageSize, sort, data = data)
-        return respondPublicWithEtag(
+        val etagSeed = postPublicReadResponseFactory.buildFeedPageEtagSeed("feed", validPage, validPageSize, sort, data = data)
+        return postPublicReadResponseFactory.respondWithEtag(
             request = request,
             response = response,
-            cachePolicy = FEED_CACHE_POLICY,
+            cachePolicy = PostPublicReadCachePolicies.FEED,
             surrogateKeys = setOf(PostCacheTags.LIST, PostCacheTags.FEED),
             etagSeed = etagSeed,
             startedAtNanos = startedAtNanos,
@@ -409,11 +123,11 @@ class ApiV1PostController(
         val validPageSize = pageSize.coerceIn(1, 30)
         val validSort = normalizeCursorSort(sort)
         val data = postPublicReadQueryUseCase.getPublicFeedByCursor(cursor, validPageSize, validSort)
-        val etagSeed = buildCursorFeedEtagSeed("feed-cursor", validPageSize, validSort, cursor, data = data)
-        return respondPublicWithEtag(
+        val etagSeed = postPublicReadResponseFactory.buildCursorFeedEtagSeed("feed-cursor", validPageSize, validSort, cursor, data = data)
+        return postPublicReadResponseFactory.respondWithEtag(
             request = request,
             response = response,
-            cachePolicy = FEED_CURSOR_CACHE_POLICY,
+            cachePolicy = PostPublicReadCachePolicies.FEED_CURSOR,
             surrogateKeys = setOf(PostCacheTags.LIST, PostCacheTags.FEED, PostCacheTags.FEED_CURSOR),
             etagSeed = etagSeed,
             startedAtNanos = startedAtNanos,
@@ -443,11 +157,20 @@ class ApiV1PostController(
         val normalizedKw = searchIntent.keyword
         val normalizedTag = searchIntent.tag
         val data = postPublicReadQueryUseCase.getPublicExplore(validPage, validPageSize, normalizedKw, normalizedTag, sort)
-        val etagSeed = buildFeedPageEtagSeed("explore", validPage, validPageSize, sort, normalizedKw, normalizedTag, data)
-        return respondPublicWithEtag(
+        val etagSeed =
+            postPublicReadResponseFactory.buildFeedPageEtagSeed(
+                "explore",
+                validPage,
+                validPageSize,
+                sort,
+                normalizedKw,
+                normalizedTag,
+                data,
+            )
+        return postPublicReadResponseFactory.respondWithEtag(
             request = request,
             response = response,
-            cachePolicy = EXPLORE_CACHE_POLICY,
+            cachePolicy = PostPublicReadCachePolicies.EXPLORE,
             surrogateKeys =
                 buildSet {
                     add(PostCacheTags.LIST)
@@ -477,11 +200,12 @@ class ApiV1PostController(
         val normalizedTag = normalizeExploreTag(tag)
         val validSort = normalizeCursorSort(sort)
         val data = postPublicReadQueryUseCase.getPublicExploreByCursor(cursor, validPageSize, normalizedTag, validSort)
-        val etagSeed = buildCursorFeedEtagSeed("explore-cursor", validPageSize, validSort, cursor, normalizedTag, data)
-        return respondPublicWithEtag(
+        val etagSeed =
+            postPublicReadResponseFactory.buildCursorFeedEtagSeed("explore-cursor", validPageSize, validSort, cursor, normalizedTag, data)
+        return postPublicReadResponseFactory.respondWithEtag(
             request = request,
             response = response,
-            cachePolicy = EXPLORE_CURSOR_CACHE_POLICY,
+            cachePolicy = PostPublicReadCachePolicies.EXPLORE_CURSOR,
             surrogateKeys =
                 setOf(
                     PostCacheTags.LIST,
@@ -513,11 +237,11 @@ class ApiV1PostController(
                 excludePostId = safeExcludePostId,
                 limit = safeLimit,
             )
-        val etagSeed = buildRelatedAuthorEtagSeed(authorId, safeExcludePostId, safeLimit, data)
-        return respondPublicWithEtag(
+        val etagSeed = postPublicReadResponseFactory.buildRelatedAuthorEtagSeed(authorId, safeExcludePostId, safeLimit, data)
+        return postPublicReadResponseFactory.respondWithEtag(
             request = request,
             response = response,
-            cachePolicy = RELATED_AUTHOR_CACHE_POLICY,
+            cachePolicy = PostPublicReadCachePolicies.RELATED_AUTHOR,
             surrogateKeys = setOf(PostCacheTags.LIST, PostCacheTags.DETAIL),
             etagSeed = etagSeed,
             startedAtNanos = startedAtNanos,
@@ -548,7 +272,7 @@ class ApiV1PostController(
                 postPublicReadQueryUseCase.getPublicExplore(validPage, validPageSize, normalizedKw, normalizedTag, sort)
             }
         val etagSeed =
-            buildFeedPageEtagSeed(
+            postPublicReadResponseFactory.buildFeedPageEtagSeed(
                 if (normalizedTag.isBlank()) "search" else "search-tag-intent",
                 validPage,
                 validPageSize,
@@ -557,22 +281,22 @@ class ApiV1PostController(
                 normalizedTag,
                 data,
             )
-        val searchPolicy = resolveSearchReadCachePolicy(normalizedKw)
+        val searchPolicy = postPublicReadResponseFactory.resolveSearchReadCachePolicy(normalizedKw)
         if (searchPolicy.noStore) {
-            applyPrivateNoStoreHeaders(response)
-            response.setHeader("X-Cache-Policy", searchPolicy.name)
-            applySurrogateKeyHeaders(
-                response,
-                buildSet {
-                    add(PostCacheTags.SEARCH)
-                    if (normalizedTag.isNotBlank()) add(PostCacheTags.byTag(normalizedTag))
-                },
+            return postPublicReadResponseFactory.respondNoStore(
+                response = response,
+                cachePolicy = searchPolicy,
+                surrogateKeys =
+                    buildSet {
+                        add(PostCacheTags.SEARCH)
+                        if (normalizedTag.isNotBlank()) add(PostCacheTags.byTag(normalizedTag))
+                    },
+                startedAtNanos = startedAtNanos,
+                originDescription = "search-no-store",
+                body = data,
             )
-            appendServerTiming(response, "cache-policy;desc=\"${searchPolicy.name}\"")
-            appendOriginTiming(response, startedAtNanos, "search-no-store")
-            return ResponseEntity.ok(data)
         }
-        return respondPublicWithEtag(
+        return postPublicReadResponseFactory.respondWithEtag(
             request = request,
             response = response,
             cachePolicy = searchPolicy,
@@ -595,11 +319,11 @@ class ApiV1PostController(
     ): ResponseEntity<List<TagCountDto>> {
         val startedAtNanos = System.nanoTime()
         val data = postPublicReadQueryUseCase.getPublicTagCounts()
-        val etagSeed = buildTagsEtagSeed(data)
-        return respondPublicWithEtag(
+        val etagSeed = postPublicReadResponseFactory.buildTagsEtagSeed(data)
+        return postPublicReadResponseFactory.respondWithEtag(
             request = request,
             response = response,
-            cachePolicy = TAGS_CACHE_POLICY,
+            cachePolicy = PostPublicReadCachePolicies.TAGS,
             surrogateKeys = setOf(PostCacheTags.TAGS),
             etagSeed = etagSeed,
             startedAtNanos = startedAtNanos,
@@ -622,18 +346,17 @@ class ApiV1PostController(
         val validSort = normalizeCursorSort(sort)
         val data = postPublicReadQueryUseCase.getPublicBootstrap(normalizedTag, validPageSize, validSort)
         val etagSeed =
-            buildBootstrapEtagSeed(
+            postPublicReadResponseFactory.buildBootstrapEtagSeed(
                 pageSize = validPageSize,
                 sort = validSort,
                 tag = normalizedTag,
-                feed = data.feed,
-                tags = data.tags,
+                data = data,
             )
 
-        return respondPublicWithEtag(
+        return postPublicReadResponseFactory.respondWithEtag(
             request = request,
             response = response,
-            cachePolicy = BOOTSTRAP_CACHE_POLICY,
+            cachePolicy = PostPublicReadCachePolicies.BOOTSTRAP,
             surrogateKeys =
                 buildSet {
                     add(PostCacheTags.LIST)
@@ -681,18 +404,18 @@ class ApiV1PostController(
         val startedAtNanos = System.nanoTime()
         if (rq.actorOrNull == null) {
             val data = postPublicReadQueryUseCase.getPublicPostDetail(id)
-            val etagSeed = buildPublicDetailEtagSeed(data)
-            return respondPublicWithEtag(
+            val etagSeed = postPublicReadResponseFactory.buildPublicDetailEtagSeed(data)
+            return postPublicReadResponseFactory.respondWithEtag(
                 request = request,
                 response = response,
-                cachePolicy = DETAIL_CACHE_POLICY,
+                cachePolicy = PostPublicReadCachePolicies.DETAIL,
                 surrogateKeys = setOf(PostCacheTags.DETAIL, PostCacheTags.byPostId(id)),
                 etagSeed = etagSeed,
                 startedAtNanos = startedAtNanos,
                 body = data,
             )
         }
-        applyPrivateNoStoreHeaders(response)
+        postPublicReadResponseFactory.applyPrivateNoStoreHeaders(response)
         val post = postUseCase.findById(id).getOrThrow()
         if (!rq.hasRole("ADMIN")) {
             post.checkActorCanRead(rq.actor)
@@ -1051,102 +774,9 @@ class ApiV1PostController(
     }
 
     companion object {
-        private val FEED_CACHE_POLICY =
-            PublicReadCachePolicy(
-                name = "feed-max20-smax60-swr60",
-                maxAgeSeconds = 20,
-                sharedMaxAgeSeconds = 60,
-                staleWhileRevalidateSeconds = 60,
-            )
-        private val FEED_CURSOR_CACHE_POLICY =
-            PublicReadCachePolicy(
-                name = "feed-cursor-max20-smax60-swr60",
-                maxAgeSeconds = 20,
-                sharedMaxAgeSeconds = 60,
-                staleWhileRevalidateSeconds = 60,
-            )
-        private val EXPLORE_CACHE_POLICY =
-            PublicReadCachePolicy(
-                name = "explore-max20-smax60-swr60",
-                maxAgeSeconds = 20,
-                sharedMaxAgeSeconds = 60,
-                staleWhileRevalidateSeconds = 60,
-            )
-        private val EXPLORE_CURSOR_CACHE_POLICY =
-            PublicReadCachePolicy(
-                name = "explore-cursor-max20-smax60-swr60",
-                maxAgeSeconds = 20,
-                sharedMaxAgeSeconds = 60,
-                staleWhileRevalidateSeconds = 60,
-            )
-        private val SEARCH_DEFAULT_CACHE_POLICY =
-            PublicReadCachePolicy(
-                name = "search-max15-smax45-swr45",
-                maxAgeSeconds = 15,
-                sharedMaxAgeSeconds = 45,
-                staleWhileRevalidateSeconds = 45,
-            )
-        private val SEARCH_SHORT_CACHE_POLICY =
-            PublicReadCachePolicy(
-                name = "search-short-max5-smax10-swr15",
-                maxAgeSeconds = 5,
-                sharedMaxAgeSeconds = 10,
-                staleWhileRevalidateSeconds = 15,
-            )
-        private val SEARCH_NO_STORE_CACHE_POLICY =
-            PublicReadCachePolicy(
-                name = "search-high-entropy-no-store",
-                maxAgeSeconds = 0,
-                sharedMaxAgeSeconds = 0,
-                staleWhileRevalidateSeconds = 0,
-                noStore = true,
-            )
-        private val TAGS_CACHE_POLICY =
-            PublicReadCachePolicy(
-                name = "tags-max60-smax300-swr300",
-                maxAgeSeconds = 60,
-                sharedMaxAgeSeconds = 300,
-                staleWhileRevalidateSeconds = 300,
-            )
-        private val BOOTSTRAP_CACHE_POLICY =
-            PublicReadCachePolicy(
-                name = "bootstrap-max20-smax60-swr60",
-                maxAgeSeconds = 20,
-                sharedMaxAgeSeconds = 60,
-                staleWhileRevalidateSeconds = 60,
-            )
-        private val DETAIL_CACHE_POLICY =
-            PublicReadCachePolicy(
-                name = "detail-max20-smax60-swr60",
-                maxAgeSeconds = 20,
-                sharedMaxAgeSeconds = 60,
-                staleWhileRevalidateSeconds = 60,
-            )
-        private val RELATED_AUTHOR_CACHE_POLICY =
-            PublicReadCachePolicy(
-                name = "related-author-max15-smax45-swr45",
-                maxAgeSeconds = 15,
-                sharedMaxAgeSeconds = 45,
-                staleWhileRevalidateSeconds = 45,
-            )
-
         private const val MAX_PUBLIC_PAGE = 200
         private const val MAX_EXPLORE_KW_LENGTH = 80
         private const val MAX_EXPLORE_TAG_LENGTH = 40
         private const val MAX_RELATED_AUTHOR_LIMIT = 12
-        private const val MAX_CACHE_TAG_LENGTH = 64
-        private const val SEARCH_SHORT_TTL_KEYWORD_LENGTH = 16
-        private const val SEARCH_NO_STORE_KEYWORD_LENGTH = 28
-        private const val SEARCH_NO_STORE_TOKEN_COUNT = 4
-        private const val SEARCH_HIGH_ENTROPY_MIN_LENGTH = 16
-        private const val SEARCH_HIGH_ENTROPY_UNIQUE_RATIO_THRESHOLD = 0.58
     }
-
-    private data class PublicReadCachePolicy(
-        val name: String,
-        val maxAgeSeconds: Int,
-        val sharedMaxAgeSeconds: Int,
-        val staleWhileRevalidateSeconds: Int,
-        val noStore: Boolean = false,
-    )
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadResponseFactory.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadResponseFactory.kt
@@ -1,0 +1,407 @@
+package com.back.boundedContexts.post.adapter.web
+
+import com.back.boundedContexts.post.dto.CursorFeedPageDto
+import com.back.boundedContexts.post.dto.FeedPostDto
+import com.back.boundedContexts.post.dto.PostWithContentDto
+import com.back.boundedContexts.post.dto.PublicPostsBootstrapDto
+import com.back.boundedContexts.post.dto.TagCountDto
+import com.back.standard.dto.page.PageDto
+import com.back.standard.dto.post.type1.PostSearchSortType1
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.time.Instant
+import java.util.Locale
+
+@Component
+class PostPublicReadResponseFactory {
+    fun <T : Any> respondWithEtag(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        cachePolicy: PublicReadCachePolicy,
+        surrogateKeys: Set<String>,
+        etagSeed: String,
+        startedAtNanos: Long,
+        body: T,
+    ): ResponseEntity<T> {
+        applyPublicReadCacheHeaders(response, cachePolicy, surrogateKeys)
+        val etag = toWeakEtag(etagSeed)
+        response.setHeader(HttpHeaders.ETAG, etag)
+        if (isNotModified(request, etag)) {
+            appendServerTiming(response, "cache;desc=\"etag-304\"")
+            appendOriginTiming(response, startedAtNanos, "etag-304")
+            response.status = HttpServletResponse.SC_NOT_MODIFIED
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build<T>()
+        }
+        appendOriginTiming(response, startedAtNanos, "etag-200")
+        return ResponseEntity.ok(body)
+    }
+
+    fun <T : Any> respondNoStore(
+        response: HttpServletResponse,
+        cachePolicy: PublicReadCachePolicy,
+        surrogateKeys: Set<String>,
+        startedAtNanos: Long,
+        originDescription: String,
+        body: T,
+    ): ResponseEntity<T> {
+        applyPrivateNoStoreHeaders(response)
+        response.setHeader("X-Cache-Policy", cachePolicy.name)
+        applySurrogateKeyHeaders(response, surrogateKeys)
+        appendServerTiming(response, "cache-policy;desc=\"${cachePolicy.name}\"")
+        appendOriginTiming(response, startedAtNanos, originDescription)
+        return ResponseEntity.ok(body)
+    }
+
+    fun applyPrivateNoStoreHeaders(response: HttpServletResponse) {
+        response.setHeader("Cache-Control", "private, no-store, max-age=0")
+    }
+
+    fun resolveSearchReadCachePolicy(keyword: String): PublicReadCachePolicy {
+        val normalized = keyword.trim()
+        if (normalized.isBlank()) return PostPublicReadCachePolicies.SEARCH_DEFAULT
+        if (isHighEntropyKeyword(normalized)) return PostPublicReadCachePolicies.SEARCH_NO_STORE
+        if (normalized.length >= SEARCH_SHORT_TTL_KEYWORD_LENGTH) return PostPublicReadCachePolicies.SEARCH_SHORT
+        return PostPublicReadCachePolicies.SEARCH_DEFAULT
+    }
+
+    fun buildFeedPageEtagSeed(
+        source: String,
+        page: Int,
+        pageSize: Int,
+        sort: PostSearchSortType1,
+        kw: String = "",
+        tag: String = "",
+        data: PageDto<FeedPostDto>,
+    ): String {
+        val itemsToken =
+            data.content.joinToString(separator = "|") {
+                "${it.id}:${toEpochMillis(it.modifiedAt)}:${it.likesCount}:${it.commentsCount}:${it.hitCount}"
+            }
+        return buildString {
+            append(source)
+            append("|page=")
+            append(page)
+            append("|size=")
+            append(pageSize)
+            append("|sort=")
+            append(sort.name)
+            append("|kw=")
+            append(kw.trim())
+            append("|tag=")
+            append(tag.trim())
+            append("|total=")
+            append(data.pageable.totalElements)
+            append("|pages=")
+            append(data.pageable.totalPages)
+            append("|items=")
+            append(itemsToken)
+        }
+    }
+
+    fun buildCursorFeedEtagSeed(
+        source: String,
+        pageSize: Int,
+        sort: PostSearchSortType1,
+        cursor: String?,
+        tag: String = "",
+        data: CursorFeedPageDto,
+    ): String {
+        val itemsToken =
+            data.content.joinToString(separator = "|") {
+                "${it.id}:${toEpochMillis(it.modifiedAt)}:${it.likesCount}:${it.commentsCount}:${it.hitCount}"
+            }
+        return buildString {
+            append(source)
+            append("|size=")
+            append(pageSize)
+            append("|sort=")
+            append(sort.name)
+            append("|cursor=")
+            append(cursor?.trim().orEmpty())
+            append("|tag=")
+            append(tag.trim())
+            append("|hasNext=")
+            append(data.hasNext)
+            append("|nextCursor=")
+            append(data.nextCursor.orEmpty())
+            append("|items=")
+            append(itemsToken)
+        }
+    }
+
+    fun buildPublicDetailEtagSeed(data: PostWithContentDto): String =
+        buildString {
+            append(data.id)
+            append("|")
+            append(toEpochMillis(data.modifiedAt))
+            append("|")
+            append(data.version)
+            append("|")
+            append(data.likesCount)
+            append("|")
+            append(data.commentsCount)
+            append("|")
+            append(data.hitCount)
+        }
+
+    fun buildTagsEtagSeed(tags: List<TagCountDto>): String = tags.joinToString(separator = "|") { "${it.tag}:${it.count}" }
+
+    fun buildRelatedAuthorEtagSeed(
+        authorId: Long,
+        excludePostId: Long?,
+        limit: Int,
+        posts: List<FeedPostDto>,
+    ): String {
+        val itemsToken =
+            posts.joinToString(separator = "|") {
+                "${it.id}:${toEpochMillis(it.modifiedAt)}:${it.likesCount}:${it.commentsCount}:${it.hitCount}"
+            }
+        return buildString {
+            append("related-author")
+            append("|authorId=")
+            append(authorId)
+            append("|excludePostId=")
+            append(excludePostId ?: 0L)
+            append("|limit=")
+            append(limit)
+            append("|items=")
+            append(itemsToken)
+        }
+    }
+
+    fun buildBootstrapEtagSeed(
+        pageSize: Int,
+        sort: PostSearchSortType1,
+        tag: String,
+        data: PublicPostsBootstrapDto,
+    ): String {
+        val feedSeed =
+            buildCursorFeedEtagSeed(
+                source = if (tag.isBlank()) "bootstrap-feed-cursor" else "bootstrap-explore-cursor",
+                pageSize = pageSize,
+                sort = sort,
+                cursor = null,
+                tag = tag,
+                data = data.feed,
+            )
+        val tagSeed = buildTagsEtagSeed(data.tags)
+        return "$feedSeed|tags=$tagSeed"
+    }
+
+    private fun applyPublicReadCacheHeaders(
+        response: HttpServletResponse,
+        policy: PublicReadCachePolicy,
+        surrogateKeys: Set<String>,
+    ) {
+        val safeMaxAge = policy.maxAgeSeconds.coerceAtLeast(0)
+        val safeSharedMaxAge = policy.sharedMaxAgeSeconds.coerceAtLeast(safeMaxAge)
+        val safeSWR = policy.staleWhileRevalidateSeconds.coerceAtLeast(0)
+        val staleIfError = (safeSharedMaxAge + safeSWR).coerceAtLeast(safeSWR)
+        response.setHeader(
+            "Cache-Control",
+            "public, max-age=$safeMaxAge, s-maxage=$safeSharedMaxAge, stale-while-revalidate=$safeSWR, stale-if-error=$staleIfError",
+        )
+        response.setHeader("X-Cache-Policy", policy.name)
+        applySurrogateKeyHeaders(response, surrogateKeys)
+        appendServerTiming(response, "cache-policy;desc=\"${policy.name}\"")
+    }
+
+    private fun applySurrogateKeyHeaders(
+        response: HttpServletResponse,
+        surrogateKeys: Set<String>,
+    ) {
+        val normalized =
+            surrogateKeys
+                .asSequence()
+                .map(::normalizeCacheTagToken)
+                .filter { it.isNotBlank() }
+                .distinct()
+                .toList()
+        if (normalized.isEmpty()) return
+        response.setHeader("Surrogate-Key", normalized.joinToString(" "))
+        response.setHeader("Cache-Tag", normalized.joinToString(","))
+    }
+
+    private fun normalizeCacheTagToken(raw: String): String =
+        raw
+            .trim()
+            .lowercase()
+            .replace(Regex("[^a-z0-9:_-]"), "-")
+            .replace(Regex("-+"), "-")
+            .trim('-')
+            .take(MAX_CACHE_TAG_LENGTH)
+
+    private fun appendServerTiming(
+        response: HttpServletResponse,
+        metric: String,
+    ) {
+        val current = response.getHeader("Server-Timing")
+        if (current.isNullOrBlank()) {
+            response.setHeader("Server-Timing", metric)
+            return
+        }
+        response.setHeader("Server-Timing", "$current, $metric")
+    }
+
+    private fun appendOriginTiming(
+        response: HttpServletResponse,
+        startedAtNanos: Long,
+        description: String,
+    ) {
+        val elapsedMs = ((System.nanoTime() - startedAtNanos).coerceAtLeast(0L)).toDouble() / 1_000_000.0
+        val durationToken = String.format(Locale.US, "%.1f", elapsedMs)
+        appendServerTiming(response, "origin;dur=$durationToken;desc=\"$description\"")
+    }
+
+    private fun normalizeEtagToken(raw: String): String = raw.trim().removePrefix("W/").removePrefix("w/")
+
+    private fun toWeakEtag(seed: String): String {
+        val digest =
+            MessageDigest
+                .getInstance("SHA-256")
+                .digest(seed.toByteArray(StandardCharsets.UTF_8))
+                .joinToString("") { each -> "%02x".format(each) }
+                .take(32)
+        return "W/\"$digest\""
+    }
+
+    private fun isNotModified(
+        request: HttpServletRequest,
+        etag: String,
+    ): Boolean {
+        val ifNoneMatch = request.getHeader(HttpHeaders.IF_NONE_MATCH)?.trim().orEmpty()
+        if (ifNoneMatch.isBlank()) return false
+        if (ifNoneMatch == "*") return true
+
+        val expected = normalizeEtagToken(etag)
+        return ifNoneMatch
+            .split(",")
+            .asSequence()
+            .map { normalizeEtagToken(it) }
+            .any { it == expected }
+    }
+
+    private fun isHighEntropyKeyword(keyword: String): Boolean {
+        if (keyword.length >= SEARCH_NO_STORE_KEYWORD_LENGTH) return true
+
+        val tokens = keyword.split(Regex("\\s+")).filter { it.isNotBlank() }
+        if (tokens.size >= SEARCH_NO_STORE_TOKEN_COUNT) return true
+
+        val alphaNumeric = keyword.filter { it.isLetterOrDigit() }
+        if (alphaNumeric.length < SEARCH_HIGH_ENTROPY_MIN_LENGTH) return false
+
+        val uniqueRatio =
+            alphaNumeric
+                .lowercase()
+                .toSet()
+                .size
+                .toDouble() / alphaNumeric.length
+        return uniqueRatio >= SEARCH_HIGH_ENTROPY_UNIQUE_RATIO_THRESHOLD
+    }
+
+    private fun toEpochMillis(instant: Instant): Long = instant.toEpochMilli()
+
+    private companion object {
+        private const val MAX_CACHE_TAG_LENGTH = 64
+        private const val SEARCH_SHORT_TTL_KEYWORD_LENGTH = 16
+        private const val SEARCH_NO_STORE_KEYWORD_LENGTH = 28
+        private const val SEARCH_NO_STORE_TOKEN_COUNT = 4
+        private const val SEARCH_HIGH_ENTROPY_MIN_LENGTH = 16
+        private const val SEARCH_HIGH_ENTROPY_UNIQUE_RATIO_THRESHOLD = 0.58
+    }
+}
+
+data class PublicReadCachePolicy(
+    val name: String,
+    val maxAgeSeconds: Int,
+    val sharedMaxAgeSeconds: Int,
+    val staleWhileRevalidateSeconds: Int,
+    val noStore: Boolean = false,
+)
+
+object PostPublicReadCachePolicies {
+    val FEED =
+        PublicReadCachePolicy(
+            name = "feed-max20-smax60-swr60",
+            maxAgeSeconds = 20,
+            sharedMaxAgeSeconds = 60,
+            staleWhileRevalidateSeconds = 60,
+        )
+    val FEED_CURSOR =
+        PublicReadCachePolicy(
+            name = "feed-cursor-max20-smax60-swr60",
+            maxAgeSeconds = 20,
+            sharedMaxAgeSeconds = 60,
+            staleWhileRevalidateSeconds = 60,
+        )
+    val EXPLORE =
+        PublicReadCachePolicy(
+            name = "explore-max20-smax60-swr60",
+            maxAgeSeconds = 20,
+            sharedMaxAgeSeconds = 60,
+            staleWhileRevalidateSeconds = 60,
+        )
+    val EXPLORE_CURSOR =
+        PublicReadCachePolicy(
+            name = "explore-cursor-max20-smax60-swr60",
+            maxAgeSeconds = 20,
+            sharedMaxAgeSeconds = 60,
+            staleWhileRevalidateSeconds = 60,
+        )
+    val SEARCH_DEFAULT =
+        PublicReadCachePolicy(
+            name = "search-max15-smax45-swr45",
+            maxAgeSeconds = 15,
+            sharedMaxAgeSeconds = 45,
+            staleWhileRevalidateSeconds = 45,
+        )
+    val SEARCH_SHORT =
+        PublicReadCachePolicy(
+            name = "search-short-max5-smax10-swr15",
+            maxAgeSeconds = 5,
+            sharedMaxAgeSeconds = 10,
+            staleWhileRevalidateSeconds = 15,
+        )
+    val SEARCH_NO_STORE =
+        PublicReadCachePolicy(
+            name = "search-high-entropy-no-store",
+            maxAgeSeconds = 0,
+            sharedMaxAgeSeconds = 0,
+            staleWhileRevalidateSeconds = 0,
+            noStore = true,
+        )
+    val TAGS =
+        PublicReadCachePolicy(
+            name = "tags-max60-smax300-swr300",
+            maxAgeSeconds = 60,
+            sharedMaxAgeSeconds = 300,
+            staleWhileRevalidateSeconds = 300,
+        )
+    val BOOTSTRAP =
+        PublicReadCachePolicy(
+            name = "bootstrap-max20-smax60-swr60",
+            maxAgeSeconds = 20,
+            sharedMaxAgeSeconds = 60,
+            staleWhileRevalidateSeconds = 60,
+        )
+    val DETAIL =
+        PublicReadCachePolicy(
+            name = "detail-max20-smax60-swr60",
+            maxAgeSeconds = 20,
+            sharedMaxAgeSeconds = 60,
+            staleWhileRevalidateSeconds = 60,
+        )
+    val RELATED_AUTHOR =
+        PublicReadCachePolicy(
+            name = "related-author-max15-smax45-swr45",
+            maxAgeSeconds = 15,
+            sharedMaxAgeSeconds = 45,
+            staleWhileRevalidateSeconds = 45,
+        )
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadResponseFactoryTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadResponseFactoryTest.kt
@@ -1,0 +1,401 @@
+package com.back.boundedContexts.post.adapter.web
+
+import com.back.boundedContexts.post.dto.CursorFeedPageDto
+import com.back.boundedContexts.post.dto.FeedPostDto
+import com.back.boundedContexts.post.dto.PostWithContentDto
+import com.back.boundedContexts.post.dto.PublicPostsBootstrapDto
+import com.back.boundedContexts.post.dto.TagCountDto
+import com.back.standard.dto.page.PageDto
+import com.back.standard.dto.page.PageableDto
+import com.back.standard.dto.post.type1.PostSearchSortType1
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import java.time.Instant
+
+@DisplayName("PostPublicReadResponseFactory 테스트")
+class PostPublicReadResponseFactoryTest {
+    private val responseFactory = PostPublicReadResponseFactory()
+
+    @Test
+    @DisplayName("공개 read 응답은 Cache-Control, surrogate key, ETag, Server-Timing을 한 번에 조립한다")
+    fun respondWithPublicCacheHeadersAndEtag() {
+        // given
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val policy =
+            PublicReadCachePolicy(
+                name = "test-max10-smax20-swr30",
+                maxAgeSeconds = 10,
+                sharedMaxAgeSeconds = 20,
+                staleWhileRevalidateSeconds = 30,
+            )
+
+        // when
+        val result =
+            responseFactory.respondWithEtag(
+                request = request,
+                response = response,
+                cachePolicy = policy,
+                surrogateKeys = setOf("Post:123", "tag: Kotlin!", "tag: Kotlin!"),
+                etagSeed = "post|123|1",
+                startedAtNanos = System.nanoTime(),
+                body = "payload",
+            )
+
+        // then
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body).isEqualTo("payload")
+        assertThat(response.getHeaders(HttpHeaders.CACHE_CONTROL)).containsExactly(
+            "public, max-age=10, s-maxage=20, stale-while-revalidate=30, stale-if-error=50",
+        )
+        assertThat(response.getHeader("X-Cache-Policy")).isEqualTo("test-max10-smax20-swr30")
+        assertThat(response.getHeader("Surrogate-Key")).isEqualTo("post:123 tag:-kotlin")
+        assertThat(response.getHeader("Cache-Tag")).isEqualTo("post:123,tag:-kotlin")
+        assertThat(response.getHeader(HttpHeaders.ETAG)).startsWith("W/\"").endsWith("\"")
+        assertThat(response.getHeader("Server-Timing"))
+            .contains("cache-policy;desc=\"test-max10-smax20-swr30\"")
+            .contains("origin;dur=")
+            .contains("etag-200")
+    }
+
+    @Test
+    @DisplayName("If-None-Match가 현재 ETag와 맞으면 동일 헤더를 유지하고 304를 반환한다")
+    fun respondNotModifiedWhenIfNoneMatchMatchesWeakEtag() {
+        // given
+        val firstRequest = MockHttpServletRequest()
+        val firstResponse = MockHttpServletResponse()
+        val policy =
+            PublicReadCachePolicy(
+                name = "test-max10-smax20-swr30",
+                maxAgeSeconds = 10,
+                sharedMaxAgeSeconds = 20,
+                staleWhileRevalidateSeconds = 30,
+            )
+        responseFactory.respondWithEtag(
+            request = firstRequest,
+            response = firstResponse,
+            cachePolicy = policy,
+            surrogateKeys = setOf("post:123"),
+            etagSeed = "post|123|1",
+            startedAtNanos = System.nanoTime(),
+            body = "payload",
+        )
+        val etag = requireNotNull(firstResponse.getHeader(HttpHeaders.ETAG))
+        val request =
+            MockHttpServletRequest().apply {
+                addHeader(HttpHeaders.IF_NONE_MATCH, "\"other\", $etag")
+            }
+        val response = MockHttpServletResponse()
+
+        // when
+        val result =
+            responseFactory.respondWithEtag(
+                request = request,
+                response = response,
+                cachePolicy = policy,
+                surrogateKeys = setOf("post:123"),
+                etagSeed = "post|123|1",
+                startedAtNanos = System.nanoTime(),
+                body = "payload",
+            )
+
+        // then
+        assertThat(result.statusCode).isEqualTo(HttpStatus.NOT_MODIFIED)
+        assertThat(result.body).isNull()
+        assertThat(response.status).isEqualTo(MockHttpServletResponse.SC_NOT_MODIFIED)
+        assertThat(response.getHeader(HttpHeaders.ETAG)).isEqualTo(etag)
+        assertThat(response.getHeader("Server-Timing"))
+            .contains("cache;desc=\"etag-304\"")
+            .contains("origin;dur=")
+            .contains("etag-304")
+    }
+
+    @Test
+    @DisplayName("no-store 검색 응답은 ETag 없이 private no-store와 cache policy timing만 반환한다")
+    fun respondNoStoreWithoutEtag() {
+        // given
+        val response = MockHttpServletResponse()
+        val policy =
+            PublicReadCachePolicy(
+                name = "search-high-entropy-no-store",
+                maxAgeSeconds = 0,
+                sharedMaxAgeSeconds = 0,
+                staleWhileRevalidateSeconds = 0,
+                noStore = true,
+            )
+
+        // when
+        val result =
+            responseFactory.respondNoStore(
+                response = response,
+                cachePolicy = policy,
+                surrogateKeys = setOf("search", "tag:Secret"),
+                startedAtNanos = System.nanoTime(),
+                originDescription = "search-no-store",
+                body = "payload",
+            )
+
+        // then
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body).isEqualTo("payload")
+        assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL)).isEqualTo("private, no-store, max-age=0")
+        assertThat(response.getHeader(HttpHeaders.ETAG)).isNull()
+        assertThat(response.getHeader("X-Cache-Policy")).isEqualTo("search-high-entropy-no-store")
+        assertThat(response.getHeader("Surrogate-Key")).isEqualTo("search tag:secret")
+        assertThat(response.getHeader("Server-Timing"))
+            .contains("cache-policy;desc=\"search-high-entropy-no-store\"")
+            .contains("origin;dur=")
+            .contains("search-no-store")
+    }
+
+    @Test
+    @DisplayName("공개 cache 응답은 음수 TTL을 보정하고 빈 surrogate key면 관련 헤더를 생략한다")
+    fun respondWithSafeCachePolicyAndWithoutEmptySurrogateHeaders() {
+        // given
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val policy =
+            PublicReadCachePolicy(
+                name = "unsafe-negative-policy",
+                maxAgeSeconds = -10,
+                sharedMaxAgeSeconds = -5,
+                staleWhileRevalidateSeconds = -1,
+            )
+
+        // when
+        responseFactory.respondWithEtag(
+            request = request,
+            response = response,
+            cachePolicy = policy,
+            surrogateKeys = setOf(" !!! ", ""),
+            etagSeed = "seed",
+            startedAtNanos = System.nanoTime(),
+            body = "payload",
+        )
+
+        // then
+        assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL)).isEqualTo(
+            "public, max-age=0, s-maxage=0, stale-while-revalidate=0, stale-if-error=0",
+        )
+        assertThat(response.getHeader("Surrogate-Key")).isNull()
+        assertThat(response.getHeader("Cache-Tag")).isNull()
+    }
+
+    @Test
+    @DisplayName("If-None-Match 와일드카드는 현재 ETag와 무관하게 304를 반환한다")
+    fun respondNotModifiedWhenIfNoneMatchWildcard() {
+        // given
+        val request =
+            MockHttpServletRequest().apply {
+                addHeader(HttpHeaders.IF_NONE_MATCH, "*")
+            }
+        val response = MockHttpServletResponse()
+
+        // when
+        val result =
+            responseFactory.respondWithEtag(
+                request = request,
+                response = response,
+                cachePolicy = PostPublicReadCachePolicies.FEED,
+                surrogateKeys = emptySet(),
+                etagSeed = "any-current-seed",
+                startedAtNanos = System.nanoTime(),
+                body = "payload",
+            )
+
+        // then
+        assertThat(result.statusCode).isEqualTo(HttpStatus.NOT_MODIFIED)
+        assertThat(response.status).isEqualTo(MockHttpServletResponse.SC_NOT_MODIFIED)
+    }
+
+    @Test
+    @DisplayName("검색어 cache policy는 공백, 짧은 검색어, 긴 검색어, 고엔트로피 검색어를 구분한다")
+    fun resolveSearchReadCachePolicyByKeywordShape() {
+        assertThat(responseFactory.resolveSearchReadCachePolicy("   "))
+            .isSameAs(PostPublicReadCachePolicies.SEARCH_DEFAULT)
+        assertThat(responseFactory.resolveSearchReadCachePolicy("kotlin"))
+            .isSameAs(PostPublicReadCachePolicies.SEARCH_DEFAULT)
+        assertThat(responseFactory.resolveSearchReadCachePolicy("kotlin spring api"))
+            .isSameAs(PostPublicReadCachePolicies.SEARCH_SHORT)
+        assertThat(responseFactory.resolveSearchReadCachePolicy("one two three four"))
+            .isSameAs(PostPublicReadCachePolicies.SEARCH_NO_STORE)
+        assertThat(responseFactory.resolveSearchReadCachePolicy("abcdefghijklmnopqrstuvwxyz12"))
+            .isSameAs(PostPublicReadCachePolicies.SEARCH_NO_STORE)
+        assertThat(responseFactory.resolveSearchReadCachePolicy("abcd1234efgh5678"))
+            .isSameAs(PostPublicReadCachePolicies.SEARCH_NO_STORE)
+        assertThat(responseFactory.resolveSearchReadCachePolicy("aaaaaaaaaaaaaaaa"))
+            .isSameAs(PostPublicReadCachePolicies.SEARCH_SHORT)
+    }
+
+    @Test
+    @DisplayName("ETag seed builder는 공개 read 응답별 변동 필드를 반영한다")
+    fun buildEtagSeedsForPublicReadResponses() {
+        // given
+        val firstPost = feedPost(id = 1L, modifiedAt = Instant.parse("2026-01-01T00:00:00Z"))
+        val secondPost = feedPost(id = 2L, modifiedAt = Instant.parse("2026-01-02T00:00:00Z"))
+        val page =
+            PageDto(
+                content = listOf(firstPost, secondPost),
+                pageable =
+                    PageableDto(
+                        pageNumber = 2,
+                        pageSize = 10,
+                        totalElements = 22,
+                        totalPages = 3,
+                        numberOfElements = 2,
+                    ),
+            )
+        val cursorFeed =
+            CursorFeedPageDto(
+                content = listOf(firstPost),
+                pageSize = 10,
+                hasNext = true,
+                nextCursor = "next-1",
+            )
+        val tags = listOf(TagCountDto(tag = "Kotlin", count = 3), TagCountDto(tag = "Spring", count = 2))
+        val bootstrap = PublicPostsBootstrapDto(feed = cursorFeed, tags = tags)
+
+        // when
+        val pageSeed =
+            responseFactory.buildFeedPageEtagSeed(
+                source = "search",
+                page = 2,
+                pageSize = 10,
+                sort = PostSearchSortType1.CREATED_AT,
+                kw = " kotlin ",
+                tag = " spring ",
+                data = page,
+            )
+        val cursorSeed =
+            responseFactory.buildCursorFeedEtagSeed(
+                source = "feed-cursor",
+                pageSize = 10,
+                sort = PostSearchSortType1.CREATED_AT,
+                cursor = " cursor-1 ",
+                tag = " backend ",
+                data = cursorFeed,
+            )
+        val detailSeed =
+            responseFactory.buildPublicDetailEtagSeed(
+                PostWithContentDto(
+                    id = 9L,
+                    createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+                    modifiedAt = Instant.parse("2026-01-03T00:00:00Z"),
+                    authorId = 1L,
+                    authorName = "Author",
+                    authorUsername = "author",
+                    authorProfileImageUrl = "https://example.com/profile.png",
+                    authorProfileImageDirectUrl = "https://example.com/profile-direct.png",
+                    title = "Title",
+                    content = "content",
+                    contentHtml = "<p>content</p>",
+                    version = 7L,
+                    published = true,
+                    listed = true,
+                    likesCount = 8,
+                    commentsCount = 9,
+                    hitCount = 10,
+                ),
+            )
+        val relatedSeed =
+            responseFactory.buildRelatedAuthorEtagSeed(
+                authorId = 3L,
+                excludePostId = null,
+                limit = 4,
+                posts = listOf(secondPost),
+            )
+        val bootstrapFeedSeed =
+            responseFactory.buildBootstrapEtagSeed(
+                pageSize = 10,
+                sort = PostSearchSortType1.CREATED_AT,
+                tag = "",
+                data = bootstrap,
+            )
+        val bootstrapExploreSeed =
+            responseFactory.buildBootstrapEtagSeed(
+                pageSize = 10,
+                sort = PostSearchSortType1.CREATED_AT,
+                tag = "kotlin",
+                data = bootstrap,
+            )
+
+        // then
+        assertThat(pageSeed).isEqualTo(
+            "search|page=2|size=10|sort=CREATED_AT|kw=kotlin|tag=spring|total=22|pages=3|" +
+                "items=1:1767225600000:11:12:13|2:1767312000000:11:12:13",
+        )
+        assertThat(cursorSeed).isEqualTo(
+            "feed-cursor|size=10|sort=CREATED_AT|cursor=cursor-1|tag=backend|hasNext=true|nextCursor=next-1|" +
+                "items=1:1767225600000:11:12:13",
+        )
+        assertThat(detailSeed).isEqualTo("9|1767398400000|7|8|9|10")
+        assertThat(responseFactory.buildTagsEtagSeed(tags)).isEqualTo("Kotlin:3|Spring:2")
+        assertThat(relatedSeed).isEqualTo("related-author|authorId=3|excludePostId=0|limit=4|items=2:1767312000000:11:12:13")
+        assertThat(bootstrapFeedSeed).startsWith("bootstrap-feed-cursor|")
+        assertThat(bootstrapExploreSeed).startsWith("bootstrap-explore-cursor|")
+    }
+
+    @Test
+    @DisplayName("공개 read cache policy registry는 모든 endpoint 정책을 노출한다")
+    fun exposeAllPublicReadCachePolicies() {
+        val policies =
+            listOf(
+                PostPublicReadCachePolicies.FEED,
+                PostPublicReadCachePolicies.FEED_CURSOR,
+                PostPublicReadCachePolicies.EXPLORE,
+                PostPublicReadCachePolicies.EXPLORE_CURSOR,
+                PostPublicReadCachePolicies.SEARCH_DEFAULT,
+                PostPublicReadCachePolicies.SEARCH_SHORT,
+                PostPublicReadCachePolicies.SEARCH_NO_STORE,
+                PostPublicReadCachePolicies.TAGS,
+                PostPublicReadCachePolicies.BOOTSTRAP,
+                PostPublicReadCachePolicies.DETAIL,
+                PostPublicReadCachePolicies.RELATED_AUTHOR,
+            )
+
+        assertThat(policies.map { it.name }).containsExactly(
+            "feed-max20-smax60-swr60",
+            "feed-cursor-max20-smax60-swr60",
+            "explore-max20-smax60-swr60",
+            "explore-cursor-max20-smax60-swr60",
+            "search-max15-smax45-swr45",
+            "search-short-max5-smax10-swr15",
+            "search-high-entropy-no-store",
+            "tags-max60-smax300-swr300",
+            "bootstrap-max20-smax60-swr60",
+            "detail-max20-smax60-swr60",
+            "related-author-max15-smax45-swr45",
+        )
+        assertThat(PostPublicReadCachePolicies.SEARCH_NO_STORE.noStore).isTrue()
+        assertThat(PostPublicReadCachePolicies.RELATED_AUTHOR.sharedMaxAgeSeconds).isEqualTo(45)
+    }
+
+    private fun feedPost(
+        id: Long,
+        modifiedAt: Instant,
+    ): FeedPostDto =
+        FeedPostDto(
+            id = id,
+            createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+            modifiedAt = modifiedAt,
+            authorId = 1L,
+            authorName = "Author",
+            authorUsername = "author",
+            authorProfileImgUrl = "https://example.com/profile.png",
+            title = "Title $id",
+            thumbnail = null,
+            summary = "Summary $id",
+            tags = listOf("kotlin"),
+            category = listOf("backend"),
+            published = true,
+            listed = true,
+            likesCount = 11,
+            commentsCount = 12,
+            hitCount = 13,
+        )
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #843

## 📝 Summary
- 공개 read API의 Cache-Control, Surrogate-Key/Cache-Tag, ETag, 304, Server-Timing 조립 책임을 `PostPublicReadResponseFactory`로 분리했습니다.
- `ApiV1PostController`는 요청 정규화와 use case 호출, 응답 factory 위임 중심으로 줄이고 기존 HTTP 캐시 계약은 유지했습니다.

## 🛠 Changes
- `PostPublicReadResponseFactory`를 추가해 public/no-store 응답 조립, ETag seed 생성, cache policy 선택을 담당하게 했습니다.
- feed/explore/search/tags/bootstrap/detail/related author controller 경로가 새 factory를 사용하도록 변경했습니다.
- factory 단위 테스트를 추가해 public cache header, surrogate key normalization, ETag 304, no-store 응답을 검증했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [ ] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `./back/gradlew -p back test --tests com.back.boundedContexts.post.adapter.web.PostPublicReadResponseFactoryTest` - success
- `./back/gradlew -p back test --tests com.back.boundedContexts.post.adapter.web.ApiV1PostControllerTest` - success
- `./back/gradlew -p back ktlintCheck` - success
- `./back/gradlew -p back test` - success
- `./back/gradlew -p back test --rerun-tasks` - success
- commit hook: `OpenApiContractExportTest` + `yarn contracts:check` - success

## 📸 Screenshot / API Example
- UI 변경 없음.
- API JSON shape 변경 없음. 공개 read 응답의 Cache-Control/ETag/Surrogate-Key 계약 유지.

## ⚠️ Risk & Rollback
- 예상 리스크: 공개 read cache/ETag 응답 조립 경로를 이동했기 때문에 304나 no-store 응답 헤더 회귀 가능성이 있습니다. 관련 factory 테스트와 controller integration 테스트로 방어했습니다.
- 롤백 방법: 이 PR의 merge commit을 revert하면 기존 controller 내부 조립 방식으로 돌아갑니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?

## 리뷰어 메모
- 공개 read cache/ETag 정책 이동만 포함합니다.
- DTO JSON shape, OpenAPI endpoint, write path, persistence query는 변경하지 않았습니다.
