### PR TITLE
[Style] 404 페이지 코드 스타일 정리

### DIFF
--- a/front/src/routes/Error/index.tsx
+++ b/front/src/routes/Error/index.tsx
@@ -1,39 +1,47 @@
-import styled from "@emotion/styled";
-import Link from "next/link";
-import React from "react";
-import AppIcon from "src/components/icons/AppIcon";
-type Props = {};
-const CustomError: React.FC<Props> = () => {
-    return (<StyledWrapper>
+import styled from "@emotion/styled"
+import Link from "next/link"
+
+import AppIcon from "src/components/icons/AppIcon"
+
+const CustomError = () => {
+  return (
+    <StyledWrapper>
       <div className="wrapper">
         <div className="top">
           <div>4</div>
-          <AppIcon name="question" className="questionIcon"/>
+          <AppIcon name="question" className="questionIcon" />
           <div>4</div>
         </div>
         <div className="copy">
           <strong>찾을 수 없는 페이지입니다.</strong>
-          <p>주소가 바뀌었거나 삭제된 글일 수 있습니다. 홈으로 돌아가 최신 글이나 블로그 소개부터 다시 확인하세요.</p>
+          <p>
+            주소가 바뀌었거나 삭제된 글일 수 있습니다. 홈으로 돌아가 최신
+            글이나 블로그 소개부터 다시 확인하세요.
+          </p>
         </div>
         <div className="actions">
           <Link href="/">홈으로 이동</Link>
           <Link href="/about">블로그 소개</Link>
         </div>
       </div>
-    </StyledWrapper>);
-};
-export default CustomError;
-const StyledWrapper = styled.div `
+    </StyledWrapper>
+  )
+}
+
+export default CustomError
+
+const StyledWrapper = styled.div`
   margin: 0 auto;
   padding-left: 1.5rem;
   padding-right: 1.5rem;
   padding-top: 3rem;
   padding-bottom: 3rem;
-  border-radius: ${({ theme }) => ("1.5rem")};
+  border-radius: 1.5rem;
   max-width: 56rem;
-  background: ${({ theme }) => ("transparent")};
-  border: 1px solid ${({ theme }) => ("transparent")};
-  box-shadow: ${({ theme }) => ("none")};
+  background: transparent;
+  border: 1px solid transparent;
+  box-shadow: none;
+
   .wrapper {
     display: flex;
     padding-top: 5rem;
@@ -51,9 +59,10 @@ const StyledWrapper = styled.div `
       .questionIcon {
         font-size: 3.1rem;
         flex: 0 0 auto;
-        color: ${({ theme }) => ("inherit")};
+        color: inherit;
       }
     }
+
     > .copy {
       display: grid;
       gap: 0.72rem;
@@ -88,8 +97,8 @@ const StyledWrapper = styled.div `
       min-height: 44px;
       padding: 0 1rem;
       border-radius: 999px;
-      border: 1px solid ${({ theme }) => (theme.colors.gray6)};
-      background: ${({ theme }) => (theme.colors.gray1)};
+      border: 1px solid ${({ theme }) => theme.colors.gray6};
+      background: ${({ theme }) => theme.colors.gray1};
       color: ${({ theme }) => theme.colors.gray12};
       text-decoration: none;
       font-size: 0.92rem;
@@ -102,8 +111,8 @@ const StyledWrapper = styled.div `
 
     > .actions a:hover {
       transform: translateY(-1px);
-      border-color: ${({ theme }) => (theme.colors.gray8)};
-      background: ${({ theme }) => (theme.colors.gray2)};
+      border-color: ${({ theme }) => theme.colors.gray8};
+      background: ${({ theme }) => theme.colors.gray2};
     }
   }
-`;
+`


### PR DESCRIPTION
## 관련 이슈

close #954

## 작업 배경

- 404 Error component가 다른 frontend 파일과 달리 semicolon style, 빈 Props type, 한 줄 return JSX, 불필요한 theme interpolation wrapper를 포함하고 있었습니다.
- 기능 변경 없이 출시 전 코드 스타일 일관성과 유지보수성을 맞추기 위한 정리입니다.

## 작업 내용

- `CustomError`의 빈 `Props` type과 `React.FC<Props>` 선언을 제거했습니다.
- JSX return을 기존 frontend formatting에 맞춰 여러 줄 구조로 정리했습니다.
- literal CSS 값에 쓰이던 불필요한 theme interpolation wrapper를 제거했습니다.
- theme token을 사용하는 CSS interpolation은 유지하되 불필요한 괄호만 정리했습니다.

## 검증

- 실행한 명령과 결과:
- `yarn --cwd front lint` 통과, ESLint warnings/errors 0건
- `yarn --cwd front build` 통과, `/404` static route 빌드 확인
- `curl -I http://127.0.0.1:3100/404` 확인, `HTTP/1.1 404 Not Found`
- `yarn --cwd front playwright screenshot --browser chromium --viewport-size=1280,720 --wait-for-timeout=500 http://127.0.0.1:3100/404 /private/tmp/pr-954-local-404.png` 통과
- 참고: `front/package.json`에는 `test` script가 없어 issue의 `yarn --cwd front test` 항목은 실행할 수 없었습니다.
- PR CI 통과: `frontend-ci`, `backend-ci`, `backend-dependency-check`, `CodeQL`
- CodeRabbit 확인: rate limit/credit 부족으로 실제 리뷰 미실행
- Codex CLI fallback review 게시: https://github.com/AquilaXk/aquila-blog/pull/963#pullrequestreview-4536997117, actionable 0
- post-merge CI 통과: https://github.com/AquilaXk/aquila-blog/actions/runs/27868071424
- post-merge Security 통과: https://github.com/AquilaXk/aquila-blog/actions/runs/27868071373
- post-merge CD 통과: https://github.com/AquilaXk/aquila-blog/actions/runs/27868226447
- live `/404` 확인: `curl -I https://www.aquilaxk.site/404`가 `HTTP/2 404` 반환
- live screenshot: `/private/tmp/pr-963-live-404.png`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
- `front/src/routes/Error/index.tsx`만 변경했습니다.
- 문구, 링크, 시각 구조는 유지하고 코드 스타일만 정리했습니다.

## 리스크

- 기능 변경은 없습니다.
- 404 화면의 CSS literal 표현을 interpolation 없이 동일 값으로 옮긴 변경이라 렌더링 차이는 없어야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
