### PR TITLE
[Docs] 개인정보 침해사고 대응과 운영 runbook 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ COPILOT.md
 docs/*
 !docs/design/
 !docs/design/**
+!docs/legal/
+!docs/legal/**
 .cursor/
 .claude/
 .aider/

--- a/docs/design/privacy-launch-gate-checklist.md
+++ b/docs/design/privacy-launch-gate-checklist.md
@@ -6,10 +6,10 @@
 
 | 항목 | 현재 판정 | 근거 | 다음 조치 |
 | --- | --- | --- | --- |
-| Production launch | `block` | #998, #1000, #1001, #1002, #1003, #1004, #1005, #1006, #1007, #1008이 open | 각 issue 완료 후 이 문서의 matrix와 evidence를 갱신한다. |
+| Production launch | `block` | #998, #1000, #1001, #1002, #1003, #1004, #1006, #1007, #1008이 open | 각 issue 완료 후 이 문서의 matrix와 evidence를 갱신한다. |
 | Public policy gate | `pass` | #1024, #1025, #1026, #1027, #1028 closed. `status: effective` 정책은 `reviewRequired=0`과 내부 검토 문구 미노출을 검증 대상으로 둔다. | `node tools/legal/validate-legal-policies.mjs`를 PR마다 실행한다. |
 | Legal sign-off | `block` | 실제 사업자 요건, processor 계약, 국외이전, 최종 정책 문구는 전문가 확인 전이다. | 출시 승인 전 법무/운영 owner가 evidence와 결정을 남긴다. |
-| Operations readiness | `block` | 침해사고 runbook, 보유기간 자동 파기, 백업 암호화/복구 privacy guard가 open issue다. | #1000, #1004, #1005 완료 후 재판정한다. |
+| Operations readiness | `block` | 보유기간 자동 파기와 백업 암호화/복구 privacy guard가 open issue다. | #1000, #1004 완료 후 재판정한다. |
 
 ## Owner And Contact
 
@@ -35,7 +35,7 @@
 | #1002 | Open | 필수 출시 전 완료 | analytics/cookie consent manager와 opt-out | consent UI, storage inventory, analytics disabled evidence | 차단 |
 | #1003 | Open | 필수 출시 전 완료 | Gemini tag recommendation 외부 처리 안전화 | default disabled config, redaction/cache regression test | 차단 |
 | #1004 | Open | 필수 출시 전 완료 | backup 암호화, deletion tombstone, restore privacy guard | backup artifact encryption, restore drill, deletion tombstone evidence | 차단 |
-| #1005 | Open | 필수 출시 전 완료 | 침해사고 대응 runbook | incident runbook, escalation/contact drill note | 차단 |
+| #1005 | Closed | 필수 출시 전 완료 | 침해사고 대응 runbook | `docs/legal/*.md`, tabletop exercise template, owner/contact/evidence 절차 | 완료 |
 | #1006 | Open | 필수 출시 전 완료 | 정책·코드 privacy drift gate | CI command, failing fixture example, passing workflow link | 차단 |
 | #1007 | Open | 필수 출시 전 완료 | 신규 개인정보 수집 feature flag 동결 | flag inventory, disabled-by-default evidence | 차단 |
 | #1008 | Open | 필수 출시 전 완료 | 기존 사용자 재동의와 legacy 고지 migration | legacy account migration, re-consent prompt, audit log evidence | 차단 |

--- a/docs/design/privacy-launch-gate-checklist.md
+++ b/docs/design/privacy-launch-gate-checklist.md
@@ -16,7 +16,7 @@
 | 역할 | Owner | 출시 전 확인 |
 | --- | --- | --- |
 | 서비스 운영 owner | AquilaXk | 운영 문의 수신, 권리 요청 처리, incident escalation을 승인한다. |
-| 개인정보 문의 수신처 | `aquilaxk10@gmail.com` | 실제 수신 가능 여부를 launch PR evidence에 남긴다. |
+| 개인정보 문의 수신처 | `privacy@aquila-blog.example` | 실제 공유 메일함 수신 가능 여부를 launch PR evidence에 남긴다. |
 | 법무 확인 owner | 외부 전문가 또는 서비스 운영자가 지정한 검토자 | 이 문서는 법률 자문이 아니며, 최종 법적 판단을 대체하지 않는다. |
 | 기술 evidence owner | PR 작성자 | 코드/정책/데이터맵/테스트 결과를 PR 본문과 이 문서에 연결한다. |
 

--- a/docs/legal/account-deletion-runbook.md
+++ b/docs/legal/account-deletion-runbook.md
@@ -21,7 +21,8 @@
 ## Deletion Steps
 
 1. 요청 id와 member id를 연결하고 본인확인 상태를 확인한다.
-2. 삭제 전 export 요청 여부와 법적 보존/분쟁/abuse hold 여부를 확인한다.
+2. 삭제 전 export 요청이 없거나 이미 완료됐는지, 법적 보존/분쟁/abuse hold 여부를 확인한다.
+   export가 pending이면 먼저 완료 또는 반려 사유를 기록한 뒤 삭제를 진행한다.
 3. active session, refresh token, API key, signup/session cookie를 revoke한다.
 4. member profile, email, nickname, OAuth link, legal acceptance metadata, privacy request metadata를 retention policy에 맞춰 soft delete, anonymize, 또는 보존 상태로 분류한다.
 5. posts/comments/profile content는 사용자 요청, 공개 게시 상태, 법적 보존 필요 여부에 따라 삭제 또는 anonymize한다.

--- a/docs/legal/account-deletion-runbook.md
+++ b/docs/legal/account-deletion-runbook.md
@@ -1,0 +1,61 @@
+# Account Deletion Runbook
+
+사용자 계정 삭제 요청, 재동의 거부 후 삭제 요청, 운영자 privacy deletion 처리에 사용하는 절차다.
+
+## Owner
+
+| 역할 | 담당 |
+| --- | --- |
+| Request owner | Privacy request owner |
+| Technical owner | member/privacy, post/comment, storage 담당 |
+| Infrastructure owner | backup/restore 담당 |
+| Legal counsel | 보존 예외 판단 필요 시 |
+
+## Trigger
+
+- `/settings/privacy` 계정 삭제 요청
+- 이메일로 접수된 삭제 요청이 본인확인 완료됨
+- 재동의 거부 사용자가 계정 삭제를 요청함
+- 침해사고 containment 후 특정 계정의 token/session/object 정리가 필요함
+
+## Deletion Steps
+
+1. 요청 id와 member id를 연결하고 본인확인 상태를 확인한다.
+2. 삭제 전 export 요청 여부와 법적 보존/분쟁/abuse hold 여부를 확인한다.
+3. active session, refresh token, API key, signup/session cookie를 revoke한다.
+4. member profile, email, nickname, OAuth link, legal acceptance metadata, privacy request metadata를 retention policy에 맞춰 soft delete, anonymize, 또는 보존 상태로 분류한다.
+5. posts/comments/profile content는 사용자 요청, 공개 게시 상태, 법적 보존 필요 여부에 따라 삭제 또는 anonymize한다.
+6. object storage 파일과 derived cache를 삭제 queue에 넣고 result를 기록한다.
+7. backup tombstone을 남겨 restore 후 삭제 상태가 되살아나지 않도록 한다.
+8. cache, search index, public feed, sitemap, CDN을 revalidate 또는 purge한다.
+
+## Backup Tombstone
+
+- tombstone key: `account-deletion:<memberId>:<requestId>`.
+- 포함 항목: member id, deletedAt, request id, deletion scope, object key hash list, legal hold 여부.
+- 포함 금지: email 원문, token 원문, object 원본 URL secret.
+- restore 후 traffic open 전에 tombstone replay 결과를 확인한다.
+
+## Evidence
+
+| Evidence | 내용 |
+| --- | --- |
+| deletion request record | request id, member id, verifiedAt, owner |
+| session revoke proof | revoked session count, command/API result |
+| row/object summary | deleted/anonymized/skipped row count, object key hash count |
+| tombstone proof | tombstone id, createdAt, replay status |
+| user response | 완료 또는 제한 사유 전달 시각 |
+
+## Exit Criteria
+
+- 사용자에게 완료 또는 제한 사유가 전달됐다.
+- active login/session이 더 이상 유효하지 않다.
+- public content/cache가 삭제 또는 anonymized 상태로 보인다.
+- backup tombstone이 생성되고 restore drill에서 replay 대상에 포함된다.
+- 법적 보존 예외가 있으면 owner, reason, review date가 있다.
+
+## Validation
+
+- 테스트 계정 삭제 요청으로 API 또는 운영 절차 dry run을 수행한다.
+- restore drill 후 삭제된 테스트 계정이 재노출되지 않는지 확인한다.
+- export/delete 안내는 `docs/legal/data-subject-request-runbook.md`와 충돌하지 않아야 한다.

--- a/docs/legal/backup-restore-privacy-runbook.md
+++ b/docs/legal/backup-restore-privacy-runbook.md
@@ -25,7 +25,7 @@
 3. restore 전 최신 deletion tombstone과 retention cutoff를 준비한다.
 4. PostgreSQL restore 후 tombstone replay를 실행하거나 수동 검증 query를 수행한다.
 5. object storage restore 후 tombstone object key hash list가 재노출되지 않는지 확인한다.
-6. session/token/auth cookie 관련 데이터가 restore 후 재사용 가능하지 않은지 확인한다.
+6. session, token, auth cookie뿐 아니라 API key, refresh token 등 모든 인증 자산이 restore 후 재사용 가능하지 않은지 확인한다.
 7. public edge probe와 live E2E는 privacy gate pass 전에는 production traffic에 연결하지 않는다.
 
 ## Tombstone Replay Checklist
@@ -38,7 +38,7 @@
 | post/comment | 삭제 또는 anonymized 상태 유지 |
 | object storage | 삭제 대상 key 재생성 없음 |
 | cache/index | restored stale cache purge |
-| session/token | active session 재활성화 없음 |
+| auth asset | active session, refresh token, API key 재활성화 없음 |
 
 ## Evidence
 
@@ -52,7 +52,7 @@
 
 - tombstone replay 또는 동등한 deletion verification이 pass다.
 - 개인정보 삭제/처리정지 요청이 restore로 되돌아가지 않았다.
-- token/session이 재활성화되지 않았다.
+- token/session/API key/refresh token이 재활성화되지 않았다.
 - service owner가 traffic open을 승인했다.
 - 실패 항목은 production 연결 전에 issue/PR로 분리됐다.
 

--- a/docs/legal/backup-restore-privacy-runbook.md
+++ b/docs/legal/backup-restore-privacy-runbook.md
@@ -1,0 +1,63 @@
+# Backup Restore Privacy Runbook
+
+운영 backup 복원, restore drill, disaster recovery 중 삭제된 개인정보가 되살아나거나 정책과 다른 상태로 노출되지 않도록 확인하는 절차다.
+
+## Owner
+
+| 역할 | 담당 |
+| --- | --- |
+| Infrastructure owner | Home server backup/restore 담당 |
+| Privacy owner | Privacy request owner |
+| Service owner | Traffic open 승인자 |
+| Legal counsel | 법적 보존/삭제 충돌 검토 필요 시 |
+
+## Trigger
+
+- `Backup Restore Drill` workflow 수동 실행
+- 운영 DB 또는 object storage restore
+- incident containment 후 clean backup 검증
+- 계정 삭제 tombstone 또는 retention job 변경 후 restore 재검증
+
+## Restore Privacy Gate
+
+1. restore target이 production traffic과 격리되어 있는지 확인한다.
+2. backup set id, backup class, source time, restore target, operator를 기록한다.
+3. restore 전 최신 deletion tombstone과 retention cutoff를 준비한다.
+4. PostgreSQL restore 후 tombstone replay를 실행하거나 수동 검증 query를 수행한다.
+5. object storage restore 후 tombstone object key hash list가 재노출되지 않는지 확인한다.
+6. session/token/auth cookie 관련 데이터가 restore 후 재사용 가능하지 않은지 확인한다.
+7. public edge probe와 live E2E는 privacy gate pass 전에는 production traffic에 연결하지 않는다.
+
+## Tombstone Replay Checklist
+
+| 대상 | 확인 |
+| --- | --- |
+| member row | deleted/anonymized 상태 유지 |
+| legal acceptance | 법적 보존 필요 metadata만 보존 |
+| privacy request | request audit record 유지 |
+| post/comment | 삭제 또는 anonymized 상태 유지 |
+| object storage | 삭제 대상 key 재생성 없음 |
+| cache/index | restored stale cache purge |
+| session/token | active session 재활성화 없음 |
+
+## Evidence
+
+- workflow run link와 artifact: `restore-drill-summary.md`, `restore-drill-result.env`, checksum file.
+- backup set id, restore startedAt/completedAt, RPO/RTO.
+- tombstone replay result: count, skipped with reason, failure list.
+- object checksum result와 redacted sample.
+- traffic open approval: approver, timestamp, gate result.
+
+## Exit Criteria
+
+- tombstone replay 또는 동등한 deletion verification이 pass다.
+- 개인정보 삭제/처리정지 요청이 restore로 되돌아가지 않았다.
+- token/session이 재활성화되지 않았다.
+- service owner가 traffic open을 승인했다.
+- 실패 항목은 production 연결 전에 issue/PR로 분리됐다.
+
+## Validation
+
+- `Backup Restore Drill` workflow를 실행하고 artifact를 확인한다.
+- 삭제된 테스트 계정 tombstone을 포함한 fixture로 restore privacy gate를 검증한다.
+- RPO/RTO 결과와 privacy deletion result를 launch gate evidence에 연결한다.

--- a/docs/legal/data-subject-request-runbook.md
+++ b/docs/legal/data-subject-request-runbook.md
@@ -1,0 +1,57 @@
+# Data Subject Request Runbook
+
+정보주체의 열람, 정정, 삭제, 처리정지, 동의 철회, export 요청을 처리하는 절차다. 외부 법정 기한과 거절 사유는 legal counsel 확인이 필요하다.
+
+## Owner
+
+| 역할 | 담당 |
+| --- | --- |
+| Intake owner | `aquilaxk10@gmail.com` 수신 담당 |
+| Privacy request owner | Service owner |
+| Technical owner | member/privacy API 담당 |
+| Legal counsel | 출시 전 지정 필요 |
+
+## Trigger
+
+- `/settings/privacy` 또는 이메일로 개인정보 열람, 정정, 삭제, 처리정지, 동의 철회, export 요청 접수
+- 계정 삭제 flow 실패 또는 legacy user 재동의 거부 후 export/delete 안내
+- processor 또는 backup restore 과정에서 사용자 데이터 확인 요청 발생
+
+## Intake And Identity Check
+
+1. 요청 id를 만든다: `privacy-request-YYYYMMDD-NN`.
+2. 요청 유형을 `access`, `correction`, `deletion`, `restriction`, `withdrawal`, `export` 중 하나로 분류한다.
+3. 로그인 상태 요청은 session member id와 요청 id를 연결한다.
+4. 이메일 요청은 계정 소유 증명 절차를 진행한다. password, token, 원본 cookie, 전체 log를 이메일로 요구하지 않는다.
+5. 미확인 요청은 `identity_pending` 상태로 두고 처리 기한과 추가 확인 필요 항목을 기록한다.
+
+## Handling Matrix
+
+| 요청 | 처리 절차 | 거절 또는 제한 사유 |
+| --- | --- | --- |
+| 열람 | account, legal acceptance, privacy request, 공개 content, session summary를 export snapshot으로 제공 | 다른 사용자의 정보 포함, 보안상 session secret 원문 포함 요청 |
+| 정정 | 사용자가 직접 수정 가능한 profile/content 경로 안내, 직접 수정 불가 데이터는 운영 변경 기록 작성 | 감사/보안 로그처럼 정정 대신 보존 사유가 있는 데이터 |
+| 삭제 | `docs/legal/account-deletion-runbook.md`를 따른다 | 법적 보존, 분쟁 대응, 보안 abuse 조사 기간 |
+| 처리정지 | optional tracking, Gemini, analytics, marketing-like processing을 중단하거나 비활성 상태 확인 | 서비스 제공에 필수인 인증/session 처리 |
+| 동의 철회 | optional consent를 철회하고 향후 processing 중단 | 필수 약관/개인정보 처리 동의 철회는 계정 제한 또는 삭제 안내 |
+| export | machine-readable snapshot 생성, 민감 token 원문 제외 | 본인확인 실패, 타인 정보 포함 |
+
+## Evidence
+
+- 요청 id, 접수 시각, requester channel, identity verification status.
+- 처리 유형, owner, due date, decision, user response sent at.
+- export/delete 결과는 원문 대신 file hash, row count, redaction note만 남긴다.
+- 이메일 원문이나 신분증 사본은 repository에 커밋하지 않는다.
+
+## Exit Criteria
+
+- 사용자에게 처리 결과 또는 제한 사유가 전달됐다.
+- 내부 기록에 요청 id, 처리자, 처리 시각, evidence 위치가 남았다.
+- 삭제나 export가 실행된 경우 관련 API/workflow output과 redacted summary가 남았다.
+- 처리 불가 또는 법무 검토 필요 건은 follow-up owner와 due date가 있다.
+
+## Validation
+
+- 테스트 계정으로 export 요청을 만들고 snapshot에 최신 legal acceptance metadata가 포함되는지 확인한다.
+- 삭제 요청 dry run은 실제 운영 계정이 아닌 테스트 계정에서만 수행한다.
+- 처리 기록에는 개인정보 원문 대신 redacted sample과 row count만 포함되는지 확인한다.

--- a/docs/legal/data-subject-request-runbook.md
+++ b/docs/legal/data-subject-request-runbook.md
@@ -6,7 +6,7 @@
 
 | 역할 | 담당 |
 | --- | --- |
-| Intake owner | `aquilaxk10@gmail.com` 수신 담당 |
+| Intake owner | `privacy@aquila-blog.example` 공유 메일함 담당 |
 | Privacy request owner | Service owner |
 | Technical owner | member/privacy API 담당 |
 | Legal counsel | 출시 전 지정 필요 |
@@ -21,9 +21,10 @@
 
 1. 요청 id를 만든다: `privacy-request-YYYYMMDD-NN`.
 2. 요청 유형을 `access`, `correction`, `deletion`, `restriction`, `withdrawal`, `export` 중 하나로 분류한다.
-3. 로그인 상태 요청은 session member id와 요청 id를 연결한다.
-4. 이메일 요청은 계정 소유 증명 절차를 진행한다. password, token, 원본 cookie, 전체 log를 이메일로 요구하지 않는다.
-5. 미확인 요청은 `identity_pending` 상태로 두고 처리 기한과 추가 확인 필요 항목을 기록한다.
+3. 로그인 상태 요청도 access, export, deletion, restriction, withdrawal 같은 고위험 작업이면 재인증 또는 step-up verification을 진행한다.
+4. 재인증이 끝난 로그인 요청은 session member id와 요청 id를 연결한다.
+5. 이메일 요청은 계정 소유 증명 절차를 진행한다. password, token, 원본 cookie, 전체 log를 이메일로 요구하지 않는다.
+6. 미확인 요청은 `identity_pending` 상태로 두고 처리 기한과 추가 확인 필요 항목을 기록한다.
 
 ## Handling Matrix
 

--- a/docs/legal/policy-change-runbook.md
+++ b/docs/legal/policy-change-runbook.md
@@ -8,7 +8,7 @@
 | --- | --- |
 | Policy author | Service owner |
 | Technical owner | frontend/backend legal metadata 담당 |
-| Privacy reviewer | `aquilaxk10@gmail.com` 운영 담당 |
+| Privacy reviewer | `privacy@aquila-blog.example` 공유 메일함 담당 |
 | Legal counsel | 출시 전 지정 필요 |
 
 ## Trigger
@@ -20,7 +20,7 @@
 ## Change Steps
 
 1. 변경 유형을 `minor_notice`, `material_reconsent`, `legal_correction`, `processor_update` 중 하나로 분류한다.
-2. 새 policy YAML을 작성하고 version, effectiveDate, contentSha256를 확정한다.
+2. 새 policy YAML을 작성하고 version, publishedAt, effectiveAt, contentSha256를 확정한다.
 3. material change이면 재동의 필요 여부와 대상 계정을 기록한다.
 4. `ActiveLegalDocumentMetadata.kt`, `front/src/apis/backend/legal.ts`, `front/src/libs/legal/serverPolicySource.ts`가 같은 version/hash를 가리키는지 확인한다.
 5. 공개 페이지 `/privacy`, `/terms`, `/cookies`, `/legal/history`에서 current link와 이전 version link를 확인한다.
@@ -39,7 +39,7 @@
 
 ## Evidence
 
-- policy diff, version/hash table, effective date.
+- policy diff, version/hash table, publishedAt/effectiveAt.
 - validator output: `node tools/legal/validate-legal-policies.mjs`.
 - backend/frontend active metadata check.
 - e2e 또는 live screenshot path for `/privacy`, `/terms`, `/cookies`, `/legal/history`.

--- a/docs/legal/policy-change-runbook.md
+++ b/docs/legal/policy-change-runbook.md
@@ -1,0 +1,59 @@
+# Policy Change Runbook
+
+개인정보처리방침, 이용약관, 쿠키 정책의 version, hash, 시행일, 재동의 필요 여부를 배포하는 절차다.
+
+## Owner
+
+| 역할 | 담당 |
+| --- | --- |
+| Policy author | Service owner |
+| Technical owner | frontend/backend legal metadata 담당 |
+| Privacy reviewer | `aquilaxk10@gmail.com` 운영 담당 |
+| Legal counsel | 출시 전 지정 필요 |
+
+## Trigger
+
+- 수집 항목, 처리 목적, 보유기간, processor, 국외이전, 사용자 권리 처리, 문의처 변경
+- terms/privacy/cookies YAML version 추가 또는 `status: effective` 변경
+- backend active legal metadata 또는 signup consent payload 변경
+
+## Change Steps
+
+1. 변경 유형을 `minor_notice`, `material_reconsent`, `legal_correction`, `processor_update` 중 하나로 분류한다.
+2. 새 policy YAML을 작성하고 version, effectiveDate, contentSha256를 확정한다.
+3. material change이면 재동의 필요 여부와 대상 계정을 기록한다.
+4. `ActiveLegalDocumentMetadata.kt`, `front/src/apis/backend/legal.ts`, `front/src/libs/legal/serverPolicySource.ts`가 같은 version/hash를 가리키는지 확인한다.
+5. 공개 페이지 `/privacy`, `/terms`, `/cookies`, `/legal/history`에서 current link와 이전 version link를 확인한다.
+6. `status: effective` 정책에는 `reviewRequired`, `출시 gate`, `추후 확정`, `구현 후 제공` 같은 내부 문구를 남기지 않는다.
+7. 배포 후 live URL에서 정책 제목, 시행일, hash/download, 문의 링크를 확인한다.
+
+## Re-consent Decision
+
+| 변경 | 재동의 판단 |
+| --- | --- |
+| 필수 수집 항목 증가 | 재동의 필요 |
+| processor 또는 국외이전 실질 변경 | 법무 확인 후 재동의 또는 사전 고지 |
+| 보유기간 확대 | 재동의 또는 명시 고지 필요 |
+| 오탈자, 링크, 담당자 표기 보정 | 고지만 가능할 수 있음 |
+| optional tracking 추가 | opt-in consent 필요 |
+
+## Evidence
+
+- policy diff, version/hash table, effective date.
+- validator output: `node tools/legal/validate-legal-policies.mjs`.
+- backend/frontend active metadata check.
+- e2e 또는 live screenshot path for `/privacy`, `/terms`, `/cookies`, `/legal/history`.
+- re-consent decision note와 legal review status.
+
+## Exit Criteria
+
+- policy YAML, frontend route, backend active metadata가 같은 version/hash다.
+- validator와 policy page e2e가 통과했다.
+- material change의 재동의 대상과 gate가 확정됐다.
+- 사용자 고지 또는 재동의 UI evidence가 PR에 연결됐다.
+
+## Validation
+
+- `node tools/legal/validate-legal-policies.mjs`
+- `yarn --cwd front playwright:preflight`
+- 정책 페이지 e2e 또는 live URL 확인 결과를 PR evidence table에 남긴다.

--- a/docs/legal/privacy-incident-runbook.md
+++ b/docs/legal/privacy-incident-runbook.md
@@ -7,7 +7,7 @@
 | 역할 | 담당 |
 | --- | --- |
 | Service owner | AquilaXk |
-| Privacy contact | `aquilaxk10@gmail.com` |
+| Privacy contact | `privacy@aquila-blog.example` |
 | Security owner | Service owner가 지정한 incident lead |
 | Infrastructure owner | Home server / GitHub Actions / Vercel / Cloudflare 운영 담당 |
 | Legal counsel | 출시 전 지정 필요 |

--- a/docs/legal/privacy-incident-runbook.md
+++ b/docs/legal/privacy-incident-runbook.md
@@ -1,0 +1,76 @@
+# Privacy Incident Runbook
+
+개인정보 침해 의심 상황을 감지했을 때 사용하는 운영 절차다. 이 문서는 법률 자문이 아니며, 신고·통지 의무와 기한은 service owner가 legal counsel과 함께 최종 판단한다.
+
+## Owner
+
+| 역할 | 담당 |
+| --- | --- |
+| Service owner | AquilaXk |
+| Privacy contact | `aquilaxk10@gmail.com` |
+| Security owner | Service owner가 지정한 incident lead |
+| Infrastructure owner | Home server / GitHub Actions / Vercel / Cloudflare 운영 담당 |
+| Legal counsel | 출시 전 지정 필요 |
+
+## Trigger
+
+- 인증 token, email, IP, user agent, OAuth subject, 게시글 비공개 데이터, backup, log, analytics payload가 허가 없이 노출된 정황
+- GitHub Actions artifact, server log, browser console, backup restore 결과, vendor dashboard에서 개인정보 과다 수집 또는 외부 전송 의심
+- 사용자 또는 외부 제보로 개인정보 오처리, 삭제 실패, export 오발송, 계정 접근 이상이 접수됨
+
+## Triage
+
+1. incident lead를 1명 지정하고 incident id를 만든다: `privacy-incident-YYYYMMDD-NN`.
+2. 새 쓰기 작업, 관련 배포, backup restore, vendor 설정 변경을 중단한다.
+3. 의심 데이터 유형, 최초 감지 시각, 관련 user id 범위, 시스템 범위, 외부 processor 관련 여부를 기록한다.
+4. 실제 개인정보 원문은 issue, PR, chat, repository에 쓰지 않는다. 민감 증거는 로컬 encrypted storage 또는 제한된 incident vault에 보관하고 evidence log에는 위치와 hash만 남긴다.
+5. false positive일 가능성이 있어도 1차 containment 전에는 로그를 삭제하지 않는다.
+
+## Containment
+
+| 상황 | 즉시 조치 |
+| --- | --- |
+| token/session 노출 | 관련 session revoke, cookie/token rotation, auth log 보존 |
+| 공개 페이지 노출 | page 또는 route disable, cache purge, Vercel/Cloudflare invalidation |
+| GitHub artifact 노출 | artifact 다운로드 중단, retention 축소, secret rotation 검토 |
+| vendor 전송 의심 | optional tracking/Gemini/vendor integration disable, processor contact |
+| backup/restore 오복원 | traffic open 중단, tombstone replay, restore target 격리 |
+
+## Impact Assessment
+
+- 영향 데이터: email, nickname, OAuth subject hash, legal acceptance metadata, post/comment/profile content, token/session, backup object, log identifier.
+- 영향 주체: signup applicant, registered member, public visitor, admin.
+- 노출 경로: app response, log, artifact, external processor, backup restore, public cache.
+- 범위 산정: affected member count, affected record count, first/last exposure time, external access 가능성.
+- 법무 판단 분리: 신고·통지 대상, 기한, 문구, 관계 기관은 legal counsel 확인 후 결정한다.
+
+## Notification And Reporting
+
+1. service owner가 법무 확인 필요 여부를 `required`, `not required`, `unknown` 중 하나로 기록한다.
+2. 사용자 통지가 필요하면 영향 범위, 발생 시각, 조치 현황, 사용자가 할 수 있는 조치, 문의처를 포함한다.
+3. 관계 기관 신고가 필요하면 신고 전 증거 보존 상태와 containment 완료 여부를 확인한다.
+4. 사용자 통지 문안과 신고 문안은 repository에 원문 개인정보 없이 보관한다.
+
+## Evidence
+
+| Evidence | 저장 위치 |
+| --- | --- |
+| incident timeline | incident vault 또는 제한된 운영 문서 |
+| affected record query | query text는 commit 가능, 결과 원본은 commit 금지 |
+| log sample | redacted sample만 PR/issue 허용 |
+| containment proof | workflow link, command output, dashboard screenshot path |
+| user notification draft | 개인정보 없는 template 또는 제한 문서 |
+
+## Exit Criteria
+
+- containment가 완료되고 신규 노출 경로가 닫혔다.
+- 영향 범위와 법무 판단 상태가 기록됐다.
+- 사용자 통지/신고 필요 여부가 결정됐다.
+- 재발 방지 issue 또는 PR이 생성됐다.
+- `docs/legal/privacy-tabletop-exercise-template.md` 형식으로 postmortem과 follow-up owner를 남겼다.
+
+## Validation
+
+- 분기 1회 또는 상용 출시 전 1회 tabletop exercise를 실행한다.
+- 테스트 시나리오: "GitHub Actions artifact에 redaction 누락 log가 포함됨".
+- exercise evidence는 실제 개인정보 없이 incident id, 참여자, decision log, missing control, follow-up issue만 남긴다.

--- a/docs/legal/privacy-tabletop-exercise-template.md
+++ b/docs/legal/privacy-tabletop-exercise-template.md
@@ -1,0 +1,52 @@
+# Privacy Tabletop Exercise Template
+
+개인정보 운영 runbook을 분기 1회 또는 상용 출시 전 1회 검증하기 위한 기록 양식이다. 실제 개인정보, secret, token, 원본 log는 이 문서나 repository에 기록하지 않는다.
+
+## Exercise Header
+
+| 항목 | 값 |
+| --- | --- |
+| Exercise id | `privacy-tabletop-YYYYMMDD-NN` |
+| Date |  |
+| Facilitator |  |
+| Participants | Service owner, privacy contact, security owner, infrastructure owner, legal reviewer |
+| Scenario |  |
+| Related runbook |  |
+
+## Scenario Examples
+
+- GitHub Actions artifact에 redaction 누락 application log가 포함됨.
+- 삭제 완료된 테스트 계정이 restore drill 후 일부 cache에 다시 보임.
+- optional analytics가 opt-out 후에도 web vital payload를 전송함.
+- processor region 또는 DPA 확인 전 외부 email provider가 활성화됨.
+
+## Timeline
+
+| Time | Event | Decision | Owner | Evidence |
+| --- | --- | --- | --- | --- |
+|  | Detection |  |  |  |
+|  | Triage |  |  |  |
+|  | Containment |  |  |  |
+|  | User/legal decision |  |  |  |
+|  | Recovery |  |  |  |
+
+## Control Checklist
+
+| Control | Pass/Fail | Evidence | Follow-up |
+| --- | --- | --- | --- |
+| Owner assigned within 15 minutes |  |  |  |
+| Sensitive evidence kept out of repository |  |  |  |
+| Affected data categories identified |  |  |  |
+| Processor impact checked |  |  |  |
+| User notification/legal review path identified |  |  |  |
+| Deletion/export impact checked |  |  |  |
+| Backup restore privacy gate considered |  |  |  |
+| Follow-up issue created for missing control |  |  |  |
+
+## Exit Record
+
+- Final decision:
+- Missing controls:
+- Follow-up issue links:
+- Evidence location:
+- Next exercise due:

--- a/docs/legal/vendor-onboarding-runbook.md
+++ b/docs/legal/vendor-onboarding-runbook.md
@@ -1,0 +1,58 @@
+# Vendor Onboarding Runbook
+
+새 processor, sub-processor, analytics, AI, email, hosting, monitoring, backup provider를 추가하거나 처리 목적을 바꿀 때 사용하는 절차다.
+
+## Owner
+
+| 역할 | 담당 |
+| --- | --- |
+| Service owner | AquilaXk |
+| Security reviewer | Service owner가 지정 |
+| Privacy reviewer | `aquilaxk10@gmail.com` 운영 담당 |
+| Legal counsel | 출시 전 지정 필요 |
+
+## Trigger
+
+- `legal/vendors/processors.yaml`에 processor를 추가 또는 변경
+- `legal/data-map/processing-activities.yaml`의 processors, overseasTransfer, retentionRule 변경
+- Gemini, analytics/RUM, SMTP, Vercel, Cloudflare, backup storage, monitoring provider의 데이터 범위 변경
+
+## Review Steps
+
+1. processor 이름, 서비스 URL, 처리 목적, 데이터 카테고리, data subject, 국가/region, 보유기간, sub-processor 여부를 기록한다.
+2. DPA, 이용약관, 보안 문서, 국외이전 조건, 삭제/반환 조건을 확인한다.
+3. 최소 전송 원칙을 검토한다. secret, access token, raw email, OAuth subject 원문이 불필요하게 전송되면 block한다.
+4. feature flag 또는 env kill switch가 있는지 확인한다.
+5. `legal/vendors/processors.yaml`, `legal/data-map/processing-activities.yaml`, 공개 정책 문서의 processor section을 같은 PR에서 갱신한다.
+6. 법무 확인 필요 항목은 `reviewRequired` 또는 launch gate issue에 남기고 `status: effective` 공개 정책에는 내부 검토 문구를 노출하지 않는다.
+
+## Approval Gate
+
+| Gate | Pass | Block |
+| --- | --- | --- |
+| Data minimization | 필요한 필드만 전송 | raw secret/token/불필요한 PII 전송 |
+| Contract evidence | DPA 또는 동등한 계약 검토 기록 존재 | 계약/삭제 조건 불명확 |
+| Overseas transfer | 국가, 이전 항목, 보유기간, 사용자 고지 판단 기록 | 국외이전 여부 미확인 |
+| Runtime control | env/feature flag로 disable 가능 | 장애 또는 거부 시 즉시 중단 불가 |
+| Policy alignment | data map, processor registry, policy가 일치 | 문서와 코드 동작 불일치 |
+
+## Evidence
+
+- processor review note: provider, scope, data categories, legal review status.
+- DPA/security document link 또는 restricted evidence path.
+- policy/data-map diff.
+- kill switch 또는 env var 확인 command output.
+- test 또는 dry run request/response sample은 redacted 상태만 저장한다.
+
+## Exit Criteria
+
+- registry, data map, policy, code configuration이 같은 의미로 정렬됐다.
+- legal counsel이 필요한 항목과 기술적으로 검증된 항목이 분리됐다.
+- processor 장애 또는 계약 문제 발생 시 disable 절차가 문서화됐다.
+- launch gate matrix에서 관련 issue 상태와 evidence가 갱신됐다.
+
+## Validation
+
+- `node tools/legal/validate-legal-policies.mjs`를 실행한다.
+- processor id가 `legal/data-map/processing-activities.yaml`와 `legal/vendors/processors.yaml`에 일관되게 존재하는지 확인한다.
+- optional integration은 disabled 환경에서 외부 요청이 발생하지 않는지 테스트한다.

--- a/docs/legal/vendor-onboarding-runbook.md
+++ b/docs/legal/vendor-onboarding-runbook.md
@@ -8,7 +8,7 @@
 | --- | --- |
 | Service owner | AquilaXk |
 | Security reviewer | Service owner가 지정 |
-| Privacy reviewer | `aquilaxk10@gmail.com` 운영 담당 |
+| Privacy reviewer | `privacy@aquila-blog.example` 공유 메일함 담당 |
 | Legal counsel | 출시 전 지정 필요 |
 
 ## Trigger

--- a/tools/guards/check-forbidden-tracked-files.sh
+++ b/tools/guards/check-forbidden-tracked-files.sh
@@ -27,7 +27,8 @@ is_allowed_markdown() {
     perf/k6/README.md|\
     tools/templates/agent-plan.compact.md|\
     tools/templates/bug-report.compact.md|\
-    docs/design/*.md)
+    docs/design/*.md|\
+    docs/legal/*.md)
       return 0
       ;;
   esac

--- a/tools/test/check-forbidden-tracked-files.test.sh
+++ b/tools/test/check-forbidden-tracked-files.test.sh
@@ -37,6 +37,11 @@ if ! run_with_temp_index "git update-index --add --cacheinfo 100644 '${readme_bl
   exit 1
 fi
 
+if ! run_with_temp_index "git update-index --add --cacheinfo 100644 '${readme_blob}' docs/legal/privacy-incident-runbook.md && bash '${guard}' >'${guard_output}' 2>&1"; then
+  echo "[test] expected tracked docs/legal/privacy-incident-runbook.md to be allowed" >&2
+  exit 1
+fi
+
 if run_with_temp_index "git update-index --add --cacheinfo 100644 '${readme_blob}' back/new-report.md && bash '${guard}' >'${guard_output}' 2>&1"; then
   echo "[test] expected tracked back/new-report.md to be rejected" >&2
   exit 1
@@ -49,6 +54,11 @@ fi
 
 if ! run_with_temp_index "git update-index --add --cacheinfo 100644 '${readme_blob}' docs/design/contract.md && bash '${guard}' --staged >'${guard_output}' 2>&1"; then
   echo "[test] expected staged docs/design/contract.md to be allowed" >&2
+  exit 1
+fi
+
+if ! run_with_temp_index "git update-index --add --cacheinfo 100644 '${readme_blob}' docs/legal/privacy-incident-runbook.md && bash '${guard}' --staged >'${guard_output}' 2>&1"; then
+  echo "[test] expected staged docs/legal/privacy-incident-runbook.md to be allowed" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## 관련 이슈

close #1005

## 작업 배경

- #1005는 개인정보 침해사고, 정보주체 요청, vendor 변경, 정책 변경, 계정 삭제, backup restore privacy 상황을 실제 수행 가능한 운영 runbook으로 문서화해야 합니다.
- 저장소에는 `docs/legal` runbook 산출물이 없었고, 기존 문서 guard는 `docs/design/**`만 tracked 문서로 허용해 #1005의 명시 산출물 경로를 커밋할 수 없었습니다.

## 작업 내용

- `docs/legal/privacy-incident-runbook.md`를 추가해 감지, triage, containment, evidence preservation, 영향 범위 산정, 통지/신고 검토, 종료 조건을 정리했습니다.
- 정보주체 요청, vendor onboarding, policy change, account deletion, backup restore privacy runbook과 tabletop exercise template을 추가했습니다.
- CodeRabbit inline review 6건을 반영해 export pending 삭제 gate, restore 인증 자산 검증, DSR step-up verification, policy YAML 필드명, role-based privacy 연락망을 보강했습니다.
- `docs/design/privacy-launch-gate-checklist.md`에서 #1005를 완료 산출물로 연결하고 남은 operations blocker를 #1000, #1004로 좁혔습니다.
- `.gitignore`와 `tools/guards/check-forbidden-tracked-files.sh`/test에 `docs/legal/*.md` allowlist를 추가해 legal runbook만 tracked 가능하게 했습니다.

## 검증

- 실행한 명령과 결과:
  - `test -f docs/legal/privacy-incident-runbook.md`: exit 0
  - `test -f docs/legal/data-subject-request-runbook.md`: exit 0
  - `test -f docs/legal/vendor-onboarding-runbook.md`: exit 0
  - `test -f docs/legal/policy-change-runbook.md`: exit 0
  - `test -f docs/legal/account-deletion-runbook.md`: exit 0
  - `test -f docs/legal/backup-restore-privacy-runbook.md`: exit 0
  - `test -f docs/legal/privacy-tabletop-exercise-template.md`: exit 0
  - `rg "Owner|Trigger|Evidence|Exit Criteria|Tabletop|Validation|privacy@aquila-blog.example|publishedAt|effectiveAt|step-up verification|refresh token" docs/legal docs/design/privacy-launch-gate-checklist.md`: exit 0
  - `rg -n "aquilaxk10@gmail\.com|effectiveDate|session/token" docs/legal docs/design/privacy-launch-gate-checklist.md`: exit 1, 금지 패턴 없음
  - `node tools/legal/validate-legal-policies.mjs`: exit 0, `[legal-policies] ok: 7 policies`
  - `bash tools/test/check-forbidden-tracked-files.test.sh`: exit 0, `[test] forbidden tracked docs guard passed`
  - `CURRENT_TASK_SLUG=issue-1005-privacy-incident-runbooks bash tools/guards/current-task-preflight.sh`: exit 0
  - GitHub Actions: `frontend-ci`, `backend-ci`, `backend-dependency-check`, `codeql (java-kotlin)`, `codeql (javascript-typescript)`, `CodeQL` 모두 pass
  - CodeRabbit: review completed, inline review thread 6건 모두 addressed/resolved
  - Vercel preview: external preview deployment rate limited, `Deployment rate limited — retry in 24 hours`; branch protection required check 아님, docs-only PR 런타임 배포 영향 없음

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| runbook 파일 존재 | local macOS | `test -f` 7개 파일 확인 | `docs/legal/*.md` | 통과 |
| 필수 섹션 및 review 보강 | local macOS | `rg`로 owner/trigger/evidence/exit/tabletop/validation/alias/schema/step-up 확인 | command output에 각 runbook heading과 보강 문구 표시 | 통과 |
| 개인 메일/구필드 제거 | local macOS | `rg -n "aquilaxk10@gmail\.com|effectiveDate|session/token" ...` | exit 1, match 없음 | 통과 |
| 정책 validator | local macOS | `node tools/legal/validate-legal-policies.mjs` | `[legal-policies] ok: 7 policies` | 통과 |
| tracked docs guard | local macOS | `bash tools/test/check-forbidden-tracked-files.test.sh` | `[test] forbidden tracked docs guard passed` | 통과 |
| current-task scope | local macOS | current-task preflight | `ok: current-task state/scope verified` | 통과 |
| PR CI | GitHub Actions | PR #1035 checks | frontend/backend/security/codeql pass | 통과 |
| Code review | GitHub / CodeRabbit | review + thread-aware GraphQL 확인 | 6개 thread `isResolved=true`, CodeRabbit success | 통과 |
| Vercel preview | Vercel external status | PR check 확인 | build rate limit URL | 외부 preview rate limit, docs-only 비차단 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `docs/legal/privacy-incident-runbook.md`, `docs/legal/data-subject-request-runbook.md`, `docs/legal/backup-restore-privacy-runbook.md`입니다.
- `docs/legal/*.md` allowlist는 #1005의 명시 산출물 경로를 추적하기 위한 최소 변경입니다. agent-only `docs/agent/**`나 임의 `docs/*.md`는 계속 차단됩니다.
- `privacy@aquila-blog.example`은 개인 Gmail을 문서에서 제거하기 위한 role-based alias 자리이며, 실제 출시 전 공유 메일함 수신 가능 여부를 launch evidence에 남겨야 합니다.

## 리스크

- 코드 런타임 변경은 없습니다.
- 이 문서는 법률 자문이 아니며, 신고·통지 기한과 문구는 출시 전 legal counsel 확인이 필요하다고 명시했습니다.
- 실제 개인정보, secret, token, 원본 log는 evidence로 커밋하지 않도록 제한했습니다.
- Vercel preview는 계정 build rate limit로 실패했지만, PR 변경은 docs/guard 문서 범위이며 GitHub Actions와 CodeRabbit은 통과했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.