### PR TITLE
[Test] CustomAuthenticationFilterTest fixture 도입

### DIFF
--- a/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
@@ -94,12 +94,7 @@ class CustomAuthenticationFilterTest {
     @Test
     @DisplayName("legacy payload에 email과 username이 없고 DB 회원도 없으면 member id 기반 principal로 인증한다")
     fun `legacy payload without persisted member falls back to member id principal`() {
-        val actorApplicationService = mock(ActorApplicationService::class.java)
-        val memberSessionUseCase = mock(MemberSessionUseCase::class.java)
-        val authIpSecurityService = mock(AuthIpSecurityService::class.java)
-        val authSecurityEventService = mock(AuthSecurityEventService::class.java)
-        val authCookieService = mock(AuthCookieService::class.java)
-        val rq = mock(Rq::class.java)
+        val fixture = CustomAuthenticationFilterFixture()
         val accessToken = "legacy-access-token"
         val sessionKey = "legacy-session-key"
         val request = MockHttpServletRequest("GET", "/member/api/v1/auth/session")
@@ -113,48 +108,8 @@ class CustomAuthenticationFilterTest {
                 ipSecurityFingerprint = null,
                 lastAuthenticatedAt = Instant.now(),
             )
-        val sessionResolver =
-            MemberSessionAuthenticationResolver(
-                memberSessionUseCase = memberSessionUseCase,
-                authCookieService = authCookieService,
-                freshLookupGraceSeconds = 15,
-            )
-        val ipSecurityVerifier =
-            AuthIpSecurityVerifier(
-                authIpSecurityService,
-                authSecurityEventService,
-                authCookieService,
-                memberSessionUseCase,
-            )
-        val securityContextAuthenticationWriter = SecurityContextAuthenticationWriter()
-        val handler =
-            AccessTokenAuthenticationHandler(
-                actorApplicationService = actorApplicationService,
-                memberSessionUseCase = memberSessionUseCase,
-                authIpSecurityVerifier = ipSecurityVerifier,
-                securityContextAuthenticationWriter = securityContextAuthenticationWriter,
-                memberSessionAuthenticationResolver = sessionResolver,
-                apiKeyAuthorityRefreshHandler =
-                    ApiKeyAuthorityRefreshHandler(
-                        actorApplicationService = actorApplicationService,
-                        memberSessionUseCase = memberSessionUseCase,
-                        authCookieService = authCookieService,
-                        authIpSecurityVerifier = ipSecurityVerifier,
-                        securityContextAuthenticationWriter = securityContextAuthenticationWriter,
-                        memberSessionAuthenticationResolver = sessionResolver,
-                        rq = rq,
-                    ),
-                legacyPayloadRecoveryHandler =
-                    LegacyPayloadRecoveryHandler(
-                        actorApplicationService = actorApplicationService,
-                        memberSessionUseCase = memberSessionUseCase,
-                        authCookieService = authCookieService,
-                        securityContextAuthenticationWriter = securityContextAuthenticationWriter,
-                        rq = rq,
-                    ),
-            )
 
-        given(actorApplicationService.payload(accessToken))
+        given(fixture.actorApplicationService.payload(accessToken))
             .willReturn(
                 AccessTokenPayload(
                     id = 54L,
@@ -167,12 +122,12 @@ class CustomAuthenticationFilterTest {
                     ipSecurityFingerprint = null,
                 ),
             )
-        given(memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(sessionSnapshot)
-        given(actorApplicationService.findById(54L)).willReturn(null)
+        given(fixture.memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(sessionSnapshot)
+        given(fixture.actorApplicationService.findById(54L)).willReturn(null)
 
         try {
             val handled =
-                handler.authenticate(
+                fixture.accessTokenAuthenticationHandler().authenticate(
                     request = request,
                     tokens =
                         ExtractedAuthTokens(
@@ -188,8 +143,8 @@ class CustomAuthenticationFilterTest {
             val authentication = SecurityContextHolder.getContext().authentication
             assertThat(authentication).isNotNull()
             assertThat(authentication?.name).isEqualTo("member-54")
-            verify(memberSessionUseCase).touchAuthenticated(sessionSnapshot)
-            verify(authCookieService, never()).issueAccessToken(
+            verify(fixture.memberSessionUseCase).touchAuthenticated(sessionSnapshot)
+            verify(fixture.authCookieService, never()).issueAccessToken(
                 ArgumentMatchers.anyString(),
                 ArgumentMatchers.anyBoolean(),
                 ArgumentMatchers.nullable(String::class.java),
@@ -203,46 +158,13 @@ class CustomAuthenticationFilterTest {
     @Test
     @DisplayName("prod Swagger와 OpenAPI 문서 경로도 쿠키 인증 필터 대상이다")
     fun `prod api docs paths are authentication filter targets`() {
-        val actorApplicationService = mock(ActorApplicationService::class.java)
-        val memberSessionUseCase = mock(MemberSessionUseCase::class.java)
-        val authIpSecurityService = mock(AuthIpSecurityService::class.java)
-        val authSecurityEventService = mock(AuthSecurityEventService::class.java)
-        val authCookieService = mock(AuthCookieService::class.java)
-        val clientIpResolver = mock(ClientIpResolver::class.java)
-        val publicApiRequestMatcher = mock(PublicApiRequestMatcher::class.java)
-        val apiCorsPolicy = mock(ApiCorsPolicy::class.java)
-        val rq = mock(Rq::class.java)
-        val objectMapper = ObjectMapper()
+        val fixture = CustomAuthenticationFilterFixture()
         val accessToken = "broken-access-token"
-        val filter =
-            CustomAuthenticationFilter(
-                actorApplicationService = actorApplicationService,
-                memberSessionUseCase = memberSessionUseCase,
-                authCookieService = authCookieService,
-                authTokenExtractor = AuthTokenExtractor(rq),
-                authIpSecurityVerifier =
-                    AuthIpSecurityVerifier(
-                        authIpSecurityService,
-                        authSecurityEventService,
-                        authCookieService,
-                        memberSessionUseCase,
-                    ),
-                securityContextAuthenticationWriter = SecurityContextAuthenticationWriter(),
-                clientIpResolver = clientIpResolver,
-                objectMapper = objectMapper,
-                publicApiRequestMatcher = publicApiRequestMatcher,
-                apiCorsPolicy = apiCorsPolicy,
-                environment = MockEnvironment().apply { setActiveProfiles("prod") },
-                rq = rq,
-                freshLookupGraceSeconds = 15,
-            )
+        val filter = fixture.authenticationFilter(profile = "prod")
 
-        given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("")
-        given(rq.getCookieValue(AuthCookieNames.API_KEY, "")).willReturn("")
-        given(rq.getCookieValue(AuthCookieNames.ACCESS_TOKEN, "")).willReturn(accessToken)
-        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn("")
-        given(rq.getCookieValue(AuthCookieNames.REFRESH_TOKEN, "")).willReturn("")
-        given(actorApplicationService.payload(accessToken)).willThrow(RuntimeException("jwt down"))
+        fixture.givenEmptyAuthorizationHeader()
+        fixture.givenCookieTokens(accessToken = accessToken)
+        given(fixture.actorApplicationService.payload(accessToken)).willThrow(RuntimeException("jwt down"))
 
         listOf(
             "/swagger-ui/index.html",
@@ -251,20 +173,10 @@ class CustomAuthenticationFilterTest {
         ).forEach { path ->
             val request = MockHttpServletRequest("GET", path)
             val response = MockHttpServletResponse()
-            val filterChain =
-                MockFilterChain(
-                    object : HttpServlet() {
-                        override fun service(
-                            req: HttpServletRequest,
-                            res: HttpServletResponse,
-                        ) {
-                            res.status = HttpServletResponse.SC_NO_CONTENT
-                        }
-                    },
-                )
+            val filterChain = fixture.noContentFilterChain()
 
-            given(publicApiRequestMatcher.matches(request)).willReturn(false)
-            given(clientIpResolver.resolve(request)).willReturn("203.0.113.20")
+            fixture.givenProtectedRequest(request)
+            fixture.givenClientIp(request, "203.0.113.20")
 
             filter.doFilter(request, response, filterChain)
 
@@ -276,38 +188,8 @@ class CustomAuthenticationFilterTest {
     @Test
     @DisplayName("non-prod 공개 문서 경로는 stale 인증 쿠키가 있어도 필터를 건너뛴다")
     fun `non prod public docs paths skip stale auth cookies`() {
-        val actorApplicationService = mock(ActorApplicationService::class.java)
-        val memberSessionUseCase = mock(MemberSessionUseCase::class.java)
-        val authIpSecurityService = mock(AuthIpSecurityService::class.java)
-        val authSecurityEventService = mock(AuthSecurityEventService::class.java)
-        val authCookieService = mock(AuthCookieService::class.java)
-        val clientIpResolver = mock(ClientIpResolver::class.java)
-        val publicApiRequestMatcher = mock(PublicApiRequestMatcher::class.java)
-        val apiCorsPolicy = mock(ApiCorsPolicy::class.java)
-        val rq = mock(Rq::class.java)
-        val objectMapper = ObjectMapper()
-        val filter =
-            CustomAuthenticationFilter(
-                actorApplicationService = actorApplicationService,
-                memberSessionUseCase = memberSessionUseCase,
-                authCookieService = authCookieService,
-                authTokenExtractor = AuthTokenExtractor(rq),
-                authIpSecurityVerifier =
-                    AuthIpSecurityVerifier(
-                        authIpSecurityService,
-                        authSecurityEventService,
-                        authCookieService,
-                        memberSessionUseCase,
-                    ),
-                securityContextAuthenticationWriter = SecurityContextAuthenticationWriter(),
-                clientIpResolver = clientIpResolver,
-                objectMapper = objectMapper,
-                publicApiRequestMatcher = publicApiRequestMatcher,
-                apiCorsPolicy = apiCorsPolicy,
-                environment = MockEnvironment().apply { setActiveProfiles("test") },
-                rq = rq,
-                freshLookupGraceSeconds = 15,
-            )
+        val fixture = CustomAuthenticationFilterFixture()
+        val filter = fixture.authenticationFilter()
 
         listOf(
             "/swagger-ui/index.html",
@@ -316,78 +198,33 @@ class CustomAuthenticationFilterTest {
         ).forEach { path ->
             val request = MockHttpServletRequest("GET", path)
             val response = MockHttpServletResponse()
-            val filterChain =
-                MockFilterChain(
-                    object : HttpServlet() {
-                        override fun service(
-                            req: HttpServletRequest,
-                            res: HttpServletResponse,
-                        ) {
-                            res.status = HttpServletResponse.SC_NO_CONTENT
-                        }
-                    },
-                )
+            val filterChain = fixture.noContentFilterChain()
 
             filter.doFilter(request, response, filterChain)
 
             assertThat(response.status).isEqualTo(HttpServletResponse.SC_NO_CONTENT)
         }
 
-        verify(actorApplicationService, never()).payload("broken-access-token")
+        verify(fixture.actorApplicationService, never()).payload("broken-access-token")
     }
 
     @Test
     @DisplayName("보호 API에서 인증 처리 중 예기치 못한 예외가 발생하면 500 대신 401-1로 응답한다")
     fun `protected api unexpected auth error returns 401`() {
-        val actorApplicationService = mock(ActorApplicationService::class.java)
-        val memberSessionUseCase = mock(MemberSessionUseCase::class.java)
-        val authIpSecurityService = mock(AuthIpSecurityService::class.java)
-        val authSecurityEventService = mock(AuthSecurityEventService::class.java)
-        val authCookieService = mock(AuthCookieService::class.java)
-        val clientIpResolver = mock(ClientIpResolver::class.java)
-        val publicApiRequestMatcher = mock(PublicApiRequestMatcher::class.java)
-        val apiCorsPolicy = mock(ApiCorsPolicy::class.java)
-        val rq = mock(Rq::class.java)
-        val objectMapper = ObjectMapper()
+        val fixture = CustomAuthenticationFilterFixture()
         val request = MockHttpServletRequest("GET", "/member/api/v1/notifications/snapshot")
         request.addHeader(HttpHeaders.ORIGIN, "https://www.aquilaxk.site")
 
-        given(publicApiRequestMatcher.matches(request)).willReturn(false)
-        given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("")
-        given(rq.getCookieValue(AuthCookieNames.API_KEY, "")).willReturn("")
-        given(rq.getCookieValue(AuthCookieNames.ACCESS_TOKEN, "")).willReturn("broken-access-token")
-        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn("")
-        given(rq.getCookieValue(AuthCookieNames.REFRESH_TOKEN, "")).willReturn("")
-        given(clientIpResolver.resolve(request)).willReturn("203.0.113.10")
-        given(actorApplicationService.payload("broken-access-token")).willThrow(RuntimeException("jwt down"))
-
-        val filter =
-            CustomAuthenticationFilter(
-                actorApplicationService = actorApplicationService,
-                memberSessionUseCase = memberSessionUseCase,
-                authCookieService = authCookieService,
-                authTokenExtractor = AuthTokenExtractor(rq),
-                authIpSecurityVerifier =
-                    AuthIpSecurityVerifier(
-                        authIpSecurityService,
-                        authSecurityEventService,
-                        authCookieService,
-                        memberSessionUseCase,
-                    ),
-                securityContextAuthenticationWriter = SecurityContextAuthenticationWriter(),
-                clientIpResolver = clientIpResolver,
-                objectMapper = objectMapper,
-                publicApiRequestMatcher = publicApiRequestMatcher,
-                apiCorsPolicy = apiCorsPolicy,
-                environment = MockEnvironment().apply { setActiveProfiles("test") },
-                rq = rq,
-                freshLookupGraceSeconds = 15,
-            )
+        fixture.givenProtectedRequest(request)
+        fixture.givenEmptyAuthorizationHeader()
+        fixture.givenCookieTokens(accessToken = "broken-access-token")
+        fixture.givenClientIp(request, "203.0.113.10")
+        given(fixture.actorApplicationService.payload("broken-access-token")).willThrow(RuntimeException("jwt down"))
 
         val response = MockHttpServletResponse()
         val filterChain = MockFilterChain()
 
-        filter.doFilter(request, response, filterChain)
+        fixture.authenticationFilter().doFilter(request, response, filterChain)
 
         assertThat(response.status).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED)
         assertThat(response.contentAsString).contains("\"resultCode\":\"401-1\"")
@@ -396,64 +233,19 @@ class CustomAuthenticationFilterTest {
     @Test
     @DisplayName("공개 API에서 인증 처리 중 예기치 못한 예외가 발생해도 익명으로 요청 처리를 계속한다")
     fun `public api unexpected auth error proceeds as anonymous`() {
-        val actorApplicationService = mock(ActorApplicationService::class.java)
-        val memberSessionUseCase = mock(MemberSessionUseCase::class.java)
-        val authIpSecurityService = mock(AuthIpSecurityService::class.java)
-        val authSecurityEventService = mock(AuthSecurityEventService::class.java)
-        val authCookieService = mock(AuthCookieService::class.java)
-        val clientIpResolver = mock(ClientIpResolver::class.java)
-        val publicApiRequestMatcher = mock(PublicApiRequestMatcher::class.java)
-        val apiCorsPolicy = mock(ApiCorsPolicy::class.java)
-        val rq = mock(Rq::class.java)
-        val objectMapper = ObjectMapper()
+        val fixture = CustomAuthenticationFilterFixture()
         val request = MockHttpServletRequest("GET", "/post/api/v1/posts")
 
-        given(publicApiRequestMatcher.matches(request)).willReturn(true)
-        given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("")
-        given(rq.getCookieValue(AuthCookieNames.API_KEY, "")).willReturn("")
-        given(rq.getCookieValue(AuthCookieNames.ACCESS_TOKEN, "")).willReturn("broken-access-token")
-        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn("")
-        given(rq.getCookieValue(AuthCookieNames.REFRESH_TOKEN, "")).willReturn("")
-        given(clientIpResolver.resolve(request)).willReturn("203.0.113.11")
-        given(actorApplicationService.payload("broken-access-token")).willThrow(RuntimeException("jwt down"))
-
-        val filter =
-            CustomAuthenticationFilter(
-                actorApplicationService = actorApplicationService,
-                memberSessionUseCase = memberSessionUseCase,
-                authCookieService = authCookieService,
-                authTokenExtractor = AuthTokenExtractor(rq),
-                authIpSecurityVerifier =
-                    AuthIpSecurityVerifier(
-                        authIpSecurityService,
-                        authSecurityEventService,
-                        authCookieService,
-                        memberSessionUseCase,
-                    ),
-                securityContextAuthenticationWriter = SecurityContextAuthenticationWriter(),
-                clientIpResolver = clientIpResolver,
-                objectMapper = objectMapper,
-                publicApiRequestMatcher = publicApiRequestMatcher,
-                apiCorsPolicy = apiCorsPolicy,
-                environment = MockEnvironment().apply { setActiveProfiles("test") },
-                rq = rq,
-                freshLookupGraceSeconds = 15,
-            )
+        fixture.givenPublicRequest(request)
+        fixture.givenEmptyAuthorizationHeader()
+        fixture.givenCookieTokens(accessToken = "broken-access-token")
+        fixture.givenClientIp(request, "203.0.113.11")
+        given(fixture.actorApplicationService.payload("broken-access-token")).willThrow(RuntimeException("jwt down"))
 
         val response = MockHttpServletResponse()
-        val filterChain =
-            MockFilterChain(
-                object : HttpServlet() {
-                    override fun service(
-                        req: HttpServletRequest,
-                        res: HttpServletResponse,
-                    ) {
-                        res.status = HttpServletResponse.SC_NO_CONTENT
-                    }
-                },
-            )
+        val filterChain = fixture.noContentFilterChain()
 
-        filter.doFilter(request, response, filterChain)
+        fixture.authenticationFilter().doFilter(request, response, filterChain)
 
         assertThat(response.status).isEqualTo(HttpServletResponse.SC_NO_CONTENT)
     }
@@ -461,24 +253,8 @@ class CustomAuthenticationFilterTest {
     @Test
     @DisplayName("payload email 누락 토큰은 DB 회원 기준으로 권한을 복구하고 accessToken을 재발급한다")
     fun `legacy payload without email restores admin authority from persisted member`() {
-        AppConfig(
-            siteBackUrl = "https://api.aquilaxk.site",
-            siteFrontUrl = "https://www.aquilaxk.site",
-            adminUsername = "admin",
-            adminEmail = "admin@test.com",
-            adminPassword = "secret",
-        )
-
-        val actorApplicationService = mock(ActorApplicationService::class.java)
-        val memberSessionUseCase = mock(MemberSessionUseCase::class.java)
-        val authIpSecurityService = mock(AuthIpSecurityService::class.java)
-        val authSecurityEventService = mock(AuthSecurityEventService::class.java)
-        val authCookieService = mock(AuthCookieService::class.java)
-        val clientIpResolver = mock(ClientIpResolver::class.java)
-        val publicApiRequestMatcher = mock(PublicApiRequestMatcher::class.java)
-        val apiCorsPolicy = mock(ApiCorsPolicy::class.java)
-        val rq = mock(Rq::class.java)
-        val objectMapper = ObjectMapper()
+        configureProductionUrls()
+        val fixture = CustomAuthenticationFilterFixture()
         val request = MockHttpServletRequest("PUT", "/post/api/v1/posts/452")
         val legacyToken = "legacy-access-token"
         val sessionKey = "legacy-session-key"
@@ -494,10 +270,9 @@ class CustomAuthenticationFilterTest {
             )
         val persistedAdmin = Member(54L, "internal-admin", null, "aquila", "admin@test.com")
 
-        given(publicApiRequestMatcher.matches(request)).willReturn(false)
-        given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("Bearer $legacyToken")
-        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn(sessionKey)
-        given(actorApplicationService.payload(legacyToken))
+        fixture.givenProtectedRequest(request)
+        fixture.givenBearerAccessToken(legacyToken, sessionKey)
+        given(fixture.actorApplicationService.payload(legacyToken))
             .willReturn(
                 AccessTokenPayload(
                     id = 54L,
@@ -510,59 +285,17 @@ class CustomAuthenticationFilterTest {
                     ipSecurityFingerprint = null,
                 ),
             )
-        given(memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(sessionSnapshot)
-        given(actorApplicationService.findById(54L)).willReturn(persistedAdmin)
-        given(actorApplicationService.genAccessToken(persistedAdmin, sessionKey, true, false, null)).willReturn("rotated-access-token")
-        given(clientIpResolver.resolve(request)).willReturn("203.0.113.12")
-
-        val filter =
-            CustomAuthenticationFilter(
-                actorApplicationService = actorApplicationService,
-                memberSessionUseCase = memberSessionUseCase,
-                authCookieService = authCookieService,
-                authTokenExtractor = AuthTokenExtractor(rq),
-                authIpSecurityVerifier =
-                    AuthIpSecurityVerifier(
-                        authIpSecurityService,
-                        authSecurityEventService,
-                        authCookieService,
-                        memberSessionUseCase,
-                    ),
-                securityContextAuthenticationWriter = SecurityContextAuthenticationWriter(),
-                clientIpResolver = clientIpResolver,
-                objectMapper = objectMapper,
-                publicApiRequestMatcher = publicApiRequestMatcher,
-                apiCorsPolicy = apiCorsPolicy,
-                environment = MockEnvironment().apply { setActiveProfiles("test") },
-                rq = rq,
-                freshLookupGraceSeconds = 15,
-            )
+        given(fixture.memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(sessionSnapshot)
+        given(fixture.actorApplicationService.findById(54L)).willReturn(persistedAdmin)
+        given(fixture.actorApplicationService.genAccessToken(persistedAdmin, sessionKey, true, false, null))
+            .willReturn("rotated-access-token")
+        fixture.givenClientIp(request, "203.0.113.12")
 
         val response = MockHttpServletResponse()
-        val filterChain =
-            MockFilterChain(
-                object : HttpServlet() {
-                    override fun service(
-                        req: HttpServletRequest,
-                        res: HttpServletResponse,
-                    ) {
-                        val authentication = SecurityContextHolder.getContext().authentication
-                        val hasAdminRole =
-                            authentication
-                                ?.authorities
-                                ?.any { authority -> authority.authority == "ROLE_ADMIN" }
-                                ?: false
-                        if (!hasAdminRole) {
-                            res.status = HttpServletResponse.SC_FORBIDDEN
-                            return
-                        }
-                        res.status = HttpServletResponse.SC_NO_CONTENT
-                    }
-                },
-            )
+        val filterChain = fixture.adminRoleRequiredFilterChain()
 
         try {
-            filter.doFilter(request, response, filterChain)
+            fixture.authenticationFilter().doFilter(request, response, filterChain)
             assertThat(response.status).isEqualTo(HttpServletResponse.SC_NO_CONTENT)
         } finally {
             SecurityContextHolder.clearContext()
@@ -572,24 +305,8 @@ class CustomAuthenticationFilterTest {
     @Test
     @DisplayName("쓰기 요청에서 accessToken payload 권한이 오래된 경우 apiKey 기준 DB 권한으로 재구성한다")
     fun `mutating request prefers apiKey member authority over stale token payload`() {
-        AppConfig(
-            siteBackUrl = "https://api.aquilaxk.site",
-            siteFrontUrl = "https://www.aquilaxk.site",
-            adminUsername = "admin",
-            adminEmail = "admin@test.com",
-            adminPassword = "secret",
-        )
-
-        val actorApplicationService = mock(ActorApplicationService::class.java)
-        val memberSessionUseCase = mock(MemberSessionUseCase::class.java)
-        val authIpSecurityService = mock(AuthIpSecurityService::class.java)
-        val authSecurityEventService = mock(AuthSecurityEventService::class.java)
-        val authCookieService = mock(AuthCookieService::class.java)
-        val clientIpResolver = mock(ClientIpResolver::class.java)
-        val publicApiRequestMatcher = mock(PublicApiRequestMatcher::class.java)
-        val apiCorsPolicy = mock(ApiCorsPolicy::class.java)
-        val rq = mock(Rq::class.java)
-        val objectMapper = ObjectMapper()
+        configureProductionUrls()
+        val fixture = CustomAuthenticationFilterFixture()
         val request = MockHttpServletRequest("PUT", "/post/api/v1/posts/452")
         val apiKey = "admin-api-key"
         val staleAccessToken = "stale-access-token"
@@ -606,12 +323,10 @@ class CustomAuthenticationFilterTest {
             )
         val persistedAdmin = Member(54L, "internal-admin", null, "aquila", "admin@test.com", apiKey)
 
-        given(publicApiRequestMatcher.matches(request)).willReturn(false)
-        given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("")
-        given(rq.getCookieValue(AuthCookieNames.API_KEY, "")).willReturn(apiKey)
-        given(rq.getCookieValue(AuthCookieNames.ACCESS_TOKEN, "")).willReturn(staleAccessToken)
-        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn(sessionKey)
-        given(actorApplicationService.payload(staleAccessToken))
+        fixture.givenProtectedRequest(request)
+        fixture.givenEmptyAuthorizationHeader()
+        fixture.givenCookieTokens(apiKey = apiKey, accessToken = staleAccessToken, sessionKey = sessionKey)
+        given(fixture.actorApplicationService.payload(staleAccessToken))
             .willReturn(
                 AccessTokenPayload(
                     id = 54L,
@@ -623,59 +338,17 @@ class CustomAuthenticationFilterTest {
                     ipSecurityFingerprint = null,
                 ),
             )
-        given(actorApplicationService.findByApiKey(apiKey)).willReturn(persistedAdmin)
-        given(memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(sessionSnapshot)
-        given(actorApplicationService.genAccessToken(persistedAdmin, sessionKey, true, false, null)).willReturn("rotated-access-token")
-        given(clientIpResolver.resolve(request)).willReturn("203.0.113.13")
-
-        val filter =
-            CustomAuthenticationFilter(
-                actorApplicationService = actorApplicationService,
-                memberSessionUseCase = memberSessionUseCase,
-                authCookieService = authCookieService,
-                authTokenExtractor = AuthTokenExtractor(rq),
-                authIpSecurityVerifier =
-                    AuthIpSecurityVerifier(
-                        authIpSecurityService,
-                        authSecurityEventService,
-                        authCookieService,
-                        memberSessionUseCase,
-                    ),
-                securityContextAuthenticationWriter = SecurityContextAuthenticationWriter(),
-                clientIpResolver = clientIpResolver,
-                objectMapper = objectMapper,
-                publicApiRequestMatcher = publicApiRequestMatcher,
-                apiCorsPolicy = apiCorsPolicy,
-                environment = MockEnvironment().apply { setActiveProfiles("test") },
-                rq = rq,
-                freshLookupGraceSeconds = 15,
-            )
+        given(fixture.actorApplicationService.findByApiKey(apiKey)).willReturn(persistedAdmin)
+        given(fixture.memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(sessionSnapshot)
+        given(fixture.actorApplicationService.genAccessToken(persistedAdmin, sessionKey, true, false, null))
+            .willReturn("rotated-access-token")
+        fixture.givenClientIp(request, "203.0.113.13")
 
         val response = MockHttpServletResponse()
-        val filterChain =
-            MockFilterChain(
-                object : HttpServlet() {
-                    override fun service(
-                        req: HttpServletRequest,
-                        res: HttpServletResponse,
-                    ) {
-                        val authentication = SecurityContextHolder.getContext().authentication
-                        val hasAdminRole =
-                            authentication
-                                ?.authorities
-                                ?.any { authority -> authority.authority == "ROLE_ADMIN" }
-                                ?: false
-                        if (!hasAdminRole) {
-                            res.status = HttpServletResponse.SC_FORBIDDEN
-                            return
-                        }
-                        res.status = HttpServletResponse.SC_NO_CONTENT
-                    }
-                },
-            )
+        val filterChain = fixture.adminRoleRequiredFilterChain()
 
         try {
-            filter.doFilter(request, response, filterChain)
+            fixture.authenticationFilter().doFilter(request, response, filterChain)
             assertThat(response.status).isEqualTo(HttpServletResponse.SC_NO_CONTENT)
         } finally {
             SecurityContextHolder.clearContext()
@@ -685,25 +358,15 @@ class CustomAuthenticationFilterTest {
     @Test
     @DisplayName("로그인 직후 GET read 요청은 세션 snapshot miss여도 최근 accessToken이면 1회 fallback 인증을 허용한다")
     fun `fresh token fallback allows safe read request`() {
-        val actorApplicationService = mock(ActorApplicationService::class.java)
-        val memberSessionUseCase = mock(MemberSessionUseCase::class.java)
-        val authIpSecurityService = mock(AuthIpSecurityService::class.java)
-        val authSecurityEventService = mock(AuthSecurityEventService::class.java)
-        val authCookieService = mock(AuthCookieService::class.java)
-        val clientIpResolver = mock(ClientIpResolver::class.java)
-        val publicApiRequestMatcher = mock(PublicApiRequestMatcher::class.java)
-        val apiCorsPolicy = mock(ApiCorsPolicy::class.java)
-        val rq = mock(Rq::class.java)
-        val objectMapper = ObjectMapper()
+        val fixture = CustomAuthenticationFilterFixture()
         val request = MockHttpServletRequest("GET", "/member/api/v1/auth/session")
         val accessToken = "fresh-access-token"
         val sessionKey = "fresh-session-key"
 
-        given(publicApiRequestMatcher.matches(request)).willReturn(false)
-        given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("Bearer $accessToken")
-        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn(sessionKey)
-        given(clientIpResolver.resolve(request)).willReturn("203.0.113.14")
-        given(actorApplicationService.payload(accessToken))
+        fixture.givenProtectedRequest(request)
+        fixture.givenBearerAccessToken(accessToken, sessionKey)
+        fixture.givenClientIp(request, "203.0.113.14")
+        given(fixture.actorApplicationService.payload(accessToken))
             .willReturn(
                 AccessTokenPayload(
                     id = 54L,
@@ -717,48 +380,15 @@ class CustomAuthenticationFilterTest {
                     issuedAt = Instant.now(),
                 ),
             )
-        given(memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(null)
-
-        val filter =
-            CustomAuthenticationFilter(
-                actorApplicationService = actorApplicationService,
-                memberSessionUseCase = memberSessionUseCase,
-                authCookieService = authCookieService,
-                authTokenExtractor = AuthTokenExtractor(rq),
-                authIpSecurityVerifier =
-                    AuthIpSecurityVerifier(
-                        authIpSecurityService,
-                        authSecurityEventService,
-                        authCookieService,
-                        memberSessionUseCase,
-                    ),
-                securityContextAuthenticationWriter = SecurityContextAuthenticationWriter(),
-                clientIpResolver = clientIpResolver,
-                objectMapper = objectMapper,
-                publicApiRequestMatcher = publicApiRequestMatcher,
-                apiCorsPolicy = apiCorsPolicy,
-                environment = MockEnvironment().apply { setActiveProfiles("test") },
-                rq = rq,
-                freshLookupGraceSeconds = 15,
-            )
+        given(fixture.memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(null)
 
         val response = MockHttpServletResponse()
-        val filterChain =
-            MockFilterChain(
-                object : HttpServlet() {
-                    override fun service(
-                        req: HttpServletRequest,
-                        res: HttpServletResponse,
-                    ) {
-                        res.status = HttpServletResponse.SC_NO_CONTENT
-                    }
-                },
-            )
+        val filterChain = fixture.noContentFilterChain()
 
         try {
-            filter.doFilter(request, response, filterChain)
+            fixture.authenticationFilter().doFilter(request, response, filterChain)
             assertThat(response.status).isEqualTo(HttpServletResponse.SC_NO_CONTENT)
-            verify(authCookieService, never()).expireAuthCookies()
+            verify(fixture.authCookieService, never()).expireAuthCookies()
         } finally {
             SecurityContextHolder.clearContext()
         }
@@ -767,25 +397,15 @@ class CustomAuthenticationFilterTest {
     @Test
     @DisplayName("로그인 직후라도 쓰기 요청은 세션 snapshot miss fallback을 허용하지 않는다")
     fun `fresh token fallback does not allow mutating request`() {
-        val actorApplicationService = mock(ActorApplicationService::class.java)
-        val memberSessionUseCase = mock(MemberSessionUseCase::class.java)
-        val authIpSecurityService = mock(AuthIpSecurityService::class.java)
-        val authSecurityEventService = mock(AuthSecurityEventService::class.java)
-        val authCookieService = mock(AuthCookieService::class.java)
-        val clientIpResolver = mock(ClientIpResolver::class.java)
-        val publicApiRequestMatcher = mock(PublicApiRequestMatcher::class.java)
-        val apiCorsPolicy = mock(ApiCorsPolicy::class.java)
-        val rq = mock(Rq::class.java)
-        val objectMapper = ObjectMapper()
+        val fixture = CustomAuthenticationFilterFixture()
         val request = MockHttpServletRequest("POST", "/member/api/v1/auth/me")
         val accessToken = "fresh-access-token"
         val sessionKey = "fresh-session-key"
 
-        given(publicApiRequestMatcher.matches(request)).willReturn(false)
-        given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("Bearer $accessToken")
-        given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn(sessionKey)
-        given(clientIpResolver.resolve(request)).willReturn("203.0.113.15")
-        given(actorApplicationService.payload(accessToken))
+        fixture.givenProtectedRequest(request)
+        fixture.givenBearerAccessToken(accessToken, sessionKey)
+        fixture.givenClientIp(request, "203.0.113.15")
+        given(fixture.actorApplicationService.payload(accessToken))
             .willReturn(
                 AccessTokenPayload(
                     id = 54L,
@@ -799,41 +419,170 @@ class CustomAuthenticationFilterTest {
                     issuedAt = Instant.now(),
                 ),
             )
-        given(memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(null)
-
-        val filter =
-            CustomAuthenticationFilter(
-                actorApplicationService = actorApplicationService,
-                memberSessionUseCase = memberSessionUseCase,
-                authCookieService = authCookieService,
-                authTokenExtractor = AuthTokenExtractor(rq),
-                authIpSecurityVerifier =
-                    AuthIpSecurityVerifier(
-                        authIpSecurityService,
-                        authSecurityEventService,
-                        authCookieService,
-                        memberSessionUseCase,
-                    ),
-                securityContextAuthenticationWriter = SecurityContextAuthenticationWriter(),
-                clientIpResolver = clientIpResolver,
-                objectMapper = objectMapper,
-                publicApiRequestMatcher = publicApiRequestMatcher,
-                apiCorsPolicy = apiCorsPolicy,
-                environment = MockEnvironment().apply { setActiveProfiles("test") },
-                rq = rq,
-                freshLookupGraceSeconds = 15,
-            )
+        given(fixture.memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(null)
 
         val response = MockHttpServletResponse()
         val filterChain = MockFilterChain()
 
         try {
-            filter.doFilter(request, response, filterChain)
+            fixture.authenticationFilter().doFilter(request, response, filterChain)
             assertThat(response.status).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED)
             assertThat(response.contentAsString).contains("\"resultCode\":\"401-8\"")
-            verify(authCookieService).expireAuthCookies()
+            verify(fixture.authCookieService).expireAuthCookies()
         } finally {
             SecurityContextHolder.clearContext()
+        }
+    }
+
+    private fun configureProductionUrls() {
+        AppConfig(
+            siteBackUrl = "https://api.aquilaxk.site",
+            siteFrontUrl = "https://www.aquilaxk.site",
+            adminUsername = "admin",
+            adminEmail = "admin@test.com",
+            adminPassword = "secret",
+        )
+    }
+
+    private class CustomAuthenticationFilterFixture {
+        val actorApplicationService: ActorApplicationService = mock(ActorApplicationService::class.java)
+        val memberSessionUseCase: MemberSessionUseCase = mock(MemberSessionUseCase::class.java)
+        val authIpSecurityService: AuthIpSecurityService = mock(AuthIpSecurityService::class.java)
+        val authSecurityEventService: AuthSecurityEventService = mock(AuthSecurityEventService::class.java)
+        val authCookieService: AuthCookieService = mock(AuthCookieService::class.java)
+        val clientIpResolver: ClientIpResolver = mock(ClientIpResolver::class.java)
+        val publicApiRequestMatcher: PublicApiRequestMatcher = mock(PublicApiRequestMatcher::class.java)
+        val apiCorsPolicy: ApiCorsPolicy = mock(ApiCorsPolicy::class.java)
+        val rq: Rq = mock(Rq::class.java)
+
+        private val memberSessionAuthenticationResolver =
+            MemberSessionAuthenticationResolver(
+                memberSessionUseCase = memberSessionUseCase,
+                authCookieService = authCookieService,
+                freshLookupGraceSeconds = 15,
+            )
+        private val authIpSecurityVerifier =
+            AuthIpSecurityVerifier(
+                authIpSecurityService,
+                authSecurityEventService,
+                authCookieService,
+                memberSessionUseCase,
+            )
+        private val securityContextAuthenticationWriter = SecurityContextAuthenticationWriter()
+
+        fun authenticationFilter(profile: String = "test"): CustomAuthenticationFilter =
+            CustomAuthenticationFilter(
+                actorApplicationService = actorApplicationService,
+                memberSessionUseCase = memberSessionUseCase,
+                authCookieService = authCookieService,
+                authTokenExtractor = AuthTokenExtractor(rq),
+                authIpSecurityVerifier = authIpSecurityVerifier,
+                securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+                clientIpResolver = clientIpResolver,
+                objectMapper = ObjectMapper(),
+                publicApiRequestMatcher = publicApiRequestMatcher,
+                apiCorsPolicy = apiCorsPolicy,
+                environment = MockEnvironment().apply { setActiveProfiles(profile) },
+                rq = rq,
+                freshLookupGraceSeconds = 15,
+            )
+
+        fun accessTokenAuthenticationHandler(): AccessTokenAuthenticationHandler =
+            AccessTokenAuthenticationHandler(
+                actorApplicationService = actorApplicationService,
+                memberSessionUseCase = memberSessionUseCase,
+                authIpSecurityVerifier = authIpSecurityVerifier,
+                securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+                memberSessionAuthenticationResolver = memberSessionAuthenticationResolver,
+                apiKeyAuthorityRefreshHandler =
+                    ApiKeyAuthorityRefreshHandler(
+                        actorApplicationService = actorApplicationService,
+                        memberSessionUseCase = memberSessionUseCase,
+                        authCookieService = authCookieService,
+                        authIpSecurityVerifier = authIpSecurityVerifier,
+                        securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+                        memberSessionAuthenticationResolver = memberSessionAuthenticationResolver,
+                        rq = rq,
+                    ),
+                legacyPayloadRecoveryHandler =
+                    LegacyPayloadRecoveryHandler(
+                        actorApplicationService = actorApplicationService,
+                        memberSessionUseCase = memberSessionUseCase,
+                        authCookieService = authCookieService,
+                        securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+                        rq = rq,
+                    ),
+            )
+
+        fun givenEmptyAuthorizationHeader() {
+            given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("")
+        }
+
+        fun givenBearerAccessToken(
+            accessToken: String,
+            sessionKey: String,
+        ) {
+            given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("Bearer $accessToken")
+            given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn(sessionKey)
+        }
+
+        fun givenCookieTokens(
+            apiKey: String = "",
+            accessToken: String = "",
+            sessionKey: String = "",
+            refreshToken: String = "",
+        ) {
+            given(rq.getCookieValue(AuthCookieNames.API_KEY, "")).willReturn(apiKey)
+            given(rq.getCookieValue(AuthCookieNames.ACCESS_TOKEN, "")).willReturn(accessToken)
+            given(rq.getCookieValue(AuthCookieNames.SESSION_KEY, "")).willReturn(sessionKey)
+            given(rq.getCookieValue(AuthCookieNames.REFRESH_TOKEN, "")).willReturn(refreshToken)
+        }
+
+        fun givenProtectedRequest(request: HttpServletRequest) {
+            given(publicApiRequestMatcher.matches(request)).willReturn(false)
+        }
+
+        fun givenPublicRequest(request: HttpServletRequest) {
+            given(publicApiRequestMatcher.matches(request)).willReturn(true)
+        }
+
+        fun givenClientIp(
+            request: HttpServletRequest,
+            clientIp: String,
+        ) {
+            given(clientIpResolver.resolve(request)).willReturn(clientIp)
+        }
+
+        fun noContentFilterChain(): MockFilterChain = MockFilterChain(NoContentServlet())
+
+        fun adminRoleRequiredFilterChain(): MockFilterChain = MockFilterChain(AdminRoleRequiredServlet())
+    }
+
+    private class NoContentServlet : HttpServlet() {
+        override fun service(
+            req: HttpServletRequest,
+            res: HttpServletResponse,
+        ) {
+            res.status = HttpServletResponse.SC_NO_CONTENT
+        }
+    }
+
+    private class AdminRoleRequiredServlet : HttpServlet() {
+        override fun service(
+            req: HttpServletRequest,
+            res: HttpServletResponse,
+        ) {
+            val authentication = SecurityContextHolder.getContext().authentication
+            val hasAdminRole =
+                authentication
+                    ?.authorities
+                    ?.any { authority -> authority.authority == "ROLE_ADMIN" }
+                    ?: false
+            if (!hasAdminRole) {
+                res.status = HttpServletResponse.SC_FORBIDDEN
+                return
+            }
+            res.status = HttpServletResponse.SC_NO_CONTENT
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈

close #856

## 작업 배경

- `CustomAuthenticationFilterTest`가 테스트마다 인증 필터와 관련 mock을 반복 조립해 시나리오 핵심보다 setup 코드가 더 크게 보였다.
- 인증 회귀 테스트의 의미는 유지하면서 fixture로 공통 조립을 모아 이후 인증 흐름 변경 시 테스트 수정 지점을 줄인다.

## 작업 내용

- `CustomAuthenticationFilterFixture`를 도입해 `ActorApplicationService`, `MemberSessionUseCase`, `AuthCookieService`, `ClientIpResolver`, `PublicApiRequestMatcher` 등 공통 mock과 filter/handler 조립을 한 곳으로 모았다.
- 반복 servlet/filter chain 조립을 `noContentFilterChain`, `adminRoleRequiredFilterChain` 헬퍼로 분리했다.
- 기존 인증 시나리오와 assertion은 유지하고 각 테스트 본문은 요청 조건, token/session stub, 응답 검증 위주로 정리했다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check` 성공
  - `./back/gradlew -p back ktlintCheck` 성공
  - `./back/gradlew -p back test --tests '*CustomAuthenticationFilterTest*'` 성공
  - `./back/gradlew -p back test --tests '*Security*'` 성공
  - `./back/gradlew -p back ciFastCheck --rerun-tasks` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `CustomAuthenticationFilterFixture`의 filter/handler 조립이 기존 테스트별 수동 조립과 같은 dependency를 사용하는지 확인 부탁드립니다.
  - `adminRoleRequiredFilterChain`은 기존 inline servlet 검증을 헬퍼로 옮긴 것이라 응답 계약은 변경하지 않았습니다.

## 리스크

- 프로덕션 코드 변경은 없고 테스트 구조 변경만 있습니다.
- fixture가 공통 setup을 숨기기 때문에, 새 인증 테스트 추가 시 필요한 cookie/header stub을 명시적으로 호출해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다. (N/A: Codex CLI fallback review 사용)
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

이 PR은 내부 테스트 코드의 개선 사항으로, 최종 사용자에게는 직접적인 영향이 없습니다.

* **Tests**
  * 인증 필터 테스트 구조 개선 및 유지보수성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->