### PR TITLE
[Fix] 클라우드 multipart 사후 리뷰 지적 수정

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/persistence/CloudVideoUploadSessionRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/persistence/CloudVideoUploadSessionRepository.kt
@@ -113,6 +113,7 @@ interface CloudVideoUploadPartRepository :
 
     override fun findBySessionId(sessionId: Long): List<CloudVideoUploadPart>
 
+    @Transactional
     @Modifying
     @Query("DELETE FROM CloudVideoUploadPart p WHERE p.sessionId = :sessionId")
     override fun deleteBySessionId(sessionId: Long)

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionService.kt
@@ -230,6 +230,7 @@ class CloudVideoUploadSessionService(
             expectedStatus = CloudVideoUploadSessionStatus.UPLOADING_PART,
             nextStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
         )
+        session.transitionTo(CloudVideoUploadSessionStatus.IN_PROGRESS, clock.instant())
         val parts = partRepository.findBySessionId(session.id)
 
         return CloudVideoUploadPartResultDto(

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionServiceTest.kt
@@ -150,8 +150,11 @@ class CloudVideoUploadSessionServiceTest {
         val completed = service.complete(7L, session.id)
 
         assertThat(firstResult.session.uploadedParts).containsExactly(1)
+        assertThat(firstResult.session.status).isEqualTo(CloudVideoUploadSessionStatus.IN_PROGRESS)
         assertThat(retryResult.session.uploadedParts).containsExactly(1)
+        assertThat(retryResult.session.status).isEqualTo(CloudVideoUploadSessionStatus.IN_PROGRESS)
         assertThat(lastResult.session.uploadedParts).containsExactly(1, 2)
+        assertThat(lastResult.session.status).isEqualTo(CloudVideoUploadSessionStatus.IN_PROGRESS)
         assertThat(storage.multipartParts).hasSize(2)
         assertThat(
             storage.completedUploads


### PR DESCRIPTION
## 관련 이슈

close #912

## 작업 배경

- PR #902 사후 Codex CLI review에서 cloud video multipart cancel/expiry cleanup의 modifying delete 트랜잭션 누락과 part upload 성공 응답 status 불일치가 확인됐습니다.
- CodeRabbit rate-limit/credit으로 누락됐던 fallback review 복구 결과로 나온 지적이며, 이미 main에 들어간 결함이라 후속 fix로 분리했습니다.

## 작업 내용

- `CloudVideoUploadPartRepository.deleteBySessionId`에 명시적 `@Transactional`을 추가해 cancel/expiry cleanup의 part delete가 repository 경계에서 트랜잭션을 갖도록 했습니다.
- part upload 성공 후 DB 상태를 `IN_PROGRESS`로 복원한 뒤 local session 상태도 같은 값으로 갱신해 응답 DTO가 transient `UPLOADING_PART`를 반환하지 않도록 했습니다.
- 기존 part upload retry 테스트에 성공 응답 status 회귀 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests '*CloudVideoUploadSessionServiceTest*'` : 성공
  - `back/gradlew -p back ktlintCheck` : 성공
  - `back/gradlew -p back ciFastCheck --rerun-tasks` : 성공
  - `git diff --check` : 성공
  - commit hook `OpenApiContractExportTest` + `yarn contracts:check` : 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `CloudVideoUploadSessionRepository.kt`의 `deleteBySessionId` transaction boundary
  - `CloudVideoUploadSessionService.uploadPart`의 local session status 복원
  - `CloudVideoUploadSessionServiceTest`의 part upload success response status 검증
- 이 PR이 merge되면 PR #902의 사후 Codex review inline thread 2건에 해결 commit과 검증 명령을 답글로 남깁니다.

## 리스크

- DB schema/API 계약 변경은 없습니다.
- part upload 성공 응답 status가 transient busy 상태에서 persisted state와 일치하는 `IN_PROGRESS`로 바뀌므로 클라이언트 오판 가능성이 줄어듭니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
