### PR TITLE
[Refactor] Design foundation token guard 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,7 @@ jobs:
           BACKEND_DEPLOY_PATHS_PATTERN='^(back/|deploy/homeserver/|deploy/env/|tools/env/|\.github/workflows/deploy\.yml|\.github/workflows/ci\.yml|\.github/workflows/reusable-backend-quality\.yml)'
           STALE_DEPLOY_BLOCK_PATHS_PATTERN='^(back/|deploy/homeserver/|deploy/env/|tools/env/|\.github/workflows/deploy\.yml|\.github/workflows/ci\.yml|\.github/workflows/reusable-backend-quality\.yml)'
           FRONT_LIVE_VERIFY_PATHS_PATTERN='^(front/|legal/policies/|\.github/workflows/deploy\.yml|\.github/workflows/ci\.yml|\.github/workflows/frontend-ci\.yml|\.github/workflows/reusable-frontend-verify\.yml)'
-          FRONT_BUILD_SHA_PATHS_PATTERN='^front/(src/|public/|packages/|scripts/(check-refactor-boundaries\.mjs|with-test-lock\.mjs|patch-lodash-template\.cjs)|site\.config\.js|next-sitemap\.config\.js|next\.config\.js|vercel\.json|tsconfig\.json|package\.json|yarn\.lock|Dockerfile|index\.d\.ts|next-env\.d\.ts)|^legal/policies/'
+          FRONT_BUILD_SHA_PATHS_PATTERN='^front/(src/|public/|packages/|scripts/(check-refactor-boundaries\.mjs|check-design-colors\.mjs|with-test-lock\.mjs|patch-lodash-template\.cjs)|site\.config\.js|next-sitemap\.config\.js|next\.config\.js|vercel\.json|tsconfig\.json|package\.json|yarn\.lock|Dockerfile|index\.d\.ts|next-env\.d\.ts)|^legal/policies/'
           EDITOR_LIVE_CANARY_PATHS_PATTERN='^(front/src/pages/editor/|front/src/routes/Admin/(Editor|WriterEditor|Markdown|markdown|editor)|front/src/components/editor/|front/src/components/markdown-editor/|front/e2e/editor-|front/e2e/helpers/authoringPlaywright\.ts)'
           CHANGED_FILES=""
           if [ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]; then

--- a/.github/workflows/reusable-frontend-verify.yml
+++ b/.github/workflows/reusable-frontend-verify.yml
@@ -25,6 +25,13 @@ jobs:
           git fetch --depth=1 origin "${GITHUB_REF}"
           git checkout --force FETCH_HEAD
 
+      - name: Fetch PR base ref for design color guard
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin "${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
+
       - name: Detect frontend-related changes
         id: changes
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -106,6 +106,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Fetch PR base ref for design color guard
+        if: github.event_name == 'pull_request' && matrix.language == 'javascript-typescript'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin "${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@256d634097be96e792d6764f9edaefc4320557b1 # v4
         with:

--- a/front/package.json
+++ b/front/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "prebuild": "yarn check:refactor-boundaries",
+    "prebuild": "yarn check:refactor-boundaries && yarn check:design-colors",
     "build": "node scripts/with-test-lock.mjs --resource front-verify --label build -- next build",
     "postinstall": "node scripts/patch-lodash-template.cjs",
     "start": "next start",

--- a/front/package.json
+++ b/front/package.json
@@ -34,6 +34,7 @@
     "storybook:gate": "node scripts/storybook/run-storybook-gate.mjs",
     "storybook:test": "HOME=$PWD/.storybook-home CI=1 STORYBOOK_DISABLE_TELEMETRY=1 STORYBOOK_DISABLE_UPDATE_CHECK=1 storybook test --watch=false",
     "check:bundle-size": "node scripts/with-test-lock.mjs --resource front-verify --label bundle-size -- node scripts/check-bundle-size.mjs",
+    "check:design-colors": "node --test scripts/check-design-colors.test.mjs && node scripts/check-design-colors.mjs",
     "check:refactor-boundaries": "node scripts/check-refactor-boundaries.mjs",
     "check:runtime-guard": "node scripts/compare-runtime-guard-metrics.mjs",
     "postbuild": "echo \"skip next-sitemap (handled by pages/sitemap.xml.tsx)\"",

--- a/front/scripts/check-design-colors.mjs
+++ b/front/scripts/check-design-colors.mjs
@@ -103,8 +103,14 @@ const formatViolations = (violations) =>
     .join("\n")
 
 export const collectDiffText = () => {
-  const baseRef = resolveBaseRef()
-  const committedDiff = runGit(diffArgs(`${baseRef}...HEAD`))
+  let committedDiff = ""
+  try {
+    const baseRef = resolveBaseRef()
+    committedDiff = runGit(diffArgs(`${baseRef}...HEAD`))
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    console.warn(`[design-colors] warning: ${reason}; checking local diffs only`)
+  }
   const stagedDiff = runGit(["diff", "--cached", ...localDiffArgs.slice(1)])
   const workingTreeDiff = runGit(localDiffArgs)
   return [committedDiff, stagedDiff, workingTreeDiff].filter(Boolean).join("\n")

--- a/front/scripts/check-design-colors.mjs
+++ b/front/scripts/check-design-colors.mjs
@@ -12,6 +12,7 @@ const TARGET_PATHS = [
 
 const DIRECT_COLOR_PATTERN =
   /(?:^|[^A-Za-z0-9_-])(?:#[0-9A-Fa-f]{3,8}\b|rgba?\([^)]*\)|hsla?\([^)]*\))/
+const FUNCTION_COLOR_START_PATTERN = /(?:^|[^A-Za-z0-9_-])(?:rgba?|hsla?)\(/
 const FRAGMENT_REFERENCE_PATTERN =
   /(?:href\s*=\s*(?:["']#[A-Za-z][\w:-]*["']|\{\s*["']#[A-Za-z][\w:-]*["']\s*\})|url\(\s*["']?#[A-Za-z][\w:-]*["']?\s*\))/g
 
@@ -94,7 +95,10 @@ export const findDirectColorViolations = (diffText) => {
 
     const sourceLine = line.slice(1)
     const colorSourceLine = sourceLine.replace(FRAGMENT_REFERENCE_PATTERN, "")
-    if (DIRECT_COLOR_PATTERN.test(colorSourceLine)) {
+    if (
+      DIRECT_COLOR_PATTERN.test(colorSourceLine) ||
+      FUNCTION_COLOR_START_PATTERN.test(colorSourceLine)
+    ) {
       violations.push({
         file: currentFile,
         line: addedLineNumber,

--- a/front/scripts/check-design-colors.mjs
+++ b/front/scripts/check-design-colors.mjs
@@ -12,6 +12,8 @@ const TARGET_PATHS = [
 
 const DIRECT_COLOR_PATTERN =
   /(?:^|[^A-Za-z0-9_-])(?:#[0-9A-Fa-f]{3,8}\b|rgba?\([^)]*\)|hsla?\([^)]*\))/
+const FRAGMENT_REFERENCE_PATTERN =
+  /(?:href\s*=\s*["']#[A-Za-z][\w:-]*["']|url\(\s*#[A-Za-z][\w:-]*\s*\))/g
 
 const runGit = (args, options = {}) =>
   execFileSync("git", args, {
@@ -91,7 +93,8 @@ export const findDirectColorViolations = (diffText) => {
     }
 
     const sourceLine = line.slice(1)
-    if (DIRECT_COLOR_PATTERN.test(sourceLine)) {
+    const colorSourceLine = sourceLine.replace(FRAGMENT_REFERENCE_PATTERN, "")
+    if (DIRECT_COLOR_PATTERN.test(colorSourceLine)) {
       violations.push({
         file: currentFile,
         line: addedLineNumber,

--- a/front/scripts/check-design-colors.mjs
+++ b/front/scripts/check-design-colors.mjs
@@ -1,0 +1,133 @@
+import { execFileSync } from "node:child_process"
+import { pathToFileURL } from "node:url"
+
+const DEFAULT_BASE_REFS = ["origin/main", "main"]
+const TARGET_PATHS = [
+  "src/design-system",
+  "src/routes/Feed",
+  "src/routes/Settings",
+  "src/components/auth",
+  "src/layouts/RootLayout",
+]
+
+const DIRECT_COLOR_PATTERN =
+  /(?:^|[^A-Za-z0-9_-])(?:#[0-9A-Fa-f]{3,8}\b|rgba?\([^)]*\)|hsla?\([^)]*\))/
+
+const runGit = (args, options = {}) =>
+  execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", options.silent ? "ignore" : "pipe"],
+    ...options,
+  })
+
+const resolveBaseRef = () => {
+  const requestedBase = process.env.DESIGN_COLOR_BASE_REF?.trim()
+  const candidates = requestedBase ? [requestedBase] : DEFAULT_BASE_REFS
+
+  for (const candidate of candidates) {
+    try {
+      runGit(["rev-parse", "--verify", candidate], { silent: true })
+      return candidate
+    } catch {
+      // Try the next local ref. CI and developer machines do not always have the same refs.
+    }
+  }
+
+  throw new Error(`Unable to resolve design color base ref: ${candidates.join(", ")}`)
+}
+
+const diffArgs = (baseRef) => [
+  "diff",
+  "--unified=0",
+  "--no-ext-diff",
+  "--diff-filter=ACMRT",
+  baseRef,
+  "--",
+  ...TARGET_PATHS,
+]
+
+const localDiffArgs = [
+  "diff",
+  "--unified=0",
+  "--no-ext-diff",
+  "--diff-filter=ACMRT",
+  "--",
+  ...TARGET_PATHS,
+]
+
+const parseAddedLineNumber = (line) => {
+  const match = line.match(/^\@\@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? \@\@/)
+  if (!match) return null
+  return Number(match[1])
+}
+
+export const findDirectColorViolations = (diffText) => {
+  const violations = []
+  let currentFile = ""
+  let addedLineNumber = 0
+
+  for (const line of diffText.split(/\r?\n/)) {
+    if (line.startsWith("+++ b/")) {
+      currentFile = line.slice("+++ b/".length)
+      continue
+    }
+
+    const hunkStart = parseAddedLineNumber(line)
+    if (hunkStart !== null) {
+      addedLineNumber = hunkStart
+      continue
+    }
+
+    if (!line.startsWith("+") || line.startsWith("+++")) {
+      continue
+    }
+
+    const sourceLine = line.slice(1)
+    if (DIRECT_COLOR_PATTERN.test(sourceLine)) {
+      violations.push({
+        file: currentFile,
+        line: addedLineNumber,
+        source: sourceLine.trim(),
+      })
+    }
+
+    addedLineNumber += 1
+  }
+
+  return violations
+}
+
+const formatViolations = (violations) =>
+  violations
+    .map((violation) => `- ${violation.file}:${violation.line} ${violation.source}`)
+    .join("\n")
+
+export const collectDiffText = () => {
+  const baseRef = resolveBaseRef()
+  const committedDiff = runGit(diffArgs(`${baseRef}...HEAD`))
+  const stagedDiff = runGit(["diff", "--cached", ...localDiffArgs.slice(1)])
+  const workingTreeDiff = runGit(localDiffArgs)
+  return [committedDiff, stagedDiff, workingTreeDiff].filter(Boolean).join("\n")
+}
+
+export const main = () => {
+  const violations = findDirectColorViolations(collectDiffText())
+
+  if (violations.length === 0) {
+    console.log("[design-colors] ok: no new direct hex/rgb/hsl colors in guarded UI paths")
+    return
+  }
+
+  console.error(
+    [
+      "[design-colors] New direct color literals are not allowed in guarded UI paths.",
+      "Use front/src/design-system semantic tokens or the existing Emotion theme instead.",
+      formatViolations(violations),
+    ].join("\n")
+  )
+  process.exitCode = 1
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+  main()
+}

--- a/front/scripts/check-design-colors.mjs
+++ b/front/scripts/check-design-colors.mjs
@@ -13,7 +13,7 @@ const TARGET_PATHS = [
 const DIRECT_COLOR_PATTERN =
   /(?:^|[^A-Za-z0-9_-])(?:#[0-9A-Fa-f]{3,8}\b|rgba?\([^)]*\)|hsla?\([^)]*\))/
 const FRAGMENT_REFERENCE_PATTERN =
-  /(?:href\s*=\s*["']#[A-Za-z][\w:-]*["']|url\(\s*#[A-Za-z][\w:-]*\s*\))/g
+  /(?:href\s*=\s*(?:["']#[A-Za-z][\w:-]*["']|\{\s*["']#[A-Za-z][\w:-]*["']\s*\})|url\(\s*["']?#[A-Za-z][\w:-]*["']?\s*\))/g
 
 const runGit = (args, options = {}) =>
   execFileSync("git", args, {

--- a/front/scripts/check-design-colors.mjs
+++ b/front/scripts/check-design-colors.mjs
@@ -102,11 +102,13 @@ const formatViolations = (violations) =>
     .map((violation) => `- ${violation.file}:${violation.line} ${violation.source}`)
     .join("\n")
 
+export const committedDiffRange = (baseRef) => `${baseRef}..HEAD`
+
 export const collectDiffText = () => {
   let committedDiff = ""
   try {
     const baseRef = resolveBaseRef()
-    committedDiff = runGit(diffArgs(`${baseRef}...HEAD`))
+    committedDiff = runGit(diffArgs(committedDiffRange(baseRef)))
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error)
     console.warn(`[design-colors] warning: ${reason}; checking local diffs only`)

--- a/front/scripts/check-design-colors.mjs
+++ b/front/scripts/check-design-colors.mjs
@@ -36,6 +36,14 @@ const resolveBaseRef = () => {
   throw new Error(`Unable to resolve design color base ref: ${candidates.join(", ")}`)
 }
 
+export const isInsideGitWorkTree = () => {
+  try {
+    return runGit(["rev-parse", "--is-inside-work-tree"], { silent: true }).trim() === "true"
+  } catch {
+    return false
+  }
+}
+
 const diffArgs = (baseRef) => [
   "diff",
   "--unified=0",
@@ -105,6 +113,11 @@ const formatViolations = (violations) =>
 export const committedDiffRange = (baseRef) => `${baseRef}..HEAD`
 
 export const collectDiffText = () => {
+  if (!isInsideGitWorkTree()) {
+    console.warn("[design-colors] warning: not inside a git worktree; skipping diff check")
+    return ""
+  }
+
   let committedDiff = ""
   try {
     const baseRef = resolveBaseRef()

--- a/front/scripts/check-design-colors.test.mjs
+++ b/front/scripts/check-design-colors.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test"
 import assert from "node:assert/strict"
-import { findDirectColorViolations } from "./check-design-colors.mjs"
+import { committedDiffRange, findDirectColorViolations } from "./check-design-colors.mjs"
 
 test("findDirectColorViolations reports added hex colors", () => {
   const diff = [
@@ -42,4 +42,8 @@ test("findDirectColorViolations ignores removed lines and theme tokens", () => {
   ].join("\n")
 
   assert.deepEqual(findDirectColorViolations(diff), [])
+})
+
+test("committedDiffRange avoids requiring a shallow checkout merge base", () => {
+  assert.equal(committedDiffRange("origin/main"), "origin/main..HEAD")
 })

--- a/front/scripts/check-design-colors.test.mjs
+++ b/front/scripts/check-design-colors.test.mjs
@@ -51,16 +51,19 @@ test("findDirectColorViolations ignores URL fragment references", () => {
   const diff = [
     "diff --git a/src/layouts/RootLayout/Header.tsx b/src/layouts/RootLayout/Header.tsx",
     "+++ b/src/layouts/RootLayout/Header.tsx",
-    "@@ -1,0 +1,3 @@",
+    "@@ -1,0 +1,6 @@",
     '+  <a href="#feed">Feed</a>',
+    '+  <a href={"#feed"}>Feed</a>',
+    "+  <a href={'#feed'}>Feed</a>",
     '+  mask: url(#fade);',
+    '+  mask: url("#fade");',
     '+  color: "#ffffff";',
   ].join("\n")
 
   assert.deepEqual(findDirectColorViolations(diff), [
     {
       file: "src/layouts/RootLayout/Header.tsx",
-      line: 3,
+      line: 6,
       source: 'color: "#ffffff";',
     },
   ])

--- a/front/scripts/check-design-colors.test.mjs
+++ b/front/scripts/check-design-colors.test.mjs
@@ -34,6 +34,26 @@ test("findDirectColorViolations reports added rgb colors", () => {
   assert.equal(findDirectColorViolations(diff).length, 1)
 })
 
+test("findDirectColorViolations reports multi-line functional colors", () => {
+  const diff = [
+    "diff --git a/src/routes/Feed/Card.tsx b/src/routes/Feed/Card.tsx",
+    "+++ b/src/routes/Feed/Card.tsx",
+    "@@ -20,0 +21,4 @@",
+    "+  box-shadow: 0 8px 20px rgba(",
+    "+    15,",
+    "+    23,",
+    "+    42,",
+  ].join("\n")
+
+  assert.deepEqual(findDirectColorViolations(diff), [
+    {
+      file: "src/routes/Feed/Card.tsx",
+      line: 21,
+      source: "box-shadow: 0 8px 20px rgba(",
+    },
+  ])
+})
+
 test("findDirectColorViolations ignores removed lines and theme tokens", () => {
   const diff = [
     "diff --git a/src/routes/Feed/Card.tsx b/src/routes/Feed/Card.tsx",

--- a/front/scripts/check-design-colors.test.mjs
+++ b/front/scripts/check-design-colors.test.mjs
@@ -47,6 +47,25 @@ test("findDirectColorViolations ignores removed lines and theme tokens", () => {
   assert.deepEqual(findDirectColorViolations(diff), [])
 })
 
+test("findDirectColorViolations ignores URL fragment references", () => {
+  const diff = [
+    "diff --git a/src/layouts/RootLayout/Header.tsx b/src/layouts/RootLayout/Header.tsx",
+    "+++ b/src/layouts/RootLayout/Header.tsx",
+    "@@ -1,0 +1,3 @@",
+    '+  <a href="#feed">Feed</a>',
+    '+  mask: url(#fade);',
+    '+  color: "#ffffff";',
+  ].join("\n")
+
+  assert.deepEqual(findDirectColorViolations(diff), [
+    {
+      file: "src/layouts/RootLayout/Header.tsx",
+      line: 3,
+      source: 'color: "#ffffff";',
+    },
+  ])
+})
+
 test("committedDiffRange avoids requiring a shallow checkout merge base", () => {
   assert.equal(committedDiffRange("origin/main"), "origin/main..HEAD")
 })

--- a/front/scripts/check-design-colors.test.mjs
+++ b/front/scripts/check-design-colors.test.mjs
@@ -1,6 +1,9 @@
 import test from "node:test"
 import assert from "node:assert/strict"
-import { committedDiffRange, findDirectColorViolations } from "./check-design-colors.mjs"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { collectDiffText, committedDiffRange, findDirectColorViolations } from "./check-design-colors.mjs"
 
 test("findDirectColorViolations reports added hex colors", () => {
   const diff = [
@@ -46,4 +49,16 @@ test("findDirectColorViolations ignores removed lines and theme tokens", () => {
 
 test("committedDiffRange avoids requiring a shallow checkout merge base", () => {
   assert.equal(committedDiffRange("origin/main"), "origin/main..HEAD")
+})
+
+test("collectDiffText skips non-git build directories", () => {
+  const originalCwd = process.cwd()
+  const buildDir = mkdtempSync(join(tmpdir(), "design-colors-no-git-"))
+
+  try {
+    process.chdir(buildDir)
+    assert.equal(collectDiffText(), "")
+  } finally {
+    process.chdir(originalCwd)
+  }
 })

--- a/front/scripts/check-design-colors.test.mjs
+++ b/front/scripts/check-design-colors.test.mjs
@@ -1,0 +1,45 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { findDirectColorViolations } from "./check-design-colors.mjs"
+
+test("findDirectColorViolations reports added hex colors", () => {
+  const diff = [
+    "diff --git a/src/routes/Feed/Card.tsx b/src/routes/Feed/Card.tsx",
+    "+++ b/src/routes/Feed/Card.tsx",
+    "@@ -1,0 +10,2 @@",
+    "+  color: #ffffff;",
+    "+  background: theme.colors.gray1;",
+  ].join("\n")
+
+  assert.deepEqual(findDirectColorViolations(diff), [
+    {
+      file: "src/routes/Feed/Card.tsx",
+      line: 10,
+      source: "color: #ffffff;",
+    },
+  ])
+})
+
+test("findDirectColorViolations reports added rgb colors", () => {
+  const diff = [
+    "diff --git a/src/routes/Settings/Page.tsx b/src/routes/Settings/Page.tsx",
+    "+++ b/src/routes/Settings/Page.tsx",
+    "@@ -20,0 +21,1 @@",
+    "+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);",
+  ].join("\n")
+
+  assert.equal(findDirectColorViolations(diff).length, 1)
+})
+
+test("findDirectColorViolations ignores removed lines and theme tokens", () => {
+  const diff = [
+    "diff --git a/src/routes/Feed/Card.tsx b/src/routes/Feed/Card.tsx",
+    "--- a/src/routes/Feed/Card.tsx",
+    "+++ b/src/routes/Feed/Card.tsx",
+    "@@ -4,1 +4,1 @@",
+    "-  color: #ffffff;",
+    "+  color: ${({ theme }) => theme.colors.gray12};",
+  ].join("\n")
+
+  assert.deepEqual(findDirectColorViolations(diff), [])
+})

--- a/front/src/design-system/index.ts
+++ b/front/src/design-system/index.ts
@@ -1,0 +1,2 @@
+export * from "./tokens"
+export * from "./primitives"

--- a/front/src/design-system/primitives.tsx
+++ b/front/src/design-system/primitives.tsx
@@ -89,10 +89,18 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
 Button.displayName = "Button"
 
-export type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
-  size?: ControlSize
-  variant?: ButtonVariant
-}
+type AccessibleIconButtonName =
+  | { "aria-label": string; "aria-labelledby"?: never }
+  | { "aria-label"?: never; "aria-labelledby": string }
+
+export type IconButtonProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "aria-label" | "aria-labelledby"
+> &
+  AccessibleIconButtonName & {
+    size?: ControlSize
+    variant?: ButtonVariant
+  }
 
 const StyledIconButton = styled.button<StyledButtonProps>`
   width: ${({ $size }) => controlHeight($size)};

--- a/front/src/design-system/primitives.tsx
+++ b/front/src/design-system/primitives.tsx
@@ -82,8 +82,8 @@ const StyledButton = styled.button<StyledButtonProps>`
 `
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ size = "lg", variant = "secondary", ...props }, ref) => (
-    <StyledButton ref={ref} $size={size} $variant={variant} {...props} />
+  ({ size = "lg", type = "button", variant = "secondary", ...props }, ref) => (
+    <StyledButton ref={ref} type={type} $size={size} $variant={variant} {...props} />
   )
 )
 
@@ -108,8 +108,8 @@ const StyledIconButton = styled.button<StyledButtonProps>`
 `
 
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
-  ({ size = "md", variant = "secondary", ...props }, ref) => (
-    <StyledIconButton ref={ref} $size={size} $variant={variant} {...props} />
+  ({ size = "md", type = "button", variant = "secondary", ...props }, ref) => (
+    <StyledIconButton ref={ref} type={type} $size={size} $variant={variant} {...props} />
   )
 )
 
@@ -182,8 +182,8 @@ const StyledChip = styled.button<{ $selected: boolean }>`
 `
 
 export const Chip = forwardRef<HTMLButtonElement, ChipProps>(
-  ({ selected = false, ...props }, ref) => (
-    <StyledChip ref={ref} $selected={selected} {...props} />
+  ({ selected = false, type = "button", ...props }, ref) => (
+    <StyledChip ref={ref} type={type} $selected={selected} {...props} />
   )
 )
 

--- a/front/src/design-system/primitives.tsx
+++ b/front/src/design-system/primitives.tsx
@@ -1,0 +1,225 @@
+import styled from "@emotion/styled"
+import { forwardRef, type ButtonHTMLAttributes, type HTMLAttributes, type InputHTMLAttributes } from "react"
+import { control, fontWeight, radius, semanticColors, space } from "./tokens"
+
+type ButtonVariant = "primary" | "secondary" | "ghost" | "danger"
+type ControlSize = "sm" | "md" | "lg"
+type SurfaceTone = "default" | "raised" | "muted"
+type BadgeTone = "neutral" | "accent" | "success" | "danger"
+
+const controlHeight = (size: ControlSize) => `${control[size]}px`
+const controlPadding = (size: ControlSize) =>
+  size === "sm" ? `0 ${space[3]}px` : `0 ${space[4]}px`
+
+const buttonColors = (
+  variant: ButtonVariant,
+  theme: Parameters<typeof semanticColors>[0]
+) => {
+  const colors = semanticColors(theme)
+
+  if (variant === "primary") {
+    return {
+      background: colors.accent,
+      border: colors.accent,
+      color: colors.accentText,
+    }
+  }
+
+  if (variant === "danger") {
+    return {
+      background: colors.dangerSurface,
+      border: theme.colors.statusDangerBorder,
+      color: colors.danger,
+    }
+  }
+
+  if (variant === "ghost") {
+    return {
+      background: "transparent",
+      border: "transparent",
+      color: colors.textSecondary,
+    }
+  }
+
+  return {
+    background: colors.surface,
+    border: colors.border,
+    color: colors.textPrimary,
+  }
+}
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  size?: ControlSize
+  variant?: ButtonVariant
+}
+
+type StyledButtonProps = {
+  $size: ControlSize
+  $variant: ButtonVariant
+}
+
+const StyledButton = styled.button<StyledButtonProps>`
+  min-height: ${({ $size }) => controlHeight($size)};
+  padding: ${({ $size }) => controlPadding($size)};
+  border: 1px solid ${({ theme, $variant }) => buttonColors($variant, theme).border};
+  border-radius: ${radius.md}px;
+  background: ${({ theme, $variant }) => buttonColors($variant, theme).background};
+  color: ${({ theme, $variant }) => buttonColors($variant, theme).color};
+  font-weight: ${fontWeight.bold};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: ${space[2]}px;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease,
+    transform 140ms ease;
+
+  &:not(:disabled):hover {
+    transform: translateY(-1px);
+  }
+`
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ size = "lg", variant = "secondary", ...props }, ref) => (
+    <StyledButton ref={ref} $size={size} $variant={variant} {...props} />
+  )
+)
+
+Button.displayName = "Button"
+
+export type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  size?: ControlSize
+  variant?: ButtonVariant
+}
+
+const StyledIconButton = styled.button<StyledButtonProps>`
+  width: ${({ $size }) => controlHeight($size)};
+  min-width: ${({ $size }) => controlHeight($size)};
+  height: ${({ $size }) => controlHeight($size)};
+  border: 1px solid ${({ theme, $variant }) => buttonColors($variant, theme).border};
+  border-radius: ${radius.md}px;
+  background: ${({ theme, $variant }) => buttonColors($variant, theme).background};
+  color: ${({ theme, $variant }) => buttonColors($variant, theme).color};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+`
+
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  ({ size = "md", variant = "secondary", ...props }, ref) => (
+    <StyledIconButton ref={ref} $size={size} $variant={variant} {...props} />
+  )
+)
+
+IconButton.displayName = "IconButton"
+
+export type TextFieldProps = InputHTMLAttributes<HTMLInputElement> & {
+  fieldSize?: ControlSize
+}
+
+const StyledTextField = styled.input<{ $fieldSize: ControlSize }>`
+  width: 100%;
+  min-height: ${({ $fieldSize }) => controlHeight($fieldSize)};
+  border: 1px solid ${({ theme }) => semanticColors(theme).border};
+  border-radius: ${radius.md}px;
+  background: ${({ theme }) => semanticColors(theme).surface};
+  color: ${({ theme }) => semanticColors(theme).textPrimary};
+  padding: 0 ${space[4]}px;
+
+  &::placeholder {
+    color: ${({ theme }) => semanticColors(theme).textMuted};
+  }
+`
+
+export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
+  ({ fieldSize = "lg", ...props }, ref) => (
+    <StyledTextField ref={ref} $fieldSize={fieldSize} {...props} />
+  )
+)
+
+TextField.displayName = "TextField"
+
+export type SurfaceProps = HTMLAttributes<HTMLElement> & {
+  tone?: SurfaceTone
+}
+
+const StyledSurface = styled.section<{ $tone: SurfaceTone }>`
+  border: 1px solid ${({ theme }) => semanticColors(theme).border};
+  border-radius: ${radius.lg}px;
+  background: ${({ theme, $tone }) => {
+    const colors = semanticColors(theme)
+    if ($tone === "raised") return colors.surfaceRaised
+    if ($tone === "muted") return colors.surfaceMuted
+    return colors.surface
+  }};
+`
+
+export const Surface = forwardRef<HTMLElement, SurfaceProps>(
+  ({ tone = "default", ...props }, ref) => (
+    <StyledSurface ref={ref} $tone={tone} {...props} />
+  )
+)
+
+Surface.displayName = "Surface"
+
+export type ChipProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  selected?: boolean
+}
+
+const StyledChip = styled.button<{ $selected: boolean }>`
+  min-height: ${control.md}px;
+  padding: 0 ${space[3]}px;
+  border: 1px solid ${({ theme, $selected }) =>
+    $selected ? semanticColors(theme).accent : semanticColors(theme).border};
+  border-radius: ${radius.pill}px;
+  background: ${({ theme, $selected }) =>
+    $selected ? semanticColors(theme).accentSurface : semanticColors(theme).surface};
+  color: ${({ theme, $selected }) =>
+    $selected ? semanticColors(theme).accentLink : semanticColors(theme).textSecondary};
+  font-weight: ${fontWeight.semibold};
+`
+
+export const Chip = forwardRef<HTMLButtonElement, ChipProps>(
+  ({ selected = false, ...props }, ref) => (
+    <StyledChip ref={ref} $selected={selected} {...props} />
+  )
+)
+
+Chip.displayName = "Chip"
+
+export type BadgeProps = HTMLAttributes<HTMLSpanElement> & {
+  tone?: BadgeTone
+}
+
+const StyledBadge = styled.span<{ $tone: BadgeTone }>`
+  min-height: ${control.sm}px;
+  padding: 0 ${space[3]}px;
+  border-radius: ${radius.pill}px;
+  display: inline-flex;
+  align-items: center;
+  color: ${({ theme, $tone }) => {
+    const colors = semanticColors(theme)
+    if ($tone === "accent") return colors.accentLink
+    if ($tone === "success") return colors.success
+    if ($tone === "danger") return colors.danger
+    return colors.textSecondary
+  }};
+  background: ${({ theme, $tone }) => {
+    const colors = semanticColors(theme)
+    if ($tone === "accent") return colors.accentSurface
+    if ($tone === "success") return colors.successSurface
+    if ($tone === "danger") return colors.dangerSurface
+    return colors.surfaceMuted
+  }};
+  font-weight: ${fontWeight.semibold};
+`
+
+export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ tone = "neutral", ...props }, ref) => (
+    <StyledBadge ref={ref} $tone={tone} {...props} />
+  )
+)
+
+Badge.displayName = "Badge"

--- a/front/src/design-system/tokens.ts
+++ b/front/src/design-system/tokens.ts
@@ -1,0 +1,85 @@
+import type { Theme } from "@emotion/react"
+
+export const space = {
+  0: 0,
+  1: 4,
+  2: 8,
+  3: 12,
+  4: 16,
+  5: 20,
+  6: 24,
+  8: 32,
+  10: 40,
+  12: 48,
+  16: 64,
+} as const
+
+export const radius = {
+  sm: 6,
+  md: 10,
+  lg: 14,
+  xl: 20,
+  pill: 999,
+} as const
+
+export const fontWeight = {
+  regular: 400,
+  medium: 500,
+  semibold: 600,
+  bold: 700,
+  extraBold: 800,
+} as const
+
+export const typeScale = {
+  h1: { size: "2.5rem", line: 1.15, weight: fontWeight.extraBold },
+  h2: { size: "1.75rem", line: 1.25, weight: fontWeight.bold },
+  h3: { size: "1.25rem", line: 1.35, weight: fontWeight.bold },
+  body: { size: "1rem", line: 1.7, weight: fontWeight.regular },
+  small: { size: "0.875rem", line: 1.5, weight: fontWeight.medium },
+  caption: { size: "0.75rem", line: 1.4, weight: fontWeight.semibold },
+} as const
+
+export const control = {
+  sm: 36,
+  md: 40,
+  lg: 44,
+} as const
+
+export const breakpoint = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  xxl: 1440,
+} as const
+
+export const semanticColors = (theme: Theme) => ({
+  canvas: theme.publicDesign.pageBackgroundColor,
+  surface: theme.publicDesign.surface,
+  surfaceRaised: theme.publicDesign.surfaceElevated,
+  surfaceMuted: theme.colors.gray2,
+  textPrimary: theme.colors.gray12,
+  textSecondary: theme.colors.gray11,
+  textMuted: theme.colors.gray10,
+  border: theme.publicDesign.border,
+  borderStrong: theme.publicDesign.borderStrong,
+  accent: theme.colors.accentControl,
+  accentHover: theme.colors.accentControlHover,
+  accentText: theme.colors.accentControlText,
+  accentLink: theme.colors.accentLink,
+  accentSurface: theme.colors.accentSurfaceSubtle,
+  danger: theme.colors.statusDangerText,
+  dangerSurface: theme.colors.statusDangerSurface,
+  success: theme.colors.statusSuccessText,
+  successSurface: theme.colors.statusSuccessSurface,
+})
+
+export const designTokens = {
+  space,
+  radius,
+  fontWeight,
+  typeScale,
+  control,
+  breakpoint,
+  semanticColors,
+} as const


### PR DESCRIPTION
## 🔗 Related Issue
- close #1047

## 📝 Summary
- Public Feed/Auth/Settings/Layout의 UI 개편을 한 번에 진행하지 않고, 먼저 공통 design foundation token과 최소 primitive 기준점을 추가했습니다.
- 후속 PR에서 guarded UI 경로에 직접 hex/rgb/hsl 색상을 새로 추가하면 실패하는 `check:design-colors` 검증을 `prebuild`와 CI build 경로에 연결했습니다.
- PR/CodeQL shallow checkout과 non-git build directory에서도 guard가 build를 불필요하게 막지 않도록 보정했습니다.

## 🛠 Changes
- `front/src/design-system`에 semantic color, spacing, radius, typography, control, breakpoint token을 추가했습니다.
- Button, IconButton, TextField, Surface, Chip, Badge primitive를 추가하고 button 계열 기본 type/a11y name 계약을 안전하게 고정했습니다.
- `front/scripts/check-design-colors.mjs`와 node test를 추가해 committed diff, staged diff, working tree diff의 추가 라인에서 직접 색상 literal을 감지합니다.
- fragment reference와 non-git build directory 오탐을 줄이고, multi-line `rgb/rgba/hsl/hsla` literal 우회를 테스트로 막았습니다.
- PR frontend CI와 CodeQL web build에서 guard base ref를 fetch하고, deploy frontend build SHA 감지 패턴에 신규 guard script를 포함했습니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [x] 로그/메트릭/운영 지표를 확인했는가? GitHub Actions check와 PR review state 확인

### 실행한 검증
- `yarn --cwd front check:design-colors`: exit 0, node:test 7 passed, guarded UI paths direct color diff 없음
- `yarn --cwd front build`: exit 0
- `yarn --cwd front playwright:preflight`: exit 0
- `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`: exit 0, 1 passed
- `git diff --check`: exit 0
- GitHub PR checks: backend-ci, frontend-ci, Security/CodeQL, CodeRabbit, Vercel all pass on `db028cb9`

### 검증 증거
| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Design color guard | local macOS / front | `yarn --cwd front check:design-colors` | local command output | node:test 7 passed, guard 통과 |
| Front build | local macOS / front | `yarn --cwd front build` | local command output | exit 0 |
| Playwright launcher 계약 | local macOS / front | `yarn --cwd front playwright:preflight` | local command output | exit 0 |
| Perf split guard | local macOS / Chromium | `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1` | local command output | 1 passed |
| PR CI | GitHub Actions / PR #1048 | `gh pr checks 1048 --watch --interval 10` | backend-ci `28000266092`, frontend-ci `28000266030`, Security `28000265919` | required checks pass |
| Code review | GitHub PR review | CodeRabbit check + Codex CLI fallback summary review | CodeRabbit pass, Codex review `4549792795` | actionable 0 after fixes |
| Post-merge CI | GitHub Actions / main | merge commit `3bbabe77` workflow 확인 | CI `28000668492`, Security `28000668391` | success |
| Post-merge CD | GitHub Actions / main | Deploy to Home Server workflow 확인 | Deploy `28000977804` | backend build/push와 blue/green deploy success, Frontend Live E2E는 Vercel deployment rate limit으로 failure |
| UI screenshot | N/A | 수동 캡처 생략 | 증거 불필요 사유: 이번 PR은 아직 화면에서 소비하지 않는 foundation/guard/CI 추가이며 사용자-facing route의 DOM/스타일을 바꾸지 않습니다. | 후속 Feed/Auth/Settings 적용 PR에서 시각 증거 첨부 |

## 📸 Screenshot / API Example
- 증거 불필요 사유: 이번 PR은 아직 화면에서 소비하지 않는 foundation/guard/CI 추가이며, 사용자-facing route의 DOM/스타일을 바꾸지 않습니다.

## ⚠️ Risk & Rollback
- 예상 리스크: 후속 PR에서 직접 색상을 추가하면 guard가 실패하므로 기존 관성으로 작성한 스타일 코드가 CI에서 막힐 수 있습니다.
- 배포 영향: `.github/workflows/deploy.yml`의 frontend build SHA 감지 패턴에 신규 guard script를 추가했습니다. main merge 후 backend blue/green deploy와 post-switch verify는 성공했고, Frontend Live E2E Verification은 Vercel deployment rate limit으로 실패했습니다.
- 롤백 방법: 이 PR을 revert하면 design-system foundation과 `check:design-colors` script/CI 연결이 함께 제거됩니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 코드 주석 정책에 맞는 이유/불변조건/운영 영향을 설명하는가?
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. Deploy to Home Server `28000977804`에서 backend blue/green deploy는 성공했고 Frontend Live E2E Verification은 Vercel deployment rate limit으로 실패했다.
