### PR TITLE
[CI] 런타임별 backend image digest 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -600,7 +600,7 @@ jobs:
               return 1
             fi
 
-            for file in .env.prod docker-compose.prod.yml .active_backend; do
+            for file in .env.prod docker-compose.prod.yml .active_backend .backend-release-state.env; do
               if [ -f "${backup_dir}/${file}" ]; then
                 cp "${backup_dir}/${file}" "deploy/homeserver/${file}"
               fi
@@ -880,7 +880,7 @@ jobs:
             exit 1
           }
 
-          if ! RUNTIME_SPLIT_ENABLED="${RUNTIME_SPLIT_ENABLED_VALUE}" RUNTIME_SPLIT_STAGE="${RUNTIME_SPLIT_STAGE_VALUE}" HEALTHCHECK_PATH=/actuator/health/readiness HEALTHCHECK_LOG_EVERY_N_TRIES=1 ./deploy/homeserver/blue_green_deploy.sh; then
+          if ! STAGED_BACK_IMAGE="${STAGED_BACK_IMAGE}" RUNTIME_SPLIT_ENABLED="${RUNTIME_SPLIT_ENABLED_VALUE}" RUNTIME_SPLIT_STAGE="${RUNTIME_SPLIT_STAGE_VALUE}" HEALTHCHECK_PATH=/actuator/health/readiness HEALTHCHECK_LOG_EVERY_N_TRIES=1 ./deploy/homeserver/blue_green_deploy.sh; then
             rollback_and_exit "blue_green_deploy_failed"
           fi
 
@@ -900,7 +900,14 @@ jobs:
 
           ACTIVE_BACKEND_CONTAINER_ID="$(docker compose --env-file deploy/homeserver/.env.prod -f deploy/homeserver/docker-compose.prod.yml ps -q "${ACTIVE_BACKEND}" | head -n 1)"
           ACTIVE_BACKEND_IMAGE="$(docker inspect --format '{{.Config.Image}}' "${ACTIVE_BACKEND_CONTAINER_ID}" 2>/dev/null | tr -d '\r')"
-          EXPECTED_BACK_IMAGE="$(extract_env_value "BACK_IMAGE")"
+          case "${ACTIVE_BACKEND}" in
+            back_blue) ACTIVE_BACKEND_IMAGE_KEY="BACK_BLUE_IMAGE" ;;
+            back_green) ACTIVE_BACKEND_IMAGE_KEY="BACK_GREEN_IMAGE" ;;
+            *)
+              rollback_and_exit "invalid_active_backend_image_key"
+              ;;
+          esac
+          EXPECTED_BACK_IMAGE="$(extract_env_value "${ACTIVE_BACKEND_IMAGE_KEY}")"
           echo "post-deploy image verify: active_backend=${ACTIVE_BACKEND}, expected_image=${EXPECTED_BACK_IMAGE}, active_image=${ACTIVE_BACKEND_IMAGE:-none}"
           if [ -z "${ACTIVE_BACKEND_CONTAINER_ID}" ] || [ -z "${ACTIVE_BACKEND_IMAGE}" ] || [ "${ACTIVE_BACKEND_IMAGE}" != "${EXPECTED_BACK_IMAGE}" ]; then
             rollback_and_exit "active_backend_image_mismatch"

--- a/deploy/env/env.contract.json
+++ b/deploy/env/env.contract.json
@@ -136,9 +136,13 @@
     },
     "home-server-runtime": {
       "extends": "home-server-source",
-      "description": "Rendered deploy/homeserver/.env.prod after deploy-time BACK_IMAGE injection.",
+      "description": "Rendered deploy/homeserver/.env.prod after deploy-time runtime-specific backend image injection.",
       "keys": [
-        { "name": "BACK_IMAGE", "kind": "digest-image" }
+        { "name": "BACK_BLUE_IMAGE", "kind": "digest-image" },
+        { "name": "BACK_GREEN_IMAGE", "kind": "digest-image" },
+        { "name": "BACK_READ_IMAGE", "kind": "digest-image" },
+        { "name": "BACK_ADMIN_IMAGE", "kind": "digest-image" },
+        { "name": "BACK_WORKER_IMAGE", "kind": "digest-image" }
       ]
     },
     "front-local": {

--- a/deploy/homeserver/blue_green_deploy.sh
+++ b/deploy/homeserver/blue_green_deploy.sh
@@ -1006,7 +1006,16 @@ runtime_backend_image_value() {
   local service="$1"
   local key
   key="$(backend_image_key "${service}")"
-  trim_quotes "$(env_value "${key}")"
+  trim_quotes "$(
+    awk -F= -v key="${key}" '
+      $1 == key {
+        value = substr($0, index($0, "=") + 1)
+      }
+      END {
+        print value
+      }
+    ' "${ENV_FILE}"
+  )"
 }
 
 upsert_runtime_backend_image() {

--- a/deploy/homeserver/blue_green_deploy.sh
+++ b/deploy/homeserver/blue_green_deploy.sh
@@ -11,6 +11,7 @@ ENV_FILE="${SCRIPT_DIR}/.env.prod"
 CADDY_FILE="${SCRIPT_DIR}/caddy/Caddyfile"
 CADDY_CONTAINER_FILE="/etc/caddy/Caddyfile"
 STATE_FILE="${SCRIPT_DIR}/.active_backend"
+RELEASE_STATE_FILE="${SCRIPT_DIR}/.backend-release-state.env"
 COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-blog_home}"
 NETWORK_NAME="blog_home_default"
 DEPLOY_LOCK_DIR="${SCRIPT_DIR}/.deploy.lock"
@@ -947,24 +948,136 @@ require_digest_image_value() {
 require_back_image() {
   local env_file_back_image
   env_file_back_image="$(trim_quotes "$(env_value "BACK_IMAGE")")"
-  if [[ -n "${env_file_back_image}" ]]; then
-    if [[ -n "${BACK_IMAGE:-}" && "${BACK_IMAGE}" != "${env_file_back_image}" ]]; then
-      echo "BACK_IMAGE shell override detected. using ${ENV_FILE} value (${env_file_back_image})" >&2
-    fi
+  if [[ -n "${STAGED_BACK_IMAGE:-}" ]]; then
+    BACK_IMAGE="${STAGED_BACK_IMAGE}"
+  elif [[ -n "${BACK_IMAGE:-}" ]]; then
+    BACK_IMAGE="${BACK_IMAGE}"
+  elif [[ -n "${env_file_back_image}" ]]; then
+    echo "legacy BACK_IMAGE detected in ${ENV_FILE}; using it as staged deploy image" >&2
     BACK_IMAGE="${env_file_back_image}"
-    export BACK_IMAGE
   fi
 
   if [[ -z "${BACK_IMAGE:-}" ]]; then
-    echo "BACK_IMAGE is empty. refusing deploy to avoid accidental latest-image rollout." >&2
-    echo "set BACK_IMAGE=ghcr.io/aquilaxk/aquila-blog-back@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" >&2
+    echo "STAGED_BACK_IMAGE is empty. refusing deploy to avoid accidental latest-image rollout." >&2
+    echo "set STAGED_BACK_IMAGE=ghcr.io/aquilaxk/aquila-blog-back@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" >&2
     exit 1
   fi
 
-  if ! require_digest_image_value "BACK_IMAGE" "${BACK_IMAGE}"; then
-    echo "set BACK_IMAGE=ghcr.io/aquilaxk/aquila-blog-back@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" >&2
+  if ! require_digest_image_value "STAGED_BACK_IMAGE" "${BACK_IMAGE}"; then
+    echo "set STAGED_BACK_IMAGE=ghcr.io/aquilaxk/aquila-blog-back@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" >&2
     exit 1
   fi
+
+  STAGED_BACK_IMAGE="${BACK_IMAGE}"
+  export STAGED_BACK_IMAGE
+}
+
+backend_image_key() {
+  local service="$1"
+  case "${service}" in
+    back_blue) echo "BACK_BLUE_IMAGE" ;;
+    back_green) echo "BACK_GREEN_IMAGE" ;;
+    back_read) echo "BACK_READ_IMAGE" ;;
+    back_admin) echo "BACK_ADMIN_IMAGE" ;;
+    back_worker) echo "BACK_WORKER_IMAGE" ;;
+    *)
+      echo "unknown backend runtime service: ${service}" >&2
+      return 1
+      ;;
+  esac
+}
+
+container_image_for_service_any_state() {
+  local service="$1"
+  local container_id
+  container_id="$(
+    docker ps -aq \
+      --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}" \
+      --filter "label=com.docker.compose.service=${service}" 2>/dev/null | head -n 1 || true
+  )"
+  if [[ -z "${container_id}" ]]; then
+    return 0
+  fi
+
+  docker inspect --format '{{.Config.Image}}' "${container_id}" 2>/dev/null | tr -d '\r' | head -n 1 || true
+}
+
+runtime_backend_image_value() {
+  local service="$1"
+  local key
+  key="$(backend_image_key "${service}")"
+  trim_quotes "$(env_value "${key}")"
+}
+
+upsert_runtime_backend_image() {
+  local service="$1"
+  local image="$2"
+  local key
+  key="$(backend_image_key "${service}")"
+  require_digest_image_value "${key}" "${image}"
+  upsert_env_key "${key}" "${image}"
+}
+
+resolve_preserved_backend_image() {
+  local service="$1"
+  local fallback="$2"
+  local image
+  image="$(runtime_backend_image_value "${service}")"
+  if [[ -n "${image}" ]]; then
+    echo "${image}"
+    return 0
+  fi
+
+  image="$(container_image_for_service_any_state "${service}" || true)"
+  if [[ -n "${image}" ]]; then
+    echo "${image}"
+    return 0
+  fi
+
+  image="$(trim_quotes "$(env_value "BACK_IMAGE")")"
+  if [[ -n "${image}" ]]; then
+    echo "${image}"
+    return 0
+  fi
+
+  echo "${fallback}"
+}
+
+write_backend_release_state() {
+  local active_backend="$1"
+  local previous_backend="$2"
+  local active_image previous_image
+  active_image="$(runtime_backend_image_value "${active_backend}")"
+  previous_image="$(runtime_backend_image_value "${previous_backend}")"
+
+  {
+    printf 'active_backend=%s\n' "${active_backend}"
+    printf 'previous_backend=%s\n' "${previous_backend}"
+    printf 'active_backend_image=%s\n' "${active_image}"
+    printf 'previous_backend_image=%s\n' "${previous_image}"
+    printf 'back_blue_image=%s\n' "$(runtime_backend_image_value "back_blue")"
+    printf 'back_green_image=%s\n' "$(runtime_backend_image_value "back_green")"
+    printf 'back_read_image=%s\n' "$(runtime_backend_image_value "back_read")"
+    printf 'back_admin_image=%s\n' "$(runtime_backend_image_value "back_admin")"
+    printf 'back_worker_image=%s\n' "$(runtime_backend_image_value "back_worker")"
+  } > "${RELEASE_STATE_FILE}"
+}
+
+prepare_runtime_backend_images() {
+  local active_backend="$1"
+  local next_backend="$2"
+  local staged_image="$3"
+  local active_image
+
+  active_image="$(resolve_preserved_backend_image "${active_backend}" "${staged_image}")"
+  upsert_runtime_backend_image "${active_backend}" "${active_image}"
+  upsert_runtime_backend_image "${next_backend}" "${staged_image}"
+  upsert_runtime_backend_image "back_read" "${staged_image}"
+  upsert_runtime_backend_image "back_admin" "${staged_image}"
+  upsert_runtime_backend_image "back_worker" "${staged_image}"
+
+  write_backend_release_state "${active_backend}" "${next_backend}"
+  echo "runtime backend image map prepared: active=${active_backend} active_image=${active_image} next=${next_backend} next_image=${staged_image}"
 }
 
 require_nonempty_env_key() {
@@ -1871,6 +1984,7 @@ rollback_to_backend() {
   echo "${rollback_backend}" > "${STATE_FILE}"
   local inactive_backend
   inactive_backend="$(other_backend "${rollback_backend}")"
+  write_backend_release_state "${rollback_backend}" "${inactive_backend}"
   drain_and_stop_backend_if_running "${inactive_backend}"
   return 0
 }
@@ -1913,6 +2027,7 @@ fi
 echo "active backend: ${active_backend}"
 echo "next backend: ${next_backend}"
 
+prepare_runtime_backend_images "${active_backend}" "${next_backend}" "${STAGED_BACK_IMAGE}"
 persist_single_runtime_caddy_upstreams "${active_backend}"
 
 action_backend_host="$(backend_host "${next_backend}")"
@@ -1971,6 +2086,7 @@ if ! check_notification_sse_route "${api_domain}"; then
 fi
 
 echo "${next_backend}" > "${STATE_FILE}"
+write_backend_release_state "${next_backend}" "${active_backend}"
 drain_and_stop_backend_if_running "${active_backend}"
 
 echo "post-switch phase: install steady-state guard"

--- a/deploy/homeserver/check_deploy_status.sh
+++ b/deploy/homeserver/check_deploy_status.sh
@@ -133,7 +133,6 @@ require_file "${ENV_FILE}"
 require_file "${STATE_FILE}"
 
 ACTIVE_BACKEND="$(cat "${STATE_FILE}" 2>/dev/null || true)"
-EXPECTED_BACK_IMAGE="$(trim_quotes "$(env_value "BACK_IMAGE")")"
 API_DOMAIN="$(trim_quotes "$(env_value "API_DOMAIN")")"
 ADMIN_API_UPSTREAM="$(trim_quotes "$(env_value "ADMIN_API_UPSTREAM")")"
 READ_API_UPSTREAM="$(trim_quotes "$(env_value "READ_API_UPSTREAM")")"
@@ -145,10 +144,13 @@ fi
 if [[ "${ACTIVE_BACKEND}" == "back_blue" ]]; then
   EXPECTED_UPSTREAM="back_blue"
   INACTIVE_BACKEND="back_green"
+  ACTIVE_BACKEND_IMAGE_KEY="BACK_BLUE_IMAGE"
 else
   EXPECTED_UPSTREAM="back_green"
   INACTIVE_BACKEND="back_blue"
+  ACTIVE_BACKEND_IMAGE_KEY="BACK_GREEN_IMAGE"
 fi
+EXPECTED_BACK_IMAGE="$(trim_quotes "$(env_value "${ACTIVE_BACKEND_IMAGE_KEY}")")"
 
 RUNNING_SERVICES="$(compose ps --status running --services 2>/dev/null || true)"
 ACTIVE_BACKEND_CONTAINER_ID="$(compose ps -q "${ACTIVE_BACKEND}" 2>/dev/null | head -n 1 || true)"
@@ -236,7 +238,7 @@ log "promtail_status=${PROMTAIL_STATUS} restarting=${PROMTAIL_RESTARTING}"
 log "grafana_loki_datasource_status=${GRAFANA_LOKI_DS_STATUS}"
 
 if [[ -z "${EXPECTED_BACK_IMAGE}" ]]; then
-  remember_failure "missing_expected_back_image"
+  remember_failure "missing_expected_back_image key=${ACTIVE_BACKEND_IMAGE_KEY:-none}"
 fi
 
 if [[ -z "${API_DOMAIN}" ]]; then

--- a/deploy/homeserver/create_deploy_backup.sh
+++ b/deploy/homeserver/create_deploy_backup.sh
@@ -12,6 +12,7 @@ BACKUP_ROOT="${SCRIPT_DIR}/.deploy-backups"
 TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 BACKUP_DIR="${BACKUP_ROOT}/${TIMESTAMP}"
 STATE_FILE="${SCRIPT_DIR}/.active_backend"
+RELEASE_STATE_FILE="${SCRIPT_DIR}/.backend-release-state.env"
 
 container_image_for_service() {
   local service="$1"
@@ -38,7 +39,7 @@ elif [[ -f "${SCRIPT_DIR}/Caddyfile" ]]; then
   cp "${SCRIPT_DIR}/Caddyfile" "${BACKUP_DIR}/caddy/Caddyfile"
 fi
 
-for file in .env.prod docker-compose.prod.yml .active_backend; do
+for file in .env.prod docker-compose.prod.yml .active_backend .backend-release-state.env; do
   if [[ -f "${SCRIPT_DIR}/${file}" ]]; then
     cp "${SCRIPT_DIR}/${file}" "${BACKUP_DIR}/${file}"
   fi
@@ -46,12 +47,22 @@ done
 
 active_backend=""
 active_backend_image=""
+back_blue_image=""
+back_green_image=""
+back_read_image=""
+back_admin_image=""
+back_worker_image=""
 if [[ -f "${STATE_FILE}" ]]; then
   active_backend="$(cat "${STATE_FILE}" || true)"
   if [[ "${active_backend}" == "back_blue" || "${active_backend}" == "back_green" ]]; then
     active_backend_image="$(container_image_for_service "${active_backend}" || true)"
   fi
 fi
+back_blue_image="$(container_image_for_service "back_blue" || true)"
+back_green_image="$(container_image_for_service "back_green" || true)"
+back_read_image="$(container_image_for_service "back_read" || true)"
+back_admin_image="$(container_image_for_service "back_admin" || true)"
+back_worker_image="$(container_image_for_service "back_worker" || true)"
 
 {
   echo "created_at=${TIMESTAMP}"
@@ -61,6 +72,21 @@ fi
   fi
   if [[ -n "${active_backend_image}" ]]; then
     echo "active_backend_image=${active_backend_image}"
+  fi
+  if [[ -n "${back_blue_image}" ]]; then
+    echo "back_blue_image=${back_blue_image}"
+  fi
+  if [[ -n "${back_green_image}" ]]; then
+    echo "back_green_image=${back_green_image}"
+  fi
+  if [[ -n "${back_read_image}" ]]; then
+    echo "back_read_image=${back_read_image}"
+  fi
+  if [[ -n "${back_admin_image}" ]]; then
+    echo "back_admin_image=${back_admin_image}"
+  fi
+  if [[ -n "${back_worker_image}" ]]; then
+    echo "back_worker_image=${back_worker_image}"
   fi
 } > "${BACKUP_DIR}/metadata.env"
 

--- a/deploy/homeserver/create_external_backup.sh
+++ b/deploy/homeserver/create_external_backup.sh
@@ -189,6 +189,52 @@ ensure_image_env_key_from_local_digest() {
   log "auto-filled ${key} from local digest (${fallback_image} -> ${digest})"
 }
 
+container_image_for_service_any_state() {
+  local service="$1"
+  local container_id
+  container_id="$(
+    docker ps -aq \
+      --filter "label=com.docker.compose.project=blog_home" \
+      --filter "label=com.docker.compose.service=${service}" 2>/dev/null | head -n 1 || true
+  )"
+  if [[ -z "${container_id}" ]]; then
+    return 0
+  fi
+
+  docker inspect --format '{{.Config.Image}}' "${container_id}" 2>/dev/null | tr -d '\r' | head -n 1 || true
+}
+
+ensure_backend_runtime_image_env_key() {
+  local key="$1"
+  local service="$2"
+  local value legacy_value container_value
+  value="$(trim_quotes "$(env_value "${key}")")"
+  if [[ -n "${value}" ]]; then
+    require_digest_image_value "${key}" "${value}"
+    return 0
+  fi
+
+  legacy_value="$(trim_quotes "$(env_value "BACK_IMAGE")")"
+  if [[ -n "${legacy_value}" ]]; then
+    require_digest_image_value "BACK_IMAGE" "${legacy_value}"
+    ensure_compose_env_work_file
+    upsert_env_key "${key}" "${legacy_value}"
+    log "auto-filled ${key} from legacy BACK_IMAGE for compose preflight"
+    return 0
+  fi
+
+  container_value="$(container_image_for_service_any_state "${service}" || true)"
+  if [[ -n "${container_value}" ]]; then
+    require_digest_image_value "${key}" "${container_value}"
+    ensure_compose_env_work_file
+    upsert_env_key "${key}" "${container_value}"
+    log "auto-filled ${key} from ${service} container image for compose preflight"
+    return 0
+  fi
+
+  fail "required backend runtime image env key is missing: ${key}"
+}
+
 ensure_compose_image_env_defaults() {
   ensure_image_env_key_from_local_digest "CLOUDFLARED_IMAGE" "cloudflare/cloudflared:latest"
   ensure_image_env_key_from_local_digest "AUTOHEAL_IMAGE" "willfarrell/autoheal:1.2.0"
@@ -202,6 +248,11 @@ ensure_compose_image_env_defaults() {
   ensure_image_env_key_from_local_digest "DB_IMAGE" "jangka512/pgj:latest"
   ensure_image_env_key_from_local_digest "REDIS_IMAGE" "redis:7-alpine"
   ensure_image_env_key_from_local_digest "MINIO_IMAGE" "minio/minio:latest"
+  ensure_backend_runtime_image_env_key "BACK_BLUE_IMAGE" "back_blue"
+  ensure_backend_runtime_image_env_key "BACK_GREEN_IMAGE" "back_green"
+  ensure_backend_runtime_image_env_key "BACK_READ_IMAGE" "back_read"
+  ensure_backend_runtime_image_env_key "BACK_ADMIN_IMAGE" "back_admin"
+  ensure_backend_runtime_image_env_key "BACK_WORKER_IMAGE" "back_worker"
 }
 
 log() {

--- a/deploy/homeserver/docker-compose.prod.yml
+++ b/deploy/homeserver/docker-compose.prod.yml
@@ -162,7 +162,7 @@ services:
       start_period: 20s
 
   back_blue:
-    image: ${BACK_IMAGE:?BACK_IMAGE is required (sha-pinned; latest forbidden)}
+    image: ${BACK_BLUE_IMAGE:?BACK_BLUE_IMAGE is required (sha-pinned; latest forbidden)}
     restart: unless-stopped
     mem_limit: ${BACK_MEM_LIMIT:-512m}
     mem_reservation: ${BACK_MEM_RESERVATION:-256m}
@@ -195,7 +195,7 @@ services:
           - back-blue
 
   back_green:
-    image: ${BACK_IMAGE:?BACK_IMAGE is required (sha-pinned; latest forbidden)}
+    image: ${BACK_GREEN_IMAGE:?BACK_GREEN_IMAGE is required (sha-pinned; latest forbidden)}
     restart: unless-stopped
     mem_limit: ${BACK_MEM_LIMIT:-512m}
     mem_reservation: ${BACK_MEM_RESERVATION:-256m}
@@ -227,7 +227,7 @@ services:
 
   back_read:
     profiles: ["runtime-split"]
-    image: ${BACK_IMAGE:?BACK_IMAGE is required (sha-pinned; latest forbidden)}
+    image: ${BACK_READ_IMAGE:?BACK_READ_IMAGE is required (sha-pinned; latest forbidden)}
     restart: unless-stopped
     mem_limit: ${BACK_READ_MEM_LIMIT:-640m}
     mem_reservation: ${BACK_READ_MEM_RESERVATION:-320m}
@@ -259,7 +259,7 @@ services:
 
   back_admin:
     profiles: ["runtime-split"]
-    image: ${BACK_IMAGE:?BACK_IMAGE is required (sha-pinned; latest forbidden)}
+    image: ${BACK_ADMIN_IMAGE:?BACK_ADMIN_IMAGE is required (sha-pinned; latest forbidden)}
     restart: unless-stopped
     mem_limit: ${BACK_ADMIN_MEM_LIMIT:-512m}
     mem_reservation: ${BACK_ADMIN_MEM_RESERVATION:-256m}
@@ -290,7 +290,7 @@ services:
           - back-admin
 
   back_worker:
-    image: ${BACK_IMAGE:?BACK_IMAGE is required (sha-pinned; latest forbidden)}
+    image: ${BACK_WORKER_IMAGE:?BACK_WORKER_IMAGE is required (sha-pinned; latest forbidden)}
     restart: unless-stopped
     mem_limit: ${BACK_WORKER_MEM_LIMIT:-768m}
     mem_reservation: ${BACK_WORKER_MEM_RESERVATION:-768m}

--- a/deploy/homeserver/pgroonga_precheck.sh
+++ b/deploy/homeserver/pgroonga_precheck.sh
@@ -11,7 +11,12 @@ ENV_FILE="${SCRIPT_DIR}/.env.prod"
 TARGET_DB_NAME="unknown"
 
 compose() {
-  BACK_IMAGE="${BACK_IMAGE}" docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" "$@"
+  BACK_BLUE_IMAGE="${BACK_IMAGE}" \
+    BACK_GREEN_IMAGE="${BACK_IMAGE}" \
+    BACK_READ_IMAGE="${BACK_IMAGE}" \
+    BACK_ADMIN_IMAGE="${BACK_IMAGE}" \
+    BACK_WORKER_IMAGE="${BACK_IMAGE}" \
+    docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" "$@"
 }
 
 env_value() {

--- a/deploy/homeserver/post_precheck_env_guard.sh
+++ b/deploy/homeserver/post_precheck_env_guard.sh
@@ -54,7 +54,7 @@ require_digest_image_value() {
   local value="$2"
 
   if [[ -z "${value}" ]]; then
-    post_precheck_env_fail "${code_prefix}_missing" "BACK_IMAGE is empty"
+    post_precheck_env_fail "${code_prefix}_missing" "STAGED_BACK_IMAGE is empty"
   fi
   if [[ "${value}" == *":latest" || "${value}" == *":latest@"* ]]; then
     post_precheck_env_fail "${code_prefix}_latest_forbidden" "latest tag is forbidden value=${value}"
@@ -69,7 +69,6 @@ main() {
   local enabled_value
   local api_key_value
   local api_key_present="false"
-  local persisted_back_image
 
   if [[ ! -f "${ENV_FILE}" ]]; then
     post_precheck_env_fail "env_file_missing" "missing env file=${ENV_FILE}"
@@ -94,13 +93,7 @@ main() {
   fi
 
   echo "[POST_PRECHECK_ENV] checkpoint=after_ai_summary_guard"
-  echo "[POST_PRECHECK_ENV] checkpoint=before_back_image_persist target=${staged_back_image}"
-
-  upsert_env_key "BACK_IMAGE" "${staged_back_image}"
-  persisted_back_image="$(trim_quotes "$(env_value "BACK_IMAGE")")"
-  require_digest_image_value "persisted_back_image" "${persisted_back_image}"
-
-  echo "[POST_PRECHECK_ENV] checkpoint=after_back_image_persist image=${persisted_back_image}"
+  echo "[POST_PRECHECK_ENV] checkpoint=staged_back_image_validated image=${staged_back_image}"
   echo "[POST_PRECHECK_ENV] passed"
 }
 

--- a/deploy/homeserver/recover.sh
+++ b/deploy/homeserver/recover.sh
@@ -61,61 +61,94 @@ container_image_for_service_any_state() {
   docker inspect --format '{{.Config.Image}}' "${container_id}" 2>/dev/null | tr -d '\r' | head -n 1 || true
 }
 
-repair_back_image_if_missing() {
-  local value repaired_value state_backend
-  value="$(trim_quotes "$(env_value "BACK_IMAGE")")"
+backend_image_key() {
+  local service="$1"
+  case "${service}" in
+    back_blue) echo "BACK_BLUE_IMAGE" ;;
+    back_green) echo "BACK_GREEN_IMAGE" ;;
+    back_read) echo "BACK_READ_IMAGE" ;;
+    back_admin) echo "BACK_ADMIN_IMAGE" ;;
+    back_worker) echo "BACK_WORKER_IMAGE" ;;
+    *)
+      echo "unknown backend runtime service: ${service}" >&2
+      return 1
+      ;;
+  esac
+}
+
+require_digest_image_value() {
+  local key="$1"
+  local value="$2"
+  if [[ -z "${value}" ]]; then
+    echo "${key} is empty in ${ENV_FILE}. refusing recover to avoid latest rollback." >&2
+    exit 1
+  fi
+  if [[ "${value}" == *":latest" || "${value}" == *":latest@"* ]]; then
+    echo "${key} latest is forbidden in ${ENV_FILE}: ${value}" >&2
+    exit 1
+  fi
+  if [[ ! "${value}" =~ ^[^[:space:]@]+@sha256:[a-fA-F0-9]{64}$ ]]; then
+    echo "${key} must include sha256 digest in ${ENV_FILE}: ${value}" >&2
+    exit 1
+  fi
+}
+
+repair_runtime_back_image_if_missing() {
+  local service="$1"
+  local fallback="$2"
+  local key value repaired_value legacy_value
+  key="$(backend_image_key "${service}")"
+  value="$(trim_quotes "$(env_value "${key}")")"
   if [[ -n "${value}" ]]; then
-    echo "recover BACK_IMAGE preserved: ${value}"
+    echo "recover ${key} preserved: ${value}"
+    require_digest_image_value "${key}" "${value}"
     return 0
   fi
 
-  state_backend="$(cat "${SCRIPT_DIR}/.active_backend" 2>/dev/null || true)"
-  if [[ "${state_backend}" == "back_blue" || "${state_backend}" == "back_green" ]]; then
-    repaired_value="$(container_image_for_service_any_state "${state_backend}" || true)"
-    if [[ -n "${repaired_value}" ]]; then
-      echo "recover BACK_IMAGE repair source=state_backend_container backend=${state_backend} image=${repaired_value}"
+  repaired_value="$(container_image_for_service_any_state "${service}" || true)"
+  if [[ -n "${repaired_value}" ]]; then
+    echo "recover ${key} repair source=${service}_container image=${repaired_value}"
+  fi
+
+  if [[ -z "${repaired_value}" ]]; then
+    legacy_value="$(trim_quotes "$(env_value "BACK_IMAGE")")"
+    if [[ -n "${legacy_value}" ]]; then
+      repaired_value="${legacy_value}"
+      echo "recover ${key} repair source=legacy_BACK_IMAGE image=${repaired_value}"
     fi
   fi
 
   if [[ -z "${repaired_value}" ]]; then
-    for backend in back_blue back_green; do
-      repaired_value="$(container_image_for_service_any_state "${backend}" || true)"
-      if [[ -n "${repaired_value}" ]]; then
-        echo "recover BACK_IMAGE repair source=${backend}_container image=${repaired_value}"
-        break
-      fi
-    done
+    repaired_value="${fallback}"
+    echo "recover ${key} repair source=fallback image=${repaired_value}"
   fi
 
-  if [[ -z "${repaired_value}" ]]; then
-    echo "BACK_IMAGE is empty in ${ENV_FILE} and no repair source is available." >&2
-    exit 1
-  fi
-
-  upsert_env_key "BACK_IMAGE" "${repaired_value}"
-  echo "recover repaired missing BACK_IMAGE=${repaired_value}"
+  require_digest_image_value "${key}" "${repaired_value}"
+  upsert_env_key "${key}" "${repaired_value}"
+  echo "recover repaired missing ${key}=${repaired_value}"
 }
 
 require_back_image() {
-  local value
-  repair_back_image_if_missing
-  value="$(trim_quotes "$(env_value "BACK_IMAGE")")"
+  local state_backend fallback_image
+  state_backend="$(cat "${SCRIPT_DIR}/.active_backend" 2>/dev/null || true)"
+  if [[ "${state_backend}" != "back_blue" && "${state_backend}" != "back_green" ]]; then
+    state_backend="back_blue"
+  fi
 
-  if [[ -z "${value}" ]]; then
-    echo "BACK_IMAGE is empty in ${ENV_FILE}. refusing recover to avoid latest rollback." >&2
-    exit 1
+  fallback_image="$(container_image_for_service_any_state "${state_backend}" || true)"
+  if [[ -z "${fallback_image}" ]]; then
+    fallback_image="$(trim_quotes "$(env_value "BACK_IMAGE")")"
   fi
-  if [[ "${value}" == *":latest" ]]; then
-    echo "BACK_IMAGE latest is forbidden in ${ENV_FILE}: ${value}" >&2
-    exit 1
-  fi
-  if [[ "${value}" != *@sha256:* && "${value}" != *:* ]]; then
-    echo "BACK_IMAGE must include tag or digest in ${ENV_FILE}: ${value}" >&2
+  if [[ -z "${fallback_image}" ]]; then
+    echo "backend image is empty in ${ENV_FILE} and no repair source is available." >&2
     exit 1
   fi
 
-  BACK_IMAGE="${value}"
-  export BACK_IMAGE
+  repair_runtime_back_image_if_missing "back_blue" "${fallback_image}"
+  repair_runtime_back_image_if_missing "back_green" "${fallback_image}"
+  repair_runtime_back_image_if_missing "back_read" "${fallback_image}"
+  repair_runtime_back_image_if_missing "back_admin" "${fallback_image}"
+  repair_runtime_back_image_if_missing "back_worker" "${fallback_image}"
 }
 
 section() {

--- a/deploy/homeserver/rollback_last_deploy.sh
+++ b/deploy/homeserver/rollback_last_deploy.sh
@@ -237,41 +237,118 @@ container_image_for_service_any_state() {
   docker inspect --format '{{.Config.Image}}' "${container_id}" 2>/dev/null | tr -d '\r' | head -n 1 || true
 }
 
-repair_back_image_if_missing() {
-  local current_value repaired_value metadata_image
-  current_value="$(trim_quotes "$(env_value "BACK_IMAGE")")"
+backend_image_key() {
+  local service="$1"
+  case "${service}" in
+    back_blue) echo "BACK_BLUE_IMAGE" ;;
+    back_green) echo "BACK_GREEN_IMAGE" ;;
+    back_read) echo "BACK_READ_IMAGE" ;;
+    back_admin) echo "BACK_ADMIN_IMAGE" ;;
+    back_worker) echo "BACK_WORKER_IMAGE" ;;
+    *)
+      echo "unknown backend runtime service: ${service}" >&2
+      return 1
+      ;;
+  esac
+}
+
+backup_image_key_for_service() {
+  local service="$1"
+  case "${service}" in
+    back_blue) echo "back_blue_image" ;;
+    back_green) echo "back_green_image" ;;
+    back_read) echo "back_read_image" ;;
+    back_admin) echo "back_admin_image" ;;
+    back_worker) echo "back_worker_image" ;;
+    *) return 1 ;;
+  esac
+}
+
+require_digest_image_value() {
+  local key="$1"
+  local value="$2"
+  if [[ -z "${value}" ]]; then
+    echo "required image value is missing: ${key}" >&2
+    return 1
+  fi
+  if [[ "${value}" == *":latest" || "${value}" == *":latest@"* ]]; then
+    echo "latest tag is not allowed for ${key}: ${value}" >&2
+    return 1
+  fi
+  if [[ ! "${value}" =~ ^[^[:space:]@]+@sha256:[a-fA-F0-9]{64}$ ]]; then
+    echo "image must be pinned by sha256 digest for ${key}: ${value}" >&2
+    return 1
+  fi
+}
+
+repair_runtime_back_image_if_missing() {
+  local service="$1"
+  local fallback="$2"
+  local key metadata_key current_value repaired_value metadata_image legacy_image
+  key="$(backend_image_key "${service}")"
+  current_value="$(trim_quotes "$(env_value "${key}")")"
   if [[ -n "${current_value}" ]]; then
-    echo "rollback BACK_IMAGE preserved: ${current_value}"
+    require_digest_image_value "${key}" "${current_value}"
+    echo "rollback ${key} preserved: ${current_value}"
     return 0
   fi
 
-  metadata_image="$(trim_quotes "$(backup_metadata_value "active_backend_image")")"
+  metadata_key="$(backup_image_key_for_service "${service}" || true)"
+  if [[ -n "${metadata_key}" ]]; then
+    metadata_image="$(trim_quotes "$(backup_metadata_value "${metadata_key}")")"
+  fi
+  if [[ -z "${metadata_image}" && "${service}" == "${target_backend:-}" ]]; then
+    metadata_image="$(trim_quotes "$(backup_metadata_value "active_backend_image")")"
+  fi
   if [[ -n "${metadata_image}" ]]; then
     repaired_value="${metadata_image}"
-    echo "rollback BACK_IMAGE repair source=backup_metadata image=${repaired_value}"
+    echo "rollback ${key} repair source=backup_metadata image=${repaired_value}"
   fi
 
-  if [[ -z "${repaired_value}" && -n "${target_backend:-}" ]]; then
-    repaired_value="$(container_image_for_service_any_state "${target_backend}" || true)"
+  if [[ -z "${repaired_value}" ]]; then
+    repaired_value="$(container_image_for_service_any_state "${service}" || true)"
     if [[ -n "${repaired_value}" ]]; then
-      echo "rollback BACK_IMAGE repair source=target_backend_container backend=${target_backend} image=${repaired_value}"
-    fi
-  fi
-
-  if [[ -z "${repaired_value}" && -n "${inactive_backend:-}" ]]; then
-    repaired_value="$(container_image_for_service_any_state "${inactive_backend}" || true)"
-    if [[ -n "${repaired_value}" ]]; then
-      echo "rollback BACK_IMAGE repair source=inactive_backend_container backend=${inactive_backend} image=${repaired_value}"
+      echo "rollback ${key} repair source=${service}_container image=${repaired_value}"
     fi
   fi
 
   if [[ -z "${repaired_value}" ]]; then
-    echo "rollback failed: BACK_IMAGE missing in restored env and no repair source available" >&2
+    legacy_image="$(trim_quotes "$(env_value "BACK_IMAGE")")"
+    if [[ -n "${legacy_image}" ]]; then
+      repaired_value="${legacy_image}"
+      echo "rollback ${key} repair source=legacy_BACK_IMAGE image=${repaired_value}"
+    fi
+  fi
+
+  if [[ -z "${repaired_value}" ]]; then
+    repaired_value="${fallback}"
+    echo "rollback ${key} repair source=fallback image=${repaired_value}"
+  fi
+
+  require_digest_image_value "${key}" "${repaired_value}"
+  upsert_env_key "${key}" "${repaired_value}"
+  echo "rollback repaired missing ${key}=${repaired_value}"
+}
+
+repair_back_image_if_missing() {
+  local target_image
+  target_image="$(container_image_for_service_any_state "${target_backend}" || true)"
+  if [[ -z "${target_image}" ]]; then
+    target_image="$(trim_quotes "$(backup_metadata_value "active_backend_image")")"
+  fi
+  if [[ -z "${target_image}" ]]; then
+    target_image="$(trim_quotes "$(env_value "BACK_IMAGE")")"
+  fi
+  if [[ -z "${target_image}" ]]; then
+    echo "rollback failed: no target backend image repair source available" >&2
     return 1
   fi
 
-  upsert_env_key "BACK_IMAGE" "${repaired_value}"
-  echo "rollback repaired missing BACK_IMAGE=${repaired_value}"
+  repair_runtime_back_image_if_missing "${target_backend}" "${target_image}"
+  repair_runtime_back_image_if_missing "${inactive_backend}" "${target_image}"
+  repair_runtime_back_image_if_missing "back_read" "${target_image}"
+  repair_runtime_back_image_if_missing "back_admin" "${target_image}"
+  repair_runtime_back_image_if_missing "back_worker" "${target_image}"
 }
 
 resolve_prod_db_name() {
@@ -568,7 +645,7 @@ trap 'release_deploy_lock' EXIT INT TERM
 
 echo "rollback from backup: ${BACKUP_DIR}"
 
-for file in .env.prod docker-compose.prod.yml .active_backend; do
+for file in .env.prod docker-compose.prod.yml .active_backend .backend-release-state.env; do
   if [[ -f "${BACKUP_DIR}/${file}" ]]; then
     cp "${BACKUP_DIR}/${file}" "${SCRIPT_DIR}/${file}"
   fi

--- a/deploy/homeserver/steady_state_guard.sh
+++ b/deploy/homeserver/steady_state_guard.sh
@@ -346,15 +346,24 @@ enforce_single_backend_rule() {
 }
 
 check_active_backend_image() {
-  local expected_image active_backend running_image
-  expected_image="$(trim_quotes "$(env_value "BACK_IMAGE")")"
-  if [[ -z "${expected_image}" ]]; then
-    log "FAIL missing BACK_IMAGE in ${ENV_FILE}"
+  local expected_image active_backend running_image image_key
+  if ! active_backend="$(resolve_active_backend)"; then
+    log "FAIL active backend unresolved for image drift check"
     return 1
   fi
 
-  if ! active_backend="$(resolve_active_backend)"; then
-    log "FAIL active backend unresolved for image drift check"
+  case "${active_backend}" in
+    back_blue) image_key="BACK_BLUE_IMAGE" ;;
+    back_green) image_key="BACK_GREEN_IMAGE" ;;
+    *)
+      log "FAIL unsupported active backend for image drift check active=${active_backend}"
+      return 1
+      ;;
+  esac
+
+  expected_image="$(trim_quotes "$(env_value "${image_key}")")"
+  if [[ -z "${expected_image}" ]]; then
+    log "FAIL missing ${image_key} in ${ENV_FILE}"
     return 1
   fi
 

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -223,26 +223,37 @@ test("home-server-source contract accepts a complete deployment env without BACK
   assert.equal(result.ok, true, result.errors.map((error) => error.message).join("\n"))
 })
 
-test("home-server runtime requires BACK_IMAGE by digest", async () => {
+const runtimeBackendImageKeys = [
+  "BACK_BLUE_IMAGE",
+  "BACK_GREEN_IMAGE",
+  "BACK_READ_IMAGE",
+  "BACK_ADMIN_IMAGE",
+  "BACK_WORKER_IMAGE",
+]
+
+const runtimeBackendImageEnv = runtimeBackendImageKeys
+  .map((key, index) => `${key}=ghcr.io/aquilaxk/aquila-blog-back@sha256:${"789ab"[index].repeat(64)}`)
+  .join("\n")
+
+test("home-server runtime requires runtime-specific backend images by digest", async () => {
   const { loadContract, validateEnvText } = await import("../env/validate-env.mjs")
   const contract = loadContract(contractPath)
-  const digestBackImage = `ghcr.io/aquilaxk/aquila-blog-back@sha256:${"a".repeat(64)}`
   const tagBackImage = `ghcr.io/aquilaxk/aquila-blog-back:sha-${"b".repeat(40)}`
 
   const digestResult = validateEnvText({
     contract,
     target: "home-server-runtime",
-    text: `${baseHomeServerEnv}\nBACK_IMAGE=${digestBackImage}\n`,
+    text: `${baseHomeServerEnv}\n${runtimeBackendImageEnv}\n`,
   })
   assert.equal(digestResult.ok, true, digestResult.errors.map((error) => `${error.key}: ${error.message}`).join("\n"))
 
   const tagResult = validateEnvText({
     contract,
     target: "home-server-runtime",
-    text: `${baseHomeServerEnv}\nBACK_IMAGE=${tagBackImage}\n`,
+    text: `${baseHomeServerEnv}\n${runtimeBackendImageEnv}\nBACK_BLUE_IMAGE=${tagBackImage}\n`,
   })
   assert.equal(tagResult.ok, false)
-  assert(tagResult.errors.some((error) => error.key === "BACK_IMAGE" && error.message.includes("digest")))
+  assert(tagResult.errors.some((error) => error.key === "BACK_BLUE_IMAGE" && error.message.includes("digest")))
 })
 
 test("runtime service images are env-backed in compose and digest-validated by contract", async () => {
@@ -257,8 +268,11 @@ test("runtime service images are env-backed in compose and digest-validated by c
     "PROMTAIL_IMAGE",
     "NODE_RUNTIME_IMAGE",
     "REDIS_IMAGE",
+    ...runtimeBackendImageKeys,
   ]
-  const contractKeys = new Set(targetKeyNames(loadContract(contractPath), "home-server-source"))
+  const contract = loadContract(contractPath)
+  const sourceContractKeys = new Set(targetKeyNames(contract, "home-server-source"))
+  const runtimeContractKeys = new Set(targetKeyNames(contract, "home-server-runtime"))
   const compose = readFileSync(composePath, "utf8")
   const literalImageLines = compose
     .split(/\r?\n/)
@@ -267,8 +281,14 @@ test("runtime service images are env-backed in compose and digest-validated by c
     .filter(({ value }) => !value.includes("${"))
 
   assert.deepEqual(literalImageLines, [])
+  assert(!compose.includes("${BACK_IMAGE"))
+  assert(!sourceContractKeys.has("BACK_IMAGE"))
+  assert(!runtimeContractKeys.has("BACK_IMAGE"))
   for (const key of runtimeImageKeys) {
-    assert(contractKeys.has(key), `${key} must be covered by the home-server-source contract`)
+    assert(
+      sourceContractKeys.has(key) || runtimeContractKeys.has(key),
+      `${key} must be covered by the env contract`,
+    )
   }
 
   const sourceWithoutAutofilledRuntimeImages = baseHomeServerEnv
@@ -861,9 +881,41 @@ test("deploy workflow uses immutable backend digest and does not push latest", (
   assert.match(workflow, /id: build_backend_image/)
   assert.match(workflow, /echo "back_image_ref=\$\{IMAGE_NAME\}@\$\{BACKEND_IMAGE_DIGEST\}"/)
   assert.match(workflow, /HOME_BACK_IMAGE: \$\{\{ needs\.buildAndPush\.outputs\.back_image_ref \}\}/)
+  assert.match(workflow, /ACTIVE_BACKEND_IMAGE_KEY=/)
+  assert.match(workflow, /EXPECTED_BACK_IMAGE="\$\(extract_env_value "\$\{ACTIVE_BACKEND_IMAGE_KEY\}"\)"/)
+  assert.doesNotMatch(workflow, /EXPECTED_BACK_IMAGE="\$\(extract_env_value "BACK_IMAGE"\)"/)
   assert.doesNotMatch(workflow, /image_latest_ref/)
   assert.doesNotMatch(workflow, /\$\{\{ needs\.calculateTag\.outputs\.image_latest_ref \}\}/)
   assert.doesNotMatch(workflow, /IMAGE_LATEST_REF="\$\{IMAGE_NAME\}:latest"/)
+})
+
+test("homeserver deploy preserves runtime-specific backend image release state", () => {
+  const deployScript = readFileSync(deployScriptPath, "utf8")
+  const backupScript = readFileSync(deployBackupScriptPath, "utf8")
+  const rollbackScript = readFileSync(path.join(repoRoot, "deploy/homeserver/rollback_last_deploy.sh"), "utf8")
+  const recoverScript = readFileSync(path.join(repoRoot, "deploy/homeserver/recover.sh"), "utf8")
+  const statusScript = readFileSync(path.join(repoRoot, "deploy/homeserver/check_deploy_status.sh"), "utf8")
+  const steadyStateGuard = readFileSync(path.join(repoRoot, "deploy/homeserver/steady_state_guard.sh"), "utf8")
+
+  for (const key of runtimeBackendImageKeys) {
+    assert.match(deployScript, new RegExp(`${key}`))
+    assert.match(rollbackScript, new RegExp(`${key}`))
+    assert.match(recoverScript, new RegExp(`${key}`))
+  }
+
+  assert.match(deployScript, /RELEASE_STATE_FILE="\$\{SCRIPT_DIR\}\/\.backend-release-state\.env"/)
+  assert.match(deployScript, /write_backend_release_state "\$\{next_backend\}" "\$\{active_backend\}"/)
+  assert.match(deployScript, /prepare_runtime_backend_images "\$\{active_backend\}" "\$\{next_backend\}" "\$\{STAGED_BACK_IMAGE\}"/)
+  assert.match(backupScript, /\.backend-release-state\.env/)
+  assert.match(backupScript, /back_blue_image=/)
+  assert.match(backupScript, /back_green_image=/)
+  assert.match(rollbackScript, /backup_image_key_for_service\(\)/)
+  assert.match(rollbackScript, /repair_runtime_back_image_if_missing "\$\{target_backend\}"/)
+  assert.match(recoverScript, /repair_runtime_back_image_if_missing "back_worker"/)
+  assert.match(statusScript, /ACTIVE_BACKEND_IMAGE_KEY="BACK_BLUE_IMAGE"/)
+  assert.match(steadyStateGuard, /image_key="BACK_BLUE_IMAGE"/)
+  assert.doesNotMatch(statusScript, /env_value "BACK_IMAGE"/)
+  assert.doesNotMatch(steadyStateGuard, /env_value "BACK_IMAGE"/)
 })
 
 test("deploy workflow requires pinned known_hosts and private GHCR credentials", () => {

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -904,6 +904,9 @@ test("homeserver deploy preserves runtime-specific backend image release state",
   }
 
   assert.match(deployScript, /RELEASE_STATE_FILE="\$\{SCRIPT_DIR\}\/\.backend-release-state\.env"/)
+  assert.match(deployScript, /awk -F= -v key="\$\{key\}"/)
+  assert.match(deployScript, /value = substr\(\$0, index\(\$0, "="\) \+ 1\)/)
+  assert.match(deployScript, /END \{\s*print value\s*\}/)
   assert.match(deployScript, /write_backend_release_state "\$\{next_backend\}" "\$\{active_backend\}"/)
   assert.match(deployScript, /prepare_runtime_backend_images "\$\{active_backend\}" "\$\{next_backend\}" "\$\{STAGED_BACK_IMAGE\}"/)
   assert.match(backupScript, /\.backend-release-state\.env/)
@@ -913,7 +916,9 @@ test("homeserver deploy preserves runtime-specific backend image release state",
   assert.match(rollbackScript, /repair_runtime_back_image_if_missing "\$\{target_backend\}"/)
   assert.match(recoverScript, /repair_runtime_back_image_if_missing "back_worker"/)
   assert.match(statusScript, /ACTIVE_BACKEND_IMAGE_KEY="BACK_BLUE_IMAGE"/)
+  assert.match(statusScript, /ACTIVE_BACKEND_IMAGE_KEY="BACK_GREEN_IMAGE"/)
   assert.match(steadyStateGuard, /image_key="BACK_BLUE_IMAGE"/)
+  assert.match(steadyStateGuard, /image_key="BACK_GREEN_IMAGE"/)
   assert.doesNotMatch(statusScript, /env_value "BACK_IMAGE"/)
   assert.doesNotMatch(steadyStateGuard, /env_value "BACK_IMAGE"/)
 })


### PR DESCRIPTION
## 관련 이슈

close #929

## 작업 배경

- homeserver compose와 deploy runtime이 `BACK_IMAGE` 하나를 공유해 blue/green/read/admin/worker가 각각 어떤 digest로 떠야 하는지 독립 상태를 보존하지 못했다.
- 새 image B 배포 중 이전 color/runtime을 재기동하면 원래 image A가 아니라 최신 `BACK_IMAGE=B`로 재생성될 수 있어 rollback 증거가 약했다.

## 작업 내용

- `docker-compose.prod.yml`의 backend runtime image 변수를 `BACK_BLUE_IMAGE`, `BACK_GREEN_IMAGE`, `BACK_READ_IMAGE`, `BACK_ADMIN_IMAGE`, `BACK_WORKER_IMAGE`로 분리했다.
- `home-server-runtime` env contract가 5개 backend runtime image digest를 요구하도록 바꿨고, source env에는 backend image를 계속 요구하지 않는다.
- blue/green deploy가 `STAGED_BACK_IMAGE`를 next color와 read/admin/worker runtime에만 반영하고, active color image는 기존 env/container/legacy value에서 보존하도록 했다.
- `.backend-release-state.env`에 active/previous backend와 runtime별 image digest를 기록하고, backup/rollback/recover/status/steady-state guard가 split digest 기준으로 동작하도록 맞췄다.
- 기존 서버의 legacy `BACK_IMAGE`만 있는 상태에서도 external backup compose preflight가 split key를 임시 보정해 첫 migration deploy가 fail-closed/repair 가능한 경로를 갖게 했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/test/env-contract.test.mjs`: 36 passed, 2회 연속 통과
  - `bash tools/test/verify-deploy-workflow-classification.sh`: 2회 연속 통과
  - modified homeserver shell scripts `bash -n`: 통과
  - `docker compose --env-file <split image env> -f docker-compose.prod.yml config --quiet`: 통과
  - split image key 누락 compose config: `BACK_GREEN_IMAGE is required` fail-closed 확인
  - `git diff --check`: 2회 연속 통과
  - PR CI on `aae4fc002dff6f4a47d56bd5b164ab2069a66bd9`: frontend-ci/backend-ci/backend-dependency-check/CodeQL/Vercel/CodeRabbit 통과
  - CodeRabbit review: actionable 1건 원 thread 답글 및 resolved 처리, re-review 확인

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| runtime image env contract | local darwin / Node test runner | `node --test tools/test/env-contract.test.mjs` | command output: 36 passed | 2회 연속 통과 |
| deploy workflow static guard | local darwin / bash | `bash tools/test/verify-deploy-workflow-classification.sh` | command output: no stderr/stdout failure | 2회 연속 통과 |
| homeserver shell syntax | local darwin / bash | `bash -n` on modified deploy scripts | command output: no syntax errors | 통과 |
| compose split image config | local darwin / Docker Compose v5.1.0 | temp env에 5개 split image digest를 넣고 `docker compose config --quiet` | command output: no errors | 통과 |
| compose missing split image guard | local darwin / Docker Compose v5.1.0 | split image digest를 빼고 `docker compose config --quiet` | command output: `BACK_GREEN_IMAGE is required` | fail-closed 확인 |
| whitespace/diff hygiene | local darwin / git | `git diff --check` | command output: no whitespace errors | 2회 연속 통과 |
| PR CI | GitHub Actions / Vercel | `gh pr checks 974 --watch --interval 20` | backend-ci: https://github.com/AquilaXk/aquila-blog/actions/runs/27883080006/job/82513851290, backend-dependency-check: https://github.com/AquilaXk/aquila-blog/actions/runs/27883079963/job/82513851273, codeql java-kotlin: https://github.com/AquilaXk/aquila-blog/actions/runs/27883079963/job/82513851306, codeql javascript-typescript: https://github.com/AquilaXk/aquila-blog/actions/runs/27883079963/job/82513851268, Vercel: https://vercel.com/aquilaxks-projects/aquila-blog/D8RbLy1YVv1CJYv8gadXWK3mLPQf | 모두 통과 |
| CodeRabbit review thread | GitHub PR review | GraphQL reviewThreads 확인 및 원 thread 답글 | https://github.com/AquilaXk/aquila-blog/pull/974#discussion_r3447468729, re-review: https://github.com/AquilaXk/aquila-blog/pull/974#discussion_r3447469561 | actionable 1건 수정/답글/resolved, 추가 finding 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `deploy/homeserver/docker-compose.prod.yml`의 runtime별 backend image 변수 분리
  - `deploy/homeserver/blue_green_deploy.sh`의 `prepare_runtime_backend_images`와 `.backend-release-state.env` 기록
  - CodeRabbit 지적 반영: `runtime_backend_image_value()`는 중복 env key 중 마지막 값을 읽어 compose 적용값과 release state 기준을 맞춘다.
  - `rollback_last_deploy.sh`, `recover.sh`, `create_external_backup.sh`의 legacy `BACK_IMAGE` migration fallback

## 리스크

- 첫 배포에서는 기존 `.env.prod`에 split key가 없을 수 있으므로 legacy `BACK_IMAGE` 또는 기존 container image로 split key를 복구한다.
- `back_read`, `back_admin`, `back_worker`는 staged image로 갱신되며, active blue/green color만 이전 digest를 보존한다.
- 이 PR은 homeserver deploy/rollback 경로를 바꾸므로 merge 후 main CI/Security와 `Deploy to Home Server` workflow_run success를 확인해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (N/A: CodeRabbit 실제 review 완료)
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
