### PR TITLE
[CI] Candidate migration 대기 연장

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -932,7 +932,7 @@ jobs:
             exit 1
           }
 
-          if ! STAGED_BACK_IMAGE="${STAGED_BACK_IMAGE}" RUNTIME_SPLIT_ENABLED="${RUNTIME_SPLIT_ENABLED_VALUE}" RUNTIME_SPLIT_STAGE="${RUNTIME_SPLIT_STAGE_VALUE}" HEALTHCHECK_PATH=/actuator/health/readiness HEALTHCHECK_LOG_EVERY_N_TRIES=1 ./deploy/homeserver/blue_green_deploy.sh; then
+          if ! STAGED_BACK_IMAGE="${STAGED_BACK_IMAGE}" RUNTIME_SPLIT_ENABLED="${RUNTIME_SPLIT_ENABLED_VALUE}" RUNTIME_SPLIT_STAGE="${RUNTIME_SPLIT_STAGE_VALUE}" HEALTHCHECK_PATH=/actuator/health/readiness HEALTHCHECK_LOG_EVERY_N_TRIES=1 CANDIDATE_HEALTHCHECK_RETRIES=450 ./deploy/homeserver/blue_green_deploy.sh; then
             rollback_and_exit "blue_green_deploy_failed"
           fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -269,7 +269,7 @@ jobs:
     if: >
       needs.calculateTag.outputs.backend_deploy == 'true' &&
       needs.buildAndPush.result == 'success'
-    timeout-minutes: 30
+    timeout-minutes: 75
     permissions:
       contents: read
 

--- a/deploy/homeserver/blue_green_deploy.sh
+++ b/deploy/homeserver/blue_green_deploy.sh
@@ -17,6 +17,7 @@ NETWORK_NAME="blog_home_default"
 DEPLOY_LOCK_DIR="${SCRIPT_DIR}/.deploy.lock"
 HEALTHCHECK_PATH="${HEALTHCHECK_PATH:-/actuator/health/readiness}"
 HEALTHCHECK_RETRIES="${HEALTHCHECK_RETRIES:-120}"
+CANDIDATE_HEALTHCHECK_RETRIES="${CANDIDATE_HEALTHCHECK_RETRIES:-450}"
 HEALTHCHECK_INTERVAL_SECONDS="${HEALTHCHECK_INTERVAL_SECONDS:-2}"
 HEALTHCHECK_CONNECT_TIMEOUT_SECONDS="${HEALTHCHECK_CONNECT_TIMEOUT_SECONDS:-2}"
 HEALTHCHECK_MAX_TIME_SECONDS="${HEALTHCHECK_MAX_TIME_SECONDS:-5}"
@@ -111,6 +112,8 @@ normalize_non_negative_int() {
 
 RUNTIME_SPLIT_ENABLED="$(normalize_bool "${RUNTIME_SPLIT_ENABLED}")"
 RUNTIME_SPLIT_STAGE="$(normalize_runtime_split_stage "${RUNTIME_SPLIT_STAGE}")"
+HEALTHCHECK_RETRIES="$(normalize_positive_int "${HEALTHCHECK_RETRIES}" "120")"
+CANDIDATE_HEALTHCHECK_RETRIES="$(normalize_positive_int "${CANDIDATE_HEALTHCHECK_RETRIES}" "450")"
 STREAM_DRAIN_SECONDS="$(normalize_non_negative_int "${STREAM_DRAIN_SECONDS}" "15")"
 BLUE_GREEN_BURN_IN_STANDARD_SECONDS="$(normalize_non_negative_int "${BLUE_GREEN_BURN_IN_STANDARD_SECONDS}" "180")"
 BLUE_GREEN_BURN_IN_HIGH_RISK_SECONDS="$(normalize_non_negative_int "${BLUE_GREEN_BURN_IN_HIGH_RISK_SECONDS}" "600")"
@@ -1905,6 +1908,16 @@ check_backend_health() {
   return 1
 }
 
+check_candidate_backend_health() {
+  local backend="$1"
+  local previous_retries="${HEALTHCHECK_RETRIES}"
+  HEALTHCHECK_RETRIES="${CANDIDATE_HEALTHCHECK_RETRIES}"
+  check_backend_health "${backend}"
+  local status=$?
+  HEALTHCHECK_RETRIES="${previous_retries}"
+  return "${status}"
+}
+
 check_notification_sse_route() {
   local api_domain="$1"
   local admin_email admin_password
@@ -2370,7 +2383,7 @@ if [[ "${RUNTIME_SPLIT_ENABLED}" == "true" ]]; then
     echo "skip runtime helper dns check before candidate health: helpers were not prebooted"
   fi
 fi
-if ! check_backend_health "${next_backend}"; then
+if ! check_candidate_backend_health "${next_backend}"; then
   echo "candidate backend health failed before cutover: ${next_backend}" >&2
   compose stop "${next_backend}" || true
   exit 1

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -1324,6 +1324,25 @@ test("blue-green deploy keeps old backend running during burn-in rollback window
   assert(burnInIndex < stateWriteIndex, "release state must not mark candidate active before burn-in completes")
 })
 
+test("blue-green deploy waits longer for candidate Flyway startup only", () => {
+  const workflow = readFileSync(workflowPath, "utf8")
+  const deployScript = readFileSync(deployScriptPath, "utf8")
+  const candidateHealthBlock = deployScript.slice(
+    deployScript.indexOf("check_candidate_backend_health()"),
+    deployScript.indexOf("check_notification_sse_route()"),
+  )
+
+  assert.match(deployScript, /CANDIDATE_HEALTHCHECK_RETRIES="\$\{CANDIDATE_HEALTHCHECK_RETRIES:-450\}"/)
+  assert.match(deployScript, /CANDIDATE_HEALTHCHECK_RETRIES="\$\(normalize_positive_int "\$\{CANDIDATE_HEALTHCHECK_RETRIES\}" "450"\)"/)
+  assert.match(candidateHealthBlock, /local previous_retries="\$\{HEALTHCHECK_RETRIES\}"/)
+  assert.match(candidateHealthBlock, /HEALTHCHECK_RETRIES="\$\{CANDIDATE_HEALTHCHECK_RETRIES\}"/)
+  assert.match(candidateHealthBlock, /HEALTHCHECK_RETRIES="\$\{previous_retries\}"/)
+  assert.match(
+    workflow,
+    /CANDIDATE_HEALTHCHECK_RETRIES=450 \.\/deploy\/homeserver\/blue_green_deploy\.sh/,
+  )
+})
+
 test("runtime-split memory tuner keeps backend color startup headroom", () => {
   const deployScript = readFileSync(deployScriptPath, "utf8")
   const splitAllocator = deployScript.slice(
@@ -1403,7 +1422,7 @@ test("runtime-split helper backends do not compete with candidate Flyway migrati
   const preCandidateHelperDnsSkipIndex = deployScript.indexOf(
     "skip runtime helper dns check before candidate health: helpers were not prebooted",
   )
-  const candidateHealthIndex = deployScript.indexOf('check_backend_health "${next_backend}"')
+  const candidateHealthIndex = deployScript.indexOf('check_candidate_backend_health "${next_backend}"')
   const helperRestartIndex = deployScript.indexOf('if ! restart_runtime_split_backends_after_candidate_ready "${next_backend}"; then')
   const postRestartHelperDnsIndex = deployScript.indexOf(
     'check_backend_dns_from_caddy "back_read"',
@@ -1451,7 +1470,7 @@ test("runtime-split helper backends do not compete with candidate Flyway migrati
   )
   assert(edgeBootIndex > activeHelperStartIndex, "edge services must start after active-image helpers exist")
   assert(candidateHealthIndex > preCandidateBootEnd, "candidate healthcheck must happen after infra boot")
-  assert.match(deployScript, /if ! check_backend_health "\$\{next_backend\}"; then/)
+  assert.match(deployScript, /if ! check_candidate_backend_health "\$\{next_backend\}"; then/)
   assert.match(deployScript, /candidate backend health failed before cutover: \$\{next_backend\}/)
   assert(helperRestartIndex > candidateHealthIndex, "runtime split helpers must restart after candidate health with explicit failure handling")
   assert(postRestartHelperDnsIndex > helperRestartIndex, "helper DNS checks must run after candidate-backed helper startup")

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -1331,12 +1331,17 @@ test("blue-green deploy waits longer for candidate Flyway startup only", () => {
     deployScript.indexOf("check_candidate_backend_health()"),
     deployScript.indexOf("check_notification_sse_route()"),
   )
+  const blueGreenDeployJob = workflow.slice(
+    workflow.indexOf("  blueGreenDeploy:"),
+    workflow.indexOf("  frontLiveE2E:"),
+  )
 
   assert.match(deployScript, /CANDIDATE_HEALTHCHECK_RETRIES="\$\{CANDIDATE_HEALTHCHECK_RETRIES:-450\}"/)
   assert.match(deployScript, /CANDIDATE_HEALTHCHECK_RETRIES="\$\(normalize_positive_int "\$\{CANDIDATE_HEALTHCHECK_RETRIES\}" "450"\)"/)
   assert.match(candidateHealthBlock, /local previous_retries="\$\{HEALTHCHECK_RETRIES\}"/)
   assert.match(candidateHealthBlock, /HEALTHCHECK_RETRIES="\$\{CANDIDATE_HEALTHCHECK_RETRIES\}"/)
   assert.match(candidateHealthBlock, /HEALTHCHECK_RETRIES="\$\{previous_retries\}"/)
+  assert.match(blueGreenDeployJob, /timeout-minutes:\s*75/)
   assert.match(
     workflow,
     /CANDIDATE_HEALTHCHECK_RETRIES=450 \.\/deploy\/homeserver\/blue_green_deploy\.sh/,

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -1327,14 +1327,17 @@ test("blue-green deploy keeps old backend running during burn-in rollback window
 test("blue-green deploy waits longer for candidate Flyway startup only", () => {
   const workflow = readFileSync(workflowPath, "utf8")
   const deployScript = readFileSync(deployScriptPath, "utf8")
-  const candidateHealthBlock = deployScript.slice(
-    deployScript.indexOf("check_candidate_backend_health()"),
-    deployScript.indexOf("check_notification_sse_route()"),
-  )
-  const blueGreenDeployJob = workflow.slice(
-    workflow.indexOf("  blueGreenDeploy:"),
-    workflow.indexOf("  frontLiveE2E:"),
-  )
+  const candidateStart = deployScript.indexOf("check_candidate_backend_health()")
+  const candidateEnd = deployScript.indexOf("check_notification_sse_route()")
+  assert.notEqual(candidateStart, -1, "candidate health helper marker must exist")
+  assert.notEqual(candidateEnd, -1, "notification route marker must exist")
+  const candidateHealthBlock = deployScript.slice(candidateStart, candidateEnd)
+
+  const deployJobStart = workflow.indexOf("  blueGreenDeploy:")
+  const deployJobEnd = workflow.indexOf("  frontLiveE2E:")
+  assert.notEqual(deployJobStart, -1, "blueGreenDeploy job marker must exist")
+  assert.notEqual(deployJobEnd, -1, "frontLiveE2E job marker must exist")
+  const blueGreenDeployJob = workflow.slice(deployJobStart, deployJobEnd)
 
   assert.match(deployScript, /CANDIDATE_HEALTHCHECK_RETRIES="\$\{CANDIDATE_HEALTHCHECK_RETRIES:-450\}"/)
   assert.match(deployScript, /CANDIDATE_HEALTHCHECK_RETRIES="\$\(normalize_positive_int "\$\{CANDIDATE_HEALTHCHECK_RETRIES\}" "450"\)"/)


### PR DESCRIPTION
## 관련 이슈

close #1052

## 작업 배경

- PR #1055 merge 후 main CI와 Security는 성공했지만 `Deploy to Home Server` run `28028196691`의 `blueGreenDeploy`가 `back_green` candidate readiness timeout으로 실패했습니다.
- 실패 로그에는 이전 원인이던 Flyway advisory lock 오류가 없고, candidate 단독으로 `V20260623.03` concurrent index migration을 수행하는 동안 기본 readiness 대기값 120회가 먼저 끝났습니다.

## 작업 내용

- candidate backend readiness에만 `CANDIDATE_HEALTHCHECK_RETRIES`를 추가해 긴 Flyway migration 동안 premature timeout이 나지 않게 했습니다.
- helper/rollback/burn-in healthcheck는 기존 `HEALTHCHECK_RETRIES` 값을 유지하도록 candidate health wrapper가 retry 값을 호출 후 복원합니다.
- GitHub deploy workflow가 `CANDIDATE_HEALTHCHECK_RETRIES=450`을 명시 전달하도록 고정했습니다.
- `blueGreenDeploy` job timeout을 75분으로 늘려 candidate readiness 최악 대기 중에도 스크립트의 rollback/cleanup 경로가 실행될 수 있게 했습니다.
- env contract test에 candidate 전용 대기 계약과 workflow 전달값 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `bash -n deploy/homeserver/blue_green_deploy.sh`: exit 0
  - `node --test tools/test/env-contract.test.mjs`: 48 pass, 0 fail
  - `git diff --check`: exit 0
  - `bash tools/test/verify-deploy-workflow-classification.sh`: exit 0
  - `back/gradlew -p back ktlintCheck`: BUILD SUCCESSFUL
  - `back/gradlew -p back ciFastCheck`: BUILD SUCCESSFUL
  - `back/gradlew -p back ciFastCheck`: BUILD SUCCESSFUL

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| post-merge CD 실패 재현 | GitHub Actions | `Deploy to Home Server` run 확인 | https://github.com/AquilaXk/aquila-blog/actions/runs/28028196691 | `back_green` readiness 120회 timeout 후 rollback |
| candidate 전용 readiness 대기 계약 | local darwin | `node --test tools/test/env-contract.test.mjs` | command output: 48 pass, 0 fail | 통과 |
| 배포 workflow 분류 | local darwin | `bash tools/test/verify-deploy-workflow-classification.sh` | command output: exit 0 | 통과 |
| backend fast CI 회귀 | local darwin | `back/gradlew -p back ciFastCheck` 2회 | command output: BUILD SUCCESSFUL 2회 | 통과 |
| PR CI/Security | GitHub Actions | PR #1056 checks 확인 | backend-ci, frontend-ci, Security/CodeQL, CodeRabbit pass | 통과 |
| Vercel preview | Vercel | PR #1056 status 확인 | `Deployment rate limited — retry in 24 hours` | 비필수 preview 실패, backend/deploy 변경과 무관 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - candidate backend에만 긴 readiness 대기를 적용하고 helper/rollback/burn-in healthcheck 기본값은 유지한 점
  - workflow가 `CANDIDATE_HEALTHCHECK_RETRIES=450`을 명시 전달하는 점
  - `blueGreenDeploy` job timeout이 candidate readiness 최악 대기 시간보다 크게 설정된 점

## 리스크

- candidate migration이 실제로 실패한 경우 실패 감지가 기존 약 4분에서 최악 약 52분으로 늦어집니다. 적용 범위를 candidate startup으로 제한해 helper와 rollback의 실패 감지는 기존 속도를 유지했고, job timeout은 75분으로 맞춰 cleanup 경로가 실행될 수 있게 했습니다.
- Vercel preview status는 build rate limit로 실패했지만, 이번 PR은 homeserver backend deploy workflow 변경이며 branch protection required check가 아닙니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
