### PR TITLE
[CI] Playwright 설치 apt source 403 복구

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1634,6 +1634,17 @@ jobs:
         working-directory: front
         run: yarn install --frozen-lockfile
 
+      - name: Disable Microsoft apt sources for Playwright deps
+        shell: bash
+        run: |
+          set -euo pipefail
+          for source in /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+            [ -e "${source}" ] || continue
+            if grep -q 'packages.microsoft.com' "${source}"; then
+              sudo mv "${source}" "${source}.disabled"
+            fi
+          done
+
       - name: Install Playwright browser
         working-directory: front
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/reusable-frontend-verify.yml
+++ b/.github/workflows/reusable-frontend-verify.yml
@@ -205,6 +205,18 @@ jobs:
           if-no-files-found: warn
           retention-days: 3
 
+      - name: Disable Microsoft apt sources for Playwright deps
+        if: steps.changes.outputs.frontend == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          for source in /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+            [ -e "${source}" ] || continue
+            if grep -q 'packages.microsoft.com' "${source}"; then
+              sudo mv "${source}" "${source}.disabled"
+            fi
+          done
+
       - name: Install Playwright browser
         if: steps.changes.outputs.frontend == 'true'
         working-directory: front


### PR DESCRIPTION
## 관련 이슈

close #1095

## 작업 배경

- main CI run 28105673779에서 `frontend-ci / Install Playwright browser`가 실패했습니다.
- 실패 원인은 `npx playwright install --with-deps chromium` 실행 중 GitHub hosted Ubuntu 24.04 runner의 Microsoft apt source가 403을 반환한 것입니다.
- runtime guard metrics missing 실패는 브라우저 설치 실패로 perf e2e가 실행되지 않아 생긴 후속 증상입니다.

## 작업 내용

- frontend reusable verify workflow에서 Playwright browser 설치 직전에 `packages.microsoft.com` apt source를 job 안에서 비활성화했습니다.
- deploy live e2e workflow의 동일 Playwright 설치 단계에도 같은 guard를 추가했습니다.
- 앱 코드, 어드민 UI, 백엔드 동작은 변경하지 않았습니다.

## 검증

- 실행한 명령과 결과:
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reusable-frontend-verify.yml"); YAML.load_file(".github/workflows/deploy.yml"); puts "yaml ok"'`: `yaml ok`\n  - `bash -c <inserted apt-source guard block without sudo mv>`: exit 0\n  - `git diff --check`: exit 0\n  - `git commit -m 'fix(ci): Playwright apt source 403 복구'`: pre-commit `yarn contracts:check` 통과 후 commit 생성\n\n## 검증 증거\n\n| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |\n| --- | --- | --- | --- | --- |\n| 기존 실패 | GitHub Actions ubuntu-24.04 | main CI 실패 run 로그 확인 | https://github.com/AquilaXk/aquila-blog/actions/runs/28105673779 | Microsoft apt source 403으로 Playwright install exit 100 |\n| workflow YAML | local darwin | Ruby YAML parser | command output `yaml ok` | 통과 |\n| shell guard | local darwin | 삽입 shell block dry run | command exit 0 | 통과 |\n| whitespace | local git | `git diff --check` | command exit 0 | 통과 |\n| PR CI | GitHub Actions | 이 PR의 `frontend-ci` 확인 | PR checks | 대기 중 |\n\n## 리뷰어 메모\n\n- 리뷰어가 먼저 봐야 할 지점: Playwright 설치 전 source guard가 `/etc/apt/sources.list.d` 안의 `packages.microsoft.com` source만 비활성화하는지 확인하면 됩니다.\n\n## 리스크\n\n- GitHub runner job 안에서만 apt source 파일을 옮기므로 앱 런타임 영향은 없습니다.\n- Microsoft apt source가 필요한 다른 step이 Playwright 설치 이후에 생기면 해당 step 전에 별도 복구가 필요합니다. 현재 workflow에는 해당 의존성이 없습니다.\n\n## 체크리스트\n\n- [ ] CI 결과를 확인했다.\n- [ ] CodeRabbit 리뷰를 확인했다.\n- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.\n- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.\n