### PR TITLE
[CI] Flyway lock retry 보강

### DIFF
--- a/back/src/main/resources/application-prod.yaml
+++ b/back/src/main/resources/application-prod.yaml
@@ -9,6 +9,7 @@ spring:
     baseline-on-migrate: true
     validate-on-migrate: true
     locations: classpath:db/migration
+    lock-retry-count: ${PROD___SPRING__FLYWAY__LOCK_RETRY_COUNT:300}
     # Flyway는 migration credential을 별도 사용하고, runtime datasource는 최소권한 role로 고정한다.
     user: "${PROD___SPRING__FLYWAY__USER:postgres}"
     password: "${PROD___SPRING__FLYWAY__PASSWORD:${PROD___POSTGRES__PASSWORD}}"

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -1271,6 +1271,7 @@ test("prod datasource uses a non-superuser runtime role contract", () => {
   assert.match(applicationProd, /username:\s*"\$\{PROD___SPRING__DATASOURCE__USERNAME\}"/)
   assert.match(applicationProd, /flyway:\n(?:.*\n)*\s+user:\s*"\$\{PROD___SPRING__FLYWAY__USER:postgres\}"/)
   assert.match(applicationProd, /password:\s*"\$\{PROD___SPRING__FLYWAY__PASSWORD:\$\{PROD___POSTGRES__PASSWORD\}\}"/)
+  assert.match(applicationProd, /lock-retry-count:\s*\$\{PROD___SPRING__FLYWAY__LOCK_RETRY_COUNT:300\}/)
   assert.match(compose, /POSTGRES_PASSWORD:\s*\$\{PROD___POSTGRES__PASSWORD:-\$\{PROD___SPRING__DATASOURCE__PASSWORD\}\}/)
   assert.match(deployScript, /validate_db_runtime_role_env/)
   assert.match(deployScript, /provision_db_runtime_role/)


### PR DESCRIPTION
## 관련 이슈

close #1052

## 작업 배경

- PR #1053 merge 후 Home Server deploy run `28019383140`이 다시 실패했습니다.
- 실패 원인은 Grafana origin auth-proxy route가 아니라 prod backend startup 중 Flyway PostgreSQL advisory lock retry 초과였습니다.
- Home Server deploy는 blue/green candidate backend와 runtime split backend들이 같은 배포 window에서 기동될 수 있으므로, Flyway lock 대기 시간을 운영 배포 window에 맞게 늘려야 합니다.

## 작업 내용

- `spring.flyway.lock-retry-count` prod 기본값을 `300`으로 설정했습니다.
- `PROD___SPRING__FLYWAY__LOCK_RETRY_COUNT` 환경변수로 운영 override가 가능하게 유지했습니다.
- env contract regression test가 prod Flyway lock retry 계약을 검사하도록 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/test/env-contract.test.mjs`: RED 단계에서 `lock-retry-count` 누락으로 45 pass / 1 fail 확인 후, 수정 뒤 46 pass / 0 fail, exit 0
  - `bash tools/test/verify-deploy-workflow-classification.sh`: exit 0
  - `git diff --check`: exit 0
  - `back/gradlew -p back ktlintCheck`: exit 0
  - `back/gradlew -p back ciFastCheck`: 1회차 exit 0
  - `back/gradlew -p back ciFastCheck`: 2회차 exit 0
  - `git commit -m "fix(deploy): flyway lock retry 보강"` pre-commit: OpenAPI export/drift check exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| post-merge CD 실패 원인 | GitHub Actions / Home Server | `blueGreenDeploy` 로그 확인 | https://github.com/AquilaXk/aquila-blog/actions/runs/28019383140 | Flyway advisory lock retry 초과로 실패 |
| Flyway prod 설정 문서 | Context7 / Spring Boot | `spring.flyway.lock-retry-count` 속성 확인 | `/spring-projects/spring-boot` FlywayProperties 문서 | Spring Boot property 경로 확인 |
| prod Flyway lock retry 계약 | local darwin | `node --test tools/test/env-contract.test.mjs` | 로컬 명령 출력 | 46 pass / 0 fail |
| backend 빠른 회귀 | local darwin | `back/gradlew -p back ciFastCheck` 2회 연속 실행 | 로컬 명령 출력 | 2회 모두 BUILD SUCCESSFUL |
| PR CI | GitHub Actions | PR #1054 checks 확인 | https://github.com/AquilaXk/aquila-blog/pull/1054/checks | required checks pass |
| Codex CLI fallback review | GitHub PR review | CodeRabbit rate limit 후 `codex review` 결과 게시 | https://github.com/AquilaXk/aquila-blog/pull/1054#pullrequestreview-4552387505 | actionable 0건 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `back/src/main/resources/application-prod.yaml`의 `spring.flyway.lock-retry-count` 기본값
  - `tools/test/env-contract.test.mjs`의 prod Flyway 설정 계약 검사

## 리스크

- Flyway lock을 기다리는 시간이 늘어 deploy 실패 가능성은 줄지만, 실제 migration deadlock이나 장시간 DB 장애가 있으면 startup 실패 감지가 늦어질 수 있습니다.
- override env를 열어두었으므로 운영에서 더 짧거나 긴 값으로 조정 가능합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
