### PR TITLE
[Fix] 태스크 동적 동시성 설정 동작 보장

### DIFF
--- a/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt
+++ b/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt
@@ -3,6 +3,7 @@ package com.back.global.task.adapter.scheduler
 import com.back.global.task.adapter.persistence.TaskRepository
 import com.back.global.task.application.TaskHandlerEntry
 import com.back.global.task.application.TaskHandlerRegistry
+import com.back.global.task.domain.Task
 import com.back.global.task.domain.TaskStatus
 import com.back.standard.dto.TaskPayload
 import io.micrometer.core.instrument.MeterRegistry
@@ -66,7 +67,7 @@ class TaskProcessingScheduledJob(
     private val dynamicBatchTargetHandlerDurationMs: Long,
     @param:Value("\${custom.task.processor.dynamicBatchMaxPrefetchMultiplier:2}")
     private val dynamicBatchMaxPrefetchMultiplier: Int,
-    @param:Value("\${custom.task.processor.perTypeMaxConcurrent:}")
+    @Value("\${custom.task.processor.perTypeMaxConcurrent:}")
     perTypeMaxConcurrentRaw: String,
     @param:Value("\${custom.task.processor.perTypeAutoTuneEnabled:true}")
     private val perTypeAutoTuneEnabled: Boolean,
@@ -124,11 +125,17 @@ class TaskProcessingScheduledJob(
         val dispatchSlots =
             transactionTemplate.execute {
                 val pendingTasks = taskRepository.findPendingTasksWithLock(fetchLimit)
-                pendingTasks.forEach { it.markAsProcessing() }
-                pendingTasks.map { TaskDispatchSlot(it.id, it.taskType) }
+                val dispatchableTasks = selectDispatchableTasks(pendingTasks, availableWorkerSlots)
+                dispatchableTasks.forEach { it.markAsProcessing() }
+                dispatchableTasks.map { TaskDispatchSlot(it.id, it.taskType) }
             } ?: emptyList()
 
+        var dispatchedWorkers = 0
         dispatchSlots.forEach { slot ->
+            if (dispatchedWorkers >= availableWorkerSlots) {
+                revertTaskToPending(slot.taskId)
+                return@forEach
+            }
             if (!concurrencyGate.tryAcquire()) {
                 revertTaskToPending(slot.taskId)
                 return@forEach
@@ -139,6 +146,7 @@ class TaskProcessingScheduledJob(
                 return@forEach
             }
 
+            dispatchedWorkers++
             executor.submit {
                 try {
                     executeTask(slot.taskId)
@@ -150,17 +158,66 @@ class TaskProcessingScheduledJob(
         }
     }
 
+    private fun selectDispatchableTasks(
+        pendingTasks: List<Task>,
+        availableWorkerSlots: Int,
+    ): List<Task> {
+        val projectedPerType = mutableMapOf<String, Int>()
+        val dispatchableTasks = mutableListOf<Task>()
+
+        for (task in pendingTasks) {
+            if (dispatchableTasks.size >= availableWorkerSlots) break
+            val projectedInFlight = projectedPerType[task.taskType] ?: 0
+            if (!canReservePerTypeSlot(task.taskType, projectedInFlight)) continue
+
+            projectedPerType[task.taskType] = projectedInFlight + 1
+            dispatchableTasks += task
+        }
+
+        return dispatchableTasks
+    }
+
+    private fun canReservePerTypeSlot(
+        taskType: String,
+        projectedInFlight: Int,
+    ): Boolean {
+        val maxAllowed = resolvePerTypeLimit(taskType)
+        if (maxAllowed <= 0) return false
+        val currentInFlight = perTypeInFlight[taskType]?.get() ?: 0
+        return currentInFlight + projectedInFlight < maxAllowed
+    }
+
     private fun resolveAvailableWorkerSlots(): Int {
         val activeWorkers = (workerConcurrency - concurrencyGate.availablePermits()).coerceAtLeast(0)
         val targetConcurrency =
             if (!dynamicConcurrencyEnabled) {
                 workerConcurrency
             } else {
-                workerConcurrency
+                resolveDynamicTargetConcurrency()
             }
 
         return (targetConcurrency - activeWorkers).coerceIn(0, workerConcurrency)
     }
+
+    private fun resolveDynamicTargetConcurrency(): Int {
+        val readyBacklog = countReadyBacklog() ?: return workerConcurrency
+        val minConcurrency = dynamicMinConcurrent.coerceIn(1, workerConcurrency)
+        val backlogPerSlot = dynamicBacklogPerSlot.coerceAtLeast(1)
+        val backlogConcurrency =
+            ceil(readyBacklog.coerceAtLeast(0).toDouble() / backlogPerSlot.toDouble())
+                .toInt()
+                .coerceAtLeast(minConcurrency)
+
+        return backlogConcurrency.coerceIn(minConcurrency, workerConcurrency)
+    }
+
+    private fun countReadyBacklog(): Long? =
+        runCatching {
+            taskRepository.countByStatusAndNextRetryAtLessThanEqual(TaskStatus.PENDING, Instant.now())
+        }.getOrElse { exception ->
+            logger.warn("Failed to count ready task backlog for dynamic concurrency; using max concurrency", exception)
+            null
+        }
 
     private fun resolveFetchLimit(
         safeBatchSize: Int,
@@ -178,11 +235,27 @@ class TaskProcessingScheduledJob(
                 else -> (targetMs.toDouble() / avgHandlerMs.toDouble()).coerceIn(0.35, 1.0)
             }
 
-        val maxClaim = minOf(safeBatchSize, availableWorkerSlots.coerceAtLeast(1))
+        val prefetchMultiplier = resolveDynamicBatchPrefetchMultiplier()
+        val maxClaim = minOf(safeBatchSize, availableWorkerSlots.coerceAtLeast(1) * prefetchMultiplier)
         val minClaim = minOf(dynamicBatchMinSize.coerceIn(1, safeBatchSize), maxClaim)
-        val raw = ceil(availableWorkerSlots.toDouble() * latencyFactor).toInt().coerceAtLeast(1)
+        val raw =
+            ceil(availableWorkerSlots.toDouble() * prefetchMultiplier.toDouble() * latencyFactor)
+                .toInt()
+                .coerceAtLeast(1)
 
         return raw.coerceIn(minClaim, maxClaim)
+    }
+
+    private fun resolveDynamicBatchPrefetchMultiplier(): Int {
+        val maxPrefetchMultiplier = dynamicBatchMaxPrefetchMultiplier.coerceIn(1, 16)
+        val backlogPerStep = dynamicBatchBacklogPerStep.coerceAtLeast(1)
+        val readyBacklog = countReadyBacklog() ?: return maxPrefetchMultiplier
+        val backlogMultiplier =
+            ceil(readyBacklog.coerceAtLeast(0).toDouble() / backlogPerStep.toDouble())
+                .toInt()
+                .coerceAtLeast(1)
+
+        return backlogMultiplier.coerceIn(1, maxPrefetchMultiplier)
     }
 
     private fun tryAcquirePerTypePermit(taskType: String): Boolean {

--- a/back/src/test/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJobPerTypeLimitTest.kt
+++ b/back/src/test/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJobPerTypeLimitTest.kt
@@ -5,33 +5,243 @@ import com.back.global.task.application.TaskHandlerEntry
 import com.back.global.task.application.TaskHandlerMethod
 import com.back.global.task.application.TaskHandlerRegistry
 import com.back.global.task.application.TaskRetryPolicy
+import com.back.global.task.domain.Task
+import com.back.global.task.domain.TaskStatus
 import com.back.standard.dto.TaskPayload
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.TransactionStatus
+import org.springframework.transaction.support.SimpleTransactionStatus
 import org.springframework.transaction.support.TransactionTemplate
 import tools.jackson.databind.ObjectMapper
+import java.time.Instant
+import java.util.Optional
 import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 class TaskProcessingScheduledJobPerTypeLimitTest {
     @Test
-    @DisplayName("dynamic capacity 산정은 claim 전에 ready backlog count를 조회하지 않는다")
-    fun `dynamic capacity resolution avoids ready backlog count before claim`() {
+    @DisplayName("dynamic concurrency는 ready backlog가 작으면 최소 동시성만 claim한다")
+    fun `dynamic concurrency uses minimum slots for small ready backlog`() {
         val fixture =
             createFixture(
                 maxConcurrent = 8,
                 perTypeMaxConcurrentRaw = "",
                 perTypeAutoTuneEnabled = true,
                 perTypeAutoTuneMinConcurrent = 1,
+                dynamicConcurrencyEnabled = true,
+                dynamicMinConcurrent = 2,
+                dynamicBacklogPerSlot = 25,
+            )
+        org.mockito.Mockito
+            .`when`(
+                fixture.taskRepository.countByStatusAndNextRetryAtLessThanEqual(
+                    pendingStatus(),
+                    anyInstant(),
+                ),
+            ).thenReturn(1L)
+
+        val availableSlots = invokeResolveAvailableWorkerSlots(fixture.job)
+
+        assertThat(availableSlots).isEqualTo(2)
+        verify(fixture.taskRepository)
+            .countByStatusAndNextRetryAtLessThanEqual(pendingStatus(), anyInstant())
+    }
+
+    @Test
+    @DisplayName("dynamic concurrency는 ready backlog가 커지면 최대 동시성까지 확장한다")
+    fun `dynamic concurrency expands slots as ready backlog grows`() {
+        val fixture =
+            createFixture(
+                maxConcurrent = 8,
+                perTypeMaxConcurrentRaw = "",
+                perTypeAutoTuneEnabled = true,
+                perTypeAutoTuneMinConcurrent = 1,
+                dynamicConcurrencyEnabled = true,
+                dynamicMinConcurrent = 2,
+                dynamicBacklogPerSlot = 25,
+            )
+        org.mockito.Mockito
+            .`when`(
+                fixture.taskRepository.countByStatusAndNextRetryAtLessThanEqual(
+                    pendingStatus(),
+                    anyInstant(),
+                ),
+            ).thenReturn(200L)
+
+        val availableSlots = invokeResolveAvailableWorkerSlots(fixture.job)
+
+        assertThat(availableSlots).isEqualTo(8)
+    }
+
+    @Test
+    @DisplayName("dynamic concurrency는 ready backlog count 실패 시 최대 동시성으로 fallback한다")
+    fun `dynamic concurrency falls back to max slots when ready backlog count fails`() {
+        val fixture =
+            createFixture(
+                maxConcurrent = 8,
+                perTypeMaxConcurrentRaw = "",
+                perTypeAutoTuneEnabled = true,
+                perTypeAutoTuneMinConcurrent = 1,
+                dynamicConcurrencyEnabled = true,
+                dynamicMinConcurrent = 2,
+                dynamicBacklogPerSlot = 25,
+            )
+        org.mockito.Mockito
+            .`when`(
+                fixture.taskRepository.countByStatusAndNextRetryAtLessThanEqual(
+                    pendingStatus(),
+                    anyInstant(),
+                ),
+            ).thenThrow(IllegalStateException("count failed"))
+
+        val availableSlots = invokeResolveAvailableWorkerSlots(fixture.job)
+
+        assertThat(availableSlots).isEqualTo(8)
+    }
+
+    @Test
+    @DisplayName("dynamic concurrency는 active worker 수를 차감한 남은 slot만 claim한다")
+    fun `dynamic concurrency subtracts active workers from target slots`() {
+        val fixture =
+            createFixture(
+                maxConcurrent = 8,
+                perTypeMaxConcurrentRaw = "",
+                perTypeAutoTuneEnabled = true,
+                perTypeAutoTuneMinConcurrent = 1,
+                dynamicConcurrencyEnabled = true,
+                dynamicMinConcurrent = 2,
+                dynamicBacklogPerSlot = 25,
+            )
+        org.mockito.Mockito
+            .`when`(
+                fixture.taskRepository.countByStatusAndNextRetryAtLessThanEqual(
+                    pendingStatus(),
+                    anyInstant(),
+                ),
+            ).thenReturn(200L)
+        acquireWorkerSlots(fixture.job, 3)
+
+        val availableSlots = invokeResolveAvailableWorkerSlots(fixture.job)
+
+        assertThat(availableSlots).isEqualTo(5)
+    }
+
+    @Test
+    @DisplayName("dynamic concurrency off는 ready backlog count 없이 고정 worker 동시성을 사용한다")
+    fun `fixed concurrency ignores ready backlog count`() {
+        val fixture =
+            createFixture(
+                maxConcurrent = 8,
+                perTypeMaxConcurrentRaw = "",
+                perTypeAutoTuneEnabled = true,
+                perTypeAutoTuneMinConcurrent = 1,
+                dynamicConcurrencyEnabled = false,
+                dynamicMinConcurrent = 2,
+                dynamicBacklogPerSlot = 25,
             )
 
-        invokeResolveAvailableWorkerSlots(fixture.job)
-        invokeResolveFetchLimit(fixture.job, safeBatchSize = 50, availableWorkerSlots = 8)
+        val availableSlots = invokeResolveAvailableWorkerSlots(fixture.job)
 
+        assertThat(availableSlots).isEqualTo(8)
         verifyNoInteractions(fixture.taskRepository)
+    }
+
+    @Test
+    @DisplayName("dynamic batch size는 backlog step과 max prefetch multiplier를 fetch limit에 반영한다")
+    fun `dynamic batch size expands fetch limit by backlog prefetch multiplier`() {
+        val fixture =
+            createFixture(
+                maxConcurrent = 8,
+                perTypeMaxConcurrentRaw = "",
+                perTypeAutoTuneEnabled = true,
+                perTypeAutoTuneMinConcurrent = 1,
+                dynamicBatchBacklogPerStep = 100,
+                dynamicBatchMaxPrefetchMultiplier = 3,
+            )
+        org.mockito.Mockito
+            .`when`(
+                fixture.taskRepository.countByStatusAndNextRetryAtLessThanEqual(
+                    pendingStatus(),
+                    anyInstant(),
+                ),
+            ).thenReturn(250L)
+
+        val fetchLimit = invokeResolveFetchLimit(fixture.job, safeBatchSize = 50, availableWorkerSlots = 4)
+
+        assertThat(fetchLimit).isEqualTo(12)
+        verify(fixture.taskRepository)
+            .countByStatusAndNextRetryAtLessThanEqual(pendingStatus(), anyInstant())
+    }
+
+    @Test
+    @DisplayName("dynamic batch prefetch가 커져도 실제 시작 worker는 dynamic target을 넘지 않는다")
+    fun `dynamic batch prefetch does not start more workers than dynamic target`() {
+        val startedWorkers = AtomicInteger(0)
+        val releaseWorkers = CountDownLatch(1)
+        val taskType = "test.dynamic-prefetch"
+        val payload = ObjectMapper().writeValueAsString(StubPayload())
+        val tasks =
+            (1L..10L).map { id ->
+                Task(
+                    id = id,
+                    uid = UUID.randomUUID(),
+                    aggregateType = "test",
+                    aggregateId = id,
+                    taskType = taskType,
+                    payload = payload,
+                )
+            }
+        val fixture =
+            createFixture(
+                maxConcurrent = 8,
+                perTypeMaxConcurrentRaw = "",
+                perTypeAutoTuneEnabled = false,
+                perTypeAutoTuneMinConcurrent = 1,
+                dynamicConcurrencyEnabled = true,
+                dynamicMinConcurrent = 1,
+                dynamicBacklogPerSlot = 2,
+                dynamicBatchBacklogPerStep = 5,
+                dynamicBatchMaxPrefetchMultiplier = 2,
+                handlerEntries = listOf(blockingTaskHandlerEntry(taskType, startedWorkers, releaseWorkers)),
+            )
+        org.mockito.Mockito
+            .`when`(
+                fixture.taskRepository.countByStatusAndNextRetryAtLessThanEqual(
+                    pendingStatus(),
+                    anyInstant(),
+                ),
+            ).thenReturn(10L)
+        org.mockito.Mockito
+            .`when`(fixture.taskRepository.findPendingTasksWithLock(10))
+            .thenReturn(tasks)
+        tasks.forEach { task ->
+            org.mockito.Mockito
+                .`when`(fixture.taskRepository.findById(task.id))
+                .thenReturn(Optional.of(task))
+        }
+
+        try {
+            fixture.job.processTasks()
+            waitUntilWorkerCount(startedWorkers, expected = 5)
+
+            assertThat(startedWorkers.get()).isEqualTo(5)
+            assertThat(tasks.count { it.status == TaskStatus.PENDING }).isEqualTo(5)
+        } finally {
+            releaseWorkers.countDown()
+            fixture.job.shutdownExecutor()
+        }
     }
 
     @Test
@@ -100,12 +310,18 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
         perTypeMaxConcurrentRaw: String,
         perTypeAutoTuneEnabled: Boolean,
         perTypeAutoTuneMinConcurrent: Int,
+        dynamicConcurrencyEnabled: Boolean = true,
+        dynamicMinConcurrent: Int = 2,
+        dynamicBacklogPerSlot: Int = 25,
     ): TaskProcessingScheduledJob =
         createFixture(
             maxConcurrent = maxConcurrent,
             perTypeMaxConcurrentRaw = perTypeMaxConcurrentRaw,
             perTypeAutoTuneEnabled = perTypeAutoTuneEnabled,
             perTypeAutoTuneMinConcurrent = perTypeAutoTuneMinConcurrent,
+            dynamicConcurrencyEnabled = dynamicConcurrencyEnabled,
+            dynamicMinConcurrent = dynamicMinConcurrent,
+            dynamicBacklogPerSlot = dynamicBacklogPerSlot,
         ).job
 
     private fun createFixture(
@@ -114,6 +330,12 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
         perTypeAutoTuneEnabled: Boolean,
         perTypeAutoTuneMinConcurrent: Int,
         registeredTaskTypes: List<String> = emptyList(),
+        dynamicConcurrencyEnabled: Boolean = true,
+        dynamicMinConcurrent: Int = 2,
+        dynamicBacklogPerSlot: Int = 25,
+        dynamicBatchBacklogPerStep: Int = 120,
+        dynamicBatchMaxPrefetchMultiplier: Int = 2,
+        handlerEntries: List<TaskHandlerEntry> = emptyList(),
     ): JobFixture {
         val taskRepository = mock(TaskRepository::class.java)
         val taskHandlerRegistry = mock(TaskHandlerRegistry::class.java)
@@ -122,25 +344,30 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
                 .`when`(taskHandlerRegistry.getRegisteredEntries())
                 .thenReturn(registeredTaskTypes.map { taskType -> taskHandlerEntry(taskType) })
         }
+        handlerEntries.forEach { entry ->
+            org.mockito.Mockito
+                .`when`(taskHandlerRegistry.getEntry(entry.taskType))
+                .thenReturn(entry)
+        }
 
         val job =
             TaskProcessingScheduledJob(
                 taskRepository = taskRepository,
                 taskHandlerRegistry = taskHandlerRegistry,
-                transactionTemplate = TransactionTemplate(mock(PlatformTransactionManager::class.java)),
+                transactionTemplate = TransactionTemplate(NoopTransactionManager()),
                 objectMapper = ObjectMapper(),
                 batchSize = 50,
                 processingTimeoutSeconds = 900,
                 maxConcurrent = maxConcurrent,
                 handlerTimeoutSeconds = 120,
-                dynamicConcurrencyEnabled = true,
-                dynamicMinConcurrent = 2,
-                dynamicBacklogPerSlot = 25,
+                dynamicConcurrencyEnabled = dynamicConcurrencyEnabled,
+                dynamicMinConcurrent = dynamicMinConcurrent,
+                dynamicBacklogPerSlot = dynamicBacklogPerSlot,
                 dynamicBatchSizeEnabled = true,
                 dynamicBatchMinSize = 4,
-                dynamicBatchBacklogPerStep = 120,
+                dynamicBatchBacklogPerStep = dynamicBatchBacklogPerStep,
                 dynamicBatchTargetHandlerDurationMs = 900,
-                dynamicBatchMaxPrefetchMultiplier = 2,
+                dynamicBatchMaxPrefetchMultiplier = dynamicBatchMaxPrefetchMultiplier,
                 perTypeMaxConcurrentRaw = perTypeMaxConcurrentRaw,
                 perTypeAutoTuneEnabled = perTypeAutoTuneEnabled,
                 perTypeAutoTuneMinConcurrent = perTypeAutoTuneMinConcurrent,
@@ -168,13 +395,73 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
             retryPolicy = TaskRetryPolicy.fallback(taskType),
         )
 
+    private fun blockingTaskHandlerEntry(
+        taskType: String,
+        startedWorkers: AtomicInteger,
+        releaseWorkers: CountDownLatch,
+    ): TaskHandlerEntry {
+        val handler = BlockingHandler(startedWorkers, releaseWorkers)
+        return TaskHandlerEntry(
+            taskType = taskType,
+            payloadClass = StubPayload::class.java,
+            handlerMethod =
+                TaskHandlerMethod(
+                    bean = handler,
+                    method =
+                        BlockingHandler::class.java.getDeclaredMethod(
+                            "handle",
+                            StubPayload::class.java,
+                        ),
+                ),
+            retryPolicy = TaskRetryPolicy.fallback(taskType),
+        )
+    }
+
+    private class BlockingHandler(
+        private val startedWorkers: AtomicInteger,
+        private val releaseWorkers: CountDownLatch,
+    ) {
+        fun handle(payload: StubPayload) {
+            startedWorkers.incrementAndGet()
+            releaseWorkers.await(5, TimeUnit.SECONDS)
+        }
+    }
+
+    private class NoopTransactionManager : PlatformTransactionManager {
+        override fun getTransaction(definition: TransactionDefinition?): TransactionStatus = SimpleTransactionStatus()
+
+        override fun commit(status: TransactionStatus) = Unit
+
+        override fun rollback(status: TransactionStatus) = Unit
+    }
+
     @Suppress("unused")
     private fun handleStubPayload(payload: StubPayload) = Unit
+
+    private fun waitUntilWorkerCount(
+        startedWorkers: AtomicInteger,
+        expected: Int,
+    ) {
+        repeat(40) {
+            if (startedWorkers.get() >= expected) return
+            Thread.sleep(25)
+        }
+    }
 
     private fun invokeResolveAvailableWorkerSlots(job: TaskProcessingScheduledJob): Int {
         val method = TaskProcessingScheduledJob::class.java.getDeclaredMethod("resolveAvailableWorkerSlots")
         method.isAccessible = true
         return method.invoke(job) as Int
+    }
+
+    private fun acquireWorkerSlots(
+        job: TaskProcessingScheduledJob,
+        permits: Int,
+    ) {
+        val field = TaskProcessingScheduledJob::class.java.getDeclaredField("concurrencyGate")
+        field.isAccessible = true
+        val gate = field.get(job) as Semaphore
+        gate.acquire(permits)
     }
 
     private fun invokeResolveFetchLimit(
@@ -205,5 +492,15 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
         val method = TaskProcessingScheduledJob::class.java.getDeclaredMethod("resolvePerTypeLimit", String::class.java)
         method.isAccessible = true
         return method.invoke(job, taskType) as Int
+    }
+
+    private fun anyInstant(): Instant {
+        any(Instant::class.java)
+        return Instant.EPOCH
+    }
+
+    private fun pendingStatus(): TaskStatus {
+        eq(TaskStatus.PENDING)
+        return TaskStatus.PENDING
     }
 }


### PR DESCRIPTION
## 관련 이슈

close #877

## 작업 배경

- `TaskProcessingScheduledJob`의 dynamic concurrency 분기가 on/off 모두 `workerConcurrency`를 반환해 운영 설정 변경이 claim/dispatch 용량에 반영되지 않았다.
- `dynamicBatchBacklogPerStep`, `dynamicBatchMaxPrefetchMultiplier`도 fetch limit 계산에 쓰이지 않아 설정 파일과 런타임 동작이 불일치했다.

## 작업 내용

- dynamic on 상태에서 ready backlog, `dynamicMinConcurrent`, `dynamicBacklogPerSlot`, active worker 수를 반영해 남은 worker slot을 계산하도록 수정했다.
- dynamic batch size 계산에 backlog step 기반 prefetch multiplier를 반영해 `dynamicBatchBacklogPerStep`, `dynamicBatchMaxPrefetchMultiplier` 설정이 fetch limit에 영향을 주도록 했다.
- dynamic off, backlog min/max 확장, active worker 차감, dynamic batch prefetch, 기존 per-type limit 보장 테스트를 추가/보강했다.

## 검증

- 실행한 명령과 결과:
- `back/gradlew -p back test --tests '*TaskProcessingScheduledJobPerTypeLimitTest*'` 실패 확인: dynamic batch prefetch RED 케이스가 기존 구현에서 실패.
- `back/gradlew -p back test --tests '*TaskProcessingScheduledJobPerTypeLimitTest*'` 성공.
- `back/gradlew -p back test --tests '*TaskProcessingScheduledJob*'` 성공.
- `back/gradlew -p back ktlintCheck` 성공.
- `back/gradlew -p back ciFastCheck` 성공.
- `back/gradlew -p back ciFastCheck` 재실행 성공: Gradle up-to-date 상태로 전체 태스크 성공.
- pre-commit OpenAPI export 및 `yarn contracts:check` 성공.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
- `resolveAvailableWorkerSlots`의 dynamic target concurrency 계산이 issue #877의 min/max/backlog/active worker 계약과 맞는지 확인해 주세요.
- `resolveFetchLimit`은 실행 동시성을 늘리지 않고 조회 한도만 prefetch multiplier로 확장합니다. 실제 실행 slot은 기존 `concurrencyGate`와 per-type permit이 계속 제한합니다.

## 리스크

- dynamic batch prefetch가 backlog가 큰 상황에서 한 tick의 조회 수를 기존보다 늘릴 수 있다. 단, `batchSize`, `availableWorkerSlots * dynamicBatchMaxPrefetchMultiplier`, latency factor로 상한을 제한했다.
- ready backlog count가 dynamic concurrency와 dynamic batch 계산에서 각각 호출될 수 있다. 현재 범위에서는 운영 설정 반영을 우선했고, 필요 시 후속 PR에서 tick 단위 snapshot으로 중복 count를 줄일 수 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
