### PR TITLE
[Chore] 출시 전 신규 개인정보 수집 feature flag 동결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -404,6 +404,11 @@ jobs:
           HOME_AI_SUMMARY_ENABLED: ${{ secrets.CUSTOM__AI__SUMMARY__ENABLED || vars.CUSTOM__AI__SUMMARY__ENABLED || '' }}
           HOME_AI_SUMMARY_GEMINI_API_KEY: ${{ secrets.CUSTOM__AI__SUMMARY__GEMINI__API_KEY || vars.CUSTOM__AI__SUMMARY__GEMINI__API_KEY || '' }}
           HOME_AI_SUMMARY_GEMINI_MODEL: ${{ secrets.CUSTOM__AI__SUMMARY__GEMINI__MODEL || vars.CUSTOM__AI__SUMMARY__GEMINI__MODEL || '' }}
+          HOME_MEMBER_SIGNUP_ENABLED: ${{ secrets.CUSTOM__MEMBER__SIGNUP__ENABLED || vars.CUSTOM__MEMBER__SIGNUP__ENABLED || 'false' }}
+          HOME_MEMBER_OAUTH_SIGNUP_ENABLED: ${{ secrets.CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED || vars.CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED || 'false' }}
+          HOME_AI_TAG_ENABLED: ${{ secrets.CUSTOM__AI__TAG__ENABLED || vars.CUSTOM__AI__TAG__ENABLED || 'false' }}
+          HOME_NEXT_PUBLIC_SIGNUP_ENABLED: ${{ secrets.NEXT_PUBLIC_SIGNUP_ENABLED || vars.NEXT_PUBLIC_SIGNUP_ENABLED || 'false' }}
+          HOME_NEXT_PUBLIC_RUM_SAMPLE_RATE: ${{ secrets.NEXT_PUBLIC_RUM_SAMPLE_RATE || vars.NEXT_PUBLIC_RUM_SAMPLE_RATE || '0' }}
         run: |
           set -euo pipefail
           PORT="${HOME_SSH_PORT:-22}"
@@ -420,6 +425,11 @@ jobs:
             printf 'HOME_AI_SUMMARY_ENABLED=%q\n' "${HOME_AI_SUMMARY_ENABLED:-}"
             printf 'HOME_AI_SUMMARY_GEMINI_API_KEY=%q\n' "${HOME_AI_SUMMARY_GEMINI_API_KEY:-}"
             printf 'HOME_AI_SUMMARY_GEMINI_MODEL=%q\n' "${HOME_AI_SUMMARY_GEMINI_MODEL:-}"
+            printf 'HOME_MEMBER_SIGNUP_ENABLED=%q\n' "${HOME_MEMBER_SIGNUP_ENABLED:-false}"
+            printf 'HOME_MEMBER_OAUTH_SIGNUP_ENABLED=%q\n' "${HOME_MEMBER_OAUTH_SIGNUP_ENABLED:-false}"
+            printf 'HOME_AI_TAG_ENABLED=%q\n' "${HOME_AI_TAG_ENABLED:-false}"
+            printf 'HOME_NEXT_PUBLIC_SIGNUP_ENABLED=%q\n' "${HOME_NEXT_PUBLIC_SIGNUP_ENABLED:-false}"
+            printf 'HOME_NEXT_PUBLIC_RUM_SAMPLE_RATE=%q\n' "${HOME_NEXT_PUBLIC_RUM_SAMPLE_RATE:-0}"
           } > "${LOCAL_REMOTE_VARS_FILE}"
           chmod 600 "${LOCAL_REMOTE_VARS_FILE}"
 
@@ -667,6 +677,27 @@ jobs:
           upsert_env_key "CUSTOM__AI__SUMMARY__ENABLED" "${HOME_AI_SUMMARY_ENABLED:-}" "deploy/homeserver/.env.prod"
           upsert_env_key "CUSTOM__AI__SUMMARY__GEMINI__API_KEY" "${HOME_AI_SUMMARY_GEMINI_API_KEY:-}" "deploy/homeserver/.env.prod"
           upsert_env_key "CUSTOM__AI__SUMMARY__GEMINI__MODEL" "${HOME_AI_SUMMARY_GEMINI_MODEL:-}" "deploy/homeserver/.env.prod"
+
+          require_privacy_freeze_value() {
+            local key="$1"
+            local actual="$2"
+            local expected="$3"
+            if [ "${actual:-${expected}}" != "${expected}" ]; then
+              echo "privacy freeze flag must stay ${expected}: ${key}=${actual}" >&2
+              exit 1
+            fi
+          }
+
+          require_privacy_freeze_value "CUSTOM__MEMBER__SIGNUP__ENABLED" "${HOME_MEMBER_SIGNUP_ENABLED:-false}" "false"
+          require_privacy_freeze_value "CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED" "${HOME_MEMBER_OAUTH_SIGNUP_ENABLED:-false}" "false"
+          require_privacy_freeze_value "CUSTOM__AI__TAG__ENABLED" "${HOME_AI_TAG_ENABLED:-false}" "false"
+          require_privacy_freeze_value "NEXT_PUBLIC_SIGNUP_ENABLED" "${HOME_NEXT_PUBLIC_SIGNUP_ENABLED:-false}" "false"
+          require_privacy_freeze_value "NEXT_PUBLIC_RUM_SAMPLE_RATE" "${HOME_NEXT_PUBLIC_RUM_SAMPLE_RATE:-0}" "0"
+          upsert_env_key "CUSTOM__MEMBER__SIGNUP__ENABLED" "${HOME_MEMBER_SIGNUP_ENABLED:-false}" "deploy/homeserver/.env.prod"
+          upsert_env_key "CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED" "${HOME_MEMBER_OAUTH_SIGNUP_ENABLED:-false}" "deploy/homeserver/.env.prod"
+          upsert_env_key "CUSTOM__AI__TAG__ENABLED" "${HOME_AI_TAG_ENABLED:-false}" "deploy/homeserver/.env.prod"
+          upsert_env_key "NEXT_PUBLIC_SIGNUP_ENABLED" "${HOME_NEXT_PUBLIC_SIGNUP_ENABLED:-false}" "deploy/homeserver/.env.prod"
+          upsert_env_key "NEXT_PUBLIC_RUM_SAMPLE_RATE" "${HOME_NEXT_PUBLIC_RUM_SAMPLE_RATE:-0}" "deploy/homeserver/.env.prod"
 
           # prod에서 sql.init 경로가 켜지면 부팅 실패(DO $$ 분리/DDL 충돌)로 이어질 수 있다.
           # HOME_SERVER_ENV 드리프트가 있어도 배포 직전에 안전값으로 강제한다.

--- a/.github/workflows/reusable-frontend-verify.yml
+++ b/.github/workflows/reusable-frontend-verify.yml
@@ -206,12 +206,15 @@ jobs:
       - name: Run smoke e2e
         if: steps.changes.outputs.frontend == 'true'
         working-directory: front
+        env:
+          NEXT_PUBLIC_SIGNUP_ENABLED: "true"
         run: yarn test:e2e:smoke
 
       - name: Run legal privacy e2e
         if: steps.changes.outputs.frontend == 'true'
         working-directory: front
         env:
+          NEXT_PUBLIC_SIGNUP_ENABLED: "true"
           NEXT_PUBLIC_RUM_SAMPLE_RATE: "1"
           NODE_ENV: production
           VERCEL_ENV: production

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt
@@ -5,6 +5,7 @@ import com.back.boundedContexts.member.subContexts.legalAcceptance.application.s
 import com.back.boundedContexts.member.subContexts.signupVerification.application.service.MemberSignupVerificationService
 import com.back.boundedContexts.member.subContexts.signupVerification.application.service.SignupEmailStartResult
 import com.back.boundedContexts.member.subContexts.signupVerification.application.service.SignupEmailVerifyResult
+import com.back.global.exception.application.AppException
 import com.back.global.rsData.RsData
 import com.back.global.web.application.Rq
 import io.swagger.v3.oas.annotations.media.Schema
@@ -13,6 +14,7 @@ import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.GetMapping
@@ -29,6 +31,8 @@ import java.time.Instant
 class ApiV1SignupVerificationController(
     private val memberSignupVerificationService: MemberSignupVerificationService,
     private val rq: Rq,
+    @param:Value("\${custom.member.signup.enabled:false}")
+    private val signupEnabled: Boolean,
 ) {
     companion object {
         const val SIGNUP_SESSION_COOKIE_NAME = "signup_session"
@@ -112,6 +116,8 @@ class ApiV1SignupVerificationController(
     fun start(
         @RequestBody @Valid reqBody: SignupEmailStartRequest,
     ): RsData<SignupEmailStartResult> {
+        requireSignupEnabled()
+
         val result =
             memberSignupVerificationService.start(
                 email = reqBody.email,
@@ -165,6 +171,8 @@ class ApiV1SignupVerificationController(
     fun complete(
         @RequestBody @Valid reqBody: SignupCompleteRequest,
     ): RsData<MemberDto> {
+        requireSignupEnabled()
+
         val member =
             memberSignupVerificationService.completeSignup(
                 signupToken = rq.getCookieValue(SIGNUP_SESSION_COOKIE_NAME, ""),
@@ -187,4 +195,10 @@ class ApiV1SignupVerificationController(
             .seconds
             .coerceIn(1, Int.MAX_VALUE.toLong())
             .toInt()
+
+    private fun requireSignupEnabled() {
+        if (!signupEnabled) {
+            throw AppException("503-5", "회원가입은 출시 준비 중입니다.")
+        }
+    }
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt
@@ -148,6 +148,8 @@ class ApiV1SignupVerificationController(
     fun verify(
         @RequestBody @Valid reqBody: SignupEmailVerifyRequest,
     ): RsData<SignupEmailVerifyResult> {
+        requireSignupEnabled()
+
         val result = memberSignupVerificationService.verifyEmail(reqBody.token)
         rq.setCookie(
             SIGNUP_SESSION_COOKIE_NAME,

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginFailureHandler.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginFailureHandler.kt
@@ -13,6 +13,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 private const val OAUTH_SIGNUP_REQUIRED_ERROR = "signup-required"
+private const val OAUTH_SIGNUP_DISABLED_ERROR = "signup-disabled"
 private const val OAUTH_FAILED_ERROR = "oauth-failed"
 
 @Component
@@ -64,12 +65,20 @@ internal fun buildOAuth2LoginFailureRedirectUrl(
 }
 
 private fun resolveOAuth2LoginFailureCode(exception: AuthenticationException): String =
-    if (containsAppExceptionCode(exception, "403-4")) OAUTH_SIGNUP_REQUIRED_ERROR else OAUTH_FAILED_ERROR
+    when {
+        containsOAuthSignupDisabledException(exception) -> OAUTH_SIGNUP_DISABLED_ERROR
+        containsAppExceptionCode(exception, "403-4") -> OAUTH_SIGNUP_REQUIRED_ERROR
+        else -> OAUTH_FAILED_ERROR
+    }
 
 private fun findOAuthSignupRequiredException(exception: Throwable): OAuthSignupRequiredAuthenticationException? =
     generateSequence(exception as Throwable?) { it.cause }
         .filterIsInstance<OAuthSignupRequiredAuthenticationException>()
         .firstOrNull()
+
+private fun containsOAuthSignupDisabledException(exception: Throwable): Boolean =
+    generateSequence(exception as Throwable?) { it.cause }
+        .any { it is OAuthSignupDisabledAuthenticationException }
 
 private fun containsAppExceptionCode(
     throwable: Throwable,

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserService.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserService.kt
@@ -7,6 +7,7 @@ import com.back.global.security.domain.SecurityUser
 import com.back.global.security.domain.toGrantedAuthorities
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.authentication.InternalAuthenticationServiceException
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
@@ -37,6 +38,8 @@ private enum class OAuth2Provider {
 class CustomOAuth2UserService(
     private val memberUseCase: MemberUseCase,
     private val oauthSignupUseCase: OAuthSignupUseCase,
+    @param:Value("\${custom.member.oauth-signup.enabled:false}")
+    private val oauthSignupEnabled: Boolean = false,
 ) : OAuth2UserService<OAuth2UserRequest, OAuth2User> {
     internal var delegate: OAuth2UserService<OAuth2UserRequest, OAuth2User> = DefaultOAuth2UserService()
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -55,6 +58,7 @@ class CustomOAuth2UserService(
             profilePayload = profilePayload,
             memberUseCase = memberUseCase,
             oauthSignupUseCase = oauthSignupUseCase,
+            oauthSignupEnabled = oauthSignupEnabled,
             logger = logger,
         ).toSecurityUser()
     }
@@ -64,6 +68,8 @@ class CustomOAuth2UserService(
 class CustomOidcUserService(
     private val memberUseCase: MemberUseCase,
     private val oauthSignupUseCase: OAuthSignupUseCase,
+    @param:Value("\${custom.member.oauth-signup.enabled:false}")
+    private val oauthSignupEnabled: Boolean = false,
 ) : OAuth2UserService<OidcUserRequest, OidcUser> {
     internal var delegate: OAuth2UserService<OidcUserRequest, OidcUser> = OidcUserService()
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -82,6 +88,7 @@ class CustomOidcUserService(
                 profilePayload = profilePayload,
                 memberUseCase = memberUseCase,
                 oauthSignupUseCase = oauthSignupUseCase,
+                oauthSignupEnabled = oauthSignupEnabled,
                 logger = logger,
             )
 
@@ -94,6 +101,7 @@ private fun loadExistingMemberOrStartSignup(
     profilePayload: OAuth2ProfilePayload,
     memberUseCase: MemberUseCase,
     oauthSignupUseCase: OAuthSignupUseCase,
+    oauthSignupEnabled: Boolean,
     logger: Logger,
 ): Member {
     val providerSubjectHash =
@@ -121,6 +129,9 @@ private fun loadExistingMemberOrStartSignup(
             ?: memberUseCase.findByLoginId(legacyLoginId)
 
     if (member == null) {
+        if (!oauthSignupEnabled) {
+            throw OAuthSignupDisabledAuthenticationException(provider.name)
+        }
         throw buildPendingSignupException(provider, profilePayload, oauthSignupUseCase)
     }
 
@@ -154,6 +165,10 @@ internal class OAuthSignupRequiredAuthenticationException(
     val pendingToken: String,
     val expiresAt: Instant,
 ) : InternalAuthenticationServiceException("OAuth signup requires local consent.")
+
+internal class OAuthSignupDisabledAuthenticationException(
+    val provider: String,
+) : InternalAuthenticationServiceException("OAuth signup is temporarily disabled.")
 
 private fun Member.toSecurityUser(): SecurityUser =
     SecurityUser(

--- a/back/src/main/resources/application-test.yaml
+++ b/back/src/main/resources/application-test.yaml
@@ -26,6 +26,7 @@ spring:
 custom:
   member:
     signup:
+      enabled: true
       legacyDirectJoinEnabled: true
   admin:
     username: admin

--- a/back/src/main/resources/application.yaml
+++ b/back/src/main/resources/application.yaml
@@ -178,6 +178,7 @@ custom:
     redisDatabase: "${custom.dev.redisDatabase}"
   member:
     signup:
+      enabled: ${CUSTOM__MEMBER__SIGNUP__ENABLED:false}
       legacyDirectJoinEnabled: ${CUSTOM__MEMBER__SIGNUP__LEGACY_DIRECT_JOIN_ENABLED:false}
       verifyPath: ${CUSTOM__MEMBER__SIGNUP__VERIFY_PATH:/signup/verify}
       emailExpirationSeconds: ${CUSTOM__MEMBER__SIGNUP__EMAIL_EXPIRATION_SECONDS:86400}
@@ -191,6 +192,8 @@ custom:
         memoryMaxEntries: ${CUSTOM__MEMBER__SIGNUP__STARTRATELIMIT__MEMORY_MAX_ENTRIES:10000}
         memoryCleanupIntervalSeconds: ${CUSTOM__MEMBER__SIGNUP__STARTRATELIMIT__MEMORY_CLEANUP_INTERVAL_SECONDS:60}
         requireRedisInProd: ${CUSTOM__MEMBER__SIGNUP__STARTRATELIMIT__REQUIRE_REDIS_IN_PROD:true}
+    oauth-signup:
+      enabled: ${CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED:false}
     notification:
       realtime:
         enabled: ${CUSTOM__MEMBER__NOTIFICATION__REALTIME__ENABLED:true}

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationFeatureFreezeTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationFeatureFreezeTest.kt
@@ -38,4 +38,19 @@ class ApiV1SignupVerificationFeatureFreezeTest : BaseSignupDisabledControllerInt
         assertThat(memberSignupVerificationRepository.findTopByEmailOrderByCreatedAtDesc("freeze@example.com"))
             .isNull()
     }
+
+    @Test
+    fun `email signup flag가 꺼져 있으면 토큰 검증과 세션 쿠키 발급도 차단한다`() {
+        val response =
+            mvc
+                .post("/member/api/v1/signup/email/verify") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = """{"token": "freeze-token"}"""
+                }.andExpect {
+                    status { isServiceUnavailable() }
+                }.andReturn()
+                .response
+
+        assertThat(response.getHeader("Set-Cookie")).isNull()
+    }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationFeatureFreezeTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationFeatureFreezeTest.kt
@@ -1,0 +1,41 @@
+package com.back.boundedContexts.member.subContexts.signupVerification.adapter.web
+
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.ActiveLegalDocumentMetadata
+import com.back.boundedContexts.member.subContexts.signupVerification.adapter.persistence.MemberSignupVerificationRepository
+import com.back.support.BaseSignupDisabledControllerIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.post
+
+@DisplayName("ApiV1SignupVerificationController feature freeze 테스트")
+class ApiV1SignupVerificationFeatureFreezeTest : BaseSignupDisabledControllerIntegrationTest() {
+    private val legalPolicyVersion = ActiveLegalDocumentMetadata.current().signupPolicyVersion
+
+    @Autowired
+    private lateinit var memberSignupVerificationRepository: MemberSignupVerificationRepository
+
+    @Test
+    fun `email signup flag가 꺼져 있으면 인증 시작 전에 차단한다`() {
+        mvc
+            .post("/member/api/v1/signup/email/start") {
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "email": "freeze@example.com",
+                        "termsAccepted": true,
+                        "privacyAccepted": true,
+                        "legalPolicyVersion": "$legalPolicyVersion"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isServiceUnavailable() }
+            }
+
+        assertThat(memberSignupVerificationRepository.findTopByEmailOrderByCreatedAtDesc("freeze@example.com"))
+            .isNull()
+    }
+}

--- a/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginFailureHandlerTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2LoginFailureHandlerTest.kt
@@ -76,6 +76,29 @@ class CustomOAuth2LoginFailureHandlerTest {
     }
 
     @Test
+    fun `신규 OAuth 가입 feature freeze는 로그인 화면에 signup-disabled 코드와 next를 전달한다`() {
+        val handler = CustomOAuth2LoginFailureHandler("https://www.aquilaxk.site")
+        val request =
+            MockHttpServletRequest("GET", "/login/oauth2/code/kakao").apply {
+                setParameter("state", OAuth2State("/posts/1?tab=comments", "state-id").encode())
+            }
+        val response = MockHttpServletResponse()
+
+        handler.onAuthenticationFailure(
+            request,
+            response,
+            InternalAuthenticationServiceException(
+                "oauth user service failed",
+                OAuthSignupDisabledAuthenticationException("KAKAO"),
+            ),
+        )
+
+        assertThat(response.status).isEqualTo(302)
+        assertThat(response.redirectedUrl)
+            .isEqualTo("https://www.aquilaxk.site/login?oauthError=signup-disabled&next=%2Fposts%2F1%3Ftab%3Dcomments")
+    }
+
+    @Test
     fun `신규 OAuth 가입 차단 실패는 로그인 화면에 signup-required 코드와 next를 전달한다`() {
         val handler = CustomOAuth2LoginFailureHandler("https://www.aquilaxk.site")
         val request =

--- a/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserServiceTest.kt
@@ -121,7 +121,11 @@ class CustomOAuth2UserServiceTest {
         val memberUseCase = RecordingMemberUseCase()
         val oauthSignupUseCase = RecordingOAuthSignupUseCase()
         val service =
-            CustomOAuth2UserService(memberUseCase.proxy, oauthSignupUseCase).apply {
+            CustomOAuth2UserService(
+                memberUseCase.proxy,
+                oauthSignupUseCase,
+                oauthSignupEnabled = true,
+            ).apply {
                 delegate =
                     OAuth2UserService<OAuth2UserRequest, OAuth2User> {
                         DefaultOAuth2User(emptyList(), mapOf("id" to "new-oauth-user-id"), "id")
@@ -145,6 +149,29 @@ class CustomOAuth2UserServiceTest {
                     profileImgUrl = null,
                 ),
             )
+    }
+
+    @Test
+    fun `OAuth2 신규 가입 flag가 꺼져 있으면 pending 동의 토큰을 발급하지 않는다`() {
+        val memberUseCase = RecordingMemberUseCase()
+        val oauthSignupUseCase = RecordingOAuthSignupUseCase()
+        val service =
+            CustomOAuth2UserService(memberUseCase.proxy, oauthSignupUseCase).apply {
+                delegate =
+                    OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+                        DefaultOAuth2User(emptyList(), mapOf("id" to "new-oauth-user-id"), "id")
+                    }
+            }
+
+        assertThatThrownBy {
+            service.loadUser(
+                OAuth2UserRequest(kakaoClientRegistration(userNameAttributeName = "id"), accessToken()),
+            )
+        }.isInstanceOf(OAuthSignupDisabledAuthenticationException::class.java)
+            .hasMessageNotContaining("new-oauth-user-id")
+
+        assertThat(memberUseCase.findLoginIds).containsExactly("KAKAO__subject-hash", "KAKAO__new-oauth-user-id")
+        assertThat(oauthSignupUseCase.pendingStarts).isEmpty()
     }
 
     @Test

--- a/back/src/test/kotlin/com/back/support/BaseMemberControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseMemberControllerWebMvcTest.kt
@@ -8,6 +8,8 @@ import com.back.global.app.AppConfig
 import com.back.global.security.application.SecurityTipProvider
 import com.back.global.security.config.CustomAuthenticationFilter
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
@@ -46,6 +48,9 @@ abstract class BaseMemberControllerWebMvcTest : BaseIntegrationTest() {
     @MockitoBean
     protected lateinit var securityTipProvider: SecurityTipProvider
 
+    @MockitoBean
+    protected lateinit var adminProperties: AdminProperties
+
     @MockitoBean(name = "jpaMappingContext")
     protected lateinit var jpaMappingContext: JpaMetamodelMappingContext
 
@@ -58,6 +63,11 @@ abstract class BaseMemberControllerWebMvcTest : BaseIntegrationTest() {
                 siteFrontUrl = "http://localhost:3000",
             )
         }
+    }
+
+    @BeforeEach
+    fun setUpAdminProperties() {
+        given(adminProperties.normalizedEmail).willReturn("admin@test.com")
     }
 
     @TestConfiguration
@@ -79,8 +89,5 @@ abstract class BaseMemberControllerWebMvcTest : BaseIntegrationTest() {
 
         @Bean
         fun appExceptionStatusCodeResolver(): ResponseStatusExceptionResolver = ResponseStatusExceptionResolver()
-
-        @Bean
-        fun adminProperties(): AdminProperties = AdminProperties(username = "admin", email = "admin@test.com")
     }
 }

--- a/back/src/test/kotlin/com/back/support/BaseSignupDisabledControllerIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseSignupDisabledControllerIntegrationTest.kt
@@ -1,0 +1,10 @@
+package com.back.support
+
+import org.springframework.test.context.TestPropertySource
+
+@TestPropertySource(
+    properties = [
+        "custom.member.signup.enabled=false",
+    ],
+)
+abstract class BaseSignupDisabledControllerIntegrationTest : BaseControllerIntegrationTest()

--- a/deploy/env/env.contract.json
+++ b/deploy/env/env.contract.json
@@ -112,6 +112,11 @@
         { "name": "CUSTOM__MEMBER__SIGNUP__VERIFY_PATH", "required": false },
         { "name": "CUSTOM__MEMBER__SIGNUP__EMAIL_EXPIRATION_SECONDS", "kind": "integer", "required": false },
         { "name": "CUSTOM__MEMBER__SIGNUP__SESSION_EXPIRATION_SECONDS", "kind": "integer", "required": false },
+        { "name": "CUSTOM__MEMBER__SIGNUP__ENABLED", "kind": "boolean", "required": false, "allowedValues": ["false"] },
+        { "name": "CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED", "kind": "boolean", "required": false, "allowedValues": ["false"] },
+        { "name": "CUSTOM__AI__TAG__ENABLED", "kind": "boolean", "required": false, "allowedValues": ["false"] },
+        { "name": "NEXT_PUBLIC_SIGNUP_ENABLED", "kind": "boolean", "required": false, "allowedValues": ["false"] },
+        { "name": "NEXT_PUBLIC_RUM_SAMPLE_RATE", "required": false, "allowedValues": ["0"] },
         { "name": "MINIO_ROOT_USER" },
         { "name": "MINIO_ROOT_PASSWORD", "secret": true, "minLength": 8 },
         { "name": "CUSTOM_STORAGE_ENABLED", "kind": "boolean" },
@@ -211,6 +216,11 @@
         { "name": "CUSTOM__AI__SUMMARY__ENABLED", "from": ["CUSTOM__AI__SUMMARY__ENABLED"], "fallback": "false" },
         { "name": "CUSTOM__AI__SUMMARY__GEMINI__API_KEY", "from": ["CUSTOM__AI__SUMMARY__GEMINI__API_KEY"], "fallback": "" },
         { "name": "CUSTOM__AI__SUMMARY__GEMINI__MODEL", "from": ["CUSTOM__AI__SUMMARY__GEMINI__MODEL"], "fallback": "gemini-2.5-flash" },
+        { "name": "CUSTOM__MEMBER__SIGNUP__ENABLED", "fallback": "false" },
+        { "name": "CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED", "fallback": "false" },
+        { "name": "CUSTOM__AI__TAG__ENABLED", "fallback": "false" },
+        { "name": "NEXT_PUBLIC_SIGNUP_ENABLED", "fallback": "false" },
+        { "name": "NEXT_PUBLIC_RUM_SAMPLE_RATE", "fallback": "0" },
         { "name": "SPRING__SECURITY__OAUTH2__CLIENT__REGISTRATION__KAKAO__CLIENT_ID", "from": ["SPRING__SECURITY__OAUTH2__CLIENT__REGISTRATION__KAKAO__CLIENT_ID"], "fallback": "" }
       ]
     }

--- a/docs/design/privacy-launch-gate-checklist.md
+++ b/docs/design/privacy-launch-gate-checklist.md
@@ -6,7 +6,7 @@
 
 | 항목 | 현재 판정 | 근거 | 다음 조치 |
 | --- | --- | --- | --- |
-| Production launch | `block` | #998, #1000, #1001, #1002, #1003, #1004, #1006, #1007, #1008이 open | 각 issue 완료 후 이 문서의 matrix와 evidence를 갱신한다. |
+| Production launch | `block` | #998, #1000, #1001, #1002, #1003, #1004, #1006, #1008이 open | 각 issue 완료 후 이 문서의 matrix와 evidence를 갱신한다. |
 | Public policy gate | `pass` | #1024, #1025, #1026, #1027, #1028 closed. `status: effective` 정책은 `reviewRequired=0`과 내부 검토 문구 미노출을 검증 대상으로 둔다. | `node tools/legal/validate-legal-policies.mjs`를 PR마다 실행한다. |
 | Legal sign-off | `block` | 실제 사업자 요건, processor 계약, 국외이전, 최종 정책 문구는 전문가 확인 전이다. | 출시 승인 전 법무/운영 owner가 evidence와 결정을 남긴다. |
 | Operations readiness | `block` | 보유기간 자동 파기와 백업 암호화/복구 privacy guard가 open issue다. | #1000, #1004 완료 후 재판정한다. |
@@ -37,7 +37,7 @@
 | #1004 | Open | 필수 출시 전 완료 | backup 암호화, deletion tombstone, restore privacy guard | backup artifact encryption, restore drill, deletion tombstone evidence | 차단 |
 | #1005 | Closed | 필수 출시 전 완료 | 침해사고 대응 runbook | `docs/legal/*.md`, tabletop exercise template, owner/contact/evidence 절차 | 완료 |
 | #1006 | Open | 필수 출시 전 완료 | 정책·코드 privacy drift gate | CI command, failing fixture example, passing workflow link | 차단 |
-| #1007 | Open | 필수 출시 전 완료 | 신규 개인정보 수집 feature flag 동결 | flag inventory, disabled-by-default evidence | 차단 |
+| #1007 | Closed | 필수 출시 전 완료 | 신규 개인정보 수집 feature flag 동결 | `back/gradlew -p back ciFastCheck --rerun-tasks` 2회 연속 exit 0, `yarn --cwd front build` 2회 exit 0, privacy data-map/env contract validator exit 0 | 완료 |
 | #1008 | Open | 필수 출시 전 완료 | 기존 사용자 재동의와 legacy 고지 migration | legacy account migration, re-consent prompt, audit log evidence | 차단 |
 | #1024 | Closed | 필수 출시 전 완료 | 공개 정책과 legal acceptance version/hash 단일화 | `ActiveLegalDocumentMetadata`와 public policy hash evidence | 완료 |
 | #1025 | Closed | 필수 출시 전 완료 | effective 정책의 내부 검토 문구 제거 | `reviewRequired=0`, internal phrase validator, page e2e | 완료 |

--- a/front/src/components/auth/AuthEntryModal.tsx
+++ b/front/src/components/auth/AuthEntryModal.tsx
@@ -50,6 +50,8 @@ const SignupSentPanel = dynamic(loadSignupSentPanel, {
   loading: AuthEntryPanelFallback,
 })
 
+const SIGNUP_ENABLED = process.env.NEXT_PUBLIC_SIGNUP_ENABLED === "true"
+
 export const preloadAuthEntryPanels = (view: AuthModalView = "login") => {
   if (view === "signup") {
     void loadSignupPanel()
@@ -185,6 +187,11 @@ const AuthEntryModal: React.FC<AuthEntryModalProps> = ({
 
   const handleSignupEmailStart = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    if (!SIGNUP_ENABLED) {
+      setSignupError("회원가입은 출시 전 개인정보 처리 점검이 완료될 때까지 사용할 수 없습니다.")
+      return
+    }
+
     const normalizedEmail = normalizeAuthEmail(signupEmail)
 
     if (!normalizedEmail) {

--- a/front/src/components/auth/AuthEntrySignupPanel.tsx
+++ b/front/src/components/auth/AuthEntrySignupPanel.tsx
@@ -19,6 +19,8 @@ type Props = {
   onSwitchToLogin: () => void
 }
 
+const SIGNUP_ENABLED = process.env.NEXT_PUBLIC_SIGNUP_ENABLED === "true"
+
 const AuthEntrySignupPanel = ({
   signupEmail,
   signupError,
@@ -36,6 +38,20 @@ const AuthEntrySignupPanel = ({
   const [emailFocused, setEmailFocused] = useState(false)
   const emailActive = useMemo(() => emailFocused || signupEmail.length > 0, [emailFocused, signupEmail])
   const signupConsentAccepted = termsAccepted && privacyAccepted
+
+  if (!SIGNUP_ENABLED) {
+    return (
+      <>
+        <p className="inlineError">회원가입은 출시 전 개인정보 처리 점검이 완료될 때까지 사용할 수 없습니다.</p>
+        <div className="signupRow">
+          <span>이미 계정이 있으신가요?</span>
+          <button type="button" className="inlineLinkButton" onClick={onSwitchToLogin}>
+            로그인
+          </button>
+        </div>
+      </>
+    )
+  }
 
   return (
     <>

--- a/front/src/libs/rum/reportWebVital.ts
+++ b/front/src/libs/rum/reportWebVital.ts
@@ -32,8 +32,8 @@ const ALLOWED_METRICS = new Set<NextWebVitalsMetric["name"]>([
 ])
 
 const toSampleRate = () => {
-  const raw = Number(process.env.NEXT_PUBLIC_RUM_SAMPLE_RATE || "0.2")
-  if (!Number.isFinite(raw)) return 0.2
+  const raw = Number(process.env.NEXT_PUBLIC_RUM_SAMPLE_RATE || "0")
+  if (!Number.isFinite(raw)) return 0
   return Math.min(1, Math.max(0, raw))
 }
 

--- a/front/src/pages/login.tsx
+++ b/front/src/pages/login.tsx
@@ -76,9 +76,11 @@ const LoginPage = () => {
   useEffect(() => {
     if (!oauthError) return
     setError(
-      oauthError === "signup-required"
-        ? "소셜 로그인 신규 가입은 현재 지원하지 않습니다. 이메일 회원가입으로 먼저 약관과 개인정보처리방침에 동의해주세요."
-        : "소셜 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.",
+      oauthError === "signup-disabled"
+        ? "신규 소셜 회원가입은 출시 전 개인정보 처리 점검이 완료될 때까지 사용할 수 없습니다. 기존 계정은 계속 로그인할 수 있습니다."
+        : oauthError === "signup-required"
+          ? "소셜 로그인 신규 가입은 현재 지원하지 않습니다. 이메일 회원가입으로 먼저 약관과 개인정보처리방침에 동의해주세요."
+          : "소셜 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.",
     )
   }, [oauthError])
 

--- a/front/src/pages/signup.tsx
+++ b/front/src/pages/signup.tsx
@@ -24,6 +24,8 @@ type SignupEmailStartResult = {
   email: string
 }
 
+const SIGNUP_ENABLED = process.env.NEXT_PUBLIC_SIGNUP_ENABLED === "true"
+
 export const getServerSideProps: GetServerSideProps<GuestPageProps> = async ({ req }) => {
   return await getGuestPageProps(req)
 }
@@ -91,6 +93,32 @@ const SignupPage = () => {
     } finally {
       setLoading(false)
     }
+  }
+
+  if (!SIGNUP_ENABLED) {
+    return (
+      <AuthShell
+        activeTab="signup"
+        title="회원가입 준비 중"
+        subtitle="개인정보 처리 점검이 끝난 뒤 다시 열립니다."
+        eyebrow="Account Setup"
+        heroTitle="회원가입 준비 중"
+        heroDescription="현재 신규 회원가입은 잠시 닫혀 있습니다."
+        footer={
+          <FooterText>
+            이미 계정이 있으면 <Link href={toLoginPath(next)}>로그인</Link>
+            <span className="policyLinks">
+              <Link href={legalPolicyCurrentPaths.privacy}>개인정보처리방침</Link>
+              <Link href={legalPolicyCurrentPaths.terms}>이용약관</Link>
+            </span>
+          </FooterText>
+        }
+        loginHref={toLoginPath(next)}
+        signupHref={toSignupPath(next)}
+      >
+        <SuccessText>회원가입은 출시 전 개인정보 처리 점검이 완료될 때까지 사용할 수 없습니다.</SuccessText>
+      </AuthShell>
+    )
   }
 
   return (

--- a/front/src/pages/signup/social/complete.tsx
+++ b/front/src/pages/signup/social/complete.tsx
@@ -30,6 +30,8 @@ type SocialSignupFragment = {
   next: string
 }
 
+const SIGNUP_ENABLED = process.env.NEXT_PUBLIC_SIGNUP_ENABLED === "true"
+
 export const getServerSideProps: GetServerSideProps<GuestPageProps> = async ({ req }) => {
   return await getGuestPageProps(req)
 }
@@ -77,6 +79,10 @@ const SocialSignupCompletePage = () => {
 
   useEffect(() => {
     if (!router.isReady) return
+    if (!SIGNUP_ENABLED) {
+      setLoadingPending(false)
+      return
+    }
 
     const existingToken = pendingTokenRef.current
     const fragment = existingToken ? null : readSocialSignupFragment()
@@ -183,6 +189,28 @@ const SocialSignupCompletePage = () => {
     } finally {
       setSubmitLoading(false)
     }
+  }
+
+  if (!SIGNUP_ENABLED) {
+    return (
+      <AuthShell
+        activeTab="signup"
+        title="소셜 회원가입 준비 중"
+        eyebrow="Social Signup"
+        heroTitle="소셜 회원가입 준비 중"
+        heroDescription="현재 신규 소셜 회원가입은 잠시 닫혀 있습니다."
+        hideTabs
+        footer={
+          <FooterText>
+            계정이 있으면 <Link href={toLoginPath(next)}>로그인</Link>
+          </FooterText>
+        }
+        loginHref={toLoginPath(next)}
+        signupHref={toSignupPath(next)}
+      >
+        <InfoText>소셜 회원가입은 출시 전 개인정보 처리 점검이 완료될 때까지 사용할 수 없습니다.</InfoText>
+      </AuthShell>
+    )
   }
 
   return (

--- a/front/src/pages/signup/verify.tsx
+++ b/front/src/pages/signup/verify.tsx
@@ -24,6 +24,8 @@ type SignupVerifyResult = {
   expiresAt: string
 }
 
+const SIGNUP_ENABLED = process.env.NEXT_PUBLIC_SIGNUP_ENABLED === "true"
+
 export const getServerSideProps: GetServerSideProps<GuestPageProps> = async ({ req }) => {
   return await getGuestPageProps(req)
 }
@@ -64,6 +66,10 @@ const SignupVerifyPage = () => {
 
   useEffect(() => {
     if (!router.isReady) return
+    if (!SIGNUP_ENABLED) {
+      setLoadingVerification(false)
+      return
+    }
 
     const token = verificationTokenRef.current ?? readSignupVerificationTokenFromFragment()
     verificationTokenRef.current = token
@@ -176,6 +182,28 @@ const SignupVerifyPage = () => {
     } finally {
       setSubmitLoading(false)
     }
+  }
+
+  if (!SIGNUP_ENABLED) {
+    return (
+      <AuthShell
+        activeTab="signup"
+        title="회원가입 준비 중"
+        eyebrow="Verified Email"
+        heroTitle="회원가입 준비 중"
+        heroDescription="현재 신규 회원가입은 잠시 닫혀 있습니다."
+        hideTabs
+        footer={
+          <FooterText>
+            계정이 있으면 <Link href={toLoginPath(next)}>로그인</Link>
+          </FooterText>
+        }
+        loginHref={toLoginPath(next)}
+        signupHref={toSignupPath(next)}
+      >
+        <InfoText>회원가입은 출시 전 개인정보 처리 점검이 완료될 때까지 사용할 수 없습니다.</InfoText>
+      </AuthShell>
+    )
   }
 
   return (

--- a/legal/data-map/processing-activities.yaml
+++ b/legal/data-map/processing-activities.yaml
@@ -30,7 +30,7 @@ activities:
     userRightsHandler: privacyRequestEmailAndFutureAccountDeletionFlow
     codeOwner: back/member-auth
     policySectionId: privacy-collection-account
-    enabledByEnv: custom.member.signup.enabled; frontend signup route availability
+    enabledByEnv: custom.member.signup.enabled defaults false via CUSTOM__MEMBER__SIGNUP__ENABLED; NEXT_PUBLIC_SIGNUP_ENABLED defaults false
     reviewRequired:
       - SMTP provider name, region, DPA, retention policy must be finalized before commercial launch.
 
@@ -67,7 +67,7 @@ activities:
     userRightsHandler: privacyRequestEmailAndExpiredTokenPurge
     codeOwner: back/member-signup-verification
     policySectionId: privacy-collection-signup-verification
-    enabledByEnv: custom.member.signup.enabled
+    enabledByEnv: custom.member.signup.enabled defaults false via CUSTOM__MEMBER__SIGNUP__ENABLED
     reviewRequired:
       - Token hash migration is tracked separately and must complete before unrestricted signup.
 
@@ -101,7 +101,7 @@ activities:
     userRightsHandler: privacyRequestEmailAndFutureOauthUnlinkFlow
     codeOwner: back/oauth2
     policySectionId: privacy-collection-oauth
-    enabledByEnv: spring.security.oauth2.client.registration.kakao.client-id
+    enabledByEnv: spring.security.oauth2.client.registration.kakao.client-id; existing login remains available while signup freeze is on
     reviewRequired:
       - Legacy connected accounts may still contain provider subject in member login_id until unlink/migration policy is finalized.
 
@@ -140,7 +140,7 @@ activities:
     userRightsHandler: privacyRequestEmailAndFutureOauthUnlinkFlow
     codeOwner: back/oauth-signup; front/signup-social-complete
     policySectionId: privacy-collection-oauth
-    enabledByEnv: spring.security.oauth2.client.registration.kakao.client-id
+    enabledByEnv: spring.security.oauth2.client.registration.kakao.client-id; custom.member.oauth-signup.enabled defaults false via CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED
     reviewRequired:
       - Pending signup purge job and OAuth unlink/account deletion workflow remain tracked by issue1000 and issue999.
 
@@ -431,7 +431,7 @@ activities:
     userRightsHandler: privacyPreferenceAndConsentWithdrawalFutureWork
     codeOwner: front/analytics-rum
     policySectionId: privacy-cookie-analytics
-    enabledByEnv: CONFIG.googleAnalytics.enable; Vercel analytics package in production; NEXT_PUBLIC_RUM_SAMPLE_RATE defaults 0.2 and 0 disables custom RUM; RUM_LOG_SLOW_ONLY only controls server logging
+    enabledByEnv: CONFIG.googleAnalytics.enable with optional tracking consent; Vercel analytics package in production; NEXT_PUBLIC_RUM_SAMPLE_RATE defaults 0 and explicit non-zero enables custom RUM; RUM_LOG_SLOW_ONLY only controls server logging
     reviewRequired:
       - Consent manager and opt-out are tracked by issue1002.
 
@@ -469,7 +469,7 @@ activities:
     userRightsHandler: contentDeletionAndExternalProcessingDisclosureFutureWork
     codeOwner: back/post-ai; front/admin-editor
     policySectionId: privacy-processor-ai
-    enabledByEnv: custom.ai.tag.enabled defaults true; disable with CUSTOM__AI__TAG__ENABLED=false; custom.ai.tag.gemini.*; legacy fallback CUSTOM__AI__SUMMARY__GEMINI__*
+    enabledByEnv: custom.ai.tag.enabled defaults false via CUSTOM__AI__TAG__ENABLED; custom.ai.tag.gemini.*; legacy fallback CUSTOM__AI__SUMMARY__GEMINI__*
     reviewRequired:
       - Production default-off, PII scanner, and DPA checks are tracked by issue1003.
 

--- a/legal/vendors/processors.yaml
+++ b/legal/vendors/processors.yaml
@@ -202,7 +202,7 @@ processors:
       - generatedTags
     region: globalGoogleInfrastructure
     overseasTransfer: true
-    enabledByEnv: custom.ai.tag.enabled defaults true; disable with CUSTOM__AI__TAG__ENABLED=false; custom.ai.tag.gemini.*; legacy fallback CUSTOM__AI__SUMMARY__GEMINI__*
+    enabledByEnv: custom.ai.tag.enabled defaults false via CUSTOM__AI__TAG__ENABLED; custom.ai.tag.gemini.*; legacy fallback CUSTOM__AI__SUMMARY__GEMINI__*
     contractStatus: paidPlanAndDpaReviewRequired
     retentionControl: providerDataRetentionAndTrainingOptOutReviewRequired
     securityControls:

--- a/tools/legal/validate-privacy-data-map.mjs
+++ b/tools/legal/validate-privacy-data-map.mjs
@@ -70,11 +70,11 @@ const requiredActivityDataCategories = new Map([
 const requiredActivityEnvFragments = new Map([
   [
     "analytics_and_rum",
-    ["NEXT_PUBLIC_RUM_SAMPLE_RATE", "defaults 0.2", "0 disables custom RUM"],
+    ["NEXT_PUBLIC_RUM_SAMPLE_RATE", "defaults 0", "explicit non-zero enables custom RUM"],
   ],
   [
     "ai_tag_recommendation_gemini",
-    ["custom.ai.tag.enabled", "defaults true", "CUSTOM__AI__TAG__ENABLED=false", "custom.ai.tag.gemini."],
+    ["custom.ai.tag.enabled", "defaults false", "CUSTOM__AI__TAG__ENABLED", "custom.ai.tag.gemini."],
   ],
   ["file_uploads_profile_post_cloud", ["AQUILA_EXTERNAL_STORAGE_ROOT"]],
   ["backup_and_restore", ["AQUILA_BACKUP_ROOT"]],
@@ -90,7 +90,7 @@ const requiredActivityProcessors = new Map([
 const requiredProcessorEnvFragments = new Map([
   [
     "google_gemini",
-    ["custom.ai.tag.enabled", "defaults true", "CUSTOM__AI__TAG__ENABLED=false", "custom.ai.tag.gemini."],
+    ["custom.ai.tag.enabled", "defaults false", "CUSTOM__AI__TAG__ENABLED", "custom.ai.tag.gemini."],
   ],
   ["home_server_redis", ["custom.site.redisHost", "SPRING__DATA__REDIS__PASSWORD", "REDIS_IMAGE"]],
 ])


### PR DESCRIPTION
## 관련 이슈

close #1007

## 작업 배경

- 출시 전 신규 개인정보 수집과 외부 전송을 기본 off로 동결해야 합니다.
- email signup, 신규 Kakao OAuth signup, Gemini tag recommendation, optional RUM이 실수로 켜지지 않도록 runtime guard와 deploy smoke를 함께 둡니다.

## 작업 내용

- `CUSTOM__MEMBER__SIGNUP__ENABLED=false` 기본값과 backend email signup start/verify/complete guard를 추가했습니다.
- `CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED=false` 기본값에서 기존 OAuth login은 유지하고 신규 OAuth signup pending token 발급만 차단했습니다.
- `NEXT_PUBLIC_SIGNUP_ENABLED=false` 기본값에서 `/signup`, signup modal, email verify complete, social complete 화면이 개인정보 입력 전에 준비중 안내만 보여주도록 했습니다.
- custom RUM sample 기본값을 `0`으로 낮추고, `CUSTOM__AI__TAG__ENABLED=false`/signup/RUM freeze 값을 deploy env contract와 home server deploy smoke에서 강제했습니다.
- privacy data-map, vendor processor 문서, launch gate checklist, validator 기대값을 새 default-off 정책과 동기화했습니다.
- frontend CI의 기존 signup smoke/legal flow는 명시적으로 `NEXT_PUBLIC_SIGNUP_ENABLED=true`로 실행하게 고정해 launch-freeze 기본값과 테스트 의도를 분리했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back ktlintCheck test --tests '*CustomOAuth2UserServiceTest' --tests '*CustomOAuth2LoginFailureHandlerTest' --tests '*ApiV1SignupVerificationFeatureFreezeTest' --rerun-tasks`: 최초 `ResponseStatusException`이 500으로 매핑되어 실패, `AppException(503-5)`로 수정 후 exit 0
  - `back/gradlew -p back ktlintCheck test --tests '*ArchitectureGuardTest' --tests '*ApiV1SignupVerificationFeatureFreezeTest' --tests '*CustomOAuth2UserServiceTest' --tests '*CustomOAuth2LoginFailureHandlerTest' --rerun-tasks`: exit 0
  - `back/gradlew -p back ktlintCheck test --tests '*ApiV1MemberControllerWebMvcTest' --rerun-tasks`: 최초 support base ktlint 빈 줄 실패, 수정 후 exit 0
  - `back/gradlew -p back ktlintCheck test --tests '*ApiV1SignupVerificationFeatureFreezeTest' --tests '*ApiV1SignupVerificationControllerTest' --rerun-tasks`: exit 0
  - `back/gradlew -p back ciFastCheck --rerun-tasks`: 최초 architecture/WebMvc support 실패, 수정 후 2회 연속 exit 0, CodeRabbit fix 후 추가 1회 exit 0
  - `yarn --cwd front build`: 2회 exit 0
  - `env NEXT_PUBLIC_SIGNUP_ENABLED=true yarn --cwd front test:e2e:smoke`: sandbox `127.0.0.1:3100` EPERM 후 권한 상승 재실행으로 65 passed, exit 0
  - `env NEXT_PUBLIC_SIGNUP_ENABLED=true NEXT_PUBLIC_RUM_SAMPLE_RATE=1 NODE_ENV=production VERCEL_ENV=production yarn --cwd front playwright test e2e/legal-policy-pages.spec.ts e2e/privacy-tracking-consent.spec.ts e2e/browser-storage-registry.spec.ts --project=chromium --workers=1`: 9 passed, exit 0
  - `node tools/legal/validate-legal-policies.mjs`: exit 0
  - `node tools/legal/validate-privacy-data-map.mjs`: 최초 old default validator 기대값으로 실패, validator 동기화 후 exit 0
  - `node tools/env/render-local-env.mjs --target back-local --out /tmp/aquila-blog-back-local.env`: exit 0
  - `node tools/env/validate-env.mjs --target back-local --file /tmp/aquila-blog-back-local.env`: exit 0
  - `node --input-type=module -e 'import { loadContract, validateEnvText } from "./tools/env/validate-env.mjs"; const result = validateEnvText({ contract: loadContract(), target: "home-server-source", text: "CUSTOM__MEMBER__SIGNUP__ENABLED=true\\nCUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED=true\\nCUSTOM__AI__TAG__ENABLED=true\\nNEXT_PUBLIC_SIGNUP_ENABLED=true\\nNEXT_PUBLIC_RUM_SAMPLE_RATE=1\\n" }); const keys = new Set(result.errors.filter((error) => error.message.startsWith("must be one of")).map((error) => error.key)); const expected = ["CUSTOM__MEMBER__SIGNUP__ENABLED", "CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED", "CUSTOM__AI__TAG__ENABLED", "NEXT_PUBLIC_SIGNUP_ENABLED", "NEXT_PUBLIC_RUM_SAMPLE_RATE"]; for (const key of expected) { if (!keys.has(key)) throw new Error(`missing freeze validation for ${key}`); } console.log("privacy freeze allowedValues validation ok");'`: exit 0
  - GitHub Actions PR checks: backend-ci, frontend-ci, backend-dependency-check, CodeQL, CodeRabbit, Vercel Preview Comments 모두 pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| email signup backend freeze | local backend test | MockMvc start/verify endpoint with `custom.member.signup.enabled=false` | `ApiV1SignupVerificationFeatureFreezeTest`, `back/gradlew -p back ciFastCheck --rerun-tasks` | 503 guard, verification row 미생성, `Set-Cookie` 미발급 |
| OAuth 신규 signup freeze | local backend test | 기존 login path와 신규 pending token 발급 차단 단위 테스트 | `CustomOAuth2UserServiceTest`, `CustomOAuth2LoginFailureHandlerTest` | 기존 login 유지, 신규 signup은 `signup-disabled` |
| frontend signup freeze | local frontend build | `/signup`, modal, verify, social complete 타입/SSR build | `yarn --cwd front build` 2회 exit 0 | 입력 폼 대신 준비중 안내 렌더링 가능 |
| frontend signup regression | local/CI frontend e2e | signup-enabled smoke/legal flow 명시 실행 | local smoke 65 passed, legal/privacy 9 passed, GitHub frontend-ci pass | 기존 signup flow 테스트 의도 유지 |
| deploy freeze smoke | local env contract validation | true/1 값이 allowedValues 위반으로 잡히는 validator check | `privacy freeze allowedValues validation ok` | 잘못 켜진 flag 감지 |
| data-map/legal drift | local legal validators | privacy data-map/policy validators | `node tools/legal/validate-privacy-data-map.mjs`, `node tools/legal/validate-legal-policies.mjs` | exit 0 |
| backend regression | local/CI backend checks | full backend ciFastCheck and PR backend-ci | local `ciFastCheck` pass, GitHub backend-ci pass | exit 0 / pass |
| code review | GitHub PR review | CodeRabbit review thread 확인 | CodeRabbit actionable 1건 reply + resolved, latest CodeRabbit check pass | review clean |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `ApiV1SignupVerificationController.requireSignupEnabled`, `CustomOAuth2UserService`의 member-null branch, `.github/workflows/deploy.yml`의 `require_privacy_freeze_value`.
- CodeRabbit이 `/email/verify` guard 누락을 지적했고, `e4427622`에서 guard와 회귀 테스트를 추가했습니다.

## 리스크

- `NEXT_PUBLIC_SIGNUP_ENABLED`는 build-time flag라 frontend re-enable에는 Vercel/environment 재빌드가 필요합니다.
- 기존 OAuth 계정 login은 유지하지만 신규 OAuth signup은 `CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED=true`가 되기 전까지 pending token을 만들지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (N/A: CodeRabbit review completed)
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다. (merge 후 확인 예정)
