### PR TITLE
[Docs] 백엔드 인증 게시글 캐시 업로드 흐름 문서 보강

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -56,12 +56,64 @@
 - 쿠키 기반 인증(`apiKey`, `accessToken`)
 - OAuth2 로그인(Kakao)
 
+#### 인증 흐름
+
+인증 요청 처리는 `CustomAuthenticationFilter`가 담당하고, 토큰 파싱은 `AuthTokenExtractor`, 세션 해석은 `MemberSessionAuthenticationResolver`, access/refresh 경로는 각각 `AccessTokenAuthenticationHandler`와 `RefreshTokenAuthenticationHandler`로 분리되어 있다.
+
+- 필터 대상 경로는 `/member/api/`, `/post/api/`, `/system/api/`, `/ws/`, `/sse/`이며, prod profile에서는 `/swagger-ui/`, `/v3/api-docs`도 보호 대상이다.
+- `Authorization` header가 있으면 cookie보다 우선한다. 형식은 `Bearer <accessToken>` 또는 `Bearer <apiKey> <accessToken>`만 허용하고, 형식 오류는 `401-2`로 처리한다.
+- header가 없으면 `AuthCookieNames`의 `apiKey`, `accessToken`, `refreshToken`, `sessionKey` cookie를 읽는다.
+- `accessToken` 경로가 먼저 실행되고, mutating 요청에서 `apiKey`가 있으면 `ApiKeyAuthorityRefreshHandler`가 apiKey 회원 기준 access token 재발급을 먼저 시도한다.
+- access token 경로가 인증을 완료하지 못하면 `RefreshTokenAuthenticationHandler`가 `sessionKey + refreshToken` 회전을 시도한다. 회전 실패나 session key 누락은 auth cookie 만료 후 `401-8`로 닫는다.
+- `MemberSessionAuthenticationResolver`는 safe read 요청에서만 짧은 fresh token fallback을 허용한다. cookie `sessionKey`와 payload `sessionKey`가 같고 `custom.auth.session.freshLookupGraceSeconds` 이내일 때만 적용된다.
+- 공개 API는 stale 또는 잘못된 인증 정보가 있어도 `SecurityContextHolder.clearContext()` 후 익명 요청으로 계속 처리한다. 보호 API는 `AppException`을 JSON API 응답으로 내리고, 예상 밖 인증 오류는 `401-1`로 변환한다.
+
 ### 운영 진단
 
 - `/actuator/health/readiness`
 - `/system/api/v1/adm/tasks`
 - `/system/api/v1/adm/storage/cleanup`
 - `/system/api/v1/adm/mail/signup`
+
+## 게시글 운영 흐름
+
+### 쓰기 후속 작업
+
+게시글 생성, 수정, 삭제의 DB 변경은 `PostApplicationService` 트랜잭션 안에서 처리하고, 캐시 무효화와 첨부파일 retention, 추천 feature store, domain event 발행은 `PostWriteAfterCommitEvent`와 `PostWriteSideEffectCommand`를 통해 commit 이후로 넘긴다.
+
+- `PostWriteSideEffectHandler.handle`은 `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)`로 실행된다.
+- `PostWriteSideEffectCommand`는 `postId`, 이전/현재/삭제 본문, 이전/현재 tag, `PostReadCacheInvalidationScope`, eviction reason, 추천 side effect(`REFRESH` 또는 `EVICT`)만 담는다.
+- cache 범위는 boolean 조합 대신 `PostReadCacheInvalidationScope`로 표현한다. 생성/삭제/복구/하드 삭제는 공개 조회 대상 전체를, `DetailOnly`는 상세만, `PublicPostModified`는 공개 여부/제목/본문/tag 영향에 따라 feed/search/tag/detail 대상을 계산한다.
+- commit 이후 `PostReadCacheInvalidator.invalidate`가 public read cache를 제거하고, `UploadedFileRetentionService.syncPostContent` 또는 `scheduleDeletedPostAttachments`가 본문 첨부파일 상태를 동기화한다.
+- 추천 갱신은 post attr을 다시 hydrate한 뒤 `PostRecommendFeatureStoreService.refresh`를 호출하고, 추천 대상에서 빠지는 경우 `evict`를 호출한다.
+- domain event가 있으면 commit 이후 별도 트랜잭션에서 `EventPublisher.publish`를 호출한다.
+- 후속 작업은 `PROPAGATION_REQUIRES_NEW` 트랜잭션으로 분리되고 실패 시 warn 로그만 남긴다. 게시글 DB commit 성공을 되돌리지는 않으므로, retention 또는 추천 갱신 실패 로그는 운영 재처리 대상으로 본다.
+
+### 공개 조회 cache 정책
+
+공개 조회 응답은 `ApiV1PostController`가 데이터를 만든 뒤 `PostPublicReadResponseFactory`에 cache header와 ETag 처리를 위임한다.
+
+- `respondWithEtag`는 `PostPublicReadCacheHeaderWriter`로 public `Cache-Control`, `X-Cache-Policy`, `Surrogate-Key`, `Cache-Tag`를 쓰고 weak ETag를 설정한다. `If-None-Match`가 일치하면 `304 Not Modified`를 반환한다.
+- public cache header는 `public, max-age=<maxAge>, s-maxage=<sharedMaxAge>, stale-while-revalidate=<swr>, stale-if-error=<sharedMaxAge+swr>` 형식이다.
+- `Surrogate-Key`는 공백 구분, `Cache-Tag`는 comma 구분으로 내려간다. token은 lowercase로 정규화하고 `[a-z0-9:_-]` 외 문자는 `-`로 바꾸며 최대 64자로 자른다.
+- `respondNoStore`는 `private, no-store, max-age=0`을 적용한다. 로그인 사용자별 `actorHasLiked`, `actorCanModify` 값이 섞이거나 high entropy 검색어처럼 공유 cache 오염 위험이 있는 응답에 사용한다.
+- `PostSearchCachePolicyResolver`는 빈 검색어는 `SEARCH_DEFAULT`, 길이 28자 이상 또는 token 4개 이상 또는 높은 unique ratio 검색어는 `SEARCH_NO_STORE`, 길이 16자 이상은 `SEARCH_SHORT`, 나머지는 `SEARCH_DEFAULT`로 분류한다.
+- `PostPublicReadCachePolicies`는 feed/explore/detail/bootstrap/tag/search/related author별 TTL을 가진다. 정책 변경 시 ETag seed builder와 cache invalidation scope가 같은 응답 변수를 반영하는지 함께 확인한다.
+
+### 업로드 retention 흐름
+
+게시글 이미지와 첨부파일 업로드는 `ApiV1PostImageController`, `PostImageStorageAdapter`, `UploadedFileRetentionService`가 나누어 처리한다.
+
+- `POST /post/api/v1/posts/images`는 이미지 8MB와 storage `maxFileSizeBytes` 중 작은 값을 한도로 검사하고, `UploadImageRequest(inputStream, contentLength, contentType, originalFilename)`로 storage port에 넘긴다.
+- `POST /post/api/v1/posts/files`는 첨부파일 10MB와 storage `maxFileSizeBytes` 중 작은 값을 한도로 검사하고, `UploadFileRequest(inputStream, contentLength, contentType, originalFilename)`로 넘긴다.
+- 컨트롤러는 `file.bytes`를 사용하지 않는다. `MultipartFile.inputStream`과 `file.size`를 같이 넘기고, `PostImageStorageAdapter.prepareRepeatableUpload`가 실제 read byte 수와 선언된 `contentLength`를 비교한다.
+- storage adapter는 input stream을 임시 파일로 복사해 repeatable upload를 만들고, 실제 크기가 설정 한도를 넘거나 `expectedContentLength`와 다르면 `400-1`로 중단한다. 성공/실패 후 임시 파일은 삭제한다.
+- 이미지 업로드는 signature 기반 content type 감지를 수행한다. 허용 타입은 `image/jpeg`, `image/png`, `image/gif`, `image/webp`이며 선언 타입과 감지 타입이 명확히 충돌하면 차단한다.
+- object key는 빈 값, `..`, `/` 시작, storage `keyPrefix` 밖 경로를 금지한다. 이 검증은 조회, 다운로드, 삭제 경로에 적용된다.
+- storage 업로드 성공 후 `UploadedFileRetentionService.registerTempUpload`이 `TEMP` row를 `PROPAGATION_REQUIRES_NEW` 트랜잭션으로 등록한다. `purgeAfter`는 현재 시각 + `tempUploadSeconds`다.
+- 게시글 저장/수정 commit 이후 `syncPostContent`가 현재 본문 URL의 object key를 게시글에 attach하고, 이전 본문에서 빠진 key는 `DETACHED_POST_ATTACHMENT`로 삭제 예약한다.
+- 게시글 삭제는 `scheduleDeletedPostAttachments`가 본문 key를 `DELETED_POST_ATTACHMENT`로 삭제 예약하고, 복구는 `restoreDeletedPostAttachments`가 `DELETED`가 아닌 추적 row를 다시 attach한다.
+- `purgeExpiredFiles`는 `TEMP`와 `PENDING_DELETE` 중 `purgeAfter <= now`인 row를 정리한다. 삭제 전 `isStillReferenced`로 게시글 본문과 member profile 참조를 다시 확인하고, 참조 중이면 active로 복구한다.
 
 ## 로컬 실행
 


### PR DESCRIPTION
## 관련 이슈

close #853

## 작업 배경

- 인증, 게시글 쓰기 side effect, 공개 조회 cache 정책, 업로드 retention 흐름이 여러 backend class에 흩어져 있어 신규 개발자가 정책 의도를 코드만으로 추적해야 했다.
- 저장소 guard가 `docs/` 추적을 금지하므로, 허용된 backend 문서인 `back/README.md`에 운영 흐름을 통합했다.

## 작업 내용

- `CustomAuthenticationFilter`, `AuthTokenExtractor`, access/refresh handler 기준 인증 흐름과 공개/보호 API 실패 기준을 정리했다.
- `PostWriteSideEffectHandler`, `PostWriteSideEffectCommand` 기준 after-commit 후속 작업과 실패 정책을 정리했다.
- `PostPublicReadResponseFactory`, cache header writer, search cache resolver 기준 공개 조회 cache/ETag/CDN purge key 정책을 정리했다.
- `ApiV1PostImageController`, `PostImageStorageAdapter`, `UploadedFileRetentionService` 기준 stream 업로드와 retention cleanup 흐름을 정리했다.

## 검증

- 실행한 명령과 결과:
  - `rg -n "CustomAuthenticationFilter|AuthTokenExtractor|PostWriteSideEffectHandler|PostPublicReadResponseFactory|UploadedFileRetentionService|PostImageStorageAdapter|ApiV1PostImageController" back/README.md back/src/main/kotlin`: 관련 문서/코드 경로 확인 완료
  - `git diff --cached --check`: 통과
  - `bash tools/guards/check-forbidden-tracked-files.sh --staged`: 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `back/README.md`의 `인증 흐름`, `게시글 운영 흐름` 섹션
  - `docs/`는 repo guard에서 추적 금지라 별도 markdown 파일 대신 `back/README.md`에 통합했다.

## 리스크

- 문서 전용 변경이라 런타임 동작 변경은 없다.
- 구현 코드가 바뀌면 README의 class/function 설명이 stale해질 수 있다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.