### PR TITLE
[Refactor] ApiV1PostController 검색 의도 파싱 분리

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostController.kt
@@ -48,14 +48,10 @@ class ApiV1PostController(
     private val postHitDedupUseCase: PostHitDedupUseCase,
     private val postPublicReadQueryUseCase: PostPublicReadQueryUseCase,
     private val postPublicReadResponseFactory: PostPublicReadResponseFactory,
+    private val postSearchIntentResolver: PostSearchIntentResolver,
     private val rq: Rq,
 ) {
     private val logger = LoggerFactory.getLogger(ApiV1PostController::class.java)
-
-    private data class SearchIntent(
-        val keyword: String,
-        val tag: String,
-    )
 
     /**
      * makePostDtoPage 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
@@ -153,7 +149,7 @@ class ApiV1PostController(
         val startedAtNanos = System.nanoTime()
         val validPage = normalizePublicPage(page)
         val validPageSize = pageSize.coerceIn(1, 30)
-        val searchIntent = resolveSearchIntent(kw, tag)
+        val searchIntent = postSearchIntentResolver.resolve(kw, tag)
         val normalizedKw = searchIntent.keyword
         val normalizedTag = searchIntent.tag
         val data = postPublicReadQueryUseCase.getPublicExplore(validPage, validPageSize, normalizedKw, normalizedTag, sort)
@@ -262,7 +258,7 @@ class ApiV1PostController(
         val startedAtNanos = System.nanoTime()
         val validPage = normalizePublicPage(page)
         val validPageSize = pageSize.coerceIn(1, 30)
-        val searchIntent = resolveSearchIntent(kw, "")
+        val searchIntent = postSearchIntentResolver.resolve(kw, "")
         val normalizedKw = searchIntent.keyword
         val normalizedTag = searchIntent.tag
         val data =
@@ -671,52 +667,6 @@ class ApiV1PostController(
             .trim()
             .replace(Regex("\\s+"), " ")
             .take(maxLength)
-
-    private fun resolveSearchIntent(
-        rawKw: String,
-        rawTag: String,
-    ): SearchIntent {
-        val normalizedKw = normalizeExploreKeyword(rawKw)
-        val normalizedTag = normalizeExploreTag(rawTag)
-        if (normalizedTag.isNotBlank()) {
-            return SearchIntent(keyword = normalizedKw, tag = normalizedTag)
-        }
-
-        val hashtagRegex = Regex("(^|\\s)#([\\p{L}\\p{N}_-]{1,40})")
-        val hashMatchedTag =
-            hashtagRegex
-                .find(normalizedKw)
-                ?.groupValues
-                ?.getOrNull(2)
-                .orEmpty()
-        if (hashMatchedTag.isNotBlank()) {
-            val cleanedKeyword =
-                hashtagRegex
-                    .replace(normalizedKw, " ")
-                    .replace(Regex("\\s+"), " ")
-                    .trim()
-            return SearchIntent(
-                keyword = cleanedKeyword.take(MAX_EXPLORE_KW_LENGTH),
-                tag = normalizeExploreTag(hashMatchedTag),
-            )
-        }
-
-        val prefixedTagRegex = Regex("^(?:tag|태그)\\s*:\\s*([\\p{L}\\p{N}_-]{1,40})$", RegexOption.IGNORE_CASE)
-        val prefixedTag =
-            prefixedTagRegex
-                .find(normalizedKw)
-                ?.groupValues
-                ?.getOrNull(1)
-                .orEmpty()
-        if (prefixedTag.isNotBlank()) {
-            return SearchIntent(
-                keyword = "",
-                tag = normalizeExploreTag(prefixedTag),
-            )
-        }
-
-        return SearchIntent(keyword = normalizedKw, tag = "")
-    }
 
     /**
      * 실행 시점에 필요한 의존성/값을 결정합니다.

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostController.kt
@@ -193,7 +193,7 @@ class ApiV1PostController(
     ): ResponseEntity<CursorFeedPageDto> {
         val startedAtNanos = System.nanoTime()
         val validPageSize = pageSize.coerceIn(1, 30)
-        val normalizedTag = normalizeExploreTag(tag)
+        val normalizedTag = postSearchIntentResolver.normalizeTag(tag)
         val validSort = normalizeCursorSort(sort)
         val data = postPublicReadQueryUseCase.getPublicExploreByCursor(cursor, validPageSize, normalizedTag, validSort)
         val etagSeed =
@@ -337,7 +337,7 @@ class ApiV1PostController(
         @RequestParam(defaultValue = "CREATED_AT") sort: PostSearchSortType1,
     ): ResponseEntity<PublicPostsBootstrapDto> {
         val startedAtNanos = System.nanoTime()
-        val normalizedTag = normalizeExploreTag(tag)
+        val normalizedTag = postSearchIntentResolver.normalizeTag(tag)
         val validPageSize = pageSize.coerceIn(1, 30)
         val validSort = normalizeCursorSort(sort)
         val data = postPublicReadQueryUseCase.getPublicBootstrap(normalizedTag, validPageSize, validSort)
@@ -382,7 +382,7 @@ class ApiV1PostController(
     ): PageDto<PostDto> {
         val validPage = normalizePublicPage(page)
         val validPageSize = pageSize.coerceIn(1, 30)
-        val postPage = postUseCase.findPagedByKw(normalizeExploreKeyword(kw), sort, validPage, validPageSize)
+        val postPage = postUseCase.findPagedByKw(postSearchIntentResolver.normalizeKeyword(kw), sort, validPage, validPageSize)
         return makePostDtoPage(postPage)
     }
 
@@ -620,7 +620,14 @@ class ApiV1PostController(
     ): PageDto<PostDto> {
         val validPage = normalizePublicPage(page)
         val validPageSize = pageSize.coerceIn(1, 30)
-        val postPage = postUseCase.findPagedByAuthor(rq.actor, normalizeExploreKeyword(kw), sort, validPage, validPageSize)
+        val postPage =
+            postUseCase.findPagedByAuthor(
+                rq.actor,
+                postSearchIntentResolver.normalizeKeyword(kw),
+                sort,
+                validPage,
+                validPageSize,
+            )
         return makePostDtoPage(postPage)
     }
 
@@ -647,10 +654,6 @@ class ApiV1PostController(
 
     private fun normalizePublicPage(page: Int): Int = page.coerceIn(1, MAX_PUBLIC_PAGE)
 
-    private fun normalizeExploreKeyword(raw: String): String = normalizeSearchToken(raw, MAX_EXPLORE_KW_LENGTH)
-
-    private fun normalizeExploreTag(raw: String): String = normalizeSearchToken(raw, MAX_EXPLORE_TAG_LENGTH)
-
     private fun normalizeCursorSort(sort: PostSearchSortType1): PostSearchSortType1 =
         when (sort) {
             PostSearchSortType1.CREATED_AT,
@@ -658,15 +661,6 @@ class ApiV1PostController(
             -> sort
             else -> PostSearchSortType1.CREATED_AT
         }
-
-    private fun normalizeSearchToken(
-        raw: String,
-        maxLength: Int,
-    ): String =
-        raw
-            .trim()
-            .replace(Regex("\\s+"), " ")
-            .take(maxLength)
 
     /**
      * 실행 시점에 필요한 의존성/값을 결정합니다.
@@ -725,8 +719,6 @@ class ApiV1PostController(
 
     companion object {
         private const val MAX_PUBLIC_PAGE = 200
-        private const val MAX_EXPLORE_KW_LENGTH = 80
-        private const val MAX_EXPLORE_TAG_LENGTH = 40
         private const val MAX_RELATED_AUTHOR_LIMIT = 12
     }
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostSearchIntentResolver.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostSearchIntentResolver.kt
@@ -61,9 +61,9 @@ class PostSearchIntentResolver {
             ?.getOrNull(1)
             .orEmpty()
 
-    private fun normalizeKeyword(raw: String): String = normalizeSearchToken(raw, MAX_KEYWORD_LENGTH)
+    fun normalizeKeyword(raw: String): String = normalizeSearchToken(raw, MAX_KEYWORD_LENGTH)
 
-    private fun normalizeTag(raw: String): String = normalizeSearchToken(raw, MAX_TAG_LENGTH)
+    fun normalizeTag(raw: String): String = normalizeSearchToken(raw, MAX_TAG_LENGTH)
 
     private fun normalizeSearchToken(
         raw: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostSearchIntentResolver.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostSearchIntentResolver.kt
@@ -1,0 +1,84 @@
+package com.back.boundedContexts.post.adapter.web
+
+import org.springframework.stereotype.Component
+
+data class PostSearchIntent(
+    val keyword: String,
+    val tag: String,
+)
+
+@Component
+class PostSearchIntentResolver {
+    fun resolve(
+        rawKeyword: String,
+        rawTag: String,
+    ): PostSearchIntent {
+        val normalizedKeyword = normalizeKeyword(rawKeyword)
+        val normalizedTag = normalizeTag(rawTag)
+        if (normalizedTag.isNotBlank()) {
+            return PostSearchIntent(keyword = normalizedKeyword, tag = normalizedTag)
+        }
+
+        val hashtagIntent = resolveHashtagIntent(normalizedKeyword)
+        if (hashtagIntent != null) {
+            return hashtagIntent
+        }
+
+        val prefixedTag = resolvePrefixedTag(normalizedKeyword)
+        if (prefixedTag.isNotBlank()) {
+            return PostSearchIntent(keyword = "", tag = normalizeTag(prefixedTag))
+        }
+
+        return PostSearchIntent(keyword = normalizedKeyword, tag = "")
+    }
+
+    private fun resolveHashtagIntent(normalizedKeyword: String): PostSearchIntent? {
+        val hashMatchedTag =
+            HASHTAG_REGEX
+                .find(normalizedKeyword)
+                ?.groupValues
+                ?.getOrNull(2)
+                .orEmpty()
+        if (hashMatchedTag.isBlank()) return null
+
+        // Hashtag 의도는 태그 필터로 승격하고, 남은 텍스트는 keyword 검색어로 유지한다.
+        val cleanedKeyword =
+            HASHTAG_REGEX
+                .replace(normalizedKeyword, " ")
+                .replace(WHITESPACE_REGEX, " ")
+                .trim()
+
+        return PostSearchIntent(
+            keyword = cleanedKeyword.take(MAX_KEYWORD_LENGTH),
+            tag = normalizeTag(hashMatchedTag),
+        )
+    }
+
+    private fun resolvePrefixedTag(normalizedKeyword: String): String =
+        PREFIXED_TAG_REGEX
+            .find(normalizedKeyword)
+            ?.groupValues
+            ?.getOrNull(1)
+            .orEmpty()
+
+    private fun normalizeKeyword(raw: String): String = normalizeSearchToken(raw, MAX_KEYWORD_LENGTH)
+
+    private fun normalizeTag(raw: String): String = normalizeSearchToken(raw, MAX_TAG_LENGTH)
+
+    private fun normalizeSearchToken(
+        raw: String,
+        maxLength: Int,
+    ): String =
+        raw
+            .trim()
+            .replace(WHITESPACE_REGEX, " ")
+            .take(maxLength)
+
+    companion object {
+        private const val MAX_KEYWORD_LENGTH = 80
+        private const val MAX_TAG_LENGTH = 40
+        private val WHITESPACE_REGEX = Regex("\\s+")
+        private val HASHTAG_REGEX = Regex("(^|\\s)#([\\p{L}\\p{N}_-]{1,40})")
+        private val PREFIXED_TAG_REGEX = Regex("^(?:tag|태그)\\s*:\\s*([\\p{L}\\p{N}_-]{1,40})$", RegexOption.IGNORE_CASE)
+    }
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/PostSearchIntentResolverTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/PostSearchIntentResolverTest.kt
@@ -23,6 +23,20 @@ class PostSearchIntentResolverTest {
     }
 
     @Test
+    @DisplayName("tag 파라미터는 keyword 안의 hashtag 의도보다 우선한다")
+    fun resolveExplicitTagBeatsHashtagIntent() {
+        // given
+        val keyword = "  #SSE  "
+        val tag = "  Kotlin  "
+
+        // when
+        val intent = resolver.resolve(keyword, tag)
+
+        // then
+        assertThat(intent).isEqualTo(PostSearchIntent(keyword = "#SSE", tag = "Kotlin"))
+    }
+
+    @Test
     @DisplayName("hashtag 검색어는 태그 필터로 승격하고 남은 텍스트를 keyword로 유지한다")
     fun resolveHashtagIntent() {
         // given

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/PostSearchIntentResolverTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/PostSearchIntentResolverTest.kt
@@ -1,0 +1,76 @@
+package com.back.boundedContexts.post.adapter.web
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("PostSearchIntentResolver 테스트")
+class PostSearchIntentResolverTest {
+    private val resolver = PostSearchIntentResolver()
+
+    @Test
+    @DisplayName("명시 tag 파라미터가 있으면 keyword를 보존하고 tag 파라미터를 우선한다")
+    fun resolveExplicitTagParameterFirst() {
+        // given
+        val keyword = "  spring   boot  "
+        val tag = "  Kotlin  "
+
+        // when
+        val intent = resolver.resolve(keyword, tag)
+
+        // then
+        assertThat(intent).isEqualTo(PostSearchIntent(keyword = "spring boot", tag = "Kotlin"))
+    }
+
+    @Test
+    @DisplayName("hashtag 검색어는 태그 필터로 승격하고 남은 텍스트를 keyword로 유지한다")
+    fun resolveHashtagIntent() {
+        // given
+        val keyword = "  reactive   #SSE   stream  "
+
+        // when
+        val intent = resolver.resolve(keyword, "")
+
+        // then
+        assertThat(intent).isEqualTo(PostSearchIntent(keyword = "reactive stream", tag = "SSE"))
+    }
+
+    @Test
+    @DisplayName("tag prefix 검색어는 keyword 없이 태그 필터로 해석한다")
+    fun resolveEnglishTagPrefixIntent() {
+        // given
+        val keyword = "tag:Kotlin"
+
+        // when
+        val intent = resolver.resolve(keyword, "")
+
+        // then
+        assertThat(intent).isEqualTo(PostSearchIntent(keyword = "", tag = "Kotlin"))
+    }
+
+    @Test
+    @DisplayName("한글 태그 prefix 검색어도 태그 필터로 해석한다")
+    fun resolveKoreanTagPrefixIntent() {
+        // given
+        val keyword = "태그:실시간"
+
+        // when
+        val intent = resolver.resolve(keyword, "")
+
+        // then
+        assertThat(intent).isEqualTo(PostSearchIntent(keyword = "", tag = "실시간"))
+    }
+
+    @Test
+    @DisplayName("일반 검색어는 공백만 정규화하고 tag를 비운다")
+    fun resolvePlainKeywordIntent() {
+        // given
+        val keyword = "  spring    websocket  "
+
+        // when
+        val intent = resolver.resolve(keyword, "")
+
+        // then
+        assertThat(intent).isEqualTo(PostSearchIntent(keyword = "spring websocket", tag = ""))
+    }
+}


### PR DESCRIPTION
## 관련 이슈

close #850

## 작업 배경

- `ApiV1PostController`가 `hashtag`, `tag:`, `태그:` 검색 의도 파싱을 private 함수로 직접 처리하고 있어 HTTP adapter가 검색 정책까지 알고 있었습니다.
- 검색 문법 해석을 독립 resolver로 분리해 controller는 요청 정규화 결과 사용과 use case 호출에 집중하도록 정리했습니다.

## 작업 내용

- `PostSearchIntentResolver`를 추가해 keyword/tag 정규화, hashtag 승격, 영문/한글 tag prefix 해석을 캡슐화했습니다.
- `ApiV1PostController`의 private `SearchIntent`/`resolveSearchIntent`를 제거하고 resolver 주입 방식으로 변경했습니다.
- controller에 남아 있던 검색 keyword/tag 정규화도 resolver의 `normalizeKeyword`/`normalizeTag`로 통일했습니다.
- `PostSearchIntentResolverTest`를 추가해 명시 tag 파라미터 우선, hashtag, `tag:`, `태그:`, 일반 keyword, 충돌 입력 우선순위 케이스를 controller 없이 검증했습니다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back test --tests com.back.boundedContexts.post.adapter.web.PostSearchIntentResolverTest --tests com.back.boundedContexts.post.adapter.web.ApiV1PostControllerTest ktlintCheck`: 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks`: 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks`: 성공
  - commit hook `OpenApiContractExportTest`: 성공
  - commit hook `yarn contracts:check`: 성공
  - GitHub PR checks: backend-ci, frontend-ci, Security/CodeQL, Vercel 모두 성공
  - CodeRabbit review: 최초 nitpick 2건 반영 후 `ccc85382..2f76ed39` 최신 범위 재리뷰에서 actionable comment 0개 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `PostSearchIntentResolver`가 기존 controller private 함수의 정규화/파싱 계약을 그대로 옮겼는지 확인 부탁드립니다.
  - 공개 API path/request/response DTO는 변경하지 않았습니다.

## 리스크

- 검색 문법 해석 경계만 이동한 refactor라 API contract 변경 리스크는 낮습니다.
- tag/hashtag edge case 회귀를 막기 위해 resolver 단위 테스트를 추가했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (N/A: CodeRabbit 최신 리뷰 완료)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (PR 단계: Vercel preview 성공, main merge 후 자동 CD 추가 확인 예정)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 검색 입력의 태그/해시태그 해석 방식을 통합 적용하여, `tag:`, `태그:` 및 해시태그(#) 패턴을 일관되게 처리합니다.

* **Refactor**
  * 검색/탐색 관련 엔드포인트 전반에서 키워드·태그 정규화 규칙이 일관되도록 개선했습니다. 명시적 태그 파라미터가 해시태그 의도보다 우선 적용됩니다.

* **Tests**
  * 태그 우선순위, 해시태그 승격, 접두어 인식(영문/한글), 일반 검색어 처리 시나리오를 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
