### PR TITLE
[CI] prod 보안 헤더 live smoke 검증 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -906,6 +906,112 @@ jobs:
             rollback_and_exit "public_api_healthcheck_failed"
           fi
 
+          header_value_from_file() {
+            local headers_file="$1"
+            local header_name="$2"
+            awk -v header_name="${header_name}" '
+              BEGIN { target = tolower(header_name) }
+              {
+                line = $0
+                sub(/\r$/, "", line)
+                separator = index(line, ":")
+                if (separator == 0) {
+                  next
+                }
+                name = tolower(substr(line, 1, separator - 1))
+                if (name == target) {
+                  value = substr(line, separator + 1)
+                  sub(/^[[:space:]]+/, "", value)
+                  print value
+                  exit
+                }
+              }
+            ' "${headers_file}"
+          }
+
+          assert_header_contains() {
+            local label="$1"
+            local headers_file="$2"
+            local header_name="$3"
+            local expected_fragment="$4"
+            local value
+            value="$(header_value_from_file "${headers_file}" "${header_name}")"
+            if [ -z "${value}" ] || [[ "${value,,}" != *"${expected_fragment,,}"* ]]; then
+              echo "[security-header-smoke] FAIL ${label}: missing ${header_name} containing '${expected_fragment}'" >&2
+              return 1
+            fi
+          }
+
+          assert_live_security_headers() {
+            local label="$1"
+            local url="$2"
+            local status_pattern="$3"
+            local cache_policy="${4:-default}"
+            local headers_file
+            local code
+            headers_file="$(mktemp)"
+
+            code="$(
+              curl -sS \
+                --connect-timeout "${DEPLOY_SECURITY_HEADER_CONNECT_TIMEOUT_SECONDS:-5}" \
+                -m "${DEPLOY_SECURITY_HEADER_MAX_TIME_SECONDS:-15}" \
+                -D "${headers_file}" \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "${url}" || true
+            )"
+            echo "[security-header-smoke] ${label} status=${code} url=${url}"
+            if ! [[ "${code}" =~ ${status_pattern} ]]; then
+              echo "[security-header-smoke] FAIL ${label}: unexpected status=${code} url=${url}" >&2
+              rm -f "${headers_file}"
+              return 1
+            fi
+
+            assert_header_contains "${label}" "${headers_file}" "strict-transport-security" "max-age=31536000" || {
+              rm -f "${headers_file}"
+              return 1
+            }
+            assert_header_contains "${label}" "${headers_file}" "x-content-type-options" "nosniff" || {
+              rm -f "${headers_file}"
+              return 1
+            }
+            assert_header_contains "${label}" "${headers_file}" "x-frame-options" "deny" || {
+              rm -f "${headers_file}"
+              return 1
+            }
+            assert_header_contains "${label}" "${headers_file}" "referrer-policy" "strict-origin-when-cross-origin" || {
+              rm -f "${headers_file}"
+              return 1
+            }
+            assert_header_contains "${label}" "${headers_file}" "permissions-policy" "camera=()" || {
+              rm -f "${headers_file}"
+              return 1
+            }
+            if [ "${cache_policy}" = "no-store" ]; then
+              assert_header_contains "${label}" "${headers_file}" "cache-control" "no-store" || {
+                rm -f "${headers_file}"
+                return 1
+              }
+            fi
+
+            rm -f "${headers_file}"
+          }
+
+          if ! assert_live_security_headers \
+            "public-feed" \
+            "https://${API_DOMAIN}/post/api/v1/posts/feed?page=1&pageSize=1&sort=CREATED_AT" \
+            '^200$'; then
+            rollback_and_exit "public_feed_security_header_smoke_failed"
+          fi
+
+          if ! assert_live_security_headers \
+            "protected-auth-me" \
+            "https://${API_DOMAIN}/member/api/v1/auth/me" \
+            '^401$' \
+            "no-store"; then
+            rollback_and_exit "protected_auth_security_header_smoke_failed"
+          fi
+
           run_canary_ratio_check() {
             local label="$1"
             local url="$2"

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -553,6 +553,33 @@ test("deploy workflow pins production site cookie scope to the live custom domai
   )
 })
 
+test("deploy workflow validates live API security headers after homeserver rollout", () => {
+  const workflow = readFileSync(workflowPath, "utf8")
+
+  assert.match(workflow, /assert_live_security_headers\(\)/)
+  assert.match(workflow, /header_value_from_file\(\)/)
+  assert.match(workflow, /strict-transport-security" "max-age=31536000"/)
+  assert.match(workflow, /x-content-type-options" "nosniff"/)
+  assert.match(workflow, /x-frame-options" "deny"/)
+  assert.match(workflow, /referrer-policy" "strict-origin-when-cross-origin"/)
+  assert.match(workflow, /permissions-policy" "camera=\(\)"/)
+  assert.match(workflow, /cache-control" "no-store"/)
+  assert.match(workflow, /"public-feed"/)
+  assert.match(workflow, /\/post\/api\/v1\/posts\/feed\?page=1&pageSize=1&sort=CREATED_AT/)
+  assert.match(workflow, /"protected-auth-me"/)
+  assert.match(workflow, /\/member\/api\/v1\/auth\/me/)
+  assert.match(workflow, /rollback_and_exit "public_feed_security_header_smoke_failed"/)
+  assert.match(workflow, /rollback_and_exit "protected_auth_security_header_smoke_failed"/)
+  assert(
+    workflow.indexOf('wait_public_api_health "${API_DOMAIN}"') <
+      workflow.indexOf('assert_live_security_headers'),
+  )
+  assert(
+    workflow.indexOf('assert_live_security_headers') <
+      workflow.indexOf("run_canary_ratio_check()"),
+  )
+})
+
 test("required secret check does not inject multi-line HOME_SERVER_ENV into shell", () => {
   const workflow = readFileSync(workflowPath, "utf8")
 


### PR DESCRIPTION
## 관련 이슈

close #857

## 작업 배경

- prod에서는 Spring Security 기본 보안 헤더 일부를 Caddy가 보장한다는 전제가 있다.
- 기존 deploy/live smoke는 status code 중심이라 Caddy header drift가 있어도 배포 중에 즉시 실패하지 않았다.

## 작업 내용

- homeserver deploy 후 public API route와 protected API route의 live security header smoke를 추가했다.
- 공통 검사 대상:
  - `Strict-Transport-Security`
  - `X-Content-Type-Options`
  - `X-Frame-Options`
  - `Referrer-Policy`
  - `Permissions-Policy`
- 보호 API(`/member/api/v1/auth/me`)는 401 응답의 `Cache-Control: no-store`도 함께 검사한다.
- header smoke 실패 시 누락 header와 대상 URL을 로그로 남기고 rollback 경로로 실패 처리한다.
- `tools/test/env-contract.test.mjs`에 deploy workflow 계약 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/test/env-contract.test.mjs` 성공
  - `git diff --check` 성공
  - `tools/test/verify-deploy-workflow-classification.sh` 실패 확인: 기존 `origin/main`의 editor canary path regex drift(`front/src/components/editor/` vs `front/src/components/markdown-editor/`)로 #857 범위와 별개

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `.github/workflows/deploy.yml`의 `assert_live_security_headers` 함수
  - public feed API와 protected auth API의 header 검사 순서가 public healthcheck 이후, canary ratio check 이전인지 확인 부탁드립니다.

## 리스크

- 실제 prod 응답에서 Caddy/Spring header 계약이 누락되어 있으면 homeserver deploy가 실패한다.
- 네트워크 flaky와 header 누락을 구분할 수 있도록 status와 URL은 로그에 남기지만, 응답 header 전체나 secret 값은 출력하지 않는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다. (N/A: Codex CLI fallback review 사용 예정)
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
