### PR TITLE
[Fix] V4 코드블럭 제목 헤더 정렬

### DIFF
--- a/front/e2e/editor-authoring-markdown-editor.spec.ts
+++ b/front/e2e/editor-authoring-markdown-editor.spec.ts
@@ -1037,10 +1037,24 @@ test.describe("Markdown editor replacement", () => {
 
     await page.goto("/editor/new?source=local-draft")
 
-    const languageLabels = page
+    const codeTitles = page
       .getByTestId("markdown-editor-preview-pane")
-      .locator(".aq-code-language")
-    await expect(languageLabels).toHaveText(languageCases.map(([, , label]) => label))
-    expect(await languageLabels.allTextContents()).not.toContain("TXT")
+      .locator(".aq-code-title")
+    await expect(codeTitles).toHaveText(languageCases.map(([, , label]) => label))
+    expect(await codeTitles.allTextContents()).not.toContain("TXT")
+  })
+
+  test("code block title metadata renders in the V4 header next to copy", async ({ page }) => {
+    await routeAuthenticatedEditor(
+      page,
+      ["```kotlin title=\"UserService.kt\"", "fun login(): Token = token", "```"].join("\n")
+    )
+
+    await page.goto("/editor/new?source=local-draft")
+
+    const preview = page.getByTestId("markdown-editor-preview-pane")
+    const codeBlock = preview.locator(".aq-code-block").first()
+    await expect(codeBlock.locator(".aq-code-title")).toHaveText("UserService.kt")
+    await expect(codeBlock.locator(".aq-code-copy")).toHaveText("COPY")
   })
 })

--- a/front/e2e/smoke-detail-rendering.spec.ts
+++ b/front/e2e/smoke-detail-rendering.spec.ts
@@ -402,7 +402,7 @@ test.describe("core smoke detail rendering", () => {
 
   await page.goto("/posts/114")
 
-  const languageLabels = page.locator(".aq-code-language")
+  const languageLabels = page.locator(".aq-code-title")
   await expect(languageLabels).toHaveCount(languageCases.length)
   const labels = await languageLabels.allTextContents()
   expect(labels).toEqual(languageCases.map(([, , label]) => label))

--- a/front/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/front/src/components/markdown-editor/MarkdownEditor.tsx
@@ -58,7 +58,7 @@ const tableSnippet = [
   "",
 ].join("\n")
 
-const codeBlockSnippet = ["", "```", "", "```", ""].join("\n")
+const codeBlockSnippet = ["", "```text title=\"코드 제목\"", "", "```", ""].join("\n")
 const mermaidSnippet = ["", "```mermaid", "flowchart LR", "    A[Admin write] --> B[DB commit]", "```", ""].join("\n")
 const calloutSnippet = ["", "> [!TIP]", "> **설계 원칙**", "> 내용을 입력하세요.", ""].join("\n")
 const toggleSnippet = ["", ":::toggle 자세히 보기", "내용을 입력하세요.", ":::", ""].join("\n")

--- a/front/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/front/src/components/markdown-editor/MarkdownEditor.tsx
@@ -58,7 +58,7 @@ const tableSnippet = [
   "",
 ].join("\n")
 
-const codeBlockSnippet = ["", "```text title=\"코드 제목\"", "", "```", ""].join("\n")
+const codeBlockSnippet = ["", "```text", "", "```", ""].join("\n")
 const mermaidSnippet = ["", "```mermaid", "flowchart LR", "    A[Admin write] --> B[DB commit]", "```", ""].join("\n")
 const calloutSnippet = ["", "> [!TIP]", "> **설계 원칙**", "> 내용을 입력하세요.", ""].join("\n")
 const toggleSnippet = ["", ":::toggle 자세히 보기", "내용을 입력하세요.", ":::", ""].join("\n")

--- a/front/src/libs/markdown/MarkdownRenderer.tsx
+++ b/front/src/libs/markdown/MarkdownRenderer.tsx
@@ -171,7 +171,7 @@ const MarkdownRendererComponent: FC<MarkdownRendererProps> = ({
           )
         },
         pre({ node, children, className: _className, ...props }) {
-          const { language, rawCode } = extractCodeMetaFromPreChildren(children, node)
+          const { language, title, rawCode } = extractCodeMetaFromPreChildren(children, node)
           const mermaidSource = extractNormalizedMermaidSource(rawCode)
           const shouldRenderMermaid = language === "mermaid" || isMermaidSource(rawCode)
 
@@ -197,6 +197,7 @@ const MarkdownRendererComponent: FC<MarkdownRendererProps> = ({
           return (
             <PrettyCodeBlock
               language={initialCodePresentation.language}
+              title={title}
               rawCode={rawCode}
               preElement={
                 <pre {...props} className={mergedClassName}>

--- a/front/src/libs/markdown/components/MarkdownRendererRootCodeStyles.ts
+++ b/front/src/libs/markdown/components/MarkdownRendererRootCodeStyles.ts
@@ -28,105 +28,53 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
   }
 
   .aq-code-toolbar {
-    display: grid;
-    grid-template-columns: auto 1fr;
+    display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 0.75rem;
     min-height: 42px;
     padding: 0 14px;
     background: #0f1728;
     border-bottom: 1px solid #27334a;
-  }
-
-  .aq-code-toolbar-left {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.7rem;
-  }
-
-  .aq-code-dot {
-    display: none;
-  }
-
-  .aq-code-dot-red {
-    background: #ff5f56;
-  }
-
-  .aq-code-dot-yellow {
-    background: #ffbd2e;
-  }
-
-  .aq-code-dot-green {
-    background: #27c93f;
-  }
-
-  .aq-code-language {
-    justify-self: end;
-    font-size: 0.78rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
     color: #7895c9;
+    font: 600 11px / 1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Courier New", monospace;
+  }
+
+  .aq-code-title {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 700;
   }
 
   .aq-code-copy {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border: 1px solid
-      ${
-        theme.scheme === "dark" ? "rgba(255, 255, 255, 0.12)" : "rgba(17, 24, 39, 0.12)"};
-    background: ${
-      theme.scheme === "dark" ? "rgba(255, 255, 255, 0.04)" : "rgba(255, 255, 255, 0.72)"};
-    color: ${ (theme.scheme === "dark" ? "#d7dbe5" : "#334155")};
+    border: 0;
+    background: transparent;
+    color: #7895c9;
     border-radius: 0;
-    width: 2.25rem;
-    min-width: 2.25rem;
-    height: 2.05rem;
+    width: auto;
+    min-width: 0;
+    height: auto;
     padding: 0;
-    font-size: 0.8rem;
+    font: inherit;
     font-weight: 700;
+    letter-spacing: 0.02em;
     cursor: pointer;
-    transition: background-color 0.16s ease, border-color 0.16s ease, color 0.16s ease;
+    text-transform: uppercase;
+    transition: color 0.16s ease;
   }
 
   .aq-code-copy:hover {
-    background: ${
-      theme.scheme === "dark" ? "rgba(255, 255, 255, 0.08)" : "rgba(255, 255, 255, 0.9)"};
-    border-color: ${
-      theme.scheme === "dark" ? "rgba(255, 255, 255, 0.18)" : "rgba(17, 24, 39, 0.18)"};
+    color: #a9c5ff;
   }
 
-  .aq-code-copy svg {
-    width: 1rem;
-    height: 1rem;
-  }
-
-  .aq-code-copy-done {
-    line-height: 1;
-    letter-spacing: 0.02em;
-    text-transform: uppercase;
-    font-size: 0.72rem;
-    padding-top: 0.04rem;
-  }
-
-  .aq-code-copy-bottom {
-    position: absolute;
-    right: 0.74rem;
-    bottom: 0.74rem;
-    z-index: 1;
-    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
-  }
-
-  .aq-code-copy-bottom.is-copied {
+  .aq-code-copy.is-copied {
     color: ${ (theme.scheme === "dark" ? "#98c379" : "#15803d")};
-    border-color: ${
-      theme.scheme === "dark" ? "rgba(152, 195, 121, 0.35)" : "rgba(21, 128, 61, 0.22)"};
-    background: ${
-      theme.scheme === "dark" ? "rgba(152, 195, 121, 0.12)" : "rgba(220, 252, 231, 0.95)"};
-    width: auto;
-    min-width: 3.3rem;
-    padding: 0 0.58rem;
   }
 
   .aq-code-body {
@@ -151,7 +99,7 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
     border: 0;
     border-radius: 0;
     box-shadow: none;
-    padding: 1.05rem var(--aq-code-shell-padding-x) 3.55rem;
+    padding: 1.05rem var(--aq-code-shell-padding-x);
     min-width: 100%;
     background: #0f1728;
     color: #dbe7ff;
@@ -381,34 +329,8 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
       --aq-code-gutter-gap: 0.46rem;
     }
 
-    .aq-code-toolbar {
-      grid-template-columns: auto 1fr;
-    }
-
-    .aq-code-block .aq-code {
-      padding-bottom: 3.2rem;
-    }
-
-    .aq-code-copy-bottom {
-      right: 0.48rem;
-      bottom: 0.48rem;
-    }
-
     .aq-code-copy {
-      width: 2.12rem;
-      min-width: 2.12rem;
-      height: 1.94rem;
       font-size: 0.74rem;
-    }
-
-    .aq-code-copy svg {
-      width: 0.95rem;
-      height: 0.95rem;
-    }
-
-    .aq-code-copy-bottom.is-copied {
-      min-width: 3rem;
-      padding: 0 0.52rem;
     }
 
     .aq-mermaid {

--- a/front/src/libs/markdown/components/MarkdownRendererRootCodeStyles.ts
+++ b/front/src/libs/markdown/components/MarkdownRendererRootCodeStyles.ts
@@ -58,9 +58,10 @@ export const markdownRendererRootCodeStyles = (theme: Theme) => css`
     color: #7895c9;
     border-radius: 0;
     width: auto;
-    min-width: 0;
-    height: auto;
-    padding: 0;
+    min-width: 44px;
+    min-height: 32px;
+    padding: 0 8px;
+    margin-right: -8px;
     font: inherit;
     font-weight: 700;
     letter-spacing: 0.02em;

--- a/front/src/libs/markdown/components/PrettyCodeBlock.tsx
+++ b/front/src/libs/markdown/components/PrettyCodeBlock.tsx
@@ -1,15 +1,16 @@
 import { FC, ReactNode, useEffect, useState } from "react"
-import AppIcon from "src/components/icons/AppIcon"
 import { toLanguageLabel } from "src/libs/markdown/rendering"
 
 type PrettyCodeBlockProps = {
   language: string
+  title?: string
   rawCode: string
   preElement: ReactNode
 }
 
-const PrettyCodeBlock: FC<PrettyCodeBlockProps> = ({ language, rawCode, preElement }) => {
+const PrettyCodeBlock: FC<PrettyCodeBlockProps> = ({ language, title, rawCode, preElement }) => {
   const [copied, setCopied] = useState(false)
+  const label = title?.trim() || toLanguageLabel(language)
 
   useEffect(() => {
     if (!copied) return
@@ -29,24 +30,19 @@ const PrettyCodeBlock: FC<PrettyCodeBlockProps> = ({ language, rawCode, preEleme
   return (
     <div className="aq-code-block">
       <div className="aq-code-toolbar">
-        <div className="aq-code-toolbar-left" aria-hidden="true">
-          <span className="aq-code-dot aq-code-dot-red" />
-          <span className="aq-code-dot aq-code-dot-yellow" />
-          <span className="aq-code-dot aq-code-dot-green" />
-        </div>
-        <span className="aq-code-language">{toLanguageLabel(language)}</span>
-      </div>
-      <div className="aq-code-body">
-        <div className="aq-code-shell">{preElement}</div>
+        <span className="aq-code-title">{label}</span>
         <button
           type="button"
-          className={`aq-code-copy aq-code-copy-bottom${copied ? " is-copied" : ""}`}
+          className={`aq-code-copy${copied ? " is-copied" : ""}`}
           onClick={handleCopy}
           aria-label={copied ? "코드가 복사되었습니다" : "코드 복사"}
           title={copied ? "복사됨" : "복사"}
         >
-          {copied ? <span className="aq-code-copy-done">Copy</span> : <AppIcon name="copy" />}
+          {copied ? "COPIED" : "COPY"}
         </button>
+      </div>
+      <div className="aq-code-body">
+        <div className="aq-code-shell">{preElement}</div>
       </div>
     </div>
   )

--- a/front/src/libs/markdown/renderingCodeModel.ts
+++ b/front/src/libs/markdown/renderingCodeModel.ts
@@ -71,6 +71,24 @@ const readLanguageAttribute = (...values: unknown[]): string => {
   return ""
 }
 
+const readCodeMeta = (node: unknown): string => {
+  if (!node || typeof node !== "object") return ""
+  const data = (node as { data?: unknown }).data
+  const dataMeta = data && typeof data === "object" ? (data as { meta?: unknown }).meta : ""
+  const meta = (node as { meta?: unknown }).meta || dataMeta
+  return typeof meta === "string" ? meta.trim() : ""
+}
+
+const unquoteMetaValue = (value: string) => value.trim().replace(/^["']|["']$/g, "")
+
+const extractCodeTitle = (meta: string) => {
+  const titleMatch = meta.match(/(?:^|\s)title=(?:"([^"]+)"|'([^']+)'|([^\s]+))/i)
+  if (titleMatch) return unquoteMetaValue(titleMatch[1] || titleMatch[2] || titleMatch[3] || "")
+  const filenameMatch = meta.match(/(?:^|\s)filename=(?:"([^"]+)"|'([^']+)'|([^\s]+))/i)
+  if (filenameMatch) return unquoteMetaValue(filenameMatch[1] || filenameMatch[2] || filenameMatch[3] || "")
+  return ""
+}
+
 export const extractTextFromCodeAst = (node: unknown): string => {
   if (!node || typeof node !== "object") return ""
 
@@ -116,9 +134,11 @@ export const extractCodeMetaFromPreChildren = (children: ReactNode, preNode?: un
   const rawCodeFromChildren = extractTextFromNode(codeChildren)
   const rawCodeFromAst = extractTextFromCodeAst(codeAstNode)
   const rawCode = (dataRawCode || rawCodeFromChildren || rawCodeFromAst).replace(/\n$/, "")
+  const meta = readCodeMeta(codeAstNode)
 
   return {
     language: dataLanguage || classLanguage || "text",
+    title: extractCodeTitle(meta),
     rawCode,
   }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- close #1087

## 📝 Summary
- V4 코드블럭의 상단 헤더 계약에 맞춰 제목/언어 라벨을 좌측, COPY 액션을 우측에 같은 줄로 렌더합니다.
- fenced code meta의 `title=` 또는 `filename=` 값을 표시하고, 없으면 기존 언어 alias 라벨을 유지합니다.
- Markdown 원문 저장/백엔드 연동 흐름은 그대로 유지하고 렌더 표시만 보정했습니다.

## 🛠 Changes
- 코드블럭 fence meta에서 `title`/`filename` 값을 추출해 renderer로 전달합니다.
- `PrettyCodeBlock` 헤더를 V4 `code-head` 구조에 맞춰 좌측 제목 + 우측 COPY 텍스트 버튼으로 변경했습니다.
- Markdown editor의 코드블럭 삽입 snippet에 `title="코드 제목"` 예시를 넣었습니다.
- editor preview/detail E2E를 새 헤더 클래스와 제목 메타데이터 검증으로 갱신했습니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [x] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [ ] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `yarn --cwd front playwright:preflight`: exit 0
- `yarn --cwd front playwright test e2e/editor-authoring-markdown-editor.spec.ts --workers=1`: 26 passed
- `yarn --cwd front playwright test e2e/smoke-detail-rendering.spec.ts --workers=1`: 9 passed
- `yarn --cwd front playwright test e2e/editor-authoring-markdown-editor.spec.ts e2e/smoke-detail-rendering.spec.ts --workers=1`: 35 passed
- `yarn --cwd front build`: exit 0
- `node front/scripts/check-bundle-size.mjs`: all tracked budgets OK
- pre-commit hook: `yarn build`, `node scripts/check-bundle-size.mjs`, `yarn test:e2e:smoke` 66 passed

## 📸 Screenshot / API Example
- UI evidence: mocked editor preview에서 `.aq-code-title=UserService.kt`, `.aq-code-copy=COPY` 확인. 로컬 캡처 경로: `/tmp/aquilalog-v4-codeblock-title.png`.
- PR 본문 직접 첨부는 GitHub CLI 파일 업로드 경로가 없어 생략했습니다. 테스트와 로컬 캡처로 동일 상태를 검증했습니다.

## ⚠️ Risk & Rollback
- 예상 리스크: 기존 문서에서 `.aq-code-language`를 직접 참조하는 외부 CSS/테스트가 있으면 클래스명 변경 영향을 받을 수 있습니다. 저장 markdown/API 계약은 변경하지 않았습니다.
- 롤백 방법: 이 PR의 커밋을 revert하면 기존 언어 라벨/하단 COPY 버튼 구조로 돌아갑니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 코드 주석 정책에 맞는 이유/불변조건/운영 영향을 설명하는가?

SEO/권한/캐시/배포 영향: 없음.
API 계약/운영 문서 변경: 없음.
새 코드 주석: 없음.