### PR TITLE
[Refactor] 인증 필터 handler DI 구성 전환

### DIFF
--- a/back/src/main/kotlin/com/back/global/security/config/AccessTokenAuthenticationHandler.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/AccessTokenAuthenticationHandler.kt
@@ -5,8 +5,10 @@ import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.dto.shared.AccessTokenPayload
 import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
 import jakarta.servlet.http.HttpServletRequest
+import org.springframework.stereotype.Component
 
-internal class AccessTokenAuthenticationHandler(
+@Component
+class AccessTokenAuthenticationHandler(
     private val actorApplicationService: ActorApplicationService,
     private val memberSessionUseCase: MemberSessionUseCase,
     private val authIpSecurityVerifier: AuthIpSecurityVerifier,

--- a/back/src/main/kotlin/com/back/global/security/config/ApiKeyAuthorityRefreshHandler.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/ApiKeyAuthorityRefreshHandler.kt
@@ -7,8 +7,10 @@ import com.back.global.web.application.AuthCookieService
 import com.back.global.web.application.Rq
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Component
 
-internal class ApiKeyAuthorityRefreshHandler(
+@Component
+class ApiKeyAuthorityRefreshHandler(
     private val actorApplicationService: ActorApplicationService,
     private val memberSessionUseCase: MemberSessionUseCase,
     private val authCookieService: AuthCookieService,

--- a/back/src/main/kotlin/com/back/global/security/config/CustomAuthenticationFilter.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/CustomAuthenticationFilter.kt
@@ -1,16 +1,11 @@
 package com.back.global.security.config
 
-import com.back.boundedContexts.member.application.service.ActorApplicationService
-import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
 import com.back.global.exception.application.AppException
 import com.back.global.rsData.RsData
-import com.back.global.web.application.AuthCookieService
 import com.back.global.web.application.ClientIpResolver
-import com.back.global.web.application.Rq
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.env.Environment
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.security.core.context.SecurityContextHolder
@@ -26,67 +21,18 @@ import tools.jackson.databind.ObjectMapper
  */
 @Component
 class CustomAuthenticationFilter(
-    private val actorApplicationService: ActorApplicationService,
-    private val memberSessionUseCase: MemberSessionUseCase,
-    private val authCookieService: AuthCookieService,
     private val authTokenExtractor: AuthTokenExtractor,
-    private val authIpSecurityVerifier: AuthIpSecurityVerifier,
-    private val securityContextAuthenticationWriter: SecurityContextAuthenticationWriter,
+    private val accessTokenAuthenticationHandler: AccessTokenAuthenticationHandler,
+    private val refreshTokenAuthenticationHandler: RefreshTokenAuthenticationHandler,
     private val clientIpResolver: ClientIpResolver,
     private val objectMapper: ObjectMapper,
     private val publicApiRequestMatcher: PublicApiRequestMatcher,
     private val apiCorsPolicy: ApiCorsPolicy,
     private val environment: Environment,
-    private val rq: Rq,
-    @param:Value("\${custom.auth.session.freshLookupGraceSeconds:15}")
-    private val freshLookupGraceSeconds: Long,
 ) : OncePerRequestFilter() {
     private val log = org.slf4j.LoggerFactory.getLogger(CustomAuthenticationFilter::class.java)
     private val protectedDocumentationPrefixes = listOf("/swagger-ui/", "/v3/api-docs")
     private val filteredPrefixes = listOf("/member/api/", "/post/api/", "/system/api/", "/ws/", "/sse/") + protectedDocumentationPrefixes
-    private val memberSessionAuthenticationResolver =
-        MemberSessionAuthenticationResolver(
-            memberSessionUseCase = memberSessionUseCase,
-            authCookieService = authCookieService,
-            freshLookupGraceSeconds = freshLookupGraceSeconds,
-        )
-    private val apiKeyAuthorityRefreshHandler =
-        ApiKeyAuthorityRefreshHandler(
-            actorApplicationService = actorApplicationService,
-            memberSessionUseCase = memberSessionUseCase,
-            authCookieService = authCookieService,
-            authIpSecurityVerifier = authIpSecurityVerifier,
-            securityContextAuthenticationWriter = securityContextAuthenticationWriter,
-            memberSessionAuthenticationResolver = memberSessionAuthenticationResolver,
-            rq = rq,
-        )
-    private val legacyPayloadRecoveryHandler =
-        LegacyPayloadRecoveryHandler(
-            actorApplicationService = actorApplicationService,
-            memberSessionUseCase = memberSessionUseCase,
-            authCookieService = authCookieService,
-            securityContextAuthenticationWriter = securityContextAuthenticationWriter,
-            rq = rq,
-        )
-    private val accessTokenAuthenticationHandler =
-        AccessTokenAuthenticationHandler(
-            actorApplicationService = actorApplicationService,
-            memberSessionUseCase = memberSessionUseCase,
-            authIpSecurityVerifier = authIpSecurityVerifier,
-            securityContextAuthenticationWriter = securityContextAuthenticationWriter,
-            memberSessionAuthenticationResolver = memberSessionAuthenticationResolver,
-            apiKeyAuthorityRefreshHandler = apiKeyAuthorityRefreshHandler,
-            legacyPayloadRecoveryHandler = legacyPayloadRecoveryHandler,
-        )
-    private val refreshTokenAuthenticationHandler =
-        RefreshTokenAuthenticationHandler(
-            actorApplicationService = actorApplicationService,
-            memberSessionUseCase = memberSessionUseCase,
-            authCookieService = authCookieService,
-            authIpSecurityVerifier = authIpSecurityVerifier,
-            securityContextAuthenticationWriter = securityContextAuthenticationWriter,
-            rq = rq,
-        )
 
     override fun shouldNotFilter(request: HttpServletRequest): Boolean {
         val uri = request.requestURI

--- a/back/src/main/kotlin/com/back/global/security/config/LegacyPayloadRecoveryHandler.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/LegacyPayloadRecoveryHandler.kt
@@ -6,8 +6,10 @@ import com.back.boundedContexts.member.subContexts.session.application.port.inpu
 import com.back.global.web.application.AuthCookieService
 import com.back.global.web.application.Rq
 import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Component
 
-internal class LegacyPayloadRecoveryHandler(
+@Component
+class LegacyPayloadRecoveryHandler(
     private val actorApplicationService: ActorApplicationService,
     private val memberSessionUseCase: MemberSessionUseCase,
     private val authCookieService: AuthCookieService,

--- a/back/src/main/kotlin/com/back/global/security/config/MemberSessionAuthenticationResolver.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/MemberSessionAuthenticationResolver.kt
@@ -6,11 +6,15 @@ import com.back.boundedContexts.member.subContexts.session.model.MemberSessionAu
 import com.back.global.exception.application.AppException
 import com.back.global.web.application.AuthCookieService
 import jakarta.servlet.http.HttpServletRequest
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
 import java.time.Instant
 
-internal class MemberSessionAuthenticationResolver(
+@Component
+class MemberSessionAuthenticationResolver(
     private val memberSessionUseCase: MemberSessionUseCase,
     private val authCookieService: AuthCookieService,
+    @param:Value("\${custom.auth.session.freshLookupGraceSeconds:15}")
     private val freshLookupGraceSeconds: Long,
 ) {
     private val log = org.slf4j.LoggerFactory.getLogger(MemberSessionAuthenticationResolver::class.java)
@@ -122,13 +126,13 @@ internal class MemberSessionAuthenticationResolver(
     }
 }
 
-internal data class MemberSessionResolution(
+data class MemberSessionResolution(
     val sessionKeyProvided: Boolean,
     val session: MemberSessionAuthSnapshot?,
     val freshTokenFallback: Boolean = false,
 )
 
-internal data class AuthenticationSessionContext(
+data class AuthenticationSessionContext(
     val session: MemberSessionAuthSnapshot?,
     val rememberLoginEnabled: Boolean,
     val ipSecurityEnabled: Boolean,

--- a/back/src/main/kotlin/com/back/global/security/config/RefreshTokenAuthenticationHandler.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/RefreshTokenAuthenticationHandler.kt
@@ -7,8 +7,10 @@ import com.back.global.web.application.AuthCookieService
 import com.back.global.web.application.Rq
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Component
 
-internal class RefreshTokenAuthenticationHandler(
+@Component
+class RefreshTokenAuthenticationHandler(
     private val actorApplicationService: ActorApplicationService,
     private val memberSessionUseCase: MemberSessionUseCase,
     private val authCookieService: AuthCookieService,

--- a/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
@@ -29,6 +29,7 @@ import org.springframework.mock.web.MockFilterChain
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
 import tools.jackson.databind.ObjectMapper
 import java.lang.reflect.Modifier
 import java.time.Instant
@@ -54,6 +55,27 @@ class CustomAuthenticationFilterTest {
                 "ApiKeyAuthorityRefreshHandler",
                 "LegacyPayloadRecoveryHandler",
                 "RefreshTokenAuthenticationHandler",
+            )
+        assertThat(extractedBoundaryTypes)
+            .allSatisfy { boundaryType ->
+                assertThat(boundaryType.getAnnotation(Component::class.java)).isNotNull()
+            }
+
+        val filterConstructorTypes =
+            CustomAuthenticationFilter::class.java.constructors
+                .single()
+                .parameterTypes
+                .toList()
+
+        assertThat(filterConstructorTypes)
+            .contains(AccessTokenAuthenticationHandler::class.java, RefreshTokenAuthenticationHandler::class.java)
+            .doesNotContain(
+                ActorApplicationService::class.java,
+                MemberSessionUseCase::class.java,
+                AuthCookieService::class.java,
+                AuthIpSecurityVerifier::class.java,
+                SecurityContextAuthenticationWriter::class.java,
+                Rq::class.java,
             )
 
         val privateMethodNames =
@@ -526,50 +548,57 @@ class CustomAuthenticationFilterTest {
                 memberSessionUseCase,
             )
         private val securityContextAuthenticationWriter = SecurityContextAuthenticationWriter()
-
-        fun authenticationFilter(profile: String = "test"): CustomAuthenticationFilter =
-            CustomAuthenticationFilter(
+        private val apiKeyAuthorityRefreshHandler =
+            ApiKeyAuthorityRefreshHandler(
                 actorApplicationService = actorApplicationService,
                 memberSessionUseCase = memberSessionUseCase,
                 authCookieService = authCookieService,
-                authTokenExtractor = AuthTokenExtractor(rq),
                 authIpSecurityVerifier = authIpSecurityVerifier,
                 securityContextAuthenticationWriter = securityContextAuthenticationWriter,
-                clientIpResolver = clientIpResolver,
-                objectMapper = ObjectMapper(),
-                publicApiRequestMatcher = publicApiRequestMatcher,
-                apiCorsPolicy = apiCorsPolicy,
-                environment = MockEnvironment().apply { setActiveProfiles(profile) },
+                memberSessionAuthenticationResolver = memberSessionAuthenticationResolver,
                 rq = rq,
-                freshLookupGraceSeconds = 15,
             )
-
-        fun accessTokenAuthenticationHandler(): AccessTokenAuthenticationHandler =
+        private val legacyPayloadRecoveryHandler =
+            LegacyPayloadRecoveryHandler(
+                actorApplicationService = actorApplicationService,
+                memberSessionUseCase = memberSessionUseCase,
+                authCookieService = authCookieService,
+                securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+                rq = rq,
+            )
+        private val accessTokenAuthenticationHandler =
             AccessTokenAuthenticationHandler(
                 actorApplicationService = actorApplicationService,
                 memberSessionUseCase = memberSessionUseCase,
                 authIpSecurityVerifier = authIpSecurityVerifier,
                 securityContextAuthenticationWriter = securityContextAuthenticationWriter,
                 memberSessionAuthenticationResolver = memberSessionAuthenticationResolver,
-                apiKeyAuthorityRefreshHandler =
-                    ApiKeyAuthorityRefreshHandler(
-                        actorApplicationService = actorApplicationService,
-                        memberSessionUseCase = memberSessionUseCase,
-                        authCookieService = authCookieService,
-                        authIpSecurityVerifier = authIpSecurityVerifier,
-                        securityContextAuthenticationWriter = securityContextAuthenticationWriter,
-                        memberSessionAuthenticationResolver = memberSessionAuthenticationResolver,
-                        rq = rq,
-                    ),
-                legacyPayloadRecoveryHandler =
-                    LegacyPayloadRecoveryHandler(
-                        actorApplicationService = actorApplicationService,
-                        memberSessionUseCase = memberSessionUseCase,
-                        authCookieService = authCookieService,
-                        securityContextAuthenticationWriter = securityContextAuthenticationWriter,
-                        rq = rq,
-                    ),
+                apiKeyAuthorityRefreshHandler = apiKeyAuthorityRefreshHandler,
+                legacyPayloadRecoveryHandler = legacyPayloadRecoveryHandler,
             )
+        private val refreshTokenAuthenticationHandler =
+            RefreshTokenAuthenticationHandler(
+                actorApplicationService = actorApplicationService,
+                memberSessionUseCase = memberSessionUseCase,
+                authCookieService = authCookieService,
+                authIpSecurityVerifier = authIpSecurityVerifier,
+                securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+                rq = rq,
+            )
+
+        fun authenticationFilter(profile: String = "test"): CustomAuthenticationFilter =
+            CustomAuthenticationFilter(
+                authTokenExtractor = AuthTokenExtractor(rq),
+                accessTokenAuthenticationHandler = accessTokenAuthenticationHandler,
+                refreshTokenAuthenticationHandler = refreshTokenAuthenticationHandler,
+                clientIpResolver = clientIpResolver,
+                objectMapper = ObjectMapper(),
+                publicApiRequestMatcher = publicApiRequestMatcher,
+                apiCorsPolicy = apiCorsPolicy,
+                environment = MockEnvironment().apply { setActiveProfiles(profile) },
+            )
+
+        fun accessTokenAuthenticationHandler(): AccessTokenAuthenticationHandler = accessTokenAuthenticationHandler
 
         fun givenEmptyAuthorizationHeader() {
             given(rq.getHeader(HttpHeaders.AUTHORIZATION, "")).willReturn("")

--- a/back/src/test/kotlin/com/back/support/SecurityConfigEndpointExposureWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/support/SecurityConfigEndpointExposureWebMvcTest.kt
@@ -7,12 +7,17 @@ import com.back.boundedContexts.member.subContexts.session.application.port.inpu
 import com.back.boundedContexts.post.config.PostSecurityConfigurer
 import com.back.global.security.application.AuthIpSecurityService
 import com.back.global.security.application.AuthSecurityEventService
+import com.back.global.security.config.AccessTokenAuthenticationHandler
 import com.back.global.security.config.ApiCorsPolicy
+import com.back.global.security.config.ApiKeyAuthorityRefreshHandler
 import com.back.global.security.config.AuthIpSecurityVerifier
 import com.back.global.security.config.AuthTokenExtractor
 import com.back.global.security.config.CustomAuthenticationFilter
+import com.back.global.security.config.LegacyPayloadRecoveryHandler
+import com.back.global.security.config.MemberSessionAuthenticationResolver
 import com.back.global.security.config.PublicApiRequestMatcher
 import com.back.global.security.config.PublicApiRouteContributor
+import com.back.global.security.config.RefreshTokenAuthenticationHandler
 import com.back.global.security.config.SecurityConfig
 import com.back.global.security.config.SecurityContextAuthenticationWriter
 import com.back.global.security.config.oauth2.CustomOAuth2AuthorizationRequestResolver
@@ -112,26 +117,69 @@ abstract class SecurityConfigEndpointExposureWebMvcTestSupport {
             objectMapper: ObjectMapper,
         ): CustomAuthenticationFilter {
             val rq = mock(Rq::class.java)
+            val actorApplicationService = mock(ActorApplicationService::class.java)
+            val memberSessionUseCase = mock(MemberSessionUseCase::class.java)
+            val authCookieService = mock(AuthCookieService::class.java)
+            val securityContextAuthenticationWriter = SecurityContextAuthenticationWriter()
+            val memberSessionAuthenticationResolver =
+                MemberSessionAuthenticationResolver(
+                    memberSessionUseCase = memberSessionUseCase,
+                    authCookieService = authCookieService,
+                    freshLookupGraceSeconds = 15,
+                )
+            val authIpSecurityVerifier =
+                AuthIpSecurityVerifier(
+                    mock(AuthIpSecurityService::class.java),
+                    mock(AuthSecurityEventService::class.java),
+                    authCookieService,
+                    memberSessionUseCase,
+                )
+            val apiKeyAuthorityRefreshHandler =
+                ApiKeyAuthorityRefreshHandler(
+                    actorApplicationService = actorApplicationService,
+                    memberSessionUseCase = memberSessionUseCase,
+                    authCookieService = authCookieService,
+                    authIpSecurityVerifier = authIpSecurityVerifier,
+                    securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+                    memberSessionAuthenticationResolver = memberSessionAuthenticationResolver,
+                    rq = rq,
+                )
+            val legacyPayloadRecoveryHandler =
+                LegacyPayloadRecoveryHandler(
+                    actorApplicationService = actorApplicationService,
+                    memberSessionUseCase = memberSessionUseCase,
+                    authCookieService = authCookieService,
+                    securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+                    rq = rq,
+                )
+            val accessTokenAuthenticationHandler =
+                AccessTokenAuthenticationHandler(
+                    actorApplicationService = actorApplicationService,
+                    memberSessionUseCase = memberSessionUseCase,
+                    authIpSecurityVerifier = authIpSecurityVerifier,
+                    securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+                    memberSessionAuthenticationResolver = memberSessionAuthenticationResolver,
+                    apiKeyAuthorityRefreshHandler = apiKeyAuthorityRefreshHandler,
+                    legacyPayloadRecoveryHandler = legacyPayloadRecoveryHandler,
+                )
+            val refreshTokenAuthenticationHandler =
+                RefreshTokenAuthenticationHandler(
+                    actorApplicationService = actorApplicationService,
+                    memberSessionUseCase = memberSessionUseCase,
+                    authCookieService = authCookieService,
+                    authIpSecurityVerifier = authIpSecurityVerifier,
+                    securityContextAuthenticationWriter = securityContextAuthenticationWriter,
+                    rq = rq,
+                )
             return CustomAuthenticationFilter(
-                actorApplicationService = mock(ActorApplicationService::class.java),
-                memberSessionUseCase = mock(MemberSessionUseCase::class.java),
-                authCookieService = mock(AuthCookieService::class.java),
                 authTokenExtractor = AuthTokenExtractor(rq),
-                authIpSecurityVerifier =
-                    AuthIpSecurityVerifier(
-                        mock(AuthIpSecurityService::class.java),
-                        mock(AuthSecurityEventService::class.java),
-                        mock(AuthCookieService::class.java),
-                        mock(MemberSessionUseCase::class.java),
-                    ),
-                securityContextAuthenticationWriter = SecurityContextAuthenticationWriter(),
+                accessTokenAuthenticationHandler = accessTokenAuthenticationHandler,
+                refreshTokenAuthenticationHandler = refreshTokenAuthenticationHandler,
                 clientIpResolver = mock(ClientIpResolver::class.java),
                 objectMapper = objectMapper,
                 publicApiRequestMatcher = PublicApiRequestMatcher(emptyList<PublicApiRouteContributor>()),
                 apiCorsPolicy = apiCorsPolicy,
                 environment = environment,
-                rq = rq,
-                freshLookupGraceSeconds = 15,
             )
         }
     }


### PR DESCRIPTION
## 관련 이슈

close #890

## 작업 배경

- `CustomAuthenticationFilter`가 `MemberSessionAuthenticationResolver`와 access/refresh/API key/legacy handler를 생성자 내부에서 직접 조립하고 있어 handler가 Spring bean으로 관리되지 않았다.
- 이 구조에서는 인증 handler에 metric, proxy, AOP, 구성 교체를 적용하기 어렵고 테스트 fixture도 필터 내부 조립 구조를 반복해야 했다.

## 작업 내용

- `MemberSessionAuthenticationResolver`, `AccessTokenAuthenticationHandler`, `ApiKeyAuthorityRefreshHandler`, `LegacyPayloadRecoveryHandler`, `RefreshTokenAuthenticationHandler`를 Spring `@Component` bean으로 등록했다.
- `CustomAuthenticationFilter` 생성자에서 저수준 auth graph 의존성을 제거하고, 이미 조립된 access/refresh handler를 주입받도록 변경했다.
- `freshLookupGraceSeconds` 설정은 resolver bean 생성자에서 직접 주입받도록 이동했다.
- `CustomAuthenticationFilterTest`와 `SecurityConfigEndpointExposureWebMvcTest` fixture를 DI graph와 같은 구조로 정리하고, filter 생성자가 저수준 handler graph를 직접 노출하지 않는 회귀 검증을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests '*CustomAuthenticationFilter*' --tests '*Authentication*' --tests '*Auth*'` 성공
  - `back/gradlew -p back ktlintCheck` 성공
  - `back/gradlew -p back ciFastCheck --rerun-tasks` 2회 연속 성공
  - `git diff --check` 성공
  - commit hook: `OpenApiContractExportTest`, `yarn contracts:check` 성공

## 리뷰어 메모

- 먼저 볼 지점:
  - `CustomAuthenticationFilter` 내부 handler 직접 생성 제거
  - 각 handler/resolver `@Component` 등록과 public visibility 전환
  - 테스트 fixture가 DI graph를 명시적으로 재사용하도록 바뀐 부분

## 리스크

- 인증 성공/실패/fallback 순서는 유지했지만, handler가 Spring bean으로 등록되면서 constructor graph가 바뀌었다. 기존 auth/filter 테스트와 ciFastCheck로 회귀를 확인했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
