### PR TITLE
[Docs] 코드 주석 정책 문서화

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -43,3 +43,4 @@
 - [ ] 필요한 테스트와 검증 결과를 본문에 남겼는가?
 - [ ] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
 - [ ] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
+- [ ] 새 코드 주석이 있다면 [코드 주석 정책](https://github.com/AquilaXk/aquila-blog/blob/main/docs/design/code-comment-policy.md)에 맞는 이유/불변조건/운영 영향을 설명하는가?

--- a/docs/design/code-comment-policy.md
+++ b/docs/design/code-comment-policy.md
@@ -1,0 +1,66 @@
+# Code Comment Policy
+
+## 목적
+
+코드 주석은 코드가 이미 말하는 동작을 다시 설명하지 않는다. 이 저장소의 주석은 코드만으로는 바로 드러나지 않는 결정 이유, 불변조건, 운영 영향, 호환성 제약을 남기는 용도로만 사용한다.
+
+## 남겨야 하는 주석
+
+- 정책 선택 이유: 같은 결과를 낼 수 있는 구현이 여러 개일 때 왜 현재 방식을 선택했는지 설명한다.
+- 불변조건: 깨지면 데이터 정합성, 권한, 캐시, 배포 안전성이 흔들리는 조건을 명시한다.
+- 실패 시 운영 영향: 재시도, fallback, rollback, alert, SLO에 영향을 주는 실패 모드를 설명한다.
+- 호환성 임시 경로: legacy API, 구버전 데이터, 배포 순서 때문에 남긴 우회 경로와 제거 조건을 적는다.
+- 보안 경계: 인증, 권한, CSP, secret, 외부 입력 검증처럼 실수하면 공격면이 되는 경계를 설명한다.
+
+## 금지하는 주석
+
+- 메서드명이나 코드 한 줄을 자연어로 반복하는 주석
+- `처리합니다`, `조회합니다`, `설정합니다`처럼 정보가 늘지 않는 템플릿형 KDoc/JSDoc
+- 실제 코드와 쉽게 드리프트나는 구현 절차 복붙
+- TODO만 남기고 issue, 제거 조건, 검증 방법이 없는 임시 주석
+- 리뷰 지적을 피하기 위해 의도를 포장하지만 불변조건이나 운영 영향이 없는 주석
+
+## 좋은 예시
+
+```kotlin
+// Blue/green cutover 직후에는 old backend가 같은 digest를 계속 serving할 수 있다.
+// digest가 다르면 rollback 후보를 보존하고 burn-in이 끝날 때까지 green scrape를 유지한다.
+```
+
+```ts
+// Anonymous empty state must not link to /admin.
+// Admin auth resolves asynchronously, so the public CTA is the safe initial state.
+```
+
+```ts
+// Keep this legacy slug route until all indexed /page/* URLs return sitemap-free 404s.
+// Removal requires a Search Console crawl check after deployment.
+```
+
+## 나쁜 예시
+
+```kotlin
+/** 게시글을 조회합니다. */
+fun getPost(id: Long): Post
+```
+
+```ts
+// 버튼을 클릭하면 필터를 초기화한다.
+clearButton.onClick = resetFilter
+```
+
+```ts
+// TODO: 나중에 제거
+const fallbackUrl = "/admin"
+```
+
+## 리뷰 체크
+
+코드리뷰에서 새 주석을 보면 다음 질문을 확인한다.
+
+1. 이 주석이 없으면 정책 선택 이유나 운영 위험을 놓치는가?
+2. 코드 변경 없이 주석만 틀릴 가능성이 큰 구현 설명인가?
+3. 임시 경로라면 제거 조건과 검증 방법이 있는가?
+4. 보안/권한/배포/캐시 경계를 설명한다면 실패 시 영향이 구체적인가?
+
+질문 1이 아니고 질문 2에 해당하면 주석을 삭제한다. 질문 3 또는 4의 정보가 부족하면 주석을 보강하거나 issue로 추적한다.


### PR DESCRIPTION
## 관련 이슈

close #955

## 작업 배경

- 템플릿형 KDoc와 동작 반복 설명 주석이 재발하지 않도록 backend/frontend 공통 주석 정책을 문서화했습니다.
- 코드리뷰에서 주석의 필요성을 같은 기준으로 확인할 수 있도록 PR checklist에 정책 링크를 추가했습니다.

## 작업 내용

- `docs/design/code-comment-policy.md`를 추가해 남겨야 하는 주석과 금지하는 주석을 정의했습니다.
- 프로젝트 문맥의 좋은/나쁜 예시를 Kotlin/TypeScript 예시로 남겼습니다.
- `.github/pull_request_template.md` checklist에 새 코드 주석이 정책에 맞는지 확인하는 항목을 추가했습니다.

## 검증

- 실행한 명령과 결과:
- `test -f docs/design/code-comment-policy.md` 통과
- `rg -n "코드 주석 정책|code-comment-policy|주석 정책|템플릿형 KDoc|불변조건|운영 영향" docs/design/code-comment-policy.md .github/pull_request_template.md` 통과
- `git diff --check` 통과
- 문서 내용과 PR template diff를 직접 확인했습니다.
- PR #964 checks 통과: Backend CI, Frontend CI, Security, CodeRabbit, Vercel preview
- merge 후 main CI 통과: https://github.com/AquilaXk/aquila-blog/actions/runs/27868566567
- merge 후 main Security 통과: https://github.com/AquilaXk/aquila-blog/actions/runs/27868566546
- merge 후 Deploy to Home Server 통과: https://github.com/AquilaXk/aquila-blog/actions/runs/27868707553

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
- `docs/design/code-comment-policy.md`의 허용/금지 기준과 예시
- `.github/pull_request_template.md`의 checklist 링크

## 리스크

- 문서와 PR template만 변경했습니다.
- CI/CD 동작에는 직접 영향이 없습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (CodeRabbit 실제 리뷰 완료로 fallback 불필요)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (Deploy to Home Server 성공)
