### PR TITLE
[Fix] 태스크 UID를 payload 이벤트 기준으로 고정

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/event/PostReadModelTaskEventListener.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/event/PostReadModelTaskEventListener.kt
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
@@ -46,6 +47,7 @@ class PostReadModelTaskEventListener(
     )
     fun handle(event: PostWrittenEvent) =
         enqueueFollowupTasks(
+            sourceEventUid = event.uid,
             aggregateType = event.aggregateType,
             postId = event.aggregateId,
             beforeTags = event.beforeTags,
@@ -60,6 +62,7 @@ class PostReadModelTaskEventListener(
     )
     fun handle(event: PostModifiedEvent) =
         enqueueFollowupTasks(
+            sourceEventUid = event.uid,
             aggregateType = event.aggregateType,
             postId = event.aggregateId,
             beforeTags = event.beforeTags,
@@ -74,6 +77,7 @@ class PostReadModelTaskEventListener(
     )
     fun handle(event: PostDeletedEvent) =
         enqueueFollowupTasks(
+            sourceEventUid = event.uid,
             aggregateType = event.aggregateType,
             postId = event.aggregateId,
             beforeTags = event.beforeTags,
@@ -134,6 +138,7 @@ class PostReadModelTaskEventListener(
     }
 
     private fun enqueueFollowupTasks(
+        sourceEventUid: UUID,
         aggregateType: String,
         postId: Long,
         beforeTags: List<String>,
@@ -147,7 +152,7 @@ class PostReadModelTaskEventListener(
             enqueueTask("post.search-index.sync", aggregateType, postId) {
                 taskFacade.addToQueue(
                     PostSearchIndexSyncPayload(
-                        uid = UUID.randomUUID(),
+                        uid = taskPayloadUid(sourceEventUid, "post.search-index.sync"),
                         aggregateType = aggregateType,
                         aggregateId = postId,
                         postId = postId,
@@ -163,7 +168,7 @@ class PostReadModelTaskEventListener(
             enqueueTask("post.search-engine.mirror", aggregateType, postId) {
                 taskFacade.addToQueue(
                     PostSearchEngineMirrorPayload(
-                        uid = UUID.randomUUID(),
+                        uid = taskPayloadUid(sourceEventUid, "post.search-engine.mirror"),
                         aggregateType = aggregateType,
                         aggregateId = postId,
                         postId = postId,
@@ -179,7 +184,7 @@ class PostReadModelTaskEventListener(
             enqueueTask("post.read.prewarm", aggregateType, postId) {
                 taskFacade.addToQueue(
                     PostReadPrewarmPayload(
-                        uid = UUID.randomUUID(),
+                        uid = taskPayloadUid(sourceEventUid, "post.read.prewarm"),
                         aggregateType = aggregateType,
                         aggregateId = postId,
                         postId = postId,
@@ -190,6 +195,14 @@ class PostReadModelTaskEventListener(
             }
         }
     }
+
+    private fun taskPayloadUid(
+        sourceEventUid: UUID,
+        taskType: String,
+    ): UUID =
+        UUID.nameUUIDFromBytes(
+            "post-read-model:$sourceEventUid:$taskType".toByteArray(StandardCharsets.UTF_8),
+        )
 
     private fun enqueueTask(
         taskType: String,

--- a/back/src/main/kotlin/com/back/global/task/adapter/persistence/TaskRepository.kt
+++ b/back/src/main/kotlin/com/back/global/task/adapter/persistence/TaskRepository.kt
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import java.time.Instant
+import java.util.UUID
 
 /**
  * TaskRepository는 글로벌 모듈 영속 계층 연동을 담당하는 퍼시스턴스 어댑터입니다.
@@ -45,6 +46,8 @@ interface TaskRepository :
         stuckBefore: Instant,
         limit: Int,
     ): List<Task>
+
+    override fun existsByUid(uid: UUID): Boolean
 
     override fun countByStatus(status: TaskStatus): Long
 

--- a/back/src/main/kotlin/com/back/global/task/application/TaskFacade.kt
+++ b/back/src/main/kotlin/com/back/global/task/application/TaskFacade.kt
@@ -5,9 +5,9 @@ import com.back.global.task.application.port.output.TaskQueueRepositoryPort
 import com.back.global.task.domain.Task
 import com.back.standard.dto.TaskPayload
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import tools.jackson.databind.ObjectMapper
-import java.util.*
 
 @Service
 class TaskFacade(
@@ -23,16 +23,16 @@ class TaskFacade(
                 ?: error("No @TaskHandler registered for ${payload.javaClass.simpleName}")
 
         val task =
-            taskRepository.save(
+            saveTaskIdempotently(
                 Task(
-                    UUID.randomUUID(),
+                    payload.uid,
                     payload.aggregateType,
                     payload.aggregateId,
                     entry.taskType,
                     objectMapper.writeValueAsString(payload),
                     entry.retryPolicy.maxRetries,
                 ),
-            )
+            ) ?: return
 
         if (AppFacade.isNotProd && inlineWhenNotProd) {
             fire(payload)
@@ -40,6 +40,17 @@ class TaskFacade(
             taskRepository.save(task)
         }
     }
+
+    private fun saveTaskIdempotently(task: Task): Task? =
+        try {
+            taskRepository.save(task)
+        } catch (exception: DataIntegrityViolationException) {
+            if (taskRepository.existsByUid(task.uid)) {
+                null
+            } else {
+                throw exception
+            }
+        }
 
     fun fire(payload: TaskPayload) {
         val handler = taskHandlerRegistry.getHandler(payload.javaClass)

--- a/back/src/main/kotlin/com/back/global/task/application/port/output/TaskQueueRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/global/task/application/port/output/TaskQueueRepositoryPort.kt
@@ -4,9 +4,12 @@ import com.back.global.task.domain.Task
 import com.back.global.task.domain.TaskStatus
 import org.springframework.data.domain.Pageable
 import java.time.Instant
+import java.util.UUID
 
 interface TaskQueueRepositoryPort {
     fun save(task: Task): Task
+
+    fun existsByUid(uid: UUID): Boolean
 
     fun countByStatus(status: TaskStatus): Long
 

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/event/PostReadModelTaskEventListenerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/event/PostReadModelTaskEventListenerTest.kt
@@ -1,0 +1,209 @@
+package com.back.boundedContexts.post.adapter.event
+
+import com.back.boundedContexts.member.dto.MemberDto
+import com.back.boundedContexts.post.application.service.PostReadPrewarmService
+import com.back.boundedContexts.post.application.service.PostSearchEngineMirrorService
+import com.back.boundedContexts.post.application.service.PostSearchIndexSyncService
+import com.back.boundedContexts.post.dto.PostDto
+import com.back.boundedContexts.post.dto.PostReadPrewarmPayload
+import com.back.boundedContexts.post.dto.PostSearchEngineMirrorPayload
+import com.back.boundedContexts.post.dto.PostSearchIndexSyncPayload
+import com.back.boundedContexts.post.event.PostWrittenEvent
+import com.back.global.task.application.TaskFacade
+import com.back.global.task.application.TaskHandlerEntry
+import com.back.global.task.application.TaskHandlerMethod
+import com.back.global.task.application.TaskHandlerRegistry
+import com.back.global.task.application.TaskRetryPolicy
+import com.back.global.task.application.port.output.TaskQueueRepositoryPort
+import com.back.global.task.domain.Task
+import com.back.global.task.domain.TaskStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.springframework.data.domain.Pageable
+import tools.jackson.databind.ObjectMapper
+import java.time.Instant
+import java.util.UUID
+
+class PostReadModelTaskEventListenerTest {
+    @Test
+    @DisplayName("같은 source event는 task type별 deterministic task UID를 enqueue한다")
+    fun `same source event enqueues deterministic task uid per task type`() {
+        val repository = RecordingTaskQueueRepository()
+        val listener =
+            createListener(
+                taskFacade = TaskFacade(repository, createTaskHandlerRegistry(), ObjectMapper(), inlineWhenNotProd = false),
+            )
+        val event = postWrittenEvent(sourceEventUid = UUID.randomUUID())
+
+        listener.handle(event)
+        listener.handle(event)
+
+        val firstDelivery = repository.savedTasks.take(3)
+        val secondDelivery = repository.savedTasks.drop(3)
+        assertThat(firstDelivery).hasSize(3)
+        assertThat(secondDelivery).hasSize(3)
+        assertThat(firstDelivery.map { it.taskType }).containsExactly(
+            "post.search-index.sync",
+            "post.search-engine.mirror",
+            "post.read.prewarm",
+        )
+        assertThat(secondDelivery.map { it.taskType }).containsExactlyElementsOf(firstDelivery.map { it.taskType })
+        assertThat(secondDelivery.map { it.uid }).containsExactlyElementsOf(firstDelivery.map { it.uid })
+        assertThat(firstDelivery.map { it.uid }.toSet()).hasSize(3)
+    }
+
+    private fun createListener(taskFacade: TaskFacade): PostReadModelTaskEventListener =
+        PostReadModelTaskEventListener(
+            taskFacade = taskFacade,
+            postSearchIndexSyncService = mock(PostSearchIndexSyncService::class.java),
+            postSearchEngineMirrorService = mock(PostSearchEngineMirrorService::class.java),
+            postReadPrewarmService = mock(PostReadPrewarmService::class.java),
+            meterRegistry = null,
+            asyncSearchIndexSyncEnabled = true,
+            searchIndexMaxLagSeconds = 120,
+            searchEngineMirrorEnabled = true,
+            prewarmEnabled = true,
+        )
+
+    private fun createTaskHandlerRegistry(): TaskHandlerRegistry {
+        val registry = TaskHandlerRegistry()
+        val listener = createListener(taskFacade = mock(TaskFacade::class.java))
+        registerPayload(registry, "post.search-index.sync", PostSearchIndexSyncPayload::class.java, listener)
+        registerPayload(registry, "post.search-engine.mirror", PostSearchEngineMirrorPayload::class.java, listener)
+        registerPayload(registry, "post.read.prewarm", PostReadPrewarmPayload::class.java, listener)
+        return registry
+    }
+
+    private fun registerPayload(
+        registry: TaskHandlerRegistry,
+        taskType: String,
+        payloadClass: Class<out com.back.standard.dto.TaskPayload>,
+        listener: PostReadModelTaskEventListener,
+    ) {
+        registry.register(
+            taskType,
+            TaskHandlerEntry(
+                taskType = taskType,
+                payloadClass = payloadClass,
+                handlerMethod =
+                    TaskHandlerMethod(
+                        bean = listener,
+                        method = PostReadModelTaskEventListener::class.java.getDeclaredMethod("handle", payloadClass),
+                    ),
+                retryPolicy = TaskRetryPolicy.fallback(taskType),
+            ),
+        )
+    }
+
+    private fun postWrittenEvent(sourceEventUid: UUID): PostWrittenEvent =
+        PostWrittenEvent(
+            uid = sourceEventUid,
+            postDto =
+                PostDto(
+                    id = 10L,
+                    createdAt = Instant.EPOCH,
+                    modifiedAt = Instant.EPOCH,
+                    authorId = 1L,
+                    authorName = "author",
+                    authorUsername = "author",
+                    authorProfileImgUrl = "",
+                    title = "title",
+                    summary = "summary",
+                    version = 1L,
+                    published = true,
+                    listed = true,
+                    likesCount = 0,
+                    commentsCount = 0,
+                    hitCount = 0,
+                ),
+            actorDto =
+                MemberDto(
+                    id = 1L,
+                    createdAt = Instant.EPOCH,
+                    modifiedAt = Instant.EPOCH,
+                    isAdmin = false,
+                    name = "author",
+                    profileImageUrl = "",
+                ),
+            afterTags = listOf("kotlin", "spring"),
+        )
+
+    private class RecordingTaskQueueRepository : TaskQueueRepositoryPort {
+        val savedTasks = mutableListOf<Task>()
+
+        override fun save(task: Task): Task {
+            savedTasks += task
+            return task
+        }
+
+        override fun existsByUid(uid: UUID): Boolean = savedTasks.any { it.uid == uid }
+
+        override fun countByStatus(status: TaskStatus): Long = unsupported()
+
+        override fun countByStatusAndNextRetryAtLessThanEqual(
+            status: TaskStatus,
+            nextRetryAt: Instant,
+        ): Long = unsupported()
+
+        override fun countByStatusAndModifiedAtBefore(
+            status: TaskStatus,
+            modifiedAt: Instant,
+        ): Long = unsupported()
+
+        override fun countByTaskTypeAndStatus(
+            taskType: String,
+            status: TaskStatus,
+        ): Long = unsupported()
+
+        override fun countByTaskTypeAndStatusAndNextRetryAtLessThanEqual(
+            taskType: String,
+            status: TaskStatus,
+            nextRetryAt: Instant,
+        ): Long = unsupported()
+
+        override fun countByTaskTypeAndStatusAndModifiedAtBefore(
+            taskType: String,
+            status: TaskStatus,
+            modifiedAt: Instant,
+        ): Long = unsupported()
+
+        override fun findByStatusAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
+            status: TaskStatus,
+            nextRetryAt: Instant,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByStatusOrderByModifiedAtAsc(
+            status: TaskStatus,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByStatusOrderByModifiedAtDesc(
+            status: TaskStatus,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByStatusAndModifiedAtBeforeOrderByModifiedAtAsc(
+            status: TaskStatus,
+            modifiedAt: Instant,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByTaskTypeAndStatusAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
+            taskType: String,
+            status: TaskStatus,
+            nextRetryAt: Instant,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByTaskTypeAndStatusOrderByModifiedAtDesc(
+            taskType: String,
+            status: TaskStatus,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        private fun <T> unsupported(): T = throw UnsupportedOperationException("not needed in this test")
+    }
+}

--- a/back/src/test/kotlin/com/back/global/task/application/TaskFacadeTest.kt
+++ b/back/src/test/kotlin/com/back/global/task/application/TaskFacadeTest.kt
@@ -1,0 +1,191 @@
+package com.back.global.task.application
+
+import com.back.global.app.application.AppFacade
+import com.back.global.task.application.port.output.TaskQueueRepositoryPort
+import com.back.global.task.domain.Task
+import com.back.global.task.domain.TaskStatus
+import com.back.standard.dto.TaskPayload
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.springframework.core.env.Environment
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.data.domain.Pageable
+import tools.jackson.databind.ObjectMapper
+import java.time.Instant
+import java.util.UUID
+
+class TaskFacadeTest {
+    @Test
+    @DisplayName("addToQueue는 payload UID를 task UID로 고정한다")
+    fun `add to queue uses payload uid as task uid`() {
+        val repository = InMemoryTaskQueueRepository()
+        val facade = createFacade(repository)
+        val payloadUid = UUID.randomUUID()
+
+        facade.addToQueue(StubTaskPayload(uid = payloadUid))
+
+        assertThat(repository.savedTasks).singleElement().extracting<UUID> { it.uid }.isEqualTo(payloadUid)
+    }
+
+    @Test
+    @DisplayName("addToQueue는 같은 payload UID 중복 insert를 idempotent success로 처리한다")
+    fun `add to queue treats duplicate payload uid as idempotent success`() {
+        val repository = InMemoryTaskQueueRepository(rejectDuplicateUid = true)
+        val facade = createFacade(repository)
+        val payload = StubTaskPayload(uid = UUID.randomUUID())
+
+        facade.addToQueue(payload)
+
+        assertThatCode {
+            facade.addToQueue(payload)
+        }.doesNotThrowAnyException()
+        assertThat(repository.savedTasks).hasSize(1)
+    }
+
+    @Test
+    @DisplayName("addToQueue는 중복 payload UID에서 inline handler를 재실행하지 않는다")
+    fun `add to queue does not fire inline handler for duplicate payload uid`() {
+        val repository = InMemoryTaskQueueRepository(rejectDuplicateUid = true)
+        val handler = StubTaskHandler()
+        val facade = createFacade(repository, handler, inlineWhenNotProd = true)
+        val payload = StubTaskPayload(uid = UUID.randomUUID())
+
+        facade.addToQueue(payload)
+        facade.addToQueue(payload)
+
+        assertThat(handler.handledPayloads).containsExactly(payload)
+    }
+
+    private fun createFacade(
+        repository: InMemoryTaskQueueRepository,
+        handler: StubTaskHandler = StubTaskHandler(),
+        inlineWhenNotProd: Boolean = false,
+    ): TaskFacade {
+        val environment = mock(Environment::class.java)
+        `when`(environment.matchesProfiles("prod")).thenReturn(false)
+        val objectMapper = ObjectMapper()
+        AppFacade(environment, objectMapper)
+
+        val registry = TaskHandlerRegistry()
+        registry.register(
+            StubTaskPayload.TASK_TYPE,
+            TaskHandlerEntry(
+                taskType = StubTaskPayload.TASK_TYPE,
+                payloadClass = StubTaskPayload::class.java,
+                handlerMethod =
+                    TaskHandlerMethod(
+                        bean = handler,
+                        method = StubTaskHandler::class.java.getDeclaredMethod("handle", StubTaskPayload::class.java),
+                    ),
+                retryPolicy = TaskRetryPolicy.fallback(StubTaskPayload.TASK_TYPE),
+            ),
+        )
+        return TaskFacade(repository, registry, objectMapper, inlineWhenNotProd = inlineWhenNotProd)
+    }
+
+    private data class StubTaskPayload(
+        override val uid: UUID,
+        override val aggregateType: String = "test",
+        override val aggregateId: Long = 1L,
+    ) : TaskPayload {
+        companion object {
+            const val TASK_TYPE = "test.task-facade"
+        }
+    }
+
+    private class StubTaskHandler {
+        val handledPayloads = mutableListOf<StubTaskPayload>()
+
+        fun handle(payload: StubTaskPayload) {
+            handledPayloads += payload
+        }
+    }
+
+    private class InMemoryTaskQueueRepository(
+        private val rejectDuplicateUid: Boolean = false,
+    ) : TaskQueueRepositoryPort {
+        val savedTasks = mutableListOf<Task>()
+
+        override fun save(task: Task): Task {
+            if (rejectDuplicateUid && savedTasks.any { it.uid == task.uid && it !== task }) {
+                throw DataIntegrityViolationException("duplicate task uid")
+            }
+            if (savedTasks.none { it === task }) {
+                savedTasks += task
+            }
+            return task
+        }
+
+        override fun existsByUid(uid: UUID): Boolean = savedTasks.any { it.uid == uid }
+
+        override fun countByStatus(status: TaskStatus): Long = unsupported()
+
+        override fun countByStatusAndNextRetryAtLessThanEqual(
+            status: TaskStatus,
+            nextRetryAt: Instant,
+        ): Long = unsupported()
+
+        override fun countByStatusAndModifiedAtBefore(
+            status: TaskStatus,
+            modifiedAt: Instant,
+        ): Long = unsupported()
+
+        override fun countByTaskTypeAndStatus(
+            taskType: String,
+            status: TaskStatus,
+        ): Long = unsupported()
+
+        override fun countByTaskTypeAndStatusAndNextRetryAtLessThanEqual(
+            taskType: String,
+            status: TaskStatus,
+            nextRetryAt: Instant,
+        ): Long = unsupported()
+
+        override fun countByTaskTypeAndStatusAndModifiedAtBefore(
+            taskType: String,
+            status: TaskStatus,
+            modifiedAt: Instant,
+        ): Long = unsupported()
+
+        override fun findByStatusAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
+            status: TaskStatus,
+            nextRetryAt: Instant,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByStatusOrderByModifiedAtAsc(
+            status: TaskStatus,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByStatusOrderByModifiedAtDesc(
+            status: TaskStatus,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByStatusAndModifiedAtBeforeOrderByModifiedAtAsc(
+            status: TaskStatus,
+            modifiedAt: Instant,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByTaskTypeAndStatusAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
+            taskType: String,
+            status: TaskStatus,
+            nextRetryAt: Instant,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByTaskTypeAndStatusOrderByModifiedAtDesc(
+            taskType: String,
+            status: TaskStatus,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        private fun <T> unsupported(): T = throw UnsupportedOperationException("not needed in this test")
+    }
+}

--- a/back/src/test/kotlin/com/back/global/task/application/TaskProcessingLockDiagnosticsServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/task/application/TaskProcessingLockDiagnosticsServiceTest.kt
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.ObjectProvider
 import org.springframework.data.domain.Pageable
 import org.springframework.data.redis.core.StringRedisTemplate
 import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.stream.Stream
 
@@ -90,6 +91,8 @@ class TaskProcessingLockDiagnosticsServiceTest {
     ): TaskQueueRepositoryPort =
         object : TaskQueueRepositoryPort {
             override fun save(task: Task): Task = error("not used")
+
+            override fun existsByUid(uid: UUID): Boolean = error("not used")
 
             override fun countByStatus(status: TaskStatus): Long =
                 when (status) {

--- a/back/src/test/kotlin/com/back/global/task/application/TaskQueueDiagnosticsServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/task/application/TaskQueueDiagnosticsServiceTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Pageable
 import java.time.Instant
+import java.util.UUID
 
 class TaskQueueDiagnosticsServiceTest {
     @Test
@@ -56,6 +57,8 @@ class TaskQueueDiagnosticsServiceTest {
             private set
 
         override fun save(task: Task): Task = error("not used")
+
+        override fun existsByUid(uid: UUID): Boolean = error("not used")
 
         override fun countByStatus(status: TaskStatus): Long {
             statusCountCalls++


### PR DESCRIPTION
## 관련 이슈

close #879

## 작업 배경

- `TaskFacade.addToQueue()`가 `TaskPayload.uid` 대신 새 random UUID를 `Task.uid`로 저장해 같은 논리 작업 재전달이 중복 row로 저장될 수 있었다.
- 게시글 read model 후속 task는 source event UID를 기준으로 task type별 payload UID를 고정하지 않아 같은 이벤트 재전달 시 idempotency 경계가 흔들릴 수 있었다.

## 작업 내용

- `TaskFacade`가 `payload.uid`를 `Task.uid`로 저장하도록 변경했다.
- `Task.uid` unique 제약 충돌은 동일 UID 존재 여부 확인 후 idempotent success로 처리하고, duplicate enqueue에서는 inline handler를 재실행하지 않도록 했다.
- `PostReadModelTaskEventListener`가 source event UID와 task type 조합으로 deterministic payload UID를 생성하게 했다.
- task repository port에 `existsByUid`를 추가하고 JPA repository/fake repository 구현을 맞췄다.
- payload UID 고정, duplicate insert 처리, inline handler 재실행 방지, source event 기반 task type별 UID 고정 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
- `back/gradlew -p back test --tests '*TaskFacadeTest*' --tests '*PostReadModelTaskEventListenerTest*'` PASS
- `back/gradlew -p back ktlintCheck` PASS
- `back/gradlew -p back ciFastCheck` PASS 2회 연속
- `git commit` pre-commit hook PASS

## 리뷰어 메모

- `TaskFacade.saveTaskIdempotently()`의 duplicate 처리와 inline handler 재실행 방지 경계를 먼저 확인하면 된다.
- `PostReadModelTaskEventListener.taskPayloadUid()`는 source event UID와 task type을 함께 사용해 같은 이벤트 안의 서로 다른 후속 task UID 충돌을 피한다.

## 리스크

- 기존에 같은 payload UID로 중복 enqueue되던 작업은 이제 중복 row 대신 idempotent success로 흡수된다.
- `TaskQueueRepositoryPort` 메서드가 1개 늘어 테스트 fake 구현도 함께 변경했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
