### PR TITLE
[Fix] 개인정보 로그 최소화와 민감정보 redaction 적용

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/memberActionLog/application/service/MemberActionLogApplicationService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/subContexts/memberActionLog/application/service/MemberActionLogApplicationService.kt
@@ -8,13 +8,15 @@ import com.back.boundedContexts.post.domain.PostComment
 import com.back.boundedContexts.post.domain.PostLike
 import com.back.boundedContexts.post.event.*
 import com.back.standard.dto.EventPayload
-import com.back.standard.util.Ut
 import org.springframework.stereotype.Service
+import tools.jackson.databind.ObjectMapper
 
 @Service
 class MemberActionLogApplicationService(
     private val memberActionLogRepository: MemberActionLogRepositoryPort,
 ) {
+    private val objectMapper = ObjectMapper()
+
     fun save(event: EventPayload) {
         when (event) {
             is PostWrittenEvent -> savePostWrittenEvent(event)
@@ -40,7 +42,14 @@ class MemberActionLogApplicationService(
                 secondaryId = event.actorDto.id,
                 secondaryOwner = Member(event.actorDto.id),
                 actor = Member(event.actorDto.id),
-                data = Ut.JSON.toString(event),
+                data =
+                    auditData(
+                        event = event,
+                        "postId" to event.postDto.id,
+                        "actorId" to event.actorDto.id,
+                        "beforeTagCount" to event.beforeTags.size,
+                        "afterTagCount" to event.afterTags.size,
+                    ),
             ),
         )
     }
@@ -56,7 +65,14 @@ class MemberActionLogApplicationService(
                 secondaryId = event.actorDto.id,
                 secondaryOwner = Member(event.actorDto.id),
                 actor = Member(event.actorDto.id),
-                data = Ut.JSON.toString(event),
+                data =
+                    auditData(
+                        event = event,
+                        "postId" to event.postDto.id,
+                        "actorId" to event.actorDto.id,
+                        "beforeTagCount" to event.beforeTags.size,
+                        "afterTagCount" to event.afterTags.size,
+                    ),
             ),
         )
     }
@@ -72,7 +88,14 @@ class MemberActionLogApplicationService(
                 secondaryId = event.actorDto.id,
                 secondaryOwner = Member(event.actorDto.id),
                 actor = Member(event.actorDto.id),
-                data = Ut.JSON.toString(event),
+                data =
+                    auditData(
+                        event = event,
+                        "postId" to event.postDto.id,
+                        "actorId" to event.actorDto.id,
+                        "beforeTagCount" to event.beforeTags.size,
+                        "afterTagCount" to event.afterTags.size,
+                    ),
             ),
         )
     }
@@ -88,7 +111,14 @@ class MemberActionLogApplicationService(
                 secondaryId = event.postDto.id,
                 secondaryOwner = Member(event.postDto.authorId),
                 actor = Member(event.actorDto.id),
-                data = Ut.JSON.toString(event),
+                data =
+                    auditData(
+                        event = event,
+                        "commentId" to event.postCommentDto.id,
+                        "postId" to event.postDto.id,
+                        "actorId" to event.actorDto.id,
+                        "replyReceiverId" to event.replyReceiverId,
+                    ),
             ),
         )
     }
@@ -104,7 +134,13 @@ class MemberActionLogApplicationService(
                 secondaryId = event.postDto.id,
                 secondaryOwner = Member(event.postDto.authorId),
                 actor = Member(event.actorDto.id),
-                data = Ut.JSON.toString(event),
+                data =
+                    auditData(
+                        event = event,
+                        "commentId" to event.postCommentDto.id,
+                        "postId" to event.postDto.id,
+                        "actorId" to event.actorDto.id,
+                    ),
             ),
         )
     }
@@ -120,7 +156,13 @@ class MemberActionLogApplicationService(
                 secondaryId = event.postDto.id,
                 secondaryOwner = Member(event.postDto.authorId),
                 actor = Member(event.actorDto.id),
-                data = Ut.JSON.toString(event),
+                data =
+                    auditData(
+                        event = event,
+                        "commentId" to event.postCommentDto.id,
+                        "postId" to event.postDto.id,
+                        "actorId" to event.actorDto.id,
+                    ),
             ),
         )
     }
@@ -136,7 +178,13 @@ class MemberActionLogApplicationService(
                 secondaryId = event.postId,
                 secondaryOwner = Member(event.postAuthorId),
                 actor = Member(event.actorDto.id),
-                data = Ut.JSON.toString(event),
+                data =
+                    auditData(
+                        event = event,
+                        "likeId" to event.likeId,
+                        "postId" to event.postId,
+                        "actorId" to event.actorDto.id,
+                    ),
             ),
         )
     }
@@ -152,8 +200,32 @@ class MemberActionLogApplicationService(
                 secondaryId = event.postId,
                 secondaryOwner = Member(event.postAuthorId),
                 actor = Member(event.actorDto.id),
-                data = Ut.JSON.toString(event),
+                data =
+                    auditData(
+                        event = event,
+                        "likeId" to event.likeId,
+                        "postId" to event.postId,
+                        "actorId" to event.actorDto.id,
+                    ),
             ),
         )
     }
+
+    private fun auditData(
+        event: EventPayload,
+        vararg fields: Pair<String, Any?>,
+    ): String =
+        objectMapper.writeValueAsString(
+            linkedMapOf<String, Any?>(
+                "eventType" to event::class.simpleName,
+                "metadataCode" to "structured_audit_v1",
+                "aggregateType" to event.aggregateType,
+                "aggregateId" to event.aggregateId,
+                "eventUid" to event.uid.toString(),
+            ).apply {
+                fields.forEach { (key, value) ->
+                    if (value != null) put(key, value)
+                }
+            },
+        )
 }

--- a/back/src/main/kotlin/com/back/global/security/application/AuthSecurityEventService.kt
+++ b/back/src/main/kotlin/com/back/global/security/application/AuthSecurityEventService.kt
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
+import java.security.MessageDigest
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -47,7 +48,7 @@ class AuthSecurityEventService(
             AuthSecurityEvent(
                 eventType = AuthSecurityEventType.LOGIN_POLICY_APPLIED,
                 memberId = member.id,
-                loginIdentifier = loginIdentifier,
+                loginIdentifier = minimizedLoginIdentifier(member.id, loginIdentifier),
                 rememberLoginEnabled = member.rememberLoginEnabled,
                 ipSecurityEnabled = member.ipSecurityEnabled,
                 clientIpFingerprint = member.ipSecurityFingerprint,
@@ -75,7 +76,7 @@ class AuthSecurityEventService(
             AuthSecurityEvent(
                 eventType = AuthSecurityEventType.IP_SECURITY_MISMATCH_BLOCKED,
                 memberId = memberId,
-                loginIdentifier = loginIdentifier,
+                loginIdentifier = minimizedLoginIdentifier(memberId, loginIdentifier),
                 rememberLoginEnabled = rememberLoginEnabled,
                 ipSecurityEnabled = ipSecurityEnabled,
                 clientIpFingerprint = expectedIpFingerprint,
@@ -115,5 +116,19 @@ class AuthSecurityEventService(
         if (value.isNullOrBlank()) return null
         if (value.length <= 16) return value
         return "${value.take(12)}...${value.takeLast(4)}"
+    }
+
+    private fun minimizedLoginIdentifier(
+        memberId: Long?,
+        loginIdentifier: String?,
+    ): String? {
+        if (memberId != null || loginIdentifier.isNullOrBlank()) return null
+        val normalized = loginIdentifier.trim().lowercase()
+        val digest =
+            MessageDigest
+                .getInstance("SHA-256")
+                .digest(normalized.toByteArray())
+                .joinToString("") { "%02x".format(it) }
+        return "sha256:$digest"
     }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/memberActionLog/application/service/MemberActionLogApplicationServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/subContexts/memberActionLog/application/service/MemberActionLogApplicationServiceTest.kt
@@ -1,0 +1,163 @@
+package com.back.boundedContexts.member.subContexts.memberActionLog.application.service
+
+import com.back.boundedContexts.member.dto.MemberDto
+import com.back.boundedContexts.member.subContexts.memberActionLog.application.port.output.MemberActionLogRepositoryPort
+import com.back.boundedContexts.member.subContexts.memberActionLog.domain.MemberActionLog
+import com.back.boundedContexts.post.dto.PostCommentDto
+import com.back.boundedContexts.post.dto.PostDto
+import com.back.boundedContexts.post.event.PostCommentDeletedEvent
+import com.back.boundedContexts.post.event.PostCommentModifiedEvent
+import com.back.boundedContexts.post.event.PostCommentWrittenEvent
+import com.back.boundedContexts.post.event.PostDeletedEvent
+import com.back.boundedContexts.post.event.PostLikedEvent
+import com.back.boundedContexts.post.event.PostModifiedEvent
+import com.back.boundedContexts.post.event.PostUnlikedEvent
+import com.back.boundedContexts.post.event.PostWrittenEvent
+import com.back.standard.dto.EventPayload
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+@DisplayName("MemberActionLogApplicationService 테스트")
+class MemberActionLogApplicationServiceTest {
+    @Test
+    @DisplayName("action log data는 댓글 본문과 게시글 제목 원문을 저장하지 않는다")
+    fun saveCommentEventStoresStructuredMetadataOnly() {
+        // given
+        val repository = RecordingMemberActionLogRepository()
+        val service = MemberActionLogApplicationService(repository)
+        val event =
+            PostCommentWrittenEvent(
+                uid = UUID.fromString("00000000-0000-0000-0000-000000001001"),
+                postCommentDto = testCommentDto(content = "canary secret comment body"),
+                postDto = testPostDto(title = "canary secret post title"),
+                actorDto = testMemberDto(9L),
+                replyReceiverId = 3L,
+            )
+
+        // when
+        service.save(event)
+
+        // then
+        val saved = repository.saved.single()
+        assertThat(saved.data).contains("structured_audit_v1")
+        assertThat(saved.data).contains("\"commentId\":11")
+        assertThat(saved.data).contains("\"postId\":22")
+        assertThat(saved.data).doesNotContain("canary secret comment body")
+        assertThat(saved.data).doesNotContain("canary secret post title")
+    }
+
+    @Test
+    @DisplayName("모든 action log 이벤트는 구조 metadata로 저장한다")
+    fun saveAllSupportedEventsStoresStructuredMetadata() {
+        // given
+        val repository = RecordingMemberActionLogRepository()
+        val service = MemberActionLogApplicationService(repository)
+        val postDto = testPostDto(title = "canary secret post title")
+        val commentDto = testCommentDto(content = "canary secret comment body")
+        val actorDto = testMemberDto(9L)
+        val events =
+            listOf(
+                PostWrittenEvent(
+                    UUID.randomUUID(),
+                    postDto,
+                    actorDto,
+                    beforeTags = listOf("old"),
+                    afterTags = listOf("new"),
+                ),
+                PostModifiedEvent(UUID.randomUUID(), postDto, actorDto),
+                PostDeletedEvent(UUID.randomUUID(), postDto, actorDto),
+                PostCommentWrittenEvent(UUID.randomUUID(), commentDto, postDto, actorDto, replyReceiverId = null),
+                PostCommentModifiedEvent(UUID.randomUUID(), commentDto, postDto, actorDto),
+                PostCommentDeletedEvent(UUID.randomUUID(), commentDto, postDto, actorDto),
+                PostLikedEvent(
+                    UUID.randomUUID(),
+                    postId = 22L,
+                    postAuthorId = 8L,
+                    likeId = 33L,
+                    actorDto = actorDto,
+                ),
+                PostUnlikedEvent(
+                    UUID.randomUUID(),
+                    postId = 22L,
+                    postAuthorId = 8L,
+                    likeId = 33L,
+                    actorDto = actorDto,
+                ),
+            )
+
+        // when
+        events.forEach(service::save)
+        service.save(unknownEvent())
+
+        // then
+        assertThat(repository.saved).hasSize(events.size)
+        assertThat(repository.saved.map { it.data }).allSatisfy { data ->
+            assertThat(data).contains("structured_audit_v1")
+            assertThat(data).doesNotContain("canary secret comment body")
+            assertThat(data).doesNotContain("canary secret post title")
+        }
+    }
+
+    private class RecordingMemberActionLogRepository : MemberActionLogRepositoryPort {
+        val saved = mutableListOf<MemberActionLog>()
+
+        override fun save(memberActionLog: MemberActionLog): MemberActionLog {
+            saved += memberActionLog
+            return memberActionLog
+        }
+    }
+
+    private fun testCommentDto(content: String): PostCommentDto =
+        PostCommentDto(
+            id = 11L,
+            createdAt = Instant.EPOCH,
+            modifiedAt = Instant.EPOCH,
+            authorId = 9L,
+            authorName = "작성자",
+            authorUsername = "author",
+            authorProfileImageUrl = "",
+            authorProfileImageDirectUrl = "",
+            postId = 22L,
+            parentCommentId = null,
+            content = content,
+        )
+
+    private fun testPostDto(title: String): PostDto =
+        PostDto(
+            id = 22L,
+            createdAt = Instant.EPOCH,
+            modifiedAt = Instant.EPOCH,
+            authorId = 8L,
+            authorName = "작성자",
+            authorUsername = "author",
+            authorProfileImgUrl = "",
+            title = title,
+            summary = "summary",
+            version = 1L,
+            published = true,
+            listed = true,
+            likesCount = 0,
+            commentsCount = 0,
+            hitCount = 0,
+        )
+
+    private fun testMemberDto(id: Long): MemberDto =
+        MemberDto(
+            id = id,
+            createdAt = Instant.EPOCH,
+            modifiedAt = Instant.EPOCH,
+            isAdmin = false,
+            name = "작성자",
+            profileImageUrl = "",
+        )
+
+    private fun unknownEvent(): EventPayload =
+        object : EventPayload {
+            override val uid: UUID = UUID.randomUUID()
+            override val aggregateType: String = "Unknown"
+            override val aggregateId: Long = 0
+        }
+}

--- a/back/src/test/kotlin/com/back/global/security/application/AuthSecurityEventServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/application/AuthSecurityEventServiceTest.kt
@@ -1,6 +1,8 @@
 package com.back.global.security.application
 
+import com.back.boundedContexts.member.domain.shared.Member
 import com.back.global.security.application.port.output.AuthSecurityEventStore
+import com.back.global.security.domain.AuthSecurityEventType
 import com.back.global.security.model.AuthSecurityEvent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -10,6 +12,102 @@ import java.time.temporal.ChronoUnit
 
 @DisplayName("AuthSecurityEventService 테스트")
 class AuthSecurityEventServiceTest {
+    @Test
+    @DisplayName("성공 로그인 보안 이벤트는 이메일 원문 대신 memberId만 저장한다")
+    fun recordLoginPolicyAppliedDropsRawEmail() {
+        // given
+        val store = RecordingAuthSecurityEventStore()
+        val service = AuthSecurityEventService(authSecurityEventStore = store)
+        val member =
+            Member(
+                id = 7L,
+                username = "user",
+                password = null,
+                nickname = "사용자",
+                email = "canary-login@example.com",
+            )
+
+        // when
+        service.recordLoginPolicyApplied(
+            member = member,
+            loginIdentifier = "canary-login@example.com",
+            requestPath = "/member/api/v1/auth/login",
+        )
+
+        // then
+        assertThat(store.saved.single().eventType).isEqualTo(AuthSecurityEventType.LOGIN_POLICY_APPLIED)
+        assertThat(store.saved.single().memberId).isEqualTo(7L)
+        assertThat(store.saved.single().loginIdentifier).isNull()
+    }
+
+    @Test
+    @DisplayName("회원 식별자가 없는 보안 차단 이벤트는 로그인 식별자를 해시로 저장한다")
+    fun recordIpSecurityMismatchBlockedHashesAnonymousIdentifier() {
+        // given
+        val store = RecordingAuthSecurityEventStore()
+        val service = AuthSecurityEventService(authSecurityEventStore = store)
+
+        // when
+        service.recordIpSecurityMismatchBlocked(
+            memberId = null,
+            loginIdentifier = "CANARY-LOGIN@example.com",
+            rememberLoginEnabled = true,
+            ipSecurityEnabled = true,
+            expectedIpFingerprint = "fingerprint",
+            requestPath = "/member/api/v1/auth/me",
+            reason = "ip_mismatch",
+        )
+
+        // then
+        val saved = store.saved.single()
+        assertThat(saved.loginIdentifier).startsWith("sha256:")
+        assertThat(saved.loginIdentifier).doesNotContain("CANARY-LOGIN@example.com")
+        assertThat(saved.loginIdentifier).doesNotContain("canary-login@example.com")
+    }
+
+    @Test
+    @DisplayName("최근 보안 이벤트 조회는 IP fingerprint를 마스킹한다")
+    fun getRecentMasksClientIpFingerprint() {
+        // given
+        val store = RecordingAuthSecurityEventStore()
+        store.recent += securityEvent(id = 1L, fingerprint = null)
+        store.recent += securityEvent(id = 2L, fingerprint = "short-fp")
+        store.recent += securityEvent(id = 3L, fingerprint = "12345678901234567890")
+        val service = AuthSecurityEventService(authSecurityEventStore = store)
+
+        // when
+        val recent = service.getRecent(30)
+
+        // then
+        assertThat(recent.map { it.clientIpFingerprint }).containsExactly(
+            null,
+            "short-fp",
+            "123456789012...7890",
+        )
+    }
+
+    @Test
+    @DisplayName("회원 식별자가 없는 빈 로그인 식별자는 저장하지 않는다")
+    fun recordIpSecurityMismatchBlockedDropsBlankAnonymousIdentifier() {
+        // given
+        val store = RecordingAuthSecurityEventStore()
+        val service = AuthSecurityEventService(authSecurityEventStore = store)
+
+        // when
+        service.recordIpSecurityMismatchBlocked(
+            memberId = null,
+            loginIdentifier = " ",
+            rememberLoginEnabled = true,
+            ipSecurityEnabled = true,
+            expectedIpFingerprint = "fingerprint",
+            requestPath = "/member/api/v1/auth/me",
+            reason = "ip_mismatch",
+        )
+
+        // then
+        assertThat(store.saved.single().loginIdentifier).isNull()
+    }
+
     @Test
     @DisplayName("보존 기간을 지난 보안 이벤트를 DB batch delete로 삭제한다")
     fun purgeExpiredSecurityEventsWithBatchLimit() {
@@ -38,12 +136,15 @@ class AuthSecurityEventServiceTest {
 
     private class RecordingAuthSecurityEventStore : AuthSecurityEventStore {
         var nextDeletedCount = 0
+        val saved = mutableListOf<AuthSecurityEvent>()
+        val recent = mutableListOf<AuthSecurityEvent>()
         val deleteExpiredBeforeCalls = mutableListOf<DeleteExpiredBeforeCall>()
 
         override fun save(event: AuthSecurityEvent) {
+            saved += event
         }
 
-        override fun findRecent(limit: Int): List<AuthSecurityEvent> = emptyList()
+        override fun findRecent(limit: Int): List<AuthSecurityEvent> = recent.take(limit)
 
         override fun deleteExpiredBefore(
             cutoff: Instant,
@@ -58,4 +159,23 @@ class AuthSecurityEventServiceTest {
         val cutoff: Instant,
         val limit: Int,
     )
+
+    private fun securityEvent(
+        id: Long,
+        fingerprint: String?,
+    ): AuthSecurityEvent =
+        AuthSecurityEvent(
+            id = id,
+            eventType = AuthSecurityEventType.IP_SECURITY_MISMATCH_BLOCKED,
+            memberId = id,
+            loginIdentifier = null,
+            rememberLoginEnabled = true,
+            ipSecurityEnabled = true,
+            clientIpFingerprint = fingerprint,
+            requestPath = "/member/api/v1/auth/me",
+            reason = "ip_mismatch",
+        ).apply {
+            createdAt = Instant.EPOCH
+            modifiedAt = Instant.EPOCH
+        }
 }

--- a/legal/data-map/data-flow.yaml
+++ b/legal/data-map/data-flow.yaml
@@ -66,7 +66,7 @@ flows:
       - home_server_postgresql
       - home_server_redis
       - grafana_loki_monitoring
-    status: redaction은 issue1001
+    status: auth security identifiers and member action log bodies are minimized by issue1001
   - id: notifications_sse
     collectionPoint: post/comment domain events and SSE API
     stores:

--- a/legal/data-map/processing-activities.yaml
+++ b/legal/data-map/processing-activities.yaml
@@ -327,7 +327,7 @@ activities:
     policySectionId: privacy-collection-security-log
     enabledByEnv: alwaysEnabledForAuthSecurity
     reviewRequired:
-      - Raw loginIdentifier minimization and redaction are tracked by issue1001.
+      - loginIdentifier stores null for member-known success events and one-way hash for anonymous blocked identifiers.
 
   - id: member_action_logs
     name: 관리자·사용자 action log
@@ -361,7 +361,7 @@ activities:
     policySectionId: privacy-collection-action-log
     enabledByEnv: alwaysEnabledForAuditableActions
     reviewRequired:
-      - Free-text data field minimization is tracked by issue1001.
+      - action log data stores structured_audit_v1 metadata without post/comment body text.
 
   - id: notifications_sse
     name: 알림과 SSE 연결 상태

--- a/legal/vendors/processors.yaml
+++ b/legal/vendors/processors.yaml
@@ -232,7 +232,7 @@ processors:
       - restrictedNetworkAccess
       - dashboardAccessControl
     reviewRequired:
-      - Sensitive log redaction and retention are tracked by issue1001.
+      - Retention configuration still requires review; DB-backed auth/action logs minimize identifiers and content before Loki ingestion.
 
   - id: github_actions
     name: GitHub Actions


### PR DESCRIPTION
## 🔗 Related Issue
- close #1001

## 📝 Summary
- Auth security event가 성공 로그인 email 원문을 저장하지 않고 `memberId` 중심으로 남기도록 줄였습니다.
- 회원 식별자가 없는 보안 차단 identifier는 SHA-256 one-way hash로 저장하고, member action log `data`는 본문/제목 원문 없는 `structured_audit_v1` metadata로 바꿨습니다.
- privacy data-map의 issue1001 추적 문구를 실제 구현 상태와 맞췄습니다.

## 🛠 Changes
- `AuthSecurityEventService`에서 member-known 이벤트의 `loginIdentifier`를 `null`로 저장하고 anonymous blocked identifier는 `sha256:<digest>`로 저장합니다.
- `MemberActionLogApplicationService`에서 post/comment/like 이벤트 전체 JSON 대신 event type, aggregate id, actor/target id, tag count 같은 제한 metadata만 저장합니다.
- auth/action log 저장값에 raw email, post title, comment body가 남지 않는 회귀 테스트를 추가했습니다.
- legal data-map과 processor registry의 log redaction 상태 설명을 구현 결과에 맞게 갱신했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [x] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `./back/gradlew -p back ktlintCheck test --tests '*AuthSecurityEventServiceTest' --tests '*MemberActionLogApplicationServiceTest' --rerun-tasks`: exit 0
- `node tools/legal/validate-privacy-data-map.mjs`: exit 0, `[privacy-data-map] ok: 13 activities, 13 processors`
- `node tools/privacy/ci-privacy-gate.mjs`: exit 0, `[privacy-gate] ok`
- `./back/gradlew -p back ciFastCheck --rerun-tasks`: exit 0

### 검증 증거
| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Auth security event raw email 차단 | Backend unit | `AuthSecurityEventServiceTest` | `recordLoginPolicyAppliedDropsRawEmail`, `recordIpSecurityMismatchBlockedHashesAnonymousIdentifier` | raw email 미저장, anonymous identifier hash 저장 |
| Member action log 본문/제목 원문 차단 | Backend unit | `MemberActionLogApplicationServiceTest` | `saveCommentEventStoresStructuredMetadataOnly`, `saveAllSupportedEventsStoresStructuredMetadata` | post/comment 원문 없이 `structured_audit_v1` metadata 저장 |
| Privacy data-map drift | Local CI | `node tools/privacy/ci-privacy-gate.mjs` | command output | pass |
| Backend regression | Local CI | `./back/gradlew -p back ciFastCheck --rerun-tasks` | command output | pass |

## 🔎 Review / Merge Gate
- GitHub checks: pass (`backend-ci`, `frontend-ci`, `Security`, CodeQL, privacy gate)
- CodeRabbit: 한도/크레딧 부족으로 실제 리뷰 미실행
- Codex CLI fallback: PR review [`4550576326`](https://github.com/AquilaXk/aquila-blog/pull/1050#pullrequestreview-4550576326), actionable 0건
- Review threads: unresolved 0건
- CD 영향: 배포 설정 변경 없음. merge 후 main workflow 생성/실패 상태만 확인 대상

## 📸 Screenshot / API Example
- UI/API 응답 변경 없음.
- Evidence not needed because this PR changes backend audit-log persistence and legal data-map metadata only.

## ⚠️ Risk & Rollback
- 예상 리스크: 기존 운영 조회 화면에서 `loginIdentifier`가 성공 로그인 이벤트에는 `null`, anonymous 차단 이벤트에는 hash로 보입니다.
- 롤백 방법: 이 PR의 merge commit을 revert하면 이전 로그 저장 형식으로 돌아갑니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 [코드 주석 정책](https://github.com/AquilaXk/aquila-blog/blob/main/docs/design/code-comment-policy.md)에 맞는 이유/불변조건/운영 영향을 설명하는가?
