### PR TITLE
[Feat] 개인정보 권리 요청과 계정 탈퇴 self-service 구현

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberAttrRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberAttrRepositoryAdapter.kt
@@ -45,5 +45,10 @@ class MemberAttrPersistenceAdapter(
         delta: Int,
     ): Int = memberAttrRepository.incrementIntValue(subject, name, delta)
 
+    override fun clearStringValuesBySubjectIdAndNameIn(
+        subjectId: Long,
+        names: Collection<String>,
+    ): Int = memberAttrRepository.clearStringValuesBySubjectIdAndNameIn(subjectId, names)
+
     override fun save(attr: MemberAttr): MemberAttr = memberAttrRepository.save(attr)
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberAttrRepositoryCustom.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberAttrRepositoryCustom.kt
@@ -35,4 +35,9 @@ interface MemberAttrRepositoryCustom {
         name: String,
         delta: Int = 1,
     ): Int
+
+    fun clearStringValuesBySubjectIdAndNameIn(
+        subjectId: Long,
+        names: Collection<String>,
+    ): Int
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberAttrRepositoryImpl.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberAttrRepositoryImpl.kt
@@ -146,6 +146,25 @@ class MemberAttrRepositoryImpl : MemberAttrRepositoryCustom {
         }
     }
 
+    override fun clearStringValuesBySubjectIdAndNameIn(
+        subjectId: Long,
+        names: Collection<String>,
+    ): Int {
+        if (names.isEmpty()) return 0
+
+        return entityManager
+            .createQuery(
+                """
+                update MemberAttr a
+                set a.strValue = ''
+                where a.subject.id = :subjectId
+                  and a.name in :names
+                """.trimIndent(),
+            ).setParameter("subjectId", subjectId)
+            .setParameter("names", names)
+            .executeUpdate()
+    }
+
     /**
      * IntValue 항목을 수정한다.
      */

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberRepository.kt
@@ -1,9 +1,14 @@
 package com.back.boundedContexts.member.adapter.persistence
 
 import com.back.boundedContexts.member.domain.shared.Member
+import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.Optional
 
 interface MemberRepository :
     JpaRepository<Member, Long>,
@@ -13,6 +18,12 @@ interface MemberRepository :
     fun findByApiKey(apiKey: String): Member?
 
     fun findByEmail(email: String): Member?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select member from Member member where member.id = :id")
+    fun findByIdForUpdate(
+        @Param("id") id: Long,
+    ): Optional<Member>
 
     override fun findAll(pageable: Pageable): Page<Member>
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/persistence/MemberRepositoryAdapter.kt
@@ -31,6 +31,8 @@ class MemberRepositoryAdapter(
 
     override fun findById(id: Long): Optional<Member> = memberRepository.findById(id)
 
+    override fun findByIdForUpdate(id: Long): Optional<Member> = memberRepository.findByIdForUpdate(id)
+
     override fun getReferenceById(id: Long): Member = memberRepository.getReferenceById(id)
 
     override fun findQPagedByKw(query: MemberRepositoryPort.PagedQuery): MemberRepositoryPort.PagedResult<Member> {

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberController.kt
@@ -77,8 +77,8 @@ class ApiV1MemberController(
         @field:NotBlank
         @field:Size(min = 8, max = 64)
         @field:Pattern(
-            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{8,64}$",
-            message = "비밀번호는 8~64자이며 영문 대문자/소문자/숫자/특수문자를 모두 포함해야 합니다.",
+            regexp = "^(?=\\S{8,64}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9\\s]).*$",
+            message = "비밀번호는 공백 없이 8~64자이며 영문 대문자/소문자/숫자/특수문자를 모두 포함해야 합니다.",
         )
         val password: String,
         @field:NotBlank

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsController.kt
@@ -1,16 +1,20 @@
 package com.back.boundedContexts.member.adapter.web
 
+import com.back.boundedContexts.member.subContexts.privacy.application.service.AccountDeletionResult
 import com.back.boundedContexts.member.subContexts.privacy.application.service.PrivacyExportResponse
 import com.back.boundedContexts.member.subContexts.privacy.application.service.PrivacyRequestDto
 import com.back.boundedContexts.member.subContexts.privacy.application.service.PrivacyRightsApplicationService
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequestType
 import com.back.global.rsData.RsData
 import com.back.global.security.domain.SecurityUser
+import com.back.global.web.application.AuthCookieService
 import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -23,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/member/api/v1/privacy")
 class ApiV1PrivacyRightsController(
     private val privacyRightsApplicationService: PrivacyRightsApplicationService,
+    private val authCookieService: AuthCookieService,
 ) {
     data class PrivacyRequestCreateRequest(
         val type: MemberPrivacyRequestType,
@@ -32,6 +37,14 @@ class ApiV1PrivacyRightsController(
 
     data class PrivacyRequestResBody(
         val item: PrivacyRequestDto,
+    )
+
+    data class AccountDeletionRequest(
+        @field:NotBlank
+        @field:Size(max = 128)
+        val password: String,
+        @field:Size(max = 500)
+        val reason: String? = null,
     )
 
     @GetMapping("/export")
@@ -77,4 +90,24 @@ class ApiV1PrivacyRightsController(
                 item = privacyRightsApplicationService.getRequest(securityUser.id, requestId),
             ),
         )
+
+    @DeleteMapping("/account")
+    fun deleteAccount(
+        @AuthenticationPrincipal securityUser: SecurityUser,
+        @RequestBody @Valid reqBody: AccountDeletionRequest,
+    ): RsData<AccountDeletionResult> {
+        val result =
+            privacyRightsApplicationService.deleteAccount(
+                memberId = securityUser.id,
+                password = reqBody.password,
+                reason = reqBody.reason,
+            )
+        authCookieService.expireAuthCookies()
+
+        return RsData(
+            "200-1",
+            "계정 탈퇴가 완료되었습니다.",
+            result,
+        )
+    }
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsController.kt
@@ -1,0 +1,80 @@
+package com.back.boundedContexts.member.adapter.web
+
+import com.back.boundedContexts.member.subContexts.privacy.application.service.PrivacyExportResponse
+import com.back.boundedContexts.member.subContexts.privacy.application.service.PrivacyRequestDto
+import com.back.boundedContexts.member.subContexts.privacy.application.service.PrivacyRightsApplicationService
+import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequestType
+import com.back.global.rsData.RsData
+import com.back.global.security.domain.SecurityUser
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Size
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/member/api/v1/privacy")
+class ApiV1PrivacyRightsController(
+    private val privacyRightsApplicationService: PrivacyRightsApplicationService,
+) {
+    data class PrivacyRequestCreateRequest(
+        val type: MemberPrivacyRequestType,
+        @field:Size(max = 1000)
+        val message: String? = null,
+    )
+
+    data class PrivacyRequestResBody(
+        val item: PrivacyRequestDto,
+    )
+
+    @GetMapping("/export")
+    @Transactional(readOnly = true)
+    fun export(
+        @AuthenticationPrincipal securityUser: SecurityUser,
+    ): RsData<PrivacyExportResponse> =
+        RsData(
+            "200-1",
+            "개인정보 내보내기 데이터를 조회했습니다.",
+            privacyRightsApplicationService.exportFor(securityUser.id),
+        )
+
+    @PostMapping("/requests")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createRequest(
+        @AuthenticationPrincipal securityUser: SecurityUser,
+        @RequestBody @Valid reqBody: PrivacyRequestCreateRequest,
+    ): RsData<PrivacyRequestResBody> =
+        RsData(
+            "201-1",
+            "개인정보 처리 요청을 접수했습니다.",
+            PrivacyRequestResBody(
+                item =
+                    privacyRightsApplicationService.createRequest(
+                        memberId = securityUser.id,
+                        type = reqBody.type,
+                        message = reqBody.message,
+                    ),
+            ),
+        )
+
+    @GetMapping("/requests/{requestId}")
+    @Transactional(readOnly = true)
+    fun getRequest(
+        @AuthenticationPrincipal securityUser: SecurityUser,
+        @PathVariable requestId: Long,
+    ): RsData<PrivacyRequestResBody> =
+        RsData(
+            "200-1",
+            "개인정보 처리 요청 상태를 조회했습니다.",
+            PrivacyRequestResBody(
+                item = privacyRightsApplicationService.getRequest(securityUser.id, requestId),
+            ),
+        )
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsController.kt
@@ -8,8 +8,10 @@ import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRe
 import com.back.global.rsData.RsData
 import com.back.global.security.domain.SecurityUser
 import com.back.global.web.application.AuthCookieService
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -30,6 +32,8 @@ class ApiV1PrivacyRightsController(
     private val authCookieService: AuthCookieService,
 ) {
     data class PrivacyRequestCreateRequest(
+        @field:NotNull
+        @field:Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         val type: MemberPrivacyRequestType,
         @field:Size(max = 1000)
         val message: String? = null,
@@ -41,7 +45,7 @@ class ApiV1PrivacyRightsController(
 
     data class AccountDeletionRequest(
         @field:NotBlank
-        @field:Size(max = 128)
+        @field:Size(min = 1, max = 128)
         val password: String,
         @field:Size(max = 500)
         val reason: String? = null,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsController.kt
@@ -10,7 +10,6 @@ import com.back.global.security.domain.SecurityUser
 import com.back.global.web.application.AuthCookieService
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
-import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import org.springframework.http.HttpStatus
@@ -44,9 +43,9 @@ class ApiV1PrivacyRightsController(
     )
 
     data class AccountDeletionRequest(
-        @field:NotBlank
         @field:Size(min = 1, max = 128)
-        val password: String,
+        val password: String? = null,
+        val oauthAccountDeletionConfirmed: Boolean = false,
         @field:Size(max = 500)
         val reason: String? = null,
     )
@@ -104,6 +103,7 @@ class ApiV1PrivacyRightsController(
             privacyRightsApplicationService.deleteAccount(
                 memberId = securityUser.id,
                 password = reqBody.password,
+                oauthAccountDeletionConfirmed = reqBody.oauthAccountDeletionConfirmed,
                 reason = reqBody.reason,
             )
         authCookieService.expireAuthCookies()

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/port/output/MemberAttrRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/port/output/MemberAttrRepositoryPort.kt
@@ -36,5 +36,10 @@ interface MemberAttrRepositoryPort {
         delta: Int = 1,
     ): Int
 
+    fun clearStringValuesBySubjectIdAndNameIn(
+        subjectId: Long,
+        names: Collection<String>,
+    ): Int
+
     fun save(attr: MemberAttr): MemberAttr
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/application/port/output/MemberRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/application/port/output/MemberRepositoryPort.kt
@@ -33,6 +33,8 @@ interface MemberRepositoryPort {
 
     fun findById(id: Long): Optional<Member>
 
+    fun findByIdForUpdate(id: Long): Optional<Member>
+
     fun getReferenceById(id: Long): Member
 
     fun findQPagedByKw(query: PagedQuery): PagedResult<Member>

--- a/back/src/main/kotlin/com/back/boundedContexts/member/model/shared/Member.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/model/shared/Member.kt
@@ -12,6 +12,7 @@ import org.hibernate.annotations.DynamicUpdate
 import org.hibernate.annotations.NaturalId
 import org.hibernate.annotations.SQLRestriction
 import java.time.Instant
+import java.util.UUID
 
 /**
  * Member는 비즈니스 상태와 규칙을 캡슐화하는 도메인 모델입니다.
@@ -49,9 +50,9 @@ class Member(
     @field:SequenceGenerator(name = "member_seq_gen", sequenceName = "member_seq", allocationSize = 50)
     @field:GeneratedValue(strategy = SEQUENCE, generator = "member_seq_gen")
     override val id: Long = 0,
-    @field:NaturalId
+    @field:NaturalId(mutable = true)
     @field:Column(name = "login_id", nullable = false)
-    override val username: String,
+    override var username: String,
     @field:Column(nullable = true)
     var password: String? = null,
     @field:Column(nullable = false)
@@ -118,6 +119,7 @@ class Member(
 
     fun softDelete(now: Instant = Instant.now()) {
         deletedAt = now
+        username = "deleted-$id-${UUID.randomUUID()}"
         email = null
         password = null
         nickname = "탈퇴한 사용자"

--- a/back/src/main/kotlin/com/back/boundedContexts/member/model/shared/Member.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/model/shared/Member.kt
@@ -121,6 +121,8 @@ class Member(
         email = null
         password = null
         nickname = "탈퇴한 사용자"
+        ipSecurityEnabled = false
+        ipSecurityFingerprint = null
         modifyApiKey(MemberPolicy.genApiKey())
     }
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/model/shared/Member.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/model/shared/Member.kt
@@ -116,8 +116,12 @@ class Member(
     @Transient
     override var postCommentsCountAttr: MemberAttr? = null
 
-    fun softDelete() {
-        deletedAt = Instant.now()
+    fun softDelete(now: Instant = Instant.now()) {
+        deletedAt = now
+        email = null
+        password = null
+        nickname = "탈퇴한 사용자"
+        modifyApiKey(MemberPolicy.genApiKey())
     }
 
     override val member: Member

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/adapter/persistence/MemberLegalAcceptanceRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/adapter/persistence/MemberLegalAcceptanceRepository.kt
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface MemberLegalAcceptanceRepository :
     JpaRepository<MemberLegalAcceptance, Long>,
     MemberLegalAcceptanceRepositoryPort {
-    fun findTopByMemberIdOrderByAcceptedAtDesc(memberId: Long): MemberLegalAcceptance?
+    override fun findTopByMemberIdOrderByAcceptedAtDesc(memberId: Long): MemberLegalAcceptance?
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/port/output/MemberLegalAcceptanceRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/port/output/MemberLegalAcceptanceRepositoryPort.kt
@@ -4,4 +4,6 @@ import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberL
 
 interface MemberLegalAcceptanceRepositoryPort {
     fun save(memberLegalAcceptance: MemberLegalAcceptance): MemberLegalAcceptance
+
+    fun findTopByMemberIdOrderByAcceptedAtDesc(memberId: Long): MemberLegalAcceptance?
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepository.kt
@@ -14,6 +14,12 @@ interface PendingOAuthSignupRepository : JpaRepository<PendingOAuthSignup, Long>
     fun findByPendingTokenHash(pendingTokenHash: String): PendingOAuthSignup?
 
     @Modifying(flushAutomatically = true)
-    @Query("delete from PendingOAuthSignup p where p.memberLoginId = :memberLoginId")
+    @Query(
+        """
+        delete from PendingOAuthSignup p
+        where p.memberLoginId = :memberLoginId
+          and p.consumedAt is not null
+        """,
+    )
     fun deleteByMemberLoginId(memberLoginId: String): Int
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepository.kt
@@ -2,6 +2,8 @@ package com.back.boundedContexts.member.subContexts.oauthSignup.adapter.persiste
 
 import com.back.boundedContexts.member.subContexts.oauthSignup.model.PendingOAuthSignup
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 
 interface PendingOAuthSignupRepository : JpaRepository<PendingOAuthSignup, Long> {
     fun findByProviderAndProviderSubjectHash(
@@ -10,4 +12,8 @@ interface PendingOAuthSignupRepository : JpaRepository<PendingOAuthSignup, Long>
     ): PendingOAuthSignup?
 
     fun findByPendingTokenHash(pendingTokenHash: String): PendingOAuthSignup?
+
+    @Modifying(flushAutomatically = true)
+    @Query("delete from PendingOAuthSignup p where p.memberLoginId = :memberLoginId")
+    fun deleteByMemberLoginId(memberLoginId: String): Int
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/persistence/PendingOAuthSignupRepositoryAdapter.kt
@@ -21,4 +21,6 @@ class PendingOAuthSignupRepositoryAdapter(
 
     override fun findByPendingTokenHash(pendingTokenHash: String): PendingOAuthSignup? =
         pendingOAuthSignupRepository.findByPendingTokenHash(pendingTokenHash)
+
+    override fun deleteByMemberLoginId(memberLoginId: String): Int = pendingOAuthSignupRepository.deleteByMemberLoginId(memberLoginId)
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/port/input/OAuthSignupUseCase.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/port/input/OAuthSignupUseCase.kt
@@ -30,4 +30,6 @@ interface OAuthSignupUseCase {
         nickname: String?,
         legalAcceptance: LegalAcceptanceCommand,
     ): Member
+
+    fun releaseConsumedSignupForMemberLoginId(memberLoginId: String): Int
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/port/output/PendingOAuthSignupRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/port/output/PendingOAuthSignupRepositoryPort.kt
@@ -11,4 +11,6 @@ interface PendingOAuthSignupRepositoryPort {
     ): PendingOAuthSignup?
 
     fun findByPendingTokenHash(pendingTokenHash: String): PendingOAuthSignup?
+
+    fun deleteByMemberLoginId(memberLoginId: String): Int
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationService.kt
@@ -142,6 +142,10 @@ class OAuthSignupApplicationService(
         return member
     }
 
+    @Transactional
+    override fun releaseConsumedSignupForMemberLoginId(memberLoginId: String): Int =
+        pendingOAuthSignupRepository.deleteByMemberLoginId(memberLoginId)
+
     private fun findPendingOrThrow(pendingToken: String): PendingOAuthSignup {
         val normalizedToken =
             pendingToken
@@ -153,11 +157,13 @@ class OAuthSignupApplicationService(
         ) ?: throw AppException("404-2", "유효하지 않은 소셜 회원가입 세션입니다.")
     }
 
-    private fun normalizeProvider(provider: String): String =
-        provider
-            .trim()
-            .uppercase(Locale.ROOT)
-            .ifBlank { throw AppException("400-2", "소셜 로그인 제공자가 올바르지 않습니다.") }
+    private fun normalizeProvider(provider: String): String {
+        val normalizedProvider = provider.trim().uppercase(Locale.ROOT)
+        if (normalizedProvider.isBlank()) {
+            throw AppException("400-2", "소셜 로그인 제공자가 올바르지 않습니다.")
+        }
+        return normalizedProvider
+    }
 
     private fun normalizeNickname(nickname: String): String {
         val normalized = nickname.trim().ifBlank { "카카오사용자" }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/adapter/persistence/MemberAccountDeletionRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/adapter/persistence/MemberAccountDeletionRepository.kt
@@ -1,8 +1,11 @@
 package com.back.boundedContexts.member.subContexts.privacy.adapter.persistence
 
+import com.back.boundedContexts.member.subContexts.privacy.application.port.output.MemberAccountDeletionRepositoryPort
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberAccountDeletion
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface MemberAccountDeletionRepository : JpaRepository<MemberAccountDeletion, Long> {
-    fun existsByMemberId(memberId: Long): Boolean
+interface MemberAccountDeletionRepository :
+    JpaRepository<MemberAccountDeletion, Long>,
+    MemberAccountDeletionRepositoryPort {
+    override fun existsByMemberId(memberId: Long): Boolean
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/adapter/persistence/MemberAccountDeletionRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/adapter/persistence/MemberAccountDeletionRepository.kt
@@ -1,0 +1,8 @@
+package com.back.boundedContexts.member.subContexts.privacy.adapter.persistence
+
+import com.back.boundedContexts.member.subContexts.privacy.model.MemberAccountDeletion
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberAccountDeletionRepository : JpaRepository<MemberAccountDeletion, Long> {
+    fun existsByMemberId(memberId: Long): Boolean
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/adapter/persistence/MemberPrivacyRequestRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/adapter/persistence/MemberPrivacyRequestRepository.kt
@@ -1,0 +1,11 @@
+package com.back.boundedContexts.member.subContexts.privacy.adapter.persistence
+
+import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequest
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberPrivacyRequestRepository : JpaRepository<MemberPrivacyRequest, Long> {
+    fun findByIdAndMemberId(
+        id: Long,
+        memberId: Long,
+    ): MemberPrivacyRequest?
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/adapter/persistence/MemberPrivacyRequestRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/adapter/persistence/MemberPrivacyRequestRepository.kt
@@ -1,10 +1,13 @@
 package com.back.boundedContexts.member.subContexts.privacy.adapter.persistence
 
+import com.back.boundedContexts.member.subContexts.privacy.application.port.output.MemberPrivacyRequestRepositoryPort
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequest
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface MemberPrivacyRequestRepository : JpaRepository<MemberPrivacyRequest, Long> {
-    fun findByIdAndMemberId(
+interface MemberPrivacyRequestRepository :
+    JpaRepository<MemberPrivacyRequest, Long>,
+    MemberPrivacyRequestRepositoryPort {
+    override fun findByIdAndMemberId(
         id: Long,
         memberId: Long,
     ): MemberPrivacyRequest?

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/port/output/MemberAccountDeletionRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/port/output/MemberAccountDeletionRepositoryPort.kt
@@ -5,5 +5,7 @@ import com.back.boundedContexts.member.subContexts.privacy.model.MemberAccountDe
 interface MemberAccountDeletionRepositoryPort {
     fun save(memberAccountDeletion: MemberAccountDeletion): MemberAccountDeletion
 
+    fun flush()
+
     fun existsByMemberId(memberId: Long): Boolean
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/port/output/MemberAccountDeletionRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/port/output/MemberAccountDeletionRepositoryPort.kt
@@ -1,0 +1,9 @@
+package com.back.boundedContexts.member.subContexts.privacy.application.port.output
+
+import com.back.boundedContexts.member.subContexts.privacy.model.MemberAccountDeletion
+
+interface MemberAccountDeletionRepositoryPort {
+    fun save(memberAccountDeletion: MemberAccountDeletion): MemberAccountDeletion
+
+    fun existsByMemberId(memberId: Long): Boolean
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/port/output/MemberPrivacyRequestRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/port/output/MemberPrivacyRequestRepositoryPort.kt
@@ -1,0 +1,12 @@
+package com.back.boundedContexts.member.subContexts.privacy.application.port.output
+
+import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequest
+
+interface MemberPrivacyRequestRepositoryPort {
+    fun save(memberPrivacyRequest: MemberPrivacyRequest): MemberPrivacyRequest
+
+    fun findByIdAndMemberId(
+        id: Long,
+        memberId: Long,
+    ): MemberPrivacyRequest?
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
@@ -1,7 +1,22 @@
 package com.back.boundedContexts.member.subContexts.privacy.application.service
 
 import com.back.boundedContexts.member.application.port.input.MemberUseCase
+import com.back.boundedContexts.member.application.port.output.MemberAttrRepositoryPort
 import com.back.boundedContexts.member.application.port.output.MemberRepositoryPort
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.domain.shared.memberMixin.ABOUT_BIO
+import com.back.boundedContexts.member.domain.shared.memberMixin.ABOUT_DETAILS
+import com.back.boundedContexts.member.domain.shared.memberMixin.ABOUT_ROLE
+import com.back.boundedContexts.member.domain.shared.memberMixin.BLOG_TITLE
+import com.back.boundedContexts.member.domain.shared.memberMixin.HOME_INTRO_DESCRIPTION
+import com.back.boundedContexts.member.domain.shared.memberMixin.HOME_INTRO_TITLE
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_BIO
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_CONTACT_LINKS
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_IMG_URL
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_ROLE
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_SERVICE_LINKS
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_WORKSPACE_DRAFT
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_WORKSPACE_PUBLISHED
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.output.MemberLegalAcceptanceRepositoryPort
 import com.back.boundedContexts.member.subContexts.privacy.application.port.output.MemberAccountDeletionRepositoryPort
 import com.back.boundedContexts.member.subContexts.privacy.application.port.output.MemberPrivacyRequestRepositoryPort
@@ -20,6 +35,7 @@ import java.time.temporal.ChronoUnit
 class PrivacyRightsApplicationService(
     private val memberUseCase: MemberUseCase,
     private val memberRepository: MemberRepositoryPort,
+    private val memberAttrRepository: MemberAttrRepositoryPort,
     private val memberPrivacyRequestRepository: MemberPrivacyRequestRepositoryPort,
     private val memberAccountDeletionRepository: MemberAccountDeletionRepositoryPort,
     private val memberLegalAcceptanceRepository: MemberLegalAcceptanceRepositoryPort,
@@ -99,7 +115,8 @@ class PrivacyRightsApplicationService(
     @Transactional
     fun deleteAccount(
         memberId: Long,
-        password: String,
+        password: String?,
+        oauthAccountDeletionConfirmed: Boolean,
         reason: String?,
     ): AccountDeletionResult {
         val member =
@@ -107,7 +124,11 @@ class PrivacyRightsApplicationService(
                 .findByIdForUpdate(memberId)
                 .orElseThrow { AppException("404-1", "회원을 찾을 수 없습니다.") }
 
-        memberUseCase.checkPassword(member, password)
+        verifyAccountDeletionReauthentication(
+            member = member,
+            password = password,
+            oauthAccountDeletionConfirmed = oauthAccountDeletionConfirmed,
+        )
 
         if (memberAccountDeletionRepository.existsByMemberId(member.id)) {
             throw AppException("409-1", "이미 탈퇴 처리된 계정입니다.")
@@ -115,6 +136,7 @@ class PrivacyRightsApplicationService(
 
         val deletedAt = Instant.now()
         member.softDelete(deletedAt)
+        memberAttrRepository.clearStringValuesBySubjectIdAndNameIn(member.id, PROFILE_PRIVACY_ATTR_NAMES)
         memberAccountDeletionRepository.save(
             MemberAccountDeletion(
                 member = member,
@@ -129,6 +151,45 @@ class PrivacyRightsApplicationService(
             deletedAt = deletedAt,
             revokedSessionCount = revokedSessionCount,
         )
+    }
+
+    private fun verifyAccountDeletionReauthentication(
+        member: Member,
+        password: String?,
+        oauthAccountDeletionConfirmed: Boolean,
+    ) {
+        if (member.password.isNullOrBlank()) {
+            if (!oauthAccountDeletionConfirmed) {
+                throw AppException("400-2", "소셜 계정 탈퇴 확인이 필요합니다.")
+            }
+            return
+        }
+
+        val rawPassword =
+            password
+                ?.trim()
+                ?.takeIf { it.isNotBlank() }
+                ?: throw AppException("400-1", "비밀번호를 입력해주세요.")
+        memberUseCase.checkPassword(member, rawPassword)
+    }
+
+    companion object {
+        private val PROFILE_PRIVACY_ATTR_NAMES =
+            listOf(
+                PROFILE_IMG_URL,
+                PROFILE_ROLE,
+                PROFILE_BIO,
+                ABOUT_ROLE,
+                ABOUT_BIO,
+                ABOUT_DETAILS,
+                BLOG_TITLE,
+                HOME_INTRO_TITLE,
+                HOME_INTRO_DESCRIPTION,
+                PROFILE_SERVICE_LINKS,
+                PROFILE_CONTACT_LINKS,
+                PROFILE_WORKSPACE_DRAFT,
+                PROFILE_WORKSPACE_PUBLISHED,
+            )
     }
 }
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
@@ -104,7 +104,7 @@ class PrivacyRightsApplicationService(
     ): AccountDeletionResult {
         val member =
             memberRepository
-                .findById(memberId)
+                .findByIdForUpdate(memberId)
                 .orElseThrow { AppException("404-1", "회원을 찾을 수 없습니다.") }
 
         memberUseCase.checkPassword(member, password)

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
@@ -19,6 +19,7 @@ import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_WORKSPA
 import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_WORKSPACE_PUBLISHED
 import com.back.boundedContexts.member.domain.shared.memberMixin.decodeMemberProfileWorkspaceContent
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.output.MemberLegalAcceptanceRepositoryPort
+import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupUseCase
 import com.back.boundedContexts.member.subContexts.privacy.application.port.output.MemberAccountDeletionRepositoryPort
 import com.back.boundedContexts.member.subContexts.privacy.application.port.output.MemberPrivacyRequestRepositoryPort
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberAccountDeletion
@@ -43,6 +44,7 @@ class PrivacyRightsApplicationService(
     private val memberAccountDeletionRepository: MemberAccountDeletionRepositoryPort,
     private val memberLegalAcceptanceRepository: MemberLegalAcceptanceRepositoryPort,
     private val memberSessionUseCase: MemberSessionUseCase,
+    private val oauthSignupUseCase: OAuthSignupUseCase,
     private val postUseCase: PostUseCase,
     private val uploadedFileRetentionService: UploadedFileRetentionService,
 ) {
@@ -140,8 +142,10 @@ class PrivacyRightsApplicationService(
         }
 
         val deletedAt = Instant.now()
+        val originalMemberLoginId = member.username
         val profileImageUrlsForCleanup = collectProfileImageUrlsForCleanup(member)
         postUseCase.deleteContentByAuthorForAccountDeletion(member)
+        oauthSignupUseCase.releaseConsumedSignupForMemberLoginId(originalMemberLoginId)
         member.softDelete(deletedAt)
         scheduleProfileImageCleanup(member.id, profileImageUrlsForCleanup)
         memberAttrRepository.clearStringValuesBySubjectIdAndNameIn(member.id, PROFILE_PRIVACY_ATTR_NAMES)

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
@@ -25,8 +25,7 @@ import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRe
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequestStatus
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequestType
 import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
-import com.back.boundedContexts.post.application.port.output.PostCommentRepositoryPort
-import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.boundedContexts.post.application.port.input.PostUseCase
 import com.back.global.exception.application.AppException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -42,8 +41,7 @@ class PrivacyRightsApplicationService(
     private val memberAccountDeletionRepository: MemberAccountDeletionRepositoryPort,
     private val memberLegalAcceptanceRepository: MemberLegalAcceptanceRepositoryPort,
     private val memberSessionUseCase: MemberSessionUseCase,
-    private val postRepository: PostRepositoryPort,
-    private val postCommentRepository: PostCommentRepositoryPort,
+    private val postUseCase: PostUseCase,
 ) {
     @Transactional(readOnly = true)
     fun exportFor(memberId: Long): PrivacyExportResponse {
@@ -139,8 +137,7 @@ class PrivacyRightsApplicationService(
         }
 
         val deletedAt = Instant.now()
-        postCommentRepository.softDeleteByAuthorId(member.id)
-        postRepository.softDeleteByAuthorId(member.id)
+        postUseCase.deleteContentByAuthorForAccountDeletion(member)
         member.softDelete(deletedAt)
         memberAttrRepository.clearStringValuesBySubjectIdAndNameIn(member.id, PROFILE_PRIVACY_ATTR_NAMES)
         memberAccountDeletionRepository.save(

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
@@ -1,0 +1,141 @@
+package com.back.boundedContexts.member.subContexts.privacy.application.service
+
+import com.back.boundedContexts.member.application.port.output.MemberRepositoryPort
+import com.back.boundedContexts.member.subContexts.legalAcceptance.adapter.persistence.MemberLegalAcceptanceRepository
+import com.back.boundedContexts.member.subContexts.privacy.adapter.persistence.MemberPrivacyRequestRepository
+import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequest
+import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequestStatus
+import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequestType
+import com.back.global.exception.application.AppException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@Service
+class PrivacyRightsApplicationService(
+    private val memberRepository: MemberRepositoryPort,
+    private val memberPrivacyRequestRepository: MemberPrivacyRequestRepository,
+    private val memberLegalAcceptanceRepository: MemberLegalAcceptanceRepository,
+) {
+    @Transactional(readOnly = true)
+    fun exportFor(memberId: Long): PrivacyExportResponse {
+        val member =
+            memberRepository
+                .findById(memberId)
+                .orElseThrow { AppException("404-1", "회원을 찾을 수 없습니다.") }
+        val legalAcceptance = memberLegalAcceptanceRepository.findTopByMemberIdOrderByAcceptedAtDesc(memberId)
+
+        return PrivacyExportResponse(
+            generatedAt = Instant.now(),
+            member =
+                PrivacyExportMemberSnapshot(
+                    id = member.id,
+                    email = member.email,
+                    username = member.username,
+                    nickname = member.nickname,
+                    createdAt = member.createdAt,
+                    modifiedAt = member.modifiedAt,
+                ),
+            latestLegalAcceptance =
+                legalAcceptance?.let {
+                    PrivacyLegalAcceptanceSnapshot(
+                        termsVersion = it.termsVersion,
+                        termsContentSha256 = it.termsContentSha256,
+                        privacyVersion = it.privacyVersion,
+                        privacyContentSha256 = it.privacyContentSha256,
+                        age14OrOlder = it.age14OrOlder,
+                        requiredPrivacyConfirmed = it.requiredPrivacyConfirmed,
+                        analyticsConsent = it.analyticsConsent,
+                        overseasTransferAcknowledged = it.overseasTransferAcknowledged,
+                        source = it.source,
+                        acceptedAt = it.acceptedAt,
+                    )
+                },
+        )
+    }
+
+    @Transactional
+    fun createRequest(
+        memberId: Long,
+        type: MemberPrivacyRequestType,
+        message: String?,
+    ): PrivacyRequestDto {
+        val member = memberRepository.getReferenceById(memberId)
+        val requestedAt = Instant.now()
+        val request =
+            memberPrivacyRequestRepository.save(
+                MemberPrivacyRequest(
+                    member = member,
+                    type = type,
+                    message = message?.trim()?.takeIf { it.isNotBlank() },
+                    requestedAt = requestedAt,
+                    dueAt = requestedAt.plus(30, ChronoUnit.DAYS),
+                ),
+            )
+
+        return PrivacyRequestDto(request)
+    }
+
+    @Transactional(readOnly = true)
+    fun getRequest(
+        memberId: Long,
+        requestId: Long,
+    ): PrivacyRequestDto {
+        val request =
+            memberPrivacyRequestRepository.findByIdAndMemberId(requestId, memberId)
+                ?: throw AppException("404-1", "개인정보 처리 요청을 찾을 수 없습니다.")
+
+        return PrivacyRequestDto(request)
+    }
+}
+
+data class PrivacyExportResponse(
+    val generatedAt: Instant,
+    val member: PrivacyExportMemberSnapshot,
+    val latestLegalAcceptance: PrivacyLegalAcceptanceSnapshot?,
+)
+
+data class PrivacyExportMemberSnapshot(
+    val id: Long,
+    val email: String?,
+    val username: String,
+    val nickname: String,
+    val createdAt: Instant,
+    val modifiedAt: Instant,
+)
+
+data class PrivacyLegalAcceptanceSnapshot(
+    val termsVersion: String,
+    val termsContentSha256: String,
+    val privacyVersion: String,
+    val privacyContentSha256: String,
+    val age14OrOlder: Boolean,
+    val requiredPrivacyConfirmed: Boolean,
+    val analyticsConsent: Boolean,
+    val overseasTransferAcknowledged: Boolean,
+    val source: String,
+    val acceptedAt: Instant,
+)
+
+data class PrivacyRequestDto(
+    val id: Long,
+    val memberId: Long,
+    val type: MemberPrivacyRequestType,
+    val status: MemberPrivacyRequestStatus,
+    val message: String?,
+    val requestedAt: Instant,
+    val dueAt: Instant,
+    val completedAt: Instant?,
+) {
+    constructor(request: MemberPrivacyRequest) : this(
+        id = request.id,
+        memberId = request.member.id,
+        type = request.type,
+        status = request.status,
+        message = request.message,
+        requestedAt = request.requestedAt,
+        dueAt = request.dueAt,
+        completedAt = request.completedAt,
+    )
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
@@ -145,7 +145,7 @@ class PrivacyRightsApplicationService(
         memberAttrRepository.clearStringValuesBySubjectIdAndNameIn(member.id, PROFILE_PRIVACY_ATTR_NAMES)
         memberAccountDeletionRepository.save(
             MemberAccountDeletion(
-                member = member,
+                memberId = member.id,
                 reason = reason?.trim()?.takeIf { it.isNotBlank() },
                 deletedAt = deletedAt,
             ),

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
@@ -25,6 +25,8 @@ import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRe
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequestStatus
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequestType
 import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
+import com.back.boundedContexts.post.application.port.output.PostCommentRepositoryPort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
 import com.back.global.exception.application.AppException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -40,6 +42,8 @@ class PrivacyRightsApplicationService(
     private val memberAccountDeletionRepository: MemberAccountDeletionRepositoryPort,
     private val memberLegalAcceptanceRepository: MemberLegalAcceptanceRepositoryPort,
     private val memberSessionUseCase: MemberSessionUseCase,
+    private val postRepository: PostRepositoryPort,
+    private val postCommentRepository: PostCommentRepositoryPort,
 ) {
     @Transactional(readOnly = true)
     fun exportFor(memberId: Long): PrivacyExportResponse {
@@ -135,6 +139,8 @@ class PrivacyRightsApplicationService(
         }
 
         val deletedAt = Instant.now()
+        postCommentRepository.softDeleteByAuthorId(member.id)
+        postRepository.softDeleteByAuthorId(member.id)
         member.softDelete(deletedAt)
         memberAttrRepository.clearStringValuesBySubjectIdAndNameIn(member.id, PROFILE_PRIVACY_ATTR_NAMES)
         memberAccountDeletionRepository.save(

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
@@ -173,7 +173,6 @@ class PrivacyRightsApplicationService(
 
         val rawPassword =
             password
-                ?.trim()
                 ?.takeIf { it.isNotBlank() }
                 ?: throw AppException("400-1", "비밀번호를 입력해주세요.")
         memberUseCase.checkPassword(member, rawPassword)

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
@@ -144,6 +144,7 @@ class PrivacyRightsApplicationService(
         val deletedAt = Instant.now()
         val originalMemberLoginId = member.username
         val profileImageUrlsForCleanup = collectProfileImageUrlsForCleanup(member)
+        val revokedSessionCount = memberSessionUseCase.revokeAllActiveSessionsForMember(member.id)
         postUseCase.deleteContentByAuthorForAccountDeletion(member)
         oauthSignupUseCase.releaseConsumedSignupForMemberLoginId(originalMemberLoginId)
         member.softDelete(deletedAt)
@@ -156,7 +157,7 @@ class PrivacyRightsApplicationService(
                 deletedAt = deletedAt,
             ),
         )
-        val revokedSessionCount = memberSessionUseCase.revokeAllActiveSessionsForMember(member.id)
+        memberAccountDeletionRepository.flush()
 
         return AccountDeletionResult(
             memberId = member.id,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
@@ -17,6 +17,7 @@ import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_ROLE
 import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_SERVICE_LINKS
 import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_WORKSPACE_DRAFT
 import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_WORKSPACE_PUBLISHED
+import com.back.boundedContexts.member.domain.shared.memberMixin.decodeMemberProfileWorkspaceContent
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.output.MemberLegalAcceptanceRepositoryPort
 import com.back.boundedContexts.member.subContexts.privacy.application.port.output.MemberAccountDeletionRepositoryPort
 import com.back.boundedContexts.member.subContexts.privacy.application.port.output.MemberPrivacyRequestRepositoryPort
@@ -27,6 +28,7 @@ import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRe
 import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
 import com.back.boundedContexts.post.application.port.input.PostUseCase
 import com.back.global.exception.application.AppException
+import com.back.global.storage.application.UploadedFileRetentionService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -42,6 +44,7 @@ class PrivacyRightsApplicationService(
     private val memberLegalAcceptanceRepository: MemberLegalAcceptanceRepositoryPort,
     private val memberSessionUseCase: MemberSessionUseCase,
     private val postUseCase: PostUseCase,
+    private val uploadedFileRetentionService: UploadedFileRetentionService,
 ) {
     @Transactional(readOnly = true)
     fun exportFor(memberId: Long): PrivacyExportResponse {
@@ -137,8 +140,10 @@ class PrivacyRightsApplicationService(
         }
 
         val deletedAt = Instant.now()
+        val profileImageUrlsForCleanup = collectProfileImageUrlsForCleanup(member)
         postUseCase.deleteContentByAuthorForAccountDeletion(member)
         member.softDelete(deletedAt)
+        scheduleProfileImageCleanup(member.id, profileImageUrlsForCleanup)
         memberAttrRepository.clearStringValuesBySubjectIdAndNameIn(member.id, PROFILE_PRIVACY_ATTR_NAMES)
         memberAccountDeletionRepository.save(
             MemberAccountDeletion(
@@ -175,7 +180,42 @@ class PrivacyRightsApplicationService(
         memberUseCase.checkPassword(member, rawPassword)
     }
 
+    private fun collectProfileImageUrlsForCleanup(member: Member): List<String> {
+        val attrs =
+            memberAttrRepository
+                .findBySubjectInAndNameIn(listOf(member), PROFILE_IMAGE_CLEANUP_ATTR_NAMES)
+                .associateBy { it.name }
+
+        return listOfNotNull(
+            attrs[PROFILE_IMG_URL]?.strValue,
+            attrs[PROFILE_WORKSPACE_DRAFT]?.strValue?.let(::decodeMemberProfileWorkspaceContent)?.profileImageUrl,
+            attrs[PROFILE_WORKSPACE_PUBLISHED]?.strValue?.let(::decodeMemberProfileWorkspaceContent)?.profileImageUrl,
+        ).map(String::trim)
+            .filter(String::isNotBlank)
+            .distinct()
+    }
+
+    private fun scheduleProfileImageCleanup(
+        memberId: Long,
+        profileImageUrls: List<String>,
+    ) {
+        profileImageUrls.forEach { profileImageUrl ->
+            uploadedFileRetentionService.syncProfileImage(
+                memberId = memberId,
+                previousProfileImgUrl = profileImageUrl,
+                currentProfileImgUrl = null,
+            )
+        }
+    }
+
     companion object {
+        private val PROFILE_IMAGE_CLEANUP_ATTR_NAMES =
+            listOf(
+                PROFILE_IMG_URL,
+                PROFILE_WORKSPACE_DRAFT,
+                PROFILE_WORKSPACE_PUBLISHED,
+            )
+
         private val PROFILE_PRIVACY_ATTR_NAMES =
             listOf(
                 PROFILE_IMG_URL,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
@@ -1,11 +1,15 @@
 package com.back.boundedContexts.member.subContexts.privacy.application.service
 
+import com.back.boundedContexts.member.application.port.input.MemberUseCase
 import com.back.boundedContexts.member.application.port.output.MemberRepositoryPort
 import com.back.boundedContexts.member.subContexts.legalAcceptance.adapter.persistence.MemberLegalAcceptanceRepository
+import com.back.boundedContexts.member.subContexts.privacy.adapter.persistence.MemberAccountDeletionRepository
 import com.back.boundedContexts.member.subContexts.privacy.adapter.persistence.MemberPrivacyRequestRepository
+import com.back.boundedContexts.member.subContexts.privacy.model.MemberAccountDeletion
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequest
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequestStatus
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequestType
+import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
 import com.back.global.exception.application.AppException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,9 +18,12 @@ import java.time.temporal.ChronoUnit
 
 @Service
 class PrivacyRightsApplicationService(
+    private val memberUseCase: MemberUseCase,
     private val memberRepository: MemberRepositoryPort,
     private val memberPrivacyRequestRepository: MemberPrivacyRequestRepository,
+    private val memberAccountDeletionRepository: MemberAccountDeletionRepository,
     private val memberLegalAcceptanceRepository: MemberLegalAcceptanceRepository,
+    private val memberSessionUseCase: MemberSessionUseCase,
 ) {
     @Transactional(readOnly = true)
     fun exportFor(memberId: Long): PrivacyExportResponse {
@@ -88,6 +95,41 @@ class PrivacyRightsApplicationService(
 
         return PrivacyRequestDto(request)
     }
+
+    @Transactional
+    fun deleteAccount(
+        memberId: Long,
+        password: String,
+        reason: String?,
+    ): AccountDeletionResult {
+        val member =
+            memberRepository
+                .findById(memberId)
+                .orElseThrow { AppException("404-1", "회원을 찾을 수 없습니다.") }
+
+        memberUseCase.checkPassword(member, password)
+
+        if (memberAccountDeletionRepository.existsByMemberId(member.id)) {
+            throw AppException("409-1", "이미 탈퇴 처리된 계정입니다.")
+        }
+
+        val deletedAt = Instant.now()
+        member.softDelete(deletedAt)
+        memberAccountDeletionRepository.save(
+            MemberAccountDeletion(
+                member = member,
+                reason = reason?.trim()?.takeIf { it.isNotBlank() },
+                deletedAt = deletedAt,
+            ),
+        )
+        val revokedSessionCount = memberSessionUseCase.revokeAllActiveSessionsForMember(member.id)
+
+        return AccountDeletionResult(
+            memberId = member.id,
+            deletedAt = deletedAt,
+            revokedSessionCount = revokedSessionCount,
+        )
+    }
 }
 
 data class PrivacyExportResponse(
@@ -139,3 +181,9 @@ data class PrivacyRequestDto(
         completedAt = request.completedAt,
     )
 }
+
+data class AccountDeletionResult(
+    val memberId: Long,
+    val deletedAt: Instant,
+    val revokedSessionCount: Int,
+)

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/application/service/PrivacyRightsApplicationService.kt
@@ -2,9 +2,9 @@ package com.back.boundedContexts.member.subContexts.privacy.application.service
 
 import com.back.boundedContexts.member.application.port.input.MemberUseCase
 import com.back.boundedContexts.member.application.port.output.MemberRepositoryPort
-import com.back.boundedContexts.member.subContexts.legalAcceptance.adapter.persistence.MemberLegalAcceptanceRepository
-import com.back.boundedContexts.member.subContexts.privacy.adapter.persistence.MemberAccountDeletionRepository
-import com.back.boundedContexts.member.subContexts.privacy.adapter.persistence.MemberPrivacyRequestRepository
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.output.MemberLegalAcceptanceRepositoryPort
+import com.back.boundedContexts.member.subContexts.privacy.application.port.output.MemberAccountDeletionRepositoryPort
+import com.back.boundedContexts.member.subContexts.privacy.application.port.output.MemberPrivacyRequestRepositoryPort
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberAccountDeletion
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequest
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberPrivacyRequestStatus
@@ -20,9 +20,9 @@ import java.time.temporal.ChronoUnit
 class PrivacyRightsApplicationService(
     private val memberUseCase: MemberUseCase,
     private val memberRepository: MemberRepositoryPort,
-    private val memberPrivacyRequestRepository: MemberPrivacyRequestRepository,
-    private val memberAccountDeletionRepository: MemberAccountDeletionRepository,
-    private val memberLegalAcceptanceRepository: MemberLegalAcceptanceRepository,
+    private val memberPrivacyRequestRepository: MemberPrivacyRequestRepositoryPort,
+    private val memberAccountDeletionRepository: MemberAccountDeletionRepositoryPort,
+    private val memberLegalAcceptanceRepository: MemberLegalAcceptanceRepositoryPort,
     private val memberSessionUseCase: MemberSessionUseCase,
 ) {
     @Transactional(readOnly = true)

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/model/MemberAccountDeletion.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/model/MemberAccountDeletion.kt
@@ -1,0 +1,38 @@
+package com.back.boundedContexts.member.subContexts.privacy.model
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.global.jpa.domain.BaseTime
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType.SEQUENCE
+import jakarta.persistence.Id
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+
+@Entity
+@Table(
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_member_account_deletion_member", columnNames = ["member_id"]),
+    ],
+)
+class MemberAccountDeletion(
+    @field:Id
+    @field:SequenceGenerator(
+        name = "member_account_deletion_seq_gen",
+        sequenceName = "member_account_deletion_seq",
+        allocationSize = 20,
+    )
+    @field:GeneratedValue(strategy = SEQUENCE, generator = "member_account_deletion_seq_gen")
+    override val id: Long = 0,
+    @field:ManyToOne(fetch = FetchType.LAZY)
+    val member: Member,
+    @field:Column(length = 500)
+    val reason: String? = null,
+    @field:Column(nullable = false)
+    val deletedAt: Instant,
+) : BaseTime(id)

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/model/MemberAccountDeletion.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/model/MemberAccountDeletion.kt
@@ -1,15 +1,11 @@
 package com.back.boundedContexts.member.subContexts.privacy.model
 
-import com.back.boundedContexts.member.domain.shared.Member
 import com.back.global.jpa.domain.BaseTime
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType.SEQUENCE
 import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
@@ -30,9 +26,8 @@ class MemberAccountDeletion(
     )
     @field:GeneratedValue(strategy = SEQUENCE, generator = "member_account_deletion_seq_gen")
     override val id: Long = 0,
-    @field:ManyToOne(fetch = FetchType.LAZY)
-    @field:JoinColumn(name = "member_id", nullable = false)
-    val member: Member,
+    @field:Column(name = "member_id", nullable = false)
+    val memberId: Long,
     @field:Column(length = 500)
     val reason: String? = null,
     @field:Column(nullable = false)

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/model/MemberAccountDeletion.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/model/MemberAccountDeletion.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType.SEQUENCE
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
@@ -30,6 +31,7 @@ class MemberAccountDeletion(
     @field:GeneratedValue(strategy = SEQUENCE, generator = "member_account_deletion_seq_gen")
     override val id: Long = 0,
     @field:ManyToOne(fetch = FetchType.LAZY)
+    @field:JoinColumn(name = "member_id", nullable = false)
     val member: Member,
     @field:Column(length = 500)
     val reason: String? = null,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/model/MemberPrivacyRequest.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/model/MemberPrivacyRequest.kt
@@ -1,0 +1,57 @@
+package com.back.boundedContexts.member.subContexts.privacy.model
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.global.jpa.domain.BaseTime
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType.SEQUENCE
+import jakarta.persistence.Id
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.SequenceGenerator
+import java.time.Instant
+
+@Entity
+class MemberPrivacyRequest(
+    @field:Id
+    @field:SequenceGenerator(
+        name = "member_privacy_request_seq_gen",
+        sequenceName = "member_privacy_request_seq",
+        allocationSize = 20,
+    )
+    @field:GeneratedValue(strategy = SEQUENCE, generator = "member_privacy_request_seq_gen")
+    override val id: Long = 0,
+    @field:ManyToOne(fetch = FetchType.LAZY)
+    val member: Member,
+    @field:Enumerated(EnumType.STRING)
+    @field:Column(nullable = false, length = 48)
+    val type: MemberPrivacyRequestType,
+    @field:Enumerated(EnumType.STRING)
+    @field:Column(nullable = false, length = 32)
+    var status: MemberPrivacyRequestStatus = MemberPrivacyRequestStatus.RECEIVED,
+    @field:Column(length = 1000)
+    val message: String? = null,
+    @field:Column(nullable = false)
+    val requestedAt: Instant,
+    @field:Column(nullable = false)
+    val dueAt: Instant,
+    var completedAt: Instant? = null,
+) : BaseTime(id)
+
+enum class MemberPrivacyRequestType {
+    EXPORT,
+    CORRECTION,
+    DELETION,
+    PROCESSING_RESTRICTION,
+    CONSENT_WITHDRAWAL,
+}
+
+enum class MemberPrivacyRequestStatus {
+    RECEIVED,
+    IN_PROGRESS,
+    COMPLETED,
+    REJECTED,
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/model/MemberPrivacyRequest.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/privacy/model/MemberPrivacyRequest.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType.SEQUENCE
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.SequenceGenerator
 import java.time.Instant
@@ -25,6 +26,7 @@ class MemberPrivacyRequest(
     @field:GeneratedValue(strategy = SEQUENCE, generator = "member_privacy_request_seq_gen")
     override val id: Long = 0,
     @field:ManyToOne(fetch = FetchType.LAZY)
+    @field:JoinColumn(name = "member_id", nullable = false)
     val member: Member,
     @field:Enumerated(EnumType.STRING)
     @field:Column(nullable = false, length = 48)

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepository.kt
@@ -117,6 +117,20 @@ interface MemberSessionRepository : JpaRepository<MemberSession, Long> {
 
     @Modifying(flushAutomatically = true, clearAutomatically = false)
     @Query(
+        """
+        update MemberSession session
+        set session.revokedAt = :now
+        where session.member.id = :memberId
+          and session.revokedAt is null
+        """,
+    )
+    fun revokeAllActiveSessionsForMember(
+        @Param("memberId") memberId: Long,
+        @Param("now") now: Instant,
+    ): Int
+
+    @Modifying(flushAutomatically = true, clearAutomatically = false)
+    @Query(
         value = """
         delete from member_session
         where id in (

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepositoryAdapter.kt
@@ -46,6 +46,11 @@ class MemberSessionRepositoryAdapter(
         now: Instant,
     ): Int = memberSessionRepository.revokeActiveSessionsBeyondLimit(memberId, keepLimit.coerceAtLeast(1), now)
 
+    override fun revokeAllActiveSessionsForMember(
+        memberId: Long,
+        now: Instant,
+    ): Int = memberSessionRepository.revokeAllActiveSessionsForMember(memberId, now)
+
     override fun deleteRevokedBefore(
         cutoff: Instant,
         limit: Int,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/adapter/persistence/MemberSessionRepositoryAdapter.kt
@@ -1,16 +1,35 @@
 package com.back.boundedContexts.member.subContexts.session.adapter.persistence
 
+import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.subContexts.session.application.port.output.MemberSessionStorePort
 import com.back.boundedContexts.member.subContexts.session.model.MemberSession
 import com.back.boundedContexts.member.subContexts.session.model.MemberSessionAuthSnapshot
+import jakarta.persistence.EntityManager
+import jakarta.persistence.LockModeType
 import org.springframework.stereotype.Component
 import java.time.Instant
 
 @Component
 class MemberSessionRepositoryAdapter(
     private val memberSessionRepository: MemberSessionRepository,
+    private val entityManager: EntityManager,
 ) : MemberSessionStorePort {
     override fun save(memberSession: MemberSession): MemberSession = memberSessionRepository.save(memberSession)
+
+    override fun findActiveMemberForSessionIssue(memberId: Long): Member? =
+        entityManager
+            .createQuery(
+                """
+                select member
+                from Member member
+                where member.id = :memberId
+                  and member.deletedAt is null
+                """.trimIndent(),
+                Member::class.java,
+            ).setParameter("memberId", memberId)
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+            .resultList
+            .singleOrNull()
 
     override fun findBySessionKey(sessionKey: String): MemberSession? = memberSessionRepository.findBySessionKey(sessionKey)
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/port/input/MemberSessionUseCase.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/port/input/MemberSessionUseCase.kt
@@ -48,4 +48,6 @@ interface MemberSessionUseCase {
     ): MemberSessionWithRefreshToken?
 
     fun revokeSession(sessionKey: String)
+
+    fun revokeAllActiveSessionsForMember(memberId: Long): Int
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/port/output/MemberSessionStorePort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/port/output/MemberSessionStorePort.kt
@@ -37,6 +37,11 @@ interface MemberSessionStorePort {
         now: Instant,
     ): Int
 
+    fun revokeAllActiveSessionsForMember(
+        memberId: Long,
+        now: Instant,
+    ): Int
+
     fun deleteRevokedBefore(
         cutoff: Instant,
         limit: Int,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/port/output/MemberSessionStorePort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/port/output/MemberSessionStorePort.kt
@@ -1,11 +1,14 @@
 package com.back.boundedContexts.member.subContexts.session.application.port.output
 
+import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.subContexts.session.model.MemberSession
 import com.back.boundedContexts.member.subContexts.session.model.MemberSessionAuthSnapshot
 import java.time.Instant
 
 interface MemberSessionStorePort {
     fun save(memberSession: MemberSession): MemberSession
+
+    fun findActiveMemberForSessionIssue(memberId: Long): Member?
 
     fun findBySessionKey(sessionKey: String): MemberSession?
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionService.kt
@@ -8,6 +8,7 @@ import com.back.boundedContexts.member.subContexts.session.model.MemberSession
 import com.back.boundedContexts.member.subContexts.session.model.MemberSessionAuthSnapshot
 import com.back.boundedContexts.member.subContexts.session.model.MemberSessionRefreshTokenPolicy
 import com.back.boundedContexts.member.subContexts.session.model.MemberSessionWithRefreshToken
+import com.back.global.exception.application.AppException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.Cacheable
@@ -60,10 +61,13 @@ class MemberSessionService(
         userAgent: String?,
     ): MemberSessionWithRefreshToken {
         val now = Instant.now()
+        val activeMember =
+            memberSessionStorePort.findActiveMemberForSessionIssue(member.id)
+                ?: throw AppException("409-1", "탈퇴 처리된 계정은 세션을 생성할 수 없습니다.")
         val refreshToken = MemberSessionRefreshTokenPolicy.generate()
         val session =
             MemberSession(
-                member = member,
+                member = activeMember,
                 sessionKey = MemberPolicy.genApiKey(),
                 rememberLoginEnabled = rememberLoginEnabled,
                 ipSecurityEnabled = ipSecurityEnabled,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionService.kt
@@ -14,6 +14,8 @@ import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -85,7 +87,7 @@ class MemberSessionService(
                 now = now,
             )
         if (revokedCount > 0) {
-            evictAllActiveSnapshots()
+            evictAllActiveSnapshotsNowAndAfterCommit()
         }
         return MemberSessionWithRefreshToken(
             session = savedSession,
@@ -187,7 +189,7 @@ class MemberSessionService(
     override fun revokeAllActiveSessionsForMember(memberId: Long): Int {
         val revokedCount = memberSessionStorePort.revokeAllActiveSessionsForMember(memberId, Instant.now())
         if (revokedCount > 0) {
-            evictAllActiveSnapshots()
+            evictAllActiveSnapshotsNowAndAfterCommit()
         }
         return revokedCount
     }
@@ -213,6 +215,19 @@ class MemberSessionService(
 
     private fun evictAllActiveSnapshots() {
         cacheManager.getCache(MemberSessionCacheNames.ACTIVE)?.clear()
+    }
+
+    private fun evictAllActiveSnapshotsNowAndAfterCommit() {
+        evictAllActiveSnapshots()
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) return
+
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() {
+                    evictAllActiveSnapshots()
+                }
+            },
+        )
     }
 
     private fun isTouchDue(

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionService.kt
@@ -180,6 +180,15 @@ class MemberSessionService(
     }
 
     @Transactional
+    override fun revokeAllActiveSessionsForMember(memberId: Long): Int {
+        val revokedCount = memberSessionStorePort.revokeAllActiveSessionsForMember(memberId, Instant.now())
+        if (revokedCount > 0) {
+            evictAllActiveSnapshots()
+        }
+        return revokedCount
+    }
+
+    @Transactional
     fun purgeExpiredRevokedSessions(
         batchSize: Int,
         now: Instant = Instant.now(),

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt
@@ -65,8 +65,8 @@ class ApiV1SignupVerificationController(
         @field:NotBlank
         @field:Size(min = 8, max = 64)
         @field:Pattern(
-            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{8,64}$",
-            message = "비밀번호는 8~64자이며 영문 대문자/소문자/숫자/특수문자를 모두 포함해야 합니다.",
+            regexp = "^(?=\\S{8,64}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9\\s]).*$",
+            message = "비밀번호는 공백 없이 8~64자이며 영문 대문자/소문자/숫자/특수문자를 모두 포함해야 합니다.",
         )
         val password: String,
         @field:NotBlank

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/event/PostReadModelTaskEventListener.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/event/PostReadModelTaskEventListener.kt
@@ -6,6 +6,7 @@ import com.back.boundedContexts.post.application.service.PostSearchIndexSyncServ
 import com.back.boundedContexts.post.dto.PostReadPrewarmPayload
 import com.back.boundedContexts.post.dto.PostSearchEngineMirrorPayload
 import com.back.boundedContexts.post.dto.PostSearchIndexSyncPayload
+import com.back.boundedContexts.post.event.PostAccountDeletionDeletedEvent
 import com.back.boundedContexts.post.event.PostDeletedEvent
 import com.back.boundedContexts.post.event.PostModifiedEvent
 import com.back.boundedContexts.post.event.PostWrittenEvent
@@ -76,6 +77,21 @@ class PostReadModelTaskEventListener(
         fallbackExecution = true,
     )
     fun handle(event: PostDeletedEvent) =
+        enqueueFollowupTasks(
+            sourceEventUid = event.uid,
+            aggregateType = event.aggregateType,
+            postId = event.aggregateId,
+            beforeTags = event.beforeTags,
+            afterTags = event.afterTags,
+            forceClearSearchIndex = true,
+            warmDetail = false,
+        )
+
+    @TransactionalEventListener(
+        phase = TransactionPhase.AFTER_COMMIT,
+        fallbackExecution = true,
+    )
+    fun handle(event: PostAccountDeletionDeletedEvent) =
         enqueueFollowupTasks(
             sourceEventUid = event.uid,
             aggregateType = event.aggregateType,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryAdapter.kt
@@ -1,5 +1,6 @@
 package com.back.boundedContexts.post.adapter.persistence
 
+import com.back.boundedContexts.post.application.port.output.PostCommentAccountDeletionTarget
 import com.back.boundedContexts.post.application.port.output.PostCommentRepositoryPort
 import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostComment
@@ -30,8 +31,13 @@ class PostCommentRepositoryAdapter(
         rootCommentId: Long,
     ): List<PostComment> = postCommentRepository.findActiveSubtreeByPostAndRootCommentId(post, rootCommentId)
 
-    override fun findActiveByAuthorIdOrderByPostIdCreatedAtIdAsc(authorId: Long): List<PostComment> =
-        postCommentRepository.findActiveByAuthorIdOrderByPostIdCreatedAtIdAsc(authorId)
+    override fun findActiveSubtreeByPostIdAndRootCommentId(
+        postId: Long,
+        rootCommentId: Long,
+    ): List<PostComment> = postCommentRepository.findActiveSubtreeByPostIdAndRootCommentId(postId, rootCommentId)
+
+    override fun findActiveAccountDeletionTargetsByAuthorId(authorId: Long): List<PostCommentAccountDeletionTarget> =
+        postCommentRepository.findActiveAccountDeletionTargetsByAuthorId(authorId)
 
     override fun findByPostAndId(
         post: Post,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryAdapter.kt
@@ -39,6 +39,11 @@ class PostCommentRepositoryAdapter(
     override fun findActiveAccountDeletionTargetsByAuthorId(authorId: Long): List<PostCommentAccountDeletionTarget> =
         postCommentRepository.findActiveAccountDeletionTargetsByAuthorId(authorId)
 
+    override fun decrementPostCommentsCountByPostId(
+        postId: Long,
+        count: Int,
+    ): Int = postCommentRepository.decrementPostCommentsCountByPostId(postId, count)
+
     override fun findByPostAndId(
         post: Post,
         id: Long,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryAdapter.kt
@@ -30,12 +30,13 @@ class PostCommentRepositoryAdapter(
         rootCommentId: Long,
     ): List<PostComment> = postCommentRepository.findActiveSubtreeByPostAndRootCommentId(post, rootCommentId)
 
+    override fun findActiveByAuthorIdOrderByPostIdCreatedAtIdAsc(authorId: Long): List<PostComment> =
+        postCommentRepository.findActiveByAuthorIdOrderByPostIdCreatedAtIdAsc(authorId)
+
     override fun findByPostAndId(
         post: Post,
         id: Long,
     ): PostComment? = postCommentRepository.findByPostAndId(post, id)
 
     override fun findById(id: Long): Optional<PostComment> = postCommentRepository.findById(id)
-
-    override fun softDeleteByAuthorId(authorId: Long): Int = postCommentRepository.softDeleteByAuthorId(authorId)
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryAdapter.kt
@@ -36,4 +36,6 @@ class PostCommentRepositoryAdapter(
     ): PostComment? = postCommentRepository.findByPostAndId(post, id)
 
     override fun findById(id: Long): Optional<PostComment> = postCommentRepository.findById(id)
+
+    override fun softDeleteByAuthorId(authorId: Long): Int = postCommentRepository.softDeleteByAuthorId(authorId)
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryCustom.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryCustom.kt
@@ -16,4 +16,9 @@ interface PostCommentRepositoryCustom {
     ): List<PostComment>
 
     fun findActiveAccountDeletionTargetsByAuthorId(authorId: Long): List<PostCommentAccountDeletionTarget>
+
+    fun decrementPostCommentsCountByPostId(
+        postId: Long,
+        count: Int,
+    ): Int
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryCustom.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryCustom.kt
@@ -9,5 +9,5 @@ interface PostCommentRepositoryCustom {
         rootCommentId: Long,
     ): List<PostComment>
 
-    fun softDeleteByAuthorId(authorId: Long): Int
+    fun findActiveByAuthorIdOrderByPostIdCreatedAtIdAsc(authorId: Long): List<PostComment>
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryCustom.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryCustom.kt
@@ -1,5 +1,6 @@
 package com.back.boundedContexts.post.adapter.persistence
 
+import com.back.boundedContexts.post.application.port.output.PostCommentAccountDeletionTarget
 import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostComment
 
@@ -9,5 +10,10 @@ interface PostCommentRepositoryCustom {
         rootCommentId: Long,
     ): List<PostComment>
 
-    fun findActiveByAuthorIdOrderByPostIdCreatedAtIdAsc(authorId: Long): List<PostComment>
+    fun findActiveSubtreeByPostIdAndRootCommentId(
+        postId: Long,
+        rootCommentId: Long,
+    ): List<PostComment>
+
+    fun findActiveAccountDeletionTargetsByAuthorId(authorId: Long): List<PostCommentAccountDeletionTarget>
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryCustom.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryCustom.kt
@@ -8,4 +8,6 @@ interface PostCommentRepositoryCustom {
         post: Post,
         rootCommentId: Long,
     ): List<PostComment>
+
+    fun softDeleteByAuthorId(authorId: Long): Int
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryImpl.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryImpl.kt
@@ -106,9 +106,10 @@ class PostCommentRepositoryImpl : PostCommentRepositoryCustom {
 
         val commentsById = findActiveCommentsByIdsInOrder(rows.map(AccountDeletionTargetRow::commentId)).associateBy(PostComment::id)
 
-        return rows.map { row ->
+        return rows.mapNotNull { row ->
+            val comment = commentsById[row.commentId] ?: return@mapNotNull null
             PostCommentAccountDeletionTargetResult(
-                comment = commentsById.getValue(row.commentId),
+                comment = comment,
                 postId = row.postId,
                 postDeleted = row.postDeleted,
             )

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryImpl.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.back.boundedContexts.post.adapter.persistence
 import com.back.boundedContexts.post.application.port.output.PostCommentAccountDeletionTarget
 import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostComment
+import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
 
@@ -113,6 +114,26 @@ class PostCommentRepositoryImpl : PostCommentRepositoryCustom {
             )
         }
     }
+
+    override fun decrementPostCommentsCountByPostId(
+        postId: Long,
+        count: Int,
+    ): Int =
+        (
+            entityManager
+                .createNativeQuery(
+                    """
+                    update post_attr
+                    set int_value = greatest(0, coalesce(int_value, 0) - :count)
+                    where subject_id = :postId
+                      and name = :name
+                    returning int_value
+                    """.trimIndent(),
+                ).setParameter("postId", postId)
+                .setParameter("name", COMMENTS_COUNT)
+                .setParameter("count", count)
+                .singleResult as Number
+        ).toInt()
 
     private fun findActiveCommentsByIdsInOrder(ids: List<Long>): List<PostComment> {
         if (ids.isEmpty()) return emptyList()

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryImpl.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.back.boundedContexts.post.adapter.persistence
 
+import com.back.boundedContexts.post.application.port.output.PostCommentAccountDeletionTarget
 import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostComment
 import jakarta.persistence.EntityManager
@@ -43,6 +44,77 @@ class PostCommentRepositoryImpl : PostCommentRepositoryCustom {
                 .resultList
                 .map { (it as Number).toLong() }
 
+        return findActiveCommentsByIdsInOrder(ids)
+    }
+
+    override fun findActiveSubtreeByPostIdAndRootCommentId(
+        postId: Long,
+        rootCommentId: Long,
+    ): List<PostComment> {
+        val ids =
+            entityManager
+                .createNativeQuery(
+                    """
+                    with recursive comment_tree as (
+                        select pc.id, pc.created_at, 0 as depth
+                        from post_comment pc
+                        where pc.post_id = :postId
+                          and pc.id = :rootCommentId
+                          and pc.deleted_at is null
+                        union all
+                        select child.id, child.created_at, comment_tree.depth + 1
+                        from post_comment child
+                        join comment_tree on child.parent_comment_id = comment_tree.id
+                        where child.post_id = :postId
+                          and child.deleted_at is null
+                    )
+                    select id
+                    from comment_tree
+                    order by depth desc, created_at asc, id asc
+                    """.trimIndent(),
+                ).setParameter("postId", postId)
+                .setParameter("rootCommentId", rootCommentId)
+                .resultList
+                .map { (it as Number).toLong() }
+
+        return findActiveCommentsByIdsInOrder(ids)
+    }
+
+    override fun findActiveAccountDeletionTargetsByAuthorId(authorId: Long): List<PostCommentAccountDeletionTarget> {
+        val rows =
+            entityManager
+                .createNativeQuery(
+                    """
+                    select pc.id, pc.post_id, case when p.deleted_at is null then false else true end
+                    from post_comment pc
+                    join post p on p.id = pc.post_id
+                    where pc.author_id = :authorId
+                      and pc.deleted_at is null
+                    order by pc.post_id asc, pc.created_at asc, pc.id asc
+                    """.trimIndent(),
+                ).setParameter("authorId", authorId)
+                .resultList
+                .map { row ->
+                    val columns = row as Array<*>
+                    AccountDeletionTargetRow(
+                        commentId = (columns[0] as Number).toLong(),
+                        postId = (columns[1] as Number).toLong(),
+                        postDeleted = columns[2] as Boolean,
+                    )
+                }
+
+        val commentsById = findActiveCommentsByIdsInOrder(rows.map(AccountDeletionTargetRow::commentId)).associateBy(PostComment::id)
+
+        return rows.map { row ->
+            PostCommentAccountDeletionTargetResult(
+                comment = commentsById.getValue(row.commentId),
+                postId = row.postId,
+                postDeleted = row.postDeleted,
+            )
+        }
+    }
+
+    private fun findActiveCommentsByIdsInOrder(ids: List<Long>): List<PostComment> {
         if (ids.isEmpty()) return emptyList()
 
         val comments =
@@ -53,31 +125,25 @@ class PostCommentRepositoryImpl : PostCommentRepositoryCustom {
                     from PostComment c
                     join fetch c.author
                     left join fetch c.parentComment
-                    where c.post = :post
-                      and c.id in :ids
+                    where c.id in :ids
                     """.trimIndent(),
                     PostComment::class.java,
-                ).setParameter("post", post)
-                .setParameter("ids", ids)
+                ).setParameter("ids", ids)
                 .resultList
                 .associateBy(PostComment::id)
 
         return ids.mapNotNull(comments::get)
     }
 
-    override fun findActiveByAuthorIdOrderByPostIdCreatedAtIdAsc(authorId: Long): List<PostComment> =
-        entityManager
-            .createQuery(
-                """
-                select c
-                from PostComment c
-                join fetch c.author
-                join fetch c.post
-                left join fetch c.parentComment
-                where c.author.id = :authorId
-                order by c.post.id asc, c.createdAt asc, c.id asc
-                """.trimIndent(),
-                PostComment::class.java,
-            ).setParameter("authorId", authorId)
-            .resultList
+    private data class AccountDeletionTargetRow(
+        val commentId: Long,
+        val postId: Long,
+        val postDeleted: Boolean,
+    )
+
+    private data class PostCommentAccountDeletionTargetResult(
+        override val comment: PostComment,
+        override val postId: Long,
+        override val postDeleted: Boolean,
+    ) : PostCommentAccountDeletionTarget
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryImpl.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryImpl.kt
@@ -82,6 +82,31 @@ class PostCommentRepositoryImpl : PostCommentRepositoryCustom {
 
         if (affectedPostIds.isEmpty()) return 0
 
+        val commentIdsToDelete =
+            entityManager
+                .createNativeQuery(
+                    """
+                    with recursive comment_tree as (
+                        select pc.id, pc.created_at, 0 as depth
+                        from post_comment pc
+                        where pc.author_id = :authorId
+                          and pc.deleted_at is null
+                        union all
+                        select child.id, child.created_at, comment_tree.depth + 1
+                        from post_comment child
+                        join comment_tree on child.parent_comment_id = comment_tree.id
+                        where child.deleted_at is null
+                    )
+                    select distinct id
+                    from comment_tree
+                    order by id asc
+                    """.trimIndent(),
+                ).setParameter("authorId", authorId)
+                .resultList
+                .map { (it as Number).toLong() }
+
+        if (commentIdsToDelete.isEmpty()) return 0
+
         val deletedRows =
             entityManager
                 .createNativeQuery(
@@ -89,10 +114,10 @@ class PostCommentRepositoryImpl : PostCommentRepositoryCustom {
                     update post_comment
                     set deleted_at = now(),
                         modified_at = now()
-                    where author_id = :authorId
+                    where id in (:commentIds)
                       and deleted_at is null
                     """.trimIndent(),
-                ).setParameter("authorId", authorId)
+                ).setParameter("commentIds", commentIdsToDelete)
                 .executeUpdate()
 
         entityManager

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryImpl.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryImpl.kt
@@ -2,7 +2,6 @@ package com.back.boundedContexts.post.adapter.persistence
 
 import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostComment
-import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
 
@@ -66,80 +65,19 @@ class PostCommentRepositoryImpl : PostCommentRepositoryCustom {
         return ids.mapNotNull(comments::get)
     }
 
-    override fun softDeleteByAuthorId(authorId: Long): Int {
-        val affectedPostIds =
-            entityManager
-                .createNativeQuery(
-                    """
-                    select distinct post_id
-                    from post_comment
-                    where author_id = :authorId
-                      and deleted_at is null
-                    """.trimIndent(),
-                ).setParameter("authorId", authorId)
-                .resultList
-                .map { (it as Number).toLong() }
-
-        if (affectedPostIds.isEmpty()) return 0
-
-        val commentIdsToDelete =
-            entityManager
-                .createNativeQuery(
-                    """
-                    with recursive comment_tree as (
-                        select pc.id, pc.created_at, 0 as depth
-                        from post_comment pc
-                        where pc.author_id = :authorId
-                          and pc.deleted_at is null
-                        union all
-                        select child.id, child.created_at, comment_tree.depth + 1
-                        from post_comment child
-                        join comment_tree on child.parent_comment_id = comment_tree.id
-                        where child.deleted_at is null
-                    )
-                    select distinct id
-                    from comment_tree
-                    order by id asc
-                    """.trimIndent(),
-                ).setParameter("authorId", authorId)
-                .resultList
-                .map { (it as Number).toLong() }
-
-        if (commentIdsToDelete.isEmpty()) return 0
-
-        val deletedRows =
-            entityManager
-                .createNativeQuery(
-                    """
-                    update post_comment
-                    set deleted_at = now(),
-                        modified_at = now()
-                    where id in (:commentIds)
-                      and deleted_at is null
-                    """.trimIndent(),
-                ).setParameter("commentIds", commentIdsToDelete)
-                .executeUpdate()
-
+    override fun findActiveByAuthorIdOrderByPostIdCreatedAtIdAsc(authorId: Long): List<PostComment> =
         entityManager
-            .createNativeQuery(
+            .createQuery(
                 """
-                update post_attr pa
-                set int_value = counts.active_count,
-                    modified_at = now()
-                from (
-                    select p.id as post_id, count(pc.id)::int as active_count
-                    from post p
-                    left join post_comment pc on pc.post_id = p.id and pc.deleted_at is null
-                    where p.id in (:postIds)
-                    group by p.id
-                ) counts
-                where pa.subject_id = counts.post_id
-                  and pa.name = :commentsCountName
+                select c
+                from PostComment c
+                join fetch c.author
+                join fetch c.post
+                left join fetch c.parentComment
+                where c.author.id = :authorId
+                order by c.post.id asc, c.createdAt asc, c.id asc
                 """.trimIndent(),
-            ).setParameter("postIds", affectedPostIds)
-            .setParameter("commentsCountName", COMMENTS_COUNT)
-            .executeUpdate()
-
-        return deletedRows
-    }
+                PostComment::class.java,
+            ).setParameter("authorId", authorId)
+            .resultList
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryImpl.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostCommentRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.back.boundedContexts.post.adapter.persistence
 
 import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostComment
+import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
 
@@ -63,5 +64,57 @@ class PostCommentRepositoryImpl : PostCommentRepositoryCustom {
                 .associateBy(PostComment::id)
 
         return ids.mapNotNull(comments::get)
+    }
+
+    override fun softDeleteByAuthorId(authorId: Long): Int {
+        val affectedPostIds =
+            entityManager
+                .createNativeQuery(
+                    """
+                    select distinct post_id
+                    from post_comment
+                    where author_id = :authorId
+                      and deleted_at is null
+                    """.trimIndent(),
+                ).setParameter("authorId", authorId)
+                .resultList
+                .map { (it as Number).toLong() }
+
+        if (affectedPostIds.isEmpty()) return 0
+
+        val deletedRows =
+            entityManager
+                .createNativeQuery(
+                    """
+                    update post_comment
+                    set deleted_at = now(),
+                        modified_at = now()
+                    where author_id = :authorId
+                      and deleted_at is null
+                    """.trimIndent(),
+                ).setParameter("authorId", authorId)
+                .executeUpdate()
+
+        entityManager
+            .createNativeQuery(
+                """
+                update post_attr pa
+                set int_value = counts.active_count,
+                    modified_at = now()
+                from (
+                    select p.id as post_id, count(pc.id)::int as active_count
+                    from post p
+                    left join post_comment pc on pc.post_id = p.id and pc.deleted_at is null
+                    where p.id in (:postIds)
+                    group by p.id
+                ) counts
+                where pa.subject_id = counts.post_id
+                  and pa.name = :commentsCountName
+                """.trimIndent(),
+            ).setParameter("postIds", affectedPostIds)
+            .setParameter("commentsCountName", COMMENTS_COUNT)
+            .executeUpdate()
+
+        return deletedRows
     }
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostDeletedQueryRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostDeletedQueryRepository.kt
@@ -168,6 +168,11 @@ class PostDeletedQueryRepository(
                     modified_at = now()
                 where id = ?
                   and deleted_at is not null
+                  and not exists (
+                      select 1
+                      from member_account_deletion mad
+                      where mad.member_id = post.author_id
+                  )
                 """.trimIndent(),
                 id,
             )

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostDeletedQueryRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostDeletedQueryRepository.kt
@@ -159,6 +159,20 @@ class PostDeletedQueryRepository(
         return updatedRows > 0
     }
 
+    fun softDeleteByAuthorId(authorId: Long): Int =
+        jdbcTemplate.update(
+            """
+            update post
+            set published = false,
+                listed = false,
+                deleted_at = now(),
+                modified_at = now()
+            where author_id = ?
+              and deleted_at is null
+            """.trimIndent(),
+            authorId,
+        )
+
     fun restoreDeletedById(id: Long): Boolean {
         val updatedRows =
             jdbcTemplate.update(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostDeletedQueryRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostDeletedQueryRepository.kt
@@ -159,17 +159,16 @@ class PostDeletedQueryRepository(
         return updatedRows > 0
     }
 
-    fun softDeleteByAuthorId(authorId: Long): Int =
-        jdbcTemplate.update(
+    fun findActiveIdsByAuthorId(authorId: Long): List<Long> =
+        jdbcTemplate.queryForList(
             """
-            update post
-            set published = false,
-                listed = false,
-                deleted_at = now(),
-                modified_at = now()
+            select id
+            from post
             where author_id = ?
               and deleted_at is null
+            order by id asc
             """.trimIndent(),
+            Long::class.java,
             authorId,
         )
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostDeletedQueryRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostDeletedQueryRepository.kt
@@ -159,19 +159,6 @@ class PostDeletedQueryRepository(
         return updatedRows > 0
     }
 
-    fun findActiveIdsByAuthorId(authorId: Long): List<Long> =
-        jdbcTemplate.queryForList(
-            """
-            select id
-            from post
-            where author_id = ?
-              and deleted_at is null
-            order by id asc
-            """.trimIndent(),
-            Long::class.java,
-            authorId,
-        )
-
     fun restoreDeletedById(id: Long): Boolean {
         val updatedRows =
             jdbcTemplate.update(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepositoryAdapter.kt
@@ -32,10 +32,7 @@ class PostRepositoryAdapter(
 
     override fun findById(id: Long): Optional<Post> = postRepository.findById(id)
 
-    override fun findByAuthorIdOrderByIdAsc(authorId: Long): List<Post> =
-        postDeletedQueryRepository
-            .findActiveIdsByAuthorId(authorId)
-            .mapNotNull { postRepository.findById(it).orElse(null) }
+    override fun findByAuthorIdOrderByIdAsc(authorId: Long): List<Post> = postRepository.findActiveByAuthorIdOrderByIdAsc(authorId)
 
     override fun findFirstByOrderByIdDesc(): Post? = postRepository.findFirstByOrderByIdDesc()
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepositoryAdapter.kt
@@ -66,6 +66,8 @@ class PostRepositoryAdapter(
 
     override fun softDeleteById(id: Long): Boolean = postDeletedQueryRepository.softDeleteById(id)
 
+    override fun softDeleteByAuthorId(authorId: Long): Int = postDeletedQueryRepository.softDeleteByAuthorId(authorId)
+
     override fun restoreDeletedById(id: Long): Boolean = postDeletedQueryRepository.restoreDeletedById(id)
 
     override fun hardDeleteDeletedById(id: Long): Boolean = postDeletedQueryRepository.hardDeleteDeletedById(id)

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepositoryAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepositoryAdapter.kt
@@ -32,6 +32,11 @@ class PostRepositoryAdapter(
 
     override fun findById(id: Long): Optional<Post> = postRepository.findById(id)
 
+    override fun findByAuthorIdOrderByIdAsc(authorId: Long): List<Post> =
+        postDeletedQueryRepository
+            .findActiveIdsByAuthorId(authorId)
+            .mapNotNull { postRepository.findById(it).orElse(null) }
+
     override fun findFirstByOrderByIdDesc(): Post? = postRepository.findFirstByOrderByIdDesc()
 
     override fun findFirstByAuthorAndTitleAndPublishedFalseOrderByIdAsc(
@@ -65,8 +70,6 @@ class PostRepositoryAdapter(
     override fun findDeletedSnapshotById(id: Long): AdmDeletedPostSnapshotDto? = postDeletedQueryRepository.findDeletedSnapshotById(id)
 
     override fun softDeleteById(id: Long): Boolean = postDeletedQueryRepository.softDeleteById(id)
-
-    override fun softDeleteByAuthorId(authorId: Long): Int = postDeletedQueryRepository.softDeleteByAuthorId(authorId)
 
     override fun restoreDeletedById(id: Long): Boolean = postDeletedQueryRepository.restoreDeletedById(id)
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepositoryCustom.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepositoryCustom.kt
@@ -58,4 +58,6 @@ interface PostRepositoryCustom {
     fun findAllPublicListedContents(): List<String>
 
     fun findAllPublicListedTagIndexes(tagIndexAttrName: String): List<String>
+
+    fun findActiveByAuthorIdOrderByIdAsc(authorId: Long): List<Post>
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepositoryImpl.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/persistence/PostRepositoryImpl.kt
@@ -157,6 +157,16 @@ class PostRepositoryImpl(
             ).fetch()
             .filterNotNull()
 
+    override fun findActiveByAuthorIdOrderByIdAsc(authorId: Long): List<Post> =
+        queryFactory
+            .selectFrom(post)
+            .where(
+                post.author.id
+                    .eq(authorId)
+                    .and(post.deletedAt.isNull),
+            ).orderBy(post.id.asc())
+            .fetch()
+
     private fun findPosts(
         author: Member?,
         kw: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/input/PostUseCase.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/input/PostUseCase.kt
@@ -50,6 +50,8 @@ interface PostUseCase {
         actor: Member,
     )
 
+    fun deleteContentByAuthorForAccountDeletion(author: Member)
+
     fun writeComment(
         author: Member,
         post: Post,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostCommentRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostCommentRepositoryPort.kt
@@ -19,12 +19,12 @@ interface PostCommentRepositoryPort {
         rootCommentId: Long,
     ): List<PostComment>
 
+    fun findActiveByAuthorIdOrderByPostIdCreatedAtIdAsc(authorId: Long): List<PostComment>
+
     fun findByPostAndId(
         post: Post,
         id: Long,
     ): PostComment?
 
     fun findById(id: Long): Optional<PostComment>
-
-    fun softDeleteByAuthorId(authorId: Long): Int
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostCommentRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostCommentRepositoryPort.kt
@@ -4,6 +4,12 @@ import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.PostComment
 import java.util.Optional
 
+interface PostCommentAccountDeletionTarget {
+    val comment: PostComment
+    val postId: Long
+    val postDeleted: Boolean
+}
+
 interface PostCommentRepositoryPort {
     fun save(comment: PostComment): PostComment
 
@@ -19,7 +25,12 @@ interface PostCommentRepositoryPort {
         rootCommentId: Long,
     ): List<PostComment>
 
-    fun findActiveByAuthorIdOrderByPostIdCreatedAtIdAsc(authorId: Long): List<PostComment>
+    fun findActiveSubtreeByPostIdAndRootCommentId(
+        postId: Long,
+        rootCommentId: Long,
+    ): List<PostComment>
+
+    fun findActiveAccountDeletionTargetsByAuthorId(authorId: Long): List<PostCommentAccountDeletionTarget>
 
     fun findByPostAndId(
         post: Post,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostCommentRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostCommentRepositoryPort.kt
@@ -32,6 +32,11 @@ interface PostCommentRepositoryPort {
 
     fun findActiveAccountDeletionTargetsByAuthorId(authorId: Long): List<PostCommentAccountDeletionTarget>
 
+    fun decrementPostCommentsCountByPostId(
+        postId: Long,
+        count: Int,
+    ): Int
+
     fun findByPostAndId(
         post: Post,
         id: Long,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostCommentRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostCommentRepositoryPort.kt
@@ -25,4 +25,6 @@ interface PostCommentRepositoryPort {
     ): PostComment?
 
     fun findById(id: Long): Optional<PostComment>
+
+    fun softDeleteByAuthorId(authorId: Long): Int
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostRepositoryPort.kt
@@ -92,6 +92,8 @@ interface PostRepositoryPort {
 
     fun softDeleteById(id: Long): Boolean
 
+    fun softDeleteByAuthorId(authorId: Long): Int
+
     fun restoreDeletedById(id: Long): Boolean
 
     fun hardDeleteDeletedById(id: Long): Boolean

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostRepositoryPort.kt
@@ -70,6 +70,8 @@ interface PostRepositoryPort {
 
     fun findById(id: Long): Optional<Post>
 
+    fun findByAuthorIdOrderByIdAsc(authorId: Long): List<Post>
+
     fun findFirstByOrderByIdDesc(): Post?
 
     fun findFirstByAuthorAndTitleAndPublishedFalseOrderByIdAsc(
@@ -91,8 +93,6 @@ interface PostRepositoryPort {
     fun findDeletedSnapshotById(id: Long): AdmDeletedPostSnapshotDto?
 
     fun softDeleteById(id: Long): Boolean
-
-    fun softDeleteByAuthorId(authorId: Long): Int
 
     fun restoreDeletedById(id: Long): Boolean
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -398,8 +398,52 @@ class PostApplicationService(
         val posts = postRepository.findByAuthorIdOrderByIdAsc(author.id)
 
         posts.forEach { post ->
-            delete(post, author)
+            deleteForAccountDeletion(post)
         }
+    }
+
+    private fun deleteForAccountDeletion(post: Post) {
+        val deletedPostContent = post.content
+        val wasPublic = isPubliclyListed(post)
+        val wasTempDraft = postTempDraftService.isTempDraft(post)
+
+        val softDeleted = postRepository.softDeleteById(post.id)
+        if (!softDeleted) {
+            throw AppException("404-1", "${post.id}번 글을 찾을 수 없습니다.")
+        }
+        if (wasTempDraft) {
+            postTempDraftService.updateTempDraftMarker(post.author, null)
+        }
+        runCatching {
+            postCounterService.decrementMemberPostsCount(Member(post.author.id))
+        }.onFailure { exception ->
+            logger.warn("Failed to decrement member posts counter for member id={}", post.author.id, exception)
+            runCatching {
+                postCounterService.reconcileMemberPostsCount(Member(post.author.id))
+            }.onFailure { reconcileException ->
+                logger.warn("Failed to reconcile member posts counter for member id={}", post.author.id, reconcileException)
+            }
+        }
+        uploadedFileRetentionService.scheduleDeletedPostAttachments(deletedPostContent)
+
+        publishPostWriteAfterCommitEvent(
+            PostWriteSideEffectCommand(
+                postId = post.id,
+                previousContent = null,
+                currentContent = null,
+                deletedContent = null,
+                beforeTags = emptyList(),
+                afterTags = emptyList(),
+                cacheInvalidationScope =
+                    if (wasPublic) {
+                        PostReadCacheInvalidationScope.PublicPostDeleted
+                    } else {
+                        PostReadCacheInvalidationScope.None
+                    },
+                evictReason = "account-deletion-soft-delete",
+                recommendationAction = PostRecommendationSideEffect.EVICT,
+            ),
+        )
     }
 
     @Transactional

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -449,6 +449,7 @@ class PostApplicationService(
                 uid = UUID.randomUUID(),
                 aggregateId = post.id,
                 beforeTags = beforeTags,
+                afterTags = emptyList(),
             ),
         )
     }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -393,6 +393,16 @@ class PostApplicationService(
     }
 
     @Transactional
+    fun deleteContentByAuthorForAccountDeletion(author: Member) {
+        postCommentApplicationService.deleteCommentsByAuthorForAccountDeletion(author)
+        val posts = postRepository.findByAuthorIdOrderByIdAsc(author.id)
+
+        posts.forEach { post ->
+            delete(post, author)
+        }
+    }
+
+    @Transactional
     fun writeComment(
         author: Member,
         post: Post,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostApplicationService.kt
@@ -13,6 +13,7 @@ import com.back.boundedContexts.post.dto.AdmDeletedPostDto
 import com.back.boundedContexts.post.dto.PostDto
 import com.back.boundedContexts.post.dto.PublicPostDetailContentCacheDto
 import com.back.boundedContexts.post.dto.TagCountDto
+import com.back.boundedContexts.post.event.PostAccountDeletionDeletedEvent
 import com.back.boundedContexts.post.event.PostDeletedEvent
 import com.back.boundedContexts.post.event.PostModifiedEvent
 import com.back.boundedContexts.post.event.PostWrittenEvent
@@ -406,6 +407,7 @@ class PostApplicationService(
         val deletedPostContent = post.content
         val wasPublic = isPubliclyListed(post)
         val wasTempDraft = postTempDraftService.isTempDraft(post)
+        val beforeTags = postTagIndexService.extractNormalizedTags(deletedPostContent)
 
         val softDeleted = postRepository.softDeleteById(post.id)
         if (!softDeleted) {
@@ -432,7 +434,7 @@ class PostApplicationService(
                 previousContent = null,
                 currentContent = null,
                 deletedContent = null,
-                beforeTags = emptyList(),
+                beforeTags = beforeTags,
                 afterTags = emptyList(),
                 cacheInvalidationScope =
                     if (wasPublic) {
@@ -442,6 +444,11 @@ class PostApplicationService(
                     },
                 evictReason = "account-deletion-soft-delete",
                 recommendationAction = PostRecommendationSideEffect.EVICT,
+            ),
+            PostAccountDeletionDeletedEvent(
+                uid = UUID.randomUUID(),
+                aggregateId = post.id,
+                beforeTags = beforeTags,
             ),
         )
     }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCommentApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCommentApplicationService.kt
@@ -196,6 +196,7 @@ class PostCommentApplicationService(
             )
         }
 
+        postCommentRepository.decrementPostCommentsCountByPostId(postId, commentsToDelete.size)
         postRepository.flush()
     }
 

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCommentApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCommentApplicationService.kt
@@ -121,6 +121,40 @@ class PostCommentApplicationService(
         postRepository.flush()
     }
 
+    @Transactional
+    fun deleteCommentsByAuthorForAccountDeletion(author: Member): Int {
+        val rootComments =
+            findAccountDeletionRootComments(
+                postCommentRepository.findActiveByAuthorIdOrderByPostIdCreatedAtIdAsc(author.id),
+            )
+
+        rootComments.forEach { comment ->
+            deleteComment(comment.post, comment, author)
+        }
+
+        return rootComments.size
+    }
+
+    private fun findAccountDeletionRootComments(comments: List<PostComment>): List<PostComment> {
+        val authoredCommentIds = comments.mapTo(mutableSetOf(), PostComment::id)
+
+        return comments.filterNot { comment ->
+            hasAuthoredAncestor(comment, authoredCommentIds)
+        }
+    }
+
+    private fun hasAuthoredAncestor(
+        comment: PostComment,
+        authoredCommentIds: Set<Long>,
+    ): Boolean {
+        var parentComment = comment.parentComment
+        while (parentComment != null) {
+            if (parentComment.id in authoredCommentIds) return true
+            parentComment = parentComment.parentComment
+        }
+        return false
+    }
+
     fun getComments(
         post: Post,
         limit: Int,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCommentApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCommentApplicationService.kt
@@ -88,6 +88,7 @@ class PostCommentApplicationService(
         post: Post,
         postComment: PostComment,
         actor: Member,
+        publishDomainEvent: Boolean = true,
     ) {
         postHydrationService.hydratePostAttrs(post)
         val commentsToDelete =
@@ -97,9 +98,9 @@ class PostCommentApplicationService(
 
         commentsToDelete.forEach { postHydrationService.hydrateMemberCounterAttrs(it.author) }
 
-        val postDto = PostDto(post)
+        val postDto = if (publishDomainEvent) PostDto(post) else null
         commentsToDelete.forEachIndexed { index, comment ->
-            val postCommentDto = PostCommentDto(comment)
+            val postCommentDto = if (publishDomainEvent) PostCommentDto(comment) else null
             comment.author.decrementPostCommentsCount()
             postCounterService.saveMemberAttr(comment.author.postCommentsCountAttr)
             post.onCommentDeleted()
@@ -113,7 +114,17 @@ class PostCommentApplicationService(
                     } else {
                         PostInteractionRecommendationSideEffect.NONE
                     },
-                domainEvent = PostCommentDeletedEvent(UUID.randomUUID(), postCommentDto, postDto, MemberDto(actor)),
+                domainEvent =
+                    if (publishDomainEvent) {
+                        PostCommentDeletedEvent(
+                            UUID.randomUUID(),
+                            requireNotNull(postCommentDto),
+                            requireNotNull(postDto),
+                            MemberDto(actor),
+                        )
+                    } else {
+                        null
+                    },
             )
         }
 
@@ -129,7 +140,7 @@ class PostCommentApplicationService(
             )
 
         rootComments.forEach { comment ->
-            deleteComment(comment.post, comment, author)
+            deleteComment(comment.post, comment, author, publishDomainEvent = false)
         }
 
         return rootComments.size

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCommentApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostCommentApplicationService.kt
@@ -2,6 +2,7 @@ package com.back.boundedContexts.post.application.service
 
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.dto.MemberDto
+import com.back.boundedContexts.post.application.port.output.PostCommentAccountDeletionTarget
 import com.back.boundedContexts.post.application.port.output.PostCommentRepositoryPort
 import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
 import com.back.boundedContexts.post.domain.Post
@@ -94,13 +95,10 @@ class PostCommentApplicationService(
         val commentsToDelete =
             postCommentRepository
                 .findActiveSubtreeByPostAndRootCommentId(post, postComment.id)
-                .ifEmpty { listOf(postComment) }
 
         commentsToDelete.forEach { postHydrationService.hydrateMemberCounterAttrs(it.author) }
 
-        val postDto = if (publishDomainEvent) PostDto(post) else null
         commentsToDelete.forEachIndexed { index, comment ->
-            val postCommentDto = if (publishDomainEvent) PostCommentDto(comment) else null
             comment.author.decrementPostCommentsCount()
             postCounterService.saveMemberAttr(comment.author.postCommentsCountAttr)
             post.onCommentDeleted()
@@ -118,8 +116,8 @@ class PostCommentApplicationService(
                     if (publishDomainEvent) {
                         PostCommentDeletedEvent(
                             UUID.randomUUID(),
-                            requireNotNull(postCommentDto),
-                            requireNotNull(postDto),
+                            PostCommentDto(comment),
+                            PostDto(post),
                             MemberDto(actor),
                         )
                     } else {
@@ -134,23 +132,29 @@ class PostCommentApplicationService(
 
     @Transactional
     fun deleteCommentsByAuthorForAccountDeletion(author: Member): Int {
-        val rootComments =
-            findAccountDeletionRootComments(
-                postCommentRepository.findActiveByAuthorIdOrderByPostIdCreatedAtIdAsc(author.id),
+        val rootTargets =
+            findAccountDeletionRootCommentTargets(
+                postCommentRepository.findActiveAccountDeletionTargetsByAuthorId(author.id),
             )
 
-        rootComments.forEach { comment ->
-            deleteComment(comment.post, comment, author, publishDomainEvent = false)
+        rootTargets.forEach { target ->
+            if (target.postDeleted) {
+                deleteDeletedPostCommentSubtreeForAccountDeletion(target.postId, target.comment)
+            } else {
+                deleteComment(target.comment.post, target.comment, author, publishDomainEvent = false)
+            }
         }
 
-        return rootComments.size
+        return rootTargets.size
     }
 
-    private fun findAccountDeletionRootComments(comments: List<PostComment>): List<PostComment> {
-        val authoredCommentIds = comments.mapTo(mutableSetOf(), PostComment::id)
+    private fun findAccountDeletionRootCommentTargets(
+        targets: List<PostCommentAccountDeletionTarget>,
+    ): List<PostCommentAccountDeletionTarget> {
+        val authoredCommentIds = targets.mapTo(mutableSetOf()) { it.comment.id }
 
-        return comments.filterNot { comment ->
-            hasAuthoredAncestor(comment, authoredCommentIds)
+        return targets.filterNot { target ->
+            hasAuthoredAncestor(target.comment, authoredCommentIds)
         }
     }
 
@@ -164,6 +168,35 @@ class PostCommentApplicationService(
             parentComment = parentComment.parentComment
         }
         return false
+    }
+
+    private fun deleteDeletedPostCommentSubtreeForAccountDeletion(
+        postId: Long,
+        postComment: PostComment,
+    ) {
+        val commentsToDelete =
+            postCommentRepository
+                .findActiveSubtreeByPostIdAndRootCommentId(postId, postComment.id)
+
+        commentsToDelete.forEach { postHydrationService.hydrateMemberCounterAttrs(it.author) }
+
+        commentsToDelete.forEachIndexed { index, comment ->
+            comment.author.decrementPostCommentsCount()
+            postCounterService.saveMemberAttr(comment.author.postCommentsCountAttr)
+            comment.softDelete()
+            postInteractionSideEffectQueue.enqueue(
+                postId = postId,
+                recommendationAction =
+                    if (index == commentsToDelete.lastIndex) {
+                        PostInteractionRecommendationSideEffect.REFRESH
+                    } else {
+                        PostInteractionRecommendationSideEffect.NONE
+                    },
+                domainEvent = null,
+            )
+        }
+
+        postRepository.flush()
     }
 
     fun getComments(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostUseCaseAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostUseCaseAdapter.kt
@@ -57,6 +57,9 @@ class PostUseCaseAdapter(
         actor: Member,
     ) = postApplicationService.delete(post, actor)
 
+    override fun deleteContentByAuthorForAccountDeletion(author: Member) =
+        postApplicationService.deleteContentByAuthorForAccountDeletion(author)
+
     override fun writeComment(
         author: Member,
         post: Post,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandler.kt
@@ -6,6 +6,7 @@ import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
 import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
 import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
+import com.back.boundedContexts.post.event.PostAccountDeletionDeletedEvent
 import com.back.boundedContexts.post.event.PostDeletedEvent
 import com.back.boundedContexts.post.event.PostModifiedEvent
 import com.back.boundedContexts.post.event.PostWrittenEvent
@@ -174,6 +175,8 @@ class PostWriteSideEffectHandler(
         val eventType = domainEventType ?: return null
         val eventJson = domainEventJson ?: return null
         return when (eventType) {
+            PostAccountDeletionDeletedEvent::class.java.name ->
+                objectMapper.readValue(eventJson, PostAccountDeletionDeletedEvent::class.java)
             PostWrittenEvent::class.java.name -> objectMapper.readValue(eventJson, PostWrittenEvent::class.java)
             PostModifiedEvent::class.java.name -> objectMapper.readValue(eventJson, PostModifiedEvent::class.java)
             PostDeletedEvent::class.java.name -> objectMapper.readValue(eventJson, PostDeletedEvent::class.java)

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostAccountDeletionDeletedEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostAccountDeletionDeletedEvent.kt
@@ -1,0 +1,12 @@
+package com.back.boundedContexts.post.event
+
+import com.back.standard.dto.EventPayload
+import java.util.UUID
+
+data class PostAccountDeletionDeletedEvent(
+    override val uid: UUID,
+    override val aggregateType: String = "Post",
+    override val aggregateId: Long,
+    val beforeTags: List<String> = emptyList(),
+    val afterTags: List<String> = emptyList(),
+) : EventPayload

--- a/back/src/main/kotlin/com/back/boundedContexts/post/event/PostAccountDeletionDeletedEvent.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/event/PostAccountDeletionDeletedEvent.kt
@@ -7,6 +7,6 @@ data class PostAccountDeletionDeletedEvent(
     override val uid: UUID,
     override val aggregateType: String = "Post",
     override val aggregateId: Long,
-    val beforeTags: List<String> = emptyList(),
-    val afterTags: List<String> = emptyList(),
+    val beforeTags: List<String>,
+    val afterTags: List<String>,
 ) : EventPayload

--- a/back/src/main/kotlin/com/back/global/security/config/AccessTokenAuthenticationHandler.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/AccessTokenAuthenticationHandler.kt
@@ -45,6 +45,11 @@ class AccessTokenAuthenticationHandler(
                 request = request,
             )
         memberSessionAuthenticationResolver.ensureUsable(sessionResolution, requireSession = true)
+        val persistedMember = actorApplicationService.findById(payload.id)
+        memberSessionAuthenticationResolver.ensureFreshTokenFallbackMemberFound(
+            sessionResolution = sessionResolution,
+            persistedMemberFound = persistedMember != null,
+        )
         val sessionContext =
             memberSessionAuthenticationResolver.context(
                 sessionResolution = sessionResolution,
@@ -69,7 +74,7 @@ class AccessTokenAuthenticationHandler(
         if (legacyPayloadRecoveryHandler.recoverIfNeeded(payload, sessionContext)) return true
 
         sessionContext.session?.let { memberSessionUseCase.touchAuthenticated(it) }
-        val payloadMember = actorApplicationService.findById(payload.id) ?: payload.toTransientMember()
+        val payloadMember = persistedMember ?: payload.toTransientMember()
         securityContextAuthenticationWriter.write(payloadMember)
         return true
     }

--- a/back/src/main/kotlin/com/back/global/security/config/MemberSessionAuthenticationResolver.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/MemberSessionAuthenticationResolver.kt
@@ -74,6 +74,16 @@ class MemberSessionAuthenticationResolver(
         }
     }
 
+    fun ensureFreshTokenFallbackMemberFound(
+        sessionResolution: MemberSessionResolution,
+        persistedMemberFound: Boolean,
+    ) {
+        if (!sessionResolution.freshTokenFallback || persistedMemberFound) return
+
+        authCookieService.expireAuthCookies()
+        throw AppException("401-8", "세션이 만료되었습니다. 다시 로그인해주세요.")
+    }
+
     fun context(
         sessionResolution: MemberSessionResolution,
         fallbackRememberLoginEnabled: Boolean,

--- a/back/src/main/kotlin/com/back/global/security/config/MemberSessionAuthenticationResolver.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/MemberSessionAuthenticationResolver.kt
@@ -10,6 +10,9 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.time.Instant
 
+private const val MEMBER_SESSION_AUTH_MAX_PATH_LENGTH = 512
+private val MEMBER_SESSION_AUTH_LOG_CONTROL_CHAR_REGEX = Regex("[\\x00-\\x1F\\x7F]")
+
 @Component
 class MemberSessionAuthenticationResolver(
     private val memberSessionUseCase: MemberSessionUseCase,
@@ -48,7 +51,7 @@ class MemberSessionAuthenticationResolver(
 
         log.info(
             "auth_session_fresh_token_fallback path={} memberId={} graceSeconds={}",
-            sanitizeLogValue(request.requestURI, MAX_PATH_LENGTH),
+            sanitizeLogValue(request.requestURI, MEMBER_SESSION_AUTH_MAX_PATH_LENGTH),
             memberId,
             freshLookupGraceSeconds,
         )
@@ -113,16 +116,11 @@ class MemberSessionAuthenticationResolver(
                 .replace('\r', ' ')
                 .replace('\n', ' ')
                 .replace('\t', ' ')
-                .replace(LOG_CONTROL_CHAR_REGEX, "?")
+                .replace(MEMBER_SESSION_AUTH_LOG_CONTROL_CHAR_REGEX, "?")
                 .trim()
 
         if (sanitized.isBlank()) return "-"
         return sanitized.take(maxLength)
-    }
-
-    private companion object {
-        const val MAX_PATH_LENGTH = 512
-        val LOG_CONTROL_CHAR_REGEX = Regex("[\\x00-\\x1F\\x7F]")
     }
 }
 

--- a/back/src/main/resources/db/migration-test/V20260622_04__create_member_privacy_request.sql
+++ b/back/src/main/resources/db/migration-test/V20260622_04__create_member_privacy_request.sql
@@ -1,0 +1,22 @@
+CREATE SEQUENCE IF NOT EXISTS member_privacy_request_seq START WITH 1 INCREMENT BY 20;
+
+CREATE TABLE IF NOT EXISTS member_privacy_request (
+    id BIGINT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL,
+    modified_at TIMESTAMPTZ NOT NULL,
+    member_id BIGINT NOT NULL,
+    type VARCHAR(48) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    message VARCHAR(1000),
+    requested_at TIMESTAMPTZ NOT NULL,
+    due_at TIMESTAMPTZ NOT NULL,
+    completed_at TIMESTAMPTZ,
+    CONSTRAINT fk_member_privacy_request_member
+        FOREIGN KEY (member_id) REFERENCES member(id)
+);
+
+CREATE INDEX IF NOT EXISTS member_privacy_request_idx_member_requested_at
+    ON member_privacy_request (member_id, requested_at DESC);
+
+CREATE INDEX IF NOT EXISTS member_privacy_request_idx_status_due_at
+    ON member_privacy_request (status, due_at);

--- a/back/src/main/resources/db/migration-test/V20260622_04__create_member_privacy_request.sql
+++ b/back/src/main/resources/db/migration-test/V20260622_04__create_member_privacy_request.sql
@@ -11,6 +11,10 @@ CREATE TABLE IF NOT EXISTS member_privacy_request (
     requested_at TIMESTAMPTZ NOT NULL,
     due_at TIMESTAMPTZ NOT NULL,
     completed_at TIMESTAMPTZ,
+    CONSTRAINT chk_member_privacy_request_due_at
+        CHECK (due_at >= requested_at),
+    CONSTRAINT chk_member_privacy_request_completed_at
+        CHECK (completed_at IS NULL OR completed_at >= requested_at),
     CONSTRAINT fk_member_privacy_request_member
         FOREIGN KEY (member_id) REFERENCES member(id)
 );

--- a/back/src/main/resources/db/migration-test/V20260622_05__create_member_account_deletion.sql
+++ b/back/src/main/resources/db/migration-test/V20260622_05__create_member_account_deletion.sql
@@ -1,0 +1,16 @@
+CREATE SEQUENCE IF NOT EXISTS member_account_deletion_seq START WITH 1 INCREMENT BY 20;
+
+CREATE TABLE IF NOT EXISTS member_account_deletion (
+    id BIGINT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL,
+    modified_at TIMESTAMPTZ NOT NULL,
+    member_id BIGINT NOT NULL,
+    reason VARCHAR(500),
+    deleted_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT uk_member_account_deletion_member UNIQUE (member_id),
+    CONSTRAINT fk_member_account_deletion_member
+        FOREIGN KEY (member_id) REFERENCES member(id)
+);
+
+CREATE INDEX IF NOT EXISTS member_account_deletion_idx_deleted_at
+    ON member_account_deletion (deleted_at DESC);

--- a/back/src/main/resources/db/migration/V20260622_04__create_member_privacy_request.sql
+++ b/back/src/main/resources/db/migration/V20260622_04__create_member_privacy_request.sql
@@ -1,0 +1,22 @@
+CREATE SEQUENCE IF NOT EXISTS member_privacy_request_seq START WITH 1 INCREMENT BY 20;
+
+CREATE TABLE IF NOT EXISTS member_privacy_request (
+    id BIGINT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL,
+    modified_at TIMESTAMPTZ NOT NULL,
+    member_id BIGINT NOT NULL,
+    type VARCHAR(48) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    message VARCHAR(1000),
+    requested_at TIMESTAMPTZ NOT NULL,
+    due_at TIMESTAMPTZ NOT NULL,
+    completed_at TIMESTAMPTZ,
+    CONSTRAINT fk_member_privacy_request_member
+        FOREIGN KEY (member_id) REFERENCES member(id)
+);
+
+CREATE INDEX IF NOT EXISTS member_privacy_request_idx_member_requested_at
+    ON member_privacy_request (member_id, requested_at DESC);
+
+CREATE INDEX IF NOT EXISTS member_privacy_request_idx_status_due_at
+    ON member_privacy_request (status, due_at);

--- a/back/src/main/resources/db/migration/V20260622_04__create_member_privacy_request.sql
+++ b/back/src/main/resources/db/migration/V20260622_04__create_member_privacy_request.sql
@@ -11,6 +11,10 @@ CREATE TABLE IF NOT EXISTS member_privacy_request (
     requested_at TIMESTAMPTZ NOT NULL,
     due_at TIMESTAMPTZ NOT NULL,
     completed_at TIMESTAMPTZ,
+    CONSTRAINT chk_member_privacy_request_due_at
+        CHECK (due_at >= requested_at),
+    CONSTRAINT chk_member_privacy_request_completed_at
+        CHECK (completed_at IS NULL OR completed_at >= requested_at),
     CONSTRAINT fk_member_privacy_request_member
         FOREIGN KEY (member_id) REFERENCES member(id)
 );

--- a/back/src/main/resources/db/migration/V20260622_05__create_member_account_deletion.sql
+++ b/back/src/main/resources/db/migration/V20260622_05__create_member_account_deletion.sql
@@ -1,0 +1,16 @@
+CREATE SEQUENCE IF NOT EXISTS member_account_deletion_seq START WITH 1 INCREMENT BY 20;
+
+CREATE TABLE IF NOT EXISTS member_account_deletion (
+    id BIGINT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL,
+    modified_at TIMESTAMPTZ NOT NULL,
+    member_id BIGINT NOT NULL,
+    reason VARCHAR(500),
+    deleted_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT uk_member_account_deletion_member UNIQUE (member_id),
+    CONSTRAINT fk_member_account_deletion_member
+        FOREIGN KEY (member_id) REFERENCES member(id)
+);
+
+CREATE INDEX IF NOT EXISTS member_account_deletion_idx_deleted_at
+    ON member_account_deletion (deleted_at DESC);

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1MemberControllerTest.kt
@@ -2,6 +2,7 @@ package com.back.boundedContexts.member.adapter.web
 
 import com.back.boundedContexts.member.application.service.MemberApplicationService
 import com.back.support.BaseControllerIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -95,6 +96,29 @@ class ApiV1MemberControllerTest : BaseControllerIntegrationTest() {
                         match(handler().methodName("join"))
                         jsonPath("$.resultCode") { value("400-1") }
                     }
+            }
+
+            @Test
+            fun `회원 가입 요청에서 비밀번호에 공백이 있으면 400을 반환한다`() {
+                mvc
+                    .post("/member/api/v1/members") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content =
+                            """
+                            {
+                                "username": "spacepassword",
+                                "password": "Abcd 1234!",
+                                "nickname": "공백비밀번호"
+                            }
+                            """.trimIndent()
+                    }.andExpect {
+                        status { isBadRequest() }
+                        match(handler().handlerType(ApiV1MemberController::class.java))
+                        match(handler().methodName("join"))
+                        jsonPath("$.resultCode") { value("400-1") }
+                    }
+
+                assertThat(memberFacade.findByLoginId("spacepassword")).isNull()
             }
         }
     }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -384,6 +384,40 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
     }
 
     @Test
+    fun `계정 탈퇴는 비밀번호 계정에서 비밀번호가 없으면 세션과 회원 상태를 유지한다`() {
+        val member =
+            memberFacade.join(
+                username = "account-delete-missing-password-user",
+                password = "Abcd1234!",
+                nickname = "탈퇴비밀번호누락",
+                profileImgUrl = null,
+                email = "account-delete-missing-password-user@example.com",
+            )
+        val authCookies = loginAuthCookies(member.email!!)
+        val sessionKey = requireAuthCookie(authCookies, AuthCookieNames.SESSION_KEY)
+
+        mvc
+            .delete("/member/api/v1/privacy/account") {
+                authCookies.forEach { cookie(it) }
+                header("X-Aquila-CSRF", "1")
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "reason": "서비스 이용 종료"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isBadRequest() }
+                jsonPath("$.resultCode") { value("400-1") }
+                jsonPath("$.msg") { value("비밀번호를 입력해주세요.") }
+            }
+
+        assertThat(memberFacade.findByEmail("account-delete-missing-password-user@example.com")).isNotNull()
+        assertThat(memberSessionRepository.findBySessionKey(sessionKey.value)?.revokedAt).isNull()
+    }
+
+    @Test
     fun `계정 탈퇴는 기존 탈퇴 tombstone 이 있으면 409를 반환한다`() {
         val member =
             memberFacade.join(

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -1,6 +1,10 @@
 package com.back.boundedContexts.member.adapter.web
 
 import com.back.boundedContexts.member.application.service.MemberApplicationService
+import com.back.boundedContexts.member.subContexts.legalAcceptance.adapter.persistence.MemberLegalAcceptanceRepository
+import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberLegalAcceptance
+import com.back.boundedContexts.member.subContexts.privacy.adapter.persistence.MemberAccountDeletionRepository
+import com.back.boundedContexts.member.subContexts.privacy.model.MemberAccountDeletion
 import com.back.boundedContexts.member.subContexts.session.adapter.persistence.MemberSessionRepository
 import com.back.global.security.config.AuthCookieNames
 import com.back.support.BaseControllerIntegrationTest
@@ -15,10 +19,17 @@ import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
+import java.time.Instant
 
 class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
     @Autowired
     private lateinit var memberFacade: MemberApplicationService
+
+    @Autowired
+    private lateinit var memberLegalAcceptanceRepository: MemberLegalAcceptanceRepository
+
+    @Autowired
+    private lateinit var memberAccountDeletionRepository: MemberAccountDeletionRepository
 
     @Autowired
     private lateinit var memberSessionRepository: MemberSessionRepository
@@ -36,6 +47,21 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
                 profileImgUrl = null,
                 email = "privacy-export-user@example.com",
             )
+        memberLegalAcceptanceRepository.save(
+            MemberLegalAcceptance(
+                member = member,
+                termsVersion = "2026-06-21",
+                termsContentSha256 = "terms-content-sha-256",
+                privacyVersion = "2026-06-21",
+                privacyContentSha256 = "privacy-content-sha-256",
+                age14OrOlder = true,
+                requiredPrivacyConfirmed = true,
+                analyticsConsent = false,
+                overseasTransferAcknowledged = true,
+                source = "EMAIL_SIGNUP",
+                acceptedAt = Instant.parse("2026-06-21T00:00:00Z"),
+            ),
+        )
         val authCookies = loginAuthCookies(member.email!!)
 
         mvc
@@ -50,6 +76,16 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
                 jsonPath("$.data.member.username") { value("privacy-export-user") }
                 jsonPath("$.data.member.nickname") { value("정보내보내기") }
                 jsonPath("$.data.member.createdAt") { value(startsWith(member.createdAt.toString().take(20))) }
+                jsonPath("$.data.latestLegalAcceptance.termsVersion") { value("2026-06-21") }
+                jsonPath("$.data.latestLegalAcceptance.termsContentSha256") { value("terms-content-sha-256") }
+                jsonPath("$.data.latestLegalAcceptance.privacyVersion") { value("2026-06-21") }
+                jsonPath("$.data.latestLegalAcceptance.privacyContentSha256") { value("privacy-content-sha-256") }
+                jsonPath("$.data.latestLegalAcceptance.age14OrOlder") { value(true) }
+                jsonPath("$.data.latestLegalAcceptance.requiredPrivacyConfirmed") { value(true) }
+                jsonPath("$.data.latestLegalAcceptance.analyticsConsent") { value(false) }
+                jsonPath("$.data.latestLegalAcceptance.overseasTransferAcknowledged") { value(true) }
+                jsonPath("$.data.latestLegalAcceptance.source") { value("EMAIL_SIGNUP") }
+                jsonPath("$.data.latestLegalAcceptance.acceptedAt") { value("2026-06-21T00:00:00Z") }
                 jsonPath("$.data.generatedAt") { value(startsWith("20")) }
             }
     }
@@ -105,6 +141,45 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
                 jsonPath("$.data.item.type") { value("EXPORT") }
                 jsonPath("$.data.item.status") { value("RECEIVED") }
             }
+
+        mvc
+            .post("/member/api/v1/privacy/requests") {
+                authCookies.forEach { cookie(it) }
+                header("X-Aquila-CSRF", "1")
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "type": "CORRECTION"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isCreated() }
+                jsonPath("$.data.item.type") { value("CORRECTION") }
+                jsonPath("$.data.item.message") { doesNotExist() }
+            }
+    }
+
+    @Test
+    fun `존재하지 않는 개인정보 처리 요청은 404를 반환한다`() {
+        val member =
+            memberFacade.join(
+                username = "privacy-request-missing-user",
+                password = "Abcd1234!",
+                nickname = "권리요청없음",
+                profileImgUrl = null,
+                email = "privacy-request-missing-user@example.com",
+            )
+        val authCookies = loginAuthCookies(member.email!!)
+
+        mvc
+            .get("/member/api/v1/privacy/requests/999999") {
+                authCookies.forEach { cookie(it) }
+            }.andExpect {
+                status { isNotFound() }
+                jsonPath("$.resultCode") { value("404-1") }
+                jsonPath("$.msg") { value("개인정보 처리 요청을 찾을 수 없습니다.") }
+            }
     }
 
     @Test
@@ -150,6 +225,13 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(findSessionRevokedAt(firstSessionKey.value)).isNotNull()
         assertThat(findSessionRevokedAt(secondSessionKey.value)).isNotNull()
         assertThat(countDeletionTombstones(member.id, "서비스 이용 종료")).isEqualTo(1)
+        val deletion =
+            memberAccountDeletionRepository
+                .findAll()
+                .single { it.member.id == member.id }
+        assertThat(deletion.member.id).isEqualTo(member.id)
+        assertThat(deletion.reason).isEqualTo("서비스 이용 종료")
+        assertThat(deletion.deletedAt).isNotNull()
     }
 
     @Test
@@ -185,6 +267,42 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
 
         assertThat(memberFacade.findByEmail("account-delete-wrong-password-user@example.com")).isNotNull()
         assertThat(memberSessionRepository.findBySessionKey(sessionKey.value)?.revokedAt).isNull()
+    }
+
+    @Test
+    fun `계정 탈퇴는 기존 탈퇴 tombstone 이 있으면 409를 반환한다`() {
+        val member =
+            memberFacade.join(
+                username = "account-delete-duplicate-user",
+                password = "Abcd1234!",
+                nickname = "중복탈퇴",
+                profileImgUrl = null,
+                email = "account-delete-duplicate-user@example.com",
+            )
+        memberAccountDeletionRepository.save(
+            MemberAccountDeletion(
+                member = member,
+                deletedAt = Instant.parse("2026-06-21T00:00:00Z"),
+            ),
+        )
+        val authCookies = loginAuthCookies(member.email!!)
+
+        mvc
+            .delete("/member/api/v1/privacy/account") {
+                authCookies.forEach { cookie(it) }
+                header("X-Aquila-CSRF", "1")
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "password": "Abcd1234!"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isConflict() }
+                jsonPath("$.resultCode") { value("409-1") }
+                jsonPath("$.msg") { value("이미 탈퇴 처리된 계정입니다.") }
+            }
     }
 
     private fun loginAuthCookies(email: String): List<Cookie> =

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -342,8 +342,8 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         val deletion =
             memberAccountDeletionRepository
                 .findAll()
-                .single { it.member.id == member.id }
-        assertThat(deletion.member.id).isEqualTo(member.id)
+                .single { it.memberId == member.id }
+        assertThat(deletion.memberId).isEqualTo(member.id)
         assertThat(deletion.reason).isEqualTo("서비스 이용 종료")
         assertThat(deletion.deletedAt).isNotNull()
     }
@@ -395,7 +395,7 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
             )
         memberAccountDeletionRepository.save(
             MemberAccountDeletion(
-                member = member,
+                memberId = member.id,
                 deletedAt = Instant.parse("2026-06-21T00:00:00Z"),
             ),
         )

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -183,6 +183,53 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
     }
 
     @Test
+    fun `개인정보 처리 요청은 다른 회원이 조회할 수 없다`() {
+        val owner =
+            memberFacade.join(
+                username = "privacy-request-owner",
+                password = "Abcd1234!",
+                nickname = "요청소유자",
+                profileImgUrl = null,
+                email = "privacy-request-owner@example.com",
+            )
+        val attacker =
+            memberFacade.join(
+                username = "privacy-request-attacker",
+                password = "Abcd1234!",
+                nickname = "다른사용자",
+                profileImgUrl = null,
+                email = "privacy-request-attacker@example.com",
+            )
+        val ownerCookies = loginAuthCookies(owner.email!!)
+        val attackerCookies = loginAuthCookies(attacker.email!!)
+        val created =
+            mvc
+                .post("/member/api/v1/privacy/requests") {
+                    ownerCookies.forEach { cookie(it) }
+                    header("X-Aquila-CSRF", "1")
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                            "type": "EXPORT"
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isCreated() }
+                }.andReturn()
+        val requestId = JsonPath.read<Int>(created.response.contentAsString, "$.data.item.id").toLong()
+
+        mvc
+            .get("/member/api/v1/privacy/requests/$requestId") {
+                attackerCookies.forEach { cookie(it) }
+            }.andExpect {
+                status { isNotFound() }
+                jsonPath("$.resultCode") { value("404-1") }
+                jsonPath("$.msg") { value("개인정보 처리 요청을 찾을 수 없습니다.") }
+            }
+    }
+
+    @Test
     fun `계정 탈퇴는 비밀번호 재확인 후 회원을 삭제 상태로 전환하고 모든 세션을 폐기한다`() {
         val member =
             memberFacade.join(
@@ -194,6 +241,11 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
             )
         val firstAuthCookies = loginAuthCookies(member.email!!)
         val secondAuthCookies = loginAuthCookies(member.email!!)
+        member.applyLoginSecurityPolicy(
+            rememberLoginEnabled = true,
+            ipSecurityEnabled = true,
+            ipSecurityFingerprint = "fingerprint-before-delete",
+        )
         val firstSessionKey = requireAuthCookie(firstAuthCookies, AuthCookieNames.SESSION_KEY)
         val secondSessionKey = requireAuthCookie(secondAuthCookies, AuthCookieNames.SESSION_KEY)
 
@@ -222,6 +274,8 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(memberFacade.findByEmail("account-delete-user@example.com")).isNull()
         assertThat(findMemberDeletionState(member.id).email).isNull()
         assertThat(findMemberDeletionState(member.id).deletedAt).isNotNull()
+        assertThat(findMemberDeletionState(member.id).ipSecurityEnabled).isFalse()
+        assertThat(findMemberDeletionState(member.id).ipSecurityFingerprint).isNull()
         assertThat(findSessionRevokedAt(firstSessionKey.value)).isNotNull()
         assertThat(findSessionRevokedAt(secondSessionKey.value)).isNotNull()
         assertThat(countDeletionTombstones(member.id, "서비스 이용 종료")).isEqualTo(1)
@@ -350,7 +404,7 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
     private fun findMemberDeletionState(memberId: Long): MemberDeletionState =
         jdbcTemplate.queryForObject(
             """
-            select email, deleted_at
+            select email, deleted_at, ip_security_enabled, ip_security_fingerprint
             from member
             where id = ?
             """.trimIndent(),
@@ -358,6 +412,8 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
                 MemberDeletionState(
                     email = rs.getString("email"),
                     deletedAt = rs.getTimestamp("deleted_at")?.toInstant(),
+                    ipSecurityEnabled = rs.getBoolean("ip_security_enabled"),
+                    ipSecurityFingerprint = rs.getString("ip_security_fingerprint"),
                 )
             },
             memberId,
@@ -377,5 +433,7 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
     private data class MemberDeletionState(
         val email: String?,
         val deletedAt: java.time.Instant?,
+        val ipSecurityEnabled: Boolean,
+        val ipSecurityFingerprint: String?,
     )
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -111,6 +111,28 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
     }
 
     @Test
+    fun `개인정보 export 는 법적 동의 이력이 없어도 계정 스냅샷을 반환한다`() {
+        val member =
+            memberFacade.join(
+                username = "privacy-export-no-legal-user",
+                password = "Abcd1234!",
+                nickname = "동의이력없음",
+                profileImgUrl = null,
+                email = "privacy-export-no-legal-user@example.com",
+            )
+        val authCookies = loginAuthCookies(member.email!!)
+
+        mvc
+            .get("/member/api/v1/privacy/export") {
+                authCookies.forEach { cookie(it) }
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.data.member.id") { value(member.id) }
+                jsonPath("$.data.latestLegalAcceptance") { doesNotExist() }
+            }
+    }
+
+    @Test
     fun `개인정보 처리 요청은 생성 후 본인 상태 조회가 가능하다`() {
         val member =
             memberFacade.join(
@@ -170,7 +192,8 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
                 content =
                     """
                     {
-                        "type": "CORRECTION"
+                        "type": "CORRECTION",
+                        "message": "   "
                     }
                     """.trimIndent()
             }.andExpect {
@@ -315,11 +338,24 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         val replyToAuthoredComment = postFacade.writeComment(otherAuthor, otherPost, "탈퇴 댓글의 답글", authoredComment)
         val nestedReplyToAuthoredComment =
             postFacade.writeComment(member, otherPost, "탈퇴 댓글의 중첩 답글", replyToAuthoredComment)
+        val deletedOtherPost =
+            postFacade.write(
+                author = otherAuthor,
+                title = "탈퇴 댓글 대상 삭제글",
+                content = "이미 삭제된 글의 댓글도 정리되어야 한다",
+                published = true,
+                listed = true,
+            )
+        val authoredCommentOnDeletedPost =
+            postFacade.writeComment(member, deletedOtherPost, "삭제된 글에 남은 탈퇴 회원 댓글")
+        val replyToDeletedPostAuthoredComment =
+            postFacade.writeComment(otherAuthor, deletedOtherPost, "삭제된 글 탈퇴 댓글의 답글", authoredCommentOnDeletedPost)
+        deletedOtherPost.softDelete()
         val firstSessionKey = requireAuthCookie(firstAuthCookies, AuthCookieNames.SESSION_KEY)
         val secondSessionKey = requireAuthCookie(secondAuthCookies, AuthCookieNames.SESSION_KEY)
         assertThat(countMemberAttrsContaining(member.id, "민감")).isGreaterThan(0)
         assertThat(findPostCommentsCount(otherPost.id)).isEqualTo(3)
-        assertThat(findMemberPostCommentsCount(otherAuthor.id)).isEqualTo(1)
+        assertThat(findMemberPostCommentsCount(otherAuthor.id)).isEqualTo(2)
         assertThat(findUploadedFileState(legacyProfileImageKey).status).isEqualTo("ACTIVE")
         assertThat(findUploadedFileState(draftProfileImageKey).status).isEqualTo("ACTIVE")
         assertThat(findUploadedFileState(publishedProfileImageKey).status).isEqualTo("ACTIVE")
@@ -366,6 +402,8 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(findCommentDeletedAt(authoredComment.id)).isNotNull()
         assertThat(findCommentDeletedAt(replyToAuthoredComment.id)).isNotNull()
         assertThat(findCommentDeletedAt(nestedReplyToAuthoredComment.id)).isNotNull()
+        assertThat(findCommentDeletedAt(authoredCommentOnDeletedPost.id)).isNotNull()
+        assertThat(findCommentDeletedAt(replyToDeletedPostAuthoredComment.id)).isNotNull()
         assertThat(findPostCommentsCount(otherPost.id)).isZero()
         assertThat(findMemberPostCommentsCount(otherAuthor.id)).isZero()
         listOf(legacyProfileImageKey, draftProfileImageKey, publishedProfileImageKey).forEach { objectKey ->
@@ -489,6 +527,7 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
                 content =
                     """
                     {
+                        "password": "   ",
                         "reason": "서비스 이용 종료"
                     }
                     """.trimIndent()
@@ -550,6 +589,8 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
             )
         val authCookies = issueSessionAuthCookies(member)
         val sessionKey = requireAuthCookie(authCookies, AuthCookieNames.SESSION_KEY)
+        insertConsumedPendingOAuthSignup(member.username)
+        assertThat(countPendingOAuthSignupByMemberLoginId(member.username)).isEqualTo(1)
 
         mvc
             .delete("/member/api/v1/privacy/account") {
@@ -577,6 +618,7 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(findMemberDeletionState(member.id).deletedAt).isNotNull()
         assertThat(findSessionRevokedAt(sessionKey.value)).isNotNull()
         assertThat(countDeletionTombstones(member.id, "소셜 계정 탈퇴")).isEqualTo(1)
+        assertThat(countPendingOAuthSignupByMemberLoginId(member.username)).isZero()
     }
 
     @Test
@@ -742,6 +784,55 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
             },
             objectKey,
         ) ?: error("uploaded file not found")
+
+    private fun insertConsumedPendingOAuthSignup(memberLoginId: String) {
+        jdbcTemplate.update(
+            """
+            insert into pending_oauth_signup (
+                id,
+                created_at,
+                modified_at,
+                provider,
+                provider_subject_hash,
+                member_login_id,
+                pending_token_hash,
+                pending_token_expires_at,
+                nickname,
+                profile_img_url,
+                consumed_at,
+                cancelled_at
+            )
+            values (
+                nextval('pending_oauth_signup_seq'),
+                current_timestamp,
+                current_timestamp,
+                'KAKAO',
+                ?,
+                ?,
+                ?,
+                current_timestamp + interval '30 minutes',
+                '소셜탈퇴',
+                null,
+                current_timestamp,
+                null
+            )
+            """.trimIndent(),
+            "subject-hash-$memberLoginId",
+            memberLoginId,
+            "pending-token-hash-$memberLoginId",
+        )
+    }
+
+    private fun countPendingOAuthSignupByMemberLoginId(memberLoginId: String): Int =
+        jdbcTemplate.queryForObject(
+            """
+            select count(*)
+            from pending_oauth_signup
+            where member_login_id = ?
+            """.trimIndent(),
+            Int::class.java,
+            memberLoginId,
+        ) ?: 0
 
     private fun countMemberAttrsContaining(
         memberId: Long,

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -22,6 +22,7 @@ import com.back.support.BaseControllerIntegrationTest
 import com.jayway.jsonpath.JsonPath
 import jakarta.servlet.http.Cookie
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -355,6 +356,7 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         val secondSessionKey = requireAuthCookie(secondAuthCookies, AuthCookieNames.SESSION_KEY)
         assertThat(countMemberAttrsContaining(member.id, "민감")).isGreaterThan(0)
         assertThat(findPostCommentsCount(otherPost.id)).isEqualTo(3)
+        assertThat(findPostCommentsCount(deletedOtherPost.id)).isEqualTo(2)
         assertThat(findMemberPostCommentsCount(otherAuthor.id)).isEqualTo(2)
         assertThat(findUploadedFileState(legacyProfileImageKey).status).isEqualTo("ACTIVE")
         assertThat(findUploadedFileState(draftProfileImageKey).status).isEqualTo("ACTIVE")
@@ -405,7 +407,10 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(findCommentDeletedAt(authoredCommentOnDeletedPost.id)).isNotNull()
         assertThat(findCommentDeletedAt(replyToDeletedPostAuthoredComment.id)).isNotNull()
         assertThat(findPostCommentsCount(otherPost.id)).isZero()
+        assertThat(findPostCommentsCount(deletedOtherPost.id)).isZero()
         assertThat(findMemberPostCommentsCount(otherAuthor.id)).isZero()
+        assertThatThrownBy { postFacade.restoreDeletedByIdForAdmin(authoredPost.id) }
+            .hasMessage("404-1 : 이미 복구되었거나 존재하지 않는 글입니다.")
         listOf(legacyProfileImageKey, draftProfileImageKey, publishedProfileImageKey).forEach { objectKey ->
             val uploadedFile = findUploadedFileState(objectKey)
             assertThat(uploadedFile.status).isEqualTo("PENDING_DELETE")

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -16,6 +16,7 @@ import com.back.boundedContexts.member.subContexts.privacy.adapter.persistence.M
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberAccountDeletion
 import com.back.boundedContexts.member.subContexts.session.adapter.persistence.MemberSessionRepository
 import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
+import com.back.boundedContexts.post.application.service.PostApplicationService
 import com.back.global.security.config.AuthCookieNames
 import com.back.support.BaseControllerIntegrationTest
 import com.jayway.jsonpath.JsonPath
@@ -49,6 +50,9 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
 
     @Autowired
     private lateinit var authTokenIssueUseCase: AuthTokenIssueUseCase
+
+    @Autowired
+    private lateinit var postFacade: PostApplicationService
 
     @Autowired
     private lateinit var jdbcTemplate: JdbcTemplate
@@ -269,9 +273,35 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         insertMemberAttr(member.id, PROFILE_CONTACT_LINKS, """[{"label":"민감한 연락처","href":"mailto:secret@example.test"}]""")
         insertMemberAttr(member.id, PROFILE_WORKSPACE_DRAFT, """{"blocks":[{"text":"민감한 draft"}]}""")
         insertMemberAttr(member.id, PROFILE_WORKSPACE_PUBLISHED, """{"blocks":[{"text":"민감한 published"}]}""")
+        val authoredPost =
+            postFacade.write(
+                author = member,
+                title = "탈퇴 회원 작성글",
+                content = "탈퇴 후 공개 조회에서 빠져야 하는 글",
+                published = true,
+                listed = true,
+            )
+        val otherAuthor =
+            memberFacade.join(
+                username = "account-delete-other-author",
+                password = "Abcd1234!",
+                nickname = "다른작성자",
+                profileImgUrl = null,
+                email = "account-delete-other-author@example.com",
+            )
+        val otherPost =
+            postFacade.write(
+                author = otherAuthor,
+                title = "탈퇴 댓글 대상글",
+                content = "다른 회원의 공개 글",
+                published = true,
+                listed = true,
+            )
+        val authoredComment = postFacade.writeComment(member, otherPost, "탈퇴 후 숨겨져야 하는 댓글")
         val firstSessionKey = requireAuthCookie(firstAuthCookies, AuthCookieNames.SESSION_KEY)
         val secondSessionKey = requireAuthCookie(secondAuthCookies, AuthCookieNames.SESSION_KEY)
         assertThat(countMemberAttrsContaining(member.id, "민감")).isGreaterThan(0)
+        assertThat(findPostCommentsCount(otherPost.id)).isEqualTo(1)
 
         mvc
             .delete("/member/api/v1/privacy/account") {
@@ -304,6 +334,11 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(findSessionRevokedAt(secondSessionKey.value)).isNotNull()
         assertThat(countDeletionTombstones(member.id, "서비스 이용 종료")).isEqualTo(1)
         assertThat(countMemberAttrsContaining(member.id, "민감")).isZero()
+        assertThat(findPostDeletionState(authoredPost.id).deletedAt).isNotNull()
+        assertThat(findPostDeletionState(authoredPost.id).published).isFalse()
+        assertThat(findPostDeletionState(authoredPost.id).listed).isFalse()
+        assertThat(findCommentDeletedAt(authoredComment.id)).isNotNull()
+        assertThat(findPostCommentsCount(otherPost.id)).isZero()
         val deletion =
             memberAccountDeletionRepository
                 .findAll()
@@ -561,6 +596,46 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
             "%$valueFragment%",
         ) ?: 0
 
+    private fun findPostDeletionState(postId: Long): PostDeletionState =
+        jdbcTemplate.queryForObject(
+            """
+            select published, listed, deleted_at
+            from post
+            where id = ?
+            """.trimIndent(),
+            { rs, _ ->
+                PostDeletionState(
+                    published = rs.getBoolean("published"),
+                    listed = rs.getBoolean("listed"),
+                    deletedAt = rs.getTimestamp("deleted_at")?.toInstant(),
+                )
+            },
+            postId,
+        ) ?: error("post not found")
+
+    private fun findCommentDeletedAt(commentId: Long): java.time.Instant? =
+        jdbcTemplate.queryForObject(
+            """
+            select deleted_at
+            from post_comment
+            where id = ?
+            """.trimIndent(),
+            { rs, _ -> rs.getTimestamp("deleted_at")?.toInstant() },
+            commentId,
+        )
+
+    private fun findPostCommentsCount(postId: Long): Int =
+        jdbcTemplate.queryForObject(
+            """
+            select int_value
+            from post_attr
+            where subject_id = ?
+              and name = 'commentsCount'
+            """.trimIndent(),
+            Int::class.java,
+            postId,
+        ) ?: 0
+
     private fun findMemberDeletionState(memberId: Long): MemberDeletionState =
         jdbcTemplate.queryForObject(
             """
@@ -595,5 +670,11 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         val deletedAt: java.time.Instant?,
         val ipSecurityEnabled: Boolean,
         val ipSecurityFingerprint: String?,
+    )
+
+    private data class PostDeletionState(
+        val published: Boolean,
+        val listed: Boolean,
+        val deletedAt: java.time.Instant?,
     )
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -1,11 +1,21 @@
 package com.back.boundedContexts.member.adapter.web
 
+import com.back.boundedContexts.member.application.port.input.AuthTokenIssueUseCase
 import com.back.boundedContexts.member.application.service.MemberApplicationService
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.domain.shared.memberMixin.ABOUT_DETAILS
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_BIO
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_CONTACT_LINKS
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_IMG_URL
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_SERVICE_LINKS
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_WORKSPACE_DRAFT
+import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_WORKSPACE_PUBLISHED
 import com.back.boundedContexts.member.subContexts.legalAcceptance.adapter.persistence.MemberLegalAcceptanceRepository
 import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberLegalAcceptance
 import com.back.boundedContexts.member.subContexts.privacy.adapter.persistence.MemberAccountDeletionRepository
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberAccountDeletion
 import com.back.boundedContexts.member.subContexts.session.adapter.persistence.MemberSessionRepository
+import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
 import com.back.global.security.config.AuthCookieNames
 import com.back.support.BaseControllerIntegrationTest
 import com.jayway.jsonpath.JsonPath
@@ -33,6 +43,12 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
 
     @Autowired
     private lateinit var memberSessionRepository: MemberSessionRepository
+
+    @Autowired
+    private lateinit var memberSessionUseCase: MemberSessionUseCase
+
+    @Autowired
+    private lateinit var authTokenIssueUseCase: AuthTokenIssueUseCase
 
     @Autowired
     private lateinit var jdbcTemplate: JdbcTemplate
@@ -246,8 +262,16 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
             ipSecurityEnabled = true,
             ipSecurityFingerprint = "fingerprint-before-delete",
         )
+        insertMemberAttr(member.id, PROFILE_IMG_URL, "https://cdn.example.test/민감-profile.png")
+        insertMemberAttr(member.id, PROFILE_BIO, "민감한 자기소개")
+        insertMemberAttr(member.id, ABOUT_DETAILS, "민감한 상세 소개")
+        insertMemberAttr(member.id, PROFILE_SERVICE_LINKS, """[{"label":"민감한 서비스","href":"https://example.test"}]""")
+        insertMemberAttr(member.id, PROFILE_CONTACT_LINKS, """[{"label":"민감한 연락처","href":"mailto:secret@example.test"}]""")
+        insertMemberAttr(member.id, PROFILE_WORKSPACE_DRAFT, """{"blocks":[{"text":"민감한 draft"}]}""")
+        insertMemberAttr(member.id, PROFILE_WORKSPACE_PUBLISHED, """{"blocks":[{"text":"민감한 published"}]}""")
         val firstSessionKey = requireAuthCookie(firstAuthCookies, AuthCookieNames.SESSION_KEY)
         val secondSessionKey = requireAuthCookie(secondAuthCookies, AuthCookieNames.SESSION_KEY)
+        assertThat(countMemberAttrsContaining(member.id, "민감")).isGreaterThan(0)
 
         mvc
             .delete("/member/api/v1/privacy/account") {
@@ -279,6 +303,7 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(findSessionRevokedAt(firstSessionKey.value)).isNotNull()
         assertThat(findSessionRevokedAt(secondSessionKey.value)).isNotNull()
         assertThat(countDeletionTombstones(member.id, "서비스 이용 종료")).isEqualTo(1)
+        assertThat(countMemberAttrsContaining(member.id, "민감")).isZero()
         val deletion =
             memberAccountDeletionRepository
                 .findAll()
@@ -359,6 +384,81 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
             }
     }
 
+    @Test
+    fun `비밀번호가 없는 소셜 계정은 확인 플래그로 탈퇴할 수 있다`() {
+        val member =
+            memberFacade.join(
+                username = "account-delete-oauth-user",
+                password = null,
+                nickname = "소셜탈퇴",
+                profileImgUrl = null,
+                email = "account-delete-oauth-user@example.com",
+            )
+        val authCookies = issueSessionAuthCookies(member)
+        val sessionKey = requireAuthCookie(authCookies, AuthCookieNames.SESSION_KEY)
+
+        mvc
+            .delete("/member/api/v1/privacy/account") {
+                authCookies.forEach { cookie(it) }
+                header("X-Aquila-CSRF", "1")
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "oauthAccountDeletionConfirmed": true,
+                        "reason": "소셜 계정 탈퇴"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.resultCode") { value("200-1") }
+                jsonPath("$.msg") { value("계정 탈퇴가 완료되었습니다.") }
+                cookie { maxAge(AuthCookieNames.API_KEY, 0) }
+                cookie { maxAge(AuthCookieNames.ACCESS_TOKEN, 0) }
+                cookie { maxAge(AuthCookieNames.REFRESH_TOKEN, 0) }
+                cookie { maxAge(AuthCookieNames.SESSION_KEY, 0) }
+            }
+
+        assertThat(findMemberDeletionState(member.id).email).isNull()
+        assertThat(findMemberDeletionState(member.id).deletedAt).isNotNull()
+        assertThat(findSessionRevokedAt(sessionKey.value)).isNotNull()
+        assertThat(countDeletionTombstones(member.id, "소셜 계정 탈퇴")).isEqualTo(1)
+    }
+
+    @Test
+    fun `비밀번호가 없는 소셜 계정은 확인 플래그가 없으면 탈퇴할 수 없다`() {
+        val member =
+            memberFacade.join(
+                username = "account-delete-oauth-unconfirmed-user",
+                password = null,
+                nickname = "소셜탈퇴미확인",
+                profileImgUrl = null,
+                email = "account-delete-oauth-unconfirmed-user@example.com",
+            )
+        val authCookies = issueSessionAuthCookies(member)
+        val sessionKey = requireAuthCookie(authCookies, AuthCookieNames.SESSION_KEY)
+
+        mvc
+            .delete("/member/api/v1/privacy/account") {
+                authCookies.forEach { cookie(it) }
+                header("X-Aquila-CSRF", "1")
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "reason": "소셜 계정 탈퇴"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isBadRequest() }
+                jsonPath("$.resultCode") { value("400-2") }
+                jsonPath("$.msg") { value("소셜 계정 탈퇴 확인이 필요합니다.") }
+            }
+
+        assertThat(findMemberDeletionState(member.id).deletedAt).isNull()
+        assertThat(findSessionRevokedAt(sessionKey.value)).isNull()
+    }
+
     private fun loginAuthCookies(email: String): List<Cookie> =
         mvc
             .post("/member/api/v1/auth/login") {
@@ -380,6 +480,34 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
                     it.value.isNotBlank()
             }
 
+    private fun issueSessionAuthCookies(member: Member): List<Cookie> {
+        val sessionWithRefreshToken =
+            memberSessionUseCase.createSessionWithRefreshToken(
+                member = member,
+                rememberLoginEnabled = true,
+                ipSecurityEnabled = false,
+                ipSecurityFingerprint = null,
+                createdIp = "127.0.0.1",
+                userAgent = "ApiV1PrivacyRightsControllerTest",
+            )
+        val session = sessionWithRefreshToken.session
+        val accessToken =
+            authTokenIssueUseCase.genAccessToken(
+                member = member,
+                sessionKey = session.sessionKey,
+                rememberLoginEnabled = session.rememberLoginEnabled,
+                ipSecurityEnabled = session.ipSecurityEnabled,
+                ipSecurityFingerprint = session.ipSecurityFingerprint,
+            )
+
+        return listOf(
+            Cookie(AuthCookieNames.API_KEY, member.apiKey),
+            Cookie(AuthCookieNames.ACCESS_TOKEN, accessToken),
+            Cookie(AuthCookieNames.REFRESH_TOKEN, sessionWithRefreshToken.refreshToken),
+            Cookie(AuthCookieNames.SESSION_KEY, session.sessionKey),
+        )
+    }
+
     private fun requireAuthCookie(
         cookies: List<Cookie>,
         name: String,
@@ -399,6 +527,38 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
             Int::class.java,
             memberId,
             reason,
+        ) ?: 0
+
+    private fun insertMemberAttr(
+        memberId: Long,
+        name: String,
+        strValue: String,
+    ) {
+        jdbcTemplate.update(
+            """
+            insert into member_attr (id, subject_id, name, str_value)
+            values (nextval('member_attr_seq'), ?, ?, ?)
+            """.trimIndent(),
+            memberId,
+            name,
+            strValue,
+        )
+    }
+
+    private fun countMemberAttrsContaining(
+        memberId: Long,
+        valueFragment: String,
+    ): Int =
+        jdbcTemplate.queryForObject(
+            """
+            select count(*)
+            from member_attr
+            where subject_id = ?
+              and str_value like ?
+            """.trimIndent(),
+            Int::class.java,
+            memberId,
+            "%$valueFragment%",
         ) ?: 0
 
     private fun findMemberDeletionState(memberId: Long): MemberDeletionState =

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -1,0 +1,120 @@
+package com.back.boundedContexts.member.adapter.web
+
+import com.back.boundedContexts.member.application.service.MemberApplicationService
+import com.back.global.security.config.AuthCookieNames
+import com.back.support.BaseControllerIntegrationTest
+import com.jayway.jsonpath.JsonPath
+import jakarta.servlet.http.Cookie
+import org.hamcrest.Matchers.startsWith
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+
+class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
+    @Autowired
+    private lateinit var memberFacade: MemberApplicationService
+
+    @Test
+    fun `개인정보 export 는 로그인 사용자의 계정 스냅샷을 반환한다`() {
+        val member =
+            memberFacade.join(
+                username = "privacy-export-user",
+                password = "Abcd1234!",
+                nickname = "정보내보내기",
+                profileImgUrl = null,
+                email = "privacy-export-user@example.com",
+            )
+        val authCookies = loginAuthCookies(member.email!!)
+
+        mvc
+            .get("/member/api/v1/privacy/export") {
+                authCookies.forEach { cookie(it) }
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.resultCode") { value("200-1") }
+                jsonPath("$.msg") { value("개인정보 내보내기 데이터를 조회했습니다.") }
+                jsonPath("$.data.member.id") { value(member.id) }
+                jsonPath("$.data.member.email") { value("privacy-export-user@example.com") }
+                jsonPath("$.data.member.username") { value("privacy-export-user") }
+                jsonPath("$.data.member.nickname") { value("정보내보내기") }
+                jsonPath("$.data.member.createdAt") { value(startsWith(member.createdAt.toString().take(20))) }
+                jsonPath("$.data.generatedAt") { value(startsWith("20")) }
+            }
+    }
+
+    @Test
+    fun `개인정보 처리 요청은 생성 후 본인 상태 조회가 가능하다`() {
+        val member =
+            memberFacade.join(
+                username = "privacy-request-user",
+                password = "Abcd1234!",
+                nickname = "권리요청",
+                profileImgUrl = null,
+                email = "privacy-request-user@example.com",
+            )
+        val authCookies = loginAuthCookies(member.email!!)
+
+        val created =
+            mvc
+                .post("/member/api/v1/privacy/requests") {
+                    authCookies.forEach { cookie(it) }
+                    header("X-Aquila-CSRF", "1")
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                            "type": "EXPORT",
+                            "message": "가입 정보와 운영 로그 열람을 요청합니다."
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isCreated() }
+                    jsonPath("$.resultCode") { value("201-1") }
+                    jsonPath("$.msg") { value("개인정보 처리 요청을 접수했습니다.") }
+                    jsonPath("$.data.item.id") { isNumber() }
+                    jsonPath("$.data.item.type") { value("EXPORT") }
+                    jsonPath("$.data.item.status") { value("RECEIVED") }
+                    jsonPath("$.data.item.message") { value("가입 정보와 운영 로그 열람을 요청합니다.") }
+                    jsonPath("$.data.item.requestedAt") { value(startsWith("20")) }
+                    jsonPath("$.data.item.dueAt") { value(startsWith("20")) }
+                }.andReturn()
+
+        val requestId = JsonPath.read<Int>(created.response.contentAsString, "$.data.item.id").toLong()
+
+        mvc
+            .get("/member/api/v1/privacy/requests/$requestId") {
+                authCookies.forEach { cookie(it) }
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.resultCode") { value("200-1") }
+                jsonPath("$.msg") { value("개인정보 처리 요청 상태를 조회했습니다.") }
+                jsonPath("$.data.item.id") { value(requestId) }
+                jsonPath("$.data.item.memberId") { value(member.id) }
+                jsonPath("$.data.item.type") { value("EXPORT") }
+                jsonPath("$.data.item.status") { value("RECEIVED") }
+            }
+    }
+
+    private fun loginAuthCookies(email: String): List<Cookie> =
+        mvc
+            .post("/member/api/v1/auth/login") {
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "email": "$email",
+                        "password": "Abcd1234!"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isOk() }
+            }.andReturn()
+            .response
+            .cookies
+            .filter {
+                it.name in AuthCookieNames.AUTHENTICATION_COOKIE_NAMES &&
+                    it.value.isNotBlank()
+            }
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -266,13 +266,27 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
             ipSecurityEnabled = true,
             ipSecurityFingerprint = "fingerprint-before-delete",
         )
-        insertMemberAttr(member.id, PROFILE_IMG_URL, "https://cdn.example.test/민감-profile.png")
+        val legacyProfileImageKey = "profiles/account-delete/legacy-profile.png"
+        val draftProfileImageKey = "profiles/account-delete/draft-profile.png"
+        val publishedProfileImageKey = "profiles/account-delete/published-profile.png"
+        insertActiveProfileUploadedFile(member.id, legacyProfileImageKey)
+        insertActiveProfileUploadedFile(member.id, draftProfileImageKey)
+        insertActiveProfileUploadedFile(member.id, publishedProfileImageKey)
+        insertMemberAttr(member.id, PROFILE_IMG_URL, "/post/api/v1/images/$legacyProfileImageKey")
         insertMemberAttr(member.id, PROFILE_BIO, "민감한 자기소개")
         insertMemberAttr(member.id, ABOUT_DETAILS, "민감한 상세 소개")
         insertMemberAttr(member.id, PROFILE_SERVICE_LINKS, """[{"label":"민감한 서비스","href":"https://example.test"}]""")
         insertMemberAttr(member.id, PROFILE_CONTACT_LINKS, """[{"label":"민감한 연락처","href":"mailto:secret@example.test"}]""")
-        insertMemberAttr(member.id, PROFILE_WORKSPACE_DRAFT, """{"blocks":[{"text":"민감한 draft"}]}""")
-        insertMemberAttr(member.id, PROFILE_WORKSPACE_PUBLISHED, """{"blocks":[{"text":"민감한 published"}]}""")
+        insertMemberAttr(
+            member.id,
+            PROFILE_WORKSPACE_DRAFT,
+            """{"content":{"profileImageUrl":"/post/api/v1/images/$draftProfileImageKey","profileBio":"민감한 draft"}}""",
+        )
+        insertMemberAttr(
+            member.id,
+            PROFILE_WORKSPACE_PUBLISHED,
+            """{"content":{"profileImageUrl":"/post/api/v1/images/$publishedProfileImageKey","profileBio":"민감한 published"}}""",
+        )
         val authoredPost =
             postFacade.write(
                 author = member,
@@ -306,6 +320,9 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(countMemberAttrsContaining(member.id, "민감")).isGreaterThan(0)
         assertThat(findPostCommentsCount(otherPost.id)).isEqualTo(3)
         assertThat(findMemberPostCommentsCount(otherAuthor.id)).isEqualTo(1)
+        assertThat(findUploadedFileState(legacyProfileImageKey).status).isEqualTo("ACTIVE")
+        assertThat(findUploadedFileState(draftProfileImageKey).status).isEqualTo("ACTIVE")
+        assertThat(findUploadedFileState(publishedProfileImageKey).status).isEqualTo("ACTIVE")
         val taskPayloadsWithDeletedPostContentBeforeDeletion =
             countTaskPayloadsContaining("탈퇴 후 공개 조회에서 빠져야 하는 글")
         val taskPayloadsWithDeletedCommentContentBeforeDeletion =
@@ -351,6 +368,12 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(findCommentDeletedAt(nestedReplyToAuthoredComment.id)).isNotNull()
         assertThat(findPostCommentsCount(otherPost.id)).isZero()
         assertThat(findMemberPostCommentsCount(otherAuthor.id)).isZero()
+        listOf(legacyProfileImageKey, draftProfileImageKey, publishedProfileImageKey).forEach { objectKey ->
+            val uploadedFile = findUploadedFileState(objectKey)
+            assertThat(uploadedFile.status).isEqualTo("PENDING_DELETE")
+            assertThat(uploadedFile.retentionReason).isEqualTo("REPLACED_PROFILE_IMAGE")
+            assertThat(uploadedFile.purgeAfter).isNotNull()
+        }
         assertThat(countTaskPayloadsContaining("탈퇴 후 공개 조회에서 빠져야 하는 글"))
             .isEqualTo(taskPayloadsWithDeletedPostContentBeforeDeletion)
         assertThat(countTaskPayloadsContaining("탈퇴 후 숨겨져야 하는 댓글"))
@@ -679,6 +702,47 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         )
     }
 
+    private fun insertActiveProfileUploadedFile(
+        memberId: Long,
+        objectKey: String,
+    ) {
+        jdbcTemplate.update(
+            """
+            insert into uploaded_file (
+                id,
+                object_key,
+                bucket,
+                content_type,
+                file_size,
+                purpose,
+                status,
+                owner_type,
+                owner_id
+            )
+            values (nextval('uploaded_file_seq'), ?, 'test-bucket', 'image/png', 128, 'PROFILE_IMAGE', 'ACTIVE', 'MEMBER_PROFILE', ?)
+            """.trimIndent(),
+            objectKey,
+            memberId,
+        )
+    }
+
+    private fun findUploadedFileState(objectKey: String): UploadedFileState =
+        jdbcTemplate.queryForObject(
+            """
+            select status, retention_reason, purge_after
+            from uploaded_file
+            where object_key = ?
+            """.trimIndent(),
+            { rs, _ ->
+                UploadedFileState(
+                    status = rs.getString("status"),
+                    retentionReason = rs.getString("retention_reason"),
+                    purgeAfter = rs.getTimestamp("purge_after")?.toInstant(),
+                )
+            },
+            objectKey,
+        ) ?: error("uploaded file not found")
+
     private fun countMemberAttrsContaining(
         memberId: Long,
         valueFragment: String,
@@ -811,5 +875,11 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         val published: Boolean,
         val listed: Boolean,
         val deletedAt: java.time.Instant?,
+    )
+
+    private data class UploadedFileState(
+        val status: String,
+        val retentionReason: String?,
+        val purgeAfter: java.time.Instant?,
     )
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -298,10 +298,13 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
                 listed = true,
             )
         val authoredComment = postFacade.writeComment(member, otherPost, "탈퇴 후 숨겨져야 하는 댓글")
+        val replyToAuthoredComment = postFacade.writeComment(otherAuthor, otherPost, "탈퇴 댓글의 답글", authoredComment)
+        val nestedReplyToAuthoredComment =
+            postFacade.writeComment(member, otherPost, "탈퇴 댓글의 중첩 답글", replyToAuthoredComment)
         val firstSessionKey = requireAuthCookie(firstAuthCookies, AuthCookieNames.SESSION_KEY)
         val secondSessionKey = requireAuthCookie(secondAuthCookies, AuthCookieNames.SESSION_KEY)
         assertThat(countMemberAttrsContaining(member.id, "민감")).isGreaterThan(0)
-        assertThat(findPostCommentsCount(otherPost.id)).isEqualTo(1)
+        assertThat(findPostCommentsCount(otherPost.id)).isEqualTo(3)
 
         mvc
             .delete("/member/api/v1/privacy/account") {
@@ -338,6 +341,8 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(findPostDeletionState(authoredPost.id).published).isFalse()
         assertThat(findPostDeletionState(authoredPost.id).listed).isFalse()
         assertThat(findCommentDeletedAt(authoredComment.id)).isNotNull()
+        assertThat(findCommentDeletedAt(replyToAuthoredComment.id)).isNotNull()
+        assertThat(findCommentDeletedAt(nestedReplyToAuthoredComment.id)).isNotNull()
         assertThat(findPostCommentsCount(otherPost.id)).isZero()
         val deletion =
             memberAccountDeletionRepository
@@ -346,6 +351,41 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(deletion.memberId).isEqualTo(member.id)
         assertThat(deletion.reason).isEqualTo("서비스 이용 종료")
         assertThat(deletion.deletedAt).isNotNull()
+    }
+
+    @Test
+    fun `계정 탈퇴는 비밀번호 앞뒤 공백을 원문 그대로 검증한다`() {
+        val rawPassword = " Abcd1234! "
+        val member =
+            memberFacade.join(
+                username = "account-delete-spaced-password-user",
+                password = rawPassword,
+                nickname = "공백비밀번호",
+                profileImgUrl = null,
+                email = "account-delete-spaced-password-user@example.com",
+            )
+        val authCookies = loginAuthCookies(member.email!!, rawPassword)
+
+        mvc
+            .delete("/member/api/v1/privacy/account") {
+                authCookies.forEach { cookie(it) }
+                header("X-Aquila-CSRF", "1")
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "password": " Abcd1234! ",
+                        "reason": "비밀번호 원문 검증"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.resultCode") { value("200-1") }
+                jsonPath("$.msg") { value("계정 탈퇴가 완료되었습니다.") }
+            }
+
+        assertThat(findMemberDeletionState(member.id).deletedAt).isNotNull()
+        assertThat(countDeletionTombstones(member.id, "비밀번호 원문 검증")).isEqualTo(1)
     }
 
     @Test
@@ -528,7 +568,10 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(findSessionRevokedAt(sessionKey.value)).isNull()
     }
 
-    private fun loginAuthCookies(email: String): List<Cookie> =
+    private fun loginAuthCookies(
+        email: String,
+        password: String = "Abcd1234!",
+    ): List<Cookie> =
         mvc
             .post("/member/api/v1/auth/login") {
                 contentType = MediaType.APPLICATION_JSON
@@ -536,7 +579,7 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
                     """
                     {
                         "email": "$email",
-                        "password": "Abcd1234!"
+                        "password": "$password"
                     }
                     """.trimIndent()
             }.andExpect {

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -305,6 +305,7 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         val secondSessionKey = requireAuthCookie(secondAuthCookies, AuthCookieNames.SESSION_KEY)
         assertThat(countMemberAttrsContaining(member.id, "민감")).isGreaterThan(0)
         assertThat(findPostCommentsCount(otherPost.id)).isEqualTo(3)
+        assertThat(findMemberPostCommentsCount(otherAuthor.id)).isEqualTo(1)
 
         mvc
             .delete("/member/api/v1/privacy/account") {
@@ -338,12 +339,11 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(countDeletionTombstones(member.id, "서비스 이용 종료")).isEqualTo(1)
         assertThat(countMemberAttrsContaining(member.id, "민감")).isZero()
         assertThat(findPostDeletionState(authoredPost.id).deletedAt).isNotNull()
-        assertThat(findPostDeletionState(authoredPost.id).published).isFalse()
-        assertThat(findPostDeletionState(authoredPost.id).listed).isFalse()
         assertThat(findCommentDeletedAt(authoredComment.id)).isNotNull()
         assertThat(findCommentDeletedAt(replyToAuthoredComment.id)).isNotNull()
         assertThat(findCommentDeletedAt(nestedReplyToAuthoredComment.id)).isNotNull()
         assertThat(findPostCommentsCount(otherPost.id)).isZero()
+        assertThat(findMemberPostCommentsCount(otherAuthor.id)).isZero()
         val deletion =
             memberAccountDeletionRepository
                 .findAll()
@@ -711,6 +711,18 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
             """.trimIndent(),
             Int::class.java,
             postId,
+        ) ?: 0
+
+    private fun findMemberPostCommentsCount(memberId: Long): Int =
+        jdbcTemplate.queryForObject(
+            """
+            select int_value
+            from member_attr
+            where subject_id = ?
+              and name = 'postCommentsCount'
+            """.trimIndent(),
+            Int::class.java,
+            memberId,
         ) ?: 0
 
     private fun findMemberDeletionState(memberId: Long): MemberDeletionState =

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -306,6 +306,12 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(countMemberAttrsContaining(member.id, "민감")).isGreaterThan(0)
         assertThat(findPostCommentsCount(otherPost.id)).isEqualTo(3)
         assertThat(findMemberPostCommentsCount(otherAuthor.id)).isEqualTo(1)
+        val taskPayloadsWithDeletedPostContentBeforeDeletion =
+            countTaskPayloadsContaining("탈퇴 후 공개 조회에서 빠져야 하는 글")
+        val taskPayloadsWithDeletedCommentContentBeforeDeletion =
+            countTaskPayloadsContaining("탈퇴 후 숨겨져야 하는 댓글")
+        val actionLogsWithDeletingMemberProfileBeforeDeletion =
+            countActionLogsContaining("탈퇴유저")
 
         mvc
             .delete("/member/api/v1/privacy/account") {
@@ -344,6 +350,12 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(findCommentDeletedAt(nestedReplyToAuthoredComment.id)).isNotNull()
         assertThat(findPostCommentsCount(otherPost.id)).isZero()
         assertThat(findMemberPostCommentsCount(otherAuthor.id)).isZero()
+        assertThat(countTaskPayloadsContaining("탈퇴 후 공개 조회에서 빠져야 하는 글"))
+            .isEqualTo(taskPayloadsWithDeletedPostContentBeforeDeletion)
+        assertThat(countTaskPayloadsContaining("탈퇴 후 숨겨져야 하는 댓글"))
+            .isEqualTo(taskPayloadsWithDeletedCommentContentBeforeDeletion)
+        assertThat(countActionLogsContaining("탈퇴유저"))
+            .isEqualTo(actionLogsWithDeletingMemberProfileBeforeDeletion)
         val deletion =
             memberAccountDeletionRepository
                 .findAll()
@@ -670,6 +682,28 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
             """.trimIndent(),
             Int::class.java,
             memberId,
+            "%$valueFragment%",
+        ) ?: 0
+
+    private fun countTaskPayloadsContaining(valueFragment: String): Int =
+        jdbcTemplate.queryForObject(
+            """
+            select count(*)
+            from task
+            where payload like ?
+            """.trimIndent(),
+            Int::class.java,
+            "%$valueFragment%",
+        ) ?: 0
+
+    private fun countActionLogsContaining(valueFragment: String): Int =
+        jdbcTemplate.queryForObject(
+            """
+            select count(*)
+            from member_action_log
+            where data like ?
+            """.trimIndent(),
+            Int::class.java,
             "%$valueFragment%",
         ) ?: 0
 

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -337,6 +337,7 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
 
         assertThat(memberFacade.findByEmail("account-delete-user@example.com")).isNull()
         assertThat(findMemberDeletionState(member.id).email).isNull()
+        assertThat(findMemberDeletionState(member.id).username).startsWith("deleted-${member.id}-")
         assertThat(findMemberDeletionState(member.id).deletedAt).isNotNull()
         assertThat(findMemberDeletionState(member.id).ipSecurityEnabled).isFalse()
         assertThat(findMemberDeletionState(member.id).ipSecurityFingerprint).isNull()
@@ -363,6 +364,15 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         assertThat(deletion.memberId).isEqualTo(member.id)
         assertThat(deletion.reason).isEqualTo("서비스 이용 종료")
         assertThat(deletion.deletedAt).isNotNull()
+        val rejoinedMember =
+            memberFacade.joinWithVerifiedEmail(
+                email = "account-delete-user@example.com",
+                password = "Abcd1234!",
+                nickname = "재가입유저",
+                profileImgUrl = null,
+            )
+        assertThat(rejoinedMember.id).isNotEqualTo(member.id)
+        assertThat(rejoinedMember.email).isEqualTo("account-delete-user@example.com")
     }
 
     @Test
@@ -762,12 +772,13 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
     private fun findMemberDeletionState(memberId: Long): MemberDeletionState =
         jdbcTemplate.queryForObject(
             """
-            select email, deleted_at, ip_security_enabled, ip_security_fingerprint
+            select login_id, email, deleted_at, ip_security_enabled, ip_security_fingerprint
             from member
             where id = ?
             """.trimIndent(),
             { rs, _ ->
                 MemberDeletionState(
+                    username = rs.getString("login_id"),
                     email = rs.getString("email"),
                     deletedAt = rs.getTimestamp("deleted_at")?.toInstant(),
                     ipSecurityEnabled = rs.getBoolean("ip_security_enabled"),
@@ -789,6 +800,7 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         )
 
     private data class MemberDeletionState(
+        val username: String,
         val email: String?,
         val deletedAt: java.time.Instant?,
         val ipSecurityEnabled: Boolean,

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -1,20 +1,30 @@
 package com.back.boundedContexts.member.adapter.web
 
 import com.back.boundedContexts.member.application.service.MemberApplicationService
+import com.back.boundedContexts.member.subContexts.session.adapter.persistence.MemberSessionRepository
 import com.back.global.security.config.AuthCookieNames
 import com.back.support.BaseControllerIntegrationTest
 import com.jayway.jsonpath.JsonPath
 import jakarta.servlet.http.Cookie
+import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 
 class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
     @Autowired
     private lateinit var memberFacade: MemberApplicationService
+
+    @Autowired
+    private lateinit var memberSessionRepository: MemberSessionRepository
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
 
     @Test
     fun `개인정보 export 는 로그인 사용자의 계정 스냅샷을 반환한다`() {
@@ -97,6 +107,86 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
             }
     }
 
+    @Test
+    fun `계정 탈퇴는 비밀번호 재확인 후 회원을 삭제 상태로 전환하고 모든 세션을 폐기한다`() {
+        val member =
+            memberFacade.join(
+                username = "account-delete-user",
+                password = "Abcd1234!",
+                nickname = "탈퇴유저",
+                profileImgUrl = null,
+                email = "account-delete-user@example.com",
+            )
+        val firstAuthCookies = loginAuthCookies(member.email!!)
+        val secondAuthCookies = loginAuthCookies(member.email!!)
+        val firstSessionKey = requireAuthCookie(firstAuthCookies, AuthCookieNames.SESSION_KEY)
+        val secondSessionKey = requireAuthCookie(secondAuthCookies, AuthCookieNames.SESSION_KEY)
+
+        mvc
+            .delete("/member/api/v1/privacy/account") {
+                firstAuthCookies.forEach { cookie(it) }
+                header("X-Aquila-CSRF", "1")
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "password": "Abcd1234!",
+                        "reason": "서비스 이용 종료"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.resultCode") { value("200-1") }
+                jsonPath("$.msg") { value("계정 탈퇴가 완료되었습니다.") }
+                cookie { maxAge(AuthCookieNames.API_KEY, 0) }
+                cookie { maxAge(AuthCookieNames.ACCESS_TOKEN, 0) }
+                cookie { maxAge(AuthCookieNames.REFRESH_TOKEN, 0) }
+                cookie { maxAge(AuthCookieNames.SESSION_KEY, 0) }
+            }
+
+        assertThat(memberFacade.findByEmail("account-delete-user@example.com")).isNull()
+        assertThat(findMemberDeletionState(member.id).email).isNull()
+        assertThat(findMemberDeletionState(member.id).deletedAt).isNotNull()
+        assertThat(findSessionRevokedAt(firstSessionKey.value)).isNotNull()
+        assertThat(findSessionRevokedAt(secondSessionKey.value)).isNotNull()
+        assertThat(countDeletionTombstones(member.id, "서비스 이용 종료")).isEqualTo(1)
+    }
+
+    @Test
+    fun `계정 탈퇴는 비밀번호가 틀리면 세션과 회원 상태를 유지한다`() {
+        val member =
+            memberFacade.join(
+                username = "account-delete-wrong-password-user",
+                password = "Abcd1234!",
+                nickname = "탈퇴실패",
+                profileImgUrl = null,
+                email = "account-delete-wrong-password-user@example.com",
+            )
+        val authCookies = loginAuthCookies(member.email!!)
+        val sessionKey = requireAuthCookie(authCookies, AuthCookieNames.SESSION_KEY)
+
+        mvc
+            .delete("/member/api/v1/privacy/account") {
+                authCookies.forEach { cookie(it) }
+                header("X-Aquila-CSRF", "1")
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "password": "wrong-password",
+                        "reason": "서비스 이용 종료"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isUnauthorized() }
+                jsonPath("$.resultCode") { value("401-1") }
+                jsonPath("$.msg") { value("비밀번호가 일치하지 않습니다.") }
+            }
+
+        assertThat(memberFacade.findByEmail("account-delete-wrong-password-user@example.com")).isNotNull()
+        assertThat(memberSessionRepository.findBySessionKey(sessionKey.value)?.revokedAt).isNull()
+    }
+
     private fun loginAuthCookies(email: String): List<Cookie> =
         mvc
             .post("/member/api/v1/auth/login") {
@@ -117,4 +207,57 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
                 it.name in AuthCookieNames.AUTHENTICATION_COOKIE_NAMES &&
                     it.value.isNotBlank()
             }
+
+    private fun requireAuthCookie(
+        cookies: List<Cookie>,
+        name: String,
+    ): Cookie = cookies.firstOrNull { it.name == name } ?: error("$name cookie not issued")
+
+    private fun countDeletionTombstones(
+        memberId: Long,
+        reason: String,
+    ): Int =
+        jdbcTemplate.queryForObject(
+            """
+            select count(*)
+            from member_account_deletion
+            where member_id = ?
+              and reason = ?
+            """.trimIndent(),
+            Int::class.java,
+            memberId,
+            reason,
+        ) ?: 0
+
+    private fun findMemberDeletionState(memberId: Long): MemberDeletionState =
+        jdbcTemplate.queryForObject(
+            """
+            select email, deleted_at
+            from member
+            where id = ?
+            """.trimIndent(),
+            { rs, _ ->
+                MemberDeletionState(
+                    email = rs.getString("email"),
+                    deletedAt = rs.getTimestamp("deleted_at")?.toInstant(),
+                )
+            },
+            memberId,
+        ) ?: error("member not found")
+
+    private fun findSessionRevokedAt(sessionKey: String): java.time.Instant? =
+        jdbcTemplate.queryForObject(
+            """
+            select revoked_at
+            from member_session
+            where session_key = ?
+            """.trimIndent(),
+            { rs, _ -> rs.getTimestamp("revoked_at")?.toInstant() },
+            sessionKey,
+        )
+
+    private data class MemberDeletionState(
+        val email: String?,
+        val deletedAt: java.time.Instant?,
+    )
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/application/service/ActorApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/application/service/ActorApplicationServiceTest.kt
@@ -158,6 +158,8 @@ class ActorApplicationServiceTest {
 
         override fun findById(id: Long): Optional<Member> = Optional.ofNullable(member.takeIf { it.id == id })
 
+        override fun findByIdForUpdate(id: Long): Optional<Member> = findById(id)
+
         override fun getReferenceById(id: Long): Member = member.takeIf { it.id == id } ?: error("member not found")
 
         override fun findQPagedByKw(query: MemberRepositoryPort.PagedQuery): MemberRepositoryPort.PagedResult<Member> =

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/web/ApiV1OAuthSignupControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/web/ApiV1OAuthSignupControllerTest.kt
@@ -176,4 +176,7 @@ private class RecordingOAuthSignupUseCase : OAuthSignupUseCase {
             modifiedAt = Instant.EPOCH.plusSeconds(1)
         }
     }
+
+    override fun releaseConsumedSignupForMemberLoginId(memberLoginId: String): Int =
+        error("releaseConsumedSignupForMemberLoginId is not used in ApiV1OAuthSignupControllerTest")
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
@@ -111,6 +111,21 @@ class OAuthSignupApplicationServiceTest {
     }
 
     @Test
+    fun `provider가 공백이면 pending을 시작하지 않는다`() {
+        val fixture = Fixture()
+
+        assertThatThrownBy {
+            fixture.service.startPending(
+                provider = "   ",
+                providerSubject = RAW_PROVIDER_SUBJECT,
+                nickname = "카카오닉네임",
+                profileImgUrl = null,
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("소셜 로그인 제공자가 올바르지 않습니다.")
+    }
+
+    @Test
     fun `provider nickname이 정책 범위를 벗어나도 pending을 만들고 기본 표시 이름을 사용한다`() {
         val fixture = Fixture()
 
@@ -168,6 +183,26 @@ class OAuthSignupApplicationServiceTest {
             )
         }.isInstanceOf(AppException::class.java)
             .hasMessageContaining("프로필 이름은 2~30자")
+    }
+
+    @Test
+    fun `계정 탈퇴 release는 기존 member login id의 pending row를 제거한다`() {
+        val fixture = Fixture()
+        val pending =
+            PendingOAuthSignup(
+                provider = "KAKAO",
+                providerSubjectHash = "subject-release",
+                memberLoginId = "KAKAO__subject-release",
+                pendingTokenHash = "pending-release",
+                pendingTokenExpiresAt = Instant.EPOCH.plusSeconds(300),
+                nickname = "카카오닉네임",
+            )
+        fixture.pendingRepository.save(pending)
+
+        val deletedCount = fixture.service.releaseConsumedSignupForMemberLoginId(pending.memberLoginId)
+
+        assertThat(deletedCount).isEqualTo(1)
+        assertThat(fixture.pendingRepository.saved).isEmpty()
     }
 
     @Test
@@ -390,6 +425,12 @@ private class RecordingPendingOAuthSignupRepository : PendingOAuthSignupReposito
 
     override fun findByPendingTokenHash(pendingTokenHash: String): PendingOAuthSignup? =
         saved.firstOrNull { it.pendingTokenHash == pendingTokenHash }
+
+    override fun deleteByMemberLoginId(memberLoginId: String): Int {
+        val beforeCount = saved.size
+        saved.removeIf { it.memberLoginId == memberLoginId }
+        return beforeCount - saved.size
+    }
 }
 
 private class RecordingLegalAcceptanceRepository : MemberLegalAcceptanceRepositoryPort {

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
@@ -399,6 +399,11 @@ private class RecordingLegalAcceptanceRepository : MemberLegalAcceptanceReposito
         saved += memberLegalAcceptance
         return memberLegalAcceptance
     }
+
+    override fun findTopByMemberIdOrderByAcceptedAtDesc(memberId: Long): MemberLegalAcceptance? =
+        saved
+            .filter { it.member.id == memberId }
+            .maxByOrNull { it.acceptedAt }
 }
 
 private class RecordingMemberUseCase : MemberUseCase {

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
@@ -186,7 +186,7 @@ class OAuthSignupApplicationServiceTest {
     }
 
     @Test
-    fun `계정 탈퇴 release는 기존 member login id의 pending row를 제거한다`() {
+    fun `계정 탈퇴 release는 기존 member login id의 consumed pending row만 제거한다`() {
         val fixture = Fixture()
         val pending =
             PendingOAuthSignup(
@@ -197,12 +197,23 @@ class OAuthSignupApplicationServiceTest {
                 pendingTokenExpiresAt = Instant.EPOCH.plusSeconds(300),
                 nickname = "카카오닉네임",
             )
+        pending.consume(Instant.EPOCH.plusSeconds(10))
+        val activePending =
+            PendingOAuthSignup(
+                provider = "KAKAO",
+                providerSubjectHash = "subject-active",
+                memberLoginId = pending.memberLoginId,
+                pendingTokenHash = "pending-active",
+                pendingTokenExpiresAt = Instant.EPOCH.plusSeconds(300),
+                nickname = "활성닉네임",
+            )
         fixture.pendingRepository.save(pending)
+        fixture.pendingRepository.save(activePending)
 
         val deletedCount = fixture.service.releaseConsumedSignupForMemberLoginId(pending.memberLoginId)
 
         assertThat(deletedCount).isEqualTo(1)
-        assertThat(fixture.pendingRepository.saved).isEmpty()
+        assertThat(fixture.pendingRepository.saved).containsExactly(activePending)
     }
 
     @Test
@@ -428,7 +439,7 @@ private class RecordingPendingOAuthSignupRepository : PendingOAuthSignupReposito
 
     override fun deleteByMemberLoginId(memberLoginId: String): Int {
         val beforeCount = saved.size
-        saved.removeIf { it.memberLoginId == memberLoginId }
+        saved.removeIf { it.memberLoginId == memberLoginId && it.consumedAt != null }
         return beforeCount - saved.size
     }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionServiceTest.kt
@@ -263,6 +263,17 @@ class MemberSessionServiceTest {
             return sessionsToRevoke.size
         }
 
+        override fun revokeAllActiveSessionsForMember(
+            memberId: Long,
+            now: Instant,
+        ): Int {
+            val activeSessions =
+                sessionsByKey.values
+                    .filter { it.member.id == memberId && it.revokedAt == null }
+            activeSessions.forEach { it.revoke(now) }
+            return activeSessions.size
+        }
+
         override fun deleteRevokedBefore(
             cutoff: Instant,
             limit: Int,

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionServiceTest.kt
@@ -6,6 +6,7 @@ import com.back.boundedContexts.member.subContexts.session.application.port.outp
 import com.back.boundedContexts.member.subContexts.session.model.MemberSession
 import com.back.boundedContexts.member.subContexts.session.model.MemberSessionAuthSnapshot
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
@@ -128,6 +129,41 @@ class MemberSessionServiceTest {
     }
 
     @Test
+    fun `삭제된 회원은 세션을 생성할 수 없다`() {
+        val store = RecordingMemberSessionStorePort()
+        val service =
+            MemberSessionService(
+                memberSessionStorePort = store,
+                cacheManager = ConcurrentMapCacheManager(),
+                touchMinIntervalSeconds = 60,
+                refreshTokenExpirationSeconds = 3600,
+            )
+        val member =
+            Member(
+                58L,
+                "deleted-session-user",
+                null,
+                "삭제세션",
+                "deleted-session@example.com",
+                MemberPolicy.genApiKey(),
+            ).apply {
+                softDelete(Instant.parse("2026-06-21T00:00:00Z"))
+            }
+        store.deletedMemberIds += member.id
+
+        assertThatThrownBy {
+            service.createSessionWithRefreshToken(
+                member = member,
+                rememberLoginEnabled = true,
+                ipSecurityEnabled = true,
+                ipSecurityFingerprint = "fingerprint",
+                createdIp = "203.0.113.33",
+                userAgent = "test-agent",
+            )
+        }.hasMessage("409-1 : 탈퇴 처리된 계정은 세션을 생성할 수 없습니다.")
+    }
+
+    @Test
     fun `snapshot lastAuthenticatedAt 이 최소 간격 이내면 DB touch update를 생략한다`() {
         val store = RecordingMemberSessionStorePort()
         val service =
@@ -209,12 +245,23 @@ class MemberSessionServiceTest {
         var touchCallCount: Int = 0
         var lastTouchedSessionId: Long? = null
         var lastRevokedBeyondLimit: Int? = null
+        val deletedMemberIds = mutableSetOf<Long>()
         private val sessionsByKey = linkedMapOf<String, MemberSession>()
 
         override fun save(memberSession: MemberSession): MemberSession {
             sessionsByKey[memberSession.sessionKey] = memberSession
             return memberSession
         }
+
+        override fun findActiveMemberForSessionIssue(memberId: Long): Member? =
+            if (memberId in deletedMemberIds) {
+                null
+            } else {
+                sessionsByKey.values
+                    .firstOrNull { it.member.id == memberId }
+                    ?.member
+                    ?: Member(memberId, "member-$memberId", null, "회원", "member-$memberId@example.com", MemberPolicy.genApiKey())
+            }
 
         override fun findBySessionKey(sessionKey: String): MemberSession? = sessionsByKey[sessionKey]
 

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/application/service/MemberSessionServiceTest.kt
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.Instant
 
 @DisplayName("MemberSessionService 테스트")
@@ -161,6 +162,44 @@ class MemberSessionServiceTest {
                 userAgent = "test-agent",
             )
         }.hasMessage("409-1 : 탈퇴 처리된 계정은 세션을 생성할 수 없습니다.")
+    }
+
+    @Test
+    fun `회원 전체 세션 폐기는 커밋 후에도 active session cache를 다시 비운다`() {
+        val cacheManager = ConcurrentMapCacheManager(MemberSessionCacheNames.ACTIVE)
+        val store = RecordingMemberSessionStorePort()
+        val service =
+            MemberSessionService(
+                memberSessionStorePort = store,
+                cacheManager = cacheManager,
+                touchMinIntervalSeconds = 60,
+                refreshTokenExpirationSeconds = 3600,
+            )
+        val member = Member(59L, "session-revoke-all-user", null, "전체폐기", "session-revoke-all@example.com", MemberPolicy.genApiKey())
+        val session = memberSession(member, "revoke-all-session")
+        store.save(session)
+        val activeCache = requireNotNull(cacheManager.getCache(MemberSessionCacheNames.ACTIVE))
+        activeCache.put("session:${session.sessionKey}", "pre-revoke")
+        activeCache.put("member:${member.id}:session:${session.sessionKey}", "pre-revoke")
+
+        TransactionSynchronizationManager.initSynchronization()
+        try {
+            val revokedCount = service.revokeAllActiveSessionsForMember(member.id)
+            activeCache.put("session:${session.sessionKey}", "stale-repopulated-before-commit")
+            activeCache.put("member:${member.id}:session:${session.sessionKey}", "stale-repopulated-before-commit")
+
+            assertThat(revokedCount).isEqualTo(1)
+            assertThat(activeCache.get("session:${session.sessionKey}")?.get()).isEqualTo("stale-repopulated-before-commit")
+
+            TransactionSynchronizationManager.getSynchronizations().forEach { synchronization ->
+                synchronization.afterCommit()
+            }
+
+            assertThat(activeCache.get("session:${session.sessionKey}")).isNull()
+            assertThat(activeCache.get("member:${member.id}:session:${session.sessionKey}")).isNull()
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization()
+        }
     }
 
     @Test

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/job/MemberSessionCleanupScheduledJobTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/job/MemberSessionCleanupScheduledJobTest.kt
@@ -75,6 +75,11 @@ class MemberSessionCleanupScheduledJobTest {
             now: Instant,
         ): Int = 0
 
+        override fun revokeAllActiveSessionsForMember(
+            memberId: Long,
+            now: Instant,
+        ): Int = 0
+
         override fun deleteRevokedBefore(
             cutoff: Instant,
             limit: Int,

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/job/MemberSessionCleanupScheduledJobTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/session/job/MemberSessionCleanupScheduledJobTest.kt
@@ -45,6 +45,9 @@ class MemberSessionCleanupScheduledJobTest {
             return memberSession
         }
 
+        override fun findActiveMemberForSessionIssue(memberId: Long): Member? =
+            sessionsByKey.values.firstOrNull { it.member.id == memberId }?.member
+
         override fun findBySessionKey(sessionKey: String): MemberSession? = sessionsByKey[sessionKey]
 
         override fun findBySessionKeyAndRevokedAtIsNull(sessionKey: String): MemberSession? = null

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationControllerTest.kt
@@ -345,6 +345,40 @@ class ApiV1SignupVerificationControllerTest : BaseControllerIntegrationTest() {
         }
 
         @Test
+        fun `signup complete 요청에서 비밀번호에 공백이 있으면 최종 가입을 막는다`() {
+            val email = "signup-space-password@example.com"
+            val signupSessionCookie = issueSignupSessionCookie(email)
+
+            mvc
+                .post("/member/api/v1/signup/complete") {
+                    contentType = MediaType.APPLICATION_JSON
+                    cookie(signupSessionCookie)
+                    content =
+                        """
+                        {
+                            "password": "Abcd 1234!",
+                            "nickname": "공백비밀번호",
+                            "termsVersion": "${activeLegalDocuments.terms.version}",
+                            "termsContentSha256": "${activeLegalDocuments.terms.contentSha256}",
+                            "privacyVersion": "${activeLegalDocuments.privacy.version}",
+                            "privacyContentSha256": "${activeLegalDocuments.privacy.contentSha256}",
+                            "age14OrOlder": true,
+                            "requiredPrivacyConfirmed": true,
+                            "analyticsConsent": false,
+                            "overseasTransferAcknowledged": true
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isBadRequest() }
+                    match(handler().handlerType(ApiV1SignupVerificationController::class.java))
+                    match(handler().methodName("complete"))
+                    jsonPath("$.resultCode") { value("400-1") }
+                }
+
+            assertThat(memberApplicationService.findByEmail(email)).isNull()
+        }
+
+        @Test
         fun `동의 기록이 없는 기존 signup session이면 최종 가입을 막는다`() {
             val email = "legacy-without-consent@example.com"
 

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/event/PostReadModelTaskEventListenerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/event/PostReadModelTaskEventListenerTest.kt
@@ -8,6 +8,7 @@ import com.back.boundedContexts.post.dto.PostDto
 import com.back.boundedContexts.post.dto.PostReadPrewarmPayload
 import com.back.boundedContexts.post.dto.PostSearchEngineMirrorPayload
 import com.back.boundedContexts.post.dto.PostSearchIndexSyncPayload
+import com.back.boundedContexts.post.event.PostAccountDeletionDeletedEvent
 import com.back.boundedContexts.post.event.PostWrittenEvent
 import com.back.global.task.application.TaskFacade
 import com.back.global.task.application.TaskHandlerEntry
@@ -74,6 +75,42 @@ class PostReadModelTaskEventListenerTest {
             .isInstanceOf(RuntimeException::class.java)
             .hasMessage("enqueue down")
         assertThat(thrown.suppressed).hasSize(2)
+    }
+
+    @Test
+    @DisplayName("계정 탈퇴 삭제 이벤트는 개인정보 DTO 없이 search/read-model 삭제 cleanup을 enqueue한다")
+    fun `account deletion deleted event enqueues sanitized search cleanup`() {
+        val repository = RecordingTaskQueueRepository()
+        val listener =
+            createListener(
+                taskFacade = createTaskFacade(repository),
+            )
+        val event =
+            PostAccountDeletionDeletedEvent(
+                uid = UUID.randomUUID(),
+                aggregateId = 91L,
+                beforeTags = listOf("privacy", "retention"),
+            )
+
+        listener.handle(event)
+
+        assertThat(repository.savedTasks.map { it.taskType }).containsExactly(
+            "post.search-index.sync",
+            "post.search-engine.mirror",
+        )
+        val objectMapper = ObjectMapper()
+        val searchIndexPayload =
+            objectMapper.readValue(repository.savedTasks[0].payload, PostSearchIndexSyncPayload::class.java)
+        val mirrorPayload =
+            objectMapper.readValue(repository.savedTasks[1].payload, PostSearchEngineMirrorPayload::class.java)
+        assertThat(searchIndexPayload.postId).isEqualTo(91L)
+        assertThat(searchIndexPayload.forceClear).isTrue()
+        assertThat(mirrorPayload.postId).isEqualTo(91L)
+        assertThat(mirrorPayload.deleted).isTrue()
+        assertThat(mirrorPayload.tags).containsExactly("privacy", "retention")
+        assertThat(repository.savedTasks.joinToString("\n") { it.payload })
+            .doesNotContain("postDto")
+            .doesNotContain("actorDto")
     }
 
     private fun createListener(taskFacade: TaskFacade): PostReadModelTaskEventListener =

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/event/PostReadModelTaskEventListenerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/event/PostReadModelTaskEventListenerTest.kt
@@ -90,6 +90,7 @@ class PostReadModelTaskEventListenerTest {
                 uid = UUID.randomUUID(),
                 aggregateId = 91L,
                 beforeTags = listOf("privacy", "retention"),
+                afterTags = emptyList(),
             )
 
         listener.handle(event)

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationUseCaseCollaboratorTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationUseCaseCollaboratorTest.kt
@@ -297,6 +297,42 @@ class PostApplicationUseCaseCollaboratorTest {
         then(postCommentRepository).should(never()).save(anyValue())
     }
 
+    @Test
+    @DisplayName("PostCommentApplicationService는 공개 댓글 삭제 시 도메인 이벤트를 큐에 넣는다")
+    fun postCommentApplicationServiceDeletesCommentWithDomainEvent() {
+        // given
+        val postRepository: PostRepositoryPort = mock(PostRepositoryPort::class.java)
+        val postCommentRepository: PostCommentRepositoryPort = mock(PostCommentRepositoryPort::class.java)
+        val hydrationService: PostHydrationService = mock(PostHydrationService::class.java)
+        val counterService: PostCounterService = mock(PostCounterService::class.java)
+        val sideEffectQueue: PostInteractionSideEffectQueue = mock(PostInteractionSideEffectQueue::class.java)
+        val service =
+            PostCommentApplicationService(
+                postRepository = postRepository,
+                postCommentRepository = postCommentRepository,
+                postHydrationService = hydrationService,
+                postCounterService = counterService,
+                postInteractionSideEffectQueue = sideEffectQueue,
+            )
+        val author = testMember(id = 2)
+        val post = testPost()
+        val comment =
+            PostComment(7, author, post, "삭제할 댓글").also {
+                val now = Instant.now()
+                it.createdAt = now
+                it.modifiedAt = now
+            }
+        given(postCommentRepository.findActiveSubtreeByPostAndRootCommentId(post, comment.id))
+            .willReturn(listOf(comment))
+
+        // when
+        service.deleteComment(post, comment, author)
+
+        // then
+        assertThat(comment.deletedAt).isNotNull()
+        then(postRepository).should().flush()
+    }
+
     private fun testMember(id: Long = 1): Member =
         Member(id = id, username = "user-$id", nickname = "작성자$id", apiKey = "api-key-$id").also {
             val now = Instant.now()

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationUseCaseCollaboratorTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostApplicationUseCaseCollaboratorTest.kt
@@ -14,6 +14,7 @@ import com.back.boundedContexts.post.domain.PostAttr
 import com.back.boundedContexts.post.domain.PostComment
 import com.back.boundedContexts.post.domain.PostLike
 import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
+import com.back.boundedContexts.post.event.PostCommentDeletedEvent
 import com.back.global.app.AppConfig
 import com.back.global.exception.application.AppException
 import org.assertj.core.api.Assertions.assertThat
@@ -24,6 +25,7 @@ import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
 import org.mockito.Mockito.any
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockingDetails
 import org.mockito.Mockito.never
 import java.time.Instant
 import java.util.Optional
@@ -331,6 +333,10 @@ class PostApplicationUseCaseCollaboratorTest {
         // then
         assertThat(comment.deletedAt).isNotNull()
         then(postRepository).should().flush()
+        val enqueueInvocation = mockingDetails(sideEffectQueue).invocations.single { it.method.name == "enqueue" }
+        assertThat(enqueueInvocation.arguments[0]).isEqualTo(post.id)
+        assertThat(enqueueInvocation.arguments[1]).isEqualTo(PostInteractionRecommendationSideEffect.REFRESH)
+        assertThat(enqueueInvocation.arguments[2]).isInstanceOf(PostCommentDeletedEvent::class.java)
     }
 
     private fun testMember(id: Long = 1): Member =

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandlerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandlerTest.kt
@@ -319,6 +319,7 @@ class PostWriteSideEffectHandlerTest {
                 uid = UUID.randomUUID(),
                 aggregateId = 33L,
                 beforeTags = listOf("privacy"),
+                afterTags = emptyList(),
             )
         val payload =
             postWriteSideEffectPayload(

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandlerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostWriteSideEffectHandlerTest.kt
@@ -10,6 +10,7 @@ import com.back.boundedContexts.post.domain.postMixin.COMMENTS_COUNT
 import com.back.boundedContexts.post.domain.postMixin.HIT_COUNT
 import com.back.boundedContexts.post.domain.postMixin.LIKES_COUNT
 import com.back.boundedContexts.post.dto.PostDto
+import com.back.boundedContexts.post.event.PostAccountDeletionDeletedEvent
 import com.back.boundedContexts.post.event.PostDeletedEvent
 import com.back.global.event.application.EventPublisher
 import com.back.global.storage.application.UploadedFileRetentionService
@@ -307,6 +308,56 @@ class PostWriteSideEffectHandlerTest {
 
         // then
         assertThat(applicationEventPublisher.publishedEvent).isInstanceOf(PostDeletedEvent::class.java)
+    }
+
+    @Test
+    @DisplayName("계정 탈퇴 삭제 domain event payload는 durable task 처리 중 복원해 발행한다")
+    fun publishAccountDeletionDeletedDomainEventFromTaskPayload() {
+        // given
+        val domainEvent =
+            PostAccountDeletionDeletedEvent(
+                uid = UUID.randomUUID(),
+                aggregateId = 33L,
+                beforeTags = listOf("privacy"),
+            )
+        val payload =
+            postWriteSideEffectPayload(
+                postId = 33L,
+                recommendationAction = PostRecommendationSideEffect.EVICT,
+                domainEventType = PostAccountDeletionDeletedEvent::class.java.name,
+                domainEventJson = ObjectMapper().writeValueAsString(domainEvent),
+            )
+
+        // when
+        val applicationEventPublisher = RecordingApplicationEventPublisher()
+        newHandler(EventPublisher(applicationEventPublisher)).handle(payload)
+
+        // then
+        val publishedEvent = applicationEventPublisher.publishedEvent
+        assertThat(publishedEvent).isInstanceOf(PostAccountDeletionDeletedEvent::class.java)
+        assertThat((publishedEvent as PostAccountDeletionDeletedEvent).beforeTags).containsExactly("privacy")
+    }
+
+    @Test
+    @DisplayName("domain event 없는 durable task payload도 삭제 첨부 정리와 추천 갱신을 수행한다")
+    fun handleTaskPayloadWithoutDomainEvent() {
+        // given
+        val post = testPost(34L)
+        `when`(postRepository.findById(34L)).thenReturn(Optional.of(post))
+        val payload =
+            postWriteSideEffectPayload(
+                postId = 34L,
+                deletedContent = "deleted content",
+                recommendationAction = PostRecommendationSideEffect.REFRESH,
+            )
+
+        // when
+        handler.handle(payload)
+
+        // then
+        verify(uploadedFileRetentionService).scheduleDeletedPostAttachments("deleted content")
+        verify(postRecommendFeatureStoreService).refresh(post)
+        verifyNoInteractions(eventPublisher)
     }
 
     @Test

--- a/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
@@ -114,6 +114,44 @@ class CustomAuthenticationFilterTest {
     }
 
     @Test
+    @DisplayName("세션 resolver는 fresh token grace 구간의 read 요청을 fallback으로 허용한다")
+    fun `session resolver allows fresh token read fallback`() {
+        val memberSessionUseCase = mock(MemberSessionUseCase::class.java)
+        val authCookieService = mock(AuthCookieService::class.java)
+        val resolver =
+            MemberSessionAuthenticationResolver(
+                memberSessionUseCase = memberSessionUseCase,
+                authCookieService = authCookieService,
+                freshLookupGraceSeconds = 15,
+            )
+        val request = MockHttpServletRequest("GET", "/member/api/v1/auth/session\r\n")
+        val payload =
+            AccessTokenPayload(
+                id = 7L,
+                sessionKey = "fresh-session-key",
+                username = "fresh-user",
+                email = "fresh-user@example.com",
+                name = "Fresh User",
+                rememberLoginEnabled = false,
+                ipSecurityEnabled = false,
+                ipSecurityFingerprint = null,
+                issuedAt = Instant.now(),
+                expiresAt = Instant.now().plusSeconds(60),
+            )
+
+        val resolution =
+            resolver.resolve(
+                memberId = 7L,
+                cookieSessionKey = "fresh-session-key",
+                tokenSessionKey = null,
+                payload = payload,
+                request = request,
+            )
+
+        assertThat(resolution.freshTokenFallback).isTrue()
+    }
+
+    @Test
     @DisplayName("legacy payload에 email과 username이 없고 DB 회원도 없으면 member id 기반 principal로 인증한다")
     fun `legacy payload without persisted member falls back to member id principal`() {
         val fixture = CustomAuthenticationFilterFixture()

--- a/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/CustomAuthenticationFilterTest.kt
@@ -501,6 +501,8 @@ class CustomAuthenticationFilterTest {
                 ),
             )
         given(fixture.memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(null)
+        given(fixture.actorApplicationService.findById(54L))
+            .willReturn(Member(54L, "internal-admin", null, "aquila", "admin@test.com"))
 
         val response = MockHttpServletResponse()
         val filterChain = fixture.noContentFilterChain()
@@ -509,6 +511,47 @@ class CustomAuthenticationFilterTest {
             fixture.authenticationFilter().doFilter(request, response, filterChain)
             assertThat(response.status).isEqualTo(HttpServletResponse.SC_NO_CONTENT)
             verify(fixture.authCookieService, never()).expireAuthCookies()
+        } finally {
+            SecurityContextHolder.clearContext()
+        }
+    }
+
+    @Test
+    @DisplayName("로그인 직후 GET read 요청도 삭제된 계정이면 fresh token fallback 인증을 거절한다")
+    fun `fresh token fallback rejects deleted account read request`() {
+        val fixture = CustomAuthenticationFilterFixture()
+        val request = MockHttpServletRequest("GET", "/member/api/v1/auth/session")
+        val accessToken = "fresh-deleted-access-token"
+        val sessionKey = "fresh-deleted-session-key"
+
+        fixture.givenProtectedRequest(request)
+        fixture.givenBearerAccessToken(accessToken, sessionKey)
+        fixture.givenClientIp(request, "203.0.113.17")
+        given(fixture.actorApplicationService.payload(accessToken))
+            .willReturn(
+                AccessTokenPayload(
+                    id = 54L,
+                    sessionKey = sessionKey,
+                    username = "deleted-54",
+                    email = null,
+                    name = "탈퇴한 사용자",
+                    rememberLoginEnabled = true,
+                    ipSecurityEnabled = false,
+                    ipSecurityFingerprint = null,
+                    issuedAt = Instant.now(),
+                ),
+            )
+        given(fixture.memberSessionUseCase.findActiveSessionSnapshot(54L, sessionKey)).willReturn(null)
+        given(fixture.actorApplicationService.findById(54L)).willReturn(null)
+
+        val response = MockHttpServletResponse()
+        val filterChain = MockFilterChain()
+
+        try {
+            fixture.authenticationFilter().doFilter(request, response, filterChain)
+            assertThat(response.status).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED)
+            assertThat(response.contentAsString).contains("\"resultCode\":\"401-8\"")
+            verify(fixture.authCookieService).expireAuthCookies()
         } finally {
             SecurityContextHolder.clearContext()
         }

--- a/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserServiceTest.kt
@@ -302,4 +302,7 @@ private class RecordingOAuthSignupUseCase : OAuthSignupUseCase {
         nickname: String?,
         legalAcceptance: LegalAcceptanceCommand,
     ): Member = error("completeSignup is not used in CustomOAuth2UserServiceTest")
+
+    override fun releaseConsumedSignupForMemberLoginId(memberLoginId: String): Int =
+        error("releaseConsumedSignupForMemberLoginId is not used in CustomOAuth2UserServiceTest")
 }

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -4423,7 +4423,8 @@
             "maxLength" : 1000,
             "minLength" : 0
           }
-        }
+        },
+        "required" : [ "type" ]
       },
       "PrivacyRequestDto" : {
         "type" : "object",
@@ -5908,7 +5909,7 @@
           "password" : {
             "type" : "string",
             "maxLength" : 128,
-            "minLength" : 0
+            "minLength" : 1
           },
           "reason" : {
             "type" : "string",

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -1113,6 +1113,34 @@
         }
       }
     },
+    "/member/api/v1/privacy/requests" : {
+      "post" : {
+        "tags" : [ "api-v-1-privacy-rights-controller" ],
+        "operationId" : "createRequest",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PrivacyRequestCreateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RsDataPrivacyRequestResBody"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/member/api/v1/notifications/{id}/read" : {
       "post" : {
         "tags" : [ "api-v-1-member-notification-controller" ],
@@ -2406,6 +2434,51 @@
         "security" : [ {
           "bearerAuth" : [ ]
         } ]
+      }
+    },
+    "/member/api/v1/privacy/requests/{requestId}" : {
+      "get" : {
+        "tags" : [ "api-v-1-privacy-rights-controller" ],
+        "operationId" : "getRequest",
+        "parameters" : [ {
+          "name" : "requestId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RsDataPrivacyRequestResBody"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/member/api/v1/privacy/export" : {
+      "get" : {
+        "tags" : [ "api-v-1-privacy-rights-controller" ],
+        "operationId" : "export",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RsDataPrivacyExportResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/member/api/v1/notifications" : {
@@ -4310,6 +4383,78 @@
         },
         "required" : [ "age14OrOlder", "analyticsConsent", "nickname", "overseasTransferAcknowledged", "password", "privacyContentSha256", "privacyVersion", "requiredPrivacyConfirmed", "termsContentSha256", "termsVersion" ]
       },
+      "PrivacyRequestCreateRequest" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "enum" : [ "EXPORT", "CORRECTION", "DELETION", "PROCESSING_RESTRICTION", "CONSENT_WITHDRAWAL" ]
+          },
+          "message" : {
+            "type" : "string",
+            "maxLength" : 1000,
+            "minLength" : 0
+          }
+        }
+      },
+      "PrivacyRequestDto" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "memberId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "EXPORT", "CORRECTION", "DELETION", "PROCESSING_RESTRICTION", "CONSENT_WITHDRAWAL" ]
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "RECEIVED", "IN_PROGRESS", "COMPLETED", "REJECTED" ]
+          },
+          "message" : {
+            "type" : "string"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "dueAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }
+      },
+      "PrivacyRequestResBody" : {
+        "type" : "object",
+        "properties" : {
+          "item" : {
+            "$ref" : "#/components/schemas/PrivacyRequestDto"
+          }
+        }
+      },
+      "RsDataPrivacyRequestResBody" : {
+        "type" : "object",
+        "properties" : {
+          "resultCode" : {
+            "type" : "string"
+          },
+          "msg" : {
+            "type" : "string"
+          },
+          "data" : {
+            "$ref" : "#/components/schemas/PrivacyRequestResBody"
+          }
+        }
+      },
       "RsDataMapStringBoolean" : {
         "type" : "object",
         "properties" : {
@@ -5468,6 +5613,97 @@
           },
           "firstPage" : {
             "$ref" : "#/components/schemas/PageDtoPostDto"
+          }
+        }
+      },
+      "PrivacyExportMemberSnapshot" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "email" : {
+            "type" : "string"
+          },
+          "username" : {
+            "type" : "string"
+          },
+          "nickname" : {
+            "type" : "string"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "modifiedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }
+      },
+      "PrivacyExportResponse" : {
+        "type" : "object",
+        "properties" : {
+          "generatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "member" : {
+            "$ref" : "#/components/schemas/PrivacyExportMemberSnapshot"
+          },
+          "latestLegalAcceptance" : {
+            "$ref" : "#/components/schemas/PrivacyLegalAcceptanceSnapshot"
+          }
+        }
+      },
+      "PrivacyLegalAcceptanceSnapshot" : {
+        "type" : "object",
+        "properties" : {
+          "termsVersion" : {
+            "type" : "string"
+          },
+          "termsContentSha256" : {
+            "type" : "string"
+          },
+          "privacyVersion" : {
+            "type" : "string"
+          },
+          "privacyContentSha256" : {
+            "type" : "string"
+          },
+          "age14OrOlder" : {
+            "type" : "boolean"
+          },
+          "requiredPrivacyConfirmed" : {
+            "type" : "boolean"
+          },
+          "analyticsConsent" : {
+            "type" : "boolean"
+          },
+          "overseasTransferAcknowledged" : {
+            "type" : "boolean"
+          },
+          "source" : {
+            "type" : "string"
+          },
+          "acceptedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }
+      },
+      "RsDataPrivacyExportResponse" : {
+        "type" : "object",
+        "properties" : {
+          "resultCode" : {
+            "type" : "string"
+          },
+          "msg" : {
+            "type" : "string"
+          },
+          "data" : {
+            "$ref" : "#/components/schemas/PrivacyExportResponse"
           }
         }
       },

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -2891,6 +2891,34 @@
         } ]
       }
     },
+    "/member/api/v1/privacy/account" : {
+      "delete" : {
+        "tags" : [ "api-v-1-privacy-rights-controller" ],
+        "operationId" : "deleteAccount",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/AccountDeletionRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RsDataAccountDeletionResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/member/api/v1/auth/logout" : {
       "delete" : {
         "tags" : [ "api-v-1-auth-controller" ],
@@ -5871,6 +5899,53 @@
           },
           "profile" : {
             "$ref" : "#/components/schemas/MemberWithUsernameDto"
+          }
+        }
+      },
+      "AccountDeletionRequest" : {
+        "type" : "object",
+        "properties" : {
+          "password" : {
+            "type" : "string",
+            "maxLength" : 128,
+            "minLength" : 0
+          },
+          "reason" : {
+            "type" : "string",
+            "maxLength" : 500,
+            "minLength" : 0
+          }
+        },
+        "required" : [ "password" ]
+      },
+      "AccountDeletionResult" : {
+        "type" : "object",
+        "properties" : {
+          "memberId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "deletedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "revokedSessionCount" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      },
+      "RsDataAccountDeletionResult" : {
+        "type" : "object",
+        "properties" : {
+          "resultCode" : {
+            "type" : "string"
+          },
+          "msg" : {
+            "type" : "string"
+          },
+          "data" : {
+            "$ref" : "#/components/schemas/AccountDeletionResult"
           }
         }
       }

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -5911,13 +5911,15 @@
             "maxLength" : 128,
             "minLength" : 1
           },
+          "oauthAccountDeletionConfirmed" : {
+            "type" : "boolean"
+          },
           "reason" : {
             "type" : "string",
             "maxLength" : 500,
             "minLength" : 0
           }
-        },
-        "required" : [ "password" ]
+        }
       },
       "AccountDeletionResult" : {
         "type" : "object",

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -4369,7 +4369,7 @@
             "type" : "string",
             "maxLength" : 64,
             "minLength" : 8,
-            "pattern" : "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{8,64}$"
+            "pattern" : "^(?=\\S{8,64}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9\\s]).*$"
           },
           "nickname" : {
             "type" : "string",
@@ -4531,7 +4531,7 @@
             "type" : "string",
             "maxLength" : 64,
             "minLength" : 8,
-            "pattern" : "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{8,64}$"
+            "pattern" : "^(?=\\S{8,64}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9\\s]).*$"
           },
           "nickname" : {
             "type" : "string",

--- a/front/e2e/settings-privacy-account.spec.ts
+++ b/front/e2e/settings-privacy-account.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "@playwright/test"
+
+const authMember = {
+  id: 901,
+  createdAt: "2026-06-21T00:00:00Z",
+  modifiedAt: "2026-06-22T00:00:00Z",
+  username: "privacy-user",
+  nickname: "권리행사",
+  isAdmin: false,
+}
+
+test("settings privacy page exposes export snapshot and creates privacy request", async ({ page }) => {
+  let createdRequestBody: Record<string, unknown> | null = null
+
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(authMember),
+    })
+  })
+  await page.route("**/member/api/v1/privacy/export", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "200-1",
+        msg: "개인정보 내보내기 데이터를 조회했습니다.",
+        data: {
+          generatedAt: "2026-06-22T01:00:00Z",
+          member: {
+            id: authMember.id,
+            email: "privacy-user@example.com",
+            username: authMember.username,
+            nickname: authMember.nickname,
+            createdAt: authMember.createdAt,
+            modifiedAt: authMember.modifiedAt,
+          },
+          latestLegalAcceptance: {
+            termsVersion: "2026-06-21",
+            privacyVersion: "2026-06-21",
+            analyticsConsent: false,
+            overseasTransferAcknowledged: true,
+            acceptedAt: "2026-06-21T00:10:00Z",
+          },
+        },
+      }),
+    })
+  })
+  await page.route("**/member/api/v1/privacy/requests", async (route) => {
+    createdRequestBody = route.request().postDataJSON()
+    await route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "201-1",
+        msg: "개인정보 처리 요청을 접수했습니다.",
+        data: {
+          item: {
+            id: 77,
+            memberId: authMember.id,
+            type: "EXPORT",
+            status: "RECEIVED",
+            message: createdRequestBody?.message,
+            requestedAt: "2026-06-22T01:01:00Z",
+            dueAt: "2026-07-22T01:01:00Z",
+            completedAt: null,
+          },
+        },
+      }),
+    })
+  })
+
+  await page.goto("/settings/privacy")
+
+  await expect(page.getByRole("heading", { name: "개인정보 관리" })).toBeVisible()
+  await expect(page.getByText("privacy-user@example.com")).toBeVisible()
+  await expect(page.getByText("개인정보처리방침 2026-06-21")).toBeVisible()
+
+  await page.getByLabel("요청 사유").fill("가입 정보와 운영 로그 열람을 요청합니다.")
+  await page.getByRole("button", { name: "처리 요청 접수" }).click()
+
+  await expect(page.getByText("개인정보 처리 요청을 접수했습니다.")).toBeVisible()
+  await expect(page.getByText("접수 번호 77")).toBeVisible()
+  expect(createdRequestBody).toMatchObject({
+    type: "EXPORT",
+    message: "가입 정보와 운영 로그 열람을 요청합니다.",
+  })
+})
+
+test("settings account page deletes account after password reauthentication", async ({ page }) => {
+  let deletionRequestBody: Record<string, unknown> | null = null
+
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(authMember),
+    })
+  })
+  await page.route("**/member/api/v1/privacy/account", async (route) => {
+    deletionRequestBody = route.request().postDataJSON()
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "200-1",
+        msg: "계정 탈퇴가 완료되었습니다.",
+        data: {
+          memberId: authMember.id,
+          deletedAt: "2026-06-22T01:10:00Z",
+          revokedSessionCount: 2,
+        },
+      }),
+    })
+  })
+
+  await page.goto("/settings/account")
+
+  await expect(page.getByRole("heading", { name: "계정 보안" })).toBeVisible()
+  await page.getByLabel("비밀번호 재확인").fill("Abcd1234!")
+  await page.getByLabel("탈퇴 사유").fill("서비스 이용 종료")
+  await page.getByRole("checkbox", { name: "계정 탈퇴 영향을 확인했습니다." }).check()
+  await page.getByRole("button", { name: "계정 탈퇴" }).click()
+
+  await expect(page.getByText("계정 탈퇴가 완료되었습니다.")).toBeVisible()
+  await expect(page.getByText("폐기된 세션 2개")).toBeVisible()
+  expect(deletionRequestBody).toMatchObject({
+    password: "Abcd1234!",
+    reason: "서비스 이용 종료",
+  })
+})

--- a/front/e2e/settings-privacy-account.spec.ts
+++ b/front/e2e/settings-privacy-account.spec.ts
@@ -118,7 +118,7 @@ test("settings account page deletes account after password reauthentication", as
   await page.goto("/settings/account")
 
   await expect(page.getByRole("heading", { name: "계정 보안" })).toBeVisible()
-  await page.getByLabel("비밀번호 재확인").fill("Abcd1234!")
+  await page.getByLabel("비밀번호 재확인 (이메일 계정)").fill("Abcd1234!")
   await page.getByLabel("탈퇴 사유").fill("서비스 이용 종료")
   await page.getByRole("checkbox", { name: "계정 탈퇴 영향을 확인했습니다." }).check()
   await page.getByRole("button", { name: "계정 탈퇴" }).click()
@@ -129,4 +129,46 @@ test("settings account page deletes account after password reauthentication", as
     password: "Abcd1234!",
     reason: "서비스 이용 종료",
   })
+})
+
+test("settings account page sends oauth confirmation when password is empty", async ({ page }) => {
+  let deletionRequestBody: Record<string, unknown> | null = null
+
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(authMember),
+    })
+  })
+  await page.route("**/member/api/v1/privacy/account", async (route) => {
+    deletionRequestBody = route.request().postDataJSON()
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resultCode: "200-1",
+        msg: "계정 탈퇴가 완료되었습니다.",
+        data: {
+          memberId: authMember.id,
+          deletedAt: "2026-06-22T01:20:00Z",
+          revokedSessionCount: 1,
+        },
+      }),
+    })
+  })
+
+  await page.goto("/settings/account")
+
+  await expect(page.getByText("비밀번호가 없는 소셜 계정은 비워두고 확인 체크 후 진행합니다.")).toBeVisible()
+  await page.getByLabel("탈퇴 사유").fill("소셜 계정 탈퇴")
+  await page.getByRole("checkbox", { name: "계정 탈퇴 영향을 확인했습니다." }).check()
+  await page.getByRole("button", { name: "계정 탈퇴" }).click()
+
+  await expect(page.getByText("계정 탈퇴가 완료되었습니다.")).toBeVisible()
+  expect(deletionRequestBody).toMatchObject({
+    oauthAccountDeletionConfirmed: true,
+    reason: "소셜 계정 탈퇴",
+  })
+  expect(deletionRequestBody).not.toHaveProperty("password")
 })

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -406,6 +406,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/member/api/v1/privacy/requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["createRequest"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/member/api/v1/notifications/{id}/read": {
         parameters: {
             query?: never;
@@ -1028,6 +1044,38 @@ export interface paths {
         };
         /** 관리자 글 작업공간 bootstrap */
         get: operations["bootstrap_1"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/member/api/v1/privacy/requests/{requestId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getRequest"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/member/api/v1/privacy/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["export"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1833,6 +1881,36 @@ export interface components {
             analyticsConsent: boolean;
             overseasTransferAcknowledged: boolean;
         };
+        PrivacyRequestCreateRequest: {
+            /** @enum {string} */
+            type?: "EXPORT" | "CORRECTION" | "DELETION" | "PROCESSING_RESTRICTION" | "CONSENT_WITHDRAWAL";
+            message?: string;
+        };
+        PrivacyRequestDto: {
+            /** Format: int64 */
+            id?: number;
+            /** Format: int64 */
+            memberId?: number;
+            /** @enum {string} */
+            type?: "EXPORT" | "CORRECTION" | "DELETION" | "PROCESSING_RESTRICTION" | "CONSENT_WITHDRAWAL";
+            /** @enum {string} */
+            status?: "RECEIVED" | "IN_PROGRESS" | "COMPLETED" | "REJECTED";
+            message?: string;
+            /** Format: date-time */
+            requestedAt?: string;
+            /** Format: date-time */
+            dueAt?: string;
+            /** Format: date-time */
+            completedAt?: string;
+        };
+        PrivacyRequestResBody: {
+            item?: components["schemas"]["PrivacyRequestDto"];
+        };
+        RsDataPrivacyRequestResBody: {
+            resultCode?: string;
+            msg?: string;
+            data?: components["schemas"]["PrivacyRequestResBody"];
+        };
         RsDataMapStringBoolean: {
             resultCode?: string;
             msg?: string;
@@ -2270,6 +2348,41 @@ export interface components {
         AdminPostsBootstrapResBody: {
             member?: components["schemas"]["AuthSessionMemberDto"];
             firstPage?: components["schemas"]["PageDtoPostDto"];
+        };
+        PrivacyExportMemberSnapshot: {
+            /** Format: int64 */
+            id?: number;
+            email?: string;
+            username?: string;
+            nickname?: string;
+            /** Format: date-time */
+            createdAt?: string;
+            /** Format: date-time */
+            modifiedAt?: string;
+        };
+        PrivacyExportResponse: {
+            /** Format: date-time */
+            generatedAt?: string;
+            member?: components["schemas"]["PrivacyExportMemberSnapshot"];
+            latestLegalAcceptance?: components["schemas"]["PrivacyLegalAcceptanceSnapshot"];
+        };
+        PrivacyLegalAcceptanceSnapshot: {
+            termsVersion?: string;
+            termsContentSha256?: string;
+            privacyVersion?: string;
+            privacyContentSha256?: string;
+            age14OrOlder?: boolean;
+            requiredPrivacyConfirmed?: boolean;
+            analyticsConsent?: boolean;
+            overseasTransferAcknowledged?: boolean;
+            source?: string;
+            /** Format: date-time */
+            acceptedAt?: string;
+        };
+        RsDataPrivacyExportResponse: {
+            resultCode?: string;
+            msg?: string;
+            data?: components["schemas"]["PrivacyExportResponse"];
         };
         MemberNotificationDto: {
             /** Format: int64 */
@@ -3160,6 +3273,30 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["RsDataMemberDto"];
+                };
+            };
+        };
+    };
+    createRequest: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PrivacyRequestCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RsDataPrivacyRequestResBody"];
                 };
             };
         };
@@ -4083,6 +4220,48 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["AdminPostsBootstrapResBody"];
+                };
+            };
+        };
+    };
+    getRequest: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                requestId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RsDataPrivacyRequestResBody"];
+                };
+            };
+        };
+    };
+    export: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RsDataPrivacyExportResponse"];
                 };
             };
         };

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -2466,7 +2466,8 @@ export interface components {
             profile?: components["schemas"]["MemberWithUsernameDto"];
         };
         AccountDeletionRequest: {
-            password: string;
+            password?: string;
+            oauthAccountDeletionConfirmed?: boolean;
             reason?: string;
         };
         AccountDeletionResult: {

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -1358,6 +1358,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/member/api/v1/privacy/account": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: operations["deleteAccount"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/member/api/v1/auth/logout": {
         parameters: {
             query?: never;
@@ -2448,6 +2464,23 @@ export interface components {
         AdminHubBootstrapResponse: {
             member?: components["schemas"]["AuthSessionMemberDto"];
             profile?: components["schemas"]["MemberWithUsernameDto"];
+        };
+        AccountDeletionRequest: {
+            password: string;
+            reason?: string;
+        };
+        AccountDeletionResult: {
+            /** Format: int64 */
+            memberId?: number;
+            /** Format: date-time */
+            deletedAt?: string;
+            /** Format: int32 */
+            revokedSessionCount?: number;
+        };
+        RsDataAccountDeletionResult: {
+            resultCode?: string;
+            msg?: string;
+            data?: components["schemas"]["AccountDeletionResult"];
         };
     };
     responses: never;
@@ -4619,6 +4652,30 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    deleteAccount: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AccountDeletionRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RsDataAccountDeletionResult"];
                 };
             };
         };

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -1899,7 +1899,7 @@ export interface components {
         };
         PrivacyRequestCreateRequest: {
             /** @enum {string} */
-            type?: "EXPORT" | "CORRECTION" | "DELETION" | "PROCESSING_RESTRICTION" | "CONSENT_WITHDRAWAL";
+            type: "EXPORT" | "CORRECTION" | "DELETION" | "PROCESSING_RESTRICTION" | "CONSENT_WITHDRAWAL";
             message?: string;
         };
         PrivacyRequestDto: {

--- a/front/src/apis/backend/client.ts
+++ b/front/src/apis/backend/client.ts
@@ -372,6 +372,7 @@ const shouldUseBrowserBackendProxy = (safePath: string) => {
 
   return (
     safePath.startsWith("/member/api/v1/auth/") ||
+    safePath.startsWith("/member/api/v1/privacy/") ||
     safePath.startsWith("/member/api/v1/notifications/snapshot") ||
     safePath.startsWith("/member/api/v1/adm/") ||
     safePath.startsWith("/post/api/v1/posts/temp") ||

--- a/front/src/apis/backend/privacy.ts
+++ b/front/src/apis/backend/privacy.ts
@@ -1,0 +1,76 @@
+import { apiFetch } from "src/apis/backend/client"
+
+export type PrivacyRequestType =
+  | "EXPORT"
+  | "CORRECTION"
+  | "DELETION"
+  | "PROCESSING_RESTRICTION"
+  | "CONSENT_WITHDRAWAL"
+
+export type PrivacyRequestStatus = "RECEIVED" | "IN_PROGRESS" | "COMPLETED" | "REJECTED"
+
+export type PrivacyExportResponse = {
+  generatedAt: string
+  member: {
+    id: number
+    email: string | null
+    username: string
+    nickname: string
+    createdAt: string
+    modifiedAt: string
+  }
+  latestLegalAcceptance: {
+    termsVersion?: string
+    privacyVersion?: string
+    analyticsConsent?: boolean
+    overseasTransferAcknowledged?: boolean
+    acceptedAt?: string
+  } | null
+}
+
+export type PrivacyRequestItem = {
+  id: number
+  memberId: number
+  type: PrivacyRequestType
+  status: PrivacyRequestStatus
+  message: string | null
+  requestedAt: string
+  dueAt: string
+  completedAt: string | null
+}
+
+export type AccountDeletionResult = {
+  memberId: number
+  deletedAt: string
+  revokedSessionCount: number
+}
+
+type RsData<T> = {
+  resultCode: string
+  msg: string
+  data: T
+}
+
+const PRIVACY_EXPORT_PATH = "/member/api/v1/privacy/export"
+const PRIVACY_REQUESTS_PATH = "/member/api/v1/privacy/requests"
+const PRIVACY_ACCOUNT_PATH = "/member/api/v1/privacy/account"
+
+export const getPrivacyExport = () => apiFetch<RsData<PrivacyExportResponse>>(PRIVACY_EXPORT_PATH)
+
+export const createPrivacyRequest = (input: {
+  type: PrivacyRequestType
+  message?: string
+}) =>
+  apiFetch<RsData<{ item: PrivacyRequestItem }>>(PRIVACY_REQUESTS_PATH, {
+    method: "POST",
+    body: JSON.stringify(input),
+  })
+
+export const deletePrivacyAccount = (input: {
+  password: string
+  reason?: string
+}) =>
+  apiFetch<RsData<AccountDeletionResult>>(PRIVACY_ACCOUNT_PATH, {
+    method: "DELETE",
+    body: JSON.stringify(input),
+  })

--- a/front/src/apis/backend/privacy.ts
+++ b/front/src/apis/backend/privacy.ts
@@ -67,7 +67,8 @@ export const createPrivacyRequest = (input: {
   })
 
 export const deletePrivacyAccount = (input: {
-  password: string
+  password?: string
+  oauthAccountDeletionConfirmed?: boolean
   reason?: string
 }) =>
   apiFetch<RsData<AccountDeletionResult>>(PRIVACY_ACCOUNT_PATH, {

--- a/front/src/pages/settings/account.tsx
+++ b/front/src/pages/settings/account.tsx
@@ -1,0 +1,3 @@
+import SettingsAccountPage from "src/routes/Settings/SettingsAccountPage"
+
+export default SettingsAccountPage

--- a/front/src/pages/settings/privacy.tsx
+++ b/front/src/pages/settings/privacy.tsx
@@ -1,0 +1,3 @@
+import SettingsPrivacyPage from "src/routes/Settings/SettingsPrivacyPage"
+
+export default SettingsPrivacyPage

--- a/front/src/routes/Settings/SettingsAccountPage.tsx
+++ b/front/src/routes/Settings/SettingsAccountPage.tsx
@@ -20,7 +20,7 @@ const SettingsAccountPage = () => {
     const trimmedPassword = password.trim()
     try {
       const response = await deletePrivacyAccount({
-        password: trimmedPassword || undefined,
+        password: trimmedPassword ? password : undefined,
         oauthAccountDeletionConfirmed: !trimmedPassword && confirmed,
         reason: reason.trim() || undefined,
       })

--- a/front/src/routes/Settings/SettingsAccountPage.tsx
+++ b/front/src/routes/Settings/SettingsAccountPage.tsx
@@ -1,0 +1,126 @@
+import { FormEvent, useState } from "react"
+import { deletePrivacyAccount } from "src/apis/backend/privacy"
+import useAuthSession from "src/hooks/useAuthSession"
+import SettingsLayout from "./SettingsLayout"
+
+const SettingsAccountPage = () => {
+  const { clearMe } = useAuthSession()
+  const [password, setPassword] = useState("")
+  const [reason, setReason] = useState("")
+  const [confirmed, setConfirmed] = useState(false)
+  const [feedback, setFeedback] = useState("")
+  const [revokedSessionCount, setRevokedSessionCount] = useState<number | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const submitDeletion = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!confirmed || !password.trim()) return
+    setSubmitting(true)
+    setFeedback("")
+    try {
+      const response = await deletePrivacyAccount({
+        password,
+        reason: reason.trim() || undefined,
+      })
+      setRevokedSessionCount(response.data.revokedSessionCount)
+      setFeedback(response.msg)
+      window.setTimeout(() => clearMe(), 1200)
+    } catch {
+      setFeedback("비밀번호를 확인했지만 계정 탈퇴를 완료하지 못했습니다.")
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <SettingsLayout active="account" title="계정 보안">
+      <div className="settingsGrid">
+        <section className="panel" aria-label="계정 탈퇴">
+          <h2>계정 탈퇴</h2>
+          <p className="notice">
+            탈퇴하면 로그인 세션이 폐기되고 계정은 삭제 상태로 전환됩니다. 법적 의무와 보안 감사에 필요한 최소 기록은
+            제한된 접근으로 보관될 수 있습니다.
+          </p>
+          <form className="deleteForm" onSubmit={submitDeletion}>
+            <label>
+              비밀번호 재확인
+              <input
+                autoComplete="current-password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </label>
+            <label>
+              탈퇴 사유
+              <textarea value={reason} onChange={(event) => setReason(event.target.value)} rows={3} />
+            </label>
+            <label className="checkRow">
+              <input
+                type="checkbox"
+                checked={confirmed}
+                onChange={(event) => setConfirmed(event.target.checked)}
+              />
+              계정 탈퇴 영향을 확인했습니다.
+            </label>
+            <button type="submit" disabled={!confirmed || !password.trim() || submitting}>
+              {submitting ? "처리 중" : "계정 탈퇴"}
+            </button>
+          </form>
+          {feedback ? <p className="feedback">{feedback}</p> : null}
+          {revokedSessionCount != null ? <p className="result">폐기된 세션 {revokedSessionCount}개</p> : null}
+        </section>
+      </div>
+
+      <style jsx>{`
+        .notice {
+          margin: 0 0 18px;
+          color: #53606f;
+          line-height: 1.65;
+        }
+
+        .deleteForm {
+          display: grid;
+          gap: 14px;
+        }
+
+        label {
+          display: grid;
+          gap: 7px;
+          color: #44515f;
+          font-weight: 800;
+        }
+
+        input[type="password"],
+        textarea {
+          width: 100%;
+          border: 1px solid #c8d0da;
+          border-radius: 7px;
+          padding: 11px 12px;
+          color: #1f2933;
+          font: inherit;
+        }
+
+        .checkRow {
+          display: flex;
+          align-items: center;
+          gap: 10px;
+        }
+
+        .checkRow input {
+          width: 18px;
+          height: 18px;
+        }
+
+        .feedback,
+        .result {
+          margin: 12px 0 0;
+          color: #174ea6;
+          font-weight: 800;
+        }
+      `}</style>
+    </SettingsLayout>
+  )
+}
+
+export default SettingsAccountPage

--- a/front/src/routes/Settings/SettingsAccountPage.tsx
+++ b/front/src/routes/Settings/SettingsAccountPage.tsx
@@ -14,19 +14,21 @@ const SettingsAccountPage = () => {
 
   const submitDeletion = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    if (!confirmed || !password.trim()) return
+    if (!confirmed) return
     setSubmitting(true)
     setFeedback("")
+    const trimmedPassword = password.trim()
     try {
       const response = await deletePrivacyAccount({
-        password,
+        password: trimmedPassword || undefined,
+        oauthAccountDeletionConfirmed: !trimmedPassword && confirmed,
         reason: reason.trim() || undefined,
       })
       setRevokedSessionCount(response.data.revokedSessionCount)
       setFeedback(response.msg)
       window.setTimeout(() => clearMe(), 1200)
     } catch {
-      setFeedback("비밀번호를 확인했지만 계정 탈퇴를 완료하지 못했습니다.")
+      setFeedback("계정 확인 상태를 확인했지만 탈퇴를 완료하지 못했습니다.")
     } finally {
       setSubmitting(false)
     }
@@ -43,7 +45,7 @@ const SettingsAccountPage = () => {
           </p>
           <form className="deleteForm" onSubmit={submitDeletion}>
             <label>
-              비밀번호 재확인
+              비밀번호 재확인 (이메일 계정)
               <input
                 autoComplete="current-password"
                 type="password"
@@ -51,6 +53,7 @@ const SettingsAccountPage = () => {
                 onChange={(event) => setPassword(event.target.value)}
               />
             </label>
+            <p className="fieldHint">비밀번호가 없는 소셜 계정은 비워두고 확인 체크 후 진행합니다.</p>
             <label>
               탈퇴 사유
               <textarea value={reason} onChange={(event) => setReason(event.target.value)} rows={3} />
@@ -63,7 +66,7 @@ const SettingsAccountPage = () => {
               />
               계정 탈퇴 영향을 확인했습니다.
             </label>
-            <button type="submit" disabled={!confirmed || !password.trim() || submitting}>
+            <button type="submit" disabled={!confirmed || submitting}>
               {submitting ? "처리 중" : "계정 탈퇴"}
             </button>
           </form>
@@ -99,6 +102,13 @@ const SettingsAccountPage = () => {
           padding: 11px 12px;
           color: #1f2933;
           font: inherit;
+        }
+
+        .fieldHint {
+          margin: -8px 0 0;
+          color: #677484;
+          font-size: 0.92rem;
+          line-height: 1.5;
         }
 
         .checkRow {

--- a/front/src/routes/Settings/SettingsLayout.tsx
+++ b/front/src/routes/Settings/SettingsLayout.tsx
@@ -26,7 +26,7 @@ const SettingsLayout = ({ active, title, children }: SettingsLayoutProps) => {
         <section className="emptyState" aria-label="로그인 필요">
           <h1>설정</h1>
           <p>로그인 후 개인정보와 계정 설정을 관리할 수 있습니다.</p>
-          <Link className="primaryLink" href="/login?next=/settings/privacy">로그인</Link>
+          <Link className="primaryLink" href={`/login?next=/settings/${active}`}>로그인</Link>
         </section>
         <style jsx global>{settingsStyles}</style>
       </main>
@@ -42,8 +42,20 @@ const SettingsLayout = ({ active, title, children }: SettingsLayoutProps) => {
           <p className="summary">{me.nickname || me.username} 계정의 개인정보와 보안 상태를 관리합니다.</p>
         </div>
         <nav className="tabs" aria-label="설정 메뉴">
-          <Link className={active === "privacy" ? "active" : ""} href="/settings/privacy">개인정보</Link>
-          <Link className={active === "account" ? "active" : ""} href="/settings/account">계정 보안</Link>
+          <Link
+            className={active === "privacy" ? "active" : ""}
+            aria-current={active === "privacy" ? "page" : undefined}
+            href="/settings/privacy"
+          >
+            개인정보
+          </Link>
+          <Link
+            className={active === "account" ? "active" : ""}
+            aria-current={active === "account" ? "page" : undefined}
+            href="/settings/account"
+          >
+            계정 보안
+          </Link>
         </nav>
       </header>
       {children}

--- a/front/src/routes/Settings/SettingsLayout.tsx
+++ b/front/src/routes/Settings/SettingsLayout.tsx
@@ -1,0 +1,190 @@
+import Link from "next/link"
+import { ReactNode } from "react"
+import useAuthSession from "src/hooks/useAuthSession"
+
+type SettingsLayoutProps = {
+  active: "privacy" | "account"
+  title: string
+  children: ReactNode
+}
+
+const SettingsLayout = ({ active, title, children }: SettingsLayoutProps) => {
+  const { authStatus, me } = useAuthSession()
+
+  if (authStatus === "loading") {
+    return (
+      <main className="settingsPage" aria-busy="true">
+        <p className="statusText">인증 상태를 확인하는 중입니다.</p>
+        <style jsx global>{settingsStyles}</style>
+      </main>
+    )
+  }
+
+  if (authStatus !== "authenticated" || !me) {
+    return (
+      <main className="settingsPage">
+        <section className="emptyState" aria-label="로그인 필요">
+          <h1>설정</h1>
+          <p>로그인 후 개인정보와 계정 설정을 관리할 수 있습니다.</p>
+          <Link className="primaryLink" href="/login?next=/settings/privacy">로그인</Link>
+        </section>
+        <style jsx global>{settingsStyles}</style>
+      </main>
+    )
+  }
+
+  return (
+    <main className="settingsPage">
+      <header className="pageHeader">
+        <div>
+          <p className="eyebrow">Settings</p>
+          <h1>{title}</h1>
+          <p className="summary">{me.nickname || me.username} 계정의 개인정보와 보안 상태를 관리합니다.</p>
+        </div>
+        <nav className="tabs" aria-label="설정 메뉴">
+          <Link className={active === "privacy" ? "active" : ""} href="/settings/privacy">개인정보</Link>
+          <Link className={active === "account" ? "active" : ""} href="/settings/account">계정 보안</Link>
+        </nav>
+      </header>
+      {children}
+      <style jsx global>{settingsStyles}</style>
+    </main>
+  )
+}
+
+export const settingsStyles = `
+  .settingsPage {
+    width: min(980px, calc(100% - 32px));
+    margin: 0 auto;
+    padding: 48px 0 72px;
+    color: #1f2933;
+  }
+
+  .pageHeader {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 24px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid #d8dee4;
+  }
+
+  .eyebrow {
+    margin: 0 0 8px;
+    color: #65758b;
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0;
+  }
+
+  .settingsPage h1 {
+    margin: 0;
+    font-size: 2rem;
+    line-height: 1.18;
+    letter-spacing: 0;
+  }
+
+  .summary {
+    margin: 10px 0 0;
+    color: #53606f;
+    line-height: 1.6;
+  }
+
+  .tabs {
+    display: inline-flex;
+    gap: 4px;
+    padding: 4px;
+    border: 1px solid #d8dee4;
+    border-radius: 8px;
+    background: #f6f8fa;
+  }
+
+  .settingsPage .tabs a {
+    min-width: 92px;
+    padding: 9px 12px;
+    border-radius: 6px;
+    color: #44515f;
+    text-align: center;
+    text-decoration: none;
+    font-weight: 700;
+  }
+
+  .settingsPage .tabs a.active {
+    color: #0f1720;
+    background: #ffffff;
+    box-shadow: 0 1px 2px rgba(15, 23, 32, 0.08);
+  }
+
+  .settingsGrid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 18px;
+    margin-top: 24px;
+  }
+
+  .panel {
+    padding: 22px;
+    border: 1px solid #d8dee4;
+    border-radius: 8px;
+    background: #ffffff;
+  }
+
+  .panel h2 {
+    margin: 0 0 12px;
+    font-size: 1.1rem;
+    letter-spacing: 0;
+  }
+
+  .statusText,
+  .emptyState {
+    margin-top: 48px;
+    color: #53606f;
+  }
+
+  .settingsPage .primaryLink,
+  .settingsPage button {
+    min-height: 42px;
+    padding: 0 16px;
+    border: 0;
+    border-radius: 7px;
+    background: #174ea6;
+    color: #ffffff;
+    font-weight: 800;
+    cursor: pointer;
+  }
+
+  .primaryLink {
+    display: inline-flex;
+    align-items: center;
+    margin-top: 12px;
+    text-decoration: none;
+  }
+
+  .settingsPage button:disabled {
+    cursor: not-allowed;
+    background: #a8b3c2;
+  }
+
+  @media (max-width: 720px) {
+    .settingsPage {
+      width: min(100% - 24px, 980px);
+      padding-top: 28px;
+    }
+
+    .pageHeader {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .tabs {
+      width: 100%;
+    }
+
+    .settingsPage .tabs a {
+      flex: 1;
+    }
+  }
+`
+
+export default SettingsLayout

--- a/front/src/routes/Settings/SettingsPrivacyPage.tsx
+++ b/front/src/routes/Settings/SettingsPrivacyPage.tsx
@@ -1,0 +1,196 @@
+import { FormEvent, useEffect, useState } from "react"
+import {
+  createPrivacyRequest,
+  getPrivacyExport,
+  PrivacyExportResponse,
+  PrivacyRequestItem,
+  PrivacyRequestType,
+} from "src/apis/backend/privacy"
+import SettingsLayout from "./SettingsLayout"
+
+const formatDateTime = (value?: string | null) => {
+  if (!value) return "미확인"
+  return value.slice(0, 16).replace("T", " ")
+}
+
+const SettingsPrivacyPage = () => {
+  const [snapshot, setSnapshot] = useState<PrivacyExportResponse | null>(null)
+  const [requestType, setRequestType] = useState<PrivacyRequestType>("EXPORT")
+  const [message, setMessage] = useState("")
+  const [createdRequest, setCreatedRequest] = useState<PrivacyRequestItem | null>(null)
+  const [feedback, setFeedback] = useState("")
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    getPrivacyExport()
+      .then((response) => {
+        if (cancelled) return
+        setSnapshot(response.data)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setFeedback("개인정보 내보내기 데이터를 불러오지 못했습니다.")
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const submitRequest = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setSubmitting(true)
+    setFeedback("")
+    try {
+      const response = await createPrivacyRequest({
+        type: requestType,
+        message: message.trim() || undefined,
+      })
+      setCreatedRequest(response.data.item)
+      setFeedback(response.msg)
+    } catch {
+      setFeedback("개인정보 처리 요청을 접수하지 못했습니다.")
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <SettingsLayout active="privacy" title="개인정보 관리">
+      <div className="settingsGrid">
+        <section className="panel" aria-label="개인정보 내보내기">
+          <h2>내보내기 스냅샷</h2>
+          {loading ? (
+            <p className="muted">개인정보 내보내기 데이터를 불러오는 중입니다.</p>
+          ) : snapshot ? (
+            <dl className="snapshotList">
+              <div>
+                <dt>이메일</dt>
+                <dd>{snapshot.member.email || "미등록"}</dd>
+              </div>
+              <div>
+                <dt>사용자 식별자</dt>
+                <dd>{snapshot.member.username}</dd>
+              </div>
+              <div>
+                <dt>가입일</dt>
+                <dd>{formatDateTime(snapshot.member.createdAt)}</dd>
+              </div>
+              <div>
+                <dt>생성 시각</dt>
+                <dd>{formatDateTime(snapshot.generatedAt)}</dd>
+              </div>
+              <div>
+                <dt>개인정보처리방침</dt>
+                <dd>개인정보처리방침 {snapshot.latestLegalAcceptance?.privacyVersion || "미확인"}</dd>
+              </div>
+            </dl>
+          ) : (
+            <p className="muted">조회 가능한 개인정보 스냅샷이 없습니다.</p>
+          )}
+        </section>
+
+        <section className="panel" aria-label="개인정보 처리 요청">
+          <h2>처리 요청</h2>
+          <form className="requestForm" onSubmit={submitRequest}>
+            <label>
+              요청 유형
+              <select value={requestType} onChange={(event) => setRequestType(event.target.value as PrivacyRequestType)}>
+                <option value="EXPORT">내보내기</option>
+                <option value="CORRECTION">정정</option>
+                <option value="DELETION">삭제</option>
+                <option value="PROCESSING_RESTRICTION">처리 제한</option>
+                <option value="CONSENT_WITHDRAWAL">동의 철회</option>
+              </select>
+            </label>
+            <label>
+              요청 사유
+              <textarea value={message} onChange={(event) => setMessage(event.target.value)} rows={4} />
+            </label>
+            <button type="submit" disabled={submitting}>{submitting ? "접수 중" : "처리 요청 접수"}</button>
+          </form>
+          {feedback ? <p className="feedback">{feedback}</p> : null}
+          {createdRequest ? (
+            <p className="requestResult">
+              접수 번호 {createdRequest.id} · 상태 {createdRequest.status} · 기한 {formatDateTime(createdRequest.dueAt)}
+            </p>
+          ) : null}
+        </section>
+      </div>
+
+      <style jsx>{`
+        .snapshotList {
+          display: grid;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 14px;
+          margin: 0;
+        }
+
+        .snapshotList div {
+          min-width: 0;
+        }
+
+        dt {
+          color: #65758b;
+          font-size: 0.82rem;
+          font-weight: 800;
+        }
+
+        dd {
+          margin: 5px 0 0;
+          overflow-wrap: anywhere;
+          color: #1f2933;
+          font-weight: 700;
+        }
+
+        .requestForm {
+          display: grid;
+          gap: 14px;
+        }
+
+        label {
+          display: grid;
+          gap: 7px;
+          color: #44515f;
+          font-weight: 800;
+        }
+
+        select,
+        textarea {
+          width: 100%;
+          border: 1px solid #c8d0da;
+          border-radius: 7px;
+          padding: 11px 12px;
+          color: #1f2933;
+          font: inherit;
+        }
+
+        .muted,
+        .feedback,
+        .requestResult {
+          margin: 12px 0 0;
+          color: #53606f;
+          line-height: 1.6;
+        }
+
+        .feedback {
+          color: #174ea6;
+          font-weight: 800;
+        }
+
+        @media (max-width: 640px) {
+          .snapshotList {
+            grid-template-columns: 1fr;
+          }
+        }
+      `}</style>
+    </SettingsLayout>
+  )
+}
+
+export default SettingsPrivacyPage

--- a/front/src/routes/Settings/SettingsPrivacyPage.tsx
+++ b/front/src/routes/Settings/SettingsPrivacyPage.tsx
@@ -8,9 +8,15 @@ import {
 } from "src/apis/backend/privacy"
 import SettingsLayout from "./SettingsLayout"
 
+const dateTimeFormatter = new Intl.DateTimeFormat("ko-KR", {
+  dateStyle: "medium",
+  timeStyle: "short",
+})
+
 const formatDateTime = (value?: string | null) => {
   if (!value) return "미확인"
-  return value.slice(0, 16).replace("T", " ")
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? "미확인" : dateTimeFormatter.format(parsed)
 }
 
 const SettingsPrivacyPage = () => {


### PR DESCRIPTION
## 관련 이슈

close #999

## 작업 배경

- 상용 출시 전 로그인 사용자가 개인정보 열람/내보내기, 개인정보 처리 요청, 재인증 기반 계정 탈퇴를 self-service로 수행할 수 있어야 합니다.
- 기존에는 해당 API와 settings 화면이 없어 개인정보 권리 행사와 계정 삭제 처리가 수동 운영에 의존했습니다.

## 작업 내용

- `member_privacy_request`, `member_account_deletion` 테이블과 JPA 모델을 추가했습니다.
- `/member/api/v1/privacy/export`, `/member/api/v1/privacy/requests`, `/member/api/v1/privacy/account` API를 추가했습니다.
- 계정 탈퇴 시 password 또는 OAuth-only 확인 흐름으로 재인증하고, 회원 PII/profile attr/API key/session/refresh token/post/comment cleanup과 deletion tombstone을 처리하도록 구현했습니다.
- 계정 탈퇴 후 OAuth 재가입 tombstone release, profile image retention cleanup, session cache after-commit eviction, deleted post/comment cleanup, restore guard, fresh-token fallback 차단을 보강했습니다.
- `/settings/privacy`, `/settings/account` 화면과 frontend API client, Playwright e2e를 추가했습니다.
- ArchitectureGuard에 맞춰 privacy application service가 persistence adapter 구현체 대신 output port만 참조하도록 정렬했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back ktlintCheck test --tests '*OAuthSignupApplicationServiceTest' --tests '*PostApplicationUseCaseCollaboratorTest' --tests '*ApiV1PrivacyRightsControllerTest' --rerun-tasks` 성공
  - `back/gradlew -p back ktlintCheck test --tests '*CustomAuthenticationFilterTest' --tests '*ApiV1PrivacyRightsControllerTest' --tests '*MemberSessionServiceTest' --rerun-tasks` 성공
  - `back/gradlew -p back ciFastCheck --rerun-tasks` 2회 연속 성공
  - `yarn --cwd front playwright:preflight` 성공
  - `yarn --cwd front playwright test e2e/settings-privacy-account.spec.ts` 성공
  - `yarn --cwd front build` 성공
  - GitHub `backend-ci / backend-ci` 성공: https://github.com/AquilaXk/aquila-blog/actions/runs/27933284665
  - GitHub `frontend-ci / frontend-ci` 성공: https://github.com/AquilaXk/aquila-blog/actions/runs/27933284640
  - GitHub `Security` 성공: https://github.com/AquilaXk/aquila-blog/actions/runs/27933284615
  - main merge 후 `Deploy to Home Server` 성공: https://github.com/AquilaXk/aquila-blog/actions/runs/27933967687

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 개인정보 권리/계정 탈퇴 backend | local macOS/JDK | focused Gradle tests + ktlint | `back/gradlew -p back ktlintCheck test --tests '*CustomAuthenticationFilterTest' --tests '*ApiV1PrivacyRightsControllerTest' --tests '*MemberSessionServiceTest' --rerun-tasks` | 성공 |
| 리뷰 후속 OAuth/comment cleanup | local macOS/JDK | focused Gradle tests + ktlint | `back/gradlew -p back ktlintCheck test --tests '*OAuthSignupApplicationServiceTest' --tests '*PostApplicationUseCaseCollaboratorTest' --tests '*ApiV1PrivacyRightsControllerTest' --rerun-tasks` | 성공 |
| backend 회귀 | local macOS/JDK | `ciFastCheck` 2회 연속 | `back/gradlew -p back ciFastCheck --rerun-tasks` | 2회 성공 |
| settings privacy/account UI | local macOS/Chromium | Playwright preflight + e2e | `yarn --cwd front playwright:preflight`, `yarn --cwd front playwright test e2e/settings-privacy-account.spec.ts` | 성공 |
| PR backend CI | GitHub Actions | workflow run | https://github.com/AquilaXk/aquila-blog/actions/runs/27933284665 | 성공 |
| PR frontend CI | GitHub Actions | workflow run | https://github.com/AquilaXk/aquila-blog/actions/runs/27933284640 | 성공 |
| PR security | GitHub Actions | dependency check + CodeQL | https://github.com/AquilaXk/aquila-blog/actions/runs/27933284615 | 성공 |
| 코드리뷰 | GitHub PR | CodeRabbit status + unresolved thread query | PR checks `CodeRabbit` success, unresolved review threads 0 | 성공 |
| main post-merge CI | GitHub Actions | merge commit workflow run | https://github.com/AquilaXk/aquila-blog/actions/runs/27933667945 | 성공 |
| main security | GitHub Actions | merge commit security workflow run | https://github.com/AquilaXk/aquila-blog/actions/runs/27933667920 | 성공 |
| 홈서버 배포 | GitHub Actions/CD | buildAndPush + blueGreenDeploy + Frontend Live E2E Verification | https://github.com/AquilaXk/aquila-blog/actions/runs/27933967687 | 성공 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `PrivacyRightsApplicationService`의 export/request/account deletion 트랜잭션 경계
  - `Member.softDelete()`와 member attr/profile image cleanup의 PII 최소화 범위
  - `MemberSessionService.revokeAllActiveSessionsForMember()`와 cache eviction 처리
  - account deletion 이후 OAuth 재가입, deleted post/comment cleanup, admin restore 차단 정책
  - `/settings/privacy`, `/settings/account`의 인증 상태와 API 실패 UX

## 리스크

- 계정 탈퇴는 회원 row를 삭제하지 않고 `deleted_at` + tombstone으로 남깁니다. 법적/보안 감사 최소 기록을 유지하기 위한 선택이며, 이메일/password/apiKey/profile attr/session은 정리합니다.
- Vercel preview는 ignored build step으로 성공 처리됩니다. PR frontend CI와 local e2e로 settings UI 회귀를 확인했습니다.
- main merge 후 자동 CI/CD와 홈서버 blue/green 배포, live E2E까지 성공했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
