### PR TITLE
[Feat] V4 에디터 작성 화면 일치 보정

### DIFF
--- a/front/e2e/editor-authoring-markdown-editor.spec.ts
+++ b/front/e2e/editor-authoring-markdown-editor.spec.ts
@@ -307,18 +307,22 @@ test.describe("Markdown editor replacement", () => {
     expect(Math.abs(startPointContract.writeStartTop - startPointContract.previewStartTop)).toBeLessThanOrEqual(2)
   })
 
-  test("dedicated editor top actions stay inside the editor content rail", async ({ page }) => {
+  test("dedicated editor exposes V4 full-screen chrome around the editor", async ({ page }) => {
     await page.setViewportSize({ width: 2048, height: 1152 })
     await routeAuthenticatedEditor(page, "본문이 없습니다.")
 
     await page.goto("/editor/new?source=local-draft")
 
     const editor = page.getByTestId("markdown-editor")
-    const exitButton = page.getByRole("button", { name: "← 나가기" })
+    const exitButton = page.getByRole("button", { name: "← 글 관리" })
+    const guideButton = page.getByRole("button", { name: "Markdown 가이드" })
     const publishButton = page.getByRole("button", { name: "발행" }).first()
     await expect(editor).toBeVisible()
     await expect(exitButton).toBeVisible()
+    await expect(guideButton).toBeVisible()
     await expect(publishButton).toBeVisible()
+    await expect(page.getByRole("heading", { name: "Document outline" })).toBeVisible()
+    await expect(page.getByRole("heading", { name: "Publish inspector" })).toBeVisible()
 
     const editorBox = await editor.boundingBox()
     const exitBox = await exitButton.boundingBox()
@@ -328,8 +332,8 @@ test.describe("Markdown editor replacement", () => {
     expect(publishBox).not.toBeNull()
     if (!editorBox || !exitBox || !publishBox) return
 
-    expect(exitBox.x).toBeGreaterThanOrEqual(editorBox.x - 2)
-    expect(publishBox.x + publishBox.width).toBeLessThanOrEqual(editorBox.x + editorBox.width + 2)
+    expect(exitBox.y).toBeLessThan(editorBox.y)
+    expect(publishBox.y).toBeLessThan(editorBox.y)
   })
 
   test("preview matches supported table markdown for alignment, escaped pipes, and inline cell formatting", async ({
@@ -427,7 +431,7 @@ test.describe("Markdown editor replacement", () => {
     expect(wideTableContract.scrollWidth).toBeGreaterThan(wideTableContract.clientWidth)
   })
 
-  test("write pane follows the current theme surface instead of forcing dark colors", async ({ page }) => {
+  test("write pane uses the V4 dark markdown source surface", async ({ page }) => {
     await routeAuthenticatedEditor(
       page,
       [
@@ -460,10 +464,10 @@ test.describe("Markdown editor replacement", () => {
       }
     })
 
-    expect(styles.frame.backgroundColor).not.toBe("rgb(13, 17, 23)")
+    expect(styles.frame.backgroundColor).toBe("rgb(15, 23, 40)")
     expect(styles.textarea.backgroundColor).toBe(styles.frame.backgroundColor)
     expect(styles.gutterCount).toBe(0)
-    expect(styles.textarea.color).toBe("rgb(15, 23, 36)")
+    expect(styles.textarea.color).toBe("rgb(219, 231, 255)")
   })
 
   test("write pane focus does not render the global blue textarea outline", async ({ page }) => {
@@ -521,12 +525,19 @@ test.describe("Markdown editor replacement", () => {
     expect(textareaBox).not.toBeNull()
     if (!textareaBox) return
 
-    const lineHeight = await textarea.evaluate((element) => Number.parseFloat(window.getComputedStyle(element).lineHeight))
-    const targetY = textareaBox.y + 16 + lineHeight * 2 + lineHeight / 2
+    const dragMetrics = await textarea.evaluate((element) => {
+      const style = window.getComputedStyle(element)
+      return {
+        lineHeight: Number.parseFloat(style.lineHeight),
+        paddingTop: Number.parseFloat(style.paddingTop),
+        paddingLeft: Number.parseFloat(style.paddingLeft),
+      }
+    })
+    const targetY = textareaBox.y + dragMetrics.paddingTop + dragMetrics.lineHeight * 2 + dragMetrics.lineHeight / 2
 
-    await page.mouse.move(textareaBox.x + 24, targetY)
+    await page.mouse.move(textareaBox.x + dragMetrics.paddingLeft, targetY)
     await page.mouse.down()
-    await page.mouse.move(textareaBox.x + 330, targetY, {
+    await page.mouse.move(textareaBox.x + dragMetrics.paddingLeft + 330, targetY, {
       steps: 12,
     })
     await page.mouse.up()
@@ -575,8 +586,8 @@ test.describe("Markdown editor replacement", () => {
       })
 
     expect(previewContract.articleBackground).not.toBe("rgb(13, 17, 23)")
-    expect(previewContract.paddingLeft).toBe("16px")
-    expect(previewContract.paddingRight).toBe("16px")
+    expect(previewContract.paddingLeft).toBe("32px")
+    expect(previewContract.paddingRight).toBe("32px")
     expect(previewContract.marginTop).toBe("0px")
     expect(previewContract.maxWidth).toBe("768px")
     expect(previewContract.fontSize).toBe("17px")

--- a/front/e2e/editor-authoring-markdown-editor.spec.ts
+++ b/front/e2e/editor-authoring-markdown-editor.spec.ts
@@ -323,6 +323,15 @@ test.describe("Markdown editor replacement", () => {
     await expect(publishButton).toBeVisible()
     await expect(page.getByRole("heading", { name: "Document outline" })).toBeVisible()
     await expect(page.getByRole("heading", { name: "Publish inspector" })).toBeVisible()
+    await expect(page.getByLabel("Summary")).toHaveAttribute("maxLength", "150")
+
+    await page.getByLabel("Summary").fill("x".repeat(200))
+    await expect(page.getByLabel("Summary")).toHaveValue("x".repeat(150))
+
+    await page.getByPlaceholder("제목을 입력하세요").fill("")
+    await page.getByLabel("Markdown 본문").fill("")
+    await page.getByLabel("Summary").fill("")
+    await expect(page.locator('aside[aria-label="발행 설정"] b[data-tone="warn"]')).toHaveCount(3)
 
     const editorBox = await editor.boundingBox()
     const exitBox = await exitButton.boundingBox()

--- a/front/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/front/src/components/markdown-editor/MarkdownEditor.tsx
@@ -257,17 +257,6 @@ export const MarkdownEditor = ({
   return (
     <EditorRoot data-testid="markdown-editor">
       <EditorToolbar aria-label="Markdown 작성 도구">
-        <ModeTabs role="tablist" aria-label="Markdown editor mode">
-          <ModeTab type="button" role="tab" aria-selected={mode === "write"} onClick={() => setMode("write")}>
-            Write
-          </ModeTab>
-          <ModeTab type="button" role="tab" aria-selected={mode === "preview"} onClick={() => setMode("preview")}>
-            Preview
-          </ModeTab>
-          <ModeTab type="button" role="tab" aria-selected={mode === "split"} onClick={() => setMode("split")}>
-            Split
-          </ModeTab>
-        </ModeTabs>
         <ToolbarGroup>
           {toolbarMarkdownSnippets.map((snippet) => (
             <ToolbarButton
@@ -314,6 +303,17 @@ export const MarkdownEditor = ({
             />
           </ImageUploadButton>
         </ToolbarGroup>
+        <ModeTabs role="tablist" aria-label="Markdown editor mode">
+          <ModeTab type="button" role="tab" aria-selected={mode === "write"} onClick={() => setMode("write")}>
+            Write
+          </ModeTab>
+          <ModeTab type="button" role="tab" aria-selected={mode === "preview"} onClick={() => setMode("preview")}>
+            Preview
+          </ModeTab>
+          <ModeTab type="button" role="tab" aria-selected={mode === "split"} onClick={() => setMode("split")}>
+            Split
+          </ModeTab>
+        </ModeTabs>
       </EditorToolbar>
       {uploadError ? <ToolbarError role="alert">{uploadError}</ToolbarError> : null}
       <EditorBody data-mode={mode}>
@@ -376,7 +376,7 @@ const EditorToolbar = styled.div`
   gap: 0.75rem;
   padding: 0.5rem;
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
+  background: ${({ theme }) => theme.publicDesign.surfaceElevated};
   flex-wrap: wrap;
 `
 
@@ -474,7 +474,7 @@ const ToolbarError = styled.div`
 `
 
 const EditorBody = styled.div`
-  min-height: 640px;
+  min-height: min(720px, calc(100vh - 260px));
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 
@@ -500,7 +500,7 @@ const EditorBody = styled.div`
 
 const WritePane = styled.div`
   min-width: 0;
-  min-height: 640px;
+  min-height: min(720px, calc(100vh - 260px));
   border-right: 1px solid ${({ theme }) => theme.colors.gray6};
 
   @media (max-width: 980px) {
@@ -510,22 +510,22 @@ const WritePane = styled.div`
 `
 
 const WriteEditorFrame = styled.div`
-  min-height: 640px;
-  background: ${({ theme }) => theme.publicDesign.readableSurface};
-  color: ${({ theme }) => theme.colors.gray12};
+  min-height: min(720px, calc(100vh - 260px));
+  background: #0f1728;
+  color: #dbe7ff;
 `
 
 const MarkdownTextarea = styled.textarea`
   width: 100%;
-  min-height: 640px;
-  max-width: var(--article-readable-width, 48rem);
-  padding: 16px;
+  min-height: min(720px, calc(100vh - 260px));
+  max-width: none;
+  padding: 2rem;
   border: 0;
   outline: none;
   resize: vertical;
-  background: ${({ theme }) => theme.publicDesign.readableSurface};
-  color: ${({ theme }) => theme.colors.gray12};
-  caret-color: ${({ theme }) => theme.colors.gray12};
+  background: #0f1728;
+  color: #dbe7ff;
+  caret-color: #dbe7ff;
   font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
   font-size: 14px;
   line-height: 1.55;
@@ -551,8 +551,8 @@ const MarkdownTextarea = styled.textarea`
 
 const PreviewPane = styled.div`
   min-width: 0;
-  height: 640px;
-  min-height: 640px;
+  height: min(720px, calc(100vh - 260px));
+  min-height: min(720px, calc(100vh - 260px));
   display: flex;
   flex-direction: column;
   background: ${({ theme }) => theme.publicDesign.readableSurface};
@@ -563,7 +563,7 @@ const PreviewArticle = styled.article`
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding: 16px 1rem 2rem;
+  padding: 2rem;
   background: ${({ theme }) => theme.publicDesign.readableSurface};
 
   .aq-markdown {

--- a/front/src/layouts/RootLayout/index.tsx
+++ b/front/src/layouts/RootLayout/index.tsx
@@ -152,7 +152,9 @@ const RootLayout = ({
       <Scripts />
       {/* // TODO: replace react query */}
       {/* {metaConfig.type !== "Paper" && <Header />} */}
-      <Header fullWidth={false} showThemeToggle={effectiveBlogDesign === "legacy"} blogTitle={headerBlogTitle} />
+      {isDedicatedEditorRoute ? null : (
+        <Header fullWidth={false} showThemeToggle={effectiveBlogDesign === "legacy"} blogTitle={headerBlogTitle} />
+      )}
       <StyledMain $fullBleed={isFullBleedRoute}>{children}</StyledMain>
     </ThemeProvider>
   )

--- a/front/src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx
+++ b/front/src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx
@@ -5,8 +5,12 @@ import type {
   ReactNode,
   Ref,
 } from "react"
+import { useMemo, useState } from "react"
 import ProfileImage from "src/components/ProfileImage"
 import {
+  EditorGuideBackdrop,
+  EditorGuideGrid,
+  EditorGuidePanel,
   EditorExitAction,
   EditorHeaderActionButton,
   EditorHeaderAuthor,
@@ -15,6 +19,10 @@ import {
   EditorHeaderMetaActions,
   EditorHeaderMetaPill,
   EditorHeaderMetaRow,
+  EditorInspector,
+  EditorInspectorPreview,
+  EditorOutline,
+  EditorOutlineItem,
   EditorStudioDedicatedCanvasSection,
   EditorStudioDedicatedMetaSection,
   EditorStudioDedicatedTopBar,
@@ -29,8 +37,11 @@ import {
   PrimaryButton,
   PublishNotice,
   SelectedTagChip,
+  SecondaryButton,
   TitleInput,
 } from "./EditorStudioDedicatedEditorSurfaceParts"
+import type { PostVisibility } from "./editorStudioState"
+import { PUBLISH_VISIBILITY_OPTIONS } from "./EditorStudioWorkspaceControllerRootModel"
 
 type NoticeTone = "idle" | "loading" | "success" | "error"
 
@@ -59,6 +70,11 @@ type EditorStudioDedicatedEditorSurfaceProps = {
   authorAvatarSrc: string
   previewDateText: string
   currentVisibilityText: string
+  postContent: string
+  postSummary: string
+  onPostSummaryChange: (value: string) => void
+  postVisibility: PostVisibility
+  onPostVisibilityChange: (value: PostVisibility) => void
   canOpenCurrentPostDetail: boolean
   onOpenPostDetail: () => void
   onCopyPostDetailLink: () => void
@@ -68,6 +84,30 @@ type EditorStudioDedicatedEditorSurfaceProps = {
   publishNoticeText: string
   resultPanel: ReactNode
   publishModal: ReactNode
+}
+
+type OutlineItem = {
+  id: string
+  level: 1 | 2 | 3
+  text: string
+}
+
+const extractEditorOutline = (title: string, markdown: string): OutlineItem[] => {
+  const items: OutlineItem[] = []
+  const normalizedTitle = title.trim()
+  if (normalizedTitle) items.push({ id: "title", level: 1, text: normalizedTitle })
+
+  markdown.split(/\r?\n/).forEach((line, index) => {
+    const match = /^(#{2,3})\s+(.+)$/.exec(line.trim())
+    if (!match) return
+    items.push({
+      id: `heading-${index}`,
+      level: match[1].length as 2 | 3,
+      text: match[2].trim(),
+    })
+  })
+
+  return items.slice(0, 12)
 }
 
 const isComposingKeyboardEvent = (event: ReactKeyboardEvent<HTMLElement>) => {
@@ -112,6 +152,11 @@ export const EditorStudioDedicatedEditorSurface = ({
   authorAvatarSrc,
   previewDateText,
   currentVisibilityText,
+  postContent,
+  postSummary,
+  onPostSummaryChange,
+  postVisibility,
+  onPostVisibilityChange,
   canOpenCurrentPostDetail,
   onOpenPostDetail,
   onCopyPostDetailLink,
@@ -121,115 +166,198 @@ export const EditorStudioDedicatedEditorSurface = ({
   publishNoticeText,
   resultPanel,
   publishModal,
-}: EditorStudioDedicatedEditorSurfaceProps) => (
-  <EditorStudioRoot>
-    <input
-      ref={thumbnailImageFileInputRef}
-      type="file"
-      accept="image/*"
-      onChange={onThumbnailImageFileChange}
-      style={{ display: "none" }}
-    />
+}: EditorStudioDedicatedEditorSurfaceProps) => {
+  const [isGuideOpen, setIsGuideOpen] = useState(false)
+  const outlineItems = useMemo(() => extractEditorOutline(postTitle, postContent), [postContent, postTitle])
+  const summaryText = postSummary.trim() || "요약을 입력하면 발행 카드와 공개 글 설명에 함께 반영됩니다."
+  const primaryTag = postTags[0] || "Architecture"
 
-    <EditorStudioDedicatedTopBar>
-      <EditorExitAction type="button" onClick={onExit}>
-        ← 나가기
-      </EditorExitAction>
-      <EditorStudioTopBarActions>
-        {saveStateText ? (
-          <EditorStudioSaveState data-tone={saveStateTone}>{saveStateText}</EditorStudioSaveState>
-        ) : null}
-        <PrimaryButton type="button" disabled={primaryActionDisabled} onClick={onPrimaryAction}>
-          {primaryActionLabel}
-        </PrimaryButton>
-      </EditorStudioTopBarActions>
-    </EditorStudioDedicatedTopBar>
+  return (
+    <EditorStudioRoot>
+      <input
+        ref={thumbnailImageFileInputRef}
+        type="file"
+        accept="image/*"
+        onChange={onThumbnailImageFileChange}
+        style={{ display: "none" }}
+      />
 
-    <EditorStudioFrame data-testid="editor-studio-frame">
-      <EditorStudioWritingColumn data-testid="editor-writing-column" $compact={isCompactSplitPreview}>
-        <EditorStudioDedicatedMetaSection $compact={isCompactSplitPreview}>
-          <EditorTagRow aria-label="태그 입력" $compact={isCompactSplitPreview}>
-            {postTags.map((tag) => (
-              <SelectedTagChip key={tag}>
-                <span className="label">{tag}</span>
-                <button type="button" onClick={() => onRemoveTag(tag)} aria-label={`${tag} 삭제`}>
-                  ×
-                </button>
-              </SelectedTagChip>
-            ))}
-            <InlineMetaInput
-              placeholder="태그 입력 후 Enter"
-              value={tagDraft}
-              onChange={(event) => {
-                const nextValue = event.target.value
-                const commaSeparated = /[,，]/
-                if (!commaSeparated.test(nextValue)) {
-                  onTagDraftChange(nextValue)
-                  return
-                }
+      <EditorStudioDedicatedTopBar>
+        <EditorExitAction type="button" onClick={onExit}>
+          ← 글 관리
+        </EditorExitAction>
+        {saveStateText ? <EditorStudioSaveState data-tone={saveStateTone}>{saveStateText}</EditorStudioSaveState> : <span />}
+        <EditorStudioTopBarActions>
+          <SecondaryButton type="button" onClick={() => setIsGuideOpen(true)}>
+            Markdown 가이드
+          </SecondaryButton>
+          <PrimaryButton type="button" disabled={primaryActionDisabled} onClick={onPrimaryAction}>
+            {primaryActionLabel}
+          </PrimaryButton>
+        </EditorStudioTopBarActions>
+      </EditorStudioDedicatedTopBar>
 
-                const fragments = nextValue.split(commaSeparated)
-                const tailDraft = fragments.pop() ?? ""
-                const tagsToAdd = fragments.map((fragment) => fragment.trim()).filter(Boolean)
-                if (tagsToAdd.length > 0) onAddTags(tagsToAdd)
-                onTagDraftChange(tailDraft)
-              }}
-              onKeyDown={(event) => {
-                if (isComposingKeyboardEvent(event)) return
-                if (event.key === "Enter" || event.key === ",") {
-                  event.preventDefault()
-                  onAddTag(event.currentTarget.value)
-                }
-              }}
+      <EditorStudioFrame data-testid="editor-studio-frame">
+        <EditorOutline aria-label="문서 목차">
+          <h3>Document outline</h3>
+          {outlineItems.length > 0 ? (
+            outlineItems.map((item, index) => (
+              <EditorOutlineItem key={item.id} data-level={item.level} data-active={index === 0 ? "true" : "false"}>
+                <span>H{item.level}</span>
+                <strong>{item.text}</strong>
+              </EditorOutlineItem>
+            ))
+          ) : (
+            <p>제목과 본문 heading을 입력하면 목차가 표시됩니다.</p>
+          )}
+        </EditorOutline>
+
+        <EditorStudioWritingColumn data-testid="editor-writing-column" $compact={isCompactSplitPreview}>
+          <EditorStudioDedicatedMetaSection $compact={isCompactSplitPreview}>
+            <TitleInput
+              $compact={isCompactSplitPreview}
+              ref={titleInputRef}
+              id="post-title"
+              placeholder="제목을 입력하세요"
+              rows={1}
+              value={postTitle}
+              onChange={onPostTitleChange}
+              onKeyDown={onPostTitleKeyDown}
             />
-          </EditorTagRow>
-          <TitleInput
-            $compact={isCompactSplitPreview}
-            ref={titleInputRef}
-            id="post-title"
-            placeholder="제목을 입력하세요"
-            rows={1}
-            value={postTitle}
-            onChange={onPostTitleChange}
-            onKeyDown={onPostTitleKeyDown}
-          />
-          <EditorHeaderMetaRow>
-            <EditorHeaderAuthor>
-              <EditorHeaderAvatar $compact={isCompactSplitPreview}>
-                {authorAvatarSrc ? (
-                  <ProfileImage src={authorAvatarSrc} alt={`${authorName} 프로필 이미지`} fillContainer />
-                ) : (
-                  <span className="initial">{authorInitial}</span>
-                )}
-              </EditorHeaderAvatar>
-              <EditorHeaderAuthorText $compact={isCompactSplitPreview}>
-                <strong>{authorName}</strong>
-                <span>{previewDateText}</span>
-              </EditorHeaderAuthorText>
-            </EditorHeaderAuthor>
-            <EditorHeaderMetaActions>
-              <EditorHeaderMetaPill $compact={isCompactSplitPreview}>{currentVisibilityText}</EditorHeaderMetaPill>
-              {canOpenCurrentPostDetail ? (
-                <>
-                  <EditorHeaderActionButton type="button" onClick={onOpenPostDetail}>
-                    상세 열기
-                  </EditorHeaderActionButton>
-                  <EditorHeaderActionButton type="button" onClick={onCopyPostDetailLink}>
-                    링크 복사
-                  </EditorHeaderActionButton>
-                </>
-              ) : null}
-            </EditorHeaderMetaActions>
-          </EditorHeaderMetaRow>
-        </EditorStudioDedicatedMetaSection>
+            <EditorHeaderMetaRow>
+              <EditorTagRow aria-label="태그 입력" $compact={isCompactSplitPreview}>
+                {postTags.map((tag) => (
+                  <SelectedTagChip key={tag}>
+                    <span className="label">{tag}</span>
+                    <button type="button" onClick={() => onRemoveTag(tag)} aria-label={`${tag} 삭제`}>
+                      ×
+                    </button>
+                  </SelectedTagChip>
+                ))}
+                <InlineMetaInput
+                  placeholder="태그 입력 후 Enter"
+                  value={tagDraft}
+                  onChange={(event) => {
+                    const nextValue = event.target.value
+                    const commaSeparated = /[,，]/
+                    if (!commaSeparated.test(nextValue)) {
+                      onTagDraftChange(nextValue)
+                      return
+                    }
 
-        <EditorStudioDedicatedCanvasSection>{editorCanvas}</EditorStudioDedicatedCanvasSection>
+                    const fragments = nextValue.split(commaSeparated)
+                    const tailDraft = fragments.pop() ?? ""
+                    const tagsToAdd = fragments.map((fragment) => fragment.trim()).filter(Boolean)
+                    if (tagsToAdd.length > 0) onAddTags(tagsToAdd)
+                    onTagDraftChange(tailDraft)
+                  }}
+                  onKeyDown={(event) => {
+                    if (isComposingKeyboardEvent(event)) return
+                    if (event.key === "Enter" || event.key === ",") {
+                      event.preventDefault()
+                      onAddTag(event.currentTarget.value)
+                    }
+                  }}
+                />
+              </EditorTagRow>
+              <EditorHeaderMetaActions>
+                <EditorHeaderMetaPill $compact={isCompactSplitPreview}>{currentVisibilityText}</EditorHeaderMetaPill>
+                {canOpenCurrentPostDetail ? (
+                  <>
+                    <EditorHeaderActionButton type="button" onClick={onOpenPostDetail}>
+                      상세 열기
+                    </EditorHeaderActionButton>
+                    <EditorHeaderActionButton type="button" onClick={onCopyPostDetailLink}>
+                      링크 복사
+                    </EditorHeaderActionButton>
+                  </>
+                ) : null}
+              </EditorHeaderMetaActions>
+            </EditorHeaderMetaRow>
+          </EditorStudioDedicatedMetaSection>
 
-        {showPublishNotice ? <PublishNotice data-tone={publishNoticeTone}>{publishNoticeText}</PublishNotice> : null}
-      </EditorStudioWritingColumn>
-    </EditorStudioFrame>
+          <EditorStudioDedicatedCanvasSection>{editorCanvas}</EditorStudioDedicatedCanvasSection>
 
-    {resultPanel}
-    {publishModal}
-  </EditorStudioRoot>
-)
+          {showPublishNotice ? <PublishNotice data-tone={publishNoticeTone}>{publishNoticeText}</PublishNotice> : null}
+        </EditorStudioWritingColumn>
+
+        <EditorInspector aria-label="발행 설정">
+          <h3>Publish inspector</h3>
+          <label>
+            <span>Visibility</span>
+            <select value={postVisibility} onChange={(event) => onPostVisibilityChange(event.target.value as PostVisibility)}>
+              {PUBLISH_VISIBILITY_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span>Summary</span>
+            <textarea value={postSummary} onChange={(event) => onPostSummaryChange(event.target.value)} />
+          </label>
+          <section>
+            <span>Tags</span>
+            <EditorTagRow aria-label="발행 태그" $compact>
+              {postTags.map((tag) => (
+                <SelectedTagChip key={`inspector-${tag}`}>
+                  <span className="label">{tag}</span>
+                  <button type="button" onClick={() => onRemoveTag(tag)} aria-label={`${tag} 삭제`}>
+                    ×
+                  </button>
+                </SelectedTagChip>
+              ))}
+            </EditorTagRow>
+          </section>
+          <EditorInspectorPreview>
+            <div>ETAG<br />INVALIDATION</div>
+            <strong>{postTitle.trim() || "제목을 입력하세요"}</strong>
+            <span>{primaryTag} · 11분</span>
+          </EditorInspectorPreview>
+          <section>
+            <span>Quality checks</span>
+            <p><strong>제목과 본문</strong><b>PASS</b></p>
+            <p><strong>Markdown 렌더링</strong><b>PASS</b></p>
+            <p><strong>요약</strong><b>{summaryText ? "PASS" : "WARN"}</b></p>
+          </section>
+        </EditorInspector>
+      </EditorStudioFrame>
+
+      {isGuideOpen ? (
+        <EditorGuideBackdrop onClick={() => setIsGuideOpen(false)}>
+          <EditorGuidePanel role="dialog" aria-modal="true" aria-label="Markdown 작성 가이드" onClick={(event) => event.stopPropagation()}>
+            <header>
+              <div>
+                <span>Authoring help</span>
+                <h2>Markdown 작성 가이드</h2>
+              </div>
+              <button type="button" aria-label="가이드 닫기" onClick={() => setIsGuideOpen(false)}>×</button>
+            </header>
+            <p>글 제목은 별도 필드가 H1 역할을 합니다. 본문은 Markdown 원문을 저장하고 같은 renderer로 미리보기와 공개 글을 표시합니다.</p>
+            <EditorGuideGrid>
+              {[
+                ["제목과 강조", "# 제목 1\n## 제목 2\n**굵게** · _기울임_"],
+                ["목록과 인용", "- 목록\n- [x] 완료\n> 인용문"],
+                ["콜아웃", "> [!TIP]\n> **제목**\n> 내용"],
+                ["토글", ":::toggle 자세히 보기\n내용\n:::"],
+                ["표와 코드", "| 항목 | 설명 |\n| --- | --- |\n\n```kotlin\ncode\n```"],
+                ["Mermaid", "```mermaid\nflowchart LR\n A --> B\n```"],
+                ["수식과 색상", "$$\nE = mc^2\n$$\n{{color:#155eef|강조}}"],
+                ["미디어와 링크 카드", "![설명](URL)\n:::bookmark URL\n제목\n설명\n:::"],
+              ].map(([title, code]) => (
+                <section key={title}>
+                  <h3>{title}</h3>
+                  <pre>{code}</pre>
+                </section>
+              ))}
+            </EditorGuideGrid>
+          </EditorGuidePanel>
+        </EditorGuideBackdrop>
+      ) : null}
+
+      {resultPanel}
+      {publishModal}
+    </EditorStudioRoot>
+  )
+}

--- a/front/src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx
+++ b/front/src/routes/Admin/EditorStudioDedicatedEditorSurface.tsx
@@ -41,6 +41,7 @@ import {
   TitleInput,
 } from "./EditorStudioDedicatedEditorSurfaceParts"
 import type { PostVisibility } from "./editorStudioState"
+import { PREVIEW_SUMMARY_MAX_LENGTH } from "./editorStudioMetaModel"
 import { PUBLISH_VISIBILITY_OPTIONS } from "./EditorStudioWorkspaceControllerRootModel"
 
 type NoticeTone = "idle" | "loading" | "success" | "error"
@@ -169,8 +170,11 @@ export const EditorStudioDedicatedEditorSurface = ({
 }: EditorStudioDedicatedEditorSurfaceProps) => {
   const [isGuideOpen, setIsGuideOpen] = useState(false)
   const outlineItems = useMemo(() => extractEditorOutline(postTitle, postContent), [postContent, postTitle])
-  const summaryText = postSummary.trim() || "요약을 입력하면 발행 카드와 공개 글 설명에 함께 반영됩니다."
-  const primaryTag = postTags[0] || "Architecture"
+  const hasTitleAndBody = Boolean(postTitle.trim() && postContent.trim())
+  const hasMarkdownBody = Boolean(postContent.trim())
+  const hasSummaryPreview = Boolean(postSummary.trim() || postContent.trim())
+  const primaryTag = postTags[0] || "태그 없음"
+  const readTimeText = postContent.trim() ? `${Math.max(1, Math.ceil(postContent.trim().length / 500))}분` : "읽기 시간"
 
   return (
     <EditorStudioRoot>
@@ -295,7 +299,14 @@ export const EditorStudioDedicatedEditorSurface = ({
           </label>
           <label>
             <span>Summary</span>
-            <textarea value={postSummary} onChange={(event) => onPostSummaryChange(event.target.value)} />
+            <textarea
+              value={postSummary}
+              maxLength={PREVIEW_SUMMARY_MAX_LENGTH}
+              onChange={(event) => onPostSummaryChange(event.target.value)}
+            />
+            <small>
+              {postSummary.length}/{PREVIEW_SUMMARY_MAX_LENGTH}
+            </small>
           </label>
           <section>
             <span>Tags</span>
@@ -313,13 +324,22 @@ export const EditorStudioDedicatedEditorSurface = ({
           <EditorInspectorPreview>
             <div>ETAG<br />INVALIDATION</div>
             <strong>{postTitle.trim() || "제목을 입력하세요"}</strong>
-            <span>{primaryTag} · 11분</span>
+            <span>{primaryTag} · {readTimeText}</span>
           </EditorInspectorPreview>
           <section>
             <span>Quality checks</span>
-            <p><strong>제목과 본문</strong><b>PASS</b></p>
-            <p><strong>Markdown 렌더링</strong><b>PASS</b></p>
-            <p><strong>요약</strong><b>{summaryText ? "PASS" : "WARN"}</b></p>
+            <p>
+              <strong>제목과 본문</strong>
+              <b data-tone={hasTitleAndBody ? "pass" : "warn"}>{hasTitleAndBody ? "PASS" : "WARN"}</b>
+            </p>
+            <p>
+              <strong>Markdown 렌더링</strong>
+              <b data-tone={hasMarkdownBody ? "pass" : "warn"}>{hasMarkdownBody ? "PASS" : "WARN"}</b>
+            </p>
+            <p>
+              <strong>요약</strong>
+              <b data-tone={hasSummaryPreview ? "pass" : "warn"}>{hasSummaryPreview ? "PASS" : "WARN"}</b>
+            </p>
           </section>
         </EditorInspector>
       </EditorStudioFrame>

--- a/front/src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx
+++ b/front/src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx
@@ -5,21 +5,20 @@ export const EditorStudioRoot = styled.main `
   width: 100vw;
   margin-left: calc(50% - 50vw);
   margin-right: calc(50% - 50vw);
-  padding: 1.4rem 1.6rem 2rem;
+  min-height: 100vh;
+  padding: 0;
   display: grid;
-  gap: 1.2rem;
+  grid-template-rows: auto 1fr;
+  gap: 0;
   overflow-x: clip;
-  background: ${({ theme }) => "transparent"};
+  background: ${({ theme }) => theme.publicDesign.operationSurface};
 
   @media (max-width: 1024px) {
-    padding: 1rem 1rem 1.4rem;
+    padding: 0;
   }
 
   @media (max-width: 768px) {
-    padding-top: 0.92rem;
-    padding-bottom: 1.2rem;
-    padding-left: max(0.82rem, env(safe-area-inset-left, 0px));
-    padding-right: max(0.82rem, env(safe-area-inset-right, 0px));
+    padding: 0;
   }
 `;
 export const EditorStudioLoadingState = styled.div `
@@ -40,40 +39,41 @@ export const EditorStudioLoadingState = styled.div `
   }
 `;
 export const EditorStudioDedicatedTopBar = styled.div `
-  width: min(100%, var(--article-readable-width, 48rem));
-  margin: 0 auto;
-  display: flex;
+  width: 100%;
+  min-height: 58px;
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
   gap: 1rem;
-  min-height: 48px;
+  padding: 0 1rem;
+  border-bottom: 1px solid ${({ theme }) => theme.publicDesign.border};
+  background: ${({ theme }) => theme.publicDesign.readableSurface};
 
   @media (max-width: 1200px) {
-    align-items: center;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    justify-content: space-between;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     gap: 0.8rem;
   }
 
   @media (max-width: 760px) {
+    grid-template-columns: 1fr;
     align-items: stretch;
-    flex-direction: column;
     gap: 0.7rem;
+    padding: 0.72rem;
   }
 `;
 export const EditorExitAction = styled.button `
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 42px;
-  padding: 0.2rem 0.32rem;
+  min-height: 34px;
+  width: min(100%, 240px);
+  padding: 0 0.72rem;
   margin: 0;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
+  border: 1px solid ${({ theme }) => theme.publicDesign.borderStrong};
+  border-radius: 0;
+  background: ${({ theme }) => theme.publicDesign.surfaceElevated};
   color: ${({ theme }) => theme.colors.gray12};
-  font-size: 0.98rem;
+  font-size: 0.9rem;
   font-weight: 700;
   line-height: 1;
   cursor: pointer;
@@ -120,7 +120,7 @@ export const EditorStudioSaveState = styled.span `
   font-size: 0.84rem;
   font-weight: 600;
   white-space: nowrap;
-  text-align: right;
+  text-align: center;
 
   &[data-tone="success"] {
     color: ${({ theme }) => theme.colors.green10};
@@ -185,19 +185,30 @@ export const PrimaryButton = styled(Button) `
     color: ${({ theme }) => theme.colors.accentControlText};
   }
 `;
-export const EditorStudioFrame = styled.div `
-  width: min(100%, 1600px);
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 1.4rem;
-  align-items: start;
-  justify-content: center;
-  overflow-x: visible;
+export const SecondaryButton = styled(Button) `
+  border-radius: 6px;
+  border-color: ${({ theme }) => theme.publicDesign.border};
+  background: ${({ theme }) => theme.publicDesign.readableSurface};
+  color: ${({ theme }) => theme.colors.gray12};
+  font-weight: 700;
 
-  @media (min-width: 1024px) {
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.publicDesign.borderStrong};
+    background: ${({ theme }) => theme.colors.gray2};
+  }
+`;
+export const EditorStudioFrame = styled.div `
+  width: 100%;
+  min-height: calc(100vh - 58px);
+  margin: 0;
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr) 300px;
+  gap: 0;
+  align-items: stretch;
+  overflow-x: clip;
+
+  @media (max-width: 1180px) {
     grid-template-columns: minmax(0, 1fr);
-    gap: 1.4rem;
   }
 `;
 export const EditorStudioWritingColumn = styled.section<{
@@ -205,14 +216,15 @@ export const EditorStudioWritingColumn = styled.section<{
 }> `
   display: grid;
   min-width: 0;
-  gap: ${({ $compact }) => ($compact ? "0.88rem" : "1rem")};
-  overflow-x: visible;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 0;
+  overflow-x: clip;
 `;
 export const EditorStudioDedicatedMetaSection = styled.section<{
     $compact?: boolean;
 }> `
   width: 100%;
-  max-width: var(--article-readable-width, 48rem);
+  max-width: 100%;
   min-width: 0;
   margin-inline: auto;
   display: grid;
@@ -220,7 +232,8 @@ export const EditorStudioDedicatedMetaSection = styled.section<{
   border: 1px solid ${({ theme }) => ("transparent")};
   border-radius: ${({ theme }) => ("0")};
   background: ${({ theme }) => ("transparent")};
-  padding: ${({ theme, $compact }) => ("0")};
+  padding: 1.55rem 1.8rem 1.05rem;
+
 `;
 export const EditorTagRow = styled.div<{
     $compact?: boolean;
@@ -323,6 +336,7 @@ export const TitleInput = styled.textarea<{
     $compact?: boolean;
 }> `
   width: 100%;
+  max-width: 52rem;
   min-width: 0;
   border: 0;
   border-radius: 0;
@@ -444,7 +458,7 @@ export const EditorHeaderActionButton = styled(Button) `
 export const EditorStudioDedicatedCanvasSection = styled.section `
   --compose-pane-readable-width: var(--article-readable-width, 48rem);
   width: 100%;
-  max-width: var(--article-readable-width, 48rem);
+  max-width: 100%;
   min-width: 0;
   margin-inline: auto;
   min-height: clamp(28rem, 70vh, 56rem);
@@ -454,8 +468,12 @@ export const EditorStudioDedicatedCanvasSection = styled.section `
   border: 1px solid ${({ theme }) => ("transparent")};
   border-radius: ${({ theme }) => ("0")};
   background: ${({ theme }) => ("transparent")};
-  padding: ${({ theme }) => ("0")};
+  padding: 0 1.8rem 1.8rem;
   box-shadow: ${({ theme }) => ("none")};
+
+  @media (max-width: 720px) {
+    padding: 0 0.82rem 1rem;
+  }
 `;
 export const PublishNotice = styled.div `
   margin: 0;
@@ -492,5 +510,255 @@ export const PublishNotice = styled.div `
 
   @media (max-width: 720px) {
     width: 100%;
+  }
+`;
+
+export const EditorOutline = styled.aside`
+  min-width: 0;
+  padding: 1.2rem 0.88rem;
+  border-right: 1px solid ${({ theme }) => theme.publicDesign.border};
+  background: ${({ theme }) => theme.publicDesign.surfaceElevated};
+
+  h3 {
+    margin: 0 0 1.1rem;
+    color: ${({ theme }) => theme.colors.gray10};
+    font: 750 0.68rem/1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  p {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.82rem;
+    line-height: 1.6;
+  }
+
+  @media (max-width: 1180px) {
+    display: none;
+  }
+`;
+
+export const EditorOutlineItem = styled.div`
+  display: grid;
+  grid-template-columns: 1.6rem minmax(0, 1fr);
+  gap: 0.45rem;
+  padding: 0.45rem 0;
+  color: ${({ theme }) => theme.colors.gray10};
+
+  &[data-level="2"] {
+    padding-left: 0.9rem;
+  }
+
+  &[data-level="3"] {
+    padding-left: 1.8rem;
+  }
+
+  &[data-active="true"] {
+    color: ${({ theme }) => theme.publicDesign.accent};
+  }
+
+  span {
+    font: 700 0.72rem/1.3 ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+
+  strong {
+    min-width: 0;
+    font-size: 0.82rem;
+    font-weight: 650;
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+  }
+`;
+
+export const EditorInspector = styled.aside`
+  min-width: 0;
+  display: grid;
+  align-content: start;
+  gap: 1.2rem;
+  padding: 1.2rem;
+  border-left: 1px solid ${({ theme }) => theme.publicDesign.border};
+  background: ${({ theme }) => theme.publicDesign.surfaceElevated};
+
+  h3,
+  label > span,
+  section > span {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.gray10};
+    font: 750 0.68rem/1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  label,
+  section {
+    display: grid;
+    gap: 0.65rem;
+    padding-bottom: 1.15rem;
+    border-bottom: 1px solid ${({ theme }) => theme.publicDesign.border};
+  }
+
+  select,
+  textarea {
+    width: 100%;
+    border: 1px solid ${({ theme }) => theme.publicDesign.border};
+    border-radius: 6px;
+    background: ${({ theme }) => theme.publicDesign.readableSurface};
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.88rem;
+  }
+
+  select {
+    min-height: 42px;
+    padding: 0 0.65rem;
+  }
+
+  textarea {
+    min-height: 5.6rem;
+    padding: 0.8rem;
+    resize: vertical;
+    line-height: 1.65;
+  }
+
+  p {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.8rem;
+    margin: 0;
+    font-size: 0.84rem;
+  }
+
+  b {
+    border: 1px solid ${({ theme }) => theme.colors.green7};
+    padding: 0.12rem 0.34rem;
+    color: ${({ theme }) => theme.colors.green11};
+    font: 750 0.68rem/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+
+  @media (max-width: 1180px) {
+    display: none;
+  }
+`;
+
+export const EditorInspectorPreview = styled.div`
+  display: grid;
+  border: 1px solid ${({ theme }) => theme.publicDesign.border};
+  background: ${({ theme }) => theme.publicDesign.readableSurface};
+
+  div {
+    min-height: 6.8rem;
+    padding: 1.05rem;
+    background: #0f1728;
+    color: #a9c5ff;
+    font: 800 0.86rem/1.45 ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+
+  strong {
+    padding: 0.85rem 0.85rem 0.2rem;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.92rem;
+    line-height: 1.35;
+  }
+
+  span {
+    padding: 0 0.85rem 0.9rem;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.78rem;
+  }
+`;
+
+export const EditorGuideBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  justify-content: flex-end;
+  background: rgba(17, 18, 22, 0.52);
+`;
+
+export const EditorGuidePanel = styled.aside`
+  width: min(100%, 590px);
+  min-height: 100vh;
+  overflow-y: auto;
+  padding: 1rem 1.35rem 1.4rem;
+  border-left: 1px solid ${({ theme }) => theme.publicDesign.border};
+  background: ${({ theme }) => theme.publicDesign.readableSurface};
+
+  header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+
+  header span {
+    color: ${({ theme }) => theme.publicDesign.accent};
+    font: 750 0.68rem/1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  h2 {
+    margin: 0.25rem 0 0;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 1.15rem;
+    line-height: 1.25;
+  }
+
+  header button {
+    border: 0;
+    background: transparent;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 1.2rem;
+    cursor: pointer;
+  }
+
+  > p {
+    margin: 0 0 1.35rem;
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.92rem;
+    line-height: 1.7;
+  }
+`;
+
+export const EditorGuideGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border: 1px solid ${({ theme }) => theme.publicDesign.border};
+
+  section {
+    min-width: 0;
+    padding: 1rem;
+    border-right: 1px solid ${({ theme }) => theme.publicDesign.border};
+    border-bottom: 1px solid ${({ theme }) => theme.publicDesign.border};
+  }
+
+  section:nth-of-type(2n) {
+    border-right: 0;
+  }
+
+  h3 {
+    margin: 0 0 0.7rem;
+    color: ${({ theme }) => theme.colors.gray12};
+    font-size: 0.9rem;
+  }
+
+  pre {
+    margin: 0;
+    min-height: 5.6rem;
+    padding: 0.8rem;
+    overflow: auto;
+    background: #0f1728;
+    color: #dbe7ff;
+    font: 650 0.74rem/1.55 ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+
+  @media (max-width: 560px) {
+    grid-template-columns: 1fr;
+
+    section {
+      border-right: 0;
+    }
   }
 `;

--- a/front/src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx
+++ b/front/src/routes/Admin/EditorStudioDedicatedEditorSurfaceParts.tsx
@@ -598,6 +598,12 @@ export const EditorInspector = styled.aside`
     border-bottom: 1px solid ${({ theme }) => theme.publicDesign.border};
   }
 
+  small {
+    justify-self: end;
+    color: ${({ theme }) => theme.colors.gray10};
+    font: 700 0.72rem/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+
   select,
   textarea {
     width: 100%;
@@ -633,6 +639,11 @@ export const EditorInspector = styled.aside`
     padding: 0.12rem 0.34rem;
     color: ${({ theme }) => theme.colors.green11};
     font: 750 0.68rem/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+
+  b[data-tone="warn"] {
+    border-color: ${({ theme }) => theme.colors.orange7};
+    color: ${({ theme }) => theme.colors.orange10};
   }
 
   @media (max-width: 1180px) {

--- a/front/src/routes/Admin/EditorStudioWorkspaceControllerRootView.tsx
+++ b/front/src/routes/Admin/EditorStudioWorkspaceControllerRootView.tsx
@@ -566,6 +566,11 @@ export const EditorStudioWorkspaceControllerRootView = ({ props }: EditorStudioW
         authorAvatarSrc={previewAuthorAvatarSrc}
         previewDateText={previewDateText}
         currentVisibilityText={currentVisibilityText}
+        postContent={postContent}
+        postSummary={postSummary}
+        onPostSummaryChange={setPostSummary}
+        postVisibility={postVisibility}
+        onPostVisibilityChange={setPostVisibility}
         canOpenCurrentPostDetail={canOpenCurrentPostDetail}
         onOpenPostDetail={() => void openPostDetailRoute(postId)}
         onCopyPostDetailLink={() => void copyPostDetailLink(postId, postTitle)}


### PR DESCRIPTION
## 관련 이슈

close #1066

## 작업 배경

- QA 요청 기준으로 글 작성(`/editor/new`)과 글 수정(`/editor/[id]`) 전용 에디터를 첨부 V4 디자인의 Markdown editor 화면과 같은 위치/구조로 맞춘다.
- 기존 main 화면은 공개 Header가 남아 있고 중앙 단일 에디터 폭으로 렌더되어 V4 기준의 좌측 document outline, 중앙 write/preview split, 우측 publish inspector 구성이 빠져 있었다.
- 데이터는 하드코딩하지 않고 기존 editor controller의 제목/본문/요약/태그/공개 범위 상태와 저장/수정/발행 backend payload를 유지한다.

## 작업 내용

- `/editor/new`, `/editor/[id]` 전용 route에서는 공개 사이트 Header를 숨기고 V4 기준 full-screen top bar를 렌더하도록 조정했다.
- dedicated editor surface를 좌측 Document outline, 중앙 Markdown split editor, 우측 Publish inspector 3열 구조로 재배치했다.
- outline은 현재 제목과 Markdown heading에서 파생하고, inspector의 요약/공개 범위/태그는 기존 backend 연결 상태 setter를 그대로 사용하도록 연결했다.
- Markdown editor toolbar와 write pane을 V4 어두운 source surface와 동일한 방향성으로 맞추고, guide drawer를 V4 authoring guide 패널 형태로 추가했다.
- 에디터 전용 E2E를 V4 chrome, inspector, dark source surface, preview/write padding 계약에 맞춰 갱신했다.

## 검증

- 실행한 명령과 결과:
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3200 yarn --cwd front playwright test e2e/editor-authoring-markdown-editor.spec.ts --workers=1`: 25 passed
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3200 yarn --cwd front playwright test e2e/mobile-layout.spec.ts --workers=1`: 1 passed
- `yarn --cwd front build`: exit 0, Next.js production build 성공
- `yarn --cwd front check:bundle-size`: exit 0, `/`, `/posts/[id]`, `/admin` raw/gzip/brotli 모두 OK
- `git diff --check`: exit 0
- 보안 영향 점검: diff에 `dangerouslySetInnerHTML`, `innerHTML`, `eval`, `Function`, `javascript:` sink 추가 없음. 저장/수정/발행 payload는 기존 controller 흐름 유지.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| V4 editor shell | Desktop Chromium | `/editor/new?source=local-draft` 시각 확인 | 로컬 증거: `/private/tmp/aquila-blog-issue-1066/evidence/aquilalog-editor-v4-current.png` | 헤더 없는 top bar, 좌측 outline, 중앙 split editor, 우측 inspector 확인 |
| Markdown guide drawer | Desktop Chromium | `Markdown 가이드` 열기 | 로컬 증거: `/private/tmp/aquila-blog-issue-1066/evidence/aquilalog-editor-v4-guide-current.png` | V4 authoring guide 형태의 우측 drawer 확인 |
| Backend-connected populated state | Desktop Chromium | 제목/본문/태그/요약 입력 후 확인 | 로컬 증거: `/private/tmp/aquila-blog-issue-1066/evidence/aquilalog-editor-v4-populated-current-2.png` | 화면 데이터가 editor state에 반응하고 inspector/outline에 반영됨 |
| Editor E2E | Local Chromium | Playwright authoring spec | 명령 출력: 25 passed | 통과 |
| Mobile layout regression | Local Chromium | Playwright mobile layout spec | 명령 출력: 1 passed | 통과 |
| Build/bundle guard | Local Node/Next.js | production build + bundle-size check | 명령 출력: build exit 0, bundle status OK | 통과 |

로컬 증거 사유: 스크린샷은 git에 커밋하지 않는 저장소 정책을 따랐고, 외부 이미지 업로드 승인은 이 스레드에서 별도로 받지 않았다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
- `RootLayout`에서 dedicated editor route에만 공개 Header를 숨기는 조건이 들어갔다.
- `EditorStudioDedicatedEditorSurface`는 새 UI를 기존 editor state/setter에 연결한다. API/DB 계약 변경은 없다.
- `MarkdownEditor`의 source pane 색상과 padding 변경은 `/editor/*` authoring UX 기준 회귀 테스트로 고정했다.

## 리스크

- V4 원본과 CSS token/font rendering 차이로 픽셀 단위 100% 동일성은 브라우저/폰트 환경에 따라 미세 차이가 날 수 있다.
- `EditorStudioDedicatedEditorSurfaceParts.tsx`가 refactor-boundaries 경고 대상이 됐다. 이번 QA 요청 범위에서는 디자인 위치 일치가 우선이라 파일 분리는 별도 후속으로 남긴다.
- 스크린샷은 로컬 증거라 PR에서 직접 렌더링되지는 않는다. 외부 업로드 승인이 있으면 PR comment에 이미지 증거로 보강 가능하다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
