### PR TITLE
[Test] 백업 restore drill 자동화

### DIFF
--- a/.github/workflows/backup-restore-drill.yml
+++ b/.github/workflows/backup-restore-drill.yml
@@ -1,0 +1,205 @@
+name: Backup Restore Drill
+
+on:
+  workflow_dispatch:
+    inputs:
+      backup_set_id:
+        description: "Backup set id in YYYYMMDD-HHMMSS format. Empty means latest daily PostgreSQL backup."
+        required: false
+        default: ""
+        type: string
+      backup_class:
+        description: "Backup class to restore."
+        required: true
+        default: "daily"
+        type: choice
+        options:
+          - daily
+          - weekly
+          - monthly
+      rpo_target_minutes:
+        description: "RPO target recorded in the drill artifact."
+        required: true
+        default: "1440"
+        type: string
+      rto_target_minutes:
+        description: "RTO target recorded in the drill artifact."
+        required: true
+        default: "120"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backup-restore-drill
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  restore-drill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Verify required secrets
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          HOME_SSH_USER: ${{ secrets.HOME_SSH_USER }}
+          HOME_APP_DIR: ${{ secrets.HOME_APP_DIR }}
+          HOME_HOST: ${{ secrets.HOME_TAILSCALE_HOST || secrets.HOME_TS_HOST || secrets.HOME_SSH_HOST || secrets.HOME_HOST }}
+          HOME_SSH_KEY: ${{ secrets.HOME_SSH_KEY || secrets.HOME_SSH_PRIVATE_KEY }}
+          HOME_KNOWN_HOSTS: ${{ secrets.HOME_KNOWN_HOSTS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          required=(
+            TS_OAUTH_CLIENT_ID
+            TS_OAUTH_SECRET
+            HOME_SSH_USER
+            HOME_APP_DIR
+            HOME_HOST
+            HOME_SSH_KEY
+            HOME_KNOWN_HOSTS
+          )
+
+          for key in "${required[@]}"; do
+            value="${!key:-}"
+            if [ -z "${value}" ]; then
+              echo "${key} missing" >&2
+              exit 1
+            fi
+            echo "${key} present"
+          done
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: ${{ vars.TS_OAUTH_TAGS || secrets.TS_OAUTH_TAGS || 'tag:ci' }}
+
+      - name: Configure SSH key
+        env:
+          HOME_SSH_KEY: ${{ secrets.HOME_SSH_KEY || secrets.HOME_SSH_PRIVATE_KEY }}
+          HOME_KNOWN_HOSTS: ${{ secrets.HOME_KNOWN_HOSTS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          SSH_DIR="${RUNNER_TEMP}/ssh"
+          rm -rf "${SSH_DIR}"
+          mkdir -p "${SSH_DIR}"
+          chmod 700 "${SSH_DIR}"
+          printf '%s\n' "${HOME_SSH_KEY}" > "${SSH_DIR}/home_key"
+          chmod 600 "${SSH_DIR}/home_key"
+          printf '%s\n' "${HOME_KNOWN_HOSTS}" > "${SSH_DIR}/known_hosts"
+          if [ ! -s "${SSH_DIR}/known_hosts" ]; then
+            echo "HOME_KNOWN_HOSTS is required for restore drill" >&2
+            exit 1
+          fi
+          chmod 600 "${SSH_DIR}/known_hosts"
+          echo "SSH_DIR=${SSH_DIR}" >> "${GITHUB_ENV}"
+
+      - name: Run restore drill on home server
+        env:
+          HOME_HOST: ${{ secrets.HOME_TAILSCALE_HOST || secrets.HOME_TS_HOST || secrets.HOME_SSH_HOST || secrets.HOME_HOST }}
+          HOME_SSH_USER: ${{ secrets.HOME_SSH_USER }}
+          HOME_SSH_PORT: ${{ secrets.HOME_SSH_PORT }}
+          HOME_APP_DIR: ${{ secrets.HOME_APP_DIR }}
+          BACKUP_SET_ID: ${{ inputs.backup_set_id }}
+          BACKUP_CLASS: ${{ inputs.backup_class }}
+          RPO_TARGET_MINUTES: ${{ inputs.rpo_target_minutes }}
+          RTO_TARGET_MINUTES: ${{ inputs.rto_target_minutes }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PORT="${HOME_SSH_PORT:-22}"
+          HOME_APP_DIR_B64="$(printf '%s' "${HOME_APP_DIR}" | base64 | tr -d '\n')"
+          LOCAL_ARTIFACT_DIR="${RUNNER_TEMP}/restore-drill-artifacts"
+          mkdir -p "${LOCAL_ARTIFACT_DIR}"
+
+          if [[ -n "${BACKUP_SET_ID}" && ! "${BACKUP_SET_ID}" =~ ^[0-9]{8}-[0-9]{6}$ ]]; then
+            echo "unsafe backup_set_id: ${BACKUP_SET_ID}" >&2
+            exit 1
+          fi
+          case "${BACKUP_CLASS}" in
+            daily|weekly|monthly) ;;
+            *)
+              echo "unsafe backup_class: ${BACKUP_CLASS}" >&2
+              exit 1
+              ;;
+          esac
+          if [[ ! "${RPO_TARGET_MINUTES}" =~ ^[0-9]+$ ]]; then
+            echo "unsafe rpo_target_minutes: ${RPO_TARGET_MINUTES}" >&2
+            exit 1
+          fi
+          if [[ ! "${RTO_TARGET_MINUTES}" =~ ^[0-9]+$ ]]; then
+            echo "unsafe rto_target_minutes: ${RTO_TARGET_MINUTES}" >&2
+            exit 1
+          fi
+
+          REMOTE_TMP_DIR="$(ssh -i "${SSH_DIR}/home_key" -o UserKnownHostsFile="${SSH_DIR}/known_hosts" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=15 -p "${PORT}" "${HOME_SSH_USER}@${HOME_HOST}" "umask 077 && mktemp -d /tmp/aquila-restore-drill.XXXXXX")"
+          case "${REMOTE_TMP_DIR}" in
+            /tmp/aquila-restore-drill.*) ;;
+            *)
+              echo "unexpected remote tmp dir: ${REMOTE_TMP_DIR}" >&2
+              exit 1
+              ;;
+          esac
+
+          cleanup_remote_tmp() {
+            ssh -i "${SSH_DIR}/home_key" -o UserKnownHostsFile="${SSH_DIR}/known_hosts" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=15 -p "${PORT}" "${HOME_SSH_USER}@${HOME_HOST}" "rm -rf -- ${REMOTE_TMP_DIR}" || true
+          }
+          trap cleanup_remote_tmp EXIT
+
+          scp -i "${SSH_DIR}/home_key" -o UserKnownHostsFile="${SSH_DIR}/known_hosts" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -P "${PORT}" \
+            deploy/homeserver/restore_external_backup_drill.sh \
+            "${HOME_SSH_USER}@${HOME_HOST}:${REMOTE_TMP_DIR}/"
+
+          ssh -i "${SSH_DIR}/home_key" -o UserKnownHostsFile="${SSH_DIR}/known_hosts" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=15 -p "${PORT}" "${HOME_SSH_USER}@${HOME_HOST}" \
+            "HOME_APP_DIR_B64='${HOME_APP_DIR_B64}' REMOTE_TMP_DIR='${REMOTE_TMP_DIR}' BACKUP_SET_ID='${BACKUP_SET_ID}' BACKUP_CLASS='${BACKUP_CLASS}' RPO_TARGET_MINUTES='${RPO_TARGET_MINUTES}' RTO_TARGET_MINUTES='${RTO_TARGET_MINUTES}' bash -s" <<'REMOTE'
+          set -euo pipefail
+
+          decode_b64() {
+            if printf '' | base64 --decode >/dev/null 2>&1; then
+              printf '%s' "$1" | base64 --decode
+            else
+              printf '%s' "$1" | base64 -d
+            fi
+          }
+
+          HOME_APP_DIR="$(decode_b64 "${HOME_APP_DIR_B64}")"
+          cd "${HOME_APP_DIR}"
+          chmod +x "${REMOTE_TMP_DIR}/restore_external_backup_drill.sh"
+          AQUILA_RESTORE_DRILL_BACKUP_SET_ID="${BACKUP_SET_ID}" \
+            AQUILA_RESTORE_DRILL_CLASS="${BACKUP_CLASS}" \
+            AQUILA_RESTORE_DRILL_RPO_TARGET_MINUTES="${RPO_TARGET_MINUTES}" \
+            AQUILA_RESTORE_DRILL_RTO_TARGET_MINUTES="${RTO_TARGET_MINUTES}" \
+            AQUILA_RESTORE_DRILL_ARTIFACT_DIR="${REMOTE_TMP_DIR}/artifacts" \
+            "${REMOTE_TMP_DIR}/restore_external_backup_drill.sh"
+REMOTE
+
+          scp -r -i "${SSH_DIR}/home_key" -o UserKnownHostsFile="${SSH_DIR}/known_hosts" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -P "${PORT}" \
+            "${HOME_SSH_USER}@${HOME_HOST}:${REMOTE_TMP_DIR}/artifacts/." \
+            "${LOCAL_ARTIFACT_DIR}/"
+
+          {
+            echo "## Backup Restore Drill"
+            cat "${LOCAL_ARTIFACT_DIR}/restore-drill-summary.md"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload restore drill artifacts
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: backup-restore-drill
+          path: ${{ runner.temp }}/restore-drill-artifacts
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/backup-restore-drill.yml
+++ b/.github/workflows/backup-restore-drill.yml
@@ -185,7 +185,7 @@ jobs:
             AQUILA_RESTORE_DRILL_RTO_TARGET_MINUTES="${RTO_TARGET_MINUTES}" \
             AQUILA_RESTORE_DRILL_ARTIFACT_DIR="${REMOTE_TMP_DIR}/artifacts" \
             "${REMOTE_TMP_DIR}/restore_external_backup_drill.sh"
-REMOTE
+          REMOTE
 
           scp -r -i "${SSH_DIR}/home_key" -o UserKnownHostsFile="${SSH_DIR}/known_hosts" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -P "${PORT}" \
             "${HOME_SSH_USER}@${HOME_HOST}:${REMOTE_TMP_DIR}/artifacts/." \

--- a/.github/workflows/backup-restore-drill.yml
+++ b/.github/workflows/backup-restore-drill.yml
@@ -160,7 +160,7 @@ jobs:
           }
           trap cleanup_remote_tmp EXIT
 
-          scp -i "${SSH_DIR}/home_key" -o UserKnownHostsFile="${SSH_DIR}/known_hosts" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -P "${PORT}" \
+          scp -i "${SSH_DIR}/home_key" -o UserKnownHostsFile="${SSH_DIR}/known_hosts" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=15 -P "${PORT}" \
             deploy/homeserver/restore_external_backup_drill.sh \
             "${HOME_SSH_USER}@${HOME_HOST}:${REMOTE_TMP_DIR}/"
 
@@ -187,7 +187,7 @@ jobs:
             "${REMOTE_TMP_DIR}/restore_external_backup_drill.sh"
           REMOTE
 
-          scp -r -i "${SSH_DIR}/home_key" -o UserKnownHostsFile="${SSH_DIR}/known_hosts" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -P "${PORT}" \
+          scp -r -i "${SSH_DIR}/home_key" -o UserKnownHostsFile="${SSH_DIR}/known_hosts" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=15 -P "${PORT}" \
             "${HOME_SSH_USER}@${HOME_HOST}:${REMOTE_TMP_DIR}/artifacts/." \
             "${LOCAL_ARTIFACT_DIR}/"
 

--- a/deploy/homeserver/restore_external_backup_drill.sh
+++ b/deploy/homeserver/restore_external_backup_drill.sh
@@ -87,6 +87,27 @@ resolve_postgres_image() {
   printf '%s' "${image}"
 }
 
+resolve_storage_paths() {
+  local external_root="${AQUILA_EXTERNAL_STORAGE_ROOT:-}"
+  local backup_root="${AQUILA_BACKUP_ROOT:-}"
+
+  if [[ -z "${external_root}" ]]; then
+    external_root="$(read_key_from_file AQUILA_EXTERNAL_STORAGE_ROOT "${DEPLOY_DIR}/.env.prod.compose")"
+  fi
+  if [[ -z "${external_root}" ]]; then
+    external_root="$(read_key_from_file AQUILA_EXTERNAL_STORAGE_ROOT "${DEPLOY_DIR}/.env.prod")"
+  fi
+  EXTERNAL_STORAGE_ROOT="${external_root:-${DEFAULT_EXTERNAL_STORAGE_ROOT}}"
+
+  if [[ -z "${backup_root}" ]]; then
+    backup_root="$(read_key_from_file AQUILA_BACKUP_ROOT "${DEPLOY_DIR}/.env.prod.compose")"
+  fi
+  if [[ -z "${backup_root}" ]]; then
+    backup_root="$(read_key_from_file AQUILA_BACKUP_ROOT "${DEPLOY_DIR}/.env.prod")"
+  fi
+  BACKUP_ROOT="${backup_root:-${EXTERNAL_STORAGE_ROOT}/backups}"
+}
+
 latest_backup_set_id() {
   local postgres_root="${BACKUP_ROOT}/postgres/${BACKUP_CLASS}"
   [[ -d "${postgres_root}" ]] || fail "missing PostgreSQL backup class directory: ${postgres_root}"
@@ -213,7 +234,7 @@ select_minio_sample_object() {
     | sed 's#^\./##' \
     | grep -Ev '(^$|/$|(^|/)format\.json$|(^|/)\.minio\.sys/)' \
     | sort \
-    | head -n 1
+    | awk 'NR == 1 { first = $0 } END { if (first != "") print first }'
 }
 
 checksum_minio_sample() {
@@ -228,6 +249,7 @@ checksum_minio_sample() {
 require_command docker
 require_command tar
 require_command sha256sum
+resolve_storage_paths
 POSTGRES_IMAGE="$(resolve_postgres_image)"
 
 if [[ -z "${BACKUP_SET_ID}" ]]; then

--- a/deploy/homeserver/restore_external_backup_drill.sh
+++ b/deploy/homeserver/restore_external_backup_drill.sh
@@ -13,7 +13,15 @@ BACKUP_SET_ID="${AQUILA_RESTORE_DRILL_BACKUP_SET_ID:-${BACKUP_SET_ID:-}}"
 EXTERNAL_STORAGE_ROOT="${AQUILA_EXTERNAL_STORAGE_ROOT:-${DEFAULT_EXTERNAL_STORAGE_ROOT}}"
 BACKUP_ROOT="${AQUILA_BACKUP_ROOT:-${EXTERNAL_STORAGE_ROOT}/backups}"
 ARTIFACT_DIR="${AQUILA_RESTORE_DRILL_ARTIFACT_DIR:-${SCRIPT_DIR}/.restore-drills/${TIMESTAMP}}"
-POSTGRES_IMAGE="${AQUILA_RESTORE_DRILL_POSTGRES_IMAGE:-postgres:16-alpine}"
+if [[ -n "${AQUILA_RESTORE_DRILL_DEPLOY_DIR:-}" ]]; then
+  DEPLOY_DIR="${AQUILA_RESTORE_DRILL_DEPLOY_DIR}"
+elif [[ -d "$(pwd)/deploy/homeserver" ]]; then
+  DEPLOY_DIR="$(pwd)/deploy/homeserver"
+elif [[ -f "$(pwd)/.env.prod" || -f "$(pwd)/docker-compose.prod.yml" ]]; then
+  DEPLOY_DIR="$(pwd)"
+else
+  DEPLOY_DIR="${SCRIPT_DIR}"
+fi
 POSTGRES_CONTAINER="aquila-restore-drill-${TIMESTAMP}"
 POSTGRES_DB="${AQUILA_RESTORE_DRILL_DB:-restore_drill}"
 POSTGRES_PASSWORD="${AQUILA_RESTORE_DRILL_POSTGRES_PASSWORD:-restore_drill_${TIMESTAMP}}"
@@ -41,6 +49,44 @@ is_safe_backup_id() {
   [[ "$1" =~ ^[0-9]{8}-[0-9]{6}$ ]]
 }
 
+read_key_from_file() {
+  local key="$1"
+  local file="$2"
+  [[ -f "${file}" ]] || return 0
+  awk -F= -v k="${key}" '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*$/ { next }
+    {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      sub(/^[Ee][Xx][Pp][Oo][Rr][Tt][[:space:]]+/, "", line)
+      if (index(line, k "=") == 1) {
+        value = substr(line, length(k) + 2)
+        sub(/^[[:space:]]+/, "", value)
+        sub(/[[:space:]]+$/, "", value)
+        if ((value ~ /^".*"$/) || (value ~ /^'\''.*'\''$/)) {
+          value = substr(value, 2, length(value) - 2)
+        }
+        print value
+      }
+    }
+  ' "${file}" | tail -n 1
+}
+
+resolve_postgres_image() {
+  local image="${AQUILA_RESTORE_DRILL_POSTGRES_IMAGE:-${DB_IMAGE:-}}"
+  if [[ -z "${image}" ]]; then
+    image="$(read_key_from_file DB_IMAGE "${DEPLOY_DIR}/.env.prod.compose")"
+  fi
+  if [[ -z "${image}" ]]; then
+    image="$(read_key_from_file DB_IMAGE "${DEPLOY_DIR}/.env.prod")"
+  fi
+
+  [[ -n "${image}" ]] || fail "DB_IMAGE is required for restore drill PostgreSQL image"
+  [[ "${image}" != *":latest" && "${image}" != *":latest@"* ]] || fail "DB_IMAGE must not use latest tag for restore drill: ${image}"
+  printf '%s' "${image}"
+}
+
 latest_backup_set_id() {
   local postgres_root="${BACKUP_ROOT}/postgres/${BACKUP_CLASS}"
   [[ -d "${postgres_root}" ]] || fail "missing PostgreSQL backup class directory: ${postgres_root}"
@@ -50,10 +96,33 @@ latest_backup_set_id() {
     | tail -n 1
 }
 
+date_utc_epoch() {
+  local value="$1"
+  date -u -d "${value}" +%s 2>/dev/null \
+    || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "${value}" +%s 2>/dev/null \
+    || true
+}
+
+date_local_epoch_from_backup_id() {
+  local backup_id="$1"
+  local stamp="${backup_id:0:8} ${backup_id:9:2}:${backup_id:11:2}:${backup_id:13:2}"
+  date -d "${stamp}" +%s 2>/dev/null \
+    || date -j -f "%Y%m%d-%H%M%S" "${backup_id}" +%s 2>/dev/null \
+    || true
+}
+
 parse_backup_epoch() {
   local backup_id="$1"
-  local stamp="${backup_id:0:8} ${backup_id:9:2}:${backup_id:11:2}:${backup_id:13:2} UTC"
-  date -u -d "${stamp}" +%s 2>/dev/null || true
+  local metadata_file="${BACKUP_ROOT}/postgres/${BACKUP_CLASS}/${backup_id}/metadata.env"
+  local created_at_utc
+
+  created_at_utc="$(read_key_from_file created_at_utc "${metadata_file}")"
+  if [[ -n "${created_at_utc}" ]]; then
+    date_utc_epoch "${created_at_utc}"
+    return 0
+  fi
+
+  date_local_epoch_from_backup_id "${backup_id}"
 }
 
 write_result() {
@@ -70,6 +139,7 @@ write_result() {
     printf 'STATUS=%s\n' "${status}"
     printf 'BACKUP_SET_ID=%s\n' "${BACKUP_SET_ID}"
     printf 'BACKUP_CLASS=%s\n' "${BACKUP_CLASS}"
+    printf 'POSTGRES_IMAGE=%q\n' "${POSTGRES_IMAGE}"
     printf 'RPO_TARGET_MINUTES=%s\n' "${RPO_TARGET_MINUTES}"
     printf 'RPO_ACTUAL_MINUTES=%s\n' "${rpo_minutes}"
     printf 'RTO_TARGET_MINUTES=%s\n' "${RTO_TARGET_MINUTES}"
@@ -158,6 +228,7 @@ checksum_minio_sample() {
 require_command docker
 require_command tar
 require_command sha256sum
+POSTGRES_IMAGE="$(resolve_postgres_image)"
 
 if [[ -z "${BACKUP_SET_ID}" ]]; then
   BACKUP_SET_ID="$(latest_backup_set_id)"
@@ -173,7 +244,7 @@ MINIO_ARCHIVE_FILE="${BACKUP_ROOT}/minio/${BACKUP_CLASS}/${BACKUP_SET_ID}/minio-
 mkdir -p "${ARTIFACT_DIR}"
 trap cleanup EXIT
 
-start_epoch="$(date -u +%s)"
+start_epoch="${AQUILA_RESTORE_DRILL_NOW_EPOCH:-$(date -u +%s)}"
 backup_epoch="$(parse_backup_epoch "${BACKUP_SET_ID}")"
 if [[ -n "${backup_epoch}" ]]; then
   rpo_minutes=$(((start_epoch - backup_epoch) / 60))

--- a/deploy/homeserver/restore_external_backup_drill.sh
+++ b/deploy/homeserver/restore_external_backup_drill.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec </dev/null
+
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_EXTERNAL_STORAGE_ROOT="/mnt/aquila-blog-data"
+TIMESTAMP="${AQUILA_RESTORE_DRILL_TIMESTAMP:-$(date -u +%Y%m%d-%H%M%S)}"
+BACKUP_CLASS="${AQUILA_RESTORE_DRILL_CLASS:-${BACKUP_CLASS:-daily}}"
+BACKUP_SET_ID="${AQUILA_RESTORE_DRILL_BACKUP_SET_ID:-${BACKUP_SET_ID:-}}"
+EXTERNAL_STORAGE_ROOT="${AQUILA_EXTERNAL_STORAGE_ROOT:-${DEFAULT_EXTERNAL_STORAGE_ROOT}}"
+BACKUP_ROOT="${AQUILA_BACKUP_ROOT:-${EXTERNAL_STORAGE_ROOT}/backups}"
+ARTIFACT_DIR="${AQUILA_RESTORE_DRILL_ARTIFACT_DIR:-${SCRIPT_DIR}/.restore-drills/${TIMESTAMP}}"
+POSTGRES_IMAGE="${AQUILA_RESTORE_DRILL_POSTGRES_IMAGE:-postgres:16-alpine}"
+POSTGRES_CONTAINER="aquila-restore-drill-${TIMESTAMP}"
+POSTGRES_DB="${AQUILA_RESTORE_DRILL_DB:-restore_drill}"
+POSTGRES_PASSWORD="${AQUILA_RESTORE_DRILL_POSTGRES_PASSWORD:-restore_drill_${TIMESTAMP}}"
+RPO_TARGET_MINUTES="${AQUILA_RESTORE_DRILL_RPO_TARGET_MINUTES:-1440}"
+RTO_TARGET_MINUTES="${AQUILA_RESTORE_DRILL_RTO_TARGET_MINUTES:-120}"
+SUMMARY_FILE="${ARTIFACT_DIR}/restore-drill-summary.md"
+RESULT_FILE="${ARTIFACT_DIR}/restore-drill-result.env"
+CHECKSUM_FILE="${ARTIFACT_DIR}/minio-checksums.sha256"
+
+log() {
+  printf '[restore-drill] %s\n' "$*" >&2
+}
+
+fail() {
+  log "$*"
+  exit 1
+}
+
+require_command() {
+  local command_name="$1"
+  command -v "${command_name}" >/dev/null 2>&1 || fail "${command_name} is required for restore drill"
+}
+
+is_safe_backup_id() {
+  [[ "$1" =~ ^[0-9]{8}-[0-9]{6}$ ]]
+}
+
+latest_backup_set_id() {
+  local postgres_root="${BACKUP_ROOT}/postgres/${BACKUP_CLASS}"
+  [[ -d "${postgres_root}" ]] || fail "missing PostgreSQL backup class directory: ${postgres_root}"
+  find "${postgres_root}" -mindepth 1 -maxdepth 1 -type d -print \
+    | sed 's#.*/##' \
+    | sort \
+    | tail -n 1
+}
+
+parse_backup_epoch() {
+  local backup_id="$1"
+  local stamp="${backup_id:0:8} ${backup_id:9:2}:${backup_id:11:2}:${backup_id:13:2} UTC"
+  date -u -d "${stamp}" +%s 2>/dev/null || true
+}
+
+write_result() {
+  local status="$1"
+  local rto_seconds="$2"
+  local rpo_minutes="$3"
+  local flyway_success_count="$4"
+  local post_count="$5"
+  local latest_public_post_id="$6"
+  local minio_sample_object="$7"
+  local minio_sample_sha256="$8"
+
+  {
+    printf 'STATUS=%s\n' "${status}"
+    printf 'BACKUP_SET_ID=%s\n' "${BACKUP_SET_ID}"
+    printf 'BACKUP_CLASS=%s\n' "${BACKUP_CLASS}"
+    printf 'RPO_TARGET_MINUTES=%s\n' "${RPO_TARGET_MINUTES}"
+    printf 'RPO_ACTUAL_MINUTES=%s\n' "${rpo_minutes}"
+    printf 'RTO_TARGET_MINUTES=%s\n' "${RTO_TARGET_MINUTES}"
+    printf 'RTO_ACTUAL_SECONDS=%s\n' "${rto_seconds}"
+    printf 'FLYWAY_SUCCESS_COUNT=%s\n' "${flyway_success_count}"
+    printf 'POST_ROW_COUNT=%s\n' "${post_count}"
+    printf 'LATEST_PUBLIC_POST_ID=%s\n' "${latest_public_post_id}"
+    printf 'MINIO_SAMPLE_OBJECT=%q\n' "${minio_sample_object}"
+    printf 'MINIO_SAMPLE_SHA256=%s\n' "${minio_sample_sha256}"
+    printf 'SUMMARY_FILE=%q\n' "${SUMMARY_FILE}"
+  } > "${RESULT_FILE}"
+}
+
+write_summary() {
+  local status="$1"
+  local rto_seconds="$2"
+  local rpo_minutes="$3"
+  local flyway_success_count="$4"
+  local post_count="$5"
+  local latest_public_post_id="$6"
+  local minio_sample_object="$7"
+  local minio_sample_sha256="$8"
+
+  {
+    printf '# Backup Restore Drill Summary\n\n'
+    printf -- '- Status: `%s`\n' "${status}"
+    printf -- '- Backup set: `%s/%s`\n' "${BACKUP_CLASS}" "${BACKUP_SET_ID}"
+    printf -- '- PostgreSQL dump: `%s`\n' "${POSTGRES_DUMP_FILE}"
+    printf -- '- MinIO archive: `%s`\n' "${MINIO_ARCHIVE_FILE}"
+    printf -- '- RPO target: `%s minutes`\n' "${RPO_TARGET_MINUTES}"
+    printf -- '- RPO actual: `%s minutes`\n' "${rpo_minutes}"
+    printf -- '- RTO target: `%s minutes`\n' "${RTO_TARGET_MINUTES}"
+    printf -- '- RTO actual: `%s seconds`\n' "${rto_seconds}"
+    printf -- '- Flyway successful migrations: `%s`\n' "${flyway_success_count}"
+    printf -- '- Restored post rows: `%s`\n' "${post_count}"
+    printf -- '- Latest public post id: `%s`\n' "${latest_public_post_id}"
+    printf -- '- MinIO checksum sample: `%s`\n' "${minio_sample_object}"
+    printf -- '- MinIO sample sha256: `%s`\n' "${minio_sample_sha256}"
+  } > "${SUMMARY_FILE}"
+}
+
+cleanup() {
+  docker rm -f "${POSTGRES_CONTAINER}" >/dev/null 2>&1 || true
+}
+
+wait_for_postgres() {
+  local attempt
+  for attempt in $(seq 1 60); do
+    if docker exec "${POSTGRES_CONTAINER}" pg_isready -U postgres -d "${POSTGRES_DB}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  fail "temporary PostgreSQL did not become ready"
+}
+
+psql_restore() {
+  docker exec -i "${POSTGRES_CONTAINER}" psql -U postgres -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 < "${POSTGRES_DUMP_FILE}" >/dev/null
+}
+
+psql_scalar() {
+  local sql="$1"
+  docker exec "${POSTGRES_CONTAINER}" \
+    psql -U postgres -d "${POSTGRES_DB}" -At -v ON_ERROR_STOP=1 -c "${sql}" \
+    | tr -d '\r' \
+    | head -n 1
+}
+
+select_minio_sample_object() {
+  tar -tzf "${MINIO_ARCHIVE_FILE}" \
+    | sed 's#^\./##' \
+    | grep -Ev '(^$|/$|(^|/)format\.json$|(^|/)\.minio\.sys/)' \
+    | sort \
+    | head -n 1
+}
+
+checksum_minio_sample() {
+  local object_key="$1"
+  local tar_path="${object_key}"
+  if ! tar -tzf "${MINIO_ARCHIVE_FILE}" "${tar_path}" >/dev/null 2>&1; then
+    tar_path="./${object_key}"
+  fi
+  tar -xOzf "${MINIO_ARCHIVE_FILE}" "${tar_path}" | sha256sum | awk '{print $1}'
+}
+
+require_command docker
+require_command tar
+require_command sha256sum
+
+if [[ -z "${BACKUP_SET_ID}" ]]; then
+  BACKUP_SET_ID="$(latest_backup_set_id)"
+fi
+is_safe_backup_id "${BACKUP_SET_ID}" || fail "unsafe backup set id: ${BACKUP_SET_ID}"
+
+POSTGRES_DUMP_FILE="${BACKUP_ROOT}/postgres/${BACKUP_CLASS}/${BACKUP_SET_ID}/dump.sql"
+MINIO_ARCHIVE_FILE="${BACKUP_ROOT}/minio/${BACKUP_CLASS}/${BACKUP_SET_ID}/minio-data.tar.gz"
+
+[[ -s "${POSTGRES_DUMP_FILE}" ]] || fail "missing PostgreSQL dump.sql: ${POSTGRES_DUMP_FILE}"
+[[ -s "${MINIO_ARCHIVE_FILE}" ]] || fail "missing MinIO minio-data.tar.gz: ${MINIO_ARCHIVE_FILE}"
+
+mkdir -p "${ARTIFACT_DIR}"
+trap cleanup EXIT
+
+start_epoch="$(date -u +%s)"
+backup_epoch="$(parse_backup_epoch "${BACKUP_SET_ID}")"
+if [[ -n "${backup_epoch}" ]]; then
+  rpo_minutes=$(((start_epoch - backup_epoch) / 60))
+else
+  rpo_minutes="unknown"
+fi
+
+log "starting restore drill backup=${BACKUP_CLASS}/${BACKUP_SET_ID} artifact_dir=${ARTIFACT_DIR}"
+docker run -d \
+  --name "${POSTGRES_CONTAINER}" \
+  -e "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" \
+  -e "POSTGRES_DB=${POSTGRES_DB}" \
+  "${POSTGRES_IMAGE}" >/dev/null
+wait_for_postgres
+
+psql_restore
+
+flyway_success_count="$(psql_scalar "SELECT COUNT(*) FROM flyway_schema_history WHERE success = true;")"
+post_count="$(psql_scalar "SELECT COUNT(*) FROM post;")"
+latest_public_post_id="$(psql_scalar "SELECT id FROM post WHERE listed = true ORDER BY created_at DESC, id DESC LIMIT 1;")"
+[[ -n "${latest_public_post_id}" ]] || fail "latest public post query returned no rows"
+
+minio_sample_object="$(select_minio_sample_object)"
+[[ -n "${minio_sample_object}" ]] || fail "MinIO backup archive has no checksumable object sample"
+minio_sample_sha256="$(checksum_minio_sample "${minio_sample_object}")"
+printf '%s  %s\n' "${minio_sample_sha256}" "${minio_sample_object}" > "${CHECKSUM_FILE}"
+
+end_epoch="$(date -u +%s)"
+rto_seconds=$((end_epoch - start_epoch))
+status="success"
+write_result "${status}" "${rto_seconds}" "${rpo_minutes}" "${flyway_success_count}" "${post_count}" "${latest_public_post_id}" "${minio_sample_object}" "${minio_sample_sha256}"
+write_summary "${status}" "${rto_seconds}" "${rpo_minutes}" "${flyway_success_count}" "${post_count}" "${latest_public_post_id}" "${minio_sample_object}" "${minio_sample_sha256}"
+
+log "restore drill complete status=${status} summary=${SUMMARY_FILE}"
+printf '%s\n' "${ARTIFACT_DIR}"

--- a/deploy/homeserver/restore_external_backup_drill.sh
+++ b/deploy/homeserver/restore_external_backup_drill.sh
@@ -203,7 +203,7 @@ write_summary() {
 }
 
 cleanup() {
-  docker rm -f "${POSTGRES_CONTAINER}" >/dev/null 2>&1 || true
+  docker rm -f -v "${POSTGRES_CONTAINER}" >/dev/null 2>&1 || true
 }
 
 wait_for_postgres() {

--- a/docs/design/launch-gate-operations.md
+++ b/docs/design/launch-gate-operations.md
@@ -31,7 +31,7 @@
 | Upload architecture | 관련 issue/PR 또는 design evidence | 현재 출시 범위에서 upload blocking 없음 | upload 경로가 launch path인데 검증 누락 |
 | Blue/green rollback | deploy workflow log 또는 rollback script evidence | green health check 실패 시 rollback 경로 확인 가능 | rollback script 부재, rollback 후 health 미확인 |
 | Worker rollback | worker 관련 issue/PR 또는 out-of-scope 기록 | worker 변경 없음 또는 rollback 절차 확인 | worker 변경이 있는데 rollback evidence 없음 |
-| Backup/restore drill | backup metadata, restore drill issue/PR/run | restore drill evidence 연결 또는 launch-blocker defer 불가 사유 해소 | backup/restore evidence 없음 |
+| Backup/restore drill | backup metadata, restore drill issue/PR/run, RPO/RTO artifact | restore drill evidence 연결, RPO/RTO 목표 대비 결과 기록, PostgreSQL/MinIO checksum 검증 | backup/restore evidence 없음, RPO/RTO 결과 누락 |
 | Alert receiver | Prometheus/Grafana alert rule과 수신 채널 evidence | alert rule과 수신 채널이 존재하고 테스트 evidence 연결 | 운영 alert 수신 경로 없음 |
 | Live E2E account cleanup | live E2E run artifact 또는 cleanup log | 테스트 계정/데이터 cleanup 결과 확인 | live E2E가 계정/데이터를 남김 |
 | Mobile/keyboard/200% zoom QA | `docs/design/release-ui-qa-matrix.md` run table과 artifact | matrix pass run 연결 | 핵심 viewport 또는 keyboard/zoom failure |
@@ -57,8 +57,19 @@ Merge 전 PR 본문 또는 review note에는 다음 항목을 남긴다.
 - Blue/green deploy script: `deploy/homeserver/blue_green_deploy.sh`
 - Rollback script: `deploy/homeserver/rollback_last_deploy.sh`
 - Backup script: `deploy/homeserver/create_external_backup.sh`
+- Restore drill script: `deploy/homeserver/restore_external_backup_drill.sh`
+- Restore drill workflow: `.github/workflows/backup-restore-drill.yml`
 - Public edge probe: `deploy/homeserver/monitoring/public-edge-probe.mjs`
 - Alert examples: `deploy/homeserver/monitoring/prometheus-task-alerts.example.yml`
+
+## Backup Restore Drill Evidence
+
+- 수동 실행: GitHub Actions `Backup Restore Drill` workflow를 `workflow_dispatch`로 실행한다.
+- 기본 대상: `backup_class=daily`, `backup_set_id`는 비워 두면 최신 daily PostgreSQL backup을 사용한다.
+- 통과 증거: workflow artifact `backup-restore-drill` 안의 `restore-drill-summary.md`, `restore-drill-result.env`, `minio-checksums.sha256`.
+- DB 검증: 임시 PostgreSQL container에 `dump.sql`을 복원하고 `flyway_schema_history`, `post` row count, 최신 public post(`listed = true`) 조회를 확인한다.
+- Object 검증: `minio-data.tar.gz`에서 운영 object 샘플 1개 이상을 선택해 `sha256sum`을 기록한다.
+- RPO/RTO 기준: 기본 RPO target은 1440분, 기본 RTO target은 120분이며, 실제 `RPO_ACTUAL_MINUTES`와 `RTO_ACTUAL_SECONDS`를 artifact에 남긴다.
 
 ## PR Checklist
 

--- a/tools/test/verify-external-backup-restore-drill.sh
+++ b/tools/test/verify-external-backup-restore-drill.sh
@@ -63,6 +63,8 @@ require_pattern "${DRILL_SCRIPT}" 'RPO' "restore drill must record RPO"
 require_pattern "${DRILL_SCRIPT}" 'RTO' "restore drill must record RTO"
 require_pattern "${DRILL_SCRIPT}" 'DB_IMAGE is required' "restore drill must require the production DB image"
 require_pattern "${DRILL_SCRIPT}" 'created_at_utc' "restore drill must prefer UTC backup metadata for RPO"
+require_pattern "${DRILL_SCRIPT}" 'read_key_from_file AQUILA_BACKUP_ROOT' "restore drill must read backup root from deploy env"
+require_pattern "${DRILL_SCRIPT}" "awk 'NR == 1" "restore drill must select MinIO sample without head-induced SIGPIPE"
 reject_pattern "${DRILL_SCRIPT}" 'HOME_SERVER_ENV' "restore drill must not require raw production secret blobs"
 reject_pattern "${DRILL_SCRIPT}" 'postgres:16-alpine' "restore drill must not default to vanilla PostgreSQL"
 
@@ -91,7 +93,13 @@ MINIO_BACKUP_DIR="${BACKUP_ROOT}/minio/daily/${BACKUP_SET_ID}"
 MINIO_SOURCE_DIR="${WORK_DIR}/minio-source"
 FAKE_BIN_DIR="${WORK_DIR}/bin"
 ARTIFACT_DIR="${WORK_DIR}/artifacts"
-mkdir -p "${POSTGRES_BACKUP_DIR}" "${MINIO_BACKUP_DIR}" "${MINIO_SOURCE_DIR}/post-img/posts/2026/01" "${FAKE_BIN_DIR}"
+DEPLOY_DIR="${WORK_DIR}/deploy"
+mkdir -p "${POSTGRES_BACKUP_DIR}" "${MINIO_BACKUP_DIR}" "${MINIO_SOURCE_DIR}/post-img/posts/2026/01" "${FAKE_BIN_DIR}" "${DEPLOY_DIR}"
+cat > "${DEPLOY_DIR}/.env.prod" <<EOF
+AQUILA_EXTERNAL_STORAGE_ROOT=${WORK_DIR}/storage
+AQUILA_BACKUP_ROOT=${BACKUP_ROOT}
+DB_IMAGE=jangka512/pgj@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
 
 cat > "${POSTGRES_BACKUP_DIR}/dump.sql" <<'SQL'
 CREATE TABLE flyway_schema_history(success boolean);
@@ -104,6 +112,7 @@ created_at=20260101-010203
 created_at_utc=2026-01-01T01:02:03Z
 EOF
 printf 'fixture-object\n' > "${MINIO_SOURCE_DIR}/post-img/posts/2026/01/sample.txt"
+printf 'fixture-object-2\n' > "${MINIO_SOURCE_DIR}/post-img/posts/2026/01/zzz.txt"
 tar -C "${MINIO_SOURCE_DIR}" -czf "${MINIO_BACKUP_DIR}/minio-data.tar.gz" .
 
 cat > "${FAKE_BIN_DIR}/docker" <<'SH'
@@ -178,11 +187,9 @@ SH
 chmod +x "${FAKE_BIN_DIR}/docker"
 
 PATH="${FAKE_BIN_DIR}:${PATH}" \
-AQUILA_EXTERNAL_STORAGE_ROOT="${WORK_DIR}/storage" \
-AQUILA_BACKUP_ROOT="${BACKUP_ROOT}" \
 AQUILA_RESTORE_DRILL_BACKUP_SET_ID="${BACKUP_SET_ID}" \
+AQUILA_RESTORE_DRILL_DEPLOY_DIR="${DEPLOY_DIR}" \
 AQUILA_RESTORE_DRILL_ARTIFACT_DIR="${ARTIFACT_DIR}" \
-AQUILA_RESTORE_DRILL_POSTGRES_IMAGE="jangka512/pgj@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
 AQUILA_RESTORE_DRILL_TIMESTAMP="20260102-030405" \
 AQUILA_RESTORE_DRILL_NOW_EPOCH="1767323045" \
   "${DRILL_SCRIPT}" >/dev/null

--- a/tools/test/verify-external-backup-restore-drill.sh
+++ b/tools/test/verify-external-backup-restore-drill.sh
@@ -65,6 +65,7 @@ require_pattern "${DRILL_SCRIPT}" 'DB_IMAGE is required' "restore drill must req
 require_pattern "${DRILL_SCRIPT}" 'created_at_utc' "restore drill must prefer UTC backup metadata for RPO"
 require_pattern "${DRILL_SCRIPT}" 'read_key_from_file AQUILA_BACKUP_ROOT' "restore drill must read backup root from deploy env"
 require_pattern "${DRILL_SCRIPT}" "awk 'NR == 1" "restore drill must select MinIO sample without head-induced SIGPIPE"
+require_pattern "${DRILL_SCRIPT}" 'docker rm -f -v' "restore drill must remove anonymous PostgreSQL volumes"
 reject_pattern "${DRILL_SCRIPT}" 'HOME_SERVER_ENV' "restore drill must not require raw production secret blobs"
 reject_pattern "${DRILL_SCRIPT}" 'postgres:16-alpine' "restore drill must not default to vanilla PostgreSQL"
 

--- a/tools/test/verify-external-backup-restore-drill.sh
+++ b/tools/test/verify-external-backup-restore-drill.sh
@@ -61,7 +61,10 @@ require_pattern "${DRILL_SCRIPT}" 'restore-drill-summary\.md' "restore drill mus
 require_pattern "${DRILL_SCRIPT}" 'restore-drill-result\.env' "restore drill must write a machine-readable result artifact"
 require_pattern "${DRILL_SCRIPT}" 'RPO' "restore drill must record RPO"
 require_pattern "${DRILL_SCRIPT}" 'RTO' "restore drill must record RTO"
+require_pattern "${DRILL_SCRIPT}" 'DB_IMAGE is required' "restore drill must require the production DB image"
+require_pattern "${DRILL_SCRIPT}" 'created_at_utc' "restore drill must prefer UTC backup metadata for RPO"
 reject_pattern "${DRILL_SCRIPT}" 'HOME_SERVER_ENV' "restore drill must not require raw production secret blobs"
+reject_pattern "${DRILL_SCRIPT}" 'postgres:16-alpine' "restore drill must not default to vanilla PostgreSQL"
 
 require_file "${WORKFLOW}" "manual restore drill workflow"
 require_pattern "${WORKFLOW}" 'workflow_dispatch:' "restore drill workflow must be manually runnable"
@@ -94,6 +97,12 @@ cat > "${POSTGRES_BACKUP_DIR}/dump.sql" <<'SQL'
 CREATE TABLE flyway_schema_history(success boolean);
 CREATE TABLE post(id bigint, listed boolean, created_at timestamptz);
 SQL
+cat > "${POSTGRES_BACKUP_DIR}/metadata.env" <<'EOF'
+backup_set_id=20260101-010203
+class=daily
+created_at=20260101-010203
+created_at_utc=2026-01-01T01:02:03Z
+EOF
 printf 'fixture-object\n' > "${MINIO_SOURCE_DIR}/post-img/posts/2026/01/sample.txt"
 tar -C "${MINIO_SOURCE_DIR}" -czf "${MINIO_BACKUP_DIR}/minio-data.tar.gz" .
 
@@ -173,11 +182,15 @@ AQUILA_EXTERNAL_STORAGE_ROOT="${WORK_DIR}/storage" \
 AQUILA_BACKUP_ROOT="${BACKUP_ROOT}" \
 AQUILA_RESTORE_DRILL_BACKUP_SET_ID="${BACKUP_SET_ID}" \
 AQUILA_RESTORE_DRILL_ARTIFACT_DIR="${ARTIFACT_DIR}" \
+AQUILA_RESTORE_DRILL_POSTGRES_IMAGE="jangka512/pgj@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
 AQUILA_RESTORE_DRILL_TIMESTAMP="20260102-030405" \
+AQUILA_RESTORE_DRILL_NOW_EPOCH="1767323045" \
   "${DRILL_SCRIPT}" >/dev/null
 
 grep -q '^STATUS=success$' "${ARTIFACT_DIR}/restore-drill-result.env"
 grep -q '^BACKUP_SET_ID=20260101-010203$' "${ARTIFACT_DIR}/restore-drill-result.env"
+grep -q 'POSTGRES_IMAGE=jangka512/pgj@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' "${ARTIFACT_DIR}/restore-drill-result.env"
+grep -q '^RPO_ACTUAL_MINUTES=1562$' "${ARTIFACT_DIR}/restore-drill-result.env"
 grep -q '^FLYWAY_SUCCESS_COUNT=32$' "${ARTIFACT_DIR}/restore-drill-result.env"
 grep -q '^POST_ROW_COUNT=7$' "${ARTIFACT_DIR}/restore-drill-result.env"
 grep -q '^LATEST_PUBLIC_POST_ID=42$' "${ARTIFACT_DIR}/restore-drill-result.env"

--- a/tools/test/verify-external-backup-restore-drill.sh
+++ b/tools/test/verify-external-backup-restore-drill.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DRILL_SCRIPT="${ROOT_DIR}/deploy/homeserver/restore_external_backup_drill.sh"
+WORKFLOW="${ROOT_DIR}/.github/workflows/backup-restore-drill.yml"
+LAUNCH_GATE_DOC="${ROOT_DIR}/docs/design/launch-gate-operations.md"
+
+require_file() {
+  local file="$1"
+  local message="$2"
+
+  if [[ ! -f "${file}" ]]; then
+    echo "missing: ${message}" >&2
+    exit 1
+  fi
+}
+
+require_executable() {
+  local file="$1"
+  local message="$2"
+
+  if [[ ! -x "${file}" ]]; then
+    echo "missing executable: ${message}" >&2
+    exit 1
+  fi
+}
+
+require_pattern() {
+  local file="$1"
+  local pattern="$2"
+  local message="$3"
+
+  if ! grep -Eq "${pattern}" "${file}"; then
+    echo "missing: ${message}" >&2
+    exit 1
+  fi
+}
+
+reject_pattern() {
+  local file="$1"
+  local pattern="$2"
+  local message="$3"
+
+  if grep -Eq "${pattern}" "${file}"; then
+    echo "unexpected: ${message}" >&2
+    exit 1
+  fi
+}
+
+require_file "${DRILL_SCRIPT}" "restore drill script"
+require_executable "${DRILL_SCRIPT}" "restore drill script"
+require_pattern "${DRILL_SCRIPT}" '^umask 077$' "restore drill must protect generated artifacts"
+require_pattern "${DRILL_SCRIPT}" 'psql .*POSTGRES_DUMP_FILE|pg_restore .*POSTGRES_DUMP_FILE' "restore drill must restore the PostgreSQL dump"
+require_pattern "${DRILL_SCRIPT}" 'flyway_schema_history' "restore drill must verify Flyway/schema state"
+require_pattern "${DRILL_SCRIPT}" 'SELECT COUNT\(\*\) FROM post' "restore drill must verify restored post row count"
+require_pattern "${DRILL_SCRIPT}" 'WHERE listed = true' "restore drill must query latest public post"
+require_pattern "${DRILL_SCRIPT}" 'sha256sum' "restore drill must produce or compare MinIO object checksums"
+require_pattern "${DRILL_SCRIPT}" 'minio-data\.tar\.gz' "restore drill must inspect MinIO backup tarball"
+require_pattern "${DRILL_SCRIPT}" 'restore-drill-summary\.md' "restore drill must write a human-readable summary artifact"
+require_pattern "${DRILL_SCRIPT}" 'restore-drill-result\.env' "restore drill must write a machine-readable result artifact"
+require_pattern "${DRILL_SCRIPT}" 'RPO' "restore drill must record RPO"
+require_pattern "${DRILL_SCRIPT}" 'RTO' "restore drill must record RTO"
+reject_pattern "${DRILL_SCRIPT}" 'HOME_SERVER_ENV' "restore drill must not require raw production secret blobs"
+
+require_file "${WORKFLOW}" "manual restore drill workflow"
+require_pattern "${WORKFLOW}" 'workflow_dispatch:' "restore drill workflow must be manually runnable"
+require_pattern "${WORKFLOW}" 'restore_external_backup_drill\.sh' "restore drill workflow must run the drill script"
+require_pattern "${WORKFLOW}" 'actions/upload-artifact@' "restore drill workflow must upload drill artifacts"
+require_pattern "${WORKFLOW}" 'BACKUP_SET_ID' "restore drill workflow must accept or derive a backup set id"
+require_pattern "${WORKFLOW}" 'unsafe backup_set_id' "restore drill workflow must validate backup set input before SSH"
+require_pattern "${WORKFLOW}" 'RPO_TARGET_MINUTES.*=\~' "restore drill workflow must validate RPO target input before SSH"
+require_pattern "${WORKFLOW}" 'RTO_TARGET_MINUTES.*=\~' "restore drill workflow must validate RTO target input before SSH"
+
+require_pattern "${LAUNCH_GATE_DOC}" 'Backup/restore drill' "launch gate must keep backup/restore evidence gate"
+require_pattern "${LAUNCH_GATE_DOC}" 'restore_external_backup_drill\.sh' "launch gate must link restore drill script"
+require_pattern "${LAUNCH_GATE_DOC}" 'RPO/RTO' "launch gate must document restore drill RPO/RTO evidence"
+
+TMP_BASE="${TMPDIR:-/tmp}"
+TMP_BASE="${TMP_BASE%/}"
+WORK_DIR="$(mktemp -d "${TMP_BASE}/aquila-restore-drill-test.XXXXXX")"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+BACKUP_ROOT="${WORK_DIR}/storage/backups"
+BACKUP_SET_ID="20260101-010203"
+POSTGRES_BACKUP_DIR="${BACKUP_ROOT}/postgres/daily/${BACKUP_SET_ID}"
+MINIO_BACKUP_DIR="${BACKUP_ROOT}/minio/daily/${BACKUP_SET_ID}"
+MINIO_SOURCE_DIR="${WORK_DIR}/minio-source"
+FAKE_BIN_DIR="${WORK_DIR}/bin"
+ARTIFACT_DIR="${WORK_DIR}/artifacts"
+mkdir -p "${POSTGRES_BACKUP_DIR}" "${MINIO_BACKUP_DIR}" "${MINIO_SOURCE_DIR}/post-img/posts/2026/01" "${FAKE_BIN_DIR}"
+
+cat > "${POSTGRES_BACKUP_DIR}/dump.sql" <<'SQL'
+CREATE TABLE flyway_schema_history(success boolean);
+CREATE TABLE post(id bigint, listed boolean, created_at timestamptz);
+SQL
+printf 'fixture-object\n' > "${MINIO_SOURCE_DIR}/post-img/posts/2026/01/sample.txt"
+tar -C "${MINIO_SOURCE_DIR}" -czf "${MINIO_BACKUP_DIR}/minio-data.tar.gz" .
+
+cat > "${FAKE_BIN_DIR}/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  run)
+    echo "fake-postgres-container"
+    ;;
+  rm)
+    exit 0
+    ;;
+  exec)
+    shift
+    if [[ "${1:-}" == "-i" ]]; then
+      shift
+      container="$1"
+      shift
+      if [[ "${1:-}" == "psql" ]]; then
+        cat >/dev/null
+        exit 0
+      fi
+      echo "unexpected docker exec -i command for ${container}: $*" >&2
+      exit 1
+    fi
+
+    container="$1"
+    shift
+    case "${1:-}" in
+      pg_isready)
+        exit 0
+        ;;
+      psql)
+        sql=""
+        while [[ "$#" -gt 0 ]]; do
+          if [[ "$1" == "-c" ]]; then
+            shift
+            sql="${1:-}"
+            break
+          fi
+          shift
+        done
+        case "${sql}" in
+          *flyway_schema_history*)
+            echo "32"
+            ;;
+          *"COUNT(*) FROM post"*)
+            echo "7"
+            ;;
+          *"SELECT id FROM post"*)
+            echo "42"
+            ;;
+          *)
+            echo "unexpected SQL: ${sql}" >&2
+            exit 1
+            ;;
+        esac
+        ;;
+      *)
+        echo "unexpected docker exec command for ${container}: $*" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "unexpected docker command: $*" >&2
+    exit 1
+    ;;
+esac
+SH
+chmod +x "${FAKE_BIN_DIR}/docker"
+
+PATH="${FAKE_BIN_DIR}:${PATH}" \
+AQUILA_EXTERNAL_STORAGE_ROOT="${WORK_DIR}/storage" \
+AQUILA_BACKUP_ROOT="${BACKUP_ROOT}" \
+AQUILA_RESTORE_DRILL_BACKUP_SET_ID="${BACKUP_SET_ID}" \
+AQUILA_RESTORE_DRILL_ARTIFACT_DIR="${ARTIFACT_DIR}" \
+AQUILA_RESTORE_DRILL_TIMESTAMP="20260102-030405" \
+  "${DRILL_SCRIPT}" >/dev/null
+
+grep -q '^STATUS=success$' "${ARTIFACT_DIR}/restore-drill-result.env"
+grep -q '^BACKUP_SET_ID=20260101-010203$' "${ARTIFACT_DIR}/restore-drill-result.env"
+grep -q '^FLYWAY_SUCCESS_COUNT=32$' "${ARTIFACT_DIR}/restore-drill-result.env"
+grep -q '^POST_ROW_COUNT=7$' "${ARTIFACT_DIR}/restore-drill-result.env"
+grep -q '^LATEST_PUBLIC_POST_ID=42$' "${ARTIFACT_DIR}/restore-drill-result.env"
+grep -q 'post-img/posts/2026/01/sample.txt' "${ARTIFACT_DIR}/restore-drill-result.env"
+grep -q 'Backup Restore Drill Summary' "${ARTIFACT_DIR}/restore-drill-summary.md"
+grep -q 'post-img/posts/2026/01/sample.txt' "${ARTIFACT_DIR}/minio-checksums.sha256"
+
+echo "[external-backup-restore-drill] ok"

--- a/tools/test/verify-external-backup-restore-drill.sh
+++ b/tools/test/verify-external-backup-restore-drill.sh
@@ -48,6 +48,20 @@ reject_pattern() {
   fi
 }
 
+require_pattern_count() {
+  local file="$1"
+  local pattern="$2"
+  local expected="$3"
+  local message="$4"
+  local actual
+
+  actual="$(grep -Ec "${pattern}" "${file}" || true)"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "expected ${expected}, got ${actual}: ${message}" >&2
+    exit 1
+  fi
+}
+
 require_file "${DRILL_SCRIPT}" "restore drill script"
 require_executable "${DRILL_SCRIPT}" "restore drill script"
 require_pattern "${DRILL_SCRIPT}" '^umask 077$' "restore drill must protect generated artifacts"
@@ -77,6 +91,7 @@ require_pattern "${WORKFLOW}" 'BACKUP_SET_ID' "restore drill workflow must accep
 require_pattern "${WORKFLOW}" 'unsafe backup_set_id' "restore drill workflow must validate backup set input before SSH"
 require_pattern "${WORKFLOW}" 'RPO_TARGET_MINUTES.*=\~' "restore drill workflow must validate RPO target input before SSH"
 require_pattern "${WORKFLOW}" 'RTO_TARGET_MINUTES.*=\~' "restore drill workflow must validate RTO target input before SSH"
+require_pattern_count "${WORKFLOW}" '^[[:space:]]*scp .*ConnectTimeout=15' "2" "restore drill workflow scp calls must fail fast on connection timeout"
 
 require_pattern "${LAUNCH_GATE_DOC}" 'Backup/restore drill' "launch gate must keep backup/restore evidence gate"
 require_pattern "${LAUNCH_GATE_DOC}" 'restore_external_backup_drill\.sh' "launch gate must link restore drill script"


### PR DESCRIPTION
## 관련 이슈

close #935

## 작업 배경

- 기존 운영 백업은 생성/보존 경로는 있었지만 실제 PostgreSQL dump와 MinIO archive가 복원 가능한지 검증하는 restore drill 계약이 없었다.
- 출시 gate 문서도 backup/restore evidence를 요구하지만 RPO/RTO artifact와 실행 절차가 연결되어 있지 않았다.

## 작업 내용

- `deploy/homeserver/restore_external_backup_drill.sh`를 추가해 외부 백업 root의 PostgreSQL `dump.sql`을 임시 PostgreSQL container에 복원한다.
- 복원 DB에서 `flyway_schema_history`, `post` row count, 최신 public post(`listed = true`) 조회를 검증한다.
- MinIO `minio-data.tar.gz`에서 object 샘플을 선택해 `sha256sum`을 기록한다.
- `restore-drill-summary.md`, `restore-drill-result.env`, `minio-checksums.sha256` artifact를 생성한다.
- `Backup Restore Drill` 수동 workflow를 추가해 홈서버에서 drill을 실행하고 artifact를 업로드한다.
- CodeRabbit/Codex review 지적에 따라 production DB image, backup metadata UTC RPO 계산, production env path, MinIO sample 선택, Docker anonymous volume cleanup, SCP timeout 계약을 보강했다.
- launch gate 문서에 restore drill script/workflow와 RPO/RTO evidence 기준을 연결했다.

## 검증

- 실행한 명령과 결과:
  - RED: `bash tools/test/verify-external-backup-restore-drill.sh` 실패 확인 (`missing: restore drill script`)
  - GREEN: `bash tools/test/verify-external-backup-restore-drill.sh`: `[external-backup-restore-drill] ok`, 2회 연속 통과
  - `bash tools/test/verify-external-storage-backup-retention.sh`: `[external-storage-retention] ok`, 2회 연속 통과
  - `bash tools/test/verify-deploy-workflow-classification.sh`: 통과, 2회 연속 통과
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/backup-restore-drill.yml"); puts "yaml ok"'`: `yaml ok`, 2회 연속 통과
  - `git diff --check`: 통과, 2회 연속 통과
  - GitHub Actions latest head `9301407e535e4eb682b21af3cbc16fd31bf4d93a`: backend-ci, frontend-ci, Security/CodeQL, Vercel, CodeRabbit 모두 통과
  - CodeRabbit actionable 1건은 원 inline thread에 해결 답글을 남기고 resolved 처리 완료
  - Codex CLI latest-head re-review: `Actionable comments posted: 0`

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| restore drill RED | local macOS | `bash tools/test/verify-external-backup-restore-drill.sh` | command output | restore script 부재로 실패 확인 |
| restore drill GREEN | local macOS | `bash tools/test/verify-external-backup-restore-drill.sh` | command output | fake docker + fixture backup으로 artifact 생성 검증, 2회 통과 |
| backup retention regression | local macOS | `bash tools/test/verify-external-storage-backup-retention.sh` | command output | retention guard 통과, 2회 통과 |
| deploy workflow guard | local macOS | `bash tools/test/verify-deploy-workflow-classification.sh` | command output | 통과, 2회 통과 |
| workflow YAML | local macOS | Ruby YAML parser | command output | `.github/workflows/backup-restore-drill.yml` parse 통과, 2회 통과 |
| diff whitespace | local macOS | `git diff --check` | command output | 통과, 2회 통과 |
| PR CI | GitHub Actions | `gh pr checks 981` | backend-ci run `27889217135`, Security run `27889217139`, frontend-ci run `27889217122`, Vercel `AxRZXn2crSFJaFpkqULTF5dwc2qc` | 전체 통과 |
| CodeRabbit review | GitHub PR review | review thread 확인 | `.github/workflows/backup-restore-drill.yml` SCP timeout thread resolved, CodeRabbit resolved reply 확인 | unresolved actionable 없음 |
| Codex CLI review | GitHub PR review | `codex review --base origin/main --title "[Test] 백업 restore drill 자동화"` | PR review `4539041862` | latest head actionable 0 |
| CD 상태 | GitHub Actions deploy history | #933 post-merge CD failure 확인 | deploy run `27887319477`, `HOME_SERVER_ENV`의 `GRAFANA_ADMIN_PASSWORD` 길이 미달 | 이 PR merge/CD는 #933 외부 secret 갱신 전까지 보류 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `deploy/homeserver/restore_external_backup_drill.sh`의 임시 PostgreSQL restore와 artifact 출력
  - `.github/workflows/backup-restore-drill.yml`의 workflow_dispatch 입력 검증, SSH/SCP timeout, artifact 회수 경로
  - `tools/test/verify-external-backup-restore-drill.sh`의 fake docker 기반 restore drill 검증과 workflow timeout 계약

## 리스크

- 실제 홈서버 restore drill workflow는 Docker 접근 권한과 기존 backup root가 필요하다.
- 현재 #933 외부 secret 문제로 homeserver CD가 실패 중이므로, 이 PR은 CI/review clean 상태로 유지하고 `HOME_SERVER_ENV` 갱신 전 merge를 보류한다.
- 수동 workflow artifact는 실제 운영 backup을 대상으로 실행해야 최종 launch evidence가 된다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
