### PR TITLE
[Fix] cursor explore 빈 tag 캐시 태그 제거

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostPublicReadController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostPublicReadController.kt
@@ -21,6 +21,16 @@ import org.springframework.http.ResponseEntity
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.*
 
+internal fun postExploreCursorSurrogateKeys(normalizedTag: String): Set<String> =
+    buildSet {
+        add(PostCacheTags.LIST)
+        add(PostCacheTags.EXPLORE)
+        add(PostCacheTags.EXPLORE_CURSOR)
+        if (normalizedTag.isNotBlank()) {
+            add(PostCacheTags.byTag(normalizedTag))
+        }
+    }
+
 @RestController
 @RequestMapping("/post/api/v1/posts")
 class ApiV1PostPublicReadController(
@@ -144,13 +154,7 @@ class ApiV1PostPublicReadController(
             request = request,
             response = response,
             cachePolicy = PostPublicReadCachePolicies.EXPLORE_CURSOR,
-            surrogateKeys =
-                setOf(
-                    PostCacheTags.LIST,
-                    PostCacheTags.EXPLORE,
-                    PostCacheTags.EXPLORE_CURSOR,
-                    PostCacheTags.byTag(normalizedTag),
-                ),
+            surrogateKeys = postExploreCursorSurrogateKeys(normalizedTag),
             etagSeed = etagSeed,
             startedAtNanos = startedAtNanos,
             body = data,

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostControllerTest.kt
@@ -4,6 +4,7 @@ import com.back.boundedContexts.member.application.service.ActorApplicationServi
 import com.back.boundedContexts.post.application.service.PostApplicationService
 import com.back.boundedContexts.post.application.service.PostHitDedupService
 import com.back.boundedContexts.post.application.service.PostQueryCacheNames
+import com.back.boundedContexts.post.application.support.PostCacheTags
 import com.back.boundedContexts.post.dto.PublicPostDetailSnapshotCacheDto
 import com.back.global.security.config.AuthCookieNames
 import com.back.standard.dto.post.type1.PostSearchSortType1
@@ -458,6 +459,50 @@ class ApiV1PostControllerTest : BaseControllerIntegrationTest() {
                     match(handler().handlerType(ApiV1PostPublicReadController::class.java))
                     match(handler().methodName("exploreByCursor"))
                 }
+        }
+
+        @Test
+        fun `explore 커서 cache tag는 빈 tag를 tag-specific key로 추가하지 않는다`() {
+            val surrogateKeys = postExploreCursorSurrogateKeys("")
+
+            assertThat(surrogateKeys)
+                .contains(PostCacheTags.EXPLORE_CURSOR)
+                .doesNotContain("post-tag-empty")
+        }
+
+        @Test
+        fun `explore 커서 조회는 tag filter가 있으면 tag cache tag를 유지한다`() {
+            val actor = actorApplicationService.findByEmail("user1@test.com").getOrThrow()
+            postFacade.write(
+                actor,
+                "explore-cursor-tag-cache-${System.currentTimeMillis()}",
+                """
+                tags: [커서태그]
+
+                커서 태그 캐시 검증
+                """.trimIndent(),
+                true,
+                true,
+            )
+
+            val expectedTag = PostCacheTags.byTag("커서태그")
+            val response =
+                mvc
+                    .get("/post/api/v1/posts/explore/cursor") {
+                        param("sort", "CREATED_AT")
+                        param("tag", "커서태그")
+                        param("pageSize", "24")
+                    }.andExpect {
+                        status { isOk() }
+                        match(handler().handlerType(ApiV1PostPublicReadController::class.java))
+                        match(handler().methodName("exploreByCursor"))
+                        header { exists("Surrogate-Key") }
+                        header { exists("Cache-Tag") }
+                    }.andReturn()
+                    .response
+
+            assertThat(response.getHeader("Surrogate-Key")).contains(expectedTag)
+            assertThat(response.getHeader("Cache-Tag")).contains(expectedTag)
         }
 
         @Test


### PR DESCRIPTION
## 관련 이슈

close #887

## 작업 배경

- cursor explore cache tag 생성 로직이 `normalizedTag` blank 여부와 무관하게 `PostCacheTags.byTag(normalizedTag)`를 추가할 수 있는 구조였다.
- 현재 HTTP 계약은 tag 없는 cursor explore 요청을 400으로 차단하지만, key 생성 로직 자체는 blank tag를 tag-specific key로 취급하지 않도록 고정해야 한다.

## 작업 내용

- cursor explore surrogate key 생성을 `postExploreCursorSurrogateKeys`로 분리했다.
- blank tag에서는 `post-list`, `post-explore`, `post-explore-cursor`만 포함하고 `post-tag-empty`를 추가하지 않도록 했다.
- 실제 tag filter가 있는 cursor explore 응답에는 기존 tag cache tag가 유지됨을 테스트로 고정했다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests '*ApiV1PostControllerTest*'`: 통과
  - `back/gradlew -p back ktlintCheck`: 최초 import 정렬 실패 후 정렬 수정, 재실행 통과
  - `back/gradlew -p back ciFastCheck --rerun-tasks`: 2회 연속 통과
  - `git diff --check`: 통과
  - commit hook `OpenApiContractExportTest`: 통과
  - commit hook `yarn contracts:check`: worktree 의존성 누락으로 최초 실패, `yarn --cwd front install --frozen-lockfile` 후 재실행 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `postExploreCursorSurrogateKeys("")`가 `post-tag-empty`를 만들지 않는지
  - tag filter가 있는 `/post/api/v1/posts/explore/cursor` 응답의 `Surrogate-Key`/`Cache-Tag`가 유지되는지

## 리스크

- 빈 tag cursor 요청의 400 서비스 계약은 변경하지 않았다.
- OpenAPI schema와 frontend contract 변경은 없다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. (rate limit으로 실제 리뷰 미실행)
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (PR preview 통과, main merge 후 CD 확인 예정)
