### PR TITLE
[Fix] 클라우드 multipart 업로드 상태머신 보강

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/persistence/CloudVideoUploadSessionRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/persistence/CloudVideoUploadSessionRepository.kt
@@ -4,9 +4,11 @@ import com.back.boundedContexts.cloud.application.port.output.CloudVideoUploadPa
 import com.back.boundedContexts.cloud.application.port.output.CloudVideoUploadSessionRepositoryPort
 import com.back.boundedContexts.cloud.model.CloudVideoUploadPart
 import com.back.boundedContexts.cloud.model.CloudVideoUploadSession
+import com.back.boundedContexts.cloud.model.CloudVideoUploadSessionStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 
 interface CloudVideoUploadSessionRepository :
@@ -40,6 +42,65 @@ interface CloudVideoUploadSessionRepository :
         now: Instant,
         limit: Int,
     ): List<CloudVideoUploadSession>
+
+    @Transactional
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        """
+        UPDATE CloudVideoUploadSession s
+        SET s.uploadId = :uploadId,
+            s.status = :nextStatus,
+            s.failureReason = NULL,
+            s.modifiedAt = :now
+        WHERE s.id = :id
+          AND s.status = :expectedStatus
+        """,
+    )
+    override fun attachUploadIdAndTransition(
+        id: Long,
+        expectedStatus: CloudVideoUploadSessionStatus,
+        uploadId: String,
+        nextStatus: CloudVideoUploadSessionStatus,
+        now: Instant,
+    ): Int
+
+    @Transactional
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        """
+        UPDATE CloudVideoUploadSession s
+        SET s.status = :nextStatus,
+            s.failureReason = NULL,
+            s.modifiedAt = :now
+        WHERE s.id = :id
+          AND s.status = :expectedStatus
+        """,
+    )
+    override fun transitionStatus(
+        id: Long,
+        expectedStatus: CloudVideoUploadSessionStatus,
+        nextStatus: CloudVideoUploadSessionStatus,
+        now: Instant,
+    ): Int
+
+    @Transactional
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        """
+        UPDATE CloudVideoUploadSession s
+        SET s.status = 'FAILED',
+            s.failureReason = :reason,
+            s.modifiedAt = :now
+        WHERE s.id = :id
+          AND s.status = :expectedStatus
+        """,
+    )
+    override fun markFailed(
+        id: Long,
+        expectedStatus: CloudVideoUploadSessionStatus,
+        reason: String,
+        now: Instant,
+    ): Int
 }
 
 interface CloudVideoUploadPartRepository :

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/port/output/CloudVideoUploadSessionRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/port/output/CloudVideoUploadSessionRepositoryPort.kt
@@ -2,6 +2,7 @@ package com.back.boundedContexts.cloud.application.port.output
 
 import com.back.boundedContexts.cloud.model.CloudVideoUploadPart
 import com.back.boundedContexts.cloud.model.CloudVideoUploadSession
+import com.back.boundedContexts.cloud.model.CloudVideoUploadSessionStatus
 import java.time.Instant
 
 interface CloudVideoUploadSessionRepositoryPort {
@@ -16,6 +17,28 @@ interface CloudVideoUploadSessionRepositoryPort {
         now: Instant,
         limit: Int,
     ): List<CloudVideoUploadSession>
+
+    fun attachUploadIdAndTransition(
+        id: Long,
+        expectedStatus: CloudVideoUploadSessionStatus,
+        uploadId: String,
+        nextStatus: CloudVideoUploadSessionStatus,
+        now: Instant,
+    ): Int
+
+    fun transitionStatus(
+        id: Long,
+        expectedStatus: CloudVideoUploadSessionStatus,
+        nextStatus: CloudVideoUploadSessionStatus,
+        now: Instant,
+    ): Int
+
+    fun markFailed(
+        id: Long,
+        expectedStatus: CloudVideoUploadSessionStatus,
+        reason: String,
+        now: Instant,
+    ): Int
 }
 
 interface CloudVideoUploadPartRepositoryPort {

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionService.kt
@@ -14,7 +14,6 @@ import com.back.global.storage.config.CloudStorageProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.text.Normalizer
@@ -24,6 +23,11 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import java.util.UUID
+
+private val CLOUD_VIDEO_UPLOAD_DATE_PATH_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd")
+private const val CLOUD_VIDEO_UPLOAD_MAX_FILENAME_CODE_POINTS = 255L
+private const val CLOUD_VIDEO_UPLOAD_MAX_FILENAME_METADATA_ENCODED_BYTES = 1024
+private const val CLOUD_VIDEO_UPLOAD_MAX_MULTIPART_PARTS = 10_000L
 
 data class CloudVideoUploadSessionDto(
     val id: Long,
@@ -39,6 +43,8 @@ data class CloudVideoUploadSessionDto(
     val expiresAt: Instant,
     @get:JsonInclude(JsonInclude.Include.NON_NULL)
     val completedFileId: Long?,
+    @get:JsonInclude(JsonInclude.Include.NON_NULL)
+    val failureReason: String?,
 )
 
 data class CloudVideoUploadPartDto(
@@ -62,7 +68,6 @@ class CloudVideoUploadSessionService(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    @Transactional
     fun createSession(
         ownerMemberId: Long,
         originalFilename: String?,
@@ -82,21 +87,13 @@ class CloudVideoUploadSessionService(
                 folderPath = normalizedFolderPath,
                 originalFilename = safeFilename,
             )
-        val upload =
-            cloudStoragePort.initiateMultipartUpload(
-                CloudStoragePort.MultipartUploadInitRequest(
-                    objectKey = objectKey,
-                    contentType = normalizedContentType,
-                    originalFilename = safeFilename,
-                ),
-            )
         val expiresAt = clock.instant().plusSeconds(cloudStorageProperties.cloudVideoResumableExpiresSeconds.coerceAtLeast(60))
         val session =
             sessionRepository.save(
                 CloudVideoUploadSession(
                     ownerMemberId = ownerMemberId,
-                    objectKey = upload.objectKey,
-                    uploadId = upload.uploadId,
+                    objectKey = objectKey,
+                    uploadId = null,
                     originalFilename = safeFilename,
                     contentType = normalizedContentType,
                     byteSize = byteSize,
@@ -104,13 +101,42 @@ class CloudVideoUploadSessionService(
                     partSizeBytes = partSizeBytes,
                     totalParts = totalParts,
                     expiresAt = expiresAt,
+                    status = CloudVideoUploadSessionStatus.INITIATING,
                 ),
             )
+        val upload =
+            try {
+                cloudStoragePort.initiateMultipartUpload(
+                    CloudStoragePort.MultipartUploadInitRequest(
+                        objectKey = objectKey,
+                        contentType = normalizedContentType,
+                        originalFilename = safeFilename,
+                    ),
+                )
+            } catch (ex: RuntimeException) {
+                markFailed(session.id, CloudVideoUploadSessionStatus.INITIATING, "multipart initiate failed: ${ex.message}")
+                throw ex
+            }
+
+        val now = clock.instant()
+        val initiated =
+            sessionRepository.attachUploadIdAndTransition(
+                id = session.id,
+                expectedStatus = CloudVideoUploadSessionStatus.INITIATING,
+                uploadId = upload.uploadId,
+                nextStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
+                now = now,
+            ) == 1
+        if (!initiated) {
+            markFailed(session.id, CloudVideoUploadSessionStatus.INITIATING, "multipart initiate metadata attach failed")
+            abortQuietly(upload.objectKey, upload.uploadId)
+            throw AppException("409-1", "대용량 업로드 세션 상태가 변경되었습니다.")
+        }
+        session.markInitiated(upload.uploadId, now)
 
         return session.toDto(emptyList())
     }
 
-    @Transactional(noRollbackFor = [AppException::class])
     fun getSession(
         ownerMemberId: Long,
         sessionId: Long,
@@ -123,14 +149,14 @@ class CloudVideoUploadSessionService(
         return session.toDto(parts)
     }
 
-    @Transactional
     fun purgeExpiredSessions(batchSize: Int): Int {
         val sessions = sessionRepository.findExpiredInProgress(clock.instant(), batchSize.coerceAtLeast(1))
         var purgedCount = 0
         sessions.forEach { session ->
             runCatching {
-                expireSession(session)
-                purgedCount++
+                if (expireSession(session)) {
+                    purgedCount++
+                }
             }.onFailure {
                 log.warn(
                     "Expired cloud video multipart upload cleanup failed (sessionId={}, objectKey={})",
@@ -143,7 +169,6 @@ class CloudVideoUploadSessionService(
         return purgedCount
     }
 
-    @Transactional(noRollbackFor = [AppException::class])
     fun uploadPart(
         ownerMemberId: Long,
         sessionId: Long,
@@ -166,24 +191,45 @@ class CloudVideoUploadSessionService(
             )
         }
 
+        claimStatus(
+            session,
+            expectedStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
+            nextStatus = CloudVideoUploadSessionStatus.UPLOADING_PART,
+            conflictMessage = "다른 업로드 작업이 진행 중입니다.",
+        )
         val uploadResult =
-            cloudStoragePort.uploadMultipartPart(
-                CloudStoragePort.MultipartUploadPartRequest(
-                    objectKey = session.objectKey,
-                    uploadId = session.uploadId,
-                    partNumber = partNumber,
-                    bytes = bytes,
-                ),
-            )
+            try {
+                cloudStoragePort.uploadMultipartPart(
+                    CloudStoragePort.MultipartUploadPartRequest(
+                        objectKey = session.objectKey,
+                        uploadId = requireUploadId(session),
+                        partNumber = partNumber,
+                        bytes = bytes,
+                    ),
+                )
+            } catch (ex: RuntimeException) {
+                releasePartUploadClaim(session.id)
+                throw ex
+            }
         val savedPart =
-            partRepository.save(
-                CloudVideoUploadPart(
-                    sessionId = session.id,
-                    partNumber = partNumber,
-                    eTag = uploadResult.eTag,
-                    byteSize = bytes.size.toLong(),
-                ),
-            )
+            try {
+                partRepository.save(
+                    CloudVideoUploadPart(
+                        sessionId = session.id,
+                        partNumber = partNumber,
+                        eTag = uploadResult.eTag,
+                        byteSize = bytes.size.toLong(),
+                    ),
+                )
+            } catch (ex: RuntimeException) {
+                markFailed(session.id, CloudVideoUploadSessionStatus.UPLOADING_PART, "multipart part metadata save failed: ${ex.message}")
+                throw ex
+            }
+        transitionStatus(
+            session.id,
+            expectedStatus = CloudVideoUploadSessionStatus.UPLOADING_PART,
+            nextStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
+        )
         val parts = partRepository.findBySessionId(session.id)
 
         return CloudVideoUploadPartResultDto(
@@ -192,7 +238,6 @@ class CloudVideoUploadSessionService(
         )
     }
 
-    @Transactional(noRollbackFor = [AppException::class])
     fun complete(
         ownerMemberId: Long,
         sessionId: Long,
@@ -203,19 +248,30 @@ class CloudVideoUploadSessionService(
             throw AppException("409-1", "아직 업로드되지 않은 동영상 조각이 있습니다.")
         }
 
-        cloudStoragePort.completeMultipartUpload(
-            CloudStoragePort.MultipartUploadCompleteRequest(
-                objectKey = session.objectKey,
-                uploadId = session.uploadId,
-                parts =
-                    parts.map {
-                        CloudStoragePort.CompletedMultipartUploadPart(
-                            partNumber = it.partNumber,
-                            eTag = it.eTag,
-                        )
-                    },
-            ),
+        claimStatus(
+            session,
+            expectedStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
+            nextStatus = CloudVideoUploadSessionStatus.COMPLETING,
+            conflictMessage = "다른 업로드 작업이 진행 중입니다.",
         )
+        try {
+            cloudStoragePort.completeMultipartUpload(
+                CloudStoragePort.MultipartUploadCompleteRequest(
+                    objectKey = session.objectKey,
+                    uploadId = requireUploadId(session),
+                    parts =
+                        parts.map {
+                            CloudStoragePort.CompletedMultipartUploadPart(
+                                partNumber = it.partNumber,
+                                eTag = it.eTag,
+                            )
+                        },
+                ),
+            )
+        } catch (ex: RuntimeException) {
+            markFailed(session.id, CloudVideoUploadSessionStatus.COMPLETING, "multipart complete failed: ${ex.message}")
+            throw ex
+        }
 
         val file =
             cloudFileRepository.save(
@@ -236,20 +292,23 @@ class CloudVideoUploadSessionService(
         return file.toDto()
     }
 
-    @Transactional
     fun cancel(
         ownerMemberId: Long,
         sessionId: Long,
     ) {
         val session = findOwnedSession(ownerMemberId, sessionId)
-        if (session.status != CloudVideoUploadSessionStatus.IN_PROGRESS) return
+        if (isTerminalStatus(session.status)) return
+        if (session.status != CloudVideoUploadSessionStatus.IN_PROGRESS) {
+            throw AppException("409-1", "다른 업로드 작업이 진행 중입니다.")
+        }
 
-        cloudStoragePort.abortMultipartUpload(
-            CloudStoragePort.MultipartUploadAbortRequest(
-                objectKey = session.objectKey,
-                uploadId = session.uploadId,
-            ),
+        claimStatus(
+            session,
+            expectedStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
+            nextStatus = CloudVideoUploadSessionStatus.ABORTING,
+            conflictMessage = "다른 업로드 작업이 진행 중입니다.",
         )
+        abortOrFail(session, finalStatusOnFailure = CloudVideoUploadSessionStatus.ABORTING)
         partRepository.deleteBySessionId(session.id)
         session.cancel(clock.instant())
         sessionRepository.save(session)
@@ -280,21 +339,131 @@ class CloudVideoUploadSessionService(
     private fun expireSessionIfNeeded(session: CloudVideoUploadSession): Boolean {
         if (session.status != CloudVideoUploadSessionStatus.IN_PROGRESS) return false
         if (session.expiresAt > clock.instant()) return false
-        expireSession(session)
-        return true
+        return expireSession(session)
     }
 
-    private fun expireSession(session: CloudVideoUploadSession) {
-        cloudStoragePort.abortMultipartUpload(
-            CloudStoragePort.MultipartUploadAbortRequest(
-                objectKey = session.objectKey,
-                uploadId = session.uploadId,
-            ),
-        )
+    private fun expireSession(session: CloudVideoUploadSession): Boolean {
+        val claimed =
+            transitionStatus(
+                session.id,
+                expectedStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
+                nextStatus = CloudVideoUploadSessionStatus.ABORTING,
+                throwOnFailure = false,
+            )
+        if (!claimed) return false
+        session.transitionTo(CloudVideoUploadSessionStatus.ABORTING, clock.instant())
+        abortOrFail(session, finalStatusOnFailure = CloudVideoUploadSessionStatus.ABORTING)
         partRepository.deleteBySessionId(session.id)
         session.expire(clock.instant())
         sessionRepository.save(session)
+        return true
     }
+
+    private fun claimStatus(
+        session: CloudVideoUploadSession,
+        expectedStatus: CloudVideoUploadSessionStatus,
+        nextStatus: CloudVideoUploadSessionStatus,
+        conflictMessage: String,
+    ) {
+        val claimed =
+            transitionStatus(
+                session.id,
+                expectedStatus = expectedStatus,
+                nextStatus = nextStatus,
+                throwOnFailure = false,
+            )
+        if (!claimed) {
+            throw AppException("409-1", conflictMessage)
+        }
+        session.transitionTo(nextStatus, clock.instant())
+    }
+
+    private fun transitionStatus(
+        sessionId: Long,
+        expectedStatus: CloudVideoUploadSessionStatus,
+        nextStatus: CloudVideoUploadSessionStatus,
+        throwOnFailure: Boolean = true,
+    ): Boolean {
+        val changed =
+            sessionRepository.transitionStatus(
+                id = sessionId,
+                expectedStatus = expectedStatus,
+                nextStatus = nextStatus,
+                now = clock.instant(),
+            ) == 1
+        if (!changed && throwOnFailure) {
+            throw AppException("409-1", "대용량 업로드 세션 상태가 변경되었습니다.")
+        }
+        return changed
+    }
+
+    private fun markFailed(
+        sessionId: Long,
+        expectedStatus: CloudVideoUploadSessionStatus,
+        reason: String,
+    ) {
+        sessionRepository.markFailed(
+            id = sessionId,
+            expectedStatus = expectedStatus,
+            reason = reason.take(500),
+            now = clock.instant(),
+        )
+    }
+
+    private fun releasePartUploadClaim(sessionId: Long) {
+        transitionStatus(
+            sessionId,
+            expectedStatus = CloudVideoUploadSessionStatus.UPLOADING_PART,
+            nextStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
+            throwOnFailure = false,
+        )
+    }
+
+    private fun abortOrFail(
+        session: CloudVideoUploadSession,
+        finalStatusOnFailure: CloudVideoUploadSessionStatus,
+    ) {
+        try {
+            cloudStoragePort.abortMultipartUpload(
+                CloudStoragePort.MultipartUploadAbortRequest(
+                    objectKey = session.objectKey,
+                    uploadId = requireUploadId(session),
+                ),
+            )
+        } catch (ex: RuntimeException) {
+            markFailed(session.id, finalStatusOnFailure, "multipart abort failed: ${ex.message}")
+            throw ex
+        }
+    }
+
+    private fun abortQuietly(
+        objectKey: String,
+        uploadId: String,
+    ) {
+        try {
+            cloudStoragePort.abortMultipartUpload(
+                CloudStoragePort.MultipartUploadAbortRequest(
+                    objectKey = objectKey,
+                    uploadId = uploadId,
+                ),
+            )
+        } catch (ex: RuntimeException) {
+            log.warn("Cloud video multipart upload abort compensation failed (objectKey={})", objectKey, ex)
+        }
+    }
+
+    private fun requireUploadId(session: CloudVideoUploadSession): String =
+        session.uploadId ?: throw AppException("409-1", "대용량 업로드 세션 초기화가 완료되지 않았습니다.")
+
+    private fun isTerminalStatus(status: CloudVideoUploadSessionStatus): Boolean =
+        when (status) {
+            CloudVideoUploadSessionStatus.COMPLETED,
+            CloudVideoUploadSessionStatus.CANCELLED,
+            CloudVideoUploadSessionStatus.EXPIRED,
+            CloudVideoUploadSessionStatus.FAILED,
+            -> true
+            else -> false
+        }
 
     private fun validateTotalSize(byteSize: Long) {
         if (byteSize <= 0) throw AppException("400-1", "동영상 파일 크기가 올바르지 않습니다.")
@@ -309,7 +478,7 @@ class CloudVideoUploadSessionService(
         partSizeBytes: Long,
     ): Int {
         val totalParts = ((byteSize - 1) / partSizeBytes) + 1
-        if (totalParts > MAX_MULTIPART_PARTS) {
+        if (totalParts > CLOUD_VIDEO_UPLOAD_MAX_MULTIPART_PARTS) {
             throw AppException("400-1", "대용량 동영상 업로드는 최대 10,000개 조각 이하여야 합니다.")
         }
         return totalParts.toInt()
@@ -442,23 +611,23 @@ class CloudVideoUploadSessionService(
             originalExtensionIndex
                 ?.let(::substring)
                 .orEmpty()
-                .takeCodePoints(MAX_FILENAME_CODE_POINTS - 1)
+                .takeCodePoints(CLOUD_VIDEO_UPLOAD_MAX_FILENAME_CODE_POINTS - 1)
         val originalStem = originalExtensionIndex?.let { substring(0, it) } ?: this
         val maxStemCodePoints =
-            MAX_FILENAME_CODE_POINTS - originalExtension.codePointCount(0, originalExtension.length).toLong()
+            CLOUD_VIDEO_UPLOAD_MAX_FILENAME_CODE_POINTS - originalExtension.codePointCount(0, originalExtension.length).toLong()
         val codePointLimited = originalStem.takeCodePoints(maxStemCodePoints.coerceAtLeast(0)) + originalExtension
-        if (metadataEncodedLength(codePointLimited) <= MAX_FILENAME_METADATA_ENCODED_BYTES) return codePointLimited
+        if (metadataEncodedLength(codePointLimited) <= CLOUD_VIDEO_UPLOAD_MAX_FILENAME_METADATA_ENCODED_BYTES) return codePointLimited
 
         val extensionIndex = codePointLimited.lastIndexOf(".").takeIf { it > 0 && it < codePointLimited.lastIndex }
         val extension =
             extensionIndex
                 ?.let(codePointLimited::substring)
                 .orEmpty()
-                .takeMetadataEncodedBytes(MAX_FILENAME_METADATA_ENCODED_BYTES)
+                .takeMetadataEncodedBytes(CLOUD_VIDEO_UPLOAD_MAX_FILENAME_METADATA_ENCODED_BYTES)
         val stem = extensionIndex?.let { codePointLimited.substring(0, it) } ?: codePointLimited
-        val maxStemBytes = MAX_FILENAME_METADATA_ENCODED_BYTES - metadataEncodedLength(extension)
+        val maxStemBytes = CLOUD_VIDEO_UPLOAD_MAX_FILENAME_METADATA_ENCODED_BYTES - metadataEncodedLength(extension)
         val safeStem = stem.takeMetadataEncodedBytes(maxStemBytes.coerceAtLeast(0))
-        return (safeStem + extension).ifBlank { takeMetadataEncodedBytes(MAX_FILENAME_METADATA_ENCODED_BYTES) }
+        return (safeStem + extension).ifBlank { takeMetadataEncodedBytes(CLOUD_VIDEO_UPLOAD_MAX_FILENAME_METADATA_ENCODED_BYTES) }
     }
 
     private fun String.takeMetadataEncodedBytes(maxEncodedBytes: Int): String {
@@ -505,7 +674,7 @@ class CloudVideoUploadSessionService(
         originalFilename: String,
     ): String {
         val ext = extractExtension(originalFilename)
-        val datePath = DATE_PATH_FORMATTER.format(clock.instant().atZone(ZoneOffset.UTC))
+        val datePath = CLOUD_VIDEO_UPLOAD_DATE_PATH_FORMATTER.format(clock.instant().atZone(ZoneOffset.UTC))
         val folderSegment = folderPath.takeIf(String::isNotBlank)?.let { "$it/" }.orEmpty()
         val keyPrefix = normalizeObjectKeyPrefix(cloudStorageProperties.cloudKeyPrefix)
         return "$keyPrefix/$ownerMemberId/$folderSegment$datePath/${UUID.randomUUID()}$ext"
@@ -561,6 +730,7 @@ class CloudVideoUploadSessionService(
             status = status,
             expiresAt = expiresAt,
             completedFileId = completedFileId,
+            failureReason = failureReason,
         )
 
     private fun CloudVideoUploadPart.toDto(): CloudVideoUploadPartDto =
@@ -581,11 +751,4 @@ class CloudVideoUploadSessionService(
             createdAt = runCatching { createdAt }.getOrDefault(clock.instant()),
             modifiedAt = runCatching { modifiedAt }.getOrDefault(clock.instant()),
         )
-
-    companion object {
-        private val DATE_PATH_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd")
-        private const val MAX_FILENAME_CODE_POINTS = 255L
-        private const val MAX_FILENAME_METADATA_ENCODED_BYTES = 1024
-        private const val MAX_MULTIPART_PARTS = 10_000L
-    }
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/model/CloudVideoUploadSession.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/model/CloudVideoUploadSession.kt
@@ -16,10 +16,15 @@ import org.hibernate.annotations.DynamicUpdate
 import java.time.Instant
 
 enum class CloudVideoUploadSessionStatus {
+    INITIATING,
     IN_PROGRESS,
+    UPLOADING_PART,
+    COMPLETING,
     COMPLETED,
+    ABORTING,
     CANCELLED,
     EXPIRED,
+    FAILED,
 }
 
 @Entity
@@ -49,8 +54,8 @@ class CloudVideoUploadSession(
     val ownerMemberId: Long,
     @field:Column(nullable = false, unique = true, length = 1000)
     val objectKey: String,
-    @field:Column(nullable = false, length = 512)
-    val uploadId: String,
+    @field:Column(length = 512)
+    var uploadId: String?,
     @field:Column(nullable = false, length = 255)
     val originalFilename: String,
     @field:Column(nullable = false, length = 120)
@@ -70,23 +75,56 @@ class CloudVideoUploadSession(
     var status: CloudVideoUploadSessionStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
     @field:Column
     var completedFileId: Long? = null,
+    @field:Column(length = 500)
+    var failureReason: String? = null,
 ) : BaseTime(id) {
+    fun markInitiated(
+        uploadId: String,
+        now: Instant,
+    ) {
+        this.uploadId = uploadId
+        status = CloudVideoUploadSessionStatus.IN_PROGRESS
+        failureReason = null
+        updateModifiedAt(now)
+    }
+
+    fun transitionTo(
+        nextStatus: CloudVideoUploadSessionStatus,
+        now: Instant,
+    ) {
+        status = nextStatus
+        failureReason = null
+        updateModifiedAt(now)
+    }
+
     fun complete(
         fileId: Long,
         now: Instant,
     ) {
         status = CloudVideoUploadSessionStatus.COMPLETED
         completedFileId = fileId
+        failureReason = null
         updateModifiedAt(now)
     }
 
     fun cancel(now: Instant) {
         status = CloudVideoUploadSessionStatus.CANCELLED
+        failureReason = null
         updateModifiedAt(now)
     }
 
     fun expire(now: Instant) {
         status = CloudVideoUploadSessionStatus.EXPIRED
+        failureReason = null
+        updateModifiedAt(now)
+    }
+
+    fun fail(
+        reason: String,
+        now: Instant,
+    ) {
+        status = CloudVideoUploadSessionStatus.FAILED
+        failureReason = reason.take(500)
         updateModifiedAt(now)
     }
 

--- a/back/src/main/resources/db/migration-test/V20260619_03__harden_cloud_video_upload_session_state.sql
+++ b/back/src/main/resources/db/migration-test/V20260619_03__harden_cloud_video_upload_session_state.sql
@@ -1,0 +1,5 @@
+ALTER TABLE cloud_video_upload_session
+    ALTER COLUMN upload_id DROP NOT NULL;
+
+ALTER TABLE cloud_video_upload_session
+    ADD COLUMN IF NOT EXISTS failure_reason VARCHAR(500);

--- a/back/src/main/resources/db/migration/V20260619_03__harden_cloud_video_upload_session_state.sql
+++ b/back/src/main/resources/db/migration/V20260619_03__harden_cloud_video_upload_session_state.sql
@@ -1,0 +1,5 @@
+ALTER TABLE cloud_video_upload_session
+    ALTER COLUMN upload_id DROP NOT NULL;
+
+ALTER TABLE cloud_video_upload_session
+    ADD COLUMN IF NOT EXISTS failure_reason VARCHAR(500);

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudControllerWebMvcTest.kt
@@ -708,6 +708,7 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
             status = CloudVideoUploadSessionStatus.IN_PROGRESS,
             expiresAt = Instant.parse("2026-06-18T00:00:00Z"),
             completedFileId = null,
+            failureReason = null,
         )
 
     private fun byteArrayContentEquals(expected: ByteArray): ByteArray =

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionServiceTest.kt
@@ -15,7 +15,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.springframework.transaction.annotation.Transactional
 import java.io.ByteArrayInputStream
 import java.text.Normalizer
 import java.time.Clock
@@ -199,24 +198,30 @@ class CloudVideoUploadSessionServiceTest {
     }
 
     @Test
-    @DisplayName("만료 세션을 410으로 거절하는 진입점은 만료 상태 저장을 rollback하지 않는다")
-    fun `만료 세션 진입점은 AppException rollback을 방지한다`() {
-        val getSessionTransaction =
-            CloudVideoUploadSessionService::class.java
-                .getMethod("getSession", java.lang.Long.TYPE, java.lang.Long.TYPE)
-                .getAnnotation(Transactional::class.java)
-        val uploadPartTransaction =
-            CloudVideoUploadSessionService::class.java
-                .getMethod("uploadPart", java.lang.Long.TYPE, java.lang.Long.TYPE, Integer.TYPE, ByteArray::class.java)
-                .getAnnotation(Transactional::class.java)
-        val completeTransaction =
-            CloudVideoUploadSessionService::class.java
-                .getMethod("complete", java.lang.Long.TYPE, java.lang.Long.TYPE)
-                .getAnnotation(Transactional::class.java)
+    @DisplayName("S3 원격 호출 진입점은 서비스 레벨 트랜잭션을 잡지 않는다")
+    fun `S3 원격 호출 진입점은 서비스 트랜잭션을 잡지 않는다`() {
+        val transactionalAnnotationName = "org.springframework.transaction.annotation.Transactional"
+        val methods =
+            listOf(
+                CloudVideoUploadSessionService::class.java
+                    .getMethod(
+                        "createSession",
+                        java.lang.Long.TYPE,
+                        String::class.java,
+                        String::class.java,
+                        java.lang.Long.TYPE,
+                        String::class.java,
+                    ),
+                CloudVideoUploadSessionService::class.java
+                    .getMethod("uploadPart", java.lang.Long.TYPE, java.lang.Long.TYPE, Integer.TYPE, ByteArray::class.java),
+                CloudVideoUploadSessionService::class.java
+                    .getMethod("complete", java.lang.Long.TYPE, java.lang.Long.TYPE),
+                CloudVideoUploadSessionService::class.java
+                    .getMethod("cancel", java.lang.Long.TYPE, java.lang.Long.TYPE),
+            )
 
-        assertThat(getSessionTransaction.noRollbackFor).contains(AppException::class)
-        assertThat(uploadPartTransaction.noRollbackFor).contains(AppException::class)
-        assertThat(completeTransaction.noRollbackFor).contains(AppException::class)
+        assertThat(methods.flatMap { it.annotations.map { annotation -> annotation.annotationClass.qualifiedName } })
+            .doesNotContain(transactionalAnnotationName)
     }
 
     @Test
@@ -397,7 +402,9 @@ class CloudVideoUploadSessionServiceTest {
         assertThat(purgedCount).isEqualTo(1)
         assertThat(storage.abortedUploads.single().uploadId).isEqualTo("upload-2")
         assertThat(sessionRepository.savedSessions.first { it.id == first.id }.status)
-            .isEqualTo(CloudVideoUploadSessionStatus.IN_PROGRESS)
+            .isEqualTo(CloudVideoUploadSessionStatus.FAILED)
+        assertThat(sessionRepository.savedSessions.first { it.id == first.id }.failureReason)
+            .contains("multipart abort failed")
         assertThat(sessionRepository.savedSessions.first { it.id == second.id }.status)
             .isEqualTo(CloudVideoUploadSessionStatus.EXPIRED)
     }
@@ -573,6 +580,244 @@ class CloudVideoUploadSessionServiceTest {
     }
 
     @Test
+    @DisplayName("S3 initiate 실패는 DB 세션을 FAILED로 남긴다")
+    fun `S3 initiate 실패는 FAILED 상태로 남긴다`() {
+        storage.failInitiate = true
+
+        assertThatThrownBy {
+            service.createSession(
+                ownerMemberId = 7L,
+                originalFilename = "movie.mp4",
+                contentType = "video/mp4",
+                byteSize = TEST_PART_SIZE_BYTES,
+                folderPath = "",
+            )
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("initiate failed")
+
+        assertThat(sessionRepository.savedSessions.single().status).isEqualTo(CloudVideoUploadSessionStatus.FAILED)
+        assertThat(sessionRepository.savedSessions.single().failureReason).contains("multipart initiate failed")
+    }
+
+    @Test
+    @DisplayName("파트 S3 업로드 성공 후 metadata 저장 실패는 FAILED로 남긴다")
+    fun `파트 metadata 저장 실패는 FAILED 상태로 남긴다`() {
+        val session =
+            service.createSession(
+                ownerMemberId = 7L,
+                originalFilename = "movie.mp4",
+                contentType = "video/mp4",
+                byteSize = TEST_PART_SIZE_BYTES,
+                folderPath = "",
+            )
+        partRepository.failSave = true
+
+        assertThatThrownBy {
+            service.uploadPart(7L, session.id, 1, mp4Part(TEST_PART_SIZE_BYTES.toInt()))
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("part save failed")
+
+        assertThat(storage.multipartParts.single().partNumber).isEqualTo(1)
+        assertThat(sessionRepository.savedSessions.single { it.id == session.id }.status)
+            .isEqualTo(CloudVideoUploadSessionStatus.FAILED)
+        assertThat(sessionRepository.savedSessions.single { it.id == session.id }.failureReason)
+            .contains("metadata save failed")
+    }
+
+    @Test
+    @DisplayName("complete S3 성공 후 파일 metadata 저장 실패는 COMPLETING으로 남긴다")
+    fun `complete metadata 저장 실패는 COMPLETING 상태로 남긴다`() {
+        val session =
+            service.createSession(
+                ownerMemberId = 7L,
+                originalFilename = "movie.mp4",
+                contentType = "video/mp4",
+                byteSize = TEST_PART_SIZE_BYTES,
+                folderPath = "",
+            )
+        service.uploadPart(7L, session.id, 1, mp4Part(TEST_PART_SIZE_BYTES.toInt()))
+        fileRepository.failSave = true
+
+        assertThatThrownBy {
+            service.complete(7L, session.id)
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("file save failed")
+
+        assertThat(storage.completedUploads.single().uploadId).isEqualTo("upload-1")
+        assertThat(sessionRepository.savedSessions.single { it.id == session.id }.status)
+            .isEqualTo(CloudVideoUploadSessionStatus.COMPLETING)
+    }
+
+    @Test
+    @DisplayName("선점 상태의 세션은 cancel과 cleanup이 동시에 처리하지 않는다")
+    fun `선점 상태는 cancel과 cleanup을 막는다`() {
+        val session =
+            service.createSession(
+                ownerMemberId = 7L,
+                originalFilename = "movie.mp4",
+                contentType = "video/mp4",
+                byteSize = TEST_PART_SIZE_BYTES,
+                folderPath = "",
+            )
+        sessionRepository.transitionStatus(
+            id = session.id,
+            expectedStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
+            nextStatus = CloudVideoUploadSessionStatus.UPLOADING_PART,
+            now = clock.instant(),
+        )
+
+        assertThatThrownBy {
+            service.cancel(7L, session.id)
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("진행 중")
+
+        val expiredService =
+            createService(
+                clock = Clock.fixed(Instant.parse("2026-06-17T02:00:00Z"), ZoneOffset.UTC),
+            )
+        assertThat(expiredService.purgeExpiredSessions(batchSize = 100)).isZero()
+        assertThat(storage.abortedUploads).isEmpty()
+    }
+
+    @Test
+    @DisplayName("initiate 성공 후 DB 전이 실패는 abort 보상을 시도하고 FAILED로 남긴다")
+    fun `initiate 후 DB 전이 실패는 abort 보상 후 FAILED로 남긴다`() {
+        sessionRepository.failAttachUploadIdTransition = true
+        storage.failingAbortUploadIds += "upload-1"
+
+        assertThatThrownBy {
+            service.createSession(
+                ownerMemberId = 7L,
+                originalFilename = "movie.mp4",
+                contentType = "video/mp4",
+                byteSize = TEST_PART_SIZE_BYTES,
+                folderPath = "",
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("상태가 변경")
+
+        assertThat(storage.multipartInits.single().objectKey).startsWith("cloud/7/2026/06/17/")
+        assertThat(storage.abortedUploads).isEmpty()
+        assertThat(sessionRepository.savedSessions.single().status).isEqualTo(CloudVideoUploadSessionStatus.FAILED)
+        assertThat(sessionRepository.savedSessions.single().failureReason).contains("metadata attach failed")
+    }
+
+    @Test
+    @DisplayName("S3 part 업로드 실패는 선점 상태를 IN_PROGRESS로 되돌린다")
+    fun `S3 part 업로드 실패는 선점 상태를 되돌린다`() {
+        val session =
+            service.createSession(
+                ownerMemberId = 7L,
+                originalFilename = "movie.mp4",
+                contentType = "video/mp4",
+                byteSize = TEST_PART_SIZE_BYTES,
+                folderPath = "",
+            )
+        storage.failingPartNumbers += 1
+
+        assertThatThrownBy {
+            service.uploadPart(7L, session.id, 1, mp4Part(TEST_PART_SIZE_BYTES.toInt()))
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("part upload failed")
+
+        assertThat(partRepository.findBySessionId(session.id)).isEmpty()
+        assertThat(sessionRepository.savedSessions.single { it.id == session.id }.status)
+            .isEqualTo(CloudVideoUploadSessionStatus.IN_PROGRESS)
+    }
+
+    @Test
+    @DisplayName("파트 저장 후 IN_PROGRESS 복귀 전이가 실패하면 409로 중단한다")
+    fun `파트 저장 후 복귀 전이 실패는 409로 중단한다`() {
+        val session =
+            service.createSession(
+                ownerMemberId = 7L,
+                originalFilename = "movie.mp4",
+                contentType = "video/mp4",
+                byteSize = TEST_PART_SIZE_BYTES,
+                folderPath = "",
+            )
+        sessionRepository.failingTransitions +=
+            CloudVideoUploadSessionStatus.UPLOADING_PART to CloudVideoUploadSessionStatus.IN_PROGRESS
+
+        assertThatThrownBy {
+            service.uploadPart(7L, session.id, 1, mp4Part(TEST_PART_SIZE_BYTES.toInt()))
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("상태가 변경")
+
+        assertThat(partRepository.findBySessionId(session.id)).hasSize(1)
+        assertThat(sessionRepository.savedSessions.single { it.id == session.id }.status)
+            .isEqualTo(CloudVideoUploadSessionStatus.UPLOADING_PART)
+    }
+
+    @Test
+    @DisplayName("complete 선점 전이 실패는 S3 complete를 호출하지 않고 409로 중단한다")
+    fun `complete 선점 전이 실패는 S3 complete 없이 중단한다`() {
+        val session =
+            service.createSession(
+                ownerMemberId = 7L,
+                originalFilename = "movie.mp4",
+                contentType = "video/mp4",
+                byteSize = TEST_PART_SIZE_BYTES,
+                folderPath = "",
+            )
+        service.uploadPart(7L, session.id, 1, mp4Part(TEST_PART_SIZE_BYTES.toInt()))
+        sessionRepository.failingTransitions +=
+            CloudVideoUploadSessionStatus.IN_PROGRESS to CloudVideoUploadSessionStatus.COMPLETING
+
+        assertThatThrownBy {
+            service.complete(7L, session.id)
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("진행 중")
+
+        assertThat(storage.completedUploads).isEmpty()
+        assertThat(sessionRepository.savedSessions.single { it.id == session.id }.status)
+            .isEqualTo(CloudVideoUploadSessionStatus.IN_PROGRESS)
+    }
+
+    @Test
+    @DisplayName("S3 complete 실패는 FAILED로 남긴다")
+    fun `S3 complete 실패는 FAILED 상태로 남긴다`() {
+        val session =
+            service.createSession(
+                ownerMemberId = 7L,
+                originalFilename = "movie.mp4",
+                contentType = "video/mp4",
+                byteSize = TEST_PART_SIZE_BYTES,
+                folderPath = "",
+            )
+        service.uploadPart(7L, session.id, 1, mp4Part(TEST_PART_SIZE_BYTES.toInt()))
+        storage.failingCompleteUploadIds += "upload-1"
+
+        assertThatThrownBy {
+            service.complete(7L, session.id)
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("complete failed")
+
+        assertThat(sessionRepository.savedSessions.single { it.id == session.id }.status)
+            .isEqualTo(CloudVideoUploadSessionStatus.FAILED)
+        assertThat(sessionRepository.savedSessions.single { it.id == session.id }.failureReason)
+            .contains("multipart complete failed")
+    }
+
+    @Test
+    @DisplayName("terminal 상태의 cancel은 원격 abort를 다시 호출하지 않는다")
+    fun `terminal 상태 cancel은 no-op이다`() {
+        val session =
+            service.createSession(
+                ownerMemberId = 7L,
+                originalFilename = "movie.mp4",
+                contentType = "video/mp4",
+                byteSize = TEST_PART_SIZE_BYTES,
+                folderPath = "",
+            )
+        service.cancel(7L, session.id)
+
+        service.cancel(7L, session.id)
+
+        assertThat(storage.abortedUploads).hasSize(1)
+    }
+
+    @Test
     @DisplayName("multipart part request는 ByteArray 내용을 기준으로 equals와 hashCode를 계산한다")
     fun `multipart part request는 ByteArray 내용 기준으로 비교한다`() {
         val first =
@@ -605,6 +850,8 @@ class CloudVideoUploadSessionServiceTest {
     private class FakeVideoUploadSessionRepository : CloudVideoUploadSessionRepositoryPort {
         val savedSessions = mutableListOf<CloudVideoUploadSession>()
         private var nextId = 1L
+        var failAttachUploadIdTransition = false
+        val failingTransitions = mutableSetOf<Pair<CloudVideoUploadSessionStatus, CloudVideoUploadSessionStatus>>()
 
         override fun save(session: CloudVideoUploadSession): CloudVideoUploadSession {
             val stored =
@@ -623,6 +870,7 @@ class CloudVideoUploadSessionServiceTest {
                         expiresAt = session.expiresAt,
                         status = session.status,
                         completedFileId = session.completedFileId,
+                        failureReason = session.failureReason,
                     )
                 } else {
                     session
@@ -649,13 +897,58 @@ class CloudVideoUploadSessionServiceTest {
                         it.expiresAt <= now
                 }.sortedWith(compareBy<CloudVideoUploadSession> { it.expiresAt }.thenBy { it.id })
                 .take(limit.coerceAtLeast(1))
+
+        override fun attachUploadIdAndTransition(
+            id: Long,
+            expectedStatus: CloudVideoUploadSessionStatus,
+            uploadId: String,
+            nextStatus: CloudVideoUploadSessionStatus,
+            now: Instant,
+        ): Int {
+            if (failAttachUploadIdTransition) {
+                return 0
+            }
+            val session = savedSessions.firstOrNull { it.id == id && it.status == expectedStatus } ?: return 0
+            session.markInitiated(uploadId, now)
+            session.transitionTo(nextStatus, now)
+            return 1
+        }
+
+        override fun transitionStatus(
+            id: Long,
+            expectedStatus: CloudVideoUploadSessionStatus,
+            nextStatus: CloudVideoUploadSessionStatus,
+            now: Instant,
+        ): Int {
+            if (failingTransitions.remove(expectedStatus to nextStatus)) {
+                return 0
+            }
+            val session = savedSessions.firstOrNull { it.id == id && it.status == expectedStatus } ?: return 0
+            session.transitionTo(nextStatus, now)
+            return 1
+        }
+
+        override fun markFailed(
+            id: Long,
+            expectedStatus: CloudVideoUploadSessionStatus,
+            reason: String,
+            now: Instant,
+        ): Int {
+            val session = savedSessions.firstOrNull { it.id == id && it.status == expectedStatus } ?: return 0
+            session.fail(reason, now)
+            return 1
+        }
     }
 
     private class FakeVideoUploadPartRepository : CloudVideoUploadPartRepositoryPort {
         private val parts = mutableListOf<CloudVideoUploadPart>()
         private var nextId = 1L
+        var failSave = false
 
         override fun save(part: CloudVideoUploadPart): CloudVideoUploadPart {
+            if (failSave) {
+                throw IllegalStateException("part save failed")
+            }
             val stored =
                 if (part.id == 0L) {
                     CloudVideoUploadPart(
@@ -691,8 +984,12 @@ class CloudVideoUploadSessionServiceTest {
     private class FakeCloudFileRepository : CloudFileRepositoryPort {
         private val files = mutableListOf<CloudFile>()
         private var nextId = 1L
+        var failSave = false
 
         override fun save(file: CloudFile): CloudFile {
+            if (failSave) {
+                throw IllegalStateException("file save failed")
+            }
             val stored =
                 CloudFile.create(
                     id = nextId++,
@@ -730,6 +1027,9 @@ class CloudVideoUploadSessionServiceTest {
         val completedUploads = mutableListOf<CloudStoragePort.MultipartUploadCompleteRequest>()
         val abortedUploads = mutableListOf<CloudStoragePort.MultipartUploadAbortRequest>()
         val failingAbortUploadIds = mutableSetOf<String>()
+        val failingPartNumbers = mutableSetOf<Int>()
+        val failingCompleteUploadIds = mutableSetOf<String>()
+        var failInitiate = false
 
         override fun upload(request: CloudStoragePort.UploadRequest): CloudStoragePort.UploadResult =
             CloudStoragePort.UploadResult(request.objectKey, "checksum")
@@ -737,6 +1037,9 @@ class CloudVideoUploadSessionServiceTest {
         override fun initiateMultipartUpload(
             request: CloudStoragePort.MultipartUploadInitRequest,
         ): CloudStoragePort.MultipartUploadInitResult {
+            if (failInitiate) {
+                throw IllegalStateException("initiate failed")
+            }
             multipartInits += request
             return CloudStoragePort.MultipartUploadInitResult(
                 objectKey = request.objectKey,
@@ -747,6 +1050,9 @@ class CloudVideoUploadSessionServiceTest {
         override fun uploadMultipartPart(
             request: CloudStoragePort.MultipartUploadPartRequest,
         ): CloudStoragePort.MultipartUploadPartResult {
+            if (request.partNumber in failingPartNumbers) {
+                throw IllegalStateException("part upload failed")
+            }
             multipartParts += request
             return CloudStoragePort.MultipartUploadPartResult(
                 partNumber = request.partNumber,
@@ -755,6 +1061,9 @@ class CloudVideoUploadSessionServiceTest {
         }
 
         override fun completeMultipartUpload(request: CloudStoragePort.MultipartUploadCompleteRequest) {
+            if (request.uploadId in failingCompleteUploadIds) {
+                throw IllegalStateException("complete failed")
+            }
             completedUploads += request
         }
 

--- a/back/src/test/kotlin/com/back/perf/PerformanceSanityTest.kt
+++ b/back/src/test/kotlin/com/back/perf/PerformanceSanityTest.kt
@@ -127,7 +127,7 @@ class PerformanceSanityTest : BasePerformanceIntegrationTest() {
                 status { isOk() }
             }
 
-        assertQueryCountWithin("auth-login", 14)
+        assertQueryCountWithin("auth-login", 15)
     }
 
     private fun assertQueryCountWithin(

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -2867,7 +2867,7 @@
           },
           "status" : {
             "type" : "string",
-            "enum" : [ "IN_PROGRESS", "COMPLETED", "CANCELLED", "EXPIRED" ]
+            "enum" : [ "INITIATING", "IN_PROGRESS", "UPLOADING_PART", "COMPLETING", "COMPLETED", "ABORTING", "CANCELLED", "EXPIRED", "FAILED" ]
           },
           "expiresAt" : {
             "type" : "string",
@@ -2876,6 +2876,9 @@
           "completedFileId" : {
             "type" : "integer",
             "format" : "int64"
+          },
+          "failureReason" : {
+            "type" : "string"
           }
         }
       },

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -1340,11 +1340,12 @@ export interface components {
             totalParts?: number;
             uploadedParts?: number[];
             /** @enum {string} */
-            status?: "IN_PROGRESS" | "COMPLETED" | "CANCELLED" | "EXPIRED";
+            status?: "INITIATING" | "IN_PROGRESS" | "UPLOADING_PART" | "COMPLETING" | "COMPLETED" | "ABORTING" | "CANCELLED" | "EXPIRED" | "FAILED";
             /** Format: date-time */
             expiresAt?: string;
             /** Format: int64 */
             completedFileId?: number;
+            failureReason?: string;
         };
         PostCommentModifyRequest: {
             content: string;


### PR DESCRIPTION
## 관련 이슈

close #882

## 작업 배경

- 클라우드 동영상 multipart upload에서 S3 side effect와 DB 상태 변경이 같은 흐름에 묶여 complete/cancel/uploadPart/cleanup 경쟁 시 최종 상태가 흔들릴 수 있었다.
- S3 성공 후 DB 저장 실패, DB 상태 선점 실패, abort 실패가 운영자가 복구 가능한 상태로 남지 않는 경로가 있었다.

## 작업 내용

- `INITIATING`, `UPLOADING_PART`, `COMPLETING`, `ABORTING`, `FAILED` 상태를 추가해 원격 작업 전후 상태를 명시했다.
- session repository에 조건부 상태 전이 API를 추가해 경쟁 요청은 409로 중단되도록 했다.
- S3 호출 중 서비스 레벨 transaction을 잡지 않도록 create/uploadPart/complete/cancel 흐름을 상태 claim 기반으로 재구성했다.
- `failureReason`과 migration을 추가하고 OpenAPI contract/generated type을 동기화했다.
- S3 실패, DB metadata 저장 실패, 선점 상태 경쟁, cleanup 경쟁 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests 'com.back.boundedContexts.cloud.application.service.CloudVideoUploadSessionServiceTest'` 성공
  - `back/gradlew -p back test --tests '*Cloud*Upload*' --tests '*Multipart*'` 성공
  - `back/gradlew -p back ktlintCheck` 성공
  - `back/gradlew -p back ciFastCheck --rerun-tasks` 2회 연속 성공
  - commit hook `OpenApiContractExportTest` 및 `yarn contracts:check` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `CloudVideoUploadSessionService`의 상태 claim 순서와 S3 호출 실패/DB 저장 실패 처리
  - `CloudVideoUploadSessionRepository` 조건부 update query
  - `V20260619_03__harden_cloud_video_upload_session_state.sql`의 `upload_id` nullable 전환과 `failure_reason` 추가

## 리스크

- 기존 API 응답의 `status` enum 값이 늘어났고 `failureReason`이 추가된다.
- `UPLOADING_PART`는 같은 세션의 part 업로드를 직렬화하므로 동시 part 업로드 처리량보다 상태 일관성을 우선한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
