### PR TITLE
[Style] 템플릿형 코드 주석 정리

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberAttrRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberAttrRepository.kt
@@ -3,11 +3,6 @@ package com.back.boundedContexts.member.adapter.persistence
 import com.back.boundedContexts.member.domain.shared.MemberAttr
 import org.springframework.data.jpa.repository.JpaRepository
 
-/**
- * `MemberAttrRepository` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberAttrRepository :
     JpaRepository<MemberAttr, Long>,
     MemberAttrRepositoryCustom

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberAttrRepositoryCustom.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberAttrRepositoryCustom.kt
@@ -3,11 +3,6 @@ package com.back.boundedContexts.member.adapter.persistence
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.domain.shared.MemberAttr
 
-/**
- * `MemberAttrRepositoryCustom` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberAttrRepositoryCustom {
     fun findBySubjectAndName(
         subject: Member,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberRepository.kt
@@ -5,11 +5,6 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
-/**
- * `MemberRepository` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberRepository :
     JpaRepository<Member, Long>,
     MemberRepositoryCustom {

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberRepositoryCustom.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberRepositoryCustom.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.member.domain.shared.Member
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 
-/**
- * `MemberRepositoryCustom` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberRepositoryCustom {
     fun findByLoginId(loginId: String): Member?
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberRepositoryImpl.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberRepositoryImpl.kt
@@ -55,9 +55,6 @@ class MemberRepositoryImpl(
         return PageableExecutionUtils.getPage(itemsQuery.fetch(), pageable) { countQuery.fetchOne() ?: 0L }
     }
 
-    /**
-     * ItemsQuery 항목을 생성한다.
-     */
     private fun createItemsQuery(
         builder: BooleanBuilder,
         pageable: Pageable,
@@ -85,9 +82,6 @@ class MemberRepositoryImpl(
             .limit(pageable.pageSize.toLong())
     }
 
-    /**
-     * CountQuery 항목을 생성한다.
-     */
     private fun createCountQuery(builder: BooleanBuilder): JPAQuery<Long> =
         queryFactory
             .select(member.count())

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/port/input/CurrentMemberProfileQueryUseCase.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/port/input/CurrentMemberProfileQueryUseCase.kt
@@ -3,11 +3,6 @@ package com.back.boundedContexts.member.application.port.input
 import com.back.boundedContexts.member.dto.MemberProfileWorkspaceResponseDto
 import com.back.boundedContexts.member.dto.MemberWithUsernameDto
 
-/**
- * `CurrentMemberProfileQueryUseCase` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface CurrentMemberProfileQueryUseCase {
     fun getById(id: Long): MemberWithUsernameDto
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/port/input/MemberUseCase.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/port/input/MemberUseCase.kt
@@ -8,11 +8,6 @@ import com.back.standard.dto.member.type1.MemberSearchSortType1
 import com.back.standard.dto.page.PagedResult
 import java.util.Optional
 
-/**
- * `MemberUseCase` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberUseCase {
     fun count(): Long
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/port/output/MemberAttrRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/port/output/MemberAttrRepositoryPort.kt
@@ -3,11 +3,6 @@ package com.back.boundedContexts.member.application.port.output
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.domain.shared.MemberAttr
 
-/**
- * `MemberAttrRepositoryPort` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberAttrRepositoryPort {
     fun findBySubjectAndName(
         subject: Member,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/port/output/MemberRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/port/output/MemberRepositoryPort.kt
@@ -3,11 +3,6 @@ package com.back.boundedContexts.member.application.port.output
 import com.back.boundedContexts.member.domain.shared.Member
 import java.util.Optional
 
-/**
- * `MemberRepositoryPort` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberRepositoryPort {
     data class PagedQuery(
         val kw: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/ActorApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/ActorApplicationService.kt
@@ -10,10 +10,6 @@ import org.springframework.transaction.annotation.Transactional
 import java.util.Locale
 import kotlin.jvm.optionals.getOrNull
 
-/**
- * ActorApplicationService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class ActorApplicationService(
     private val authTokenService: AuthTokenService,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/AuthTokenService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/AuthTokenService.kt
@@ -9,10 +9,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.util.Date
 
-/**
- * AuthTokenService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class AuthTokenService(
     @param:Value("\${custom.jwt.secretKey}")

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/CurrentMemberProfileQueryService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/CurrentMemberProfileQueryService.kt
@@ -9,10 +9,6 @@ import com.back.boundedContexts.member.dto.MemberWithUsernameDto
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
-/**
- * CurrentMemberProfileQueryService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class CurrentMemberProfileQueryService(
     private val memberRepository: MemberRepositoryPort,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/LoginAttemptService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/LoginAttemptService.kt
@@ -11,10 +11,6 @@ import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
-/**
- * LoginAttemptService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class LoginAttemptService(
     @param:Value("\${custom.auth.login.maxAttempts:5}")
@@ -63,10 +59,6 @@ class LoginAttemptService(
         return false
     }
 
-    /**
-     * 상태 기록을 남기고 제한 정책 계산에 반영합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     override fun recordFailure(
         username: String,
         clientIp: String,
@@ -136,10 +128,6 @@ class LoginAttemptService(
         return blockedUntil > nowEpochSeconds()
     }
 
-    /**
-     * 상태 기록을 남기고 제한 정책 계산에 반영합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     private fun recordFailureInRedis(key: String): Boolean {
         if (isBlockedInRedis(key)) return true
 
@@ -165,10 +153,6 @@ class LoginAttemptService(
 
     private fun redisBlockedKey(key: String): String = "auth:login:blocked:$key"
 
-    /**
-     * 실행 시점에 필요한 의존성/값을 결정합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     private fun resolveRedisAvailability(): Boolean {
         val isRedisAvailable = redisKeyValuePort.isAvailable()
         if (!isRedisAvailable && AppFacade.isProd && requireRedisInProd) {
@@ -177,10 +161,6 @@ class LoginAttemptService(
         return isRedisAvailable
     }
 
-    /**
-     * 누적 상태를 정리해 메모리/스토리지 사용량을 관리합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     private fun cleanupInMemoryState(nowEpochSeconds: Long) {
         val shouldForceCleanup = states.size > memoryMaxEntries
         val previousCleanupAt = lastCleanupEpochSeconds.get()

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberApplicationService.kt
@@ -17,10 +17,6 @@ import org.springframework.transaction.annotation.Transactional
 import java.util.Locale
 import java.util.Optional
 
-/**
- * MemberApplicationService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class MemberApplicationService(
     private val memberRepository: MemberRepositoryPort,
@@ -42,10 +38,6 @@ class MemberApplicationService(
     @Transactional(readOnly = true)
     fun count(): Long = memberRepository.count()
 
-    /**
-     * 회원 가입 요청을 검증하고 계정을 생성합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     @Transactional
     fun join(
         username: String,
@@ -199,10 +191,6 @@ class MemberApplicationService(
         }
     }
 
-    /**
-     * 수정 요청을 처리하고 낙관적 잠금/후속 동기화를 수행합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     @Transactional
     fun modifyProfileCard(
         member: Member,
@@ -261,10 +249,6 @@ class MemberApplicationService(
                 RsData("201-1", "회원가입이 완료되었습니다.", joinedMember)
             }
 
-    /**
-     * 검색/목록 조회 조건을 정규화해 페이징 결과를 구성합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     @Transactional(readOnly = true)
     fun findPagedByKw(
         kw: String,
@@ -293,10 +277,6 @@ class MemberApplicationService(
         )
     }
 
-    /**
-     * 외부 입력값을 내부 규칙에 맞게 정규화합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     private fun normalizeZeroBasedPage(page: Int): Int {
         if (page < 1) {
             throw AppException("400-1", "page는 1 이상이어야 합니다.")
@@ -306,10 +286,6 @@ class MemberApplicationService(
         return if (page == 1) 0 else page - 1
     }
 
-    /**
-     * 외부 입력값을 내부 규칙에 맞게 정규화합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     private fun normalizePageSize(pageSize: Int): Int {
         if (pageSize !in 1..30) {
             throw AppException("400-1", "pageSize는 1~30 범위여야 합니다.")

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberProfileHydrator.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberProfileHydrator.kt
@@ -20,10 +20,6 @@ import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_WORKSPA
 import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_WORKSPACE_PUBLISHED
 import org.springframework.stereotype.Component
 
-/**
- * MemberProfileHydrator는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Component
 class MemberProfileHydrator(
     private val memberAttrRepository: MemberAttrRepositoryPort,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberUseCaseAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/service/MemberUseCaseAdapter.kt
@@ -10,10 +10,6 @@ import com.back.standard.dto.page.PagedResult
 import org.springframework.stereotype.Service
 import java.util.Optional
 
-/**
- * MemberUseCaseAdapter는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class MemberUseCaseAdapter(
     private val memberApplicationService: MemberApplicationService,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/MemberPolicy.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/MemberPolicy.kt
@@ -2,11 +2,6 @@ package com.back.boundedContexts.member.domain.shared
 
 import java.util.*
 
-/**
- * `MemberPolicy` 오브젝트입니다.
- * - 역할: 정적 유틸/상수/팩토리 기능을 제공합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 object MemberPolicy {
     val SYSTEM = Member(1, "system", null, "시스템")
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberAware.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberAware.kt
@@ -2,11 +2,6 @@ package com.back.boundedContexts.member.domain.shared.memberMixin
 
 import com.back.boundedContexts.member.domain.shared.Member
 
-/**
- * `MemberAware` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberAware {
     val id: Long
     val name: String

--- a/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberHasProfileCard.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberHasProfileCard.kt
@@ -62,11 +62,6 @@ val PROFILE_CONTACT_ICON_ALLOWED =
         "bell",
     )
 
-/**
- * `MemberProfileLinkItem` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class MemberProfileLinkItem(
     val icon: String = PROFILE_SERVICE_LINK_ICON_DEFAULT_VALUE,
     val label: String = PROFILE_LINK_LABEL_DEFAULT_VALUE,
@@ -153,11 +148,6 @@ private fun encodeProfileLinkItems(
         ),
     )
 
-/**
- * `MemberHasProfileCard` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberHasProfileCard : MemberAware {
     fun getOrInitProfileRoleAttr(loader: (() -> MemberAttr)? = null): MemberAttr =
         member.getOrPutAttr(PROFILE_ROLE) {

--- a/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberHasProfileImgUrl.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/domain/shared/memberMixin/MemberHasProfileImgUrl.kt
@@ -6,11 +6,6 @@ import com.back.global.app.AppConfig
 const val PROFILE_IMG_URL = "profileImgUrl"
 private const val PROFILE_IMG_URL_DEFAULT_VALUE = ""
 
-/**
- * `MemberHasProfileImgUrl` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberHasProfileImgUrl : MemberAware {
     private fun appendProfileImgVersion(url: String): String {
         val version =

--- a/back/src/main/kotlin/com/back/boundedContexts/member/dto/MemberDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/dto/MemberDto.kt
@@ -5,11 +5,6 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.Instant
 
-/**
- * `MemberDto` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class MemberDto
     @JsonCreator
     constructor(

--- a/back/src/main/kotlin/com/back/boundedContexts/member/dto/MemberWithUsernameDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/dto/MemberWithUsernameDto.kt
@@ -7,11 +7,6 @@ import com.back.boundedContexts.member.domain.shared.memberMixin.convertAboutSec
 import com.back.boundedContexts.member.domain.shared.memberMixin.parseLegacyAboutDetailsToBlocks
 import java.time.Instant
 
-/**
- * `MemberProfileLinkItemDto` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class MemberProfileLinkItemDto(
     val icon: String,
     val label: String,
@@ -24,11 +19,6 @@ data class MemberProfileLinkItemDto(
     )
 }
 
-/**
- * `MemberWithUsernameDto` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class MemberWithUsernameDto(
     val id: Long,
     val createdAt: Instant,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/dto/shared/AccessTokenPayload.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/dto/shared/AccessTokenPayload.kt
@@ -2,11 +2,6 @@ package com.back.boundedContexts.member.dto.shared
 
 import java.time.Instant
 
-/**
- * `AccessTokenPayload` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class AccessTokenPayload(
     val id: Long,
     val sessionKey: String? = null,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/memberActionLog/adapter/persistence/MemberActionLogRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/memberActionLog/adapter/persistence/MemberActionLogRepository.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.member.subContexts.memberActionLog.application.p
 import com.back.boundedContexts.member.subContexts.memberActionLog.domain.MemberActionLog
 import org.springframework.data.jpa.repository.JpaRepository
 
-/**
- * `MemberActionLogRepository` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberActionLogRepository :
     JpaRepository<MemberActionLog, Long>,
     MemberActionLogRepositoryPort

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/memberActionLog/application/port/output/MemberActionLogRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/memberActionLog/application/port/output/MemberActionLogRepositoryPort.kt
@@ -2,11 +2,6 @@ package com.back.boundedContexts.member.subContexts.memberActionLog.application.
 
 import com.back.boundedContexts.member.subContexts.memberActionLog.domain.MemberActionLog
 
-/**
- * `MemberActionLogRepositoryPort` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberActionLogRepositoryPort {
     fun save(memberActionLog: MemberActionLog): MemberActionLog
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/memberActionLog/application/service/MemberActionLogApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/memberActionLog/application/service/MemberActionLogApplicationService.kt
@@ -11,10 +11,6 @@ import com.back.standard.dto.EventPayload
 import com.back.standard.util.Ut
 import org.springframework.stereotype.Service
 
-/**
- * MemberActionLogApplicationService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class MemberActionLogApplicationService(
     private val memberActionLogRepository: MemberActionLogRepositoryPort,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/adapter/persistence/MemberNotificationRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/adapter/persistence/MemberNotificationRepository.kt
@@ -9,11 +9,6 @@ import org.springframework.data.repository.query.Param
 import java.time.Instant
 import java.util.UUID
 
-/**
- * `MemberNotificationRepository` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberNotificationRepository : JpaRepository<MemberNotification, Long> {
     @Query(
         """

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/port/output/MemberNotificationRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/port/output/MemberNotificationRepositoryPort.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.member.subContexts.notification.domain.MemberNot
 import java.time.Instant
 import java.util.UUID
 
-/**
- * `MemberNotificationRepositoryPort` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberNotificationRepositoryPort {
     fun save(notification: MemberNotification): MemberNotification
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationApplicationService.kt
@@ -14,10 +14,6 @@ import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import kotlin.jvm.optionals.getOrNull
 
-/**
- * MemberNotificationApplicationService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class MemberNotificationApplicationService(
     private val memberRepository: MemberRepositoryPort,
@@ -32,9 +28,6 @@ class MemberNotificationApplicationService(
         val unreadCount: Int,
     )
 
-    /**
-     * ForCommentWritten 항목을 생성한다.
-     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun createForCommentWritten(event: PostCommentWrittenEvent) {
         if (memberNotificationRepository.existsByEventUid(event.uid)) {
@@ -126,10 +119,6 @@ class MemberNotificationApplicationService(
         id: Long,
     ): Boolean = memberNotificationRepository.markRead(id, member.id, java.time.Instant.now()) > 0
 
-    /**
-     * 실행 시점에 필요한 의존성/값을 결정합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     private fun resolveReceiver(event: PostCommentWrittenEvent): ReceiverInfo? {
         val parentCommentId = event.postCommentDto.parentCommentId
         if (parentCommentId != null) {

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationRealtimeRelayService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationRealtimeRelayService.kt
@@ -11,10 +11,6 @@ import org.springframework.stereotype.Service
 import tools.jackson.databind.ObjectMapper
 import java.nio.charset.StandardCharsets
 
-/**
- * MemberNotificationRealtimeRelayService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class MemberNotificationRealtimeRelayService(
     private val memberNotificationSseService: MemberNotificationSseService,
@@ -30,10 +26,6 @@ class MemberNotificationRealtimeRelayService(
         val unreadCount: Int,
     )
 
-    /**
-     * 이벤트/메시지를 전파하고 실패를 안전하게 처리합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     fun publish(
         memberId: Long,
         notification: MemberNotificationDto,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationSseService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/application/service/MemberNotificationSseService.kt
@@ -16,10 +16,6 @@ import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
-/**
- * MemberNotificationSseService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class MemberNotificationSseService(
     private val memberNotificationRepository: MemberNotificationRepositoryPort,
@@ -115,10 +111,6 @@ class MemberNotificationSseService(
         return emitter
     }
 
-    /**
-     * 이벤트/메시지를 전파하고 실패를 안전하게 처리합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     fun publish(
         memberId: Long,
         notification: MemberNotificationDto,
@@ -150,10 +142,6 @@ class MemberNotificationSseService(
         )
     }
 
-    /**
-     * 이벤트/메시지를 전파하고 실패를 안전하게 처리합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     private fun send(
         emitter: SseEmitter,
         memberId: Long?,
@@ -337,10 +325,6 @@ class MemberNotificationSseService(
         return latestId
     }
 
-    /**
-     * 원본 입력에서 필요한 값을 안전하게 추출합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     private fun parseLastNotificationId(lastEventIdRaw: String?): Long? {
         val raw = lastEventIdRaw?.trim().orEmpty()
         if (raw.isBlank()) return null

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/domain/MemberNotificationType.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/domain/MemberNotificationType.kt
@@ -1,10 +1,5 @@
 package com.back.boundedContexts.member.subContexts.notification.domain
 
-/**
- * `MemberNotificationType` 열거형입니다.
- * - 역할: 도메인 상태/타입 상수를 안전하게 표현합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 enum class MemberNotificationType {
     COMMENT_REPLY,
     POST_COMMENT,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/dto/MemberNotificationDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/dto/MemberNotificationDto.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.member.subContexts.notification.domain.MemberNot
 import com.back.boundedContexts.member.subContexts.notification.domain.MemberNotificationType
 import java.time.Instant
 
-/**
- * `MemberNotificationDto` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class MemberNotificationDto(
     val id: Long,
     val type: MemberNotificationType,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/dto/MemberNotificationStreamPayload.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/notification/dto/MemberNotificationStreamPayload.kt
@@ -1,10 +1,5 @@
 package com.back.boundedContexts.member.subContexts.notification.dto
 
-/**
- * `MemberNotificationStreamPayload` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class MemberNotificationStreamPayload(
     val notification: MemberNotificationDto,
     val unreadCount: Int,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/persistence/MemberSignupVerificationRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/persistence/MemberSignupVerificationRepository.kt
@@ -3,11 +3,6 @@ package com.back.boundedContexts.member.subContexts.signupVerification.adapter.p
 import com.back.boundedContexts.member.subContexts.signupVerification.domain.MemberSignupVerification
 import org.springframework.data.jpa.repository.JpaRepository
 
-/**
- * `MemberSignupVerificationRepository` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberSignupVerificationRepository : JpaRepository<MemberSignupVerification, Long> {
     fun findByEmailVerificationToken(emailVerificationToken: String): MemberSignupVerification?
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/port/output/MemberSignupVerificationRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/port/output/MemberSignupVerificationRepositoryPort.kt
@@ -2,11 +2,6 @@ package com.back.boundedContexts.member.subContexts.signupVerification.applicati
 
 import com.back.boundedContexts.member.subContexts.signupVerification.domain.MemberSignupVerification
 
-/**
- * `MemberSignupVerificationRepositoryPort` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberSignupVerificationRepositoryPort {
     fun save(memberSignupVerification: MemberSignupVerification): MemberSignupVerification
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/port/output/SignupVerificationMailSenderPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/port/output/SignupVerificationMailSenderPort.kt
@@ -2,11 +2,6 @@ package com.back.boundedContexts.member.subContexts.signupVerification.applicati
 
 import java.time.Instant
 
-/**
- * `SignupVerificationMailSenderPort` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface SignupVerificationMailSenderPort {
     fun send(
         toEmail: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/MemberSignupVerificationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/MemberSignupVerificationService.kt
@@ -18,30 +18,16 @@ import java.time.Instant
 import java.util.Locale
 import java.util.UUID
 
-/**
- * `SignupEmailStartResult` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class SignupEmailStartResult(
     val email: String,
 )
 
-/**
- * `SignupEmailVerifyResult` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class SignupEmailVerifyResult(
     val email: String,
     val signupToken: String,
     val expiresAt: Instant,
 )
 
-/**
- * MemberSignupVerificationService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class MemberSignupVerificationService(
     private val memberRepository: MemberRepositoryPort,
@@ -204,10 +190,6 @@ class MemberSignupVerificationService(
         }
     }
 
-    /**
-     * 외부 입력값을 내부 규칙에 맞게 정규화합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     private fun normalizeNextPath(nextPath: String?): String? {
         val trimmed = nextPath?.trim()?.takeIf { it.isNotBlank() } ?: return null
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/SignupMailDiagnosticsService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/SignupMailDiagnosticsService.kt
@@ -14,11 +14,6 @@ import org.springframework.mail.javamail.JavaMailSenderImpl
 import org.springframework.stereotype.Service
 import java.time.Instant
 
-/**
- * `SignupMailDiagnostics` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class SignupMailDiagnostics(
     val status: String,
     val adapter: String,
@@ -38,10 +33,6 @@ data class SignupMailDiagnostics(
     val queueRuntime: TaskProcessingLockDiagnostics,
 )
 
-/**
- * SignupMailDiagnosticsService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class SignupMailDiagnosticsService(
     private val signupVerificationMailSenderProvider: ObjectProvider<SignupVerificationMailSenderPort>,
@@ -175,10 +166,6 @@ class SignupMailDiagnosticsService(
         )
     }
 
-    /**
-     * 이벤트/메시지를 전파하고 실패를 안전하게 처리합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     fun sendTestMail(email: String) {
         val diagnostics = diagnose(checkConnection = false)
         if (diagnostics.status !in listOf("READY", "TEST_MODE")) {

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/SignupStartRateLimitService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/SignupStartRateLimitService.kt
@@ -11,10 +11,6 @@ import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
-/**
- * SignupStartRateLimitService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class SignupStartRateLimitService(
     @param:Value("\${custom.member.signup.startRateLimit.maxAttemptsPerEmail:5}")
@@ -57,10 +53,6 @@ class SignupStartRateLimitService(
         }
     }
 
-    /**
-     * 실행 시점에 필요한 의존성/값을 결정합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     private fun resolveRedisTemplate(): StringRedisTemplate? {
         val redisTemplate = redisTemplateProvider.getIfAvailable()
         if (redisTemplate == null && AppFacade.isProd && requireRedisInProd) {
@@ -99,10 +91,6 @@ class SignupStartRateLimitService(
         return nextCount <= maxAttempts.toLong()
     }
 
-    /**
-     * 누적 상태를 정리해 메모리/스토리지 사용량을 관리합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     private fun cleanupInMemoryState(nowEpochSeconds: Long) {
         val shouldForceCleanup = states.size > memoryMaxEntries
         val previousCleanupAt = lastCleanupEpochSeconds.get()

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/dto/SendSignupVerificationMailPayload.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/dto/SendSignupVerificationMailPayload.kt
@@ -13,11 +13,6 @@ import java.util.UUID
     backoffMultiplier = 2.0,
     maxDelaySeconds = 3600,
 )
-/**
- * `SendSignupVerificationMailPayload` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class SendSignupVerificationMailPayload(
     override val uid: UUID,
     override val aggregateType: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostAttrRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostAttrRepository.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostAttr
 import org.springframework.data.jpa.repository.JpaRepository
 
-/**
- * `PostAttrRepository` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostAttrRepository :
     JpaRepository<PostAttr, Long>,
     PostAttrRepositoryCustom {

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostAttrRepositoryCustom.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostAttrRepositoryCustom.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostAttr
 import java.time.Instant
 
-/**
- * `PostAttrRepositoryCustom` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostAttrRepositoryCustom {
     fun findBySubjectAndName(
         subject: Post,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepository.kt
@@ -7,11 +7,6 @@ import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.Optional
 
-/**
- * `PostCommentRepository` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostCommentRepository :
     JpaRepository<PostComment, Long>,
     PostCommentRepositoryCustom {

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryCustom.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryCustom.kt
@@ -3,11 +3,6 @@ package com.back.boundedContexts.post.adapter.persistence
 import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostComment
 
-/**
- * `PostCommentRepositoryCustom` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostCommentRepositoryCustom {
     fun findActiveSubtreeByPostAndRootCommentId(
         post: Post,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostLikeRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostLikeRepository.kt
@@ -7,11 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 
-/**
- * `PostLikeRepository` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostLikeRepository :
     JpaRepository<PostLike, Long>,
     PostLikeRepositoryCustom {

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostLikeRepositoryCustom.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostLikeRepositoryCustom.kt
@@ -3,11 +3,6 @@ package com.back.boundedContexts.post.adapter.persistence
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.post.domain.Post
 
-/**
- * `PostLikeRepositoryCustom` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostLikeRepositoryCustom {
     /**
      * @return 신규 좋아요 row id, 이미 존재하면 null

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepository.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.post.domain.Post
 import org.springframework.data.jpa.repository.JpaRepository
 
-/**
- * `PostRepository` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostRepository :
     JpaRepository<Post, Long>,
     PostRepositoryCustom {

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepositoryCustom.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepositoryCustom.kt
@@ -7,11 +7,6 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import java.time.Instant
 
-/**
- * `PostRepositoryCustom` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostRepositoryCustom {
     fun findQPagedByKw(
         kw: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepositoryImpl.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepositoryImpl.kt
@@ -471,9 +471,6 @@ class PostRepositoryImpl(
         return rows.sortedBy { row -> orderById[row.id] ?: Int.MAX_VALUE }
     }
 
-    /**
-     * CountQuery 항목을 생성한다.
-     */
     private fun createCountQuery(builder: BooleanBuilder): JPAQuery<Long> =
         queryFactory
             .select(post.id.countDistinct())

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostWriteRequestIdempotencyRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostWriteRequestIdempotencyRepository.kt
@@ -6,11 +6,6 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import java.time.Instant
 
-/**
- * `PostWriteRequestIdempotencyRepository` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostWriteRequestIdempotencyRepository : JpaRepository<PostWriteRequestIdempotency, Long> {
     fun findByActorAndRequestKey(
         actor: Member,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/input/PostUseCase.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/input/PostUseCase.kt
@@ -11,11 +11,6 @@ import com.back.standard.dto.page.PagedResult
 import com.back.standard.dto.post.type1.PostSearchSortType1
 import java.time.Instant
 
-/**
- * `PostUseCase` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostUseCase {
     fun count(): Long
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/MemberAttrRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/MemberAttrRepositoryPort.kt
@@ -3,11 +3,6 @@ package com.back.boundedContexts.post.application.port.output
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.domain.shared.MemberAttr
 
-/**
- * `MemberAttrRepositoryPort` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface MemberAttrRepositoryPort {
     fun findBySubjectAndName(
         subject: Member,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostAttrRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostAttrRepositoryPort.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostAttr
 import java.time.Instant
 
-/**
- * `PostAttrRepositoryPort` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostAttrRepositoryPort {
     fun findBySubjectAndName(
         subject: Post,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostCommentRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostCommentRepositoryPort.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostComment
 import java.util.Optional
 
-/**
- * `PostCommentRepositoryPort` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostCommentRepositoryPort {
     fun save(comment: PostComment): PostComment
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostLikeRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostLikeRepositoryPort.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostLike
 
-/**
- * `PostLikeRepositoryPort` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostLikeRepositoryPort {
     fun insertIfAbsent(
         liker: Member,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostRepositoryPort.kt
@@ -8,11 +8,6 @@ import com.back.boundedContexts.post.dto.PublicPostDetailContentCacheDto
 import java.time.Instant
 import java.util.Optional
 
-/**
- * `PostRepositoryPort` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostRepositoryPort {
     data class PagedQuery(
         val kw: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostTagIndexRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostTagIndexRepositoryPort.kt
@@ -1,7 +1,6 @@
 package com.back.boundedContexts.post.application.port.output
 
 /**
- * `PostTagIndexRepositoryPort` 인터페이스입니다.
  * - 역할: post 태그 인덱스 저장/집계 계약을 정의합니다.
  * - 목적: 공개 태그 집계를 본문 스캔 없이 DB 집계로 처리합니다.
  */

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostWriteRequestIdempotencyRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostWriteRequestIdempotencyRepositoryPort.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.post.domain.PostWriteRequestIdempotency
 import java.time.Instant
 
-/**
- * `PostWriteRequestIdempotencyRepositoryPort` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostWriteRequestIdempotencyRepositoryPort {
     fun findByActorAndRequestKey(
         actor: Member,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/SecureTipPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/SecureTipPort.kt
@@ -1,10 +1,5 @@
 package com.back.boundedContexts.post.application.port.output
 
-/**
- * `SecureTipPort` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface SecureTipPort {
     fun randomSecureTip(): String
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -35,10 +35,6 @@ import java.time.Instant
 import java.util.UUID
 import kotlin.jvm.optionals.getOrNull
 
-/**
- * PostApplicationService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class PostApplicationService(
     private val postRepository: PostRepositoryPort,
@@ -62,10 +58,6 @@ class PostApplicationService(
 
     fun randomSecureTip(): String = secureTipPort.randomSecureTip()
 
-    /**
-     * 생성 요청을 처리하고 멱등성·후속 동기화 절차를 함께 수행합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     @Transactional
     fun write(
         author: Member,
@@ -205,10 +197,6 @@ class PostApplicationService(
 
     fun findLatest(): Post? = postRepository.findFirstByOrderByIdDesc()
 
-    /**
-     * 수정 요청을 처리하고 낙관적 잠금/후속 동기화를 수행합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     @Transactional
     fun modify(
         actor: Member,
@@ -297,10 +285,6 @@ class PostApplicationService(
         )
     }
 
-    /**
-     * 생성 요청을 처리하고 멱등성·후속 동기화 절차를 함께 수행합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     private fun writeNewPost(
         author: Member,
         persistenceAuthor: Member,
@@ -327,9 +311,6 @@ class PostApplicationService(
         return savedPost
     }
 
-    /**
-     * IdempotencyRequestSlot 항목을 생성한다.
-     */
     private fun createIdempotencyRequestSlot(
         persistenceAuthor: Member,
         idempotencyKey: String,
@@ -355,10 +336,6 @@ class PostApplicationService(
         }
     }
 
-    /**
-     * 삭제 요청을 처리하고 캐시/카운터/첨부파일 정리를 후속으로 연결합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     @Transactional
     fun delete(
         post: Post,
@@ -415,10 +392,6 @@ class PostApplicationService(
         )
     }
 
-    /**
-     * 댓글 생성 요청을 처리하고 댓글/작성자 집계값을 함께 갱신합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     @Transactional
     fun writeComment(
         author: Member,
@@ -427,10 +400,6 @@ class PostApplicationService(
         parentComment: PostComment? = null,
     ): PostComment = postCommentApplicationService.writeComment(author, post, content, parentComment)
 
-    /**
-     * 댓글 내용을 수정하고 변경 이벤트를 발행합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     @Transactional
     fun modifyComment(
         postComment: PostComment,
@@ -438,10 +407,6 @@ class PostApplicationService(
         content: String,
     ) = postCommentApplicationService.modifyComment(postComment, actor, content)
 
-    /**
-     * 댓글 삭제를 처리하고 연관 집계값을 함께 보정합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     @Transactional
     fun deleteComment(
         post: Post,
@@ -449,20 +414,12 @@ class PostApplicationService(
         actor: Member,
     ) = postCommentApplicationService.deleteComment(post, postComment, actor)
 
-    /**
-     * 좋아요 상태 변경을 반영하고 경쟁 상황에서의 정합성을 보장합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     @Transactional
     fun like(
         post: Post,
         actor: Member,
     ): PostLikeToggleResult = postLikeApplicationService.like(post, actor)
 
-    /**
-     * 좋아요 상태 변경을 반영하고 경쟁 상황에서의 정합성을 보장합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     @Transactional
     fun unlike(
         post: Post,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostHitDedupService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostHitDedupService.kt
@@ -14,10 +14,6 @@ import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
-/**
- * PostHitDedupService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class PostHitDedupService(
     @param:Value("\${custom.post.hit.viewerWindowSeconds:86400}")
@@ -85,10 +81,6 @@ class PostHitDedupService(
 
     private fun redisKey(value: String): String = "$redisKeyPrefix$value"
 
-    /**
-     * 누적 상태를 정리해 메모리/스토리지 사용량을 관리합니다.
-     * 애플리케이션 서비스 계층에서 예외 처리와 트랜잭션 경계, 후속 작업을 함께 관리합니다.
-     */
     private fun cleanupInMemoryState(nowEpochSeconds: Long) {
         val shouldForceCleanup = memoryState.size > memoryMaxEntries
         val previousCleanupAt = lastCleanupEpochSeconds.get()

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostLikeReconciliationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostLikeReconciliationService.kt
@@ -8,10 +8,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 
-/**
- * PostLikeReconciliationService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class PostLikeReconciliationService(
     private val postAttrRepository: PostAttrRepositoryPort,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryService.kt
@@ -33,10 +33,6 @@ import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 import kotlin.math.max
 
-/**
- * PostPublicReadQueryService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class PostPublicReadQueryService(
     private val postUseCase: PostUseCase,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostQueryCacheNames.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostQueryCacheNames.kt
@@ -1,10 +1,5 @@
 package com.back.boundedContexts.post.application.service
 
-/**
- * `PostQueryCacheNames` 오브젝트입니다.
- * - 역할: 정적 유틸/상수/팩토리 기능을 제공합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 object PostQueryCacheNames {
     const val ADMIN_POSTS_FIRST_PAGE = "post-admin-posts-first-page-v1"
     const val FEED = "post-feed-v4"

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostUseCaseAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostUseCaseAdapter.kt
@@ -13,10 +13,6 @@ import com.back.standard.dto.post.type1.PostSearchSortType1
 import org.springframework.stereotype.Service
 import java.time.Instant
 
-/**
- * PostUseCaseAdapter는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class PostUseCaseAdapter(
     private val postApplicationService: PostApplicationService,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteRequestIdempotencyRetentionService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteRequestIdempotencyRetentionService.kt
@@ -7,10 +7,6 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-/**
- * PostWriteRequestIdempotencyRetentionService는 유스케이스 단위 비즈니스 흐름을 조합하는 애플리케이션 서비스입니다.
- * 트랜잭션 경계, 도메인 규칙 적용, 후속 동기화(캐시/이벤트/스토리지)를 담당합니다.
- */
 @Service
 class PostWriteRequestIdempotencyRetentionService(
     private val postWriteRequestIdempotencyRepository: PostWriteRequestIdempotencyRepositoryPort,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/config/PostImageStorageProperties.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/config/PostImageStorageProperties.kt
@@ -2,11 +2,6 @@ package com.back.boundedContexts.post.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 
-/**
- * `PostImageStorageProperties` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 @ConfigurationProperties("custom.storage")
 data class PostImageStorageProperties(
     var enabled: Boolean = false,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/domain/PostMember.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/domain/PostMember.kt
@@ -9,11 +9,6 @@ const val POSTS_COUNT_DEFAULT_VALUE = 0
 const val POST_COMMENTS_COUNT = "postCommentsCount"
 const val POST_COMMENTS_COUNT_DEFAULT_VALUE = 0
 
-/**
- * `PostMember` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostMember : MemberAware {
     val username: String
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/domain/postCommentMixin/PostCommentAware.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/domain/postCommentMixin/PostCommentAware.kt
@@ -2,11 +2,6 @@ package com.back.boundedContexts.post.domain.postCommentMixin
 
 import com.back.boundedContexts.post.domain.PostComment
 
-/**
- * `PostCommentAware` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostCommentAware {
     val postComment: PostComment
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/domain/postCommentMixin/PostCommentHasPolicy.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/domain/postCommentMixin/PostCommentHasPolicy.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.member.domain.shared.Member
 import com.back.global.exception.application.AppException
 import com.back.global.rsData.RsData
 
-/**
- * `PostCommentHasPolicy` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostCommentHasPolicy : PostCommentAware {
     fun getCheckActorCanModifyRs(actor: Member?): RsData<Void> {
         if (actor == null) return RsData.fail("401-1", "로그인 후 이용해주세요.")

--- a/back/src/main/kotlin/com/back/boundedContexts/post/domain/postMixin/PostAware.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/domain/postMixin/PostAware.kt
@@ -2,11 +2,6 @@ package com.back.boundedContexts.post.domain.postMixin
 
 import com.back.boundedContexts.post.domain.Post
 
-/**
- * `PostAware` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostAware {
     val post: Post
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/domain/postMixin/PostHasComments.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/domain/postMixin/PostHasComments.kt
@@ -7,11 +7,6 @@ import com.back.boundedContexts.post.domain.PostComment
 const val COMMENTS_COUNT = "commentsCount"
 private const val COMMENTS_COUNT_DEFAULT_VALUE = 0
 
-/**
- * `PostHasComments` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostHasComments : PostAware {
     var commentsCount: Int
         get() = post.commentsCountAttr?.intValue ?: COMMENTS_COUNT_DEFAULT_VALUE

--- a/back/src/main/kotlin/com/back/boundedContexts/post/domain/postMixin/PostHasHit.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/domain/postMixin/PostHasHit.kt
@@ -5,11 +5,6 @@ import com.back.boundedContexts.post.domain.PostAttr
 const val HIT_COUNT = "hitCount"
 private const val HIT_COUNT_DEFAULT_VALUE = 0
 
-/**
- * `PostHasHit` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostHasHit : PostAware {
     val hitCount: Int
         get() = post.hitCountAttr?.intValue ?: HIT_COUNT_DEFAULT_VALUE

--- a/back/src/main/kotlin/com/back/boundedContexts/post/domain/postMixin/PostHasLikes.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/domain/postMixin/PostHasLikes.kt
@@ -5,21 +5,11 @@ import com.back.boundedContexts.post.domain.PostAttr
 const val LIKES_COUNT = "likesCount"
 private const val LIKES_COUNT_DEFAULT_VALUE = 0
 
-/**
- * `PostLikeToggleResult` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class PostLikeToggleResult(
     val isLiked: Boolean,
     val likeId: Long,
 )
 
-/**
- * `PostHasLikes` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostHasLikes : PostAware {
     var likesCount: Int
         get() = post.likesCountAttr?.intValue ?: LIKES_COUNT_DEFAULT_VALUE

--- a/back/src/main/kotlin/com/back/boundedContexts/post/domain/postMixin/PostHasPolicy.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/domain/postMixin/PostHasPolicy.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.member.domain.shared.Member
 import com.back.global.exception.application.AppException
 import com.back.global.rsData.RsData
 
-/**
- * `PostHasPolicy` 인터페이스입니다.
- * - 역할: 계층 간 계약(포트/스펙) 정의를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 interface PostHasPolicy : PostAware {
     /**
      * 권한/상태 조건을 검증하고 처리 가능 여부를 판정합니다.

--- a/back/src/main/kotlin/com/back/boundedContexts/post/dto/AdmDeletedPostDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/dto/AdmDeletedPostDto.kt
@@ -2,11 +2,6 @@ package com.back.boundedContexts.post.dto
 
 import java.time.Instant
 
-/**
- * `AdmDeletedPostDto` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class AdmDeletedPostDto(
     val id: Long,
     val title: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/dto/AdmDeletedPostSnapshotDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/dto/AdmDeletedPostSnapshotDto.kt
@@ -1,10 +1,5 @@
 package com.back.boundedContexts.post.dto
 
-/**
- * `AdmDeletedPostSnapshotDto` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class AdmDeletedPostSnapshotDto(
     val id: Long,
     val title: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/dto/FeedPostDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/dto/FeedPostDto.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.post.domain.Post
 import org.slf4j.LoggerFactory
 import java.time.Instant
 
-/**
- * `FeedPostDto` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class FeedPostDto(
     val id: Long,
     val createdAt: Instant,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/dto/PostCommentDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/dto/PostCommentDto.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.post.domain.PostComment
 import com.fasterxml.jackson.annotation.JsonCreator
 import java.time.Instant
 
-/**
- * `PostCommentDto` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class PostCommentDto
     @JsonCreator
     constructor(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/dto/PostDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/dto/PostDto.kt
@@ -4,11 +4,6 @@ import com.back.boundedContexts.post.domain.Post
 import com.fasterxml.jackson.annotation.JsonCreator
 import java.time.Instant
 
-/**
- * `PostDto` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class PostDto
     @JsonCreator
     constructor(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/dto/PostMetaExtractor.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/dto/PostMetaExtractor.kt
@@ -1,10 +1,5 @@
 package com.back.boundedContexts.post.dto
 
-/**
- * `PostMetaExtractor` 오브젝트입니다.
- * - 역할: 정적 유틸/상수/팩토리 기능을 제공합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 object PostMetaExtractor {
     private const val CACHE_MAX_ENTRIES = 1024
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/dto/PostPreviewExtractor.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/dto/PostPreviewExtractor.kt
@@ -1,10 +1,5 @@
 package com.back.boundedContexts.post.dto
 
-/**
- * `PostPreviewExtractor` 오브젝트입니다.
- * - 역할: 정적 유틸/상수/팩토리 기능을 제공합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 object PostPreviewExtractor {
     private const val SUMMARY_MAX_LENGTH = 180
     private const val CACHE_MAX_ENTRIES = 1024

--- a/back/src/main/kotlin/com/back/boundedContexts/post/dto/PostWithContentDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/dto/PostWithContentDto.kt
@@ -3,11 +3,6 @@ package com.back.boundedContexts.post.dto
 import com.back.boundedContexts.post.domain.Post
 import java.time.Instant
 
-/**
- * `PostWithContentDto` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class PostWithContentDto(
     val id: Long,
     val createdAt: Instant,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/dto/TagCountDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/dto/TagCountDto.kt
@@ -1,10 +1,5 @@
 package com.back.boundedContexts.post.dto
 
-/**
- * `TagCountDto` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class TagCountDto(
     val tag: String,
     val count: Int,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostCommentDeletedEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostCommentDeletedEvent.kt
@@ -10,11 +10,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.*
 
-/**
- * `PostCommentDeletedEvent` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class PostCommentDeletedEvent
     @JsonCreator
     constructor(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostCommentModifiedEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostCommentModifiedEvent.kt
@@ -10,11 +10,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.*
 
-/**
- * `PostCommentModifiedEvent` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class PostCommentModifiedEvent
     @JsonCreator
     constructor(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostCommentWrittenEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostCommentWrittenEvent.kt
@@ -10,11 +10,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.*
 
-/**
- * `PostCommentWrittenEvent` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class PostCommentWrittenEvent
     @JsonCreator
     constructor(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostDeletedEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostDeletedEvent.kt
@@ -9,11 +9,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.*
 
-/**
- * `PostDeletedEvent` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class PostDeletedEvent
     @JsonCreator
     constructor(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostLikedEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostLikedEvent.kt
@@ -6,11 +6,6 @@ import com.back.standard.dto.EventPayload
 import com.fasterxml.jackson.annotation.JsonCreator
 import java.util.*
 
-/**
- * `PostLikedEvent` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class PostLikedEvent
     @JsonCreator
     constructor(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostModifiedEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostModifiedEvent.kt
@@ -9,11 +9,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.*
 
-/**
- * `PostModifiedEvent` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class PostModifiedEvent
     @JsonCreator
     constructor(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostUnlikedEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostUnlikedEvent.kt
@@ -6,11 +6,6 @@ import com.back.standard.dto.EventPayload
 import com.fasterxml.jackson.annotation.JsonCreator
 import java.util.*
 
-/**
- * `PostUnlikedEvent` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class PostUnlikedEvent
     @JsonCreator
     constructor(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostWrittenEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostWrittenEvent.kt
@@ -9,11 +9,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.*
 
-/**
- * `PostWrittenEvent` 데이터 클래스입니다.
- * - 역할: 요청/응답/이벤트/상태 전달용 불변 데이터 구조를 담당합니다.
- * - 주의: 변경 시 호출 경계와 데이터 흐름 영향을 함께 검토합니다.
- */
 data class PostWrittenEvent
     @JsonCreator
     constructor(

--- a/back/src/main/kotlin/com/back/global/app/config/ProdConfigGuard.kt
+++ b/back/src/main/kotlin/com/back/global/app/config/ProdConfigGuard.kt
@@ -7,10 +7,6 @@ import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
-/**
- * ProdConfigGuard는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
 @Profile("prod")
 @Component
 class ProdConfigGuard(
@@ -22,10 +18,6 @@ class ProdConfigGuard(
     private val backUrl: String,
     private val adminProperties: AdminProperties,
 ) : ApplicationRunner {
-    /**
-     * 애플리케이션 시작/스케줄 실행 시점에 점검 로직을 수행합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     override fun run(args: ApplicationArguments) {
         val missingKeys =
             buildList {

--- a/back/src/main/kotlin/com/back/global/exception/config/ExceptionHandler.kt
+++ b/back/src/main/kotlin/com/back/global/exception/config/ExceptionHandler.kt
@@ -21,11 +21,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.multipart.MaxUploadSizeExceededException
 import org.springframework.web.multipart.MultipartException
 
-/**
- * ExceptionHandler는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
-
 @RestControllerAdvice
 class ExceptionHandler(
     @Autowired(required = false)
@@ -33,10 +28,6 @@ class ExceptionHandler(
 ) {
     private val logger = LoggerFactory.getLogger(ExceptionHandler::class.java)
 
-    /**
-     * 예외 또는 이벤트를 수신해 표준 처리 흐름으로 변환합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     @ExceptionHandler(NoSuchElementException::class)
     fun handleNoSuchElementException(
         @Suppress("UNUSED_PARAMETER") ex: NoSuchElementException,
@@ -45,10 +36,6 @@ class ExceptionHandler(
             .status(HttpStatus.NOT_FOUND)
             .body(RsData("404-1", "해당 데이터가 존재하지 않습니다."))
 
-    /**
-     * 예외 또는 이벤트를 수신해 표준 처리 흐름으로 변환합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     @ExceptionHandler(ConstraintViolationException::class)
     fun handleConstraintViolationException(e: ConstraintViolationException): ResponseEntity<RsData<Void>> {
         val message =
@@ -70,10 +57,6 @@ class ExceptionHandler(
             .body(RsData("400-1", message))
     }
 
-    /**
-     * 예외 또는 이벤트를 수신해 표준 처리 흐름으로 변환합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<RsData<Void>> {
         val message =
@@ -90,10 +73,6 @@ class ExceptionHandler(
             .body(RsData("400-1", message))
     }
 
-    /**
-     * 예외 또는 이벤트를 수신해 표준 처리 흐름으로 변환합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     @ExceptionHandler(HttpMessageNotReadableException::class)
     fun handleHttpMessageNotReadableException(
         @Suppress("UNUSED_PARAMETER") e: HttpMessageNotReadableException,
@@ -187,10 +166,6 @@ class ExceptionHandler(
         return response.body(ex.rsData)
     }
 
-    /**
-     * 예외 또는 이벤트를 수신해 표준 처리 흐름으로 변환합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     @ExceptionHandler(DataIntegrityViolationException::class)
     fun handleDataIntegrityViolationException(ex: DataIntegrityViolationException): ResponseEntity<RsData<Void>> {
         val repaired = prodSequenceGuardService?.repairIfSequenceDrift(ex) == true

--- a/back/src/main/kotlin/com/back/global/jpa/config/AfterDDLConfig.kt
+++ b/back/src/main/kotlin/com/back/global/jpa/config/AfterDDLConfig.kt
@@ -10,11 +10,6 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.core.annotation.Order
 import javax.sql.DataSource
 
-/**
- * AfterDDLConfig는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
-
 @Configuration
 class AfterDDLConfig(
     @param:Value("\${custom.jpa.after-ddl.enabled:true}")
@@ -24,10 +19,6 @@ class AfterDDLConfig(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    /**
-     * afterDDLRunner 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     @Bean
     @Order(0)
     fun afterDDLRunner(

--- a/back/src/main/kotlin/com/back/global/jpa/config/CustomDevPostgreSQLDialect.kt
+++ b/back/src/main/kotlin/com/back/global/jpa/config/CustomDevPostgreSQLDialect.kt
@@ -4,10 +4,6 @@ import org.hibernate.mapping.Table
 import org.hibernate.tool.schema.internal.StandardTableExporter
 import org.hibernate.tool.schema.spi.Exporter
 
-/**
- * CustomDevPostgreSQLDialect는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
 open class CustomDevPostgreSQLDialect : CustomPostgreSQLDialect() {
     private val unloggedTableExporter =
         object : StandardTableExporter(this) {

--- a/back/src/main/kotlin/com/back/global/jpa/config/CustomPostgreSQLDialect.kt
+++ b/back/src/main/kotlin/com/back/global/jpa/config/CustomPostgreSQLDialect.kt
@@ -6,15 +6,7 @@ import org.hibernate.dialect.PostgreSQLDialect
 import org.hibernate.type.BasicType
 import org.hibernate.type.SqlTypes
 
-/**
- * CustomPostgreSQLDialect는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
 open class CustomPostgreSQLDialect : PostgreSQLDialect() {
-    /**
-     * initializeFunctionRegistry 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     override fun initializeFunctionRegistry(functionContributions: FunctionContributions) {
         super.initializeFunctionRegistry(functionContributions)
 

--- a/back/src/main/kotlin/com/back/global/jpa/config/JpaConfig.kt
+++ b/back/src/main/kotlin/com/back/global/jpa/config/JpaConfig.kt
@@ -6,11 +6,6 @@ import jakarta.persistence.PersistenceContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
-/**
- * JpaConfig는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
-
 @Configuration
 class JpaConfig {
     @PersistenceContext

--- a/back/src/main/kotlin/com/back/global/jpa/model/BaseEntity.kt
+++ b/back/src/main/kotlin/com/back/global/jpa/model/BaseEntity.kt
@@ -7,10 +7,6 @@ import jakarta.persistence.Transient
 import org.hibernate.Hibernate
 import org.springframework.data.domain.Persistable
 
-/**
- * BaseEntity는 글로벌 모듈 도메인 상태와 규칙을 표현하는 모델입니다.
- * 불변조건을 유지하며 상태 전이를 메서드 단위로 캡슐화합니다.
- */
 @MappedSuperclass
 abstract class BaseEntity : Persistable<Long> {
     abstract val id: Long
@@ -39,10 +35,6 @@ abstract class BaseEntity : Persistable<Long> {
         defaultValue: () -> T,
     ): T = attrCache.getOrPut(key, defaultValue) as T
 
-    /**
-     * equals 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 도메인 계층에서 불변조건을 유지하며 상태 전이를 제어합니다.
-     */
     override fun equals(other: Any?): Boolean {
         if (other === this) return true
         if (other !is BaseEntity) return false
@@ -62,10 +54,6 @@ abstract class BaseEntity : Persistable<Long> {
 
     private fun effectiveClass(entity: Any): Class<*> = Hibernate.getClass(entity)
 
-    /**
-     * identityClass 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 도메인 계층에서 불변조건을 유지하며 상태 전이를 제어합니다.
-     */
     private fun identityClass(entity: Any): Class<*> {
         var clazz = effectiveClass(entity)
 

--- a/back/src/main/kotlin/com/back/global/pGroonga/config/PGroongaCompositeMatchFunction.kt
+++ b/back/src/main/kotlin/com/back/global/pGroonga/config/PGroongaCompositeMatchFunction.kt
@@ -13,10 +13,6 @@ import org.hibernate.sql.ast.tree.SqlAstNode
 import org.hibernate.type.BasicType
 import org.hibernate.type.BindingContext
 
-/**
- * PGroongaCompositeMatchFunction는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
 class PGroongaCompositeMatchFunction(
     functionName: String,
     booleanType: BasicType<Boolean>,
@@ -27,10 +23,6 @@ class PGroongaCompositeMatchFunction(
         StandardFunctionReturnTypeResolvers.invariant(booleanType),
         null,
     ) {
-    /**
-     * render 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     override fun render(
         sqlAppender: SqlAppender,
         sqlAstArguments: List<SqlAstNode>,
@@ -62,10 +54,6 @@ class PGroongaCompositeMatchFunction(
             validateCount(arguments.size, functionName)
         }
 
-        /**
-         * validateCount 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-         * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-         */
         private fun validateCount(
             size: Int,
             functionName: String,

--- a/back/src/main/kotlin/com/back/global/pGroonga/config/PGroongaStartupValidator.kt
+++ b/back/src/main/kotlin/com/back/global/pGroonga/config/PGroongaStartupValidator.kt
@@ -9,10 +9,6 @@ import org.springframework.context.annotation.Profile
 import org.springframework.core.annotation.Order
 import javax.sql.DataSource
 
-/**
- * PGroongaStartupValidator는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
 @Profile("prod")
 @Configuration
 class PGroongaStartupValidator(

--- a/back/src/main/kotlin/com/back/global/redisCache/config/RedisCacheConfig.kt
+++ b/back/src/main/kotlin/com/back/global/redisCache/config/RedisCacheConfig.kt
@@ -19,11 +19,6 @@ import org.springframework.scheduling.annotation.EnableScheduling
 import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator
 import java.time.Duration
 
-/**
- * RedisCacheConfig는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
-
 @Configuration
 @EnableCaching
 @EnableScheduling
@@ -76,10 +71,6 @@ class RedisCacheConfig(
     @Bean
     fun cacheErrorHandler(): CacheErrorHandler = cacheErrorHandlerDelegate
 
-    /**
-     * cacheManager 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     @Bean
     fun cacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
         val ptv =

--- a/back/src/main/kotlin/com/back/global/redisCache/config/RedisCacheProperties.kt
+++ b/back/src/main/kotlin/com/back/global/redisCache/config/RedisCacheProperties.kt
@@ -2,10 +2,6 @@ package com.back.global.redisCache.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 
-/**
- * RedisCacheProperties는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
 @ConfigurationProperties("custom.cache")
 data class RedisCacheProperties(
     val ttlSeconds: Long = 3600,

--- a/back/src/main/kotlin/com/back/global/revalidate/adapter/event/RevalidateEventListener.kt
+++ b/back/src/main/kotlin/com/back/global/revalidate/adapter/event/RevalidateEventListener.kt
@@ -13,10 +13,6 @@ import org.springframework.transaction.event.TransactionalEventListener
 import java.nio.charset.StandardCharsets
 import java.util.UUID
 
-/**
- * RevalidateEventListener는 도메인 이벤트를 수신해 후속 처리를 연결하는 이벤트 어댑터입니다.
- * 이벤트 수신 시 비동기 작업 등록과 재처리 경로를 담당합니다.
- */
 @Component
 class RevalidateEventListener(
     private val taskFacade: TaskFacade,
@@ -46,10 +42,6 @@ class RevalidateEventListener(
         revalidateService.revalidatePath(payload.path)
     }
 
-    /**
-     * enqueueHomeRevalidate 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 어댑터 계층에서 외부 시스템 연동 오류를 캡슐화해 상위 계층 영향을 최소화합니다.
-     */
     private fun enqueueRevalidatePaths(
         sourceEventUid: UUID,
         aggregateType: String,

--- a/back/src/main/kotlin/com/back/global/security/config/CustomUserDetailsService.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/CustomUserDetailsService.kt
@@ -9,19 +9,10 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.stereotype.Service
 import java.util.Locale
 
-/**
- * CustomUserDetailsService는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
-
 @Service
 class CustomUserDetailsService(
     private val actorApplicationService: ActorApplicationService,
 ) : UserDetailsService {
-    /**
-     * 외부 인증/사용자 정보를 로드하고 내부 모델로 매핑합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     override fun loadUserByUsername(username: String): UserDetails {
         val normalizedIdentifier = username.trim()
         if (!normalizedIdentifier.contains("@")) throw UsernameNotFoundException("사용자를 찾을 수 없습니다.")

--- a/back/src/main/kotlin/com/back/global/security/config/PublicApiRequestMatcher.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/PublicApiRequestMatcher.kt
@@ -3,10 +3,6 @@ package com.back.global.security.config
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.stereotype.Component
 
-/**
- * PublicApiRequestMatcher는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
 @Component
 class PublicApiRequestMatcher(
     contributors: List<PublicApiRouteContributor>,

--- a/back/src/main/kotlin/com/back/global/security/config/PublicApiRouteContributor.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/PublicApiRouteContributor.kt
@@ -1,9 +1,5 @@
 package com.back.global.security.config
 
-/**
- * PublicApiRouteContributor는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
 interface PublicApiRouteContributor {
     fun publicApiRoutes(): List<PublicApiRouteSpec>
 }

--- a/back/src/main/kotlin/com/back/global/security/config/PublicApiRouteSpec.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/PublicApiRouteSpec.kt
@@ -6,20 +6,12 @@ import org.springframework.http.server.PathContainer
 import org.springframework.security.config.annotation.web.AuthorizeHttpRequestsDsl
 import org.springframework.web.util.pattern.PathPatternParser
 
-/**
- * PublicApiRouteSpec는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
 data class PublicApiRouteSpec(
     val pattern: String,
     val method: HttpMethod? = null,
 ) {
     private val pathPattern = PathPatternParser.defaultInstance.parse(pattern)
 
-    /**
-     * authorizePermitAll 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     fun authorizePermitAll(authorize: AuthorizeHttpRequestsDsl) {
         if (method == null) {
             authorize.authorize(pattern, authorize.permitAll)
@@ -29,10 +21,6 @@ data class PublicApiRouteSpec(
         authorize.authorize(method, pattern, authorize.permitAll)
     }
 
-    /**
-     * matches 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     fun matches(request: HttpServletRequest): Boolean {
         if (method != null && request.method != method.name()) return false
 

--- a/back/src/main/kotlin/com/back/global/security/config/SecurityConfig.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/SecurityConfig.kt
@@ -29,11 +29,6 @@ import java.net.Inet4Address
 import java.net.Inet6Address
 import java.net.InetAddress
 
-/**
- * SecurityConfig는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
-
 @Configuration
 class SecurityConfig(
     private val customAuthenticationFilter: CustomAuthenticationFilter,
@@ -48,10 +43,6 @@ class SecurityConfig(
     private val objectMapper: ObjectMapper,
     private val environment: Environment,
 ) {
-    /**
-     * 보안/인프라 설정을 요청 처리 체인에 반영합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     @Bean
     fun filterChain(
         http: HttpSecurity,
@@ -162,10 +153,6 @@ class SecurityConfig(
         return http.build()
     }
 
-    /**
-     * corsConfigurationSource 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     @Bean
     fun corsConfigurationSource(): UrlBasedCorsConfigurationSource =
         UrlBasedCorsConfigurationSource().apply {

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2AuthorizationRequestResolver.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2AuthorizationRequestResolver.kt
@@ -10,11 +10,6 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequest
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
 import org.springframework.stereotype.Component
 
-/**
- * CustomOAuth2AuthorizationRequestResolver는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
-
 @Component
 class CustomOAuth2AuthorizationRequestResolver(
     private val clientRegistrationRepository: ClientRegistrationRepository,

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginSuccessHandler.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginSuccessHandler.kt
@@ -15,11 +15,6 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
-/**
- * CustomOAuth2LoginSuccessHandler는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
-
 @Component
 class CustomOAuth2LoginSuccessHandler(
     private val actorApplicationService: ActorApplicationService,
@@ -27,10 +22,6 @@ class CustomOAuth2LoginSuccessHandler(
     private val authCookieService: AuthCookieService,
     private val clientIpResolver: ClientIpResolver,
 ) : AuthenticationSuccessHandler {
-    /**
-     * onAuthenticationSuccess 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     @Transactional
     override fun onAuthenticationSuccess(
         request: HttpServletRequest,

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserService.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserService.kt
@@ -19,10 +19,6 @@ import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
-/**
- * OAuth2Provider는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
 private enum class OAuth2Provider {
     KAKAO,
     ;
@@ -34,11 +30,6 @@ private enum class OAuth2Provider {
     }
 }
 
-/**
- * CustomOAuth2UserService는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
-
 @Service
 class CustomOAuth2UserService(
     private val memberUseCase: MemberUseCase,
@@ -46,10 +37,6 @@ class CustomOAuth2UserService(
     internal var delegate: OAuth2UserService<OAuth2UserRequest, OAuth2User> = DefaultOAuth2UserService()
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    /**
-     * 외부 인증/사용자 정보를 로드하고 내부 모델로 매핑합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     @Transactional
     override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
         val oAuth2User = delegate.loadUser(userRequest)

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/application/OAuth2State.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/application/OAuth2State.kt
@@ -28,10 +28,6 @@ data class OAuth2State(
             )
         }
 
-        /**
-         * 입력/환경 데이터를 파싱·정규화해 내부 처리에 안전한 값으로 변환합니다.
-         * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-         */
         private fun normalizeRedirectUrl(raw: String): String {
             val redirectUrl = raw.trim()
             if (redirectUrl.isBlank()) return DEFAULT_REDIRECT_URL

--- a/back/src/main/kotlin/com/back/global/session/config/SessionConfig.kt
+++ b/back/src/main/kotlin/com/back/global/session/config/SessionConfig.kt
@@ -7,11 +7,6 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.session.web.http.CookieHttpSessionIdResolver
 import org.springframework.session.web.http.HttpSessionIdResolver
 
-/**
- * SessionConfig는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
-
 @Configuration
 class SessionConfig {
     private val sessionPathsPrefixes =
@@ -20,28 +15,16 @@ class SessionConfig {
             "/login/oauth2/",
         )
 
-    /**
-     * httpSessionIdResolver 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     @Bean
     fun httpSessionIdResolver(): HttpSessionIdResolver {
         val delegate = CookieHttpSessionIdResolver()
 
         return object : HttpSessionIdResolver {
-            /**
-             * 입력/환경 데이터를 파싱·정규화해 내부 처리에 안전한 값으로 변환합니다.
-             * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-             */
             override fun resolveSessionIds(request: HttpServletRequest): MutableList<String> {
                 if (!shouldUseSession(request.requestURI)) return mutableListOf()
                 return delegate.resolveSessionIds(request)
             }
 
-            /**
-             * setSessionId 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-             * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-             */
             override fun setSessionId(
                 request: HttpServletRequest,
                 response: HttpServletResponse,
@@ -51,10 +34,6 @@ class SessionConfig {
                 delegate.setSessionId(request, response, sessionId)
             }
 
-            /**
-             * 쿠키 속성을 정책에 맞게 설정하고 보안 플래그를 강제합니다.
-             * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-             */
             override fun expireSession(
                 request: HttpServletRequest,
                 response: HttpServletResponse,

--- a/back/src/main/kotlin/com/back/global/shedLock/config/ShedLockConfig.kt
+++ b/back/src/main/kotlin/com/back/global/shedLock/config/ShedLockConfig.kt
@@ -7,11 +7,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory
 
-/**
- * ShedLockConfig는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
-
 @Configuration
 @EnableSchedulerLock(defaultLockAtMostFor = "PT2H")
 class ShedLockConfig {

--- a/back/src/main/kotlin/com/back/global/springDoc/config/SpringDocConfig.kt
+++ b/back/src/main/kotlin/com/back/global/springDoc/config/SpringDocConfig.kt
@@ -6,11 +6,6 @@ import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
-/**
- * SpringDocConfig는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
-
 @Configuration
 @OpenAPIDefinition(info = Info(title = "API 서버", version = "beta", description = "API 서버 문서입니다."))
 class SpringDocConfig {

--- a/back/src/main/kotlin/com/back/global/storage/config/UploadedFileRetentionConfig.kt
+++ b/back/src/main/kotlin/com/back/global/storage/config/UploadedFileRetentionConfig.kt
@@ -4,11 +4,6 @@ import com.back.global.storage.application.UploadedFileRetentionProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 
-/**
- * UploadedFileRetentionConfig는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
-
 @Configuration
 @EnableConfigurationProperties(UploadedFileRetentionProperties::class)
 class UploadedFileRetentionConfig

--- a/back/src/main/kotlin/com/back/global/system/adapter/web/ApiV1AdmSystemController.kt
+++ b/back/src/main/kotlin/com/back/global/system/adapter/web/ApiV1AdmSystemController.kt
@@ -114,10 +114,6 @@ class ApiV1AdmSystemController(
             dashboard = adminDashboardSnapshotService.getSnapshot(),
         )
 
-    /**
-     * health 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 어댑터 계층에서 외부 시스템 연동 오류를 캡슐화해 상위 계층 영향을 최소화합니다.
-     */
     @GetMapping("/health")
     @Transactional(readOnly = true)
     fun health(

--- a/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt
+++ b/back/src/main/kotlin/com/back/global/task/adapter/scheduler/TaskProcessingScheduledJob.kt
@@ -29,10 +29,6 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
-/**
- * TaskProcessingScheduledJob는 주기 작업을 트리거하는 스케줄러 어댑터입니다.
- * 정기 실행 중 오류가 전체 처리 흐름으로 전파되지 않도록 실패를 격리합니다.
- */
 @Component
 @ConditionalOnProperty(
     prefix = "custom.runtime",
@@ -125,10 +121,6 @@ class TaskProcessingScheduledJob(
         val taskType: String,
     )
 
-    /**
-     * processTasks 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 어댑터 계층에서 외부 시스템 연동 오류를 캡슐화해 상위 계층 영향을 최소화합니다.
-     */
     @Scheduled(fixedDelayString = "\${custom.task.processor.fixedDelayMs}")
     // Queue polling is short-lived; keeping the orphan lock window tight avoids multi-hour ready backlog stalls.
     @SchedulerLock(name = "processTasks", lockAtLeastFor = "PT1M", lockAtMostFor = "PT2M")
@@ -313,10 +305,6 @@ class TaskProcessingScheduledJob(
         perTypeDynamicRefreshedAtEpochMs = nowEpochMs
     }
 
-    /**
-     * 만료/중단 상태를 정리해 리소스와 큐 정합성을 유지합니다.
-     * 어댑터 계층에서 외부 시스템 연동 오류를 캡슐화해 상위 계층 영향을 최소화합니다.
-     */
     private fun recoverStaleProcessingTasks(limit: Int) {
         val stuckBefore = Instant.now().minusSeconds(processingTimeoutSeconds)
         val recoveredTaskIds =
@@ -392,10 +380,6 @@ class TaskProcessingScheduledJob(
             LoadedTaskExecution(task.id, task.uid, leaseToken, task.taskType, task.payload)
         }
 
-    /**
-     * 작업 상태를 전이하고 실패 시 복구 가능한 상태로 보정합니다.
-     * 어댑터 계층에서 외부 시스템 연동 오류를 캡슐화해 상위 계층 영향을 최소화합니다.
-     */
     private fun markTaskCompleted(
         taskId: Long,
         leaseToken: UUID,
@@ -414,10 +398,6 @@ class TaskProcessingScheduledJob(
         }
     }
 
-    /**
-     * 작업 상태를 전이하고 실패 시 복구 가능한 상태로 보정합니다.
-     * 어댑터 계층에서 외부 시스템 연동 오류를 캡슐화해 상위 계층 영향을 최소화합니다.
-     */
     private fun markTaskFailed(
         taskId: Long,
         leaseToken: UUID,
@@ -475,10 +455,6 @@ class TaskProcessingScheduledJob(
         return sanitized.take(80).ifBlank { "unknown" }
     }
 
-    /**
-     * 작업 상태를 전이하고 실패 시 복구 가능한 상태로 보정합니다.
-     * 어댑터 계층에서 외부 시스템 연동 오류를 캡슐화해 상위 계층 영향을 최소화합니다.
-     */
     private fun revertTaskToPending(
         taskId: Long,
         leaseToken: UUID,
@@ -491,10 +467,6 @@ class TaskProcessingScheduledJob(
         }
     }
 
-    /**
-     * 핸들러를 제한 시간 내 실행하고 타임아웃/예외를 분리 처리합니다.
-     * 어댑터 계층에서 외부 시스템 연동 오류를 캡슐화해 상위 계층 영향을 최소화합니다.
-     */
     private fun invokeHandlerWithTimeout(
         context: LoadedTaskExecution,
         entry: TaskHandlerEntry,

--- a/back/src/main/kotlin/com/back/global/task/config/TaskHandlerConfigurer.kt
+++ b/back/src/main/kotlin/com/back/global/task/config/TaskHandlerConfigurer.kt
@@ -13,19 +13,11 @@ import org.springframework.context.ApplicationListener
 import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.stereotype.Component
 
-/**
- * TaskHandlerConfigurer는 글로벌 런타임 동작을 정의하는 설정 클래스입니다.
- * 보안, 캐시, 세션, JPA, 스케줄링 등 공통 인프라 설정을 등록합니다.
- */
 @Component
 class TaskHandlerConfigurer(
     private val applicationContext: ApplicationContext,
     private val taskHandlerRegistry: TaskHandlerRegistry,
 ) : ApplicationListener<ContextRefreshedEvent> {
-    /**
-     * onApplicationEvent 처리 흐름에서 예외 경로와 운영 안정성을 함께 고려합니다.
-     * 설정 계층에서 등록된 정책이 전체 애플리케이션 동작에 일관되게 적용되도록 구성합니다.
-     */
     override fun onApplicationEvent(event: ContextRefreshedEvent) {
         val beanFactory = applicationContext.autowireCapableBeanFactory as? ConfigurableListableBeanFactory
         applicationContext.beanDefinitionNames.forEach { beanName ->


### PR DESCRIPTION
## 관련 이슈

close #895

## 작업 배경

- Backend Kotlin 코드에 메서드명, 계층명, DTO/interface/object 종류를 반복하는 템플릿형 KDoc이 남아 있어 실제 의도와 불변조건을 설명하는 주석의 신뢰도를 낮추고 있었습니다.
- #895 범위에 맞춰 동작 코드가 이미 말하는 설명형 주석은 제거하고, 실패 영향이나 보안 의도처럼 판단 근거가 있는 주석은 유지했습니다.

## 작업 내용

- `PostApplicationService`, `TaskProcessingScheduledJob`의 생성형 KDoc을 제거했습니다.
- backend Kotlin 전반에서 `처리 흐름`, `운영 안정성`, `애플리케이션 서비스 계층`, `데이터 클래스입니다`, `인터페이스입니다` 등 자동 생성형 문구를 제거했습니다.
- `PostTagIndexRepositoryPort`처럼 역할/목적이 실제 계약을 설명하는 주석은 본문을 유지하고 템플릿 첫 줄만 정리했습니다.
- 런타임 로직, API 계약, 테스트 코드는 변경하지 않았습니다.

## 검증

- 실행한 명령과 결과:
  - `rg "처리 흐름|운영 안정성|애플리케이션 서비스 계층|유스케이스 단위|글로벌 런타임 동작|데이터 클래스입니다|인터페이스입니다|오브젝트입니다|열거형입니다|항목을 생성한다|설정 계층에서 등록된 정책|트랜잭션 경계, 도메인 규칙|요청/응답/이벤트/상태 전달용|계층 간 계약\\(포트/스펙\\)|변경 시 호출 경계" back/src/main/kotlin`: 0건
  - `git diff --check`: 통과
  - `back/gradlew -p back ktlintCheck`: BUILD SUCCESSFUL
  - pre-commit `OpenApiContractExportTest`: BUILD SUCCESSFUL
  - pre-commit `yarn contracts:check`: generated types are up-to-date

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 변경은 Kotlin 주석 삭제에 한정됩니다.
  - 주석을 남긴 곳은 queue backlog, Redis/Kotlin serialization, redirect 차단, count 추정 total 등 실제 판단 근거가 있는 부분입니다.
  - 로컬 커밋 훅 실행을 위해 `front` 의존성을 설치했지만, `node_modules`나 lockfile 변경은 포함하지 않았습니다.

## 리스크

- 런타임 동작 변경은 없습니다.
- 변경 파일 수가 많아 diff가 넓지만, 모두 템플릿 주석 삭제입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 상태를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향 없음. PR preview 상태를 확인했다.
