### PR TITLE
[Fix] 태스크 timeout 후 중복 side effect 방지

### DIFF
--- a/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt
+++ b/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt
@@ -1,6 +1,8 @@
 package com.back.global.task.adapter.scheduler
 
 import com.back.global.task.adapter.persistence.TaskRepository
+import com.back.global.task.application.TaskExecutionContext
+import com.back.global.task.application.TaskExecutionContextHolder
 import com.back.global.task.application.TaskHandlerEntry
 import com.back.global.task.application.TaskHandlerRegistry
 import com.back.global.task.domain.Task
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.support.TransactionTemplate
 import tools.jackson.databind.ObjectMapper
 import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
@@ -91,14 +94,17 @@ class TaskProcessingScheduledJob(
     @Volatile
     private var perTypeDynamicRefreshedAtEpochMs: Long = 0
 
-    private data class TaskExecutionContext(
+    private data class LoadedTaskExecution(
         val taskId: Long,
+        val taskUid: UUID,
+        val leaseToken: UUID,
         val taskType: String,
         val payload: String,
     )
 
     private data class TaskDispatchSlot(
         val taskId: Long,
+        val leaseToken: UUID,
         val taskType: String,
     )
 
@@ -126,30 +132,32 @@ class TaskProcessingScheduledJob(
             transactionTemplate.execute {
                 val pendingTasks = taskRepository.findPendingTasksWithLock(fetchLimit)
                 val dispatchableTasks = selectDispatchableTasks(pendingTasks, availableWorkerSlots)
-                dispatchableTasks.forEach { it.markAsProcessing() }
-                dispatchableTasks.map { TaskDispatchSlot(it.id, it.taskType) }
+                dispatchableTasks.map {
+                    val leaseToken = it.markAsProcessing()
+                    TaskDispatchSlot(it.id, leaseToken, it.taskType)
+                }
             } ?: emptyList()
 
         var dispatchedWorkers = 0
         dispatchSlots.forEach { slot ->
             if (dispatchedWorkers >= availableWorkerSlots) {
-                revertTaskToPending(slot.taskId)
+                revertTaskToPending(slot.taskId, slot.leaseToken)
                 return@forEach
             }
             if (!concurrencyGate.tryAcquire()) {
-                revertTaskToPending(slot.taskId)
+                revertTaskToPending(slot.taskId, slot.leaseToken)
                 return@forEach
             }
             if (!tryAcquirePerTypePermit(slot.taskType)) {
                 concurrencyGate.release()
-                revertTaskToPending(slot.taskId)
+                revertTaskToPending(slot.taskId, slot.leaseToken)
                 return@forEach
             }
 
             dispatchedWorkers++
             executor.submit {
                 try {
-                    executeTask(slot.taskId)
+                    executeTask(slot.taskId, slot.leaseToken)
                 } finally {
                     releasePerTypePermit(slot.taskType)
                     concurrencyGate.release()
@@ -377,45 +385,60 @@ class TaskProcessingScheduledJob(
         }
     }
 
-    private fun executeTask(taskId: Long) =
-        run {
-            val context = loadTaskExecutionContext(taskId) ?: return
-            val entry = taskHandlerRegistry.getEntry(context.taskType)
-            val startedAtNanos = System.nanoTime()
+    private fun executeTask(
+        taskId: Long,
+        leaseToken: UUID,
+    ) = run {
+        val context = loadTaskExecutionContext(taskId, leaseToken) ?: return
+        val entry = taskHandlerRegistry.getEntry(context.taskType)
+        val startedAtNanos = System.nanoTime()
 
-            if (entry == null) {
-                logger.warn("No handler found for task type: {}", context.taskType)
-                markTaskFailed(taskId, context.taskType, "No handler found")
-                return
-            }
-
-            try {
-                val payload = objectMapper.readValue(context.payload, entry.payloadClass) as TaskPayload
-                invokeHandlerWithTimeout(context.taskId, context.taskType, entry, payload)
-                markTaskCompleted(taskId, context.taskType)
-                recordTaskDuration(context.taskType, startedAtNanos)
-            } catch (exception: TimeoutException) {
-                logger.error(
-                    "Task handler timeout: {} (type={}, timeoutSeconds={})",
-                    taskId,
-                    context.taskType,
-                    handlerTimeoutSeconds,
-                )
-                markTaskFailed(taskId, context.taskType, "Task handler timed out after ${handlerTimeoutSeconds}s")
-                recordTaskDuration(context.taskType, startedAtNanos)
-            } catch (exception: Exception) {
-                val rootCause = exception.cause ?: exception
-                logger.error("Task failed: {} (type={})", taskId, context.taskType, rootCause)
-                markTaskFailed(taskId, context.taskType, rootCause.message ?: rootCause::class.simpleName)
-                recordTaskDuration(context.taskType, startedAtNanos)
-            }
+        if (entry == null) {
+            logger.warn("No handler found for task type: {}", context.taskType)
+            markTaskFailed(taskId, context.leaseToken, context.taskType, "No handler found")
+            return
         }
 
-    private fun loadTaskExecutionContext(taskId: Long): TaskExecutionContext? =
+        try {
+            val payload = objectMapper.readValue(context.payload, entry.payloadClass) as TaskPayload
+            invokeHandlerWithTimeout(context, entry, payload)
+            markTaskCompleted(taskId, context.leaseToken, context.taskType)
+            recordTaskDuration(context.taskType, startedAtNanos)
+        } catch (exception: TimeoutException) {
+            logger.error(
+                "Task handler timeout: {} (type={}, timeoutSeconds={})",
+                taskId,
+                context.taskType,
+                handlerTimeoutSeconds,
+            )
+            markTaskFailed(
+                taskId,
+                context.leaseToken,
+                context.taskType,
+                "Task handler timed out after ${handlerTimeoutSeconds}s",
+            )
+            recordTaskDuration(context.taskType, startedAtNanos)
+        } catch (exception: Exception) {
+            val rootCause = exception.cause ?: exception
+            logger.error("Task failed: {} (type={})", taskId, context.taskType, rootCause)
+            markTaskFailed(
+                taskId,
+                context.leaseToken,
+                context.taskType,
+                rootCause.message ?: rootCause::class.simpleName,
+            )
+            recordTaskDuration(context.taskType, startedAtNanos)
+        }
+    }
+
+    private fun loadTaskExecutionContext(
+        taskId: Long,
+        leaseToken: UUID,
+    ): LoadedTaskExecution? =
         transactionTemplate.execute {
             val task = taskRepository.findById(taskId).orElse(null) ?: return@execute null
-            if (task.status != TaskStatus.PROCESSING) return@execute null
-            TaskExecutionContext(task.id, task.taskType, task.payload)
+            if (!task.isCurrentExecution(leaseToken)) return@execute null
+            LoadedTaskExecution(task.id, task.uid, leaseToken, task.taskType, task.payload)
         }
 
     /**
@@ -424,15 +447,20 @@ class TaskProcessingScheduledJob(
      */
     private fun markTaskCompleted(
         taskId: Long,
+        leaseToken: UUID,
         taskType: String,
     ) {
+        var completed = false
         transactionTemplate.execute {
             val task = taskRepository.findById(taskId).orElse(null) ?: return@execute
-            if (task.status != TaskStatus.PROCESSING) return@execute
+            if (!task.isCurrentExecution(leaseToken)) return@execute
             task.markAsCompleted()
             task.errorMessage = null
+            completed = true
         }
-        recordTaskResult(taskType, "success")
+        if (completed) {
+            recordTaskResult(taskType, "success")
+        }
     }
 
     /**
@@ -441,12 +469,13 @@ class TaskProcessingScheduledJob(
      */
     private fun markTaskFailed(
         taskId: Long,
+        leaseToken: UUID,
         taskType: String,
         errorMessage: String?,
     ) {
         transactionTemplate.execute {
             val task = taskRepository.findById(taskId).orElse(null) ?: return@execute
-            if (task.status != TaskStatus.PROCESSING) return@execute
+            if (!task.isCurrentExecution(leaseToken)) return@execute
             task.errorMessage = errorMessage
             task.scheduleRetry(taskHandlerRegistry.getRetryPolicy(taskType))
             if (task.status == TaskStatus.FAILED) {
@@ -499,11 +528,15 @@ class TaskProcessingScheduledJob(
      * 작업 상태를 전이하고 실패 시 복구 가능한 상태로 보정합니다.
      * 어댑터 계층에서 외부 시스템 연동 오류를 캡슐화해 상위 계층 영향을 최소화합니다.
      */
-    private fun revertTaskToPending(taskId: Long) {
+    private fun revertTaskToPending(
+        taskId: Long,
+        leaseToken: UUID,
+    ) {
         transactionTemplate.execute {
             val task = taskRepository.findById(taskId).orElse(null) ?: return@execute
-            if (task.status != TaskStatus.PROCESSING) return@execute
+            if (!task.isCurrentExecution(leaseToken)) return@execute
             task.status = TaskStatus.PENDING
+            task.clearProcessingLease()
         }
     }
 
@@ -512,15 +545,24 @@ class TaskProcessingScheduledJob(
      * 어댑터 계층에서 외부 시스템 연동 오류를 캡슐화해 상위 계층 영향을 최소화합니다.
      */
     private fun invokeHandlerWithTimeout(
-        taskId: Long,
-        taskType: String,
+        context: LoadedTaskExecution,
         entry: TaskHandlerEntry,
         payload: TaskPayload,
     ) {
         val timeoutSeconds = handlerTimeoutSeconds.coerceIn(5, 3600)
+        val handlerContext =
+            TaskExecutionContext(
+                taskId = context.taskId,
+                taskUid = context.taskUid,
+                taskType = context.taskType,
+                executionLeaseToken = context.leaseToken,
+                idempotencyKey = context.taskUid.toString(),
+            )
         val future =
             executor.submit<Unit> {
-                entry.handlerMethod.method.invoke(entry.handlerMethod.bean, payload)
+                TaskExecutionContextHolder.withContext(handlerContext) {
+                    entry.handlerMethod.method.invoke(entry.handlerMethod.bean, payload)
+                }
             }
 
         try {
@@ -533,8 +575,8 @@ class TaskProcessingScheduledJob(
             if (cause is Exception) throw cause
             logger.error(
                 "Task handler failed with non-exception throwable (taskId={}, taskType={})",
-                taskId,
-                taskType,
+                context.taskId,
+                context.taskType,
                 cause,
             )
             throw RuntimeException(cause)
@@ -542,8 +584,8 @@ class TaskProcessingScheduledJob(
             Thread.currentThread().interrupt()
             logger.warn(
                 "Task worker interrupted while executing handler (taskId={}, taskType={})",
-                taskId,
-                taskType,
+                context.taskId,
+                context.taskType,
             )
             throw interruptedException
         }

--- a/back/src/main/kotlin/com/back/global/task/application/TaskExecutionContextHolder.kt
+++ b/back/src/main/kotlin/com/back/global/task/application/TaskExecutionContextHolder.kt
@@ -1,0 +1,34 @@
+package com.back.global.task.application
+
+import java.util.UUID
+
+data class TaskExecutionContext(
+    val taskId: Long,
+    val taskUid: UUID,
+    val taskType: String,
+    val executionLeaseToken: UUID,
+    val idempotencyKey: String,
+)
+
+object TaskExecutionContextHolder {
+    private val currentContext = ThreadLocal<TaskExecutionContext>()
+
+    fun current(): TaskExecutionContext? = currentContext.get()
+
+    fun <T> withContext(
+        context: TaskExecutionContext,
+        block: () -> T,
+    ): T {
+        val previous = currentContext.get()
+        currentContext.set(context)
+        return try {
+            block()
+        } finally {
+            if (previous == null) {
+                currentContext.remove()
+            } else {
+                currentContext.set(previous)
+            }
+        }
+    }
+}

--- a/back/src/main/kotlin/com/back/global/task/model/Task.kt
+++ b/back/src/main/kotlin/com/back/global/task/model/Task.kt
@@ -69,6 +69,7 @@ class Task(
     var nextRetryAt: Instant = Instant.now(),
     @field:Column(columnDefinition = "TEXT")
     var errorMessage: String? = null,
+    var executionLeaseToken: UUID? = null,
 ) : BaseTime(id) {
     constructor(
         uid: UUID,
@@ -89,6 +90,7 @@ class Task(
 
     fun scheduleRetry(retryPolicy: TaskRetryPolicy) {
         retryCount++
+        executionLeaseToken = null
         if (retryCount >= maxRetries) {
             status = TaskStatus.FAILED
         } else {
@@ -100,10 +102,20 @@ class Task(
 
     fun markAsCompleted() {
         status = TaskStatus.COMPLETED
+        executionLeaseToken = null
     }
 
-    fun markAsProcessing() {
+    fun markAsProcessing(): UUID {
+        val leaseToken = UUID.randomUUID()
         status = TaskStatus.PROCESSING
+        executionLeaseToken = leaseToken
+        return leaseToken
+    }
+
+    fun isCurrentExecution(leaseToken: UUID): Boolean = status == TaskStatus.PROCESSING && executionLeaseToken == leaseToken
+
+    fun clearProcessingLease() {
+        executionLeaseToken = null
     }
 
     fun recoverFromStuckProcessing(
@@ -112,6 +124,7 @@ class Task(
     ) {
         retryCount++
         errorMessage = message
+        executionLeaseToken = null
 
         if (retryCount >= maxRetries) {
             status = TaskStatus.FAILED

--- a/back/src/main/resources/db/migration-test/V20260619_01__add_task_execution_lease_token.sql
+++ b/back/src/main/resources/db/migration-test/V20260619_01__add_task_execution_lease_token.sql
@@ -1,0 +1,2 @@
+ALTER TABLE task
+    ADD COLUMN IF NOT EXISTS execution_lease_token UUID;

--- a/back/src/main/resources/db/migration/V20260619_01__add_task_execution_lease_token.sql
+++ b/back/src/main/resources/db/migration/V20260619_01__add_task_execution_lease_token.sql
@@ -1,0 +1,2 @@
+ALTER TABLE task
+    ADD COLUMN IF NOT EXISTS execution_lease_token UUID;

--- a/back/src/test/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJobPerTypeLimitTest.kt
+++ b/back/src/test/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJobPerTypeLimitTest.kt
@@ -1,6 +1,7 @@
 package com.back.global.task.adapter.scheduler
 
 import com.back.global.task.adapter.persistence.TaskRepository
+import com.back.global.task.application.TaskExecutionContextHolder
 import com.back.global.task.application.TaskHandlerEntry
 import com.back.global.task.application.TaskHandlerMethod
 import com.back.global.task.application.TaskHandlerRegistry
@@ -12,6 +13,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
@@ -29,6 +31,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 class TaskProcessingScheduledJobPerTypeLimitTest {
     @Test
@@ -245,6 +248,173 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
     }
 
     @Test
+    @DisplayName("stale 실행은 retry 실행의 PROCESSING 상태를 완료로 확정하지 못한다")
+    fun `stale execution cannot complete retried processing task`() {
+        val taskType = "test.timeout-fencing"
+        val payload = ObjectMapper().writeValueAsString(StubPayload())
+        val task =
+            Task(
+                id = 1L,
+                uid = UUID.randomUUID(),
+                aggregateType = "test",
+                aggregateId = 1L,
+                taskType = taskType,
+                payload = payload,
+            )
+        val handler = AttemptBlockingHandler()
+        val fixture =
+            createFixture(
+                maxConcurrent = 2,
+                perTypeMaxConcurrentRaw = "",
+                perTypeAutoTuneEnabled = false,
+                perTypeAutoTuneMinConcurrent = 1,
+                dynamicConcurrencyEnabled = false,
+                handlerEntries = listOf(attemptBlockingTaskHandlerEntry(taskType, handler)),
+            )
+        org.mockito.Mockito
+            .`when`(fixture.taskRepository.findStaleProcessingTasksWithLock(anyInstant(), anyInt()))
+            .thenReturn(emptyList(), listOf(task))
+        org.mockito.Mockito
+            .`when`(fixture.taskRepository.findPendingTasksWithLock(anyInt()))
+            .thenReturn(listOf(task), listOf(task), emptyList())
+        org.mockito.Mockito
+            .`when`(fixture.taskRepository.findById(task.id))
+            .thenReturn(Optional.of(task))
+
+        try {
+            fixture.job.processTasks()
+            assertThat(handler.firstStarted.await(1, TimeUnit.SECONDS)).isTrue()
+
+            fixture.job.processTasks()
+            assertThat(handler.retryStarted.await(1, TimeUnit.SECONDS)).isTrue()
+
+            handler.releaseFirst.countDown()
+            assertThat(handler.firstReturned.await(1, TimeUnit.SECONDS)).isTrue()
+            assertStatusRemains(task, TaskStatus.PROCESSING)
+
+            assertThat(task.status).isEqualTo(TaskStatus.PROCESSING)
+
+            handler.releaseRetry.countDown()
+            waitUntilStatus(task, TaskStatus.COMPLETED)
+            assertThat(task.status).isEqualTo(TaskStatus.COMPLETED)
+        } finally {
+            handler.releaseFirst.countDown()
+            handler.releaseRetry.countDown()
+            fixture.job.shutdownExecutor()
+        }
+    }
+
+    @Test
+    @DisplayName("지연 시작 stale worker는 retry lease를 대신 실행하지 않는다")
+    fun `delayed stale worker cannot adopt retry lease`() {
+        val taskType = "test.delayed-timeout-fencing"
+        val payload = ObjectMapper().writeValueAsString(StubPayload())
+        val task =
+            Task(
+                id = 1L,
+                uid = UUID.randomUUID(),
+                aggregateType = "test",
+                aggregateId = 1L,
+                taskType = taskType,
+                payload = payload,
+            )
+        val handler = CountingBlockingHandler()
+        val firstFindStarted = CountDownLatch(1)
+        val releaseFirstFind = CountDownLatch(1)
+        val findByIdCalls = AtomicInteger(0)
+        val fixture =
+            createFixture(
+                maxConcurrent = 2,
+                perTypeMaxConcurrentRaw = "",
+                perTypeAutoTuneEnabled = false,
+                perTypeAutoTuneMinConcurrent = 1,
+                dynamicConcurrencyEnabled = false,
+                handlerEntries = listOf(countingBlockingTaskHandlerEntry(taskType, handler)),
+            )
+        org.mockito.Mockito
+            .`when`(fixture.taskRepository.findStaleProcessingTasksWithLock(anyInstant(), anyInt()))
+            .thenReturn(emptyList(), listOf(task))
+        org.mockito.Mockito
+            .`when`(fixture.taskRepository.findPendingTasksWithLock(anyInt()))
+            .thenReturn(listOf(task), listOf(task), emptyList())
+        org.mockito.Mockito
+            .`when`(fixture.taskRepository.findById(task.id))
+            .thenAnswer {
+                if (findByIdCalls.incrementAndGet() == 1) {
+                    firstFindStarted.countDown()
+                    releaseFirstFind.await(5, TimeUnit.SECONDS)
+                }
+                Optional.of(task)
+            }
+
+        try {
+            fixture.job.processTasks()
+            assertThat(firstFindStarted.await(1, TimeUnit.SECONDS)).isTrue()
+
+            fixture.job.processTasks()
+            assertThat(handler.started.await(1, TimeUnit.SECONDS)).isTrue()
+            assertThat(handler.invocations.get()).isEqualTo(1)
+
+            releaseFirstFind.countDown()
+            assertAtomicCountRemains(handler.invocations, expected = 1)
+
+            handler.release.countDown()
+            waitUntilStatus(task, TaskStatus.COMPLETED)
+            assertThat(task.status).isEqualTo(TaskStatus.COMPLETED)
+        } finally {
+            releaseFirstFind.countDown()
+            handler.release.countDown()
+            fixture.job.shutdownExecutor()
+        }
+    }
+
+    @Test
+    @DisplayName("handler는 task UID 기반 idempotency key를 실행 context에서 조회할 수 있다")
+    fun `handler can read task uid idempotency key from execution context`() {
+        val taskType = "test.execution-context"
+        val taskUid = UUID.randomUUID()
+        val payload = ObjectMapper().writeValueAsString(StubPayload(uid = taskUid))
+        val task =
+            Task(
+                id = 1L,
+                uid = taskUid,
+                aggregateType = "test",
+                aggregateId = 1L,
+                taskType = taskType,
+                payload = payload,
+            )
+        val handler = ContextCapturingHandler()
+        val fixture =
+            createFixture(
+                maxConcurrent = 1,
+                perTypeMaxConcurrentRaw = "",
+                perTypeAutoTuneEnabled = false,
+                perTypeAutoTuneMinConcurrent = 1,
+                dynamicConcurrencyEnabled = false,
+                handlerEntries = listOf(contextCapturingTaskHandlerEntry(taskType, handler)),
+            )
+        org.mockito.Mockito
+            .`when`(fixture.taskRepository.findStaleProcessingTasksWithLock(anyInstant(), anyInt()))
+            .thenReturn(emptyList())
+        org.mockito.Mockito
+            .`when`(fixture.taskRepository.findPendingTasksWithLock(anyInt()))
+            .thenReturn(listOf(task), emptyList())
+        org.mockito.Mockito
+            .`when`(fixture.taskRepository.findById(task.id))
+            .thenReturn(Optional.of(task))
+
+        try {
+            fixture.job.processTasks()
+            assertThat(handler.handled.await(1, TimeUnit.SECONDS)).isTrue()
+
+            assertThat(handler.capturedIdempotencyKey.get()).isEqualTo(taskUid.toString())
+            assertThat(TaskExecutionContextHolder.current()).isNull()
+        } finally {
+            fixture.job.shutdownExecutor()
+        }
+    }
+
+    @Test
     @DisplayName("per-type auto-tune refresh는 task type별 ready backlog count를 조회하지 않는다")
     fun `per type auto tune refresh avoids ready backlog count by task type`() {
         val fixture =
@@ -348,6 +518,9 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
             org.mockito.Mockito
                 .`when`(taskHandlerRegistry.getEntry(entry.taskType))
                 .thenReturn(entry)
+            org.mockito.Mockito
+                .`when`(taskHandlerRegistry.getRetryPolicy(entry.taskType))
+                .thenReturn(entry.retryPolicy)
         }
 
         val job =
@@ -417,6 +590,63 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
         )
     }
 
+    private fun attemptBlockingTaskHandlerEntry(
+        taskType: String,
+        handler: AttemptBlockingHandler,
+    ): TaskHandlerEntry =
+        TaskHandlerEntry(
+            taskType = taskType,
+            payloadClass = StubPayload::class.java,
+            handlerMethod =
+                TaskHandlerMethod(
+                    bean = handler,
+                    method =
+                        AttemptBlockingHandler::class.java.getDeclaredMethod(
+                            "handle",
+                            StubPayload::class.java,
+                        ),
+                ),
+            retryPolicy = TaskRetryPolicy.fallback(taskType),
+        )
+
+    private fun contextCapturingTaskHandlerEntry(
+        taskType: String,
+        handler: ContextCapturingHandler,
+    ): TaskHandlerEntry =
+        TaskHandlerEntry(
+            taskType = taskType,
+            payloadClass = StubPayload::class.java,
+            handlerMethod =
+                TaskHandlerMethod(
+                    bean = handler,
+                    method =
+                        ContextCapturingHandler::class.java.getDeclaredMethod(
+                            "handle",
+                            StubPayload::class.java,
+                        ),
+                ),
+            retryPolicy = TaskRetryPolicy.fallback(taskType),
+        )
+
+    private fun countingBlockingTaskHandlerEntry(
+        taskType: String,
+        handler: CountingBlockingHandler,
+    ): TaskHandlerEntry =
+        TaskHandlerEntry(
+            taskType = taskType,
+            payloadClass = StubPayload::class.java,
+            handlerMethod =
+                TaskHandlerMethod(
+                    bean = handler,
+                    method =
+                        CountingBlockingHandler::class.java.getDeclaredMethod(
+                            "handle",
+                            StubPayload::class.java,
+                        ),
+                ),
+            retryPolicy = TaskRetryPolicy.fallback(taskType),
+        )
+
     private class BlockingHandler(
         private val startedWorkers: AtomicInteger,
         private val releaseWorkers: CountDownLatch,
@@ -424,6 +654,52 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
         fun handle(payload: StubPayload) {
             startedWorkers.incrementAndGet()
             releaseWorkers.await(5, TimeUnit.SECONDS)
+        }
+    }
+
+    private class AttemptBlockingHandler {
+        val firstStarted = CountDownLatch(1)
+        val retryStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val releaseRetry = CountDownLatch(1)
+        val firstReturned = CountDownLatch(1)
+        private val attempts = AtomicInteger(0)
+
+        fun handle(payload: StubPayload) {
+            when (attempts.incrementAndGet()) {
+                1 -> {
+                    firstStarted.countDown()
+                    releaseFirst.await(5, TimeUnit.SECONDS)
+                    firstReturned.countDown()
+                }
+
+                2 -> {
+                    retryStarted.countDown()
+                    releaseRetry.await(5, TimeUnit.SECONDS)
+                }
+            }
+        }
+    }
+
+    private class CountingBlockingHandler {
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val invocations = AtomicInteger(0)
+
+        fun handle(payload: StubPayload) {
+            invocations.incrementAndGet()
+            started.countDown()
+            release.await(5, TimeUnit.SECONDS)
+        }
+    }
+
+    private class ContextCapturingHandler {
+        val handled = CountDownLatch(1)
+        val capturedIdempotencyKey = AtomicReference<String?>()
+
+        fun handle(payload: StubPayload) {
+            capturedIdempotencyKey.set(TaskExecutionContextHolder.current()?.idempotencyKey)
+            handled.countDown()
         }
     }
 
@@ -444,6 +720,36 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
     ) {
         repeat(40) {
             if (startedWorkers.get() >= expected) return
+            Thread.sleep(25)
+        }
+    }
+
+    private fun waitUntilStatus(
+        task: Task,
+        expected: TaskStatus,
+    ) {
+        repeat(40) {
+            if (task.status == expected) return
+            Thread.sleep(25)
+        }
+    }
+
+    private fun assertStatusRemains(
+        task: Task,
+        expected: TaskStatus,
+    ) {
+        repeat(10) {
+            assertThat(task.status).isEqualTo(expected)
+            Thread.sleep(25)
+        }
+    }
+
+    private fun assertAtomicCountRemains(
+        actual: AtomicInteger,
+        expected: Int,
+    ) {
+        repeat(10) {
+            assertThat(actual.get()).isEqualTo(expected)
             Thread.sleep(25)
         }
     }


### PR DESCRIPTION
## 🔗 Related Issue
- close #878

## 📝 Summary
- task 실행마다 `executionLeaseToken`을 발급해 stale worker가 retry worker의 `PROCESSING` 상태를 완료/실패로 확정하지 못하게 했습니다.
- handler thread에는 task UID 기반 idempotency key를 조회할 수 있는 `TaskExecutionContextHolder`를 설치했습니다.
- 운영/test Flyway migration에 `task.execution_lease_token` 컬럼을 추가했습니다.

## 🛠 Changes
- `Task.markAsProcessing()`이 새 lease token을 발급하고 완료/실패/retry/stale recovery 시 lease를 정리합니다.
- `TaskProcessingScheduledJob`의 complete/fail/revert 경로가 현재 lease owner인지 확인한 뒤 상태를 전이합니다.
- task handler 실행 중 `TaskExecutionContextHolder.current()`로 `taskId`, `taskUid`, `taskType`, `executionLeaseToken`, `idempotencyKey`를 조회할 수 있게 했습니다.
- stale 실행이 retry 실행의 PROCESSING 상태를 완료로 바꾸지 못하는 회귀 테스트와 idempotency context 테스트를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [x] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `back/gradlew -p back test --tests '*TaskProcessingScheduledJobPerTypeLimitTest.stale execution cannot complete retried processing task'` 실패 확인: 기존 구현은 stale 실행이 retry PROCESSING 상태를 COMPLETED로 확정.
- `back/gradlew -p back test --tests '*TaskProcessingScheduledJobPerTypeLimitTest.handler can read task uid idempotency key from execution context'` 실패 확인: context holder 미구현으로 compile 실패.
- `back/gradlew -p back test --tests '*TaskProcessingScheduledJobPerTypeLimitTest*'` 성공.
- `back/gradlew -p back ktlintCheck` 성공.
- `back/gradlew -p back test --tests '*TaskProcessingScheduledJob*' --tests '*Task*'` 성공.
- `back/gradlew -p back ciFastCheck` 성공.
- `back/gradlew -p back ciFastCheck` 재실행 성공: up-to-date 상태로 전체 태스크 성공.
- pre-commit OpenAPI export 및 `yarn contracts:check` 성공.

## 📸 Screenshot / API Example
- UI 변경 없음.
- handler 예시: `TaskExecutionContextHolder.current()?.idempotencyKey`로 현재 task UID 기반 idempotency key를 조회할 수 있습니다.

## ⚠️ Risk & Rollback
- 예상 리스크: `task` 테이블에 nullable UUID 컬럼이 추가됩니다. 기존 row는 null이며 새 실행부터 lease token이 발급됩니다.
- 예상 리스크: handler가 context holder를 사용하려면 worker thread 안에서만 조회해야 합니다. handler 밖에서는 `current()`가 null입니다.
- 롤백 방법: PR revert 후 필요하면 `task.execution_lease_token` 컬럼을 제거하는 별도 migration을 적용합니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
