### PR TITLE
[Style] 어드민 심볼 로고 적용

### DIFF
--- a/front/e2e/admin-surface-primitives.spec.ts
+++ b/front/e2e/admin-surface-primitives.spec.ts
@@ -465,6 +465,7 @@ test.describe("관리자 표면 공통 계약", () => {
     const source = readFileSync(path.resolve(__dirname, "../src/routes/Admin/AdminShell.tsx"), "utf8")
 
     expect(source).toContain('import ProfileImage from "src/components/ProfileImage"')
+    expect(source).toContain('import BrandLogoMark from "src/components/branding/BrandMark"')
     expect(source).toContain("profileSnapshot?: AdminShellProfileSnapshot | null")
     expect(source).toContain('const sidebarIdentityName = (member.nickname || member.username || "관리자").trim()')
     expect(source).toContain('const brandTitle = (profileSnapshot?.blogTitle || member.blogTitle || CONFIG.blog.title || "AquilaLog").trim()')
@@ -489,6 +490,7 @@ test.describe("관리자 표면 공통 계약", () => {
     expect(source).not.toContain("<SidebarSectionLabel>관리 메뉴</SidebarSectionLabel>")
     expect(source.indexOf("<BrandBlock>")).toBeLessThan(source.indexOf("<SidebarNavSection>"))
     expect(source.indexOf("<SidebarNavSection>")).toBeLessThan(source.indexOf("<SidebarProfile>"))
+    expect(getStyledComponentBlock(source, "BrandMark")).not.toContain("border: 1px solid")
     expect(source).not.toContain('<SidebarStatusCard aria-label="현재 화면">')
     expect(source).not.toContain("SidebarCardTitle")
   })

--- a/front/src/routes/Admin/AdminShell.tsx
+++ b/front/src/routes/Admin/AdminShell.tsx
@@ -272,14 +272,11 @@ const BrandBlock = styled.div`
 `
 
 const BrandMark = styled.div`
-  width: 1.72rem;
-  height: 1.72rem;
-  border-radius: 2px;
+  width: 1.9rem;
+  height: 1.9rem;
   display: grid;
   place-items: center;
-  border: 1px solid ${adminBorderStrong};
   background: transparent;
-  color: ${adminTextPrimary};
 
   .brandLogoMark {
     display: block;


### PR DESCRIPTION
## 관련 이슈

close #1109

## 작업 배경

- QA 요청에 따라 어드민 공통 shell의 브랜드 마크가 네모 프레임처럼 보이는 문제를 수정합니다.
- 기존 `BrandLogoMark`는 `/brand-mascot.png`를 쓰고 있었지만, admin shell wrapper가 border를 그려 실제 블로그 심볼보다 사각 프레임이 먼저 보였습니다.

## 작업 내용

- `AdminShell` sidebar brand mark wrapper에서 border/radius/color 프레임을 제거했습니다.
- 브랜드 심볼 크기를 1.9rem로 조정해 `/brand-mascot.png`가 직접 보이도록 했습니다.
- 관리자 shell contract test에 `BrandLogoMark` 사용과 `BrandMark` border 제거 회귀 방지 assertion을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front lint --file src/routes/Admin/AdminShell.tsx --file e2e/admin-surface-primitives.spec.ts --file e2e/mobile-layout-admin.spec.ts`: exit 0
  - `yarn --cwd front playwright:preflight`: exit 0
  - `yarn --cwd front playwright test e2e/admin-surface-primitives.spec.ts -g "관리자 사이드바는 V4 reference rail 순서와 하단 프로필을 유지한다" --workers=1`: 1 passed
  - `yarn --cwd front playwright test e2e/mobile-layout-admin.spec.ts --workers=1`: 2 passed
  - `yarn --cwd front build`: exit 0
  - `node front/scripts/check-bundle-size.mjs`: checked routes OK

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 어드민 심볼 로고 | Chromium 1440x900 | QA bypass + route mock `/admin/posts` screenshot | local-only: `/private/tmp/aquila-blog-admin-symbol-logo.png` | sidebar brand가 네모 프레임 없이 `/brand-mascot.png` 심볼로 표시됨 |
| 로고 wrapper style | Chromium 1440x900 | DOM computed style 확인 | `imgSrc=/brand-mascot.png`, `wrapperBorder=0px none rgb(15, 23, 36)` | 사각 border wrapper 제거 확인 |
| 로컬 증거 업로드 제한 | GitHub PR | PR 생성 경로 점검 | 민감 정보 없는 route-mocked screenshot을 로컬 증거로 보관 | PR에는 local path와 DOM 증거를 기록 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `AdminShell`의 `BrandMark` styled wrapper에서만 프레임을 제거했습니다.
  - public header나 글 관리 동작은 변경하지 않았습니다.

## 리스크

- sidebar brand mark 크기가 1.72rem에서 1.9rem로 약간 커졌습니다. sidebar layout 폭은 그대로 유지됩니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 관리자 사이드바의 브랜드 마크가 더 크게 표시되도록 조정했고, 테두리와 둥근 모서리 스타일을 제거해 더 깔끔한 외형으로 정리했습니다.
  * 사이드바 하단 프로필과 주요 항목 순서가 기존대로 유지되는지 확인하는 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->