### PR TITLE
[Fix] 어드민 글 관리 V4 컨트롤 반경 정렬

### DIFF
--- a/front/e2e/admin-surface-primitives.spec.ts
+++ b/front/e2e/admin-surface-primitives.spec.ts
@@ -20,9 +20,9 @@ const getContrastRatio = (foreground: string, background: string) => {
 }
 
 const getStyledComponentBlock = (source: string, componentName: string) => {
-  const marker = `export const ${componentName} =`
+  const marker = `const ${componentName} =`
   const start = source.indexOf(marker)
-  expect(start, `${componentName} export`).toBeGreaterThanOrEqual(0)
+  expect(start, `${componentName} const`).toBeGreaterThanOrEqual(0)
 
   const templateStart = source.indexOf("`", start)
   expect(templateStart, `${componentName} template start`).toBeGreaterThanOrEqual(0)
@@ -207,6 +207,14 @@ test.describe("관리자 표면 공통 계약", () => {
       path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspaceList.styles.ts"),
       "utf8",
     )
+    const postsFilterSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspaceFilterToolbar.tsx"),
+      "utf8",
+    )
+    const postsSectionSource = readFileSync(
+      path.resolve(__dirname, "../src/routes/Admin/AdminPostsWorkspacePageSections.tsx"),
+      "utf8",
+    )
     const toolsPageSource = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminToolsWorkspacePage.tsx"), "utf8")
     const toolsExecutionSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/AdminToolsExecutionSection.tsx"),
@@ -225,6 +233,11 @@ test.describe("관리자 표면 공통 계약", () => {
     expect(postsListStyleSource).toContain("export const RowPrimaryButton = styled(AdminTextActionButton)`")
     expect(postsListStyleSource).toContain("export const RowActions = styled(AdminInlineActionRow)``")
     expect(postsListSource).toContain("VisibilityBadge,")
+    expectStyledComponentRadius(postsFilterSource, "SummaryPill", "2px")
+    expectStyledComponentRadius(postsFilterSource, "SearchField", "2px")
+    expect(postsSectionSource).toContain(
+      ".stateLabel {\n    display: inline-flex;\n    align-items: center;\n    min-height: 24px;\n    padding: 0 0.56rem;\n    border-radius: 2px;",
+    )
 
     expect(toolsTokenStyleSource).toContain("export const StatusBadge = styled(AdminStatusPill)`")
     expect(toolsTokenStyleSource).toContain("export const FreshnessBadge = styled(AdminStatusPill)`")
@@ -437,6 +450,9 @@ test.describe("관리자 표면 공통 계약", () => {
     expect(source).not.toContain("운영 도구 바로가기")
     expect(source).not.toContain("ProfileImage")
     expect(source).not.toContain('<AppIcon name="camera" />')
+    expectStyledComponentRadius(source, "SearchField", "2px")
+    expectStyledComponentRadius(source, "SearchInput", "2px")
+    expectStyledComponentRadius(source, "CurrentViewChip", "2px")
   })
 
   test("관리자 사이드바는 V4 reference rail 순서와 하단 프로필을 유지한다", () => {

--- a/front/src/routes/Admin/AdminPostsWorkspaceFilterToolbar.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspaceFilterToolbar.tsx
@@ -165,7 +165,7 @@ export const AdminPostsWorkspaceFilterToolbar: React.FC<AdminPostsWorkspaceFilte
 
 const baseButton = ({ theme }: { theme: any }) => `
   min-height: 48px;
-  border-radius: 12px;
+  border-radius: 2px;
   border: 1px solid ${theme.colors.gray5};
   font-size: 0.95rem;
   font-weight: 800;
@@ -249,7 +249,7 @@ const ScopeTabButton = styled.button<{ "data-active"?: boolean }>`
   @media (max-width: 767px) {
     min-height: 38px;
     padding: 0 0.46rem;
-    border-radius: 10px;
+    border-radius: 2px;
     font-size: 0.78rem;
   }
 `
@@ -270,7 +270,7 @@ const SearchField = styled.div`
     width: 100%;
     min-width: 0;
     min-height: 46px;
-    border-radius: 12px;
+    border-radius: 2px;
     border: 1px solid ${({ theme }) => theme.colors.gray5};
     background: ${({ theme }) => theme.colors.gray1};
     color: ${({ theme }) => theme.colors.gray12};
@@ -294,7 +294,7 @@ const SearchField = styled.div`
 
     input {
       min-height: 38px;
-      border-radius: 10px;
+      border-radius: 2px;
       padding: 0 0.7rem;
       font-size: 0.86rem;
     }
@@ -362,7 +362,7 @@ const FieldBox = styled.div`
     width: 100%;
     min-width: 0;
     min-height: 44px;
-    border-radius: 12px;
+    border-radius: 2px;
     border: 1px solid ${({ theme }) => theme.colors.gray5};
     background: ${({ theme }) => theme.colors.gray1};
     color: ${({ theme }) => theme.colors.gray12};
@@ -434,7 +434,7 @@ const SummaryPill = styled.span<{ "data-tone"?: "neutral" }>`
   min-width: 0;
   min-height: 32px;
   padding: 0 0.72rem;
-  border-radius: 999px;
+  border-radius: 2px;
   border: 1px solid ${({ theme }) => theme.colors.gray6};
   background: ${({ theme, "data-tone": tone }) => (tone === "neutral" ? theme.colors.gray1 : theme.colors.gray3)};
   color: ${({ theme }) => theme.colors.gray11};

--- a/front/src/routes/Admin/AdminPostsWorkspacePageSections.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspacePageSections.tsx
@@ -174,7 +174,7 @@ export const RecentActionList = styled.ul`
     align-items: center;
     min-height: 24px;
     padding: 0 0.56rem;
-    border-radius: 999px;
+    border-radius: 2px;
     border: 1px solid ${({ theme }) => theme.colors.gray6};
     background: ${({ theme }) => theme.colors.gray2};
     color: ${({ theme }) => theme.colors.gray11};

--- a/front/src/routes/Admin/AdminUtilityBar.tsx
+++ b/front/src/routes/Admin/AdminUtilityBar.tsx
@@ -262,7 +262,7 @@ const SearchField = styled.div`
   }
 
   @media (max-width: 720px) {
-    border-radius: 999px;
+    border-radius: 2px;
     box-shadow: ${({ theme }) =>
       theme.scheme === "light"
         ? "0 14px 28px rgba(15, 23, 42, 0.12)"
@@ -276,7 +276,7 @@ const SearchInput = styled.input`
   height: 2.58rem;
   padding: 0 0.92rem 0 2.55rem;
   border: 1px solid ${adminBorder};
-  border-radius: 999px;
+  border-radius: 2px;
   background: ${adminSurface};
   color: ${adminTextPrimary};
   font-size: 0.88rem;
@@ -339,7 +339,7 @@ const CurrentViewChip = styled.div`
   gap: 0.48rem;
   min-width: 0;
   padding: 0 0.1rem;
-  border-radius: 999px;
+  border-radius: 2px;
   border: none;
   background: transparent;
   color: ${adminTextMuted};


### PR DESCRIPTION
## 🔗 Related Issue
- close #1090

## 📝 Summary
- `/admin/posts` 필터/상태/상단 utility 조작 컨트롤에 남은 pill형 반경을 V4 기준 2px 컨트롤로 정렬했습니다.
- 기존 posts/admin/session/profile 데이터 흐름은 변경하지 않고, 스타일과 source-level 회귀 계약만 보강했습니다.

## 🛠 Changes
- 글 관리 범위 탭, 검색 input, 고급 검색 input/select, summary pill, 최근 작업 상태 label을 2px radius로 맞췄습니다.
- 공통 `AdminUtilityBar`의 검색 field/input/current view chip radius를 2px로 맞췄습니다.
- `admin-surface-primitives`가 export 여부와 무관하게 styled-component block 안의 radius를 검사하도록 보강했습니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Editor / Content Rendering
- [x] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [x] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `CURRENT_TASK_SLUG=admin-posts-v4-controls bash tools/guards/current-task-preflight.sh`: pass
- `yarn --cwd front playwright:preflight`: pass
- `yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts --workers=1`: first run failed with `spawn playwright ENOENT` because the new worktree had no `front/node_modules`; linked the existing dependency directory, then 14 passed
- `yarn --cwd front playwright test e2e/admin-layout-regression.spec.ts --grep "글 관리" --workers=1`: 2 passed
- `yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts --workers=1`: 14 passed, same test second successful run
- `yarn --cwd front playwright test e2e/admin-layout-regression.spec.ts --grep "글 관리" --workers=1`: 2 passed, same test second successful run
- `yarn --cwd front build`: pass
- `node front/scripts/check-bundle-size.mjs`: pass, `/admin` brotli 118.3KB <= 127.1KB budget
- Browser `/admin/posts` 1440x900 check: page rendered, no framework overlay, target controls computed `border-radius: 2px`; only existing Next `legacyBehavior` deprecation appeared in console
- `git diff --check`: pass

## 📸 Screenshot / API Example

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| `/admin/posts` V4 controls | Browser iab, 1440x900 | local dev `/admin/posts` 렌더 후 button/input/pill computed style 확인 | local evidence: `/private/tmp/admin-posts-v4-controls-1440.png` | 주요 글 관리 버튼/input/summary pill radius 2px 확인 |
| Source contract | Playwright Chromium | `admin-surface-primitives.spec.ts` | command output above | 대상 styled-component block radius 2px 고정 |

Screenshot upload note: GitHub CLI path in this environment does not expose direct binary attachment upload for PR body. Local screenshot evidence is kept under `/private/tmp/admin-posts-v4-controls-1440.png`; rendered behavior is also covered by the Browser computed-style check and Playwright source contract.

## ⚠️ Risk & Rollback
- 예상 리스크: radius-only 변경이라 기능/API 리스크는 낮지만, 글 관리 필터 컨트롤의 모바일 인상이 더 각져 보일 수 있습니다.
- 롤백 방법: 이 PR의 commit을 revert하면 기존 radius로 돌아갑니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 코드 주석 정책에 맞는 이유/불변조건/운영 영향을 설명하는가?
