### PR TITLE
[Fix] 전역 error boundary와 500 UX 추가

### DIFF
--- a/front/e2e/error-boundary.spec.ts
+++ b/front/e2e/error-boundary.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "@playwright/test"
+import { existsSync, readFileSync } from "fs"
+import path from "path"
+
+const sourcePath = (...parts: string[]) => path.resolve(__dirname, "../src", ...parts)
+type ClientErrorReport = {
+  boundary: string
+  surface: string
+  path: string
+}
+
+test.describe("error boundary launch gate", () => {
+  test("source wiring keeps global, markdown, and editor boundaries in place", () => {
+    const appSource = readFileSync(sourcePath("pages", "_app.tsx"), "utf8")
+    const postDetailSource = readFileSync(sourcePath("routes", "Detail", "PostDetail", "index.tsx"), "utf8")
+    const writerHostSource = readFileSync(sourcePath("routes", "Admin", "WriterEditorHost.tsx"), "utf8")
+
+    expect(existsSync(sourcePath("pages", "500.tsx"))).toBe(true)
+    expect(existsSync(sourcePath("components", "error", "ErrorBoundary.tsx"))).toBe(true)
+    expect(existsSync(sourcePath("libs", "rum", "reportClientError.ts"))).toBe(true)
+    expect(existsSync(sourcePath("pages", "api", "rum", "client-errors.ts"))).toBe(true)
+
+    expect(appSource).toContain("GlobalErrorBoundary")
+    expect(postDetailSource).toContain('surface="markdown"')
+    expect(postDetailSource).toContain("<RecoverableSurfaceBoundary")
+    expect(writerHostSource).toContain('surface="editor"')
+    expect(writerHostSource).toContain("<RecoverableSurfaceBoundary")
+  })
+
+  test("global render exception shows recoverable 500 UX and sanitized telemetry", async ({ page }) => {
+    await page.goto("/_qa/error-boundary?mode=global")
+
+    await expect(page.getByRole("heading", { name: "문제가 발생했습니다" })).toBeVisible()
+    await expect(page.getByText(/오류 ID: err_/)).toBeVisible()
+    await expect(page.getByRole("button", { name: "다시 시도" })).toBeVisible()
+    await expect(page.getByRole("link", { name: "홈으로 이동" })).toBeVisible()
+
+    const reports = await page.evaluate(
+      () =>
+        ((window as Window & { __AQUILA_CLIENT_ERROR_REPORTS__?: ClientErrorReport[] })
+          .__AQUILA_CLIENT_ERROR_REPORTS__ || [])
+    )
+    expect(reports).toHaveLength(1)
+    expect(reports[0]).toMatchObject({
+      boundary: "global",
+      surface: "app",
+      path: "/_qa/error-boundary",
+    })
+    expect(JSON.stringify(reports[0])).not.toContain("secret-token")
+  })
+
+  test("local surface render exception is contained without replacing the whole app", async ({ page }) => {
+    await page.goto("/_qa/error-boundary?mode=local")
+
+    await expect(page.getByTestId("qa-error-boundary-shell")).toBeVisible()
+    await expect(page.getByRole("heading", { name: "콘텐츠를 표시하지 못했습니다" })).toBeVisible()
+    await expect(page.getByText(/오류 ID: err_/)).toBeVisible()
+    await expect(page.getByRole("button", { name: "다시 시도" })).toBeVisible()
+    await expect(page.getByRole("link", { name: "홈으로 이동" })).toBeVisible()
+
+    const reports = await page.evaluate(
+      () =>
+        ((window as Window & { __AQUILA_CLIENT_ERROR_REPORTS__?: ClientErrorReport[] })
+          .__AQUILA_CLIENT_ERROR_REPORTS__ || [])
+    )
+    expect(reports).toHaveLength(1)
+    expect(reports[0]).toMatchObject({
+      boundary: "surface",
+      surface: "markdown",
+      path: "/_qa/error-boundary",
+    })
+    expect(JSON.stringify(reports[0])).not.toContain("secret-token")
+  })
+
+  test("client error telemetry endpoint accepts only sanitized POST payloads", async ({ request }) => {
+    const response = await request.post("/api/rum/client-errors", {
+      data: {
+        id: "err_fixture_123",
+        boundary: "global",
+        surface: "app",
+        path: "/_qa/error-boundary",
+        errorName: "Error",
+        message: "secret-token must be ignored",
+        stack: "secret-token must be ignored",
+      },
+    })
+
+    expect(response.status()).toBe(204)
+
+    const getResponse = await request.get("/api/rum/client-errors")
+    expect(getResponse.status()).toBe(405)
+  })
+})

--- a/front/e2e/error-boundary.spec.ts
+++ b/front/e2e/error-boundary.spec.ts
@@ -13,6 +13,7 @@ test.describe("error boundary launch gate", () => {
   test("source wiring keeps global, markdown, and editor boundaries in place", () => {
     const appSource = readFileSync(sourcePath("pages", "_app.tsx"), "utf8")
     const clientErrorsSource = readFileSync(sourcePath("pages", "api", "rum", "client-errors.ts"), "utf8")
+    const serverErrorSource = readFileSync(sourcePath("pages", "500.tsx"), "utf8")
     const postDetailSource = readFileSync(sourcePath("routes", "Detail", "PostDetail", "index.tsx"), "utf8")
     const writerHostSource = readFileSync(sourcePath("routes", "Admin", "WriterEditorHost.tsx"), "utf8")
 
@@ -26,7 +27,10 @@ test.describe("error boundary launch gate", () => {
     expect(postDetailSource).toContain("<RecoverableSurfaceBoundary")
     expect(writerHostSource).toContain('surface="editor"')
     expect(writerHostSource).toContain("<RecoverableSurfaceBoundary")
+    expect(serverErrorSource).toContain('onRetry={() => router.reload()}')
     expect(clientErrorsSource).toContain("console.info(\"[rum:client-error] boundary caught client render error\", {")
+    expect(clientErrorsSource).toContain('const ALLOWED_SURFACES = new Set(["app", "markdown", "editor"])')
+    expect(clientErrorsSource).toContain("ALLOWED_SURFACES.has(surface)")
     for (const field of ["id", "boundary", "surface", "path", "errorName", "occurredAt"]) {
       expect(clientErrorsSource).toContain(`${field},`)
     }
@@ -96,5 +100,14 @@ test.describe("error boundary launch gate", () => {
 
     const getResponse = await request.get("/api/rum/client-errors")
     expect(getResponse.status()).toBe(405)
+  })
+
+  test("500 page keeps the global retry action available", async ({ page }) => {
+    await page.goto("/500")
+
+    await expect(page.getByRole("heading", { name: "문제가 발생했습니다" })).toBeVisible()
+    await expect(page.getByText("오류 ID: err_server_500")).toBeVisible()
+    await expect(page.getByRole("button", { name: "다시 시도" })).toBeVisible()
+    await expect(page.getByRole("link", { name: "홈으로 이동" })).toBeVisible()
   })
 })

--- a/front/e2e/error-boundary.spec.ts
+++ b/front/e2e/error-boundary.spec.ts
@@ -12,6 +12,7 @@ type ClientErrorReport = {
 test.describe("error boundary launch gate", () => {
   test("source wiring keeps global, markdown, and editor boundaries in place", () => {
     const appSource = readFileSync(sourcePath("pages", "_app.tsx"), "utf8")
+    const clientErrorsSource = readFileSync(sourcePath("pages", "api", "rum", "client-errors.ts"), "utf8")
     const postDetailSource = readFileSync(sourcePath("routes", "Detail", "PostDetail", "index.tsx"), "utf8")
     const writerHostSource = readFileSync(sourcePath("routes", "Admin", "WriterEditorHost.tsx"), "utf8")
 
@@ -25,6 +26,12 @@ test.describe("error boundary launch gate", () => {
     expect(postDetailSource).toContain("<RecoverableSurfaceBoundary")
     expect(writerHostSource).toContain('surface="editor"')
     expect(writerHostSource).toContain("<RecoverableSurfaceBoundary")
+    expect(clientErrorsSource).toContain("console.info(\"[rum:client-error] boundary caught client render error\", {")
+    for (const field of ["id", "boundary", "surface", "path", "errorName", "occurredAt"]) {
+      expect(clientErrorsSource).toContain(`${field},`)
+    }
+    expect(clientErrorsSource).not.toContain("body.message")
+    expect(clientErrorsSource).not.toContain("body.stack")
   })
 
   test("global render exception shows recoverable 500 UX and sanitized telemetry", async ({ page }) => {

--- a/front/src/components/error/ErrorBoundary.tsx
+++ b/front/src/components/error/ErrorBoundary.tsx
@@ -1,0 +1,88 @@
+import type { ErrorInfo, ReactNode } from "react"
+import React from "react"
+
+import { ErrorFallbackView } from "./ErrorFallbackView"
+import {
+  createClientErrorId,
+  reportClientError,
+  type ClientErrorBoundaryKind,
+  type ClientErrorSurface,
+} from "src/libs/rum/reportClientError"
+
+type ErrorBoundaryProps = {
+  children: ReactNode
+  boundary: ClientErrorBoundaryKind
+  surface: ClientErrorSurface
+  resetKey?: string | number
+}
+
+type ErrorBoundaryState = {
+  errorId: string | null
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {
+    errorId: null,
+  }
+
+  static getDerivedStateFromError() {
+    return {
+      errorId: createClientErrorId(),
+    }
+  }
+
+  componentDidCatch(error: unknown, _info: ErrorInfo) {
+    const errorId = this.state.errorId || createClientErrorId()
+    reportClientError({
+      id: errorId,
+      boundary: this.props.boundary,
+      surface: this.props.surface,
+      error,
+    })
+  }
+
+  componentDidUpdate(previousProps: ErrorBoundaryProps) {
+    if (previousProps.resetKey !== this.props.resetKey && this.state.errorId) {
+      this.setState({ errorId: null })
+    }
+  }
+
+  private retry = () => {
+    this.setState({ errorId: null })
+  }
+
+  render() {
+    if (this.state.errorId) {
+      return (
+        <ErrorFallbackView
+          variant={this.props.boundary === "global" ? "global" : "surface"}
+          errorId={this.state.errorId}
+          onRetry={this.retry}
+        />
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+type BoundaryWrapperProps = {
+  children: ReactNode
+  resetKey?: string | number
+}
+
+export const GlobalErrorBoundary = ({ children, resetKey }: BoundaryWrapperProps) => (
+  <ErrorBoundary boundary="global" surface="app" resetKey={resetKey}>
+    {children}
+  </ErrorBoundary>
+)
+
+export const RecoverableSurfaceBoundary = ({
+  children,
+  resetKey,
+  surface,
+}: BoundaryWrapperProps & { surface: Exclude<ClientErrorSurface, "app"> }) => (
+  <ErrorBoundary boundary="surface" surface={surface} resetKey={resetKey}>
+    {children}
+  </ErrorBoundary>
+)

--- a/front/src/components/error/ErrorFallbackView.tsx
+++ b/front/src/components/error/ErrorFallbackView.tsx
@@ -1,0 +1,136 @@
+import styled from "@emotion/styled"
+import Link from "next/link"
+
+type ErrorFallbackVariant = "global" | "surface"
+
+type ErrorFallbackViewProps = {
+  variant: ErrorFallbackVariant
+  errorId: string
+  onRetry?: () => void
+}
+
+const copyByVariant = {
+  global: {
+    status: "500",
+    title: "문제가 발생했습니다",
+    description:
+      "예상하지 못한 오류로 화면을 표시하지 못했습니다. 오류 ID를 남겨두고 다시 시도하거나 홈으로 이동하세요.",
+  },
+  surface: {
+    status: "!",
+    title: "콘텐츠를 표시하지 못했습니다",
+    description:
+      "이 영역을 렌더링하는 중 오류가 발생했습니다. 작성 중인 내용은 브라우저에 남아 있으며 다시 시도할 수 있습니다.",
+  },
+}
+
+export const ErrorFallbackView = ({ variant, errorId, onRetry }: ErrorFallbackViewProps) => {
+  const copy = copyByVariant[variant]
+
+  return (
+    <StyledWrapper data-error-boundary={variant}>
+      <div className="shell">
+        <div className="status" aria-hidden="true">
+          {copy.status}
+        </div>
+        <div className="copy">
+          <h1>{copy.title}</h1>
+          <p>{copy.description}</p>
+          <span>{`오류 ID: ${errorId}`}</span>
+        </div>
+        <div className="actions">
+          {onRetry ? (
+            <button type="button" onClick={onRetry}>
+              다시 시도
+            </button>
+          ) : null}
+          <Link href="/">홈으로 이동</Link>
+        </div>
+      </div>
+    </StyledWrapper>
+  )
+}
+
+const StyledWrapper = styled.section`
+  display: grid;
+  place-items: center;
+  min-height: min(72vh, 42rem);
+  padding: clamp(2rem, 6vw, 4.5rem) 1rem;
+  color: #111827;
+
+  .shell {
+    display: grid;
+    gap: 1.25rem;
+    justify-items: center;
+    width: min(100%, 38rem);
+    text-align: center;
+  }
+
+  .status {
+    display: grid;
+    place-items: center;
+    width: 4.25rem;
+    height: 4.25rem;
+    border: 1px solid #d1d5db;
+    border-radius: 50%;
+    background: #f9fafb;
+    color: #374151;
+    font-size: 1.35rem;
+    font-weight: 800;
+  }
+
+  .copy {
+    display: grid;
+    gap: 0.7rem;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: clamp(1.55rem, 4vw, 2.2rem);
+    line-height: 1.2;
+    letter-spacing: 0;
+  }
+
+  p {
+    margin: 0;
+    color: #4b5563;
+    line-height: 1.7;
+  }
+
+  span {
+    color: #6b7280;
+    font-size: 0.88rem;
+    font-weight: 700;
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.7rem;
+  }
+
+  button,
+  a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    padding: 0 1rem;
+    border: 1px solid #d1d5db;
+    border-radius: 999px;
+    background: #ffffff;
+    color: #111827;
+    font: inherit;
+    font-size: 0.92rem;
+    font-weight: 800;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  button:hover,
+  a:hover {
+    border-color: #9ca3af;
+    background: #f3f4f6;
+  }
+`

--- a/front/src/libs/rum/reportClientError.ts
+++ b/front/src/libs/rum/reportClientError.ts
@@ -1,0 +1,82 @@
+export type ClientErrorBoundaryKind = "global" | "surface"
+
+export type ClientErrorSurface = "app" | "markdown" | "editor"
+
+export type ClientErrorReport = {
+  id: string
+  boundary: ClientErrorBoundaryKind
+  surface: ClientErrorSurface
+  path: string
+  errorName: string
+  occurredAt: string
+}
+
+declare global {
+  interface Window {
+    __AQUILA_CLIENT_ERROR_REPORTS__?: ClientErrorReport[]
+  }
+}
+
+type ReportClientErrorInput = {
+  id: string
+  boundary: ClientErrorBoundaryKind
+  surface: ClientErrorSurface
+  error: unknown
+}
+
+const CLIENT_ERROR_ENDPOINT = "/api/rum/client-errors"
+
+export const createClientErrorId = () => {
+  const timestamp = Date.now().toString(36)
+  const random = Math.random().toString(36).slice(2, 8)
+  return `err_${timestamp}_${random}`
+}
+
+const resolveErrorName = (error: unknown) => {
+  if (error instanceof Error && error.name.trim()) return error.name.trim().slice(0, 80)
+  return "Error"
+}
+
+const sendClientError = (payload: ClientErrorReport) => {
+  const body = JSON.stringify(payload)
+
+  if (typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function") {
+    try {
+      if (navigator.sendBeacon(CLIENT_ERROR_ENDPOINT, new Blob([body], { type: "application/json" }))) {
+        return
+      }
+    } catch {
+      // fallback to fetch below
+    }
+  }
+
+  void fetch(CLIENT_ERROR_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body,
+    keepalive: true,
+  }).catch(() => {
+    // ignore
+  })
+}
+
+export const reportClientError = ({ id, boundary, surface, error }: ReportClientErrorInput) => {
+  if (typeof window === "undefined") return
+
+  const payload: ClientErrorReport = {
+    id,
+    boundary,
+    surface,
+    path: window.location.pathname,
+    errorName: resolveErrorName(error),
+    occurredAt: new Date().toISOString(),
+  }
+
+  window.__AQUILA_CLIENT_ERROR_REPORTS__ = [...(window.__AQUILA_CLIENT_ERROR_REPORTS__ || []), payload]
+
+  if (process.env.NODE_ENV === "production") {
+    sendClientError(payload)
+  }
+}

--- a/front/src/pages/500.tsx
+++ b/front/src/pages/500.tsx
@@ -1,0 +1,19 @@
+import { CONFIG } from "site.config"
+import MetaConfig from "src/components/MetaConfig"
+import { ErrorFallbackView } from "src/components/error/ErrorFallbackView"
+
+const ServerErrorPage = () => (
+  <>
+    <MetaConfig
+      title="문제가 발생했습니다"
+      description="요청한 화면을 표시하지 못했습니다."
+      type="website"
+      url={CONFIG.link}
+      robots="noindex, follow"
+      canonicalUrl={null}
+    />
+    <ErrorFallbackView variant="global" errorId="err_server_500" />
+  </>
+)
+
+export default ServerErrorPage

--- a/front/src/pages/500.tsx
+++ b/front/src/pages/500.tsx
@@ -1,19 +1,24 @@
+import { useRouter } from "next/router"
 import { CONFIG } from "site.config"
 import MetaConfig from "src/components/MetaConfig"
 import { ErrorFallbackView } from "src/components/error/ErrorFallbackView"
 
-const ServerErrorPage = () => (
-  <>
-    <MetaConfig
-      title="문제가 발생했습니다"
-      description="요청한 화면을 표시하지 못했습니다."
-      type="website"
-      url={CONFIG.link}
-      robots="noindex, follow"
-      canonicalUrl={null}
-    />
-    <ErrorFallbackView variant="global" errorId="err_server_500" />
-  </>
-)
+const ServerErrorPage = () => {
+  const router = useRouter()
+
+  return (
+    <>
+      <MetaConfig
+        title="문제가 발생했습니다"
+        description="요청한 화면을 표시하지 못했습니다."
+        type="website"
+        url={CONFIG.link}
+        robots="noindex, follow"
+        canonicalUrl={null}
+      />
+      <ErrorFallbackView variant="global" errorId="err_server_500" onRetry={() => router.reload()} />
+    </>
+  )
+}
 
 export default ServerErrorPage

--- a/front/src/pages/_app.tsx
+++ b/front/src/pages/_app.tsx
@@ -4,8 +4,10 @@ import { HydrationBoundary, QueryClientProvider } from "@tanstack/react-query"
 import type { NextWebVitalsMetric } from "next/app"
 import dynamic from "next/dynamic"
 import Head from "next/head"
+import { useRouter } from "next/router"
 import { RootLayout } from "src/layouts"
 import type { AdminProfile } from "src/hooks/useAdminProfile"
+import { GlobalErrorBoundary } from "src/components/error/ErrorBoundary"
 import createEmotionCache from "src/libs/emotion/createEmotionCache"
 import { createQueryClient } from "src/libs/react-query"
 import { useState } from "react"
@@ -31,6 +33,7 @@ function App({ Component, pageProps, emotionCache = clientSideEmotionCache }: Ap
   const initialAdminProfile = appPageProps.initialAdminProfile ?? appPageProps.initialProfileSnapshot ?? null
   const initialAdminProfileShouldRefetch = appPageProps.initialAdminProfileSource === "static-fallback"
   const [queryClient] = useState(createQueryClient)
+  const router = useRouter()
 
   return (
     <CacheProvider value={emotionCache}>
@@ -38,22 +41,24 @@ function App({ Component, pageProps, emotionCache = clientSideEmotionCache }: Ap
         <title>AquilaLog</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
       </Head>
-      <QueryClientProvider client={queryClient}>
-        <HydrationBoundary state={pageProps.dehydratedState}>
-          <RootLayout
-            initialAdminProfile={initialAdminProfile}
-            initialAdminProfileShouldRefetch={initialAdminProfileShouldRefetch}
-          >
-            {getLayout(<Component {...pageProps} />)}
-            {process.env.NODE_ENV === "production" ? (
-              <>
-                <Analytics />
-                <SpeedInsights />
-              </>
-            ) : null}
-          </RootLayout>
-        </HydrationBoundary>
-      </QueryClientProvider>
+      <GlobalErrorBoundary resetKey={router.asPath}>
+        <QueryClientProvider client={queryClient}>
+          <HydrationBoundary state={pageProps.dehydratedState}>
+            <RootLayout
+              initialAdminProfile={initialAdminProfile}
+              initialAdminProfileShouldRefetch={initialAdminProfileShouldRefetch}
+            >
+              {getLayout(<Component {...pageProps} />)}
+              {process.env.NODE_ENV === "production" ? (
+                <>
+                  <Analytics />
+                  <SpeedInsights />
+                </>
+              ) : null}
+            </RootLayout>
+          </HydrationBoundary>
+        </QueryClientProvider>
+      </GlobalErrorBoundary>
     </CacheProvider>
   )
 }

--- a/front/src/pages/_qa/error-boundary.tsx
+++ b/front/src/pages/_qa/error-boundary.tsx
@@ -1,0 +1,45 @@
+import type { GetServerSideProps, NextPage } from "next"
+import { useRouter } from "next/router"
+
+import { RecoverableSurfaceBoundary } from "src/components/error/ErrorBoundary"
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  if (process.env.ENABLE_QA_ROUTES !== "true") {
+    return {
+      notFound: true,
+    }
+  }
+
+  return {
+    props: {},
+  }
+}
+
+const ThrowingSurface = () => {
+  if (typeof window === "undefined") return <p>Preparing local crash fixture.</p>
+  throw new Error("qa local crash secret-token")
+}
+
+const GlobalThrow = () => {
+  if (typeof window === "undefined") return <p>Preparing global crash fixture.</p>
+  throw new Error("qa global crash secret-token")
+}
+
+const ErrorBoundaryQaPage: NextPage = () => {
+  const { query } = useRouter()
+
+  if (query.mode === "global") {
+    return <GlobalThrow />
+  }
+
+  return (
+    <div data-testid="qa-error-boundary-shell">
+      <p>QA shell keeps rendering around the failed surface.</p>
+      <RecoverableSurfaceBoundary surface="markdown">
+        <ThrowingSurface />
+      </RecoverableSurfaceBoundary>
+    </div>
+  )
+}
+
+export default ErrorBoundaryQaPage

--- a/front/src/pages/api/rum/client-errors.ts
+++ b/front/src/pages/api/rum/client-errors.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+type ClientErrorBody = {
+  id?: unknown
+  boundary?: unknown
+  surface?: unknown
+  path?: unknown
+  errorName?: unknown
+  occurredAt?: unknown
+}
+
+const ALLOWED_BOUNDARIES = new Set(["global", "surface"])
+const SAFE_TEXT = /^[A-Za-z0-9_./:-]+$/
+
+const toSafeString = (value: unknown, maxLength: number) => {
+  if (typeof value !== "string") return ""
+  const normalized = value.replace(/[\r\n\t]/g, " ").replace(/\s+/g, " ").trim().slice(0, maxLength)
+  return SAFE_TEXT.test(normalized) ? normalized : ""
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST")
+    return res.status(405).json({ message: "Method Not Allowed" })
+  }
+
+  const body = (req.body || {}) as ClientErrorBody
+  const id = toSafeString(body.id, 80)
+  const boundary = toSafeString(body.boundary, 16)
+  const surface = toSafeString(body.surface, 40)
+  const path = toSafeString(body.path, 260)
+  const errorName = toSafeString(body.errorName, 80)
+  const occurredAt = toSafeString(body.occurredAt, 40)
+
+  if (id && ALLOWED_BOUNDARIES.has(boundary) && surface && path && errorName && occurredAt) {
+    console.info("[rum:client-error] boundary caught client render error")
+  }
+
+  return res.status(204).end()
+}

--- a/front/src/pages/api/rum/client-errors.ts
+++ b/front/src/pages/api/rum/client-errors.ts
@@ -33,7 +33,14 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const occurredAt = toSafeString(body.occurredAt, 40)
 
   if (id && ALLOWED_BOUNDARIES.has(boundary) && surface && path && errorName && occurredAt) {
-    console.info("[rum:client-error] boundary caught client render error")
+    console.info("[rum:client-error] boundary caught client render error", {
+      id,
+      boundary,
+      surface,
+      path,
+      errorName,
+      occurredAt,
+    })
   }
 
   return res.status(204).end()

--- a/front/src/pages/api/rum/client-errors.ts
+++ b/front/src/pages/api/rum/client-errors.ts
@@ -10,6 +10,7 @@ type ClientErrorBody = {
 }
 
 const ALLOWED_BOUNDARIES = new Set(["global", "surface"])
+const ALLOWED_SURFACES = new Set(["app", "markdown", "editor"])
 const SAFE_TEXT = /^[A-Za-z0-9_./:-]+$/
 
 const toSafeString = (value: unknown, maxLength: number) => {
@@ -32,7 +33,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const errorName = toSafeString(body.errorName, 80)
   const occurredAt = toSafeString(body.occurredAt, 40)
 
-  if (id && ALLOWED_BOUNDARIES.has(boundary) && surface && path && errorName && occurredAt) {
+  if (id && ALLOWED_BOUNDARIES.has(boundary) && ALLOWED_SURFACES.has(surface) && path && errorName && occurredAt) {
     console.info("[rum:client-error] boundary caught client render error", {
       id,
       boundary,

--- a/front/src/routes/Admin/WriterEditorHost.tsx
+++ b/front/src/routes/Admin/WriterEditorHost.tsx
@@ -1,4 +1,5 @@
 import { Profiler } from "react"
+import { RecoverableSurfaceBoundary } from "src/components/error/ErrorBoundary"
 import { MarkdownEditor } from "src/components/markdown-editor/MarkdownEditor"
 
 type WriterEditorHostProps = {
@@ -29,13 +30,15 @@ export const WriterEditorHost = ({
       onCommitDuration?.(actualDuration)
     }}
   >
-    <MarkdownEditor
-      value={markdown}
-      onChange={onMarkdownChange}
-      onFlushMarkdownReady={onFlushMarkdownReady}
-      onUploadImage={onImageUpload}
-      disableMermaid={!mermaidEnabled}
-      disabled={disabled}
-    />
+    <RecoverableSurfaceBoundary surface="editor" resetKey={canvasId}>
+      <MarkdownEditor
+        value={markdown}
+        onChange={onMarkdownChange}
+        onFlushMarkdownReady={onFlushMarkdownReady}
+        onUploadImage={onImageUpload}
+        disableMermaid={!mermaidEnabled}
+        disabled={disabled}
+      />
+    </RecoverableSurfaceBoundary>
   </Profiler>
 )

--- a/front/src/routes/Detail/PostDetail/index.tsx
+++ b/front/src/routes/Detail/PostDetail/index.tsx
@@ -18,6 +18,7 @@ import { LEFT_RAIL_HYBRID_MIN_VIEWPORT_PX, RIGHT_RAIL_HYBRID_MIN_VIEWPORT_PX, ap
 import { CompactToc, FloatingActionRail, MobileSummaryActions, RightTocRail } from "./PostDetailActionSections"
 import { usePostDetailEngagementActions } from "./usePostDetailEngagementActions"
 import { usePostDetailRelatedPosts } from "./usePostDetailRelatedPosts"
+import { RecoverableSurfaceBoundary } from "src/components/error/ErrorBoundary"
 
 type Props = {
   initialComments?: TPostComment[] | null
@@ -466,7 +467,9 @@ const PostDetail: React.FC<Props> = ({ initialComments = null }) => {
             />
           )}
           <BodySection data-rum-section="body">
-            <MarkdownRenderer content={renderedContent} />
+            <RecoverableSurfaceBoundary surface="markdown" resetKey={postId}>
+              <MarkdownRenderer content={renderedContent} />
+            </RecoverableSurfaceBoundary>
           </BodySection>
           {data.type[0] === "Post" && <div ref={relatedPrefetchTriggerRef} className="relatedPrefetchTrigger" aria-hidden="true" />}
           {data.type[0] === "Post" && shouldFetchRelated ? (


### PR DESCRIPTION
## 관련 이슈

close #936

## 작업 배경

- client render exception이 발생했을 때 전역 fallback, 500 페이지, Markdown/editor 국소 fallback, privacy-safe telemetry 수신 계약이 없어 blank screen과 작성 흐름 손실 위험이 있었다.
- QA-only render exception fixture로 전역/국소 boundary가 실제 브라우저 렌더 예외를 복구하는지 검증할 수 있게 했다.

## 작업 내용

- `_app`에 `GlobalErrorBoundary`를 추가하고 route 변경 시 fallback state를 reset한다.
- Markdown 상세 본문과 editor host를 `RecoverableSurfaceBoundary`로 감싸 국소 렌더 오류가 전체 앱을 대체하지 않게 했다.
- `/500` 페이지와 공통 `ErrorFallbackView`를 추가해 오류 ID, 다시 시도, 홈 이동 UX를 제공한다.
- `reportClientError`와 `/api/rum/client-errors`를 추가해 error message/stack 없이 id, boundary, surface, path, errorName, occurredAt만 수신한다.
- `/api/rum/client-errors`는 boundary와 surface allowlist를 모두 적용해 RUM 로그 카디널리티 오염을 막는다.
- `_qa/error-boundary`와 e2e spec을 추가해 global/local render crash, telemetry sanitization, 500 retry, endpoint 204/405 계약을 검증한다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front test`: 실패. `front/package.json`에 `test` script가 없어 `Command "test" not found`로 종료됨.
  - `yarn --cwd front playwright:preflight`: 성공.
  - `yarn --cwd front playwright test e2e/error-boundary.spec.ts --workers=1`: 성공, 5 passed. CodeRabbit follow-up 후 동일 명령 2회 연속 성공.
  - `yarn --cwd front test:e2e:smoke`: 성공, 65 passed.
  - `yarn --cwd front build`: 성공. `/500`, `/_qa/error-boundary`, `/api/rum/client-errors` route 포함.
  - `yarn --cwd front check:bundle-size`: 성공. `/`, `/posts/[id]`, `/admin` raw/gzip/brotli 모두 budget OK.
  - `git diff --check`: 성공.
  - PR checks: `frontend-ci`, `backend-ci`, `Security/CodeQL`, `Vercel`, `CodeRabbit` 모두 성공.
  - post-merge main CI/Security: 성공. `CI` run `27890763638`, `Security` run `27890763603`.
  - post-merge CD: 성공. `Deploy to Home Server` run `27890896566`, `Frontend Live E2E Verification` 성공. 이번 frontend-only merge에서 `buildAndPush`와 `blueGreenDeploy`는 deploy target 조건상 skipped.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 전역 error boundary UX | local production Next server, Chromium via DOM snapshot | `/_qa/error-boundary?mode=global` 렌더 후 DOM snapshot 확인 | heading `문제가 발생했습니다`, `오류 ID: err_`, `다시 시도`, `홈으로 이동`, `bodyContainsSecret=false` | 통과 |
| 국소 Markdown boundary UX | local production Next server, Chromium via DOM snapshot | `/_qa/error-boundary?mode=local` 렌더 후 DOM snapshot 확인 | shell 유지, heading `콘텐츠를 표시하지 못했습니다`, `오류 ID: err_`, `다시 시도`, `홈으로 이동`, `bodyContainsSecret=false` | 통과 |
| 500 retry UX | local Playwright | `/500` route 렌더 후 retry/home action 확인 | `오류 ID: err_server_500`, `다시 시도`, `홈으로 이동` | 통과 |
| telemetry sanitization | Playwright fixture | `window.__AQUILA_CLIENT_ERROR_REPORTS__`와 endpoint POST fixture 검증 | report payload는 `boundary`, `surface`, `path`를 포함하고 `secret-token` 미포함. `/api/rum/client-errors` POST 204, GET 405 | 통과 |
| 공개 상세/모바일 회귀 | local Playwright | `yarn --cwd front test:e2e:smoke` | 65 passed | 통과 |
| bundle budget | local build artifact | `yarn --cwd front check:bundle-size` | `/` gzip 160.1KB OK, `/posts/[id]` gzip 157.1KB OK, `/admin` gzip 137.7KB OK | 통과 |

## 리뷰어 메모

- Codex CLI fallback initial finding 1건은 PR review로 먼저 게시한 뒤 `ffa9454d`에서 수정했고, 원래 inline thread에 해결 답글을 남긴 뒤 resolved 처리했다.
- CodeRabbit actionable 2건은 PR review로 게시된 뒤 `68c89ef7`에서 수정했고, 각 원래 inline thread에 해결 답글을 남겼으며 CodeRabbit addressed 확인과 resolved 상태를 확인했다.
- `reportClientError`는 privacy-safe payload만 만들고 production에서 `sendBeacon` 실패 시 `fetch`로 fallback한다.
- QA route는 `ENABLE_QA_ROUTES=true`일 때만 열리며 production 기본 환경에서는 `notFound`다.

## 리스크

- React는 render crash 원본 error를 브라우저 console에 출력한다. telemetry payload와 DOM에는 원문 message/stack을 싣지 않는 방식으로 개인정보 노출을 줄였다.
- frontend runtime 변경이므로 main merge 후 홈서버 CD와 live e2e 상태를 확인했다. #933 HOME_SERVER_ENV secret blocker는 `2026-06-21`에 갱신 및 failed deployment rerun 성공으로 해소됐다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
