### PR TITLE
[Fix] live e2e 재동의 gate 처리 추가

### DIFF
--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -14,6 +14,7 @@ import {
   liveLoginTimeoutMs,
   liveRetryBaseDelayMs,
   liveUiRedirectTimeoutMs,
+  quickReconsentProbeTimeoutMs,
   resolveApiBaseUrl,
   sleep,
   waitForApiReachability,
@@ -379,7 +380,12 @@ test.describe("editor live visual regression", () => {
     await loginThroughUi(page)
 
     await page.goto("/editor/new")
-    await completeLegalReconsentIfRequired(page, "/editor/new")
+    await completeLegalReconsentIfRequired(
+      page,
+      "/editor/new",
+      liveUiRedirectTimeoutMs,
+      quickReconsentProbeTimeoutMs
+    )
     await page.waitForURL(/\/editor(\/|$)/, { timeout: 30_000 })
     await expect(page.getByPlaceholder("제목을 입력하세요").first()).toBeVisible()
     await expectMarkdownEditorShell(page)
@@ -408,7 +414,12 @@ test.describe("editor live visual regression", () => {
 
     try {
       await page.goto(`/editor/${postId}`)
-      await completeLegalReconsentIfRequired(page, `/editor/${postId}`)
+      await completeLegalReconsentIfRequired(
+        page,
+        `/editor/${postId}`,
+        liveUiRedirectTimeoutMs,
+        quickReconsentProbeTimeoutMs
+      )
       await page.waitForURL(new RegExp(`/editor/${postId}(\\?|$)`), { timeout: 30_000 })
       await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(title)
       await expectMarkdownEditorShell(page)
@@ -444,7 +455,7 @@ test.describe("editor live visual regression", () => {
     )
 
     await page.goto("/editor/507")
-    await completeLegalReconsentIfRequired(page, "/editor/507")
+    await completeLegalReconsentIfRequired(page, "/editor/507", liveUiRedirectTimeoutMs, quickReconsentProbeTimeoutMs)
     await page.waitForURL(/\/editor\/507(\?|$)/, { timeout: 30_000 })
     await expect(page.getByPlaceholder("제목을 입력하세요").first()).toBeVisible()
 

--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -210,6 +210,7 @@ const loginThroughUi = async (page: Page) => {
     )
     return
   }
+  if (await completeLegalReconsentIfRequired(page, "/editor/new", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)) return
 
   const apiBaseUrl = resolveApiBaseUrl(page.url())
   await waitForApiReachability(page, apiBaseUrl)

--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -65,8 +65,8 @@ const tryEnterEditorRoute = async (page: Page, timeoutMs: number) => {
       if (!isNavigationInterruptedError(error)) throw error
     }
 
-    if (editorUrlPattern.test(page.url())) return true
     if (await completeLegalReconsentIfRequired(page, "/editor/new", timeoutMs)) return true
+    if (editorUrlPattern.test(page.url())) return true
 
     try {
       await page.waitForURL(editorUrlPattern, { timeout: perTryTimeout })
@@ -200,7 +200,10 @@ const loginWithRetry = async (page: Page, apiBaseUrl: string) => {
 
 const loginThroughUi = async (page: Page) => {
   const route = await gotoLoginForEditor(page, liveUiRedirectTimeoutMs)
-  if (route === "editor") return
+  if (route === "editor") {
+    await completeLegalReconsentIfRequired(page, "/editor/new", liveUiRedirectTimeoutMs)
+    return
+  }
 
   const apiBaseUrl = resolveApiBaseUrl(page.url())
   await waitForApiReachability(page, apiBaseUrl)
@@ -238,7 +241,10 @@ const loginThroughUi = async (page: Page) => {
 
     if (outcome.kind === "response") {
       if (outcome.status < 400) {
-        if (editorUrlPattern.test(page.url())) return
+        if (editorUrlPattern.test(page.url())) {
+          await completeLegalReconsentIfRequired(page, "/editor/new", liveUiRedirectTimeoutMs)
+          return
+        }
         if (await tryEnterEditorRoute(page, liveUiRedirectTimeoutMs)) return
       } else {
         lastFailure = `status=${outcome.status} body=${outcome.bodyPreview}`
@@ -253,7 +259,10 @@ const loginThroughUi = async (page: Page) => {
       }
     }
 
-    if (outcome.kind === "editor-url") return
+    if (outcome.kind === "editor-url") {
+      await completeLegalReconsentIfRequired(page, "/editor/new", liveUiRedirectTimeoutMs)
+      return
+    }
 
     if (outcome.kind === "auth-cookie") {
       if (await tryEnterEditorRoute(page, liveUiRedirectTimeoutMs)) return

--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -66,12 +66,12 @@ const tryEnterEditorRoute = async (page: Page, timeoutMs: number) => {
       if (!isNavigationInterruptedError(error)) throw error
     }
 
-    if (await completeLegalReconsentIfRequired(page, "/editor/new", timeoutMs, timeoutMs)) return true
+    if (await completeLegalReconsentIfRequired(page, "/editor/new", timeoutMs, quickReconsentProbeTimeoutMs)) return true
     if (editorUrlPattern.test(page.url())) return true
 
     try {
       await page.waitForURL(editorUrlPattern, { timeout: perTryTimeout })
-      if (await completeLegalReconsentIfRequired(page, "/editor/new", timeoutMs, timeoutMs)) return true
+      if (await completeLegalReconsentIfRequired(page, "/editor/new", timeoutMs, quickReconsentProbeTimeoutMs)) return true
       return true
     } catch {
       if (attempt < tries) await sleep(400 * attempt)
@@ -206,7 +206,7 @@ const loginThroughUi = async (page: Page) => {
       page,
       "/editor/new",
       liveUiRedirectTimeoutMs,
-      liveUiRedirectTimeoutMs
+      quickReconsentProbeTimeoutMs
     )
     return
   }
@@ -258,7 +258,7 @@ const loginThroughUi = async (page: Page) => {
             page,
             "/editor/new",
             liveUiRedirectTimeoutMs,
-            liveUiRedirectTimeoutMs
+            quickReconsentProbeTimeoutMs
           )
           return
         }
@@ -281,7 +281,7 @@ const loginThroughUi = async (page: Page) => {
         page,
         "/editor/new",
         liveUiRedirectTimeoutMs,
-        liveUiRedirectTimeoutMs
+        quickReconsentProbeTimeoutMs
       )
       return
     }

--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -210,7 +210,12 @@ const loginThroughUi = async (page: Page) => {
     )
     return
   }
-  if (await completeLegalReconsentIfRequired(page, "/editor/new", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)) return
+  if (await completeLegalReconsentIfRequired(
+    page,
+    "/editor/new",
+    liveUiRedirectTimeoutMs,
+    quickReconsentProbeTimeoutMs
+  )) return
 
   const apiBaseUrl = resolveApiBaseUrl(page.url())
   await waitForApiReachability(page, apiBaseUrl)

--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -66,12 +66,12 @@ const tryEnterEditorRoute = async (page: Page, timeoutMs: number) => {
       if (!isNavigationInterruptedError(error)) throw error
     }
 
-    if (await completeLegalReconsentIfRequired(page, "/editor/new", timeoutMs)) return true
+    if (await completeLegalReconsentIfRequired(page, "/editor/new", timeoutMs, timeoutMs)) return true
     if (editorUrlPattern.test(page.url())) return true
 
     try {
       await page.waitForURL(editorUrlPattern, { timeout: perTryTimeout })
-      if (await completeLegalReconsentIfRequired(page, "/editor/new", timeoutMs)) return true
+      if (await completeLegalReconsentIfRequired(page, "/editor/new", timeoutMs, timeoutMs)) return true
       return true
     } catch {
       if (attempt < tries) await sleep(400 * attempt)
@@ -202,7 +202,12 @@ const loginWithRetry = async (page: Page, apiBaseUrl: string) => {
 const loginThroughUi = async (page: Page) => {
   const route = await gotoLoginForEditor(page, liveUiRedirectTimeoutMs)
   if (route === "editor") {
-    await completeLegalReconsentIfRequired(page, "/editor/new", liveUiRedirectTimeoutMs)
+    await completeLegalReconsentIfRequired(
+      page,
+      "/editor/new",
+      liveUiRedirectTimeoutMs,
+      liveUiRedirectTimeoutMs
+    )
     return
   }
 
@@ -243,7 +248,12 @@ const loginThroughUi = async (page: Page) => {
     if (outcome.kind === "response") {
       if (outcome.status < 400) {
         if (editorUrlPattern.test(page.url())) {
-          await completeLegalReconsentIfRequired(page, "/editor/new", liveUiRedirectTimeoutMs)
+          await completeLegalReconsentIfRequired(
+            page,
+            "/editor/new",
+            liveUiRedirectTimeoutMs,
+            liveUiRedirectTimeoutMs
+          )
           return
         }
         if (await tryEnterEditorRoute(page, liveUiRedirectTimeoutMs)) return
@@ -261,7 +271,12 @@ const loginThroughUi = async (page: Page) => {
     }
 
     if (outcome.kind === "editor-url") {
-      await completeLegalReconsentIfRequired(page, "/editor/new", liveUiRedirectTimeoutMs)
+      await completeLegalReconsentIfRequired(
+        page,
+        "/editor/new",
+        liveUiRedirectTimeoutMs,
+        liveUiRedirectTimeoutMs
+      )
       return
     }
 

--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -4,6 +4,7 @@ import {
   adminLegacyLoginId,
   adminPassword,
   buildLoginPayloadCandidates,
+  completeLegalReconsentIfRequired,
   hasAuthCookie,
   isInvalidLoginRequestBody,
   isNavigationInterruptedError,
@@ -65,9 +66,11 @@ const tryEnterEditorRoute = async (page: Page, timeoutMs: number) => {
     }
 
     if (editorUrlPattern.test(page.url())) return true
+    if (await completeLegalReconsentIfRequired(page, "/editor/new", timeoutMs)) return true
 
     try {
       await page.waitForURL(editorUrlPattern, { timeout: perTryTimeout })
+      if (await completeLegalReconsentIfRequired(page, "/editor/new", timeoutMs)) return true
       return true
     } catch {
       if (attempt < tries) await sleep(400 * attempt)
@@ -367,6 +370,7 @@ test.describe("editor live visual regression", () => {
     await loginThroughUi(page)
 
     await page.goto("/editor/new")
+    await completeLegalReconsentIfRequired(page, "/editor/new")
     await page.waitForURL(/\/editor(\/|$)/, { timeout: 30_000 })
     await expect(page.getByPlaceholder("제목을 입력하세요").first()).toBeVisible()
     await expectMarkdownEditorShell(page)
@@ -395,6 +399,7 @@ test.describe("editor live visual regression", () => {
 
     try {
       await page.goto(`/editor/${postId}`)
+      await completeLegalReconsentIfRequired(page, `/editor/${postId}`)
       await page.waitForURL(new RegExp(`/editor/${postId}(\\?|$)`), { timeout: 30_000 })
       await expect(page.getByPlaceholder("제목을 입력하세요").first()).toHaveValue(title)
       await expectMarkdownEditorShell(page)
@@ -430,6 +435,7 @@ test.describe("editor live visual regression", () => {
     )
 
     await page.goto("/editor/507")
+    await completeLegalReconsentIfRequired(page, "/editor/507")
     await page.waitForURL(/\/editor\/507(\?|$)/, { timeout: 30_000 })
     await expect(page.getByPlaceholder("제목을 입력하세요").first()).toBeVisible()
 

--- a/front/e2e/helpers/liveAuth.ts
+++ b/front/e2e/helpers/liveAuth.ts
@@ -66,6 +66,16 @@ export const isLegalReconsentGateUrl = (url: string) => {
   }
 }
 
+const isCurrentFallbackPath = (currentUrl: string, fallbackPath: string) => {
+  try {
+    const current = new URL(currentUrl)
+    const fallback = new URL(fallbackPath, current.origin)
+    return current.pathname === fallback.pathname
+  } catch {
+    return false
+  }
+}
+
 export const completeLegalReconsentIfRequired = async (
   page: Page,
   fallbackPath: string,
@@ -75,7 +85,10 @@ export const completeLegalReconsentIfRequired = async (
   const reconsentPanel = page.getByRole("region", { name: "법적 문서 재동의" })
   let isGate = isLegalReconsentGateUrl(page.url()) || (await reconsentPanel.isVisible().catch(() => false))
   if (!isGate) {
-    const gateProbeTimeoutMs = Math.min(timeoutMs, probeTimeoutMs)
+    const destinationProbeTimeoutMs = isCurrentFallbackPath(page.url(), fallbackPath)
+      ? quickReconsentProbeTimeoutMs
+      : probeTimeoutMs
+    const gateProbeTimeoutMs = Math.min(timeoutMs, destinationProbeTimeoutMs)
     isGate = await expect
       .poll(
         async () => isLegalReconsentGateUrl(page.url()) || (await reconsentPanel.isVisible().catch(() => false)),

--- a/front/e2e/helpers/liveAuth.ts
+++ b/front/e2e/helpers/liveAuth.ts
@@ -85,10 +85,7 @@ export const completeLegalReconsentIfRequired = async (
   const reconsentPanel = page.getByRole("region", { name: "법적 문서 재동의" })
   let isGate = isLegalReconsentGateUrl(page.url()) || (await reconsentPanel.isVisible().catch(() => false))
   if (!isGate) {
-    const destinationProbeTimeoutMs = isCurrentFallbackPath(page.url(), fallbackPath)
-      ? quickReconsentProbeTimeoutMs
-      : probeTimeoutMs
-    const gateProbeTimeoutMs = Math.min(timeoutMs, destinationProbeTimeoutMs)
+    const gateProbeTimeoutMs = Math.min(timeoutMs, probeTimeoutMs)
     isGate = await expect
       .poll(
         async () => isLegalReconsentGateUrl(page.url()) || (await reconsentPanel.isVisible().catch(() => false)),

--- a/front/e2e/helpers/liveAuth.ts
+++ b/front/e2e/helpers/liveAuth.ts
@@ -73,15 +73,17 @@ export const completeLegalReconsentIfRequired = async (
   const reconsentPanel = page.getByRole("region", { name: "법적 문서 재동의" })
   let isGate = isLegalReconsentGateUrl(page.url()) || (await reconsentPanel.isVisible().catch(() => false))
   if (!isGate) {
-    const probeTimeoutMs = Math.min(timeoutMs, 3_000)
-    isGate =
-      (await page.waitForURL((url) => isLegalReconsentGateUrl(url.href), { timeout: probeTimeoutMs }).then(
+    const probeTimeoutMs = Math.min(timeoutMs, 1_500)
+    isGate = await expect
+      .poll(
+        async () => isLegalReconsentGateUrl(page.url()) || (await reconsentPanel.isVisible().catch(() => false)),
+        { timeout: probeTimeoutMs }
+      )
+      .toBe(true)
+      .then(
         () => true,
         () => false
-      )) || (await reconsentPanel.waitFor({ state: "visible", timeout: probeTimeoutMs }).then(
-        () => true,
-        () => false
-      ))
+      )
   }
   if (!isGate) return false
 

--- a/front/e2e/helpers/liveAuth.ts
+++ b/front/e2e/helpers/liveAuth.ts
@@ -9,6 +9,7 @@ export const liveLoginAttempts = Number.parseInt(process.env.E2E_LIVE_LOGIN_ATTE
 export const liveLoginTimeoutMs = Number.parseInt(process.env.E2E_LIVE_LOGIN_TIMEOUT_MS || "30000", 10)
 export const liveRetryBaseDelayMs = Number.parseInt(process.env.E2E_LIVE_RETRY_BASE_DELAY_MS || "2000", 10)
 export const liveUiRedirectTimeoutMs = Number.parseInt(process.env.E2E_LIVE_UI_REDIRECT_TIMEOUT_MS || "20000", 10)
+export const quickReconsentProbeTimeoutMs = 1_500
 
 export const stripTrailingSlash = (value: string) => value.replace(/\/+$/, "")
 export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
@@ -68,16 +69,17 @@ export const isLegalReconsentGateUrl = (url: string) => {
 export const completeLegalReconsentIfRequired = async (
   page: Page,
   fallbackPath: string,
-  timeoutMs = liveUiRedirectTimeoutMs
+  timeoutMs = liveUiRedirectTimeoutMs,
+  probeTimeoutMs = timeoutMs
 ) => {
   const reconsentPanel = page.getByRole("region", { name: "법적 문서 재동의" })
   let isGate = isLegalReconsentGateUrl(page.url()) || (await reconsentPanel.isVisible().catch(() => false))
   if (!isGate) {
-    const probeTimeoutMs = Math.min(timeoutMs, 1_500)
+    const gateProbeTimeoutMs = Math.min(timeoutMs, probeTimeoutMs)
     isGate = await expect
       .poll(
         async () => isLegalReconsentGateUrl(page.url()) || (await reconsentPanel.isVisible().catch(() => false)),
-        { timeout: probeTimeoutMs }
+        { timeout: gateProbeTimeoutMs }
       )
       .toBe(true)
       .then(

--- a/front/e2e/helpers/liveAuth.ts
+++ b/front/e2e/helpers/liveAuth.ts
@@ -76,6 +76,22 @@ const isCurrentFallbackPath = (currentUrl: string, fallbackPath: string) => {
   }
 }
 
+const hasRequiredLegalReconsent = async (page: Page, timeoutMs: number) => {
+  try {
+    const response = await page.request.get(`${resolveApiBaseUrl(page.url())}/member/api/v1/auth/session`, {
+      timeout: timeoutMs,
+    })
+    if (!response.ok()) return false
+
+    const session = (await response.json().catch(() => null)) as
+      | { legalReconsent?: { required?: boolean } | null }
+      | null
+    return session?.legalReconsent?.required === true
+  } catch {
+    return false
+  }
+}
+
 export const completeLegalReconsentIfRequired = async (
   page: Page,
   fallbackPath: string,
@@ -96,6 +112,10 @@ export const completeLegalReconsentIfRequired = async (
         () => true,
         () => false
       )
+  }
+  if (!isGate && (await hasRequiredLegalReconsent(page, timeoutMs))) {
+    await page.goto(`/settings/privacy?reconsent=required&next=${encodeURIComponent(fallbackPath)}`)
+    isGate = true
   }
   if (!isGate) return false
 

--- a/front/e2e/helpers/liveAuth.ts
+++ b/front/e2e/helpers/liveAuth.ts
@@ -85,7 +85,7 @@ export const completeLegalReconsentIfRequired = async (
   const reconsentPanel = page.getByRole("region", { name: "법적 문서 재동의" })
   let isGate = isLegalReconsentGateUrl(page.url()) || (await reconsentPanel.isVisible().catch(() => false))
   if (!isGate) {
-    const gateProbeTimeoutMs = Math.min(timeoutMs, probeTimeoutMs, quickReconsentProbeTimeoutMs)
+    const gateProbeTimeoutMs = Math.min(timeoutMs, probeTimeoutMs)
     isGate = await expect
       .poll(
         async () => isLegalReconsentGateUrl(page.url()) || (await reconsentPanel.isVisible().catch(() => false)),
@@ -99,9 +99,26 @@ export const completeLegalReconsentIfRequired = async (
   }
   if (!isGate) return false
 
-  await page.getByLabel("만 14세 이상입니다.").check()
-  await page.getByLabel("필수 개인정보 처리 안내를 확인했습니다.").check()
-  await page.getByLabel("국외 이전 및 외부 처리자 안내를 확인했습니다.").check()
+  const ageCheckbox = page.getByLabel("만 14세 이상입니다.")
+  const privacyCheckbox = page.getByLabel("필수 개인정보 처리 안내를 확인했습니다.")
+  const overseasCheckbox = page.getByLabel("국외 이전 및 외부 처리자 안내를 확인했습니다.")
+  const hasForm = await expect
+    .poll(() => ageCheckbox.isVisible().catch(() => false), { timeout: quickReconsentProbeTimeoutMs })
+    .toBe(true)
+    .then(
+      () => true,
+      () => false
+    )
+  if (!hasForm) {
+    if (!isCurrentFallbackPath(page.url(), fallbackPath)) {
+      await page.goto(fallbackPath)
+    }
+    return true
+  }
+
+  await ageCheckbox.check()
+  await privacyCheckbox.check()
+  await overseasCheckbox.check()
   await page.getByRole("button", { name: "동의하고 계속 이용" }).click()
 
   await expect

--- a/front/e2e/helpers/liveAuth.ts
+++ b/front/e2e/helpers/liveAuth.ts
@@ -85,7 +85,7 @@ export const completeLegalReconsentIfRequired = async (
   const reconsentPanel = page.getByRole("region", { name: "법적 문서 재동의" })
   let isGate = isLegalReconsentGateUrl(page.url()) || (await reconsentPanel.isVisible().catch(() => false))
   if (!isGate) {
-    const gateProbeTimeoutMs = Math.min(timeoutMs, probeTimeoutMs)
+    const gateProbeTimeoutMs = Math.min(timeoutMs, probeTimeoutMs, quickReconsentProbeTimeoutMs)
     isGate = await expect
       .poll(
         async () => isLegalReconsentGateUrl(page.url()) || (await reconsentPanel.isVisible().catch(() => false)),

--- a/front/e2e/helpers/liveAuth.ts
+++ b/front/e2e/helpers/liveAuth.ts
@@ -103,17 +103,14 @@ export const completeLegalReconsentIfRequired = async (
   const privacyCheckbox = page.getByLabel("필수 개인정보 처리 안내를 확인했습니다.")
   const overseasCheckbox = page.getByLabel("국외 이전 및 외부 처리자 안내를 확인했습니다.")
   const hasForm = await expect
-    .poll(() => ageCheckbox.isVisible().catch(() => false), { timeout: quickReconsentProbeTimeoutMs })
+    .poll(() => ageCheckbox.isVisible().catch(() => false), { timeout: timeoutMs })
     .toBe(true)
     .then(
       () => true,
       () => false
     )
   if (!hasForm) {
-    if (!isCurrentFallbackPath(page.url(), fallbackPath)) {
-      await page.goto(fallbackPath)
-    }
-    return true
+    throw new Error(`Legal reconsent gate did not expose the required form. url=${page.url()}`)
   }
 
   await ageCheckbox.check()

--- a/front/e2e/helpers/liveAuth.ts
+++ b/front/e2e/helpers/liveAuth.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test"
+import { expect, type Page } from "@playwright/test"
 
 export const adminEmail = process.env.E2E_ADMIN_EMAIL?.trim() || ""
 export const adminLegacyLoginId = process.env.E2E_ADMIN_USERNAME?.trim() || ""
@@ -54,6 +54,51 @@ export const hasAuthCookie = async (page: Page) => {
 export const isNavigationInterruptedError = (error: unknown) => {
   const message = error instanceof Error ? error.message : String(error)
   return /(interrupted by another navigation|net::ERR_ABORTED)/i.test(message)
+}
+
+export const isLegalReconsentGateUrl = (url: string) => {
+  try {
+    const parsed = new URL(url)
+    return parsed.pathname === "/settings/privacy" && parsed.searchParams.get("reconsent") === "required"
+  } catch {
+    return false
+  }
+}
+
+export const completeLegalReconsentIfRequired = async (
+  page: Page,
+  fallbackPath: string,
+  timeoutMs = liveUiRedirectTimeoutMs
+) => {
+  const reconsentPanel = page.getByRole("region", { name: "법적 문서 재동의" })
+  let isGate = isLegalReconsentGateUrl(page.url()) || (await reconsentPanel.isVisible().catch(() => false))
+  if (!isGate) {
+    const probeTimeoutMs = Math.min(timeoutMs, 3_000)
+    isGate =
+      (await page.waitForURL((url) => isLegalReconsentGateUrl(url.href), { timeout: probeTimeoutMs }).then(
+        () => true,
+        () => false
+      )) || (await reconsentPanel.waitFor({ state: "visible", timeout: probeTimeoutMs }).then(
+        () => true,
+        () => false
+      ))
+  }
+  if (!isGate) return false
+
+  await page.getByLabel("만 14세 이상입니다.").check()
+  await page.getByLabel("필수 개인정보 처리 안내를 확인했습니다.").check()
+  await page.getByLabel("국외 이전 및 외부 처리자 안내를 확인했습니다.").check()
+  await page.getByRole("button", { name: "동의하고 계속 이용" }).click()
+
+  await expect
+    .poll(() => page.url(), { timeout: timeoutMs })
+    .not.toContain("reconsent=required")
+
+  if (!page.url().includes(fallbackPath)) {
+    await page.goto(fallbackPath)
+  }
+
+  return true
 }
 
 export const waitForApiReachability = async (page: Page, apiBaseUrl: string) => {

--- a/front/e2e/helpers/liveAuth.ts
+++ b/front/e2e/helpers/liveAuth.ts
@@ -111,7 +111,7 @@ export const completeLegalReconsentIfRequired = async (
     .poll(() => page.url(), { timeout: timeoutMs })
     .not.toContain("reconsent=required")
 
-  if (!page.url().includes(fallbackPath)) {
+  if (!isCurrentFallbackPath(page.url(), fallbackPath)) {
     await page.goto(fallbackPath)
   }
 

--- a/front/e2e/helpers/liveAuth.ts
+++ b/front/e2e/helpers/liveAuth.ts
@@ -70,7 +70,7 @@ export const completeLegalReconsentIfRequired = async (
   page: Page,
   fallbackPath: string,
   timeoutMs = liveUiRedirectTimeoutMs,
-  probeTimeoutMs = timeoutMs
+  probeTimeoutMs = quickReconsentProbeTimeoutMs
 ) => {
   const reconsentPanel = page.getByRole("region", { name: "법적 문서 재동의" })
   let isGate = isLegalReconsentGateUrl(page.url()) || (await reconsentPanel.isVisible().catch(() => false))

--- a/front/e2e/live-auth-helper.spec.ts
+++ b/front/e2e/live-auth-helper.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test"
 
-import { isNavigationInterruptedError } from "./helpers/liveAuth"
+import { isLegalReconsentGateUrl, isNavigationInterruptedError } from "./helpers/liveAuth"
 
 test.describe("live auth navigation helper", () => {
   test("treats Playwright net ERR_ABORTED as a retriable navigation interruption", () => {
@@ -19,5 +19,11 @@ test.describe("live auth navigation helper", () => {
     const error = new Error("page.goto: net::ERR_NAME_NOT_RESOLVED at https://www.aquilaxk.site/editor/new")
 
     expect(isNavigationInterruptedError(error)).toBe(false)
+  })
+
+  test("detects legal reconsent gate urls", () => {
+    expect(isLegalReconsentGateUrl("https://www.aquilaxk.site/settings/privacy?reconsent=required")).toBe(true)
+    expect(isLegalReconsentGateUrl("https://www.aquilaxk.site/settings/privacy")).toBe(false)
+    expect(isLegalReconsentGateUrl("https://www.aquilaxk.site/editor/new")).toBe(false)
   })
 })

--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -49,12 +49,12 @@ const tryEnterAdminRoute = async (page: Page, timeoutMs: number) => {
       if (!isNavigationInterruptedError(error)) throw error
     }
 
-    if (await completeLegalReconsentIfRequired(page, "/admin", timeoutMs)) return true
+    if (await completeLegalReconsentIfRequired(page, "/admin", timeoutMs, timeoutMs)) return true
     if (adminUrlPattern.test(page.url())) return true
 
     try {
       await page.waitForURL(adminUrlPattern, { timeout: perTryTimeout })
-      if (await completeLegalReconsentIfRequired(page, "/admin", timeoutMs)) return true
+      if (await completeLegalReconsentIfRequired(page, "/admin", timeoutMs, timeoutMs)) return true
       return true
     } catch {
       if (attempt < tries) {
@@ -322,7 +322,7 @@ const loginThroughUi = async (
   for (let attempt = 1; attempt <= liveLoginAttempts; attempt += 1) {
     const route = await gotoLoginForAdmin(page, liveUiRedirectTimeoutMs)
     if (route === "admin") {
-      await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs)
+      await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)
       return
     }
 
@@ -365,7 +365,7 @@ const loginThroughUi = async (
           await loginWithRetry(page, apiBaseUrl, loginEmail, legacyLoginId, password)
           await page.goto("/admin")
           await expect(page).toHaveURL(/\/admin(\/|$)/, { timeout: liveUiRedirectTimeoutMs })
-          await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs)
+          await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)
           return
         }
 
@@ -377,14 +377,14 @@ const loginThroughUi = async (
       }
 
       if (adminUrlPattern.test(page.url())) {
-        await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs)
+        await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)
         return
       }
       if (await tryEnterAdminRoute(page, liveUiRedirectTimeoutMs)) return
     }
 
     if (outcome.kind === "admin-url") {
-      await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs)
+      await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)
       return
     }
 

--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -4,6 +4,7 @@ import {
   adminLegacyLoginId,
   adminPassword,
   buildLoginPayloadCandidates,
+  completeLegalReconsentIfRequired,
   hasAuthCookie,
   isInvalidLoginRequestBody,
   isNavigationInterruptedError,
@@ -48,9 +49,11 @@ const tryEnterAdminRoute = async (page: Page, timeoutMs: number) => {
     }
 
     if (adminUrlPattern.test(page.url())) return true
+    if (await completeLegalReconsentIfRequired(page, "/admin", timeoutMs)) return true
 
     try {
       await page.waitForURL(adminUrlPattern, { timeout: perTryTimeout })
+      if (await completeLegalReconsentIfRequired(page, "/admin", timeoutMs)) return true
       return true
     } catch {
       if (attempt < tries) {
@@ -451,6 +454,7 @@ const expectLiveAdminRoute = async (
       continue
     }
 
+    await completeLegalReconsentIfRequired(page, path)
     await expect(page, `${label} route url`).toHaveURL(routePattern, { timeout: 20_000 })
     await expect(page.getByRole("heading", { name: headingPattern }), `${label} heading`).toBeVisible()
     return

--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -325,7 +325,7 @@ const loginThroughUi = async (
       await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)
       return
     }
-    if (await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)) return
+    if (await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, quickReconsentProbeTimeoutMs)) return
 
     await expect(page.getByRole("heading", { name: "로그인" })).toBeVisible()
     await page.getByLabel("이메일").fill(loginEmail)

--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -325,6 +325,7 @@ const loginThroughUi = async (
       await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)
       return
     }
+    if (await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)) return
 
     await expect(page.getByRole("heading", { name: "로그인" })).toBeVisible()
     await page.getByLabel("이메일").fill(loginEmail)

--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -365,8 +365,8 @@ const loginThroughUi = async (
         if (isInvalidLoginRequestBody(status, bodyPreview)) {
           await loginWithRetry(page, apiBaseUrl, loginEmail, legacyLoginId, password)
           await page.goto("/admin")
-          await expect(page).toHaveURL(/\/admin(\/|$)/, { timeout: liveUiRedirectTimeoutMs })
           await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)
+          await expect(page).toHaveURL(/\/admin(\/|$)/, { timeout: liveUiRedirectTimeoutMs })
           return
         }
 

--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -49,12 +49,12 @@ const tryEnterAdminRoute = async (page: Page, timeoutMs: number) => {
       if (!isNavigationInterruptedError(error)) throw error
     }
 
-    if (await completeLegalReconsentIfRequired(page, "/admin", timeoutMs, timeoutMs)) return true
+    if (await completeLegalReconsentIfRequired(page, "/admin", timeoutMs, quickReconsentProbeTimeoutMs)) return true
     if (adminUrlPattern.test(page.url())) return true
 
     try {
       await page.waitForURL(adminUrlPattern, { timeout: perTryTimeout })
-      if (await completeLegalReconsentIfRequired(page, "/admin", timeoutMs, timeoutMs)) return true
+      if (await completeLegalReconsentIfRequired(page, "/admin", timeoutMs, quickReconsentProbeTimeoutMs)) return true
       return true
     } catch {
       if (attempt < tries) {
@@ -322,7 +322,7 @@ const loginThroughUi = async (
   for (let attempt = 1; attempt <= liveLoginAttempts; attempt += 1) {
     const route = await gotoLoginForAdmin(page, liveUiRedirectTimeoutMs)
     if (route === "admin") {
-      await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)
+      await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, quickReconsentProbeTimeoutMs)
       return
     }
     if (await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, quickReconsentProbeTimeoutMs)) return
@@ -365,7 +365,7 @@ const loginThroughUi = async (
         if (isInvalidLoginRequestBody(status, bodyPreview)) {
           await loginWithRetry(page, apiBaseUrl, loginEmail, legacyLoginId, password)
           await page.goto("/admin")
-          await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)
+          await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, quickReconsentProbeTimeoutMs)
           await expect(page).toHaveURL(/\/admin(\/|$)/, { timeout: liveUiRedirectTimeoutMs })
           return
         }
@@ -378,14 +378,14 @@ const loginThroughUi = async (
       }
 
       if (adminUrlPattern.test(page.url())) {
-        await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)
+        await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, quickReconsentProbeTimeoutMs)
         return
       }
       if (await tryEnterAdminRoute(page, liveUiRedirectTimeoutMs)) return
     }
 
     if (outcome.kind === "admin-url") {
-      await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, liveUiRedirectTimeoutMs)
+      await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs, quickReconsentProbeTimeoutMs)
       return
     }
 

--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -48,8 +48,8 @@ const tryEnterAdminRoute = async (page: Page, timeoutMs: number) => {
       if (!isNavigationInterruptedError(error)) throw error
     }
 
-    if (adminUrlPattern.test(page.url())) return true
     if (await completeLegalReconsentIfRequired(page, "/admin", timeoutMs)) return true
+    if (adminUrlPattern.test(page.url())) return true
 
     try {
       await page.waitForURL(adminUrlPattern, { timeout: perTryTimeout })
@@ -320,7 +320,10 @@ const loginThroughUi = async (
 
   for (let attempt = 1; attempt <= liveLoginAttempts; attempt += 1) {
     const route = await gotoLoginForAdmin(page, liveUiRedirectTimeoutMs)
-    if (route === "admin") return
+    if (route === "admin") {
+      await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs)
+      return
+    }
 
     await expect(page.getByRole("heading", { name: "로그인" })).toBeVisible()
     await page.getByLabel("이메일").fill(loginEmail)
@@ -361,6 +364,7 @@ const loginThroughUi = async (
           await loginWithRetry(page, apiBaseUrl, loginEmail, legacyLoginId, password)
           await page.goto("/admin")
           await expect(page).toHaveURL(/\/admin(\/|$)/, { timeout: liveUiRedirectTimeoutMs })
+          await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs)
           return
         }
 
@@ -371,11 +375,17 @@ const loginThroughUi = async (
         throw new Error(`UI login request failed. ${lastFailure}`)
       }
 
-      if (adminUrlPattern.test(page.url())) return
+      if (adminUrlPattern.test(page.url())) {
+        await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs)
+        return
+      }
       if (await tryEnterAdminRoute(page, liveUiRedirectTimeoutMs)) return
     }
 
-    if (outcome.kind === "admin-url") return
+    if (outcome.kind === "admin-url") {
+      await completeLegalReconsentIfRequired(page, "/admin", liveUiRedirectTimeoutMs)
+      return
+    }
 
     // 성공 쿠키가 있는데 리다이렉트가 지연되는 경우 /admin 재진입으로 판정한다.
     // 단, 쿠키가 만료/무효일 수 있으므로 즉시 실패시키지 않고 API 로그인 복구 경로를 탄다.

--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -14,6 +14,7 @@ import {
   liveLoginTimeoutMs,
   liveRetryBaseDelayMs,
   liveUiRedirectTimeoutMs,
+  quickReconsentProbeTimeoutMs,
   resolveApiBaseUrl,
   sleep,
   waitForApiReachability,
@@ -464,7 +465,7 @@ const expectLiveAdminRoute = async (
       continue
     }
 
-    await completeLegalReconsentIfRequired(page, path)
+    await completeLegalReconsentIfRequired(page, path, liveUiRedirectTimeoutMs, quickReconsentProbeTimeoutMs)
     await expect(page, `${label} route url`).toHaveURL(routePattern, { timeout: 20_000 })
     await expect(page.getByRole("heading", { name: headingPattern }), `${label} heading`).toBeVisible()
     return


### PR DESCRIPTION
## 관련 이슈

close #1039

## 작업 배경

- PR #1038 merge 후 Deploy to Home Server run `27976978391`에서 `blueGreenDeploy`는 성공했지만 `Frontend Live E2E Verification`이 실패했습니다.
- 실패 화면은 `/settings/privacy?reconsent=required` 재동의 화면이었고, live e2e가 `/editor/new` 제목 입력을 기다리다 timeout 됐습니다.
- 운영 계정을 최신 동의자로 수동 backfill하지 않고, live e2e가 policy bump 후 재동의 gate를 처리하게 합니다.

## 작업 내용

- `front/e2e/helpers/liveAuth.ts`에 재동의 gate URL 감지와 필수 체크/제출 helper를 추가했습니다.
- `front/e2e/live.spec.ts` admin 진입과 `front/e2e/editor-live-visual.spec.ts` editor 진입에서 해당 helper를 재사용합니다.
- `front/e2e/live-auth-helper.spec.ts`에 재동의 gate URL 감지 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright test e2e/live-auth-helper.spec.ts --project=chromium`: 처음 RED에서 `isLegalReconsentGateUrl is not a function`으로 실패 확인, 구현 후 3 passed / exit 0
  - `yarn --cwd front playwright:preflight`: exit 0
  - `yarn --cwd front build`: exit 0
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 기존 실패 | GitHub Actions CD | Deploy run `27976978391`의 live e2e 실패 로그와 artifact 확인 | `front-live-e2e-playwright-report`, screenshot `test-failed-1.png` | `/settings/privacy?reconsent=required` 화면에서 `/editor/new` assertion 실패 확인 |
| helper 회귀 테스트 | local macOS | `yarn --cwd front playwright test e2e/live-auth-helper.spec.ts --project=chromium` | command output | 3 passed / exit 0 |
| frontend preflight | local macOS | `yarn --cwd front playwright:preflight` | command output | exit 0 |
| frontend build | local macOS | `yarn --cwd front build` | command output | exit 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `completeLegalReconsentIfRequired`가 제품 gate를 완화하지 않고 live e2e에서만 재동의 화면을 완료하는지 확인해 주세요.

## 리스크

- live admin 계정이 이미 재동의를 완료한 경우 helper가 3초까지 gate 출현을 짧게 probe하므로 live e2e 시간이 소폭 늘 수 있습니다.
- 운영 DB 동의 기록을 수동 backfill하지 않으므로 실제 동의 증빙 정책은 유지됩니다.

## 체크리스트

- [x] CI 결과를 확인했다. (로컬 검증 완료, PR CI 대기)
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (기존 CD 실패 `27976978391`, 이 PR merge 후 재확인 예정)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 에디터 및 관리자 페이지 접근 시 법적 재동의 프로세스에 대한 테스트 범위 확대 및 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->