### PR TITLE
[Style] 운영 대시보드 V4 디자인 정렬

### DIFF
--- a/front/e2e/admin-layout-regression.spec.ts
+++ b/front/e2e/admin-layout-regression.spec.ts
@@ -197,43 +197,45 @@ test("관리자 프로필 1440px 데스크톱은 간결한 heading 아래 편집
 const captureDashboardPrioritySnapshot = async (page: Page) =>
   page.evaluate(() => {
     const priorityHeading = Array.from(document.querySelectorAll<HTMLElement>("h2")).find(
-      (element) => element.textContent?.trim() === "우선 점검 항목",
+      (element) => element.textContent?.trim() === "Steady-state guard",
     )
     const prioritySection = priorityHeading?.closest<HTMLElement>("section")
-    const priorityTable = prioritySection?.querySelector<HTMLElement>("table")
+    const priorityRows = prioritySection?.querySelector<HTMLElement>("[data-ui='dashboard-guard-rows']")
     const headingRect = priorityHeading?.getBoundingClientRect()
     const sectionRect = prioritySection?.getBoundingClientRect()
-    const tableRect = priorityTable?.getBoundingClientRect()
+    const rowsRect = priorityRows?.getBoundingClientRect()
 
     return {
       viewportHeight: window.innerHeight,
       viewportWidth: window.innerWidth,
       headingTop: headingRect?.top ?? Number.POSITIVE_INFINITY,
       sectionTop: sectionRect?.top ?? Number.POSITIVE_INFINITY,
-      tableTop: tableRect?.top ?? Number.POSITIVE_INFINITY,
+      rowsTop: rowsRect?.top ?? Number.POSITIVE_INFINITY,
       bodyScrollWidth: document.body.scrollWidth,
     }
   })
 
-test("관리자 대시보드 1440px 데스크톱은 우선 점검 테이블을 first fold 안에 노출한다", async ({ page }) => {
+test("관리자 대시보드 1440px 데스크톱은 V4 steady-state guard를 first fold 안에 노출한다", async ({ page }) => {
   await mockAdminDashboardEndpoints(page)
   await page.setViewportSize({ width: 1440, height: 900 })
   await page.goto("/admin/dashboard")
 
-  await expect(page.getByRole("heading", { name: "우선 점검 항목" })).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Steady-state guard" })).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Public read latency" })).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Live logs" })).toBeVisible()
 
   const snapshot = await captureDashboardPrioritySnapshot(page)
 
-  expect(snapshot.tableTop).toBeLessThanOrEqual(860)
+  expect(snapshot.rowsTop).toBeLessThanOrEqual(860)
   expect(snapshot.bodyScrollWidth).toBeLessThanOrEqual(snapshot.viewportWidth)
 })
 
-test("관리자 대시보드 모바일은 우선 점검 heading을 first fold 안에 노출한다", async ({ page }) => {
+test("관리자 대시보드 모바일은 V4 steady-state guard heading을 first fold 안에 노출한다", async ({ page }) => {
   await mockAdminDashboardEndpoints(page)
   await page.setViewportSize({ width: 393, height: 852 })
   await page.goto("/admin/dashboard")
 
-  await expect(page.getByRole("heading", { name: "우선 점검 항목" })).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Steady-state guard" })).toBeVisible()
 
   const snapshot = await captureDashboardPrioritySnapshot(page)
 
@@ -262,7 +264,7 @@ test("관리자 대시보드는 알림 snapshot 백그라운드 갱신을 유지
   })
 
   await page.goto("/admin/dashboard")
-  await expect(page.getByRole("heading", { name: "우선 점검 항목" })).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Steady-state guard" })).toBeVisible()
 
   await expect.poll(() => snapshotRequestCount).toBeGreaterThan(0)
 })

--- a/front/e2e/admin-layout-regression.spec.ts
+++ b/front/e2e/admin-layout-regression.spec.ts
@@ -223,6 +223,7 @@ test("관리자 대시보드 1440px 데스크톱은 V4 steady-state guard를 fir
   await expect(page.getByRole("heading", { name: "Steady-state guard" })).toBeVisible()
   await expect(page.getByRole("heading", { name: "Public read latency" })).toBeVisible()
   await expect(page.getByRole("heading", { name: "Live logs" })).toBeVisible()
+  await expect(page.getByRole("link", { name: "도구 열기" })).toHaveAttribute("href", "/admin/tools")
 
   const snapshot = await captureDashboardPrioritySnapshot(page)
 

--- a/front/e2e/admin-surface-primitives.spec.ts
+++ b/front/e2e/admin-surface-primitives.spec.ts
@@ -168,7 +168,7 @@ test.describe("관리자 표면 공통 계약", () => {
     expect(source).toContain("export const AdminWorkspaceHero = styled.section`")
   })
 
-  test("대시보드 컨텍스트 레일은 태블릿 폭에서 우선 영역을 먼저 노출한다", () => {
+  test("대시보드는 V4 운영 화면의 metric, guard, log 구조를 먼저 노출한다", () => {
     const workspaceSource = readFileSync(
       path.resolve(__dirname, "../src/routes/Admin/AdminDashboardWorkspacePage.tsx"),
       "utf8",
@@ -187,23 +187,21 @@ test.describe("관리자 표면 공통 계약", () => {
     )
 
     expect(workspaceSource).toContain('"/system/api/v1/adm/dashboard-snapshot"')
-    expect(workspaceSource).toContain("const grafanaPanelsCanEmbed = env.monitoringEmbedIsPublicGrafana && Boolean(grafanaDashboardUrl)")
-    expect(workspaceSource).toContain("private Grafana 대시보드라 iframe 대신 링크로만 제공합니다.")
-    expect(viewSource).toContain("<strong>최근 실패</strong>")
-    expect(viewSource).toContain("<strong>런북</strong>")
-    expect(viewSource).toContain("<strong>즉시 이동</strong>")
-    expect(viewSource).toContain("<ContextGrid>")
-    expect(viewSource).toContain("<AdditionalPanelsSection>")
-    expect(layoutStyleSource).toContain("grid-template-columns: repeat(2, minmax(0, 1fr));")
-    expect(layoutStyleSource).toContain("@media (max-width: 1180px) {\n    grid-template-columns: 1fr;")
-    expect(priorityStyleSource).toContain("export const ContextLinkGrid = styled(AdminInfoList)`")
-    expect(layoutStyleSource).toContain("export const CompactPanelCard = styled(PanelCard)`")
-    expect(layoutStyleSource).toContain("export const CompactPanelSummary = styled.div`")
-    expect(layoutStyleSource).toContain("export const SnapshotLeadBody = styled(PanelBody)`")
-    expect(layoutStyleSource).toContain("export const LeadMetaGrid = styled.div`")
-    expect(priorityStyleSource).toContain("export const InsightLink = styled(AdminTextActionLink)`")
+    expect(workspaceSource).toContain("const chartBars: DashboardChartBar[]")
+    expect(workspaceSource).toContain("const logRows: DashboardLogRow[]")
+    expect(viewSource).toContain("<h2>Public read latency</h2>")
+    expect(viewSource).toContain("<h2>Steady-state guard</h2>")
+    expect(viewSource).toContain("<h2>Live logs</h2>")
+    expect(viewSource).toContain('<StatusRows data-ui="dashboard-guard-rows">')
+    expect(viewSource).not.toContain("<ContextGrid>")
+    expect(viewSource).not.toContain("<AdditionalPanelsSection>")
+    expect(viewSource).not.toContain("<PriorityTable>")
+    expect(layoutStyleSource).toContain("export const OpsGrid = styled.section`")
+    expect(layoutStyleSource).toContain("grid-template-columns: minmax(0, 1fr) 20rem;")
+    expect(layoutStyleSource).toContain("export const ChartBars = styled.div`")
+    expect(layoutStyleSource).toContain("export const LogLines = styled.div`")
+    expect(priorityStyleSource).toContain("export const PrioritySection = styled(AdminPlainCard)`")
     expect(priorityStyleSource).toContain("export const PrioritySummary = styled.div`")
-    expect(priorityStyleSource).toContain("export const PriorityLink = styled(AdminTextActionLink)`")
     expect(`${layoutStyleSource}\n${priorityStyleSource}`).not.toContain("${AdminInfoPanelCard}")
     expect(`${layoutStyleSource}\n${priorityStyleSource}`).not.toContain("${AdminInfoLinkCard}")
   })
@@ -293,7 +291,7 @@ test.describe("관리자 표면 공통 계약", () => {
 
     expect(profileSectionSource).toContain('from "src/routes/Admin/AdminProfileWorkspace.styles"')
     expect(toolsSource).toContain('from "src/routes/Admin/AdminToolsWorkspace.styles"')
-    expect(dashboardSource).toContain('from "src/routes/Admin/AdminDashboardWorkspace.styles"')
+    expect(dashboardSource).toContain('export { default } from "src/routes/Admin/AdminDashboardWorkspacePage"')
 
     expect(profileSource).not.toContain("const PreviewRail = styled(")
     expect(profileSource).not.toContain("const ModalOverlay = styled.div`")
@@ -318,8 +316,10 @@ test.describe("관리자 표면 공통 계약", () => {
     expectStyledComponentRadius(profileLinkStyles, "DragHandleButton", "2px")
     expect(toolsLayoutStyles).toContain("export const ExecutionLayout = styled.div`")
     expect(toolsLayoutStyles).toContain("export const ResultPanel = styled.pre`")
-    expect(dashboardLayoutStyles).toContain("export const PanelGrid = styled.section`")
-    expect(dashboardPriorityStyles).toContain("export const PriorityTable = styled.table`")
+    expect(dashboardLayoutStyles).toContain("export const OpsGrid = styled.section`")
+    expect(dashboardLayoutStyles).toContain("export const ChartBars = styled.div`")
+    expect(dashboardLayoutStyles).toContain("export const LogLines = styled.div`")
+    expect(dashboardPriorityStyles).toContain("export const PrioritySection = styled(AdminPlainCard)`")
 
     expect(profileSource.split("\n").length).toBeLessThan(2600)
     expect(toolsSource.split("\n").length).toBeLessThan(2100)

--- a/front/e2e/helpers/perfFixtures.ts
+++ b/front/e2e/helpers/perfFixtures.ts
@@ -535,9 +535,9 @@ export const getVisualLayoutFingerprint = async (page: Page) =>
       ...(route === "/admin/dashboard"
         ? {
             dashboardServiceRailRect: readRect('[data-ui="monitoring-service-rail"]'),
-            dashboardPrioritySectionRect: readSectionRectByHeading("우선 점검 항목"),
-            dashboardPanelGridRect: readRect('[data-ui="monitoring-panel-grid"]'),
-            dashboardFirstPanelRect: readRect('[data-ui="monitoring-panel-card"]'),
+            dashboardPrioritySectionRect: readSectionRectByHeading("Steady-state guard"),
+            dashboardPanelGridRect: readSectionRectByHeading("Public read latency"),
+            dashboardFirstPanelRect: readSectionRectByHeading("Live logs"),
           }
         : {}),
     }

--- a/front/e2e/perf-layout.spec.ts
+++ b/front/e2e/perf-layout.spec.ts
@@ -359,19 +359,18 @@ test.describe("성능 레이아웃과 표면 예산", () => {
       const htmlScrollWidth = snapshot.scrollWidth?.html ?? 0
       const bodyScrollWidth = snapshot.scrollWidth?.body ?? 0
 
-      // V4 관리자 first fold는 iPad mini 768 환경에서 우선 점검 영역을 300px 전후로 당긴다.
-      // V4 shell compact topbar에서는 Linux headless 기준 287px까지 내려온다.
+      // V4 관리자 dashboard는 iPad mini 768 환경에서 metric strip 다음 steady-state guard를 먼저 노출한다.
       // 관리자 route는 full-bleed 작업 공간이므로 콘텐츠 폭은 742px 안팎으로 고정한다.
       expect(serviceRailWidth).toBeGreaterThanOrEqual(738)
       expect(serviceRailWidth).toBeLessThanOrEqual(744)
-      expect(prioritySectionY).toBeGreaterThanOrEqual(285)
-      expect(prioritySectionY).toBeLessThanOrEqual(320)
+      expect(prioritySectionY).toBeGreaterThanOrEqual(540)
+      expect(prioritySectionY).toBeLessThanOrEqual(590)
       expect(panelGridWidth).toBeGreaterThanOrEqual(738)
       expect(panelGridWidth).toBeLessThanOrEqual(744)
       expect(firstPanelWidth).toBeGreaterThanOrEqual(738)
       expect(firstPanelWidth).toBeLessThanOrEqual(744)
       expect(firstPanelY).toBeGreaterThanOrEqual(prioritySectionBottom)
-      expect(firstPanelY).toBeLessThanOrEqual(650)
+      expect(firstPanelY).toBeLessThanOrEqual(1120)
       expect(htmlScrollWidth).toBeLessThanOrEqual(768)
       expect(bodyScrollWidth).toBeLessThanOrEqual(768)
       continue

--- a/front/src/pages/admin/dashboard.tsx
+++ b/front/src/pages/admin/dashboard.tsx
@@ -1,95 +1,15 @@
-import { useQuery } from "@tanstack/react-query"
-import { GetServerSideProps, NextPage } from "next"
 import { IncomingMessage } from "http"
-import Link from "next/link"
-import type { SimpleIcon } from "simple-icons"
-import { useEffect, useRef, useState } from "react"
-import { apiFetch } from "src/apis/backend/client"
-import AppIcon from "src/components/icons/AppIcon"
+import { GetServerSideProps } from "next"
 import type { AuthMember } from "src/hooks/useAuthSession"
-import useAuthSession from "src/hooks/useAuthSession"
 import { AdminPageProps, buildAdminPagePropsFromMember, getAdminPageProps, readAdminProtectedBootstrap } from "src/libs/server/adminPage"
 import { hasServerAuthCookie } from "src/libs/server/authSession"
 import { serverApiFetch } from "src/libs/server/backend"
 import { appendSsrDebugTiming, timed } from "src/libs/server/serverTiming"
 import {
-  DASHBOARD_PANEL_CARDS,
-  buildGrafanaPanelEmbedUrl,
-  buildMonitoringItems,
-  getMonitoringEnv,
-} from "src/routes/Admin/adminMonitoring"
-import AdminShell from "src/routes/Admin/AdminShell"
-import {
-  DASHBOARD_BACKEND_CHECK_LABEL,
-  DASHBOARD_DATA_MISSING_LABEL,
-  EMPTY_INITIAL_SNAPSHOT,
-  formatAge,
-  formatInstant,
-  getMailStatusLabel,
-  getMailStatusTone,
-  getSystemHealthStatusLabel,
-  getSystemHealthTone,
-  getTaskQueueTone,
-  hasDashboardSnapshot,
   type AdminDashboardInitialSnapshot,
-  type DashboardKpiCard,
-  type DashboardPriorityRow,
-  type DashboardQuickAction,
   type DashboardSnapshotPayload,
   type SystemHealthPayload,
 } from "src/routes/Admin/AdminDashboardWorkspaceModel"
-import {
-  Main,
-  Shell,
-  HeroPanel,
-  HeroTop,
-  HeroCopy,
-  HeroActions,
-  StatusChip,
-  HeaderLink,
-  ServiceRail,
-  MetricCard,
-  MetricIcon,
-  MetricCopy,
-  PanelGrid,
-  PanelCard,
-  LeadPanelCard,
-  CompactPanelCard,
-  PanelHeader,
-  LaunchLink,
-  PanelBody,
-  SnapshotLeadBody,
-  PanelFrame,
-  CompactPanelBody,
-  CompactPanelSummary,
-  PanelFallback,
-  InsightRail,
-  LeadMetaGrid,
-  LeadMetaCard,
-  ActionList,
-  ActionListLinkCard,
-  SectionHeader,
-  PrioritySection,
-  ContextGrid,
-  ContextSection,
-  ContextLinkGrid,
-  ContextMonitoringLinkCard,
-  AdditionalPanelsSection,
-  AdditionalPanelsDisclosure,
-  AdditionalPanelsSummary,
-  AdditionalPanelsGrid,
-  PriorityTable,
-  PriorityCellCopy,
-  PrioritySummary,
-  PriorityLink,
-  InsightLink,
-} from "src/routes/Admin/AdminDashboardWorkspace.styles"
-import {
-  AdminInfoLinkCard,
-  AdminInfoList,
-  AdminInfoStatusItem,
-  AdminInfoStatusList,
-} from "src/routes/Admin/AdminSurfacePrimitives"
 
 type AdminDashboardPageProps = AdminPageProps & {
   initialSnapshot: AdminDashboardInitialSnapshot

--- a/front/src/routes/Admin/AdminDashboardWorkspace.styles.layout.ts
+++ b/front/src/routes/Admin/AdminDashboardWorkspace.styles.layout.ts
@@ -7,71 +7,93 @@ import {
 } from "src/routes/Admin/AdminSurfacePrimitives"
 import {
   adminAppBackground,
+  adminAccentText,
   adminBorder,
+  adminBorderStrong,
+  adminControlText,
   adminSurface,
+  adminSurfaceAccent,
   adminSurfaceRaised,
+  adminTeal,
+  adminTealBorder,
+  adminTealHover,
+  adminTextMuted,
   adminTextPrimary,
   adminTextSecondary,
 } from "src/routes/Admin/adminColorTokens"
 
 export const Main = styled.main`
+  display: grid;
+  gap: 2rem;
+  align-items: start;
+  min-width: 0;
   min-height: 100vh;
+  padding: 2.55rem 2.125rem 4.375rem;
   background: ${adminAppBackground};
+
+  @media (max-width: 768px) {
+    padding: 1rem 0.82rem 2rem;
+  }
 `
 
 export const Shell = styled.div`
-  width: 100%;
-  margin: 0;
-  padding: 1.05rem 1.45rem 4.5rem;
   display: grid;
-  gap: 8px;
-
-  @media (max-width: 768px) {
-    width: 100%;
-    padding: 0.85rem 0.82rem 3rem;
-    gap: 8px;
-  }
+  gap: 1.5rem;
+  width: 100%;
+  min-width: 0;
+  margin: 0;
 `
 
 export const HeroPanel = styled.section`
   display: grid;
-  gap: 6px;
-  padding: 0 0 9px;
-  border-bottom: 1px solid ${adminBorder};
-
-  @media (max-width: 820px) {
-    gap: 6px;
-    padding-bottom: 11px;
-  }
+  min-width: 0;
 `
 
 export const HeroTop = styled.div`
-  display: flex;
-  justify-content: space-between;
-  gap: 18px;
-  align-items: flex-end;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: start;
 
-  @media (max-width: 700px) {
-    flex-direction: column;
-    align-items: stretch;
+  @media (max-width: 860px) {
+    grid-template-columns: 1fr;
   }
 `
 
 export const HeroCopy = styled.div`
   display: grid;
-  gap: 0;
+  gap: 0.85rem;
+  min-width: 0;
+
+  > span {
+    color: ${adminTeal};
+    font-size: 0.62rem;
+    font-weight: 820;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
 
   h1 {
     margin: 0;
     color: ${adminTextPrimary};
-    font-size: clamp(1.16rem, 2vw, 1.42rem);
-    line-height: 1.1;
+    font-size: 2.125rem;
+    line-height: 1.08;
     letter-spacing: 0;
-    font-weight: 800;
+    font-weight: 840;
+    overflow-wrap: anywhere;
   }
+
+  p {
+    margin: 0;
+    color: ${adminTextMuted};
+    font-size: 1rem;
+    font-weight: 500;
+    line-height: 1.5;
+  }
+
   @media (max-width: 768px) {
     h1 {
-      font-size: clamp(1.16rem, 6vw, 1.42rem);
+      font-size: 1.38rem;
     }
   }
 `
@@ -90,165 +112,257 @@ export const HeroActions = styled.div`
 export const StatusChip = styled.span`
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   min-height: 38px;
-  padding: 0 15px;
-  border-radius: 4px;
+  padding: 0 0.78rem;
+  border-radius: 2px;
   border: 1px solid ${adminBorder};
-  background: ${adminSurface};
+  background: ${adminSurfaceRaised};
   color: ${adminTextPrimary};
-  font-size: 0.84rem;
-  font-weight: 800;
+  font-size: 0.72rem;
+  font-weight: 820;
+  letter-spacing: 0.04em;
 
   &[data-tone="good"] {
-    border-color: ${({ theme }) => theme.colors.green7};
-    background: ${({ theme }) => theme.colors.accentSurfaceSubtle};
+    border-color: ${adminTealBorder};
+    background: ${adminSurfaceAccent};
+    color: ${adminTeal};
   }
 
   &[data-tone="warn"] {
-    border-color: ${({ theme }) => theme.colors.orange7};
+    border-color: ${adminBorderStrong};
+    color: ${adminAccentText};
   }
 `
 
 export const HeaderLink = styled.a`
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   min-height: 38px;
-  padding: 0 15px;
-  border-radius: 4px;
+  padding: 0 0.9rem;
+  border-radius: 2px;
   border: 1px solid ${adminBorder};
-  background: ${adminSurface};
+  background: ${adminSurfaceRaised};
   color: ${adminTextPrimary};
   text-decoration: none;
-  font-size: 0.84rem;
+  font-size: 0.82rem;
   font-weight: 780;
+
+  &[data-variant="primary"] {
+    border-color: ${adminTealBorder};
+    background: ${adminTeal};
+    color: ${adminControlText};
+    font-weight: 820;
+  }
+
+  &[data-variant="primary"]:hover {
+    background: ${adminTealHover};
+  }
 `
 
 export const ServiceRail = styled.section`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(13.5rem, 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+  border: 1px solid ${adminBorder};
+  background: ${adminSurface};
 
-  @media (max-width: 720px) {
+  @media (max-width: 1040px) {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 6px;
+  }
+
+  @media (max-width: 560px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 `
 
 export const MetricCard = styled.article`
   display: grid;
-  gap: 10px;
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: start;
-  padding: 12px;
-  border-radius: 2px;
-  border: 1px solid ${adminBorder};
-  background: ${adminSurface};
-  box-shadow: none;
+  gap: 0.48rem;
+  min-width: 0;
+  min-height: 9rem;
+  align-content: center;
+  padding: 1.25rem;
+  border-right: 1px solid ${adminBorder};
+  background: transparent;
 
-  &[data-tone="good"] {
-    border-color: ${({ theme }) => theme.colors.green7};
+  &:last-of-type {
+    border-right: 0;
   }
 
-  &[data-tone="warn"] {
-    border-color: ${({ theme }) => theme.colors.orange7};
+  @media (max-width: 1040px) {
+    &:nth-of-type(2n) {
+      border-right: 0;
+    }
+
+    &:nth-of-type(-n + 2) {
+      border-bottom: 1px solid ${adminBorder};
+    }
   }
 
-  @media (max-width: 820px) {
-    padding: 11px;
-    gap: 9px;
-  }
+  @media (max-width: 560px) {
+    min-height: 6.2rem;
+    padding: 0.82rem;
+    border-bottom: 1px solid ${adminBorder};
 
-  @media (max-width: 720px) {
-    gap: 7px;
-    padding: 8px;
-    border-radius: 2px;
-  }
-`
+    &:nth-of-type(odd) {
+      border-right: 1px solid ${adminBorder};
+    }
 
-export const MetricIcon = styled.div`
-  width: 42px;
-  height: 42px;
-  border-radius: 2px;
-  display: grid;
-  place-items: center;
-  background: ${adminSurfaceRaised};
-  color: ${adminTextSecondary};
-
-  &[data-tone="good"] {
-    background: ${({ theme }) =>
-      theme.scheme === "light" ? "rgba(34, 197, 94, 0.1)" : "rgba(34, 197, 94, 0.18)"};
-    color: ${({ theme }) => theme.colors.green7};
-  }
-
-  &[data-tone="warn"] {
-    background: ${({ theme }) =>
-      theme.scheme === "light" ? "rgba(249, 115, 22, 0.1)" : "rgba(249, 115, 22, 0.18)"};
-    color: ${({ theme }) => theme.colors.orange7};
-  }
-
-  @media (max-width: 720px) {
-    width: 30px;
-    height: 30px;
-    border-radius: 2px;
+    &:nth-last-of-type(-n + 2) {
+      border-bottom: 0;
+    }
   }
 `
 
 export const MetricCopy = styled.div`
   display: grid;
-  gap: 4px;
+  gap: 0.48rem;
   min-width: 0;
 
   span {
-    color: ${({ theme }) => theme.colors.gray10};
-    font-size: 0.82rem;
-    font-weight: 700;
-    line-height: 1.4;
-    word-break: keep-all;
+    color: ${adminTextMuted};
+    font-size: 0.63rem;
+    font-weight: 820;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
 
   strong {
-    color: ${({ theme }) => theme.colors.gray12};
-    font-size: 1.22rem;
-    font-weight: 820;
-    line-height: 1.24;
+    color: ${adminTextPrimary};
+    font-size: 1.55rem;
+    font-weight: 840;
+    line-height: 1.05;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
-  @media (max-width: 820px) {
-    strong {
-      font-size: 1.08rem;
-    }
+  small {
+    color: ${adminTextSecondary};
+    font-size: 0.78rem;
+    font-weight: 500;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
   }
 
   @media (max-width: 720px) {
-    gap: 2px;
-
-    span {
-      font-size: 0.68rem;
-      line-height: 1.22;
-    }
-
     strong {
-      font-size: 0.92rem;
-      line-height: 1.18;
+      font-size: 1.12rem;
     }
   }
 `
 
-export const PanelGrid = styled.section`
+export const OpsGrid = styled.section`
   display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(17.5rem, 0.8fr);
-  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) 20rem;
+  gap: 1rem;
   align-items: start;
+  min-width: 0;
 
-  @media (max-width: 1180px) {
-    grid-template-columns: 1fr;
+  > [data-size="wide"] {
+    grid-column: 1 / -1;
   }
 
-  @media (max-width: 720px) {
-    gap: 10px;
+  @media (max-width: 1120px) {
+    grid-template-columns: 1fr;
+  }
+`
+
+export const Chart = styled.div`
+  min-height: 20rem;
+  display: grid;
+  align-items: end;
+  padding: 1.25rem;
+  background: ${adminSurface};
+`
+
+export const ChartBars = styled.div`
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  align-items: end;
+  gap: 0.55rem;
+  min-height: 16rem;
+`
+
+export const ChartBar = styled.i`
+  display: block;
+  min-height: 8%;
+  border-radius: 2px 2px 0 0;
+  background: ${adminTeal};
+
+  &[data-tone="warn"] {
+    background: ${adminAccentText};
+  }
+
+  &[data-tone="neutral"] {
+    background: ${adminTextSecondary};
+  }
+`
+
+export const StatusRows = styled.div`
+  display: grid;
+`
+
+export const StatusRow = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+  min-height: 4rem;
+  padding: 0.72rem 1rem;
+  border-bottom: 1px solid ${adminBorder};
+
+  &:last-of-type {
+    border-bottom: 0;
+  }
+
+  > span {
+    display: flex;
+    align-items: center;
+    gap: 0.62rem;
+    min-width: 0;
+  }
+
+  strong,
+  small {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  strong {
+    color: ${adminTextPrimary};
+    font-size: 0.98rem;
+    font-weight: 800;
+  }
+
+  small {
+    color: ${adminTextMuted};
+    font-size: 0.74rem;
+    font-weight: 600;
+    line-height: 1.35;
+  }
+`
+
+export const StatusDot = styled.i`
+  width: 0.48rem;
+  height: 0.48rem;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: ${adminTeal};
+  box-shadow: 0 0 0 4px rgba(17, 145, 112, 0.12);
+
+  &[data-tone="warn"] {
+    background: ${adminAccentText};
+    box-shadow: 0 0 0 4px rgba(180, 83, 9, 0.14);
+  }
+
+  &[data-tone="neutral"] {
+    background: ${adminTextSecondary};
+    box-shadow: 0 0 0 4px rgba(91, 107, 129, 0.12);
   }
 `
 
@@ -269,27 +383,33 @@ export const CompactPanelCard = styled(PanelCard)`
 export const PanelHeader = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
-  gap: 16px;
-  padding: 14px 16px 10px;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 3.25rem;
+  padding: 0 1rem;
   border-bottom: 1px solid ${adminBorder};
 
+  h2,
   strong {
     display: block;
+    margin: 0;
     color: ${adminTextPrimary};
-    font-size: 1.02rem;
-    font-weight: 840;
-    letter-spacing: -0.03em;
+    font-size: 0.98rem;
+    font-weight: 820;
+    letter-spacing: 0;
   }
 
   span {
-    display: none;
+    color: ${adminTextMuted};
+    font-size: 0.76rem;
+    font-weight: 700;
   }
 
   @media (max-width: 720px) {
     gap: 10px;
     padding: 10px 12px 8px;
 
+    h2,
     strong {
       font-size: 0.92rem;
     }
@@ -309,6 +429,61 @@ export const LaunchLink = styled.a`
   text-decoration: none;
   font-size: 0.88rem;
   font-weight: 780;
+`
+
+export const LogLines = styled.div`
+  display: grid;
+  padding: 0.35rem 1rem 1rem;
+  background: ${adminSurface};
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+`
+
+export const LogLine = styled.div`
+  display: grid;
+  grid-template-columns: 8rem minmax(0, 1fr);
+  gap: 1rem;
+  padding: 0.58rem 0;
+  border-bottom: 1px solid ${adminBorder};
+  color: ${adminTextPrimary};
+  font-size: 0.78rem;
+  line-height: 1.45;
+
+  &:last-of-type {
+    border-bottom: 0;
+  }
+
+  > span {
+    color: ${adminTeal};
+    font-weight: 800;
+    white-space: nowrap;
+  }
+
+  &[data-tone="warn"] > span {
+    color: ${adminAccentText};
+  }
+
+  &[data-tone="neutral"] > span {
+    color: ${adminTextSecondary};
+  }
+
+  p {
+    margin: 0;
+    min-width: 0;
+    font-weight: 760;
+  }
+
+  small {
+    display: block;
+    color: ${adminTextMuted};
+    font-size: 0.72rem;
+    font-weight: 600;
+    overflow-wrap: anywhere;
+  }
+
+  @media (max-width: 640px) {
+    grid-template-columns: 1fr;
+    gap: 0.18rem;
+  }
 `
 
 export const PanelBody = styled.div`

--- a/front/src/routes/Admin/AdminDashboardWorkspace.styles.priority.ts
+++ b/front/src/routes/Admin/AdminDashboardWorkspace.styles.priority.ts
@@ -6,6 +6,15 @@ import {
   AdminSectionTitleStack,
   AdminTextActionLink,
 } from "src/routes/Admin/AdminSurfacePrimitives"
+import {
+  adminBorder,
+  adminSurface,
+  adminSurfaceAccent,
+  adminTeal,
+  adminTealBorder,
+  adminTextPrimary,
+  adminTextSecondary,
+} from "src/routes/Admin/adminColorTokens"
 
 export const SectionHeader = styled(AdminSectionTitleStack)`
   h2 {
@@ -15,13 +24,13 @@ export const SectionHeader = styled(AdminSectionTitleStack)`
 
 export const PrioritySection = styled(AdminPlainCard)`
   display: grid;
-  gap: 10px;
-  padding: 14px 16px;
+  gap: 0;
+  padding: 0;
   border-radius: 2px;
+  overflow: hidden;
 
-  @media (max-width: 720px) {
-    gap: 8px;
-    padding: 12px;
+  @media (max-width: 1120px) {
+    order: -1;
   }
 `
 
@@ -189,25 +198,29 @@ export const PriorityCellCopy = styled.div`
 export const PrioritySummary = styled.div`
   display: inline-flex;
   align-items: center;
-  min-height: 34px;
-  padding: 0.32rem 0.72rem;
+  justify-content: center;
+  min-width: 4.4rem;
+  min-height: 1.8rem;
+  padding: 0.2rem 0.5rem;
   border-radius: 2px;
-  border: 1px solid ${({ theme }) => theme.colors.gray6};
-  background: ${({ theme }) => theme.colors.gray2};
-  color: ${({ theme }) => theme.colors.gray12};
-  font-size: 0.78rem;
-  font-weight: 760;
-  line-height: 1.4;
+  border: 1px solid ${adminBorder};
+  background: ${adminSurface};
+  color: ${adminTextSecondary};
+  font-size: 0.67rem;
+  font-weight: 820;
+  line-height: 1.2;
+  text-align: center;
   white-space: normal;
 
   &[data-tone="good"] {
-    border-color: ${({ theme }) => theme.colors.green7};
-    background: ${({ theme }) => theme.colors.accentSurfaceSubtle};
+    border-color: ${adminTealBorder};
+    background: ${adminSurfaceAccent};
+    color: ${adminTeal};
   }
 
   &[data-tone="warn"] {
-    border-color: ${({ theme }) => theme.colors.orange7};
-    background: ${({ theme }) => theme.colors.orange2};
+    border-color: ${adminBorder};
+    color: ${adminTextPrimary};
   }
 `
 

--- a/front/src/routes/Admin/AdminDashboardWorkspace.styles.priority.ts
+++ b/front/src/routes/Admin/AdminDashboardWorkspace.styles.priority.ts
@@ -210,7 +210,12 @@ export const PrioritySummary = styled.div`
   font-weight: 820;
   line-height: 1.2;
   text-align: center;
+  text-decoration: none;
   white-space: normal;
+
+  &[href] {
+    cursor: pointer;
+  }
 
   &[data-tone="good"] {
     border-color: ${adminTealBorder};

--- a/front/src/routes/Admin/AdminDashboardWorkspaceModel.ts
+++ b/front/src/routes/Admin/AdminDashboardWorkspaceModel.ts
@@ -66,6 +66,21 @@ export type DashboardQuickAction = {
   label: string
 }
 
+export type DashboardChartBar = {
+  key: string
+  label: string
+  height: number
+  tone: "neutral" | "good" | "warn"
+}
+
+export type DashboardLogRow = {
+  key: string
+  time: string
+  message: string
+  detail: string
+  tone: "neutral" | "good" | "warn"
+}
+
 export const EMPTY_INITIAL_SNAPSHOT: AdminDashboardInitialSnapshot = {
   systemHealth: null,
   dashboard: null,

--- a/front/src/routes/Admin/AdminDashboardWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminDashboardWorkspacePage.tsx
@@ -4,12 +4,6 @@ import { apiFetch } from "src/apis/backend/client"
 import type { AuthMember } from "src/hooks/useAuthSession"
 import useAuthSession from "src/hooks/useAuthSession"
 import {
-  DASHBOARD_PANEL_CARDS,
-  buildGrafanaPanelEmbedUrl,
-  buildMonitoringItems,
-  getMonitoringEnv,
-} from "src/routes/Admin/adminMonitoring"
-import {
   DASHBOARD_BACKEND_CHECK_LABEL,
   DASHBOARD_DATA_MISSING_LABEL,
   EMPTY_INITIAL_SNAPSHOT,
@@ -22,9 +16,10 @@ import {
   getTaskQueueTone,
   hasDashboardSnapshot,
   type AdminDashboardInitialSnapshot,
+  type DashboardChartBar,
   type DashboardKpiCard,
+  type DashboardLogRow,
   type DashboardPriorityRow,
-  type DashboardQuickAction,
   type DashboardSnapshotPayload,
   type SystemHealthPayload,
 } from "src/routes/Admin/AdminDashboardWorkspaceModel"
@@ -34,8 +29,6 @@ type AdminDashboardPageProps = {
   initialMember: AuthMember
   initialSnapshot: AdminDashboardInitialSnapshot
 }
-
-const env = getMonitoringEnv()
 
 const AdminDashboardPage: NextPage<AdminDashboardPageProps> = ({
   initialMember,
@@ -79,10 +72,6 @@ const AdminDashboardPage: NextPage<AdminDashboardPageProps> = ({
   const rawSystemHealthStatus = systemHealthQuery.data?.status ?? null
   const dashboardSnapshot = dashboardSnapshotQuery.data ?? initialSnapshot.dashboard
   const hasSnapshot = hasDashboardSnapshot(dashboardSnapshot)
-  const monitoringItems = buildMonitoringItems(rawSystemHealthStatus ?? "", env)
-  const grafanaDashboardUrl = env.monitoringEmbedLooksLikeGrafana ? env.monitoringEmbedUrl : ""
-  const grafanaPanelsCanEmbed = env.monitoringEmbedIsPublicGrafana && Boolean(grafanaDashboardUrl)
-  const secondaryPanels = DASHBOARD_PANEL_CARDS
   const dashboardStatusLabel = getSystemHealthStatusLabel(rawSystemHealthStatus)
   const dashboardStatusTone = getSystemHealthTone(rawSystemHealthStatus)
   const dashboardSnapshotGeneratedAt = hasSnapshot ? formatInstant(dashboardSnapshot.generatedAt) : DASHBOARD_DATA_MISSING_LABEL
@@ -93,83 +82,6 @@ const AdminDashboardPage: NextPage<AdminDashboardPageProps> = ({
   const authSecurityDetail = hasSnapshot
     ? `최근 기록 ${dashboardSnapshot.authSecurity.recentEventCount}건`
     : DASHBOARD_DATA_MISSING_LABEL
-  const leadFailureItems = hasSnapshot ? [
-    {
-      key: "task-failed",
-      label: "실패 task",
-      value: `${dashboardSnapshot.taskQueue.failedCount}건`,
-      tone: dashboardSnapshot.taskQueue.failedCount ? ("warn" as const) : ("good" as const),
-    },
-    {
-      key: "task-stale",
-      label: "정체 task",
-      value: `${dashboardSnapshot.taskQueue.staleProcessingCount}건`,
-      tone: dashboardSnapshot.taskQueue.staleProcessingCount ? ("warn" as const) : ("good" as const),
-    },
-    {
-      key: "mail-failure",
-      label: "메일 최근 실패",
-      value: dashboardSnapshot.signupMail.latestFailureAt
-        ? formatInstant(dashboardSnapshot.signupMail.latestFailureAt)
-        : DASHBOARD_DATA_MISSING_LABEL,
-      tone: dashboardSnapshot.signupMail.latestFailureAt ? ("warn" as const) : ("good" as const),
-    },
-    {
-      key: "auth-blocked",
-      label: "최근 인증 차단",
-      value: dashboardSnapshot.authSecurity.latestBlockedAt
-        ? formatInstant(dashboardSnapshot.authSecurity.latestBlockedAt)
-        : DASHBOARD_DATA_MISSING_LABEL,
-      tone: dashboardSnapshot.authSecurity.latestBlockedAt ? ("warn" as const) : ("good" as const),
-    },
-  ] : [
-    {
-      key: "snapshot-missing",
-      label: "운영 스냅샷",
-      value: DASHBOARD_DATA_MISSING_LABEL,
-      tone: "neutral" as const,
-    },
-  ]
-
-  const leadFailureMetaItems = hasSnapshot ? [
-    {
-      key: "mail-message",
-      label: "메일 실패 메시지",
-      value: dashboardSnapshot.signupMail.latestFailureMessage ?? DASHBOARD_DATA_MISSING_LABEL,
-    },
-    {
-      key: "task-message",
-      label: "task 실패 메시지",
-      value: dashboardSnapshot.taskQueue.latestFailureMessage ?? DASHBOARD_DATA_MISSING_LABEL,
-    },
-    {
-      key: "mail-latest",
-      label: "메일 실패 시각",
-      value: dashboardSnapshot.signupMail.latestFailureAt
-        ? formatInstant(dashboardSnapshot.signupMail.latestFailureAt)
-        : DASHBOARD_DATA_MISSING_LABEL,
-    },
-    {
-      key: "task-latest",
-      label: "task 실패 시각",
-      value: dashboardSnapshot.taskQueue.latestFailureAt
-        ? formatInstant(dashboardSnapshot.taskQueue.latestFailureAt)
-        : DASHBOARD_DATA_MISSING_LABEL,
-    },
-    {
-      key: "auth-latest",
-      label: "차단 시각",
-      value: dashboardSnapshot.authSecurity.latestBlockedAt
-        ? formatInstant(dashboardSnapshot.authSecurity.latestBlockedAt)
-        : DASHBOARD_DATA_MISSING_LABEL,
-    },
-  ] : [
-    {
-      key: "snapshot-check",
-      label: "스냅샷",
-      value: DASHBOARD_BACKEND_CHECK_LABEL,
-    },
-  ]
 
   const kpiCards: DashboardKpiCard[] = [
     {
@@ -266,55 +178,139 @@ const AdminDashboardPage: NextPage<AdminDashboardPageProps> = ({
     },
   ]
 
-  const quickActions: DashboardQuickAction[] = [
-    {
-      key: "tools",
-      href: "/admin/tools",
-      label: "운영 진단 열기",
-    },
-    ...(grafanaDashboardUrl
-      ? [
-          {
-            key: "grafana",
-            href: grafanaDashboardUrl,
-            label: "Grafana 열기",
-          },
-        ]
-      : []),
-    ...(env.logsDashboardUrl
-      ? [
-          {
-            key: "logs",
-            href: env.logsDashboardUrl,
-            label: "로그 보드",
-          },
-        ]
-      : []),
-  ]
+  const chartBars: DashboardChartBar[] = hasSnapshot
+    ? ([
+        {
+          key: "ready",
+          label: "ready",
+          value: dashboardSnapshot.taskQueue.readyPendingCount,
+          tone: dashboardSnapshot.taskQueue.readyPendingCount ? "neutral" : "good",
+        },
+        {
+          key: "processing",
+          label: "processing",
+          value: dashboardSnapshot.taskQueue.processingCount,
+          tone: "neutral",
+        },
+        {
+          key: "failed",
+          label: "failed",
+          value: dashboardSnapshot.taskQueue.failedCount,
+          tone: dashboardSnapshot.taskQueue.failedCount ? "warn" : "good",
+        },
+        {
+          key: "stale",
+          label: "stale",
+          value: dashboardSnapshot.taskQueue.staleProcessingCount,
+          tone: dashboardSnapshot.taskQueue.staleProcessingCount ? "warn" : "good",
+        },
+        {
+          key: "auth-recent",
+          label: "auth",
+          value: dashboardSnapshot.authSecurity.recentEventCount,
+          tone: "neutral",
+        },
+        {
+          key: "auth-blocked",
+          label: "blocked",
+          value: dashboardSnapshot.authSecurity.blockedEventCount,
+          tone: dashboardSnapshot.authSecurity.blockedEventCount ? "warn" : "good",
+        },
+        {
+          key: "purge",
+          label: "purge",
+          value: dashboardSnapshot.storageCleanup.eligibleForPurgeCount,
+          tone: dashboardSnapshot.storageCleanup.eligibleForPurgeCount ? "warn" : "good",
+        },
+        {
+          key: "mail-lag",
+          label: "mail",
+          value: dashboardSnapshot.signupMail.queueLagSeconds ?? 0,
+          tone: getMailStatusTone(dashboardSnapshot.signupMail.status),
+        },
+      ] as Array<{ key: string; label: string; value: number; tone: DashboardChartBar["tone"] }>)
+        .map((item, _index, items) => {
+          const maxValue = Math.max(...items.map((bar) => bar.value), 1)
+          const height = item.value > 0 ? Math.max(14, Math.round((item.value / maxValue) * 100)) : 8
+          return {
+            key: item.key,
+            label: item.label,
+            height,
+            tone: item.tone,
+          }
+        })
+    : []
 
-  const grafanaPanelFallbackTitle = grafanaDashboardUrl ? "Grafana 패널은 새 창에서 확인하세요." : "대시보드를 불러올 수 없습니다."
-  const grafanaPanelFallbackBody = grafanaDashboardUrl
-    ? env.monitoringEmbedIsPrivateGrafana
-      ? "현재 URL은 인증이 필요한 private Grafana 대시보드라 iframe 대신 링크로만 제공합니다."
-      : "현재 대시보드는 iframe 임베드를 지원하지 않아 새 창 링크로만 제공합니다."
-    : "Grafana embed URL 또는 public dashboard 구성을 먼저 확인하세요."
+  const logRows: DashboardLogRow[] = hasSnapshot
+    ? [
+        {
+          key: "snapshot",
+          time: formatInstant(dashboardSnapshot.generatedAt),
+          message: "운영 스냅샷 수집",
+          detail: `system ${dashboardStatusLabel}`,
+          tone: dashboardStatusTone,
+        },
+        {
+          key: "task-queue",
+          time: dashboardSnapshot.taskQueue.latestFailureAt
+            ? formatInstant(dashboardSnapshot.taskQueue.latestFailureAt)
+            : formatInstant(dashboardSnapshot.generatedAt),
+          message: "작업 큐 상태",
+          detail: `ready ${dashboardSnapshot.taskQueue.readyPendingCount} · failed ${dashboardSnapshot.taskQueue.failedCount} · stale ${dashboardSnapshot.taskQueue.staleProcessingCount}`,
+          tone: getTaskQueueTone(dashboardSnapshot),
+        },
+        {
+          key: "signup-mail",
+          time: dashboardSnapshot.signupMail.latestFailureAt
+            ? formatInstant(dashboardSnapshot.signupMail.latestFailureAt)
+            : formatInstant(dashboardSnapshot.generatedAt),
+          message: "회원가입 메일",
+          detail: dashboardSnapshot.signupMail.latestFailureMessage ?? mailStatusLabel,
+          tone: getMailStatusTone(dashboardSnapshot.signupMail.status),
+        },
+        {
+          key: "auth-security",
+          time: dashboardSnapshot.authSecurity.latestEventAt
+            ? formatInstant(dashboardSnapshot.authSecurity.latestEventAt)
+            : formatInstant(dashboardSnapshot.generatedAt),
+          message: "인증 이벤트",
+          detail: `recent ${dashboardSnapshot.authSecurity.recentEventCount} · blocked ${dashboardSnapshot.authSecurity.blockedEventCount}`,
+          tone: dashboardSnapshot.authSecurity.blockedEventCount ? "warn" : "good",
+        },
+        {
+          key: "storage-cleanup",
+          time: dashboardSnapshot.storageCleanup.oldestEligiblePurgeAfter
+            ? formatInstant(dashboardSnapshot.storageCleanup.oldestEligiblePurgeAfter)
+            : formatInstant(dashboardSnapshot.generatedAt),
+          message: "스토리지 정리",
+          detail: dashboardSnapshot.storageCleanup.blockedBySafetyThreshold
+            ? "safety threshold blocked"
+            : `eligible ${dashboardSnapshot.storageCleanup.eligibleForPurgeCount}`,
+          tone:
+            dashboardSnapshot.storageCleanup.blockedBySafetyThreshold ||
+            dashboardSnapshot.storageCleanup.eligibleForPurgeCount > 0
+              ? "warn"
+              : "good",
+        },
+      ]
+    : [
+        {
+          key: "snapshot-missing",
+          time: DASHBOARD_DATA_MISSING_LABEL,
+          message: "운영 스냅샷 미수집",
+          detail: DASHBOARD_BACKEND_CHECK_LABEL,
+          tone: "neutral",
+        },
+      ]
 
   return (
     <AdminDashboardWorkspaceView
-      buildGrafanaPanelEmbedUrl={buildGrafanaPanelEmbedUrl}
+      chartBars={chartBars}
       dashboardStatusLabel={dashboardStatusLabel}
       dashboardStatusTone={dashboardStatusTone}
-      focusItems={leadFailureItems}
-      grafanaDashboardUrl={grafanaDashboardUrl}
-      grafanaPanelFallbackBody={grafanaPanelFallbackBody}
-      grafanaPanelFallbackTitle={grafanaPanelFallbackTitle}
-      grafanaPanelsCanEmbed={grafanaPanelsCanEmbed}
       kpiCards={kpiCards}
-      leadFailureMetaItems={leadFailureMetaItems}
-      monitoringItems={monitoringItems}
+      logRows={logRows}
       priorityRows={priorityRows}
-      quickActions={quickActions}
-      secondaryPanels={secondaryPanels}
       sessionMember={sessionMember}
     />
   )

--- a/front/src/routes/Admin/AdminDashboardWorkspaceView.tsx
+++ b/front/src/routes/Admin/AdminDashboardWorkspaceView.tsx
@@ -111,7 +111,15 @@ export const AdminDashboardWorkspaceView = (props: Record<string, any>) => {
                         <small>{row.summary}</small>
                       </span>
                     </span>
-                    <PrioritySummary data-tone={row.tone}>{row.actionLabel}</PrioritySummary>
+                    {row.href ? (
+                      <Link href={row.href} passHref legacyBehavior>
+                        <PrioritySummary as="a" data-tone={row.tone}>
+                          {row.actionLabel}
+                        </PrioritySummary>
+                      </Link>
+                    ) : (
+                      <PrioritySummary data-tone={row.tone}>{row.actionLabel}</PrioritySummary>
+                    )}
                   </StatusRow>
                 ))}
               </StatusRows>

--- a/front/src/routes/Admin/AdminDashboardWorkspaceView.tsx
+++ b/front/src/routes/Admin/AdminDashboardWorkspaceView.tsx
@@ -1,80 +1,41 @@
 import Link from "next/link"
-import AppIcon from "src/components/icons/AppIcon"
 import {
-  DASHBOARD_PANEL_STAGGER_MS,
-  DeferredPanelFrame,
-} from "src/routes/Admin/AdminDashboardDeferredPanelFrame"
-import {
-  ActionList,
-  ActionListLinkCard,
-  AdditionalPanelsDisclosure,
-  AdditionalPanelsGrid,
-  AdditionalPanelsSection,
-  AdditionalPanelsSummary,
-  CompactPanelBody,
-  CompactPanelCard,
-  CompactPanelSummary,
-  ContextGrid,
-  ContextLinkGrid,
-  ContextMonitoringLinkCard,
-  ContextSection,
+  Chart,
+  ChartBar,
+  ChartBars,
   HeaderLink,
   HeroActions,
   HeroCopy,
   HeroPanel,
   HeroTop,
-  InsightLink,
-  InsightRail,
-  LaunchLink,
-  LeadMetaCard,
-  LeadMetaGrid,
-  LeadPanelCard,
+  LogLine,
+  LogLines,
   Main,
   MetricCard,
   MetricCopy,
-  MetricIcon,
-  PanelBody,
+  OpsGrid,
   PanelCard,
-  PanelFallback,
-  PanelGrid,
   PanelHeader,
-  PriorityCellCopy,
-  PriorityLink,
   PrioritySection,
   PrioritySummary,
-  PriorityTable,
-  SectionHeader,
   Shell,
-  SnapshotLeadBody,
   ServiceRail,
   StatusChip,
+  StatusDot,
+  StatusRow,
+  StatusRows,
 } from "src/routes/Admin/AdminDashboardWorkspace.styles"
-import { renderMonitoringBrand } from "src/routes/Admin/AdminDashboardWorkspaceSections"
 import AdminShell from "src/routes/Admin/AdminShell"
-import {
-  AdminInfoLinkCard,
-  AdminInfoList,
-  AdminInfoStatusItem,
-  AdminInfoStatusList,
-} from "src/routes/Admin/AdminSurfacePrimitives"
 
 export const AdminDashboardWorkspaceView = (props: Record<string, any>) => {
   const {
+    chartBars,
     dashboardStatusLabel,
     dashboardStatusTone,
-    focusItems,
-    grafanaDashboardUrl,
-    grafanaPanelFallbackBody,
-    grafanaPanelFallbackTitle,
-    grafanaPanelsCanEmbed,
     kpiCards,
-    monitoringItems,
+    logRows,
     priorityRows,
-    quickActions,
-    secondaryPanels,
     sessionMember,
-    buildGrafanaPanelEmbedUrl,
-    leadFailureMetaItems,
   } = props
 
   return (
@@ -84,12 +45,17 @@ export const AdminDashboardWorkspaceView = (props: Record<string, any>) => {
           <HeroPanel>
             <HeroTop>
               <HeroCopy>
-                <h1>운영 상태</h1>
+                <span>Operations</span>
+                <h1>운영 상태와 복구</h1>
+                <p>배포 슬롯, readiness, 로그와 주요 시스템 지표를 확인합니다.</p>
               </HeroCopy>
               <HeroActions>
                 <StatusChip data-tone={dashboardStatusTone}>{dashboardStatusLabel}</StatusChip>
                 <Link href="/admin/tools" passHref legacyBehavior>
-                  <HeaderLink>진단/실행 열기</HeaderLink>
+                  <HeaderLink>Doctor 실행</HeaderLink>
+                </Link>
+                <Link href="/admin/tools" passHref legacyBehavior>
+                  <HeaderLink data-variant="primary">Rollback</HeaderLink>
                 </Link>
               </HeroActions>
             </HeroTop>
@@ -98,221 +64,77 @@ export const AdminDashboardWorkspaceView = (props: Record<string, any>) => {
           <ServiceRail data-ui="monitoring-service-rail">
             {kpiCards.map((item: any) => (
               <MetricCard key={item.key} data-tone={item.tone}>
-                <MetricIcon data-tone={item.tone}>
-                  <AppIcon name={item.icon} aria-hidden="true" />
-                </MetricIcon>
                 <MetricCopy>
                   <span>{item.label}</span>
                   <strong>{item.value}</strong>
+                  <small>{item.detail}</small>
                 </MetricCopy>
               </MetricCard>
             ))}
           </ServiceRail>
 
-          <PrioritySection>
-            <SectionHeader>
-              <h2>우선 점검 항목</h2>
-            </SectionHeader>
-
-            <PriorityTable>
-              <thead>
-                <tr>
-                  <th>항목</th>
-                  <th>현재 상태</th>
-                  <th>관리</th>
-                </tr>
-              </thead>
-              <tbody>
-                {priorityRows.map((row: any) => (
-                  <tr key={row.key}>
-                    <td>
-                      <PriorityCellCopy>
-                        <strong>{row.title}</strong>
-                      </PriorityCellCopy>
-                    </td>
-                    <td>
-                      <PrioritySummary data-tone={row.tone}>{row.summary}</PrioritySummary>
-                    </td>
-                    <td>
-                      {row.href ? (
-                        <PriorityLink
-                          href={row.href}
-                          target={row.href.startsWith("http") ? "_blank" : undefined}
-                          rel={row.href.startsWith("http") ? "noreferrer noopener" : undefined}
-                        >
-                          {row.actionLabel}
-                        </PriorityLink>
-                      ) : (
-                        <PriorityLink as="span">환경 확인</PriorityLink>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </PriorityTable>
-          </PrioritySection>
-
-          <PanelGrid data-ui="monitoring-panel-grid">
-            <LeadPanelCard data-ui="monitoring-panel-card">
+          <OpsGrid>
+            <PanelCard>
               <PanelHeader>
-                <div>
-                  <strong>최근 실패</strong>
-                </div>
-                <Link href="/admin/tools" passHref legacyBehavior>
-                  <LaunchLink>운영 도구</LaunchLink>
-                </Link>
+                <h2>Public read latency</h2>
+                <StatusChip data-tone={dashboardStatusTone}>LIVE</StatusChip>
               </PanelHeader>
-              <SnapshotLeadBody>
-                <AdminInfoStatusList>
-                  {focusItems.map((item: any) => (
-                    <AdminInfoStatusItem key={item.key} data-tone={item.tone}>
-                      <span>{item.label}</span>
-                      <strong>{item.value}</strong>
-                    </AdminInfoStatusItem>
-                  ))}
-                </AdminInfoStatusList>
-                <LeadMetaGrid>
-                  {leadFailureMetaItems.map((item: any) => (
-                    <LeadMetaCard key={item.key}>
-                      <small>{item.label}</small>
-                      <strong>{item.value}</strong>
-                    </LeadMetaCard>
-                  ))}
-                </LeadMetaGrid>
-              </SnapshotLeadBody>
-            </LeadPanelCard>
-
-            <InsightRail>
-              <CompactPanelCard data-ui="monitoring-panel-card">
-                <PanelHeader>
-                  <div>
-                    <strong>런북</strong>
-                  </div>
-                </PanelHeader>
-                <CompactPanelBody>
-                  <ActionList>
-                    {quickActions.map((action: any) => (
-                      <Link key={action.key} href={action.href} passHref legacyBehavior>
-                        <ActionListLinkCard
-                          $withIcon={false}
-                          target={action.href.startsWith("http") ? "_blank" : undefined}
-                          rel={action.href.startsWith("http") ? "noreferrer noopener" : undefined}
-                        >
-                          <strong>{action.label}</strong>
-                        </ActionListLinkCard>
-                      </Link>
+              <Chart aria-label="운영 스냅샷 기반 지표 차트">
+                {chartBars.length ? (
+                  <ChartBars>
+                    {chartBars.map((bar: any) => (
+                      <ChartBar
+                        key={bar.key}
+                        aria-label={`${bar.label} ${bar.height}`}
+                        data-tone={bar.tone}
+                        style={{ height: `${bar.height}%` }}
+                      />
                     ))}
-                  </ActionList>
-                </CompactPanelBody>
-              </CompactPanelCard>
+                  </ChartBars>
+                ) : (
+                  <PrioritySummary data-tone="neutral">데이터 미수집 · 백엔드 확인 필요</PrioritySummary>
+                )}
+              </Chart>
+            </PanelCard>
 
-              <CompactPanelCard data-ui="monitoring-panel-card">
-                <PanelHeader>
-                  <div>
-                    <strong>즉시 이동</strong>
-                  </div>
-                </PanelHeader>
-                <CompactPanelBody>
-                  <CompactPanelSummary>
-                    <span>{monitoringItems.length ? `${monitoringItems.length}개 채널이 연결되어 있습니다.` : "연결 채널 설정을 먼저 확인하세요."}</span>
-                    {grafanaDashboardUrl ? (
-                      <InsightLink href={grafanaDashboardUrl} target="_blank" rel="noreferrer noopener">
-                        Grafana 열기
-                      </InsightLink>
-                    ) : (
-                      <InsightLink as="span">환경 확인</InsightLink>
-                    )}
-                  </CompactPanelSummary>
-                </CompactPanelBody>
-              </CompactPanelCard>
-            </InsightRail>
-          </PanelGrid>
-
-          {secondaryPanels.length ? (
-            <AdditionalPanelsSection>
-              <AdditionalPanelsDisclosure>
-                <AdditionalPanelsSummary>
-                  <div>
-                    <strong>추가 Grafana 패널</strong>
-                    <span>{secondaryPanels.length}개</span>
-                  </div>
-                  <small>열기</small>
-                </AdditionalPanelsSummary>
-                <AdditionalPanelsGrid>
-                  {secondaryPanels.map((panel: any, index: number) => {
-                    const panelUrl = grafanaPanelsCanEmbed ? buildGrafanaPanelEmbedUrl(grafanaDashboardUrl, panel.panelId) : ""
-                    return (
-                      <PanelCard key={`secondary-${panel.key}`} data-ui="monitoring-panel-card">
-                        <PanelHeader>
-                          <div>
-                            <strong>{panel.title}</strong>
-                          </div>
-                          {grafanaDashboardUrl ? (
-                            <LaunchLink href={panelUrl || grafanaDashboardUrl} target="_blank" rel="noreferrer noopener">
-                              새 창
-                            </LaunchLink>
-                          ) : null}
-                        </PanelHeader>
-                        <PanelBody>
-                          {panelUrl ? (
-                            <DeferredPanelFrame
-                              eager={false}
-                              activationDelayMs={index * DASHBOARD_PANEL_STAGGER_MS}
-                              src={panelUrl}
-                              title={panel.title}
-                            />
-                          ) : (
-                            <PanelFallback>
-                              <strong>{grafanaPanelFallbackTitle}</strong>
-                              <span>{grafanaPanelFallbackBody}</span>
-                            </PanelFallback>
-                          )}
-                        </PanelBody>
-                      </PanelCard>
-                    )
-                  })}
-                </AdditionalPanelsGrid>
-              </AdditionalPanelsDisclosure>
-            </AdditionalPanelsSection>
-          ) : null}
-
-          <ContextGrid>
-            <ContextSection>
-              <SectionHeader>
-                <h2>운영 링크</h2>
-              </SectionHeader>
-              <AdminInfoList>
-                {quickActions.map((action: any) => (
-                  <Link key={action.key} href={action.href} passHref legacyBehavior>
-                    <AdminInfoLinkCard
-                      $withIcon={false}
-                      target={action.href.startsWith("http") ? "_blank" : undefined}
-                      rel={action.href.startsWith("http") ? "noreferrer noopener" : undefined}
-                    >
-                      <strong>{action.label}</strong>
-                    </AdminInfoLinkCard>
-                  </Link>
-                ))}
-              </AdminInfoList>
-            </ContextSection>
-
-            <ContextSection>
-              <SectionHeader>
-                <h2>연결된 채널</h2>
-              </SectionHeader>
-              <ContextLinkGrid>
-                {monitoringItems.map((item: any) => (
-                  <ContextMonitoringLinkCard key={item.key} href={item.href} target="_blank" rel="noreferrer noopener">
-                    <span className="iconWrap">{renderMonitoringBrand(item.brand.icon, item.brand.fallbackIcon, item.title)}</span>
-                    <span className="copy">
-                      <strong>{item.title}</strong>
-                      <span>{item.status}</span>
+            <PrioritySection>
+              <PanelHeader>
+                <h2>Steady-state guard</h2>
+              </PanelHeader>
+              <StatusRows data-ui="dashboard-guard-rows">
+                {priorityRows.map((row: any) => (
+                  <StatusRow key={row.key} data-tone={row.tone}>
+                    <span>
+                      <StatusDot data-tone={row.tone} aria-hidden="true" />
+                      <span>
+                        <strong>{row.title}</strong>
+                        <small>{row.summary}</small>
+                      </span>
                     </span>
-                  </ContextMonitoringLinkCard>
+                    <PrioritySummary data-tone={row.tone}>{row.actionLabel}</PrioritySummary>
+                  </StatusRow>
                 ))}
-              </ContextLinkGrid>
-            </ContextSection>
-          </ContextGrid>
+              </StatusRows>
+            </PrioritySection>
+
+            <PanelCard data-size="wide">
+              <PanelHeader>
+                <h2>Live logs</h2>
+                <span>Loki · production</span>
+              </PanelHeader>
+              <LogLines>
+                {logRows.map((row: any) => (
+                  <LogLine key={row.key} data-tone={row.tone}>
+                    <span>{row.time}</span>
+                    <p>
+                      {row.message}
+                      <small>{row.detail}</small>
+                    </p>
+                  </LogLine>
+                ))}
+              </LogLines>
+            </PanelCard>
+          </OpsGrid>
         </Shell>
       </Main>
     </AdminShell>


### PR DESCRIPTION
## 관련 이슈

close #1101

## 작업 배경

- `/admin/dashboard`가 V4 HTML의 `dashboard()`/`ops()` 운영 화면과 다른 우선 점검/Grafana 중심 구조로 렌더링되어, 관리자 V4 적용 순서 중 `운영 대시보드` 화면을 기준 구조에 맞춘다.
- 기존 backend health/dashboard snapshot 데이터 연결은 유지하고, 하드코딩 화면으로 대체하지 않는다.

## 작업 내용

- 운영 대시보드 화면을 V4 기준의 `Operations` hero, metric strip, `Public read latency`, `Steady-state guard`, `Live logs` 구조로 재배치했다.
- `system health`와 `dashboard snapshot` 실제 응답에서 KPI, guard row, chart bar, log row를 계산하도록 연결을 유지했다.
- V4 운영 구조를 기준으로 admin layout/source/perf e2e 계약을 갱신했다.
- 더 이상 렌더링하지 않는 Grafana/quick action 계산과 props 전달을 제거했다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`: exit 0
  - `yarn --cwd front playwright test e2e/admin-dashboard-state.spec.ts e2e/admin-layout-regression.spec.ts e2e/admin-surface-primitives.spec.ts --workers=1`: 24 passed
  - `yarn --cwd front build`: exit 0
  - `node front/scripts/check-bundle-size.mjs`: OK
  - `yarn --cwd front playwright test e2e/perf-layout.spec.ts --workers=1`: 6 passed
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 운영 대시보드 V4 구조 | macOS / Chromium / 1440x900 | QA bypass dev server + Playwright screenshot | 로컬 증거 `/private/tmp/admin-dashboard-v4-1440.png` (GitHub CLI 단독 환경이라 이미지 첨부 업로드 불가) | Operations hero, metric strip, Public read latency, Steady-state guard, Live logs 렌더 확인 |
| 대시보드 상태/레이아웃/소스 계약 | macOS / Chromium | `admin-dashboard-state`, `admin-layout-regression`, `admin-surface-primitives` | 24 passed | 통과 |
| 프로덕션 빌드 | local Next.js build | `yarn --cwd front build` | `/admin/dashboard` route 6.53 kB, First Load 149 kB | 통과 |
| 번들 예산 | local bundle-size | `node front/scripts/check-bundle-size.mjs` | `/admin` gzip current 138.3KB <= budget 148.2KB | 통과 |
| perf layout 회귀 | macOS / Chromium | `e2e/perf-layout.spec.ts` | 6 passed | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `AdminDashboardWorkspaceView.tsx`가 V4 HTML의 `dashboard(){return ops()}` 구조와 대응되는지 확인해 주세요.
  - `AdminDashboardWorkspacePage.tsx`에서 chart/log/guard 데이터가 backend snapshot 기반으로 계산되는지 확인해 주세요.

## 리스크

- `AdminDashboardWorkspace.styles.layout.ts`는 기존 파일 크기 경고가 남아 있다. 이번 PR은 화면 구조 정렬에 한정했고, 파일 분리는 별도 작업에서 처리하는 편이 안전하다.
- 로컬 스크린샷 증거는 GitHub CLI만으로 직접 첨부하지 못해 PR 본문에는 경로와 자동 검증 결과를 함께 남겼다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 관리자 대시보드가 새 운영 화면 구성으로 전환되어, 상태 요약, 차트, 로그가 한 화면에 더 명확하게 표시됩니다.
  * 주요 작업 진입점이 정리되어 **Doctor 실행**과 **Rollback** 링크를 바로 사용할 수 있습니다.

* **Bug Fixes**
  * 대시보드 첫 화면의 레이아웃 기준과 표시 순서를 조정해, 데스크톱·태블릿·모바일에서 주요 섹션이 더 안정적으로 보이도록 개선했습니다.
  * 상태 카드와 로그 영역의 가시성 및 스크롤/폭 동작을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->