### PR TITLE
[Refactor] UploadedFileRetentionService 책임 분리

### DIFF
--- a/back/src/main/kotlin/com/back/global/storage/application/PostAttachmentRetentionService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/PostAttachmentRetentionService.kt
@@ -1,0 +1,143 @@
+package com.back.global.storage.application
+
+import com.back.boundedContexts.post.config.PostImageStorageProperties
+import com.back.global.storage.application.port.output.UploadedFileRepositoryPort
+import com.back.global.storage.domain.UploadedFile
+import com.back.global.storage.domain.UploadedFilePurpose
+import com.back.global.storage.domain.UploadedFileRetentionReason
+import com.back.global.storage.domain.UploadedFileStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.Instant
+
+@Service
+class PostAttachmentRetentionService(
+    private val uploadedFileRepository: UploadedFileRepositoryPort,
+    private val storageProperties: PostImageStorageProperties,
+    private val retentionProperties: UploadedFileRetentionProperties,
+    private val clock: Clock,
+) {
+    @Transactional
+    fun syncPostContent(
+        postId: Long,
+        previousContent: String?,
+        currentContent: String,
+    ) {
+        syncPostAttachmentKeys(
+            postId = postId,
+            currentKeys = UploadedFileUrlCodec.extractImageObjectKeysFromContent(currentContent),
+            previousKeys = UploadedFileUrlCodec.extractImageObjectKeysFromContent(previousContent.orEmpty()),
+            purpose = UploadedFilePurpose.POST_IMAGE,
+        )
+        syncPostAttachmentKeys(
+            postId = postId,
+            currentKeys = UploadedFileUrlCodec.extractFileObjectKeysFromContent(currentContent),
+            previousKeys = UploadedFileUrlCodec.extractFileObjectKeysFromContent(previousContent.orEmpty()),
+            purpose = UploadedFilePurpose.POST_FILE,
+        )
+    }
+
+    @Transactional
+    fun scheduleDeletedPostAttachments(content: String) {
+        scheduleDeletionForContent(
+            purpose = UploadedFilePurpose.POST_IMAGE,
+            keys = UploadedFileUrlCodec.extractImageObjectKeysFromContent(content),
+        )
+        scheduleDeletionForContent(
+            purpose = UploadedFilePurpose.POST_FILE,
+            keys = UploadedFileUrlCodec.extractFileObjectKeysFromContent(content),
+        )
+    }
+
+    @Transactional
+    fun restoreDeletedPostAttachments(
+        postId: Long,
+        content: String,
+    ) {
+        restorePostAttachmentKeys(
+            postId = postId,
+            keys = UploadedFileUrlCodec.extractImageObjectKeysFromContent(content),
+            purpose = UploadedFilePurpose.POST_IMAGE,
+        )
+        restorePostAttachmentKeys(
+            postId = postId,
+            keys = UploadedFileUrlCodec.extractFileObjectKeysFromContent(content),
+            purpose = UploadedFilePurpose.POST_FILE,
+        )
+    }
+
+    private fun syncPostAttachmentKeys(
+        postId: Long,
+        currentKeys: Set<String>,
+        previousKeys: Set<String>,
+        purpose: UploadedFilePurpose,
+    ) {
+        currentKeys.forEach { objectKey ->
+            val uploadedFile = findOrCreate(objectKey)
+            uploadedFile.attachToPost(postId, purpose)
+            uploadedFileRepository.save(uploadedFile)
+        }
+
+        (previousKeys - currentKeys).forEach { objectKey ->
+            scheduleDeletionIfKnown(
+                objectKey = objectKey,
+                purpose = purpose,
+                reason = UploadedFileRetentionReason.DETACHED_POST_ATTACHMENT,
+                purgeAfter = now().plusSeconds(retentionProperties.deletedPostAttachmentSeconds),
+            )
+        }
+    }
+
+    private fun scheduleDeletionForContent(
+        keys: Set<String>,
+        purpose: UploadedFilePurpose,
+    ) {
+        keys.forEach { objectKey ->
+            scheduleDeletionIfKnown(
+                objectKey = objectKey,
+                purpose = purpose,
+                reason = UploadedFileRetentionReason.DELETED_POST_ATTACHMENT,
+                purgeAfter = now().plusSeconds(retentionProperties.deletedPostAttachmentSeconds),
+            )
+        }
+    }
+
+    private fun restorePostAttachmentKeys(
+        postId: Long,
+        keys: Set<String>,
+        purpose: UploadedFilePurpose,
+    ) {
+        keys.forEach { objectKey ->
+            val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey) ?: return@forEach
+            if (uploadedFile.status == UploadedFileStatus.DELETED) return@forEach
+            uploadedFile.attachToPost(postId, purpose)
+            uploadedFileRepository.save(uploadedFile)
+        }
+    }
+
+    private fun scheduleDeletionIfKnown(
+        objectKey: String,
+        purpose: UploadedFilePurpose,
+        reason: UploadedFileRetentionReason,
+        purgeAfter: Instant,
+    ) {
+        if (objectKey.isBlank()) return
+
+        val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey) ?: return
+        uploadedFile.purpose = purpose
+        uploadedFile.scheduleDeletion(reason, purgeAfter)
+        uploadedFileRepository.save(uploadedFile)
+    }
+
+    private fun findOrCreate(objectKey: String): UploadedFile =
+        uploadedFileRepository.findByObjectKey(objectKey)
+            ?: UploadedFile(
+                objectKey = objectKey,
+                bucket = storageProperties.bucket,
+                contentType = "application/octet-stream",
+                fileSize = 0,
+            )
+
+    private fun now(): Instant = Instant.now(clock)
+}

--- a/back/src/main/kotlin/com/back/global/storage/application/ProfileImageRetentionService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/ProfileImageRetentionService.kt
@@ -1,0 +1,147 @@
+package com.back.global.storage.application
+
+import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
+import com.back.boundedContexts.post.config.PostImageStorageProperties
+import com.back.global.exception.application.AppException
+import com.back.global.storage.application.port.output.UploadedFileRepositoryPort
+import com.back.global.storage.domain.UploadedFile
+import com.back.global.storage.domain.UploadedFileOwnerType
+import com.back.global.storage.domain.UploadedFilePurpose
+import com.back.global.storage.domain.UploadedFileRetentionReason
+import com.back.global.storage.domain.UploadedFileStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Clock
+import java.time.Instant
+
+@Service
+class ProfileImageRetentionService(
+    private val uploadedFileRepository: UploadedFileRepositoryPort,
+    private val postImageStoragePort: PostImageStoragePort,
+    private val storageProperties: PostImageStorageProperties,
+    private val retentionProperties: UploadedFileRetentionProperties,
+    private val transactionManager: PlatformTransactionManager,
+    private val clock: Clock,
+) {
+    private val writeTransactionTemplate = TransactionTemplate(transactionManager)
+
+    @Transactional
+    fun syncProfileImage(
+        memberId: Long,
+        previousProfileImgUrl: String?,
+        currentProfileImgUrl: String?,
+    ) {
+        val previousObjectKey = UploadedFileUrlCodec.extractObjectKeyFromImageUrl(previousProfileImgUrl)
+        val currentObjectKey = UploadedFileUrlCodec.extractObjectKeyFromImageUrl(currentProfileImgUrl)
+
+        currentObjectKey?.let { objectKey ->
+            val uploadedFile = findOrCreate(objectKey)
+            uploadedFile.attachToMemberProfile(memberId)
+            uploadedFileRepository.save(uploadedFile)
+        }
+
+        if (previousObjectKey != null && previousObjectKey != currentObjectKey) {
+            scheduleProfileImageDeletionIfKnown(
+                memberId = memberId,
+                objectKey = previousObjectKey,
+                reason = UploadedFileRetentionReason.REPLACED_PROFILE_IMAGE,
+                purgeAfter = now().plusSeconds(retentionProperties.replacedProfileImageSeconds),
+            )
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun listProfileImages(
+        memberId: Long,
+        protectedProfileImgUrls: Collection<String?>,
+    ): List<ProfileImageHistoryDto> {
+        val protectedObjectKeys = protectedProfileImgUrls.extractProfileImageObjectKeys()
+        val profileImages =
+            uploadedFileRepository.findByPurposeAndOwnerTypeAndOwnerIdAndStatusNotOrderByCreatedAtDescIdDesc(
+                purpose = UploadedFilePurpose.PROFILE_IMAGE,
+                ownerType = UploadedFileOwnerType.MEMBER_PROFILE,
+                ownerId = memberId,
+                status = UploadedFileStatus.DELETED,
+            )
+
+        return profileImages.map { uploadedFile ->
+            uploadedFile.toProfileImageHistoryDto(
+                isCurrent = uploadedFile.objectKey in protectedObjectKeys,
+            )
+        }
+    }
+
+    fun deleteProfileImage(
+        memberId: Long,
+        fileId: Long,
+        protectedProfileImgUrls: Collection<String?>,
+    ) {
+        val uploadedFile =
+            uploadedFileRepository.findByIdAndPurposeAndOwnerTypeAndOwnerId(
+                id = fileId,
+                purpose = UploadedFilePurpose.PROFILE_IMAGE,
+                ownerType = UploadedFileOwnerType.MEMBER_PROFILE,
+                ownerId = memberId,
+            )
+                ?: throw AppException("404-1", "프로필 이미지를 찾을 수 없습니다.")
+        if (uploadedFile.objectKey in protectedProfileImgUrls.extractProfileImageObjectKeys()) {
+            throw AppException("400-1", "현재 사용 중인 프로필 이미지는 삭제할 수 없습니다.")
+        }
+
+        postImageStoragePort.deletePostImage(uploadedFile.objectKey)
+        markProfileImageDeleted(uploadedFile)
+    }
+
+    private fun markProfileImageDeleted(uploadedFile: UploadedFile) {
+        writeTransactionTemplate.executeWithoutResult {
+            uploadedFile.markDeleted()
+            uploadedFileRepository.save(uploadedFile)
+        }
+    }
+
+    private fun scheduleProfileImageDeletionIfKnown(
+        memberId: Long,
+        objectKey: String,
+        reason: UploadedFileRetentionReason,
+        purgeAfter: Instant,
+    ) {
+        if (objectKey.isBlank()) return
+
+        val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey) ?: return
+        uploadedFile.purpose = UploadedFilePurpose.PROFILE_IMAGE
+        uploadedFile.ownerType = UploadedFileOwnerType.MEMBER_PROFILE
+        uploadedFile.ownerId = memberId
+        uploadedFile.scheduleDeletion(reason, purgeAfter)
+        uploadedFileRepository.save(uploadedFile)
+    }
+
+    private fun findOrCreate(objectKey: String): UploadedFile =
+        uploadedFileRepository.findByObjectKey(objectKey)
+            ?: UploadedFile(
+                objectKey = objectKey,
+                bucket = storageProperties.bucket,
+                contentType = "application/octet-stream",
+                fileSize = 0,
+            )
+
+    private fun UploadedFile.toProfileImageHistoryDto(isCurrent: Boolean): ProfileImageHistoryDto =
+        ProfileImageHistoryDto(
+            id = id,
+            imageUrl = UploadedFileUrlCodec.buildImageUrl(objectKey),
+            objectKey = objectKey,
+            contentType = contentType,
+            fileSize = fileSize,
+            status = status,
+            isCurrent = isCurrent,
+            createdAt = createdAt,
+            modifiedAt = modifiedAt,
+        )
+
+    private fun Collection<String?>.extractProfileImageObjectKeys(): Set<String> =
+        mapNotNull(UploadedFileUrlCodec::extractObjectKeyFromImageUrl)
+            .toSet()
+
+    private fun now(): Instant = Instant.now(clock)
+}

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFilePurgeService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFilePurgeService.kt
@@ -1,0 +1,140 @@
+package com.back.global.storage.application
+
+import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
+import com.back.global.storage.application.port.output.UploadedFileRepositoryPort
+import com.back.global.storage.domain.UploadedFile
+import com.back.global.storage.domain.UploadedFileStatus
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Clock
+import java.time.Instant
+
+@Service
+class UploadedFilePurgeService(
+    private val uploadedFileRepository: UploadedFileRepositoryPort,
+    private val postImageStoragePort: PostImageStoragePort,
+    private val retentionProperties: UploadedFileRetentionProperties,
+    private val referenceQueryService: UploadedFileReferenceQueryService,
+    private val transactionManager: PlatformTransactionManager,
+    private val clock: Clock,
+) {
+    private val logger = LoggerFactory.getLogger(UploadedFilePurgeService::class.java)
+    private val purgeCandidateStatuses = listOf(UploadedFileStatus.TEMP, UploadedFileStatus.PENDING_DELETE)
+    private val readOnlyTransactionTemplate =
+        TransactionTemplate(transactionManager).apply {
+            propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRED
+            isReadOnly = true
+        }
+    private val writeTransactionTemplate = TransactionTemplate(transactionManager)
+
+    fun purgeExpiredFiles(limit: Int) {
+        val safeLimit = limit.coerceIn(1, 500)
+        val safetyThreshold = retentionProperties.cleanupSafetyThreshold.coerceAtLeast(1)
+        val now = now()
+        val eligibleCount =
+            uploadedFileRepository.countByStatusInAndPurgeAfterLessThanEqual(
+                purgeCandidateStatuses,
+                now,
+            )
+
+        val effectiveLimit =
+            if (eligibleCount > safetyThreshold) {
+                logger.warn(
+                    "Throttling uploaded file purge because eligible candidate count {} exceeds safety threshold {}",
+                    eligibleCount,
+                    safetyThreshold,
+                )
+                minOf(safeLimit, safetyThreshold)
+            } else {
+                safeLimit
+            }
+
+        val candidates = loadPurgeCandidates(now, effectiveLimit)
+        if (candidates.isEmpty()) {
+            logger.debug(
+                "No uploaded files eligible for purge (eligibleCount={}, effectiveLimit={})",
+                eligibleCount,
+                effectiveLimit,
+            )
+            return
+        }
+
+        val referencedObjectKeys = referenceQueryService.findReferencedObjectKeys(candidates)
+        candidates.forEach { uploadedFile ->
+            if (uploadedFile.objectKey in referencedObjectKeys) {
+                restoreActive(uploadedFile.objectKey)
+                return@forEach
+            }
+
+            try {
+                postImageStoragePort.deletePostImage(uploadedFile.objectKey)
+                markDeleted(uploadedFile.objectKey)
+            } catch (exception: Exception) {
+                logger.error("Failed to purge uploaded file: {}", uploadedFile.objectKey, exception)
+            }
+        }
+    }
+
+    fun diagnoseCleanup(sampleSize: Int): UploadedFileCleanupDiagnostics {
+        val now = now()
+        val safeSampleSize = sampleSize.coerceIn(1, 20)
+        val eligibleCandidates =
+            uploadedFileRepository.findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
+                statuses = purgeCandidateStatuses,
+                purgeAfter = now,
+                pageable = PageRequest.of(0, safeSampleSize),
+            )
+
+        val eligibleCount =
+            uploadedFileRepository.countByStatusInAndPurgeAfterLessThanEqual(
+                purgeCandidateStatuses,
+                now,
+            )
+
+        return UploadedFileCleanupDiagnostics(
+            tempCount = uploadedFileRepository.countByStatus(UploadedFileStatus.TEMP),
+            activeCount = uploadedFileRepository.countByStatus(UploadedFileStatus.ACTIVE),
+            pendingDeleteCount = uploadedFileRepository.countByStatus(UploadedFileStatus.PENDING_DELETE),
+            deletedCount = uploadedFileRepository.countByStatus(UploadedFileStatus.DELETED),
+            eligibleForPurgeCount = eligibleCount,
+            cleanupSafetyThreshold = retentionProperties.cleanupSafetyThreshold,
+            blockedBySafetyThreshold = eligibleCount > retentionProperties.cleanupSafetyThreshold,
+            oldestEligiblePurgeAfter = eligibleCandidates.firstOrNull()?.purgeAfter,
+            sampleEligibleObjectKeys = eligibleCandidates.map { it.objectKey },
+        )
+    }
+
+    private fun loadPurgeCandidates(
+        now: Instant,
+        effectiveLimit: Int,
+    ): List<UploadedFile> =
+        readOnlyTransactionTemplate.execute<List<UploadedFile>> {
+            uploadedFileRepository.findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
+                statuses = purgeCandidateStatuses,
+                purgeAfter = now,
+                pageable = PageRequest.of(0, effectiveLimit),
+            )
+        } ?: emptyList()
+
+    private fun restoreActive(objectKey: String) {
+        writeTransactionTemplate.executeWithoutResult {
+            val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey) ?: return@executeWithoutResult
+            uploadedFile.restoreActive()
+            uploadedFileRepository.save(uploadedFile)
+        }
+    }
+
+    private fun markDeleted(objectKey: String) {
+        writeTransactionTemplate.executeWithoutResult {
+            val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey) ?: return@executeWithoutResult
+            uploadedFile.markDeleted()
+            uploadedFileRepository.save(uploadedFile)
+        }
+    }
+
+    private fun now(): Instant = Instant.now(clock)
+}

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileReferenceQueryService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileReferenceQueryService.kt
@@ -1,0 +1,50 @@
+package com.back.global.storage.application
+
+import com.back.boundedContexts.member.application.port.output.MemberAttrRepositoryPort
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_IMG_URL
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.global.storage.domain.UploadedFile
+import com.back.global.storage.domain.UploadedFileOwnerType
+import org.springframework.stereotype.Service
+
+@Service
+class UploadedFileReferenceQueryService(
+    private val postRepository: PostRepositoryPort,
+    private val memberAttrRepository: MemberAttrRepositoryPort,
+) {
+    fun findReferencedObjectKeys(candidates: Collection<UploadedFile>): Set<String> {
+        if (candidates.isEmpty()) return emptySet()
+
+        val referencedKeys = linkedSetOf<String>()
+        candidates.forEach { uploadedFile ->
+            if (isReferencedByKnownOwner(uploadedFile) || isReferencedByFallbackLookup(uploadedFile)) {
+                referencedKeys += uploadedFile.objectKey
+            }
+        }
+        return referencedKeys
+    }
+
+    private fun isReferencedByKnownOwner(uploadedFile: UploadedFile): Boolean {
+        val ownerId = uploadedFile.ownerId ?: return false
+        return when (uploadedFile.ownerType) {
+            UploadedFileOwnerType.POST -> postRepository.existsByIdAndContentContaining(ownerId, uploadedFile.objectKey)
+            UploadedFileOwnerType.MEMBER_PROFILE ->
+                memberAttrRepository.existsBySubjectIdAndNameAndStrValueContaining(
+                    ownerId,
+                    PROFILE_IMG_URL,
+                    uploadedFile.objectKey,
+                )
+            else -> false
+        }
+    }
+
+    private fun isReferencedByFallbackLookup(uploadedFile: UploadedFile): Boolean {
+        val objectKey = uploadedFile.objectKey
+        val imageUrl = UploadedFileUrlCodec.buildImageUrl(objectKey)
+        val fileUrl = UploadedFileUrlCodec.buildFileUrl(objectKey)
+        return postRepository.existsByContentContaining(objectKey) ||
+            postRepository.existsByContentContaining(fileUrl) ||
+            memberAttrRepository.existsByNameAndStrValueContaining(PROFILE_IMG_URL, objectKey) ||
+            memberAttrRepository.existsByNameAndStrValue(PROFILE_IMG_URL, imageUrl)
+    }
+}

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRegistrationService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRegistrationService.kt
@@ -1,0 +1,140 @@
+package com.back.global.storage.application
+
+import com.back.boundedContexts.post.config.PostImageStorageProperties
+import com.back.global.jpa.application.ProdSequenceGuardService
+import com.back.global.storage.application.port.output.UploadedFileRepositoryPort
+import com.back.global.storage.domain.UploadedFile
+import com.back.global.storage.domain.UploadedFilePurpose
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Clock
+import java.time.Instant
+
+@Service
+class UploadedFileRegistrationService(
+    private val uploadedFileRepository: UploadedFileRepositoryPort,
+    private val storageProperties: PostImageStorageProperties,
+    private val retentionProperties: UploadedFileRetentionProperties,
+    private val transactionManager: PlatformTransactionManager,
+    private val clock: Clock,
+    @param:Autowired(required = false)
+    private val prodSequenceGuardService: ProdSequenceGuardService? = null,
+) {
+    private val logger = LoggerFactory.getLogger(UploadedFileRegistrationService::class.java)
+    private val registerRetryLimit = 2
+    private val requiresNewTransactionTemplate =
+        TransactionTemplate(transactionManager).apply {
+            propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
+        }
+
+    fun registerTempUpload(
+        objectKey: String,
+        contentType: String,
+        fileSize: Long,
+        purpose: UploadedFilePurpose,
+    ) {
+        val normalizedContentType = contentType.ifBlank { "application/octet-stream" }
+        val safeFileSize = fileSize.coerceAtLeast(0)
+        val purgeAfter = now().plusSeconds(retentionProperties.tempUploadSeconds)
+
+        var attempt = 1
+        while (true) {
+            try {
+                saveTempUploadInRequiresNewTransaction(
+                    objectKey = objectKey,
+                    normalizedContentType = normalizedContentType,
+                    safeFileSize = safeFileSize,
+                    purpose = purpose,
+                    purgeAfter = purgeAfter,
+                )
+                return
+            } catch (exception: DataIntegrityViolationException) {
+                if (
+                    recoverTempUploadFromExistingObjectKey(
+                        objectKey = objectKey,
+                        normalizedContentType = normalizedContentType,
+                        safeFileSize = safeFileSize,
+                        purpose = purpose,
+                        purgeAfter = purgeAfter,
+                    )
+                ) {
+                    return
+                }
+
+                val repaired = repairSequenceDriftInRequiresNewTransaction(exception)
+                logger.warn(
+                    "uploaded_file_register_conflict objectKey={} attempt={} repaired={}",
+                    objectKey,
+                    attempt,
+                    repaired,
+                )
+                if (!repaired || attempt >= registerRetryLimit) throw exception
+                attempt += 1
+            }
+        }
+    }
+
+    private fun saveTempUploadInRequiresNewTransaction(
+        objectKey: String,
+        normalizedContentType: String,
+        safeFileSize: Long,
+        purpose: UploadedFilePurpose,
+        purgeAfter: Instant,
+    ) {
+        requiresNewTransactionTemplate.executeWithoutResult {
+            val uploadedFile =
+                findOrCreate(objectKey).apply {
+                    bucket = storageProperties.bucket
+                    contentType = normalizedContentType
+                    fileSize = safeFileSize
+                    markTemporary(purpose, purgeAfter)
+                }
+            uploadedFileRepository.save(uploadedFile)
+            uploadedFileRepository.flush()
+        }
+    }
+
+    private fun recoverTempUploadFromExistingObjectKey(
+        objectKey: String,
+        normalizedContentType: String,
+        safeFileSize: Long,
+        purpose: UploadedFilePurpose,
+        purgeAfter: Instant,
+    ): Boolean =
+        requiresNewTransactionTemplate.execute<Boolean> {
+            val existing = uploadedFileRepository.findByObjectKey(objectKey) ?: return@execute false
+            existing.bucket = storageProperties.bucket
+            existing.contentType = normalizedContentType
+            existing.fileSize = safeFileSize
+            existing.markTemporary(purpose, purgeAfter)
+            uploadedFileRepository.save(existing)
+            uploadedFileRepository.flush()
+            true
+        } ?: false
+
+    private fun repairSequenceDriftInRequiresNewTransaction(exception: DataIntegrityViolationException): Boolean =
+        requiresNewTransactionTemplate.execute<Boolean> {
+            val repairedByConstraint = prodSequenceGuardService?.repairIfSequenceDrift(exception) == true
+            if (repairedByConstraint) {
+                return@execute true
+            }
+
+            prodSequenceGuardService?.repairUploadedFileSequence() == true
+        } ?: false
+
+    private fun findOrCreate(objectKey: String): UploadedFile =
+        uploadedFileRepository.findByObjectKey(objectKey)
+            ?: UploadedFile(
+                objectKey = objectKey,
+                bucket = storageProperties.bucket,
+                contentType = "application/octet-stream",
+                fileSize = 0,
+            )
+
+    private fun now(): Instant = Instant.now(clock)
+}

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionClockConfig.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionClockConfig.kt
@@ -1,0 +1,13 @@
+package com.back.global.storage.application
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+@Configuration
+class UploadedFileRetentionClockConfig {
+    @Bean
+    @ConditionalOnMissingBean(Clock::class)
+    fun uploadedFileRetentionClock(): Clock = Clock.systemUTC()
+}

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
@@ -1,28 +1,9 @@
 package com.back.global.storage.application
 
-import com.back.boundedContexts.member.application.port.output.MemberAttrRepositoryPort
-import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_IMG_URL
-import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
-import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
-import com.back.boundedContexts.post.config.PostImageStorageProperties
-import com.back.global.exception.application.AppException
-import com.back.global.jpa.application.ProdSequenceGuardService
-import com.back.global.storage.application.port.output.UploadedFileRepositoryPort
-import com.back.global.storage.domain.UploadedFile
-import com.back.global.storage.domain.UploadedFileOwnerType
 import com.back.global.storage.domain.UploadedFilePurpose
-import com.back.global.storage.domain.UploadedFileRetentionReason
 import com.back.global.storage.domain.UploadedFileStatus
 import com.fasterxml.jackson.annotation.JsonProperty
-import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.dao.DataIntegrityViolationException
-import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
-import org.springframework.transaction.PlatformTransactionManager
-import org.springframework.transaction.TransactionDefinition
-import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionTemplate
 import java.time.Instant
 
 data class UploadedFileCleanupDiagnostics(
@@ -52,460 +33,87 @@ data class ProfileImageHistoryDto(
 
 @Service
 class UploadedFileRetentionService(
-    private val uploadedFileRepository: UploadedFileRepositoryPort,
-    private val postRepository: PostRepositoryPort,
-    private val memberAttrRepository: MemberAttrRepositoryPort,
-    private val postImageStoragePort: PostImageStoragePort,
-    private val storageProperties: PostImageStorageProperties,
-    private val retentionProperties: UploadedFileRetentionProperties,
-    private val transactionManager: PlatformTransactionManager,
-    @param:Autowired(required = false)
-    private val prodSequenceGuardService: ProdSequenceGuardService? = null,
+    private val registrationService: UploadedFileRegistrationService,
+    private val postAttachmentRetentionService: PostAttachmentRetentionService,
+    private val profileImageRetentionService: ProfileImageRetentionService,
+    private val purgeService: UploadedFilePurgeService,
 ) {
-    private val logger = LoggerFactory.getLogger(UploadedFileRetentionService::class.java)
-    private val purgeCandidateStatuses = listOf(UploadedFileStatus.TEMP, UploadedFileStatus.PENDING_DELETE)
-    private val registerRetryLimit = 2
-    private val requiresNewTransactionTemplate =
-        TransactionTemplate(transactionManager).apply {
-            propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
-        }
-
     fun registerTempUpload(
         objectKey: String,
         contentType: String,
         fileSize: Long,
         purpose: UploadedFilePurpose,
     ) {
-        val normalizedContentType = contentType.ifBlank { "application/octet-stream" }
-        val safeFileSize = fileSize.coerceAtLeast(0)
-        val purgeAfter = Instant.now().plusSeconds(retentionProperties.tempUploadSeconds)
-
-        for (attempt in 1..registerRetryLimit) {
-            try {
-                saveTempUploadInRequiresNewTransaction(
-                    objectKey = objectKey,
-                    normalizedContentType = normalizedContentType,
-                    safeFileSize = safeFileSize,
-                    purpose = purpose,
-                    purgeAfter = purgeAfter,
-                )
-                return
-            } catch (exception: DataIntegrityViolationException) {
-                if (
-                    recoverTempUploadFromExistingObjectKey(
-                        objectKey = objectKey,
-                        normalizedContentType = normalizedContentType,
-                        safeFileSize = safeFileSize,
-                        purpose = purpose,
-                        purgeAfter = purgeAfter,
-                    )
-                ) {
-                    return
-                }
-
-                val repaired = repairSequenceDriftInRequiresNewTransaction(exception)
-                logger.warn(
-                    "uploaded_file_register_conflict objectKey={} attempt={} repaired={}",
-                    objectKey,
-                    attempt,
-                    repaired,
-                )
-                if (!repaired || attempt >= registerRetryLimit) throw exception
-            }
-        }
+        registrationService.registerTempUpload(
+            objectKey = objectKey,
+            contentType = contentType,
+            fileSize = fileSize,
+            purpose = purpose,
+        )
     }
 
-    private fun saveTempUploadInRequiresNewTransaction(
-        objectKey: String,
-        normalizedContentType: String,
-        safeFileSize: Long,
-        purpose: UploadedFilePurpose,
-        purgeAfter: Instant,
-    ) {
-        requiresNewTransactionTemplate.executeWithoutResult {
-            val uploadedFile =
-                findOrCreate(objectKey).apply {
-                    bucket = storageProperties.bucket
-                    this.contentType = normalizedContentType
-                    this.fileSize = safeFileSize
-                    markTemporary(purpose, purgeAfter)
-                }
-            uploadedFileRepository.save(uploadedFile)
-            uploadedFileRepository.flush()
-        }
-    }
-
-    private fun recoverTempUploadFromExistingObjectKey(
-        objectKey: String,
-        normalizedContentType: String,
-        safeFileSize: Long,
-        purpose: UploadedFilePurpose,
-        purgeAfter: Instant,
-    ): Boolean =
-        requiresNewTransactionTemplate.execute<Boolean> {
-            val existing = uploadedFileRepository.findByObjectKey(objectKey) ?: return@execute false
-            existing.bucket = storageProperties.bucket
-            existing.contentType = normalizedContentType
-            existing.fileSize = safeFileSize
-            existing.markTemporary(purpose, purgeAfter)
-            uploadedFileRepository.save(existing)
-            uploadedFileRepository.flush()
-            true
-        } ?: false
-
-    private fun repairSequenceDriftInRequiresNewTransaction(exception: DataIntegrityViolationException): Boolean =
-        requiresNewTransactionTemplate.execute<Boolean> {
-            val repairedByConstraint = prodSequenceGuardService?.repairIfSequenceDrift(exception) == true
-            if (repairedByConstraint) {
-                return@execute true
-            }
-
-            // uploaded_file 등록 경로는 제약명 파싱 실패 시에도 전용 시퀀스 보정 fallback을 시도한다.
-            prodSequenceGuardService?.repairUploadedFileSequence() == true
-        } ?: false
-
-    @Transactional
     fun syncPostContent(
         postId: Long,
         previousContent: String?,
         currentContent: String,
     ) {
-        syncPostAttachmentKeys(
+        postAttachmentRetentionService.syncPostContent(
             postId = postId,
-            currentKeys = UploadedFileUrlCodec.extractImageObjectKeysFromContent(currentContent),
-            previousKeys = UploadedFileUrlCodec.extractImageObjectKeysFromContent(previousContent.orEmpty()),
-            purpose = UploadedFilePurpose.POST_IMAGE,
-        )
-        syncPostAttachmentKeys(
-            postId = postId,
-            currentKeys = UploadedFileUrlCodec.extractFileObjectKeysFromContent(currentContent),
-            previousKeys = UploadedFileUrlCodec.extractFileObjectKeysFromContent(previousContent.orEmpty()),
-            purpose = UploadedFilePurpose.POST_FILE,
+            previousContent = previousContent,
+            currentContent = currentContent,
         )
     }
 
-    @Transactional
     fun scheduleDeletedPostAttachments(content: String) {
-        scheduleDeletionForContent(
-            purpose = UploadedFilePurpose.POST_IMAGE,
-            keys = UploadedFileUrlCodec.extractImageObjectKeysFromContent(content),
-        )
-        scheduleDeletionForContent(
-            purpose = UploadedFilePurpose.POST_FILE,
-            keys = UploadedFileUrlCodec.extractFileObjectKeysFromContent(content),
-        )
+        postAttachmentRetentionService.scheduleDeletedPostAttachments(content)
     }
 
-    @Transactional
     fun restoreDeletedPostAttachments(
         postId: Long,
         content: String,
     ) {
-        restorePostAttachmentKeys(
+        postAttachmentRetentionService.restoreDeletedPostAttachments(
             postId = postId,
-            keys = UploadedFileUrlCodec.extractImageObjectKeysFromContent(content),
-            purpose = UploadedFilePurpose.POST_IMAGE,
-        )
-        restorePostAttachmentKeys(
-            postId = postId,
-            keys = UploadedFileUrlCodec.extractFileObjectKeysFromContent(content),
-            purpose = UploadedFilePurpose.POST_FILE,
+            content = content,
         )
     }
 
-    private fun syncPostAttachmentKeys(
-        postId: Long,
-        currentKeys: Set<String>,
-        previousKeys: Set<String>,
-        purpose: UploadedFilePurpose,
-    ) {
-        currentKeys.forEach { objectKey ->
-            val uploadedFile = findOrCreate(objectKey)
-            uploadedFile.attachToPost(postId, purpose)
-            uploadedFileRepository.save(uploadedFile)
-        }
-
-        (previousKeys - currentKeys).forEach { objectKey ->
-            scheduleDeletionIfKnown(
-                objectKey = objectKey,
-                purpose = purpose,
-                reason = UploadedFileRetentionReason.DETACHED_POST_ATTACHMENT,
-                purgeAfter = Instant.now().plusSeconds(retentionProperties.deletedPostAttachmentSeconds),
-            )
-        }
-    }
-
-    private fun scheduleDeletionForContent(
-        keys: Set<String>,
-        purpose: UploadedFilePurpose,
-    ) {
-        keys.forEach { objectKey ->
-            scheduleDeletionIfKnown(
-                objectKey = objectKey,
-                purpose = purpose,
-                reason = UploadedFileRetentionReason.DELETED_POST_ATTACHMENT,
-                purgeAfter = Instant.now().plusSeconds(retentionProperties.deletedPostAttachmentSeconds),
-            )
-        }
-    }
-
-    private fun restorePostAttachmentKeys(
-        postId: Long,
-        keys: Set<String>,
-        purpose: UploadedFilePurpose,
-    ) {
-        keys.forEach { objectKey ->
-            val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey) ?: return@forEach
-            if (uploadedFile.status == UploadedFileStatus.DELETED) return@forEach
-            uploadedFile.attachToPost(postId, purpose)
-            uploadedFileRepository.save(uploadedFile)
-        }
-    }
-
-    @Transactional
     fun syncProfileImage(
         memberId: Long,
         previousProfileImgUrl: String?,
         currentProfileImgUrl: String?,
     ) {
-        val previousObjectKey = UploadedFileUrlCodec.extractObjectKeyFromImageUrl(previousProfileImgUrl)
-        val currentObjectKey = UploadedFileUrlCodec.extractObjectKeyFromImageUrl(currentProfileImgUrl)
-
-        currentObjectKey?.let { objectKey ->
-            val uploadedFile = findOrCreate(objectKey)
-            uploadedFile.attachToMemberProfile(memberId)
-            uploadedFileRepository.save(uploadedFile)
-        }
-
-        if (previousObjectKey != null && previousObjectKey != currentObjectKey) {
-            scheduleProfileImageDeletionIfKnown(
-                memberId = memberId,
-                objectKey = previousObjectKey,
-                reason = UploadedFileRetentionReason.REPLACED_PROFILE_IMAGE,
-                purgeAfter = Instant.now().plusSeconds(retentionProperties.replacedProfileImageSeconds),
-            )
-        }
+        profileImageRetentionService.syncProfileImage(
+            memberId = memberId,
+            previousProfileImgUrl = previousProfileImgUrl,
+            currentProfileImgUrl = currentProfileImgUrl,
+        )
     }
 
-    @Transactional(readOnly = true)
     fun listProfileImages(
         memberId: Long,
         protectedProfileImgUrls: Collection<String?>,
-    ): List<ProfileImageHistoryDto> {
-        val protectedObjectKeys = protectedProfileImgUrls.extractProfileImageObjectKeys()
-        val profileImages =
-            uploadedFileRepository.findByPurposeAndOwnerTypeAndOwnerIdAndStatusNotOrderByCreatedAtDescIdDesc(
-                purpose = UploadedFilePurpose.PROFILE_IMAGE,
-                ownerType = UploadedFileOwnerType.MEMBER_PROFILE,
-                ownerId = memberId,
-                status = UploadedFileStatus.DELETED,
-            )
+    ): List<ProfileImageHistoryDto> =
+        profileImageRetentionService.listProfileImages(
+            memberId = memberId,
+            protectedProfileImgUrls = protectedProfileImgUrls,
+        )
 
-        return profileImages.map { uploadedFile ->
-            uploadedFile.toProfileImageHistoryDto(
-                isCurrent = uploadedFile.objectKey in protectedObjectKeys,
-            )
-        }
-    }
-
-    @Transactional
     fun deleteProfileImage(
         memberId: Long,
         fileId: Long,
         protectedProfileImgUrls: Collection<String?>,
     ) {
-        val uploadedFile =
-            uploadedFileRepository.findByIdAndPurposeAndOwnerTypeAndOwnerId(
-                id = fileId,
-                purpose = UploadedFilePurpose.PROFILE_IMAGE,
-                ownerType = UploadedFileOwnerType.MEMBER_PROFILE,
-                ownerId = memberId,
-            )
-                ?: throw AppException("404-1", "프로필 이미지를 찾을 수 없습니다.")
-        if (uploadedFile.objectKey in protectedProfileImgUrls.extractProfileImageObjectKeys()) {
-            throw AppException("400-1", "현재 사용 중인 프로필 이미지는 삭제할 수 없습니다.")
-        }
-
-        postImageStoragePort.deletePostImage(uploadedFile.objectKey)
-        uploadedFile.markDeleted()
-        uploadedFileRepository.save(uploadedFile)
+        profileImageRetentionService.deleteProfileImage(
+            memberId = memberId,
+            fileId = fileId,
+            protectedProfileImgUrls = protectedProfileImgUrls,
+        )
     }
 
-    @Transactional
     fun purgeExpiredFiles(limit: Int) {
-        val safeLimit = limit.coerceIn(1, 500)
-        val safetyThreshold = retentionProperties.cleanupSafetyThreshold.coerceAtLeast(1)
-        val now = Instant.now()
-        val eligibleCount =
-            uploadedFileRepository.countByStatusInAndPurgeAfterLessThanEqual(
-                purgeCandidateStatuses,
-                now,
-            )
-
-        val effectiveLimit =
-            if (eligibleCount > safetyThreshold) {
-                logger.warn(
-                    "Throttling uploaded file purge because eligible candidate count {} exceeds safety threshold {}",
-                    eligibleCount,
-                    safetyThreshold,
-                )
-                minOf(safeLimit, safetyThreshold)
-            } else {
-                safeLimit
-            }
-
-        if (effectiveLimit <= 0) {
-            logger.error(
-                "Skipping uploaded file purge because effective limit is non-positive (safeLimit={}, threshold={})",
-                safeLimit,
-                safetyThreshold,
-            )
-            return
-        }
-
-        val candidates =
-            uploadedFileRepository.findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
-                statuses = purgeCandidateStatuses,
-                purgeAfter = now,
-                pageable = PageRequest.of(0, effectiveLimit),
-            )
-
-        if (candidates.isEmpty()) {
-            logger.debug(
-                "No uploaded files eligible for purge (eligibleCount={}, effectiveLimit={})",
-                eligibleCount,
-                effectiveLimit,
-            )
-            return
-        }
-
-        candidates.forEach { uploadedFile ->
-            if (isStillReferenced(uploadedFile)) {
-                uploadedFile.restoreActive()
-                uploadedFileRepository.save(uploadedFile)
-                return@forEach
-            }
-
-            try {
-                postImageStoragePort.deletePostImage(uploadedFile.objectKey)
-                uploadedFile.markDeleted()
-                uploadedFileRepository.save(uploadedFile)
-            } catch (exception: Exception) {
-                logger.error("Failed to purge uploaded file: {}", uploadedFile.objectKey, exception)
-            }
-        }
+        purgeService.purgeExpiredFiles(limit)
     }
 
-    @Transactional(readOnly = true)
-    fun diagnoseCleanup(sampleSize: Int = 5): UploadedFileCleanupDiagnostics {
-        val now = Instant.now()
-        val safeSampleSize = sampleSize.coerceIn(1, 20)
-        val eligibleCandidates =
-            uploadedFileRepository.findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
-                statuses = purgeCandidateStatuses,
-                purgeAfter = now,
-                pageable = PageRequest.of(0, safeSampleSize),
-            )
-
-        val eligibleCount =
-            uploadedFileRepository.countByStatusInAndPurgeAfterLessThanEqual(
-                purgeCandidateStatuses,
-                now,
-            )
-
-        return UploadedFileCleanupDiagnostics(
-            tempCount = uploadedFileRepository.countByStatus(UploadedFileStatus.TEMP),
-            activeCount = uploadedFileRepository.countByStatus(UploadedFileStatus.ACTIVE),
-            pendingDeleteCount = uploadedFileRepository.countByStatus(UploadedFileStatus.PENDING_DELETE),
-            deletedCount = uploadedFileRepository.countByStatus(UploadedFileStatus.DELETED),
-            eligibleForPurgeCount = eligibleCount,
-            cleanupSafetyThreshold = retentionProperties.cleanupSafetyThreshold,
-            // 임계치 초과 시 전체 중단 대신 배치 제한으로 완만히 정리한다.
-            blockedBySafetyThreshold = eligibleCount > retentionProperties.cleanupSafetyThreshold,
-            oldestEligiblePurgeAfter = eligibleCandidates.firstOrNull()?.purgeAfter,
-            sampleEligibleObjectKeys = eligibleCandidates.map { it.objectKey },
-        )
-    }
-
-    private fun scheduleDeletionIfKnown(
-        objectKey: String,
-        purpose: UploadedFilePurpose,
-        reason: UploadedFileRetentionReason,
-        purgeAfter: Instant,
-    ) {
-        if (objectKey.isBlank()) return
-
-        // legacy 본문에는 업로드 추적 테이블에 없는 이미지 URL이 섞여 있을 수 있다.
-        // 삭제 예약 단계에서는 미등록 키를 새로 생성하지 않고, 추적 중인 파일만 상태 전환한다.
-        val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey) ?: return
-        uploadedFile.purpose = purpose
-        uploadedFile.scheduleDeletion(reason, purgeAfter)
-        uploadedFileRepository.save(uploadedFile)
-    }
-
-    private fun scheduleProfileImageDeletionIfKnown(
-        memberId: Long,
-        objectKey: String,
-        reason: UploadedFileRetentionReason,
-        purgeAfter: Instant,
-    ) {
-        if (objectKey.isBlank()) return
-
-        val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey) ?: return
-        uploadedFile.purpose = UploadedFilePurpose.PROFILE_IMAGE
-        uploadedFile.ownerType = UploadedFileOwnerType.MEMBER_PROFILE
-        uploadedFile.ownerId = memberId
-        uploadedFile.scheduleDeletion(reason, purgeAfter)
-        uploadedFileRepository.save(uploadedFile)
-    }
-
-    private fun findOrCreate(objectKey: String): UploadedFile =
-        uploadedFileRepository.findByObjectKey(objectKey)
-            ?: UploadedFile(
-                objectKey = objectKey,
-                bucket = storageProperties.bucket,
-                contentType = "application/octet-stream",
-                fileSize = 0,
-            )
-
-    private fun UploadedFile.toProfileImageHistoryDto(isCurrent: Boolean): ProfileImageHistoryDto =
-        ProfileImageHistoryDto(
-            id = id,
-            imageUrl = UploadedFileUrlCodec.buildImageUrl(objectKey),
-            objectKey = objectKey,
-            contentType = contentType,
-            fileSize = fileSize,
-            status = status,
-            isCurrent = isCurrent,
-            createdAt = createdAt,
-            modifiedAt = modifiedAt,
-        )
-
-    private fun Collection<String?>.extractProfileImageObjectKeys(): Set<String> =
-        mapNotNull(UploadedFileUrlCodec::extractObjectKeyFromImageUrl)
-            .toSet()
-
-    private fun isStillReferenced(uploadedFile: UploadedFile): Boolean {
-        val objectKey = uploadedFile.objectKey
-        val ownerId = uploadedFile.ownerId
-
-        if (uploadedFile.ownerType == UploadedFileOwnerType.POST && ownerId != null) {
-            if (postRepository.existsByIdAndContentContaining(ownerId, objectKey)) {
-                return true
-            }
-        }
-
-        if (uploadedFile.ownerType == UploadedFileOwnerType.MEMBER_PROFILE && ownerId != null) {
-            if (memberAttrRepository.existsBySubjectIdAndNameAndStrValueContaining(ownerId, PROFILE_IMG_URL, objectKey)) {
-                return true
-            }
-        }
-
-        val imageUrl = UploadedFileUrlCodec.buildImageUrl(objectKey)
-        val fileUrl = UploadedFileUrlCodec.buildFileUrl(objectKey)
-        return postRepository.existsByContentContaining(objectKey) ||
-            postRepository.existsByContentContaining(fileUrl) ||
-            memberAttrRepository.existsByNameAndStrValueContaining(PROFILE_IMG_URL, objectKey) ||
-            memberAttrRepository.existsByNameAndStrValue(PROFILE_IMG_URL, imageUrl)
-    }
+    fun diagnoseCleanup(sampleSize: Int = 5): UploadedFileCleanupDiagnostics = purgeService.diagnoseCleanup(sampleSize)
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionServiceTest.kt
@@ -62,6 +62,20 @@ class CloudVideoUploadSessionServiceTest {
         )
 
     @Test
+    @DisplayName("기본 설정 생성자는 빈 만료 세션 정리를 수행할 수 있다")
+    fun defaultConstructorArguments() {
+        val defaultService =
+            CloudVideoUploadSessionService(
+                sessionRepository = FakeVideoUploadSessionRepository(),
+                partRepository = FakeVideoUploadPartRepository(),
+                cloudFileRepository = FakeCloudFileRepository(),
+                cloudStoragePort = FakeCloudStoragePort(),
+            )
+
+        assertThat(defaultService.purgeExpiredSessions(batchSize = 1)).isZero()
+    }
+
+    @Test
     @DisplayName("세션 생성 시 5GB 이하 동영상 metadata와 S3 multipart upload id를 저장한다")
     fun `세션 생성은 동영상 metadata와 multipart upload id를 저장한다`() {
         val nfcName = "대용량_소개영상.mp4"

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
@@ -21,7 +21,9 @@ import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.SimpleTransactionStatus
+import java.time.Clock
 import java.time.Instant
+import java.time.ZoneOffset
 
 class UploadedFileRetentionServiceConflictRecoveryTest {
     private val postRepository = mock(PostRepositoryPort::class.java)
@@ -29,6 +31,7 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
     private val postImageStoragePort = mock(PostImageStoragePort::class.java)
     private val prodSequenceGuardService = mock(ProdSequenceGuardService::class.java)
     private val transactionManager = NoopTransactionManager()
+    private val clock = Clock.fixed(Instant.parse("2026-06-19T00:00:00Z"), ZoneOffset.UTC)
 
     @Test
     fun `registerTempUpload은 sequence drift 충돌 시 같은 요청에서 보정 후 재시도한다`() {
@@ -97,17 +100,53 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
         verify(prodSequenceGuardService).repairUploadedFileSequence()
     }
 
-    private fun newService(repository: UploadedFileRepositoryPort): UploadedFileRetentionService =
-        UploadedFileRetentionService(
-            uploadedFileRepository = repository,
-            postRepository = postRepository,
-            memberAttrRepository = memberAttrRepository,
-            postImageStoragePort = postImageStoragePort,
-            storageProperties = PostImageStorageProperties(),
-            retentionProperties = UploadedFileRetentionProperties(),
-            transactionManager = transactionManager,
-            prodSequenceGuardService = prodSequenceGuardService,
+    private fun newService(repository: UploadedFileRepositoryPort): UploadedFileRetentionService {
+        val registrationService =
+            UploadedFileRegistrationService(
+                uploadedFileRepository = repository,
+                storageProperties = PostImageStorageProperties(),
+                retentionProperties = UploadedFileRetentionProperties(),
+                transactionManager = transactionManager,
+                clock = clock,
+                prodSequenceGuardService = prodSequenceGuardService,
+            )
+        val postAttachmentRetentionService =
+            PostAttachmentRetentionService(
+                uploadedFileRepository = repository,
+                storageProperties = PostImageStorageProperties(),
+                retentionProperties = UploadedFileRetentionProperties(),
+                clock = clock,
+            )
+        val profileImageRetentionService =
+            ProfileImageRetentionService(
+                uploadedFileRepository = repository,
+                postImageStoragePort = postImageStoragePort,
+                storageProperties = PostImageStorageProperties(),
+                retentionProperties = UploadedFileRetentionProperties(),
+                transactionManager = transactionManager,
+                clock = clock,
+            )
+        val referenceQueryService =
+            UploadedFileReferenceQueryService(
+                postRepository = postRepository,
+                memberAttrRepository = memberAttrRepository,
+            )
+        val purgeService =
+            UploadedFilePurgeService(
+                uploadedFileRepository = repository,
+                postImageStoragePort = postImageStoragePort,
+                retentionProperties = UploadedFileRetentionProperties(),
+                referenceQueryService = referenceQueryService,
+                transactionManager = transactionManager,
+                clock = clock,
+            )
+        return UploadedFileRetentionService(
+            registrationService = registrationService,
+            postAttachmentRetentionService = postAttachmentRetentionService,
+            profileImageRetentionService = profileImageRetentionService,
+            purgeService = purgeService,
         )
+    }
 
     private class SequenceDriftRecoveringRepository(
         private val firstConflict: DataIntegrityViolationException,

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceTest.kt
@@ -1,7 +1,9 @@
 package com.back.global.storage.application
 
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_IMG_URL
 import com.back.global.app.AppConfig
 import com.back.global.storage.adapter.persistence.UploadedFileRepository
+import com.back.global.storage.domain.UploadedFile
 import com.back.global.storage.domain.UploadedFileOwnerType
 import com.back.global.storage.domain.UploadedFilePurpose
 import com.back.global.storage.domain.UploadedFileRetentionReason
@@ -12,9 +14,14 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
+import org.mockito.BDDMockito.willThrow
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.Duration
+import java.time.Clock
 import java.time.Instant
 
 @org.junit.jupiter.api.DisplayName("UploadedFileRetentionService 테스트")
@@ -24,6 +31,18 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
 
     @Autowired
     private lateinit var uploadedFileRepository: UploadedFileRepository
+
+    @Autowired
+    private lateinit var clock: Clock
+
+    @Autowired
+    private lateinit var retentionProperties: UploadedFileRetentionProperties
+
+    @Autowired
+    private lateinit var uploadedFileReferenceQueryService: UploadedFileReferenceQueryService
+
+    @Autowired
+    private lateinit var uploadedFilePurgeService: UploadedFilePurgeService
 
     @Test
     fun `업로드 직후 파일은 1일 보존 임시 파일로 등록된다`() {
@@ -42,10 +61,8 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
         assertThat(uploadedFile.retentionReason).isEqualTo(UploadedFileRetentionReason.TEMP_UPLOAD)
         assertThat(uploadedFile.purpose).isEqualTo(UploadedFilePurpose.POST_IMAGE)
         assertThat(uploadedFile.fileSize).isEqualTo(2048)
-        assertThat(Duration.between(Instant.now(), uploadedFile.purgeAfter)).isBetween(
-            Duration.ofHours(23),
-            Duration.ofHours(25),
-        )
+        assertThat(uploadedFile.purgeAfter)
+            .isEqualTo(Instant.now(clock).plusSeconds(retentionProperties.tempUploadSeconds))
     }
 
     @Test
@@ -97,10 +114,8 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
         assertThat(oldFile.status).isEqualTo(UploadedFileStatus.PENDING_DELETE)
         assertThat(oldFile.retentionReason).isEqualTo(UploadedFileRetentionReason.REPLACED_PROFILE_IMAGE)
         assertThat(oldFile.purpose).isEqualTo(UploadedFilePurpose.PROFILE_IMAGE)
-        assertThat(Duration.between(Instant.now(), oldFile.purgeAfter)).isBetween(
-            Duration.ofDays(2),
-            Duration.ofDays(4),
-        )
+        assertThat(oldFile.purgeAfter)
+            .isEqualTo(Instant.now(clock).plusSeconds(retentionProperties.replacedProfileImageSeconds))
     }
 
     @Test
@@ -142,6 +157,17 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
         assertThatThrownBy {
             uploadedFileRetentionService.deleteProfileImage(7, newFile.id, protectedProfileImgUrls = listOf(newUrl))
         }.hasMessageContaining("현재 사용 중인 프로필 이미지는 삭제할 수 없습니다")
+    }
+
+    @Test
+    fun `존재하지 않는 프로필 이미지는 삭제할 수 없다`() {
+        assertThatThrownBy {
+            uploadedFileRetentionService.deleteProfileImage(
+                memberId = 7,
+                fileId = 9_999,
+                protectedProfileImgUrls = emptyList(),
+            )
+        }.hasMessageContaining("프로필 이미지를 찾을 수 없습니다")
     }
 
     @Test
@@ -193,10 +219,52 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
 
         assertThat(removedFile.status).isEqualTo(UploadedFileStatus.PENDING_DELETE)
         assertThat(removedFile.retentionReason).isEqualTo(UploadedFileRetentionReason.DETACHED_POST_ATTACHMENT)
-        assertThat(Duration.between(Instant.now(), removedFile.purgeAfter)).isBetween(
-            Duration.ofDays(13),
-            Duration.ofDays(15),
+        assertThat(removedFile.purgeAfter)
+            .isEqualTo(Instant.now(clock).plusSeconds(retentionProperties.deletedPostAttachmentSeconds))
+    }
+
+    @Test
+    fun `미등록 게시글 첨부파일 동기화는 추적 row를 생성하고 활성화한다`() {
+        val imageKey = "posts/2026/03/new-image.png"
+        val fileKey = "posts/2026/03/new-file.pdf"
+        val currentContent =
+            """
+            ![](${UploadedFileUrlCodec.buildImageUrl(imageKey)})
+            [file](${UploadedFileUrlCodec.buildFileUrl(fileKey)})
+            """.trimIndent()
+
+        uploadedFileRetentionService.syncPostContent(
+            postId = 41,
+            previousContent = null,
+            currentContent = currentContent,
         )
+
+        val imageFile = uploadedFileRepository.findByObjectKey(imageKey)!!
+        val postFile = uploadedFileRepository.findByObjectKey(fileKey)!!
+        assertThat(imageFile.status).isEqualTo(UploadedFileStatus.ACTIVE)
+        assertThat(imageFile.purpose).isEqualTo(UploadedFilePurpose.POST_IMAGE)
+        assertThat(imageFile.ownerId).isEqualTo(41)
+        assertThat(postFile.status).isEqualTo(UploadedFileStatus.ACTIVE)
+        assertThat(postFile.purpose).isEqualTo(UploadedFilePurpose.POST_FILE)
+        assertThat(postFile.ownerId).isEqualTo(41)
+    }
+
+    @Test
+    fun `미등록 프로필 이미지 동기화는 추적 row를 생성하고 활성화한다`() {
+        val profileKey = "posts/2026/03/new-profile.png"
+        val profileUrl = UploadedFileUrlCodec.buildImageUrl(profileKey)
+
+        uploadedFileRetentionService.syncProfileImage(
+            memberId = 9,
+            previousProfileImgUrl = null,
+            currentProfileImgUrl = profileUrl,
+        )
+
+        val profileFile = uploadedFileRepository.findByObjectKey(profileKey)!!
+        assertThat(profileFile.status).isEqualTo(UploadedFileStatus.ACTIVE)
+        assertThat(profileFile.purpose).isEqualTo(UploadedFilePurpose.PROFILE_IMAGE)
+        assertThat(profileFile.ownerType).isEqualTo(UploadedFileOwnerType.MEMBER_PROFILE)
+        assertThat(profileFile.ownerId).isEqualTo(9)
     }
 
     @Test
@@ -235,14 +303,131 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
         )
 
         val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey)!!
-        uploadedFile.purgeAfter = Instant.now().minusSeconds(60)
+        uploadedFile.purgeAfter = Instant.now(clock).minusSeconds(60)
         uploadedFileRepository.save(uploadedFile)
 
-        val diagnostics = uploadedFileRetentionService.diagnoseCleanup()
+        val diagnostics = uploadedFileRetentionService.diagnoseCleanup(sampleSize = 5)
+        val directDiagnostics = uploadedFilePurgeService.diagnoseCleanup(sampleSize = 5)
 
         assertThat(diagnostics.tempCount).isGreaterThanOrEqualTo(1)
         assertThat(diagnostics.eligibleForPurgeCount).isGreaterThanOrEqualTo(1)
         assertThat(diagnostics.sampleEligibleObjectKeys).contains(objectKey)
+        assertThat(directDiagnostics.sampleEligibleObjectKeys).contains(objectKey)
+    }
+
+    @Test
+    fun `reference query는 빈 후보 목록을 그대로 빈 결과로 반환한다`() {
+        assertThat(uploadedFileReferenceQueryService.findReferencedObjectKeys(emptyList())).isEmpty()
+    }
+
+    @Test
+    fun `reference query는 알 수 없는 owner type 후보를 fallback lookup으로 확인한다`() {
+        val uploadedFile =
+            UploadedFile(
+                objectKey = "posts/2026/03/reference-unknown-owner.png",
+                bucket = "post-img",
+                contentType = "image/png",
+                fileSize = 100,
+            ).apply {
+                ownerId = 101
+            }
+
+        val referencedObjectKeys = uploadedFileReferenceQueryService.findReferencedObjectKeys(listOf(uploadedFile))
+
+        assertThat(referencedObjectKeys).isEmpty()
+    }
+
+    @Test
+    fun `purge는 참조 없는 만료 파일을 storage 삭제 후 deleted로 전환한다`() {
+        val objectKey = "posts/2026/03/purge-delete.png"
+        uploadedFileRetentionService.registerTempUpload(objectKey, "image/png", 100, UploadedFilePurpose.POST_IMAGE)
+        expireUpload(objectKey)
+
+        uploadedFileRetentionService.purgeExpiredFiles(limit = 10)
+
+        assertThat(uploadedFileRepository.findByObjectKey(objectKey)!!.status).isEqualTo(UploadedFileStatus.DELETED)
+        then(postImageStoragePort).should().deletePostImage(objectKey)
+    }
+
+    @Test
+    fun `purge는 게시글에서 다시 참조 중인 만료 파일을 active로 복구한다`() {
+        val objectKey = "posts/2026/03/purge-post-reference.png"
+        val content = "![](${UploadedFileUrlCodec.buildImageUrl(objectKey)})"
+        uploadedFileRetentionService.registerTempUpload(objectKey, "image/png", 100, UploadedFilePurpose.POST_IMAGE)
+        uploadedFileRetentionService.syncPostContent(postId = 44, previousContent = null, currentContent = content)
+        val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey)!!
+        uploadedFile.scheduleDeletion(
+            UploadedFileRetentionReason.DETACHED_POST_ATTACHMENT,
+            Instant.now(clock).minusSeconds(60),
+        )
+        uploadedFileRepository.save(uploadedFile)
+        given(postRepository.existsByIdAndContentContaining(44, objectKey)).willReturn(true)
+
+        uploadedFileRetentionService.purgeExpiredFiles(limit = 10)
+
+        assertThat(uploadedFileRepository.findByObjectKey(objectKey)!!.status).isEqualTo(UploadedFileStatus.ACTIVE)
+        then(postImageStoragePort).should(never()).deletePostImage(objectKey)
+    }
+
+    @Test
+    fun `purge는 프로필에서 다시 참조 중인 만료 파일을 active로 복구한다`() {
+        val objectKey = "posts/2026/03/purge-profile-reference.png"
+        val profileUrl = UploadedFileUrlCodec.buildImageUrl(objectKey)
+        uploadedFileRetentionService.registerTempUpload(objectKey, "image/png", 100, UploadedFilePurpose.PROFILE_IMAGE)
+        uploadedFileRetentionService.syncProfileImage(77, previousProfileImgUrl = null, currentProfileImgUrl = profileUrl)
+        val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey)!!
+        uploadedFile.scheduleDeletion(
+            UploadedFileRetentionReason.REPLACED_PROFILE_IMAGE,
+            Instant.now(clock).minusSeconds(60),
+        )
+        uploadedFileRepository.save(uploadedFile)
+        given(
+            memberAttrRepository.existsBySubjectIdAndNameAndStrValueContaining(
+                77,
+                PROFILE_IMG_URL,
+                objectKey,
+            ),
+        ).willReturn(true)
+
+        uploadedFileRetentionService.purgeExpiredFiles(limit = 10)
+
+        assertThat(uploadedFileRepository.findByObjectKey(objectKey)!!.status).isEqualTo(UploadedFileStatus.ACTIVE)
+        then(postImageStoragePort).should(never()).deletePostImage(objectKey)
+    }
+
+    @Test
+    fun `purge는 storage 삭제 실패 시 DB 삭제 전환을 남기지 않는다`() {
+        val objectKey = "posts/2026/03/purge-storage-fail.png"
+        uploadedFileRetentionService.registerTempUpload(objectKey, "image/png", 100, UploadedFilePurpose.POST_IMAGE)
+        expireUpload(objectKey)
+        willThrow(RuntimeException("storage down"))
+            .given(postImageStoragePort)
+            .deletePostImage(objectKey)
+
+        uploadedFileRetentionService.purgeExpiredFiles(limit = 10)
+
+        assertThat(uploadedFileRepository.findByObjectKey(objectKey)!!.status).isEqualTo(UploadedFileStatus.TEMP)
+    }
+
+    @Test
+    fun `purge는 safety threshold 초과 시 threshold 범위까지만 처리한다`() {
+        val keys =
+            (1..26).map { index ->
+                "posts/2026/03/purge-threshold-$index.png"
+            }
+        keys.forEach { objectKey ->
+            uploadedFileRetentionService.registerTempUpload(objectKey, "image/png", 100, UploadedFilePurpose.POST_IMAGE)
+            expireUpload(objectKey)
+        }
+
+        uploadedFileRetentionService.purgeExpiredFiles(limit = 500)
+
+        val deletedCount =
+            keys.count { objectKey ->
+                uploadedFileRepository.findByObjectKey(objectKey)!!.status == UploadedFileStatus.DELETED
+            }
+        assertThat(deletedCount).isEqualTo(retentionProperties.cleanupSafetyThreshold)
+        then(postImageStoragePort).should(times(retentionProperties.cleanupSafetyThreshold)).deletePostImage(anyString())
     }
 
     @Test
@@ -283,6 +468,12 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
         assertThat(restoredFile.ownerId).isEqualTo(33)
         assertThat(restoredFile.retentionReason).isNull()
         assertThat(restoredFile.purgeAfter).isNull()
+    }
+
+    private fun expireUpload(objectKey: String) {
+        val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey)!!
+        uploadedFile.purgeAfter = Instant.now(clock).minusSeconds(60)
+        uploadedFileRepository.save(uploadedFile)
     }
 
     companion object {

--- a/back/src/test/kotlin/com/back/perf/PerformanceSanityTest.kt
+++ b/back/src/test/kotlin/com/back/perf/PerformanceSanityTest.kt
@@ -127,7 +127,7 @@ class PerformanceSanityTest : BasePerformanceIntegrationTest() {
                 status { isOk() }
             }
 
-        assertQueryCountWithin("auth-login", 14)
+        assertQueryCountWithin("auth-login", 15)
     }
 
     private fun assertQueryCountWithin(

--- a/back/src/test/kotlin/com/back/support/BaseUploadedFileRetentionServiceIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseUploadedFileRetentionServiceIntegrationTest.kt
@@ -6,6 +6,11 @@ import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
 import com.back.boundedContexts.post.config.PostImageStorageProperties
 import com.back.global.app.AppConfig
 import com.back.global.jpa.config.JpaConfig
+import com.back.global.storage.application.PostAttachmentRetentionService
+import com.back.global.storage.application.ProfileImageRetentionService
+import com.back.global.storage.application.UploadedFilePurgeService
+import com.back.global.storage.application.UploadedFileReferenceQueryService
+import com.back.global.storage.application.UploadedFileRegistrationService
 import com.back.global.storage.application.UploadedFileRetentionProperties
 import com.back.global.storage.application.UploadedFileRetentionService
 import org.junit.jupiter.api.BeforeAll
@@ -15,11 +20,19 @@ import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(
     UploadedFileRetentionService::class,
+    UploadedFileRegistrationService::class,
+    PostAttachmentRetentionService::class,
+    ProfileImageRetentionService::class,
+    UploadedFilePurgeService::class,
+    UploadedFileReferenceQueryService::class,
     JpaConfig::class,
     BaseUploadedFileRetentionServiceIntegrationTest.TestConfig::class,
 )
@@ -54,5 +67,8 @@ abstract class BaseUploadedFileRetentionServiceIntegrationTest : BaseIntegration
 
         @Bean
         fun uploadedFileRetentionProperties(): UploadedFileRetentionProperties = UploadedFileRetentionProperties()
+
+        @Bean
+        fun uploadedFileRetentionClock(): Clock = Clock.fixed(Instant.parse("2026-06-19T00:00:00Z"), ZoneOffset.UTC)
     }
 }


### PR DESCRIPTION
## 관련 이슈

close #884

## 작업 배경

- `UploadedFileRetentionService`가 임시 업로드 등록, 게시글 첨부 attach/detach, 프로필 이미지 이력/삭제, purge/reference 검사, sequence drift 복구를 한 클래스에서 직접 처리하고 있었다.
- 이 구조에서는 storage delete와 DB 상태 전환이 한 흐름에 섞이고, purge 후보별 reference 판단 책임도 retention facade에 묶여 변경 영향 범위가 커졌다.

## 작업 내용

- 기존 `UploadedFileRetentionService` public method 계약은 유지하고 내부 구현을 facade 위임 구조로 전환했다.
- 등록 책임을 `UploadedFileRegistrationService`로 분리하고 sequence drift 복구와 REQUIRES_NEW 등록 재시도를 이 서비스 안에 격리했다.
- 게시글 첨부 retention은 `PostAttachmentRetentionService`, 프로필 이미지 retention은 `ProfileImageRetentionService`로 분리했다.
- purge 실행은 `UploadedFilePurgeService`, reference 판단은 `UploadedFileReferenceQueryService`로 분리했다.
- purge는 후보 조회, reference 판단, storage delete, DB 상태 전환 단계를 분리해 storage delete와 DB 저장이 원자 트랜잭션처럼 보이지 않게 했다.
- retention 시간 계산에 `Clock`을 주입하고 테스트에서는 고정 clock으로 purgeAfter를 결정적으로 검증한다.
- `ciFastCheck`의 기존 cloud upload session 기본 인자 coverage 누락을 테스트 1건으로 보강했다.
- #902/#904 main 병합 후 `registerTempUploadWithCompensation` 공개 계약을 유지하면서 실제 보상 삭제 책임은 `UploadedFileRegistrationService`로 이동하도록 충돌을 해결했다.
- 보상 등록 성공 경로는 storage delete를 호출하지 않는 테스트를 추가해 100% line coverage gate를 맞췄다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests '*UploadedFileRetention*' --tests '*Upload*'` 성공
  - `back/gradlew -p back ktlintCheck` 성공
  - `back/gradlew -p back ciFastCheck --rerun-tasks` 성공
  - `back/gradlew -p back ciFastCheck --rerun-tasks` 2회 연속 성공
  - commit hook `OpenApiContractExportTest` 성공
  - commit hook `yarn contracts:check` 성공
  - #902/#904 main 병합: 충돌 2건 수동 해결
  - main 병합 후 `back/gradlew -p back compileTestKotlin` 성공
  - main 병합 후 `back/gradlew -p back test --tests '*UploadedFileRetentionService*' --tests '*CloudVideoUploadSessionService*' --tests '*ApiV1PostImageControllerTest*'` 성공
  - main 병합 후 `back/gradlew -p back test --tests '*UploadedFileRetentionServiceConflictRecoveryTest*'` 성공
  - main 병합 후 `back/gradlew -p back ktlintCheck` 성공
  - main 병합 후 `yarn --cwd front contracts:check` 성공
  - main 병합 후 `back/gradlew -p back ciFastCheck --rerun-tasks` 2회 연속 성공
- 참고:
  - 1차 main 병합 후 전체 회귀는 `ciFastCoverageVerification`에서 line coverage `0.99/1.00`으로 실패했다.
  - 원인은 `UploadedFileRegistrationService.registerTempUploadWithCompensation` 성공 경로 미검증으로 분류했고, 성공 시 보상 삭제가 호출되지 않는 테스트를 추가한 뒤 전체 회귀를 다시 2회 연속 통과시켰다.

## 리뷰어 메모

- 먼저 `UploadedFileRetentionService`가 facade로 축소되고 각 하위 서비스가 기존 public 계약을 그대로 유지하는지 봐 주세요.
- `registerTempUploadWithCompensation`는 controller 호출 계약을 유지하고, 등록 실패 보상 삭제만 registration service 내부 책임으로 이동했습니다.
- `UploadedFilePurgeService`에서 reference 판단과 storage delete/DB 상태 전환이 분리된 흐름을 중점 확인해 주세요.
- cloud test 변경은 이번 리팩터링 로직 변경이 아니라 `ciFastCheck` 100% line coverage gate를 통과시키기 위한 기존 기본 인자 경로 보강입니다.

## 리스크

- Spring bean 분리가 들어가므로 retention 관련 테스트 base에서 새 service import와 fixed `Clock` bean을 함께 구성했다.
- #902/#904 병합으로 업로드 상태머신/보상 등록 로직이 main에 먼저 들어왔고, 이 PR에서 해당 충돌은 해결했다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
