### PR TITLE
[Refactor] 게시글 좋아요 충돌 복구 서비스 이동

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostController.kt
@@ -4,7 +4,6 @@ import com.back.boundedContexts.post.application.port.input.PostHitDedupUseCase
 import com.back.boundedContexts.post.application.port.input.PostPublicReadQueryUseCase
 import com.back.boundedContexts.post.application.port.input.PostUseCase
 import com.back.boundedContexts.post.application.support.PostCacheTags
-import com.back.boundedContexts.post.domain.postMixin.PostLikeToggleResult
 import com.back.boundedContexts.post.dto.CursorFeedPageDto
 import com.back.boundedContexts.post.dto.FeedPostDto
 import com.back.boundedContexts.post.dto.PostDto
@@ -12,14 +11,12 @@ import com.back.boundedContexts.post.dto.PostWithContentDto
 import com.back.boundedContexts.post.dto.PublicPostsBootstrapDto
 import com.back.boundedContexts.post.dto.TagCountDto
 import com.back.boundedContexts.post.model.Post
-import com.back.global.exception.application.AppException
 import com.back.global.rsData.RsData
 import com.back.global.web.application.Rq
 import com.back.standard.dto.page.PageDto
 import com.back.standard.dto.page.PagedResult
 import com.back.standard.dto.post.type1.PostSearchSortType1
 import com.back.standard.extensions.getOrThrow
-import jakarta.persistence.OptimisticLockException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
@@ -27,15 +24,10 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.Size
-import org.slf4j.LoggerFactory
-import org.springframework.dao.DataIntegrityViolationException
-import org.springframework.dao.OptimisticLockingFailureException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.*
-import java.sql.SQLException
 
 /**
  * ApiV1PostController는 웹 계층에서 HTTP 요청/응답을 처리하는 클래스입니다.
@@ -51,8 +43,6 @@ class ApiV1PostController(
     private val postSearchIntentResolver: PostSearchIntentResolver,
     private val rq: Rq,
 ) {
-    private val logger = LoggerFactory.getLogger(ApiV1PostController::class.java)
-
     /**
      * makePostDtoPage 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
      * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
@@ -575,7 +565,7 @@ class ApiV1PostController(
         if (!rq.hasRole("ADMIN")) {
             post.checkActorCanRead(rq.actorOrNull)
         }
-        val likeResult = resolveLikeResult(post) { postUseCase.like(post, rq.actor) }
+        val likeResult = postUseCase.like(post, rq.actor)
         return RsData(
             "200-1",
             "좋아요를 반영했습니다.",
@@ -599,7 +589,7 @@ class ApiV1PostController(
         if (!rq.hasRole("ADMIN")) {
             post.checkActorCanRead(rq.actorOrNull)
         }
-        val likeResult = resolveLikeResult(post) { postUseCase.unlike(post, rq.actor) }
+        val likeResult = postUseCase.unlike(post, rq.actor)
         return RsData(
             "200-1",
             "좋아요 취소를 반영했습니다.",
@@ -661,61 +651,6 @@ class ApiV1PostController(
             -> sort
             else -> PostSearchSortType1.CREATED_AT
         }
-
-    /**
-     * 실행 시점에 필요한 의존성/값을 결정합니다.
-     * 컨트롤러 계층에서 요청 DTO를 검증한 뒤 서비스 호출 결과를 응답 규격으로 변환합니다.
-     */
-    private fun resolveLikeResult(
-        post: Post,
-        action: () -> PostLikeToggleResult,
-    ): PostLikeToggleResult =
-        try {
-            action()
-        } catch (exception: Exception) {
-            if (!isRecoverableLikeConflict(exception)) throw exception
-            recoverLikeResult(post, exception)
-        }
-
-    /**
-     * recoverLikeResult 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
-    private fun recoverLikeResult(
-        post: Post,
-        exception: Exception,
-    ): PostLikeToggleResult {
-        logger.warn("Like conflict recovered with reconcile/snapshot. postId={} actorId={}", post.id, rq.actor.id, exception)
-        return try {
-            postUseCase.reconcileLikeState(post, rq.actor)
-        } catch (reconcileException: Exception) {
-            logger.warn(
-                "Like reconcile failed, fallback to snapshot. postId={} actorId={}",
-                post.id,
-                rq.actor.id,
-                reconcileException,
-            )
-            postUseCase.readLikeSnapshot(post, rq.actor)
-        }
-    }
-
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 컨트롤러 계층에서 요청 DTO를 검증한 뒤 서비스 호출 결과를 응답 규격으로 변환합니다.
-     */
-    private fun isRecoverableLikeConflict(exception: Exception): Boolean {
-        if (exception is DataIntegrityViolationException) return true
-        if (exception is ObjectOptimisticLockingFailureException) return true
-        if (exception is OptimisticLockingFailureException) return true
-        if (exception is OptimisticLockException) return true
-        if (exception is AppException && exception.rsData.statusCode == 409) return true
-
-        val sqlException =
-            generateSequence<Throwable>(exception) { it.cause }
-                .filterIsInstance<SQLException>()
-                .firstOrNull()
-        return sqlException?.sqlState in setOf("23505", "40001", "40P01")
-    }
 
     companion object {
         private const val MAX_PUBLIC_PAGE = 200

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/input/PostUseCase.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/input/PostUseCase.kt
@@ -84,16 +84,6 @@ interface PostUseCase {
         actor: Member,
     ): PostLikeToggleResult
 
-    fun reconcileLikeState(
-        post: Post,
-        actor: Member,
-    ): PostLikeToggleResult
-
-    fun readLikeSnapshot(
-        post: Post,
-        actor: Member,
-    ): PostLikeToggleResult
-
     fun incrementHit(post: Post)
 
     fun getComments(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -51,6 +51,7 @@ import org.springframework.context.ApplicationEventPublisher
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.util.UUID
@@ -653,7 +654,7 @@ class PostApplicationService(
         return PostLikeToggleResult(false, existingLikeId ?: 0L)
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun reconcileLikeState(
         post: Post,
         actor: Member,
@@ -668,7 +669,7 @@ class PostApplicationService(
         )
     }
 
-    @Transactional(readOnly = true)
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
     fun readLikeSnapshot(
         post: Post,
         actor: Member,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostLikeConflictResolver.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostLikeConflictResolver.kt
@@ -1,0 +1,71 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.post.domain.postMixin.PostLikeToggleResult
+import com.back.boundedContexts.post.model.Post
+import com.back.global.exception.application.AppException
+import jakarta.persistence.OptimisticLockException
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.dao.OptimisticLockingFailureException
+import org.springframework.orm.ObjectOptimisticLockingFailureException
+import org.springframework.stereotype.Service
+import java.sql.SQLException
+
+@Service
+class PostLikeConflictResolver {
+    private val logger = LoggerFactory.getLogger(PostLikeConflictResolver::class.java)
+
+    fun resolve(
+        post: Post,
+        actor: Member,
+        action: () -> PostLikeToggleResult,
+        reconcile: () -> PostLikeToggleResult,
+        snapshot: () -> PostLikeToggleResult,
+    ): PostLikeToggleResult =
+        try {
+            action()
+        } catch (exception: Exception) {
+            if (!isRecoverableLikeConflict(exception)) throw exception
+            recoverLikeResult(post, actor, exception, reconcile, snapshot)
+        }
+
+    private fun recoverLikeResult(
+        post: Post,
+        actor: Member,
+        exception: Exception,
+        reconcile: () -> PostLikeToggleResult,
+        snapshot: () -> PostLikeToggleResult,
+    ): PostLikeToggleResult {
+        logger.warn("Like conflict recovered with reconcile/snapshot. postId={} actorId={}", post.id, actor.id, exception)
+        return try {
+            reconcile()
+        } catch (reconcileException: Exception) {
+            logger.warn(
+                "Like reconcile failed, fallback to snapshot. postId={} actorId={}",
+                post.id,
+                actor.id,
+                reconcileException,
+            )
+            snapshot()
+        }
+    }
+
+    private fun isRecoverableLikeConflict(exception: Exception): Boolean {
+        if (exception is DataIntegrityViolationException) return true
+        if (exception is ObjectOptimisticLockingFailureException) return true
+        if (exception is OptimisticLockingFailureException) return true
+        if (exception is OptimisticLockException) return true
+        if (exception is AppException && exception.rsData.statusCode == 409) return true
+
+        val sqlException =
+            generateSequence<Throwable>(exception) { it.cause }
+                .filterIsInstance<SQLException>()
+                .firstOrNull()
+        return sqlException?.sqlState in RECOVERABLE_SQL_STATES
+    }
+
+    private companion object {
+        private val RECOVERABLE_SQL_STATES = setOf("23505", "40001", "40P01")
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostLikeConflictResolver.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostLikeConflictResolver.kt
@@ -6,7 +6,6 @@ import com.back.boundedContexts.post.model.Post
 import com.back.global.exception.application.AppException
 import jakarta.persistence.OptimisticLockException
 import org.slf4j.LoggerFactory
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.dao.OptimisticLockingFailureException
 import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.stereotype.Service
@@ -52,7 +51,6 @@ class PostLikeConflictResolver {
     }
 
     private fun isRecoverableLikeConflict(exception: Exception): Boolean {
-        if (exception is DataIntegrityViolationException) return true
         if (exception is ObjectOptimisticLockingFailureException) return true
         if (exception is OptimisticLockingFailureException) return true
         if (exception is OptimisticLockException) return true

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostUseCaseAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostUseCaseAdapter.kt
@@ -20,6 +20,7 @@ import java.time.Instant
 @Service
 class PostUseCaseAdapter(
     private val postApplicationService: PostApplicationService,
+    private val postLikeConflictResolver: PostLikeConflictResolver,
 ) : PostUseCase {
     override fun count(): Long = postApplicationService.count()
 
@@ -82,22 +83,26 @@ class PostUseCaseAdapter(
     override fun like(
         post: Post,
         actor: Member,
-    ): PostLikeToggleResult = postApplicationService.like(post, actor)
+    ): PostLikeToggleResult =
+        postLikeConflictResolver.resolve(
+            post = post,
+            actor = actor,
+            action = { postApplicationService.like(post, actor) },
+            reconcile = { postApplicationService.reconcileLikeState(post, actor) },
+            snapshot = { postApplicationService.readLikeSnapshot(post, actor) },
+        )
 
     override fun unlike(
         post: Post,
         actor: Member,
-    ): PostLikeToggleResult = postApplicationService.unlike(post, actor)
-
-    override fun reconcileLikeState(
-        post: Post,
-        actor: Member,
-    ): PostLikeToggleResult = postApplicationService.reconcileLikeState(post, actor)
-
-    override fun readLikeSnapshot(
-        post: Post,
-        actor: Member,
-    ): PostLikeToggleResult = postApplicationService.readLikeSnapshot(post, actor)
+    ): PostLikeToggleResult =
+        postLikeConflictResolver.resolve(
+            post = post,
+            actor = actor,
+            action = { postApplicationService.unlike(post, actor) },
+            reconcile = { postApplicationService.reconcileLikeState(post, actor) },
+            snapshot = { postApplicationService.readLikeSnapshot(post, actor) },
+        )
 
     override fun incrementHit(post: Post) = postApplicationService.incrementHit(post)
 

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostLikeConflictResolverTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostLikeConflictResolverTest.kt
@@ -1,0 +1,86 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.post.domain.postMixin.PostLikeToggleResult
+import com.back.boundedContexts.post.model.Post
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.dao.DataIntegrityViolationException
+import java.sql.SQLException
+
+@DisplayName("PostLikeConflictResolver 테스트")
+class PostLikeConflictResolverTest {
+    private val resolver = PostLikeConflictResolver()
+    private val actor = Member(1L, "user1", null, "user1", "user1@test.com")
+    private val post = Post(1L, actor, "title", "content", published = true, listed = true)
+
+    @Test
+    @DisplayName("recoverable DB 충돌이면 reconcile 결과를 반환한다")
+    fun recoverRecoverableDatabaseConflictWithReconcile() {
+        // given
+        var reconcileCalls = 0
+        val expected = PostLikeToggleResult(isLiked = true, likeId = 10L)
+
+        // when
+        val result =
+            resolver.resolve(
+                post = post,
+                actor = actor,
+                action = { throw DataIntegrityViolationException("duplicate like", SQLException("duplicate", "23505")) },
+                reconcile = {
+                    reconcileCalls += 1
+                    expected
+                },
+                snapshot = { PostLikeToggleResult(isLiked = false, likeId = 0L) },
+            )
+
+        // then
+        assertThat(result).isEqualTo(expected)
+        assertThat(reconcileCalls).isEqualTo(1)
+    }
+
+    @Test
+    @DisplayName("reconcile도 실패하면 snapshot 결과를 반환한다")
+    fun fallbackToSnapshotWhenReconcileFails() {
+        // given
+        var snapshotCalls = 0
+        val expected = PostLikeToggleResult(isLiked = false, likeId = 0L)
+
+        // when
+        val result =
+            resolver.resolve(
+                post = post,
+                actor = actor,
+                action = { throw DataIntegrityViolationException("deadlock", SQLException("deadlock", "40P01")) },
+                reconcile = { throw IllegalStateException("reconcile failed") },
+                snapshot = {
+                    snapshotCalls += 1
+                    expected
+                },
+            )
+
+        // then
+        assertThat(result).isEqualTo(expected)
+        assertThat(snapshotCalls).isEqualTo(1)
+    }
+
+    @Test
+    @DisplayName("recoverable 충돌이 아니면 예외를 그대로 전파한다")
+    fun throwNonRecoverableException() {
+        // given
+        val exception = IllegalArgumentException("invalid like request")
+
+        // when & then
+        assertThatThrownBy {
+            resolver.resolve(
+                post = post,
+                actor = actor,
+                action = { throw exception },
+                reconcile = { PostLikeToggleResult(isLiked = true, likeId = 1L) },
+                snapshot = { PostLikeToggleResult(isLiked = false, likeId = 0L) },
+            )
+        }.isSameAs(exception)
+    }
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostLikeConflictResolverTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostLikeConflictResolverTest.kt
@@ -83,4 +83,22 @@ class PostLikeConflictResolverTest {
             )
         }.isSameAs(exception)
     }
+
+    @Test
+    @DisplayName("recoverable SQLState가 아니면 DB 무결성 예외도 그대로 전파한다")
+    fun throwNonRecoverableDatabaseConflict() {
+        // given
+        val exception = DataIntegrityViolationException("foreign key violation", SQLException("fk", "23503"))
+
+        // when & then
+        assertThatThrownBy {
+            resolver.resolve(
+                post = post,
+                actor = actor,
+                action = { throw exception },
+                reconcile = { PostLikeToggleResult(isLiked = true, likeId = 1L) },
+                snapshot = { PostLikeToggleResult(isLiked = false, likeId = 0L) },
+            )
+        }.isSameAs(exception)
+    }
 }


### PR DESCRIPTION
## 관련 이슈

close #851

## 작업 배경

- 게시글 좋아요/좋아요 취소 충돌 복구 정책이 `ApiV1PostController` private 함수에 남아 있어 web adapter가 SQL state와 persistence 예외를 직접 판별하고 있었습니다.
- 좋아요 PUT/DELETE의 idempotent 계약과 동시성 충돌 복구 정책은 유지하되, DB 예외 판별은 application 계층으로 이동해야 합니다.

## 작업 내용

- `PostLikeConflictResolver`를 추가해 recoverable 좋아요 충돌 판별, reconcile 재시도, snapshot fallback을 application service 계층에서 처리하도록 했습니다.
- `PostUseCaseAdapter`가 `PostApplicationService.like/unlike` 호출을 resolver로 감싸도록 변경해 controller가 복구 정책을 몰라도 기존 service proxy 호출 경계를 유지합니다.
- `PostUseCase`에서 controller 전용으로 노출되던 `reconcileLikeState`, `readLikeSnapshot` 포트 메서드를 제거했습니다.
- `ApiV1PostController`의 SQL state/constraint 관련 import와 private 복구 함수를 제거하고, 좋아요 응답 변환만 남겼습니다.
- CodeRabbit 리뷰 반영으로 `DataIntegrityViolationException` blanket 복구를 제거하고, `reconcileLikeState`/`readLikeSnapshot`을 `REQUIRES_NEW` 복구 경계로 분리했습니다.
- `PostLikeConflictResolverTest`를 추가해 recoverable DB 충돌, reconcile 실패 시 snapshot fallback, non-recoverable 예외와 비복구 SQLState 전파를 검증했습니다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back ktlintCheck` 성공
  - `./back/gradlew -p back test --tests '*PostLikeConflictResolverTest*'` 성공
  - `./back/gradlew -p back test --tests '*PostLike*'` 성공
  - `./back/gradlew -p back test --tests '*ApiV1PostControllerTest*'` 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks` 성공, 2회 연속 통과
- GitHub checks:
  - `backend-ci / backend-ci` 성공
  - `frontend-ci / frontend-ci` 성공
  - `backend-dependency-check` 성공
  - `codeql (java-kotlin)` 성공
  - `codeql (javascript-typescript)` 성공
  - `Vercel` 성공
  - `CodeRabbit` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `PostUseCaseAdapter.like/unlike`가 resolver를 통해 `PostApplicationService` proxy 호출 실패를 잡고, reconcile/snapshot은 `REQUIRES_NEW`가 적용된 service proxy로 다시 호출하는 구조입니다.
  - controller에서 SQL state, `DataIntegrityViolationException`, optimistic locking 예외 판별이 제거됐는지 확인해 주세요.
  - CodeRabbit actionable 2건은 `d61ac84a`에서 반영했고 review threads를 resolved 처리했습니다.

## 리스크

- 좋아요 충돌 복구 위치와 복구 트랜잭션 경계만 변경했으며 응답 DTO, resultCode, HTTP status는 변경하지 않았습니다.
- 복구 정책이 application resolver에 모였으므로 향후 recoverable SQL state 추가는 controller가 아니라 resolver 테스트와 함께 변경해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (CodeRabbit 실제 리뷰 성공으로 fallback 미사용)
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다. (main merge 후 확인)
