### PR TITLE
[Feat] 게시글 상세 구조화 데이터와 소셜 메타 보강

### DIFF
--- a/front/e2e/post-detail-structured-metadata.spec.ts
+++ b/front/e2e/post-detail-structured-metadata.spec.ts
@@ -1,0 +1,180 @@
+import { expect, type Page, test } from "@playwright/test"
+
+type PostFixture = {
+  id: number
+  title: string
+  summary: string
+  createdAt: string
+  modifiedAt: string
+}
+
+const fixtures: PostFixture[] = [
+  {
+    id: 1313,
+    title: "구조화 데이터 첫 번째 글",
+    summary: "첫 번째 글 요약입니다.",
+    createdAt: "2026-06-01T01:02:03Z",
+    modifiedAt: "2026-06-05T04:05:06Z",
+  },
+  {
+    id: 1314,
+    title: "구조화 데이터 두 번째 글",
+    summary: "두 번째 글 요약입니다.",
+    createdAt: "2026-06-10T07:08:09Z",
+    modifiedAt: "2026-06-11T10:11:12Z",
+  },
+]
+
+const mockPost = async (page: Page, fixture: PostFixture) => {
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({ resultCode: "401-1", msg: "unauthorized" }),
+    })
+  })
+  await page.route(`**/post/api/v1/posts/${fixture.id}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: fixture.id,
+        createdAt: fixture.createdAt,
+        modifiedAt: fixture.modifiedAt,
+        authorId: 1,
+        authorName: "관리자",
+        authorUsername: "aquila",
+        authorProfileImageDirectUrl: "/avatar.png",
+        title: fixture.title,
+        content: fixture.summary,
+        type: "Post",
+        tags: ["SEO"],
+        category: ["메타데이터"],
+        published: true,
+        listed: true,
+        likesCount: 0,
+        commentsCount: 0,
+        hitCount: 0,
+        actorHasLiked: false,
+        actorCanModify: false,
+        actorCanDelete: false,
+      }),
+    })
+  })
+  await page.route(`**/post/api/v1/posts/${fixture.id}/hit`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "200-1",
+        msg: "ok",
+        data: { hitCount: 1 },
+      }),
+    })
+  })
+}
+
+const toExpectedIso = (value: string) => new Date(value).toISOString()
+
+const toExpectedFallbackImage = (title: string) =>
+  `https://og-image-korean.vercel.app/${encodeURIComponent(title)}.png`
+
+const readStructuredData = async (page: Page) => {
+  return await page
+    .locator('script[type="application/ld+json"]')
+    .evaluateAll((nodes) =>
+      nodes
+        .map((node) => {
+          try {
+            return JSON.parse(node.textContent || "{}")
+          } catch {
+            return null
+          }
+        })
+        .filter(Boolean)
+    )
+}
+
+test.describe("post detail structured metadata", () => {
+  for (const fixture of fixtures) {
+    test(`${fixture.title} head metadata는 canonical post와 같은 DTO 값을 사용한다`, async ({
+      page,
+    }) => {
+      await mockPost(page, fixture)
+
+      await page.goto(`/posts/${fixture.id}`)
+      await expect(
+        page.getByRole("heading", { name: fixture.title })
+      ).toBeVisible()
+
+      const canonicalUrl = `https://www.aquilaxk.site/posts/${fixture.id}`
+      const expectedCreatedAt = toExpectedIso(fixture.createdAt)
+      const expectedModifiedAt = toExpectedIso(fixture.modifiedAt)
+      const expectedImage = toExpectedFallbackImage(fixture.title)
+      await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+        "href",
+        canonicalUrl
+      )
+      await expect(
+        page.locator('meta[property="og:site_name"]')
+      ).toHaveAttribute("content", "AquilaLog")
+      await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
+        "content",
+        expectedImage
+      )
+      await expect(
+        page.locator('meta[property="article:published_time"]')
+      ).toHaveAttribute("content", expectedCreatedAt)
+      await expect(
+        page.locator('meta[property="article:modified_time"]')
+      ).toHaveAttribute("content", expectedModifiedAt)
+
+      const structuredData = await readStructuredData(page)
+      const blogPosting = structuredData.find(
+        (entry) => entry["@type"] === "BlogPosting"
+      )
+      const breadcrumb = structuredData.find(
+        (entry) => entry["@type"] === "BreadcrumbList"
+      )
+
+      expect(blogPosting).toMatchObject({
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        headline: fixture.title,
+        description: fixture.summary,
+        url: canonicalUrl,
+        mainEntityOfPage: canonicalUrl,
+        datePublished: expectedCreatedAt,
+        dateModified: expectedModifiedAt,
+        image: [expectedImage],
+      })
+      expect(blogPosting.author).toMatchObject({
+        "@type": "Person",
+        name: "관리자",
+      })
+      expect(blogPosting.publisher).toMatchObject({
+        "@type": "Organization",
+        name: "AquilaLog",
+      })
+
+      expect(breadcrumb).toMatchObject({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+      })
+      expect(breadcrumb.itemListElement).toEqual([
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "홈",
+          item: "https://www.aquilaxk.site",
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: fixture.title,
+          item: canonicalUrl,
+        },
+      ])
+    })
+  }
+})

--- a/front/src/components/MetaConfig/index.tsx
+++ b/front/src/components/MetaConfig/index.tsx
@@ -6,10 +6,12 @@ export type MetaConfigProps = {
   description: string
   type: "Website" | "Post" | "Page" | string
   date?: string
+  modifiedDate?: string
   image?: string
   url: string
   robots?: string
   canonicalUrl?: string | null
+  jsonLd?: Array<Record<string, unknown>>
 }
 
 const SITE_TITLE = CONFIG.blog.title || "AquilaLog"
@@ -19,17 +21,24 @@ const resolveBrowserTabTitle = (title: string) => {
   if (!pageTitle || pageTitle === SITE_TITLE) {
     return SITE_TITLE
   }
-  if (pageTitle.endsWith(` | ${SITE_TITLE}`) || pageTitle.endsWith(` - ${SITE_TITLE}`)) {
+  if (
+    pageTitle.endsWith(` | ${SITE_TITLE}`) ||
+    pageTitle.endsWith(` - ${SITE_TITLE}`)
+  ) {
     return pageTitle
   }
 
   return `${pageTitle} | ${SITE_TITLE}`
 }
 
+const serializeJsonLd = (value: Record<string, unknown>) =>
+  JSON.stringify(value).replace(/</g, "\\u003c")
+
 const MetaConfig: React.FC<MetaConfigProps> = (props) => {
   const browserTabTitle = resolveBrowserTabTitle(props.title)
   const robots = props.robots || "follow, index"
-  const canonicalUrl = props.canonicalUrl === undefined ? props.url : props.canonicalUrl
+  const canonicalUrl =
+    props.canonicalUrl === undefined ? props.url : props.canonicalUrl
 
   return (
     <Head>
@@ -43,6 +52,7 @@ const MetaConfig: React.FC<MetaConfigProps> = (props) => {
       <meta property="og:title" content={props.title} />
       <meta property="og:description" content={props.description} />
       <meta property="og:url" content={props.url} />
+      <meta property="og:site_name" content={SITE_TITLE} />
       {CONFIG.lang && <meta property="og:locale" content={CONFIG.lang} />}
       {props.image && <meta property="og:image" content={props.image} />}
       {/* twitter */}
@@ -53,10 +63,25 @@ const MetaConfig: React.FC<MetaConfigProps> = (props) => {
       {/* post */}
       {props.type === "Post" && (
         <>
-          <meta property="article:published_time" content={props.date} />
+          {props.date && (
+            <meta property="article:published_time" content={props.date} />
+          )}
+          {props.modifiedDate && (
+            <meta
+              property="article:modified_time"
+              content={props.modifiedDate}
+            />
+          )}
           <meta property="article:author" content={CONFIG.profile.name} />
         </>
       )}
+      {props.jsonLd?.map((entry, index) => (
+        <script
+          key={`json-ld-${index}`}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(entry) }}
+        />
+      ))}
     </Head>
   )
 }

--- a/front/src/pages/posts/[id].tsx
+++ b/front/src/pages/posts/[id].tsx
@@ -1,4 +1,3 @@
-import { CONFIG } from "site.config"
 import { GetStaticPaths, GetStaticProps } from "next"
 import { NextPageWithLayout } from "../../types"
 import styled from "@emotion/styled"
@@ -12,7 +11,7 @@ import {
   buildCanonicalPostDetailStaticPaths,
   buildCanonicalPostDetailStaticProps,
 } from "src/libs/server/postDetailPage"
-import { toCanonicalPostPath } from "src/libs/utils/postPath"
+import { buildPostDetailMetadata } from "src/routes/Detail/PostDetail/postDetailMetadataModel"
 
 export const getStaticPaths: GetStaticPaths = async () => {
   return await buildCanonicalPostDetailStaticPaths()
@@ -29,7 +28,9 @@ type DetailPageProps = {
   initialAdminProfileSource: "published" | "static-fallback"
 }
 
-const CanonicalPostPage: NextPageWithLayout<DetailPageProps> = ({ initialComments }) => {
+const CanonicalPostPage: NextPageWithLayout<DetailPageProps> = ({
+  initialComments,
+}) => {
   const { post, isLoading, isNotFound } = usePostQuery()
   if (isLoading) {
     return (
@@ -69,19 +70,7 @@ const CanonicalPostPage: NextPageWithLayout<DetailPageProps> = ({ initialComment
   }
   if (isNotFound || !post) return <CustomError />
 
-  const date = post.createdTime || post.date?.start_date || ""
-  const publishedDate = new Date(date)
-  const publishedDateIso = Number.isNaN(publishedDate.getTime()) ? undefined : publishedDate.toISOString()
-  const canonicalPath = toCanonicalPostPath(post.id)
-
-  const meta = {
-    title: post.title,
-    date: publishedDateIso,
-    image: post.thumbnail ?? `${CONFIG.ogImageGenerateURL}/${encodeURIComponent(post.title)}.png`,
-    description: post.summary || "",
-    type: Array.isArray(post.type) ? post.type[0] : post.type,
-    url: `${CONFIG.link}${canonicalPath}`,
-  }
+  const meta = buildPostDetailMetadata(post)
 
   return (
     <>

--- a/front/src/routes/Detail/PostDetail/postDetailMetadataModel.ts
+++ b/front/src/routes/Detail/PostDetail/postDetailMetadataModel.ts
@@ -1,0 +1,107 @@
+import { CONFIG } from "site.config"
+import type { MetaConfigProps } from "src/components/MetaConfig"
+import type { TPost } from "src/types"
+import { toCanonicalPostPath } from "src/libs/utils/postPath"
+
+type JsonLdObject = Record<string, unknown>
+
+const SITE_TITLE = CONFIG.blog.title || "AquilaLog"
+const SITE_URL = CONFIG.link.replace(/\/+$/, "")
+
+const toIsoDate = (value: string | undefined) => {
+  if (!value) return undefined
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString()
+}
+
+const normalizePostImage = (post: TPost) =>
+  post.thumbnail?.trim() ||
+  `${CONFIG.ogImageGenerateURL}/${encodeURIComponent(post.title)}.png`
+
+const normalizeAuthorName = (post: TPost) =>
+  post.author?.find((author) => author.name.trim().length > 0)?.name.trim() ||
+  CONFIG.profile.name
+
+const buildBlogPostingJsonLd = ({
+  post,
+  canonicalUrl,
+  publishedDate,
+  modifiedDate,
+  image,
+}: {
+  post: TPost
+  canonicalUrl: string
+  publishedDate?: string
+  modifiedDate?: string
+  image: string
+}): JsonLdObject => ({
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  headline: post.title,
+  description: post.summary || "",
+  url: canonicalUrl,
+  mainEntityOfPage: canonicalUrl,
+  ...(publishedDate ? { datePublished: publishedDate } : {}),
+  ...(modifiedDate ? { dateModified: modifiedDate } : {}),
+  ...(image ? { image: [image] } : {}),
+  author: {
+    "@type": "Person",
+    name: normalizeAuthorName(post),
+  },
+  publisher: {
+    "@type": "Organization",
+    name: SITE_TITLE,
+  },
+})
+
+const buildBreadcrumbJsonLd = (
+  post: TPost,
+  canonicalUrl: string
+): JsonLdObject => ({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "홈",
+      item: SITE_URL,
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: post.title,
+      item: canonicalUrl,
+    },
+  ],
+})
+
+export const buildPostDetailMetadata = (post: TPost): MetaConfigProps => {
+  const canonicalPath = toCanonicalPostPath(post.id)
+  const canonicalUrl = `${SITE_URL}${canonicalPath}`
+  const publishedDate = toIsoDate(post.createdTime || post.date?.start_date)
+  const modifiedDate = toIsoDate(
+    post.modifiedTime || post.createdTime || post.date?.start_date
+  )
+  const image = normalizePostImage(post)
+
+  return {
+    title: post.title,
+    date: publishedDate,
+    modifiedDate,
+    image,
+    description: post.summary || "",
+    type: Array.isArray(post.type) ? post.type[0] : post.type,
+    url: canonicalUrl,
+    jsonLd: [
+      buildBlogPostingJsonLd({
+        post,
+        canonicalUrl,
+        publishedDate,
+        modifiedDate,
+        image,
+      }),
+      buildBreadcrumbJsonLd(post, canonicalUrl),
+    ],
+  }
+}


### PR DESCRIPTION
## 관련 이슈

close #1013

## 작업 배경

- 게시글 상세 페이지가 브라우저 title과 canonical은 보강되어 있었지만 `og:site_name`, `article:modified_time`, BlogPosting JSON-LD, BreadcrumbList JSON-LD 계약은 없었다.
- 검색엔진과 소셜 미리보기에서 같은 게시글의 canonical URL, 발행일, 수정일, 대표 이미지, 작성자 정보가 서로 다른 값을 가리키지 않도록 테스트로 고정한다.

## 작업 내용

- `MetaConfig`에 `og:site_name`, `article:modified_time`, JSON-LD script 렌더링 props를 추가했다.
- 게시글 상세 전용 metadata model을 분리해 canonical URL, 발행/수정 ISO timestamp, fallback OG image, BlogPosting JSON-LD, BreadcrumbList JSON-LD를 한 곳에서 생성한다.
- 게시글 상세 페이지가 직접 meta object를 조립하지 않고 전용 metadata model을 사용하도록 변경했다.
- fixture 게시글 2개로 rendered head metadata와 JSON-LD가 각 게시글 canonical 값을 유지하는 Playwright 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight` 통과
  - `yarn --cwd front playwright test e2e/post-detail-structured-metadata.spec.ts --workers=1` 2 passed
  - `yarn --cwd front build` 통과
  - `yarn --cwd front check:bundle-size` `/posts/[id]` 포함 전부 OK
  - `yarn --cwd front playwright test e2e/smoke-detail-layout.spec.ts e2e/smoke.spec.ts --workers=1` 13 passed
  - commit hook: `yarn build`, `node scripts/check-bundle-size.mjs`, `yarn test:e2e:smoke` 통과, smoke 65 passed

## 리뷰어 메모

- 먼저 볼 지점은 `front/src/routes/Detail/PostDetail/postDetailMetadataModel.ts`의 JSON-LD 생성 정책과 `front/e2e/post-detail-structured-metadata.spec.ts`의 rendered head 검증이다.
- 현재 public detail API는 thumbnail을 별도 DTO 필드로 내려주지 않으므로 대표 이미지는 기존 OG image generator fallback을 사용한다.

## 리스크

- JSON-LD script는 `JSON.stringify` 뒤 `<`를 `\u003c`로 escape해 head에 삽입한다.
- Twitter 계정 정책은 아직 확정되지 않았으므로 `twitter:site`와 `twitter:creator`는 추가하지 않았다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (해당 없음: CodeRabbit 완료)
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다. (merge 후 확인)
