### PR TITLE
[Fix] 홈 bootstrap 실패를 빈 글 목록으로 숨기지 않기

### DIFF
--- a/front/e2e/perf-feed.spec.ts
+++ b/front/e2e/perf-feed.spec.ts
@@ -42,6 +42,49 @@ test.describe("perf feed scroll budgets", () => {
     ])
   })
 
+  test("홈 피드는 초기 bootstrap/feed 실패를 빈 글 목록으로 숨기지 않는다", async ({ page }) => {
+    let feedAttempts = 0
+    let allowFeedRecovery = false
+
+    await mockFeedEndpoints(page, {
+      feedHandler: async (route) => {
+        feedAttempts += 1
+        if (!allowFeedRecovery) {
+          await route.fulfill({
+            status: 503,
+            contentType: "application/json",
+            body: JSON.stringify({ message: "feed bootstrap temporarily unavailable" }),
+          })
+          return
+        }
+
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            content: [buildMockExploreItem(1171)],
+            pageSize: 24,
+            hasNext: false,
+            nextCursor: null,
+          }),
+        })
+      },
+    })
+
+    await page.goto("/")
+    await waitForPageReady(page)
+
+    await expect(page.getByText("게시글을 불러오지 못했습니다.")).toBeVisible()
+    await expect(page.getByText("아직 게시글이 없습니다.")).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "다시 시도" })).toBeVisible()
+
+    allowFeedRecovery = true
+    await page.getByRole("button", { name: "다시 시도" }).click()
+
+    await expect(page.getByRole("heading", { name: "CLS 예산 점검 1171" })).toBeVisible()
+    expect(feedAttempts).toBeGreaterThan(1)
+  })
+
   test("홈 피드는 다음 cursor 실패를 빈 결과로 숨기지 않고 재시도 버튼을 보여준다", async ({ page }) => {
   let nextCursorAttempts = 0
   const firstPageIds = Array.from({ length: 16 }, (_, index) => 1201 + index)

--- a/front/e2e/perf-feed.spec.ts
+++ b/front/e2e/perf-feed.spec.ts
@@ -78,11 +78,12 @@ test.describe("perf feed scroll budgets", () => {
     await expect(page.getByText("아직 게시글이 없습니다.")).toHaveCount(0)
     await expect(page.getByRole("button", { name: "다시 시도" })).toBeVisible()
 
+    const attemptsBeforeRetry = feedAttempts
     allowFeedRecovery = true
     await page.getByRole("button", { name: "다시 시도" }).click()
 
     await expect(page.getByRole("heading", { name: "CLS 예산 점검 1171" })).toBeVisible()
-    expect(feedAttempts).toBeGreaterThan(1)
+    expect(feedAttempts).toBeGreaterThan(attemptsBeforeRetry)
   })
 
   test("홈 피드는 다음 cursor 실패를 빈 결과로 숨기지 않고 재시도 버튼을 보여준다", async ({ page }) => {

--- a/front/src/hooks/useExplorePostsQuery.ts
+++ b/front/src/hooks/useExplorePostsQuery.ts
@@ -163,9 +163,12 @@ const useExplorePostsQuery = ({
     loadedPagesCount: query.data?.pages.length ?? 0,
     hasNextPage: query.hasNextPage ?? false,
     isInitialLoading: query.isLoading,
+    isInitialLoadError: query.isError && !(query.data?.pages.length),
+    hasInitialLoadSucceeded: query.isSuccess,
     isFetchingNextPage: query.isFetchingNextPage,
     isFetchNextPageError: query.isFetchNextPageError,
     fetchNextPage: query.fetchNextPage,
+    refetchInitialPage: query.refetch,
   }
 }
 

--- a/front/src/hooks/useExplorePostsQuery.ts
+++ b/front/src/hooks/useExplorePostsQuery.ts
@@ -164,7 +164,7 @@ const useExplorePostsQuery = ({
     hasNextPage: query.hasNextPage ?? false,
     isInitialLoading: query.isLoading,
     isInitialLoadError: query.isError && !(query.data?.pages.length),
-    hasInitialLoadSucceeded: query.isSuccess,
+    hasInitialLoadSucceeded: query.isSuccess && query.isFetchedAfterMount,
     isFetchingNextPage: query.isFetchingNextPage,
     isFetchNextPageError: query.isFetchNextPageError,
     fetchNextPage: query.fetchNextPage,

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -20,6 +20,7 @@ import { setAdminProfileCache } from "src/hooks/useAdminProfile"
 const HOME_ISR_REVALIDATE_SECONDS = 60
 const HOME_QA_SHELL_REVALIDATE_SECONDS = 15
 const IS_QA_STATIC_SHELL_MODE = process.env.ENABLE_QA_ROUTES === "true"
+type HomeBootstrapStatus = "ready" | "degraded" | "shell"
 
 const fetchPublicAdminProfile = async (): Promise<AdminProfile> =>
   await apiFetch<AdminProfile>("/member/api/v1/members/adminProfile")
@@ -41,6 +42,7 @@ export const getStaticProps: GetStaticProps = async () => {
         nextCursor: null as string | null,
         postsLoaded: false,
         tagsLoaded: false,
+        status: "shell" as HomeBootstrapStatus,
       }
     }
 
@@ -61,6 +63,7 @@ export const getStaticProps: GetStaticProps = async () => {
         nextCursor: bootstrapResult.nextCursor ?? null,
         postsLoaded: true,
         tagsLoaded: true,
+        status: "ready" as HomeBootstrapStatus,
       }
     } catch {
       return {
@@ -72,10 +75,11 @@ export const getStaticProps: GetStaticProps = async () => {
         nextCursor: null as string | null,
         postsLoaded: false,
         tagsLoaded: false,
+        status: "degraded" as HomeBootstrapStatus,
       }
     }
   })()
-  const { posts, tagCounts, totalCount, initialPageTotalCount, hasNext, nextCursor, postsLoaded, tagsLoaded } =
+  const { posts, tagCounts, totalCount, initialPageTotalCount, hasNext, nextCursor, postsLoaded, tagsLoaded, status } =
     bootstrapSnapshot
 
   setAdminProfileCache(queryClient, initialAdminProfile)
@@ -120,6 +124,7 @@ export const getStaticProps: GetStaticProps = async () => {
       dehydratedState: dehydrate(queryClient),
       initialAdminProfile,
       initialAdminProfileSource,
+      initialHomeBootstrapStatus: status,
     },
     revalidate:
       IS_QA_STATIC_SHELL_MODE || !postsLoaded ? HOME_QA_SHELL_REVALIDATE_SECONDS : HOME_ISR_REVALIDATE_SECONDS,
@@ -129,9 +134,10 @@ export const getStaticProps: GetStaticProps = async () => {
 type FeedPageProps = {
   initialAdminProfile: AdminProfile | null
   initialAdminProfileSource: StaticAdminProfileSeedSource
+  initialHomeBootstrapStatus: HomeBootstrapStatus
 }
 
-const FeedPage: NextPageWithLayout<FeedPageProps> = ({ initialAdminProfile }) => {
+const FeedPage: NextPageWithLayout<FeedPageProps> = ({ initialAdminProfile, initialHomeBootstrapStatus }) => {
   const feedTitle =
     initialAdminProfile?.blogTitle ||
     CONFIG.blog.title ||
@@ -148,7 +154,7 @@ const FeedPage: NextPageWithLayout<FeedPageProps> = ({ initialAdminProfile }) =>
   return (
     <>
       <MetaConfig {...meta} />
-      <Feed initialAdminProfile={initialAdminProfile} />
+      <Feed initialAdminProfile={initialAdminProfile} initialHomeBootstrapStatus={initialHomeBootstrapStatus} />
     </>
   )
 }

--- a/front/src/routes/Feed/FeedExplorer.tsx
+++ b/front/src/routes/Feed/FeedExplorer.tsx
@@ -45,7 +45,12 @@ import {
 
 const LOAD_MORE_THROTTLE_MS = 800
 const LOAD_MORE_OBSERVER_THROTTLE_MS = 180
-const FeedExplorer = () => {
+
+type FeedExplorerProps = {
+  initialBootstrapDegraded?: boolean
+}
+
+const FeedExplorer: React.FC<FeedExplorerProps> = ({ initialBootstrapDegraded = false }) => {
   const queryClient = useQueryClient()
   const [q, setQ] = useState("")
   const [isComposing, setIsComposing] = useState(false)
@@ -87,9 +92,12 @@ const FeedExplorer = () => {
     loadedPagesCount,
     hasNextPage,
     isInitialLoading,
+    isInitialLoadError,
+    hasInitialLoadSucceeded,
     isFetchingNextPage,
     isFetchNextPageError,
     fetchNextPage,
+    refetchInitialPage,
   } = useExplorePostsQuery({
     kw: debouncedQ,
     tag: currentTag,
@@ -402,6 +410,7 @@ const FeedExplorer = () => {
 
   const hasFilter = Boolean(normalizedQuery || currentTag)
   const resultCount = pinnedPosts.length + regularPosts.length
+  const showBootstrapDegraded = initialBootstrapDegraded && !hasInitialLoadSucceeded
   const hasQueryFilter = normalizedQuery.length > 0
   const hasTagFilter = Boolean(currentTag)
   const filterSummary = useMemo(() => {
@@ -413,8 +422,9 @@ const FeedExplorer = () => {
   }, [currentTag, hasFilter, hasQueryFilter, hasTagFilter, normalizedQuery])
   const contextStatusLabel = useMemo(() => {
     if (isInitialLoading) return hasFilter ? "검색 결과를 불러오는 중..." : "피드를 불러오는 중..."
+    if (showBootstrapDegraded && resultCount > 0) return "최근 저장된 글을 먼저 표시 중"
     return ""
-  }, [hasFilter, isInitialLoading])
+  }, [hasFilter, isInitialLoading, resultCount, showBootstrapDegraded])
 
   const handleClearFilters = useCallback(() => {
     setQ("")
@@ -470,10 +480,12 @@ const FeedExplorer = () => {
             hasExternalResults={pinnedPosts.length > 0}
             onClearFilters={handleClearFilters}
             isInitialLoading={isInitialLoading}
+            isInitialLoadError={isInitialLoadError || (showBootstrapDegraded && resultCount === 0)}
             isFetchingNextPage={isFetchingNextPage}
             isFetchNextPageError={isFetchNextPageError}
             hasNextPage={hasNextPage}
             onLoadMore={handleLoadMore}
+            onRetryInitialLoad={refetchInitialPage}
             onRetryLoadMore={handleRetryLoadMore}
             loadMoreTriggerRef={loadMoreTriggerRef}
           />

--- a/front/src/routes/Feed/PostList/InitialLoadErrorState.tsx
+++ b/front/src/routes/Feed/PostList/InitialLoadErrorState.tsx
@@ -1,0 +1,76 @@
+import React, { memo } from "react"
+import styled from "@emotion/styled"
+import AppIcon from "src/components/icons/AppIcon"
+
+type Props = {
+  hasFilter: boolean
+  onRetryInitialLoad?: () => void
+}
+
+const InitialLoadErrorState: React.FC<Props> = ({ hasFilter, onRetryInitialLoad }) => (
+  <StyledWrapper role="alert" aria-live="assertive">
+    <div className="initialLoadErrorIcon" aria-hidden="true">
+      <AppIcon name="question" />
+    </div>
+    <h3>{hasFilter ? "검색 결과를 불러오지 못했습니다." : "게시글을 불러오지 못했습니다."}</h3>
+    <p>일시적인 연결 문제일 수 있습니다. 기존 빈 목록으로 처리하지 않고 다시 시도할 수 있습니다.</p>
+    <button type="button" onClick={onRetryInitialLoad}>
+      다시 시도
+    </button>
+  </StyledWrapper>
+)
+
+export default memo(InitialLoadErrorState)
+
+const StyledWrapper = styled.section`
+  grid-column: 1 / -1;
+  border-top: 1px solid ${({ theme }) => theme.colors.red6};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.red6};
+  min-height: 10rem;
+  padding: 1rem 0;
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 0.48rem;
+  text-align: center;
+
+  .initialLoadErrorIcon {
+    width: 2.1rem;
+    height: 2.1rem;
+    border-radius: 8px;
+    border: 1px solid ${({ theme }) => theme.colors.red6};
+    color: ${({ theme }) => theme.colors.red11};
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+  }
+
+  h3 {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.red11};
+    font-size: 1.02rem;
+    font-weight: 800;
+    line-height: 1.35;
+  }
+
+  p {
+    margin: 0;
+    max-width: 29rem;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.88rem;
+    line-height: 1.55;
+  }
+
+  button {
+    min-height: 36px;
+    padding: 0 0.82rem;
+    border-radius: 8px;
+    border: 1px solid ${({ theme }) => theme.colors.blue7};
+    background: transparent;
+    color: ${({ theme }) => theme.colors.blue11};
+    font-size: 0.84rem;
+    font-weight: 700;
+    cursor: pointer;
+  }
+`

--- a/front/src/routes/Feed/PostList/index.tsx
+++ b/front/src/routes/Feed/PostList/index.tsx
@@ -2,6 +2,7 @@ import React, { RefObject, memo, useEffect, useRef, useState } from "react"
 import styled from "@emotion/styled"
 import Link from "next/link"
 import PostCard from "src/routes/Feed/PostList/PostCard"
+import InitialLoadErrorState from "src/routes/Feed/PostList/InitialLoadErrorState"
 import AppIcon from "src/components/icons/AppIcon"
 import useAuthSession from "src/hooks/useAuthSession"
 import { TPost } from "src/types"
@@ -12,10 +13,12 @@ type Props = {
   hasExternalResults?: boolean
   onClearFilters?: () => void
   isInitialLoading?: boolean
+  isInitialLoadError?: boolean
   isFetchingNextPage?: boolean
   isFetchNextPageError?: boolean
   hasNextPage?: boolean
   onLoadMore?: () => void
+  onRetryInitialLoad?: () => void
   onRetryLoadMore?: () => void
   loadMoreTriggerRef?: RefObject<HTMLDivElement>
 }
@@ -103,10 +106,12 @@ const PostList: React.FC<Props> = ({
   hasExternalResults = false,
   onClearFilters,
   isInitialLoading = false,
+  isInitialLoadError = false,
   isFetchingNextPage = false,
   isFetchNextPageError = false,
   hasNextPage = false,
   onLoadMore,
+  onRetryInitialLoad,
   onRetryLoadMore,
   loadMoreTriggerRef,
 }) => {
@@ -115,7 +120,8 @@ const PostList: React.FC<Props> = ({
   const [mountedCardCount, setMountedCardCount] = useState(() =>
     Math.min(posts.length, DEFERRED_MOUNT_INITIAL_COUNT)
   )
-  const showEmptyState = !isInitialLoading && !posts.length && !hasExternalResults
+  const showInitialLoadError = !isInitialLoading && isInitialLoadError && !posts.length && !hasExternalResults
+  const showEmptyState = !showInitialLoadError && !isInitialLoading && !posts.length && !hasExternalResults
 
   useEffect(() => {
     const nextFirstPostId = posts[0] ? String(posts[0].id) : null
@@ -180,6 +186,9 @@ const PostList: React.FC<Props> = ({
             ))}
           </div>
         ))}
+      {showInitialLoadError && (
+        <InitialLoadErrorState hasFilter={hasFilter} onRetryInitialLoad={onRetryInitialLoad} />
+      )}
       {showEmptyState && <EmptyPostState hasFilter={hasFilter} onClearFilters={onClearFilters} />}
       {posts.map((post, index) => {
         const shouldMountCard = index < mountedCardCount

--- a/front/src/routes/Feed/index.tsx
+++ b/front/src/routes/Feed/index.tsx
@@ -11,11 +11,12 @@ import { replaceShallowRoutePreservingScroll } from "src/libs/router"
 
 type Props = {
   initialAdminProfile?: AdminProfile | null
+  initialHomeBootstrapStatus?: "ready" | "degraded" | "shell"
 }
 
 const TOPIC_RAIL_TAG_LIMIT = 3
 
-const Feed: React.FC<Props> = ({ initialAdminProfile = null }) => {
+const Feed: React.FC<Props> = ({ initialAdminProfile = null, initialHomeBootstrapStatus = "ready" }) => {
   const router = useRouter()
   const adminProfile = useAdminProfile(initialAdminProfile)
   const { tagEntries } = useTagsQuery()
@@ -79,7 +80,7 @@ const Feed: React.FC<Props> = ({ initialAdminProfile = null }) => {
           </div>
           <ProfileSummaryCard initialAdminProfile={initialAdminProfile} />
         </IntroCard>
-        <FeedExplorer />
+        <FeedExplorer initialBootstrapDegraded={initialHomeBootstrapStatus === "degraded"} />
         <div className="footer">
           <Footer />
         </div>


### PR DESCRIPTION
## 관련 이슈

close #937

## 작업 배경

- 홈 `getStaticProps` bootstrap 실패가 `posts: []` 상태로만 내려가면 실제 빈 블로그와 backend 장애가 구분되지 않는다.
- 초기 feed 요청이 자동 retry까지 실패해도 기존 empty state가 보여 운영 장애를 정상 빈 목록처럼 오인할 수 있다.

## 작업 내용

- 홈 bootstrap 결과에 `ready | degraded | shell` 상태를 추가하고 `Feed`까지 전달했다.
- React Query 초기 feed load error와 retry 함수를 `FeedExplorer`/`PostList`에 연결했다.
- 초기 게시글 로드 실패 전용 `InitialLoadErrorState`를 추가해 “게시글을 불러오지 못했습니다.”와 `다시 시도` 동작을 제공한다.
- client fetch가 성공하면 SSR degraded 상태를 해제해 실제 빈 목록은 기존 empty state로 표시되게 했다.
- 초기 feed 실패가 empty state로 숨겨지지 않고 retry 후 정상 카드로 복구되는 Playwright 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - RED: `yarn --cwd front playwright test e2e/perf-feed.spec.ts --grep "초기 bootstrap/feed 실패" --workers=1` 실패 확인 (`게시글을 불러오지 못했습니다.` 미노출)
  - `yarn --cwd front playwright:preflight`: 통과
  - `yarn --cwd front playwright test e2e/perf-feed.spec.ts --workers=1`: 8 passed, 2회 연속 통과
  - `yarn --cwd front build`: 통과
  - `node front/scripts/check-bundle-size.mjs`: OK
  - `git diff --check`: 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `front/src/pages/index.tsx`의 `initialHomeBootstrapStatus`
  - `front/src/routes/Feed/FeedExplorer.tsx`의 SSR degraded 해제 조건
  - `front/src/routes/Feed/PostList/InitialLoadErrorState.tsx`의 초기 실패 UX와 retry
  - `front/e2e/perf-feed.spec.ts`의 자동 retry 전부 실패 후 사용자 retry fixture

## 리스크

- #934 post-merge CD가 `OPERATIONS_ALERT_WEBHOOK_URL` 누락으로 아직 실패 중이다. 이 PR도 merge 후 CD 완료 확인은 #934 secret blocker 해소 후 가능하다.
- bootstrap degraded 상태는 client feed fetch 성공 후 해제된다. backend가 계속 실패하면 retry UI가 유지된다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 홈 피드 로드 실패 시 명확한 오류 메시지와 "다시 시도" 버튼을 표시하여 사용자가 손쉽게 복구할 수 있도록 개선

* **새 기능**
  * 초기 로드 실패 상황에서 부트스트랩 상태를 구분하여 더 안정적인 피드 복구 환경 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->