### PR TITLE
[Fix] 새로고침 초기 테마 색상 깜빡임 제거

### DIFF
--- a/front/e2e/smoke-public-shell.spec.ts
+++ b/front/e2e/smoke-public-shell.spec.ts
@@ -13,12 +13,12 @@ test.beforeEach(async ({ page }) => {
 })
 
 test.describe("core smoke public shell", () => {
-  test("system dark 공개 페이지는 hydration 첫 렌더에서 light scheme으로 되돌아가지 않는다", async () => {
+  test("system dark 공개 페이지는 hydration 첫 렌더와 bootstrap 동기화 경계를 분리한다", async () => {
     const useSchemeSource = readFileSync(path.resolve(__dirname, "../src/hooks/useScheme.ts"), "utf8")
 
     expect(useSchemeSource).toContain('CONFIG.blog.scheme === "system" ? "light" : CONFIG.blog.scheme')
     expect(useSchemeSource).toContain("const resolveBootstrapScheme = (): SchemeType | null =>")
-    expect(useSchemeSource).toContain("initialData: () => resolveBootstrapScheme() ?? fallbackScheme")
+    expect(useSchemeSource).toContain("initialData: fallbackScheme")
     expect(useSchemeSource).toContain("resolveBootstrapScheme() ??")
     expect(useSchemeSource).not.toContain("getCookie")
     expect(useSchemeSource).toContain("if (bootstrapScheme !== data)")

--- a/front/e2e/theme-color-scheme.spec.ts
+++ b/front/e2e/theme-color-scheme.spec.ts
@@ -159,7 +159,15 @@ test.describe("theme color-scheme", () => {
     page.on("console", (message) => {
       if (message.type() !== "error") return
       const text = message.text()
-      if (text.includes("Hydration failed") || text.includes("did not match")) {
+      if (
+        text.includes("Hydration failed") ||
+        text.includes("There was an error while hydrating") ||
+        text.includes("did not match") ||
+        text.includes("Minified React error #418") ||
+        text.includes("Minified React error #423") ||
+        text.includes("Minified React error `#418`") ||
+        text.includes("Minified React error `#423`")
+      ) {
         hydrationErrors.push(text)
       }
     })

--- a/front/e2e/theme-color-scheme.spec.ts
+++ b/front/e2e/theme-color-scheme.spec.ts
@@ -155,6 +155,14 @@ test.describe("theme color-scheme", () => {
   test("저장된 dark 테마 새로고침은 hydration 중 light frame으로 되돌아가지 않는다", async ({ page }) => {
     await prepareHomeThemePage(page)
     await installSchemeFrameSampler(page)
+    const hydrationErrors: string[] = []
+    page.on("console", (message) => {
+      if (message.type() !== "error") return
+      const text = message.text()
+      if (text.includes("Hydration failed") || text.includes("did not match")) {
+        hydrationErrors.push(text)
+      }
+    })
 
     await page.goto("/")
     await expect(page.getByRole("button", { name: "라이트 모드로 전환" })).toBeVisible()
@@ -166,6 +174,7 @@ test.describe("theme color-scheme", () => {
     expect(sampledSchemes).toEqual(new Set(["dark"]))
     expect(samples.every((sample) => sample.datasetScheme === "dark")).toBe(true)
     await expect(page.locator("html")).toHaveAttribute("data-aquila-scheme", "dark")
+    expect(hydrationErrors).toEqual([])
   })
 
   test("헤더 테마 토글은 루트, form control, 메인 feed surface를 함께 전환한다", async ({ page }) => {

--- a/front/src/hooks/useScheme.ts
+++ b/front/src/hooks/useScheme.ts
@@ -51,7 +51,7 @@ const useScheme = (): [SchemeType, SetScheme] => {
     queryFn: () => fallbackScheme,
     enabled: false,
     staleTime: Infinity,
-    initialData: () => resolveBootstrapScheme() ?? fallbackScheme,
+    initialData: fallbackScheme,
   })
 
   const setScheme = useCallback((scheme: SchemeType) => {


### PR DESCRIPTION
## 관련 이슈

close #1073

## 작업 배경

- QA 요청으로 새로고침 직후 상단 네비와 전역 UI가 dark 색상으로 먼저 렌더된 뒤 light 색상으로 돌아오고 React hydration mismatch가 발생하는 증상을 확인했다.
- 원인은 `_document` bootstrap은 cookie/system 기준 dark seed를 HTML에 적용하는데, 서버 React render의 `useScheme()` fallback과 클라이언트 첫 render seed가 달라 Emotion className mismatch가 발생하는 것이었다.

## 작업 내용

- `useScheme()`의 React Query `initialData`를 서버 render와 같은 fallback seed로 맞춰 hydration 첫 render className을 안정화했다.
- 기존 effect가 hydration 후 bootstrap seed를 읽어 실제 저장 테마로 동기화하는 흐름은 유지했다.
- `theme-color-scheme` e2e에 hydration mismatch console error guard를 추가하고 React hydration fallback/minified error 패턴까지 감지하도록 보강했다.
- public shell smoke 계약을 새 seed 경계와 맞게 갱신했다.

## 검증

- 실행한 명령과 결과:
- `yarn --cwd front playwright:preflight`: exit 0
- `yarn --cwd front playwright test e2e/theme-color-scheme.spec.ts --workers=1`: 3 passed, exit 0
- `yarn --cwd front build`: 2회 연속 exit 0
- `yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`: 1 passed, exit 0
- `yarn --cwd front playwright test e2e/mobile-layout.spec.ts --workers=1`: 1 passed, exit 0
- `yarn --cwd front playwright test e2e/theme-color-scheme.spec.ts e2e/perf.spec.ts e2e/mobile-layout.spec.ts --workers=1`: 5 passed, exit 0
- `yarn --cwd front playwright test e2e/smoke-public-shell.spec.ts -g 'system dark 공개 페이지는 hydration 첫 렌더와 bootstrap 동기화 경계를 분리한다' --workers=1`: 1 passed, exit 0
- PR CI: `frontend-ci`, backend CI, CodeQL, privacy drift, Vercel preview 모두 pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 새로고침 테마 seed | Local Browser `http://localhost:3100/` | 새 탭 새로고침 직후/1.2초 후 computed style 비교 | Codex Browser 측정: initial `rootScheme=dark`, `bootstrapScheme=dark`, `body.backgroundColor=rgb(13, 17, 23)`; settled `rootScheme=dark`, `bootstrapScheme=null`, `body.backgroundColor=rgb(18, 18, 18)` | 색상이 light로 튀지 않고 dark 계열 유지 |
| hydration overlay | Local Browser `http://localhost:3100/` | Next.js overlay DOM 확인 | Codex Browser 측정: `hasOverlay=false`, 화면 텍스트 정상 렌더 | overlay 없음 |
| hydration console guard | Chromium Playwright | `theme-color-scheme.spec.ts`에서 hydration mismatch/error 수집 | `3 passed`, 재실행 묶음에서 `5 passed` | mismatch error 0건 |
| header/mobile 회귀 | Chromium Playwright | mobile layout source boundary spec | `1 passed`, 재실행 묶음 포함 | 통과 |
| build 회귀 | Local build | Next production build | `yarn --cwd front build` 2회 연속 exit 0 | 통과 |
| PR CI | GitHub Actions/Vercel | PR #1074 checks | `frontend-ci` 8m23s pass, CodeQL/backend/privacy/Vercel pass | 통과 |
| 코드리뷰 | CodeRabbit/Codex CLI fallback | review thread 및 PR checks 확인 | CodeRabbit actionable 1건 해결 답글 + resolved, Codex CLI fallback actionable 0건 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
- `front/src/hooks/useScheme.ts`의 `initialData` 변경은 의도적으로 서버 첫 render와 클라이언트 hydration 첫 render를 맞추는 최소 수정이다.
- 실제 저장 테마 반영은 기존 `useEffect`의 `resolveBootstrapScheme()` 경로가 계속 담당한다.

## 리스크

- 시스템 테마가 dark인 최초 방문자는 서버 HTML은 light seed로 hydrate한 뒤 bootstrap guard/effect를 통해 dark로 동기화된다. 기존 dark pre-hydration guard가 유지되어 light frame 노출을 막는 계약에 의존한다.
- Browser screenshot은 Codex Browser 내부 증거로 확인했지만 현재 GitHub issue/PR 작성 경로에서 이미지 바이너리 업로드를 제공하지 않아 PR에는 측정값과 명령 결과로 대체했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 테마/색상 스키마 초기 렌더링과 하이드레이션 동기화가 더 안정적으로 동작하도록 개선되었습니다.
  * 새로고침 시 저장된 다크 테마가 유지되는지, 하이드레이션 오류가 발생하지 않는지 더 엄격하게 검증합니다.
  * 공개 쉘의 초기 스키마 처리 기준이 정리되어 첫 화면에서 잘못된 테마로 되돌아가는 현상을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
