### PR TITLE
[Feat] 홈 topic rail을 실제 태그 기반으로 전환

### DIFF
--- a/front/e2e/smoke-feed-search.spec.ts
+++ b/front/e2e/smoke-feed-search.spec.ts
@@ -88,6 +88,44 @@ test.describe("core smoke feed and search", () => {
   await expect(page.locator("a[href^='/posts/'] h2").filter({ hasText: "태그:검색" })).toBeVisible()
 })
 
+  test("홈 topic rail은 모바일 viewport에서도 tag 탐색으로 연결한다", async ({ page }) => {
+  const capturedTag: string[] = []
+
+  await page.setViewportSize({ width: 390, height: 844 })
+  await mockFeedEndpoints(page)
+  await page.route("**/post/api/v1/posts/tags", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        { tag: "운영", count: 9 },
+        { tag: "검색", count: 7 },
+        { tag: "alpha", count: 5 },
+      ]),
+    })
+  })
+  await page.route("**/post/api/v1/posts/explore**", async (route) => {
+    const url = new URL(route.request().url())
+    const tag = url.searchParams.get("tag") || ""
+    capturedTag.push(tag)
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(createExplorePage(tag ? `태그:${tag}` : "기본목록", tag || "운영")),
+    })
+  })
+
+  await page.goto("/")
+  const topicRail = page.locator('[data-ui="feed-topic-rail"]')
+  await expect(topicRail).toBeVisible()
+
+  await topicRail.getByRole("button", { name: "태그 검색 글 7개 보기" }).click()
+
+  await expect.poll(() => capturedTag.some((value) => value === "검색")).toBeTruthy()
+  await expect(page.locator("a[href^='/posts/'] h2").filter({ hasText: "태그:검색" })).toBeVisible()
+})
+
   test("홈 topic rail은 태그가 없으면 렌더하지 않는다", async ({ page }) => {
   await page.setViewportSize({ width: 1680, height: 1200 })
   await mockFeedEndpoints(page)

--- a/front/e2e/smoke-feed-search.spec.ts
+++ b/front/e2e/smoke-feed-search.spec.ts
@@ -46,6 +46,64 @@ test.describe("core smoke feed and search", () => {
   expect(homeStyles.firstCard?.borderWidth).toBe("1px")
 })
 
+  test("홈 topic rail은 실제 태그 count 상위 항목을 표시하고 tag 탐색으로 연결한다", async ({ page }) => {
+  const capturedTag: string[] = []
+
+  await page.setViewportSize({ width: 1680, height: 1200 })
+  await mockFeedEndpoints(page)
+  await page.route("**/post/api/v1/posts/tags", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        { tag: "alpha", count: 5 },
+        { tag: "운영", count: 9 },
+        { tag: "검색", count: 7 },
+        { tag: "Spring", count: 1 },
+      ]),
+    })
+  })
+  await page.route("**/post/api/v1/posts/explore**", async (route) => {
+    const url = new URL(route.request().url())
+    const tag = url.searchParams.get("tag") || ""
+    capturedTag.push(tag)
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(createExplorePage(tag ? `태그:${tag}` : "기본목록", tag || "운영")),
+    })
+  })
+
+  await page.goto("/")
+  const topicRail = page.locator('[data-ui="feed-topic-rail"]')
+  await expect(topicRail).toBeVisible()
+  await expect(topicRail.locator('[data-ui="feed-topic-rail-chip"]')).toHaveText(["운영", "검색", "alpha"])
+  await expect(page.getByText("Architecture")).toHaveCount(0)
+  await expect(page.getByText("Infrastructure")).toHaveCount(0)
+
+  await topicRail.getByRole("button", { name: "태그 검색 글 7개 보기" }).click()
+
+  await expect.poll(() => capturedTag.some((value) => value === "검색")).toBeTruthy()
+  await expect(page.locator("a[href^='/posts/'] h2").filter({ hasText: "태그:검색" })).toBeVisible()
+})
+
+  test("홈 topic rail은 태그가 없으면 렌더하지 않는다", async ({ page }) => {
+  await page.setViewportSize({ width: 1680, height: 1200 })
+  await mockFeedEndpoints(page)
+  await page.route("**/post/api/v1/posts/tags", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([]),
+    })
+  })
+
+  await page.goto("/")
+
+  await expect(page.locator('[data-ui="feed-topic-rail"]')).toHaveCount(0)
+})
+
   test("홈 새로고침 이후에도 제품형 브랜드 문구를 유지한다", async ({ page }) => {
   await mockFeedEndpoints(page)
 

--- a/front/src/routes/Feed/index.tsx
+++ b/front/src/routes/Feed/index.tsx
@@ -1,20 +1,54 @@
 import Footer from "./Footer"
 import styled from "@emotion/styled"
+import { startTransition, useCallback, useMemo } from "react"
 import { AdminProfile, useAdminProfile } from "src/hooks/useAdminProfile"
 import { CONFIG } from "site.config"
 import FeedExplorer from "./FeedExplorer"
 import ProfileSummaryCard from "./ProfileSummaryCard"
+import { useTagsQuery } from "src/hooks/useTagsQuery"
+import { useRouter } from "next/router"
+import { replaceShallowRoutePreservingScroll } from "src/libs/router"
 
 type Props = {
   initialAdminProfile?: AdminProfile | null
 }
 
+const TOPIC_RAIL_TAG_LIMIT = 3
+
 const Feed: React.FC<Props> = ({ initialAdminProfile = null }) => {
+  const router = useRouter()
   const adminProfile = useAdminProfile(initialAdminProfile)
+  const { tagEntries } = useTagsQuery()
+  const topicEntries = useMemo(
+    () => tagEntries.slice(0, TOPIC_RAIL_TAG_LIMIT),
+    [tagEntries]
+  )
   const introTitle =
     adminProfile?.blogTitle || CONFIG.blog.title || "AquilaLog"
   const introRole = adminProfile?.profileRole || CONFIG.profile.role || "Backend Engineering"
   const introDescription = adminProfile?.homeIntroDescription || CONFIG.blog.homeIntroDescription || CONFIG.blog.description
+
+  const navigateWithTag = useCallback((value: string) => {
+    const { category: _deprecatedCategory, ...restQuery } = router.query
+    startTransition(() => {
+      void replaceShallowRoutePreservingScroll(router, {
+        pathname: "/",
+        query: {
+          ...restQuery,
+          tag: value,
+        },
+      })
+    })
+  }, [router])
+
+  const handleClickTopic = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const value = event.currentTarget.dataset.tag
+      if (!value) return
+      navigateWithTag(value)
+    },
+    [navigateWithTag]
+  )
 
   return (
     <StyledWrapper data-ui="feed-home-product-shell">
@@ -26,11 +60,22 @@ const Feed: React.FC<Props> = ({ initialAdminProfile = null }) => {
             </span>
             <h1>{introTitle}</h1>
             <p>{introDescription}</p>
-            <div className="topicRail" aria-label="AquilaLog topics">
-              <span>Spring</span>
-              <span>Architecture</span>
-              <span>Infrastructure</span>
-            </div>
+            {topicEntries.length > 0 && (
+              <div className="topicRail" data-ui="feed-topic-rail" aria-label="인기 태그">
+                {topicEntries.map(([tag, count]) => (
+                  <button
+                    key={tag}
+                    type="button"
+                    data-ui="feed-topic-rail-chip"
+                    data-tag={tag}
+                    aria-label={`태그 ${tag} 글 ${count}개 보기`}
+                    onClick={handleClickTopic}
+                  >
+                    {tag}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
           <ProfileSummaryCard initialAdminProfile={initialAdminProfile} />
         </IntroCard>
@@ -142,7 +187,7 @@ const IntroCard = styled.section`
     flex-wrap: wrap;
   }
 
-  .topicRail span {
+  .topicRail button {
     display: inline-flex;
     align-items: center;
     min-height: 30px;
@@ -153,6 +198,16 @@ const IntroCard = styled.section`
     padding: 0 0.72rem;
     font-size: 0.76rem;
     font-weight: 780;
+    cursor: pointer;
+    appearance: none;
+    font-family: inherit;
+  }
+
+  .topicRail button:hover,
+  .topicRail button:focus-visible {
+    border-color: rgba(88, 166, 255, 0.72);
+    color: #f0f6fc;
+    outline: none;
   }
 
   @media (max-width: 1024px) {

--- a/front/src/routes/Feed/index.tsx
+++ b/front/src/routes/Feed/index.tsx
@@ -216,7 +216,7 @@ const IntroCard = styled.section`
   }
 
   @media (max-width: 768px) {
-    padding-bottom: 1rem;
+    padding-bottom: 0.18rem;
 
     [data-ui="feed-profile-summary"] {
       display: none;
@@ -235,7 +235,7 @@ const IntroCard = styled.section`
     }
 
     .topicRail {
-      margin-top: 0.76rem;
+      margin-top: 0.28rem;
       gap: 0.4rem;
     }
 

--- a/front/src/routes/Feed/index.tsx
+++ b/front/src/routes/Feed/index.tsx
@@ -222,10 +222,6 @@ const IntroCard = styled.section`
       display: none;
     }
 
-    .topicRail {
-      display: none;
-    }
-
     h1 {
       max-width: none;
       font-size: clamp(2rem, 11vw, 2.55rem);
@@ -236,6 +232,17 @@ const IntroCard = styled.section`
       margin-top: 0.64rem;
       font-size: 0.95rem;
       line-height: 1.5;
+    }
+
+    .topicRail {
+      margin-top: 0.76rem;
+      gap: 0.4rem;
+    }
+
+    .topicRail button {
+      min-height: 28px;
+      padding: 0 0.62rem;
+      font-size: 0.72rem;
     }
   }
 `


### PR DESCRIPTION
## 관련 이슈

close #952

## 작업 배경

- 홈 intro topic rail이 `Spring`, `Architecture`, `Infrastructure` 고정 label만 표시해 실제 공개 글 tag 분포와 어긋났습니다.
- issue #952의 완료 조건은 실제 tag count 기반 표시, tag 없음 fallback, tag 클릭 navigation, fixture 검증입니다.

## 작업 내용

- `front/src/routes/Feed/index.tsx`에서 `useTagsQuery()`의 count 정렬 결과 상위 3개 tag를 topic rail chip으로 렌더합니다.
- tag가 없으면 intro topic rail 자체를 렌더하지 않도록 했습니다.
- topic chip 클릭 시 기존 shallow route helper를 사용해 `?tag=<tag>` 탐색으로 연결합니다.
- 모바일 viewport에서도 topic rail을 노출하되, `perf-layout` 검색/카드 y 좌표 예산을 넘지 않도록 spacing을 조정했습니다.
- `front/e2e/smoke-feed-search.spec.ts`에 실제 tag 표시, 빈 상태, 데스크톱/모바일 클릭 navigation fixture 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=issue-952-topic-rail-tags bash tools/guards/current-task-preflight.sh` → PASS
  - `yarn --cwd front test:e2e:smoke --grep "topic rail"` → PASS, 3 passed
  - `yarn --cwd front build` → PASS
  - `yarn --cwd front test:e2e:perf` → PASS, 13 passed
  - `yarn --cwd front test:e2e:smoke` → PASS, 63 passed
  - PR CI → PASS: frontend-ci, backend-ci, backend-dependency-check, CodeQL, Vercel
  - CodeRabbit → PASS: initial nitpick fixed, 재검토 결과 actionable comments 없음
  - post-merge CI/Security → PASS: CI `27873480133`, Security `27873480110`
  - Home Server Deploy → PASS: `27873633138`, Frontend Live E2E Verification success
  - live UI 확인 → PASS: `https://www.aquilaxk.site` mobile/desktop topic rail 표시, console error/warn 0건, topic chip 클릭 시 `?tag=개발 철학` 이동 확인
  - 최초 로컬 smoke 실행은 worktree에 `front/node_modules`가 없어 `spawn playwright ENOENT`로 실패했고, 원본 checkout의 ignored `front/node_modules`를 symlink해 동일 명령을 재실행했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - topic rail이 tag count 정렬 결과 상위 3개만 표시하는지 확인해 주세요.
  - tag 클릭이 기존 tag query navigation 계약과 동일하게 동작하는지 확인해 주세요.
  - 모바일에서 topic rail 노출 후에도 `perf-layout` y 좌표 예산을 유지하는지 확인해 주세요.

## 리스크

- tag API가 빈 배열을 반환하면 topic rail이 숨겨지므로, 홈 intro의 보조 탐색 UI가 줄어듭니다. 이는 issue의 fallback 조건과 일치합니다.
- 기존 tag rail과 같은 endpoint를 추가 구독하므로 API 응답 장애 시 기존 `useTagsQuery` fallback 동작을 따릅니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (N/A: CodeRabbit 재검토 완료)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.