### PR TITLE
[Docs] 개인정보처리방침과 이용약관 공개

### DIFF
--- a/front/e2e/legal-policy-pages.spec.ts
+++ b/front/e2e/legal-policy-pages.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test"
+import { addPublicAboutSnapshotCookie, mockAvatarAsset, mockFeedEndpoints } from "./helpers/smokeFixtures"
+
+test.describe("legal policy public pages", () => {
+  test("privacy and terms pages expose legal notices and data deletion contact", async ({ page }) => {
+    await page.goto("/privacy", { waitUntil: "domcontentloaded" })
+
+    await expect(page).toHaveTitle(/개인정보처리방침/)
+    await expect(page.locator("meta[name='robots']")).toHaveAttribute("content", /index/)
+    await expect(page.getByRole("heading", { name: "개인정보처리방침" })).toBeVisible()
+    await expect(page.getByRole("heading", { name: "데이터 삭제 요청" })).toBeVisible()
+    await expect(page.getByRole("link", { name: /illusiveman7@gmail\.com/ })).toHaveAttribute(
+      "href",
+      "mailto:illusiveman7@gmail.com?subject=AquilaLog%20%EB%8D%B0%EC%9D%B4%ED%84%B0%20%EC%82%AD%EC%A0%9C%20%EC%9A%94%EC%B2%AD",
+    )
+
+    await page.goto("/terms", { waitUntil: "domcontentloaded" })
+
+    await expect(page).toHaveTitle(/이용약관/)
+    await expect(page.locator("meta[name='robots']")).toHaveAttribute("content", /index/)
+    await expect(page.getByRole("heading", { name: "이용약관" })).toBeVisible()
+    await expect(page.getByText("문의 및 데이터 삭제 요청")).toBeVisible()
+    await expect(page.getByRole("link", { name: "개인정보처리방침" })).toHaveAttribute("href", "/privacy")
+  })
+
+  test("auth and footer surfaces link to privacy and terms", async ({ page }) => {
+    await page.goto("/login", { waitUntil: "domcontentloaded" })
+
+    await expect(page.getByRole("link", { name: "개인정보처리방침" })).toHaveAttribute("href", "/privacy")
+    await expect(page.getByRole("link", { name: "이용약관" })).toHaveAttribute("href", "/terms")
+
+    await page.goto("/signup", { waitUntil: "domcontentloaded" })
+
+    await expect(page.getByRole("link", { name: "개인정보처리방침" })).toHaveAttribute("href", "/privacy")
+    await expect(page.getByRole("link", { name: "이용약관" })).toHaveAttribute("href", "/terms")
+
+    await mockAvatarAsset(page)
+    await addPublicAboutSnapshotCookie(page)
+    await mockFeedEndpoints(page)
+    await page.goto("/", { waitUntil: "domcontentloaded" })
+
+    const footer = page.locator("footer")
+
+    await expect(footer.getByRole("link", { name: "개인정보처리방침" })).toHaveAttribute(
+      "href",
+      "/privacy",
+    )
+    await expect(footer.getByRole("link", { name: "이용약관" })).toHaveAttribute(
+      "href",
+      "/terms",
+    )
+  })
+})

--- a/front/src/components/auth/LoginPage.styles.ts
+++ b/front/src/components/auth/LoginPage.styles.ts
@@ -325,6 +325,13 @@ export const FooterText = styled.p`
     align-items: center;
     min-height: 34px;
   }
+
+  .policyLinks {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.7rem;
+    margin-top: 0.25rem;
+  }
 `
 
 export const SocialSection = styled.div`

--- a/front/src/pages/login.tsx
+++ b/front/src/pages/login.tsx
@@ -166,6 +166,10 @@ const LoginPage = () => {
       footer={
         <FooterText>
           계정이 없으면 <Link href={toSignupPath(next)}>회원가입</Link>
+          <span className="policyLinks">
+            <Link href="/privacy">개인정보처리방침</Link>
+            <Link href="/terms">이용약관</Link>
+          </span>
         </FooterText>
       }
       loginHref={toLoginPath(next)}

--- a/front/src/pages/privacy.tsx
+++ b/front/src/pages/privacy.tsx
@@ -1,0 +1,64 @@
+import { CONFIG } from "site.config"
+import MetaConfig from "src/components/MetaConfig"
+import LegalPolicyPage, { DATA_DELETION_MAILTO } from "src/routes/LegalPolicy/LegalPolicyPage"
+
+const PrivacyPage = () => {
+  const meta = {
+    title: "개인정보처리방침",
+    description: "AquilaLog가 처리하는 개인정보 항목, 이용 목적, 보관 기준, 삭제 요청 경로를 안내합니다.",
+    type: "website",
+    url: `${CONFIG.link}/privacy`,
+    robots: "follow, index",
+  }
+
+  return (
+    <>
+      <MetaConfig {...meta} />
+      <LegalPolicyPage
+        eyebrow="Privacy"
+        title="개인정보처리방침"
+        description="AquilaLog는 계정 제공, 콘텐츠 운영, 보안 감사, 서비스 품질 개선에 필요한 최소한의 개인정보와 운영 데이터를 처리합니다."
+        updatedAt="2026-06-21"
+        sections={[
+          {
+            title: "처리하는 정보",
+            body: [
+              "회원가입과 로그인 과정에서 이메일 주소, OAuth 제공자 식별자, 인증 쿠키, 접속 세션 정보를 처리합니다.",
+              "댓글, 업로드 파일, 프로필 이미지, 작성/수정/삭제 action log, IP 보안 정보, security log, analytics와 RUM 이벤트가 서비스 운영과 보안 점검에 사용될 수 있습니다.",
+            ],
+          },
+          {
+            title: "이용 목적",
+            body: [
+              "계정 인증, 게시글·댓글 작성, 관리자 도구 접근 제어, 악용 방지, 장애 분석, 성능 개선, 법적 요청 대응을 위해 정보를 사용합니다.",
+              "RUM과 analytics 데이터는 페이지 품질과 오류 추적을 위한 집계 분석에 사용하며, 사용자를 불필요하게 식별하는 목적의 별도 판매나 공유는 하지 않습니다.",
+            ],
+          },
+          {
+            title: "보관 및 파기",
+            body: [
+              "계정 정보와 사용자가 작성한 콘텐츠는 계정 유지 또는 서비스 제공에 필요한 기간 동안 보관합니다.",
+              "보안·감사 로그는 운영 안정성과 침해 대응을 위해 필요한 기간 보관한 뒤 접근 권한을 제한하거나 삭제합니다.",
+            ],
+          },
+          {
+            title: "데이터 삭제 요청",
+            body: [
+              `데이터 삭제 요청은 ${CONFIG.profile.email}로 보낼 수 있습니다. 요청 시 계정 이메일, 삭제 대상, 본인 확인에 필요한 최소 정보를 함께 알려주세요.`,
+              `빠른 접수를 위해 메일 링크를 사용할 수 있습니다: ${DATA_DELETION_MAILTO}`,
+            ],
+          },
+          {
+            title: "문의",
+            body: [
+              `개인정보 처리, 계정 정보 정정, 데이터 삭제, 서비스 이용 문의는 ${CONFIG.profile.email}로 연락해 주세요.`,
+              "정책이 변경되면 이 페이지의 시행일과 내용을 갱신합니다.",
+            ],
+          },
+        ]}
+      />
+    </>
+  )
+}
+
+export default PrivacyPage

--- a/front/src/pages/privacy.tsx
+++ b/front/src/pages/privacy.tsx
@@ -1,8 +1,9 @@
 import { CONFIG } from "site.config"
 import MetaConfig from "src/components/MetaConfig"
-import LegalPolicyPage, { DATA_DELETION_MAILTO } from "src/routes/LegalPolicy/LegalPolicyPage"
+import LegalPolicyPage, { buildDataDeletionMailto } from "src/routes/LegalPolicy/LegalPolicyPage"
 
 const PrivacyPage = () => {
+  const dataDeletionMailto = buildDataDeletionMailto(CONFIG.profile.email)
   const meta = {
     title: "개인정보처리방침",
     description: "AquilaLog가 처리하는 개인정보 항목, 이용 목적, 보관 기준, 삭제 요청 경로를 안내합니다.",
@@ -45,7 +46,7 @@ const PrivacyPage = () => {
             title: "데이터 삭제 요청",
             body: [
               `데이터 삭제 요청은 ${CONFIG.profile.email}로 보낼 수 있습니다. 요청 시 계정 이메일, 삭제 대상, 본인 확인에 필요한 최소 정보를 함께 알려주세요.`,
-              `빠른 접수를 위해 메일 링크를 사용할 수 있습니다: ${DATA_DELETION_MAILTO}`,
+              `빠른 접수를 위해 메일 링크를 사용할 수 있습니다: ${dataDeletionMailto}`,
             ],
           },
           {

--- a/front/src/pages/signup.tsx
+++ b/front/src/pages/signup.tsx
@@ -97,6 +97,10 @@ const SignupPage = () => {
       footer={
         <FooterText>
           이미 계정이 있으면 <Link href={toLoginPath(next)}>로그인</Link>
+          <span className="policyLinks">
+            <Link href="/privacy">개인정보처리방침</Link>
+            <Link href="/terms">이용약관</Link>
+          </span>
         </FooterText>
       }
       loginHref={toLoginPath(next)}
@@ -325,5 +329,12 @@ const FooterText = styled.div`
     display: inline-flex;
     align-items: center;
     min-height: 34px;
+  }
+
+  .policyLinks {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.7rem;
+    margin-top: 0.25rem;
   }
 `

--- a/front/src/pages/terms.tsx
+++ b/front/src/pages/terms.tsx
@@ -1,0 +1,64 @@
+import { CONFIG } from "site.config"
+import MetaConfig from "src/components/MetaConfig"
+import LegalPolicyPage from "src/routes/LegalPolicy/LegalPolicyPage"
+
+const TermsPage = () => {
+  const meta = {
+    title: "이용약관",
+    description: "AquilaLog 서비스 이용 조건, 계정과 콘텐츠 책임, 문의 및 데이터 삭제 요청 경로를 안내합니다.",
+    type: "website",
+    url: `${CONFIG.link}/terms`,
+    robots: "follow, index",
+  }
+
+  return (
+    <>
+      <MetaConfig {...meta} />
+      <LegalPolicyPage
+        eyebrow="Terms"
+        title="이용약관"
+        description="AquilaLog를 이용할 때 적용되는 계정, 콘텐츠, 보안, 운영 문의 기준입니다."
+        updatedAt="2026-06-21"
+        sections={[
+          {
+            title: "서비스 이용",
+            body: [
+              "AquilaLog는 기술 글, 댓글, 프로필, 관리자 도구를 제공하는 개인 운영 블로그 서비스입니다.",
+              "사용자는 관련 법령과 본 약관을 지키며 서비스를 이용해야 하고, 계정 정보와 인증 수단을 안전하게 관리해야 합니다.",
+            ],
+          },
+          {
+            title: "계정과 보안",
+            body: [
+              "이메일 로그인, OAuth 로그인, 인증 쿠키, IP 보안 설정은 계정 보호와 접근 제어를 위해 사용됩니다.",
+              "비정상 접근, 자동화 남용, 다른 사용자의 계정 또는 데이터를 침해하는 행위는 제한될 수 있습니다.",
+            ],
+          },
+          {
+            title: "콘텐츠와 댓글",
+            body: [
+              "사용자가 작성한 댓글과 업로드한 파일은 사용자가 책임을 집니다. 타인의 권리 침해, 악성 코드, 불법 정보, 과도한 광고성 콘텐츠는 삭제될 수 있습니다.",
+              "서비스 운영자는 보안, 장애 대응, 법적 요청, 커뮤니티 보호를 위해 필요한 범위에서 콘텐츠 노출을 제한하거나 삭제할 수 있습니다.",
+            ],
+          },
+          {
+            title: "문의 및 데이터 삭제 요청",
+            body: [
+              `서비스 문의, 계정 문제, 데이터 삭제 요청은 ${CONFIG.profile.email}로 접수합니다.`,
+              "개인정보 처리 기준과 삭제 요청 절차는 개인정보처리방침에서 함께 확인할 수 있습니다.",
+            ],
+          },
+          {
+            title: "약관 변경",
+            body: [
+              "서비스 구조, 법령, 운영 정책이 바뀌면 약관을 갱신할 수 있습니다.",
+              "중요한 변경은 이 페이지의 시행일과 본문을 통해 확인할 수 있게 공개합니다.",
+            ],
+          },
+        ]}
+      />
+    </>
+  )
+}
+
+export default TermsPage

--- a/front/src/routes/Feed/Footer.tsx
+++ b/front/src/routes/Feed/Footer.tsx
@@ -1,4 +1,5 @@
 import { CONFIG } from "site.config"
+import Link from "next/link"
 import React from "react"
 import styled from "@emotion/styled"
 
@@ -13,20 +14,32 @@ type Props = {
 const Footer: React.FC<Props> = ({ className }) => {
   return (
     <StyledWrapper className={className}>
-      <a
-        href={`https://github.com/${CONFIG.profile.github}`}
-        target="_blank"
-        rel="noreferrer"
-      >
-        © {CONFIG.profile.name} {from === y || !from ? y : `${from} - ${y}`}
-      </a>
+      <div className="footerLinks">
+        <a
+          href={`https://github.com/${CONFIG.profile.github}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          © {CONFIG.profile.name} {from === y || !from ? y : `${from} - ${y}`}
+        </a>
+        <Link href="/privacy">개인정보처리방침</Link>
+        <Link href="/terms">이용약관</Link>
+      </div>
     </StyledWrapper>
   )
 }
 
 export default Footer
 
-const StyledWrapper = styled.div`
+const StyledWrapper = styled.footer`
+  .footerLinks {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem 0.85rem;
+  }
+
   a {
     display: inline-flex;
     align-items: center;

--- a/front/src/routes/LegalPolicy/LegalPolicyPage.tsx
+++ b/front/src/routes/LegalPolicy/LegalPolicyPage.tsx
@@ -1,0 +1,144 @@
+import Link from "next/link"
+import styled from "@emotion/styled"
+import { CONFIG } from "site.config"
+
+export const DATA_DELETION_MAILTO =
+  "mailto:illusiveman7@gmail.com?subject=AquilaLog%20%EB%8D%B0%EC%9D%B4%ED%84%B0%20%EC%82%AD%EC%A0%9C%20%EC%9A%94%EC%B2%AD"
+
+type LegalPolicySection = {
+  title: string
+  body: string[]
+}
+
+type LegalPolicyPageProps = {
+  eyebrow: string
+  title: string
+  description: string
+  updatedAt: string
+  sections: LegalPolicySection[]
+}
+
+const LegalPolicyPage = ({ eyebrow, title, description, updatedAt, sections }: LegalPolicyPageProps) => {
+  return (
+    <StyledWrapper>
+      <div className="legalShell">
+        <header className="legalHeader">
+          <p className="eyebrow">{eyebrow}</p>
+          <h1>{title}</h1>
+          <p className="description">{description}</p>
+          <p className="updated">시행일: {updatedAt}</p>
+          <nav aria-label="정책 문서">
+            <Link href="/privacy">개인정보처리방침</Link>
+            <Link href="/terms">이용약관</Link>
+            <a href={DATA_DELETION_MAILTO}>{CONFIG.profile.email}</a>
+          </nav>
+        </header>
+
+        <main className="legalBody">
+          {sections.map((section) => (
+            <section key={section.title}>
+              <h2>{section.title}</h2>
+              {section.body.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </section>
+          ))}
+        </main>
+      </div>
+    </StyledWrapper>
+  )
+}
+
+export default LegalPolicyPage
+
+const StyledWrapper = styled.div`
+  min-height: calc(100vh - 4rem);
+  padding: 3rem 1rem 4rem;
+  background: ${({ theme }) => theme.colors.gray1};
+  color: ${({ theme }) => theme.colors.gray12};
+
+  .legalShell {
+    width: min(860px, 100%);
+    margin: 0 auto;
+  }
+
+  .legalHeader {
+    border-bottom: 1px solid ${({ theme }) => theme.colors.gray5};
+    padding-bottom: 1.4rem;
+    margin-bottom: 1.6rem;
+  }
+
+  .eyebrow {
+    margin: 0 0 0.55rem;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.78rem;
+    font-weight: 760;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: clamp(2rem, 5vw, 3rem);
+    line-height: 1.14;
+  }
+
+  .description {
+    max-width: 680px;
+    margin: 0.9rem 0 0;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 1.02rem;
+    line-height: 1.72;
+  }
+
+  .updated {
+    margin: 1rem 0 0;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.9rem;
+  }
+
+  nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem 0.9rem;
+    margin-top: 1.1rem;
+  }
+
+  a {
+    color: ${({ theme }) => theme.colors.accentLink};
+    font-weight: 700;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  .legalBody {
+    display: grid;
+    gap: 1.3rem;
+  }
+
+  section {
+    padding-bottom: 1.3rem;
+    border-bottom: 1px solid ${({ theme }) => theme.colors.gray4};
+  }
+
+  section:last-of-type {
+    border-bottom: 0;
+  }
+
+  h2 {
+    margin: 0 0 0.65rem;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 1.18rem;
+    line-height: 1.35;
+  }
+
+  p {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray11};
+    line-height: 1.78;
+  }
+
+  p + p {
+    margin-top: 0.58rem;
+  }
+`

--- a/front/src/routes/LegalPolicy/LegalPolicyPage.tsx
+++ b/front/src/routes/LegalPolicy/LegalPolicyPage.tsx
@@ -2,8 +2,9 @@ import Link from "next/link"
 import styled from "@emotion/styled"
 import { CONFIG } from "site.config"
 
-export const DATA_DELETION_MAILTO =
-  "mailto:illusiveman7@gmail.com?subject=AquilaLog%20%EB%8D%B0%EC%9D%B4%ED%84%B0%20%EC%82%AD%EC%A0%9C%20%EC%9A%94%EC%B2%AD"
+const DATA_DELETION_SUBJECT = encodeURIComponent("AquilaLog 데이터 삭제 요청")
+
+export const buildDataDeletionMailto = (email: string) => `mailto:${email}?subject=${DATA_DELETION_SUBJECT}`
 
 type LegalPolicySection = {
   title: string
@@ -30,7 +31,7 @@ const LegalPolicyPage = ({ eyebrow, title, description, updatedAt, sections }: L
           <nav aria-label="정책 문서">
             <Link href="/privacy">개인정보처리방침</Link>
             <Link href="/terms">이용약관</Link>
-            <a href={DATA_DELETION_MAILTO}>{CONFIG.profile.email}</a>
+            <a href={buildDataDeletionMailto(CONFIG.profile.email)}>{CONFIG.profile.email}</a>
           </nav>
         </header>
 
@@ -38,8 +39,8 @@ const LegalPolicyPage = ({ eyebrow, title, description, updatedAt, sections }: L
           {sections.map((section) => (
             <section key={section.title}>
               <h2>{section.title}</h2>
-              {section.body.map((paragraph) => (
-                <p key={paragraph}>{paragraph}</p>
+              {section.body.map((paragraph, index) => (
+                <p key={`${section.title}-${index}`}>{paragraph}</p>
               ))}
             </section>
           ))}


### PR DESCRIPTION
## 관련 이슈

close #951

## 작업 배경

- 출시 전 공개 서비스가 처리하는 계정, 인증 쿠키, 댓글, 업로드 파일, action/security log, analytics/RUM 데이터에 대한 사용자 고지가 필요했다.
- 기존에는 `/privacy`, `/terms` 공개 페이지와 login/signup/footer 접근 링크가 없었다.

## 작업 내용

- `/privacy` 개인정보처리방침 페이지를 추가했다.
- `/terms` 이용약관 페이지를 추가했다.
- 두 정책 페이지는 `follow, index` robots meta와 canonical URL을 갖는 공개 문서로 노출한다.
- 문의 및 데이터 삭제 요청 경로를 `CONFIG.profile.email` 기반 mailto 링크로 공개했다.
- login/signup footer와 홈 footer에서 개인정보처리방침/이용약관으로 접근할 수 있게 했다.
- `front/e2e/legal-policy-pages.spec.ts`로 정책 페이지, meta, 삭제 요청 링크, auth/footer 접근 링크를 검증했다.
- CodeRabbit 지적에 따라 표시 이메일과 실제 mailto 수신자를 단일 설정값으로 정렬하고 문단 key를 안정화했다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`: PASS
  - `yarn --cwd front playwright test e2e/legal-policy-pages.spec.ts --workers=1`: RED 확인, 정책 페이지 title/link 누락으로 실패
  - `yarn --cwd front playwright test e2e/legal-policy-pages.spec.ts --workers=1`: PASS, 2 tests
  - `yarn --cwd front build`: PASS, `/privacy`, `/terms` static pages 생성 확인
  - `git diff --check`: PASS
  - `CURRENT_TASK_SLUG=issue-951-legal-policy-pages bash tools/guards/current-task-preflight.sh`: PASS
  - PR CI: Backend CI `27897694689` PASS, Frontend CI `27897694698` PASS, Security `27897694684` PASS
  - CodeRabbit: actionable 1건 확인, follow-up commit `977998e68ce3fc829d8d6055593eadcdb98d2ba5` 반영, 원 review thread resolved 및 CodeRabbit addressed 확인
  - main CI: `27897889767` PASS
  - main Security: `27897889749` PASS
  - Deploy to Home Server: `27898044216` PASS, Frontend Live E2E Verification PASS (`buildAndPush`, `blueGreenDeploy`는 frontend-only 변경으로 skip)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 정책 페이지는 출시 전 사용자가 찾아야 하는 공개 문서라 `robots: follow, index`로 결정했다.
  - 이 PR은 법적 문구의 제품 내 공개와 접근 경로 보강이며, 인증 API/쿠키 동작이나 개인정보 수집 범위는 변경하지 않는다.

## 리스크

- 정책 문구는 운영 현황 기준의 제품 고지이며, 별도 법률 자문 문서가 아니다.
- 향후 수집 항목이나 외부 처리자가 추가되면 같은 페이지와 e2e 계약을 함께 갱신해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (N/A: CodeRabbit 실제 리뷰 및 follow-up 확인 완료)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
