### PR TITLE
[Fix] 404 robots와 canonical 정책 분리

### DIFF
--- a/front/e2e/smoke-detail-layout.spec.ts
+++ b/front/e2e/smoke-detail-layout.spec.ts
@@ -5,6 +5,18 @@ test.beforeEach(async ({ page }) => {
 })
 
 test.describe("core smoke detail layout", () => {
+  test("404 robots 정책은 noindex이고 canonical은 생략하며 정상 페이지 기본값은 유지한다", async ({ page }) => {
+  await page.goto("/404")
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", "noindex, follow")
+  await expect(page.locator('link[rel="canonical"]')).toHaveCount(0)
+
+  await addPublicAboutSnapshotCookie(page)
+  await page.goto("/about")
+  await expect(page.locator('[data-ui="about-eyebrow"]')).toHaveText("Profile")
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", "follow, index")
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", /\/about$/)
+})
+
   test("게시글 상세 browser title은 글 제목을 포함하고 일반 페이지 title은 site suffix를 중복하지 않는다", async ({ page }) => {
   await page.route("**/member/api/v1/auth/me", async (route) => {
     await route.fulfill({

--- a/front/src/components/MetaConfig/index.tsx
+++ b/front/src/components/MetaConfig/index.tsx
@@ -8,6 +8,8 @@ export type MetaConfigProps = {
   date?: string
   image?: string
   url: string
+  robots?: string
+  canonicalUrl?: string | null
 }
 
 const SITE_TITLE = CONFIG.blog.title || "AquilaLog"
@@ -26,14 +28,16 @@ const resolveBrowserTabTitle = (title: string) => {
 
 const MetaConfig: React.FC<MetaConfigProps> = (props) => {
   const browserTabTitle = resolveBrowserTabTitle(props.title)
+  const robots = props.robots || "follow, index"
+  const canonicalUrl = props.canonicalUrl === undefined ? props.url : props.canonicalUrl
 
   return (
     <Head>
       <title>{browserTabTitle}</title>
-      <meta name="robots" content="follow, index" />
+      <meta name="robots" content={robots} />
       <meta charSet="UTF-8" />
       <meta name="description" content={props.description} />
-      <link rel="canonical" href={props.url} />
+      {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
       {/* og */}
       <meta property="og:type" content={props.type} />
       <meta property="og:title" content={props.title} />

--- a/front/src/pages/404.tsx
+++ b/front/src/pages/404.tsx
@@ -11,6 +11,8 @@ const NotFoundPage = () => {
           description: CONFIG.blog.description,
           type: "website",
           url: CONFIG.link,
+          robots: "noindex, follow",
+          canonicalUrl: null,
         }}
       />
       <CustomError />


### PR DESCRIPTION
## 관련 이슈

close #925

## 작업 배경

- 404 페이지가 공통 `MetaConfig` 기본값을 그대로 사용해 `follow, index` robots와 홈 canonical을 출력하고 있었다.
- 이 상태는 soft 404 신호와 홈 canonical 혼동을 만들 수 있어, 404의 색인 정책을 정상 페이지 기본값과 분리한다.

## 작업 내용

- `MetaConfig`에 `robots`와 `canonicalUrl` 선택 props를 추가했다.
- 기존 페이지는 기본값으로 `follow, index` robots와 `url` canonical을 유지한다.
- 404 페이지는 `noindex, follow` robots를 명시하고 canonical을 생략한다.
- smoke 테스트에 404 robots/canonical 정책과 `/about` 정상 페이지 기본값 회귀 검증을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test:e2e:smoke --grep "404 robots"`: RED 확인. 404 robots가 기존 `follow, index`로 출력되어 기대 실패.
  - `yarn --cwd front test:e2e:smoke --grep "404 robots"`: PASS, 1 passed.
  - `yarn --cwd front build`: PASS.
  - `yarn --cwd front test:e2e:smoke`: PASS, 65 passed.
  - `yarn --cwd front test:e2e:smoke`: PASS, 65 passed.
  - PR CI: PASS. `frontend-ci`, `backend-ci`, `backend-dependency-check`, `CodeQL`, `Vercel`, `Vercel Preview Comments` 모두 통과.
  - CodeRabbit: 최초 자동 리뷰는 rate limit으로 미실행. reset 후 `@coderabbitai review` 재요청 결과, actionable comments 0개.
  - post-merge CI: PASS. main `CI` run `27876560166`, `Security` run `27876560122`.
  - post-merge CD: PASS. `Deploy to Home Server` run `27876733022`, `Frontend Live E2E Verification` 성공.
  - live 확인: `https://www.aquilaxk.site/__codex-issue-925-not-found`가 HTTP 404를 반환하고, HTML에 `meta name="robots" content="noindex, follow"` 및 `aquila-build-sha=a5e4ca472735d3a843f2cabf1170e47bf87c17a4`가 존재하며 `rel="canonical"`은 없음.

## 리뷰어 메모

- `MetaConfig`의 `url`은 OG URL 기본값으로 유지하고, canonical 출력만 `canonicalUrl`로 분리한 점을 먼저 봐주면 된다.
- `canonicalUrl: null`은 canonical 생략 의도를 명시하는 404 전용 사용이다.

## 리스크

- 낮음. 기본 props를 지정하지 않은 기존 페이지는 이전과 같은 robots/canonical 출력을 유지한다.
- 404에서 canonical이 사라지므로 검색엔진 정책상 soft 404 혼동을 줄이는 방향의 변경이다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (N/A: CodeRabbit 실제 리뷰 완료)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
