### PR TITLE
[CI] 개인정보 freeze env 검증 합성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -318,11 +318,23 @@ jobs:
       - name: Validate HOME_SERVER_ENV contract
         env:
           HOME_SERVER_ENV: ${{ secrets.HOME_SERVER_ENV }}
+          HOME_MEMBER_SIGNUP_ENABLED: ${{ secrets.CUSTOM__MEMBER__SIGNUP__ENABLED || vars.CUSTOM__MEMBER__SIGNUP__ENABLED || 'false' }}
+          HOME_MEMBER_OAUTH_SIGNUP_ENABLED: ${{ secrets.CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED || vars.CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED || 'false' }}
+          HOME_AI_TAG_ENABLED: ${{ secrets.CUSTOM__AI__TAG__ENABLED || vars.CUSTOM__AI__TAG__ENABLED || 'false' }}
+          HOME_NEXT_PUBLIC_SIGNUP_ENABLED: ${{ secrets.NEXT_PUBLIC_SIGNUP_ENABLED || vars.NEXT_PUBLIC_SIGNUP_ENABLED || 'false' }}
+          HOME_NEXT_PUBLIC_RUM_SAMPLE_RATE: ${{ secrets.NEXT_PUBLIC_RUM_SAMPLE_RATE || vars.NEXT_PUBLIC_RUM_SAMPLE_RATE || '0' }}
         shell: bash
         run: |
           set -euo pipefail
           home_server_env_file="${RUNNER_TEMP}/home-server.env"
-          printf '%s\n' "${HOME_SERVER_ENV}" > "${home_server_env_file}"
+          {
+            printf '%s\n' "${HOME_SERVER_ENV}"
+            printf 'CUSTOM__MEMBER__SIGNUP__ENABLED=%s\n' "${HOME_MEMBER_SIGNUP_ENABLED:-false}"
+            printf 'CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED=%s\n' "${HOME_MEMBER_OAUTH_SIGNUP_ENABLED:-false}"
+            printf 'CUSTOM__AI__TAG__ENABLED=%s\n' "${HOME_AI_TAG_ENABLED:-false}"
+            printf 'NEXT_PUBLIC_SIGNUP_ENABLED=%s\n' "${HOME_NEXT_PUBLIC_SIGNUP_ENABLED:-false}"
+            printf 'NEXT_PUBLIC_RUM_SAMPLE_RATE=%s\n' "${HOME_NEXT_PUBLIC_RUM_SAMPLE_RATE:-0}"
+          } > "${home_server_env_file}"
           node tools/env/validate-env.mjs --target home-server-source --file "${home_server_env_file}"
 
       - name: Resolve Tailscale OAuth tags


### PR DESCRIPTION
## 관련 이슈

close #1007

## 작업 배경

- PR #1036 merge 후 `Deploy to Home Server`가 `Validate HOME_SERVER_ENV contract` 단계에서 실패했습니다.
- 실패 원인은 legacy `HOME_SERVER_ENV` 안의 `CUSTOM__AI__TAG__ENABLED` 값이 launch freeze contract의 허용값 `false`와 맞지 않았기 때문입니다.
- 실제 deploy step은 이미 별도 freeze env를 `.env.prod`에 upsert하므로, validation도 같은 effective deploy env 기준으로 맞춥니다.

## 작업 내용

- `Validate HOME_SERVER_ENV contract` 단계에 deploy step과 동일한 privacy freeze env 값을 주입했습니다.
- raw `HOME_SERVER_ENV` 뒤에 freeze override 값을 덧붙여 validator가 실제 배포에 쓰일 최종 key 값을 검사하게 했습니다.
- 별도 secret/var가 `true`로 설정되면 마지막 값이 `true`가 되어 여전히 contract가 실패합니다.

## 검증

- 실행한 명령과 결과:
  - `node --input-type=module -e 'import { loadContract, validateEnvText } from "./tools/env/validate-env.mjs"; const result = validateEnvText({ contract: loadContract(), target: "home-server-source", text: "CUSTOM__AI__TAG__ENABLED=true\\nCUSTOM__AI__TAG__ENABLED=false\\n" }); const tagErrors = result.errors.filter((error) => error.key === "CUSTOM__AI__TAG__ENABLED"); if (tagErrors.length) throw new Error(JSON.stringify(tagErrors)); console.log("stale HOME_SERVER_ENV privacy freeze override validation ok");'`: exit 0
  - `node --input-type=module -e 'import { loadContract, validateEnvText } from "./tools/env/validate-env.mjs"; const result = validateEnvText({ contract: loadContract(), target: "home-server-source", text: "CUSTOM__AI__TAG__ENABLED=false\\nCUSTOM__AI__TAG__ENABLED=true\\n" }); const tagErrors = result.errors.filter((error) => error.key === "CUSTOM__AI__TAG__ENABLED" && error.message.startsWith("must be one of")); if (tagErrors.length !== 1) throw new Error(JSON.stringify(result.errors)); console.log("bad privacy freeze override still rejected");'`: exit 0
  - `git diff --check`: exit 0
  - `gh pr checks 1037 --watch`: all checks pass
  - `codex review --base origin/main --title "[CI] 개인정보 freeze env 검증 합성"`: actionable findings 0
  - `gh run view 27968940047 --json status,conclusion,url,jobs`: conclusion success

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| stale HOME_SERVER_ENV override | local Node validator | duplicate env key의 마지막 false 값이 contract에 적용되는지 확인 | `stale HOME_SERVER_ENV privacy freeze override validation ok` | exit 0 |
| bad override rejection | local Node validator | 마지막 값이 true이면 allowedValues 위반으로 실패하는지 확인 | `bad privacy freeze override still rejected` | exit 0 |
| workflow syntax drift | local git check | whitespace/conflict marker check | `git diff --check` | exit 0 |
| PR CI | GitHub Actions | PR #1037 checks 확인 | `backend-ci`, `frontend-ci`, `CodeQL`, `backend-dependency-check` | pass |
| code review fallback | GitHub PR review | CodeRabbit rate-limit 확인 후 Codex CLI fallback review 게시 | https://github.com/AquilaXk/aquila-blog/pull/1037#pullrequestreview-4546158901 | actionable 0 |
| post-merge CI/Security | GitHub Actions | merge commit `2563d42a` 기준 main workflow 확인 | CI https://github.com/AquilaXk/aquila-blog/actions/runs/27968406531, Security https://github.com/AquilaXk/aquila-blog/actions/runs/27968406496 | success |
| post-merge CD | GitHub Actions | merge 후 `Deploy to Home Server` 재실행 | https://github.com/AquilaXk/aquila-blog/actions/runs/27968940047 | success: env contract, blue/green deploy, live e2e pass |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `.github/workflows/deploy.yml`의 `Validate HOME_SERVER_ENV contract` 단계입니다.
- 이 변경은 raw secret을 느슨하게 허용하는 것이 아니라, deploy step에서 실제로 upsert하는 freeze env와 같은 값으로 validation 입력을 합성합니다.

## 리스크

- `HOME_SERVER_ENV` 안의 stale 값은 즉시 secret을 수정하지 않아도 배포 effective env에서는 false로 덮입니다.
- 별도 GitHub secret/var로 freeze flag를 true로 설정하면 이 PR 이후에도 validation이 실패합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
