### PR TITLE
[Refactor] CustomAuthenticationFilter 추가 인증 handler 분리

### DIFF
--- a/back/src/main/kotlin/com/back/global/security/config/AccessTokenAuthenticationHandler.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/AccessTokenAuthenticationHandler.kt
@@ -1,0 +1,100 @@
+package com.back.global.security.config
+
+import com.back.boundedContexts.member.application.service.ActorApplicationService
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.dto.shared.AccessTokenPayload
+import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
+import jakarta.servlet.http.HttpServletRequest
+
+internal class AccessTokenAuthenticationHandler(
+    private val actorApplicationService: ActorApplicationService,
+    private val memberSessionUseCase: MemberSessionUseCase,
+    private val authIpSecurityVerifier: AuthIpSecurityVerifier,
+    private val securityContextAuthenticationWriter: SecurityContextAuthenticationWriter,
+    private val memberSessionAuthenticationResolver: MemberSessionAuthenticationResolver,
+    private val apiKeyAuthorityRefreshHandler: ApiKeyAuthorityRefreshHandler,
+    private val legacyPayloadRecoveryHandler: LegacyPayloadRecoveryHandler,
+) {
+    fun authenticate(
+        request: HttpServletRequest,
+        tokens: ExtractedAuthTokens,
+        clientIp: String,
+    ): Boolean {
+        val payload = tokens.accessToken.takeIf { it.isNotBlank() }?.let(actorApplicationService::payload) ?: return false
+
+        if (
+            apiKeyAuthorityRefreshHandler.authenticateIfPreferred(
+                request = request,
+                apiKey = tokens.apiKey,
+                payload = payload,
+                sessionKey = tokens.sessionKey,
+                clientIp = clientIp,
+            )
+        ) {
+            return true
+        }
+
+        val sessionResolution =
+            memberSessionAuthenticationResolver.resolve(
+                memberId = payload.id,
+                cookieSessionKey = tokens.sessionKey,
+                tokenSessionKey = payload.sessionKey,
+                payload = payload,
+                request = request,
+            )
+        memberSessionAuthenticationResolver.ensureUsable(sessionResolution, requireSession = true)
+        val sessionContext =
+            memberSessionAuthenticationResolver.context(
+                sessionResolution = sessionResolution,
+                fallbackRememberLoginEnabled = payload.rememberLoginEnabled,
+                fallbackIpSecurityEnabled = payload.ipSecurityEnabled,
+                fallbackIpSecurityFingerprint = payload.ipSecurityFingerprint,
+            )
+
+        authIpSecurityVerifier.verify(
+            AuthIpSecurityCheck(
+                memberId = payload.id,
+                loginIdentifier = resolveTokenLoginIdentifier(payload),
+                rememberLoginEnabled = sessionContext.rememberLoginEnabled,
+                ipSecurityEnabled = sessionContext.ipSecurityEnabled,
+                expectedIpFingerprint = sessionContext.ipSecurityFingerprint,
+                requestPath = request.requestURI,
+                reason = "token-payload-ip-mismatch",
+            ),
+            clientIp,
+        )
+
+        if (legacyPayloadRecoveryHandler.recoverIfNeeded(payload, sessionContext)) return true
+
+        sessionContext.session?.let { memberSessionUseCase.touchAuthenticated(it) }
+        val payloadMember =
+            Member(
+                id = payload.id,
+                username = resolvePrincipalUsername(payload),
+                password = null,
+                nickname = payload.name,
+                email = payload.email,
+            )
+        securityContextAuthenticationWriter.write(payloadMember)
+        return true
+    }
+
+    private fun resolveTokenLoginIdentifier(payload: AccessTokenPayload): String? {
+        val normalizedEmail = payload.email?.trim().orEmpty()
+        if (normalizedEmail.isNotBlank()) return normalizedEmail
+
+        val normalizedUsername = payload.username?.trim().orEmpty()
+        if (normalizedUsername.isNotBlank()) return normalizedUsername
+        return null
+    }
+
+    private fun resolvePrincipalUsername(payload: AccessTokenPayload): String {
+        val normalizedUsername = payload.username?.trim().orEmpty()
+        if (normalizedUsername.isNotBlank()) return normalizedUsername
+
+        val normalizedEmail = payload.email?.trim().orEmpty()
+        if (normalizedEmail.isNotBlank()) return normalizedEmail
+
+        return "member-${payload.id}"
+    }
+}

--- a/back/src/main/kotlin/com/back/global/security/config/ApiKeyAuthorityRefreshHandler.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/ApiKeyAuthorityRefreshHandler.kt
@@ -1,0 +1,78 @@
+package com.back.global.security.config
+
+import com.back.boundedContexts.member.application.service.ActorApplicationService
+import com.back.boundedContexts.member.dto.shared.AccessTokenPayload
+import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
+import com.back.global.web.application.AuthCookieService
+import com.back.global.web.application.Rq
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpHeaders
+
+internal class ApiKeyAuthorityRefreshHandler(
+    private val actorApplicationService: ActorApplicationService,
+    private val memberSessionUseCase: MemberSessionUseCase,
+    private val authCookieService: AuthCookieService,
+    private val authIpSecurityVerifier: AuthIpSecurityVerifier,
+    private val securityContextAuthenticationWriter: SecurityContextAuthenticationWriter,
+    private val memberSessionAuthenticationResolver: MemberSessionAuthenticationResolver,
+    private val rq: Rq,
+) {
+    fun authenticateIfPreferred(
+        request: HttpServletRequest,
+        apiKey: String,
+        payload: AccessTokenPayload,
+        sessionKey: String,
+        clientIp: String,
+    ): Boolean {
+        if (!AuthRequestMethodPolicy.isMutating(request) || apiKey.isBlank()) return false
+
+        val apiKeyMember = actorApplicationService.findByApiKey(apiKey) ?: return false
+        val sessionResolution =
+            memberSessionAuthenticationResolver.resolve(
+                memberId = apiKeyMember.id,
+                cookieSessionKey = sessionKey,
+                tokenSessionKey = payload.sessionKey,
+                payload = payload,
+                request = request,
+            )
+        memberSessionAuthenticationResolver.ensureUsable(sessionResolution, requireSession = true)
+        val sessionContext =
+            memberSessionAuthenticationResolver.context(
+                sessionResolution = sessionResolution,
+                fallbackRememberLoginEnabled = apiKeyMember.rememberLoginEnabled,
+                fallbackIpSecurityEnabled = apiKeyMember.ipSecurityEnabled,
+                fallbackIpSecurityFingerprint = apiKeyMember.ipSecurityFingerprint,
+            )
+
+        authIpSecurityVerifier.verify(
+            AuthIpSecurityCheck(
+                memberId = apiKeyMember.id,
+                loginIdentifier = apiKeyMember.username,
+                rememberLoginEnabled = sessionContext.rememberLoginEnabled,
+                ipSecurityEnabled = sessionContext.ipSecurityEnabled,
+                expectedIpFingerprint = sessionContext.ipSecurityFingerprint,
+                requestPath = request.requestURI,
+                reason = "apikey-ip-mismatch",
+            ),
+            clientIp,
+        )
+
+        val rotatedAccessToken =
+            actorApplicationService.genAccessToken(
+                member = apiKeyMember,
+                sessionKey = sessionContext.session?.sessionKey,
+                rememberLoginEnabled = sessionContext.rememberLoginEnabled,
+                ipSecurityEnabled = sessionContext.ipSecurityEnabled,
+                ipSecurityFingerprint = sessionContext.ipSecurityFingerprint,
+            )
+        authCookieService.issueAccessToken(
+            accessToken = rotatedAccessToken,
+            rememberLoginEnabled = sessionContext.rememberLoginEnabled,
+            sessionKey = sessionContext.session?.sessionKey,
+        )
+        rq.setHeader(HttpHeaders.AUTHORIZATION, "Bearer $rotatedAccessToken")
+        sessionContext.session?.let { memberSessionUseCase.touchAuthenticated(it) }
+        securityContextAuthenticationWriter.write(apiKeyMember)
+        return true
+    }
+}

--- a/back/src/main/kotlin/com/back/global/security/config/AuthRequestMethodPolicy.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/AuthRequestMethodPolicy.kt
@@ -1,0 +1,19 @@
+package com.back.global.security.config
+
+import jakarta.servlet.http.HttpServletRequest
+import java.util.Locale
+
+internal object AuthRequestMethodPolicy {
+    private val MUTATING_METHODS = setOf("POST", "PUT", "PATCH", "DELETE")
+    private val SAFE_METHODS = setOf("GET", "HEAD")
+
+    fun isMutating(request: HttpServletRequest): Boolean = normalizedMethod(request) in MUTATING_METHODS
+
+    fun isSafeRead(request: HttpServletRequest): Boolean = normalizedMethod(request) in SAFE_METHODS
+
+    private fun normalizedMethod(request: HttpServletRequest): String =
+        request.method
+            ?.trim()
+            ?.uppercase(Locale.ROOT)
+            .orEmpty()
+}

--- a/back/src/main/kotlin/com/back/global/security/config/CustomAuthenticationFilter.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/CustomAuthenticationFilter.kt
@@ -1,10 +1,7 @@
 package com.back.global.security.config
 
 import com.back.boundedContexts.member.application.service.ActorApplicationService
-import com.back.boundedContexts.member.domain.shared.Member
-import com.back.boundedContexts.member.dto.shared.AccessTokenPayload
 import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
-import com.back.boundedContexts.member.subContexts.session.model.MemberSessionAuthSnapshot
 import com.back.global.exception.application.AppException
 import com.back.global.rsData.RsData
 import com.back.global.web.application.AuthCookieService
@@ -15,14 +12,11 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.env.Environment
-import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 import tools.jackson.databind.ObjectMapper
-import java.time.Instant
-import java.util.Locale
 
 /**
  * API 요청의 쿠키/JWT 인증을 SecurityContext로 연결하는 servlet filter입니다.
@@ -50,6 +44,49 @@ class CustomAuthenticationFilter(
     private val log = org.slf4j.LoggerFactory.getLogger(CustomAuthenticationFilter::class.java)
     private val protectedDocumentationPrefixes = listOf("/swagger-ui/", "/v3/api-docs")
     private val filteredPrefixes = listOf("/member/api/", "/post/api/", "/system/api/", "/ws/", "/sse/") + protectedDocumentationPrefixes
+    private val memberSessionAuthenticationResolver =
+        MemberSessionAuthenticationResolver(
+            memberSessionUseCase = memberSessionUseCase,
+            authCookieService = authCookieService,
+            freshLookupGraceSeconds = freshLookupGraceSeconds,
+        )
+    private val apiKeyAuthorityRefreshHandler =
+        ApiKeyAuthorityRefreshHandler(
+            actorApplicationService = actorApplicationService,
+            memberSessionUseCase = memberSessionUseCase,
+            authCookieService = authCookieService,
+            authIpSecurityVerifier = authIpSecurityVerifier,
+            securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+            memberSessionAuthenticationResolver = memberSessionAuthenticationResolver,
+            rq = rq,
+        )
+    private val legacyPayloadRecoveryHandler =
+        LegacyPayloadRecoveryHandler(
+            actorApplicationService = actorApplicationService,
+            memberSessionUseCase = memberSessionUseCase,
+            authCookieService = authCookieService,
+            securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+            rq = rq,
+        )
+    private val accessTokenAuthenticationHandler =
+        AccessTokenAuthenticationHandler(
+            actorApplicationService = actorApplicationService,
+            memberSessionUseCase = memberSessionUseCase,
+            authIpSecurityVerifier = authIpSecurityVerifier,
+            securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+            memberSessionAuthenticationResolver = memberSessionAuthenticationResolver,
+            apiKeyAuthorityRefreshHandler = apiKeyAuthorityRefreshHandler,
+            legacyPayloadRecoveryHandler = legacyPayloadRecoveryHandler,
+        )
+    private val refreshTokenAuthenticationHandler =
+        RefreshTokenAuthenticationHandler(
+            actorApplicationService = actorApplicationService,
+            memberSessionUseCase = memberSessionUseCase,
+            authCookieService = authCookieService,
+            authIpSecurityVerifier = authIpSecurityVerifier,
+            securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+            rq = rq,
+        )
 
     override fun shouldNotFilter(request: HttpServletRequest): Boolean {
         val uri = request.requestURI
@@ -73,7 +110,7 @@ class CustomAuthenticationFilter(
 
         try {
             try {
-                authenticateIfPossible(request, response)
+                authenticateIfPossible(request)
             } catch (e: AppException) {
                 if (!isPublicApi) throw e
                 // 공개 API는 잘못된 인증정보가 있어도 익명으로 계속 처리한다.
@@ -117,171 +154,14 @@ class CustomAuthenticationFilter(
     /**
      * 기존 accessToken을 먼저 검증하고, 실패하면 refreshToken 회전 경로로 이동합니다.
      */
-    private fun authenticateIfPossible(
-        request: HttpServletRequest,
-        response: HttpServletResponse,
-    ) {
+    private fun authenticateIfPossible(request: HttpServletRequest) {
         val tokens = authTokenExtractor.extract()
-        val apiKey = tokens.apiKey
-        val accessToken = tokens.accessToken
-        val sessionKey = tokens.sessionKey
-        val refreshToken = tokens.refreshToken
         val clientIp = clientIpResolver.resolve(request)
 
-        if (apiKey.isBlank() && accessToken.isBlank() && refreshToken.isBlank()) return
+        if (tokens.apiKey.isBlank() && tokens.accessToken.isBlank() && tokens.refreshToken.isBlank()) return
 
-        val payload = accessToken.takeIf { it.isNotBlank() }?.let(actorApplicationService::payload)
-
-        if (payload != null) {
-            // 쓰기 요청은 apiKey 기준 DB 회원을 우선 사용해 role 드리프트(특히 관리자 403 오탐)를 방지한다.
-            if (shouldPreferApiKeyAuthorityOnWrite(request, apiKey)) {
-                val apiKeyMember = actorApplicationService.findByApiKey(apiKey)
-                if (apiKeyMember != null) {
-                    val sessionResolution = resolveMemberSession(apiKeyMember.id, sessionKey, payload.sessionKey, payload, request)
-                    ensureSessionIsUsable(sessionResolution, requireSession = true)
-                    val memberSession = sessionResolution.session
-                    val rememberLoginEnabled = memberSession?.rememberLoginEnabled ?: apiKeyMember.rememberLoginEnabled
-                    val ipSecurityEnabled = memberSession?.ipSecurityEnabled ?: apiKeyMember.ipSecurityEnabled
-                    val ipSecurityFingerprint = memberSession?.ipSecurityFingerprint ?: apiKeyMember.ipSecurityFingerprint
-
-                    authIpSecurityVerifier.verify(
-                        AuthIpSecurityCheck(
-                            memberId = apiKeyMember.id,
-                            loginIdentifier = apiKeyMember.username,
-                            rememberLoginEnabled = rememberLoginEnabled,
-                            ipSecurityEnabled = ipSecurityEnabled,
-                            expectedIpFingerprint = ipSecurityFingerprint,
-                            requestPath = request.requestURI,
-                            reason = "apikey-ip-mismatch",
-                        ),
-                        clientIp,
-                    )
-
-                    val rotatedAccessToken =
-                        actorApplicationService.genAccessToken(
-                            member = apiKeyMember,
-                            sessionKey = memberSession?.sessionKey,
-                            rememberLoginEnabled = rememberLoginEnabled,
-                            ipSecurityEnabled = ipSecurityEnabled,
-                            ipSecurityFingerprint = ipSecurityFingerprint,
-                        )
-                    authCookieService.issueAccessToken(
-                        accessToken = rotatedAccessToken,
-                        rememberLoginEnabled = rememberLoginEnabled,
-                        sessionKey = memberSession?.sessionKey,
-                    )
-                    rq.setHeader(HttpHeaders.AUTHORIZATION, "Bearer $rotatedAccessToken")
-                    memberSession?.let { memberSessionUseCase.touchAuthenticated(it) }
-                    securityContextAuthenticationWriter.write(apiKeyMember)
-                    return
-                }
-            }
-
-            val sessionResolution = resolveMemberSession(payload.id, sessionKey, payload.sessionKey, payload, request)
-            ensureSessionIsUsable(sessionResolution, requireSession = true)
-            val memberSession = sessionResolution.session
-            val rememberLoginEnabled = memberSession?.rememberLoginEnabled ?: payload.rememberLoginEnabled
-            val ipSecurityEnabled = memberSession?.ipSecurityEnabled ?: payload.ipSecurityEnabled
-            val ipSecurityFingerprint = memberSession?.ipSecurityFingerprint ?: payload.ipSecurityFingerprint
-            val tokenLoginIdentifier = resolveTokenLoginIdentifier(payload)
-            authIpSecurityVerifier.verify(
-                AuthIpSecurityCheck(
-                    memberId = payload.id,
-                    loginIdentifier = tokenLoginIdentifier,
-                    rememberLoginEnabled = rememberLoginEnabled,
-                    ipSecurityEnabled = ipSecurityEnabled,
-                    expectedIpFingerprint = ipSecurityFingerprint,
-                    requestPath = request.requestURI,
-                    reason = "token-payload-ip-mismatch",
-                ),
-                clientIp,
-            )
-
-            // 과거 토큰(payload.email 누락)과 현재 이메일 기반 관리자 판정의 드리프트를 즉시 복구한다.
-            if (payload.email.isNullOrBlank()) {
-                actorApplicationService.findById(payload.id)?.let { persistedMember ->
-                    val rotatedAccessToken =
-                        actorApplicationService.genAccessToken(
-                            member = persistedMember,
-                            sessionKey = memberSession?.sessionKey,
-                            rememberLoginEnabled = rememberLoginEnabled,
-                            ipSecurityEnabled = ipSecurityEnabled,
-                            ipSecurityFingerprint = ipSecurityFingerprint,
-                        )
-                    authCookieService.issueAccessToken(
-                        accessToken = rotatedAccessToken,
-                        rememberLoginEnabled = rememberLoginEnabled,
-                        sessionKey = memberSession?.sessionKey,
-                    )
-                    rq.setHeader(HttpHeaders.AUTHORIZATION, "Bearer $rotatedAccessToken")
-                    memberSession?.let { memberSessionUseCase.touchAuthenticated(it) }
-                    securityContextAuthenticationWriter.write(persistedMember)
-                    return
-                }
-            }
-
-            memberSession?.let { memberSessionUseCase.touchAuthenticated(it) }
-            val payloadMember =
-                Member(
-                    id = payload.id,
-                    username = resolvePrincipalUsername(payload),
-                    password = null,
-                    nickname = payload.name,
-                    email = payload.email,
-                )
-            securityContextAuthenticationWriter.write(payloadMember)
-            return
-        }
-
-        if (sessionKey.isBlank() || refreshToken.isBlank()) {
-            authCookieService.expireAuthCookies()
-            throw AppException("401-8", "세션이 만료되었습니다. 다시 로그인해주세요.")
-        }
-
-        val refreshedSession =
-            memberSessionUseCase.rotateRefreshToken(sessionKey, refreshToken)
-                ?: run {
-                    authCookieService.expireAuthCookies()
-                    throw AppException("401-8", "세션이 만료되었습니다. 다시 로그인해주세요.")
-                }
-
-        val memberSession = refreshedSession.session
-        val member = memberSession.member
-        val rememberLoginEnabled = memberSession.rememberLoginEnabled
-        val ipSecurityEnabled = memberSession.ipSecurityEnabled
-        val ipSecurityFingerprint = memberSession.ipSecurityFingerprint
-
-        authIpSecurityVerifier.verify(
-            AuthIpSecurityCheck(
-                memberId = member.id,
-                loginIdentifier = member.username,
-                rememberLoginEnabled = rememberLoginEnabled,
-                ipSecurityEnabled = ipSecurityEnabled,
-                expectedIpFingerprint = ipSecurityFingerprint,
-                requestPath = request.requestURI,
-                reason = "refresh-token-ip-mismatch",
-                revokeSessionKey = memberSession.sessionKey,
-            ),
-            clientIp,
-        )
-
-        val newAccessToken =
-            actorApplicationService.genAccessToken(
-                member = member,
-                sessionKey = memberSession.sessionKey,
-                rememberLoginEnabled = rememberLoginEnabled,
-                ipSecurityEnabled = ipSecurityEnabled,
-                ipSecurityFingerprint = ipSecurityFingerprint,
-            )
-        authCookieService.issueAccessToken(
-            accessToken = newAccessToken,
-            rememberLoginEnabled = rememberLoginEnabled,
-            sessionKey = memberSession.sessionKey,
-            refreshToken = refreshedSession.refreshToken,
-        )
-        rq.setHeader(HttpHeaders.AUTHORIZATION, "Bearer $newAccessToken")
-
-        securityContextAuthenticationWriter.write(member)
+        if (accessTokenAuthenticationHandler.authenticate(request, tokens, clientIp)) return
+        refreshTokenAuthenticationHandler.authenticate(request, tokens, clientIp)
     }
 
     private fun sanitizeLogValue(
@@ -305,118 +185,5 @@ class CustomAuthenticationFilter(
     companion object {
         private const val MAX_PATH_LENGTH = 512
         private val LOG_CONTROL_CHAR_REGEX = Regex("[\\x00-\\x1F\\x7F]")
-        private val MUTATING_METHODS = setOf("POST", "PUT", "PATCH", "DELETE")
-        private val SAFE_METHODS = setOf("GET", "HEAD")
-    }
-
-    private data class SessionResolution(
-        val sessionKeyProvided: Boolean,
-        val session: MemberSessionAuthSnapshot?,
-        val freshTokenFallback: Boolean = false,
-    )
-
-    private fun resolveMemberSession(
-        memberId: Long,
-        cookieSessionKey: String,
-        tokenSessionKey: String?,
-        payload: AccessTokenPayload?,
-        request: HttpServletRequest,
-    ): SessionResolution {
-        val effectiveSessionKey =
-            when {
-                cookieSessionKey.isNotBlank() -> cookieSessionKey
-                !tokenSessionKey.isNullOrBlank() -> tokenSessionKey
-                else -> ""
-            }.trim()
-
-        if (effectiveSessionKey.isBlank()) {
-            return SessionResolution(sessionKeyProvided = false, session = null)
-        }
-
-        val resolution =
-            SessionResolution(
-                sessionKeyProvided = true,
-                session = memberSessionUseCase.findActiveSessionSnapshot(memberId, effectiveSessionKey),
-            )
-
-        if (resolution.session != null || !resolution.sessionKeyProvided) return resolution
-        if (!canUseFreshTokenSessionFallback(request, payload, cookieSessionKey, effectiveSessionKey)) return resolution
-
-        log.info(
-            "auth_session_fresh_token_fallback path={} memberId={} graceSeconds={}",
-            sanitizeLogValue(request.requestURI, MAX_PATH_LENGTH),
-            memberId,
-            freshLookupGraceSeconds,
-        )
-
-        return resolution.copy(freshTokenFallback = true)
-    }
-
-    private fun ensureSessionIsUsable(
-        sessionResolution: SessionResolution,
-        requireSession: Boolean = false,
-    ) {
-        if (!sessionResolution.sessionKeyProvided && requireSession) {
-            authCookieService.expireAuthCookies()
-            throw AppException("401-8", "세션이 만료되었습니다. 다시 로그인해주세요.")
-        }
-
-        if (sessionResolution.sessionKeyProvided && sessionResolution.session == null && !sessionResolution.freshTokenFallback) {
-            authCookieService.expireAuthCookies()
-            throw AppException("401-8", "세션이 만료되었습니다. 다시 로그인해주세요.")
-        }
-    }
-
-    private fun canUseFreshTokenSessionFallback(
-        request: HttpServletRequest,
-        payload: AccessTokenPayload?,
-        cookieSessionKey: String,
-        effectiveSessionKey: String,
-    ): Boolean {
-        if (payload == null) return false
-        if (freshLookupGraceSeconds <= 0) return false
-        val method =
-            request.method
-                ?.trim()
-                ?.uppercase(Locale.ROOT)
-                .orEmpty()
-        if (method !in SAFE_METHODS) return false
-        if (cookieSessionKey.isBlank() || effectiveSessionKey.isBlank()) return false
-        if (payload.sessionKey.isNullOrBlank() || payload.sessionKey != effectiveSessionKey) return false
-
-        val issuedAt = payload.issuedAt ?: return false
-        return !Instant.now().isAfter(issuedAt.plusSeconds(freshLookupGraceSeconds))
-    }
-
-    private fun resolveTokenLoginIdentifier(payload: AccessTokenPayload): String? {
-        val normalizedEmail = payload.email?.trim().orEmpty()
-        if (normalizedEmail.isNotBlank()) return normalizedEmail
-
-        val normalizedUsername = payload.username?.trim().orEmpty()
-        if (normalizedUsername.isNotBlank()) return normalizedUsername
-        return null
-    }
-
-    private fun resolvePrincipalUsername(payload: AccessTokenPayload): String {
-        val normalizedUsername = payload.username?.trim().orEmpty()
-        if (normalizedUsername.isNotBlank()) return normalizedUsername
-
-        val normalizedEmail = payload.email?.trim().orEmpty()
-        if (normalizedEmail.isNotBlank()) return normalizedEmail
-
-        return "member-${payload.id}"
-    }
-
-    private fun shouldPreferApiKeyAuthorityOnWrite(
-        request: HttpServletRequest,
-        apiKey: String,
-    ): Boolean {
-        if (apiKey.isBlank()) return false
-        val method =
-            request.method
-                ?.trim()
-                ?.uppercase(Locale.ROOT)
-                .orEmpty()
-        return method in MUTATING_METHODS
     }
 }

--- a/back/src/main/kotlin/com/back/global/security/config/LegacyPayloadRecoveryHandler.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/LegacyPayloadRecoveryHandler.kt
@@ -1,0 +1,42 @@
+package com.back.global.security.config
+
+import com.back.boundedContexts.member.application.service.ActorApplicationService
+import com.back.boundedContexts.member.dto.shared.AccessTokenPayload
+import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
+import com.back.global.web.application.AuthCookieService
+import com.back.global.web.application.Rq
+import org.springframework.http.HttpHeaders
+
+internal class LegacyPayloadRecoveryHandler(
+    private val actorApplicationService: ActorApplicationService,
+    private val memberSessionUseCase: MemberSessionUseCase,
+    private val authCookieService: AuthCookieService,
+    private val securityContextAuthenticationWriter: SecurityContextAuthenticationWriter,
+    private val rq: Rq,
+) {
+    fun recoverIfNeeded(
+        payload: AccessTokenPayload,
+        sessionContext: AuthenticationSessionContext,
+    ): Boolean {
+        if (!payload.email.isNullOrBlank()) return false
+
+        val persistedMember = actorApplicationService.findById(payload.id) ?: return false
+        val rotatedAccessToken =
+            actorApplicationService.genAccessToken(
+                member = persistedMember,
+                sessionKey = sessionContext.session?.sessionKey,
+                rememberLoginEnabled = sessionContext.rememberLoginEnabled,
+                ipSecurityEnabled = sessionContext.ipSecurityEnabled,
+                ipSecurityFingerprint = sessionContext.ipSecurityFingerprint,
+            )
+        authCookieService.issueAccessToken(
+            accessToken = rotatedAccessToken,
+            rememberLoginEnabled = sessionContext.rememberLoginEnabled,
+            sessionKey = sessionContext.session?.sessionKey,
+        )
+        rq.setHeader(HttpHeaders.AUTHORIZATION, "Bearer $rotatedAccessToken")
+        sessionContext.session?.let { memberSessionUseCase.touchAuthenticated(it) }
+        securityContextAuthenticationWriter.write(persistedMember)
+        return true
+    }
+}

--- a/back/src/main/kotlin/com/back/global/security/config/MemberSessionAuthenticationResolver.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/MemberSessionAuthenticationResolver.kt
@@ -1,0 +1,136 @@
+package com.back.global.security.config
+
+import com.back.boundedContexts.member.dto.shared.AccessTokenPayload
+import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
+import com.back.boundedContexts.member.subContexts.session.model.MemberSessionAuthSnapshot
+import com.back.global.exception.application.AppException
+import com.back.global.web.application.AuthCookieService
+import jakarta.servlet.http.HttpServletRequest
+import java.time.Instant
+
+internal class MemberSessionAuthenticationResolver(
+    private val memberSessionUseCase: MemberSessionUseCase,
+    private val authCookieService: AuthCookieService,
+    private val freshLookupGraceSeconds: Long,
+) {
+    private val log = org.slf4j.LoggerFactory.getLogger(MemberSessionAuthenticationResolver::class.java)
+
+    fun resolve(
+        memberId: Long,
+        cookieSessionKey: String,
+        tokenSessionKey: String?,
+        payload: AccessTokenPayload?,
+        request: HttpServletRequest,
+    ): MemberSessionResolution {
+        val effectiveSessionKey =
+            when {
+                cookieSessionKey.isNotBlank() -> cookieSessionKey
+                !tokenSessionKey.isNullOrBlank() -> tokenSessionKey
+                else -> ""
+            }.trim()
+
+        if (effectiveSessionKey.isBlank()) {
+            return MemberSessionResolution(sessionKeyProvided = false, session = null)
+        }
+
+        val resolution =
+            MemberSessionResolution(
+                sessionKeyProvided = true,
+                session = memberSessionUseCase.findActiveSessionSnapshot(memberId, effectiveSessionKey),
+            )
+
+        if (resolution.session != null || !resolution.sessionKeyProvided) return resolution
+        if (!canUseFreshTokenSessionFallback(request, payload, cookieSessionKey, effectiveSessionKey)) return resolution
+
+        log.info(
+            "auth_session_fresh_token_fallback path={} memberId={} graceSeconds={}",
+            sanitizeLogValue(request.requestURI, MAX_PATH_LENGTH),
+            memberId,
+            freshLookupGraceSeconds,
+        )
+
+        return resolution.copy(freshTokenFallback = true)
+    }
+
+    fun ensureUsable(
+        sessionResolution: MemberSessionResolution,
+        requireSession: Boolean = false,
+    ) {
+        if (!sessionResolution.sessionKeyProvided && requireSession) {
+            authCookieService.expireAuthCookies()
+            throw AppException("401-8", "세션이 만료되었습니다. 다시 로그인해주세요.")
+        }
+
+        if (sessionResolution.sessionKeyProvided && sessionResolution.session == null && !sessionResolution.freshTokenFallback) {
+            authCookieService.expireAuthCookies()
+            throw AppException("401-8", "세션이 만료되었습니다. 다시 로그인해주세요.")
+        }
+    }
+
+    fun context(
+        sessionResolution: MemberSessionResolution,
+        fallbackRememberLoginEnabled: Boolean,
+        fallbackIpSecurityEnabled: Boolean,
+        fallbackIpSecurityFingerprint: String?,
+    ): AuthenticationSessionContext {
+        val memberSession = sessionResolution.session
+        return AuthenticationSessionContext(
+            session = memberSession,
+            rememberLoginEnabled = memberSession?.rememberLoginEnabled ?: fallbackRememberLoginEnabled,
+            ipSecurityEnabled = memberSession?.ipSecurityEnabled ?: fallbackIpSecurityEnabled,
+            ipSecurityFingerprint = memberSession?.ipSecurityFingerprint ?: fallbackIpSecurityFingerprint,
+        )
+    }
+
+    private fun canUseFreshTokenSessionFallback(
+        request: HttpServletRequest,
+        payload: AccessTokenPayload?,
+        cookieSessionKey: String,
+        effectiveSessionKey: String,
+    ): Boolean {
+        if (payload == null) return false
+        if (freshLookupGraceSeconds <= 0) return false
+        if (!AuthRequestMethodPolicy.isSafeRead(request)) return false
+        if (cookieSessionKey.isBlank() || effectiveSessionKey.isBlank()) return false
+        if (payload.sessionKey.isNullOrBlank() || payload.sessionKey != effectiveSessionKey) return false
+
+        val issuedAt = payload.issuedAt ?: return false
+        return !Instant.now().isAfter(issuedAt.plusSeconds(freshLookupGraceSeconds))
+    }
+
+    private fun sanitizeLogValue(
+        raw: String?,
+        maxLength: Int,
+    ): String {
+        if (raw.isNullOrBlank()) return "-"
+
+        val sanitized =
+            raw
+                .replace('\r', ' ')
+                .replace('\n', ' ')
+                .replace('\t', ' ')
+                .replace(LOG_CONTROL_CHAR_REGEX, "?")
+                .trim()
+
+        if (sanitized.isBlank()) return "-"
+        return sanitized.take(maxLength)
+    }
+
+    private companion object {
+        const val MAX_PATH_LENGTH = 512
+        val LOG_CONTROL_CHAR_REGEX = Regex("[\\x00-\\x1F\\x7F]")
+    }
+}
+
+internal data class MemberSessionResolution(
+    val sessionKeyProvided: Boolean,
+    val session: MemberSessionAuthSnapshot?,
+    val freshTokenFallback: Boolean = false,
+)
+
+internal data class AuthenticationSessionContext(
+    val session: MemberSessionAuthSnapshot?,
+    val rememberLoginEnabled: Boolean,
+    val ipSecurityEnabled: Boolean,
+    val ipSecurityFingerprint: String?,
+)

--- a/back/src/main/kotlin/com/back/global/security/config/RefreshTokenAuthenticationHandler.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/RefreshTokenAuthenticationHandler.kt
@@ -1,0 +1,74 @@
+package com.back.global.security.config
+
+import com.back.boundedContexts.member.application.service.ActorApplicationService
+import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
+import com.back.global.exception.application.AppException
+import com.back.global.web.application.AuthCookieService
+import com.back.global.web.application.Rq
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpHeaders
+
+internal class RefreshTokenAuthenticationHandler(
+    private val actorApplicationService: ActorApplicationService,
+    private val memberSessionUseCase: MemberSessionUseCase,
+    private val authCookieService: AuthCookieService,
+    private val authIpSecurityVerifier: AuthIpSecurityVerifier,
+    private val securityContextAuthenticationWriter: SecurityContextAuthenticationWriter,
+    private val rq: Rq,
+) {
+    fun authenticate(
+        request: HttpServletRequest,
+        tokens: ExtractedAuthTokens,
+        clientIp: String,
+    ) {
+        if (tokens.sessionKey.isBlank() || tokens.refreshToken.isBlank()) {
+            authCookieService.expireAuthCookies()
+            throw AppException("401-8", "세션이 만료되었습니다. 다시 로그인해주세요.")
+        }
+
+        val refreshedSession =
+            memberSessionUseCase.rotateRefreshToken(tokens.sessionKey, tokens.refreshToken)
+                ?: run {
+                    authCookieService.expireAuthCookies()
+                    throw AppException("401-8", "세션이 만료되었습니다. 다시 로그인해주세요.")
+                }
+
+        val memberSession = refreshedSession.session
+        val member = memberSession.member
+        val rememberLoginEnabled = memberSession.rememberLoginEnabled
+        val ipSecurityEnabled = memberSession.ipSecurityEnabled
+        val ipSecurityFingerprint = memberSession.ipSecurityFingerprint
+
+        authIpSecurityVerifier.verify(
+            AuthIpSecurityCheck(
+                memberId = member.id,
+                loginIdentifier = member.username,
+                rememberLoginEnabled = rememberLoginEnabled,
+                ipSecurityEnabled = ipSecurityEnabled,
+                expectedIpFingerprint = ipSecurityFingerprint,
+                requestPath = request.requestURI,
+                reason = "refresh-token-ip-mismatch",
+                revokeSessionKey = memberSession.sessionKey,
+            ),
+            clientIp,
+        )
+
+        val newAccessToken =
+            actorApplicationService.genAccessToken(
+                member = member,
+                sessionKey = memberSession.sessionKey,
+                rememberLoginEnabled = rememberLoginEnabled,
+                ipSecurityEnabled = ipSecurityEnabled,
+                ipSecurityFingerprint = ipSecurityFingerprint,
+            )
+        authCookieService.issueAccessToken(
+            accessToken = newAccessToken,
+            rememberLoginEnabled = rememberLoginEnabled,
+            sessionKey = memberSession.sessionKey,
+            refreshToken = refreshedSession.refreshToken,
+        )
+        rq.setHeader(HttpHeaders.AUTHORIZATION, "Bearer $newAccessToken")
+
+        securityContextAuthenticationWriter.write(member)
+    }
+}

--- a/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
@@ -18,6 +18,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers
 import org.mockito.BDDMockito.given
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
@@ -189,9 +190,10 @@ class CustomAuthenticationFilterTest {
             assertThat(authentication?.name).isEqualTo("member-54")
             verify(memberSessionUseCase).touchAuthenticated(sessionSnapshot)
             verify(authCookieService, never()).issueAccessToken(
-                accessToken = "legacy-access-token",
-                rememberLoginEnabled = false,
-                sessionKey = sessionKey,
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyBoolean(),
+                ArgumentMatchers.nullable(String::class.java),
+                ArgumentMatchers.nullable(String::class.java),
             )
         } finally {
             SecurityContextHolder.clearContext()

--- a/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
@@ -15,6 +15,7 @@ import jakarta.servlet.http.HttpServlet
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
@@ -28,10 +29,175 @@ import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.core.context.SecurityContextHolder
 import tools.jackson.databind.ObjectMapper
+import java.lang.reflect.Modifier
 import java.time.Instant
 
 @DisplayName("CustomAuthenticationFilter 테스트")
 class CustomAuthenticationFilterTest {
+    @Test
+    @DisplayName("인증 세부 경로는 전용 handler와 resolver 경계로 분리되어 있다")
+    fun `authentication path responsibilities are extracted to handlers`() {
+        val extractedBoundaryTypes =
+            listOf(
+                "com.back.global.security.config.MemberSessionAuthenticationResolver",
+                "com.back.global.security.config.AccessTokenAuthenticationHandler",
+                "com.back.global.security.config.ApiKeyAuthorityRefreshHandler",
+                "com.back.global.security.config.LegacyPayloadRecoveryHandler",
+                "com.back.global.security.config.RefreshTokenAuthenticationHandler",
+            ).map(Class<*>::forName)
+
+        assertThat(extractedBoundaryTypes.map { it.simpleName })
+            .containsExactly(
+                "MemberSessionAuthenticationResolver",
+                "AccessTokenAuthenticationHandler",
+                "ApiKeyAuthorityRefreshHandler",
+                "LegacyPayloadRecoveryHandler",
+                "RefreshTokenAuthenticationHandler",
+            )
+
+        val privateMethodNames =
+            CustomAuthenticationFilter::class.java.declaredMethods
+                .filter { Modifier.isPrivate(it.modifiers) }
+                .map { it.name }
+
+        assertThat(privateMethodNames)
+            .doesNotContain(
+                "resolveMemberSession",
+                "ensureSessionIsUsable",
+                "canUseFreshTokenSessionFallback",
+                "resolveTokenLoginIdentifier",
+                "resolvePrincipalUsername",
+                "shouldPreferApiKeyAuthorityOnWrite",
+            )
+    }
+
+    @Test
+    @DisplayName("세션 검증 resolver는 세션이 선택 사항인 경로에서 쿠키를 만료하지 않는다")
+    fun `session resolver keeps optional missing session usable`() {
+        val memberSessionUseCase = mock(MemberSessionUseCase::class.java)
+        val authCookieService = mock(AuthCookieService::class.java)
+        val resolver =
+            MemberSessionAuthenticationResolver(
+                memberSessionUseCase = memberSessionUseCase,
+                authCookieService = authCookieService,
+                freshLookupGraceSeconds = 15,
+            )
+
+        assertThatCode {
+            resolver.ensureUsable(MemberSessionResolution(sessionKeyProvided = false, session = null))
+        }.doesNotThrowAnyException()
+
+        verify(authCookieService, never()).expireAuthCookies()
+    }
+
+    @Test
+    @DisplayName("legacy payload에 email과 username이 없고 DB 회원도 없으면 member id 기반 principal로 인증한다")
+    fun `legacy payload without persisted member falls back to member id principal`() {
+        val actorApplicationService = mock(ActorApplicationService::class.java)
+        val memberSessionUseCase = mock(MemberSessionUseCase::class.java)
+        val authIpSecurityService = mock(AuthIpSecurityService::class.java)
+        val authSecurityEventService = mock(AuthSecurityEventService::class.java)
+        val authCookieService = mock(AuthCookieService::class.java)
+        val rq = mock(Rq::class.java)
+        val accessToken = "legacy-access-token"
+        val sessionKey = "legacy-session-key"
+        val request = MockHttpServletRequest("GET", "/member/api/v1/auth/session")
+        val sessionSnapshot =
+            MemberSessionAuthSnapshot(
+                id = 11L,
+                memberId = 54L,
+                sessionKey = sessionKey,
+                rememberLoginEnabled = false,
+                ipSecurityEnabled = false,
+                ipSecurityFingerprint = null,
+                lastAuthenticatedAt = Instant.now(),
+            )
+        val sessionResolver =
+            MemberSessionAuthenticationResolver(
+                memberSessionUseCase = memberSessionUseCase,
+                authCookieService = authCookieService,
+                freshLookupGraceSeconds = 15,
+            )
+        val ipSecurityVerifier =
+            AuthIpSecurityVerifier(
+                authIpSecurityService,
+                authSecurityEventService,
+                authCookieService,
+                memberSessionUseCase,
+            )
+        val securityContextAuthenticationWriter = SecurityContextAuthenticationWriter()
+        val handler =
+            AccessTokenAuthenticationHandler(
+                actorApplicationService = actorApplicationService,
+                memberSessionUseCase = memberSessionUseCase,
+                authIpSecurityVerifier = ipSecurityVerifier,
+                securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+                memberSessionAuthenticationResolver = sessionResolver,
+                apiKeyAuthorityRefreshHandler =
+                    ApiKeyAuthorityRefreshHandler(
+                        actorApplicationService = actorApplicationService,
+                        memberSessionUseCase = memberSessionUseCase,
+                        authCookieService = authCookieService,
+                        authIpSecurityVerifier = ipSecurityVerifier,
+                        securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+                        memberSessionAuthenticationResolver = sessionResolver,
+                        rq = rq,
+                    ),
+                legacyPayloadRecoveryHandler =
+                    LegacyPayloadRecoveryHandler(
+                        actorApplicationService = actorApplicationService,
+                        memberSessionUseCase = memberSessionUseCase,
+                        authCookieService = authCookieService,
+                        securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+                        rq = rq,
+                    ),
+            )
+
+        given(actorApplicationService.payload(accessToken))
+            .willReturn(
+                AccessTokenPayload(
+                    id = 54L,
+                    sessionKey = sessionKey,
+                    username = null,
+                    email = null,
+                    name = "aquila",
+                    rememberLoginEnabled = false,
+                    ipSecurityEnabled = false,
+                    ipSecurityFingerprint = null,
+                ),
+            )
+        given(memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(sessionSnapshot)
+        given(actorApplicationService.findById(54L)).willReturn(null)
+
+        try {
+            val handled =
+                handler.authenticate(
+                    request = request,
+                    tokens =
+                        ExtractedAuthTokens(
+                            apiKey = "",
+                            accessToken = accessToken,
+                            sessionKey = sessionKey,
+                            refreshToken = "",
+                        ),
+                    clientIp = "203.0.113.30",
+                )
+
+            assertThat(handled).isTrue()
+            val authentication = SecurityContextHolder.getContext().authentication
+            assertThat(authentication).isNotNull()
+            assertThat(authentication?.name).isEqualTo("member-54")
+            verify(memberSessionUseCase).touchAuthenticated(sessionSnapshot)
+            verify(authCookieService, never()).issueAccessToken(
+                accessToken = "legacy-access-token",
+                rememberLoginEnabled = false,
+                sessionKey = sessionKey,
+            )
+        } finally {
+            SecurityContextHolder.clearContext()
+        }
+    }
+
     @Test
     @DisplayName("prod Swagger와 OpenAPI 문서 경로도 쿠키 인증 필터 대상이다")
     fun `prod api docs paths are authentication filter targets`() {


### PR DESCRIPTION
## 관련 이슈

close #859

## 작업 배경

- `CustomAuthenticationFilter`가 accessToken 인증, apiKey authority 보정, legacy payload 복구, refreshToken 회전, session fallback 판단을 직접 담당해 인증 변경 시 회귀 위험이 컸습니다.
- 공개 API fallback, 보호 API 401 변환, 쓰기 요청 session snapshot 요구, refreshToken 회전 정책은 유지하면서 책임 경계만 분리합니다.

## 작업 내용

- `AccessTokenAuthenticationHandler`, `RefreshTokenAuthenticationHandler`, `ApiKeyAuthorityRefreshHandler`, `LegacyPayloadRecoveryHandler`, `MemberSessionAuthenticationResolver`를 추가해 인증 세부 경로를 분리했습니다.
- HTTP method 판단을 `AuthRequestMethodPolicy`로 분리했습니다.
- `CustomAuthenticationFilter.authenticateIfPossible`는 token 추출, client IP 확인, access/refresh handler 위임만 담당하도록 줄였습니다.
- handler/resolver 경계와 legacy payload fallback 동작을 `CustomAuthenticationFilterTest`에 고정했습니다.
- CodeRabbit 지적에 따라 legacy fallback 테스트가 `issueAccessToken` 호출 자체를 금지하도록 검증을 강화했습니다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back test --tests '*CustomAuthenticationFilterTest.legacy payload without persisted member falls back to member id principal*'` 성공
  - `./back/gradlew -p back test --tests '*CustomAuthenticationFilterTest*'` 성공
  - `./back/gradlew -p back test --tests '*Auth*'` 성공
  - `./back/gradlew -p back ktlintCheck` 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks` 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks` 동일 조건 2회차 성공
  - commit hook: `OpenApiContractExportTest` 및 `yarn contracts:check` 성공
  - GitHub checks: backend-ci, frontend-ci, Security/CodeQL, Vercel Preview 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `CustomAuthenticationFilter`에서 기존 인증 정책이 handler 위임 뒤에도 동일하게 유지되는지
  - legacy payload email 누락 복구와 DB 회원 미존재 fallback principal 동작
  - fresh token session snapshot fallback이 안전한 read 요청에만 유지되는지

## 리스크

- 인증 필터 내부 구조 변경이므로 accessToken/apiKey/refreshToken 조합별 회귀 위험이 있습니다.
- 기존 constructor signature는 유지해 Spring wiring 변경 범위를 줄였습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. 실제 CodeRabbit review가 생성되어 fallback은 불필요했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. PR preview는 성공했고 main merge 후 홈서버 CD를 별도 확인한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 보안 개선
* 토큰 및 API 키 기반 인증 처리 강화
* 세션 관리 및 IP 보안 검증 메커니즘 개선

## 테스트
* 인증 흐름 및 세션 처리 관련 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
