### PR TITLE
[Refactor] domain-to-model typealias 경계 정리

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/domain/PersistenceModelAliases.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/domain/PersistenceModelAliases.kt
@@ -1,5 +1,7 @@
 package com.back.boundedContexts.post.domain
 
+// Legacy bridge only: these names still point to persistence entities.
+// ArchitectureGuardTest owns the allowlist so new model aliases need an explicit boundary decision.
 typealias Post = com.back.boundedContexts.post.model.Post
 typealias PostAttr = com.back.boundedContexts.post.model.PostAttr
 typealias PostComment = com.back.boundedContexts.post.model.PostComment

--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -51,8 +51,10 @@ class ArchitectureGuardTest {
         Regex("""^(com\.back\.[A-Za-z0-9_.]+\.domain(?:\.[A-Za-z0-9_]+)*)\.([A-Za-z][A-Za-z0-9_]*)$""")
     private val persistenceModelAliasTargetRegex =
         Regex("""^com\.back\.[A-Za-z0-9_.]+\.model(?:\.[A-Za-z0-9_]+)*\.[A-Za-z][A-Za-z0-9_]*$""")
+    private val aliasTargetTokenRegex =
+        Regex("""[A-Za-z][A-Za-z0-9_.]*""")
     private val typeAliasRegex =
-        Regex("""\btypealias\s+([A-Za-z][A-Za-z0-9_]*)\s*=\s*([A-Za-z][A-Za-z0-9_.]*)""")
+        Regex("""\btypealias\s+([A-Za-z][A-Za-z0-9_]*)\s*=\s*([^\r\n]+(?:\r?\n[ \t]+[^\r\n]+)*)""")
 
     private data class PersistenceModelAlias(
         val sourcePath: String,
@@ -161,6 +163,78 @@ class ArchitectureGuardTest {
         return persistenceBridgeTargetsInPackage(packageName, excludingPath)[aliasName]
     }
 
+    private fun persistenceModelTargetForAliasToken(
+        aliasTarget: String,
+        importedModelTargets: Map<String, String>,
+        wildcardModelImports: List<String>,
+        importedBridgeTargets: Map<String, String>,
+        wildcardBridgeImports: List<String>,
+        currentPackageName: String?,
+        localBridgeTargets: Map<String, String>,
+        excludingPath: Path,
+    ): String? =
+        when {
+            persistenceModelAliasTargetRegex.matches(aliasTarget) -> aliasTarget
+            importedModelTargets.containsKey(aliasTarget) -> importedModelTargets.getValue(aliasTarget)
+            importedBridgeTargets.containsKey(aliasTarget) -> importedBridgeTargets.getValue(aliasTarget)
+            localBridgeTargets.containsKey(aliasTarget) -> localBridgeTargets.getValue(aliasTarget)
+            bridgeAliasTargetFqcn(aliasTarget, currentPackageName, localBridgeTargets, excludingPath) != null ->
+                bridgeAliasTargetFqcn(aliasTarget, currentPackageName, localBridgeTargets, excludingPath)
+            wildcardBridgeImports.isNotEmpty() && !aliasTarget.contains(".") ->
+                wildcardBridgeImports
+                    .mapNotNull { importPath -> persistenceBridgeTargetsInPackage(importPath)[aliasTarget] }
+                    .takeIf { targets -> targets.isNotEmpty() }
+                    ?.joinToString("|")
+            wildcardModelImports.isNotEmpty() && !aliasTarget.contains(".") ->
+                wildcardModelTargets(wildcardModelImports, aliasTarget)
+                    .takeIf { targets -> targets.isNotEmpty() }
+                    ?.joinToString("|")
+            else -> null
+        }
+
+    private fun persistenceModelTargetsInAliasTarget(
+        aliasTarget: String,
+        importedModelTargets: Map<String, String>,
+        wildcardModelImports: List<String>,
+        importedBridgeTargets: Map<String, String>,
+        wildcardBridgeImports: List<String>,
+        currentPackageName: String?,
+        localBridgeTargets: Map<String, String>,
+        excludingPath: Path,
+    ): List<String> {
+        val directTarget =
+            persistenceModelTargetForAliasToken(
+                aliasTarget,
+                importedModelTargets,
+                wildcardModelImports,
+                importedBridgeTargets,
+                wildcardBridgeImports,
+                currentPackageName,
+                localBridgeTargets,
+                excludingPath,
+            )
+
+        if (directTarget != null) {
+            return listOf(directTarget)
+        }
+
+        return aliasTargetTokenRegex
+            .findAll(aliasTarget)
+            .mapNotNull { match ->
+                persistenceModelTargetForAliasToken(
+                    match.value,
+                    importedModelTargets,
+                    wildcardModelImports,
+                    importedBridgeTargets,
+                    wildcardBridgeImports,
+                    currentPackageName,
+                    localBridgeTargets,
+                    excludingPath,
+                )
+            }.distinct()
+            .toList()
+    }
+
     private fun persistenceBridgeTargetsInPackage(
         packageName: String,
         excludingPath: Path? = null,
@@ -232,36 +306,20 @@ class ArchitectureGuardTest {
             sourceBridgeTargetsChanged = false
 
             sourceAliasDeclarations.forEach { (aliasName, aliasTarget) ->
+                val localBridgeTargets = externalSamePackageBridgeTargets + sourceBridgeTargets
                 val targetFqcn =
-                    when {
-                        persistenceModelAliasTargetRegex.matches(aliasTarget) -> aliasTarget
-                        importedModelTargets.containsKey(aliasTarget) -> importedModelTargets.getValue(aliasTarget)
-                        importedBridgeTargets.containsKey(aliasTarget) -> importedBridgeTargets.getValue(aliasTarget)
-                        externalSamePackageBridgeTargets.containsKey(aliasTarget) ->
-                            externalSamePackageBridgeTargets.getValue(aliasTarget)
-                        bridgeAliasTargetFqcn(aliasTarget, currentPackageName, sourceBridgeTargets, path) != null ->
-                            bridgeAliasTargetFqcn(aliasTarget, currentPackageName, sourceBridgeTargets, path)
-                                ?: return@forEach
-                        sourceBridgeTargets.containsKey(aliasTarget) -> sourceBridgeTargets.getValue(aliasTarget)
-                        wildcardBridgeImports.isNotEmpty() && !aliasTarget.contains(".") -> {
-                            val bridgeTargets =
-                                wildcardBridgeImports.mapNotNull { importPath ->
-                                    persistenceBridgeTargetsInPackage(importPath)[aliasTarget]
-                                }
-
-                            if (bridgeTargets.isEmpty()) {
-                                return@forEach
-                            }
-
-                            bridgeTargets.joinToString("|")
-                        }
-                        wildcardModelImports.isNotEmpty() && !aliasTarget.contains(".") ->
-                            wildcardModelTargets(wildcardModelImports, aliasTarget)
-                                .takeIf { targets -> targets.isNotEmpty() }
-                                ?.joinToString("|")
-                                ?: return@forEach
-                        else -> return@forEach
-                    }
+                    persistenceModelTargetsInAliasTarget(
+                        aliasTarget,
+                        importedModelTargets,
+                        wildcardModelImports,
+                        importedBridgeTargets,
+                        wildcardBridgeImports,
+                        currentPackageName,
+                        localBridgeTargets,
+                        path,
+                    ).takeIf { targets -> targets.isNotEmpty() }
+                        ?.joinToString("|")
+                        ?: return@forEach
 
                 if (sourceBridgeTargets[aliasName] != targetFqcn) {
                     sourceBridgeTargets[aliasName] = targetFqcn
@@ -277,33 +335,18 @@ class ArchitectureGuardTest {
             .mapNotNull { match ->
                 val aliasTarget = match.groupValues[2]
                 val targetFqcn =
-                    when {
-                        persistenceModelAliasTargetRegex.matches(aliasTarget) -> aliasTarget
-                        importedModelTargets.containsKey(aliasTarget) -> importedModelTargets.getValue(aliasTarget)
-                        importedBridgeTargets.containsKey(aliasTarget) -> importedBridgeTargets.getValue(aliasTarget)
-                        samePackageBridgeTargets.containsKey(aliasTarget) -> samePackageBridgeTargets.getValue(aliasTarget)
-                        bridgeAliasTargetFqcn(aliasTarget, currentPackageName, samePackageBridgeTargets, path) != null ->
-                            bridgeAliasTargetFqcn(aliasTarget, currentPackageName, samePackageBridgeTargets, path)
-                                ?: return@mapNotNull null
-                        wildcardBridgeImports.isNotEmpty() && !aliasTarget.contains(".") -> {
-                            val bridgeTargets =
-                                wildcardBridgeImports.mapNotNull { importPath ->
-                                    persistenceBridgeTargetsInPackage(importPath)[aliasTarget]
-                                }
-
-                            if (bridgeTargets.isEmpty()) {
-                                return@mapNotNull null
-                            }
-
-                            bridgeTargets.joinToString("|")
-                        }
-                        wildcardModelImports.isNotEmpty() && !aliasTarget.contains(".") ->
-                            wildcardModelTargets(wildcardModelImports, aliasTarget)
-                                .takeIf { targets -> targets.isNotEmpty() }
-                                ?.joinToString("|")
-                                ?: return@mapNotNull null
-                        else -> return@mapNotNull null
-                    }
+                    persistenceModelTargetsInAliasTarget(
+                        aliasTarget,
+                        importedModelTargets,
+                        wildcardModelImports,
+                        importedBridgeTargets,
+                        wildcardBridgeImports,
+                        currentPackageName,
+                        samePackageBridgeTargets,
+                        path,
+                    ).takeIf { targets -> targets.isNotEmpty() }
+                        ?.joinToString("|")
+                        ?: return@mapNotNull null
 
                 PersistenceModelAlias(
                     sourcePath = relativeMainSourcePath(path),
@@ -606,6 +649,8 @@ class ArchitectureGuardTest {
                     |typealias ImportedPostAttrAlias = ImportedPostAttr
                     |typealias WildcardPostComment = PostComment
                     |typealias LocalId = Long
+                    |typealias ImportedPostList = List<Post>
+                    |typealias ImportedPostHandler = (Post) -> ImportedPostAttr
                     |typealias MultilinePost =
                     |    com.back.boundedContexts.post.model.PostLike
                     """.trimMargin(),
@@ -627,6 +672,16 @@ class ArchitectureGuardTest {
                     "example/domain/PersistenceModelAliases.kt",
                     "WildcardPostComment",
                     "com.back.boundedContexts.post.model.PostComment",
+                ),
+                PersistenceModelAlias(
+                    "example/domain/PersistenceModelAliases.kt",
+                    "ImportedPostList",
+                    "com.back.boundedContexts.post.model.Post",
+                ),
+                PersistenceModelAlias(
+                    "example/domain/PersistenceModelAliases.kt",
+                    "ImportedPostHandler",
+                    "com.back.boundedContexts.post.model.Post|com.back.boundedContexts.post.model.PostAttr",
                 ),
                 PersistenceModelAlias(
                     "example/domain/PersistenceModelAliases.kt",

--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -28,6 +28,11 @@ class ArchitectureGuardTest {
                 """(?:\s+as\s+([A-Za-z][A-Za-z0-9_]*))?\s*$""",
             RegexOption.MULTILINE,
         )
+    private val persistenceModelWildcardImportRegex =
+        Regex(
+            """^import\s+(com\.back\.[A-Za-z0-9_.]+\.model(?:\.[A-Za-z0-9_]+)*)\.\*\s*$""",
+            RegexOption.MULTILINE,
+        )
     private val persistenceModelAliasTargetRegex =
         Regex("""^com\.back\.[A-Za-z0-9_.]+\.model(?:\.[A-Za-z0-9_]+)*\.[A-Za-z][A-Za-z0-9_]*$""")
     private val typeAliasRegex =
@@ -94,6 +99,11 @@ class ArchitectureGuardTest {
 
                     importedName to targetFqcn
                 }
+        val wildcardModelImports =
+            persistenceModelWildcardImportRegex
+                .findAll(source)
+                .map { match -> match.groupValues[1] }
+                .toList()
 
         return typeAliasRegex
             .findAll(source)
@@ -103,6 +113,8 @@ class ArchitectureGuardTest {
                     when {
                         persistenceModelAliasTargetRegex.matches(aliasTarget) -> aliasTarget
                         importedModelTargets.containsKey(aliasTarget) -> importedModelTargets.getValue(aliasTarget)
+                        wildcardModelImports.isNotEmpty() && !aliasTarget.contains(".") ->
+                            wildcardModelImports.joinToString("|") { importPath -> "$importPath.$aliasTarget" }
                         else -> return@mapNotNull null
                     }
 
@@ -391,7 +403,7 @@ class ArchitectureGuardTest {
     }
 
     @Test
-    fun `persistence model typealias scanner는 import와 multiline alias 우회를 수집한다`() {
+    fun `persistence model typealias scanner는 import wildcard multiline alias 우회를 수집한다`() {
         val aliases =
             persistenceModelAliasesIn(
                 path = mainSourceRoot.resolve("example/domain/PersistenceModelAliases.kt"),
@@ -401,9 +413,11 @@ class ArchitectureGuardTest {
                     |
                     |import com.back.boundedContexts.post.model.Post
                     |import com.back.boundedContexts.post.model.PostAttr as ImportedPostAttr
+                    |import com.back.boundedContexts.post.model.*
                     |
                     |typealias ImportedPost = Post
                     |typealias ImportedPostAttrAlias = ImportedPostAttr
+                    |typealias WildcardPostComment = PostComment
                     |typealias MultilinePost =
                     |    com.back.boundedContexts.post.model.PostLike
                     """.trimMargin(),
@@ -420,6 +434,11 @@ class ArchitectureGuardTest {
                     "example/domain/PersistenceModelAliases.kt",
                     "ImportedPostAttrAlias",
                     "com.back.boundedContexts.post.model.PostAttr",
+                ),
+                PersistenceModelAlias(
+                    "example/domain/PersistenceModelAliases.kt",
+                    "WildcardPostComment",
+                    "com.back.boundedContexts.post.model.PostComment",
                 ),
                 PersistenceModelAlias(
                     "example/domain/PersistenceModelAliases.kt",

--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -17,6 +17,8 @@ class ArchitectureGuardTest {
     private val mainSourceRoot: Path = Path.of("src/main/kotlin")
     private val mainBoundedContextSourceRoot: Path = Path.of("src/main/kotlin/com/back/boundedContexts")
     private val testSourceRoot: Path = Path.of("src/test/kotlin")
+    private val packageRegex =
+        Regex("""^package\s+([A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)*)\s*$""", RegexOption.MULTILINE)
     private val boundedContextPackageRegex =
         Regex("""^package\s+com\.back\.boundedContexts\.([A-Za-z][A-Za-z0-9_]*)(?:\.|$)""", RegexOption.MULTILINE)
     private val boundedContextImportRegex =
@@ -100,8 +102,21 @@ class ArchitectureGuardTest {
 
     private fun sourcePackagePath(packageName: String): Path = mainSourceRoot.resolve(packageName.replace(".", "/"))
 
-    private fun persistenceBridgeTargetsInPackage(packageName: String): Map<String, String> {
+    private fun sourcePackageName(source: String): String? =
+        packageRegex
+            .find(source)
+            ?.groupValues
+            ?.get(1)
+
+    private fun persistenceBridgeTargetsInPackage(
+        packageName: String,
+        excludingPath: Path? = null,
+    ): Map<String, String> {
         val aliasesPath = sourcePackagePath(packageName).resolve("PersistenceModelAliases.kt")
+
+        if (excludingPath != null && aliasesPath.normalize() == excludingPath.normalize()) {
+            return emptyMap()
+        }
 
         if (!Files.isRegularFile(aliasesPath)) {
             return emptyMap()
@@ -147,6 +162,10 @@ class ArchitectureGuardTest {
                 .findAll(source)
                 .map { match -> match.groupValues[1] }
                 .toList()
+        val samePackageBridgeTargets =
+            sourcePackageName(source)
+                ?.let { packageName -> persistenceBridgeTargetsInPackage(packageName, excludingPath = path) }
+                .orEmpty()
 
         return typeAliasRegex
             .findAll(source)
@@ -157,6 +176,7 @@ class ArchitectureGuardTest {
                         persistenceModelAliasTargetRegex.matches(aliasTarget) -> aliasTarget
                         importedModelTargets.containsKey(aliasTarget) -> importedModelTargets.getValue(aliasTarget)
                         importedBridgeTargets.containsKey(aliasTarget) -> importedBridgeTargets.getValue(aliasTarget)
+                        samePackageBridgeTargets.containsKey(aliasTarget) -> samePackageBridgeTargets.getValue(aliasTarget)
                         wildcardBridgeImports.isNotEmpty() && !aliasTarget.contains(".") -> {
                             val bridgeTargets =
                                 wildcardBridgeImports.mapNotNull { importPath ->
@@ -531,6 +551,35 @@ class ArchitectureGuardTest {
                 PersistenceModelAlias(
                     "example/domain/PersistenceModelAliases.kt",
                     "BridgePostAttr",
+                    "com.back.boundedContexts.post.model.PostAttr",
+                ),
+            )
+    }
+
+    @Test
+    fun `persistence model typealias scanner는 같은 패키지 bridge alias 체인 우회를 수집한다`() {
+        val aliases =
+            persistenceModelAliasesIn(
+                path = mainSourceRoot.resolve("com/back/boundedContexts/post/domain/PostAlias.kt"),
+                source =
+                    """
+                    |package com.back.boundedContexts.post.domain
+                    |
+                    |typealias Article = Post
+                    |typealias ArticleAttr = PostAttr
+                    """.trimMargin(),
+            )
+
+        assertThat(aliases)
+            .containsExactlyInAnyOrder(
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/post/domain/PostAlias.kt",
+                    "Article",
+                    "com.back.boundedContexts.post.model.Post",
+                ),
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/post/domain/PostAlias.kt",
+                    "ArticleAttr",
                     "com.back.boundedContexts.post.model.PostAttr",
                 ),
             )

--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -14,12 +14,24 @@ import java.nio.file.Path
 
 @org.junit.jupiter.api.DisplayName("ArchitectureGuard 테스트")
 class ArchitectureGuardTest {
+    private val mainSourceRoot: Path = Path.of("src/main/kotlin")
     private val mainBoundedContextSourceRoot: Path = Path.of("src/main/kotlin/com/back/boundedContexts")
     private val testSourceRoot: Path = Path.of("src/test/kotlin")
     private val boundedContextPackageRegex =
         Regex("""^package\s+com\.back\.boundedContexts\.([A-Za-z][A-Za-z0-9_]*)(?:\.|$)""", RegexOption.MULTILINE)
     private val boundedContextImportRegex =
         Regex("""^import\s+com\.back\.boundedContexts\.([A-Za-z][A-Za-z0-9_]*)\.([A-Za-z0-9_.*]+)(?:\s+as\s+\w+)?\s*$""")
+    private val persistenceModelAliasRegex =
+        Regex(
+            """^typealias\s+([A-Za-z][A-Za-z0-9_]*)\s*=\s*""" +
+                """(com\.back\.[A-Za-z0-9_.]+\.model(?:\.[A-Za-z0-9_]+)*\.[A-Za-z][A-Za-z0-9_]*)\s*$""",
+        )
+
+    private data class PersistenceModelAlias(
+        val sourcePath: String,
+        val aliasName: String,
+        val targetFqcn: String,
+    )
 
     private fun importedClasses(): JavaClasses =
         ClassFileImporter()
@@ -46,7 +58,30 @@ class ArchitectureGuardTest {
                     .toList()
             }
 
+    private fun kotlinMainSources(): List<Path> =
+        Files
+            .walk(mainSourceRoot)
+            .use { paths ->
+                paths
+                    .filter { Files.isRegularFile(it) }
+                    .filter { it.toString().endsWith(".kt") }
+                    .toList()
+            }
+
     private fun sourceText(path: Path): String = Files.readString(path)
+
+    private fun persistenceModelAliasesIn(path: Path): List<PersistenceModelAlias> =
+        sourceText(path)
+            .lineSequence()
+            .mapNotNull { line ->
+                val match = persistenceModelAliasRegex.matchEntire(line.trim()) ?: return@mapNotNull null
+
+                PersistenceModelAlias(
+                    sourcePath = mainSourceRoot.relativize(path).toString(),
+                    aliasName = match.groupValues[1],
+                    targetFqcn = match.groupValues[2],
+                )
+            }.toList()
 
     private fun sourceBoundedContextName(source: String): String? =
         boundedContextPackageRegex
@@ -213,6 +248,115 @@ class ArchitectureGuardTest {
         assertThat(isForbiddenDirectCrossBoundedContextImport("domain.shared.Member")).isFalse()
         assertThat(isForbiddenDirectCrossBoundedContextImport("dto.MemberDto")).isFalse()
         assertThat(isForbiddenDirectCrossBoundedContextImport("config.shared.AuthSecurityConfigurer")).isFalse()
+    }
+
+    @Test
+    fun `persistence model typealias는 명시된 legacy bridge만 허용한다`() {
+        val allowedAliases =
+            setOf(
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/member/domain/shared/PersistenceModelAliases.kt",
+                    "Member",
+                    "com.back.boundedContexts.member.model.shared.Member",
+                ),
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/member/domain/shared/PersistenceModelAliases.kt",
+                    "MemberAttr",
+                    "com.back.boundedContexts.member.model.shared.MemberAttr",
+                ),
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/member/subContexts/memberActionLog/domain/PersistenceModelAliases.kt",
+                    "MemberActionLog",
+                    "com.back.boundedContexts.member.subContexts.memberActionLog.model.MemberActionLog",
+                ),
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/member/subContexts/notification/domain/PersistenceModelAliases.kt",
+                    "MemberNotification",
+                    "com.back.boundedContexts.member.subContexts.notification.model.MemberNotification",
+                ),
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/member/subContexts/signupVerification/domain/PersistenceModelAliases.kt",
+                    "MemberSignupVerification",
+                    "com.back.boundedContexts.member.subContexts.signupVerification.model.MemberSignupVerification",
+                ),
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/post/domain/PersistenceModelAliases.kt",
+                    "Post",
+                    "com.back.boundedContexts.post.model.Post",
+                ),
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/post/domain/PersistenceModelAliases.kt",
+                    "PostAttr",
+                    "com.back.boundedContexts.post.model.PostAttr",
+                ),
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/post/domain/PersistenceModelAliases.kt",
+                    "PostComment",
+                    "com.back.boundedContexts.post.model.PostComment",
+                ),
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/post/domain/PersistenceModelAliases.kt",
+                    "PostLike",
+                    "com.back.boundedContexts.post.model.PostLike",
+                ),
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/post/domain/PersistenceModelAliases.kt",
+                    "PostWriteRequestIdempotency",
+                    "com.back.boundedContexts.post.model.PostWriteRequestIdempotency",
+                ),
+                PersistenceModelAlias(
+                    "com/back/global/jpa/domain/PersistenceModelAliases.kt",
+                    "BaseEntity",
+                    "com.back.global.jpa.model.BaseEntity",
+                ),
+                PersistenceModelAlias(
+                    "com/back/global/jpa/domain/PersistenceModelAliases.kt",
+                    "BaseTime",
+                    "com.back.global.jpa.model.BaseTime",
+                ),
+                PersistenceModelAlias(
+                    "com/back/global/storage/domain/PersistenceModelAliases.kt",
+                    "UploadedFile",
+                    "com.back.global.storage.model.UploadedFile",
+                ),
+                PersistenceModelAlias(
+                    "com/back/global/storage/domain/PersistenceModelAliases.kt",
+                    "UploadedFileOwnerType",
+                    "com.back.global.storage.model.UploadedFileOwnerType",
+                ),
+                PersistenceModelAlias(
+                    "com/back/global/storage/domain/PersistenceModelAliases.kt",
+                    "UploadedFilePurpose",
+                    "com.back.global.storage.model.UploadedFilePurpose",
+                ),
+                PersistenceModelAlias(
+                    "com/back/global/storage/domain/PersistenceModelAliases.kt",
+                    "UploadedFileRetentionReason",
+                    "com.back.global.storage.model.UploadedFileRetentionReason",
+                ),
+                PersistenceModelAlias(
+                    "com/back/global/storage/domain/PersistenceModelAliases.kt",
+                    "UploadedFileStatus",
+                    "com.back.global.storage.model.UploadedFileStatus",
+                ),
+                PersistenceModelAlias(
+                    "com/back/global/task/domain/PersistenceModelAliases.kt",
+                    "Task",
+                    "com.back.global.task.model.Task",
+                ),
+                PersistenceModelAlias(
+                    "com/back/global/task/domain/PersistenceModelAliases.kt",
+                    "TaskStatus",
+                    "com.back.global.task.model.TaskStatus",
+                ),
+            )
+
+        val aliases =
+            kotlinMainSources()
+                .flatMap(::persistenceModelAliasesIn)
+                .toSet()
+
+        assertThat(aliases).containsExactlyInAnyOrderElementsOf(allowedAliases)
     }
 
     @Test

--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -33,6 +33,18 @@ class ArchitectureGuardTest {
             """^import\s+(com\.back\.[A-Za-z0-9_.]+\.model(?:\.[A-Za-z0-9_]+)*)\.\*\s*$""",
             RegexOption.MULTILINE,
         )
+    private val persistenceBridgeImportRegex =
+        Regex(
+            """^import\s+""" +
+                """(com\.back\.[A-Za-z0-9_.]+\.domain(?:\.[A-Za-z0-9_]+)*\.([A-Za-z][A-Za-z0-9_]*))""" +
+                """(?:\s+as\s+([A-Za-z][A-Za-z0-9_]*))?\s*$""",
+            RegexOption.MULTILINE,
+        )
+    private val persistenceBridgeWildcardImportRegex =
+        Regex(
+            """^import\s+(com\.back\.[A-Za-z0-9_.]+\.domain(?:\.[A-Za-z0-9_]+)*)\.\*\s*$""",
+            RegexOption.MULTILINE,
+        )
     private val persistenceModelAliasTargetRegex =
         Regex("""^com\.back\.[A-Za-z0-9_.]+\.model(?:\.[A-Za-z0-9_]+)*\.[A-Za-z][A-Za-z0-9_]*$""")
     private val typeAliasRegex =
@@ -86,6 +98,19 @@ class ArchitectureGuardTest {
             .relativize(path)
             .joinToString("/") { it.toString() }
 
+    private fun sourcePackagePath(packageName: String): Path = mainSourceRoot.resolve(packageName.replace(".", "/"))
+
+    private fun persistenceBridgeTargetsInPackage(packageName: String): Map<String, String> {
+        val aliasesPath = sourcePackagePath(packageName).resolve("PersistenceModelAliases.kt")
+
+        if (!Files.isRegularFile(aliasesPath)) {
+            return emptyMap()
+        }
+
+        return persistenceModelAliasesIn(aliasesPath)
+            .associate { alias -> alias.aliasName to alias.targetFqcn }
+    }
+
     private fun persistenceModelAliasesIn(
         path: Path,
         source: String = sourceText(path),
@@ -104,6 +129,24 @@ class ArchitectureGuardTest {
                 .findAll(source)
                 .map { match -> match.groupValues[1] }
                 .toList()
+        val importedBridgeTargets =
+            persistenceBridgeImportRegex
+                .findAll(source)
+                .mapNotNull { match ->
+                    val packageName = match.groupValues[1].substringBeforeLast(".")
+                    val aliasName = match.groupValues[2]
+                    val importedName = match.groupValues[3].ifBlank { aliasName }
+                    val targetFqcn =
+                        persistenceBridgeTargetsInPackage(packageName)[aliasName]
+                            ?: return@mapNotNull null
+
+                    importedName to targetFqcn
+                }.toMap()
+        val wildcardBridgeImports =
+            persistenceBridgeWildcardImportRegex
+                .findAll(source)
+                .map { match -> match.groupValues[1] }
+                .toList()
 
         return typeAliasRegex
             .findAll(source)
@@ -113,6 +156,19 @@ class ArchitectureGuardTest {
                     when {
                         persistenceModelAliasTargetRegex.matches(aliasTarget) -> aliasTarget
                         importedModelTargets.containsKey(aliasTarget) -> importedModelTargets.getValue(aliasTarget)
+                        importedBridgeTargets.containsKey(aliasTarget) -> importedBridgeTargets.getValue(aliasTarget)
+                        wildcardBridgeImports.isNotEmpty() && !aliasTarget.contains(".") -> {
+                            val bridgeTargets =
+                                wildcardBridgeImports.mapNotNull { importPath ->
+                                    persistenceBridgeTargetsInPackage(importPath)[aliasTarget]
+                                }
+
+                            if (bridgeTargets.isEmpty()) {
+                                return@mapNotNull null
+                            }
+
+                            bridgeTargets.joinToString("|")
+                        }
                         wildcardModelImports.isNotEmpty() && !aliasTarget.contains(".") ->
                             wildcardModelImports.joinToString("|") { importPath -> "$importPath.$aliasTarget" }
                         else -> return@mapNotNull null
@@ -444,6 +500,38 @@ class ArchitectureGuardTest {
                     "example/domain/PersistenceModelAliases.kt",
                     "MultilinePost",
                     "com.back.boundedContexts.post.model.PostLike",
+                ),
+            )
+    }
+
+    @Test
+    fun `persistence model typealias scanner는 legacy bridge alias 체인 우회를 수집한다`() {
+        val aliases =
+            persistenceModelAliasesIn(
+                path = mainSourceRoot.resolve("example/domain/PersistenceModelAliases.kt"),
+                source =
+                    """
+                    |package com.back.example.domain
+                    |
+                    |import com.back.boundedContexts.post.domain.Post as DomainPost
+                    |import com.back.boundedContexts.post.domain.*
+                    |
+                    |typealias Article = DomainPost
+                    |typealias BridgePostAttr = PostAttr
+                    """.trimMargin(),
+            )
+
+        assertThat(aliases)
+            .containsExactlyInAnyOrder(
+                PersistenceModelAlias(
+                    "example/domain/PersistenceModelAliases.kt",
+                    "Article",
+                    "com.back.boundedContexts.post.model.Post",
+                ),
+                PersistenceModelAlias(
+                    "example/domain/PersistenceModelAliases.kt",
+                    "BridgePostAttr",
+                    "com.back.boundedContexts.post.model.PostAttr",
                 ),
             )
     }

--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -21,11 +21,17 @@ class ArchitectureGuardTest {
         Regex("""^package\s+com\.back\.boundedContexts\.([A-Za-z][A-Za-z0-9_]*)(?:\.|$)""", RegexOption.MULTILINE)
     private val boundedContextImportRegex =
         Regex("""^import\s+com\.back\.boundedContexts\.([A-Za-z][A-Za-z0-9_]*)\.([A-Za-z0-9_.*]+)(?:\s+as\s+\w+)?\s*$""")
-    private val persistenceModelAliasRegex =
+    private val persistenceModelImportRegex =
         Regex(
-            """^typealias\s+([A-Za-z][A-Za-z0-9_]*)\s*=\s*""" +
-                """(com\.back\.[A-Za-z0-9_.]+\.model(?:\.[A-Za-z0-9_]+)*\.[A-Za-z][A-Za-z0-9_]*)\s*$""",
+            """^import\s+""" +
+                """(com\.back\.[A-Za-z0-9_.]+\.model(?:\.[A-Za-z0-9_]+)*\.[A-Za-z][A-Za-z0-9_]*)""" +
+                """(?:\s+as\s+([A-Za-z][A-Za-z0-9_]*))?\s*$""",
+            RegexOption.MULTILINE,
         )
+    private val persistenceModelAliasTargetRegex =
+        Regex("""^com\.back\.[A-Za-z0-9_.]+\.model(?:\.[A-Za-z0-9_]+)*\.[A-Za-z][A-Za-z0-9_]*$""")
+    private val typeAliasRegex =
+        Regex("""\btypealias\s+([A-Za-z][A-Za-z0-9_]*)\s*=\s*([A-Za-z][A-Za-z0-9_.]*)""")
 
     private data class PersistenceModelAlias(
         val sourcePath: String,
@@ -70,18 +76,43 @@ class ArchitectureGuardTest {
 
     private fun sourceText(path: Path): String = Files.readString(path)
 
-    private fun persistenceModelAliasesIn(path: Path): List<PersistenceModelAlias> =
-        sourceText(path)
-            .lineSequence()
-            .mapNotNull { line ->
-                val match = persistenceModelAliasRegex.matchEntire(line.trim()) ?: return@mapNotNull null
+    private fun relativeMainSourcePath(path: Path): String =
+        mainSourceRoot
+            .relativize(path)
+            .joinToString("/") { it.toString() }
+
+    private fun persistenceModelAliasesIn(
+        path: Path,
+        source: String = sourceText(path),
+    ): List<PersistenceModelAlias> {
+        val importedModelTargets =
+            persistenceModelImportRegex
+                .findAll(source)
+                .associate { match ->
+                    val targetFqcn = match.groupValues[1]
+                    val importedName = match.groupValues[2].ifBlank { targetFqcn.substringAfterLast(".") }
+
+                    importedName to targetFqcn
+                }
+
+        return typeAliasRegex
+            .findAll(source)
+            .mapNotNull { match ->
+                val aliasTarget = match.groupValues[2]
+                val targetFqcn =
+                    when {
+                        persistenceModelAliasTargetRegex.matches(aliasTarget) -> aliasTarget
+                        importedModelTargets.containsKey(aliasTarget) -> importedModelTargets.getValue(aliasTarget)
+                        else -> return@mapNotNull null
+                    }
 
                 PersistenceModelAlias(
-                    sourcePath = mainSourceRoot.relativize(path).toString(),
+                    sourcePath = relativeMainSourcePath(path),
                     aliasName = match.groupValues[1],
-                    targetFqcn = match.groupValues[2],
+                    targetFqcn = targetFqcn,
                 )
             }.toList()
+    }
 
     private fun sourceBoundedContextName(source: String): String? =
         boundedContextPackageRegex
@@ -357,6 +388,45 @@ class ArchitectureGuardTest {
                 .toSet()
 
         assertThat(aliases).containsExactlyInAnyOrderElementsOf(allowedAliases)
+    }
+
+    @Test
+    fun `persistence model typealias scanner는 import와 multiline alias 우회를 수집한다`() {
+        val aliases =
+            persistenceModelAliasesIn(
+                path = mainSourceRoot.resolve("example/domain/PersistenceModelAliases.kt"),
+                source =
+                    """
+                    |package com.back.example.domain
+                    |
+                    |import com.back.boundedContexts.post.model.Post
+                    |import com.back.boundedContexts.post.model.PostAttr as ImportedPostAttr
+                    |
+                    |typealias ImportedPost = Post
+                    |typealias ImportedPostAttrAlias = ImportedPostAttr
+                    |typealias MultilinePost =
+                    |    com.back.boundedContexts.post.model.PostLike
+                    """.trimMargin(),
+            )
+
+        assertThat(aliases)
+            .containsExactlyInAnyOrder(
+                PersistenceModelAlias(
+                    "example/domain/PersistenceModelAliases.kt",
+                    "ImportedPost",
+                    "com.back.boundedContexts.post.model.Post",
+                ),
+                PersistenceModelAlias(
+                    "example/domain/PersistenceModelAliases.kt",
+                    "ImportedPostAttrAlias",
+                    "com.back.boundedContexts.post.model.PostAttr",
+                ),
+                PersistenceModelAlias(
+                    "example/domain/PersistenceModelAliases.kt",
+                    "MultilinePost",
+                    "com.back.boundedContexts.post.model.PostLike",
+                ),
+            )
     }
 
     @Test

--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -54,7 +54,7 @@ class ArchitectureGuardTest {
     private val aliasTargetTokenRegex =
         Regex("""[A-Za-z][A-Za-z0-9_.]*""")
     private val typeAliasRegex =
-        Regex("""\btypealias\s+([A-Za-z][A-Za-z0-9_]*)\s*=\s*([^\r\n]+(?:\r?\n[ \t]+[^\r\n]+)*)""")
+        Regex("""\btypealias\s+([A-Za-z][A-Za-z0-9_]*)(?:\s*<[^=\r\n]+>)?\s*=\s*([^\r\n]+(?:\r?\n[ \t]+[^\r\n]+)*)""")
 
     private data class PersistenceModelAlias(
         val sourcePath: String,
@@ -650,6 +650,7 @@ class ArchitectureGuardTest {
                     |typealias WildcardPostComment = PostComment
                     |typealias LocalId = Long
                     |typealias ImportedPostList = List<Post>
+                    |typealias ImportedPostMap<T> = Map<T, Post>
                     |typealias ImportedPostHandler = (Post) -> ImportedPostAttr
                     |typealias MultilinePost =
                     |    com.back.boundedContexts.post.model.PostLike
@@ -676,6 +677,11 @@ class ArchitectureGuardTest {
                 PersistenceModelAlias(
                     "example/domain/PersistenceModelAliases.kt",
                     "ImportedPostList",
+                    "com.back.boundedContexts.post.model.Post",
+                ),
+                PersistenceModelAlias(
+                    "example/domain/PersistenceModelAliases.kt",
+                    "ImportedPostMap",
                     "com.back.boundedContexts.post.model.Post",
                 ),
                 PersistenceModelAlias(

--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -47,6 +47,8 @@ class ArchitectureGuardTest {
             """^import\s+(com\.back\.[A-Za-z0-9_.]+\.domain(?:\.[A-Za-z0-9_]+)*)\.\*\s*$""",
             RegexOption.MULTILINE,
         )
+    private val persistenceBridgeAliasTargetRegex =
+        Regex("""^(com\.back\.[A-Za-z0-9_.]+\.domain(?:\.[A-Za-z0-9_]+)*)\.([A-Za-z][A-Za-z0-9_]*)$""")
     private val persistenceModelAliasTargetRegex =
         Regex("""^com\.back\.[A-Za-z0-9_.]+\.model(?:\.[A-Za-z0-9_]+)*\.[A-Za-z][A-Za-z0-9_]*$""")
     private val typeAliasRegex =
@@ -142,6 +144,23 @@ class ArchitectureGuardTest {
             }
         }
 
+    private fun bridgeAliasTargetFqcn(
+        aliasTarget: String,
+        currentPackageName: String?,
+        localBridgeTargets: Map<String, String>,
+        excludingPath: Path,
+    ): String? {
+        val match = persistenceBridgeAliasTargetRegex.matchEntire(aliasTarget) ?: return null
+        val packageName = match.groupValues[1]
+        val aliasName = match.groupValues[2]
+
+        if (packageName == currentPackageName) {
+            return localBridgeTargets[aliasName]
+        }
+
+        return persistenceBridgeTargetsInPackage(packageName, excludingPath)[aliasName]
+    }
+
     private fun persistenceBridgeTargetsInPackage(
         packageName: String,
         excludingPath: Path? = null,
@@ -196,8 +215,9 @@ class ArchitectureGuardTest {
                 .findAll(source)
                 .map { match -> match.groupValues[1] }
                 .toList()
+        val currentPackageName = sourcePackageName(source)
         val externalSamePackageBridgeTargets =
-            sourcePackageName(source)
+            currentPackageName
                 ?.let { packageName -> persistenceBridgeTargetsInPackage(packageName, excludingPath = path) }
                 .orEmpty()
         val sourceAliasDeclarations =
@@ -219,6 +239,9 @@ class ArchitectureGuardTest {
                         importedBridgeTargets.containsKey(aliasTarget) -> importedBridgeTargets.getValue(aliasTarget)
                         externalSamePackageBridgeTargets.containsKey(aliasTarget) ->
                             externalSamePackageBridgeTargets.getValue(aliasTarget)
+                        bridgeAliasTargetFqcn(aliasTarget, currentPackageName, sourceBridgeTargets, path) != null ->
+                            bridgeAliasTargetFqcn(aliasTarget, currentPackageName, sourceBridgeTargets, path)
+                                ?: return@forEach
                         sourceBridgeTargets.containsKey(aliasTarget) -> sourceBridgeTargets.getValue(aliasTarget)
                         wildcardBridgeImports.isNotEmpty() && !aliasTarget.contains(".") -> {
                             val bridgeTargets =
@@ -259,6 +282,9 @@ class ArchitectureGuardTest {
                         importedModelTargets.containsKey(aliasTarget) -> importedModelTargets.getValue(aliasTarget)
                         importedBridgeTargets.containsKey(aliasTarget) -> importedBridgeTargets.getValue(aliasTarget)
                         samePackageBridgeTargets.containsKey(aliasTarget) -> samePackageBridgeTargets.getValue(aliasTarget)
+                        bridgeAliasTargetFqcn(aliasTarget, currentPackageName, samePackageBridgeTargets, path) != null ->
+                            bridgeAliasTargetFqcn(aliasTarget, currentPackageName, samePackageBridgeTargets, path)
+                                ?: return@mapNotNull null
                         wildcardBridgeImports.isNotEmpty() && !aliasTarget.contains(".") -> {
                             val bridgeTargets =
                                 wildcardBridgeImports.mapNotNull { importPath ->
@@ -623,6 +649,7 @@ class ArchitectureGuardTest {
                     |import com.back.boundedContexts.post.domain.*
                     |
                     |typealias Article = DomainPost
+                    |typealias FullyQualifiedArticle = com.back.boundedContexts.post.domain.Post
                     |typealias BridgePostAttr = PostAttr
                     """.trimMargin(),
             )
@@ -632,6 +659,11 @@ class ArchitectureGuardTest {
                 PersistenceModelAlias(
                     "example/domain/PersistenceModelAliases.kt",
                     "Article",
+                    "com.back.boundedContexts.post.model.Post",
+                ),
+                PersistenceModelAlias(
+                    "example/domain/PersistenceModelAliases.kt",
+                    "FullyQualifiedArticle",
                     "com.back.boundedContexts.post.model.Post",
                 ),
                 PersistenceModelAlias(

--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -162,10 +162,26 @@ class ArchitectureGuardTest {
                 .findAll(source)
                 .map { match -> match.groupValues[1] }
                 .toList()
+        val sourceBridgeTargets =
+            typeAliasRegex
+                .findAll(source)
+                .mapNotNull { match ->
+                    val aliasName = match.groupValues[1]
+                    val aliasTarget = match.groupValues[2]
+                    val targetFqcn =
+                        when {
+                            persistenceModelAliasTargetRegex.matches(aliasTarget) -> aliasTarget
+                            importedModelTargets.containsKey(aliasTarget) -> importedModelTargets.getValue(aliasTarget)
+                            importedBridgeTargets.containsKey(aliasTarget) -> importedBridgeTargets.getValue(aliasTarget)
+                            else -> return@mapNotNull null
+                        }
+
+                    aliasName to targetFqcn
+                }.toMap()
         val samePackageBridgeTargets =
             sourcePackageName(source)
                 ?.let { packageName -> persistenceBridgeTargetsInPackage(packageName, excludingPath = path) }
-                .orEmpty()
+                .orEmpty() + sourceBridgeTargets
 
         return typeAliasRegex
             .findAll(source)
@@ -581,6 +597,35 @@ class ArchitectureGuardTest {
                     "com/back/boundedContexts/post/domain/PostAlias.kt",
                     "ArticleAttr",
                     "com.back.boundedContexts.post.model.PostAttr",
+                ),
+            )
+    }
+
+    @Test
+    fun `persistence model typealias scanner는 기존 bridge 파일 내부 alias 체인 우회를 수집한다`() {
+        val aliases =
+            persistenceModelAliasesIn(
+                path = mainSourceRoot.resolve("com/back/boundedContexts/post/domain/PersistenceModelAliases.kt"),
+                source =
+                    """
+                    |package com.back.boundedContexts.post.domain
+                    |
+                    |typealias Post = com.back.boundedContexts.post.model.Post
+                    |typealias Article = Post
+                    """.trimMargin(),
+            )
+
+        assertThat(aliases)
+            .containsExactlyInAnyOrder(
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/post/domain/PersistenceModelAliases.kt",
+                    "Post",
+                    "com.back.boundedContexts.post.model.Post",
+                ),
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/post/domain/PersistenceModelAliases.kt",
+                    "Article",
+                    "com.back.boundedContexts.post.model.Post",
                 ),
             )
     }

--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -162,26 +162,55 @@ class ArchitectureGuardTest {
                 .findAll(source)
                 .map { match -> match.groupValues[1] }
                 .toList()
-        val sourceBridgeTargets =
-            typeAliasRegex
-                .findAll(source)
-                .mapNotNull { match ->
-                    val aliasName = match.groupValues[1]
-                    val aliasTarget = match.groupValues[2]
-                    val targetFqcn =
-                        when {
-                            persistenceModelAliasTargetRegex.matches(aliasTarget) -> aliasTarget
-                            importedModelTargets.containsKey(aliasTarget) -> importedModelTargets.getValue(aliasTarget)
-                            importedBridgeTargets.containsKey(aliasTarget) -> importedBridgeTargets.getValue(aliasTarget)
-                            else -> return@mapNotNull null
-                        }
-
-                    aliasName to targetFqcn
-                }.toMap()
-        val samePackageBridgeTargets =
+        val externalSamePackageBridgeTargets =
             sourcePackageName(source)
                 ?.let { packageName -> persistenceBridgeTargetsInPackage(packageName, excludingPath = path) }
-                .orEmpty() + sourceBridgeTargets
+                .orEmpty()
+        val sourceAliasDeclarations =
+            typeAliasRegex
+                .findAll(source)
+                .map { match -> match.groupValues[1] to match.groupValues[2] }
+                .toList()
+        val sourceBridgeTargets = mutableMapOf<String, String>()
+        var sourceBridgeTargetsChanged = true
+
+        while (sourceBridgeTargetsChanged) {
+            sourceBridgeTargetsChanged = false
+
+            sourceAliasDeclarations.forEach { (aliasName, aliasTarget) ->
+                val targetFqcn =
+                    when {
+                        persistenceModelAliasTargetRegex.matches(aliasTarget) -> aliasTarget
+                        importedModelTargets.containsKey(aliasTarget) -> importedModelTargets.getValue(aliasTarget)
+                        importedBridgeTargets.containsKey(aliasTarget) -> importedBridgeTargets.getValue(aliasTarget)
+                        externalSamePackageBridgeTargets.containsKey(aliasTarget) ->
+                            externalSamePackageBridgeTargets.getValue(aliasTarget)
+                        sourceBridgeTargets.containsKey(aliasTarget) -> sourceBridgeTargets.getValue(aliasTarget)
+                        wildcardBridgeImports.isNotEmpty() && !aliasTarget.contains(".") -> {
+                            val bridgeTargets =
+                                wildcardBridgeImports.mapNotNull { importPath ->
+                                    persistenceBridgeTargetsInPackage(importPath)[aliasTarget]
+                                }
+
+                            if (bridgeTargets.isEmpty()) {
+                                return@forEach
+                            }
+
+                            bridgeTargets.joinToString("|")
+                        }
+                        wildcardModelImports.isNotEmpty() && !aliasTarget.contains(".") ->
+                            wildcardModelImports.joinToString("|") { importPath -> "$importPath.$aliasTarget" }
+                        else -> return@forEach
+                    }
+
+                if (sourceBridgeTargets[aliasName] != targetFqcn) {
+                    sourceBridgeTargets[aliasName] = targetFqcn
+                    sourceBridgeTargetsChanged = true
+                }
+            }
+        }
+
+        val samePackageBridgeTargets = externalSamePackageBridgeTargets + sourceBridgeTargets
 
         return typeAliasRegex
             .findAll(source)
@@ -612,6 +641,7 @@ class ArchitectureGuardTest {
                     |
                     |typealias Post = com.back.boundedContexts.post.model.Post
                     |typealias Article = Post
+                    |typealias PublicArticle = Article
                     """.trimMargin(),
             )
 
@@ -625,6 +655,11 @@ class ArchitectureGuardTest {
                 PersistenceModelAlias(
                     "com/back/boundedContexts/post/domain/PersistenceModelAliases.kt",
                     "Article",
+                    "com.back.boundedContexts.post.model.Post",
+                ),
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/post/domain/PersistenceModelAliases.kt",
+                    "PublicArticle",
                     "com.back.boundedContexts.post.model.Post",
                 ),
             )

--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -163,6 +163,25 @@ class ArchitectureGuardTest {
         return persistenceBridgeTargetsInPackage(packageName, excludingPath)[aliasName]
     }
 
+    private fun samePackageModelTargetFqcn(
+        aliasTarget: String,
+        currentPackageName: String?,
+    ): String? {
+        if (currentPackageName == null || aliasTarget.contains(".")) {
+            return null
+        }
+
+        if (!currentPackageName.split(".").contains("model")) {
+            return null
+        }
+
+        if (!packageDeclaresType(currentPackageName, aliasTarget)) {
+            return null
+        }
+
+        return "$currentPackageName.$aliasTarget"
+    }
+
     private fun persistenceModelTargetForAliasToken(
         aliasTarget: String,
         importedModelTargets: Map<String, String>,
@@ -180,6 +199,8 @@ class ArchitectureGuardTest {
             localBridgeTargets.containsKey(aliasTarget) -> localBridgeTargets.getValue(aliasTarget)
             bridgeAliasTargetFqcn(aliasTarget, currentPackageName, localBridgeTargets, excludingPath) != null ->
                 bridgeAliasTargetFqcn(aliasTarget, currentPackageName, localBridgeTargets, excludingPath)
+            samePackageModelTargetFqcn(aliasTarget, currentPackageName) != null ->
+                samePackageModelTargetFqcn(aliasTarget, currentPackageName)
             wildcardBridgeImports.isNotEmpty() && !aliasTarget.contains(".") ->
                 wildcardBridgeImports
                     .mapNotNull { importPath -> persistenceBridgeTargetsInPackage(importPath)[aliasTarget] }
@@ -731,6 +752,35 @@ class ArchitectureGuardTest {
                     "example/domain/PersistenceModelAliases.kt",
                     "BridgePostAttr",
                     "com.back.boundedContexts.post.model.PostAttr",
+                ),
+            )
+    }
+
+    @Test
+    fun `persistence model typealias scanner는 같은 model 패키지 alias 우회를 수집한다`() {
+        val aliases =
+            persistenceModelAliasesIn(
+                path = mainSourceRoot.resolve("com/back/boundedContexts/post/model/PostAlias.kt"),
+                source =
+                    """
+                    |package com.back.boundedContexts.post.model
+                    |
+                    |typealias Article = Post
+                    |typealias ArticlePair = Pair<Post, PostAttr>
+                    """.trimMargin(),
+            )
+
+        assertThat(aliases)
+            .containsExactlyInAnyOrder(
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/post/model/PostAlias.kt",
+                    "Article",
+                    "com.back.boundedContexts.post.model.Post",
+                ),
+                PersistenceModelAlias(
+                    "com/back/boundedContexts/post/model/PostAlias.kt",
+                    "ArticlePair",
+                    "com.back.boundedContexts.post.model.Post|com.back.boundedContexts.post.model.PostAttr",
                 ),
             )
     }

--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -108,6 +108,40 @@ class ArchitectureGuardTest {
             ?.groupValues
             ?.get(1)
 
+    private fun packageDeclaresType(
+        packageName: String,
+        typeName: String,
+    ): Boolean {
+        val packagePath = sourcePackagePath(packageName)
+        val typeDeclarationRegex =
+            Regex("""\b(?:data\s+class|enum\s+class|class|interface|object)\s+${Regex.escape(typeName)}\b""")
+
+        if (!Files.isDirectory(packagePath)) {
+            return false
+        }
+
+        return Files
+            .walk(packagePath, 1)
+            .use { paths ->
+                paths
+                    .filter { Files.isRegularFile(it) }
+                    .filter { it.toString().endsWith(".kt") }
+                    .anyMatch { sourcePath -> typeDeclarationRegex.containsMatchIn(sourceText(sourcePath)) }
+            }
+    }
+
+    private fun wildcardModelTargets(
+        wildcardModelImports: List<String>,
+        aliasTarget: String,
+    ): List<String> =
+        wildcardModelImports.mapNotNull { importPath ->
+            if (packageDeclaresType(importPath, aliasTarget)) {
+                "$importPath.$aliasTarget"
+            } else {
+                null
+            }
+        }
+
     private fun persistenceBridgeTargetsInPackage(
         packageName: String,
         excludingPath: Path? = null,
@@ -199,7 +233,10 @@ class ArchitectureGuardTest {
                             bridgeTargets.joinToString("|")
                         }
                         wildcardModelImports.isNotEmpty() && !aliasTarget.contains(".") ->
-                            wildcardModelImports.joinToString("|") { importPath -> "$importPath.$aliasTarget" }
+                            wildcardModelTargets(wildcardModelImports, aliasTarget)
+                                .takeIf { targets -> targets.isNotEmpty() }
+                                ?.joinToString("|")
+                                ?: return@forEach
                         else -> return@forEach
                     }
 
@@ -235,7 +272,10 @@ class ArchitectureGuardTest {
                             bridgeTargets.joinToString("|")
                         }
                         wildcardModelImports.isNotEmpty() && !aliasTarget.contains(".") ->
-                            wildcardModelImports.joinToString("|") { importPath -> "$importPath.$aliasTarget" }
+                            wildcardModelTargets(wildcardModelImports, aliasTarget)
+                                .takeIf { targets -> targets.isNotEmpty() }
+                                ?.joinToString("|")
+                                ?: return@mapNotNull null
                         else -> return@mapNotNull null
                     }
 
@@ -539,6 +579,7 @@ class ArchitectureGuardTest {
                     |typealias ImportedPost = Post
                     |typealias ImportedPostAttrAlias = ImportedPostAttr
                     |typealias WildcardPostComment = PostComment
+                    |typealias LocalId = Long
                     |typealias MultilinePost =
                     |    com.back.boundedContexts.post.model.PostLike
                     """.trimMargin(),


### PR DESCRIPTION
## 관련 이슈

close #891

## 작업 배경

- `domain/PersistenceModelAliases.kt`가 `model` JPA entity를 typealias로 노출하면 코드상 `domain` import처럼 보이지만 실제로는 persistence model을 그대로 참조한다.
- 기존 ArchitectureGuard는 class dependency 중심이라 Kotlin source-level typealias 우회를 명시적으로 검증하지 못했다.

## 작업 내용

- `ArchitectureGuardTest`에 main Kotlin source를 스캔하는 persistence model typealias 검증을 추가했다.
- 현재 존재하는 model typealias는 legacy bridge allowlist로 고정해, 신규 alias 추가 시 명시적 경계 결정 없이 테스트를 통과하지 못하게 했다.
- post domain alias 파일에 해당 alias가 새 domain model이 아니라 persistence entity bridge임을 주석으로 명시했다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests '*Architecture*' --tests '*ArchUnit*'` 성공
  - `back/gradlew -p back ktlintCheck` 성공
  - `back/gradlew -p back ciFastCheck --rerun-tasks` 성공, 동일 조건 2회 연속 통과
  - `git diff --check` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `ArchitectureGuardTest`의 `persistence model typealias는 명시된 legacy bridge만 허용한다` 테스트가 현재 alias 목록을 의도적 legacy bridge로 고정한다.
  - 이번 PR은 model/domain 완전 분리를 수행하지 않고, 기존 런타임 entity mapping과 API 계약을 유지한다.

## 리스크

- 기존 alias를 제거하지 않았기 때문에 domain/model 완전 분리는 별도 migration 작업으로 남는다.
- 새 persistence model alias가 정말 필요한 경우 ArchitectureGuard allowlist를 수정해야 하므로, 의도적 경계 결정이 PR에 드러나게 된다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 레거시 브리지 목적의 기존 모델 별칭과 새로운 모델 별칭의 경계 결정 필요성에 대한 문서화 추가

* **Tests**
  * Persistence 모델 별칭 해석 및 스캐닝 로직에 대한 테스트 강화
  * 아키텍처 규칙 검증 테스트 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->