### PR TITLE
[Fix] 클라우드 동영상 미리보기 재생 UI 정직화

### DIFF
--- a/front/e2e/admin-cloud.spec.ts
+++ b/front/e2e/admin-cloud.spec.ts
@@ -588,11 +588,18 @@ test.describe("관리자 클라우드", () => {
     await expect(page.getByLabel("사진 썸네일")).toHaveCount(0)
 
     await page.locator('button[title="deploy-walkthrough.mp4"]').click()
-    await expect(page.getByRole("heading", { name: "동영상 플레이어" })).toBeVisible()
-    await expect(page.getByText("IINA playback model")).toBeVisible()
-    await expect(page.getByText("챕터 3개")).toBeVisible()
-    await expect(page.getByRole("button", { name: "자막" })).toBeVisible()
-    await expect(page.getByText("재생 기록 00:00")).toBeVisible()
+    await expect(page.getByRole("heading", { name: "클라우드 동영상" })).toBeVisible()
+    await expect(page.getByText("IINA playback model")).toHaveCount(0)
+    await expect(page.getByText(/IINA/)).toHaveCount(0)
+    await expect(page.getByText(/mpv/i)).toHaveCount(0)
+    await expect(page.getByText(/챕터 \d+개/)).toHaveCount(0)
+    await expect(page.getByText(/재생 기록/)).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "자막" })).toHaveCount(0)
+
+    const video = page.locator("video")
+    await expect(video).toBeVisible()
+    await page.getByRole("button", { name: "1.5x" }).click()
+    await expect.poll(async () => video.evaluate((node) => (node as HTMLVideoElement).playbackRate)).toBe(1.5)
 
     await expect(page.getByRole("button", { name: "deploy-walkthrough.mp4 삭제" })).toHaveCount(0)
     await page.getByRole("checkbox", { name: "deploy-walkthrough.mp4 선택" }).check()

--- a/front/src/routes/Admin/AdminCloudWorkspaceModel.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspaceModel.ts
@@ -25,19 +25,6 @@ export const CLOUD_FILTERS: Array<{ value: CloudMediaFilter; label: string }> = 
   { value: "VIDEO", label: "동영상" },
 ]
 
-export const IINA_SHORTCUTS = [
-  { key: "Space", label: "재생/일시정지" },
-  { key: "← / →", label: "5초 이동" },
-  { key: "J / L", label: "챕터 이동" },
-  { key: "S", label: "자막 전환" },
-]
-
-export const IINA_CHAPTERS = [
-  { at: "00:00", label: "시작" },
-  { at: "01:12", label: "핵심 구간" },
-  { at: "03:40", label: "점검 메모" },
-]
-
 export const PLAYBACK_SPEEDS = [0.75, 1, 1.25, 1.5, 2] as const
 
 export const getCloudKindLabel = (kind: CloudMediaFilter) => {

--- a/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
+++ b/front/src/routes/Admin/AdminCloudWorkspacePage.tsx
@@ -21,8 +21,6 @@ import {
 import AppIcon from "src/components/icons/AppIcon"
 import {
   CLOUD_FILTERS,
-  IINA_CHAPTERS,
-  IINA_SHORTCUTS,
   PLAYBACK_SPEEDS,
   doesCloudFileMatchFilters,
   formatCloudDate,
@@ -89,7 +87,6 @@ import {
   SkeletonRow,
   SkeletonRows,
   ToastViewport,
-  Timeline,
   UploadZone,
   UploadInput,
   ViewModeButton,
@@ -376,25 +373,29 @@ type VideoPreviewProps = {
 }
 
 const VideoPreview = ({ file, contentUrl }: VideoPreviewProps) => {
+  const videoRef = useRef<HTMLVideoElement>(null)
   const [speed, setSpeed] = useState<(typeof PLAYBACK_SPEEDS)[number]>(1)
-  const [subtitlesEnabled, setSubtitlesEnabled] = useState(true)
+
+  useEffect(() => {
+    const video = videoRef.current
+    if (!video) return
+
+    video.playbackRate = speed
+  }, [speed, contentUrl])
 
   return (
     <PreviewStage>
       <PreviewHeader>
-        <h3>동영상 플레이어</h3>
+        <h3>클라우드 동영상</h3>
       </PreviewHeader>
       <VideoFrame>
-        <video src={contentUrl} controls preload="metadata" />
-        <PlayerBar aria-label="IINA playback model">
-          <Timeline aria-hidden="true" />
+        <video ref={videoRef} src={contentUrl} controls preload="metadata" playsInline />
+        <PlayerBar aria-label="클라우드 동영상 재생 제어">
           <InlineList>
-            <span>IINA playback model</span>
-            <span>Range streaming</span>
-            <span>챕터 {IINA_CHAPTERS.length}개</span>
-            <span>재생 기록 00:00</span>
+            <span>브라우저 기본 재생</span>
+            <span>원본 파일 재생</span>
           </InlineList>
-          <FilterGroup aria-label="동영상 재생 제어">
+          <FilterGroup aria-label="동영상 재생 속도">
             {PLAYBACK_SPEEDS.map((candidate) => (
               <GhostButton
                 key={candidate}
@@ -405,21 +406,7 @@ const VideoPreview = ({ file, contentUrl }: VideoPreviewProps) => {
                 {candidate}x
               </GhostButton>
             ))}
-            <GhostButton
-              type="button"
-              data-active={subtitlesEnabled ? "true" : "false"}
-              onClick={() => setSubtitlesEnabled((current) => !current)}
-            >
-              자막
-            </GhostButton>
           </FilterGroup>
-          <InlineList aria-label="키보드 단축키">
-            {IINA_SHORTCUTS.map((shortcut) => (
-              <span key={shortcut.key}>
-                {shortcut.key} {shortcut.label}
-              </span>
-            ))}
-          </InlineList>
         </PlayerBar>
       </VideoFrame>
     </PreviewStage>


### PR DESCRIPTION
## 🔗 Related Issue
- close #1153

## 📝 Summary
- 관리자 클라우드 동영상 preview가 IINA/MPV급 기능처럼 보이던 정적 라벨과 실제 데이터 없는 보조 UI를 제거했습니다.
- 남아 있는 속도 버튼은 실제 `HTMLVideoElement.playbackRate`에 연결해 화면에 보이는 제어가 실제 동작하게 했습니다.

## 🛠 Changes
- `IINA playback model`, 정적 챕터 수, 정적 재생 기록, 정적 단축키, 자막 버튼을 동영상 preview에서 제거했습니다.
- 동영상 preview heading과 보조 라벨을 `클라우드 동영상`, `브라우저 기본 재생`, `원본 파일 재생`으로 중립화했습니다.
- 속도 버튼 클릭 시 video element의 `playbackRate`가 변경되도록 `videoRef` 연결을 추가했습니다.
- admin-cloud E2E에서 오해 라벨 제거와 `1.5x` 실제 재생 속도 변경을 검증하도록 계약을 갱신했습니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Editor / Content Rendering
- [x] Admin / Dashboard
- [x] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [ ] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `yarn --cwd front playwright:preflight`: exit 0
- `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/admin-cloud.spec.ts --workers=1`: RED 확인 후 수정, 24 passed, 이후 2회차 24 passed
- `yarn --cwd front build`: exit 0
- `env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn --cwd front playwright test e2e/perf.spec.ts --workers=1`: 1 passed, 이후 2회차 1 passed

## 📸 Screenshot / API Example
| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 동영상 preview 정직화 | Chromium 1440x900 local mock | `/admin/cloud`에서 `deploy-walkthrough.mp4` preview를 열고 `1.5x` 클릭 | local evidence: `/private/tmp/admin-cloud-video-preview-after.png`; Codex chat에 렌더 확인 이미지 표시 | IINA/mpv/챕터/재생 기록/자막 버튼 없이 중립 라벨과 속도 버튼만 노출 |

## ⚠️ Risk & Rollback
- 예상 리스크: 관리자 preview의 보조 안내 문구가 줄어들지만, 실제 제공하지 않는 기능을 제거하는 변경이라 사용자 기능 손실은 없습니다.
- 롤백 방법: 이 PR의 단일 commit `2330c315`를 revert합니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 코드 주석 정책에 맞는 이유/불변조건/운영 영향을 설명하는가?

SEO/권한/캐시/배포 영향: 없음. API/DB/계약 변경 없음. 새 코드 주석 없음.