### PR TITLE
[Fix] 공개 게시글 작성자 표현 캐시 정합성 수정

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/event/MemberPublicProfileChangedEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/event/MemberPublicProfileChangedEvent.kt
@@ -1,0 +1,9 @@
+package com.back.boundedContexts.member.application.event
+
+data class MemberPublicProfileChangedEvent(
+    val memberId: Long,
+    val previousNickname: String,
+    val currentNickname: String,
+    val previousProfileImgUrl: String,
+    val currentProfileImgUrl: String,
+)

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt
@@ -1,5 +1,6 @@
 package com.back.boundedContexts.member.application.service
 
+import com.back.boundedContexts.member.application.event.MemberPublicProfileChangedEvent
 import com.back.boundedContexts.member.application.port.output.MemberAttrRepositoryPort
 import com.back.boundedContexts.member.application.port.output.MemberRepositoryPort
 import com.back.boundedContexts.member.domain.shared.Member
@@ -13,6 +14,7 @@ import com.back.global.rsData.RsData
 import com.back.global.storage.application.UploadedFileRetentionService
 import com.back.standard.dto.member.type1.MemberSearchSortType1
 import com.back.standard.dto.page.PagedResult
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
@@ -31,6 +33,7 @@ class MemberApplicationService(
     private val memberProfileHydrator: MemberProfileHydrator,
     private val passwordEncoder: PasswordEncoder,
     private val uploadedFileRetentionService: UploadedFileRetentionService,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
     companion object {
         private const val USERNAME_MAX_LENGTH = 30
@@ -175,6 +178,7 @@ class MemberApplicationService(
     ) {
         memberProfileHydrator.hydrate(member)
         ensureProfileWorkspaceSnapshotsInitialized(member)
+        val previousNickname = member.nickname
         val previousProfileImgUrl = member.profileImgUrl
         val publishedProfileImgUrl = member.getProfileWorkspacePublishedContent().profileImageUrl
         member.modify(nickname, profileImgUrl)
@@ -185,6 +189,17 @@ class MemberApplicationService(
                 member.id,
                 previousProfileImgUrl.takeUnless { it == publishedProfileImgUrl },
                 member.profileImgUrl,
+            )
+        }
+        if (previousNickname != member.nickname || previousProfileImgUrl != member.profileImgUrl) {
+            applicationEventPublisher.publishEvent(
+                MemberPublicProfileChangedEvent(
+                    memberId = member.id,
+                    previousNickname = previousNickname,
+                    currentNickname = member.nickname,
+                    previousProfileImgUrl = previousProfileImgUrl,
+                    currentProfileImgUrl = member.profileImgUrl,
+                ),
             )
         }
     }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/model/shared/Member.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/model/shared/Member.kt
@@ -53,7 +53,7 @@ class Member(
     override val id: Long = 0,
     @field:NaturalId
     @field:Column(name = "login_id", nullable = false)
-    val username: String,
+    override val username: String,
     @field:Column(nullable = true)
     var password: String? = null,
     @field:Column(nullable = false)

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadEtagSeedBuilder.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadEtagSeedBuilder.kt
@@ -84,6 +84,16 @@ class PostPublicReadEtagSeedBuilder {
             append(data.commentsCount)
             append("|")
             append(data.hitCount)
+            append("|author=")
+            append(
+                buildLengthPrefixedToken(
+                    data.authorId.toString(),
+                    data.authorName,
+                    data.authorUsername,
+                    data.authorProfileImageUrl,
+                    data.authorProfileImageDirectUrl,
+                ),
+            )
         }
 
     fun buildTagsEtagSeed(tags: List<TagCountDto>): String = tags.joinToString(separator = "|") { "${it.tag}:${it.count}" }
@@ -129,7 +139,20 @@ class PostPublicReadEtagSeedBuilder {
 
     private fun buildFeedItemsToken(posts: List<FeedPostDto>): String =
         posts.joinToString(separator = "|") {
-            "${it.id}:${toEpochMillis(it.modifiedAt)}:${it.likesCount}:${it.commentsCount}:${it.hitCount}"
+            "${it.id}:${toEpochMillis(it.modifiedAt)}:${it.likesCount}:${it.commentsCount}:${it.hitCount}:" +
+                "author=${
+                    buildLengthPrefixedToken(
+                        it.authorId.toString(),
+                        it.authorName,
+                        it.authorUsername,
+                        it.authorProfileImgUrl,
+                    )
+                }"
+        }
+
+    private fun buildLengthPrefixedToken(vararg parts: String): String =
+        parts.joinToString(separator = ",") { part ->
+            "${part.length}:$part"
         }
 
     private fun toEpochMillis(instant: Instant): Long = instant.toEpochMilli()

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostAuthorPublicReadCacheInvalidationListener.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostAuthorPublicReadCacheInvalidationListener.kt
@@ -1,0 +1,23 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.application.event.MemberPublicProfileChangedEvent
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class PostAuthorPublicReadCacheInvalidationListener(
+    private val postReadCacheInvalidator: PostReadCacheInvalidator,
+) {
+    private val logger = LoggerFactory.getLogger(PostAuthorPublicReadCacheInvalidationListener::class.java)
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    fun handle(event: MemberPublicProfileChangedEvent) {
+        runCatching {
+            postReadCacheInvalidator.invalidateAuthorRepresentation("author-representation")
+        }.onFailure { exception ->
+            logger.warn("Failed to evict post read caches after author update: memberId={}", event.memberId, exception)
+        }
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostReadCacheInvalidator.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostReadCacheInvalidator.kt
@@ -23,6 +23,24 @@ class PostReadCacheInvalidator(
     private val hotSorts = listOf(PostSearchSortType1.CREATED_AT)
     private val maxTagCacheEvict = 12
 
+    internal fun invalidateAuthorRepresentation(reason: String) {
+        listOf(
+            PostQueryCacheNames.ADMIN_POSTS_FIRST_PAGE,
+            PostQueryCacheNames.FEED,
+            PostQueryCacheNames.EXPLORE,
+            PostQueryCacheNames.FEED_CURSOR_FIRST,
+            PostQueryCacheNames.EXPLORE_CURSOR_FIRST,
+            PostQueryCacheNames.BOOTSTRAP,
+            PostQueryCacheNames.SEARCH,
+            PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT,
+            PostQueryCacheNames.DETAIL_PUBLIC_META,
+            PostQueryCacheNames.DETAIL_PUBLIC_CONTENT,
+        ).forEach { cacheName ->
+            cacheManager.getCache(cacheName)?.clear()
+            recordCacheEvict(cacheName, "clear", reason)
+        }
+    }
+
     internal fun invalidate(
         request: PostReadCacheInvalidationRequest,
         onPublicTagsEvicted: () -> Unit,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/domain/PostMember.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/domain/PostMember.kt
@@ -15,6 +15,8 @@ const val POST_COMMENTS_COUNT_DEFAULT_VALUE = 0
  * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
  */
 interface PostMember : MemberAware {
+    val username: String
+
     var postsCountAttr: MemberAttr?
 
     var postCommentsCountAttr: MemberAttr?

--- a/back/src/main/kotlin/com/back/boundedContexts/post/dto/FeedPostDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/dto/FeedPostDto.kt
@@ -44,7 +44,7 @@ data class FeedPostDto(
                     modifiedAt = post.modifiedAt,
                     authorId = post.author.id,
                     authorName = post.author.name,
-                    authorUsername = post.author.name,
+                    authorUsername = post.author.username,
                     authorProfileImgUrl = post.author.profileImgUrlVersionedOrDefault,
                     title = post.title,
                     thumbnail = preview.thumbnail,
@@ -66,7 +66,7 @@ data class FeedPostDto(
                     modifiedAt = post.modifiedAt,
                     authorId = runCatching { post.author.id }.getOrDefault(0),
                     authorName = runCatching { post.author.name }.getOrDefault("unknown"),
-                    authorUsername = runCatching { post.author.name }.getOrDefault("unknown"),
+                    authorUsername = runCatching { post.author.username }.getOrDefault("unknown"),
                     authorProfileImgUrl =
                         runCatching { post.author.profileImgUrlVersionedOrDefault }
                             .getOrDefault(FALLBACK_PROFILE_IMAGE_URL),

--- a/back/src/main/kotlin/com/back/boundedContexts/post/dto/PostWithContentDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/dto/PostWithContentDto.kt
@@ -37,7 +37,7 @@ data class PostWithContentDto(
         post.modifiedAt,
         post.author.id,
         post.author.name,
-        post.author.name,
+        post.author.username,
         post.author.redirectToProfileImgUrlVersionedOrDefault,
         post.author.profileImgUrlVersionedOrDefault,
         post.title,

--- a/back/src/test/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationServiceTest.kt
@@ -2,14 +2,18 @@ package com.back.boundedContexts.member.application.service
 
 import com.back.boundedContexts.member.adapter.persistence.MemberAttrRepository
 import com.back.boundedContexts.member.adapter.persistence.MemberRepository
+import com.back.boundedContexts.member.application.event.MemberPublicProfileChangedEvent
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.support.BaseMemberApplicationServiceIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.test.context.event.ApplicationEvents
+import org.springframework.test.context.event.RecordApplicationEvents
 
 @org.junit.jupiter.api.DisplayName("MemberApplicationService 테스트")
+@RecordApplicationEvents
 class MemberApplicationServiceTest : BaseMemberApplicationServiceIntegrationTest() {
     @Autowired
     private lateinit var memberFacade: MemberApplicationService
@@ -22,6 +26,9 @@ class MemberApplicationServiceTest : BaseMemberApplicationServiceIntegrationTest
 
     @Autowired
     private lateinit var passwordEncoder: PasswordEncoder
+
+    @Autowired
+    private lateinit var applicationEvents: ApplicationEvents
 
     @Test
     fun `회원 생성에서 profileImgUrl 을 함께 넘기면 기본 이미지 대신 저장된 이미지가 사용된다`() {
@@ -57,6 +64,25 @@ class MemberApplicationServiceTest : BaseMemberApplicationServiceIntegrationTest
         assertThat(memberAttrRepository.findBySubjectAndName(member, "profileImgUrl"))
             .extracting("value")
             .isEqualTo("https://example.com/updated-user1.png")
+    }
+
+    @Test
+    fun `회원 수정은 공개 작성자 표시 변경 이벤트를 발행한다`() {
+        val member = createMember("member-public-author-event", "변경전")
+
+        memberFacade.modify(
+            member = member,
+            nickname = "변경후",
+            profileImgUrl = "https://example.com/author-event.png",
+        )
+
+        val events = applicationEvents.stream(MemberPublicProfileChangedEvent::class.java).toList()
+        assertThat(events).hasSize(1)
+        assertThat(events.single().memberId).isEqualTo(member.id)
+        assertThat(events.single().previousNickname).isEqualTo("변경전")
+        assertThat(events.single().currentNickname).isEqualTo("변경후")
+        assertThat(events.single().previousProfileImgUrl).isEmpty()
+        assertThat(events.single().currentProfileImgUrl).isEqualTo("https://example.com/author-event.png")
     }
 
     @Test

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadResponseFactoryTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadResponseFactoryTest.kt
@@ -327,15 +327,22 @@ class PostPublicReadResponseFactoryTest {
         // then
         assertThat(pageSeed).isEqualTo(
             "search|page=2|size=10|sort=CREATED_AT|kw=kotlin|tag=spring|total=22|pages=3|" +
-                "items=1:1767225600000:11:12:13|2:1767312000000:11:12:13",
+                "items=1:1767225600000:11:12:13:author=1:1,6:Author,6:author,31:https://example.com/profile.png|" +
+                "2:1767312000000:11:12:13:author=1:1,6:Author,6:author,31:https://example.com/profile.png",
         )
         assertThat(cursorSeed).isEqualTo(
             "feed-cursor|size=10|sort=CREATED_AT|cursor=cursor-1|tag=backend|hasNext=true|nextCursor=next-1|" +
-                "items=1:1767225600000:11:12:13",
+                "items=1:1767225600000:11:12:13:author=1:1,6:Author,6:author,31:https://example.com/profile.png",
         )
-        assertThat(detailSeed).isEqualTo("9|1767398400000|7|8|9|10")
+        assertThat(detailSeed).isEqualTo(
+            "9|1767398400000|7|8|9|10|author=1:1,6:Author,6:author," +
+                "31:https://example.com/profile.png,38:https://example.com/profile-direct.png",
+        )
         assertThat(responseFactory.buildTagsEtagSeed(tags)).isEqualTo("Kotlin:3|Spring:2")
-        assertThat(relatedSeed).isEqualTo("related-author|authorId=3|excludePostId=0|limit=4|items=2:1767312000000:11:12:13")
+        assertThat(relatedSeed).isEqualTo(
+            "related-author|authorId=3|excludePostId=0|limit=4|" +
+                "items=2:1767312000000:11:12:13:author=1:1,6:Author,6:author,31:https://example.com/profile.png",
+        )
         assertThat(bootstrapFeedSeed).startsWith("bootstrap-feed-cursor|")
         assertThat(bootstrapExploreSeed).startsWith("bootstrap-explore-cursor|")
     }
@@ -398,6 +405,33 @@ class PostPublicReadResponseFactoryTest {
     }
 
     @Test
+    @DisplayName("ETag seed builder는 작성자 표현 필드 변경을 공개 read 표현 변경으로 반영한다")
+    fun buildEtagSeedsWithAuthorRepresentationFields() {
+        val basePost = feedPost(id = 1L, modifiedAt = Instant.parse("2026-01-01T00:00:00Z"))
+        val renamedPost = basePost.copy(authorName = "Renamed Author")
+        val usernameChangedPost = basePost.copy(authorUsername = "renamed-author")
+        val profileChangedPost = basePost.copy(authorProfileImgUrl = "https://example.com/profile-v2.png")
+        val baseDetail = detailPost()
+        val renamedDetail = baseDetail.copy(authorName = "Renamed Author")
+        val usernameChangedDetail = baseDetail.copy(authorUsername = "renamed-author")
+        val profileChangedDetail = baseDetail.copy(authorProfileImageUrl = "https://example.com/profile-v2.png")
+
+        val baseFeedSeed = responseFactory.buildFeedPageEtagSeed("feed", 0, 10, PostSearchSortType1.CREATED_AT, data = pageOf(basePost))
+        val baseDetailSeed = responseFactory.buildPublicDetailEtagSeed(baseDetail)
+
+        assertThat(responseFactory.buildFeedPageEtagSeed("feed", 0, 10, PostSearchSortType1.CREATED_AT, data = pageOf(renamedPost)))
+            .isNotEqualTo(baseFeedSeed)
+        assertThat(responseFactory.buildFeedPageEtagSeed("feed", 0, 10, PostSearchSortType1.CREATED_AT, data = pageOf(usernameChangedPost)))
+            .isNotEqualTo(baseFeedSeed)
+        assertThat(responseFactory.buildFeedPageEtagSeed("feed", 0, 10, PostSearchSortType1.CREATED_AT, data = pageOf(profileChangedPost)))
+            .isNotEqualTo(baseFeedSeed)
+
+        assertThat(responseFactory.buildPublicDetailEtagSeed(renamedDetail)).isNotEqualTo(baseDetailSeed)
+        assertThat(responseFactory.buildPublicDetailEtagSeed(usernameChangedDetail)).isNotEqualTo(baseDetailSeed)
+        assertThat(responseFactory.buildPublicDetailEtagSeed(profileChangedDetail)).isNotEqualTo(baseDetailSeed)
+    }
+
+    @Test
     @DisplayName("공개 read cache policy registry는 모든 endpoint 정책을 노출한다")
     fun exposeAllPublicReadCachePolicies() {
         val policies =
@@ -454,5 +488,39 @@ class PostPublicReadResponseFactoryTest {
             likesCount = 11,
             commentsCount = 12,
             hitCount = 13,
+        )
+
+    private fun pageOf(post: FeedPostDto): PageDto<FeedPostDto> =
+        PageDto(
+            content = listOf(post),
+            pageable =
+                PageableDto(
+                    pageNumber = 0,
+                    pageSize = 10,
+                    totalElements = 1,
+                    totalPages = 1,
+                    numberOfElements = 1,
+                ),
+        )
+
+    private fun detailPost(): PostWithContentDto =
+        PostWithContentDto(
+            id = 9L,
+            createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+            modifiedAt = Instant.parse("2026-01-03T00:00:00Z"),
+            authorId = 1L,
+            authorName = "Author",
+            authorUsername = "author",
+            authorProfileImageUrl = "https://example.com/profile.png",
+            authorProfileImageDirectUrl = "https://example.com/profile-direct.png",
+            title = "Title",
+            content = "content",
+            contentHtml = "<p>content</p>",
+            version = 7L,
+            published = true,
+            listed = true,
+            likesCount = 8,
+            commentsCount = 9,
+            hitCount = 10,
         )
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostAuthorPublicReadCacheInvalidationListenerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostAuthorPublicReadCacheInvalidationListenerTest.kt
@@ -1,0 +1,44 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.application.event.MemberPublicProfileChangedEvent
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+@DisplayName("PostAuthorPublicReadCacheInvalidationListener 테스트")
+class PostAuthorPublicReadCacheInvalidationListenerTest {
+    @Test
+    fun `작성자 공개 표시 변경 이벤트는 공개 읽기 캐시를 축출한다`() {
+        val invalidator = mock(PostReadCacheInvalidator::class.java)
+        val listener = PostAuthorPublicReadCacheInvalidationListener(invalidator)
+
+        listener.handle(event())
+
+        verify(invalidator).invalidateAuthorRepresentation("author-representation")
+    }
+
+    @Test
+    fun `작성자 공개 표시 캐시 축출 실패는 이벤트 처리 예외로 전파하지 않는다`() {
+        val invalidator = mock(PostReadCacheInvalidator::class.java)
+        doThrow(IllegalStateException("cache unavailable"))
+            .`when`(invalidator)
+            .invalidateAuthorRepresentation("author-representation")
+        val listener = PostAuthorPublicReadCacheInvalidationListener(invalidator)
+
+        assertThatCode {
+            listener.handle(event())
+        }.doesNotThrowAnyException()
+    }
+
+    private fun event(): MemberPublicProfileChangedEvent =
+        MemberPublicProfileChangedEvent(
+            memberId = 1L,
+            previousNickname = "before",
+            currentNickname = "after",
+            previousProfileImgUrl = "https://example.com/before.png",
+            currentProfileImgUrl = "https://example.com/after.png",
+        )
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostReadCacheInvalidatorTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostReadCacheInvalidatorTest.kt
@@ -105,6 +105,48 @@ class PostReadCacheInvalidatorTest {
         assertThat(get(PostQueryCacheNames.DETAIL_PUBLIC_NEGATIVE, 101L)).isNull()
     }
 
+    @Test
+    @DisplayName("작성자 표시 변경은 공개 응답 캐시를 전체 clear한다")
+    fun invalidateAuthorRepresentationClearsPublicResponseCaches() {
+        // given
+        put(PostQueryCacheNames.ADMIN_POSTS_FIRST_PAGE, "page=3:size=20:sort=CREATED_AT")
+        put(PostQueryCacheNames.FEED, "page=9:size=99:sort=CREATED_AT")
+        put(PostQueryCacheNames.EXPLORE, "page=4:size=15:sort=CREATED_AT:kw=_:tag=spring")
+        put(PostQueryCacheNames.FEED_CURSOR_FIRST, "size=45:sort=CREATED_AT")
+        put(PostQueryCacheNames.EXPLORE_CURSOR_FIRST, "size=45:sort=CREATED_AT:tag=kotlin")
+        put(PostQueryCacheNames.BOOTSTRAP, PostPublicReadQueryService.buildBootstrapCacheKey(45, PostSearchSortType1.CREATED_AT, "Kotlin"))
+        put(PostQueryCacheNames.SEARCH, "page=2:size=25:sort=CREATED_AT:kw=author")
+        put(PostQueryCacheNames.SEARCH_NEGATIVE, "page=2:size=25:sort=CREATED_AT:kw=missing")
+        put(PostQueryCacheNames.TAGS, "public")
+        put(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT, 201L)
+        put(PostQueryCacheNames.DETAIL_PUBLIC_META, 201L)
+        put(PostQueryCacheNames.DETAIL_PUBLIC_CONTENT, 201L)
+        put(PostQueryCacheNames.DETAIL_PUBLIC_NEGATIVE, 201L)
+
+        // when
+        invalidator.invalidateAuthorRepresentation("test-author")
+
+        // then
+        assertThat(get(PostQueryCacheNames.ADMIN_POSTS_FIRST_PAGE, "page=3:size=20:sort=CREATED_AT")).isNull()
+        assertThat(get(PostQueryCacheNames.FEED, "page=9:size=99:sort=CREATED_AT")).isNull()
+        assertThat(get(PostQueryCacheNames.EXPLORE, "page=4:size=15:sort=CREATED_AT:kw=_:tag=spring")).isNull()
+        assertThat(get(PostQueryCacheNames.FEED_CURSOR_FIRST, "size=45:sort=CREATED_AT")).isNull()
+        assertThat(get(PostQueryCacheNames.EXPLORE_CURSOR_FIRST, "size=45:sort=CREATED_AT:tag=kotlin")).isNull()
+        assertThat(
+            get(
+                PostQueryCacheNames.BOOTSTRAP,
+                PostPublicReadQueryService.buildBootstrapCacheKey(45, PostSearchSortType1.CREATED_AT, "Kotlin"),
+            ),
+        ).isNull()
+        assertThat(get(PostQueryCacheNames.SEARCH, "page=2:size=25:sort=CREATED_AT:kw=author")).isNull()
+        assertThat(get(PostQueryCacheNames.DETAIL_PUBLIC_SNAPSHOT, 201L)).isNull()
+        assertThat(get(PostQueryCacheNames.DETAIL_PUBLIC_META, 201L)).isNull()
+        assertThat(get(PostQueryCacheNames.DETAIL_PUBLIC_CONTENT, 201L)).isNull()
+        assertThat(get(PostQueryCacheNames.SEARCH_NEGATIVE, "page=2:size=25:sort=CREATED_AT:kw=missing")).isEqualTo("cached")
+        assertThat(get(PostQueryCacheNames.TAGS, "public")).isEqualTo("cached")
+        assertThat(get(PostQueryCacheNames.DETAIL_PUBLIC_NEGATIVE, 201L)).isEqualTo("cached")
+    }
+
     private fun put(
         cacheName: String,
         key: Any,

--- a/back/src/test/kotlin/com/back/boundedContexts/post/dto/PostAuthorDtoMappingTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/dto/PostAuthorDtoMappingTest.kt
@@ -1,0 +1,77 @@
+package com.back.boundedContexts.post.dto
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.post.domain.Post
+import com.back.global.app.AppConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+@DisplayName("게시글 작성자 DTO 매핑")
+class PostAuthorDtoMappingTest {
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun initAppConfig() {
+            AppConfig(
+                siteBackUrl = "https://api.example.com",
+                siteFrontUrl = "https://example.com",
+                adminUsername = "",
+                adminEmail = "",
+                adminPassword = "",
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("feed DTO는 작성자의 nickname과 username을 별도 필드에 매핑한다")
+    fun mapsFeedAuthorNameAndUsernameSeparately() {
+        val post = postByAuthor(username = "aquila-login", nickname = "아퀼라")
+
+        val dto = FeedPostDto.from(post)
+
+        assertThat(dto.authorName).isEqualTo("아퀼라")
+        assertThat(dto.authorUsername).isEqualTo("aquila-login")
+    }
+
+    @Test
+    @DisplayName("detail DTO는 작성자의 nickname과 username을 별도 필드에 매핑한다")
+    fun mapsDetailAuthorNameAndUsernameSeparately() {
+        val post = postByAuthor(username = "aquila-login", nickname = "아퀼라")
+
+        val dto = PostWithContentDto(post)
+
+        assertThat(dto.authorName).isEqualTo("아퀼라")
+        assertThat(dto.authorUsername).isEqualTo("aquila-login")
+    }
+
+    private fun postByAuthor(
+        username: String,
+        nickname: String,
+    ): Post {
+        val author =
+            Member(
+                id = 1L,
+                username = username,
+                password = null,
+                nickname = nickname,
+                email = null,
+            ).apply {
+                createdAt = Instant.parse("2026-01-01T00:00:00Z")
+                modifiedAt = Instant.parse("2026-01-01T00:01:00Z")
+            }
+        return Post(
+            id = 10L,
+            author = author,
+            title = "작성자 매핑",
+            content = "본문",
+            published = true,
+            listed = true,
+        ).apply {
+            createdAt = Instant.parse("2026-01-02T00:00:00Z")
+            modifiedAt = Instant.parse("2026-01-02T00:01:00Z")
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #875
- close #876

## 📝 Summary
- 공개 게시글 feed/detail DTO의 `authorUsername`이 nickname이 아니라 실제 username을 사용하도록 수정했습니다.
- public read ETag seed에 작성자 이름, username, 프로필 이미지 URL을 포함해 작성자 표현 변경이 304 캐시에 가려지지 않게 했습니다.
- 작성자 nickname/profile image 변경 시 기존 공개 읽기 캐시가 stale DTO를 계속 제공하지 않도록 커밋 후 캐시 무효화 경로를 추가했습니다.

## 🛠 Changes
- `PostMember` author projection 계약에 `username`을 추가하고 `Member.username`이 이를 구현하도록 명시했습니다.
- `FeedPostDto`와 `PostWithContentDto`의 `authorUsername` 매핑을 `post.author.username`으로 변경했습니다.
- feed/detail/related/bootstrap ETag seed가 작성자 표현 필드를 length-prefix token으로 포함하도록 변경했습니다.
- member 수정 경로에서 작성자 공개 표시 변경 이벤트를 발행하고, post 쪽 listener가 공개 읽기 응답 캐시를 clear하도록 보강했습니다.
- nickname과 username이 다른 작성자 DTO 테스트, 작성자 표현 필드 변경 시 ETag seed 변경 테스트, 작성자 표시 변경 캐시 무효화 테스트를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [ ] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `back/gradlew -p back test --tests '*PostAuthorDtoMappingTest*' --tests '*PostPublicReadResponseFactoryTest.buildEtagSeedsWithAuthorRepresentationFields'`
- `back/gradlew -p back test --tests '*PostPublicReadResponseFactoryTest*'`
- `back/gradlew -p back test --tests '*MemberApplicationServiceTest*' --tests '*PostAuthorPublicReadCacheInvalidationListenerTest*' --tests '*PostReadCacheInvalidatorTest*'`
- `back/gradlew -p back test --tests '*MemberApplicationServiceTest*' --tests '*PostAuthorPublicReadCacheInvalidationListenerTest*' --tests '*PostReadCacheInvalidatorTest*' --tests '*PostAuthorDtoMappingTest*' --tests '*PostPublicReadResponseFactoryTest*' --tests '*ApiV1PostControllerTest*' --tests '*OpenApiContractExportTest*'`
- `back/gradlew -p back ktlintCheck`
- `back/gradlew -p back ciFastCheck`
- Codex CLI fallback review: `Actionable comments posted: 1`, `18d671be`에서 반영 후 단일 PR review로 기록
- pre-commit hook: `OpenApiContractExportTest`, `yarn contracts:check`

## 📸 Screenshot / API Example
- UI 변경 없음.
- API schema 변경 없음. 응답의 기존 `authorUsername` 필드 값이 nickname에서 username으로 바로잡힙니다.

## ⚠️ Risk & Rollback
- 예상 리스크: ETag seed 형식 변경과 작성자 표시 변경 시 공개 읽기 캐시 clear로 기존 public read 응답이 1회 갱신됩니다. 응답 표현 변경을 반영하기 위한 의도된 cache invalidation입니다.
- 롤백 방법: 이 PR revert 후 기존 DTO 매핑, ETag seed builder, 작성자 표시 변경 캐시 무효화 경로를 되돌립니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
