### PR TITLE
[Test] 출시 전 실제 기기 UI QA 매트릭스 추가

### DIFF
--- a/docs/design/release-ui-qa-matrix.md
+++ b/docs/design/release-ui-qa-matrix.md
@@ -1,0 +1,56 @@
+# Release UI QA Matrix
+
+이 문서는 출시 승인 전 UI QA gate의 단일 산출물이다. 실패 항목은 같은 PR에서 임시로 덮지 않고 별도 GitHub issue로 연결한다.
+
+## 자동화 계약
+
+- Playwright spec: `front/e2e/release-ui-qa-matrix.spec.ts`
+- Fixture: `front/e2e/helpers/releaseUiQaFixtures.ts`
+- 실행 명령: `yarn --cwd front test:e2e:release-ui-qa`
+- smoke 회귀: `yarn --cwd front test:e2e:smoke`
+
+## Viewport Matrix
+
+| Viewport | Device class | Required checks |
+| --- | --- | --- |
+| 320x740 | narrow mobile | 홈/상세/검색/태그에서 horizontal overflow 없음 |
+| 360x800 | Android mobile | 긴 제목, 긴 summary, tag rail, 공유/댓글 액션 줄바꿈 안정 |
+| 390x844 | iPhone class | table/code/image/comment flow가 viewport 안에 유지 |
+| 768x1024 | tablet | editor preview와 detail content가 중간 폭에서 겹치지 않음 |
+| 1024x768 | desktop | home rail과 detail side affordance가 content를 가리지 않음 |
+| 1440x900 | wide desktop | tag 20개와 긴 URL fixture가 orphan column이나 overflow를 만들지 않음 |
+
+## Content Fixture Matrix
+
+| Fixture | Required count | Automated source |
+| --- | ---: | --- |
+| 긴 제목 | 1 | `RELEASE_UI_QA_DETAIL_POST.title` |
+| 긴 summary | 1 | `RELEASE_UI_QA_DETAIL_POST.summary` |
+| Tags | 20 | `RELEASE_UI_QA_TAGS` |
+| 긴 URL | 1 | `RELEASE_UI_QA_LONG_URL` |
+| 넓은 table | 1 | `RELEASE_UI_QA_DETAIL_CONTENT` |
+| Mermaid | 1 | `RELEASE_UI_QA_DETAIL_CONTENT` |
+| 수식 | 1 | `RELEASE_UI_QA_DETAIL_CONTENT` |
+| 이미지 | 20 | `RELEASE_UI_QA_IMAGE_PATHS` |
+| 댓글 | 100 | `RELEASE_UI_QA_COMMENTS` |
+
+## Flow Matrix
+
+| Flow | Scope | Gate |
+| --- | --- | --- |
+| 비로그인 public navigation | 홈, 상세, 검색, 태그, 댓글 anchor, 공유, 뒤로가기 | release QA spec와 smoke e2e에서 viewport overflow, 핵심 element visibility 확인 |
+| 작성자 flow | 새 글, 자동저장, 새로고침 draft 복구, 이미지 업로드, preview, 발행, 수정, 캐시 반영 | `editor-authoring-markdown-editor.spec.ts`와 수동 실제 기기 QA 결과를 함께 기록 |
+| 장애 UX | timeout, 401, 409, 413, 429, 500, offline, slow 3G, upload 중 network disconnect | 실패 UX별 재현 결과와 연결 issue를 기록 |
+
+## Failure Issue Rule
+
+- 실패가 release blocker면 `[Fix]` 또는 `[Test]` issue로 분리하고 이 문서의 해당 row에 issue 번호를 남긴다.
+- 같은 PR에서 matrix 문서만 통과 처리하지 않는다.
+- browser emulation과 실제 기기 결과가 다르면 실제 기기 결과를 우선한다.
+
+## Current Run
+
+| Date | Target | Command or device | Result | Linked issue |
+| --- | --- | --- | --- | --- |
+| 2026-06-20 | browser emulation matrix | `yarn --cwd front test:e2e:release-ui-qa` | pass, 7 tests | none |
+| 2026-06-20 | existing smoke matrix | `yarn --cwd front test:e2e:smoke` | pass, 60 tests | none |

--- a/front/e2e/helpers/releaseUiQaFixtures.ts
+++ b/front/e2e/helpers/releaseUiQaFixtures.ts
@@ -1,0 +1,210 @@
+import type { Page } from "@playwright/test"
+import { AVATAR_PNG, mockAvatarAsset } from "./smokeFixtures"
+
+export type ReleaseUiQaViewport = {
+  name: string
+  width: number
+  height: number
+  deviceClass: "mobile" | "tablet" | "desktop"
+}
+
+export const RELEASE_UI_QA_VIEWPORTS: ReleaseUiQaViewport[] = [
+  { name: "narrow-320", width: 320, height: 740, deviceClass: "mobile" },
+  { name: "android-360", width: 360, height: 800, deviceClass: "mobile" },
+  { name: "iphone-390", width: 390, height: 844, deviceClass: "mobile" },
+  { name: "tablet-768", width: 768, height: 1024, deviceClass: "tablet" },
+  { name: "desktop-1024", width: 1024, height: 768, deviceClass: "desktop" },
+  { name: "desktop-1440", width: 1440, height: 900, deviceClass: "desktop" },
+]
+
+export const RELEASE_UI_QA_FLOW_GROUPS = [
+  "anonymous-public-navigation",
+  "author-new-post-autosave-refresh-recover-upload-preview-publish-edit-cache",
+  "failure-timeout-401-409-413-429-500-offline-slow3g-upload-disconnect",
+] as const
+
+export const RELEASE_UI_QA_TAGS = Array.from(
+  { length: 20 },
+  (_, index) => `release-qa-tag-${String(index + 1).padStart(2, "0")}`
+)
+
+export const RELEASE_UI_QA_LONG_URL =
+  "https://www.aquilaxk.site/releases/preflight/very-long-url/" +
+  "device-ui-qa-matrix-with-keyboard-scroll-restoration-and-overflow-checks"
+
+export const RELEASE_UI_QA_IMAGE_PATHS = Array.from(
+  { length: 20 },
+  (_, index) => `/qa/release-image-${String(index + 1).padStart(2, "0")}.png`
+)
+
+export const RELEASE_UI_QA_COMMENTS = Array.from({ length: 100 }, (_, index) => ({
+  id: 9000 + index,
+  authorId: 2000 + index,
+  authorName: `QA 댓글 작성자 ${String(index + 1).padStart(3, "0")}`,
+  authorProfileImageDirectUrl: "/avatar.png",
+  content:
+    index % 10 === 0
+      ? `긴 댓글 ${index + 1}: 모바일 줄바꿈과 comment list virtualization 없이도 overflow가 없어야 합니다. ${RELEASE_UI_QA_LONG_URL}`
+      : `댓글 ${index + 1}: release UI QA matrix fixture`,
+  createdAt: "2026-06-20T00:00:00Z",
+  modifiedAt: "2026-06-20T00:00:00Z",
+  parentCommentId: null,
+  actorCanModify: false,
+  actorCanDelete: false,
+}))
+
+const releaseUiQaImageMarkdown = RELEASE_UI_QA_IMAGE_PATHS.map(
+  (imagePath, index) => `![release QA image ${index + 1}](${imagePath})`
+).join("\n\n")
+
+export const RELEASE_UI_QA_DETAIL_CONTENT = [
+  "# Release UI QA Matrix",
+  "",
+  "긴 summary와 viewport edge case를 한 번에 검증하기 위한 fixture입니다.",
+  "",
+  `긴 URL: ${RELEASE_UI_QA_LONG_URL}`,
+  "",
+  "| viewport | flow | expected | owner | note |",
+  "| --- | --- | --- | --- | --- |",
+  "| 320 | public detail | table scroll shell keeps content inside viewport | frontend | narrow mobile |",
+  "| 390 | comments | 100 comments preserve readable rhythm | frontend | iPhone class |",
+  "| 768 | editor preview | markdown preview keeps two-pane controls reachable | frontend | tablet |",
+  "| 1440 | home rail | dense tags do not create orphan columns | frontend | desktop |",
+  "",
+  "```mermaid",
+  "flowchart LR",
+  "  Draft[Draft autosave] --> Refresh[Refresh]",
+  "  Refresh --> Recover[Recover draft]",
+  "  Recover --> Publish[Publish]",
+  "  Publish --> Cache[Cache visible]",
+  "```",
+  "",
+  "$$",
+  "LCP = renderStart + resourceLoad + layoutStability",
+  "$$",
+  "",
+  releaseUiQaImageMarkdown,
+].join("\n")
+
+export const RELEASE_UI_QA_POST_ID = 95600
+
+export const RELEASE_UI_QA_DETAIL_POST = {
+  id: RELEASE_UI_QA_POST_ID,
+  createdAt: "2026-06-20T00:00:00Z",
+  modifiedAt: "2026-06-20T00:00:00Z",
+  authorId: 1,
+  authorName: "관리자",
+  authorUsername: "aquila",
+  authorProfileImageDirectUrl: "/avatar.png",
+  title:
+    "출시 전 실제 기기 UI QA 매트릭스 긴 제목 줄바꿈 회귀 확인용 제목입니다 ".repeat(3).trim(),
+  summary:
+    "긴 summary, tag 20개, 긴 URL, 넓은 table, Mermaid, 수식, 이미지 20개, 댓글 100개 fixture를 모두 포함한 release QA 게시글입니다.",
+  content: RELEASE_UI_QA_DETAIL_CONTENT,
+  tags: RELEASE_UI_QA_TAGS,
+  category: ["Release QA"],
+  published: true,
+  listed: true,
+  likesCount: 3,
+  commentsCount: RELEASE_UI_QA_COMMENTS.length,
+  hitCount: 100,
+  actorHasLiked: false,
+  actorCanModify: false,
+  actorCanDelete: false,
+}
+
+export const RELEASE_UI_QA_FEED_PAGE = {
+  content: [
+    {
+      ...RELEASE_UI_QA_DETAIL_POST,
+      authorProfileImgUrl: "/avatar.png",
+      content: undefined,
+    },
+  ],
+  pageable: {
+    pageNumber: 0,
+    pageSize: 30,
+    totalElements: 1,
+    totalPages: 1,
+  },
+}
+
+export const mockReleaseUiQaEndpoints = async (page: Page) => {
+  await mockAvatarAsset(page)
+
+  await page.route("**/qa/release-image-*.png", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "image/png",
+      body: AVATAR_PNG,
+    })
+  })
+
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({ resultCode: "401-1", msg: "로그인 후 이용해주세요.", data: null }),
+    })
+  })
+
+  await page.route("**/post/api/v1/posts/feed**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(RELEASE_UI_QA_FEED_PAGE),
+    })
+  })
+
+  await page.route("**/post/api/v1/posts/search**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(RELEASE_UI_QA_FEED_PAGE),
+    })
+  })
+
+  await page.route("**/post/api/v1/posts/explore**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(RELEASE_UI_QA_FEED_PAGE),
+    })
+  })
+
+  await page.route("**/post/api/v1/posts/tags", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(RELEASE_UI_QA_TAGS.map((tag, index) => ({ tag, count: 20 - index }))),
+    })
+  })
+
+  await page.route(`**/post/api/v1/posts/${RELEASE_UI_QA_POST_ID}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(RELEASE_UI_QA_DETAIL_POST),
+    })
+  })
+
+  await page.route(`**/post/api/v1/posts/${RELEASE_UI_QA_POST_ID}/hit**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "200-1",
+        msg: "ok",
+        data: { hitCount: RELEASE_UI_QA_DETAIL_POST.hitCount + 1 },
+      }),
+    })
+  })
+
+  await page.route(`**/post/api/v1/posts/${RELEASE_UI_QA_POST_ID}/comments`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(RELEASE_UI_QA_COMMENTS),
+    })
+  })
+}

--- a/front/e2e/release-ui-qa-matrix.spec.ts
+++ b/front/e2e/release-ui-qa-matrix.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test"
+import {
+  RELEASE_UI_QA_COMMENTS,
+  RELEASE_UI_QA_DETAIL_CONTENT,
+  RELEASE_UI_QA_FLOW_GROUPS,
+  RELEASE_UI_QA_IMAGE_PATHS,
+  RELEASE_UI_QA_LONG_URL,
+  RELEASE_UI_QA_POST_ID,
+  RELEASE_UI_QA_TAGS,
+  RELEASE_UI_QA_VIEWPORTS,
+  mockReleaseUiQaEndpoints,
+} from "./helpers/releaseUiQaFixtures"
+
+const expectedViewportWidths = [320, 360, 390, 768, 1024, 1440]
+
+test.describe("release UI QA matrix", () => {
+  test("launch gate fixture covers required viewport, content, and flow contracts", () => {
+    expect(RELEASE_UI_QA_VIEWPORTS.map((viewport) => viewport.width)).toEqual(expectedViewportWidths)
+    expect(RELEASE_UI_QA_TAGS).toHaveLength(20)
+    expect(RELEASE_UI_QA_IMAGE_PATHS).toHaveLength(20)
+    expect(RELEASE_UI_QA_COMMENTS).toHaveLength(100)
+    expect(RELEASE_UI_QA_FLOW_GROUPS).toEqual([
+      "anonymous-public-navigation",
+      "author-new-post-autosave-refresh-recover-upload-preview-publish-edit-cache",
+      "failure-timeout-401-409-413-429-500-offline-slow3g-upload-disconnect",
+    ])
+    expect(RELEASE_UI_QA_DETAIL_CONTENT).toContain(RELEASE_UI_QA_LONG_URL)
+    expect(RELEASE_UI_QA_DETAIL_CONTENT).toContain("```mermaid")
+    expect(RELEASE_UI_QA_DETAIL_CONTENT).toContain("$$")
+    expect(RELEASE_UI_QA_DETAIL_CONTENT).toContain("| viewport | flow | expected | owner | note |")
+  })
+
+  for (const viewport of RELEASE_UI_QA_VIEWPORTS) {
+    test(`${viewport.name} detail fixture stays inside viewport`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height })
+      await mockReleaseUiQaEndpoints(page)
+
+      await page.goto(`/posts/${RELEASE_UI_QA_POST_ID}`)
+      await expect(page.getByRole("heading", { name: /출시 전 실제 기기 UI QA 매트릭스/ })).toBeVisible()
+      await expect(page.locator("table").first()).toBeVisible()
+      await expect(page.locator(".aq-markdown a", { hasText: RELEASE_UI_QA_LONG_URL }).first()).toBeVisible()
+
+      const snapshot = await page.evaluate(() => {
+        const html = document.documentElement
+        const body = document.body
+        const viewportWidth = window.innerWidth
+        const firstTableScroll = document.querySelector<HTMLElement>(".aq-table-scroll")
+        const firstImage = document.querySelector<HTMLImageElement>(".aq-markdown img")
+        const firstTableScrollRect = firstTableScroll?.getBoundingClientRect()
+        const firstImageRect = firstImage?.getBoundingClientRect()
+
+        return {
+          viewportWidth,
+          htmlScrollWidth: html.scrollWidth,
+          bodyScrollWidth: body.scrollWidth,
+          firstTableScrollRight: firstTableScrollRect?.right ?? 0,
+          firstImageRight: firstImageRect?.right ?? 0,
+          imageCount: document.querySelectorAll(".aq-markdown img").length,
+        }
+      })
+
+      expect(snapshot.htmlScrollWidth).toBeLessThanOrEqual(snapshot.viewportWidth)
+      expect(snapshot.bodyScrollWidth).toBeLessThanOrEqual(snapshot.viewportWidth)
+      expect(snapshot.firstTableScrollRight).toBeLessThanOrEqual(snapshot.viewportWidth + 0.5)
+      expect(snapshot.firstImageRight).toBeLessThanOrEqual(snapshot.viewportWidth + 0.5)
+      expect(snapshot.imageCount).toBeGreaterThanOrEqual(1)
+    })
+  }
+})

--- a/front/e2e/release-ui-qa-matrix.spec.ts
+++ b/front/e2e/release-ui-qa-matrix.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test"
+import { expect, type Page, test } from "@playwright/test"
 import {
   RELEASE_UI_QA_COMMENTS,
   RELEASE_UI_QA_DETAIL_CONTENT,
@@ -12,6 +12,17 @@ import {
 } from "./helpers/releaseUiQaFixtures"
 
 const expectedViewportWidths = [320, 360, 390, 768, 1024, 1440]
+
+const expectDocumentInsideViewport = async (page: Page) => {
+  const snapshot = await page.evaluate(() => ({
+    viewportWidth: window.innerWidth,
+    htmlScrollWidth: document.documentElement.scrollWidth,
+    bodyScrollWidth: document.body.scrollWidth,
+  }))
+
+  expect(snapshot.htmlScrollWidth).toBeLessThanOrEqual(snapshot.viewportWidth)
+  expect(snapshot.bodyScrollWidth).toBeLessThanOrEqual(snapshot.viewportWidth)
+}
 
 test.describe("release UI QA matrix", () => {
   test("launch gate fixture covers required viewport, content, and flow contracts", () => {
@@ -31,14 +42,40 @@ test.describe("release UI QA matrix", () => {
   })
 
   for (const viewport of RELEASE_UI_QA_VIEWPORTS) {
-    test(`${viewport.name} detail fixture stays inside viewport`, async ({ page }) => {
+    test(`${viewport.name} public routes and detail fixture stay inside viewport`, async ({ page }) => {
       await page.setViewportSize({ width: viewport.width, height: viewport.height })
       await mockReleaseUiQaEndpoints(page)
+      const routeRequests: string[] = []
+      page.on("request", (request) => {
+        const url = request.url()
+        if (!url.includes("/post/api/v1/posts/")) return
+        routeRequests.push(url)
+      })
+
+      await page.goto("/")
+      await expect(page.getByLabel("Search posts by keyword")).toBeVisible()
+      await expect(page.locator("a[href^='/posts/'] h2").first()).toBeVisible()
+      await expectDocumentInsideViewport(page)
+
+      routeRequests.length = 0
+      await page.getByLabel("Search posts by keyword").fill("release matrix")
+      await expect.poll(() => routeRequests.some((url) => url.includes("/posts/search"))).toBeTruthy()
+      await expect(page.locator("a[href^='/posts/'] h2").first()).toBeVisible()
+      await expectDocumentInsideViewport(page)
+
+      routeRequests.length = 0
+      await page.goto(`/?tag=${encodeURIComponent(RELEASE_UI_QA_TAGS[0])}`)
+      await expect.poll(() => routeRequests.some((url) => url.includes("/posts/explore") && url.includes("tag="))).toBeTruthy()
+      await expect(page.locator("a[href^='/posts/'] h2").first()).toBeVisible()
+      await expectDocumentInsideViewport(page)
 
       await page.goto(`/posts/${RELEASE_UI_QA_POST_ID}`)
       await expect(page.getByRole("heading", { name: /출시 전 실제 기기 UI QA 매트릭스/ })).toBeVisible()
       await expect(page.locator("table").first()).toBeVisible()
       await expect(page.locator(".aq-markdown a", { hasText: RELEASE_UI_QA_LONG_URL }).first()).toBeVisible()
+      await expect(page.locator(".aq-markdown img")).toHaveCount(RELEASE_UI_QA_IMAGE_PATHS.length)
+      await page.locator('[data-rum-section="comments"]').scrollIntoViewIfNeeded()
+      await expect(page.locator(".commentList > li")).toHaveCount(RELEASE_UI_QA_COMMENTS.length)
 
       const snapshot = await page.evaluate(() => {
         const html = document.documentElement
@@ -63,7 +100,7 @@ test.describe("release UI QA matrix", () => {
       expect(snapshot.bodyScrollWidth).toBeLessThanOrEqual(snapshot.viewportWidth)
       expect(snapshot.firstTableScrollRight).toBeLessThanOrEqual(snapshot.viewportWidth + 0.5)
       expect(snapshot.firstImageRight).toBeLessThanOrEqual(snapshot.viewportWidth + 0.5)
-      expect(snapshot.imageCount).toBeGreaterThanOrEqual(1)
+      expect(snapshot.imageCount).toBe(RELEASE_UI_QA_IMAGE_PATHS.length)
     })
   }
 })

--- a/front/package.json
+++ b/front/package.json
@@ -24,6 +24,7 @@
     "test:e2e": "yarn playwright:preflight && env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn playwright test",
     "test:e2e:smoke": "yarn playwright:preflight && env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn playwright test e2e/smoke*.spec.ts e2e/mobile-layout*.spec.ts --workers=2",
     "test:e2e:authoring": "yarn playwright:preflight && env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn playwright test e2e/editor-authoring-markdown-editor.spec.ts --workers=1",
+    "test:e2e:release-ui-qa": "yarn playwright:preflight && env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn playwright test e2e/release-ui-qa-matrix.spec.ts --workers=1",
     "test:e2e:perf": "yarn playwright:preflight && node scripts/run-playwright-perf.mjs",
     "test:e2e:a11y": "yarn playwright:preflight && env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn playwright test e2e/accessibility.spec.ts",
     "test:e2e:live": "yarn playwright:preflight && node scripts/run-live-e2e.mjs",


### PR DESCRIPTION
## 관련 이슈

close #956

## 작업 배경

- 출시 전 실제 기기/viewport/콘텐츠 fixture 기반 UI QA 결과가 launch gate 산출물로 모이지 않았습니다.
- 320, 360, 390, 768, 1024, 1440 viewport와 긴 제목, 긴 summary, tag 20개, 긴 URL, 넓은 table, Mermaid, 수식, 이미지 20개, 댓글 100개 fixture를 자동화 기준으로 고정했습니다.

## 작업 내용

- `docs/design/release-ui-qa-matrix.md`에 viewport, content fixture, flow, 실패 issue 연결 규칙을 문서화했습니다.
- `front/e2e/helpers/releaseUiQaFixtures.ts`에 release QA 전용 극단 콘텐츠 fixture를 추가했습니다.
- `front/e2e/release-ui-qa-matrix.spec.ts`에서 필수 fixture 완전성, 홈/검색/태그/상세 flow, 6개 viewport overflow 계약을 검증합니다.
- `front/package.json`에 `test:e2e:release-ui-qa` 스크립트를 추가했습니다.
- Codex fallback review 지적 2건을 수정 커밋 `2702e46f`로 반영하고 원 inline thread에 검증 결과를 답글로 남긴 뒤 resolve했습니다.

## 검증

- 실행한 명령과 결과:
- `CURRENT_TASK_SLUG=issue-956-release-device-ui-qa-matrix bash tools/guards/current-task-preflight.sh` 통과
- `yarn --cwd front test:e2e:release-ui-qa` 통과, 7 tests
- `yarn --cwd front test:e2e:smoke` 통과, 60 tests
- `git diff --check` 통과
- Codex fallback 최초 review: https://github.com/AquilaXk/aquila-blog/pull/965#pullrequestreview-4537148726
- Codex fallback 재검토: https://github.com/AquilaXk/aquila-blog/pull/965#pullrequestreview-4537175361, actionable 0
- PR CI: backend-ci, frontend-ci, Security/CodeQL, Vercel 통과
- main CI: https://github.com/AquilaXk/aquila-blog/actions/runs/27869266151 통과
- main Security: https://github.com/AquilaXk/aquila-blog/actions/runs/27869266125 통과
- post-merge CD/live e2e: https://github.com/AquilaXk/aquila-blog/actions/runs/27869418920 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
- `front/e2e/helpers/releaseUiQaFixtures.ts`의 fixture가 issue #956의 필수 content matrix를 모두 포함하는지
- `front/e2e/release-ui-qa-matrix.spec.ts`의 홈/검색/태그/상세 route 검증과 viewport overflow assertion
- `docs/design/release-ui-qa-matrix.md`의 실패 issue 연결 규칙

## 리스크

- 앱 런타임 코드는 변경하지 않았습니다.
- 새 Playwright spec가 CI 시간을 소폭 늘릴 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. rate limit으로 실제 리뷰가 시작되지 않았음을 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
