### PR TITLE
[Docs] 루트 README 진입점 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ GEMINI.md
 CURSOR.md
 COPILOT.md
 docs/*
+!docs/README.md
 !docs/design/
 !docs/design/**
 !docs/legal/

--- a/README.md
+++ b/README.md
@@ -1,379 +1,170 @@
 # Aquila Blog
 
-> 운영 가능한 기술 블로그를 목표로 만든 풀스택 콘텐츠 플랫폼입니다.<br>
-> 단순 게시글 CRUD보다 **실서비스 운영, 장애 복구, 배포 자동화, 회귀 방지**에 더 큰 비중을 두고 설계했습니다.
+> 공개 블로그, 관리자 글쓰기 작업실, 홈서버 배포를 포함한 개인 풀스택 기술 블로그 프로젝트입니다.
+
+[Live Site](https://www.aquilaxk.site) ·
+[Frontend](front/README.md) ·
+[Backend](back/README.md) ·
+[Deploy](deploy/homeserver/HARDENING.md) ·
+[Docs](docs/README.md)
+
+![Frontend](https://img.shields.io/badge/Frontend-Next.js-000000?logo=nextdotjs&logoColor=white)
+![Backend](https://img.shields.io/badge/Backend-Spring_Boot-6DB33F?logo=springboot&logoColor=white)
+![Language](https://img.shields.io/badge/Language-Kotlin-7F52FF?logo=kotlin&logoColor=white)
+![Database](https://img.shields.io/badge/Database-PostgreSQL-4169E1?logo=postgresql&logoColor=white)
+
+## Overview
+
+Aquila Blog는 공개 블로그, 관리자 글쓰기 작업실, 백엔드 API, 홈서버 배포 구성을 하나의 저장소에 둔 개인 풀스택 프로젝트입니다.
+
+단순 게시글 CRUD뿐 아니라 Markdown 렌더링, 검색/태그 탐색, 이미지 저장, 캐시, 배포, 모니터링, 회귀 검증처럼 실제 운영에 필요한 흐름까지 함께 다룹니다.
+
+## Screenshots
 
 <p align="center">
-  <a href="https://www.aquilaxk.site">
-    <img src="https://img.shields.io/badge/Live-aquilaxk.site-d6b66c?style=for-the-badge" alt="Live site" />
-  </a>
-  &nbsp;
-  <a href="https://github.com/AquilaXk/aquila-blog">
-    <img src="https://img.shields.io/badge/GitHub-aquila--blog-181717?style=for-the-badge&logo=github" alt="GitHub repository" />
-  </a>
+  <img src="README.assets/portfolio/feed-overview-live.png" alt="Feed overview" width="32%" />
+  <img src="README.assets/portfolio/post-detail-live.png" alt="Post detail" width="32%" />
+  <img src="README.assets/portfolio/admin-workspace-live.png" alt="Admin workspace" width="32%" />
 </p>
 
-<p align="center">
-  <img src="https://img.shields.io/badge/Next.js-15.5-000000?style=flat-square&logo=next.js&logoColor=white" alt="Next.js 15.5" />
-  <img src="https://img.shields.io/badge/React-18-61DAFB?style=flat-square&logo=react&logoColor=111111" alt="React 18" />
-  <img src="https://img.shields.io/badge/Spring_Boot-4.0-6DB33F?style=flat-square&logo=springboot&logoColor=white" alt="Spring Boot 4.0" />
-  <img src="https://img.shields.io/badge/Kotlin-2.2-7F52FF?style=flat-square&logo=kotlin&logoColor=white" alt="Kotlin 2.2" />
-  <img src="https://img.shields.io/badge/PostgreSQL-4169E1?style=flat-square&logo=postgresql&logoColor=white" alt="PostgreSQL" />
-</p>
+## Features
 
----
+- **Public Blog**: 게시글 피드, 상세 페이지, 검색, 태그 기반 탐색
+- **Content Studio**: 관리자 글 작성, 미리보기, 임시 저장, 발행 관리
+- **Markdown Rendering**: GFM, 코드 하이라이트, Mermaid, 수식, 콜아웃 렌더링
+- **Auth & Profile**: 로그인, OAuth, 프로필/작성자 정보 관리
+- **Storage**: MinIO 기반 이미지 업로드와 정리 흐름
+- **Operations**: 홈서버 배포, 헬스체크, 롤백, 모니터링, 회귀 검증
 
-## 목차
-
-- [프로젝트 개요](#프로젝트-개요)
-- [주요 기능](#주요-기능)
-- [시스템 아키텍처](#시스템-아키텍처)
-- [주요 설계 포인트](#주요-설계-포인트)
-- [기술 스택](#기술-스택)
-- [화면 및 운영 플로우](#화면-및-운영-플로우)
-- [프로젝트 구조](#프로젝트-구조)
-- [시작하기](#시작하기)
-- [환경 변수](#환경-변수)
-- [품질 게이트](#품질-게이트)
-- [운영 및 배포](#운영-및-배포)
-- [운영 계약 문서](#운영-계약-문서)
-- [트러블슈팅 기록](#트러블슈팅-기록)
-- [현재 상태와 개선 방향](#현재-상태와-개선-방향)
-- [관련 링크](#관련-링크)
-
----
-
-## 프로젝트 개요
-
-### 배경
-
-개인 기술 블로그는 글 작성과 공개만으로도 만들 수 있지만, 실제 운영을 계속하려면 게시글 렌더링, 인증, 이미지 저장, 배포 실패, 캐시 불일치, 성능 회귀까지 함께 다뤄야 합니다.
-
-| 문제 | 운영에서 드러나는 영향 |
-| --- | --- |
-| 렌더링 회귀 | Markdown, Mermaid, 코드 블록, 표가 배포 후 깨질 수 있음 |
-| 배포 실패 | 홈서버 배포 중 일부 컨테이너만 살아남으면 복구 기준이 흐려짐 |
-| 캐시 불일치 | 글 수정 후 공개 상세 페이지가 오래된 내용을 보여줄 수 있음 |
-| 운영 관측 부족 | 장애 원인을 로그와 지표로 추적하기 어려움 |
-
-### 목표
-
-Aquila Blog는 글 작성 도구와 공개 블로그를 하나로 묶고, 운영 중 문제가 생겨도 원인을 분리하고 복구할 수 있는 구조를 목표로 합니다.
-
-| 구분 | AS-IS | TO-BE |
-| --- | --- | --- |
-| 콘텐츠 관리 | 글 작성, 미리보기, 발행 흐름이 분산됨 | 관리자 작업실에서 작성, 메타 편집, 미리보기, 발행을 연결 |
-| 공개 읽기 경로 | 렌더링 실패와 캐시 실패가 사용자 경험에 바로 노출됨 | fallback, timeout, cache fail-open으로 공개 경로 방어 |
-| 배포 운영 | 배포 성공 여부를 수동 확인에 의존 | Blue/Green, health probe, rollback, steady-state guard로 자동 판정 |
-| 회귀 방지 | 화면과 계약 변경을 배포 후 확인 | Playwright, Storybook, OpenAPI contract, k6로 사전 검증 |
-
-### 핵심 가치
-
-- **운영 우선 설계**: 배포, 복구, 관측, 회귀 테스트를 프로젝트의 기본 기능으로 취급합니다.
-- **방어적인 공개 경로**: 공개 피드와 상세 조회는 실패해도 가능한 한 읽기 경험을 유지하도록 설계합니다.
-- **문서와 검증 동기화**: 장애 원인, 재발 방지, 검증 명령을 같은 작업 단위에서 남깁니다.
-
----
-
-## 주요 기능
-
-| 영역 | 기능 | 설명 |
-| --- | --- | --- |
-| Public Blog | 피드, 검색, 태그 탐색 | 공개 글 목록, 태그 필터, 검색 진입점을 제공합니다. |
-| Public Blog | 글 상세 | 태그, 작성자, 본문, 좋아요, 댓글, 목차를 한 화면에서 제공합니다. |
-| Content Rendering | Markdown 확장 | GitHub Flavored Markdown, Mermaid, 수식, 코드 하이라이팅, 콜아웃을 렌더링합니다. |
-| Content Studio | 글 작성/수정 | 블록 기반 에디터, 태그, 썸네일, 요약, 공개 범위, 미리보기를 관리합니다. |
-| Content Studio | 발행 관리 | 임시저장, 발행, 비공개, soft delete, 복구, 영구 삭제 흐름을 분리합니다. |
-| Auth & Profile | 로그인/프로필 | 이메일 로그인, Kakao OAuth, 쿠키 기반 인증, 관리자 프로필 편집을 지원합니다. |
-| Storage | 이미지 lifecycle | MinIO 기반 업로드, 임시 파일 활성화, 지연 삭제를 추적합니다. |
-| Operations | 운영 도구 | doctor, recover, steady-state guard, 배포 상태 점검 스크립트를 제공합니다. |
-| Observability | 모니터링 | Prometheus, Grafana, Loki, Promtail 기반 지표와 로그를 운영합니다. |
-
----
-
-## 시스템 아키텍처
-
-![Aquila Blog System Architecture](README.assets/portfolio/aquila-system-architecture.png)
+## Architecture
 
 ```text
-[User / Admin]
-      |
-      v
-[Vercel - Next.js 15 SSR]
-  |   |   |
-  |   |   +-- Public feed/detail, search, profile
-  |   +------ Admin workspace, editor, preview
-  +---------- API client with browser/server runtime boundary
-      |
-      v
-[Home Server - Caddy + Cloudflare Tunnel]
-      |
-      v
-[Spring Boot 4 + Kotlin]
-  |   |   |
-  |   |   +-- read/admin/worker runtime split
-  |   +------ auth, post, comment, notification, storage domains
-  +---------- OpenAPI contract and operational metrics
-      |
-      +-- PostgreSQL
-      +-- Redis
-      +-- MinIO
-      +-- Prometheus / Grafana / Loki / Promtail
+User / Admin
+    |
+    v
+Vercel / Next.js
+    |
+    v
+Home Server / Caddy + Cloudflare Tunnel
+    |
+    v
+Spring Boot + Kotlin API
+    |
+    +-- PostgreSQL
+    +-- Redis
+    +-- MinIO
+    +-- Prometheus / Grafana / Loki
 ```
 
----
+## Tech Stack
 
-## 주요 설계 포인트
-
-### 1. Hybrid Runtime
-
-프런트엔드는 Vercel에서 SSR과 브라우저 런타임을 맡고, 백엔드는 홈서버에서 운영합니다. 백엔드 런타임은 `all`, `read`, `admin`, `worker` 모드로 나눌 수 있어 공개 읽기 경로와 관리자/작업 경로를 분리해 운영할 수 있습니다.
-
-### 2. Defensive Read Path
-
-공개 피드와 상세 조회는 캐시, Redis, cursor 조회가 실패해도 가능한 한 원본 데이터나 page fallback으로 복구하도록 설계했습니다. 캐시 stampede 완화, timeout, bulkhead, fail-open 정책을 공개 경로의 기본 계약으로 둡니다.
-
-### 3. Editor and Rendering Contract
-
-작성 화면과 공개 상세 화면은 같은 콘텐츠를 다르게 보여주기 때문에 회귀가 자주 생길 수 있습니다. Markdown, Mermaid, 코드 블록, 표, 토글, 콜아웃은 Playwright와 serialization 테스트로 검증하고, 글 저장 후 공개 상세 재검증 경로를 따로 둡니다.
-
-### 4. Safe Deployment
-
-홈서버 배포는 `deploy/homeserver/blue_green_deploy.sh`를 중심으로 동작합니다. 새 슬롯 배포, health check, Caddy 전환, 실패 시 rollback, 배포 후 steady-state guard 확인을 하나의 운영 경로로 묶었습니다.
-
----
-
-## 기술 스택
-
-| 영역 | 사용 기술 |
+| Area | Stack |
 | --- | --- |
-| Frontend | Next.js 15.5, React 18, TypeScript, Emotion, React Query |
-| Editor | Tiptap 3, Markdown serialization, custom slash menu, Playwright editor QA |
-| Content Rendering | react-markdown, remark-gfm, remark-math, Mermaid, rehype-pretty-code, Shiki, KaTeX |
-| Backend | Java 24, Kotlin 2.2, Spring Boot 4.0, Spring Security, JPA, QueryDSL, Flyway |
-| Data | PostgreSQL, Redis, MinIO |
-| Infra | Vercel, Home Server, Caddy, Cloudflare Tunnel, Docker Compose, Terraform |
+| Frontend | Next.js, React, TypeScript, Emotion, TanStack Query |
+| Editor / Rendering | Tiptap, react-markdown, Mermaid, Shiki, KaTeX |
+| Backend | Spring Boot, Kotlin, Spring Security, JPA, QueryDSL, Flyway |
+| Data / Storage | PostgreSQL, Redis, MinIO |
+| Infra / Deploy | Vercel, Home Server, Caddy, Cloudflare Tunnel, Docker Compose |
 | Observability | Prometheus, Grafana, Loki, Promtail, Micrometer |
-| Quality | ktlint, ArchUnit, JUnit 5, Testcontainers, Playwright, Storybook, k6, OpenAPI contract check |
+| Quality | JUnit5, Testcontainers, ArchUnit, Playwright, Storybook, k6 |
 
----
-
-## 화면 및 운영 플로우
-
-### Feed
-
-![Feed Overview - Live](README.assets/portfolio/feed-overview-live.png)
-
-메인 피드는 태그 필터와 검색을 중심으로 공개 글을 빠르게 탐색하도록 구성했습니다.
-
-### Post Detail
-
-![Post Detail - Live](README.assets/portfolio/post-detail-live.png)
-
-글 상세는 본문 가독성을 우선하면서 태그, 작성 메타, 반응 액션, 목차를 함께 제공합니다.
-
-### Admin Workspace
-
-![Admin Workspace - Live](README.assets/portfolio/admin-workspace-live.png)
-
-관리자 작업실은 작성, 메타데이터 편집, 미리보기, 발행 판단을 한 흐름에서 처리하도록 구성했습니다.
-
-### Content Publish Flow
-
-| 단계 | 화면 / 주체 | 핵심 액션 | 반영 대상 | 운영 체크포인트 |
-| --- | --- | --- | --- | --- |
-| 1. Draft Start | `/admin/posts/new` | 제목과 본문 초안 작성 | `post.title`, `post.content` | 초안 유실 방지, 신규/수정 분기 |
-| 2. Metadata Enrichment | 글 작업실 | 태그, 요약, 썸네일, 공개 범위 설정 | `post_tag_index`, `post_attr`, `uploaded_file` | 태그 품질, 이미지 연결, 공개 정책 |
-| 3. Preview QA | 글 작업실 미리보기 | Markdown, 코드, Mermaid, 이미지 확인 | `post.content_html` | 발행 전 렌더링 깨짐 점검 |
-| 4. Publish Control | 관리자 API | 발행, 비공개, soft delete, 복구 | `post.published`, `post.listed`, `post.deleted_at` | rollback 가능 여부 |
-| 5. Delivery & Feedback | 공개 피드/상세 | 조회, 댓글, 좋아요, 알림 반영 | `post_attr`, `post_comment`, `post_like`, `member_notification` | 집계 정합성, SSE 알림 |
-
----
-
-## 프로젝트 구조
+## Project Structure
 
 ```text
 .
 ├── front/                  # Next.js frontend, admin/editor UI, Storybook, Playwright
-├── back/                   # Spring Boot 4 + Kotlin backend
-├── deploy/homeserver/      # Blue/Green 배포, 복구, Caddy, monitoring 스크립트
-├── infra/                  # Terraform 기반 인프라 정의
-├── perf/k6/                # 공개 읽기 경로 성능/chaos 시나리오
-├── docs/                   # 운영 계약과 설계 문서
-├── tools/                  # repo guard, bundle-size, current-task 관련 도구
-└── README.assets/          # README용 화면/아키텍처 이미지
+├── back/                   # Spring Boot + Kotlin API server
+├── deploy/homeserver/      # Production compose, Caddy, blue-green deploy, rollback, monitoring
+├── perf/k6/                # Read-path load and chaos scenarios
+├── docs/                   # Design, operations, quality, legal document hub
+├── tools/                  # Repository guards and automation scripts
+├── infra/                  # Legacy / experimental Terraform setup
+└── README.assets/          # Screenshots and README images
 ```
 
----
+## Getting Started
 
-## 시작하기
-
-### 사전 요구사항
+### Prerequisites
 
 - Java 24
 - Node.js LTS
 - Yarn Classic 1.22.x
-- Docker & Docker Compose
+- Docker / Docker Compose
 
-### 1. 저장소 클론
+### 1. Clone
 
 ```bash
 git clone https://github.com/AquilaXk/aquila-blog.git
 cd aquila-blog
 ```
 
-### 2. 개발용 인프라 실행
+### 2. Start Local Infrastructure
 
 ```bash
 docker compose -f back/devInfra/docker-compose.yml up -d
 ```
 
-기본 개발 인프라는 PostgreSQL, Redis, MinIO를 실행합니다.
-
-| 서비스 | 기본 주소 |
-| --- | --- |
-| PostgreSQL | `localhost:5432` |
-| Redis | `localhost:6379` |
-| MinIO API | `localhost:9000` |
-| MinIO Console | `localhost:9001` |
-
-### 3. 백엔드 실행
+### 3. Start Backend
 
 ```bash
 cd back
 ./gradlew bootRun
 ```
 
-- API: [http://localhost:8080](http://localhost:8080)
-- Swagger UI: [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
-
-### 4. 프런트엔드 실행
+### 4. Start Frontend
 
 ```bash
 cd front
 yarn install
+
 NEXT_PUBLIC_BACKEND_URL=http://localhost:8080 \
 BACKEND_INTERNAL_URL=http://localhost:8080 \
 yarn dev
 ```
 
-- Frontend: [http://localhost:3000](http://localhost:3000)
+| Service | URL |
+| --- | --- |
+| Frontend | `http://localhost:3000` |
+| Backend API | `http://localhost:8080` |
+| Swagger UI | `http://localhost:8080/swagger-ui/index.html` |
 
----
+## Environment Variables
 
-## 환경 변수
+Local development can run with the default development infrastructure. External integrations require additional variables.
 
-로컬 개발은 기본값으로도 대부분 실행할 수 있습니다. 외부 연동이나 운영 모드에서는 아래 값을 명시합니다.
-
-| 변수 | 사용 위치 | 설명 |
+| Variable | Used by | Description |
 | --- | --- | --- |
-| `NEXT_PUBLIC_BACKEND_URL` | Frontend | 브라우저 런타임에서 접근할 API base URL |
-| `BACKEND_INTERNAL_URL` | Frontend SSR | 서버 런타임에서 접근할 API base URL |
-| `CUSTOM__JWT__SECRET_KEY` | Backend | JWT 서명 키, 운영에서는 32 bytes 이상 필요 |
-| `SPRING__DATA__REDIS__PASSWORD` | Backend | Redis 비밀번호 |
-| `CUSTOM__AI__TAG__GEMINI__API_KEY` | Backend | AI 태그 추천을 실제 호출로 확인할 때 사용 |
-| `SPRING__SECURITY__OAUTH2__CLIENT__REGISTRATION__KAKAO__CLIENT_ID` | Backend | Kakao OAuth client ID |
-| `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD` | Infra | MinIO root 계정 |
+| `NEXT_PUBLIC_BACKEND_URL` | Frontend | Browser-facing backend URL |
+| `BACKEND_INTERNAL_URL` | Frontend SSR | Server-side backend URL |
+| `CUSTOM__JWT__SECRET_KEY` | Backend | JWT signing key |
+| `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` | MinIO | Local object storage credentials |
+| `CUSTOM__AI__TAG__GEMINI__API_KEY` | Backend | Optional AI tag recommendation |
+| `CUSTOM__OAUTH2__KAKAO__CLIENT_ID` | Backend | Optional Kakao OAuth login |
 
-전체 기본값과 운영 프로필은 `back/src/main/resources/application.yaml`, `application-dev.yaml`, `application-prod.yaml`에서 확인할 수 있습니다.
-
----
-
-## 품질 게이트
-
-### Backend
+## Quality Checks
 
 ```bash
+# Backend
 cd back
 ./gradlew ktlintCheck
-./gradlew compileKotlin
 ./gradlew test
+
+# Frontend
+cd front
+yarn lint
+yarn build
+yarn contracts:check
 ```
 
-`./gradlew test`는 `back/testInfra/docker-compose.yml` 기반 테스트 인프라를 함께 사용합니다.
+Additional checks include Playwright E2E, Storybook gates, bundle-size checks, k6 load scenarios, and backend architecture tests.
 
-### Frontend
+## Documentation
 
-```bash
-yarn --cwd front lint
-yarn --cwd front build
-yarn --cwd front check:bundle-size
-yarn --cwd front test:e2e:smoke
-yarn --cwd front test:e2e:perf
-yarn --cwd front test:e2e:a11y
-yarn --cwd front storybook:gate
-yarn --cwd front contracts:check
-```
-
-Playwright 계열 스크립트는 `playwright:preflight`를 먼저 실행해 로컬 브라우저 실행 계약 드리프트를 fail-fast로 확인합니다.
-
----
-
-## 운영 및 배포
-
-```text
-작업 브랜치
-  -> PR to main
-  -> CI / guard / security 검증
-  -> main merge
-  -> 홈서버 자동 배포
-  -> Blue/Green cutover
-  -> health probe / steady-state guard
-```
-
-| 도구 | 역할 |
+| Document | Description |
 | --- | --- |
-| `deploy/homeserver/blue_green_deploy.sh` | 새 백엔드 슬롯 배포, health check, Caddy 전환 |
-| `deploy/homeserver/rollback_last_deploy.sh` | 마지막 정상 배포본으로 rollback |
-| `deploy/homeserver/recover.sh` | 운영 컨테이너 복구 |
-| `deploy/homeserver/doctor.sh` | 홈서버 상태 진단 |
-| `deploy/homeserver/steady_state_guard.sh` | Caddy mount, readiness, 단일 실행 규칙 점검 |
-| `deploy/homeserver/monitoring/` | Prometheus, Grafana, Loki, Promtail 구성 |
-
----
-
-## 운영 계약 문서
-
-| 문서 | 설명 |
-| --- | --- |
-| [Task Delivery Guarantees](docs/design/task-delivery-guarantees.md) | durable task queue 전달 보장, retry, idempotency key, DLQ replay 계약 |
-| [Cache Consistency Contract](docs/design/cache-consistency-contract.md) | 공개 post read ETag, Redis/local cache, CDN cache tag, author representation invalidation 계약 |
-| [Cloud Multipart Upload State Machine](docs/design/cloud-multipart-state-machine.md) | 클라우드 동영상 multipart upload session 상태 전이와 실패 복구 기준 |
-| [Profile Workspace Persistence](docs/design/profile-workspace-persistence.md) | profile workspace draft/published/legacy attr 저장 규칙과 복구 절차 |
-
----
-
-## 트러블슈팅 기록
-
-이 프로젝트의 장애 대응은 원인, 대책, 검증을 같은 작업 단위에 남기는 방식을 따릅니다.
-
-| 이슈 유형 | 원인 분리 방식 | 재발 방지 |
-| --- | --- | --- |
-| Blue/Green 전환 실패 | health probe, Caddy 전환, 이전 슬롯 종료 단계를 분리해 확인 | rollback 스크립트와 steady-state guard로 종료 조건 고정 |
-| 공개 상세 stale 응답 | 관리자 저장, revalidate API, SSR/cache 계층을 분리해 추적 | 저장 후 revalidate와 공개 상세 회귀 테스트 유지 |
-| Markdown 렌더링 회귀 | 작성 surface, serialization, 공개 renderer를 분리해 재현 | smoke, mobile-layout, editor serialization, mermaid 테스트 유지 |
-| Redis/cache 장애 | source fallback과 cache fail-open 여부를 확인 | 공개 읽기 경로 fallback 정책과 운영 로그 유지 |
-
----
-
-## 현재 상태와 개선 방향
-
-| 현재 상태 | 다음 개선 방향 |
-| --- | --- |
-| 공개 블로그와 관리자 작성 흐름 운영 가능 | 에디터 대형 모듈을 더 작은 책임 단위로 지속 분해 |
-| Blue/Green 배포와 운영 스크립트 보유 | 배포 후 실페이지 자동 계측 범위 확대 |
-| Markdown/Mermaid/코드블록 회귀 테스트 보유 | 콘텐츠 fixture 기반 렌더링 회귀 케이스 확대 |
-| 모니터링 대시보드와 로그 수집 보유 | 알림 규칙과 운영 런북 정리 강화 |
-
----
-
-## 관련 링크
-
-| 구분 | URL |
-| --- | --- |
-| 서비스 | [www.aquilaxk.site](https://www.aquilaxk.site) |
-| GitHub | [AquilaXk/aquila-blog](https://github.com/AquilaXk/aquila-blog) |
-| Frontend README | [front/README.md](front/README.md) |
-| k6 시나리오 | [perf/k6/README.md](perf/k6/README.md) |
-| 홈서버 운영 문서 | [deploy/homeserver/HARDENING.md](deploy/homeserver/HARDENING.md) |
-| 인프라 문서 | [infra/README.md](infra/README.md) |
+| [Docs Hub](docs/README.md) | Design, operations, quality, performance, and legal document entry point |
+| [Frontend README](front/README.md) | Frontend routes, scripts, environment variables, and UI checks |
+| [Backend README](back/README.md) | Backend architecture, API modules, quality checks, and OpenAPI flow |
+| [k6 Guide](perf/k6/README.md) | Load and chaos scenarios for public read paths |
+| [Home Server Hardening](deploy/homeserver/HARDENING.md) | Home server hardening and operational checklist |
+| [Legacy Infra](infra/README.md) | Legacy cloud infra experiment; production uses homeserver deploy |

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Local development can run with the default development infrastructure. External 
 | `CUSTOM__JWT__SECRET_KEY` | Backend | JWT signing key |
 | `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` | MinIO | Local object storage credentials |
 | `CUSTOM__AI__TAG__GEMINI__API_KEY` | Backend | Optional AI tag recommendation |
-| `CUSTOM__OAUTH2__KAKAO__CLIENT_ID` | Backend | Optional Kakao OAuth login |
+| `SPRING__SECURITY__OAUTH2__CLIENT__REGISTRATION__KAKAO__CLIENT_ID` | Backend | Optional Kakao OAuth client ID |
 
 ## Quality Checks
 
@@ -150,7 +150,7 @@ cd back
 ./gradlew test
 
 # Frontend
-cd front
+cd ../front
 yarn lint
 yarn build
 yarn contracts:check

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,39 @@
+# Aquila Blog Docs
+
+Aquila Blog의 설계, 운영, 품질, 성능, 법무 문서를 모아 둔 문서 허브입니다.
+
+## Entry Points
+
+| Area | Document | Description |
+| --- | --- | --- |
+| Frontend | [front/README.md](../front/README.md) | Frontend routes, scripts, environment variables, UI quality checks |
+| Backend | [back/README.md](../back/README.md) | Backend architecture, API modules, quality checks, OpenAPI flow |
+| Performance | [perf/k6/README.md](../perf/k6/README.md) | Read-path load and chaos scenarios |
+| Deployment | [deploy/homeserver/HARDENING.md](../deploy/homeserver/HARDENING.md) | Home server hardening checklist |
+| Legacy Infra | [infra/README.md](../infra/README.md) | Legacy cloud infra experiment; current production uses homeserver deploy |
+
+## Design Notes
+
+| Document | Description |
+| --- | --- |
+| [Task Delivery Guarantees](design/task-delivery-guarantees.md) | Durable task queue delivery, retry, idempotency, DLQ replay contract |
+| [Cache Consistency Contract](design/cache-consistency-contract.md) | Public read cache, ETag, invalidation, CDN cache tag contract |
+| [Cloud Multipart State Machine](design/cloud-multipart-state-machine.md) | Multipart upload session transitions and recovery rules |
+| [Profile Workspace Persistence](design/profile-workspace-persistence.md) | Profile workspace draft and published persistence rules |
+| [Release UI QA Matrix](design/release-ui-qa-matrix.md) | Release UI quality checklist |
+| [Security CSP Rollout](design/security-csp-rollout.md) | CSP rollout notes |
+| [Launch Gate Operations](design/launch-gate-operations.md) | Launch readiness and operations checks |
+| [Privacy Launch Gate Checklist](design/privacy-launch-gate-checklist.md) | Privacy launch checklist |
+| [Code Comment Policy](design/code-comment-policy.md) | Code comment policy |
+
+## Legal / Privacy Runbooks
+
+| Document | Description |
+| --- | --- |
+| [Account Deletion Runbook](legal/account-deletion-runbook.md) | Account deletion process |
+| [Backup Restore Privacy Runbook](legal/backup-restore-privacy-runbook.md) | Backup and restore privacy checks |
+| [Data Subject Request Runbook](legal/data-subject-request-runbook.md) | Data subject request handling |
+| [Policy Change Runbook](legal/policy-change-runbook.md) | Policy change process |
+| [Privacy Incident Runbook](legal/privacy-incident-runbook.md) | Privacy incident response |
+| [Privacy Tabletop Exercise Template](legal/privacy-tabletop-exercise-template.md) | Tabletop exercise template |
+| [Vendor Onboarding Runbook](legal/vendor-onboarding-runbook.md) | Vendor onboarding checks |

--- a/front/README.md
+++ b/front/README.md
@@ -4,7 +4,7 @@
 
 ## Stack
 
-- Next.js 14 (Pages Router)
+- Next.js Pages Router
 - React 18 + TypeScript
 - TanStack Query (SSR hydrate + client cache)
 - Emotion
@@ -24,7 +24,7 @@
 
 ```bash
 cd front
-yarn
+yarn install
 yarn dev
 ```
 
@@ -50,10 +50,10 @@ yarn dev
 
 ## 인증/세션 동작 요약
 
-- 로그인 상태 조회는 `/member/api/v1/auth/me` 기반.
-- SSR에서 auth 스냅샷(`authMeProbe`)을 주입하고, 비로그인 확정 상태에서는 클라이언트 재검증 호출을 생략.
-- 비로그인 새로고침 시 `auth/me 401` 콘솔 노이즈를 줄이기 위한 억제 로직이 포함되어 있음.
-- 알림 채널은 production에서 `polling-only`를 기본값으로 사용하며, snapshot 요청은 ETag/304 조건부 요청으로 대역폭을 절감한다.
+- 로그인 상태 조회는 `/member/api/v1/auth/me` 기반입니다.
+- SSR에서 auth 스냅샷(`authMeProbe`)을 주입하고, 비로그인 확정 상태에서는 클라이언트 재검증 호출을 생략합니다.
+- 비로그인 새로고침 시 `auth/me 401` 콘솔 노이즈를 줄이기 위한 억제 로직이 포함되어 있습니다.
+- 알림 채널은 production에서 `polling-only`를 기본값으로 사용하며, snapshot 요청은 ETag/304 조건부 요청으로 대역폭을 절감합니다.
 
 관련 코드:
 
@@ -91,6 +91,5 @@ yarn check:bundle-size
 
 ## 문서
 
-- 사람용 인덱스: [`../docs/README.md`](../docs/README.md)
-- 프론트 작업 기준: [`../docs/design/Frontend-Working-Guide.md`](../docs/design/Frontend-Working-Guide.md)
-- 성능 기준: [`../docs/design/Frontend-Performance-Guide.md`](../docs/design/Frontend-Performance-Guide.md)
+- 문서 허브: [../docs/README.md](../docs/README.md)
+- UI 릴리즈 QA: [../docs/design/release-ui-qa-matrix.md](../docs/design/release-ui-qa-matrix.md)

--- a/front/e2e/accessibility.spec.ts
+++ b/front/e2e/accessibility.spec.ts
@@ -88,7 +88,7 @@ const mockAuthenticatedEditor = async (page: Page) => {
           tags: ["a11y"],
           category: "",
           visibility: "PUBLIC_UNLISTED",
-          savedAt: "2026-06-20T10:00:00.000Z",
+          savedAt: new Date().toISOString(),
         })
       )
     },

--- a/tools/guards/check-forbidden-tracked-files.sh
+++ b/tools/guards/check-forbidden-tracked-files.sh
@@ -19,6 +19,7 @@ is_allowed_markdown() {
     back/README.md|\
     back/REFACTORING_ROADMAP.md|\
     deploy/homeserver/HARDENING.md|\
+    docs/README.md|\
     front/.github/CODE_OF_CONDUCT.md|\
     front/.github/CONTRIBUTING.md|\
     front/.github/PULL_REQUEST_TEMPLATE.md|\


### PR DESCRIPTION
## 🔗 Related Issue
- close #1164

## 📝 Summary
- 루트 README를 프로젝트 소개, 주요 기능/구조, 실행 방법, 문서 링크 중심의 진입점으로 축약했습니다.
- 세부 설계/운영/품질/성능/법무 문서는 `docs/README.md` 허브로 넘기고, 프론트 README의 버전/문서 링크 드리프트를 정리했습니다.
- `docs/README.md`가 tracked 문서 허브가 되도록 ignore/guard 허용 목록을 함께 맞췄습니다.

## 🛠 Changes
- `README.md`를 379줄에서 170줄로 줄이고, 운영/트러블슈팅/개선 방향 상세는 문서 링크로 분리했습니다.
- `docs/README.md`를 새 문서 허브로 추가해 실제 존재하는 front/back/perf/deploy/design/legal 문서만 연결했습니다.
- `front/README.md`의 `Next.js 14` 표기를 `Next.js Pages Router`로 바꾸고, 존재하지 않는 프론트 가이드 링크를 실제 존재하는 문서 링크로 교체했습니다.
- `.gitignore`와 `tools/guards/check-forbidden-tracked-files.sh`에 `docs/README.md` 예외를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [ ] 로그/메트릭/운영 지표를 확인했는가? 문서 전용 변경이라 해당 없음.

### 실행한 검증
- `! rg -n "Terraform 기반 인프라 정의|Next\\.js 14|CUSTOM__OAUTH2__KAKAO__CLIENT_ID" README.md front/README.md`: exit 0
- `rg -n "Legacy / experimental Terraform setup|Next\\.js Pages Router|docs/README.md|SPRING__SECURITY__OAUTH2__CLIENT__REGISTRATION__KAKAO__CLIENT_ID|cd ../front" README.md front/README.md docs/README.md`: exit 0
- `rg -n "feed-overview-live|post-detail-live|admin-workspace-live" README.md`: exit 0
- `test -f docs/README.md`: exit 0
- `test -f README.assets/portfolio/feed-overview-live.png`: exit 0
- `test -f README.assets/portfolio/post-detail-live.png`: exit 0
- `test -f README.assets/portfolio/admin-workspace-live.png`: exit 0
- `python3 - <<'PY' ... PY`: `Local README links look valid.`
- `git diff --check README.md docs/README.md front/README.md .gitignore tools/guards/check-forbidden-tracked-files.sh`: exit 0
- `CURRENT_TASK_SLUG=readme-entry-simplification bash tools/guards/check-current-task-state.sh`: exit 0
- `CURRENT_TASK_SLUG=readme-entry-simplification bash tools/guards/check-current-task-scope.sh --worktree`: exit 0
- `yarn --cwd front install --frozen-lockfile`: exit 0
- `yarn --cwd front test:e2e:a11y`: exit 0, 8 passed
- `yarn --cwd front test:e2e:a11y`: exit 0, 8 passed

## 📸 Screenshot / API Example
- 증거 불필요 사유: 런타임 UI/API 동작 변경이 없는 문서 전용 변경입니다.
- 대체 증거: README 이미지 경로 3개 존재 확인과 로컬 상대 링크 검사 통과 결과를 검증 항목에 남겼습니다.

## 🤖 Codex CLI Code Review - 변경 요청 및 재검토

초기 CodeRabbit 리뷰가 한도/크레딧 부족으로 시작되지 않아 Codex CLI로 PR diff를 확인했습니다. 최초 리뷰에서 아래 변경 요청을 확인했고, 같은 PR에 수정 커밋으로 반영했습니다.

실행 정보
- 사유: 초기 CodeRabbit 한도/크레딧 부족으로 Codex fallback 필요
- 범위: PR [[Docs] 루트 README 진입점 정리 #1165](https://github.com/AquilaXk/aquila-blog/pull/1165) (`origin/main...docs/readme-entry-simplification`)
- 명령: `codex review --base origin/main --title "[Docs] 루트 README 진입점 정리"`
- 수정 커밋: `54d83020c1a22c53cb5f85026cf3dfccb0f714ea`
- 재검토 명령: `codex review --base origin/main --title "[Docs] 루트 README 진입점 정리"`

최초 리뷰 결과
- 발견 이슈: `[P2] README.md`: Kakao OAuth 환경 변수명이 실제 Spring Boot 설정 키와 다름
  - 영향: README대로 설정하면 선택 OAuth 연동 client id가 비어 있을 수 있음
  - 요청: 환경 변수 표의 Kakao OAuth key를 실제 설정 키로 교체
  - 반영: `SPRING__SECURITY__OAUTH2__CLIENT__REGISTRATION__KAKAO__CLIENT_ID`로 교체하고 오래된 `CUSTOM__OAUTH2__KAKAO__CLIENT_ID` 문구 제거를 검증
- 발견 이슈: `[P2] README.md`: Quality Checks 명령 블록에서 `cd back` 뒤 `cd front`가 한 셸에서 실패
  - 영향: 복붙 실행 시 `back/front` 경로로 이동하려 해 frontend 검증 명령이 실패
  - 요청: frontend 이동 명령을 루트 기준으로 실행 가능하게 수정
  - 반영: `cd ../front`로 교체하고 새 명령 문구를 검증

재검토 결과
- 결론: 추가 수정 필요 없음
- 남은 이슈: 0건
- 확인한 내용: 기존 inline thread 2개에 해결 답글을 남기고 resolve 처리함
- 후속 확인: frontend-ci 실패 원인이 된 accessibility fixture 만료 문제는 `70d3f928`에서 수정하고 같은 E2E를 로컬에서 2회 연속 통과 확인함
- CodeRabbit 후속 리뷰: blocking finding 없음, README 아키텍처 표현 관련 non-blocking nitpick 1건만 확인됨

검증
- `codex review --base origin/main --title "[Docs] 루트 README 진입점 정리"`: 최초 리뷰 actionable 2건
- `codex review --base origin/main --title "[Docs] 루트 README 진입점 정리"`: 재검토 actionable 0건
- `codex review --base origin/main --title "[Docs] 루트 README 진입점 정리"`: 최신 head `70d3f928` 재검토 actionable 0건
- GitHub review threads: 2개 모두 resolved

후속 조치
- 추가 수정 없음.

## ⚠️ Risk & Rollback
- 예상 리스크: README에서 제거한 상세 설명을 찾는 독자가 문서 허브 링크를 따라가야 합니다.
- 롤백 방법: 이 PR의 네 커밋을 revert 하면 이전 README와 문서 정책으로 돌아갑니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 코드 주석 정책에 맞는 이유/불변조건/운영 영향을 설명하는가? 새 코드 주석 없음.
