### PR TITLE
[CI] Grafana route 검증을 backend 배포 rollback에서 분리

### DIFF
--- a/deploy/homeserver/blue_green_deploy.sh
+++ b/deploy/homeserver/blue_green_deploy.sh
@@ -615,7 +615,7 @@ check_grafana_embed_origin_route() {
 
 warn_grafana_embed_origin_route() {
   check_grafana_embed_origin_route && return 0
-  echo "WARN grafana origin auth-proxy route unhealthy; backend deploy continues and steady-state guard monitors it" >&2
+  echo "WARN grafana origin auth-proxy route unhealthy; backend deploy continues" >&2
   return 0
 }
 
@@ -2101,7 +2101,6 @@ run_blue_green_burn_in() {
       return 1
     fi
 
-    warn_grafana_embed_origin_route
   done
 
   echo "burn-in ok: candidate=${candidate_backend}, previous=${previous_backend}, duration_seconds=${duration_seconds}"

--- a/deploy/homeserver/blue_green_deploy.sh
+++ b/deploy/homeserver/blue_green_deploy.sh
@@ -613,6 +613,12 @@ check_grafana_embed_origin_route() {
   return 1
 }
 
+warn_grafana_embed_origin_route() {
+  check_grafana_embed_origin_route && return 0
+  echo "WARN grafana origin auth-proxy route unhealthy; backend deploy continues and steady-state guard monitors it" >&2
+  return 0
+}
+
 warn_grafana_embed_public_route() {
   local url
   url="$(monitoring_embed_candidate_url)"
@@ -2095,11 +2101,7 @@ run_blue_green_burn_in() {
       return 1
     fi
 
-    if ! check_grafana_embed_origin_route; then
-      echo "burn-in grafana origin auth-proxy route verify failed" >&2
-      rollback_caddy_route_only "${previous_backend}" "${candidate_backend}" "${api_domain}" || true
-      return 1
-    fi
+    warn_grafana_embed_origin_route
   done
 
   echo "burn-in ok: candidate=${candidate_backend}, previous=${previous_backend}, duration_seconds=${duration_seconds}"
@@ -2191,7 +2193,7 @@ compose_up_with_retry "${services_to_boot[@]}"
 compose_up_no_deps_with_retry loki promtail prometheus grafana
 ensure_caddy_mount_sync
 check_cloudflared_runtime "${api_domain}"
-check_grafana_embed_origin_route
+warn_grafana_embed_origin_route
 warn_grafana_embed_public_route
 validate_db_runtime_role_env
 provision_db_runtime_role
@@ -2256,12 +2258,7 @@ if ! check_cloudflared_runtime "${api_domain}"; then
 fi
 
 echo "post-switch phase: grafana embed route verify"
-if ! check_grafana_embed_origin_route; then
-  echo "post-switch grafana origin auth-proxy route verify failed" >&2
-  rollback_to_backend "${active_backend}" "${api_domain}" || true
-  compose stop "${next_backend}" || true
-  exit 1
-fi
+warn_grafana_embed_origin_route
 warn_grafana_embed_public_route
 
 echo "post-switch phase: public read prewarm"

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -955,6 +955,15 @@ test("deploy workflow validates live API security headers after homeserver rollo
   )
 })
 
+test("blue green deploy keeps grafana route checks out of backend rollback decisions", () => {
+  const deployScript = readFileSync(deployScriptPath, "utf8")
+
+  assert.match(deployScript, /warn_grafana_embed_origin_route\(\)/)
+  assert.doesNotMatch(deployScript, /if ! check_grafana_embed_origin_route; then/)
+  assert.doesNotMatch(deployScript, /^check_grafana_embed_origin_route$/m)
+  assert.doesNotMatch(deployScript, /grafana origin auth-proxy route verify failed[\s\S]{0,220}rollback_/)
+})
+
 test("required secret check does not inject multi-line HOME_SERVER_ENV into shell", () => {
   const workflow = readFileSync(workflowPath, "utf8")
 

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -957,11 +957,17 @@ test("deploy workflow validates live API security headers after homeserver rollo
 
 test("blue green deploy keeps grafana route checks out of backend rollback decisions", () => {
   const deployScript = readFileSync(deployScriptPath, "utf8")
+  const burnInBody = deployScript.slice(
+    deployScript.indexOf("run_blue_green_burn_in()"),
+    deployScript.indexOf("rollback_to_backend()"),
+  )
 
   assert.match(deployScript, /warn_grafana_embed_origin_route\(\)/)
   assert.doesNotMatch(deployScript, /if ! check_grafana_embed_origin_route; then/)
   assert.doesNotMatch(deployScript, /^check_grafana_embed_origin_route$/m)
   assert.doesNotMatch(deployScript, /grafana origin auth-proxy route verify failed[\s\S]{0,220}rollback_/)
+  assert.doesNotMatch(burnInBody, /warn_grafana_embed_origin_route/)
+  assert.doesNotMatch(deployScript, /steady-state guard monitors it/)
 })
 
 test("required secret check does not inject multi-line HOME_SERVER_ENV into shell", () => {


### PR DESCRIPTION
## 🔗 Related Issue
- close #1052

## 📝 Summary
- 홈서버 blue/green 배포에서 Grafana origin auth-proxy route 실패가 backend rollback으로 분류되던 경로를 분리했습니다.
- backend 배포 성공 판정은 backend/Caddy/API health와 public read canary에 남기고, Grafana route 상태는 warning으로 기록합니다.

## 🛠 Changes
- `blue_green_deploy.sh`의 Grafana origin route 확인을 `warn_grafana_embed_origin_route`로 감싸 실패해도 backend rollback을 실행하지 않게 했습니다.
- burn-in, pre-switch, post-switch Grafana route 확인에서 rollback/exit 경로를 제거했습니다.
- deploy 계약 테스트에 Grafana route check가 backend rollback block에 다시 묶이지 않는 회귀 검증을 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [ ] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `node --test tools/test/env-contract.test.mjs`: exit 1로 RED 확인 후 수정 후 exit 0, 46 tests pass
- `bash tools/test/verify-deploy-workflow-classification.sh`: exit 0
- `git diff --check`: exit 0
- PR checks: backend-ci, frontend-ci, Security, Vercel, Vercel Preview Comments 모두 pass
- CodeRabbit: rate limit/credit 부족으로 실제 리뷰 미실행 확인
- Codex CLI fallback: 최초 `Actionable comments posted: 2`, follow-up 후 re-review `Actionable comments posted: 0`

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Grafana route rollback 분리 회귀 | local macOS / Node test runner | `node --test tools/test/env-contract.test.mjs` | 로컬 명령 출력: 46 tests pass | 통과 |
| deploy workflow 분류 계약 | local macOS / bash | `bash tools/test/verify-deploy-workflow-classification.sh` | 로컬 명령 exit code | 통과 |
| patch whitespace | local git | `git diff --check` | 로컬 명령 exit code | 통과 |

## 📸 Screenshot / API Example
- UI/API 변경이 아니므로 스크린샷과 API 예시는 없음.

## ⚠️ Risk & Rollback
- 예상 리스크: Grafana embed route 장애가 backend 배포 실패로 즉시 차단되지 않고 warning으로만 남습니다. steady-state guard가 별도 관측 경로로 계속 확인합니다.
- 롤백 방법: 이 PR의 커밋을 revert하면 Grafana origin route 실패가 다시 backend blue/green rollback 조건으로 복구됩니다.

## 리뷰어 메모
- 리뷰어가 먼저 봐야 할 지점: `deploy/homeserver/blue_green_deploy.sh`에서 backend rollback 조건에 남아야 하는 check와 warning-only로 빠져야 하는 Grafana route check의 분리입니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 코드 주석 정책에 맞는 이유/불변조건/운영 영향을 설명하는가?
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
