### PR TITLE
[Fix] PostCard keyboard focus 표시 복원

### DIFF
--- a/front/e2e/accessibility.spec.ts
+++ b/front/e2e/accessibility.spec.ts
@@ -307,34 +307,52 @@ test("홈 피드 주요 영역은 reduced motion과 landmark 계약에서 심각
   await expectLaunchGateAccessibility(page, testInfo, "home-reduced-motion")
 })
 
-test("홈 피드 PostCard는 keyboard focus ring을 pointer capability와 무관하게 노출한다", async ({ page }) => {
-  await page.setViewportSize({ width: 393, height: 852 })
-  await mockFeedEndpoints(page)
-  await page.goto("/")
-
-  const firstCard = page.locator('[data-ui="feed-post-card"]').first()
-  await expect(firstCard).toBeVisible()
-
-  for (let index = 0; index < 16; index += 1) {
-    if (await firstCard.evaluate((node) => node === document.activeElement)) break
-    await page.keyboard.press("Tab")
-  }
-
-  await expect(firstCard).toBeFocused()
-  const focusRing = await firstCard.evaluate((node) => {
-    const style = getComputedStyle(node)
-    return {
-      outlineStyle: style.outlineStyle,
-      outlineWidth: style.outlineWidth,
-      outlineColor: style.outlineColor,
-      outlineOffset: style.outlineOffset,
-    }
+test("홈 피드 PostCard는 keyboard focus ring을 pointer capability와 무관하게 노출한다", async ({ browser }) => {
+  const context = await browser.newContext({
+    baseURL: testBaseUrl,
+    hasTouch: true,
+    isMobile: true,
+    viewport: { width: 393, height: 852 },
   })
+  const page = await context.newPage()
 
-  expect(focusRing.outlineStyle).not.toBe("none")
-  expect(Number.parseFloat(focusRing.outlineWidth)).toBeGreaterThanOrEqual(2)
-  expect(focusRing.outlineColor).not.toBe("rgba(0, 0, 0, 0)")
-  expect(Number.parseFloat(focusRing.outlineOffset)).toBeGreaterThanOrEqual(2)
+  try {
+    await mockAvatarAsset(page)
+    await mockAnonymousSession(page)
+    await mockFeedEndpoints(page)
+    await page.goto("/")
+
+    const firstCard = page.locator('[data-ui="feed-post-card"]').first()
+    await expect(firstCard).toBeVisible()
+    const coarsePointerState = await page.evaluate(() => ({
+      hoverNone: window.matchMedia("(hover: none)").matches,
+      pointerCoarse: window.matchMedia("(pointer: coarse)").matches,
+    }))
+    expect(coarsePointerState.hoverNone || coarsePointerState.pointerCoarse).toBe(true)
+
+    for (let index = 0; index < 16; index += 1) {
+      if (await firstCard.evaluate((node) => node === document.activeElement)) break
+      await page.keyboard.press("Tab")
+    }
+
+    await expect(firstCard).toBeFocused()
+    const focusRing = await firstCard.evaluate((node) => {
+      const style = getComputedStyle(node)
+      return {
+        outlineStyle: style.outlineStyle,
+        outlineWidth: style.outlineWidth,
+        outlineColor: style.outlineColor,
+        outlineOffset: style.outlineOffset,
+      }
+    })
+
+    expect(focusRing.outlineStyle).not.toBe("none")
+    expect(Number.parseFloat(focusRing.outlineWidth)).toBeGreaterThanOrEqual(2)
+    expect(focusRing.outlineColor).not.toBe("rgba(0, 0, 0, 0)")
+    expect(Number.parseFloat(focusRing.outlineOffset)).toBeGreaterThanOrEqual(2)
+  } finally {
+    await context.close()
+  }
 })
 
 test("상세 댓글 composer와 200% zoom 상태는 심각도 높은 접근성 위반이 없다", async ({

--- a/front/e2e/accessibility.spec.ts
+++ b/front/e2e/accessibility.spec.ts
@@ -307,6 +307,36 @@ test("홈 피드 주요 영역은 reduced motion과 landmark 계약에서 심각
   await expectLaunchGateAccessibility(page, testInfo, "home-reduced-motion")
 })
 
+test("홈 피드 PostCard는 keyboard focus ring을 pointer capability와 무관하게 노출한다", async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 })
+  await mockFeedEndpoints(page)
+  await page.goto("/")
+
+  const firstCard = page.locator('[data-ui="feed-post-card"]').first()
+  await expect(firstCard).toBeVisible()
+
+  for (let index = 0; index < 16; index += 1) {
+    if (await firstCard.evaluate((node) => node === document.activeElement)) break
+    await page.keyboard.press("Tab")
+  }
+
+  await expect(firstCard).toBeFocused()
+  const focusRing = await firstCard.evaluate((node) => {
+    const style = getComputedStyle(node)
+    return {
+      outlineStyle: style.outlineStyle,
+      outlineWidth: style.outlineWidth,
+      outlineColor: style.outlineColor,
+      outlineOffset: style.outlineOffset,
+    }
+  })
+
+  expect(focusRing.outlineStyle).not.toBe("none")
+  expect(Number.parseFloat(focusRing.outlineWidth)).toBeGreaterThanOrEqual(2)
+  expect(focusRing.outlineColor).not.toBe("rgba(0, 0, 0, 0)")
+  expect(Number.parseFloat(focusRing.outlineOffset)).toBeGreaterThanOrEqual(2)
+})
+
 test("상세 댓글 composer와 200% zoom 상태는 심각도 높은 접근성 위반이 없다", async ({
   page,
 }, testInfo) => {

--- a/front/src/routes/Feed/PostList/PostCard.tsx
+++ b/front/src/routes/Feed/PostList/PostCard.tsx
@@ -170,6 +170,7 @@ const StyledWrapper = styled.a`
   --post-card-translate-y: -8px;
   --post-card-border-color: ${({ theme }) => theme.publicDesign.border};
   --post-card-border-strong: ${({ theme }) => theme.publicDesign.accent};
+  --post-card-focus-ring: ${({ theme }) => theme.colors.indigo8};
   --post-card-surface: ${({ theme }) => theme.publicDesign.readableSurface};
   --post-card-surface-elevated: ${({ theme }) => theme.publicDesign.surfaceElevated};
   --post-card-shadow-current: ${({ theme }) =>
@@ -184,7 +185,13 @@ const StyledWrapper = styled.a`
       : "linear-gradient(135deg, rgba(88, 166, 255, 0.2), rgba(126, 231, 135, 0.08)), #111722"};
 
   &:focus-visible {
-    outline: 0;
+    outline: 3px solid var(--post-card-focus-ring);
+    outline-offset: 3px;
+  }
+
+  &:focus-visible article {
+    border-color: var(--post-card-border-strong);
+    box-shadow: var(--post-card-shadow-hover-current);
   }
 
   article {


### PR DESCRIPTION
## 관련 이슈

close #945

## 작업 배경

- Feed PostCard가 `focus-visible` 기본 outline을 제거하고 실제 card focus 효과를 hover-capable media query 안에 둬 mobile/tablet 또는 hover 미지원 환경에서 keyboard focus 위치가 약하게 보일 수 있었다.

## 작업 내용

- PostCard link 자체에 theme token 기반 `focus-visible` outline과 `outline-offset`을 복원했다.
- pointer media query 밖에서도 focused card의 border/shadow가 보강되도록 했다.
- `accessibility.spec.ts`에 touch/mobile context를 생성하고 `(hover: none)` 또는 `(pointer: coarse)` 상태를 확인한 뒤 PostCard focus ring computed style을 검증하는 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front install --frozen-lockfile`: PASS
  - `yarn --cwd front playwright:preflight`: PASS
  - `yarn --cwd front playwright test e2e/accessibility.spec.ts -g "PostCard는 keyboard focus ring" --workers=1`: RED 확인, `outlineStyle`이 `none`이라 실패
  - `yarn --cwd front playwright test e2e/accessibility.spec.ts -g "PostCard는 keyboard focus ring" --workers=1`: PASS, 1 test
  - `yarn --cwd front playwright test e2e/accessibility.spec.ts --workers=1`: PASS, 7 tests
  - `yarn --cwd front build`: PASS
  - `git diff --check`: PASS
  - `CURRENT_TASK_SLUG=issue-945-postcard-focus-ring bash tools/guards/current-task-preflight.sh`: PASS
  - `yarn --cwd front test`: 실행 불가, `front/package.json`에 `test` script 없음
  - PR CI: `backend-ci`, `frontend-ci`, `Security`, `CodeQL`, `Vercel` PASS
  - main CI after merge: `CI` run `27895830298` PASS, `Security` run `27895830261` PASS
  - CD after merge: `Deploy to Home Server` run `27895973260` PASS, `Frontend Live E2E Verification` PASS; frontend-only 변경이라 `buildAndPush`/`blueGreenDeploy`는 skipped

## Codex CLI Code Review - 변경 요청 및 재검토

- 최초 리뷰 지적사항: touch/mobile viewport만 설정하면 Chromium의 `(hover)/(pointer)` media feature가 desktop 기본값으로 남을 수 있어, coarse pointer 환경 보호 테스트가 실제 media 조건을 보장하지 못한다.
- 영향: focus ring이 다시 hover-capable media query 안으로 이동해도 회귀 테스트가 통과할 수 있다.
- 요청: 테스트에서 `(hover: none)` 또는 `(pointer: coarse)` 상태를 명시적으로 확인하고, 해당 조건에서 focused PostCard outline/offset을 검증한다.
- 반영: `browser.newContext({ isMobile: true, hasTouch: true })`로 touch/mobile context를 만들고 media query 상태를 먼저 검증한 뒤 focused card의 outline/offset을 확인하게 수정했다.
- 해결 답글: 원 inline review thread에 변경 내용, 검증 명령, fix commit `4bd8673`를 답글로 남겼고 thread를 resolve했다.
- 재검토 결과: Codex CLI fallback 재리뷰를 latest head `4bd8673bddd13e113099d07dcbc39799f9200b7e`에 대해 게시했고 `Actionable comments posted: 0`이다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `outline`/`outline-offset`이 link 자체에 있어 pointer capability와 무관하게 보이는지
  - hover 전용 transform은 기존 media query 안에 유지됐고 focus visibility만 media query 밖으로 나온 점

## 리스크

- focused PostCard에 명시적인 outline이 새로 보인다. keyboard-only 접근성 복구 범위의 의도된 시각 변화다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
