### PR TITLE
[Test] 테스트 명명과 private reflection 결합 정리

### DIFF
--- a/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt
+++ b/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
-import kotlin.math.ceil
 
 /**
  * TaskProcessingScheduledJob는 주기 작업을 트리거하는 스케줄러 어댑터입니다.
@@ -89,7 +88,21 @@ class TaskProcessingScheduledJob(
     private val meterRegistry: MeterRegistry? = null,
 ) {
     private val logger = LoggerFactory.getLogger(TaskProcessingScheduledJob::class.java)
-    private val workerConcurrency = maxConcurrent.coerceIn(1, 256)
+    private val concurrencyPolicy =
+        TaskProcessorConcurrencyPolicy(
+            workerConcurrency = maxConcurrent,
+            dynamicConcurrencyEnabled = dynamicConcurrencyEnabled,
+            dynamicMinConcurrent = dynamicMinConcurrent,
+            dynamicBacklogPerSlot = dynamicBacklogPerSlot,
+            dynamicBatchSizeEnabled = dynamicBatchSizeEnabled,
+            dynamicBatchMinSize = dynamicBatchMinSize,
+            dynamicBatchBacklogPerStep = dynamicBatchBacklogPerStep,
+            dynamicBatchTargetHandlerDurationMs = dynamicBatchTargetHandlerDurationMs,
+            dynamicBatchMaxPrefetchMultiplier = dynamicBatchMaxPrefetchMultiplier,
+            perTypeAutoTuneEnabled = perTypeAutoTuneEnabled,
+            perTypeAutoTuneMinConcurrent = perTypeAutoTuneMinConcurrent,
+        )
+    private val workerConcurrency = concurrencyPolicy.workerConcurrency
     private val concurrencyGate = Semaphore(workerConcurrency)
     private val executor = Executors.newVirtualThreadPerTaskExecutor()
     private val explicitPerTypeMaxConcurrent = parsePerTypeMaxConcurrent(perTypeMaxConcurrentRaw)
@@ -203,26 +216,7 @@ class TaskProcessingScheduledJob(
 
     private fun resolveAvailableWorkerSlots(): Int {
         val activeWorkers = (workerConcurrency - concurrencyGate.availablePermits()).coerceAtLeast(0)
-        val targetConcurrency =
-            if (!dynamicConcurrencyEnabled) {
-                workerConcurrency
-            } else {
-                resolveDynamicTargetConcurrency()
-            }
-
-        return (targetConcurrency - activeWorkers).coerceIn(0, workerConcurrency)
-    }
-
-    private fun resolveDynamicTargetConcurrency(): Int {
-        val readyBacklog = countReadyBacklog() ?: return workerConcurrency
-        val minConcurrency = dynamicMinConcurrent.coerceIn(1, workerConcurrency)
-        val backlogPerSlot = dynamicBacklogPerSlot.coerceAtLeast(1)
-        val backlogConcurrency =
-            ceil(readyBacklog.coerceAtLeast(0).toDouble() / backlogPerSlot.toDouble())
-                .toInt()
-                .coerceAtLeast(minConcurrency)
-
-        return backlogConcurrency.coerceIn(minConcurrency, workerConcurrency)
+        return concurrencyPolicy.availableWorkerSlots(activeWorkers) { countReadyBacklog() }
     }
 
     private fun countReadyBacklog(): Long? =
@@ -236,41 +230,14 @@ class TaskProcessingScheduledJob(
     private fun resolveFetchLimit(
         safeBatchSize: Int,
         availableWorkerSlots: Int,
-    ): Int {
-        if (!dynamicBatchSizeEnabled) {
-            return minOf(safeBatchSize, availableWorkerSlots)
+    ): Int =
+        concurrencyPolicy.fetchLimit(
+            safeBatchSize = safeBatchSize,
+            availableWorkerSlots = availableWorkerSlots,
+            recentHandlerDurationMs = recentHandlerDurationMs.get(),
+        ) {
+            countReadyBacklog()
         }
-
-        val avgHandlerMs = recentHandlerDurationMs.get().coerceAtLeast(1)
-        val targetMs = dynamicBatchTargetHandlerDurationMs.coerceIn(100, 60_000)
-        val latencyFactor =
-            when {
-                avgHandlerMs <= targetMs -> 1.0
-                else -> (targetMs.toDouble() / avgHandlerMs.toDouble()).coerceIn(0.35, 1.0)
-            }
-
-        val prefetchMultiplier = resolveDynamicBatchPrefetchMultiplier()
-        val maxClaim = minOf(safeBatchSize, availableWorkerSlots.coerceAtLeast(1) * prefetchMultiplier)
-        val minClaim = minOf(dynamicBatchMinSize.coerceIn(1, safeBatchSize), maxClaim)
-        val raw =
-            ceil(availableWorkerSlots.toDouble() * prefetchMultiplier.toDouble() * latencyFactor)
-                .toInt()
-                .coerceAtLeast(1)
-
-        return raw.coerceIn(minClaim, maxClaim)
-    }
-
-    private fun resolveDynamicBatchPrefetchMultiplier(): Int {
-        val maxPrefetchMultiplier = dynamicBatchMaxPrefetchMultiplier.coerceIn(1, 16)
-        val backlogPerStep = dynamicBatchBacklogPerStep.coerceAtLeast(1)
-        val readyBacklog = countReadyBacklog() ?: return maxPrefetchMultiplier
-        val backlogMultiplier =
-            ceil(readyBacklog.coerceAtLeast(0).toDouble() / backlogPerStep.toDouble())
-                .toInt()
-                .coerceAtLeast(1)
-
-        return backlogMultiplier.coerceIn(1, maxPrefetchMultiplier)
-    }
 
     private fun tryAcquirePerTypePermit(taskType: String): Boolean {
         val maxAllowed = resolvePerTypeLimit(taskType)
@@ -298,11 +265,9 @@ class TaskProcessingScheduledJob(
     }
 
     private fun resolvePerTypeLimit(taskType: String): Int {
-        explicitPerTypeMaxConcurrent[taskType]?.let { return it }
-        if (!perTypeAutoTuneEnabled) return workerConcurrency
         // Auto-tune refresh 지연/예산 소진으로 limit map이 비어도 task type을 영구 0 permit로 막지 않는다.
         // 전체 동시성은 worker semaphore가 제한하므로, 미지정 타입은 최소 1 슬롯으로 처리 기회를 보장한다.
-        return perTypeDynamicLimits[taskType] ?: perTypeAutoTuneMinConcurrent.coerceIn(1, workerConcurrency)
+        return concurrencyPolicy.perTypeLimit(taskType, explicitPerTypeMaxConcurrent, perTypeDynamicLimits)
     }
 
     private fun parsePerTypeMaxConcurrent(raw: String): Map<String, Int> =
@@ -334,33 +299,15 @@ class TaskProcessingScheduledJob(
                 .distinct()
         if (registeredTaskTypes.isEmpty()) return
 
-        val dynamicTypes = registeredTaskTypes.filterNot { explicitPerTypeMaxConcurrent.containsKey(it) }
-        if (dynamicTypes.isEmpty()) {
-            perTypeDynamicLimits.clear()
-            perTypeDynamicRefreshedAtEpochMs = nowEpochMs
-            return
-        }
-
-        val minConcurrent = perTypeAutoTuneMinConcurrent.coerceIn(1, workerConcurrency)
-        val explicitReserved = explicitPerTypeMaxConcurrent.values.sum().coerceIn(0, workerConcurrency)
-        val dynamicBudget = (workerConcurrency - explicitReserved).coerceAtLeast(0)
-        if (dynamicBudget == 0) {
-            perTypeDynamicLimits.clear()
-            perTypeDynamicRefreshedAtEpochMs = nowEpochMs
-            return
-        }
-
-        val baseLimit = (dynamicBudget / dynamicTypes.size.coerceAtLeast(1)).coerceAtLeast(minConcurrent)
         val desiredByType =
-            dynamicTypes
-                .associateWith { baseLimit.coerceIn(1, workerConcurrency) }
-                .toMutableMap()
-
-        while (desiredByType.values.sum() > dynamicBudget) {
-            val typeToReduce = desiredByType.maxByOrNull { it.value }?.key ?: break
-            val current = desiredByType[typeToReduce] ?: break
-            if (current <= 1) break
-            desiredByType[typeToReduce] = current - 1
+            concurrencyPolicy.dynamicPerTypeLimits(
+                registeredTaskTypes = registeredTaskTypes,
+                explicitPerTypeMaxConcurrent = explicitPerTypeMaxConcurrent,
+            )
+        if (desiredByType.isEmpty()) {
+            perTypeDynamicLimits.clear()
+            perTypeDynamicRefreshedAtEpochMs = nowEpochMs
+            return
         }
 
         perTypeDynamicLimits.clear()

--- a/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt
+++ b/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt
@@ -81,8 +81,6 @@ class TaskProcessingScheduledJob(
     private val perTypeAutoTuneEnabled: Boolean,
     @param:Value("\${custom.task.processor.perTypeAutoTuneMinConcurrent:1}")
     private val perTypeAutoTuneMinConcurrent: Int,
-    @param:Value("\${custom.task.processor.perTypeAutoTuneBacklogPerSlot:20}")
-    private val perTypeAutoTuneBacklogPerSlot: Int,
     @param:Value("\${custom.task.processor.perTypeAutoTuneRefreshMs:15000}")
     private val perTypeAutoTuneRefreshMs: Long,
     private val meterRegistry: MeterRegistry? = null,

--- a/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessorConcurrencyPolicy.kt
+++ b/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessorConcurrencyPolicy.kt
@@ -1,0 +1,131 @@
+package com.back.global.task.adapter.scheduler
+
+import kotlin.math.ceil
+
+internal class TaskProcessorConcurrencyPolicy(
+    workerConcurrency: Int,
+    private val dynamicConcurrencyEnabled: Boolean,
+    private val dynamicMinConcurrent: Int,
+    private val dynamicBacklogPerSlot: Int,
+    private val dynamicBatchSizeEnabled: Boolean,
+    private val dynamicBatchMinSize: Int,
+    private val dynamicBatchBacklogPerStep: Int,
+    private val dynamicBatchTargetHandlerDurationMs: Long,
+    private val dynamicBatchMaxPrefetchMultiplier: Int,
+    private val perTypeAutoTuneEnabled: Boolean,
+    private val perTypeAutoTuneMinConcurrent: Int,
+) {
+    val workerConcurrency: Int = workerConcurrency.coerceIn(1, 256)
+
+    fun availableWorkerSlots(
+        activeWorkers: Int,
+        readyBacklog: () -> Long?,
+    ): Int {
+        val targetConcurrency =
+            if (dynamicConcurrencyEnabled) {
+                dynamicTargetConcurrency(readyBacklog())
+            } else {
+                workerConcurrency
+            }
+
+        return (targetConcurrency - activeWorkers.coerceAtLeast(0)).coerceIn(0, workerConcurrency)
+    }
+
+    fun fetchLimit(
+        safeBatchSize: Int,
+        availableWorkerSlots: Int,
+        recentHandlerDurationMs: Long,
+        readyBacklog: () -> Long?,
+    ): Int {
+        if (!dynamicBatchSizeEnabled) {
+            return minOf(safeBatchSize, availableWorkerSlots)
+        }
+
+        val avgHandlerMs = recentHandlerDurationMs.coerceAtLeast(1)
+        val targetMs = dynamicBatchTargetHandlerDurationMs.coerceIn(100, 60_000)
+        val latencyFactor =
+            when {
+                avgHandlerMs <= targetMs -> 1.0
+                else -> (targetMs.toDouble() / avgHandlerMs.toDouble()).coerceIn(0.35, 1.0)
+            }
+
+        val prefetchMultiplier = dynamicBatchPrefetchMultiplier(readyBacklog())
+        val maxClaim = minOf(safeBatchSize, availableWorkerSlots.coerceAtLeast(1) * prefetchMultiplier)
+        val minClaim = minOf(dynamicBatchMinSize.coerceIn(1, safeBatchSize), maxClaim)
+        val raw =
+            ceil(availableWorkerSlots.toDouble() * prefetchMultiplier.toDouble() * latencyFactor)
+                .toInt()
+                .coerceAtLeast(1)
+
+        return raw.coerceIn(minClaim, maxClaim)
+    }
+
+    fun perTypeLimit(
+        taskType: String,
+        explicitPerTypeMaxConcurrent: Map<String, Int>,
+        perTypeDynamicLimits: Map<String, Int>,
+    ): Int {
+        explicitPerTypeMaxConcurrent[taskType]?.let { return it.coerceIn(1, workerConcurrency) }
+        if (!perTypeAutoTuneEnabled) return workerConcurrency
+        return perTypeDynamicLimits[taskType] ?: perTypeAutoTuneMinConcurrent.coerceIn(1, workerConcurrency)
+    }
+
+    fun dynamicPerTypeLimits(
+        registeredTaskTypes: List<String>,
+        explicitPerTypeMaxConcurrent: Map<String, Int>,
+    ): Map<String, Int> {
+        if (!perTypeAutoTuneEnabled) return emptyMap()
+
+        val dynamicTypes =
+            registeredTaskTypes
+                .distinct()
+                .filterNot { explicitPerTypeMaxConcurrent.containsKey(it) }
+        if (dynamicTypes.isEmpty()) return emptyMap()
+
+        val minConcurrent = perTypeAutoTuneMinConcurrent.coerceIn(1, workerConcurrency)
+        val explicitReserved = explicitPerTypeMaxConcurrent.values.sum().coerceIn(0, workerConcurrency)
+        val dynamicBudget = (workerConcurrency - explicitReserved).coerceAtLeast(0)
+        if (dynamicBudget == 0) return emptyMap()
+
+        val baseLimit = (dynamicBudget / dynamicTypes.size.coerceAtLeast(1)).coerceAtLeast(minConcurrent)
+        val desiredByType =
+            dynamicTypes
+                .associateWith { baseLimit.coerceIn(1, workerConcurrency) }
+                .toMutableMap()
+
+        while (desiredByType.values.sum() > dynamicBudget) {
+            val typeToReduce = desiredByType.maxByOrNull { it.value }?.key ?: break
+            val current = desiredByType[typeToReduce] ?: break
+            if (current <= 1) break
+            desiredByType[typeToReduce] = current - 1
+        }
+
+        return desiredByType
+    }
+
+    private fun dynamicTargetConcurrency(readyBacklog: Long?): Int {
+        if (readyBacklog == null) return workerConcurrency
+
+        val minConcurrency = dynamicMinConcurrent.coerceIn(1, workerConcurrency)
+        val backlogPerSlot = dynamicBacklogPerSlot.coerceAtLeast(1)
+        val backlogConcurrency =
+            ceil(readyBacklog.coerceAtLeast(0).toDouble() / backlogPerSlot.toDouble())
+                .toInt()
+                .coerceAtLeast(minConcurrency)
+
+        return backlogConcurrency.coerceIn(minConcurrency, workerConcurrency)
+    }
+
+    private fun dynamicBatchPrefetchMultiplier(readyBacklog: Long?): Int {
+        val maxPrefetchMultiplier = dynamicBatchMaxPrefetchMultiplier.coerceIn(1, 16)
+        if (readyBacklog == null) return maxPrefetchMultiplier
+
+        val backlogPerStep = dynamicBatchBacklogPerStep.coerceAtLeast(1)
+        val backlogMultiplier =
+            ceil(readyBacklog.coerceAtLeast(0).toDouble() / backlogPerStep.toDouble())
+                .toInt()
+                .coerceAtLeast(1)
+
+        return backlogMultiplier.coerceIn(1, maxPrefetchMultiplier)
+    }
+}

--- a/back/src/main/resources/application.yaml
+++ b/back/src/main/resources/application.yaml
@@ -262,7 +262,6 @@ custom:
       perTypeMaxConcurrent: ${CUSTOM__TASK__PROCESSOR__PER_TYPE_MAX_CONCURRENT:post.search-index.sync=4,post.read.prewarm=2,post.search-engine.mirror=1}
       perTypeAutoTuneEnabled: ${CUSTOM__TASK__PROCESSOR__PER_TYPE_AUTO_TUNE_ENABLED:true}
       perTypeAutoTuneMinConcurrent: ${CUSTOM__TASK__PROCESSOR__PER_TYPE_AUTO_TUNE_MIN_CONCURRENT:1}
-      perTypeAutoTuneBacklogPerSlot: ${CUSTOM__TASK__PROCESSOR__PER_TYPE_AUTO_TUNE_BACKLOG_PER_SLOT:20}
       perTypeAutoTuneRefreshMs: ${CUSTOM__TASK__PROCESSOR__PER_TYPE_AUTO_TUNE_REFRESH_MS:15000}
       inlineWhenNotProd: ${CUSTOM__TASK__PROCESSOR__INLINE_WHEN_NOT_PROD:false}
     diagnostics:

--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -83,30 +83,24 @@ class ArchitectureGuardTest {
             }
 
     private fun taskSchedulerPrivateReflectionUses(): List<ForbiddenReflectionUse> {
-        val forbiddenTargets =
-            listOf(
-                "resolveAvailableWorkerSlots",
-                "resolveFetchLimit",
-                "refreshPerTypeDynamicLimitsIfNeeded",
-                "resolvePerTypeLimit",
-                "concurrencyGate",
+        val reflectionUseRegex =
+            Regex(
+                """TaskProcessingScheduledJob\s*::class\.java\s*\.\s*getDeclared(?:Method|Field)\s*\(\s*"([^"]+)"""",
             )
+        val allowedPublicTargets = setOf("processTasks")
 
         return kotlinTestSources()
             .flatMap { sourcePath ->
                 val source = sourceText(sourcePath)
-                forbiddenTargets.mapNotNull { target ->
-                    val callsPrivateMethod =
-                        source.contains("""TaskProcessingScheduledJob::class.java.getDeclaredMethod("$target"""")
-                    val readsPrivateField =
-                        source.contains("""TaskProcessingScheduledJob::class.java.getDeclaredField("$target"""")
-
-                    if (callsPrivateMethod || readsPrivateField) {
-                        ForbiddenReflectionUse(sourcePath.toString(), target)
-                    } else {
-                        null
-                    }
-                }
+                reflectionUseRegex
+                    .findAll(source)
+                    .filterNot { match -> allowedPublicTargets.contains(match.groupValues[1]) }
+                    .map { match ->
+                        ForbiddenReflectionUse(
+                            sourcePath = sourcePath.toString(),
+                            target = match.groupValues[1],
+                        )
+                    }.toList()
             }
     }
 

--- a/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/ArchitectureGuardTest.kt
@@ -62,6 +62,11 @@ class ArchitectureGuardTest {
         val targetFqcn: String,
     )
 
+    private data class ForbiddenReflectionUse(
+        val sourcePath: String,
+        val target: String,
+    )
+
     private fun importedClasses(): JavaClasses =
         ClassFileImporter()
             .withImportOption(ImportOption.DoNotIncludeTests())
@@ -76,6 +81,34 @@ class ArchitectureGuardTest {
                     .filter { it.toString().endsWith(".kt") }
                     .toList()
             }
+
+    private fun taskSchedulerPrivateReflectionUses(): List<ForbiddenReflectionUse> {
+        val forbiddenTargets =
+            listOf(
+                "resolveAvailableWorkerSlots",
+                "resolveFetchLimit",
+                "refreshPerTypeDynamicLimitsIfNeeded",
+                "resolvePerTypeLimit",
+                "concurrencyGate",
+            )
+
+        return kotlinTestSources()
+            .flatMap { sourcePath ->
+                val source = sourceText(sourcePath)
+                forbiddenTargets.mapNotNull { target ->
+                    val callsPrivateMethod =
+                        source.contains("""TaskProcessingScheduledJob::class.java.getDeclaredMethod("$target"""")
+                    val readsPrivateField =
+                        source.contains("""TaskProcessingScheduledJob::class.java.getDeclaredField("$target"""")
+
+                    if (callsPrivateMethod || readsPrivateField) {
+                        ForbiddenReflectionUse(sourcePath.toString(), target)
+                    } else {
+                        null
+                    }
+                }
+            }
+    }
 
     private fun kotlinMainBoundedContextSources(): List<Path> =
         Files
@@ -651,6 +684,11 @@ class ArchitectureGuardTest {
                 .toSet()
 
         assertThat(aliases).containsExactlyInAnyOrderElementsOf(allowedAliases)
+    }
+
+    @Test
+    fun `task scheduler concurrency 테스트는 private scheduler 구현을 reflection으로 호출하지 않는다`() {
+        assertThat(taskSchedulerPrivateReflectionUses()).isEmpty()
     }
 
     @Test

--- a/back/src/test/kotlin/com/back/architecture/BackendTestConventionBacklogTest.kt
+++ b/back/src/test/kotlin/com/back/architecture/BackendTestConventionBacklogTest.kt
@@ -1,0 +1,71 @@
+package com.back.architecture
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("BackendTestConventionBacklog 테스트")
+class BackendTestConventionBacklogTest {
+    @Test
+    @DisplayName("backend 테스트 명명 기준은 class와 method display name을 한국어 동작 설명으로 고정한다")
+    fun `backend test naming convention is fixed`() {
+        assertThat(BackendTestConvention.CLASS_DISPLAY_NAME_RULE)
+            .isEqualTo("대상 기능 또는 guard 이름 뒤에 '테스트'를 붙인다")
+        assertThat(BackendTestConvention.METHOD_DISPLAY_NAME_RULE)
+            .isEqualTo("조건과 기대 동작을 한국어 문장으로 쓴다")
+        assertThat(BackendTestConvention.METHOD_NAME_RULE)
+            .isEqualTo("Kotlin backtick 이름은 display name과 같은 동작을 영어 또는 한국어로 설명한다")
+    }
+
+    @Test
+    @DisplayName("failure injection backlog는 cache, task, cloud, retention 도메인을 모두 포함한다")
+    fun `failure injection backlog covers core backend domains`() {
+        val backlogDomains = BackendFailureInjectionBacklog.items.map { it.domain }.toSet()
+
+        assertThat(backlogDomains)
+            .containsExactlyInAnyOrder("cache", "task", "cloud", "retention")
+        assertThat(BackendFailureInjectionBacklog.items)
+            .allSatisfy { item ->
+                assertThat(item.scenario).isNotBlank()
+                assertThat(item.validationTarget).isNotBlank()
+            }
+    }
+
+    private object BackendTestConvention {
+        const val CLASS_DISPLAY_NAME_RULE = "대상 기능 또는 guard 이름 뒤에 '테스트'를 붙인다"
+        const val METHOD_DISPLAY_NAME_RULE = "조건과 기대 동작을 한국어 문장으로 쓴다"
+        const val METHOD_NAME_RULE = "Kotlin backtick 이름은 display name과 같은 동작을 영어 또는 한국어로 설명한다"
+    }
+
+    private object BackendFailureInjectionBacklog {
+        val items =
+            listOf(
+                FailureInjectionBacklogItem(
+                    domain = "cache",
+                    scenario = "cache 저장소 장애 시 reader가 stale data 또는 fallback 경로로 안전하게 응답하는지 검증한다",
+                    validationTarget = "cache adapter failure injection test",
+                ),
+                FailureInjectionBacklogItem(
+                    domain = "task",
+                    scenario = "task handler 예외와 stale lease 경합이 retry/fencing 규칙을 깨지 않는지 검증한다",
+                    validationTarget = "task scheduler failure injection test",
+                ),
+                FailureInjectionBacklogItem(
+                    domain = "cloud",
+                    scenario = "cloud upload/delete provider 실패가 도메인 상태와 재시도 정책을 불일치시키지 않는지 검증한다",
+                    validationTarget = "cloud storage failure injection test",
+                ),
+                FailureInjectionBacklogItem(
+                    domain = "retention",
+                    scenario = "retention archive/delete 실패가 cutoff 이후 데이터 조회와 재실행 안전성을 깨지 않는지 검증한다",
+                    validationTarget = "retention job failure injection test",
+                ),
+            )
+    }
+
+    private data class FailureInjectionBacklogItem(
+        val domain: String,
+        val scenario: String,
+        val validationTarget: String,
+    )
+}

--- a/back/src/test/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJobPerTypeLimitTest.kt
+++ b/back/src/test/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJobPerTypeLimitTest.kt
@@ -16,8 +16,6 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.verifyNoInteractions
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.TransactionStatus
@@ -28,166 +26,11 @@ import java.time.Instant
 import java.util.Optional
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 class TaskProcessingScheduledJobPerTypeLimitTest {
-    @Test
-    @DisplayName("dynamic concurrency는 ready backlog가 작으면 최소 동시성만 claim한다")
-    fun `dynamic concurrency uses minimum slots for small ready backlog`() {
-        val fixture =
-            createFixture(
-                maxConcurrent = 8,
-                perTypeMaxConcurrentRaw = "",
-                perTypeAutoTuneEnabled = true,
-                perTypeAutoTuneMinConcurrent = 1,
-                dynamicConcurrencyEnabled = true,
-                dynamicMinConcurrent = 2,
-                dynamicBacklogPerSlot = 25,
-            )
-        org.mockito.Mockito
-            .`when`(
-                fixture.taskRepository.countByStatusAndNextRetryAtLessThanEqual(
-                    pendingStatus(),
-                    anyInstant(),
-                ),
-            ).thenReturn(1L)
-
-        val availableSlots = invokeResolveAvailableWorkerSlots(fixture.job)
-
-        assertThat(availableSlots).isEqualTo(2)
-        verify(fixture.taskRepository)
-            .countByStatusAndNextRetryAtLessThanEqual(pendingStatus(), anyInstant())
-    }
-
-    @Test
-    @DisplayName("dynamic concurrency는 ready backlog가 커지면 최대 동시성까지 확장한다")
-    fun `dynamic concurrency expands slots as ready backlog grows`() {
-        val fixture =
-            createFixture(
-                maxConcurrent = 8,
-                perTypeMaxConcurrentRaw = "",
-                perTypeAutoTuneEnabled = true,
-                perTypeAutoTuneMinConcurrent = 1,
-                dynamicConcurrencyEnabled = true,
-                dynamicMinConcurrent = 2,
-                dynamicBacklogPerSlot = 25,
-            )
-        org.mockito.Mockito
-            .`when`(
-                fixture.taskRepository.countByStatusAndNextRetryAtLessThanEqual(
-                    pendingStatus(),
-                    anyInstant(),
-                ),
-            ).thenReturn(200L)
-
-        val availableSlots = invokeResolveAvailableWorkerSlots(fixture.job)
-
-        assertThat(availableSlots).isEqualTo(8)
-    }
-
-    @Test
-    @DisplayName("dynamic concurrency는 ready backlog count 실패 시 최대 동시성으로 fallback한다")
-    fun `dynamic concurrency falls back to max slots when ready backlog count fails`() {
-        val fixture =
-            createFixture(
-                maxConcurrent = 8,
-                perTypeMaxConcurrentRaw = "",
-                perTypeAutoTuneEnabled = true,
-                perTypeAutoTuneMinConcurrent = 1,
-                dynamicConcurrencyEnabled = true,
-                dynamicMinConcurrent = 2,
-                dynamicBacklogPerSlot = 25,
-            )
-        org.mockito.Mockito
-            .`when`(
-                fixture.taskRepository.countByStatusAndNextRetryAtLessThanEqual(
-                    pendingStatus(),
-                    anyInstant(),
-                ),
-            ).thenThrow(IllegalStateException("count failed"))
-
-        val availableSlots = invokeResolveAvailableWorkerSlots(fixture.job)
-
-        assertThat(availableSlots).isEqualTo(8)
-    }
-
-    @Test
-    @DisplayName("dynamic concurrency는 active worker 수를 차감한 남은 slot만 claim한다")
-    fun `dynamic concurrency subtracts active workers from target slots`() {
-        val fixture =
-            createFixture(
-                maxConcurrent = 8,
-                perTypeMaxConcurrentRaw = "",
-                perTypeAutoTuneEnabled = true,
-                perTypeAutoTuneMinConcurrent = 1,
-                dynamicConcurrencyEnabled = true,
-                dynamicMinConcurrent = 2,
-                dynamicBacklogPerSlot = 25,
-            )
-        org.mockito.Mockito
-            .`when`(
-                fixture.taskRepository.countByStatusAndNextRetryAtLessThanEqual(
-                    pendingStatus(),
-                    anyInstant(),
-                ),
-            ).thenReturn(200L)
-        acquireWorkerSlots(fixture.job, 3)
-
-        val availableSlots = invokeResolveAvailableWorkerSlots(fixture.job)
-
-        assertThat(availableSlots).isEqualTo(5)
-    }
-
-    @Test
-    @DisplayName("dynamic concurrency off는 ready backlog count 없이 고정 worker 동시성을 사용한다")
-    fun `fixed concurrency ignores ready backlog count`() {
-        val fixture =
-            createFixture(
-                maxConcurrent = 8,
-                perTypeMaxConcurrentRaw = "",
-                perTypeAutoTuneEnabled = true,
-                perTypeAutoTuneMinConcurrent = 1,
-                dynamicConcurrencyEnabled = false,
-                dynamicMinConcurrent = 2,
-                dynamicBacklogPerSlot = 25,
-            )
-
-        val availableSlots = invokeResolveAvailableWorkerSlots(fixture.job)
-
-        assertThat(availableSlots).isEqualTo(8)
-        verifyNoInteractions(fixture.taskRepository)
-    }
-
-    @Test
-    @DisplayName("dynamic batch size는 backlog step과 max prefetch multiplier를 fetch limit에 반영한다")
-    fun `dynamic batch size expands fetch limit by backlog prefetch multiplier`() {
-        val fixture =
-            createFixture(
-                maxConcurrent = 8,
-                perTypeMaxConcurrentRaw = "",
-                perTypeAutoTuneEnabled = true,
-                perTypeAutoTuneMinConcurrent = 1,
-                dynamicBatchBacklogPerStep = 100,
-                dynamicBatchMaxPrefetchMultiplier = 3,
-            )
-        org.mockito.Mockito
-            .`when`(
-                fixture.taskRepository.countByStatusAndNextRetryAtLessThanEqual(
-                    pendingStatus(),
-                    anyInstant(),
-                ),
-            ).thenReturn(250L)
-
-        val fetchLimit = invokeResolveFetchLimit(fixture.job, safeBatchSize = 50, availableWorkerSlots = 4)
-
-        assertThat(fetchLimit).isEqualTo(12)
-        verify(fixture.taskRepository)
-            .countByStatusAndNextRetryAtLessThanEqual(pendingStatus(), anyInstant())
-    }
-
     @Test
     @DisplayName("dynamic batch prefetch가 커져도 실제 시작 worker는 dynamic target을 넘지 않는다")
     fun `dynamic batch prefetch does not start more workers than dynamic target`() {
@@ -414,56 +257,6 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
         }
     }
 
-    @Test
-    @DisplayName("per-type auto-tune refresh는 task type별 ready backlog count를 조회하지 않는다")
-    fun `per type auto tune refresh avoids ready backlog count by task type`() {
-        val fixture =
-            createFixture(
-                maxConcurrent = 8,
-                perTypeMaxConcurrentRaw = "",
-                perTypeAutoTuneEnabled = true,
-                perTypeAutoTuneMinConcurrent = 1,
-                registeredTaskTypes = listOf("post.search-index.sync", "post.read.prewarm"),
-            )
-
-        invokeRefreshPerTypeDynamicLimitsIfNeeded(fixture.job)
-
-        verifyNoInteractions(fixture.taskRepository)
-        assertThat(invokeResolvePerTypeLimit(fixture.job, "post.search-index.sync")).isGreaterThanOrEqualTo(1)
-    }
-
-    @Test
-    @DisplayName("auto-tune limit map이 비어도 미지정 task type은 최소 1 permit을 보장한다")
-    fun `unknown task type fallback never returns zero permit`() {
-        val job =
-            createJob(
-                maxConcurrent = 8,
-                perTypeMaxConcurrentRaw = "",
-                perTypeAutoTuneEnabled = true,
-                perTypeAutoTuneMinConcurrent = 0,
-            )
-
-        val resolved = invokeResolvePerTypeLimit(job, "member.signupVerification.sendMail")
-
-        assertThat(resolved).isEqualTo(1)
-    }
-
-    @Test
-    @DisplayName("명시된 per-type 설정이 있으면 auto-tune fallback보다 우선한다")
-    fun `explicit per type max concurrent overrides fallback`() {
-        val job =
-            createJob(
-                maxConcurrent = 8,
-                perTypeMaxConcurrentRaw = "member.signupVerification.sendMail=2",
-                perTypeAutoTuneEnabled = true,
-                perTypeAutoTuneMinConcurrent = 4,
-            )
-
-        val resolved = invokeResolvePerTypeLimit(job, "member.signupVerification.sendMail")
-
-        assertThat(resolved).isEqualTo(2)
-    }
-
     private data class JobFixture(
         val job: TaskProcessingScheduledJob,
         val taskRepository: TaskRepository,
@@ -474,25 +267,6 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
         override val aggregateType: String = "test",
         override val aggregateId: Long = 1,
     ) : TaskPayload
-
-    private fun createJob(
-        maxConcurrent: Int,
-        perTypeMaxConcurrentRaw: String,
-        perTypeAutoTuneEnabled: Boolean,
-        perTypeAutoTuneMinConcurrent: Int,
-        dynamicConcurrencyEnabled: Boolean = true,
-        dynamicMinConcurrent: Int = 2,
-        dynamicBacklogPerSlot: Int = 25,
-    ): TaskProcessingScheduledJob =
-        createFixture(
-            maxConcurrent = maxConcurrent,
-            perTypeMaxConcurrentRaw = perTypeMaxConcurrentRaw,
-            perTypeAutoTuneEnabled = perTypeAutoTuneEnabled,
-            perTypeAutoTuneMinConcurrent = perTypeAutoTuneMinConcurrent,
-            dynamicConcurrencyEnabled = dynamicConcurrencyEnabled,
-            dynamicMinConcurrent = dynamicMinConcurrent,
-            dynamicBacklogPerSlot = dynamicBacklogPerSlot,
-        ).job
 
     private fun createFixture(
         maxConcurrent: Int,
@@ -752,52 +526,6 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
             assertThat(actual.get()).isEqualTo(expected)
             Thread.sleep(25)
         }
-    }
-
-    private fun invokeResolveAvailableWorkerSlots(job: TaskProcessingScheduledJob): Int {
-        val method = TaskProcessingScheduledJob::class.java.getDeclaredMethod("resolveAvailableWorkerSlots")
-        method.isAccessible = true
-        return method.invoke(job) as Int
-    }
-
-    private fun acquireWorkerSlots(
-        job: TaskProcessingScheduledJob,
-        permits: Int,
-    ) {
-        val field = TaskProcessingScheduledJob::class.java.getDeclaredField("concurrencyGate")
-        field.isAccessible = true
-        val gate = field.get(job) as Semaphore
-        gate.acquire(permits)
-    }
-
-    private fun invokeResolveFetchLimit(
-        job: TaskProcessingScheduledJob,
-        safeBatchSize: Int,
-        availableWorkerSlots: Int,
-    ): Int {
-        val method =
-            TaskProcessingScheduledJob::class.java.getDeclaredMethod(
-                "resolveFetchLimit",
-                Int::class.javaPrimitiveType,
-                Int::class.javaPrimitiveType,
-            )
-        method.isAccessible = true
-        return method.invoke(job, safeBatchSize, availableWorkerSlots) as Int
-    }
-
-    private fun invokeRefreshPerTypeDynamicLimitsIfNeeded(job: TaskProcessingScheduledJob) {
-        val method = TaskProcessingScheduledJob::class.java.getDeclaredMethod("refreshPerTypeDynamicLimitsIfNeeded")
-        method.isAccessible = true
-        method.invoke(job)
-    }
-
-    private fun invokeResolvePerTypeLimit(
-        job: TaskProcessingScheduledJob,
-        taskType: String,
-    ): Int {
-        val method = TaskProcessingScheduledJob::class.java.getDeclaredMethod("resolvePerTypeLimit", String::class.java)
-        method.isAccessible = true
-        return method.invoke(job, taskType) as Int
     }
 
     private fun anyInstant(): Instant {

--- a/back/src/test/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJobPerTypeLimitTest.kt
+++ b/back/src/test/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJobPerTypeLimitTest.kt
@@ -318,7 +318,6 @@ class TaskProcessingScheduledJobPerTypeLimitTest {
                 perTypeMaxConcurrentRaw = perTypeMaxConcurrentRaw,
                 perTypeAutoTuneEnabled = perTypeAutoTuneEnabled,
                 perTypeAutoTuneMinConcurrent = perTypeAutoTuneMinConcurrent,
-                perTypeAutoTuneBacklogPerSlot = 20,
                 perTypeAutoTuneRefreshMs = 15_000,
                 meterRegistry = null,
             )

--- a/back/src/test/kotlin/com/back/global/task/adapter/scheduler/TaskProcessorConcurrencyPolicyTest.kt
+++ b/back/src/test/kotlin/com/back/global/task/adapter/scheduler/TaskProcessorConcurrencyPolicyTest.kt
@@ -1,0 +1,156 @@
+package com.back.global.task.adapter.scheduler
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("TaskProcessorConcurrencyPolicy 테스트")
+class TaskProcessorConcurrencyPolicyTest {
+    @Test
+    @DisplayName("dynamic concurrency off는 backlog 조회 없이 고정 worker 동시성을 사용한다")
+    fun `fixed concurrency ignores ready backlog count`() {
+        val policy =
+            createPolicy(
+                workerConcurrency = 8,
+                dynamicConcurrencyEnabled = false,
+            )
+        var backlogCounted = false
+
+        val slots =
+            policy.availableWorkerSlots(activeWorkers = 0) {
+                backlogCounted = true
+                1L
+            }
+
+        assertThat(slots).isEqualTo(8)
+        assertThat(backlogCounted).isFalse()
+    }
+
+    @Test
+    @DisplayName("dynamic concurrency on은 backlog 증가에 따라 target worker 수를 확장한다")
+    fun `dynamic concurrency expands target workers by ready backlog`() {
+        val policy =
+            createPolicy(
+                workerConcurrency = 8,
+                dynamicConcurrencyEnabled = true,
+                dynamicMinConcurrent = 2,
+                dynamicBacklogPerSlot = 25,
+            )
+
+        assertThat(policy.availableWorkerSlots(activeWorkers = 0) { 1L }).isEqualTo(2)
+        assertThat(policy.availableWorkerSlots(activeWorkers = 0) { 200L }).isEqualTo(8)
+        assertThat(policy.availableWorkerSlots(activeWorkers = 3) { 200L }).isEqualTo(5)
+    }
+
+    @Test
+    @DisplayName("dynamic concurrency는 backlog 조회 실패 시 최대 worker 동시성으로 fallback한다")
+    fun `dynamic concurrency falls back to max workers when ready backlog count fails`() {
+        val policy =
+            createPolicy(
+                workerConcurrency = 8,
+                dynamicConcurrencyEnabled = true,
+                dynamicMinConcurrent = 2,
+                dynamicBacklogPerSlot = 25,
+            )
+
+        val slots = policy.availableWorkerSlots(activeWorkers = 0) { null }
+
+        assertThat(slots).isEqualTo(8)
+    }
+
+    @Test
+    @DisplayName("dynamic batch size는 backlog step과 max prefetch multiplier를 fetch limit에 반영한다")
+    fun `dynamic batch size expands fetch limit by backlog prefetch multiplier`() {
+        val policy =
+            createPolicy(
+                workerConcurrency = 8,
+                dynamicBatchBacklogPerStep = 100,
+                dynamicBatchMaxPrefetchMultiplier = 3,
+            )
+
+        val fetchLimit =
+            policy.fetchLimit(
+                safeBatchSize = 50,
+                availableWorkerSlots = 4,
+                recentHandlerDurationMs = 900,
+            ) {
+                250L
+            }
+
+        assertThat(fetchLimit).isEqualTo(12)
+    }
+
+    @Test
+    @DisplayName("per-type auto-tune은 explicit 설정을 우선하고 미지정 type은 최소 permit을 보장한다")
+    fun `per type limit prefers explicit value and keeps fallback permit`() {
+        val policy =
+            createPolicy(
+                workerConcurrency = 8,
+                perTypeAutoTuneEnabled = true,
+                perTypeAutoTuneMinConcurrent = 0,
+            )
+
+        assertThat(
+            policy.perTypeLimit(
+                taskType = "member.signupVerification.sendMail",
+                explicitPerTypeMaxConcurrent = mapOf("member.signupVerification.sendMail" to 2),
+                perTypeDynamicLimits = emptyMap(),
+            ),
+        ).isEqualTo(2)
+        assertThat(
+            policy.perTypeLimit(
+                taskType = "post.read.prewarm",
+                explicitPerTypeMaxConcurrent = emptyMap(),
+                perTypeDynamicLimits = emptyMap(),
+            ),
+        ).isEqualTo(1)
+    }
+
+    @Test
+    @DisplayName("per-type auto-tune은 등록 type별 dynamic budget을 worker concurrency 안에서 배분한다")
+    fun `per type dynamic limits distribute registered task types within worker budget`() {
+        val policy =
+            createPolicy(
+                workerConcurrency = 4,
+                perTypeAutoTuneEnabled = true,
+                perTypeAutoTuneMinConcurrent = 1,
+            )
+
+        val limits =
+            policy.dynamicPerTypeLimits(
+                registeredTaskTypes = listOf("post.search-index.sync", "post.read.prewarm"),
+                explicitPerTypeMaxConcurrent = mapOf("member.signupVerification.sendMail" to 1),
+            )
+
+        assertThat(limits).containsOnlyKeys("post.search-index.sync", "post.read.prewarm")
+        assertThat(limits.values.sum()).isLessThanOrEqualTo(3)
+        assertThat(limits.values).allSatisfy { limit -> assertThat(limit).isGreaterThanOrEqualTo(1) }
+    }
+
+    private fun createPolicy(
+        workerConcurrency: Int = 8,
+        dynamicConcurrencyEnabled: Boolean = true,
+        dynamicMinConcurrent: Int = 2,
+        dynamicBacklogPerSlot: Int = 25,
+        dynamicBatchSizeEnabled: Boolean = true,
+        dynamicBatchMinSize: Int = 4,
+        dynamicBatchBacklogPerStep: Int = 120,
+        dynamicBatchTargetHandlerDurationMs: Long = 900,
+        dynamicBatchMaxPrefetchMultiplier: Int = 2,
+        perTypeAutoTuneEnabled: Boolean = true,
+        perTypeAutoTuneMinConcurrent: Int = 1,
+    ): TaskProcessorConcurrencyPolicy =
+        TaskProcessorConcurrencyPolicy(
+            workerConcurrency = workerConcurrency,
+            dynamicConcurrencyEnabled = dynamicConcurrencyEnabled,
+            dynamicMinConcurrent = dynamicMinConcurrent,
+            dynamicBacklogPerSlot = dynamicBacklogPerSlot,
+            dynamicBatchSizeEnabled = dynamicBatchSizeEnabled,
+            dynamicBatchMinSize = dynamicBatchMinSize,
+            dynamicBatchBacklogPerStep = dynamicBatchBacklogPerStep,
+            dynamicBatchTargetHandlerDurationMs = dynamicBatchTargetHandlerDurationMs,
+            dynamicBatchMaxPrefetchMultiplier = dynamicBatchMaxPrefetchMultiplier,
+            perTypeAutoTuneEnabled = perTypeAutoTuneEnabled,
+            perTypeAutoTuneMinConcurrent = perTypeAutoTuneMinConcurrent,
+        )
+}

--- a/back/src/test/kotlin/com/back/global/task/adapter/scheduler/TaskProcessorConcurrencyPolicyTest.kt
+++ b/back/src/test/kotlin/com/back/global/task/adapter/scheduler/TaskProcessorConcurrencyPolicyTest.kt
@@ -40,6 +40,7 @@ class TaskProcessorConcurrencyPolicyTest {
         assertThat(policy.availableWorkerSlots(activeWorkers = 0) { 1L }).isEqualTo(2)
         assertThat(policy.availableWorkerSlots(activeWorkers = 0) { 200L }).isEqualTo(8)
         assertThat(policy.availableWorkerSlots(activeWorkers = 3) { 200L }).isEqualTo(5)
+        assertThat(policy.availableWorkerSlots(activeWorkers = 10) { 200L }).isZero()
     }
 
     @Test
@@ -81,6 +82,51 @@ class TaskProcessorConcurrencyPolicyTest {
     }
 
     @Test
+    @DisplayName("dynamic batch size off는 batch size와 남은 worker slot 중 작은 값을 사용한다")
+    fun `fixed batch size uses lower batch size and available slots`() {
+        val policy =
+            createPolicy(
+                workerConcurrency = 8,
+                dynamicBatchSizeEnabled = false,
+            )
+        var backlogCounted = false
+
+        val fetchLimit =
+            policy.fetchLimit(
+                safeBatchSize = 50,
+                availableWorkerSlots = 3,
+                recentHandlerDurationMs = 900,
+            ) {
+                backlogCounted = true
+                100L
+            }
+
+        assertThat(fetchLimit).isEqualTo(3)
+        assertThat(backlogCounted).isFalse()
+    }
+
+    @Test
+    @DisplayName("dynamic batch size는 backlog 조회 실패 시 max prefetch multiplier로 fallback한다")
+    fun `dynamic batch size falls back to max prefetch multiplier when backlog count fails`() {
+        val policy =
+            createPolicy(
+                workerConcurrency = 8,
+                dynamicBatchMaxPrefetchMultiplier = 3,
+            )
+
+        val fetchLimit =
+            policy.fetchLimit(
+                safeBatchSize = 50,
+                availableWorkerSlots = 2,
+                recentHandlerDurationMs = 3_600,
+            ) {
+                null
+            }
+
+        assertThat(fetchLimit).isEqualTo(4)
+    }
+
+    @Test
     @DisplayName("per-type auto-tune은 explicit 설정을 우선하고 미지정 type은 최소 permit을 보장한다")
     fun `per type limit prefers explicit value and keeps fallback permit`() {
         val policy =
@@ -101,9 +147,40 @@ class TaskProcessorConcurrencyPolicyTest {
             policy.perTypeLimit(
                 taskType = "post.read.prewarm",
                 explicitPerTypeMaxConcurrent = emptyMap(),
+                perTypeDynamicLimits = mapOf("post.read.prewarm" to 3),
+            ),
+        ).isEqualTo(3)
+        assertThat(
+            policy.perTypeLimit(
+                taskType = "post.search-index.sync",
+                explicitPerTypeMaxConcurrent = emptyMap(),
                 perTypeDynamicLimits = emptyMap(),
             ),
         ).isEqualTo(1)
+    }
+
+    @Test
+    @DisplayName("per-type auto-tune off는 미지정 type에 전체 worker 동시성을 사용한다")
+    fun `per type limit uses worker concurrency when auto tune is disabled`() {
+        val policy =
+            createPolicy(
+                workerConcurrency = 8,
+                perTypeAutoTuneEnabled = false,
+            )
+
+        assertThat(
+            policy.perTypeLimit(
+                taskType = "post.read.prewarm",
+                explicitPerTypeMaxConcurrent = emptyMap(),
+                perTypeDynamicLimits = emptyMap(),
+            ),
+        ).isEqualTo(8)
+        assertThat(
+            policy.dynamicPerTypeLimits(
+                registeredTaskTypes = listOf("post.search-index.sync"),
+                explicitPerTypeMaxConcurrent = emptyMap(),
+            ),
+        ).isEmpty()
     }
 
     @Test
@@ -125,6 +202,55 @@ class TaskProcessorConcurrencyPolicyTest {
         assertThat(limits).containsOnlyKeys("post.search-index.sync", "post.read.prewarm")
         assertThat(limits.values.sum()).isLessThanOrEqualTo(3)
         assertThat(limits.values).allSatisfy { limit -> assertThat(limit).isGreaterThanOrEqualTo(1) }
+    }
+
+    @Test
+    @DisplayName("per-type auto-tune은 최소 permit 합계가 budget을 넘으면 큰 limit부터 줄인다")
+    fun `per type dynamic limits trim largest limit when minimum total exceeds budget`() {
+        val policy =
+            createPolicy(
+                workerConcurrency = 8,
+                perTypeAutoTuneEnabled = true,
+                perTypeAutoTuneMinConcurrent = 3,
+            )
+
+        val limits =
+            policy.dynamicPerTypeLimits(
+                registeredTaskTypes =
+                    listOf(
+                        "post.search-index.sync",
+                        "post.read.prewarm",
+                        "member.signupVerification.sendMail",
+                    ),
+                explicitPerTypeMaxConcurrent = emptyMap(),
+            )
+
+        assertThat(limits.values.sum()).isEqualTo(8)
+        assertThat(limits.values).containsExactlyInAnyOrder(2, 3, 3)
+    }
+
+    @Test
+    @DisplayName("per-type auto-tune은 explicit type만 있거나 남은 budget이 없으면 dynamic limit을 비운다")
+    fun `per type dynamic limits are empty without dynamic type budget`() {
+        val policy =
+            createPolicy(
+                workerConcurrency = 2,
+                perTypeAutoTuneEnabled = true,
+                perTypeAutoTuneMinConcurrent = 1,
+            )
+
+        assertThat(
+            policy.dynamicPerTypeLimits(
+                registeredTaskTypes = listOf("post.read.prewarm"),
+                explicitPerTypeMaxConcurrent = mapOf("post.read.prewarm" to 1),
+            ),
+        ).isEmpty()
+        assertThat(
+            policy.dynamicPerTypeLimits(
+                registeredTaskTypes = listOf("post.read.prewarm"),
+                explicitPerTypeMaxConcurrent = mapOf("member.signupVerification.sendMail" to 8),
+            ),
+        ).isEmpty()
     }
 
     private fun createPolicy(


### PR DESCRIPTION
## 관련 이슈

close #893

## 작업 배경

- task scheduler concurrency 테스트가 `TaskProcessingScheduledJob` private method/field를 reflection으로 호출해 구현 세부 이름에 결합되어 있었다.
- backend 테스트 naming 기준과 cache/task/cloud/retention failure injection backlog가 #893 완료 기준으로 고정되어 있지 않았다.

## 작업 내용

- `TaskProcessorConcurrencyPolicy`를 추가해 dynamic worker slot, fetch limit, per-type limit 계산을 scheduler private method 밖으로 분리했다.
- 기존 private reflection 기반 concurrency 테스트를 정책 객체 테스트와 관찰 가능한 scheduler 동작 테스트로 대체했다.
- architecture guard에 `TaskProcessingScheduledJob` private reflection 접근 금지 검사를 추가하고, public annotation 확인용 `processTasks`만 예외로 허용했다.
- backend 테스트 naming 기준과 failure injection backlog를 `BackendTestConventionBacklogTest`로 고정했다.
- unused `perTypeAutoTuneBacklogPerSlot` 설정을 제거하고 CI coverage gate 분기 테스트를 보강했다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back cleanTest test --tests '*Task*'` 성공
  - `back/gradlew -p back cleanTest test --tests '*Post*' --tests '*Cloud*' --tests '*Upload*'` 성공
  - `back/gradlew -p back cleanTest test --tests '*BackendTestConventionBacklogTest*'` 성공
  - `back/gradlew -p back cleanTest test --tests '*ArchitectureGuardTest*'` 성공
  - `back/gradlew -p back ciFastCoverageVerification` 성공
  - `back/gradlew -p back ktlintCheck` 성공
  - `git diff --check` 성공
- GitHub checks: backend-ci, frontend-ci, Security CodeQL, Vercel 모두 성공.
- CodeRabbit: actionable inline thread 해결 답글 작성 및 resolved 확인.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `TaskProcessingScheduledJob`에서 계산식 이동 전후의 dynamic concurrency/fetch/per-type limit 동작 동일성, `ArchitectureGuardTest`의 scheduler reflection 탐지 범위와 `processTasks` 예외.

## 리스크

- scheduler 계산식은 정책 객체로 이동했지만 public API나 runtime 설정 이름 중 실제 사용되는 항목은 유지했다. per-type budget 배분과 dynamic fallback 동작은 정책 테스트, task 회귀 테스트, CI coverage gate로 확인했다.
- 한 번 병렬 Gradle 테스트 실행으로 `testInfraDown`과 test output이 충돌했으며, 이후 모든 Gradle 검증은 단일 명령으로 순차 재실행해 성공 상태를 확인했다.
- `perTypeAutoTuneBacklogPerSlot`은 사용되지 않는 설정이라 제거했다. 참조 검색과 CodeRabbit 지적을 기준으로 dead config로 판단했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (해당 없음: CodeRabbit check 성공 및 review thread resolved)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음, Vercel preview 성공 확인)