### PR TITLE
[Fix] 게시글 업로드 stream 기반 전환

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberController.kt
@@ -311,7 +311,8 @@ class ApiV1AdmMemberController(
         val member = memberUseCase.findById(id).orElseThrow()
         val uploadRequest =
             PostImageStoragePort.UploadImageRequest(
-                bytes = file.bytes,
+                inputStream = file.inputStream,
+                contentLength = file.size,
                 contentType = file.contentType,
                 originalFilename = file.originalFilename,
             )

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapter.kt
@@ -18,10 +18,14 @@ import software.amazon.awssdk.services.s3.model.HeadBucketRequest
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.S3Exception
+import java.io.BufferedInputStream
+import java.io.InputStream
 import java.net.URI
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.UUID
@@ -103,69 +107,88 @@ class PostImageStorageAdapter(
      * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
      */
     override fun uploadPostImage(request: PostImageStoragePort.UploadImageRequest): String {
-        val client = requireClient()
-        if (request.bytes.isEmpty()) throw AppException("400-1", "이미지 파일이 비어 있습니다.")
-        if (request.bytes.size > properties.maxFileSizeBytes) {
-            throw AppException("400-1", "이미지 파일은 ${properties.maxFileSizeBytes / (1024 * 1024)}MB 이하여야 합니다.")
-        }
+        validateUploadContentLength(
+            contentLength = request.contentLength,
+            emptyMessage = "이미지 파일이 비어 있습니다.",
+            oversizedMessage = "이미지 파일은 ${properties.maxFileSizeBytes / (1024 * 1024)}MB 이하여야 합니다.",
+        )
 
-        val declaredContentType = normalizeDeclaredContentType(request.contentType)
-        val signature = request.bytes.copyOfRange(0, minOf(16, request.bytes.size))
-        val detectedType = detectImageContentType(signature)
-        if (detectedType == null || detectedType !in allowedContentTypes) {
-            throw AppException("400-1", "지원하지 않는 이미지 형식입니다.")
-        }
-
-        // Browser/OS에 따라 image/x-png 등 별칭이 전달될 수 있어 선언 타입은 정규화 후 참고한다.
-        // 단, 정규화된 선언 타입이 명확히 존재하고 감지 결과와 다르면 위장 업로드로 보고 차단한다.
-        if (declaredContentType != null &&
-            declaredContentType in allowedContentTypes &&
-            declaredContentType != detectedType
-        ) {
-            throw AppException("400-1", "지원하지 않는 이미지 형식입니다.")
-        }
-
-        val contentType = detectedType
-
-        val key = buildObjectKey(request.originalFilename)
-
+        val preparedUpload = prepareRepeatableUpload(request.inputStream, request.contentLength)
         try {
-            putObject(
-                client = client,
-                objectKey = key,
-                contentType = contentType,
-                bytes = request.bytes,
-                originalFilename = request.originalFilename,
-            )
-        } catch (e: Exception) {
-            logger.error("Post image upload failed", e)
-            throw AppException("500-1", "이미지 업로드에 실패했습니다.")
-        }
+            val signature =
+                Files.newInputStream(preparedUpload.path).use { uploadStream ->
+                    uploadStream.asResettableStream().use { resettableStream ->
+                        resettableStream.mark(IMAGE_SIGNATURE_MAX_BYTES)
+                        resettableStream.readNBytes(IMAGE_SIGNATURE_MAX_BYTES)
+                    }
+                }
 
-        return key
+            val declaredContentType = normalizeDeclaredContentType(request.contentType)
+            val detectedType = detectImageContentType(signature)
+            if (detectedType == null || detectedType !in allowedContentTypes) {
+                throw AppException("400-1", "지원하지 않는 이미지 형식입니다.")
+            }
+
+            // Browser/OS에 따라 image/x-png 등 별칭이 전달될 수 있어 선언 타입은 정규화 후 참고한다.
+            // 단, 정규화된 선언 타입이 명확히 존재하고 감지 결과와 다르면 위장 업로드로 보고 차단한다.
+            if (declaredContentType != null &&
+                declaredContentType in allowedContentTypes &&
+                declaredContentType != detectedType
+            ) {
+                throw AppException("400-1", "지원하지 않는 이미지 형식입니다.")
+            }
+
+            val key = buildObjectKey(request.originalFilename)
+            val client = requireClient()
+
+            try {
+                putObject(
+                    client = client,
+                    objectKey = key,
+                    contentType = detectedType,
+                    uploadPath = preparedUpload.path,
+                    contentLength = preparedUpload.contentLength,
+                    originalFilename = request.originalFilename,
+                )
+            } catch (e: Exception) {
+                logger.error("Post image upload failed", e)
+                throw AppException("500-1", "이미지 업로드에 실패했습니다.")
+            }
+
+            return key
+        } finally {
+            preparedUpload.deleteQuietly()
+        }
     }
 
     override fun uploadPostFile(request: PostImageStoragePort.UploadFileRequest): String {
-        val client = requireClient()
-        if (request.bytes.isEmpty()) throw AppException("400-1", "첨부 파일이 비어 있습니다.")
-        if (request.bytes.size > properties.maxFileSizeBytes) {
-            throw AppException("400-1", "첨부 파일은 ${properties.maxFileSizeBytes / (1024 * 1024)}MB 이하여야 합니다.")
-        }
+        validateUploadContentLength(
+            contentLength = request.contentLength,
+            emptyMessage = "첨부 파일이 비어 있습니다.",
+            oversizedMessage = "첨부 파일은 ${properties.maxFileSizeBytes / (1024 * 1024)}MB 이하여야 합니다.",
+        )
 
         val key = buildObjectKey(request.originalFilename)
         val contentType = normalizeDeclaredContentType(request.contentType) ?: "application/octet-stream"
 
+        val preparedUpload = prepareRepeatableUpload(request.inputStream, request.contentLength)
         try {
-            putObject(
-                client = client,
-                objectKey = key,
-                contentType = contentType,
-                bytes = request.bytes,
-                originalFilename = request.originalFilename,
-            )
-        } catch (e: Exception) {
-            logger.error("Post file upload failed", e)
-            throw AppException("500-1", "첨부 파일 업로드에 실패했습니다.")
+            val client = requireClient()
+            try {
+                putObject(
+                    client = client,
+                    objectKey = key,
+                    contentType = contentType,
+                    uploadPath = preparedUpload.path,
+                    contentLength = preparedUpload.contentLength,
+                    originalFilename = request.originalFilename,
+                )
+            } catch (e: Exception) {
+                logger.error("Post file upload failed", e)
+                throw AppException("500-1", "첨부 파일 업로드에 실패했습니다.")
+            }
+        } finally {
+            preparedUpload.deleteQuietly()
         }
 
         return key
@@ -248,7 +271,8 @@ class PostImageStorageAdapter(
         client: S3Client,
         objectKey: String,
         contentType: String,
-        bytes: ByteArray,
+        uploadPath: Path,
+        contentLength: Long,
         originalFilename: String?,
     ) {
         val metadata =
@@ -271,10 +295,67 @@ class PostImageStorageAdapter(
                 .bucket(properties.bucket)
                 .key(objectKey)
                 .contentType(contentType)
+                .contentLength(contentLength)
                 .metadata(metadata)
                 .build(),
-            RequestBody.fromBytes(bytes),
+            RequestBody.fromFile(uploadPath),
         )
+    }
+
+    private fun prepareRepeatableUpload(
+        inputStream: InputStream,
+        expectedContentLength: Long,
+    ): PreparedUpload {
+        val path = Files.createTempFile("post-upload-", ".tmp")
+        var totalBytes = 0L
+
+        try {
+            inputStream.use { source ->
+                Files.newOutputStream(path).use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        val read = source.read(buffer)
+                        if (read == -1) break
+                        totalBytes += read
+                        if (totalBytes > properties.maxFileSizeBytes) {
+                            throw AppException("400-1", "업로드 파일 크기가 허용 범위를 초과했습니다.")
+                        }
+                        output.write(buffer, 0, read)
+                    }
+                }
+            }
+
+            if (totalBytes != expectedContentLength) {
+                throw AppException("400-1", "업로드 파일 크기 정보가 올바르지 않습니다.")
+            }
+
+            return PreparedUpload(path = path, contentLength = totalBytes)
+        } catch (e: Exception) {
+            Files.deleteIfExists(path)
+            throw e
+        }
+    }
+
+    private fun validateUploadContentLength(
+        contentLength: Long,
+        emptyMessage: String,
+        oversizedMessage: String,
+    ) {
+        if (contentLength <= 0) throw AppException("400-1", emptyMessage)
+        if (contentLength > properties.maxFileSizeBytes) {
+            throw AppException("400-1", oversizedMessage)
+        }
+    }
+
+    private fun InputStream.asResettableStream(): InputStream = if (markSupported()) this else BufferedInputStream(this)
+
+    private data class PreparedUpload(
+        val path: Path,
+        val contentLength: Long,
+    ) {
+        fun deleteQuietly() {
+            runCatching { Files.deleteIfExists(path) }
+        }
     }
 
     /**
@@ -457,6 +538,7 @@ class PostImageStorageAdapter(
             )
 
         private val ENV_REFERENCE_REGEX = Regex("^\\$\\{([A-Za-z_][A-Za-z0-9_]*)(?::-(.*))?}$")
+        private const val IMAGE_SIGNATURE_MAX_BYTES = 16
     }
 
     /**

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageController.kt
@@ -78,7 +78,8 @@ class ApiV1PostImageController(
 
         val uploadRequest =
             PostImageStoragePort.UploadImageRequest(
-                bytes = file.bytes,
+                inputStream = file.inputStream,
+                contentLength = file.size,
                 contentType = file.contentType,
                 originalFilename = file.originalFilename,
             )
@@ -123,7 +124,8 @@ class ApiV1PostImageController(
 
         val uploadRequest =
             PostImageStoragePort.UploadFileRequest(
-                bytes = file.bytes,
+                inputStream = file.inputStream,
+                contentLength = file.size,
                 contentType = file.contentType,
                 originalFilename = file.originalFilename,
             )

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostImageStoragePort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostImageStoragePort.kt
@@ -3,19 +3,22 @@ package com.back.boundedContexts.post.application.port.output
 import java.io.InputStream
 
 /**
- * `PostImageStoragePort` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
+ * 게시글/프로필 이미지와 첨부파일을 외부 object storage에 저장하는 포트입니다.
+ *
+ * 업로드 요청은 `MultipartFile.bytes`의 전체 메모리 복사를 피하기 위해 stream과
+ * Spring multipart metadata의 `contentLength`를 함께 전달합니다.
  */
 interface PostImageStoragePort {
     data class UploadImageRequest(
-        val bytes: ByteArray,
+        val inputStream: InputStream,
+        val contentLength: Long,
         val contentType: String?,
         val originalFilename: String?,
     )
 
     data class UploadFileRequest(
-        val bytes: ByteArray,
+        val inputStream: InputStream,
+        val contentLength: Long,
         val contentType: String?,
         val originalFilename: String?,
     )

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapterTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapterTest.kt
@@ -1,12 +1,18 @@
 package com.back.boundedContexts.post.adapter.storage
 
+import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
 import com.back.boundedContexts.post.config.PostImageStorageProperties
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
 
+@DisplayName("PostImageStorageAdapter 테스트")
 class PostImageStorageAdapterTest {
     @Test
+    @DisplayName("post prefix 밖 object key는 storage 접근 전에 거절한다")
     fun `post object reader rejects keys outside configured post prefix before storage access`() {
+        // given
         val adapter =
             PostImageStorageAdapter(
                 PostImageStorageProperties(
@@ -15,6 +21,7 @@ class PostImageStorageAdapterTest {
                 ),
             )
 
+        // when & then
         assertThatThrownBy {
             adapter.getPostImage("cloud/1/private/2026/06/leaked.png")
         }.hasMessageContaining("400-1")
@@ -22,7 +29,9 @@ class PostImageStorageAdapterTest {
     }
 
     @Test
+    @DisplayName("post prefix 내부 object key는 정상 storage 경로로 진행한다")
     fun `post object reader keeps configured post prefix keys on the normal storage path`() {
+        // given
         val adapter =
             PostImageStorageAdapter(
                 PostImageStorageProperties(
@@ -31,9 +40,132 @@ class PostImageStorageAdapterTest {
                 ),
             )
 
+        // when & then
         assertThatThrownBy {
             adapter.getPostImage("posts/2026/06/image.png")
         }.hasMessageContaining("503-1")
             .hasMessageContaining("이미지 스토리지가 비활성화되어 있습니다.")
     }
+
+    @Test
+    @DisplayName("stream 이미지 업로드는 빈 contentLength를 storage 접근 전에 거절한다")
+    fun rejectEmptyImageUploadBeforeStorageAccess() {
+        // given
+        val adapter = disabledAdapter()
+
+        // when & then
+        assertThatThrownBy {
+            adapter.uploadPostImage(
+                PostImageStoragePort.UploadImageRequest(
+                    inputStream = ByteArrayInputStream(ByteArray(0)),
+                    contentLength = 0,
+                    contentType = "image/png",
+                    originalFilename = "empty.png",
+                ),
+            )
+        }.hasMessageContaining("400-1")
+            .hasMessageContaining("이미지 파일이 비어 있습니다.")
+    }
+
+    @Test
+    @DisplayName("stream 이미지 업로드는 크기 초과를 storage 접근 전에 거절한다")
+    fun rejectOversizedImageUploadBeforeStorageAccess() {
+        // given
+        val adapter = disabledAdapter(maxFileSizeBytes = 8)
+
+        // when & then
+        assertThatThrownBy {
+            adapter.uploadPostImage(
+                PostImageStoragePort.UploadImageRequest(
+                    inputStream = ByteArrayInputStream(pngBytes()),
+                    contentLength = 9,
+                    contentType = "image/png",
+                    originalFilename = "large.png",
+                ),
+            )
+        }.hasMessageContaining("400-1")
+            .hasMessageContaining("이미지 파일은 0MB 이하여야 합니다.")
+    }
+
+    @Test
+    @DisplayName("stream 이미지 업로드는 signature 기반 형식 검증을 유지한다")
+    fun rejectUnsupportedImageSignatureBeforeStorageAccess() {
+        // given
+        val adapter = disabledAdapter()
+
+        // when & then
+        assertThatThrownBy {
+            adapter.uploadPostImage(
+                PostImageStoragePort.UploadImageRequest(
+                    inputStream = ByteArrayInputStream("not-image".toByteArray()),
+                    contentLength = "not-image".length.toLong(),
+                    contentType = "image/png",
+                    originalFilename = "spoof.png",
+                ),
+            )
+        }.hasMessageContaining("400-1")
+            .hasMessageContaining("지원하지 않는 이미지 형식입니다.")
+    }
+
+    @Test
+    @DisplayName("stream 이미지 업로드는 실제 stream 길이와 contentLength 불일치를 거절한다")
+    fun rejectImageUploadWhenStreamLengthDiffersFromContentLength() {
+        // given
+        val adapter = disabledAdapter()
+
+        // when & then
+        assertThatThrownBy {
+            adapter.uploadPostImage(
+                PostImageStoragePort.UploadImageRequest(
+                    inputStream = ByteArrayInputStream(pngBytes()),
+                    contentLength = pngBytes().size + 1L,
+                    contentType = "image/png",
+                    originalFilename = "truncated.png",
+                ),
+            )
+        }.hasMessageContaining("400-1")
+            .hasMessageContaining("업로드 파일 크기 정보가 올바르지 않습니다.")
+    }
+
+    @Test
+    @DisplayName("stream 첨부파일 업로드는 크기 초과를 storage 접근 전에 거절한다")
+    fun rejectOversizedFileUploadBeforeStorageAccess() {
+        // given
+        val adapter = disabledAdapter(maxFileSizeBytes = 2)
+
+        // when & then
+        assertThatThrownBy {
+            adapter.uploadPostFile(
+                PostImageStoragePort.UploadFileRequest(
+                    inputStream = ByteArrayInputStream("pdf".toByteArray()),
+                    contentLength = 3,
+                    contentType = "application/pdf",
+                    originalFilename = "large.pdf",
+                ),
+            )
+        }.hasMessageContaining("400-1")
+            .hasMessageContaining("첨부 파일은 0MB 이하여야 합니다.")
+    }
+
+    private fun disabledAdapter(maxFileSizeBytes: Long = 10 * 1024 * 1024): PostImageStorageAdapter =
+        PostImageStorageAdapter(
+            PostImageStorageProperties(
+                enabled = false,
+                keyPrefix = "posts",
+                maxFileSizeBytes = maxFileSizeBytes,
+            ),
+        )
+
+    private fun pngBytes(): ByteArray =
+        byteArrayOf(
+            0x89.toByte(),
+            0x50,
+            0x4E,
+            0x47,
+            0x0D,
+            0x0A,
+            0x1A,
+            0x0A,
+            0x00,
+        )
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageControllerTest.kt
@@ -7,11 +7,15 @@ import com.back.global.storage.application.UploadedFileRetentionService
 import com.back.global.storage.domain.UploadedFilePurpose
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import org.springframework.mock.web.MockMultipartFile
+import org.springframework.web.multipart.MultipartFile
+import java.io.ByteArrayInputStream
+import java.io.InputStream
 
+@DisplayName("ApiV1PostImageController 업로드 테스트")
 class ApiV1PostImageControllerTest {
     companion object {
         @JvmStatic
@@ -37,13 +41,19 @@ class ApiV1PostImageControllerTest {
         )
 
     @Test
+    @DisplayName("게시글 이미지는 MultipartFile.bytes 복사 없이 stream으로 업로드한다")
     fun `posts images 업로드는 uploaded_file purpose를 POST_IMAGE로 저장한다`() {
-        val file = MockMultipartFile("file", "sample.png", "image/png", "png".toByteArray())
+        // given
+        val file = ByteAccessFailingMultipartFile("file", "sample.png", "image/png", pngBytes())
         postImageStorageService.nextImageKey = "posts/2026/03/sample.png"
 
+        // when
         val response = controller.uploadPostImage(file)
 
+        // then
         assertThat(response.resultCode).isEqualTo("201-1")
+        assertThat(postImageStorageService.lastImageContentLength).isEqualTo(file.size)
+        assertThat(postImageStorageService.lastImageBytes).containsExactly(*pngBytes())
         verify(uploadedFileRetentionService).registerTempUpload(
             "posts/2026/03/sample.png",
             "image/png",
@@ -53,13 +63,19 @@ class ApiV1PostImageControllerTest {
     }
 
     @Test
+    @DisplayName("게시글 첨부파일은 MultipartFile.bytes 복사 없이 stream으로 업로드한다")
     fun `posts files 업로드는 uploaded_file purpose를 POST_FILE로 저장한다`() {
-        val file = MockMultipartFile("file", "manual.pdf", "application/pdf", "pdf".toByteArray())
+        // given
+        val file = ByteAccessFailingMultipartFile("file", "manual.pdf", "application/pdf", "pdf".toByteArray())
         postImageStorageService.nextFileKey = "posts/2026/03/manual.pdf"
 
+        // when
         val response = controller.uploadPostFile(file)
 
+        // then
         assertThat(response.resultCode).isEqualTo("201-2")
+        assertThat(postImageStorageService.lastFileContentLength).isEqualTo(file.size)
+        assertThat(postImageStorageService.lastFileBytes).containsExactly(*"pdf".toByteArray())
         verify(uploadedFileRetentionService).registerTempUpload(
             "posts/2026/03/manual.pdf",
             "application/pdf",
@@ -71,10 +87,22 @@ class ApiV1PostImageControllerTest {
     private class FakePostImageStoragePort : PostImageStoragePort {
         var nextImageKey: String = "posts/placeholder/image.png"
         var nextFileKey: String = "posts/placeholder/file.bin"
+        var lastImageContentLength: Long? = null
+        var lastFileContentLength: Long? = null
+        var lastImageBytes: ByteArray = ByteArray(0)
+        var lastFileBytes: ByteArray = ByteArray(0)
 
-        override fun uploadPostImage(request: PostImageStoragePort.UploadImageRequest): String = nextImageKey
+        override fun uploadPostImage(request: PostImageStoragePort.UploadImageRequest): String {
+            lastImageContentLength = request.contentLength
+            lastImageBytes = request.inputStream.use(InputStream::readBytes)
+            return nextImageKey
+        }
 
-        override fun uploadPostFile(request: PostImageStoragePort.UploadFileRequest): String = nextFileKey
+        override fun uploadPostFile(request: PostImageStoragePort.UploadFileRequest): String {
+            lastFileContentLength = request.contentLength
+            lastFileBytes = request.inputStream.use(InputStream::readBytes)
+            return nextFileKey
+        }
 
         override fun getPostImage(objectKey: String): PostImageStoragePort.StoredObject? = null
 
@@ -84,4 +112,41 @@ class ApiV1PostImageControllerTest {
 
         override fun deletePostFile(objectKey: String) {}
     }
+
+    private class ByteAccessFailingMultipartFile(
+        private val name: String,
+        private val originalFilename: String,
+        private val contentType: String,
+        private val content: ByteArray,
+    ) : MultipartFile {
+        override fun getName(): String = name
+
+        override fun getOriginalFilename(): String = originalFilename
+
+        override fun getContentType(): String = contentType
+
+        override fun isEmpty(): Boolean = content.isEmpty()
+
+        override fun getSize(): Long = content.size.toLong()
+
+        override fun getBytes(): ByteArray =
+            throw AssertionError("controller must pass upload content as stream without reading MultipartFile.bytes")
+
+        override fun getInputStream(): InputStream = ByteArrayInputStream(content)
+
+        override fun transferTo(dest: java.io.File) = dest.writeBytes(content)
+    }
+
+    private fun pngBytes(): ByteArray =
+        byteArrayOf(
+            0x89.toByte(),
+            0x50,
+            0x4E,
+            0x47,
+            0x0D,
+            0x0A,
+            0x1A,
+            0x0A,
+            0x00,
+        )
 }


### PR DESCRIPTION
## 관련 이슈

close #845

## 작업 배경

- 게시글 이미지/첨부파일 및 관리자 프로필 이미지 업로드 경로가 `MultipartFile.bytes`로 전체 파일을 `ByteArray` 복사해 스토리지 포트로 전달하고 있었다.
- 파일 크기 제한은 있지만 동시 업로드 시 요청 처리 중 메모리 피크가 커질 수 있어 stream 기반 계약으로 전환한다.
- Codex CLI review에서 S3 retry 시 `fromInputStream` 본문 재생 가능성 리스크가 확인돼, 스토리지 어댑터 내부에서는 bounded temp file로 spool한 뒤 retry 가능한 `RequestBody.fromFile`을 사용한다.

## 작업 내용

- `PostImageStoragePort` 업로드 요청을 `ByteArray` 대신 `InputStream` + `contentLength` 기반으로 변경했다.
- `ApiV1PostImageController`와 `ApiV1AdmMemberController`에서 `file.bytes` 호출을 제거하고 `file.inputStream`/`file.size`를 전달하도록 변경했다.
- `PostImageStorageAdapter`가 `contentLength`로 빈 파일/크기 초과를 먼저 검증하고, 실제 stream 길이와 선언 길이 불일치를 거절하도록 보강했다.
- S3 업로드 본문은 bounded temp file로 spool해 이미지 signature 검증과 SDK retry replayability를 함께 보장하도록 변경했다.
- 컨트롤러 테스트에 `MultipartFile.bytes` 접근 시 실패하는 fixture를 추가해 stream 전달 계약을 회귀 테스트로 고정했다.
- 스토리지 어댑터 테스트에 빈 파일, 크기 초과, unsupported signature, contentLength 불일치 케이스를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back test --tests com.back.boundedContexts.post.adapter.web.ApiV1PostImageControllerTest --tests com.back.boundedContexts.post.adapter.storage.PostImageStorageAdapterTest` 성공
  - `./back/gradlew -p back ktlintCheck` 성공
  - `./back/gradlew -p back test` 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks` 성공
  - `codex review --base origin/main --title "[Fix] 게시글 업로드 stream 기반 전환"` 최초 리뷰에서 S3 retry replayability 지적 확인
  - `codex review --base origin/main --title "[Fix] 게시글 업로드 stream 기반 전환"` 재리뷰에서 추가 지적 없음 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `PostImageStoragePort` 업로드 요청 계약 변경
  - `PostImageStorageAdapter.prepareRepeatableUpload`의 bounded temp file spool 및 length 검증
  - `RequestBody.fromFile(uploadPath)` 사용으로 S3 retry 재생 가능성을 유지한 부분
  - 컨트롤러 테스트의 `ByteAccessFailingMultipartFile` 회귀 가드

## 리스크

- `PostImageStoragePort` 구현/호출부 계약이 변경된다. 현재 repository 내 호출부는 게시글 이미지/첨부파일 및 관리자 프로필 이미지 업로드 경로만 확인해 함께 수정했다.
- 업로드 중 임시 파일을 사용하므로 서버의 temp directory 쓰기 권한과 여유 공간이 필요하다. 파일 크기 상한과 length 검증으로 무제한 spool은 차단한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
