### PR TITLE
[Fix] Live editor 종료 동선 CD 실패 수정

### DIFF
--- a/front/e2e/live.spec.ts
+++ b/front/e2e/live.spec.ts
@@ -602,6 +602,12 @@ test.describe("live production e2e", () => {
     const previewPane = await appendMarkdownToEditor(page, liveEditorSmokeMarkdown)
     await expectLiveEditorHoverWheelScrollChain(page, previewPane)
 
+    const backToPostManagement = page.getByRole("button", { name: /글 관리/ }).first()
+    if (await backToPostManagement.isVisible().catch(() => false)) {
+      await backToPostManagement.click()
+      await expectLiveAdminRoute(page, apiBaseUrl, "/admin/posts", adminPostsHeadingPattern, "admin posts after editor")
+    }
+
     await page.getByRole("button", { name: "Logout", exact: true }).click()
     await expect(page).toHaveURL(/\/login/)
     await expect(page.getByRole("heading", { name: "로그인" })).toBeVisible()


### PR DESCRIPTION
## 관련 이슈

close #1069

## 작업 배경

- Home Server Deploy run `28220163503`의 `Frontend Live E2E Verification`이 실패했습니다.
- 실패 지점은 `front/e2e/live.spec.ts:605`의 `Logout` 버튼 클릭 대기 timeout입니다.
- 실패 artifact snapshot 기준 현재 화면은 V4 dedicated editor(`/editor/new`)이며, 공통 Header `Logout` 대신 `← 글 관리` 버튼만 있습니다.

## 작업 내용

- live e2e의 핵심 운영 경로 검증에서 editor 확인 후 `← 글 관리`로 `/admin/posts`에 복귀하도록 정렬했습니다.
- 기존 Header `Logout` 검증은 관리자 글 목록 복귀 후 그대로 수행합니다.
- dedicated editor V4 chrome에는 별도 logout action을 추가하지 않았습니다.

## 검증

- 실행한 명령과 결과:
- `yarn --cwd front playwright:preflight`: exit 0
- `PLAYWRIGHT_USE_WEBSERVER=false PLAYWRIGHT_BASE_URL=https://www.aquilaxk.site E2E_API_BASE_URL=https://api.aquilaxk.site yarn --cwd front playwright test e2e/live.spec.ts --grep "핵심 운영 경로" --workers=1 --max-failures=1`: 1 skipped, 로컬 live credential 부재
- `yarn --cwd front build`: exit 0
- `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| CD 실패 원인 | GitHub Actions | run `28220163503` job log와 Playwright snapshot 확인 | https://github.com/AquilaXk/aquila-blog/actions/runs/28220163503 | `/editor/new` 화면에서 Header `Logout` 미존재 |
| focused live spec | local macOS | live spec focused 실행 | command output | credential 부재로 1 skipped |
| frontend build | local macOS | `yarn --cwd front build` | command output | exit 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `front/e2e/live.spec.ts`의 editor 종료부입니다.

## 리스크

- 실제 live credential 환경에서만 최종 통과 여부가 확인됩니다. 로컬은 credential 부재로 focused live spec이 skip됐습니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
