### PR TITLE
[CI] 개인정보 drift gate 추가

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,6 +22,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  privacy-drift-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "20"
+
+      - name: Run privacy drift gate
+        run: node tools/privacy/ci-privacy-gate.mjs
+
   backend-dependency-check:
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/tools/privacy/ci-privacy-gate.mjs
+++ b/tools/privacy/ci-privacy-gate.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process"
+import path from "node:path"
+
+const repoRoot = path.resolve(import.meta.dirname, "../..")
+
+const checks = [
+  {
+    name: "legal policy schema/hash/version drift",
+    command: [process.execPath, "tools/legal/validate-legal-policies.mjs"],
+  },
+  {
+    name: "privacy data-map processor/retention drift",
+    command: [process.execPath, "tools/legal/validate-privacy-data-map.mjs"],
+  },
+  {
+    name: "legal validator failure fixtures",
+    command: [process.execPath, "--test", "tools/test/legal-policy-validator-fixtures.test.mjs"],
+  },
+]
+
+for (const check of checks) {
+  console.log(`[privacy-gate] ${check.name}`)
+  const result = spawnSync(check.command[0], check.command.slice(1), {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: "inherit",
+  })
+
+  if (result.error) {
+    console.error(`[privacy-gate] ${check.name} failed to start: ${result.error.message}`)
+    process.exit(1)
+  }
+  if (result.status !== 0) {
+    console.error(`[privacy-gate] ${check.name} failed`)
+    process.exit(result.status ?? 1)
+  }
+}
+
+console.log("[privacy-gate] ok")


### PR DESCRIPTION
## 관련 이슈

close #1006

## 작업 배경

- 개인정보 정책 validator와 data-map validator가 이미 있지만, PR에서 독립 privacy drift gate check로 보이지 않아 정책/hash/processor/retention drift를 한 번에 확인하기 어렵습니다.

## 작업 내용

- `tools/privacy/ci-privacy-gate.mjs`를 추가해 기존 legal policy validator, privacy data-map validator, validator failure fixture test를 순차 실행합니다.
- Security workflow에 `privacy-drift-gate` job을 추가해 pull_request/main push에서 같은 command를 실행합니다.

## 검증

- 실행한 명령과 결과:
- `node tools/privacy/ci-privacy-gate.mjs`: exit 0, policies 7개/data-map activities 13개/processors 13개/fixture test 2개 pass
- GitHub PR checks: `privacy-drift-gate`, `backend-ci`, `frontend-ci`, `backend-dependency-check`, `codeql (java-kotlin)`, `codeql (javascript-typescript)` pass
- Codex CLI fallback review: actionable comments 0, PR review https://github.com/AquilaXk/aquila-blog/pull/1042#pullrequestreview-4548647939

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| privacy drift gate 정상 경로 | local Node.js | `node tools/privacy/ci-privacy-gate.mjs` | command output | exit 0 |
| policy hash drift fixture | local Node.js test runner | gate 내부 `node --test tools/test/legal-policy-validator-fixtures.test.mjs` | command output | 2 pass |
| PR privacy drift gate | GitHub Actions | Security workflow `privacy-drift-gate` | https://github.com/AquilaXk/aquila-blog/actions/runs/27988986273/job/82837038393 | pass |
| PR security checks | GitHub Actions | backend dependency check + CodeQL | https://github.com/AquilaXk/aquila-blog/actions/runs/27988986273 | pass |
| PR 기본 CI | GitHub Actions | backend-ci + frontend-ci | PR checks | pass |
| 코드 리뷰 fallback | GitHub PR review | Codex CLI review, CodeRabbit rate limit 대체 | https://github.com/AquilaXk/aquila-blog/pull/1042#pullrequestreview-4548647939 | actionable 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/privacy/ci-privacy-gate.mjs`, `.github/workflows/security.yml`의 `privacy-drift-gate` job
- 새 validator를 만들지 않고 기존 검증을 재사용했습니다.

## 리스크

- Security workflow에 빠른 Node-only job이 하나 추가됩니다. 정책/데이터맵 drift가 있으면 PR에서 더 일찍 실패합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.