### PR TITLE
[Fix] 비관리자 empty state 글 작성 CTA 숨김

### DIFF
--- a/front/e2e/home-feed-redesign.spec.ts
+++ b/front/e2e/home-feed-redesign.spec.ts
@@ -249,6 +249,21 @@ test.describe("home feed product redesign", () => {
     await expect(profileSummary.locator(".links a")).toHaveCount(0)
   })
 
+  test("비관리자 empty state는 글 작성이나 admin CTA를 노출하지 않는다", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await mockHomeFeedRedesignEndpoints(page, [])
+
+    await page.goto("/")
+
+    const emptyState = page.locator(".emptyState")
+    await expect(emptyState).toBeVisible()
+    await expect(emptyState).toContainText("아직 게시글이 없습니다.")
+    await expect(emptyState).toContainText("곧 새로운 글을 준비하겠습니다.")
+    await expect(emptyState.getByRole("link", { name: "블로그 소개" })).toHaveAttribute("href", "/about")
+    await expect(emptyState.getByRole("link", { name: /글 작성/ })).toHaveCount(0)
+    await expect(emptyState.locator('a[href="/admin"]')).toHaveCount(0)
+  })
+
   test("category-only 글은 restore snapshot과 memo guard에서도 stale fallback으로 떨어지지 않는다", () => {
     const feedRoot = path.resolve(__dirname, "../src/routes/Feed")
     const restoreSource = readFileSync(path.join(feedRoot, "FeedExplorerRestoreModel.ts"), "utf8")

--- a/front/src/routes/Feed/PostList/index.tsx
+++ b/front/src/routes/Feed/PostList/index.tsx
@@ -33,17 +33,7 @@ const DEFERRED_MOUNT_ROOT_MARGIN = "680px 0px"
 const EmptyPostStateInner: React.FC<EmptyPostStateProps> = ({ hasFilter, onClearFilters }) => {
   const { me, authStatus } = useAuthSession()
   const isAdmin = authStatus === "authenticated" && Boolean(me?.isAdmin)
-  const secondaryCta = isAdmin
-    ? {
-        href: "/admin",
-        icon: "service" as const,
-        label: "관리자 허브",
-      }
-    : {
-        href: "/about",
-        icon: "service" as const,
-        label: "블로그 소개",
-      }
+  const emptyStateMessage = isAdmin ? "첫 글을 발행해보세요." : "곧 새로운 글을 준비하겠습니다."
 
   return (
     <section className="emptyState" aria-live="polite">
@@ -51,23 +41,28 @@ const EmptyPostStateInner: React.FC<EmptyPostStateProps> = ({ hasFilter, onClear
         <AppIcon name={hasFilter ? "search" : "edit"} />
       </div>
       <h3>{hasFilter ? "검색 결과가 없습니다." : "아직 게시글이 없습니다."}</h3>
-      <p>{hasFilter ? "다른 검색어를 입력해보세요." : "첫 글을 발행해보세요."}</p>
+      <p>{hasFilter ? "다른 검색어를 입력해보세요." : emptyStateMessage}</p>
       <div className="emptyActions">
         {hasFilter ? (
           <button type="button" onClick={onClearFilters} className="actionBtn actionBtn--primary">
             <AppIcon name="search" />
             초기화
           </button>
-        ) : (
-          <Link href={isAdmin ? "/editor/new" : "/admin"} className="actionBtn actionBtn--primary">
+        ) : isAdmin ? (
+          <Link href="/editor/new" className="actionBtn actionBtn--primary">
             <AppIcon name="edit" />
-            글 작성
+            첫 글 작성
+          </Link>
+        ) : (
+          <Link href="/about" className="actionBtn actionBtn--primary">
+            <AppIcon name="service" />
+            블로그 소개
           </Link>
         )}
-        {!hasFilter && (
-          <Link href={secondaryCta.href} className="actionBtn">
-            <AppIcon name={secondaryCta.icon} />
-            {secondaryCta.label}
+        {!hasFilter && isAdmin && (
+          <Link href="/admin" className="actionBtn">
+            <AppIcon name="service" />
+            관리자 허브
           </Link>
         )}
       </div>


### PR DESCRIPTION
## 관련 이슈

close #953

## 작업 배경

- Feed empty state에서 비관리자/비로그인 사용자에게도 “글 작성” CTA가 표시되고 `/admin`으로 이동하는 문제가 있었습니다.
- 글 작성과 관리자 허브 CTA는 관리자에게만 보여야 하므로 empty state CTA를 사용자 권한 기준으로 분리했습니다.

## 작업 내용

- 비관리자/비로그인 empty state 메시지를 공개 사용자용 문구로 변경했습니다.
- 관리자인 경우에만 `/editor/new` “첫 글 작성” CTA와 `/admin` “관리자 허브” CTA를 노출합니다.
- 비관리자/비로그인에게는 `/about` “블로그 소개” CTA만 primary로 노출합니다.
- 빈 feed fixture e2e에서 비관리자 상태에 “글 작성”과 `/admin` CTA가 없는지 검증합니다.

## 검증

- 실행한 명령과 결과:
- `yarn --cwd front playwright:preflight` 통과
- `yarn --cwd front playwright test e2e/home-feed-redesign.spec.ts --workers=1` 2회 연속 통과, 9 passed
- `yarn --cwd front build` 2회 연속 통과
- PR CI 통과: `frontend-ci`, `backend-ci`, `backend-dependency-check`, `CodeQL`
- CodeRabbit 확인: rate limit/credit 부족으로 실제 리뷰 미실행
- Codex CLI fallback review 게시: https://github.com/AquilaXk/aquila-blog/pull/962#pullrequestreview-4536946172, actionable 0
- post-merge CI 통과: https://github.com/AquilaXk/aquila-blog/actions/runs/27867526440
- post-merge Security 통과: https://github.com/AquilaXk/aquila-blog/actions/runs/27867526427
- post-merge CD 통과: https://github.com/AquilaXk/aquila-blog/actions/runs/27867664813
- live UI 확인: `https://www.aquilaxk.site` 홈 feed 렌더링, 검색 입력 `JWT` 적용 후 `검색 "JWT"`/4개 결과 표시, Browser console error/warn 0건
- live screenshot: `/private/tmp/pr-962-live-home-loaded.png`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
- `front/src/routes/Feed/PostList/index.tsx`의 `EmptyPostStateInner` 권한별 CTA 분기
- `front/e2e/home-feed-redesign.spec.ts`의 비관리자 empty state fixture

## 리스크

- 비관리자 빈 feed에서는 더 이상 글 작성 CTA를 제공하지 않으므로, 관리자 판정이 늦게 끝나는 경우 초기 화면은 공개 사용자 CTA를 먼저 보여줄 수 있습니다.
- 관리자 인증 상태가 확정되면 기존처럼 작성/관리자 CTA가 표시됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
