### PR TITLE
[CI] Grafana 관리자 비밀번호 fallback 제거

### DIFF
--- a/deploy/env/env.contract.json
+++ b/deploy/env/env.contract.json
@@ -53,7 +53,13 @@
         { "name": "PUBLIC_EDGE_PROBE_TIMEOUT_MS", "kind": "integer", "required": false },
         { "name": "PUBLIC_EDGE_PROBE_BASE_URL", "kind": "https-url", "required": false },
         { "name": "GRAFANA_ADMIN_USER" },
-        { "name": "GRAFANA_ADMIN_PASSWORD", "secret": true, "minLength": 8 },
+        {
+          "name": "GRAFANA_ADMIN_PASSWORD",
+          "secret": true,
+          "minLength": 16,
+          "forbiddenValues": ["change_me_grafana_password"],
+          "mustDifferFrom": "GRAFANA_ADMIN_USER"
+        },
         { "name": "GRAFANA_ROOT_URL", "kind": "https-url" },
         { "name": "PROD___SPRING__DATASOURCE__USERNAME" },
         { "name": "PROD___SPRING__FLYWAY__USER", "required": false },

--- a/deploy/homeserver/docker-compose.prod.yml
+++ b/deploy/homeserver/docker-compose.prod.yml
@@ -63,7 +63,7 @@ services:
     restart: unless-stopped
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-change_me_grafana_password}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required}
       GF_SECURITY_ALLOW_EMBEDDING: "true"
       GF_AUTH_ANONYMOUS_ENABLED: "false"
       GF_AUTH_PROXY_ENABLED: "true"

--- a/tools/env/validate-env.mjs
+++ b/tools/env/validate-env.mjs
@@ -126,7 +126,6 @@ export const validateEnvText = ({ contract, target, text }) => {
 
     if (definition.placeholderForbidden !== false && placeholder.test(value)) {
       errors.push(safeError(definition.name, "must not contain placeholder value"))
-      continue
     }
 
     if (definition.allowedValues && !definition.allowedValues.includes(value)) {
@@ -135,6 +134,14 @@ export const validateEnvText = ({ contract, target, text }) => {
 
     if (definition.minLength && value.length < definition.minLength) {
       errors.push(safeError(definition.name, `must be at least ${definition.minLength} characters`))
+    }
+
+    if (definition.forbiddenValues?.includes(value)) {
+      errors.push(safeError(definition.name, "must not use forbidden value"))
+    }
+
+    if (definition.mustDifferFrom && value === valueOf(env, definition.mustDifferFrom)) {
+      errors.push(safeError(definition.name, `must differ from ${definition.mustDifferFrom}`))
     }
 
     const kindError = validateKind(definition, value)

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -223,6 +223,48 @@ test("home-server-source contract accepts a complete deployment env without BACK
   assert.equal(result.ok, true, result.errors.map((error) => error.message).join("\n"))
 })
 
+test("grafana admin password has no compose fallback and rejects weak contract values", async () => {
+  const { loadContract, validateEnvText } = await import("../env/validate-env.mjs")
+  const compose = readFileSync(composePath, "utf8")
+  const contract = loadContract(contractPath)
+  const assertGrafanaPasswordRejected = (text, expectedMessagePart) => {
+    const result = validateEnvText({
+      contract,
+      target: "home-server-source",
+      text,
+    })
+
+    assert.equal(result.ok, false)
+    assert(
+      result.errors.some(
+        (error) => error.key === "GRAFANA_ADMIN_PASSWORD" && error.message.includes(expectedMessagePart),
+      ),
+      result.errors.map((error) => `${error.key}: ${error.message}`).join("\n"),
+    )
+  }
+
+  assert.match(
+    compose,
+    /GF_SECURITY_ADMIN_PASSWORD:\s+\$\{GRAFANA_ADMIN_PASSWORD:\?GRAFANA_ADMIN_PASSWORD is required\}/,
+  )
+  assert(!compose.includes("change_me_grafana_password"))
+  assert(!compose.includes("${GRAFANA_ADMIN_PASSWORD:-"))
+  assertGrafanaPasswordRejected(
+    baseHomeServerEnv.replace("GRAFANA_ADMIN_PASSWORD=valid-grafana-password", "GRAFANA_ADMIN_PASSWORD=change_me_grafana_password"),
+    "forbidden value",
+  )
+  assertGrafanaPasswordRejected(
+    baseHomeServerEnv.replace("GRAFANA_ADMIN_PASSWORD=valid-grafana-password", "GRAFANA_ADMIN_PASSWORD=123456789012345"),
+    "at least 16 characters",
+  )
+  assertGrafanaPasswordRejected(
+    baseHomeServerEnv
+      .replace("GRAFANA_ADMIN_USER=admin", "GRAFANA_ADMIN_USER=grafana-operator")
+      .replace("GRAFANA_ADMIN_PASSWORD=valid-grafana-password", "GRAFANA_ADMIN_PASSWORD=grafana-operator"),
+    "must differ from GRAFANA_ADMIN_USER",
+  )
+})
+
 const runtimeBackendImageKeys = [
   "BACK_BLUE_IMAGE",
   "BACK_GREEN_IMAGE",


### PR DESCRIPTION
## 관련 이슈

close #933

## 작업 배경

- Grafana 관리자 비밀번호가 `GRAFANA_ADMIN_PASSWORD` 누락 시 `${GRAFANA_ADMIN_PASSWORD:-change_me_grafana_password}` fallback으로 평가될 수 있었다.
- 운영 환경에서 secret 누락이 compose/config 실패가 아니라 예측 가능한 관리자 비밀번호 기동으로 이어질 수 있었다.
- env contract가 기존에는 필수 여부와 8자 길이만 확인해 알려진 default, 15자 이하 값, username과 같은 값을 명시적으로 차단하지 않았다.

## 작업 내용

- `GF_SECURITY_ADMIN_PASSWORD` compose interpolation을 `${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required}`로 바꿔 누락/빈 값을 실패로 전환했다.
- `GRAFANA_ADMIN_PASSWORD` env contract를 강화했다.
  - 최소 길이 16자
  - `change_me_grafana_password` 금지
  - `GRAFANA_ADMIN_USER`와 같은 값 금지
- env validator에 `forbiddenValues`, `mustDifferFrom` 정책을 추가했다.
- Grafana admin password fallback 제거와 약한 값 차단을 `tools/test/env-contract.test.mjs` 회귀 테스트로 고정했다.

## 검증

- 실행한 명령과 결과:
  - RED: `node --test tools/test/env-contract.test.mjs` 실패 확인 (`GF_SECURITY_ADMIN_PASSWORD` fallback regex 불일치)
  - GREEN: `node --test tools/test/env-contract.test.mjs`: 39 passed, 2회 연속 통과
  - `node tools/env/validate-env.mjs --target home-server-runtime --file .codex/tmp/good-home-server.env`: validation ok
  - `docker compose --env-file .codex/tmp/good-home-server.env -f deploy/homeserver/docker-compose.prod.yml config --quiet`: 통과
  - `GRAFANA_ADMIN_PASSWORD= docker compose --env-file .codex/tmp/good-home-server.env -f deploy/homeserver/docker-compose.prod.yml config`: expected failure, `GRAFANA_ADMIN_PASSWORD is required`
  - `git diff --check`: 통과
  - PR CI: 최신 commit `340cb86d` 기준 모두 통과
  - CodeRabbit: rate limit/credit 부족으로 실제 리뷰 미실행 확인
  - Codex CLI fallback review: `Actionable comments posted: 0`
  - post-merge CI: main merge commit `940f2bf6` 기준 CI 성공
  - post-merge Security: main merge commit `940f2bf6` 기준 Security workflow 성공
  - post-merge CD: `Deploy to Home Server` run `27887319477` 실패. `blueGreenDeploy`의 `Validate HOME_SERVER_ENV contract` 단계에서 `GRAFANA_ADMIN_PASSWORD: must be at least 16 characters`로 fail-fast 확인

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| env contract RED | local macOS | `node --test tools/test/env-contract.test.mjs` | command output | 신규 Grafana 테스트 1개 실패 확인 |
| env contract GREEN | local macOS | `node --test tools/test/env-contract.test.mjs` | command output | 39 passed, 2회 연속 통과 |
| runtime env contract fixture | local macOS | `node tools/env/validate-env.mjs --target home-server-runtime --file .codex/tmp/good-home-server.env` | command output | validation ok |
| compose 정상 config | local macOS | `docker compose --env-file .codex/tmp/good-home-server.env -f deploy/homeserver/docker-compose.prod.yml config --quiet` | command output | 통과 |
| compose 누락 password config | local macOS | `GRAFANA_ADMIN_PASSWORD= docker compose --env-file .codex/tmp/good-home-server.env -f deploy/homeserver/docker-compose.prod.yml config` | command output | required variable 실패 확인 |
| diff whitespace | local macOS | `git diff --check` | command output | 통과 |
| PR CI | GitHub Actions/Vercel | `gh pr checks 979 --repo AquilaXk/aquila-blog --watch` | backend-ci https://github.com/AquilaXk/aquila-blog/actions/runs/27887037590/job/82523998330, frontend-ci https://github.com/AquilaXk/aquila-blog/actions/runs/27887037583/job/82523998383, Security https://github.com/AquilaXk/aquila-blog/actions/runs/27887037566 | 최신 commit 기준 모두 통과 |
| CodeRabbit 상태 | GitHub PR #979 | PR comment 확인 | https://github.com/AquilaXk/aquila-blog/pull/979#issuecomment-4760285698 | rate limit/credit 부족으로 실제 리뷰 미실행 |
| Codex CLI fallback review | GitHub PR #979 | 단일 PR review 게시 | https://github.com/AquilaXk/aquila-blog/pull/979#pullrequestreview-4538953901 | actionable 0개 |
| post-merge CI | GitHub Actions main | `gh run view 27887169959 --repo AquilaXk/aquila-blog` | https://github.com/AquilaXk/aquila-blog/actions/runs/27887169959 | 성공 |
| post-merge Security | GitHub Actions main | `gh run view 27887169917 --repo AquilaXk/aquila-blog` | https://github.com/AquilaXk/aquila-blog/actions/runs/27887169917 | 성공 |
| post-merge CD | GitHub Actions workflow_run | `gh run view 27887319477 --repo AquilaXk/aquila-blog --job 82524743075 --log` | https://github.com/AquilaXk/aquila-blog/actions/runs/27887319477/job/82524743075 | 실패: 운영 `HOME_SERVER_ENV`의 `GRAFANA_ADMIN_PASSWORD`가 16자 미만이라 contract validation에서 중단 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `deploy/homeserver/docker-compose.prod.yml`의 `GF_SECURITY_ADMIN_PASSWORD` interpolation
  - `deploy/env/env.contract.json`의 `GRAFANA_ADMIN_PASSWORD` 정책
  - `tools/env/validate-env.mjs`의 secret 값을 출력하지 않는 key-level validation 메시지

## 리스크

- 운영 `HOME_SERVER_ENV`의 `GRAFANA_ADMIN_PASSWORD`가 16자 미만이거나 `GRAFANA_ADMIN_USER`와 같으면 다음 배포에서 fail-fast 된다.
- `GRAFANA_ADMIN_USER` 자체는 기존 default `admin`을 유지한다. 이번 변경 범위는 관리자 password fallback 제거와 password strength contract 강화로 제한했다.
- 현재 main merge 후 CD가 실제로 fail-fast 되었으므로 운영 secret rotation 또는 `HOME_SERVER_ENV` secret 갱신 후 failed job rerun이 필요하다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
