### PR TITLE
[Fix] Live editor list locator strict violation 수정

### DIFF
--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -419,7 +419,7 @@ test.describe("editor live visual regression", () => {
     await expect(preview.getByRole("heading", { name: "Live Markdown editor" })).toBeVisible()
     await expect(preview.locator("table")).toContainText(post507FinalTableTargetCell)
     await expect(preview.locator("pre")).toContainText(post507CodeText)
-    await expect(preview.getByRole("listitem", { name: post507ListText, exact: true })).toBeVisible()
+    await expect(preview.getByRole("listitem").filter({ hasText: post507ListText })).toBeVisible()
     await expect(page.locator("[data-table-affordance]")).toHaveCount(0)
   })
 
@@ -452,7 +452,7 @@ test.describe("editor live visual regression", () => {
       const preview = page.getByTestId("markdown-editor-preview-pane")
       await expect(preview.locator("table")).toContainText(post507FinalTableSelectAllNeedle)
       await expect(preview.locator("pre")).toContainText(post507CodeText)
-      await expect(preview.getByText(post507ListText)).toBeVisible()
+      await expect(preview.getByRole("listitem").filter({ hasText: post507ListText })).toBeVisible()
 
       await focusMarkdownEditor(page)
       await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A")
@@ -494,7 +494,7 @@ test.describe("editor live visual regression", () => {
     await expect(finalReferenceTable).toContainText(post507FinalTableTargetCell, { timeout: 30_000 })
     await expect(finalReferenceTable).toContainText(post507FinalTableSelectAllNeedle)
     await expect(tokenCodeBlock).toContainText(post507CodeText)
-    await expect(preview.getByText(post507ListText)).toBeVisible()
+    await expect(preview.getByRole("listitem").filter({ hasText: post507ListText })).toBeVisible()
 
     await expect(page.locator("[data-table-affordance]")).toHaveCount(0)
   })

--- a/front/e2e/editor-live-visual.spec.ts
+++ b/front/e2e/editor-live-visual.spec.ts
@@ -419,7 +419,7 @@ test.describe("editor live visual regression", () => {
     await expect(preview.getByRole("heading", { name: "Live Markdown editor" })).toBeVisible()
     await expect(preview.locator("table")).toContainText(post507FinalTableTargetCell)
     await expect(preview.locator("pre")).toContainText(post507CodeText)
-    await expect(preview.getByText(post507ListText)).toBeVisible()
+    await expect(preview.getByRole("listitem", { name: post507ListText, exact: true })).toBeVisible()
     await expect(page.locator("[data-table-affordance]")).toHaveCount(0)
   })
 


### PR DESCRIPTION
## 관련 이슈

close #1148

## 작업 배경

- Home Server Deploy workflow run 28216787413과 28219521179의 `Frontend Live E2E Verification` job이 `front/e2e/editor-live-visual.spec.ts:422`에서 strict mode violation으로 실패했습니다.
- `세션이랑 JWT` 텍스트가 preview paragraph와 list item에 모두 존재할 수 있는데 테스트가 전체 preview에서 `getByText`로 조회했습니다.

## 작업 내용

- live editor visual e2e의 list canary assertion을 `preview.getByRole("listitem").filter({ hasText })`로 좁혔습니다.
- 같은 파일의 저장글/507 canary list assertion도 동일하게 좁혀 broad `getByText` 재발을 막았습니다.
- 제품 코드, API, 저장/발행 동작은 변경하지 않았습니다.

## 검증

- 실행한 명령과 결과:
- `yarn --cwd front playwright:preflight`: exit 0
- `PLAYWRIGHT_USE_WEBSERVER=false PLAYWRIGHT_BASE_URL=https://www.aquilaxk.site E2E_API_BASE_URL=https://api.aquilaxk.site E2E_LIVE_EDITOR_507_CANARY=true yarn --cwd front playwright test e2e/editor-live-visual.spec.ts --workers=1 --max-failures=1`: 3 skipped, 로컬 세션에 live UI login credential이 없어 `test.skip(!hasUiLoginCredentials)` 조건이 적용됨
- `yarn --cwd front build`: exit 0
- `git diff --check`: exit 0
- `codex review --base origin/main --title "[Fix] Live editor list locator strict violation 수정 재검토"`: 추가 지적 0건

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 기존 CD 실패 | GitHub Actions | Home Server Deploy 실패 로그 확인 | https://github.com/AquilaXk/aquila-blog/actions/runs/28216787413 | `preview.getByText(post507ListText)`가 paragraph/list item 2개를 매칭해 strict violation |
| 최신 main CD 실패 | GitHub Actions | Home Server Deploy 실패 로그 확인 | https://github.com/AquilaXk/aquila-blog/actions/runs/28219521179 | 동일한 `preview.getByText(post507ListText)` strict violation 재현 |
| Playwright preflight | local macOS | `yarn --cwd front playwright:preflight` | command output | exit 0 |
| live editor visual e2e | local macOS -> live URL | live URL 대상 e2e 실행 | command output | 3 skipped, credential 부재로 로컬 실사용 검증은 CI/CD에서 확인 필요 |
| front build | local macOS | `yarn --cwd front build` | command output | exit 0 |
| Codex fallback review | GitHub PR review | CodeRabbit rate limit 후 Codex CLI fallback/re-review | PR review #4576935826, #4576947615 | 최초 1건 지적 반영, 재검토 0건 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `front/e2e/editor-live-visual.spec.ts`의 list assertion 범위 축소입니다.

## 리스크

- 테스트 locator만 좁히는 변경이라 제품 동작 리스크는 낮습니다.
- live credential이 로컬에 없어 실제 live e2e pass 여부는 PR CI/CD와 merge 후 Home Server Deploy에서 확인해야 합니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.