### PR TITLE
[Fix] cursor pagination 다음 페이지 오류를 빈 결과로 숨기지 않기

### DIFF
--- a/front/e2e/perf-feed.spec.ts
+++ b/front/e2e/perf-feed.spec.ts
@@ -123,6 +123,8 @@ test.describe("perf feed scroll budgets", () => {
   await expect(page.getByText("다음 글을 불러오지 못했습니다.")).toBeVisible()
   await expect(page.getByRole("button", { name: "다시 시도" })).toBeVisible()
   await expect(page.getByRole("button", { name: "더보기" })).toHaveCount(0)
+  await page.waitForTimeout(500)
+  expect(nextCursorAttempts).toBe(2)
 
   await page.getByRole("button", { name: "다시 시도" }).click()
 

--- a/front/e2e/perf-feed.spec.ts
+++ b/front/e2e/perf-feed.spec.ts
@@ -93,6 +93,98 @@ test.describe("perf feed scroll budgets", () => {
   expect(nextCursorAttempts).toBe(3)
 })
 
+  test("홈 피드는 cursor 첫 요청 fallback 이후 다음 page를 page API로 이어간다", async ({ page }) => {
+  const pageRequests: number[] = []
+  const firstPageIds = [1301, 1302]
+  const secondPageIds = [1303, 1304]
+
+  await mockFeedEndpoints(page, {
+    feedHandler: async (route) => {
+      const url = new URL(route.request().url())
+      const isCursorEndpoint = url.pathname.endsWith("/cursor")
+      const pageNumber = Number(url.searchParams.get("page") || "1")
+      const pageSize = Number(url.searchParams.get("pageSize") || "24")
+
+      if (isCursorEndpoint) {
+        await route.fulfill({
+          status: 503,
+          contentType: "application/json",
+          body: JSON.stringify({ message: "cursor disabled for fallback regression" }),
+        })
+        return
+      }
+
+      pageRequests.push(pageNumber)
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          content: (pageNumber === 1 ? firstPageIds : secondPageIds).map(buildMockExploreItem),
+          pageable: {
+            pageNumber: Math.max(pageNumber - 1, 0),
+            pageSize,
+            totalElements: pageSize * 2,
+            totalPages: 2,
+          },
+        }),
+      })
+    },
+  })
+
+  await page.goto("/")
+  await waitForPageReady(page)
+  await expect(page.getByRole("heading", { name: "CLS 예산 점검 1301" })).toBeVisible()
+
+  await page.getByRole("button", { name: "더보기" }).click()
+
+  await expect(page.getByRole("heading", { name: "CLS 예산 점검 1303" })).toBeVisible()
+  expect(pageRequests).toContain(2)
+  expect(pageRequests.filter((value) => value === 2)).toHaveLength(1)
+})
+
+  test("태그와 keyword 조합은 explore page API에 keyword를 보존한다", async ({ page }) => {
+  const capturedExploreRequests: Array<{ isCursorEndpoint: boolean; kw: string; tag: string }> = []
+
+  await mockFeedEndpoints(page, {
+    exploreHandler: async (route) => {
+      const url = new URL(route.request().url())
+      const isCursorEndpoint = url.pathname.endsWith("/cursor")
+      const kw = url.searchParams.get("kw") || ""
+      const tag = url.searchParams.get("tag") || ""
+      capturedExploreRequests.push({ isCursorEndpoint, kw, tag })
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          content: [buildMockExploreItem(1401)],
+          pageable: {
+            pageNumber: 0,
+            pageSize: Number(url.searchParams.get("pageSize") || "24"),
+            totalElements: 1,
+            totalPages: 1,
+          },
+        }),
+      })
+    },
+  })
+
+  await page.goto("/?tag=perf")
+  await waitForPageReady(page)
+
+  capturedExploreRequests.length = 0
+  await page.getByLabel("Search posts by keyword").fill("latency")
+
+  await expect(page.getByRole("heading", { name: "CLS 예산 점검 1401" })).toBeVisible()
+  await expect
+    .poll(() =>
+      capturedExploreRequests.some(
+        (request) => !request.isCursorEndpoint && request.kw === "latency" && request.tag === "perf"
+      )
+    )
+    .toBeTruthy()
+})
+
   test("홈 피드 무한스크롤은 연속 트리거에서도 feed 호출이 폭주하지 않는다", async ({ page }) => {
   const feedCalls: number[] = []
   const feedCallSignatures: string[] = []

--- a/front/e2e/perf-feed.spec.ts
+++ b/front/e2e/perf-feed.spec.ts
@@ -6,6 +6,93 @@ import {
 } from "./helpers/perfFixtures"
 
 test.describe("perf feed scroll budgets", () => {
+  test("홈 피드는 다음 cursor 실패를 빈 결과로 숨기지 않고 재시도 버튼을 보여준다", async ({ page }) => {
+  let nextCursorAttempts = 0
+  const firstPageIds = [1201, 1202]
+  const secondPageIds = [1203, 1204]
+
+  await mockFeedEndpoints(page, {
+    feedHandler: async (route) => {
+      const url = new URL(route.request().url())
+      const isCursorEndpoint = url.pathname.endsWith("/cursor")
+      const cursorParam = url.searchParams.get("cursor")
+      const pageNumber = Number(url.searchParams.get("page") || "1")
+      const pageSize = Number(url.searchParams.get("pageSize") || "24")
+
+      if (isCursorEndpoint) {
+        if (cursorParam) {
+          nextCursorAttempts += 1
+          if (nextCursorAttempts <= 2) {
+            await route.fulfill({
+              status: 503,
+              contentType: "application/json",
+              body: JSON.stringify({ message: "cursor page temporarily unavailable" }),
+            })
+            return
+          }
+
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              content: secondPageIds.map(buildMockExploreItem),
+              pageSize,
+              hasNext: false,
+              nextCursor: null,
+            }),
+          })
+          return
+        }
+
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            content: firstPageIds.map(buildMockExploreItem),
+            pageSize,
+            hasNext: true,
+            nextCursor: "cursor-2",
+          }),
+        })
+        return
+      }
+
+      await route.fulfill({
+        status: pageNumber === 1 ? 200 : 503,
+        contentType: "application/json",
+        body: JSON.stringify(
+          pageNumber === 1
+            ? {
+                content: firstPageIds.map(buildMockExploreItem),
+                pageable: {
+                  pageNumber: 0,
+                  pageSize,
+                  totalElements: pageSize * 2,
+                  totalPages: 2,
+                },
+              }
+            : { message: "page fallback should not hide next cursor failure" }
+        ),
+      })
+    },
+  })
+
+  await page.goto("/")
+  await waitForPageReady(page)
+  await expect(page.getByRole("heading", { name: "CLS 예산 점검 1201" })).toBeVisible()
+
+  await page.getByRole("button", { name: "더보기" }).click()
+
+  await expect(page.getByRole("heading", { name: "CLS 예산 점검 1201" })).toBeVisible()
+  await expect(page.getByText("다음 글을 불러오지 못했습니다.")).toBeVisible()
+  await expect(page.getByRole("button", { name: "다시 시도" })).toBeVisible()
+
+  await page.getByRole("button", { name: "다시 시도" }).click()
+
+  await expect(page.getByRole("heading", { name: "CLS 예산 점검 1203" })).toBeVisible()
+  expect(nextCursorAttempts).toBe(3)
+})
+
   test("홈 피드 무한스크롤은 연속 트리거에서도 feed 호출이 폭주하지 않는다", async ({ page }) => {
   const feedCalls: number[] = []
   const feedCallSignatures: string[] = []
@@ -81,7 +168,7 @@ test.describe("perf feed scroll budgets", () => {
     return acc
   }, {} as Record<string, number>)
   const duplicatedPages = Object.entries(callCounts).filter(
-    ([signature, count]) => count > 1 && signature !== "page:1"
+    ([signature, count]) => count > 1 && !["page:1", "cursor:1"].includes(signature)
   )
   console.log(
     `[infinite-load-guard] calls=${JSON.stringify(feedCalls)} signatures=${JSON.stringify(feedCallSignatures)} unique=${JSON.stringify(uniqueCalls)}`
@@ -171,7 +258,7 @@ test.describe("perf feed scroll budgets", () => {
     return acc
   }, {} as Record<string, number>)
   const duplicatedPages = Object.entries(callCounts).filter(
-    ([signature, count]) => count > 1 && signature !== "page:1"
+    ([signature, count]) => count > 1 && !["page:1", "cursor:1"].includes(signature)
   )
   const maxRequestedPage = feedCalls.length ? Math.max(...feedCalls) : 0
 

--- a/front/e2e/perf-feed.spec.ts
+++ b/front/e2e/perf-feed.spec.ts
@@ -1,11 +1,47 @@
 import { expect, test } from "@playwright/test"
 import {
+  toRestoredPageParams,
+  type FeedExplorerRestoreSnapshot,
+} from "../src/routes/Feed/FeedExplorerRestoreModel"
+import {
   buildMockExploreItem,
   mockFeedEndpoints,
   waitForPageReady,
 } from "./helpers/perfFixtures"
 
 test.describe("perf feed scroll budgets", () => {
+  test("restore snapshot은 cursor pageParams를 cursor chain으로 복원한다", () => {
+    const snapshot: FeedExplorerRestoreSnapshot = {
+      savedAt: Date.now(),
+      pages: [
+        {
+          posts: [],
+          totalCount: 4,
+          pageNumber: 1,
+          pageSize: 2,
+          hasNext: true,
+          nextCursor: "cursor-2",
+          paginationMode: "cursor",
+        },
+        {
+          posts: [],
+          totalCount: 4,
+          pageNumber: 2,
+          pageSize: 2,
+          hasNext: false,
+          nextCursor: null,
+          paginationMode: "cursor",
+        },
+      ],
+    }
+
+    expect(toRestoredPageParams(snapshot)).toEqual([null, "cursor-2"])
+    expect(toRestoredPageParams({ ...snapshot, pageParams: [null, "persisted-cursor-2"] })).toEqual([
+      null,
+      "persisted-cursor-2",
+    ])
+  })
+
   test("홈 피드는 다음 cursor 실패를 빈 결과로 숨기지 않고 재시도 버튼을 보여준다", async ({ page }) => {
   let nextCursorAttempts = 0
   const firstPageIds = Array.from({ length: 16 }, (_, index) => 1201 + index)

--- a/front/e2e/perf-feed.spec.ts
+++ b/front/e2e/perf-feed.spec.ts
@@ -142,6 +142,53 @@ test.describe("perf feed scroll budgets", () => {
   expect(pageRequests.filter((value) => value === 2)).toHaveLength(1)
 })
 
+  test("홈 피드 page fallback은 빈 page에서 추가 요청을 멈춘다", async ({ page }) => {
+  const pageRequests: number[] = []
+
+  await mockFeedEndpoints(page, {
+    feedHandler: async (route) => {
+      const url = new URL(route.request().url())
+      const isCursorEndpoint = url.pathname.endsWith("/cursor")
+      const pageNumber = Number(url.searchParams.get("page") || "1")
+      const pageSize = Number(url.searchParams.get("pageSize") || "24")
+
+      if (isCursorEndpoint) {
+        await route.fulfill({
+          status: 503,
+          contentType: "application/json",
+          body: JSON.stringify({ message: "cursor disabled for empty-page guard regression" }),
+        })
+        return
+      }
+
+      pageRequests.push(pageNumber)
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          content: pageNumber === 1 ? [buildMockExploreItem(1351)] : [],
+          pageable: {
+            pageNumber: Math.max(pageNumber - 1, 0),
+            pageSize,
+            totalElements: pageSize * 3,
+            totalPages: 3,
+          },
+        }),
+      })
+    },
+  })
+
+  await page.goto("/")
+  await waitForPageReady(page)
+  await expect(page.getByRole("heading", { name: "CLS 예산 점검 1351" })).toBeVisible()
+
+  await page.getByRole("button", { name: "더보기" }).click()
+
+  await expect(page.getByRole("button", { name: "더보기" })).toHaveCount(0)
+  expect(pageRequests).toContain(2)
+  expect(pageRequests).not.toContain(3)
+})
+
   test("태그와 keyword 조합은 explore page API에 keyword를 보존한다", async ({ page }) => {
   const capturedExploreRequests: Array<{ isCursorEndpoint: boolean; kw: string; tag: string }> = []
 

--- a/front/e2e/perf-feed.spec.ts
+++ b/front/e2e/perf-feed.spec.ts
@@ -36,9 +36,9 @@ test.describe("perf feed scroll budgets", () => {
     }
 
     expect(toRestoredPageParams(snapshot)).toEqual([null, "cursor-2"])
-    expect(toRestoredPageParams({ ...snapshot, pageParams: [null, "persisted-cursor-2"] })).toEqual([
+    expect(toRestoredPageParams({ ...snapshot, pageParams: [1, "persisted-cursor-2"] })).toEqual([
       null,
-      "persisted-cursor-2",
+      "cursor-2",
     ])
   })
 

--- a/front/e2e/perf-feed.spec.ts
+++ b/front/e2e/perf-feed.spec.ts
@@ -8,8 +8,8 @@ import {
 test.describe("perf feed scroll budgets", () => {
   test("홈 피드는 다음 cursor 실패를 빈 결과로 숨기지 않고 재시도 버튼을 보여준다", async ({ page }) => {
   let nextCursorAttempts = 0
-  const firstPageIds = [1201, 1202]
-  const secondPageIds = [1203, 1204]
+  const firstPageIds = Array.from({ length: 16 }, (_, index) => 1201 + index)
+  const secondPageIds = [1251, 1252]
 
   await mockFeedEndpoints(page, {
     feedHandler: async (route) => {
@@ -89,14 +89,14 @@ test.describe("perf feed scroll budgets", () => {
 
   await page.getByRole("button", { name: "다시 시도" }).click()
 
-  await expect(page.getByRole("heading", { name: "CLS 예산 점검 1203" })).toBeVisible()
+  await expect(page.getByText("피드 18개")).toBeVisible()
   expect(nextCursorAttempts).toBe(3)
 })
 
   test("홈 피드는 cursor 첫 요청 fallback 이후 다음 page를 page API로 이어간다", async ({ page }) => {
   const pageRequests: number[] = []
-  const firstPageIds = [1301, 1302]
-  const secondPageIds = [1303, 1304]
+  const firstPageIds = Array.from({ length: 16 }, (_, index) => 1301 + index)
+  const secondPageIds = [1351, 1352]
 
   await mockFeedEndpoints(page, {
     feedHandler: async (route) => {
@@ -137,7 +137,7 @@ test.describe("perf feed scroll budgets", () => {
 
   await page.getByRole("button", { name: "더보기" }).click()
 
-  await expect(page.getByRole("heading", { name: "CLS 예산 점검 1303" })).toBeVisible()
+  await expect(page.getByText("피드 18개")).toBeVisible()
   expect(pageRequests).toContain(2)
   expect(pageRequests.filter((value) => value === 2)).toHaveLength(1)
 })

--- a/front/e2e/perf-feed.spec.ts
+++ b/front/e2e/perf-feed.spec.ts
@@ -86,6 +86,7 @@ test.describe("perf feed scroll budgets", () => {
   await expect(page.getByRole("heading", { name: "CLS 예산 점검 1201" })).toBeVisible()
   await expect(page.getByText("다음 글을 불러오지 못했습니다.")).toBeVisible()
   await expect(page.getByRole("button", { name: "다시 시도" })).toBeVisible()
+  await expect(page.getByRole("button", { name: "더보기" })).toHaveCount(0)
 
   await page.getByRole("button", { name: "다시 시도" }).click()
 

--- a/front/src/apis/backend/posts/PostApiRequests.ts
+++ b/front/src/apis/backend/posts/PostApiRequests.ts
@@ -319,15 +319,7 @@ export const getFeedPostsCursorPage = async ({
     if (isAbortError(error)) {
       throw error
     }
-    return {
-      posts: [],
-      totalCount: 0,
-      pageNumber: 1,
-      pageSize: safePageSize,
-      hasNext: false,
-      nextCursor: null,
-      paginationMode: "cursor",
-    }
+    throw error
   }
 }
 
@@ -402,15 +394,7 @@ export const getExplorePostsCursorPage = async ({
     if (isAbortError(error)) {
       throw error
     }
-    return {
-      posts: [],
-      totalCount: 0,
-      pageNumber: 1,
-      pageSize: safePageSize,
-      hasNext: false,
-      nextCursor: null,
-      paginationMode: "cursor",
-    }
+    throw error
   }
 }
 

--- a/front/src/hooks/useExplorePostsQuery.ts
+++ b/front/src/hooks/useExplorePostsQuery.ts
@@ -118,6 +118,7 @@ const useExplorePostsQuery = ({
           ? lastPage.nextCursor.trim()
           : undefined
       }
+      if (lastPage.posts.length === 0) return undefined
       if (lastPage.pageNumber * lastPage.pageSize >= lastPage.totalCount) return undefined
       return lastPage.pageNumber + 1
     },

--- a/front/src/hooks/useExplorePostsQuery.ts
+++ b/front/src/hooks/useExplorePostsQuery.ts
@@ -2,7 +2,9 @@ import { useInfiniteQuery } from "@tanstack/react-query"
 import { toSafeInt } from "@shared/utils"
 import {
   getExplorePostsCursorPage,
+  getExplorePostsPage,
   getFeedPostsCursorPage,
+  getFeedPostsPage,
   getSearchPostsPage,
 } from "src/apis/backend/posts"
 import { FEED_EXPLORE_PAGE_SIZE } from "src/constants/feed"
@@ -55,7 +57,17 @@ const useExplorePostsQuery = ({
             order,
           }),
     queryFn: ({ pageParam, signal }: { pageParam: ExplorePageParam; signal?: AbortSignal }) => {
+      const pageNumber = toSafeInt(pageParam, 1)
+
       if (feedMode) {
+        if (typeof pageParam === "number") {
+          return getFeedPostsPage({
+            order,
+            page: pageNumber,
+            pageSize,
+            signal: signal ?? undefined,
+          })
+        }
         const cursor = typeof pageParam === "string" ? pageParam : undefined
         return getFeedPostsCursorPage({
           order,
@@ -65,11 +77,19 @@ const useExplorePostsQuery = ({
         })
       }
 
-      const pageNumber = toSafeInt(pageParam, 1)
-
       if (searchMode) {
         return getSearchPostsPage({
           kw: normalizedKw,
+          order,
+          page: pageNumber,
+          pageSize,
+          signal: signal ?? undefined,
+        })
+      }
+      if (normalizedKw.length > 0 || typeof pageParam === "number") {
+        return getExplorePostsPage({
+          kw: normalizedKw,
+          tag: normalizedTag,
           order,
           page: pageNumber,
           pageSize,
@@ -90,7 +110,7 @@ const useExplorePostsQuery = ({
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
-    initialPageParam: searchMode ? OFFSET_INITIAL_PAGE_PARAM : null,
+    initialPageParam: normalizedKw.length > 0 ? OFFSET_INITIAL_PAGE_PARAM : null,
     getNextPageParam: (lastPage) => {
       if (lastPage.paginationMode === "cursor") {
         if (lastPage.hasNext !== true) return undefined

--- a/front/src/hooks/useExplorePostsQuery.ts
+++ b/front/src/hooks/useExplorePostsQuery.ts
@@ -1,8 +1,8 @@
 import { useInfiniteQuery } from "@tanstack/react-query"
 import { toSafeInt } from "@shared/utils"
 import {
-  getExplorePostsPage,
-  getFeedPostsPage,
+  getExplorePostsCursorPage,
+  getFeedPostsCursorPage,
   getSearchPostsPage,
 } from "src/apis/backend/posts"
 import { FEED_EXPLORE_PAGE_SIZE } from "src/constants/feed"
@@ -21,7 +21,7 @@ type Params = {
 
 const EMPTY_POSTS: TPost[] = []
 const OFFSET_INITIAL_PAGE_PARAM = 1
-type ExplorePageParam = number
+type ExplorePageParam = number | string | null
 
 const useExplorePostsQuery = ({
   kw,
@@ -55,16 +55,17 @@ const useExplorePostsQuery = ({
             order,
           }),
     queryFn: ({ pageParam, signal }: { pageParam: ExplorePageParam; signal?: AbortSignal }) => {
-      const pageNumber = toSafeInt(pageParam, 1)
-
       if (feedMode) {
-        return getFeedPostsPage({
+        const cursor = typeof pageParam === "string" ? pageParam : undefined
+        return getFeedPostsCursorPage({
           order,
-          page: pageNumber,
           pageSize,
+          cursor,
           signal: signal ?? undefined,
         })
       }
+
+      const pageNumber = toSafeInt(pageParam, 1)
 
       if (searchMode) {
         return getSearchPostsPage({
@@ -75,12 +76,12 @@ const useExplorePostsQuery = ({
           signal: signal ?? undefined,
         })
       }
-      return getExplorePostsPage({
-        kw: normalizedKw,
+      const cursor = typeof pageParam === "string" ? pageParam : undefined
+      return getExplorePostsCursorPage({
         tag: normalizedTag,
         order,
-        page: pageNumber,
         pageSize,
+        cursor,
         signal: signal ?? undefined,
       })
     },
@@ -89,9 +90,14 @@ const useExplorePostsQuery = ({
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
-    initialPageParam: OFFSET_INITIAL_PAGE_PARAM,
+    initialPageParam: searchMode ? OFFSET_INITIAL_PAGE_PARAM : null,
     getNextPageParam: (lastPage) => {
-      if (lastPage.posts.length === 0) return undefined
+      if (lastPage.paginationMode === "cursor") {
+        if (lastPage.hasNext !== true) return undefined
+        return typeof lastPage.nextCursor === "string" && lastPage.nextCursor.trim()
+          ? lastPage.nextCursor.trim()
+          : undefined
+      }
       if (lastPage.pageNumber * lastPage.pageSize >= lastPage.totalCount) return undefined
       return lastPage.pageNumber + 1
     },
@@ -137,6 +143,7 @@ const useExplorePostsQuery = ({
     hasNextPage: query.hasNextPage ?? false,
     isInitialLoading: query.isLoading,
     isFetchingNextPage: query.isFetchingNextPage,
+    isFetchNextPageError: query.isFetchNextPageError,
     fetchNextPage: query.fetchNextPage,
   }
 }

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -107,6 +107,7 @@ export const getStaticProps: GetStaticProps = async () => {
             pageSize: FEED_EXPLORE_PAGE_SIZE,
             hasNext,
             nextCursor,
+            paginationMode: "cursor",
           },
         ],
         pageParams: [1],

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -110,7 +110,7 @@ export const getStaticProps: GetStaticProps = async () => {
             paginationMode: "cursor",
           },
         ],
-        pageParams: [1],
+        pageParams: [null],
       }
     )
   }

--- a/front/src/routes/Feed/FeedExplorer.tsx
+++ b/front/src/routes/Feed/FeedExplorer.tsx
@@ -32,12 +32,15 @@ import {
   scheduleIdleRevalidate,
   toFeedExplorerInfiniteQueryKey,
   toPersistFingerprint,
+  toRestoredPageParams,
   toRestoredPage,
+  toSnapshotPageParam,
   toSnapshotPage,
   useDebouncedValue,
   type FeedExplorerRestoreSnapshot,
   type FeedExplorerRestoreState,
   type FeedExplorerSnapshotPage,
+  type FeedExplorerSnapshotPageParam,
 } from "./FeedExplorerRestoreModel"
 
 const LOAD_MORE_THROTTLE_MS = 800
@@ -50,6 +53,7 @@ const FeedExplorer = () => {
   const searchInputRef = useRef<HTMLInputElement | null>(null)
   const restoreStateRef = useRef<FeedExplorerRestoreState | null>(null)
   const restoreQueryPagesRef = useRef<FeedExplorerSnapshotPage[] | null>(null)
+  const restoreQueryPageParamsRef = useRef<FeedExplorerSnapshotPageParam[] | null>(null)
   const hasHydratedQuerySnapshotRef = useRef(false)
   const hasAppliedRestoreSnapshotRef = useRef(false)
   const hasScheduledIdleRevalidateRef = useRef(false)
@@ -143,7 +147,14 @@ const FeedExplorer = () => {
       window.sessionStorage.getItem(restoreSnapshotStorageKey)
     )
     if (restoredSnapshot?.pages?.length) {
-      restoreQueryPagesRef.current = restoredSnapshot.pages.slice(0, resolveSnapshotPageCap())
+      const restoredPages = restoredSnapshot.pages.slice(0, resolveSnapshotPageCap())
+      const restoredPageParams = toRestoredPageParams({
+        ...restoredSnapshot,
+        pages: restoredPages,
+        pageParams: restoredSnapshot.pageParams?.slice(0, restoredPages.length),
+      })
+      restoreQueryPagesRef.current = restoredPages
+      restoreQueryPageParamsRef.current = restoredPageParams
     }
 
   }, [currentTag, q, restoreSnapshotStorageKey, restoreStorageKey, router.isReady])
@@ -174,7 +185,10 @@ const FeedExplorer = () => {
 
     queryClient.setQueryData<InfiniteData<ExplorePostsPage>>(restoreQueryKey, {
       pages: restoredPages.map(toRestoredPage),
-      pageParams: restoredPages.map((page) => page.pageNumber),
+      pageParams:
+        restoreQueryPageParamsRef.current?.length === restoredPages.length
+          ? restoreQueryPageParamsRef.current
+          : toRestoredPageParams({ savedAt: restored.savedAt, pages: restoredPages }),
     })
     hasHydratedQuerySnapshotRef.current = true
     hasAppliedRestoreSnapshotRef.current = true
@@ -247,9 +261,14 @@ const FeedExplorer = () => {
       const pages = queryData?.pages ?? []
 
       if (pages.length > 0) {
+        const snapshotPages = pages.slice(0, resolveSnapshotPageCap()).map(toSnapshotPage)
+        const snapshotPageParams = (queryData?.pageParams ?? [])
+          .slice(0, snapshotPages.length)
+          .map(toSnapshotPageParam)
         const snapshotPayload: FeedExplorerRestoreSnapshot = {
           savedAt: state.savedAt,
-          pages: pages.slice(0, resolveSnapshotPageCap()).map(toSnapshotPage),
+          pages: snapshotPages,
+          ...(snapshotPageParams.length === snapshotPages.length ? { pageParams: snapshotPageParams } : {}),
         }
         const snapshotJson = JSON.stringify(snapshotPayload)
         if (snapshotJson.length <= FEED_EXPLORER_SNAPSHOT_MAX_BYTES) {

--- a/front/src/routes/Feed/FeedExplorer.tsx
+++ b/front/src/routes/Feed/FeedExplorer.tsx
@@ -341,6 +341,11 @@ const FeedExplorer = () => {
     lastLoadMoreAtRef.current = now
     void fetchNextPage()
   }, [fetchNextPage])
+  const handleRetryLoadMore = useCallback(() => {
+    if (!hasNextPageRef.current || isFetchingNextPageRef.current) return
+    lastLoadMoreAtRef.current = 0
+    void fetchNextPage()
+  }, [fetchNextPage])
   const handleLoadMoreRef = useRef(handleLoadMore)
 
   useEffect(() => {
@@ -443,6 +448,7 @@ const FeedExplorer = () => {
             isFetchNextPageError={isFetchNextPageError}
             hasNextPage={hasNextPage}
             onLoadMore={handleLoadMore}
+            onRetryLoadMore={handleRetryLoadMore}
             loadMoreTriggerRef={loadMoreTriggerRef}
           />
         </section>

--- a/front/src/routes/Feed/FeedExplorer.tsx
+++ b/front/src/routes/Feed/FeedExplorer.tsx
@@ -102,6 +102,7 @@ const FeedExplorer = () => {
   const lastObserverTriggerAtRef = useRef(0)
   const hasNextPageRef = useRef(hasNextPage)
   const isFetchingNextPageRef = useRef(isFetchingNextPage)
+  const isFetchNextPageErrorRef = useRef(isFetchNextPageError)
 
   useEffect(() => {
     hasNextPageRef.current = hasNextPage
@@ -110,6 +111,10 @@ const FeedExplorer = () => {
   useEffect(() => {
     isFetchingNextPageRef.current = isFetchingNextPage
   }, [isFetchingNextPage])
+
+  useEffect(() => {
+    isFetchNextPageErrorRef.current = isFetchNextPageError
+  }, [isFetchNextPageError])
 
   useEffect(() => {
     restoreSnapshotRef.current = {
@@ -354,6 +359,7 @@ const FeedExplorer = () => {
   ])
 
   const handleLoadMore = useCallback(() => {
+    if (isFetchNextPageErrorRef.current) return
     if (!hasNextPageRef.current || isFetchingNextPageRef.current) return
     const now = Date.now()
     if (now - lastLoadMoreAtRef.current < LOAD_MORE_THROTTLE_MS) return
@@ -378,6 +384,7 @@ const FeedExplorer = () => {
     const observer = new IntersectionObserver(
       (entries) => {
         if (!entries.some((entry) => entry.isIntersecting)) return
+        if (isFetchNextPageErrorRef.current) return
         if (typeof document !== "undefined" && document.visibilityState !== "visible") return
         const now = Date.now()
         if (now - lastObserverTriggerAtRef.current < LOAD_MORE_OBSERVER_THROTTLE_MS) return

--- a/front/src/routes/Feed/FeedExplorer.tsx
+++ b/front/src/routes/Feed/FeedExplorer.tsx
@@ -84,6 +84,7 @@ const FeedExplorer = () => {
     hasNextPage,
     isInitialLoading,
     isFetchingNextPage,
+    isFetchNextPageError,
     fetchNextPage,
   } = useExplorePostsQuery({
     kw: debouncedQ,
@@ -439,6 +440,7 @@ const FeedExplorer = () => {
             onClearFilters={handleClearFilters}
             isInitialLoading={isInitialLoading}
             isFetchingNextPage={isFetchingNextPage}
+            isFetchNextPageError={isFetchNextPageError}
             hasNextPage={hasNextPage}
             onLoadMore={handleLoadMore}
             loadMoreTriggerRef={loadMoreTriggerRef}

--- a/front/src/routes/Feed/FeedExplorerRestoreModel.ts
+++ b/front/src/routes/Feed/FeedExplorerRestoreModel.ts
@@ -27,7 +27,10 @@ export type FeedExplorerRestoreState = {
 export type FeedExplorerRestoreSnapshot = {
   savedAt: number
   pages: FeedExplorerSnapshotPage[]
+  pageParams?: FeedExplorerSnapshotPageParam[]
 }
+
+export type FeedExplorerSnapshotPageParam = number | string | null
 
 export type FeedExplorerSnapshotPost = {
   id: string
@@ -181,6 +184,47 @@ export const toRestoredPage = (page: FeedExplorerSnapshotPage): ExplorePostsPage
   posts: page.posts.map(toRestoredPost),
 })
 
+const normalizeSnapshotPageParam = (value: unknown): FeedExplorerSnapshotPageParam | undefined => {
+  if (value === null) return null
+  if (typeof value === "number" && Number.isFinite(value)) return Math.trunc(value)
+  if (typeof value !== "string") return undefined
+
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+export const toSnapshotPageParam = (value: unknown): FeedExplorerSnapshotPageParam => {
+  return normalizeSnapshotPageParam(value) ?? null
+}
+
+const toFallbackRestoredPageParam = (
+  pages: FeedExplorerSnapshotPage[],
+  index: number
+): FeedExplorerSnapshotPageParam => {
+  const page = pages[index]
+  if (page?.paginationMode !== "cursor") {
+    return typeof page?.pageNumber === "number" && Number.isFinite(page.pageNumber)
+      ? Math.trunc(page.pageNumber)
+      : index + 1
+  }
+  if (index === 0) return null
+
+  const previousCursor = pages[index - 1]?.nextCursor
+  return typeof previousCursor === "string" && previousCursor.trim().length > 0
+    ? previousCursor.trim()
+    : null
+}
+
+export const toRestoredPageParams = (
+  snapshot: FeedExplorerRestoreSnapshot
+): FeedExplorerSnapshotPageParam[] => {
+  const pageParams = Array.isArray(snapshot.pageParams) ? snapshot.pageParams : []
+  return snapshot.pages.map((_, index) => {
+    const parsed = normalizeSnapshotPageParam(pageParams[index])
+    return parsed === undefined ? toFallbackRestoredPageParam(snapshot.pages, index) : parsed
+  })
+}
+
 export const scheduleIdleRevalidate = (callback: () => void) => {
   if (typeof window === "undefined") return () => {}
 
@@ -225,9 +269,14 @@ export const parseFeedExplorerRestoreSnapshot = (raw: string | null): FeedExplor
     if (savedAt <= 0) return null
     if (Date.now() - savedAt > FEED_EXPLORER_RESTORE_TTL_MS) return null
 
+    const pageParams = Array.isArray(parsed.pageParams)
+      ? parsed.pageParams.map(toSnapshotPageParam).slice(0, parsed.pages.length)
+      : undefined
+
     return {
       savedAt,
       pages: parsed.pages as FeedExplorerSnapshotPage[],
+      ...(pageParams ? { pageParams } : {}),
     }
   } catch {
     return null

--- a/front/src/routes/Feed/FeedExplorerRestoreModel.ts
+++ b/front/src/routes/Feed/FeedExplorerRestoreModel.ts
@@ -219,7 +219,11 @@ export const toRestoredPageParams = (
   snapshot: FeedExplorerRestoreSnapshot
 ): FeedExplorerSnapshotPageParam[] => {
   const pageParams = Array.isArray(snapshot.pageParams) ? snapshot.pageParams : []
-  return snapshot.pages.map((_, index) => {
+  return snapshot.pages.map((page, index) => {
+    if (page.paginationMode === "cursor") {
+      return toFallbackRestoredPageParam(snapshot.pages, index)
+    }
+
     const parsed = normalizeSnapshotPageParam(pageParams[index])
     return parsed === undefined ? toFallbackRestoredPageParam(snapshot.pages, index) : parsed
   })

--- a/front/src/routes/Feed/FeedExplorerRestoreModel.ts
+++ b/front/src/routes/Feed/FeedExplorerRestoreModel.ts
@@ -54,6 +54,9 @@ export type FeedExplorerSnapshotPage = {
   totalCount: number
   pageNumber: number
   pageSize: number
+  hasNext?: boolean
+  nextCursor?: string | null
+  paginationMode?: "cursor" | "page"
 }
 
 export type NavigatorConnectionLike = {
@@ -134,6 +137,9 @@ export const toSnapshotPage = (page: ExplorePostsPage): FeedExplorerSnapshotPage
   totalCount: page.totalCount,
   pageNumber: page.pageNumber,
   pageSize: page.pageSize,
+  ...(typeof page.hasNext === "boolean" ? { hasNext: page.hasNext } : {}),
+  ...(typeof page.nextCursor === "string" || page.nextCursor === null ? { nextCursor: page.nextCursor } : {}),
+  ...(page.paginationMode ? { paginationMode: page.paginationMode } : {}),
   posts: page.posts.map(toSnapshotPost),
 })
 
@@ -169,6 +175,9 @@ export const toRestoredPage = (page: FeedExplorerSnapshotPage): ExplorePostsPage
   totalCount: page.totalCount,
   pageNumber: page.pageNumber,
   pageSize: page.pageSize,
+  ...(typeof page.hasNext === "boolean" ? { hasNext: page.hasNext } : {}),
+  ...(typeof page.nextCursor === "string" || page.nextCursor === null ? { nextCursor: page.nextCursor } : {}),
+  ...(page.paginationMode ? { paginationMode: page.paginationMode } : {}),
   posts: page.posts.map(toRestoredPost),
 })
 

--- a/front/src/routes/Feed/PostList/index.tsx
+++ b/front/src/routes/Feed/PostList/index.tsx
@@ -211,7 +211,7 @@ const PostList: React.FC<Props> = ({
               </button>
             </div>
           )}
-          {hasNextPage && (
+          {hasNextPage && !isFetchNextPageError && (
             <button
               type="button"
               className="loadMoreButton"

--- a/front/src/routes/Feed/PostList/index.tsx
+++ b/front/src/routes/Feed/PostList/index.tsx
@@ -201,9 +201,7 @@ const PostList: React.FC<Props> = ({
       })}
       {(hasNextPage || isFetchingNextPage || isFetchNextPageError) && (
         <section className="loadMoreArea">
-          {!isFetchNextPageError && (
-            <div ref={loadMoreTriggerRef} className="loadMoreTrigger" aria-hidden="true" />
-          )}
+          <div ref={loadMoreTriggerRef} className="loadMoreTrigger" aria-hidden="true" />
           {isFetchNextPageError && !isFetchingNextPage && (
             <div className="loadMoreError" role="alert" aria-live="assertive">
               <strong>다음 글을 불러오지 못했습니다.</strong>

--- a/front/src/routes/Feed/PostList/index.tsx
+++ b/front/src/routes/Feed/PostList/index.tsx
@@ -13,6 +13,7 @@ type Props = {
   onClearFilters?: () => void
   isInitialLoading?: boolean
   isFetchingNextPage?: boolean
+  isFetchNextPageError?: boolean
   hasNextPage?: boolean
   onLoadMore?: () => void
   loadMoreTriggerRef?: RefObject<HTMLDivElement>
@@ -102,6 +103,7 @@ const PostList: React.FC<Props> = ({
   onClearFilters,
   isInitialLoading = false,
   isFetchingNextPage = false,
+  isFetchNextPageError = false,
   hasNextPage = false,
   onLoadMore,
   loadMoreTriggerRef,
@@ -195,9 +197,18 @@ const PostList: React.FC<Props> = ({
           </div>
         )
       })}
-      {(hasNextPage || isFetchingNextPage) && (
+      {(hasNextPage || isFetchingNextPage || isFetchNextPageError) && (
         <section className="loadMoreArea">
           <div ref={loadMoreTriggerRef} className="loadMoreTrigger" aria-hidden="true" />
+          {isFetchNextPageError && !isFetchingNextPage && (
+            <div className="loadMoreError" role="alert" aria-live="assertive">
+              <strong>다음 글을 불러오지 못했습니다.</strong>
+              <span>기존 목록은 유지했습니다. 잠시 후 다시 시도해주세요.</span>
+              <button type="button" className="loadMoreButton" onClick={onLoadMore}>
+                다시 시도
+              </button>
+            </div>
+          )}
           {hasNextPage && (
             <button
               type="button"
@@ -386,6 +397,29 @@ const StyledWrapper = styled.div`
     width: 100%;
     display: grid;
     gap: 0.72rem;
+  }
+
+  .loadMoreError {
+    width: min(100%, 34rem);
+    display: grid;
+    justify-items: center;
+    gap: 0.42rem;
+    border-top: 1px solid ${({ theme }) => theme.colors.red6};
+    border-bottom: 1px solid ${({ theme }) => theme.colors.red6};
+    padding: 0.85rem 0;
+    text-align: center;
+
+    strong {
+      color: ${({ theme }) => theme.colors.red11};
+      font-size: 0.9rem;
+      font-weight: 800;
+    }
+
+    span {
+      color: ${({ theme }) => theme.colors.gray10};
+      font-size: 0.8rem;
+      line-height: 1.5;
+    }
   }
 
   .loadMoreSkeletonCopy {

--- a/front/src/routes/Feed/PostList/index.tsx
+++ b/front/src/routes/Feed/PostList/index.tsx
@@ -201,7 +201,9 @@ const PostList: React.FC<Props> = ({
       })}
       {(hasNextPage || isFetchingNextPage || isFetchNextPageError) && (
         <section className="loadMoreArea">
-          <div ref={loadMoreTriggerRef} className="loadMoreTrigger" aria-hidden="true" />
+          {!isFetchNextPageError && (
+            <div ref={loadMoreTriggerRef} className="loadMoreTrigger" aria-hidden="true" />
+          )}
           {isFetchNextPageError && !isFetchingNextPage && (
             <div className="loadMoreError" role="alert" aria-live="assertive">
               <strong>다음 글을 불러오지 못했습니다.</strong>

--- a/front/src/routes/Feed/PostList/index.tsx
+++ b/front/src/routes/Feed/PostList/index.tsx
@@ -16,6 +16,7 @@ type Props = {
   isFetchNextPageError?: boolean
   hasNextPage?: boolean
   onLoadMore?: () => void
+  onRetryLoadMore?: () => void
   loadMoreTriggerRef?: RefObject<HTMLDivElement>
 }
 
@@ -106,6 +107,7 @@ const PostList: React.FC<Props> = ({
   isFetchNextPageError = false,
   hasNextPage = false,
   onLoadMore,
+  onRetryLoadMore,
   loadMoreTriggerRef,
 }) => {
   const deferredMountTriggerRef = useRef<HTMLDivElement | null>(null)
@@ -204,7 +206,7 @@ const PostList: React.FC<Props> = ({
             <div className="loadMoreError" role="alert" aria-live="assertive">
               <strong>다음 글을 불러오지 못했습니다.</strong>
               <span>기존 목록은 유지했습니다. 잠시 후 다시 시도해주세요.</span>
-              <button type="button" className="loadMoreButton" onClick={onLoadMore}>
+              <button type="button" className="loadMoreButton" onClick={onRetryLoadMore ?? onLoadMore}>
                 다시 시도
               </button>
             </div>


### PR DESCRIPTION
## 관련 이슈

close #927

## 작업 배경

- cursor pagination의 다음 페이지 요청 실패가 빈 마지막 페이지처럼 변환되면 사용자는 실제 마지막 페이지로 오인하고, 기존 피드가 조용히 잘린다.
- 첫 cursor page 실패는 기존 page API fallback으로 복구하되, 다음 cursor 실패는 기존 목록을 유지하면서 오류 상태와 재시도 경로를 보여줘야 한다.

## 작업 내용

- `getFeedPostsCursorPage()`와 `getExplorePostsCursorPage()`에서 다음 cursor 요청의 non-abort 오류를 빈 cursor page로 변환하지 않고 throw하도록 변경했다.
- Feed/Explore infinite query를 feed/tag 모드에서 cursor API와 `nextCursor` 기반 pageParam을 사용하도록 전환했다. 검색 모드와 keyword+tag 조합은 기존 page API를 유지했다.
- static bootstrap과 feed restore snapshot에 cursor metadata 및 pageParams를 보존/재구성해 cursor mode가 offset page mode로 섞이지 않게 했다.
- PostList 하단에 next-page error alert와 `다시 시도` 버튼을 추가하고, 오류 상태에서는 자동 infinite-scroll 재시도만 차단하되 retry 성공 후 sentinel 연결은 유지했다.
- perf feed e2e에 다음 cursor 실패, 자동 retry 소진, 기존 목록 유지, 수동 재시도 성공, fallback/page guard/restore 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`: 통과
  - `yarn --cwd front playwright:preflight`: 통과
  - `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf-feed.spec.ts --workers=1`: 7 passed, 최종 head에서 2회 연속 통과
  - `yarn --cwd front build`: 통과
  - `yarn --cwd front test:e2e:smoke`: 65 passed, 최종 head에서 2회 연속 통과
  - `codex review --base origin/main --title "[Fix] cursor pagination 다음 페이지 오류를 빈 결과로 숨기지 않기"`: 최초 지적사항은 모두 PR inline review로 게시 후 follow-up commit으로 수정, thread reply와 resolve 완료, 최종 review `4538713772`에서 actionable 0건
  - PR checks: CodeQL, backend-ci, backend-dependency-check, frontend-ci, CodeRabbit, Vercel, Vercel Preview Comments 모두 통과
  - post-merge main workflows: CI `27881371687`, Security `27881371678`, Deploy to Home Server `27881507097` 모두 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| cursor next-page error UI 및 retry | local darwin / Chromium | `front/e2e/perf-feed.spec.ts` | `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf-feed.spec.ts --workers=1` 출력 | 7 passed, 2회 연속 통과 |
| build/type/lint gate | local darwin | `yarn --cwd front build` | local command output | 통과 |
| smoke/mobile regression | local darwin / Chromium | `yarn --cwd front test:e2e:smoke` | local command output | 65 passed, 2회 연속 통과 |
| Codex CLI review fallback | GitHub PR #972 | 단일 PR review + inline thread reply 확인 | review `4538713772`, unresolved review thread count `0` | 최종 actionable 0건 |
| PR CI | GitHub Actions / Vercel | `gh pr checks 972 --watch --interval 20` | frontend-ci `82508881205`, backend-ci `82508881249`, CodeQL `82509082344`, Vercel preview `CrASxp5Va8BNJ7MxA6wQaLeo9HHx` | 모두 통과 |
| post-merge CI/CD | GitHub Actions | `gh run watch` | CI run `27881371687`, Security run `27881371678`, Deploy to Home Server run `27881507097` | 모두 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `front/src/apis/backend/posts/PostApiRequests.ts`의 첫 cursor fallback 유지와 다음 cursor throw 분기
  - `front/src/hooks/useExplorePostsQuery.ts`의 feed/tag cursor pageParam 전환, numeric fallback, search/page mode 유지
  - `front/src/routes/Feed/FeedExplorer.tsx`와 `front/src/routes/Feed/PostList/index.tsx`의 error state, retry handler, sentinel 유지 조건
  - `front/src/routes/Feed/FeedExplorerRestoreModel.ts`와 `front/src/pages/index.tsx`의 cursor pageParams 보존/재구성

## 리스크

- feed/tag 탐색은 cursor API를 기본으로 사용하므로 cursor endpoint 장애가 다음 페이지 UX에 명시적으로 드러난다.
- React Query의 기존 `retry: 1` 정책은 유지했다. 자동 retry까지 실패한 뒤 alert와 수동 재시도 버튼이 표시된다.
- post-merge 자동 배포는 merge 이후 main workflow에서 성공까지 확인했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
