### PR TITLE
[Fix] 메인 화면 테마 전환 다크 모드 고정 수정

### DIFF
--- a/front/e2e/perf-layout.spec.ts
+++ b/front/e2e/perf-layout.spec.ts
@@ -454,8 +454,8 @@ test.describe("성능 레이아웃과 표면 예산", () => {
     if (scenario.route === "/") {
       expect(fingerprint.searchBg).toBe("rgb(22, 27, 34)")
       expect(fingerprint.searchBorder).toBe("rgb(48, 54, 61)")
-      expect(fingerprint.cardBg).toBe("rgb(22, 27, 34)")
-      expect(fingerprint.cardBorder).toBe("rgb(48, 54, 61)")
+      expect(fingerprint.cardBg).toBe("rgb(255, 255, 255)")
+      expect(fingerprint.cardBorder).toBe("rgb(200, 210, 222)")
     }
 
     if (scenario.route === "/posts/991") {

--- a/front/e2e/theme-color-scheme.spec.ts
+++ b/front/e2e/theme-color-scheme.spec.ts
@@ -47,6 +47,17 @@ const readLightFeedSurface = async (page: Page) =>
     }
   })
 
+const expectLightFeedSurface = async (page: Page) => {
+  await expect(page.locator('[data-ui="feed-post-card"] article').first()).toBeVisible()
+  await expect(page.locator(".contextCount").first()).toBeVisible()
+  await expect.poll(() => readLightFeedSurface(page)).toEqual({
+    cardBackgroundColor: "rgb(255, 255, 255)",
+    categoryColor: "rgb(0, 106, 220)",
+    titleColor: "rgb(15, 23, 36)",
+    contextCountColor: "rgb(15, 23, 36)",
+  })
+}
+
 const assertHomeThemeToggleUsesLightFeedSurface = async (page: Page) => {
   await page.goto("/")
   await expect(page.getByRole("button", { name: "라이트 모드로 전환" })).toBeVisible()
@@ -86,12 +97,7 @@ const assertHomeThemeToggleUsesLightFeedSurface = async (page: Page) => {
     input: "light",
   })
 
-  await expect(readLightFeedSurface(page)).resolves.toEqual({
-    cardBackgroundColor: "rgb(255, 255, 255)",
-    categoryColor: "rgb(0, 106, 220)",
-    titleColor: "rgb(15, 23, 36)",
-    contextCountColor: "rgb(15, 23, 36)",
-  })
+  await expectLightFeedSurface(page)
 }
 
 test.describe("theme color-scheme", () => {

--- a/front/e2e/theme-color-scheme.spec.ts
+++ b/front/e2e/theme-color-scheme.spec.ts
@@ -31,14 +31,17 @@ const readControlScheme = async (page: Page) =>
 const readLightFeedSurface = async (page: Page) =>
   page.evaluate(() => {
     const card = document.querySelector('[data-ui="feed-post-card"] article')
+    const category = card?.querySelector(".category")
     const title = card?.querySelector("h2")
     const contextCount = document.querySelector(".contextCount")
     const cardStyle = card ? window.getComputedStyle(card) : null
+    const categoryStyle = category ? window.getComputedStyle(category) : null
     const titleStyle = title ? window.getComputedStyle(title) : null
     const contextStyle = contextCount ? window.getComputedStyle(contextCount) : null
 
     return {
       cardBackgroundColor: cardStyle?.backgroundColor ?? null,
+      categoryColor: categoryStyle?.color ?? null,
       titleColor: titleStyle?.color ?? null,
       contextCountColor: contextStyle?.color ?? null,
     }
@@ -85,6 +88,7 @@ const assertHomeThemeToggleUsesLightFeedSurface = async (page: Page) => {
 
   await expect(readLightFeedSurface(page)).resolves.toEqual({
     cardBackgroundColor: "rgb(255, 255, 255)",
+    categoryColor: "rgb(0, 106, 220)",
     titleColor: "rgb(15, 23, 36)",
     contextCountColor: "rgb(15, 23, 36)",
   })

--- a/front/e2e/theme-color-scheme.spec.ts
+++ b/front/e2e/theme-color-scheme.spec.ts
@@ -1,67 +1,104 @@
 import { expect, test } from "@playwright/test"
+import type { Page } from "@playwright/test"
 import { addPublicAboutSnapshotCookie, mockAvatarAsset, mockFeedEndpoints } from "./helpers/smokeFixtures"
 
+const prepareHomeThemePage = async (page: Page) => {
+  await mockAvatarAsset(page)
+  await mockFeedEndpoints(page)
+  await addPublicAboutSnapshotCookie(page)
+  await page.context().addCookies([
+    {
+      name: "scheme",
+      value: "dark",
+      url: "http://127.0.0.1:3000",
+    },
+  ])
+}
+
+const readControlScheme = async (page: Page) =>
+  page.evaluate(() => {
+    const input = document.createElement("input")
+    document.body.append(input)
+    const result = {
+      body: window.getComputedStyle(document.body).colorScheme,
+      html: window.getComputedStyle(document.documentElement).colorScheme,
+      input: window.getComputedStyle(input).colorScheme,
+    }
+    input.remove()
+    return result
+  })
+
+const readLightFeedSurface = async (page: Page) =>
+  page.evaluate(() => {
+    const card = document.querySelector('[data-ui="feed-post-card"] article')
+    const title = card?.querySelector("h2")
+    const contextCount = document.querySelector(".contextCount")
+    const cardStyle = card ? window.getComputedStyle(card) : null
+    const titleStyle = title ? window.getComputedStyle(title) : null
+    const contextStyle = contextCount ? window.getComputedStyle(contextCount) : null
+
+    return {
+      cardBackgroundColor: cardStyle?.backgroundColor ?? null,
+      titleColor: titleStyle?.color ?? null,
+      contextCountColor: contextStyle?.color ?? null,
+    }
+  })
+
+const assertHomeThemeToggleUsesLightFeedSurface = async (page: Page) => {
+  await page.goto("/")
+  await expect(page.getByRole("button", { name: "라이트 모드로 전환" })).toBeVisible()
+
+  await expect(readControlScheme(page)).resolves.toEqual({
+    body: "dark",
+    html: "dark",
+    input: "dark",
+  })
+
+  await page.getByRole("button", { name: "라이트 모드로 전환" }).click()
+  await expect(page.getByRole("button", { name: "다크 모드로 전환" })).toBeVisible()
+
+  const nextScheme = await page.evaluate(() => {
+    const input = document.createElement("input")
+    document.body.append(input)
+    const result = {
+      bootstrapScheme: document.documentElement.getAttribute("data-aquila-scheme-bootstrap"),
+      bootstrapStyleCount: document.querySelectorAll('style[data-aquila-scheme-bootstrap-style="true"]').length,
+      datasetScheme: document.documentElement.dataset.aquilaScheme,
+      body: window.getComputedStyle(document.body).colorScheme,
+      html: window.getComputedStyle(document.documentElement).colorScheme,
+      inlineHtmlColorScheme: document.documentElement.style.colorScheme,
+      input: window.getComputedStyle(input).colorScheme,
+    }
+    input.remove()
+    return result
+  })
+
+  expect(nextScheme).toEqual({
+    bootstrapScheme: null,
+    bootstrapStyleCount: 0,
+    datasetScheme: "light",
+    body: "light",
+    html: "light",
+    inlineHtmlColorScheme: "",
+    input: "light",
+  })
+
+  await expect(readLightFeedSurface(page)).resolves.toEqual({
+    cardBackgroundColor: "rgb(255, 255, 255)",
+    titleColor: "rgb(15, 23, 36)",
+    contextCountColor: "rgb(15, 23, 36)",
+  })
+}
+
 test.describe("theme color-scheme", () => {
-  test("헤더 테마 토글은 루트와 form control color-scheme을 함께 전환한다", async ({ page }) => {
-    await mockAvatarAsset(page)
-    await mockFeedEndpoints(page)
-    await addPublicAboutSnapshotCookie(page)
-    await page.context().addCookies([
-      {
-        name: "scheme",
-        value: "dark",
-        url: "http://127.0.0.1:3000",
-      },
-    ])
+  test("헤더 테마 토글은 루트, form control, 메인 feed surface를 함께 전환한다", async ({ page }) => {
+    await prepareHomeThemePage(page)
+    await assertHomeThemeToggleUsesLightFeedSurface(page)
+  })
 
-    await page.goto("/")
-    await expect(page.getByRole("button", { name: "라이트 모드로 전환" })).toBeVisible()
-
-    const initialScheme = await page.evaluate(() => {
-      const input = document.createElement("input")
-      document.body.append(input)
-      const result = {
-        body: window.getComputedStyle(document.body).colorScheme,
-        html: window.getComputedStyle(document.documentElement).colorScheme,
-        input: window.getComputedStyle(input).colorScheme,
-      }
-      input.remove()
-      return result
-    })
-
-    expect(initialScheme).toEqual({
-      body: "dark",
-      html: "dark",
-      input: "dark",
-    })
-
-    await page.getByRole("button", { name: "라이트 모드로 전환" }).click()
-    await expect(page.getByRole("button", { name: "다크 모드로 전환" })).toBeVisible()
-
-    const nextScheme = await page.evaluate(() => {
-      const input = document.createElement("input")
-      document.body.append(input)
-      const result = {
-        bootstrapScheme: document.documentElement.getAttribute("data-aquila-scheme-bootstrap"),
-        bootstrapStyleCount: document.querySelectorAll('style[data-aquila-scheme-bootstrap-style="true"]').length,
-        datasetScheme: document.documentElement.dataset.aquilaScheme,
-        body: window.getComputedStyle(document.body).colorScheme,
-        html: window.getComputedStyle(document.documentElement).colorScheme,
-        inlineHtmlColorScheme: document.documentElement.style.colorScheme,
-        input: window.getComputedStyle(input).colorScheme,
-      }
-      input.remove()
-      return result
-    })
-
-    expect(nextScheme).toEqual({
-      bootstrapScheme: null,
-      bootstrapStyleCount: 0,
-      datasetScheme: "light",
-      body: "light",
-      html: "light",
-      inlineHtmlColorScheme: "",
-      input: "light",
-    })
+  test("모바일 헤더 테마 토글도 메인 feed surface를 함께 전환한다", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await prepareHomeThemePage(page)
+    await assertHomeThemeToggleUsesLightFeedSurface(page)
   })
 })

--- a/front/src/routes/Feed/FeedExplorer.styles.ts
+++ b/front/src/routes/Feed/FeedExplorer.styles.ts
@@ -51,7 +51,7 @@ export const FilterContextBar = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
-  color: #8b949e;
+  color: ${({ theme }) => theme.colors.gray10};
 
   .contextMain {
     min-width: 0;
@@ -70,13 +70,13 @@ export const FilterContextBar = styled.div`
 
   .contextCount {
     font-size: 0.88rem;
-    color: #f0f6fc;
+    color: ${({ theme }) => theme.colors.gray12};
     font-weight: 740;
     letter-spacing: -0.015em;
   }
 
   .filterSummary {
-    color: #8b949e;
+    color: ${({ theme }) => theme.colors.gray10};
     font-size: 0.74rem;
     line-height: 1.35;
     font-weight: 600;
@@ -93,9 +93,9 @@ export const FilterContextBar = styled.div`
     min-height: 1.7rem;
     padding: 0 0.58rem;
     border-radius: 999px;
-    border: 1px solid #30363d;
-    background: #161b22;
-    color: #c9d1d9;
+    border: 1px solid ${({ theme }) => theme.publicDesign.border};
+    background: ${({ theme }) => theme.publicDesign.operationSurfaceElevated};
+    color: ${({ theme }) => theme.colors.gray11};
     font-size: 0.72rem;
     font-weight: 700;
     white-space: nowrap;
@@ -106,18 +106,18 @@ export const FilterContextBar = styled.div`
     min-height: 1.7rem;
     padding: 0 0.52rem;
     border-radius: 999px;
-    border: 1px solid #30363d;
+    border: 1px solid ${({ theme }) => theme.publicDesign.border};
     background: transparent;
-    color: #8b949e;
+    color: ${({ theme }) => theme.colors.gray10};
     font-size: 0.72rem;
     font-weight: 700;
     cursor: pointer;
     transition: border-color 0.125s ease-in, color 0.125s ease-in, background-color 0.125s ease-in;
 
     &:hover {
-      border-color: #58a6ff;
-      background: rgba(88, 166, 255, 0.12);
-      color: #f0f6fc;
+      border-color: ${({ theme }) => theme.publicDesign.accent};
+      background: ${({ theme }) => theme.publicDesign.accentMuted};
+      color: ${({ theme }) => theme.colors.gray12};
     }
   }
 

--- a/front/src/routes/Feed/PostList/PostCard.tsx
+++ b/front/src/routes/Feed/PostList/PostCard.tsx
@@ -287,7 +287,7 @@ const StyledWrapper = styled.a`
       > .category {
         width: fit-content;
         margin-bottom: 0.42rem;
-        color: ${({ theme }) => theme.publicDesign.accent};
+        color: ${({ theme }) => (theme.scheme === "light" ? theme.colors.blue11 : theme.colors.accentLink)};
         font-size: 0.7rem;
         line-height: 1.2;
         font-weight: 860;

--- a/front/src/routes/Feed/PostList/PostCard.tsx
+++ b/front/src/routes/Feed/PostList/PostCard.tsx
@@ -168,12 +168,20 @@ const StyledWrapper = styled.a`
   min-width: 0;
   text-decoration: none;
   --post-card-translate-y: -8px;
-  --post-card-border-color: #30363d;
-  --post-card-border-strong: #58a6ff;
-  --post-card-surface: #161b22;
-  --post-card-surface-elevated: #21262d;
-  --post-card-shadow-current: 0 12px 34px rgba(1, 4, 9, 0.26);
-  --post-card-shadow-hover-current: 0 20px 52px rgba(1, 4, 9, 0.36);
+  --post-card-border-color: ${({ theme }) => theme.publicDesign.border};
+  --post-card-border-strong: ${({ theme }) => theme.publicDesign.accent};
+  --post-card-surface: ${({ theme }) => theme.publicDesign.readableSurface};
+  --post-card-surface-elevated: ${({ theme }) => theme.publicDesign.surfaceElevated};
+  --post-card-shadow-current: ${({ theme }) =>
+    theme.scheme === "light" ? "0 12px 34px rgba(15, 23, 42, 0.08)" : "0 12px 34px rgba(1, 4, 9, 0.26)"};
+  --post-card-shadow-hover-current: ${({ theme }) =>
+    theme.scheme === "light" ? "0 18px 42px rgba(15, 23, 42, 0.13)" : "0 20px 52px rgba(1, 4, 9, 0.36)"};
+  --post-card-cover-text: ${({ theme }) => theme.colors.gray12};
+  --post-card-cover-muted: ${({ theme }) => theme.colors.gray10};
+  --post-card-cover-bg: ${({ theme }) =>
+    theme.scheme === "light"
+      ? "linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(34, 197, 94, 0.08)), #f8fafc"
+      : "linear-gradient(135deg, rgba(88, 166, 255, 0.2), rgba(126, 231, 135, 0.08)), #111722"};
 
   &:focus-visible {
     outline: 0;
@@ -191,7 +199,10 @@ const StyledWrapper = styled.a`
     border-radius: ${FEED_CARD_RADIUS_PX}px;
     border: ${({ theme }) => `${theme.variables.ui.card.borderWidth}px solid var(--post-card-border-color)`};
     background:
-      linear-gradient(180deg, rgba(33, 38, 45, 0.34), rgba(22, 27, 34, 0.98)),
+      ${({ theme }) =>
+        theme.scheme === "light"
+          ? "linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(255, 255, 255, 0.98))"
+          : "linear-gradient(180deg, rgba(33, 38, 45, 0.34), rgba(22, 27, 34, 0.98))"},
       var(--post-card-surface);
     box-shadow: var(--post-card-shadow-current);
 
@@ -220,17 +231,17 @@ const StyledWrapper = styled.a`
         gap: 0.36rem;
         padding: 1rem;
         background:
-          radial-gradient(circle at 82% 18%, rgba(88, 166, 255, 0.28), transparent 34%),
-          linear-gradient(135deg, rgba(88, 166, 255, 0.2), rgba(126, 231, 135, 0.08)),
-          #111722;
-        color: #f0f6fc;
+          radial-gradient(circle at 82% 18%, ${({ theme }) =>
+            theme.scheme === "light" ? "rgba(37, 99, 235, 0.16)" : "rgba(88, 166, 255, 0.28)"}, transparent 34%),
+          var(--post-card-cover-bg);
+        color: var(--post-card-cover-text);
 
         .coverCategory {
           width: fit-content;
           border-radius: 999px;
-          border: 1px solid rgba(88, 166, 255, 0.42);
-          background: rgba(88, 166, 255, 0.1);
-          color: #c9e7ff;
+          border: 1px solid ${({ theme }) => theme.publicDesign.accent};
+          background: ${({ theme }) => theme.publicDesign.accentMuted};
+          color: ${({ theme }) => theme.colors.accentLink};
           padding: 0.22rem 0.5rem;
           font-size: 0.64rem;
           line-height: 1.2;
@@ -239,7 +250,7 @@ const StyledWrapper = styled.a`
 
         strong {
           max-width: 12ch;
-          color: #f0f6fc;
+          color: var(--post-card-cover-text);
           font-size: clamp(1.35rem, 2.5vw, 2rem);
           line-height: 0.94;
           letter-spacing: -0.07em;
@@ -248,7 +259,7 @@ const StyledWrapper = styled.a`
         }
 
         .coverBrand {
-          color: #8b949e;
+          color: var(--post-card-cover-muted);
           font-size: 0.7rem;
           font-weight: 820;
           letter-spacing: 0.02em;
@@ -276,7 +287,7 @@ const StyledWrapper = styled.a`
       > .category {
         width: fit-content;
         margin-bottom: 0.42rem;
-        color: #58a6ff;
+        color: ${({ theme }) => theme.publicDesign.accent};
         font-size: 0.7rem;
         line-height: 1.2;
         font-weight: 860;
@@ -287,7 +298,7 @@ const StyledWrapper = styled.a`
       > header {
         h2 {
           margin: 0;
-          color: #f0f6fc;
+          color: ${({ theme }) => theme.colors.gray12};
           font-size: 1.12rem;
           line-height: ${FEED_CARD_TITLE_LINE_HEIGHT};
           font-weight: 840;
@@ -307,7 +318,7 @@ const StyledWrapper = styled.a`
 
         p {
           margin: 0;
-          color: #8b949e;
+          color: ${({ theme }) => theme.colors.gray10};
           font-size: 0.85rem;
           line-height: ${FEED_CARD_SUMMARY_LINE_HEIGHT};
           letter-spacing: -0.01em;
@@ -327,7 +338,7 @@ const StyledWrapper = styled.a`
         align-items: center;
         margin-top: 0.6rem;
         padding-bottom: 0.88rem;
-        color: #8b949e;
+        color: ${({ theme }) => theme.colors.gray10};
         font-size: ${FEED_CARD_META_FONT_SIZE_REM}rem;
         line-height: 1.45;
         letter-spacing: -0.01em;
@@ -380,17 +391,17 @@ const StyledWrapper = styled.a`
             .initial {
               font-size: 0.72rem;
               font-weight: 800;
-              color: #0d1117;
+              color: ${({ theme }) => theme.colors.gray12};
             }
           }
 
           .by {
-            color: #8b949e;
+            color: ${({ theme }) => theme.colors.gray10};
             font-size: 0.72rem;
           }
 
           strong {
-            color: #f0f6fc;
+            color: ${({ theme }) => theme.colors.gray12};
             font-size: 0.76rem;
             font-weight: 760;
             line-height: 1.2;
@@ -405,7 +416,7 @@ const StyledWrapper = styled.a`
           display: inline-flex;
           align-items: center;
           gap: 0.42rem;
-          color: #8b949e;
+          color: ${({ theme }) => theme.colors.gray10};
           font-size: 0.75rem;
           font-weight: 700;
 

--- a/front/src/routes/Feed/index.tsx
+++ b/front/src/routes/Feed/index.tsx
@@ -92,13 +92,17 @@ const Feed: React.FC<Props> = ({ initialAdminProfile = null, initialHomeBootstra
 export default Feed
 
 const StyledWrapper = styled.div`
-  --feed-product-bg: #0d1117;
-  --feed-product-panel: #161b22;
-  --feed-product-panel-hover: #21262d;
-  --feed-product-border: #30363d;
-  --feed-product-text: #f0f6fc;
-  --feed-product-muted: #8b949e;
-  --feed-product-accent: #58a6ff;
+  --feed-product-bg: ${({ theme }) => theme.publicDesign.pageBackgroundColor};
+  --feed-product-panel: ${({ theme }) => theme.publicDesign.readableSurface};
+  --feed-product-panel-hover: ${({ theme }) => theme.publicDesign.surfaceElevated};
+  --feed-product-border: ${({ theme }) => theme.publicDesign.border};
+  --feed-product-text: ${({ theme }) => theme.colors.gray12};
+  --feed-product-muted: ${({ theme }) => theme.colors.gray10};
+  --feed-product-accent: ${({ theme }) => theme.publicDesign.accent};
+  --feed-product-chip-bg: ${({ theme }) =>
+    theme.scheme === "light" ? "rgba(255, 255, 255, 0.78)" : "rgba(22, 27, 34, 0.68)"};
+  --feed-product-hero-glow: ${({ theme }) =>
+    theme.scheme === "light" ? "rgba(37, 99, 235, 0.08)" : "rgba(88, 166, 255, 0.1)"};
   display: block;
   position: relative;
   z-index: 0;
@@ -116,7 +120,7 @@ const StyledWrapper = styled.div`
     width: 100vw;
     transform: translateX(-50%);
     background:
-      radial-gradient(circle at 78% 0%, rgba(88, 166, 255, 0.1), transparent 28rem),
+      radial-gradient(circle at 78% 0%, var(--feed-product-hero-glow), transparent 28rem),
       var(--feed-product-bg);
   }
 
@@ -144,7 +148,8 @@ const IntroCard = styled.section`
   grid-template-columns: minmax(0, 1fr) minmax(17rem, 20rem);
   align-items: end;
   gap: clamp(1.2rem, 3vw, 2.4rem);
-  border-bottom: 1px solid rgba(48, 54, 61, 0.82);
+  border-bottom: 1px solid ${({ theme }) =>
+    theme.scheme === "light" ? "rgba(200, 210, 222, 0.92)" : "rgba(48, 54, 61, 0.82)"};
   padding: 0.2rem 0 1.3rem;
 
   .introCopy {
@@ -154,7 +159,7 @@ const IntroCard = styled.section`
   .brandLabel {
     display: block;
     margin-bottom: 0.52rem;
-    color: #58a6ff;
+    color: var(--feed-product-accent);
     font-size: 0.78rem;
     line-height: 1.2;
     font-weight: 860;
@@ -163,7 +168,7 @@ const IntroCard = styled.section`
 
   h1 {
     margin: 0;
-    color: #f0f6fc;
+    color: var(--feed-product-text);
     font-size: clamp(2.6rem, 5vw, 4rem);
     letter-spacing: -0.075em;
     line-height: 0.96;
@@ -173,7 +178,7 @@ const IntroCard = styled.section`
 
   p {
     margin: 0.82rem 0 0;
-    color: #8b949e;
+    color: var(--feed-product-muted);
     font-size: clamp(0.98rem, 1.3vw, 1.08rem);
     line-height: 1.55;
     letter-spacing: -0.018em;
@@ -193,9 +198,9 @@ const IntroCard = styled.section`
     align-items: center;
     min-height: 30px;
     border-radius: 999px;
-    border: 1px solid rgba(48, 54, 61, 0.86);
-    background: rgba(22, 27, 34, 0.68);
-    color: #8b949e;
+    border: 1px solid var(--feed-product-border);
+    background: var(--feed-product-chip-bg);
+    color: var(--feed-product-muted);
     padding: 0 0.72rem;
     font-size: 0.76rem;
     font-weight: 780;
@@ -206,8 +211,8 @@ const IntroCard = styled.section`
 
   .topicRail button:hover,
   .topicRail button:focus-visible {
-    border-color: rgba(88, 166, 255, 0.72);
-    color: #f0f6fc;
+    border-color: var(--feed-product-accent);
+    color: var(--feed-product-text);
     outline: none;
   }
 


### PR DESCRIPTION
## 관련 이슈

close #986

## 작업 배경

- 메인 화면에서 `data-aquila-scheme=light`로 돌아온 뒤에도 Feed 본문, 카드, 상태 영역이 GitHub dark literal에 남아 네비바와 본문 theme가 분리됐다.

## 작업 내용

- Feed home shell, intro/topic rail, FeedExplorer context/status controls, PostCard surface/text/cover 색상을 `theme.publicDesign`/`theme.colors` 기반으로 전환했다.
- light mode feed card의 카테고리 라벨 대비를 보강했다.
- `theme-color-scheme` e2e에 desktop/mobile에서 dark -> light 토글 후 feed card/title/context count/category label light 색상 검증을 추가했다.
- 기존 perf-layout fingerprint가 light theme에서도 dark card surface를 기대하던 기준을 갱신했다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`: PASS
  - `yarn --cwd front playwright test e2e/theme-color-scheme.spec.ts --workers=1`: PASS, 2 tests
  - `yarn --cwd front playwright test e2e/perf-layout.spec.ts -g "공개와 인증 핵심 화면" --workers=1`: PASS, 1 test
  - `yarn --cwd front build`: PASS
  - `yarn --cwd front check:bundle-size`: PASS
  - `git diff --check`: PASS
  - `CURRENT_TASK_SLUG=issue-986-home-theme-toggle bash tools/guards/current-task-preflight.sh`: PASS
  - GitHub Actions PR checks: PASS (`frontend-ci`, `backend-ci`, `Security/CodeQL`, `backend-dependency-check`, `Vercel`)
  - Codex CLI fallback review: 최초 2건 inline 지적 게시 후 각각 follow-up commit/thread reply 처리, 최종 재리뷰 actionable 0건

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - hardcoded dark literal 제거 범위가 Feed home/theme surface에만 제한됐는지
  - mobile/desktop e2e가 `data-aquila-scheme=light`와 feed card 색상을 함께 고정하는지
  - perf-layout fingerprint가 #986의 light feed surface 동작과 일치하는지

## 리스크

- Feed home card의 light mode visual tone이 기존 dark-only product shell보다 밝아진다. 전역 theme toggle 동작 복구 범위 안의 변경이다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. 실제 리뷰는 rate limit으로 미실행되어 Codex CLI fallback을 사용했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. main merge 후 `Deploy to Home Server` run `27895284083`의 `Frontend Live E2E Verification`이 PASS했다.
