### PR TITLE
[Chore] CodeRabbit Sonar 리뷰 범위 정렬

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -35,6 +35,9 @@ reviews:
     - "!**/coverage/**"
     - "!**/test-results/**"
     - "!**/playwright-report/**"
+    - "!front/public/pdf.worker.min.mjs"
+    - "!front/contracts/openapi/**"
+    - "!front/packages/shared-contracts/src/generated/**"
 
   auto_review:
     enabled: true
@@ -67,6 +70,12 @@ reviews:
     - path: ".github/**"
       instructions: |
         GitHub Actions 변경은 권한 최소화, secret 노출, pull_request_target 안전성, cache key 안정성, required check drift, 배포 조건 누락을 우선 검토한다.
+    - path: "sonar-project.properties"
+      instructions: |
+        Sonar 분석 범위가 현재 운영 모드와 일치하는지 확인한다.
+        CI-based analysis에서는 sources/tests/exclusions/coverage report path drift를 우선 검토한다.
+        Automatic Analysis 운영 중이면 sonar-project.properties가 실제 분석에 적용되지 않을 수 있음을 지적한다.
+        generated/vendor 파일 제외와 CodeRabbit path_filters가 불일치하면 지적한다.
     - path: "deploy/**"
       instructions: |
         배포 변경은 rollback 가능성, secret/env drift, health check, live verification, 홈서버 배포 경로와 main merge 후 자동 배포 계약을 우선 검토한다.


### PR DESCRIPTION
## 🔗 Related Issue
- close #1161

## 📝 Summary
- CodeRabbit 리뷰 제외 범위를 SonarCloud 제외 범위와 맞췄습니다.
- `sonar-project.properties` 변경 시 Automatic Analysis와 CI-based analysis 차이를 리뷰하도록 지침을 추가했습니다.

## 🛠 Changes
- CodeRabbit path filters에 PDF worker, OpenAPI contract artifact, generated shared contracts 제외를 추가했습니다.
- Sonar 설정 파일 전용 path instruction을 추가해 source/test/exclusion/coverage path drift와 Automatic Analysis 적용 한계를 검토하게 했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [x] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `ruby -e 'require "yaml"; YAML.load_file(".coderabbit.yaml"); puts "yaml ok"'`: `yaml ok`
- `git diff --check`: exit 0
- `git diff --cached --check`: exit 0
- `gh pr checks 1162 --repo AquilaXk/aquila-blog`: all checks pass
- Codex CLI fallback review: actionable comments 0

## 📸 Screenshot / API Example
- 설정 파일 변경만 있어 스크린샷/API 예시는 없습니다.
- Codex fallback review: https://github.com/AquilaXk/aquila-blog/pull/1162#pullrequestreview-4579783744

## ⚠️ Risk & Rollback
- 예상 리스크: OpenAPI/generated artifact에 대한 CodeRabbit 리뷰가 줄어듭니다. 계약 드리프트는 기존 CI 검증이 담당합니다.
- 롤백 방법: 이 PR의 `.coderabbit.yaml` 변경을 revert합니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 [코드 주석 정책](https://github.com/AquilaXk/aquila-blog/blob/main/docs/design/code-comment-policy.md)에 맞는 이유/불변조건/운영 영향을 설명하는가?
