### PR TITLE
[Fix] 라이브 관리자 허브 heading 검증 복구

### DIFF
--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -23,7 +23,7 @@ import {
 const hasLiveCredentials = Boolean((adminEmail || adminLegacyLoginId) && adminPassword)
 const hasUiLoginCredentials = Boolean(adminEmail && adminPassword)
 const expectedFrontendCommitSha = process.env.E2E_EXPECTED_FRONT_COMMIT_SHA?.trim() || ""
-const adminLandingHeadingPattern = /^관리자 허브$/
+const adminLandingHeadingPattern = /^좋은 아침이에요,/
 const adminDashboardHeadingPattern = /^운영 상태$/
 const adminCloudHeadingPattern = /^내 파일$/
 const adminProfileHeadingPattern = /^프로필$/


### PR DESCRIPTION
## 관련 이슈

close #1071

## 작업 배경

- PR #1070 merge 후 `Deploy to Home Server` run https://github.com/AquilaXk/aquila-blog/actions/runs/28093886573 의 live e2e가 `/admin` UI 로그인 직후 `관리자 허브` heading을 찾지 못해 실패했습니다.
- 실패 artifact의 accessibility snapshot에서 `관리자 허브`는 AdminShell top-bar의 strong 텍스트이고, 실제 h1 heading은 `좋은 아침이에요, aquila.` 형태였습니다.

## 작업 내용

- `front/e2e/live.spec.ts`의 `/admin` landing heading pattern을 top-bar label이 아니라 실제 h1 시작 문구 `좋은 아침이에요,` 기준으로 변경했습니다.
- dashboard/cloud/profile/posts/tools heading 검증은 기존 실제 h1 기준을 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright test e2e/live.spec.ts --grep "관리자 UI 로그인" --workers=1`: 1 skipped, local live credentials absent
  - `yarn --cwd front playwright test e2e/live.spec.ts --grep "관리자 로그인 후 핵심 운영 경로" --workers=1`: 1 skipped, local live credentials absent
  - `gh pr checks 1072 --repo AquilaXk/aquila-blog`: all checks passed
  - post-merge `Deploy to Home Server` run `28095192303`: success

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| CD 실패 원인 | GitHub Actions | 실패 로그와 Playwright artifact 확인 | https://github.com/AquilaXk/aquila-blog/actions/runs/28093886573, artifact https://github.com/AquilaXk/aquila-blog/actions/runs/28093886573/artifacts/7847610530 | `/admin` 화면은 로드됐지만 `관리자 허브`가 heading role이 아니어서 assertion 실패 |
| UI snapshot | local artifact inspection | 실패 artifact error-context/screenshot 확인 | `/tmp/aquila-cd-28093886573/test-results/playwright/pid-3205/live-live-production-e2e-관리자-UI-로그인-경로가-정상-동작한다-chromium/error-context.md` | 실제 h1은 `좋은 아침이에요, aquila.` |
| focused live UI login spec | local Playwright chromium | focused live e2e | `yarn --cwd front playwright test e2e/live.spec.ts --grep "관리자 UI 로그인" --workers=1` | 1 skipped, local live credentials absent |
| focused live admin journey spec | local Playwright chromium | focused live e2e | `yarn --cwd front playwright test e2e/live.spec.ts --grep "관리자 로그인 후 핵심 운영 경로" --workers=1` | 1 skipped, local live credentials absent |
| CI | GitHub Actions | PR checks | https://github.com/AquilaXk/aquila-blog/pull/1072/checks | all checks passed |
| post-merge CD | GitHub Actions | Deploy to Home Server | https://github.com/AquilaXk/aquila-blog/actions/runs/28095192303 | success |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `front/e2e/live.spec.ts`의 `adminLandingHeadingPattern`

## 리스크

- 로컬에서는 live credential이 없어 실제 로그인 경로가 skip됩니다. merge 후 CD live e2e에서 운영 credential로 통과 확인했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.