### PR TITLE
[Refactor] PostApplicationService 유스케이스 분리

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostTagIndexJdbcRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostTagIndexJdbcRepository.kt
@@ -67,7 +67,7 @@ class PostTagIndexJdbcRepository(
 
     override fun findAllPublicTagCounts(): List<PostTagIndexRepositoryPort.TagCountRow> =
         if (!isTableAvailable()) {
-            emptyList()
+            throw IllegalStateException("post_tag_index table is unavailable")
         } else {
             try {
                 jdbcTemplate.query(
@@ -92,7 +92,7 @@ class PostTagIndexJdbcRepository(
                 }
             } catch (exception: DataAccessException) {
                 markUnavailable(exception)
-                emptyList()
+                throw exception
             }
         }
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -1,44 +1,21 @@
 package com.back.boundedContexts.post.application.service
 
 import com.back.boundedContexts.member.domain.shared.Member
-import com.back.boundedContexts.member.domain.shared.MemberAttr
-import com.back.boundedContexts.member.domain.shared.MemberProxy
-import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_IMG_URL
 import com.back.boundedContexts.member.dto.MemberDto
-import com.back.boundedContexts.post.application.port.output.MemberAttrRepositoryPort
-import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
-import com.back.boundedContexts.post.application.port.output.PostCommentRepositoryPort
-import com.back.boundedContexts.post.application.port.output.PostLikeRepositoryPort
 import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
-import com.back.boundedContexts.post.application.port.output.PostTagIndexRepositoryPort
 import com.back.boundedContexts.post.application.port.output.PostWriteRequestIdempotencyRepositoryPort
 import com.back.boundedContexts.post.application.port.output.SecureTipPort
-import com.back.boundedContexts.post.domain.POSTS_COUNT
-import com.back.boundedContexts.post.domain.POST_COMMENTS_COUNT
 import com.back.boundedContexts.post.domain.Post
-import com.back.boundedContexts.post.domain.PostAttr
 import com.back.boundedContexts.post.domain.PostComment
 import com.back.boundedContexts.post.domain.PostWriteRequestIdempotency
-import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
-import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
-import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
-import com.back.boundedContexts.post.domain.postMixin.META_TAGS_INDEX
 import com.back.boundedContexts.post.domain.postMixin.PostLikeToggleResult
 import com.back.boundedContexts.post.dto.AdmDeletedPostDto
-import com.back.boundedContexts.post.dto.PostCommentDto
 import com.back.boundedContexts.post.dto.PostDto
-import com.back.boundedContexts.post.dto.PostMetaExtractor
 import com.back.boundedContexts.post.dto.PublicPostDetailContentCacheDto
 import com.back.boundedContexts.post.dto.TagCountDto
-import com.back.boundedContexts.post.event.PostCommentDeletedEvent
-import com.back.boundedContexts.post.event.PostCommentModifiedEvent
-import com.back.boundedContexts.post.event.PostCommentWrittenEvent
 import com.back.boundedContexts.post.event.PostDeletedEvent
-import com.back.boundedContexts.post.event.PostLikedEvent
 import com.back.boundedContexts.post.event.PostModifiedEvent
-import com.back.boundedContexts.post.event.PostUnlikedEvent
 import com.back.boundedContexts.post.event.PostWrittenEvent
-import com.back.global.event.application.EventPublisher
 import com.back.global.exception.application.AppException
 import com.back.global.security.application.HtmlContentSanitizer
 import com.back.global.storage.application.UploadedFileRetentionService
@@ -47,7 +24,6 @@ import com.back.standard.dto.EventPayload
 import com.back.standard.dto.page.PagedResult
 import com.back.standard.dto.post.type1.PostSearchSortType1
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.stereotype.Service
@@ -57,7 +33,6 @@ import tools.jackson.databind.ObjectMapper
 import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
 import kotlin.jvm.optionals.getOrNull
 
 /**
@@ -67,36 +42,21 @@ import kotlin.jvm.optionals.getOrNull
 @Service
 class PostApplicationService(
     private val postRepository: PostRepositoryPort,
-    private val postTagIndexRepository: PostTagIndexRepositoryPort,
-    private val postAttrRepository: PostAttrRepositoryPort,
-    private val memberAttrRepository: MemberAttrRepositoryPort,
-    private val postCommentRepository: PostCommentRepositoryPort,
-    private val postLikeRepository: PostLikeRepositoryPort,
     private val postWriteRequestIdempotencyRepository: PostWriteRequestIdempotencyRepositoryPort,
     private val secureTipPort: SecureTipPort,
-    private val eventPublisher: EventPublisher,
     private val uploadedFileRetentionService: UploadedFileRetentionService,
     private val postRecommendRankingService: PostRecommendRankingService,
-    private val postRecommendFeatureStoreService: PostRecommendFeatureStoreService,
     private val postKeywordSearchPipelineService: PostKeywordSearchPipelineService,
     private val taskFacade: TaskFacade,
     private val objectMapper: ObjectMapper,
-    @param:Value("\${custom.post.read.tags-local-cache-ttl-seconds:180}")
-    private val tagsLocalCacheTtlSeconds: Long,
+    private val postHydrationService: PostHydrationService,
+    private val postCounterService: PostCounterService,
+    private val postTagIndexService: PostTagIndexService,
+    private val postTempDraftService: PostTempDraftService,
+    private val postCommentApplicationService: PostCommentApplicationService,
+    private val postLikeApplicationService: PostLikeApplicationService,
 ) {
     private val logger = LoggerFactory.getLogger(PostApplicationService::class.java)
-    private val activeTempDraftPostIdAttrName = "activeTempDraftPostId"
-    private val activeTempDraftLockAttrName = "activeTempDraftLock"
-
-    private data class TagCountsCache(
-        val expiresAtMillis: Long,
-        val values: List<TagCountDto>,
-    )
-
-    @Volatile
-    private var publicTagCountsCache: TagCountsCache? = null
-
-    private val tagCacheTtlMillis: Long = tagsLocalCacheTtlSeconds.coerceAtLeast(5) * 1_000
 
     fun count(): Long = postRepository.count()
 
@@ -116,7 +76,7 @@ class PostApplicationService(
         idempotencyKey: String? = null,
         contentHtml: String? = null,
     ): Post {
-        val persistenceAuthor = toPersistenceMember(author)
+        val persistenceAuthor = author.toPersistenceMember()
         val normalizedIdempotencyKey = idempotencyKey?.trim()?.takeIf { it.isNotBlank() }
 
         if (normalizedIdempotencyKey == null) {
@@ -130,7 +90,7 @@ class PostApplicationService(
                     listed = listed,
                     contentHtml = contentHtml,
                 )
-            val createdTags = extractNormalizedTags(created.content)
+            val createdTags = postTagIndexService.extractNormalizedTags(created.content)
             val isPublic = isPubliclyListed(created)
             publishPostWriteAfterCommitEvent(
                 PostWriteSideEffectCommand(
@@ -191,7 +151,7 @@ class PostApplicationService(
 
         requestSlot.postId = createdPost.id
         postWriteRequestIdempotencyRepository.save(requestSlot)
-        val createdTags = extractNormalizedTags(createdPost.content)
+        val createdTags = postTagIndexService.extractNormalizedTags(createdPost.content)
         val isPublic = isPubliclyListed(createdPost)
         publishPostWriteAfterCommitEvent(
             PostWriteSideEffectCommand(
@@ -227,8 +187,8 @@ class PostApplicationService(
             .findById(id)
             .getOrNull()
             ?.also { post ->
-                hydratePostAttrs(post)
-                hydrateMembersProfileImgAttrs(listOf(post.author))
+                postHydrationService.hydratePostAttrs(post)
+                postHydrationService.hydrateMembersProfileImgAttrs(listOf(post.author))
             }
 
     fun findPublicDetailById(id: Long): Post? =
@@ -236,9 +196,9 @@ class PostApplicationService(
             .findPublicDetailById(id)
             ?.also { post ->
                 if (post.likesCountAttr == null || post.commentsCountAttr == null || post.hitCountAttr == null) {
-                    hydratePostAttrs(post)
+                    postHydrationService.hydratePostAttrs(post)
                 }
-                hydrateMembersProfileImgAttrs(listOf(post.author))
+                postHydrationService.hydrateMembersProfileImgAttrs(listOf(post.author))
             }
 
     fun findPublicDetailContentById(id: Long): PublicPostDetailContentCacheDto? = postRepository.findPublicDetailContentById(id)
@@ -260,9 +220,9 @@ class PostApplicationService(
         expectedVersion: Long,
         contentHtml: String? = null,
     ) {
-        hydratePostAttrs(post)
+        postHydrationService.hydratePostAttrs(post)
         val currentVersion = post.version ?: 0L
-        val wasTempDraft = isTempDraft(post)
+        val wasTempDraft = postTempDraftService.isTempDraft(post)
         if (expectedVersion != currentVersion) {
             throw AppException("409-1", "다른 세션에서 이미 수정되었습니다. 최신 글을 다시 불러온 뒤 수정해주세요.")
         }
@@ -271,7 +231,7 @@ class PostApplicationService(
         val previousContent = post.content
         val previousContentHtml = post.contentHtml
         val wasPublic = isPubliclyListed(post)
-        val previousTags = extractNormalizedTags(previousContent)
+        val previousTags = postTagIndexService.extractNormalizedTags(previousContent)
         try {
             val sanitizedContentHtml =
                 if (contentHtml == null) {
@@ -281,14 +241,14 @@ class PostApplicationService(
                 }
             post.modify(title, content, published, listed, sanitizedContentHtml)
             postRepository.flush()
-            syncMetaTagIndexAttr(post)
+            postTagIndexService.syncMetaTagIndexAttr(post)
             if (wasTempDraft) {
-                updateTempDraftMarker(post.author, null)
+                postTempDraftService.updateTempDraftMarker(post.author, null)
             }
         } catch (exception: ObjectOptimisticLockingFailureException) {
             throw AppException("409-1", "다른 세션에서 이미 수정되었습니다. 최신 글을 다시 불러온 뒤 수정해주세요.")
         }
-        val afterTags = extractNormalizedTags(post.content)
+        val afterTags = postTagIndexService.extractNormalizedTags(post.content)
         val isPublic = isPubliclyListed(post)
         val listingVisibilityChanged = wasPublic != isPublic
         val contentChanged = previousContent != post.content
@@ -355,8 +315,8 @@ class PostApplicationService(
                 HtmlContentSanitizer.sanitizeRichHtmlOrNull(contentHtml),
             )
         val savedPost = postRepository.saveAndFlush(post)
-        syncMetaTagIndexAttr(savedPost)
-        incrementMemberPostsCount(persistenceAuthor)
+        postTagIndexService.syncMetaTagIndexAttr(savedPost)
+        postCounterService.incrementMemberPostsCount(persistenceAuthor)
         return savedPost
     }
 
@@ -399,23 +359,23 @@ class PostApplicationService(
     ) {
         val deletedPostContent = post.content
         val wasPublic = isPubliclyListed(post)
-        val wasTempDraft = isTempDraft(post)
-        val beforeTags = extractNormalizedTags(deletedPostContent)
+        val wasTempDraft = postTempDraftService.isTempDraft(post)
+        val beforeTags = postTagIndexService.extractNormalizedTags(deletedPostContent)
 
         val softDeleted = postRepository.softDeleteById(post.id)
         if (!softDeleted) {
             throw AppException("404-1", "${post.id}번 글을 찾을 수 없습니다.")
         }
         if (wasTempDraft) {
-            updateTempDraftMarker(post.author, null)
+            postTempDraftService.updateTempDraftMarker(post.author, null)
         }
         // 카운터 보정 실패는 삭제 실패로 전파하지 않는다. 실패 시 실제 개수 재동기화를 시도한다.
         runCatching {
-            decrementMemberPostsCount(Member(post.author.id))
+            postCounterService.decrementMemberPostsCount(Member(post.author.id))
         }.onFailure { exception ->
             logger.warn("Failed to decrement member posts counter for member id={}", post.author.id, exception)
             runCatching {
-                reconcileMemberPostsCount(Member(post.author.id))
+                postCounterService.reconcileMemberPostsCount(Member(post.author.id))
             }.onFailure { reconcileException ->
                 logger.warn("Failed to reconcile member posts counter for member id={}", post.author.id, reconcileException)
             }
@@ -458,34 +418,7 @@ class PostApplicationService(
         post: Post,
         content: String,
         parentComment: PostComment? = null,
-    ): PostComment {
-        val persistenceAuthor = toPersistenceMember(author)
-        val persistedParentComment = parentComment?.let { findCommentById(post, it.id) ?: it }
-        val comment =
-            postCommentRepository.save(
-                post.newComment(
-                    author = persistenceAuthor,
-                    content = content,
-                    parentComment = persistedParentComment,
-                ),
-            )
-        incrementCommentsCount(post)
-        incrementMemberPostCommentsCount(persistenceAuthor)
-        enqueuePostInteractionSideEffect(
-            postId = post.id,
-            recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
-            domainEvent =
-                PostCommentWrittenEvent(
-                    UUID.randomUUID(),
-                    PostCommentDto(comment),
-                    PostDto(post),
-                    MemberDto(author),
-                    persistedParentComment?.author?.id,
-                ),
-        )
-
-        return comment
-    }
+    ): PostComment = postCommentApplicationService.writeComment(author, post, content, parentComment)
 
     /**
      * 댓글 내용을 수정하고 변경 이벤트를 발행합니다.
@@ -496,20 +429,7 @@ class PostApplicationService(
         postComment: PostComment,
         actor: Member,
         content: String,
-    ) {
-        postComment.modify(content)
-
-        enqueuePostInteractionSideEffect(
-            postId = postComment.post.id,
-            domainEvent =
-                PostCommentModifiedEvent(
-                    UUID.randomUUID(),
-                    PostCommentDto(postComment),
-                    PostDto(postComment.post),
-                    MemberDto(actor),
-                ),
-        )
-    }
+    ) = postCommentApplicationService.modifyComment(postComment, actor, content)
 
     /**
      * 댓글 삭제를 처리하고 연관 집계값을 함께 보정합니다.
@@ -520,38 +440,7 @@ class PostApplicationService(
         post: Post,
         postComment: PostComment,
         actor: Member,
-    ) {
-        hydratePostAttrs(post)
-        val commentsToDelete =
-            postCommentRepository
-                .findActiveSubtreeByPostAndRootCommentId(post, postComment.id)
-                .ifEmpty { listOf(postComment) }
-
-        commentsToDelete.forEach { hydrateMemberCounterAttrs(it.author) }
-
-        val postDto = PostDto(post)
-        commentsToDelete.forEachIndexed { index, comment ->
-            val postCommentDto = PostCommentDto(comment)
-            comment.author.decrementPostCommentsCount()
-            saveMemberAttr(comment.author.postCommentsCountAttr)
-            post.onCommentDeleted()
-            comment.softDelete()
-
-            enqueuePostInteractionSideEffect(
-                postId = comment.post.id,
-                recommendationAction =
-                    if (index == commentsToDelete.lastIndex) {
-                        PostInteractionRecommendationSideEffect.REFRESH
-                    } else {
-                        PostInteractionRecommendationSideEffect.NONE
-                    },
-                domainEvent = PostCommentDeletedEvent(UUID.randomUUID(), postCommentDto, postDto, MemberDto(actor)),
-            )
-        }
-
-        savePostAttr(post.commentsCountAttr)
-        postRepository.flush()
-    }
+    ) = postCommentApplicationService.deleteComment(post, postComment, actor)
 
     /**
      * 좋아요 상태 변경을 반영하고 경쟁 상황에서의 정합성을 보장합니다.
@@ -561,48 +450,7 @@ class PostApplicationService(
     fun like(
         post: Post,
         actor: Member,
-    ): PostLikeToggleResult {
-        val persistenceActor = toPersistenceMember(actor)
-        hydratePostAttrs(post)
-        val insertedLikeId = postLikeRepository.insertIfAbsent(persistenceActor, post)
-
-        if (insertedLikeId == null) {
-            val existingLike = postLikeRepository.findByLikerAndPost(persistenceActor, post)
-            if (existingLike != null) {
-                ensureLikesCountLoaded(post)
-                return PostLikeToggleResult(true, existingLike.id)
-            }
-
-            // 동시 unlike 경쟁으로 row가 사라진 경우 한 번 더 보정한다.
-            val recoveredLikeId = postLikeRepository.insertIfAbsent(persistenceActor, post)
-            if (recoveredLikeId == null) {
-                syncLikesCount(post)
-                return PostLikeToggleResult(
-                    isLiked = postLikeRepository.existsByLikerAndPost(persistenceActor, post),
-                    likeId = 0L,
-                )
-            }
-
-            incrementLikesCount(post)
-            postRepository.flush()
-            enqueuePostInteractionSideEffect(
-                postId = post.id,
-                recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
-                domainEvent = PostLikedEvent(UUID.randomUUID(), post.id, post.author.id, recoveredLikeId, MemberDto(actor)),
-            )
-            return PostLikeToggleResult(true, recoveredLikeId)
-        }
-
-        incrementLikesCount(post)
-        postRepository.flush()
-        enqueuePostInteractionSideEffect(
-            postId = post.id,
-            recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
-            domainEvent = PostLikedEvent(UUID.randomUUID(), post.id, post.author.id, insertedLikeId, MemberDto(actor)),
-        )
-
-        return PostLikeToggleResult(true, insertedLikeId)
-    }
+    ): PostLikeToggleResult = postLikeApplicationService.like(post, actor)
 
     /**
      * 좋아요 상태 변경을 반영하고 경쟁 상황에서의 정합성을 보장합니다.
@@ -612,109 +460,42 @@ class PostApplicationService(
     fun unlike(
         post: Post,
         actor: Member,
-    ): PostLikeToggleResult {
-        val persistenceActor = toPersistenceMember(actor)
-        hydratePostAttrs(post)
-        val existingLike = postLikeRepository.findByLikerAndPost(persistenceActor, post)
-        val postAuthorId = post.author.id
-        val existingLikeId = existingLike?.id
-        val deletedCount = postLikeRepository.deleteByLikerAndPost(persistenceActor, post)
-        if (deletedCount > 1) {
-            // Legacy 중복 row 정리 시에는 실제 개수 기준으로 즉시 재동기화한다.
-            syncLikesCount(post)
-        } else if (deletedCount == 1) {
-            decrementLikesCount(post)
-        } else {
-            ensureLikesCountLoaded(post)
-        }
-        postRepository.flush()
-
-        if (deletedCount > 0 && existingLikeId != null) {
-            enqueuePostInteractionSideEffect(
-                postId = post.id,
-                recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
-                domainEvent = PostUnlikedEvent(UUID.randomUUID(), post.id, postAuthorId, existingLikeId, MemberDto(actor)),
-            )
-        } else {
-            enqueuePostInteractionSideEffect(
-                postId = post.id,
-                recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
-            )
-        }
-
-        return PostLikeToggleResult(false, existingLikeId ?: 0L)
-    }
+    ): PostLikeToggleResult = postLikeApplicationService.unlike(post, actor)
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun reconcileLikeState(
         post: Post,
         actor: Member,
-    ): PostLikeToggleResult {
-        val persistenceActor = toPersistenceMember(actor)
-        hydratePostAttrs(post)
-        syncLikesCount(post)
-        val existingLike = postLikeRepository.findByLikerAndPost(persistenceActor, post)
-        return PostLikeToggleResult(
-            isLiked = existingLike != null,
-            likeId = existingLike?.id ?: 0L,
-        )
-    }
+    ): PostLikeToggleResult = postLikeApplicationService.reconcileLikeState(post, actor)
 
     @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
     fun readLikeSnapshot(
         post: Post,
         actor: Member,
-    ): PostLikeToggleResult {
-        val persistenceActor = toPersistenceMember(actor)
-        post.likesCount = postLikeRepository.countByPost(post).toInt()
-        val existingLike = postLikeRepository.findByLikerAndPost(persistenceActor, post)
-        return PostLikeToggleResult(
-            isLiked = existingLike != null,
-            likeId = existingLike?.id ?: 0L,
-        )
-    }
+    ): PostLikeToggleResult = postLikeApplicationService.readLikeSnapshot(post, actor)
 
     @Transactional
-    fun incrementHit(post: Post) {
-        val updatedHitCount = postAttrRepository.incrementIntValue(post, HIT_COUNT)
-        val refreshedAttr = post.hitCountAttr ?: postAttrRepository.findBySubjectAndName(post, HIT_COUNT)
-        refreshedAttr?.let {
-            it.intValue = updatedHitCount
-            post.hitCountAttr = it
-        }
-    }
+    fun incrementHit(post: Post) = postCounterService.incrementHit(post)
 
     fun getComments(
         post: Post,
         limit: Int,
-    ): List<PostComment> =
-        postCommentRepository.findByPostOrderByCreatedAtAscIdAsc(post, limit.coerceIn(1, 500)).also { comments ->
-            hydrateMembersProfileImgAttrs(comments.map { it.author })
-        }
+    ): List<PostComment> = postCommentApplicationService.getComments(post, limit)
 
     fun findCommentById(
         post: Post,
         id: Long,
-    ): PostComment? = postCommentRepository.findByPostAndId(post, id)
+    ): PostComment? = postCommentApplicationService.findCommentById(post, id)
 
     fun isLiked(
         post: Post,
         liker: Member?,
-    ): Boolean {
-        if (liker == null) return false
-        return postLikeRepository.existsByLikerAndPost(toPersistenceMember(liker), post)
-    }
+    ): Boolean = postLikeApplicationService.isLiked(post, liker)
 
     fun findLikedPostIds(
         liker: Member?,
         posts: List<Post>,
-    ): Set<Long> {
-        if (liker == null || posts.isEmpty()) return emptySet()
-        return postLikeRepository
-            .findByLikerAndPostIn(toPersistenceMember(liker), posts)
-            .map { it.post.id }
-            .toSet()
-    }
+    ): Set<Long> = postLikeApplicationService.findLikedPostIds(liker, posts)
 
     fun findPagedByKw(
         kw: String,
@@ -858,11 +639,11 @@ class PostApplicationService(
         val authorRef = Member(snapshot.authorId)
 
         runCatching {
-            incrementMemberPostsCount(authorRef)
+            postCounterService.incrementMemberPostsCount(authorRef)
         }.onFailure { exception ->
             logger.warn("Failed to increment member posts counter for member id={}", snapshot.authorId, exception)
             runCatching {
-                reconcileMemberPostsCount(authorRef)
+                postCounterService.reconcileMemberPostsCount(authorRef)
             }.onFailure { reconcileException ->
                 logger.warn("Failed to reconcile member posts counter for member id={}", snapshot.authorId, reconcileException)
             }
@@ -880,7 +661,7 @@ class PostApplicationService(
         val restoredPost =
             postRepository.findById(id).getOrNull()
                 ?: throw AppException("404-1", "복구된 글을 확인할 수 없습니다.")
-        val restoredTags = extractNormalizedTags(restoredPost.content)
+        val restoredTags = postTagIndexService.extractNormalizedTags(restoredPost.content)
         val isPublic = isPubliclyListed(restoredPost)
         publishPostWriteAfterCommitEvent(
             PostWriteSideEffectCommand(
@@ -921,7 +702,7 @@ class PostApplicationService(
                 previousContent = null,
                 currentContent = null,
                 deletedContent = snapshot.content,
-                beforeTags = extractNormalizedTags(snapshot.content),
+                beforeTags = postTagIndexService.extractNormalizedTags(snapshot.content),
                 afterTags = emptyList(),
                 cacheInvalidationScope =
                     if (snapshot.published && snapshot.listed) {
@@ -944,7 +725,7 @@ class PostApplicationService(
     ): PagedResult<Post> =
         findAndHydratePagedPosts(page, pageSize) {
             postRepository.findQPagedByAuthorAndKw(
-                toPersistenceMember(author),
+                author.toPersistenceMember(),
                 PostRepositoryPort.PagedQuery(
                     kw = kw,
                     zeroBasedPage = page - 1,
@@ -1031,62 +812,14 @@ class PostApplicationService(
         }
     }
 
-    fun getPublicTagCounts(): List<TagCountDto> {
-        val now = System.currentTimeMillis()
-        publicTagCountsCache?.takeIf { it.expiresAtMillis > now }?.let { return it.values }
+    fun getPublicTagCounts(): List<TagCountDto> = postTagIndexService.getPublicTagCounts()
 
-        synchronized(this) {
-            val refreshedNow = System.currentTimeMillis()
-            publicTagCountsCache?.takeIf { it.expiresAtMillis > refreshedNow }?.let { return it.values }
-
-            val result =
-                runCatching {
-                    postTagIndexRepository.findAllPublicTagCounts().map { row ->
-                        TagCountDto(row.tag, row.count)
-                    }
-                }.getOrElse { exception ->
-                    logger.warn(
-                        "public_tag_counts_query_failed: fallback to legacy metaTagsIndex path",
-                        exception,
-                    )
-                    loadPublicTagCountsFromMetaTagIndex()
-                }
-
-            publicTagCountsCache = TagCountsCache(refreshedNow + tagCacheTtlMillis, result)
-            return result
-        }
-    }
-
-    fun findTemp(author: Member): Post? {
-        val persistenceAuthor = toPersistenceMember(author)
-        return resolveTrackedTempPost(persistenceAuthor) ?: findLegacyTemp(persistenceAuthor)
-    }
+    fun findTemp(author: Member): Post? = postTempDraftService.findTemp(author)
 
     @Transactional
-    fun getOrCreateTemp(author: Member): Pair<Post, Boolean> {
-        val persistenceAuthor = toPersistenceMember(author)
-        if (!tryAcquireTempDraftLock(persistenceAuthor)) {
-            throw AppException("409-2", "다른 탭에서 임시글을 준비 중입니다. 잠시 후 다시 시도해주세요.")
-        }
+    fun getOrCreateTemp(author: Member): Pair<Post, Boolean> = postTempDraftService.getOrCreateTemp(author)
 
-        return try {
-            val existingTemp = resolveTrackedTempPost(persistenceAuthor) ?: findLegacyTemp(persistenceAuthor)
-            if (existingTemp != null) {
-                updateTempDraftMarker(persistenceAuthor, existingTemp.id)
-                postRepository.flush()
-                existingTemp to false
-            } else {
-                val newPost = postRepository.save(Post(0, persistenceAuthor, "임시글", "임시글 입니다."))
-                updateTempDraftMarker(persistenceAuthor, newPost.id)
-                postRepository.flush()
-                newPost to true
-            }
-        } finally {
-            releaseTempDraftLock(persistenceAuthor)
-        }
-    }
-
-    fun isTempDraft(post: Post): Boolean = resolveTrackedTempPostId(post.author) == post.id
+    fun isTempDraft(post: Post): Boolean = postTempDraftService.isTempDraft(post)
 
     private fun findAndHydratePagedPosts(
         page: Int,
@@ -1094,8 +827,8 @@ class PostApplicationService(
         loader: () -> PostRepositoryPort.PagedResult<Post>,
     ): PagedResult<Post> {
         val pageResult = loader()
-        hydratePostAttrs(pageResult.content)
-        hydrateMembersProfileImgAttrs(pageResult.content.map { it.author })
+        postHydrationService.hydratePostAttrs(pageResult.content)
+        postHydrationService.hydrateMembersProfileImgAttrs(pageResult.content.map { it.author })
         return PagedResult(
             content = pageResult.content,
             page = page,
@@ -1107,183 +840,10 @@ class PostApplicationService(
     private fun findAndHydratePublicCursorPosts(loader: () -> List<Post>): List<Post> {
         val posts = loader()
         if (posts.isEmpty()) return posts
-        hydratePostAttrs(posts)
-        hydrateMembersProfileImgAttrs(posts.map { it.author })
+        postHydrationService.hydratePostAttrs(posts)
+        postHydrationService.hydrateMembersProfileImgAttrs(posts.map { it.author })
         return posts
     }
-
-    private fun hydratePostAttrs(post: Post) {
-        post.likesCountAttr ?: postAttrRepository.findBySubjectAndName(post, LIKES_COUNT)?.let { post.likesCountAttr = it }
-        post.commentsCountAttr ?: postAttrRepository.findBySubjectAndName(post, COMMENTS_COUNT)?.let { post.commentsCountAttr = it }
-        post.hitCountAttr ?: postAttrRepository.findBySubjectAndName(post, HIT_COUNT)?.let { post.hitCountAttr = it }
-    }
-
-    private fun hydratePostAttrs(posts: List<Post>) {
-        if (posts.isEmpty()) return
-
-        // 목록 조회 시 post마다 natural-id lookup을 반복하면 쿼리가 급증하므로 일괄 hydrate 한다.
-        val attrsByKey =
-            postAttrRepository
-                .findBySubjectInAndNameIn(posts, listOf(LIKES_COUNT, COMMENTS_COUNT, HIT_COUNT))
-                .associateBy { "${it.subject.id}:${it.name}" }
-
-        posts.forEach { post ->
-            post.likesCountAttr = post.likesCountAttr ?: attrsByKey["${post.id}:$LIKES_COUNT"]
-            post.commentsCountAttr = post.commentsCountAttr ?: attrsByKey["${post.id}:$COMMENTS_COUNT"]
-            post.hitCountAttr = post.hitCountAttr ?: attrsByKey["${post.id}:$HIT_COUNT"]
-        }
-    }
-
-    private fun hydrateMemberCounterAttrs(member: Member) {
-        member.postsCountAttr ?: memberAttrRepository.findBySubjectAndName(member, POSTS_COUNT)?.let { member.postsCountAttr = it }
-        member.postCommentsCountAttr ?: memberAttrRepository
-            .findBySubjectAndName(member, POST_COMMENTS_COUNT)
-            ?.let { member.postCommentsCountAttr = it }
-    }
-
-    private fun hydrateMembersProfileImgAttrs(members: List<Member>) {
-        if (members.isEmpty()) return
-
-        val uniqueMembers = members.distinctBy { it.id }
-        val profileAttrsByMemberId =
-            memberAttrRepository
-                .findBySubjectInAndNameIn(uniqueMembers, listOf(PROFILE_IMG_URL))
-                .associateBy { it.subject.id }
-
-        // DTO 매핑에서 redirectToProfileImgUrlOrDefault 접근 시 profile attr lazy-load를 미리 해소한다.
-        uniqueMembers.forEach { member ->
-            member.getOrInitProfileImgUrlAttr {
-                profileAttrsByMemberId[member.id] ?: MemberAttr(0, member, PROFILE_IMG_URL, "")
-            }
-        }
-    }
-
-    private fun savePostAttr(attr: PostAttr?) {
-        attr?.let(postAttrRepository::save)
-    }
-
-    private fun syncLikesCount(post: Post) {
-        val actualLikesCount = postLikeRepository.countByPost(post).toInt()
-        post.likesCount = actualLikesCount
-        savePostAttr(post.likesCountAttr)
-    }
-
-    private fun ensureLikesCountLoaded(post: Post) {
-        post.likesCountAttr = postAttrRepository.findBySubjectAndName(post, LIKES_COUNT)
-    }
-
-    private fun incrementLikesCount(post: Post) {
-        val updatedLikesCount = postAttrRepository.incrementIntValue(post, LIKES_COUNT)
-        applyLikesCount(post, updatedLikesCount)
-    }
-
-    private fun incrementCommentsCount(post: Post) {
-        val updatedCommentsCount = postAttrRepository.incrementIntValue(post, COMMENTS_COUNT)
-        applyCommentsCount(post, updatedCommentsCount)
-    }
-
-    private fun decrementLikesCount(post: Post) {
-        val updatedLikesCount = postAttrRepository.incrementIntValue(post, LIKES_COUNT, -1).coerceAtLeast(0)
-        applyLikesCount(post, updatedLikesCount)
-    }
-
-    private fun applyLikesCount(
-        post: Post,
-        likesCount: Int,
-    ) {
-        val refreshedAttr = post.likesCountAttr ?: postAttrRepository.findBySubjectAndName(post, LIKES_COUNT)
-        refreshedAttr?.let {
-            it.intValue = likesCount
-            post.likesCountAttr = it
-        }
-    }
-
-    private fun applyCommentsCount(
-        post: Post,
-        commentsCount: Int,
-    ) {
-        val refreshedAttr = post.commentsCountAttr ?: postAttrRepository.findBySubjectAndName(post, COMMENTS_COUNT)
-        refreshedAttr?.let {
-            it.intValue = commentsCount
-            post.commentsCountAttr = it
-        }
-    }
-
-    private fun incrementMemberPostCommentsCount(member: Member) {
-        val updatedCount = memberAttrRepository.incrementIntValue(member, POST_COMMENTS_COUNT)
-        val refreshedAttr = member.postCommentsCountAttr ?: memberAttrRepository.findBySubjectAndName(member, POST_COMMENTS_COUNT)
-        refreshedAttr?.let {
-            it.intValue = updatedCount
-            member.postCommentsCountAttr = it
-        }
-    }
-
-    private fun incrementMemberPostsCount(member: Member) {
-        val updatedCount = memberAttrRepository.incrementIntValue(member, POSTS_COUNT)
-        member.postsCountAttr?.intValue = updatedCount
-    }
-
-    private fun decrementMemberPostsCount(member: Member) {
-        var updatedCount = memberAttrRepository.incrementIntValue(member, POSTS_COUNT, -1)
-        if (updatedCount < 0) {
-            updatedCount = memberAttrRepository.incrementIntValue(member, POSTS_COUNT, -updatedCount)
-        }
-        member.postsCountAttr?.intValue = updatedCount
-    }
-
-    private fun reconcileMemberPostsCount(member: Member) {
-        val actualCount = postRepository.countByAuthor(member).coerceAtLeast(0).toInt()
-        val refreshedAttr = member.postsCountAttr ?: memberAttrRepository.findBySubjectAndName(member, POSTS_COUNT)
-        val counterAttr = refreshedAttr ?: MemberAttr(0, member, POSTS_COUNT, actualCount)
-        counterAttr.intValue = actualCount
-        member.postsCountAttr = counterAttr
-        saveMemberAttr(counterAttr)
-    }
-
-    private fun saveMemberAttr(attr: MemberAttr?) {
-        attr?.let(memberAttrRepository::save)
-    }
-
-    private fun findLegacyTemp(author: Member): Post? = postRepository.findFirstByAuthorAndTitleAndPublishedFalseOrderByIdAsc(author, "임시글")
-
-    private fun resolveTrackedTempPost(author: Member): Post? {
-        val trackedPostId = resolveTrackedTempPostId(author) ?: return null
-        val trackedPost = postRepository.findById(trackedPostId).getOrNull() ?: return null
-        return trackedPost.takeIf { it.author.id == author.id }
-    }
-
-    private fun resolveTrackedTempPostId(author: Member): Long? =
-        memberAttrRepository
-            .findBySubjectAndName(author, activeTempDraftPostIdAttrName)
-            ?.strValue
-            ?.trim()
-            ?.takeIf { it.isNotBlank() }
-            ?.toLongOrNull()
-
-    private fun updateTempDraftMarker(
-        author: Member,
-        postId: Long?,
-    ) {
-        val attr =
-            memberAttrRepository.findBySubjectAndName(author, activeTempDraftPostIdAttrName)
-                ?: MemberAttr(0, author, activeTempDraftPostIdAttrName, "")
-        attr.strValue = postId?.toString().orEmpty()
-        saveMemberAttr(attr)
-    }
-
-    private fun tryAcquireTempDraftLock(author: Member): Boolean {
-        val lockValue = memberAttrRepository.incrementIntValue(author, activeTempDraftLockAttrName, 1)
-        if (lockValue == 1) return true
-        memberAttrRepository.incrementIntValue(author, activeTempDraftLockAttrName, -1)
-        return false
-    }
-
-    private fun releaseTempDraftLock(author: Member) {
-        memberAttrRepository.incrementIntValue(author, activeTempDraftLockAttrName, -1)
-    }
-
-    // SecurityContext actor는 MemberProxy일 수 있어 영속 경계에서는 실제 엔티티를 사용한다.
-    private fun toPersistenceMember(member: Member): Member = if (member is MemberProxy) member.persistenceMember else member
 
     private fun recommendationActionFor(isPublic: Boolean): PostRecommendationSideEffect =
         if (isPublic) PostRecommendationSideEffect.REFRESH else PostRecommendationSideEffect.EVICT
@@ -1293,7 +853,7 @@ class PostApplicationService(
         domainEvent: EventPayload? = null,
     ) {
         if (command.cacheInvalidationScope.evictsPublicTags()) {
-            publicTagCountsCache = null
+            postTagIndexService.evictPublicTagCountsCache()
         }
         taskFacade.addToQueue(command.toTaskPayload(domainEvent), inlineWhenEnabled = false)
     }
@@ -1329,125 +889,6 @@ class PostApplicationService(
         return command.operationUid
     }
 
-    private fun enqueuePostInteractionSideEffect(
-        postId: Long,
-        recommendationAction: PostInteractionRecommendationSideEffect = PostInteractionRecommendationSideEffect.NONE,
-        domainEvent: EventPayload? = null,
-        operationUid: UUID = UUID.randomUUID(),
-    ) {
-        if (domainEvent != null && recommendationAction != PostInteractionRecommendationSideEffect.NONE) {
-            addPostInteractionSideEffectTask(
-                postId = postId,
-                recommendationAction = PostInteractionRecommendationSideEffect.NONE,
-                domainEvent = domainEvent,
-                operationUid = operationUid,
-            )
-            addPostInteractionSideEffectTask(
-                postId = postId,
-                recommendationAction = recommendationAction,
-                domainEvent = null,
-                operationUid = postInteractionRefreshSideEffectTaskUid(domainEvent),
-            )
-            return
-        }
-
-        addPostInteractionSideEffectTask(
-            postId = postId,
-            recommendationAction = recommendationAction,
-            domainEvent = domainEvent,
-            operationUid = operationUid,
-        )
-    }
-
-    private fun addPostInteractionSideEffectTask(
-        postId: Long,
-        recommendationAction: PostInteractionRecommendationSideEffect,
-        domainEvent: EventPayload?,
-        operationUid: UUID,
-    ) {
-        taskFacade.addToQueue(
-            PostInteractionSideEffectPayload(
-                uid = postInteractionSideEffectTaskUid(domainEvent, operationUid),
-                aggregateType = domainEvent?.aggregateType ?: "Post",
-                aggregateId = domainEvent?.aggregateId ?: postId,
-                postId = postId,
-                recommendationAction = recommendationAction,
-                domainEventUid = domainEvent?.uid,
-                domainEventType = domainEvent?.javaClass?.name,
-                postCommentDto = postInteractionCommentDto(domainEvent),
-                postDto = postInteractionPostDto(domainEvent),
-                actorDto = postInteractionActorDto(domainEvent),
-                replyReceiverId = postInteractionReplyReceiverId(domainEvent),
-                postAuthorId = postInteractionPostAuthorId(domainEvent),
-                likeId = postInteractionLikeId(domainEvent),
-            ),
-            inlineWhenEnabled = false,
-        )
-    }
-
-    private fun postInteractionRefreshSideEffectTaskUid(domainEvent: EventPayload): UUID =
-        UUID.nameUUIDFromBytes(
-            "${PostInteractionSideEffectPayload.TASK_TYPE}:refresh:${domainEvent.uid}".toByteArray(
-                StandardCharsets.UTF_8,
-            ),
-        )
-
-    private fun postInteractionCommentDto(domainEvent: EventPayload?): PostCommentDto? =
-        when (domainEvent) {
-            is PostCommentWrittenEvent -> domainEvent.postCommentDto
-            is PostCommentModifiedEvent -> domainEvent.postCommentDto
-            is PostCommentDeletedEvent -> domainEvent.postCommentDto
-            else -> null
-        }
-
-    private fun postInteractionPostDto(domainEvent: EventPayload?): PostDto? =
-        when (domainEvent) {
-            is PostCommentWrittenEvent -> domainEvent.postDto
-            is PostCommentModifiedEvent -> domainEvent.postDto
-            is PostCommentDeletedEvent -> domainEvent.postDto
-            else -> null
-        }
-
-    private fun postInteractionActorDto(domainEvent: EventPayload?): MemberDto? =
-        when (domainEvent) {
-            is PostCommentWrittenEvent -> domainEvent.actorDto
-            is PostCommentModifiedEvent -> domainEvent.actorDto
-            is PostCommentDeletedEvent -> domainEvent.actorDto
-            is PostLikedEvent -> domainEvent.actorDto
-            is PostUnlikedEvent -> domainEvent.actorDto
-            else -> null
-        }
-
-    private fun postInteractionReplyReceiverId(domainEvent: EventPayload?): Long? =
-        when (domainEvent) {
-            is PostCommentWrittenEvent -> domainEvent.replyReceiverId
-            else -> null
-        }
-
-    private fun postInteractionPostAuthorId(domainEvent: EventPayload?): Long? =
-        when (domainEvent) {
-            is PostLikedEvent -> domainEvent.postAuthorId
-            is PostUnlikedEvent -> domainEvent.postAuthorId
-            else -> null
-        }
-
-    private fun postInteractionLikeId(domainEvent: EventPayload?): Long? =
-        when (domainEvent) {
-            is PostLikedEvent -> domainEvent.likeId
-            is PostUnlikedEvent -> domainEvent.likeId
-            else -> null
-        }
-
-    private fun postInteractionSideEffectTaskUid(
-        domainEvent: EventPayload?,
-        operationUid: UUID,
-    ): UUID {
-        val eventUid = domainEvent?.uid ?: return operationUid
-        return UUID.nameUUIDFromBytes(
-            "${PostInteractionSideEffectPayload.TASK_TYPE}:$eventUid".toByteArray(StandardCharsets.UTF_8),
-        )
-    }
-
     private fun buildPublicPostChangeImpacts(
         listingVisibilityChanged: Boolean,
         titleChanged: Boolean,
@@ -1462,75 +903,4 @@ class PostApplicationService(
         }
 
     private fun isPubliclyListed(post: Post): Boolean = post.published && post.listed
-
-    private fun refreshRecommendFeatureStoreForPublicPost(post: Post) {
-        if (!isPubliclyListed(post)) return
-        runCatching {
-            postRecommendFeatureStoreService.refresh(post)
-        }.onFailure { exception ->
-            logger.warn("recommend_feature_store_refresh_failed postId={}", post.id, exception)
-        }
-    }
-
-    private fun syncMetaTagIndexAttr(post: Post) {
-        val normalizedTags = extractNormalizedTags(post.content)
-
-        val indexValue =
-            if (normalizedTags.isEmpty()) {
-                ""
-            } else {
-                normalizedTags.joinToString(separator = "|", prefix = "|", postfix = "|")
-            }
-
-        val tagIndexAttr = postAttrRepository.findBySubjectAndName(post, META_TAGS_INDEX) ?: PostAttr(0, post, META_TAGS_INDEX, "")
-        if ((tagIndexAttr.strValue ?: "") != indexValue) {
-            tagIndexAttr.strValue = indexValue
-            postAttrRepository.save(tagIndexAttr)
-        }
-
-        runCatching {
-            postTagIndexRepository.replacePostTags(post.id, normalizedTags)
-        }.onFailure { exception ->
-            logger.warn("failed_to_sync_post_tag_index postId={}", post.id, exception)
-        }
-    }
-
-    private fun loadPublicTagCountsFromMetaTagIndex(): List<TagCountDto> {
-        val tagCounts = ConcurrentHashMap<String, Int>()
-        val indexedTagRows = postRepository.findAllPublicListedTagIndexes(META_TAGS_INDEX)
-
-        indexedTagRows.forEach { tagIndex ->
-            parseTagIndex(tagIndex).forEach { normalizedTag ->
-                tagCounts.merge(normalizedTag, 1, Int::plus)
-            }
-        }
-
-        if (indexedTagRows.isEmpty()) {
-            logger.warn(
-                "public_tag_counts_index_empty: skip legacy content-scan fallback to protect DB under load",
-            )
-        }
-
-        return tagCounts
-            .entries
-            .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key.lowercase() })
-            .map { TagCountDto(it.key, it.value) }
-    }
-
-    private fun normalizeTag(tag: String): String = tag.trim()
-
-    private fun extractNormalizedTags(content: String): List<String> =
-        PostMetaExtractor
-            .extract(content)
-            .tags
-            .map(::normalizeTag)
-            .filter(String::isNotBlank)
-            .distinct()
-
-    private fun parseTagIndex(tagIndex: String): List<String> =
-        tagIndex
-            .split('|')
-            .map(String::trim)
-            .filter(String::isNotBlank)
-            .distinct()
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -246,6 +246,13 @@ class PostApplicationService(
                 postTempDraftService.updateTempDraftMarker(post.author, null)
             }
         } catch (exception: ObjectOptimisticLockingFailureException) {
+            logger.warn(
+                "post_modify_optimistic_lock_conflict postId={} expectedVersion={} currentVersion={}",
+                post.id,
+                expectedVersion,
+                currentVersion,
+                exception,
+            )
             throw AppException("409-1", "다른 세션에서 이미 수정되었습니다. 최신 글을 다시 불러온 뒤 수정해주세요.")
         }
         val afterTags = postTagIndexService.extractNormalizedTags(post.content)

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCommentApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCommentApplicationService.kt
@@ -1,0 +1,131 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.dto.MemberDto
+import com.back.boundedContexts.post.application.port.output.PostCommentRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.boundedContexts.post.domain.Post
+import com.back.boundedContexts.post.domain.PostComment
+import com.back.boundedContexts.post.dto.PostCommentDto
+import com.back.boundedContexts.post.dto.PostDto
+import com.back.boundedContexts.post.event.PostCommentDeletedEvent
+import com.back.boundedContexts.post.event.PostCommentModifiedEvent
+import com.back.boundedContexts.post.event.PostCommentWrittenEvent
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class PostCommentApplicationService(
+    private val postRepository: PostRepositoryPort,
+    private val postCommentRepository: PostCommentRepositoryPort,
+    private val postHydrationService: PostHydrationService,
+    private val postCounterService: PostCounterService,
+    private val postInteractionSideEffectQueue: PostInteractionSideEffectQueue,
+) {
+    @Transactional
+    fun writeComment(
+        author: Member,
+        post: Post,
+        content: String,
+        parentComment: PostComment? = null,
+    ): PostComment {
+        val persistenceAuthor = author.toPersistenceMember()
+        val persistedParentComment = parentComment?.let { findCommentById(post, it.id) ?: it }
+        val comment =
+            postCommentRepository.save(
+                post.newComment(
+                    author = persistenceAuthor,
+                    content = content,
+                    parentComment = persistedParentComment,
+                ),
+            )
+        postCounterService.incrementCommentsCount(post)
+        postCounterService.incrementMemberPostCommentsCount(persistenceAuthor)
+        postInteractionSideEffectQueue.enqueue(
+            postId = post.id,
+            recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
+            domainEvent =
+                PostCommentWrittenEvent(
+                    UUID.randomUUID(),
+                    PostCommentDto(comment),
+                    PostDto(post),
+                    MemberDto(author),
+                    persistedParentComment?.author?.id,
+                ),
+        )
+
+        return comment
+    }
+
+    @Transactional
+    fun modifyComment(
+        postComment: PostComment,
+        actor: Member,
+        content: String,
+    ) {
+        postComment.modify(content)
+
+        postInteractionSideEffectQueue.enqueue(
+            postId = postComment.post.id,
+            domainEvent =
+                PostCommentModifiedEvent(
+                    UUID.randomUUID(),
+                    PostCommentDto(postComment),
+                    PostDto(postComment.post),
+                    MemberDto(actor),
+                ),
+        )
+    }
+
+    @Transactional
+    fun deleteComment(
+        post: Post,
+        postComment: PostComment,
+        actor: Member,
+    ) {
+        postHydrationService.hydratePostAttrs(post)
+        val commentsToDelete =
+            postCommentRepository
+                .findActiveSubtreeByPostAndRootCommentId(post, postComment.id)
+                .ifEmpty { listOf(postComment) }
+
+        commentsToDelete.forEach { postHydrationService.hydrateMemberCounterAttrs(it.author) }
+
+        val postDto = PostDto(post)
+        commentsToDelete.forEachIndexed { index, comment ->
+            val postCommentDto = PostCommentDto(comment)
+            comment.author.decrementPostCommentsCount()
+            postCounterService.saveMemberAttr(comment.author.postCommentsCountAttr)
+            post.onCommentDeleted()
+            comment.softDelete()
+
+            postInteractionSideEffectQueue.enqueue(
+                postId = comment.post.id,
+                recommendationAction =
+                    if (index == commentsToDelete.lastIndex) {
+                        PostInteractionRecommendationSideEffect.REFRESH
+                    } else {
+                        PostInteractionRecommendationSideEffect.NONE
+                    },
+                domainEvent = PostCommentDeletedEvent(UUID.randomUUID(), postCommentDto, postDto, MemberDto(actor)),
+            )
+        }
+
+        postCounterService.savePostAttr(post.commentsCountAttr)
+        postRepository.flush()
+    }
+
+    fun getComments(
+        post: Post,
+        limit: Int,
+    ): List<PostComment> =
+        postCommentRepository.findByPostOrderByCreatedAtAscIdAsc(post, limit.coerceIn(1, 500)).also { comments ->
+            postHydrationService.hydrateMembersProfileImgAttrs(comments.map { it.author })
+        }
+
+    fun findCommentById(
+        post: Post,
+        id: Long,
+    ): PostComment? = postCommentRepository.findByPostAndId(post, id)
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCommentApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCommentApplicationService.kt
@@ -11,6 +11,7 @@ import com.back.boundedContexts.post.dto.PostDto
 import com.back.boundedContexts.post.event.PostCommentDeletedEvent
 import com.back.boundedContexts.post.event.PostCommentModifiedEvent
 import com.back.boundedContexts.post.event.PostCommentWrittenEvent
+import com.back.global.exception.application.AppException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -31,7 +32,11 @@ class PostCommentApplicationService(
         parentComment: PostComment? = null,
     ): PostComment {
         val persistenceAuthor = author.toPersistenceMember()
-        val persistedParentComment = parentComment?.let { findCommentById(post, it.id) ?: it }
+        val persistedParentComment =
+            parentComment?.let {
+                findCommentById(post, it.id)
+                    ?: throw AppException("404-1", "부모 댓글을 찾을 수 없습니다.")
+            }
         val comment =
             postCommentRepository.save(
                 post.newComment(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCounterService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCounterService.kt
@@ -1,0 +1,119 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.domain.shared.MemberAttr
+import com.back.boundedContexts.post.application.port.output.MemberAttrRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostLikeRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.boundedContexts.post.domain.POSTS_COUNT
+import com.back.boundedContexts.post.domain.POST_COMMENTS_COUNT
+import com.back.boundedContexts.post.domain.Post
+import com.back.boundedContexts.post.domain.PostAttr
+import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
+import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
+import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
+import org.springframework.stereotype.Service
+
+@Service
+class PostCounterService(
+    private val postRepository: PostRepositoryPort,
+    private val postAttrRepository: PostAttrRepositoryPort,
+    private val memberAttrRepository: MemberAttrRepositoryPort,
+    private val postLikeRepository: PostLikeRepositoryPort,
+) {
+    fun incrementHit(post: Post) {
+        val updatedHitCount = postAttrRepository.incrementIntValue(post, HIT_COUNT)
+        val refreshedAttr = post.hitCountAttr ?: postAttrRepository.findBySubjectAndName(post, HIT_COUNT)
+        refreshedAttr?.let {
+            it.intValue = updatedHitCount
+            post.hitCountAttr = it
+        }
+    }
+
+    fun syncLikesCount(post: Post) {
+        val actualLikesCount = postLikeRepository.countByPost(post).toInt()
+        post.likesCount = actualLikesCount
+        savePostAttr(post.likesCountAttr)
+    }
+
+    fun ensureLikesCountLoaded(post: Post) {
+        post.likesCountAttr = postAttrRepository.findBySubjectAndName(post, LIKES_COUNT)
+    }
+
+    fun incrementLikesCount(post: Post) {
+        val updatedLikesCount = postAttrRepository.incrementIntValue(post, LIKES_COUNT)
+        applyLikesCount(post, updatedLikesCount)
+    }
+
+    fun decrementLikesCount(post: Post) {
+        val updatedLikesCount = postAttrRepository.incrementIntValue(post, LIKES_COUNT, -1).coerceAtLeast(0)
+        applyLikesCount(post, updatedLikesCount)
+    }
+
+    fun incrementCommentsCount(post: Post) {
+        val updatedCommentsCount = postAttrRepository.incrementIntValue(post, COMMENTS_COUNT)
+        applyCommentsCount(post, updatedCommentsCount)
+    }
+
+    fun incrementMemberPostCommentsCount(member: Member) {
+        val updatedCount = memberAttrRepository.incrementIntValue(member, POST_COMMENTS_COUNT)
+        val refreshedAttr = member.postCommentsCountAttr ?: memberAttrRepository.findBySubjectAndName(member, POST_COMMENTS_COUNT)
+        refreshedAttr?.let {
+            it.intValue = updatedCount
+            member.postCommentsCountAttr = it
+        }
+    }
+
+    fun incrementMemberPostsCount(member: Member) {
+        val updatedCount = memberAttrRepository.incrementIntValue(member, POSTS_COUNT)
+        member.postsCountAttr?.intValue = updatedCount
+    }
+
+    fun decrementMemberPostsCount(member: Member) {
+        var updatedCount = memberAttrRepository.incrementIntValue(member, POSTS_COUNT, -1)
+        if (updatedCount < 0) {
+            updatedCount = memberAttrRepository.incrementIntValue(member, POSTS_COUNT, -updatedCount)
+        }
+        member.postsCountAttr?.intValue = updatedCount
+    }
+
+    fun reconcileMemberPostsCount(member: Member) {
+        val actualCount = postRepository.countByAuthor(member).coerceAtLeast(0).toInt()
+        val refreshedAttr = member.postsCountAttr ?: memberAttrRepository.findBySubjectAndName(member, POSTS_COUNT)
+        val counterAttr = refreshedAttr ?: MemberAttr(0, member, POSTS_COUNT, actualCount)
+        counterAttr.intValue = actualCount
+        member.postsCountAttr = counterAttr
+        saveMemberAttr(counterAttr)
+    }
+
+    fun savePostAttr(attr: PostAttr?) {
+        attr?.let(postAttrRepository::save)
+    }
+
+    fun saveMemberAttr(attr: MemberAttr?) {
+        attr?.let(memberAttrRepository::save)
+    }
+
+    private fun applyLikesCount(
+        post: Post,
+        likesCount: Int,
+    ) {
+        val refreshedAttr = post.likesCountAttr ?: postAttrRepository.findBySubjectAndName(post, LIKES_COUNT)
+        refreshedAttr?.let {
+            it.intValue = likesCount
+            post.likesCountAttr = it
+        }
+    }
+
+    private fun applyCommentsCount(
+        post: Post,
+        commentsCount: Int,
+    ) {
+        val refreshedAttr = post.commentsCountAttr ?: postAttrRepository.findBySubjectAndName(post, COMMENTS_COUNT)
+        refreshedAttr?.let {
+            it.intValue = commentsCount
+            post.commentsCountAttr = it
+        }
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCounterService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCounterService.kt
@@ -47,7 +47,10 @@ class PostCounterService(
     }
 
     fun decrementLikesCount(post: Post) {
-        val updatedLikesCount = postAttrRepository.incrementIntValue(post, LIKES_COUNT, -1).coerceAtLeast(0)
+        var updatedLikesCount = postAttrRepository.incrementIntValue(post, LIKES_COUNT, -1)
+        if (updatedLikesCount < 0) {
+            updatedLikesCount = postAttrRepository.incrementIntValue(post, LIKES_COUNT, -updatedLikesCount)
+        }
         applyLikesCount(post, updatedLikesCount)
     }
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostHydrationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostHydrationService.kt
@@ -1,0 +1,64 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.domain.shared.MemberAttr
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_IMG_URL
+import com.back.boundedContexts.post.application.port.output.MemberAttrRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
+import com.back.boundedContexts.post.domain.POSTS_COUNT
+import com.back.boundedContexts.post.domain.POST_COMMENTS_COUNT
+import com.back.boundedContexts.post.domain.Post
+import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
+import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
+import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
+import org.springframework.stereotype.Service
+
+@Service
+class PostHydrationService(
+    private val postAttrRepository: PostAttrRepositoryPort,
+    private val memberAttrRepository: MemberAttrRepositoryPort,
+) {
+    fun hydratePostAttrs(post: Post) {
+        post.likesCountAttr ?: postAttrRepository.findBySubjectAndName(post, LIKES_COUNT)?.let { post.likesCountAttr = it }
+        post.commentsCountAttr ?: postAttrRepository.findBySubjectAndName(post, COMMENTS_COUNT)?.let { post.commentsCountAttr = it }
+        post.hitCountAttr ?: postAttrRepository.findBySubjectAndName(post, HIT_COUNT)?.let { post.hitCountAttr = it }
+    }
+
+    fun hydratePostAttrs(posts: List<Post>) {
+        if (posts.isEmpty()) return
+
+        val attrsByKey =
+            postAttrRepository
+                .findBySubjectInAndNameIn(posts, listOf(LIKES_COUNT, COMMENTS_COUNT, HIT_COUNT))
+                .associateBy { "${it.subject.id}:${it.name}" }
+
+        posts.forEach { post ->
+            post.likesCountAttr = post.likesCountAttr ?: attrsByKey["${post.id}:$LIKES_COUNT"]
+            post.commentsCountAttr = post.commentsCountAttr ?: attrsByKey["${post.id}:$COMMENTS_COUNT"]
+            post.hitCountAttr = post.hitCountAttr ?: attrsByKey["${post.id}:$HIT_COUNT"]
+        }
+    }
+
+    fun hydrateMemberCounterAttrs(member: Member) {
+        member.postsCountAttr ?: memberAttrRepository.findBySubjectAndName(member, POSTS_COUNT)?.let { member.postsCountAttr = it }
+        member.postCommentsCountAttr ?: memberAttrRepository
+            .findBySubjectAndName(member, POST_COMMENTS_COUNT)
+            ?.let { member.postCommentsCountAttr = it }
+    }
+
+    fun hydrateMembersProfileImgAttrs(members: List<Member>) {
+        if (members.isEmpty()) return
+
+        val uniqueMembers = members.distinctBy { it.id }
+        val profileAttrsByMemberId =
+            memberAttrRepository
+                .findBySubjectInAndNameIn(uniqueMembers, listOf(PROFILE_IMG_URL))
+                .associateBy { it.subject.id }
+
+        uniqueMembers.forEach { member ->
+            member.getOrInitProfileImgUrlAttr {
+                profileAttrsByMemberId[member.id] ?: MemberAttr(0, member, PROFILE_IMG_URL, "")
+            }
+        }
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostHydrationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostHydrationService.kt
@@ -55,7 +55,7 @@ class PostHydrationService(
                 .findBySubjectInAndNameIn(uniqueMembers, listOf(PROFILE_IMG_URL))
                 .associateBy { it.subject.id }
 
-        uniqueMembers.forEach { member ->
+        members.forEach { member ->
             member.getOrInitProfileImgUrlAttr {
                 profileAttrsByMemberId[member.id] ?: MemberAttr(0, member, PROFILE_IMG_URL, "")
             }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostInteractionSideEffectQueue.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostInteractionSideEffectQueue.kt
@@ -1,0 +1,139 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.dto.MemberDto
+import com.back.boundedContexts.post.dto.PostCommentDto
+import com.back.boundedContexts.post.dto.PostDto
+import com.back.boundedContexts.post.event.PostCommentDeletedEvent
+import com.back.boundedContexts.post.event.PostCommentModifiedEvent
+import com.back.boundedContexts.post.event.PostCommentWrittenEvent
+import com.back.boundedContexts.post.event.PostLikedEvent
+import com.back.boundedContexts.post.event.PostUnlikedEvent
+import com.back.global.task.application.TaskFacade
+import com.back.standard.dto.EventPayload
+import org.springframework.stereotype.Service
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+@Service
+class PostInteractionSideEffectQueue(
+    private val taskFacade: TaskFacade,
+) {
+    fun enqueue(
+        postId: Long,
+        recommendationAction: PostInteractionRecommendationSideEffect = PostInteractionRecommendationSideEffect.NONE,
+        domainEvent: EventPayload? = null,
+        operationUid: UUID = UUID.randomUUID(),
+    ) {
+        if (domainEvent != null && recommendationAction != PostInteractionRecommendationSideEffect.NONE) {
+            addTask(
+                postId = postId,
+                recommendationAction = PostInteractionRecommendationSideEffect.NONE,
+                domainEvent = domainEvent,
+                operationUid = operationUid,
+            )
+            addTask(
+                postId = postId,
+                recommendationAction = recommendationAction,
+                domainEvent = null,
+                operationUid = refreshTaskUid(domainEvent),
+            )
+            return
+        }
+
+        addTask(
+            postId = postId,
+            recommendationAction = recommendationAction,
+            domainEvent = domainEvent,
+            operationUid = operationUid,
+        )
+    }
+
+    private fun addTask(
+        postId: Long,
+        recommendationAction: PostInteractionRecommendationSideEffect,
+        domainEvent: EventPayload?,
+        operationUid: UUID,
+    ) {
+        taskFacade.addToQueue(
+            PostInteractionSideEffectPayload(
+                uid = taskUid(domainEvent, operationUid),
+                aggregateType = domainEvent?.aggregateType ?: "Post",
+                aggregateId = domainEvent?.aggregateId ?: postId,
+                postId = postId,
+                recommendationAction = recommendationAction,
+                domainEventUid = domainEvent?.uid,
+                domainEventType = domainEvent?.javaClass?.name,
+                postCommentDto = commentDto(domainEvent),
+                postDto = postDto(domainEvent),
+                actorDto = actorDto(domainEvent),
+                replyReceiverId = replyReceiverId(domainEvent),
+                postAuthorId = postAuthorId(domainEvent),
+                likeId = likeId(domainEvent),
+            ),
+            inlineWhenEnabled = false,
+        )
+    }
+
+    private fun refreshTaskUid(domainEvent: EventPayload): UUID =
+        UUID.nameUUIDFromBytes(
+            "${PostInteractionSideEffectPayload.TASK_TYPE}:refresh:${domainEvent.uid}".toByteArray(
+                StandardCharsets.UTF_8,
+            ),
+        )
+
+    private fun commentDto(domainEvent: EventPayload?): PostCommentDto? =
+        when (domainEvent) {
+            is PostCommentWrittenEvent -> domainEvent.postCommentDto
+            is PostCommentModifiedEvent -> domainEvent.postCommentDto
+            is PostCommentDeletedEvent -> domainEvent.postCommentDto
+            else -> null
+        }
+
+    private fun postDto(domainEvent: EventPayload?): PostDto? =
+        when (domainEvent) {
+            is PostCommentWrittenEvent -> domainEvent.postDto
+            is PostCommentModifiedEvent -> domainEvent.postDto
+            is PostCommentDeletedEvent -> domainEvent.postDto
+            else -> null
+        }
+
+    private fun actorDto(domainEvent: EventPayload?): MemberDto? =
+        when (domainEvent) {
+            is PostCommentWrittenEvent -> domainEvent.actorDto
+            is PostCommentModifiedEvent -> domainEvent.actorDto
+            is PostCommentDeletedEvent -> domainEvent.actorDto
+            is PostLikedEvent -> domainEvent.actorDto
+            is PostUnlikedEvent -> domainEvent.actorDto
+            else -> null
+        }
+
+    private fun replyReceiverId(domainEvent: EventPayload?): Long? =
+        when (domainEvent) {
+            is PostCommentWrittenEvent -> domainEvent.replyReceiverId
+            else -> null
+        }
+
+    private fun postAuthorId(domainEvent: EventPayload?): Long? =
+        when (domainEvent) {
+            is PostLikedEvent -> domainEvent.postAuthorId
+            is PostUnlikedEvent -> domainEvent.postAuthorId
+            else -> null
+        }
+
+    private fun likeId(domainEvent: EventPayload?): Long? =
+        when (domainEvent) {
+            is PostLikedEvent -> domainEvent.likeId
+            is PostUnlikedEvent -> domainEvent.likeId
+            else -> null
+        }
+
+    private fun taskUid(
+        domainEvent: EventPayload?,
+        operationUid: UUID,
+    ): UUID {
+        val eventUid = domainEvent?.uid ?: return operationUid
+        return UUID.nameUUIDFromBytes(
+            "${PostInteractionSideEffectPayload.TASK_TYPE}:$eventUid".toByteArray(StandardCharsets.UTF_8),
+        )
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostLikeApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostLikeApplicationService.kt
@@ -1,0 +1,157 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.dto.MemberDto
+import com.back.boundedContexts.post.application.port.output.PostLikeRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.boundedContexts.post.domain.Post
+import com.back.boundedContexts.post.domain.postMixin.PostLikeToggleResult
+import com.back.boundedContexts.post.event.PostLikedEvent
+import com.back.boundedContexts.post.event.PostUnlikedEvent
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class PostLikeApplicationService(
+    private val postRepository: PostRepositoryPort,
+    private val postLikeRepository: PostLikeRepositoryPort,
+    private val postHydrationService: PostHydrationService,
+    private val postCounterService: PostCounterService,
+    private val postInteractionSideEffectQueue: PostInteractionSideEffectQueue,
+) {
+    @Transactional
+    fun like(
+        post: Post,
+        actor: Member,
+    ): PostLikeToggleResult {
+        val persistenceActor = actor.toPersistenceMember()
+        postHydrationService.hydratePostAttrs(post)
+        val insertedLikeId = postLikeRepository.insertIfAbsent(persistenceActor, post)
+
+        if (insertedLikeId == null) {
+            val existingLike = postLikeRepository.findByLikerAndPost(persistenceActor, post)
+            if (existingLike != null) {
+                postCounterService.ensureLikesCountLoaded(post)
+                return PostLikeToggleResult(true, existingLike.id)
+            }
+
+            val recoveredLikeId = postLikeRepository.insertIfAbsent(persistenceActor, post)
+            if (recoveredLikeId == null) {
+                postCounterService.syncLikesCount(post)
+                return PostLikeToggleResult(
+                    isLiked = postLikeRepository.existsByLikerAndPost(persistenceActor, post),
+                    likeId = 0L,
+                )
+            }
+
+            postCounterService.incrementLikesCount(post)
+            postRepository.flush()
+            enqueueLiked(post, actor, recoveredLikeId)
+            return PostLikeToggleResult(true, recoveredLikeId)
+        }
+
+        postCounterService.incrementLikesCount(post)
+        postRepository.flush()
+        enqueueLiked(post, actor, insertedLikeId)
+
+        return PostLikeToggleResult(true, insertedLikeId)
+    }
+
+    @Transactional
+    fun unlike(
+        post: Post,
+        actor: Member,
+    ): PostLikeToggleResult {
+        val persistenceActor = actor.toPersistenceMember()
+        postHydrationService.hydratePostAttrs(post)
+        val existingLike = postLikeRepository.findByLikerAndPost(persistenceActor, post)
+        val postAuthorId = post.author.id
+        val existingLikeId = existingLike?.id
+        val deletedCount = postLikeRepository.deleteByLikerAndPost(persistenceActor, post)
+        if (deletedCount > 1) {
+            postCounterService.syncLikesCount(post)
+        } else if (deletedCount == 1) {
+            postCounterService.decrementLikesCount(post)
+        } else {
+            postCounterService.ensureLikesCountLoaded(post)
+        }
+        postRepository.flush()
+
+        if (deletedCount > 0 && existingLikeId != null) {
+            postInteractionSideEffectQueue.enqueue(
+                postId = post.id,
+                recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
+                domainEvent = PostUnlikedEvent(UUID.randomUUID(), post.id, postAuthorId, existingLikeId, MemberDto(actor)),
+            )
+        } else {
+            postInteractionSideEffectQueue.enqueue(
+                postId = post.id,
+                recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
+            )
+        }
+
+        return PostLikeToggleResult(false, existingLikeId ?: 0L)
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun reconcileLikeState(
+        post: Post,
+        actor: Member,
+    ): PostLikeToggleResult {
+        val persistenceActor = actor.toPersistenceMember()
+        postHydrationService.hydratePostAttrs(post)
+        postCounterService.syncLikesCount(post)
+        val existingLike = postLikeRepository.findByLikerAndPost(persistenceActor, post)
+        return PostLikeToggleResult(
+            isLiked = existingLike != null,
+            likeId = existingLike?.id ?: 0L,
+        )
+    }
+
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+    fun readLikeSnapshot(
+        post: Post,
+        actor: Member,
+    ): PostLikeToggleResult {
+        val persistenceActor = actor.toPersistenceMember()
+        post.likesCount = postLikeRepository.countByPost(post).toInt()
+        val existingLike = postLikeRepository.findByLikerAndPost(persistenceActor, post)
+        return PostLikeToggleResult(
+            isLiked = existingLike != null,
+            likeId = existingLike?.id ?: 0L,
+        )
+    }
+
+    fun isLiked(
+        post: Post,
+        liker: Member?,
+    ): Boolean {
+        if (liker == null) return false
+        return postLikeRepository.existsByLikerAndPost(liker.toPersistenceMember(), post)
+    }
+
+    fun findLikedPostIds(
+        liker: Member?,
+        posts: List<Post>,
+    ): Set<Long> {
+        if (liker == null || posts.isEmpty()) return emptySet()
+        return postLikeRepository
+            .findByLikerAndPostIn(liker.toPersistenceMember(), posts)
+            .map { it.post.id }
+            .toSet()
+    }
+
+    private fun enqueueLiked(
+        post: Post,
+        actor: Member,
+        likeId: Long,
+    ) {
+        postInteractionSideEffectQueue.enqueue(
+            postId = post.id,
+            recommendationAction = PostInteractionRecommendationSideEffect.REFRESH,
+            domainEvent = PostLikedEvent(UUID.randomUUID(), post.id, post.author.id, likeId, MemberDto(actor)),
+        )
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostMemberPersistenceSupport.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostMemberPersistenceSupport.kt
@@ -1,0 +1,6 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.domain.shared.MemberProxy
+
+internal fun Member.toPersistenceMember(): Member = if (this is MemberProxy) persistenceMember else this

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostTagIndexService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostTagIndexService.kt
@@ -1,0 +1,127 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostTagIndexRepositoryPort
+import com.back.boundedContexts.post.domain.Post
+import com.back.boundedContexts.post.domain.PostAttr
+import com.back.boundedContexts.post.domain.postMixin.META_TAGS_INDEX
+import com.back.boundedContexts.post.dto.PostMetaExtractor
+import com.back.boundedContexts.post.dto.TagCountDto
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.util.concurrent.ConcurrentHashMap
+
+@Service
+class PostTagIndexService(
+    private val postRepository: PostRepositoryPort,
+    private val postTagIndexRepository: PostTagIndexRepositoryPort,
+    private val postAttrRepository: PostAttrRepositoryPort,
+    @param:Value("\${custom.post.read.tags-local-cache-ttl-seconds:180}")
+    tagsLocalCacheTtlSeconds: Long,
+) {
+    private val logger = LoggerFactory.getLogger(PostTagIndexService::class.java)
+
+    private data class TagCountsCache(
+        val expiresAtMillis: Long,
+        val values: List<TagCountDto>,
+    )
+
+    @Volatile
+    private var publicTagCountsCache: TagCountsCache? = null
+
+    private val tagCacheTtlMillis: Long = tagsLocalCacheTtlSeconds.coerceAtLeast(5) * 1_000
+
+    fun getPublicTagCounts(): List<TagCountDto> {
+        val now = System.currentTimeMillis()
+        publicTagCountsCache?.takeIf { it.expiresAtMillis > now }?.let { return it.values }
+
+        synchronized(this) {
+            val refreshedNow = System.currentTimeMillis()
+            publicTagCountsCache?.takeIf { it.expiresAtMillis > refreshedNow }?.let { return it.values }
+
+            val result =
+                runCatching {
+                    postTagIndexRepository.findAllPublicTagCounts().map { row ->
+                        TagCountDto(row.tag, row.count)
+                    }
+                }.getOrElse { exception ->
+                    logger.warn(
+                        "public_tag_counts_query_failed: fallback to legacy metaTagsIndex path",
+                        exception,
+                    )
+                    loadPublicTagCountsFromMetaTagIndex()
+                }
+
+            publicTagCountsCache = TagCountsCache(refreshedNow + tagCacheTtlMillis, result)
+            return result
+        }
+    }
+
+    fun evictPublicTagCountsCache() {
+        publicTagCountsCache = null
+    }
+
+    fun syncMetaTagIndexAttr(post: Post) {
+        val normalizedTags = extractNormalizedTags(post.content)
+
+        val indexValue =
+            if (normalizedTags.isEmpty()) {
+                ""
+            } else {
+                normalizedTags.joinToString(separator = "|", prefix = "|", postfix = "|")
+            }
+
+        val tagIndexAttr = postAttrRepository.findBySubjectAndName(post, META_TAGS_INDEX) ?: PostAttr(0, post, META_TAGS_INDEX, "")
+        if ((tagIndexAttr.strValue ?: "") != indexValue) {
+            tagIndexAttr.strValue = indexValue
+            postAttrRepository.save(tagIndexAttr)
+        }
+
+        runCatching {
+            postTagIndexRepository.replacePostTags(post.id, normalizedTags)
+        }.onFailure { exception ->
+            logger.warn("failed_to_sync_post_tag_index postId={}", post.id, exception)
+        }
+    }
+
+    fun extractNormalizedTags(content: String): List<String> =
+        PostMetaExtractor
+            .extract(content)
+            .tags
+            .map(::normalizeTag)
+            .filter(String::isNotBlank)
+            .distinct()
+
+    private fun loadPublicTagCountsFromMetaTagIndex(): List<TagCountDto> {
+        val tagCounts = ConcurrentHashMap<String, Int>()
+        val indexedTagRows = postRepository.findAllPublicListedTagIndexes(META_TAGS_INDEX)
+
+        indexedTagRows.forEach { tagIndex ->
+            parseTagIndex(tagIndex).forEach { normalizedTag ->
+                tagCounts.merge(normalizedTag, 1, Int::plus)
+            }
+        }
+
+        if (indexedTagRows.isEmpty()) {
+            logger.warn(
+                "public_tag_counts_index_empty: skip legacy content-scan fallback to protect DB under load",
+            )
+        }
+
+        return tagCounts
+            .entries
+            .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key.lowercase() })
+            .map { TagCountDto(it.key, it.value) }
+    }
+
+    private fun normalizeTag(tag: String): String = tag.trim()
+
+    private fun parseTagIndex(tagIndex: String): List<String> =
+        tagIndex
+            .split('|')
+            .map(String::trim)
+            .filter(String::isNotBlank)
+            .distinct()
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostTempDraftService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostTempDraftService.kt
@@ -1,0 +1,89 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.domain.shared.MemberAttr
+import com.back.boundedContexts.post.application.port.output.MemberAttrRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.boundedContexts.post.domain.Post
+import com.back.global.exception.application.AppException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.jvm.optionals.getOrNull
+
+@Service
+class PostTempDraftService(
+    private val postRepository: PostRepositoryPort,
+    private val memberAttrRepository: MemberAttrRepositoryPort,
+) {
+    private val activeTempDraftPostIdAttrName = "activeTempDraftPostId"
+    private val activeTempDraftLockAttrName = "activeTempDraftLock"
+
+    fun findTemp(author: Member): Post? {
+        val persistenceAuthor = author.toPersistenceMember()
+        return resolveTrackedTempPost(persistenceAuthor) ?: findLegacyTemp(persistenceAuthor)
+    }
+
+    @Transactional
+    fun getOrCreateTemp(author: Member): Pair<Post, Boolean> {
+        val persistenceAuthor = author.toPersistenceMember()
+        if (!tryAcquireTempDraftLock(persistenceAuthor)) {
+            throw AppException("409-2", "다른 탭에서 임시글을 준비 중입니다. 잠시 후 다시 시도해주세요.")
+        }
+
+        return try {
+            val existingTemp = resolveTrackedTempPost(persistenceAuthor) ?: findLegacyTemp(persistenceAuthor)
+            if (existingTemp != null) {
+                updateTempDraftMarker(persistenceAuthor, existingTemp.id)
+                postRepository.flush()
+                existingTemp to false
+            } else {
+                val newPost = postRepository.save(Post(0, persistenceAuthor, "임시글", "임시글 입니다."))
+                updateTempDraftMarker(persistenceAuthor, newPost.id)
+                postRepository.flush()
+                newPost to true
+            }
+        } finally {
+            releaseTempDraftLock(persistenceAuthor)
+        }
+    }
+
+    fun isTempDraft(post: Post): Boolean = resolveTrackedTempPostId(post.author) == post.id
+
+    fun updateTempDraftMarker(
+        author: Member,
+        postId: Long?,
+    ) {
+        val attr =
+            memberAttrRepository.findBySubjectAndName(author, activeTempDraftPostIdAttrName)
+                ?: MemberAttr(0, author, activeTempDraftPostIdAttrName, "")
+        attr.strValue = postId?.toString().orEmpty()
+        memberAttrRepository.save(attr)
+    }
+
+    private fun findLegacyTemp(author: Member): Post? = postRepository.findFirstByAuthorAndTitleAndPublishedFalseOrderByIdAsc(author, "임시글")
+
+    private fun resolveTrackedTempPost(author: Member): Post? {
+        val trackedPostId = resolveTrackedTempPostId(author) ?: return null
+        val trackedPost = postRepository.findById(trackedPostId).getOrNull() ?: return null
+        return trackedPost.takeIf { it.author.id == author.id }
+    }
+
+    private fun resolveTrackedTempPostId(author: Member): Long? =
+        memberAttrRepository
+            .findBySubjectAndName(author, activeTempDraftPostIdAttrName)
+            ?.strValue
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?.toLongOrNull()
+
+    private fun tryAcquireTempDraftLock(author: Member): Boolean {
+        val lockValue = memberAttrRepository.incrementIntValue(author, activeTempDraftLockAttrName, 1)
+        if (lockValue == 1) return true
+        memberAttrRepository.incrementIntValue(author, activeTempDraftLockAttrName, -1)
+        return false
+    }
+
+    private fun releaseTempDraftLock(author: Member) {
+        memberAttrRepository.incrementIntValue(author, activeTempDraftLockAttrName, -1)
+    }
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationServiceDeleteResilienceTest.kt
@@ -98,25 +98,56 @@ class PostApplicationServiceDeleteResilienceTest {
             environment = MockEnvironment().also { it.setActiveProfiles("test") },
             inlineWhenNotProd = false,
         )
+    private val postHydrationService = PostHydrationService(postAttrRepository, memberAttrRepository)
+    private val postCounterService =
+        PostCounterService(
+            postRepository = postRepository,
+            postAttrRepository = postAttrRepository,
+            memberAttrRepository = memberAttrRepository,
+            postLikeRepository = postLikeRepository,
+        )
+    private val postTagIndexService =
+        PostTagIndexService(
+            postRepository = postRepository,
+            postTagIndexRepository = postTagIndexRepository,
+            postAttrRepository = postAttrRepository,
+            tagsLocalCacheTtlSeconds = 180,
+        )
+    private val postTempDraftService = PostTempDraftService(postRepository, memberAttrRepository)
+    private val postInteractionSideEffectQueue = PostInteractionSideEffectQueue(taskFacade)
+    private val postCommentApplicationService =
+        PostCommentApplicationService(
+            postRepository = postRepository,
+            postCommentRepository = postCommentRepository,
+            postHydrationService = postHydrationService,
+            postCounterService = postCounterService,
+            postInteractionSideEffectQueue = postInteractionSideEffectQueue,
+        )
+    private val postLikeApplicationService =
+        PostLikeApplicationService(
+            postRepository = postRepository,
+            postLikeRepository = postLikeRepository,
+            postHydrationService = postHydrationService,
+            postCounterService = postCounterService,
+            postInteractionSideEffectQueue = postInteractionSideEffectQueue,
+        )
 
     private val service =
         PostApplicationService(
             postRepository = postRepository,
-            postTagIndexRepository = postTagIndexRepository,
-            postAttrRepository = postAttrRepository,
-            memberAttrRepository = memberAttrRepository,
-            postCommentRepository = postCommentRepository,
-            postLikeRepository = postLikeRepository,
             postWriteRequestIdempotencyRepository = postWriteRequestIdempotencyRepository,
             secureTipPort = secureTipPort,
-            eventPublisher = eventPublisher,
             uploadedFileRetentionService = uploadedFileRetentionService,
             postRecommendRankingService = postRecommendRankingService,
-            postRecommendFeatureStoreService = postRecommendFeatureStoreService,
             postKeywordSearchPipelineService = postKeywordSearchPipelineService,
             taskFacade = taskFacade,
             objectMapper = objectMapper,
-            tagsLocalCacheTtlSeconds = 180,
+            postHydrationService = postHydrationService,
+            postCounterService = postCounterService,
+            postTagIndexService = postTagIndexService,
+            postTempDraftService = postTempDraftService,
+            postCommentApplicationService = postCommentApplicationService,
+            postLikeApplicationService = postLikeApplicationService,
         )
 
     @Test

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationUseCaseCollaboratorTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationUseCaseCollaboratorTest.kt
@@ -2,6 +2,7 @@ package com.back.boundedContexts.post.application.service
 
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.domain.shared.MemberAttr
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_IMG_URL
 import com.back.boundedContexts.post.application.port.output.MemberAttrRepositoryPort
 import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
 import com.back.boundedContexts.post.application.port.output.PostCommentRepositoryPort
@@ -23,6 +24,7 @@ import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
 import org.mockito.Mockito.any
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import java.time.Instant
 import java.util.Optional
 
@@ -53,17 +55,21 @@ class PostApplicationUseCaseCollaboratorTest {
         post.likesCountAttr = likesAttr
         given(postLikeRepository.countByPost(post)).willReturn(7)
         given(postAttrRepository.save(likesAttr)).willReturn(likesAttr)
+        given(postAttrRepository.incrementIntValue(post, LIKES_COUNT, -1)).willReturn(-2)
+        given(postAttrRepository.incrementIntValue(post, LIKES_COUNT, 2)).willReturn(0)
         given(memberAttrRepository.incrementIntValue(member, POSTS_COUNT, -1)).willReturn(-2)
         given(memberAttrRepository.incrementIntValue(member, POSTS_COUNT, 2)).willReturn(0)
 
         // when
         service.syncLikesCount(post)
+        service.decrementLikesCount(post)
         service.decrementMemberPostsCount(member)
 
         // then
-        assertThat(post.likesCount).isEqualTo(7)
-        assertThat(likesAttr.intValue).isEqualTo(7)
+        assertThat(post.likesCount).isZero()
+        assertThat(likesAttr.intValue).isZero()
         then(postAttrRepository).should().save(likesAttr)
+        then(postAttrRepository).should().incrementIntValue(post, LIKES_COUNT, 2)
         then(memberAttrRepository).should().incrementIntValue(member, POSTS_COUNT, 2)
     }
 
@@ -208,6 +214,27 @@ class PostApplicationUseCaseCollaboratorTest {
     }
 
     @Test
+    @DisplayName("PostHydrationService는 중복 member id 입력에도 모든 인스턴스에 profile image attr을 주입한다")
+    fun postHydrationServiceHydratesEveryDuplicateMemberInstance() {
+        // given
+        val postAttrRepository: PostAttrRepositoryPort = mock(PostAttrRepositoryPort::class.java)
+        val memberAttrRepository: MemberAttrRepositoryPort = mock(MemberAttrRepositoryPort::class.java)
+        val service = PostHydrationService(postAttrRepository, memberAttrRepository)
+        val first = testMember(id = 3)
+        val second = testMember(id = 3)
+        val persistedAttr = MemberAttr(1, first, PROFILE_IMG_URL, "https://example.com/profile.png")
+        given(memberAttrRepository.findBySubjectInAndNameIn(listOf(first), listOf(PROFILE_IMG_URL)))
+            .willReturn(listOf(persistedAttr))
+
+        // when
+        service.hydrateMembersProfileImgAttrs(listOf(first, second))
+
+        // then
+        assertThat(first.profileImgUrl).isEqualTo("https://example.com/profile.png")
+        assertThat(second.profileImgUrl).isEqualTo("https://example.com/profile.png")
+    }
+
+    @Test
     @DisplayName("PostCommentApplicationService는 parentComment 생략 시 새 댓글을 저장한다")
     fun postCommentApplicationServiceWritesRootCommentWithDefaultParent() {
         // given
@@ -242,6 +269,35 @@ class PostApplicationUseCaseCollaboratorTest {
         assertThat(comment.content).isEqualTo("댓글")
         then(counterService).should().incrementCommentsCount(post)
         then(counterService).should().incrementMemberPostCommentsCount(author)
+    }
+
+    @Test
+    @DisplayName("PostCommentApplicationService는 부모 댓글을 현재 게시글에서 찾지 못하면 저장하지 않는다")
+    fun postCommentApplicationServiceRejectsMissingParentComment() {
+        // given
+        val postRepository: PostRepositoryPort = mock(PostRepositoryPort::class.java)
+        val postCommentRepository: PostCommentRepositoryPort = mock(PostCommentRepositoryPort::class.java)
+        val hydrationService: PostHydrationService = mock(PostHydrationService::class.java)
+        val counterService: PostCounterService = mock(PostCounterService::class.java)
+        val sideEffectQueue: PostInteractionSideEffectQueue = mock(PostInteractionSideEffectQueue::class.java)
+        val service =
+            PostCommentApplicationService(
+                postRepository = postRepository,
+                postCommentRepository = postCommentRepository,
+                postHydrationService = hydrationService,
+                postCounterService = counterService,
+                postInteractionSideEffectQueue = sideEffectQueue,
+            )
+        val author = testMember(id = 2)
+        val post = testPost()
+        val parentComment = PostComment(99, author, post, "부모 댓글")
+        given(postCommentRepository.findByPostAndId(post, parentComment.id)).willReturn(null)
+
+        // when / then
+        assertThatThrownBy { service.writeComment(author, post, "대댓글", parentComment) }
+            .isInstanceOf(AppException::class.java)
+            .hasMessageContaining("부모 댓글을 찾을 수 없습니다.")
+        then(postCommentRepository).should(never()).save(anyValue())
     }
 
     private fun testMember(id: Long = 1): Member =

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationUseCaseCollaboratorTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationUseCaseCollaboratorTest.kt
@@ -1,0 +1,276 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.domain.shared.MemberAttr
+import com.back.boundedContexts.post.application.port.output.MemberAttrRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostCommentRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostLikeRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.boundedContexts.post.domain.POSTS_COUNT
+import com.back.boundedContexts.post.domain.Post
+import com.back.boundedContexts.post.domain.PostAttr
+import com.back.boundedContexts.post.domain.PostComment
+import com.back.boundedContexts.post.domain.PostLike
+import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
+import com.back.global.app.AppConfig
+import com.back.global.exception.application.AppException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.then
+import org.mockito.Mockito.any
+import org.mockito.Mockito.mock
+import java.time.Instant
+import java.util.Optional
+
+@DisplayName("PostApplicationService collaborator 분리 테스트")
+class PostApplicationUseCaseCollaboratorTest {
+    init {
+        AppConfig(
+            siteBackUrl = "http://localhost:8080",
+            siteFrontUrl = "http://localhost:3000",
+            adminUsername = "admin",
+            adminEmail = "admin@example.com",
+            adminPassword = "password",
+        )
+    }
+
+    @Test
+    @DisplayName("PostCounterService는 좋아요 수 재동기화와 member posts 음수 보정을 처리한다")
+    fun postCounterServiceRepairsCounts() {
+        // given
+        val postRepository: PostRepositoryPort = mock(PostRepositoryPort::class.java)
+        val postAttrRepository: PostAttrRepositoryPort = mock(PostAttrRepositoryPort::class.java)
+        val memberAttrRepository: MemberAttrRepositoryPort = mock(MemberAttrRepositoryPort::class.java)
+        val postLikeRepository: PostLikeRepositoryPort = mock(PostLikeRepositoryPort::class.java)
+        val service = PostCounterService(postRepository, postAttrRepository, memberAttrRepository, postLikeRepository)
+        val post = testPost()
+        val likesAttr = PostAttr(1, post, LIKES_COUNT, 0)
+        val member = testMember()
+        post.likesCountAttr = likesAttr
+        given(postLikeRepository.countByPost(post)).willReturn(7)
+        given(postAttrRepository.save(likesAttr)).willReturn(likesAttr)
+        given(memberAttrRepository.incrementIntValue(member, POSTS_COUNT, -1)).willReturn(-2)
+        given(memberAttrRepository.incrementIntValue(member, POSTS_COUNT, 2)).willReturn(0)
+
+        // when
+        service.syncLikesCount(post)
+        service.decrementMemberPostsCount(member)
+
+        // then
+        assertThat(post.likesCount).isEqualTo(7)
+        assertThat(likesAttr.intValue).isEqualTo(7)
+        then(postAttrRepository).should().save(likesAttr)
+        then(memberAttrRepository).should().incrementIntValue(member, POSTS_COUNT, 2)
+    }
+
+    @Test
+    @DisplayName("PostCounterService는 member posts 실제 개수로 신규 attr을 보정한다")
+    fun postCounterServiceReconcilesMissingMemberAttr() {
+        // given
+        val postRepository: PostRepositoryPort = mock(PostRepositoryPort::class.java)
+        val postAttrRepository: PostAttrRepositoryPort = mock(PostAttrRepositoryPort::class.java)
+        val memberAttrRepository: MemberAttrRepositoryPort = mock(MemberAttrRepositoryPort::class.java)
+        val postLikeRepository: PostLikeRepositoryPort = mock(PostLikeRepositoryPort::class.java)
+        val service = PostCounterService(postRepository, postAttrRepository, memberAttrRepository, postLikeRepository)
+        val member = testMember()
+        given(postRepository.countByAuthor(member)).willReturn(3)
+        given(memberAttrRepository.findBySubjectAndName(member, POSTS_COUNT)).willReturn(null)
+        given(memberAttrRepository.save(anyValue())).willAnswer { it.arguments[0] as MemberAttr }
+
+        // when
+        service.reconcileMemberPostsCount(member)
+
+        // then
+        assertThat(member.postsCountAttr?.intValue).isEqualTo(3)
+        then(memberAttrRepository).should().save(member.postsCountAttr!!)
+    }
+
+    @Test
+    @DisplayName("PostTempDraftService는 tracked temp 조회와 lock 경쟁 실패를 처리한다")
+    fun postTempDraftServiceFindsTrackedTempAndRejectsLockContention() {
+        // given
+        val postRepository: PostRepositoryPort = mock(PostRepositoryPort::class.java)
+        val memberAttrRepository: MemberAttrRepositoryPort = mock(MemberAttrRepositoryPort::class.java)
+        val service = PostTempDraftService(postRepository, memberAttrRepository)
+        val author = testMember()
+        val tempPost = testPost(author = author)
+        val marker = MemberAttr(1, author, "activeTempDraftPostId", tempPost.id.toString())
+        given(memberAttrRepository.findBySubjectAndName(author, "activeTempDraftPostId")).willReturn(marker)
+        given(postRepository.findById(tempPost.id)).willReturn(Optional.of(tempPost))
+        given(memberAttrRepository.incrementIntValue(author, "activeTempDraftLock", 1)).willReturn(2)
+
+        // when
+        val found = service.findTemp(author)
+
+        // then
+        assertThat(found).isSameAs(tempPost)
+        assertThatThrownBy { service.getOrCreateTemp(author) }
+            .isInstanceOf(AppException::class.java)
+            .hasMessageContaining("다른 탭")
+        then(memberAttrRepository).should().incrementIntValue(author, "activeTempDraftLock", -1)
+    }
+
+    @Test
+    @DisplayName("PostLikeApplicationService는 insert 경쟁 복구 성공/실패와 중복 unlike 보정을 처리한다")
+    fun postLikeApplicationServiceHandlesRaceRecoveryBranches() {
+        // given
+        val postRepository: PostRepositoryPort = mock(PostRepositoryPort::class.java)
+        val postLikeRepository: PostLikeRepositoryPort = mock(PostLikeRepositoryPort::class.java)
+        val hydrationService: PostHydrationService = mock(PostHydrationService::class.java)
+        val counterService: PostCounterService = mock(PostCounterService::class.java)
+        val sideEffectQueue: PostInteractionSideEffectQueue = mock(PostInteractionSideEffectQueue::class.java)
+        val service =
+            PostLikeApplicationService(
+                postRepository = postRepository,
+                postLikeRepository = postLikeRepository,
+                postHydrationService = hydrationService,
+                postCounterService = counterService,
+                postInteractionSideEffectQueue = sideEffectQueue,
+            )
+        val actor = testMember(id = 2)
+        val post = testPost()
+        given(postLikeRepository.insertIfAbsent(actor, post)).willReturn(null, 99)
+        given(postLikeRepository.findByLikerAndPost(actor, post)).willReturn(null)
+
+        // when
+        val recovered = service.like(post, actor)
+
+        // then
+        assertThat(recovered.isLiked).isTrue()
+        assertThat(recovered.likeId).isEqualTo(99)
+        then(counterService).should().incrementLikesCount(post)
+        then(postRepository).should().flush()
+
+        // given
+        val secondPost = testPost(id = 11)
+        given(postLikeRepository.insertIfAbsent(actor, secondPost)).willReturn(null, null)
+        given(postLikeRepository.findByLikerAndPost(actor, secondPost)).willReturn(null)
+        given(postLikeRepository.existsByLikerAndPost(actor, secondPost)).willReturn(true)
+
+        // when
+        val failedRecovery = service.like(secondPost, actor)
+
+        // then
+        assertThat(failedRecovery.isLiked).isTrue()
+        assertThat(failedRecovery.likeId).isZero()
+        then(counterService).should().syncLikesCount(secondPost)
+
+        // given
+        val like = PostLike(55, actor, post)
+        given(postLikeRepository.findByLikerAndPost(actor, post)).willReturn(like)
+        given(postLikeRepository.deleteByLikerAndPost(actor, post)).willReturn(2)
+
+        // when
+        val unliked = service.unlike(post, actor)
+
+        // then
+        assertThat(unliked.isLiked).isFalse()
+        assertThat(unliked.likeId).isEqualTo(55)
+        then(counterService).should().syncLikesCount(post)
+    }
+
+    @Test
+    @DisplayName("PostLikeApplicationService는 reconcile과 snapshot 조회를 별도 transaction 경로에서 반환한다")
+    fun postLikeApplicationServiceReadsReconcileAndSnapshot() {
+        // given
+        val postRepository: PostRepositoryPort = mock(PostRepositoryPort::class.java)
+        val postLikeRepository: PostLikeRepositoryPort = mock(PostLikeRepositoryPort::class.java)
+        val hydrationService: PostHydrationService = mock(PostHydrationService::class.java)
+        val counterService: PostCounterService = mock(PostCounterService::class.java)
+        val sideEffectQueue: PostInteractionSideEffectQueue = mock(PostInteractionSideEffectQueue::class.java)
+        val service =
+            PostLikeApplicationService(
+                postRepository = postRepository,
+                postLikeRepository = postLikeRepository,
+                postHydrationService = hydrationService,
+                postCounterService = counterService,
+                postInteractionSideEffectQueue = sideEffectQueue,
+            )
+        val actor = testMember(id = 2)
+        val post = testPost()
+        val like = PostLike(77, actor, post)
+        given(postLikeRepository.findByLikerAndPost(actor, post)).willReturn(like)
+        given(postLikeRepository.countByPost(post)).willReturn(4)
+
+        // when
+        val reconciled = service.reconcileLikeState(post, actor)
+        val snapshot = service.readLikeSnapshot(post, actor)
+
+        // then
+        assertThat(reconciled.likeId).isEqualTo(77)
+        assertThat(snapshot.likeId).isEqualTo(77)
+        assertThat(post.likesCount).isEqualTo(4)
+        then(counterService).should().syncLikesCount(post)
+    }
+
+    @Test
+    @DisplayName("PostCommentApplicationService는 parentComment 생략 시 새 댓글을 저장한다")
+    fun postCommentApplicationServiceWritesRootCommentWithDefaultParent() {
+        // given
+        val postRepository: PostRepositoryPort = mock(PostRepositoryPort::class.java)
+        val postCommentRepository: PostCommentRepositoryPort = mock(PostCommentRepositoryPort::class.java)
+        val hydrationService: PostHydrationService = mock(PostHydrationService::class.java)
+        val counterService: PostCounterService = mock(PostCounterService::class.java)
+        val sideEffectQueue: PostInteractionSideEffectQueue = mock(PostInteractionSideEffectQueue::class.java)
+        val service =
+            PostCommentApplicationService(
+                postRepository = postRepository,
+                postCommentRepository = postCommentRepository,
+                postHydrationService = hydrationService,
+                postCounterService = counterService,
+                postInteractionSideEffectQueue = sideEffectQueue,
+            )
+        val author = testMember(id = 2)
+        val post = testPost()
+        given(postCommentRepository.save(anyValue())).willAnswer {
+            (it.arguments[0] as PostComment).also { comment ->
+                val now = Instant.now()
+                comment.createdAt = now
+                comment.modifiedAt = now
+            }
+        }
+
+        // when
+        val comment = service.writeComment(author, post, "댓글")
+
+        // then
+        assertThat(comment.author.id).isEqualTo(author.id)
+        assertThat(comment.content).isEqualTo("댓글")
+        then(counterService).should().incrementCommentsCount(post)
+        then(counterService).should().incrementMemberPostCommentsCount(author)
+    }
+
+    private fun testMember(id: Long = 1): Member =
+        Member(id = id, username = "user-$id", nickname = "작성자$id", apiKey = "api-key-$id").also {
+            val now = Instant.now()
+            it.createdAt = now
+            it.modifiedAt = now
+        }
+
+    private fun testPost(
+        id: Long = 10,
+        author: Member = testMember(),
+    ): Post =
+        Post(
+            id = id,
+            author = author,
+            title = "제목$id",
+            content = "본문$id",
+            published = true,
+            listed = true,
+        ).also {
+            val now = Instant.now()
+            it.createdAt = now
+            it.modifiedAt = now
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> anyValue(): T {
+        any<T>()
+        return null as T
+    }
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostTagIndexServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostTagIndexServiceTest.kt
@@ -1,0 +1,136 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.post.application.port.output.PostAttrRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostTagIndexRepositoryPort
+import com.back.boundedContexts.post.domain.Post
+import com.back.boundedContexts.post.domain.PostAttr
+import com.back.boundedContexts.post.domain.postMixin.META_TAGS_INDEX
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.then
+import org.mockito.BDDMockito.willThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+
+@DisplayName("PostTagIndexService 테스트")
+class PostTagIndexServiceTest {
+    private val postRepository: PostRepositoryPort = mock(PostRepositoryPort::class.java)
+    private val postTagIndexRepository: PostTagIndexRepositoryPort = mock(PostTagIndexRepositoryPort::class.java)
+    private val postAttrRepository: PostAttrRepositoryPort = mock(PostAttrRepositoryPort::class.java)
+    private val service =
+        PostTagIndexService(
+            postRepository = postRepository,
+            postTagIndexRepository = postTagIndexRepository,
+            postAttrRepository = postAttrRepository,
+            tagsLocalCacheTtlSeconds = 180,
+        )
+
+    @Test
+    @DisplayName("공개 태그 집계는 repository 결과를 캐시하고 명시 evict 뒤 다시 조회한다")
+    fun cachePublicTagCountsUntilEvicted() {
+        // given
+        given(postTagIndexRepository.findAllPublicTagCounts())
+            .willReturn(
+                listOf(
+                    PostTagIndexRepositoryPort.TagCountRow("spring", 3),
+                    PostTagIndexRepositoryPort.TagCountRow("kotlin", 2),
+                ),
+            )
+
+        // when
+        val first = service.getPublicTagCounts()
+        val cached = service.getPublicTagCounts()
+        service.evictPublicTagCountsCache()
+        val refreshed = service.getPublicTagCounts()
+
+        // then
+        assertThat(first.map { it.tag }).containsExactly("spring", "kotlin")
+        assertThat(cached).isSameAs(first)
+        assertThat(refreshed.map { it.count }).containsExactly(3, 2)
+        then(postTagIndexRepository).should(times(2)).findAllPublicTagCounts()
+    }
+
+    @Test
+    @DisplayName("집계 repository 실패 시 legacy metaTagsIndex 값으로 fallback한다")
+    fun fallbackToLegacyTagIndexRows() {
+        // given
+        given(postTagIndexRepository.findAllPublicTagCounts()).willThrow(RuntimeException("aggregate unavailable"))
+        given(postRepository.findAllPublicListedTagIndexes(META_TAGS_INDEX))
+            .willReturn(listOf("|spring|kotlin|", "|spring|", "| kotlin |spring|"))
+
+        // when
+        val result = service.getPublicTagCounts()
+
+        // then
+        assertThat(result.map { it.tag to it.count })
+            .containsExactly("spring" to 3, "kotlin" to 2)
+    }
+
+    @Test
+    @DisplayName("legacy index도 비어 있으면 빈 태그 집계를 반환한다")
+    fun fallbackEmptyLegacyRows() {
+        // given
+        given(postTagIndexRepository.findAllPublicTagCounts()).willThrow(RuntimeException("aggregate unavailable"))
+        given(postRepository.findAllPublicListedTagIndexes(META_TAGS_INDEX)).willReturn(emptyList())
+
+        // when
+        val result = service.getPublicTagCounts()
+
+        // then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    @DisplayName("본문 태그를 attr와 정규화 테이블에 동기화하고 replace 실패는 전파하지 않는다")
+    fun syncMetaTagIndexAttrAndSuppressReplaceFailure() {
+        // given
+        val post = testPost(content = "tags: kotlin, spring, kotlin\n\n본문")
+        val attr = PostAttr(1, post, META_TAGS_INDEX, "")
+        given(postAttrRepository.findBySubjectAndName(post, META_TAGS_INDEX)).willReturn(attr)
+        given(postAttrRepository.save(attr)).willReturn(attr)
+        willThrow(RuntimeException("tag table unavailable"))
+            .given(postTagIndexRepository)
+            .replacePostTags(post.id, listOf("kotlin", "spring"))
+
+        // when
+        service.syncMetaTagIndexAttr(post)
+
+        // then
+        assertThat(attr.strValue).isEqualTo("|kotlin|spring|")
+        then(postAttrRepository).should().save(attr)
+        then(postTagIndexRepository).should().replacePostTags(post.id, listOf("kotlin", "spring"))
+    }
+
+    @Test
+    @DisplayName("태그가 없고 기존 attr 값이 같으면 attr 저장 없이 정규화 테이블만 갱신한다")
+    fun syncEmptyTagsWithoutSavingSameAttr() {
+        // given
+        val post = testPost(content = "본문만 있음")
+        val attr = PostAttr(1, post, META_TAGS_INDEX, "")
+        given(postAttrRepository.findBySubjectAndName(post, META_TAGS_INDEX)).willReturn(attr)
+
+        // when
+        service.syncMetaTagIndexAttr(post)
+
+        // then
+        assertThat(attr.strValue).isEqualTo("")
+        then(postAttrRepository).should().findBySubjectAndName(post, META_TAGS_INDEX)
+        then(postAttrRepository).should(never()).save(attr)
+        then(postTagIndexRepository).should().replacePostTags(post.id, emptyList())
+    }
+
+    private fun testPost(content: String): Post =
+        Post(
+            id = 10,
+            author = Member(id = 1, username = "author", nickname = "작성자", apiKey = "author-api-key"),
+            title = "제목",
+            content = content,
+            published = true,
+            listed = true,
+        )
+}


### PR DESCRIPTION
## 관련 이슈

close #885

## 작업 배경

- `PostApplicationService`가 글 작성/수정/삭제, 댓글, 좋아요, 조회 hydration, 태그 인덱스/캐시, 임시글 lock, 카운터 보정, interaction side effect 큐잉을 한 클래스에서 처리해 변경 영향 범위가 과도하게 넓었습니다.
- controller/usecase의 공개 호출 계약은 유지하면서 내부 책임을 collaborator로 분리해 회귀 원인 추적과 단위 테스트 대상을 명확히 했습니다.

## 작업 내용

- `PostApplicationService`를 기존 public method signature를 유지하는 facade로 축소했습니다.
- 댓글 책임을 `PostCommentApplicationService`로 분리하고, 댓글 작성/수정/삭제의 counter 및 interaction side effect 큐잉 계약을 유지했습니다.
- 좋아요 책임을 `PostLikeApplicationService`로 분리하고, insert 경쟁 복구, 중복 unlike 보정, reconcile/snapshot 경로를 유지했습니다.
- post/member attr hydration, counter 보정, 태그 인덱스/공개 태그 캐시, 임시글 lock/marker, interaction side effect payload 조립을 각각 전담 서비스로 분리했습니다.
- `PostTagIndexServiceTest`, `PostApplicationUseCaseCollaboratorTest`를 추가해 cache/fallback, lock 경쟁, counter 보정, 좋아요 복구 분기, 댓글 기본 parent 경로를 검증했습니다.
- CodeRabbit 리뷰 지적을 반영해 optimistic lock 충돌 로그, 부모 댓글 조회 실패 거절, 좋아요 음수 counter 복구, 중복 member hydration, tag index 실패 신호 계약을 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back compileKotlin` 성공
  - `back/gradlew -p back test --tests '*PostApplicationService*' --tests '*PostComment*' --tests '*PostLike*'` 성공
  - `back/gradlew -p back test --tests '*PostTagIndexServiceTest'` 성공
  - `back/gradlew -p back test --tests '*PostApplicationUseCaseCollaboratorTest'` 성공
  - `back/gradlew -p back test --tests '*PostApplicationService*' --tests '*PostComment*' --tests '*PostLike*' --tests '*PostTagIndexService*'` 성공
  - `back/gradlew -p back ktlintCheck` 성공
  - `back/gradlew -p back ciFastCheck --rerun-tasks` 2회 연속 성공
  - commit hook `OpenApiContractExportTest` 및 `yarn contracts:check` 성공
  - PR #907 원격 backend-ci, frontend-ci, dependency-check, CodeQL, Vercel, CodeRabbit 재검토 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `PostApplicationService` public method signature와 controller/usecase 호출 계약이 유지되는지
  - 댓글/좋아요 side effect task payload가 분리 전과 같은 도메인 이벤트 정보를 담는지
  - `PostTagIndexService` fallback/cache invalidation 경로가 기존 공개 태그 집계 동작과 같은지
  - `PostTempDraftService` lock 실패와 marker clear가 기존 modify/delete 흐름에서 그대로 호출되는지

## 리스크

- 생성자 주입 대상이 늘어난 만큼 수동 조립 테스트는 collaborator를 명시적으로 구성해야 합니다. `PostApplicationServiceDeleteResilienceTest`에 해당 조립을 반영했습니다.
- 태그 서비스의 `@param:Value`는 기존 `PostSearchEngineMirrorService`와 같은 패턴이며 Kotlin compile warning은 발생하지만 빌드/ktlint에는 영향이 없습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
