### PR TITLE
[Refactor] HtmlContentSanitizer Safelist 기반 정제 정책 검토

### DIFF
--- a/back/src/main/kotlin/com/back/global/security/application/HtmlContentSanitizer.kt
+++ b/back/src/main/kotlin/com/back/global/security/application/HtmlContentSanitizer.kt
@@ -1,6 +1,8 @@
 package com.back.global.security.application
 
 import org.jsoup.Jsoup
+import org.jsoup.safety.Cleaner
+import org.jsoup.safety.Safelist
 
 /**
  * 게시글 contentHtml 렌더링 전 XSS 위험을 줄이기 위한 HTML 정제 유틸입니다.
@@ -9,81 +11,89 @@ import org.jsoup.Jsoup
  * target="_blank" 링크에는 opener 참조를 막기 위한 rel 값을 보강합니다.
  */
 object HtmlContentSanitizer {
-    private val allowedTags =
-        setOf(
-            "a",
-            "b",
-            "blockquote",
-            "br",
-            "code",
-            "del",
-            "details",
-            "div",
-            "em",
-            "h1",
-            "h2",
-            "h3",
-            "h4",
-            "h5",
-            "h6",
-            "hr",
-            "i",
-            "img",
-            "li",
-            "mark",
-            "ol",
-            "p",
-            "pre",
-            "s",
-            "span",
-            "strong",
-            "sub",
-            "summary",
-            "sup",
-            "table",
-            "tbody",
-            "td",
-            "th",
-            "thead",
-            "tr",
-            "u",
-            "ul",
-        )
+    private const val SANITIZER_BASE_URI = "https://aquilaxk.local/"
 
-    private val blockedProtocols = listOf("javascript:", "vbscript:", "data:")
-    private val uriAttributes = setOf("href", "src")
+    private val safelist =
+        Safelist
+            .none()
+            .addTags(
+                "a",
+                "b",
+                "blockquote",
+                "br",
+                "code",
+                "del",
+                "details",
+                "div",
+                "em",
+                "h1",
+                "h2",
+                "h3",
+                "h4",
+                "h5",
+                "h6",
+                "hr",
+                "i",
+                "img",
+                "li",
+                "mark",
+                "ol",
+                "p",
+                "pre",
+                "s",
+                "span",
+                "strong",
+                "sub",
+                "summary",
+                "sup",
+                "table",
+                "tbody",
+                "td",
+                "th",
+                "thead",
+                "tr",
+                "u",
+                "ul",
+            ).addAttributes(
+                ":all",
+                "class",
+                "id",
+                "title",
+                "role",
+                "aria-hidden",
+                "aria-label",
+                "aria-live",
+                "data-aq-mermaid",
+                "data-callout-type",
+                "data-has-title",
+                "data-language",
+                "data-line",
+                "data-mermaid-rendered",
+                "data-mermaid-source",
+                "data-prism-language",
+                "data-prism-source",
+                "data-raw-code",
+                "data-theme",
+            ).addAttributes("a", "href", "rel", "target")
+            .addAttributes("img", "alt", "decoding", "height", "loading", "src", "width")
+            .addAttributes("ol", "start", "type")
+            .addAttributes("li", "value")
+            .addAttributes("details", "open")
+            .addAttributes("td", "align", "colspan", "rowspan")
+            .addAttributes("th", "align", "colspan", "rowspan")
+            .addProtocols("a", "href", "http", "https", "mailto")
+            .addProtocols("img", "src", "http", "https")
+            .preserveRelativeLinks(true)
+
+    private val cleaner = Cleaner(safelist)
 
     fun sanitizeRichHtmlOrNull(rawHtml: String?): String? {
         if (rawHtml.isNullOrBlank()) return null
 
-        val document = Jsoup.parseBodyFragment(rawHtml)
-        val body = document.body()
+        val document = Jsoup.parseBodyFragment(rawHtml, SANITIZER_BASE_URI)
+        val body = cleaner.clean(document).body()
 
-        body.getAllElements().toList().forEach { element ->
-            if (element === body) return@forEach
-
-            if (element.tagName().lowercase() !in allowedTags) {
-                element.unwrap()
-                return@forEach
-            }
-
-            element.attributes().toList().forEach { attr ->
-                val key = attr.key.lowercase()
-                val value = attr.value.trim()
-
-                if (key.startsWith("on") || key == "style" || key == "srcdoc") {
-                    element.removeAttr(attr.key)
-                    return@forEach
-                }
-
-                if (key in uriAttributes) {
-                    val normalized = normalizeUriForProtocolCheck(value)
-                    if (blockedProtocols.any { normalized.startsWith(it) }) {
-                        element.removeAttr(attr.key)
-                    }
-                }
-            }
-
+        body.getAllElements().forEach { element ->
             if (element.tagName().equals("a", ignoreCase = true) && element.attr("target") == "_blank") {
                 val mergedRel =
                     element
@@ -101,9 +111,4 @@ object HtmlContentSanitizer {
         val sanitized = body.html().trim()
         return sanitized.ifBlank { null }
     }
-
-    private fun normalizeUriForProtocolCheck(value: String): String =
-        value
-            .filterNot { it.isWhitespace() || it.isISOControl() }
-            .lowercase()
 }

--- a/back/src/test/kotlin/com/back/global/security/application/HtmlContentSanitizerTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/application/HtmlContentSanitizerTest.kt
@@ -61,6 +61,70 @@ class HtmlContentSanitizerTest {
     }
 
     @Test
+    @DisplayName("srcset 같은 비필수 URL 속성은 정제 결과에 남기지 않는다")
+    fun removesNonEssentialUriAttributes() {
+        // given
+        val rawHtml =
+            """
+            <img src="https://cdn.example.com/a.png" srcset="javascript:alert(1) 1x, https://cdn.example.com/a@2x.png 2x">
+            <table background="javascript:alert(2)"><tr><td formaction="javascript:alert(3)">cell</td></tr></table>
+            """.trimIndent()
+
+        // when
+        val sanitized = HtmlContentSanitizer.sanitizeRichHtmlOrNull(rawHtml)
+
+        // then
+        assertThat(sanitized).contains("<img src=\"https://cdn.example.com/a.png\">")
+        assertThat(sanitized).contains("<table>")
+        assertThat(sanitized).contains("<td>cell</td>")
+        assertThat(sanitized).doesNotContain("srcset")
+        assertThat(sanitized).doesNotContain("background")
+        assertThat(sanitized).doesNotContain("formaction")
+        assertThat(sanitized).doesNotContain("javascript:")
+    }
+
+    @Test
+    @DisplayName("Markdown 코드 렌더링에 필요한 class와 data 속성은 유지한다")
+    fun preservesMarkdownRenderingMetadataAttributes() {
+        // given
+        val rawHtml =
+            """
+            <pre class="aq-pretty-pre" data-language="kotlin" data-prism-source="println(1)">
+            <code class="language-kotlin" data-prism-language="kotlin" data-raw-code="println(1)">
+            <span class="line" data-line="true">println(1)</span>
+            </code>
+            </pre>
+            """.trimIndent()
+
+        // when
+        val sanitized = HtmlContentSanitizer.sanitizeRichHtmlOrNull(rawHtml)
+
+        // then
+        assertThat(sanitized).contains("class=\"aq-pretty-pre\"")
+        assertThat(sanitized).contains("data-language=\"kotlin\"")
+        assertThat(sanitized).contains("data-prism-source=\"println(1)\"")
+        assertThat(sanitized).contains("class=\"language-kotlin\"")
+        assertThat(sanitized).contains("data-prism-language=\"kotlin\"")
+        assertThat(sanitized).contains("data-raw-code=\"println(1)\"")
+        assertThat(sanitized).contains("class=\"line\"")
+        assertThat(sanitized).contains("data-line=\"true\"")
+    }
+
+    @Test
+    @DisplayName("상대 경로 href/src는 절대 URL로 바꾸지 않고 유지한다")
+    fun preservesRelativeHrefAndSrc() {
+        // given
+        val rawHtml = """<a href="/posts/1">post</a><img src="/images/a.png" alt="thumbnail">"""
+
+        // when
+        val sanitized = HtmlContentSanitizer.sanitizeRichHtmlOrNull(rawHtml)
+
+        // then
+        assertThat(sanitized).contains("""<a href="/posts/1">post</a>""")
+        assertThat(sanitized).contains("""<img src="/images/a.png" alt="thumbnail">""")
+    }
+
+    @Test
     @DisplayName("target blank 링크에는 opener 참조 차단 rel을 보강한다")
     fun addsNoopenerNoreferrerToBlankTargets() {
         // given


### PR DESCRIPTION
## 관련 이슈

close #860

## 작업 배경

- `HtmlContentSanitizer`가 허용 태그 판단, 속성 제거, 위험 URI 차단을 직접 순회하며 처리해 URL성 속성 누락 위험이 있었다.
- 기존 `href/src` 차단 계약과 `_blank` rel 보강은 유지하면서 jsoup `Safelist` 기반 allowlist로 좁힐 필요가 있었다.

## 작업 내용

- `HtmlContentSanitizer`를 `Safelist.none()` 기반으로 전환해 허용 태그, 속성, URI protocol을 명시했다.
- `srcset`, `background`, `formaction`처럼 게시글 렌더링에 필요하지 않은 URL성 속성은 정제 결과에 남지 않도록 했다.
- Markdown 코드 렌더링에 필요한 `class`, `data-language`, `data-prism-*`, `data-raw-code`, `data-line` 속성과 상대 경로 `href/src` 보존 테스트를 추가했다.
- `target="_blank"` 링크의 `noopener noreferrer` 보강은 Safelist 정제 후처리로 유지했다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back test --tests '*HtmlContentSanitizerTest*'` 성공
  - `./back/gradlew -p back ktlintCheck` 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks` 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks` 성공
  - commit hook `OpenApiContractExportTest`, `yarn contracts:check` 성공
  - GitHub PR checks: backend-ci, frontend-ci, Security/CodeQL, Vercel 성공
  - CodeRabbit review: actionable comment 0개

## 리뷰어 메모

- `HtmlContentSanitizer.kt`의 Safelist 허용 속성이 기존 렌더링 계약을 충분히 보존하면서 불필요한 URL성 속성을 줄였는지 먼저 봐 주세요.
- 첫 RED 테스트에서 기존 수동 구현은 `srcset/background/formaction` 차단 케이스를 실패했고, Safelist 전환 후 통과했습니다.

## 리스크

- 허용 속성이 이전보다 좁아졌기 때문에 저장된 일부 커스텀 HTML 속성이 렌더링에서 제거될 수 있다.
- 게시글 렌더링에 필요한 코드/mermaid 관련 class/data 속성은 테스트로 보존했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (N/A: CodeRabbit 실제 리뷰 완료)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (N/A: backend sanitizer 변경, PR preview 배포만 확인)
