### PR TITLE
[Fix] 에디터 conflict와 offline 장애 UX 복구

### DIFF
--- a/front/e2e/editor-failure-ux.spec.ts
+++ b/front/e2e/editor-failure-ux.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test"
+import { ApiError, ApiTimeoutError } from "src/apis/backend/client"
+import {
+  resolveEditorFailureRecovery,
+  resolveEditorUploadFailureRecovery,
+} from "src/routes/Admin/editorFailureRecoveryModel"
+
+test.describe("editor failure recovery UX model", () => {
+  test("409 저장 충돌은 현재 draft 보호와 서버 최신본 확인을 안내한다", () => {
+    const recovery = resolveEditorFailureRecovery(new ApiError(409, "/post/api/v1/posts/7", ""), {
+      action: "modify",
+      isOnline: true,
+    })
+
+    expect(recovery.statusText).toContain("수정 실패")
+    expect(recovery.statusText).toContain("서버 최신본")
+    expect(recovery.statusText).toContain("작성 내용은 유지됩니다")
+    expect(recovery.result).toMatchObject({
+      errorType: "version-conflict",
+      draftProtected: true,
+      canRetry: true,
+    })
+    expect(recovery.result.nextActions).toEqual(
+      expect.arrayContaining([
+        "현재 내용을 로컬 임시저장으로 보존",
+        "서버 최신본을 다시 불러와 차이를 비교",
+        "필요한 내용을 수동 병합한 뒤 다시 저장",
+      ]),
+    )
+  })
+
+  test("offline과 timeout은 작성 내용 보존과 재시도를 명확히 안내한다", () => {
+    const offline = resolveEditorFailureRecovery(new TypeError("Failed to fetch"), {
+      action: "write",
+      isOnline: false,
+    })
+    const timeout = resolveEditorFailureRecovery(new ApiTimeoutError("/post/api/v1/posts", 10_000), {
+      action: "publish-temp",
+      isOnline: true,
+    })
+
+    expect(offline.statusText).toContain("오프라인")
+    expect(offline.statusText).toContain("작성 내용은 유지됩니다")
+    expect(offline.result).toMatchObject({ errorType: "offline", draftProtected: true, canRetry: true })
+
+    expect(timeout.statusText).toContain("응답이 지연")
+    expect(timeout.statusText).toContain("작성 내용은 유지됩니다")
+    expect(timeout.result).toMatchObject({ errorType: "timeout", draftProtected: true, canRetry: true })
+  })
+
+  test("401 413 429 500은 사용자가 다음 행동을 판단할 수 있는 상태로 분류된다", () => {
+    const session = resolveEditorFailureRecovery(new ApiError(401, "/post/api/v1/posts", ""), {
+      action: "write",
+      isOnline: true,
+    })
+    const tooLarge = resolveEditorFailureRecovery(new ApiError(413, "/post/api/v1/posts/files", ""), {
+      action: "write",
+      isOnline: true,
+    })
+    const rateLimited = resolveEditorFailureRecovery(new ApiError(429, "/post/api/v1/posts", ""), {
+      action: "modify",
+      isOnline: true,
+    })
+    const server = resolveEditorFailureRecovery(new ApiError(500, "/post/api/v1/posts", ""), {
+      action: "publish-temp",
+      isOnline: true,
+    })
+
+    expect(session.statusText).toContain("로그인")
+    expect(session.result.nextActions).toContain("새 탭에서 다시 로그인한 뒤 이 탭으로 돌아와 저장")
+    expect(tooLarge.statusText).toContain("용량")
+    expect(rateLimited.statusText).toContain("잠시 후")
+    expect(server.statusText).toContain("서버 오류")
+
+    for (const recovery of [session, tooLarge, rateLimited, server]) {
+      expect(recovery.statusText).toContain("작성 내용은 유지됩니다")
+      expect(recovery.result.draftProtected).toBe(true)
+    }
+  })
+
+  test("업로드 실패는 파일명과 파일별 실패 상태, 재시도 경로를 포함한다", () => {
+    const recovery = resolveEditorUploadFailureRecovery(new ApiError(413, "/post/api/v1/posts/images", ""), {
+      kind: "image",
+      fileName: "diagram.png",
+      isOnline: true,
+    })
+
+    expect(recovery.statusText).toContain("diagram.png")
+    expect(recovery.statusText).toContain("이미지 업로드 실패")
+    expect(recovery.statusText).toContain("파일별 실패 상태")
+    expect(recovery.statusText).toContain("다시 시도")
+    expect(recovery.result).toMatchObject({
+      errorType: "too-large",
+      fileName: "diagram.png",
+      draftProtected: true,
+      canRetry: true,
+    })
+  })
+})

--- a/front/e2e/editor-failure-ux.spec.ts
+++ b/front/e2e/editor-failure-ux.spec.ts
@@ -96,4 +96,29 @@ test.describe("editor failure recovery UX model", () => {
       canRetry: true,
     })
   })
+
+  test("plain Error 업로드 실패도 HTTP status와 원본 메시지를 보존한다", () => {
+    const tooLarge = resolveEditorUploadFailureRecovery(
+      new Error("이미지 업로드 실패 (413): 업로드 가능한 파일 용량을 초과했습니다."),
+      {
+        kind: "image",
+        fileName: "huge.png",
+        isOnline: true,
+      },
+    )
+    const validation = resolveEditorUploadFailureRecovery(new Error("지원하지 않는 이미지 형식입니다."), {
+      kind: "thumbnail",
+      fileName: "broken.bmp",
+      isOnline: true,
+    })
+
+    expect(tooLarge.result.errorType).toBe("too-large")
+    expect(tooLarge.statusText).toContain("용량")
+    expect(tooLarge.statusText).toContain("업로드 가능한 파일 용량을 초과했습니다")
+
+    expect(validation.result.errorType).toBe("unknown")
+    expect(validation.result.message).toBe("지원하지 않는 이미지 형식입니다.")
+    expect(validation.statusText).toContain("broken.bmp")
+    expect(validation.statusText).toContain("지원하지 않는 이미지 형식입니다.")
+  })
 })

--- a/front/src/routes/Admin/editorFailureRecoveryModel.ts
+++ b/front/src/routes/Admin/editorFailureRecoveryModel.ts
@@ -1,0 +1,170 @@
+import { ApiError, ApiTimeoutError } from "src/apis/backend/client"
+
+export type EditorFailureAction = "write" | "modify" | "publish-temp"
+export type EditorUploadFailureKind = "image" | "file" | "thumbnail"
+export type EditorFailureType =
+  | "version-conflict"
+  | "offline"
+  | "timeout"
+  | "session-expired"
+  | "too-large"
+  | "rate-limited"
+  | "server-error"
+  | "unknown"
+
+export type EditorFailureRecovery = {
+  statusText: string
+  result: {
+    errorType: EditorFailureType
+    message: string
+    draftProtected: true
+    canRetry: boolean
+    nextActions: string[]
+    status?: number
+    fileName?: string
+  }
+}
+
+type ResolveEditorFailureRecoveryParams = {
+  action: EditorFailureAction
+  isOnline?: boolean
+}
+
+type ResolveEditorUploadFailureRecoveryParams = {
+  kind: EditorUploadFailureKind
+  fileName: string
+  isOnline?: boolean
+}
+
+const actionLabels: Record<EditorFailureAction, string> = {
+  write: "작성",
+  modify: "수정",
+  "publish-temp": "새 글 작성",
+}
+
+const uploadLabels: Record<EditorUploadFailureKind, string> = {
+  image: "이미지",
+  file: "첨부 파일",
+  thumbnail: "썸네일",
+}
+
+const preserveDraftAction = "현재 내용을 로컬 임시저장으로 보존"
+const retryAction = "네트워크와 상태를 확인한 뒤 다시 시도"
+
+const isBrowserOffline = (isOnline: boolean | undefined) => isOnline === false
+
+const isFetchTransportError = (error: unknown) =>
+  error instanceof TypeError &&
+  /failed to fetch|networkerror|load failed|fetch/i.test(error.message)
+
+const getStatus = (error: unknown) => error instanceof ApiError ? error.status : undefined
+
+const classifyEditorFailure = (
+  error: unknown,
+  isOnline: boolean | undefined,
+): { type: EditorFailureType; status?: number } => {
+  if (isBrowserOffline(isOnline) || isFetchTransportError(error)) return { type: "offline" }
+  if (error instanceof ApiTimeoutError) return { type: "timeout" }
+
+  const status = getStatus(error)
+  if (status === 409) return { type: "version-conflict", status }
+  if (status === 401) return { type: "session-expired", status }
+  if (status === 413) return { type: "too-large", status }
+  if (status === 429) return { type: "rate-limited", status }
+  if (typeof status === "number" && status >= 500) return { type: "server-error", status }
+
+  return { type: "unknown", status }
+}
+
+const buildMessage = (type: EditorFailureType) => {
+  switch (type) {
+    case "version-conflict":
+      return "서버 최신본과 충돌했습니다. 작성 내용은 유지됩니다."
+    case "offline":
+      return "오프라인 상태라 서버에 연결하지 못했습니다. 작성 내용은 유지됩니다."
+    case "timeout":
+      return "응답이 지연되고 있습니다. 작성 내용은 유지됩니다."
+    case "session-expired":
+      return "로그인 세션이 만료되었습니다. 작성 내용은 유지됩니다."
+    case "too-large":
+      return "요청 또는 업로드 용량이 너무 큽니다. 작성 내용은 유지됩니다."
+    case "rate-limited":
+      return "요청이 많아 제한되었습니다. 잠시 후 다시 시도해주세요. 작성 내용은 유지됩니다."
+    case "server-error":
+      return "서버 오류로 요청을 완료하지 못했습니다. 작성 내용은 유지됩니다."
+    case "unknown":
+      return "요청을 완료하지 못했습니다. 작성 내용은 유지됩니다."
+  }
+}
+
+const buildNextActions = (type: EditorFailureType) => {
+  switch (type) {
+    case "version-conflict":
+      return [
+        preserveDraftAction,
+        "서버 최신본을 다시 불러와 차이를 비교",
+        "필요한 내용을 수동 병합한 뒤 다시 저장",
+      ]
+    case "session-expired":
+      return [preserveDraftAction, "새 탭에서 다시 로그인한 뒤 이 탭으로 돌아와 저장"]
+    case "too-large":
+      return [preserveDraftAction, "이미지와 첨부 파일 용량을 줄인 뒤 다시 시도"]
+    case "rate-limited":
+      return [preserveDraftAction, "잠시 후 같은 버튼으로 다시 시도"]
+    case "server-error":
+      return [preserveDraftAction, retryAction]
+    case "offline":
+      return [preserveDraftAction, "연결이 복구되면 같은 버튼으로 다시 시도"]
+    case "timeout":
+      return [preserveDraftAction, "중복 저장 여부를 확인한 뒤 같은 버튼으로 다시 시도"]
+    case "unknown":
+      return [preserveDraftAction, retryAction]
+  }
+}
+
+const canRetryFailure = (type: EditorFailureType) => type !== "unknown"
+
+export const resolveEditorFailureRecovery = (
+  error: unknown,
+  { action, isOnline }: ResolveEditorFailureRecoveryParams,
+): EditorFailureRecovery => {
+  const { type, status } = classifyEditorFailure(error, isOnline)
+  const actionLabel = actionLabels[action]
+  const message = buildMessage(type)
+  const nextActions = buildNextActions(type)
+
+  return {
+    statusText: `${actionLabel} 실패: ${message} ${nextActions.join(" · ")}`,
+    result: {
+      errorType: type,
+      message,
+      draftProtected: true,
+      canRetry: canRetryFailure(type),
+      nextActions,
+      ...(typeof status === "number" ? { status } : {}),
+    },
+  }
+}
+
+export const resolveEditorUploadFailureRecovery = (
+  error: unknown,
+  { kind, fileName, isOnline }: ResolveEditorUploadFailureRecoveryParams,
+): EditorFailureRecovery => {
+  const { type, status } = classifyEditorFailure(error, isOnline)
+  const uploadLabel = uploadLabels[kind]
+  const message = buildMessage(type)
+  const nextActions = buildNextActions(type)
+
+  return {
+    statusText: `${uploadLabel} 업로드 실패: "${fileName}" 파일별 실패 상태입니다. ${message} ${nextActions.join(" · ")} 다시 시도할 수 있습니다.`,
+    result: {
+      errorType: type,
+      message,
+      draftProtected: true,
+      canRetry: canRetryFailure(type),
+      nextActions,
+      fileName,
+      ...(typeof status === "number" ? { status } : {}),
+    },
+  }
+}

--- a/front/src/routes/Admin/editorFailureRecoveryModel.ts
+++ b/front/src/routes/Admin/editorFailureRecoveryModel.ts
@@ -57,7 +57,21 @@ const isFetchTransportError = (error: unknown) =>
   error instanceof TypeError &&
   /failed to fetch|networkerror|load failed|fetch/i.test(error.message)
 
-const getStatus = (error: unknown) => error instanceof ApiError ? error.status : undefined
+const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error) return error.message.trim()
+  return String(error || "").trim()
+}
+
+const getStatusFromMessage = (message: string) => {
+  const statusMatch = message.match(/(?:^|[^\d])([45]\d{2})(?:[^\d]|$)/)
+  if (!statusMatch) return undefined
+  return Number(statusMatch[1])
+}
+
+const getStatus = (error: unknown) => {
+  if (error instanceof ApiError) return error.status
+  return getStatusFromMessage(getErrorMessage(error))
+}
 
 const classifyEditorFailure = (
   error: unknown,
@@ -76,7 +90,12 @@ const classifyEditorFailure = (
   return { type: "unknown", status }
 }
 
-const buildMessage = (type: EditorFailureType) => {
+const appendOriginalMessage = (message: string, originalMessage: string) => {
+  if (!originalMessage || message.includes(originalMessage)) return message
+  return `${message} ${originalMessage}`
+}
+
+const buildMessage = (type: EditorFailureType, originalMessage: string) => {
   switch (type) {
     case "version-conflict":
       return "서버 최신본과 충돌했습니다. 작성 내용은 유지됩니다."
@@ -93,9 +112,12 @@ const buildMessage = (type: EditorFailureType) => {
     case "server-error":
       return "서버 오류로 요청을 완료하지 못했습니다. 작성 내용은 유지됩니다."
     case "unknown":
-      return "요청을 완료하지 못했습니다. 작성 내용은 유지됩니다."
+      return originalMessage || "요청을 완료하지 못했습니다. 작성 내용은 유지됩니다."
   }
 }
+
+const buildDetailedMessage = (type: EditorFailureType, originalMessage: string) =>
+  appendOriginalMessage(buildMessage(type, originalMessage), originalMessage)
 
 const buildNextActions = (type: EditorFailureType) => {
   switch (type) {
@@ -130,7 +152,7 @@ export const resolveEditorFailureRecovery = (
 ): EditorFailureRecovery => {
   const { type, status } = classifyEditorFailure(error, isOnline)
   const actionLabel = actionLabels[action]
-  const message = buildMessage(type)
+  const message = buildDetailedMessage(type, getErrorMessage(error))
   const nextActions = buildNextActions(type)
 
   return {
@@ -152,7 +174,7 @@ export const resolveEditorUploadFailureRecovery = (
 ): EditorFailureRecovery => {
   const { type, status } = classifyEditorFailure(error, isOnline)
   const uploadLabel = uploadLabels[kind]
-  const message = buildMessage(type)
+  const message = buildDetailedMessage(type, getErrorMessage(error))
   const nextActions = buildNextActions(type)
 
   return {

--- a/front/src/routes/Admin/useEditorStudioPersistence.ts
+++ b/front/src/routes/Admin/useEditorStudioPersistence.ts
@@ -5,6 +5,7 @@ import {
   type SetStateAction,
 } from "react"
 import { apiFetch } from "src/apis/backend/client"
+import { resolveEditorFailureRecovery } from "./editorFailureRecoveryModel"
 import { isTempDraftTitlePlaceholder } from "./editorTempDraft"
 import { useEditorStudioPersistenceUploads } from "./useEditorStudioPersistenceModel"
 
@@ -38,6 +39,8 @@ type EditorFingerprintPayload = {
   category: string
   visibility: PostVisibility
 }
+
+const isBrowserOnline = () => typeof navigator === "undefined" ? undefined : navigator.onLine
 
 type UseEditorStudioPersistenceParams = {
   editorMode: EditorMode
@@ -276,9 +279,12 @@ export const useEditorStudioPersistence = ({
       setKnownTags((prev) => dedupeStrings([...prev, ...postTags]).sort((a, b) => a.localeCompare(b)))
       return true
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      setResult(pretty({ error: message }))
-      setPublishStatus({ tone: "error", text: `작성 실패: ${message}` })
+      const recovery = resolveEditorFailureRecovery(error, {
+        action: "write",
+        isOnline: isBrowserOnline(),
+      })
+      setResult(pretty(recovery.result))
+      setPublishStatus({ tone: "error", text: recovery.statusText })
       return false
     } finally {
       setLoadingKey("")
@@ -396,9 +402,12 @@ export const useEditorStudioPersistence = ({
       setResult(pretty(response))
       return true
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      setPublishStatus({ tone: "error", text: `수정 실패: ${message}` })
-      setResult(pretty({ error: message }))
+      const recovery = resolveEditorFailureRecovery(error, {
+        action: "modify",
+        isOnline: isBrowserOnline(),
+      })
+      setPublishStatus({ tone: "error", text: recovery.statusText })
+      setResult(pretty(recovery.result))
       return false
     } finally {
       setLoadingKey("")
@@ -508,9 +517,12 @@ export const useEditorStudioPersistence = ({
       setResult(pretty(response))
       return true
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      setPublishStatus({ tone: "error", text: `새 글 작성 실패: ${message}` })
-      setResult(pretty({ error: message }))
+      const recovery = resolveEditorFailureRecovery(error, {
+        action: "publish-temp",
+        isOnline: isBrowserOnline(),
+      })
+      setPublishStatus({ tone: "error", text: recovery.statusText })
+      setResult(pretty(recovery.result))
       return false
     } finally {
       setLoadingKey("")

--- a/front/src/routes/Admin/useEditorStudioPersistenceModel.ts
+++ b/front/src/routes/Admin/useEditorStudioPersistenceModel.ts
@@ -4,10 +4,10 @@ import { getApiBaseUrl } from "src/apis/backend/client"
 import { parseStandaloneMarkdownImageLine } from "src/libs/markdown/rendering"
 import {
   buildImageOptimizationSummary,
-  normalizeProfileImageUploadError,
   preparePostImageForUpload,
 } from "src/libs/profileImageUpload"
 import { stripThumbnailFocusFromUrl } from "src/libs/thumbnailFocus"
+import { resolveEditorUploadFailureRecovery } from "./editorFailureRecoveryModel"
 
 type StudioSetState<T> = Dispatch<SetStateAction<T>>
 type NoticeTone = "idle" | "loading" | "success" | "error"
@@ -33,6 +33,8 @@ type UploadPostFileResponse = {
     name?: string
   }
 }
+
+const isBrowserOnline = () => typeof navigator === "undefined" ? undefined : navigator.onLine
 
 export type MarkdownImageUploadAttrs = {
   src: string
@@ -139,10 +141,14 @@ export const useEditorStudioPersistenceUploads = ({
         align: parsed?.align || "center",
       }
     } catch (error) {
-      const message = normalizeProfileImageUploadError(error)
+      const recovery = resolveEditorUploadFailureRecovery(error, {
+        kind: "image",
+        fileName: file.name,
+        isOnline: isBrowserOnline(),
+      })
       setPublishStatus({
         tone: "error",
-        text: `이미지 업로드 실패: ${message}`,
+        text: recovery.statusText,
       })
       throw error
     }
@@ -188,10 +194,14 @@ export const useEditorStudioPersistenceUploads = ({
         sizeBytes: file.size,
       }
     } catch (error) {
-      const message = normalizeProfileImageUploadError(error)
+      const recovery = resolveEditorUploadFailureRecovery(error, {
+        kind: "file",
+        fileName: file.name,
+        isOnline: isBrowserOnline(),
+      })
       setPublishStatus({
         tone: "error",
-        text: `첨부 파일 업로드 실패: ${message}`,
+        text: recovery.statusText,
       })
       throw error
     }
@@ -221,10 +231,14 @@ export const useEditorStudioPersistenceUploads = ({
         text: `썸네일 파일 업로드가 완료되었습니다. ${uploaded.prepared.summary}`,
       })
     } catch (error) {
-      const message = normalizeProfileImageUploadError(error)
+      const recovery = resolveEditorUploadFailureRecovery(error, {
+        kind: "thumbnail",
+        fileName: file.name,
+        isOnline: isBrowserOnline(),
+      })
       setPublishStatus({
         tone: "error",
-        text: `썸네일 업로드 실패: ${message}`,
+        text: recovery.statusText,
       })
     } finally {
       setLoadingKey("")


### PR DESCRIPTION
## 관련 이슈

close #1014

## 작업 배경

- 출시 전 코드리뷰에서 에디터 작성 중 409 version conflict, offline, slow network, upload disconnect, 401, 413, 429, 500 장애를 작성 내용 손실 없이 복구 가능한 UX로 고정해야 한다는 지적이 있었다.
- 기존 저장/수정/임시글 발행 catch는 원시 `Error.message`만 표시했고, 업로드 catch도 파일별 복구 행동과 draft 보호 상태를 일관되게 설명하지 못했다.

## 작업 내용

- `editorFailureRecoveryModel`을 추가해 `ApiError`, `ApiTimeoutError`, offline/fetch transport error를 `version-conflict`, `offline`, `timeout`, `session-expired`, `too-large`, `rate-limited`, `server-error`로 분류한다.
- 저장, 수정, 임시글 발행 실패 시 현재 작성 내용이 유지됨을 명시하고 서버 최신본 확인, 로그인 복구, 용량 축소, 잠시 후 재시도 같은 다음 행동을 status와 result log에 남기도록 연결했다.
- 이미지, 첨부 파일, 썸네일 업로드 실패 시 파일명과 파일별 실패 상태, 재시도 가능 여부를 status에 포함하도록 보강했다.
- `editor-failure-ux.spec.ts`로 409, offline, timeout, 401, 413, 429, 500, 업로드 파일별 실패 메시지 계약을 고정했다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`: 통과
  - `yarn --cwd front playwright:preflight`: 통과
  - `yarn --cwd front playwright test e2e/editor-failure-ux.spec.ts --workers=1`: 4 passed
  - `yarn --cwd front build`: 통과
  - `node front/scripts/check-bundle-size.mjs`: 통과
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`: 8 passed

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `front/src/routes/Admin/editorFailureRecoveryModel.ts`의 상태 분류와 next action 문구
  - `useEditorStudioPersistence.ts`의 저장/수정/임시글 발행 catch 연결
  - `useEditorStudioPersistenceModel.ts`의 이미지/파일/썸네일 업로드 실패 연결

## 리스크

- 상태 메시지 문구가 기존보다 길어졌다. 기존 상태 영역은 wrapping되는 strong 텍스트로 표시되며, 과도한 상세 정보는 result log에도 구조화해서 남긴다.
- 실제 네트워크 장애 UI 조작 E2E가 아니라 recovery model 계약 테스트로 고정했다. hook 연결은 같은 모델을 직접 호출하는 방식으로 검증 범위를 좁혔다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
