### PR TITLE
[Feat] AquilaLog V4 글작성 수정 에디터 적용

### DIFF
--- a/front/e2e/mobile-layout.spec.ts
+++ b/front/e2e/mobile-layout.spec.ts
@@ -79,8 +79,8 @@ test.describe("모바일 레이아웃 소스 경계", () => {
     expect(adminDashboardSource).toContain("adminSurface")
     expect(authShellSource).toContain("theme.colors.gray1")
     expect(errorSource).toContain("theme.colors.gray1")
-    expect(editorComposeSource).toContain("theme.colors.gray2")
-    expect(editorDedicatedSource).toContain("theme.colors.gray2")
+    expect(editorComposeSource).toContain("theme.publicDesign")
+    expect(editorDedicatedSource).toContain("theme.publicDesign")
     expect(editorPreviewSource).toContain("theme.colors.gray1")
     for (const source of [authShellSource, errorSource, editorComposeSource, editorDedicatedSource, editorPreviewSource]) {
       expect(source).not.toContain("theme.blogDesign")

--- a/front/src/routes/Admin/EditorStudioComposeWorkspace.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeWorkspace.tsx
@@ -243,14 +243,14 @@ const Button = styled.button `
 const PrimaryButton = styled(Button) `
   border-radius: 6px;
   padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => theme.publicDesign.accent};
-  background: ${({ theme }) => theme.publicDesign.accent};
+  border-color: ${({ theme }) => (theme.scheme === "dark" ? "#0a58ca" : "#0969da")};
+  background: ${({ theme }) => (theme.scheme === "dark" ? "#0a58ca" : "#0969da")};
   color: ${({ theme }) => theme.colors.accentControlText};
   font-weight: 700;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.accentControlHover};
-    background: ${({ theme }) => theme.colors.accentControlHover};
+    border-color: ${({ theme }) => (theme.scheme === "dark" ? "#084298" : "#075bb5")};
+    background: ${({ theme }) => (theme.scheme === "dark" ? "#084298" : "#075bb5")};
     color: ${({ theme }) => theme.colors.accentControlText};
   }
 `;

--- a/front/src/routes/Admin/EditorStudioComposeWorkspace.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeWorkspace.tsx
@@ -138,11 +138,10 @@ const ComposeSurfaceSection = styled.section `
   display: grid;
   gap: 1.2rem;
   border: 1px solid ${({ theme }) => (theme.colors.gray4)};
-  border-radius: ${({ theme }) => ("14px")};
+  border-radius: 6px;
   padding: 1.1rem 1.1rem 1.3rem;
   margin-bottom: 1.2rem;
-  background:
-    ${({ theme }) => `radial-gradient(circle at top left, rgba(96, 165, 250, 0.04), transparent 24%), ${theme.colors.gray1}`};
+  background: ${({ theme }) => theme.publicDesign.operationSurface};
   box-shadow: ${({ theme }) => ("none")};
 
   h2 {
@@ -153,7 +152,7 @@ const ComposeSurfaceSection = styled.section `
 
   @media (max-width: 420px) {
     gap: 1rem;
-    border-radius: 12px;
+    border-radius: 6px;
     padding: 0.82rem 0.82rem 1rem;
     margin-bottom: 0.95rem;
   }
@@ -210,7 +209,7 @@ const SubActionRow = styled.div `
 `;
 const Button = styled.button `
   border: 1px solid ${({ theme }) => (theme.colors.gray6)};
-  border-radius: 8px;
+  border-radius: 6px;
   padding: 0.62rem 0.92rem;
   min-height: 44px;
   background: ${({ theme }) => ("transparent")};
@@ -242,16 +241,16 @@ const Button = styled.button `
   }
 `;
 const PrimaryButton = styled(Button) `
-  border-radius: 8px;
+  border-radius: 6px;
   padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => (theme.colors.blue9)};
-  background: ${({ theme }) => (theme.colors.blue9)};
-  color: ${({ theme }) => (theme.colors.gray1)};
+  border-color: ${({ theme }) => theme.publicDesign.accent};
+  background: ${({ theme }) => theme.publicDesign.accent};
+  color: ${({ theme }) => theme.colors.accentControlText};
   font-weight: 700;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => (theme.colors.blue10)};
-    background: ${({ theme }) => (theme.colors.blue10)};
-    color: ${({ theme }) => (theme.colors.gray1)};
+    border-color: ${({ theme }) => theme.colors.accentControlHover};
+    background: ${({ theme }) => theme.colors.accentControlHover};
+    color: ${({ theme }) => theme.colors.accentControlText};
   }
 `;

--- a/front/src/routes/Admin/EditorStudioComposeWritingSurfaceParts.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeWritingSurfaceParts.tsx
@@ -62,8 +62,8 @@ export const ComposeStudioContextItem = styled.div `
   min-width: 7rem;
   padding: 0.5rem 0.68rem;
   border: 1px solid ${({ theme }) => (theme.colors.gray5)};
-  border-radius: ${({ theme }) => ("12px")};
-  background: ${({ theme }) => (theme.colors.gray2)};
+  border-radius: 6px;
+  background: ${({ theme }) => theme.publicDesign.surfaceElevated};
 
   span {
     color: ${({ theme }) => theme.colors.gray10};
@@ -104,9 +104,9 @@ export const WriterHeader = styled.div `
 `;
 export const WriterAccent = styled.div `
   width: 5rem;
-  height: 0.42rem;
-  border-radius: 999px;
-  background: ${({ theme }) => (theme.colors.gray8)};
+  height: 2px;
+  border-radius: 0;
+  background: ${({ theme }) => theme.publicDesign.accent};
 `;
 export const TitleInput = styled.textarea `
   width: 100%;
@@ -166,9 +166,9 @@ export const ComposeSummaryInput = styled.textarea `
   width: 100%;
   min-height: 5.6rem;
   border: 1px solid ${({ theme }) => (theme.colors.gray5)};
-  border-radius: ${({ theme }) => ("16px")};
+  border-radius: 6px;
   padding: 0.95rem 1rem;
-  background: ${({ theme }) => (theme.colors.gray2)};
+  background: ${({ theme }) => theme.publicDesign.readableSurface};
   color: ${({ theme }) => theme.colors.gray12};
   font-size: 1rem;
   line-height: 1.7;
@@ -267,9 +267,9 @@ export const SelectedTagChip = styled.span `
   min-width: 0;
   max-width: 100%;
   min-height: 32px;
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid ${({ theme }) => (theme.colors.gray6)};
-  background: ${({ theme }) => (theme.colors.gray3)};
+  background: ${({ theme }) => theme.publicDesign.surfaceElevated};
   overflow: hidden;
   transition:
     border-color 0.18s ease,
@@ -303,7 +303,7 @@ export const SelectedTagChip = styled.span `
     padding: 0 0.52rem;
     border: 0;
     border-left: 1px solid ${({ theme }) => (theme.colors.gray6)};
-    background: ${({ theme }) => (theme.colors.gray2)};
+    background: ${({ theme }) => theme.publicDesign.readableSurface};
     color: ${({ theme }) => theme.colors.gray10};
     cursor: pointer;
     flex: 0 0 auto;
@@ -408,7 +408,7 @@ export const WriterFooterActions = styled.div `
 `;
 export const Button = styled.button `
   border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 8px;
+  border-radius: 6px;
   padding: 0.62rem 0.92rem;
   min-height: 44px;
   background: transparent;
@@ -440,16 +440,16 @@ export const Button = styled.button `
   }
 `;
 export const PrimaryButton = styled(Button) `
-  border-radius: 8px;
+  border-radius: 6px;
   padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => theme.colors.blue9};
-  background: ${({ theme }) => theme.colors.blue9};
-  color: ${({ theme }) => theme.colors.gray1};
+  border-color: ${({ theme }) => theme.publicDesign.accent};
+  background: ${({ theme }) => theme.publicDesign.accent};
+  color: ${({ theme }) => theme.colors.accentControlText};
   font-weight: 700;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.blue10};
-    background: ${({ theme }) => theme.colors.blue10};
-    color: ${({ theme }) => theme.colors.gray1};
+    border-color: ${({ theme }) => theme.colors.accentControlHover};
+    background: ${({ theme }) => theme.colors.accentControlHover};
+    color: ${({ theme }) => theme.colors.accentControlText};
   }
 `;

--- a/front/src/routes/Admin/EditorStudioComposeWritingSurfaceParts.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeWritingSurfaceParts.tsx
@@ -442,14 +442,14 @@ export const Button = styled.button `
 export const PrimaryButton = styled(Button) `
   border-radius: 6px;
   padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => theme.publicDesign.accent};
-  background: ${({ theme }) => theme.publicDesign.accent};
+  border-color: ${({ theme }) => (theme.scheme === "dark" ? "#0a58ca" : "#0969da")};
+  background: ${({ theme }) => (theme.scheme === "dark" ? "#0a58ca" : "#0969da")};
   color: ${({ theme }) => theme.colors.accentControlText};
   font-weight: 700;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.accentControlHover};
-    background: ${({ theme }) => theme.colors.accentControlHover};
+    border-color: ${({ theme }) => (theme.scheme === "dark" ? "#084298" : "#075bb5")};
+    background: ${({ theme }) => (theme.scheme === "dark" ? "#084298" : "#075bb5")};
     color: ${({ theme }) => theme.colors.accentControlText};
   }
 `;

--- a/front/src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx
+++ b/front/src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx
@@ -70,7 +70,7 @@ export const EditorExitAction = styled.button `
   padding: 0.2rem 0.32rem;
   margin: 0;
   border: 0;
-  border-radius: 10px;
+  border-radius: 6px;
   background: transparent;
   color: ${({ theme }) => theme.colors.gray12};
   font-size: 0.98rem;
@@ -140,7 +140,7 @@ export const EditorStudioSaveState = styled.span `
 `;
 const Button = styled.button `
   border: 1px solid ${({ theme }) => (theme.colors.gray6)};
-  border-radius: 8px;
+  border-radius: 6px;
   padding: 0.62rem 0.92rem;
   min-height: 44px;
   background: ${({ theme }) => ("transparent")};
@@ -172,17 +172,17 @@ const Button = styled.button `
   }
 `;
 export const PrimaryButton = styled(Button) `
-  border-radius: 8px;
+  border-radius: 6px;
   padding: 0.6rem 0.88rem;
-  border-color: #005fc4;
-  background: #005fc4;
-  color: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray1 : theme.colors.gray12)};
+  border-color: ${({ theme }) => theme.publicDesign.accent};
+  background: ${({ theme }) => theme.publicDesign.accent};
+  color: ${({ theme }) => theme.colors.accentControlText};
   font-weight: 700;
 
   &:hover:not(:disabled) {
-    border-color: #0052ad;
-    background: #0052ad;
-    color: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray1 : theme.colors.gray12)};
+    border-color: ${({ theme }) => theme.colors.accentControlHover};
+    background: ${({ theme }) => theme.colors.accentControlHover};
+    color: ${({ theme }) => theme.colors.accentControlText};
   }
 `;
 export const EditorStudioFrame = styled.div `
@@ -238,9 +238,9 @@ export const SelectedTagChip = styled.span `
   min-width: 0;
   max-width: 100%;
   min-height: 32px;
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray3};
+  background: ${({ theme }) => theme.publicDesign.surfaceElevated};
   overflow: hidden;
   transition:
     border-color 0.18s ease,
@@ -274,7 +274,7 @@ export const SelectedTagChip = styled.span `
     padding: 0 0.52rem;
     border: 0;
     border-left: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray2};
+    background: ${({ theme }) => theme.publicDesign.readableSurface};
     color: ${({ theme }) => theme.colors.gray10};
     cursor: pointer;
     flex: 0 0 auto;
@@ -383,7 +383,8 @@ export const EditorHeaderAvatar = styled.div<{
   width: ${({ $compact }) => ($compact ? "40px" : "48px")};
   height: ${({ $compact }) => ($compact ? "40px" : "48px")};
   flex-shrink: 0;
-  border-radius: 999px;
+  border-radius: 0;
+  border: 1px solid ${({ theme }) => theme.publicDesign.borderStrong};
   overflow: hidden;
   background: ${({ theme }) => theme.colors.gray3};
 
@@ -426,9 +427,9 @@ export const EditorHeaderMetaPill = styled.span<{
   align-items: center;
   min-height: ${({ $compact }) => ($compact ? "30px" : "34px")};
   padding: ${({ $compact }) => ($compact ? "0 0.72rem" : "0 0.82rem")};
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
+  background: ${({ theme }) => theme.publicDesign.surfaceElevated};
   color: ${({ theme }) => theme.colors.gray11};
   font-size: ${({ $compact }) => ($compact ? "0.74rem" : "0.82rem")};
   font-weight: 650;
@@ -437,7 +438,7 @@ export const EditorHeaderMetaPill = styled.span<{
 export const EditorHeaderActionButton = styled(Button) `
   min-height: 34px;
   padding: 0.45rem 0.7rem;
-  border-radius: 999px;
+  border-radius: 6px;
   font-size: 0.78rem;
 `;
 export const EditorStudioDedicatedCanvasSection = styled.section `

--- a/front/src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx
+++ b/front/src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx
@@ -174,14 +174,14 @@ const Button = styled.button `
 export const PrimaryButton = styled(Button) `
   border-radius: 6px;
   padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => theme.publicDesign.accent};
-  background: ${({ theme }) => theme.publicDesign.accent};
+  border-color: ${({ theme }) => (theme.scheme === "dark" ? "#0a58ca" : "#0969da")};
+  background: ${({ theme }) => (theme.scheme === "dark" ? "#0a58ca" : "#0969da")};
   color: ${({ theme }) => theme.colors.accentControlText};
   font-weight: 700;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.accentControlHover};
-    background: ${({ theme }) => theme.colors.accentControlHover};
+    border-color: ${({ theme }) => (theme.scheme === "dark" ? "#084298" : "#075bb5")};
+    background: ${({ theme }) => (theme.scheme === "dark" ? "#084298" : "#075bb5")};
     color: ${({ theme }) => theme.colors.accentControlText};
   }
 `;


### PR DESCRIPTION
## 🔗 Related Issue
- close #1059

## 📝 Summary
- 글작성(`/editor/new`)과 글수정(`/editor/[id]`)의 editor surface를 V4 공개 화면과 같은 각진 컨트롤, 낮은 장식, public design token 톤으로 맞췄습니다.
- temp draft, 저장, 수정, 발행, Markdown editor 데이터 흐름은 변경하지 않고 스타일 diff만 적용했습니다.

## 🛠 Changes
- 작성 surface section/button/primary action의 radius와 surface 색상을 V4 톤으로 조정했습니다.
- 제목/요약/태그 chip/toolbar 주변 editor 부품을 둥근 pill 중심에서 직각형 컨트롤 중심으로 맞췄습니다.
- 전용 editor header action, avatar, meta pill, tag chip을 같은 V4 시각 계약으로 정리했습니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [x] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [ ] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `yarn --cwd front build`: pass
- `node front/scripts/check-bundle-size.mjs`: pass
- `yarn --cwd front playwright:preflight`: pass
- `yarn --cwd front playwright test e2e/editor-authoring-flow.spec.ts --workers=1`: 1 passed
- `yarn --cwd front playwright test e2e/editor-authoring-markdown-editor.spec.ts --workers=1`: 25 passed
- `yarn --cwd front playwright test e2e/editor-v4-evidence.tmp.spec.ts --workers=1`: 1 passed, screenshot capture only
- `git diff --check`: pass
- diff-scoped security scan: changed editor style files contain no `dangerouslySetInnerHTML`, `eval`, `new Function`, DOM HTML sinks, storage access, cookie access, or `javascript:` URL additions.

## 📸 Screenshot / API Example
- Local evidence folder: `/Volumes/MACSSD/Projects/GitProjects/aquila-blog/front/test-results/aquilalog-v4-editor-evidence`
- Captured files:
  - `editor-new-desktop.png`
  - `editor-new-mobile.png`
  - `editor-edit-desktop.png`
  - `editor-edit-mobile.png`

## ⚠️ Risk & Rollback
- 예상 리스크: editor 화면의 시각 밀도와 컨트롤 톤이 바뀌므로 사용자가 기존 pill형 UI보다 더 건조하게 느낄 수 있습니다.
- 롤백 방법: 이 PR의 `feat(editor): V4 작성 수정 화면 적용` 커밋을 revert합니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 코드 주석 정책에 맞는 이유/불변조건/운영 영향을 설명하는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 편집 스튜디오의 버튼, 표면 영역, 칩 등 다양한 UI 컴포넌트 스타일 업데이트
  * 테두리 라운딩 값 조정으로 전체 디자인 일관성 강화
  * 새로운 디자인 토큰 기반 색상 테마 적용으로 시각적 통일성 개선
  * 주요 상호작용 요소의 호버 및 활성 상태 색상 표현 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->