### PR TITLE
[Fix] 일반 업로드 temp 등록 실패 보상 추가

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberController.kt
@@ -305,7 +305,7 @@ class ApiV1AdmMemberController(
                 originalFilename = file.originalFilename,
             )
         val key = postImageStorageService.uploadPostImage(uploadRequest)
-        uploadedFileRetentionService.registerTempUpload(
+        uploadedFileRetentionService.registerTempUploadWithCompensation(
             objectKey = key,
             contentType = file.contentType.orEmpty(),
             fileSize = file.size,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageController.kt
@@ -76,7 +76,7 @@ class ApiV1PostImageController(
                 originalFilename = file.originalFilename,
             )
         val key = postImageStorageService.uploadPostImage(uploadRequest)
-        uploadedFileRetentionService.registerTempUpload(
+        uploadedFileRetentionService.registerTempUploadWithCompensation(
             objectKey = key,
             contentType = file.contentType.orEmpty(),
             fileSize = file.size,
@@ -122,7 +122,7 @@ class ApiV1PostImageController(
                 originalFilename = file.originalFilename,
             )
         val key = postImageStorageService.uploadPostFile(uploadRequest)
-        uploadedFileRetentionService.registerTempUpload(
+        uploadedFileRetentionService.registerTempUploadWithCompensation(
             objectKey = key,
             contentType = file.contentType.orEmpty(),
             fileSize = file.size,

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
@@ -115,6 +115,48 @@ class UploadedFileRetentionService(
         }
     }
 
+    fun registerTempUploadWithCompensation(
+        objectKey: String,
+        contentType: String,
+        fileSize: Long,
+        purpose: UploadedFilePurpose,
+    ) {
+        try {
+            registerTempUpload(
+                objectKey = objectKey,
+                contentType = contentType,
+                fileSize = fileSize,
+                purpose = purpose,
+            )
+        } catch (exception: RuntimeException) {
+            deleteUploadedObjectAfterRegisterFailure(objectKey, purpose, exception)
+            throw exception
+        }
+    }
+
+    private fun deleteUploadedObjectAfterRegisterFailure(
+        objectKey: String,
+        purpose: UploadedFilePurpose,
+        registerFailure: RuntimeException,
+    ) {
+        runCatching {
+            when (purpose) {
+                UploadedFilePurpose.POST_FILE -> postImageStoragePort.deletePostFile(objectKey)
+                UploadedFilePurpose.POST_IMAGE,
+                UploadedFilePurpose.PROFILE_IMAGE,
+                -> postImageStoragePort.deletePostImage(objectKey)
+            }
+        }.onFailure { deleteFailure ->
+            logger.error(
+                "uploaded_file_register_compensation_delete_failed objectKey={} purpose={} registerFailure={}",
+                objectKey,
+                purpose,
+                registerFailure::class.simpleName,
+                deleteFailure,
+            )
+        }
+    }
+
     private fun saveTempUploadInRequiresNewTransaction(
         objectKey: String,
         normalizedContentType: String,

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageControllerTest.kt
@@ -54,7 +54,7 @@ class ApiV1PostImageControllerTest {
         assertThat(response.resultCode).isEqualTo("201-1")
         assertThat(postImageStorageService.lastImageContentLength).isEqualTo(file.size)
         assertThat(postImageStorageService.lastImageBytes).containsExactly(*pngBytes())
-        verify(uploadedFileRetentionService).registerTempUpload(
+        verify(uploadedFileRetentionService).registerTempUploadWithCompensation(
             "posts/2026/03/sample.png",
             "image/png",
             file.size,
@@ -76,7 +76,7 @@ class ApiV1PostImageControllerTest {
         assertThat(response.resultCode).isEqualTo("201-2")
         assertThat(postImageStorageService.lastFileContentLength).isEqualTo(file.size)
         assertThat(postImageStorageService.lastFileBytes).containsExactly(*"pdf".toByteArray())
-        verify(uploadedFileRetentionService).registerTempUpload(
+        verify(uploadedFileRetentionService).registerTempUploadWithCompensation(
             "posts/2026/03/manual.pdf",
             "application/pdf",
             file.size,

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
@@ -10,8 +10,10 @@ import com.back.global.storage.domain.UploadedFile
 import com.back.global.storage.domain.UploadedFilePurpose
 import com.back.global.storage.domain.UploadedFileStatus
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
@@ -97,6 +99,60 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
         verify(prodSequenceGuardService).repairUploadedFileSequence()
     }
 
+    @Test
+    fun `registerTempUploadWithCompensation은 POST_IMAGE 등록 실패 시 업로드 이미지를 삭제한다`() {
+        val failure = IllegalStateException("temp row save failed")
+        val service = newService(AlwaysFailingRepository(failure))
+
+        assertThatThrownBy {
+            service.registerTempUploadWithCompensation(
+                objectKey = "posts/2026/03/orphan.png",
+                contentType = "image/png",
+                fileSize = 256,
+                purpose = UploadedFilePurpose.POST_IMAGE,
+            )
+        }.isSameAs(failure)
+
+        verify(postImageStoragePort).deletePostImage("posts/2026/03/orphan.png")
+    }
+
+    @Test
+    fun `registerTempUploadWithCompensation은 POST_FILE 등록 실패 시 업로드 파일을 삭제한다`() {
+        val failure = IllegalStateException("temp row save failed")
+        val service = newService(AlwaysFailingRepository(failure))
+
+        assertThatThrownBy {
+            service.registerTempUploadWithCompensation(
+                objectKey = "posts/2026/03/orphan.pdf",
+                contentType = "application/pdf",
+                fileSize = 512,
+                purpose = UploadedFilePurpose.POST_FILE,
+            )
+        }.isSameAs(failure)
+
+        verify(postImageStoragePort).deletePostFile("posts/2026/03/orphan.pdf")
+    }
+
+    @Test
+    fun `registerTempUploadWithCompensation은 보상 삭제 실패가 나도 등록 실패 원인을 유지한다`() {
+        val failure = IllegalStateException("temp row save failed")
+        doThrow(IllegalStateException("delete failed"))
+            .`when`(postImageStoragePort)
+            .deletePostImage("posts/2026/03/delete-fail.png")
+        val service = newService(AlwaysFailingRepository(failure))
+
+        assertThatThrownBy {
+            service.registerTempUploadWithCompensation(
+                objectKey = "posts/2026/03/delete-fail.png",
+                contentType = "image/png",
+                fileSize = 256,
+                purpose = UploadedFilePurpose.PROFILE_IMAGE,
+            )
+        }.isSameAs(failure)
+
+        verify(postImageStoragePort).deletePostImage("posts/2026/03/delete-fail.png")
+    }
+
     private fun newService(repository: UploadedFileRepositoryPort): UploadedFileRetentionService =
         UploadedFileRetentionService(
             uploadedFileRepository = repository,
@@ -108,6 +164,43 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
             transactionManager = transactionManager,
             prodSequenceGuardService = prodSequenceGuardService,
         )
+
+    private class AlwaysFailingRepository(
+        private val failure: RuntimeException,
+    ) : UploadedFileRepositoryPort {
+        override fun save(entity: UploadedFile): UploadedFile = throw failure
+
+        override fun flush() {}
+
+        override fun findByObjectKey(objectKey: String): UploadedFile? = null
+
+        override fun countByStatus(status: UploadedFileStatus): Long = 0
+
+        override fun findByPurposeAndOwnerTypeAndOwnerIdAndStatusNotOrderByCreatedAtDescIdDesc(
+            purpose: com.back.global.storage.domain.UploadedFilePurpose,
+            ownerType: com.back.global.storage.domain.UploadedFileOwnerType,
+            ownerId: Long,
+            status: UploadedFileStatus,
+        ): List<UploadedFile> = emptyList()
+
+        override fun findByIdAndPurposeAndOwnerTypeAndOwnerId(
+            id: Long,
+            purpose: com.back.global.storage.domain.UploadedFilePurpose,
+            ownerType: com.back.global.storage.domain.UploadedFileOwnerType,
+            ownerId: Long,
+        ): UploadedFile? = null
+
+        override fun countByStatusInAndPurgeAfterLessThanEqual(
+            statuses: Collection<UploadedFileStatus>,
+            purgeAfter: Instant,
+        ): Long = 0
+
+        override fun findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
+            statuses: Collection<UploadedFileStatus>,
+            purgeAfter: Instant,
+            pageable: org.springframework.data.domain.Pageable,
+        ): List<UploadedFile> = emptyList()
+    }
 
     private class SequenceDriftRecoveringRepository(
         private val firstConflict: DataIntegrityViolationException,


### PR DESCRIPTION
## 관련 이슈

close #883

## 작업 배경

- 일반 업로드는 storage upload 성공 후 `registerTempUpload`로 temp row를 등록한다.
- temp row 등록이 실패하면 API는 실패하지만 이미 업로드된 object가 retention/purge 추적 없이 남을 수 있다.

## 작업 내용

- `UploadedFileRetentionService.registerTempUploadWithCompensation`을 추가해 temp 등록 실패 시 업로드 object를 즉시 삭제하도록 했다.
- `POST_IMAGE`, `PROFILE_IMAGE`는 `deletePostImage`, `POST_FILE`은 `deletePostFile`로 보상 삭제한다.
- 보상 삭제까지 실패해도 원래 temp 등록 실패 예외를 유지하고, object key/purpose/register failure를 포함한 운영 로그를 남긴다.
- 게시글 이미지, 게시글 첨부파일, 관리자 프로필 이미지 업로드 경로를 보상 포함 등록 메서드로 전환했다.
- upload 성공 후 temp 등록 실패, file/image별 delete 호출, delete 실패 시 원 예외 유지 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests '*Upload*' --tests '*UploadedFileRetention*'` 성공
  - `back/gradlew -p back ktlintCheck` 성공
  - `back/gradlew -p back ciFastCheck --rerun-tasks` 2회 연속 성공
  - commit hook `OpenApiContractExportTest` 및 `yarn contracts:check` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `UploadedFileRetentionService.registerTempUploadWithCompensation`의 purpose별 delete 분기
  - 등록 실패와 보상 삭제 실패가 겹칠 때 원 예외를 유지하는지
  - `ApiV1PostImageController`, `ApiV1AdmMemberController` 호출부가 기존 성공 응답 계약을 유지하는지

## 리스크

- temp 등록 실패 시 기존에는 남던 storage object가 즉시 삭제된다.
- 보상 삭제 실패는 retry row 없이 로그 기반 운영 대응으로 남는다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
