### PR TITLE
[Refactor] MemberApplicationService 프로필 저장 모델 분리

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt
@@ -1,14 +1,9 @@
 package com.back.boundedContexts.member.application.service
 
 import com.back.boundedContexts.member.application.event.MemberPublicProfileChangedEvent
-import com.back.boundedContexts.member.application.port.output.MemberAttrRepositoryPort
 import com.back.boundedContexts.member.application.port.output.MemberRepositoryPort
 import com.back.boundedContexts.member.domain.shared.Member
-import com.back.boundedContexts.member.domain.shared.memberMixin.BLOG_DESIGN
-import com.back.boundedContexts.member.domain.shared.memberMixin.LEGACY_BLOG_SCHEME
-import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileLinkItem
 import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileWorkspaceContent
-import com.back.boundedContexts.member.domain.shared.memberMixin.normalizeMemberProfileWorkspaceContent
 import com.back.global.exception.application.AppException
 import com.back.global.rsData.RsData
 import com.back.global.storage.application.UploadedFileRetentionService
@@ -29,8 +24,8 @@ import java.util.Optional
 @Service
 class MemberApplicationService(
     private val memberRepository: MemberRepositoryPort,
-    private val memberAttrRepository: MemberAttrRepositoryPort,
     private val memberProfileHydrator: MemberProfileHydrator,
+    private val memberProfilePersistenceService: MemberProfilePersistenceService,
     private val passwordEncoder: PasswordEncoder,
     private val uploadedFileRetentionService: UploadedFileRetentionService,
     private val applicationEventPublisher: ApplicationEventPublisher,
@@ -94,7 +89,7 @@ class MemberApplicationService(
         memberProfileHydrator.hydrate(member)
         profileImgUrl?.let {
             member.profileImgUrl = it
-            saveProfileImgUrlAttr(member)
+            memberProfilePersistenceService.saveProfileImage(member)
             uploadedFileRetentionService.syncProfileImage(member.id, null, member.profileImgUrl)
         }
 
@@ -177,14 +172,14 @@ class MemberApplicationService(
         profileImgUrl: String?,
     ) {
         memberProfileHydrator.hydrate(member)
-        ensureProfileWorkspaceSnapshotsInitialized(member)
+        memberProfilePersistenceService.ensureWorkspaceSnapshotsInitialized(member)
         val previousNickname = member.nickname
         val previousProfileImgUrl = member.profileImgUrl
         val publishedProfileImgUrl = member.getProfileWorkspacePublishedContent().profileImageUrl
         member.modify(nickname, profileImgUrl)
         if (profileImgUrl != null) {
-            saveProfileImgUrlAttr(member)
-            syncDraftWorkspaceFromLegacy(member)
+            memberProfilePersistenceService.saveProfileImage(member)
+            memberProfilePersistenceService.syncDraftWorkspaceFromLegacy(member)
             uploadedFileRetentionService.syncProfileImage(
                 member.id,
                 previousProfileImgUrl.takeUnless { it == publishedProfileImgUrl },
@@ -211,58 +206,11 @@ class MemberApplicationService(
     @Transactional
     fun modifyProfileCard(
         member: Member,
-        role: String,
-        bio: String,
-        aboutRole: String?,
-        aboutBio: String?,
-        aboutDetails: String?,
-        blogTitle: String,
-        homeIntroTitle: String,
-        homeIntroDescription: String,
-        blogDesign: String,
-        legacyBlogScheme: String,
-        serviceLinks: List<MemberProfileLinkItem>,
-        contactLinks: List<MemberProfileLinkItem>,
+        command: UpdateProfileCardCommand,
     ) {
         memberProfileHydrator.hydrate(member)
-        ensureProfileWorkspaceSnapshotsInitialized(member)
-        member.profileRole = role
-        member.profileBio = bio
-        if (aboutRole != null) {
-            member.aboutRole = aboutRole
-        }
-        if (aboutBio != null) {
-            member.aboutBio = aboutBio
-        }
-        if (aboutDetails != null) {
-            member.aboutDetails = aboutDetails
-        }
-        member.blogTitle = blogTitle
-        member.homeIntroTitle = homeIntroTitle
-        member.homeIntroDescription = homeIntroDescription
-        member.blogDesign = blogDesign
-        member.legacyBlogScheme = legacyBlogScheme
-        member.serviceLinks = serviceLinks
-        member.contactLinks = contactLinks
-        saveProfileRoleAttr(member)
-        saveProfileBioAttr(member)
-        if (aboutRole != null) {
-            saveAboutRoleAttr(member)
-        }
-        if (aboutBio != null) {
-            saveAboutBioAttr(member)
-        }
-        if (aboutDetails != null) {
-            saveAboutDetailsAttr(member)
-        }
-        saveBlogTitleAttr(member)
-        saveHomeIntroTitleAttr(member)
-        saveHomeIntroDescriptionAttr(member)
-        saveBlogDesignAttr(member)
-        saveLegacyBlogSchemeAttr(member)
-        saveServiceLinksAttr(member)
-        saveContactLinksAttr(member)
-        syncDraftWorkspaceFromLegacy(member)
+        memberProfilePersistenceService.ensureWorkspaceSnapshotsInitialized(member)
+        memberProfilePersistenceService.updateProfileCard(member, command)
     }
 
     @Transactional
@@ -271,31 +219,13 @@ class MemberApplicationService(
         content: MemberProfileWorkspaceContent,
     ) {
         memberProfileHydrator.hydrate(member)
-        ensureProfileWorkspaceSnapshotsInitialized(member)
-        val normalizedContent = normalizeMemberProfileWorkspaceContent(content)
-        val previousProfileImgUrl = member.profileImgUrl
-        val publishedProfileImgUrl = member.getProfileWorkspacePublishedContent().profileImageUrl
-        member.applyProfileWorkspaceContent(normalizedContent)
-        saveProfileImgUrlAttr(member)
-        saveProfileRoleAttr(member)
-        saveProfileBioAttr(member)
-        saveAboutRoleAttr(member)
-        saveAboutBioAttr(member)
-        saveAboutDetailsAttr(member)
-        saveBlogTitleAttr(member)
-        saveHomeIntroTitleAttr(member)
-        saveHomeIntroDescriptionAttr(member)
-        saveBlogDesignAttr(member)
-        saveLegacyBlogSchemeAttr(member)
-        saveServiceLinksAttr(member)
-        saveContactLinksAttr(member)
-        member.setProfileWorkspaceDraftContent(normalizedContent)
-        saveProfileWorkspaceDraftAttr(member)
-        if (previousProfileImgUrl != member.profileImgUrl) {
+        memberProfilePersistenceService.ensureWorkspaceSnapshotsInitialized(member)
+        val imageSyncRequest = memberProfilePersistenceService.saveWorkspaceDraft(member, content)
+        if (imageSyncRequest != null) {
             uploadedFileRetentionService.syncProfileImage(
                 member.id,
-                previousProfileImgUrl.takeUnless { it == publishedProfileImgUrl },
-                member.profileImgUrl,
+                imageSyncRequest.previousProfileImgUrl,
+                imageSyncRequest.currentProfileImgUrl,
             )
         }
     }
@@ -303,16 +233,13 @@ class MemberApplicationService(
     @Transactional
     fun publishProfileWorkspace(member: Member) {
         memberProfileHydrator.hydrate(member)
-        ensureProfileWorkspaceSnapshotsInitialized(member)
-        val previousPublished = member.getProfileWorkspacePublishedContent()
-        val draft = member.getProfileWorkspaceDraftContent()
-        member.setProfileWorkspacePublishedContent(draft)
-        saveProfileWorkspacePublishedAttr(member)
-        if (previousPublished.profileImageUrl != draft.profileImageUrl) {
+        memberProfilePersistenceService.ensureWorkspaceSnapshotsInitialized(member)
+        val imageSyncRequest = memberProfilePersistenceService.publishWorkspace(member)
+        if (imageSyncRequest != null) {
             uploadedFileRetentionService.syncProfileImage(
                 member.id,
-                previousPublished.profileImageUrl,
-                draft.profileImageUrl,
+                imageSyncRequest.previousProfileImgUrl,
+                imageSyncRequest.currentProfileImgUrl,
             )
         }
     }
@@ -389,91 +316,6 @@ class MemberApplicationService(
         }
 
         return pageSize
-    }
-
-    private fun saveProfileImgUrlAttr(member: Member) {
-        memberAttrRepository.save(member.getOrInitProfileImgUrlAttr())
-    }
-
-    private fun saveProfileRoleAttr(member: Member) {
-        memberAttrRepository.save(member.getOrInitProfileRoleAttr())
-    }
-
-    private fun saveProfileBioAttr(member: Member) {
-        memberAttrRepository.save(member.getOrInitProfileBioAttr())
-    }
-
-    private fun saveAboutRoleAttr(member: Member) {
-        memberAttrRepository.save(member.getOrInitAboutRoleAttr())
-    }
-
-    private fun saveAboutBioAttr(member: Member) {
-        memberAttrRepository.save(member.getOrInitAboutBioAttr())
-    }
-
-    private fun saveAboutDetailsAttr(member: Member) {
-        memberAttrRepository.save(member.getOrInitAboutDetailsAttr())
-    }
-
-    private fun saveBlogTitleAttr(member: Member) {
-        memberAttrRepository.save(member.getOrInitBlogTitleAttr())
-    }
-
-    private fun saveHomeIntroTitleAttr(member: Member) {
-        memberAttrRepository.save(member.getOrInitHomeIntroTitleAttr())
-    }
-
-    private fun saveHomeIntroDescriptionAttr(member: Member) {
-        memberAttrRepository.save(member.getOrInitHomeIntroDescriptionAttr())
-    }
-
-    private fun saveBlogDesignAttr(member: Member) {
-        val attr =
-            memberAttrRepository.findBySubjectAndName(member, BLOG_DESIGN)
-                ?: member.getOrInitBlogDesignAttr()
-        attr.strValue = member.blogDesign
-        memberAttrRepository.save(attr)
-    }
-
-    private fun saveLegacyBlogSchemeAttr(member: Member) {
-        val attr =
-            memberAttrRepository.findBySubjectAndName(member, LEGACY_BLOG_SCHEME)
-                ?: member.getOrInitLegacyBlogSchemeAttr()
-        attr.strValue = member.legacyBlogScheme
-        memberAttrRepository.save(attr)
-    }
-
-    private fun saveServiceLinksAttr(member: Member) {
-        memberAttrRepository.save(member.getOrInitServiceLinksAttr())
-    }
-
-    private fun saveContactLinksAttr(member: Member) {
-        memberAttrRepository.save(member.getOrInitContactLinksAttr())
-    }
-
-    private fun saveProfileWorkspaceDraftAttr(member: Member) {
-        memberAttrRepository.save(member.getOrInitProfileWorkspaceDraftAttr())
-    }
-
-    private fun saveProfileWorkspacePublishedAttr(member: Member) {
-        memberAttrRepository.save(member.getOrInitProfileWorkspacePublishedAttr())
-    }
-
-    private fun ensureProfileWorkspaceSnapshotsInitialized(member: Member) {
-        val legacyContent = member.currentProfileWorkspaceContent
-        if (!member.hasPersistedProfileWorkspacePublished()) {
-            member.setProfileWorkspacePublishedContent(legacyContent)
-            saveProfileWorkspacePublishedAttr(member)
-        }
-        if (!member.hasPersistedProfileWorkspaceDraft()) {
-            member.setProfileWorkspaceDraftContent(legacyContent)
-            saveProfileWorkspaceDraftAttr(member)
-        }
-    }
-
-    private fun syncDraftWorkspaceFromLegacy(member: Member) {
-        member.setProfileWorkspaceDraftContent(member.currentProfileWorkspaceContent)
-        saveProfileWorkspaceDraftAttr(member)
     }
 
     private fun normalizeEmailOrNull(email: String?): String? =

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberProfilePersistenceService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberProfilePersistenceService.kt
@@ -1,0 +1,211 @@
+package com.back.boundedContexts.member.application.service
+
+import com.back.boundedContexts.member.application.port.output.MemberAttrRepositoryPort
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.domain.shared.memberMixin.BLOG_DESIGN
+import com.back.boundedContexts.member.domain.shared.memberMixin.LEGACY_BLOG_SCHEME
+import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileLinkItem
+import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileWorkspaceContent
+import com.back.boundedContexts.member.domain.shared.memberMixin.normalizeMemberProfileWorkspaceContent
+import org.springframework.stereotype.Service
+
+data class UpdateProfileCardCommand(
+    val role: String,
+    val bio: String,
+    val aboutRole: String?,
+    val aboutBio: String?,
+    val aboutDetails: String?,
+    val blogTitle: String,
+    val homeIntroTitle: String,
+    val homeIntroDescription: String,
+    val blogDesign: String,
+    val legacyBlogScheme: String,
+    val serviceLinks: List<MemberProfileLinkItem>,
+    val contactLinks: List<MemberProfileLinkItem>,
+)
+
+data class ProfileImageSyncRequest(
+    val previousProfileImgUrl: String?,
+    val currentProfileImgUrl: String?,
+)
+
+@Service
+class MemberProfilePersistenceService(
+    private val memberAttrRepository: MemberAttrRepositoryPort,
+) {
+    fun saveProfileImage(member: Member) {
+        memberAttrRepository.save(member.getOrInitProfileImgUrlAttr())
+    }
+
+    fun ensureWorkspaceSnapshotsInitialized(member: Member) {
+        val legacyContent = member.currentProfileWorkspaceContent
+        if (!member.hasPersistedProfileWorkspacePublished()) {
+            member.setProfileWorkspacePublishedContent(legacyContent)
+            saveProfileWorkspacePublishedAttr(member)
+        }
+        if (!member.hasPersistedProfileWorkspaceDraft()) {
+            member.setProfileWorkspaceDraftContent(legacyContent)
+            saveProfileWorkspaceDraftAttr(member)
+        }
+    }
+
+    fun updateProfileCard(
+        member: Member,
+        command: UpdateProfileCardCommand,
+    ) {
+        member.profileRole = command.role
+        member.profileBio = command.bio
+        command.aboutRole?.let { member.aboutRole = it }
+        command.aboutBio?.let { member.aboutBio = it }
+        command.aboutDetails?.let { member.aboutDetails = it }
+        member.blogTitle = command.blogTitle
+        member.homeIntroTitle = command.homeIntroTitle
+        member.homeIntroDescription = command.homeIntroDescription
+        member.blogDesign = command.blogDesign
+        member.legacyBlogScheme = command.legacyBlogScheme
+        member.serviceLinks = command.serviceLinks
+        member.contactLinks = command.contactLinks
+
+        saveProfileRoleAttr(member)
+        saveProfileBioAttr(member)
+        if (command.aboutRole != null) {
+            saveAboutRoleAttr(member)
+        }
+        if (command.aboutBio != null) {
+            saveAboutBioAttr(member)
+        }
+        if (command.aboutDetails != null) {
+            saveAboutDetailsAttr(member)
+        }
+        saveRequiredProfileCardAttrs(member)
+        syncDraftWorkspaceFromLegacy(member)
+    }
+
+    fun saveWorkspaceDraft(
+        member: Member,
+        content: MemberProfileWorkspaceContent,
+    ): ProfileImageSyncRequest? {
+        val normalizedContent = normalizeMemberProfileWorkspaceContent(content)
+        val previousProfileImgUrl = member.profileImgUrl
+        val publishedProfileImgUrl = member.getProfileWorkspacePublishedContent().profileImageUrl
+
+        member.applyProfileWorkspaceContent(normalizedContent)
+        saveProfileImage(member)
+        saveAllProfileCardAttrs(member)
+        member.setProfileWorkspaceDraftContent(normalizedContent)
+        saveProfileWorkspaceDraftAttr(member)
+
+        if (previousProfileImgUrl == member.profileImgUrl) {
+            return null
+        }
+
+        return ProfileImageSyncRequest(
+            previousProfileImgUrl = previousProfileImgUrl.takeUnless { it == publishedProfileImgUrl },
+            currentProfileImgUrl = member.profileImgUrl,
+        )
+    }
+
+    fun publishWorkspace(member: Member): ProfileImageSyncRequest? {
+        val previousPublished = member.getProfileWorkspacePublishedContent()
+        val draft = member.getProfileWorkspaceDraftContent()
+        member.setProfileWorkspacePublishedContent(draft)
+        saveProfileWorkspacePublishedAttr(member)
+
+        if (previousPublished.profileImageUrl == draft.profileImageUrl) {
+            return null
+        }
+
+        return ProfileImageSyncRequest(
+            previousProfileImgUrl = previousPublished.profileImageUrl,
+            currentProfileImgUrl = draft.profileImageUrl,
+        )
+    }
+
+    fun syncDraftWorkspaceFromLegacy(member: Member) {
+        member.setProfileWorkspaceDraftContent(member.currentProfileWorkspaceContent)
+        saveProfileWorkspaceDraftAttr(member)
+    }
+
+    private fun saveAllProfileCardAttrs(member: Member) {
+        saveProfileRoleAttr(member)
+        saveProfileBioAttr(member)
+        saveAboutRoleAttr(member)
+        saveAboutBioAttr(member)
+        saveAboutDetailsAttr(member)
+        saveRequiredProfileCardAttrs(member)
+    }
+
+    private fun saveRequiredProfileCardAttrs(member: Member) {
+        saveBlogTitleAttr(member)
+        saveHomeIntroTitleAttr(member)
+        saveHomeIntroDescriptionAttr(member)
+        saveBlogDesignAttr(member)
+        saveLegacyBlogSchemeAttr(member)
+        saveServiceLinksAttr(member)
+        saveContactLinksAttr(member)
+    }
+
+    private fun saveProfileRoleAttr(member: Member) {
+        memberAttrRepository.save(member.getOrInitProfileRoleAttr())
+    }
+
+    private fun saveProfileBioAttr(member: Member) {
+        memberAttrRepository.save(member.getOrInitProfileBioAttr())
+    }
+
+    private fun saveAboutRoleAttr(member: Member) {
+        memberAttrRepository.save(member.getOrInitAboutRoleAttr())
+    }
+
+    private fun saveAboutBioAttr(member: Member) {
+        memberAttrRepository.save(member.getOrInitAboutBioAttr())
+    }
+
+    private fun saveAboutDetailsAttr(member: Member) {
+        memberAttrRepository.save(member.getOrInitAboutDetailsAttr())
+    }
+
+    private fun saveBlogTitleAttr(member: Member) {
+        memberAttrRepository.save(member.getOrInitBlogTitleAttr())
+    }
+
+    private fun saveHomeIntroTitleAttr(member: Member) {
+        memberAttrRepository.save(member.getOrInitHomeIntroTitleAttr())
+    }
+
+    private fun saveHomeIntroDescriptionAttr(member: Member) {
+        memberAttrRepository.save(member.getOrInitHomeIntroDescriptionAttr())
+    }
+
+    private fun saveBlogDesignAttr(member: Member) {
+        val attr =
+            memberAttrRepository.findBySubjectAndName(member, BLOG_DESIGN)
+                ?: member.getOrInitBlogDesignAttr()
+        attr.strValue = member.blogDesign
+        memberAttrRepository.save(attr)
+    }
+
+    private fun saveLegacyBlogSchemeAttr(member: Member) {
+        val attr =
+            memberAttrRepository.findBySubjectAndName(member, LEGACY_BLOG_SCHEME)
+                ?: member.getOrInitLegacyBlogSchemeAttr()
+        attr.strValue = member.legacyBlogScheme
+        memberAttrRepository.save(attr)
+    }
+
+    private fun saveServiceLinksAttr(member: Member) {
+        memberAttrRepository.save(member.getOrInitServiceLinksAttr())
+    }
+
+    private fun saveContactLinksAttr(member: Member) {
+        memberAttrRepository.save(member.getOrInitContactLinksAttr())
+    }
+
+    private fun saveProfileWorkspaceDraftAttr(member: Member) {
+        memberAttrRepository.save(member.getOrInitProfileWorkspaceDraftAttr())
+    }
+
+    private fun saveProfileWorkspacePublishedAttr(member: Member) {
+        memberAttrRepository.save(member.getOrInitProfileWorkspacePublishedAttr())
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberUseCaseAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberUseCaseAdapter.kt
@@ -68,18 +68,21 @@ class MemberUseCaseAdapter(
         contactLinks: List<MemberProfileLinkItem>,
     ) = memberApplicationService.modifyProfileCard(
         member = member,
-        role = role,
-        bio = bio,
-        aboutRole = aboutRole,
-        aboutBio = aboutBio,
-        aboutDetails = aboutDetails,
-        blogTitle = blogTitle,
-        homeIntroTitle = homeIntroTitle,
-        homeIntroDescription = homeIntroDescription,
-        blogDesign = blogDesign,
-        legacyBlogScheme = legacyBlogScheme,
-        serviceLinks = serviceLinks,
-        contactLinks = contactLinks,
+        command =
+            UpdateProfileCardCommand(
+                role = role,
+                bio = bio,
+                aboutRole = aboutRole,
+                aboutBio = aboutBio,
+                aboutDetails = aboutDetails,
+                blogTitle = blogTitle,
+                homeIntroTitle = homeIntroTitle,
+                homeIntroDescription = homeIntroDescription,
+                blogDesign = blogDesign,
+                legacyBlogScheme = legacyBlogScheme,
+                serviceLinks = serviceLinks,
+                contactLinks = contactLinks,
+            ),
     )
 
     override fun saveProfileWorkspaceDraft(

--- a/back/src/test/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationServiceTest.kt
@@ -4,9 +4,14 @@ import com.back.boundedContexts.member.adapter.persistence.MemberAttrRepository
 import com.back.boundedContexts.member.adapter.persistence.MemberRepository
 import com.back.boundedContexts.member.application.event.MemberPublicProfileChangedEvent
 import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileAboutSectionBlock
+import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileLinkItem
+import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileWorkspaceContent
 import com.back.support.BaseMemberApplicationServiceIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.then
+import org.mockito.Mockito.reset
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.test.context.event.ApplicationEvents
@@ -124,6 +129,123 @@ class MemberApplicationServiceTest : BaseMemberApplicationServiceIntegrationTest
         assertThat(rsData.data).isEqualTo(member)
         assertThat(member.nickname).isEqualTo("신규유저")
         assertThat(member.profileImgUrl).isEqualTo("https://example.com/join-or-modify-user.png")
+    }
+
+    @Test
+    fun `프로필 카드 수정은 legacy attr 과 draft workspace 만 동기화한다`() {
+        val member = createMember("profile-card-target", "프로필카드")
+
+        memberFacade.modifyProfileCard(
+            member = member,
+            command =
+                UpdateProfileCardCommand(
+                    role = "Backend Engineer",
+                    bio = "서비스 구조를 다룹니다",
+                    aboutRole = "API 설계",
+                    aboutBio = "운영 가능한 흐름을 만듭니다",
+                    aboutDetails = "## 경험\n- Kotlin",
+                    blogTitle = "Aquila Blog",
+                    homeIntroTitle = "기록",
+                    homeIntroDescription = "개발 기록",
+                    blogDesign = "grid",
+                    legacyBlogScheme = "light",
+                    serviceLinks = listOf(MemberProfileLinkItem(icon = "rocket", label = "서비스", href = "/service")),
+                    contactLinks = listOf(MemberProfileLinkItem(icon = "github", label = "GitHub", href = "https://github.com/AquilaXk")),
+                ),
+        )
+
+        assertThat(memberAttrRepository.findBySubjectAndName(member, "profileRole"))
+            .extracting("value")
+            .isEqualTo("Backend Engineer")
+        assertThat(memberAttrRepository.findBySubjectAndName(member, "blogDesign"))
+            .extracting("value")
+            .isEqualTo("grid")
+
+        val draft = member.getProfileWorkspaceDraftContent()
+        val published = member.getProfileWorkspacePublishedContent()
+        assertThat(draft.profileRole).isEqualTo("Backend Engineer")
+        assertThat(draft.blogDesign).isEqualTo("grid")
+        assertThat(draft.serviceLinks).containsExactly(MemberProfileLinkItem(icon = "rocket", label = "서비스", href = "/service"))
+        assertThat(published.profileRole).isEmpty()
+        assertThat(published.blogDesign).isEqualTo("legacy")
+    }
+
+    @Test
+    fun `프로필 workspace draft 저장은 정규화 결과를 legacy attr 과 draft 에 함께 저장한다`() {
+        val member = createMember("profile-workspace-draft", "워크스페이스")
+
+        memberFacade.saveProfileWorkspaceDraft(
+            member = member,
+            content =
+                MemberProfileWorkspaceContent(
+                    profileImageUrl = "  https://example.com/workspace.png  ",
+                    profileRole = "  Architect  ",
+                    profileBio = "  경계를 정리합니다  ",
+                    aboutRole = "  Backend  ",
+                    aboutBio = "  테스트 가능한 구조  ",
+                    aboutSections =
+                        listOf(
+                            MemberProfileAboutSectionBlock(title = "  "),
+                            MemberProfileAboutSectionBlock(title = " 경험 ", items = listOf(" Kotlin ", " ")),
+                        ),
+                    blogTitle = "  블로그  ",
+                    homeIntroTitle = "  홈  ",
+                    homeIntroDescription = "  소개  ",
+                    blogDesign = "unknown",
+                    legacyBlogScheme = "light",
+                ),
+        )
+
+        assertThat(member.profileImgUrl).isEqualTo("https://example.com/workspace.png")
+        assertThat(member.profileRole).isEqualTo("Architect")
+        assertThat(member.blogDesign).isEqualTo("legacy")
+        assertThat(memberAttrRepository.findBySubjectAndName(member, "profileImgUrl"))
+            .extracting("value")
+            .isEqualTo("https://example.com/workspace.png")
+
+        val draft = member.getProfileWorkspaceDraftContent()
+        assertThat(draft.profileImageUrl).isEqualTo("https://example.com/workspace.png")
+        assertThat(draft.profileRole).isEqualTo("Architect")
+        assertThat(draft.aboutSections).containsExactly(
+            MemberProfileAboutSectionBlock(id = "section-2", title = "경험", items = listOf("Kotlin")),
+        )
+        assertThat(draft.blogDesign).isEqualTo("legacy")
+        assertThat(draft.legacyBlogScheme).isEqualTo("light")
+    }
+
+    @Test
+    fun `프로필 workspace publish 와 draft 이미지 교체는 published 이미지 보호 기준으로 sync 한다`() {
+        val member = createMember("profile-workspace-image-sync", "이미지동기화")
+        val publishedImageUrl = "https://example.com/published.png"
+        val draftImageUrl = "https://example.com/draft.png"
+        val nextDraftImageUrl = "https://example.com/next-draft.png"
+
+        memberFacade.saveProfileWorkspaceDraft(
+            member = member,
+            content = MemberProfileWorkspaceContent(profileImageUrl = publishedImageUrl),
+        )
+        memberFacade.publishProfileWorkspace(member)
+
+        reset(uploadedFileRetentionService)
+        memberFacade.saveProfileWorkspaceDraft(
+            member = member,
+            content = MemberProfileWorkspaceContent(profileImageUrl = draftImageUrl),
+        )
+
+        then(uploadedFileRetentionService).should().syncProfileImage(member.id, null, draftImageUrl)
+
+        reset(uploadedFileRetentionService)
+        memberFacade.saveProfileWorkspaceDraft(
+            member = member,
+            content = MemberProfileWorkspaceContent(profileImageUrl = nextDraftImageUrl),
+        )
+
+        then(uploadedFileRetentionService).should().syncProfileImage(member.id, draftImageUrl, nextDraftImageUrl)
+
+        reset(uploadedFileRetentionService)
+        memberFacade.publishProfileWorkspace(member)
+
+        then(uploadedFileRetentionService).should().syncProfileImage(member.id, publishedImageUrl, nextDraftImageUrl)
     }
 
     private fun createMember(

--- a/back/src/test/kotlin/com/back/support/BaseMemberApplicationServiceIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseMemberApplicationServiceIntegrationTest.kt
@@ -6,12 +6,16 @@ import com.back.boundedContexts.member.application.service.MemberApplicationServ
 import com.back.boundedContexts.member.application.service.MemberProfileHydrator
 import com.back.boundedContexts.member.application.service.MemberProfilePersistenceService
 import com.back.global.app.AppConfig
+import com.back.global.app.application.AppFacade
 import com.back.global.jpa.config.JpaConfig
 import com.back.global.storage.application.UploadedFileRetentionService
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
+import tools.jackson.databind.ObjectMapper
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -21,10 +25,18 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
     MemberRepositoryAdapter::class,
     MemberAttrPersistenceAdapter::class,
     MemberProfileHydrator::class,
+    AppFacade::class,
     JpaConfig::class,
     AppConfig::class,
+    BaseMemberApplicationServiceIntegrationTest.JsonTestConfig::class,
 )
 abstract class BaseMemberApplicationServiceIntegrationTest : BaseIntegrationTest() {
     @MockitoBean
     protected lateinit var uploadedFileRetentionService: UploadedFileRetentionService
+
+    @TestConfiguration
+    class JsonTestConfig {
+        @Bean
+        fun objectMapper(): ObjectMapper = ObjectMapper()
+    }
 }

--- a/back/src/test/kotlin/com/back/support/BaseMemberApplicationServiceIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseMemberApplicationServiceIntegrationTest.kt
@@ -4,6 +4,7 @@ import com.back.boundedContexts.member.adapter.persistence.MemberAttrPersistence
 import com.back.boundedContexts.member.adapter.persistence.MemberRepositoryAdapter
 import com.back.boundedContexts.member.application.service.MemberApplicationService
 import com.back.boundedContexts.member.application.service.MemberProfileHydrator
+import com.back.boundedContexts.member.application.service.MemberProfilePersistenceService
 import com.back.global.app.AppConfig
 import com.back.global.jpa.config.JpaConfig
 import com.back.global.storage.application.UploadedFileRetentionService
@@ -16,6 +17,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(
     MemberApplicationService::class,
+    MemberProfilePersistenceService::class,
     MemberRepositoryAdapter::class,
     MemberAttrPersistenceAdapter::class,
     MemberProfileHydrator::class,

--- a/back/src/test/kotlin/com/back/support/DatabaseCleanup.kt
+++ b/back/src/test/kotlin/com/back/support/DatabaseCleanup.kt
@@ -4,6 +4,7 @@ import com.back.boundedContexts.member.adapter.bootstrap.MemberNotProdInitData
 import com.back.boundedContexts.post.adapter.bootstrap.PostNotProdInitData
 import jakarta.persistence.EntityManager
 import org.springframework.context.ApplicationContext
+import org.springframework.dao.TransientDataAccessException
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.jdbc.core.JdbcTemplate
 
@@ -12,27 +13,12 @@ class DatabaseCleanup(
     private val entityManager: EntityManager,
     private val applicationContext: ApplicationContext,
 ) {
+    private val cleanupDeadlockMaxAttempts = 3
+
     fun cleanup() {
         entityManager.clear()
 
-        jdbcTemplate.execute(
-            """
-            TRUNCATE TABLE
-                uploaded_file,
-                task,
-                member_notification,
-                member_action_log,
-                member_signup_verification,
-                post_comment,
-                post_like,
-                post_attr,
-                post,
-                member_attr,
-                member
-            RESTART IDENTITY
-            CASCADE
-            """.trimIndent(),
-        )
+        truncateTables()
 
         entityManager.clear()
 
@@ -50,5 +36,41 @@ class DatabaseCleanup(
         applicationContext.getBean(MemberNotProdInitData::class.java).makeBaseMembers()
         applicationContext.getBean(PostNotProdInitData::class.java).makeBasePosts()
         entityManager.clear()
+    }
+
+    private fun truncateTables() {
+        var attempt = 1
+        while (true) {
+            try {
+                jdbcTemplate.execute(TRUNCATE_TABLES_SQL)
+                return
+            } catch (exception: TransientDataAccessException) {
+                if (attempt >= cleanupDeadlockMaxAttempts) {
+                    throw exception
+                }
+                Thread.sleep(100L * attempt)
+                attempt += 1
+            }
+        }
+    }
+
+    companion object {
+        private val TRUNCATE_TABLES_SQL =
+            """
+            TRUNCATE TABLE
+                uploaded_file,
+                task,
+                member_notification,
+                member_action_log,
+                member_signup_verification,
+                post_comment,
+                post_like,
+                post_attr,
+                post,
+                member_attr,
+                member
+            RESTART IDENTITY
+            CASCADE
+            """.trimIndent()
     }
 }


### PR DESCRIPTION
## 관련 이슈

close #888

## 작업 배경

- `MemberApplicationService`가 profile card primitive 입력, workspace draft/published 저장, legacy member attr 저장을 직접 처리하고 있어 새 프로필 필드 추가 시 저장 누락 위험이 컸습니다.
- public `MemberUseCase`/controller request-response 계약과 attr key/storage format은 유지하면서 application 내부 저장 경계를 분리합니다.

## 작업 내용

- `UpdateProfileCardCommand`로 프로필 카드 수정 입력을 묶었습니다.
- `MemberProfilePersistenceService`를 추가해 profile image, profile card attr, workspace draft/published 저장 규칙을 한 곳으로 이동했습니다.
- `MemberApplicationService`는 hydrator, transaction, event, uploaded-file retention sync 조합 역할만 남기도록 정리했습니다.
- profile card, workspace draft, publish 이미지 sync 경계 테스트를 추가했습니다.
- slice test에서 production JSON 초기화 경계를 맞추도록 `AppFacade`/`ObjectMapper` 테스트 설정을 추가했습니다.
- seeded integration test cleanup의 PostgreSQL transient deadlock을 짧게 재시도하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew clean test --tests 'com.back.boundedContexts.member.application.service.MemberApplicationServiceTest'` 성공 (`back/`)
  - `back/gradlew -p back test --tests '*MemberApplicationService*' --tests '*Profile*'` 성공
  - `back/gradlew -p back test --tests 'com.back.perf.PerformanceSanityTest'` 성공
  - `back/gradlew -p back ktlintCheck` 성공
  - `back/gradlew -p back ciFastCheck --rerun-tasks` 성공 2회 연속
  - `git diff --check` 성공
  - 원격 `backend-ci`, `frontend-ci`, `backend-dependency-check`, `codeql`, Vercel 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `MemberProfilePersistenceService`가 기존 `MemberApplicationService`의 attr 저장 순서와 nullable about field 저장 조건을 보존하는지
  - `saveWorkspaceDraft`/`publishWorkspace`가 기존 profile image retention sync 인자를 유지하는지
  - `DatabaseCleanup` retry가 seeded test reset의 transient deadlock에만 한정되어 있는지

## 리스크

- public API는 변경하지 않았지만, profile card/workspace 저장 경계를 이동했으므로 draft/published snapshot과 legacy attr 동기화 회귀가 주요 리스크입니다.
- 이 리스크는 `MemberApplicationServiceTest`의 profile card/workspace draft/publish image sync 테스트와 `ciFastCheck` coverage gate로 확인했습니다.
- test infra retry는 `TransientDataAccessException` 발생 시 최대 3회만 재시도하며, 반복 실패는 그대로 노출합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (backend test/refactor 변경으로 PR preview/CI만 해당)
