### PR TITLE
[Fix] 어드민 도구 V4 컨트롤 radius 정렬

### DIFF
--- a/front/e2e/admin-tools-state.spec.ts
+++ b/front/e2e/admin-tools-state.spec.ts
@@ -39,6 +39,7 @@ test.describe("admin tools state contract", () => {
   test("운영 도구는 helper copy와 읽기 전용 pill 없이 요약 카드와 실행 버튼만 남긴다", () => {
     const source = readRouteSource("AdminToolsWorkspaceSections.tsx")
     const styleSource = readRouteSource("AdminToolsWorkspace.styles.tokens.ts")
+    const layoutStyleSource = readRouteSource("AdminToolsWorkspace.styles.layout.ts")
 
     expect(source).toContain("<h1>운영 도구</h1>")
     expect(styleSource).toContain("grid-template-columns: repeat(auto-fit, minmax(13.5rem, 1fr));")
@@ -49,6 +50,8 @@ test.describe("admin tools state contract", () => {
     expect(source).not.toContain("운영 변경 없이 현재 상태와 영향 범위를 먼저 다시 확인합니다.")
     expect(source).not.toContain("복구 전에 같이 읽어야 할 화면과 기록으로 바로 이동합니다.")
     expect(source).not.toContain('data-emphasis="primary"')
+    expect(styleSource).not.toContain("border-radius: 999px;")
+    expect(layoutStyleSource).not.toContain("border-radius: 999px;")
   })
 
   test("운영 도구는 최근 진단 결과 panel 렌더링을 Admin route component로 위임한다", () => {

--- a/front/src/routes/Admin/AdminToolsWorkspace.styles.layout.ts
+++ b/front/src/routes/Admin/AdminToolsWorkspace.styles.layout.ts
@@ -279,7 +279,7 @@ export const TextArea = styled.textarea`
 export const PrimaryButton = styled.button`
   min-height: 42px;
   padding: 0 0.95rem;
-  border-radius: 999px;
+  border-radius: 2px;
   border: 1px solid ${({ theme }) => theme.colors.accentControl};
   background: ${({ theme }) => theme.colors.accentControl};
   color: ${({ theme }) => theme.colors.accentControlText};
@@ -344,7 +344,7 @@ export const DangerButton = styled.button`
   width: fit-content;
   min-height: 42px;
   padding: 0 0.95rem;
-  border-radius: 999px;
+  border-radius: 2px;
   border: 1px solid ${({ theme }) => theme.colors.statusDangerBorder};
   background: transparent;
   color: ${({ theme }) => theme.colors.statusDangerText};
@@ -370,7 +370,7 @@ export const ResultFilterButton = styled.button`
   gap: 0.45rem;
   min-height: 36px;
   padding: 0 0.8rem;
-  border-radius: 999px;
+  border-radius: 2px;
   border: 1px solid ${({ theme }) => theme.colors.gray6};
   background: ${({ theme }) => theme.colors.gray1};
   color: ${({ theme }) => theme.colors.gray11};

--- a/front/src/routes/Admin/AdminToolsWorkspace.styles.tokens.ts
+++ b/front/src/routes/Admin/AdminToolsWorkspace.styles.tokens.ts
@@ -320,7 +320,7 @@ export const DiagnosticsTabs = styled.div`
 export const DiagnosticsTabButton = styled.button`
   min-height: 38px;
   padding: 0 0.82rem;
-  border-radius: 999px;
+  border-radius: 2px;
   border: 1px solid ${({ theme }) => theme.colors.gray6};
   background: ${({ theme }) => theme.colors.gray1};
   color: ${({ theme }) => theme.colors.gray10};


### PR DESCRIPTION
## 관련 이슈

close #1079

## 작업 배경

- `/admin/tools` 운영 도구 화면에 V4 ADMIN HUB 기준과 맞지 않는 pill/원형 `border-radius: 999px` 컨트롤이 남아 있었다.
- V4 admin surface의 각진 neutral 컨트롤과 맞추기 위해 운영 도구 버튼 radius를 기존 admin token 흐름의 `2px`로 정렬한다.

## 작업 내용

- `AdminToolsWorkspace.styles.layout.ts`의 primary/danger/result filter button radius를 `2px`로 정렬했다.
- `AdminToolsWorkspace.styles.tokens.ts`의 diagnostics tab button radius를 `2px`로 정렬했다.
- `admin-tools-state` source-level 계약에 운영 도구 style에서 `border-radius: 999px` 재도입을 막는 검증을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `CURRENT_TASK_SLUG=admin-tools-v4-radius bash tools/guards/current-task-preflight.sh`: exit 0
  - `yarn --cwd front playwright:preflight`: exit 0
  - `yarn --cwd front playwright test e2e/admin-tools-state.spec.ts --workers=1`: 7 passed
  - `git diff --check`: exit 0
  - `yarn --cwd front build`: exit 0
  - `node front/scripts/check-bundle-size.mjs`: exit 0, `/`, `/posts/[id]`, `/admin` all OK
  - `rg -n "dangerouslySetInnerHTML|eval\\(|new Function|innerHTML|outerHTML|document\\.cookie|localStorage|sessionStorage|javascript:" front/src/routes/Admin/AdminToolsWorkspace.styles.layout.ts front/src/routes/Admin/AdminToolsWorkspace.styles.tokens.ts front/e2e/admin-tools-state.spec.ts`: exit 1, no matches

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Admin tools radius | Desktop 1440x900 | Browser screenshot + DOM radius audit | Local evidence: `/private/tmp/admin-tools-v4-radius-after.png` | `메일 진단`, `파일 정리 진단`, `인증 보안 기록`, `테스트 메일 발송` 모두 `2px`; 20px 이상 large radius 0개 |
| Admin tools contract | Chromium | Playwright source-level regression | `e2e/admin-tools-state.spec.ts`: 7 passed | `border-radius: 999px` 재도입 차단 |
| Bundle budget | Local build artifact | bundle-size script | `front/test-results/bundle-size/bundle-size-report.md` | `/`, `/posts/[id]`, `/admin` budget OK |
| Diff security pattern | Local grep | dangerous browser/API pattern scan | `rg` exit 1 | 신규 위험 패턴 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `front/src/routes/Admin/AdminToolsWorkspace.styles.layout.ts`
  - `front/src/routes/Admin/AdminToolsWorkspace.styles.tokens.ts`
  - `front/e2e/admin-tools-state.spec.ts`

## 리스크

- 동작/API 변경 없이 CSS radius만 정렬했다.
- screenshot은 QA bypass 로컬 렌더 evidence다. 운영 관리자 데이터 노출을 피하기 위해 PR에는 로컬 경로만 기록했다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.