### PR TITLE
[Fix] 게시글 상세 브라우저 제목을 글 제목으로 반영

### DIFF
--- a/front/e2e/smoke-detail-layout.spec.ts
+++ b/front/e2e/smoke-detail-layout.spec.ts
@@ -1,10 +1,70 @@
 import { expect, test } from "@playwright/test"
-import { mockAvatarAsset } from "./helpers/smokeFixtures"
+import { addPublicAboutSnapshotCookie, mockAvatarAsset } from "./helpers/smokeFixtures"
 test.beforeEach(async ({ page }) => {
   await mockAvatarAsset(page)
 })
 
 test.describe("core smoke detail layout", () => {
+  test("게시글 상세 browser title은 글 제목을 포함하고 일반 페이지 title은 site suffix를 중복하지 않는다", async ({ page }) => {
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({ resultCode: "401-1", msg: "unauthorized" }),
+    })
+  })
+  await page.route("**/post/api/v1/posts/924", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: 924,
+        createdAt: "2026-06-20T00:00:00Z",
+        modifiedAt: "2026-06-20T00:00:00Z",
+        authorId: 1,
+        authorName: "관리자",
+        authorUsername: "aquila",
+        authorProfileImageDirectUrl: "/avatar.png",
+        title: "브라우저 title 회귀 테스트",
+        content: "게시글 상세 document title이 글 제목을 포함하는지 확인합니다.",
+        type: "Post",
+        tags: ["SEO"],
+        category: [],
+        published: true,
+        listed: true,
+        likesCount: 0,
+        commentsCount: 0,
+        hitCount: 0,
+        actorHasLiked: false,
+        actorCanModify: false,
+        actorCanDelete: false,
+      }),
+    })
+  })
+  await page.route("**/post/api/v1/posts/924/hit", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "200-1",
+        msg: "ok",
+        data: { hitCount: 1 },
+      }),
+    })
+  })
+
+  await page.goto("/posts/924")
+  await expect(page.getByRole("heading", { name: "브라우저 title 회귀 테스트" })).toBeVisible()
+  await expect(page).toHaveTitle("브라우저 title 회귀 테스트 | AquilaLog")
+  await expect(page.locator('meta[property="og:title"]')).toHaveAttribute("content", "브라우저 title 회귀 테스트")
+  await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute("content", "브라우저 title 회귀 테스트")
+
+  await addPublicAboutSnapshotCookie(page)
+  await page.goto("/about")
+  await expect(page.locator('[data-ui="about-eyebrow"]')).toHaveText("Profile")
+  await expect(page).toHaveTitle("About - AquilaLog")
+})
+
   test("상세 table hover 중 wheel 입력도 page scroll chain을 유지한다", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 900 })
 

--- a/front/src/components/MetaConfig/index.tsx
+++ b/front/src/components/MetaConfig/index.tsx
@@ -10,8 +10,22 @@ export type MetaConfigProps = {
   url: string
 }
 
+const SITE_TITLE = CONFIG.blog.title || "AquilaLog"
+
+const resolveBrowserTabTitle = (title: string) => {
+  const pageTitle = title.trim()
+  if (!pageTitle || pageTitle === SITE_TITLE) {
+    return SITE_TITLE
+  }
+  if (pageTitle.endsWith(` | ${SITE_TITLE}`) || pageTitle.endsWith(` - ${SITE_TITLE}`)) {
+    return pageTitle
+  }
+
+  return `${pageTitle} | ${SITE_TITLE}`
+}
+
 const MetaConfig: React.FC<MetaConfigProps> = (props) => {
-  const browserTabTitle = "AquilaLog"
+  const browserTabTitle = resolveBrowserTabTitle(props.title)
 
   return (
     <Head>


### PR DESCRIPTION
## 관련 이슈

close #924

## 작업 배경

- 게시글 상세 페이지가 `MetaConfig`에 글 제목을 전달하지만 브라우저 `<title>`은 `AquilaLog` 고정값으로 렌더되어 검색 결과와 브라우저 탭에서 글 식별성이 떨어졌다.
- Open Graph/Twitter title은 이미 `props.title`을 사용하므로 document title도 같은 title 계약을 따르도록 정렬한다.

## 작업 내용

- `MetaConfig`의 browser title을 `props.title` 기반으로 생성하도록 변경했다.
- 빈 title 또는 site title 자체는 `AquilaLog`로 유지하고, `About - AquilaLog`처럼 이미 site title suffix를 포함한 일반 페이지는 suffix를 중복하지 않도록 했다.
- 공개 상세 smoke에 게시글 상세 title, OG/Twitter title, 일반 `/about` title 중복 방지 검증을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:smoke --grep "browser title"` → 최초 RED: expected `브라우저 title 회귀 테스트 | AquilaLog`, received `AquilaLog`
  - `yarn --cwd front test:e2e:smoke --grep "browser title"` → PASS, 1 passed
  - `yarn --cwd front build` → PASS
  - `yarn --cwd front test:e2e:smoke` → PASS, 64 passed
  - `yarn --cwd front test:e2e:smoke` → PASS, 64 passed
  - PR #969 CI/checks → PASS: `frontend-ci`, `backend-ci`, `backend-dependency-check`, `CodeQL`, `Vercel`
  - CodeRabbit → rate limit 후 `@coderabbitai review` 재요청, `No actionable comments were generated in the recent review.`
  - GitHub reviewThreads → 없음
  - main merge 후 `CI` run `27874964814` → PASS
  - main merge 후 `Security` run `27874964749` → PASS
  - `Deploy to Home Server` run `27875134991` → PASS, `Frontend Live E2E Verification` PASS
  - 실제 배포본 `https://www.aquilaxk.site/posts/507` → `<title>Stateless란 무엇인가? | AquilaLog</title>`, build SHA `dfbddeab954f98b8f6b250b55804e58adf8222b0`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `front/src/components/MetaConfig/index.tsx`의 site title suffix 중복 방지 조건
  - `front/e2e/smoke-detail-layout.spec.ts`의 상세/일반 페이지 title 계약

## 리스크

- 브라우저 탭 title만 바뀌며 OG/Twitter meta title은 기존 `props.title` 정책을 유지한다.
- 일반 페이지가 이미 `AquilaLog`를 title에 포함한 경우 중복 suffix를 붙이지 않는 정책을 택했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (CodeRabbit 재리뷰 완료. Codex CLI fallback은 private repo diff 외부 전송 정책 차단으로 사용하지 않음)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
