### PR TITLE
[Fix] sitemap lastmod 실제 수정일 반영

### DIFF
--- a/front/e2e/sitemap.spec.ts
+++ b/front/e2e/sitemap.spec.ts
@@ -1,16 +1,21 @@
 import { expect, test } from "@playwright/test"
 import type { ExplorePostsPage } from "../src/apis/backend/posts"
-import { collectSitemapPosts } from "../src/libs/sitemapPosts"
+import { buildSitemapFields, collectSitemapPosts } from "../src/libs/sitemapPosts"
 import type { TPost, TPostStatus } from "../src/types"
 
-const makePost = (id: number, status: TPostStatus[] = ["Public"]): TPost => ({
+const makePost = (
+  id: number,
+  status: TPostStatus[] = ["Public"],
+  timestamps: { createdTime?: string; modifiedTime?: string } = {}
+): TPost => ({
   id: String(id),
   date: { start_date: `2026-06-${String((id % 28) + 1).padStart(2, "0")}` },
   type: ["Post"],
   slug: `post-${id}`,
   title: `Post ${id}`,
   status,
-  createdTime: `2026-06-${String((id % 28) + 1).padStart(2, "0")}T00:00:00.000Z`,
+  createdTime: timestamps.createdTime ?? `2026-06-${String((id % 28) + 1).padStart(2, "0")}T00:00:00.000Z`,
+  ...(timestamps.modifiedTime ? { modifiedTime: timestamps.modifiedTime } : {}),
   fullWidth: false,
 })
 
@@ -89,5 +94,48 @@ test.describe("server sitemap post collection", () => {
 
     expect(collected.map((post) => post.id)).toEqual(posts.map((post) => post.id))
     expect(requestedPages).toEqual([1, 2])
+  })
+
+  test("uses stable content timestamps for sitemap lastmod fields", () => {
+    const updatedPost = makePost(1, ["Public"], {
+      createdTime: "2026-06-01T00:00:00.000Z",
+      modifiedTime: "2026-06-07T12:34:56.000Z",
+    })
+    const createdOnlyPost = makePost(2, ["Public"], {
+      createdTime: "2026-06-10T08:00:00.000Z",
+    })
+
+    const firstFields = buildSitemapFields(
+      [updatedPost, createdOnlyPost],
+      "https://example.com/",
+      "2026-01-01T00:00:00.000Z"
+    )
+    const secondFields = buildSitemapFields(
+      [updatedPost, createdOnlyPost],
+      "https://example.com/",
+      "2026-01-01T00:00:00.000Z"
+    )
+
+    expect(secondFields).toEqual(firstFields)
+    expect(firstFields).toEqual([
+      {
+        loc: "https://example.com",
+        lastmod: "2026-06-10T08:00:00.000Z",
+        priority: 1,
+        changefreq: "daily",
+      },
+      {
+        loc: "https://example.com/posts/1",
+        lastmod: "2026-06-07T12:34:56.000Z",
+        priority: 0.7,
+        changefreq: "daily",
+      },
+      {
+        loc: "https://example.com/posts/2",
+        lastmod: "2026-06-10T08:00:00.000Z",
+        priority: 0.7,
+        changefreq: "daily",
+      },
+    ])
   })
 })

--- a/front/src/libs/sitemapPosts.ts
+++ b/front/src/libs/sitemapPosts.ts
@@ -1,5 +1,6 @@
 import { getFeedPostsPage, type ExplorePostsPage } from "src/apis/backend/posts"
 import type { TPost } from "src/types"
+import { toCanonicalPostPath } from "src/libs/utils/postPath"
 
 export const SITEMAP_POST_PAGE_SIZE = 30
 export const SITEMAP_MAX_POST_PAGES = 1_000
@@ -15,15 +16,44 @@ type CollectSitemapPostsOptions = {
   maxPages?: number
 }
 
+type SitemapField = {
+  loc: string
+  lastmod: string
+  priority: number
+  changefreq: "daily"
+}
+
 const toSafePositiveInteger = (value: number | undefined, fallback: number) => {
   if (!Number.isFinite(value)) return fallback
   return Math.max(1, Math.trunc(value || fallback))
+}
+
+const toStableIsoTimestamp = (value: string | undefined) => {
+  if (typeof value !== "string" || value.trim().length === 0) return null
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) return null
+  return new Date(timestamp).toISOString()
 }
 
 const isSitemapVisiblePost = (post: TPost) =>
   post.status.includes("Public") &&
   !post.status.includes("Private") &&
   !post.status.includes("PublicOnDetail")
+
+export const getSitemapPostLastmod = (post: TPost) =>
+  toStableIsoTimestamp(post.modifiedTime) ??
+  toStableIsoTimestamp(post.createdTime) ??
+  toStableIsoTimestamp(post.date.start_date) ??
+  "1970-01-01T00:00:00.000Z"
+
+const getLatestLastmod = (lastmods: string[], fallback: string) =>
+  lastmods.reduce((latest, candidate) => {
+    const latestTime = Date.parse(latest)
+    const candidateTime = Date.parse(candidate)
+    if (!Number.isFinite(candidateTime)) return latest
+    if (!Number.isFinite(latestTime)) return candidate
+    return candidateTime > latestTime ? candidate : latest
+  }, fallback)
 
 const hasMoreSitemapPages = (page: ExplorePostsPage, requestedPage: number, requestedPageSize: number) => {
   if (page.hasNext === true) return true
@@ -67,4 +97,34 @@ export const collectSitemapPosts = async (
   }
 
   return posts
+}
+
+export const buildSitemapFields = (
+  posts: TPost[],
+  siteUrl: string,
+  fallbackSiteLastmod = "1970-01-01T00:00:00.000Z"
+): SitemapField[] => {
+  const normalizedSiteUrl = siteUrl.replace(/\/+$/, "")
+  const normalizedFallbackLastmod =
+    toStableIsoTimestamp(fallbackSiteLastmod) ?? "1970-01-01T00:00:00.000Z"
+
+  const postFields = posts.map((post) => ({
+    loc: `${normalizedSiteUrl}${toCanonicalPostPath(post.id)}`,
+    lastmod: getSitemapPostLastmod(post),
+    priority: 0.7,
+    changefreq: "daily" as const,
+  }))
+
+  return [
+    {
+      loc: normalizedSiteUrl,
+      lastmod: getLatestLastmod(
+        postFields.map((field) => field.lastmod),
+        normalizedFallbackLastmod
+      ),
+      priority: 1.0,
+      changefreq: "daily",
+    },
+    ...postFields,
+  ]
 }

--- a/front/src/pages/sitemap.xml.tsx
+++ b/front/src/pages/sitemap.xml.tsx
@@ -1,26 +1,11 @@
 import { CONFIG } from "site.config"
-import { getServerSideSitemap, ISitemapField } from "next-sitemap"
+import { getServerSideSitemap } from "next-sitemap"
 import { GetServerSideProps } from "next"
-import { collectSitemapPosts } from "src/libs/sitemapPosts"
-import { toCanonicalPostPath } from "src/libs/utils/postPath"
+import { buildSitemapFields, collectSitemapPosts } from "src/libs/sitemapPosts"
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const posts = await collectSitemapPosts()
-  const dynamicPaths = posts.map((post) => `${CONFIG.link}${toCanonicalPostPath(post.id)}`)
-
-  const fields: ISitemapField[] = dynamicPaths.map((path) => ({
-    loc: path,
-    lastmod: new Date().toISOString(),
-    priority: 0.7,
-    changefreq: "daily",
-  }))
-
-  fields.unshift({
-    loc: CONFIG.link,
-    lastmod: new Date().toISOString(),
-    priority: 1.0,
-    changefreq: "daily",
-  })
+  const fields = buildSitemapFields(posts, CONFIG.link, `${CONFIG.since}-01-01T00:00:00.000Z`)
 
   return getServerSideSitemap(ctx, fields)
 }


### PR DESCRIPTION
## 관련 이슈

close #923

## 작업 배경

- `/sitemap.xml`의 게시글과 홈 `lastmod`가 요청 시각으로 생성되어 같은 콘텐츠라도 요청할 때마다 수정된 것처럼 보일 수 있었습니다.
- 검색엔진에는 실제 콘텐츠 변경 시각을 전달해야 하므로 sitemap field 생성에서 `modifiedTime`/`createdTime` 기반 timestamp를 사용하도록 고쳤습니다.

## 작업 내용

- sitemap helper에 `getSitemapPostLastmod`, `buildSitemapFields`를 추가했습니다.
- 게시글 `lastmod`는 `modifiedTime`, 없으면 `createdTime`, 없으면 `date.start_date` 순서로 안정적인 ISO timestamp를 사용합니다.
- 홈 `lastmod`는 sitemap에 포함된 공개 글 중 가장 최신 `lastmod`를 사용하고, 공개 글이 없으면 `CONFIG.since` 기반 fallback을 사용합니다.
- `/sitemap.xml` SSR 경로에서 요청 시각 `new Date()` 의존을 제거했습니다.
- 같은 fixture로 sitemap field를 반복 생성해도 `lastmod`가 바뀌지 않는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
- `yarn --cwd front playwright test e2e/sitemap.spec.ts --workers=1` 2회 연속 통과, 7 passed
- `yarn --cwd front build` 2회 연속 통과
- `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1` 2회 연속 통과, 1 passed
- PR CI: `backend-ci`, `frontend-ci`, `backend-dependency-check`, `codeql (java-kotlin)`, `codeql (javascript-typescript)`, Vercel preview 모두 통과
- CodeRabbit: rate limit/credit 부족으로 실제 리뷰가 시작되지 않음
- Codex CLI fallback review: https://github.com/AquilaXk/aquila-blog/pull/960#pullrequestreview-4536836917, Actionable comments posted: 0
- Merge commit: `dc3ed449e479a91e5f2bf79fc985c701eb9a344e`
- main CI: https://github.com/AquilaXk/aquila-blog/actions/runs/27866414180 성공
- main Security: https://github.com/AquilaXk/aquila-blog/actions/runs/27866414148 성공
- Deploy to Home Server: https://github.com/AquilaXk/aquila-blog/actions/runs/27866565237 성공
- live sitemap: `https://www.aquilaxk.site/sitemap.xml` 2회 응답 SHA-256 `12d26cf0d835fcd15109f17228164c1539eb565162cdd8cee156246e962ceaf9`로 동일, `cmp` 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
- `front/src/libs/sitemapPosts.ts`의 timestamp fallback 순서와 홈 `lastmod` 최신값 계산
- `front/e2e/sitemap.spec.ts`의 반복 생성 안정성 테스트

## 리스크

- 기존 backend public post DTO가 전달하는 `modifiedAt`/`createdAt` 값이 잘못된 형식이면 sitemap helper가 다음 fallback으로 내려갑니다.
- 공개 글이 하나도 없으면 홈 `lastmod`는 `CONFIG.since`의 1월 1일 UTC timestamp로 고정됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. CodeRabbit은 rate limit/credit 부족으로 실제 리뷰를 생성하지 못했습니다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
