### PR TITLE
[Docs] 비동기·캐시·업로드 운영 계약 문서화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@ CLAUDE.md
 GEMINI.md
 CURSOR.md
 COPILOT.md
-docs/
+docs/*
+!docs/design/
+!docs/design/**
 .cursor/
 .claude/
 .aider/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - [환경 변수](#환경-변수)
 - [품질 게이트](#품질-게이트)
 - [운영 및 배포](#운영-및-배포)
+- [운영 계약 문서](#운영-계약-문서)
 - [트러블슈팅 기록](#트러블슈팅-기록)
 - [현재 상태와 개선 방향](#현재-상태와-개선-방향)
 - [관련 링크](#관련-링크)
@@ -198,7 +199,7 @@ Aquila Blog는 글 작성 도구와 공개 블로그를 하나로 묶고, 운영
 ├── deploy/homeserver/      # Blue/Green 배포, 복구, Caddy, monitoring 스크립트
 ├── infra/                  # Terraform 기반 인프라 정의
 ├── perf/k6/                # 공개 읽기 경로 성능/chaos 시나리오
-├── docs/                   # agent 작업 계획과 Superpowers spec/plan
+├── docs/                   # 운영 계약과 설계 문서
 ├── tools/                  # repo guard, bundle-size, current-task 관련 도구
 └── README.assets/          # README용 화면/아키텍처 이미지
 ```
@@ -328,6 +329,17 @@ Playwright 계열 스크립트는 `playwright:preflight`를 먼저 실행해 로
 | `deploy/homeserver/doctor.sh` | 홈서버 상태 진단 |
 | `deploy/homeserver/steady_state_guard.sh` | Caddy mount, readiness, 단일 실행 규칙 점검 |
 | `deploy/homeserver/monitoring/` | Prometheus, Grafana, Loki, Promtail 구성 |
+
+---
+
+## 운영 계약 문서
+
+| 문서 | 설명 |
+| --- | --- |
+| [Task Delivery Guarantees](docs/design/task-delivery-guarantees.md) | durable task queue 전달 보장, retry, idempotency key, DLQ replay 계약 |
+| [Cache Consistency Contract](docs/design/cache-consistency-contract.md) | 공개 post read ETag, Redis/local cache, CDN cache tag, author representation invalidation 계약 |
+| [Cloud Multipart Upload State Machine](docs/design/cloud-multipart-state-machine.md) | 클라우드 동영상 multipart upload session 상태 전이와 실패 복구 기준 |
+| [Profile Workspace Persistence](docs/design/profile-workspace-persistence.md) | profile workspace draft/published/legacy attr 저장 규칙과 복구 절차 |
 
 ---
 

--- a/back/src/test/kotlin/com/back/support/BasePerformanceIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BasePerformanceIntegrationTest.kt
@@ -7,6 +7,7 @@ import org.springframework.test.context.TestPropertySource
         "spring.jpa.properties.hibernate.generate_statistics=true",
         "spring.task.scheduling.enabled=false",
         "custom.task.processor.enabled=false",
+        "custom.runtime.worker-enabled=false",
     ],
 )
 abstract class BasePerformanceIntegrationTest : BaseControllerIntegrationTest()

--- a/docs/design/cache-consistency-contract.md
+++ b/docs/design/cache-consistency-contract.md
@@ -1,0 +1,62 @@
+# Cache Consistency Contract
+
+## 목적
+
+공개 post read path의 ETag, Redis/local cache, CDN cache tag, 작성자 표시 변경의 일관성 계약을 정의한다.
+
+## 구현 근거
+
+| 책임 | 구현 |
+| --- | --- |
+| ETag seed | `back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadEtagSeedBuilder.kt` |
+| Cache header | `back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/PostPublicReadCacheHeaderWriter.kt` |
+| Cache tag token | `back/src/main/kotlin/com/back/boundedContexts/post/application/support/PostCacheTags.kt` |
+| Read cache eviction | `back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostReadCacheInvalidator.kt` |
+| Write side effect | `back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt` |
+| Invalidation scope | `back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectCommand.kt` |
+| Author update listener | `back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostAuthorPublicReadCacheInvalidationListener.kt` |
+| Member profile event | `back/src/main/kotlin/com/back/boundedContexts/member/application/event/MemberPublicProfileChangedEvent.kt` |
+
+## Consistency guarantee
+
+- 공개 feed/detail ETag seed는 post modified time, version, count fields, author public representation을 포함한다.
+- author representation은 `authorId`, `authorName`, `authorUsername`, profile image URL 계열을 length-prefixed token으로 포함한다.
+- post write side effect는 DB commit 이후 task로 실행되어 read cache eviction, CDN purge event, recommendation refresh/evict를 분리 수행한다.
+- author nickname/profile image 변경은 `MemberPublicProfileChangedEvent`로 발행되고, post read cache는 `invalidateAuthorRepresentation`으로 clear된다.
+- Cache tag는 `PostCacheTags`에서 단일 정의하며 response header와 purge key drift를 줄인다.
+
+## Invalidation scope
+
+| 변경 | Eviction target |
+| --- | --- |
+| public post create/delete/restore/hard delete | hot read pages, search first page, impacted tag pages, public tags, detail |
+| public post title/content/tag/listed visibility 변경 | impact에 따라 hot read pages, search, tag pages, public tags, detail |
+| detail-only 변경 | detail snapshot/meta/content/negative cache |
+| author public representation 변경 | admin first page, feed, explore, cursor first page, bootstrap, search, public detail snapshot/meta/content clear |
+| tag count 변경 | local tag count cache와 `PostQueryCacheNames.TAGS` public key |
+
+## Retry 조건
+
+- post write side effect task는 `post.write.side-effect`이며 `maxRetries=5`, `baseDelaySeconds=10`, `backoffMultiplier=2.0`, `maxDelaySeconds=300`으로 재시도된다.
+- cache eviction 자체는 idempotent하므로 같은 task가 여러 번 실행되어도 안전해야 한다.
+- author update listener는 transaction after-commit에서 동작하며 eviction 실패를 warn log로 남긴다. listener 실패는 member update transaction을 되돌리지 않는다.
+
+## Idempotency key
+
+- Queue key는 post write side effect payload UID이다.
+- CDN/cache purge key는 `PostCacheTags.writeInvalidationTags(postId, beforeTags, afterTags)` 결과와 invalidation scope로 결정된다.
+- ETag key는 response body DTO의 public representation으로 계산되며 별도 저장 상태를 만들지 않는다.
+
+## 실패 후 수동 복구
+
+1. post write side effect task가 FAILED이면 `GET /system/api/v1/adm/tasks`에서 `post.write.side-effect` 상태를 확인한다.
+2. `POST /system/api/v1/adm/tasks/replay-failed`로 `post.write.side-effect`만 replay한다.
+3. author representation stale이 의심되면 해당 member update 이후 post read caches가 clear됐는지 `post.read.cache.evict` metric의 `reason=author-representation`을 확인한다.
+4. CDN stale이 의심되면 response의 cache tag와 `PostCacheTags` token이 같은지 확인하고, 해당 post/tag/list/detail tag를 purge한다.
+5. Redis 장애 또는 cache miss는 공개 read path가 DB/source fallback을 사용하므로 데이터 정합성보다 응답 지연을 먼저 점검한다.
+
+## 금지 사항
+
+- ETag seed에 포함된 public field를 변경하면서 read cache invalidation 범위를 갱신하지 않으면 안 된다.
+- `PostCacheTags` 밖에서 임의 cache tag string을 만들지 않는다.
+- author nickname/profile image 변경은 post cache clear와 연결되어야 한다.

--- a/docs/design/cloud-multipart-state-machine.md
+++ b/docs/design/cloud-multipart-state-machine.md
@@ -44,7 +44,8 @@
 - multipart upload는 client-driven API 흐름이므로 일반 task retry 대상이 아니다.
 - part upload 중 remote storage 호출이 실패하면 `UPLOADING_PART -> IN_PROGRESS`로 claim을 풀고 client가 같은 part를 다시 보낼 수 있게 한다.
 - part metadata 저장 실패는 remote part가 이미 저장됐을 수 있으므로 session을 `FAILED`로 표시한다.
-- complete 실패는 `COMPLETING` 기준 `FAILED`로 표시한다.
+- remote complete 호출 자체가 실패하면 `COMPLETING` 기준 `FAILED`로 표시한다.
+- remote complete가 성공한 뒤 `CloudFile` 저장 또는 session `COMPLETED` 저장이 실패하면 row가 `COMPLETING`에 남을 수 있다. 이 상태는 client retry로 재완료할 수 없으므로 stuck completion 복구 대상으로 본다.
 - abort 실패는 `ABORTING` 기준 `FAILED`로 표시한다.
 - expired session cleanup은 scheduler가 batch로 호출하며 session 단위 실패를 warn log로 격리하고 다음 batch에서 다른 session 처리를 계속한다.
 
@@ -62,8 +63,9 @@
 2. `FAILED`가 `INITIATING` failure이고 uploadId가 없다면 remote multipart가 생성되지 않았거나 attach 전에 실패한 상태다. client가 새 session을 만들게 한다.
 3. `FAILED`가 `UPLOADING_PART` metadata save failure이면 remote part가 있을 수 있다. 같은 objectKey/uploadId를 remote storage에서 abort한 뒤 session을 운영 기록에 남기고 client에게 새 session을 만들게 한다.
 4. `FAILED`가 `COMPLETING` failure이면 remote complete 결과가 불명확하다. remote object 존재 여부를 확인하고, object가 존재하면 `CloudFile` row 누락 여부를 점검한다.
-5. `FAILED`가 `ABORTING` failure이면 remote multipart upload가 orphan일 수 있다. remote storage에서 uploadId를 abort한 뒤 session을 terminal recovery 대상으로 기록한다.
-6. 만료 session은 `CloudVideoUploadSessionCleanupScheduledJob`가 `purgeExpiredSessions`로 처리한다. scheduler가 멈췄다면 worker/admin runtime 상태와 cleanup job log를 먼저 확인한다.
+5. `COMPLETING` 상태가 요청 timeout/retry window를 지나 계속 남아 있으면 remote complete 성공 후 DB 저장이 실패한 stuck completion으로 분류한다. remote object와 `CloudFile` row, `completedFileId`를 대조하고 운영 기록을 남긴 뒤 보정 SQL 또는 재처리 작업으로 `CloudFile`/session terminal 상태를 맞춘다.
+6. `FAILED`가 `ABORTING` failure이면 remote multipart upload가 orphan일 수 있다. remote storage에서 uploadId를 abort한 뒤 session을 terminal recovery 대상으로 기록한다.
+7. 만료 session은 `CloudVideoUploadSessionCleanupScheduledJob`가 `purgeExpiredSessions`로 처리한다. scheduler가 멈췄다면 worker/admin runtime 상태와 cleanup job log를 먼저 확인한다.
 
 ## 금지 사항
 

--- a/docs/design/cloud-multipart-state-machine.md
+++ b/docs/design/cloud-multipart-state-machine.md
@@ -1,0 +1,72 @@
+# Cloud Multipart Upload State Machine
+
+## 목적
+
+클라우드 동영상 multipart upload session의 상태 전이, retry 기준, idempotency key, 장애 후 수동 복구 절차를 정의한다.
+
+## 구현 근거
+
+| 책임 | 구현 |
+| --- | --- |
+| 상태 모델 | `back/src/main/kotlin/com/back/boundedContexts/cloud/model/CloudVideoUploadSession.kt` |
+| 상태 전이 서비스 | `back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionService.kt` |
+| Session repository port | `back/src/main/kotlin/com/back/boundedContexts/cloud/application/port/output/CloudVideoUploadSessionRepositoryPort.kt` |
+| Part repository port | `back/src/main/kotlin/com/back/boundedContexts/cloud/application/port/output/CloudVideoUploadSessionRepositoryPort.kt` |
+| Cleanup scheduler | `back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/scheduler/CloudVideoUploadSessionCleanupScheduledJob.kt` |
+| Storage adapter contract | `back/src/main/kotlin/com/back/global/storage/application/port/output/CloudStoragePort.kt` |
+
+## 상태
+
+| 상태 | 의미 |
+| --- | --- |
+| `INITIATING` | DB session row는 생성됐고 remote multipart upload init을 진행 중이다. |
+| `IN_PROGRESS` | uploadId가 연결됐고 part upload/complete/cancel 요청을 받을 수 있다. |
+| `UPLOADING_PART` | 특정 part를 remote storage에 업로드 중이다. |
+| `COMPLETING` | 모든 part metadata가 있고 remote complete 호출 중이다. |
+| `ABORTING` | cancel/expire 보상으로 remote multipart abort 호출 중이다. |
+| `COMPLETED` | remote complete가 끝났고 `CloudFile` row가 생성됐다. |
+| `CANCELLED` | 사용자가 취소했고 part metadata가 삭제됐다. |
+| `EXPIRED` | 만료 cleanup이 abort와 part metadata 삭제를 끝냈다. |
+| `FAILED` | initiate/part metadata/complete/abort 중 복구 불가능한 예외가 기록됐다. |
+
+## 전이 계약
+
+- `createSession`은 `INITIATING` row를 먼저 저장한 뒤 remote `initiateMultipartUpload`을 호출한다.
+- uploadId attach는 `INITIATING -> IN_PROGRESS` compare-and-set 전이다.
+- `uploadPart`는 `IN_PROGRESS -> UPLOADING_PART -> IN_PROGRESS`로 claim을 잡고 해제한다.
+- 같은 `sessionId + partNumber`가 이미 저장되어 있고 byte size가 같으면 기존 part 응답을 반환한다.
+- `complete`는 모든 part number가 `1..totalParts`로 존재할 때만 `IN_PROGRESS -> COMPLETING -> COMPLETED`로 진행한다.
+- `cancel`과 expiry cleanup은 `IN_PROGRESS -> ABORTING -> CANCELLED|EXPIRED` 경로를 사용한다.
+- terminal status는 `COMPLETED`, `CANCELLED`, `EXPIRED`, `FAILED`이다.
+
+## Retry 조건
+
+- multipart upload는 client-driven API 흐름이므로 일반 task retry 대상이 아니다.
+- part upload 중 remote storage 호출이 실패하면 `UPLOADING_PART -> IN_PROGRESS`로 claim을 풀고 client가 같은 part를 다시 보낼 수 있게 한다.
+- part metadata 저장 실패는 remote part가 이미 저장됐을 수 있으므로 session을 `FAILED`로 표시한다.
+- complete 실패는 `COMPLETING` 기준 `FAILED`로 표시한다.
+- abort 실패는 `ABORTING` 기준 `FAILED`로 표시한다.
+- expired session cleanup은 scheduler가 batch로 호출하며 session 단위 실패를 warn log로 격리하고 다음 batch에서 다른 session 처리를 계속한다.
+
+## Idempotency key
+
+- Session identity: `CloudVideoUploadSession.id`.
+- Remote object identity: `CloudVideoUploadSession.objectKey`, DB unique column.
+- Remote upload identity: `CloudVideoUploadSession.uploadId`.
+- Part identity: unique constraint `session_id + part_number` on `CloudVideoUploadPart`.
+- Completed file identity: `completedFileId`; complete가 성공하면 같은 session은 terminal status라 재완료되지 않는다.
+
+## 실패 후 수동 복구
+
+1. session status를 DB에서 확인한다: `cloud_video_upload_session.status`, `failure_reason`, `object_key`, `upload_id`, `expires_at`.
+2. `FAILED`가 `INITIATING` failure이고 uploadId가 없다면 remote multipart가 생성되지 않았거나 attach 전에 실패한 상태다. client가 새 session을 만들게 한다.
+3. `FAILED`가 `UPLOADING_PART` metadata save failure이면 remote part가 있을 수 있다. 같은 objectKey/uploadId를 remote storage에서 abort한 뒤 session을 운영 기록에 남기고 client에게 새 session을 만들게 한다.
+4. `FAILED`가 `COMPLETING` failure이면 remote complete 결과가 불명확하다. remote object 존재 여부를 확인하고, object가 존재하면 `CloudFile` row 누락 여부를 점검한다.
+5. `FAILED`가 `ABORTING` failure이면 remote multipart upload가 orphan일 수 있다. remote storage에서 uploadId를 abort한 뒤 session을 terminal recovery 대상으로 기록한다.
+6. 만료 session은 `CloudVideoUploadSessionCleanupScheduledJob`가 `purgeExpiredSessions`로 처리한다. scheduler가 멈췄다면 worker/admin runtime 상태와 cleanup job log를 먼저 확인한다.
+
+## 금지 사항
+
+- `UPLOADING_PART`, `COMPLETING`, `ABORTING` 상태를 DB에서 직접 `IN_PROGRESS`로 되돌리지 않는다. remote side effect 결과를 먼저 확인해야 한다.
+- part metadata를 수동 insert할 때 remote eTag 없이 임의 값을 넣지 않는다.
+- `objectKey`를 재사용해 새 session을 만들지 않는다.

--- a/docs/design/profile-workspace-persistence.md
+++ b/docs/design/profile-workspace-persistence.md
@@ -1,0 +1,62 @@
+# Profile Workspace Persistence
+
+## 목적
+
+관리자 프로필 workspace의 draft/published/legacy attr 저장 규칙, retry 기준, idempotency key, 장애 후 복구 절차를 정의한다.
+
+## 구현 근거
+
+| 책임 | 구현 |
+| --- | --- |
+| Workspace model | `back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberProfileWorkspace.kt` |
+| Legacy/profile attr bridge | `back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberHasProfileCard.kt` |
+| Persistence service | `back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberProfilePersistenceService.kt` |
+| Application boundary | `back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt` |
+| Query boundary | `back/src/main/kotlin/com/back/boundedContexts/member/application/service/CurrentMemberProfileQueryService.kt` |
+| Admin API | `back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberController.kt` |
+| Public profile change event | `back/src/main/kotlin/com/back/boundedContexts/member/application/event/MemberPublicProfileChangedEvent.kt` |
+
+## 저장 슬롯
+
+| 슬롯 | attr name | 역할 |
+| --- | --- | --- |
+| legacy attrs | `profileRole`, `profileBio`, `aboutRole`, `aboutBio`, `aboutDetails`, `blogTitle`, `homeIntroTitle`, `homeIntroDescription`, `blogDesign`, `legacyBlogScheme`, `profileServiceLinks`, `profileContactLinks`, `profileImgUrl` | 기존 공개/관리자 경로와 호환되는 필드 저장소 |
+| draft workspace | `profileWorkspaceDraft` | 관리자 workspace에서 편집 중인 normalized JSON snapshot |
+| published workspace | `profileWorkspacePublished` | 공개 프로필 read path가 우선 사용하는 normalized JSON snapshot |
+
+## Persistence contract
+
+- `ensureWorkspaceSnapshotsInitialized`는 workspace attr이 없으면 현재 legacy attrs에서 published와 draft snapshot을 만든다.
+- `modifyProfileCard`는 legacy attrs를 갱신하고 draft workspace를 legacy 기준으로 동기화한다. published workspace는 바꾸지 않는다.
+- `saveProfileWorkspaceDraft`는 request content를 normalize한 뒤 legacy attrs와 draft workspace를 함께 저장한다. published workspace는 바꾸지 않는다.
+- `publishProfileWorkspace`는 draft workspace를 published workspace로 복사한다. legacy attrs는 draft save 시점에 이미 동기화된다.
+- 공개 profile query는 `getProfileWorkspacePublishedContent()`와 published modifiedAt을 사용한다.
+- workspace JSON decode가 실패하거나 비어 있으면 legacy attrs에서 `currentProfileWorkspaceContent`를 만들어 fallback한다.
+
+## Retry 조건
+
+- profile workspace 저장은 HTTP transaction 안에서 처리되며 별도 async task retry 대상이 아니다.
+- DB transaction 실패 또는 optimistic conflict가 발생하면 client가 같은 payload로 다시 요청해야 한다.
+- image URL이 바뀌면 `UploadedFileRetentionService.syncProfileImage`가 이전/현재 profile image 참조를 동기화한다. 이 호출은 같은 transaction boundary 안에서 수행된다.
+- nickname/profile image가 바뀌면 `MemberPublicProfileChangedEvent`가 발행되어 post author representation cache invalidation을 유도한다.
+
+## Idempotency key
+
+- Workspace identity: member ID + attr name.
+- Draft save idempotency: 같은 member ID에 같은 normalized content를 다시 저장하면 draft JSON과 legacy attrs가 같은 값으로 덮인다.
+- Publish idempotency: draft와 published가 같으면 다시 publish해도 공개 content는 변하지 않는다.
+- Profile image retention identity: member ID + previous/current profile image URL.
+
+## 실패 후 수동 복구
+
+1. 관리자 API `GET /member/api/v1/adm/members/{id}/profileWorkspace`로 draft/published와 `dirtyFromPublished`를 확인한다.
+2. draft JSON이 깨졌거나 비어 있고 legacy attrs가 정상이라면 `PUT /member/api/v1/adm/members/{id}/profileWorkspace/draft`로 legacy 기준 content를 다시 저장한다.
+3. published가 오래됐으면 draft 내용을 확인한 뒤 `POST /member/api/v1/adm/members/{id}/profileWorkspace/publish`를 다시 호출한다.
+4. profile image 참조가 맞지 않으면 member의 legacy `profileImgUrl`, draft/published `profileImageUrl`, uploaded file retention 상태를 함께 확인한다.
+5. author 표시가 post public read path에 stale로 보이면 `MemberPublicProfileChangedEvent` 이후 post cache invalidation metric과 `docs/design/cache-consistency-contract.md`의 author recovery 절차를 따른다.
+
+## 금지 사항
+
+- published workspace를 거치지 않고 공개 profile DTO에 draft content를 사용하지 않는다.
+- `profileWorkspaceDraft` 또는 `profileWorkspacePublished` JSON을 수동 편집할 때 normalize 규칙을 우회하지 않는다.
+- legacy attrs와 draft workspace를 따로 고치지 않는다. draft save 경로는 두 저장소를 함께 동기화한다.

--- a/docs/design/profile-workspace-persistence.md
+++ b/docs/design/profile-workspace-persistence.md
@@ -38,7 +38,8 @@
 - profile workspace 저장은 HTTP transaction 안에서 처리되며 별도 async task retry 대상이 아니다.
 - DB transaction 실패 또는 optimistic conflict가 발생하면 client가 같은 payload로 다시 요청해야 한다.
 - image URL이 바뀌면 `UploadedFileRetentionService.syncProfileImage`가 이전/현재 profile image 참조를 동기화한다. 이 호출은 같은 transaction boundary 안에서 수행된다.
-- nickname/profile image가 바뀌면 `MemberPublicProfileChangedEvent`가 발행되어 post author representation cache invalidation을 유도한다.
+- 계정 profile 수정 경로(`MemberApplicationService.modify`)에서 nickname/profile image가 바뀌면 `MemberPublicProfileChangedEvent`가 발행되어 post author representation cache invalidation을 유도한다.
+- workspace draft save와 publish 경로는 profile image file retention을 동기화하지만 `MemberPublicProfileChangedEvent`를 발행하지 않는다.
 
 ## Idempotency key
 
@@ -53,7 +54,7 @@
 2. draft JSON이 깨졌거나 비어 있고 legacy attrs가 정상이라면 `PUT /member/api/v1/adm/members/{id}/profileWorkspace/draft`로 legacy 기준 content를 다시 저장한다.
 3. published가 오래됐으면 draft 내용을 확인한 뒤 `POST /member/api/v1/adm/members/{id}/profileWorkspace/publish`를 다시 호출한다.
 4. profile image 참조가 맞지 않으면 member의 legacy `profileImgUrl`, draft/published `profileImageUrl`, uploaded file retention 상태를 함께 확인한다.
-5. author 표시가 post public read path에 stale로 보이면 `MemberPublicProfileChangedEvent` 이후 post cache invalidation metric과 `docs/design/cache-consistency-contract.md`의 author recovery 절차를 따른다.
+5. workspace draft save 또는 publish로 profile image가 바뀐 뒤 post public read path의 author image가 stale로 보이면 자동 event 발행을 기대하지 않는다. 계정 profile 수정 event 발생 여부를 먼저 확인하고, event가 없었다면 `docs/design/cache-consistency-contract.md`의 author recovery 절차로 post cache를 수동 복구한다.
 
 ## 금지 사항
 

--- a/docs/design/task-delivery-guarantees.md
+++ b/docs/design/task-delivery-guarantees.md
@@ -1,0 +1,66 @@
+# Task Delivery Guarantees
+
+## 목적
+
+이 문서는 backend durable task queue의 전달 보장, retry 기준, idempotency key, 장애 후 수동 복구 절차를 정의한다. 대상 구현은 `back/src/main/kotlin/com/back/global/task/**`와 post side effect task이다.
+
+## 구현 근거
+
+| 책임 | 구현 |
+| --- | --- |
+| Queue 저장 | `back/src/main/kotlin/com/back/global/task/application/TaskFacade.kt` |
+| 상태 모델 | `back/src/main/kotlin/com/back/global/task/model/Task.kt` |
+| Scheduler/worker | `back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt` |
+| Retry policy | `back/src/main/kotlin/com/back/global/task/application/TaskRetryPolicy.kt` |
+| Handler context | `back/src/main/kotlin/com/back/global/task/application/TaskExecutionContextHolder.kt` |
+| DLQ replay | `back/src/main/kotlin/com/back/global/task/application/TaskDlqReplayService.kt` |
+| 운영 API | `back/src/main/kotlin/com/back/global/system/adapter/web/ApiV1AdmSystemController.kt` |
+| Post write task | `back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectCommand.kt` |
+| Post interaction task | `back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostInteractionSideEffectCommand.kt` |
+
+## Delivery guarantee
+
+- Queue insert는 `Task.uid` unique constraint와 `TaskFacade.saveTaskIdempotently`로 idempotent insert를 보장한다.
+- Scheduler는 `PENDING` + `nextRetryAt <= now` task를 DB lock으로 가져와 `PROCESSING`으로 전이한다.
+- Worker는 task마다 `executionLeaseToken`을 발급하고, 완료/실패 전이는 현재 lease가 일치할 때만 반영한다.
+- 처리 보장은 at-least-once이다. 동일 task가 timeout, worker crash, stale PROCESSING recovery 뒤 재실행될 수 있으므로 handler는 `TaskExecutionContext.idempotencyKey` 또는 payload UID를 기준으로 idempotent해야 한다.
+- Post write/interaction side effect task는 payload UID를 이벤트 UID 또는 command operation UID에서 만든다. 같은 payload UID는 queue에 중복 저장되지 않는다.
+
+## Retry 조건
+
+- Handler 예외 또는 timeout은 `Task.scheduleRetry`로 처리한다.
+- retry delay는 handler의 `@Task` annotation에서 지정한 `TaskRetryPolicy`를 사용한다.
+- handler 등록이 없으면 즉시 실패 처리된다.
+- `retryCount >= maxRetries`가 되면 `FAILED` 상태로 남고 DLQ로 취급한다.
+- `PROCESSING`이 `custom.task.processor.processingTimeoutSeconds`보다 오래 유지되면 `recoverStaleProcessingTasks`가 lease를 비우고 retry 또는 FAILED로 이동시킨다.
+
+## Idempotency key
+
+- Queue-level key: `Task.uid`.
+- Handler-level key: `TaskExecutionContext.idempotencyKey`, 현재 구현에서는 `taskUid.toString()`.
+- Post write side effect:
+  - domain event가 있으면 event UID 기반.
+  - no-event side effect는 command operation UID 기반.
+- Post interaction side effect:
+  - domain event와 recommendation refresh가 동시에 필요하면 event publish task와 recommendation refresh task를 분리해 각각 UID를 가진다.
+
+## 실패 후 수동 복구
+
+1. 운영 API `GET /system/api/v1/adm/tasks`로 pending/processing/failed/stale 상태를 확인한다.
+2. FAILED task는 `POST /system/api/v1/adm/tasks/replay-failed`로 재투입한다.
+3. replay 요청에서 `taskType`을 지정하면 특정 handler만 재시도한다.
+4. `resetRetryCount=true`는 retry count를 0으로 되돌리고, `false`는 `maxRetries - 1` 이하로 보정한다.
+5. replay된 task는 `PENDING`, `nextRetryAt=now`, `errorMessage=manual-dlq-replay@...`로 저장된다.
+
+## 운영 확인 지표
+
+- `task.processor.result{status=success|retry|dlq}`
+- `task.processor.handler.duration`
+- `task.processor.fetch.limit`
+- `task.dlq.replay.count`
+
+## 금지 사항
+
+- handler 내부에서 payload UID를 무시하고 non-idempotent external side effect를 직접 수행하면 안 된다.
+- timeout 이후 동일 side effect가 다시 실행될 수 있으므로 외부 시스템 호출은 task UID, aggregate ID, event UID 중 하나로 중복 방지되어야 한다.
+- `PROCESSING` row를 DB에서 직접 수정해 lease를 우회하지 않는다. 수동 복구는 DLQ replay API 또는 stale recovery 경로를 사용한다.

--- a/tools/guards/check-forbidden-tracked-files.sh
+++ b/tools/guards/check-forbidden-tracked-files.sh
@@ -37,6 +37,8 @@ is_allowed_markdown() {
 declare -a targets=()
 while IFS= read -r -d '' file; do
   case "${file}" in
+    docs/design/*.md)
+      ;;
     docs/*|AGENTS.md|CLAUDE.md|GEMINI.md|CURSOR.md|COPILOT.md|.cursor/*|.claude/*|.aider/*|.aider*|.windsurf/*|.codex/*|.ai/*)
       targets+=("${file}")
       ;;

--- a/tools/guards/check-forbidden-tracked-files.sh
+++ b/tools/guards/check-forbidden-tracked-files.sh
@@ -26,7 +26,8 @@ is_allowed_markdown() {
     infra/README.md|\
     perf/k6/README.md|\
     tools/templates/agent-plan.compact.md|\
-    tools/templates/bug-report.compact.md)
+    tools/templates/bug-report.compact.md|\
+    docs/design/*.md)
       return 0
       ;;
   esac
@@ -37,9 +38,12 @@ is_allowed_markdown() {
 declare -a targets=()
 while IFS= read -r -d '' file; do
   case "${file}" in
-    docs/design/*.md)
+    docs/*)
+      if ! is_allowed_markdown "${file}"; then
+        targets+=("${file}")
+      fi
       ;;
-    docs/*|AGENTS.md|CLAUDE.md|GEMINI.md|CURSOR.md|COPILOT.md|.cursor/*|.claude/*|.aider/*|.aider*|.windsurf/*|.codex/*|.ai/*)
+    AGENTS.md|CLAUDE.md|GEMINI.md|CURSOR.md|COPILOT.md|.cursor/*|.claude/*|.aider/*|.aider*|.windsurf/*|.codex/*|.ai/*)
       targets+=("${file}")
       ;;
     *.md)

--- a/tools/test/check-forbidden-tracked-files.test.sh
+++ b/tools/test/check-forbidden-tracked-files.test.sh
@@ -32,6 +32,11 @@ if run_with_temp_index "git update-index --add --cacheinfo 100644 '${readme_blob
   exit 1
 fi
 
+if ! run_with_temp_index "git update-index --add --cacheinfo 100644 '${readme_blob}' docs/design/contract.md && bash '${guard}' >'${guard_output}' 2>&1"; then
+  echo "[test] expected tracked docs/design/contract.md to be allowed" >&2
+  exit 1
+fi
+
 if run_with_temp_index "git update-index --add --cacheinfo 100644 '${readme_blob}' back/new-report.md && bash '${guard}' >'${guard_output}' 2>&1"; then
   echo "[test] expected tracked back/new-report.md to be rejected" >&2
   exit 1
@@ -39,6 +44,11 @@ fi
 
 if run_with_temp_index "git update-index --add --cacheinfo 100644 '${readme_blob}' docs/leak.md && bash '${guard}' --staged >'${guard_output}' 2>&1"; then
   echo "[test] expected staged docs/leak.md to be rejected" >&2
+  exit 1
+fi
+
+if ! run_with_temp_index "git update-index --add --cacheinfo 100644 '${readme_blob}' docs/design/contract.md && bash '${guard}' --staged >'${guard_output}' 2>&1"; then
+  echo "[test] expected staged docs/design/contract.md to be allowed" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## 관련 이슈

close #894

## 작업 배경

- 비동기 task, 공개 read cache, cloud multipart upload, profile workspace 저장 계약이 코드에 흩어져 있어 장애 대응 기준을 한 곳에서 확인하기 어려웠습니다.
- `docs/` 전체가 ignore되어 있어 issue가 요구한 `docs/design/*.md`를 tracked 운영 계약 문서로 추가할 수 없었습니다.
- PR 검증 중 backend performance sanity가 worker scheduled job query 간섭을 받는 것이 확인되어 성능 테스트 base에서 runtime worker를 비활성화했습니다.

## 작업 내용

- `docs/design/task-delivery-guarantees.md`에 durable task queue의 at-least-once 전달 보장, retry, idempotency key, DLQ replay 절차를 정리했습니다.
- `docs/design/cache-consistency-contract.md`에 public post ETag, cache invalidation scope, author representation cache clear, CDN/cache tag 계약을 정리했습니다.
- `docs/design/cloud-multipart-state-machine.md`에 cloud video multipart session 상태 전이, 실패 상태, part/session idempotency, stuck `COMPLETING` 복구 기준을 정리했습니다.
- `docs/design/profile-workspace-persistence.md`에 profile draft/published/legacy attr 저장 규칙, workspace image event 예외, 복구 절차를 정리했습니다.
- `.gitignore`와 forbidden tracked file guard/test를 조정해 `docs/design/*.md`만 tracked 문서로 허용하고 agent-local docs 차단은 유지했습니다.
- `BasePerformanceIntegrationTest`에서 `custom.runtime.worker-enabled=false`를 설정해 performance sanity 측정 중 worker query 유입을 막았습니다.
- README에 운영 계약 문서 링크를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - 문서에 언급한 Kotlin class/path 존재 수동 확인: 성공
  - `git diff --check`: 성공
  - `bash tools/guards/check-forbidden-tracked-files.sh --staged`: 성공
  - `bash tools/test/check-forbidden-tracked-files.test.sh`: 성공
  - `back/gradlew -p back test --tests com.back.perf.PerformanceSanityTest`: 성공
  - `back/gradlew -p back ktlintCheck`: 성공
  - GitHub CI 최신 head `2b5132d58485d82d6333ca2e5b3e95572e167640`: backend-ci, frontend-ci, backend-dependency-check, CodeQL java-kotlin, CodeQL javascript-typescript, Vercel Preview 모두 성공
  - CodeRabbit 최신 재리뷰 `cf004b15-dbeb-48e3-b1e7-281210473161`: No actionable comments

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `docs/design/*.md` 내용이 실제 Kotlin class/path와 맞는지 확인해 주세요.
  - `.gitignore`와 `tools/guards/check-forbidden-tracked-files.sh`가 `docs/design/*.md`만 허용하고 `docs/agent`, `.codex` 등 agent-local 문서는 계속 차단하는지 확인해 주세요.
  - CodeRabbit 첫 지적과 Codex fallback 지적은 각각 원 inline thread에 해결 답글을 남기고 resolved 처리했습니다.

## 리스크

- 문서 중심 변경이지만 guard 예외가 추가되어, 허용 범위를 `docs/design/*.md`로 좁혀 agent/AI metadata 유입을 막았습니다.
- backend production code는 변경하지 않았고, 테스트 base property만 worker 비활성화로 조정했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.