### PR TITLE
[Feat] 기존 사용자 법적 문서 재동의 gate 추가

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AdmMemberController.kt
@@ -15,6 +15,8 @@ import com.back.boundedContexts.member.dto.AuthSessionMemberDto
 import com.back.boundedContexts.member.dto.MemberProfileWorkspaceResponseDto
 import com.back.boundedContexts.member.dto.MemberWithUsernameDto
 import com.back.boundedContexts.member.model.shared.Member
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalReconsentReport
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.input.LegalAcceptanceUseCase
 import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
 import com.back.boundedContexts.post.config.PostImageStorageProperties
 import com.back.global.app.AppConfig
@@ -61,6 +63,7 @@ class ApiV1AdmMemberController(
     private val postImageStorageService: PostImageStoragePort,
     private val postImageStorageProperties: PostImageStorageProperties,
     private val uploadedFileRetentionService: UploadedFileRetentionService,
+    private val legalAcceptanceUseCase: LegalAcceptanceUseCase,
 ) {
     companion object {
         private const val PROFILE_IMAGE_MAX_FILE_SIZE_BYTES = 2L * 1024 * 1024
@@ -80,6 +83,10 @@ class ApiV1AdmMemberController(
         val images: List<ProfileImageHistoryDto>,
     )
 
+    data class LegalReconsentReportResponse(
+        val report: LegalReconsentReport,
+    )
+
     private enum class LinkSection(
         val displayName: String,
         val defaultIcon: String,
@@ -94,6 +101,13 @@ class ApiV1AdmMemberController(
         @field:Size(max = 2000)
         val profileImgUrl: String,
     )
+
+    @GetMapping("/legal-reconsent/report")
+    @Transactional(readOnly = true)
+    fun legalReconsentReport(): LegalReconsentReportResponse =
+        LegalReconsentReportResponse(
+            report = legalAcceptanceUseCase.legalReconsentReport(),
+        )
 
     data class UpdateProfileIdentityRequest(
         @field:NotBlank

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthController.kt
@@ -10,6 +10,9 @@ import com.back.boundedContexts.member.domain.shared.MemberPolicy
 import com.back.boundedContexts.member.dto.AuthSessionMemberDto
 import com.back.boundedContexts.member.dto.MemberDto
 import com.back.boundedContexts.member.dto.MemberWithUsernameDto
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalAcceptanceCommand
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalReconsentStatus
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.input.LegalAcceptanceUseCase
 import com.back.boundedContexts.member.subContexts.session.application.port.input.MemberSessionUseCase
 import com.back.global.exception.application.AppException
 import com.back.global.rsData.RsData
@@ -31,6 +34,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
 import java.util.Locale
 
 @RestController
@@ -46,6 +50,7 @@ class ApiV1AuthController(
     private val clientIpResolver: ClientIpResolver,
     private val loginAttemptPolicyUseCase: LoginAttemptPolicyUseCase,
     private val memberSessionUseCase: MemberSessionUseCase,
+    private val legalAcceptanceUseCase: LegalAcceptanceUseCase,
 ) {
     companion object {
         private const val MAX_EMAIL_LENGTH = 320
@@ -67,6 +72,33 @@ class ApiV1AuthController(
 
     data class MemberLoginResBody(
         val item: MemberDto,
+    )
+
+    data class LegalReconsentRequest(
+        val termsVersion: String,
+        val termsContentSha256: String,
+        val privacyVersion: String,
+        val privacyContentSha256: String,
+        val age14OrOlder: Boolean,
+        val requiredPrivacyConfirmed: Boolean,
+        val analyticsConsent: Boolean,
+        val overseasTransferAcknowledged: Boolean,
+    ) {
+        fun toCommand(): LegalAcceptanceCommand =
+            LegalAcceptanceCommand(
+                termsVersion = termsVersion,
+                termsContentSha256 = termsContentSha256,
+                privacyVersion = privacyVersion,
+                privacyContentSha256 = privacyContentSha256,
+                age14OrOlder = age14OrOlder,
+                requiredPrivacyConfirmed = requiredPrivacyConfirmed,
+                analyticsConsent = analyticsConsent,
+                overseasTransferAcknowledged = overseasTransferAcknowledged,
+            )
+    }
+
+    data class LegalReconsentResponse(
+        val legalReconsent: LegalReconsentStatus,
     )
 
     @PostMapping("/login")
@@ -188,7 +220,40 @@ class ApiV1AuthController(
     @Transactional(readOnly = true)
     fun session(
         @AuthenticationPrincipal securityUser: SecurityUser,
-    ): AuthSessionMemberDto = AuthSessionMemberDto(securityUser)
+    ): AuthSessionMemberDto =
+        AuthSessionMemberDto(
+            securityUser = securityUser,
+            legalReconsent = legalAcceptanceUseCase.legalReconsentStatus(securityUser.id),
+        )
+
+    @PostMapping("/legal-reconsent")
+    @Transactional
+    fun legalReconsent(
+        request: HttpServletRequest,
+        @AuthenticationPrincipal securityUser: SecurityUser,
+        @RequestBody @Valid reqBody: LegalReconsentRequest,
+    ): RsData<LegalReconsentResponse> {
+        val member =
+            memberUseCase
+                .findById(securityUser.id)
+                .orElseThrow { AppException("404-1", "회원을 찾을 수 없습니다.") }
+
+        legalAcceptanceUseCase.recordLegalReconsent(
+            member = member,
+            command = reqBody.toCommand(),
+            acceptedAt = Instant.now(),
+            clientIp = extractClientIp(request),
+            userAgent = request.getHeader("User-Agent"),
+        )
+
+        return RsData(
+            "200-1",
+            "최신 약관과 개인정보처리방침 동의를 저장했습니다.",
+            LegalReconsentResponse(
+                legalReconsent = legalAcceptanceUseCase.legalReconsentStatus(member.id),
+            ),
+        )
+    }
 
     private fun isPasswordValid(
         member: Member,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthController.kt
@@ -22,6 +22,7 @@ import com.back.global.security.config.AuthCookieNames
 import com.back.global.security.domain.SecurityUser
 import com.back.global.web.application.AuthCookieService
 import com.back.global.web.application.ClientIpResolver
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
@@ -75,13 +76,25 @@ class ApiV1AuthController(
     )
 
     data class LegalReconsentRequest(
+        @field:NotBlank
+        @field:Size(max = 32)
         val termsVersion: String,
+        @field:NotBlank
+        @field:Size(min = 64, max = 64)
         val termsContentSha256: String,
+        @field:NotBlank
+        @field:Size(max = 32)
         val privacyVersion: String,
+        @field:NotBlank
+        @field:Size(min = 64, max = 64)
         val privacyContentSha256: String,
+        @field:Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         val age14OrOlder: Boolean,
+        @field:Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         val requiredPrivacyConfirmed: Boolean,
+        @field:Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         val analyticsConsent: Boolean,
+        @field:Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         val overseasTransferAcknowledged: Boolean,
     ) {
         fun toCommand(): LegalAcceptanceCommand =

--- a/back/src/main/kotlin/com/back/boundedContexts/member/dto/AuthSessionMemberDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/dto/AuthSessionMemberDto.kt
@@ -1,5 +1,6 @@
 package com.back.boundedContexts.member.dto
 
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalReconsentStatus
 import com.back.global.security.domain.SecurityUser
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
@@ -11,11 +12,16 @@ data class AuthSessionMemberDto(
     val isAdmin: Boolean,
     val username: String,
     val nickname: String,
+    val legalReconsent: LegalReconsentStatus? = null,
 ) {
-    constructor(securityUser: SecurityUser) : this(
+    constructor(
+        securityUser: SecurityUser,
+        legalReconsent: LegalReconsentStatus? = null,
+    ) : this(
         id = securityUser.id,
         isAdmin = securityUser.authorities.any { it.authority == "ROLE_ADMIN" },
         username = securityUser.nickname,
         nickname = securityUser.nickname,
+        legalReconsent = legalReconsent,
     )
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/adapter/persistence/MemberLegalAcceptanceRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/adapter/persistence/MemberLegalAcceptanceRepository.kt
@@ -3,9 +3,50 @@ package com.back.boundedContexts.member.subContexts.legalAcceptance.adapter.pers
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.output.MemberLegalAcceptanceRepositoryPort
 import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberLegalAcceptance
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface MemberLegalAcceptanceRepository :
     JpaRepository<MemberLegalAcceptance, Long>,
     MemberLegalAcceptanceRepositoryPort {
     override fun findTopByMemberIdOrderByAcceptedAtDesc(memberId: Long): MemberLegalAcceptance?
+
+    @Query(
+        """
+        select count(distinct acceptance.member.id)
+        from MemberLegalAcceptance acceptance
+        where acceptance.termsVersion = :termsVersion
+          and acceptance.termsContentSha256 = :termsContentSha256
+          and acceptance.privacyVersion = :privacyVersion
+          and acceptance.privacyContentSha256 = :privacyContentSha256
+        """,
+    )
+    override fun countMembersWithCurrentAcceptance(
+        @Param("termsVersion") termsVersion: String,
+        @Param("termsContentSha256") termsContentSha256: String,
+        @Param("privacyVersion") privacyVersion: String,
+        @Param("privacyContentSha256") privacyContentSha256: String,
+    ): Long
+
+    @Query(
+        """
+        select count(member)
+        from Member member
+        where not exists (
+            select acceptance.id
+            from MemberLegalAcceptance acceptance
+            where acceptance.member = member
+              and acceptance.termsVersion = :termsVersion
+              and acceptance.termsContentSha256 = :termsContentSha256
+              and acceptance.privacyVersion = :privacyVersion
+              and acceptance.privacyContentSha256 = :privacyContentSha256
+        )
+        """,
+    )
+    override fun countMembersMissingCurrentAcceptance(
+        @Param("termsVersion") termsVersion: String,
+        @Param("termsContentSha256") termsContentSha256: String,
+        @Param("privacyVersion") privacyVersion: String,
+        @Param("privacyContentSha256") privacyContentSha256: String,
+    ): Long
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/adapter/persistence/MemberLegalAcceptanceRepository.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/adapter/persistence/MemberLegalAcceptanceRepository.kt
@@ -13,12 +13,17 @@ interface MemberLegalAcceptanceRepository :
 
     @Query(
         """
-        select count(distinct acceptance.member.id)
-        from MemberLegalAcceptance acceptance
-        where acceptance.termsVersion = :termsVersion
-          and acceptance.termsContentSha256 = :termsContentSha256
-          and acceptance.privacyVersion = :privacyVersion
-          and acceptance.privacyContentSha256 = :privacyContentSha256
+        select count(member)
+        from Member member
+        where exists (
+            select acceptance.id
+            from MemberLegalAcceptance acceptance
+            where acceptance.member = member
+              and acceptance.termsVersion = :termsVersion
+              and acceptance.termsContentSha256 = :termsContentSha256
+              and acceptance.privacyVersion = :privacyVersion
+              and acceptance.privacyContentSha256 = :privacyContentSha256
+        )
         """,
     )
     override fun countMembersWithCurrentAcceptance(

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/dto/LegalAcceptanceDtos.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/dto/LegalAcceptanceDtos.kt
@@ -1,0 +1,40 @@
+package com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto
+
+import java.time.Instant
+
+data class LegalAcceptanceCommand(
+    val termsVersion: String,
+    val termsContentSha256: String,
+    val privacyVersion: String,
+    val privacyContentSha256: String,
+    val age14OrOlder: Boolean,
+    val requiredPrivacyConfirmed: Boolean,
+    val analyticsConsent: Boolean,
+    val overseasTransferAcknowledged: Boolean,
+)
+
+data class LegalReconsentStatus(
+    val status: String,
+    val required: Boolean,
+    val termsVersion: String,
+    val termsContentSha256: String,
+    val privacyVersion: String,
+    val privacyContentSha256: String,
+    val acceptedAt: Instant?,
+    val refusalGuidePath: String = "/settings/privacy",
+    val exportGuidePath: String = "/settings/privacy",
+    val deletionGuidePath: String = "/settings/account",
+)
+
+data class LegalReconsentReport(
+    val currentAcceptedMembers: Long,
+    val reconsentRequiredMembers: Long,
+) {
+    val totalMembers: Long = currentAcceptedMembers + reconsentRequiredMembers
+    val completionRate: Double =
+        if (totalMembers == 0L) {
+            1.0
+        } else {
+            currentAcceptedMembers.toDouble() / totalMembers.toDouble()
+        }
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/port/input/LegalAcceptanceUseCase.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/port/input/LegalAcceptanceUseCase.kt
@@ -1,0 +1,42 @@
+package com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.input
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalAcceptanceCommand
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalReconsentReport
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalReconsentStatus
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.ActiveLegalDocumentMetadata
+import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberLegalAcceptance
+import java.time.Instant
+
+interface LegalAcceptanceUseCase {
+    fun currentDocuments(): ActiveLegalDocumentMetadata
+
+    fun validateStoredSignupPolicyVersion(legalPolicyVersion: String?)
+
+    fun validateEmailSignupAcceptance(command: LegalAcceptanceCommand)
+
+    fun legalReconsentStatus(memberId: Long): LegalReconsentStatus
+
+    fun legalReconsentReport(): LegalReconsentReport
+
+    fun recordEmailSignupAcceptance(
+        member: Member,
+        command: LegalAcceptanceCommand,
+        acceptedAt: Instant,
+    ): MemberLegalAcceptance
+
+    fun recordSocialSignupAcceptance(
+        member: Member,
+        command: LegalAcceptanceCommand,
+        acceptedAt: Instant,
+        source: String,
+    ): MemberLegalAcceptance
+
+    fun recordLegalReconsent(
+        member: Member,
+        command: LegalAcceptanceCommand,
+        acceptedAt: Instant,
+        clientIp: String?,
+        userAgent: String?,
+    ): MemberLegalAcceptance
+}

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/port/output/MemberLegalAcceptanceRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/port/output/MemberLegalAcceptanceRepositoryPort.kt
@@ -6,4 +6,18 @@ interface MemberLegalAcceptanceRepositoryPort {
     fun save(memberLegalAcceptance: MemberLegalAcceptance): MemberLegalAcceptance
 
     fun findTopByMemberIdOrderByAcceptedAtDesc(memberId: Long): MemberLegalAcceptance?
+
+    fun countMembersWithCurrentAcceptance(
+        termsVersion: String,
+        termsContentSha256: String,
+        privacyVersion: String,
+        privacyContentSha256: String,
+    ): Long
+
+    fun countMembersMissingCurrentAcceptance(
+        termsVersion: String,
+        termsContentSha256: String,
+        privacyVersion: String,
+        privacyContentSha256: String,
+    ): Long
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/LegalAcceptanceApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/LegalAcceptanceApplicationService.kt
@@ -1,31 +1,25 @@
 package com.back.boundedContexts.member.subContexts.legalAcceptance.application.service
 
 import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalAcceptanceCommand
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalReconsentReport
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalReconsentStatus
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.input.LegalAcceptanceUseCase
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.output.MemberLegalAcceptanceRepositoryPort
 import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberLegalAcceptance
 import com.back.global.exception.application.AppException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.security.MessageDigest
 import java.time.Instant
-
-data class LegalAcceptanceCommand(
-    val termsVersion: String,
-    val termsContentSha256: String,
-    val privacyVersion: String,
-    val privacyContentSha256: String,
-    val age14OrOlder: Boolean,
-    val requiredPrivacyConfirmed: Boolean,
-    val analyticsConsent: Boolean,
-    val overseasTransferAcknowledged: Boolean,
-)
 
 @Service
 class LegalAcceptanceApplicationService(
     private val memberLegalAcceptanceRepository: MemberLegalAcceptanceRepositoryPort,
-) {
-    fun currentDocuments(): ActiveLegalDocumentMetadata = ActiveLegalDocumentMetadata.current()
+) : LegalAcceptanceUseCase {
+    override fun currentDocuments(): ActiveLegalDocumentMetadata = ActiveLegalDocumentMetadata.current()
 
-    fun validateStoredSignupPolicyVersion(legalPolicyVersion: String?) {
+    override fun validateStoredSignupPolicyVersion(legalPolicyVersion: String?) {
         val storedVersion = legalPolicyVersion?.trim().orEmpty()
         val active = currentDocuments()
 
@@ -34,7 +28,7 @@ class LegalAcceptanceApplicationService(
         }
     }
 
-    fun validateEmailSignupAcceptance(command: LegalAcceptanceCommand) {
+    override fun validateEmailSignupAcceptance(command: LegalAcceptanceCommand) {
         if (!command.age14OrOlder) {
             throw AppException("400-2", "만 14세 이상인 경우에만 회원가입할 수 있습니다.")
         }
@@ -57,8 +51,49 @@ class LegalAcceptanceApplicationService(
         }
     }
 
+    override fun legalReconsentStatus(memberId: Long): LegalReconsentStatus {
+        val active = currentDocuments()
+        val latest = memberLegalAcceptanceRepository.findTopByMemberIdOrderByAcceptedAtDesc(memberId)
+        val current =
+            latest != null &&
+                latest.termsVersion == active.terms.version &&
+                latest.termsContentSha256 == active.terms.contentSha256 &&
+                latest.privacyVersion == active.privacy.version &&
+                latest.privacyContentSha256 == active.privacy.contentSha256
+
+        return LegalReconsentStatus(
+            status = if (current) "CURRENT" else "RECONSENT_REQUIRED",
+            required = !current,
+            termsVersion = active.terms.version,
+            termsContentSha256 = active.terms.contentSha256,
+            privacyVersion = active.privacy.version,
+            privacyContentSha256 = active.privacy.contentSha256,
+            acceptedAt = latest?.acceptedAt?.takeIf { current },
+        )
+    }
+
+    override fun legalReconsentReport(): LegalReconsentReport {
+        val active = currentDocuments()
+        return LegalReconsentReport(
+            currentAcceptedMembers =
+                memberLegalAcceptanceRepository.countMembersWithCurrentAcceptance(
+                    termsVersion = active.terms.version,
+                    termsContentSha256 = active.terms.contentSha256,
+                    privacyVersion = active.privacy.version,
+                    privacyContentSha256 = active.privacy.contentSha256,
+                ),
+            reconsentRequiredMembers =
+                memberLegalAcceptanceRepository.countMembersMissingCurrentAcceptance(
+                    termsVersion = active.terms.version,
+                    termsContentSha256 = active.terms.contentSha256,
+                    privacyVersion = active.privacy.version,
+                    privacyContentSha256 = active.privacy.contentSha256,
+                ),
+        )
+    }
+
     @Transactional
-    fun recordEmailSignupAcceptance(
+    override fun recordEmailSignupAcceptance(
         member: Member,
         command: LegalAcceptanceCommand,
         acceptedAt: Instant,
@@ -71,7 +106,7 @@ class LegalAcceptanceApplicationService(
         )
 
     @Transactional
-    fun recordSocialSignupAcceptance(
+    override fun recordSocialSignupAcceptance(
         member: Member,
         command: LegalAcceptanceCommand,
         acceptedAt: Instant,
@@ -84,11 +119,30 @@ class LegalAcceptanceApplicationService(
             source = source,
         )
 
+    @Transactional
+    override fun recordLegalReconsent(
+        member: Member,
+        command: LegalAcceptanceCommand,
+        acceptedAt: Instant,
+        clientIp: String?,
+        userAgent: String?,
+    ): MemberLegalAcceptance =
+        recordSignupAcceptance(
+            member = member,
+            command = command,
+            acceptedAt = acceptedAt,
+            source = "RECONSENT",
+            clientIpHash = sha256OrNull(clientIp),
+            userAgentHash = sha256OrNull(userAgent),
+        )
+
     private fun recordSignupAcceptance(
         member: Member,
         command: LegalAcceptanceCommand,
         acceptedAt: Instant,
         source: String,
+        clientIpHash: String? = null,
+        userAgentHash: String? = null,
     ): MemberLegalAcceptance {
         validateEmailSignupAcceptance(command)
 
@@ -104,8 +158,20 @@ class LegalAcceptanceApplicationService(
                 analyticsConsent = command.analyticsConsent,
                 overseasTransferAcknowledged = command.overseasTransferAcknowledged,
                 source = source.trim().take(32),
+                clientIpHash = clientIpHash,
+                userAgentHash = userAgentHash,
                 acceptedAt = acceptedAt,
             ),
         )
+    }
+
+    private fun sha256OrNull(value: String?): String? {
+        val normalized = value?.trim().orEmpty()
+        if (normalized.isBlank()) return null
+
+        return MessageDigest
+            .getInstance("SHA-256")
+            .digest(normalized.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
     }
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/model/MemberLegalAcceptance.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/model/MemberLegalAcceptance.kt
@@ -42,6 +42,10 @@ class MemberLegalAcceptance(
     val overseasTransferAcknowledged: Boolean,
     @field:Column(nullable = false, length = 32)
     val source: String,
+    @field:Column(length = 64)
+    val clientIpHash: String? = null,
+    @field:Column(length = 64)
+    val userAgentHash: String? = null,
     @field:Column(nullable = false)
     val acceptedAt: Instant,
 ) : BaseTime(id)

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/web/ApiV1OAuthSignupController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/web/ApiV1OAuthSignupController.kt
@@ -1,7 +1,7 @@
 package com.back.boundedContexts.member.subContexts.oauthSignup.adapter.web
 
 import com.back.boundedContexts.member.dto.MemberDto
-import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupUseCase
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingDetails
 import com.back.global.rsData.RsData

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/port/input/OAuthSignupUseCase.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/port/input/OAuthSignupUseCase.kt
@@ -1,7 +1,7 @@
 package com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input
 
 import com.back.boundedContexts.member.domain.shared.Member
-import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingDetails
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingStartResult
 

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationService.kt
@@ -2,8 +2,8 @@ package com.back.boundedContexts.member.subContexts.oauthSignup.application.serv
 
 import com.back.boundedContexts.member.application.port.input.MemberUseCase
 import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceApplicationService
-import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupUseCase
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.output.PendingOAuthSignupRepositoryPort
 import com.back.boundedContexts.member.subContexts.oauthSignup.model.PendingOAuthSignup

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/adapter/web/ApiV1SignupVerificationController.kt
@@ -1,7 +1,7 @@
 package com.back.boundedContexts.member.subContexts.signupVerification.adapter.web
 
 import com.back.boundedContexts.member.dto.MemberDto
-import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.signupVerification.application.service.MemberSignupVerificationService
 import com.back.boundedContexts.member.subContexts.signupVerification.application.service.SignupEmailStartResult
 import com.back.boundedContexts.member.subContexts.signupVerification.application.service.SignupEmailVerifyResult

--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/MemberSignupVerificationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/signupVerification/application/service/MemberSignupVerificationService.kt
@@ -3,8 +3,8 @@ package com.back.boundedContexts.member.subContexts.signupVerification.applicati
 import com.back.boundedContexts.member.application.port.output.MemberRepositoryPort
 import com.back.boundedContexts.member.application.service.MemberApplicationService
 import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceApplicationService
-import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.signupVerification.application.port.output.MemberSignupVerificationRepositoryPort
 import com.back.boundedContexts.member.subContexts.signupVerification.domain.MemberSignupVerification
 import com.back.boundedContexts.member.subContexts.signupVerification.dto.SendSignupVerificationMailPayload

--- a/back/src/main/resources/db/migration-test/V20260623_01__add_member_legal_reconsent_metadata.sql
+++ b/back/src/main/resources/db/migration-test/V20260623_01__add_member_legal_reconsent_metadata.sql
@@ -1,0 +1,3 @@
+ALTER TABLE member_legal_acceptance
+    ADD COLUMN IF NOT EXISTS client_ip_hash VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS user_agent_hash VARCHAR(64);

--- a/back/src/main/resources/db/migration/V20260623_01__add_member_legal_reconsent_metadata.sql
+++ b/back/src/main/resources/db/migration/V20260623_01__add_member_legal_reconsent_metadata.sql
@@ -1,0 +1,3 @@
+ALTER TABLE member_legal_acceptance
+    ADD COLUMN IF NOT EXISTS client_ip_hash VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS user_agent_hash VARCHAR(64);

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
@@ -3,6 +3,8 @@ package com.back.boundedContexts.member.adapter.web
 import com.back.boundedContexts.member.application.service.AuthTokenService
 import com.back.boundedContexts.member.application.service.LoginAttemptService
 import com.back.boundedContexts.member.application.service.MemberApplicationService
+import com.back.boundedContexts.member.subContexts.legalAcceptance.adapter.persistence.MemberLegalAcceptanceRepository
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.ActiveLegalDocumentMetadata
 import com.back.boundedContexts.member.subContexts.session.adapter.persistence.MemberSessionRepository
 import com.back.global.security.config.AuthCookieNames
 import com.back.support.BaseControllerIntegrationTest
@@ -34,6 +36,9 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
 
     @Autowired
     private lateinit var memberSessionRepository: MemberSessionRepository
+
+    @Autowired
+    private lateinit var memberLegalAcceptanceRepository: MemberLegalAcceptanceRepository
 
     @AfterEach
     fun clearLoginAttemptState() {
@@ -572,6 +577,64 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
                     jsonPath("$.isAdmin") { value(member.isAdmin) }
                     jsonPath("$.username") { value(member.name) }
                     jsonPath("$.nickname") { value(member.nickname) }
+                    jsonPath("$.legalReconsent.status") { value("RECONSENT_REQUIRED") }
+                    jsonPath("$.legalReconsent.required") { value(true) }
+                }
+        }
+
+        @Test
+        fun `최신 약관 재동의를 저장하면 세션 재동의 상태가 current 로 바뀐다`() {
+            val active = ActiveLegalDocumentMetadata.current()
+            val member =
+                memberFacade.join(
+                    username = "legal-reconsent-user",
+                    password = "Abcd1234!",
+                    nickname = "재동의유저",
+                    profileImgUrl = null,
+                    email = "legal-reconsent-user@example.com",
+                )
+            val authCookies = loginAuthCookies(member.email!!)
+
+            mvc
+                .post("/member/api/v1/auth/legal-reconsent") {
+                    authCookies.forEach { cookie(it) }
+                    header("X-Aquila-CSRF", "1")
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                            "termsVersion": "${active.terms.version}",
+                            "termsContentSha256": "${active.terms.contentSha256}",
+                            "privacyVersion": "${active.privacy.version}",
+                            "privacyContentSha256": "${active.privacy.contentSha256}",
+                            "age14OrOlder": true,
+                            "requiredPrivacyConfirmed": true,
+                            "analyticsConsent": false,
+                            "overseasTransferAcknowledged": true
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isOk() }
+                    match(handler().handlerType(ApiV1AuthController::class.java))
+                    match(handler().methodName("legalReconsent"))
+                    jsonPath("$.resultCode") { value("200-1") }
+                    jsonPath("$.data.legalReconsent.status") { value("CURRENT") }
+                    jsonPath("$.data.legalReconsent.required") { value(false) }
+                }
+
+            val saved = memberLegalAcceptanceRepository.findTopByMemberIdOrderByAcceptedAtDesc(member.id)
+            assertThat(saved).isNotNull
+            assertThat(saved!!.source).isEqualTo("RECONSENT")
+            assertThat(saved.termsVersion).isEqualTo(active.terms.version)
+            assertThat(saved.privacyVersion).isEqualTo(active.privacy.version)
+
+            mvc
+                .get("/member/api/v1/auth/session") {
+                    authCookies.forEach { cookie(it) }
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.legalReconsent.status") { value("CURRENT") }
+                    jsonPath("$.legalReconsent.required") { value(false) }
                 }
         }
 

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/web/ApiV1AuthControllerTest.kt
@@ -639,6 +639,33 @@ class ApiV1AuthControllerTest : BaseControllerIntegrationTest() {
         }
 
         @Test
+        fun `재동의 요청 DTO는 모든 법적 증빙 필드를 command 로 전달한다`() {
+            val active = ActiveLegalDocumentMetadata.current()
+            val request =
+                ApiV1AuthController.LegalReconsentRequest(
+                    termsVersion = active.terms.version,
+                    termsContentSha256 = active.terms.contentSha256,
+                    privacyVersion = active.privacy.version,
+                    privacyContentSha256 = active.privacy.contentSha256,
+                    age14OrOlder = true,
+                    requiredPrivacyConfirmed = true,
+                    analyticsConsent = false,
+                    overseasTransferAcknowledged = true,
+                )
+
+            val command = request.toCommand()
+
+            assertThat(command.termsVersion).isEqualTo(request.termsVersion)
+            assertThat(command.termsContentSha256).isEqualTo(request.termsContentSha256)
+            assertThat(command.privacyVersion).isEqualTo(request.privacyVersion)
+            assertThat(command.privacyContentSha256).isEqualTo(request.privacyContentSha256)
+            assertThat(command.age14OrOlder).isEqualTo(request.age14OrOlder)
+            assertThat(command.requiredPrivacyConfirmed).isEqualTo(request.requiredPrivacyConfirmed)
+            assertThat(command.analyticsConsent).isEqualTo(request.analyticsConsent)
+            assertThat(command.overseasTransferAcknowledged).isEqualTo(request.overseasTransferAcknowledged)
+        }
+
+        @Test
         fun `내 정보 조회는 apiKey 쿠키만 있으면 세션 만료로 거부한다`() {
             val member = memberFacade.findByLoginId("user1")!!
 

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/LegalAcceptanceApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/LegalAcceptanceApplicationServiceTest.kt
@@ -1,0 +1,67 @@
+package com.back.boundedContexts.member.subContexts.legalAcceptance.application.service
+
+import com.back.boundedContexts.member.adapter.web.ApiV1AdmMemberController
+import com.back.boundedContexts.member.dto.AuthSessionMemberDto
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalReconsentReport
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.output.MemberLegalAcceptanceRepositoryPort
+import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberLegalAcceptance
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class LegalAcceptanceApplicationServiceTest {
+    @Test
+    @DisplayName("legal reconsent report uses current policy counts")
+    fun legalReconsentReportUsesCurrentPolicyCounts() {
+        val repository = CountingLegalAcceptanceRepository(currentAcceptedMembers = 3, reconsentRequiredMembers = 2)
+        val report = LegalAcceptanceApplicationService(repository).legalReconsentReport()
+
+        assertThat(report.currentAcceptedMembers).isEqualTo(3)
+        assertThat(report.reconsentRequiredMembers).isEqualTo(2)
+        assertThat(report.totalMembers).isEqualTo(5)
+        assertThat(report.completionRate).isEqualTo(0.6)
+        assertThat(repository.lastTermsVersion).isEqualTo(ActiveLegalDocumentMetadata.current().terms.version)
+        assertThat(ApiV1AdmMemberController.LegalReconsentReportResponse(report).report).isSameAs(report)
+    }
+
+    @Test
+    @DisplayName("legal reconsent report is complete when there are no legacy members")
+    fun legalReconsentReportIsCompleteWhenThereAreNoLegacyMembers() {
+        val report = LegalReconsentReport(currentAcceptedMembers = 0, reconsentRequiredMembers = 0)
+
+        assertThat(report.totalMembers).isEqualTo(0)
+        assertThat(report.completionRate).isEqualTo(1.0)
+        assertThat(AuthSessionMemberDto(id = 1, isAdmin = false, username = "user", nickname = "nick").legalReconsent)
+            .isNull()
+    }
+
+    private class CountingLegalAcceptanceRepository(
+        private val currentAcceptedMembers: Long,
+        private val reconsentRequiredMembers: Long,
+    ) : MemberLegalAcceptanceRepositoryPort {
+        var lastTermsVersion: String? = null
+
+        override fun save(memberLegalAcceptance: MemberLegalAcceptance): MemberLegalAcceptance =
+            throw UnsupportedOperationException("not used")
+
+        override fun findTopByMemberIdOrderByAcceptedAtDesc(memberId: Long): MemberLegalAcceptance? =
+            throw UnsupportedOperationException("not used")
+
+        override fun countMembersWithCurrentAcceptance(
+            termsVersion: String,
+            termsContentSha256: String,
+            privacyVersion: String,
+            privacyContentSha256: String,
+        ): Long {
+            lastTermsVersion = termsVersion
+            return currentAcceptedMembers
+        }
+
+        override fun countMembersMissingCurrentAcceptance(
+            termsVersion: String,
+            termsContentSha256: String,
+            privacyVersion: String,
+            privacyContentSha256: String,
+        ): Long = reconsentRequiredMembers
+    }
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/web/ApiV1OAuthSignupControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/adapter/web/ApiV1OAuthSignupControllerTest.kt
@@ -1,8 +1,8 @@
 package com.back.boundedContexts.member.subContexts.oauthSignup.adapter.web
 
 import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.ActiveLegalDocumentMetadata
-import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupUseCase
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingDetails
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingStartResult

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/oauthSignup/application/service/OAuthSignupApplicationServiceTest.kt
@@ -4,10 +4,10 @@ import com.back.boundedContexts.member.application.port.input.MemberUseCase
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileLinkItem
 import com.back.boundedContexts.member.domain.shared.memberMixin.MemberProfileWorkspaceContent
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.output.MemberLegalAcceptanceRepositoryPort
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.ActiveLegalDocumentMetadata
 import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceApplicationService
-import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.legalAcceptance.model.MemberLegalAcceptance
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.output.PendingOAuthSignupRepositoryPort
 import com.back.boundedContexts.member.subContexts.oauthSignup.model.PendingOAuthSignup
@@ -459,6 +459,30 @@ private class RecordingLegalAcceptanceRepository : MemberLegalAcceptanceReposito
         saved
             .filter { it.member.id == memberId }
             .maxByOrNull { it.acceptedAt }
+
+    override fun countMembersWithCurrentAcceptance(
+        termsVersion: String,
+        termsContentSha256: String,
+        privacyVersion: String,
+        privacyContentSha256: String,
+    ): Long =
+        saved
+            .filter {
+                it.termsVersion == termsVersion &&
+                    it.termsContentSha256 == termsContentSha256 &&
+                    it.privacyVersion == privacyVersion &&
+                    it.privacyContentSha256 == privacyContentSha256
+            }.map { it.member.id }
+            .distinct()
+            .size
+            .toLong()
+
+    override fun countMembersMissingCurrentAcceptance(
+        termsVersion: String,
+        termsContentSha256: String,
+        privacyVersion: String,
+        privacyContentSha256: String,
+    ): Long = 0
 }
 
 private class RecordingMemberUseCase : MemberUseCase {

--- a/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserServiceTest.kt
@@ -2,7 +2,7 @@ package com.back.global.security.config.oauth2
 
 import com.back.boundedContexts.member.application.port.input.MemberUseCase
 import com.back.boundedContexts.member.domain.shared.Member
-import com.back.boundedContexts.member.subContexts.legalAcceptance.application.service.LegalAcceptanceCommand
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.dto.LegalAcceptanceCommand
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.port.input.OAuthSignupUseCase
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingDetails
 import com.back.boundedContexts.member.subContexts.oauthSignup.application.service.OAuthSignupPendingStartResult

--- a/back/src/test/kotlin/com/back/support/BaseAdmMemberControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseAdmMemberControllerWebMvcTest.kt
@@ -3,6 +3,7 @@ package com.back.support
 import com.back.boundedContexts.member.adapter.web.ApiV1AdmMemberController
 import com.back.boundedContexts.member.application.port.input.CurrentMemberProfileQueryUseCase
 import com.back.boundedContexts.member.application.port.input.MemberUseCase
+import com.back.boundedContexts.member.subContexts.legalAcceptance.application.port.input.LegalAcceptanceUseCase
 import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
 import com.back.boundedContexts.post.config.PostImageStorageProperties
 import com.back.global.app.AppConfig
@@ -51,6 +52,9 @@ abstract class BaseAdmMemberControllerWebMvcTest : BaseIntegrationTest() {
 
     @MockitoBean
     protected lateinit var uploadedFileRetentionService: UploadedFileRetentionService
+
+    @MockitoBean
+    protected lateinit var legalAcceptanceUseCase: LegalAcceptanceUseCase
 
     @MockitoBean(name = "jpaMappingContext")
     protected lateinit var jpaMappingContext: JpaMetamodelMappingContext

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -4635,16 +4635,24 @@
         "type" : "object",
         "properties" : {
           "termsVersion" : {
-            "type" : "string"
+            "type" : "string",
+            "maxLength" : 32,
+            "minLength" : 0
           },
           "termsContentSha256" : {
-            "type" : "string"
+            "type" : "string",
+            "maxLength" : 64,
+            "minLength" : 64
           },
           "privacyVersion" : {
-            "type" : "string"
+            "type" : "string",
+            "maxLength" : 32,
+            "minLength" : 0
           },
           "privacyContentSha256" : {
-            "type" : "string"
+            "type" : "string",
+            "maxLength" : 64,
+            "minLength" : 64
           },
           "age14OrOlder" : {
             "type" : "boolean"
@@ -4658,7 +4666,8 @@
           "overseasTransferAcknowledged" : {
             "type" : "boolean"
           }
-        }
+        },
+        "required" : [ "age14OrOlder", "analyticsConsent", "overseasTransferAcknowledged", "privacyContentSha256", "privacyVersion", "requiredPrivacyConfirmed", "termsContentSha256", "termsVersion" ]
       },
       "LegalReconsentResponse" : {
         "type" : "object",

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -1242,6 +1242,34 @@
         }
       }
     },
+    "/member/api/v1/auth/legal-reconsent" : {
+      "post" : {
+        "tags" : [ "api-v-1-auth-controller" ],
+        "operationId" : "legalReconsent",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/LegalReconsentRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RsDataLegalReconsentResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/member/api/v1/adm/members/{id}/profileWorkspace/publish" : {
       "post" : {
         "tags" : [ "api-v-1-adm-member-controller" ],
@@ -2815,6 +2843,24 @@
               "*/*" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/AdminProfileBootstrapResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/member/api/v1/adm/members/legal-reconsent/report" : {
+      "get" : {
+        "tags" : [ "api-v-1-adm-member-controller" ],
+        "operationId" : "legalReconsentReport",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LegalReconsentReportResponse"
                 }
               }
             }
@@ -4585,6 +4631,93 @@
           }
         }
       },
+      "LegalReconsentRequest" : {
+        "type" : "object",
+        "properties" : {
+          "termsVersion" : {
+            "type" : "string"
+          },
+          "termsContentSha256" : {
+            "type" : "string"
+          },
+          "privacyVersion" : {
+            "type" : "string"
+          },
+          "privacyContentSha256" : {
+            "type" : "string"
+          },
+          "age14OrOlder" : {
+            "type" : "boolean"
+          },
+          "requiredPrivacyConfirmed" : {
+            "type" : "boolean"
+          },
+          "analyticsConsent" : {
+            "type" : "boolean"
+          },
+          "overseasTransferAcknowledged" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "LegalReconsentResponse" : {
+        "type" : "object",
+        "properties" : {
+          "legalReconsent" : {
+            "$ref" : "#/components/schemas/LegalReconsentStatus"
+          }
+        }
+      },
+      "LegalReconsentStatus" : {
+        "type" : "object",
+        "properties" : {
+          "status" : {
+            "type" : "string"
+          },
+          "required" : {
+            "type" : "boolean"
+          },
+          "termsVersion" : {
+            "type" : "string"
+          },
+          "termsContentSha256" : {
+            "type" : "string"
+          },
+          "privacyVersion" : {
+            "type" : "string"
+          },
+          "privacyContentSha256" : {
+            "type" : "string"
+          },
+          "acceptedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "refusalGuidePath" : {
+            "type" : "string"
+          },
+          "exportGuidePath" : {
+            "type" : "string"
+          },
+          "deletionGuidePath" : {
+            "type" : "string"
+          }
+        }
+      },
+      "RsDataLegalReconsentResponse" : {
+        "type" : "object",
+        "properties" : {
+          "resultCode" : {
+            "type" : "string"
+          },
+          "msg" : {
+            "type" : "string"
+          },
+          "data" : {
+            "$ref" : "#/components/schemas/LegalReconsentResponse"
+          }
+        }
+      },
       "MemberWithUsernameDto" : {
         "type" : "object",
         "properties" : {
@@ -5349,6 +5482,9 @@
           "nickname" : {
             "type" : "string"
           },
+          "legalReconsent" : {
+            "$ref" : "#/components/schemas/LegalReconsentStatus"
+          },
           "isAdmin" : {
             "type" : "boolean"
           }
@@ -5889,6 +6025,35 @@
           },
           "workspace" : {
             "$ref" : "#/components/schemas/MemberProfileWorkspaceResponseDto"
+          }
+        }
+      },
+      "LegalReconsentReport" : {
+        "type" : "object",
+        "properties" : {
+          "currentAcceptedMembers" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "reconsentRequiredMembers" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "totalMembers" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "completionRate" : {
+            "type" : "number",
+            "format" : "double"
+          }
+        }
+      },
+      "LegalReconsentReportResponse" : {
+        "type" : "object",
+        "properties" : {
+          "report" : {
+            "$ref" : "#/components/schemas/LegalReconsentReport"
           }
         }
       },

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -1993,14 +1993,14 @@ export interface components {
             data?: components["schemas"]["MemberLoginResBody"];
         };
         LegalReconsentRequest: {
-            termsVersion?: string;
-            termsContentSha256?: string;
-            privacyVersion?: string;
-            privacyContentSha256?: string;
-            age14OrOlder?: boolean;
-            requiredPrivacyConfirmed?: boolean;
-            analyticsConsent?: boolean;
-            overseasTransferAcknowledged?: boolean;
+            termsVersion: string;
+            termsContentSha256: string;
+            privacyVersion: string;
+            privacyContentSha256: string;
+            age14OrOlder: boolean;
+            requiredPrivacyConfirmed: boolean;
+            analyticsConsent: boolean;
+            overseasTransferAcknowledged: boolean;
         };
         LegalReconsentResponse: {
             legalReconsent?: components["schemas"]["LegalReconsentStatus"];

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -486,6 +486,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/member/api/v1/auth/legal-reconsent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["legalReconsent"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/member/api/v1/adm/members/{id}/profileWorkspace/publish": {
         parameters: {
             query?: never;
@@ -1308,6 +1324,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/member/api/v1/adm/members/legal-reconsent/report": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["legalReconsentReport"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/member/api/v1/adm/members/bootstrap": {
         parameters: {
             query?: never;
@@ -1960,6 +1992,37 @@ export interface components {
             msg?: string;
             data?: components["schemas"]["MemberLoginResBody"];
         };
+        LegalReconsentRequest: {
+            termsVersion?: string;
+            termsContentSha256?: string;
+            privacyVersion?: string;
+            privacyContentSha256?: string;
+            age14OrOlder?: boolean;
+            requiredPrivacyConfirmed?: boolean;
+            analyticsConsent?: boolean;
+            overseasTransferAcknowledged?: boolean;
+        };
+        LegalReconsentResponse: {
+            legalReconsent?: components["schemas"]["LegalReconsentStatus"];
+        };
+        LegalReconsentStatus: {
+            status?: string;
+            required?: boolean;
+            termsVersion?: string;
+            termsContentSha256?: string;
+            privacyVersion?: string;
+            privacyContentSha256?: string;
+            /** Format: date-time */
+            acceptedAt?: string;
+            refusalGuidePath?: string;
+            exportGuidePath?: string;
+            deletionGuidePath?: string;
+        };
+        RsDataLegalReconsentResponse: {
+            resultCode?: string;
+            msg?: string;
+            data?: components["schemas"]["LegalReconsentResponse"];
+        };
         MemberWithUsernameDto: {
             /** Format: int64 */
             id?: number;
@@ -2253,6 +2316,7 @@ export interface components {
             id?: number;
             username?: string;
             nickname?: string;
+            legalReconsent?: components["schemas"]["LegalReconsentStatus"];
             isAdmin?: boolean;
         };
         AuthSecurityEventDto: {
@@ -2460,6 +2524,19 @@ export interface components {
         AdminProfileBootstrapResponse: {
             member?: components["schemas"]["AuthSessionMemberDto"];
             workspace?: components["schemas"]["MemberProfileWorkspaceResponseDto"];
+        };
+        LegalReconsentReport: {
+            /** Format: int64 */
+            currentAcceptedMembers?: number;
+            /** Format: int64 */
+            reconsentRequiredMembers?: number;
+            /** Format: int64 */
+            totalMembers?: number;
+            /** Format: double */
+            completionRate?: number;
+        };
+        LegalReconsentReportResponse: {
+            report?: components["schemas"]["LegalReconsentReport"];
         };
         AdminHubBootstrapResponse: {
             member?: components["schemas"]["AuthSessionMemberDto"];
@@ -3421,6 +3498,30 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["RsDataMemberLoginResBody"];
+                };
+            };
+        };
+    };
+    legalReconsent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LegalReconsentRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RsDataLegalReconsentResponse"];
                 };
             };
         };
@@ -4591,6 +4692,26 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["AdminProfileBootstrapResponse"];
+                };
+            };
+        };
+    };
+    legalReconsentReport: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["LegalReconsentReportResponse"];
                 };
             };
         };

--- a/front/src/apis/backend/legal.ts
+++ b/front/src/apis/backend/legal.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from "./client"
+
 export const ACTIVE_LEGAL_DOCUMENTS = {
   signupPolicyVersion: "1.0.1",
   terms: {
@@ -29,3 +31,43 @@ export const buildEmailSignupLegalAcceptancePayload = (input: {
 })
 
 export const buildSocialSignupLegalAcceptancePayload = buildEmailSignupLegalAcceptancePayload
+
+export type LegalReconsentStatus = {
+  status: "CURRENT" | "RECONSENT_REQUIRED"
+  required: boolean
+  termsVersion: string
+  termsContentSha256: string
+  privacyVersion: string
+  privacyContentSha256: string
+  acceptedAt?: string | null
+  refusalGuidePath: string
+  exportGuidePath: string
+  deletionGuidePath: string
+}
+
+type RsData<T> = {
+  resultCode: string
+  msg: string
+  data: T
+}
+
+type AuthSessionLegalResponse = {
+  legalReconsent?: LegalReconsentStatus | null
+}
+
+export const getLegalReconsentStatus = async () => {
+  const session = await apiFetch<AuthSessionLegalResponse>("/member/api/v1/auth/session")
+  return session.legalReconsent ?? null
+}
+
+export const submitLegalReconsent = async (input: {
+  age14OrOlder: boolean
+  requiredPrivacyConfirmed: boolean
+  analyticsConsent: boolean
+  overseasTransferAcknowledged: boolean
+}) => {
+  return await apiFetch<RsData<{ legalReconsent: LegalReconsentStatus }>>("/member/api/v1/auth/legal-reconsent", {
+    method: "POST",
+    body: JSON.stringify(buildEmailSignupLegalAcceptancePayload(input)),
+  })
+}

--- a/front/src/hooks/useAuthSession.ts
+++ b/front/src/hooks/useAuthSession.ts
@@ -137,7 +137,10 @@ const useAuthSession = () => {
 
   useEffect(() => {
     if (!isMounted || authStatus !== "authenticated" || !me) return
-    if (router.asPath.startsWith("/settings/privacy")) return
+    const pathname = router.asPath.split("?")[0] || router.pathname
+    const canReadLegalDocument =
+      ["/settings/privacy", "/terms", "/privacy"].includes(pathname) || pathname.startsWith("/legal/")
+    if (canReadLegalDocument) return
 
     let cancelled = false
     const routeToReconsent = async () => {

--- a/front/src/hooks/useAuthSession.ts
+++ b/front/src/hooks/useAuthSession.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
 import { ApiError, apiFetch } from "src/apis/backend/client"
+import type { LegalReconsentStatus } from "src/apis/backend/legal"
 import { queryKey } from "src/constants/queryKey"
 import type { ProfileCardLinkItem } from "src/constants/profileCardLinks"
 import type { BlogDesignType, LegacyBlogScheme } from "src/types"
@@ -54,6 +55,7 @@ export type AuthMember = {
   legacyBlogScheme?: LegacyBlogScheme
   serviceLinks?: ProfileCardLinkItem[]
   contactLinks?: ProfileCardLinkItem[]
+  legalReconsent?: LegalReconsentStatus | null
 }
 
 const useAuthSession = () => {

--- a/front/src/hooks/useAuthSession.ts
+++ b/front/src/hooks/useAuthSession.ts
@@ -1,9 +1,11 @@
+import { useRouter } from "next/router"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
 import { ApiError, apiFetch } from "src/apis/backend/client"
-import type { LegalReconsentStatus } from "src/apis/backend/legal"
+import { getLegalReconsentStatus, type LegalReconsentStatus } from "src/apis/backend/legal"
 import { queryKey } from "src/constants/queryKey"
 import type { ProfileCardLinkItem } from "src/constants/profileCardLinks"
+import { replaceRoute } from "src/libs/router"
 import type { BlogDesignType, LegacyBlogScheme } from "src/types"
 
 const AUTH_ME_ANON_SUPPRESS_UNTIL_KEY = "auth:me:anon-probe-suppress-until:v1"
@@ -59,6 +61,7 @@ export type AuthMember = {
 }
 
 const useAuthSession = () => {
+  const router = useRouter()
   const [isMounted, setIsMounted] = useState(false)
   useEffect(() => {
     setIsMounted(true)
@@ -131,6 +134,29 @@ const useAuthSession = () => {
           : hasResolvedSnapshot
             ? "anonymous"
             : "loading"
+
+  useEffect(() => {
+    if (!isMounted || authStatus !== "authenticated" || !me) return
+    if (router.asPath.startsWith("/settings/privacy")) return
+
+    let cancelled = false
+    const routeToReconsent = async () => {
+      const status = me.legalReconsent ?? (await getLegalReconsentStatus())
+      if (!cancelled && status?.required) {
+        await replaceRoute(router, "/settings/privacy?reconsent=required")
+      }
+    }
+
+    routeToReconsent().catch(() => {
+      if (!cancelled) {
+        void replaceRoute(router, "/settings/privacy?reconsent=required")
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [authStatus, isMounted, me, router, router.asPath])
 
   const logout = async () => {
     try {

--- a/front/src/hooks/useAuthSession.ts
+++ b/front/src/hooks/useAuthSession.ts
@@ -5,7 +5,7 @@ import { ApiError, apiFetch } from "src/apis/backend/client"
 import { getLegalReconsentStatus, type LegalReconsentStatus } from "src/apis/backend/legal"
 import { queryKey } from "src/constants/queryKey"
 import type { ProfileCardLinkItem } from "src/constants/profileCardLinks"
-import { replaceRoute } from "src/libs/router"
+import { replaceRoute, toLegalReconsentPath } from "src/libs/router"
 import type { BlogDesignType, LegacyBlogScheme } from "src/types"
 
 const AUTH_ME_ANON_SUPPRESS_UNTIL_KEY = "auth:me:anon-probe-suppress-until:v1"
@@ -147,7 +147,7 @@ const useAuthSession = () => {
     const routeToReconsent = async () => {
       const status = me.legalReconsent ?? (await getLegalReconsentStatus())
       if (!cancelled && status?.required) {
-        await replaceRoute(router, "/settings/privacy?reconsent=required")
+        await replaceRoute(router, toLegalReconsentPath(router.asPath))
       }
     }
 

--- a/front/src/hooks/useAuthSession.ts
+++ b/front/src/hooks/useAuthSession.ts
@@ -139,7 +139,8 @@ const useAuthSession = () => {
     if (!isMounted || authStatus !== "authenticated" || !me) return
     const pathname = router.asPath.split("?")[0] || router.pathname
     const canReadLegalDocument =
-      ["/settings/privacy", "/terms", "/privacy"].includes(pathname) || pathname.startsWith("/legal/")
+      ["/settings/privacy", "/settings/account", "/terms", "/privacy"].includes(pathname) ||
+      pathname.startsWith("/legal/")
     if (canReadLegalDocument) return
 
     let cancelled = false

--- a/front/src/hooks/useAuthSession.ts
+++ b/front/src/hooks/useAuthSession.ts
@@ -150,11 +150,7 @@ const useAuthSession = () => {
       }
     }
 
-    routeToReconsent().catch(() => {
-      if (!cancelled) {
-        void replaceRoute(router, "/settings/privacy?reconsent=required")
-      }
-    })
+    void routeToReconsent().catch(() => undefined)
 
     return () => {
       cancelled = true

--- a/front/src/libs/router.ts
+++ b/front/src/libs/router.ts
@@ -123,6 +123,9 @@ export const toLoginPath = (nextPath: NextPathInput, fallback = "/") =>
 export const toSignupPath = (nextPath: NextPathInput, fallback = "/") =>
   `/signup?next=${encodeURIComponent(normalizeNextPath(nextPath, fallback))}`
 
+export const toLegalReconsentPath = (nextPath: NextPathInput, fallback = "/") =>
+  `/settings/privacy?reconsent=required&next=${encodeURIComponent(normalizeNextPath(nextPath, fallback))}`
+
 const toSafeClientRedirectTarget = (target: string, fallback = "/"): string => {
   if (typeof window === "undefined") return normalizeNextPath(target, fallback)
 

--- a/front/src/pages/login.tsx
+++ b/front/src/pages/login.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router"
 import { FormEvent, useEffect, useMemo, useState } from "react"
 import { apiFetch } from "src/apis/backend/client"
 import { toAuthErrorMessage } from "src/apis/backend/errorMessages"
+import { getLegalReconsentStatus } from "src/apis/backend/legal"
 import { ErrorText, FooterText, SuccessText } from "src/components/auth/LoginPage.styles"
 import { LoginPageForm } from "src/components/auth/LoginPageForm"
 import AuthShell from "src/components/auth/AuthShell"
@@ -147,6 +148,9 @@ const LoginPage = () => {
         }
       }
 
+      const legalReconsent = await getLegalReconsentStatus().catch(() => null)
+      const destination = legalReconsent?.required ? "/settings/privacy?reconsent=required" : next
+
       const normalizePathname = (value: string) => {
         if (!value) return "/"
         if (value === "/") return "/"
@@ -155,12 +159,12 @@ const LoginPage = () => {
       }
 
       const currentPathname = normalizePathname(router.asPath.split("?")[0] || router.pathname)
-      const nextPathname = normalizePathname(next.split("?")[0] || "/")
+      const nextPathname = normalizePathname(destination.split("?")[0] || "/")
       const shouldNavigate = nextPathname !== currentPathname
 
-      if (shouldNavigate && router.asPath !== next) {
-        await replaceRoute(router, next, {
-          preferHardNavigation: nextPathname.startsWith("/editor/"),
+      if (shouldNavigate && router.asPath !== destination) {
+        await replaceRoute(router, destination, {
+          preferHardNavigation: destination.startsWith("/editor/"),
         })
       }
     } catch (authError) {

--- a/front/src/pages/login.tsx
+++ b/front/src/pages/login.tsx
@@ -12,7 +12,7 @@ import { buildSocialAuthItems } from "src/components/auth/socialAuth"
 import useAuthSession from "src/hooks/useAuthSession"
 import type { AuthMember } from "src/hooks/useAuthSession"
 import { loadAuthLoginPolicyPrefs, saveAuthLoginPolicyPrefs } from "src/libs/authLoginPolicy"
-import { normalizeNextPath, replaceRoute, toLoginPath, toSignupPath } from "src/libs/router"
+import { normalizeNextPath, replaceRoute, toLegalReconsentPath, toLoginPath, toSignupPath } from "src/libs/router"
 import { GuestPageProps, getGuestPageProps } from "src/libs/server/guestPage"
 import { isValidAuthEmail, normalizeAuthEmail } from "src/libs/validation/auth"
 
@@ -149,7 +149,7 @@ const LoginPage = () => {
       }
 
       const legalReconsent = await getLegalReconsentStatus().catch(() => ({ required: true }))
-      const destination = legalReconsent?.required === false ? next : "/settings/privacy?reconsent=required"
+      const destination = legalReconsent?.required === false ? next : toLegalReconsentPath(next)
 
       const normalizePathname = (value: string) => {
         if (!value) return "/"

--- a/front/src/pages/login.tsx
+++ b/front/src/pages/login.tsx
@@ -148,8 +148,8 @@ const LoginPage = () => {
         }
       }
 
-      const legalReconsent = await getLegalReconsentStatus().catch(() => null)
-      const destination = legalReconsent?.required ? "/settings/privacy?reconsent=required" : next
+      const legalReconsent = await getLegalReconsentStatus().catch(() => ({ required: true }))
+      const destination = legalReconsent?.required === false ? next : "/settings/privacy?reconsent=required"
 
       const normalizePathname = (value: string) => {
         if (!value) return "/"

--- a/front/src/routes/Settings/SettingsPrivacyPage.tsx
+++ b/front/src/routes/Settings/SettingsPrivacyPage.tsx
@@ -1,4 +1,6 @@
+import Link from "next/link"
 import { FormEvent, useEffect, useState } from "react"
+import { getLegalReconsentStatus, LegalReconsentStatus, submitLegalReconsent } from "src/apis/backend/legal"
 import {
   createPrivacyRequest,
   getPrivacyExport,
@@ -25,9 +27,15 @@ const SettingsPrivacyPage = () => {
   const [requestType, setRequestType] = useState<PrivacyRequestType>("EXPORT")
   const [message, setMessage] = useState("")
   const [createdRequest, setCreatedRequest] = useState<PrivacyRequestItem | null>(null)
+  const [legalReconsent, setLegalReconsent] = useState<LegalReconsentStatus | null>(null)
+  const [ageConfirmed, setAgeConfirmed] = useState(false)
+  const [privacyConfirmed, setPrivacyConfirmed] = useState(false)
+  const [overseasConfirmed, setOverseasConfirmed] = useState(false)
   const [feedback, setFeedback] = useState("")
+  const [legalFeedback, setLegalFeedback] = useState("")
   const [loading, setLoading] = useState(true)
   const [submitting, setSubmitting] = useState(false)
+  const [legalSubmitting, setLegalSubmitting] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -43,6 +51,13 @@ const SettingsPrivacyPage = () => {
       })
       .finally(() => {
         if (!cancelled) setLoading(false)
+      })
+    getLegalReconsentStatus()
+      .then((status) => {
+        if (!cancelled) setLegalReconsent(status)
+      })
+      .catch(() => {
+        if (!cancelled) setLegalFeedback("법적 문서 동의 상태를 불러오지 못했습니다.")
       })
     return () => {
       cancelled = true
@@ -70,9 +85,77 @@ const SettingsPrivacyPage = () => {
     }
   }
 
+  const submitReconsent = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setLegalSubmitting(true)
+    setLegalFeedback("")
+    try {
+      const response = await submitLegalReconsent({
+        age14OrOlder: ageConfirmed,
+        requiredPrivacyConfirmed: privacyConfirmed,
+        analyticsConsent: false,
+        overseasTransferAcknowledged: overseasConfirmed,
+      })
+      setLegalReconsent(response.data.legalReconsent)
+      setLegalFeedback(response.msg)
+    } catch {
+      setLegalFeedback("최신 약관과 개인정보처리방침 동의를 저장하지 못했습니다.")
+    } finally {
+      setLegalSubmitting(false)
+    }
+  }
+
   return (
     <SettingsLayout active="privacy" title="개인정보 관리">
       <div className="settingsGrid">
+        <section className="panel" aria-label="법적 문서 재동의">
+          <h2>약관·개인정보처리방침 동의</h2>
+          {legalReconsent?.required ? (
+            <>
+              <p className="muted">
+                기존 계정은 최신 <Link href="/terms">이용약관</Link>과{" "}
+                <Link href="/privacy">개인정보처리방침</Link> 확인 후 계속 이용할 수 있습니다.
+              </p>
+              <form className="requestForm" onSubmit={submitReconsent}>
+                <label className="checkLabel">
+                  <input type="checkbox" checked={ageConfirmed} onChange={(event) => setAgeConfirmed(event.target.checked)} />
+                  만 14세 이상입니다.
+                </label>
+                <label className="checkLabel">
+                  <input
+                    type="checkbox"
+                    checked={privacyConfirmed}
+                    onChange={(event) => setPrivacyConfirmed(event.target.checked)}
+                  />
+                  필수 개인정보 처리 안내를 확인했습니다.
+                </label>
+                <label className="checkLabel">
+                  <input
+                    type="checkbox"
+                    checked={overseasConfirmed}
+                    onChange={(event) => setOverseasConfirmed(event.target.checked)}
+                  />
+                  국외 이전 및 외부 처리자 안내를 확인했습니다.
+                </label>
+                <button type="submit" disabled={legalSubmitting || !ageConfirmed || !privacyConfirmed || !overseasConfirmed}>
+                  {legalSubmitting ? "저장 중" : "동의하고 계속 이용"}
+                </button>
+              </form>
+              <p className="muted">
+                동의하지 않는 경우 이 화면에서 개인정보 내보내기 또는 삭제 요청을 접수할 수 있습니다.
+              </p>
+            </>
+          ) : legalReconsent ? (
+            <p className="muted">
+              최신 약관·개인정보처리방침 동의 상태입니다.
+              {legalReconsent?.acceptedAt ? ` 저장 시각: ${formatDateTime(legalReconsent.acceptedAt)}` : ""}
+            </p>
+          ) : (
+            <p className="muted">법적 문서 동의 상태를 확인하는 중입니다.</p>
+          )}
+          {legalFeedback ? <p className="feedback">{legalFeedback}</p> : null}
+        </section>
+
         <section className="panel" aria-label="개인정보 내보내기">
           <h2>내보내기 스냅샷</h2>
           {loading ? (
@@ -168,6 +251,17 @@ const SettingsPrivacyPage = () => {
           gap: 7px;
           color: #44515f;
           font-weight: 800;
+        }
+
+        .checkLabel {
+          display: flex;
+          align-items: center;
+          gap: 9px;
+        }
+
+        .checkLabel input {
+          width: 18px;
+          height: 18px;
         }
 
         select,

--- a/front/src/routes/Settings/SettingsPrivacyPage.tsx
+++ b/front/src/routes/Settings/SettingsPrivacyPage.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import { useRouter } from "next/router"
 import { FormEvent, useEffect, useState } from "react"
 import { getLegalReconsentStatus, LegalReconsentStatus, submitLegalReconsent } from "src/apis/backend/legal"
 import {
@@ -9,6 +10,7 @@ import {
   PrivacyRequestType,
 } from "src/apis/backend/privacy"
 import { setOptionalTrackingConsent } from "src/libs/privacy/browserStorageRegistry"
+import { normalizeNextPath, replaceRoute } from "src/libs/router"
 import SettingsLayout from "./SettingsLayout"
 
 const dateTimeFormatter = new Intl.DateTimeFormat("ko-KR", {
@@ -23,6 +25,7 @@ const formatDateTime = (value?: string | null) => {
 }
 
 const SettingsPrivacyPage = () => {
+  const router = useRouter()
   const [snapshot, setSnapshot] = useState<PrivacyExportResponse | null>(null)
   const [requestType, setRequestType] = useState<PrivacyRequestType>("EXPORT")
   const [message, setMessage] = useState("")
@@ -99,6 +102,7 @@ const SettingsPrivacyPage = () => {
       setLegalReconsent(response.data.legalReconsent)
       setOptionalTrackingConsent(false)
       setLegalFeedback(response.msg)
+      await replaceRoute(router, normalizeNextPath(router.query.next, "/"))
     } catch {
       setLegalFeedback("최신 약관과 개인정보처리방침 동의를 저장하지 못했습니다.")
     } finally {

--- a/front/src/routes/Settings/SettingsPrivacyPage.tsx
+++ b/front/src/routes/Settings/SettingsPrivacyPage.tsx
@@ -97,6 +97,7 @@ const SettingsPrivacyPage = () => {
         overseasTransferAcknowledged: overseasConfirmed,
       })
       setLegalReconsent(response.data.legalReconsent)
+      setOptionalTrackingConsent(false)
       setLegalFeedback(response.msg)
     } catch {
       setLegalFeedback("최신 약관과 개인정보처리방침 동의를 저장하지 못했습니다.")


### PR DESCRIPTION
## 관련 이슈

close #1008

## 작업 배경

- 기존 회원을 최신 약관·개인정보처리방침에 동의한 것처럼 자동 backfill하면 실제 동의 증빙이 왜곡됩니다.
- 최신 법적 문서 version/hash 기준으로 기존 회원을 `RECONSENT_REQUIRED` 상태로 식별하고, 실제 재동의가 있을 때만 acceptance row를 저장해야 합니다.

## 작업 내용

- `member_legal_acceptance`에 재동의 증빙용 `client_ip_hash`, `user_agent_hash` 컬럼을 추가했습니다.
- auth session 응답에 `legalReconsent` 상태를 포함하고, `/member/api/v1/auth/legal-reconsent`에서 최신 version/hash 재동의를 저장하도록 추가했습니다.
- admin report endpoint로 현재 동의 회원 수, 재동의 필요 회원 수, 완료율을 조회할 수 있게 했습니다.
- 로그인 후 재동의 필요 계정은 개인정보 설정 화면으로 이동하고, 해당 화면에서 최신 약관/개인정보처리방침 확인 후 재동의를 제출할 수 있게 했습니다.
- OpenAPI snapshot과 shared contract 타입을 새 endpoint에 맞게 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back ktlintCheck`: exit 0
  - `back/gradlew -p back test --tests '*LegalAcceptance*' --tests '*ApiV1AuthControllerTest' --rerun-tasks`: exit 0
  - `back/gradlew -p back ciFastCheck`: exit 0
  - `node tools/legal/validate-legal-policies.mjs`: exit 0
  - `yarn --cwd front contracts:check`: exit 0
  - `yarn --cwd front playwright:preflight`: exit 0
  - `yarn --cwd front build`: exit 0
  - `git diff --check`: exit 0
  - commit hook OpenAPI export/contract drift check: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Backend legal reconsent | local JVM | targeted test + ciFastCheck | local command output | session status, reconsent save, report coverage 통과 |
| Frontend reconsent UI | local Next.js | `yarn --cwd front build` | local build output | `/login`, `/settings/privacy` type/build 통과 |
| OpenAPI contract | local Node.js | `yarn --cwd front contracts:check` + commit hook | `front/contracts/openapi/openapi.json`, `front/packages/shared-contracts/src/generated/backend-openapi.d.ts` | generated types up-to-date |
| Legal policy metadata | local Node.js | `node tools/legal/validate-legal-policies.mjs` | local command output | 7 policies ok |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 기존 회원을 최신 동의로 backfill하지 않고 `RECONSENT_REQUIRED`로만 식별하는 repository query와 service 상태 계산
  - 재동의 저장 시 원문 client metadata 대신 SHA-256 hash만 저장하는 부분
  - 로그인 후 재동의 필요 계정의 `/settings/privacy?reconsent=required` 이동 흐름

## 리스크

- 재동의 gate는 frontend login redirect와 settings 화면 안내로 시작합니다. API 전체 서버 차단은 이번 범위에 넣지 않았습니다.
- 기존 회원 수가 큰 경우 admin report query 비용이 커질 수 있어, 운영 데이터에서 느리면 별도 집계 테이블/스케줄러로 분리해야 합니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 법적 약관 재동의 기능 추가
  * 회원의 약관 동의 상태를 세션에 포함하여 실시간 추적
  * 재동의 필요 시 자동으로 개인정보 설정 페이지로 이동
  * 관리자용 약관 재동의 현황 리포트 조회 기능 추가
  * 사용자가 법적 약관을 재동의할 수 있는 UI 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->