### PR TITLE
[Fix] CD live admin dashboard guard 계약 정렬

### DIFF
--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -577,7 +577,7 @@ test.describe("live production e2e", () => {
     const dashboardKpiRail = page.locator('[data-ui="monitoring-service-rail"]')
     await expect(dashboardKpiRail).toBeVisible()
     await expect(dashboardKpiRail.getByText("서비스 상태")).toBeVisible()
-    await expect(page.getByRole("heading", { name: "우선 점검 항목" })).toBeVisible()
+    await expect(page.getByRole("heading", { name: "Steady-state guard" })).toBeVisible()
 
     await expectLiveAdminRoute(page, apiBaseUrl, "/admin/cloud", adminCloudHeadingPattern, "admin cloud")
     const visibleCloudUploadButtons = page


### PR DESCRIPTION
## 관련 이슈

close #1107

## 작업 배경

- PR #1106 merge 후 새 `Deploy to Home Server` run `28139347324`에서 live e2e가 다시 실패했습니다.
- `/admin/dashboard`의 h1 `운영 상태와 복구`와 KPI rail `서비스 상태`는 통과했지만, 다음 assertion이 이전 copy `우선 점검 항목`을 기다렸습니다.
- 실제 구현과 CD artifact snapshot의 guard section heading은 `Steady-state guard`입니다.

## 작업 내용

- `front/e2e/live.spec.ts`의 dashboard guard section assertion을 실제 렌더링 heading `Steady-state guard`와 맞췄습니다.
- UI 구현, 인증, 배포 workflow는 변경하지 않았습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`: exit 0
  - `yarn --cwd front playwright:preflight`: exit 0
  - `rg -n "Steady-state guard|우선 점검 항목" front/e2e/live.spec.ts front/src/routes/Admin/AdminDashboardWorkspaceView.tsx`: spec와 구현이 `Steady-state guard`로 일치
  - `yarn --cwd front playwright test e2e/live.spec.ts --grep "로그인 후 핵심 운영 경로" --workers=1`: exit 0, 로컬 live credential 부재로 1 skipped

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| CD 실패 원인 | GitHub Actions | `Deploy to Home Server` run 로그와 Playwright artifact 확인 | https://github.com/AquilaXk/aquila-blog/actions/runs/28139347324 | `우선 점검 항목` heading assertion 실패 확인 |
| Dashboard guard 계약 | local | `rg -n "Steady-state guard|우선 점검 항목" front/e2e/live.spec.ts front/src/routes/Admin/AdminDashboardWorkspaceView.tsx` | 명령 출력 | spec와 구현이 `Steady-state guard`로 일치 |
| Playwright launcher 계약 | local | `yarn --cwd front playwright:preflight` | exit 0 | 통과 |
| Target live scenario | local | `yarn --cwd front playwright test e2e/live.spec.ts --grep "로그인 후 핵심 운영 경로" --workers=1` | exit 0, 1 skipped | 로컬 live credential 부재로 skip, PR/CD에서 실제 credential 경로 확인 예정 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `front/e2e/live.spec.ts`의 dashboard guard heading assertion 한 줄입니다.

## 리스크

- 테스트 기대값만 실제 렌더링 copy와 맞추는 변경이라 제품 동작 리스크는 낮습니다.
- 로컬에서는 live credential이 없어 실제 로그인 경로가 skip되므로, PR CI와 merge 후 CD run으로 최종 확인합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
