### PR TITLE
[Fix] 게시글 후속 작업을 durable outbox로 전환

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/event/PostReadModelTaskEventListener.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/event/PostReadModelTaskEventListener.kt
@@ -147,6 +147,7 @@ class PostReadModelTaskEventListener(
         warmDetail: Boolean,
     ) {
         val normalizedAfterTags = normalizeTags(afterTags)
+        val failures = mutableListOf<Throwable>()
 
         if (asyncSearchIndexSyncEnabled) {
             enqueueTask("post.search-index.sync", aggregateType, postId) {
@@ -161,7 +162,7 @@ class PostReadModelTaskEventListener(
                         enqueuedAtEpochMs = System.currentTimeMillis(),
                     ),
                 )
-            }
+            }?.let(failures::add)
         }
 
         if (searchEngineMirrorEnabled) {
@@ -177,7 +178,7 @@ class PostReadModelTaskEventListener(
                         enqueuedAtEpochMs = System.currentTimeMillis(),
                     ),
                 )
-            }
+            }?.let(failures::add)
         }
 
         if (prewarmEnabled && warmDetail) {
@@ -192,8 +193,10 @@ class PostReadModelTaskEventListener(
                         warmDetail = warmDetail,
                     ),
                 )
-            }
+            }?.let(failures::add)
         }
+
+        if (failures.isNotEmpty()) throwEnqueueFailure(failures)
     }
 
     private fun taskPayloadUid(
@@ -209,14 +212,20 @@ class PostReadModelTaskEventListener(
         aggregateType: String,
         postId: Long,
         enqueueAction: () -> Unit,
-    ) {
+    ): Throwable? =
         runCatching(enqueueAction)
             .onSuccess {
                 meterRegistry?.counter("task.processor.enqueue.result", "taskType", taskType, "status", "success")?.increment()
             }.onFailure { exception ->
                 meterRegistry?.counter("task.processor.enqueue.result", "taskType", taskType, "status", "failed")?.increment()
                 log.warn("Failed to enqueue task: taskType={} aggregate={}:{}", taskType, aggregateType, postId, exception)
-            }
+            }.exceptionOrNull()
+
+    private fun throwEnqueueFailure(failures: List<Throwable>) {
+        val first = failures.first()
+        failures.drop(1).forEach(first::addSuppressed)
+        if (first is RuntimeException) throw first
+        throw IllegalStateException("Post read-model task enqueue failed", first)
     }
 
     private fun normalizeTags(tags: List<String>): List<String> =

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -1338,17 +1338,7 @@ class PostApplicationService(
             )
         }
 
-        val fingerprint =
-            listOf(
-                PostWriteSideEffectPayload.TASK_TYPE,
-                command.postId,
-                command.evictReason,
-                command.beforeTags.joinToString(","),
-                command.afterTags.joinToString(","),
-                command.cacheInvalidationScope.targets().joinToString(",") { it.name },
-                command.recommendationAction.name,
-            ).joinToString(":")
-        return UUID.nameUUIDFromBytes(fingerprint.toByteArray(StandardCharsets.UTF_8))
+        return command.operationUid
     }
 
     private fun buildPublicPostChangeImpacts(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -42,17 +42,19 @@ import com.back.global.event.application.EventPublisher
 import com.back.global.exception.application.AppException
 import com.back.global.security.application.HtmlContentSanitizer
 import com.back.global.storage.application.UploadedFileRetentionService
+import com.back.global.task.application.TaskFacade
 import com.back.standard.dto.EventPayload
 import com.back.standard.dto.page.PagedResult
 import com.back.standard.dto.post.type1.PostSearchSortType1
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
+import tools.jackson.databind.ObjectMapper
+import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -77,7 +79,8 @@ class PostApplicationService(
     private val postRecommendRankingService: PostRecommendRankingService,
     private val postRecommendFeatureStoreService: PostRecommendFeatureStoreService,
     private val postKeywordSearchPipelineService: PostKeywordSearchPipelineService,
-    private val applicationEventPublisher: ApplicationEventPublisher,
+    private val taskFacade: TaskFacade,
+    private val objectMapper: ObjectMapper,
     @param:Value("\${custom.post.read.tags-local-cache-ttl-seconds:180}")
     private val tagsLocalCacheTtlSeconds: Long,
 ) {
@@ -1304,7 +1307,48 @@ class PostApplicationService(
         if (command.cacheInvalidationScope.evictsPublicTags()) {
             publicTagCountsCache = null
         }
-        applicationEventPublisher.publishEvent(PostWriteAfterCommitEvent(command, domainEvent))
+        taskFacade.addToQueue(command.toTaskPayload(domainEvent), inlineWhenEnabled = false)
+    }
+
+    private fun PostWriteSideEffectCommand.toTaskPayload(domainEvent: EventPayload?): PostWriteSideEffectPayload =
+        PostWriteSideEffectPayload(
+            uid = postWriteSideEffectTaskUid(this, domainEvent),
+            aggregateType = domainEvent?.aggregateType ?: "Post",
+            aggregateId = postId,
+            postId = postId,
+            previousContent = previousContent,
+            currentContent = currentContent,
+            deletedContent = deletedContent,
+            beforeTags = beforeTags,
+            afterTags = afterTags,
+            cacheInvalidationTargets = cacheInvalidationScope.targets(),
+            evictReason = evictReason,
+            recommendationAction = recommendationAction,
+            domainEventType = domainEvent?.javaClass?.name,
+            domainEventJson = domainEvent?.let(objectMapper::writeValueAsString),
+        )
+
+    private fun postWriteSideEffectTaskUid(
+        command: PostWriteSideEffectCommand,
+        domainEvent: EventPayload?,
+    ): UUID {
+        domainEvent?.uid?.let { eventUid ->
+            return UUID.nameUUIDFromBytes(
+                "${PostWriteSideEffectPayload.TASK_TYPE}:$eventUid".toByteArray(StandardCharsets.UTF_8),
+            )
+        }
+
+        val fingerprint =
+            listOf(
+                PostWriteSideEffectPayload.TASK_TYPE,
+                command.postId,
+                command.evictReason,
+                command.beforeTags.joinToString(","),
+                command.afterTags.joinToString(","),
+                command.cacheInvalidationScope.targets().joinToString(",") { it.name },
+                command.recommendationAction.name,
+            ).joinToString(":")
+        return UUID.nameUUIDFromBytes(fingerprint.toByteArray(StandardCharsets.UTF_8))
     }
 
     private fun buildPublicPostChangeImpacts(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectCommand.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectCommand.kt
@@ -1,5 +1,38 @@
 package com.back.boundedContexts.post.application.service
 
+import com.back.global.task.annotation.Task
+import com.back.standard.dto.TaskPayload
+import java.util.UUID
+
+@Task(
+    type = PostWriteSideEffectPayload.TASK_TYPE,
+    label = "게시글 쓰기 후속 작업",
+    maxRetries = 5,
+    baseDelaySeconds = 10,
+    backoffMultiplier = 2.0,
+    maxDelaySeconds = 300,
+)
+data class PostWriteSideEffectPayload(
+    override val uid: UUID,
+    override val aggregateType: String,
+    override val aggregateId: Long,
+    val postId: Long,
+    val previousContent: String?,
+    val currentContent: String?,
+    val deletedContent: String?,
+    val beforeTags: List<String>,
+    val afterTags: List<String>,
+    val cacheInvalidationTargets: Set<PostReadCacheInvalidationTarget>,
+    val evictReason: String,
+    val recommendationAction: PostRecommendationSideEffect,
+    val domainEventType: String?,
+    val domainEventJson: String?,
+) : TaskPayload {
+    companion object {
+        const val TASK_TYPE = "post.write.side-effect"
+    }
+}
+
 internal data class PostWriteSideEffectCommand(
     val postId: Long,
     val previousContent: String?,
@@ -12,12 +45,12 @@ internal data class PostWriteSideEffectCommand(
     val recommendationAction: PostRecommendationSideEffect,
 )
 
-internal enum class PostRecommendationSideEffect {
+enum class PostRecommendationSideEffect {
     REFRESH,
     EVICT,
 }
 
-internal enum class PostReadCacheInvalidationTarget {
+enum class PostReadCacheInvalidationTarget {
     HOT_READ_PAGES,
     SEARCH_FIRST_PAGE,
     IMPACTED_TAG_PAGES,
@@ -33,7 +66,7 @@ internal enum class PostPublicChangeImpact {
 }
 
 internal sealed class PostReadCacheInvalidationScope(
-    private val targets: Set<PostReadCacheInvalidationTarget>,
+    private val targetSet: Set<PostReadCacheInvalidationTarget>,
 ) {
     data object None : PostReadCacheInvalidationScope(emptySet())
 
@@ -51,14 +84,27 @@ internal sealed class PostReadCacheInvalidationScope(
         impacts: Set<PostPublicChangeImpact>,
     ) : PostReadCacheInvalidationScope(targetsForModifiedPublicPost(impacts))
 
-    fun evicts(target: PostReadCacheInvalidationTarget): Boolean = target in targets
+    private class Explicit(
+        targets: Set<PostReadCacheInvalidationTarget>,
+    ) : PostReadCacheInvalidationScope(targets)
+
+    fun targets(): Set<PostReadCacheInvalidationTarget> = targetSet
+
+    fun evicts(target: PostReadCacheInvalidationTarget): Boolean = target in targetSet
 
     fun evictsPublicTags(): Boolean = evicts(PostReadCacheInvalidationTarget.PUBLIC_TAGS)
 
-    fun isEmpty(): Boolean = targets.isEmpty()
+    fun isEmpty(): Boolean = targetSet.isEmpty()
 
     companion object {
         private val ALL_PUBLIC_READ_TARGETS = PostReadCacheInvalidationTarget.entries.toSet()
+
+        fun fromTargets(targets: Set<PostReadCacheInvalidationTarget>): PostReadCacheInvalidationScope =
+            if (targets.isEmpty()) {
+                None
+            } else {
+                Explicit(targets)
+            }
 
         private fun targetsForModifiedPublicPost(impacts: Set<PostPublicChangeImpact>): Set<PostReadCacheInvalidationTarget> =
             buildSet {

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectCommand.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectCommand.kt
@@ -43,6 +43,7 @@ internal data class PostWriteSideEffectCommand(
     val cacheInvalidationScope: PostReadCacheInvalidationScope,
     val evictReason: String,
     val recommendationAction: PostRecommendationSideEffect,
+    val operationUid: UUID = UUID.randomUUID(),
 )
 
 enum class PostRecommendationSideEffect {

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt
@@ -167,6 +167,7 @@ class PostWriteSideEffectHandler(
             cacheInvalidationScope = PostReadCacheInvalidationScope.fromTargets(cacheInvalidationTargets),
             evictReason = evictReason,
             recommendationAction = recommendationAction,
+            operationUid = uid,
         )
 
     private fun PostWriteSideEffectPayload.toDomainEvent(): EventPayload? {

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt
@@ -6,15 +6,19 @@ import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
 import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
 import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
+import com.back.boundedContexts.post.event.PostDeletedEvent
+import com.back.boundedContexts.post.event.PostModifiedEvent
+import com.back.boundedContexts.post.event.PostWrittenEvent
 import com.back.global.event.application.EventPublisher
 import com.back.global.storage.application.UploadedFileRetentionService
+import com.back.global.task.annotation.TaskHandler
+import com.back.standard.dto.EventPayload
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
-import org.springframework.transaction.event.TransactionPhase
-import org.springframework.transaction.event.TransactionalEventListener
 import org.springframework.transaction.support.TransactionTemplate
+import tools.jackson.databind.ObjectMapper
 import kotlin.jvm.optionals.getOrNull
 
 @Component
@@ -25,6 +29,7 @@ class PostWriteSideEffectHandler(
     private val postRepository: PostRepositoryPort,
     private val postAttrRepository: PostAttrRepositoryPort,
     private val eventPublisher: EventPublisher,
+    private val objectMapper: ObjectMapper,
     transactionManager: PlatformTransactionManager,
 ) {
     private val logger = LoggerFactory.getLogger(PostWriteSideEffectHandler::class.java)
@@ -33,7 +38,21 @@ class PostWriteSideEffectHandler(
             propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
         }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    @TaskHandler
+    fun handle(payload: PostWriteSideEffectPayload) {
+        val command = payload.toCommand()
+        val failures = handle(command).toMutableList()
+        payload.toDomainEvent()?.let { domainEvent ->
+            runAfterCommitSideEffectInNewTransaction(
+                postId = command.postId,
+                failureMessage = "Failed to publish post write domain event after commit",
+            ) {
+                eventPublisher.publish(domainEvent)
+            }?.let(failures::add)
+        }
+        if (failures.isNotEmpty()) throwForTaskRetry(failures)
+    }
+
     internal fun handle(event: PostWriteAfterCommitEvent) {
         handle(event.command)
         event.domainEvent?.let { domainEvent ->
@@ -46,11 +65,14 @@ class PostWriteSideEffectHandler(
         }
     }
 
-    private fun handle(command: PostWriteSideEffectCommand) {
+    private fun handle(command: PostWriteSideEffectCommand): List<Throwable> {
+        val failures = mutableListOf<Throwable>()
+
         runCatching {
             postReadCacheInvalidator.invalidate(command.toCacheInvalidationRequest()) {}
         }.onFailure { exception ->
             logger.warn("Failed to evict post read caches after commit: postId={}", command.postId, exception)
+            failures += exception
         }
 
         command.currentContent?.let { currentContent ->
@@ -59,7 +81,7 @@ class PostWriteSideEffectHandler(
                 failureMessage = "Failed to sync post attachments after commit",
             ) {
                 uploadedFileRetentionService.syncPostContent(command.postId, command.previousContent, currentContent)
-            }
+            }?.let(failures::add)
         }
 
         command.deletedContent?.let { deletedContent ->
@@ -68,7 +90,7 @@ class PostWriteSideEffectHandler(
                 failureMessage = "Failed to schedule cleanup for deleted post after commit",
             ) {
                 uploadedFileRetentionService.scheduleDeletedPostAttachments(deletedContent)
-            }
+            }?.let(failures::add)
         }
 
         when (command.recommendationAction) {
@@ -78,7 +100,7 @@ class PostWriteSideEffectHandler(
                     failureMessage = "Failed to refresh recommend feature store after commit",
                 ) {
                     refreshRecommendFeatureStoreAfterCommit(command.postId)
-                }
+                }?.let(failures::add)
 
             PostRecommendationSideEffect.EVICT ->
                 runAfterCommitSideEffectInNewTransaction(
@@ -86,22 +108,26 @@ class PostWriteSideEffectHandler(
                     failureMessage = "Failed to evict recommend feature store after commit",
                 ) {
                     postRecommendFeatureStoreService.evict(command.postId)
-                }
+                }?.let(failures::add)
         }
+
+        return failures
     }
 
     private fun runAfterCommitSideEffectInNewTransaction(
         postId: Long,
         failureMessage: String,
         block: () -> Unit,
-    ) {
+    ): Throwable? {
         runCatching {
             afterCommitSideEffectTransactionTemplate.executeWithoutResult {
                 block()
             }
         }.onFailure { exception ->
             logger.warn("{}: postId={}", failureMessage, postId, exception)
+            return exception
         }
+        return null
     }
 
     private fun refreshRecommendFeatureStoreAfterCommit(postId: Long) {
@@ -129,4 +155,38 @@ class PostWriteSideEffectHandler(
             scope = cacheInvalidationScope,
             evictReason = evictReason,
         )
+
+    private fun PostWriteSideEffectPayload.toCommand(): PostWriteSideEffectCommand =
+        PostWriteSideEffectCommand(
+            postId = postId,
+            previousContent = previousContent,
+            currentContent = currentContent,
+            deletedContent = deletedContent,
+            beforeTags = beforeTags,
+            afterTags = afterTags,
+            cacheInvalidationScope = PostReadCacheInvalidationScope.fromTargets(cacheInvalidationTargets),
+            evictReason = evictReason,
+            recommendationAction = recommendationAction,
+        )
+
+    private fun PostWriteSideEffectPayload.toDomainEvent(): EventPayload? {
+        val eventType = domainEventType ?: return null
+        val eventJson = domainEventJson ?: return null
+        return when (eventType) {
+            PostWrittenEvent::class.java.name -> objectMapper.readValue(eventJson, PostWrittenEvent::class.java)
+            PostModifiedEvent::class.java.name -> objectMapper.readValue(eventJson, PostModifiedEvent::class.java)
+            PostDeletedEvent::class.java.name -> objectMapper.readValue(eventJson, PostDeletedEvent::class.java)
+            else -> {
+                logger.warn("post_write_side_effect_unknown_domain_event_type type={}", eventType)
+                null
+            }
+        }
+    }
+
+    private fun throwForTaskRetry(failures: List<Throwable>) {
+        val first = failures.first()
+        failures.drop(1).forEach(first::addSuppressed)
+        if (first is RuntimeException) throw first
+        throw IllegalStateException("Post write side effect failed", first)
+    }
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostDeletedEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostDeletedEvent.kt
@@ -20,8 +20,8 @@ data class PostDeletedEvent
         override val uid: UUID,
         override val aggregateType: String,
         override val aggregateId: Long,
-        @field:JsonIgnore
-        @field:JsonProperty("postDto")
+        @param:JsonProperty("postDto")
+        @get:JsonIgnore
         val postDto: PostDto,
         val actorDto: MemberDto,
         val beforeTags: List<String> = emptyList(),

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostWrittenEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostWrittenEvent.kt
@@ -20,8 +20,8 @@ data class PostWrittenEvent
         override val uid: UUID,
         override val aggregateType: String,
         override val aggregateId: Long,
-        @field:JsonIgnore
-        @JsonProperty("postDto")
+        @param:JsonProperty("postDto")
+        @get:JsonIgnore
         val postDto: PostDto,
         val actorDto: MemberDto,
         val beforeTags: List<String> = emptyList(),

--- a/back/src/main/kotlin/com/back/global/revalidate/adapter/event/CdnCachePurgeEventListener.kt
+++ b/back/src/main/kotlin/com/back/global/revalidate/adapter/event/CdnCachePurgeEventListener.kt
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 /**
@@ -28,6 +29,7 @@ class CdnCachePurgeEventListener(
     fun handle(event: PostWrittenEvent) =
         enqueue(
             aggregateType = event.aggregateType,
+            sourceEventUid = event.uid,
             postId = event.aggregateId,
             beforeTags = event.beforeTags,
             afterTags = event.afterTags,
@@ -40,6 +42,7 @@ class CdnCachePurgeEventListener(
     fun handle(event: PostModifiedEvent) =
         enqueue(
             aggregateType = event.aggregateType,
+            sourceEventUid = event.uid,
             postId = event.aggregateId,
             beforeTags = event.beforeTags,
             afterTags = event.afterTags,
@@ -52,6 +55,7 @@ class CdnCachePurgeEventListener(
     fun handle(event: PostDeletedEvent) =
         enqueue(
             aggregateType = event.aggregateType,
+            sourceEventUid = event.uid,
             postId = event.aggregateId,
             beforeTags = event.beforeTags,
             afterTags = event.afterTags,
@@ -68,6 +72,7 @@ class CdnCachePurgeEventListener(
 
     private fun enqueue(
         aggregateType: String,
+        sourceEventUid: UUID,
         postId: Long,
         beforeTags: List<String>,
         afterTags: List<String>,
@@ -77,7 +82,7 @@ class CdnCachePurgeEventListener(
         runCatching {
             taskFacade.addToQueue(
                 PurgePostReadCachesPayload(
-                    uid = UUID.randomUUID(),
+                    uid = cachePurgeTaskUid(sourceEventUid),
                     aggregateType = aggregateType,
                     aggregateId = postId,
                     postId = postId,
@@ -92,8 +97,14 @@ class CdnCachePurgeEventListener(
                 postId,
                 exception,
             )
+            throw exception
         }
     }
+
+    private fun cachePurgeTaskUid(sourceEventUid: UUID): UUID =
+        UUID.nameUUIDFromBytes(
+            "post-cdn-cache-purge:$sourceEventUid".toByteArray(StandardCharsets.UTF_8),
+        )
 
     companion object {
         private val log = LoggerFactory.getLogger(CdnCachePurgeEventListener::class.java)

--- a/back/src/main/kotlin/com/back/global/revalidate/adapter/event/RevalidateEventListener.kt
+++ b/back/src/main/kotlin/com/back/global/revalidate/adapter/event/RevalidateEventListener.kt
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 /**
@@ -26,19 +27,19 @@ class RevalidateEventListener(
         phase = TransactionPhase.AFTER_COMMIT,
         fallbackExecution = true,
     )
-    fun handle(event: PostWrittenEvent) = enqueueRevalidatePaths(event.aggregateType, event.aggregateId)
+    fun handle(event: PostWrittenEvent) = enqueueRevalidatePaths(event.uid, event.aggregateType, event.aggregateId)
 
     @TransactionalEventListener(
         phase = TransactionPhase.AFTER_COMMIT,
         fallbackExecution = true,
     )
-    fun handle(event: PostModifiedEvent) = enqueueRevalidatePaths(event.aggregateType, event.aggregateId)
+    fun handle(event: PostModifiedEvent) = enqueueRevalidatePaths(event.uid, event.aggregateType, event.aggregateId)
 
     @TransactionalEventListener(
         phase = TransactionPhase.AFTER_COMMIT,
         fallbackExecution = true,
     )
-    fun handle(event: PostDeletedEvent) = enqueueRevalidatePaths(event.aggregateType, event.aggregateId)
+    fun handle(event: PostDeletedEvent) = enqueueRevalidatePaths(event.uid, event.aggregateType, event.aggregateId)
 
     @TaskHandler
     fun handle(payload: RevalidateHomePayload) {
@@ -50,6 +51,7 @@ class RevalidateEventListener(
      * 어댑터 계층에서 외부 시스템 연동 오류를 캡슐화해 상위 계층 영향을 최소화합니다.
      */
     private fun enqueueRevalidatePaths(
+        sourceEventUid: UUID,
         aggregateType: String,
         aggregateId: Long,
     ) {
@@ -60,11 +62,12 @@ class RevalidateEventListener(
                 "/sitemap.xml",
             )
 
+        val failures = mutableListOf<Throwable>()
         pathsToRevalidate.forEach { path ->
             runCatching {
                 taskFacade.addToQueue(
                     RevalidateHomePayload(
-                        uid = UUID.randomUUID(),
+                        uid = revalidateTaskUid(sourceEventUid, path),
                         aggregateType = aggregateType,
                         aggregateId = aggregateId,
                         path = path,
@@ -78,8 +81,25 @@ class RevalidateEventListener(
                     path,
                     exception,
                 )
+                failures += exception
             }
         }
+        if (failures.isNotEmpty()) throwEnqueueFailure(failures)
+    }
+
+    private fun revalidateTaskUid(
+        sourceEventUid: UUID,
+        path: String,
+    ): UUID =
+        UUID.nameUUIDFromBytes(
+            "post-revalidate:$sourceEventUid:$path".toByteArray(StandardCharsets.UTF_8),
+        )
+
+    private fun throwEnqueueFailure(failures: List<Throwable>) {
+        val first = failures.first()
+        failures.drop(1).forEach(first::addSuppressed)
+        if (first is RuntimeException) throw first
+        throw IllegalStateException("Revalidate task enqueue failed", first)
     }
 
     companion object {

--- a/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingLockJanitor.kt
+++ b/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingLockJanitor.kt
@@ -14,6 +14,12 @@ import org.springframework.stereotype.Component
     havingValue = "true",
     matchIfMissing = true,
 )
+@ConditionalOnProperty(
+    prefix = "custom.task.processor",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
 class TaskProcessingLockJanitor(
     private val taskProcessingLockDiagnosticsService: TaskProcessingLockDiagnosticsService,
 ) {

--- a/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt
+++ b/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt
@@ -41,6 +41,12 @@ import kotlin.math.ceil
     havingValue = "true",
     matchIfMissing = true,
 )
+@ConditionalOnProperty(
+    prefix = "custom.task.processor",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
 class TaskProcessingScheduledJob(
     private val taskRepository: TaskRepository,
     private val taskHandlerRegistry: TaskHandlerRegistry,

--- a/back/src/main/kotlin/com/back/global/task/application/TaskFacade.kt
+++ b/back/src/main/kotlin/com/back/global/task/application/TaskFacade.kt
@@ -1,23 +1,28 @@
 package com.back.global.task.application
 
-import com.back.global.app.application.AppFacade
 import com.back.global.task.application.port.output.TaskQueueRepositoryPort
 import com.back.global.task.domain.Task
 import com.back.standard.dto.TaskPayload
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.env.Environment
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import tools.jackson.databind.ObjectMapper
+import java.lang.reflect.InvocationTargetException
 
 @Service
 class TaskFacade(
     private val taskRepository: TaskQueueRepositoryPort,
     private val taskHandlerRegistry: TaskHandlerRegistry,
     private val objectMapper: ObjectMapper,
+    private val environment: Environment,
     @param:Value("\${custom.task.processor.inlineWhenNotProd:false}")
     private val inlineWhenNotProd: Boolean,
 ) {
-    fun addToQueue(payload: TaskPayload) {
+    fun addToQueue(
+        payload: TaskPayload,
+        inlineWhenEnabled: Boolean = true,
+    ) {
         val entry =
             taskHandlerRegistry.getEntry(payload.javaClass)
                 ?: error("No @TaskHandler registered for ${payload.javaClass.simpleName}")
@@ -34,7 +39,7 @@ class TaskFacade(
                 ),
             ) ?: return
 
-        if (AppFacade.isNotProd && inlineWhenNotProd) {
+        if (inlineWhenEnabled && inlineWhenNotProd && !environment.matchesProfiles("prod")) {
             fire(payload)
             task.markAsCompleted()
             taskRepository.save(task)
@@ -54,6 +59,10 @@ class TaskFacade(
 
     fun fire(payload: TaskPayload) {
         val handler = taskHandlerRegistry.getHandler(payload.javaClass)
-        handler?.method?.invoke(handler.bean, payload)
+        try {
+            handler?.method?.invoke(handler.bean, payload)
+        } catch (exception: InvocationTargetException) {
+            throw exception.targetException
+        }
     }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/event/PostReadModelTaskEventListenerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/event/PostReadModelTaskEventListenerTest.kt
@@ -18,10 +18,12 @@ import com.back.global.task.application.port.output.TaskQueueRepositoryPort
 import com.back.global.task.domain.Task
 import com.back.global.task.domain.TaskStatus
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.springframework.data.domain.Pageable
+import org.springframework.mock.env.MockEnvironment
 import tools.jackson.databind.ObjectMapper
 import java.time.Instant
 import java.util.UUID
@@ -33,7 +35,7 @@ class PostReadModelTaskEventListenerTest {
         val repository = RecordingTaskQueueRepository()
         val listener =
             createListener(
-                taskFacade = TaskFacade(repository, createTaskHandlerRegistry(), ObjectMapper(), inlineWhenNotProd = false),
+                taskFacade = createTaskFacade(repository),
             )
         val event = postWrittenEvent(sourceEventUid = UUID.randomUUID())
 
@@ -54,6 +56,26 @@ class PostReadModelTaskEventListenerTest {
         assertThat(firstDelivery.map { it.uid }.toSet()).hasSize(3)
     }
 
+    @Test
+    @DisplayName("read-model task enqueue 실패는 source task retry를 위해 전파한다")
+    fun `enqueue failure propagates for source task retry`() {
+        val repository = RecordingTaskQueueRepository(failOnSave = true)
+        val listener =
+            createListener(
+                taskFacade = createTaskFacade(repository),
+            )
+
+        val thrown =
+            catchThrowable {
+                listener.handle(postWrittenEvent(sourceEventUid = UUID.randomUUID()))
+            }
+
+        assertThat(thrown)
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessage("enqueue down")
+        assertThat(thrown.suppressed).hasSize(2)
+    }
+
     private fun createListener(taskFacade: TaskFacade): PostReadModelTaskEventListener =
         PostReadModelTaskEventListener(
             taskFacade = taskFacade,
@@ -66,6 +88,19 @@ class PostReadModelTaskEventListenerTest {
             searchEngineMirrorEnabled = true,
             prewarmEnabled = true,
         )
+
+    private fun createTaskFacade(repository: RecordingTaskQueueRepository): TaskFacade {
+        val objectMapper = ObjectMapper()
+        val environment = MockEnvironment()
+        environment.setActiveProfiles("test")
+        return TaskFacade(
+            taskRepository = repository,
+            taskHandlerRegistry = createTaskHandlerRegistry(),
+            objectMapper = objectMapper,
+            environment = environment,
+            inlineWhenNotProd = false,
+        )
+    }
 
     private fun createTaskHandlerRegistry(): TaskHandlerRegistry {
         val registry = TaskHandlerRegistry()
@@ -130,10 +165,13 @@ class PostReadModelTaskEventListenerTest {
             afterTags = listOf("kotlin", "spring"),
         )
 
-    private class RecordingTaskQueueRepository : TaskQueueRepositoryPort {
+    private class RecordingTaskQueueRepository(
+        private val failOnSave: Boolean = false,
+    ) : TaskQueueRepositoryPort {
         val savedTasks = mutableListOf<Task>()
 
         override fun save(task: Task): Task {
+            if (failOnSave) throw RuntimeException("enqueue down")
             savedTasks += task
             return task
         }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
@@ -9,8 +9,12 @@ import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
 import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
 import com.back.boundedContexts.post.event.PostModifiedEvent
 import com.back.boundedContexts.post.event.PostWrittenEvent
+import com.back.global.task.adapter.persistence.TaskRepository
+import com.back.global.task.application.TaskFacade
+import com.back.global.task.model.Task
 import com.back.support.BasePostApplicationServiceAfterCommitIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
@@ -22,6 +26,7 @@ import org.mockito.Mockito.verifyNoInteractions
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.transaction.support.TransactionTemplate
+import tools.jackson.databind.ObjectMapper
 
 @DisplayName("PostApplicationService 후속 작업 AFTER_COMMIT 테스트")
 class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCommitIntegrationTest() {
@@ -33,6 +38,15 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
 
     @Autowired
     private lateinit var postAttrRepository: PostAttrRepositoryPort
+
+    @Autowired
+    private lateinit var taskRepository: TaskRepository
+
+    @Autowired
+    private lateinit var taskFacade: TaskFacade
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
 
     @Autowired
     private lateinit var transactionTemplate: TransactionTemplate
@@ -66,11 +80,12 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
     }
 
     @Test
-    @DisplayName("글 작성 트랜잭션이 commit되면 첨부파일·추천 후속 작업을 실행한다")
+    @DisplayName("글 작성 트랜잭션이 commit되면 durable task 실행으로 첨부파일·추천 후속 작업을 처리한다")
     fun writeCommitRunsSideEffects() {
         // given
         clearSideEffectMocks()
         val admin = actorApplicationService.findByEmail("admin@test.com")!!
+        val previousTaskIds = taskRepository.findAll().map { it.id }.toSet()
         val sideEffectTransactions = mutableListOf<Boolean>()
         recordActiveTransactionDuringSideEffects(sideEffectTransactions)
 
@@ -84,6 +99,12 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
                 listed = true,
             )
         }
+        val payload = singlePostWriteSideEffectPayloadSince(previousTaskIds)
+
+        clearSideEffectMocks()
+
+        // and when
+        taskFacade.fire(payload)
 
         // then
         assertThat(invokedMethodNames(uploadedFileRetentionService)).contains("syncPostContent")
@@ -93,11 +114,40 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
     }
 
     @Test
-    @DisplayName("커밋 후 캐시 축출 실패는 첨부파일·추천 후속 작업을 막지 않는다")
+    @DisplayName("글 작성 commit은 후속 작업을 durable task row로 남긴다")
+    fun writeCommitCreatesDurablePostWriteSideEffectTask() {
+        // given
+        clearSideEffectMocks()
+        val admin = actorApplicationService.findByEmail("admin@test.com")!!
+        val previousTaskIds = taskRepository.findAll().map { it.id }.toSet()
+
+        // when
+        val post =
+            transactionTemplate.execute {
+                postApplicationService.write(
+                    author = admin,
+                    title = "durable side effect source",
+                    content = "durable side effect content",
+                    published = true,
+                    listed = true,
+                )
+            }!!
+
+        // then
+        val sideEffectTasks = postWriteSideEffectTasksSince(previousTaskIds)
+        assertThat(sideEffectTasks).hasSize(1)
+        val sideEffectTask = sideEffectTasks.single()
+        assertThat(sideEffectTask.aggregateId).isEqualTo(post.id)
+        assertThat(sideEffectTask.payload).contains("\"postId\":${post.id}")
+    }
+
+    @Test
+    @DisplayName("durable task 실행 중 캐시 축출 실패는 첨부파일·추천 후속 작업 이후 retry로 전파된다")
     fun writeCommitContinuesSideEffectsWhenCacheEvictionFails() {
         // given
         clearSideEffectMocks()
         val admin = actorApplicationService.findByEmail("admin@test.com")!!
+        val previousTaskIds = taskRepository.findAll().map { it.id }.toSet()
         doThrow(RuntimeException("cache backend down"))
             .`when`(cacheManager)
             .getCache(PostQueryCacheNames.FEED)
@@ -112,6 +162,13 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
                 listed = true,
             )
         }
+        val payload = singlePostWriteSideEffectPayloadSince(previousTaskIds)
+
+        // when
+        assertThatThrownBy {
+            taskFacade.fire(payload)
+        }.isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("cache backend down")
 
         // then
         assertThat(invokedMethodNames(uploadedFileRetentionService)).contains("syncPostContent")
@@ -142,6 +199,7 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
         val refreshedCounters = mutableListOf<PostCounterSnapshot>()
         clearSideEffectMocks()
         recordRefreshedCounters(refreshedCounters)
+        val previousTaskIds = taskRepository.findAll().map { it.id }.toSet()
 
         // when
         transactionTemplate.executeWithoutResult {
@@ -156,6 +214,10 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
                 expectedVersion = latestPost.version ?: 0L,
             )
         }
+        val payload = singlePostWriteSideEffectPayloadSince(previousTaskIds)
+
+        // and when
+        taskFacade.fire(payload)
 
         // then
         assertThat(refreshedCounters).contains(
@@ -185,6 +247,7 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
                 )
             }!!
         clearSideEffectMocks()
+        val previousTaskIds = taskRepository.findAll().map { it.id }.toSet()
 
         // when
         transactionTemplate.executeWithoutResult {
@@ -200,6 +263,10 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
                 contentHtml = "<p>rendered html only</p>",
             )
         }
+        val payload = singlePostWriteSideEffectPayloadSince(previousTaskIds)
+
+        // and when
+        taskFacade.fire(payload)
 
         // then
         assertThat(cacheLookupNames()).contains(PostQueryCacheNames.DETAIL_PUBLIC_CONTENT)
@@ -228,6 +295,19 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
             .invocations
             .filter { it.method.name == "publish" }
             .map { it.arguments.firstOrNull() }
+
+    private fun singlePostWriteSideEffectPayloadSince(previousTaskIds: Set<Long>): PostWriteSideEffectPayload {
+        val sideEffectTasks = postWriteSideEffectTasksSince(previousTaskIds)
+        assertThat(sideEffectTasks).hasSize(1)
+        return objectMapper.readValue(sideEffectTasks.single().payload, PostWriteSideEffectPayload::class.java)
+    }
+
+    private fun postWriteSideEffectTasksSince(previousTaskIds: Set<Long>): List<Task> =
+        taskRepository
+            .findAll()
+            .filter { task ->
+                task.id !in previousTaskIds && task.taskType == PostWriteSideEffectPayload.TASK_TYPE
+            }
 
     private fun recordActiveTransactionDuringSideEffects(sideEffectTransactions: MutableList<Boolean>) {
         doAnswer {

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
@@ -15,25 +15,35 @@ import com.back.boundedContexts.post.dto.AdmDeletedPostSnapshotDto
 import com.back.global.app.AppConfig
 import com.back.global.event.application.EventPublisher
 import com.back.global.storage.application.UploadedFileRetentionService
+import com.back.global.task.application.TaskFacade
+import com.back.global.task.application.TaskHandlerEntry
+import com.back.global.task.application.TaskHandlerMethod
+import com.back.global.task.application.TaskHandlerRegistry
+import com.back.global.task.application.TaskRetryPolicy
+import com.back.global.task.application.port.output.TaskQueueRepositoryPort
+import com.back.global.task.domain.Task
+import com.back.global.task.domain.TaskStatus
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
-import org.mockito.ArgumentCaptor
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verifyNoInteractions
 import org.springframework.cache.CacheManager
-import org.springframework.context.ApplicationEventPublisher
+import org.springframework.data.domain.Pageable
+import org.springframework.mock.env.MockEnvironment
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.TransactionException
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.SimpleTransactionStatus
+import tools.jackson.databind.ObjectMapper
 import java.time.Instant
 import java.util.Optional
+import java.util.UUID
 
 @DisplayName("PostApplicationServiceDeleteResilience 테스트")
 class PostApplicationServiceDeleteResilienceTest {
@@ -65,7 +75,7 @@ class PostApplicationServiceDeleteResilienceTest {
         mock(PostRecommendFeatureStoreService::class.java)
     private val postKeywordSearchPipelineService: PostKeywordSearchPipelineService =
         mock(PostKeywordSearchPipelineService::class.java)
-    private val applicationEventPublisher: ApplicationEventPublisher = mock(ApplicationEventPublisher::class.java)
+    private val objectMapper = ObjectMapper()
     private val postReadCacheInvalidator = PostReadCacheInvalidator(cacheManager)
     private val postWriteSideEffectHandler =
         PostWriteSideEffectHandler(
@@ -75,7 +85,17 @@ class PostApplicationServiceDeleteResilienceTest {
             postRepository = postRepository,
             postAttrRepository = postAttrRepository,
             eventPublisher = eventPublisher,
+            objectMapper = objectMapper,
             transactionManager = transactionManager,
+        )
+    private val taskRepository = RecordingTaskQueueRepository()
+    private val taskFacade: TaskFacade =
+        TaskFacade(
+            taskRepository = taskRepository,
+            taskHandlerRegistry = postWriteTaskHandlerRegistry(),
+            objectMapper = objectMapper,
+            environment = MockEnvironment().also { it.setActiveProfiles("test") },
+            inlineWhenNotProd = false,
         )
 
     private val service =
@@ -93,7 +113,8 @@ class PostApplicationServiceDeleteResilienceTest {
             postRecommendRankingService = postRecommendRankingService,
             postRecommendFeatureStoreService = postRecommendFeatureStoreService,
             postKeywordSearchPipelineService = postKeywordSearchPipelineService,
-            applicationEventPublisher = applicationEventPublisher,
+            taskFacade = taskFacade,
+            objectMapper = objectMapper,
             tagsLocalCacheTtlSeconds = 180,
         )
 
@@ -189,13 +210,13 @@ class PostApplicationServiceDeleteResilienceTest {
 
         // when
         service.restoreDeletedByIdForAdmin(21)
-        val afterCommitEvent = capturePostWriteAfterCommitEvent()
+        val payload = capturePostWriteSideEffectPayload()
 
         // then
         verifyNoInteractions(cacheManager, postRecommendFeatureStoreService)
 
         // when
-        postWriteSideEffectHandler.handle(afterCommitEvent)
+        postWriteSideEffectHandler.handle(payload)
 
         // then
         then(cacheManager).should().getCache(PostQueryCacheNames.FEED)
@@ -220,13 +241,13 @@ class PostApplicationServiceDeleteResilienceTest {
 
         // when
         service.hardDeleteDeletedByIdForAdmin(22)
-        val afterCommitEvent = capturePostWriteAfterCommitEvent()
+        val payload = capturePostWriteSideEffectPayload()
 
         // then
         verifyNoInteractions(cacheManager, uploadedFileRetentionService, postRecommendFeatureStoreService)
 
         // when
-        postWriteSideEffectHandler.handle(afterCommitEvent)
+        postWriteSideEffectHandler.handle(payload)
 
         // then
         then(cacheManager).should().getCache(PostQueryCacheNames.FEED)
@@ -252,9 +273,9 @@ class PostApplicationServiceDeleteResilienceTest {
 
         // when
         service.hardDeleteDeletedByIdForAdmin(23)
-        val afterCommitEvent = capturePostWriteAfterCommitEvent()
+        val payload = capturePostWriteSideEffectPayload()
 
-        postWriteSideEffectHandler.handle(afterCommitEvent)
+        postWriteSideEffectHandler.handle(payload)
 
         // then
         verifyNoInteractions(cacheManager)
@@ -287,9 +308,9 @@ class PostApplicationServiceDeleteResilienceTest {
 
         // when
         service.hardDeleteDeletedByIdForAdmin(24)
-        val afterCommitEvent = capturePostWriteAfterCommitEvent()
+        val payload = capturePostWriteSideEffectPayload()
 
-        postWriteSideEffectHandler.handle(afterCommitEvent)
+        postWriteSideEffectHandler.handle(payload)
 
         // then
         verifyNoInteractions(cacheManager)
@@ -297,10 +318,108 @@ class PostApplicationServiceDeleteResilienceTest {
         then(postRecommendFeatureStoreService).should().evict(24)
     }
 
-    private fun capturePostWriteAfterCommitEvent(): PostWriteAfterCommitEvent {
-        val captor = ArgumentCaptor.forClass(PostWriteAfterCommitEvent::class.java)
-        then(applicationEventPublisher).should().publishEvent(captor.capture())
-        return captor.value
+    private fun capturePostWriteSideEffectPayload(): PostWriteSideEffectPayload {
+        val task = taskRepository.savedTasks.single { it.taskType == PostWriteSideEffectPayload.TASK_TYPE }
+        return objectMapper.readValue(task.payload, PostWriteSideEffectPayload::class.java)
+    }
+
+    private fun postWriteTaskHandlerRegistry(): TaskHandlerRegistry {
+        val registry = TaskHandlerRegistry()
+        registry.register(
+            PostWriteSideEffectPayload.TASK_TYPE,
+            TaskHandlerEntry(
+                taskType = PostWriteSideEffectPayload.TASK_TYPE,
+                payloadClass = PostWriteSideEffectPayload::class.java,
+                handlerMethod =
+                    TaskHandlerMethod(
+                        bean = postWriteSideEffectHandler,
+                        method =
+                            PostWriteSideEffectHandler::class.java.getDeclaredMethod(
+                                "handle",
+                                PostWriteSideEffectPayload::class.java,
+                            ),
+                    ),
+                retryPolicy = TaskRetryPolicy.fallback(PostWriteSideEffectPayload.TASK_TYPE),
+            ),
+        )
+        return registry
+    }
+
+    private class RecordingTaskQueueRepository : TaskQueueRepositoryPort {
+        val savedTasks = mutableListOf<Task>()
+
+        override fun save(task: Task): Task {
+            savedTasks += task
+            return task
+        }
+
+        override fun existsByUid(uid: UUID): Boolean = savedTasks.any { it.uid == uid }
+
+        override fun countByStatus(status: TaskStatus): Long = unsupported()
+
+        override fun countByStatusAndNextRetryAtLessThanEqual(
+            status: TaskStatus,
+            nextRetryAt: Instant,
+        ): Long = unsupported()
+
+        override fun countByStatusAndModifiedAtBefore(
+            status: TaskStatus,
+            modifiedAt: Instant,
+        ): Long = unsupported()
+
+        override fun countByTaskTypeAndStatus(
+            taskType: String,
+            status: TaskStatus,
+        ): Long = unsupported()
+
+        override fun countByTaskTypeAndStatusAndNextRetryAtLessThanEqual(
+            taskType: String,
+            status: TaskStatus,
+            nextRetryAt: Instant,
+        ): Long = unsupported()
+
+        override fun countByTaskTypeAndStatusAndModifiedAtBefore(
+            taskType: String,
+            status: TaskStatus,
+            modifiedAt: Instant,
+        ): Long = unsupported()
+
+        override fun findByStatusAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
+            status: TaskStatus,
+            nextRetryAt: Instant,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByStatusOrderByModifiedAtAsc(
+            status: TaskStatus,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByStatusOrderByModifiedAtDesc(
+            status: TaskStatus,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByStatusAndModifiedAtBeforeOrderByModifiedAtAsc(
+            status: TaskStatus,
+            modifiedAt: Instant,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByTaskTypeAndStatusAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
+            taskType: String,
+            status: TaskStatus,
+            nextRetryAt: Instant,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        override fun findByTaskTypeAndStatusOrderByModifiedAtDesc(
+            taskType: String,
+            status: TaskStatus,
+            pageable: Pageable,
+        ): List<Task> = unsupported()
+
+        private fun <T> unsupported(): T = throw UnsupportedOperationException("not needed in this test")
     }
 
     private class NoopTransactionManager : PlatformTransactionManager {

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
@@ -23,6 +23,7 @@ import com.back.global.task.application.TaskRetryPolicy
 import com.back.global.task.application.port.output.TaskQueueRepositoryPort
 import com.back.global.task.domain.Task
 import com.back.global.task.domain.TaskStatus
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -224,6 +225,50 @@ class PostApplicationServiceDeleteResilienceTest {
     }
 
     @Test
+    @DisplayName("관리자 복구 후속 작업 UID는 같은 글 반복 복구에서도 충돌하지 않는다")
+    fun createUniqueRestoreSideEffectTaskUidForRepeatedRestore() {
+        // given
+        val snapshot =
+            AdmDeletedPostSnapshotDto(
+                id = 25,
+                title = "반복 복구 대상",
+                content = "반복 복구 본문 #tag",
+                authorId = 3,
+                published = true,
+                listed = true,
+            )
+        val restoredPost =
+            Post(
+                id = 25,
+                author =
+                    Member(
+                        id = 3,
+                        username = "repeat-restore-author",
+                        password = null,
+                        nickname = "반복복구작성자",
+                        email = null,
+                        apiKey = "repeat-restore-author-api-key",
+                    ),
+                title = "반복 복구 대상",
+                content = "반복 복구 본문 #tag",
+                published = true,
+                listed = true,
+            )
+        given(postRepository.findDeletedSnapshotById(25)).willReturn(snapshot)
+        given(postRepository.restoreDeletedById(25)).willReturn(true)
+        given(postRepository.findById(25)).willReturn(Optional.of(restoredPost))
+
+        // when
+        service.restoreDeletedByIdForAdmin(25)
+        service.restoreDeletedByIdForAdmin(25)
+
+        // then
+        val payloads = capturePostWriteSideEffectPayloads()
+        assertThat(payloads).hasSize(2)
+        assertThat(payloads.map { it.uid }).doesNotHaveDuplicates()
+    }
+
+    @Test
     @DisplayName("관리자 영구삭제는 캐시와 첨부파일 정리와 추천 evict를 commit 이후에 실행한다")
     fun runHardDeleteSideEffectsAfterCommit() {
         // given
@@ -319,9 +364,16 @@ class PostApplicationServiceDeleteResilienceTest {
     }
 
     private fun capturePostWriteSideEffectPayload(): PostWriteSideEffectPayload {
-        val task = taskRepository.savedTasks.single { it.taskType == PostWriteSideEffectPayload.TASK_TYPE }
+        val task = postWriteSideEffectTasks().single()
         return objectMapper.readValue(task.payload, PostWriteSideEffectPayload::class.java)
     }
+
+    private fun capturePostWriteSideEffectPayloads(): List<PostWriteSideEffectPayload> =
+        postWriteSideEffectTasks()
+            .map { task -> objectMapper.readValue(task.payload, PostWriteSideEffectPayload::class.java) }
+
+    private fun postWriteSideEffectTasks(): List<Task> =
+        taskRepository.savedTasks.filter { it.taskType == PostWriteSideEffectPayload.TASK_TYPE }
 
     private fun postWriteTaskHandlerRegistry(): TaskHandlerRegistry {
         val registry = TaskHandlerRegistry()

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostRecommendRankingServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostRecommendRankingServiceTest.kt
@@ -1,0 +1,81 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
+import com.back.boundedContexts.post.domain.Post
+import com.back.boundedContexts.post.dto.TagCountDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import tools.jackson.databind.ObjectMapper
+import java.time.Instant
+
+@DisplayName("PostRecommendRankingService 테스트")
+class PostRecommendRankingServiceTest {
+    @Test
+    @DisplayName("추천 후보가 있으면 feature vector를 계산해 재정렬 결과를 반환한다")
+    fun rerankNonEmptyCandidates() {
+        // given
+        val featureStore =
+            PostRecommendFeatureStoreService(
+                postAttrRepository = mock(PostAttrRepositoryPort::class.java),
+                objectMapper = ObjectMapper(),
+                enabled = false,
+                staleSeconds = 900,
+                localCacheTtlSeconds = 120,
+            )
+        val rankingService =
+            PostRecommendRankingService(
+                postRecommendFeatureStoreService = featureStore,
+                enabled = true,
+                candidatePoolSize = 60,
+                maxRerankPages = 4,
+                hotTagsLimit = 24,
+            )
+        val olderPost =
+            testPost(
+                id = 1L,
+                createdAt = Instant.parse("2026-06-18T00:00:00Z"),
+                content = "오래된 글 #kotlin",
+            )
+        val newerPost =
+            testPost(
+                id = 2L,
+                createdAt = Instant.parse("2026-06-19T00:00:00Z"),
+                content = "새 글 #spring",
+            )
+
+        // when
+        val result =
+            rankingService.rerank(
+                candidates = listOf(olderPost, newerPost),
+                tagCounts = listOf(TagCountDto("spring", 10), TagCountDto("kotlin", 4)),
+                page = 1,
+                pageSize = 10,
+                candidateTotalElements = 2,
+            )
+
+        // then
+        assertThat(result.content).hasSize(2)
+        assertThat(result.content.map(Post::id)).containsExactly(newerPost.id, olderPost.id)
+        assertThat(result.totalElements).isEqualTo(2)
+    }
+
+    private fun testPost(
+        id: Long,
+        createdAt: Instant,
+        content: String,
+    ): Post =
+        Post(
+            id = id,
+            author = Member(id = 1, username = "author", nickname = "작성자", apiKey = "author-api-key"),
+            title = "title-$id",
+            content = content,
+            published = true,
+            listed = true,
+        ).also {
+            it.createdAt = createdAt
+            it.modifiedAt = createdAt
+        }
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandlerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandlerTest.kt
@@ -1,6 +1,7 @@
 package com.back.boundedContexts.post.application.service
 
 import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.dto.MemberDto
 import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
 import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
 import com.back.boundedContexts.post.domain.Post
@@ -8,10 +9,14 @@ import com.back.boundedContexts.post.domain.PostAttr
 import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
 import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
 import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
+import com.back.boundedContexts.post.dto.PostDto
+import com.back.boundedContexts.post.event.PostDeletedEvent
 import com.back.global.event.application.EventPublisher
 import com.back.global.storage.application.UploadedFileRetentionService
+import com.back.global.task.annotation.TaskHandler
 import com.back.standard.dto.EventPayload
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -23,14 +28,16 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.TransactionException
 import org.springframework.transaction.TransactionStatus
-import org.springframework.transaction.event.TransactionPhase
-import org.springframework.transaction.event.TransactionalEventListener
 import org.springframework.transaction.support.SimpleTransactionStatus
+import tools.jackson.databind.ObjectMapper
+import java.time.Instant
 import java.util.Optional
+import java.util.UUID
 
 @DisplayName("PostWriteSideEffectHandler 테스트")
 class PostWriteSideEffectHandlerTest {
@@ -41,7 +48,9 @@ class PostWriteSideEffectHandlerTest {
     private val postRepository: PostRepositoryPort = mock(PostRepositoryPort::class.java)
     private val postAttrRepository: PostAttrRepositoryPort = mock(PostAttrRepositoryPort::class.java)
     private val eventPublisher: EventPublisher = mock(EventPublisher::class.java)
-    private val handler =
+    private val handler = newHandler()
+
+    private fun newHandler(eventPublisher: EventPublisher = this.eventPublisher): PostWriteSideEffectHandler =
         PostWriteSideEffectHandler(
             postReadCacheInvalidator = PostReadCacheInvalidator(ConcurrentMapCacheManager()),
             uploadedFileRetentionService = uploadedFileRetentionService,
@@ -49,6 +58,7 @@ class PostWriteSideEffectHandlerTest {
             postRepository = postRepository,
             postAttrRepository = postAttrRepository,
             eventPublisher = eventPublisher,
+            objectMapper = ObjectMapper(),
             transactionManager = NoopTransactionManager(),
         )
 
@@ -102,20 +112,20 @@ class PostWriteSideEffectHandlerTest {
     }
 
     @Test
-    @DisplayName("후속 작업 handler는 Spring transaction commit 이후 이벤트로만 호출된다")
-    fun handlePostWriteEventAfterCommit() {
+    @DisplayName("후속 작업 handler는 durable task payload handler로 등록된다")
+    fun handlePostWriteSideEffectPayloadAsTaskHandler() {
         // when
-        val handlerMethod =
+        val handlerMethods =
             PostWriteSideEffectHandler::class.java
-                .declaredMethods
-                .single { method ->
-                    method.parameterTypes.contentEquals(arrayOf(PostWriteAfterCommitEvent::class.java))
+                .methods
+                .filter { method ->
+                    method.name == "handle" &&
+                        method.parameterTypes.contentEquals(arrayOf(PostWriteSideEffectPayload::class.java))
                 }
-        val annotation = handlerMethod.getAnnotation(TransactionalEventListener::class.java)
 
         // then
-        assertThat(annotation.phase).isEqualTo(TransactionPhase.AFTER_COMMIT)
-        assertThat(annotation.fallbackExecution).isTrue()
+        assertThat(handlerMethods).hasSize(1)
+        assertThat(handlerMethods.single().getAnnotation(TaskHandler::class.java)).isNotNull()
     }
 
     @Test
@@ -164,6 +174,29 @@ class PostWriteSideEffectHandlerTest {
             )
         }
         verify(postRecommendFeatureStoreService).evict(15L)
+    }
+
+    @Test
+    @DisplayName("task payload 처리 중 첨부파일 동기화 실패는 task retry를 위해 전파한다")
+    fun propagateAttachmentSyncFailureWhenHandlingTaskPayload() {
+        // given
+        doThrow(RuntimeException("storage down"))
+            .`when`(uploadedFileRetentionService)
+            .syncPostContent(20L, "before", "after")
+
+        val payload =
+            postWriteSideEffectPayload(
+                postId = 20L,
+                previousContent = "before",
+                currentContent = "after",
+                recommendationAction = PostRecommendationSideEffect.EVICT,
+            )
+
+        // when & then
+        assertThatThrownBy {
+            handler.handle(payload)
+        }.isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("storage down")
     }
 
     @Test
@@ -247,6 +280,83 @@ class PostWriteSideEffectHandlerTest {
         verify(postRecommendFeatureStoreService).refresh(post)
     }
 
+    @Test
+    @DisplayName("삭제 domain event payload는 durable task 처리 중 복원해 발행한다")
+    fun publishDeletedDomainEventFromTaskPayload() {
+        // given
+        val post = testPost(30L)
+        val domainEvent =
+            PostDeletedEvent(
+                uid = UUID.randomUUID(),
+                postDto = testPostDto(post.id),
+                actorDto = testMemberDto(post.author.id),
+                beforeTags = listOf("spring"),
+                afterTags = emptyList(),
+            )
+        val payload =
+            postWriteSideEffectPayload(
+                postId = 30L,
+                recommendationAction = PostRecommendationSideEffect.EVICT,
+                domainEventType = PostDeletedEvent::class.java.name,
+                domainEventJson = ObjectMapper().writeValueAsString(domainEvent),
+            )
+
+        // when
+        val applicationEventPublisher = RecordingApplicationEventPublisher()
+        newHandler(EventPublisher(applicationEventPublisher)).handle(payload)
+
+        // then
+        assertThat(applicationEventPublisher.publishedEvent).isInstanceOf(PostDeletedEvent::class.java)
+    }
+
+    @Test
+    @DisplayName("알 수 없는 domain event type은 task 실패로 전파하지 않고 발행만 건너뛴다")
+    fun skipUnknownDomainEventTypeWhenHandlingTaskPayload() {
+        // given
+        val payload =
+            postWriteSideEffectPayload(
+                postId = 31L,
+                recommendationAction = PostRecommendationSideEffect.EVICT,
+                domainEventType = "unknown.event.Type",
+                domainEventJson = "{}",
+            )
+
+        // when & then
+        assertDoesNotThrow {
+            handler.handle(payload)
+        }
+        verifyNoInteractions(eventPublisher)
+    }
+
+    @Test
+    @DisplayName("task payload 처리 중 non-runtime 실패는 retry 가능한 예외로 감싸 전파한다")
+    fun wrapNonRuntimeFailureWhenHandlingTaskPayload() {
+        // given
+        val post = testPost(32L)
+        val domainEvent =
+            PostDeletedEvent(
+                uid = UUID.randomUUID(),
+                postDto = testPostDto(post.id),
+                actorDto = testMemberDto(post.author.id),
+            )
+        val applicationEventPublisher = ThrowingApplicationEventPublisher(AssertionError("event publish failed"))
+
+        val payload =
+            postWriteSideEffectPayload(
+                postId = 32L,
+                recommendationAction = PostRecommendationSideEffect.EVICT,
+                domainEventType = PostDeletedEvent::class.java.name,
+                domainEventJson = ObjectMapper().writeValueAsString(domainEvent),
+            )
+
+        // when & then
+        assertThatThrownBy {
+            newHandler(EventPublisher(applicationEventPublisher)).handle(payload)
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Post write side effect failed")
+            .hasCauseInstanceOf(AssertionError::class.java)
+    }
+
     private fun sideEffectCommand(
         postId: Long,
         previousContent: String? = null,
@@ -283,6 +393,64 @@ class PostWriteSideEffectHandlerTest {
             listed = true,
         )
 
+    private fun testPostDto(id: Long): PostDto =
+        PostDto(
+            id = id,
+            createdAt = Instant.EPOCH,
+            modifiedAt = Instant.EPOCH,
+            authorId = 1L,
+            authorName = "작성자",
+            authorUsername = "author",
+            authorProfileImgUrl = "",
+            title = "title",
+            thumbnail = null,
+            summary = "summary",
+            version = 1L,
+            published = true,
+            listed = true,
+            likesCount = 0,
+            commentsCount = 0,
+            hitCount = 0,
+        )
+
+    private fun testMemberDto(id: Long): MemberDto =
+        MemberDto(
+            id = id,
+            createdAt = Instant.EPOCH,
+            modifiedAt = Instant.EPOCH,
+            isAdmin = false,
+            name = "작성자",
+            profileImageUrl = "",
+        )
+
+    private fun postWriteSideEffectPayload(
+        postId: Long,
+        previousContent: String? = null,
+        currentContent: String? = null,
+        deletedContent: String? = null,
+        beforeTags: List<String> = emptyList(),
+        afterTags: List<String> = emptyList(),
+        recommendationAction: PostRecommendationSideEffect = PostRecommendationSideEffect.REFRESH,
+        domainEventType: String? = null,
+        domainEventJson: String? = null,
+    ): PostWriteSideEffectPayload =
+        PostWriteSideEffectPayload(
+            uid = UUID.randomUUID(),
+            aggregateType = "Post",
+            aggregateId = postId,
+            postId = postId,
+            previousContent = previousContent,
+            currentContent = currentContent,
+            deletedContent = deletedContent,
+            beforeTags = beforeTags,
+            afterTags = afterTags,
+            cacheInvalidationTargets = emptySet(),
+            evictReason = "test",
+            recommendationAction = recommendationAction,
+            domainEventType = domainEventType,
+            domainEventJson = domainEventJson,
+        )
+
     private class NoopTransactionManager : PlatformTransactionManager {
         override fun getTransaction(definition: TransactionDefinition?): TransactionStatus = SimpleTransactionStatus()
 
@@ -291,5 +459,19 @@ class PostWriteSideEffectHandlerTest {
 
         @Throws(TransactionException::class)
         override fun rollback(status: TransactionStatus) = Unit
+    }
+
+    private class RecordingApplicationEventPublisher : ApplicationEventPublisher {
+        var publishedEvent: Any? = null
+
+        override fun publishEvent(event: Any) {
+            publishedEvent = event
+        }
+    }
+
+    private class ThrowingApplicationEventPublisher(
+        private val throwable: Throwable,
+    ) : ApplicationEventPublisher {
+        override fun publishEvent(event: Any): Unit = throw throwable
     }
 }

--- a/back/src/test/kotlin/com/back/global/task/application/TaskFacadeTest.kt
+++ b/back/src/test/kotlin/com/back/global/task/application/TaskFacadeTest.kt
@@ -1,19 +1,17 @@
 package com.back.global.task.application
 
-import com.back.global.app.application.AppFacade
 import com.back.global.task.application.port.output.TaskQueueRepositoryPort
 import com.back.global.task.domain.Task
 import com.back.global.task.domain.TaskStatus
 import com.back.standard.dto.TaskPayload
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
-import org.springframework.core.env.Environment
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.domain.Pageable
+import org.springframework.mock.env.MockEnvironment
 import tools.jackson.databind.ObjectMapper
 import java.time.Instant
 import java.util.UUID
@@ -60,15 +58,44 @@ class TaskFacadeTest {
         assertThat(handler.handledPayloads).containsExactly(payload)
     }
 
+    @Test
+    @DisplayName("addToQueue는 호출자가 inline 실행을 비활성화할 수 있다")
+    fun `add to queue can disable inline handler execution`() {
+        val repository = InMemoryTaskQueueRepository()
+        val handler = StubTaskHandler()
+        val facade = createFacade(repository, handler, inlineWhenNotProd = true)
+        val payload = StubTaskPayload(uid = UUID.randomUUID())
+
+        facade.addToQueue(payload, inlineWhenEnabled = false)
+
+        assertThat(repository.savedTasks).hasSize(1)
+        assertThat(handler.handledPayloads).isEmpty()
+    }
+
+    @Test
+    @DisplayName("fire는 handler 원본 예외를 그대로 전파한다")
+    fun `fire unwraps handler exception`() {
+        val repository = InMemoryTaskQueueRepository()
+        val failure = RuntimeException("handler down")
+        val facade = createFacade(repository, StubTaskHandler(failure = failure))
+
+        assertThatThrownBy {
+            facade.fire(StubTaskPayload(uid = UUID.randomUUID()))
+        }.isSameAs(failure)
+    }
+
     private fun createFacade(
         repository: InMemoryTaskQueueRepository,
         handler: StubTaskHandler = StubTaskHandler(),
         inlineWhenNotProd: Boolean = false,
     ): TaskFacade {
-        val environment = mock(Environment::class.java)
-        `when`(environment.matchesProfiles("prod")).thenReturn(false)
+        val environment =
+            MockEnvironment()
+                .withProperty("custom.site.cookieDomain", "")
+                .withProperty("custom.site.frontUrl", "http://localhost:3000")
+                .withProperty("custom.site.backUrl", "http://localhost:8080")
+        environment.setActiveProfiles("test")
         val objectMapper = ObjectMapper()
-        AppFacade(environment, objectMapper)
 
         val registry = TaskHandlerRegistry()
         registry.register(
@@ -84,7 +111,13 @@ class TaskFacadeTest {
                 retryPolicy = TaskRetryPolicy.fallback(StubTaskPayload.TASK_TYPE),
             ),
         )
-        return TaskFacade(repository, registry, objectMapper, inlineWhenNotProd = inlineWhenNotProd)
+        return TaskFacade(
+            taskRepository = repository,
+            taskHandlerRegistry = registry,
+            objectMapper = objectMapper,
+            environment = environment,
+            inlineWhenNotProd = inlineWhenNotProd,
+        )
     }
 
     private data class StubTaskPayload(
@@ -97,10 +130,13 @@ class TaskFacadeTest {
         }
     }
 
-    private class StubTaskHandler {
+    private class StubTaskHandler(
+        private val failure: RuntimeException? = null,
+    ) {
         val handledPayloads = mutableListOf<StubTaskPayload>()
 
         fun handle(payload: StubTaskPayload) {
+            failure?.let { throw it }
             handledPayloads += payload
         }
     }

--- a/back/src/test/kotlin/com/back/global/task/application/TaskProcessingLockDiagnosticsServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/task/application/TaskProcessingLockDiagnosticsServiceTest.kt
@@ -70,6 +70,49 @@ class TaskProcessingLockDiagnosticsServiceTest {
         verify(redisTemplate, never()).delete(PROCESS_TASKS_LOCK_KEY)
     }
 
+    @Test
+    fun `redis ttl을 알 수 없으면 legacy processTasks lock으로 삭제하지 않는다`() {
+        given(redisTemplate.hasKey(PROCESS_TASKS_LOCK_KEY)).willReturn(true)
+        given(redisTemplate.getExpire(PROCESS_TASKS_LOCK_KEY, TimeUnit.SECONDS)).willReturn(-1L)
+
+        val service =
+            TaskProcessingLockDiagnosticsService(
+                stringRedisTemplateProvider = objectProvider(redisTemplate),
+                taskQueueRepository = fakeTaskQueueRepository(readyPendingCount = 2L, processingCount = 0L),
+                currentNodeWorkerEnabled = true,
+                currentNodeApiMode = "all",
+                legacyLockCleanupThresholdSeconds = 300,
+            )
+
+        val cleanupResult = service.clearLegacyProcessTasksLockIfNeeded()
+
+        assertEquals(null, cleanupResult.diagnostics.processTasksLockTtlSeconds)
+        assertFalse(cleanupResult.diagnostics.legacyOrphanLikely)
+        assertFalse(cleanupResult.attempted)
+        assertFalse(cleanupResult.deleted)
+        verify(redisTemplate, never()).delete(PROCESS_TASKS_LOCK_KEY)
+    }
+
+    @Test
+    fun `processTasks lock이 없으면 ttl 없이 정상으로 진단한다`() {
+        given(redisTemplate.hasKey(PROCESS_TASKS_LOCK_KEY)).willReturn(false)
+
+        val service =
+            TaskProcessingLockDiagnosticsService(
+                stringRedisTemplateProvider = objectProvider(redisTemplate),
+                taskQueueRepository = fakeTaskQueueRepository(readyPendingCount = 2L, processingCount = 0L),
+                currentNodeWorkerEnabled = true,
+                currentNodeApiMode = "all",
+                legacyLockCleanupThresholdSeconds = 300,
+            )
+
+        val diagnostics = service.diagnose()
+
+        assertFalse(diagnostics.processTasksLockExists)
+        assertEquals(null, diagnostics.processTasksLockTtlSeconds)
+        assertFalse(diagnostics.legacyOrphanLikely)
+    }
+
     private fun objectProvider(redisTemplate: StringRedisTemplate?): ObjectProvider<StringRedisTemplate> =
         object : ObjectProvider<StringRedisTemplate> {
             override fun getObject(vararg args: Any?): StringRedisTemplate = redisTemplate ?: error("No redis template")

--- a/back/src/test/kotlin/com/back/perf/PerformanceSanityTest.kt
+++ b/back/src/test/kotlin/com/back/perf/PerformanceSanityTest.kt
@@ -127,7 +127,7 @@ class PerformanceSanityTest : BasePerformanceIntegrationTest() {
                 status { isOk() }
             }
 
-        assertQueryCountWithin("auth-login", 10)
+        assertQueryCountWithin("auth-login", 12)
     }
 
     private fun assertQueryCountWithin(

--- a/back/src/test/kotlin/com/back/support/BaseIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseIntegrationTest.kt
@@ -1,6 +1,12 @@
 package com.back.support
 
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
 
 @ActiveProfiles("test")
+@TestPropertySource(
+    properties = [
+        "custom.task.processor.enabled=false",
+    ],
+)
 abstract class BaseIntegrationTest

--- a/back/src/test/kotlin/com/back/support/BasePerformanceIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BasePerformanceIntegrationTest.kt
@@ -6,6 +6,7 @@ import org.springframework.test.context.TestPropertySource
     properties = [
         "spring.jpa.properties.hibernate.generate_statistics=true",
         "spring.task.scheduling.enabled=false",
+        "custom.task.processor.enabled=false",
     ],
 )
 abstract class BasePerformanceIntegrationTest : BaseControllerIntegrationTest()


### PR DESCRIPTION
## 관련 이슈

close #880

## 작업 배경

- 게시글 작성/수정/삭제/복구/영구삭제 후속 작업이 메모리 AFTER_COMMIT 이벤트에만 의존해, commit 직후 프로세스가 종료되면 cache invalidation, attachment cleanup, recommendation 갱신, domain event publish가 누락될 수 있었다.
- `post.write.side-effect` task row를 write 트랜잭션 안에서 저장하고 task worker가 후속 작업을 재시도하도록 durable outbox 경로로 전환했다.

## 작업 내용

- `PostWriteSideEffectPayload` task payload와 `PostWriteSideEffectHandler` task handler를 추가해 게시글 후속 작업을 durable task로 실행하도록 변경했다.
- `PostApplicationService`의 post write 후속 작업 발행을 `TaskFacade.addToQueue(..., inlineWhenEnabled = false)` 기반으로 전환했다.
- read-model/revalidate/CDN purge task enqueue 실패가 조용히 묻히지 않도록 결정적 UID와 실패 전파를 정리했다.
- `PostWrittenEvent`/`PostDeletedEvent`의 `postDto` JSON 왕복 annotation을 `PostModifiedEvent`와 맞춰 durable payload 재처리 시 domain event 복원이 실패하지 않게 했다.
- 통합 테스트에서는 전체 runtime worker를 끄지 않고 `custom.task.processor.enabled=false`로 task processor만 비활성화해 cleanup deadlock을 막고 기존 scheduled job coverage는 유지했다.

## 검증

- 실행한 명령과 결과:
  - PASS `back/gradlew -p back test --rerun-tasks --tests 'com.back.boundedContexts.member.subContexts.notification.application.service.MemberNotificationEventListenerTest'`
  - PASS `back/gradlew -p back test --tests '*PostApplicationService*' --tests '*PostWriteSideEffect*' --tests '*PostReadModelTaskEventListener*' --tests '*RevalidateEventListener*' --tests '*Task*' --tests '*PostRecommendRankingServiceTest*'`
  - PASS `back/gradlew -p back test --tests '*PostRecommendRankingServiceTest*' --tests '*TaskProcessingLockDiagnosticsServiceTest*'`
  - PASS `back/gradlew -p back ktlintCheck`
  - PASS `back/gradlew -p back ciFastCheck --rerun-tasks` 2회 연속

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `PostApplicationService.publishPostWriteAfterCommitEvent`가 task row 저장으로 바뀐 흐름
  - `PostWriteSideEffectHandler.handle(PostWriteSideEffectPayload)`의 실패 수집 및 retry 전파
  - `custom.task.processor.enabled` test gate가 `custom.runtime.worker-enabled` 전역 disable을 대체하는 부분

## 리스크

- 게시글 write 후속 작업이 worker 재시도 경로로 이동해 task queue 적체가 있으면 cache/recommendation/domain event 반영이 지연될 수 있다.
- domain event JSON 왕복 annotation을 맞췄으므로 이벤트 로그 직렬화 shape 변화가 없는지 PR CI와 리뷰에서 확인이 필요하다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
