### PR TITLE
[Test] RSS feed discovery 계약 검증

### DIFF
--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -491,6 +491,22 @@ test.describe("live frontend build metadata", () => {
   })
 })
 
+test.describe("live public RSS feed", () => {
+  test("/feed는 RSS XML discovery 계약을 만족한다", async ({ page }) => {
+    const response = await page.request.get("/feed")
+    expect(response.status()).toBe(200)
+    expect(response.headers()["content-type"]).toContain("application/rss+xml")
+
+    const body = await response.text()
+    expect(body).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+    expect(body).toContain('<rss version="2.0">')
+    expect(body).toContain("<channel>")
+    expect(body).toContain("<link>https://www.aquilaxk.site</link>")
+    expect(body).toMatch(/<item>[\s\S]*<guid>https:\/\/www\.aquilaxk\.site\/posts\/\d+<\/guid>[\s\S]*<\/item>/)
+    expect(body).not.toContain("<!DOCTYPE")
+  })
+})
+
 test.describe("live production e2e", () => {
   test.skip(!hasLiveCredentials, "E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD is required")
   test.setTimeout(120_000)

--- a/front/e2e/rss-feed.spec.ts
+++ b/front/e2e/rss-feed.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "@playwright/test"
+import type { GetServerSidePropsContext } from "next"
+import type { ExplorePostsPage } from "../src/apis/backend/posts"
+import { createFeedServerSideProps } from "../src/pages/feed"
+import {
+  buildRssFeedXml,
+  collectRssFeedPosts,
+  RSS_FEED_CONTENT_TYPE,
+} from "../src/libs/rssFeed"
+import type { TPost, TPostStatus } from "../src/types"
+
+const makePost = (
+  id: number,
+  status: TPostStatus[] = ["Public"],
+  timestamps: { createdTime?: string; modifiedTime?: string } = {}
+): TPost => ({
+  id: String(id),
+  date: { start_date: `2026-06-${String((id % 28) + 1).padStart(2, "0")}` },
+  type: ["Post"],
+  slug: `rss-post-${id}`,
+  title: `RSS Post ${id}`,
+  status,
+  createdTime: timestamps.createdTime ?? `2026-06-${String((id % 28) + 1).padStart(2, "0")}T00:00:00.000Z`,
+  ...(timestamps.modifiedTime ? { modifiedTime: timestamps.modifiedTime } : {}),
+  summary: `RSS summary ${id}`,
+  fullWidth: false,
+})
+
+const createPagedLoader =
+  (posts: TPost[], requestedPages: number[]) =>
+  async ({ page, pageSize }: { page?: number; pageSize?: number }): Promise<ExplorePostsPage> => {
+    const safePage = page ?? 1
+    const safePageSize = pageSize ?? 30
+    requestedPages.push(safePage)
+    const start = (safePage - 1) * safePageSize
+
+    return {
+      posts: posts.slice(start, start + safePageSize),
+      totalCount: posts.length,
+      pageNumber: safePage,
+      pageSize: safePageSize,
+      paginationMode: "page",
+    }
+  }
+
+test.describe("RSS feed contract", () => {
+  test("collects only public feed posts and sorts newest first", async () => {
+    const newestPublicPost = makePost(1, ["Public"], {
+      createdTime: "2026-06-20T00:00:00.000Z",
+      modifiedTime: "2026-06-21T00:00:00.000Z",
+    })
+    const olderPublicPost = makePost(2, ["Public"], {
+      createdTime: "2026-06-10T00:00:00.000Z",
+    })
+    const privatePost = makePost(3, ["Private"], {
+      createdTime: "2026-06-22T00:00:00.000Z",
+    })
+    const detailOnlyPost = makePost(4, ["PublicOnDetail"], {
+      createdTime: "2026-06-23T00:00:00.000Z",
+    })
+    const requestedPages: number[] = []
+
+    const posts = await collectRssFeedPosts(
+      createPagedLoader([olderPublicPost, privatePost, detailOnlyPost, newestPublicPost], requestedPages),
+      { pageSize: 2 }
+    )
+
+    expect(requestedPages).toEqual([1, 2])
+    expect(posts.map((post) => post.id)).toEqual(["1", "2"])
+  })
+
+  test("builds valid RSS XML with canonical item URLs", () => {
+    const xml = buildRssFeedXml(
+      [
+        makePost(1, ["Public"], {
+          createdTime: "2026-06-20T00:00:00.000Z",
+          modifiedTime: "2026-06-21T00:00:00.000Z",
+        }),
+      ],
+      {
+        siteUrl: "https://example.com/",
+        title: "AquilaLog",
+        description: "RSS contract",
+        lang: "ko-KR",
+      }
+    )
+
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+    expect(xml).toContain('<rss version="2.0">')
+    expect(xml).toContain("<link>https://example.com</link>")
+    expect(xml).toContain("<guid>https://example.com/posts/1</guid>")
+    expect(xml).toContain("<pubDate>Sun, 21 Jun 2026 00:00:00 GMT</pubDate>")
+  })
+
+  test("feed route writes 200 RSS response headers and XML body", async () => {
+    const chunks: string[] = []
+    const headers = new Map<string, string>()
+    const res = {
+      statusCode: 0,
+      setHeader: (name: string, value: string) => headers.set(name.toLowerCase(), value),
+      write: (chunk: string) => chunks.push(chunk),
+      end: () => undefined,
+    }
+
+    const getServerSideProps = createFeedServerSideProps(
+      createPagedLoader([makePost(1), makePost(2, ["Private"])], [])
+    )
+
+    await getServerSideProps({ res } as unknown as GetServerSidePropsContext)
+
+    expect(res.statusCode).toBe(200)
+    expect(headers.get("content-type")).toBe(RSS_FEED_CONTENT_TYPE)
+    expect(chunks.join("")).toContain("<title>RSS Post 1</title>")
+    expect(chunks.join("")).not.toContain("RSS Post 2")
+  })
+})

--- a/front/src/libs/rssFeed.ts
+++ b/front/src/libs/rssFeed.ts
@@ -1,0 +1,138 @@
+import type { ExplorePostsPage } from "src/apis/backend/posts"
+import type { TPost } from "src/types"
+import { toCanonicalPostPath } from "src/libs/utils/postPath"
+
+export const RSS_FEED_CONTENT_TYPE = "application/rss+xml; charset=utf-8"
+export const RSS_FEED_PAGE_SIZE = 30
+export const RSS_FEED_MAX_PAGES = 1_000
+
+export type RssFeedPostPageLoader = (params: {
+  order?: "asc" | "desc"
+  page?: number
+  pageSize?: number
+}) => Promise<ExplorePostsPage>
+
+type CollectRssFeedPostsOptions = {
+  pageSize?: number
+  maxPages?: number
+}
+
+type BuildRssFeedOptions = {
+  siteUrl: string
+  title: string
+  description: string
+  lang: string
+}
+
+const toSafePositiveInteger = (value: number | undefined, fallback: number) => {
+  if (!Number.isFinite(value)) return fallback
+  return Math.max(1, Math.trunc(value || fallback))
+}
+
+const normalizeSiteUrl = (siteUrl: string) => siteUrl.replace(/\/+$/, "")
+
+const toStableDate = (value: string | undefined) => {
+  if (typeof value !== "string" || value.trim().length === 0) return null
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) return null
+  return new Date(timestamp)
+}
+
+const getRssPostDate = (post: TPost) =>
+  toStableDate(post.modifiedTime) ??
+  toStableDate(post.createdTime) ??
+  toStableDate(post.date.start_date) ??
+  new Date(0)
+
+const isRssVisiblePost = (post: TPost) =>
+  post.status.includes("Public") &&
+  !post.status.includes("Private") &&
+  !post.status.includes("PublicOnDetail")
+
+const hasMoreRssPages = (page: ExplorePostsPage, requestedPage: number, requestedPageSize: number) => {
+  if (page.hasNext === true) return true
+  const responsePageSize = toSafePositiveInteger(page.pageSize, requestedPageSize)
+  const totalCount = Number.isFinite(page.totalCount) ? Math.max(0, Math.trunc(page.totalCount)) : 0
+  return requestedPage * responsePageSize < totalCount
+}
+
+const escapeXml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+
+export const collectRssFeedPosts = async (
+  loadPage: RssFeedPostPageLoader,
+  { pageSize = RSS_FEED_PAGE_SIZE, maxPages = RSS_FEED_MAX_PAGES }: CollectRssFeedPostsOptions = {}
+) => {
+  const safePageSize = toSafePositiveInteger(pageSize, RSS_FEED_PAGE_SIZE)
+  const safeMaxPages = toSafePositiveInteger(maxPages, RSS_FEED_MAX_PAGES)
+  const posts: TPost[] = []
+  const seenPostIds = new Set<string>()
+
+  for (let page = 1; page <= safeMaxPages; page += 1) {
+    const result = await loadPage({
+      order: "desc",
+      page,
+      pageSize: safePageSize,
+    })
+
+    for (const post of result.posts) {
+      if (!isRssVisiblePost(post) || seenPostIds.has(post.id)) continue
+      seenPostIds.add(post.id)
+      posts.push(post)
+    }
+
+    const hasMore = result.posts.length > 0 && hasMoreRssPages(result, page, safePageSize)
+    if (!hasMore) break
+
+    if (page === safeMaxPages) {
+      throw new Error(
+        `RSS feed collection reached maxPages=${safeMaxPages} before exhausting posts. Increase the limit or split the feed.`
+      )
+    }
+  }
+
+  return posts.sort((left, right) => getRssPostDate(right).getTime() - getRssPostDate(left).getTime())
+}
+
+export const buildRssFeedXml = (posts: TPost[], options: BuildRssFeedOptions) => {
+  const siteUrl = normalizeSiteUrl(options.siteUrl)
+  const latestPostDate = posts.length > 0 ? getRssPostDate(posts[0]) : new Date(0)
+  const items = posts
+    .map((post) => {
+      const canonicalUrl = `${siteUrl}${toCanonicalPostPath(post.id)}`
+      const summary = post.summary?.trim() || post.title
+
+      return [
+        "    <item>",
+        `      <title>${escapeXml(post.title)}</title>`,
+        `      <link>${escapeXml(canonicalUrl)}</link>`,
+        `      <guid>${escapeXml(canonicalUrl)}</guid>`,
+        `      <description>${escapeXml(summary)}</description>`,
+        `      <pubDate>${getRssPostDate(post).toUTCString()}</pubDate>`,
+        "    </item>",
+      ].join("\n")
+    })
+    .join("\n")
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0">',
+    "  <channel>",
+    `    <title>${escapeXml(options.title)}</title>`,
+    `    <link>${escapeXml(siteUrl)}</link>`,
+    `    <description>${escapeXml(options.description)}</description>`,
+    `    <language>${escapeXml(options.lang)}</language>`,
+    `    <lastBuildDate>${latestPostDate.toUTCString()}</lastBuildDate>`,
+    items,
+    "  </channel>",
+    "</rss>",
+    "",
+  ]
+    .filter((line) => line.length > 0)
+    .join("\n")
+}

--- a/front/src/pages/feed.tsx
+++ b/front/src/pages/feed.tsx
@@ -1,0 +1,35 @@
+import type { GetServerSideProps, GetServerSidePropsContext } from "next"
+import { CONFIG } from "site.config"
+import { getFeedPostsPage } from "src/apis/backend/posts"
+import {
+  buildRssFeedXml,
+  collectRssFeedPosts,
+  RSS_FEED_CONTENT_TYPE,
+  type RssFeedPostPageLoader,
+} from "src/libs/rssFeed"
+
+export const createFeedServerSideProps =
+  (loadPage: RssFeedPostPageLoader = getFeedPostsPage): GetServerSideProps =>
+  async ({ res }: GetServerSidePropsContext) => {
+    const posts = await collectRssFeedPosts(loadPage)
+    const rssXml = buildRssFeedXml(posts, {
+      siteUrl: CONFIG.link,
+      title: CONFIG.blog.title,
+      description: CONFIG.blog.description,
+      lang: CONFIG.lang,
+    })
+
+    res.statusCode = 200
+    res.setHeader("Content-Type", RSS_FEED_CONTENT_TYPE)
+    res.setHeader("Cache-Control", "public, s-maxage=600, stale-while-revalidate=3600")
+    res.write(rssXml)
+    res.end()
+
+    return { props: {} }
+  }
+
+export const getServerSideProps = createFeedServerSideProps()
+
+const FeedPage = () => null
+
+export default FeedPage


### PR DESCRIPTION
## 관련 이슈

close #950

## 작업 배경

- `_document`는 `/feed` RSS discovery link를 노출하지만 실제 `/feed` route와 RSS response contract가 없었다.
- 출시 전 RSS reader와 검색엔진 discovery가 깨져도 자동으로 감지하기 어려웠다.

## 작업 내용

- `/feed` RSS route를 추가해 `application/rss+xml; charset=utf-8` XML 응답을 반환한다.
- RSS feed 수집 helper를 추가해 공개 글만 포함하고 `Private`, `PublicOnDetail` 글을 제외한다.
- RSS item URL은 `CONFIG.link + /posts/{id}` canonical URL로 생성하고, `modifiedTime`/`createdTime` 기준 최신순으로 정렬한다.
- `front/e2e/rss-feed.spec.ts`에서 공개/비공개 fixture 포함/제외, 정렬, XML 구조, route header/body contract를 검증한다.
- `front/e2e/live.spec.ts`에 `/feed` live smoke를 추가해 배포본 status/content-type/XML validity를 확인한다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`: PASS
  - `yarn --cwd front playwright test e2e/rss-feed.spec.ts --workers=1`: RED 확인, `/feed` route 부재로 `Cannot find module '../src/pages/feed'`
  - `yarn --cwd front playwright test e2e/rss-feed.spec.ts --workers=1`: PASS, 3 tests
  - `yarn --cwd front build`: PASS, `/feed` dynamic route 생성 확인
  - `yarn --cwd front playwright test e2e/rss-feed.spec.ts --workers=1`: PASS, 3 tests
  - `git diff --check`: PASS
  - `CURRENT_TASK_SLUG=issue-950-rss-feed-contract bash tools/guards/current-task-preflight.sh`: PASS
  - PR CI: Backend CI `27898329312` PASS, Frontend CI `27898329314` PASS, Security `27898329315` PASS
  - CodeRabbit: status check SUCCESS이나 GitHub review/review thread 없음 확인
  - Codex CLI fallback review: PR review `4539396324`, actionable 0건
  - main CI: `27898515508` PASS
  - main Security: `27898515524` PASS
  - Deploy to Home Server: `27898683512` PASS, Frontend Live E2E Verification PASS (`buildAndPush`, `blueGreenDeploy`는 frontend-only 변경으로 skip)
  - `curl -fsSI https://www.aquilaxk.site/feed`: PASS, `HTTP/2 200`, `content-type: application/rss+xml; charset=utf-8`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `/feed`는 browser page가 아니라 서버 응답 route라 `createFeedServerSideProps` factory를 노출해 response header/body contract를 테스트한다.
  - 배포 전 live URL에는 아직 새 `/feed` route가 없으므로 live smoke는 merge 후 CD의 Frontend Live E2E Verification에서 최종 확인한다.

## 리스크

- feed endpoint가 backend feed page API에 의존하므로 backend feed 장애 시 `/feed`도 실패한다.
- RSS XML escaping은 helper에서 처리하지만, 향후 item에 HTML content를 넣으면 별도 CDATA/encoding 정책이 필요하다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. (status SUCCESS, 실제 review/thread 없음)
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
