### PR TITLE
[CI] blue-green cutover 후 burn-in rollback 유지

### DIFF
--- a/deploy/homeserver/blue_green_deploy.sh
+++ b/deploy/homeserver/blue_green_deploy.sh
@@ -28,6 +28,11 @@ PREWARM_RETRIES="${PREWARM_RETRIES:-2}"
 PREWARM_BACKOFF_SECONDS="${PREWARM_BACKOFF_SECONDS:-1}"
 PREWARM_PUBLIC_ROUTE_POST_LIMIT="${PREWARM_PUBLIC_ROUTE_POST_LIMIT:-5}"
 STREAM_DRAIN_SECONDS="${STREAM_DRAIN_SECONDS:-15}"
+BLUE_GREEN_BURN_IN_PROFILE="${BLUE_GREEN_BURN_IN_PROFILE:-standard}"
+BLUE_GREEN_BURN_IN_SECONDS="${BLUE_GREEN_BURN_IN_SECONDS:-}"
+BLUE_GREEN_BURN_IN_STANDARD_SECONDS="${BLUE_GREEN_BURN_IN_STANDARD_SECONDS:-180}"
+BLUE_GREEN_BURN_IN_HIGH_RISK_SECONDS="${BLUE_GREEN_BURN_IN_HIGH_RISK_SECONDS:-600}"
+BLUE_GREEN_BURN_IN_PROBE_INTERVAL_SECONDS="${BLUE_GREEN_BURN_IN_PROBE_INTERVAL_SECONDS:-15}"
 RUNTIME_SPLIT_ENABLED="${RUNTIME_SPLIT_ENABLED:-false}"
 RUNTIME_SPLIT_STAGE="${RUNTIME_SPLIT_STAGE:-A}"
 AUTO_MEMORY_TUNER_ENABLED="${AUTO_MEMORY_TUNER_ENABLED:-true}"
@@ -107,6 +112,9 @@ normalize_non_negative_int() {
 RUNTIME_SPLIT_ENABLED="$(normalize_bool "${RUNTIME_SPLIT_ENABLED}")"
 RUNTIME_SPLIT_STAGE="$(normalize_runtime_split_stage "${RUNTIME_SPLIT_STAGE}")"
 STREAM_DRAIN_SECONDS="$(normalize_non_negative_int "${STREAM_DRAIN_SECONDS}" "15")"
+BLUE_GREEN_BURN_IN_STANDARD_SECONDS="$(normalize_non_negative_int "${BLUE_GREEN_BURN_IN_STANDARD_SECONDS}" "180")"
+BLUE_GREEN_BURN_IN_HIGH_RISK_SECONDS="$(normalize_non_negative_int "${BLUE_GREEN_BURN_IN_HIGH_RISK_SECONDS}" "600")"
+BLUE_GREEN_BURN_IN_PROBE_INTERVAL_SECONDS="$(normalize_positive_int "${BLUE_GREEN_BURN_IN_PROBE_INTERVAL_SECONDS}" "15")"
 AUTO_MEMORY_TUNER_ENABLED="$(normalize_bool "${AUTO_MEMORY_TUNER_ENABLED}")"
 AUTO_MEMORY_TUNER_MAX_BUDGET_MB="$(normalize_positive_int "${AUTO_MEMORY_TUNER_MAX_BUDGET_MB}" "4096")"
 AUTO_MEMORY_TUNER_SYSTEM_RESERVE_MB="$(normalize_positive_int "${AUTO_MEMORY_TUNER_SYSTEM_RESERVE_MB}" "2048")"
@@ -1965,6 +1973,135 @@ ensure_steady_state_guard() {
   "${installer}"
 }
 
+resolve_blue_green_burn_in_seconds() {
+  local profile
+  profile="$(echo "${BLUE_GREEN_BURN_IN_PROFILE}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')"
+
+  local default_seconds
+  case "${profile}" in
+    disabled|off|none)
+      default_seconds="0"
+      ;;
+    high|high-risk)
+      default_seconds="${BLUE_GREEN_BURN_IN_HIGH_RISK_SECONDS}"
+      ;;
+    *)
+      default_seconds="${BLUE_GREEN_BURN_IN_STANDARD_SECONDS}"
+      ;;
+  esac
+
+  if [[ -n "${BLUE_GREEN_BURN_IN_SECONDS}" ]]; then
+    normalize_non_negative_int "${BLUE_GREEN_BURN_IN_SECONDS}" "${default_seconds}"
+    return
+  fi
+
+  echo "${default_seconds}"
+}
+
+rollback_caddy_route_only() {
+  local previous_backend="$1"
+  local candidate_backend="$2"
+  local api_domain="$3"
+
+  echo "burn-in failed; keeping previous backend active: previous=${previous_backend}, candidate=${candidate_backend}" >&2
+
+  if ! is_backend_running "${previous_backend}"; then
+    echo "burn-in rollback blocked: previous backend is not running: ${previous_backend}" >&2
+    return 1
+  fi
+
+  if ! check_backend_dns_from_caddy "${previous_backend}"; then
+    echo "burn-in rollback blocked: DNS not resolvable for ${previous_backend}" >&2
+    return 1
+  fi
+
+  if ! check_backend_health "${previous_backend}"; then
+    echo "burn-in rollback blocked: healthcheck failed for ${previous_backend}" >&2
+    return 1
+  fi
+
+  switch_caddy_upstream "${previous_backend}"
+
+  if ! verify_caddy_route "${previous_backend}" "${api_domain}"; then
+    echo "burn-in rollback failed: caddy route verify failed" >&2
+    return 1
+  fi
+
+  echo "${previous_backend}" > "${STATE_FILE}"
+  write_backend_release_state "${previous_backend}" "${candidate_backend}"
+  compose stop "${candidate_backend}" || true
+  echo "burn-in rollback ok: route=${previous_backend}, stopped_candidate=${candidate_backend}"
+  return 0
+}
+
+run_blue_green_burn_in() {
+  local candidate_backend="$1"
+  local previous_backend="$2"
+  local api_domain="$3"
+  local duration_seconds
+  duration_seconds="$(resolve_blue_green_burn_in_seconds)"
+
+  if (( duration_seconds == 0 )); then
+    echo "burn-in skipped: profile=${BLUE_GREEN_BURN_IN_PROFILE}, duration_seconds=0"
+    return 0
+  fi
+
+  echo "burn-in start: candidate=${candidate_backend}, previous=${previous_backend}, duration_seconds=${duration_seconds}, interval_seconds=${BLUE_GREEN_BURN_IN_PROBE_INTERVAL_SECONDS}"
+
+  local elapsed=0
+  local wait_seconds
+  local post_code
+  while (( elapsed < duration_seconds )); do
+    wait_seconds="${BLUE_GREEN_BURN_IN_PROBE_INTERVAL_SECONDS}"
+    if (( elapsed + wait_seconds > duration_seconds )); then
+      wait_seconds=$((duration_seconds - elapsed))
+    fi
+
+    if (( wait_seconds > 0 )); then
+      sleep "${wait_seconds}"
+      elapsed=$((elapsed + wait_seconds))
+    fi
+
+    if ! check_backend_health "${candidate_backend}"; then
+      rollback_caddy_route_only "${previous_backend}" "${candidate_backend}" "${api_domain}" || true
+      return 1
+    fi
+
+    if ! verify_caddy_route "${candidate_backend}" "${api_domain}"; then
+      rollback_caddy_route_only "${previous_backend}" "${candidate_backend}" "${api_domain}" || true
+      return 1
+    fi
+
+    post_code="$(probe_caddy_http_code "${api_domain}")"
+    if ! is_healthy_http_code "${post_code}"; then
+      echo "burn-in public route verify failed (status=${post_code:-none})" >&2
+      rollback_caddy_route_only "${previous_backend}" "${candidate_backend}" "${api_domain}" || true
+      return 1
+    fi
+
+    if ! check_notification_sse_route "${api_domain}"; then
+      echo "burn-in notification sse verify failed" >&2
+      rollback_caddy_route_only "${previous_backend}" "${candidate_backend}" "${api_domain}" || true
+      return 1
+    fi
+
+    if ! check_cloudflared_runtime "${api_domain}"; then
+      echo "burn-in cloudflared runtime verify failed" >&2
+      rollback_caddy_route_only "${previous_backend}" "${candidate_backend}" "${api_domain}" || true
+      return 1
+    fi
+
+    if ! check_grafana_embed_origin_route; then
+      echo "burn-in grafana origin auth-proxy route verify failed" >&2
+      rollback_caddy_route_only "${previous_backend}" "${candidate_backend}" "${api_domain}" || true
+      return 1
+    fi
+  done
+
+  echo "burn-in ok: candidate=${candidate_backend}, previous=${previous_backend}, duration_seconds=${duration_seconds}"
+  return 0
+}
+
 rollback_to_backend() {
   local rollback_backend="$1"
   local api_domain="$2"
@@ -2094,6 +2231,11 @@ if ! check_notification_sse_route "${api_domain}"; then
   exit 1
 fi
 
+echo "post-switch phase: blue/green burn-in"
+if ! run_blue_green_burn_in "${next_backend}" "${active_backend}" "${api_domain}"; then
+  exit 1
+fi
+
 echo "${next_backend}" > "${STATE_FILE}"
 write_backend_release_state "${next_backend}" "${active_backend}"
 drain_and_stop_backend_if_running "${active_backend}"
@@ -2121,5 +2263,5 @@ warn_grafana_embed_public_route
 echo "post-switch phase: public read prewarm"
 prewarm_public_read_cache "${api_domain}"
 
-echo "post-switch verify ok (status=${post_code}); inactive backend stopped"
+echo "post-switch verify ok (status=${post_code}); burn-in complete; inactive backend stopped"
 compose ps

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -1035,6 +1035,27 @@ test("blue-green deploy pauses autoheal while staging a candidate backend", () =
   )
 })
 
+test("blue-green deploy keeps old backend running during burn-in rollback window", () => {
+  const deployScript = readFileSync(deployScriptPath, "utf8")
+  const burnInIndex = deployScript.indexOf('run_blue_green_burn_in "${next_backend}" "${active_backend}" "${api_domain}"')
+  const stopOldIndex = deployScript.indexOf('drain_and_stop_backend_if_running "${active_backend}"')
+  const stateWriteIndex = deployScript.indexOf('write_backend_release_state "${next_backend}" "${active_backend}"')
+
+  assert.match(deployScript, /BLUE_GREEN_BURN_IN_STANDARD_SECONDS=/)
+  assert.match(deployScript, /BLUE_GREEN_BURN_IN_HIGH_RISK_SECONDS=/)
+  assert.match(deployScript, /resolve_blue_green_burn_in_seconds\(\)/)
+  assert.match(deployScript, /rollback_caddy_route_only\(\)/)
+  assert.match(deployScript, /run_blue_green_burn_in\(\)/)
+  assert.match(deployScript, /rollback_caddy_route_only "\$\{previous_backend\}" "\$\{candidate_backend\}" "\$\{api_domain\}"/)
+  assert.match(deployScript, /burn-in failed; keeping previous backend active/)
+  assert.match(deployScript, /burn-in ok: candidate=.*previous=.*duration_seconds=/)
+  assert(burnInIndex > 0, "deploy script must run burn-in after candidate cutover")
+  assert(stopOldIndex > 0, "deploy script must still stop old backend after burn-in")
+  assert(stateWriteIndex > 0, "deploy script must write release state after burn-in")
+  assert(burnInIndex < stopOldIndex, "old backend must not stop before burn-in completes")
+  assert(burnInIndex < stateWriteIndex, "release state must not mark candidate active before burn-in completes")
+})
+
 test("runtime-split memory tuner keeps backend color startup headroom", () => {
   const deployScript = readFileSync(deployScriptPath, "utf8")
   const splitAllocator = deployScript.slice(


### PR DESCRIPTION
## 관련 이슈

close #930

## 작업 배경

- `blue_green_deploy.sh`는 Caddy upstream을 candidate로 전환한 뒤 route/SSE 검증이 통과하면 기존 active backend를 바로 drain/stop했다.
- 이 흐름에서는 cutover 몇 분 뒤 드러나는 endpoint 500, memory/session 회귀를 기존 backend로 route-only rollback할 시간이 부족하다.

## 작업 내용

- blue/green cutover 후 `run_blue_green_burn_in` 단계를 추가해 burn-in 동안 기존 backend를 running 상태로 유지했다.
- 기본 정책은 standard 180초, high-risk 600초이며 `BLUE_GREEN_BURN_IN_PROFILE`, `BLUE_GREEN_BURN_IN_SECONDS`, `BLUE_GREEN_BURN_IN_PROBE_INTERVAL_SECONDS`로 조정할 수 있게 했다.
- burn-in 중 candidate health, Caddy route, public route, notification SSE, cloudflared runtime, Grafana auth-proxy route 검증이 실패하면 `rollback_caddy_route_only`로 Caddy upstream을 기존 backend로 되돌리고 candidate를 중지한다.
- candidate active state 기록과 기존 backend drain/stop은 burn-in 성공 이후에만 실행되도록 순서를 바꿨다.
- env-contract static test에 burn-in rollback window 계약을 추가했다.

## 검증

- 실행한 명령과 결과:
  - RED: `node --test tools/test/env-contract.test.mjs` 실패 확인 (`BLUE_GREEN_BURN_IN_STANDARD_SECONDS` 계약 미충족)
  - GREEN: `node --test tools/test/env-contract.test.mjs`: 37 passed, 2회 연속 통과
  - `bash -n deploy/homeserver/blue_green_deploy.sh`: 통과
  - `bash tools/test/verify-deploy-workflow-classification.sh`: 통과
  - `git diff --check`: 통과
  - PR CI:
    - frontend-ci: https://github.com/AquilaXk/aquila-blog/actions/runs/27884474044/job/82517480082 통과
    - backend-ci: https://github.com/AquilaXk/aquila-blog/actions/runs/27884474040/job/82517479944 통과
    - backend-dependency-check: https://github.com/AquilaXk/aquila-blog/actions/runs/27884474032/job/82517480152 통과
    - CodeQL java-kotlin: https://github.com/AquilaXk/aquila-blog/actions/runs/27884474032/job/82517480159 통과
    - CodeQL javascript-typescript: https://github.com/AquilaXk/aquila-blog/actions/runs/27884474032/job/82517480162 통과
    - Vercel preview: https://vercel.com/aquilaxks-projects/aquila-blog/58TPniECBrwxisKewzMJvsaypane 통과
  - CodeRabbit: https://github.com/AquilaXk/aquila-blog/pull/976#issuecomment-4760044800 실제 review 완료, actionable comments 없음
  - post-merge main:
    - CI: https://github.com/AquilaXk/aquila-blog/actions/runs/27884652527 통과
    - Security: https://github.com/AquilaXk/aquila-blog/actions/runs/27884652520 통과
    - Deploy to Home Server: https://github.com/AquilaXk/aquila-blog/actions/runs/27884825406 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `run_blue_green_burn_in()`의 검증 항목과 실패 시 `rollback_caddy_route_only()` 호출
  - `write_backend_release_state "${next_backend}" "${active_backend}"`와 `drain_and_stop_backend_if_running "${active_backend}"`가 burn-in 이후로 이동한 점
  - 기본 180초 burn-in으로 deploy 시간이 늘어나는 점

## 리스크

- 기본 deploy 시간이 약 3분 증가한다.
- burn-in 중 route rollback 자체가 실패하면 기존처럼 deploy를 fail-closed로 종료한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
