### PR TITLE
[Docs] 자동 생성형 주석 제거 및 의도 중심 주석 정리

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/home/adapter/web/HomeController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/home/adapter/web/HomeController.kt
@@ -10,17 +10,9 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 import java.net.InetAddress
 
-/**
- * HomeController는 웹 계층에서 HTTP 요청/응답을 처리하는 클래스입니다.
- * 입력 DTO 검증과 응답 포맷팅을 담당하고 비즈니스 처리는 애플리케이션 계층에 위임합니다.
- */
 @RestController
 @Tag(name = "HomeController", description = "홈 컨트롤러")
 class HomeController {
-    /**
-     * main 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     @GetMapping(produces = [MediaType.TEXT_HTML_VALUE])
     @Operation(summary = "메인 페이지")
     fun main(): String {
@@ -84,10 +76,6 @@ class HomeController {
             """.trimMargin()
     }
 
-    /**
-     * session 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     @GetMapping("/session")
     @Operation(summary = "세션 확인")
     fun session(session: HttpSession): Map<String, Any> {

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap/MemberNotProdInitData.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap/MemberNotProdInitData.kt
@@ -32,10 +32,6 @@ class MemberNotProdInitData(
             self.makeBaseMembers()
         }
 
-    /**
-     * makeBaseMembers 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 부트스트랩 단계에서 중복 실행/기존 데이터 충돌을 방지하며 초기 상태를 맞춥니다.
-     */
     @Transactional
     fun makeBaseMembers() {
         val adminUsername = AppConfig.adminUsernameOrBlank.trim().ifBlank { "admin" }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap/MemberProdInitData.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap/MemberProdInitData.kt
@@ -39,10 +39,6 @@ class MemberProdInitData(
             self.ensureConfiguredAdminMember()
         }
 
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 초기화 단계에서 중복 생성 방지와 기본값 보정을 함께 수행합니다.
-     */
     @Transactional
     fun ensureConfiguredAdminMember() {
         val configuredAdminUsername = AppConfig.adminUsernameOrBlank.trim()

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberController.kt
@@ -52,10 +52,6 @@ import org.springframework.web.multipart.MultipartFile
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
-/**
- * ApiV1AdmMemberController는 웹 계층에서 HTTP 요청/응답을 처리하는 클래스입니다.
- * 입력 DTO 검증과 응답 포맷팅을 담당하고 비즈니스 처리는 애플리케이션 계층에 위임합니다.
- */
 @Validated
 @RestController
 @RequestMapping("/member/api/v1/adm/members")
@@ -203,10 +199,6 @@ class ApiV1AdmMemberController(
         val contactLinks: List<@Valid ProfileCardLinkItemRequest> = emptyList(),
     )
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     @GetMapping
     @Transactional(readOnly = true)
     fun getItems(
@@ -286,10 +278,6 @@ class ApiV1AdmMemberController(
         return currentMemberProfileQueryUseCase.getById(id)
     }
 
-    /**
-     * uploadProfileImageFile 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     @PostMapping("/{id}/profileImageFile", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     @Transactional
     @CacheEvict(cacheNames = [ApiV1MemberController.ADMIN_PROFILE_CACHE_NAME], allEntries = true)

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthController.kt
@@ -33,10 +33,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.Locale
 
-/**
- * ApiV1AuthController는 웹 계층에서 HTTP 요청/응답을 처리하는 클래스입니다.
- * 입력 DTO 검증과 응답 포맷팅을 담당하고 비즈니스 처리는 애플리케이션 계층에 위임합니다.
- */
 @RestController
 @RequestMapping("/member/api/v1/auth")
 class ApiV1AuthController(
@@ -73,10 +69,6 @@ class ApiV1AuthController(
         val item: MemberDto,
     )
 
-    /**
-     * 로그인 요청을 처리하고 인증/잠금 정책을 반영합니다.
-     * 컨트롤러 계층에서 요청 DTO를 검증한 뒤 서비스 호출 결과를 응답 규격으로 변환합니다.
-     */
     @PostMapping("/login")
     @Transactional
     fun login(

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberController.kt
@@ -19,10 +19,6 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.*
 import java.net.URI
 
-/**
- * ApiV1MemberController는 웹 계층에서 HTTP 요청/응답을 처리하는 클래스입니다.
- * 입력 DTO 검증과 응답 포맷팅을 담당하고 비즈니스 처리는 애플리케이션 계층에 위임합니다.
- */
 @RestController
 @RequestMapping("/member/api/v1/members")
 class ApiV1MemberController(
@@ -37,10 +33,6 @@ class ApiV1MemberController(
     @GetMapping("/randomSecureTip")
     fun randomSecureTip() = securityTipProvider.signupPasswordTip()
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     @GetMapping("/adminProfile")
     @Transactional(readOnly = true)
     fun getAdminProfile(): MemberWithUsernameDto {
@@ -59,10 +51,6 @@ class ApiV1MemberController(
         return currentMemberProfileQueryUseCase.getPublishedById(adminMember.id)
     }
 
-    /**
-     * redirectToProfileImg 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     @GetMapping("/{id}/redirectToProfileImg")
     @ResponseStatus(HttpStatus.FOUND)
     @Transactional(readOnly = true)
@@ -97,10 +85,6 @@ class ApiV1MemberController(
         val nickname: String,
     )
 
-    /**
-     * 회원 가입 요청을 검증하고 계정을 생성합니다.
-     * 컨트롤러 계층에서 요청 DTO를 검증한 뒤 서비스 호출 결과를 응답 규격으로 변환합니다.
-     */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @Transactional

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/AuthTokenService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/AuthTokenService.kt
@@ -58,10 +58,6 @@ class AuthTokenService(
             .signWith(Keys.hmacShaKeyFor(jwtSecretKey.toByteArray()))
             .compact()
 
-    /**
-     * payload 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     fun payload(accessToken: String): AccessTokenPayload? {
         val claims =
             runCatching {

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/LoginAttemptService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/LoginAttemptService.kt
@@ -40,10 +40,6 @@ class LoginAttemptService(
     private val states = ConcurrentHashMap<String, LoginAttemptState>()
     private val lastCleanupEpochSeconds = AtomicLong(0)
 
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     override fun isBlocked(
         username: String,
         clientIp: String,
@@ -108,10 +104,6 @@ class LoginAttemptService(
         return nextState.blockedUntil > now
     }
 
-    /**
-     * clear 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     override fun clear(
         username: String,
         clientIp: String,
@@ -133,19 +125,11 @@ class LoginAttemptService(
         }
     }
 
-    /**
-     * key 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun key(
         username: String,
         clientIp: String,
     ): String = "${username.trim().lowercase()}|${clientIp.trim()}"
 
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     private fun isBlockedInRedis(key: String): Boolean {
         val blockedUntil = redisKeyValuePort.get(redisBlockedKey(key))?.toLongOrNull() ?: return false
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt
@@ -156,10 +156,6 @@ class MemberApplicationService(
                 memberProfileHydrator.hydrate(member)
             }
 
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     @Transactional(readOnly = true)
     fun checkPassword(
         member: Member,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberProfileHydrator.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberProfileHydrator.kt
@@ -49,10 +49,6 @@ class MemberProfileHydrator(
 
     fun hydrate(member: Member): Member = hydrateAll(listOf(member)).first()
 
-    /**
-     * hydrateAll 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     fun hydrateAll(members: List<Member>): List<Member> {
         if (members.isEmpty()) return members
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberHasProfileCard.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberHasProfileCard.kt
@@ -128,10 +128,6 @@ private fun normalizeProfileLinkItems(
             item.label.isNotBlank() && item.href.isNotBlank()
         }
 
-/**
- * decodeProfileLinkItems 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
- * 도메인 계층에서 불변조건을 지키며 상태 전이를 캡슐화합니다.
- */
 private fun decodeProfileLinkItems(
     rawValue: String?,
     defaultIcon: String,
@@ -146,10 +142,6 @@ private fun decodeProfileLinkItems(
     }.let { normalizeProfileLinkItems(it, defaultIcon, allowedIcons) }
 }
 
-/**
- * encodeProfileLinkItems 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
- * 도메인 계층에서 불변조건을 지키며 상태 전이를 캡슐화합니다.
- */
 private fun encodeProfileLinkItems(
     items: List<MemberProfileLinkItem>,
     defaultIcon: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberHasProfileImgUrl.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberHasProfileImgUrl.kt
@@ -12,10 +12,6 @@ private const val PROFILE_IMG_URL_DEFAULT_VALUE = ""
  * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
  */
 interface MemberHasProfileImgUrl : MemberAware {
-    /**
-     * appendProfileImgVersion 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 도메인 계층에서 불변조건을 지키며 상태 전이를 캡슐화합니다.
-     */
     private fun appendProfileImgVersion(url: String): String {
         val version =
             runCatching { getOrInitProfileImgUrlAttr().modifiedAt.toEpochMilli() }.getOrNull()

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/memberActionLog/application/service/MemberActionLogApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/memberActionLog/application/service/MemberActionLogApplicationService.kt
@@ -19,10 +19,6 @@ import org.springframework.stereotype.Service
 class MemberActionLogApplicationService(
     private val memberActionLogRepository: MemberActionLogRepositoryPort,
 ) {
-    /**
-     * save 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     fun save(event: EventPayload) {
         when (event) {
             is PostWrittenEvent -> savePostWrittenEvent(event)
@@ -37,10 +33,6 @@ class MemberActionLogApplicationService(
         }
     }
 
-    /**
-     * save 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun savePostWrittenEvent(event: PostWrittenEvent) {
         memberActionLogRepository.save(
             MemberActionLog(
@@ -57,10 +49,6 @@ class MemberActionLogApplicationService(
         )
     }
 
-    /**
-     * save 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun savePostModifiedEvent(event: PostModifiedEvent) {
         memberActionLogRepository.save(
             MemberActionLog(
@@ -77,10 +65,6 @@ class MemberActionLogApplicationService(
         )
     }
 
-    /**
-     * save 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun savePostDeletedEvent(event: PostDeletedEvent) {
         memberActionLogRepository.save(
             MemberActionLog(
@@ -97,10 +81,6 @@ class MemberActionLogApplicationService(
         )
     }
 
-    /**
-     * save 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun savePostCommentWrittenEvent(event: PostCommentWrittenEvent) {
         memberActionLogRepository.save(
             MemberActionLog(
@@ -117,10 +97,6 @@ class MemberActionLogApplicationService(
         )
     }
 
-    /**
-     * save 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun savePostCommentModifiedEvent(event: PostCommentModifiedEvent) {
         memberActionLogRepository.save(
             MemberActionLog(
@@ -137,10 +113,6 @@ class MemberActionLogApplicationService(
         )
     }
 
-    /**
-     * save 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun savePostCommentDeletedEvent(event: PostCommentDeletedEvent) {
         memberActionLogRepository.save(
             MemberActionLog(
@@ -157,10 +129,6 @@ class MemberActionLogApplicationService(
         )
     }
 
-    /**
-     * save 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun savePostLikedEvent(event: PostLikedEvent) {
         memberActionLogRepository.save(
             MemberActionLog(
@@ -177,10 +145,6 @@ class MemberActionLogApplicationService(
         )
     }
 
-    /**
-     * save 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun savePostUnlikedEvent(event: PostUnlikedEvent) {
         memberActionLogRepository.save(
             MemberActionLog(

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/adapter/web/ApiV1MemberNotificationController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/adapter/web/ApiV1MemberNotificationController.kt
@@ -25,10 +25,6 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 
-/**
- * ApiV1MemberNotificationController는 웹 계층에서 HTTP 요청/응답을 처리하는 클래스입니다.
- * 입력 DTO 검증과 응답 포맷팅을 담당하고 비즈니스 처리는 애플리케이션 계층에 위임합니다.
- */
 @RestController
 @RequestMapping("/member/api/v1/notifications")
 class ApiV1MemberNotificationController(

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationApplicationService.kt
@@ -115,10 +115,6 @@ class MemberNotificationApplicationService(
     @Transactional
     fun markAllRead(member: Member): Int = memberNotificationRepository.markAllRead(member.id, java.time.Instant.now())
 
-    /**
-     * markRead 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     @Transactional
     fun markRead(
         member: Member,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationRealtimeRelayService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationRealtimeRelayService.kt
@@ -71,10 +71,6 @@ class MemberNotificationRealtimeRelayService(
         }
     }
 
-    /**
-     * onMessage 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     override fun onMessage(
         message: Message,
         pattern: ByteArray?,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationSseService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationSseService.kt
@@ -79,10 +79,6 @@ class MemberNotificationSseService(
             }
         }
 
-    /**
-     * subscribe 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     fun subscribe(
         memberId: Long,
         lastEventIdRaw: String?,
@@ -197,10 +193,6 @@ class MemberNotificationSseService(
         heartbeatSentCount.incrementAndGet()
     }
 
-    /**
-     * registerHeartbeat 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun registerHeartbeat(
         memberId: Long,
         emitter: SseEmitter,
@@ -253,10 +245,6 @@ class MemberNotificationSseService(
         return true
     }
 
-    /**
-     * enforceMemberEmitterLimit 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun enforceMemberEmitterLimit(
         memberId: Long,
         emitters: MutableSet<SseEmitter>,
@@ -269,10 +257,6 @@ class MemberNotificationSseService(
         }
     }
 
-    /**
-     * enforceGlobalEmitterLimit 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun enforceGlobalEmitterLimit() {
         val safeGlobalLimit = maxGlobalEmitters.coerceAtLeast(100)
         while (emitterConnectedAtEpochMillis.size > safeGlobalLimit) {
@@ -291,10 +275,6 @@ class MemberNotificationSseService(
         }
     }
 
-    /**
-     * replayMissedNotificationEvents 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun replayMissedNotificationEvents(
         memberId: Long,
         emitter: SseEmitter,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt
@@ -21,10 +21,6 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
-/**
- * ApiV1SignupVerificationController는 웹 계층에서 HTTP 요청/응답을 처리하는 클래스입니다.
- * 입력 DTO 검증과 응답 포맷팅을 담당하고 비즈니스 처리는 애플리케이션 계층에 위임합니다.
- */
 @RestController
 @RequestMapping("/member/api/v1/signup")
 class ApiV1SignupVerificationController(
@@ -57,10 +53,6 @@ class ApiV1SignupVerificationController(
         val nickname: String,
     )
 
-    /**
-     * 생성/시작 처리 흐름을 수행하고 중복 요청과 예외 케이스를 함께 다룹니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     @PostMapping("/email/start")
     @ResponseStatus(HttpStatus.ACCEPTED)
     @Transactional
@@ -98,10 +90,6 @@ class ApiV1SignupVerificationController(
         )
     }
 
-    /**
-     * 생성/시작 처리 흐름을 수행하고 중복 요청과 예외 케이스를 함께 다룹니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     @PostMapping("/complete")
     @ResponseStatus(HttpStatus.CREATED)
     @Transactional

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/MemberSignupVerificationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/MemberSignupVerificationService.kt
@@ -64,10 +64,6 @@ class MemberSignupVerificationService(
             )
     }
 
-    /**
-     * 생성/시작 처리 흐름을 수행하고 중복 요청과 예외 케이스를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     @Transactional
     fun start(
         email: String,
@@ -113,10 +109,6 @@ class MemberSignupVerificationService(
         return SignupEmailStartResult(email = normalizedEmail)
     }
 
-    /**
-     * verifyEmail 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     @Transactional
     fun verifyEmail(emailVerificationToken: String): SignupEmailVerifyResult {
         val normalizedToken = emailVerificationToken.trim()
@@ -146,10 +138,6 @@ class MemberSignupVerificationService(
         )
     }
 
-    /**
-     * 생성/시작 처리 흐름을 수행하고 중복 요청과 예외 케이스를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     @Transactional
     fun completeSignup(
         signupToken: String,
@@ -185,10 +173,6 @@ class MemberSignupVerificationService(
         return member
     }
 
-    /**
-     * buildVerificationLink 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun buildVerificationLink(
         token: String,
         nextPath: String?,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/SignupMailDiagnosticsService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/SignupMailDiagnosticsService.kt
@@ -70,10 +70,6 @@ class SignupMailDiagnosticsService(
             .getAnnotation(com.back.global.task.annotation.Task::class.java)
             .type
 
-    /**
-     * diagnose 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     fun diagnose(checkConnection: Boolean = false): SignupMailDiagnostics {
         val sender = signupVerificationMailSenderProvider.getIfAvailable()
         val adapter = sender?.javaClass?.simpleName ?: "UNAVAILABLE"
@@ -200,10 +196,6 @@ class SignupMailDiagnosticsService(
             ) ?: throw AppException("503-2", "회원가입 메일 발송 어댑터를 찾지 못했습니다.")
     }
 
-    /**
-     * buildMissingKeys 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun buildMissingKeys(): List<String> {
         val missing = mutableListOf<String>()
 
@@ -227,10 +219,6 @@ class SignupMailDiagnosticsService(
                 }
             }
 
-    /**
-     * testConnection 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun testConnection(): ConnectionTestResult {
         val javaMailSender = javaMailSenderProvider.getIfAvailable()
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/SignupStartRateLimitService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/SignupStartRateLimitService.kt
@@ -39,10 +39,6 @@ class SignupStartRateLimitService(
     private val states = ConcurrentHashMap<String, WindowState>()
     private val lastCleanupEpochSeconds = AtomicLong(0)
 
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     fun checkAndConsume(
         email: String,
         clientIp: String,
@@ -73,10 +69,6 @@ class SignupStartRateLimitService(
         return redisTemplate
     }
 
-    /**
-     * consumeInMemory 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun consumeInMemory(
         key: String,
         maxAttempts: Int,
@@ -94,10 +86,6 @@ class SignupStartRateLimitService(
         return next.count <= maxAttempts
     }
 
-    /**
-     * consumeInRedis 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun consumeInRedis(
         redisTemplate: StringRedisTemplate,
         key: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/model/MemberSignupVerification.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/model/MemberSignupVerification.kt
@@ -52,10 +52,6 @@ class MemberSignupVerification(
         cancelledAt = now
     }
 
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 도메인 모델 내부에서 불변조건을 지키며 상태 변경을 캡슐화합니다.
-     */
     fun ensureVerifiable(now: Instant) {
         if (cancelledAt != null || consumedAt != null) {
             throw AppException("410-1", "회원가입 링크가 더 이상 유효하지 않습니다.")
@@ -76,10 +72,6 @@ class MemberSignupVerification(
         signupSessionExpiresAt = expiresAt
     }
 
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 도메인 모델 내부에서 불변조건을 지키며 상태 변경을 캡슐화합니다.
-     */
     fun ensureCompletable(now: Instant) {
         if (cancelledAt != null || consumedAt != null) {
             throw AppException("410-1", "회원가입 세션이 더 이상 유효하지 않습니다.")

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapter.kt
@@ -56,10 +56,6 @@ class PostImageStorageAdapter(
     // 앱 부팅 시점에는 스토리지가 아직 준비되지 않을 수 있다(컨테이너 기동 순서 경쟁).
     // 백엔드 재시작 없이 요청 자체가 회복되도록 이 메서드는 재시도 가능해야 한다.
 
-    /**
-     * 실행 환경 설정과 의존성을 확인해 안전한 실행 컨텍스트를 구성합니다.
-     * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
-     */
     private fun initializeStorage(forceRetry: Boolean) {
         if (!properties.enabled) return
 
@@ -102,10 +98,6 @@ class PostImageStorageAdapter(
         }
     }
 
-    /**
-     * 스토리지 I/O를 수행하며 키/경로/콘텐츠 타입 규칙을 함께 검증합니다.
-     * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
-     */
     override fun uploadPostImage(request: PostImageStoragePort.UploadImageRequest): String {
         validateUploadContentLength(
             contentLength = request.contentLength,
@@ -194,10 +186,6 @@ class PostImageStorageAdapter(
         return key
     }
 
-    /**
-     * 스토리지 I/O를 수행하며 키/경로/콘텐츠 타입 규칙을 함께 검증합니다.
-     * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
-     */
     override fun getPostImage(objectKey: String): PostImageStoragePort.StoredObject? = getStoredObject(objectKey, "이미지를 불러오지 못했습니다.")
 
     override fun getPostFile(objectKey: String): PostImageStoragePort.StoredObject? = getStoredObject(objectKey, "첨부 파일을 불러오지 못했습니다.")
@@ -233,10 +221,6 @@ class PostImageStorageAdapter(
         }
     }
 
-    /**
-     * 스토리지 I/O를 수행하며 키/경로/콘텐츠 타입 규칙을 함께 검증합니다.
-     * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
-     */
     override fun deletePostImage(objectKey: String) {
         deleteObject(objectKey, "이미지 삭제에 실패했습니다.")
     }
@@ -358,18 +342,10 @@ class PostImageStorageAdapter(
         }
     }
 
-    /**
-     * ensureStorageEnabled 처리 흐름에서 예외와 경계 조건을 함께 다룹니다.
-     * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
-     */
     private fun ensureStorageEnabled() {
         if (!properties.enabled) throw AppException("503-1", "이미지 스토리지가 비활성화되어 있습니다.")
     }
 
-    /**
-     * 실행 환경 설정과 의존성을 확인해 안전한 실행 컨텍스트를 구성합니다.
-     * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
-     */
     private fun requireClient(): S3Client {
         ensureStorageEnabled()
 
@@ -385,10 +361,6 @@ class PostImageStorageAdapter(
         return s3Client ?: throw AppException("503-1", "이미지 스토리지가 아직 준비되지 않았습니다.")
     }
 
-    /**
-     * 실행 환경 설정과 의존성을 확인해 안전한 실행 컨텍스트를 구성합니다.
-     * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
-     */
     private fun buildClient(): S3Client {
         val accessKey =
             resolveProperty(
@@ -435,10 +407,6 @@ class PostImageStorageAdapter(
             .build()
     }
 
-    /**
-     * 실행 환경 설정과 의존성을 확인해 안전한 실행 컨텍스트를 구성합니다.
-     * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
-     */
     private fun resolveProperty(
         rawValue: String,
         envKeyName: String,
@@ -458,10 +426,6 @@ class PostImageStorageAdapter(
         return resolved
     }
 
-    /**
-     * 실행 환경 설정과 의존성을 확인해 안전한 실행 컨텍스트를 구성합니다.
-     * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
-     */
     private fun resolveEnvReference(value: String): String? {
         val match = ENV_REFERENCE_REGEX.matchEntire(value) ?: return null
         val envName = match.groupValues[1]
@@ -470,10 +434,6 @@ class PostImageStorageAdapter(
         return if (envValue.isNotBlank()) envValue else defaultValue
     }
 
-    /**
-     * 실행 환경 설정과 의존성을 확인해 안전한 실행 컨텍스트를 구성합니다.
-     * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
-     */
     private fun buildObjectKey(originalFilename: String?): String {
         val ext = extractExtension(originalFilename)
         val datePath = LocalDate.now().format(datePathFormatter)
@@ -482,10 +442,6 @@ class PostImageStorageAdapter(
         return if (prefix.isBlank()) "$datePath/$uuid$ext" else "$prefix/$datePath/$uuid$ext"
     }
 
-    /**
-     * 입력 데이터를 정규화/검증하여 저장소 연동 시 오류 가능성을 줄입니다.
-     * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
-     */
     private fun extractExtension(originalFilename: String?): String {
         val name = originalFilename?.trim().orEmpty()
         if (!name.contains(".")) return ""
@@ -498,10 +454,6 @@ class PostImageStorageAdapter(
         return if (ext.isBlank()) "" else ".$ext"
     }
 
-    /**
-     * 입력 데이터를 정규화/검증하여 저장소 연동 시 오류 가능성을 줄입니다.
-     * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
-     */
     private fun validateObjectKey(objectKey: String) {
         val prefix = properties.keyPrefix.trim().trim('/')
         if (
@@ -541,10 +493,6 @@ class PostImageStorageAdapter(
         private const val IMAGE_SIGNATURE_MAX_BYTES = 16
     }
 
-    /**
-     * 입력 데이터를 정규화/검증하여 저장소 연동 시 오류 가능성을 줄입니다.
-     * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
-     */
     private fun normalizeDeclaredContentType(raw: String?): String? {
         val normalized =
             raw
@@ -557,10 +505,6 @@ class PostImageStorageAdapter(
         return contentTypeAliases[normalized] ?: normalized
     }
 
-    /**
-     * 입력 데이터를 정규화/검증하여 저장소 연동 시 오류 가능성을 줄입니다.
-     * 스토리지 어댑터 계층에서 MinIO/파일 시스템 연동 실패를 고려해 방어적으로 동작합니다.
-     */
     private fun detectImageContentType(signature: ByteArray): String? {
         if (signature.size >= 3 &&
             signature[0] == 0xFF.toByte() &&

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1AdmPostController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1AdmPostController.kt
@@ -32,10 +32,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
-/**
- * ApiV1AdmPostController는 웹 계층에서 HTTP 요청/응답을 처리하는 클래스입니다.
- * 입력 DTO 검증과 응답 포맷팅을 담당하고 비즈니스 처리는 애플리케이션 계층에 위임합니다.
- */
 @RestController
 @RequestMapping("/post/api/v1/adm/posts")
 @Tag(name = "ApiV1AdmPostController", description = "관리자용 API 글 컨트롤러")
@@ -139,10 +135,6 @@ class ApiV1AdmPostController(
         return RsData("200-1", "${id}번 삭제 글을 영구삭제했습니다.")
     }
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     @GetMapping("/{id}")
     @Transactional(readOnly = true)
     @Operation(summary = "관리자용 글 상세 (숨김글 포함)")
@@ -176,10 +168,6 @@ class ApiV1AdmPostController(
         val degraded: Boolean = provider == "rule",
     )
 
-    /**
-     * 생성 로직을 실행하고 실패 시 대체 경로를 적용합니다.
-     * 컨트롤러 계층에서 요청 DTO를 검증한 뒤 서비스 호출 결과를 응답 규격으로 변환합니다.
-     */
     @PostMapping("/recommend-tags")
     @Operation(summary = "관리자용 AI 태그 추천")
     fun recommendTags(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostCommentController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostCommentController.kt
@@ -22,10 +22,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
-/**
- * ApiV1PostCommentController는 웹 계층에서 HTTP 요청/응답을 처리하는 클래스입니다.
- * 입력 DTO 검증과 응답 포맷팅을 담당하고 비즈니스 처리는 애플리케이션 계층에 위임합니다.
- */
 @RestController
 @RequestMapping("/post/api/v1/posts/{postId}/comments")
 class ApiV1PostCommentController(
@@ -77,10 +73,6 @@ class ApiV1PostCommentController(
         val parentCommentId: Long? = null,
     )
 
-    /**
-     * 생성 요청을 처리하고 멱등성·후속 동기화 절차를 함께 수행합니다.
-     * 컨트롤러 계층에서 요청 DTO를 검증한 뒤 서비스 호출 결과를 응답 규격으로 변환합니다.
-     */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @Transactional

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostController.kt
@@ -29,10 +29,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.*
 
-/**
- * ApiV1PostController는 웹 계층에서 HTTP 요청/응답을 처리하는 클래스입니다.
- * 입력 DTO 검증과 응답 포맷팅을 담당하고 비즈니스 처리는 애플리케이션 계층에 위임합니다.
- */
 @RestController
 @RequestMapping("/post/api/v1/posts")
 class ApiV1PostController(
@@ -43,10 +39,6 @@ class ApiV1PostController(
     private val postSearchIntentResolver: PostSearchIntentResolver,
     private val rq: Rq,
 ) {
-    /**
-     * makePostDtoPage 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     private fun makePostDtoPage(postPage: PagedResult<Post>): PageDto<PostDto> {
         val actor = rq.actorOrNull
         val likedPostIds = postUseCase.findLikedPostIds(actor, postPage.content)
@@ -121,10 +113,6 @@ class ApiV1PostController(
         )
     }
 
-    /**
-     * 검색/목록 조회 조건을 정규화해 페이징 결과를 구성합니다.
-     * 컨트롤러 계층에서 요청 DTO를 검증한 뒤 서비스 호출 결과를 응답 규격으로 변환합니다.
-     */
     @GetMapping("/explore")
     @Transactional(readOnly = true)
     fun explore(
@@ -376,10 +364,6 @@ class ApiV1PostController(
         return makePostDtoPage(postPage)
     }
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     @GetMapping("/{id}")
     @Transactional(readOnly = true)
     fun getItem(
@@ -421,10 +405,6 @@ class ApiV1PostController(
         val listed: Boolean?,
     )
 
-    /**
-     * 생성 요청을 처리하고 멱등성·후속 동기화 절차를 함께 수행합니다.
-     * 컨트롤러 계층에서 요청 DTO를 검증한 뒤 서비스 호출 결과를 응답 규격으로 변환합니다.
-     */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @Transactional
@@ -476,10 +456,6 @@ class ApiV1PostController(
             listed = post.listed,
         )
 
-    /**
-     * 수정 요청을 처리하고 낙관적 잠금/후속 동기화를 수행합니다.
-     * 컨트롤러 계층에서 요청 DTO를 검증한 뒤 서비스 호출 결과를 응답 규격으로 변환합니다.
-     */
     @PutMapping("/{id}")
     @Transactional
     fun modify(
@@ -524,10 +500,6 @@ class ApiV1PostController(
         val hitCount: Int,
     )
 
-    /**
-     * incrementHit 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     @PostMapping("/{id}/hit")
     @Transactional
     fun incrementHit(
@@ -552,10 +524,6 @@ class ApiV1PostController(
         val likesCount: Int,
     )
 
-    /**
-     * 좋아요 상태 변경을 반영하고 경쟁 상황에서의 정합성을 보장합니다.
-     * 컨트롤러 계층에서 요청 DTO를 검증한 뒤 서비스 호출 결과를 응답 규격으로 변환합니다.
-     */
     @PutMapping("/{id}/like")
     @Transactional
     fun like(
@@ -576,10 +544,6 @@ class ApiV1PostController(
         )
     }
 
-    /**
-     * 좋아요 상태 변경을 반영하고 경쟁 상황에서의 정합성을 보장합니다.
-     * 컨트롤러 계층에서 요청 DTO를 검증한 뒤 서비스 호출 결과를 응답 규격으로 변환합니다.
-     */
     @DeleteMapping("/{id}/like")
     @Transactional
     fun unlike(
@@ -621,10 +585,6 @@ class ApiV1PostController(
         return makePostDtoPage(postPage)
     }
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     @PostMapping("/temp")
     @Transactional
     fun getOrCreateTemp(response: jakarta.servlet.http.HttpServletResponse): RsData<PostWithContentDto> {

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageController.kt
@@ -31,10 +31,6 @@ import java.nio.charset.StandardCharsets
 import java.util.Base64
 import java.util.concurrent.TimeUnit
 
-/**
- * ApiV1PostImageController는 웹 계층에서 HTTP 요청/응답을 처리하는 클래스입니다.
- * 입력 DTO 검증과 응답 포맷팅을 담당하고 비즈니스 처리는 애플리케이션 계층에 위임합니다.
- */
 @RestController
 @RequestMapping("/post/api/v1")
 class ApiV1PostImageController(
@@ -59,10 +55,6 @@ class ApiV1PostImageController(
         val name: String,
     )
 
-    /**
-     * uploadPostImage 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     @PostMapping("/posts/images", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun uploadPostImage(
         @RequestPart("file") file: MultipartFile,
@@ -159,10 +151,6 @@ class ApiV1PostImageController(
         )
     }
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     @GetMapping("/images/**")
     @Transactional(readOnly = true)
     fun getPostImage(request: HttpServletRequest): ResponseEntity<Resource> {
@@ -330,10 +318,6 @@ class ApiV1PostImageController(
         return finalizedBuilder.body(InputStreamResource(storedFile.inputStream))
     }
 
-    /**
-     * 원본 입력에서 필요한 값을 안전하게 추출합니다.
-     * 컨트롤러 계층에서 요청 DTO를 검증한 뒤 서비스 호출 결과를 응답 규격으로 변환합니다.
-     */
     private fun extractObjectKey(
         request: HttpServletRequest,
         prefix: String,
@@ -348,10 +332,6 @@ class ApiV1PostImageController(
         return URLDecoder.decode(encodedKey, StandardCharsets.UTF_8)
     }
 
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 컨트롤러 계층에서 요청 DTO를 검증한 뒤 서비스 호출 결과를 응답 규격으로 변환합니다.
-     */
     private fun isNotModified(
         ifNoneMatch: String?,
         currentEtag: String,
@@ -363,10 +343,6 @@ class ApiV1PostImageController(
             .any { it == "*" || it == currentEtag }
     }
 
-    /**
-     * 원본 입력에서 필요한 값을 안전하게 추출합니다.
-     * 컨트롤러 계층에서 요청 DTO를 검증한 뒤 서비스 호출 결과를 응답 규격으로 변환합니다.
-     */
     private fun parseSingleRange(
         rangeHeader: String,
         totalLength: Long,
@@ -406,10 +382,6 @@ class ApiV1PostImageController(
         return start..end
     }
 
-    /**
-     * skipFully 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     private fun skipFully(
         input: InputStream,
         count: Long,
@@ -429,10 +401,6 @@ class ApiV1PostImageController(
         }
     }
 
-    /**
-     * sliceStream 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-     */
     private fun sliceStream(
         source: InputStream,
         range: LongRange,
@@ -441,10 +409,6 @@ class ApiV1PostImageController(
         return object : InputStream() {
             private var remaining = range.last - range.first + 1
 
-            /**
-             * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-             * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-             */
             override fun read(): Int {
                 if (remaining <= 0) return -1
                 val value = source.read()
@@ -452,10 +416,6 @@ class ApiV1PostImageController(
                 return value
             }
 
-            /**
-             * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-             * 컨트롤러 계층에서 요청 파라미터를 검증하고 서비스 결과를 API 응답 형식으로 변환합니다.
-             */
             override fun read(
                 b: ByteArray,
                 off: Int,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -701,19 +701,11 @@ class PostApplicationService(
             hydrateMembersProfileImgAttrs(comments.map { it.author })
         }
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     fun findCommentById(
         post: Post,
         id: Long,
     ): PostComment? = postCommentRepository.findByPostAndId(post, id)
 
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     fun isLiked(
         post: Post,
         liker: Member?,
@@ -722,10 +714,6 @@ class PostApplicationService(
         return postLikeRepository.existsByLikerAndPost(toPersistenceMember(liker), post)
     }
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     fun findLikedPostIds(
         liker: Member?,
         posts: List<Post>,
@@ -844,10 +832,6 @@ class PostApplicationService(
             )
         }
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     fun findDeletedPagedByKwForAdmin(
         kw: String,
         page: Int,
@@ -869,10 +853,6 @@ class PostApplicationService(
         )
     }
 
-    /**
-     * 삭제/복구 흐름을 처리하고 연관 데이터 정합성을 함께 보정합니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     @Transactional
     fun restoreDeletedByIdForAdmin(id: Long): Post {
         val snapshot =
@@ -933,10 +913,6 @@ class PostApplicationService(
         return restoredPost
     }
 
-    /**
-     * hardDeleteDeletedByIdForAdmin 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     @Transactional
     fun hardDeleteDeletedByIdForAdmin(id: Long) {
         val snapshot =
@@ -1064,10 +1040,6 @@ class PostApplicationService(
         }
     }
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     fun getPublicTagCounts(): List<TagCountDto> {
         val now = System.currentTimeMillis()
         publicTagCountsCache?.takeIf { it.expiresAtMillis > now }?.let { return it.values }
@@ -1099,10 +1071,6 @@ class PostApplicationService(
         return resolveTrackedTempPost(persistenceAuthor) ?: findLegacyTemp(persistenceAuthor)
     }
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     @Transactional
     fun getOrCreateTemp(author: Member): Pair<Post, Boolean> {
         val persistenceAuthor = toPersistenceMember(author)
@@ -1159,10 +1127,6 @@ class PostApplicationService(
         post.hitCountAttr ?: postAttrRepository.findBySubjectAndName(post, HIT_COUNT)?.let { post.hitCountAttr = it }
     }
 
-    /**
-     * hydratePostAttrs 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun hydratePostAttrs(posts: List<Post>) {
         if (posts.isEmpty()) return
 
@@ -1186,10 +1150,6 @@ class PostApplicationService(
             ?.let { member.postCommentsCountAttr = it }
     }
 
-    /**
-     * hydrateMembersProfileImgAttrs 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun hydrateMembersProfileImgAttrs(members: List<Member>) {
         if (members.isEmpty()) return
 
@@ -1371,10 +1331,6 @@ class PostApplicationService(
         }
     }
 
-    /**
-     * syncMetaTagIndexAttr 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun syncMetaTagIndexAttr(post: Post) {
         val normalizedTags = extractNormalizedTags(post.content)
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostHitDedupService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostHitDedupService.kt
@@ -37,10 +37,6 @@ class PostHitDedupService(
     private val suppressedRedisFallbackWarnCount = AtomicLong(0)
     private val redisKeyPrefix = "post:hit:viewed:"
 
-    /**
-     * shouldCountHit 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     override fun shouldCountHit(
         postId: Long,
         viewerKey: String,
@@ -121,10 +117,6 @@ class PostHitDedupService(
         keysToTrim.forEach(memoryState::remove)
     }
 
-    /**
-     * warnRedisFallback 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     private fun warnRedisFallback(exception: Exception) {
         val nowEpochSeconds = Instant.now().epochSecond
         val warnInterval = redisWarnIntervalSeconds.coerceAtLeast(1)

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostLikeReconciliationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostLikeReconciliationService.kt
@@ -19,10 +19,6 @@ class PostLikeReconciliationService(
 ) {
     private val logger = LoggerFactory.getLogger(PostLikeReconciliationService::class.java)
 
-    /**
-     * reconcileRecentlyTouchedPosts 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     @Transactional
     fun reconcileRecentlyTouchedPosts(
         lookbackHours: Long,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostReadPrewarmService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostReadPrewarmService.kt
@@ -23,10 +23,6 @@ class PostReadPrewarmService(
     private val bootstrapWarmPageSizes = listOf(HOME_BOOTSTRAP_PAGE_SIZE, safePageSize).distinct().sorted()
     private val safeMaxTagWarmups = maxTagWarmups.coerceIn(0, 10)
 
-    /**
-     * prewarm 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 핵심 경로(feed/explore/tags/detail + 변경 태그 탐색)를 개별 격리 실행해 부분 실패 전파를 막습니다.
-     */
     fun prewarm(
         postId: Long,
         tags: List<String>,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostSearchIndexSyncService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostSearchIndexSyncService.kt
@@ -22,10 +22,6 @@ class PostSearchIndexSyncService(
     private val logger = LoggerFactory.getLogger(PostSearchIndexSyncService::class.java)
     private val safeMaxTags = maxTags.coerceIn(1, 128)
 
-    /**
-     * sync 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * forceClear=true면 인덱스를 즉시 비우고, 그렇지 않으면 DB 본문 태그 우선으로 재구성합니다.
-     */
     @Transactional
     fun sync(
         postId: Long,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteRequestIdempotencyRetentionService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteRequestIdempotencyRetentionService.kt
@@ -17,10 +17,6 @@ class PostWriteRequestIdempotencyRetentionService(
     @param:Value("\${custom.post.idempotency.retentionDays:30}")
     private val retentionDays: Int,
 ) {
-    /**
-     * purgeExpired 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 서비스 계층에서 트랜잭션 경계와 후속 처리(캐시/이벤트/스토리지 동기화)를 함께 관리합니다.
-     */
     @Transactional
     fun purgeExpired(batchSize: Int): Int {
         val safeBatchSize = batchSize.coerceIn(1, 1_000)

--- a/back/src/main/kotlin/com/back/boundedContexts/post/config/PostSecurityConfigurer.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/config/PostSecurityConfigurer.kt
@@ -34,10 +34,6 @@ class PostSecurityConfigurer : PublicApiRouteContributor {
             PublicApiRouteSpec("/post/api/*/posts/{postId:\\d+}/comments/{id:\\d+}", HttpMethod.GET),
         )
 
-    /**
-     * configure 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 설정 계층에서 런타임 규칙이 실제 요청 체인에 반영되도록 구성합니다.
-     */
     fun configure(authorize: AuthorizeHttpRequestsDsl) {
         publicApiRoutes().forEach { it.authorizePermitAll(authorize) }
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/domain/PostMember.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/domain/PostMember.kt
@@ -47,10 +47,6 @@ interface PostMember : MemberAware {
         postCommentsCount--
     }
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 도메인 계층에서 불변조건을 지키며 상태 전이를 캡슐화합니다.
-     */
     fun getOrInitPostsCountAttr(): MemberAttr {
         if (postsCountAttr == null) {
             postsCountAttr = MemberAttr(0, member, POSTS_COUNT, POSTS_COUNT_DEFAULT_VALUE)
@@ -58,10 +54,6 @@ interface PostMember : MemberAware {
         return postsCountAttr!!
     }
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 도메인 계층에서 불변조건을 지키며 상태 전이를 캡슐화합니다.
-     */
     fun getOrInitPostCommentsCountAttr(): MemberAttr {
         if (postCommentsCountAttr == null) {
             postCommentsCountAttr = MemberAttr(0, member, POST_COMMENTS_COUNT, POST_COMMENTS_COUNT_DEFAULT_VALUE)

--- a/back/src/main/kotlin/com/back/boundedContexts/post/domain/postCommentMixin/PostCommentHasPolicy.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/domain/postCommentMixin/PostCommentHasPolicy.kt
@@ -10,29 +10,17 @@ import com.back.global.rsData.RsData
  * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
  */
 interface PostCommentHasPolicy : PostCommentAware {
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 도메인 계층에서 불변조건을 지키며 상태 전이를 캡슐화합니다.
-     */
     fun getCheckActorCanModifyRs(actor: Member?): RsData<Void> {
         if (actor == null) return RsData.fail("401-1", "로그인 후 이용해주세요.")
         if (actor == postComment.author) return RsData.OK
         return RsData.fail("403-1", "작성자만 댓글을 수정할 수 있습니다.")
     }
 
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 도메인 모델 내부에서 불변조건을 지키며 상태 변경을 캡슐화합니다.
-     */
     fun checkActorCanModify(actor: Member?) {
         val rs = getCheckActorCanModifyRs(actor)
         if (rs.isFail) throw AppException(rs.resultCode, rs.msg)
     }
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 도메인 계층에서 불변조건을 지키며 상태 전이를 캡슐화합니다.
-     */
     fun getCheckActorCanDeleteRs(actor: Member?): RsData<Void> {
         if (actor == null) return RsData.fail("401-1", "로그인 후 이용해주세요.")
         if (actor.isAdmin) return RsData.OK
@@ -40,10 +28,6 @@ interface PostCommentHasPolicy : PostCommentAware {
         return RsData.fail("403-2", "작성자만 댓글을 삭제할 수 있습니다.")
     }
 
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 도메인 모델 내부에서 불변조건을 지키며 상태 변경을 캡슐화합니다.
-     */
     fun checkActorCanDelete(actor: Member?) {
         val rs = getCheckActorCanDeleteRs(actor)
         if (rs.isFail) throw AppException(rs.resultCode, rs.msg)

--- a/back/src/main/kotlin/com/back/boundedContexts/post/domain/postMixin/PostHasPolicy.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/domain/postMixin/PostHasPolicy.kt
@@ -19,18 +19,10 @@ interface PostHasPolicy : PostAware {
         return true
     }
 
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 도메인 모델 내부에서 불변조건을 지키며 상태 변경을 캡슐화합니다.
-     */
     fun checkActorCanRead(actor: Member?) {
         if (!canRead(actor)) throw AppException("403-3", "${post.id}번 글 조회권한이 없습니다.")
     }
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 도메인 계층에서 불변조건을 지키며 상태 전이를 캡슐화합니다.
-     */
     fun getCheckActorCanModifyRs(actor: Member?): RsData<Void> {
         if (actor == null) return RsData.fail("401-1", "로그인 후 이용해주세요.")
         if (actor.isAdmin) return RsData.OK
@@ -38,19 +30,11 @@ interface PostHasPolicy : PostAware {
         return RsData.fail("403-1", "작성자만 글을 수정할 수 있습니다.")
     }
 
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 도메인 모델 내부에서 불변조건을 지키며 상태 변경을 캡슐화합니다.
-     */
     fun checkActorCanModify(actor: Member?) {
         val rs = getCheckActorCanModifyRs(actor)
         if (rs.isFail) throw AppException(rs.resultCode, rs.msg)
     }
 
-    /**
-     * 조회 조건을 적용해 필요한 데이터를 안전하게 반환합니다.
-     * 도메인 계층에서 불변조건을 지키며 상태 전이를 캡슐화합니다.
-     */
     fun getCheckActorCanDeleteRs(actor: Member?): RsData<Void> {
         if (actor == null) return RsData.fail("401-1", "로그인 후 이용해주세요.")
         if (actor.isAdmin) return RsData.OK
@@ -58,10 +42,6 @@ interface PostHasPolicy : PostAware {
         return RsData.fail("403-2", "작성자만 글을 삭제할 수 있습니다.")
     }
 
-    /**
-     * 검증 규칙을 적용해 허용 여부를 판정합니다.
-     * 도메인 모델 내부에서 불변조건을 지키며 상태 변경을 캡슐화합니다.
-     */
     fun checkActorCanDelete(actor: Member?) {
         val rs = getCheckActorCanDeleteRs(actor)
         if (rs.isFail) throw AppException(rs.resultCode, rs.msg)

--- a/back/src/main/kotlin/com/back/global/app/application/AppFacade.kt
+++ b/back/src/main/kotlin/com/back/global/app/application/AppFacade.kt
@@ -5,11 +5,6 @@ import org.springframework.core.env.Environment
 import org.springframework.stereotype.Component
 import tools.jackson.databind.ObjectMapper
 
-/**
- * AppFacade는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
-
 @Component
 class AppFacade(
     environment: Environment,

--- a/back/src/main/kotlin/com/back/global/event/application/EventPublisher.kt
+++ b/back/src/main/kotlin/com/back/global/event/application/EventPublisher.kt
@@ -4,11 +4,6 @@ import com.back.standard.dto.EventPayload
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 
-/**
- * EventPublisher는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
-
 @Service
 class EventPublisher(
     private val applicationEventPublisher: ApplicationEventPublisher,

--- a/back/src/main/kotlin/com/back/global/exception/application/AppException.kt
+++ b/back/src/main/kotlin/com/back/global/exception/application/AppException.kt
@@ -2,10 +2,6 @@ package com.back.global.exception.application
 
 import com.back.global.rsData.RsData
 
-/**
- * AppException는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 class AppException(
     private val resultCode: String,
     private val msg: String,

--- a/back/src/main/kotlin/com/back/global/jpa/application/ProdSequenceGuardService.kt
+++ b/back/src/main/kotlin/com/back/global/jpa/application/ProdSequenceGuardService.kt
@@ -10,11 +10,6 @@ import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Component
 import java.util.regex.Pattern
 
-/**
- * ProdSequenceGuardService는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
-
 @Profile("prod")
 @Component
 class ProdSequenceGuardService(
@@ -22,19 +17,11 @@ class ProdSequenceGuardService(
     @param:Value("\${custom.db.sequence-guard-on-startup:true}")
     private val sequenceGuardOnStartup: Boolean,
 ) : ApplicationRunner {
-    /**
-     * 애플리케이션 시작/스케줄 실행 시점에 점검 로직을 수행합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     override fun run(args: ApplicationArguments) {
         if (!sequenceGuardOnStartup) return
         repairAllKnownSequences()
     }
 
-    /**
-     * repairIfSequenceDrift 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     fun repairIfSequenceDrift(exception: DataIntegrityViolationException): Boolean {
         val message = exception.mostSpecificCause?.message ?: exception.message ?: return false
         if (!isDuplicateKeyViolation(exception, message)) return false
@@ -119,10 +106,6 @@ class ProdSequenceGuardService(
             )
         }.getOrElse { false }
 
-    /**
-     * 입력/환경 데이터를 파싱·정규화해 내부 처리에 안전한 값으로 변환합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     private fun extractConstraintName(
         exception: DataIntegrityViolationException,
         message: String,

--- a/back/src/main/kotlin/com/back/global/revalidate/CdnCachePurgeService.kt
+++ b/back/src/main/kotlin/com/back/global/revalidate/CdnCachePurgeService.kt
@@ -65,10 +65,6 @@ class CdnCachePurgeService(
         )
     }
 
-    /**
-     * purgeByTags 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * 네트워크 오류가 발생해도 본 요청 흐름은 차단하지 않습니다.
-     */
     fun purgeByTags(
         tags: Collection<String>,
         reason: String,

--- a/back/src/main/kotlin/com/back/global/revalidate/adapter/event/CdnCachePurgeEventListener.kt
+++ b/back/src/main/kotlin/com/back/global/revalidate/adapter/event/CdnCachePurgeEventListener.kt
@@ -66,10 +66,6 @@ class CdnCachePurgeEventListener(
         )
     }
 
-    /**
-     * enqueue 처리 로직을 수행하고 예외 경로를 함께 다룹니다.
-     * purge 비활성화/큐 등록 실패가 본 트랜잭션 경로를 차단하지 않도록 fail-open으로 유지합니다.
-     */
     private fun enqueue(
         aggregateType: String,
         postId: Long,

--- a/back/src/main/kotlin/com/back/global/security/application/SecurityTipProvider.kt
+++ b/back/src/main/kotlin/com/back/global/security/application/SecurityTipProvider.kt
@@ -2,10 +2,6 @@ package com.back.global.security.application
 
 import org.springframework.stereotype.Component
 
-/**
- * SecurityTipProvider는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 @Component
 class SecurityTipProvider {
     fun signupPasswordTip(): String = "비밀번호는 영문, 숫자, 특수문자를 조합하여 8자 이상으로 설정하세요."

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/application/OAuth2State.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/application/OAuth2State.kt
@@ -9,10 +9,6 @@ import java.util.*
 private const val DELIMITER = "#"
 private const val DEFAULT_REDIRECT_URL = "/"
 
-/**
- * OAuth2State는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 data class OAuth2State(
     val redirectUrl: String = DEFAULT_REDIRECT_URL,
     val originState: String = UUID.randomUUID().toString(),

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionProperties.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionProperties.kt
@@ -2,10 +2,6 @@ package com.back.global.storage.application
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 
-/**
- * UploadedFileRetentionProperties는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 @ConfigurationProperties("custom.storage.retention")
 data class UploadedFileRetentionProperties(
     val tempUploadSeconds: Long = 86_400,

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
@@ -25,10 +25,6 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.Instant
 
-/**
- * UploadedFileCleanupDiagnostics는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 data class UploadedFileCleanupDiagnostics(
     val tempCount: Long,
     val activeCount: Long,
@@ -53,11 +49,6 @@ data class ProfileImageHistoryDto(
     val createdAt: Instant,
     val modifiedAt: Instant,
 )
-
-/**
- * UploadedFileRetentionService는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 
 @Service
 class UploadedFileRetentionService(
@@ -173,10 +164,6 @@ class UploadedFileRetentionService(
             prodSequenceGuardService?.repairUploadedFileSequence() == true
         } ?: false
 
-    /**
-     * 데이터 동기화 또는 리밸리데이션 요청을 조정해 최신 상태를 유지합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     @Transactional
     fun syncPostContent(
         postId: Long,
@@ -209,10 +196,6 @@ class UploadedFileRetentionService(
         )
     }
 
-    /**
-     * restoreDeletedPostAttachments 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     @Transactional
     fun restoreDeletedPostAttachments(
         postId: Long,
@@ -279,10 +262,6 @@ class UploadedFileRetentionService(
         }
     }
 
-    /**
-     * 데이터 동기화 또는 리밸리데이션 요청을 조정해 최신 상태를 유지합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     @Transactional
     fun syncProfileImage(
         memberId: Long,
@@ -352,10 +331,6 @@ class UploadedFileRetentionService(
         uploadedFileRepository.save(uploadedFile)
     }
 
-    /**
-     * 만료/중단 상태를 정리해 리소스와 큐 정합성을 유지합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     @Transactional
     fun purgeExpiredFiles(limit: Int) {
         val safeLimit = limit.coerceIn(1, 500)
@@ -421,10 +396,6 @@ class UploadedFileRetentionService(
         }
     }
 
-    /**
-     * diagnoseCleanup 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     @Transactional(readOnly = true)
     fun diagnoseCleanup(sampleSize: Int = 5): UploadedFileCleanupDiagnostics {
         val now = Instant.now()
@@ -456,10 +427,6 @@ class UploadedFileRetentionService(
         )
     }
 
-    /**
-     * scheduleDeletionIfKnown 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     private fun scheduleDeletionIfKnown(
         objectKey: String,
         purpose: UploadedFilePurpose,
@@ -518,10 +485,6 @@ class UploadedFileRetentionService(
         mapNotNull(UploadedFileUrlCodec::extractObjectKeyFromImageUrl)
             .toSet()
 
-    /**
-     * 정책 조건을 검증해 처리 가능 여부를 판정합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     private fun isStillReferenced(uploadedFile: UploadedFile): Boolean {
         val objectKey = uploadedFile.objectKey
         val ownerId = uploadedFile.ownerId

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileUrlCodec.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileUrlCodec.kt
@@ -5,10 +5,6 @@ import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
-/**
- * UploadedFileUrlCodec는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 object UploadedFileUrlCodec {
     private const val IMAGE_PATH_PREFIX = "/post/api/v1/images/"
     private const val FILE_PATH_PREFIX = "/post/api/v1/files/"
@@ -41,10 +37,6 @@ object UploadedFileUrlCodec {
         return encodedKey
     }
 
-    /**
-     * 입력/환경 데이터를 파싱·정규화해 내부 처리에 안전한 값으로 변환합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     fun extractObjectKeyFromImageUrl(url: String?): String? = extractObjectKeyFromUrl(url, IMAGE_PATH_PREFIX)
 
     fun extractObjectKeyFromFileUrl(url: String?): String? = extractObjectKeyFromUrl(url, FILE_PATH_PREFIX)
@@ -78,10 +70,6 @@ object UploadedFileUrlCodec {
         return decodeOrNull(encodedKey)
     }
 
-    /**
-     * 입력/환경 데이터를 파싱·정규화해 내부 처리에 안전한 값으로 변환합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     fun extractObjectKeysFromContent(content: String): Set<String> =
         extractImageObjectKeysFromContent(content) + extractFileObjectKeysFromContent(content)
 

--- a/back/src/main/kotlin/com/back/global/task/application/TaskFacade.kt
+++ b/back/src/main/kotlin/com/back/global/task/application/TaskFacade.kt
@@ -9,11 +9,6 @@ import org.springframework.stereotype.Service
 import tools.jackson.databind.ObjectMapper
 import java.util.*
 
-/**
- * TaskFacade는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
-
 @Service
 class TaskFacade(
     private val taskRepository: TaskQueueRepositoryPort,
@@ -22,10 +17,6 @@ class TaskFacade(
     @param:Value("\${custom.task.processor.inlineWhenNotProd:false}")
     private val inlineWhenNotProd: Boolean,
 ) {
-    /**
-     * 작업 큐에 태스크를 등록하고 실행 파라미터를 표준화합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     fun addToQueue(payload: TaskPayload) {
         val entry =
             taskHandlerRegistry.getEntry(payload.javaClass)

--- a/back/src/main/kotlin/com/back/global/task/application/TaskHandlerRegistry.kt
+++ b/back/src/main/kotlin/com/back/global/task/application/TaskHandlerRegistry.kt
@@ -4,19 +4,11 @@ import com.back.standard.dto.TaskPayload
 import org.springframework.stereotype.Component
 import java.lang.reflect.Method
 
-/**
- * TaskHandlerMethod는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 data class TaskHandlerMethod(
     val bean: Any,
     val method: Method,
 )
 
-/**
- * TaskHandlerEntry는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 data class TaskHandlerEntry(
     val taskType: String,
     val payloadClass: Class<out TaskPayload>,
@@ -24,10 +16,6 @@ data class TaskHandlerEntry(
     val retryPolicy: TaskRetryPolicy,
 )
 
-/**
- * TaskHandlerRegistry는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 @Component
 class TaskHandlerRegistry {
     private val byType = mutableMapOf<String, TaskHandlerEntry>()
@@ -46,10 +34,6 @@ class TaskHandlerRegistry {
         typeByClass[entry.payloadClass] = type
     }
 
-    /**
-     * getHandler 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     fun getHandler(payloadClass: Class<out TaskPayload>): TaskHandlerMethod? {
         val type = typeByClass[payloadClass] ?: return null
         return byType[type]?.handlerMethod
@@ -57,10 +41,6 @@ class TaskHandlerRegistry {
 
     fun getType(payloadClass: Class<out TaskPayload>): String? = typeByClass[payloadClass]
 
-    /**
-     * getEntry 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     fun getEntry(payloadClass: Class<out TaskPayload>): TaskHandlerEntry? {
         val type = typeByClass[payloadClass] ?: return null
         return byType[type]

--- a/back/src/main/kotlin/com/back/global/task/application/TaskQueueDiagnosticsService.kt
+++ b/back/src/main/kotlin/com/back/global/task/application/TaskQueueDiagnosticsService.kt
@@ -10,10 +10,6 @@ import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.math.max
 
-/**
- * TaskTypeDiagnostics는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 data class TaskTypeDiagnostics(
     val taskType: String,
     val label: String,
@@ -32,10 +28,6 @@ data class TaskTypeDiagnostics(
     val retryPolicy: TaskRetryPolicy,
 )
 
-/**
- * TaskExecutionSample는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 data class TaskExecutionSample(
     val taskId: Long,
     val taskType: String,
@@ -50,10 +42,6 @@ data class TaskExecutionSample(
     val errorMessage: String?,
 )
 
-/**
- * TaskQueueDiagnostics는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 data class TaskQueueDiagnostics(
     val pendingCount: Long,
     val readyPendingCount: Long,
@@ -72,11 +60,6 @@ data class TaskQueueDiagnostics(
     val staleProcessingSamples: List<TaskExecutionSample>,
 )
 
-/**
- * TaskQueueDiagnosticsService는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
-
 @Service
 class TaskQueueDiagnosticsService(
     private val taskRepository: TaskQueueRepositoryPort,
@@ -93,10 +76,6 @@ class TaskQueueDiagnosticsService(
 
     private val diagnosticsSnapshotRef = AtomicReference<DiagnosticsSnapshot?>(null)
 
-    /**
-     * diagnoseQueue 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     fun diagnoseQueue(): TaskQueueDiagnostics {
         val now = Instant.now()
         diagnosticsSnapshotRef.get()?.let { snapshot ->
@@ -111,10 +90,6 @@ class TaskQueueDiagnosticsService(
         return refreshed
     }
 
-    /**
-     * buildDiagnostics 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     private fun buildDiagnostics(now: Instant): TaskQueueDiagnostics {
         val readyPendingCount = taskRepository.countByStatusAndNextRetryAtLessThanEqual(TaskStatus.PENDING, now)
         val pendingCount = taskRepository.countByStatus(TaskStatus.PENDING)
@@ -169,10 +144,6 @@ class TaskQueueDiagnosticsService(
         return diagnoseTaskType(taskType, now, stuckBefore)
     }
 
-    /**
-     * diagnoseTaskType 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     private fun diagnoseTaskType(
         taskType: String,
         now: Instant,
@@ -227,10 +198,6 @@ class TaskQueueDiagnosticsService(
         )
     }
 
-    /**
-     * toTaskExecutionSample 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     private fun toTaskExecutionSample(task: Task): TaskExecutionSample {
         val retryPolicy = taskHandlerRegistry.getRetryPolicy(task.taskType)
 

--- a/back/src/main/kotlin/com/back/global/task/application/TaskQueueMetricsBinder.kt
+++ b/back/src/main/kotlin/com/back/global/task/application/TaskQueueMetricsBinder.kt
@@ -9,10 +9,6 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.util.concurrent.atomic.AtomicLong
 
-/**
- * TaskQueueMetricsBinder는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 @Component
 class TaskQueueMetricsBinder(
     private val taskQueueDiagnosticsService: TaskQueueDiagnosticsService,
@@ -32,10 +28,6 @@ class TaskQueueMetricsBinder(
     private val oldestReadyPendingAgeSeconds = AtomicLong(0)
     private val oldestProcessingAgeSeconds = AtomicLong(0)
 
-    /**
-     * 메트릭/상태 스냅샷을 갱신해 관측 지표를 최신화합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     override fun bindTo(registry: MeterRegistry) {
         registerGauge(registry, "task.queue.pending", pending)
         registerGauge(registry, "task.queue.ready_pending", readyPending)
@@ -49,10 +41,6 @@ class TaskQueueMetricsBinder(
         refreshSnapshot()
     }
 
-    /**
-     * 메트릭/상태 스냅샷을 갱신해 관측 지표를 최신화합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     @Scheduled(fixedDelayString = "\${custom.task.metrics.refreshFixedDelayMs:60000}")
     fun refreshSnapshot() {
         if (!refreshEnabled || !workerEnabled) {

--- a/back/src/main/kotlin/com/back/global/task/application/TaskRetryPolicy.kt
+++ b/back/src/main/kotlin/com/back/global/task/application/TaskRetryPolicy.kt
@@ -3,10 +3,6 @@ package com.back.global.task.application
 import kotlin.math.pow
 import kotlin.math.roundToLong
 
-/**
- * TaskRetryPolicy는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 data class TaskRetryPolicy(
     val label: String,
     val maxRetries: Int,
@@ -24,10 +20,6 @@ data class TaskRetryPolicy(
         }
     }
 
-    /**
-     * 재시도 횟수에 따라 다음 지연 시간을 계산합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     fun nextDelaySeconds(retryCount: Int): Long {
         if (retryCount <= 0) return baseDelaySeconds
 

--- a/back/src/main/kotlin/com/back/global/web/application/Rq.kt
+++ b/back/src/main/kotlin/com/back/global/web/application/Rq.kt
@@ -15,10 +15,6 @@ import org.springframework.stereotype.Component
 import java.time.Duration
 import java.util.Locale
 
-/**
- * Rq는 글로벌 공통 유스케이스를 조합하는 애플리케이션 계층 구성요소입니다.
- * 트랜잭션 경계, 예외 처리, 후속 동기화(캐시/이벤트/큐)를 함께 관리합니다.
- */
 @Component
 class Rq(
     private val req: HttpServletRequest,
@@ -75,10 +71,6 @@ class Rq(
             ?.lastOrNull()
             ?: defaultValue
 
-    /**
-     * 쿠키 속성을 정책에 맞게 설정하고 보안 플래그를 강제합니다.
-     * 애플리케이션 계층에서 트랜잭션 경계와 후속 처리(캐시/큐/이벤트)를 함께 관리합니다.
-     */
     fun setCookie(
         name: String,
         value: String?,


### PR DESCRIPTION
## 관련 이슈

close #854

## 작업 배경

- 백엔드 main Kotlin 소스에 `처리 로직을 수행`, `조회 조건을 적용`, `검증 규칙`, `트랜잭션 경계와 후속 처리` 같은 자동 생성형 KDoc이 남아 있었다.
- 실제 운영 의도나 보안/캐시/동시성 이유를 설명하지 않는 주석은 코드 이해를 돕지 못하고 stale 설명이 될 수 있다.

## 작업 내용

- `back/src/main/kotlin`에서 자동 생성형 boilerplate KDoc 블록을 제거했다.
- 코드 토큰과 동작은 변경하지 않고 주석 블록만 정리했다.
- #854가 지목한 `ApiV1PostController`, `ApiV1PostImageController`, `PostApplicationService`, storage/auth 관련 파일의 일반론 주석도 함께 제거했다.

## 검증

- 실행한 명령과 결과:
  - `rg -n "처리 로직을 수행|조회 조건을 적용|검증 규칙|트랜잭션 경계와 후속 처리|글로벌 공통 유스케이스|웹 계층에서 HTTP 요청|컨트롤러 계층에서 요청|스토리지 어댑터 계층" back/src/main/kotlin`: 0건
  - `git diff --check`: 통과
  - `bash tools/guards/check-forbidden-tracked-files.sh --staged`: 통과
  - `./back/gradlew -p back ktlintCheck`: 통과
  - pre-commit `OpenApiContractExportTest`: 통과
  - pre-commit `yarn contracts:check`: 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 변경은 54개 Kotlin 파일의 KDoc 삭제만 포함한다.
  - 남은 주석 추가/교체가 아니라, 의미 없는 주석을 제거해 코드 자체가 설명하도록 둔 변경이다.

## 리스크

- 동작 변경은 없다.
- diff가 파일 수 기준으로 넓으므로, 실제 코드 라인이 변경되지 않았는지 중심으로 확인하면 된다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.