### PR TITLE
[Fix] sitemap 전체 공개 글 누락 방지

### DIFF
--- a/front/e2e/sitemap.spec.ts
+++ b/front/e2e/sitemap.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test"
+import type { ExplorePostsPage } from "../src/apis/backend/posts"
+import { collectSitemapPosts } from "../src/libs/sitemapPosts"
+import type { TPost, TPostStatus } from "../src/types"
+
+const makePost = (id: number, status: TPostStatus[] = ["Public"]): TPost => ({
+  id: String(id),
+  date: { start_date: `2026-06-${String((id % 28) + 1).padStart(2, "0")}` },
+  type: ["Post"],
+  slug: `post-${id}`,
+  title: `Post ${id}`,
+  status,
+  createdTime: `2026-06-${String((id % 28) + 1).padStart(2, "0")}T00:00:00.000Z`,
+  fullWidth: false,
+})
+
+const createPagedLoader =
+  (posts: TPost[], requestedPages: number[]) =>
+  async ({ page, pageSize }: { page?: number; pageSize?: number }): Promise<ExplorePostsPage> => {
+    const safePage = page ?? 1
+    const safePageSize = pageSize ?? 30
+    requestedPages.push(safePage)
+    const start = (safePage - 1) * safePageSize
+
+    return {
+      posts: posts.slice(start, start + safePageSize),
+      totalCount: posts.length,
+      pageNumber: safePage,
+      pageSize: safePageSize,
+      paginationMode: "page",
+    }
+  }
+
+test.describe("server sitemap post collection", () => {
+  for (const postCount of [31, 100, 1000]) {
+    test(`collects all ${postCount} public feed posts without first-page truncation`, async () => {
+      const posts = Array.from({ length: postCount }, (_, index) => makePost(index + 1))
+      const requestedPages: number[] = []
+
+      const collected = await collectSitemapPosts(createPagedLoader(posts, requestedPages), {
+        pageSize: 30,
+      })
+
+      expect(collected.map((post) => post.id)).toEqual(posts.map((post) => post.id))
+      expect(new Set(collected.map((post) => post.id)).size).toBe(postCount)
+      expect(requestedPages).toEqual(
+        Array.from({ length: Math.ceil(postCount / 30) }, (_, index) => index + 1)
+      )
+    })
+  }
+
+  test("filters non-public detail-only posts and deduplicates repeated feed rows", async () => {
+    const publicPost = makePost(1)
+    const repeatedPublicPost = makePost(1)
+    const privatePost = makePost(2, ["Private"])
+    const detailOnlyPost = makePost(3, ["PublicOnDetail"])
+    const requestedPages: number[] = []
+
+    const collected = await collectSitemapPosts(
+      createPagedLoader([publicPost, repeatedPublicPost, privatePost, detailOnlyPost], requestedPages),
+      { pageSize: 2 }
+    )
+
+    expect(collected.map((post) => post.id)).toEqual(["1"])
+    expect(requestedPages).toEqual([1, 2])
+  })
+})

--- a/front/e2e/sitemap.spec.ts
+++ b/front/e2e/sitemap.spec.ts
@@ -15,7 +15,7 @@ const makePost = (id: number, status: TPostStatus[] = ["Public"]): TPost => ({
 })
 
 const createPagedLoader =
-  (posts: TPost[], requestedPages: number[]) =>
+  (posts: TPost[], requestedPages: number[], pageNumberOffset = 0) =>
   async ({ page, pageSize }: { page?: number; pageSize?: number }): Promise<ExplorePostsPage> => {
     const safePage = page ?? 1
     const safePageSize = pageSize ?? 30
@@ -25,7 +25,7 @@ const createPagedLoader =
     return {
       posts: posts.slice(start, start + safePageSize),
       totalCount: posts.length,
-      pageNumber: safePage,
+      pageNumber: safePage + pageNumberOffset,
       pageSize: safePageSize,
       paginationMode: "page",
     }
@@ -76,5 +76,18 @@ test.describe("server sitemap post collection", () => {
       })
     ).rejects.toThrow("Sitemap collection reached maxPages=1 before exhausting posts")
     expect(requestedPages).toEqual([1])
+  })
+
+  test("does not treat zero-based response pageNumber as extra pages at the cap", async () => {
+    const posts = Array.from({ length: 60 }, (_, index) => makePost(index + 1))
+    const requestedPages: number[] = []
+
+    const collected = await collectSitemapPosts(createPagedLoader(posts, requestedPages, -1), {
+      pageSize: 30,
+      maxPages: 2,
+    })
+
+    expect(collected.map((post) => post.id)).toEqual(posts.map((post) => post.id))
+    expect(requestedPages).toEqual([1, 2])
   })
 })

--- a/front/e2e/sitemap.spec.ts
+++ b/front/e2e/sitemap.spec.ts
@@ -64,4 +64,17 @@ test.describe("server sitemap post collection", () => {
     expect(collected.map((post) => post.id)).toEqual(["1"])
     expect(requestedPages).toEqual([1, 2])
   })
+
+  test("fails loudly when maxPages is reached before exhausting public posts", async () => {
+    const posts = Array.from({ length: 31 }, (_, index) => makePost(index + 1))
+    const requestedPages: number[] = []
+
+    await expect(
+      collectSitemapPosts(createPagedLoader(posts, requestedPages), {
+        pageSize: 30,
+        maxPages: 1,
+      })
+    ).rejects.toThrow("Sitemap collection reached maxPages=1 before exhausting posts")
+    expect(requestedPages).toEqual([1])
+  })
 })

--- a/front/src/libs/sitemapPosts.ts
+++ b/front/src/libs/sitemapPosts.ts
@@ -55,8 +55,15 @@ export const collectSitemapPosts = async (
       posts.push(post)
     }
 
-    if (result.posts.length === 0 || !hasMoreSitemapPages(result, page, safePageSize)) {
+    const hasMore = result.posts.length > 0 && hasMoreSitemapPages(result, page, safePageSize)
+    if (!hasMore) {
       break
+    }
+
+    if (page === safeMaxPages) {
+      throw new Error(
+        `Sitemap collection reached maxPages=${safeMaxPages} before exhausting posts. Increase the limit or split the sitemap.`
+      )
     }
   }
 

--- a/front/src/libs/sitemapPosts.ts
+++ b/front/src/libs/sitemapPosts.ts
@@ -1,0 +1,64 @@
+import { getFeedPostsPage, type ExplorePostsPage } from "src/apis/backend/posts"
+import type { TPost } from "src/types"
+
+export const SITEMAP_POST_PAGE_SIZE = 30
+export const SITEMAP_MAX_POST_PAGES = 1_000
+
+export type SitemapPostPageLoader = (params: {
+  order?: "asc" | "desc"
+  page?: number
+  pageSize?: number
+}) => Promise<ExplorePostsPage>
+
+type CollectSitemapPostsOptions = {
+  pageSize?: number
+  maxPages?: number
+}
+
+const toSafePositiveInteger = (value: number | undefined, fallback: number) => {
+  if (!Number.isFinite(value)) return fallback
+  return Math.max(1, Math.trunc(value || fallback))
+}
+
+const isSitemapVisiblePost = (post: TPost) =>
+  post.status.includes("Public") &&
+  !post.status.includes("Private") &&
+  !post.status.includes("PublicOnDetail")
+
+const hasMoreSitemapPages = (page: ExplorePostsPage, requestedPage: number, requestedPageSize: number) => {
+  if (page.hasNext === true) return true
+  const responsePageNumber = toSafePositiveInteger(page.pageNumber, requestedPage)
+  const responsePageSize = toSafePositiveInteger(page.pageSize, requestedPageSize)
+  const totalCount = Number.isFinite(page.totalCount) ? Math.max(0, Math.trunc(page.totalCount)) : 0
+  return responsePageNumber * responsePageSize < totalCount
+}
+
+export const collectSitemapPosts = async (
+  loadPage: SitemapPostPageLoader = getFeedPostsPage,
+  { pageSize = SITEMAP_POST_PAGE_SIZE, maxPages = SITEMAP_MAX_POST_PAGES }: CollectSitemapPostsOptions = {}
+) => {
+  const safePageSize = toSafePositiveInteger(pageSize, SITEMAP_POST_PAGE_SIZE)
+  const safeMaxPages = toSafePositiveInteger(maxPages, SITEMAP_MAX_POST_PAGES)
+  const posts: TPost[] = []
+  const seenPostIds = new Set<string>()
+
+  for (let page = 1; page <= safeMaxPages; page += 1) {
+    const result = await loadPage({
+      order: "desc",
+      page,
+      pageSize: safePageSize,
+    })
+
+    for (const post of result.posts) {
+      if (!isSitemapVisiblePost(post) || seenPostIds.has(post.id)) continue
+      seenPostIds.add(post.id)
+      posts.push(post)
+    }
+
+    if (result.posts.length === 0 || !hasMoreSitemapPages(result, page, safePageSize)) {
+      break
+    }
+  }
+
+  return posts
+}

--- a/front/src/libs/sitemapPosts.ts
+++ b/front/src/libs/sitemapPosts.ts
@@ -27,10 +27,9 @@ const isSitemapVisiblePost = (post: TPost) =>
 
 const hasMoreSitemapPages = (page: ExplorePostsPage, requestedPage: number, requestedPageSize: number) => {
   if (page.hasNext === true) return true
-  const responsePageNumber = toSafePositiveInteger(page.pageNumber, requestedPage)
   const responsePageSize = toSafePositiveInteger(page.pageSize, requestedPageSize)
   const totalCount = Number.isFinite(page.totalCount) ? Math.max(0, Math.trunc(page.totalCount)) : 0
-  return responsePageNumber * responsePageSize < totalCount
+  return requestedPage * responsePageSize < totalCount
 }
 
 export const collectSitemapPosts = async (

--- a/front/src/pages/sitemap.xml.tsx
+++ b/front/src/pages/sitemap.xml.tsx
@@ -1,11 +1,11 @@
-import { getPosts } from "src/apis"
 import { CONFIG } from "site.config"
 import { getServerSideSitemap, ISitemapField } from "next-sitemap"
 import { GetServerSideProps } from "next"
+import { collectSitemapPosts } from "src/libs/sitemapPosts"
 import { toCanonicalPostPath } from "src/libs/utils/postPath"
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-  const posts = await getPosts()
+  const posts = await collectSitemapPosts()
   const dynamicPaths = posts.map((post) => `${CONFIG.link}${toCanonicalPostPath(post.id)}`)
 
   const fields: ISitemapField[] = dynamicPaths.map((path) => ({


### PR DESCRIPTION
## 관련 이슈

close #922

## 작업 배경

- `/sitemap.xml`이 기존 `getPosts()` 첫 페이지 결과에 묶여 공개 글이 31개 이상이면 31번째 이후 URL이 누락될 수 있었습니다.
- 검색엔진 수집 대상은 공개 feed 전체여야 하므로 sitemap 전용 수집 로직에서 page feed를 끝까지 순회하도록 수정했습니다.

## 작업 내용

- sitemap post 수집 helper를 추가해 `getFeedPostsPage`를 page 단위로 순회합니다.
- sitemap 대상은 `Public` 글만 포함하고 `Private`, `PublicOnDetail` 글은 제외하며, 중복 post id는 한 번만 포함합니다.
- `/sitemap.xml` SSR 경로가 `getPosts()` 대신 sitemap helper를 사용하도록 변경했습니다.
- `maxPages` 상한에 도달했는데 다음 page가 남아 있으면 부분 sitemap을 반환하지 않고 오류로 실패시킵니다.
- zero-based `pageNumber` 응답에서도 상한 도달 여부를 잘못 판단하지 않도록 요청 page 기준으로 `totalCount`를 비교합니다.
- 31개, 100개, 1,000개 공개 글 fixture와 비공개/detail-only/중복 row 제외, maxPages 초과, zero-based pageNumber 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
- `yarn --cwd front playwright:preflight` 통과
- `yarn --cwd front playwright test e2e/sitemap.spec.ts --workers=1` 6 passed
- `yarn --cwd front build` 통과
- `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1` 1 passed
- `yarn --cwd front playwright test e2e/import-boundary.spec.ts --workers=1` 통과
- CodeRabbit review finding 1건 원 thread 답글 후 resolved
- Codex CLI review finding 1건 원 thread 답글 후 resolved
- Codex CLI 재검토 review: `Actionable comments posted: 0`
- PR CI: `frontend-ci`, `backend-ci`, `backend-dependency-check`, `CodeQL`, `CodeRabbit`, `Vercel` 통과
- main merge 후 `CI`, `Security`, `Deploy to Home Server` workflow 통과
- live `https://www.aquilaxk.site/sitemap.xml` 200 XML 응답 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
- `front/src/libs/sitemapPosts.ts`의 page 순회 종료 조건, maxPages 초과 처리, 공개 상태 필터
- `front/e2e/sitemap.spec.ts`의 31/100/1000개 fixture와 maxPages/zero-based pageNumber 회귀 케이스

## 리스크

- 공개 글 수가 매우 많으면 sitemap 요청 시 backend page 호출 수가 증가합니다. 현재 `SITEMAP_MAX_POST_PAGES=1000`, page size 30으로 무한 순회를 방지했고, 상한 초과 시 조용한 누락 대신 명시적으로 실패합니다.
- `lastmod` 실제 수정일 반영은 별도 issue #923 범위로 남겼습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 사이트맵 게시물 수집 기능에 대한 엔드투엔드 테스트 추가

* **개선사항**
  * 사이트맵 생성 로직을 개선하여 공개 게시물만 더 정확하게 수집하도록 최적화했습니다. 중복 제거 및 페이지 기반 처리를 통해 사이트맵의 정확성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
