### PR TITLE
[Style] AquilaLog V4 editor Markdown 블록 정렬

### DIFF
--- a/front/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/front/src/components/markdown-editor/MarkdownEditor.tsx
@@ -58,7 +58,7 @@ const tableSnippet = [
   "",
 ].join("\n")
 
-const codeBlockSnippet = ["", "```kotlin", "", "```", ""].join("\n")
+const codeBlockSnippet = ["", "```", "", "```", ""].join("\n")
 const mermaidSnippet = ["", "```mermaid", "flowchart LR", "    A[Admin write] --> B[DB commit]", "```", ""].join("\n")
 const calloutSnippet = ["", "> [!TIP]", "> **설계 원칙**", "> 내용을 입력하세요.", ""].join("\n")
 const toggleSnippet = ["", ":::toggle 자세히 보기", "내용을 입력하세요.", ":::", ""].join("\n")
@@ -589,40 +589,6 @@ const PreviewArticle = styled.article`
 
   .aq-markdown > :first-child {
     margin-top: 0;
-  }
-
-  .aq-mermaid {
-    padding: 0;
-    border: 1px solid ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.publicDesign.readableSurface};
-  }
-
-  .aq-mermaid::before {
-    content: "Mermaid · diagram";
-    height: 42px;
-    padding: 0 14px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
-    color: ${({ theme }) => theme.colors.gray9};
-    background: ${({ theme }) => theme.publicDesign.surfaceElevated};
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
-    font-size: 10px;
-    font-weight: 700;
-    line-height: 1;
-    text-transform: uppercase;
-  }
-
-  .aq-mermaid[data-mermaid-rendered="pending"] {
-    min-height: 12rem;
-  }
-
-  .aq-mermaid-stage {
-    padding: 28px;
-    background-image: linear-gradient(${({ theme }) => theme.publicDesign.surfaceElevated} 1px, transparent 1px),
-      linear-gradient(90deg, ${({ theme }) => theme.publicDesign.surfaceElevated} 1px, transparent 1px);
-    background-size: 28px 28px;
   }
 
   @media (max-width: 980px) {

--- a/front/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/front/src/components/markdown-editor/MarkdownEditor.tsx
@@ -47,7 +47,7 @@ const toolbarMarkdownSnippets = [
   { label: "List", title: "목록", before: "- ", after: "" },
   { label: "Task", title: "작업 목록", before: "- [ ] ", after: "" },
   { label: "Code", title: "인라인 코드", before: "`", after: "`" },
-  { label: "Link", title: "링크", before: "[링크 텍스트](https://)", after: "" },
+  { label: "Link", title: "링크", before: "[", after: "](https://)" },
 ] as const
 
 const tableSnippet = [

--- a/front/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/front/src/components/markdown-editor/MarkdownEditor.tsx
@@ -38,14 +38,16 @@ type TextareaSelection = {
 }
 
 const toolbarMarkdownSnippets = [
-  { label: "H", title: "제목", before: "## ", after: "" },
+  { label: "H1", title: "제목 1", before: "# ", after: "" },
+  { label: "H2", title: "제목 2", before: "## ", after: "" },
+  { label: "H3", title: "제목 3", before: "### ", after: "" },
   { label: "B", title: "굵게", before: "**", after: "**" },
   { label: "I", title: "기울임", before: "_", after: "_" },
-  { label: "Quote", title: "인용문", before: "> ", after: "" },
-  { label: "Code", title: "코드", before: "`", after: "`" },
-  { label: "Link", title: "링크", before: "[", after: "](https://)" },
+  { label: ">", title: "인용문", before: "> ", after: "" },
   { label: "List", title: "목록", before: "- ", after: "" },
   { label: "Task", title: "작업 목록", before: "- [ ] ", after: "" },
+  { label: "Code", title: "인라인 코드", before: "`", after: "`" },
+  { label: "Link", title: "링크", before: "[링크 텍스트](https://)", after: "" },
 ] as const
 
 const tableSnippet = [
@@ -56,7 +58,19 @@ const tableSnippet = [
   "",
 ].join("\n")
 
-const codeBlockSnippet = ["", "```", "", "```", ""].join("\n")
+const codeBlockSnippet = ["", "```kotlin", "", "```", ""].join("\n")
+const mermaidSnippet = ["", "```mermaid", "flowchart LR", "    A[Admin write] --> B[DB commit]", "```", ""].join("\n")
+const calloutSnippet = ["", "> [!TIP]", "> **설계 원칙**", "> 내용을 입력하세요.", ""].join("\n")
+const toggleSnippet = ["", ":::toggle 자세히 보기", "내용을 입력하세요.", ":::", ""].join("\n")
+
+const blockMarkdownSnippets = [
+  { label: "Code", title: "코드 블록", snippet: codeBlockSnippet },
+  { label: "Table", title: "표", snippet: tableSnippet },
+  { label: "Mermaid", title: "Mermaid", snippet: mermaidSnippet, disableWhenMermaid: true },
+  { label: "Callout", title: "콜아웃", snippet: calloutSnippet },
+  { label: "Toggle", title: "토글", snippet: toggleSnippet },
+] as const
+
 const WHEEL_DELTA_PIXEL = 0
 const WHEEL_DELTA_LINE = 1
 const WHEEL_DELTA_PAGE = 2
@@ -271,24 +285,18 @@ export const MarkdownEditor = ({
               {snippet.label}
             </ToolbarButton>
           ))}
-          <ToolbarButton
-            type="button"
-            aria-label="코드 블록"
-            disabled={disabled}
-            onMouseDown={(event) => event.preventDefault()}
-            onClick={() => applySnippet(codeBlockSnippet)}
-          >
-            Code block
-          </ToolbarButton>
-          <ToolbarButton
-            type="button"
-            aria-label="표"
-            disabled={disabled}
-            onMouseDown={(event) => event.preventDefault()}
-            onClick={() => applySnippet(tableSnippet)}
-          >
-            Table
-          </ToolbarButton>
+          {blockMarkdownSnippets.map((snippet) => (
+            <ToolbarButton
+              key={snippet.title}
+              type="button"
+              aria-label={snippet.title}
+              disabled={disabled || ("disableWhenMermaid" in snippet && disableMermaid)}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => applySnippet(snippet.snippet)}
+            >
+              {snippet.label}
+            </ToolbarButton>
+          ))}
           <ImageUploadButton>
             Image
             <input
@@ -362,45 +370,50 @@ export const MarkdownEditor = ({
 
 const EditorRoot = styled.section`
   border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 6px;
+  border-radius: 0;
   overflow: hidden;
   background: ${({ theme }) => theme.publicDesign.readableSurface};
   color: ${({ theme }) => theme.colors.gray12};
 `
 
 const EditorToolbar = styled.div`
-  min-height: 48px;
+  min-height: 44px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.5rem;
+  gap: 0.5rem;
+  padding: 0.35rem 0.55rem;
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.publicDesign.surfaceElevated};
+  background: ${({ theme }) => theme.publicDesign.readableSurface};
   flex-wrap: wrap;
 `
 
 const ModeTabs = styled.div`
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: ${({ theme }) => theme.publicDesign.surfaceElevated};
 `
 
 const ModeTab = styled.button`
-  border: 1px solid transparent;
-  border-radius: 6px;
-  min-height: 32px;
-  padding: 0 0.75rem;
+  border: 0;
+  border-left: 1px solid ${({ theme }) => theme.colors.gray6};
+  min-height: 28px;
+  padding: 0 0.62rem;
   background: transparent;
   color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.86rem;
-  font-weight: 600;
+  font-size: 0.72rem;
+  font-weight: 750;
   cursor: pointer;
 
+  &:first-of-type {
+    border-left: 0;
+  }
+
   &[aria-selected="true"] {
-    background: ${({ theme }) => theme.publicDesign.readableSurface};
-    border-color: ${({ theme }) => theme.colors.gray6};
-    color: ${({ theme }) => theme.colors.gray12};
+    background: ${({ theme }) => theme.colors.gray12};
+    color: ${({ theme }) => theme.colors.gray1};
   }
 
   &:focus-visible {
@@ -412,19 +425,19 @@ const ModeTab = styled.button`
 const ToolbarGroup = styled.div`
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: 0.25rem;
+  justify-content: flex-start;
+  gap: 0.12rem;
   flex-wrap: wrap;
 `
 
 const ToolbarButton = styled.button`
   border: 0;
-  border-radius: 6px;
-  min-height: 32px;
-  padding: 0 0.58rem;
+  border-radius: 4px;
+  min-height: 30px;
+  padding: 0 0.52rem;
   background: transparent;
   color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.78rem;
+  font-size: 0.7rem;
   font-weight: 700;
   cursor: pointer;
 
@@ -440,13 +453,13 @@ const ToolbarButton = styled.button`
 `
 
 const ImageUploadButton = styled.label`
-  border-radius: 6px;
-  min-height: 32px;
+  border-radius: 4px;
+  min-height: 30px;
   display: inline-flex;
   align-items: center;
-  padding: 0 0.58rem;
+  padding: 0 0.52rem;
   color: ${({ theme }) => theme.colors.gray10};
-  font-size: 0.78rem;
+  font-size: 0.7rem;
   font-weight: 700;
   cursor: pointer;
 
@@ -576,6 +589,40 @@ const PreviewArticle = styled.article`
 
   .aq-markdown > :first-child {
     margin-top: 0;
+  }
+
+  .aq-mermaid {
+    padding: 0;
+    border: 1px solid ${({ theme }) => theme.colors.gray6};
+    background: ${({ theme }) => theme.publicDesign.readableSurface};
+  }
+
+  .aq-mermaid::before {
+    content: "Mermaid · diagram";
+    height: 42px;
+    padding: 0 14px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid ${({ theme }) => theme.colors.gray6};
+    color: ${({ theme }) => theme.colors.gray9};
+    background: ${({ theme }) => theme.publicDesign.surfaceElevated};
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
+  .aq-mermaid[data-mermaid-rendered="pending"] {
+    min-height: 12rem;
+  }
+
+  .aq-mermaid-stage {
+    padding: 28px;
+    background-image: linear-gradient(${({ theme }) => theme.publicDesign.surfaceElevated} 1px, transparent 1px),
+      linear-gradient(90deg, ${({ theme }) => theme.publicDesign.surfaceElevated} 1px, transparent 1px);
+    background-size: 28px 28px;
   }
 
   @media (max-width: 980px) {

--- a/front/src/libs/markdown/components/MarkdownRendererRootCalloutStyles.ts
+++ b/front/src/libs/markdown/components/MarkdownRendererRootCalloutStyles.ts
@@ -3,20 +3,19 @@ import { articleTypographyScale } from "src/libs/markdown/contentTypography"
 
 export const markdownRendererRootCalloutStyles = (theme: Theme) => css`
   .aq-callout.aq-admonition {
-    --ad-header-h: 52px;
-    --ad-accent: ${ (theme.scheme === "dark" ? "#4cc9f0" : "#0b63a8")};
-    --ad-header-bg: ${ (theme.scheme === "dark" ? "rgba(76, 201, 240, 0.2)" : "#e9f4ff")};
-    --ad-body-bg: ${ (theme.scheme === "dark" ? "rgba(76, 201, 240, 0.12)" : "#f4f9ff")};
-    --ad-border: ${ (theme.scheme === "dark" ? "rgba(76, 201, 240, 0.38)" : "#9cc4e8")};
+    --ad-accent: ${ (theme.scheme === "dark" ? "#7dd3fc" : "#155eef")};
+    --ad-body-bg: ${ (theme.scheme === "dark" ? "rgba(125, 211, 252, 0.08)" : "rgba(21, 94, 239, 0.04)")};
+    --ad-border: ${ (theme.scheme === "dark" ? "rgba(125, 211, 252, 0.28)" : "rgba(21, 94, 239, 0.3)")};
     --ad-text: ${ (theme.scheme === "dark" ? "#e6edf6" : "#1f2937")};
     position: relative;
-    display: block;
+    display: grid;
+    grid-template-columns: 34px minmax(0, 1fr);
+    gap: 13px;
     border: 1px solid var(--ad-border);
-    border-left: 8px solid var(--ad-accent);
-    border-radius: 8px;
-    overflow: hidden;
-    padding: 0;
-    margin: 0.9rem 0;
+    border-radius: 0;
+    overflow: visible;
+    padding: 19px 20px;
+    margin: 30px 0;
     background: var(--ad-body-bg);
     color: var(--ad-text);
   }
@@ -27,37 +26,45 @@ export const markdownRendererRootCalloutStyles = (theme: Theme) => css`
   }
 
   .aq-callout.aq-admonition .aq-callout-box-text {
+    grid-column: 2;
     margin-left: 0;
-    padding: 0 24px 18px;
+    padding: 0;
     color: var(--ad-text);
   }
 
   .aq-callout.aq-admonition .aq-callout-head {
     display: flex;
     align-items: center;
-    gap: 0.7rem;
-    min-height: var(--ad-header-h);
-    margin: 0 -24px 14px;
-    padding: 0 24px;
-    background: var(--ad-header-bg);
-    border-bottom: 1px solid var(--ad-border);
+    gap: 8px;
+    min-height: 0;
+    margin: 0 0 5px;
+    padding: 0;
+    background: transparent;
+    border-bottom: 0;
   }
 
   .aq-callout.aq-admonition .aq-callout-head[data-has-title="false"] {
-    margin-bottom: 12px;
+    margin-bottom: 0;
   }
 
   .aq-callout.aq-admonition .aq-callout-emoji {
+    width: 30px;
+    height: 30px;
+    display: grid;
+    place-items: center;
+    margin-left: -47px;
+    border: 1px solid currentColor;
     color: var(--ad-accent);
-    font-size: ${articleTypographyScale.bodyFontSize};
-    font-weight: 600;
-    line-height: ${articleTypographyScale.bodyLineHeight};
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1;
   }
 
   .aq-callout.aq-admonition .aq-callout-title {
-    color: var(--ad-accent);
+    color: var(--ad-text);
     font-size: ${articleTypographyScale.calloutTitleFontSize};
-    font-weight: 700;
+    font-weight: 750;
     line-height: ${articleTypographyScale.calloutTitleLineHeight};
     letter-spacing: 0;
   }
@@ -67,50 +74,44 @@ export const markdownRendererRootCalloutStyles = (theme: Theme) => css`
   }
 
   .aq-callout.aq-admonition .aq-markdown-text {
-    color: var(--ad-text);
+    color: ${theme.colors.gray11};
     font-size: ${articleTypographyScale.bodyFontSize};
     line-height: ${articleTypographyScale.bodyLineHeight};
   }
 
   .aq-callout.aq-admonition-tip {
-    --ad-accent: ${ (theme.scheme === "dark" ? "#f6ad55" : "#c46a10")};
-    --ad-header-bg: ${ (theme.scheme === "dark" ? "rgba(246, 173, 85, 0.2)" : "#fff1d8")};
-    --ad-body-bg: ${ (theme.scheme === "dark" ? "rgba(246, 173, 85, 0.12)" : "#fff8e8")};
-    --ad-border: ${ (theme.scheme === "dark" ? "rgba(246, 173, 85, 0.36)" : "#e9c27d")};
+    --ad-accent: ${ (theme.scheme === "dark" ? "#86efac" : "#12805c")};
+    --ad-body-bg: ${ (theme.scheme === "dark" ? "rgba(134, 239, 172, 0.08)" : "rgba(18, 128, 92, 0.04)")};
+    --ad-border: ${ (theme.scheme === "dark" ? "rgba(134, 239, 172, 0.28)" : "rgba(18, 128, 92, 0.3)")};
   }
 
   .aq-callout.aq-admonition-info {
     --ad-accent: ${ (theme.scheme === "dark" ? "#4cc9f0" : "#0b63a8")};
-    --ad-header-bg: ${ (theme.scheme === "dark" ? "rgba(76, 201, 240, 0.2)" : "#e9f4ff")};
-    --ad-body-bg: ${ (theme.scheme === "dark" ? "rgba(76, 201, 240, 0.12)" : "#f4f9ff")};
-    --ad-border: ${ (theme.scheme === "dark" ? "rgba(76, 201, 240, 0.38)" : "#9cc4e8")};
+    --ad-body-bg: ${ (theme.scheme === "dark" ? "rgba(76, 201, 240, 0.08)" : "rgba(21, 94, 239, 0.04)")};
+    --ad-border: ${ (theme.scheme === "dark" ? "rgba(76, 201, 240, 0.28)" : "rgba(21, 94, 239, 0.3)")};
   }
 
   .aq-callout.aq-admonition-warning {
-    --ad-accent: ${ (theme.scheme === "dark" ? "#fb7185" : "#b42344")};
-    --ad-header-bg: ${ (theme.scheme === "dark" ? "rgba(251, 113, 133, 0.2)" : "#fdecef")};
-    --ad-body-bg: ${ (theme.scheme === "dark" ? "rgba(251, 113, 133, 0.12)" : "#fff6f8")};
-    --ad-border: ${ (theme.scheme === "dark" ? "rgba(251, 113, 133, 0.38)" : "#e8a8b8")};
+    --ad-accent: ${ (theme.scheme === "dark" ? "#fbbf24" : "#a15c00")};
+    --ad-body-bg: ${ (theme.scheme === "dark" ? "rgba(251, 191, 36, 0.08)" : "rgba(161, 92, 0, 0.05)")};
+    --ad-border: ${ (theme.scheme === "dark" ? "rgba(251, 191, 36, 0.32)" : "rgba(161, 92, 0, 0.34)")};
   }
 
   .aq-callout.aq-admonition-outline {
     --ad-accent: ${ (theme.scheme === "dark" ? "#94a3b8" : "#475569")};
-    --ad-header-bg: ${ (theme.scheme === "dark" ? "rgba(148, 163, 184, 0.2)" : "#eef2f6")};
-    --ad-body-bg: ${ (theme.scheme === "dark" ? "rgba(148, 163, 184, 0.12)" : "#f8fafc")};
-    --ad-border: ${ (theme.scheme === "dark" ? "rgba(148, 163, 184, 0.34)" : "#c7d1dd")};
+    --ad-body-bg: ${ (theme.scheme === "dark" ? "rgba(148, 163, 184, 0.08)" : theme.publicDesign.surfaceElevated)};
+    --ad-border: ${ theme.colors.gray6};
   }
 
   .aq-callout.aq-admonition-example {
     --ad-accent: ${ (theme.scheme === "dark" ? "#4ade80" : "#166534")};
-    --ad-header-bg: ${ (theme.scheme === "dark" ? "rgba(74, 222, 128, 0.2)" : "#e8f7ef")};
-    --ad-body-bg: ${ (theme.scheme === "dark" ? "rgba(74, 222, 128, 0.12)" : "#f4fcf7")};
-    --ad-border: ${ (theme.scheme === "dark" ? "rgba(74, 222, 128, 0.36)" : "#9fd9b4")};
+    --ad-body-bg: ${ (theme.scheme === "dark" ? "rgba(74, 222, 128, 0.08)" : "rgba(22, 101, 52, 0.04)")};
+    --ad-border: ${ (theme.scheme === "dark" ? "rgba(74, 222, 128, 0.28)" : "rgba(22, 101, 52, 0.28)")};
   }
 
   .aq-callout.aq-admonition-summary {
     --ad-accent: ${ (theme.scheme === "dark" ? "#a78bfa" : "#5b4ab8")};
-    --ad-header-bg: ${ (theme.scheme === "dark" ? "rgba(167, 139, 250, 0.2)" : "#efecff")};
-    --ad-body-bg: ${ (theme.scheme === "dark" ? "rgba(167, 139, 250, 0.12)" : "#f7f5ff")};
-    --ad-border: ${ (theme.scheme === "dark" ? "rgba(167, 139, 250, 0.38)" : "#bfb3eb")};
+    --ad-body-bg: ${theme.publicDesign.surfaceElevated};
+    --ad-border: ${theme.colors.gray7};
   }
 `

--- a/front/src/libs/markdown/components/MarkdownRendererRootCodeStyles.ts
+++ b/front/src/libs/markdown/components/MarkdownRendererRootCodeStyles.ts
@@ -4,34 +4,27 @@ import { articleTypographyScale } from "src/libs/markdown/contentTypography"
 
 export const markdownRendererRootCodeStyles = (theme: Theme) => css`
   .aq-code {
-    border-radius: 14px;
+    border-radius: 0;
     padding: 1.02rem 1.1rem;
     overflow-x: auto;
-    background: ${
-      theme.scheme === "dark"
-        ? "linear-gradient(180deg, rgba(20, 26, 34, 0.98), rgba(15, 19, 27, 0.98))"
-        : "linear-gradient(180deg, #f8fafc, #f3f5f8)"};
-    border: 1px solid
-      ${
-        theme.scheme === "dark" ? "rgba(255, 255, 255, 0.08)" : "rgba(17, 24, 39, 0.08)"};
-    box-shadow: ${
-      theme.scheme === "dark" ? "0 16px 36px rgba(2, 6, 23, 0.32)" : "0 16px 32px rgba(15, 23, 42, 0.06)"};
+    background: #0f1728;
+    border: 1px solid #27334a;
+    box-shadow: none;
   }
 
   .aq-code-block {
     --aq-code-shell-padding-x: 0.72rem;
     --aq-code-gutter-width: 1.34rem;
     --aq-code-gutter-gap: 0.54rem;
-    margin: 1.2rem 0;
+    margin: 28px 0;
     max-width: 100%;
     min-width: 0;
-    border-radius: 14px;
+    border-radius: 0;
     overflow: hidden;
     border: 1px solid
       ${
         theme.scheme === "dark" ? "rgba(255, 255, 255, 0.08)" : "rgba(17, 24, 39, 0.08)"};
-    box-shadow: ${
-      theme.scheme === "dark" ? "0 18px 38px rgba(2, 6, 23, 0.34)" : "0 18px 36px rgba(15, 23, 42, 0.08)"};
+    box-shadow: none;
   }
 
   .aq-code-toolbar {
@@ -39,14 +32,10 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
     grid-template-columns: auto 1fr;
     align-items: center;
     gap: 0.75rem;
-    padding: 0.84rem 0.96rem 0.76rem;
-    background: ${
-      theme.scheme === "dark"
-        ? "linear-gradient(180deg, #3a3f59, #363b54)"
-        : "linear-gradient(180deg, #dee4ef, #d6dde8)"};
-    border-bottom: 1px solid
-      ${
-        theme.scheme === "dark" ? "rgba(255, 255, 255, 0.06)" : "rgba(17, 24, 39, 0.08)"};
+    min-height: 42px;
+    padding: 0 14px;
+    background: #0f1728;
+    border-bottom: 1px solid #27334a;
   }
 
   .aq-code-toolbar-left {
@@ -56,10 +45,7 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
   }
 
   .aq-code-dot {
-    width: 0.92rem;
-    height: 0.92rem;
-    border-radius: 999px;
-    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
+    display: none;
   }
 
   .aq-code-dot-red {
@@ -80,7 +66,7 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
     font-weight: 700;
     letter-spacing: 0.04em;
     text-transform: uppercase;
-    color: ${ (theme.scheme === "dark" ? "#ff9d62" : "#7b4b2a")};
+    color: #7895c9;
   }
 
   .aq-code-copy {
@@ -93,7 +79,7 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
     background: ${
       theme.scheme === "dark" ? "rgba(255, 255, 255, 0.04)" : "rgba(255, 255, 255, 0.72)"};
     color: ${ (theme.scheme === "dark" ? "#d7dbe5" : "#334155")};
-    border-radius: 10px;
+    border-radius: 0;
     width: 2.25rem;
     min-width: 2.25rem;
     height: 2.05rem;
@@ -156,8 +142,7 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-x: contain;
     touch-action: pan-x;
-    background: ${
-      theme.scheme === "dark" ? "#2b2d3a" : "#f2f4f8"};
+    background: #0f1728;
   }
 
   .aq-code-block .aq-code {
@@ -168,9 +153,8 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
     box-shadow: none;
     padding: 1.05rem var(--aq-code-shell-padding-x) 3.55rem;
     min-width: 100%;
-    background: ${
-      theme.scheme === "dark" ? "#2b2d3a" : "#f2f4f8"};
-    color: ${ (theme.scheme === "dark" ? "#a9b7c6" : "#2f3747")};
+    background: #0f1728;
+    color: #dbe7ff;
   }
 
   .aq-code pre,
@@ -220,13 +204,13 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
   .aq-pretty-pre code > [data-highlighted-line] {
     background: ${
       theme.scheme === "dark" ? "rgba(96, 165, 250, 0.11)" : "rgba(59, 130, 246, 0.1)"};
-    border-radius: 6px;
+    border-radius: 0;
   }
 
   .aq-pretty-pre code [data-highlighted-chars] {
     background: ${
       theme.scheme === "dark" ? "rgba(250, 204, 21, 0.2)" : "rgba(250, 204, 21, 0.25)"};
-    border-radius: 4px;
+    border-radius: 0;
     padding: 0.04em 0.2em;
   }
 
@@ -240,7 +224,7 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
     margin: 1rem 0;
     max-width: 100%;
     min-width: 0;
-    border-radius: 14px;
+    border-radius: 0;
     overflow: hidden;
     border: 1px solid ${ theme.colors.gray6};
     background: ${

--- a/front/src/libs/markdown/components/MarkdownRendererRootCodeStyles.ts
+++ b/front/src/libs/markdown/components/MarkdownRendererRootCodeStyles.ts
@@ -197,19 +197,17 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
     top: 0;
     width: var(--aq-code-gutter-width);
     text-align: right;
-    color: ${ (theme.scheme === "dark" ? "#6d768b" : "#90a0b7")};
+    color: #6d768b;
     user-select: none;
   }
 
   .aq-pretty-pre code > [data-highlighted-line] {
-    background: ${
-      theme.scheme === "dark" ? "rgba(96, 165, 250, 0.11)" : "rgba(59, 130, 246, 0.1)"};
+    background: rgba(96, 165, 250, 0.11);
     border-radius: 0;
   }
 
   .aq-pretty-pre code [data-highlighted-chars] {
-    background: ${
-      theme.scheme === "dark" ? "rgba(250, 204, 21, 0.2)" : "rgba(250, 204, 21, 0.25)"};
+    background: rgba(250, 204, 21, 0.2);
     border-radius: 0;
     padding: 0.04em 0.2em;
   }
@@ -269,12 +267,12 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
   pre code .token.prolog,
   pre code .token.doctype,
   pre code .token.cdata {
-    color: ${ (theme.scheme === "dark" ? "#808b99" : "#6a7280")};
+    color: #808b99;
     font-style: italic;
   }
 
   pre code .token.punctuation {
-    color: ${ (theme.scheme === "dark" ? "#a9b7c6" : "#495367")};
+    color: #a9b7c6;
   }
 
   pre code .token.property,
@@ -282,12 +280,12 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
   pre code .token.constant,
   pre code .token.symbol,
   pre code .token.deleted {
-    color: ${ (theme.scheme === "dark" ? "#cc7832" : "#b45309")};
+    color: #cc7832;
   }
 
   pre code .token.boolean,
   pre code .token.number {
-    color: ${ (theme.scheme === "dark" ? "#6897bb" : "#1d4ed8")};
+    color: #6897bb;
   }
 
   pre code .token.selector,
@@ -296,14 +294,14 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
   pre code .token.char,
   pre code .token.builtin,
   pre code .token.inserted {
-    color: ${ (theme.scheme === "dark" ? "#6aab73" : "#047857")};
+    color: #6aab73;
   }
 
   pre code .token.operator,
   pre code .token.entity,
   pre code .token.url,
   pre code .token.variable {
-    color: ${ (theme.scheme === "dark" ? "#9876aa" : "#7c3aed")};
+    color: #9876aa;
   }
 
   pre code .token.atrule,
@@ -311,18 +309,18 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
   pre code .token.keyword,
   pre code .token.annotation,
   pre code .token.decorator {
-    color: ${ (theme.scheme === "dark" ? "#cc7832" : "#1d4ed8")};
+    color: #cc7832;
     font-weight: 600;
   }
 
   pre code .token.function,
   pre code .token.class-name {
-    color: ${ (theme.scheme === "dark" ? "#ffc66d" : "#be185d")};
+    color: #ffc66d;
   }
 
   pre code .token.regex,
   pre code .token.important {
-    color: ${ (theme.scheme === "dark" ? "#bbb529" : "#92400e")};
+    color: #bbb529;
   }
 
   @media (max-width: 768px) {

--- a/front/src/libs/markdown/components/MarkdownRendererRootMermaidStyles.ts
+++ b/front/src/libs/markdown/components/MarkdownRendererRootMermaidStyles.ts
@@ -7,12 +7,12 @@ export const markdownRendererRootMermaidStyles = (theme: Theme) => css`
     --aq-toggle-gap: 0.52rem;
     --aq-toggle-summary-padding-x: 0;
     --aq-toggle-indent: calc(var(--aq-toggle-summary-padding-x) + var(--aq-toggle-caret-hit) + var(--aq-toggle-gap));
-    margin: 0.98rem 0;
+    margin: 30px 0;
     position: relative;
   }
 
   .aq-mermaid {
-    margin: 1rem 0;
+    margin: 30px 0;
     display: block;
     width: 100%;
     max-width: 100%;
@@ -91,7 +91,8 @@ export const markdownRendererRootMermaidStyles = (theme: Theme) => css`
   }
 
   .aq-mermaid-error-state {
-    border-radius: 12px;
+    margin: 28px;
+    border-radius: 0;
     border: 1px solid ${ (theme.scheme === "dark" ? "rgba(217, 119, 6, 0.46)" : "rgba(217, 119, 6, 0.42)")};
     background: ${ (theme.scheme === "dark" ? "rgba(120, 53, 15, 0.16)" : "rgba(254, 243, 199, 0.88)")};
     padding: 0.88rem 0.94rem;
@@ -119,7 +120,7 @@ export const markdownRendererRootMermaidStyles = (theme: Theme) => css`
   }
 
   .aq-mermaid-error-guidance code {
-    border-radius: 6px;
+    border-radius: 0;
     border: 1px solid ${ (theme.scheme === "dark" ? "rgba(251, 191, 36, 0.3)" : "rgba(217, 119, 6, 0.32)")};
     background: ${ (theme.scheme === "dark" ? "rgba(120, 53, 15, 0.24)" : "rgba(255, 251, 235, 0.92)")};
     padding: 0.08rem 0.34rem;
@@ -149,7 +150,7 @@ export const markdownRendererRootMermaidStyles = (theme: Theme) => css`
     color: ${ (theme.scheme === "dark" ? "#fef3c7" : "#7c2d12")};
     font-size: 0.78rem;
     line-height: 1.5;
-    border-radius: 8px;
+    border-radius: 0;
     border: 1px solid ${ (theme.scheme === "dark" ? "rgba(251, 191, 36, 0.22)" : "rgba(217, 119, 6, 0.24)")};
     background: ${ (theme.scheme === "dark" ? "rgba(120, 53, 15, 0.18)" : "rgba(255, 251, 235, 0.82)")};
     margin-top: 0.34rem;
@@ -159,7 +160,7 @@ export const markdownRendererRootMermaidStyles = (theme: Theme) => css`
   .aq-mermaid-expand-btn {
     margin: 0.45rem 0 0;
     min-height: 32px;
-    border-radius: 999px;
+    border-radius: 0;
     border: 1px solid ${ theme.colors.gray6};
     background: ${ theme.colors.gray2};
     color: ${ theme.colors.gray11};

--- a/front/src/libs/markdown/components/MarkdownRendererRootMermaidStyles.ts
+++ b/front/src/libs/markdown/components/MarkdownRendererRootMermaidStyles.ts
@@ -20,12 +20,29 @@ export const markdownRendererRootMermaidStyles = (theme: Theme) => css`
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     white-space: normal;
-    padding: 0.2rem 0;
-    border: 0;
+    padding: 0;
+    border: 1px solid ${theme.colors.gray6};
     border-radius: 0;
     background: transparent;
     box-shadow: none;
     scrollbar-width: thin;
+  }
+
+  .aq-mermaid::before {
+    content: "Mermaid · diagram";
+    height: 42px;
+    padding: 0 14px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid ${theme.colors.gray6};
+    color: ${theme.colors.gray9};
+    background: ${theme.publicDesign.surfaceElevated};
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+    text-transform: uppercase;
   }
 
   .aq-mermaid[data-mermaid-wide="true"] {
@@ -37,7 +54,7 @@ export const markdownRendererRootMermaidStyles = (theme: Theme) => css`
   }
 
   .aq-mermaid[data-mermaid-rendered="pending"] {
-    min-height: 7.5rem;
+    min-height: 12rem;
   }
 
   .aq-mermaid[data-mermaid-rendered="pending"] > code {
@@ -53,6 +70,10 @@ export const markdownRendererRootMermaidStyles = (theme: Theme) => css`
     align-items: flex-start;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
+    padding: 28px;
+    background-image: linear-gradient(${theme.publicDesign.surfaceElevated} 1px, transparent 1px),
+      linear-gradient(90deg, ${theme.publicDesign.surfaceElevated} 1px, transparent 1px);
+    background-size: 28px 28px;
   }
 
   .aq-mermaid[data-mermaid-wide="true"] .aq-mermaid-stage {

--- a/front/src/libs/markdown/components/MarkdownRendererRootMermaidStyles.ts
+++ b/front/src/libs/markdown/components/MarkdownRendererRootMermaidStyles.ts
@@ -63,6 +63,7 @@ export const markdownRendererRootMermaidStyles = (theme: Theme) => css`
 
   .aq-mermaid-stage {
     display: flex;
+    box-sizing: border-box;
     width: 100%;
     min-width: 0;
     max-width: 100%;

--- a/front/src/libs/markdown/components/MarkdownRendererRootTableToggleStyles.ts
+++ b/front/src/libs/markdown/components/MarkdownRendererRootTableToggleStyles.ts
@@ -5,8 +5,6 @@ import {
 } from "src/libs/markdown/tableMetadata"
 import {
   getTableChromePalette,
-  TABLE_SHARED_MARGIN_Y,
-  TABLE_SHARED_RADIUS_PX,
 } from "src/libs/markdown/tableChrome"
 
 export const markdownRendererRootTableToggleStyles = (theme: Theme) => css`
@@ -15,10 +13,10 @@ export const markdownRendererRootTableToggleStyles = (theme: Theme) => css`
     position: relative;
     display: block;
     list-style: none;
-    padding: 0.1rem var(--aq-toggle-summary-padding-x) 0.1rem var(--aq-toggle-indent);
+    padding: 0.16rem var(--aq-toggle-summary-padding-x) 0.16rem var(--aq-toggle-indent);
     color: var(--color-gray12);
-    font-size: 1.01rem;
-    font-weight: 580;
+    font-size: 0.96rem;
+    font-weight: 650;
     line-height: 1.58;
   }
 
@@ -75,7 +73,7 @@ export const markdownRendererRootTableToggleStyles = (theme: Theme) => css`
     width: 100%;
     max-width: 100%;
     min-width: 0;
-    margin: ${TABLE_SHARED_MARGIN_Y} 0;
+    margin: 30px 0;
   }
 
   .aq-table-scroll {
@@ -88,9 +86,9 @@ export const markdownRendererRootTableToggleStyles = (theme: Theme) => css`
     overflow-x: auto;
     overflow-y: hidden;
     border: 1px solid ${tableChrome.border};
-    border-radius: ${TABLE_SHARED_RADIUS_PX}px;
+    border-radius: 0;
     background: ${tableChrome.background};
-    box-shadow: ${tableChrome.shadow};
+    box-shadow: none;
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-x: contain;
     overscroll-behavior-y: auto;
@@ -133,11 +131,15 @@ export const markdownRendererRootTableToggleStyles = (theme: Theme) => css`
       return `
     text-align: left;
     background: ${tableChrome.headerBackground};
-    font-weight: 700;
-    line-height: 1.52;
-    padding-top: calc(0.78rem + 0.14rem);
-    padding-bottom: calc(0.78rem - 0.14rem);
-    border-bottom: 2px solid ${tableChrome.headerRule};
+    color: ${theme.colors.gray10};
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
+    font-size: 11px;
+    font-weight: 750;
+    line-height: 1.4;
+    text-transform: uppercase;
+    padding-top: 13px;
+    padding-bottom: 13px;
+    border-bottom: 1px solid ${tableChrome.headerRule};
       `
     })()}
   }
@@ -145,9 +147,9 @@ export const markdownRendererRootTableToggleStyles = (theme: Theme) => css`
   @media (min-width: 769px) {
     thead th,
     .aq-table thead th {
-      line-height: 1.6;
-      padding-top: calc(0.78rem + 0.32rem);
-      padding-bottom: calc(0.78rem - 0.04rem);
+      line-height: 1.4;
+      padding-top: 13px;
+      padding-bottom: 13px;
     }
   }
 
@@ -155,7 +157,7 @@ export const markdownRendererRootTableToggleStyles = (theme: Theme) => css`
   td,
   .aq-table th,
   .aq-table td {
-    padding: 0.78rem 0.92rem;
+    padding: 13px 15px;
     border-right: 1px solid ${ theme.colors.gray6};
     border-bottom: 1px solid ${ theme.colors.gray6};
     vertical-align: top;
@@ -192,7 +194,7 @@ export const markdownRendererRootTableToggleStyles = (theme: Theme) => css`
 
   @media (max-width: 480px) {
     .aq-table-shell {
-      margin: calc(${TABLE_SHARED_MARGIN_Y} - 0.1rem) 0;
+      margin: 24px 0;
       width: 100%;
       max-width: 100%;
       min-width: 0;


### PR DESCRIPTION
## 관련 이슈

close #1076

## 작업 배경

- #1059/#1060에서 글 작성/수정 shell은 V4 톤으로 정렬됐지만 Markdown toolbar와 preview block(callout/table/mermaid/toggle/code)은 기존 rounded/card 스타일이 남아 있었다.
- QA 요청은 `/editor/new`, `/editor/[id]`의 실제 작성 UI를 V4 reference 위치와 톤에 맞추되, 기존 `value/onChange/upload/save/publish` 데이터 흐름을 유지하는 것이다.

## 작업 내용

- Markdown toolbar를 V4 reference 순서에 맞춰 `H1/H2/H3/B/I/>/List/Task/Code/Link/Code/Table/Mermaid/Callout/Toggle/Image`로 정렬했다.
- callout/table/code preview를 V4의 직각 border, 낮은 장식, 문서형 spacing으로 정렬했다.
- Mermaid V4 chrome은 editor preview 내부로만 scope해서 public detail Mermaid의 transparent preset 계약을 유지했다.
- toolbar snippet 삽입, image upload, temp draft/local draft 복원, publish modal 흐름은 기존 backend 연동 경로를 유지했다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`: exit 0
  - `yarn --cwd front playwright test e2e/editor-authoring-markdown-editor.spec.ts --workers=1`: 25 passed
  - `yarn --cwd front playwright test e2e/smoke-detail-mermaid.spec.ts --workers=1`: 7 passed
  - `yarn --cwd front build`: exit 0
  - `node front/scripts/check-bundle-size.mjs`: all tracked budgets OK
  - `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`: 8 passed
  - `git commit` pre-commit guard: `yarn build`, `node scripts/check-bundle-size.mjs`, `yarn test:e2e:smoke` 실행, 66 passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| editor toolbar + callout/table/mermaid | Chromium desktop | Playwright authenticated editor flow screenshot | `/private/tmp/aquilalog-v4-editor-blocks-desktop.png` | V4 toolbar 순서와 preview block chrome 확인 |
| editor mermaid/code/toggle 하단 | Chromium desktop | Preview pane scroll 후 screenshot | `/private/tmp/aquilalog-v4-editor-blocks-desktop-bottom.png` | mermaid/code/toggle 렌더 확인 |
| editor mobile preview | Chromium mobile viewport | Preview tab screenshot | `/private/tmp/aquilalog-v4-editor-blocks-mobile.png` | 모바일 toolbar wrapping과 preview 확인 |
| editor mobile mermaid/code | Chromium mobile viewport | Preview pane scroll 후 screenshot | `/private/tmp/aquilalog-v4-editor-blocks-mobile-bottom.png` | 모바일 table/mermaid/code 흐름 확인 |
| authoring backend 연동 계약 | Chromium | focused editor E2E | `e2e/editor-authoring-markdown-editor.spec.ts`: 25 passed | temp draft, local draft, image upload, publish modal 흐름 유지 |
| public detail Mermaid 회귀 | Chromium | public detail Mermaid E2E | `e2e/smoke-detail-mermaid.spec.ts`: 7 passed | public transparent preset 유지 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `front/src/components/markdown-editor/MarkdownEditor.tsx`의 toolbar 순서와 editor-scoped Mermaid chrome
  - `front/src/libs/markdown/components/MarkdownRendererRoot*Styles.ts`의 callout/table/code block V4 스타일

## 리스크

- Screenshot evidence는 로컬 Playwright 산출물이다. GitHub PR 본문에 바이너리 attachment를 올리는 CLI 경로가 없어 로컬 경로와 E2E command output을 함께 남겼다.
- `MarkdownEditor.tsx`는 기존 파일 길이 경고가 있으며, 이번 변경은 추가 abstraction 없이 같은 컴포넌트 안에서 editor-only style scope를 유지했다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
