### PR TITLE
[Style] 글 상세 프로필 액션 UI 정리

### DIFF
--- a/front/src/components/ProfileImage.tsx
+++ b/front/src/components/ProfileImage.tsx
@@ -48,6 +48,7 @@ const ProfileImage: React.FC<Props> = ({
       onError={handleImageError}
       style={{
         display: "block",
+        borderRadius: "50%",
         objectFit: "cover",
         objectPosition: "center 38%",
         ...(fillContainer

--- a/front/src/components/ProfileImage.tsx
+++ b/front/src/components/ProfileImage.tsx
@@ -48,7 +48,6 @@ const ProfileImage: React.FC<Props> = ({
       onError={handleImageError}
       style={{
         display: "block",
-        borderRadius: "50%",
         objectFit: "cover",
         objectPosition: "center 38%",
         ...(fillContainer

--- a/front/src/routes/Detail/PostDetail/PostHeader.styles.ts
+++ b/front/src/routes/Detail/PostDetail/PostHeader.styles.ts
@@ -76,10 +76,10 @@ export const StyledWrapper = styled.header `
     position: relative;
     width: 38px;
     height: 38px;
-    border-radius: 0;
+    border-radius: 50%;
     overflow: hidden;
-    border: 1px solid #c8ccd2;
-    background: #ffffff;
+    background: #f0f1f2;
+    box-shadow: inset 0 0 0 1px #dfe1e5;
 
     img {
       object-fit: cover;
@@ -145,6 +145,16 @@ export const StyledWrapper = styled.header `
     color: #8c9199;
   }
 
+  .metaUtilities {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 0.52rem;
+    min-width: 0;
+    margin-left: auto;
+  }
+
   .stats {
     display: inline-flex;
     align-items: center;
@@ -163,7 +173,6 @@ export const StyledWrapper = styled.header `
     align-items: center;
     flex-wrap: wrap;
     gap: 0.45rem;
-    margin-top: 0.5rem;
   }
 
   .authorUtilities[data-shell-only="true"] {
@@ -209,13 +218,13 @@ export const StyledWrapper = styled.header `
     display: inline-flex;
     align-items: center;
     gap: 0.42rem;
-    min-height: 34px;
-    padding: 0 0.76rem;
+    min-height: 40px;
+    padding: 0 0.9rem;
     border-radius: 6px;
     border: 1px solid #dfe1e5;
-    background: #ffffff;
+    background: transparent;
     color: #111216;
-    font-size: 0.82rem;
+    font-size: 0.9rem;
     font-weight: 700;
     cursor: pointer;
     transition:
@@ -238,7 +247,7 @@ export const StyledWrapper = styled.header `
   }
 
   .dangerButton {
-    border-color: #c33a3a;
+    border-color: #ead0d0;
     background: transparent;
     color: #c33a3a;
   }
@@ -357,6 +366,11 @@ export const StyledWrapper = styled.header `
     .metaRow {
       align-items: flex-start;
       flex-direction: column;
+    }
+
+    .metaUtilities {
+      justify-content: flex-start;
+      margin-left: 0;
     }
 
     .actions[data-hide-mobile="true"] {

--- a/front/src/routes/Detail/PostDetail/PostHeader.tsx
+++ b/front/src/routes/Detail/PostDetail/PostHeader.tsx
@@ -140,86 +140,91 @@ const PostHeader: React.FC<Props> = ({
             <div className="authorText">
               <strong>{authorName}</strong>
               {authorRole ? <div className="metaText">{authorRole}</div> : null}
-              {shouldRenderAuthorUtilities && (
-                <div className="authorUtilities" data-shell-only={authorUtilitiesShellOnly ? "true" : "false"}>
-                  {(showModifyAction || shellModifyFallback) && (
-                    <button
-                      type="button"
-                      className="adminButton"
-                      data-shell-fallback={shellModifyFallback ? "true" : "false"}
-                      onClick={onEditPost}
-                      disabled={adminActionPending}
-                    >
-                      <AppIcon name="edit" />
-                      <span>수정</span>
-                    </button>
-                  )}
-                  {(showDeleteAction || shellDeleteFallback) && (
-                    <button
-                      type="button"
-                      className="adminButton dangerButton"
-                      data-shell-fallback={shellDeleteFallback ? "true" : "false"}
-                      onClick={onDeletePost}
-                      disabled={adminActionPending}
-                    >
-                      <AppIcon name="trash" />
-                      <span>{adminActionPending ? "삭제 중..." : "삭제"}</span>
-                    </button>
-                  )}
-                </div>
-              )}
             </div>
           </div>
         )}
 
-        {showEngagement ? (
-          <div className="actions" data-hide-mobile={hideActionButtonsOnMobile}>
-            <div className="engagementRow" aria-label="post engagement">
-              <div className="stats" aria-label="post stats">
-                <span className="statChip">{publishedAt}</span>
-                <span className="statChip">{readTimeText}</span>
-                <span className="statChip">{viewText}</span>
-                {modifiedAt ? <span className="statChip">UPDATED {modifiedAt}</span> : null}
+        {shouldRenderAuthorUtilities || showEngagement ? (
+          <div className="metaUtilities">
+            {shouldRenderAuthorUtilities && (
+              <div className="authorUtilities" data-shell-only={authorUtilitiesShellOnly ? "true" : "false"}>
+                {(showModifyAction || shellModifyFallback) && (
+                  <button
+                    type="button"
+                    className="adminButton"
+                    data-shell-fallback={shellModifyFallback ? "true" : "false"}
+                    onClick={onEditPost}
+                    disabled={adminActionPending}
+                  >
+                    <AppIcon name="edit" />
+                    <span>수정</span>
+                  </button>
+                )}
+                {(showDeleteAction || shellDeleteFallback) && (
+                  <button
+                    type="button"
+                    className="adminButton dangerButton"
+                    data-shell-fallback={shellDeleteFallback ? "true" : "false"}
+                    onClick={onDeletePost}
+                    disabled={adminActionPending}
+                  >
+                    <AppIcon name="trash" />
+                    <span>{adminActionPending ? "삭제 중..." : "삭제"}</span>
+                  </button>
+                )}
               </div>
-              <button
-                type="button"
-                className="likeButton"
-                aria-pressed={actorHasLiked}
-                data-active={actorHasLiked}
-                data-hide-desktop={hideLikeActionOnDesktop}
-                data-hide-mobile={hideActionButtonsOnMobile}
-                disabled={likePending}
-                onClick={onToggleLike}
-              >
-                <AppIcon name={actorHasLiked ? "heart-filled" : "heart"} />
-                <span>좋아요 {likesCount ?? data.likesCount ?? 0}</span>
-              </button>
-
-              {onSharePost && (
-                <button
-                  type="button"
-                  className="shareButton"
-                  data-hide-desktop={hideShareActionOnDesktop}
-                  data-hide-mobile={hideActionButtonsOnMobile}
-                  aria-label="게시글 공유"
-                  onClick={onSharePost}
-                >
-                  <AppIcon name="share" />
-                  <span>공유</span>
-                </button>
-              )}
-            </div>
-            {shareFeedback && (
-              <span
-                className="shareFeedbackPill"
-                data-hide-desktop={hideShareActionOnDesktop}
-                data-hide-mobile={hideActionButtonsOnMobile}
-                role="status"
-                aria-live="polite"
-              >
-                {shareFeedbackMessage}
-              </span>
             )}
+
+            {showEngagement ? (
+              <div className="actions" data-hide-mobile={hideActionButtonsOnMobile}>
+                <div className="engagementRow" aria-label="post engagement">
+                  <div className="stats" aria-label="post stats">
+                    <span className="statChip">{publishedAt}</span>
+                    <span className="statChip">{readTimeText}</span>
+                    <span className="statChip">{viewText}</span>
+                    {modifiedAt ? <span className="statChip">UPDATED {modifiedAt}</span> : null}
+                  </div>
+                  <button
+                    type="button"
+                    className="likeButton"
+                    aria-pressed={actorHasLiked}
+                    data-active={actorHasLiked}
+                    data-hide-desktop={hideLikeActionOnDesktop}
+                    data-hide-mobile={hideActionButtonsOnMobile}
+                    disabled={likePending}
+                    onClick={onToggleLike}
+                  >
+                    <AppIcon name={actorHasLiked ? "heart-filled" : "heart"} />
+                    <span>좋아요 {likesCount ?? data.likesCount ?? 0}</span>
+                  </button>
+
+                  {onSharePost && (
+                    <button
+                      type="button"
+                      className="shareButton"
+                      data-hide-desktop={hideShareActionOnDesktop}
+                      data-hide-mobile={hideActionButtonsOnMobile}
+                      aria-label="게시글 공유"
+                      onClick={onSharePost}
+                    >
+                      <AppIcon name="share" />
+                      <span>공유</span>
+                    </button>
+                  )}
+                </div>
+                {shareFeedback && (
+                  <span
+                    className="shareFeedbackPill"
+                    data-hide-desktop={hideShareActionOnDesktop}
+                    data-hide-mobile={hideActionButtonsOnMobile}
+                    role="status"
+                    aria-live="polite"
+                  >
+                    {shareFeedbackMessage}
+                  </span>
+                )}
+              </div>
+            ) : null}
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
## 🔗 Related Issue
- close #1151

## 📝 Summary
- 글 상세 헤더의 작성자 프로필 옆에 붙어 있던 관리자 `수정/삭제` 액션을 별도 utility 영역으로 분리했습니다.
- 글 상세 작성자 프로필 이미지는 원형 avatar 마스크로 표시되도록 정리했습니다.
- 공통 `ProfileImage`는 썸네일 회귀를 막기 위해 shape-neutral 상태를 유지하고, 프로필 UI별 컨테이너에서 원형을 책임지도록 했습니다.

## 🛠 Changes
- `PostHeader`에서 작성자 메타와 관리자 액션 JSX를 분리했습니다.
- 관리자 액션 버튼을 좋아요/공유 버튼과 같은 40px outline 톤으로 낮추고, 삭제 버튼은 낮은 대비 danger border만 유지했습니다.
- 상세 작성자 avatar 컨테이너를 원형으로 정리하고, 공통 이미지 컴포넌트 전역 원형화로 썸네일이 잘리는 회귀는 제거했습니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [x] 코드리뷰 fallback 결과를 확인했는가?
- [ ] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `yarn --cwd front build`: exit 0, 2회 연속 통과. pre-commit hook에서도 추가 1회 통과.
- `node front/scripts/check-bundle-size.mjs`: exit 0, 2회 연속 통과. `/posts/[id]` gzip 159.4KB, budget 168.6KB.
- `yarn --cwd front playwright:preflight`: exit 0, 2회 연속 통과.
- `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`: exit 0, 8 passed, 2회 연속 통과.
- `yarn --cwd front test:e2e:smoke`: pre-commit hook에서 exit 0, 69 passed.
- `yarn --cwd front lint --file src/routes/Detail/PostDetail/PostHeader.tsx --file src/routes/Detail/PostDetail/PostHeader.styles.ts`: exit 0.
- Browser QA `http://127.0.0.1:3100/posts/507` desktop 1440x900: page identity 정상, blank 아님, framework overlay 없음, console error/warn 없음.
- Browser QA `http://127.0.0.1:3100/posts/507` mobile 393x852: page identity 정상, blank 아님, framework overlay 없음, console error/warn 없음.
- Playwright admin shell visual check: desktop/mobile 모두 `authorContainsAdminButtons=false`, 버튼 텍스트 `수정`, `삭제` 확인.
- Codex CLI fallback review 1차: `ProfileImage` 전역 원형화 회귀 가능성 1건 확인 후 PR review로 게시.
- Codex CLI fallback review 재검토: actionable finding 0건.

## 📸 Screenshot / API Example
| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 공개 상세 프로필 원형 렌더 | Desktop 1440x900 | Browser screenshot + DOM/log check | Browser screenshot emitted in Codex thread | 통과 |
| 공개 상세 모바일 프로필 원형 렌더 | Mobile 393x852 | Browser screenshot + DOM/log check | Browser screenshot emitted in Codex thread | 통과 |
| 관리자 액션 위치 | Desktop 1440x900 | Playwright admin shell screenshot + rect check | Local-only `/private/tmp/aquila-detail-admin-desktop.png` | 통과, 작성자 블록 밖 utility 영역 |
| 관리자 액션 위치 | Mobile 393x852 | Playwright admin shell screenshot + rect check | Local-only `/private/tmp/aquila-detail-admin-mobile.png` | 통과, 작성자 아래 별도 utility 줄 |

스크린샷은 GitHub 첨부 업로드 기능이 현재 CLI/connector 경로에 없어 PR에 직접 업로드하지 않고 local-only evidence로 남겼습니다. 민감 데이터는 없으며, 필요하면 같은 명령으로 재캡처할 수 있습니다.

## ⚠️ Risk & Rollback
- 예상 리스크: 상세 헤더의 action row 위치가 바뀌므로 기존 관리자 화면의 시각 배치가 달라집니다. 공개 상세의 좋아요/공유 동작과 관리자 수정/삭제 handler 계약은 유지했습니다.
- 롤백 방법: `867d158e`, `42da8900` 커밋을 revert합니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 [코드 주석 정책](https://github.com/AquilaXk/aquila-blog/blob/main/docs/design/code-comment-policy.md)에 맞는 이유/불변조건/운영 영향을 설명하는가?
