### PR TITLE
[Fix] 댓글·좋아요 이벤트 발행 정책 통일

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/adapter/persistence/MemberNotificationRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/adapter/persistence/MemberNotificationRepository.kt
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.Instant
+import java.util.UUID
 
 /**
  * `MemberNotificationRepository` 인터페이스입니다.
@@ -45,6 +46,8 @@ interface MemberNotificationRepository : JpaRepository<MemberNotification, Long>
     ): List<MemberNotification>
 
     fun countByReceiverIdAndReadAtIsNull(receiverId: Long): Long
+
+    fun existsByEventUid(eventUid: UUID): Boolean
 
     @Modifying(clearAutomatically = false, flushAutomatically = true)
     @Query(

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/adapter/persistence/MemberNotificationRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/adapter/persistence/MemberNotificationRepositoryAdapter.kt
@@ -5,6 +5,7 @@ import com.back.boundedContexts.member.subContexts.notification.domain.MemberNot
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
 import java.time.Instant
+import java.util.UUID
 
 /**
  * MemberNotificationRepositoryAdapter는 영속 계층(JPA/쿼리) 연동을 담당하는 퍼시스턴스 어댑터입니다.
@@ -31,6 +32,8 @@ class MemberNotificationRepositoryAdapter(
         )
 
     override fun countUnreadByReceiverId(receiverId: Long): Long = memberNotificationRepository.countByReceiverIdAndReadAtIsNull(receiverId)
+
+    override fun existsByEventUid(eventUid: UUID): Boolean = memberNotificationRepository.existsByEventUid(eventUid)
 
     override fun markAllRead(
         receiverId: Long,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/port/output/MemberNotificationRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/port/output/MemberNotificationRepositoryPort.kt
@@ -2,6 +2,7 @@ package com.back.boundedContexts.member.subContexts.notification.application.por
 
 import com.back.boundedContexts.member.subContexts.notification.domain.MemberNotification
 import java.time.Instant
+import java.util.UUID
 
 /**
  * `MemberNotificationRepositoryPort` 인터페이스입니다.
@@ -20,6 +21,8 @@ interface MemberNotificationRepositoryPort {
     ): List<MemberNotification>
 
     fun countUnreadByReceiverId(receiverId: Long): Long
+
+    fun existsByEventUid(eventUid: UUID): Boolean
 
     fun markAllRead(
         receiverId: Long,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationApplicationService.kt
@@ -37,6 +37,10 @@ class MemberNotificationApplicationService(
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun createForCommentWritten(event: PostCommentWrittenEvent) {
+        if (memberNotificationRepository.existsByEventUid(event.uid)) {
+            return
+        }
+
         val actorId = event.postCommentDto.authorId
         val receiverInfo = resolveReceiver(event) ?: return
         if (receiverInfo.receiverId == actorId) {
@@ -53,6 +57,7 @@ class MemberNotificationApplicationService(
                     commentId = event.postCommentDto.id,
                     postTitle = normalizePostTitle(event.postDto.title),
                     commentPreview = normalizeCommentPreview(event.postCommentDto.content),
+                    eventUid = event.uid,
                 ),
             )
 
@@ -128,6 +133,7 @@ class MemberNotificationApplicationService(
     private fun resolveReceiver(event: PostCommentWrittenEvent): ReceiverInfo? {
         val parentCommentId = event.postCommentDto.parentCommentId
         if (parentCommentId != null) {
+            event.replyReceiverId?.let { return ReceiverInfo(it, MemberNotificationType.COMMENT_REPLY) }
             val parentComment = postCommentRepository.findById(parentCommentId).getOrNull() ?: return null
             return ReceiverInfo(parentComment.author.id, MemberNotificationType.COMMENT_REPLY)
         }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/model/MemberNotification.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/model/MemberNotification.kt
@@ -16,6 +16,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.SequenceGenerator
 import java.time.Instant
+import java.util.UUID
 
 /**
  * MemberNotification는 비즈니스 상태와 규칙을 캡슐화하는 도메인 모델입니다.
@@ -60,6 +61,8 @@ class MemberNotification(
     val postTitle: String,
     @field:Column(nullable = false, length = 240)
     val commentPreview: String,
+    @field:Column
+    val eventUid: UUID? = null,
 ) : BaseTime(id) {
     @field:Column
     var readAt: Instant? = null

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -471,15 +471,18 @@ class PostApplicationService(
             )
         incrementCommentsCount(post)
         incrementMemberPostCommentsCount(persistenceAuthor)
-        refreshRecommendFeatureStoreForPublicPost(post)
-
-        runCatching {
-            eventPublisher.publish(
-                PostCommentWrittenEvent(UUID.randomUUID(), PostCommentDto(comment), PostDto(post), MemberDto(author)),
-            )
-        }.onFailure { exception ->
-            logger.warn("Failed to publish PostCommentWrittenEvent: postId={}, commentId={}", post.id, comment.id, exception)
-        }
+        enqueuePostInteractionSideEffect(
+            postId = post.id,
+            recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
+            domainEvent =
+                PostCommentWrittenEvent(
+                    UUID.randomUUID(),
+                    PostCommentDto(comment),
+                    PostDto(post),
+                    MemberDto(author),
+                    persistedParentComment?.author?.id,
+                ),
+        )
 
         return comment
     }
@@ -496,23 +499,16 @@ class PostApplicationService(
     ) {
         postComment.modify(content)
 
-        runCatching {
-            eventPublisher.publish(
+        enqueuePostInteractionSideEffect(
+            postId = postComment.post.id,
+            domainEvent =
                 PostCommentModifiedEvent(
                     UUID.randomUUID(),
                     PostCommentDto(postComment),
                     PostDto(postComment.post),
                     MemberDto(actor),
                 ),
-            )
-        }.onFailure { exception ->
-            logger.warn(
-                "Failed to publish PostCommentModifiedEvent: postId={}, commentId={}",
-                postComment.post.id,
-                postComment.id,
-                exception,
-            )
-        }
+        )
     }
 
     /**
@@ -534,30 +530,27 @@ class PostApplicationService(
         commentsToDelete.forEach { hydrateMemberCounterAttrs(it.author) }
 
         val postDto = PostDto(post)
-        commentsToDelete.forEach { comment ->
+        commentsToDelete.forEachIndexed { index, comment ->
             val postCommentDto = PostCommentDto(comment)
             comment.author.decrementPostCommentsCount()
             saveMemberAttr(comment.author.postCommentsCountAttr)
             post.onCommentDeleted()
             comment.softDelete()
 
-            runCatching {
-                eventPublisher.publish(
-                    PostCommentDeletedEvent(UUID.randomUUID(), postCommentDto, postDto, MemberDto(actor)),
-                )
-            }.onFailure { exception ->
-                logger.warn(
-                    "Failed to publish PostCommentDeletedEvent: postId={}, commentId={}",
-                    comment.post.id,
-                    comment.id,
-                    exception,
-                )
-            }
+            enqueuePostInteractionSideEffect(
+                postId = comment.post.id,
+                recommendationAction =
+                    if (index == commentsToDelete.lastIndex) {
+                        PostInteractionRecommendationSideEffect.REFRESH
+                    } else {
+                        PostInteractionRecommendationSideEffect.NONE
+                    },
+                domainEvent = PostCommentDeletedEvent(UUID.randomUUID(), postCommentDto, postDto, MemberDto(actor)),
+            )
         }
 
         savePostAttr(post.commentsCountAttr)
         postRepository.flush()
-        refreshRecommendFeatureStoreForPublicPost(post)
     }
 
     /**
@@ -592,28 +585,21 @@ class PostApplicationService(
 
             incrementLikesCount(post)
             postRepository.flush()
-            refreshRecommendFeatureStoreForPublicPost(post)
-            runCatching {
-                eventPublisher.publish(
-                    PostLikedEvent(UUID.randomUUID(), post.id, post.author.id, recoveredLikeId, MemberDto(actor)),
-                )
-            }.onFailure { exception ->
-                logger.warn("Failed to publish recovered PostLikedEvent: postId={}, likeId={}", post.id, recoveredLikeId, exception)
-            }
+            enqueuePostInteractionSideEffect(
+                postId = post.id,
+                recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
+                domainEvent = PostLikedEvent(UUID.randomUUID(), post.id, post.author.id, recoveredLikeId, MemberDto(actor)),
+            )
             return PostLikeToggleResult(true, recoveredLikeId)
         }
 
         incrementLikesCount(post)
         postRepository.flush()
-        refreshRecommendFeatureStoreForPublicPost(post)
-
-        runCatching {
-            eventPublisher.publish(
-                PostLikedEvent(UUID.randomUUID(), post.id, post.author.id, insertedLikeId, MemberDto(actor)),
-            )
-        }.onFailure { exception ->
-            logger.warn("Failed to publish PostLikedEvent: postId={}, likeId={}", post.id, insertedLikeId, exception)
-        }
+        enqueuePostInteractionSideEffect(
+            postId = post.id,
+            recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
+            domainEvent = PostLikedEvent(UUID.randomUUID(), post.id, post.author.id, insertedLikeId, MemberDto(actor)),
+        )
 
         return PostLikeToggleResult(true, insertedLikeId)
     }
@@ -642,16 +628,18 @@ class PostApplicationService(
             ensureLikesCountLoaded(post)
         }
         postRepository.flush()
-        refreshRecommendFeatureStoreForPublicPost(post)
 
         if (deletedCount > 0 && existingLikeId != null) {
-            runCatching {
-                eventPublisher.publish(
-                    PostUnlikedEvent(UUID.randomUUID(), post.id, postAuthorId, existingLikeId, MemberDto(actor)),
-                )
-            }.onFailure { exception ->
-                logger.warn("Failed to publish PostUnlikedEvent: postId={}, likeId={}", post.id, existingLikeId, exception)
-            }
+            enqueuePostInteractionSideEffect(
+                postId = post.id,
+                recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
+                domainEvent = PostUnlikedEvent(UUID.randomUUID(), post.id, postAuthorId, existingLikeId, MemberDto(actor)),
+            )
+        } else {
+            enqueuePostInteractionSideEffect(
+                postId = post.id,
+                recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
+            )
         }
 
         return PostLikeToggleResult(false, existingLikeId ?: 0L)
@@ -1339,6 +1327,125 @@ class PostApplicationService(
         }
 
         return command.operationUid
+    }
+
+    private fun enqueuePostInteractionSideEffect(
+        postId: Long,
+        recommendationAction: PostInteractionRecommendationSideEffect = PostInteractionRecommendationSideEffect.NONE,
+        domainEvent: EventPayload? = null,
+        operationUid: UUID = UUID.randomUUID(),
+    ) {
+        if (domainEvent != null && recommendationAction != PostInteractionRecommendationSideEffect.NONE) {
+            addPostInteractionSideEffectTask(
+                postId = postId,
+                recommendationAction = PostInteractionRecommendationSideEffect.NONE,
+                domainEvent = domainEvent,
+                operationUid = operationUid,
+            )
+            addPostInteractionSideEffectTask(
+                postId = postId,
+                recommendationAction = recommendationAction,
+                domainEvent = null,
+                operationUid = postInteractionRefreshSideEffectTaskUid(domainEvent),
+            )
+            return
+        }
+
+        addPostInteractionSideEffectTask(
+            postId = postId,
+            recommendationAction = recommendationAction,
+            domainEvent = domainEvent,
+            operationUid = operationUid,
+        )
+    }
+
+    private fun addPostInteractionSideEffectTask(
+        postId: Long,
+        recommendationAction: PostInteractionRecommendationSideEffect,
+        domainEvent: EventPayload?,
+        operationUid: UUID,
+    ) {
+        taskFacade.addToQueue(
+            PostInteractionSideEffectPayload(
+                uid = postInteractionSideEffectTaskUid(domainEvent, operationUid),
+                aggregateType = domainEvent?.aggregateType ?: "Post",
+                aggregateId = domainEvent?.aggregateId ?: postId,
+                postId = postId,
+                recommendationAction = recommendationAction,
+                domainEventUid = domainEvent?.uid,
+                domainEventType = domainEvent?.javaClass?.name,
+                postCommentDto = postInteractionCommentDto(domainEvent),
+                postDto = postInteractionPostDto(domainEvent),
+                actorDto = postInteractionActorDto(domainEvent),
+                replyReceiverId = postInteractionReplyReceiverId(domainEvent),
+                postAuthorId = postInteractionPostAuthorId(domainEvent),
+                likeId = postInteractionLikeId(domainEvent),
+            ),
+            inlineWhenEnabled = false,
+        )
+    }
+
+    private fun postInteractionRefreshSideEffectTaskUid(domainEvent: EventPayload): UUID =
+        UUID.nameUUIDFromBytes(
+            "${PostInteractionSideEffectPayload.TASK_TYPE}:refresh:${domainEvent.uid}".toByteArray(
+                StandardCharsets.UTF_8,
+            ),
+        )
+
+    private fun postInteractionCommentDto(domainEvent: EventPayload?): PostCommentDto? =
+        when (domainEvent) {
+            is PostCommentWrittenEvent -> domainEvent.postCommentDto
+            is PostCommentModifiedEvent -> domainEvent.postCommentDto
+            is PostCommentDeletedEvent -> domainEvent.postCommentDto
+            else -> null
+        }
+
+    private fun postInteractionPostDto(domainEvent: EventPayload?): PostDto? =
+        when (domainEvent) {
+            is PostCommentWrittenEvent -> domainEvent.postDto
+            is PostCommentModifiedEvent -> domainEvent.postDto
+            is PostCommentDeletedEvent -> domainEvent.postDto
+            else -> null
+        }
+
+    private fun postInteractionActorDto(domainEvent: EventPayload?): MemberDto? =
+        when (domainEvent) {
+            is PostCommentWrittenEvent -> domainEvent.actorDto
+            is PostCommentModifiedEvent -> domainEvent.actorDto
+            is PostCommentDeletedEvent -> domainEvent.actorDto
+            is PostLikedEvent -> domainEvent.actorDto
+            is PostUnlikedEvent -> domainEvent.actorDto
+            else -> null
+        }
+
+    private fun postInteractionReplyReceiverId(domainEvent: EventPayload?): Long? =
+        when (domainEvent) {
+            is PostCommentWrittenEvent -> domainEvent.replyReceiverId
+            else -> null
+        }
+
+    private fun postInteractionPostAuthorId(domainEvent: EventPayload?): Long? =
+        when (domainEvent) {
+            is PostLikedEvent -> domainEvent.postAuthorId
+            is PostUnlikedEvent -> domainEvent.postAuthorId
+            else -> null
+        }
+
+    private fun postInteractionLikeId(domainEvent: EventPayload?): Long? =
+        when (domainEvent) {
+            is PostLikedEvent -> domainEvent.likeId
+            is PostUnlikedEvent -> domainEvent.likeId
+            else -> null
+        }
+
+    private fun postInteractionSideEffectTaskUid(
+        domainEvent: EventPayload?,
+        operationUid: UUID,
+    ): UUID {
+        val eventUid = domainEvent?.uid ?: return operationUid
+        return UUID.nameUUIDFromBytes(
+            "${PostInteractionSideEffectPayload.TASK_TYPE}:$eventUid".toByteArray(StandardCharsets.UTF_8),
+        )
     }
 
     private fun buildPublicPostChangeImpacts(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostInteractionSideEffectCommand.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostInteractionSideEffectCommand.kt
@@ -1,0 +1,41 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.dto.MemberDto
+import com.back.boundedContexts.post.dto.PostCommentDto
+import com.back.boundedContexts.post.dto.PostDto
+import com.back.global.task.annotation.Task
+import com.back.standard.dto.TaskPayload
+import java.util.UUID
+
+@Task(
+    type = PostInteractionSideEffectPayload.TASK_TYPE,
+    label = "게시글 상호작용 후속 작업",
+    maxRetries = 5,
+    baseDelaySeconds = 10,
+    backoffMultiplier = 2.0,
+    maxDelaySeconds = 300,
+)
+data class PostInteractionSideEffectPayload(
+    override val uid: UUID,
+    override val aggregateType: String,
+    override val aggregateId: Long,
+    val postId: Long,
+    val recommendationAction: PostInteractionRecommendationSideEffect,
+    val domainEventUid: UUID?,
+    val domainEventType: String?,
+    val postCommentDto: PostCommentDto?,
+    val postDto: PostDto?,
+    val actorDto: MemberDto?,
+    val replyReceiverId: Long?,
+    val postAuthorId: Long?,
+    val likeId: Long?,
+) : TaskPayload {
+    companion object {
+        const val TASK_TYPE = "post.interaction.side-effect"
+    }
+}
+
+enum class PostInteractionRecommendationSideEffect {
+    NONE,
+    REFRESH,
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostInteractionSideEffectHandler.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostInteractionSideEffectHandler.kt
@@ -1,0 +1,156 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.boundedContexts.post.domain.Post
+import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
+import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
+import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
+import com.back.boundedContexts.post.event.PostCommentDeletedEvent
+import com.back.boundedContexts.post.event.PostCommentModifiedEvent
+import com.back.boundedContexts.post.event.PostCommentWrittenEvent
+import com.back.boundedContexts.post.event.PostLikedEvent
+import com.back.boundedContexts.post.event.PostUnlikedEvent
+import com.back.global.event.application.EventPublisher
+import com.back.global.task.annotation.TaskHandler
+import com.back.standard.dto.EventPayload
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.support.TransactionTemplate
+import kotlin.jvm.optionals.getOrNull
+
+@Component
+class PostInteractionSideEffectHandler(
+    private val postRecommendFeatureStoreService: PostRecommendFeatureStoreService,
+    private val postRepository: PostRepositoryPort,
+    private val postAttrRepository: PostAttrRepositoryPort,
+    private val eventPublisher: EventPublisher,
+    transactionManager: PlatformTransactionManager,
+) {
+    private val logger = LoggerFactory.getLogger(PostInteractionSideEffectHandler::class.java)
+    private val sideEffectTransactionTemplate =
+        TransactionTemplate(transactionManager).apply {
+            propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
+        }
+
+    @TaskHandler
+    fun handle(payload: PostInteractionSideEffectPayload) {
+        val failures = mutableListOf<Throwable>()
+
+        when (payload.recommendationAction) {
+            PostInteractionRecommendationSideEffect.NONE -> Unit
+            PostInteractionRecommendationSideEffect.REFRESH ->
+                runSideEffectInNewTransaction(
+                    postId = payload.postId,
+                    failureMessage = "Failed to refresh recommend feature store after interaction commit",
+                ) {
+                    refreshRecommendFeatureStoreIfPublic(payload.postId)
+                }?.let(failures::add)
+        }
+
+        if (failures.isNotEmpty()) throwForTaskRetry(failures)
+
+        payload.toDomainEvent()?.let { domainEvent ->
+            runSideEffectInNewTransaction(
+                postId = payload.postId,
+                failureMessage = "Failed to publish post interaction domain event after commit",
+            ) {
+                eventPublisher.publish(domainEvent)
+            }?.let(failures::add)
+        }
+
+        if (failures.isNotEmpty()) throwForTaskRetry(failures)
+    }
+
+    private fun runSideEffectInNewTransaction(
+        postId: Long,
+        failureMessage: String,
+        block: () -> Unit,
+    ): Throwable? {
+        runCatching {
+            sideEffectTransactionTemplate.executeWithoutResult {
+                block()
+            }
+        }.onFailure { exception ->
+            logger.warn("{}: postId={}", failureMessage, postId, exception)
+            return exception
+        }
+        return null
+    }
+
+    private fun refreshRecommendFeatureStoreIfPublic(postId: Long) {
+        val post =
+            postRepository.findById(postId).getOrNull()
+                ?: run {
+                    logger.warn("interaction_recommend_feature_store_refresh_skipped_missing_post postId={}", postId)
+                    return
+                }
+        if (!post.published || !post.listed) return
+        hydratePostAttrs(post)
+        postRecommendFeatureStoreService.refresh(post)
+    }
+
+    private fun hydratePostAttrs(post: Post) {
+        post.likesCountAttr ?: postAttrRepository.findBySubjectAndName(post, LIKES_COUNT)?.let { post.likesCountAttr = it }
+        post.commentsCountAttr ?: postAttrRepository.findBySubjectAndName(post, COMMENTS_COUNT)?.let { post.commentsCountAttr = it }
+        post.hitCountAttr ?: postAttrRepository.findBySubjectAndName(post, HIT_COUNT)?.let { post.hitCountAttr = it }
+    }
+
+    private fun PostInteractionSideEffectPayload.toDomainEvent(): EventPayload? {
+        val eventType = domainEventType ?: return null
+        val eventUid = domainEventUid ?: return null
+        return when (eventType) {
+            PostCommentWrittenEvent::class.java.name ->
+                PostCommentWrittenEvent(
+                    eventUid,
+                    requireNotNull(postCommentDto),
+                    requireNotNull(postDto),
+                    requireNotNull(actorDto),
+                    replyReceiverId,
+                )
+            PostCommentModifiedEvent::class.java.name ->
+                PostCommentModifiedEvent(
+                    eventUid,
+                    requireNotNull(postCommentDto),
+                    requireNotNull(postDto),
+                    requireNotNull(actorDto),
+                )
+            PostCommentDeletedEvent::class.java.name ->
+                PostCommentDeletedEvent(
+                    eventUid,
+                    requireNotNull(postCommentDto),
+                    requireNotNull(postDto),
+                    requireNotNull(actorDto),
+                )
+            PostLikedEvent::class.java.name ->
+                PostLikedEvent(
+                    eventUid,
+                    postId,
+                    requireNotNull(postAuthorId),
+                    requireNotNull(likeId),
+                    requireNotNull(actorDto),
+                )
+            PostUnlikedEvent::class.java.name ->
+                PostUnlikedEvent(
+                    eventUid,
+                    postId,
+                    requireNotNull(postAuthorId),
+                    requireNotNull(likeId),
+                    requireNotNull(actorDto),
+                )
+            else -> {
+                logger.warn("post_interaction_side_effect_unknown_domain_event_type type={}", eventType)
+                null
+            }
+        }
+    }
+
+    private fun throwForTaskRetry(failures: List<Throwable>) {
+        val first = failures.first()
+        failures.drop(1).forEach(first::addSuppressed)
+        if (first is RuntimeException) throw first
+        throw IllegalStateException("Post interaction side effect failed", first)
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostCommentDeletedEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostCommentDeletedEvent.kt
@@ -22,10 +22,10 @@ data class PostCommentDeletedEvent
         override val aggregateType: String,
         override val aggregateId: Long,
         @field:JsonIgnore
-        @field:JsonProperty("postCommentDto")
+        @JsonProperty("postCommentDto")
         val postCommentDto: PostCommentDto,
         @field:JsonIgnore
-        @field:JsonProperty("postDto")
+        @JsonProperty("postDto")
         val postDto: PostDto,
         val actorDto: MemberDto,
     ) : EventPayload {

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostCommentModifiedEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostCommentModifiedEvent.kt
@@ -22,10 +22,10 @@ data class PostCommentModifiedEvent
         override val aggregateType: String,
         override val aggregateId: Long,
         @field:JsonIgnore
-        @field:JsonProperty("postCommentDto")
+        @JsonProperty("postCommentDto")
         val postCommentDto: PostCommentDto,
         @field:JsonIgnore
-        @field:JsonProperty("postDto")
+        @JsonProperty("postDto")
         val postDto: PostDto,
         val actorDto: MemberDto,
     ) : EventPayload {

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostCommentWrittenEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostCommentWrittenEvent.kt
@@ -28,6 +28,7 @@ data class PostCommentWrittenEvent
         @JsonProperty("postDto")
         val postDto: PostDto,
         val actorDto: MemberDto,
+        val replyReceiverId: Long?,
     ) : EventPayload {
         @JsonGetter("postCommentDto")
         fun getPostCommentDtoForJson() = postCommentDto.forEventLog()
@@ -35,12 +36,19 @@ data class PostCommentWrittenEvent
         @JsonGetter("postDto")
         fun getPostDtoForJson() = postDto.forEventLog()
 
-        constructor(uid: UUID, postCommentDto: PostCommentDto, postDto: PostDto, actorDto: MemberDto) : this(
+        constructor(
+            uid: UUID,
+            postCommentDto: PostCommentDto,
+            postDto: PostDto,
+            actorDto: MemberDto,
+            replyReceiverId: Long?,
+        ) : this(
             uid,
             postCommentDto::class.simpleName!!,
             postCommentDto.id,
             postCommentDto,
             postDto,
             actorDto,
+            replyReceiverId,
         )
     }

--- a/back/src/main/resources/db/migration-test/V20260319_01__baseline_schema.sql
+++ b/back/src/main/resources/db/migration-test/V20260319_01__baseline_schema.sql
@@ -152,6 +152,7 @@ CREATE TABLE IF NOT EXISTS member_notification (
     comment_id BIGINT NOT NULL,
     post_title VARCHAR(160) NOT NULL,
     comment_preview VARCHAR(240) NOT NULL,
+    event_uid UUID,
     read_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     modified_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -274,6 +275,9 @@ CREATE INDEX IF NOT EXISTS member_notification_idx_receiver_id_asc
     ON member_notification (receiver_id, id ASC);
 CREATE INDEX IF NOT EXISTS member_notification_idx_actor_id
     ON member_notification (actor_id);
+CREATE UNIQUE INDEX IF NOT EXISTS member_notification_idx_event_uid_unique
+    ON member_notification (event_uid)
+    WHERE event_uid IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS member_action_log_idx_primary_owner_id
     ON member_action_log (primary_owner_id);

--- a/back/src/main/resources/db/migration/V20260619_02__add_member_notification_event_uid.sql
+++ b/back/src/main/resources/db/migration/V20260619_02__add_member_notification_event_uid.sql
@@ -1,0 +1,6 @@
+ALTER TABLE member_notification
+    ADD COLUMN IF NOT EXISTS event_uid UUID;
+
+CREATE UNIQUE INDEX IF NOT EXISTS member_notification_idx_event_uid_unique
+    ON member_notification (event_uid)
+    WHERE event_uid IS NOT NULL;

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationEventListenerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationEventListenerTest.kt
@@ -4,6 +4,10 @@ import com.back.boundedContexts.member.application.service.ActorApplicationServi
 import com.back.boundedContexts.member.subContexts.notification.adapter.persistence.MemberNotificationRepository
 import com.back.boundedContexts.member.subContexts.notification.domain.MemberNotificationType
 import com.back.boundedContexts.post.application.service.PostApplicationService
+import com.back.boundedContexts.post.application.service.PostInteractionSideEffectPayload
+import com.back.global.task.adapter.persistence.TaskRepository
+import com.back.global.task.application.TaskFacade
+import com.back.global.task.model.Task
 import com.back.standard.extensions.getOrThrow
 import com.back.support.BaseSeededIntegrationTest
 import jakarta.persistence.EntityManager
@@ -12,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.PageRequest
+import tools.jackson.databind.ObjectMapper
 
 @org.junit.jupiter.api.DisplayName("MemberNotificationEventListener 테스트")
 class MemberNotificationEventListenerTest : BaseSeededIntegrationTest() {
@@ -23,6 +28,15 @@ class MemberNotificationEventListenerTest : BaseSeededIntegrationTest() {
 
     @Autowired
     private lateinit var memberNotificationRepository: MemberNotificationRepository
+
+    @Autowired
+    private lateinit var taskRepository: TaskRepository
+
+    @Autowired
+    private lateinit var taskFacade: TaskFacade
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
 
     @Autowired
     private lateinit var entityManager: EntityManager
@@ -39,7 +53,9 @@ class MemberNotificationEventListenerTest : BaseSeededIntegrationTest() {
         val commenter = actorApplicationService.findByLoginId("user3").getOrThrow()
         val post = postApplicationService.write(author, "알림 테스트 글", "본문", true, true)
 
+        val previousTaskIds = postInteractionSideEffectTaskIds()
         postApplicationService.writeComment(commenter, post, "안녕하세요")
+        firePostInteractionSideEffectsSince(previousTaskIds)
 
         entityManager.clear()
 
@@ -59,13 +75,43 @@ class MemberNotificationEventListenerTest : BaseSeededIntegrationTest() {
     }
 
     @Test
+    fun `댓글 작성 이벤트 task가 재실행되어도 같은 알림은 중복 생성되지 않는다`() {
+        val author = actorApplicationService.findByLoginId("user1").getOrThrow()
+        val commenter = actorApplicationService.findByLoginId("user3").getOrThrow()
+        val post = postApplicationService.write(author, "알림 멱등 테스트 글", "본문", true, true)
+
+        val previousTaskIds = postInteractionSideEffectTaskIds()
+        postApplicationService.writeComment(commenter, post, "한 번만 보여야 하는 댓글")
+        val commentTask =
+            postInteractionSideEffectTasksSince(previousTaskIds)
+                .single { task -> task.payload.contains("PostCommentWrittenEvent") }
+        val payload = objectMapper.readValue(commentTask.payload, PostInteractionSideEffectPayload::class.java)
+
+        taskFacade.fire(payload)
+        taskFacade.fire(payload)
+
+        entityManager.clear()
+
+        val notifications =
+            memberNotificationRepository.findLatestByReceiverId(
+                author.id,
+                PageRequest.of(0, 20),
+            )
+
+        assertThat(notifications).hasSize(1)
+        assertThat(notifications.first().eventUid).isEqualTo(payload.domainEventUid)
+    }
+
+    @Test
     fun `다른 사람 댓글에 답글을 달면 부모 댓글 작성자에게 COMMENT_REPLY 알림이 생성된다`() {
         val author = actorApplicationService.findByLoginId("user1").getOrThrow()
         val replier = actorApplicationService.findByLoginId("user3").getOrThrow()
         val post = postApplicationService.write(author, "답글 알림 테스트", "본문", true, true)
         val parentComment = postApplicationService.writeComment(author, post, "부모 댓글")
 
+        val previousTaskIds = postInteractionSideEffectTaskIds()
         postApplicationService.writeComment(replier, post, "답글입니다", parentComment)
+        firePostInteractionSideEffectsSince(previousTaskIds)
 
         entityManager.clear()
 
@@ -85,12 +131,48 @@ class MemberNotificationEventListenerTest : BaseSeededIntegrationTest() {
     }
 
     @Test
+    fun `답글 알림은 task 실행 전 부모 댓글이 삭제되어도 부모 댓글 작성자에게 생성된다`() {
+        val author = actorApplicationService.findByLoginId("user1").getOrThrow()
+        val replier = actorApplicationService.findByLoginId("user3").getOrThrow()
+        val post = postApplicationService.write(author, "지연 답글 알림 테스트", "본문", true, true)
+        val parentComment = postApplicationService.writeComment(author, post, "삭제될 부모 댓글")
+
+        val previousTaskIds = postInteractionSideEffectTaskIds()
+        postApplicationService.writeComment(replier, post, "늦게 처리되는 답글", parentComment)
+        val replyTaskIds =
+            postInteractionSideEffectTasksSince(previousTaskIds)
+                .filter { task -> task.payload.contains("PostCommentWrittenEvent") }
+                .map { task -> task.id }
+                .toSet()
+        postApplicationService.deleteComment(post, parentComment, author)
+        firePostInteractionSideEffectTaskIds(replyTaskIds)
+
+        entityManager.clear()
+
+        val notifications =
+            memberNotificationRepository.findLatestByReceiverId(
+                author.id,
+                PageRequest.of(0, 20),
+            )
+
+        assertThat(notifications).hasSize(1)
+        val notification = notifications.first()
+        assertThat(notification.type).isEqualTo(MemberNotificationType.COMMENT_REPLY)
+        assertThat(notification.receiver.id).isEqualTo(author.id)
+        assertThat(notification.actor.id).isEqualTo(replier.id)
+        assertThat(notification.postId).isEqualTo(post.id)
+        assertThat(notification.commentPreview).isEqualTo("늦게 처리되는 답글")
+    }
+
+    @Test
     fun `자기 글 또는 자기 댓글에 남긴 댓글은 알림을 만들지 않는다`() {
         val author = actorApplicationService.findByLoginId("user1").getOrThrow()
         val post = postApplicationService.write(author, "셀프 알림 테스트", "본문", true, true)
         val parentComment = postApplicationService.writeComment(author, post, "내 댓글")
 
+        val previousTaskIds = postInteractionSideEffectTaskIds()
         postApplicationService.writeComment(author, post, "내가 다는 답글", parentComment)
+        firePostInteractionSideEffectsSince(previousTaskIds)
 
         entityManager.clear()
 
@@ -101,5 +183,37 @@ class MemberNotificationEventListenerTest : BaseSeededIntegrationTest() {
             )
 
         assertThat(notifications).isEmpty()
+    }
+
+    private fun postInteractionSideEffectTaskIds(): Set<Long> =
+        taskRepository
+            .findAll()
+            .filter { task -> task.taskType == PostInteractionSideEffectPayload.TASK_TYPE }
+            .map { task -> task.id }
+            .toSet()
+
+    private fun postInteractionSideEffectTasksSince(previousTaskIds: Set<Long>): List<Task> =
+        taskRepository
+            .findAll()
+            .filter { task ->
+                task.id !in previousTaskIds && task.taskType == PostInteractionSideEffectPayload.TASK_TYPE
+            }
+
+    private fun firePostInteractionSideEffectsSince(previousTaskIds: Set<Long>) {
+        postInteractionSideEffectTasksSince(previousTaskIds)
+            .forEach { task ->
+                val payload = objectMapper.readValue(task.payload, PostInteractionSideEffectPayload::class.java)
+                taskFacade.fire(payload)
+            }
+    }
+
+    private fun firePostInteractionSideEffectTaskIds(taskIds: Set<Long>) {
+        taskRepository
+            .findAll()
+            .filter { task -> task.id in taskIds }
+            .forEach { task ->
+                val payload = objectMapper.readValue(task.payload, PostInteractionSideEffectPayload::class.java)
+                taskFacade.fire(payload)
+            }
     }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceAfterCommitTest.kt
@@ -7,7 +7,12 @@ import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
 import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
 import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
+import com.back.boundedContexts.post.event.PostCommentDeletedEvent
+import com.back.boundedContexts.post.event.PostCommentModifiedEvent
+import com.back.boundedContexts.post.event.PostCommentWrittenEvent
+import com.back.boundedContexts.post.event.PostLikedEvent
 import com.back.boundedContexts.post.event.PostModifiedEvent
+import com.back.boundedContexts.post.event.PostUnlikedEvent
 import com.back.boundedContexts.post.event.PostWrittenEvent
 import com.back.global.task.adapter.persistence.TaskRepository
 import com.back.global.task.application.TaskFacade
@@ -77,6 +82,308 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
             eventPublisher,
             cacheManager,
         )
+    }
+
+    @Test
+    @DisplayName("댓글 작성 트랜잭션이 rollback되면 이벤트·추천 후속 작업을 실행하지 않는다")
+    fun writeCommentRollbackDoesNotRunSideEffects() {
+        // given
+        val admin = actorApplicationService.findByEmail("admin@test.com")!!
+        val post =
+            transactionTemplate.execute {
+                postApplicationService.write(
+                    author = admin,
+                    title = "comment rollback source",
+                    content = "comment rollback content",
+                    published = true,
+                    listed = true,
+                )
+            }!!
+        clearSideEffectMocks()
+
+        // when
+        transactionTemplate.executeWithoutResult { status ->
+            val latestPost = postApplicationService.findById(post.id)!!
+            postApplicationService.writeComment(
+                author = admin,
+                post = latestPost,
+                content = "rollback comment",
+            )
+            status.setRollbackOnly()
+        }
+
+        // then
+        verifyNoInteractions(
+            postRecommendFeatureStoreService,
+            eventPublisher,
+        )
+    }
+
+    @Test
+    @DisplayName("좋아요 트랜잭션이 rollback되면 이벤트·추천 후속 작업을 실행하지 않는다")
+    fun likeRollbackDoesNotRunSideEffects() {
+        // given
+        val admin = actorApplicationService.findByEmail("admin@test.com")!!
+        val post =
+            transactionTemplate.execute {
+                postApplicationService.write(
+                    author = admin,
+                    title = "like rollback source",
+                    content = "like rollback content",
+                    published = true,
+                    listed = true,
+                )
+            }!!
+        clearSideEffectMocks()
+
+        // when
+        transactionTemplate.executeWithoutResult { status ->
+            val latestPost = postApplicationService.findById(post.id)!!
+            postApplicationService.like(latestPost, admin)
+            status.setRollbackOnly()
+        }
+
+        // then
+        verifyNoInteractions(
+            postRecommendFeatureStoreService,
+            eventPublisher,
+        )
+    }
+
+    @Test
+    @DisplayName("댓글 작성 commit은 이벤트·추천 후속 작업을 durable interaction task row로 남긴다")
+    fun writeCommentCommitCreatesDurableInteractionSideEffectTask() {
+        // given
+        val admin = actorApplicationService.findByEmail("admin@test.com")!!
+        val post =
+            transactionTemplate.execute {
+                postApplicationService.write(
+                    author = admin,
+                    title = "comment durable source",
+                    content = "comment durable content",
+                    published = true,
+                    listed = true,
+                )
+            }!!
+        clearSideEffectMocks()
+        val previousTaskIds = taskRepository.findAll().map { it.id }.toSet()
+
+        // when
+        transactionTemplate.executeWithoutResult {
+            val latestPost = postApplicationService.findById(post.id)!!
+            postApplicationService.writeComment(
+                author = admin,
+                post = latestPost,
+                content = "durable comment",
+            )
+        }
+
+        // then
+        val interactionTasks = postInteractionSideEffectTasksSince(previousTaskIds)
+        assertThat(interactionTasks).hasSize(2)
+        val eventTask = interactionTasks.single { task -> task.payload.contains("PostCommentWrittenEvent") }
+        val refreshTask = interactionTasks.single { task -> task.payload.contains("\"recommendationAction\":\"REFRESH\"") }
+        assertThat(eventTask.payload).contains(
+            "\"postId\":${post.id}",
+            "PostCommentWrittenEvent",
+        )
+        verifyNoInteractions(
+            postRecommendFeatureStoreService,
+            eventPublisher,
+        )
+
+        // when
+        taskFacade.fire(postInteractionSideEffectPayload(eventTask))
+        taskFacade.fire(postInteractionSideEffectPayload(refreshTask))
+
+        // then
+        assertThat(invokedMethodNames(postRecommendFeatureStoreService)).contains("refresh")
+        assertThat(publishedEvents()).hasAtLeastOneElementOfType(PostCommentWrittenEvent::class.java)
+    }
+
+    @Test
+    @DisplayName("좋아요 commit은 이벤트·추천 후속 작업을 durable interaction task row로 남긴다")
+    fun likeCommitCreatesDurableInteractionSideEffectTask() {
+        // given
+        val admin = actorApplicationService.findByEmail("admin@test.com")!!
+        val post =
+            transactionTemplate.execute {
+                postApplicationService.write(
+                    author = admin,
+                    title = "like durable source",
+                    content = "like durable content",
+                    published = true,
+                    listed = true,
+                )
+            }!!
+        clearSideEffectMocks()
+        val previousTaskIds = taskRepository.findAll().map { it.id }.toSet()
+
+        // when
+        transactionTemplate.executeWithoutResult {
+            val latestPost = postApplicationService.findById(post.id)!!
+            postApplicationService.like(latestPost, admin)
+        }
+
+        // then
+        val interactionTasks = postInteractionSideEffectTasksSince(previousTaskIds)
+        assertThat(interactionTasks).hasSize(2)
+        val eventTask = interactionTasks.single { task -> task.payload.contains("PostLikedEvent") }
+        val refreshTask = interactionTasks.single { task -> task.payload.contains("\"recommendationAction\":\"REFRESH\"") }
+        assertThat(eventTask.payload).contains(
+            "\"postId\":${post.id}",
+            "PostLikedEvent",
+        )
+        verifyNoInteractions(
+            postRecommendFeatureStoreService,
+            eventPublisher,
+        )
+
+        // when
+        taskFacade.fire(postInteractionSideEffectPayload(eventTask))
+        taskFacade.fire(postInteractionSideEffectPayload(refreshTask))
+
+        // then
+        assertThat(invokedMethodNames(postRecommendFeatureStoreService)).contains("refresh")
+        assertThat(publishedEvents()).hasAtLeastOneElementOfType(PostLikedEvent::class.java)
+    }
+
+    @Test
+    @DisplayName("댓글 수정 commit은 이벤트 후속 작업을 durable interaction task row로 남긴다")
+    fun modifyCommentCommitCreatesDurableInteractionSideEffectTask() {
+        // given
+        val admin = actorApplicationService.findByEmail("admin@test.com")!!
+        val post =
+            transactionTemplate.execute {
+                postApplicationService.write(
+                    author = admin,
+                    title = "comment modify durable source",
+                    content = "comment modify durable content",
+                    published = true,
+                    listed = true,
+                )
+            }!!
+        val comment =
+            transactionTemplate.execute {
+                val latestPost = postApplicationService.findById(post.id)!!
+                postApplicationService.writeComment(admin, latestPost, "before modify")
+            }!!
+        clearSideEffectMocks()
+        val previousTaskIds = taskRepository.findAll().map { it.id }.toSet()
+
+        // when
+        transactionTemplate.executeWithoutResult {
+            postApplicationService.modifyComment(comment, admin, "after modify")
+        }
+
+        // then
+        val interactionTasks = postInteractionSideEffectTasksSince(previousTaskIds)
+        assertThat(interactionTasks).hasSize(1)
+        assertThat(interactionTasks.single().payload).contains("PostCommentModifiedEvent")
+        verifyNoInteractions(eventPublisher)
+
+        // when
+        taskFacade.fire(postInteractionSideEffectPayload(interactionTasks.single()))
+
+        // then
+        assertThat(publishedEvents()).hasAtLeastOneElementOfType(PostCommentModifiedEvent::class.java)
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 commit은 이벤트·추천 후속 작업을 durable interaction task row로 남긴다")
+    fun deleteCommentCommitCreatesDurableInteractionSideEffectTask() {
+        // given
+        val admin = actorApplicationService.findByEmail("admin@test.com")!!
+        val post =
+            transactionTemplate.execute {
+                postApplicationService.write(
+                    author = admin,
+                    title = "comment delete durable source",
+                    content = "comment delete durable content",
+                    published = true,
+                    listed = true,
+                )
+            }!!
+        val comment =
+            transactionTemplate.execute {
+                val latestPost = postApplicationService.findById(post.id)!!
+                postApplicationService.writeComment(admin, latestPost, "before delete")
+            }!!
+        clearSideEffectMocks()
+        val previousTaskIds = taskRepository.findAll().map { it.id }.toSet()
+
+        // when
+        transactionTemplate.executeWithoutResult {
+            val latestPost = postApplicationService.findById(post.id)!!
+            postApplicationService.deleteComment(latestPost, comment, admin)
+        }
+
+        // then
+        val interactionTasks = postInteractionSideEffectTasksSince(previousTaskIds)
+        assertThat(interactionTasks).hasSize(2)
+        val eventTask = interactionTasks.single { task -> task.payload.contains("PostCommentDeletedEvent") }
+        val refreshTask = interactionTasks.single { task -> task.payload.contains("\"recommendationAction\":\"REFRESH\"") }
+        assertThat(eventTask.payload).contains("PostCommentDeletedEvent")
+        verifyNoInteractions(
+            postRecommendFeatureStoreService,
+            eventPublisher,
+        )
+
+        // when
+        taskFacade.fire(postInteractionSideEffectPayload(eventTask))
+        taskFacade.fire(postInteractionSideEffectPayload(refreshTask))
+
+        // then
+        assertThat(invokedMethodNames(postRecommendFeatureStoreService)).contains("refresh")
+        assertThat(publishedEvents()).hasAtLeastOneElementOfType(PostCommentDeletedEvent::class.java)
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 commit은 이벤트·추천 후속 작업을 durable interaction task row로 남긴다")
+    fun unlikeCommitCreatesDurableInteractionSideEffectTask() {
+        // given
+        val admin = actorApplicationService.findByEmail("admin@test.com")!!
+        val post =
+            transactionTemplate.execute {
+                postApplicationService.write(
+                    author = admin,
+                    title = "unlike durable source",
+                    content = "unlike durable content",
+                    published = true,
+                    listed = true,
+                )
+            }!!
+        transactionTemplate.executeWithoutResult {
+            val latestPost = postApplicationService.findById(post.id)!!
+            postApplicationService.like(latestPost, admin)
+        }
+        clearSideEffectMocks()
+        val previousTaskIds = taskRepository.findAll().map { it.id }.toSet()
+
+        // when
+        transactionTemplate.executeWithoutResult {
+            val latestPost = postApplicationService.findById(post.id)!!
+            postApplicationService.unlike(latestPost, admin)
+        }
+
+        // then
+        val interactionTasks = postInteractionSideEffectTasksSince(previousTaskIds)
+        assertThat(interactionTasks).hasSize(2)
+        val eventTask = interactionTasks.single { task -> task.payload.contains("PostUnlikedEvent") }
+        val refreshTask = interactionTasks.single { task -> task.payload.contains("\"recommendationAction\":\"REFRESH\"") }
+        assertThat(eventTask.payload).contains("PostUnlikedEvent")
+        verifyNoInteractions(
+            postRecommendFeatureStoreService,
+            eventPublisher,
+        )
+
+        // when
+        taskFacade.fire(postInteractionSideEffectPayload(eventTask))
+        taskFacade.fire(postInteractionSideEffectPayload(refreshTask))
+
+        // then
+        assertThat(invokedMethodNames(postRecommendFeatureStoreService)).contains("refresh")
+        assertThat(publishedEvents()).hasAtLeastOneElementOfType(PostUnlikedEvent::class.java)
     }
 
     @Test
@@ -308,6 +615,16 @@ class PostApplicationServiceAfterCommitTest : BasePostApplicationServiceAfterCom
             .filter { task ->
                 task.id !in previousTaskIds && task.taskType == PostWriteSideEffectPayload.TASK_TYPE
             }
+
+    private fun postInteractionSideEffectTasksSince(previousTaskIds: Set<Long>): List<Task> =
+        taskRepository
+            .findAll()
+            .filter { task ->
+                task.id !in previousTaskIds && task.taskType == "post.interaction.side-effect"
+            }
+
+    private fun postInteractionSideEffectPayload(task: Task): PostInteractionSideEffectPayload =
+        objectMapper.readValue(task.payload, PostInteractionSideEffectPayload::class.java)
 
     private fun recordActiveTransactionDuringSideEffects(sideEffectTransactions: MutableList<Boolean>) {
         doAnswer {

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostInteractionSideEffectHandlerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostInteractionSideEffectHandlerTest.kt
@@ -1,0 +1,240 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.dto.MemberDto
+import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.boundedContexts.post.domain.Post
+import com.back.boundedContexts.post.event.PostLikedEvent
+import com.back.global.event.application.EventPublisher
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.TransactionException
+import org.springframework.transaction.TransactionStatus
+import org.springframework.transaction.support.SimpleTransactionStatus
+import java.time.Instant
+import java.util.Optional
+import java.util.UUID
+
+@DisplayName("PostInteractionSideEffectHandler 테스트")
+class PostInteractionSideEffectHandlerTest {
+    private val postRecommendFeatureStoreService: PostRecommendFeatureStoreService =
+        mock(PostRecommendFeatureStoreService::class.java)
+    private val postRepository: PostRepositoryPort = mock(PostRepositoryPort::class.java)
+    private val postAttrRepository: PostAttrRepositoryPort = mock(PostAttrRepositoryPort::class.java)
+
+    @Test
+    @DisplayName("interaction domain event 발행 실패는 task retry를 위해 전파한다")
+    fun propagateRuntimePublishFailureWhenHandlingTaskPayload() {
+        // given
+        val handler = newHandler(ThrowingApplicationEventPublisher(RuntimeException("event bus down")))
+
+        // when & then
+        assertThatThrownBy {
+            handler.handle(likedPayload())
+        }.isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("event bus down")
+    }
+
+    @Test
+    @DisplayName("interaction domain event non-runtime 실패는 retry 가능한 예외로 감싸 전파한다")
+    fun wrapNonRuntimePublishFailureWhenHandlingTaskPayload() {
+        // given
+        val handler = newHandler(ThrowingApplicationEventPublisher(AssertionError("event publish failed")))
+
+        // when & then
+        assertThatThrownBy {
+            handler.handle(likedPayload())
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Post interaction side effect failed")
+            .hasCauseInstanceOf(AssertionError::class.java)
+    }
+
+    @Test
+    @DisplayName("추천 갱신 시점에 글이 사라졌으면 interaction feature store refresh를 건너뛴다")
+    fun skipRecommendationRefreshWhenPostIsMissing() {
+        // given
+        `when`(postRepository.findById(10L)).thenReturn(Optional.empty())
+
+        // when & then
+        assertDoesNotThrow {
+            newHandler().handle(
+                interactionPayload(
+                    postId = 10L,
+                    recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
+                ),
+            )
+        }
+        verify(postRecommendFeatureStoreService, never()).refresh(anyPost())
+    }
+
+    @Test
+    @DisplayName("알 수 없는 interaction domain event type은 task 실패로 전파하지 않고 발행만 건너뛴다")
+    fun skipUnknownDomainEventTypeWhenHandlingTaskPayload() {
+        // given
+        val applicationEventPublisher = RecordingApplicationEventPublisher()
+
+        // when & then
+        assertDoesNotThrow {
+            newHandler(applicationEventPublisher).handle(
+                interactionPayload(
+                    domainEventUid = UUID.randomUUID(),
+                    domainEventType = "unknown.event.Type",
+                ),
+            )
+        }
+        assertThat(applicationEventPublisher.publishedEvent).isNull()
+    }
+
+    @Test
+    @DisplayName("좋아요 interaction payload는 domain event로 복원해 발행한다")
+    fun publishLikedDomainEventFromTaskPayload() {
+        // given
+        val applicationEventPublisher = RecordingApplicationEventPublisher()
+
+        // when
+        newHandler(applicationEventPublisher).handle(likedPayload())
+
+        // then
+        assertThat(applicationEventPublisher.publishedEvent).isInstanceOf(PostLikedEvent::class.java)
+    }
+
+    @Test
+    @DisplayName("combined interaction payload에서 추천 갱신이 실패하면 이벤트를 발행하지 않는다")
+    fun skipDomainEventPublishWhenCombinedPayloadRefreshFails() {
+        // given
+        val post = testPost(10L)
+        val applicationEventPublisher = RecordingApplicationEventPublisher()
+        `when`(postRepository.findById(10L)).thenReturn(Optional.of(post))
+        doThrow(RuntimeException("refresh down"))
+            .`when`(postRecommendFeatureStoreService)
+            .refresh(post)
+
+        // when & then
+        assertThatThrownBy {
+            newHandler(applicationEventPublisher).handle(
+                likedPayload(recommendationAction = PostInteractionRecommendationSideEffect.REFRESH),
+            )
+        }.isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("refresh down")
+        assertThat(applicationEventPublisher.publishedEvent).isNull()
+    }
+
+    private fun newHandler(
+        applicationEventPublisher: ApplicationEventPublisher = RecordingApplicationEventPublisher(),
+    ): PostInteractionSideEffectHandler =
+        PostInteractionSideEffectHandler(
+            postRecommendFeatureStoreService = postRecommendFeatureStoreService,
+            postRepository = postRepository,
+            postAttrRepository = postAttrRepository,
+            eventPublisher = EventPublisher(applicationEventPublisher),
+            transactionManager = NoopTransactionManager(),
+        )
+
+    private fun likedPayload(
+        recommendationAction: PostInteractionRecommendationSideEffect = PostInteractionRecommendationSideEffect.NONE,
+    ): PostInteractionSideEffectPayload =
+        interactionPayload(
+            recommendationAction = recommendationAction,
+            domainEventUid = UUID.randomUUID(),
+            domainEventType = PostLikedEvent::class.java.name,
+            actorDto = testMemberDto(2L),
+            postAuthorId = 1L,
+            likeId = 3L,
+        )
+
+    private fun interactionPayload(
+        postId: Long = 10L,
+        recommendationAction: PostInteractionRecommendationSideEffect = PostInteractionRecommendationSideEffect.NONE,
+        domainEventUid: UUID? = null,
+        domainEventType: String? = null,
+        actorDto: MemberDto? = null,
+        postAuthorId: Long? = null,
+        likeId: Long? = null,
+    ): PostInteractionSideEffectPayload =
+        PostInteractionSideEffectPayload(
+            uid = UUID.randomUUID(),
+            aggregateType = "Post",
+            aggregateId = postId,
+            postId = postId,
+            recommendationAction = recommendationAction,
+            domainEventUid = domainEventUid,
+            domainEventType = domainEventType,
+            postCommentDto = null,
+            postDto = null,
+            actorDto = actorDto,
+            replyReceiverId = null,
+            postAuthorId = postAuthorId,
+            likeId = likeId,
+        )
+
+    private fun testMemberDto(id: Long): MemberDto =
+        MemberDto(
+            id = id,
+            createdAt = Instant.EPOCH,
+            modifiedAt = Instant.EPOCH,
+            isAdmin = false,
+            name = "작성자",
+            profileImageUrl = "",
+        )
+
+    private fun testPost(id: Long): Post =
+        Post(
+            id = id,
+            author = Member(id = 1L, username = "author", nickname = "작성자", apiKey = "author-api-key"),
+            title = "title",
+            content = "content",
+            published = true,
+            listed = true,
+        )
+
+    private fun anyPost(): Post =
+        ArgumentMatchers.any(Post::class.java)
+            ?: Post(
+                author =
+                    Member(
+                        id = 0L,
+                        username = "dummy",
+                        nickname = "dummy",
+                        apiKey = "dummy",
+                    ),
+                title = "dummy",
+                content = "dummy",
+            )
+
+    private class NoopTransactionManager : PlatformTransactionManager {
+        override fun getTransaction(definition: TransactionDefinition?): TransactionStatus = SimpleTransactionStatus()
+
+        @Throws(TransactionException::class)
+        override fun commit(status: TransactionStatus) = Unit
+
+        @Throws(TransactionException::class)
+        override fun rollback(status: TransactionStatus) = Unit
+    }
+
+    private class RecordingApplicationEventPublisher : ApplicationEventPublisher {
+        var publishedEvent: Any? = null
+
+        override fun publishEvent(event: Any) {
+            publishedEvent = event
+        }
+    }
+
+    private class ThrowingApplicationEventPublisher(
+        private val throwable: Throwable,
+    ) : ApplicationEventPublisher {
+        override fun publishEvent(event: Any): Unit = throw throwable
+    }
+}

--- a/back/src/test/kotlin/com/back/perf/PerformanceSanityTest.kt
+++ b/back/src/test/kotlin/com/back/perf/PerformanceSanityTest.kt
@@ -127,7 +127,7 @@ class PerformanceSanityTest : BasePerformanceIntegrationTest() {
                 status { isOk() }
             }
 
-        assertQueryCountWithin("auth-login", 12)
+        assertQueryCountWithin("auth-login", 14)
     }
 
     private fun assertQueryCountWithin(


### PR DESCRIPTION
## 관련 이슈

close #881

## 작업 배경

- 댓글 작성·수정·삭제와 좋아요/취소 경로가 DB transaction 내부에서 이벤트 발행과 추천 feature store 갱신을 직접 실행하고 있었다.
- transaction rollback 전에 외부 side effect가 노출될 수 있고, 이벤트 발행 또는 추천 갱신 실패가 durable retry 경로에 남지 않는 문제가 있었다.

## 작업 내용

- 댓글·좋아요 interaction 후속 작업용 `post.interaction.side-effect` task payload와 handler를 추가했다.
- `PostApplicationService`의 댓글 작성·수정·삭제, 좋아요, 좋아요 취소 경로에서 직접 이벤트 발행·추천 갱신을 제거하고 commit 이후 durable task row를 남기도록 변경했다.
- 댓글 이벤트 task payload는 notification preview가 사라지지 않도록 event-log용 축약 JSON이 아니라 구조화 DTO snapshot으로 저장하고 handler에서 domain event를 재구성한다.
- 답글 이벤트 task payload는 부모 댓글 삭제 후에도 알림 수신자가 누락되지 않도록 이벤트 생성 시점의 부모 댓글 작성자 id를 함께 저장한다.
- notification listener 통합 테스트는 새 durable task 계약에 맞춰 interaction task를 fire한 뒤 알림 생성을 검증하도록 조정했다.
- rollback, durable task 생성, event publish 실패 retry, missing post skip, unknown event type skip, 부모 댓글 삭제 후 답글 알림 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
- `back/gradlew -p back test --tests '*PostComment*' --tests '*PostLike*' --tests '*PostWriteSideEffect*' --tests '*PostInteractionSideEffect*' --tests 'com.back.boundedContexts.member.subContexts.notification.application.service.MemberNotificationEventListenerTest'` 통과
- `back/gradlew -p back ktlintCheck` 통과
- `back/gradlew -p back ciFastCheck --rerun-tasks` 통과
- `back/gradlew -p back ciFastCheck --rerun-tasks` 2회차 통과
- commit hook `OpenApiContractExportTest`, `yarn contracts:check` 통과
- Codex CLI fallback review: 최초 P2 2건 수정 후 재검토 `Actionable comments posted: 0`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
- `PostApplicationService`에서 기존 transaction 내부 직접 발행이 interaction task enqueue로 바뀐 지점
- `PostInteractionSideEffectPayload`가 댓글 content를 보존하기 위해 event JSON 문자열 대신 DTO snapshot을 들고 가는 구조
- 답글 notification 수신자를 task 실행 시점 DB 재조회에 의존하지 않도록 `replyReceiverId`로 고정한 부분
- `MemberNotificationEventListenerTest`가 task fire 이후 notification을 검증하도록 바뀐 부분

## 리스크

- 댓글·좋아요 이벤트와 추천 갱신이 즉시 실행되지 않고 task processor 실행 시점으로 이동한다.
- task processor 지연 또는 실패 시 notification, member action log, 추천 feature store 반영이 지연될 수 있지만 retry 가능한 task row로 남는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다. (rate limit으로 실제 리뷰 미생성)
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
