### PR TITLE
[Refactor] PostPublicReadResponseFactory 응답 정책 컴포넌트 분리

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadCacheHeaderWriter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadCacheHeaderWriter.kt
@@ -1,0 +1,60 @@
+package com.back.boundedContexts.post.adapter.web
+
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+
+@Component
+class PostPublicReadCacheHeaderWriter(
+    private val serverTimingWriter: PostPublicReadServerTimingWriter = PostPublicReadServerTimingWriter(),
+) {
+    fun applyPublicReadCacheHeaders(
+        response: HttpServletResponse,
+        policy: PublicReadCachePolicy,
+        surrogateKeys: Set<String>,
+    ) {
+        val safeMaxAge = policy.maxAgeSeconds.coerceAtLeast(0)
+        val safeSharedMaxAge = policy.sharedMaxAgeSeconds.coerceAtLeast(safeMaxAge)
+        val safeSWR = policy.staleWhileRevalidateSeconds.coerceAtLeast(0)
+        val staleIfError = (safeSharedMaxAge + safeSWR).coerceAtLeast(safeSWR)
+        response.setHeader(
+            "Cache-Control",
+            "public, max-age=$safeMaxAge, s-maxage=$safeSharedMaxAge, stale-while-revalidate=$safeSWR, stale-if-error=$staleIfError",
+        )
+        response.setHeader("X-Cache-Policy", policy.name)
+        applySurrogateKeyHeaders(response, surrogateKeys)
+        serverTimingWriter.appendMetric(response, "cache-policy;desc=\"${policy.name}\"")
+    }
+
+    fun applyPrivateNoStoreHeaders(response: HttpServletResponse) {
+        response.setHeader("Cache-Control", "private, no-store, max-age=0")
+    }
+
+    fun applySurrogateKeyHeaders(
+        response: HttpServletResponse,
+        surrogateKeys: Set<String>,
+    ) {
+        val normalized =
+            surrogateKeys
+                .asSequence()
+                .map(::normalizeCacheTagToken)
+                .filter { it.isNotBlank() }
+                .distinct()
+                .toList()
+        if (normalized.isEmpty()) return
+        response.setHeader("Surrogate-Key", normalized.joinToString(" "))
+        response.setHeader("Cache-Tag", normalized.joinToString(","))
+    }
+
+    private fun normalizeCacheTagToken(raw: String): String =
+        raw
+            .trim()
+            .lowercase()
+            .replace(Regex("[^a-z0-9:_-]"), "-")
+            .replace(Regex("-+"), "-")
+            .trim('-')
+            .take(MAX_CACHE_TAG_LENGTH)
+
+    private companion object {
+        private const val MAX_CACHE_TAG_LENGTH = 64
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadCachePolicies.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadCachePolicies.kt
@@ -1,0 +1,90 @@
+package com.back.boundedContexts.post.adapter.web
+
+data class PublicReadCachePolicy(
+    val name: String,
+    val maxAgeSeconds: Int,
+    val sharedMaxAgeSeconds: Int,
+    val staleWhileRevalidateSeconds: Int,
+    val noStore: Boolean = false,
+)
+
+object PostPublicReadCachePolicies {
+    val FEED =
+        PublicReadCachePolicy(
+            name = "feed-max20-smax60-swr60",
+            maxAgeSeconds = 20,
+            sharedMaxAgeSeconds = 60,
+            staleWhileRevalidateSeconds = 60,
+        )
+    val FEED_CURSOR =
+        PublicReadCachePolicy(
+            name = "feed-cursor-max20-smax60-swr60",
+            maxAgeSeconds = 20,
+            sharedMaxAgeSeconds = 60,
+            staleWhileRevalidateSeconds = 60,
+        )
+    val EXPLORE =
+        PublicReadCachePolicy(
+            name = "explore-max20-smax60-swr60",
+            maxAgeSeconds = 20,
+            sharedMaxAgeSeconds = 60,
+            staleWhileRevalidateSeconds = 60,
+        )
+    val EXPLORE_CURSOR =
+        PublicReadCachePolicy(
+            name = "explore-cursor-max20-smax60-swr60",
+            maxAgeSeconds = 20,
+            sharedMaxAgeSeconds = 60,
+            staleWhileRevalidateSeconds = 60,
+        )
+    val SEARCH_DEFAULT =
+        PublicReadCachePolicy(
+            name = "search-max15-smax45-swr45",
+            maxAgeSeconds = 15,
+            sharedMaxAgeSeconds = 45,
+            staleWhileRevalidateSeconds = 45,
+        )
+    val SEARCH_SHORT =
+        PublicReadCachePolicy(
+            name = "search-short-max5-smax10-swr15",
+            maxAgeSeconds = 5,
+            sharedMaxAgeSeconds = 10,
+            staleWhileRevalidateSeconds = 15,
+        )
+    val SEARCH_NO_STORE =
+        PublicReadCachePolicy(
+            name = "search-high-entropy-no-store",
+            maxAgeSeconds = 0,
+            sharedMaxAgeSeconds = 0,
+            staleWhileRevalidateSeconds = 0,
+            noStore = true,
+        )
+    val TAGS =
+        PublicReadCachePolicy(
+            name = "tags-max60-smax300-swr300",
+            maxAgeSeconds = 60,
+            sharedMaxAgeSeconds = 300,
+            staleWhileRevalidateSeconds = 300,
+        )
+    val BOOTSTRAP =
+        PublicReadCachePolicy(
+            name = "bootstrap-max20-smax60-swr60",
+            maxAgeSeconds = 20,
+            sharedMaxAgeSeconds = 60,
+            staleWhileRevalidateSeconds = 60,
+        )
+    val DETAIL =
+        PublicReadCachePolicy(
+            name = "detail-max20-smax60-swr60",
+            maxAgeSeconds = 20,
+            sharedMaxAgeSeconds = 60,
+            staleWhileRevalidateSeconds = 60,
+        )
+    val RELATED_AUTHOR =
+        PublicReadCachePolicy(
+            name = "related-author-max15-smax45-swr45",
+            maxAgeSeconds = 15,
+            sharedMaxAgeSeconds = 45,
+            staleWhileRevalidateSeconds = 45,
+        )
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadEtagSeedBuilder.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadEtagSeedBuilder.kt
@@ -1,0 +1,136 @@
+package com.back.boundedContexts.post.adapter.web
+
+import com.back.boundedContexts.post.dto.CursorFeedPageDto
+import com.back.boundedContexts.post.dto.FeedPostDto
+import com.back.boundedContexts.post.dto.PostWithContentDto
+import com.back.boundedContexts.post.dto.PublicPostsBootstrapDto
+import com.back.boundedContexts.post.dto.TagCountDto
+import com.back.standard.dto.page.PageDto
+import com.back.standard.dto.post.type1.PostSearchSortType1
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+@Component
+class PostPublicReadEtagSeedBuilder {
+    fun buildFeedPageEtagSeed(
+        source: String,
+        page: Int,
+        pageSize: Int,
+        sort: PostSearchSortType1,
+        kw: String = "",
+        tag: String = "",
+        data: PageDto<FeedPostDto>,
+    ): String {
+        val itemsToken = buildFeedItemsToken(data.content)
+        return buildString {
+            append(source)
+            append("|page=")
+            append(page)
+            append("|size=")
+            append(pageSize)
+            append("|sort=")
+            append(sort.name)
+            append("|kw=")
+            append(kw.trim())
+            append("|tag=")
+            append(tag.trim())
+            append("|total=")
+            append(data.pageable.totalElements)
+            append("|pages=")
+            append(data.pageable.totalPages)
+            append("|items=")
+            append(itemsToken)
+        }
+    }
+
+    fun buildCursorFeedEtagSeed(
+        source: String,
+        pageSize: Int,
+        sort: PostSearchSortType1,
+        cursor: String?,
+        tag: String = "",
+        data: CursorFeedPageDto,
+    ): String {
+        val itemsToken = buildFeedItemsToken(data.content)
+        return buildString {
+            append(source)
+            append("|size=")
+            append(pageSize)
+            append("|sort=")
+            append(sort.name)
+            append("|cursor=")
+            append(cursor?.trim().orEmpty())
+            append("|tag=")
+            append(tag.trim())
+            append("|hasNext=")
+            append(data.hasNext)
+            append("|nextCursor=")
+            append(data.nextCursor.orEmpty())
+            append("|items=")
+            append(itemsToken)
+        }
+    }
+
+    fun buildPublicDetailEtagSeed(data: PostWithContentDto): String =
+        buildString {
+            append(data.id)
+            append("|")
+            append(toEpochMillis(data.modifiedAt))
+            append("|")
+            append(data.version)
+            append("|")
+            append(data.likesCount)
+            append("|")
+            append(data.commentsCount)
+            append("|")
+            append(data.hitCount)
+        }
+
+    fun buildTagsEtagSeed(tags: List<TagCountDto>): String = tags.joinToString(separator = "|") { "${it.tag}:${it.count}" }
+
+    fun buildRelatedAuthorEtagSeed(
+        authorId: Long,
+        excludePostId: Long?,
+        limit: Int,
+        posts: List<FeedPostDto>,
+    ): String {
+        val itemsToken = buildFeedItemsToken(posts)
+        return buildString {
+            append("related-author")
+            append("|authorId=")
+            append(authorId)
+            append("|excludePostId=")
+            append(excludePostId ?: 0L)
+            append("|limit=")
+            append(limit)
+            append("|items=")
+            append(itemsToken)
+        }
+    }
+
+    fun buildBootstrapEtagSeed(
+        pageSize: Int,
+        sort: PostSearchSortType1,
+        tag: String,
+        data: PublicPostsBootstrapDto,
+    ): String {
+        val feedSeed =
+            buildCursorFeedEtagSeed(
+                source = if (tag.isBlank()) "bootstrap-feed-cursor" else "bootstrap-explore-cursor",
+                pageSize = pageSize,
+                sort = sort,
+                cursor = null,
+                tag = tag,
+                data = data.feed,
+            )
+        val tagSeed = buildTagsEtagSeed(data.tags)
+        return "$feedSeed|tags=$tagSeed"
+    }
+
+    private fun buildFeedItemsToken(posts: List<FeedPostDto>): String =
+        posts.joinToString(separator = "|") {
+            "${it.id}:${toEpochMillis(it.modifiedAt)}:${it.likesCount}:${it.commentsCount}:${it.hitCount}"
+        }
+
+    private fun toEpochMillis(instant: Instant): Long = instant.toEpochMilli()
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadEtagSupport.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadEtagSupport.kt
@@ -1,0 +1,38 @@
+package com.back.boundedContexts.post.adapter.web
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+@Component
+class PostPublicReadEtagSupport {
+    fun toWeakEtag(seed: String): String {
+        val digest =
+            MessageDigest
+                .getInstance("SHA-256")
+                .digest(seed.toByteArray(StandardCharsets.UTF_8))
+                .joinToString("") { each -> "%02x".format(each) }
+                .take(32)
+        return "W/\"$digest\""
+    }
+
+    fun isNotModified(
+        request: HttpServletRequest,
+        etag: String,
+    ): Boolean {
+        val ifNoneMatch = request.getHeader(HttpHeaders.IF_NONE_MATCH)?.trim().orEmpty()
+        if (ifNoneMatch.isBlank()) return false
+        if (ifNoneMatch == "*") return true
+
+        val expected = normalizeEtagToken(etag)
+        return ifNoneMatch
+            .split(",")
+            .asSequence()
+            .map { normalizeEtagToken(it) }
+            .any { it == expected }
+    }
+
+    private fun normalizeEtagToken(raw: String): String = raw.trim().removePrefix("W/").removePrefix("w/")
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadResponseFactory.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadResponseFactory.kt
@@ -13,13 +13,15 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
-import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
-import java.time.Instant
-import java.util.Locale
 
 @Component
-class PostPublicReadResponseFactory {
+class PostPublicReadResponseFactory(
+    private val cacheHeaderWriter: PostPublicReadCacheHeaderWriter = PostPublicReadCacheHeaderWriter(),
+    private val serverTimingWriter: PostPublicReadServerTimingWriter = PostPublicReadServerTimingWriter(),
+    private val etagSupport: PostPublicReadEtagSupport = PostPublicReadEtagSupport(),
+    private val etagSeedBuilder: PostPublicReadEtagSeedBuilder = PostPublicReadEtagSeedBuilder(),
+    private val searchCachePolicyResolver: PostSearchCachePolicyResolver = PostSearchCachePolicyResolver(),
+) {
     fun <T : Any> respondWithEtag(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -29,16 +31,16 @@ class PostPublicReadResponseFactory {
         startedAtNanos: Long,
         body: T,
     ): ResponseEntity<T> {
-        applyPublicReadCacheHeaders(response, cachePolicy, surrogateKeys)
-        val etag = toWeakEtag(etagSeed)
+        cacheHeaderWriter.applyPublicReadCacheHeaders(response, cachePolicy, surrogateKeys)
+        val etag = etagSupport.toWeakEtag(etagSeed)
         response.setHeader(HttpHeaders.ETAG, etag)
-        if (isNotModified(request, etag)) {
-            appendServerTiming(response, "cache;desc=\"etag-304\"")
-            appendOriginTiming(response, startedAtNanos, "etag-304")
+        if (etagSupport.isNotModified(request, etag)) {
+            serverTimingWriter.appendMetric(response, "cache;desc=\"etag-304\"")
+            serverTimingWriter.appendOriginTiming(response, startedAtNanos, "etag-304")
             response.status = HttpServletResponse.SC_NOT_MODIFIED
             return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build<T>()
         }
-        appendOriginTiming(response, startedAtNanos, "etag-200")
+        serverTimingWriter.appendOriginTiming(response, startedAtNanos, "etag-200")
         return ResponseEntity.ok(body)
     }
 
@@ -50,25 +52,19 @@ class PostPublicReadResponseFactory {
         originDescription: String,
         body: T,
     ): ResponseEntity<T> {
-        applyPrivateNoStoreHeaders(response)
+        cacheHeaderWriter.applyPrivateNoStoreHeaders(response)
         response.setHeader("X-Cache-Policy", cachePolicy.name)
-        applySurrogateKeyHeaders(response, surrogateKeys)
-        appendServerTiming(response, "cache-policy;desc=\"${cachePolicy.name}\"")
-        appendOriginTiming(response, startedAtNanos, originDescription)
+        cacheHeaderWriter.applySurrogateKeyHeaders(response, surrogateKeys)
+        serverTimingWriter.appendMetric(response, "cache-policy;desc=\"${cachePolicy.name}\"")
+        serverTimingWriter.appendOriginTiming(response, startedAtNanos, originDescription)
         return ResponseEntity.ok(body)
     }
 
     fun applyPrivateNoStoreHeaders(response: HttpServletResponse) {
-        response.setHeader("Cache-Control", "private, no-store, max-age=0")
+        cacheHeaderWriter.applyPrivateNoStoreHeaders(response)
     }
 
-    fun resolveSearchReadCachePolicy(keyword: String): PublicReadCachePolicy {
-        val normalized = keyword.trim()
-        if (normalized.isBlank()) return PostPublicReadCachePolicies.SEARCH_DEFAULT
-        if (isHighEntropyKeyword(normalized)) return PostPublicReadCachePolicies.SEARCH_NO_STORE
-        if (normalized.length >= SEARCH_SHORT_TTL_KEYWORD_LENGTH) return PostPublicReadCachePolicies.SEARCH_SHORT
-        return PostPublicReadCachePolicies.SEARCH_DEFAULT
-    }
+    fun resolveSearchReadCachePolicy(keyword: String): PublicReadCachePolicy = searchCachePolicyResolver.resolve(keyword)
 
     fun buildFeedPageEtagSeed(
         source: String,
@@ -78,31 +74,16 @@ class PostPublicReadResponseFactory {
         kw: String = "",
         tag: String = "",
         data: PageDto<FeedPostDto>,
-    ): String {
-        val itemsToken =
-            data.content.joinToString(separator = "|") {
-                "${it.id}:${toEpochMillis(it.modifiedAt)}:${it.likesCount}:${it.commentsCount}:${it.hitCount}"
-            }
-        return buildString {
-            append(source)
-            append("|page=")
-            append(page)
-            append("|size=")
-            append(pageSize)
-            append("|sort=")
-            append(sort.name)
-            append("|kw=")
-            append(kw.trim())
-            append("|tag=")
-            append(tag.trim())
-            append("|total=")
-            append(data.pageable.totalElements)
-            append("|pages=")
-            append(data.pageable.totalPages)
-            append("|items=")
-            append(itemsToken)
-        }
-    }
+    ): String =
+        etagSeedBuilder.buildFeedPageEtagSeed(
+            source = source,
+            page = page,
+            pageSize = pageSize,
+            sort = sort,
+            kw = kw,
+            tag = tag,
+            data = data,
+        )
 
     fun buildCursorFeedEtagSeed(
         source: String,
@@ -111,297 +92,43 @@ class PostPublicReadResponseFactory {
         cursor: String?,
         tag: String = "",
         data: CursorFeedPageDto,
-    ): String {
-        val itemsToken =
-            data.content.joinToString(separator = "|") {
-                "${it.id}:${toEpochMillis(it.modifiedAt)}:${it.likesCount}:${it.commentsCount}:${it.hitCount}"
-            }
-        return buildString {
-            append(source)
-            append("|size=")
-            append(pageSize)
-            append("|sort=")
-            append(sort.name)
-            append("|cursor=")
-            append(cursor?.trim().orEmpty())
-            append("|tag=")
-            append(tag.trim())
-            append("|hasNext=")
-            append(data.hasNext)
-            append("|nextCursor=")
-            append(data.nextCursor.orEmpty())
-            append("|items=")
-            append(itemsToken)
-        }
-    }
+    ): String =
+        etagSeedBuilder.buildCursorFeedEtagSeed(
+            source = source,
+            pageSize = pageSize,
+            sort = sort,
+            cursor = cursor,
+            tag = tag,
+            data = data,
+        )
 
-    fun buildPublicDetailEtagSeed(data: PostWithContentDto): String =
-        buildString {
-            append(data.id)
-            append("|")
-            append(toEpochMillis(data.modifiedAt))
-            append("|")
-            append(data.version)
-            append("|")
-            append(data.likesCount)
-            append("|")
-            append(data.commentsCount)
-            append("|")
-            append(data.hitCount)
-        }
+    fun buildPublicDetailEtagSeed(data: PostWithContentDto): String = etagSeedBuilder.buildPublicDetailEtagSeed(data)
 
-    fun buildTagsEtagSeed(tags: List<TagCountDto>): String = tags.joinToString(separator = "|") { "${it.tag}:${it.count}" }
+    fun buildTagsEtagSeed(tags: List<TagCountDto>): String = etagSeedBuilder.buildTagsEtagSeed(tags)
 
     fun buildRelatedAuthorEtagSeed(
         authorId: Long,
         excludePostId: Long?,
         limit: Int,
         posts: List<FeedPostDto>,
-    ): String {
-        val itemsToken =
-            posts.joinToString(separator = "|") {
-                "${it.id}:${toEpochMillis(it.modifiedAt)}:${it.likesCount}:${it.commentsCount}:${it.hitCount}"
-            }
-        return buildString {
-            append("related-author")
-            append("|authorId=")
-            append(authorId)
-            append("|excludePostId=")
-            append(excludePostId ?: 0L)
-            append("|limit=")
-            append(limit)
-            append("|items=")
-            append(itemsToken)
-        }
-    }
+    ): String =
+        etagSeedBuilder.buildRelatedAuthorEtagSeed(
+            authorId = authorId,
+            excludePostId = excludePostId,
+            limit = limit,
+            posts = posts,
+        )
 
     fun buildBootstrapEtagSeed(
         pageSize: Int,
         sort: PostSearchSortType1,
         tag: String,
         data: PublicPostsBootstrapDto,
-    ): String {
-        val feedSeed =
-            buildCursorFeedEtagSeed(
-                source = if (tag.isBlank()) "bootstrap-feed-cursor" else "bootstrap-explore-cursor",
-                pageSize = pageSize,
-                sort = sort,
-                cursor = null,
-                tag = tag,
-                data = data.feed,
-            )
-        val tagSeed = buildTagsEtagSeed(data.tags)
-        return "$feedSeed|tags=$tagSeed"
-    }
-
-    private fun applyPublicReadCacheHeaders(
-        response: HttpServletResponse,
-        policy: PublicReadCachePolicy,
-        surrogateKeys: Set<String>,
-    ) {
-        val safeMaxAge = policy.maxAgeSeconds.coerceAtLeast(0)
-        val safeSharedMaxAge = policy.sharedMaxAgeSeconds.coerceAtLeast(safeMaxAge)
-        val safeSWR = policy.staleWhileRevalidateSeconds.coerceAtLeast(0)
-        val staleIfError = (safeSharedMaxAge + safeSWR).coerceAtLeast(safeSWR)
-        response.setHeader(
-            "Cache-Control",
-            "public, max-age=$safeMaxAge, s-maxage=$safeSharedMaxAge, stale-while-revalidate=$safeSWR, stale-if-error=$staleIfError",
-        )
-        response.setHeader("X-Cache-Policy", policy.name)
-        applySurrogateKeyHeaders(response, surrogateKeys)
-        appendServerTiming(response, "cache-policy;desc=\"${policy.name}\"")
-    }
-
-    private fun applySurrogateKeyHeaders(
-        response: HttpServletResponse,
-        surrogateKeys: Set<String>,
-    ) {
-        val normalized =
-            surrogateKeys
-                .asSequence()
-                .map(::normalizeCacheTagToken)
-                .filter { it.isNotBlank() }
-                .distinct()
-                .toList()
-        if (normalized.isEmpty()) return
-        response.setHeader("Surrogate-Key", normalized.joinToString(" "))
-        response.setHeader("Cache-Tag", normalized.joinToString(","))
-    }
-
-    private fun normalizeCacheTagToken(raw: String): String =
-        raw
-            .trim()
-            .lowercase()
-            .replace(Regex("[^a-z0-9:_-]"), "-")
-            .replace(Regex("-+"), "-")
-            .trim('-')
-            .take(MAX_CACHE_TAG_LENGTH)
-
-    private fun appendServerTiming(
-        response: HttpServletResponse,
-        metric: String,
-    ) {
-        val current = response.getHeader("Server-Timing")
-        if (current.isNullOrBlank()) {
-            response.setHeader("Server-Timing", metric)
-            return
-        }
-        response.setHeader("Server-Timing", "$current, $metric")
-    }
-
-    private fun appendOriginTiming(
-        response: HttpServletResponse,
-        startedAtNanos: Long,
-        description: String,
-    ) {
-        val elapsedMs = ((System.nanoTime() - startedAtNanos).coerceAtLeast(0L)).toDouble() / 1_000_000.0
-        val durationToken = String.format(Locale.US, "%.1f", elapsedMs)
-        appendServerTiming(response, "origin;dur=$durationToken;desc=\"$description\"")
-    }
-
-    private fun normalizeEtagToken(raw: String): String = raw.trim().removePrefix("W/").removePrefix("w/")
-
-    private fun toWeakEtag(seed: String): String {
-        val digest =
-            MessageDigest
-                .getInstance("SHA-256")
-                .digest(seed.toByteArray(StandardCharsets.UTF_8))
-                .joinToString("") { each -> "%02x".format(each) }
-                .take(32)
-        return "W/\"$digest\""
-    }
-
-    private fun isNotModified(
-        request: HttpServletRequest,
-        etag: String,
-    ): Boolean {
-        val ifNoneMatch = request.getHeader(HttpHeaders.IF_NONE_MATCH)?.trim().orEmpty()
-        if (ifNoneMatch.isBlank()) return false
-        if (ifNoneMatch == "*") return true
-
-        val expected = normalizeEtagToken(etag)
-        return ifNoneMatch
-            .split(",")
-            .asSequence()
-            .map { normalizeEtagToken(it) }
-            .any { it == expected }
-    }
-
-    private fun isHighEntropyKeyword(keyword: String): Boolean {
-        if (keyword.length >= SEARCH_NO_STORE_KEYWORD_LENGTH) return true
-
-        val tokens = keyword.split(Regex("\\s+")).filter { it.isNotBlank() }
-        if (tokens.size >= SEARCH_NO_STORE_TOKEN_COUNT) return true
-
-        val alphaNumeric = keyword.filter { it.isLetterOrDigit() }
-        if (alphaNumeric.length < SEARCH_HIGH_ENTROPY_MIN_LENGTH) return false
-
-        val uniqueRatio =
-            alphaNumeric
-                .lowercase()
-                .toSet()
-                .size
-                .toDouble() / alphaNumeric.length
-        return uniqueRatio >= SEARCH_HIGH_ENTROPY_UNIQUE_RATIO_THRESHOLD
-    }
-
-    private fun toEpochMillis(instant: Instant): Long = instant.toEpochMilli()
-
-    private companion object {
-        private const val MAX_CACHE_TAG_LENGTH = 64
-        private const val SEARCH_SHORT_TTL_KEYWORD_LENGTH = 16
-        private const val SEARCH_NO_STORE_KEYWORD_LENGTH = 28
-        private const val SEARCH_NO_STORE_TOKEN_COUNT = 4
-        private const val SEARCH_HIGH_ENTROPY_MIN_LENGTH = 16
-        private const val SEARCH_HIGH_ENTROPY_UNIQUE_RATIO_THRESHOLD = 0.58
-    }
-}
-
-data class PublicReadCachePolicy(
-    val name: String,
-    val maxAgeSeconds: Int,
-    val sharedMaxAgeSeconds: Int,
-    val staleWhileRevalidateSeconds: Int,
-    val noStore: Boolean = false,
-)
-
-object PostPublicReadCachePolicies {
-    val FEED =
-        PublicReadCachePolicy(
-            name = "feed-max20-smax60-swr60",
-            maxAgeSeconds = 20,
-            sharedMaxAgeSeconds = 60,
-            staleWhileRevalidateSeconds = 60,
-        )
-    val FEED_CURSOR =
-        PublicReadCachePolicy(
-            name = "feed-cursor-max20-smax60-swr60",
-            maxAgeSeconds = 20,
-            sharedMaxAgeSeconds = 60,
-            staleWhileRevalidateSeconds = 60,
-        )
-    val EXPLORE =
-        PublicReadCachePolicy(
-            name = "explore-max20-smax60-swr60",
-            maxAgeSeconds = 20,
-            sharedMaxAgeSeconds = 60,
-            staleWhileRevalidateSeconds = 60,
-        )
-    val EXPLORE_CURSOR =
-        PublicReadCachePolicy(
-            name = "explore-cursor-max20-smax60-swr60",
-            maxAgeSeconds = 20,
-            sharedMaxAgeSeconds = 60,
-            staleWhileRevalidateSeconds = 60,
-        )
-    val SEARCH_DEFAULT =
-        PublicReadCachePolicy(
-            name = "search-max15-smax45-swr45",
-            maxAgeSeconds = 15,
-            sharedMaxAgeSeconds = 45,
-            staleWhileRevalidateSeconds = 45,
-        )
-    val SEARCH_SHORT =
-        PublicReadCachePolicy(
-            name = "search-short-max5-smax10-swr15",
-            maxAgeSeconds = 5,
-            sharedMaxAgeSeconds = 10,
-            staleWhileRevalidateSeconds = 15,
-        )
-    val SEARCH_NO_STORE =
-        PublicReadCachePolicy(
-            name = "search-high-entropy-no-store",
-            maxAgeSeconds = 0,
-            sharedMaxAgeSeconds = 0,
-            staleWhileRevalidateSeconds = 0,
-            noStore = true,
-        )
-    val TAGS =
-        PublicReadCachePolicy(
-            name = "tags-max60-smax300-swr300",
-            maxAgeSeconds = 60,
-            sharedMaxAgeSeconds = 300,
-            staleWhileRevalidateSeconds = 300,
-        )
-    val BOOTSTRAP =
-        PublicReadCachePolicy(
-            name = "bootstrap-max20-smax60-swr60",
-            maxAgeSeconds = 20,
-            sharedMaxAgeSeconds = 60,
-            staleWhileRevalidateSeconds = 60,
-        )
-    val DETAIL =
-        PublicReadCachePolicy(
-            name = "detail-max20-smax60-swr60",
-            maxAgeSeconds = 20,
-            sharedMaxAgeSeconds = 60,
-            staleWhileRevalidateSeconds = 60,
-        )
-    val RELATED_AUTHOR =
-        PublicReadCachePolicy(
-            name = "related-author-max15-smax45-swr45",
-            maxAgeSeconds = 15,
-            sharedMaxAgeSeconds = 45,
-            staleWhileRevalidateSeconds = 45,
+    ): String =
+        etagSeedBuilder.buildBootstrapEtagSeed(
+            pageSize = pageSize,
+            sort = sort,
+            tag = tag,
+            data = data,
         )
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadServerTimingWriter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadServerTimingWriter.kt
@@ -1,0 +1,30 @@
+package com.back.boundedContexts.post.adapter.web
+
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import java.util.Locale
+
+@Component
+class PostPublicReadServerTimingWriter {
+    fun appendMetric(
+        response: HttpServletResponse,
+        metric: String,
+    ) {
+        val current = response.getHeader("Server-Timing")
+        if (current.isNullOrBlank()) {
+            response.setHeader("Server-Timing", metric)
+            return
+        }
+        response.setHeader("Server-Timing", "$current, $metric")
+    }
+
+    fun appendOriginTiming(
+        response: HttpServletResponse,
+        startedAtNanos: Long,
+        description: String,
+    ) {
+        val elapsedMs = ((System.nanoTime() - startedAtNanos).coerceAtLeast(0L)).toDouble() / 1_000_000.0
+        val durationToken = String.format(Locale.US, "%.1f", elapsedMs)
+        appendMetric(response, "origin;dur=$durationToken;desc=\"$description\"")
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostSearchCachePolicyResolver.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostSearchCachePolicyResolver.kt
@@ -1,0 +1,40 @@
+package com.back.boundedContexts.post.adapter.web
+
+import org.springframework.stereotype.Component
+
+@Component
+class PostSearchCachePolicyResolver {
+    fun resolve(keyword: String): PublicReadCachePolicy {
+        val normalized = keyword.trim()
+        if (normalized.isBlank()) return PostPublicReadCachePolicies.SEARCH_DEFAULT
+        if (isHighEntropyKeyword(normalized)) return PostPublicReadCachePolicies.SEARCH_NO_STORE
+        if (normalized.length >= SEARCH_SHORT_TTL_KEYWORD_LENGTH) return PostPublicReadCachePolicies.SEARCH_SHORT
+        return PostPublicReadCachePolicies.SEARCH_DEFAULT
+    }
+
+    private fun isHighEntropyKeyword(keyword: String): Boolean {
+        if (keyword.length >= SEARCH_NO_STORE_KEYWORD_LENGTH) return true
+
+        val tokens = keyword.split(Regex("\\s+")).filter { it.isNotBlank() }
+        if (tokens.size >= SEARCH_NO_STORE_TOKEN_COUNT) return true
+
+        val alphaNumeric = keyword.filter { it.isLetterOrDigit() }
+        if (alphaNumeric.length < SEARCH_HIGH_ENTROPY_MIN_LENGTH) return false
+
+        val uniqueRatio =
+            alphaNumeric
+                .lowercase()
+                .toSet()
+                .size
+                .toDouble() / alphaNumeric.length
+        return uniqueRatio >= SEARCH_HIGH_ENTROPY_UNIQUE_RATIO_THRESHOLD
+    }
+
+    private companion object {
+        private const val SEARCH_SHORT_TTL_KEYWORD_LENGTH = 16
+        private const val SEARCH_NO_STORE_KEYWORD_LENGTH = 28
+        private const val SEARCH_NO_STORE_TOKEN_COUNT = 4
+        private const val SEARCH_HIGH_ENTROPY_MIN_LENGTH = 16
+        private const val SEARCH_HIGH_ENTROPY_UNIQUE_RATIO_THRESHOLD = 0.58
+    }
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadResponseFactoryTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadResponseFactoryTest.kt
@@ -341,6 +341,63 @@ class PostPublicReadResponseFactoryTest {
     }
 
     @Test
+    @DisplayName("ETag seed builder는 기본 검색어와 non-null 제외 post id 경로를 안정적으로 직렬화한다")
+    fun buildEtagSeedsWithDefaultFiltersAndExcludedPost() {
+        // given
+        val post = feedPost(id = 7L, modifiedAt = Instant.parse("2026-01-07T00:00:00Z"))
+        val page =
+            PageDto(
+                content = listOf(post),
+                pageable =
+                    PageableDto(
+                        pageNumber = 0,
+                        pageSize = 20,
+                        totalElements = 1,
+                        totalPages = 1,
+                        numberOfElements = 1,
+                    ),
+            )
+        val cursorFeed =
+            CursorFeedPageDto(
+                content = listOf(post),
+                pageSize = 20,
+                hasNext = false,
+                nextCursor = null,
+            )
+        val seedBuilder = PostPublicReadEtagSeedBuilder()
+
+        // when
+        val pageSeed =
+            seedBuilder.buildFeedPageEtagSeed(
+                source = "feed",
+                page = 0,
+                pageSize = 20,
+                sort = PostSearchSortType1.CREATED_AT,
+                data = page,
+            )
+        val cursorSeed =
+            seedBuilder.buildCursorFeedEtagSeed(
+                source = "feed-cursor",
+                pageSize = 20,
+                sort = PostSearchSortType1.CREATED_AT,
+                cursor = null,
+                data = cursorFeed,
+            )
+        val relatedSeed =
+            seedBuilder.buildRelatedAuthorEtagSeed(
+                authorId = 3L,
+                excludePostId = 7L,
+                limit = 4,
+                posts = listOf(post),
+            )
+
+        // then
+        assertThat(pageSeed).contains("|kw=|tag=|")
+        assertThat(cursorSeed).contains("|cursor=|tag=|hasNext=false|nextCursor=|")
+        assertThat(relatedSeed).contains("|excludePostId=7|")
+    }
+
+    @Test
     @DisplayName("공개 read cache policy registry는 모든 endpoint 정책을 노출한다")
     fun exposeAllPublicReadCachePolicies() {
         val policies =


### PR DESCRIPTION
## 관련 이슈

close #852

## 작업 배경

- `PostPublicReadResponseFactory`가 공개 조회 응답의 Cache-Control, Surrogate-Key/Cache-Tag, ETag 생성/비교, Server-Timing, 검색 cache policy, ETag seed 생성을 한 클래스에서 함께 처리해 변경 영향 범위가 넓었습니다.
- 기존 공개 read API 응답 계약은 유지하면서 역할별 컴포넌트로 분리해 컨트롤러와 factory의 책임을 좁힙니다.

## 작업 내용

- `PostPublicReadCacheHeaderWriter`로 public/private cache header와 surrogate key 작성 책임을 분리했습니다.
- `PostPublicReadServerTimingWriter`로 Server-Timing metric append 책임을 분리했습니다.
- `PostPublicReadEtagSupport`로 weak ETag 생성과 `If-None-Match` 비교 책임을 분리했습니다.
- `PostPublicReadEtagSeedBuilder`로 feed/cursor/detail/tag/related/bootstrap ETag seed 생성을 분리했습니다.
- `PostSearchCachePolicyResolver`와 `PostPublicReadCachePolicies`로 검색 cache policy 판단과 정책 registry를 분리했습니다.
- 기존 `PostPublicReadResponseFactory`는 공개 조회 응답 조립 orchestration만 담당하도록 축소했습니다.
- 기존 응답 header/ETag/no-store/seed 계약과 새 seed builder default argument 경로를 테스트로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back ktlintCheck` 성공
  - `./back/gradlew -p back test --tests '*PostPublicRead*'` 성공
  - `./back/gradlew -p back test --tests '*ApiV1PostControllerTest*'` 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks` 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks` 2회차 성공
  - pre-commit `OpenApiContractExportTest` 성공
  - pre-commit `yarn contracts:check` 성공

## 리뷰어 메모

- 먼저 볼 지점:
  - `PostPublicReadResponseFactory`가 기존 public method 계약을 유지하면서 역할별 컴포넌트로 위임하는지
  - cache header, ETag, Server-Timing, search cache policy 값이 기존 테스트와 동일하게 유지되는지
  - 새 컴포넌트가 Spring bean 주입과 직접 unit test instantiation 양쪽에서 문제 없는지

## 리스크

- 공개 조회 API의 CDN/cache header 계약에 영향이 있을 수 있어 기존 header/ETag/no-store 테스트와 `ApiV1PostControllerTest`로 회귀를 확인했습니다.
- 런타임 동작 변경 목적이 아닌 책임 분리 작업입니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * HTTP 캐싱 정책 및 캐시 헤더 지원 추가
  * ETag 기반 조건부 요청 및 304 Not Modified 응답 지원
  * 서버 성능 메트릭(Server-Timing) 헤더 추가
  * 검색 키워드별 캐싱 최적화

* **Refactor**
  * 응답 처리 로직 모듈화 및 재구성

* **Tests**
  * ETag 시드 생성 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->