### PR TITLE
[Refactor] PostApplicationService 게시글 쓰기 책임 분리

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -918,9 +918,12 @@ class PostApplicationService(
                 ?: throw AppException("404-1", "복구된 글을 확인할 수 없습니다.")
         val restoredTags = extractNormalizedTags(restoredPost.content)
         val isPublic = isPubliclyListed(restoredPost)
-        evictReadCaches(
-            PostReadCacheInvalidationRequest(
+        enqueuePostWriteSideEffect(
+            PostWriteSideEffectCommand(
                 postId = id,
+                previousContent = null,
+                currentContent = null,
+                deletedContent = null,
                 beforeTags = emptyList(),
                 afterTags = restoredTags,
                 evictHotReadPages = isPublic,
@@ -929,13 +932,9 @@ class PostApplicationService(
                 evictTagsPublic = isPublic,
                 evictDetail = isPublic,
                 evictReason = "restore",
+                recommendationAction = recommendationActionFor(isPublic),
             ),
         )
-        if (isPublic) {
-            postRecommendFeatureStoreService.refresh(restoredPost)
-        } else {
-            postRecommendFeatureStoreService.evict(restoredPost.id)
-        }
 
         return restoredPost
     }
@@ -950,20 +949,17 @@ class PostApplicationService(
             postRepository.findDeletedSnapshotById(id)
                 ?: throw AppException("404-1", "해당 글을 찾을 수 없습니다.")
 
-        runCatching {
-            uploadedFileRetentionService.scheduleDeletedPostAttachments(snapshot.content)
-        }.onFailure { exception ->
-            logger.warn("Failed to schedule cleanup for hard-deleted post id={}", id, exception)
-        }
-
         val hardDeleted = postRepository.hardDeleteDeletedById(id)
         if (!hardDeleted) {
             throw AppException("404-1", "이미 영구삭제되었거나 존재하지 않는 글입니다.")
         }
 
-        evictReadCaches(
-            PostReadCacheInvalidationRequest(
+        enqueuePostWriteSideEffect(
+            PostWriteSideEffectCommand(
                 postId = id,
+                previousContent = null,
+                currentContent = null,
+                deletedContent = snapshot.content,
                 beforeTags = extractNormalizedTags(snapshot.content),
                 afterTags = emptyList(),
                 evictHotReadPages = true,
@@ -972,9 +968,9 @@ class PostApplicationService(
                 evictTagsPublic = true,
                 evictDetail = true,
                 evictReason = "hard-delete",
+                recommendationAction = PostRecommendationSideEffect.EVICT,
             ),
         )
-        postRecommendFeatureStoreService.evict(id)
     }
 
     fun findPagedByAuthor(
@@ -1348,12 +1344,6 @@ class PostApplicationService(
 
     private fun enqueuePostWriteSideEffect(command: PostWriteSideEffectCommand) {
         postWriteSideEffectHandler.enqueue(command) {
-            publicTagCountsCache = null
-        }
-    }
-
-    private fun evictReadCaches(request: PostReadCacheInvalidationRequest) {
-        postWriteSideEffectHandler.evictReadCaches(request) {
             publicTagCountsCache = null
         }
     }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -44,19 +44,12 @@ import com.back.global.security.application.HtmlContentSanitizer
 import com.back.global.storage.application.UploadedFileRetentionService
 import com.back.standard.dto.page.PagedResult
 import com.back.standard.dto.post.type1.PostSearchSortType1
-import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.cache.CacheManager
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.stereotype.Service
-import org.springframework.transaction.PlatformTransactionManager
-import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionSynchronization
-import org.springframework.transaction.support.TransactionSynchronizationManager
-import org.springframework.transaction.support.TransactionTemplate
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -78,12 +71,10 @@ class PostApplicationService(
     private val secureTipPort: SecureTipPort,
     private val eventPublisher: EventPublisher,
     private val uploadedFileRetentionService: UploadedFileRetentionService,
-    private val cacheManager: CacheManager,
-    private val transactionManager: PlatformTransactionManager,
-    private val meterRegistry: MeterRegistry? = null,
     private val postRecommendRankingService: PostRecommendRankingService,
     private val postRecommendFeatureStoreService: PostRecommendFeatureStoreService,
     private val postKeywordSearchPipelineService: PostKeywordSearchPipelineService,
+    private val postWriteSideEffectHandler: PostWriteSideEffectHandler,
     @param:Value("\${custom.post.read.tags-local-cache-ttl-seconds:180}")
     private val tagsLocalCacheTtlSeconds: Long,
 ) {
@@ -100,13 +91,6 @@ class PostApplicationService(
     private var publicTagCountsCache: TagCountsCache? = null
 
     private val tagCacheTtlMillis: Long = tagsLocalCacheTtlSeconds.coerceAtLeast(5) * 1_000
-    private val hotPageSizes = listOf(30, 24, 16)
-    private val hotSorts = listOf(PostSearchSortType1.CREATED_AT)
-    private val maxTagCacheEvict = 12
-    private val afterCommitSideEffectTransactionTemplate =
-        TransactionTemplate(transactionManager).apply {
-            propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
-        }
 
     fun count(): Long = postRepository.count()
 
@@ -934,15 +918,18 @@ class PostApplicationService(
                 ?: throw AppException("404-1", "복구된 글을 확인할 수 없습니다.")
         val restoredTags = extractNormalizedTags(restoredPost.content)
         val isPublic = isPubliclyListed(restoredPost)
-        clearReadCaches(
-            postId = id,
-            afterTags = restoredTags,
-            evictHotReadPages = isPublic,
-            evictSearchFirstPage = isPublic,
-            evictImpactedTagPages = isPublic,
-            evictTagsPublic = isPublic,
-            evictDetail = isPublic,
-            evictReason = "restore",
+        evictReadCaches(
+            PostReadCacheInvalidationRequest(
+                postId = id,
+                beforeTags = emptyList(),
+                afterTags = restoredTags,
+                evictHotReadPages = isPublic,
+                evictSearchFirstPage = isPublic,
+                evictImpactedTagPages = isPublic,
+                evictTagsPublic = isPublic,
+                evictDetail = isPublic,
+                evictReason = "restore",
+            ),
         )
         if (isPublic) {
             postRecommendFeatureStoreService.refresh(restoredPost)
@@ -974,16 +961,18 @@ class PostApplicationService(
             throw AppException("404-1", "이미 영구삭제되었거나 존재하지 않는 글입니다.")
         }
 
-        clearReadCaches(
-            postId = id,
-            beforeTags = extractNormalizedTags(snapshot.content),
-            afterTags = emptyList(),
-            evictHotReadPages = true,
-            evictSearchFirstPage = true,
-            evictImpactedTagPages = true,
-            evictTagsPublic = true,
-            evictDetail = true,
-            evictReason = "hard-delete",
+        evictReadCaches(
+            PostReadCacheInvalidationRequest(
+                postId = id,
+                beforeTags = extractNormalizedTags(snapshot.content),
+                afterTags = emptyList(),
+                evictHotReadPages = true,
+                evictSearchFirstPage = true,
+                evictImpactedTagPages = true,
+                evictTagsPublic = true,
+                evictDetail = true,
+                evictReason = "hard-delete",
+            ),
         )
         postRecommendFeatureStoreService.evict(id)
     }
@@ -1358,241 +1347,15 @@ class PostApplicationService(
         if (isPublic) PostRecommendationSideEffect.REFRESH else PostRecommendationSideEffect.EVICT
 
     private fun enqueuePostWriteSideEffect(command: PostWriteSideEffectCommand) {
-        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-            handlePostWriteSideEffect(command)
-            return
-        }
-
-        if (command.evictTagsPublic) {
+        postWriteSideEffectHandler.enqueue(command) {
             publicTagCountsCache = null
         }
-        TransactionSynchronizationManager.registerSynchronization(
-            object : TransactionSynchronization {
-                override fun afterCommit() {
-                    handlePostWriteSideEffect(command)
-                }
-            },
-        )
     }
 
-    private fun handlePostWriteSideEffect(command: PostWriteSideEffectCommand) {
-        runCatching {
-            clearReadCaches(
-                postId = command.postId,
-                beforeTags = command.beforeTags,
-                afterTags = command.afterTags,
-                evictHotReadPages = command.evictHotReadPages,
-                evictSearchFirstPage = command.evictSearchFirstPage,
-                evictImpactedTagPages = command.evictImpactedTagPages,
-                evictTagsPublic = command.evictTagsPublic,
-                evictDetail = command.evictDetail,
-                evictReason = command.evictReason,
-            )
-        }.onFailure { exception ->
-            logger.warn("Failed to evict post read caches after commit: postId={}", command.postId, exception)
-        }
-
-        command.currentContent?.let { currentContent ->
-            runAfterCommitSideEffectInNewTransaction(
-                postId = command.postId,
-                failureMessage = "Failed to sync post attachments after commit",
-            ) {
-                uploadedFileRetentionService.syncPostContent(command.postId, command.previousContent, currentContent)
-            }
-        }
-
-        command.deletedContent?.let { deletedContent ->
-            runAfterCommitSideEffectInNewTransaction(
-                postId = command.postId,
-                failureMessage = "Failed to schedule cleanup for deleted post after commit",
-            ) {
-                uploadedFileRetentionService.scheduleDeletedPostAttachments(deletedContent)
-            }
-        }
-
-        when (command.recommendationAction) {
-            PostRecommendationSideEffect.REFRESH ->
-                runAfterCommitSideEffectInNewTransaction(
-                    postId = command.postId,
-                    failureMessage = "Failed to refresh recommend feature store after commit",
-                ) {
-                    refreshRecommendFeatureStoreAfterCommit(command.postId)
-                }
-
-            PostRecommendationSideEffect.EVICT -> postRecommendFeatureStoreService.evict(command.postId)
-        }
-    }
-
-    private fun runAfterCommitSideEffectInNewTransaction(
-        postId: Long,
-        failureMessage: String,
-        block: () -> Unit,
-    ) {
-        runCatching {
-            afterCommitSideEffectTransactionTemplate.executeWithoutResult {
-                block()
-            }
-        }.onFailure { exception ->
-            logger.warn("{}: postId={}", failureMessage, postId, exception)
-        }
-    }
-
-    private fun refreshRecommendFeatureStoreAfterCommit(postId: Long) {
-        val post =
-            postRepository.findById(postId).getOrNull()
-                ?: run {
-                    logger.warn("recommend_feature_store_refresh_skipped_missing_post postId={}", postId)
-                    return
-                }
-        hydratePostAttrs(post)
-        postRecommendFeatureStoreService.refresh(post)
-    }
-
-    private fun clearReadCaches(
-        postId: Long? = null,
-        beforeTags: Collection<String> = emptyList(),
-        afterTags: Collection<String> = emptyList(),
-        evictHotReadPages: Boolean = true,
-        evictSearchFirstPage: Boolean = true,
-        evictImpactedTagPages: Boolean = true,
-        evictTagsPublic: Boolean = true,
-        evictDetail: Boolean = true,
-        evictReason: String = "unknown",
-    ) {
-        if (evictTagsPublic) {
+    private fun evictReadCaches(request: PostReadCacheInvalidationRequest) {
+        postWriteSideEffectHandler.evictReadCaches(request) {
             publicTagCountsCache = null
-            recordCacheEvict("local-tag-counts", "clear", evictReason)
         }
-        val feedCache = cacheManager.getCache(PostQueryCacheNames.FEED)
-        val exploreCache = cacheManager.getCache(PostQueryCacheNames.EXPLORE)
-        val adminPostsFirstPageCache = cacheManager.getCache(PostQueryCacheNames.ADMIN_POSTS_FIRST_PAGE)
-        val feedCursorFirstCache = cacheManager.getCache(PostQueryCacheNames.FEED_CURSOR_FIRST)
-        val exploreCursorFirstCache = cacheManager.getCache(PostQueryCacheNames.EXPLORE_CURSOR_FIRST)
-        val bootstrapCache = cacheManager.getCache(PostQueryCacheNames.BOOTSTRAP)
-        val searchCache = cacheManager.getCache(PostQueryCacheNames.SEARCH)
-        val searchNegativeCache = cacheManager.getCache(PostQueryCacheNames.SEARCH_NEGATIVE)
-        val tagsCache = cacheManager.getCache(PostQueryCacheNames.TAGS)
-
-        if (evictHotReadPages || evictSearchFirstPage) {
-            adminPostsFirstPageCache?.evict("page=1:size=20:sort=${PostSearchSortType1.CREATED_AT.name}")
-            recordCacheEvict(PostQueryCacheNames.ADMIN_POSTS_FIRST_PAGE, "key", evictReason)
-            hotPageSizes.forEach { pageSize ->
-                hotSorts.forEach { sort ->
-                    val sortName = sort.name
-                    if (evictHotReadPages) {
-                        feedCache?.evict("page=1:size=$pageSize:sort=$sortName")
-                        recordCacheEvict(PostQueryCacheNames.FEED, "key", evictReason)
-                        exploreCache?.evict("page=1:size=$pageSize:sort=$sortName:kw=_:tag=_")
-                        recordCacheEvict(PostQueryCacheNames.EXPLORE, "key", evictReason)
-                        feedCursorFirstCache?.evict("size=$pageSize:sort=$sortName")
-                        recordCacheEvict(PostQueryCacheNames.FEED_CURSOR_FIRST, "key", evictReason)
-                        exploreCursorFirstCache?.evict("size=$pageSize:sort=$sortName:tag=_")
-                        recordCacheEvict(PostQueryCacheNames.EXPLORE_CURSOR_FIRST, "key", evictReason)
-                        bootstrapCache?.evict(
-                            PostPublicReadQueryService.buildBootstrapCacheKey(
-                                pageSize = pageSize,
-                                sort = sort,
-                                tag = "",
-                            ),
-                        )
-                        recordCacheEvict(PostQueryCacheNames.BOOTSTRAP, "key", evictReason)
-                    }
-                    if (evictSearchFirstPage) {
-                        searchCache?.evict("page=1:size=$pageSize:sort=$sortName:kw=_")
-                        recordCacheEvict(PostQueryCacheNames.SEARCH, "key", evictReason)
-                        searchNegativeCache?.evict("page=1:size=$pageSize:sort=$sortName:kw=_")
-                        recordCacheEvict(PostQueryCacheNames.SEARCH_NEGATIVE, "key", evictReason)
-                    }
-                }
-            }
-        }
-
-        if (evictImpactedTagPages) {
-            val impactedTagTokens =
-                buildList(beforeTags.size + afterTags.size) {
-                    addAll(beforeTags)
-                    addAll(afterTags)
-                }.asSequence()
-                    .map(String::trim)
-                    .filter(String::isNotBlank)
-                    .map(PostPublicReadQueryService::toCacheKeyToken)
-                    .distinct()
-                    .take(maxTagCacheEvict)
-                    .toList()
-
-            impactedTagTokens.forEach { token ->
-                hotPageSizes.forEach { pageSize ->
-                    hotSorts.forEach { sort ->
-                        val sortName = sort.name
-                        exploreCache?.evict("page=1:size=$pageSize:sort=$sortName:kw=_:tag=$token")
-                        recordCacheEvict(PostQueryCacheNames.EXPLORE, "key", evictReason)
-                        exploreCursorFirstCache?.evict("size=$pageSize:sort=$sortName:tag=$token")
-                        recordCacheEvict(PostQueryCacheNames.EXPLORE_CURSOR_FIRST, "key", evictReason)
-                    }
-                }
-            }
-
-            buildList(beforeTags.size + afterTags.size) {
-                addAll(beforeTags)
-                addAll(afterTags)
-            }.asSequence()
-                .map(String::trim)
-                .filter(String::isNotBlank)
-                .distinct()
-                .take(maxTagCacheEvict)
-                .forEach { rawTag ->
-                    hotPageSizes.forEach { pageSize ->
-                        hotSorts.forEach { sort ->
-                            bootstrapCache?.evict(
-                                PostPublicReadQueryService.buildBootstrapCacheKey(
-                                    pageSize = pageSize,
-                                    sort = sort,
-                                    tag = rawTag,
-                                ),
-                            )
-                            recordCacheEvict(PostQueryCacheNames.BOOTSTRAP, "key", evictReason)
-                        }
-                    }
-                }
-        }
-
-        if (evictTagsPublic) {
-            tagsCache?.evict("public")
-            recordCacheEvict(PostQueryCacheNames.TAGS, "key", evictReason)
-        }
-        if (evictDetail) {
-            val detailSnapshotCache = cacheManager.getCache(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT)
-            val detailMetaCache = cacheManager.getCache(PostQueryCacheNames.DETAIL_PUBLIC_META)
-            val detailContentCache = cacheManager.getCache(PostQueryCacheNames.DETAIL_PUBLIC_CONTENT)
-            val detailNegativeCache = cacheManager.getCache(PostQueryCacheNames.DETAIL_PUBLIC_NEGATIVE)
-            if (postId == null) {
-                detailSnapshotCache?.clear()
-                recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT, "clear", evictReason)
-                detailMetaCache?.clear()
-                recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_META, "clear", evictReason)
-                detailContentCache?.clear()
-                recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_CONTENT, "clear", evictReason)
-                detailNegativeCache?.clear()
-                recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_NEGATIVE, "clear", evictReason)
-            } else {
-                detailSnapshotCache?.evict(postId)
-                recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT, "key", evictReason)
-                detailMetaCache?.evict(postId)
-                recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_META, "key", evictReason)
-                detailContentCache?.evict(postId)
-                recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_CONTENT, "key", evictReason)
-                detailNegativeCache?.evict(postId)
-                recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_NEGATIVE, "key", evictReason)
-            }
-        }
-    }
-
-    private fun recordCacheEvict(
-        cacheName: String,
-        scope: String,
-        reason: String,
-    ) {
-        meterRegistry?.counter("post.read.cache.evict", "cache", cacheName, "scope", scope, "reason", reason)?.increment()
     }
 
     private fun isPubliclyListed(post: Post): Boolean = post.published && post.listed

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostReadCacheInvalidator.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostReadCacheInvalidator.kt
@@ -1,0 +1,182 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.standard.dto.post.type1.PostSearchSortType1
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import org.springframework.stereotype.Component
+
+internal data class PostReadCacheInvalidationRequest(
+    val postId: Long?,
+    val beforeTags: Collection<String>,
+    val afterTags: Collection<String>,
+    val evictHotReadPages: Boolean,
+    val evictSearchFirstPage: Boolean,
+    val evictImpactedTagPages: Boolean,
+    val evictTagsPublic: Boolean,
+    val evictDetail: Boolean,
+    val evictReason: String,
+)
+
+@Component
+class PostReadCacheInvalidator(
+    private val cacheManager: CacheManager,
+    private val meterRegistry: MeterRegistry? = null,
+) {
+    private val hotPageSizes = listOf(30, 24, 16)
+    private val hotSorts = listOf(PostSearchSortType1.CREATED_AT)
+    private val maxTagCacheEvict = 12
+
+    internal fun invalidate(
+        request: PostReadCacheInvalidationRequest,
+        onPublicTagsEvicted: () -> Unit,
+    ) {
+        if (request.evictTagsPublic) {
+            onPublicTagsEvicted()
+            recordCacheEvict("local-tag-counts", "clear", request.evictReason)
+        }
+        val feedCache = cacheManager.getCache(PostQueryCacheNames.FEED)
+        val exploreCache = cacheManager.getCache(PostQueryCacheNames.EXPLORE)
+        val adminPostsFirstPageCache = cacheManager.getCache(PostQueryCacheNames.ADMIN_POSTS_FIRST_PAGE)
+        val feedCursorFirstCache = cacheManager.getCache(PostQueryCacheNames.FEED_CURSOR_FIRST)
+        val exploreCursorFirstCache = cacheManager.getCache(PostQueryCacheNames.EXPLORE_CURSOR_FIRST)
+        val bootstrapCache = cacheManager.getCache(PostQueryCacheNames.BOOTSTRAP)
+        val searchCache = cacheManager.getCache(PostQueryCacheNames.SEARCH)
+        val searchNegativeCache = cacheManager.getCache(PostQueryCacheNames.SEARCH_NEGATIVE)
+        val tagsCache = cacheManager.getCache(PostQueryCacheNames.TAGS)
+
+        if (request.evictHotReadPages || request.evictSearchFirstPage) {
+            adminPostsFirstPageCache?.evict("page=1:size=20:sort=${PostSearchSortType1.CREATED_AT.name}")
+            recordCacheEvict(PostQueryCacheNames.ADMIN_POSTS_FIRST_PAGE, "key", request.evictReason)
+            hotPageSizes.forEach { pageSize ->
+                hotSorts.forEach { sort ->
+                    val sortName = sort.name
+                    if (request.evictHotReadPages) {
+                        feedCache?.evict("page=1:size=$pageSize:sort=$sortName")
+                        recordCacheEvict(PostQueryCacheNames.FEED, "key", request.evictReason)
+                        exploreCache?.evict("page=1:size=$pageSize:sort=$sortName:kw=_:tag=_")
+                        recordCacheEvict(PostQueryCacheNames.EXPLORE, "key", request.evictReason)
+                        feedCursorFirstCache?.evict("size=$pageSize:sort=$sortName")
+                        recordCacheEvict(PostQueryCacheNames.FEED_CURSOR_FIRST, "key", request.evictReason)
+                        exploreCursorFirstCache?.evict("size=$pageSize:sort=$sortName:tag=_")
+                        recordCacheEvict(PostQueryCacheNames.EXPLORE_CURSOR_FIRST, "key", request.evictReason)
+                        bootstrapCache?.evict(
+                            PostPublicReadQueryService.buildBootstrapCacheKey(
+                                pageSize = pageSize,
+                                sort = sort,
+                                tag = "",
+                            ),
+                        )
+                        recordCacheEvict(PostQueryCacheNames.BOOTSTRAP, "key", request.evictReason)
+                    }
+                    if (request.evictSearchFirstPage) {
+                        searchCache?.evict("page=1:size=$pageSize:sort=$sortName:kw=_")
+                        recordCacheEvict(PostQueryCacheNames.SEARCH, "key", request.evictReason)
+                        searchNegativeCache?.evict("page=1:size=$pageSize:sort=$sortName:kw=_")
+                        recordCacheEvict(PostQueryCacheNames.SEARCH_NEGATIVE, "key", request.evictReason)
+                    }
+                }
+            }
+        }
+
+        if (request.evictImpactedTagPages) {
+            evictImpactedTagPages(request, exploreCache, exploreCursorFirstCache, bootstrapCache)
+        }
+
+        if (request.evictTagsPublic) {
+            tagsCache?.evict("public")
+            recordCacheEvict(PostQueryCacheNames.TAGS, "key", request.evictReason)
+        }
+        if (request.evictDetail) {
+            evictDetailCaches(request)
+        }
+    }
+
+    private fun evictImpactedTagPages(
+        request: PostReadCacheInvalidationRequest,
+        exploreCache: Cache?,
+        exploreCursorFirstCache: Cache?,
+        bootstrapCache: Cache?,
+    ) {
+        val impactedTagTokens =
+            buildList(request.beforeTags.size + request.afterTags.size) {
+                addAll(request.beforeTags)
+                addAll(request.afterTags)
+            }.asSequence()
+                .map(String::trim)
+                .filter(String::isNotBlank)
+                .map(PostPublicReadQueryService::toCacheKeyToken)
+                .distinct()
+                .take(maxTagCacheEvict)
+                .toList()
+
+        impactedTagTokens.forEach { token ->
+            hotPageSizes.forEach { pageSize ->
+                hotSorts.forEach { sort ->
+                    val sortName = sort.name
+                    exploreCache?.evict("page=1:size=$pageSize:sort=$sortName:kw=_:tag=$token")
+                    recordCacheEvict(PostQueryCacheNames.EXPLORE, "key", request.evictReason)
+                    exploreCursorFirstCache?.evict("size=$pageSize:sort=$sortName:tag=$token")
+                    recordCacheEvict(PostQueryCacheNames.EXPLORE_CURSOR_FIRST, "key", request.evictReason)
+                }
+            }
+        }
+
+        buildList(request.beforeTags.size + request.afterTags.size) {
+            addAll(request.beforeTags)
+            addAll(request.afterTags)
+        }.asSequence()
+            .map(String::trim)
+            .filter(String::isNotBlank)
+            .distinct()
+            .take(maxTagCacheEvict)
+            .forEach { rawTag ->
+                hotPageSizes.forEach { pageSize ->
+                    hotSorts.forEach { sort ->
+                        bootstrapCache?.evict(
+                            PostPublicReadQueryService.buildBootstrapCacheKey(
+                                pageSize = pageSize,
+                                sort = sort,
+                                tag = rawTag,
+                            ),
+                        )
+                        recordCacheEvict(PostQueryCacheNames.BOOTSTRAP, "key", request.evictReason)
+                    }
+                }
+            }
+    }
+
+    private fun evictDetailCaches(request: PostReadCacheInvalidationRequest) {
+        val detailSnapshotCache = cacheManager.getCache(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT)
+        val detailMetaCache = cacheManager.getCache(PostQueryCacheNames.DETAIL_PUBLIC_META)
+        val detailContentCache = cacheManager.getCache(PostQueryCacheNames.DETAIL_PUBLIC_CONTENT)
+        val detailNegativeCache = cacheManager.getCache(PostQueryCacheNames.DETAIL_PUBLIC_NEGATIVE)
+        if (request.postId == null) {
+            detailSnapshotCache?.clear()
+            recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT, "clear", request.evictReason)
+            detailMetaCache?.clear()
+            recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_META, "clear", request.evictReason)
+            detailContentCache?.clear()
+            recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_CONTENT, "clear", request.evictReason)
+            detailNegativeCache?.clear()
+            recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_NEGATIVE, "clear", request.evictReason)
+        } else {
+            detailSnapshotCache?.evict(request.postId)
+            recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT, "key", request.evictReason)
+            detailMetaCache?.evict(request.postId)
+            recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_META, "key", request.evictReason)
+            detailContentCache?.evict(request.postId)
+            recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_CONTENT, "key", request.evictReason)
+            detailNegativeCache?.evict(request.postId)
+            recordCacheEvict(PostQueryCacheNames.DETAIL_PUBLIC_NEGATIVE, "key", request.evictReason)
+        }
+    }
+
+    private fun recordCacheEvict(
+        cacheName: String,
+        scope: String,
+        reason: String,
+    ) {
+        meterRegistry?.counter("post.read.cache.evict", "cache", cacheName, "scope", scope, "reason", reason)?.increment()
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt
@@ -1,0 +1,146 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.boundedContexts.post.domain.Post
+import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
+import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
+import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
+import com.back.global.storage.application.UploadedFileRetentionService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import org.springframework.transaction.support.TransactionTemplate
+import kotlin.jvm.optionals.getOrNull
+
+@Component
+class PostWriteSideEffectHandler(
+    private val postReadCacheInvalidator: PostReadCacheInvalidator,
+    private val uploadedFileRetentionService: UploadedFileRetentionService,
+    private val postRecommendFeatureStoreService: PostRecommendFeatureStoreService,
+    private val postRepository: PostRepositoryPort,
+    private val postAttrRepository: PostAttrRepositoryPort,
+    transactionManager: PlatformTransactionManager,
+) {
+    private val logger = LoggerFactory.getLogger(PostWriteSideEffectHandler::class.java)
+    private val afterCommitSideEffectTransactionTemplate =
+        TransactionTemplate(transactionManager).apply {
+            propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
+        }
+
+    internal fun enqueue(
+        command: PostWriteSideEffectCommand,
+        onPublicTagsEvicted: () -> Unit,
+    ) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            handle(command, onPublicTagsEvicted)
+            return
+        }
+
+        if (command.evictTagsPublic) {
+            onPublicTagsEvicted()
+        }
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() {
+                    handle(command, onPublicTagsEvicted)
+                }
+            },
+        )
+    }
+
+    internal fun evictReadCaches(
+        request: PostReadCacheInvalidationRequest,
+        onPublicTagsEvicted: () -> Unit,
+    ) {
+        postReadCacheInvalidator.invalidate(request, onPublicTagsEvicted)
+    }
+
+    private fun handle(
+        command: PostWriteSideEffectCommand,
+        onPublicTagsEvicted: () -> Unit,
+    ) {
+        runCatching {
+            postReadCacheInvalidator.invalidate(command.toCacheInvalidationRequest(), onPublicTagsEvicted)
+        }.onFailure { exception ->
+            logger.warn("Failed to evict post read caches after commit: postId={}", command.postId, exception)
+        }
+
+        command.currentContent?.let { currentContent ->
+            runAfterCommitSideEffectInNewTransaction(
+                postId = command.postId,
+                failureMessage = "Failed to sync post attachments after commit",
+            ) {
+                uploadedFileRetentionService.syncPostContent(command.postId, command.previousContent, currentContent)
+            }
+        }
+
+        command.deletedContent?.let { deletedContent ->
+            runAfterCommitSideEffectInNewTransaction(
+                postId = command.postId,
+                failureMessage = "Failed to schedule cleanup for deleted post after commit",
+            ) {
+                uploadedFileRetentionService.scheduleDeletedPostAttachments(deletedContent)
+            }
+        }
+
+        when (command.recommendationAction) {
+            PostRecommendationSideEffect.REFRESH ->
+                runAfterCommitSideEffectInNewTransaction(
+                    postId = command.postId,
+                    failureMessage = "Failed to refresh recommend feature store after commit",
+                ) {
+                    refreshRecommendFeatureStoreAfterCommit(command.postId)
+                }
+
+            PostRecommendationSideEffect.EVICT -> postRecommendFeatureStoreService.evict(command.postId)
+        }
+    }
+
+    private fun runAfterCommitSideEffectInNewTransaction(
+        postId: Long,
+        failureMessage: String,
+        block: () -> Unit,
+    ) {
+        runCatching {
+            afterCommitSideEffectTransactionTemplate.executeWithoutResult {
+                block()
+            }
+        }.onFailure { exception ->
+            logger.warn("{}: postId={}", failureMessage, postId, exception)
+        }
+    }
+
+    private fun refreshRecommendFeatureStoreAfterCommit(postId: Long) {
+        val post =
+            postRepository.findById(postId).getOrNull()
+                ?: run {
+                    logger.warn("recommend_feature_store_refresh_skipped_missing_post postId={}", postId)
+                    return
+                }
+        hydratePostAttrs(post)
+        postRecommendFeatureStoreService.refresh(post)
+    }
+
+    private fun hydratePostAttrs(post: Post) {
+        post.likesCountAttr ?: postAttrRepository.findBySubjectAndName(post, LIKES_COUNT)?.let { post.likesCountAttr = it }
+        post.commentsCountAttr ?: postAttrRepository.findBySubjectAndName(post, COMMENTS_COUNT)?.let { post.commentsCountAttr = it }
+        post.hitCountAttr ?: postAttrRepository.findBySubjectAndName(post, HIT_COUNT)?.let { post.hitCountAttr = it }
+    }
+
+    private fun PostWriteSideEffectCommand.toCacheInvalidationRequest(): PostReadCacheInvalidationRequest =
+        PostReadCacheInvalidationRequest(
+            postId = postId,
+            beforeTags = beforeTags,
+            afterTags = afterTags,
+            evictHotReadPages = evictHotReadPages,
+            evictSearchFirstPage = evictSearchFirstPage,
+            evictImpactedTagPages = evictImpactedTagPages,
+            evictTagsPublic = evictTagsPublic,
+            evictDetail = evictDetail,
+            evictReason = evictReason,
+        )
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt
@@ -52,13 +52,6 @@ class PostWriteSideEffectHandler(
         )
     }
 
-    internal fun evictReadCaches(
-        request: PostReadCacheInvalidationRequest,
-        onPublicTagsEvicted: () -> Unit,
-    ) {
-        postReadCacheInvalidator.invalidate(request, onPublicTagsEvicted)
-    }
-
     private fun handle(
         command: PostWriteSideEffectCommand,
         onPublicTagsEvicted: () -> Unit,
@@ -96,7 +89,13 @@ class PostWriteSideEffectHandler(
                     refreshRecommendFeatureStoreAfterCommit(command.postId)
                 }
 
-            PostRecommendationSideEffect.EVICT -> postRecommendFeatureStoreService.evict(command.postId)
+            PostRecommendationSideEffect.EVICT ->
+                runAfterCommitSideEffectInNewTransaction(
+                    postId = command.postId,
+                    failureMessage = "Failed to evict recommend feature store after commit",
+                ) {
+                    postRecommendFeatureStoreService.evict(command.postId)
+                }
         }
     }
 

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
@@ -11,6 +11,7 @@ import com.back.boundedContexts.post.application.port.output.PostWriteRequestIde
 import com.back.boundedContexts.post.application.port.output.SecureTipPort
 import com.back.boundedContexts.post.domain.POSTS_COUNT
 import com.back.boundedContexts.post.domain.Post
+import com.back.boundedContexts.post.dto.AdmDeletedPostSnapshotDto
 import com.back.global.event.application.EventPublisher
 import com.back.global.storage.application.UploadedFileRetentionService
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
@@ -18,13 +19,16 @@ import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verifyNoInteractions
 import org.springframework.cache.CacheManager
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.TransactionException
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.SimpleTransactionStatus
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.Instant
+import java.util.Optional
 
 @org.junit.jupiter.api.DisplayName("PostApplicationServiceDeleteResilience 테스트")
 class PostApplicationServiceDeleteResilienceTest {
@@ -126,6 +130,79 @@ class PostApplicationServiceDeleteResilienceTest {
         then(postRepository).should().softDeleteById(post.id)
         then(memberAttrRepository).should().incrementIntValue(author, POSTS_COUNT, -1)
         then(postRepository).should().countByAuthor(author)
+    }
+
+    @Test
+    fun `관리자 복구는 캐시와 추천 후속 작업을 commit 이후에 실행한다`() {
+        val snapshot =
+            AdmDeletedPostSnapshotDto(
+                id = 21,
+                title = "복구 대상",
+                content = "복구 본문 #tag",
+                authorId = 3,
+            )
+        val restoredPost =
+            Post(
+                id = 21,
+                author =
+                    Member(
+                        id = 3,
+                        username = "restored-author",
+                        password = null,
+                        nickname = "복구작성자",
+                        email = null,
+                        apiKey = "restored-author-api-key",
+                    ),
+                title = "복구 대상",
+                content = "복구 본문 #tag",
+                published = true,
+                listed = true,
+            )
+        given(postRepository.findDeletedSnapshotById(21)).willReturn(snapshot)
+        given(postRepository.restoreDeletedById(21)).willReturn(true)
+        given(postRepository.findById(21)).willReturn(Optional.of(restoredPost))
+
+        TransactionSynchronizationManager.initSynchronization()
+        try {
+            service.restoreDeletedByIdForAdmin(21)
+
+            verifyNoInteractions(cacheManager, postRecommendFeatureStoreService)
+
+            TransactionSynchronizationManager.getSynchronizations().forEach { it.afterCommit() }
+
+            then(cacheManager).should().getCache(PostQueryCacheNames.FEED)
+            then(postRecommendFeatureStoreService).should().refresh(restoredPost)
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization()
+        }
+    }
+
+    @Test
+    fun `관리자 영구삭제는 캐시와 첨부파일 정리와 추천 evict를 commit 이후에 실행한다`() {
+        val snapshot =
+            AdmDeletedPostSnapshotDto(
+                id = 22,
+                title = "영구삭제 대상",
+                content = "영구삭제 본문 #tag",
+                authorId = 4,
+            )
+        given(postRepository.findDeletedSnapshotById(22)).willReturn(snapshot)
+        given(postRepository.hardDeleteDeletedById(22)).willReturn(true)
+
+        TransactionSynchronizationManager.initSynchronization()
+        try {
+            service.hardDeleteDeletedByIdForAdmin(22)
+
+            verifyNoInteractions(cacheManager, uploadedFileRetentionService, postRecommendFeatureStoreService)
+
+            TransactionSynchronizationManager.getSynchronizations().forEach { it.afterCommit() }
+
+            then(cacheManager).should().getCache(PostQueryCacheNames.FEED)
+            then(uploadedFileRetentionService).should().scheduleDeletedPostAttachments(snapshot.content)
+            then(postRecommendFeatureStoreService).should().evict(22)
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization()
+        }
     }
 
     private class NoopTransactionManager : PlatformTransactionManager {

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
@@ -46,6 +46,16 @@ class PostApplicationServiceDeleteResilienceTest {
         mock(PostRecommendFeatureStoreService::class.java)
     private val postKeywordSearchPipelineService: PostKeywordSearchPipelineService =
         mock(PostKeywordSearchPipelineService::class.java)
+    private val postReadCacheInvalidator = PostReadCacheInvalidator(cacheManager)
+    private val postWriteSideEffectHandler =
+        PostWriteSideEffectHandler(
+            postReadCacheInvalidator = postReadCacheInvalidator,
+            uploadedFileRetentionService = uploadedFileRetentionService,
+            postRecommendFeatureStoreService = postRecommendFeatureStoreService,
+            postRepository = postRepository,
+            postAttrRepository = postAttrRepository,
+            transactionManager = transactionManager,
+        )
 
     private val service =
         PostApplicationService(
@@ -59,11 +69,10 @@ class PostApplicationServiceDeleteResilienceTest {
             secureTipPort = secureTipPort,
             eventPublisher = eventPublisher,
             uploadedFileRetentionService = uploadedFileRetentionService,
-            cacheManager = cacheManager,
-            transactionManager = transactionManager,
             postRecommendRankingService = postRecommendRankingService,
             postRecommendFeatureStoreService = postRecommendFeatureStoreService,
             postKeywordSearchPipelineService = postKeywordSearchPipelineService,
+            postWriteSideEffectHandler = postWriteSideEffectHandler,
             tagsLocalCacheTtlSeconds = 180,
         )
 

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostReadCacheInvalidatorTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostReadCacheInvalidatorTest.kt
@@ -1,0 +1,144 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.standard.dto.post.type1.PostSearchSortType1
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.cache.CacheManager
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+
+@DisplayName("PostReadCacheInvalidator 테스트")
+class PostReadCacheInvalidatorTest {
+    private val meterRegistry = SimpleMeterRegistry()
+    private val cacheManager = newCacheManager()
+    private val invalidator = PostReadCacheInvalidator(cacheManager, meterRegistry)
+
+    @Test
+    @DisplayName("공개 글 변경은 hot feed, 검색 첫 페이지, 영향 태그, 상세 캐시를 함께 축출한다")
+    fun invalidatePublicPostReadCaches() {
+        // given
+        val callbackCalls = mutableListOf<Unit>()
+        put(PostQueryCacheNames.FEED, "page=1:size=30:sort=CREATED_AT")
+        put(PostQueryCacheNames.EXPLORE, "page=1:size=30:sort=CREATED_AT:kw=_:tag=_")
+        put(PostQueryCacheNames.EXPLORE, "page=1:size=30:sort=CREATED_AT:kw=_:tag=kotlin")
+        put(PostQueryCacheNames.FEED_CURSOR_FIRST, "size=30:sort=CREATED_AT")
+        put(PostQueryCacheNames.EXPLORE_CURSOR_FIRST, "size=30:sort=CREATED_AT:tag=kotlin")
+        put(
+            PostQueryCacheNames.BOOTSTRAP,
+            PostPublicReadQueryService.buildBootstrapCacheKey(30, PostSearchSortType1.CREATED_AT, "Kotlin"),
+        )
+        put(PostQueryCacheNames.SEARCH, "page=1:size=30:sort=CREATED_AT:kw=_")
+        put(PostQueryCacheNames.SEARCH_NEGATIVE, "page=1:size=30:sort=CREATED_AT:kw=_")
+        put(PostQueryCacheNames.TAGS, "public")
+        put(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT, 77L)
+        put(PostQueryCacheNames.DETAIL_PUBLIC_META, 77L)
+        put(PostQueryCacheNames.DETAIL_PUBLIC_CONTENT, 77L)
+        put(PostQueryCacheNames.DETAIL_PUBLIC_NEGATIVE, 77L)
+
+        // when
+        invalidator.invalidate(
+            PostReadCacheInvalidationRequest(
+                postId = 77L,
+                beforeTags = listOf("Kotlin"),
+                afterTags = listOf("Spring"),
+                evictHotReadPages = true,
+                evictSearchFirstPage = true,
+                evictImpactedTagPages = true,
+                evictTagsPublic = true,
+                evictDetail = true,
+                evictReason = "test-public",
+            ),
+        ) {
+            callbackCalls += Unit
+        }
+
+        // then
+        assertThat(callbackCalls).hasSize(1)
+        assertThat(get(PostQueryCacheNames.FEED, "page=1:size=30:sort=CREATED_AT")).isNull()
+        assertThat(get(PostQueryCacheNames.EXPLORE, "page=1:size=30:sort=CREATED_AT:kw=_:tag=_")).isNull()
+        assertThat(get(PostQueryCacheNames.EXPLORE, "page=1:size=30:sort=CREATED_AT:kw=_:tag=kotlin")).isNull()
+        assertThat(get(PostQueryCacheNames.FEED_CURSOR_FIRST, "size=30:sort=CREATED_AT")).isNull()
+        assertThat(get(PostQueryCacheNames.EXPLORE_CURSOR_FIRST, "size=30:sort=CREATED_AT:tag=kotlin")).isNull()
+        assertThat(
+            get(
+                PostQueryCacheNames.BOOTSTRAP,
+                PostPublicReadQueryService.buildBootstrapCacheKey(30, PostSearchSortType1.CREATED_AT, "Kotlin"),
+            ),
+        ).isNull()
+        assertThat(get(PostQueryCacheNames.SEARCH, "page=1:size=30:sort=CREATED_AT:kw=_")).isNull()
+        assertThat(get(PostQueryCacheNames.SEARCH_NEGATIVE, "page=1:size=30:sort=CREATED_AT:kw=_")).isNull()
+        assertThat(get(PostQueryCacheNames.TAGS, "public")).isNull()
+        assertThat(get(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT, 77L)).isNull()
+        assertThat(get(PostQueryCacheNames.DETAIL_PUBLIC_META, 77L)).isNull()
+        assertThat(get(PostQueryCacheNames.DETAIL_PUBLIC_CONTENT, 77L)).isNull()
+        assertThat(get(PostQueryCacheNames.DETAIL_PUBLIC_NEGATIVE, 77L)).isNull()
+        assertThat(meterRegistry.find("post.read.cache.evict").counters()).isNotEmpty
+    }
+
+    @Test
+    @DisplayName("postId 없는 상세 축출은 상세 캐시만 전체 clear하고 공개 태그 callback은 호출하지 않는다")
+    fun invalidateAllDetailCachesWithoutTagEviction() {
+        // given
+        val callbackCalls = mutableListOf<Unit>()
+        put(PostQueryCacheNames.FEED, "page=1:size=30:sort=CREATED_AT")
+        put(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT, 101L)
+        put(PostQueryCacheNames.DETAIL_PUBLIC_META, 101L)
+        put(PostQueryCacheNames.DETAIL_PUBLIC_CONTENT, 101L)
+        put(PostQueryCacheNames.DETAIL_PUBLIC_NEGATIVE, 101L)
+
+        // when
+        invalidator.invalidate(
+            PostReadCacheInvalidationRequest(
+                postId = null,
+                beforeTags = emptyList(),
+                afterTags = emptyList(),
+                evictHotReadPages = false,
+                evictSearchFirstPage = false,
+                evictImpactedTagPages = false,
+                evictTagsPublic = false,
+                evictDetail = true,
+                evictReason = "test-detail-clear",
+            ),
+        ) {
+            callbackCalls += Unit
+        }
+
+        // then
+        assertThat(callbackCalls).isEmpty()
+        assertThat(get(PostQueryCacheNames.FEED, "page=1:size=30:sort=CREATED_AT")).isEqualTo("cached")
+        assertThat(get(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT, 101L)).isNull()
+        assertThat(get(PostQueryCacheNames.DETAIL_PUBLIC_META, 101L)).isNull()
+        assertThat(get(PostQueryCacheNames.DETAIL_PUBLIC_CONTENT, 101L)).isNull()
+        assertThat(get(PostQueryCacheNames.DETAIL_PUBLIC_NEGATIVE, 101L)).isNull()
+    }
+
+    private fun put(
+        cacheName: String,
+        key: Any,
+    ) {
+        cacheManager.getCache(cacheName)!!.put(key, "cached")
+    }
+
+    private fun get(
+        cacheName: String,
+        key: Any,
+    ): Any? = cacheManager.getCache(cacheName)!!.get(key)?.get()
+
+    private fun newCacheManager(): CacheManager =
+        ConcurrentMapCacheManager(
+            PostQueryCacheNames.ADMIN_POSTS_FIRST_PAGE,
+            PostQueryCacheNames.FEED,
+            PostQueryCacheNames.EXPLORE,
+            PostQueryCacheNames.FEED_CURSOR_FIRST,
+            PostQueryCacheNames.EXPLORE_CURSOR_FIRST,
+            PostQueryCacheNames.BOOTSTRAP,
+            PostQueryCacheNames.SEARCH,
+            PostQueryCacheNames.SEARCH_NEGATIVE,
+            PostQueryCacheNames.TAGS,
+            PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT,
+            PostQueryCacheNames.DETAIL_PUBLIC_META,
+            PostQueryCacheNames.DETAIL_PUBLIC_CONTENT,
+            PostQueryCacheNames.DETAIL_PUBLIC_NEGATIVE,
+        )
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandlerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandlerTest.kt
@@ -1,0 +1,122 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.boundedContexts.post.domain.Post
+import com.back.global.storage.application.UploadedFileRetentionService
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.TransactionException
+import org.springframework.transaction.TransactionStatus
+import org.springframework.transaction.support.SimpleTransactionStatus
+import java.util.Optional
+
+@DisplayName("PostWriteSideEffectHandler 테스트")
+class PostWriteSideEffectHandlerTest {
+    private val uploadedFileRetentionService: UploadedFileRetentionService =
+        mock(UploadedFileRetentionService::class.java)
+    private val postRecommendFeatureStoreService: PostRecommendFeatureStoreService =
+        mock(PostRecommendFeatureStoreService::class.java)
+    private val postRepository: PostRepositoryPort = mock(PostRepositoryPort::class.java)
+    private val postAttrRepository: PostAttrRepositoryPort = mock(PostAttrRepositoryPort::class.java)
+    private val handler =
+        PostWriteSideEffectHandler(
+            postReadCacheInvalidator = PostReadCacheInvalidator(ConcurrentMapCacheManager()),
+            uploadedFileRetentionService = uploadedFileRetentionService,
+            postRecommendFeatureStoreService = postRecommendFeatureStoreService,
+            postRepository = postRepository,
+            postAttrRepository = postAttrRepository,
+            transactionManager = NoopTransactionManager(),
+        )
+
+    @Test
+    @DisplayName("첨부파일 동기화 실패는 후속 작업 handler 밖으로 전파하지 않는다")
+    fun continueWhenAttachmentSyncFails() {
+        // given
+        doThrow(RuntimeException("storage down"))
+            .`when`(uploadedFileRetentionService)
+            .syncPostContent(10L, "before", "after")
+
+        // when & then
+        assertDoesNotThrow {
+            handler.enqueue(
+                sideEffectCommand(
+                    postId = 10L,
+                    previousContent = "before",
+                    currentContent = "after",
+                    recommendationAction = PostRecommendationSideEffect.EVICT,
+                ),
+            ) {}
+        }
+        verify(postRecommendFeatureStoreService).evict(10L)
+    }
+
+    @Test
+    @DisplayName("추천 갱신 시점에 글이 사라졌으면 feature store refresh를 건너뛴다")
+    fun skipRecommendationRefreshWhenPostIsMissing() {
+        // given
+        `when`(postRepository.findById(11L)).thenReturn(Optional.empty())
+
+        // when & then
+        assertDoesNotThrow {
+            handler.enqueue(
+                sideEffectCommand(
+                    postId = 11L,
+                    recommendationAction = PostRecommendationSideEffect.REFRESH,
+                ),
+            ) {}
+        }
+        verify(postRecommendFeatureStoreService, never()).refresh(anyPost())
+    }
+
+    private fun sideEffectCommand(
+        postId: Long,
+        previousContent: String? = null,
+        currentContent: String? = null,
+        recommendationAction: PostRecommendationSideEffect,
+    ): PostWriteSideEffectCommand =
+        PostWriteSideEffectCommand(
+            postId = postId,
+            previousContent = previousContent,
+            currentContent = currentContent,
+            deletedContent = null,
+            beforeTags = emptyList(),
+            afterTags = emptyList(),
+            evictHotReadPages = false,
+            evictSearchFirstPage = false,
+            evictImpactedTagPages = false,
+            evictTagsPublic = false,
+            evictDetail = false,
+            evictReason = "unit-test",
+            recommendationAction = recommendationAction,
+        )
+
+    private fun anyPost(): Post =
+        ArgumentMatchers.any(Post::class.java)
+            ?: Post(
+                author = Member(id = 0, username = "dummy", nickname = "dummy", apiKey = "dummy"),
+                title = "dummy",
+                content = "dummy",
+            )
+
+    private class NoopTransactionManager : PlatformTransactionManager {
+        override fun getTransaction(definition: TransactionDefinition?): TransactionStatus = SimpleTransactionStatus()
+
+        @Throws(TransactionException::class)
+        override fun commit(status: TransactionStatus) = Unit
+
+        @Throws(TransactionException::class)
+        override fun rollback(status: TransactionStatus) = Unit
+    }
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandlerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandlerTest.kt
@@ -20,6 +20,7 @@ import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.TransactionException
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.SimpleTransactionStatus
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.util.Optional
 
 @DisplayName("PostWriteSideEffectHandler 테스트")
@@ -60,6 +61,53 @@ class PostWriteSideEffectHandlerTest {
             ) {}
         }
         verify(postRecommendFeatureStoreService).evict(10L)
+    }
+
+    @Test
+    @DisplayName("추천 feature store evict 실패는 후속 작업 handler 밖으로 전파하지 않는다")
+    fun continueWhenRecommendationEvictFails() {
+        // given
+        doThrow(RuntimeException("recommendation cache down"))
+            .`when`(postRecommendFeatureStoreService)
+            .evict(12L)
+
+        // when & then
+        assertDoesNotThrow {
+            handler.enqueue(
+                sideEffectCommand(
+                    postId = 12L,
+                    recommendationAction = PostRecommendationSideEffect.EVICT,
+                ),
+            ) {}
+        }
+    }
+
+    @Test
+    @DisplayName("트랜잭션 동기화가 활성화되면 후속 작업은 afterCommit 전까지 실행하지 않는다")
+    fun deferSideEffectsUntilAfterCommitWhenSynchronizationIsActive() {
+        // given
+        TransactionSynchronizationManager.initSynchronization()
+
+        try {
+            // when
+            handler.enqueue(
+                sideEffectCommand(
+                    postId = 13L,
+                    recommendationAction = PostRecommendationSideEffect.EVICT,
+                ),
+            ) {}
+
+            // then
+            verify(postRecommendFeatureStoreService, never()).evict(13L)
+
+            // when
+            TransactionSynchronizationManager.getSynchronizations().forEach { it.afterCommit() }
+
+            // then
+            verify(postRecommendFeatureStoreService).evict(13L)
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization()
+        }
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈

close #847

## 작업 배경

- `PostApplicationService`가 게시글 생성/수정/삭제 후 read cache eviction, attachment sync, recommendation side effect 실행까지 직접 조립해 쓰기 유스케이스 변경 범위가 커져 있었다.
- 이번 PR에서는 API 계약을 바꾸지 않고 게시글 쓰기 후속 처리와 read cache eviction 책임을 별도 application component로 1차 분리한다.

## 작업 내용

- `PostReadCacheInvalidator`를 추가해 feed/explore/search/tag/detail 공개 조회 캐시 축출 책임을 분리했다.
- `PostWriteSideEffectHandler`를 추가해 after-commit 등록, 새 트랜잭션 후속 작업, attachment sync, recommendation refresh/evict 실행을 분리했다.
- `PostApplicationService`는 게시글 쓰기 정책 판단과 command 생성만 유지하고 후속 처리 실행은 handler로 위임하도록 정리했다.
- CodeRabbit 지적사항을 반영해 admin restore/hard-delete 경로의 cache eviction도 after-commit handler를 거치도록 보강했고, recommendation `EVICT` 실패도 `REFRESH`와 같은 방식으로 격리했다.
- cache eviction과 side-effect failure path, transaction synchronization deferral을 검증하는 단위 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back test --tests '*PostReadCacheInvalidatorTest*'`: 성공
  - `./back/gradlew -p back test --tests '*PostWriteSideEffectHandlerTest*'`: 성공
  - `./back/gradlew -p back test --tests '*PostApplicationService*'`: 성공
  - `./back/gradlew -p back test --tests '*ApiV1PostControllerTest*'`: 성공
  - `./back/gradlew -p back ktlintCheck`: 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks`: 2회 연속 성공
  - pre-commit `OpenApiContractExportTest` 및 `yarn contracts:check`: 성공
  - PR #864 GitHub checks: 성공
  - CodeRabbit latest-head 재리뷰: 04:29 UTC `Review finished`, status context SUCCESS

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `PostWriteSideEffectHandler.enqueue`가 기존처럼 트랜잭션 활성 상태에서는 afterCommit에 등록하고, 트랜잭션이 없으면 즉시 실행하는지 확인해 달라.
  - `PostReadCacheInvalidator`의 cache key가 기존 `PostApplicationService.clearReadCaches`에서 이동된 key와 동일한지 확인해 달라.
  - `restoreDeletedByIdForAdmin`, `hardDeleteDeletedByIdForAdmin`가 커밋 전 직접 cache eviction을 하지 않는지 확인해 달라.

## 리스크

- API request/response schema, 권한, optimistic lock, idempotency 동작은 변경하지 않았다.
- 변경 리스크는 게시글 쓰기 후 공개 조회 cache eviction 또는 after-commit 후속 작업 누락이며, focused 테스트와 `ciFastCheck`로 기존 경로를 검증했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (해당 없음: CodeRabbit latest-head 재리뷰 완료)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (Vercel preview 성공, main merge 후 CD 재확인 예정)
