### PR TITLE
[Test] 백엔드 테스트 DisplayName Given-When-Then 컨벤션 통일

### DIFF
--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
@@ -16,6 +16,7 @@ import com.back.global.app.AppConfig
 import com.back.global.event.application.EventPublisher
 import com.back.global.storage.application.UploadedFileRetentionService
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -34,7 +35,7 @@ import org.springframework.transaction.support.SimpleTransactionStatus
 import java.time.Instant
 import java.util.Optional
 
-@org.junit.jupiter.api.DisplayName("PostApplicationServiceDeleteResilience 테스트")
+@DisplayName("PostApplicationServiceDeleteResilience 테스트")
 class PostApplicationServiceDeleteResilienceTest {
     init {
         AppConfig(
@@ -97,7 +98,9 @@ class PostApplicationServiceDeleteResilienceTest {
         )
 
     @Test
-    fun `delete는 member posts 카운터 보정 실패가 나도 soft delete를 완료한다`() {
+    @DisplayName("delete는 member posts 카운터 보정 실패가 나도 soft delete를 완료한다")
+    fun completeSoftDeleteWhenMemberPostsCounterRepairFails() {
+        // given
         val author =
             Member(
                 id = 1,
@@ -139,17 +142,21 @@ class PostApplicationServiceDeleteResilienceTest {
         given(memberAttrRepository.findBySubjectAndName(author, POSTS_COUNT)).willReturn(null)
         given(postRepository.softDeleteById(post.id)).willReturn(true)
 
+        // when & then
         assertDoesNotThrow {
             service.delete(post, actor)
         }
 
+        // then
         then(postRepository).should().softDeleteById(post.id)
         then(memberAttrRepository).should().incrementIntValue(author, POSTS_COUNT, -1)
         then(postRepository).should().countByAuthor(author)
     }
 
     @Test
-    fun `관리자 복구는 캐시와 추천 후속 작업을 commit 이후에 실행한다`() {
+    @DisplayName("관리자 복구는 캐시와 추천 후속 작업을 commit 이후에 실행한다")
+    fun runRestoreSideEffectsAfterCommit() {
+        // given
         val snapshot =
             AdmDeletedPostSnapshotDto(
                 id = 21,
@@ -180,19 +187,25 @@ class PostApplicationServiceDeleteResilienceTest {
         given(postRepository.restoreDeletedById(21)).willReturn(true)
         given(postRepository.findById(21)).willReturn(Optional.of(restoredPost))
 
+        // when
         service.restoreDeletedByIdForAdmin(21)
         val afterCommitEvent = capturePostWriteAfterCommitEvent()
 
+        // then
         verifyNoInteractions(cacheManager, postRecommendFeatureStoreService)
 
+        // when
         postWriteSideEffectHandler.handle(afterCommitEvent)
 
+        // then
         then(cacheManager).should().getCache(PostQueryCacheNames.FEED)
         then(postRecommendFeatureStoreService).should().refresh(restoredPost)
     }
 
     @Test
-    fun `관리자 영구삭제는 캐시와 첨부파일 정리와 추천 evict를 commit 이후에 실행한다`() {
+    @DisplayName("관리자 영구삭제는 캐시와 첨부파일 정리와 추천 evict를 commit 이후에 실행한다")
+    fun runHardDeleteSideEffectsAfterCommit() {
+        // given
         val snapshot =
             AdmDeletedPostSnapshotDto(
                 id = 22,
@@ -205,20 +218,26 @@ class PostApplicationServiceDeleteResilienceTest {
         given(postRepository.findDeletedSnapshotById(22)).willReturn(snapshot)
         given(postRepository.hardDeleteDeletedById(22)).willReturn(true)
 
+        // when
         service.hardDeleteDeletedByIdForAdmin(22)
         val afterCommitEvent = capturePostWriteAfterCommitEvent()
 
+        // then
         verifyNoInteractions(cacheManager, uploadedFileRetentionService, postRecommendFeatureStoreService)
 
+        // when
         postWriteSideEffectHandler.handle(afterCommitEvent)
 
+        // then
         then(cacheManager).should().getCache(PostQueryCacheNames.FEED)
         then(uploadedFileRetentionService).should().scheduleDeletedPostAttachments(snapshot.content)
         then(postRecommendFeatureStoreService).should().evict(22)
     }
 
     @Test
-    fun `관리자 비공개 글 영구삭제는 공개 읽기 캐시를 무효화하지 않는다`() {
+    @DisplayName("관리자 비공개 글 영구삭제는 공개 읽기 캐시를 무효화하지 않는다")
+    fun skipPublicReadCacheInvalidationForPrivateHardDelete() {
+        // given
         val snapshot =
             AdmDeletedPostSnapshotDto(
                 id = 23,
@@ -231,11 +250,13 @@ class PostApplicationServiceDeleteResilienceTest {
         given(postRepository.findDeletedSnapshotById(23)).willReturn(snapshot)
         given(postRepository.hardDeleteDeletedById(23)).willReturn(true)
 
+        // when
         service.hardDeleteDeletedByIdForAdmin(23)
         val afterCommitEvent = capturePostWriteAfterCommitEvent()
 
         postWriteSideEffectHandler.handle(afterCommitEvent)
 
+        // then
         verifyNoInteractions(cacheManager)
         then(uploadedFileRetentionService).should().scheduleDeletedPostAttachments(snapshot.content)
         then(postRecommendFeatureStoreService).should().evict(23)
@@ -246,10 +267,12 @@ class PostApplicationServiceDeleteResilienceTest {
         "true,false",
         "false,true",
     )
-    fun `관리자 부분공개 상태 영구삭제는 공개 읽기 캐시를 무효화하지 않는다`(
+    @DisplayName("관리자 부분공개 상태 영구삭제는 공개 읽기 캐시를 무효화하지 않는다")
+    fun skipPublicReadCacheInvalidationForPartiallyPublicHardDelete(
         published: Boolean,
         listed: Boolean,
     ) {
+        // given
         val snapshot =
             AdmDeletedPostSnapshotDto(
                 id = 24,
@@ -262,11 +285,13 @@ class PostApplicationServiceDeleteResilienceTest {
         given(postRepository.findDeletedSnapshotById(24)).willReturn(snapshot)
         given(postRepository.hardDeleteDeletedById(24)).willReturn(true)
 
+        // when
         service.hardDeleteDeletedByIdForAdmin(24)
         val afterCommitEvent = capturePostWriteAfterCommitEvent()
 
         postWriteSideEffectHandler.handle(afterCommitEvent)
 
+        // then
         verifyNoInteractions(cacheManager)
         then(uploadedFileRetentionService).should().scheduleDeletedPostAttachments(snapshot.content)
         then(postRecommendFeatureStoreService).should().evict(24)

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostReadPrewarmServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostReadPrewarmServiceTest.kt
@@ -8,6 +8,7 @@ import com.back.boundedContexts.post.dto.PublicPostsBootstrapDto
 import com.back.boundedContexts.post.dto.TagCountDto
 import com.back.standard.dto.page.PageDto
 import com.back.standard.dto.post.type1.PostSearchSortType1
+import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -16,7 +17,9 @@ import java.time.Instant
 @DisplayName("PostReadPrewarmService 테스트")
 class PostReadPrewarmServiceTest {
     @Test
-    fun `모든 prewarm step이 실패하면 예외를 던진다`() {
+    @DisplayName("모든 prewarm step이 실패하면 예외를 던진다")
+    fun throwWhenAllPrewarmStepsFail() {
+        // given
         val useCase =
             FakePostPublicReadQueryUseCase(
                 failFeedByCursor = true,
@@ -27,6 +30,7 @@ class PostReadPrewarmServiceTest {
             )
         val sut = PostReadPrewarmService(postPublicReadQueryUseCase = useCase, pageSize = 30, maxTagWarmups = 3)
 
+        // when & then
         assertThatThrownBy {
             sut.prewarm(postId = 101L, tags = listOf("kotlin"), warmDetail = true)
         }.isInstanceOf(IllegalStateException::class.java)
@@ -34,7 +38,9 @@ class PostReadPrewarmServiceTest {
     }
 
     @Test
-    fun `일부 prewarm step이 성공하면 예외를 던지지 않는다`() {
+    @DisplayName("일부 prewarm step이 성공하면 예외를 던지지 않는다")
+    fun completeWhenAnyPrewarmStepSucceeds() {
+        // given
         val useCase =
             FakePostPublicReadQueryUseCase(
                 failFeedByCursor = false,
@@ -45,7 +51,10 @@ class PostReadPrewarmServiceTest {
             )
         val sut = PostReadPrewarmService(postPublicReadQueryUseCase = useCase, pageSize = 30, maxTagWarmups = 3)
 
-        sut.prewarm(postId = 102L, tags = listOf("kotlin"), warmDetail = true)
+        // when & then
+        assertThatCode {
+            sut.prewarm(postId = 102L, tags = listOf("kotlin"), warmDetail = true)
+        }.doesNotThrowAnyException()
     }
 
     private class FakePostPublicReadQueryUseCase(

--- a/back/src/test/kotlin/com/back/global/jpa/application/ProdSequenceGuardServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/jpa/application/ProdSequenceGuardServiceTest.kt
@@ -1,6 +1,7 @@
 package com.back.global.jpa.application
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.contains
 import org.mockito.Mockito.doThrow
@@ -12,14 +13,19 @@ import org.springframework.boot.ApplicationArguments
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.jdbc.core.JdbcTemplate
 
+@DisplayName("ProdSequenceGuardService 테스트")
 class ProdSequenceGuardServiceTest {
     @Test
-    fun `startup guard는 owner 권한이 필요한 ALTER 없이 setval만 수행한다`() {
+    @DisplayName("startup guard는 owner 권한이 필요한 ALTER 없이 setval만 수행한다")
+    fun runStartupGuardWithSetvalOnly() {
+        // given
         val jdbcTemplate = mock(JdbcTemplate::class.java)
         val service = ProdSequenceGuardService(jdbcTemplate, sequenceGuardOnStartup = true)
 
+        // when
         service.run(mock(ApplicationArguments::class.java))
 
+        // then
         verify(jdbcTemplate, never()).execute(contains("ALTER SEQUENCE"))
         verify(jdbcTemplate).execute(
             "SELECT setval('public.post_seq', COALESCE((SELECT MAX(id) FROM public.post), 0) + 50, false)",
@@ -27,15 +33,19 @@ class ProdSequenceGuardServiceTest {
     }
 
     @Test
-    fun `post_pkey 충돌이면 allocation 정렬 setval로 보정한다`() {
+    @DisplayName("post_pkey 충돌이면 allocation size 기준으로 post_seq setval을 보정한다")
+    fun repairPostSequenceWhenPostPrimaryKeyConflict() {
+        // given
         val jdbcTemplate = mock(JdbcTemplate::class.java)
         val service = ProdSequenceGuardService(jdbcTemplate, sequenceGuardOnStartup = false)
 
+        // when
         val repaired =
             service.repairIfSequenceDrift(
                 DataIntegrityViolationException("duplicate key value violates unique constraint \"post_pkey\""),
             )
 
+        // then
         assertThat(repaired).isTrue()
         verify(jdbcTemplate).execute("ALTER SEQUENCE IF EXISTS public.post_seq INCREMENT BY 50")
         verify(jdbcTemplate).execute(
@@ -44,10 +54,13 @@ class ProdSequenceGuardServiceTest {
     }
 
     @Test
-    fun `pk_member_signup_verification 별칭도 보정 타깃으로 인식한다`() {
+    @DisplayName("pk_member_signup_verification 별칭도 보정 타깃으로 인식한다")
+    fun repairSignupVerificationSequenceAlias() {
+        // given
         val jdbcTemplate = mock(JdbcTemplate::class.java)
         val service = ProdSequenceGuardService(jdbcTemplate, sequenceGuardOnStartup = false)
 
+        // when
         val repaired =
             service.repairIfSequenceDrift(
                 DataIntegrityViolationException(
@@ -55,6 +68,7 @@ class ProdSequenceGuardServiceTest {
                 ),
             )
 
+        // then
         assertThat(repaired).isTrue()
         verify(jdbcTemplate).execute("ALTER SEQUENCE IF EXISTS public.member_signup_verification_seq INCREMENT BY 20")
         verify(jdbcTemplate).execute(
@@ -63,15 +77,19 @@ class ProdSequenceGuardServiceTest {
     }
 
     @Test
-    fun `한글 로케일 duplicate 메시지도 uploaded_file 시퀀스 보정 타깃으로 인식한다`() {
+    @DisplayName("한글 로케일 duplicate 메시지도 uploaded_file 시퀀스 보정 타깃으로 인식한다")
+    fun repairUploadedFileSequenceFromKoreanDuplicateMessage() {
+        // given
         val jdbcTemplate = mock(JdbcTemplate::class.java)
         val service = ProdSequenceGuardService(jdbcTemplate, sequenceGuardOnStartup = false)
 
+        // when
         val repaired =
             service.repairIfSequenceDrift(
                 DataIntegrityViolationException("중복 키 값이 고유 제약 조건 \"uploaded_file_pkey\"을 위반했습니다."),
             )
 
+        // then
         assertThat(repaired).isTrue()
         verify(jdbcTemplate).execute("ALTER SEQUENCE IF EXISTS public.uploaded_file_seq INCREMENT BY 1")
         verify(jdbcTemplate).execute(
@@ -80,15 +98,19 @@ class ProdSequenceGuardServiceTest {
     }
 
     @Test
-    fun `uploaded_file 전용 보정은 ALTER 실패 시 setval-only fallback으로 복구한다`() {
+    @DisplayName("uploaded_file 전용 보정은 ALTER 실패 시 setval-only fallback으로 복구한다")
+    fun fallbackToSetvalOnlyWhenUploadedFileAlterFails() {
+        // given
         val jdbcTemplate = mock(JdbcTemplate::class.java)
         doThrow(RuntimeException("permission denied for sequence uploaded_file_seq"))
             .`when`(jdbcTemplate)
             .execute(contains("ALTER SEQUENCE IF EXISTS public.uploaded_file_seq"))
         val service = ProdSequenceGuardService(jdbcTemplate, sequenceGuardOnStartup = false)
 
+        // when
         val repaired = service.repairUploadedFileSequence()
 
+        // then
         assertThat(repaired).isTrue()
         verify(jdbcTemplate).execute("ALTER SEQUENCE IF EXISTS public.uploaded_file_seq INCREMENT BY 1")
         verify(jdbcTemplate).execute(
@@ -97,18 +119,22 @@ class ProdSequenceGuardServiceTest {
     }
 
     @Test
-    fun `일반 시퀀스 보정도 ALTER 권한 실패 시 setval-only fallback으로 복구한다`() {
+    @DisplayName("일반 시퀀스 보정도 ALTER 권한 실패 시 setval-only fallback으로 복구한다")
+    fun fallbackToSetvalOnlyWhenGeneralSequenceAlterFails() {
+        // given
         val jdbcTemplate = mock(JdbcTemplate::class.java)
         doThrow(RuntimeException("must be owner of sequence post_seq"))
             .`when`(jdbcTemplate)
             .execute(contains("ALTER SEQUENCE IF EXISTS public.post_seq"))
         val service = ProdSequenceGuardService(jdbcTemplate, sequenceGuardOnStartup = false)
 
+        // when
         val repaired =
             service.repairIfSequenceDrift(
                 DataIntegrityViolationException("duplicate key value violates unique constraint \"post_pkey\""),
             )
 
+        // then
         assertThat(repaired).isTrue()
         verify(jdbcTemplate).execute("ALTER SEQUENCE IF EXISTS public.post_seq INCREMENT BY 50")
         verify(jdbcTemplate).execute(
@@ -117,15 +143,19 @@ class ProdSequenceGuardServiceTest {
     }
 
     @Test
-    fun `시퀀스 대상이 아닌 unique 충돌은 보정하지 않는다`() {
+    @DisplayName("시퀀스 대상이 아닌 unique 충돌은 보정하지 않는다")
+    fun ignoreUniqueConflictOutsideSequenceTargets() {
+        // given
         val jdbcTemplate = mock(JdbcTemplate::class.java)
         val service = ProdSequenceGuardService(jdbcTemplate, sequenceGuardOnStartup = false)
 
+        // when
         val repaired =
             service.repairIfSequenceDrift(
                 DataIntegrityViolationException("duplicate key value violates unique constraint \"uk_post_like_liker_post\""),
             )
 
+        // then
         assertThat(repaired).isFalse()
         verifyNoInteractions(jdbcTemplate)
     }

--- a/back/src/test/kotlin/com/back/global/security/application/AuthSecurityEventServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/application/AuthSecurityEventServiceTest.kt
@@ -11,7 +11,9 @@ import java.time.temporal.ChronoUnit
 @DisplayName("AuthSecurityEventService 테스트")
 class AuthSecurityEventServiceTest {
     @Test
-    fun `보존 기간을 지난 보안 이벤트를 DB batch delete로 삭제한다`() {
+    @DisplayName("보존 기간을 지난 보안 이벤트를 DB batch delete로 삭제한다")
+    fun purgeExpiredSecurityEventsWithBatchLimit() {
+        // given
         val now = Instant.parse("2026-05-21T00:00:00Z")
         val store = RecordingAuthSecurityEventStore()
         store.nextDeletedCount = 1000
@@ -21,8 +23,10 @@ class AuthSecurityEventServiceTest {
                 retentionDays = 30,
             )
 
+        // when
         val purgedCount = service.purgeExpired(batchSize = 5_000, now = now)
 
+        // then
         assertThat(purgedCount).isEqualTo(1000)
         assertThat(store.deleteExpiredBeforeCalls).containsExactly(
             DeleteExpiredBeforeCall(

--- a/back/src/test/kotlin/com/back/global/security/job/AuthSecurityEventCleanupScheduledJobTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/job/AuthSecurityEventCleanupScheduledJobTest.kt
@@ -11,7 +11,9 @@ import java.time.Instant
 @DisplayName("AuthSecurityEventCleanupScheduledJob 테스트")
 class AuthSecurityEventCleanupScheduledJobTest {
     @Test
-    fun `cleanup은 만료된 보안 이벤트를 정리한다`() {
+    @DisplayName("cleanup은 만료된 보안 이벤트를 정리한다")
+    fun cleanupPurgesExpiredSecurityEvents() {
+        // given
         val store = RecordingAuthSecurityEventStore()
         store.deletedCounts += 1
         val service =
@@ -26,13 +28,17 @@ class AuthSecurityEventCleanupScheduledJobTest {
                 maxBatches = 1,
             )
 
+        // when
         job.cleanup()
 
+        // then
         assertThat(store.deleteExpiredBeforeCalls).hasSize(1)
     }
 
     @Test
-    fun `cleanup은 한 번의 스케줄에서 최대 batch 수만큼 반복 정리한다`() {
+    @DisplayName("cleanup은 한 번의 스케줄에서 최대 batch 수만큼 반복 정리한다")
+    fun cleanupRepeatsUntilMaxBatchCount() {
+        // given
         val store = RecordingAuthSecurityEventStore()
         store.deletedCounts += listOf(1, 1, 1)
         val service =
@@ -47,8 +53,10 @@ class AuthSecurityEventCleanupScheduledJobTest {
                 maxBatches = 2,
             )
 
+        // when
         job.cleanup()
 
+        // then
         assertThat(store.deleteExpiredBeforeCalls).hasSize(2)
     }
 


### PR DESCRIPTION
## 관련 이슈

close #855

## 작업 배경

- backend 테스트의 `@DisplayName`, 영어 함수명, given/when/then 구분이 일부 핵심 테스트에서 섞여 있어 CI 실패 시 의도 파악이 늦었습니다.
- 리뷰에서 직접 지적된 `ProdSequenceGuardServiceTest`와 post/auth/security 핵심 테스트 일부를 우선 정리했습니다.

## 작업 내용

- `ProdSequenceGuardServiceTest`에 class/test-level `@DisplayName`을 추가하고 테스트 함수명을 영어 camelCase로 정리했습니다.
- `PostReadPrewarmServiceTest`, `AuthSecurityEventServiceTest`, `AuthSecurityEventCleanupScheduledJobTest`의 테스트별 `@DisplayName`, 영어 함수명, given/when/then 구분을 맞췄습니다.
- `PostApplicationServiceDeleteResilienceTest`의 DisplayName import와 테스트별 설명/단계 구분을 정리했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check` 성공
  - `./back/gradlew -p back ktlintCheck` 성공
  - `./back/gradlew -p back test --tests '*ProdSequenceGuardServiceTest*' --tests '*PostReadPrewarmServiceTest*' --tests '*AuthSecurityEventServiceTest*' --tests '*AuthSecurityEventCleanupScheduledJobTest*' --tests '*PostApplicationServiceDeleteResilienceTest*'` 성공
  - `./back/gradlew -p back test` 성공
  - PR #872 Backend CI / Frontend CI / Security / Vercel success
  - Codex CLI review: actionable comments 0

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 테스트 실행 로직은 바꾸지 않고 표시명, 함수명, 단계 구분만 정리했습니다.

## 리스크

- 예상 리스크: JUnit 리포트에 표시되는 테스트 이름이 기존 백틱 함수명에서 `@DisplayName` 중심으로 바뀝니다.
- 롤백 방법: commit `54583041` revert

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
