### PR TITLE
[CI] 무인 배포 release planner와 migration gate 추가

### DIFF
--- a/.github/workflows/reusable-backend-quality.yml
+++ b/.github/workflows/reusable-backend-quality.yml
@@ -63,7 +63,7 @@ jobs:
                 fi
                 curl "${curl_args[@]}" "${api_url}" > "${response_body}"
               fi
-              jq -r '.[].filename' "${response_body}" >> "${changed_files}"
+              jq -r '.[] | .filename, (.previous_filename // empty)' "${response_body}" >> "${changed_files}"
               api_url="$(
                 awk -F'[<>]' '/rel="next"/ { print $2 }' "${response_headers}" | tail -n 1
               )"
@@ -84,6 +84,79 @@ jobs:
           done < "${RUNNER_TEMP}/changed-files.txt"
 
           echo "backend=${backend}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check Flyway deploy safety
+        if: github.event_name == 'pull_request'
+        id: flyway_safety
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          report="${RUNNER_TEMP}/flyway-deploy-safety.json"
+          set +e
+          node tools/ci/check-flyway-deploy-safety.mjs \
+            --json \
+            --changed-files "${RUNNER_TEMP}/changed-files.txt" \
+            --output "${report}" \
+            > "${RUNNER_TEMP}/flyway-deploy-safety.stdout"
+          status=$?
+          set -e
+
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          node - "${report}" <<'NODE'
+          const fs = require("node:fs")
+          const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"))
+          fs.appendFileSync(
+            process.env.GITHUB_STEP_SUMMARY,
+            [
+              "## Flyway deploy safety",
+              `- checked files: ${report.checkedFiles.length}`,
+              `- blocked: ${report.blocked}`,
+              `- findings: ${report.findings.length}`,
+              "",
+            ].join("\n"),
+          )
+          NODE
+
+      - name: Classify release risk
+        if: github.event_name == 'pull_request'
+        id: release_policy
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          report="${RUNNER_TEMP}/release-plan.json"
+          node tools/ci/classify-release.mjs \
+            --json \
+            --changed-files "${RUNNER_TEMP}/changed-files.txt" \
+            --migration-safety-json "${RUNNER_TEMP}/flyway-deploy-safety.json" \
+            --github-output "$GITHUB_OUTPUT" \
+            > "${report}"
+          node - "${report}" <<'NODE'
+          const fs = require("node:fs")
+          const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"))
+          fs.appendFileSync(
+            process.env.GITHUB_STEP_SUMMARY,
+            [
+              "## Release policy",
+              `- change scope: ${report.changeScope}`,
+              `- risk profile: ${report.riskProfile}`,
+              `- deploy backend: ${report.deployBackend}`,
+              `- verify frontend: ${report.verifyFrontend}`,
+              `- reasons: ${report.reasons.join(", ") || "none"}`,
+              "",
+            ].join("\n"),
+          )
+          NODE
+
+      - name: Enforce blocked release policy
+        if: github.event_name == 'pull_request' && steps.release_policy.outputs.release_risk_profile == 'blocked'
+        run: |
+          echo "Release policy blocked this change. Destructive migrations must be redesigned as expand-only changes." >&2
+          exit 1
+
+      - name: Test release planner guards
+        run: node --test tools/test/release-plan.test.mjs tools/test/flyway-deploy-safety.test.mjs
 
       - name: Guard forbidden AI docs and tool metadata
         run: bash tools/guards/check-forbidden-tracked-files.sh

--- a/.github/workflows/reusable-frontend-verify.yml
+++ b/.github/workflows/reusable-frontend-verify.yml
@@ -56,7 +56,7 @@ jobs:
                 fi
                 curl "${curl_args[@]}" "${api_url}" > "${response_body}"
               fi
-              jq -r '.[].filename' "${response_body}" >> "${changed_files}"
+              jq -r '.[] | .filename, (.previous_filename // empty)' "${response_body}" >> "${changed_files}"
               api_url="$(
                 awk -F'[<>]' '/rel="next"/ { print $2 }' "${response_headers}" | tail -n 1
               )"
@@ -77,6 +77,36 @@ jobs:
           done < "${RUNNER_TEMP}/changed-files.txt"
 
           echo "frontend=${frontend}" >> "${GITHUB_OUTPUT}"
+
+      - name: Classify release risk
+        if: github.event_name == 'pull_request'
+        id: release_policy
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          report="${RUNNER_TEMP}/release-plan.json"
+          node tools/ci/classify-release.mjs \
+            --json \
+            --changed-files "${RUNNER_TEMP}/changed-files.txt" \
+            --github-output "$GITHUB_OUTPUT" \
+            > "${report}"
+          node - "${report}" <<'NODE'
+          const fs = require("node:fs")
+          const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"))
+          fs.appendFileSync(
+            process.env.GITHUB_STEP_SUMMARY,
+            [
+              "## Release policy",
+              `- change scope: ${report.changeScope}`,
+              `- risk profile: ${report.riskProfile}`,
+              `- deploy backend: ${report.deployBackend}`,
+              `- verify frontend: ${report.verifyFrontend}`,
+              `- reasons: ${report.reasons.join(", ") || "none"}`,
+              "",
+            ].join("\n"),
+          )
+          NODE
 
       - name: Skip frontend-heavy checks
         if: steps.changes.outputs.frontend != 'true'

--- a/tools/ci/check-flyway-deploy-safety.mjs
+++ b/tools/ci/check-flyway-deploy-safety.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
+import path from "node:path"
+
+const parseArgs = (argv) => {
+  const args = { json: false, repoRoot: process.cwd() }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--json") args.json = true
+    else if (arg === "--repo-root") args.repoRoot = argv[++index]
+    else if (arg === "--changed-files") args.changedFiles = argv[++index]
+    else if (arg === "--output") args.output = argv[++index]
+    else throw new Error(`Unknown argument: ${arg}`)
+  }
+  if (!args.changedFiles) throw new Error("--changed-files is required")
+  return args
+}
+
+const readChangedFiles = (file) =>
+  readFileSync(file, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+
+const isMigrationFile = (file) => /^back\/src\/main\/resources\/db\/migration\/.+\.sql$/.test(file)
+
+const isProceduralBodyPrefix = (statement) =>
+  /\bdo\s+(?:language\s+[a-z_][a-z0-9_]*\s+)?$/i.test(statement) || /\bas\s*$/i.test(statement)
+
+const stripCommentsAndStrings = (sql, options = {}) => {
+  const inspectStringLiterals = options.inspectStringLiterals === true
+  let output = ""
+  for (let index = 0; index < sql.length; index += 1) {
+    const current = sql[index]
+    const next = sql[index + 1]
+
+    if (current === "-" && next === "-") {
+      while (index < sql.length && sql[index] !== "\n") index += 1
+      output += "\n"
+      continue
+    }
+
+    if (current === "/" && next === "*") {
+      index += 2
+      while (index < sql.length && !(sql[index] === "*" && sql[index + 1] === "/")) index += 1
+      index += 1
+      output += " "
+      continue
+    }
+
+    if (current === "$") {
+      const rest = sql.slice(index)
+      const delimiter = rest.match(/^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$/)?.[0]
+      if (delimiter) {
+        const closeIndex = sql.indexOf(delimiter, index + delimiter.length)
+        if (closeIndex !== -1) {
+          const currentStatement = output.slice(output.lastIndexOf(";") + 1)
+          const isProceduralBody = isProceduralBodyPrefix(currentStatement)
+          const body = sql.slice(index + delimiter.length, closeIndex)
+          index = closeIndex + delimiter.length - 1
+          if (isProceduralBody || inspectStringLiterals) {
+            output += ` ${stripCommentsAndStrings(body, { inspectStringLiterals: true })} `
+          } else {
+            output += " "
+          }
+          continue
+        }
+      }
+    }
+
+    if ((current === "E" || current === "e") && next === "'") {
+      const currentStatement = output.slice(output.lastIndexOf(";") + 1)
+      const isProceduralBody = isProceduralBodyPrefix(currentStatement)
+      const captureLiteral = isProceduralBody || inspectStringLiterals
+      index += 2
+      let literal = ""
+      while (index < sql.length) {
+        if (sql[index] === "\\") {
+          if (captureLiteral && index + 1 < sql.length) literal += sql[index + 1]
+          index += 2
+          continue
+        }
+        if (sql[index] === "'" && sql[index + 1] === "'") {
+          if (captureLiteral) literal += "'"
+          index += 2
+          continue
+        }
+        if (sql[index] === "'") break
+        if (captureLiteral) literal += sql[index]
+        index += 1
+      }
+      if (captureLiteral) {
+        output += ` ${stripCommentsAndStrings(literal, { inspectStringLiterals: true })} `
+      } else {
+        output += " "
+      }
+      continue
+    }
+
+    if (current === "'") {
+      const currentStatement = output.slice(output.lastIndexOf(";") + 1)
+      const isProceduralBody = isProceduralBodyPrefix(currentStatement)
+      const captureLiteral = isProceduralBody || inspectStringLiterals
+      index += 1
+      let literal = ""
+      while (index < sql.length) {
+        if (sql[index] === "'" && sql[index + 1] === "'") {
+          if (captureLiteral) literal += "'"
+          index += 2
+          continue
+        }
+        if (sql[index] === "'") break
+        if (captureLiteral) literal += sql[index]
+        index += 1
+      }
+      if (captureLiteral) {
+        output += ` ${stripCommentsAndStrings(literal, { inspectStringLiterals: true })} `
+      } else {
+        output += " "
+      }
+      continue
+    }
+
+    output += current
+  }
+  return output
+}
+
+const destructiveRules = [
+  { rule: "drop-table", pattern: /\bdrop\s+table\b/i },
+  { rule: "drop-schema", pattern: /\bdrop\s+schema\b/i },
+  { rule: "drop-schema-object", pattern: /\bdrop\s+(?:database|domain|extension|function|materialized\s+view|procedure|sequence|trigger|type|view)\b/i },
+  { rule: "drop-column", pattern: /\balter\s+table\b[^;]*?\bdrop\s+(?:column\s+)?(?!constraint\b|not\b|default\b)[a-zA-Z_"]/i },
+  { rule: "truncate-table", pattern: /(?:^|;|\bbegin\b|\bthen\b|\belse\b|\bloop\b|\bexecute\b)\s*truncate\s+(?:table\s+)?\b/i },
+  { rule: "rename-table", pattern: /\balter\s+table\b[^;]*?\brename\s+to\b/i },
+  { rule: "rename-column", pattern: /\balter\s+table\b[^;]*?\brename\s+(?:column\s+)?(?!constraint\b|to\b)[^;]*?\bto\b/i },
+  { rule: "alter-column-type", pattern: /\balter\s+table\b[^;]*?\balter\s+(?:column\s+)?[^;]*?\btype\b/i },
+  { rule: "set-not-null", pattern: /\balter\s+table\b[^;]*?\balter\s+(?:column\s+)?[^;]*?\bset\s+not\s+null\b/i },
+]
+
+const inspectFile = ({ repoRoot, file }) => {
+  const fullPath = path.join(repoRoot, file)
+  if (!existsSync(fullPath)) return [{ file, rule: "missing-migration-file" }]
+  const stripped = stripCommentsAndStrings(readFileSync(fullPath, "utf8"))
+  return destructiveRules
+    .filter(({ pattern }) => pattern.test(stripped))
+    .map(({ rule }) => ({ file, rule }))
+}
+
+const main = () => {
+  const args = parseArgs(process.argv.slice(2))
+  const checkedFiles = readChangedFiles(args.changedFiles).filter(isMigrationFile)
+  const findings = checkedFiles.flatMap((file) => inspectFile({ repoRoot: args.repoRoot, file }))
+  const result = {
+    version: 1,
+    ok: findings.length === 0,
+    blocked: findings.length > 0,
+    checkedFiles,
+    findings,
+  }
+  const output = `${JSON.stringify(result, null, 2)}\n`
+
+  if (args.output) writeFileSync(args.output, output)
+
+  if (args.json) process.stdout.write(output)
+  else if (result.blocked) {
+    for (const finding of findings) {
+      process.stderr.write(`destructive migration blocked: ${finding.file} ${finding.rule}\n`)
+    }
+  } else {
+    process.stdout.write(`Flyway deploy safety passed: ${checkedFiles.length} migration files checked\n`)
+  }
+
+  process.exit(result.blocked ? 1 : 0)
+}
+
+main()

--- a/tools/ci/classify-release.mjs
+++ b/tools/ci/classify-release.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+import { readFileSync, appendFileSync } from "node:fs"
+
+const parseArgs = (argv) => {
+  const args = { json: false }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--json") args.json = true
+    else if (arg === "--changed-files") args.changedFiles = argv[++index]
+    else if (arg === "--migration-safety-json") args.migrationSafetyJson = argv[++index]
+    else if (arg === "--github-output") args.githubOutput = argv[++index]
+    else throw new Error(`Unknown argument: ${arg}`)
+  }
+  return args
+}
+
+const readChangedFiles = (args) => {
+  const text = args.changedFiles ? readFileSync(args.changedFiles, "utf8") : readFileSync(0, "utf8")
+  return [...new Set(text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean))]
+}
+
+const isDocsFile = (file) =>
+  file.startsWith("docs/") ||
+  ["AGENTS.md", "CLAUDE.md", "GEMINI.md", "CURSOR.md", "COPILOT.md", "README.md"].includes(file)
+
+const isFrontendFile = (file) => file.startsWith("front/")
+
+const isBackendFile = (file) =>
+  file.startsWith("back/") ||
+  file.startsWith("deploy/homeserver/")
+
+const isPipelineFile = (file) =>
+  file.startsWith(".github/workflows/") ||
+  file.startsWith("tools/ci/") ||
+  file === "back/Dockerfile" ||
+  file === "front/Dockerfile"
+
+const isMigrationFile = (file) => /^back\/src\/main\/resources\/db\/migration\/.+\.sql$/.test(file)
+
+const extendedRules = [
+  { reason: "security-or-auth", pattern: /(^|[/_.-])(security|authorization|oauth|auth(?!or)|session|cookie|csrf|cors)/i },
+  { reason: "storage", pattern: /(storage|upload|cloud|minio|s3)/i },
+  { reason: "task-or-worker", pattern: /(task|outbox|worker|scheduler|queue)/i },
+  { reason: "deploy", pattern: /^(?:deploy\/|.*(?:docker-compose|Caddyfile))/i },
+  { reason: "workflow", pattern: /^\.github\/workflows\// },
+  { reason: "dockerfile", pattern: /(^|\/)Dockerfile$/ },
+  { reason: "migration", pattern: /^back\/src\/main\/resources\/db\/migration\/.+\.sql$/ },
+]
+
+const loadMigrationSafety = (path) => {
+  if (!path) return null
+  return JSON.parse(readFileSync(path, "utf8"))
+}
+
+const classifyScope = (files) => {
+  if (files.length > 0 && files.every(isDocsFile)) return "docs-only"
+
+  const hasBackend = files.some(isBackendFile)
+  const hasFrontend = files.some(isFrontendFile)
+  const hasPipeline = files.some(isPipelineFile)
+
+  if (hasBackend && !hasFrontend && !hasPipeline) return "backend-only"
+  if (hasFrontend && !hasBackend && !hasPipeline) return "frontend-only"
+  return "mixed"
+}
+
+const classify = ({ files, migrationSafety }) => {
+  const reasons = []
+  const changeScope = classifyScope(files)
+
+  if (changeScope === "docs-only") {
+    return {
+      version: 1,
+      changedFiles: files,
+      changeScope,
+      riskProfile: "standard",
+      deployBackend: false,
+      verifyFrontend: false,
+      reasons: ["docs-only"],
+    }
+  }
+  if (files.some(isBackendFile)) reasons.push("backend")
+  if (files.some(isFrontendFile)) reasons.push("frontend")
+  if (files.some(isPipelineFile)) reasons.push("pipeline")
+  if (files.some(isMigrationFile)) reasons.push("migration")
+  if (files.some(isBackendFile) && files.some(isFrontendFile)) reasons.push("backend-and-frontend")
+
+  for (const { reason, pattern } of extendedRules) {
+    if (files.some((file) => pattern.test(file)) && !reasons.includes(reason)) {
+      reasons.push(reason)
+    }
+  }
+
+  let riskProfile = reasons.some((reason) =>
+    ["security-or-auth", "storage", "task-or-worker", "deploy", "workflow", "dockerfile", "migration", "backend-and-frontend", "pipeline"].includes(reason),
+  )
+    ? "extended"
+    : "standard"
+
+  if (changeScope === "docs-only") riskProfile = "standard"
+
+  if (migrationSafety?.blocked) {
+    riskProfile = "blocked"
+    if (!reasons.includes("destructive-migration")) reasons.push("destructive-migration")
+  }
+
+  return {
+    version: 1,
+    changedFiles: files,
+    changeScope,
+    riskProfile,
+    deployBackend: changeScope === "backend-only" || changeScope === "mixed",
+    verifyFrontend: changeScope === "frontend-only" || changeScope === "mixed",
+    reasons,
+  }
+}
+
+const writeGithubOutput = (path, result) => {
+  if (!path) return
+  appendFileSync(
+    path,
+    [
+      `release_change_scope=${result.changeScope}`,
+      `release_risk_profile=${result.riskProfile}`,
+      `release_deploy_backend=${result.deployBackend}`,
+      `release_verify_frontend=${result.verifyFrontend}`,
+      "",
+    ].join("\n"),
+  )
+}
+
+const main = () => {
+  const args = parseArgs(process.argv.slice(2))
+  const result = classify({
+    files: readChangedFiles(args),
+    migrationSafety: loadMigrationSafety(args.migrationSafetyJson),
+  })
+
+  writeGithubOutput(args.githubOutput, result)
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+    return
+  }
+
+  process.stdout.write(`release change_scope=${result.changeScope} risk_profile=${result.riskProfile}\n`)
+}
+
+main()

--- a/tools/test/flyway-deploy-safety.test.mjs
+++ b/tools/test/flyway-deploy-safety.test.mjs
@@ -1,0 +1,282 @@
+import assert from "node:assert/strict"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { spawnSync } from "node:child_process"
+import test from "node:test"
+
+const repoRoot = path.resolve(import.meta.dirname, "../..")
+const scriptPath = path.join(repoRoot, "tools/ci/check-flyway-deploy-safety.mjs")
+
+const createRepo = ({ files }) => {
+  const root = mkdtempSync(path.join(tmpdir(), "flyway-safety-"))
+  for (const [file, content] of Object.entries(files)) {
+    const target = path.join(root, file)
+    mkdirSync(path.dirname(target), { recursive: true })
+    writeFileSync(target, content)
+  }
+  return root
+}
+
+const runSafety = ({ root, changedFiles }) => {
+  const changedPath = path.join(root, "changed-files.txt")
+  writeFileSync(changedPath, `${changedFiles.join("\n")}\n`)
+
+  const result = spawnSync(process.execPath, [scriptPath, "--json", "--repo-root", root, "--changed-files", changedPath], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  })
+
+  return {
+    ...result,
+    json: result.stdout ? JSON.parse(result.stdout) : null,
+  }
+}
+
+test("safe expand-only migrations pass", () => {
+  const file = "back/src/main/resources/db/migration/V20260619_03__expand_safe.sql"
+  const root = createRepo({
+    files: {
+      [file]: `
+        CREATE TABLE public.release_audit (id bigint);
+        ALTER TABLE public.post ADD COLUMN release_note text;
+        CREATE INDEX IF NOT EXISTS idx_release_audit_id ON public.release_audit(id);
+        INSERT INTO public.release_audit(id) VALUES (1);
+      `,
+    },
+  })
+
+  try {
+    const result = runSafety({ root, changedFiles: [file] })
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.json.ok, true)
+    assert.equal(result.json.blocked, false)
+    assert.deepEqual(result.json.findings, [])
+    assert.deepEqual(result.json.checkedFiles, [file])
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test("destructive schema changes fail closed", () => {
+  const files = {
+    "back/src/main/resources/db/migration/V20260619_03__drop_schema.sql": "DROP SCHEMA public CASCADE;",
+    "back/src/main/resources/db/migration/V20260619_04__drop_table.sql": "DROP TABLE public.post;",
+    "back/src/main/resources/db/migration/V20260619_05__drop_column.sql": "ALTER TABLE public.post DROP COLUMN title;",
+    "back/src/main/resources/db/migration/V20260619_06__truncate.sql": "TRUNCATE TABLE public.post;",
+    "back/src/main/resources/db/migration/V20260619_07__rename_table.sql": "ALTER TABLE public.post RENAME TO archived_post;",
+    "back/src/main/resources/db/migration/V20260619_08__rename_column.sql": "ALTER TABLE public.post RENAME COLUMN title TO subject;",
+    "back/src/main/resources/db/migration/V20260619_09__type_change.sql": "ALTER TABLE public.post ALTER COLUMN title TYPE varchar(255);",
+    "back/src/main/resources/db/migration/V20260619_10__drop_view.sql": "DROP VIEW public.post_summary;",
+    "back/src/main/resources/db/migration/V20260619_10__not_null.sql": "ALTER TABLE public.post ALTER COLUMN title SET NOT NULL;",
+    "back/src/main/resources/db/migration/V20260619_16__type_change_shorthand.sql": "ALTER TABLE public.post ALTER title TYPE varchar(255);",
+    "back/src/main/resources/db/migration/V20260619_17__not_null_shorthand.sql": "ALTER TABLE public.post ALTER title SET NOT NULL;",
+    "back/src/main/resources/db/migration/V20260619_18__do_block_drop.sql": `
+      DO $$
+      BEGIN
+        ALTER TABLE public.post DROP COLUMN title;
+      END
+      $$;
+    `,
+    "back/src/main/resources/db/migration/V20260619_19__function_body_drop.sql": `
+      CREATE FUNCTION public.drop_post_title() RETURNS void AS $fn$
+      BEGIN
+        ALTER TABLE public.post DROP COLUMN title;
+      END
+      $fn$ LANGUAGE plpgsql;
+    `,
+    "back/src/main/resources/db/migration/V20260619_20__dynamic_sql_drop.sql": `
+      DO $$
+      BEGIN
+        EXECUTE 'DROP TABLE public.post';
+      END
+      $$;
+    `,
+    "back/src/main/resources/db/migration/V20260619_21__single_quoted_function_body_drop.sql": `
+      CREATE FUNCTION public.drop_post_title() RETURNS void AS '
+      BEGIN
+        ALTER TABLE public.post DROP COLUMN title;
+      END
+      ' LANGUAGE plpgsql;
+    `,
+    "back/src/main/resources/db/migration/V20260619_22__do_block_truncate.sql": `
+      DO $$
+      BEGIN
+        TRUNCATE TABLE public.post;
+      END
+      $$;
+    `,
+    "back/src/main/resources/db/migration/V20260619_23__dynamic_sql_truncate.sql": `
+      DO $$
+      BEGIN
+        EXECUTE 'TRUNCATE TABLE public.post';
+      END
+      $$;
+    `,
+    "back/src/main/resources/db/migration/V20260619_24__drop_type.sql": "DROP TYPE public.post_state;",
+    "back/src/main/resources/db/migration/V20260619_25__drop_sequence.sql": "DROP SEQUENCE public.post_id_seq;",
+  }
+  const root = createRepo({ files })
+
+  try {
+    const result = runSafety({ root, changedFiles: Object.keys(files) })
+    assert.equal(result.status, 1)
+    assert.equal(result.json.ok, false)
+    assert.equal(result.json.blocked, true)
+    assert.deepEqual(
+      result.json.findings.map((finding) => finding.rule).sort(),
+      [
+        "alter-column-type",
+        "alter-column-type",
+        "drop-column",
+        "drop-column",
+        "drop-column",
+        "drop-column",
+        "drop-schema",
+        "drop-schema-object",
+        "drop-schema-object",
+        "drop-schema-object",
+        "drop-table",
+        "drop-table",
+        "rename-column",
+        "rename-table",
+        "set-not-null",
+        "set-not-null",
+        "truncate-table",
+        "truncate-table",
+        "truncate-table",
+      ],
+    )
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test("comments and string literals do not trigger destructive findings", () => {
+  const file = "back/src/main/resources/db/migration/V20260619_10__safe_mentions.sql"
+  const root = createRepo({
+    files: {
+      [file]: `
+        -- DROP TABLE public.post;
+        /* ALTER TABLE public.post DROP COLUMN title; */
+        INSERT INTO public.release_audit(message) VALUES ('TRUNCATE TABLE public.post');
+        INSERT INTO public.release_audit(message) VALUES ($$DROP TABLE public.post$$);
+        INSERT INTO public.release_audit(message) VALUES ($safe$ALTER TABLE public.post DROP COLUMN title$safe$);
+        INSERT INTO public.release_audit(message) VALUES (E'it\\'s DROP TABLE public.post');
+        GRANT TRUNCATE ON TABLE public.post TO app_user;
+        REVOKE TRUNCATE ON TABLE public.post FROM app_user;
+      `,
+    },
+  })
+
+  try {
+    const result = runSafety({ root, changedFiles: [file] })
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.json.ok, true)
+    assert.equal(result.json.blocked, false)
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test("PostgreSQL column drop and rename shorthand fail closed", () => {
+  const files = {
+    "back/src/main/resources/db/migration/V20260619_11__drop_column_shorthand.sql": "ALTER TABLE public.post DROP title;",
+    "back/src/main/resources/db/migration/V20260619_12__rename_column_shorthand.sql": "ALTER TABLE public.post RENAME title TO subject;",
+  }
+  const root = createRepo({ files })
+
+  try {
+    const result = runSafety({ root, changedFiles: Object.keys(files) })
+    assert.equal(result.status, 1)
+    assert.equal(result.json.ok, false)
+    assert.equal(result.json.blocked, true)
+    assert.deepEqual(
+      result.json.findings.map((finding) => finding.rule).sort(),
+      ["drop-column", "rename-column"],
+    )
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test("constraint and index cleanup does not look like a column drop", () => {
+  const file = "back/src/main/resources/db/migration/V20260619_13__drop_duplicate_index.sql"
+  const root = createRepo({
+    files: {
+      [file]: `
+        ALTER TABLE public.member
+          DROP CONSTRAINT IF EXISTS uk_member_legacy;
+        DROP INDEX IF EXISTS public.uk_member_legacy;
+      `,
+    },
+  })
+
+  try {
+    const result = runSafety({ root, changedFiles: [file] })
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.json.ok, true)
+    assert.equal(result.json.blocked, false)
+    assert.deepEqual(result.json.findings, [])
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test("constraint relaxation does not look like a column drop", () => {
+  const file = "back/src/main/resources/db/migration/V20260619_14__relax_column.sql"
+  const root = createRepo({
+    files: {
+      [file]: `
+        ALTER TABLE public.post ALTER COLUMN title DROP NOT NULL;
+        ALTER TABLE public.post ALTER COLUMN title DROP DEFAULT;
+      `,
+    },
+  })
+
+  try {
+    const result = runSafety({ root, changedFiles: [file] })
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.json.ok, true)
+    assert.equal(result.json.blocked, false)
+    assert.deepEqual(result.json.findings, [])
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test("missing changed migration file fails closed for rename and delete", () => {
+  const missingFile = "back/src/main/resources/db/migration/V20260619_15__renamed_away.sql"
+  const root = createRepo({ files: {} })
+
+  try {
+    const result = runSafety({ root, changedFiles: [missingFile] })
+    assert.equal(result.status, 1)
+    assert.equal(result.json.ok, false)
+    assert.equal(result.json.blocked, true)
+    assert.deepEqual(result.json.findings, [{ file: missingFile, rule: "missing-migration-file" }])
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test("non migration changed files are ignored", () => {
+  const root = createRepo({
+    files: {
+      "back/src/main/kotlin/com/back/PostController.kt": "class PostController",
+    },
+  })
+
+  try {
+    const result = runSafety({
+      root,
+      changedFiles: ["back/src/main/kotlin/com/back/PostController.kt"],
+    })
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.json.ok, true)
+    assert.equal(result.json.blocked, false)
+    assert.deepEqual(result.json.checkedFiles, [])
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+})

--- a/tools/test/release-plan.test.mjs
+++ b/tools/test/release-plan.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { spawnSync } from "node:child_process"
+import test from "node:test"
+
+const repoRoot = path.resolve(import.meta.dirname, "../..")
+const scriptPath = path.join(repoRoot, "tools/ci/classify-release.mjs")
+const backendWorkflowPath = path.join(repoRoot, ".github/workflows/reusable-backend-quality.yml")
+const frontendWorkflowPath = path.join(repoRoot, ".github/workflows/reusable-frontend-verify.yml")
+
+const runClassifier = (files, args = []) => {
+  const result = spawnSync(process.execPath, [scriptPath, "--json", ...args], {
+    cwd: repoRoot,
+    input: `${files.join("\n")}\n`,
+    encoding: "utf8",
+  })
+
+  return {
+    ...result,
+    json: result.stdout ? JSON.parse(result.stdout) : null,
+  }
+}
+
+test("docs-only changes stay standard and skip deploy verifications", () => {
+  const result = runClassifier(["docs/agent/infra-oauth.md"])
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.equal(result.json.changeScope, "docs-only")
+  assert.equal(result.json.riskProfile, "standard")
+  assert.equal(result.json.deployBackend, false)
+  assert.equal(result.json.verifyFrontend, false)
+  assert.deepEqual(result.json.reasons, ["docs-only"])
+})
+
+test("backend-only and frontend-only changes keep independent standard routing", () => {
+  const backend = runClassifier(["back/src/main/kotlin/com/back/PostController.kt"])
+  const frontend = runClassifier(["front/src/pages/index.tsx"])
+
+  assert.equal(backend.status, 0, backend.stderr)
+  assert.equal(backend.json.changeScope, "backend-only")
+  assert.equal(backend.json.riskProfile, "standard")
+  assert.equal(backend.json.deployBackend, true)
+  assert.equal(backend.json.verifyFrontend, false)
+
+  assert.equal(frontend.status, 0, frontend.stderr)
+  assert.equal(frontend.json.changeScope, "frontend-only")
+  assert.equal(frontend.json.riskProfile, "standard")
+  assert.equal(frontend.json.deployBackend, false)
+  assert.equal(frontend.json.verifyFrontend, true)
+})
+
+test("security deploy storage task migration workflow and dockerfile changes are extended", () => {
+  const cases = [
+    "back/src/main/kotlin/com/back/global/security/AuthPolicy.kt",
+    "back/src/main/kotlin/com/back/global/AuthorizationFilter.kt",
+    "back/src/main/kotlin/com/back/global/oauth/OAuthService.kt",
+    "back/src/main/kotlin/com/back/global/session/SessionCookie.kt",
+    "back/src/main/kotlin/com/back/boundedContexts/upload/StorageService.kt",
+    "back/src/main/kotlin/com/back/boundedContexts/task/TaskWorker.kt",
+    "deploy/homeserver/docker-compose.prod.yml",
+    "back/src/main/resources/db/migration/V20260619_03__add_safe_column.sql",
+    ".github/workflows/reusable-backend-quality.yml",
+    "back/Dockerfile",
+  ]
+
+  for (const file of cases) {
+    const result = runClassifier([file])
+    assert.equal(result.status, 0, `${file}\n${result.stderr}`)
+    assert.equal(result.json.riskProfile, "extended", file)
+    assert(result.json.reasons.length > 0, file)
+  }
+})
+
+test("authoring paths do not count as auth risk", () => {
+  const result = runClassifier(["front/e2e/editor-authoring-flow.spec.ts"])
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.equal(result.json.changeScope, "frontend-only")
+  assert.equal(result.json.riskProfile, "standard")
+  assert(!result.json.reasons.includes("security-or-auth"))
+})
+
+test("backend and frontend together are mixed extended", () => {
+  const result = runClassifier([
+    "back/src/main/kotlin/com/back/PostController.kt",
+    "front/src/pages/index.tsx",
+  ])
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.equal(result.json.changeScope, "mixed")
+  assert.equal(result.json.riskProfile, "extended")
+  assert.equal(result.json.deployBackend, true)
+  assert.equal(result.json.verifyFrontend, true)
+  assert(result.json.reasons.includes("backend-and-frontend"))
+})
+
+test("destructive migration safety result blocks release", () => {
+  const workDir = mkdtempSync(path.join(tmpdir(), "release-plan-"))
+  const safetyPath = path.join(workDir, "migration-safety.json")
+
+  try {
+    writeFileSync(
+      safetyPath,
+      JSON.stringify({
+        ok: false,
+        blocked: true,
+        findings: [{ file: "back/src/main/resources/db/migration/V20260619_99__drop_table.sql", rule: "drop-table" }],
+      }),
+    )
+
+    const result = runClassifier(
+      ["back/src/main/resources/db/migration/V20260619_99__drop_table.sql"],
+      ["--migration-safety-json", safetyPath],
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.json.changeScope, "backend-only")
+    assert.equal(result.json.riskProfile, "blocked")
+    assert(result.json.reasons.includes("destructive-migration"))
+  } finally {
+    rmSync(workDir, { force: true, recursive: true })
+  }
+})
+
+test("reusable workflows run release planner policy checks", () => {
+  const backendWorkflow = readFileSync(backendWorkflowPath, "utf8")
+  const frontendWorkflow = readFileSync(frontendWorkflowPath, "utf8")
+
+  assert.match(backendWorkflow, /Check Flyway deploy safety/)
+  assert.match(backendWorkflow, /previous_filename/)
+  assert.match(backendWorkflow, /tools\/ci\/check-flyway-deploy-safety\.mjs/)
+  assert.match(backendWorkflow, /Classify release risk/)
+  assert.match(backendWorkflow, /tools\/ci\/classify-release\.mjs/)
+  assert.match(backendWorkflow, /--migration-safety-json "\$\{RUNNER_TEMP\}\/flyway-deploy-safety\.json"/)
+  assert(backendWorkflow.indexOf("Check Flyway deploy safety") < backendWorkflow.indexOf("Classify release risk"))
+  assert(backendWorkflow.indexOf("Classify release risk") < backendWorkflow.indexOf("Skip backend-heavy checks"))
+  assert.match(backendWorkflow, /node --test tools\/test\/release-plan\.test\.mjs tools\/test\/flyway-deploy-safety\.test\.mjs/)
+
+  assert.match(frontendWorkflow, /Classify release risk/)
+  assert.match(frontendWorkflow, /previous_filename/)
+  assert.match(frontendWorkflow, /tools\/ci\/classify-release\.mjs/)
+  assert(frontendWorkflow.indexOf("Classify release risk") < frontendWorkflow.indexOf("Skip frontend-heavy checks"))
+})


### PR DESCRIPTION
## 관련 이슈

close #903

## 작업 배경

- 사람 승인 없는 자동 배포로 가기 전에 PR 단계에서 배포 위험도를 기계적으로 분류하고, destructive Flyway migration을 fail-closed로 막는 최소 release planner가 필요했다.
- 이번 PR은 무인 배포 전체 전환이 아니라 PR 1 범위인 정적 release classification과 migration gate만 추가한다.

## 작업 내용

- `tools/ci/classify-release.mjs`를 추가해 변경 파일 목록을 `docs-only`, `backend-only`, `frontend-only`, `mixed`로 분류하고 `standard`, `extended`, `blocked` 위험도를 산출했다.
- `tools/ci/check-flyway-deploy-safety.mjs`를 추가해 changed Flyway migration SQL에서 table/schema/schema object drop, column drop, truncate, rename, column type 변경, `SET NOT NULL`을 destructive 변경으로 차단한다.
- backend reusable quality workflow에 Flyway deploy safety 검사, release risk classification, blocked release enforcement를 추가했다.
- backend/frontend PR file 수집에서 `previous_filename`까지 포함해 rename-away 변경도 release classification에 반영되게 했다.
- frontend reusable verify workflow에 release risk classification summary를 추가했다.
- release planner와 migration gate의 CLI 계약 및 workflow 연결을 Node test로 고정했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/test/release-plan.test.mjs tools/test/flyway-deploy-safety.test.mjs`: PASS, 15 tests / 15 pass
  - `git diff --check`: PASS
  - `back/gradlew -p back ktlintCheck`: PASS, BUILD SUCCESSFUL
  - `yarn --cwd front install --frozen-lockfile`: PASS
  - `yarn --cwd front build`: PASS
  - `yarn contracts:check`: PASS, pre-commit에서 실행
  - `codex review --base origin/main --title "[CI] 무인 배포 release planner와 migration gate 추가"`: PASS, current head `d0291ded`에서 actionable bugs 없음
  - GitHub PR checks: PASS, backend-ci / frontend-ci / Security CodeQL / Vercel / CodeRabbit completed
- 참고:
  - `./gradlew -p back ktlintCheck`는 저장소 루트에 wrapper가 없어 실패했고, 저장소 구조에 맞는 `back/gradlew -p back ktlintCheck`로 검증했다.
  - `yarn --cwd front build`는 worktree에 `front/node_modules`가 없어 최초 `next ENOENT`로 실패했고, `yarn --cwd front install --frozen-lockfile` 후 동일 명령이 통과했다.
  - `bash tools/test/verify-deploy-workflow-classification.sh`는 이번 PR에서 수정하지 않은 `.github/workflows/deploy.yml`의 editor canary path classification mismatch로 실패했다. 이번 PR의 allow 범위 밖 기존 deploy workflow guard라 PR 1 완료 조건에서는 제외했다.
  - CodeRabbit status는 ready 전 draft에서 `Review skipped`였고, ready 전환 후 `Review completed` 상태를 확인했다. Codex CLI fallback review도 단일 PR review로 게시했다. fallback 중 발견된 migration checker와 classifier edge case는 모두 current head `d0291ded`에 반영했다.

## 리뷰어 메모

- 먼저 볼 지점:
  - `.github/workflows/reusable-backend-quality.yml`의 `Check Flyway deploy safety` -> `Classify release risk` -> `Enforce blocked release policy` 순서
  - `.github/workflows/reusable-frontend-verify.yml`의 `previous_filename` 포함 PR file 수집과 release classification summary
  - `tools/ci/classify-release.mjs`의 위험도 기준과 GitHub output 이름
  - `tools/ci/check-flyway-deploy-safety.mjs`의 destructive SQL rule 목록

## 리스크

- release planner는 path 기반 heuristic이라 실제 runtime 위험을 완전히 판정하지 않는다. digest pin, canary burn-in, rollback gate는 후속 PR에서 분리해야 한다.
- SQL 검사는 full SQL parser가 아니라 comments/string/procedural body 처리 후 destructive pattern을 검사한다. fail-closed 목적에는 맞지만 SQL dialect edge case는 후속 보강 대상이다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
