### PR TITLE
[Refactor] 게시글 후속 작업 TransactionalEventListener 전환

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -42,10 +42,12 @@ import com.back.global.event.application.EventPublisher
 import com.back.global.exception.application.AppException
 import com.back.global.security.application.HtmlContentSanitizer
 import com.back.global.storage.application.UploadedFileRetentionService
+import com.back.standard.dto.EventPayload
 import com.back.standard.dto.page.PagedResult
 import com.back.standard.dto.post.type1.PostSearchSortType1
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.stereotype.Service
@@ -74,7 +76,7 @@ class PostApplicationService(
     private val postRecommendRankingService: PostRecommendRankingService,
     private val postRecommendFeatureStoreService: PostRecommendFeatureStoreService,
     private val postKeywordSearchPipelineService: PostKeywordSearchPipelineService,
-    private val postWriteSideEffectHandler: PostWriteSideEffectHandler,
+    private val applicationEventPublisher: ApplicationEventPublisher,
     @param:Value("\${custom.post.read.tags-local-cache-ttl-seconds:180}")
     private val tagsLocalCacheTtlSeconds: Long,
 ) {
@@ -126,7 +128,7 @@ class PostApplicationService(
                 )
             val createdTags = extractNormalizedTags(created.content)
             val isPublic = isPubliclyListed(created)
-            enqueuePostWriteSideEffect(
+            publishPostWriteAfterCommitEvent(
                 PostWriteSideEffectCommand(
                     postId = created.id,
                     previousContent = null,
@@ -142,8 +144,14 @@ class PostApplicationService(
                     evictReason = "write",
                     recommendationAction = recommendationActionFor(isPublic),
                 ),
+                PostWrittenEvent(
+                    UUID.randomUUID(),
+                    PostDto(created),
+                    MemberDto(author),
+                    emptyList(),
+                    createdTags,
+                ),
             )
-            publishPostWrittenEvent(author, created, createdTags)
             return created
         }
 
@@ -180,7 +188,7 @@ class PostApplicationService(
         postWriteRequestIdempotencyRepository.save(requestSlot)
         val createdTags = extractNormalizedTags(createdPost.content)
         val isPublic = isPubliclyListed(createdPost)
-        enqueuePostWriteSideEffect(
+        publishPostWriteAfterCommitEvent(
             PostWriteSideEffectCommand(
                 postId = createdPost.id,
                 previousContent = null,
@@ -196,8 +204,14 @@ class PostApplicationService(
                 evictReason = "write-idempotent",
                 recommendationAction = recommendationActionFor(isPublic),
             ),
+            PostWrittenEvent(
+                UUID.randomUUID(),
+                PostDto(createdPost),
+                MemberDto(author),
+                emptyList(),
+                createdTags,
+            ),
         )
-        publishPostWrittenEvent(author, createdPost, createdTags)
 
         return createdPost
     }
@@ -274,7 +288,7 @@ class PostApplicationService(
         val titleChanged = previousTitle != post.title
         val tagChanged = previousTags != afterTags
         val affectsPublicRead = wasPublic || isPublic
-        enqueuePostWriteSideEffect(
+        publishPostWriteAfterCommitEvent(
             PostWriteSideEffectCommand(
                 postId = post.id,
                 previousContent = previousContent,
@@ -290,21 +304,14 @@ class PostApplicationService(
                 evictReason = "modify",
                 recommendationAction = recommendationActionFor(isPublic),
             ),
+            PostModifiedEvent(
+                UUID.randomUUID(),
+                PostDto(post),
+                MemberDto(actor),
+                previousTags,
+                afterTags,
+            ),
         )
-
-        runCatching {
-            eventPublisher.publish(
-                PostModifiedEvent(
-                    UUID.randomUUID(),
-                    PostDto(post),
-                    MemberDto(actor),
-                    previousTags,
-                    afterTags,
-                ),
-            )
-        }.onFailure { exception ->
-            logger.warn("Failed to publish PostModifiedEvent: postId={}", post.id, exception)
-        }
     }
 
     /**
@@ -335,26 +342,6 @@ class PostApplicationService(
         syncMetaTagIndexAttr(savedPost)
         incrementMemberPostsCount(persistenceAuthor)
         return savedPost
-    }
-
-    private fun publishPostWrittenEvent(
-        author: Member,
-        post: Post,
-        afterTags: List<String>,
-    ) {
-        runCatching {
-            eventPublisher.publish(
-                PostWrittenEvent(
-                    UUID.randomUUID(),
-                    PostDto(post),
-                    MemberDto(author),
-                    emptyList(),
-                    afterTags,
-                ),
-            )
-        }.onFailure { exception ->
-            logger.warn("Failed to publish PostWrittenEvent: postId={}", post.id, exception)
-        }
     }
 
     /**
@@ -418,7 +405,7 @@ class PostApplicationService(
             }
         }
 
-        enqueuePostWriteSideEffect(
+        publishPostWriteAfterCommitEvent(
             PostWriteSideEffectCommand(
                 postId = post.id,
                 previousContent = null,
@@ -434,22 +421,14 @@ class PostApplicationService(
                 evictReason = "soft-delete",
                 recommendationAction = PostRecommendationSideEffect.EVICT,
             ),
+            PostDeletedEvent(
+                UUID.randomUUID(),
+                PostDto(post),
+                MemberDto(actor),
+                beforeTags,
+                emptyList(),
+            ),
         )
-
-        runCatching {
-            val postDto = PostDto(post)
-            eventPublisher.publish(
-                PostDeletedEvent(
-                    UUID.randomUUID(),
-                    postDto,
-                    MemberDto(actor),
-                    beforeTags,
-                    emptyList(),
-                ),
-            )
-        }.onFailure { exception ->
-            logger.warn("Failed to publish PostDeletedEvent for post id={}", post.id, exception)
-        }
     }
 
     /**
@@ -918,7 +897,7 @@ class PostApplicationService(
                 ?: throw AppException("404-1", "복구된 글을 확인할 수 없습니다.")
         val restoredTags = extractNormalizedTags(restoredPost.content)
         val isPublic = isPubliclyListed(restoredPost)
-        enqueuePostWriteSideEffect(
+        publishPostWriteAfterCommitEvent(
             PostWriteSideEffectCommand(
                 postId = id,
                 previousContent = null,
@@ -954,7 +933,7 @@ class PostApplicationService(
             throw AppException("404-1", "이미 영구삭제되었거나 존재하지 않는 글입니다.")
         }
 
-        enqueuePostWriteSideEffect(
+        publishPostWriteAfterCommitEvent(
             PostWriteSideEffectCommand(
                 postId = id,
                 previousContent = null,
@@ -1342,10 +1321,14 @@ class PostApplicationService(
     private fun recommendationActionFor(isPublic: Boolean): PostRecommendationSideEffect =
         if (isPublic) PostRecommendationSideEffect.REFRESH else PostRecommendationSideEffect.EVICT
 
-    private fun enqueuePostWriteSideEffect(command: PostWriteSideEffectCommand) {
-        postWriteSideEffectHandler.enqueue(command) {
+    private fun publishPostWriteAfterCommitEvent(
+        command: PostWriteSideEffectCommand,
+        domainEvent: EventPayload? = null,
+    ) {
+        if (command.evictTagsPublic) {
             publicTagCountsCache = null
         }
+        applicationEventPublisher.publishEvent(PostWriteAfterCommitEvent(command, domainEvent))
     }
 
     private fun isPubliclyListed(post: Post): Boolean = post.published && post.listed

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteAfterCommitEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteAfterCommitEvent.kt
@@ -1,0 +1,8 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.standard.dto.EventPayload
+
+internal data class PostWriteAfterCommitEvent(
+    val command: PostWriteSideEffectCommand,
+    val domainEvent: EventPayload?,
+)

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt
@@ -37,15 +37,11 @@ class PostWriteSideEffectHandler(
     internal fun handle(event: PostWriteAfterCommitEvent) {
         handle(event.command)
         event.domainEvent?.let { domainEvent ->
-            runCatching {
+            runAfterCommitSideEffectInNewTransaction(
+                postId = event.command.postId,
+                failureMessage = "Failed to publish post write domain event after commit",
+            ) {
                 eventPublisher.publish(domainEvent)
-            }.onFailure { exception ->
-                logger.warn(
-                    "Failed to publish post write domain event after commit: postId={}, event={}",
-                    event.command.postId,
-                    domainEvent::class.simpleName,
-                    exception,
-                )
             }
         }
     }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt
@@ -6,13 +6,14 @@ import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
 import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
 import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
+import com.back.global.event.application.EventPublisher
 import com.back.global.storage.application.UploadedFileRetentionService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
-import org.springframework.transaction.support.TransactionSynchronization
-import org.springframework.transaction.support.TransactionSynchronizationManager
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
 import org.springframework.transaction.support.TransactionTemplate
 import kotlin.jvm.optionals.getOrNull
 
@@ -23,6 +24,7 @@ class PostWriteSideEffectHandler(
     private val postRecommendFeatureStoreService: PostRecommendFeatureStoreService,
     private val postRepository: PostRepositoryPort,
     private val postAttrRepository: PostAttrRepositoryPort,
+    private val eventPublisher: EventPublisher,
     transactionManager: PlatformTransactionManager,
 ) {
     private val logger = LoggerFactory.getLogger(PostWriteSideEffectHandler::class.java)
@@ -31,33 +33,26 @@ class PostWriteSideEffectHandler(
             propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
         }
 
-    internal fun enqueue(
-        command: PostWriteSideEffectCommand,
-        onPublicTagsEvicted: () -> Unit,
-    ) {
-        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-            handle(command, onPublicTagsEvicted)
-            return
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    internal fun handle(event: PostWriteAfterCommitEvent) {
+        handle(event.command)
+        event.domainEvent?.let { domainEvent ->
+            runCatching {
+                eventPublisher.publish(domainEvent)
+            }.onFailure { exception ->
+                logger.warn(
+                    "Failed to publish post write domain event after commit: postId={}, event={}",
+                    event.command.postId,
+                    domainEvent::class.simpleName,
+                    exception,
+                )
+            }
         }
-
-        if (command.evictTagsPublic) {
-            onPublicTagsEvicted()
-        }
-        TransactionSynchronizationManager.registerSynchronization(
-            object : TransactionSynchronization {
-                override fun afterCommit() {
-                    handle(command, onPublicTagsEvicted)
-                }
-            },
-        )
     }
 
-    private fun handle(
-        command: PostWriteSideEffectCommand,
-        onPublicTagsEvicted: () -> Unit,
-    ) {
+    private fun handle(command: PostWriteSideEffectCommand) {
         runCatching {
-            postReadCacheInvalidator.invalidate(command.toCacheInvalidationRequest(), onPublicTagsEvicted)
+            postReadCacheInvalidator.invalidate(command.toCacheInvalidationRequest()) {}
         }.onFailure { exception ->
             logger.warn("Failed to evict post read caches after commit: postId={}", command.postId, exception)
         }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
@@ -7,6 +7,8 @@ import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
 import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
 import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
+import com.back.boundedContexts.post.event.PostModifiedEvent
+import com.back.boundedContexts.post.event.PostWrittenEvent
 import com.back.support.BasePostApplicationServiceAfterCommitIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -58,6 +60,7 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
         verifyNoInteractions(
             uploadedFileRetentionService,
             postRecommendFeatureStoreService,
+            eventPublisher,
             cacheManager,
         )
     }
@@ -86,6 +89,7 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
         assertThat(invokedMethodNames(uploadedFileRetentionService)).contains("syncPostContent")
         assertThat(invokedMethodNames(postRecommendFeatureStoreService)).contains("refresh")
         assertThat(sideEffectTransactions).containsOnly(true)
+        assertThat(publishedEvents()).hasAtLeastOneElementOfType(PostWrittenEvent::class.java)
     }
 
     @Test
@@ -161,6 +165,7 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
                 commentsCount = 3,
             ),
         )
+        assertThat(publishedEvents()).hasAtLeastOneElementOfType(PostModifiedEvent::class.java)
     }
 
     private fun clearSideEffectMocks() {
@@ -173,6 +178,12 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
     }
 
     private fun invokedMethodNames(mock: Any): List<String> = mockingDetails(mock).invocations.map { it.method.name }
+
+    private fun publishedEvents(): List<Any?> =
+        mockingDetails(eventPublisher)
+            .invocations
+            .filter { it.method.name == "publish" }
+            .map { it.arguments.firstOrNull() }
 
     private fun recordActiveTransactionDuringSideEffects(sideEffectTransactions: MutableList<Boolean>) {
         doAnswer {

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
@@ -16,17 +16,18 @@ import com.back.global.event.application.EventPublisher
 import com.back.global.storage.application.UploadedFileRetentionService
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verifyNoInteractions
 import org.springframework.cache.CacheManager
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.TransactionException
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.SimpleTransactionStatus
-import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.Instant
 import java.util.Optional
 
@@ -50,6 +51,7 @@ class PostApplicationServiceDeleteResilienceTest {
         mock(PostRecommendFeatureStoreService::class.java)
     private val postKeywordSearchPipelineService: PostKeywordSearchPipelineService =
         mock(PostKeywordSearchPipelineService::class.java)
+    private val applicationEventPublisher: ApplicationEventPublisher = mock(ApplicationEventPublisher::class.java)
     private val postReadCacheInvalidator = PostReadCacheInvalidator(cacheManager)
     private val postWriteSideEffectHandler =
         PostWriteSideEffectHandler(
@@ -58,6 +60,7 @@ class PostApplicationServiceDeleteResilienceTest {
             postRecommendFeatureStoreService = postRecommendFeatureStoreService,
             postRepository = postRepository,
             postAttrRepository = postAttrRepository,
+            eventPublisher = eventPublisher,
             transactionManager = transactionManager,
         )
 
@@ -76,7 +79,7 @@ class PostApplicationServiceDeleteResilienceTest {
             postRecommendRankingService = postRecommendRankingService,
             postRecommendFeatureStoreService = postRecommendFeatureStoreService,
             postKeywordSearchPipelineService = postKeywordSearchPipelineService,
-            postWriteSideEffectHandler = postWriteSideEffectHandler,
+            applicationEventPublisher = applicationEventPublisher,
             tagsLocalCacheTtlSeconds = 180,
         )
 
@@ -162,19 +165,15 @@ class PostApplicationServiceDeleteResilienceTest {
         given(postRepository.restoreDeletedById(21)).willReturn(true)
         given(postRepository.findById(21)).willReturn(Optional.of(restoredPost))
 
-        TransactionSynchronizationManager.initSynchronization()
-        try {
-            service.restoreDeletedByIdForAdmin(21)
+        service.restoreDeletedByIdForAdmin(21)
+        val afterCommitEvent = capturePostWriteAfterCommitEvent()
 
-            verifyNoInteractions(cacheManager, postRecommendFeatureStoreService)
+        verifyNoInteractions(cacheManager, postRecommendFeatureStoreService)
 
-            TransactionSynchronizationManager.getSynchronizations().forEach { it.afterCommit() }
+        postWriteSideEffectHandler.handle(afterCommitEvent)
 
-            then(cacheManager).should().getCache(PostQueryCacheNames.FEED)
-            then(postRecommendFeatureStoreService).should().refresh(restoredPost)
-        } finally {
-            TransactionSynchronizationManager.clearSynchronization()
-        }
+        then(cacheManager).should().getCache(PostQueryCacheNames.FEED)
+        then(postRecommendFeatureStoreService).should().refresh(restoredPost)
     }
 
     @Test
@@ -189,20 +188,22 @@ class PostApplicationServiceDeleteResilienceTest {
         given(postRepository.findDeletedSnapshotById(22)).willReturn(snapshot)
         given(postRepository.hardDeleteDeletedById(22)).willReturn(true)
 
-        TransactionSynchronizationManager.initSynchronization()
-        try {
-            service.hardDeleteDeletedByIdForAdmin(22)
+        service.hardDeleteDeletedByIdForAdmin(22)
+        val afterCommitEvent = capturePostWriteAfterCommitEvent()
 
-            verifyNoInteractions(cacheManager, uploadedFileRetentionService, postRecommendFeatureStoreService)
+        verifyNoInteractions(cacheManager, uploadedFileRetentionService, postRecommendFeatureStoreService)
 
-            TransactionSynchronizationManager.getSynchronizations().forEach { it.afterCommit() }
+        postWriteSideEffectHandler.handle(afterCommitEvent)
 
-            then(cacheManager).should().getCache(PostQueryCacheNames.FEED)
-            then(uploadedFileRetentionService).should().scheduleDeletedPostAttachments(snapshot.content)
-            then(postRecommendFeatureStoreService).should().evict(22)
-        } finally {
-            TransactionSynchronizationManager.clearSynchronization()
-        }
+        then(cacheManager).should().getCache(PostQueryCacheNames.FEED)
+        then(uploadedFileRetentionService).should().scheduleDeletedPostAttachments(snapshot.content)
+        then(postRecommendFeatureStoreService).should().evict(22)
+    }
+
+    private fun capturePostWriteAfterCommitEvent(): PostWriteAfterCommitEvent {
+        val captor = ArgumentCaptor.forClass(PostWriteAfterCommitEvent::class.java)
+        then(applicationEventPublisher).should().publishEvent(captor.capture())
+        return captor.value
     }
 
     private class NoopTransactionManager : PlatformTransactionManager {

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandlerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandlerTest.kt
@@ -4,7 +4,14 @@ import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
 import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
 import com.back.boundedContexts.post.domain.Post
+import com.back.boundedContexts.post.domain.PostAttr
+import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
+import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
+import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
+import com.back.global.event.application.EventPublisher
 import com.back.global.storage.application.UploadedFileRetentionService
+import com.back.standard.dto.EventPayload
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -13,14 +20,16 @@ import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.TransactionException
 import org.springframework.transaction.TransactionStatus
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
 import org.springframework.transaction.support.SimpleTransactionStatus
-import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.util.Optional
 
 @DisplayName("PostWriteSideEffectHandler 테스트")
@@ -31,6 +40,7 @@ class PostWriteSideEffectHandlerTest {
         mock(PostRecommendFeatureStoreService::class.java)
     private val postRepository: PostRepositoryPort = mock(PostRepositoryPort::class.java)
     private val postAttrRepository: PostAttrRepositoryPort = mock(PostAttrRepositoryPort::class.java)
+    private val eventPublisher: EventPublisher = mock(EventPublisher::class.java)
     private val handler =
         PostWriteSideEffectHandler(
             postReadCacheInvalidator = PostReadCacheInvalidator(ConcurrentMapCacheManager()),
@@ -38,6 +48,7 @@ class PostWriteSideEffectHandlerTest {
             postRecommendFeatureStoreService = postRecommendFeatureStoreService,
             postRepository = postRepository,
             postAttrRepository = postAttrRepository,
+            eventPublisher = eventPublisher,
             transactionManager = NoopTransactionManager(),
         )
 
@@ -51,14 +62,18 @@ class PostWriteSideEffectHandlerTest {
 
         // when & then
         assertDoesNotThrow {
-            handler.enqueue(
-                sideEffectCommand(
-                    postId = 10L,
-                    previousContent = "before",
-                    currentContent = "after",
-                    recommendationAction = PostRecommendationSideEffect.EVICT,
+            handler.handle(
+                PostWriteAfterCommitEvent(
+                    command =
+                        sideEffectCommand(
+                            postId = 10L,
+                            previousContent = "before",
+                            currentContent = "after",
+                            recommendationAction = PostRecommendationSideEffect.EVICT,
+                        ),
+                    domainEvent = null,
                 ),
-            ) {}
+            )
         }
         verify(postRecommendFeatureStoreService).evict(10L)
     }
@@ -73,41 +88,82 @@ class PostWriteSideEffectHandlerTest {
 
         // when & then
         assertDoesNotThrow {
-            handler.enqueue(
-                sideEffectCommand(
-                    postId = 12L,
-                    recommendationAction = PostRecommendationSideEffect.EVICT,
+            handler.handle(
+                PostWriteAfterCommitEvent(
+                    command =
+                        sideEffectCommand(
+                            postId = 12L,
+                            recommendationAction = PostRecommendationSideEffect.EVICT,
+                        ),
+                    domainEvent = null,
                 ),
-            ) {}
+            )
         }
     }
 
     @Test
-    @DisplayName("트랜잭션 동기화가 활성화되면 후속 작업은 afterCommit 전까지 실행하지 않는다")
-    fun deferSideEffectsUntilAfterCommitWhenSynchronizationIsActive() {
+    @DisplayName("후속 작업 handler는 Spring transaction commit 이후 이벤트로만 호출된다")
+    fun handlePostWriteEventAfterCommit() {
+        // when
+        val handlerMethod =
+            PostWriteSideEffectHandler::class.java
+                .declaredMethods
+                .single { method ->
+                    method.parameterTypes.contentEquals(arrayOf(PostWriteAfterCommitEvent::class.java))
+                }
+        val annotation = handlerMethod.getAnnotation(TransactionalEventListener::class.java)
+
+        // then
+        assertThat(annotation.phase).isEqualTo(TransactionPhase.AFTER_COMMIT)
+        assertThat(annotation.fallbackExecution).isTrue()
+    }
+
+    @Test
+    @DisplayName("외부 post write 이벤트는 후속 작업 이후에 발행한다")
+    fun publishDomainEventAfterSideEffects() {
         // given
-        TransactionSynchronizationManager.initSynchronization()
+        val domainEvent = mock(EventPayload::class.java)
 
-        try {
-            // when
-            handler.enqueue(
-                sideEffectCommand(
-                    postId = 13L,
-                    recommendationAction = PostRecommendationSideEffect.EVICT,
+        // when
+        handler.handle(
+            PostWriteAfterCommitEvent(
+                command =
+                    sideEffectCommand(
+                        postId = 14L,
+                        recommendationAction = PostRecommendationSideEffect.EVICT,
+                    ),
+                domainEvent = domainEvent,
+            ),
+        )
+
+        // then
+        verify(postRecommendFeatureStoreService).evict(14L)
+        verify(eventPublisher).publish(domainEvent)
+    }
+
+    @Test
+    @DisplayName("외부 post write 이벤트 발행 실패는 후속 작업 handler 밖으로 전파하지 않는다")
+    fun continueWhenDomainEventPublishFails() {
+        // given
+        val domainEvent = mock(EventPayload::class.java)
+        doThrow(RuntimeException("event bus down"))
+            .`when`(eventPublisher)
+            .publish(domainEvent)
+
+        // when & then
+        assertDoesNotThrow {
+            handler.handle(
+                PostWriteAfterCommitEvent(
+                    command =
+                        sideEffectCommand(
+                            postId = 15L,
+                            recommendationAction = PostRecommendationSideEffect.EVICT,
+                        ),
+                    domainEvent = domainEvent,
                 ),
-            ) {}
-
-            // then
-            verify(postRecommendFeatureStoreService, never()).evict(13L)
-
-            // when
-            TransactionSynchronizationManager.getSynchronizations().forEach { it.afterCommit() }
-
-            // then
-            verify(postRecommendFeatureStoreService).evict(13L)
-        } finally {
-            TransactionSynchronizationManager.clearSynchronization()
+            )
         }
+        verify(postRecommendFeatureStoreService).evict(15L)
     }
 
     @Test
@@ -118,14 +174,77 @@ class PostWriteSideEffectHandlerTest {
 
         // when & then
         assertDoesNotThrow {
-            handler.enqueue(
-                sideEffectCommand(
-                    postId = 11L,
-                    recommendationAction = PostRecommendationSideEffect.REFRESH,
+            handler.handle(
+                PostWriteAfterCommitEvent(
+                    command =
+                        sideEffectCommand(
+                            postId = 11L,
+                            recommendationAction = PostRecommendationSideEffect.REFRESH,
+                        ),
+                    domainEvent = null,
                 ),
-            ) {}
+            )
         }
         verify(postRecommendFeatureStoreService, never()).refresh(anyPost())
+    }
+
+    @Test
+    @DisplayName("추천 갱신 전 누락된 post counter attr를 조회해 hydrate한다")
+    fun hydrateMissingCountersBeforeRecommendationRefresh() {
+        // given
+        val post = testPost(16L)
+        `when`(postRepository.findById(16L)).thenReturn(Optional.of(post))
+        `when`(postAttrRepository.findBySubjectAndName(post, LIKES_COUNT))
+            .thenReturn(PostAttr(1L, post, LIKES_COUNT, 7))
+        `when`(postAttrRepository.findBySubjectAndName(post, COMMENTS_COUNT))
+            .thenReturn(PostAttr(2L, post, COMMENTS_COUNT, 3))
+        `when`(postAttrRepository.findBySubjectAndName(post, HIT_COUNT))
+            .thenReturn(PostAttr(3L, post, HIT_COUNT, 11))
+
+        // when
+        handler.handle(
+            PostWriteAfterCommitEvent(
+                command =
+                    sideEffectCommand(
+                        postId = 16L,
+                        recommendationAction = PostRecommendationSideEffect.REFRESH,
+                    ),
+                domainEvent = null,
+            ),
+        )
+
+        // then
+        assertThat(post.likesCount).isEqualTo(7)
+        assertThat(post.commentsCount).isEqualTo(3)
+        assertThat(post.hitCount).isEqualTo(11)
+        verify(postRecommendFeatureStoreService).refresh(post)
+    }
+
+    @Test
+    @DisplayName("post counter attr가 이미 있으면 추천 갱신 전 재조회하지 않는다")
+    fun skipCounterLookupWhenCountersAlreadyHydrated() {
+        // given
+        val post = testPost(17L)
+        post.likesCountAttr = PostAttr(4L, post, LIKES_COUNT, 8)
+        post.commentsCountAttr = PostAttr(5L, post, COMMENTS_COUNT, 4)
+        post.hitCountAttr = PostAttr(6L, post, HIT_COUNT, 12)
+        `when`(postRepository.findById(17L)).thenReturn(Optional.of(post))
+
+        // when
+        handler.handle(
+            PostWriteAfterCommitEvent(
+                command =
+                    sideEffectCommand(
+                        postId = 17L,
+                        recommendationAction = PostRecommendationSideEffect.REFRESH,
+                    ),
+                domainEvent = null,
+            ),
+        )
+
+        // then
+        verifyNoInteractions(postAttrRepository)
+        verify(postRecommendFeatureStoreService).refresh(post)
     }
 
     private fun sideEffectCommand(
@@ -157,6 +276,16 @@ class PostWriteSideEffectHandlerTest {
                 title = "dummy",
                 content = "dummy",
             )
+
+    private fun testPost(id: Long): Post =
+        Post(
+            id = id,
+            author = Member(id = 1, username = "author", nickname = "작성자", apiKey = "author-api-key"),
+            title = "title",
+            content = "content",
+            published = true,
+            listed = true,
+        )
 
     private class NoopTransactionManager : PlatformTransactionManager {
         override fun getTransaction(definition: TransactionDefinition?): TransactionStatus = SimpleTransactionStatus()


### PR DESCRIPTION
## 관련 이슈

close #848

## 작업 배경

- 게시글 작성/수정/삭제 트랜잭션 안에서 캐시 축출, 첨부파일 retention, 추천 feature store 갱신, post write domain event 발행이 함께 실행될 수 있었다.
- DB commit 성공 이후에만 외부 후속 작업이 실행되도록 Spring `@TransactionalEventListener(phase = AFTER_COMMIT)` 경계로 분리한다.

## 작업 내용

- `PostApplicationService`가 직접 후속 작업을 실행하지 않고 `PostWriteAfterCommitEvent`를 Spring event로 발행하도록 변경했다.
- `PostWriteSideEffectHandler`를 `@TransactionalEventListener(AFTER_COMMIT, fallbackExecution = true)` handler로 전환했다.
- cache/attachment/recommendation side effect와 `PostWrittenEvent`/`PostModifiedEvent`/`PostDeletedEvent` 외부 발행을 commit 이후 handler에서 처리하도록 옮겼다.
- CodeRabbit 리뷰 지적을 반영해 외부 post write event 발행도 다른 후속 작업과 동일하게 `REQUIRES_NEW` 트랜잭션 안에서 실행하도록 보강했다.
- public tag count local cache는 같은 JVM 조회 일관성을 위해 service에서 즉시 무효화하고, 실제 read cache 축출은 after commit에서 실행한다.
- after-commit rollback/commit 동작, domain event 발행, handler 실패 격리, 추천 counter hydrate 분기 테스트를 보강했다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back test --tests com.back.boundedContexts.post.application.service.PostWriteSideEffectHandlerTest --tests com.back.boundedContexts.post.application.service.PostApplicationServiceAfterCommitTest --tests com.back.boundedContexts.post.application.service.PostApplicationServiceDeleteResilienceTest`: 성공
  - `./back/gradlew -p back ktlintCheck`: 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks`: 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks`: 성공, 동일 조건 2회 연속 통과
  - pre-commit `OpenApiContractExportTest`: 성공
  - pre-commit `yarn contracts:check`: 성공
  - GitHub PR CI: 성공
  - CodeRabbit review: actionable 1건 반영 후 thread resolved

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `PostApplicationService.publishPostWriteAfterCommitEvent`가 internal event만 발행하고 직접 side effect를 실행하지 않는지
  - `PostWriteSideEffectHandler.handle(PostWriteAfterCommitEvent)`의 `@TransactionalEventListener(AFTER_COMMIT)` 경계
  - `PostWrittenEvent`/`PostModifiedEvent`/`PostDeletedEvent`가 commit 이후 `REQUIRES_NEW` 트랜잭션 안에서 기존 `EventPublisher`로 발행되는지

## 리스크

- Spring transaction event listener 경계로 이동하면서 rollback 시 외부 이벤트와 cache/storage/recommendation side effect가 실행되지 않는 것이 의도된 동작이다.
- `fallbackExecution = true`는 트랜잭션 없는 테스트/관리 경로의 handler 호출 호환성을 유지하기 위한 설정이다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (CodeRabbit 리뷰 완료로 fallback 불필요)
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다. (main merge 후 확인)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 포스트 작성 후 처리 로직을 트랜잭션 커밋 이후 이벤트 기반으로 개선했습니다.
  * 생성, 수정, 삭제, 복구 등 모든 포스트 작업 후처리를 통일된 이벤트 방식으로 처리하도록 변경했습니다.

* **Tests**
  * 트랜잭션 커밋 후 동작 검증을 위한 테스트를 강화했습니다.
  * 이벤트 발행 및 캐시 무효화 동작 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
