### PR TITLE
[Fix] Gemini 태그 추천 외부 처리 guard 추가

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationService.kt
@@ -117,7 +117,6 @@ class PostTagRecommendationService(
         val normalizedTitle = title.trim()
         val normalizedContent = content.trim()
         val normalizedExistingTags = sanitizeTags(existingTags, normalizedMaxTags * 2)
-        val fallbackTags = buildRuleTags(normalizedTitle, normalizedContent, normalizedExistingTags, normalizedMaxTags)
         val traceId = newTraceId()
         val cacheKey = recommendationCacheKey(normalizedTitle, normalizedContent, normalizedExistingTags, normalizedMaxTags)
         val now = System.currentTimeMillis()
@@ -135,9 +134,22 @@ class PostTagRecommendationService(
             return traced
         }
 
+        if (hasSensitiveExternalProcessingInput(normalizedTitle, normalizedContent, normalizedExistingTags)) {
+            return done(
+                fallbackAndCache(
+                    cacheKey = cacheKey,
+                    tags = emptyList(),
+                    reason = "pii-blocked",
+                    nowMillis = now,
+                ),
+            )
+        }
+
         readCache(cacheKey, now)?.let {
             return done(it)
         }
+
+        val fallbackTags = buildRuleTags(normalizedTitle, normalizedContent, normalizedExistingTags, normalizedMaxTags)
 
         if (!aiTagEnabled) {
             return done(
@@ -157,17 +169,6 @@ class PostTagRecommendationService(
                     cacheKey = cacheKey,
                     tags = fallbackTags,
                     reason = "api-key-missing",
-                    nowMillis = now,
-                ),
-            )
-        }
-
-        if (hasSensitiveExternalProcessingInput(normalizedTitle, normalizedContent, normalizedExistingTags)) {
-            return done(
-                fallbackAndCache(
-                    cacheKey = cacheKey,
-                    tags = emptyList(),
-                    reason = "pii-blocked",
                     nowMillis = now,
                 ),
             )

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationService.kt
@@ -783,7 +783,10 @@ class PostTagRecommendationService(
             )
         private val KOREAN_RRN_LIKE_REGEX = Regex("(?<!\\d)\\d{6}[-\\s]?\\d{7}(?!\\d)")
         private val OAUTH_CODE_REGEX =
-            Regex("\\b(?:oauth[_-]?code|authorization[_-]?code|code)\\b\\s*[:=]\\s*[^\"'\\s,)&}]{8,}", RegexOption.IGNORE_CASE)
+            Regex(
+                """["']?\b(?:oauth[_-]?code|authorization[_-]?code|code)\b["']?\s*[:=]\s*(?:"[^"]{8,}"|'[^']{8,}'|[^"'\s,)&}]{8,})""",
+                RegexOption.IGNORE_CASE,
+            )
         private val SENSITIVE_EXTERNAL_PROCESSING_REGEXES =
             listOf(
                 EMAIL_REGEX,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationService.kt
@@ -166,7 +166,7 @@ class PostTagRecommendationService(
             return done(
                 fallbackAndCache(
                     cacheKey = cacheKey,
-                    tags = fallbackTags,
+                    tags = emptyList(),
                     reason = "pii-blocked",
                     nowMillis = now,
                 ),

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationService.kt
@@ -162,6 +162,17 @@ class PostTagRecommendationService(
             )
         }
 
+        if (hasSensitiveExternalProcessingInput(normalizedTitle, normalizedContent, normalizedExistingTags)) {
+            return done(
+                fallbackAndCache(
+                    cacheKey = cacheKey,
+                    tags = fallbackTags,
+                    reason = "pii-blocked",
+                    nowMillis = now,
+                ),
+            )
+        }
+
         if (!allowRequest(now)) {
             return done(
                 fallbackAndCache(
@@ -559,6 +570,20 @@ class PostTagRecommendationService(
             .replace(PHONE_REGEX, "[redacted-phone]")
     }
 
+    private fun hasSensitiveExternalProcessingInput(
+        title: String,
+        content: String,
+        existingTags: List<String>,
+    ): Boolean {
+        val value =
+            buildString {
+                appendLine(title)
+                appendLine(content)
+                append(existingTags.joinToString("\n"))
+            }
+        return SENSITIVE_EXTERNAL_PROCESSING_REGEXES.any { it.containsMatchIn(value) }
+    }
+
     private fun stripCodeFence(raw: String): String {
         val trimmed = raw.trim()
         if (!trimmed.startsWith("```")) return trimmed
@@ -755,6 +780,18 @@ class PostTagRecommendationService(
             Regex(
                 """["']?\b(api[_-]?key|token|password|secret|authorization)\b["']?\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,)&}]+)""",
                 RegexOption.IGNORE_CASE,
+            )
+        private val KOREAN_RRN_LIKE_REGEX = Regex("(?<!\\d)\\d{6}[-\\s]?\\d{7}(?!\\d)")
+        private val OAUTH_CODE_REGEX =
+            Regex("\\b(?:oauth[_-]?code|authorization[_-]?code|code)\\b\\s*[:=]\\s*[^\"'\\s,)&}]{8,}", RegexOption.IGNORE_CASE)
+        private val SENSITIVE_EXTERNAL_PROCESSING_REGEXES =
+            listOf(
+                EMAIL_REGEX,
+                PHONE_REGEX,
+                AUTHORIZATION_SECRET_REGEX,
+                SECRET_ASSIGNMENT_REGEX,
+                KOREAN_RRN_LIKE_REGEX,
+                OAUTH_CODE_REGEX,
             )
         private val FENCED_CODE_REGEX = Regex("```[\\s\\S]*?```")
         private val MARKDOWN_IMAGE_REGEX = Regex("!\\[[^\\]]*\\]\\(([^)\\s]+)(?:\\s+\"[^\"]*\")?\\)")

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationService.kt
@@ -784,7 +784,7 @@ class PostTagRecommendationService(
         private val KOREAN_RRN_LIKE_REGEX = Regex("(?<!\\d)\\d{6}[-\\s]?\\d{7}(?!\\d)")
         private val OAUTH_CODE_REGEX =
             Regex(
-                """["']?\b(?:oauth[_-]?code|authorization[_-]?code|code)\b["']?\s*[:=]\s*(?:"[^"]{8,}"|'[^']{8,}'|[^"'\s,)&}]{8,})""",
+                """["']?\b(?:oauth[_-]?code|authorization[_-]?code|auth[_-]?code)\b["']?\s*[:=]\s*(?:"[^"]{8,}"|'[^']{8,}'|[^"'\s,)&}]{8,})|\b(?:oauth|authorization|auth|callback)\b[\s\S]{0,80}["']?\bcode\b["']?\s*[:=]\s*(?:"[^"]{8,}"|'[^']{8,}'|[^"'\s,)&}]{8,})""",
                 RegexOption.IGNORE_CASE,
             )
         private val SENSITIVE_EXTERNAL_PROCESSING_REGEXES =

--- a/back/src/main/kotlin/com/back/global/app/config/ProdConfigGuard.kt
+++ b/back/src/main/kotlin/com/back/global/app/config/ProdConfigGuard.kt
@@ -16,6 +16,18 @@ class ProdConfigGuard(
     private val frontUrl: String,
     @param:Value("\${custom.site.backUrl:}")
     private val backUrl: String,
+    @param:Value("\${custom.ai.tag.enabled:false}")
+    private val aiTagEnabled: Boolean,
+    @param:Value("\${custom.ai.tag.policy.dpaConfirmed:false}")
+    private val aiTagDpaConfirmed: Boolean,
+    @param:Value("\${custom.ai.tag.policy.regionConfirmed:false}")
+    private val aiTagRegionConfirmed: Boolean,
+    @param:Value("\${custom.ai.tag.policy.retentionConfirmed:false}")
+    private val aiTagRetentionConfirmed: Boolean,
+    @param:Value("\${custom.ai.tag.policy.trainingOptOutConfirmed:false}")
+    private val aiTagTrainingOptOutConfirmed: Boolean,
+    @param:Value("\${custom.ai.tag.policy.processorRegistryConfirmed:false}")
+    private val aiTagProcessorRegistryConfirmed: Boolean,
     private val adminProperties: AdminProperties,
 ) : ApplicationRunner {
     override fun run(args: ApplicationArguments) {
@@ -40,5 +52,15 @@ class ProdConfigGuard(
         require(backUrl.startsWith("https://")) {
             "custom.site.backUrl must use https in prod profile."
         }
+        require(!aiTagEnabled || aiTagPolicyConfirmed()) {
+            "custom.ai.tag.enabled requires confirmed DPA, region, retention, training opt-out, and processor registry in prod profile."
+        }
     }
+
+    private fun aiTagPolicyConfirmed(): Boolean =
+        aiTagDpaConfirmed &&
+            aiTagRegionConfirmed &&
+            aiTagRetentionConfirmed &&
+            aiTagTrainingOptOutConfirmed &&
+            aiTagProcessorRegistryConfirmed
 }

--- a/back/src/main/resources/application.yaml
+++ b/back/src/main/resources/application.yaml
@@ -321,6 +321,12 @@ custom:
         apiKey: "${CUSTOM__AI__TAG__GEMINI__API_KEY:${CUSTOM__AI__SUMMARY__GEMINI__API_KEY:}}"
         model: "${CUSTOM__AI__TAG__GEMINI__MODEL:${CUSTOM__AI__SUMMARY__GEMINI__MODEL:gemini-2.5-flash}}"
         baseUrl: "${CUSTOM__AI__TAG__GEMINI__BASE_URL:${CUSTOM__AI__SUMMARY__GEMINI__BASE_URL:https://generativelanguage.googleapis.com/v1beta}}"
+      policy:
+        dpaConfirmed: ${CUSTOM__AI__TAG__POLICY__DPA_CONFIRMED:false}
+        regionConfirmed: ${CUSTOM__AI__TAG__POLICY__REGION_CONFIRMED:false}
+        retentionConfirmed: ${CUSTOM__AI__TAG__POLICY__RETENTION_CONFIRMED:false}
+        trainingOptOutConfirmed: ${CUSTOM__AI__TAG__POLICY__TRAINING_OPT_OUT_CONFIRMED:false}
+        processorRegistryConfirmed: ${CUSTOM__AI__TAG__POLICY__PROCESSOR_REGISTRY_CONFIRMED:false}
   storage:
     enabled: ${CUSTOM_STORAGE_ENABLED:false}
     endpoint: ${CUSTOM_STORAGE_ENDPOINT:http://localhost:9000}

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationServiceResilienceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationServiceResilienceTest.kt
@@ -81,8 +81,8 @@ class PostTagRecommendationServiceResilienceTest {
     }
 
     @Test
-    @DisplayName("규칙 fallback 태그 추천은 secret-like 토큰을 반환하거나 캐시하지 않는다")
-    fun `rule fallback recommendation redacts secret-like tokens before returning and caching`() {
+    @DisplayName("비활성 AI도 secret-like 토큰을 태그나 캐시에 남기지 않는다")
+    fun `disabled ai fallback does not return or cache secret-like tokens`() {
         val redisPort = capturingRedisPort()
         val service = createService(aiEnabled = false, redisPort = redisPort)
 
@@ -105,7 +105,8 @@ class PostTagRecommendationServiceResilienceTest {
         val cachedPayload = redisPort.writes.flatMap { listOf(it.key, it.value) }.joinToString("\n")
 
         assertThat(result.provider).isEqualTo("rule")
-        assertThat(result.reason).isEqualTo("ai-disabled")
+        assertThat(result.reason).isEqualTo("pii-blocked")
+        assertThat(result.tags).isEmpty()
         assertThat(returnedTags)
             .doesNotContain("super-secret-title-token")
             .doesNotContain("frontmatter-secret-token")
@@ -208,40 +209,27 @@ class PostTagRecommendationServiceResilienceTest {
     }
 
     @Test
-    @DisplayName("PII 차단 fallback은 새 민감 패턴을 태그나 캐시에 남기지 않는다")
-    fun `pii blocked fallback does not return or cache newly detected sensitive tokens`() {
+    @DisplayName("비활성 AI도 새 민감 패턴을 태그나 캐시에 남기지 않는다")
+    fun `disabled ai fallback does not return or cache newly detected sensitive tokens`() {
         val redisPort = capturingRedisPort()
-        val capturedBodies = mutableListOf<String>()
-        val server = startGeminiServer(capturedBodies)
-        val service =
-            createService(
-                aiEnabled = true,
-                redisPort = redisPort,
-                geminiApiKey = "test-key",
-                geminiBaseUrl = "http://127.0.0.1:${server.address.port}/v1beta",
+        val service = createService(aiEnabled = false, redisPort = redisPort)
+
+        val result =
+            service.recommend(
+                title = "OAuth callback 900101-1234567",
+                content = """응답 예시는 {"code":"quoted-oauth-code-123456"} 형태입니다.""",
+                existingTags = emptyList(),
+                maxTags = 5,
             )
 
-        try {
-            val result =
-                service.recommend(
-                    title = "OAuth callback 900101-1234567",
-                    content = """응답 예시는 {"code":"quoted-oauth-code-123456"} 형태입니다.""",
-                    existingTags = emptyList(),
-                    maxTags = 5,
-                )
+        val cachedPayload = redisPort.writes.flatMap { listOf(it.key, it.value) }.joinToString("\n")
 
-            val cachedPayload = redisPort.writes.flatMap { listOf(it.key, it.value) }.joinToString("\n")
-
-            assertThat(result.provider).isEqualTo("rule")
-            assertThat(result.reason).isEqualTo("pii-blocked")
-            assertThat(result.tags).isEmpty()
-            assertThat(capturedBodies).isEmpty()
-            assertThat(cachedPayload)
-                .doesNotContain("900101-1234567")
-                .doesNotContain("quoted-oauth-code-123456")
-        } finally {
-            server.stop(0)
-        }
+        assertThat(result.provider).isEqualTo("rule")
+        assertThat(result.reason).isEqualTo("pii-blocked")
+        assertThat(result.tags).isEmpty()
+        assertThat(cachedPayload)
+            .doesNotContain("900101-1234567")
+            .doesNotContain("quoted-oauth-code-123456")
     }
 
     @Test

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationServiceResilienceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationServiceResilienceTest.kt
@@ -178,6 +178,36 @@ class PostTagRecommendationServiceResilienceTest {
     }
 
     @Test
+    @DisplayName("Gemini 태그 추천은 quoted OAuth code도 외부 전송하지 않는다")
+    fun `gemini tag recommendation blocks quoted oauth code`() {
+        val capturedBodies = mutableListOf<String>()
+        val server = startGeminiServer(capturedBodies)
+        val service =
+            createService(
+                aiEnabled = true,
+                redisPort = fakeRedisPort(),
+                geminiApiKey = "test-key",
+                geminiBaseUrl = "http://127.0.0.1:${server.address.port}/v1beta",
+            )
+
+        try {
+            val result =
+                service.recommend(
+                    title = "OAuth callback debugging",
+                    content = """응답 예시는 {"code":"quoted-oauth-code-123456"} 형태입니다.""",
+                    existingTags = emptyList(),
+                    maxTags = 5,
+                )
+
+            assertThat(result.provider).isEqualTo("rule")
+            assertThat(result.reason).isEqualTo("pii-blocked")
+            assertThat(capturedBodies).isEmpty()
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
     @DisplayName("Gemini 태그 추천은 민감정보 없는 명시 요청만 외부 호출한다")
     fun `gemini tag recommendation allows explicit safe request`() {
         val redisPort = capturingRedisPort()

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationServiceResilienceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationServiceResilienceTest.kt
@@ -131,8 +131,8 @@ class PostTagRecommendationServiceResilienceTest {
     }
 
     @Test
-    @DisplayName("Gemini 요청과 캐시는 원문 개인정보와 secret을 저장하지 않는다")
-    fun `gemini request and cache redact raw personal data and secrets`() {
+    @DisplayName("Gemini 태그 추천은 개인정보와 secret-like 입력을 외부 전송하지 않는다")
+    fun `gemini tag recommendation blocks external call for personal data and secrets`() {
         val redisPort = capturingRedisPort()
         val capturedBodies = mutableListOf<String>()
         val server = startGeminiServer(capturedBodies)
@@ -160,21 +160,9 @@ class PostTagRecommendationServiceResilienceTest {
                     maxTags = 5,
                 )
 
-            assertThat(result.provider).isEqualTo("gemini")
-            assertThat(capturedBodies).hasSize(1)
-            assertThat(capturedBodies.single())
-                .doesNotContain("secret@example.com")
-                .doesNotContain("010-1234-5678")
-                .doesNotContain("super-secret-token")
-                .doesNotContain("multi word secret")
-                .doesNotContain("quoted token value")
-                .doesNotContain("json-secret-token")
-                .doesNotContain("json-bearer-token")
-                .doesNotContain("bearer-secret-token")
-                .contains("[redacted-email]")
-                .contains("[redacted-phone]")
-                .contains("apiKey=[redacted-secret]")
-                .contains("Authorization=[redacted-secret]")
+            assertThat(result.provider).isEqualTo("rule")
+            assertThat(result.reason).isEqualTo("pii-blocked")
+            assertThat(capturedBodies).isEmpty()
             assertThat(redisPort.writes.flatMap { listOf(it.key, it.value) }.joinToString("\n"))
                 .doesNotContain("secret@example.com")
                 .doesNotContain("010-1234-5678")
@@ -184,6 +172,38 @@ class PostTagRecommendationServiceResilienceTest {
                 .doesNotContain("json-secret-token")
                 .doesNotContain("json-bearer-token")
                 .doesNotContain("bearer-secret-token")
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    @DisplayName("Gemini 태그 추천은 민감정보 없는 명시 요청만 외부 호출한다")
+    fun `gemini tag recommendation allows explicit safe request`() {
+        val redisPort = capturingRedisPort()
+        val capturedBodies = mutableListOf<String>()
+        val server = startGeminiServer(capturedBodies)
+        val service =
+            createService(
+                aiEnabled = true,
+                redisPort = redisPort,
+                geminiApiKey = "test-key",
+                geminiBaseUrl = "http://127.0.0.1:${server.address.port}/v1beta",
+            )
+
+        try {
+            val result =
+                service.recommend(
+                    title = "Kotlin coroutine scheduler",
+                    content = "백엔드 작업 큐와 coroutine dispatcher 튜닝 내용을 정리한다.",
+                    existingTags = listOf("Kotlin"),
+                    maxTags = 5,
+                )
+
+            assertThat(result.provider).isEqualTo("gemini")
+            assertThat(capturedBodies).hasSize(1)
+            assertThat(redisPort.writes.flatMap { listOf(it.key, it.value) }.joinToString("\n"))
+                .doesNotContain("백엔드 작업 큐와 coroutine dispatcher")
         } finally {
             server.stop(0)
         }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationServiceResilienceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationServiceResilienceTest.kt
@@ -208,6 +208,35 @@ class PostTagRecommendationServiceResilienceTest {
     }
 
     @Test
+    @DisplayName("Gemini 태그 추천은 일반 API code 필드를 민감 OAuth code로 오탐하지 않는다")
+    fun `gemini tag recommendation allows ordinary api code field`() {
+        val capturedBodies = mutableListOf<String>()
+        val server = startGeminiServer(capturedBodies)
+        val service =
+            createService(
+                aiEnabled = true,
+                redisPort = fakeRedisPort(),
+                geminiApiKey = "test-key",
+                geminiBaseUrl = "http://127.0.0.1:${server.address.port}/v1beta",
+            )
+
+        try {
+            val result =
+                service.recommend(
+                    title = "API error response",
+                    content = """응답 예시는 {"code":"USER_NOT_FOUND"} 형태입니다.""",
+                    existingTags = emptyList(),
+                    maxTags = 5,
+                )
+
+            assertThat(result.provider).isEqualTo("gemini")
+            assertThat(capturedBodies).hasSize(1)
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
     @DisplayName("Gemini 태그 추천은 민감정보 없는 명시 요청만 외부 호출한다")
     fun `gemini tag recommendation allows explicit safe request`() {
         val redisPort = capturingRedisPort()

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationServiceResilienceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostTagRecommendationServiceResilienceTest.kt
@@ -208,6 +208,43 @@ class PostTagRecommendationServiceResilienceTest {
     }
 
     @Test
+    @DisplayName("PII 차단 fallback은 새 민감 패턴을 태그나 캐시에 남기지 않는다")
+    fun `pii blocked fallback does not return or cache newly detected sensitive tokens`() {
+        val redisPort = capturingRedisPort()
+        val capturedBodies = mutableListOf<String>()
+        val server = startGeminiServer(capturedBodies)
+        val service =
+            createService(
+                aiEnabled = true,
+                redisPort = redisPort,
+                geminiApiKey = "test-key",
+                geminiBaseUrl = "http://127.0.0.1:${server.address.port}/v1beta",
+            )
+
+        try {
+            val result =
+                service.recommend(
+                    title = "OAuth callback 900101-1234567",
+                    content = """응답 예시는 {"code":"quoted-oauth-code-123456"} 형태입니다.""",
+                    existingTags = emptyList(),
+                    maxTags = 5,
+                )
+
+            val cachedPayload = redisPort.writes.flatMap { listOf(it.key, it.value) }.joinToString("\n")
+
+            assertThat(result.provider).isEqualTo("rule")
+            assertThat(result.reason).isEqualTo("pii-blocked")
+            assertThat(result.tags).isEmpty()
+            assertThat(capturedBodies).isEmpty()
+            assertThat(cachedPayload)
+                .doesNotContain("900101-1234567")
+                .doesNotContain("quoted-oauth-code-123456")
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
     @DisplayName("Gemini 태그 추천은 일반 API code 필드를 민감 OAuth code로 오탐하지 않는다")
     fun `gemini tag recommendation allows ordinary api code field`() {
         val capturedBodies = mutableListOf<String>()

--- a/back/src/test/kotlin/com/back/global/app/config/ProdConfigGuardTest.kt
+++ b/back/src/test/kotlin/com/back/global/app/config/ProdConfigGuardTest.kt
@@ -1,0 +1,63 @@
+package com.back.global.app.config
+
+import com.back.global.app.AdminProperties
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.boot.DefaultApplicationArguments
+
+@DisplayName("ProdConfigGuard 테스트")
+class ProdConfigGuardTest {
+    @Test
+    @DisplayName("prod에서 AI 태그 추천은 정책 확인 값 없이 활성화할 수 없다")
+    fun `ai tag recommendation requires policy confirmations in prod`() {
+        val guard = createGuard(aiTagEnabled = true)
+
+        assertThatThrownBy { guard.run(DefaultApplicationArguments()) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("custom.ai.tag.enabled requires confirmed DPA")
+    }
+
+    @Test
+    @DisplayName("prod에서 AI 태그 추천 정책 확인 값이 모두 있으면 부팅을 허용한다")
+    fun `ai tag recommendation allows prod boot when policy confirmations are present`() {
+        val guard =
+            createGuard(
+                aiTagEnabled = true,
+                aiTagDpaConfirmed = true,
+                aiTagRegionConfirmed = true,
+                aiTagRetentionConfirmed = true,
+                aiTagTrainingOptOutConfirmed = true,
+                aiTagProcessorRegistryConfirmed = true,
+            )
+
+        assertThatCode { guard.run(DefaultApplicationArguments()) }.doesNotThrowAnyException()
+    }
+
+    private fun createGuard(
+        aiTagEnabled: Boolean,
+        aiTagDpaConfirmed: Boolean = false,
+        aiTagRegionConfirmed: Boolean = false,
+        aiTagRetentionConfirmed: Boolean = false,
+        aiTagTrainingOptOutConfirmed: Boolean = false,
+        aiTagProcessorRegistryConfirmed: Boolean = false,
+    ): ProdConfigGuard =
+        ProdConfigGuard(
+            cookieDomain = "blog.oa.gg",
+            frontUrl = "https://www.blog.oa.gg",
+            backUrl = "https://api.blog.oa.gg",
+            aiTagEnabled = aiTagEnabled,
+            aiTagDpaConfirmed = aiTagDpaConfirmed,
+            aiTagRegionConfirmed = aiTagRegionConfirmed,
+            aiTagRetentionConfirmed = aiTagRetentionConfirmed,
+            aiTagTrainingOptOutConfirmed = aiTagTrainingOptOutConfirmed,
+            aiTagProcessorRegistryConfirmed = aiTagProcessorRegistryConfirmed,
+            adminProperties =
+                AdminProperties(
+                    username = "admin",
+                    email = "admin@example.com",
+                    password = "secret-password",
+                ),
+        )
+}

--- a/legal/data-map/processing-activities.yaml
+++ b/legal/data-map/processing-activities.yaml
@@ -471,7 +471,7 @@ activities:
     policySectionId: privacy-processor-ai
     enabledByEnv: custom.ai.tag.enabled defaults false via CUSTOM__AI__TAG__ENABLED; custom.ai.tag.gemini.*; legacy fallback CUSTOM__AI__SUMMARY__GEMINI__*
     reviewRequired:
-      - Production default-off, PII scanner, and DPA checks are tracked by issue1003.
+      - Production default-off, PII block, and DPA/region/retention/training opt-out startup checks are enforced by issue1003.
 
   - id: backup_and_restore
     name: PostgreSQL, MinIO, deploy rollback backup

--- a/legal/vendors/processors.yaml
+++ b/legal/vendors/processors.yaml
@@ -208,9 +208,10 @@ processors:
     securityControls:
       - serverSideApiKey
       - HTTPS
-      - explicitAdminActionRequiredFutureWork
+      - explicitAdminActionRequired
+      - prodActivationPolicyGuard
     reviewRequired:
-      - Production default-off, PII scanner, and DPA guard are tracked by issue1003.
+      - Production default-off, PII block, and DPA/region/retention/training opt-out startup checks are enforced by issue1003.
 
   - id: grafana_loki_monitoring
     name: Grafana and Loki monitoring stack


### PR DESCRIPTION
## 관련 이슈

close #1003

## 작업 배경

- Gemini 태그 추천은 기본 비활성/secret redaction 일부는 있었지만, PII 입력을 redaction 후 외부 AI로 보낼 수 있고 prod에서 활성화 전 계약 확인 guard가 부족했습니다.

## 작업 내용

- email, phone, 주민등록번호 유사 패턴, OAuth code, API key/token/password/authorization 입력은 Gemini 호출 없이 `pii-blocked` rule fallback으로 처리합니다.
- `prod`에서 `custom.ai.tag.enabled=true`일 때 DPA, region, retention, training opt-out, processor registry 확인 값이 모두 없으면 boot를 실패시킵니다.
- application.yaml 기본값과 legal data map / processor registry 문구를 새 guard 상태에 맞췄습니다.

## 검증

- 실행한 명령과 결과:
- `back/gradlew -p back ktlintCheck test --tests '*PostTagRecommendationServiceResilienceTest' --tests '*ProdConfigGuardTest' --rerun-tasks`: exit 0
- `back/gradlew -p back ciFastCheck --rerun-tasks`: exit 0
- `back/gradlew -p back ciFastCheck --rerun-tasks`: exit 0, same condition 2회 연속 통과
- GitHub Actions `backend-ci / backend-ci`: pass, https://github.com/AquilaXk/aquila-blog/actions/runs/27987219469/job/82831445984
- GitHub Actions `frontend-ci / frontend-ci`: pass, https://github.com/AquilaXk/aquila-blog/actions/runs/27987219475/job/82831445910
- GitHub Actions `Security`: pass, https://github.com/AquilaXk/aquila-blog/actions/runs/27987219417
- Codex CLI fallback review: actionable 0건, https://github.com/AquilaXk/aquila-blog/pull/1041#pullrequestreview-4548453512
- Post-merge `CI`: success, https://github.com/AquilaXk/aquila-blog/actions/runs/27987629146
- Post-merge `Security`: success, https://github.com/AquilaXk/aquila-blog/actions/runs/27987628901
- Post-merge `Deploy to Home Server`: success, https://github.com/AquilaXk/aquila-blog/actions/runs/27988060749

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| PII/secret 입력 Gemini 차단 | local backend test | `PostTagRecommendationServiceResilienceTest` | focused test command output | `pii-blocked`, captured Gemini request empty |
| prod AI tag activation guard | local backend test | `ProdConfigGuardTest` | focused test command output | policy 확인 값 없으면 boot 실패, 모두 있으면 통과 |
| backend 회귀 | local backend | `ciFastCheck` 2회 | command output | exit 0 / exit 0 |
| PR CI | GitHub Actions | backend/frontend/security checks | workflow links in 검증 section | pass |
| 코드리뷰 fallback | GitHub PR review | CodeRabbit 미완료 후 Codex CLI review | PR review #4548453512 | actionable 0건 |
| main CI/CD | GitHub Actions | merge 후 CI/Security/Deploy 확인 | workflow links in 검증 section | success |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `PostTagRecommendationService.hasSensitiveExternalProcessingInput`, `ProdConfigGuard.aiTagPolicyConfirmed`
- CodeRabbit status는 pending/review-in-progress로 남았지만 실제 actionable review가 완료되지 않아 Codex CLI fallback을 실행했고, 이전 inline finding 4건은 모두 fix commit 답글과 함께 resolved 처리했습니다.

## 리스크

- PII/secret-like 패턴이 있는 글은 외부 AI 대신 rule fallback을 사용합니다. 상용 개인정보 보호 쪽으로 보수적인 동작입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.