### PR TITLE
[Fix] 회원가입 token URL 노출 제거와 hash 저장 전환

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/config/MemberSecurityConfigurer.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/config/MemberSecurityConfigurer.kt
@@ -26,6 +26,7 @@ class MemberSecurityConfigurer(
             add(PublicApiRouteSpec("/member/api/*/members/{id:\\d+}/redirectToProfileImg", HttpMethod.GET))
             add(PublicApiRouteSpec("/member/api/*/signup/email/start", HttpMethod.POST))
             add(PublicApiRouteSpec("/member/api/*/signup/email/verify", HttpMethod.GET))
+            add(PublicApiRouteSpec("/member/api/*/signup/email/verify", HttpMethod.POST))
             add(PublicApiRouteSpec("/member/api/*/signup/complete", HttpMethod.POST))
         }
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/persistence/MemberSignupVerificationRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/persistence/MemberSignupVerificationRepository.kt
@@ -4,9 +4,9 @@ import com.back.boundedContexts.member.subContexts.signupVerification.domain.Mem
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberSignupVerificationRepository : JpaRepository<MemberSignupVerification, Long> {
-    fun findByEmailVerificationToken(emailVerificationToken: String): MemberSignupVerification?
+    fun findByEmailVerificationTokenHash(emailVerificationTokenHash: String): MemberSignupVerification?
 
-    fun findBySignupSessionToken(signupSessionToken: String): MemberSignupVerification?
+    fun findBySignupSessionTokenHash(signupSessionTokenHash: String): MemberSignupVerification?
 
     fun findTopByEmailOrderByCreatedAtDesc(email: String): MemberSignupVerification?
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/persistence/MemberSignupVerificationRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/persistence/MemberSignupVerificationRepositoryAdapter.kt
@@ -15,11 +15,11 @@ class MemberSignupVerificationRepositoryAdapter(
     override fun save(memberSignupVerification: MemberSignupVerification): MemberSignupVerification =
         memberSignupVerificationRepository.save(memberSignupVerification)
 
-    override fun findByEmailVerificationToken(emailVerificationToken: String): MemberSignupVerification? =
-        memberSignupVerificationRepository.findByEmailVerificationToken(emailVerificationToken)
+    override fun findByEmailVerificationTokenHash(emailVerificationTokenHash: String): MemberSignupVerification? =
+        memberSignupVerificationRepository.findByEmailVerificationTokenHash(emailVerificationTokenHash)
 
-    override fun findBySignupSessionToken(signupSessionToken: String): MemberSignupVerification? =
-        memberSignupVerificationRepository.findBySignupSessionToken(signupSessionToken)
+    override fun findBySignupSessionTokenHash(signupSessionTokenHash: String): MemberSignupVerification? =
+        memberSignupVerificationRepository.findBySignupSessionTokenHash(signupSessionTokenHash)
 
     override fun findTopByEmail(email: String): MemberSignupVerification? =
         memberSignupVerificationRepository.findTopByEmailOrderByCreatedAtDesc(email)

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt
@@ -6,8 +6,8 @@ import com.back.boundedContexts.member.subContexts.signupVerification.applicatio
 import com.back.boundedContexts.member.subContexts.signupVerification.application.service.SignupEmailStartResult
 import com.back.boundedContexts.member.subContexts.signupVerification.application.service.SignupEmailVerifyResult
 import com.back.global.rsData.RsData
+import com.back.global.web.application.Rq
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
@@ -19,15 +19,21 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import java.time.Duration
+import java.time.Instant
 
 @RestController
 @RequestMapping("/member/api/v1/signup")
 class ApiV1SignupVerificationController(
     private val memberSignupVerificationService: MemberSignupVerificationService,
+    private val rq: Rq,
 ) {
+    companion object {
+        const val SIGNUP_SESSION_COOKIE_NAME = "signup_session"
+    }
+
     data class SignupEmailStartRequest(
         @field:Email
         @field:NotBlank
@@ -45,9 +51,12 @@ class ApiV1SignupVerificationController(
         val nextPath: String? = null,
     )
 
-    data class SignupCompleteRequest(
+    data class SignupEmailVerifyRequest(
         @field:NotBlank
-        val signupToken: String,
+        val token: String,
+    )
+
+    data class SignupCompleteRequest(
         @field:Pattern(
             regexp = "^$",
             message = "username 필드는 더 이상 지원되지 않습니다.",
@@ -101,7 +110,6 @@ class ApiV1SignupVerificationController(
     @ResponseStatus(HttpStatus.ACCEPTED)
     @Transactional
     fun start(
-        request: HttpServletRequest,
         @RequestBody @Valid reqBody: SignupEmailStartRequest,
     ): RsData<SignupEmailStartResult> {
         val result =
@@ -111,7 +119,7 @@ class ApiV1SignupVerificationController(
                 privacyAccepted = reqBody.privacyAccepted,
                 legalPolicyVersion = reqBody.legalPolicyVersion,
                 nextPath = reqBody.nextPath,
-                clientIp = extractClientIp(request),
+                clientIp = rq.clientIp,
             )
 
         return RsData(
@@ -121,19 +129,33 @@ class ApiV1SignupVerificationController(
         )
     }
 
-    private fun extractClientIp(request: HttpServletRequest): String = request.remoteAddr.orEmpty()
-
     @GetMapping("/email/verify")
+    @ResponseStatus(HttpStatus.GONE)
+    fun verifyLegacyGet(): RsData<Void> =
+        RsData(
+            "410-3",
+            "query 기반 회원가입 인증 링크는 더 이상 지원되지 않습니다. 새 인증 메일을 요청해주세요.",
+        )
+
+    @PostMapping("/email/verify")
     @Transactional
     fun verify(
-        @RequestParam token: String,
+        @RequestBody @Valid reqBody: SignupEmailVerifyRequest,
     ): RsData<SignupEmailVerifyResult> {
-        val result = memberSignupVerificationService.verifyEmail(token)
+        val result = memberSignupVerificationService.verifyEmail(reqBody.token)
+        rq.setCookie(
+            SIGNUP_SESSION_COOKIE_NAME,
+            result.signupToken,
+            maxAgeSeconds = cookieMaxAgeSeconds(result.expiresAt),
+        )
 
         return RsData(
             "200-2",
             "이메일 인증이 완료되었습니다.",
-            result,
+            SignupEmailVerifyResult(
+                email = result.email,
+                expiresAt = result.expiresAt,
+            ),
         )
     }
 
@@ -145,11 +167,12 @@ class ApiV1SignupVerificationController(
     ): RsData<MemberDto> {
         val member =
             memberSignupVerificationService.completeSignup(
-                signupToken = reqBody.signupToken,
+                signupToken = rq.getCookieValue(SIGNUP_SESSION_COOKIE_NAME, ""),
                 password = reqBody.password,
                 nickname = reqBody.nickname,
                 legalAcceptance = reqBody.toLegalAcceptanceCommand(),
             )
+        rq.deleteCookie(SIGNUP_SESSION_COOKIE_NAME)
 
         return RsData(
             "201-2",
@@ -157,4 +180,11 @@ class ApiV1SignupVerificationController(
             MemberDto(member),
         )
     }
+
+    private fun cookieMaxAgeSeconds(expiresAt: Instant): Int =
+        Duration
+            .between(Instant.now(), expiresAt)
+            .seconds
+            .coerceIn(1, Int.MAX_VALUE.toLong())
+            .toInt()
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/port/output/MemberSignupVerificationRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/port/output/MemberSignupVerificationRepositoryPort.kt
@@ -5,9 +5,9 @@ import com.back.boundedContexts.member.subContexts.signupVerification.domain.Mem
 interface MemberSignupVerificationRepositoryPort {
     fun save(memberSignupVerification: MemberSignupVerification): MemberSignupVerification
 
-    fun findByEmailVerificationToken(emailVerificationToken: String): MemberSignupVerification?
+    fun findByEmailVerificationTokenHash(emailVerificationTokenHash: String): MemberSignupVerification?
 
-    fun findBySignupSessionToken(signupSessionToken: String): MemberSignupVerification?
+    fun findBySignupSessionTokenHash(signupSessionTokenHash: String): MemberSignupVerification?
 
     fun findTopByEmail(email: String): MemberSignupVerification?
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/MemberSignupVerificationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/MemberSignupVerificationService.kt
@@ -26,6 +26,11 @@ data class SignupEmailStartResult(
 
 data class SignupEmailVerifyResult(
     val email: String,
+    val expiresAt: Instant,
+)
+
+data class SignupEmailVerifiedSession(
+    val email: String,
     val signupToken: String,
     val expiresAt: Instant,
 )
@@ -38,6 +43,7 @@ class MemberSignupVerificationService(
     private val memberSignupVerificationRepository: MemberSignupVerificationRepositoryPort,
     private val taskFacade: TaskFacade,
     private val signupStartRateLimitService: SignupStartRateLimitService,
+    private val signupTokenHashService: SignupTokenHashService,
     @Value("\${custom.member.signup.verifyPath:/signup/verify}")
     private val verifyPath: String,
     @Value("\${custom.member.signup.emailExpirationSeconds:86400}")
@@ -83,12 +89,13 @@ class MemberSignupVerificationService(
             ?.takeIf { it.consumedAt == null && it.cancelledAt == null }
             ?.cancel(now)
 
+        val emailVerificationToken = UUID.randomUUID().toString()
         val verificationExpiresAt = now.plusSeconds(emailExpirationSeconds)
         val verification =
             memberSignupVerificationRepository.save(
                 MemberSignupVerification(
                     email = normalizedEmail,
-                    emailVerificationToken = UUID.randomUUID().toString(),
+                    emailVerificationTokenHash = signupTokenHashService.emailVerificationTokenHash(emailVerificationToken),
                     emailVerificationExpiresAt = verificationExpiresAt,
                     termsAcceptedAt = now,
                     privacyAcceptedAt = now,
@@ -102,7 +109,7 @@ class MemberSignupVerificationService(
                 aggregateType = MemberSignupVerification::class.simpleName!!,
                 aggregateId = verification.id,
                 toEmail = normalizedEmail,
-                verificationLink = buildVerificationLink(verification.emailVerificationToken, nextPath),
+                verificationLink = buildVerificationLink(emailVerificationToken, nextPath),
                 expiresAt = verificationExpiresAt,
             ),
         )
@@ -111,7 +118,7 @@ class MemberSignupVerificationService(
     }
 
     @Transactional
-    fun verifyEmail(emailVerificationToken: String): SignupEmailVerifyResult {
+    fun verifyEmail(emailVerificationToken: String): SignupEmailVerifiedSession {
         val normalizedToken = emailVerificationToken.trim()
         if (normalizedToken.isBlank()) {
             throw AppException("400-2", "회원가입 링크가 올바르지 않습니다.")
@@ -119,7 +126,9 @@ class MemberSignupVerificationService(
 
         val now = Instant.now()
         val verification =
-            memberSignupVerificationRepository.findByEmailVerificationToken(normalizedToken)
+            memberSignupVerificationRepository.findByEmailVerificationTokenHash(
+                signupTokenHashService.emailVerificationTokenHash(normalizedToken),
+            )
                 ?: throw AppException("404-2", "유효하지 않은 회원가입 링크입니다.")
 
         verification.ensureVerifiable(now)
@@ -130,9 +139,13 @@ class MemberSignupVerificationService(
 
         val sessionToken = UUID.randomUUID().toString()
         val sessionExpiresAt = now.plusSeconds(sessionExpirationSeconds)
-        verification.issueSignupSession(sessionToken, sessionExpiresAt, now)
+        verification.issueSignupSession(
+            signupTokenHashService.signupSessionTokenHash(sessionToken),
+            sessionExpiresAt,
+            now,
+        )
 
-        return SignupEmailVerifyResult(
+        return SignupEmailVerifiedSession(
             email = verification.email,
             signupToken = sessionToken,
             expiresAt = sessionExpiresAt,
@@ -153,7 +166,9 @@ class MemberSignupVerificationService(
 
         val now = Instant.now()
         val verification =
-            memberSignupVerificationRepository.findBySignupSessionToken(normalizedToken)
+            memberSignupVerificationRepository.findBySignupSessionTokenHash(
+                signupTokenHashService.signupSessionTokenHash(normalizedToken),
+            )
                 ?: throw AppException("404-2", "유효하지 않은 회원가입 세션입니다.")
 
         verification.ensureCompletable(now)
@@ -204,13 +219,14 @@ class MemberSignupVerificationService(
         return buildString {
             append(AppConfig.siteFrontUrl)
             append(normalizedPath)
-            append("?token=")
-            append(token)
 
             if (normalizedNextPath != null) {
-                append("&next=")
+                append("?next=")
                 append(URLEncoder.encode(normalizedNextPath, StandardCharsets.UTF_8))
             }
+
+            append("#token=")
+            append(URLEncoder.encode(token, StandardCharsets.UTF_8))
         }
     }
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/SignupMailDiagnosticsService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/SignupMailDiagnosticsService.kt
@@ -172,7 +172,7 @@ class SignupMailDiagnosticsService(
             throw AppException("503-2", "회원가입 메일 설정이 아직 준비되지 않았습니다.")
         }
 
-        val verificationLink = "${AppConfig.siteFrontUrl}${normalizeVerifyPath()}?token=test-signup-mail"
+        val verificationLink = "${AppConfig.siteFrontUrl}${normalizeVerifyPath()}#token=test-signup-mail"
 
         signupVerificationMailSenderProvider
             .getIfAvailable()

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/SignupTokenHashService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/SignupTokenHashService.kt
@@ -1,0 +1,42 @@
+package com.back.boundedContexts.member.subContexts.signupVerification.application.service
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Base64
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+@Service
+class SignupTokenHashService(
+    @param:Value("\${custom.member.signup.tokenHashSecret:}")
+    private val configuredTokenHashSecret: String,
+    @param:Value("\${custom.jwt.secretKey}")
+    private val jwtSecretKey: String,
+) {
+    fun emailVerificationTokenHash(rawToken: String): String = digest("email-verification", rawToken)
+
+    fun signupSessionTokenHash(rawToken: String): String = digest("signup-session", rawToken)
+
+    private fun digest(
+        purpose: String,
+        rawToken: String,
+    ): String {
+        val normalizedToken = rawToken.trim()
+        require(normalizedToken.isNotBlank()) { "signup token must not be blank" }
+
+        val mac = Mac.getInstance(HMAC_ALGORITHM)
+        mac.init(SecretKeySpec(resolveSecret().toByteArray(UTF_8), HMAC_ALGORITHM))
+        val digest = mac.doFinal("$purpose:$normalizedToken".toByteArray(UTF_8))
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(digest)
+    }
+
+    private fun resolveSecret(): String =
+        configuredTokenHashSecret
+            .ifBlank { jwtSecretKey }
+            .ifBlank { error("custom.member.signup.tokenHashSecret or custom.jwt.secretKey is required") }
+
+    companion object {
+        private const val HMAC_ALGORITHM = "HmacSHA256"
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/model/MemberSignupVerification.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/model/MemberSignupVerification.kt
@@ -33,12 +33,12 @@ class MemberSignupVerification(
     override val id: Long = 0,
     @field:Column(nullable = false)
     val email: String,
-    @field:Column(unique = true, nullable = false, length = 120)
-    var emailVerificationToken: String,
+    @field:Column(unique = true, nullable = false, length = 128)
+    var emailVerificationTokenHash: String,
     @field:Column(nullable = false)
     var emailVerificationExpiresAt: Instant,
-    @field:Column(unique = true, length = 120)
-    var signupSessionToken: String? = null,
+    @field:Column(unique = true, length = 128)
+    var signupSessionTokenHash: String? = null,
     @field:Column
     var signupSessionExpiresAt: Instant? = null,
     @field:Column
@@ -69,12 +69,12 @@ class MemberSignupVerification(
     }
 
     fun issueSignupSession(
-        token: String,
+        tokenHash: String,
         expiresAt: Instant,
         now: Instant,
     ) {
         verifiedAt = verifiedAt ?: now
-        signupSessionToken = token
+        signupSessionTokenHash = tokenHash
         signupSessionExpiresAt = expiresAt
     }
 
@@ -83,7 +83,7 @@ class MemberSignupVerification(
             throw AppException("410-1", "회원가입 세션이 더 이상 유효하지 않습니다.")
         }
 
-        if (verifiedAt == null || signupSessionToken.isNullOrBlank() || signupSessionExpiresAt == null) {
+        if (verifiedAt == null || signupSessionTokenHash.isNullOrBlank() || signupSessionExpiresAt == null) {
             throw AppException("401-4", "이메일 인증이 완료되지 않았습니다.")
         }
 

--- a/back/src/main/resources/db/migration-test/V20260319_01__baseline_schema.sql
+++ b/back/src/main/resources/db/migration-test/V20260319_01__baseline_schema.sql
@@ -164,9 +164,9 @@ CREATE TABLE IF NOT EXISTS member_notification (
 CREATE TABLE IF NOT EXISTS member_signup_verification (
     id BIGINT NOT NULL DEFAULT nextval('member_signup_verification_seq'),
     email VARCHAR(255) NOT NULL,
-    email_verification_token VARCHAR(120) NOT NULL,
+    email_verification_token_hash VARCHAR(128) NOT NULL,
     email_verification_expires_at TIMESTAMPTZ NOT NULL,
-    signup_session_token VARCHAR(120),
+    signup_session_token_hash VARCHAR(128),
     signup_session_expires_at TIMESTAMPTZ,
     verified_at TIMESTAMPTZ,
     consumed_at TIMESTAMPTZ,
@@ -177,8 +177,8 @@ CREATE TABLE IF NOT EXISTS member_signup_verification (
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     modified_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT pk_member_signup_verification PRIMARY KEY (id),
-    CONSTRAINT uk_member_signup_verification_email_verification_token UNIQUE (email_verification_token),
-    CONSTRAINT uk_member_signup_verification_signup_session_token UNIQUE (signup_session_token)
+    CONSTRAINT uk_member_signup_verification_email_verification_token_hash UNIQUE (email_verification_token_hash),
+    CONSTRAINT uk_member_signup_verification_signup_session_token_hash UNIQUE (signup_session_token_hash)
 );
 
 CREATE TABLE IF NOT EXISTS uploaded_file (

--- a/back/src/main/resources/db/migration/V20260622_02__hash_signup_verification_tokens.sql
+++ b/back/src/main/resources/db/migration/V20260622_02__hash_signup_verification_tokens.sql
@@ -1,0 +1,35 @@
+ALTER TABLE public.member_signup_verification
+    ADD COLUMN IF NOT EXISTS email_verification_token_hash VARCHAR(128);
+
+ALTER TABLE public.member_signup_verification
+    ADD COLUMN IF NOT EXISTS signup_session_token_hash VARCHAR(128);
+
+UPDATE public.member_signup_verification
+SET email_verification_token_hash = CONCAT('legacy-email-token-invalidated-', id)
+WHERE email_verification_token_hash IS NULL;
+
+UPDATE public.member_signup_verification
+SET signup_session_token_hash = NULL
+WHERE signup_session_token_hash IS NULL;
+
+ALTER TABLE public.member_signup_verification
+    ALTER COLUMN email_verification_token_hash SET NOT NULL;
+
+ALTER TABLE public.member_signup_verification
+    DROP CONSTRAINT IF EXISTS uk_member_signup_verification_email_verification_token;
+
+ALTER TABLE public.member_signup_verification
+    DROP CONSTRAINT IF EXISTS uk_member_signup_verification_signup_session_token;
+
+ALTER TABLE public.member_signup_verification
+    DROP COLUMN IF EXISTS email_verification_token;
+
+ALTER TABLE public.member_signup_verification
+    DROP COLUMN IF EXISTS signup_session_token;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_member_signup_verification_email_verification_token_hash
+    ON public.member_signup_verification (email_verification_token_hash);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_member_signup_verification_signup_session_token_hash
+    ON public.member_signup_verification (signup_session_token_hash)
+    WHERE signup_session_token_hash IS NOT NULL;

--- a/back/src/main/resources/db/migration/V20260622_02__hash_signup_verification_tokens.sql
+++ b/back/src/main/resources/db/migration/V20260622_02__hash_signup_verification_tokens.sql
@@ -13,19 +13,13 @@ SET signup_session_token_hash = NULL
 WHERE signup_session_token_hash IS NULL;
 
 ALTER TABLE public.member_signup_verification
-    ALTER COLUMN email_verification_token_hash SET NOT NULL;
+    ALTER COLUMN email_verification_token DROP NOT NULL;
 
 ALTER TABLE public.member_signup_verification
     DROP CONSTRAINT IF EXISTS uk_member_signup_verification_email_verification_token;
 
 ALTER TABLE public.member_signup_verification
     DROP CONSTRAINT IF EXISTS uk_member_signup_verification_signup_session_token;
-
-ALTER TABLE public.member_signup_verification
-    DROP COLUMN IF EXISTS email_verification_token;
-
-ALTER TABLE public.member_signup_verification
-    DROP COLUMN IF EXISTS signup_session_token;
 
 CREATE UNIQUE INDEX IF NOT EXISTS uk_member_signup_verification_email_verification_token_hash
     ON public.member_signup_verification (email_verification_token_hash);

--- a/back/src/main/resources/db/migration/V20260622_02__hash_signup_verification_tokens.sql
+++ b/back/src/main/resources/db/migration/V20260622_02__hash_signup_verification_tokens.sql
@@ -27,3 +27,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS uk_member_signup_verification_email_verificati
 CREATE UNIQUE INDEX IF NOT EXISTS uk_member_signup_verification_signup_session_token_hash
     ON public.member_signup_verification (signup_session_token_hash)
     WHERE signup_session_token_hash IS NOT NULL;
+
+ALTER TABLE public.member_signup_verification
+    ADD CONSTRAINT ck_member_signup_verification_email_verification_token_hash_present
+    CHECK (email_verification_token_hash IS NOT NULL) NOT VALID;

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/mail/SmtpSignupVerificationMailSenderAdapterTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/mail/SmtpSignupVerificationMailSenderAdapterTest.kt
@@ -28,7 +28,7 @@ class SmtpSignupVerificationMailSenderAdapterTest {
                 mailSubject = "Aquila 블로그 회원가입",
             )
 
-        val verificationLink = "https://www.aquilaxk.site/signup/verify?token=test-token"
+        val verificationLink = "https://www.aquilaxk.site/signup/verify#token=test-token"
         adapter.send(
             toEmail = "tester@example.com",
             verificationLink = verificationLink,
@@ -64,7 +64,7 @@ class SmtpSignupVerificationMailSenderAdapterTest {
 
         adapter.send(
             toEmail = "tester@example.com",
-            verificationLink = "https://www.aquilaxk.site/signup/verify?token=test-token",
+            verificationLink = "https://www.aquilaxk.site/signup/verify#token=test-token",
             expiresAt = Instant.parse("2026-03-12T10:05:13Z"),
         )
 

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationControllerTest.kt
@@ -4,11 +4,12 @@ import com.back.boundedContexts.member.application.service.MemberApplicationServ
 import com.back.boundedContexts.member.subContexts.legalAcceptance.adapter.persistence.MemberLegalAcceptanceRepository
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.ActiveLegalDocumentMetadata
 import com.back.boundedContexts.member.subContexts.signupVerification.adapter.persistence.MemberSignupVerificationRepository
+import com.back.boundedContexts.member.subContexts.signupVerification.adapter.web.ApiV1SignupVerificationController.Companion.SIGNUP_SESSION_COOKIE_NAME
 import com.back.global.task.adapter.persistence.TaskRepository
 import com.back.global.task.domain.TaskStatus
 import com.back.support.BaseControllerIntegrationTest
+import jakarta.servlet.http.Cookie
 import org.assertj.core.api.Assertions.assertThat
-import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -16,6 +17,8 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 
 @org.junit.jupiter.api.DisplayName("ApiV1SignupVerificationController 테스트")
 class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
@@ -62,7 +65,6 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
                 memberSignupVerificationRepository.findTopByEmailOrderByCreatedAtDesc("new-user@example.com")
 
             checkNotNull(verification)
-            assertThat(verification.emailVerificationToken).isNotBlank()
             assertThat(verification.termsAcceptedAt).isNotNull()
             assertThat(verification.privacyAcceptedAt).isNotNull()
             assertThat(verification.legalPolicyVersion).isEqualTo(legalPolicyVersion)
@@ -70,7 +72,14 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
                 taskRepository.findAll().filter { it.taskType == "member.signupVerification.sendMail" }
             assertThat(mailTasks).hasSize(1)
             assertThat(mailTasks.single().aggregateId).isEqualTo(verification.id)
+            assertThat(mailTasks.single().payload).doesNotContain("?token=")
+            assertThat(mailTasks.single().payload).contains("#token=")
             assertThat(mailTasks.single().status).isEqualTo(TaskStatus.COMPLETED)
+
+            val emailVerificationToken = emailVerificationTokenFromMailTask(verification.id)
+            assertThat(verification.emailVerificationTokenHash).isNotBlank()
+            assertThat(verification.emailVerificationTokenHash).isNotEqualTo(emailVerificationToken)
+            assertThat(mailTasks.single().payload).doesNotContain(verification.emailVerificationTokenHash)
         }
 
         @Test
@@ -169,6 +178,19 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
     @Nested
     inner class EmailVerifyAndComplete {
         @Test
+        fun `legacy GET verify는 query token을 처리하지 않고 410을 반환한다`() {
+            mvc
+                .get("/member/api/v1/signup/email/verify") {
+                    param("token", "legacy-query-token")
+                }.andExpect {
+                    status { isGone() }
+                    match(handler().handlerType(ApiV1SignupVerificationController::class.java))
+                    match(handler().methodName("verifyLegacyGet"))
+                    jsonPath("$.resultCode") { value("410-3") }
+                }
+        }
+
+        @Test
         fun `이메일 인증 후 최종 가입을 완료할 수 있다`() {
             val email = "verify-user@example.com"
 
@@ -188,32 +210,39 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
             val verification =
                 memberSignupVerificationRepository.findTopByEmailOrderByCreatedAtDesc(email)
                     ?: error("verification row not created")
+            val emailVerificationToken = emailVerificationTokenFromMailTask(verification.id)
 
-            mvc
-                .get("/member/api/v1/signup/email/verify") {
-                    param("token", verification.emailVerificationToken)
-                }.andExpect {
-                    status { isOk() }
-                    match(handler().handlerType(ApiV1SignupVerificationController::class.java))
-                    match(handler().methodName("verify"))
-                    jsonPath("$.resultCode") { value("200-2") }
-                    jsonPath("$.data.email") { value(email) }
-                    jsonPath("$.data.signupToken") { value(startsWith("")) }
-                }
+            val signupSessionCookie =
+                mvc
+                    .post("/member/api/v1/signup/email/verify") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = """{"token": "$emailVerificationToken"}"""
+                    }.andExpect {
+                        status { isOk() }
+                        match(handler().handlerType(ApiV1SignupVerificationController::class.java))
+                        match(handler().methodName("verify"))
+                        jsonPath("$.resultCode") { value("200-2") }
+                        jsonPath("$.data.email") { value(email) }
+                        jsonPath("$.data.signupToken") { doesNotExist() }
+                    }.andReturn()
+                    .response
+                    .getHeader("Set-Cookie")
+                    .let(::signupSessionCookieFrom)
 
             val refreshed =
                 memberSignupVerificationRepository.findTopByEmailOrderByCreatedAtDesc(email)
                     ?: error("verification row missing after verify")
 
-            val signupToken = refreshed.signupSessionToken ?: error("signup token not issued")
+            assertThat(refreshed.signupSessionTokenHash).isNotBlank()
+            assertThat(refreshed.signupSessionTokenHash).isNotEqualTo(signupSessionCookie.value)
 
             mvc
                 .post("/member/api/v1/signup/complete") {
                     contentType = MediaType.APPLICATION_JSON
+                    cookie(signupSessionCookie)
                     content =
                         """
                         {
-                            "signupToken": "$signupToken",
                             "password": "Abcd1234!",
                             "nickname": "이메일인증회원",
                             "termsVersion": "${activeLegalDocuments.terms.version}",
@@ -256,7 +285,6 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
         fun `signup complete request는 법적 동의 command로 변환된다`() {
             val request =
                 ApiV1SignupVerificationController.SignupCompleteRequest(
-                    signupToken = "signup-token",
                     password = "Abcd1234!",
                     nickname = "동의요청회원",
                     termsVersion = activeLegalDocuments.terms.version,
@@ -291,14 +319,13 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
         }
 
         @Test
-        fun `유효하지 않은 signup token이면 최종 가입을 막는다`() {
+        fun `signup session cookie가 없으면 최종 가입을 막는다`() {
             mvc
                 .post("/member/api/v1/signup/complete") {
                     contentType = MediaType.APPLICATION_JSON
                     content =
                         """
                         {
-                            "signupToken": "invalid-token",
                             "password": "Abcd1234!",
                             "nickname": "이메일인증회원",
                             "termsVersion": "${activeLegalDocuments.terms.version}",
@@ -312,8 +339,8 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
                         }
                         """.trimIndent()
                 }.andExpect {
-                    status { isNotFound() }
-                    jsonPath("$.resultCode") { value("404-2") }
+                    status { isBadRequest() }
+                    jsonPath("$.resultCode") { value("400-2") }
                 }
         }
 
@@ -342,23 +369,16 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
             verification.legalPolicyVersion = null
             memberSignupVerificationRepository.save(verification)
 
-            mvc.get("/member/api/v1/signup/email/verify") {
-                param("token", verification.emailVerificationToken)
-            }
-
-            val signupToken =
-                memberSignupVerificationRepository
-                    .findTopByEmailOrderByCreatedAtDesc(email)
-                    ?.signupSessionToken
-                    ?: error("signup token not issued")
+            val signupSessionCookie =
+                verifySignupEmailAndIssueCookie(emailVerificationTokenFromMailTask(verification.id))
 
             mvc
                 .post("/member/api/v1/signup/complete") {
                     contentType = MediaType.APPLICATION_JSON
+                    cookie(signupSessionCookie)
                     content =
                         """
                         {
-                            "signupToken": "$signupToken",
                             "password": "Abcd1234!",
                             "nickname": "동의누락회원",
                             "termsVersion": "${activeLegalDocuments.terms.version}",
@@ -401,23 +421,16 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
                 memberSignupVerificationRepository.findTopByEmailOrderByCreatedAtDesc(email)
                     ?: error("verification row not created")
 
-            mvc.get("/member/api/v1/signup/email/verify") {
-                param("token", verification.emailVerificationToken)
-            }
-
-            val signupToken =
-                memberSignupVerificationRepository
-                    .findTopByEmailOrderByCreatedAtDesc(email)
-                    ?.signupSessionToken
-                    ?: error("signup token not issued")
+            val signupSessionCookie =
+                verifySignupEmailAndIssueCookie(emailVerificationTokenFromMailTask(verification.id))
 
             mvc
                 .post("/member/api/v1/signup/complete") {
                     contentType = MediaType.APPLICATION_JSON
+                    cookie(signupSessionCookie)
                     content =
                         """
                         {
-                            "signupToken": "$signupToken",
                             "username": "legacy-signup-user",
                             "password": "Abcd1234!",
                             "nickname": "레거시회원",
@@ -439,15 +452,15 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
         @Test
         fun `만 14세 이상 확인이 없으면 최종 가입을 막고 member를 생성하지 않는다`() {
             val email = "under-age-direct@example.com"
-            val signupToken = issueSignupToken(email)
+            val signupSessionCookie = issueSignupSessionCookie(email)
 
             mvc
                 .post("/member/api/v1/signup/complete") {
                     contentType = MediaType.APPLICATION_JSON
+                    cookie(signupSessionCookie)
                     content =
                         """
                         {
-                            "signupToken": "$signupToken",
                             "password": "Abcd1234!",
                             "nickname": "연령미확인회원",
                             "termsVersion": "${activeLegalDocuments.terms.version}",
@@ -472,15 +485,15 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
         @Test
         fun `필수 개인정보 처리 확인이 없으면 최종 가입을 막고 member를 생성하지 않는다`() {
             val email = "missing-required-privacy@example.com"
-            val signupToken = issueSignupToken(email)
+            val signupSessionCookie = issueSignupSessionCookie(email)
 
             mvc
                 .post("/member/api/v1/signup/complete") {
                     contentType = MediaType.APPLICATION_JSON
+                    cookie(signupSessionCookie)
                     content =
                         """
                         {
-                            "signupToken": "$signupToken",
                             "password": "Abcd1234!",
                             "nickname": "개인정보미확인회원",
                             "termsVersion": "${activeLegalDocuments.terms.version}",
@@ -505,15 +518,15 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
         @Test
         fun `국외 이전 안내 확인이 없으면 최종 가입을 막고 member를 생성하지 않는다`() {
             val email = "missing-overseas-transfer@example.com"
-            val signupToken = issueSignupToken(email)
+            val signupSessionCookie = issueSignupSessionCookie(email)
 
             mvc
                 .post("/member/api/v1/signup/complete") {
                     contentType = MediaType.APPLICATION_JSON
+                    cookie(signupSessionCookie)
                     content =
                         """
                         {
-                            "signupToken": "$signupToken",
                             "password": "Abcd1234!",
                             "nickname": "국외이전미확인회원",
                             "termsVersion": "${activeLegalDocuments.terms.version}",
@@ -538,15 +551,15 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
         @Test
         fun `정책 hash가 최신 active 문서와 다르면 최종 가입을 409로 막는다`() {
             val email = "stale-policy@example.com"
-            val signupToken = issueSignupToken(email)
+            val signupSessionCookie = issueSignupSessionCookie(email)
 
             mvc
                 .post("/member/api/v1/signup/complete") {
                     contentType = MediaType.APPLICATION_JSON
+                    cookie(signupSessionCookie)
                     content =
                         """
                         {
-                            "signupToken": "$signupToken",
                             "password": "Abcd1234!",
                             "nickname": "오래된정책회원",
                             "termsVersion": "${activeLegalDocuments.terms.version}",
@@ -571,15 +584,15 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
         @Test
         fun `가입 시작에 저장된 정책 버전이 최신 active 문서와 다르면 최종 가입을 409로 막는다`() {
             val email = "stale-start-policy@example.com"
-            val signupToken = issueSignupToken(email, legalPolicyVersion = "2026-01-01")
+            val signupSessionCookie = issueSignupSessionCookie(email, legalPolicyVersion = "2026-01-01")
 
             mvc
                 .post("/member/api/v1/signup/complete") {
                     contentType = MediaType.APPLICATION_JSON
+                    cookie(signupSessionCookie)
                     content =
                         """
                         {
-                            "signupToken": "$signupToken",
                             "password": "Abcd1234!",
                             "nickname": "오래된시작정책회원",
                             "termsVersion": "${activeLegalDocuments.terms.version}",
@@ -601,10 +614,10 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
             assertThat(memberApplicationService.findByEmail(email)).isNull()
         }
 
-        private fun issueSignupToken(
+        private fun issueSignupSessionCookie(
             email: String,
             legalPolicyVersion: String = this@ApiV1SignupVerificationControllerTest.legalPolicyVersion,
-        ): String {
+        ): Cookie {
             mvc.post("/member/api/v1/signup/email/start") {
                 contentType = MediaType.APPLICATION_JSON
                 content =
@@ -622,14 +635,49 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
                 memberSignupVerificationRepository.findTopByEmailOrderByCreatedAtDesc(email)
                     ?: error("verification row not created")
 
-            mvc.get("/member/api/v1/signup/email/verify") {
-                param("token", verification.emailVerificationToken)
-            }
-
-            return memberSignupVerificationRepository
-                .findTopByEmailOrderByCreatedAtDesc(email)
-                ?.signupSessionToken
-                ?: error("signup token not issued")
+            return verifySignupEmailAndIssueCookie(emailVerificationTokenFromMailTask(verification.id))
         }
+
+        private fun verifySignupEmailAndIssueCookie(emailVerificationToken: String): Cookie =
+            mvc
+                .post("/member/api/v1/signup/email/verify") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = """{"token": "$emailVerificationToken"}"""
+                }.andExpect {
+                    status { isOk() }
+                }.andReturn()
+                .response
+                .getHeader("Set-Cookie")
+                .let(::signupSessionCookieFrom)
+
+        private fun signupSessionCookieFrom(setCookieHeader: String?): Cookie {
+            val headerValue = setCookieHeader ?: error("signup session cookie not issued")
+            assertThat(headerValue).contains("$SIGNUP_SESSION_COOKIE_NAME=")
+            assertThat(headerValue).contains("HttpOnly")
+            assertThat(headerValue).contains("Secure")
+            assertThat(headerValue).contains("SameSite=Strict")
+
+            val cookieValue = headerValue.substringBefore(";").substringAfter("=")
+            assertThat(cookieValue).isNotBlank()
+            return Cookie(SIGNUP_SESSION_COOKIE_NAME, cookieValue)
+        }
+    }
+
+    private fun emailVerificationTokenFromMailTask(verificationId: Long): String {
+        val payload =
+            taskRepository
+                .findAll()
+                .single {
+                    it.taskType == "member.signupVerification.sendMail" &&
+                        it.aggregateId == verificationId
+                }.payload
+        val encodedToken =
+            Regex("#token=([^\"\\\\\\s<]+)")
+                .find(payload)
+                ?.groupValues
+                ?.get(1)
+                ?: error("verification token fragment not found")
+
+        return URLDecoder.decode(encodedToken, StandardCharsets.UTF_8)
     }
 }

--- a/deploy/homeserver/caddy/Caddyfile
+++ b/deploy/homeserver/caddy/Caddyfile
@@ -112,6 +112,10 @@ http://{$API_DOMAIN} {
 
   @notificationSse path /member/api/v1/notifications/stream
   log_skip @notificationSse
+
+  @signupVerifySensitive path /member/api/v1/signup/email/verify
+  log_skip @signupVerifySensitive
+
   handle @notificationSse {
     header {
       Cache-Control "no-cache, no-transform"

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -957,6 +957,50 @@
         } ]
       }
     },
+    "/member/api/v1/signup/email/verify" : {
+      "get" : {
+        "tags" : [ "api-v-1-signup-verification-controller" ],
+        "operationId" : "verifyLegacyGet",
+        "responses" : {
+          "410" : {
+            "description" : "Gone",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RsDataVoid"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "api-v-1-signup-verification-controller" ],
+        "operationId" : "verify",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SignupEmailVerifyRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RsDataSignupEmailVerifyResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/member/api/v1/signup/email/start" : {
       "post" : {
         "tags" : [ "api-v-1-signup-verification-controller" ],
@@ -2306,32 +2350,6 @@
         "security" : [ {
           "bearerAuth" : [ ]
         } ]
-      }
-    },
-    "/member/api/v1/signup/email/verify" : {
-      "get" : {
-        "tags" : [ "api-v-1-signup-verification-controller" ],
-        "operationId" : "verify",
-        "parameters" : [ {
-          "name" : "token",
-          "in" : "query",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/RsDataSignupEmailVerifyResult"
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/member/api/v1/notifications" : {
@@ -3968,6 +3986,42 @@
           }
         }
       },
+      "SignupEmailVerifyRequest" : {
+        "type" : "object",
+        "properties" : {
+          "token" : {
+            "type" : "string",
+            "minLength" : 1
+          }
+        },
+        "required" : [ "token" ]
+      },
+      "RsDataSignupEmailVerifyResult" : {
+        "type" : "object",
+        "properties" : {
+          "resultCode" : {
+            "type" : "string"
+          },
+          "msg" : {
+            "type" : "string"
+          },
+          "data" : {
+            "$ref" : "#/components/schemas/SignupEmailVerifyResult"
+          }
+        }
+      },
+      "SignupEmailVerifyResult" : {
+        "type" : "object",
+        "properties" : {
+          "email" : {
+            "type" : "string"
+          },
+          "expiresAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }
+      },
       "SignupEmailStartRequest" : {
         "type" : "object",
         "properties" : {
@@ -4018,10 +4072,6 @@
       "SignupCompleteRequest" : {
         "type" : "object",
         "properties" : {
-          "signupToken" : {
-            "type" : "string",
-            "minLength" : 1
-          },
           "username" : {
             "type" : "string",
             "pattern" : "^$"
@@ -4070,7 +4120,7 @@
             "type" : "boolean"
           }
         },
-        "required" : [ "age14OrOlder", "analyticsConsent", "nickname", "overseasTransferAcknowledged", "password", "privacyContentSha256", "privacyVersion", "requiredPrivacyConfirmed", "signupToken", "termsContentSha256", "termsVersion" ]
+        "required" : [ "age14OrOlder", "analyticsConsent", "nickname", "overseasTransferAcknowledged", "password", "privacyContentSha256", "privacyVersion", "requiredPrivacyConfirmed", "termsContentSha256", "termsVersion" ]
       },
       "MemberDto" : {
         "type" : "object",
@@ -5273,35 +5323,6 @@
           },
           "firstPage" : {
             "$ref" : "#/components/schemas/PageDtoPostDto"
-          }
-        }
-      },
-      "RsDataSignupEmailVerifyResult" : {
-        "type" : "object",
-        "properties" : {
-          "resultCode" : {
-            "type" : "string"
-          },
-          "msg" : {
-            "type" : "string"
-          },
-          "data" : {
-            "$ref" : "#/components/schemas/SignupEmailVerifyResult"
-          }
-        }
-      },
-      "SignupEmailVerifyResult" : {
-        "type" : "object",
-        "properties" : {
-          "email" : {
-            "type" : "string"
-          },
-          "signupToken" : {
-            "type" : "string"
-          },
-          "expiresAt" : {
-            "type" : "string",
-            "format" : "date-time"
           }
         }
       },

--- a/front/e2e/signup-token-url.spec.ts
+++ b/front/e2e/signup-token-url.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test"
+import fs from "node:fs"
+import path from "node:path"
+
+const repoRoot = path.resolve(__dirname, "../..")
+
+const readRepoFile = (relativePath: string) => fs.readFileSync(path.join(repoRoot, relativePath), "utf8")
+
+test("signup verify flow keeps token and completion email out of query URLs", () => {
+  const signupVerifyPage = readRepoFile("front/src/pages/signup/verify.tsx")
+  const signupVerificationService = readRepoFile(
+    "back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/MemberSignupVerificationService.kt",
+  )
+  const signupVerificationController = readRepoFile(
+    "back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt",
+  )
+
+  expect(signupVerifyPage).toContain("window.location.hash")
+  expect(signupVerifyPage).toContain("window.history.replaceState")
+  expect(signupVerifyPage).toContain('"/member/api/v1/signup/email/verify"')
+  expect(signupVerifyPage).not.toContain("router.query.token")
+  expect(signupVerifyPage).not.toContain("/email/verify?token=")
+  expect(signupVerifyPage).not.toContain("signup=done&email=")
+  expect(signupVerifyPage).not.toContain("signupToken:")
+
+  expect(signupVerificationService).toContain('append("#token=")')
+  expect(signupVerificationService).not.toContain('append("?token=")')
+  expect(signupVerificationService).not.toContain("findByEmailVerificationToken(")
+  expect(signupVerificationService).not.toContain("findBySignupSessionToken(")
+
+  expect(signupVerificationController).toContain("SIGNUP_SESSION_COOKIE_NAME")
+  expect(signupVerificationController).toContain("@PostMapping(\"/email/verify\")")
+  expect(signupVerificationController).toContain("@GetMapping(\"/email/verify\")")
+  expect(signupVerificationController).not.toContain("@RequestParam token")
+})

--- a/front/e2e/signup-token-url.spec.ts
+++ b/front/e2e/signup-token-url.spec.ts
@@ -17,6 +17,8 @@ test("signup verify flow keeps token and completion email out of query URLs", ()
 
   expect(signupVerifyPage).toContain("window.location.hash")
   expect(signupVerifyPage).toContain("window.history.replaceState")
+  expect(signupVerifyPage).toContain("verificationTokenRef.current ?? readSignupVerificationTokenFromFragment()")
+  expect(signupVerifyPage).toContain("setVerifyRetryCount")
   expect(signupVerifyPage).toContain('"/member/api/v1/signup/email/verify"')
   expect(signupVerifyPage).not.toContain("router.query.token")
   expect(signupVerifyPage).not.toContain("/email/verify?token=")

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -326,6 +326,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/member/api/v1/signup/email/verify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["verifyLegacyGet"];
+        put?: never;
+        post: operations["verify"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/member/api/v1/signup/email/start": {
         parameters: {
             query?: never;
@@ -980,22 +996,6 @@ export interface paths {
         };
         /** 관리자 글 작업공간 bootstrap */
         get: operations["bootstrap_1"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/member/api/v1/signup/email/verify": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["verify"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1715,6 +1715,19 @@ export interface components {
             msg?: string;
             data?: components["schemas"]["RecommendTagsResBody"];
         };
+        SignupEmailVerifyRequest: {
+            token: string;
+        };
+        RsDataSignupEmailVerifyResult: {
+            resultCode?: string;
+            msg?: string;
+            data?: components["schemas"]["SignupEmailVerifyResult"];
+        };
+        SignupEmailVerifyResult: {
+            email?: string;
+            /** Format: date-time */
+            expiresAt?: string;
+        };
         SignupEmailStartRequest: {
             /** Format: email */
             email: string;
@@ -1732,7 +1745,6 @@ export interface components {
             email?: string;
         };
         SignupCompleteRequest: {
-            signupToken: string;
             username?: string;
             password: string;
             nickname: string;
@@ -2199,17 +2211,6 @@ export interface components {
         AdminPostsBootstrapResBody: {
             member?: components["schemas"]["AuthSessionMemberDto"];
             firstPage?: components["schemas"]["PageDtoPostDto"];
-        };
-        RsDataSignupEmailVerifyResult: {
-            resultCode?: string;
-            msg?: string;
-            data?: components["schemas"]["SignupEmailVerifyResult"];
-        };
-        SignupEmailVerifyResult: {
-            email?: string;
-            signupToken?: string;
-            /** Format: date-time */
-            expiresAt?: string;
         };
         MemberNotificationDto: {
             /** Format: int64 */
@@ -2960,6 +2961,50 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["RsDataRecommendTagsResBody"];
+                };
+            };
+        };
+    };
+    verifyLegacyGet: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Gone */
+            410: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    verify: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SignupEmailVerifyRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RsDataSignupEmailVerifyResult"];
                 };
             };
         };
@@ -3931,28 +3976,6 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["AdminPostsBootstrapResBody"];
-                };
-            };
-        };
-    };
-    verify: {
-        parameters: {
-            query: {
-                token: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["RsDataSignupEmailVerifyResult"];
                 };
             };
         };

--- a/front/src/pages/signup/verify.tsx
+++ b/front/src/pages/signup/verify.tsx
@@ -54,6 +54,7 @@ const SignupVerifyPage = () => {
   const [overseasTransferAcknowledged, setOverseasTransferAcknowledged] = useState(false)
   const [submitError, setSubmitError] = useState("")
   const [submitLoading, setSubmitLoading] = useState(false)
+  const [verifyRetryCount, setVerifyRetryCount] = useState(0)
   const verificationTokenRef = useRef<string | null>(null)
 
   const next = useMemo(() => {
@@ -102,7 +103,12 @@ const SignupVerifyPage = () => {
     return () => {
       cancelled = true
     }
-  }, [router.isReady])
+  }, [router.isReady, verifyRetryCount])
+
+  const retryVerification = () => {
+    if (!verificationTokenRef.current) return
+    setVerifyRetryCount((value) => value + 1)
+  }
 
   const passwordPolicy = useMemo(() => evaluatePasswordPolicy(password), [password])
   const hasPasswordInput = password.length > 0
@@ -189,7 +195,12 @@ const SignupVerifyPage = () => {
       {loadingVerification ? (
         <InfoText>회원가입 링크를 확인하고 있습니다...</InfoText>
       ) : verificationError ? (
-        <ErrorText>{verificationError}</ErrorText>
+        <ErrorPanel>
+          <ErrorText>{verificationError}</ErrorText>
+          <GhostButton type="button" onClick={retryVerification} disabled={!verificationTokenRef.current}>
+            다시 확인
+          </GhostButton>
+        </ErrorPanel>
       ) : verification ? (
         <form onSubmit={onSubmit}>
           <Field>
@@ -513,6 +524,16 @@ const GhostButton = styled.button`
   color: ${({ theme }) => theme.colors.gray12};
   cursor: pointer;
   white-space: nowrap;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`
+
+const ErrorPanel = styled.div`
+  display: grid;
+  gap: 0.8rem;
 `
 
 const PrimaryButton = styled.button`

--- a/front/src/pages/signup/verify.tsx
+++ b/front/src/pages/signup/verify.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled"
 import { GetServerSideProps } from "next"
 import Link from "next/link"
 import { useRouter } from "next/router"
-import { FormEvent, useEffect, useMemo, useState } from "react"
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react"
 import { apiFetch } from "src/apis/backend/client"
 import { toAuthErrorMessage } from "src/apis/backend/errorMessages"
 import { ACTIVE_LEGAL_DOCUMENTS, buildEmailSignupLegalAcceptancePayload } from "src/apis/backend/legal"
@@ -20,12 +20,23 @@ type RsData<T> = {
 
 type SignupVerifyResult = {
   email: string
-  signupToken: string
   expiresAt: string
 }
 
 export const getServerSideProps: GetServerSideProps<GuestPageProps> = async ({ req }) => {
   return await getGuestPageProps(req)
+}
+
+const readSignupVerificationTokenFromFragment = () => {
+  if (typeof window === "undefined") return null
+
+  const fragment = window.location.hash.replace(/^#/, "")
+  const params = new URLSearchParams(fragment)
+  const token = params.get("token")?.trim() || null
+  const cleanUrl = `${window.location.pathname}${window.location.search}`
+  window.history.replaceState(window.history.state, "", cleanUrl)
+
+  return token
 }
 
 const SignupVerifyPage = () => {
@@ -43,17 +54,17 @@ const SignupVerifyPage = () => {
   const [overseasTransferAcknowledged, setOverseasTransferAcknowledged] = useState(false)
   const [submitError, setSubmitError] = useState("")
   const [submitLoading, setSubmitLoading] = useState(false)
+  const verificationTokenRef = useRef<string | null>(null)
 
-  const token = useMemo(() => {
-    const raw = router.query.token
-    return Array.isArray(raw) ? raw[0] : raw
-  }, [router.query.token])
   const next = useMemo(() => {
     return normalizeNextPath(router.query.next)
   }, [router.query.next])
 
   useEffect(() => {
     if (!router.isReady) return
+
+    const token = verificationTokenRef.current ?? readSignupVerificationTokenFromFragment()
+    verificationTokenRef.current = token
 
     if (!token) {
       setVerificationError("회원가입 링크가 올바르지 않습니다.")
@@ -69,7 +80,11 @@ const SignupVerifyPage = () => {
 
       try {
         const response = await apiFetch<RsData<SignupVerifyResult>>(
-          `/member/api/v1/signup/email/verify?token=${encodeURIComponent(token)}`
+          "/member/api/v1/signup/email/verify",
+          {
+            method: "POST",
+            body: JSON.stringify({ token }),
+          }
         )
 
         if (cancelled) return
@@ -87,7 +102,7 @@ const SignupVerifyPage = () => {
     return () => {
       cancelled = true
     }
-  }, [router.isReady, token])
+  }, [router.isReady])
 
   const passwordPolicy = useMemo(() => evaluatePasswordPolicy(password), [password])
   const hasPasswordInput = password.length > 0
@@ -104,7 +119,7 @@ const SignupVerifyPage = () => {
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
 
-    if (!verification?.signupToken) {
+    if (!verification) {
       setSubmitError("회원가입 세션이 준비되지 않았습니다.")
       return
     }
@@ -136,7 +151,6 @@ const SignupVerifyPage = () => {
       await apiFetch<RsData<unknown>>("/member/api/v1/signup/complete", {
         method: "POST",
         body: JSON.stringify({
-          signupToken: verification.signupToken,
           password,
           nickname: nickname.trim(),
           ...buildEmailSignupLegalAcceptancePayload({
@@ -148,10 +162,7 @@ const SignupVerifyPage = () => {
         }),
       })
 
-      await replaceRoute(
-        router,
-        `/login?signup=done&email=${encodeURIComponent(verification.email)}&next=${encodeURIComponent(next)}`
-      )
+      await replaceRoute(router, `/login?signup=done&next=${encodeURIComponent(next)}`)
     } catch (error) {
       setSubmitError(toAuthErrorMessage("signupComplete", error, "회원가입에 실패했습니다."))
     } finally {

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -9,6 +9,7 @@ const repoRoot = path.resolve(import.meta.dirname, "../..")
 const contractPath = path.join(repoRoot, "deploy/env/env.contract.json")
 const workflowPath = path.join(repoRoot, ".github/workflows/deploy.yml")
 const composePath = path.join(repoRoot, "deploy/homeserver/docker-compose.prod.yml")
+const caddyfilePath = path.join(repoRoot, "deploy/homeserver/caddy/Caddyfile")
 const applicationProdPath = path.join(repoRoot, "back/src/main/resources/application-prod.yaml")
 const deployScriptPath = path.join(repoRoot, "deploy/homeserver/blue_green_deploy.sh")
 const deployBackupScriptPath = path.join(repoRoot, "deploy/homeserver/create_deploy_backup.sh")
@@ -228,6 +229,22 @@ test("home-server-source contract accepts a complete deployment env without BACK
   })
 
   assert.equal(result.ok, true, result.errors.map((error) => error.message).join("\n"))
+})
+
+test("Caddy access logs skip signup verification endpoint before proxying", () => {
+  const caddyfile = readFileSync(caddyfilePath, "utf8")
+  const matcherIndex = caddyfile.indexOf("@signupVerifySensitive path /member/api/v1/signup/email/verify")
+  const skipIndex = caddyfile.indexOf("log_skip @signupVerifySensitive")
+  const apiBlockIndex = caddyfile.indexOf("http://{$API_DOMAIN}")
+  const proxyIndex = caddyfile.indexOf("reverse_proxy {$ADMIN_API_UPSTREAM:back_blue}:8080", apiBlockIndex)
+
+  assert.notEqual(apiBlockIndex, -1, "API domain block must be configured")
+  assert.notEqual(matcherIndex, -1, "signup verify sensitive matcher must be configured")
+  assert.notEqual(skipIndex, -1, "signup verify access log skip must be configured")
+  assert(skipIndex > matcherIndex, "signup verify log_skip must reference the sensitive matcher")
+  assert(skipIndex < proxyIndex, "signup verify log_skip must be declared before API proxy handling")
+  assert(!caddyfile.includes("?token="), "Caddy config must not preserve signup verification token query examples")
+  assert(!caddyfile.includes("signup=done&email="), "Caddy config must not preserve signup completion email query examples")
 })
 
 test("home-server-source contract allows no-auth operations alert SMTP relay", async () => {


### PR DESCRIPTION
## 관련 이슈

close #998

## 작업 배경

- 회원가입 이메일 인증 token과 가입 완료 email이 URL query에 남으면 browser history, proxy access log, analytics, error report에 노출될 수 있다.
- signup verification/session token을 DB에 원문 저장하면 DB 유출 시 미완료 가입 세션을 탈취할 수 있다.

## 작업 내용

- 이메일 인증 링크를 `/signup/verify#token=...` fragment 방식으로 바꾸고, verify page가 fragment를 읽은 즉시 `history.replaceState`로 제거하도록 변경했다.
- `/member/api/v1/signup/email/verify`를 POST JSON body 기반으로 전환하고, legacy GET query 인증은 410 응답만 반환하게 했다.
- verify 응답에서 `signupToken`을 제거하고, signup session은 HttpOnly/Secure/SameSite=Strict `signup_session` cookie로만 전달하게 했다.
- complete 요청 body에서 `signupToken`을 제거하고, backend가 cookie의 session token으로 가입을 완료하게 했다.
- DB 저장/lookup을 raw token 컬럼에서 `email_verification_token_hash`, `signup_session_token_hash` HMAC lookup으로 전환하고 Flyway migration 및 test baseline을 갱신했다.
- Caddy access log에서 signup verify endpoint를 `log_skip` 처리해 legacy query 요청이 들어와도 access log에 token query가 남지 않게 했다.
- OpenAPI snapshot/shared contract와 signup token URL canary test를 갱신했다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back ktlintCheck` pass
  - `back/gradlew -p back test` pass
  - `yarn --cwd front install --frozen-lockfile` pass
  - `yarn --cwd front build` pass
  - `yarn --cwd front playwright:preflight` pass
  - `yarn --cwd front playwright test e2e/signup-token-url.spec.ts --workers=1` pass
  - `yarn --cwd front contracts:check` pass
  - `node --test tools/test/env-contract.test.mjs` pass
  - `rg -n "/email/verify\\?token=|signup=done&email|router\\.query\\.token|\\\"signupToken\\\"\\s*:|\\?token=test-signup-mail" front/src back/src/main deploy/homeserver .github || true` no matches
  - `yarn --cwd front playwright test e2e/live.spec.ts --workers=1` local environment fail: `/feed` returned 500 because local backend URL resolution hit `fetch failed` / `bad port`; this is not caused by the signup change and needs live/deployed environment rerun after merge.

## 리뷰어 메모

- 먼저 볼 지점:
  - `ApiV1SignupVerificationController.kt`: POST verify, legacy GET 410, HttpOnly signup cookie, complete body token 제거
  - `MemberSignupVerificationService.kt` / `SignupTokenHashService.kt`: raw token 생성 직후 HMAC 저장 및 hash lookup
  - `V20260622_02__hash_signup_verification_tokens.sql`: raw token 컬럼 제거와 hash 컬럼 전환
  - `signup-token-url.spec.ts` / `env-contract.test.mjs`: URL/query/log 회귀 가드

## 리스크

- 기존에 발송된 구형 `?token=` 회원가입 링크는 더 이상 완료되지 않고 410으로 실패한다. token 노출 제거 목적상 의도된 차단이며, 사용자는 새 인증 메일을 요청해야 한다.
- migration 시 기존 미완료 signup session은 hash로 복구하지 않고 무효화된다. 이미 가입 완료된 member에는 영향이 없다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 강화**
  * 회원가입 인증 토큰을 해시 기반으로 저장하도록 변경하여 보안성 개선
  * API 엔드포인트의 민감한 요청에 대한 로깅 비활성화

* **API 변경**
  * 이메일 검증 요청이 GET에서 POST로 변경되고, 토큰은 URL 프래그먼트(`#token=`)로 전달되도록 개선
  * 회원가입 완료 요청이 쿠키 기반 인증으로 처리되도록 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->