### PR TITLE
[Refactor] 인증 쿠키 이름 상수화

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthController.kt
@@ -15,6 +15,7 @@ import com.back.global.exception.application.AppException
 import com.back.global.rsData.RsData
 import com.back.global.security.application.AuthIpSecurityService
 import com.back.global.security.application.AuthSecurityEventService
+import com.back.global.security.config.AuthCookieNames
 import com.back.global.security.domain.SecurityUser
 import com.back.global.web.application.AuthCookieService
 import com.back.global.web.application.ClientIpResolver
@@ -174,7 +175,7 @@ class ApiV1AuthController(
     fun logout(request: HttpServletRequest): RsData<Void> {
         val sessionKeyCookie =
             request.cookies
-                ?.firstOrNull { it.name == "sessionKey" }
+                ?.firstOrNull { it.name == AuthCookieNames.SESSION_KEY }
                 ?.value
                 ?.trim()
                 .orEmpty()

--- a/back/src/main/kotlin/com/back/global/security/config/ApiMutationCsrfGuardFilter.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/ApiMutationCsrfGuardFilter.kt
@@ -45,7 +45,10 @@ class ApiMutationCsrfGuardFilter(
 
     private fun hasAuthCookie(request: HttpServletRequest): Boolean =
         request.cookies
-            ?.any { cookie -> cookie.name in AUTH_COOKIE_NAMES && cookie.value.isNotBlank() }
+            ?.any { cookie ->
+                cookie.name in AuthCookieNames.MUTATION_CSRF_GUARD_COOKIE_NAMES &&
+                    cookie.value.isNotBlank()
+            }
             ?: false
 
     private fun requestPath(request: HttpServletRequest): String {
@@ -74,7 +77,6 @@ class ApiMutationCsrfGuardFilter(
         const val CSRF_PREFLIGHT_VALUE = "1"
 
         private val SAFE_METHODS = setOf("GET", "HEAD")
-        private val AUTH_COOKIE_NAMES = setOf("apiKey", "accessToken", "sessionKey")
         private val API_PATH_REGEX = Regex("^/[^/]+/api/.*")
     }
 }

--- a/back/src/main/kotlin/com/back/global/security/config/AuthCookieNames.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/AuthCookieNames.kt
@@ -1,0 +1,14 @@
+package com.back.global.security.config
+
+object AuthCookieNames {
+    const val API_KEY = "apiKey"
+    const val ACCESS_TOKEN = "accessToken"
+    const val REFRESH_TOKEN = "refreshToken"
+    const val SESSION_KEY = "sessionKey"
+
+    val AUTHENTICATION_COOKIE_NAMES: Set<String> =
+        setOf(API_KEY, ACCESS_TOKEN, REFRESH_TOKEN, SESSION_KEY)
+
+    val MUTATION_CSRF_GUARD_COOKIE_NAMES: Set<String> =
+        setOf(API_KEY, ACCESS_TOKEN, SESSION_KEY)
+}

--- a/back/src/main/kotlin/com/back/global/security/config/AuthTokenExtractor.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/AuthTokenExtractor.kt
@@ -14,15 +14,15 @@ class AuthTokenExtractor(
 ) {
     fun extract(): ExtractedAuthTokens {
         val headerAuthorization = rq.getHeader(HttpHeaders.AUTHORIZATION, "").orEmpty()
-        val sessionKey = rq.getCookieValue("sessionKey", "").orEmpty()
-        val refreshToken = rq.getCookieValue("refreshToken", "").orEmpty()
+        val sessionKey = rq.getCookieValue(AuthCookieNames.SESSION_KEY, "").orEmpty()
+        val refreshToken = rq.getCookieValue(AuthCookieNames.REFRESH_TOKEN, "").orEmpty()
 
         return if (headerAuthorization.isNotBlank()) {
             extractBearerTokens(headerAuthorization, sessionKey, refreshToken)
         } else {
             ExtractedAuthTokens(
-                apiKey = rq.getCookieValue("apiKey", "").orEmpty(),
-                accessToken = rq.getCookieValue("accessToken", "").orEmpty(),
+                apiKey = rq.getCookieValue(AuthCookieNames.API_KEY, "").orEmpty(),
+                accessToken = rq.getCookieValue(AuthCookieNames.ACCESS_TOKEN, "").orEmpty(),
                 sessionKey = sessionKey,
                 refreshToken = refreshToken,
             )

--- a/back/src/main/kotlin/com/back/global/web/application/AuthCookieService.kt
+++ b/back/src/main/kotlin/com/back/global/web/application/AuthCookieService.kt
@@ -1,5 +1,6 @@
 package com.back.global.web.application
 
+import com.back.global.security.config.AuthCookieNames
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
@@ -8,10 +9,11 @@ import org.springframework.stereotype.Component
 import java.time.Duration
 
 /**
- * AuthCookieService는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
+ * 인증 쿠키 발급/갱신/만료를 같은 이름 정책으로 처리합니다.
+ *
+ * 표준 domain cookie를 발급하기 전 과거 host-only cookie를 먼저 만료해
+ * 브라우저에 같은 이름의 auth cookie가 중복으로 남지 않게 합니다.
  */
-
 @Component
 class AuthCookieService(
     private val rq: Rq,
@@ -30,11 +32,11 @@ class AuthCookieService(
         sessionKey: String? = null,
         rememberLoginEnabled: Boolean = true,
     ) {
-        issueCookie("apiKey", apiKey, apiKeyCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
-        issueCookie("accessToken", accessToken, accessTokenCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
-        issueCookie("refreshToken", refreshToken, refreshTokenCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
+        issueCookie(AuthCookieNames.API_KEY, apiKey, apiKeyCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
+        issueCookie(AuthCookieNames.ACCESS_TOKEN, accessToken, accessTokenCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
+        issueCookie(AuthCookieNames.REFRESH_TOKEN, refreshToken, refreshTokenCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
         if (!sessionKey.isNullOrBlank()) {
-            issueCookie("sessionKey", sessionKey, apiKeyCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
+            issueCookie(AuthCookieNames.SESSION_KEY, sessionKey, apiKeyCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
         }
     }
 
@@ -45,24 +47,26 @@ class AuthCookieService(
         refreshToken: String? = null,
     ) {
         issueCookie(
-            "accessToken",
+            AuthCookieNames.ACCESS_TOKEN,
             accessToken,
             accessTokenCookieMaxAgeSeconds,
             sessionOnly = !rememberLoginEnabled,
         )
         if (!refreshToken.isNullOrBlank()) {
-            issueCookie("refreshToken", refreshToken, refreshTokenCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
+            issueCookie(
+                AuthCookieNames.REFRESH_TOKEN,
+                refreshToken,
+                refreshTokenCookieMaxAgeSeconds,
+                sessionOnly = !rememberLoginEnabled,
+            )
         }
         if (!sessionKey.isNullOrBlank()) {
-            issueCookie("sessionKey", sessionKey, apiKeyCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
+            issueCookie(AuthCookieNames.SESSION_KEY, sessionKey, apiKeyCookieMaxAgeSeconds, sessionOnly = !rememberLoginEnabled)
         }
     }
 
     fun expireAuthCookies() {
-        expireCookie("apiKey")
-        expireCookie("accessToken")
-        expireCookie("refreshToken")
-        expireCookie("sessionKey")
+        AuthCookieNames.AUTHENTICATION_COOKIE_NAMES.forEach(::expireCookie)
     }
 
     private fun issueCookie(
@@ -82,10 +86,6 @@ class AuthCookieService(
         rq.deleteCookie(name)
     }
 
-    /**
-     * 쿠키 속성을 정책에 맞게 설정하고 보안 플래그를 강제합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     private fun expireHostOnlyCookie(name: String) {
         val hostOnlyCookie =
             ResponseCookie

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
@@ -4,6 +4,7 @@ import com.back.boundedContexts.member.application.service.AuthTokenService
 import com.back.boundedContexts.member.application.service.LoginAttemptService
 import com.back.boundedContexts.member.application.service.MemberApplicationService
 import com.back.boundedContexts.member.subContexts.session.adapter.persistence.MemberSessionRepository
+import com.back.global.security.config.AuthCookieNames
 import com.back.support.BaseControllerIntegrationTest
 import jakarta.servlet.http.Cookie
 import org.assertj.core.api.Assertions.assertThat
@@ -81,28 +82,28 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
             val result = resultActions.andReturn()
 
             val apiKeyCookie =
-                result.response.cookies.firstOrNull { it.name == "apiKey" && it.value == member.apiKey }
+                result.response.cookies.firstOrNull { it.name == AuthCookieNames.API_KEY && it.value == member.apiKey }
             assertThat(apiKeyCookie).isNotNull
             assertThat(apiKeyCookie!!.value).isEqualTo(member.apiKey)
             assertThat(apiKeyCookie.path).isEqualTo("/")
             assertThat(apiKeyCookie.isHttpOnly).isTrue
 
             val accessTokenCookie =
-                result.response.cookies.firstOrNull { it.name == "accessToken" && it.value.isNotBlank() }
+                result.response.cookies.firstOrNull { it.name == AuthCookieNames.ACCESS_TOKEN && it.value.isNotBlank() }
             assertThat(accessTokenCookie).isNotNull
             assertThat(accessTokenCookie!!.value).isNotBlank()
             assertThat(accessTokenCookie.path).isEqualTo("/")
             assertThat(accessTokenCookie.isHttpOnly).isTrue
 
             val refreshTokenCookie =
-                result.response.cookies.firstOrNull { it.name == "refreshToken" && it.value.isNotBlank() }
+                result.response.cookies.firstOrNull { it.name == AuthCookieNames.REFRESH_TOKEN && it.value.isNotBlank() }
             assertThat(refreshTokenCookie).isNotNull
             assertThat(refreshTokenCookie!!.value).isNotBlank()
             assertThat(refreshTokenCookie.path).isEqualTo("/")
             assertThat(refreshTokenCookie.isHttpOnly).isTrue
 
             val sessionKeyCookie =
-                result.response.cookies.firstOrNull { it.name == "sessionKey" && it.value.isNotBlank() }
+                result.response.cookies.firstOrNull { it.name == AuthCookieNames.SESSION_KEY && it.value.isNotBlank() }
             assertThat(sessionKeyCookie).isNotNull
             val activeSession = memberSessionRepository.findBySessionKeyAndRevokedAtIsNull(sessionKeyCookie!!.value)
             assertThat(activeSession).isNotNull
@@ -166,15 +167,15 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                         status { isOk() }
                     }.andReturn()
 
-            val apiKeyCookie = result.response.getCookie("apiKey")
+            val apiKeyCookie = result.response.getCookie(AuthCookieNames.API_KEY)
             val issuedApiKeyCookie =
-                result.response.cookies.firstOrNull { it.name == "apiKey" && it.value.isNotBlank() }
+                result.response.cookies.firstOrNull { it.name == AuthCookieNames.API_KEY && it.value.isNotBlank() }
             val issuedAccessTokenCookie =
-                result.response.cookies.firstOrNull { it.name == "accessToken" && it.value.isNotBlank() }
+                result.response.cookies.firstOrNull { it.name == AuthCookieNames.ACCESS_TOKEN && it.value.isNotBlank() }
             val issuedRefreshTokenCookie =
-                result.response.cookies.firstOrNull { it.name == "refreshToken" && it.value.isNotBlank() }
+                result.response.cookies.firstOrNull { it.name == AuthCookieNames.REFRESH_TOKEN && it.value.isNotBlank() }
             val issuedSessionKeyCookie =
-                result.response.cookies.firstOrNull { it.name == "sessionKey" && it.value.isNotBlank() }
+                result.response.cookies.firstOrNull { it.name == AuthCookieNames.SESSION_KEY && it.value.isNotBlank() }
 
             assertThat(apiKeyCookie).isNotNull
             assertThat(issuedApiKeyCookie).isNotNull
@@ -215,10 +216,17 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
             val issuedCookies =
                 loginResult.response.cookies.filter {
-                    it.name in setOf("apiKey", "accessToken", "refreshToken", "sessionKey") && it.value.isNotBlank()
+                    it.name in AuthCookieNames.AUTHENTICATION_COOKIE_NAMES &&
+                        it.value.isNotBlank()
                 }
 
-            assertThat(issuedCookies.map { it.name }).contains("apiKey", "accessToken", "refreshToken", "sessionKey")
+            assertThat(issuedCookies.map { it.name })
+                .contains(
+                    AuthCookieNames.API_KEY,
+                    AuthCookieNames.ACCESS_TOKEN,
+                    AuthCookieNames.REFRESH_TOKEN,
+                    AuthCookieNames.SESSION_KEY,
+                )
 
             mvc
                 .get("/member/api/v1/auth/session") {
@@ -259,11 +267,11 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                     }.andReturn()
 
             val firstApiKeyCookie =
-                firstLogin.response.cookies.firstOrNull { it.name == "apiKey" && it.value.isNotBlank() }
+                firstLogin.response.cookies.firstOrNull { it.name == AuthCookieNames.API_KEY && it.value.isNotBlank() }
             val firstAccessTokenCookie =
-                firstLogin.response.cookies.firstOrNull { it.name == "accessToken" && it.value.isNotBlank() }
+                firstLogin.response.cookies.firstOrNull { it.name == AuthCookieNames.ACCESS_TOKEN && it.value.isNotBlank() }
             val firstSessionKeyCookie =
-                firstLogin.response.cookies.firstOrNull { it.name == "sessionKey" && it.value.isNotBlank() }
+                firstLogin.response.cookies.firstOrNull { it.name == AuthCookieNames.SESSION_KEY && it.value.isNotBlank() }
             assertThat(firstApiKeyCookie).isNotNull
             assertThat(firstAccessTokenCookie).isNotNull
             assertThat(firstSessionKeyCookie).isNotNull
@@ -284,15 +292,15 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                     }.andReturn()
 
             val secondApiKeyCookie =
-                secondLogin.response.cookies.firstOrNull { it.name == "apiKey" && it.value.isNotBlank() }
+                secondLogin.response.cookies.firstOrNull { it.name == AuthCookieNames.API_KEY && it.value.isNotBlank() }
             assertThat(secondApiKeyCookie).isNotNull
             assertThat(secondApiKeyCookie!!.value).isEqualTo(firstApiKeyCookie!!.value)
 
             mvc
                 .get("/member/api/v1/auth/me") {
-                    cookie(Cookie("apiKey", firstApiKeyCookie.value))
-                    cookie(Cookie("accessToken", firstAccessTokenCookie!!.value))
-                    cookie(Cookie("sessionKey", firstSessionKeyCookie!!.value))
+                    cookie(Cookie(AuthCookieNames.API_KEY, firstApiKeyCookie.value))
+                    cookie(Cookie(AuthCookieNames.ACCESS_TOKEN, firstAccessTokenCookie!!.value))
+                    cookie(Cookie(AuthCookieNames.SESSION_KEY, firstSessionKeyCookie!!.value))
                 }.andExpect {
                     status { isOk() }
                     jsonPath("$.id") { value(member.id) }
@@ -458,7 +466,7 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                         status { isOk() }
                     }.andReturn()
             val sessionKeyCookie =
-                loginResponse.response.cookies.firstOrNull { it.name == "sessionKey" && it.value.isNotBlank() }
+                loginResponse.response.cookies.firstOrNull { it.name == AuthCookieNames.SESSION_KEY && it.value.isNotBlank() }
             assertThat(sessionKeyCookie).isNotNull
             val resultActions =
                 mvc
@@ -475,28 +483,28 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
             val result = resultActions.andReturn()
 
-            val apiKeyCookie: Cookie? = result.response.getCookie("apiKey")
+            val apiKeyCookie: Cookie? = result.response.getCookie(AuthCookieNames.API_KEY)
             assertThat(apiKeyCookie).isNotNull
             assertThat(apiKeyCookie!!.value).isEmpty()
             assertThat(apiKeyCookie.maxAge).isEqualTo(0)
             assertThat(apiKeyCookie.path).isEqualTo("/")
             assertThat(apiKeyCookie.isHttpOnly).isTrue
 
-            val accessTokenCookie: Cookie? = result.response.getCookie("accessToken")
+            val accessTokenCookie: Cookie? = result.response.getCookie(AuthCookieNames.ACCESS_TOKEN)
             assertThat(accessTokenCookie).isNotNull
             assertThat(accessTokenCookie!!.value).isEmpty()
             assertThat(accessTokenCookie.maxAge).isEqualTo(0)
             assertThat(accessTokenCookie.path).isEqualTo("/")
             assertThat(accessTokenCookie.isHttpOnly).isTrue
 
-            val refreshTokenCookie: Cookie? = result.response.getCookie("refreshToken")
+            val refreshTokenCookie: Cookie? = result.response.getCookie(AuthCookieNames.REFRESH_TOKEN)
             assertThat(refreshTokenCookie).isNotNull
             assertThat(refreshTokenCookie!!.value).isEmpty()
             assertThat(refreshTokenCookie.maxAge).isEqualTo(0)
             assertThat(refreshTokenCookie.path).isEqualTo("/")
             assertThat(refreshTokenCookie.isHttpOnly).isTrue
 
-            val expiredSessionKeyCookie: Cookie? = result.response.getCookie("sessionKey")
+            val expiredSessionKeyCookie: Cookie? = result.response.getCookie(AuthCookieNames.SESSION_KEY)
             assertThat(expiredSessionKeyCookie).isNotNull
             assertThat(expiredSessionKeyCookie!!.value).isEmpty()
             assertThat(expiredSessionKeyCookie.maxAge).isEqualTo(0)
@@ -573,15 +581,15 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
             mvc
                 .get("/member/api/v1/auth/me") {
-                    cookie(Cookie("apiKey", member.apiKey))
+                    cookie(Cookie(AuthCookieNames.API_KEY, member.apiKey))
                 }.andExpect {
                     status { isUnauthorized() }
                     jsonPath("$.resultCode") { value("401-8") }
                     jsonPath("$.msg") { value("세션이 만료되었습니다. 다시 로그인해주세요.") }
-                    cookie { maxAge("apiKey", 0) }
-                    cookie { maxAge("accessToken", 0) }
-                    cookie { maxAge("refreshToken", 0) }
-                    cookie { maxAge("sessionKey", 0) }
+                    cookie { maxAge(AuthCookieNames.API_KEY, 0) }
+                    cookie { maxAge(AuthCookieNames.ACCESS_TOKEN, 0) }
+                    cookie { maxAge(AuthCookieNames.REFRESH_TOKEN, 0) }
+                    cookie { maxAge(AuthCookieNames.SESSION_KEY, 0) }
                 }
         }
 
@@ -619,13 +627,13 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                     email = "session-bound-rotate-user@example.com",
                 )
             val authCookies = loginAuthCookies(member.email!!)
-            val sessionKeyCookie = requireAuthCookie(authCookies, "sessionKey")
-            val refreshTokenCookie = requireAuthCookie(authCookies, "refreshToken")
+            val sessionKeyCookie = requireAuthCookie(authCookies, AuthCookieNames.SESSION_KEY)
+            val refreshTokenCookie = requireAuthCookie(authCookies, AuthCookieNames.REFRESH_TOKEN)
 
             val resultActions =
                 mvc
                     .get("/member/api/v1/auth/me") {
-                        cookie(Cookie("accessToken", "wrong-access-token"))
+                        cookie(Cookie(AuthCookieNames.ACCESS_TOKEN, "wrong-access-token"))
                         cookie(refreshTokenCookie)
                         cookie(sessionKeyCookie)
                     }.andExpect {
@@ -644,9 +652,9 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
             val result = resultActions.andReturn()
             val accessTokenCookie =
-                result.response.cookies.firstOrNull { it.name == "accessToken" && it.value.isNotBlank() }
+                result.response.cookies.firstOrNull { it.name == AuthCookieNames.ACCESS_TOKEN && it.value.isNotBlank() }
             val rotatedRefreshTokenCookie =
-                result.response.cookies.firstOrNull { it.name == "refreshToken" && it.value.isNotBlank() }
+                result.response.cookies.firstOrNull { it.name == AuthCookieNames.REFRESH_TOKEN && it.value.isNotBlank() }
 
             assertThat(accessTokenCookie).isNotNull
             assertThat(accessTokenCookie!!.value).isNotBlank()
@@ -672,12 +680,12 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                     email = "session-bound-reuse-user@example.com",
                 )
             val authCookies = loginAuthCookies(member.email!!)
-            val sessionKeyCookie = requireAuthCookie(authCookies, "sessionKey")
-            val staleRefreshTokenCookie = requireAuthCookie(authCookies, "refreshToken")
+            val sessionKeyCookie = requireAuthCookie(authCookies, AuthCookieNames.SESSION_KEY)
+            val staleRefreshTokenCookie = requireAuthCookie(authCookies, AuthCookieNames.REFRESH_TOKEN)
 
             mvc
                 .get("/member/api/v1/auth/me") {
-                    cookie(Cookie("accessToken", "wrong-access-token"))
+                    cookie(Cookie(AuthCookieNames.ACCESS_TOKEN, "wrong-access-token"))
                     cookie(staleRefreshTokenCookie)
                     cookie(sessionKeyCookie)
                 }.andExpect {
@@ -686,17 +694,17 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
             mvc
                 .get("/member/api/v1/auth/me") {
-                    cookie(Cookie("accessToken", "wrong-access-token"))
+                    cookie(Cookie(AuthCookieNames.ACCESS_TOKEN, "wrong-access-token"))
                     cookie(staleRefreshTokenCookie)
                     cookie(sessionKeyCookie)
                 }.andExpect {
                     status { isUnauthorized() }
                     jsonPath("$.resultCode") { value("401-8") }
                     jsonPath("$.msg") { value("세션이 만료되었습니다. 다시 로그인해주세요.") }
-                    cookie { maxAge("apiKey", 0) }
-                    cookie { maxAge("accessToken", 0) }
-                    cookie { maxAge("refreshToken", 0) }
-                    cookie { maxAge("sessionKey", 0) }
+                    cookie { maxAge(AuthCookieNames.API_KEY, 0) }
+                    cookie { maxAge(AuthCookieNames.ACCESS_TOKEN, 0) }
+                    cookie { maxAge(AuthCookieNames.REFRESH_TOKEN, 0) }
+                    cookie { maxAge(AuthCookieNames.SESSION_KEY, 0) }
                 }
 
             val revokedSession = memberSessionRepository.findBySessionKey(sessionKeyCookie.value)
@@ -716,9 +724,9 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                     email = "session-bound-bearer-user@example.com",
                 )
             val authCookies = loginAuthCookies(member.email!!)
-            val apiKeyCookie = requireAuthCookie(authCookies, "apiKey")
-            val accessTokenCookie = requireAuthCookie(authCookies, "accessToken")
-            val sessionKeyCookie = requireAuthCookie(authCookies, "sessionKey")
+            val apiKeyCookie = requireAuthCookie(authCookies, AuthCookieNames.API_KEY)
+            val accessTokenCookie = requireAuthCookie(authCookies, AuthCookieNames.ACCESS_TOKEN)
+            val sessionKeyCookie = requireAuthCookie(authCookies, AuthCookieNames.SESSION_KEY)
 
             val resultActions =
                 mvc
@@ -741,7 +749,7 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
             val result = resultActions.andReturn()
 
-            assertThat(result.response.getCookie("accessToken")).isNull()
+            assertThat(result.response.getCookie(AuthCookieNames.ACCESS_TOKEN)).isNull()
             assertThat(result.response.getHeader(HttpHeaders.AUTHORIZATION)).isNull()
         }
 
@@ -757,10 +765,10 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                     status { isUnauthorized() }
                     jsonPath("$.resultCode") { value("401-8") }
                     jsonPath("$.msg") { value("세션이 만료되었습니다. 다시 로그인해주세요.") }
-                    cookie { maxAge("apiKey", 0) }
-                    cookie { maxAge("accessToken", 0) }
-                    cookie { maxAge("refreshToken", 0) }
-                    cookie { maxAge("sessionKey", 0) }
+                    cookie { maxAge(AuthCookieNames.API_KEY, 0) }
+                    cookie { maxAge(AuthCookieNames.ACCESS_TOKEN, 0) }
+                    cookie { maxAge(AuthCookieNames.REFRESH_TOKEN, 0) }
+                    cookie { maxAge(AuthCookieNames.SESSION_KEY, 0) }
                 }
         }
 
@@ -792,11 +800,11 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                     }.andReturn()
 
             val apiKeyCookie =
-                loginResponse.response.cookies.firstOrNull { it.name == "apiKey" && it.value.isNotBlank() }
+                loginResponse.response.cookies.firstOrNull { it.name == AuthCookieNames.API_KEY && it.value.isNotBlank() }
             val accessTokenCookie =
-                loginResponse.response.cookies.firstOrNull { it.name == "accessToken" && it.value.isNotBlank() }
+                loginResponse.response.cookies.firstOrNull { it.name == AuthCookieNames.ACCESS_TOKEN && it.value.isNotBlank() }
             val sessionKeyCookie =
-                loginResponse.response.cookies.firstOrNull { it.name == "sessionKey" && it.value.isNotBlank() }
+                loginResponse.response.cookies.firstOrNull { it.name == AuthCookieNames.SESSION_KEY && it.value.isNotBlank() }
             assertThat(apiKeyCookie).isNotNull
             assertThat(accessTokenCookie).isNotNull
             assertThat(sessionKeyCookie).isNotNull
@@ -812,10 +820,10 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                     jsonPath("$.resultCode") { value("401-7") }
                     jsonPath("$.msg") { value("IP 보안 검증에 실패했습니다. 다시 로그인해주세요.") }
                 }.andExpect {
-                    cookie { maxAge("apiKey", 0) }
-                    cookie { maxAge("accessToken", 0) }
-                    cookie { maxAge("refreshToken", 0) }
-                    cookie { maxAge("sessionKey", 0) }
+                    cookie { maxAge(AuthCookieNames.API_KEY, 0) }
+                    cookie { maxAge(AuthCookieNames.ACCESS_TOKEN, 0) }
+                    cookie { maxAge(AuthCookieNames.REFRESH_TOKEN, 0) }
+                    cookie { maxAge(AuthCookieNames.SESSION_KEY, 0) }
                 }
         }
 
@@ -849,11 +857,11 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                     }.andReturn()
 
             val apiKeyCookie =
-                loginResponse.response.cookies.firstOrNull { it.name == "apiKey" && it.value.isNotBlank() }
+                loginResponse.response.cookies.firstOrNull { it.name == AuthCookieNames.API_KEY && it.value.isNotBlank() }
             val accessTokenCookie =
-                loginResponse.response.cookies.firstOrNull { it.name == "accessToken" && it.value.isNotBlank() }
+                loginResponse.response.cookies.firstOrNull { it.name == AuthCookieNames.ACCESS_TOKEN && it.value.isNotBlank() }
             val sessionKeyCookie =
-                loginResponse.response.cookies.firstOrNull { it.name == "sessionKey" && it.value.isNotBlank() }
+                loginResponse.response.cookies.firstOrNull { it.name == AuthCookieNames.SESSION_KEY && it.value.isNotBlank() }
             assertThat(apiKeyCookie).isNotNull
             assertThat(accessTokenCookie).isNotNull
             assertThat(sessionKeyCookie).isNotNull
@@ -889,7 +897,10 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
             }.andReturn()
             .response
             .cookies
-            .filter { it.name in setOf("apiKey", "accessToken", "refreshToken", "sessionKey") && it.value.isNotBlank() }
+            .filter {
+                it.name in AuthCookieNames.AUTHENTICATION_COOKIE_NAMES &&
+                    it.value.isNotBlank()
+            }
 
     private fun requireAuthCookie(
         cookies: List<Cookie>,

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerWebMvcTest.kt
@@ -2,6 +2,7 @@ package com.back.boundedContexts.member.adapter.web
 
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.dto.MemberWithUsernameDto
+import com.back.global.security.config.AuthCookieNames
 import com.back.support.BaseMemberControllerWebMvcTest
 import jakarta.servlet.http.Cookie
 import org.hamcrest.Matchers.startsWith
@@ -37,8 +38,8 @@ class ApiV1MemberControllerWebMvcTest : BaseMemberControllerWebMvcTest() {
 
             mvc
                 .get("/member/api/v1/members/adminProfile") {
-                    cookie(Cookie("apiKey", "invalid-api-key"))
-                    cookie(Cookie("accessToken", "invalid-access-token"))
+                    cookie(Cookie(AuthCookieNames.API_KEY, "invalid-api-key"))
+                    cookie(Cookie(AuthCookieNames.ACCESS_TOKEN, "invalid-access-token"))
                     header(HttpHeaders.AUTHORIZATION, "Bearer invalid-api-key invalid-access-token")
                 }.andExpect {
                     status { isOk() }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostCommentControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostCommentControllerTest.kt
@@ -5,6 +5,7 @@ import com.back.boundedContexts.member.subContexts.session.application.port.inpu
 import com.back.boundedContexts.post.application.service.PostApplicationService
 import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostComment
+import com.back.global.security.config.AuthCookieNames
 import com.back.standard.extensions.getOrThrow
 import com.back.support.BaseControllerIntegrationTest
 import jakarta.servlet.http.Cookie
@@ -91,8 +92,8 @@ class ApiV1PostCommentControllerTest : BaseControllerIntegrationTest() {
         fun `댓글 목록 조회는 잘못된 인증 정보가 있어도 정상 반환된다`() {
             mvc
                 .get("/post/api/v1/posts/${post.id}/comments") {
-                    cookie(Cookie("apiKey", "invalid-api-key"))
-                    cookie(Cookie("accessToken", "invalid-access-token"))
+                    cookie(Cookie(AuthCookieNames.API_KEY, "invalid-api-key"))
+                    cookie(Cookie(AuthCookieNames.ACCESS_TOKEN, "invalid-access-token"))
                     header(HttpHeaders.AUTHORIZATION, "Bearer invalid-api-key invalid-access-token")
                 }.andExpect {
                     status { isOk() }
@@ -129,9 +130,9 @@ class ApiV1PostCommentControllerTest : BaseControllerIntegrationTest() {
 
             mvc
                 .get("/post/api/v1/posts/${privatePost.id}/comments") {
-                    cookie(Cookie("apiKey", admin.apiKey))
-                    cookie(Cookie("accessToken", accessToken))
-                    cookie(Cookie("sessionKey", session.sessionKey))
+                    cookie(Cookie(AuthCookieNames.API_KEY, admin.apiKey))
+                    cookie(Cookie(AuthCookieNames.ACCESS_TOKEN, accessToken))
+                    cookie(Cookie(AuthCookieNames.SESSION_KEY, session.sessionKey))
                 }.andExpect {
                     status { isOk() }
                     match(handler().handlerType(ApiV1PostCommentController::class.java))
@@ -429,5 +430,8 @@ class ApiV1PostCommentControllerTest : BaseControllerIntegrationTest() {
             }.andReturn()
             .response
             .cookies
-            .filter { it.name in setOf("apiKey", "accessToken", "sessionKey") && it.value.isNotBlank() }
+            .filter {
+                it.name in AuthCookieNames.MUTATION_CSRF_GUARD_COOKIE_NAMES &&
+                    it.value.isNotBlank()
+            }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostControllerTest.kt
@@ -5,6 +5,7 @@ import com.back.boundedContexts.post.application.service.PostApplicationService
 import com.back.boundedContexts.post.application.service.PostHitDedupService
 import com.back.boundedContexts.post.application.service.PostQueryCacheNames
 import com.back.boundedContexts.post.dto.PublicPostDetailSnapshotCacheDto
+import com.back.global.security.config.AuthCookieNames
 import com.back.standard.dto.post.type1.PostSearchSortType1
 import com.back.standard.extensions.getOrThrow
 import com.back.support.BaseControllerIntegrationTest
@@ -403,8 +404,8 @@ class ApiV1PostControllerTest : BaseControllerIntegrationTest() {
         fun `공개 글 목록 조회는 잘못된 인증 정보가 있어도 정상 반환된다`() {
             mvc
                 .get("/post/api/v1/posts") {
-                    cookie(Cookie("apiKey", "invalid-api-key"))
-                    cookie(Cookie("accessToken", "invalid-access-token"))
+                    cookie(Cookie(AuthCookieNames.API_KEY, "invalid-api-key"))
+                    cookie(Cookie(AuthCookieNames.ACCESS_TOKEN, "invalid-access-token"))
                     header(HttpHeaders.AUTHORIZATION, "Bearer invalid-api-key invalid-access-token")
                 }.andExpect {
                     status { isOk() }
@@ -419,8 +420,8 @@ class ApiV1PostControllerTest : BaseControllerIntegrationTest() {
                 .get("/post/api/v1/posts/feed/cursor") {
                     param("sort", "CREATED_AT")
                     param("pageSize", "24")
-                    cookie(Cookie("apiKey", "invalid-api-key"))
-                    cookie(Cookie("accessToken", "invalid-access-token"))
+                    cookie(Cookie(AuthCookieNames.API_KEY, "invalid-api-key"))
+                    cookie(Cookie(AuthCookieNames.ACCESS_TOKEN, "invalid-access-token"))
                     header(HttpHeaders.AUTHORIZATION, "Bearer invalid-api-key invalid-access-token")
                 }.andExpect {
                     status { isOk() }
@@ -449,8 +450,8 @@ class ApiV1PostControllerTest : BaseControllerIntegrationTest() {
                     param("sort", "CREATED_AT")
                     param("tag", "커서공개")
                     param("pageSize", "24")
-                    cookie(Cookie("apiKey", "invalid-api-key"))
-                    cookie(Cookie("accessToken", "invalid-access-token"))
+                    cookie(Cookie(AuthCookieNames.API_KEY, "invalid-api-key"))
+                    cookie(Cookie(AuthCookieNames.ACCESS_TOKEN, "invalid-access-token"))
                     header(HttpHeaders.AUTHORIZATION, "Bearer invalid-api-key invalid-access-token")
                 }.andExpect {
                     status { isOk() }
@@ -638,8 +639,8 @@ class ApiV1PostControllerTest : BaseControllerIntegrationTest() {
                     param("page", "1")
                     param("pageSize", "24")
                     param("sort", "CREATED_AT")
-                    cookie(Cookie("apiKey", "invalid-api-key"))
-                    cookie(Cookie("accessToken", "invalid-access-token"))
+                    cookie(Cookie(AuthCookieNames.API_KEY, "invalid-api-key"))
+                    cookie(Cookie(AuthCookieNames.ACCESS_TOKEN, "invalid-access-token"))
                     header(HttpHeaders.AUTHORIZATION, "Bearer invalid-api-key invalid-access-token")
                 }.andExpect {
                     status { isOk() }

--- a/back/src/test/kotlin/com/back/global/security/config/ApiMutationCsrfGuardFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/ApiMutationCsrfGuardFilterTest.kt
@@ -20,7 +20,7 @@ class ApiMutationCsrfGuardFilterTest {
     fun `cookie authenticated mutation without csrf preflight header is forbidden`() {
         val filter = createFilter()
         val request = MockHttpServletRequest("POST", "/post/api/v1/posts/1/comments")
-        request.setCookies(Cookie("apiKey", "api-key"))
+        request.setCookies(Cookie(AuthCookieNames.API_KEY, "api-key"))
         request.addHeader(HttpHeaders.ORIGIN, "https://www.aquilaxk.site")
         val response = MockHttpServletResponse()
 
@@ -36,7 +36,7 @@ class ApiMutationCsrfGuardFilterTest {
     fun `cookie authenticated mutation with csrf preflight header passes`() {
         val filter = createFilter()
         val request = MockHttpServletRequest("POST", "/post/api/v1/posts/1/comments")
-        request.setCookies(Cookie("apiKey", "api-key"))
+        request.setCookies(Cookie(AuthCookieNames.API_KEY, "api-key"))
         request.addHeader(ApiMutationCsrfGuardFilter.CSRF_PREFLIGHT_HEADER, "1")
         val response = MockHttpServletResponse()
         val filterChain =
@@ -62,7 +62,7 @@ class ApiMutationCsrfGuardFilterTest {
         val filter = createFilter()
         val request = MockHttpServletRequest("POST", "/app/post/api/v1/posts/1/comments")
         request.contextPath = "/app"
-        request.setCookies(Cookie("apiKey", "api-key"))
+        request.setCookies(Cookie(AuthCookieNames.API_KEY, "api-key"))
         request.addHeader(ApiMutationCsrfGuardFilter.CSRF_PREFLIGHT_HEADER, "1")
         val response = MockHttpServletResponse()
         val filterChain =
@@ -87,7 +87,7 @@ class ApiMutationCsrfGuardFilterTest {
     fun `cookie authenticated mutation from disallowed origin is forbidden`() {
         val filter = createFilter()
         val request = MockHttpServletRequest("POST", "/post/api/v1/posts/1/comments")
-        request.setCookies(Cookie("apiKey", "api-key"))
+        request.setCookies(Cookie(AuthCookieNames.API_KEY, "api-key"))
         request.addHeader(HttpHeaders.ORIGIN, "https://evil.example")
         request.addHeader(ApiMutationCsrfGuardFilter.CSRF_PREFLIGHT_HEADER, "1")
         val response = MockHttpServletResponse()

--- a/back/src/test/kotlin/com/back/global/security/config/AuthTokenExtractorTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/AuthTokenExtractorTest.kt
@@ -13,13 +13,26 @@ import org.springframework.http.HttpHeaders
 @DisplayName("AuthTokenExtractor 테스트")
 class AuthTokenExtractorTest {
     @Test
+    @DisplayName("인증 쿠키 이름은 AuthCookieNames 상수로 한 곳에서 관리한다")
+    fun authCookieNamesAreCentralized() {
+        assertThat(AuthCookieNames.API_KEY).isEqualTo("apiKey")
+        assertThat(AuthCookieNames.ACCESS_TOKEN).isEqualTo("accessToken")
+        assertThat(AuthCookieNames.REFRESH_TOKEN).isEqualTo("refreshToken")
+        assertThat(AuthCookieNames.SESSION_KEY).isEqualTo("sessionKey")
+        assertThat(AuthCookieNames.AUTHENTICATION_COOKIE_NAMES)
+            .containsExactlyInAnyOrder("apiKey", "accessToken", "refreshToken", "sessionKey")
+        assertThat(AuthCookieNames.MUTATION_CSRF_GUARD_COOKIE_NAMES)
+            .containsExactlyInAnyOrder("apiKey", "accessToken", "sessionKey")
+    }
+
+    @Test
     @DisplayName("Authorization Bearer accessToken만 있으면 apiKey 없이 accessToken을 추출한다")
     fun extractBearerAccessTokenOnly() {
         // given
         val rq = mock(Rq::class.java)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("Bearer access-token")
-        given(rq.getCookieValue("sessionKey", "")).willReturn("session-key")
-        given(rq.getCookieValue("refreshToken", "")).willReturn("refresh-token")
+        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn("session-key")
+        given(rq.getCookieValue(AuthCookieNames.REFRESH_TOKEN, "")).willReturn("refresh-token")
         val extractor = AuthTokenExtractor(rq)
 
         // when
@@ -43,8 +56,8 @@ class AuthTokenExtractorTest {
         // given
         val rq = mock(Rq::class.java)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("Bearer api-key access-token")
-        given(rq.getCookieValue("sessionKey", "")).willReturn("session-key")
-        given(rq.getCookieValue("refreshToken", "")).willReturn("refresh-token")
+        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn("session-key")
+        given(rq.getCookieValue(AuthCookieNames.REFRESH_TOKEN, "")).willReturn("refresh-token")
         val extractor = AuthTokenExtractor(rq)
 
         // when
@@ -63,10 +76,10 @@ class AuthTokenExtractorTest {
         // given
         val rq = mock(Rq::class.java)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("")
-        given(rq.getCookieValue("apiKey", "")).willReturn("cookie-api-key")
-        given(rq.getCookieValue("accessToken", "")).willReturn("cookie-access-token")
-        given(rq.getCookieValue("sessionKey", "")).willReturn("cookie-session-key")
-        given(rq.getCookieValue("refreshToken", "")).willReturn("cookie-refresh-token")
+        given(rq.getCookieValue(AuthCookieNames.API_KEY, "")).willReturn("cookie-api-key")
+        given(rq.getCookieValue(AuthCookieNames.ACCESS_TOKEN, "")).willReturn("cookie-access-token")
+        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn("cookie-session-key")
+        given(rq.getCookieValue(AuthCookieNames.REFRESH_TOKEN, "")).willReturn("cookie-refresh-token")
         val extractor = AuthTokenExtractor(rq)
 
         // when
@@ -90,8 +103,8 @@ class AuthTokenExtractorTest {
         // given
         val rq = mock(Rq::class.java)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("Basic abc")
-        given(rq.getCookieValue("sessionKey", "")).willReturn("")
-        given(rq.getCookieValue("refreshToken", "")).willReturn("")
+        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn("")
+        given(rq.getCookieValue(AuthCookieNames.REFRESH_TOKEN, "")).willReturn("")
         val extractor = AuthTokenExtractor(rq)
 
         // when / then
@@ -106,8 +119,8 @@ class AuthTokenExtractorTest {
         // given
         val rq = mock(Rq::class.java)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("Bearer api-key access-token extra-token")
-        given(rq.getCookieValue("sessionKey", "")).willReturn("")
-        given(rq.getCookieValue("refreshToken", "")).willReturn("")
+        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn("")
+        given(rq.getCookieValue(AuthCookieNames.REFRESH_TOKEN, "")).willReturn("")
         val extractor = AuthTokenExtractor(rq)
 
         // when / then

--- a/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
@@ -70,10 +70,10 @@ class CustomAuthenticationFilterTest {
             )
 
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("")
-        given(rq.getCookieValue("apiKey", "")).willReturn("")
-        given(rq.getCookieValue("accessToken", "")).willReturn(accessToken)
-        given(rq.getCookieValue("sessionKey", "")).willReturn("")
-        given(rq.getCookieValue("refreshToken", "")).willReturn("")
+        given(rq.getCookieValue(AuthCookieNames.API_KEY, "")).willReturn("")
+        given(rq.getCookieValue(AuthCookieNames.ACCESS_TOKEN, "")).willReturn(accessToken)
+        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn("")
+        given(rq.getCookieValue(AuthCookieNames.REFRESH_TOKEN, "")).willReturn("")
         given(actorApplicationService.payload(accessToken)).willThrow(RuntimeException("jwt down"))
 
         listOf(
@@ -186,10 +186,10 @@ class CustomAuthenticationFilterTest {
 
         given(publicApiRequestMatcher.matches(request)).willReturn(false)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("")
-        given(rq.getCookieValue("apiKey", "")).willReturn("")
-        given(rq.getCookieValue("accessToken", "")).willReturn("broken-access-token")
-        given(rq.getCookieValue("sessionKey", "")).willReturn("")
-        given(rq.getCookieValue("refreshToken", "")).willReturn("")
+        given(rq.getCookieValue(AuthCookieNames.API_KEY, "")).willReturn("")
+        given(rq.getCookieValue(AuthCookieNames.ACCESS_TOKEN, "")).willReturn("broken-access-token")
+        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn("")
+        given(rq.getCookieValue(AuthCookieNames.REFRESH_TOKEN, "")).willReturn("")
         given(clientIpResolver.resolve(request)).willReturn("203.0.113.10")
         given(actorApplicationService.payload("broken-access-token")).willThrow(RuntimeException("jwt down"))
 
@@ -242,10 +242,10 @@ class CustomAuthenticationFilterTest {
 
         given(publicApiRequestMatcher.matches(request)).willReturn(true)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("")
-        given(rq.getCookieValue("apiKey", "")).willReturn("")
-        given(rq.getCookieValue("accessToken", "")).willReturn("broken-access-token")
-        given(rq.getCookieValue("sessionKey", "")).willReturn("")
-        given(rq.getCookieValue("refreshToken", "")).willReturn("")
+        given(rq.getCookieValue(AuthCookieNames.API_KEY, "")).willReturn("")
+        given(rq.getCookieValue(AuthCookieNames.ACCESS_TOKEN, "")).willReturn("broken-access-token")
+        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn("")
+        given(rq.getCookieValue(AuthCookieNames.REFRESH_TOKEN, "")).willReturn("")
         given(clientIpResolver.resolve(request)).willReturn("203.0.113.11")
         given(actorApplicationService.payload("broken-access-token")).willThrow(RuntimeException("jwt down"))
 
@@ -328,7 +328,7 @@ class CustomAuthenticationFilterTest {
 
         given(publicApiRequestMatcher.matches(request)).willReturn(false)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("Bearer $legacyToken")
-        given(rq.getCookieValue("sessionKey", "")).willReturn(sessionKey)
+        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn(sessionKey)
         given(actorApplicationService.payload(legacyToken))
             .willReturn(
                 AccessTokenPayload(
@@ -440,9 +440,9 @@ class CustomAuthenticationFilterTest {
 
         given(publicApiRequestMatcher.matches(request)).willReturn(false)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("")
-        given(rq.getCookieValue("apiKey", "")).willReturn(apiKey)
-        given(rq.getCookieValue("accessToken", "")).willReturn(staleAccessToken)
-        given(rq.getCookieValue("sessionKey", "")).willReturn(sessionKey)
+        given(rq.getCookieValue(AuthCookieNames.API_KEY, "")).willReturn(apiKey)
+        given(rq.getCookieValue(AuthCookieNames.ACCESS_TOKEN, "")).willReturn(staleAccessToken)
+        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn(sessionKey)
         given(actorApplicationService.payload(staleAccessToken))
             .willReturn(
                 AccessTokenPayload(
@@ -533,7 +533,7 @@ class CustomAuthenticationFilterTest {
 
         given(publicApiRequestMatcher.matches(request)).willReturn(false)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("Bearer $accessToken")
-        given(rq.getCookieValue("sessionKey", "")).willReturn(sessionKey)
+        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn(sessionKey)
         given(clientIpResolver.resolve(request)).willReturn("203.0.113.14")
         given(actorApplicationService.payload(accessToken))
             .willReturn(
@@ -615,7 +615,7 @@ class CustomAuthenticationFilterTest {
 
         given(publicApiRequestMatcher.matches(request)).willReturn(false)
         given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("Bearer $accessToken")
-        given(rq.getCookieValue("sessionKey", "")).willReturn(sessionKey)
+        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn(sessionKey)
         given(clientIpResolver.resolve(request)).willReturn("203.0.113.15")
         given(actorApplicationService.payload(accessToken))
             .willReturn(


### PR DESCRIPTION
## 관련 이슈

close #858

## 작업 배경

- 인증 쿠키 이름(`apiKey`, `accessToken`, `refreshToken`, `sessionKey`)이 extractor, cookie service, CSRF guard, controller, test에 문자열로 분산되어 이름 변경이나 오타 발생 시 계층 간 drift가 생길 수 있었습니다.

## 작업 내용

- `AuthCookieNames`를 추가해 인증 쿠키 이름과 CSRF guard 대상 쿠키 집합을 단일 상수로 모았습니다.
- `AuthTokenExtractor`, `AuthCookieService`, `ApiMutationCsrfGuardFilter`, `ApiV1AuthController`의 쿠키 이름 참조를 상수 기반으로 전환했습니다.
- 인증/게시글 관련 테스트의 쿠키 이름 기대값도 같은 상수를 사용하도록 정리했습니다.
- 같은 범위에서 명백히 실제 역할과 맞지 않던 `AuthCookieService` 주석을 쿠키 발급/만료 정책 설명으로 교체했습니다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back test --tests '*AuthTokenExtractorTest*'` 성공
  - `./back/gradlew -p back test --tests '*CustomAuthenticationFilterTest*' --tests '*ApiMutationCsrfGuardFilterTest*' --tests '*ApiV1AuthControllerTest*'` 성공
  - `./back/gradlew -p back ktlintCheck` 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks` 성공 2회 연속
  - `rg -n '"apiKey"|"accessToken"|"refreshToken"|"sessionKey"' ...` 결과: 남은 문자열은 `AuthCookieNames` 상수 정의와 상수값 검증 테스트뿐임

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `AuthCookieNames`의 실제 문자열 값은 기존 쿠키 이름과 동일하게 유지했습니다.
  - 쿠키 path/domain/secure/sameSite/maxAge 정책은 변경하지 않았습니다.

## 리스크

- 낮음. 쿠키 이름 문자열 참조를 상수로 치환한 리팩터링이며 런타임 쿠키 이름과 보안 속성은 그대로입니다.
- 테스트는 상수값 자체를 검증해 의도치 않은 쿠키 이름 변경을 빠르게 감지하도록 했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
