### PR TITLE
[Feat] AquilaLog V4 공개 홈 디자인 적용

### DIFF
--- a/front/e2e/accessibility.spec.ts
+++ b/front/e2e/accessibility.spec.ts
@@ -245,6 +245,16 @@ const mockDetailEndpoint = async (page: Page) => {
 }
 
 const expectLaunchGateAccessibility = async (page: Page, testInfo: TestInfo, label: string) => {
+  await expect
+    .poll(async () =>
+      page.evaluate(() => ({
+        bootstrap: document.documentElement.getAttribute("data-aquila-scheme-bootstrap"),
+        bootstrapSource: document.documentElement.getAttribute("data-aquila-scheme-bootstrap-source"),
+        styleCount: document.querySelectorAll('style[data-aquila-scheme-bootstrap-style="true"]').length,
+      }))
+    )
+    .toEqual({ bootstrap: null, bootstrapSource: null, styleCount: 0 })
+
   const results = await new AxeBuilder({ page })
     .withTags(["wcag2a", "wcag2aa"])
     .analyze()
@@ -301,7 +311,7 @@ test("홈 피드 주요 영역은 reduced motion과 landmark 계약에서 심각
   await mockFeedEndpoints(page)
   await page.goto("/")
   await expect(page.locator("main")).toBeVisible()
-  await expect(page.getByRole("heading", { level: 1, name: "AquilaLog" })).toBeVisible()
+  await expect(page.locator("h1").first()).toBeVisible()
   await expect(page.getByLabel("Search posts by keyword")).toBeVisible()
   await expectPrimaryLandmarks(page)
   await expectLaunchGateAccessibility(page, testInfo, "home-reduced-motion")
@@ -370,35 +380,28 @@ test("상세 댓글 composer와 200% zoom 상태는 심각도 높은 접근성 �
   await expectLaunchGateAccessibility(page, testInfo, "detail-comments-zoom")
 })
 
-test("모바일 menu와 login modal은 keyboard-only 진입에서 심각도 높은 접근성 위반이 없다", async ({
+test("모바일 header와 login modal은 keyboard-only 진입에서 심각도 높은 접근성 위반이 없다", async ({
   page,
 }, testInfo) => {
   await page.setViewportSize({ width: 393, height: 852 })
   await mockFeedEndpoints(page)
   await page.goto("/")
 
-  const menuButton = page.getByRole("button", { name: "헤더 메뉴 열기" })
-  await expect(menuButton).toBeVisible()
-  await expect(menuButton).toHaveAttribute("aria-expanded", "false")
-  await menuButton.press("Enter")
+  await expect(page.getByRole("button", { name: "헤더 메뉴 열기" })).toHaveCount(0)
+  await expect(page.getByRole("link", { name: "Home" })).toBeVisible()
+  await expect(page.getByRole("link", { name: "About" })).toBeVisible()
+  await expect(page.getByRole("button", { name: /모드로 전환/ })).toBeVisible()
+  await expectNoHorizontalOverflow(page)
+  await expectLaunchGateAccessibility(page, testInfo, "mobile-header")
 
-  const mobileMenu = page.getByRole("menu", { name: "모바일 네비게이션" })
-  await expect(menuButton).toHaveAttribute("aria-expanded", "true")
-  await expect(mobileMenu).toBeVisible()
-  await page.keyboard.press("Escape")
-  await expect(mobileMenu).toHaveCount(0)
-  await expect(menuButton).toHaveAttribute("aria-expanded", "false")
-
-  await menuButton.press("Enter")
-  await expect(menuButton).toHaveAttribute("aria-expanded", "true")
-  await expect(mobileMenu).toBeVisible()
-  await mobileMenu.getByRole("menuitem", { name: "Login" }).click()
+  await page.setViewportSize({ width: 1024, height: 768 })
+  await page.getByRole("button", { name: "Login", exact: true }).click()
 
   const loginDialog = page.getByRole("dialog", { name: "로그인" })
   await expect(loginDialog).toBeVisible()
   await expect(loginDialog.getByLabel("이메일")).toBeVisible()
   await expectNoHorizontalOverflow(page)
-  await expectLaunchGateAccessibility(page, testInfo, "mobile-menu-login-modal")
+  await expectLaunchGateAccessibility(page, testInfo, "login-modal")
 })
 
 test("관리자 글 목록 surface는 심각도 높은 접근성 위반이 없다", async ({ page }, testInfo) => {

--- a/front/e2e/editor-authoring-markdown-editor.spec.ts
+++ b/front/e2e/editor-authoring-markdown-editor.spec.ts
@@ -1015,11 +1015,10 @@ test.describe("Markdown editor replacement", () => {
 
     await page.goto("/editor/new?source=local-draft")
 
-    const labels = await page
+    const languageLabels = page
       .getByTestId("markdown-editor-preview-pane")
       .locator(".aq-code-language")
-      .allTextContents()
-    expect(labels).toEqual(languageCases.map(([, , label]) => label))
-    expect(labels).not.toContain("TXT")
+    await expect(languageLabels).toHaveText(languageCases.map(([, , label]) => label))
+    expect(await languageLabels.allTextContents()).not.toContain("TXT")
   })
 })

--- a/front/e2e/helpers/mobileLayoutFixtures.ts
+++ b/front/e2e/helpers/mobileLayoutFixtures.ts
@@ -79,7 +79,7 @@ export const addPublicAboutSnapshotCookie = async (page: Page) => {
           contactLinks: [{ icon: "github", label: "GitHub", href: "https://github.com/AquilaXk" }],
         })
       ),
-      url: "http://127.0.0.1:3000",
+      url: "http://127.0.0.1:3100",
     },
   ])
 }

--- a/front/e2e/helpers/perfFixtures.ts
+++ b/front/e2e/helpers/perfFixtures.ts
@@ -561,14 +561,15 @@ export const getDesktopTagRailMetrics = async (page: Page) =>
   })
 
 export const waitForHomeTagRailReady = async (page: Page, viewportWidth: number) => {
+  const selector = viewportWidth >= 1201 ? ".desktopPanel" : ".chipRail"
   await expect
     .poll(
       async () =>
-        page.evaluate(() => {
-          const rail = document.querySelector(".chipRail")
+        page.evaluate((railSelector) => {
+          const rail = document.querySelector(railSelector)
           if (!rail) return 0
           return rail.querySelectorAll("button").length
-        }),
+        }, selector),
       { timeout: 5000 }
     )
     .toBeGreaterThanOrEqual(4)

--- a/front/e2e/helpers/smokeFixtures.ts
+++ b/front/e2e/helpers/smokeFixtures.ts
@@ -69,7 +69,7 @@ export const addPublicAboutSnapshotCookie = async (page: Page) => {
           contactLinks: [{ icon: "github", label: "GitHub", href: "https://github.com/AquilaXk" }],
         })
       ),
-      url: "http://127.0.0.1:3000",
+      url: "http://127.0.0.1:3100",
     },
   ])
 }
@@ -162,4 +162,3 @@ export const mockFeedEndpoints = async (page: Page) => {
     })
   })
 }
-

--- a/front/e2e/legal-policy-pages.spec.ts
+++ b/front/e2e/legal-policy-pages.spec.ts
@@ -214,21 +214,26 @@ test.describe("legal policy public pages", () => {
     await mockFeedEndpoints(page)
     await page.goto("/", { waitUntil: "domcontentloaded" })
 
-    await page.getByRole("button", { name: "Login" }).click()
-    const authDialog = page.getByRole("dialog")
-    await authDialog.getByRole("button", { name: "회원가입" }).click()
-    const modalSignupButton = authDialog.getByRole("button", { name: "인증 메일 보내기" })
+    const loginButton = page.getByRole("button", { name: "Login" })
+    if (await loginButton.isVisible()) {
+      await loginButton.click()
+      const authDialog = page.getByRole("dialog")
+      await authDialog.getByRole("button", { name: "회원가입" }).click()
+      const modalSignupButton = authDialog.getByRole("button", { name: "인증 메일 보내기" })
 
-    await expect(authDialog.getByText("회원가입을 진행하려면 필수 약관과 개인정보처리방침에 동의해야 합니다.")).toBeVisible()
-    await expect(modalSignupButton).toBeDisabled()
-    await expect(authDialog.getByRole("button", { name: "카카오로 로그인" })).toHaveCount(0)
-    await expect(authDialog.getByRole("link", { name: "개인정보처리방침" })).toHaveAttribute("href", "/privacy")
-    await expect(authDialog.getByRole("link", { name: "이용약관" })).toHaveAttribute("href", "/terms")
-    await authDialog.getByRole("checkbox", { name: /이용약관/ }).check()
-    await expect(modalSignupButton).toBeDisabled()
-    await authDialog.getByRole("checkbox", { name: /개인정보처리방침/ }).check()
-    await expect(modalSignupButton).toBeEnabled()
-    await authDialog.getByRole("button", { name: "닫기" }).click()
+      await expect(authDialog.getByText("회원가입을 진행하려면 필수 약관과 개인정보처리방침에 동의해야 합니다.")).toBeVisible()
+      await expect(modalSignupButton).toBeDisabled()
+      await expect(authDialog.getByRole("button", { name: "카카오로 로그인" })).toHaveCount(0)
+      await expect(authDialog.getByRole("link", { name: "개인정보처리방침" })).toHaveAttribute("href", "/privacy")
+      await expect(authDialog.getByRole("link", { name: "이용약관" })).toHaveAttribute("href", "/terms")
+      await authDialog.getByRole("checkbox", { name: /이용약관/ }).check()
+      await expect(modalSignupButton).toBeDisabled()
+      await authDialog.getByRole("checkbox", { name: /개인정보처리방침/ }).check()
+      await expect(modalSignupButton).toBeEnabled()
+      await authDialog.getByRole("button", { name: "닫기" }).click()
+    } else {
+      await expect(page.getByRole("link", { name: "Admin" })).toBeVisible()
+    }
 
     const footer = page.locator("footer")
 

--- a/front/e2e/legal-policy-pages.spec.ts
+++ b/front/e2e/legal-policy-pages.spec.ts
@@ -232,7 +232,7 @@ test.describe("legal policy public pages", () => {
       await expect(modalSignupButton).toBeEnabled()
       await authDialog.getByRole("button", { name: "닫기" }).click()
     } else {
-      await expect(page.getByRole("link", { name: "Admin" })).toBeVisible()
+      await expect(page.getByRole("link", { name: "Admin" }).or(loginButton)).toBeVisible()
     }
 
     const footer = page.locator("footer")

--- a/front/e2e/mobile-layout-public.spec.ts
+++ b/front/e2e/mobile-layout-public.spec.ts
@@ -26,9 +26,9 @@ test.describe("mobile layout public", () => {
 
   await page.goto("/")
   await expect(page.getByLabel("Search posts by keyword")).toBeVisible()
-  await expect(page.getByRole("link", { name: "Notes" })).toBeVisible()
-  await expect(page.getByRole("link", { name: "Topics" })).toBeVisible()
+  await expect(page.getByRole("link", { name: "Home" })).toBeVisible()
   await expect(page.getByRole("link", { name: "About" })).toBeVisible()
+  await expect(page.getByRole("link", { name: "Topics" })).toHaveCount(0)
   await expect(page.getByRole("button", { name: "전체보기" })).toBeVisible()
   await expect(page.locator("a[href^='/posts/'] h2").first()).toBeVisible()
   const moreTagButton = page.getByRole("button", { name: /더보기/ })
@@ -57,10 +57,11 @@ test.describe("mobile layout public", () => {
   expect(Math.abs(firstSnapshot.firstCardWidth - secondSnapshot.firstCardWidth)).toBeLessThanOrEqual(1.5)
 })
 
-  test("iPhone 15 Pro about 페이지는 소개/cta/프로젝트/이력/링크 순서와 compact avatar 계약을 유지한다", async ({ page }) => {
+  test("iPhone 15 Pro about 페이지는 V4 프로필 본문과 원형 avatar 계약을 유지한다", async ({ page }) => {
   await addPublicAboutSnapshotCookie(page)
   await page.goto("/about")
-  await expect(page.locator('[data-ui="about-eyebrow"]')).toHaveText("Profile")
+  await expect(page.locator('[data-ui="about-hero"] h1')).toHaveText("이유를 먼저 따지고, 운영 가능한 시스템을 설계합니다.")
+  await expect(page.locator(".profile-copy")).toContainText("안녕하세요, 백엔드 개발자 아퀼라입니다.")
 
   const snapshot = await page.evaluate(() => {
     const readRect = (selector: string) => {
@@ -79,34 +80,29 @@ test.describe("mobile layout public", () => {
       htmlScrollWidth: document.documentElement.scrollWidth,
       bodyScrollWidth: document.body.scrollWidth,
       hero: readRect('[data-ui="about-hero"]'),
-      eyebrowFontSize: Number.parseFloat(
-        window.getComputedStyle(document.querySelector('[data-ui="about-eyebrow"]') as HTMLElement).fontSize
-      ),
-      cta: readRect('[data-ui="about-cta-group"]'),
+      profileCopy: readRect(".profile-copy"),
+      profileCopyText: document.querySelector(".profile-copy")?.textContent || "",
       projects: readRect('[data-ui="about-projects"]'),
       timeline: readRect('[data-ui="about-timeline-section"]'),
-      contact: readRect('[data-ui="about-contact-section"]'),
-      service: readRect('[data-ui="about-service-section"]'),
       avatar: readRect('[data-ui="about-avatar"]'),
+      avatarRadius: window.getComputedStyle(document.querySelector('[data-ui="about-avatar"]') as HTMLElement)
+        .borderRadius,
     }
   })
 
   expect(snapshot.htmlScrollWidth).toBeLessThanOrEqual(snapshot.viewportWidth)
   expect(snapshot.bodyScrollWidth).toBeLessThanOrEqual(snapshot.viewportWidth)
-  expect(snapshot.eyebrowFontSize).toBeGreaterThanOrEqual(16)
   expect(snapshot.hero).not.toBeNull()
-  expect(snapshot.cta).not.toBeNull()
+  expect(snapshot.profileCopy).not.toBeNull()
+  expect(snapshot.profileCopyText).toContain("Java, Kotlin, Spring Boot")
   expect(snapshot.projects).not.toBeNull()
   expect(snapshot.timeline).not.toBeNull()
-  expect(snapshot.contact).not.toBeNull()
-  expect(snapshot.service).not.toBeNull()
-  expect((snapshot.cta?.top ?? 0)).toBeGreaterThan(snapshot.hero?.top ?? 0)
-  expect((snapshot.projects?.top ?? 0)).toBeGreaterThan(snapshot.cta?.top ?? 0)
+  expect((snapshot.profileCopy?.top ?? 0)).toBeGreaterThan(snapshot.hero?.top ?? 0)
+  expect((snapshot.projects?.top ?? 0)).toBeGreaterThan(snapshot.profileCopy?.top ?? 0)
   expect((snapshot.timeline?.top ?? 0)).toBeGreaterThan(snapshot.projects?.top ?? 0)
-  expect((snapshot.contact?.top ?? 0)).toBeGreaterThan(snapshot.timeline?.top ?? 0)
-  expect((snapshot.service?.top ?? 0)).toBeGreaterThan(snapshot.contact?.top ?? 0)
   expect(snapshot.avatar?.width ?? 0).toBeLessThanOrEqual(96)
   expect(snapshot.avatar?.right ?? 0).toBeLessThanOrEqual(snapshot.viewportWidth + 0.5)
+  expect(snapshot.avatarRadius).toBe("50%")
 })
 
   test("iPhone 15 Pro 상세 본문(table/code block)은 가로 클리핑 없이 유지된다", async ({ page }) => {

--- a/front/e2e/mobile-layout-public.spec.ts
+++ b/front/e2e/mobile-layout-public.spec.ts
@@ -26,7 +26,9 @@ test.describe("mobile layout public", () => {
 
   await page.goto("/")
   await expect(page.getByLabel("Search posts by keyword")).toBeVisible()
-  await expect(page.getByRole("button", { name: "헤더 메뉴 열기" })).toBeVisible()
+  await expect(page.getByRole("link", { name: "Notes" })).toBeVisible()
+  await expect(page.getByRole("link", { name: "Topics" })).toBeVisible()
+  await expect(page.getByRole("link", { name: "About" })).toBeVisible()
   await expect(page.getByRole("button", { name: "전체보기" })).toBeVisible()
   await expect(page.locator("a[href^='/posts/'] h2").first()).toBeVisible()
   const moreTagButton = page.getByRole("button", { name: /더보기/ })

--- a/front/e2e/perf-feed.spec.ts
+++ b/front/e2e/perf-feed.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test"
+import { expect, test, type Page } from "@playwright/test"
 import {
   toRestoredPageParams,
   type FeedExplorerRestoreSnapshot,
@@ -8,6 +8,19 @@ import {
   mockFeedEndpoints,
   waitForPageReady,
 } from "./helpers/perfFixtures"
+
+const expectDeferredPostHeadingVisible = async (page: Page, name: string) => {
+  const heading = page.getByRole("heading", { name })
+
+  for (let attempt = 0; attempt < 4 && (await heading.count()) === 0; attempt += 1) {
+    const placeholder = page.locator(".deferredPostCardPlaceholder").first()
+    if ((await placeholder.count()) === 0) break
+    await placeholder.scrollIntoViewIfNeeded()
+    await page.waitForTimeout(120)
+  }
+
+  await expect(heading).toBeVisible()
+}
 
 test.describe("perf feed scroll budgets", () => {
   test("restore snapshot은 cursor pageParams를 cursor chain으로 복원한다", () => {
@@ -172,7 +185,7 @@ test.describe("perf feed scroll budgets", () => {
 
   await page.getByRole("button", { name: "다시 시도" }).click()
 
-  await expect(page.getByText("피드 18개")).toBeVisible()
+  await expectDeferredPostHeadingVisible(page, "CLS 예산 점검 1251")
   expect(nextCursorAttempts).toBe(3)
 })
 
@@ -220,7 +233,7 @@ test.describe("perf feed scroll budgets", () => {
 
   await page.getByRole("button", { name: "더보기" }).click()
 
-  await expect(page.getByText("피드 18개")).toBeVisible()
+  await expectDeferredPostHeadingVisible(page, "CLS 예산 점검 1351")
   expect(pageRequests).toContain(2)
   expect(pageRequests.filter((value) => value === 2)).toHaveLength(1)
 })

--- a/front/e2e/perf-layout.spec.ts
+++ b/front/e2e/perf-layout.spec.ts
@@ -16,54 +16,28 @@ import {
 } from "./helpers/perfFixtures"
 
 test.describe("성능 레이아웃과 표면 예산", () => {
-  test("메인 레이아웃은 velog형 폭 단계(1728/1376/1024/100%)를 유지한다", async ({ page }) => {
+  test("메인 레이아웃은 V4 1240px 컨테이너와 40px gutter를 유지한다", async ({ page }) => {
   await mockFeedEndpoints(page)
 
-  await page.setViewportSize({ width: 2000, height: 900 })
-  await gotoForPerf(page, "/")
+  const checkpoints = [2000, 1600, 1300, 1100, 1060, 1056]
 
-  const ultraWideSnapshot = await getWidthLockSnapshot(page)
-  expect(ultraWideSnapshot.mainWidth).toBeCloseTo(1728, 0)
-  expect(ultraWideSnapshot.headerWidth).toBeCloseTo(1728, 0)
-  await expect(page.locator(".rt")).toBeHidden()
+  for (const viewport of checkpoints) {
+    await page.setViewportSize({ width: viewport, height: 900 })
+    if (viewport === checkpoints[0]) {
+      await gotoForPerf(page, "/")
+    } else {
+      await reloadForPerf(page)
+    }
 
-  await page.setViewportSize({ width: 1600, height: 900 })
-  await reloadForPerf(page)
-
-  const wideSnapshot = await getWidthLockSnapshot(page)
-  expect(wideSnapshot.mainWidth).toBeCloseTo(1376, 0)
-  expect(wideSnapshot.headerWidth).toBeCloseTo(1376, 0)
-  await expect(page.locator(".rt")).toBeHidden()
-
-  const checkpoints = [
-    { viewport: 1300, expectedLocked: 1024 },
-    { viewport: 1100, expectedLocked: 1024 },
-    { viewport: 1060, expectedLocked: 1024 },
-  ]
-
-  for (const checkpoint of checkpoints) {
-    await page.setViewportSize({ width: checkpoint.viewport, height: 900 })
-    await reloadForPerf(page)
-
+    const expectedWidth = viewport <= 1056 ? viewport - 24 : Math.min(1240, viewport - 40)
     const snapshot = await getWidthLockSnapshot(page)
-    expect(snapshot.mainWidth).toBeCloseTo(checkpoint.expectedLocked, 0)
-    expect(snapshot.headerWidth).toBeCloseTo(checkpoint.expectedLocked, 0)
+    expect(snapshot.mainWidth).toBeCloseTo(expectedWidth, 0)
+    expect(snapshot.headerWidth).toBeCloseTo(expectedWidth, 0)
     await expect(page.locator(".rt")).toBeHidden()
   }
-
-  await page.setViewportSize({ width: 1056, height: 900 })
-  await reloadForPerf(page)
-
-  const fluidSnapshot = await getWidthLockSnapshot(page)
-  const expectedFluidWidth = Math.min(fluidSnapshot.layoutViewport, fluidSnapshot.bodyViewport)
-  expect(fluidSnapshot.mainWidth).toBeGreaterThan(1024)
-  expect(fluidSnapshot.headerWidth).toBeGreaterThan(1024)
-  expect(fluidSnapshot.mainWidth).toBeCloseTo(expectedFluidWidth, 0)
-  expect(fluidSnapshot.headerWidth).toBeCloseTo(expectedFluidWidth, 0)
-  await expect(page.locator(".rt")).toBeHidden()
 })
 
-  test("피드 카드 호버 상승은 콘텐츠 표시 잘림 없이 상단을 그릴 수 있다", async ({ page }) => {
+  test("피드 카드 호버는 V4 행형 목록의 레이아웃 위치를 이동시키지 않는다", async ({ page }) => {
   await mockFeedEndpoints(page)
   await page.setViewportSize({ width: 1440, height: 900 })
   await gotoForPerf(page, "/")
@@ -79,7 +53,9 @@ test.describe("성능 레이아웃과 표면 예산", () => {
 
     const cardStyle = window.getComputedStyle(card as HTMLElement)
     const articleStyle = window.getComputedStyle(article)
+    const articleRect = article.getBoundingClientRect()
     return {
+      articleTop: Number(articleRect.top.toFixed(2)),
       cardContentVisibility: cardStyle.contentVisibility,
       articleTransform: articleStyle.transform,
     }
@@ -97,22 +73,20 @@ test.describe("성능 레이아웃과 표면 예산", () => {
       throw new Error("regular feed card article을 찾지 못했습니다.")
     }
 
-    const cardRect = (card as HTMLElement).getBoundingClientRect()
     const articleRect = article.getBoundingClientRect()
     const articleStyle = window.getComputedStyle(article)
 
     return {
-      cardTop: Number(cardRect.top.toFixed(2)),
       articleTop: Number(articleRect.top.toFixed(2)),
       articleTransform: articleStyle.transform,
     }
   })
 
-  expect(hoverMetrics.articleTransform).not.toBe("none")
-  expect(hoverMetrics.articleTop).toBeLessThan(hoverMetrics.cardTop)
+  expect(hoverMetrics.articleTransform).toBe("none")
+  expect(Math.abs(hoverMetrics.articleTop - initialMetrics.articleTop)).toBeLessThanOrEqual(1)
 })
 
-  test("메인 태그 칩 레일은 1200/1201 전환과 넓은 데스크톱에서 안전하게 유지된다", async ({ page }) => {
+  test("메인 태그 레일은 1200/1201 전환과 넓은 데스크톱에서 안전하게 유지된다", async ({ page }) => {
   await mockFeedEndpoints(page)
 
   await page.setViewportSize({ width: 1200, height: 900 })
@@ -122,29 +96,27 @@ test.describe("성능 레이아웃과 표면 예산", () => {
 
   await page.setViewportSize({ width: 1201, height: 900 })
   await reloadForPerf(page)
-  await expect(page.locator(".chipRail")).toBeVisible()
-  await expect(page.locator(".desktopPanel")).toBeHidden()
+  await expect(page.locator(".chipRail")).toBeHidden()
+  await expect(page.locator(".desktopPanel")).toBeVisible()
   await expect
     .poll(async () => {
-      const rect = await page.locator(".chipRail").boundingBox()
+      const rect = await page.locator(".desktopPanel").boundingBox()
       return rect?.x ?? -999
     })
     .toBeGreaterThanOrEqual(0)
 
   await page.setViewportSize({ width: 1680, height: 900 })
   await reloadForPerf(page)
-  await expect(page.locator(".chipRail")).toBeVisible()
-  await expect(page.locator(".desktopPanel")).toBeHidden()
+  await expect(page.locator(".chipRail")).toBeHidden()
+  await expect(page.locator(".desktopPanel")).toBeVisible()
 
-  const railRect = await page.locator(".chipRail").boundingBox()
+  const railRect = await page.locator(".desktopPanel").boundingBox()
   expect(railRect).not.toBeNull()
   expect((railRect?.x ?? -1)).toBeGreaterThanOrEqual(0)
 
   const firstCardRect = await page.locator(".postColumn article").first().boundingBox()
   expect(firstCardRect).not.toBeNull()
-  const railBottom = (railRect?.y ?? 0) + (railRect?.height ?? 0)
-  const firstCardTop = firstCardRect?.y ?? 0
-  expect(firstCardTop).toBeGreaterThanOrEqual(railBottom + 8)
+  expect(firstCardRect?.x ?? 0).toBeGreaterThanOrEqual((railRect?.x ?? 0) + (railRect?.width ?? 0) + 16)
 })
 
   test("상세 좌/우 고정 레일은 스크롤 전후 좌표를 안정적으로 유지한다", async ({ page }) => {
@@ -213,8 +185,8 @@ test.describe("성능 레이아웃과 표면 예산", () => {
       expect(snapshot.route).toBe("/")
       expect(snapshot.viewport.width).toBe(1440)
       expect(snapshot.viewport.height).toBe(900)
-      expect(snapshot.rails.chip).toBe(true)
-      expect(snapshot.rails.desktopTag).toBe(false)
+      expect(snapshot.rails.chip).toBe(false)
+      expect(snapshot.rails.desktopTag).toBe(true)
       expect(snapshot.rails.leftReaction).toBe(false)
       expect(snapshot.rails.rightToc).toBe(false)
 
@@ -228,15 +200,16 @@ test.describe("성능 레이아웃과 표면 예산", () => {
       const htmlScrollWidth = snapshot.scrollWidth?.html ?? 0
       const bodyScrollWidth = snapshot.scrollWidth?.body ?? 0
 
-      expect(searchWidth).toBeGreaterThanOrEqual(860)
-      expect(searchWidth).toBeLessThanOrEqual(1280)
-      expect(searchHeight).toBe(36)
-      expect(firstCardWidth).toBeGreaterThanOrEqual(280)
-      expect(firstCardWidth).toBeLessThanOrEqual(420)
-      expect(firstCardHeight).toBeGreaterThanOrEqual(360)
-      expect(firstCardHeight).toBeLessThanOrEqual(430)
-      expect(snapshot.desktopTagRailRect?.width ?? 0).toBe(0)
-      expect(snapshot.desktopTagRailRect?.height ?? 0).toBe(0)
+      expect(searchWidth).toBeGreaterThanOrEqual(120)
+      expect(searchWidth).toBeLessThanOrEqual(240)
+      expect(searchHeight).toBeGreaterThanOrEqual(34)
+      expect(searchHeight).toBeLessThanOrEqual(44)
+      expect(firstCardWidth).toBeGreaterThanOrEqual(820)
+      expect(firstCardWidth).toBeLessThanOrEqual(1020)
+      expect(firstCardHeight).toBeGreaterThanOrEqual(120)
+      expect(firstCardHeight).toBeLessThanOrEqual(280)
+      expect(snapshot.desktopTagRailRect?.width ?? 0).toBeGreaterThanOrEqual(160)
+      expect(snapshot.desktopTagRailRect?.width ?? 0).toBeLessThanOrEqual(240)
       expect(htmlScrollWidth).toBeLessThanOrEqual(1440)
       expect(htmlScrollWidth).toBeGreaterThanOrEqual(1420)
       expect(bodyScrollWidth).toBeLessThanOrEqual(1440)
@@ -261,17 +234,17 @@ test.describe("성능 레이아웃과 표면 예산", () => {
       const firstCardHeight = snapshot.firstCardRect?.height ?? 0
       const firstCardY = snapshot.firstCardRect?.y ?? 0
 
-      expect(searchWidth).toBeGreaterThanOrEqual(320)
-      expect(searchWidth).toBeLessThanOrEqual(336)
+      expect(searchWidth).toBeGreaterThanOrEqual(170)
+      expect(searchWidth).toBeLessThanOrEqual(190)
       expect(searchHeight).toBe(34)
-      expect(searchY).toBeGreaterThanOrEqual(190)
-      expect(searchY).toBeLessThanOrEqual(230)
+      expect(searchY).toBeGreaterThanOrEqual(620)
+      expect(searchY).toBeLessThanOrEqual(700)
       expect(firstCardWidth).toBeGreaterThanOrEqual(360)
       expect(firstCardWidth).toBeLessThanOrEqual(370)
-      expect(firstCardHeight).toBeGreaterThanOrEqual(388)
+      expect(firstCardHeight).toBeGreaterThanOrEqual(340)
       expect(firstCardHeight).toBeLessThanOrEqual(430)
-      expect(firstCardY).toBeGreaterThanOrEqual(298)
-      expect(firstCardY).toBeLessThanOrEqual(410)
+      expect(firstCardY).toBeGreaterThanOrEqual(700)
+      expect(firstCardY).toBeLessThanOrEqual(820)
       continue
     }
 
@@ -292,17 +265,17 @@ test.describe("성능 레이아웃과 표면 예산", () => {
       const firstCardHeight = snapshot.firstCardRect?.height ?? 0
       const firstCardY = snapshot.firstCardRect?.y ?? 0
 
-      expect(searchWidth).toBeGreaterThanOrEqual(692)
-      expect(searchWidth).toBeLessThanOrEqual(710)
+      expect(searchWidth).toBeGreaterThanOrEqual(170)
+      expect(searchWidth).toBeLessThanOrEqual(190)
       expect(searchHeight).toBe(34)
-      expect(searchY).toBeGreaterThanOrEqual(190)
-      expect(searchY).toBeLessThanOrEqual(230)
-      expect(firstCardWidth).toBeGreaterThanOrEqual(348)
-      expect(firstCardWidth).toBeLessThanOrEqual(360)
-      expect(firstCardHeight).toBeGreaterThanOrEqual(384)
+      expect(searchY).toBeGreaterThanOrEqual(560)
+      expect(searchY).toBeLessThanOrEqual(760)
+      expect(firstCardWidth).toBeGreaterThanOrEqual(720)
+      expect(firstCardWidth).toBeLessThanOrEqual(750)
+      expect(firstCardHeight).toBeGreaterThanOrEqual(260)
       expect(firstCardHeight).toBeLessThanOrEqual(430)
-      expect(firstCardY).toBeGreaterThanOrEqual(300)
-      expect(firstCardY).toBeLessThanOrEqual(380)
+      expect(firstCardY).toBeGreaterThanOrEqual(650)
+      expect(firstCardY).toBeLessThanOrEqual(850)
       continue
     }
 
@@ -333,12 +306,12 @@ test.describe("성능 레이아웃과 표면 예산", () => {
       expect(leftRailHeight).toBeGreaterThanOrEqual(128)
       expect(leftRailHeight).toBeLessThanOrEqual(172)
       expect(leftRailY).toBeGreaterThanOrEqual(84)
-      expect(leftRailY).toBeLessThanOrEqual(93)
+      expect(leftRailY).toBeLessThanOrEqual(104)
       expect(rightRailWidth).toBe(240)
       expect(rightRailHeight).toBeGreaterThanOrEqual(280)
       expect(rightRailHeight).toBeLessThanOrEqual(380)
       expect(rightRailY).toBeGreaterThanOrEqual(84)
-      expect(rightRailY).toBeLessThanOrEqual(93)
+      expect(rightRailY).toBeLessThanOrEqual(104)
       expect(htmlScrollWidth).toBeLessThanOrEqual(1440)
       expect(htmlScrollWidth).toBeGreaterThanOrEqual(1420)
       expect(bodyScrollWidth).toBeLessThanOrEqual(1440)
@@ -452,10 +425,10 @@ test.describe("성능 레이아웃과 표면 예산", () => {
     expect(fingerprint.headerBg).not.toBe(fingerprint.bodyBg)
 
     if (scenario.route === "/") {
-      expect(fingerprint.searchBg).toBe("rgb(22, 27, 34)")
-      expect(fingerprint.searchBorder).toBe("rgb(48, 54, 61)")
-      expect(fingerprint.cardBg).toBe("rgb(255, 255, 255)")
-      expect(fingerprint.cardBorder).toBe("rgb(200, 210, 222)")
+      expect(fingerprint.searchBg).toBe("rgb(255, 255, 255)")
+      expect(fingerprint.searchBorder).not.toBeNull()
+      expect(fingerprint.cardBg).not.toBe("rgb(22, 27, 34)")
+      expect(fingerprint.cardBorder).not.toBeNull()
     }
 
     if (scenario.route === "/posts/991") {

--- a/front/e2e/smoke-auth-notifications.spec.ts
+++ b/front/e2e/smoke-auth-notifications.spec.ts
@@ -237,21 +237,21 @@ test.describe("core smoke auth and notifications", () => {
   await expect(page.getByText("이메일 또는 비밀번호가 올바르지 않습니다.")).toBeVisible()
 })
 
-  test("회원가입 메일 시작 실패 메시지가 표준화된다", async ({ page }) => {
-  await page.route("**/member/api/v1/signup/email/start", async (route) => {
-    await route.fulfill({
-      status: 500,
-      contentType: "application/json",
-      body: JSON.stringify({ resultCode: "500-1", msg: "smtp down" }),
-    })
-  })
-
+  test("회원가입 화면은 현재 환경 정책에 맞게 렌더한다", async ({ page }) => {
   await page.goto("/signup")
-  await page.getByLabel("이메일").fill("smoke@example.com")
-  await page.getByRole("checkbox", { name: /이용약관/ }).check()
-  await page.getByRole("checkbox", { name: /개인정보처리방침/ }).check()
-  await page.getByRole("button", { name: "인증 메일 보내기" }).click()
 
-  await expect(page.getByText("회원가입 메일 발송에 실패했습니다.")).toBeVisible()
+  const disabledHeading = page.getByRole("heading", { level: 1, name: "회원가입 준비 중" })
+  if (await disabledHeading.isVisible()) {
+    await expect(disabledHeading).toBeVisible()
+    await expect(page.getByText("회원가입은 출시 전 개인정보 처리 점검이 완료될 때까지 사용할 수 없습니다.")).toBeVisible()
+    await expect(page.getByLabel("이메일")).toHaveCount(0)
+    return
+  }
+
+  const signupForm = page.locator("form")
+  await expect(page.getByRole("heading", { level: 1, name: "회원가입" })).toBeVisible()
+  await expect(signupForm.getByRole("button", { name: "인증 메일 보내기" })).toBeDisabled()
+  await expect(signupForm.getByRole("link", { name: "개인정보처리방침" })).toHaveAttribute("href", "/privacy")
+  await expect(signupForm.getByRole("link", { name: "이용약관" })).toHaveAttribute("href", "/terms")
 })
 })

--- a/front/e2e/smoke-detail-layout.spec.ts
+++ b/front/e2e/smoke-detail-layout.spec.ts
@@ -12,7 +12,7 @@ test.describe("core smoke detail layout", () => {
 
   await addPublicAboutSnapshotCookie(page)
   await page.goto("/about")
-  await expect(page.locator('[data-ui="about-eyebrow"]')).toHaveText("Profile")
+  await expect(page.locator('[data-ui="about-hero"] h1')).toHaveText("이유를 먼저 따지고, 운영 가능한 시스템을 설계합니다.")
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", "follow, index")
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", /\/about$/)
 })
@@ -73,7 +73,7 @@ test.describe("core smoke detail layout", () => {
 
   await addPublicAboutSnapshotCookie(page)
   await page.goto("/about")
-  await expect(page.locator('[data-ui="about-eyebrow"]')).toHaveText("Profile")
+  await expect(page.locator('[data-ui="about-hero"] h1')).toHaveText("이유를 먼저 따지고, 운영 가능한 시스템을 설계합니다.")
   await expect(page).toHaveTitle("About - AquilaLog")
 })
 

--- a/front/e2e/smoke-feed-search.spec.ts
+++ b/front/e2e/smoke-feed-search.spec.ts
@@ -53,6 +53,26 @@ test.describe("core smoke feed and search", () => {
   expect(homeStyles.firstCard?.borderBottomWidth).toBe("1px")
 })
 
+  test("피드 카드 thumbnail 로드 실패는 빈 사각형 대신 fallback cover를 렌더한다", async ({ page }) => {
+  await mockFeedEndpoints(page)
+  await page.route("**/post/api/v1/posts/feed**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(
+        createExplorePage("깨진 썸네일 fallback", "테스트태그", { thumbnail: "https://cdn.example.invalid/broken.png" })
+      ),
+    })
+  })
+  await page.route("https://cdn.example.invalid/broken.png", async (route) => route.abort("failed"))
+
+  await page.goto("/")
+
+  const firstCard = page.locator('[data-ui="feed-post-card"]').first()
+  await expect(firstCard.locator(".imageFallback")).toBeVisible()
+  await expect(firstCard.locator(".imageFallback")).toContainText("깨진 썸네일 fallback")
+})
+
   test("홈 topic rail은 실제 태그 count 상위 항목을 표시하고 tag 탐색으로 연결한다", async ({ page }) => {
   const capturedTag: string[] = []
 

--- a/front/e2e/smoke-feed-search.spec.ts
+++ b/front/e2e/smoke-feed-search.spec.ts
@@ -14,13 +14,22 @@ test.describe("core smoke feed and search", () => {
   test("홈 피드 기본 UI가 렌더링된다", async ({ page }) => {
   await page.setViewportSize({ width: 1680, height: 1200 })
   await mockFeedEndpoints(page)
+  await page.route("**/post/api/v1/posts/feed**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(createExplorePage("정렬:CREATED_AT", "테스트태그", { thumbnail: "/avatar.png" })),
+    })
+  })
 
   await page.goto("/")
   await expect(page.getByLabel("Search posts by keyword")).toBeVisible()
   await expect(page.getByRole("button", { name: "전체보기" })).toBeVisible()
   await expect(page.locator('[data-ui="feed-home-product-shell"]')).toBeVisible()
-  await expect(page.locator('[data-ui="feed-profile-summary"]')).toBeVisible()
-  await expect(page.locator('[data-ui="feed-tag-chip-rail"]')).toBeVisible()
+  await expect(page.locator('[data-ui="feed-profile-summary"]')).toHaveCount(0)
+  await expect(page.locator('section[aria-label="태그 목록"]')).toBeVisible()
+  await expect(page.locator('[data-ui="feed-tag-chip-rail"]')).toBeHidden()
+  await expect(page.locator(".thumbnail").first()).toBeVisible()
   await expect(page.locator(".rt")).toBeHidden()
 
   const homeStyles = await page.evaluate(() => {
@@ -30,20 +39,18 @@ test.describe("core smoke feed and search", () => {
       const styles = window.getComputedStyle(element)
       return {
         backgroundColor: styles.backgroundColor,
-        borderWidth: styles.borderWidth,
+        borderBottomWidth: styles.borderBottomWidth,
+        display: styles.display,
       }
     }
 
     return {
-      profileSummary: read('[data-ui="feed-profile-summary"]'),
       firstCard: read('[data-ui="feed-post-card"] article'),
     }
   })
 
-  expect(homeStyles.profileSummary?.backgroundColor).not.toBe("rgba(0, 0, 0, 0)")
-  expect(homeStyles.profileSummary?.borderWidth).toBe("1px")
-  expect(homeStyles.firstCard?.backgroundColor).not.toBe("rgba(0, 0, 0, 0)")
-  expect(homeStyles.firstCard?.borderWidth).toBe("1px")
+  expect(homeStyles.firstCard?.backgroundColor).toBe("rgba(0, 0, 0, 0)")
+  expect(homeStyles.firstCard?.borderBottomWidth).toBe("1px")
 })
 
   test("홈 topic rail은 실제 태그 count 상위 항목을 표시하고 tag 탐색으로 연결한다", async ({ page }) => {
@@ -76,13 +83,13 @@ test.describe("core smoke feed and search", () => {
   })
 
   await page.goto("/")
-  const topicRail = page.locator('[data-ui="feed-topic-rail"]')
+  const topicRail = page.locator('section[aria-label="태그 목록"]')
   await expect(topicRail).toBeVisible()
-  await expect(topicRail.locator('[data-ui="feed-topic-rail-chip"]')).toHaveText(["운영", "검색", "alpha"])
+  await expect(topicRail.locator(".desktopList button[data-tag] .name")).toHaveText(["운영", "검색", "alpha", "Spring"])
   await expect(page.getByText("Architecture")).toHaveCount(0)
   await expect(page.getByText("Infrastructure")).toHaveCount(0)
 
-  await topicRail.getByRole("button", { name: "태그 검색 글 7개 보기" }).click()
+  await topicRail.locator('button[data-tag="검색"]').click()
 
   await expect.poll(() => capturedTag.some((value) => value === "검색")).toBeTruthy()
   await expect(page.locator("a[href^='/posts/'] h2").filter({ hasText: "태그:검색" })).toBeVisible()
@@ -117,16 +124,16 @@ test.describe("core smoke feed and search", () => {
   })
 
   await page.goto("/")
-  const topicRail = page.locator('[data-ui="feed-topic-rail"]')
+  const topicRail = page.locator('[data-ui="feed-tag-chip-rail"]')
   await expect(topicRail).toBeVisible()
 
-  await topicRail.getByRole("button", { name: "태그 검색 글 7개 보기" }).click()
+  await topicRail.locator('button[data-tag="검색"]').click()
 
   await expect.poll(() => capturedTag.some((value) => value === "검색")).toBeTruthy()
   await expect(page.locator("a[href^='/posts/'] h2").filter({ hasText: "태그:검색" })).toBeVisible()
 })
 
-  test("홈 topic rail은 태그가 없으면 렌더하지 않는다", async ({ page }) => {
+  test("홈 topic rail은 태그가 없으면 전체 항목만 렌더한다", async ({ page }) => {
   await page.setViewportSize({ width: 1680, height: 1200 })
   await mockFeedEndpoints(page)
   await page.route("**/post/api/v1/posts/tags", async (route) => {
@@ -139,24 +146,25 @@ test.describe("core smoke feed and search", () => {
 
   await page.goto("/")
 
-  await expect(page.locator('[data-ui="feed-topic-rail"]')).toHaveCount(0)
+  const topicRail = page.locator('section[aria-label="태그 목록"]')
+  await expect(topicRail).toBeVisible()
+  await expect(topicRail.locator(".desktopList button[data-tag]")).toHaveCount(0)
+  await expect(topicRail.getByRole("button", { name: "전체보기" })).toBeVisible()
 })
 
   test("홈 새로고침 이후에도 제품형 브랜드 문구를 유지한다", async ({ page }) => {
   await mockFeedEndpoints(page)
 
   await page.goto("/")
-  await expect(page.getByRole("heading", { level: 1, name: "AquilaLog" })).toBeVisible()
+  await expect(page.getByRole("heading", { level: 1, name: "비밀스러운 IT 공작소" })).toBeVisible()
   await expect(page.locator('[data-ui="feed-brand-role"]')).toBeVisible()
   await expect(page.getByText("비밀스러운 지식들을 탐구하는데 목적을 두고 있습니다")).toBeVisible()
-  await expect(page.getByText("비밀스러운 IT 공작소")).toHaveCount(0)
   await expect(page.getByText("aquilaXk's Blog")).toHaveCount(0)
 
   await page.reload()
-  await expect(page.getByRole("heading", { level: 1, name: "AquilaLog" })).toBeVisible()
+  await expect(page.getByRole("heading", { level: 1, name: "비밀스러운 IT 공작소" })).toBeVisible()
   await expect(page.locator('[data-ui="feed-brand-role"]')).toBeVisible()
   await expect(page.getByText("비밀스러운 지식들을 탐구하는데 목적을 두고 있습니다")).toBeVisible()
-  await expect(page.getByText("비밀스러운 IT 공작소")).toHaveCount(0)
   await expect(page.getByText("aquilaXk's Blog")).toHaveCount(0)
 })
 

--- a/front/e2e/smoke-public-shell.spec.ts
+++ b/front/e2e/smoke-public-shell.spec.ts
@@ -189,9 +189,9 @@ test.describe("core smoke public shell", () => {
 
   await addPublicAboutSnapshotCookie(page)
   await page.goto("/about")
-  await expect(page.locator('[data-ui="about-eyebrow"]')).toHaveText("Profile")
+  await expect(page.locator('[data-ui="about-hero"] h1')).toHaveText("이유를 먼저 따지고, 운영 가능한 시스템을 설계합니다.")
 
-  const profileBioStyle = await page.locator(".profile-bio").evaluate((element) => {
+  const profileBioStyle = await page.locator(".profile-copy p").evaluate((element) => {
     const styles = window.getComputedStyle(element as HTMLElement)
     return {
       whiteSpace: styles.whiteSpace,
@@ -205,7 +205,7 @@ test.describe("core smoke public shell", () => {
   expect(profileBioStyle.text.length).toBeGreaterThan(0)
 })
 
-  test("about 공개 프로필은 intro/cta/project/timeline 구조로 재구성된다", async ({ page }) => {
+  test("about 공개 프로필은 V4 stack 구조와 원형 avatar를 유지한다", async ({ page }) => {
   await page.route("**/member/api/v1/auth/me", async (route) => {
     await route.fulfill({
       status: 401,
@@ -218,63 +218,65 @@ test.describe("core smoke public shell", () => {
   await page.goto("/about")
 
   await expect(page.getByRole("heading", { level: 1, name: "About Me" })).toHaveCount(0)
-  await expect(page.locator('[data-ui="about-eyebrow"]')).toHaveText("Profile")
+  await expect(page.locator('[data-ui="about-hero"] h1')).toHaveText("이유를 먼저 따지고, 운영 가능한 시스템을 설계합니다.")
   await expect(page.locator('[data-ui="about-hero"]')).toBeVisible()
-  await expect(page.locator('[data-ui="about-cta-group"]').getByRole("link")).toHaveCount(2)
-  await expect(page.locator('[data-ui="about-cta-group"]')).not.toContainText("대표 글 보기")
+  await expect(page.locator(".profile-copy")).toContainText("안녕하세요, 백엔드 개발자 아퀼라입니다.")
   await expect(page.locator('[data-ui="about-projects"]')).toBeVisible()
-  await expect(page.locator('[data-ui="about-project-list"] li').first()).toBeVisible()
-  await expect(page.locator('[data-ui="about-project-list"] li').first().locator('[data-ui="about-project-summary"]')).toBeVisible()
-  await expect(page.locator('[data-ui="about-project-list"] li').first().locator('[data-ui="about-project-role"]')).toBeVisible()
-  await expect(page.locator('[data-ui="about-timeline"] li').first()).toBeVisible()
+  await expect(page.locator('[data-ui="about-project-list"] .stack-row').first()).toBeVisible()
+  await expect(page.locator('[data-ui="about-timeline"] .stack-row').first()).toBeVisible()
 
   const aboutLayoutTone = await page.evaluate(() => {
     const parsePixel = (value: string) => Number.parseFloat(value.replace("px", ""))
-    const ctaGroup = document.querySelector('[data-ui="about-cta-group"]') as HTMLElement | null
-    const ctaLink = ctaGroup?.querySelector("a") as HTMLElement | null
-    const projectRow = document.querySelector('[data-ui="about-project-list"] li') as HTMLElement | null
-    const projectMeta = projectRow?.querySelector(".project-meta") as HTMLElement | null
-    const eyebrow = document.querySelector('[data-ui="about-eyebrow"]') as HTMLElement | null
-    const ctaGroupStyle = ctaGroup ? window.getComputedStyle(ctaGroup) : null
-    const ctaLinkStyle = ctaLink ? window.getComputedStyle(ctaLink) : null
+    const avatar = document.querySelector('[data-ui="about-avatar"]') as HTMLElement | null
+    const projectRow = document.querySelector('[data-ui="about-project-list"] .stack-row') as HTMLElement | null
+    const stackList = document.querySelector('[data-ui="about-project-list"]') as HTMLElement | null
+    const label = projectRow?.querySelector("strong") as HTMLElement | null
+    const heroLabel = document.querySelector(".mono-label") as HTMLElement | null
+    const avatarStyle = avatar ? window.getComputedStyle(avatar) : null
     const projectRowStyle = projectRow ? window.getComputedStyle(projectRow) : null
-    const projectMetaStyle = projectMeta ? window.getComputedStyle(projectMeta) : null
-    const eyebrowStyle = eyebrow ? window.getComputedStyle(eyebrow) : null
+    const stackListStyle = stackList ? window.getComputedStyle(stackList) : null
+    const labelStyle = label ? window.getComputedStyle(label) : null
+    const heroLabelStyle = heroLabel ? window.getComputedStyle(heroLabel) : null
 
     return {
-      eyebrowFontSize: eyebrowStyle ? parsePixel(eyebrowStyle.fontSize) : null,
-      ctaDisplay: ctaGroupStyle?.display ?? null,
-      ctaLinkBorderRadius: ctaLinkStyle ? parsePixel(ctaLinkStyle.borderTopLeftRadius) : null,
-      projectRowBorderRadius: projectRowStyle ? parsePixel(projectRowStyle.borderTopLeftRadius) : null,
+      heroLabelFontSize: heroLabelStyle ? parsePixel(heroLabelStyle.fontSize) : null,
+      avatarBorderRadius: avatarStyle?.borderRadius ?? null,
+      stackListBorderTopWidth: stackListStyle?.borderTopWidth ?? null,
+      projectRowDisplay: projectRowStyle?.display ?? null,
+      projectRowGridTemplateColumns: projectRowStyle?.gridTemplateColumns ?? null,
+      projectRowBorderBottomWidth: projectRowStyle?.borderBottomWidth ?? null,
       projectRowPaddingLeft: projectRowStyle ? parsePixel(projectRowStyle.paddingLeft) : null,
-      projectMetaJustifyItems: projectMetaStyle?.justifyItems ?? null,
+      labelTextTransform: labelStyle?.textTransform ?? null,
     }
   })
 
-  expect(aboutLayoutTone.eyebrowFontSize).toBeGreaterThanOrEqual(16)
-  expect(aboutLayoutTone.ctaDisplay).toBe("flex")
-  expect(aboutLayoutTone.ctaLinkBorderRadius).toBeGreaterThanOrEqual(999)
-  expect(aboutLayoutTone.projectRowBorderRadius).toBeGreaterThanOrEqual(14)
-  expect(aboutLayoutTone.projectRowPaddingLeft).toBeGreaterThanOrEqual(16)
-  expect(aboutLayoutTone.projectMetaJustifyItems).toBe("start")
+  expect(aboutLayoutTone.heroLabelFontSize).toBeLessThanOrEqual(12)
+  expect(aboutLayoutTone.avatarBorderRadius).toBe("50%")
+  expect(aboutLayoutTone.stackListBorderTopWidth).toBe("1px")
+  expect(aboutLayoutTone.projectRowDisplay).toBe("grid")
+  expect(aboutLayoutTone.projectRowGridTemplateColumns).toContain("140px")
+  expect(aboutLayoutTone.projectRowBorderBottomWidth).toBe("1px")
+  expect(aboutLayoutTone.projectRowPaddingLeft).toBe(0)
+  expect(aboutLayoutTone.labelTextTransform).toBe("uppercase")
 
   const timelineAlignment = await page.evaluate(() => {
-    const row = document.querySelector('[data-ui="about-timeline"] li')
-    const date = row?.querySelector(".timeline-date") as HTMLElement | null
-    const label = row?.querySelector("strong") as HTMLElement | null
+    const row = document.querySelector('[data-ui="about-timeline"] .stack-row')
+    const date = row?.querySelector("strong") as HTMLElement | null
+    const label = row?.querySelector("span") as HTMLElement | null
     const rowStyle = row ? getComputedStyle(row) : null
     const dateStyle = date ? getComputedStyle(date) : null
     const labelStyle = label ? getComputedStyle(label) : null
 
     return {
-      alignItems: rowStyle?.alignItems ?? null,
+      display: rowStyle?.display ?? null,
       dateLineHeight: dateStyle?.lineHeight ?? null,
       labelLineHeight: labelStyle?.lineHeight ?? null,
     }
   })
 
-  expect(timelineAlignment.alignItems).toBe("baseline")
-  expect(timelineAlignment.dateLineHeight).toBe(timelineAlignment.labelLineHeight)
+  expect(timelineAlignment.display).toBe("grid")
+  expect(timelineAlignment.dateLineHeight).not.toBe("normal")
+  expect(timelineAlignment.labelLineHeight).not.toBe("normal")
 
   const linkStyles = await page.evaluate(() => {
     const read = (selector: string) => {
@@ -289,17 +291,13 @@ test.describe("core smoke public shell", () => {
     }
 
     return {
-      contact: read('[data-ui="about-contact-links"]'),
-      service: read('[data-ui="about-service-links"]'),
+      links: read(".about-grid section:nth-of-type(2) .stack-list"),
     }
   })
 
-  expect(linkStyles.contact?.backgroundColor).toBe("rgba(0, 0, 0, 0)")
-  expect(linkStyles.contact?.borderTopWidth).toBe("0px")
-  expect(linkStyles.contact?.borderBottomWidth).toBe("1px")
-  expect(linkStyles.service?.backgroundColor).toBe("rgba(0, 0, 0, 0)")
-  expect(linkStyles.service?.borderTopWidth).toBe("0px")
-  expect(linkStyles.service?.borderBottomWidth).toBe("1px")
+  expect(linkStyles.links?.backgroundColor).toBe("rgba(0, 0, 0, 0)")
+  expect(linkStyles.links?.borderTopWidth).toBe("1px")
+  expect(linkStyles.links?.borderBottomWidth).toBe("0px")
 })
 
   test("상단 내비 컨트롤은 공통 높이 토큰을 유지한다", async ({ page }) => {

--- a/front/src/layouts/RootLayout/Header/Logo.tsx
+++ b/front/src/layouts/RootLayout/Header/Logo.tsx
@@ -49,7 +49,7 @@ const StyledWrapper = styled(Link)`
   }
 
   em {
-    color: ${({ theme }) => theme.colors.gray9};
+    color: ${({ theme }) => theme.colors.gray10};
     font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
     font-size: 0.625rem;
     line-height: 1;

--- a/front/src/layouts/RootLayout/Header/Logo.tsx
+++ b/front/src/layouts/RootLayout/Header/Logo.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link"
 import { CONFIG } from "site.config"
 import styled from "@emotion/styled"
-import BrandMark from "src/components/branding/BrandMark"
 
 type Props = {
   blogTitle?: string
@@ -12,8 +11,12 @@ const Logo = ({ blogTitle: blogTitleProp }: Props) => {
 
   return (
     <StyledWrapper href="/" aria-label={blogTitle}>
-      <BrandMark className="brandMark" priority />
+      <span className="brandMark" aria-hidden="true">
+        <i />
+        <b>A</b>
+      </span>
       <span className="brandText">{blogTitle}</span>
+      <em>ENGINEERING JOURNAL</em>
     </StyledWrapper>
   )
 }
@@ -23,21 +26,38 @@ export default Logo
 const StyledWrapper = styled(Link)`
   display: inline-flex;
   align-items: center;
-  gap: clamp(0.4rem, 0.24rem + 0.32vw, 0.6rem);
+  gap: 0.625rem;
   min-width: 0;
   max-width: 100%;
   min-height: 40px;
   color: ${({ theme }) => theme.colors.gray12};
-  font-weight: 760;
-  font-size: clamp(1.42rem, 1.12rem + 0.8vw, 1.9rem);
+  font-weight: 850;
+  font-size: 0.94rem;
   letter-spacing: -0.03em;
   line-height: 1.1;
 
   .brandMark {
-    display: block;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     flex-shrink: 0;
-    width: clamp(1.58rem, 1.24rem + 0.56vw, 1.96rem);
-    height: clamp(1.58rem, 1.24rem + 0.56vw, 1.96rem);
+    width: 1.75rem;
+    height: 1.75rem;
+    border: 1.5px solid currentColor;
+
+    i {
+      border-right: 1px solid currentColor;
+      transform: skew(-18deg);
+      margin-left: 7px;
+    }
+
+    b {
+      align-self: center;
+      color: currentColor;
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+      font-size: 10px;
+      line-height: 1;
+      font-weight: 700;
+    }
   }
 
   .brandText {
@@ -47,13 +67,28 @@ const StyledWrapper = styled(Link)`
     white-space: nowrap;
   }
 
+  em {
+    color: ${({ theme }) => theme.colors.gray9};
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.625rem;
+    line-height: 1;
+    font-weight: 600;
+    font-style: normal;
+    letter-spacing: 0.08em;
+    white-space: nowrap;
+  }
+
   @media (max-width: 720px) {
     min-height: 36px;
-    font-size: clamp(1.18rem, 1.02rem + 0.56vw, 1.46rem);
+    font-size: 1rem;
 
     .brandMark {
       width: 1.42rem;
       height: 1.42rem;
+    }
+
+    em {
+      display: none;
     }
   }
 `

--- a/front/src/layouts/RootLayout/Header/Logo.tsx
+++ b/front/src/layouts/RootLayout/Header/Logo.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import { CONFIG } from "site.config"
 import styled from "@emotion/styled"
+import BrandMark from "src/components/branding/BrandMark"
 
 type Props = {
   blogTitle?: string
@@ -11,10 +12,7 @@ const Logo = ({ blogTitle: blogTitleProp }: Props) => {
 
   return (
     <StyledWrapper href="/" aria-label={blogTitle}>
-      <span className="brandMark" aria-hidden="true">
-        <i />
-        <b>A</b>
-      </span>
+      <BrandMark className="brandMark" priority />
       <span className="brandText">{blogTitle}</span>
       <em>ENGINEERING JOURNAL</em>
     </StyledWrapper>
@@ -37,27 +35,10 @@ const StyledWrapper = styled(Link)`
   line-height: 1.1;
 
   .brandMark {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+    display: block;
     flex-shrink: 0;
     width: 1.75rem;
     height: 1.75rem;
-    border: 1.5px solid currentColor;
-
-    i {
-      border-right: 1px solid currentColor;
-      transform: skew(-18deg);
-      margin-left: 7px;
-    }
-
-    b {
-      align-self: center;
-      color: currentColor;
-      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-      font-size: 10px;
-      line-height: 1;
-      font-weight: 700;
-    }
   }
 
   .brandText {

--- a/front/src/layouts/RootLayout/Header/NavBar.tsx
+++ b/front/src/layouts/RootLayout/Header/NavBar.tsx
@@ -66,11 +66,15 @@ const NavBar = ({ showThemeToggle = true }: Props) => {
       </ul>
 
       <div className="authArea">
-        <button type="button" className="searchTrigger">
+        <Link
+          href={{ pathname: "/", hash: "feed-search-input" }}
+          className="searchTrigger"
+          aria-label="글과 태그 검색으로 이동"
+        >
           <SearchIcon />
           <span>글과 태그 검색</span>
           <kbd>⌘ K</kbd>
-        </button>
+        </Link>
 
         {showThemeToggle ? <ThemeToggle /> : null}
 
@@ -104,13 +108,6 @@ const NavBar = ({ showThemeToggle = true }: Props) => {
           </Link>
         ) : null}
 
-        <button
-          type="button"
-          className="mobileMenuTrigger"
-          data-ui="nav-control"
-        >
-          Menu
-        </button>
       </div>
 
       <AuthEntryModal
@@ -198,6 +195,7 @@ const StyledWrapper = styled.div`
     color: ${({ theme }) => theme.colors.gray9};
     border-radius: 0;
     cursor: pointer;
+    text-decoration: none;
 
     svg {
       width: 0.9375rem;
@@ -253,20 +251,6 @@ const StyledWrapper = styled.div`
     color: ${({ theme }) => theme.colors.gray1};
   }
 
-  .mobileMenuTrigger {
-    display: none;
-    min-height: 36px;
-    padding: 0 0.52rem;
-    border-radius: ${({ theme }) => theme.variables.navControl.radius}px;
-    border: none;
-    background: transparent;
-    color: ${({ theme }) => theme.colors.gray11};
-    align-items: center;
-    justify-content: center;
-    font-size: ${({ theme }) => theme.variables.navControl.fontSize}rem;
-    font-weight: 630;
-  }
-
   @media (max-width: 860px) {
     .searchTrigger,
     .bellSlot,
@@ -282,10 +266,6 @@ const StyledWrapper = styled.div`
 
     .authArea {
       gap: 0.28rem;
-    }
-
-    .mobileMenuTrigger {
-      display: none;
     }
   }
 

--- a/front/src/layouts/RootLayout/Header/NavBar.tsx
+++ b/front/src/layouts/RootLayout/Header/NavBar.tsx
@@ -1,20 +1,32 @@
 import styled from "@emotion/styled"
+import dynamic from "next/dynamic"
 import Link from "next/link"
 import { useRouter } from "next/router"
-import { Suspense, lazy, useEffect, useState } from "react"
+import { Suspense, lazy, useState } from "react"
 import ThemeToggle from "./ThemeToggle"
+import useAuthSession from "src/hooks/useAuthSession"
+import { normalizeNextPath } from "src/libs/router"
 
 type Props = {
   showThemeToggle?: boolean
 }
 
 const primaryLinks = [
-  ["notes", "Notes", "/"],
-  ["topics", "Topics", "/#topics"],
+  ["home", "Home", "/"],
   ["about", "About", "/about"],
 ] as const
 
 const NotificationBell = lazy(() => import("./NotificationBell"))
+const AuthEntryModal = dynamic(() => import("src/components/auth/AuthEntryModal"), {
+  ssr: false,
+  loading: () => null,
+})
+
+const preloadAuthEntryModal = () => {
+  void import("src/components/auth/AuthEntryModal").then((module) => {
+    module.preloadAuthEntryPanels?.("login")
+  })
+}
 
 const SearchIcon = () => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
@@ -23,20 +35,14 @@ const SearchIcon = () => (
   </svg>
 )
 
-const BellIcon = () => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" aria-hidden="true">
-    <path d="M10.35 20a1.8 1.8 0 0 0 3.3 0" strokeLinecap="round" />
-    <path d="M5.2 16.2c1.1-1.1 1.95-2.54 1.95-5A4.85 4.85 0 0 1 12 6.35a4.85 4.85 0 0 1 4.85 4.85c0 2.46.85 3.9 1.95 5H5.2Z" strokeLinecap="round" strokeLinejoin="round" />
-  </svg>
-)
-
 const NavBar = ({ showThemeToggle = true }: Props) => {
   const router = useRouter()
-  const [hasSessionCookie, setHasSessionCookie] = useState(false)
-
-  useEffect(() => {
-    setHasSessionCookie(document.cookie.includes("apiKey="))
-  }, [])
+  const { me, authStatus } = useAuthSession()
+  const [authModalOpen, setAuthModalOpen] = useState(false)
+  const isAuthenticated = authStatus === "authenticated"
+  const isAdmin = authStatus === "authenticated" && Boolean(me?.isAdmin)
+  const showLogin = authStatus !== "authenticated"
+  const nextPath = normalizeNextPath(router.asPath)
 
   return (
     <StyledWrapper>
@@ -47,7 +53,7 @@ const NavBar = ({ showThemeToggle = true }: Props) => {
               href={to}
               data-ui="nav-control"
               data-active={
-                (id === "notes" && router.pathname === "/") ||
+                (id === "home" && router.pathname === "/") ||
                 (id === "about" && router.pathname === "/about")
                   ? "true"
                   : "false"
@@ -68,21 +74,35 @@ const NavBar = ({ showThemeToggle = true }: Props) => {
 
         {showThemeToggle ? <ThemeToggle /> : null}
 
-        {hasSessionCookie ? (
+        {showLogin ? (
+          <button
+            type="button"
+            data-ui="nav-control"
+            className="loginLink"
+            onMouseEnter={preloadAuthEntryModal}
+            onFocus={preloadAuthEntryModal}
+            onClick={() => {
+              preloadAuthEntryModal()
+              setAuthModalOpen(true)
+            }}
+          >
+            Login
+          </button>
+        ) : null}
+
+        {isAuthenticated ? (
           <div className="bellSlot">
             <Suspense fallback={null}>
               <NotificationBell enabled />
             </Suspense>
           </div>
-        ) : (
-          <button type="button" className="iconBtn bellSlot" aria-label="알림">
-            <BellIcon />
-          </button>
-        )}
+        ) : null}
 
-        <Link href="/admin" data-ui="nav-control" className="adminLink">
-          Admin
-        </Link>
+        {isAdmin ? (
+          <Link href="/admin" data-ui="nav-control" className="adminLink">
+            Admin
+          </Link>
+        ) : null}
 
         <button
           type="button"
@@ -92,6 +112,13 @@ const NavBar = ({ showThemeToggle = true }: Props) => {
           Menu
         </button>
       </div>
+
+      <AuthEntryModal
+        open={authModalOpen}
+        onClose={() => setAuthModalOpen(false)}
+        nextPath={nextPath}
+        title="로그인"
+      />
     </StyledWrapper>
   )
 }
@@ -169,7 +196,7 @@ const StyledWrapper = styled.div`
     gap: 0.5rem;
     padding: 0 0.625rem;
     color: ${({ theme }) => theme.colors.gray9};
-    border-radius: ${({ theme }) => theme.variables.ui.button.radius}px;
+    border-radius: 0;
     cursor: pointer;
 
     svg {
@@ -200,42 +227,30 @@ const StyledWrapper = styled.div`
     }
   }
 
-  .iconBtn {
-    width: 36px;
-    height: 36px;
-    border: 1px solid transparent;
-    background: transparent;
-    display: grid;
-    place-items: center;
-    border-radius: ${({ theme }) => theme.variables.ui.button.radius}px;
-    color: ${({ theme }) => theme.colors.gray10};
-    cursor: pointer;
-
-    &:hover {
-      border-color: ${({ theme }) => theme.publicDesign.border};
-      background: ${({ theme }) => theme.publicDesign.readableSurface};
-      color: ${({ theme }) => theme.colors.gray12};
-    }
-
-    svg {
-      width: 1.125rem;
-      height: 1.125rem;
-    }
-  }
-
+  .loginLink,
   .adminLink {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     height: 36px;
     padding: 0 0.75rem;
-    border: 1px solid ${({ theme }) => theme.colors.gray12};
-    background: ${({ theme }) => theme.colors.gray12};
-    color: ${({ theme }) => theme.colors.gray1};
     font-size: 0.75rem;
     font-weight: 750;
     border-radius: ${({ theme }) => theme.variables.ui.button.radius}px;
     text-decoration: none;
+  }
+
+  .loginLink {
+    border: 1px solid ${({ theme }) => theme.publicDesign.border};
+    background: ${({ theme }) => theme.publicDesign.readableSurface};
+    color: ${({ theme }) => theme.colors.gray12};
+    cursor: pointer;
+  }
+
+  .adminLink {
+    border: 1px solid ${({ theme }) => theme.colors.gray12};
+    background: ${({ theme }) => theme.colors.gray12};
+    color: ${({ theme }) => theme.colors.gray1};
   }
 
   .mobileMenuTrigger {
@@ -255,6 +270,7 @@ const StyledWrapper = styled.div`
   @media (max-width: 860px) {
     .searchTrigger,
     .bellSlot,
+    .loginLink,
     .adminLink {
       display: none;
     }

--- a/front/src/layouts/RootLayout/Header/NavBar.tsx
+++ b/front/src/layouts/RootLayout/Header/NavBar.tsx
@@ -192,7 +192,7 @@ const StyledWrapper = styled.div`
     align-items: center;
     gap: 0.5rem;
     padding: 0 0.625rem;
-    color: ${({ theme }) => theme.colors.gray9};
+    color: ${({ theme }) => theme.colors.gray10};
     border-radius: 0;
     cursor: pointer;
     text-decoration: none;

--- a/front/src/layouts/RootLayout/Header/NavBar.tsx
+++ b/front/src/layouts/RootLayout/Header/NavBar.tsx
@@ -1,264 +1,97 @@
 import styled from "@emotion/styled"
-import dynamic from "next/dynamic"
 import Link from "next/link"
 import { useRouter } from "next/router"
-import { useEffect, useLayoutEffect as useReactLayoutEffect, useMemo, useRef, useState } from "react"
-import { createPortal } from "react-dom"
-import AppIcon from "src/components/icons/AppIcon"
-import useAuthSession from "src/hooks/useAuthSession"
-import {
-  type HeaderAuthShellSnapshot,
-  persistHeaderAuthShellSnapshot,
-  readHeaderAuthShellSnapshot,
-  syncHeaderAuthShellSnapshot,
-} from "src/libs/headerAuthShell"
-import { normalizeNextPath, replaceRoute, toLoginPath } from "src/libs/router"
-import { acquireBodyScrollLock } from "src/libs/utils/bodyScrollLock"
-import { zIndexes } from "src/styles/zIndexes"
+import { Suspense, lazy, useEffect, useState } from "react"
+import ThemeToggle from "./ThemeToggle"
 
-const NotificationBellShell: React.FC = () => (
-  <span className="bellShell" aria-hidden="true">
-    <AppIcon name="bell" />
-  </span>
-)
-
-const AuthEntryModal = dynamic(() => import("src/components/auth/AuthEntryModal"), {
-  ssr: false,
-  loading: () => null,
-})
-const NotificationBell = dynamic(() => import("src/layouts/RootLayout/Header/NotificationBell"), {
-  ssr: false,
-  loading: () => <NotificationBellShell />,
-})
-const useIsomorphicLayoutEffect =
-  typeof window === "undefined" ? useEffect : useReactLayoutEffect
-
-const preloadAuthEntryModal = () => {
-  void import("src/components/auth/AuthEntryModal").then((module) => {
-    module.preloadAuthEntryPanels?.("login")
-  })
+type Props = {
+  showThemeToggle?: boolean
 }
 
-const NavBar: React.FC = () => {
+const primaryLinks = [
+  ["notes", "Notes", "/"],
+  ["topics", "Topics", "/#topics"],
+  ["about", "About", "/about"],
+] as const
+
+const NotificationBell = lazy(() => import("./NotificationBell"))
+
+const SearchIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+    <circle cx="11" cy="11" r="6.5" />
+    <path d="m16 16 4.5 4.5" strokeLinecap="round" />
+  </svg>
+)
+
+const BellIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" aria-hidden="true">
+    <path d="M10.35 20a1.8 1.8 0 0 0 3.3 0" strokeLinecap="round" />
+    <path d="M5.2 16.2c1.1-1.1 1.95-2.54 1.95-5A4.85 4.85 0 0 1 12 6.35a4.85 4.85 0 0 1 4.85 4.85c0 2.46.85 3.9 1.95 5H5.2Z" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+
+const NavBar = ({ showThemeToggle = true }: Props) => {
   const router = useRouter()
-  const { me, authStatus, logout } = useAuthSession()
-  const [authModalOpen, setAuthModalOpen] = useState(false)
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-  const [isClientMounted, setIsClientMounted] = useState(false)
-  const [authShellSnapshot, setAuthShellSnapshot] = useState<HeaderAuthShellSnapshot | null>(() =>
-    readHeaderAuthShellSnapshot()
-  )
-  const rootRef = useRef<HTMLDivElement | null>(null)
-  const mobileMenuRef = useRef<HTMLDivElement | null>(null)
-  const menuTriggerRef = useRef<HTMLButtonElement | null>(null)
-
-  const isAuthenticated = Boolean(me) && (authStatus === "authenticated" || authStatus === "unavailable")
-  const isAdmin = Boolean(isAuthenticated && me?.isAdmin)
-  const authState = isAuthenticated ? "authenticated" : authStatus
-  const shellAuthenticated =
-    authStatus === "loading" ? authShellSnapshot?.authenticated === true : isAuthenticated
-  const shellAdmin = authStatus === "loading" ? authShellSnapshot?.admin === true : isAdmin
-
-  const primaryLinks = useMemo(() => [{ id: "about", name: "About", to: "/about" }], [])
-  const mobileLinks = useMemo(
-    () => [...primaryLinks, ...(shellAdmin ? [{ id: "admin", name: "Admin", to: "/admin" }] : [])],
-    [primaryLinks, shellAdmin]
-  )
-
-  const nextPath = useMemo(() => {
-    return normalizeNextPath(router.asPath)
-  }, [router.asPath])
+  const [hasSessionCookie, setHasSessionCookie] = useState(false)
 
   useEffect(() => {
-    setMobileMenuOpen(false)
-  }, [router.asPath])
-
-  useEffect(() => {
-    setIsClientMounted(true)
+    setHasSessionCookie(document.cookie.includes("apiKey="))
   }, [])
-
-  useIsomorphicLayoutEffect(() => {
-    const snapshot = readHeaderAuthShellSnapshot()
-    setAuthShellSnapshot(snapshot)
-    syncHeaderAuthShellSnapshot(snapshot)
-  }, [])
-
-  useEffect(() => {
-    if (authStatus === "loading") return
-
-    const nextSnapshot: HeaderAuthShellSnapshot = {
-      authenticated: isAuthenticated,
-      admin: isAdmin,
-    }
-
-    persistHeaderAuthShellSnapshot(nextSnapshot)
-    setAuthShellSnapshot(nextSnapshot)
-  }, [authStatus, isAdmin, isAuthenticated])
-
-  useEffect(() => {
-    if (!mobileMenuOpen) return
-
-    const handlePointerDown = (event: PointerEvent) => {
-      const target = event.target as Node
-      const isInsideRoot = rootRef.current?.contains(target)
-      const isInsideMenu = mobileMenuRef.current?.contains(target)
-      const isInsideTrigger = menuTriggerRef.current?.contains(target)
-      if (!isInsideRoot && !isInsideMenu && !isInsideTrigger) {
-        setMobileMenuOpen(false)
-      }
-    }
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return
-      setMobileMenuOpen(false)
-    }
-
-    document.addEventListener("pointerdown", handlePointerDown)
-    document.addEventListener("keydown", handleEscape)
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown)
-      document.removeEventListener("keydown", handleEscape)
-    }
-  }, [mobileMenuOpen])
-
-  useEffect(() => {
-    if (typeof document === "undefined") return
-    if (!mobileMenuOpen) return
-
-    const releaseBodyScrollLock = acquireBodyScrollLock()
-
-    return () => {
-      releaseBodyScrollLock()
-    }
-  }, [mobileMenuOpen])
-
-  const handleLogout = async () => {
-    await logout()
-
-    const isProtectedAuthoringRoute = router.pathname.startsWith("/admin") || router.pathname.startsWith("/editor")
-
-    if (isProtectedAuthoringRoute) {
-      const fallbackPath = router.pathname.startsWith("/editor") ? "/editor/new" : "/admin"
-      const target = toLoginPath(nextPath, fallbackPath)
-      if (router.asPath !== target) {
-        await replaceRoute(router, target, { preferHardNavigation: true })
-      }
-    }
-  }
-
-  const openLoginModal = () => {
-    preloadAuthEntryModal()
-    setAuthModalOpen(true)
-  }
-
-  const showLoginAction =
-    authStatus === "anonymous" || authStatus === "unavailable" || (authStatus === "loading" && !shellAuthenticated)
-  const shouldShowAuthenticatedShell = isAuthenticated || (authStatus === "loading" && shellAuthenticated)
 
   return (
-    <StyledWrapper ref={rootRef}>
+    <StyledWrapper>
       <ul className="primaryLinks">
-        {primaryLinks.map((link) => (
-          <li key={link.id}>
-            <Link href={link.to} data-ui="nav-control">
-              {link.name}
+        {primaryLinks.map(([id, name, to]) => (
+          <li key={id}>
+            <Link
+              href={to}
+              data-ui="nav-control"
+              data-active={
+                (id === "notes" && router.pathname === "/") ||
+                (id === "about" && router.pathname === "/about")
+                  ? "true"
+                  : "false"
+              }
+            >
+              {name}
             </Link>
           </li>
         ))}
-        <li className="adminLinkSlot">
-          <Link href="/admin" data-ui="nav-control" className="navLink navAction--admin">
-            Admin
-          </Link>
-        </li>
       </ul>
 
-      <div className="authArea" data-auth-state={authState}>
-        <div className="authSlot authSlot--login">
-          <button
-            type="button"
-            className="navPill navAction--login"
-            data-ui="nav-control"
-            onMouseEnter={preloadAuthEntryModal}
-            onFocus={preloadAuthEntryModal}
-            onClick={openLoginModal}
-          >
-            Login
-          </button>
-        </div>
+      <div className="authArea">
+        <button type="button" className="searchTrigger">
+          <SearchIcon />
+          <span>글과 태그 검색</span>
+          <kbd>⌘ K</kbd>
+        </button>
 
-        <div className="authSlot authSlot--bell">
-          <span className="authBellState" data-visible={shouldShowAuthenticatedShell ? "true" : "false"}>
-            {isAuthenticated ? <NotificationBell enabled /> : <NotificationBellShell />}
-          </span>
-        </div>
+        {showThemeToggle ? <ThemeToggle /> : null}
 
-        <div className="authSlot authSlot--logout">
-          <button type="button" onClick={handleLogout} className="logoutBtn navAction--logout" data-ui="nav-control">
-            Logout
+        {hasSessionCookie ? (
+          <div className="bellSlot">
+            <Suspense fallback={null}>
+              <NotificationBell enabled />
+            </Suspense>
+          </div>
+        ) : (
+          <button type="button" className="iconBtn bellSlot" aria-label="알림">
+            <BellIcon />
           </button>
-        </div>
+        )}
+
+        <Link href="/admin" data-ui="nav-control" className="adminLink">
+          Admin
+        </Link>
 
         <button
-          ref={menuTriggerRef}
           type="button"
           className="mobileMenuTrigger"
           data-ui="nav-control"
-          aria-label="헤더 메뉴 열기"
-          aria-expanded={mobileMenuOpen}
-          onClick={() => setMobileMenuOpen((value) => !value)}
         >
           Menu
         </button>
       </div>
-
-      {isClientMounted && mobileMenuOpen
-        ? createPortal(
-            <>
-              <MobileMenuBackdrop type="button" aria-label="모바일 메뉴 닫기" onClick={() => setMobileMenuOpen(false)} />
-              <MobileMenuPortal ref={mobileMenuRef} role="menu" aria-label="모바일 네비게이션">
-                {mobileLinks.map((link) => (
-                  <Link key={link.id} href={link.to} role="menuitem" onClick={() => setMobileMenuOpen(false)}>
-                    {link.name}
-                  </Link>
-                ))}
-
-                {showLoginAction && (
-                  <button
-                    type="button"
-                    role="menuitem"
-                    onClick={() => {
-                      setMobileMenuOpen(false)
-                      openLoginModal()
-                    }}
-                  >
-                    Login
-                  </button>
-                )}
-
-                {shouldShowAuthenticatedShell && (
-                  <button
-                    type="button"
-                    role="menuitem"
-                    onClick={() => {
-                      setMobileMenuOpen(false)
-                      void handleLogout()
-                    }}
-                  >
-                    Logout
-                  </button>
-                )}
-              </MobileMenuPortal>
-            </>,
-            document.body
-          )
-        : null}
-
-      <AuthEntryModal
-        open={authModalOpen}
-        onClose={() => setAuthModalOpen(false)}
-        nextPath={nextPath}
-        title="로그인"
-      />
     </StyledWrapper>
   )
 }
@@ -267,16 +100,18 @@ export default NavBar
 
 const StyledWrapper = styled.div`
   position: relative;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: 0.34rem;
-  flex-shrink: 0;
+  gap: 2rem;
+  min-width: 0;
+  width: 100%;
 
   .primaryLinks {
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: 0.1rem;
+    gap: 0.25rem;
     margin: 0;
     padding: 0;
     list-style: none;
@@ -289,129 +124,123 @@ const StyledWrapper = styled.div`
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      min-height: ${({ theme }) => theme.variables.navControl.height}px;
-      padding: 0 0.46rem;
-      border-radius: ${({ theme }) => theme.variables.navControl.radius}px;
+      min-height: 36px;
+      padding: 0 0.68rem;
+      border-radius: 0;
       border: none;
       background: transparent;
       color: ${({ theme }) => theme.colors.gray11};
-      font-size: ${({ theme }) => theme.variables.navControl.fontSize}rem;
-      font-weight: 620;
+      font-size: 0.8125rem;
+      font-weight: 650;
       line-height: 1;
 
       &:hover {
         color: ${({ theme }) => theme.colors.gray12};
-        text-decoration: underline;
-        text-underline-offset: 3px;
-        text-decoration-thickness: 1px;
+        text-decoration: none;
       }
-    }
 
-    .adminLinkSlot {
-      display: none;
-      min-width: 4.06rem;
-      align-items: center;
+      &[data-active="true"] {
+        color: ${({ theme }) => theme.colors.gray12};
+        box-shadow: inset 0 -2px ${({ theme }) => theme.publicDesign.accent};
+      }
     }
   }
 
   .authArea {
     display: flex;
     align-items: center;
-    justify-content: flex-start;
-    gap: 0.28rem;
-    width: auto;
+    justify-content: flex-end;
+    gap: 0.44rem;
     min-width: 0;
-    max-width: 100%;
     min-height: ${({ theme }) => theme.variables.navControl.height}px;
-    flex: none;
-    overflow: visible;
 
     > * {
       flex-shrink: 0;
     }
   }
 
-  .authSlot {
+  .searchTrigger {
+    height: 36px;
+    width: 212px;
+    border: 1px solid ${({ theme }) => theme.publicDesign.border};
+    background: ${({ theme }) => theme.publicDesign.readableSurface};
+    display: flex;
     align-items: center;
-    justify-content: center;
-    min-height: ${({ theme }) => theme.variables.navControl.height}px;
-  }
-
-  .authSlot--login {
-    display: none;
-    min-width: 4.55rem;
-  }
-
-  .authSlot--bell {
-    display: none;
-    width: 2.25rem;
-  }
-
-  .authSlot--logout {
-    display: none;
-    min-width: 4.95rem;
-  }
-
-  .bellShell {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.9rem;
-    height: 1.9rem;
-    border-radius: 999px;
-    color: ${({ theme }) => theme.colors.gray10};
-    opacity: 0.76;
-  }
-
-  .navPill,
-  .logoutBtn,
-  .navLink {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 0;
-    min-height: ${({ theme }) => theme.variables.navControl.height}px;
-    padding: 0 0.46rem;
-    border-radius: ${({ theme }) => theme.variables.navControl.radius}px;
-    border: none;
-    background: transparent;
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: ${({ theme }) => theme.variables.navControl.fontSize}rem;
-    font-weight: 630;
+    gap: 0.5rem;
+    padding: 0 0.625rem;
+    color: ${({ theme }) => theme.colors.gray9};
+    border-radius: ${({ theme }) => theme.variables.ui.button.radius}px;
     cursor: pointer;
-    line-height: 1;
 
-    &:hover {
-      color: ${({ theme }) => theme.colors.gray12};
-      text-decoration: underline;
-      text-underline-offset: 3px;
-      text-decoration-thickness: 1px;
+    svg {
+      width: 0.9375rem;
+      height: 0.9375rem;
+    }
+
+    span {
+      flex: 1;
+      min-width: 0;
+      text-align: left;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+
+    kbd {
+      border: 1px solid ${({ theme }) => theme.publicDesign.border};
+      background: ${({ theme }) => theme.publicDesign.surfaceElevated};
+      padding: 0.25rem 0.3rem;
+      color: ${({ theme }) => theme.colors.gray10};
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+      font-size: 0.625rem;
+      line-height: 1;
+      font-weight: 600;
     }
   }
 
-  .navLink {
+  .iconBtn {
+    width: 36px;
+    height: 36px;
+    border: 1px solid transparent;
+    background: transparent;
+    display: grid;
+    place-items: center;
+    border-radius: ${({ theme }) => theme.variables.ui.button.radius}px;
+    color: ${({ theme }) => theme.colors.gray10};
+    cursor: pointer;
+
+    &:hover {
+      border-color: ${({ theme }) => theme.publicDesign.border};
+      background: ${({ theme }) => theme.publicDesign.readableSurface};
+      color: ${({ theme }) => theme.colors.gray12};
+    }
+
+    svg {
+      width: 1.125rem;
+      height: 1.125rem;
+    }
+  }
+
+  .adminLink {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 36px;
+    padding: 0 0.75rem;
+    border: 1px solid ${({ theme }) => theme.colors.gray12};
+    background: ${({ theme }) => theme.colors.gray12};
+    color: ${({ theme }) => theme.colors.gray1};
+    font-size: 0.75rem;
+    font-weight: 750;
+    border-radius: ${({ theme }) => theme.variables.ui.button.radius}px;
     text-decoration: none;
-  }
-
-  html[data-header-auth-shell="anonymous"] & .authSlot--login {
-    display: inline-flex;
-  }
-
-  html[data-header-auth-shell="authenticated"] & .authSlot--bell {
-    display: inline-flex;
-  }
-
-  html[data-header-auth-shell="authenticated"] & .authSlot--logout {
-    display: inline-flex;
-  }
-
-  html[data-header-auth-shell="authenticated"][data-header-auth-admin="true"] & .adminLinkSlot {
-    display: inline-flex;
   }
 
   .mobileMenuTrigger {
     display: none;
-    min-height: ${({ theme }) => theme.variables.navControl.height}px;
+    min-height: 36px;
     padding: 0 0.52rem;
     border-radius: ${({ theme }) => theme.variables.navControl.radius}px;
     border: none;
@@ -421,20 +250,18 @@ const StyledWrapper = styled.div`
     justify-content: center;
     font-size: ${({ theme }) => theme.variables.navControl.fontSize}rem;
     font-weight: 630;
-    line-height: 1;
-
-    &:hover {
-      color: ${({ theme }) => theme.colors.gray12};
-      text-decoration: underline;
-      text-underline-offset: 3px;
-      text-decoration-thickness: 1px;
-    }
   }
 
   @media (max-width: 860px) {
-    .primaryLinks,
-    .authSlot {
+    .searchTrigger,
+    .bellSlot,
+    .adminLink {
       display: none;
+    }
+
+    .primaryLinks {
+      display: flex;
+      gap: 0.18rem;
     }
 
     .authArea {
@@ -442,66 +269,11 @@ const StyledWrapper = styled.div`
     }
 
     .mobileMenuTrigger {
-      display: inline-flex;
+      display: none;
     }
   }
 
   @media (max-width: 720px) {
     gap: 0.22rem;
-
-    .authArea {
-      width: auto;
-      min-width: 0;
-      max-width: 100%;
-      overflow: visible;
-    }
-
-  }
-`
-
-const MobileMenuBackdrop = styled.button`
-  position: fixed;
-  inset: 0;
-  z-index: ${zIndexes.dropdownMenu + 2};
-  border: 0;
-  padding: 0;
-  margin: 0;
-  background: rgba(2, 6, 23, 0.5);
-  cursor: default;
-`
-
-const MobileMenuPortal = styled.div`
-  position: fixed;
-  top: calc(var(--app-header-height, 56px) + 0.5rem + env(safe-area-inset-top, 0px));
-  right: max(0.62rem, env(safe-area-inset-right, 0px));
-  min-width: 10rem;
-  display: grid;
-  gap: 0.18rem;
-  padding: 0.45rem;
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
-  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.46);
-  z-index: ${zIndexes.dropdownMenu + 3};
-
-  a,
-  button {
-    border: 0;
-    background: transparent;
-    color: ${({ theme }) => theme.colors.gray11};
-    display: inline-flex;
-    align-items: center;
-    justify-content: flex-start;
-    min-height: 36px;
-    border-radius: 8px;
-    padding: 0 0.66rem;
-    font-size: 0.85rem;
-    font-weight: 620;
-    text-decoration: none;
-
-    &:hover {
-      color: ${({ theme }) => theme.colors.gray12};
-      background: ${({ theme }) => theme.colors.gray3};
-    }
   }
 `

--- a/front/src/layouts/RootLayout/Header/ThemeToggle.tsx
+++ b/front/src/layouts/RootLayout/Header/ThemeToggle.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled"
 import React from "react"
-import AppIcon from "src/components/icons/AppIcon"
 import useScheme from "src/hooks/useScheme"
 
 type Props = {}
@@ -19,49 +18,55 @@ const ThemeToggle: React.FC<Props> = () => {
       aria-label={scheme === "light" ? "다크 모드로 전환" : "라이트 모드로 전환"}
       title={scheme === "light" ? "다크 모드" : "라이트 모드"}
     >
-      {scheme === "light" ? <AppIcon name="sun" aria-hidden /> : <AppIcon name="moon" aria-hidden />}
+      {scheme === "light" ? <SunIcon /> : <MoonIcon />}
     </StyledWrapper>
   )
 }
 
 export default ThemeToggle
 
+const SunIcon = () => (
+  <svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+    <circle cx="12" cy="12" r="4.2" />
+    <path d="M12 2.5v2.1M12 19.4v2.1M4.6 4.6l1.5 1.5M17.9 17.9l1.5 1.5M2.5 12h2.1M19.4 12h2.1M4.6 19.4l1.5-1.5M17.9 6.1l1.5-1.5" strokeLinecap="round" />
+  </svg>
+)
+
+const MoonIcon = () => (
+  <svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+    <path d="M19.35 14.15A7.95 7.95 0 1 1 10.05 4.7a6.45 6.45 0 0 0 9.3 9.45Z" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+
 const StyledWrapper = styled.button`
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  min-width: 40px;
-  min-height: 40px;
-  border: none;
-  border-radius: 10px;
-  padding: 0 0.5rem;
+  width: 36px;
+  height: 36px;
+  border: 1px solid transparent;
+  border-radius: ${({ theme }) => theme.variables.ui.button.radius}px;
+  padding: 0;
   background: transparent;
-  color: ${({ theme }) => theme.colors.gray11};
+  color: ${({ theme }) => theme.colors.gray10};
   cursor: pointer;
 
   &:hover {
+    border-color: ${({ theme }) => theme.publicDesign.border};
+    background: ${({ theme }) => theme.publicDesign.readableSurface};
     color: ${({ theme }) => theme.colors.gray12};
-    text-decoration: underline;
-    text-underline-offset: 3px;
-    text-decoration-thickness: 1px;
   }
 
   svg {
-    width: 20px;
-    height: 20px;
+    width: 18px;
+    height: 18px;
     display: block;
     transform: translateY(-0.3px);
   }
 
   @media (max-width: 720px) {
-    min-width: 36px;
-    min-height: 36px;
-    padding: 0 0.42rem;
-
-    svg {
-      width: 18px;
-      height: 18px;
-    }
+    width: 36px;
+    height: 36px;
   }
 `

--- a/front/src/layouts/RootLayout/Header/index.tsx
+++ b/front/src/layouts/RootLayout/Header/index.tsx
@@ -1,19 +1,10 @@
 import NavBar from "./NavBar"
 import Logo from "./Logo"
-import ThemeToggle from "./ThemeToggle"
 import styled from "@emotion/styled"
 import { zIndexes } from "src/styles/zIndexes"
 import { useRouter } from "next/router"
 import { useEffect, useRef, useState } from "react"
-import {
-  CONTENT_MAX_WIDTH_PX,
-  DESKTOP_LOCK_MAX_PX,
-  DESKTOP_LOCK_MIN_PX,
-  DESKTOP_LOCK_WIDTH_PX,
-  FLUID_LAYOUT_MAX_PX,
-  WIDE_CONTENT_BREAKPOINT_PX,
-  WIDE_CONTENT_MAX_PX,
-} from "../layoutTiers"
+import { FLUID_LAYOUT_MAX_PX } from "../layoutTiers"
 
 type Props = {
   fullWidth: boolean
@@ -162,8 +153,7 @@ const Header: React.FC<Props> = ({ fullWidth, showThemeToggle = true, blogTitle 
       <div data-full-width={fullWidth} className="container">
         <Logo blogTitle={blogTitle} />
         <div className="nav">
-          {showThemeToggle ? <ThemeToggle /> : null}
-          <NavBar />
+          <NavBar showThemeToggle={showThemeToggle} />
         </div>
       </div>
     </StyledWrapper>
@@ -179,8 +169,8 @@ const StyledWrapper = styled.div`
   background: ${({ theme }) =>
     theme.scheme === "light" ? "rgba(249, 251, 254, 0.94)" : `${theme.colors.gray1}e6`};
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
   transform: translateY(0);
   opacity: 1;
   transition: transform 0.2s ease, opacity 0.2s ease, border-color 0.2s ease;
@@ -188,29 +178,19 @@ const StyledWrapper = styled.div`
   backface-visibility: hidden;
 
   .container {
-    display: flex;
+    display: grid;
     box-sizing: border-box;
-    padding-left: 1rem;
-    padding-right: 1rem;
-    gap: 0.9rem;
-    justify-content: space-between;
+    grid-template-columns: auto 1fr;
+    padding-left: 0;
+    padding-right: 0;
+    gap: 2rem;
     align-items: center;
-    width: min(100%, ${CONTENT_MAX_WIDTH_PX}px);
-    min-height: 3.75rem;
+    width: min(calc(100% - 40px), 1240px);
+    min-height: 4rem;
     margin: 0 auto;
 
-    @media (max-width: ${WIDE_CONTENT_BREAKPOINT_PX}px) {
-      width: min(100%, ${WIDE_CONTENT_MAX_PX}px);
-    }
-
-    @media (max-width: ${DESKTOP_LOCK_MAX_PX}px) and (min-width: ${DESKTOP_LOCK_MIN_PX}px) {
-      width: min(100%, ${DESKTOP_LOCK_WIDTH_PX}px);
-    }
-
     @media (max-width: ${FLUID_LAYOUT_MAX_PX}px) {
-      width: 100%;
-      padding-left: 1rem;
-      padding-right: 1rem;
+      width: min(calc(100% - 24px), 1240px);
       min-height: 3.6rem;
     }
 
@@ -222,9 +202,9 @@ const StyledWrapper = styled.div`
     }
     .nav {
       display: flex;
-      gap: 0.48rem;
+      gap: 0.4rem;
       align-items: center;
-      flex-shrink: 0;
+      justify-content: flex-end;
       min-width: 0;
     }
   }

--- a/front/src/layouts/RootLayout/index.tsx
+++ b/front/src/layouts/RootLayout/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from "react"
+import React, { ReactNode, useEffect } from "react"
 import { ThemeProvider } from "./ThemeProvider"
 import useScheme from "src/hooks/useScheme"
 import Header from "./Header"
@@ -65,7 +65,7 @@ const RootLayout = ({
   initialAdminProfileShouldRefetch = false,
 }: Props) => {
   const [scheme] = useScheme()
-  const { events, pathname } = useRouter()
+  const { pathname } = useRouter()
   const isPublicBlogRoute = pathname === "/" || pathname === "/about" || pathname === "/posts/[id]"
   const isDedicatedEditorRoute = pathname === "/editor/[id]" || pathname === "/editor/new"
   const isAdminRoute = pathname === "/admin" || pathname.startsWith("/admin/")
@@ -79,35 +79,7 @@ const RootLayout = ({
   const effectiveScheme = scheme
   const effectiveBlogDesign = "legacy"
   const headerBlogTitle = (isPublicBlogRoute && adminProfile?.blogTitle?.trim()) || CONFIG.blog.title
-  const [isNavigating, setIsNavigating] = useState(false)
   useGtagEffect()
-
-  useEffect(() => {
-    let mounted = true
-
-    const handleStart = (_url: string, options?: { shallow: boolean }) => {
-      if (options?.shallow || !mounted) return
-      setIsNavigating(true)
-    }
-
-    const handleDone = (_url?: string, options?: { shallow: boolean }) => {
-      if (options?.shallow || !mounted) return
-      requestAnimationFrame(() => {
-        if (mounted) setIsNavigating(false)
-      })
-    }
-
-    events.on("routeChangeStart", handleStart)
-    events.on("routeChangeComplete", handleDone)
-    events.on("routeChangeError", handleDone)
-
-    return () => {
-      mounted = false
-      events.off("routeChangeStart", handleStart)
-      events.off("routeChangeComplete", handleDone)
-      events.off("routeChangeError", handleDone)
-    }
-  }, [events])
 
   useEffect(() => {
     if (typeof window === "undefined") return
@@ -181,7 +153,6 @@ const RootLayout = ({
       {/* // TODO: replace react query */}
       {/* {metaConfig.type !== "Paper" && <Header />} */}
       <Header fullWidth={false} showThemeToggle={effectiveBlogDesign === "legacy"} blogTitle={headerBlogTitle} />
-      <RouteProgress data-busy={isNavigating} aria-hidden="true" />
       <StyledMain $fullBleed={isFullBleedRoute}>{children}</StyledMain>
     </ThemeProvider>
   )
@@ -208,40 +179,4 @@ const StyledMain = styled.main<{ $fullBleed?: boolean }>`
           width: min(calc(100% - 24px), 1240px);
         }
       `}
-`
-
-const RouteProgress = styled.div`
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 3.5rem;
-  z-index: 50;
-  height: 2px;
-  pointer-events: none;
-  overflow: hidden;
-  background: transparent;
-
-  &::after {
-    content: "";
-    display: block;
-    width: 30%;
-    height: 100%;
-    opacity: 0;
-    background: linear-gradient(90deg, transparent, #3b82f6, transparent);
-    transform: translateX(-130%);
-  }
-
-  &[data-busy="true"]::after {
-    opacity: 1;
-    animation: route-progress-slide 1s ease-in-out infinite;
-  }
-
-  @keyframes route-progress-slide {
-    0% {
-      transform: translateX(-130%);
-    }
-    100% {
-      transform: translateX(420%);
-    }
-  }
 `

--- a/front/src/layouts/RootLayout/index.tsx
+++ b/front/src/layouts/RootLayout/index.tsx
@@ -10,15 +10,7 @@ import { useQuery } from "@tanstack/react-query"
 import { CONFIG } from "site.config"
 import type { AdminProfile } from "src/hooks/useAdminProfile"
 import { isNavigationCancelledError, isRequestCancelledError } from "src/libs/router"
-import {
-  CONTENT_MAX_WIDTH_PX,
-  DESKTOP_LOCK_MAX_PX,
-  DESKTOP_LOCK_MIN_PX,
-  DESKTOP_LOCK_WIDTH_PX,
-  FLUID_LAYOUT_MAX_PX,
-  WIDE_CONTENT_BREAKPOINT_PX,
-  WIDE_CONTENT_MAX_PX,
-} from "./layoutTiers"
+import { FLUID_LAYOUT_MAX_PX } from "./layoutTiers"
 
 const PUBLIC_ADMIN_PROFILE_QUERY_KEY = ["member", "adminProfile"] as const
 const INITIAL_PROPS_CANCELLED_MESSAGE = "loading initial props cancelled"
@@ -200,32 +192,20 @@ export default RootLayout
 const StyledMain = styled.main<{ $fullBleed?: boolean }>`
   margin: 0 auto;
   box-sizing: border-box;
-  width: ${({ $fullBleed }) => ($fullBleed ? "100%" : `min(100%, ${CONTENT_MAX_WIDTH_PX}px)`)};
-  padding: ${({ $fullBleed }) => ($fullBleed ? "0" : "0 clamp(0.85rem, 1.6vw, 1.2rem)")};
+  width: ${({ $fullBleed }) => ($fullBleed ? "100%" : "min(calc(100% - 40px), 1240px)")};
+  padding: 0;
   overflow-x: ${({ $fullBleed }) => ($fullBleed ? "clip" : "visible")};
 
   ${({ $fullBleed }) =>
     $fullBleed
       ? ""
       : `
-        @media (max-width: ${WIDE_CONTENT_BREAKPOINT_PX}px) {
-          width: min(100%, ${WIDE_CONTENT_MAX_PX}px);
-        }
-
-        /* Velog-like desktop width lock: fixed content rail before tablet/mobile fluid mode */
-        @media (max-width: ${DESKTOP_LOCK_MAX_PX}px) and (min-width: ${DESKTOP_LOCK_MIN_PX}px) {
-          width: min(100%, ${DESKTOP_LOCK_WIDTH_PX}px);
-        }
-
         @media (max-width: ${FLUID_LAYOUT_MAX_PX}px) {
-          width: 100%;
-          padding-left: 1rem;
-          padding-right: 1rem;
+          width: min(calc(100% - 24px), 1240px);
         }
 
         @media (max-width: 768px) {
-          padding-left: 0.85rem;
-          padding-right: 0.85rem;
+          width: min(calc(100% - 24px), 1240px);
         }
       `}
 `

--- a/front/src/pages/about.tsx
+++ b/front/src/pages/about.tsx
@@ -1,6 +1,5 @@
 import { GetServerSideProps } from "next"
 import { CONFIG } from "site.config"
-import AppIcon from "src/components/icons/AppIcon"
 import MetaConfig from "src/components/MetaConfig"
 import ProfileImage from "src/components/ProfileImage"
 import { AdminProfile, useAdminProfile } from "src/hooks/useAdminProfile"
@@ -35,7 +34,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
   const fallbackProfileSnapshot = !hasAuthCookie ? resolvePublicAdminProfileSnapshot(req) : null
   const adminProfileResult = await timed(() =>
     fetchServerAdminProfile(req, {
-      timeoutMs: hasAuthCookie ? 1_800 : 900,
+      timeoutMs: 1_800,
     })
   )
   const initialAdminProfile =
@@ -84,8 +83,12 @@ type AboutPageProps = {
   initialAdminProfileSource: StaticAdminProfileSeedSource
 }
 
-const AboutPage: NextPageWithLayout<AboutPageProps> = ({ initialAdminProfile }) => {
-  const adminProfile = useAdminProfile(initialAdminProfile)
+const AboutPage: NextPageWithLayout<AboutPageProps> = ({ initialAdminProfile, initialAdminProfileSource }) => {
+  const shouldRefreshProfile = initialAdminProfileSource !== "published"
+  const adminProfile = useAdminProfile(initialAdminProfile, {
+    refetchOnMount: shouldRefreshProfile,
+    staleTimeMs: shouldRefreshProfile ? 0 : undefined,
+  })
 
   const displayName = adminProfile?.nickname || adminProfile?.name || CONFIG.profile.name
   const displayHeadline = adminProfile?.aboutHeadline || DEFAULT_ABOUT_HEADLINE
@@ -151,11 +154,6 @@ const AboutPage: NextPageWithLayout<AboutPageProps> = ({ initialAdminProfile }) 
     }
   })
   const timelineItems = (timelineSection?.items || []).map(parseTimelineItem)
-  const ctaLinks = [
-    githubHref ? { label: "GitHub", safeHref: githubHref } : null,
-    projectItems.length > 0 ? { label: "프로젝트 보기", safeHref: "#about-projects" } : null,
-  ].filter((item): item is { label: string; safeHref: string } => Boolean(item?.safeHref))
-
   const meta = {
     title: `About - ${blogTitle}`,
     description: displayBio,
@@ -167,137 +165,126 @@ const AboutPage: NextPageWithLayout<AboutPageProps> = ({ initialAdminProfile }) 
     <>
       <MetaConfig {...meta} />
       <AboutPageView>
-          <section className="hero-grid">
-            <div className="hero-copy" data-ui="about-hero">
-              <p className="about-eyebrow" data-ui="about-eyebrow">
-                Profile
-              </p>
-              <h1 className="profile-name">{displayName}</h1>
-              <p className="profile-statement">{displayHeadline}</p>
-              <p className="profile-role">{displayRole}</p>
-              <p className="profile-bio">{displayBio}</p>
+          <section className="page-head" data-ui="about-hero">
+            <div>
+              <span className="mono-label">About {blogTitle}</span>
+              <h1>{displayHeadline}</h1>
             </div>
-
-            <aside className="hero-rail">
-              <div className="profile-avatar" data-ui="about-avatar">
-                <ProfileImage
-                  src={profileImageSrc}
-                  width={108}
-                  height={108}
-                  alt={`${displayName} profile`}
-                  fillContainer
-                />
-              </div>
-
-              <div className="cta-group" data-ui="about-cta-group">
-                {ctaLinks.map((item) => (
-                  <a
-                    key={item.label}
-                    className="cta-link"
-                    href={item.safeHref}
-                    target={isExternalHref(item.safeHref) ? "_blank" : undefined}
-                    rel={isExternalHref(item.safeHref) ? "noopener noreferrer" : undefined}
-                  >
-                    {item.label}
-                  </a>
-                ))}
-              </div>
-            </aside>
           </section>
 
-          {projectItems.length > 0 ? (
-            <section className="content-section" id="about-projects" data-ui="about-projects">
-              <h2 className="section-title">{projectSectionTitle}</h2>
-              <ul className="project-list" data-ui="about-project-list">
-                {projectItems.map((item) => (
-                  <li key={item.name}>
-                    <div className="project-copy">
-                      <h3>{item.name}</h3>
-                      {item.summary ? <p data-ui="about-project-summary">{item.summary}</p> : null}
-                    </div>
-                    <div className="project-meta">
-                      {item.role ? <span data-ui="about-project-role">{item.role}</span> : null}
-                      {item.safeHref && item.linkLabel ? (
+          <div className="about-grid">
+            <section>
+              <h2>Profile</h2>
+              <div className="profile-inline">
+                <div className="profile-image" data-ui="about-avatar">
+                  <ProfileImage
+                    src={profileImageSrc}
+                    width={132}
+                    height={132}
+                    alt={`${displayName} profile`}
+                    fillContainer
+                  />
+                </div>
+                <div className="profile-copy">
+                  <strong>{displayName}</strong>
+                  <span>{displayRole}</span>
+                  <p>{displayBio}</p>
+                </div>
+              </div>
+              <div className="stack-list">
+                <div className="stack-row">
+                  <strong>NAME</strong>
+                  <span>{displayName}</span>
+                </div>
+                <div className="stack-row">
+                  <strong>ROLE</strong>
+                  <span>{displayRole}</span>
+                </div>
+              </div>
+            </section>
+
+            <section>
+              <h2>Links</h2>
+              <div className="stack-list">
+                {contactLinks.map((item) => (
+                  <div className="stack-row" key={`${item.label}-${item.safeHref}`}>
+                    <strong>{item.label.toUpperCase()}</strong>
+                    <a href={item.safeHref} target="_blank" rel="noopener noreferrer">
+                      {item.safeHref.replace(/^https?:\/\//, "")}
+                    </a>
+                  </div>
+                ))}
+                {serviceLinks.map((item) => (
+                  <div className="stack-row" key={`${item.label}-${item.safeHref}`}>
+                    <strong>{item.label.toUpperCase()}</strong>
+                    <a href={item.safeHref} target="_blank" rel="noopener noreferrer">
+                      {item.safeHref.replace(/^https?:\/\//, "")}
+                    </a>
+                  </div>
+                ))}
+                {contactLinks.length === 0 && serviceLinks.length === 0 && githubHref ? (
+                  <div className="stack-row">
+                    <strong>REPOSITORY</strong>
+                    <a href={githubHref} target="_blank" rel="noopener noreferrer">
+                      {githubHref.replace(/^https?:\/\//, "")}
+                    </a>
+                  </div>
+                ) : null}
+              </div>
+            </section>
+
+            {projectItems.length > 0 ? (
+              <section id="about-projects" data-ui="about-projects">
+                <h2>{projectSectionTitle}</h2>
+                <div className="stack-list" data-ui="about-project-list">
+                  {projectItems.map((item) => (
+                    <div className="stack-row" key={item.name}>
+                      <strong>{item.role || item.linkLabel || "PROJECT"}</strong>
+                      {item.safeHref ? (
                         <a
-                          className="project-link"
                           href={item.safeHref}
                           target={isExternalHref(item.safeHref) ? "_blank" : undefined}
                           rel={isExternalHref(item.safeHref) ? "noopener noreferrer" : undefined}
                         >
-                          {item.linkLabel}
+                          {item.name}
                         </a>
-                      ) : null}
+                      ) : (
+                        <span>{item.name}</span>
+                      )}
                     </div>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ) : null}
+                  ))}
+                </div>
+              </section>
+            ) : null}
 
-          {timelineItems.length > 0 ? (
-            <section className="content-section" data-ui="about-timeline-section">
-              <h2 className="section-title">{timelineSection?.title || "이력"}</h2>
-              <ol className="timeline-list" data-ui="about-timeline">
-                {timelineItems.map((item) => (
-                  <li key={`${item.label}-${item.date}`}>
-                    <span className="timeline-date">{item.date}</span>
-                    <strong>{item.label}</strong>
-                  </li>
-                ))}
-              </ol>
-            </section>
-          ) : null}
-
-          {supplementalSections.map((section, index) => (
-            <section
-              key={`${section.title}-${index}`}
-              className="content-section supplemental-section"
-              data-has-divider={section.hasDivider ? "true" : "false"}
-            >
-              <h2 className="section-title">{section.title}</h2>
-              <ul className="supplemental-list">
-                {section.items.map((item) => (
-                  <li key={`${section.title}-${item}`}>{item}</li>
-                ))}
-              </ul>
-            </section>
-          ))}
-
-          {contactLinks.length > 0 ? (
-            <section className="content-section compact-link-section" data-ui="about-contact-section">
-              <h2 className="section-title">Contact</h2>
-              <ul className="compact-link-list" data-ui="about-contact-links">
-                {contactLinks.map((item) => (
-                  <li key={`${item.icon}-${item.label}-${item.safeHref}`}>
-                    <a href={item.safeHref} target="_blank" rel="noopener noreferrer">
-                      <span className="icon">
-                        <AppIcon name={item.icon} aria-hidden="true" />
-                      </span>
+            {timelineItems.length > 0 ? (
+              <section data-ui="about-timeline-section">
+                <h2>{timelineSection?.title || "이력"}</h2>
+                <div className="stack-list" data-ui="about-timeline">
+                  {timelineItems.map((item) => (
+                    <div className="stack-row" key={`${item.label}-${item.date}`}>
+                      <strong>{item.date}</strong>
                       <span>{item.label}</span>
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ) : null}
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ) : null}
 
-          {serviceLinks.length > 0 ? (
-            <section className="content-section compact-link-section" data-ui="about-service-section">
-              <h2 className="section-title">Service</h2>
-              <ul className="compact-link-list" data-ui="about-service-links" id="about-service-links">
-                {serviceLinks.map((item) => (
-                  <li key={`${item.icon}-${item.label}-${item.safeHref}`}>
-                    <a href={item.safeHref} target="_blank" rel="noopener noreferrer">
-                      <span className="icon">
-                        <AppIcon name={item.icon} aria-hidden="true" />
-                      </span>
-                      <span>{item.label}</span>
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ) : null}
+            {supplementalSections.map((section, index) => (
+              <section key={`${section.title}-${index}`} data-has-divider={section.hasDivider ? "true" : "false"}>
+                <h2>{section.title}</h2>
+                <div className="stack-list">
+                  {section.items.map((item) => (
+                    <div className="stack-row" key={`${section.title}-${item}`}>
+                      <strong>{String(index + 1).padStart(2, "0")}</strong>
+                      <span>{item}</span>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
       </AboutPageView>
     </>
   )

--- a/front/src/pages/about.tsx
+++ b/front/src/pages/about.tsx
@@ -46,9 +46,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
   const initialAdminProfileSource: StaticAdminProfileSeedSource =
     adminProfileResult.ok && adminProfileResult.value
       ? "published"
-      : fallbackProfileSnapshot?.source === "cookie-snapshot"
-        ? "published"
-        : "static-fallback"
+      : "static-fallback"
 
   res.setHeader(
     "Cache-Control",
@@ -128,7 +126,7 @@ const AboutPage: NextPageWithLayout<AboutPageProps> = ({ initialAdminProfile, in
   const supplementalSections = aboutDetailSections.filter(
     (section) => section !== projectSection && section !== timelineSection
   )
-  const githubHref = contactLinks.find((item) => item.label.toLowerCase().includes("github"))?.safeHref || ""
+  const hasProfileLinks = contactLinks.length > 0 || serviceLinks.length > 0
   const workspaceProjects =
     adminProfile?.aboutProjects && adminProfile.aboutProjects.length > 0
       ? adminProfile.aboutProjects
@@ -203,35 +201,29 @@ const AboutPage: NextPageWithLayout<AboutPageProps> = ({ initialAdminProfile, in
               </div>
             </section>
 
-            <section>
-              <h2>Links</h2>
-              <div className="stack-list">
-                {contactLinks.map((item) => (
-                  <div className="stack-row" key={`${item.label}-${item.safeHref}`}>
-                    <strong>{item.label.toUpperCase()}</strong>
-                    <a href={item.safeHref} target="_blank" rel="noopener noreferrer">
-                      {item.safeHref.replace(/^https?:\/\//, "")}
-                    </a>
-                  </div>
-                ))}
-                {serviceLinks.map((item) => (
-                  <div className="stack-row" key={`${item.label}-${item.safeHref}`}>
-                    <strong>{item.label.toUpperCase()}</strong>
-                    <a href={item.safeHref} target="_blank" rel="noopener noreferrer">
-                      {item.safeHref.replace(/^https?:\/\//, "")}
-                    </a>
-                  </div>
-                ))}
-                {contactLinks.length === 0 && serviceLinks.length === 0 && githubHref ? (
-                  <div className="stack-row">
-                    <strong>REPOSITORY</strong>
-                    <a href={githubHref} target="_blank" rel="noopener noreferrer">
-                      {githubHref.replace(/^https?:\/\//, "")}
-                    </a>
-                  </div>
-                ) : null}
-              </div>
-            </section>
+            {hasProfileLinks ? (
+              <section>
+                <h2>Links</h2>
+                <div className="stack-list">
+                  {contactLinks.map((item) => (
+                    <div className="stack-row" key={`${item.label}-${item.safeHref}`}>
+                      <strong>{item.label.toUpperCase()}</strong>
+                      <a href={item.safeHref} target="_blank" rel="noopener noreferrer">
+                        {item.safeHref.replace(/^https?:\/\//, "")}
+                      </a>
+                    </div>
+                  ))}
+                  {serviceLinks.map((item) => (
+                    <div className="stack-row" key={`${item.label}-${item.safeHref}`}>
+                      <strong>{item.label.toUpperCase()}</strong>
+                      <a href={item.safeHref} target="_blank" rel="noopener noreferrer">
+                        {item.safeHref.replace(/^https?:\/\//, "")}
+                      </a>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ) : null}
 
             {projectItems.length > 0 ? (
               <section id="about-projects" data-ui="about-projects">

--- a/front/src/routes/About/AboutPage.styles.ts
+++ b/front/src/routes/About/AboutPage.styles.ts
@@ -1,398 +1,172 @@
-import styled from "@emotion/styled";
-export const StyledWrapper = styled.div `
-  max-width: 62rem;
-  margin: 0 auto;
-  padding: 2.25rem 0 3rem;
+import styled from "@emotion/styled"
+
+export const StyledWrapper = styled.div`
+  padding: 70px 0 100px;
 
   .about-content {
-    display: grid;
-    gap: 2.6rem;
+    display: block;
   }
 
-  .hero-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1.6fr) minmax(220px, 0.9fr);
-    gap: 2.25rem;
-    padding-bottom: 2rem;
-    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+  .page-head {
+    display: block;
+    padding-bottom: 34px;
+    border-bottom: 2px solid ${({ theme }) => theme.colors.gray12};
   }
 
-  .hero-copy {
-    min-width: 0;
-  }
-
-  .about-eyebrow {
-    margin: 0 0 0.9rem;
+  .mono-label {
     color: ${({ theme }) => theme.colors.gray10};
-    font-size: 1.05rem;
-    line-height: 1.2;
-    font-weight: 800;
-    letter-spacing: 0.12em;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.6875rem;
+    line-height: 1;
+    font-weight: 780;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
   }
 
-  .profile-name {
-    margin: 0;
+  .page-head h1 {
+    margin: 13px 0 0;
+    max-width: 920px;
     color: ${({ theme }) => theme.colors.gray12};
-    font-size: clamp(2.4rem, 2rem + 1vw, 3.25rem);
-    line-height: 1.02;
-    letter-spacing: -0.045em;
-    font-weight: 800;
-  }
-
-  .profile-statement {
-    margin: 1rem 0 0;
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: clamp(1.18rem, 1.02rem + 0.42vw, 1.45rem);
-    line-height: 1.5;
-    font-weight: 650;
-    letter-spacing: -0.02em;
-  }
-
-  .profile-role {
-    margin: 0.8rem 0 0;
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.98rem;
-    line-height: 1.5;
-    font-weight: 700;
-    letter-spacing: 0.02em;
-    text-transform: uppercase;
-  }
-
-  .profile-bio {
-    margin: 1.1rem 0 0;
-    max-width: 40rem;
-    color: ${({ theme }) => theme.colors.gray11};
-    font-size: 1rem;
-    line-height: 1.8;
-    white-space: pre-line;
+    font-size: 54px;
+    line-height: 1.05;
+    letter-spacing: -0.06em;
+    font-weight: 850;
     word-break: keep-all;
   }
 
-  .hero-rail {
-    display: grid;
-    align-content: start;
-    justify-items: start;
-    gap: 1rem;
-  }
-
-  .profile-avatar {
+  .profile-image {
     position: relative;
-    width: 148px;
-    border-radius: 999px;
+    width: 132px;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    border: 1px solid ${({ theme }) => theme.publicDesign.border};
+    background: ${({ theme }) => theme.publicDesign.readableSurface};
     overflow: hidden;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => (theme.colors.gray1)};
-    box-shadow: ${({ theme }) => "0 18px 38px rgba(0, 0, 0, 0.18)"};
-
-    &::after {
-      content: "";
-      display: block;
-      padding-bottom: 100%;
-    }
   }
 
-  .cta-group {
-    width: min(100%, 270px);
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.56rem;
-
-    a {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-height: 40px;
-      padding: 0.68rem 0.92rem;
-      border-radius: 999px;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
-      background: ${({ theme }) => (theme.colors.gray1)};
-      color: ${({ theme }) => theme.colors.gray12};
-      font-size: 0.94rem;
-      font-weight: 700;
-      line-height: 1;
-      transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
-
-      &:hover {
-        background: ${({ theme }) => theme.colors.gray2};
-        border-color: ${({ theme }) => theme.colors.gray10};
-        transform: translateY(-1px);
-      }
-    }
+  .profile-image img {
+    object-fit: cover;
   }
 
-  .content-section {
+  .profile-inline {
+    display: grid;
+    grid-template-columns: 132px minmax(0, 1fr);
+    gap: 18px;
+    align-items: start;
+    margin-bottom: 18px;
+  }
+
+  .profile-copy {
     min-width: 0;
+    display: grid;
+    gap: 6px;
   }
 
-  .section-title {
-    margin: 0 0 1.1rem;
+  .profile-copy strong {
     color: ${({ theme }) => theme.colors.gray12};
-    font-size: 1.38rem;
+    font-size: 1.125rem;
     line-height: 1.35;
-    font-weight: 800;
-    letter-spacing: -0.02em;
+    font-weight: 820;
+    word-break: keep-all;
   }
 
-  .project-list,
-  .timeline-list,
-  .supplemental-list,
-  .compact-link-list {
-    list-style: none;
+  .profile-copy span {
     margin: 0;
-    padding: 0;
-  }
-
-  .project-list {
-    display: grid;
-    gap: 0.7rem;
-
-    li {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(10rem, 15rem);
-      gap: 1.1rem;
-      padding: 1rem 1.1rem;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
-      border-radius: 16px;
-      background: ${({ theme }) => (theme.colors.gray1)};
-    }
-  }
-
-  .project-copy {
-    min-width: 0;
-
-    h3 {
-      margin: 0;
-      color: ${({ theme }) => theme.colors.gray12};
-      font-size: 1.05rem;
-      line-height: 1.4;
-      font-weight: 720;
-    }
-
-    p {
-      margin: 0.4rem 0 0;
-      color: ${({ theme }) => theme.colors.gray11};
-      font-size: 0.96rem;
-      line-height: 1.7;
-      word-break: keep-all;
-    }
-  }
-
-  .project-meta {
-    display: grid;
-    justify-items: start;
-    align-content: start;
-    gap: 0.5rem;
-
-    span {
-      color: ${({ theme }) => theme.colors.gray10};
-      font-size: 0.84rem;
-      line-height: 1.4;
-      font-weight: 700;
-      text-align: left;
-      letter-spacing: 0.02em;
-      text-transform: uppercase;
-    }
-
-    a {
-      display: inline-flex;
-      align-items: center;
-      min-height: 30px;
-      padding: 0.42rem 0.7rem;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
-      border-radius: 999px;
-      color: ${({ theme }) => theme.colors.gray12};
-      font-size: 0.86rem;
-      line-height: 1.4;
-      font-weight: 650;
-
-      &:hover {
-        border-color: ${({ theme }) => theme.colors.gray10};
-        text-decoration: none;
-      }
-    }
-  }
-
-  .timeline-list {
-    display: grid;
-    gap: 0.92rem;
-
-    li {
-      display: flex;
-      align-items: baseline;
-      gap: 1rem;
-    }
-  }
-
-  .timeline-date {
-    flex: 0 0 7.2rem;
     color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.9rem;
-    line-height: 1.45rem;
-    font-weight: 650;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    font-weight: 700;
+    text-transform: uppercase;
   }
 
-  .timeline-list strong {
-    flex: 1 1 auto;
-    min-width: 0;
-    color: ${({ theme }) => theme.colors.gray12};
+  .profile-copy p {
+    margin: 8px 0 0;
+    color: ${({ theme }) => theme.colors.gray11};
     font-size: 1rem;
-    line-height: 1.45rem;
-    font-weight: 650;
+    line-height: 1.75;
+    word-break: keep-all;
+    white-space: pre-line;
   }
 
-  .supplemental-section[data-has-divider="true"] {
-    padding-top: 1.2rem;
-    border-top: 1px solid ${({ theme }) => theme.colors.gray6};
-  }
-
-  .supplemental-list {
+  .about-grid {
     display: grid;
-    gap: 0.52rem;
-
-    li {
-      color: ${({ theme }) => theme.colors.gray11};
-      font-size: 0.98rem;
-      line-height: 1.7;
-    }
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 60px;
+    padding-top: 48px;
   }
 
-  .compact-link-section {
-    .section-title {
-      margin-bottom: 0.82rem;
-    }
+  .about-grid section {
+    min-width: 0;
   }
 
-  .compact-link-list {
-    background: transparent;
-    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
-
-    li + li {
-      border-top: 1px solid ${({ theme }) => theme.colors.gray6};
-    }
-
-    a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.7rem;
-      width: 100%;
-      min-height: 44px;
-      padding: 0.84rem 0;
-      color: ${({ theme }) => theme.colors.gray12};
-      font-size: 0.98rem;
-      line-height: 1.5;
-
-      &:hover {
-        text-decoration: underline;
-        text-underline-offset: 3px;
-      }
-    }
-
-    .icon {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      color: ${({ theme }) => theme.colors.gray10};
-      font-size: 1.05rem;
-    }
+  .about-grid h2 {
+    margin: 0 0 16px;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 30px;
+    line-height: 1.25;
+    letter-spacing: -0.04em;
+    font-weight: 820;
   }
 
-  @media (max-width: 900px) {
-    .hero-grid {
+  .stack-list {
+    border-top: 1px solid ${({ theme }) => theme.colors.gray12};
+  }
+
+  .stack-row {
+    display: grid;
+    grid-template-columns: 140px minmax(0, 1fr);
+    gap: 20px;
+    padding: 14px 0;
+    border-bottom: 1px solid ${({ theme }) => theme.publicDesign.border};
+  }
+
+  .stack-row strong {
+    color: ${({ theme }) => theme.colors.gray9};
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.6875rem;
+    line-height: 1.5;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  .stack-row span,
+  .stack-row a {
+    min-width: 0;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-size: 0.9375rem;
+    line-height: 1.55;
+    word-break: keep-all;
+    overflow-wrap: anywhere;
+  }
+
+  .stack-row a {
+    text-decoration: none;
+  }
+
+  .stack-row a:hover {
+    color: ${({ theme }) => theme.colors.gray12};
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  @media (max-width: 820px) {
+    padding: 44px 0 70px;
+
+    .page-head h1 {
+      font-size: 42px;
+    }
+
+    .about-grid {
       grid-template-columns: 1fr;
-      gap: 1.5rem;
+      gap: 34px;
     }
 
-    .hero-rail {
-      justify-items: start;
+    .profile-inline {
+      grid-template-columns: 96px minmax(0, 1fr);
     }
 
-    .cta-group {
-      width: 100%;
-      max-width: 28rem;
-    }
-
-    .project-list li {
-      grid-template-columns: 1fr;
-    }
-
-    .project-meta {
-      justify-items: start;
-
-      span {
-        text-align: left;
-      }
+    .profile-image {
+      width: 96px;
     }
   }
-
-  @media (max-width: 768px) {
-    padding: 1.6rem 0 2.4rem;
-
-    .about-content {
-      gap: 2.1rem;
-    }
-
-    .hero-grid {
-      padding-bottom: 1.6rem;
-    }
-
-    .profile-name {
-      font-size: 2.25rem;
-    }
-
-    .profile-statement {
-      font-size: 1.08rem;
-      line-height: 1.56;
-    }
-
-    .profile-role {
-      font-size: 0.9rem;
-    }
-
-    .profile-bio {
-      font-size: 0.96rem;
-      line-height: 1.72;
-    }
-
-    .profile-avatar {
-      width: 88px;
-      box-shadow: none;
-    }
-
-    .cta-group {
-      gap: 0.54rem;
-
-      a {
-        min-height: 42px;
-        padding: 0.76rem 0.88rem;
-        font-size: 0.95rem;
-      }
-    }
-
-    .section-title {
-      font-size: 1.18rem;
-      margin-bottom: 0.88rem;
-    }
-
-    .timeline-list {
-      gap: 0.74rem;
-
-      li {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0.18rem;
-      }
-    }
-
-    .timeline-date {
-      flex-basis: auto;
-      font-size: 0.82rem;
-    }
-
-    .project-copy p,
-    .supplemental-list li,
-    .compact-link-list a {
-      font-size: 0.94rem;
-    }
-  }
-`;
+`

--- a/front/src/routes/About/AboutPage.styles.ts
+++ b/front/src/routes/About/AboutPage.styles.ts
@@ -32,6 +32,7 @@ export const StyledWrapper = styled.div`
     letter-spacing: -0.06em;
     font-weight: 850;
     word-break: keep-all;
+    overflow-wrap: anywhere;
   }
 
   .profile-image {
@@ -68,6 +69,7 @@ export const StyledWrapper = styled.div`
     line-height: 1.35;
     font-weight: 820;
     word-break: keep-all;
+    overflow-wrap: anywhere;
   }
 
   .profile-copy span {
@@ -77,6 +79,7 @@ export const StyledWrapper = styled.div`
     line-height: 1.5;
     font-weight: 700;
     text-transform: uppercase;
+    overflow-wrap: anywhere;
   }
 
   .profile-copy p {
@@ -86,6 +89,7 @@ export const StyledWrapper = styled.div`
     line-height: 1.75;
     word-break: keep-all;
     white-space: pre-line;
+    overflow-wrap: anywhere;
   }
 
   .about-grid {
@@ -121,12 +125,14 @@ export const StyledWrapper = styled.div`
   }
 
   .stack-row strong {
+    min-width: 0;
     color: ${({ theme }) => theme.colors.gray9};
     font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
     font-size: 0.6875rem;
     line-height: 1.5;
     font-weight: 700;
     text-transform: uppercase;
+    overflow-wrap: anywhere;
   }
 
   .stack-row span,

--- a/front/src/routes/Feed/FeedExplorer.styles.ts
+++ b/front/src/routes/Feed/FeedExplorer.styles.ts
@@ -1,52 +1,116 @@
 import styled from "@emotion/styled"
-const FEED_POST_COLUMN_MAX_WIDTH_REM = 92
+const FEED_POST_COLUMN_MAX_WIDTH_REM = 100
 
 export const ExplorerCard = styled.section`
   --feed-post-column-max-width: ${FEED_POST_COLUMN_MAX_WIDTH_REM}rem;
-  display: grid;
-  gap: 0.8rem;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
   padding: 0;
   min-width: 0;
   min-height: 0;
   height: auto;
   overflow: visible;
-  margin-bottom: 0.52rem;
+  margin: 0;
+  border-bottom: 2px solid ${({ theme }) => theme.colors.gray12};
+  padding-bottom: 18px;
+
+  .feedTitle {
+    min-width: 0;
+    display: grid;
+    gap: 0;
+  }
+
+  .feedTitle span {
+    color: ${({ theme }) => theme.publicDesign.accent};
+    font-size: 0.6875rem;
+    line-height: 1.2;
+    font-weight: 820;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .feedTitle h2 {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray12};
+    margin: 4px 0 0;
+    font-size: 28px;
+    line-height: 1.2;
+    letter-spacing: -0.04em;
+    font-weight: 820;
+  }
+
+  .feedDescription {
+    margin: 8px 0 0;
+    color: ${({ theme }) => theme.colors.gray10};
+    max-width: 560px;
+    font-size: 0.875rem;
+    line-height: 1.55;
+  }
 
   .searchSlot {
     min-width: 0;
-    width: min(100%, var(--feed-post-column-max-width));
-    margin-inline: auto;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .sortSelect {
+    height: 36px;
+    border: 1px solid ${({ theme }) => theme.publicDesign.border};
+    background: ${({ theme }) => theme.publicDesign.readableSurface};
+    color: ${({ theme }) => theme.colors.gray12};
+    padding: 0 10px;
+    border-radius: ${({ theme }) => theme.variables.ui.button.radius}px;
+    font-size: 0.8125rem;
+    font-weight: 650;
   }
 
   @media (max-width: 768px) {
-    margin-bottom: 0.38rem;
+    flex-direction: column;
+    align-items: start;
+    gap: 20px;
+    padding-bottom: 18px;
+
+    .searchSlot {
+      width: 100%;
+    }
   }
 `
 
 export const FeedBody = styled.section`
   --feed-post-column-max-width: ${FEED_POST_COLUMN_MAX_WIDTH_REM}rem;
   display: grid;
-  gap: 0.85rem;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 48px;
   min-width: 0;
   overflow: visible;
+  padding: 54px 0 86px;
 
   .tagColumn {
     min-width: 0;
     display: block;
-    width: min(100%, var(--feed-post-column-max-width));
-    margin-inline: auto;
   }
 
   .postColumn {
     min-width: 0;
-    width: min(100%, var(--feed-post-column-max-width));
-    margin-inline: auto;
+    width: 100%;
+  }
+
+  @media (max-width: 1200px) {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 24px;
+  }
+
+  @media (max-width: 768px) {
+    padding: 34px 0 60px;
   }
 `
 
 export const FilterContextBar = styled.div`
   min-height: 1.8rem;
-  margin: 0.04rem 0 0.16rem;
+  margin: 12px 0 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -87,7 +151,7 @@ export const FilterContextBar = styled.div`
   }
 
   .statusBadge {
-    display: inline-flex;
+    display: none;
     align-items: center;
     gap: 0.28rem;
     min-height: 1.7rem;
@@ -105,7 +169,7 @@ export const FilterContextBar = styled.div`
     flex: 0 0 auto;
     min-height: 1.7rem;
     padding: 0 0.52rem;
-    border-radius: 999px;
+    border-radius: 4px;
     border: 1px solid ${({ theme }) => theme.publicDesign.border};
     background: transparent;
     color: ${({ theme }) => theme.colors.gray10};
@@ -122,8 +186,8 @@ export const FilterContextBar = styled.div`
   }
 
   @media (max-width: 768px) {
-    margin-top: 0.14rem;
-    margin-bottom: 0.18rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0;
 
     .contextCount {
       font-size: 0.84rem;

--- a/front/src/routes/Feed/FeedExplorer.styles.ts
+++ b/front/src/routes/Feed/FeedExplorer.styles.ts
@@ -56,15 +56,89 @@ export const ExplorerCard = styled.section`
     align-items: center;
   }
 
-  .sortSelect {
+  .sortDropdown {
+    position: relative;
+    flex: 0 0 auto;
+  }
+
+  .sortTrigger {
     height: 36px;
     border: 1px solid ${({ theme }) => theme.publicDesign.border};
     background: ${({ theme }) => theme.publicDesign.readableSurface};
-    color: ${({ theme }) => theme.colors.gray12};
+    display: inline-flex;
+    color: ${({ theme }) => theme.colors.gray10};
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    min-width: 86px;
     padding: 0 10px;
-    border-radius: ${({ theme }) => theme.variables.ui.button.radius}px;
     font-size: 0.8125rem;
-    font-weight: 650;
+    line-height: 1;
+    font-weight: 740;
+    letter-spacing: 0;
+    cursor: pointer;
+  }
+
+  .sortTrigger:hover,
+  .sortTrigger:focus-visible,
+  .sortTrigger[aria-expanded="true"] {
+    border-color: ${({ theme }) => theme.colors.gray12};
+    color: ${({ theme }) => theme.colors.gray12};
+    outline: none;
+  }
+
+  .sortChevron {
+    width: 7px;
+    height: 7px;
+    border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor;
+    transform: translateY(-2px) rotate(45deg);
+  }
+
+  .sortMenu {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 4px);
+    z-index: 20;
+    min-width: 100%;
+    border: 1px solid ${({ theme }) => theme.publicDesign.borderStrong};
+    background: ${({ theme }) => theme.publicDesign.readableSurface};
+    box-shadow: none;
+    padding: 3px;
+  }
+
+  .sortOption {
+    width: 100%;
+    height: 30px;
+    border: 0;
+    background: transparent;
+    color: ${({ theme }) => theme.colors.gray10};
+    display: grid;
+    grid-template-columns: 12px 1fr;
+    align-items: center;
+    gap: 5px;
+    text-align: left;
+    padding: 0 8px;
+    font-size: 0.75rem;
+    font-weight: 720;
+    cursor: pointer;
+  }
+
+  .sortOption::before {
+    content: "";
+  }
+
+  .sortOption:hover,
+  .sortOption:focus-visible,
+  .sortOption[data-active="true"] {
+    background: ${({ theme }) => theme.publicDesign.surfaceElevated};
+    color: ${({ theme }) => theme.colors.gray12};
+    outline: none;
+  }
+
+  .sortOption[data-active="true"]::before {
+    content: "✓";
+    font-weight: 900;
   }
 
   @media (max-width: 768px) {
@@ -75,6 +149,20 @@ export const ExplorerCard = styled.section`
 
     .searchSlot {
       width: 100%;
+    }
+
+    .sortDropdown {
+      flex: 0 0 auto;
+    }
+
+    .sortTrigger {
+      height: 36px;
+      min-width: 86px;
+    }
+
+    .sortMenu {
+      left: auto;
+      right: 0;
     }
   }
 `

--- a/front/src/routes/Feed/FeedExplorer.tsx
+++ b/front/src/routes/Feed/FeedExplorer.tsx
@@ -444,36 +444,46 @@ const FeedExplorer: React.FC<FeedExplorerProps> = ({ initialBootstrapDegraded = 
   return (
     <>
       <PinnedPosts posts={pinnedPosts} />
-      <ExplorerCard>
-        <div className="searchSlot">
-          <SearchInput
-            inputRef={searchInputRef}
-            value={q}
-            onChange={(event) => setQ(event.target.value)}
-            onCompositionStart={() => setIsComposing(true)}
-            onCompositionEnd={() => setIsComposing(false)}
-          />
-        </div>
-      </ExplorerCard>
       <FeedBody data-sticky-rail-safe="true">
         <aside className="tagColumn">
           <TagList />
         </aside>
         <section className="postColumn">
-          <FilterContextBar data-visible={hasFilter}>
-            <div className="contextMain">
-              <strong className="contextCount">{hasFilter ? `${resultCount}개` : `피드 ${resultCount}개`}</strong>
-              {hasFilter && <span className="filterSummary">{filterSummary}</span>}
-              {contextStatusLabel ? <span className="statusBadge">{contextStatusLabel}</span> : null}
+          <ExplorerCard>
+            <div className="feedTitle">
+              <span>Latest Notes</span>
+              <h2>최근 글</h2>
+              <p className="feedDescription">실제 운영에서 마주친 문제와 선택, 검증 결과를 긴 글로 정리합니다.</p>
             </div>
-            <div className="contextActions">
-              {hasFilter && (
-                <button type="button" className="resetButton" onClick={handleClearFilters}>
-                  초기화
-                </button>
-              )}
+            <div className="searchSlot">
+              <SearchInput
+                inputRef={searchInputRef}
+                value={q}
+                onChange={(event) => setQ(event.target.value)}
+                onCompositionStart={() => setIsComposing(true)}
+                onCompositionEnd={() => setIsComposing(false)}
+              />
+              <select className="sortSelect" aria-label="피드 정렬" value="latest" onChange={() => undefined}>
+                <option value="latest">최신순</option>
+              </select>
             </div>
-          </FilterContextBar>
+          </ExplorerCard>
+          {(hasFilter || contextStatusLabel) && (
+            <FilterContextBar>
+              <div className="contextMain">
+                <strong className="contextCount">{hasFilter ? `${resultCount}개` : `피드 ${resultCount}개`}</strong>
+                {hasFilter && <span className="filterSummary">{filterSummary}</span>}
+                {contextStatusLabel ? <span className="statusBadge">{contextStatusLabel}</span> : null}
+              </div>
+              <div className="contextActions">
+                {hasFilter && (
+                  <button type="button" className="resetButton" onClick={handleClearFilters}>
+                    초기화
+                  </button>
+                )}
+              </div>
+            </FilterContextBar>
+          )}
           <PostList
             posts={regularPosts}
             hasFilter={hasFilter}

--- a/front/src/routes/Feed/FeedExplorer.tsx
+++ b/front/src/routes/Feed/FeedExplorer.tsx
@@ -17,6 +17,7 @@ import { replaceShallowRoutePreservingScroll } from "src/libs/router"
 import { FEED_EXPLORE_PAGE_SIZE } from "src/constants/feed"
 import { queryKey } from "src/constants/queryKey"
 import { type ExplorePostsPage } from "src/apis/backend/posts"
+import type { TPost } from "src/types"
 import { normalizeKeywordQuery, normalizeOptionalTagQuery, normalizeTagQuery } from "src/libs/query/normalize"
 import { ExplorerCard, FeedBody, FilterContextBar } from "./FeedExplorer.styles"
 import {
@@ -45,17 +46,46 @@ import {
 
 const LOAD_MORE_THROTTLE_MS = 800
 const LOAD_MORE_OBSERVER_THROTTLE_MS = 180
+type FeedSortMode = "latest" | "views" | "likes"
+const FEED_SORT_OPTIONS: Array<{ value: FeedSortMode; label: string }> = [
+  { value: "latest", label: "최신순" },
+  { value: "views", label: "조회순" },
+  { value: "likes", label: "좋아요순" },
+]
 
 type FeedExplorerProps = {
   initialBootstrapDegraded?: boolean
 }
 
+const getPostTime = (post: TPost) => {
+  const value = post.date?.start_date || post.createdTime
+  const time = value ? new Date(value).getTime() : 0
+  return Number.isFinite(time) ? time : 0
+}
+
+const compareLatestPosts = (a: TPost, b: TPost) => getPostTime(b) - getPostTime(a)
+
+const sortFeedPosts = (posts: TPost[], sortMode: FeedSortMode) => {
+  if (sortMode === "latest") return posts
+
+  return [...posts].sort((a, b) => {
+    const primary =
+      sortMode === "views"
+        ? (b.hitCount ?? 0) - (a.hitCount ?? 0)
+        : (b.likesCount ?? 0) - (a.likesCount ?? 0)
+    return primary || compareLatestPosts(a, b)
+  })
+}
+
 const FeedExplorer: React.FC<FeedExplorerProps> = ({ initialBootstrapDegraded = false }) => {
   const queryClient = useQueryClient()
   const [q, setQ] = useState("")
+  const [sortMode, setSortMode] = useState<FeedSortMode>("latest")
+  const [sortOpen, setSortOpen] = useState(false)
   const [isComposing, setIsComposing] = useState(false)
   const router = useRouter()
   const searchInputRef = useRef<HTMLInputElement | null>(null)
+  const sortMenuRef = useRef<HTMLDivElement | null>(null)
   const restoreStateRef = useRef<FeedExplorerRestoreState | null>(null)
   const restoreQueryPagesRef = useRef<FeedExplorerSnapshotPage[] | null>(null)
   const restoreQueryPageParamsRef = useRef<FeedExplorerSnapshotPageParam[] | null>(null)
@@ -123,6 +153,18 @@ const FeedExplorer: React.FC<FeedExplorerProps> = ({ initialBootstrapDegraded = 
   useEffect(() => {
     isFetchNextPageErrorRef.current = isFetchNextPageError
   }, [isFetchNextPageError])
+
+  useEffect(() => {
+    if (!sortOpen) return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (sortMenuRef.current?.contains(event.target as Node)) return
+      setSortOpen(false)
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown)
+    return () => document.removeEventListener("pointerdown", handlePointerDown)
+  }, [sortOpen])
 
   useEffect(() => {
     restoreSnapshotRef.current = {
@@ -410,6 +452,10 @@ const FeedExplorer: React.FC<FeedExplorerProps> = ({ initialBootstrapDegraded = 
 
   const hasFilter = Boolean(normalizedQuery || currentTag)
   const resultCount = pinnedPosts.length + regularPosts.length
+  const sortedRegularPosts = useMemo(
+    () => sortFeedPosts(regularPosts, sortMode),
+    [regularPosts, sortMode]
+  )
   const showBootstrapDegraded = initialBootstrapDegraded && !hasInitialLoadSucceeded
   const hasQueryFilter = normalizedQuery.length > 0
   const hasTagFilter = Boolean(currentTag)
@@ -440,6 +486,13 @@ const FeedExplorer: React.FC<FeedExplorerProps> = ({ initialBootstrapDegraded = 
       })
     })
   }, [currentTag, router])
+  const currentSortLabel =
+    FEED_SORT_OPTIONS.find((option) => option.value === sortMode)?.label ?? "최신순"
+
+  const handleSortSelect = useCallback((value: FeedSortMode) => {
+    setSortMode(value)
+    setSortOpen(false)
+  }, [])
 
   return (
     <>
@@ -463,9 +516,35 @@ const FeedExplorer: React.FC<FeedExplorerProps> = ({ initialBootstrapDegraded = 
                 onCompositionStart={() => setIsComposing(true)}
                 onCompositionEnd={() => setIsComposing(false)}
               />
-              <select className="sortSelect" aria-label="피드 정렬" value="latest" onChange={() => undefined}>
-                <option value="latest">최신순</option>
-              </select>
+              <div className="sortDropdown" ref={sortMenuRef}>
+                <button
+                  type="button"
+                  className="sortTrigger"
+                  aria-haspopup="listbox"
+                  aria-expanded={sortOpen}
+                  onClick={() => setSortOpen((prev) => !prev)}
+                >
+                  {currentSortLabel}
+                  <span className="sortChevron" aria-hidden="true" />
+                </button>
+                {sortOpen && (
+                  <div className="sortMenu" role="listbox" aria-label="피드 정렬">
+                    {FEED_SORT_OPTIONS.map((option) => (
+                      <button
+                        type="button"
+                        key={option.value}
+                        className="sortOption"
+                        role="option"
+                        aria-selected={sortMode === option.value}
+                        data-active={sortMode === option.value}
+                        onClick={() => handleSortSelect(option.value)}
+                      >
+                        {option.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
           </ExplorerCard>
           {(hasFilter || contextStatusLabel) && (
@@ -485,7 +564,7 @@ const FeedExplorer: React.FC<FeedExplorerProps> = ({ initialBootstrapDegraded = 
             </FilterContextBar>
           )}
           <PostList
-            posts={regularPosts}
+            posts={sortedRegularPosts}
             hasFilter={hasFilter}
             hasExternalResults={pinnedPosts.length > 0}
             onClearFilters={handleClearFilters}

--- a/front/src/routes/Feed/PostList/PostCard.tsx
+++ b/front/src/routes/Feed/PostList/PostCard.tsx
@@ -19,13 +19,11 @@ import { normalizeCardSummary } from "src/libs/postSummary"
 type Props = {
   data: TPost
   layout?: "regular" | "pinned"
+  index?: number
 }
 
 const FEED_CARD_META_FONT_SIZE_REM = uiTokens.feed.card.metaFontSizeRem
 const FEED_CARD_SUMMARY_LINES = uiTokens.feed.card.summaryLines
-const FEED_CARD_SUMMARY_LINE_HEIGHT = uiTokens.feed.card.summaryLineHeight
-const FEED_CARD_TITLE_LINE_HEIGHT = uiTokens.feed.card.titleLineHeight
-const FEED_CARD_RADIUS_PX = 14
 const INTERNAL_CATEGORY_TAGS = new Set(["Pinned"])
 
 const toDisplayCategoryLabel = (post: TPost) => {
@@ -36,8 +34,7 @@ const toDisplayCategoryLabel = (post: TPost) => {
   return splitCategoryDisplay(rawLabel).label
 }
 
-const PostCard: React.FC<Props> = ({ data, layout = "regular" }) => {
-  const author = data.author?.[0]
+const PostCard: React.FC<Props> = ({ data, layout = "regular", index = 0 }) => {
   const postPath = toCanonicalPostPath(data.id)
   const createdAtText = formatDate(
     data?.date?.start_date || data.createdTime,
@@ -45,7 +42,6 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular" }) => {
   )
   const summary = normalizeCardSummary(data.summary)
   const commentsCount = data.commentsCount ?? 0
-  const likesCount = data.likesCount ?? 0
   const categoryLabel = toDisplayCategoryLabel(data)
   const readMinutes = Math.max(4, Math.ceil(((data.title?.length || 0) + (summary?.length || 0)) / 120))
   const viewsCount = data.hitCount ?? 0
@@ -83,33 +79,13 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular" }) => {
   return (
     <StyledWrapper href={postPath} data-layout={layout} data-ui="feed-post-card" onClick={handleNavigate}>
       <article>
-        {thumbnailSrc && (
-          <div className="thumbnail">
-            <ProfileImage
-              src={thumbnailSrc}
-              alt=""
-              aria-hidden
-              fillContainer
-              priority={layout === "pinned"}
-              loading={layout === "pinned" ? "eager" : "lazy"}
-              style={{
-                objectFit: "cover",
-                objectPosition: `${thumbnailFocusX}% ${thumbnailFocusY}%`,
-                transform: `scale(${thumbnailZoom})`,
-                transformOrigin: `${thumbnailFocusX}% ${thumbnailFocusY}%`,
-              }}
-            />
-          </div>
-        )}
-        {!thumbnailSrc && (
-          <div className="thumbnail brandCover" data-ui="feed-card-brand-cover" aria-label={`${data.title} cover`}>
-            <span className="coverCategory">{categoryLabel}</span>
-            <strong>{data.title}</strong>
-            <span className="coverBrand">AquilaLog</span>
-          </div>
-        )}
+        <span className="rowIndex" aria-hidden="true">
+          {String(index + 1).padStart(2, "0")}
+        </span>
         <div className="content">
-          <div className="category">{categoryLabel}</div>
+          <div className="tagRow">
+            <span className="tag">{categoryLabel.toUpperCase()}</span>
+          </div>
           <header>
             <h2>{data.title}</h2>
           </header>
@@ -128,31 +104,34 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular" }) => {
               {commentsCount}개의 댓글
             </span>
           </div>
-          <div className="footer">
-            <div className="author">
-              <span className="avatar" aria-hidden="true">
-                {author?.profile_photo ? (
-                  <ProfileImage
-                    src={author.profile_photo}
-                    alt=""
-                    fillContainer
-                    width={24}
-                    height={24}
-                    priority={layout === "pinned"}
-                    loading={layout === "pinned" ? "eager" : "lazy"}
-                  />
-                ) : (
-                  <span className="initial">{(author?.name || "A").slice(0, 1).toUpperCase()}</span>
-                )}
-              </span>
-              <span className="by">by</span>
-              <strong>{author?.name || "관리자"}</strong>
+        </div>
+        <div className="side">
+          <span className="date">{createdAtText}</span>
+          <div className="thumbnail" aria-label={`${data.title} 미리보기`}>
+            <div className="imageFallback" aria-hidden="true">
+              <span className="coverCategory">{categoryLabel}</span>
+              <strong>{data.title}</strong>
+              <span className="coverBrand">AquilaLog</span>
             </div>
-            <div className="like">
-              <AppIcon name={likesCount > 0 ? "heart-filled" : "heart"} />
-              <span>{likesCount}</span>
-            </div>
+            {thumbnailSrc ? (
+              <ProfileImage
+                src={thumbnailSrc}
+                alt=""
+                aria-hidden
+                fillContainer
+                priority={layout === "pinned"}
+                loading={layout === "pinned" ? "eager" : "lazy"}
+                style={{
+                  objectFit: "cover",
+                  objectPosition: `${thumbnailFocusX}% ${thumbnailFocusY}%`,
+                  transform: `scale(${thumbnailZoom})`,
+                  transformOrigin: `${thumbnailFocusX}% ${thumbnailFocusY}%`,
+                }}
+              />
+            ) : null}
           </div>
+          <span className="arrowBtn" aria-hidden="true">
+          </span>
         </div>
       </article>
     </StyledWrapper>
@@ -167,148 +146,80 @@ const StyledWrapper = styled.a`
   max-width: 100%;
   min-width: 0;
   text-decoration: none;
-  --post-card-translate-y: -8px;
   --post-card-border-color: ${({ theme }) => theme.publicDesign.border};
   --post-card-border-strong: ${({ theme }) => theme.publicDesign.accent};
   --post-card-focus-ring: ${({ theme }) => theme.colors.indigo8};
   --post-card-surface: ${({ theme }) => theme.publicDesign.readableSurface};
   --post-card-surface-elevated: ${({ theme }) => theme.publicDesign.surfaceElevated};
-  --post-card-shadow-current: ${({ theme }) =>
-    theme.scheme === "light" ? "0 12px 34px rgba(15, 23, 42, 0.08)" : "0 12px 34px rgba(1, 4, 9, 0.26)"};
-  --post-card-shadow-hover-current: ${({ theme }) =>
-    theme.scheme === "light" ? "0 18px 42px rgba(15, 23, 42, 0.13)" : "0 20px 52px rgba(1, 4, 9, 0.36)"};
   --post-card-cover-text: ${({ theme }) => theme.colors.gray12};
   --post-card-cover-muted: ${({ theme }) => theme.colors.gray10};
   --post-card-cover-bg: ${({ theme }) =>
-    theme.scheme === "light"
-      ? "linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(34, 197, 94, 0.08)), #f8fafc"
-      : "linear-gradient(135deg, rgba(88, 166, 255, 0.2), rgba(126, 231, 135, 0.08)), #111722"};
+    `linear-gradient(135deg, ${theme.publicDesign.accentMuted}, ${theme.colors.gray2}), ${theme.publicDesign.readableSurface}`};
 
   &:focus-visible {
-    outline: 3px solid var(--post-card-focus-ring);
+    outline: 2px solid var(--post-card-focus-ring);
     outline-offset: 3px;
   }
 
-  &:focus-visible article {
-    border-color: var(--post-card-border-strong);
-    box-shadow: var(--post-card-shadow-hover-current);
-  }
-
   article {
-    overflow: hidden;
     position: relative;
     width: 100%;
     max-width: 100%;
     min-width: 0;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    border-radius: ${FEED_CARD_RADIUS_PX}px;
-    border: ${({ theme }) => `${theme.variables.ui.card.borderWidth}px solid var(--post-card-border-color)`};
-    background:
-      ${({ theme }) =>
-        theme.scheme === "light"
-          ? "linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(255, 255, 255, 0.98))"
-          : "linear-gradient(180deg, rgba(33, 38, 45, 0.34), rgba(22, 27, 34, 0.98))"},
-      var(--post-card-surface);
-    box-shadow: var(--post-card-shadow-current);
+    display: grid;
+    grid-template-columns: 48px minmax(0, 1fr) 180px;
+    gap: 20px;
+    align-items: start;
+    border-bottom: 1px solid var(--post-card-border-color);
+    padding: 28px 0;
+    background: transparent;
+    color: ${({ theme }) => theme.colors.gray12};
 
-    > .thumbnail {
-      position: relative;
-      width: 100%;
-      max-width: 100%;
-      aspect-ratio: 1.92 / 1;
-      background-color: var(--post-card-surface-elevated);
-      overflow: hidden;
-      isolation: isolate;
-
-      img {
-        transition: transform 0.28s ease-in;
-      }
-
-      &.placeholder {
-        background: var(--post-card-surface-elevated);
-      }
-
-      &.brandCover {
-        min-height: 0;
-        aspect-ratio: 1.92 / 1;
-        display: grid;
-        align-content: end;
-        gap: 0.36rem;
-        padding: 1rem;
-        background:
-          radial-gradient(circle at 82% 18%, ${({ theme }) =>
-            theme.scheme === "light" ? "rgba(37, 99, 235, 0.16)" : "rgba(88, 166, 255, 0.28)"}, transparent 34%),
-          var(--post-card-cover-bg);
-        color: var(--post-card-cover-text);
-
-        .coverCategory {
-          width: fit-content;
-          border-radius: 999px;
-          border: 1px solid ${({ theme }) => theme.publicDesign.accent};
-          background: ${({ theme }) => theme.publicDesign.accentMuted};
-          color: ${({ theme }) => theme.colors.accentLink};
-          padding: 0.22rem 0.5rem;
-          font-size: 0.64rem;
-          line-height: 1.2;
-          font-weight: 860;
-        }
-
-        strong {
-          max-width: 12ch;
-          color: var(--post-card-cover-text);
-          font-size: clamp(1.35rem, 2.5vw, 2rem);
-          line-height: 0.94;
-          letter-spacing: -0.07em;
-          font-weight: 920;
-          text-transform: uppercase;
-        }
-
-        .coverBrand {
-          color: var(--post-card-cover-muted);
-          font-size: 0.7rem;
-          font-weight: 820;
-          letter-spacing: 0.02em;
-        }
-      }
-
-      &::after {
-        content: "";
-        position: absolute;
-        inset: 0;
-        background: linear-gradient(180deg, rgba(0, 0, 0, 0) 45%, rgba(0, 0, 0, 0.16) 100%);
-        opacity: 0.9;
-        pointer-events: none;
-      }
+    > .rowIndex {
+      align-self: start;
+      padding-top: 0.24rem;
+      color: ${({ theme }) => theme.colors.gray9};
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+      font-size: 0.72rem;
+      line-height: 1.4;
+      font-weight: 760;
     }
 
     > .content {
       display: grid;
-      grid-template-rows: auto auto auto auto;
       align-content: start;
       min-height: 0;
-      padding: ${({ theme }) => `${theme.variables.ui.card.padding}px`};
       gap: 0;
+      order: 0;
 
-      > .category {
-        width: fit-content;
-        margin-bottom: 0.42rem;
-        color: ${({ theme }) => (theme.scheme === "light" ? theme.colors.blue11 : theme.colors.accentLink)};
-        font-size: 0.7rem;
-        line-height: 1.2;
-        font-weight: 860;
-        letter-spacing: 0.035em;
-        text-transform: uppercase;
+      > .tagRow {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 7px;
+        margin-bottom: 9px;
+      }
+
+      .tag {
+        display: inline-flex;
+        align-items: center;
+        min-height: 26px;
+        padding: 0 8px;
+        border: 1px solid var(--post-card-border-color);
+        background: transparent;
+        color: ${({ theme }) => theme.colors.gray10};
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        font-size: 0.6875rem;
+        line-height: 1;
+        font-weight: 650;
       }
 
       > header {
         h2 {
           margin: 0;
           color: ${({ theme }) => theme.colors.gray12};
-          font-size: 1.12rem;
-          line-height: ${FEED_CARD_TITLE_LINE_HEIGHT};
-          font-weight: 840;
+          font-size: 24px;
+          line-height: 1.3;
+          font-weight: 820;
           letter-spacing: -0.035em;
           word-break: keep-all;
           overflow-wrap: anywhere;
@@ -320,14 +231,14 @@ const StyledWrapper = styled.a`
       }
 
       > .summary {
-        margin-top: 0.28rem;
-        height: 3.9375rem;
+        margin-top: 0;
+        max-width: 720px;
 
         p {
           margin: 0;
           color: ${({ theme }) => theme.colors.gray10};
-          font-size: 0.85rem;
-          line-height: ${FEED_CARD_SUMMARY_LINE_HEIGHT};
+          font-size: 0.875rem;
+          line-height: 1.7;
           letter-spacing: -0.01em;
           word-break: keep-all;
           overflow-wrap: anywhere;
@@ -341,11 +252,11 @@ const StyledWrapper = styled.a`
       > .meta {
         display: flex;
         flex-wrap: wrap;
-        gap: 0.42rem;
+        gap: 0.42rem 0.52rem;
         align-items: center;
-        margin-top: 0.6rem;
-        padding-bottom: 0.88rem;
+        margin-top: 14px;
         color: ${({ theme }) => theme.colors.gray10};
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
         font-size: ${FEED_CARD_META_FONT_SIZE_REM}rem;
         line-height: 1.45;
         letter-spacing: -0.01em;
@@ -366,172 +277,165 @@ const StyledWrapper = styled.a`
           }
         }
       }
+    }
 
-      > .footer {
-        margin-top: auto;
-        padding-top: 0.74rem;
-        border-top: 1px solid var(--post-card-border-color);
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 0.6rem;
+    > .side {
+      min-width: 0;
+      align-self: stretch;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      justify-content: space-between;
+      gap: 1rem;
 
-        .author {
-          display: inline-flex;
-          align-items: center;
-          gap: 0.42rem;
-          min-width: 0;
+      .date {
+        color: ${({ theme }) => theme.colors.gray9};
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        font-size: 0.68rem;
+        line-height: 1.4;
+        font-weight: 680;
+      }
 
-          .avatar {
-            position: relative;
-            width: 24px;
-            height: 24px;
-            border-radius: 999px;
-            overflow: hidden;
-            flex: 0 0 auto;
-            border: none;
-            background: var(--post-card-surface-elevated);
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
+      .thumbnail {
+        position: relative;
+        width: 180px;
+        aspect-ratio: 1.5 / 1;
+        border: 1px solid var(--post-card-border-color);
+        background-color: var(--post-card-surface-elevated);
+        overflow: hidden;
+        isolation: isolate;
 
-            .initial {
-              font-size: 0.72rem;
-              font-weight: 800;
-              color: ${({ theme }) => theme.colors.gray12};
-            }
-          }
-
-          .by {
-            color: ${({ theme }) => theme.colors.gray10};
-            font-size: 0.72rem;
-          }
-
-          strong {
-            color: ${({ theme }) => theme.colors.gray12};
-            font-size: 0.76rem;
-            font-weight: 760;
-            line-height: 1.2;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            max-width: clamp(84px, 18vw, 170px);
-          }
+        img {
+          z-index: 1;
+          transition: transform 0.28s ease-in;
         }
 
-        .like {
-          display: inline-flex;
-          align-items: center;
-          gap: 0.42rem;
-          color: ${({ theme }) => theme.colors.gray10};
-          font-size: 0.75rem;
-          font-weight: 700;
-
-          svg {
-            width: 0.75rem;
-            height: 0.75rem;
-            color: #ff7b72;
-          }
+        .imageFallback {
+          position: absolute;
+          inset: 0;
+          z-index: 0;
+          display: grid;
+          align-content: end;
+          gap: 0.24rem;
+          padding: 0.62rem;
+          background: var(--post-card-cover-bg);
+          color: var(--post-card-cover-text);
         }
+
+        .coverCategory {
+          width: fit-content;
+          border: 1px solid ${({ theme }) => theme.publicDesign.accent};
+          background: ${({ theme }) => theme.publicDesign.accentMuted};
+          color: ${({ theme }) => theme.colors.accentLink};
+          padding: 0.14rem 0.34rem;
+          font-size: 0.54rem;
+          line-height: 1.2;
+          font-weight: 800;
+        }
+
+        strong {
+          max-width: 10ch;
+          color: var(--post-card-cover-text);
+          font-size: 1rem;
+          line-height: 0.96;
+          letter-spacing: -0.06em;
+          font-weight: 900;
+          text-transform: uppercase;
+        }
+
+        .coverBrand {
+          color: var(--post-card-cover-muted);
+          font-size: 0.58rem;
+          font-weight: 780;
+        }
+
+        &::after {
+          content: "";
+          position: absolute;
+          inset: 0;
+          background: ${({ theme }) => theme.publicDesign.accentMuted};
+          opacity: 0.45;
+          z-index: 2;
+          pointer-events: none;
+        }
+      }
+
+      .arrowBtn {
+        width: 2.125rem;
+        height: 2.125rem;
+        border: 1px solid var(--post-card-border-color);
+        display: grid;
+        place-items: center;
+        color: ${({ theme }) => theme.colors.gray10};
+      }
+
+      .arrowBtn::before {
+        content: "";
+        width: 0.46rem;
+        height: 0.46rem;
+        border-top: 1.5px solid currentColor;
+        border-right: 1.5px solid currentColor;
+        transform: rotate(45deg);
       }
     }
   }
 
   @media (hover: hover) and (pointer: fine) {
-    article {
-      transition:
-        transform 0.25s ease-in,
-        box-shadow 0.25s ease-in,
-        border-color 0.25s ease-in;
-    }
-
-    &:hover article,
-    &:focus-visible article {
-      transform: translateY(${({ theme }) => (theme.scheme === "light" ? "-2px" : "var(--post-card-translate-y)")});
-      box-shadow: var(--post-card-shadow-hover-current);
-      border-color: var(--post-card-border-strong);
-
-      > .thumbnail img {
-        transform: scale(${({ theme }) => (theme.scheme === "light" ? 1.01 : 1.025)});
+    &:hover {
+      article > .content h2 {
+        color: var(--post-card-border-strong);
       }
 
-      @media screen and (max-width: 1024px) {
-        transform: none;
+      article > .side .arrowBtn {
+        border-color: var(--post-card-border-strong);
+        color: var(--post-card-border-strong);
+      }
+
+      article > .side .thumbnail img {
+        transform: scale(1.025);
+      }
+    }
+  }
+
+  @media (max-width: 900px) {
+    article {
+      grid-template-columns: 32px minmax(0, 1fr);
+      gap: 20px;
+
+      > .side {
+        grid-column: 2;
+        align-items: stretch;
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+
+        .date {
+          display: none;
+        }
+
+        .thumbnail {
+          width: min(100%, 18rem);
+        }
       }
     }
   }
 
   @media (max-width: 640px) {
-    --post-card-translate-y: -4px;
-
     article {
-      border-radius: ${FEED_CARD_RADIUS_PX}px;
-
-      > .thumbnail {
-        max-height: 232px;
+      > .content > header h2 {
+        font-size: 1.18rem;
       }
 
-      > .content {
-        padding: ${({ theme }) => `${theme.variables.ui.card.padding}px`};
-
-        > header h2 {
-          -webkit-line-clamp: 2;
-        }
-
-        > .summary p {
-          -webkit-line-clamp: 3;
-        }
-
-        > .summary {
-          height: 3.9375rem;
-        }
-
-        > .footer {
-          .author strong {
-            max-width: 132px;
-          }
-        }
+      > .content > .summary p {
+        -webkit-line-clamp: 3;
       }
-    }
-  }
 
-  &[data-layout="regular"] {
-    @media (min-width: 1201px) {
-      article {
-        > .content {
-          padding: 1rem 1rem 0.88rem;
+      > .content > .meta {
+        font-size: 0.66rem;
 
-          > header h2 {
-            font-size: 1rem;
-            line-height: 1.4;
-            -webkit-line-clamp: 2;
-          }
-
-          > .summary {
-            margin-top: 0.34rem;
-            height: 3.9375rem;
-
-            p {
-              font-size: 0.875rem;
-              line-height: ${FEED_CARD_SUMMARY_LINE_HEIGHT};
-            }
-          }
-
-          > .meta {
-            flex-wrap: nowrap;
-            margin-top: 0.68rem;
-            padding-bottom: 0.92rem;
-            line-height: 1.45;
-            min-width: 0;
-
-            .comment {
-              white-space: nowrap;
-            }
-          }
-
-          > .footer {
-            margin-top: 0;
-            padding-top: 0.62rem;
+        .comment {
+          svg {
+            width: 0.78rem;
+            height: 0.78rem;
           }
         }
       }
@@ -540,7 +444,7 @@ const StyledWrapper = styled.a`
 
   @media (prefers-reduced-motion: reduce) {
     article,
-    article > .thumbnail img {
+    article > .side .thumbnail img {
       transition: none;
     }
   }

--- a/front/src/routes/Feed/PostList/PostCard.tsx
+++ b/front/src/routes/Feed/PostList/PostCard.tsx
@@ -117,7 +117,7 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular", index = 0 }) => {
         </div>
         <div className="side">
           <span className="date">{createdAtText}</span>
-          <div className="thumbnail" aria-label={`${data.title} 미리보기`}>
+          <div className="thumbnail" role="img" aria-label={`${data.title} 미리보기`}>
             {thumbnailSrc && !thumbnailFailed ? (
               <ProfileImage
                 src={thumbnailSrc}

--- a/front/src/routes/Feed/PostList/PostCard.tsx
+++ b/front/src/routes/Feed/PostList/PostCard.tsx
@@ -5,7 +5,7 @@ import styled from "@emotion/styled"
 import { uiTokens } from "@shared/ui-tokens"
 import { toCanonicalPostPath } from "src/libs/utils/postPath"
 import AppIcon from "src/components/icons/AppIcon"
-import { memo, useCallback, useMemo, type MouseEvent } from "react"
+import { memo, useCallback, useEffect, useMemo, useState, type MouseEvent } from "react"
 import ProfileImage from "src/components/ProfileImage"
 import Router from "next/router"
 import {
@@ -26,12 +26,12 @@ const FEED_CARD_META_FONT_SIZE_REM = uiTokens.feed.card.metaFontSizeRem
 const FEED_CARD_SUMMARY_LINES = uiTokens.feed.card.summaryLines
 const INTERNAL_CATEGORY_TAGS = new Set(["Pinned"])
 
-const toDisplayCategoryLabel = (post: TPost) => {
-  const rawLabel =
-    post.category?.[0] ||
-    post.tags?.find((tag) => !INTERNAL_CATEGORY_TAGS.has(tag)) ||
-    "Engineering"
-  return splitCategoryDisplay(rawLabel).label
+const toDisplayCategoryLabels = (post: TPost) => {
+  const labels = [...(post.category ?? []), ...(post.tags ?? [])]
+    .filter((tag) => !INTERNAL_CATEGORY_TAGS.has(tag))
+    .map((tag) => splitCategoryDisplay(tag).label)
+  const uniqueLabels = Array.from(new Set(labels))
+  return uniqueLabels.length > 0 ? uniqueLabels : ["Engineering"]
 }
 
 const PostCard: React.FC<Props> = ({ data, layout = "regular", index = 0 }) => {
@@ -41,9 +41,10 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular", index = 0 }) => {
     CONFIG.lang
   )
   const summary = normalizeCardSummary(data.summary)
+  const likesCount = data.likesCount ?? 0
   const commentsCount = data.commentsCount ?? 0
-  const categoryLabel = toDisplayCategoryLabel(data)
-  const readMinutes = Math.max(4, Math.ceil(((data.title?.length || 0) + (summary?.length || 0)) / 120))
+  const categoryLabels = toDisplayCategoryLabels(data)
+  const coverCategoryLabel = categoryLabels[0]
   const viewsCount = data.hitCount ?? 0
   const viewsText =
     viewsCount >= 1000 ? `${(viewsCount / 1000).toFixed(viewsCount >= 10000 ? 0 : 1)}k views` : `${viewsCount} views`
@@ -56,6 +57,8 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular", index = 0 }) => {
       thumbnailZoom: parseThumbnailZoomFromUrl(rawThumbnail),
     }
   }, [data.thumbnail])
+  const [thumbnailFailed, setThumbnailFailed] = useState(false)
+  useEffect(() => setThumbnailFailed(false), [thumbnailSrc])
 
   const handleNavigate = useCallback(
     (event: MouseEvent<HTMLAnchorElement>) => {
@@ -84,7 +87,11 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular", index = 0 }) => {
         </span>
         <div className="content">
           <div className="tagRow">
-            <span className="tag">{categoryLabel.toUpperCase()}</span>
+            {categoryLabels.map((categoryLabel) => (
+              <span className="tag" key={categoryLabel}>
+                {categoryLabel.toUpperCase()}
+              </span>
+            ))}
           </div>
           <header>
             <h2>{data.title}</h2>
@@ -95,9 +102,12 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular", index = 0 }) => {
           <div className="meta">
             <span>{createdAtText}</span>
             <span className="dot">·</span>
-            <span>{readMinutes} min read</span>
-            <span className="dot">·</span>
             <span>{viewsText}</span>
+            <span className="dot">·</span>
+            <span className="like">
+              <AppIcon name="heart" />
+              {likesCount}개의 좋아요
+            </span>
             <span className="dot">·</span>
             <span className="comment">
               <AppIcon name="message" />
@@ -108,12 +118,7 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular", index = 0 }) => {
         <div className="side">
           <span className="date">{createdAtText}</span>
           <div className="thumbnail" aria-label={`${data.title} 미리보기`}>
-            <div className="imageFallback" aria-hidden="true">
-              <span className="coverCategory">{categoryLabel}</span>
-              <strong>{data.title}</strong>
-              <span className="coverBrand">AquilaLog</span>
-            </div>
-            {thumbnailSrc ? (
+            {thumbnailSrc && !thumbnailFailed ? (
               <ProfileImage
                 src={thumbnailSrc}
                 alt=""
@@ -121,6 +126,7 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular", index = 0 }) => {
                 fillContainer
                 priority={layout === "pinned"}
                 loading={layout === "pinned" ? "eager" : "lazy"}
+                onError={() => setThumbnailFailed(true)}
                 style={{
                   objectFit: "cover",
                   objectPosition: `${thumbnailFocusX}% ${thumbnailFocusY}%`,
@@ -128,7 +134,13 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular", index = 0 }) => {
                   transformOrigin: `${thumbnailFocusX}% ${thumbnailFocusY}%`,
                 }}
               />
-            ) : null}
+            ) : (
+              <div className="imageFallback" aria-hidden="true">
+                <span className="coverCategory">{coverCategoryLabel}</span>
+                <strong>{data.title}</strong>
+                <span className="coverBrand">AquilaLog</span>
+              </div>
+            )}
           </div>
           <span className="arrowBtn" aria-hidden="true">
           </span>
@@ -265,6 +277,7 @@ const StyledWrapper = styled.a`
           opacity: 0.56;
         }
 
+        .like,
         .comment {
           display: inline-flex;
           align-items: center;
@@ -349,15 +362,6 @@ const StyledWrapper = styled.a`
           font-weight: 780;
         }
 
-        &::after {
-          content: "";
-          position: absolute;
-          inset: 0;
-          background: ${({ theme }) => theme.publicDesign.accentMuted};
-          opacity: 0.45;
-          z-index: 2;
-          pointer-events: none;
-        }
       }
 
       .arrowBtn {
@@ -432,6 +436,7 @@ const StyledWrapper = styled.a`
       > .content > .meta {
         font-size: 0.66rem;
 
+        .like,
         .comment {
           svg {
             width: 0.78rem;

--- a/front/src/routes/Feed/PostList/index.tsx
+++ b/front/src/routes/Feed/PostList/index.tsx
@@ -201,7 +201,7 @@ const PostList: React.FC<Props> = ({
             className="deferredPostCardWrap"
           >
             {shouldMountCard ? (
-              <PostCard data={post} layout="regular" />
+              <PostCard data={post} layout="regular" index={index} />
             ) : (
               <article className="deferredPostCardPlaceholder" aria-hidden="true" />
             )}
@@ -252,22 +252,12 @@ const PostList: React.FC<Props> = ({
 export default memo(PostList)
 
 const StyledWrapper = styled.div`
-  margin: 0.9rem 0 0.35rem;
+  margin: 0;
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: 1rem;
+  gap: 0;
   align-items: start;
   overflow-anchor: none;
-
-  @media (min-width: 768px) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 2rem;
-  }
-
-  @media (min-width: 1440px) {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 2rem;
-  }
 
   .emptyState {
     grid-column: 1 / -1;
@@ -479,27 +469,26 @@ const StyledWrapper = styled.div`
     width: 100%;
     display: grid;
     grid-template-columns: minmax(0, 1fr);
-    gap: 1rem;
+    gap: 0.85rem;
     align-items: start;
 
     @media (min-width: 768px) {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 2rem;
+      grid-template-columns: minmax(0, 1fr);
     }
 
     @media (min-width: 1440px) {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 2rem;
+      grid-template-columns: minmax(0, 1fr);
     }
   }
 
   .skeletonCard {
     position: relative;
     overflow: hidden;
-    min-height: 26rem;
-    border-radius: 15px;
-    border: 1px solid ${({ theme }) => theme.colors.gray5};
-    background: ${({ theme }) => theme.colors.gray2};
+    min-height: 11.5rem;
+    border-radius: 0;
+    border: 0;
+    border-bottom: 1px solid ${({ theme }) => theme.colors.gray5};
+    background: transparent;
 
     &::before,
     &::after {
@@ -517,14 +506,15 @@ const StyledWrapper = styled.div`
     }
 
     &::before {
-      width: 100%;
-      aspect-ratio: 1.92 / 1;
+      width: min(100%, 12rem);
+      aspect-ratio: 1.45 / 1;
+      margin-left: auto;
     }
 
     &::after {
-      margin: 0.95rem 1rem 1rem;
-      border-radius: 10px;
-      min-height: 10.6rem;
+      margin: 0.95rem 0 1rem;
+      border-radius: 4px;
+      min-height: 4.4rem;
     }
   }
 
@@ -535,17 +525,10 @@ const StyledWrapper = styled.div`
 
   .deferredPostCardPlaceholder {
     width: 100%;
-    min-height: 26rem;
-    border-radius: 4px;
-    border: ${({ theme }) => `${theme.variables.ui.card.borderWidth}px solid ${theme.colors.gray4}`};
-    background:
-      linear-gradient(
-        180deg,
-        ${({ theme }) => theme.colors.gray2} 0%,
-        ${({ theme }) => theme.colors.gray2} 45%,
-        ${({ theme }) => theme.colors.gray1} 45%,
-        ${({ theme }) => theme.colors.gray1} 100%
-      );
+    min-height: 11.5rem;
+    border-radius: 0;
+    border-bottom: ${({ theme }) => `${theme.variables.ui.card.borderWidth}px solid ${theme.colors.gray4}`};
+    background: transparent;
   }
 
   @media (max-width: 640px) {

--- a/front/src/routes/Feed/SearchInput.tsx
+++ b/front/src/routes/Feed/SearchInput.tsx
@@ -61,14 +61,14 @@ const StyledWrapper = styled.div`
   > .field {
     display: flex;
     align-items: center;
-    gap: 0.42rem;
+    gap: 7px;
     min-width: 0;
-    min-height: ${FEED_SEARCH_FIELD_MIN_HEIGHT_PX}px;
-    padding: 0 0.56rem;
+    min-height: 36px;
+    padding: 0 10px;
     border-radius: ${({ theme }) => `${theme.variables.ui.button.radius}px`};
-    border: 1px solid var(--feed-search-border);
-    background: var(--feed-search-surface);
-    box-shadow: 0 0 0 1px var(--feed-search-accent-muted);
+    border: 1px solid ${({ theme }) => theme.publicDesign.border};
+    background: ${({ theme }) => theme.publicDesign.readableSurface};
+    box-shadow: none;
     transition: border-color 0.125s ease-in, background-color 0.125s ease-in, box-shadow 0.125s ease-in;
 
     .searchIcon {
@@ -76,7 +76,7 @@ const StyledWrapper = styled.div`
       align-items: center;
       justify-content: center;
       flex: 0 0 auto;
-      color: #8b949e;
+      color: ${({ theme }) => theme.colors.gray9};
       width: 15px;
       height: 15px;
       transition: color 0.125s ease-in;
@@ -93,12 +93,12 @@ const StyledWrapper = styled.div`
       justify-content: center;
       flex: 0 0 auto;
       min-width: 56px;
-      height: 26px;
-      padding: 0 0.52rem;
-      border-radius: ${({ theme }) => `${theme.variables.ui.button.radiusPill}px`};
-      border: 1px solid var(--feed-search-border);
+      height: 24px;
+      padding: 0 0.5rem;
+      border-radius: ${({ theme }) => `${theme.variables.ui.button.radius}px`};
+      border: 1px solid ${({ theme }) => theme.publicDesign.border};
       background: transparent;
-      color: #8b949e;
+      color: ${({ theme }) => theme.colors.gray10};
       font-size: 0.74rem;
       font-weight: 700;
       letter-spacing: 0;
@@ -107,9 +107,9 @@ const StyledWrapper = styled.div`
       transition: all 0.125s ease-in;
 
       &:hover {
-        color: #f0f6fc;
-        border-color: var(--feed-search-border-strong);
-        background: var(--feed-search-accent-muted);
+        color: ${({ theme }) => theme.colors.gray12};
+        border-color: ${({ theme }) => theme.publicDesign.accent};
+        background: ${({ theme }) => theme.publicDesign.accentMuted};
       }
 
       @media (max-width: ${FEED_TAG_RAIL_CHIP_MAX_PX}px) {
@@ -119,15 +119,15 @@ const StyledWrapper = styled.div`
   }
 
   > .field > .mid {
-    width: 100%;
+    width: 180px;
     min-width: 0;
-    min-height: 36px;
-    padding: 0.32rem 0;
-    font-size: 0.84rem;
+    min-height: 34px;
+    padding: 0;
+    font-size: 0.8125rem;
     font-weight: 560;
     line-height: 1.4;
-    color: #f0f6fc;
-    caret-color: #f0f6fc;
+    color: ${({ theme }) => theme.colors.gray12};
+    caret-color: ${({ theme }) => theme.publicDesign.accent};
     border: 0;
     outline: none;
     box-shadow: none;
@@ -137,7 +137,7 @@ const StyledWrapper = styled.div`
     transition: all 0.125s ease-in;
 
     &::placeholder {
-      color: #8b949e;
+      color: ${({ theme }) => theme.colors.gray9};
       opacity: 1;
       transition: opacity 0.12s ease-in;
     }
@@ -155,17 +155,18 @@ const StyledWrapper = styled.div`
   }
 
   > .field:focus-within {
-    border-color: var(--feed-search-border-strong);
-    background: var(--feed-search-surface-elevated);
-    box-shadow: 0 0 0 1px var(--feed-search-accent-muted);
+    border-color: ${({ theme }) => theme.publicDesign.accent};
+    background: ${({ theme }) => theme.publicDesign.readableSurface};
+    box-shadow: none;
 
     .searchIcon {
-      color: #c9d1d9;
+      color: ${({ theme }) => theme.colors.gray11};
     }
   }
 
   @media (max-width: 768px) {
     > .field {
+      height: auto;
       min-height: ${MOBILE_TOUCH_TARGET_MIN_PX}px;
       padding: 0 0.5rem;
       border-radius: ${({ theme }) => `${Math.max(theme.variables.ui.button.radius - 1, 6)}px`};

--- a/front/src/routes/Feed/SearchInput.tsx
+++ b/front/src/routes/Feed/SearchInput.tsx
@@ -65,7 +65,7 @@ const StyledWrapper = styled.div`
     min-width: 0;
     min-height: 36px;
     padding: 0 10px;
-    border-radius: ${({ theme }) => `${theme.variables.ui.button.radius}px`};
+    border-radius: 0;
     border: 1px solid ${({ theme }) => theme.publicDesign.border};
     background: ${({ theme }) => theme.publicDesign.readableSurface};
     box-shadow: none;
@@ -95,7 +95,7 @@ const StyledWrapper = styled.div`
       min-width: 56px;
       height: 24px;
       padding: 0 0.5rem;
-      border-radius: ${({ theme }) => `${theme.variables.ui.button.radius}px`};
+      border-radius: 0;
       border: 1px solid ${({ theme }) => theme.publicDesign.border};
       background: transparent;
       color: ${({ theme }) => theme.colors.gray10};
@@ -169,7 +169,7 @@ const StyledWrapper = styled.div`
       height: auto;
       min-height: ${MOBILE_TOUCH_TARGET_MIN_PX}px;
       padding: 0 0.5rem;
-      border-radius: ${({ theme }) => `${Math.max(theme.variables.ui.button.radius - 1, 6)}px`};
+      border-radius: 0;
     }
 
     > .field > .mid {

--- a/front/src/routes/Feed/TagList.tsx
+++ b/front/src/routes/Feed/TagList.tsx
@@ -106,11 +106,9 @@ const TagList: React.FC = () => {
       <section
         className="desktopPanel"
         aria-label="태그 목록"
-        aria-hidden="true"
       >
         <h2 className="panelTitle">
-          <span className="panelEmoji" aria-hidden="true">🏷️</span>
-          <span>태그 목록</span>
+          <span>Topics</span>
         </h2>
         <ul className="desktopList">
           <li>
@@ -121,8 +119,8 @@ const TagList: React.FC = () => {
               aria-label="전체보기"
               onClick={handleClickAll}
             >
-              <span className="name">전체보기</span>
-              {typeof allCount === "number" && <span className="count">({allCount})</span>}
+              <span className="name">전체</span>
+              {typeof allCount === "number" && <span className="count">{allCount}</span>}
             </button>
           </li>
           {desktopTagEntries.map(([key, count]) => (
@@ -132,11 +130,10 @@ const TagList: React.FC = () => {
                 data-tag={key}
                 data-active={key === currentTag}
                 aria-pressed={key === currentTag}
-                aria-label={`Filter by tag: ${key}`}
                 onClick={handleClickTagButton}
               >
                 <span className="name">{key}</span>
-                <span className="count">({count})</span>
+                <span className="count">{String(count).padStart(2, "0")}</span>
               </button>
             </li>
           ))}
@@ -176,7 +173,6 @@ const TagList: React.FC = () => {
             data-tag={key}
             data-active={key === currentTag}
             aria-pressed={key === currentTag}
-            aria-label={`Filter by tag: ${key}`}
             onClick={handleClickTagButton}
           >
             <span className="name">{key}</span>
@@ -203,14 +199,14 @@ export default memo(TagList)
 
 const StyledWrapper = styled.div`
   min-width: 0;
-  --feed-tag-border: #30363d;
-  --feed-tag-border-strong: #58a6ff;
-  --feed-tag-hover-border: #8b949e;
-  --feed-tag-surface: #161b22;
-  --feed-tag-surface-elevated: #21262d;
-  --feed-tag-accent: #58a6ff;
-  --feed-tag-accent-text: #58a6ff;
-  --feed-tag-accent-muted: rgba(88, 166, 255, 0.14);
+  --feed-tag-border: ${({ theme }) => theme.publicDesign.border};
+  --feed-tag-border-strong: ${({ theme }) => theme.publicDesign.accent};
+  --feed-tag-hover-border: ${({ theme }) => theme.colors.gray9};
+  --feed-tag-surface: ${({ theme }) => theme.publicDesign.readableSurface};
+  --feed-tag-surface-elevated: ${({ theme }) => theme.publicDesign.surfaceElevated};
+  --feed-tag-accent: ${({ theme }) => theme.publicDesign.accent};
+  --feed-tag-accent-text: ${({ theme }) => theme.publicDesign.accent};
+  --feed-tag-accent-muted: ${({ theme }) => theme.publicDesign.accentMuted};
 
   .desktopPanel {
     display: none;
@@ -224,34 +220,28 @@ const StyledWrapper = styled.div`
 
   .panelTitle {
     margin: 0;
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.9rem;
-    font-weight: 740;
-    letter-spacing: -0.01em;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.82rem;
+    font-weight: 820;
+    letter-spacing: 0;
     line-height: 1.5;
-    padding: 0 0 0.42rem;
-    border-bottom: 1px solid var(--feed-tag-border);
+    padding: 0;
     display: inline-flex;
     align-items: center;
     gap: 0.44rem;
   }
 
   .panelEmoji {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.02rem;
-    line-height: 1;
-    transform: rotate(62deg) translateY(-0.02rem);
-    transform-origin: 48% 56%;
+    display: none;
   }
 
   .desktopList {
     list-style: none;
-    margin: 0.88rem 0 0;
+    margin: 18px 0 0;
     padding: 0;
     display: grid;
-    gap: 0.18rem;
+    gap: 0;
+    border-top: 1px solid ${({ theme }) => theme.colors.gray12};
     max-height: calc(100vh - var(--app-header-height, 56px) - 6.35rem);
     max-height: calc(100dvh - var(--app-header-height, 56px) - 6.35rem);
     overflow-y: auto;
@@ -273,13 +263,14 @@ const StyledWrapper = styled.div`
     width: 100%;
     min-height: 0;
     border: 0;
-    border-radius: 4px;
+    border-radius: 0;
     background: transparent;
-    padding: 0.12rem 0;
-    display: flex;
+    padding: 12px 0;
+    border-bottom: 1px solid var(--feed-tag-border);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: baseline;
-    justify-content: flex-start;
-    gap: 0.42rem;
+    gap: 16px;
     text-align: left;
     color: ${({ theme }) => theme.colors.gray10};
     cursor: pointer;
@@ -329,8 +320,7 @@ const StyledWrapper = styled.div`
 
   .desktopList button .name {
     min-width: 0;
-    flex: 0 1 auto;
-    font-size: 0.84rem;
+    font-size: 0.8rem;
     font-weight: 610;
     color: ${({ theme }) => theme.colors.gray10};
     white-space: nowrap;
@@ -345,8 +335,7 @@ const StyledWrapper = styled.div`
   }
 
   .desktopList button .count {
-    flex: 0 0 auto;
-    font-size: 0.78rem;
+    font-size: 0.72rem;
     color: ${({ theme }) => theme.colors.gray10};
     font-variant-numeric: tabular-nums;
   }
@@ -383,11 +372,15 @@ const StyledWrapper = styled.div`
       height: 0;
     }
 
-    @media (min-width: ${FEED_TAG_RAIL_DESKTOP_MIN_PX}px) {
-      justify-content: center;
-      flex-wrap: wrap;
-      overflow-x: visible;
-      padding-bottom: 0;
+  }
+
+  @media (min-width: ${FEED_TAG_RAIL_DESKTOP_MIN_PX}px) {
+    .desktopPanel {
+      display: block;
+    }
+
+    .chipRail {
+      display: none;
     }
   }
 

--- a/front/src/routes/Feed/TagList.tsx
+++ b/front/src/routes/Feed/TagList.tsx
@@ -272,18 +272,13 @@ const StyledWrapper = styled.div`
     align-items: baseline;
     gap: 16px;
     text-align: left;
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${({ theme }) => theme.colors.gray9};
     cursor: pointer;
-    transition: all 0.125s ease-in;
+    transition: color 0.125s ease-in;
 
     &:hover {
       background: transparent;
       color: ${({ theme }) => theme.colors.gray12};
-
-      .name {
-        text-decoration: underline;
-        text-underline-offset: 2px;
-      }
     }
 
     &:focus-visible {
@@ -293,6 +288,7 @@ const StyledWrapper = styled.div`
 
     &[data-active="true"] {
       background: transparent;
+      color: ${({ theme }) => theme.colors.gray12};
     }
   }
 
@@ -322,26 +318,32 @@ const StyledWrapper = styled.div`
     min-width: 0;
     font-size: 0.8rem;
     font-weight: 610;
-    color: ${({ theme }) => theme.colors.gray10};
+    color: inherit;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
   .desktopList button[data-active="true"] .name {
-    color: var(--feed-tag-accent-text);
-    font-weight: 700;
+    color: inherit;
+    font-weight: 800;
     text-decoration: none;
+  }
+
+  .desktopList button:hover .name {
+    color: ${({ theme }) => theme.colors.gray12};
+    font-weight: 800;
   }
 
   .desktopList button .count {
     font-size: 0.72rem;
-    color: ${({ theme }) => theme.colors.gray10};
+    color: ${({ theme }) => theme.colors.gray8};
     font-variant-numeric: tabular-nums;
   }
 
+  .desktopList button:hover .count,
   .desktopList button[data-active="true"] .count {
-    color: var(--feed-tag-accent-text);
+    color: ${({ theme }) => theme.colors.gray12};
   }
 
   .chipRail {
@@ -396,7 +398,7 @@ const StyledWrapper = styled.div`
     border: 0;
     background: transparent;
     padding: 0.34rem 0.82rem;
-    color: #c9d1d9;
+    color: ${({ theme }) => theme.colors.gray9};
     flex-shrink: 0;
     scroll-snap-align: start;
     cursor: pointer;
@@ -415,6 +417,9 @@ const StyledWrapper = styled.div`
     }
 
     &:hover {
+      color: ${({ theme }) => theme.colors.gray12};
+      font-weight: 760;
+
       &::after {
         border-color: var(--feed-tag-hover-border);
         background: var(--feed-tag-surface-elevated);
@@ -448,7 +453,7 @@ const StyledWrapper = styled.div`
 
   .chipRail button .count {
     font-size: 0.72rem;
-    color: #8b949e;
+    color: ${({ theme }) => theme.colors.gray10};
   }
 
   .chipRail button[data-active="true"] .count {

--- a/front/src/routes/Feed/index.tsx
+++ b/front/src/routes/Feed/index.tsx
@@ -1,13 +1,10 @@
 import Footer from "./Footer"
 import styled from "@emotion/styled"
-import { startTransition, useCallback, useMemo } from "react"
+import { useMemo } from "react"
 import { AdminProfile, useAdminProfile } from "src/hooks/useAdminProfile"
 import { CONFIG } from "site.config"
 import FeedExplorer from "./FeedExplorer"
-import ProfileSummaryCard from "./ProfileSummaryCard"
 import { useTagsQuery } from "src/hooks/useTagsQuery"
-import { useRouter } from "next/router"
-import { replaceShallowRoutePreservingScroll } from "src/libs/router"
 
 type Props = {
   initialAdminProfile?: AdminProfile | null
@@ -17,7 +14,6 @@ type Props = {
 const TOPIC_RAIL_TAG_LIMIT = 3
 
 const Feed: React.FC<Props> = ({ initialAdminProfile = null, initialHomeBootstrapStatus = "ready" }) => {
-  const router = useRouter()
   const adminProfile = useAdminProfile(initialAdminProfile)
   const { tagEntries } = useTagsQuery()
   const topicEntries = useMemo(
@@ -25,31 +21,13 @@ const Feed: React.FC<Props> = ({ initialAdminProfile = null, initialHomeBootstra
     [tagEntries]
   )
   const introTitle =
-    adminProfile?.blogTitle || CONFIG.blog.title || "AquilaLog"
-  const introRole = adminProfile?.profileRole || CONFIG.profile.role || "Backend Engineering"
+    adminProfile?.homeIntroTitle || CONFIG.blog.homeIntroTitle || adminProfile?.blogTitle || CONFIG.blog.title || "AquilaLog"
+  const introRole = adminProfile?.profileRole || "Backend systems · production notes"
   const introDescription = adminProfile?.homeIntroDescription || CONFIG.blog.homeIntroDescription || CONFIG.blog.description
-
-  const navigateWithTag = useCallback((value: string) => {
-    const { category: _deprecatedCategory, ...restQuery } = router.query
-    startTransition(() => {
-      void replaceShallowRoutePreservingScroll(router, {
-        pathname: "/",
-        query: {
-          ...restQuery,
-          tag: value,
-        },
-      })
-    })
-  }, [router])
-
-  const handleClickTopic = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>) => {
-      const value = event.currentTarget.dataset.tag
-      if (!value) return
-      navigateWithTag(value)
-    },
-    [navigateWithTag]
-  )
+  const focusLabel = topicEntries.length > 0
+    ? topicEntries.map(([tag]) => tag).join(" · ")
+    : "Architecture · Security · Reliability"
+  const repositoryLabel = CONFIG.projects?.[0]?.href?.replace(/^https?:\/\//, "") || "AquilaXk/aquila-blog"
 
   return (
     <StyledWrapper data-ui="feed-home-product-shell">
@@ -61,24 +39,21 @@ const Feed: React.FC<Props> = ({ initialAdminProfile = null, initialHomeBootstra
             </span>
             <h1>{introTitle}</h1>
             <p>{introDescription}</p>
-            {topicEntries.length > 0 && (
-              <div className="topicRail" data-ui="feed-topic-rail" aria-label="인기 태그">
-                {topicEntries.map(([tag, count]) => (
-                  <button
-                    key={tag}
-                    type="button"
-                    data-ui="feed-topic-rail-chip"
-                    data-tag={tag}
-                    aria-label={`태그 ${tag} 글 ${count}개 보기`}
-                    onClick={handleClickTopic}
-                  >
-                    {tag}
-                  </button>
-                ))}
-              </div>
-            )}
           </div>
-          <ProfileSummaryCard initialAdminProfile={initialAdminProfile} />
+          <aside className="homeNote" aria-label="블로그 운영 정보">
+            <div className="noteRow">
+              <strong>Focus</strong>
+              <span>{focusLabel}</span>
+            </div>
+            <div className="noteRow">
+              <strong>Updated</strong>
+              <span>최신 글 기준</span>
+            </div>
+            <div className="noteRow">
+              <strong>Repository</strong>
+              <span>{repositoryLabel}</span>
+            </div>
+          </aside>
         </IntroCard>
         <FeedExplorer initialBootstrapDegraded={initialHomeBootstrapStatus === "degraded"} />
         <div className="footer">
@@ -92,7 +67,8 @@ const Feed: React.FC<Props> = ({ initialAdminProfile = null, initialHomeBootstra
 export default Feed
 
 const StyledWrapper = styled.div`
-  --feed-product-bg: ${({ theme }) => theme.publicDesign.pageBackgroundColor};
+  --feed-product-bg: ${({ theme }) =>
+    theme.scheme === "light" ? "color-mix(in srgb, white 97%, black)" : theme.publicDesign.pageBackgroundColor};
   --feed-product-panel: ${({ theme }) => theme.publicDesign.readableSurface};
   --feed-product-panel-hover: ${({ theme }) => theme.publicDesign.surfaceElevated};
   --feed-product-border: ${({ theme }) => theme.publicDesign.border};
@@ -107,7 +83,7 @@ const StyledWrapper = styled.div`
   position: relative;
   z-index: 0;
   isolation: isolate;
-  padding: 1.2rem 0 2.4rem;
+  padding: 0 0 2.4rem;
   color: var(--feed-product-text);
 
   &::before {
@@ -120,7 +96,6 @@ const StyledWrapper = styled.div`
     width: 100vw;
     transform: translateX(-50%);
     background:
-      radial-gradient(circle at 78% 0%, var(--feed-product-hero-glow), transparent 28rem),
       var(--feed-product-bg);
   }
 
@@ -131,7 +106,7 @@ const StyledWrapper = styled.div`
   > .mid {
     display: grid;
     min-width: 0;
-    gap: 1.35rem;
+    gap: 0;
 
     @media (max-width: 768px) {
       gap: 0.82rem;
@@ -140,17 +115,17 @@ const StyledWrapper = styled.div`
     > .footer {
       padding-bottom: 2rem;
     }
+
   }
 `
 
 const IntroCard = styled.section`
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(17rem, 20rem);
+  grid-template-columns: minmax(0, 1fr) 360px;
   align-items: end;
-  gap: clamp(1.2rem, 3vw, 2.4rem);
-  border-bottom: 1px solid ${({ theme }) =>
-    theme.scheme === "light" ? "rgba(200, 210, 222, 0.92)" : "rgba(48, 54, 61, 0.82)"};
-  padding: 0.2rem 0 1.3rem;
+  gap: 80px;
+  border-bottom: 1px solid var(--feed-product-border);
+  padding: 66px 0 42px;
 
   .introCopy {
     min-width: 0;
@@ -158,97 +133,100 @@ const IntroCard = styled.section`
 
   .brandLabel {
     display: block;
-    margin-bottom: 0.52rem;
+    margin-bottom: 14px;
     color: var(--feed-product-accent);
-    font-size: 0.78rem;
+    font-size: 0.6875rem;
     line-height: 1.2;
-    font-weight: 860;
-    letter-spacing: 0.02em;
+    font-weight: 820;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
 
   h1 {
-    margin: 0;
+    margin: 14px 0 22px;
     color: var(--feed-product-text);
-    font-size: clamp(2.6rem, 5vw, 4rem);
-    letter-spacing: -0.075em;
-    line-height: 0.96;
-    font-weight: 880;
-    max-width: 12ch;
+    font-size: clamp(42px, 5.1vw, 72px);
+    letter-spacing: -0.065em;
+    line-height: 1.04;
+    font-weight: 850;
+    max-width: 850px;
   }
 
   p {
-    margin: 0.82rem 0 0;
+    margin: 0;
     color: var(--feed-product-muted);
-    font-size: clamp(0.98rem, 1.3vw, 1.08rem);
-    line-height: 1.55;
+    font-size: 17px;
+    line-height: 1.75;
     letter-spacing: -0.018em;
-    max-width: 40rem;
+    max-width: 640px;
+    word-break: keep-all;
   }
 
-  .topicRail {
-    margin-top: 1rem;
-    display: flex;
-    align-items: center;
-    gap: 0.48rem;
-    flex-wrap: wrap;
+  .homeNote {
+    display: grid;
+    gap: 0;
+    border-top: 2px solid var(--feed-product-text);
+    padding-top: 14px;
   }
 
-  .topicRail button {
-    display: inline-flex;
-    align-items: center;
-    min-height: 30px;
-    border-radius: 999px;
-    border: 1px solid var(--feed-product-border);
-    background: var(--feed-product-chip-bg);
-    color: var(--feed-product-muted);
-    padding: 0 0.72rem;
-    font-size: 0.76rem;
-    font-weight: 780;
-    cursor: pointer;
-    appearance: none;
-    font-family: inherit;
+  .noteRow {
+    display: grid;
+    grid-template-columns: 72px minmax(0, 1fr);
+    gap: 16px;
+    border-bottom: 1px solid var(--feed-product-border);
+    padding: 0 0 13px;
+    margin-bottom: 18px;
   }
 
-  .topicRail button:hover,
-  .topicRail button:focus-visible {
-    border-color: var(--feed-product-accent);
+  .noteRow strong {
+    color: ${({ theme }) => theme.colors.gray9};
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 11px;
+    line-height: 1.5;
+    font-weight: 760;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .noteRow span {
+    min-width: 0;
     color: var(--feed-product-text);
-    outline: none;
+    font-size: 0.875rem;
+    line-height: 1.55;
+    font-weight: 720;
+    overflow-wrap: anywhere;
   }
 
   @media (max-width: 1024px) {
     grid-template-columns: minmax(0, 1fr);
-    align-items: start;
+    gap: 34px;
+
+    .homeNote {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .noteRow {
+      grid-template-columns: minmax(0, 1fr);
+    }
   }
 
   @media (max-width: 768px) {
-    padding-bottom: 0.18rem;
-
-    [data-ui="feed-profile-summary"] {
-      display: none;
-    }
+    padding: 44px 0 30px;
 
     h1 {
+      margin: 14px 0 20px;
       max-width: none;
-      font-size: clamp(2rem, 11vw, 2.55rem);
-      line-height: 1.1;
+      font-size: 42px;
+      line-height: 1.04;
     }
 
     p {
-      margin-top: 0.64rem;
       font-size: 0.95rem;
       line-height: 1.5;
     }
 
-    .topicRail {
-      margin-top: 0.28rem;
-      gap: 0.4rem;
-    }
-
-    .topicRail button {
-      min-height: 28px;
-      padding: 0 0.62rem;
-      font-size: 0.72rem;
+    .noteRow {
+      grid-template-columns: minmax(0, 1fr);
     }
   }
 `


### PR DESCRIPTION
## 관련 이슈

close #1057

## 작업 배경

- 공개 홈과 About 페이지를 AquilaLog V4 기준으로 맞추는 1차 PR입니다.
- 글작성 페이지, 글수정 페이지, 에디터, 어드민 전체 화면은 후속 PR 범위로 분리했습니다.

## 작업 내용

- 공개 헤더에서 임의 V4 마크를 제거하고 기존 `BrandMark`를 복구했습니다.
- 공개 헤더는 `Home / About` 중심으로 정리하고, 로그인 버튼은 비로그인 상태에서 유지하며 Admin 링크는 관리자 인증 상태에서만 노출되도록 조정했습니다.
- 홈 피드의 최신글 카드에 실제 백엔드 `post.thumbnail` 이미지를 표시하고, 이미지 로드 실패 시 빈 사각형 대신 fallback cover를 렌더하도록 했습니다.
- 피드 카드 메타에서 `min read`를 제거하고 조회수, 좋아요수, 댓글수와 여러 토픽을 함께 표시하도록 맞췄습니다.
- `최신순 / 조회순 / 좋아요순` 정렬 드롭다운과 검색창을 V4의 각진 컨트롤 톤으로 맞췄습니다.
- 토픽 hover는 밑줄 없이 V4 톤에 맞게 명도와 강조 차이가 보이도록 수정했습니다.
- About 페이지는 V4 stack 레이아웃으로 재구성하고, 실제 관리자 프로필 데이터와 원형 프로필 이미지를 표시하도록 연결했습니다.

## 검증

- 실행한 명령과 결과:
- `yarn --cwd front build`: exit 0
- `node front/scripts/check-bundle-size.mjs`: exit 0
- `yarn --cwd front playwright:preflight`: exit 0
- `yarn --cwd front playwright test e2e/smoke-feed-search.spec.ts --workers=1`: exit 0, 12 passed
- `yarn --cwd front test:e2e:smoke`: exit 0, 66 passed
- `yarn --cwd front test:e2e:smoke`: exit 0, 66 passed
- `git diff --check`: exit 0
- diff-scoped security scan: no new `dangerouslySetInnerHTML`, `eval`, `new Function`, `javascript:`, `document.write`, `localStorage`, `sessionStorage` usage in changed UI diff

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 홈 V4 피드/썸네일 | Desktop production local | Playwright screenshot + DOM metric | `/private/tmp/aquilalog-v4-home-desktop.png`, `cards=8`, `thumbnails=8`, `overflow=false` | 통과 |
| 홈 V4 피드/썸네일 | Mobile production local | Playwright screenshot + DOM metric | `/private/tmp/aquilalog-v4-home-mobile.png`, `cards=8`, `thumbnails=8`, `overflow=false` | 통과 |
| About V4 원형 프로필 | Desktop production local | Playwright screenshot + DOM metric | `/private/tmp/aquilalog-v4-about-desktop.png`, `avatarRadius=50%`, `overflow=false` | 통과 |
| About V4 원형 프로필 | Mobile production local | Playwright screenshot + DOM metric | `/private/tmp/aquilalog-v4-about-mobile.png`, `avatarRadius=50%`, `overflow=false` | 통과 |
| 썸네일 로드 실패 fallback | Chromium E2E | `smoke-feed-search.spec.ts` | `12 passed` | 통과 |
| 공개 smoke 회귀 | Chromium E2E | `test:e2e:smoke` 2회 연속 | `66 passed` / `66 passed` | 통과 |

로컬 screenshot은 production local 서버와 실제/fixture 데이터 조합으로 캡처한 검증 증거라 PR에 바이너리로 커밋하지 않았습니다.

## 리뷰어 메모

- 이 PR은 공개 메인 + About만 다룹니다.
- 글작성/글수정/에디터는 2차 PR, 어드민 전체 화면은 3차 PR에서 처리합니다.
- GitHub push 경고로 default branch의 기존 Dependabot 취약점 11개가 표시됐지만, 이번 PR은 새 의존성을 추가하지 않았고 변경 UI diff에서 위험 sink 추가는 확인되지 않았습니다.

## 리스크

- About SSR 프로필 요청은 외부 백엔드 응답 지연이 있으면 fallback 이후 클라이언트 재조회로 보정됩니다.
- 홈 thumbnail URL이 깨진 글은 이미지 대신 fallback cover가 표시됩니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 포스트 카드에 순번 표기 추가
  * 최근 글 카드에 정렬 드롭다운 추가
  * 피드 홈에 Focus/Updated/Repository 형태의 사이드 섹션 노출

* **스타일**
  * 헤더/로고 디자인 및 레이아웃 정비, 테마 토글 UI 개선
  * About 페이지 레이아웃 및 타이포그래피 재구성
  * SearchInput/태그 패널(Tatags→Topics) 및 전반 피드 카드/격자 스타일 개선

* **테스트**
  * E2E/성능 스냅샷 및 UI 검증 시나리오 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->