### PR TITLE
[Feat] Kakao OAuth 신규 가입 pending 동의 흐름 전환

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/config/MemberSecurityConfigurer.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/config/MemberSecurityConfigurer.kt
@@ -28,6 +28,8 @@ class MemberSecurityConfigurer(
             add(PublicApiRouteSpec("/member/api/*/signup/email/verify", HttpMethod.GET))
             add(PublicApiRouteSpec("/member/api/*/signup/email/verify", HttpMethod.POST))
             add(PublicApiRouteSpec("/member/api/*/signup/complete", HttpMethod.POST))
+            add(PublicApiRouteSpec("/member/api/*/signup/social/pending", HttpMethod.POST))
+            add(PublicApiRouteSpec("/member/api/*/signup/social/complete", HttpMethod.POST))
         }
 
     fun configure(authorize: AuthorizeHttpRequestsDsl) {

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/ActiveLegalDocumentMetadata.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/ActiveLegalDocumentMetadata.kt
@@ -22,7 +22,7 @@ data class ActiveLegalDocumentMetadata(
                 privacy =
                     LegalDocumentMetadata(
                         version = "2026-06-21",
-                        contentSha256 = "4cc6ae3260aaca5f5ff35b235af91679a60760f13dccad9e85c94fda4d1552d9",
+                        contentSha256 = "cedbfea674a9e2aca9e29bf6a01492a1e3fa640b0ff53d47f969d64c057b980f",
                     ),
             )
     }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/LegalAcceptanceApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/LegalAcceptanceApplicationService.kt
@@ -62,6 +62,33 @@ class LegalAcceptanceApplicationService(
         member: Member,
         command: LegalAcceptanceCommand,
         acceptedAt: Instant,
+    ): MemberLegalAcceptance =
+        recordSignupAcceptance(
+            member = member,
+            command = command,
+            acceptedAt = acceptedAt,
+            source = "EMAIL_SIGNUP",
+        )
+
+    @Transactional
+    fun recordSocialSignupAcceptance(
+        member: Member,
+        command: LegalAcceptanceCommand,
+        acceptedAt: Instant,
+        source: String,
+    ): MemberLegalAcceptance =
+        recordSignupAcceptance(
+            member = member,
+            command = command,
+            acceptedAt = acceptedAt,
+            source = source,
+        )
+
+    private fun recordSignupAcceptance(
+        member: Member,
+        command: LegalAcceptanceCommand,
+        acceptedAt: Instant,
+        source: String,
     ): MemberLegalAcceptance {
         validateEmailSignupAcceptance(command)
 
@@ -76,7 +103,7 @@ class LegalAcceptanceApplicationService(
                 requiredPrivacyConfirmed = command.requiredPrivacyConfirmed,
                 analyticsConsent = command.analyticsConsent,
                 overseasTransferAcknowledged = command.overseasTransferAcknowledged,
-                source = "EMAIL_SIGNUP",
+                source = source.trim().take(32),
                 acceptedAt = acceptedAt,
             ),
         )

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepository.kt
@@ -1,6 +1,6 @@
 package com.back.boundedContexts.member.subContexts.oauthSignup.adapter.persistence
 
-import com.back.boundedContexts.member.subContexts.oauthSignup.domain.PendingOAuthSignup
+import com.back.boundedContexts.member.subContexts.oauthSignup.model.PendingOAuthSignup
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface PendingOAuthSignupRepository : JpaRepository<PendingOAuthSignup, Long> {

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepository.kt
@@ -1,0 +1,13 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.adapter.persistence
+
+import com.back.boundedContexts.member.subContexts.oauthSignup.domain.PendingOAuthSignup
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PendingOAuthSignupRepository : JpaRepository<PendingOAuthSignup, Long> {
+    fun findByProviderAndProviderSubjectHash(
+        provider: String,
+        providerSubjectHash: String,
+    ): PendingOAuthSignup?
+
+    fun findByPendingTokenHash(pendingTokenHash: String): PendingOAuthSignup?
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepositoryAdapter.kt
@@ -1,7 +1,7 @@
 package com.back.boundedContexts.member.subContexts.oauthSignup.adapter.persistence
 
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.output.PendingOAuthSignupRepositoryPort
-import com.back.boundedContexts.member.subContexts.oauthSignup.domain.PendingOAuthSignup
+import com.back.boundedContexts.member.subContexts.oauthSignup.model.PendingOAuthSignup
 import org.springframework.stereotype.Component
 
 @Component

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepositoryAdapter.kt
@@ -1,0 +1,24 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.adapter.persistence
+
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.output.PendingOAuthSignupRepositoryPort
+import com.back.boundedContexts.member.subContexts.oauthSignup.domain.PendingOAuthSignup
+import org.springframework.stereotype.Component
+
+@Component
+class PendingOAuthSignupRepositoryAdapter(
+    private val pendingOAuthSignupRepository: PendingOAuthSignupRepository,
+) : PendingOAuthSignupRepositoryPort {
+    override fun save(pendingOAuthSignup: PendingOAuthSignup): PendingOAuthSignup = pendingOAuthSignupRepository.save(pendingOAuthSignup)
+
+    override fun findByProviderAndProviderSubjectHash(
+        provider: String,
+        providerSubjectHash: String,
+    ): PendingOAuthSignup? =
+        pendingOAuthSignupRepository.findByProviderAndProviderSubjectHash(
+            provider = provider,
+            providerSubjectHash = providerSubjectHash,
+        )
+
+    override fun findByPendingTokenHash(pendingTokenHash: String): PendingOAuthSignup? =
+        pendingOAuthSignupRepository.findByPendingTokenHash(pendingTokenHash)
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/web/ApiV1OAuthSignupController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/web/ApiV1OAuthSignupController.kt
@@ -1,0 +1,99 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.adapter.web
+
+import com.back.boundedContexts.member.dto.MemberDto
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupPendingDetails
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupUseCase
+import com.back.global.rsData.RsData
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import org.springframework.http.HttpStatus
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/member/api/v1/signup/social")
+class ApiV1OAuthSignupController(
+    private val oauthSignupUseCase: OAuthSignupUseCase,
+) {
+    data class SocialSignupPendingRequest(
+        @field:NotBlank
+        val token: String,
+    )
+
+    data class SocialSignupCompleteRequest(
+        @field:NotBlank
+        val token: String,
+        @field:Size(min = 2, max = 30)
+        val nickname: String? = null,
+        @field:NotBlank
+        @field:Size(max = 32)
+        val termsVersion: String,
+        @field:NotBlank
+        @field:Size(min = 64, max = 64)
+        val termsContentSha256: String,
+        @field:NotBlank
+        @field:Size(max = 32)
+        val privacyVersion: String,
+        @field:NotBlank
+        @field:Size(min = 64, max = 64)
+        val privacyContentSha256: String,
+        @field:Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        val age14OrOlder: Boolean,
+        @field:Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        val requiredPrivacyConfirmed: Boolean,
+        @field:Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        val analyticsConsent: Boolean,
+        @field:Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        val overseasTransferAcknowledged: Boolean,
+    ) {
+        fun toLegalAcceptanceCommand(): LegalAcceptanceCommand =
+            LegalAcceptanceCommand(
+                termsVersion = termsVersion,
+                termsContentSha256 = termsContentSha256,
+                privacyVersion = privacyVersion,
+                privacyContentSha256 = privacyContentSha256,
+                age14OrOlder = age14OrOlder,
+                requiredPrivacyConfirmed = requiredPrivacyConfirmed,
+                analyticsConsent = analyticsConsent,
+                overseasTransferAcknowledged = overseasTransferAcknowledged,
+            )
+    }
+
+    @PostMapping("/pending")
+    @Transactional(readOnly = true)
+    fun pending(
+        @RequestBody @Valid reqBody: SocialSignupPendingRequest,
+    ): RsData<OAuthSignupPendingDetails> =
+        RsData(
+            "200-3",
+            "소셜 회원가입 세션을 확인했습니다.",
+            oauthSignupUseCase.findPending(reqBody.token),
+        )
+
+    @PostMapping("/complete")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Transactional
+    fun complete(
+        @RequestBody @Valid reqBody: SocialSignupCompleteRequest,
+    ): RsData<MemberDto> {
+        val member =
+            oauthSignupUseCase.completeSignup(
+                pendingToken = reqBody.token,
+                nickname = reqBody.nickname,
+                legalAcceptance = reqBody.toLegalAcceptanceCommand(),
+            )
+
+        return RsData(
+            "201-3",
+            "${member.nickname}님 환영합니다. 소셜 회원가입이 완료되었습니다.",
+            MemberDto(member),
+        )
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/web/ApiV1OAuthSignupController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/web/ApiV1OAuthSignupController.kt
@@ -2,8 +2,8 @@ package com.back.boundedContexts.member.subContexts.oauthSignup.adapter.web
 
 import com.back.boundedContexts.member.dto.MemberDto
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
-import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupPendingDetails
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupUseCase
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingDetails
 import com.back.global.rsData.RsData
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/port/input/OAuthSignupUseCase.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/port/input/OAuthSignupUseCase.kt
@@ -1,0 +1,45 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
+import java.time.Instant
+
+data class OAuthSignupPendingStartResult(
+    val provider: String,
+    val pendingToken: String,
+    val expiresAt: Instant,
+)
+
+data class OAuthSignupPendingDetails(
+    val provider: String,
+    val nickname: String,
+    val profileImgUrl: String?,
+    val expiresAt: Instant,
+)
+
+interface OAuthSignupUseCase {
+    fun providerSubjectHash(
+        provider: String,
+        providerSubject: String,
+    ): String
+
+    fun memberLoginId(
+        provider: String,
+        providerSubjectHash: String,
+    ): String
+
+    fun startPending(
+        provider: String,
+        providerSubject: String,
+        nickname: String,
+        profileImgUrl: String?,
+    ): OAuthSignupPendingStartResult
+
+    fun findPending(pendingToken: String): OAuthSignupPendingDetails
+
+    fun completeSignup(
+        pendingToken: String,
+        nickname: String?,
+        legalAcceptance: LegalAcceptanceCommand,
+    ): Member
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/port/input/OAuthSignupUseCase.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/port/input/OAuthSignupUseCase.kt
@@ -2,20 +2,8 @@ package com.back.boundedContexts.member.subContexts.oauthSignup.application.port
 
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
-import java.time.Instant
-
-data class OAuthSignupPendingStartResult(
-    val provider: String,
-    val pendingToken: String,
-    val expiresAt: Instant,
-)
-
-data class OAuthSignupPendingDetails(
-    val provider: String,
-    val nickname: String,
-    val profileImgUrl: String?,
-    val expiresAt: Instant,
-)
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingDetails
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingStartResult
 
 interface OAuthSignupUseCase {
     fun providerSubjectHash(

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/port/output/PendingOAuthSignupRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/port/output/PendingOAuthSignupRepositoryPort.kt
@@ -1,6 +1,6 @@
 package com.back.boundedContexts.member.subContexts.oauthSignup.application.port.output
 
-import com.back.boundedContexts.member.subContexts.oauthSignup.domain.PendingOAuthSignup
+import com.back.boundedContexts.member.subContexts.oauthSignup.model.PendingOAuthSignup
 
 interface PendingOAuthSignupRepositoryPort {
     fun save(pendingOAuthSignup: PendingOAuthSignup): PendingOAuthSignup

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/port/output/PendingOAuthSignupRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/port/output/PendingOAuthSignupRepositoryPort.kt
@@ -1,0 +1,14 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.application.port.output
+
+import com.back.boundedContexts.member.subContexts.oauthSignup.domain.PendingOAuthSignup
+
+interface PendingOAuthSignupRepositoryPort {
+    fun save(pendingOAuthSignup: PendingOAuthSignup): PendingOAuthSignup
+
+    fun findByProviderAndProviderSubjectHash(
+        provider: String,
+        providerSubjectHash: String,
+    ): PendingOAuthSignup?
+
+    fun findByPendingTokenHash(pendingTokenHash: String): PendingOAuthSignup?
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationService.kt
@@ -4,11 +4,9 @@ import com.back.boundedContexts.member.application.port.input.MemberUseCase
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceApplicationService
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
-import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupPendingDetails
-import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupPendingStartResult
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupUseCase
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.output.PendingOAuthSignupRepositoryPort
-import com.back.boundedContexts.member.subContexts.oauthSignup.domain.PendingOAuthSignup
+import com.back.boundedContexts.member.subContexts.oauthSignup.model.PendingOAuthSignup
 import com.back.global.exception.application.AppException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationService.kt
@@ -56,7 +56,7 @@ class OAuthSignupApplicationService(
         val pendingToken = UUID.randomUUID().toString()
         val pendingTokenHash = oauthSignupHashService.pendingTokenHash(pendingToken)
         val expiresAt = now.plusSeconds(pendingExpirationSeconds.coerceAtLeast(60))
-        val normalizedNickname = normalizeNickname(nickname)
+        val pendingNickname = normalizePendingNickname(nickname)
 
         val pending =
             pendingOAuthSignupRepository
@@ -70,7 +70,7 @@ class OAuthSignupApplicationService(
                     it.refresh(
                         pendingTokenHash = pendingTokenHash,
                         expiresAt = expiresAt,
-                        nickname = normalizedNickname,
+                        nickname = pendingNickname,
                         profileImgUrl = profileImgUrl,
                     )
                 }
@@ -80,7 +80,7 @@ class OAuthSignupApplicationService(
                     memberLoginId = memberLoginId,
                     pendingTokenHash = pendingTokenHash,
                     pendingTokenExpiresAt = expiresAt,
-                    nickname = normalizedNickname,
+                    nickname = pendingNickname,
                     profileImgUrl = profileImgUrl,
                 )
 
@@ -166,4 +166,10 @@ class OAuthSignupApplicationService(
         }
         return normalized
     }
+
+    private fun normalizePendingNickname(nickname: String): String =
+        nickname
+            .trim()
+            .takeIf { it.length in 2..30 }
+            ?: "카카오사용자"
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationService.kt
@@ -10,6 +10,7 @@ import com.back.boundedContexts.member.subContexts.oauthSignup.model.PendingOAut
 import com.back.global.exception.application.AppException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.util.Locale
@@ -36,7 +37,7 @@ class OAuthSignupApplicationService(
         providerSubjectHash: String,
     ): String = oauthSignupHashService.memberLoginId(provider, providerSubjectHash)
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     override fun startPending(
         provider: String,
         providerSubject: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationService.kt
@@ -1,0 +1,170 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.application.service
+
+import com.back.boundedContexts.member.application.port.input.MemberUseCase
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceApplicationService
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupPendingDetails
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupPendingStartResult
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupUseCase
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.output.PendingOAuthSignupRepositoryPort
+import com.back.boundedContexts.member.subContexts.oauthSignup.domain.PendingOAuthSignup
+import com.back.global.exception.application.AppException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.util.Locale
+import java.util.UUID
+
+@Service
+class OAuthSignupApplicationService(
+    private val memberUseCase: MemberUseCase,
+    private val legalAcceptanceApplicationService: LegalAcceptanceApplicationService,
+    private val pendingOAuthSignupRepository: PendingOAuthSignupRepositoryPort,
+    private val oauthSignupHashService: OAuthSignupHashService,
+    @param:Value("\${custom.member.oauthSignup.pendingExpirationSeconds:1800}")
+    private val pendingExpirationSeconds: Long,
+) : OAuthSignupUseCase {
+    @Transactional(readOnly = true)
+    override fun providerSubjectHash(
+        provider: String,
+        providerSubject: String,
+    ): String = oauthSignupHashService.providerSubjectHash(provider, providerSubject)
+
+    @Transactional(readOnly = true)
+    override fun memberLoginId(
+        provider: String,
+        providerSubjectHash: String,
+    ): String = oauthSignupHashService.memberLoginId(provider, providerSubjectHash)
+
+    @Transactional
+    override fun startPending(
+        provider: String,
+        providerSubject: String,
+        nickname: String,
+        profileImgUrl: String?,
+    ): OAuthSignupPendingStartResult {
+        val normalizedProvider = normalizeProvider(provider)
+        val providerSubjectHash = oauthSignupHashService.providerSubjectHash(normalizedProvider, providerSubject)
+        val memberLoginId = oauthSignupHashService.memberLoginId(normalizedProvider, providerSubjectHash)
+
+        if (memberUseCase.findByLoginId(memberLoginId) != null) {
+            throw AppException("409-4", "이미 연결된 소셜 계정입니다. 로그인 화면에서 다시 시도해주세요.")
+        }
+
+        val now = Instant.now()
+        val pendingToken = UUID.randomUUID().toString()
+        val pendingTokenHash = oauthSignupHashService.pendingTokenHash(pendingToken)
+        val expiresAt = now.plusSeconds(pendingExpirationSeconds.coerceAtLeast(60))
+        val normalizedNickname = normalizeNickname(nickname)
+
+        val pending =
+            pendingOAuthSignupRepository
+                .findByProviderAndProviderSubjectHash(
+                    provider = normalizedProvider,
+                    providerSubjectHash = providerSubjectHash,
+                )?.also {
+                    if (it.consumedAt != null) {
+                        throw AppException("409-4", "이미 처리된 소셜 회원가입입니다. 로그인 화면에서 다시 시도해주세요.")
+                    }
+                    it.refresh(
+                        pendingTokenHash = pendingTokenHash,
+                        expiresAt = expiresAt,
+                        nickname = normalizedNickname,
+                        profileImgUrl = profileImgUrl,
+                    )
+                }
+                ?: PendingOAuthSignup(
+                    provider = normalizedProvider,
+                    providerSubjectHash = providerSubjectHash,
+                    memberLoginId = memberLoginId,
+                    pendingTokenHash = pendingTokenHash,
+                    pendingTokenExpiresAt = expiresAt,
+                    nickname = normalizedNickname,
+                    profileImgUrl = profileImgUrl,
+                )
+
+        pendingOAuthSignupRepository.save(pending)
+
+        return OAuthSignupPendingStartResult(
+            provider = normalizedProvider,
+            pendingToken = pendingToken,
+            expiresAt = expiresAt,
+        )
+    }
+
+    @Transactional(readOnly = true)
+    override fun findPending(pendingToken: String): OAuthSignupPendingDetails {
+        val pending = findPendingOrThrow(pendingToken)
+        pending.ensureReadable(Instant.now())
+
+        return OAuthSignupPendingDetails(
+            provider = pending.provider,
+            nickname = pending.nickname,
+            profileImgUrl = pending.profileImgUrl,
+            expiresAt = pending.pendingTokenExpiresAt,
+        )
+    }
+
+    @Transactional
+    override fun completeSignup(
+        pendingToken: String,
+        nickname: String?,
+        legalAcceptance: LegalAcceptanceCommand,
+    ): Member {
+        val pending = findPendingOrThrow(pendingToken)
+        val now = Instant.now()
+        pending.ensureReadable(now)
+
+        legalAcceptanceApplicationService.validateEmailSignupAcceptance(legalAcceptance)
+        if (memberUseCase.findByLoginId(pending.memberLoginId) != null) {
+            pending.cancel(now)
+            throw AppException("409-4", "이미 연결된 소셜 계정입니다. 로그인 화면에서 다시 시도해주세요.")
+        }
+
+        val member =
+            memberUseCase.join(
+                username = pending.memberLoginId,
+                password = null,
+                nickname = normalizeNickname(nickname ?: pending.nickname),
+                profileImgUrl = pending.profileImgUrl,
+                email = null,
+            )
+
+        legalAcceptanceApplicationService.recordSocialSignupAcceptance(
+            member = member,
+            command = legalAcceptance,
+            acceptedAt = now,
+            source = "${pending.provider}_OAUTH_SIGNUP",
+        )
+        pending.consume(now)
+
+        return member
+    }
+
+    private fun findPendingOrThrow(pendingToken: String): PendingOAuthSignup {
+        val normalizedToken =
+            pendingToken
+                .trim()
+                .ifBlank { throw AppException("400-2", "소셜 회원가입 세션이 올바르지 않습니다.") }
+
+        return pendingOAuthSignupRepository.findByPendingTokenHash(
+            oauthSignupHashService.pendingTokenHash(normalizedToken),
+        ) ?: throw AppException("404-2", "유효하지 않은 소셜 회원가입 세션입니다.")
+    }
+
+    private fun normalizeProvider(provider: String): String =
+        provider
+            .trim()
+            .uppercase(Locale.ROOT)
+            .ifBlank { throw AppException("400-2", "소셜 로그인 제공자가 올바르지 않습니다.") }
+
+    private fun normalizeNickname(nickname: String): String {
+        val normalized = nickname.trim().ifBlank { "카카오사용자" }
+        if (normalized.length !in 2..30) {
+            throw AppException("400-2", "프로필 이름은 2~30자로 입력해주세요.")
+        }
+        return normalized
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupHashService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupHashService.kt
@@ -1,0 +1,73 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.application.service
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Base64
+import java.util.Locale
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+@Service
+class OAuthSignupHashService(
+    @param:Value("\${custom.member.oauthSignup.tokenHashSecret:}")
+    private val configuredOAuthSignupSecret: String,
+    @param:Value("\${custom.member.signup.tokenHashSecret:}")
+    private val configuredSignupSecret: String,
+    @param:Value("\${custom.jwt.secretKey}")
+    private val jwtSecretKey: String,
+) {
+    fun pendingTokenHash(rawToken: String): String = digest("oauth-signup-pending-token", rawToken)
+
+    fun providerSubjectHash(
+        provider: String,
+        providerSubject: String,
+    ): String {
+        val normalizedProvider = normalizeProvider(provider)
+        val normalizedSubject = providerSubject.trim()
+        require(normalizedSubject.isNotBlank()) { "oauth provider subject must not be blank" }
+
+        return digest("oauth-provider-subject:$normalizedProvider", normalizedSubject)
+    }
+
+    fun memberLoginId(
+        provider: String,
+        providerSubjectHash: String,
+    ): String {
+        val normalizedProvider = normalizeProvider(provider)
+        val normalizedHash = providerSubjectHash.trim()
+        require(normalizedHash.isNotBlank()) { "oauth provider subject hash must not be blank" }
+
+        return "${normalizedProvider}__${normalizedHash.take(LOGIN_ID_HASH_LENGTH)}"
+    }
+
+    private fun digest(
+        purpose: String,
+        rawValue: String,
+    ): String {
+        val normalizedValue = rawValue.trim()
+        require(normalizedValue.isNotBlank()) { "$purpose value must not be blank" }
+
+        val mac = Mac.getInstance(HMAC_ALGORITHM)
+        mac.init(SecretKeySpec(resolveSecret().toByteArray(UTF_8), HMAC_ALGORITHM))
+        val digest = mac.doFinal("$purpose:$normalizedValue".toByteArray(UTF_8))
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(digest)
+    }
+
+    private fun resolveSecret(): String =
+        configuredOAuthSignupSecret
+            .ifBlank { configuredSignupSecret }
+            .ifBlank { jwtSecretKey }
+            .ifBlank { error("custom.member.oauthSignup.tokenHashSecret or custom.jwt.secretKey is required") }
+
+    private fun normalizeProvider(provider: String): String =
+        provider
+            .trim()
+            .uppercase(Locale.ROOT)
+            .ifBlank { throw IllegalArgumentException("oauth provider must not be blank") }
+
+    companion object {
+        private const val HMAC_ALGORITHM = "HmacSHA256"
+        private const val LOGIN_ID_HASH_LENGTH = 43
+    }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupResults.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupResults.kt
@@ -1,0 +1,16 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.application.service
+
+import java.time.Instant
+
+data class OAuthSignupPendingStartResult(
+    val provider: String,
+    val pendingToken: String,
+    val expiresAt: Instant,
+)
+
+data class OAuthSignupPendingDetails(
+    val provider: String,
+    val nickname: String,
+    val profileImgUrl: String?,
+    val expiresAt: Instant,
+)

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/domain/PersistenceModelAliases.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/domain/PersistenceModelAliases.kt
@@ -1,0 +1,3 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.domain
+
+typealias PendingOAuthSignup = com.back.boundedContexts.member.subContexts.oauthSignup.model.PendingOAuthSignup

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/domain/PersistenceModelAliases.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/domain/PersistenceModelAliases.kt
@@ -1,3 +1,0 @@
-package com.back.boundedContexts.member.subContexts.oauthSignup.domain
-
-typealias PendingOAuthSignup = com.back.boundedContexts.member.subContexts.oauthSignup.model.PendingOAuthSignup

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/model/PendingOAuthSignup.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/model/PendingOAuthSignup.kt
@@ -1,0 +1,87 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.model
+
+import com.back.global.exception.application.AppException
+import com.back.global.jpa.domain.BaseTime
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+
+@Entity
+@Table(
+    name = "pending_oauth_signup",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_pending_oauth_signup_provider_subject_hash",
+            columnNames = ["provider", "provider_subject_hash"],
+        ),
+        UniqueConstraint(
+            name = "uk_pending_oauth_signup_pending_token_hash",
+            columnNames = ["pending_token_hash"],
+        ),
+    ],
+)
+class PendingOAuthSignup(
+    @field:Id
+    @field:SequenceGenerator(
+        name = "pending_oauth_signup_seq_gen",
+        sequenceName = "pending_oauth_signup_seq",
+        allocationSize = 20,
+    )
+    @field:GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "pending_oauth_signup_seq_gen")
+    override val id: Long = 0,
+    @field:Column(nullable = false, length = 32)
+    val provider: String,
+    @field:Column(nullable = false, length = 128)
+    val providerSubjectHash: String,
+    @field:Column(nullable = false, length = 80)
+    val memberLoginId: String,
+    @field:Column(nullable = false, length = 128)
+    var pendingTokenHash: String,
+    @field:Column(nullable = false)
+    var pendingTokenExpiresAt: Instant,
+    @field:Column(nullable = false, length = 30)
+    var nickname: String,
+    @field:Column(length = 2048)
+    var profileImgUrl: String? = null,
+    @field:Column
+    var consumedAt: Instant? = null,
+    @field:Column
+    var cancelledAt: Instant? = null,
+) : BaseTime(id) {
+    fun refresh(
+        pendingTokenHash: String,
+        expiresAt: Instant,
+        nickname: String,
+        profileImgUrl: String?,
+    ) {
+        this.pendingTokenHash = pendingTokenHash
+        this.pendingTokenExpiresAt = expiresAt
+        this.nickname = nickname
+        this.profileImgUrl = profileImgUrl
+        this.cancelledAt = null
+    }
+
+    fun ensureReadable(now: Instant) {
+        if (cancelledAt != null || consumedAt != null) {
+            throw AppException("410-1", "소셜 회원가입 세션이 더 이상 유효하지 않습니다.")
+        }
+        if (pendingTokenExpiresAt.isBefore(now)) {
+            throw AppException("410-1", "소셜 회원가입 세션이 만료되었습니다. 다시 로그인해주세요.")
+        }
+    }
+
+    fun consume(now: Instant) {
+        ensureReadable(now)
+        consumedAt = now
+    }
+
+    fun cancel(now: Instant) {
+        cancelledAt = now
+    }
+}

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginFailureHandler.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginFailureHandler.kt
@@ -43,6 +43,17 @@ internal fun buildOAuth2LoginFailureRedirectUrl(
     exception: AuthenticationException,
 ): String {
     val redirectUrl = encodedState?.let { runCatching { OAuth2State.decode(it).redirectUrl }.getOrNull() }
+    findOAuthSignupRequiredException(exception)?.let { signupException ->
+        val parameters =
+            buildList {
+                add("token" to signupException.pendingToken)
+                add("provider" to signupException.provider.lowercase())
+                resolveNextPath(redirectUrl)?.let { add("next" to it) }
+            }
+
+        return appendFragment(resolveSignupCompleteBaseUrl(siteFrontUrl, redirectUrl), parameters)
+    }
+
     val parameters =
         buildList {
             add("oauthError" to resolveOAuth2LoginFailureCode(exception))
@@ -54,6 +65,11 @@ internal fun buildOAuth2LoginFailureRedirectUrl(
 
 private fun resolveOAuth2LoginFailureCode(exception: AuthenticationException): String =
     if (containsAppExceptionCode(exception, "403-4")) OAUTH_SIGNUP_REQUIRED_ERROR else OAUTH_FAILED_ERROR
+
+private fun findOAuthSignupRequiredException(exception: Throwable): OAuthSignupRequiredAuthenticationException? =
+    generateSequence(exception as Throwable?) { it.cause }
+        .filterIsInstance<OAuthSignupRequiredAuthenticationException>()
+        .firstOrNull()
 
 private fun containsAppExceptionCode(
     throwable: Throwable,
@@ -73,6 +89,19 @@ private fun resolveLoginBaseUrl(
 
     val normalizedFrontUrl = siteFrontUrl.trim().removeSuffix("/")
     return if (normalizedFrontUrl.isBlank()) "/login" else "$normalizedFrontUrl/login"
+}
+
+private fun resolveSignupCompleteBaseUrl(
+    siteFrontUrl: String,
+    redirectUrl: String?,
+): String {
+    val redirectUri = runCatching { URI(redirectUrl.orEmpty()) }.getOrNull()
+    if (redirectUri != null && redirectUri.isAbsolute && !redirectUri.rawAuthority.isNullOrBlank()) {
+        return "${redirectUri.scheme}://${redirectUri.rawAuthority}/signup/social/complete"
+    }
+
+    val normalizedFrontUrl = siteFrontUrl.trim().removeSuffix("/")
+    return if (normalizedFrontUrl.isBlank()) "/signup/social/complete" else "$normalizedFrontUrl/signup/social/complete"
 }
 
 private fun resolveNextPath(redirectUrl: String?): String? {
@@ -100,6 +129,18 @@ private fun appendQuery(
     return parameters.joinToString(
         separator = "&",
         prefix = baseUrl + separator,
+    ) { (key, value) -> "${encodeQueryValue(key)}=${encodeQueryValue(value)}" }
+}
+
+private fun appendFragment(
+    baseUrl: String,
+    parameters: List<Pair<String, String>>,
+): String {
+    if (parameters.isEmpty()) return baseUrl
+
+    return parameters.joinToString(
+        separator = "&",
+        prefix = "$baseUrl#",
     ) { (key, value) -> "${encodeQueryValue(key)}=${encodeQueryValue(value)}" }
 }
 

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserService.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserService.kt
@@ -119,18 +119,21 @@ private fun loadExistingMemberOrStartSignup(
     val member =
         memberUseCase.findByLoginId(memberLoginId)
             ?: memberUseCase.findByLoginId(legacyLoginId)
-            ?: startPendingSignup(provider, profilePayload, oauthSignupUseCase)
+
+    if (member == null) {
+        throw buildPendingSignupException(provider, profilePayload, oauthSignupUseCase)
+    }
 
     memberUseCase.modify(member, profilePayload.nickname, profilePayload.profileImgUrl)
 
     return member
 }
 
-private fun startPendingSignup(
+private fun buildPendingSignupException(
     provider: OAuth2Provider,
     profilePayload: OAuth2ProfilePayload,
     oauthSignupUseCase: OAuthSignupUseCase,
-): Nothing {
+): OAuthSignupRequiredAuthenticationException {
     val pending =
         oauthSignupUseCase.startPending(
             provider = provider.name,
@@ -139,7 +142,7 @@ private fun startPendingSignup(
             profileImgUrl = profilePayload.profileImgUrl,
         )
 
-    throw OAuthSignupRequiredAuthenticationException(
+    return OAuthSignupRequiredAuthenticationException(
         provider = pending.provider,
         pendingToken = pending.pendingToken,
         expiresAt = pending.expiresAt,

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserService.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserService.kt
@@ -2,7 +2,7 @@ package com.back.global.security.config.oauth2
 
 import com.back.boundedContexts.member.application.port.input.MemberUseCase
 import com.back.boundedContexts.member.domain.shared.Member
-import com.back.global.exception.application.AppException
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupUseCase
 import com.back.global.security.domain.SecurityUser
 import com.back.global.security.domain.toGrantedAuthorities
 import org.slf4j.Logger
@@ -20,6 +20,7 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
 
 private enum class OAuth2Provider {
     KAKAO,
@@ -35,6 +36,7 @@ private enum class OAuth2Provider {
 @Service
 class CustomOAuth2UserService(
     private val memberUseCase: MemberUseCase,
+    private val oauthSignupUseCase: OAuthSignupUseCase,
 ) : OAuth2UserService<OAuth2UserRequest, OAuth2User> {
     internal var delegate: OAuth2UserService<OAuth2UserRequest, OAuth2User> = DefaultOAuth2UserService()
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -48,13 +50,20 @@ class CustomOAuth2UserService(
                 OAuth2Provider.KAKAO -> OAuth2ProfileExtractor.extractKakao(oAuth2User.attributes, oAuth2User.name)
             }
 
-        return upsertMember(provider, profilePayload, memberUseCase, logger).toSecurityUser()
+        return loadExistingMemberOrStartSignup(
+            provider = provider,
+            profilePayload = profilePayload,
+            memberUseCase = memberUseCase,
+            oauthSignupUseCase = oauthSignupUseCase,
+            logger = logger,
+        ).toSecurityUser()
     }
 }
 
 @Service
 class CustomOidcUserService(
     private val memberUseCase: MemberUseCase,
+    private val oauthSignupUseCase: OAuthSignupUseCase,
 ) : OAuth2UserService<OidcUserRequest, OidcUser> {
     internal var delegate: OAuth2UserService<OidcUserRequest, OidcUser> = OidcUserService()
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -67,41 +76,81 @@ class CustomOidcUserService(
             when (provider) {
                 OAuth2Provider.KAKAO -> OAuth2ProfileExtractor.extractKakao(oidcUser.claims, oidcUser.name)
             }
-        val member = upsertMember(provider, profilePayload, memberUseCase, logger)
+        val member =
+            loadExistingMemberOrStartSignup(
+                provider = provider,
+                profilePayload = profilePayload,
+                memberUseCase = memberUseCase,
+                oauthSignupUseCase = oauthSignupUseCase,
+                logger = logger,
+            )
 
         return member.toSecurityOidcUser(oidcUser)
     }
 }
 
-private fun upsertMember(
+private fun loadExistingMemberOrStartSignup(
     provider: OAuth2Provider,
     profilePayload: OAuth2ProfilePayload,
     memberUseCase: MemberUseCase,
+    oauthSignupUseCase: OAuthSignupUseCase,
     logger: Logger,
 ): Member {
+    val providerSubjectHash =
+        oauthSignupUseCase.providerSubjectHash(
+            provider = provider.name,
+            providerSubject = profilePayload.oauthUserId,
+        )
     if (profilePayload.nickname == OAuth2ProfileExtractor.DEFAULT_KAKAO_NICKNAME) {
         logger.warn(
-            "oauth2_kakao_profile_fallback_used provider={} oauthUserId={}",
+            "oauth2_kakao_profile_fallback_used provider={} providerSubjectHash={}",
             provider.name.lowercase(),
-            profilePayload.oauthUserId,
+            providerSubjectHash,
         )
     }
 
-    val username = "${provider.name}__${profilePayload.oauthUserId}"
+    val memberLoginId =
+        oauthSignupUseCase.memberLoginId(
+            provider = provider.name,
+            providerSubjectHash = providerSubjectHash,
+        )
+    val legacyLoginId = "${provider.name}__${profilePayload.oauthUserId}"
 
     val member =
-        memberUseCase.findByLoginId(username)
-            ?: throw signupRequiredAuthenticationException()
+        memberUseCase.findByLoginId(memberLoginId)
+            ?: memberUseCase.findByLoginId(legacyLoginId)
+            ?: startPendingSignup(provider, profilePayload, oauthSignupUseCase)
 
     memberUseCase.modify(member, profilePayload.nickname, profilePayload.profileImgUrl)
 
     return member
 }
 
-private fun signupRequiredAuthenticationException(): InternalAuthenticationServiceException {
-    val cause = AppException("403-4", "소셜 로그인 신규 가입은 현재 지원하지 않습니다. 이메일 회원가입으로 먼저 약관과 개인정보처리방침에 동의해주세요.")
-    return InternalAuthenticationServiceException(cause.message ?: "OAuth signup is not supported.", cause)
+private fun startPendingSignup(
+    provider: OAuth2Provider,
+    profilePayload: OAuth2ProfilePayload,
+    oauthSignupUseCase: OAuthSignupUseCase,
+): Nothing {
+    val pending =
+        oauthSignupUseCase.startPending(
+            provider = provider.name,
+            providerSubject = profilePayload.oauthUserId,
+            nickname = profilePayload.nickname,
+            profileImgUrl = profilePayload.profileImgUrl,
+        )
+
+    throw OAuthSignupRequiredAuthenticationException(
+        provider = pending.provider,
+        pendingToken = pending.pendingToken,
+        expiresAt = pending.expiresAt,
+    )
 }
+
+internal class OAuthSignupRequiredAuthenticationException(
+    val provider: String,
+    val pendingToken: String,
+    val expiresAt: Instant,
+) : InternalAuthenticationServiceException("OAuth signup requires local consent.")
 
 private fun Member.toSecurityUser(): SecurityUser =
     SecurityUser(

--- a/back/src/main/resources/db/migration-test/V20260622_03__create_pending_oauth_signup.sql
+++ b/back/src/main/resources/db/migration-test/V20260622_03__create_pending_oauth_signup.sql
@@ -1,0 +1,24 @@
+CREATE SEQUENCE IF NOT EXISTS pending_oauth_signup_seq START WITH 1 INCREMENT BY 20;
+
+CREATE TABLE IF NOT EXISTS pending_oauth_signup (
+    id BIGINT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL,
+    modified_at TIMESTAMPTZ NOT NULL,
+    provider VARCHAR(32) NOT NULL,
+    provider_subject_hash VARCHAR(128) NOT NULL,
+    member_login_id VARCHAR(80) NOT NULL,
+    pending_token_hash VARCHAR(128) NOT NULL,
+    pending_token_expires_at TIMESTAMPTZ NOT NULL,
+    nickname VARCHAR(30) NOT NULL,
+    profile_img_url VARCHAR(2048),
+    consumed_at TIMESTAMPTZ,
+    cancelled_at TIMESTAMPTZ,
+    CONSTRAINT uk_pending_oauth_signup_provider_subject_hash UNIQUE (provider, provider_subject_hash),
+    CONSTRAINT uk_pending_oauth_signup_pending_token_hash UNIQUE (pending_token_hash)
+);
+
+CREATE INDEX IF NOT EXISTS pending_oauth_signup_idx_expires_at
+    ON pending_oauth_signup (pending_token_expires_at);
+
+CREATE INDEX IF NOT EXISTS pending_oauth_signup_idx_member_login_id
+    ON pending_oauth_signup (member_login_id);

--- a/back/src/main/resources/db/migration/V20260622_03__create_pending_oauth_signup.sql
+++ b/back/src/main/resources/db/migration/V20260622_03__create_pending_oauth_signup.sql
@@ -1,0 +1,24 @@
+CREATE SEQUENCE IF NOT EXISTS pending_oauth_signup_seq START WITH 1 INCREMENT BY 20;
+
+CREATE TABLE IF NOT EXISTS pending_oauth_signup (
+    id BIGINT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL,
+    modified_at TIMESTAMPTZ NOT NULL,
+    provider VARCHAR(32) NOT NULL,
+    provider_subject_hash VARCHAR(128) NOT NULL,
+    member_login_id VARCHAR(80) NOT NULL,
+    pending_token_hash VARCHAR(128) NOT NULL,
+    pending_token_expires_at TIMESTAMPTZ NOT NULL,
+    nickname VARCHAR(30) NOT NULL,
+    profile_img_url VARCHAR(2048),
+    consumed_at TIMESTAMPTZ,
+    cancelled_at TIMESTAMPTZ,
+    CONSTRAINT uk_pending_oauth_signup_provider_subject_hash UNIQUE (provider, provider_subject_hash),
+    CONSTRAINT uk_pending_oauth_signup_pending_token_hash UNIQUE (pending_token_hash)
+);
+
+CREATE INDEX IF NOT EXISTS pending_oauth_signup_idx_expires_at
+    ON pending_oauth_signup (pending_token_expires_at);
+
+CREATE INDEX IF NOT EXISTS pending_oauth_signup_idx_member_login_id
+    ON pending_oauth_signup (member_login_id);

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepositoryAdapterTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepositoryAdapterTest.kt
@@ -1,0 +1,42 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.adapter.persistence
+
+import com.back.boundedContexts.member.subContexts.oauthSignup.model.PendingOAuthSignup
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import java.time.Instant
+
+@DisplayName("PendingOAuthSignupRepositoryAdapter 테스트")
+class PendingOAuthSignupRepositoryAdapterTest {
+    @Test
+    fun `repository port 호출을 Spring Data repository로 위임한다`() {
+        val repository = mock(PendingOAuthSignupRepository::class.java)
+        val adapter = PendingOAuthSignupRepositoryAdapter(repository)
+        val pending = pendingOAuthSignup()
+        given(repository.save(pending)).willReturn(pending)
+        given(repository.findByProviderAndProviderSubjectHash("KAKAO", "subject-hash")).willReturn(pending)
+        given(repository.findByPendingTokenHash("token-hash")).willReturn(pending)
+
+        assertThat(adapter.save(pending)).isSameAs(pending)
+        assertThat(adapter.findByProviderAndProviderSubjectHash("KAKAO", "subject-hash")).isSameAs(pending)
+        assertThat(adapter.findByPendingTokenHash("token-hash")).isSameAs(pending)
+
+        verify(repository).save(pending)
+        verify(repository).findByProviderAndProviderSubjectHash("KAKAO", "subject-hash")
+        verify(repository).findByPendingTokenHash("token-hash")
+    }
+}
+
+private fun pendingOAuthSignup(): PendingOAuthSignup =
+    PendingOAuthSignup(
+        provider = "KAKAO",
+        providerSubjectHash = "subject-hash",
+        memberLoginId = "KAKAO__subject-hash",
+        pendingTokenHash = "token-hash",
+        pendingTokenExpiresAt = Instant.EPOCH.plusSeconds(300),
+        nickname = "카카오닉네임",
+        profileImgUrl = null,
+    )

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/web/ApiV1OAuthSignupControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/web/ApiV1OAuthSignupControllerTest.kt
@@ -1,0 +1,179 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.adapter.web
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupUseCase
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingDetails
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingStartResult
+import com.back.global.app.AppConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+@DisplayName("ApiV1OAuthSignupController 테스트")
+class ApiV1OAuthSignupControllerTest {
+    @Test
+    fun `pending은 token으로 social signup 세션을 조회한다`() {
+        val useCase = RecordingOAuthSignupUseCase()
+        val controller = ApiV1OAuthSignupController(useCase)
+
+        val response =
+            controller.pending(
+                ApiV1OAuthSignupController.SocialSignupPendingRequest(
+                    token = "pending-token",
+                ),
+            )
+
+        assertThat(response.resultCode).isEqualTo("200-3")
+        assertThat(response.data.provider).isEqualTo("KAKAO")
+        assertThat(response.data.nickname).isEqualTo("카카오닉네임")
+        assertThat(response.data.profileImgUrl).isEqualTo("https://kakao.cdn/profile.png")
+        assertThat(response.data.expiresAt).isEqualTo(Instant.EPOCH.plusSeconds(300))
+        assertThat(useCase.lastFindPendingToken).isEqualTo("pending-token")
+    }
+
+    @Test
+    fun `complete는 legal acceptance payload와 nickname으로 social signup을 완료한다`() {
+        AppConfig(
+            siteBackUrl = "https://api.aquilaxk.site",
+            siteFrontUrl = "https://www.aquilaxk.site",
+        )
+        val useCase = RecordingOAuthSignupUseCase()
+        val controller = ApiV1OAuthSignupController(useCase)
+
+        val response =
+            controller.complete(
+                ApiV1OAuthSignupController.SocialSignupCompleteRequest(
+                    token = "pending-token",
+                    nickname = "완료닉네임",
+                    termsVersion = "2026-06-21",
+                    termsContentSha256 = TERMS_HASH,
+                    privacyVersion = "2026-06-21",
+                    privacyContentSha256 = PRIVACY_HASH,
+                    age14OrOlder = true,
+                    requiredPrivacyConfirmed = true,
+                    analyticsConsent = false,
+                    overseasTransferAcknowledged = true,
+                ),
+            )
+
+        assertThat(response.resultCode).isEqualTo("201-3")
+        assertThat(response.msg).contains("완료닉네임")
+        assertThat(response.data.name).isEqualTo("완료닉네임")
+        assertThat(useCase.lastCompletePendingToken).isEqualTo("pending-token")
+        assertThat(useCase.lastCompleteNickname).isEqualTo("완료닉네임")
+        assertThat(useCase.lastLegalAcceptance)
+            .isEqualTo(
+                LegalAcceptanceCommand(
+                    termsVersion = "2026-06-21",
+                    termsContentSha256 = TERMS_HASH,
+                    privacyVersion = "2026-06-21",
+                    privacyContentSha256 = PRIVACY_HASH,
+                    age14OrOlder = true,
+                    requiredPrivacyConfirmed = true,
+                    analyticsConsent = false,
+                    overseasTransferAcknowledged = true,
+                ),
+            )
+    }
+
+    @Test
+    fun `complete request는 nickname 생략과 legal command 변환을 지원한다`() {
+        val request =
+            ApiV1OAuthSignupController.SocialSignupCompleteRequest(
+                token = "pending-token",
+                termsVersion = "2026-06-21",
+                termsContentSha256 = TERMS_HASH,
+                privacyVersion = "2026-06-21",
+                privacyContentSha256 = PRIVACY_HASH,
+                age14OrOlder = true,
+                requiredPrivacyConfirmed = true,
+                analyticsConsent = true,
+                overseasTransferAcknowledged = true,
+            )
+
+        val command = request.toLegalAcceptanceCommand()
+
+        assertThat(request.token).isEqualTo("pending-token")
+        assertThat(request.nickname).isNull()
+        assertThat(request.termsVersion).isEqualTo("2026-06-21")
+        assertThat(request.termsContentSha256).isEqualTo(TERMS_HASH)
+        assertThat(request.privacyVersion).isEqualTo("2026-06-21")
+        assertThat(request.privacyContentSha256).isEqualTo(PRIVACY_HASH)
+        assertThat(request.age14OrOlder).isTrue()
+        assertThat(request.requiredPrivacyConfirmed).isTrue()
+        assertThat(request.analyticsConsent).isTrue()
+        assertThat(request.overseasTransferAcknowledged).isTrue()
+        assertThat(command.termsVersion).isEqualTo("2026-06-21")
+        assertThat(command.termsContentSha256).isEqualTo(TERMS_HASH)
+        assertThat(command.privacyVersion).isEqualTo("2026-06-21")
+        assertThat(command.privacyContentSha256).isEqualTo(PRIVACY_HASH)
+        assertThat(command.age14OrOlder).isTrue()
+        assertThat(command.requiredPrivacyConfirmed).isTrue()
+        assertThat(command.analyticsConsent).isTrue()
+        assertThat(command.overseasTransferAcknowledged).isTrue()
+    }
+
+    private companion object {
+        private const val TERMS_HASH = "3b71950e518b16b9a24cb4f9873633720ca7a9fce145a7bb9787c48845b56c5b"
+        private const val PRIVACY_HASH = "cedbfea674a9e2aca9e29bf6a01492a1e3fa640b0ff53d47f969d64c057b980f"
+    }
+}
+
+private class RecordingOAuthSignupUseCase : OAuthSignupUseCase {
+    var lastFindPendingToken: String? = null
+        private set
+    var lastCompletePendingToken: String? = null
+        private set
+    var lastCompleteNickname: String? = null
+        private set
+    var lastLegalAcceptance: LegalAcceptanceCommand? = null
+        private set
+
+    override fun providerSubjectHash(
+        provider: String,
+        providerSubject: String,
+    ): String = error("providerSubjectHash is not used in ApiV1OAuthSignupControllerTest")
+
+    override fun memberLoginId(
+        provider: String,
+        providerSubjectHash: String,
+    ): String = error("memberLoginId is not used in ApiV1OAuthSignupControllerTest")
+
+    override fun startPending(
+        provider: String,
+        providerSubject: String,
+        nickname: String,
+        profileImgUrl: String?,
+    ): OAuthSignupPendingStartResult = error("startPending is not used in ApiV1OAuthSignupControllerTest")
+
+    override fun findPending(pendingToken: String): OAuthSignupPendingDetails {
+        lastFindPendingToken = pendingToken
+        return OAuthSignupPendingDetails(
+            provider = "KAKAO",
+            nickname = "카카오닉네임",
+            profileImgUrl = "https://kakao.cdn/profile.png",
+            expiresAt = Instant.EPOCH.plusSeconds(300),
+        )
+    }
+
+    override fun completeSignup(
+        pendingToken: String,
+        nickname: String?,
+        legalAcceptance: LegalAcceptanceCommand,
+    ): Member {
+        lastCompletePendingToken = pendingToken
+        lastCompleteNickname = nickname
+        lastLegalAcceptance = legalAcceptance
+        return Member(
+            id = 7,
+            username = "KAKAO__subject-hash",
+            password = null,
+            nickname = nickname ?: "카카오사용자",
+        ).apply {
+            createdAt = Instant.EPOCH
+            modifiedAt = Instant.EPOCH.plusSeconds(1)
+        }
+    }
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
@@ -1,0 +1,336 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.application.service
+
+import com.back.boundedContexts.member.application.port.input.MemberUseCase
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileLinkItem
+import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileWorkspaceContent
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.output.MemberLegalAcceptanceRepositoryPort
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceApplicationService
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
+import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberLegalAcceptance
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.output.PendingOAuthSignupRepositoryPort
+import com.back.boundedContexts.member.subContexts.oauthSignup.domain.PendingOAuthSignup
+import com.back.global.exception.application.AppException
+import com.back.global.rsData.RsData
+import com.back.standard.dto.member.type1.MemberSearchSortType1
+import com.back.standard.dto.page.PagedResult
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.Optional
+
+@DisplayName("OAuthSignupApplicationService 테스트")
+class OAuthSignupApplicationServiceTest {
+    @Test
+    fun `신규 OAuth pending은 원문 token과 provider subject 대신 hash를 저장한다`() {
+        val fixture = Fixture()
+        val result =
+            fixture.service.startPending(
+                provider = "kakao",
+                providerSubject = RAW_PROVIDER_SUBJECT,
+                nickname = "카카오닉네임",
+                profileImgUrl = "https://kakao.cdn/profile.png",
+            )
+
+        val pending = fixture.pendingRepository.saved.single()
+
+        assertThat(result.pendingToken).isNotBlank()
+        assertThat(pending.provider).isEqualTo("KAKAO")
+        assertThat(pending.providerSubjectHash).isEqualTo(
+            fixture.hashService.providerSubjectHash("KAKAO", RAW_PROVIDER_SUBJECT),
+        )
+        assertThat(pending.memberLoginId).isEqualTo(
+            fixture.hashService.memberLoginId("KAKAO", pending.providerSubjectHash),
+        )
+        assertThat(pending.pendingTokenHash).isEqualTo(fixture.hashService.pendingTokenHash(result.pendingToken))
+        assertThat(pending.pendingTokenHash).doesNotContain(result.pendingToken)
+        assertThat(pending.providerSubjectHash).doesNotContain(RAW_PROVIDER_SUBJECT)
+        assertThat(pending.memberLoginId).doesNotContain(RAW_PROVIDER_SUBJECT)
+    }
+
+    @Test
+    fun `같은 OAuth subject가 다시 callback되면 기존 pending row를 새 token hash로 갱신한다`() {
+        val fixture = Fixture()
+        val first =
+            fixture.service.startPending(
+                provider = "KAKAO",
+                providerSubject = "subject-1",
+                nickname = "첫닉네임",
+                profileImgUrl = null,
+            )
+        val second =
+            fixture.service.startPending(
+                provider = "KAKAO",
+                providerSubject = "subject-1",
+                nickname = "둘닉네임",
+                profileImgUrl = "/profile.png",
+            )
+
+        assertThat(first.pendingToken).isNotEqualTo(second.pendingToken)
+        assertThat(fixture.pendingRepository.saved).hasSize(1)
+        val refreshedPending = fixture.pendingRepository.saved.single()
+        assertThat(refreshedPending.nickname)
+            .isEqualTo("둘닉네임")
+        assertThat(refreshedPending.pendingTokenHash)
+            .isEqualTo(fixture.hashService.pendingTokenHash(second.pendingToken))
+    }
+
+    @Test
+    fun `pending 완료는 member와 social legal acceptance를 생성하고 pending을 소비한다`() {
+        val fixture = Fixture()
+        val start =
+            fixture.service.startPending(
+                provider = "KAKAO",
+                providerSubject = "subject-2",
+                nickname = "카카오닉네임",
+                profileImgUrl = null,
+            )
+
+        val member =
+            fixture.service.completeSignup(
+                pendingToken = start.pendingToken,
+                nickname = "완료닉네임",
+                legalAcceptance = validLegalAcceptance(),
+            )
+
+        assertThat(member.username).isEqualTo(
+            fixture.hashService.memberLoginId(
+                "KAKAO",
+                fixture.hashService.providerSubjectHash("KAKAO", "subject-2"),
+            ),
+        )
+        assertThat(member.nickname).isEqualTo("완료닉네임")
+        val legalAcceptance = fixture.legalAcceptanceRepository.saved.single()
+        val consumedPending = fixture.pendingRepository.saved.single()
+        assertThat(legalAcceptance.source)
+            .isEqualTo("KAKAO_OAUTH_SIGNUP")
+        assertThat(consumedPending.consumedAt)
+            .isNotNull()
+    }
+
+    @Test
+    fun `소비된 pending token은 재사용할 수 없다`() {
+        val fixture = Fixture()
+        val start =
+            fixture.service.startPending(
+                provider = "KAKAO",
+                providerSubject = "subject-3",
+                nickname = "카카오닉네임",
+                profileImgUrl = null,
+            )
+        fixture.service.completeSignup(
+            pendingToken = start.pendingToken,
+            nickname = null,
+            legalAcceptance = validLegalAcceptance(),
+        )
+
+        assertThatThrownBy {
+            fixture.service.completeSignup(
+                pendingToken = start.pendingToken,
+                nickname = null,
+                legalAcceptance = validLegalAcceptance(),
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("더 이상 유효하지 않습니다")
+    }
+
+    @Test
+    fun `이미 같은 login id의 member가 있으면 pending 완료를 취소하고 충돌을 반환한다`() {
+        val fixture = Fixture()
+        val start =
+            fixture.service.startPending(
+                provider = "KAKAO",
+                providerSubject = "subject-4",
+                nickname = "카카오닉네임",
+                profileImgUrl = null,
+            )
+        fixture.memberUseCase.existingLoginIds +=
+            fixture.hashService.memberLoginId(
+                "KAKAO",
+                fixture.hashService.providerSubjectHash("KAKAO", "subject-4"),
+            )
+
+        assertThatThrownBy {
+            fixture.service.completeSignup(
+                pendingToken = start.pendingToken,
+                nickname = null,
+                legalAcceptance = validLegalAcceptance(),
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("이미 연결된 소셜 계정")
+
+        val cancelledPending = fixture.pendingRepository.saved.single()
+        assertThat(cancelledPending.cancelledAt)
+            .isNotNull()
+    }
+
+    private class Fixture {
+        val memberUseCase = RecordingMemberUseCase()
+        val legalAcceptanceRepository = RecordingLegalAcceptanceRepository()
+        val legalAcceptanceService = LegalAcceptanceApplicationService(legalAcceptanceRepository)
+        val pendingRepository = RecordingPendingOAuthSignupRepository()
+        val hashService = OAuthSignupHashService("", "", "test-jwt-secret")
+        val service =
+            OAuthSignupApplicationService(
+                memberUseCase = memberUseCase,
+                legalAcceptanceApplicationService = legalAcceptanceService,
+                pendingOAuthSignupRepository = pendingRepository,
+                oauthSignupHashService = hashService,
+                pendingExpirationSeconds = 1800,
+            )
+    }
+
+    private companion object {
+        private const val RAW_PROVIDER_SUBJECT = "raw-kakao-subject"
+    }
+}
+
+private fun validLegalAcceptance(): LegalAcceptanceCommand =
+    LegalAcceptanceCommand(
+        termsVersion = "2026-06-21",
+        termsContentSha256 = "3b71950e518b16b9a24cb4f9873633720ca7a9fce145a7bb9787c48845b56c5b",
+        privacyVersion = "2026-06-21",
+        privacyContentSha256 = "4cc6ae3260aaca5f5ff35b235af91679a60760f13dccad9e85c94fda4d1552d9",
+        age14OrOlder = true,
+        requiredPrivacyConfirmed = true,
+        analyticsConsent = false,
+        overseasTransferAcknowledged = true,
+    )
+
+private class RecordingPendingOAuthSignupRepository : PendingOAuthSignupRepositoryPort {
+    val saved = mutableListOf<PendingOAuthSignup>()
+
+    override fun save(pendingOAuthSignup: PendingOAuthSignup): PendingOAuthSignup {
+        saved.removeIf {
+            it.provider == pendingOAuthSignup.provider &&
+                it.providerSubjectHash == pendingOAuthSignup.providerSubjectHash
+        }
+        saved += pendingOAuthSignup
+        return pendingOAuthSignup
+    }
+
+    override fun findByProviderAndProviderSubjectHash(
+        provider: String,
+        providerSubjectHash: String,
+    ): PendingOAuthSignup? =
+        saved.firstOrNull {
+            it.provider == provider &&
+                it.providerSubjectHash == providerSubjectHash
+        }
+
+    override fun findByPendingTokenHash(pendingTokenHash: String): PendingOAuthSignup? =
+        saved.firstOrNull { it.pendingTokenHash == pendingTokenHash }
+}
+
+private class RecordingLegalAcceptanceRepository : MemberLegalAcceptanceRepositoryPort {
+    val saved = mutableListOf<MemberLegalAcceptance>()
+
+    override fun save(memberLegalAcceptance: MemberLegalAcceptance): MemberLegalAcceptance {
+        saved += memberLegalAcceptance
+        return memberLegalAcceptance
+    }
+}
+
+private class RecordingMemberUseCase : MemberUseCase {
+    val existingLoginIds = mutableSetOf<String>()
+    val members = mutableListOf<Member>()
+
+    override fun count(): Long = members.size.toLong()
+
+    override fun join(
+        username: String,
+        password: String?,
+        nickname: String,
+        profileImgUrl: String?,
+        email: String?,
+    ): Member {
+        if (existingLoginIds.contains(username)) {
+            throw AppException("409-1", "이미 존재하는 회원 아이디입니다.")
+        }
+
+        val member =
+            Member(
+                id = members.size.toLong() + 1,
+                username = username,
+                password = password,
+                nickname = nickname,
+                email = email,
+            )
+        members += member
+        existingLoginIds += username
+        profileImgUrl?.let { member.profileImgUrl = it }
+        return member
+    }
+
+    override fun joinWithVerifiedEmail(
+        email: String,
+        password: String?,
+        nickname: String,
+        profileImgUrl: String?,
+    ): Member = error("joinWithVerifiedEmail is not used")
+
+    override fun findByLoginId(loginId: String): Member? =
+        members.firstOrNull { it.username == loginId }
+            ?: existingLoginIds
+                .takeIf { it.contains(loginId) }
+                ?.let { Member(id = 99, username = loginId, password = null, nickname = "기존회원") }
+
+    override fun findByEmail(email: String): Member? = null
+
+    override fun findById(id: Long): Optional<Member> = Optional.empty()
+
+    override fun checkPassword(
+        member: Member,
+        rawPassword: String,
+    ) = Unit
+
+    override fun modify(
+        member: Member,
+        nickname: String,
+        profileImgUrl: String?,
+    ) = Unit
+
+    override fun modifyProfileCard(
+        member: Member,
+        role: String,
+        bio: String,
+        aboutRole: String?,
+        aboutBio: String?,
+        aboutDetails: String?,
+        blogTitle: String,
+        homeIntroTitle: String,
+        homeIntroDescription: String,
+        blogDesign: String,
+        legacyBlogScheme: String,
+        serviceLinks: List<MemberProfileLinkItem>,
+        contactLinks: List<MemberProfileLinkItem>,
+    ) = Unit
+
+    override fun saveProfileWorkspaceDraft(
+        member: Member,
+        content: MemberProfileWorkspaceContent,
+    ) = Unit
+
+    override fun publishProfileWorkspace(member: Member) = Unit
+
+    override fun modifyOrJoin(
+        username: String,
+        password: String?,
+        nickname: String,
+        profileImgUrl: String?,
+    ): RsData<Member> = error("modifyOrJoin is not used")
+
+    override fun findPagedByKw(
+        kw: String,
+        sort: MemberSearchSortType1,
+        page: Int,
+        pageSize: Int,
+    ): PagedResult<Member> =
+        PagedResult(
+            content = emptyList(),
+            page = page,
+            pageSize = pageSize,
+            totalElements = 0,
+        )
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
@@ -9,7 +9,7 @@ import com.back.boundedContexts.member.subContexts.legalAcceptance.application.s
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberLegalAcceptance
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.output.PendingOAuthSignupRepositoryPort
-import com.back.boundedContexts.member.subContexts.oauthSignup.domain.PendingOAuthSignup
+import com.back.boundedContexts.member.subContexts.oauthSignup.model.PendingOAuthSignup
 import com.back.global.exception.application.AppException
 import com.back.global.rsData.RsData
 import com.back.standard.dto.member.type1.MemberSearchSortType1

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
@@ -18,10 +18,29 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import java.util.Optional
 
 @DisplayName("OAuthSignupApplicationService 테스트")
 class OAuthSignupApplicationServiceTest {
+    @Test
+    fun `pending 시작은 OAuth redirect 예외 rollback과 분리되는 새 transaction에서 실행한다`() {
+        val method =
+            OAuthSignupApplicationService::class.java.getMethod(
+                "startPending",
+                String::class.java,
+                String::class.java,
+                String::class.java,
+                String::class.java,
+            )
+
+        val transactional = method.getAnnotation(Transactional::class.java)
+
+        assertThat(transactional.propagation)
+            .isEqualTo(Propagation.REQUIRES_NEW)
+    }
+
     @Test
     fun `신규 OAuth pending은 원문 token과 provider subject 대신 hash를 저장한다`() {
         val fixture = Fixture()

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
@@ -69,6 +69,42 @@ class OAuthSignupApplicationServiceTest {
     }
 
     @Test
+    fun `provider nickname이 정책 범위를 벗어나도 pending을 만들고 기본 표시 이름을 사용한다`() {
+        val fixture = Fixture()
+
+        fixture.service.startPending(
+            provider = "KAKAO",
+            providerSubject = "subject-invalid-nickname",
+            nickname = "x",
+            profileImgUrl = null,
+        )
+
+        val pending = fixture.pendingRepository.saved.single()
+        assertThat(pending.nickname).isEqualTo("카카오사용자")
+    }
+
+    @Test
+    fun `최종 제출 nickname은 정책 범위 검증을 유지한다`() {
+        val fixture = Fixture()
+        val start =
+            fixture.service.startPending(
+                provider = "KAKAO",
+                providerSubject = "subject-final-invalid-nickname",
+                nickname = "카카오닉네임",
+                profileImgUrl = null,
+            )
+
+        assertThatThrownBy {
+            fixture.service.completeSignup(
+                pendingToken = start.pendingToken,
+                nickname = "x",
+                legalAcceptance = validLegalAcceptance(),
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("프로필 이름은 2~30자")
+    }
+
+    @Test
     fun `같은 OAuth subject가 다시 callback되면 기존 pending row를 새 token hash로 갱신한다`() {
         val fixture = Fixture()
         val first =
@@ -210,7 +246,7 @@ private fun validLegalAcceptance(): LegalAcceptanceCommand =
         termsVersion = "2026-06-21",
         termsContentSha256 = "3b71950e518b16b9a24cb4f9873633720ca7a9fce145a7bb9787c48845b56c5b",
         privacyVersion = "2026-06-21",
-        privacyContentSha256 = "4cc6ae3260aaca5f5ff35b235af91679a60760f13dccad9e85c94fda4d1552d9",
+        privacyContentSha256 = "cedbfea674a9e2aca9e29bf6a01492a1e3fa640b0ff53d47f969d64c057b980f",
         age14OrOlder = true,
         requiredPrivacyConfirmed = true,
         analyticsConsent = false,

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
 import java.util.Optional
 
 @DisplayName("OAuthSignupApplicationService 테스트")
@@ -69,6 +70,47 @@ class OAuthSignupApplicationServiceTest {
     }
 
     @Test
+    fun `provider subject hash와 member login id helper는 hash service 계약을 노출한다`() {
+        val fixture = Fixture()
+
+        val providerSubjectHash =
+            fixture.service.providerSubjectHash(
+                provider = " kakao ",
+                providerSubject = RAW_PROVIDER_SUBJECT,
+            )
+        val memberLoginId =
+            fixture.service.memberLoginId(
+                provider = " kakao ",
+                providerSubjectHash = providerSubjectHash,
+            )
+
+        assertThat(providerSubjectHash)
+            .isEqualTo(fixture.hashService.providerSubjectHash(" kakao ", RAW_PROVIDER_SUBJECT))
+        assertThat(memberLoginId)
+            .isEqualTo(fixture.hashService.memberLoginId(" kakao ", providerSubjectHash))
+    }
+
+    @Test
+    fun `이미 연결된 member login id가 있으면 pending을 시작하지 않는다`() {
+        val fixture = Fixture()
+        fixture.memberUseCase.existingLoginIds +=
+            fixture.hashService.memberLoginId(
+                "KAKAO",
+                fixture.hashService.providerSubjectHash("KAKAO", "subject-existing-member"),
+            )
+
+        assertThatThrownBy {
+            fixture.service.startPending(
+                provider = "KAKAO",
+                providerSubject = "subject-existing-member",
+                nickname = "카카오닉네임",
+                profileImgUrl = null,
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("이미 연결된 소셜 계정")
+    }
+
+    @Test
     fun `provider nickname이 정책 범위를 벗어나도 pending을 만들고 기본 표시 이름을 사용한다`() {
         val fixture = Fixture()
 
@@ -81,6 +123,30 @@ class OAuthSignupApplicationServiceTest {
 
         val pending = fixture.pendingRepository.saved.single()
         assertThat(pending.nickname).isEqualTo("카카오사용자")
+    }
+
+    @Test
+    fun `이미 소비된 pending row가 있으면 callback refresh를 거부한다`() {
+        val fixture = Fixture()
+        fixture.service.startPending(
+            provider = "KAKAO",
+            providerSubject = "subject-consumed",
+            nickname = "카카오닉네임",
+            profileImgUrl = null,
+        )
+        fixture.pendingRepository.saved
+            .single()
+            .consume(Instant.EPOCH.plusSeconds(1))
+
+        assertThatThrownBy {
+            fixture.service.startPending(
+                provider = "KAKAO",
+                providerSubject = "subject-consumed",
+                nickname = "카카오닉네임",
+                profileImgUrl = null,
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("이미 처리된 소셜 회원가입")
     }
 
     @Test
@@ -132,6 +198,52 @@ class OAuthSignupApplicationServiceTest {
     }
 
     @Test
+    fun `pending 조회는 token hash로 세션 상세를 반환한다`() {
+        val fixture = Fixture()
+        val start =
+            fixture.service.startPending(
+                provider = "KAKAO",
+                providerSubject = "subject-readable",
+                nickname = "카카오닉네임",
+                profileImgUrl = "https://kakao.cdn/profile.png",
+            )
+
+        val pending = fixture.service.findPending(start.pendingToken)
+
+        assertThat(pending.provider).isEqualTo("KAKAO")
+        assertThat(pending.nickname).isEqualTo("카카오닉네임")
+        assertThat(pending.profileImgUrl).isEqualTo("https://kakao.cdn/profile.png")
+        assertThat(pending.expiresAt).isEqualTo(start.expiresAt)
+    }
+
+    @Test
+    fun `pending 조회는 blank token과 없는 token을 거부한다`() {
+        val fixture = Fixture()
+
+        assertThatThrownBy { fixture.service.findPending(" ") }
+            .isInstanceOf(AppException::class.java)
+            .hasMessageContaining("올바르지 않습니다")
+        assertThatThrownBy { fixture.service.findPending("missing-token") }
+            .isInstanceOf(AppException::class.java)
+            .hasMessageContaining("유효하지 않은")
+    }
+
+    @Test
+    fun `blank provider는 pending 시작을 거부한다`() {
+        val fixture = Fixture()
+
+        assertThatThrownBy {
+            fixture.service.startPending(
+                provider = " ",
+                providerSubject = "subject",
+                nickname = "카카오닉네임",
+                profileImgUrl = null,
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("제공자가 올바르지 않습니다")
+    }
+
+    @Test
     fun `pending 완료는 member와 social legal acceptance를 생성하고 pending을 소비한다`() {
         val fixture = Fixture()
         val start =
@@ -158,6 +270,8 @@ class OAuthSignupApplicationServiceTest {
         assertThat(member.nickname).isEqualTo("완료닉네임")
         val legalAcceptance = fixture.legalAcceptanceRepository.saved.single()
         val consumedPending = fixture.pendingRepository.saved.single()
+        assertThat(legalAcceptance.id)
+            .isEqualTo(0)
         assertThat(legalAcceptance.source)
             .isEqualTo("KAKAO_OAUTH_SIGNUP")
         assertThat(consumedPending.consumedAt)

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupHashServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupHashServiceTest.kt
@@ -1,0 +1,67 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.application.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("OAuthSignupHashService 테스트")
+class OAuthSignupHashServiceTest {
+    @Test
+    fun `pending token과 provider subject는 목적별 HMAC으로 변환한다`() {
+        val service = OAuthSignupHashService("oauth-secret", "signup-secret", "jwt-secret")
+
+        val tokenHash = service.pendingTokenHash(" pending-token ")
+        val subjectHash = service.providerSubjectHash(" kakao ", " provider-subject ")
+
+        assertThat(tokenHash).isEqualTo(service.pendingTokenHash("pending-token"))
+        assertThat(subjectHash).isEqualTo(service.providerSubjectHash("KAKAO", "provider-subject"))
+        assertThat(tokenHash).isNotEqualTo(subjectHash)
+        assertThat(tokenHash).doesNotContain("pending-token")
+        assertThat(subjectHash).doesNotContain("provider-subject")
+    }
+
+    @Test
+    fun `member login id는 정규화 provider와 hash prefix로 만든다`() {
+        val service = OAuthSignupHashService("oauth-secret", "signup-secret", "jwt-secret")
+        val providerSubjectHash = "a".repeat(80)
+
+        val loginId = service.memberLoginId(" kakao ", providerSubjectHash)
+
+        assertThat(loginId).isEqualTo("KAKAO__${"a".repeat(43)}")
+    }
+
+    @Test
+    fun `전용 secret이 비어 있으면 signup secret과 jwt secret 순서로 fallback한다`() {
+        val signupFallback = OAuthSignupHashService("", "signup-secret", "jwt-secret")
+        val jwtFallback = OAuthSignupHashService("", "", "jwt-secret")
+
+        assertThat(signupFallback.pendingTokenHash("token"))
+            .isNotBlank()
+        assertThat(jwtFallback.pendingTokenHash("token"))
+            .isNotBlank()
+        assertThat(signupFallback.pendingTokenHash("token"))
+            .isNotEqualTo(jwtFallback.pendingTokenHash("token"))
+    }
+
+    @Test
+    fun `blank 입력과 secret은 거부한다`() {
+        val service = OAuthSignupHashService("oauth-secret", "signup-secret", "jwt-secret")
+
+        assertThatThrownBy { service.pendingTokenHash(" ") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("oauth-signup-pending-token")
+        assertThatThrownBy { service.providerSubjectHash(" ", "subject") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("oauth provider")
+        assertThatThrownBy { service.providerSubjectHash("KAKAO", " ") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("oauth provider subject")
+        assertThatThrownBy { service.memberLoginId("KAKAO", " ") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("oauth provider subject hash")
+        assertThatThrownBy { OAuthSignupHashService("", "", "").pendingTokenHash("token") }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("custom.member.oauthSignup.tokenHashSecret")
+    }
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/model/PendingOAuthSignupTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/model/PendingOAuthSignupTest.kt
@@ -1,0 +1,91 @@
+package com.back.boundedContexts.member.subContexts.oauthSignup.model
+
+import com.back.global.exception.application.AppException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+@DisplayName("PendingOAuthSignup 테스트")
+class PendingOAuthSignupTest {
+    @Test
+    fun `refresh는 token과 만료시각과 프로필을 갱신하고 취소 상태를 해제한다`() {
+        val pending =
+            pendingOAuthSignup(
+                id = 11,
+                profileImgUrl = "https://old.example/profile.png",
+            )
+        pending.cancel(Instant.EPOCH.plusSeconds(1))
+
+        pending.refresh(
+            pendingTokenHash = "new-token-hash",
+            expiresAt = Instant.EPOCH.plusSeconds(600),
+            nickname = "새닉네임",
+            profileImgUrl = "https://new.example/profile.png",
+        )
+
+        assertThat(pending.id).isEqualTo(11)
+        assertThat(pending.pendingTokenHash).isEqualTo("new-token-hash")
+        assertThat(pending.pendingTokenExpiresAt).isEqualTo(Instant.EPOCH.plusSeconds(600))
+        assertThat(pending.nickname).isEqualTo("새닉네임")
+        assertThat(pending.profileImgUrl).isEqualTo("https://new.example/profile.png")
+        assertThat(pending.cancelledAt).isNull()
+    }
+
+    @Test
+    fun `consume은 readable pending만 소비한다`() {
+        val pending = pendingOAuthSignup()
+        val pendingWithoutProfile =
+            PendingOAuthSignup(
+                provider = "KAKAO",
+                providerSubjectHash = "subject-hash",
+                memberLoginId = "KAKAO__subject-hash",
+                pendingTokenHash = "token-hash",
+                pendingTokenExpiresAt = Instant.EPOCH.plusSeconds(300),
+                nickname = "카카오닉네임",
+            )
+
+        assertThat(pending.profileImgUrl).isNull()
+        assertThat(pendingWithoutProfile.profileImgUrl).isNull()
+        pending.consume(Instant.EPOCH.plusSeconds(1))
+
+        assertThat(pending.consumedAt).isEqualTo(Instant.EPOCH.plusSeconds(1))
+        assertThatThrownBy { pending.ensureReadable(Instant.EPOCH.plusSeconds(2)) }
+            .isInstanceOf(AppException::class.java)
+            .hasMessageContaining("더 이상 유효하지 않습니다")
+    }
+
+    @Test
+    fun `cancelled pending과 expired pending은 읽을 수 없다`() {
+        val cancelled = pendingOAuthSignup()
+        cancelled.cancel(Instant.EPOCH.plusSeconds(1))
+        val expired =
+            pendingOAuthSignup(
+                expiresAt = Instant.EPOCH.plusSeconds(10),
+            )
+
+        assertThatThrownBy { cancelled.ensureReadable(Instant.EPOCH.plusSeconds(2)) }
+            .isInstanceOf(AppException::class.java)
+            .hasMessageContaining("더 이상 유효하지 않습니다")
+        assertThatThrownBy { expired.ensureReadable(Instant.EPOCH.plusSeconds(11)) }
+            .isInstanceOf(AppException::class.java)
+            .hasMessageContaining("만료되었습니다")
+    }
+}
+
+private fun pendingOAuthSignup(
+    id: Long = 0,
+    expiresAt: Instant = Instant.EPOCH.plusSeconds(300),
+    profileImgUrl: String? = null,
+): PendingOAuthSignup =
+    PendingOAuthSignup(
+        id = id,
+        provider = "KAKAO",
+        providerSubjectHash = "subject-hash",
+        memberLoginId = "KAKAO__subject-hash",
+        pendingTokenHash = "token-hash",
+        pendingTokenExpiresAt = expiresAt,
+        nickname = "카카오닉네임",
+        profileImgUrl = profileImgUrl,
+    )

--- a/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginFailureHandlerTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginFailureHandlerTest.kt
@@ -9,9 +9,36 @@ import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.authentication.InternalAuthenticationServiceException
 import org.springframework.security.core.AuthenticationException
+import java.time.Instant
 
 @org.junit.jupiter.api.DisplayName("CustomOAuth2LoginFailureHandler 테스트")
 class CustomOAuth2LoginFailureHandlerTest {
+    @Test
+    fun `pending OAuth 가입은 social complete 화면에 fragment token과 next를 전달한다`() {
+        val handler = CustomOAuth2LoginFailureHandler("https://www.aquilaxk.site")
+        val request =
+            MockHttpServletRequest("GET", "/login/oauth2/code/kakao").apply {
+                setParameter("state", OAuth2State("/posts/1?tab=comments", "state-id").encode())
+            }
+        val response = MockHttpServletResponse()
+
+        handler.onAuthenticationFailure(
+            request,
+            response,
+            OAuthSignupRequiredAuthenticationException(
+                provider = "KAKAO",
+                pendingToken = "pending-token",
+                expiresAt = Instant.EPOCH.plusSeconds(300),
+            ),
+        )
+
+        assertThat(response.status).isEqualTo(302)
+        assertThat(response.redirectedUrl)
+            .isEqualTo(
+                "https://www.aquilaxk.site/signup/social/complete#token=pending-token&provider=kakao&next=%2Fposts%2F1%3Ftab%3Dcomments",
+            )
+    }
+
     @Test
     fun `신규 OAuth 가입 차단 실패는 로그인 화면에 signup-required 코드와 next를 전달한다`() {
         val handler = CustomOAuth2LoginFailureHandler("https://www.aquilaxk.site")

--- a/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginFailureHandlerTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginFailureHandlerTest.kt
@@ -40,6 +40,42 @@ class CustomOAuth2LoginFailureHandlerTest {
     }
 
     @Test
+    fun `absolute redirect state는 해당 origin의 social complete 화면으로 pending token을 전달한다`() {
+        AppConfig("https://api.aquilaxk.site", "https://preview.aquilaxk.site")
+        try {
+            val handler = CustomOAuth2LoginFailureHandler("https://www.aquilaxk.site")
+            val request =
+                MockHttpServletRequest("GET", "/login/oauth2/code/kakao").apply {
+                    setParameter(
+                        "state",
+                        OAuth2State
+                            .of("https://preview.aquilaxk.site/editor?draft=1")
+                            .encode(),
+                    )
+                }
+            val response = MockHttpServletResponse()
+
+            handler.onAuthenticationFailure(
+                request,
+                response,
+                OAuthSignupRequiredAuthenticationException(
+                    provider = "KAKAO",
+                    pendingToken = "pending-token",
+                    expiresAt = Instant.EPOCH.plusSeconds(300),
+                ),
+            )
+
+            assertThat(response.status).isEqualTo(302)
+            assertThat(response.redirectedUrl)
+                .isEqualTo(
+                    "https://preview.aquilaxk.site/signup/social/complete#token=pending-token&provider=kakao&next=%2Feditor%3Fdraft%3D1",
+                )
+        } finally {
+            AppConfig("https://api.aquilaxk.site", "https://www.aquilaxk.site")
+        }
+    }
+
+    @Test
     fun `신규 OAuth 가입 차단 실패는 로그인 화면에 signup-required 코드와 next를 전달한다`() {
         val handler = CustomOAuth2LoginFailureHandler("https://www.aquilaxk.site")
         val request =

--- a/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserServiceTest.kt
@@ -2,13 +2,15 @@ package com.back.global.security.config.oauth2
 
 import com.back.boundedContexts.member.application.port.input.MemberUseCase
 import com.back.boundedContexts.member.domain.shared.Member
-import com.back.global.exception.application.AppException
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupPendingDetails
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupPendingStartResult
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupUseCase
 import com.back.global.security.domain.SecurityUser
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.springframework.security.authentication.InternalAuthenticationServiceException
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.client.registration.ClientRegistration
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
@@ -31,8 +33,9 @@ class CustomOAuth2UserServiceTest {
     @Test
     fun `OAuth2 기존 사용자는 내부 SecurityUser로 매핑하고 프로필을 갱신한다`() {
         val memberUseCase = RecordingMemberUseCase(existingMemberUsername = "KAKAO__oauth-user-id")
+        val oauthSignupUseCase = RecordingOAuthSignupUseCase()
         val service =
-            CustomOAuth2UserService(memberUseCase.proxy).apply {
+            CustomOAuth2UserService(memberUseCase.proxy, oauthSignupUseCase).apply {
                 delegate =
                     OAuth2UserService<OAuth2UserRequest, OAuth2User> {
                         DefaultOAuth2User(emptyList(), mapOf("id" to "oauth-user-id"), "id")
@@ -45,6 +48,8 @@ class CustomOAuth2UserServiceTest {
             ) as SecurityUser
 
         assertThat(memberUseCase.lastFindLoginId).isEqualTo("KAKAO__oauth-user-id")
+        assertThat(memberUseCase.findLoginIds).containsExactly("KAKAO__subject-hash", "KAKAO__oauth-user-id")
+        assertThat(oauthSignupUseCase.pendingStarts).isEmpty()
         assertThat(memberUseCase.lastModifyRequest)
             .isEqualTo(
                 ModifyRequest(
@@ -60,6 +65,7 @@ class CustomOAuth2UserServiceTest {
     @Test
     fun `OIDC claims는 SecurityUser이자 OidcUser인 principal로 매핑한다`() {
         val memberUseCase = RecordingMemberUseCase(existingMemberUsername = "KAKAO__oidc-user-id")
+        val oauthSignupUseCase = RecordingOAuthSignupUseCase()
         val idToken =
             OidcIdToken(
                 "id-token",
@@ -79,7 +85,7 @@ class CustomOAuth2UserServiceTest {
                 ),
             )
         val service =
-            CustomOidcUserService(memberUseCase.proxy).apply {
+            CustomOidcUserService(memberUseCase.proxy, oauthSignupUseCase).apply {
                 delegate =
                     OAuth2UserService<OidcUserRequest, OidcUser> {
                         DefaultOidcUser(emptyList(), idToken, userInfo, "sub")
@@ -93,6 +99,8 @@ class CustomOAuth2UserServiceTest {
         val securityUser = principal as SecurityUser
 
         assertThat(memberUseCase.lastFindLoginId).isEqualTo("KAKAO__oidc-user-id")
+        assertThat(memberUseCase.findLoginIds).containsExactly("KAKAO__subject-hash", "KAKAO__oidc-user-id")
+        assertThat(oauthSignupUseCase.pendingStarts).isEmpty()
         assertThat(memberUseCase.lastModifyRequest)
             .isEqualTo(
                 ModifyRequest(
@@ -109,9 +117,11 @@ class CustomOAuth2UserServiceTest {
     }
 
     @Test
-    fun `OAuth2 신규 사용자는 동의 기록이 없으므로 자동 가입하지 않는다`() {
+    fun `OAuth2 신규 사용자는 member를 만들지 않고 pending 동의 토큰을 발급한다`() {
+        val memberUseCase = RecordingMemberUseCase()
+        val oauthSignupUseCase = RecordingOAuthSignupUseCase()
         val service =
-            CustomOAuth2UserService(RecordingMemberUseCase().proxy).apply {
+            CustomOAuth2UserService(memberUseCase.proxy, oauthSignupUseCase).apply {
                 delegate =
                     OAuth2UserService<OAuth2UserRequest, OAuth2User> {
                         DefaultOAuth2User(emptyList(), mapOf("id" to "new-oauth-user-id"), "id")
@@ -122,16 +132,25 @@ class CustomOAuth2UserServiceTest {
             service.loadUser(
                 OAuth2UserRequest(kakaoClientRegistration(userNameAttributeName = "id"), accessToken()),
             )
-        }.isInstanceOf(InternalAuthenticationServiceException::class.java)
-            .cause()
-            .isInstanceOf(AppException::class.java)
-            .hasMessageContaining("소셜 로그인 신규 가입은 현재 지원하지 않습니다.")
+        }.isInstanceOf(OAuthSignupRequiredAuthenticationException::class.java)
+            .hasMessageNotContaining("new-oauth-user-id")
+
+        assertThat(memberUseCase.findLoginIds).containsExactly("KAKAO__subject-hash", "KAKAO__new-oauth-user-id")
+        assertThat(oauthSignupUseCase.pendingStarts)
+            .containsExactly(
+                PendingStartRequest(
+                    provider = "KAKAO",
+                    providerSubject = "new-oauth-user-id",
+                    nickname = OAuth2ProfileExtractor.DEFAULT_KAKAO_NICKNAME,
+                    profileImgUrl = null,
+                ),
+            )
     }
 
     @Test
     fun `지원하지 않는 provider는 명시적으로 거부한다`() {
         val service =
-            CustomOAuth2UserService(RecordingMemberUseCase().proxy).apply {
+            CustomOAuth2UserService(RecordingMemberUseCase().proxy, RecordingOAuthSignupUseCase()).apply {
                 delegate =
                     OAuth2UserService<OAuth2UserRequest, OAuth2User> {
                         DefaultOAuth2User(emptyList(), mapOf("id" to "oauth-user-id"), "id")
@@ -184,11 +203,19 @@ private data class ModifyRequest(
     val profileImgUrl: String?,
 )
 
+private data class PendingStartRequest(
+    val provider: String,
+    val providerSubject: String,
+    val nickname: String,
+    val profileImgUrl: String?,
+)
+
 private class RecordingMemberUseCase(
     private val existingMemberUsername: String? = null,
 ) {
     var lastFindLoginId: String? = null
         private set
+    val findLoginIds = mutableListOf<String>()
     var lastModifyRequest: ModifyRequest? = null
         private set
     private var existingMember: Member? =
@@ -211,6 +238,7 @@ private class RecordingMemberUseCase(
                     "findByLoginId" -> {
                         val loginId = args?.get(0) as String
                         lastFindLoginId = loginId
+                        findLoginIds += loginId
                         existingMember?.takeIf { it.username == loginId }
                     }
                     "modify" -> {
@@ -231,4 +259,47 @@ private class RecordingMemberUseCase(
                     else -> error("Unexpected MemberUseCase method: ${method.name}")
                 }
             } as MemberUseCase
+}
+
+private class RecordingOAuthSignupUseCase : OAuthSignupUseCase {
+    val pendingStarts = mutableListOf<PendingStartRequest>()
+
+    override fun providerSubjectHash(
+        provider: String,
+        providerSubject: String,
+    ): String = "subject-hash"
+
+    override fun memberLoginId(
+        provider: String,
+        providerSubjectHash: String,
+    ): String = "${provider}__$providerSubjectHash"
+
+    override fun startPending(
+        provider: String,
+        providerSubject: String,
+        nickname: String,
+        profileImgUrl: String?,
+    ): OAuthSignupPendingStartResult {
+        pendingStarts +=
+            PendingStartRequest(
+                provider = provider,
+                providerSubject = providerSubject,
+                nickname = nickname,
+                profileImgUrl = profileImgUrl,
+            )
+        return OAuthSignupPendingStartResult(
+            provider = provider,
+            pendingToken = "pending-token",
+            expiresAt = Instant.EPOCH.plusSeconds(300),
+        )
+    }
+
+    override fun findPending(pendingToken: String): OAuthSignupPendingDetails =
+        error("findPending is not used in CustomOAuth2UserServiceTest")
+
+    override fun completeSignup(
+        pendingToken: String,
+        nickname: String?,
+        legalAcceptance: LegalAcceptanceCommand,
+    ): Member = error("completeSignup is not used in CustomOAuth2UserServiceTest")
 }

--- a/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserServiceTest.kt
@@ -3,9 +3,9 @@ package com.back.global.security.config.oauth2
 import com.back.boundedContexts.member.application.port.input.MemberUseCase
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
-import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupPendingDetails
-import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupPendingStartResult
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupUseCase
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingDetails
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingStartResult
 import com.back.global.security.domain.SecurityUser
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -957,6 +957,62 @@
         } ]
       }
     },
+    "/member/api/v1/signup/social/pending" : {
+      "post" : {
+        "tags" : [ "api-v-1-o-auth-signup-controller" ],
+        "operationId" : "pending",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SocialSignupPendingRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RsDataOAuthSignupPendingDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/member/api/v1/signup/social/complete" : {
+      "post" : {
+        "tags" : [ "api-v-1-o-auth-signup-controller" ],
+        "operationId" : "complete",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SocialSignupCompleteRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RsDataMemberDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/member/api/v1/signup/email/verify" : {
       "get" : {
         "tags" : [ "api-v-1-signup-verification-controller" ],
@@ -1032,7 +1088,7 @@
     "/member/api/v1/signup/complete" : {
       "post" : {
         "tags" : [ "api-v-1-signup-verification-controller" ],
-        "operationId" : "complete",
+        "operationId" : "complete_1",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3986,6 +4042,138 @@
           }
         }
       },
+      "SocialSignupPendingRequest" : {
+        "type" : "object",
+        "properties" : {
+          "token" : {
+            "type" : "string",
+            "minLength" : 1
+          }
+        },
+        "required" : [ "token" ]
+      },
+      "OAuthSignupPendingDetails" : {
+        "type" : "object",
+        "properties" : {
+          "provider" : {
+            "type" : "string"
+          },
+          "nickname" : {
+            "type" : "string"
+          },
+          "profileImgUrl" : {
+            "type" : "string"
+          },
+          "expiresAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }
+      },
+      "RsDataOAuthSignupPendingDetails" : {
+        "type" : "object",
+        "properties" : {
+          "resultCode" : {
+            "type" : "string"
+          },
+          "msg" : {
+            "type" : "string"
+          },
+          "data" : {
+            "$ref" : "#/components/schemas/OAuthSignupPendingDetails"
+          }
+        }
+      },
+      "SocialSignupCompleteRequest" : {
+        "type" : "object",
+        "properties" : {
+          "token" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "nickname" : {
+            "type" : "string",
+            "maxLength" : 30,
+            "minLength" : 2
+          },
+          "termsVersion" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "minLength" : 0
+          },
+          "termsContentSha256" : {
+            "type" : "string",
+            "maxLength" : 64,
+            "minLength" : 64
+          },
+          "privacyVersion" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "minLength" : 0
+          },
+          "privacyContentSha256" : {
+            "type" : "string",
+            "maxLength" : 64,
+            "minLength" : 64
+          },
+          "age14OrOlder" : {
+            "type" : "boolean"
+          },
+          "requiredPrivacyConfirmed" : {
+            "type" : "boolean"
+          },
+          "analyticsConsent" : {
+            "type" : "boolean"
+          },
+          "overseasTransferAcknowledged" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "age14OrOlder", "analyticsConsent", "overseasTransferAcknowledged", "privacyContentSha256", "privacyVersion", "requiredPrivacyConfirmed", "termsContentSha256", "termsVersion", "token" ]
+      },
+      "MemberDto" : {
+        "type" : "object",
+        "properties" : {
+          "isAdmin" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "modifiedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "profileImageUrl" : {
+            "type" : "string"
+          },
+          "admin" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "RsDataMemberDto" : {
+        "type" : "object",
+        "properties" : {
+          "resultCode" : {
+            "type" : "string"
+          },
+          "msg" : {
+            "type" : "string"
+          },
+          "data" : {
+            "$ref" : "#/components/schemas/MemberDto"
+          }
+        }
+      },
       "SignupEmailVerifyRequest" : {
         "type" : "object",
         "properties" : {
@@ -4121,49 +4309,6 @@
           }
         },
         "required" : [ "age14OrOlder", "analyticsConsent", "nickname", "overseasTransferAcknowledged", "password", "privacyContentSha256", "privacyVersion", "requiredPrivacyConfirmed", "termsContentSha256", "termsVersion" ]
-      },
-      "MemberDto" : {
-        "type" : "object",
-        "properties" : {
-          "isAdmin" : {
-            "type" : "boolean"
-          },
-          "id" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "createdAt" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "modifiedAt" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "name" : {
-            "type" : "string"
-          },
-          "profileImageUrl" : {
-            "type" : "string"
-          },
-          "admin" : {
-            "type" : "boolean"
-          }
-        }
-      },
-      "RsDataMemberDto" : {
-        "type" : "object",
-        "properties" : {
-          "resultCode" : {
-            "type" : "string"
-          },
-          "msg" : {
-            "type" : "string"
-          },
-          "data" : {
-            "$ref" : "#/components/schemas/MemberDto"
-          }
-        }
       },
       "RsDataMapStringBoolean" : {
         "type" : "object",

--- a/front/e2e/signup-token-url.spec.ts
+++ b/front/e2e/signup-token-url.spec.ts
@@ -14,6 +14,10 @@ test("signup verify flow keeps token and completion email out of query URLs", ()
   const signupVerificationController = readRepoFile(
     "back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt",
   )
+  const socialSignupPage = readRepoFile("front/src/pages/signup/social/complete.tsx")
+  const oauthFailureHandler = readRepoFile(
+    "back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginFailureHandler.kt",
+  )
 
   expect(signupVerifyPage).toContain("window.location.hash")
   expect(signupVerifyPage).toContain("window.history.replaceState")
@@ -34,4 +38,12 @@ test("signup verify flow keeps token and completion email out of query URLs", ()
   expect(signupVerificationController).toContain("@PostMapping(\"/email/verify\")")
   expect(signupVerificationController).toContain("@GetMapping(\"/email/verify\")")
   expect(signupVerificationController).not.toContain("@RequestParam token")
+
+  expect(socialSignupPage).toContain("window.location.hash")
+  expect(socialSignupPage).toContain("window.history.replaceState")
+  expect(socialSignupPage).toContain('"/member/api/v1/signup/social/pending"')
+  expect(socialSignupPage).toContain('"/member/api/v1/signup/social/complete"')
+  expect(socialSignupPage).not.toContain("router.query.token")
+  expect(oauthFailureHandler).toContain("appendFragment")
+  expect(oauthFailureHandler).toContain("signup/social/complete")
 })

--- a/front/e2e/social-signup-consent.spec.ts
+++ b/front/e2e/social-signup-consent.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test"
+
+test("social signup completion keeps token in fragment and requires legal consent", async ({ page }) => {
+  let pendingRequestBody: unknown = null
+  let completeRequestBody: Record<string, unknown> | null = null
+
+  await page.route("**/member/api/v1/signup/social/pending", async (route) => {
+    pendingRequestBody = route.request().postDataJSON()
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "200-3",
+        msg: "소셜 회원가입 세션을 확인했습니다.",
+        data: {
+          provider: "KAKAO",
+          nickname: "카카오닉네임",
+          profileImgUrl: null,
+          expiresAt: "2026-06-22T10:00:00Z",
+        },
+      }),
+    })
+  })
+
+  await page.route("**/member/api/v1/signup/social/complete", async (route) => {
+    completeRequestBody = route.request().postDataJSON()
+    await route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "201-3",
+        msg: "소셜 회원가입이 완료되었습니다.",
+        data: {
+          id: 77,
+          username: "KAKAO__hashed-subject",
+          nickname: completeRequestBody?.nickname,
+        },
+      }),
+    })
+  })
+
+  await page.goto("/signup/social/complete#token=social-token&provider=kakao&next=%2Fposts%2F1")
+
+  await expect(page).toHaveURL(/\/signup\/social\/complete$/)
+  await expect(page.getByRole("heading", { name: "소셜 회원가입" })).toBeVisible()
+  await expect(page.getByLabel("소셜 회원가입 프로필 정보")).toContainText("카카오닉네임")
+  await expect(page.getByLabel("Kakao OAuth 처리 항목")).toContainText("Kakao OAuth provider subject hash")
+  await expect(page.getByRole("button", { name: "가입" })).toBeDisabled()
+  expect(pendingRequestBody).toEqual({ token: "social-token" })
+
+  await page.getByLabel("프로필 이름").fill("최종닉네임")
+  await page.getByRole("checkbox", { name: /만 14세 이상/ }).check()
+  await page.getByRole("checkbox", { name: /개인정보처리방침/ }).check()
+  await page.getByRole("checkbox", { name: /Kakao OAuth와 서비스 운영/ }).check()
+  await expect(page.getByRole("button", { name: "가입" })).toBeEnabled()
+  await page.getByRole("button", { name: "가입" }).click()
+
+  await expect(page).toHaveURL(/\/login\?signup=done&next=%2Fposts%2F1/)
+  expect(completeRequestBody).toMatchObject({
+    token: "social-token",
+    nickname: "최종닉네임",
+    age14OrOlder: true,
+    requiredPrivacyConfirmed: true,
+    overseasTransferAcknowledged: true,
+    analyticsConsent: false,
+  })
+  expect(JSON.stringify(completeRequestBody)).not.toContain("password")
+})

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -326,6 +326,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/member/api/v1/signup/social/pending": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["pending"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/member/api/v1/signup/social/complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["complete"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/member/api/v1/signup/email/verify": {
         parameters: {
             query?: never;
@@ -367,7 +399,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        post: operations["complete"];
+        post: operations["complete_1"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1715,6 +1747,50 @@ export interface components {
             msg?: string;
             data?: components["schemas"]["RecommendTagsResBody"];
         };
+        SocialSignupPendingRequest: {
+            token: string;
+        };
+        OAuthSignupPendingDetails: {
+            provider?: string;
+            nickname?: string;
+            profileImgUrl?: string;
+            /** Format: date-time */
+            expiresAt?: string;
+        };
+        RsDataOAuthSignupPendingDetails: {
+            resultCode?: string;
+            msg?: string;
+            data?: components["schemas"]["OAuthSignupPendingDetails"];
+        };
+        SocialSignupCompleteRequest: {
+            token: string;
+            nickname?: string;
+            termsVersion: string;
+            termsContentSha256: string;
+            privacyVersion: string;
+            privacyContentSha256: string;
+            age14OrOlder: boolean;
+            requiredPrivacyConfirmed: boolean;
+            analyticsConsent: boolean;
+            overseasTransferAcknowledged: boolean;
+        };
+        MemberDto: {
+            isAdmin?: boolean;
+            /** Format: int64 */
+            id?: number;
+            /** Format: date-time */
+            createdAt?: string;
+            /** Format: date-time */
+            modifiedAt?: string;
+            name?: string;
+            profileImageUrl?: string;
+            admin?: boolean;
+        };
+        RsDataMemberDto: {
+            resultCode?: string;
+            msg?: string;
+            data?: components["schemas"]["MemberDto"];
+        };
         SignupEmailVerifyRequest: {
             token: string;
         };
@@ -1756,23 +1832,6 @@ export interface components {
             requiredPrivacyConfirmed: boolean;
             analyticsConsent: boolean;
             overseasTransferAcknowledged: boolean;
-        };
-        MemberDto: {
-            isAdmin?: boolean;
-            /** Format: int64 */
-            id?: number;
-            /** Format: date-time */
-            createdAt?: string;
-            /** Format: date-time */
-            modifiedAt?: string;
-            name?: string;
-            profileImageUrl?: string;
-            admin?: boolean;
-        };
-        RsDataMemberDto: {
-            resultCode?: string;
-            msg?: string;
-            data?: components["schemas"]["MemberDto"];
         };
         RsDataMapStringBoolean: {
             resultCode?: string;
@@ -2965,6 +3024,54 @@ export interface operations {
             };
         };
     };
+    pending: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SocialSignupPendingRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RsDataOAuthSignupPendingDetails"];
+                };
+            };
+        };
+    };
+    complete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SocialSignupCompleteRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RsDataMemberDto"];
+                };
+            };
+        };
+    };
     verifyLegacyGet: {
         parameters: {
             query?: never;
@@ -3033,7 +3140,7 @@ export interface operations {
             };
         };
     };
-    complete: {
+    complete_1: {
         parameters: {
             query?: never;
             header?: never;

--- a/front/src/apis/backend/legal.ts
+++ b/front/src/apis/backend/legal.ts
@@ -6,7 +6,7 @@ export const ACTIVE_LEGAL_DOCUMENTS = {
   },
   privacy: {
     version: "2026-06-21",
-    contentSha256: "4cc6ae3260aaca5f5ff35b235af91679a60760f13dccad9e85c94fda4d1552d9",
+    contentSha256: "cedbfea674a9e2aca9e29bf6a01492a1e3fa640b0ff53d47f969d64c057b980f",
   },
 } as const
 

--- a/front/src/apis/backend/legal.ts
+++ b/front/src/apis/backend/legal.ts
@@ -27,3 +27,5 @@ export const buildEmailSignupLegalAcceptancePayload = (input: {
   analyticsConsent: input.analyticsConsent,
   overseasTransferAcknowledged: input.overseasTransferAcknowledged,
 })
+
+export const buildSocialSignupLegalAcceptancePayload = buildEmailSignupLegalAcceptancePayload

--- a/front/src/pages/signup/social/complete.tsx
+++ b/front/src/pages/signup/social/complete.tsx
@@ -1,0 +1,555 @@
+import styled from "@emotion/styled"
+import { GetServerSideProps } from "next"
+import Link from "next/link"
+import { useRouter } from "next/router"
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react"
+import { apiFetch } from "src/apis/backend/client"
+import { toAuthErrorMessage } from "src/apis/backend/errorMessages"
+import { ACTIVE_LEGAL_DOCUMENTS, buildSocialSignupLegalAcceptancePayload } from "src/apis/backend/legal"
+import AuthShell from "src/components/auth/AuthShell"
+import { normalizeNextPath, replaceRoute, toLoginPath, toSignupPath } from "src/libs/router"
+import { GuestPageProps, getGuestPageProps } from "src/libs/server/guestPage"
+
+type RsData<T> = {
+  resultCode: string
+  msg: string
+  data: T
+}
+
+type SocialSignupPendingDetails = {
+  provider: string
+  nickname: string
+  profileImgUrl: string | null
+  expiresAt: string
+}
+
+type SocialSignupFragment = {
+  token: string | null
+  provider: string | null
+  next: string
+}
+
+export const getServerSideProps: GetServerSideProps<GuestPageProps> = async ({ req }) => {
+  return await getGuestPageProps(req)
+}
+
+const readSocialSignupFragment = (): SocialSignupFragment => {
+  if (typeof window === "undefined") {
+    return { token: null, provider: null, next: "/" }
+  }
+
+  const fragment = window.location.hash.replace(/^#/, "")
+  const params = new URLSearchParams(fragment)
+  const token = params.get("token")?.trim() || null
+  const provider = params.get("provider")?.trim() || null
+  const next = normalizeNextPath(params.get("next"), "/")
+  const cleanUrl = `${window.location.pathname}${window.location.search}`
+  window.history.replaceState(window.history.state, "", cleanUrl)
+
+  return { token, provider, next }
+}
+
+const providerLabel = (provider: string | null | undefined) => {
+  const normalizedProvider = provider?.trim().toLowerCase()
+  if (normalizedProvider === "kakao") return "Kakao"
+  return provider?.trim() || "Social"
+}
+
+const SocialSignupCompletePage = () => {
+  const router = useRouter()
+  const [pending, setPending] = useState<SocialSignupPendingDetails | null>(null)
+  const [loadingPending, setLoadingPending] = useState(true)
+  const [pendingError, setPendingError] = useState("")
+  const [nickname, setNickname] = useState("")
+  const [provider, setProvider] = useState<string | null>(null)
+  const [next, setNext] = useState("/")
+  const [age14OrOlder, setAge14OrOlder] = useState(false)
+  const [requiredPrivacyConfirmed, setRequiredPrivacyConfirmed] = useState(false)
+  const [analyticsConsent, setAnalyticsConsent] = useState(false)
+  const [overseasTransferAcknowledged, setOverseasTransferAcknowledged] = useState(false)
+  const [submitError, setSubmitError] = useState("")
+  const [submitLoading, setSubmitLoading] = useState(false)
+  const [pendingRetryCount, setPendingRetryCount] = useState(0)
+  const pendingTokenRef = useRef<string | null>(null)
+
+  const fallbackNext = useMemo(() => normalizeNextPath(router.query.next, "/"), [router.query.next])
+
+  useEffect(() => {
+    if (!router.isReady) return
+
+    const existingToken = pendingTokenRef.current
+    const fragment = existingToken ? null : readSocialSignupFragment()
+    const token = existingToken ?? fragment?.token ?? null
+    pendingTokenRef.current = token
+    if (fragment) {
+      setProvider(fragment.provider)
+      setNext(fragment.next || fallbackNext)
+    }
+
+    if (!token) {
+      setPendingError("소셜 회원가입 세션이 올바르지 않습니다.")
+      setLoadingPending(false)
+      return
+    }
+
+    let cancelled = false
+
+    const fetchPending = async () => {
+      setLoadingPending(true)
+      setPendingError("")
+
+      try {
+        const response = await apiFetch<RsData<SocialSignupPendingDetails>>(
+          "/member/api/v1/signup/social/pending",
+          {
+            method: "POST",
+            body: JSON.stringify({ token }),
+          },
+        )
+
+        if (cancelled) return
+        setPending(response.data)
+        setProvider(response.data.provider)
+        setNickname(response.data.nickname)
+      } catch (error) {
+        if (cancelled) return
+        setPendingError(toAuthErrorMessage("signupVerify", error, "소셜 회원가입 세션을 확인하지 못했습니다."))
+      } finally {
+        if (!cancelled) setLoadingPending(false)
+      }
+    }
+
+    void fetchPending()
+
+    return () => {
+      cancelled = true
+    }
+  }, [fallbackNext, pendingRetryCount, router.isReady])
+
+  const retryPending = () => {
+    if (!pendingTokenRef.current) return
+    setPendingRetryCount((value) => value + 1)
+  }
+
+  const requiredLegalAccepted = age14OrOlder && requiredPrivacyConfirmed && overseasTransferAcknowledged
+  const resolvedProviderLabel = providerLabel(pending?.provider ?? provider)
+  const submitFeedbackMessage = submitError ? (
+    <ErrorText>{submitError}</ErrorText>
+  ) : (
+    <InfoText>가입이 끝나면 로그인 화면으로 이동합니다. 이후부터는 {resolvedProviderLabel} 계정으로 로그인합니다.</InfoText>
+  )
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!pending || !pendingTokenRef.current) {
+      setSubmitError("소셜 회원가입 세션이 준비되지 않았습니다.")
+      return
+    }
+
+    if (!nickname.trim()) {
+      setSubmitError("프로필 이름을 입력해주세요.")
+      return
+    }
+
+    if (!requiredLegalAccepted) {
+      setSubmitError("만 14세 이상, 개인정보 필수 안내, 국외 이전 안내를 모두 확인해주세요.")
+      return
+    }
+
+    setSubmitLoading(true)
+    setSubmitError("")
+
+    try {
+      await apiFetch<RsData<unknown>>("/member/api/v1/signup/social/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          token: pendingTokenRef.current,
+          nickname: nickname.trim(),
+          ...buildSocialSignupLegalAcceptancePayload({
+            age14OrOlder,
+            requiredPrivacyConfirmed,
+            analyticsConsent,
+            overseasTransferAcknowledged,
+          }),
+        }),
+      })
+
+      await replaceRoute(router, `/login?signup=done&next=${encodeURIComponent(next)}`)
+    } catch (error) {
+      setSubmitError(toAuthErrorMessage("signupComplete", error, "소셜 회원가입에 실패했습니다."))
+    } finally {
+      setSubmitLoading(false)
+    }
+  }
+
+  return (
+    <AuthShell
+      activeTab="signup"
+      title="소셜 회원가입"
+      eyebrow="Social Signup"
+      heroTitle="소셜 회원가입"
+      heroDescription="Kakao에서 받은 프로필 정보를 확인하고 필수 약관에 동의하면 가입이 완료됩니다."
+      hideTabs
+      footer={
+        <FooterText>
+          다시 시작하려면 <Link href={toSignupPath(next)}>회원가입 처음으로</Link>
+        </FooterText>
+      }
+      loginHref={toLoginPath(next)}
+      signupHref={toSignupPath(next)}
+    >
+      {loadingPending ? (
+        <InfoText>소셜 회원가입 세션을 확인하고 있습니다...</InfoText>
+      ) : pendingError ? (
+        <ErrorPanel>
+          <ErrorText>{pendingError}</ErrorText>
+          <GhostButton type="button" onClick={retryPending} disabled={!pendingTokenRef.current}>
+            다시 확인
+          </GhostButton>
+        </ErrorPanel>
+      ) : pending ? (
+        <form onSubmit={onSubmit}>
+          <ProfileSummary aria-label="소셜 회원가입 프로필 정보">
+            <AvatarFrame>
+              {pending.profileImgUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={pending.profileImgUrl} alt="" />
+              ) : (
+                <AvatarFallback>{resolvedProviderLabel.slice(0, 1)}</AvatarFallback>
+              )}
+            </AvatarFrame>
+            <div>
+              <ProviderName>{resolvedProviderLabel}</ProviderName>
+              <ProfileName>{pending.nickname}</ProfileName>
+            </div>
+          </ProfileSummary>
+
+          <Field>
+            <FieldTop>
+              <Label htmlFor="social-signup-nickname">프로필 이름</Label>
+              <FieldHint>Kakao 프로필에서 가져옴</FieldHint>
+            </FieldTop>
+            <Input
+              id="social-signup-nickname"
+              value={nickname}
+              onChange={(event) => setNickname(event.target.value)}
+              placeholder="프로필 이름을 입력하세요."
+              autoComplete="nickname"
+            />
+          </Field>
+
+          <CollectedDataBox aria-label="Kakao OAuth 처리 항목">
+            <strong>처리 항목</strong>
+            <ul>
+              <li>Kakao OAuth provider subject hash</li>
+              <li>프로필 이름</li>
+              <li>프로필 이미지 URL</li>
+              <li>OAuth state와 redirect origin</li>
+            </ul>
+          </CollectedDataBox>
+
+          <RequiredConsentBox aria-label="소셜 회원가입 완료 필수 확인">
+            <p>
+              가입 시점 기준 정책 버전: 이용약관 {ACTIVE_LEGAL_DOCUMENTS.terms.version}, 개인정보처리방침{" "}
+              {ACTIVE_LEGAL_DOCUMENTS.privacy.version}
+            </p>
+            <label>
+              <input
+                type="checkbox"
+                checked={age14OrOlder}
+                onChange={(event) => setAge14OrOlder(event.target.checked)}
+              />
+              <span>만 14세 이상입니다.</span>
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={requiredPrivacyConfirmed}
+                onChange={(event) => setRequiredPrivacyConfirmed(event.target.checked)}
+              />
+              <span>
+                <Link href="/privacy">개인정보처리방침</Link>의 Kakao 로그인 및 필수 수집·이용 항목을 확인했습니다.
+              </span>
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={overseasTransferAcknowledged}
+                onChange={(event) => setOverseasTransferAcknowledged(event.target.checked)}
+              />
+              <span>Kakao OAuth와 서비스 운영에 필요한 외부 처리자 안내를 확인했습니다.</span>
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={analyticsConsent}
+                onChange={(event) => setAnalyticsConsent(event.target.checked)}
+              />
+              <span>서비스 품질 개선을 위한 analytics/RUM 처리에 선택 동의합니다.</span>
+            </label>
+          </RequiredConsentBox>
+
+          <FeedbackSlot aria-live="polite">{submitFeedbackMessage}</FeedbackSlot>
+
+          <ActionRow>
+            <CancelLink href={toSignupPath(next)}>취소</CancelLink>
+            <PrimaryButton type="submit" disabled={submitLoading || !requiredLegalAccepted}>
+              {submitLoading ? "가입 중..." : "가입"}
+            </PrimaryButton>
+          </ActionRow>
+        </form>
+      ) : null}
+    </AuthShell>
+  )
+}
+
+export default SocialSignupCompletePage
+
+const Field = styled.div`
+  display: grid;
+  gap: 0.42rem;
+`
+
+const FieldTop = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+
+  @media (max-width: 640px) {
+    display: grid;
+    gap: 0.16rem;
+  }
+`
+
+const Label = styled.label`
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.gray12};
+`
+
+const FieldHint = styled.span`
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: 0.78rem;
+`
+
+const Input = styled.input`
+  width: 100%;
+  border: 1px solid ${({ theme }) => theme.colors.gray7};
+  border-radius: 14px;
+  padding: 0.82rem 0.88rem;
+  background: ${({ theme }) => theme.colors.gray1};
+  color: ${({ theme }) => theme.colors.gray12};
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.blue8};
+    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.blue4};
+    transform: translateY(-1px);
+  }
+`
+
+const ProfileSummary = styled.div`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.8rem;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 14px;
+  background: ${({ theme }) => theme.colors.gray2};
+  padding: 0.78rem 0.84rem;
+`
+
+const AvatarFrame = styled.div`
+  position: relative;
+  width: 64px;
+  height: 64px;
+  overflow: hidden;
+  border-radius: 50%;
+  background: ${({ theme }) => theme.colors.gray4};
+
+  > img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`
+
+const AvatarFallback = styled.div`
+  display: grid;
+  width: 100%;
+  height: 100%;
+  place-items: center;
+  color: ${({ theme }) => theme.colors.gray12};
+  font-weight: 800;
+`
+
+const ProviderName = styled.div`
+  color: ${({ theme }) => theme.colors.gray11};
+  font-size: 0.82rem;
+  font-weight: 700;
+`
+
+const ProfileName = styled.div`
+  margin-top: 0.18rem;
+  color: ${({ theme }) => theme.colors.gray12};
+  font-size: 1rem;
+  font-weight: 800;
+  word-break: break-word;
+`
+
+const CollectedDataBox = styled.div`
+  display: grid;
+  gap: 0.46rem;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 14px;
+  background: ${({ theme }) => theme.colors.gray2};
+  padding: 0.74rem 0.84rem;
+
+  strong {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.84rem;
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 1rem;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.82rem;
+    line-height: 1.55;
+  }
+`
+
+const RequiredConsentBox = styled.div`
+  display: grid;
+  gap: 0.58rem;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 14px;
+  background: ${({ theme }) => theme.colors.gray2};
+  padding: 0.74rem 0.84rem;
+
+  p {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.82rem;
+    line-height: 1.55;
+  }
+
+  label {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.5rem;
+    align-items: start;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.84rem;
+    line-height: 1.5;
+  }
+
+  input {
+    margin-top: 0.22rem;
+  }
+
+  a {
+    color: ${({ theme }) => theme.colors.blue10};
+    font-weight: 700;
+  }
+`
+
+const GhostButton = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.gray7};
+  border-radius: 14px;
+  padding: 0.82rem 0.9rem;
+  background: ${({ theme }) => theme.colors.gray2};
+  color: ${({ theme }) => theme.colors.gray12};
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`
+
+const ErrorPanel = styled.div`
+  display: grid;
+  gap: 0.8rem;
+`
+
+const PrimaryButton = styled.button`
+  min-width: 140px;
+  border: 1px solid ${({ theme }) => theme.colors.green8};
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  background: ${({ theme }) => theme.colors.green9};
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`
+
+const CancelLink = styled(Link)`
+  min-width: 120px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  background: ${({ theme }) => theme.colors.gray2};
+  color: ${({ theme }) => theme.colors.gray11};
+  text-decoration: none;
+  font-weight: 700;
+`
+
+const ActionRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 0.8rem;
+
+  @media (max-width: 640px) {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+`
+
+const FeedbackSlot = styled.div`
+  min-height: 4.8rem;
+  display: flex;
+  align-items: stretch;
+
+  > * {
+    width: 100%;
+  }
+`
+
+const ErrorText = styled.p`
+  margin: 0;
+  border-radius: 14px;
+  border: 1px solid ${({ theme }) => theme.colors.red7};
+  background: ${({ theme }) => theme.colors.red3};
+  color: ${({ theme }) => theme.colors.red11};
+  padding: 0.82rem 0.9rem;
+  font-size: 0.9rem;
+  line-height: 1.55;
+`
+
+const InfoText = styled.p`
+  margin: 0;
+  border-radius: 14px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.colors.gray2};
+  color: ${({ theme }) => theme.colors.gray11};
+  padding: 0.82rem 0.9rem;
+  font-size: 0.87rem;
+  line-height: 1.65;
+`
+
+const FooterText = styled.div`
+  font-size: 0.9rem;
+`

--- a/legal/data-map/data-flow.yaml
+++ b/legal/data-map/data-flow.yaml
@@ -13,11 +13,13 @@ flows:
     collectionPoint: Kakao redirect and Spring Security OAuth2
     stores:
       - PostgreSQL member
+      - PostgreSQL pending_oauth_signup for new applicants
+      - PostgreSQL member_legal_acceptance after consent
       - OAuth state cookie
     processors:
       - home_server_postgresql
       - kakao_oauth
-    status: 신규 가입 pending 동의는 issue997
+    status: 신규 가입은 /signup/social/complete pending 동의 완료 후 계정 생성
   - id: auth_session
     collectionPoint: login form and auth filter
     stores:

--- a/legal/data-map/legal-basis-matrix.yaml
+++ b/legal/data-map/legal-basis-matrix.yaml
@@ -7,14 +7,15 @@ legalBasis:
   - id: contractPreparationAndConsentEvidence
     activities:
       - signup_email_verification
+      - kakao_oauth_pending_signup
     rationale: 회원가입 전 이메일 소유 확인과 동의 증빙 연결
-    reviewRequired: token hash/URL 제거는 issue998
+    reviewRequired: token hash/URL 제거는 issue998; OAuth pending purge 자동화는 issue1000
   - id: contractAndLegitimateSecurityInterest
     activities:
       - kakao_oauth_existing_login
       - auth_session_and_cookies
     rationale: 로그인 제공과 세션 보안·오남용 방지
-    reviewRequired: OAuth pending 가입은 issue997
+    reviewRequired: legacy OAuth provider subject unlink/migration 정책 확정 필요
   - id: contractAndUserPublishedContent
     activities:
       - user_content_posts_comments

--- a/legal/data-map/processing-activities.yaml
+++ b/legal/data-map/processing-activities.yaml
@@ -97,13 +97,52 @@ activities:
       - accountOwner
       - serviceAdmin
       - databaseOperator
-    encryption: transportTls; providerSubjectStoredInAccountRecord
+    encryption: transportTls; legacyProviderSubjectMayExistInAccountRecord; newAccountsUseProviderSubjectHashLoginId
     userRightsHandler: privacyRequestEmailAndFutureOauthUnlinkFlow
     codeOwner: back/oauth2
     policySectionId: privacy-collection-oauth
     enabledByEnv: spring.security.oauth2.client.registration.kakao.client-id
     reviewRequired:
-      - New OAuth signup pending-consent flow is tracked by issue997.
+      - Legacy connected accounts may still contain provider subject in member login_id until unlink/migration policy is finalized.
+
+  - id: kakao_oauth_pending_signup
+    name: Kakao OAuth 신규 가입 pending 동의
+    dataCategories:
+      - oauthProvider
+      - oauthProviderSubjectHash
+      - pendingOAuthSignupTokenHash
+      - profileNickname
+      - profileImageUrl
+      - authState
+      - redirectOrigin
+      - legalAcceptanceVersion
+      - legalAcceptanceTimestamp
+    dataSubjects:
+      - oauthApplicant
+      - registeredMemberAfterConsent
+    purpose: Kakao OAuth 신규 사용자를 로컬 약관·개인정보·연령 동의 완료 전 pending 상태로 제한하고 동의 완료 후 계정 생성
+    legalBasis: contractPreparationAndConsentEvidence
+    collectionSource: Kakao OAuth redirect, /signup/social/complete, /member/api/v1/signup/social/*
+    requiredOrOptional: optionalSignupMethod
+    systemOfRecord: PostgreSQL pending_oauth_signup, member, member_legal_acceptance
+    processors:
+      - kakao_oauth
+      - home_server_postgresql
+    overseasTransfer: noPlannedOverseasTransferByService; Kakao processing terms apply
+    retentionRule: pendingTokenTtlThenPurge; accountLifetimeAfterConsent
+    destructionMethod: expireCancelConsumeThenPurgeByRetentionJob; unlinkOrAccountDeletion
+    accessRoles:
+      - signupApplicant
+      - accountOwner
+      - serviceAdmin
+      - databaseOperator
+    encryption: pendingTokenHmacHashAtRest; providerSubjectHmacHashAtRest; transportTls
+    userRightsHandler: privacyRequestEmailAndFutureOauthUnlinkFlow
+    codeOwner: back/oauth-signup; front/signup-social-complete
+    policySectionId: privacy-collection-oauth
+    enabledByEnv: spring.security.oauth2.client.registration.kakao.client-id
+    reviewRequired:
+      - Pending signup purge job and OAuth unlink/account deletion workflow remain tracked by issue1000 and issue999.
 
   - id: auth_session_and_cookies
     name: 인증 세션, refresh token, 보안 cookie

--- a/legal/data-map/retention-matrix.yaml
+++ b/legal/data-map/retention-matrix.yaml
@@ -11,6 +11,10 @@ retentionRules:
     retention: accountLifetimeForLinkedIdentifier; transientStateCookieUntilCallback
     destruction: unlinkOrAccountDeletion; transientCookieExpiry
     followUp: issue997
+  - activityId: kakao_oauth_pending_signup
+    retention: pendingTokenTtlThenPurge; accountLifetimeAfterConsent
+    destruction: expireCancelConsumeThenPurgeByRetentionJob; unlinkOrAccountDeletion
+    followUp: issue997
   - activityId: auth_session_and_cookies
     retention: untilLogoutRevocationExpiryOrSessionCleanupJob
     destruction: revokeSessionExpireCookiePurgeExpiredSessions

--- a/legal/policies/privacy.ko-KR.v1.0.0.yaml
+++ b/legal/policies/privacy.ko-KR.v1.0.0.yaml
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "publishedAt": "2026-06-21T00:00:00+09:00",
   "effectiveAt": "2026-06-21T00:00:00+09:00",
-  "contentSha256": "07f764f66c04291bc8094ccdcd6ae5c04c99bddd06b4cae632efb61d537cc4ca",
+  "contentSha256": "cedbfea674a9e2aca9e29bf6a01492a1e3fa640b0ff53d47f969d64c057b980f",
   "supersedes": null,
   "owner": "AquilaLog",
   "contactEmail": "aquilaxk10@gmail.com",
@@ -106,8 +106,8 @@
       "id": "privacy-kakao",
       "title": "Kakao 로그인",
       "body": [
-        "Kakao OAuth는 기존 연결 계정 로그인에 사용할 수 있으며 OAuth provider subject, authorization code, state, redirect origin 같은 정보가 처리됩니다.",
-        "신규 Kakao 가입은 로컬 약관·개인정보 처리 확인 흐름이 완성되기 전까지 pending consent 전환 이슈에서 별도로 관리합니다."
+        "Kakao OAuth는 기존 연결 계정 로그인과 신규 소셜 회원가입에 사용할 수 있으며 OAuth provider, provider subject hash, authorization code, state, redirect origin, 프로필 이름, 프로필 이미지 URL 같은 정보가 처리됩니다.",
+        "신규 Kakao 가입은 pending_oauth_signup에 pending token hash와 provider subject hash를 저장한 뒤 /signup/social/complete에서 약관, 개인정보 처리방침, 만 14세 이상 여부를 확인해야 계정과 동의 증빙이 생성됩니다."
       ]
     },
     {


### PR DESCRIPTION
## 관련 이슈

close #997

## 작업 배경

- Kakao OAuth 신규 callback이 로컬 약관·개인정보·만 14세 이상 동의 완료 전에는 계정을 만들지 않도록 pending signup 경계를 추가했습니다.
- 기존 연결 OAuth 회원은 기존 로그인 경로를 유지하고, 신규 회원만 `/signup/social/complete` 동의 완료 화면으로 이동하게 했습니다.

## 작업 내용

- Kakao OAuth 신규 사용자를 `pending_oauth_signup`에 저장하고 pending token/provider subject를 HMAC hash로만 조회하도록 추가했습니다.
- OAuth 실패 handler가 신규 가입 필요 예외를 `/signup/social/complete#token=...` fragment redirect로 전달하도록 변경했습니다.
- social signup pending/complete API를 추가하고, 완료 시 member와 legal acceptance를 같은 transaction에서 생성하도록 구현했습니다.
- `/signup/social/complete` 화면, frontend API payload, Playwright 회귀 테스트를 추가했습니다.
- Kakao OAuth pending signup 처리 항목을 privacy data-map, retention, legal-basis, privacy policy에 반영했습니다.
- OpenAPI snapshot과 shared contract를 새 signup social API에 맞춰 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back ktlintCheck` 성공
  - `back/gradlew -p back test --tests '*CustomOAuth2UserServiceTest' --tests '*CustomOAuth2LoginFailureHandlerTest' --tests '*OAuthSignupApplicationServiceTest'` 성공
  - `back/gradlew -p back test --tests '*ArchitectureGuardTest' --tests '*CustomOAuth2UserServiceTest' --tests '*CustomOAuth2LoginFailureHandlerTest' --tests '*OAuthSignupApplicationServiceTest'` 성공
  - `back/gradlew -p back test` 성공
  - `yarn --cwd front install --frozen-lockfile` 성공
  - `yarn --cwd front build` 성공
  - `yarn --cwd front playwright:preflight` 성공
  - `yarn --cwd front playwright test e2e/social-signup-consent.spec.ts e2e/signup-token-url.spec.ts` 성공
  - `node tools/legal/validate-privacy-data-map.mjs` 성공
  - `node tools/legal/validate-legal-policies.mjs` 성공

## 리뷰어 메모

- 먼저 볼 지점:
  - `CustomOAuth2UserService`의 hash login id 우선 조회와 legacy raw login id fallback
  - `OAuthSignupApplicationService`의 pending token hash 저장, 중복 callback refresh, complete transaction
  - `/signup/social/complete`의 fragment token 제거와 legal consent payload
  - `legal/data-map/processing-activities.yaml`의 Kakao OAuth pending signup 처리 항목

## 리스크

- 기존 legacy OAuth 계정은 `KAKAO__rawSubject` login id fallback으로 유지됩니다. 새 계정은 hash 기반 login id를 사용하므로 향후 unlink/migration 정책은 별도 이슈에서 다뤄야 합니다.
- pending signup purge job과 OAuth unlink/account deletion workflow는 #1000, #999 후속 범위입니다.
- Vercel rate limit으로 main 배포 frontend 반영이 지연될 수 있으며, merge 후 CD에서 live build SHA 확인이 필요합니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
