### PR TITLE
[Fix] 클라우드 파일 Range GET을 storage range 요청으로 개선

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudController.kt
@@ -38,7 +38,6 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import java.io.ByteArrayOutputStream
-import java.io.EOFException
 import java.io.InputStream
 import java.nio.charset.StandardCharsets
 import io.swagger.v3.oas.annotations.parameters.RequestBody as OpenApiRequestBody
@@ -247,35 +246,31 @@ class ApiV1AdmCloudController(
         id: Long,
         request: HttpServletRequest,
     ): ResponseEntity<Resource> {
-        val content =
-            cloudFileService.openContent(
-                ownerMemberId = securityUser.id,
-                fileId = id,
-            )
-        val storedObject = content.storedObject
-        val totalLength = storedObject.contentLength ?: -1
         val rangeHeader = request.getHeader(HttpHeaders.RANGE)
 
         // 동영상 seek 호환을 위해 단일 byte range만 허용하고 multi-range는 거절한다.
         if (!rangeHeader.isNullOrBlank()) {
-            if (totalLength <= 0) {
-                storedObject.close()
-                return noStoreHeaders(
-                    ResponseEntity
-                        .status(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
-                        .header(HttpHeaders.CONTENT_RANGE, "bytes */*"),
-                ).build()
-            }
-
+            val file =
+                cloudFileService.get(
+                    ownerMemberId = securityUser.id,
+                    fileId = id,
+                )
+            val totalLength = file.byteSize
             val range = parseSingleRange(rangeHeader, totalLength)
             if (range == null) {
-                storedObject.close()
                 return noStoreHeaders(
                     ResponseEntity
                         .status(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
                         .header(HttpHeaders.CONTENT_RANGE, "bytes */$totalLength"),
                 ).build()
             }
+            val content =
+                cloudFileService.openContentRange(
+                    ownerMemberId = securityUser.id,
+                    fileId = id,
+                    range = range,
+                )
+            val storedObject = content.storedObject
 
             return noStoreHeaders(
                 ResponseEntity
@@ -285,9 +280,16 @@ class ApiV1AdmCloudController(
                     .header(HttpHeaders.CONTENT_RANGE, "bytes ${range.first}-${range.last}/$totalLength")
                     .header(HttpHeaders.CONTENT_DISPOSITION, inlineDisposition(content.file.originalFilename))
                     .contentLength(range.last - range.first + 1),
-            ).body(InputStreamResource(sliceStream(storedObject.inputStream, range)))
+            ).body(InputStreamResource(storedObject.inputStream))
         }
 
+        val content =
+            cloudFileService.openContent(
+                ownerMemberId = securityUser.id,
+                fileId = id,
+            )
+        val storedObject = content.storedObject
+        val totalLength = storedObject.contentLength ?: -1
         val responseBuilder =
             noStoreHeaders(
                 ResponseEntity
@@ -378,25 +380,6 @@ class ApiV1AdmCloudController(
         return start..end
     }
 
-    private fun skipFully(
-        input: InputStream,
-        count: Long,
-    ) {
-        var remaining = count
-        while (remaining > 0) {
-            val skipped = input.skip(remaining)
-            if (skipped > 0) {
-                remaining -= skipped
-                continue
-            }
-
-            if (input.read() == -1) {
-                throw EOFException("Unexpected EOF while skipping stream")
-            }
-            remaining -= 1
-        }
-    }
-
     private fun readBoundedPartBytes(
         input: InputStream,
         expectedBytes: Long,
@@ -416,38 +399,5 @@ class ApiV1AdmCloudController(
         }
 
         return output.toByteArray()
-    }
-
-    private fun sliceStream(
-        source: InputStream,
-        range: LongRange,
-    ): InputStream {
-        skipFully(source, range.first)
-        return object : InputStream() {
-            private var remaining = range.last - range.first + 1
-
-            override fun read(): Int {
-                if (remaining <= 0) return -1
-                val value = source.read()
-                if (value >= 0) remaining -= 1
-                return value
-            }
-
-            override fun read(
-                b: ByteArray,
-                off: Int,
-                len: Int,
-            ): Int {
-                if (remaining <= 0) return -1
-                val allowed = minOf(remaining, len.toLong()).toInt()
-                val read = source.read(b, off, allowed)
-                if (read > 0) remaining -= read.toLong()
-                return read
-            }
-
-            override fun close() {
-                source.close()
-            }
-        }
     }
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -140,6 +140,25 @@ class CloudFileService(
         )
     }
 
+    @Transactional(readOnly = true)
+    fun openContentRange(
+        ownerMemberId: Long,
+        fileId: Long,
+        range: LongRange,
+    ): CloudFileContent {
+        val file =
+            cloudFileRepository.findActiveByIdAndOwner(fileId, ownerMemberId)
+                ?: throw AppException("404-1", "클라우드 파일을 찾을 수 없습니다.")
+        val storedObject =
+            cloudStoragePort.openRange(file.objectKey, range)
+                ?: throw AppException("404-1", "클라우드 파일을 찾을 수 없습니다.")
+
+        return CloudFileContent(
+            file = file.toDto(),
+            storedObject = storedObject,
+        )
+    }
+
     @Transactional
     fun delete(
         ownerMemberId: Long,

--- a/back/src/main/kotlin/com/back/global/storage/adapter/CloudStorageAdapter.kt
+++ b/back/src/main/kotlin/com/back/global/storage/adapter/CloudStorageAdapter.kt
@@ -108,6 +108,38 @@ class CloudStorageAdapter(
         }
     }
 
+    override fun openRange(
+        objectKey: String,
+        range: LongRange,
+    ): CloudStoragePort.StoredObject? {
+        val client = requireClient()
+        validateObjectKey(objectKey)
+
+        return try {
+            val response =
+                client.getObject(
+                    GetObjectRequest
+                        .builder()
+                        .bucket(properties.bucket)
+                        .key(objectKey)
+                        .range("bytes=${range.first}-${range.last}")
+                        .build(),
+                )
+            CloudStoragePort.StoredObject(
+                inputStream = response,
+                contentType = response.response().contentType() ?: "application/octet-stream",
+                contentLength = response.response().contentLength(),
+                originalFilename = decodeStoredOriginalFilename(response.response().metadata()["original-filename"]),
+            )
+        } catch (_: NoSuchKeyException) {
+            null
+        } catch (e: S3Exception) {
+            if (e.statusCode() == 404) return null
+            logger.error("Cloud file range download failed (objectKey={}, range={}-{})", objectKey, range.first, range.last, e)
+            throw AppException("500-1", "클라우드 파일을 불러오지 못했습니다.")
+        }
+    }
+
     override fun initiateMultipartUpload(
         request: CloudStoragePort.MultipartUploadInitRequest,
     ): CloudStoragePort.MultipartUploadInitResult {

--- a/back/src/main/kotlin/com/back/global/storage/application/port/output/CloudStoragePort.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/port/output/CloudStoragePort.kt
@@ -125,5 +125,10 @@ interface CloudStoragePort {
 
     fun open(objectKey: String): StoredObject?
 
+    fun openRange(
+        objectKey: String,
+        range: LongRange,
+    ): StoredObject?
+
     fun delete(objectKey: String)
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudControllerWebMvcTest.kt
@@ -2,18 +2,15 @@ package com.back.boundedContexts.cloud.adapter.web
 
 import com.back.boundedContexts.cloud.application.service.CloudFileContent
 import com.back.boundedContexts.cloud.application.service.CloudFileDto
-import com.back.boundedContexts.cloud.application.service.CloudFileService
 import com.back.boundedContexts.cloud.application.service.CloudVideoUploadPartDto
 import com.back.boundedContexts.cloud.application.service.CloudVideoUploadPartResultDto
 import com.back.boundedContexts.cloud.application.service.CloudVideoUploadSessionDto
-import com.back.boundedContexts.cloud.application.service.CloudVideoUploadSessionService
 import com.back.boundedContexts.cloud.model.CloudFileMediaKind
 import com.back.boundedContexts.cloud.model.CloudVideoUploadSessionStatus
 import com.back.global.security.domain.SecurityUser
 import com.back.global.storage.application.port.output.CloudStoragePort
 import com.back.support.BaseAdmCloudControllerWebMvcTest
 import jakarta.servlet.http.HttpServletRequest
-import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -21,6 +18,7 @@ import org.mockito.ArgumentMatchers
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.mock.web.DelegatingServletInputStream
@@ -28,15 +26,12 @@ import org.springframework.mock.web.MockMultipartFile
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
-import org.springframework.test.util.ReflectionTestUtils
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.multipart
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.put
 import java.io.ByteArrayInputStream
-import java.io.EOFException
-import java.io.InputStream
 import java.time.Instant
 
 @DisplayName("관리자 클라우드 WebMvc 테스트")
@@ -427,94 +422,116 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
     }
 
     @Test
-    @DisplayName("content Range 요청은 private partial response를 반환한다")
-    fun `content Range 요청은 private partial response를 반환한다`() {
+    @DisplayName("content Range bytes=0-1023 요청은 storage range stream으로 private partial response를 반환한다")
+    fun `content Range bytes 0-1023 요청은 storage range stream으로 private partial response를 반환한다`() {
         val admin = adminUser(id = 7L)
-        givenContent(ownerMemberId = 7L, fileId = 12L, bytes = "0123456789".toByteArray(), contentLength = 10L)
+        val bytes = ByteArray(1024) { (it % 251).toByte() }
+        givenRangeContent(ownerMemberId = 7L, fileId = 12L, totalLength = 2048L, range = 0L..1023L, bytes = bytes)
 
         mvc
             .get("/system/api/v1/adm/cloud/files/12/content") {
-                header(HttpHeaders.RANGE, "bytes=2-5")
+                header(HttpHeaders.RANGE, "bytes=0-1023")
                 with(user(admin))
             }.andExpect {
                 status { isPartialContent() }
                 header { string(HttpHeaders.ACCEPT_RANGES, "bytes") }
-                header { string(HttpHeaders.CONTENT_RANGE, "bytes 2-5/10") }
+                header { string(HttpHeaders.CONTENT_RANGE, "bytes 0-1023/2048") }
+                header { longValue(HttpHeaders.CONTENT_LENGTH, 1024L) }
                 header { string(HttpHeaders.CACHE_CONTROL, "private, no-store, max-age=0") }
                 content { contentType("video/mp4") }
-                content { bytes("2345".toByteArray()) }
+                content { bytes(bytes) }
             }
+
+        then(cloudFileService).should().openContentRange(ownerMemberId = 7L, fileId = 12L, range = 0L..1023L)
+        then(cloudFileService).should(never()).openContent(ownerMemberId = 7L, fileId = 12L)
     }
 
     @Test
-    @DisplayName("content suffix Range 요청은 마지막 byte 구간을 반환한다")
-    fun `content suffix Range 요청은 마지막 byte 구간을 반환한다`() {
+    @DisplayName("content Range bytes=1024- 요청은 끝까지 반환한다")
+    fun `content Range bytes 1024 open ended 요청은 끝까지 반환한다`() {
         val admin = adminUser(id = 7L)
-        givenContent(ownerMemberId = 7L, fileId = 12L, bytes = "0123456789".toByteArray(), contentLength = 10L)
+        val bytes = ByteArray(1024) { (it % 251).toByte() }
+        givenRangeContent(ownerMemberId = 7L, fileId = 12L, totalLength = 2048L, range = 1024L..2047L, bytes = bytes)
 
         mvc
             .get("/system/api/v1/adm/cloud/files/12/content") {
-                header(HttpHeaders.RANGE, "bytes=-4")
+                header(HttpHeaders.RANGE, "bytes=1024-")
                 with(user(admin))
             }.andExpect {
                 status { isPartialContent() }
-                header { string(HttpHeaders.CONTENT_RANGE, "bytes 6-9/10") }
-                content { bytes("6789".toByteArray()) }
+                header { string(HttpHeaders.CONTENT_RANGE, "bytes 1024-2047/2048") }
+                header { longValue(HttpHeaders.CONTENT_LENGTH, 1024L) }
+                content { bytes(bytes) }
             }
     }
 
     @Test
-    @DisplayName("content open-ended Range 요청은 끝까지 반환한다")
-    fun `content open-ended Range 요청은 끝까지 반환한다`() {
+    @DisplayName("content suffix Range bytes=-1024 요청은 total보다 크면 전체 길이로 clamp한다")
+    fun `content suffix Range bytes minus 1024 요청은 total보다 크면 전체 길이로 clamp한다`() {
         val admin = adminUser(id = 7L)
-        givenContent(ownerMemberId = 7L, fileId = 12L, bytes = "0123456789".toByteArray(), contentLength = 10L)
+        givenRangeContent(
+            ownerMemberId = 7L,
+            fileId = 12L,
+            totalLength = 10L,
+            range = 0L..9L,
+            bytes = "0123456789".toByteArray(),
+        )
 
         mvc
             .get("/system/api/v1/adm/cloud/files/12/content") {
-                header(HttpHeaders.RANGE, "bytes=7-")
+                header(HttpHeaders.RANGE, "bytes=-1024")
                 with(user(admin))
             }.andExpect {
                 status { isPartialContent() }
-                header { string(HttpHeaders.CONTENT_RANGE, "bytes 7-9/10") }
-                content { bytes("789".toByteArray()) }
+                header { string(HttpHeaders.CONTENT_RANGE, "bytes 0-9/10") }
+                header { longValue(HttpHeaders.CONTENT_LENGTH, 10L) }
+                content { bytes("0123456789".toByteArray()) }
             }
     }
 
     @Test
-    @DisplayName("content Range 요청은 stream 길이를 모르면 416을 반환하고 stream을 닫는다")
-    fun `content Range 요청은 stream 길이를 모르면 416을 반환하고 stream을 닫는다`() {
+    @DisplayName("content invalid Range 요청은 416을 반환하고 storage stream을 열지 않는다")
+    fun `content invalid Range 요청은 416을 반환하고 storage stream을 열지 않는다`() {
         val admin = adminUser(id = 7L)
-        val inputStream =
-            givenContent(
-                ownerMemberId = 7L,
-                fileId = 12L,
-                bytes = "0123456789".toByteArray(),
-                contentLength = null,
-            )
+        givenFileMetadata(ownerMemberId = 7L, fileId = 12L, totalLength = 10L)
 
         mvc
             .get("/system/api/v1/adm/cloud/files/12/content") {
-                header(HttpHeaders.RANGE, "bytes=0-1")
+                header(HttpHeaders.RANGE, "bytes=abc-def")
                 with(user(admin))
             }.andExpect {
                 status { isRequestedRangeNotSatisfiable() }
-                header { string(HttpHeaders.CONTENT_RANGE, "bytes */*") }
+                header { string(HttpHeaders.CONTENT_RANGE, "bytes */10") }
             }
 
-        assertThat(inputStream.closed).isTrue()
+        then(cloudFileService).should().get(ownerMemberId = 7L, fileId = 12L)
+        then(cloudFileService).shouldHaveNoMoreInteractions()
     }
 
     @Test
-    @DisplayName("content Range 요청은 multi-range를 거절하고 stream을 닫는다")
-    fun `content Range 요청은 multi-range를 거절하고 stream을 닫는다`() {
+    @DisplayName("content unsatisfiable Range 요청은 416을 반환하고 storage stream을 열지 않는다")
+    fun `content unsatisfiable Range 요청은 416을 반환하고 storage stream을 열지 않는다`() {
         val admin = adminUser(id = 7L)
-        val inputStream =
-            givenContent(
-                ownerMemberId = 7L,
-                fileId = 12L,
-                bytes = "0123456789".toByteArray(),
-                contentLength = 10L,
-            )
+        givenFileMetadata(ownerMemberId = 7L, fileId = 12L, totalLength = 10L)
+
+        mvc
+            .get("/system/api/v1/adm/cloud/files/12/content") {
+                header(HttpHeaders.RANGE, "bytes=10-")
+                with(user(admin))
+            }.andExpect {
+                status { isRequestedRangeNotSatisfiable() }
+                header { string(HttpHeaders.CONTENT_RANGE, "bytes */10") }
+            }
+
+        then(cloudFileService).should().get(ownerMemberId = 7L, fileId = 12L)
+        then(cloudFileService).shouldHaveNoMoreInteractions()
+    }
+
+    @Test
+    @DisplayName("content Range 요청은 multi-range를 거절하고 storage stream을 열지 않는다")
+    fun `content Range 요청은 multi-range를 거절하고 storage stream을 열지 않는다`() {
+        val admin = adminUser(id = 7L)
+        givenFileMetadata(ownerMemberId = 7L, fileId = 12L, totalLength = 10L)
 
         mvc
             .get("/system/api/v1/adm/cloud/files/12/content") {
@@ -525,7 +542,8 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
                 header { string(HttpHeaders.CONTENT_RANGE, "bytes */10") }
             }
 
-        assertThat(inputStream.closed).isTrue()
+        then(cloudFileService).should().get(ownerMemberId = 7L, fileId = 12L)
+        then(cloudFileService).shouldHaveNoMoreInteractions()
     }
 
     @Test
@@ -547,68 +565,6 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
                 status { isInternalServerError() }
                 jsonPath("$.resultCode") { value("500-1") }
             }
-    }
-
-    @Test
-    @DisplayName("slice stream은 단일 byte read에서도 지정된 구간만 반환한다")
-    fun `slice stream은 단일 byte read에서도 지정된 구간만 반환한다`() {
-        val controller =
-            ApiV1AdmCloudController(
-                mock(CloudFileService::class.java),
-                mock(CloudVideoUploadSessionService::class.java),
-            )
-        val stream =
-            ReflectionTestUtils.invokeMethod<InputStream>(
-                controller,
-                "sliceStream",
-                ByteArrayInputStream("0123456789".toByteArray()),
-                2L..4L,
-            )!!
-
-        val values = generateSequence { stream.read().takeIf { it >= 0 } }.toList()
-        stream.close()
-
-        assertThat(values).containsExactly('2'.code, '3'.code, '4'.code)
-    }
-
-    @Test
-    @DisplayName("slice stream은 시작 위치까지 건너뛰지 못하면 EOF로 실패한다")
-    fun `slice stream은 시작 위치까지 건너뛰지 못하면 EOF로 실패한다`() {
-        val controller =
-            ApiV1AdmCloudController(
-                mock(CloudFileService::class.java),
-                mock(CloudVideoUploadSessionService::class.java),
-            )
-
-        assertThatThrownBy {
-            ReflectionTestUtils.invokeMethod<InputStream>(
-                controller,
-                "sliceStream",
-                ByteArrayInputStream("abc".toByteArray()),
-                5L..6L,
-            )
-        }.rootCause()
-            .isInstanceOf(EOFException::class.java)
-    }
-
-    @Test
-    @DisplayName("slice stream은 skip이 0이면 read로 건너뛰기를 이어간다")
-    fun `slice stream은 skip이 0이면 read로 건너뛰기를 이어간다`() {
-        val controller =
-            ApiV1AdmCloudController(
-                mock(CloudFileService::class.java),
-                mock(CloudVideoUploadSessionService::class.java),
-            )
-        val stream =
-            ReflectionTestUtils.invokeMethod<InputStream>(
-                controller,
-                "sliceStream",
-                ZeroSkipInputStream("abc".toByteArray()),
-                2L..2L,
-            )!!
-
-        assertThat(stream.read()).isEqualTo('c'.code)
-        assertThat(stream.read()).isEqualTo(-1)
     }
 
     @Test
@@ -653,6 +609,51 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
                             inputStream = inputStream,
                             contentType = contentType,
                             contentLength = contentLength,
+                            originalFilename = "demo.mp4",
+                        ),
+                ),
+            )
+        return inputStream
+    }
+
+    private fun givenFileMetadata(
+        ownerMemberId: Long,
+        fileId: Long,
+        totalLength: Long,
+        contentType: String = "video/mp4",
+    ): CloudFileDto {
+        val file =
+            sampleDto(
+                id = fileId,
+                ownerMemberId = ownerMemberId,
+                originalFilename = "demo.mp4",
+                contentType = contentType,
+                byteSize = totalLength,
+                mediaKind = CloudFileMediaKind.VIDEO,
+            )
+        given(cloudFileService.get(ownerMemberId = ownerMemberId, fileId = fileId)).willReturn(file)
+        return file
+    }
+
+    private fun givenRangeContent(
+        ownerMemberId: Long,
+        fileId: Long,
+        totalLength: Long,
+        range: LongRange,
+        bytes: ByteArray,
+        contentType: String = "video/mp4",
+    ): CloseAwareInputStream {
+        val inputStream = CloseAwareInputStream(bytes)
+        val file = givenFileMetadata(ownerMemberId, fileId, totalLength, contentType)
+        given(cloudFileService.openContentRange(ownerMemberId = ownerMemberId, fileId = fileId, range = range))
+            .willReturn(
+                CloudFileContent(
+                    file = file,
+                    storedObject =
+                        CloudStoragePort.StoredObject(
+                            inputStream = inputStream,
+                            contentType = contentType,
+                            contentLength = bytes.size.toLong(),
                             originalFilename = "demo.mp4",
                         ),
                 ),
@@ -725,11 +726,5 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
             closed = true
             super.close()
         }
-    }
-
-    private class ZeroSkipInputStream(
-        bytes: ByteArray,
-    ) : ByteArrayInputStream(bytes) {
-        override fun skip(n: Long): Long = 0
     }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -747,11 +747,12 @@ class CloudFileServiceTest {
                 originalFilename = "demo.mp4",
             )
 
-        val content = service.openContent(ownerMemberId = 7L, fileId = saved.id)
+        val content = service.openContentRange(ownerMemberId = 7L, fileId = saved.id, range = 2L..5L)
 
         assertThat(content.file.id).isEqualTo(saved.id)
         assertThat(content.storedObject.contentType).isEqualTo("video/mp4")
-        assertThat(storage.openedObjectKeys).containsExactly(saved.objectKey)
+        assertThat(storage.openedObjectKeys).isEmpty()
+        assertThat(storage.openedRanges).containsExactly(saved.objectKey to (2L..5L))
     }
 
     @Test
@@ -997,6 +998,7 @@ class CloudFileServiceTest {
     private class FakeCloudStoragePort : CloudStoragePort {
         val uploaded = mutableListOf<CloudStoragePort.UploadRequest>()
         val openedObjectKeys = mutableListOf<String>()
+        val openedRanges = mutableListOf<Pair<String, LongRange>>()
         val deletedObjectKeys = mutableListOf<String>()
         val objects = mutableMapOf<String, CloudStoragePort.StoredObject>()
         var deleteFailure: RuntimeException? = null
@@ -1031,6 +1033,14 @@ class CloudFileServiceTest {
 
         override fun open(objectKey: String): CloudStoragePort.StoredObject? {
             openedObjectKeys += objectKey
+            return objects[objectKey]
+        }
+
+        override fun openRange(
+            objectKey: String,
+            range: LongRange,
+        ): CloudStoragePort.StoredObject? {
+            openedRanges += objectKey to range
             return objects[objectKey]
         }
 

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -724,6 +724,79 @@ class CloudFileServiceTest {
     }
 
     @Test
+    @DisplayName("content 조회는 owner match 뒤에 저장소 stream을 반환한다")
+    fun `content 조회는 owner match 뒤에 저장소 stream을 반환한다`() {
+        val saved =
+            repository.save(
+                cloudFile(
+                    ownerMemberId = 7L,
+                    objectKey = "cloud/7/docs/file.pdf",
+                    originalFilename = "file.pdf",
+                    mediaKind = CloudFileMediaKind.DOCUMENT,
+                    folderPath = "docs",
+                ),
+            )
+        storage.objects[saved.objectKey] =
+            CloudStoragePort.StoredObject(
+                inputStream = ByteArrayInputStream("content".toByteArray()),
+                contentType = "application/pdf",
+                contentLength = 7L,
+                originalFilename = "file.pdf",
+            )
+
+        val content = service.openContent(ownerMemberId = 7L, fileId = saved.id)
+
+        assertThat(content.file.id).isEqualTo(saved.id)
+        assertThat(content.storedObject.contentType).isEqualTo("application/pdf")
+        assertThat(storage.openedObjectKeys).containsExactly(saved.objectKey)
+        assertThat(storage.openedRanges).isEmpty()
+    }
+
+    @Test
+    @DisplayName("Range content 조회 시 owner match 없이는 저장소 range stream을 열지 않는다")
+    fun `Range content 조회는 owner match 없이는 저장소 range stream을 열지 않는다`() {
+        val saved =
+            repository.save(
+                cloudFile(
+                    ownerMemberId = 7L,
+                    objectKey = "cloud/7/video/hidden.mp4",
+                    originalFilename = "hidden.mp4",
+                    mediaKind = CloudFileMediaKind.VIDEO,
+                    folderPath = "video",
+                ),
+            )
+
+        assertThatThrownBy {
+            service.openContentRange(ownerMemberId = 8L, fileId = saved.id, range = 0L..9L)
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("파일을 찾을 수 없습니다")
+
+        assertThat(storage.openedRanges).isEmpty()
+    }
+
+    @Test
+    @DisplayName("Range content 조회 시 metadata는 있지만 object가 없으면 404로 실패한다")
+    fun `Range content 조회는 metadata는 있지만 object가 없으면 실패한다`() {
+        val saved =
+            repository.save(
+                cloudFile(
+                    ownerMemberId = 7L,
+                    objectKey = "cloud/7/video/missing.mp4",
+                    originalFilename = "missing.mp4",
+                    mediaKind = CloudFileMediaKind.VIDEO,
+                    folderPath = "video",
+                ),
+            )
+
+        assertThatThrownBy {
+            service.openContentRange(ownerMemberId = 7L, fileId = saved.id, range = 0L..9L)
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("파일을 찾을 수 없습니다")
+
+        assertThat(storage.openedRanges).containsExactly(saved.objectKey to (0L..9L))
+    }
+
+    @Test
     @DisplayName("Range content 조회는 owner match 뒤에만 저장소 stream을 반환한다")
     fun `Range content 조회는 owner match 뒤에만 저장소 stream을 반환한다`() {
         val saved =

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionServiceTest.kt
@@ -1094,6 +1094,11 @@ class CloudVideoUploadSessionServiceTest {
         override fun open(objectKey: String): CloudStoragePort.StoredObject? =
             CloudStoragePort.StoredObject(ByteArrayInputStream(ByteArray(0)), "video/mp4", 0, "empty.mp4")
 
+        override fun openRange(
+            objectKey: String,
+            range: LongRange,
+        ): CloudStoragePort.StoredObject? = CloudStoragePort.StoredObject(ByteArrayInputStream(ByteArray(0)), "video/mp4", 0, "empty.mp4")
+
         override fun delete(objectKey: String) = Unit
     }
 

--- a/back/src/test/kotlin/com/back/global/storage/adapter/CloudStorageAdapterTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/adapter/CloudStorageAdapterTest.kt
@@ -1,0 +1,151 @@
+package com.back.global.storage.adapter
+
+import com.back.global.exception.application.AppException
+import com.back.global.storage.config.CloudStorageProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.test.util.ReflectionTestUtils
+import software.amazon.awssdk.core.ResponseInputStream
+import software.amazon.awssdk.http.AbortableInputStream
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectResponse
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import software.amazon.awssdk.services.s3.model.S3Exception
+import java.io.ByteArrayInputStream
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+@DisplayName("CloudStorageAdapter 테스트")
+class CloudStorageAdapterTest {
+    private val objectKey = "cloud/7/video/demo.mp4"
+
+    @Test
+    @DisplayName("openRange는 S3 Range GET 요청으로 지정 구간만 연다")
+    fun openRangeUsesS3RangeRequest() {
+        // given
+        val s3Client = RecordingS3Client { storedResponse("demo-range".toByteArray()) }
+        val adapter = adapterWithClient(s3Client)
+
+        // when
+        val storedObject = adapter.openRange(objectKey, 2L..11L)
+
+        // then
+        assertThat(s3Client.lastGetObjectRequest!!.bucket()).isEqualTo("test-bucket")
+        assertThat(s3Client.lastGetObjectRequest!!.key()).isEqualTo(objectKey)
+        assertThat(s3Client.lastGetObjectRequest!!.range()).isEqualTo("bytes=2-11")
+        assertThat(storedObject).isNotNull
+        assertThat(storedObject!!.contentType).isEqualTo("video/mp4")
+        assertThat(storedObject.contentLength).isEqualTo(10)
+        assertThat(storedObject.originalFilename).isEqualTo("demo video.mp4")
+        assertThat(storedObject.inputStream.readBytes()).isEqualTo("demo-range".toByteArray())
+    }
+
+    @Test
+    @DisplayName("openRange는 S3 NoSuchKey를 null로 변환한다")
+    fun openRangeReturnsNullForNoSuchKey() {
+        // given
+        val s3Client =
+            RecordingS3Client {
+                throw NoSuchKeyException.builder().message("missing").build()
+            }
+        val adapter = adapterWithClient(s3Client)
+
+        // when
+        val storedObject = adapter.openRange(objectKey, 0L..9L)
+
+        // then
+        assertThat(storedObject).isNull()
+    }
+
+    @Test
+    @DisplayName("openRange는 S3 404를 null로 변환한다")
+    fun openRangeReturnsNullForS3NotFound() {
+        // given
+        val s3Client =
+            RecordingS3Client {
+                throw S3Exception
+                    .builder()
+                    .statusCode(404)
+                    .message("missing")
+                    .build()
+            }
+        val adapter = adapterWithClient(s3Client)
+
+        // when
+        val storedObject = adapter.openRange(objectKey, 0L..9L)
+
+        // then
+        assertThat(storedObject).isNull()
+    }
+
+    @Test
+    @DisplayName("openRange는 S3 500을 AppException으로 변환한다")
+    fun openRangeThrowsAppExceptionForS3Failure() {
+        // given
+        val s3Client =
+            RecordingS3Client {
+                throw S3Exception
+                    .builder()
+                    .statusCode(500)
+                    .message("storage error")
+                    .build()
+            }
+        val adapter = adapterWithClient(s3Client)
+
+        // when & then
+        assertThatThrownBy { adapter.openRange(objectKey, 0L..9L) }
+            .isInstanceOf(AppException::class.java)
+            .hasMessageContaining("500-1")
+            .hasMessageContaining("클라우드 파일을 불러오지 못했습니다.")
+    }
+
+    private fun adapterWithClient(s3Client: S3Client): CloudStorageAdapter {
+        val adapter =
+            CloudStorageAdapter(
+                CloudStorageProperties(
+                    enabled = true,
+                    bucket = "test-bucket",
+                    cloudKeyPrefix = "cloud",
+                ),
+            )
+        ReflectionTestUtils.setField(adapter, "s3Client", s3Client)
+        return adapter
+    }
+
+    private fun storedResponse(bytes: ByteArray): ResponseInputStream<GetObjectResponse> {
+        val response =
+            GetObjectResponse
+                .builder()
+                .contentType("video/mp4")
+                .contentLength(bytes.size.toLong())
+                .metadata(
+                    mapOf(
+                        "original-filename" to
+                            URLEncoder
+                                .encode("demo video.mp4", StandardCharsets.UTF_8)
+                                .replace("+", "%20"),
+                    ),
+                ).build()
+        return ResponseInputStream(response, AbortableInputStream.create(ByteArrayInputStream(bytes)))
+    }
+
+    private class RecordingS3Client(
+        private val onGetObject: () -> ResponseInputStream<GetObjectResponse>,
+    ) : S3Client {
+        var lastGetObjectRequest: GetObjectRequest? = null
+            private set
+
+        override fun getObject(getObjectRequest: GetObjectRequest): ResponseInputStream<GetObjectResponse> {
+            lastGetObjectRequest = getObjectRequest
+            return onGetObject()
+        }
+
+        override fun serviceName(): String = "s3"
+
+        override fun close() {
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- close #1155

## 📝 Summary
- 클라우드 파일 Range 요청이 앱 서버의 stream skip/slice에 의존하지 않고 storage adapter의 S3/MinIO Range GET을 사용하도록 바꿨습니다.
- 기존 `/files/{id}/content`의 `200`, `206`, `416`, `Content-Range`, `Accept-Ranges` contract는 유지합니다.

## 🛠 Changes
- `CloudStoragePort.openRange(objectKey, range)` 계약을 추가했습니다.
- `CloudStorageAdapter`에서 `GetObjectRequest.range("bytes=start-end")`로 Range GET을 호출합니다.
- 관리자 cloud content Range 요청은 metadata로 range를 검증한 뒤 `openContentRange`를 통해 range stream을 반환합니다.
- off-by-one 방지를 위해 `bytes=0-1023`, `bytes=1024-`, `bytes=-1024`, invalid, unsatisfiable, multi-range, non-range 테스트를 정리했습니다.
- `CloudStorageAdapter.openRange`의 S3 request contract와 404/500 변환 테스트를 추가해 CI coverage gate를 보강했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Editor / Content Rendering
- [x] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [ ] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `back/gradlew -p back test --tests com.back.boundedContexts.cloud.application.service.CloudFileServiceTest --tests com.back.boundedContexts.cloud.adapter.web.ApiV1AdmCloudControllerWebMvcTest`: fail 확인 후 구현, 최종 `BUILD SUCCESSFUL`
- `back/gradlew -p back test --tests com.back.global.storage.adapter.CloudStorageAdapterTest --tests com.back.boundedContexts.cloud.application.service.CloudFileServiceTest`: `BUILD SUCCESSFUL`
- `back/gradlew -p back ciFastCoverageVerification`: 최초 CI 동일 실패 재현 후 test 보강, 최종 2회 연속 `BUILD SUCCESSFUL`
- `back/gradlew -p back ktlintCheck`: `BUILD SUCCESSFUL`
- `back/gradlew -p back test`: `BUILD SUCCESSFUL`
- pre-commit hook `OpenApiContractExportTest` + `yarn contracts:check`: `BUILD SUCCESSFUL`, generated types up-to-date

## 📸 Screenshot / API Example
- UI 변경 없음. API contract 증거는 WebMvc 테스트로 확인했습니다.
- `Range: bytes=0-1023` → `206`, `Content-Range: bytes 0-1023/2048`, `Content-Length: 1024`
- `Range: bytes=1024-` → `206`, `Content-Range: bytes 1024-2047/2048`, `Content-Length: 1024`
- `Range: bytes=-1024` with 10 byte file → `206`, `Content-Range: bytes 0-9/10`, `Content-Length: 10`
- invalid/unsatisfiable/multi-range → `416`, `Content-Range: bytes */{total}`

## ⚠️ Risk & Rollback
- 예상 리스크: DB metadata byteSize와 object 실제 길이가 어긋난 파일은 Range 계산과 storage 응답이 다를 수 있습니다. 기존 upload path는 byteSize를 저장하므로 정상 파일에서는 일치합니다.
- 롤백 방법: 이 PR을 revert하면 기존 전체 object open + controller slice 방식으로 돌아갑니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 [코드 주석 정책](https://github.com/AquilaXk/aquila-blog/blob/main/docs/design/code-comment-policy.md)에 맞는 이유/불변조건/운영 영향을 설명하는가?
