### PR TITLE
[Hotfix] 런타임 image migration repair 보정

### DIFF
--- a/deploy/homeserver/create_external_backup.sh
+++ b/deploy/homeserver/create_external_backup.sh
@@ -96,6 +96,13 @@ trim_quotes() {
   printf '%s' "${value}"
 }
 
+is_digest_image_value() {
+  local value="$1"
+  [[ -n "${value}" ]] || return 1
+  [[ "${value}" != *":latest" && "${value}" != *":latest@"* ]] || return 1
+  [[ "${value}" =~ @sha256:[a-fA-F0-9]{64}$ ]]
+}
+
 require_digest_image_value() {
   local key="$1"
   local value="$2"
@@ -210,17 +217,21 @@ ensure_backend_runtime_image_env_key() {
   local value legacy_value container_value
   value="$(trim_quotes "$(env_value "${key}")")"
   if [[ -n "${value}" ]]; then
-    require_digest_image_value "${key}" "${value}"
-    return 0
+    if is_digest_image_value "${value}"; then
+      return 0
+    fi
+    log "invalid ${key} runtime image env value will try fallback sources before backup compose evaluation"
   fi
 
   legacy_value="$(trim_quotes "$(env_value "BACK_IMAGE")")"
   if [[ -n "${legacy_value}" ]]; then
-    require_digest_image_value "BACK_IMAGE" "${legacy_value}"
-    ensure_compose_env_work_file
-    upsert_env_key "${key}" "${legacy_value}"
-    log "auto-filled ${key} from legacy BACK_IMAGE for compose preflight"
-    return 0
+    if is_digest_image_value "${legacy_value}"; then
+      ensure_compose_env_work_file
+      upsert_env_key "${key}" "${legacy_value}"
+      log "auto-filled ${key} from legacy BACK_IMAGE for compose preflight"
+      return 0
+    fi
+    log "invalid legacy BACK_IMAGE value will try container image before backup compose evaluation"
   fi
 
   container_value="$(container_image_for_service_any_state "${service}" || true)"

--- a/deploy/homeserver/create_external_backup.sh
+++ b/deploy/homeserver/create_external_backup.sh
@@ -149,6 +149,15 @@ upsert_env_key() {
   fi
 }
 
+stage_backend_runtime_image_env_key() {
+  local key="$1"
+  local image="$2"
+  require_digest_image_value "${key}" "${image}"
+  ensure_compose_env_work_file
+  upsert_env_key "${key}" "${image}"
+  export "${key}=${image}"
+}
+
 resolve_local_repo_digest() {
   local image_ref="$1"
   docker image inspect --format '{{index .RepoDigests 0}}' "${image_ref}" 2>/dev/null | head -n 1 | tr -d '\r'
@@ -218,6 +227,7 @@ ensure_backend_runtime_image_env_key() {
   value="$(trim_quotes "$(env_value "${key}")")"
   if [[ -n "${value}" ]]; then
     if is_digest_image_value "${value}"; then
+      stage_backend_runtime_image_env_key "${key}" "${value}"
       return 0
     fi
     log "invalid ${key} runtime image env value will try fallback sources before backup compose evaluation"
@@ -226,8 +236,7 @@ ensure_backend_runtime_image_env_key() {
   legacy_value="$(trim_quotes "$(env_value "BACK_IMAGE")")"
   if [[ -n "${legacy_value}" ]]; then
     if is_digest_image_value "${legacy_value}"; then
-      ensure_compose_env_work_file
-      upsert_env_key "${key}" "${legacy_value}"
+      stage_backend_runtime_image_env_key "${key}" "${legacy_value}"
       log "auto-filled ${key} from legacy BACK_IMAGE for compose preflight"
       return 0
     fi
@@ -236,9 +245,7 @@ ensure_backend_runtime_image_env_key() {
 
   container_value="$(container_image_for_service_any_state "${service}" || true)"
   if [[ -n "${container_value}" ]]; then
-    require_digest_image_value "${key}" "${container_value}"
-    ensure_compose_env_work_file
-    upsert_env_key "${key}" "${container_value}"
+    stage_backend_runtime_image_env_key "${key}" "${container_value}"
     log "auto-filled ${key} from ${service} container image for compose preflight"
     return 0
   fi

--- a/deploy/homeserver/rollback_last_deploy.sh
+++ b/deploy/homeserver/rollback_last_deploy.sh
@@ -285,6 +285,9 @@ repair_runtime_back_image_if_missing() {
   local service="$1"
   local fallback="$2"
   local key metadata_key current_value repaired_value metadata_image legacy_image
+  repaired_value=""
+  metadata_image=""
+  legacy_image=""
   key="$(backend_image_key "${service}")"
   current_value="$(trim_quotes "$(env_value "${key}")")"
   if [[ -n "${current_value}" ]]; then

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -892,6 +892,7 @@ test("deploy workflow uses immutable backend digest and does not push latest", (
 test("homeserver deploy preserves runtime-specific backend image release state", () => {
   const deployScript = readFileSync(deployScriptPath, "utf8")
   const backupScript = readFileSync(deployBackupScriptPath, "utf8")
+  const externalBackupScript = readFileSync(externalBackupScriptPath, "utf8")
   const rollbackScript = readFileSync(path.join(repoRoot, "deploy/homeserver/rollback_last_deploy.sh"), "utf8")
   const recoverScript = readFileSync(path.join(repoRoot, "deploy/homeserver/recover.sh"), "utf8")
   const statusScript = readFileSync(path.join(repoRoot, "deploy/homeserver/check_deploy_status.sh"), "utf8")
@@ -907,12 +908,22 @@ test("homeserver deploy preserves runtime-specific backend image release state",
   assert.match(deployScript, /awk -F= -v key="\$\{key\}"/)
   assert.match(deployScript, /value = substr\(\$0, index\(\$0, "="\) \+ 1\)/)
   assert.match(deployScript, /END \{\s*print value\s*\}/)
+  assert.match(externalBackupScript, /is_digest_image_value\(\)/)
+  assert.doesNotMatch(
+    externalBackupScript,
+    /if \[\[ -n "\$\{value\}" \]\]; then\s*require_digest_image_value "\$\{key\}" "\$\{value\}"\s*return 0\s*fi/s,
+  )
+  assert.match(
+    externalBackupScript,
+    /invalid .*runtime image env .*will try fallback sources before backup compose evaluation/,
+  )
   assert.match(deployScript, /write_backend_release_state "\$\{next_backend\}" "\$\{active_backend\}"/)
   assert.match(deployScript, /prepare_runtime_backend_images "\$\{active_backend\}" "\$\{next_backend\}" "\$\{STAGED_BACK_IMAGE\}"/)
   assert.match(backupScript, /\.backend-release-state\.env/)
   assert.match(backupScript, /back_blue_image=/)
   assert.match(backupScript, /back_green_image=/)
   assert.match(rollbackScript, /backup_image_key_for_service\(\)/)
+  assert.match(rollbackScript, /local key metadata_key current_value repaired_value metadata_image legacy_image\s+repaired_value=""/)
   assert.match(rollbackScript, /repair_runtime_back_image_if_missing "\$\{target_backend\}"/)
   assert.match(recoverScript, /repair_runtime_back_image_if_missing "back_worker"/)
   assert.match(statusScript, /ACTIVE_BACKEND_IMAGE_KEY="BACK_BLUE_IMAGE"/)

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -909,6 +909,8 @@ test("homeserver deploy preserves runtime-specific backend image release state",
   assert.match(deployScript, /value = substr\(\$0, index\(\$0, "="\) \+ 1\)/)
   assert.match(deployScript, /END \{\s*print value\s*\}/)
   assert.match(externalBackupScript, /is_digest_image_value\(\)/)
+  assert.match(externalBackupScript, /stage_backend_runtime_image_env_key\(\)/)
+  assert.match(externalBackupScript, /export "\$\{key\}=\$\{image\}"/)
   assert.doesNotMatch(
     externalBackupScript,
     /if \[\[ -n "\$\{value\}" \]\]; then\s*require_digest_image_value "\$\{key\}" "\$\{value\}"\s*return 0\s*fi/s,
@@ -917,6 +919,8 @@ test("homeserver deploy preserves runtime-specific backend image release state",
     externalBackupScript,
     /invalid .*runtime image env .*will try fallback sources before backup compose evaluation/,
   )
+  assert.match(externalBackupScript, /stage_backend_runtime_image_env_key "\$\{key\}" "\$\{legacy_value\}"/)
+  assert.match(externalBackupScript, /stage_backend_runtime_image_env_key "\$\{key\}" "\$\{container_value\}"/)
   assert.match(deployScript, /write_backend_release_state "\$\{next_backend\}" "\$\{active_backend\}"/)
   assert.match(deployScript, /prepare_runtime_backend_images "\$\{active_backend\}" "\$\{next_backend\}" "\$\{STAGED_BACK_IMAGE\}"/)
   assert.match(backupScript, /\.backend-release-state\.env/)


### PR DESCRIPTION
## 관련 이슈

close #929

## 작업 배경

- PR #974 merge 후 `Deploy to Home Server` run `27883416076`의 `blueGreenDeploy` 단계가 실패했다.
- 실패 시그니처는 external backup preflight의 `image env key must include sha256 digest before backup compose evaluation`와 rollback 경로의 `repaired_value: unbound variable`이다.
- 기존 서버/secret에 non-digest split runtime image key가 남아 있으면 fallback source를 확인하기 전에 fail했고, 그 뒤 rollback repair 함수도 `set -u`에서 초기화되지 않은 변수를 참조했다.

## 작업 내용

- `create_external_backup.sh`에 digest image 판별 helper를 추가하고, invalid split runtime image key는 즉시 fail하지 않고 legacy `BACK_IMAGE` 또는 기존 container digest fallback을 시도하도록 바꿨다.
- legacy `BACK_IMAGE`가 invalid인 경우에도 container image fallback을 계속 시도한다.
- fallback으로 확정한 runtime image digest를 temp compose env file과 process environment에 동시에 반영해 Docker Compose interpolation이 stale exported 값을 보지 않게 했다.
- `rollback_last_deploy.sh`의 runtime image repair 지역 변수를 빈 문자열로 초기화해 `set -u` rollback 실패를 막았다.
- `env-contract` 테스트에 external backup invalid key fallback, compose env override 보정, rollback repair nounset-safe 계약을 추가했다.

## 검증

- 실행한 명령과 결과:
  - RED: `node --test tools/test/env-contract.test.mjs` 실패 확인 (`is_digest_image_value()` 계약 미충족)
  - GREEN: `node --test tools/test/env-contract.test.mjs`: 36 passed, 2회 연속 통과
  - `bash -n deploy/homeserver/create_external_backup.sh`: 통과
  - `bash -n deploy/homeserver/rollback_last_deploy.sh`: 통과
  - `bash tools/test/verify-deploy-workflow-classification.sh`: 통과
  - `git diff --check`: 통과
  - PR CI:
    - frontend-ci: https://github.com/AquilaXk/aquila-blog/actions/runs/27883849481/job/82515841646 통과
    - backend-ci: https://github.com/AquilaXk/aquila-blog/actions/runs/27883849493/job/82515841654 통과
    - backend-dependency-check: https://github.com/AquilaXk/aquila-blog/actions/runs/27883849476/job/82515841652 통과
    - CodeQL java-kotlin: https://github.com/AquilaXk/aquila-blog/actions/runs/27883849476/job/82515841673 통과
    - CodeQL javascript-typescript: https://github.com/AquilaXk/aquila-blog/actions/runs/27883849476/job/82515841656 통과
    - Vercel preview: https://vercel.com/aquilaxks-projects/aquila-blog/8UqsSQrRQKXfXkFzPp3p6SWLmhRc 통과
  - CodeRabbit: credit/rate limit으로 실제 review 미수행
  - Codex CLI fallback review:
    - 최초 review: https://github.com/AquilaXk/aquila-blog/pull/975#pullrequestreview-4538820350
    - inline finding 해결 답글: https://github.com/AquilaXk/aquila-blog/pull/975#discussion_r3447503281
    - 재검토 review: https://github.com/AquilaXk/aquila-blog/pull/975#pullrequestreview-4538827250
  - post-merge main:
    - CI: https://github.com/AquilaXk/aquila-blog/actions/runs/27884025579 통과
    - Security: https://github.com/AquilaXk/aquila-blog/actions/runs/27884025554 통과
    - Deploy to Home Server: https://github.com/AquilaXk/aquila-blog/actions/runs/27884191277 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 실패 재현 | local darwin / Node test runner | production patch 전 `node --test tools/test/env-contract.test.mjs` | failing test: `homeserver deploy preserves runtime-specific backend image release state`, `is_digest_image_value()` 미검출 | RED 확인 |
| hotfix 계약 테스트 | local darwin / Node test runner | `node --test tools/test/env-contract.test.mjs` | command output: 36 passed | 2회 연속 통과 |
| shell syntax | local darwin / bash | `bash -n deploy/homeserver/create_external_backup.sh`, `bash -n deploy/homeserver/rollback_last_deploy.sh` | command output: no syntax errors | 통과 |
| deploy workflow guard | local darwin / bash | `bash tools/test/verify-deploy-workflow-classification.sh` | command output: no stderr/stdout failure | 통과 |
| whitespace/diff hygiene | local darwin / git | `git diff --check` | command output: no whitespace errors | 통과 |
| PR CI | GitHub Actions / Vercel | `gh pr checks 975 --watch --interval 20` | frontend/backend/security/Vercel checks | 통과 |
| 코드리뷰 | CodeRabbit / Codex CLI fallback | GitHub PR review 확인 | CodeRabbit 미수행, Codex fallback 1건 지적 후 fix commit과 thread 답글, 재검토 0건 | 통과 |
| post-merge CI/CD | GitHub Actions | main merge commit `db3d492fbaa294c24c28596b960396b6c0964fca` run 확인 | CI/Security/Deploy to Home Server | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `create_external_backup.sh`의 invalid split runtime image key fallback 순서
  - `stage_backend_runtime_image_env_key()`가 temp env file과 process environment를 함께 갱신하는지
  - `rollback_last_deploy.sh`의 `repaired_value`/metadata/legacy 초기화
  - post-merge 실패 run: https://github.com/AquilaXk/aquila-blog/actions/runs/27883416076

## 리스크

- invalid split key가 있어도 fallback source가 모두 없거나 digest가 아니면 기존처럼 fail-closed 된다.
- 이 PR은 post-merge deploy 실패 복구용 hotfix이므로 merge 후 main CI/Security와 `Deploy to Home Server` 재실행 성공 확인이 필요하다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
