### PR TITLE
[Fix] frontend CSP directive 확장

### DIFF
--- a/docs/design/security-csp-rollout.md
+++ b/docs/design/security-csp-rollout.md
@@ -9,6 +9,8 @@
 - `script-src`는 Next.js runtime, 현재 inline bootstrap, Vercel Analytics/Toolbar, Google Analytics script source만 허용한다.
 - `style-src`는 Emotion/Next.js inline style 운용을 위해 `'unsafe-inline'`을 유지한다.
 - `img-src`, `connect-src`, `font-src`, `media-src`, `frame-src`는 현재 운영 image domain, same-origin API proxy, Vercel telemetry, Google Analytics, monitoring embed origin을 명시한다.
+- `img-src`의 `http:`/`https:` scheme source는 현재 markdown image와 unfurl thumbnail 입력 계약이 외부 image URL을 허용하기 때문에 유지한다. 별도 image proxy 또는 domain validation으로 좁히는 변경은 content validation 이슈로 분리한다.
+- `connect-src`의 `http://localhost:8080`, `http://127.0.0.1:8080`은 `NEXT_PUBLIC_BACKEND_URL`이 없을 때 쓰는 local backend fallback을 위해 development build에서만 포함한다.
 - nonce 기반 `script-src`는 Next.js proxy 동적 렌더링 전환이 필요하므로 이번 변경에서는 적용하지 않는다. nonce 전환 시 `script-src 'nonce-<value>' 'strict-dynamic'`과 `style-src 'nonce-<value>'`를 별도 이슈로 검증한다.
 
 ## Report-Only Rollout

--- a/docs/design/security-csp-rollout.md
+++ b/docs/design/security-csp-rollout.md
@@ -1,0 +1,31 @@
+# Frontend CSP Rollout
+
+## 목적
+- `front/next.config.js`의 `Content-Security-Policy`는 운영 차단 정책으로 유지한다.
+- 새 외부 script, API, image, iframe, monitoring origin을 추가할 때는 먼저 report-only로 위반 로그를 확인한 뒤 차단 정책에 반영한다.
+
+## 현재 정책
+- `default-src 'self'`를 기본값으로 둔다.
+- `script-src`는 Next.js runtime, 현재 inline bootstrap, Vercel Analytics/Toolbar, Google Analytics script source만 허용한다.
+- `style-src`는 Emotion/Next.js inline style 운용을 위해 `'unsafe-inline'`을 유지한다.
+- `img-src`, `connect-src`, `font-src`, `media-src`, `frame-src`는 현재 운영 image domain, same-origin API proxy, Vercel telemetry, Google Analytics, monitoring embed origin을 명시한다.
+- nonce 기반 `script-src`는 Next.js proxy 동적 렌더링 전환이 필요하므로 이번 변경에서는 적용하지 않는다. nonce 전환 시 `script-src 'nonce-<value>' 'strict-dynamic'`과 `style-src 'nonce-<value>'`를 별도 이슈로 검증한다.
+
+## Report-Only Rollout
+1. 새 외부 origin이 필요한 변경은 PR에서 `Content-Security-Policy-Report-Only` 후보값을 PR 본문에 적는다.
+2. preview 또는 canary 환경에서 브라우저 console의 CSP violation을 확인한다.
+3. violation이 의도된 source라면 `front/next.config.js`의 source allowlist에 origin 단위로 추가한다.
+4. path, query string, wildcard 최상위 도메인 전체 허용은 피하고, 가능한 한 origin 또는 필요한 하위 도메인만 허용한다.
+5. `front/e2e/security-csp-header.spec.ts`에 새 source 계약을 추가한 뒤 차단 정책으로 승격한다.
+
+## Violation Triage
+- `script-src`: 새 script host가 필요한지 먼저 확인한다. inline script 증가는 nonce/hash 전환 대상인지 분리한다.
+- `connect-src`: API, analytics, SSE/WebSocket endpoint인지 확인하고 credential 전송 범위를 함께 본다.
+- `img-src`: 사용자 콘텐츠/프로필/markdown image domain인지 확인하고 `data:`/`blob:` 확장이 필요한지 별도 판단한다.
+- `frame-src`: monitoring 또는 Vercel preview tooling처럼 실제 iframe이 필요한 origin만 추가한다.
+- `style-src`: 새 inline style 요구는 component library/runtime 제약인지 확인하고 가능한 경우 CSS 파일 또는 nonce 전환 이슈로 분리한다.
+
+## 검증
+- `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/security-csp-header.spec.ts --workers=1`
+- `yarn --cwd front build`
+- 배포 후 실제 페이지에서 browser console CSP violation이 없는지 확인한다.

--- a/front/e2e/security-csp-header.spec.ts
+++ b/front/e2e/security-csp-header.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "@playwright/test"
+
+type NextHeader = {
+  key: string
+  value: string
+}
+
+type NextHeaderRule = {
+  source: string
+  headers: NextHeader[]
+}
+
+const getCspHeader = async () => {
+  const nextConfigModule = await import("../next.config.js")
+  const nextConfig = nextConfigModule.default as {
+    headers: () => Promise<NextHeaderRule[]>
+  }
+  const rules = await nextConfig.headers()
+  const globalRule = rules.find((rule) => rule.source === "/:path*")
+  const csp = globalRule?.headers.find(
+    (header) => header.key.toLowerCase() === "content-security-policy",
+  )?.value
+
+  expect(csp).toBeTruthy()
+  return csp ?? ""
+}
+
+const parseCspDirectives = (csp: string) => {
+  const directives = new Map<string, string[]>()
+
+  for (const rawDirective of csp.split(";")) {
+    const parts = rawDirective.trim().split(/\s+/).filter(Boolean)
+    const [name, ...sources] = parts
+    if (!name) continue
+    directives.set(name, sources)
+  }
+
+  return directives
+}
+
+test.describe("frontend security headers", () => {
+  test("CSP declares script style image connect and font boundaries", async () => {
+    const directives = parseCspDirectives(await getCspHeader())
+
+    expect(directives.get("default-src")).toEqual(["'self'"])
+    expect(directives.get("script-src")).toEqual(
+      expect.arrayContaining(["'self'", "'unsafe-inline'", "https://va.vercel-scripts.com"]),
+    )
+    expect(directives.get("style-src")).toEqual(expect.arrayContaining(["'self'", "'unsafe-inline'"]))
+    expect(directives.get("img-src")).toEqual(
+      expect.arrayContaining([
+        "'self'",
+        "data:",
+        "blob:",
+        "https://*.aquilaxk.site",
+        "https://www.notion.so",
+        "https://avatars.githubusercontent.com",
+      ]),
+    )
+    expect(directives.get("connect-src")).toEqual(
+      expect.arrayContaining([
+        "'self'",
+        "https://*.aquilaxk.site",
+        "https://vitals.vercel-insights.com",
+        "https://vercel.live",
+      ]),
+    )
+    expect(directives.get("font-src")).toEqual(expect.arrayContaining(["'self'", "data:"]))
+    expect(directives.get("media-src")).toEqual(
+      expect.arrayContaining(["'self'", "blob:", "https://*.aquilaxk.site"]),
+    )
+    expect(directives.get("object-src")).toEqual(["'none'"])
+    expect(directives.get("base-uri")).toEqual(["'self'"])
+    expect(directives.get("frame-ancestors")).toEqual(["'self'"])
+    expect(directives.get("upgrade-insecure-requests")).toEqual([])
+  })
+
+  test("CSP includes configured runtime origins without duplicating full URLs", async () => {
+    const previousBackendUrl = process.env.NEXT_PUBLIC_BACKEND_URL
+    const previousMonitoringUrl = process.env.NEXT_PUBLIC_MONITORING_EMBED_URL
+
+    process.env.NEXT_PUBLIC_BACKEND_URL = "https://api.example.com/member/api/v1"
+    process.env.NEXT_PUBLIC_MONITORING_EMBED_URL = "https://grafana.example.com/d/live?kiosk=1"
+
+    try {
+      const directives = parseCspDirectives(await getCspHeader())
+
+      expect(directives.get("connect-src")).toEqual(
+        expect.arrayContaining(["https://api.example.com", "https://grafana.example.com"]),
+      )
+      expect(directives.get("frame-src")).toEqual(
+        expect.arrayContaining(["'self'", "https://grafana.example.com", "https://vercel.live"]),
+      )
+      expect(directives.get("connect-src")).not.toContain("https://api.example.com/member/api/v1")
+      expect(directives.get("frame-src")).not.toContain("https://grafana.example.com/d/live?kiosk=1")
+    } finally {
+      if (previousBackendUrl === undefined) delete process.env.NEXT_PUBLIC_BACKEND_URL
+      else process.env.NEXT_PUBLIC_BACKEND_URL = previousBackendUrl
+
+      if (previousMonitoringUrl === undefined) delete process.env.NEXT_PUBLIC_MONITORING_EMBED_URL
+      else process.env.NEXT_PUBLIC_MONITORING_EMBED_URL = previousMonitoringUrl
+    }
+  })
+})

--- a/front/e2e/security-csp-header.spec.ts
+++ b/front/e2e/security-csp-header.spec.ts
@@ -75,6 +75,22 @@ test.describe("frontend security headers", () => {
     expect(directives.get("upgrade-insecure-requests")).toEqual([])
   })
 
+  test("CSP frame-src keeps supported markdown embed preview providers available", async () => {
+    const directives = parseCspDirectives(await getCspHeader())
+
+    expect(directives.get("frame-src")).toEqual(
+      expect.arrayContaining([
+        "'self'",
+        "https://www.youtube.com",
+        "https://player.vimeo.com",
+        "https://www.loom.com",
+        "https://www.figma.com",
+        "https://codepen.io",
+        "https://codesandbox.io",
+      ]),
+    )
+  })
+
   test("CSP includes configured runtime origins without duplicating full URLs", async () => {
     const previousBackendUrl = process.env.NEXT_PUBLIC_BACKEND_URL
     const previousMonitoringUrl = process.env.NEXT_PUBLIC_MONITORING_EMBED_URL

--- a/front/e2e/security-csp-header.spec.ts
+++ b/front/e2e/security-csp-header.spec.ts
@@ -52,6 +52,8 @@ test.describe("frontend security headers", () => {
         "'self'",
         "data:",
         "blob:",
+        "https:",
+        "http:",
         "https://*.aquilaxk.site",
         "https://www.notion.so",
         "https://avatars.githubusercontent.com",
@@ -73,6 +75,28 @@ test.describe("frontend security headers", () => {
     expect(directives.get("base-uri")).toEqual(["'self'"])
     expect(directives.get("frame-ancestors")).toEqual(["'self'"])
     expect(directives.get("upgrade-insecure-requests")).toEqual([])
+  })
+
+  test("CSP connect-src keeps documented local backend fallback available in development", async () => {
+    const previousNodeEnv = process.env.NODE_ENV
+    const previousBackendUrl = process.env.NEXT_PUBLIC_BACKEND_URL
+
+    process.env.NODE_ENV = "development"
+    delete process.env.NEXT_PUBLIC_BACKEND_URL
+
+    try {
+      const directives = parseCspDirectives(await getCspHeader())
+
+      expect(directives.get("connect-src")).toEqual(
+        expect.arrayContaining(["http://localhost:8080", "http://127.0.0.1:8080"]),
+      )
+    } finally {
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = previousNodeEnv
+
+      if (previousBackendUrl === undefined) delete process.env.NEXT_PUBLIC_BACKEND_URL
+      else process.env.NEXT_PUBLIC_BACKEND_URL = previousBackendUrl
+    }
   })
 
   test("CSP frame-src keeps supported markdown embed preview providers available", async () => {

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -43,6 +43,7 @@ const buildContentSecurityPolicy = () => {
     "https://vercel.live",
     "wss://ws-us3.pusher.com",
   ]
+  const localDevConnectSources = isDev ? ["http://localhost:8080", "http://127.0.0.1:8080"] : []
   const embedFrameSources = [
     "https://www.youtube.com",
     "https://player.vimeo.com",
@@ -62,6 +63,8 @@ const buildContentSecurityPolicy = () => {
     "'self'",
     "data:",
     "blob:",
+    "https:",
+    "http:",
     ...aquilaDomains,
     "https://www.notion.so",
     "https://lh5.googleusercontent.com",
@@ -89,6 +92,7 @@ const buildContentSecurityPolicy = () => {
       "'self'",
       ...aquilaDomains,
       ...runtimeOrigins,
+      ...localDevConnectSources,
       ...vercelConnectSources,
       ...googleConnectSources,
     ],

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -43,6 +43,14 @@ const buildContentSecurityPolicy = () => {
     "https://vercel.live",
     "wss://ws-us3.pusher.com",
   ]
+  const embedFrameSources = [
+    "https://www.youtube.com",
+    "https://player.vimeo.com",
+    "https://www.loom.com",
+    "https://www.figma.com",
+    "https://codepen.io",
+    "https://codesandbox.io",
+  ]
   const googleScriptSources = ["https://www.googletagmanager.com"]
   const googleConnectSources = [
     "https://www.google-analytics.com",
@@ -86,7 +94,7 @@ const buildContentSecurityPolicy = () => {
     ],
     ["font-src", "'self'", "data:"],
     ["media-src", "'self'", "blob:", ...aquilaDomains, ...runtimeOrigins],
-    ["frame-src", "'self'", "https://vercel.live", ...runtimeOrigins],
+    ["frame-src", "'self'", "https://vercel.live", ...runtimeOrigins, ...embedFrameSources],
     ["object-src", "'none'"],
     ["base-uri", "'self'"],
     ["form-action", "'self'"],

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -1,4 +1,105 @@
-const securityHeaders = [
+/**
+ * @param {string[]} sources
+ */
+const uniqueSources = (sources) => [...new Set(sources.filter(Boolean))]
+
+/**
+ * @param {string | undefined} value
+ */
+const originFromEnvUrl = (value) => {
+  const raw = value?.trim()
+  if (!raw) return ""
+
+  try {
+    const url = new URL(raw)
+    if (url.protocol !== "http:" && url.protocol !== "https:") return ""
+    return url.origin
+  } catch {
+    return ""
+  }
+}
+
+const configuredRuntimeOrigins = () =>
+  uniqueSources(
+    [
+      process.env.NEXT_PUBLIC_SITE_URL,
+      process.env.NEXT_PUBLIC_BACKEND_URL,
+      process.env.NEXT_PUBLIC_MONITORING_EMBED_URL,
+      process.env.NEXT_PUBLIC_GRAFANA_EMBED_URL,
+      process.env.NEXT_PUBLIC_LOGS_EMBED_URL,
+      process.env.NEXT_PUBLIC_GRAFANA_LOGS_EMBED_URL,
+      process.env.NEXT_PUBLIC_PROMETHEUS_URL,
+      process.env.UPTIME_KUMA_PROXY_ORIGIN,
+    ].map(originFromEnvUrl),
+  )
+
+const buildContentSecurityPolicy = () => {
+  const isDev = process.env.NODE_ENV === "development"
+  const runtimeOrigins = configuredRuntimeOrigins()
+  const aquilaDomains = ["https://*.aquilaxk.site"]
+  const vercelScriptSources = ["https://va.vercel-scripts.com", "https://vercel.live"]
+  const vercelConnectSources = [
+    "https://vitals.vercel-insights.com",
+    "https://vercel.live",
+    "wss://ws-us3.pusher.com",
+  ]
+  const googleScriptSources = ["https://www.googletagmanager.com"]
+  const googleConnectSources = [
+    "https://www.google-analytics.com",
+    "https://analytics.google.com",
+    "https://region1.google-analytics.com",
+    "https://stats.g.doubleclick.net",
+  ]
+  const imageSources = [
+    "'self'",
+    "data:",
+    "blob:",
+    ...aquilaDomains,
+    "https://www.notion.so",
+    "https://lh5.googleusercontent.com",
+    "https://s3-us-west-2.amazonaws.com",
+    "https://avatars.githubusercontent.com",
+    "https://placehold.co",
+    ...googleConnectSources,
+    ...runtimeOrigins,
+  ]
+
+  const directives = [
+    ["default-src", "'self'"],
+    [
+      "script-src",
+      "'self'",
+      "'unsafe-inline'",
+      ...(isDev ? ["'unsafe-eval'"] : []),
+      ...vercelScriptSources,
+      ...googleScriptSources,
+    ],
+    ["style-src", "'self'", "'unsafe-inline'"],
+    ["img-src", ...imageSources],
+    [
+      "connect-src",
+      "'self'",
+      ...aquilaDomains,
+      ...runtimeOrigins,
+      ...vercelConnectSources,
+      ...googleConnectSources,
+    ],
+    ["font-src", "'self'", "data:"],
+    ["media-src", "'self'", "blob:", ...aquilaDomains, ...runtimeOrigins],
+    ["frame-src", "'self'", "https://vercel.live", ...runtimeOrigins],
+    ["object-src", "'none'"],
+    ["base-uri", "'self'"],
+    ["form-action", "'self'"],
+    ["frame-ancestors", "'self'"],
+    ["upgrade-insecure-requests"],
+  ]
+
+  return directives
+    .map(([name, ...sources]) => uniqueSources([name, ...sources]).join(" "))
+    .join("; ")
+}
+
+const buildSecurityHeaders = () => [
   {
     key: "X-Content-Type-Options",
     value: "nosniff",
@@ -21,9 +122,13 @@ const securityHeaders = [
   },
   {
     key: "Content-Security-Policy",
-    value: "base-uri 'self'; object-src 'none'; frame-ancestors 'self'; upgrade-insecure-requests",
+    value: buildContentSecurityPolicy(),
   },
 ]
+
+/**
+ * @typedef {{ source: string, destination: string }} RewriteRule
+ */
 
 module.exports = {
   images: {
@@ -58,12 +163,13 @@ module.exports = {
     return [
       {
         source: "/:path*",
-        headers: securityHeaders,
+        headers: buildSecurityHeaders(),
       },
     ]
   },
   async rewrites() {
     const uptimeProxyOrigin = process.env.UPTIME_KUMA_PROXY_ORIGIN?.trim()
+    /** @type {RewriteRule[]} */
     const rules = []
 
     if (!uptimeProxyOrigin) return rules
@@ -87,10 +193,16 @@ module.exports = {
 
     return rules
   },
+  /**
+   * @param {import("webpack").Configuration} config
+   */
   webpack(config) {
     const existingIgnoreWarnings = Array.isArray(config.ignoreWarnings) ? config.ignoreWarnings : []
     config.ignoreWarnings = [
       ...existingIgnoreWarnings,
+      /**
+       * @param {any} warning
+       */
       (warning) => {
         const message = typeof warning?.message === "string" ? warning.message : ""
         if (!message.includes("Critical dependency: the request of a dependency is an expression")) {


### PR DESCRIPTION
## 관련 이슈

close #946

## 작업 배경

- 기존 frontend CSP는 `base-uri`, `object-src`, `frame-ancestors`, `upgrade-insecure-requests` 중심이라 script/style/img/connect/font 경계를 명시하지 못했다.
- Next.js runtime, 현재 inline bootstrap, Vercel Analytics/Speed Insights, Google Analytics, image/API/monitoring origin을 반영한 defense-in-depth 정책이 필요했다.

## 작업 내용

- `front/next.config.js`에 CSP builder를 추가해 `default-src`, `script-src`, `style-src`, `img-src`, `connect-src`, `font-src`, `media-src`, `frame-src`를 명시했다.
- runtime env URL은 path/query가 아니라 origin만 추출해 CSP source에 반영하게 했다.
- markdown embed provider iframe origin과 local backend fallback origin을 CSP에 반영했다.
- 현재 markdown image/unfurl thumbnail 입력 계약과 맞도록 `img-src`에 `http:`/`https:` scheme source를 명시했다.
- CSP header contract test를 추가해 directive, env origin, embed provider, dev fallback, image source 계약을 검증했다.
- `docs/design/security-csp-rollout.md`에 report-only rollout과 violation triage 절차를 정리했다.

## 검증

- 실행한 명령과 결과:
  - `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/security-csp-header.spec.ts --workers=1`: RED 확인, `default-src`/`connect-src` 누락으로 2 tests failed
  - `yarn --cwd front playwright:preflight`: PASS
  - `PLAYWRIGHT_USE_WEBSERVER=false yarn --cwd front playwright test e2e/security-csp-header.spec.ts --workers=1`: PASS, 4 tests
  - `yarn --cwd front build`: PASS
  - `git diff --check`: PASS
  - `CURRENT_TASK_SLUG=issue-946-frontend-csp-directives bash tools/guards/current-task-preflight.sh`: PASS
  - PR CI: `frontend-ci`, `backend-ci`, `backend-dependency-check`, `codeql (java-kotlin)`, `codeql (javascript-typescript)`, Vercel 모두 PASS
  - main CI: `CI` run `27896837954` PASS
  - main Security: `Security` run `27896837942` PASS
  - CD/live: `Deploy to Home Server` run `27896982639` PASS, `Frontend Live E2E Verification` PASS

## Codex CLI Code Review - 변경 요청 및 재검토

- CodeRabbit status check는 SUCCESS였지만 실제 GitHub review 객체/inline review가 확인되지 않아 Codex CLI fallback을 사용했다.
- 최초 Codex review: actionable 1건
  - 지적: markdown embed provider iframe origin이 `frame-src`에서 빠져 기존 embed preview가 CSP로 차단될 수 있음.
  - 반영: `frame-src`에 YouTube, Vimeo, Loom, Figma, CodePen, CodeSandbox origin 추가.
  - 커밋: `36acc12a6f2c386df020fc022320c9702bbfb959`
  - 원 inline thread 답글 및 resolve 완료.
- 재검토 Codex review: actionable 2건
  - 지적: development local backend fallback `http://localhost:8080`, `http://127.0.0.1:8080`이 `connect-src`에서 빠짐.
  - 지적: 현재 markdown image/unfurl thumbnail URL 허용 범위와 `img-src`가 맞지 않음.
  - 반영: development `connect-src`에 local fallback origin 추가, `img-src`에 `http:`/`https:` scheme source 추가, contract test와 rollout 문서 갱신.
  - 커밋: `bd493107c1ae1d969f7e1c581e9a624dbc4a66e8`
  - 원 inline thread 2개 답글 및 resolve 완료.
- 최종 Codex re-review: actionable 0건
  - PR review: `4539321541`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `script-src`의 `unsafe-inline`은 현재 GA inline bootstrap/정적 header 운용을 위한 운영 가능한 대체 정책이며, nonce 전환은 별도 이슈로 분리했다.
  - runtime URL은 전체 URL이 아니라 origin만 CSP에 추가된다.
  - `img-src`의 `http:`/`https:`는 현재 markdown image/unfurl thumbnail 입력 계약을 보존하기 위한 source이며, image proxy/domain validation 축소는 별도 content validation 이슈로 분리한다.

## 리스크

- CSP가 넓어졌지만 새 외부 origin 추가가 명시적으로 관리된다.
- 누락된 실제 운영 origin이 있으면 배포 후 browser console CSP violation으로 드러날 수 있어 report-only/triage 문서를 함께 추가했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
