### PR TITLE
[CI] restore privacy gate 배포 env 주입 보강

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -445,6 +445,7 @@ jobs:
             printf 'HOME_AI_TAG_ENABLED=%q\n' "${HOME_AI_TAG_ENABLED:-false}"
             printf 'HOME_NEXT_PUBLIC_SIGNUP_ENABLED=%q\n' "${HOME_NEXT_PUBLIC_SIGNUP_ENABLED:-false}"
             printf 'HOME_NEXT_PUBLIC_RUM_SAMPLE_RATE=%q\n' "${HOME_NEXT_PUBLIC_RUM_SAMPLE_RATE:-0}"
+            printf 'HOME_RESTORE_PRIVACY_GATE_SCRIPT=%q\n' "${HOME_RESTORE_PRIVACY_GATE_SCRIPT:-/opt/aquila-blog/restore-privacy-gate.sh}"
           } > "${LOCAL_REMOTE_VARS_FILE}"
           chmod 600 "${LOCAL_REMOTE_VARS_FILE}"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -323,12 +323,14 @@ jobs:
           HOME_AI_TAG_ENABLED: ${{ secrets.CUSTOM__AI__TAG__ENABLED || vars.CUSTOM__AI__TAG__ENABLED || 'false' }}
           HOME_NEXT_PUBLIC_SIGNUP_ENABLED: ${{ secrets.NEXT_PUBLIC_SIGNUP_ENABLED || vars.NEXT_PUBLIC_SIGNUP_ENABLED || 'false' }}
           HOME_NEXT_PUBLIC_RUM_SAMPLE_RATE: ${{ secrets.NEXT_PUBLIC_RUM_SAMPLE_RATE || vars.NEXT_PUBLIC_RUM_SAMPLE_RATE || '0' }}
+          HOME_RESTORE_PRIVACY_GATE_SCRIPT: ${{ secrets.AQUILA_RESTORE_PRIVACY_GATE_SCRIPT || vars.AQUILA_RESTORE_PRIVACY_GATE_SCRIPT || '/opt/aquila-blog/restore-privacy-gate.sh' }}
         shell: bash
         run: |
           set -euo pipefail
           home_server_env_file="${RUNNER_TEMP}/home-server.env"
           {
             printf '%s\n' "${HOME_SERVER_ENV}"
+            printf 'AQUILA_RESTORE_PRIVACY_GATE_SCRIPT=%s\n' "${HOME_RESTORE_PRIVACY_GATE_SCRIPT}"
             printf 'CUSTOM__MEMBER__SIGNUP__ENABLED=%s\n' "${HOME_MEMBER_SIGNUP_ENABLED:-false}"
             printf 'CUSTOM__MEMBER__OAUTH_SIGNUP__ENABLED=%s\n' "${HOME_MEMBER_OAUTH_SIGNUP_ENABLED:-false}"
             printf 'CUSTOM__AI__TAG__ENABLED=%s\n' "${HOME_AI_TAG_ENABLED:-false}"
@@ -421,6 +423,7 @@ jobs:
           HOME_AI_TAG_ENABLED: ${{ secrets.CUSTOM__AI__TAG__ENABLED || vars.CUSTOM__AI__TAG__ENABLED || 'false' }}
           HOME_NEXT_PUBLIC_SIGNUP_ENABLED: ${{ secrets.NEXT_PUBLIC_SIGNUP_ENABLED || vars.NEXT_PUBLIC_SIGNUP_ENABLED || 'false' }}
           HOME_NEXT_PUBLIC_RUM_SAMPLE_RATE: ${{ secrets.NEXT_PUBLIC_RUM_SAMPLE_RATE || vars.NEXT_PUBLIC_RUM_SAMPLE_RATE || '0' }}
+          HOME_RESTORE_PRIVACY_GATE_SCRIPT: ${{ secrets.AQUILA_RESTORE_PRIVACY_GATE_SCRIPT || vars.AQUILA_RESTORE_PRIVACY_GATE_SCRIPT || '/opt/aquila-blog/restore-privacy-gate.sh' }}
         run: |
           set -euo pipefail
           PORT="${HOME_SSH_PORT:-22}"
@@ -689,6 +692,7 @@ jobs:
           upsert_env_key "CUSTOM__AI__SUMMARY__ENABLED" "${HOME_AI_SUMMARY_ENABLED:-}" "deploy/homeserver/.env.prod"
           upsert_env_key "CUSTOM__AI__SUMMARY__GEMINI__API_KEY" "${HOME_AI_SUMMARY_GEMINI_API_KEY:-}" "deploy/homeserver/.env.prod"
           upsert_env_key "CUSTOM__AI__SUMMARY__GEMINI__MODEL" "${HOME_AI_SUMMARY_GEMINI_MODEL:-}" "deploy/homeserver/.env.prod"
+          upsert_env_key "AQUILA_RESTORE_PRIVACY_GATE_SCRIPT" "${HOME_RESTORE_PRIVACY_GATE_SCRIPT:-/opt/aquila-blog/restore-privacy-gate.sh}" "deploy/homeserver/.env.prod"
 
           require_privacy_freeze_value() {
             local key="$1"

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -896,6 +896,7 @@ test("deploy workflow validates HOME_SERVER_ENV before SSH deployment", () => {
     2,
   )
   assert.match(workflow, /printf 'AQUILA_RESTORE_PRIVACY_GATE_SCRIPT=%s\\n' "\$\{HOME_RESTORE_PRIVACY_GATE_SCRIPT\}"/)
+  assert.match(workflow, /printf 'HOME_RESTORE_PRIVACY_GATE_SCRIPT=%q\\n' "\$\{HOME_RESTORE_PRIVACY_GATE_SCRIPT:-\/opt\/aquila-blog\/restore-privacy-gate\.sh\}"/)
   assert.match(workflow, /upsert_env_key "AQUILA_RESTORE_PRIVACY_GATE_SCRIPT" "\$\{HOME_RESTORE_PRIVACY_GATE_SCRIPT:-\/opt\/aquila-blog\/restore-privacy-gate\.sh\}" "deploy\/homeserver\/\.env\.prod"/)
   assert(workflow.indexOf("Validate HOME_SERVER_ENV contract") < workflow.indexOf("Deploy over SSH"))
   assert.match(workflow, /export HOME_SERVER_ENV/)

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -890,6 +890,13 @@ test("deploy workflow validates HOME_SERVER_ENV before SSH deployment", () => {
 
   assert.match(workflow, /Validate HOME_SERVER_ENV contract/)
   assert.match(workflow, /tools\/env\/validate-env\.mjs --target home-server-source/)
+  assert.match(workflow, /HOME_RESTORE_PRIVACY_GATE_SCRIPT: \$\{\{ secrets\.AQUILA_RESTORE_PRIVACY_GATE_SCRIPT \|\| vars\.AQUILA_RESTORE_PRIVACY_GATE_SCRIPT \|\| '\/opt\/aquila-blog\/restore-privacy-gate\.sh' \}\}/)
+  assert.equal(
+    workflow.match(/HOME_RESTORE_PRIVACY_GATE_SCRIPT: \$\{\{ secrets\.AQUILA_RESTORE_PRIVACY_GATE_SCRIPT \|\| vars\.AQUILA_RESTORE_PRIVACY_GATE_SCRIPT \|\| '\/opt\/aquila-blog\/restore-privacy-gate\.sh' \}\}/g)?.length,
+    2,
+  )
+  assert.match(workflow, /printf 'AQUILA_RESTORE_PRIVACY_GATE_SCRIPT=%s\\n' "\$\{HOME_RESTORE_PRIVACY_GATE_SCRIPT\}"/)
+  assert.match(workflow, /upsert_env_key "AQUILA_RESTORE_PRIVACY_GATE_SCRIPT" "\$\{HOME_RESTORE_PRIVACY_GATE_SCRIPT:-\/opt\/aquila-blog\/restore-privacy-gate\.sh\}" "deploy\/homeserver\/\.env\.prod"/)
   assert(workflow.indexOf("Validate HOME_SERVER_ENV contract") < workflow.indexOf("Deploy over SSH"))
   assert.match(workflow, /export HOME_SERVER_ENV/)
   assert(workflow.indexOf("export HOME_SERVER_ENV") < workflow.indexOf("create_external_backup.sh"))


### PR DESCRIPTION
## 관련 이슈

close #1044

## 작업 배경

- PR #1043 merge 후 `Deploy to Home Server` run `27994045773`이 `AQUILA_RESTORE_PRIVACY_GATE_SCRIPT: is required`로 실패했습니다.
- live `HOME_SERVER_ENV` secret은 읽을 수 없고 전체 교체도 위험하므로, workflow가 새 필수 키만 안전한 기본 경로로 주입하도록 보강합니다.

## 작업 내용

- `Validate HOME_SERVER_ENV contract` 단계에 `HOME_RESTORE_PRIVACY_GATE_SCRIPT` 값을 추가하고 `AQUILA_RESTORE_PRIVACY_GATE_SCRIPT` 라인으로 검증 파일에 주입했습니다.
- `Deploy over SSH` 단계에도 같은 값을 전달하고, 원격 `.env.prod`에 `AQUILA_RESTORE_PRIVACY_GATE_SCRIPT`를 upsert하도록 했습니다.
- env contract test가 validation/deploy 양쪽 env 주입, 검증 파일 라인, `.env.prod` upsert를 확인하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/test/env-contract.test.mjs`: exit 0, 45 pass (2회 연속)
  - `tools/test/verify-deploy-workflow-classification.sh`: exit 0 (2회 연속)
  - `git diff --check`: exit 0 (2회 연속)

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| CD 실패 재현 | GitHub Actions main | `gh run view 27994045773 --log-failed` | run `27994045773`, `AQUILA_RESTORE_PRIVACY_GATE_SCRIPT: is required` | 재현됨 |
| env contract 회귀 | local macOS | `node --test tools/test/env-contract.test.mjs` | 터미널 출력: 45 pass, exit 0, 2회 | 통과 |
| deploy workflow guard | local macOS | `tools/test/verify-deploy-workflow-classification.sh` | 터미널 출력: exit 0, 2회 | 통과 |
| whitespace guard | local macOS | `git diff --check` | 터미널 출력: exit 0, 2회 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `.github/workflows/deploy.yml`에서 validation 단계와 SSH deploy 단계가 같은 restore privacy gate script 값을 쓰는지 확인해 주세요.

## 리스크

- 기본값 `/opt/aquila-blog/restore-privacy-gate.sh`가 원격 서버에 없으면 restore drill 단계에서 실패할 수 있습니다. 기존 runbook/PR #1043 계약상 해당 script를 traffic open gate 전에 준비해야 합니다.
- `HOME_SERVER_ENV` secret 전체 교체는 하지 않았습니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.