### PR TITLE
[CI] 홈서버 live e2e stale 프론트 SHA 처리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,6 +96,7 @@ jobs:
           FRONT_LIVE_VERIFY="false"
           EDITOR_LIVE_CANARY="false"
           EXPECTED_FRONT_COMMIT_SHA=""
+          FRONT_BUILD_SHA_SUPERSEDED="false"
           CHANGE_SOURCE="first-parent-diff"
           BACKEND_DEPLOY_PATHS_PATTERN='^(back/|deploy/homeserver/|deploy/env/|tools/env/|\.github/workflows/deploy\.yml|\.github/workflows/ci\.yml|\.github/workflows/reusable-backend-quality\.yml)'
           STALE_DEPLOY_BLOCK_PATHS_PATTERN='^(back/|deploy/homeserver/|deploy/env/|tools/env/|\.github/workflows/deploy\.yml|\.github/workflows/ci\.yml|\.github/workflows/reusable-backend-quality\.yml)'
@@ -126,6 +127,10 @@ jobs:
                 echo "${STALE_CHANGED_FILES}" >&2
                 exit 1
               fi
+              if echo "${STALE_CHANGED_FILES}" | grep -Eq "${FRONT_BUILD_SHA_PATHS_PATTERN}"; then
+                FRONT_BUILD_SHA_SUPERSEDED="true"
+                CHANGE_SOURCE="${CHANGE_SOURCE}+front-build-superseded"
+              fi
               echo "stale workflow_run allowed after backend-neutral newer main changes: deploy_sha=${DEPLOY_SHA} origin_main=${REMOTE_MAIN_SHA}"
               CHANGE_SOURCE="${CHANGE_SOURCE}+path-aware-stale-neutral"
             fi
@@ -148,7 +153,7 @@ jobs:
             if echo "${CHANGED_FILES}" | grep -Eq "${FRONT_LIVE_VERIFY_PATHS_PATTERN}"; then
               FRONT_LIVE_VERIFY="true"
             fi
-            if echo "${CHANGED_FILES}" | grep -Eq "${FRONT_BUILD_SHA_PATHS_PATTERN}"; then
+            if [ "${FRONT_BUILD_SHA_SUPERSEDED}" != "true" ] && echo "${CHANGED_FILES}" | grep -Eq "${FRONT_BUILD_SHA_PATHS_PATTERN}"; then
               # Vercel can keep the previous frontend build for workflow/backend-only commits.
               EXPECTED_FRONT_COMMIT_SHA="${DEPLOY_SHA}"
             fi
@@ -199,7 +204,7 @@ jobs:
               if [ -n "${EXPECTED_FRONT_COMMIT_SHA}" ]; then
                 echo "- frontend build sha: ${EXPECTED_FRONT_COMMIT_SHA}"
               else
-                echo "- frontend build sha: not asserted for non-frontend deploy"
+                echo "- frontend build sha: not asserted for non-frontend or superseded deploy"
               fi
               echo "- editor live canary: ${EDITOR_LIVE_CANARY}"
             else


### PR DESCRIPTION
## 관련 이슈

close #1085

## 작업 배경

- `Deploy to Home Server` run 28099888548에서 stale `workflow_run`이 이전 frontend build SHA를 계속 기대해 실패했습니다.
- 같은 head의 후속 deploy run 28100108642는 성공했으므로 운영 상태는 회복됐지만, stale-neutral run이 최신 live frontend를 실패로 기록하는 재발 경로가 남아 있었습니다.

## 작업 내용

- `calculateTag`에서 backend-neutral newer main을 허용하되, newer main에 frontend build 영향 파일이 있으면 이전 deploy SHA를 frontend expected SHA로 단언하지 않게 했습니다.
- 최신 main 대상 deploy에서는 기존처럼 frontend build SHA 검증을 유지합니다.

## 검증

- 실행한 명령과 결과:
  - `ruby -e "require \"yaml\"; YAML.load_file(".github/workflows/deploy.yml"); puts "yaml ok""`: `yaml ok`
  - `bash -n /private/tmp/calculateTag-meta.sh`: exit 0
  - stale 재현 스크립트 실행: `expected_front_commit_sha=` 빈 값, `front_live_verify=true`
  - 최신 main 스크립트 실행: `expected_front_commit_sha=3434ac94caa1c7fc0dbc704c99673c5c616f88c6`
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 실패 재현 | GitHub Actions | 실패 run 로그 확인 | https://github.com/AquilaXk/aquila-blog/actions/runs/28099888548 | stale deploy SHA `05e4ae...`가 live `3434ac94...`와 불일치해 실패 |
| 운영 회복 | GitHub Actions | 후속 deploy run 확인 | https://github.com/AquilaXk/aquila-blog/actions/runs/28100108642 | 같은 최신 head deploy 성공 |
| stale 계산 보정 | Local shell | `calculateTag` inline script를 실패 SHA 조합으로 실행 | `expected_front_commit_sha=` / `front_live_verify=true` | 통과 |
| 최신 main 계약 유지 | Local shell | `calculateTag` inline script를 최신 main SHA로 실행 | `expected_front_commit_sha=3434ac94caa1c7fc0dbc704c99673c5c616f88c6` | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `.github/workflows/deploy.yml`의 stale-neutral branch와 `EXPECTED_FRONT_COMMIT_SHA` 설정 조건입니다.

## 리스크

- stale run이 최신 live frontend를 smoke 검증하는 것은 유지됩니다. 이전 frontend SHA만 강제하지 않기 때문에, 실제 최신 main deploy 실패는 최신 main deploy run에서 계속 잡힙니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 프론트엔드 빌드 버전 검증이 더 정확해졌습니다.
  * 최신 메인 변경으로 인해 이전 배포가 대체된 경우, 불필요하게 빌드 버전을 단정하지 않도록 개선했습니다.
  * 배포 요약 메시지가 비프론트엔드 또는 대체된 배포 상황을 더 명확하게 반영합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->