### PR TITLE
[Feat] 이메일 회원가입 법적 동의 증빙 저장

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/adapter/persistence/MemberLegalAcceptanceRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/adapter/persistence/MemberLegalAcceptanceRepository.kt
@@ -1,0 +1,11 @@
+package com.back.boundedContexts.member.subContexts.legalAcceptance.adapter.persistence
+
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.output.MemberLegalAcceptanceRepositoryPort
+import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberLegalAcceptance
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberLegalAcceptanceRepository :
+    JpaRepository<MemberLegalAcceptance, Long>,
+    MemberLegalAcceptanceRepositoryPort {
+    fun findTopByMemberIdOrderByAcceptedAtDesc(memberId: Long): MemberLegalAcceptance?
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/port/output/MemberLegalAcceptanceRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/port/output/MemberLegalAcceptanceRepositoryPort.kt
@@ -1,0 +1,7 @@
+package com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.output
+
+import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberLegalAcceptance
+
+interface MemberLegalAcceptanceRepositoryPort {
+    fun save(memberLegalAcceptance: MemberLegalAcceptance): MemberLegalAcceptance
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/ActiveLegalDocumentMetadata.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/ActiveLegalDocumentMetadata.kt
@@ -6,12 +6,14 @@ data class LegalDocumentMetadata(
 )
 
 data class ActiveLegalDocumentMetadata(
+    val signupPolicyVersion: String,
     val terms: LegalDocumentMetadata,
     val privacy: LegalDocumentMetadata,
 ) {
     companion object {
         fun current(): ActiveLegalDocumentMetadata =
             ActiveLegalDocumentMetadata(
+                signupPolicyVersion = "2026-06-21",
                 terms =
                     LegalDocumentMetadata(
                         version = "2026-06-21",

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/ActiveLegalDocumentMetadata.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/ActiveLegalDocumentMetadata.kt
@@ -1,0 +1,27 @@
+package com.back.boundedContexts.member.subContexts.legalAcceptance.application.service
+
+data class LegalDocumentMetadata(
+    val version: String,
+    val contentSha256: String,
+)
+
+data class ActiveLegalDocumentMetadata(
+    val terms: LegalDocumentMetadata,
+    val privacy: LegalDocumentMetadata,
+) {
+    companion object {
+        fun current(): ActiveLegalDocumentMetadata =
+            ActiveLegalDocumentMetadata(
+                terms =
+                    LegalDocumentMetadata(
+                        version = "2026-06-21",
+                        contentSha256 = "3b71950e518b16b9a24cb4f9873633720ca7a9fce145a7bb9787c48845b56c5b",
+                    ),
+                privacy =
+                    LegalDocumentMetadata(
+                        version = "2026-06-21",
+                        contentSha256 = "4cc6ae3260aaca5f5ff35b235af91679a60760f13dccad9e85c94fda4d1552d9",
+                    ),
+            )
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/LegalAcceptanceApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/LegalAcceptanceApplicationService.kt
@@ -1,0 +1,75 @@
+package com.back.boundedContexts.member.subContexts.legalAcceptance.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.output.MemberLegalAcceptanceRepositoryPort
+import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberLegalAcceptance
+import com.back.global.exception.application.AppException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+data class LegalAcceptanceCommand(
+    val termsVersion: String,
+    val termsContentSha256: String,
+    val privacyVersion: String,
+    val privacyContentSha256: String,
+    val age14OrOlder: Boolean,
+    val requiredPrivacyConfirmed: Boolean,
+    val analyticsConsent: Boolean,
+    val overseasTransferAcknowledged: Boolean,
+)
+
+@Service
+class LegalAcceptanceApplicationService(
+    private val memberLegalAcceptanceRepository: MemberLegalAcceptanceRepositoryPort,
+) {
+    fun currentDocuments(): ActiveLegalDocumentMetadata = ActiveLegalDocumentMetadata.current()
+
+    fun validateEmailSignupAcceptance(command: LegalAcceptanceCommand) {
+        if (!command.age14OrOlder) {
+            throw AppException("400-2", "만 14세 이상인 경우에만 회원가입할 수 있습니다.")
+        }
+        if (!command.requiredPrivacyConfirmed) {
+            throw AppException("400-2", "개인정보 처리 필수 안내를 확인해야 회원가입할 수 있습니다.")
+        }
+        if (!command.overseasTransferAcknowledged) {
+            throw AppException("400-2", "국외 이전 및 외부 처리자 안내를 확인해야 회원가입할 수 있습니다.")
+        }
+
+        val active = currentDocuments()
+        val matchesActiveDocuments =
+            command.termsVersion.trim() == active.terms.version &&
+                command.termsContentSha256.trim().lowercase() == active.terms.contentSha256 &&
+                command.privacyVersion.trim() == active.privacy.version &&
+                command.privacyContentSha256.trim().lowercase() == active.privacy.contentSha256
+
+        if (!matchesActiveDocuments) {
+            throw AppException("409-4", "약관 또는 개인정보처리방침이 변경되었습니다. 최신 내용을 확인하고 다시 동의해주세요.")
+        }
+    }
+
+    @Transactional
+    fun recordEmailSignupAcceptance(
+        member: Member,
+        command: LegalAcceptanceCommand,
+        acceptedAt: Instant,
+    ): MemberLegalAcceptance {
+        validateEmailSignupAcceptance(command)
+
+        return memberLegalAcceptanceRepository.save(
+            MemberLegalAcceptance(
+                member = member,
+                termsVersion = command.termsVersion.trim(),
+                termsContentSha256 = command.termsContentSha256.trim().lowercase(),
+                privacyVersion = command.privacyVersion.trim(),
+                privacyContentSha256 = command.privacyContentSha256.trim().lowercase(),
+                age14OrOlder = command.age14OrOlder,
+                requiredPrivacyConfirmed = command.requiredPrivacyConfirmed,
+                analyticsConsent = command.analyticsConsent,
+                overseasTransferAcknowledged = command.overseasTransferAcknowledged,
+                source = "EMAIL_SIGNUP",
+                acceptedAt = acceptedAt,
+            ),
+        )
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/LegalAcceptanceApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/LegalAcceptanceApplicationService.kt
@@ -25,6 +25,18 @@ class LegalAcceptanceApplicationService(
 ) {
     fun currentDocuments(): ActiveLegalDocumentMetadata = ActiveLegalDocumentMetadata.current()
 
+    fun validateStoredSignupPolicyVersion(legalPolicyVersion: String?) {
+        val storedVersion = legalPolicyVersion?.trim().orEmpty()
+        val active = currentDocuments()
+        val matchesActiveDocuments =
+            storedVersion == active.terms.version &&
+                storedVersion == active.privacy.version
+
+        if (!matchesActiveDocuments) {
+            throw AppException("409-4", "약관 또는 개인정보처리방침이 변경되었습니다. 최신 내용을 확인하고 다시 동의해주세요.")
+        }
+    }
+
     fun validateEmailSignupAcceptance(command: LegalAcceptanceCommand) {
         if (!command.age14OrOlder) {
             throw AppException("400-2", "만 14세 이상인 경우에만 회원가입할 수 있습니다.")

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/LegalAcceptanceApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/LegalAcceptanceApplicationService.kt
@@ -28,11 +28,8 @@ class LegalAcceptanceApplicationService(
     fun validateStoredSignupPolicyVersion(legalPolicyVersion: String?) {
         val storedVersion = legalPolicyVersion?.trim().orEmpty()
         val active = currentDocuments()
-        val matchesActiveDocuments =
-            storedVersion == active.terms.version &&
-                storedVersion == active.privacy.version
 
-        if (!matchesActiveDocuments) {
+        if (storedVersion != active.signupPolicyVersion) {
             throw AppException("409-4", "약관 또는 개인정보처리방침이 변경되었습니다. 최신 내용을 확인하고 다시 동의해주세요.")
         }
     }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/model/MemberLegalAcceptance.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/model/MemberLegalAcceptance.kt
@@ -1,0 +1,47 @@
+package com.back.boundedContexts.member.subContexts.legalAcceptance.model
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.global.jpa.domain.BaseTime
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.SequenceGenerator
+import java.time.Instant
+
+@Entity
+class MemberLegalAcceptance(
+    @field:Id
+    @field:SequenceGenerator(
+        name = "member_legal_acceptance_seq_gen",
+        sequenceName = "member_legal_acceptance_seq",
+        allocationSize = 20,
+    )
+    @field:GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "member_legal_acceptance_seq_gen")
+    override val id: Long = 0,
+    @field:ManyToOne(fetch = FetchType.LAZY)
+    val member: Member,
+    @field:Column(nullable = false, length = 32)
+    val termsVersion: String,
+    @field:Column(nullable = false, length = 64)
+    val termsContentSha256: String,
+    @field:Column(nullable = false, length = 32)
+    val privacyVersion: String,
+    @field:Column(nullable = false, length = 64)
+    val privacyContentSha256: String,
+    @field:Column(name = "age14_or_older", nullable = false)
+    val age14OrOlder: Boolean,
+    @field:Column(nullable = false)
+    val requiredPrivacyConfirmed: Boolean,
+    @field:Column(nullable = false)
+    val analyticsConsent: Boolean,
+    @field:Column(nullable = false)
+    val overseasTransferAcknowledged: Boolean,
+    @field:Column(nullable = false, length = 32)
+    val source: String,
+    @field:Column(nullable = false)
+    val acceptedAt: Instant,
+) : BaseTime(id)

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt
@@ -1,6 +1,7 @@
 package com.back.boundedContexts.member.subContexts.signupVerification.adapter.web
 
 import com.back.boundedContexts.member.dto.MemberDto
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.signupVerification.application.service.MemberSignupVerificationService
 import com.back.boundedContexts.member.subContexts.signupVerification.application.service.SignupEmailStartResult
 import com.back.boundedContexts.member.subContexts.signupVerification.application.service.SignupEmailVerifyResult
@@ -62,7 +63,39 @@ class ApiV1SignupVerificationController(
         @field:NotBlank
         @field:Size(min = 2, max = 30)
         val nickname: String,
-    )
+        @field:NotBlank
+        @field:Size(max = 32)
+        val termsVersion: String,
+        @field:NotBlank
+        @field:Size(min = 64, max = 64)
+        val termsContentSha256: String,
+        @field:NotBlank
+        @field:Size(max = 32)
+        val privacyVersion: String,
+        @field:NotBlank
+        @field:Size(min = 64, max = 64)
+        val privacyContentSha256: String,
+        @field:Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        val age14OrOlder: Boolean,
+        @field:Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        val requiredPrivacyConfirmed: Boolean,
+        @field:Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        val analyticsConsent: Boolean,
+        @field:Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        val overseasTransferAcknowledged: Boolean,
+    ) {
+        fun toLegalAcceptanceCommand(): LegalAcceptanceCommand =
+            LegalAcceptanceCommand(
+                termsVersion = termsVersion,
+                termsContentSha256 = termsContentSha256,
+                privacyVersion = privacyVersion,
+                privacyContentSha256 = privacyContentSha256,
+                age14OrOlder = age14OrOlder,
+                requiredPrivacyConfirmed = requiredPrivacyConfirmed,
+                analyticsConsent = analyticsConsent,
+                overseasTransferAcknowledged = overseasTransferAcknowledged,
+            )
+    }
 
     @PostMapping("/email/start")
     @ResponseStatus(HttpStatus.ACCEPTED)
@@ -115,6 +148,7 @@ class ApiV1SignupVerificationController(
                 signupToken = reqBody.signupToken,
                 password = reqBody.password,
                 nickname = reqBody.nickname,
+                legalAcceptance = reqBody.toLegalAcceptanceCommand(),
             )
 
         return RsData(

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/MemberSignupVerificationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/MemberSignupVerificationService.kt
@@ -3,6 +3,8 @@ package com.back.boundedContexts.member.subContexts.signupVerification.applicati
 import com.back.boundedContexts.member.application.port.output.MemberRepositoryPort
 import com.back.boundedContexts.member.application.service.MemberApplicationService
 import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceApplicationService
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.signupVerification.application.port.output.MemberSignupVerificationRepositoryPort
 import com.back.boundedContexts.member.subContexts.signupVerification.domain.MemberSignupVerification
 import com.back.boundedContexts.member.subContexts.signupVerification.dto.SendSignupVerificationMailPayload
@@ -32,6 +34,7 @@ data class SignupEmailVerifyResult(
 class MemberSignupVerificationService(
     private val memberRepository: MemberRepositoryPort,
     private val memberApplicationService: MemberApplicationService,
+    private val legalAcceptanceApplicationService: LegalAcceptanceApplicationService,
     private val memberSignupVerificationRepository: MemberSignupVerificationRepositoryPort,
     private val taskFacade: TaskFacade,
     private val signupStartRateLimitService: SignupStartRateLimitService,
@@ -141,6 +144,7 @@ class MemberSignupVerificationService(
         signupToken: String,
         password: String,
         nickname: String,
+        legalAcceptance: LegalAcceptanceCommand,
     ): Member {
         val normalizedToken = signupToken.trim()
         if (normalizedToken.isBlank()) {
@@ -154,6 +158,7 @@ class MemberSignupVerificationService(
 
         verification.ensureCompletable(now)
         verification.ensureLegalAcceptanceRecorded(now)
+        legalAcceptanceApplicationService.validateEmailSignupAcceptance(legalAcceptance)
         if (memberRepository.existsByEmail(verification.email)) {
             verification.cancel(now)
             throw AppException("404-2", "유효하지 않은 회원가입 세션입니다.")
@@ -167,6 +172,11 @@ class MemberSignupVerificationService(
                 profileImgUrl = null,
             )
 
+        legalAcceptanceApplicationService.recordEmailSignupAcceptance(
+            member = member,
+            command = legalAcceptance,
+            acceptedAt = now,
+        )
         verification.consume(now)
 
         return member

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/MemberSignupVerificationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/MemberSignupVerificationService.kt
@@ -158,6 +158,7 @@ class MemberSignupVerificationService(
 
         verification.ensureCompletable(now)
         verification.ensureLegalAcceptanceRecorded(now)
+        legalAcceptanceApplicationService.validateStoredSignupPolicyVersion(verification.legalPolicyVersion)
         legalAcceptanceApplicationService.validateEmailSignupAcceptance(legalAcceptance)
         if (memberRepository.existsByEmail(verification.email)) {
             verification.cancel(now)

--- a/back/src/main/resources/db/migration-test/V20260622_01__create_member_legal_acceptance.sql
+++ b/back/src/main/resources/db/migration-test/V20260622_01__create_member_legal_acceptance.sql
@@ -1,0 +1,21 @@
+CREATE SEQUENCE IF NOT EXISTS member_legal_acceptance_seq START WITH 1 INCREMENT BY 20;
+
+CREATE TABLE IF NOT EXISTS member_legal_acceptance (
+    id BIGINT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL,
+    modified_at TIMESTAMPTZ NOT NULL,
+    member_id BIGINT NOT NULL REFERENCES member(id),
+    terms_version VARCHAR(32) NOT NULL,
+    terms_content_sha256 VARCHAR(64) NOT NULL,
+    privacy_version VARCHAR(32) NOT NULL,
+    privacy_content_sha256 VARCHAR(64) NOT NULL,
+    age14_or_older BOOLEAN NOT NULL,
+    required_privacy_confirmed BOOLEAN NOT NULL,
+    analytics_consent BOOLEAN NOT NULL,
+    overseas_transfer_acknowledged BOOLEAN NOT NULL,
+    source VARCHAR(32) NOT NULL,
+    accepted_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS member_legal_acceptance_idx_member_accepted_at_desc
+    ON member_legal_acceptance (member_id, accepted_at DESC);

--- a/back/src/main/resources/db/migration/V20260622_01__create_member_legal_acceptance.sql
+++ b/back/src/main/resources/db/migration/V20260622_01__create_member_legal_acceptance.sql
@@ -1,0 +1,21 @@
+CREATE SEQUENCE IF NOT EXISTS member_legal_acceptance_seq START WITH 1 INCREMENT BY 20;
+
+CREATE TABLE IF NOT EXISTS member_legal_acceptance (
+    id BIGINT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL,
+    modified_at TIMESTAMPTZ NOT NULL,
+    member_id BIGINT NOT NULL REFERENCES member(id),
+    terms_version VARCHAR(32) NOT NULL,
+    terms_content_sha256 VARCHAR(64) NOT NULL,
+    privacy_version VARCHAR(32) NOT NULL,
+    privacy_content_sha256 VARCHAR(64) NOT NULL,
+    age14_or_older BOOLEAN NOT NULL,
+    required_privacy_confirmed BOOLEAN NOT NULL,
+    analytics_consent BOOLEAN NOT NULL,
+    overseas_transfer_acknowledged BOOLEAN NOT NULL,
+    source VARCHAR(32) NOT NULL,
+    accepted_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS member_legal_acceptance_idx_member_accepted_at_desc
+    ON member_legal_acceptance (member_id, accepted_at DESC);

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationControllerTest.kt
@@ -1,6 +1,8 @@
 package com.back.boundedContexts.member.subContexts.signupVerification.adapter.web
 
 import com.back.boundedContexts.member.application.service.MemberApplicationService
+import com.back.boundedContexts.member.subContexts.legalAcceptance.adapter.persistence.MemberLegalAcceptanceRepository
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.ActiveLegalDocumentMetadata
 import com.back.boundedContexts.member.subContexts.signupVerification.adapter.persistence.MemberSignupVerificationRepository
 import com.back.global.task.adapter.persistence.TaskRepository
 import com.back.global.task.domain.TaskStatus
@@ -18,9 +20,13 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler
 @org.junit.jupiter.api.DisplayName("ApiV1SignupVerificationController 테스트")
 class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
     private val legalPolicyVersion = "2026-06-21"
+    private val activeLegalDocuments = ActiveLegalDocumentMetadata.current()
 
     @Autowired
     private lateinit var memberApplicationService: MemberApplicationService
+
+    @Autowired
+    private lateinit var memberLegalAcceptanceRepository: MemberLegalAcceptanceRepository
 
     @Autowired
     private lateinit var memberSignupVerificationRepository: MemberSignupVerificationRepository
@@ -209,7 +215,15 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
                         {
                             "signupToken": "$signupToken",
                             "password": "Abcd1234!",
-                            "nickname": "이메일인증회원"
+                            "nickname": "이메일인증회원",
+                            "termsVersion": "${activeLegalDocuments.terms.version}",
+                            "termsContentSha256": "${activeLegalDocuments.terms.contentSha256}",
+                            "privacyVersion": "${activeLegalDocuments.privacy.version}",
+                            "privacyContentSha256": "${activeLegalDocuments.privacy.contentSha256}",
+                            "age14OrOlder": true,
+                            "requiredPrivacyConfirmed": true,
+                            "analyticsConsent": false,
+                            "overseasTransferAcknowledged": true
                         }
                         """.trimIndent()
                 }.andExpect {
@@ -223,6 +237,16 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
             val joinedMember = memberApplicationService.findByEmail(email)
             checkNotNull(joinedMember)
             assertThat(joinedMember.email).isEqualTo(email)
+            val acceptance = memberLegalAcceptanceRepository.findTopByMemberIdOrderByAcceptedAtDesc(joinedMember.id)
+            checkNotNull(acceptance)
+            assertThat(acceptance.termsVersion).isEqualTo(activeLegalDocuments.terms.version)
+            assertThat(acceptance.termsContentSha256).isEqualTo(activeLegalDocuments.terms.contentSha256)
+            assertThat(acceptance.privacyVersion).isEqualTo(activeLegalDocuments.privacy.version)
+            assertThat(acceptance.privacyContentSha256).isEqualTo(activeLegalDocuments.privacy.contentSha256)
+            assertThat(acceptance.age14OrOlder).isTrue()
+            assertThat(acceptance.requiredPrivacyConfirmed).isTrue()
+            assertThat(acceptance.analyticsConsent).isFalse()
+            assertThat(acceptance.overseasTransferAcknowledged).isTrue()
         }
 
         @Test
@@ -235,7 +259,15 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
                         {
                             "signupToken": "invalid-token",
                             "password": "Abcd1234!",
-                            "nickname": "이메일인증회원"
+                            "nickname": "이메일인증회원",
+                            "termsVersion": "${activeLegalDocuments.terms.version}",
+                            "termsContentSha256": "${activeLegalDocuments.terms.contentSha256}",
+                            "privacyVersion": "${activeLegalDocuments.privacy.version}",
+                            "privacyContentSha256": "${activeLegalDocuments.privacy.contentSha256}",
+                            "age14OrOlder": true,
+                            "requiredPrivacyConfirmed": true,
+                            "analyticsConsent": false,
+                            "overseasTransferAcknowledged": true
                         }
                         """.trimIndent()
                 }.andExpect {
@@ -287,7 +319,15 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
                         {
                             "signupToken": "$signupToken",
                             "password": "Abcd1234!",
-                            "nickname": "동의누락회원"
+                            "nickname": "동의누락회원",
+                            "termsVersion": "${activeLegalDocuments.terms.version}",
+                            "termsContentSha256": "${activeLegalDocuments.terms.contentSha256}",
+                            "privacyVersion": "${activeLegalDocuments.privacy.version}",
+                            "privacyContentSha256": "${activeLegalDocuments.privacy.contentSha256}",
+                            "age14OrOlder": true,
+                            "requiredPrivacyConfirmed": true,
+                            "analyticsConsent": false,
+                            "overseasTransferAcknowledged": true
                         }
                         """.trimIndent()
                 }.andExpect {
@@ -339,12 +379,114 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
                             "signupToken": "$signupToken",
                             "username": "legacy-signup-user",
                             "password": "Abcd1234!",
-                            "nickname": "레거시회원"
+                            "nickname": "레거시회원",
+                            "termsVersion": "${activeLegalDocuments.terms.version}",
+                            "termsContentSha256": "${activeLegalDocuments.terms.contentSha256}",
+                            "privacyVersion": "${activeLegalDocuments.privacy.version}",
+                            "privacyContentSha256": "${activeLegalDocuments.privacy.contentSha256}",
+                            "age14OrOlder": true,
+                            "requiredPrivacyConfirmed": true,
+                            "analyticsConsent": false,
+                            "overseasTransferAcknowledged": true
                         }
                         """.trimIndent()
                 }.andExpect {
                     status { isBadRequest() }
                 }
+        }
+
+        @Test
+        fun `만 14세 이상 확인이 없으면 최종 가입을 막고 member를 생성하지 않는다`() {
+            val email = "under-age-direct@example.com"
+            val signupToken = issueSignupToken(email)
+
+            mvc
+                .post("/member/api/v1/signup/complete") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                            "signupToken": "$signupToken",
+                            "password": "Abcd1234!",
+                            "nickname": "연령미확인회원",
+                            "termsVersion": "${activeLegalDocuments.terms.version}",
+                            "termsContentSha256": "${activeLegalDocuments.terms.contentSha256}",
+                            "privacyVersion": "${activeLegalDocuments.privacy.version}",
+                            "privacyContentSha256": "${activeLegalDocuments.privacy.contentSha256}",
+                            "age14OrOlder": false,
+                            "requiredPrivacyConfirmed": true,
+                            "analyticsConsent": false,
+                            "overseasTransferAcknowledged": true
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.resultCode") { value("400-2") }
+                    jsonPath("$.msg") { value("만 14세 이상인 경우에만 회원가입할 수 있습니다.") }
+                }
+
+            assertThat(memberApplicationService.findByEmail(email)).isNull()
+        }
+
+        @Test
+        fun `정책 hash가 최신 active 문서와 다르면 최종 가입을 409로 막는다`() {
+            val email = "stale-policy@example.com"
+            val signupToken = issueSignupToken(email)
+
+            mvc
+                .post("/member/api/v1/signup/complete") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                            "signupToken": "$signupToken",
+                            "password": "Abcd1234!",
+                            "nickname": "오래된정책회원",
+                            "termsVersion": "${activeLegalDocuments.terms.version}",
+                            "termsContentSha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                            "privacyVersion": "${activeLegalDocuments.privacy.version}",
+                            "privacyContentSha256": "${activeLegalDocuments.privacy.contentSha256}",
+                            "age14OrOlder": true,
+                            "requiredPrivacyConfirmed": true,
+                            "analyticsConsent": false,
+                            "overseasTransferAcknowledged": true
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isConflict() }
+                    jsonPath("$.resultCode") { value("409-4") }
+                    jsonPath("$.msg") { value("약관 또는 개인정보처리방침이 변경되었습니다. 최신 내용을 확인하고 다시 동의해주세요.") }
+                }
+
+            assertThat(memberApplicationService.findByEmail(email)).isNull()
+        }
+
+        private fun issueSignupToken(email: String): String {
+            mvc.post("/member/api/v1/signup/email/start") {
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "email": "$email",
+                        "termsAccepted": true,
+                        "privacyAccepted": true,
+                        "legalPolicyVersion": "$legalPolicyVersion"
+                    }
+                    """.trimIndent()
+            }
+
+            val verification =
+                memberSignupVerificationRepository.findTopByEmailOrderByCreatedAtDesc(email)
+                    ?: error("verification row not created")
+
+            mvc.get("/member/api/v1/signup/email/verify") {
+                param("token", verification.emailVerificationToken)
+            }
+
+            return memberSignupVerificationRepository
+                .findTopByEmailOrderByCreatedAtDesc(email)
+                ?.signupSessionToken
+                ?: error("signup token not issued")
         }
     }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationControllerTest.kt
@@ -461,7 +461,43 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
             assertThat(memberApplicationService.findByEmail(email)).isNull()
         }
 
-        private fun issueSignupToken(email: String): String {
+        @Test
+        fun `가입 시작에 저장된 정책 버전이 최신 active 문서와 다르면 최종 가입을 409로 막는다`() {
+            val email = "stale-start-policy@example.com"
+            val signupToken = issueSignupToken(email, legalPolicyVersion = "2026-01-01")
+
+            mvc
+                .post("/member/api/v1/signup/complete") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                            "signupToken": "$signupToken",
+                            "password": "Abcd1234!",
+                            "nickname": "오래된시작정책회원",
+                            "termsVersion": "${activeLegalDocuments.terms.version}",
+                            "termsContentSha256": "${activeLegalDocuments.terms.contentSha256}",
+                            "privacyVersion": "${activeLegalDocuments.privacy.version}",
+                            "privacyContentSha256": "${activeLegalDocuments.privacy.contentSha256}",
+                            "age14OrOlder": true,
+                            "requiredPrivacyConfirmed": true,
+                            "analyticsConsent": false,
+                            "overseasTransferAcknowledged": true
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isConflict() }
+                    jsonPath("$.resultCode") { value("409-4") }
+                    jsonPath("$.msg") { value("약관 또는 개인정보처리방침이 변경되었습니다. 최신 내용을 확인하고 다시 동의해주세요.") }
+                }
+
+            assertThat(memberApplicationService.findByEmail(email)).isNull()
+        }
+
+        private fun issueSignupToken(
+            email: String,
+            legalPolicyVersion: String = this@ApiV1SignupVerificationControllerTest.legalPolicyVersion,
+        ): String {
             mvc.post("/member/api/v1/signup/email/start") {
                 contentType = MediaType.APPLICATION_JSON
                 content =

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationControllerTest.kt
@@ -19,8 +19,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler
 
 @org.junit.jupiter.api.DisplayName("ApiV1SignupVerificationController 테스트")
 class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
-    private val legalPolicyVersion = "2026-06-21"
     private val activeLegalDocuments = ActiveLegalDocumentMetadata.current()
+    private val legalPolicyVersion = activeLegalDocuments.signupPolicyVersion
 
     @Autowired
     private lateinit var memberApplicationService: MemberApplicationService

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationControllerTest.kt
@@ -243,10 +243,51 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
             assertThat(acceptance.termsContentSha256).isEqualTo(activeLegalDocuments.terms.contentSha256)
             assertThat(acceptance.privacyVersion).isEqualTo(activeLegalDocuments.privacy.version)
             assertThat(acceptance.privacyContentSha256).isEqualTo(activeLegalDocuments.privacy.contentSha256)
+            assertThat(acceptance.member.id).isEqualTo(joinedMember.id)
             assertThat(acceptance.age14OrOlder).isTrue()
             assertThat(acceptance.requiredPrivacyConfirmed).isTrue()
             assertThat(acceptance.analyticsConsent).isFalse()
             assertThat(acceptance.overseasTransferAcknowledged).isTrue()
+            assertThat(acceptance.source).isEqualTo("EMAIL_SIGNUP")
+            assertThat(acceptance.acceptedAt).isNotNull()
+        }
+
+        @Test
+        fun `signup complete request는 법적 동의 command로 변환된다`() {
+            val request =
+                ApiV1SignupVerificationController.SignupCompleteRequest(
+                    signupToken = "signup-token",
+                    password = "Abcd1234!",
+                    nickname = "동의요청회원",
+                    termsVersion = activeLegalDocuments.terms.version,
+                    termsContentSha256 = activeLegalDocuments.terms.contentSha256,
+                    privacyVersion = activeLegalDocuments.privacy.version,
+                    privacyContentSha256 = activeLegalDocuments.privacy.contentSha256,
+                    age14OrOlder = true,
+                    requiredPrivacyConfirmed = true,
+                    analyticsConsent = false,
+                    overseasTransferAcknowledged = true,
+                )
+
+            assertThat(request.termsVersion).isEqualTo(activeLegalDocuments.terms.version)
+            assertThat(request.termsContentSha256).isEqualTo(activeLegalDocuments.terms.contentSha256)
+            assertThat(request.privacyVersion).isEqualTo(activeLegalDocuments.privacy.version)
+            assertThat(request.privacyContentSha256).isEqualTo(activeLegalDocuments.privacy.contentSha256)
+            assertThat(request.age14OrOlder).isTrue()
+            assertThat(request.requiredPrivacyConfirmed).isTrue()
+            assertThat(request.analyticsConsent).isFalse()
+            assertThat(request.overseasTransferAcknowledged).isTrue()
+
+            val command = request.toLegalAcceptanceCommand()
+
+            assertThat(command.termsVersion).isEqualTo(request.termsVersion)
+            assertThat(command.termsContentSha256).isEqualTo(request.termsContentSha256)
+            assertThat(command.privacyVersion).isEqualTo(request.privacyVersion)
+            assertThat(command.privacyContentSha256).isEqualTo(request.privacyContentSha256)
+            assertThat(command.age14OrOlder).isEqualTo(request.age14OrOlder)
+            assertThat(command.requiredPrivacyConfirmed).isEqualTo(request.requiredPrivacyConfirmed)
+            assertThat(command.analyticsConsent).isEqualTo(request.analyticsConsent)
+            assertThat(command.overseasTransferAcknowledged).isEqualTo(request.overseasTransferAcknowledged)
         }
 
         @Test
@@ -423,6 +464,72 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
                     status { isBadRequest() }
                     jsonPath("$.resultCode") { value("400-2") }
                     jsonPath("$.msg") { value("만 14세 이상인 경우에만 회원가입할 수 있습니다.") }
+                }
+
+            assertThat(memberApplicationService.findByEmail(email)).isNull()
+        }
+
+        @Test
+        fun `필수 개인정보 처리 확인이 없으면 최종 가입을 막고 member를 생성하지 않는다`() {
+            val email = "missing-required-privacy@example.com"
+            val signupToken = issueSignupToken(email)
+
+            mvc
+                .post("/member/api/v1/signup/complete") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                            "signupToken": "$signupToken",
+                            "password": "Abcd1234!",
+                            "nickname": "개인정보미확인회원",
+                            "termsVersion": "${activeLegalDocuments.terms.version}",
+                            "termsContentSha256": "${activeLegalDocuments.terms.contentSha256}",
+                            "privacyVersion": "${activeLegalDocuments.privacy.version}",
+                            "privacyContentSha256": "${activeLegalDocuments.privacy.contentSha256}",
+                            "age14OrOlder": true,
+                            "requiredPrivacyConfirmed": false,
+                            "analyticsConsent": false,
+                            "overseasTransferAcknowledged": true
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.resultCode") { value("400-2") }
+                    jsonPath("$.msg") { value("개인정보 처리 필수 안내를 확인해야 회원가입할 수 있습니다.") }
+                }
+
+            assertThat(memberApplicationService.findByEmail(email)).isNull()
+        }
+
+        @Test
+        fun `국외 이전 안내 확인이 없으면 최종 가입을 막고 member를 생성하지 않는다`() {
+            val email = "missing-overseas-transfer@example.com"
+            val signupToken = issueSignupToken(email)
+
+            mvc
+                .post("/member/api/v1/signup/complete") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                            "signupToken": "$signupToken",
+                            "password": "Abcd1234!",
+                            "nickname": "국외이전미확인회원",
+                            "termsVersion": "${activeLegalDocuments.terms.version}",
+                            "termsContentSha256": "${activeLegalDocuments.terms.contentSha256}",
+                            "privacyVersion": "${activeLegalDocuments.privacy.version}",
+                            "privacyContentSha256": "${activeLegalDocuments.privacy.contentSha256}",
+                            "age14OrOlder": true,
+                            "requiredPrivacyConfirmed": true,
+                            "analyticsConsent": false,
+                            "overseasTransferAcknowledged": false
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.resultCode") { value("400-2") }
+                    jsonPath("$.msg") { value("국외 이전 및 외부 처리자 안내를 확인해야 회원가입할 수 있습니다.") }
                 }
 
             assertThat(memberApplicationService.findByEmail(email)).isNull()

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -4036,9 +4036,41 @@
             "type" : "string",
             "maxLength" : 30,
             "minLength" : 2
+          },
+          "termsVersion" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "minLength" : 0
+          },
+          "termsContentSha256" : {
+            "type" : "string",
+            "maxLength" : 64,
+            "minLength" : 64
+          },
+          "privacyVersion" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "minLength" : 0
+          },
+          "privacyContentSha256" : {
+            "type" : "string",
+            "maxLength" : 64,
+            "minLength" : 64
+          },
+          "age14OrOlder" : {
+            "type" : "boolean"
+          },
+          "requiredPrivacyConfirmed" : {
+            "type" : "boolean"
+          },
+          "analyticsConsent" : {
+            "type" : "boolean"
+          },
+          "overseasTransferAcknowledged" : {
+            "type" : "boolean"
           }
         },
-        "required" : [ "nickname", "password", "signupToken" ]
+        "required" : [ "age14OrOlder", "analyticsConsent", "nickname", "overseasTransferAcknowledged", "password", "privacyContentSha256", "privacyVersion", "requiredPrivacyConfirmed", "signupToken", "termsContentSha256", "termsVersion" ]
       },
       "MemberDto" : {
         "type" : "object",

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -1736,6 +1736,14 @@ export interface components {
             username?: string;
             password: string;
             nickname: string;
+            termsVersion: string;
+            termsContentSha256: string;
+            privacyVersion: string;
+            privacyContentSha256: string;
+            age14OrOlder: boolean;
+            requiredPrivacyConfirmed: boolean;
+            analyticsConsent: boolean;
+            overseasTransferAcknowledged: boolean;
         };
         MemberDto: {
             isAdmin?: boolean;

--- a/front/src/apis/backend/errorMessages.ts
+++ b/front/src/apis/backend/errorMessages.ts
@@ -24,9 +24,21 @@ const authStatusMessages: Record<AuthAction, Partial<Record<number, string>>> = 
   },
   signupComplete: {
     400: "입력값을 다시 확인해주세요.",
-    409: "약관 또는 개인정보처리방침이 변경되었습니다. 최신 내용을 확인하고 다시 동의해주세요.",
     500: "회원가입 처리 중 서버 오류가 발생했습니다.",
   },
+}
+
+const signupPolicyChangedMessage = "약관 또는 개인정보처리방침이 변경되었습니다. 최신 내용을 확인하고 다시 동의해주세요."
+
+const readApiResultCode = (body: string) => {
+  if (!body.trim()) return ""
+
+  try {
+    const parsed = JSON.parse(body) as { resultCode?: unknown }
+    return typeof parsed.resultCode === "string" ? parsed.resultCode.trim() : ""
+  } catch {
+    return ""
+  }
 }
 
 export const toFriendlyApiMessage = (error: unknown, fallback: string) => {
@@ -51,6 +63,11 @@ export const toAuthErrorMessage = (action: AuthAction, error: unknown, fallback:
   }
 
   if (error instanceof ApiError) {
+    if (action === "signupComplete" && error.status === 409) {
+      if (readApiResultCode(error.body) === "409-4") return signupPolicyChangedMessage
+      return "이미 처리되었거나 가입 상태가 변경되었습니다. 처음부터 다시 시도해주세요."
+    }
+
     const mapped = authStatusMessages[action][error.status]
     if (mapped) return mapped
     return error.userMessage || fallback

--- a/front/src/apis/backend/errorMessages.ts
+++ b/front/src/apis/backend/errorMessages.ts
@@ -24,7 +24,7 @@ const authStatusMessages: Record<AuthAction, Partial<Record<number, string>>> = 
   },
   signupComplete: {
     400: "입력값을 다시 확인해주세요.",
-    409: "이미 사용 중인 정보입니다.",
+    409: "약관 또는 개인정보처리방침이 변경되었습니다. 최신 내용을 확인하고 다시 동의해주세요.",
     500: "회원가입 처리 중 서버 오류가 발생했습니다.",
   },
 }

--- a/front/src/apis/backend/legal.ts
+++ b/front/src/apis/backend/legal.ts
@@ -1,0 +1,28 @@
+export const ACTIVE_LEGAL_DOCUMENTS = {
+  terms: {
+    version: "2026-06-21",
+    contentSha256: "3b71950e518b16b9a24cb4f9873633720ca7a9fce145a7bb9787c48845b56c5b",
+  },
+  privacy: {
+    version: "2026-06-21",
+    contentSha256: "4cc6ae3260aaca5f5ff35b235af91679a60760f13dccad9e85c94fda4d1552d9",
+  },
+} as const
+
+export const SIGNUP_LEGAL_POLICY_VERSION = ACTIVE_LEGAL_DOCUMENTS.terms.version
+
+export const buildEmailSignupLegalAcceptancePayload = (input: {
+  age14OrOlder: boolean
+  requiredPrivacyConfirmed: boolean
+  analyticsConsent: boolean
+  overseasTransferAcknowledged: boolean
+}) => ({
+  termsVersion: ACTIVE_LEGAL_DOCUMENTS.terms.version,
+  termsContentSha256: ACTIVE_LEGAL_DOCUMENTS.terms.contentSha256,
+  privacyVersion: ACTIVE_LEGAL_DOCUMENTS.privacy.version,
+  privacyContentSha256: ACTIVE_LEGAL_DOCUMENTS.privacy.contentSha256,
+  age14OrOlder: input.age14OrOlder,
+  requiredPrivacyConfirmed: input.requiredPrivacyConfirmed,
+  analyticsConsent: input.analyticsConsent,
+  overseasTransferAcknowledged: input.overseasTransferAcknowledged,
+})

--- a/front/src/apis/backend/legal.ts
+++ b/front/src/apis/backend/legal.ts
@@ -1,4 +1,5 @@
 export const ACTIVE_LEGAL_DOCUMENTS = {
+  signupPolicyVersion: "2026-06-21",
   terms: {
     version: "2026-06-21",
     contentSha256: "3b71950e518b16b9a24cb4f9873633720ca7a9fce145a7bb9787c48845b56c5b",
@@ -9,7 +10,7 @@ export const ACTIVE_LEGAL_DOCUMENTS = {
   },
 } as const
 
-export const SIGNUP_LEGAL_POLICY_VERSION = ACTIVE_LEGAL_DOCUMENTS.terms.version
+export const SIGNUP_LEGAL_POLICY_VERSION = ACTIVE_LEGAL_DOCUMENTS.signupPolicyVersion
 
 export const buildEmailSignupLegalAcceptancePayload = (input: {
   age14OrOlder: boolean

--- a/front/src/components/auth/AuthEntryModal.tsx
+++ b/front/src/components/auth/AuthEntryModal.tsx
@@ -3,6 +3,7 @@ import { FormEvent, useEffect, useMemo, useState } from "react"
 import { createPortal } from "react-dom"
 import { apiFetch } from "src/apis/backend/client"
 import { toAuthErrorMessage } from "src/apis/backend/errorMessages"
+import { SIGNUP_LEGAL_POLICY_VERSION } from "src/apis/backend/legal"
 import AppIcon from "src/components/icons/AppIcon"
 import useAuthSession from "src/hooks/useAuthSession"
 import { useSignupMailCooldown } from "src/hooks/useSignupMailCooldown"
@@ -24,8 +25,6 @@ import {
 const loadLoginPanel = () => import("./AuthEntryLoginPanel")
 const loadSignupPanel = () => import("./AuthEntrySignupPanel")
 const loadSignupSentPanel = () => import("./AuthEntrySignupSentPanel")
-
-const SIGNUP_LEGAL_POLICY_VERSION = "2026-06-21"
 
 const AuthEntryPanelFallback = () => (
   <div className="panelFallback" aria-hidden="true">

--- a/front/src/pages/signup.tsx
+++ b/front/src/pages/signup.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router"
 import { FormEvent, useMemo, useState } from "react"
 import { apiFetch } from "src/apis/backend/client"
 import { toAuthErrorMessage } from "src/apis/backend/errorMessages"
+import { SIGNUP_LEGAL_POLICY_VERSION } from "src/apis/backend/legal"
 import AuthShell from "src/components/auth/AuthShell"
 import AppIcon from "src/components/icons/AppIcon"
 import { formatSignupCooldown, useSignupMailCooldown } from "src/hooks/useSignupMailCooldown"
@@ -21,8 +22,6 @@ type RsData<T> = {
 type SignupEmailStartResult = {
   email: string
 }
-
-const SIGNUP_LEGAL_POLICY_VERSION = "2026-06-21"
 
 export const getServerSideProps: GetServerSideProps<GuestPageProps> = async ({ req }) => {
   return await getGuestPageProps(req)

--- a/front/src/pages/signup/verify.tsx
+++ b/front/src/pages/signup/verify.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router"
 import { FormEvent, useEffect, useMemo, useState } from "react"
 import { apiFetch } from "src/apis/backend/client"
 import { toAuthErrorMessage } from "src/apis/backend/errorMessages"
+import { ACTIVE_LEGAL_DOCUMENTS, buildEmailSignupLegalAcceptancePayload } from "src/apis/backend/legal"
 import AuthShell from "src/components/auth/AuthShell"
 import AppIcon from "src/components/icons/AppIcon"
 import { normalizeNextPath, replaceRoute, toLoginPath, toSignupPath } from "src/libs/router"
@@ -36,6 +37,10 @@ const SignupVerifyPage = () => {
   const [passwordConfirm, setPasswordConfirm] = useState("")
   const [nickname, setNickname] = useState("")
   const [showPassword, setShowPassword] = useState(false)
+  const [age14OrOlder, setAge14OrOlder] = useState(false)
+  const [requiredPrivacyConfirmed, setRequiredPrivacyConfirmed] = useState(false)
+  const [analyticsConsent, setAnalyticsConsent] = useState(false)
+  const [overseasTransferAcknowledged, setOverseasTransferAcknowledged] = useState(false)
   const [submitError, setSubmitError] = useState("")
   const [submitLoading, setSubmitLoading] = useState(false)
 
@@ -89,6 +94,7 @@ const SignupVerifyPage = () => {
   const hasPasswordConfirmInput = passwordConfirm.length > 0
   const passwordMatched = hasPasswordInput && hasPasswordConfirmInput && password === passwordConfirm
   const passwordMismatch = hasPasswordConfirmInput && password !== passwordConfirm
+  const requiredLegalAccepted = age14OrOlder && requiredPrivacyConfirmed && overseasTransferAcknowledged
   const submitFeedbackMessage = submitError ? (
     <ErrorText>{submitError}</ErrorText>
   ) : (
@@ -118,6 +124,11 @@ const SignupVerifyPage = () => {
       return
     }
 
+    if (!requiredLegalAccepted) {
+      setSubmitError("만 14세 이상, 개인정보 필수 안내, 국외 이전 안내를 모두 확인해주세요.")
+      return
+    }
+
     setSubmitLoading(true)
     setSubmitError("")
 
@@ -128,6 +139,12 @@ const SignupVerifyPage = () => {
           signupToken: verification.signupToken,
           password,
           nickname: nickname.trim(),
+          ...buildEmailSignupLegalAcceptancePayload({
+            age14OrOlder,
+            requiredPrivacyConfirmed,
+            analyticsConsent,
+            overseasTransferAcknowledged,
+          }),
         }),
       })
 
@@ -262,11 +279,52 @@ const SignupVerifyPage = () => {
             </PasswordPolicyList>
           </PasswordPolicyCard>
 
+          <RequiredConsentBox aria-label="회원가입 완료 필수 확인">
+            <p>
+              가입 시점 기준 정책 버전: 이용약관 {ACTIVE_LEGAL_DOCUMENTS.terms.version}, 개인정보처리방침{" "}
+              {ACTIVE_LEGAL_DOCUMENTS.privacy.version}
+            </p>
+            <label>
+              <input
+                type="checkbox"
+                checked={age14OrOlder}
+                onChange={(event) => setAge14OrOlder(event.target.checked)}
+              />
+              <span>만 14세 이상입니다.</span>
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={requiredPrivacyConfirmed}
+                onChange={(event) => setRequiredPrivacyConfirmed(event.target.checked)}
+              />
+              <span>
+                <Link href="/privacy">개인정보처리방침</Link>의 필수 수집·이용 항목을 확인했습니다.
+              </span>
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={overseasTransferAcknowledged}
+                onChange={(event) => setOverseasTransferAcknowledged(event.target.checked)}
+              />
+              <span>서비스 운영에 필요한 외부 처리자와 국외 이전 가능성을 확인했습니다.</span>
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={analyticsConsent}
+                onChange={(event) => setAnalyticsConsent(event.target.checked)}
+              />
+              <span>서비스 품질 개선을 위한 analytics/RUM 처리에 선택 동의합니다.</span>
+            </label>
+          </RequiredConsentBox>
+
           <FeedbackSlot aria-live="polite">{submitFeedbackMessage}</FeedbackSlot>
 
           <ActionRow>
             <CancelLink href={toSignupPath(next)}>취소</CancelLink>
-            <PrimaryButton type="submit" disabled={submitLoading}>
+            <PrimaryButton type="submit" disabled={submitLoading || !requiredLegalAccepted}>
               {submitLoading ? "가입 중..." : "가입"}
             </PrimaryButton>
           </ActionRow>
@@ -398,6 +456,41 @@ const PasswordPolicyItem = styled.li`
 
   &[data-ok="false"] {
     color: ${({ theme }) => theme.colors.gray10};
+  }
+`
+
+const RequiredConsentBox = styled.div`
+  display: grid;
+  gap: 0.58rem;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 14px;
+  background: ${({ theme }) => theme.colors.gray2};
+  padding: 0.74rem 0.84rem;
+
+  p {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.82rem;
+    line-height: 1.55;
+  }
+
+  label {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.5rem;
+    align-items: start;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.84rem;
+    line-height: 1.5;
+  }
+
+  input {
+    margin-top: 0.22rem;
+  }
+
+  a {
+    color: ${({ theme }) => theme.colors.blue10};
+    font-weight: 700;
   }
 `
 


### PR DESCRIPTION
## 🔗 Related Issue
- close #996

## 📝 Summary
- 이메일 회원가입 완료 시점에 active 이용약관/개인정보처리방침 version+sha256, 만 14세 이상, 필수 개인정보 확인, 국외 이전 고지 확인을 서버에서 검증합니다.
- 회원 생성과 `member_legal_acceptance` 저장을 같은 transaction에 묶고, analytics 선택 동의 거부는 가입을 막지 않도록 저장합니다.

## 🛠 Changes
- `member_legal_acceptance` entity/repository/port/service와 prod/test Flyway migration을 추가했습니다.
- `/member/api/v1/signup/complete` request에 legal acceptance payload를 추가하고 active policy hash 불일치 시 409로 최신 정책 재확인을 요구합니다.
- 회원가입 완료 화면에 필수 확인 3개와 선택 analytics 동의를 추가하고 OpenAPI/TypeScript contract를 갱신했습니다.

## 🎯 Scope
- [x] Frontend
- [x] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [ ] 필요한 수동 확인을 마쳤는가?
- [ ] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `./gradlew test --tests com.back.boundedContexts.member.subContexts.signupVerification.adapter.web.ApiV1SignupVerificationControllerTest` 성공
- `./gradlew ktlintCheck` 성공
- `./gradlew test` 성공
- `./gradlew cleanTest test` 성공
- `yarn --cwd front build` 성공
- `yarn --cwd front contracts:check` 성공
- `yarn --cwd front playwright:preflight` 성공
- pre-commit hook: OpenAPI export + `yarn contracts:check` 성공

## 📸 Screenshot / API Example
- API 예시: `signup/complete`는 `termsVersion`, `termsContentSha256`, `privacyVersion`, `privacyContentSha256`, `age14OrOlder`, `requiredPrivacyConfirmed`, `analyticsConsent`, `overseasTransferAcknowledged`를 요구합니다.
- UI 캡처는 PR CI와 리뷰 이후 필요 시 추가합니다.

## ⚠️ Risk & Rollback
- 예상 리스크: 기존 미완료 signup session이 새 complete payload 없이는 완료되지 않습니다. 가입 완료 화면을 통해 진행하면 새 payload가 전송됩니다.
- 롤백 방법: 이 PR revert 후 `member_legal_acceptance` migration 적용 여부를 운영 DB에서 확인하고, 필요 시 후속 migration으로 테이블을 보존 또는 제거합니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 [코드 주석 정책](https://github.com/AquilaXk/aquila-blog/blob/main/docs/design/code-comment-policy.md)에 맞는 이유/불변조건/운영 영향을 설명하는가?
