### PR TITLE
[Fix] 법적 동의 증빙 version/hash를 공개 정책과 단일화

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/ActiveLegalDocumentMetadata.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/ActiveLegalDocumentMetadata.kt
@@ -13,15 +13,15 @@ data class ActiveLegalDocumentMetadata(
     companion object {
         fun current(): ActiveLegalDocumentMetadata =
             ActiveLegalDocumentMetadata(
-                signupPolicyVersion = "2026-06-21",
+                signupPolicyVersion = "1.0.0",
                 terms =
                     LegalDocumentMetadata(
-                        version = "2026-06-21",
-                        contentSha256 = "3b71950e518b16b9a24cb4f9873633720ca7a9fce145a7bb9787c48845b56c5b",
+                        version = "1.0.0",
+                        contentSha256 = "5c0d0013897baf15be95d57adc15acfbd10d2772ab48572b07a75f8e2c9360a8",
                     ),
                 privacy =
                     LegalDocumentMetadata(
-                        version = "2026-06-21",
+                        version = "1.0.0",
                         contentSha256 = "cedbfea674a9e2aca9e29bf6a01492a1e3fa640b0ff53d47f969d64c057b980f",
                     ),
             )

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1PrivacyRightsControllerTest.kt
@@ -11,6 +11,7 @@ import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_SERVICE
 import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_WORKSPACE_DRAFT
 import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_WORKSPACE_PUBLISHED
 import com.back.boundedContexts.member.subContexts.legalAcceptance.adapter.persistence.MemberLegalAcceptanceRepository
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.ActiveLegalDocumentMetadata
 import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberLegalAcceptance
 import com.back.boundedContexts.member.subContexts.privacy.adapter.persistence.MemberAccountDeletionRepository
 import com.back.boundedContexts.member.subContexts.privacy.model.MemberAccountDeletion
@@ -60,6 +61,7 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
 
     @Test
     fun `개인정보 export 는 로그인 사용자의 계정 스냅샷을 반환한다`() {
+        val activeLegalDocuments = ActiveLegalDocumentMetadata.current()
         val member =
             memberFacade.join(
                 username = "privacy-export-user",
@@ -71,10 +73,10 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
         memberLegalAcceptanceRepository.save(
             MemberLegalAcceptance(
                 member = member,
-                termsVersion = "2026-06-21",
-                termsContentSha256 = "terms-content-sha-256",
-                privacyVersion = "2026-06-21",
-                privacyContentSha256 = "privacy-content-sha-256",
+                termsVersion = activeLegalDocuments.terms.version,
+                termsContentSha256 = activeLegalDocuments.terms.contentSha256,
+                privacyVersion = activeLegalDocuments.privacy.version,
+                privacyContentSha256 = activeLegalDocuments.privacy.contentSha256,
                 age14OrOlder = true,
                 requiredPrivacyConfirmed = true,
                 analyticsConsent = false,
@@ -97,10 +99,14 @@ class ApiV1PrivacyRightsControllerTest : BaseControllerIntegrationTest() {
                 jsonPath("$.data.member.username") { value("privacy-export-user") }
                 jsonPath("$.data.member.nickname") { value("정보내보내기") }
                 jsonPath("$.data.member.createdAt") { value(startsWith(member.createdAt.toString().take(20))) }
-                jsonPath("$.data.latestLegalAcceptance.termsVersion") { value("2026-06-21") }
-                jsonPath("$.data.latestLegalAcceptance.termsContentSha256") { value("terms-content-sha-256") }
-                jsonPath("$.data.latestLegalAcceptance.privacyVersion") { value("2026-06-21") }
-                jsonPath("$.data.latestLegalAcceptance.privacyContentSha256") { value("privacy-content-sha-256") }
+                jsonPath("$.data.latestLegalAcceptance.termsVersion") { value(activeLegalDocuments.terms.version) }
+                jsonPath("$.data.latestLegalAcceptance.termsContentSha256") {
+                    value(activeLegalDocuments.terms.contentSha256)
+                }
+                jsonPath("$.data.latestLegalAcceptance.privacyVersion") { value(activeLegalDocuments.privacy.version) }
+                jsonPath("$.data.latestLegalAcceptance.privacyContentSha256") {
+                    value(activeLegalDocuments.privacy.contentSha256)
+                }
                 jsonPath("$.data.latestLegalAcceptance.age14OrOlder") { value(true) }
                 jsonPath("$.data.latestLegalAcceptance.requiredPrivacyConfirmed") { value(true) }
                 jsonPath("$.data.latestLegalAcceptance.analyticsConsent") { value(false) }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/ActiveLegalDocumentMetadataTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/ActiveLegalDocumentMetadataTest.kt
@@ -1,0 +1,37 @@
+package com.back.boundedContexts.member.subContexts.legalAcceptance.application.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+import kotlin.io.path.readText
+
+class ActiveLegalDocumentMetadataTest {
+    @Test
+    @DisplayName("current legal metadata matches the public policy source files")
+    fun currentMetadataMatchesPublicPolicySources() {
+        val active = ActiveLegalDocumentMetadata.current()
+
+        val terms = readPolicyMetadata("../legal/policies/terms.ko-KR.v1.0.0.yaml")
+        val privacy = readPolicyMetadata("../legal/policies/privacy.ko-KR.v1.0.0.yaml")
+
+        assertThat(active.signupPolicyVersion).isEqualTo(terms.version)
+        assertThat(active.terms).isEqualTo(terms)
+        assertThat(active.privacy).isEqualTo(privacy)
+    }
+
+    private fun readPolicyMetadata(path: String): LegalDocumentMetadata {
+        val raw = Path.of(path).readText()
+        val version = requireNotNull(extractJsonString(raw, "version")) { "missing version in $path" }
+        val contentSha256 = requireNotNull(extractJsonString(raw, "contentSha256")) { "missing contentSha256 in $path" }
+        return LegalDocumentMetadata(version = version, contentSha256 = contentSha256)
+    }
+
+    private fun extractJsonString(
+        raw: String,
+        key: String,
+    ): String? {
+        val pattern = Regex(""""$key"\s*:\s*"([^"]+)"""")
+        return pattern.find(raw)?.groupValues?.get(1)
+    }
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/web/ApiV1OAuthSignupControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/web/ApiV1OAuthSignupControllerTest.kt
@@ -1,6 +1,7 @@
 package com.back.boundedContexts.member.subContexts.oauthSignup.adapter.web
 
 import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.ActiveLegalDocumentMetadata
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupUseCase
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingDetails
@@ -13,6 +14,8 @@ import java.time.Instant
 
 @DisplayName("ApiV1OAuthSignupController 테스트")
 class ApiV1OAuthSignupControllerTest {
+    private val activeLegalDocuments = ActiveLegalDocumentMetadata.current()
+
     @Test
     fun `pending은 token으로 social signup 세션을 조회한다`() {
         val useCase = RecordingOAuthSignupUseCase()
@@ -47,10 +50,10 @@ class ApiV1OAuthSignupControllerTest {
                 ApiV1OAuthSignupController.SocialSignupCompleteRequest(
                     token = "pending-token",
                     nickname = "완료닉네임",
-                    termsVersion = "2026-06-21",
-                    termsContentSha256 = TERMS_HASH,
-                    privacyVersion = "2026-06-21",
-                    privacyContentSha256 = PRIVACY_HASH,
+                    termsVersion = activeLegalDocuments.terms.version,
+                    termsContentSha256 = activeLegalDocuments.terms.contentSha256,
+                    privacyVersion = activeLegalDocuments.privacy.version,
+                    privacyContentSha256 = activeLegalDocuments.privacy.contentSha256,
                     age14OrOlder = true,
                     requiredPrivacyConfirmed = true,
                     analyticsConsent = false,
@@ -66,10 +69,10 @@ class ApiV1OAuthSignupControllerTest {
         assertThat(useCase.lastLegalAcceptance)
             .isEqualTo(
                 LegalAcceptanceCommand(
-                    termsVersion = "2026-06-21",
-                    termsContentSha256 = TERMS_HASH,
-                    privacyVersion = "2026-06-21",
-                    privacyContentSha256 = PRIVACY_HASH,
+                    termsVersion = activeLegalDocuments.terms.version,
+                    termsContentSha256 = activeLegalDocuments.terms.contentSha256,
+                    privacyVersion = activeLegalDocuments.privacy.version,
+                    privacyContentSha256 = activeLegalDocuments.privacy.contentSha256,
                     age14OrOlder = true,
                     requiredPrivacyConfirmed = true,
                     analyticsConsent = false,
@@ -83,10 +86,10 @@ class ApiV1OAuthSignupControllerTest {
         val request =
             ApiV1OAuthSignupController.SocialSignupCompleteRequest(
                 token = "pending-token",
-                termsVersion = "2026-06-21",
-                termsContentSha256 = TERMS_HASH,
-                privacyVersion = "2026-06-21",
-                privacyContentSha256 = PRIVACY_HASH,
+                termsVersion = activeLegalDocuments.terms.version,
+                termsContentSha256 = activeLegalDocuments.terms.contentSha256,
+                privacyVersion = activeLegalDocuments.privacy.version,
+                privacyContentSha256 = activeLegalDocuments.privacy.contentSha256,
                 age14OrOlder = true,
                 requiredPrivacyConfirmed = true,
                 analyticsConsent = true,
@@ -97,27 +100,22 @@ class ApiV1OAuthSignupControllerTest {
 
         assertThat(request.token).isEqualTo("pending-token")
         assertThat(request.nickname).isNull()
-        assertThat(request.termsVersion).isEqualTo("2026-06-21")
-        assertThat(request.termsContentSha256).isEqualTo(TERMS_HASH)
-        assertThat(request.privacyVersion).isEqualTo("2026-06-21")
-        assertThat(request.privacyContentSha256).isEqualTo(PRIVACY_HASH)
+        assertThat(request.termsVersion).isEqualTo(activeLegalDocuments.terms.version)
+        assertThat(request.termsContentSha256).isEqualTo(activeLegalDocuments.terms.contentSha256)
+        assertThat(request.privacyVersion).isEqualTo(activeLegalDocuments.privacy.version)
+        assertThat(request.privacyContentSha256).isEqualTo(activeLegalDocuments.privacy.contentSha256)
         assertThat(request.age14OrOlder).isTrue()
         assertThat(request.requiredPrivacyConfirmed).isTrue()
         assertThat(request.analyticsConsent).isTrue()
         assertThat(request.overseasTransferAcknowledged).isTrue()
-        assertThat(command.termsVersion).isEqualTo("2026-06-21")
-        assertThat(command.termsContentSha256).isEqualTo(TERMS_HASH)
-        assertThat(command.privacyVersion).isEqualTo("2026-06-21")
-        assertThat(command.privacyContentSha256).isEqualTo(PRIVACY_HASH)
+        assertThat(command.termsVersion).isEqualTo(activeLegalDocuments.terms.version)
+        assertThat(command.termsContentSha256).isEqualTo(activeLegalDocuments.terms.contentSha256)
+        assertThat(command.privacyVersion).isEqualTo(activeLegalDocuments.privacy.version)
+        assertThat(command.privacyContentSha256).isEqualTo(activeLegalDocuments.privacy.contentSha256)
         assertThat(command.age14OrOlder).isTrue()
         assertThat(command.requiredPrivacyConfirmed).isTrue()
         assertThat(command.analyticsConsent).isTrue()
         assertThat(command.overseasTransferAcknowledged).isTrue()
-    }
-
-    private companion object {
-        private const val TERMS_HASH = "3b71950e518b16b9a24cb4f9873633720ca7a9fce145a7bb9787c48845b56c5b"
-        private const val PRIVACY_HASH = "cedbfea674a9e2aca9e29bf6a01492a1e3fa640b0ff53d47f969d64c057b980f"
     }
 }
 

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
@@ -5,6 +5,7 @@ import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileLinkItem
 import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileWorkspaceContent
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.output.MemberLegalAcceptanceRepositoryPort
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.ActiveLegalDocumentMetadata
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceApplicationService
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberLegalAcceptance
@@ -402,16 +403,18 @@ class OAuthSignupApplicationServiceTest {
 }
 
 private fun validLegalAcceptance(): LegalAcceptanceCommand =
-    LegalAcceptanceCommand(
-        termsVersion = "2026-06-21",
-        termsContentSha256 = "3b71950e518b16b9a24cb4f9873633720ca7a9fce145a7bb9787c48845b56c5b",
-        privacyVersion = "2026-06-21",
-        privacyContentSha256 = "cedbfea674a9e2aca9e29bf6a01492a1e3fa640b0ff53d47f969d64c057b980f",
-        age14OrOlder = true,
-        requiredPrivacyConfirmed = true,
-        analyticsConsent = false,
-        overseasTransferAcknowledged = true,
-    )
+    ActiveLegalDocumentMetadata.current().let { active ->
+        LegalAcceptanceCommand(
+            termsVersion = active.terms.version,
+            termsContentSha256 = active.terms.contentSha256,
+            privacyVersion = active.privacy.version,
+            privacyContentSha256 = active.privacy.contentSha256,
+            age14OrOlder = true,
+            requiredPrivacyConfirmed = true,
+            analyticsConsent = false,
+            overseasTransferAcknowledged = true,
+        )
+    }
 
 private class RecordingPendingOAuthSignupRepository : PendingOAuthSignupRepositoryPort {
     val saved = mutableListOf<PendingOAuthSignup>()

--- a/front/e2e/settings-privacy-account.spec.ts
+++ b/front/e2e/settings-privacy-account.spec.ts
@@ -37,8 +37,8 @@ test("settings privacy page exposes export snapshot and creates privacy request"
             modifiedAt: authMember.modifiedAt,
           },
           latestLegalAcceptance: {
-            termsVersion: "2026-06-21",
-            privacyVersion: "2026-06-21",
+            termsVersion: "1.0.0",
+            privacyVersion: "1.0.0",
             analyticsConsent: false,
             overseasTransferAcknowledged: true,
             acceptedAt: "2026-06-21T00:10:00Z",
@@ -75,7 +75,7 @@ test("settings privacy page exposes export snapshot and creates privacy request"
 
   await expect(page.getByRole("heading", { name: "개인정보 관리" })).toBeVisible()
   await expect(page.getByText("privacy-user@example.com")).toBeVisible()
-  await expect(page.getByText("개인정보처리방침 2026-06-21")).toBeVisible()
+  await expect(page.getByText("개인정보처리방침 1.0.0")).toBeVisible()
 
   await page.getByLabel("요청 사유").fill("가입 정보와 운영 로그 열람을 요청합니다.")
   await page.getByRole("button", { name: "처리 요청 접수" }).click()

--- a/front/src/apis/backend/legal.ts
+++ b/front/src/apis/backend/legal.ts
@@ -1,11 +1,11 @@
 export const ACTIVE_LEGAL_DOCUMENTS = {
-  signupPolicyVersion: "2026-06-21",
+  signupPolicyVersion: "1.0.0",
   terms: {
-    version: "2026-06-21",
-    contentSha256: "3b71950e518b16b9a24cb4f9873633720ca7a9fce145a7bb9787c48845b56c5b",
+    version: "1.0.0",
+    contentSha256: "5c0d0013897baf15be95d57adc15acfbd10d2772ab48572b07a75f8e2c9360a8",
   },
   privacy: {
-    version: "2026-06-21",
+    version: "1.0.0",
     contentSha256: "cedbfea674a9e2aca9e29bf6a01492a1e3fa640b0ff53d47f969d64c057b980f",
   },
 } as const

--- a/tools/legal/validate-legal-policies.mjs
+++ b/tools/legal/validate-legal-policies.mjs
@@ -5,6 +5,11 @@ import path from "node:path"
 
 const root = process.cwd()
 const policiesDir = path.join(root, "legal/policies")
+const frontendLegalMetadataPath = path.join(root, "front/src/apis/backend/legal.ts")
+const backendLegalMetadataPath = path.join(
+  root,
+  "back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/ActiveLegalDocumentMetadata.kt",
+)
 const requiredFields = [
   "documentType",
   "locale",
@@ -125,6 +130,83 @@ const readRawPolicy = (fileName) => {
   return fs.readFileSync(filePath, "utf8")
 }
 
+const extractQuotedValue = (source, pattern, label) => {
+  const match = source.match(pattern)
+  if (!match) {
+    fail(`missing ${label}`)
+    return ""
+  }
+  return match[1]
+}
+
+const readFrontendActiveMetadata = () => {
+  if (!fs.existsSync(frontendLegalMetadataPath)) {
+    fail(`missing frontend legal metadata ${frontendLegalMetadataPath}`)
+    return null
+  }
+
+  const source = fs.readFileSync(frontendLegalMetadataPath, "utf8")
+  return {
+    signupPolicyVersion: extractQuotedValue(
+      source,
+      /signupPolicyVersion:\s*"([^"]+)"/,
+      "frontend signupPolicyVersion",
+    ),
+    terms: {
+      version: extractQuotedValue(source, /terms:\s*\{[\s\S]*?version:\s*"([^"]+)"/, "frontend terms version"),
+      contentSha256: extractQuotedValue(
+        source,
+        /terms:\s*\{[\s\S]*?contentSha256:\s*"([^"]+)"/,
+        "frontend terms contentSha256",
+      ),
+    },
+    privacy: {
+      version: extractQuotedValue(source, /privacy:\s*\{[\s\S]*?version:\s*"([^"]+)"/, "frontend privacy version"),
+      contentSha256: extractQuotedValue(
+        source,
+        /privacy:\s*\{[\s\S]*?contentSha256:\s*"([^"]+)"/,
+        "frontend privacy contentSha256",
+      ),
+    },
+  }
+}
+
+const readBackendActiveMetadata = () => {
+  if (!fs.existsSync(backendLegalMetadataPath)) {
+    fail(`missing backend legal metadata ${backendLegalMetadataPath}`)
+    return null
+  }
+
+  const source = fs.readFileSync(backendLegalMetadataPath, "utf8")
+  return {
+    signupPolicyVersion: extractQuotedValue(
+      source,
+      /signupPolicyVersion\s*=\s*"([^"]+)"/,
+      "backend signupPolicyVersion",
+    ),
+    terms: {
+      version: extractQuotedValue(source, /terms\s*=\s*[\s\S]*?version\s*=\s*"([^"]+)"/, "backend terms version"),
+      contentSha256: extractQuotedValue(
+        source,
+        /terms\s*=\s*[\s\S]*?contentSha256\s*=\s*"([^"]+)"/,
+        "backend terms contentSha256",
+      ),
+    },
+    privacy: {
+      version: extractQuotedValue(
+        source,
+        /privacy\s*=\s*[\s\S]*?version\s*=\s*"([^"]+)"/,
+        "backend privacy version",
+      ),
+      contentSha256: extractQuotedValue(
+        source,
+        /privacy\s*=\s*[\s\S]*?contentSha256\s*=\s*"([^"]+)"/,
+        "backend privacy contentSha256",
+      ),
+    },
+  }
+}
+
 const assertRequiredShape = (fileName, policy) => {
   for (const field of requiredFields) {
     if (!(field in policy)) fail(`${fileName} is missing ${field}`)
@@ -166,6 +248,26 @@ const assertTextIncludes = (fileName, policy, tokens) => {
   }
 }
 
+const assertActiveMetadataMatchesPolicies = (sourceName, metadata, termsPolicy, privacyPolicy) => {
+  if (!metadata || !termsPolicy || !privacyPolicy) return
+
+  if (metadata.signupPolicyVersion !== termsPolicy.version) {
+    fail(`${sourceName} signupPolicyVersion mismatch: expected ${termsPolicy.version}`)
+  }
+  if (metadata.terms.version !== termsPolicy.version) {
+    fail(`${sourceName} terms version mismatch: expected ${termsPolicy.version}`)
+  }
+  if (metadata.terms.contentSha256 !== termsPolicy.contentSha256) {
+    fail(`${sourceName} terms contentSha256 mismatch: expected ${termsPolicy.contentSha256}`)
+  }
+  if (metadata.privacy.version !== privacyPolicy.version) {
+    fail(`${sourceName} privacy version mismatch: expected ${privacyPolicy.version}`)
+  }
+  if (metadata.privacy.contentSha256 !== privacyPolicy.contentSha256) {
+    fail(`${sourceName} privacy contentSha256 mismatch: expected ${privacyPolicy.contentSha256}`)
+  }
+}
+
 const policies = new Map()
 const policyFiles = getPolicyFiles()
 for (const fileName of policyFiles) {
@@ -191,6 +293,9 @@ if (terms) {
   assertSectionTitles("terms.ko-KR.v1.0.0.yaml", terms, requiredTermsSections)
   assertTextIncludes("terms.ko-KR.v1.0.0.yaml", terms, ["고의 또는 중대한 과실", "부당하게 불리한 전속 관할"])
 }
+
+assertActiveMetadataMatchesPolicies("frontend active legal metadata", readFrontendActiveMetadata(), terms, privacy)
+assertActiveMetadataMatchesPolicies("backend active legal metadata", readBackendActiveMetadata(), terms, privacy)
 
 const cookies = policies.get("COOKIE_POLICY")
 if (cookies) {


### PR DESCRIPTION
## 관련 이슈

close #1024

## 작업 배경

- 공개 정책 원본은 `legal/policies/terms.ko-KR.v1.0.0.yaml`, `privacy.ko-KR.v1.0.0.yaml`의 `version: 1.0.0`과 `contentSha256`을 사용합니다.
- 회원가입 동의 증빙 payload와 backend current metadata는 기존 날짜형 version과 오래된 terms hash를 사용해, 사용자가 열람한 공개 문서와 저장 증빙이 서로 달랐습니다.

## 작업 내용

- frontend `ACTIVE_LEGAL_DOCUMENTS`와 backend `ActiveLegalDocumentMetadata.current()`를 공개 정책 원본의 `version`/`contentSha256`과 일치시켰습니다.
- `tools/legal/validate-legal-policies.mjs`가 frontend/backend active legal metadata와 공개 정책 원본을 함께 대조하도록 보강했습니다.
- backend regression test `ActiveLegalDocumentMetadataTest`를 추가해 정책 원본과 backend current metadata drift를 테스트에서 잡도록 했습니다.
- OAuth signup, privacy export, settings privacy/account e2e fixture가 active policy version `1.0.0`을 기준으로 검증되도록 정렬했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests '*ActiveLegalDocumentMetadataTest' --rerun-tasks` RED: 기존 코드에서 terms/privacy version/hash mismatch로 실패 확인
  - `node tools/legal/validate-legal-policies.mjs` RED: 기존 frontend/backend active metadata mismatch 실패 확인
  - `node tools/legal/validate-legal-policies.mjs` 성공
  - `back/gradlew -p back ktlintCheck test --tests '*ActiveLegalDocumentMetadataTest' --tests '*ApiV1SignupVerificationControllerTest' --tests '*ApiV1OAuthSignupControllerTest' --tests '*OAuthSignupApplicationServiceTest' --tests '*ApiV1PrivacyRightsControllerTest' --rerun-tasks` 성공
  - `yarn --cwd front install --frozen-lockfile` 성공
  - `yarn --cwd front build` 성공
  - `yarn --cwd front playwright:preflight` 성공
  - `yarn --cwd front playwright test e2e/settings-privacy-account.spec.ts` 성공, 3 passed
  - `back/gradlew -p back ciFastCheck --rerun-tasks` 2회 연속 성공
  - pre-commit hook `OpenApiContractExportTest`, `yarn contracts:check` 성공
  - GitHub `backend-ci / backend-ci` 성공: https://github.com/AquilaXk/aquila-blog/actions/runs/27935172009
  - GitHub `frontend-ci / frontend-ci` 성공: https://github.com/AquilaXk/aquila-blog/actions/runs/27935171994
  - GitHub `Security` 성공: https://github.com/AquilaXk/aquila-blog/actions/runs/27935171991
  - CodeRabbit review 완료: actionable comments 0
  - main merge 후 GitHub `CI` 성공: https://github.com/AquilaXk/aquila-blog/actions/runs/27935535740
  - main merge 후 GitHub `Security` 성공: https://github.com/AquilaXk/aquila-blog/actions/runs/27935535683
  - main merge 후 `Deploy to Home Server` 성공: https://github.com/AquilaXk/aquila-blog/actions/runs/27935885179

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| active metadata drift RED | local macOS/JDK/Node | regression test와 validator를 수정 전 실행 | `ActiveLegalDocumentMetadataTest` 실패, `validate-legal-policies.mjs` mismatch 실패 로그 | 실패 확인 |
| policy metadata validator | local macOS/Node | 정책 원본과 frontend/backend metadata 대조 | `node tools/legal/validate-legal-policies.mjs` | 성공 |
| backend legal/signup/privacy | local macOS/JDK | ktlint + focused Gradle tests | `back/gradlew -p back ktlintCheck test --tests '*ActiveLegalDocumentMetadataTest' --tests '*ApiV1SignupVerificationControllerTest' --tests '*ApiV1OAuthSignupControllerTest' --tests '*OAuthSignupApplicationServiceTest' --tests '*ApiV1PrivacyRightsControllerTest' --rerun-tasks` | 성공 |
| frontend build | local macOS/Node | Next build/typecheck | `yarn --cwd front build` | 성공 |
| settings privacy/account e2e | local macOS/Chromium | Playwright preflight + spec | `yarn --cwd front playwright:preflight`, `yarn --cwd front playwright test e2e/settings-privacy-account.spec.ts` | 3 passed |
| backend fast regression | local macOS/JDK | CI fast check 동일 조건 반복 | `back/gradlew -p back ciFastCheck --rerun-tasks` | 2회 성공 |
| OpenAPI contract | local git hook | pre-commit hook | `OpenApiContractExportTest`, `yarn contracts:check` | 성공 |
| PR backend CI | GitHub Actions | workflow run | https://github.com/AquilaXk/aquila-blog/actions/runs/27935172009 | 성공 |
| PR frontend CI | GitHub Actions | workflow run | https://github.com/AquilaXk/aquila-blog/actions/runs/27935171994 | 성공 |
| PR security | GitHub Actions | dependency check + CodeQL | https://github.com/AquilaXk/aquila-blog/actions/runs/27935171991 | 성공 |
| 코드리뷰 | GitHub PR | CodeRabbit review + unresolved thread query | CodeRabbit actionable comments 0, unresolved review threads 0 | 성공 |
| main CI | GitHub Actions | merge commit `dc05b8a81b7ea659bc2a522041b7a1be719e063b` workflow run | https://github.com/AquilaXk/aquila-blog/actions/runs/27935535740 | 성공 |
| main security | GitHub Actions | merge commit `dc05b8a81b7ea659bc2a522041b7a1be719e063b` workflow run | https://github.com/AquilaXk/aquila-blog/actions/runs/27935535683 | 성공 |
| 홈서버 배포 | GitHub Actions/CD | buildAndPush, blueGreenDeploy, Frontend Live E2E Verification | https://github.com/AquilaXk/aquila-blog/actions/runs/27935885179 | 성공 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `tools/legal/validate-legal-policies.mjs`의 frontend/backend metadata drift detection
  - `ActiveLegalDocumentMetadata.current()`와 `front/src/apis/backend/legal.ts`의 공개 정책 원본 값 정렬
  - `ActiveLegalDocumentMetadataTest`가 정책 파일을 읽어 backend current metadata를 검증하는 방식

## 리스크

- 기존에 저장된 날짜형 `2026-06-21` 동의 이력은 그대로 조회될 수 있습니다. 이번 PR은 신규 가입·소셜 가입 payload와 current validation 기준을 공개 정책 원본 `1.0.0`으로 맞추는 변경입니다.
- `yarn --cwd front build` 첫 실행은 새 worktree의 `node_modules` 부재로 `next ENOENT` 환경 실패가 났고, `yarn --cwd front install --frozen-lockfile` 후 동일 명령이 성공했습니다.
- main merge 후 자동 CI/CD와 홈서버 배포 live e2e까지 성공했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
