### PR TITLE
[Fix] UploadedFile-Object Storage 정합성 reconcile 추가

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapter.kt
@@ -517,7 +517,12 @@ class PostImageStorageAdapter(
             properties.keyPrefix
                 .trim()
                 .trim('/')
-                .ifBlank { "posts" }
+        if (allowedPrefix.isBlank()) {
+            if (normalized.contains("..")) {
+                throw AppException("400-1", "유효하지 않은 이미지 경로입니다.")
+            }
+            return if (normalized.isBlank() || normalized.endsWith("/")) normalized else "$normalized/"
+        }
         if (
             normalized.isBlank() ||
             normalized.contains("..") ||

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapter.kt
@@ -239,7 +239,7 @@ class PostImageStorageAdapter(
         val client = requireClient()
         val objects = mutableListOf<PostImageStoragePort.StoredObjectSummary>()
         var continuationToken: String? = null
-        var hasMore = false
+        var hasMore: Boolean
 
         do {
             val remaining = safeLimit - objects.size

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapter.kt
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.s3.model.CreateBucketRequest
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.S3Exception
@@ -227,6 +228,50 @@ class PostImageStorageAdapter(
 
     override fun deletePostFile(objectKey: String) {
         deleteObject(objectKey, "첨부 파일 삭제에 실패했습니다.")
+    }
+
+    override fun listObjects(
+        prefix: String,
+        limit: Int,
+    ): PostImageStoragePort.StoredObjectListing {
+        val normalizedPrefix = normalizeObjectPrefix(prefix)
+        val safeLimit = limit.coerceIn(1, MAX_LIST_OBJECTS)
+        val client = requireClient()
+        val objects = mutableListOf<PostImageStoragePort.StoredObjectSummary>()
+        var continuationToken: String? = null
+        var hasMore = false
+
+        do {
+            val remaining = safeLimit - objects.size
+            val response =
+                client.listObjectsV2(
+                    ListObjectsV2Request
+                        .builder()
+                        .bucket(properties.bucket)
+                        .prefix(normalizedPrefix)
+                        .maxKeys(remaining.coerceAtMost(S3_PAGE_SIZE))
+                        .continuationToken(continuationToken)
+                        .build(),
+                )
+
+            response.contents().forEach { s3Object ->
+                if (objects.size < safeLimit) {
+                    objects +=
+                        PostImageStoragePort.StoredObjectSummary(
+                            objectKey = s3Object.key(),
+                            size = s3Object.size(),
+                        )
+                }
+            }
+
+            continuationToken = response.nextContinuationToken()
+            hasMore = response.isTruncated == true || continuationToken != null
+        } while (objects.size < safeLimit && continuationToken != null)
+
+        return PostImageStoragePort.StoredObjectListing(
+            objects = objects,
+            isTruncated = hasMore && objects.size >= safeLimit,
+        )
     }
 
     private fun deleteObject(
@@ -466,6 +511,24 @@ class PostImageStorageAdapter(
         }
     }
 
+    private fun normalizeObjectPrefix(prefix: String): String {
+        val normalized = prefix.trim().trimStart('/')
+        val allowedPrefix =
+            properties.keyPrefix
+                .trim()
+                .trim('/')
+                .ifBlank { "posts" }
+        if (
+            normalized.isBlank() ||
+            normalized.contains("..") ||
+            normalized != allowedPrefix &&
+            !normalized.startsWith("$allowedPrefix/")
+        ) {
+            throw AppException("400-1", "유효하지 않은 이미지 경로입니다.")
+        }
+        return if (normalized.endsWith("/")) normalized else "$normalized/"
+    }
+
     private fun decodeStoredOriginalFilename(value: String?): String? {
         val encoded = value?.trim().orEmpty()
         if (encoded.isBlank()) return null
@@ -491,6 +554,8 @@ class PostImageStorageAdapter(
 
         private val ENV_REFERENCE_REGEX = Regex("^\\$\\{([A-Za-z_][A-Za-z0-9_]*)(?::-(.*))?}$")
         private const val IMAGE_SIGNATURE_MAX_BYTES = 16
+        private const val MAX_LIST_OBJECTS = 1_000
+        private const val S3_PAGE_SIZE = 1_000
     }
 
     private fun normalizeDeclaredContentType(raw: String?): String? {

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapter.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapter.kt
@@ -253,8 +253,9 @@ class PostImageStorageAdapter(
                         .continuationToken(continuationToken)
                         .build(),
                 )
+            val responseObjects = response.contents()
 
-            response.contents().forEach { s3Object ->
+            responseObjects.forEach { s3Object ->
                 if (objects.size < safeLimit) {
                     objects +=
                         PostImageStoragePort.StoredObjectSummary(
@@ -265,7 +266,7 @@ class PostImageStorageAdapter(
             }
 
             continuationToken = response.nextContinuationToken()
-            hasMore = response.isTruncated == true || continuationToken != null
+            hasMore = response.isTruncated == true || continuationToken != null || responseObjects.size > remaining
         } while (objects.size < safeLimit && continuationToken != null)
 
         return PostImageStoragePort.StoredObjectListing(

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostImageStoragePort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostImageStoragePort.kt
@@ -30,6 +30,16 @@ interface PostImageStoragePort {
         val originalFilename: String? = null,
     )
 
+    data class StoredObjectSummary(
+        val objectKey: String,
+        val size: Long,
+    )
+
+    data class StoredObjectListing(
+        val objects: List<StoredObjectSummary>,
+        val isTruncated: Boolean,
+    )
+
     fun uploadPostImage(request: UploadImageRequest): String
 
     fun uploadPostFile(request: UploadFileRequest): String
@@ -41,4 +51,9 @@ interface PostImageStoragePort {
     fun deletePostImage(objectKey: String)
 
     fun deletePostFile(objectKey: String)
+
+    fun listObjects(
+        prefix: String,
+        limit: Int,
+    ): StoredObjectListing
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostImageStoragePort.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/port/output/PostImageStoragePort.kt
@@ -52,6 +52,10 @@ interface PostImageStoragePort {
 
     fun deletePostFile(objectKey: String)
 
+    /**
+     * Returns at most [limit] objects under [prefix], ordered stably by `objectKey`.
+     * `isTruncated=true` means additional matching objects may exist beyond this result.
+     */
     fun listObjects(
         prefix: String,
         limit: Int,

--- a/back/src/main/kotlin/com/back/global/storage/adapter/persistence/UploadedFileRepository.kt
+++ b/back/src/main/kotlin/com/back/global/storage/adapter/persistence/UploadedFileRepository.kt
@@ -18,6 +18,8 @@ interface UploadedFileRepository :
     UploadedFileRepositoryPort {
     override fun findByObjectKey(objectKey: String): UploadedFile?
 
+    override fun findByObjectKeyIn(objectKeys: Collection<String>): List<UploadedFile>
+
     override fun findByPurposeAndOwnerTypeAndOwnerIdAndStatusNotOrderByCreatedAtDescIdDesc(
         purpose: UploadedFilePurpose,
         ownerType: UploadedFileOwnerType,
@@ -48,6 +50,12 @@ interface UploadedFileRepository :
     override fun findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
         statuses: Collection<UploadedFileStatus>,
         purgeAfter: Instant,
+        pageable: Pageable,
+    ): List<UploadedFile>
+
+    override fun findByStatusInAndObjectKeyStartingWithOrderByIdAsc(
+        statuses: Collection<UploadedFileStatus>,
+        objectKeyPrefix: String,
         pageable: Pageable,
     ): List<UploadedFile>
 }

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFilePurgeService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFilePurgeService.kt
@@ -83,19 +83,8 @@ class UploadedFilePurgeService(
 
     fun diagnoseCleanup(sampleSize: Int): UploadedFileCleanupDiagnostics {
         val now = now()
+        val cleanupSummary = diagnoseCleanupSummary(sampleSize)
         val safeSampleSize = sampleSize.coerceIn(1, 20)
-        val eligibleCandidates =
-            uploadedFileRepository.findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
-                statuses = purgeCandidateStatuses,
-                purgeAfter = now,
-                pageable = PageRequest.of(0, safeSampleSize),
-            )
-
-        val eligibleCount =
-            uploadedFileRepository.countByStatusInAndPurgeAfterLessThanEqual(
-                purgeCandidateStatuses,
-                now,
-            )
         val reconcileDiagnostics = diagnoseReconcile(now, safeSampleSize)
 
         return UploadedFileCleanupDiagnostics(
@@ -103,14 +92,47 @@ class UploadedFilePurgeService(
             activeCount = uploadedFileRepository.countByStatus(UploadedFileStatus.ACTIVE),
             pendingDeleteCount = uploadedFileRepository.countByStatus(UploadedFileStatus.PENDING_DELETE),
             deletedCount = uploadedFileRepository.countByStatus(UploadedFileStatus.DELETED),
-            eligibleForPurgeCount = eligibleCount,
+            eligibleForPurgeCount = cleanupSummary.eligibleForPurgeCount,
             cleanupSafetyThreshold = retentionProperties.cleanupSafetyThreshold,
-            blockedBySafetyThreshold = eligibleCount > retentionProperties.cleanupSafetyThreshold,
-            oldestEligiblePurgeAfter = eligibleCandidates.firstOrNull()?.purgeAfter,
-            sampleEligibleObjectKeys = eligibleCandidates.map { it.objectKey },
+            blockedBySafetyThreshold = cleanupSummary.blockedBySafetyThreshold,
+            oldestEligiblePurgeAfter = cleanupSummary.oldestEligiblePurgeAfter,
+            sampleEligibleObjectKeys = loadEligibleObjectKeys(now, safeSampleSize),
             reconcile = reconcileDiagnostics,
         )
     }
+
+    fun diagnoseCleanupSummary(sampleSize: Int): UploadedFileCleanupSummary {
+        val now = now()
+        val safeSampleSize = sampleSize.coerceIn(1, 20)
+        val eligibleCandidates =
+            uploadedFileRepository.findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
+                statuses = purgeCandidateStatuses,
+                purgeAfter = now,
+                pageable = PageRequest.of(0, safeSampleSize),
+            )
+        val eligibleCount =
+            uploadedFileRepository.countByStatusInAndPurgeAfterLessThanEqual(
+                purgeCandidateStatuses,
+                now,
+            )
+
+        return UploadedFileCleanupSummary(
+            eligibleForPurgeCount = eligibleCount,
+            blockedBySafetyThreshold = eligibleCount > retentionProperties.cleanupSafetyThreshold,
+            oldestEligiblePurgeAfter = eligibleCandidates.firstOrNull()?.purgeAfter,
+        )
+    }
+
+    private fun loadEligibleObjectKeys(
+        now: Instant,
+        sampleSize: Int,
+    ): List<String> =
+        uploadedFileRepository
+            .findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
+                statuses = purgeCandidateStatuses,
+                purgeAfter = now,
+                pageable = PageRequest.of(0, sampleSize),
+            ).map { it.objectKey }
 
     private fun diagnoseReconcile(
         now: Instant,

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFilePurgeService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFilePurgeService.kt
@@ -1,6 +1,7 @@
 package com.back.global.storage.application
 
 import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
+import com.back.boundedContexts.post.config.PostImageStorageProperties
 import com.back.global.storage.application.port.output.UploadedFileRepositoryPort
 import com.back.global.storage.domain.UploadedFile
 import com.back.global.storage.domain.UploadedFileStatus
@@ -17,6 +18,7 @@ import java.time.Instant
 class UploadedFilePurgeService(
     private val uploadedFileRepository: UploadedFileRepositoryPort,
     private val postImageStoragePort: PostImageStoragePort,
+    private val storageProperties: PostImageStorageProperties,
     private val retentionProperties: UploadedFileRetentionProperties,
     private val referenceQueryService: UploadedFileReferenceQueryService,
     private val transactionManager: PlatformTransactionManager,
@@ -114,9 +116,21 @@ class UploadedFilePurgeService(
         now: Instant,
         sampleSize: Int,
     ): UploadedFileReconcileDiagnostics {
-        val objectPrefix = normalizeReconcilePrefix(retentionProperties.reconcileObjectPrefix)
+        val objectPrefix = resolveReconcilePrefix()
         val inventoryLimit = retentionProperties.reconcileInventoryLimit.coerceIn(1, MAX_RECONCILE_INVENTORY_LIMIT)
-        val inventory = postImageStoragePort.listObjects(objectPrefix, inventoryLimit)
+        val inventory =
+            runCatching { postImageStoragePort.listObjects(objectPrefix, inventoryLimit) }
+                .getOrElse { exception ->
+                    logger.warn(
+                        "Skip uploaded file reconcile inventory because object storage listing failed (prefix={})",
+                        objectPrefix,
+                        exception,
+                    )
+                    return degradedReconcileDiagnostics(
+                        objectPrefix = objectPrefix,
+                        inventoryLimit = inventoryLimit,
+                    )
+                }
         val inventoryObjectKeys = inventory.objects.map { it.objectKey }
         val uploadedFilesByKey =
             if (inventoryObjectKeys.isEmpty()) {
@@ -203,12 +217,36 @@ class UploadedFilePurgeService(
 
     private fun now(): Instant = Instant.now(clock)
 
+    private fun resolveReconcilePrefix(): String =
+        normalizeReconcilePrefix(
+            retentionProperties.reconcileObjectPrefix.ifBlank { storageProperties.keyPrefix },
+        )
+
     private fun normalizeReconcilePrefix(prefix: String): String =
         prefix
             .trim()
             .trimStart('/')
-            .ifBlank { "posts/" }
+            .ifBlank { "posts" }
             .let { if (it.endsWith("/")) it else "$it/" }
+
+    private fun degradedReconcileDiagnostics(
+        objectPrefix: String,
+        inventoryLimit: Int,
+    ): UploadedFileReconcileDiagnostics =
+        UploadedFileReconcileDiagnostics(
+            objectPrefix = objectPrefix,
+            inventoryLimit = inventoryLimit,
+            inventoryObjectCount = 0,
+            inventoryAvailable = false,
+            inventoryTruncated = false,
+            bucketOnlyObjectCount = 0,
+            sampleBucketOnlyObjectKeys = emptyList(),
+            dbOnlyMissingObjectCount = 0,
+            sampleDbOnlyObjectKeys = emptyList(),
+            longLivedPendingDeleteCount = 0,
+            sampleLongLivedPendingDeleteObjectKeys = emptyList(),
+            repairMode = "dry-run-degraded",
+        )
 
     companion object {
         private const val MAX_RECONCILE_INVENTORY_LIMIT = 1_000

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFilePurgeService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFilePurgeService.kt
@@ -149,14 +149,16 @@ class UploadedFilePurgeService(
             uploadedFileRepository.findByStatusInAndObjectKeyStartingWithOrderByIdAsc(
                 statuses = activeStorageStatuses,
                 objectKeyPrefix = objectPrefix,
-                pageable = PageRequest.of(0, inventoryLimit),
+                pageable = PageRequest.of(0, inventoryLimit + 1),
             )
+        val dbRowsTruncated = dbRows.size > inventoryLimit
+        val sampledDbRows = dbRows.take(inventoryLimit)
         val dbOnlyMissingObjectKeys =
             if (inventory.isTruncated) {
                 emptyList()
             } else {
                 val inventorySet = inventoryObjectKeys.toSet()
-                dbRows
+                sampledDbRows
                     .map { it.objectKey }
                     .filterNot(inventorySet::contains)
             }
@@ -178,6 +180,7 @@ class UploadedFilePurgeService(
             inventoryLimit = inventoryLimit,
             inventoryObjectCount = inventory.objects.size,
             inventoryTruncated = inventory.isTruncated,
+            dbRowsTruncated = dbRowsTruncated,
             bucketOnlyObjectCount = inventoryObjectKeys.size - uploadedFilesByKey.size,
             sampleBucketOnlyObjectKeys = bucketOnlyObjectKeys,
             dbOnlyMissingObjectCount = dbOnlyMissingObjectKeys.size,
@@ -226,8 +229,7 @@ class UploadedFilePurgeService(
         prefix
             .trim()
             .trimStart('/')
-            .ifBlank { "posts" }
-            .let { if (it.endsWith("/")) it else "$it/" }
+            .let { if (it.isBlank() || it.endsWith("/")) it else "$it/" }
 
     private fun degradedReconcileDiagnostics(
         objectPrefix: String,
@@ -239,6 +241,7 @@ class UploadedFilePurgeService(
             inventoryObjectCount = 0,
             inventoryAvailable = false,
             inventoryTruncated = false,
+            dbRowsTruncated = false,
             bucketOnlyObjectCount = 0,
             sampleBucketOnlyObjectKeys = emptyList(),
             dbOnlyMissingObjectCount = 0,

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFilePurgeService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFilePurgeService.kt
@@ -118,6 +118,7 @@ class UploadedFilePurgeService(
     ): UploadedFileReconcileDiagnostics {
         val objectPrefix = resolveReconcilePrefix()
         val inventoryLimit = retentionProperties.reconcileInventoryLimit.coerceIn(1, MAX_RECONCILE_INVENTORY_LIMIT)
+        val longLivedPendingDelete = loadLongLivedPendingDeleteDiagnostics(now, sampleSize)
         val inventory =
             runCatching { postImageStoragePort.listObjects(objectPrefix, inventoryLimit) }
                 .getOrElse { exception ->
@@ -129,6 +130,7 @@ class UploadedFilePurgeService(
                     return degradedReconcileDiagnostics(
                         objectPrefix = objectPrefix,
                         inventoryLimit = inventoryLimit,
+                        longLivedPendingDelete = longLivedPendingDelete,
                     )
                 }
         val inventoryObjectKeys = inventory.objects.map { it.objectKey }
@@ -138,6 +140,7 @@ class UploadedFilePurgeService(
             } else {
                 uploadedFileRepository
                     .findByObjectKeyIn(inventoryObjectKeys)
+                    .filter { it.status in activeStorageStatuses }
                     .associateBy { it.objectKey }
             }
         val bucketOnlyObjectKeys =
@@ -162,19 +165,6 @@ class UploadedFilePurgeService(
                     .map { it.objectKey }
                     .filterNot(inventorySet::contains)
             }
-        val longLivedPendingDeleteCutoff = now.minusSeconds(retentionProperties.longPendingDeleteSeconds.coerceAtLeast(1))
-        val longLivedPendingDeleteCandidates =
-            uploadedFileRepository.findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
-                statuses = listOf(UploadedFileStatus.PENDING_DELETE),
-                purgeAfter = longLivedPendingDeleteCutoff,
-                pageable = PageRequest.of(0, sampleSize),
-            )
-        val longLivedPendingDeleteCount =
-            uploadedFileRepository.countByStatusInAndPurgeAfterLessThanEqual(
-                statuses = listOf(UploadedFileStatus.PENDING_DELETE),
-                purgeAfter = longLivedPendingDeleteCutoff,
-            )
-
         return UploadedFileReconcileDiagnostics(
             objectPrefix = objectPrefix,
             inventoryLimit = inventoryLimit,
@@ -185,8 +175,31 @@ class UploadedFilePurgeService(
             sampleBucketOnlyObjectKeys = bucketOnlyObjectKeys,
             dbOnlyMissingObjectCount = dbOnlyMissingObjectKeys.size,
             sampleDbOnlyObjectKeys = dbOnlyMissingObjectKeys.take(sampleSize),
-            longLivedPendingDeleteCount = longLivedPendingDeleteCount,
-            sampleLongLivedPendingDeleteObjectKeys = longLivedPendingDeleteCandidates.map { it.objectKey },
+            longLivedPendingDeleteCount = longLivedPendingDelete.count,
+            sampleLongLivedPendingDeleteObjectKeys = longLivedPendingDelete.sampleObjectKeys,
+        )
+    }
+
+    private fun loadLongLivedPendingDeleteDiagnostics(
+        now: Instant,
+        sampleSize: Int,
+    ): LongLivedPendingDeleteDiagnostics {
+        val cutoff = now.minusSeconds(retentionProperties.longPendingDeleteSeconds.coerceAtLeast(1))
+        val candidates =
+            uploadedFileRepository.findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
+                statuses = listOf(UploadedFileStatus.PENDING_DELETE),
+                purgeAfter = cutoff,
+                pageable = PageRequest.of(0, sampleSize),
+            )
+        val count =
+            uploadedFileRepository.countByStatusInAndPurgeAfterLessThanEqual(
+                statuses = listOf(UploadedFileStatus.PENDING_DELETE),
+                purgeAfter = cutoff,
+            )
+
+        return LongLivedPendingDeleteDiagnostics(
+            count = count,
+            sampleObjectKeys = candidates.map { it.objectKey },
         )
     }
 
@@ -234,6 +247,7 @@ class UploadedFilePurgeService(
     private fun degradedReconcileDiagnostics(
         objectPrefix: String,
         inventoryLimit: Int,
+        longLivedPendingDelete: LongLivedPendingDeleteDiagnostics,
     ): UploadedFileReconcileDiagnostics =
         UploadedFileReconcileDiagnostics(
             objectPrefix = objectPrefix,
@@ -246,10 +260,15 @@ class UploadedFilePurgeService(
             sampleBucketOnlyObjectKeys = emptyList(),
             dbOnlyMissingObjectCount = 0,
             sampleDbOnlyObjectKeys = emptyList(),
-            longLivedPendingDeleteCount = 0,
-            sampleLongLivedPendingDeleteObjectKeys = emptyList(),
+            longLivedPendingDeleteCount = longLivedPendingDelete.count,
+            sampleLongLivedPendingDeleteObjectKeys = longLivedPendingDelete.sampleObjectKeys,
             repairMode = "dry-run-degraded",
         )
+
+    private data class LongLivedPendingDeleteDiagnostics(
+        val count: Long,
+        val sampleObjectKeys: List<String>,
+    )
 
     companion object {
         private const val MAX_RECONCILE_INVENTORY_LIMIT = 1_000

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFilePurgeService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFilePurgeService.kt
@@ -94,6 +94,7 @@ class UploadedFilePurgeService(
                 purgeCandidateStatuses,
                 now,
             )
+        val reconcileDiagnostics = diagnoseReconcile(now, safeSampleSize)
 
         return UploadedFileCleanupDiagnostics(
             tempCount = uploadedFileRepository.countByStatus(UploadedFileStatus.TEMP),
@@ -105,6 +106,70 @@ class UploadedFilePurgeService(
             blockedBySafetyThreshold = eligibleCount > retentionProperties.cleanupSafetyThreshold,
             oldestEligiblePurgeAfter = eligibleCandidates.firstOrNull()?.purgeAfter,
             sampleEligibleObjectKeys = eligibleCandidates.map { it.objectKey },
+            reconcile = reconcileDiagnostics,
+        )
+    }
+
+    private fun diagnoseReconcile(
+        now: Instant,
+        sampleSize: Int,
+    ): UploadedFileReconcileDiagnostics {
+        val objectPrefix = normalizeReconcilePrefix(retentionProperties.reconcileObjectPrefix)
+        val inventoryLimit = retentionProperties.reconcileInventoryLimit.coerceIn(1, MAX_RECONCILE_INVENTORY_LIMIT)
+        val inventory = postImageStoragePort.listObjects(objectPrefix, inventoryLimit)
+        val inventoryObjectKeys = inventory.objects.map { it.objectKey }
+        val uploadedFilesByKey =
+            if (inventoryObjectKeys.isEmpty()) {
+                emptyMap()
+            } else {
+                uploadedFileRepository
+                    .findByObjectKeyIn(inventoryObjectKeys)
+                    .associateBy { it.objectKey }
+            }
+        val bucketOnlyObjectKeys =
+            inventoryObjectKeys
+                .filterNot(uploadedFilesByKey::containsKey)
+                .take(sampleSize)
+
+        val dbRows =
+            uploadedFileRepository.findByStatusInAndObjectKeyStartingWithOrderByIdAsc(
+                statuses = activeStorageStatuses,
+                objectKeyPrefix = objectPrefix,
+                pageable = PageRequest.of(0, inventoryLimit),
+            )
+        val dbOnlyMissingObjectKeys =
+            if (inventory.isTruncated) {
+                emptyList()
+            } else {
+                val inventorySet = inventoryObjectKeys.toSet()
+                dbRows
+                    .map { it.objectKey }
+                    .filterNot(inventorySet::contains)
+            }
+        val longLivedPendingDeleteCutoff = now.minusSeconds(retentionProperties.longPendingDeleteSeconds.coerceAtLeast(1))
+        val longLivedPendingDeleteCandidates =
+            uploadedFileRepository.findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
+                statuses = listOf(UploadedFileStatus.PENDING_DELETE),
+                purgeAfter = longLivedPendingDeleteCutoff,
+                pageable = PageRequest.of(0, sampleSize),
+            )
+        val longLivedPendingDeleteCount =
+            uploadedFileRepository.countByStatusInAndPurgeAfterLessThanEqual(
+                statuses = listOf(UploadedFileStatus.PENDING_DELETE),
+                purgeAfter = longLivedPendingDeleteCutoff,
+            )
+
+        return UploadedFileReconcileDiagnostics(
+            objectPrefix = objectPrefix,
+            inventoryLimit = inventoryLimit,
+            inventoryObjectCount = inventory.objects.size,
+            inventoryTruncated = inventory.isTruncated,
+            bucketOnlyObjectCount = inventoryObjectKeys.size - uploadedFilesByKey.size,
+            sampleBucketOnlyObjectKeys = bucketOnlyObjectKeys,
+            dbOnlyMissingObjectCount = dbOnlyMissingObjectKeys.size,
+            sampleDbOnlyObjectKeys = dbOnlyMissingObjectKeys.take(sampleSize),
+            longLivedPendingDeleteCount = longLivedPendingDeleteCount,
+            sampleLongLivedPendingDeleteObjectKeys = longLivedPendingDeleteCandidates.map { it.objectKey },
         )
     }
 
@@ -137,4 +202,21 @@ class UploadedFilePurgeService(
     }
 
     private fun now(): Instant = Instant.now(clock)
+
+    private fun normalizeReconcilePrefix(prefix: String): String =
+        prefix
+            .trim()
+            .trimStart('/')
+            .ifBlank { "posts/" }
+            .let { if (it.endsWith("/")) it else "$it/" }
+
+    companion object {
+        private const val MAX_RECONCILE_INVENTORY_LIMIT = 1_000
+        private val activeStorageStatuses =
+            listOf(
+                UploadedFileStatus.TEMP,
+                UploadedFileStatus.ACTIVE,
+                UploadedFileStatus.PENDING_DELETE,
+            )
+    }
 }

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinder.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinder.kt
@@ -23,7 +23,7 @@ class UploadedFileReconcileMetricsBinder(
     private val bucketOnlyObjects = AtomicLong(0)
     private val dbOnlyMissingObjects = AtomicLong(0)
     private val longLivedPendingDelete = AtomicLong(0)
-    private val inventoryAvailable = AtomicLong(1)
+    private val inventoryAvailable = AtomicLong(if (workerEnabled && refreshEnabled) 1 else 0)
     private val inventoryTruncated = AtomicLong(0)
     private val dbRowsTruncated = AtomicLong(0)
     private val cleanupRefreshFailures = AtomicLong(0)

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinder.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinder.kt
@@ -23,6 +23,7 @@ class UploadedFileReconcileMetricsBinder(
     private val bucketOnlyObjects = AtomicLong(0)
     private val dbOnlyMissingObjects = AtomicLong(0)
     private val longLivedPendingDelete = AtomicLong(0)
+    private val inventoryAvailable = AtomicLong(1)
     private val inventoryTruncated = AtomicLong(0)
     private val cleanupRefreshFailures = AtomicLong(0)
 
@@ -30,6 +31,7 @@ class UploadedFileReconcileMetricsBinder(
         registerGauge(registry, "storage.uploaded_file.reconcile.bucket_only_objects", bucketOnlyObjects)
         registerGauge(registry, "storage.uploaded_file.reconcile.db_only_missing_objects", dbOnlyMissingObjects)
         registerGauge(registry, "storage.uploaded_file.reconcile.long_lived_pending_delete", longLivedPendingDelete)
+        registerGauge(registry, "storage.uploaded_file.reconcile.inventory_available", inventoryAvailable)
         registerGauge(registry, "storage.uploaded_file.reconcile.inventory_truncated", inventoryTruncated)
         FunctionCounter
             .builder("storage.uploaded_file.cleanup.refresh_failures", cleanupRefreshFailures) { it.get().toDouble() }
@@ -51,6 +53,7 @@ class UploadedFileReconcileMetricsBinder(
                 bucketOnlyObjects.set(reconcile.bucketOnlyObjectCount.toLong())
                 dbOnlyMissingObjects.set(reconcile.dbOnlyMissingObjectCount.toLong())
                 longLivedPendingDelete.set(reconcile.longLivedPendingDeleteCount)
+                inventoryAvailable.set(if (reconcile.inventoryAvailable) 1 else 0)
                 inventoryTruncated.set(if (reconcile.inventoryTruncated) 1 else 0)
             }.onFailure { exception ->
                 cleanupRefreshFailures.incrementAndGet()

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinder.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinder.kt
@@ -25,6 +25,7 @@ class UploadedFileReconcileMetricsBinder(
     private val longLivedPendingDelete = AtomicLong(0)
     private val inventoryAvailable = AtomicLong(1)
     private val inventoryTruncated = AtomicLong(0)
+    private val dbRowsTruncated = AtomicLong(0)
     private val cleanupRefreshFailures = AtomicLong(0)
 
     override fun bindTo(registry: MeterRegistry) {
@@ -33,6 +34,7 @@ class UploadedFileReconcileMetricsBinder(
         registerGauge(registry, "storage.uploaded_file.reconcile.long_lived_pending_delete", longLivedPendingDelete)
         registerGauge(registry, "storage.uploaded_file.reconcile.inventory_available", inventoryAvailable)
         registerGauge(registry, "storage.uploaded_file.reconcile.inventory_truncated", inventoryTruncated)
+        registerGauge(registry, "storage.uploaded_file.reconcile.db_rows_truncated", dbRowsTruncated)
         FunctionCounter
             .builder("storage.uploaded_file.cleanup.refresh_failures", cleanupRefreshFailures) { it.get().toDouble() }
             .register(registry)
@@ -55,6 +57,7 @@ class UploadedFileReconcileMetricsBinder(
                 longLivedPendingDelete.set(reconcile.longLivedPendingDeleteCount)
                 inventoryAvailable.set(if (reconcile.inventoryAvailable) 1 else 0)
                 inventoryTruncated.set(if (reconcile.inventoryTruncated) 1 else 0)
+                dbRowsTruncated.set(if (reconcile.dbRowsTruncated) 1 else 0)
             }.onFailure { exception ->
                 cleanupRefreshFailures.incrementAndGet()
                 logger.warn("Skip uploaded file reconcile metrics refresh due to diagnostics error", exception)

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinder.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinder.kt
@@ -1,0 +1,70 @@
+package com.back.global.storage.application
+
+import io.micrometer.core.instrument.FunctionCounter
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.binder.MeterBinder
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicLong
+
+@Component
+class UploadedFileReconcileMetricsBinder(
+    private val uploadedFileRetentionService: UploadedFileRetentionService,
+    @Value("\${custom.runtime.worker-enabled:true}")
+    private val workerEnabled: Boolean,
+    @Value("\${custom.storage.retention.reconcileMetricsRefreshEnabled:true}")
+    private val refreshEnabled: Boolean,
+) : MeterBinder {
+    private val logger = LoggerFactory.getLogger(UploadedFileReconcileMetricsBinder::class.java)
+
+    private val bucketOnlyObjects = AtomicLong(0)
+    private val dbOnlyMissingObjects = AtomicLong(0)
+    private val longLivedPendingDelete = AtomicLong(0)
+    private val inventoryTruncated = AtomicLong(0)
+    private val cleanupRefreshFailures = AtomicLong(0)
+
+    override fun bindTo(registry: MeterRegistry) {
+        registerGauge(registry, "storage.uploaded_file.reconcile.bucket_only_objects", bucketOnlyObjects)
+        registerGauge(registry, "storage.uploaded_file.reconcile.db_only_missing_objects", dbOnlyMissingObjects)
+        registerGauge(registry, "storage.uploaded_file.reconcile.long_lived_pending_delete", longLivedPendingDelete)
+        registerGauge(registry, "storage.uploaded_file.reconcile.inventory_truncated", inventoryTruncated)
+        FunctionCounter
+            .builder("storage.uploaded_file.cleanup.refresh_failures", cleanupRefreshFailures) { it.get().toDouble() }
+            .register(registry)
+    }
+
+    @Scheduled(
+        initialDelayString = "\${custom.storage.retention.reconcileMetricsInitialDelayMs:60000}",
+        fixedDelayString = "\${custom.storage.retention.reconcileMetricsRefreshFixedDelayMs:60000}",
+    )
+    fun refreshSnapshot() {
+        if (!refreshEnabled || !workerEnabled) {
+            return
+        }
+
+        runCatching { uploadedFileRetentionService.diagnoseCleanup() }
+            .onSuccess { diagnostics ->
+                val reconcile = diagnostics.reconcile
+                bucketOnlyObjects.set(reconcile.bucketOnlyObjectCount.toLong())
+                dbOnlyMissingObjects.set(reconcile.dbOnlyMissingObjectCount.toLong())
+                longLivedPendingDelete.set(reconcile.longLivedPendingDeleteCount)
+                inventoryTruncated.set(if (reconcile.inventoryTruncated) 1 else 0)
+            }.onFailure { exception ->
+                cleanupRefreshFailures.incrementAndGet()
+                logger.warn("Skip uploaded file reconcile metrics refresh due to diagnostics error", exception)
+            }
+    }
+
+    private fun registerGauge(
+        registry: MeterRegistry,
+        name: String,
+        holder: AtomicLong,
+    ) {
+        Gauge
+            .builder(name) { holder.get().toDouble() }
+            .register(registry)
+    }
+}

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionProperties.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionProperties.kt
@@ -10,4 +10,7 @@ data class UploadedFileRetentionProperties(
     val cleanupFixedDelayMs: Long = 3_600_000,
     val cleanupBatchSize: Int = 100,
     val cleanupSafetyThreshold: Int = 25,
+    val reconcileObjectPrefix: String = "posts/",
+    val reconcileInventoryLimit: Int = 1_000,
+    val longPendingDeleteSeconds: Long = 2_592_000,
 )

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionProperties.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionProperties.kt
@@ -10,7 +10,7 @@ data class UploadedFileRetentionProperties(
     val cleanupFixedDelayMs: Long = 3_600_000,
     val cleanupBatchSize: Int = 100,
     val cleanupSafetyThreshold: Int = 25,
-    val reconcileObjectPrefix: String = "posts/",
+    val reconcileObjectPrefix: String = "",
     val reconcileInventoryLimit: Int = 1_000,
     val longPendingDeleteSeconds: Long = 2_592_000,
 )

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
@@ -16,6 +16,21 @@ data class UploadedFileCleanupDiagnostics(
     val blockedBySafetyThreshold: Boolean,
     val oldestEligiblePurgeAfter: Instant?,
     val sampleEligibleObjectKeys: List<String>,
+    val reconcile: UploadedFileReconcileDiagnostics,
+)
+
+data class UploadedFileReconcileDiagnostics(
+    val objectPrefix: String,
+    val inventoryLimit: Int,
+    val inventoryObjectCount: Int,
+    val inventoryTruncated: Boolean,
+    val bucketOnlyObjectCount: Int,
+    val sampleBucketOnlyObjectKeys: List<String>,
+    val dbOnlyMissingObjectCount: Int,
+    val sampleDbOnlyObjectKeys: List<String>,
+    val longLivedPendingDeleteCount: Long,
+    val sampleLongLivedPendingDeleteObjectKeys: List<String>,
+    val repairMode: String = "dry-run",
 )
 
 data class ProfileImageHistoryDto(

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
@@ -23,6 +23,7 @@ data class UploadedFileReconcileDiagnostics(
     val objectPrefix: String,
     val inventoryLimit: Int,
     val inventoryObjectCount: Int,
+    val inventoryAvailable: Boolean = true,
     val inventoryTruncated: Boolean,
     val bucketOnlyObjectCount: Int,
     val sampleBucketOnlyObjectKeys: List<String>,

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
@@ -19,6 +19,12 @@ data class UploadedFileCleanupDiagnostics(
     val reconcile: UploadedFileReconcileDiagnostics,
 )
 
+data class UploadedFileCleanupSummary(
+    val eligibleForPurgeCount: Long,
+    val blockedBySafetyThreshold: Boolean,
+    val oldestEligiblePurgeAfter: Instant?,
+)
+
 data class UploadedFileReconcileDiagnostics(
     val objectPrefix: String,
     val inventoryLimit: Int,
@@ -147,4 +153,6 @@ class UploadedFileRetentionService(
     }
 
     fun diagnoseCleanup(sampleSize: Int = 5): UploadedFileCleanupDiagnostics = purgeService.diagnoseCleanup(sampleSize)
+
+    fun diagnoseCleanupSummary(sampleSize: Int = 5): UploadedFileCleanupSummary = purgeService.diagnoseCleanupSummary(sampleSize)
 }

--- a/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/UploadedFileRetentionService.kt
@@ -25,6 +25,7 @@ data class UploadedFileReconcileDiagnostics(
     val inventoryObjectCount: Int,
     val inventoryAvailable: Boolean = true,
     val inventoryTruncated: Boolean,
+    val dbRowsTruncated: Boolean = false,
     val bucketOnlyObjectCount: Int,
     val sampleBucketOnlyObjectKeys: List<String>,
     val dbOnlyMissingObjectCount: Int,

--- a/back/src/main/kotlin/com/back/global/storage/application/port/output/UploadedFileRepositoryPort.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/port/output/UploadedFileRepositoryPort.kt
@@ -14,6 +14,8 @@ interface UploadedFileRepositoryPort {
 
     fun findByObjectKey(objectKey: String): UploadedFile?
 
+    fun findByObjectKeyIn(objectKeys: Collection<String>): List<UploadedFile>
+
     fun findByPurposeAndOwnerTypeAndOwnerIdAndStatusNotOrderByCreatedAtDescIdDesc(
         purpose: UploadedFilePurpose,
         ownerType: UploadedFileOwnerType,
@@ -38,6 +40,12 @@ interface UploadedFileRepositoryPort {
     fun findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
         statuses: Collection<UploadedFileStatus>,
         purgeAfter: Instant,
+        pageable: Pageable,
+    ): List<UploadedFile>
+
+    fun findByStatusInAndObjectKeyStartingWithOrderByIdAsc(
+        statuses: Collection<UploadedFileStatus>,
+        objectKeyPrefix: String,
         pageable: Pageable,
     ): List<UploadedFile>
 }

--- a/back/src/main/kotlin/com/back/global/system/application/AdminDashboardSnapshotService.kt
+++ b/back/src/main/kotlin/com/back/global/system/application/AdminDashboardSnapshotService.kt
@@ -59,7 +59,7 @@ class AdminDashboardSnapshotService(
         val taskQueue = taskQueueDiagnosticsService.diagnoseQueue()
         val signupMail = signupMailDiagnosticsService.diagnose(checkConnection = false)
         val authEvents = authSecurityEventService.getRecent(30)
-        val cleanup = uploadedFileRetentionService.diagnoseCleanup()
+        val cleanup = uploadedFileRetentionService.diagnoseCleanupSummary()
         val latestFailure = taskQueue.recentFailures.firstOrNull()
         val latestTaskTypeFailure = taskQueue.taskTypes.firstOrNull { it.latestFailureAt != null }
         val latestBlockedEvent =

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapterTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapterTest.kt
@@ -2,9 +2,15 @@ package com.back.boundedContexts.post.adapter.storage
 
 import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
 import com.back.boundedContexts.post.config.PostImageStorageProperties
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.springframework.test.util.ReflectionTestUtils
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response
+import software.amazon.awssdk.services.s3.model.S3Object
 import java.io.ByteArrayInputStream
 
 @DisplayName("PostImageStorageAdapter 테스트")
@@ -45,6 +51,65 @@ class PostImageStorageAdapterTest {
             adapter.getPostImage("posts/2026/06/image.png")
         }.hasMessageContaining("503-1")
             .hasMessageContaining("이미지 스토리지가 비활성화되어 있습니다.")
+    }
+
+    @Test
+    @DisplayName("listObjects는 post prefix와 limit으로 S3 inventory를 조회한다")
+    fun listObjectsUsesConfiguredPostPrefixAndLimit() {
+        // given
+        val s3Client =
+            RecordingS3Client(
+                ListObjectsV2Response
+                    .builder()
+                    .contents(
+                        S3Object
+                            .builder()
+                            .key("posts/2026/06/a.png")
+                            .size(10L)
+                            .build(),
+                        S3Object
+                            .builder()
+                            .key("posts/2026/06/b.png")
+                            .size(20L)
+                            .build(),
+                    ).isTruncated(false)
+                    .build(),
+            )
+        val adapter =
+            PostImageStorageAdapter(
+                PostImageStorageProperties(
+                    enabled = true,
+                    bucket = "test-bucket",
+                    keyPrefix = "posts",
+                ),
+            )
+        ReflectionTestUtils.setField(adapter, "s3Client", s3Client)
+
+        // when
+        val listing = adapter.listObjects("posts/2026/06", limit = 25)
+
+        // then
+        assertThat(s3Client.lastListObjectsRequest!!.bucket()).isEqualTo("test-bucket")
+        assertThat(s3Client.lastListObjectsRequest!!.prefix()).isEqualTo("posts/2026/06/")
+        assertThat(s3Client.lastListObjectsRequest!!.maxKeys()).isEqualTo(25)
+        assertThat(listing.isTruncated).isFalse()
+        assertThat(listing.objects).containsExactly(
+            PostImageStoragePort.StoredObjectSummary("posts/2026/06/a.png", 10),
+            PostImageStoragePort.StoredObjectSummary("posts/2026/06/b.png", 20),
+        )
+    }
+
+    @Test
+    @DisplayName("listObjects는 post prefix 밖 inventory 요청을 거절한다")
+    fun listObjectsRejectsPrefixOutsideConfiguredPostPrefix() {
+        // given
+        val adapter = disabledAdapter()
+
+        // when & then
+        assertThatThrownBy {
+            adapter.listObjects("cloud/2026/06", limit = 25)
+        }.hasMessageContaining("400-1")
+            .hasMessageContaining("유효하지 않은 이미지 경로입니다.")
     }
 
     @Test
@@ -168,4 +233,21 @@ class PostImageStorageAdapterTest {
             0x0A,
             0x00,
         )
+
+    private class RecordingS3Client(
+        private val response: ListObjectsV2Response,
+    ) : S3Client {
+        var lastListObjectsRequest: ListObjectsV2Request? = null
+            private set
+
+        override fun listObjectsV2(listObjectsV2Request: ListObjectsV2Request): ListObjectsV2Response {
+            lastListObjectsRequest = listObjectsV2Request
+            return response
+        }
+
+        override fun serviceName(): String = "s3"
+
+        override fun close() {
+        }
+    }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapterTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapterTest.kt
@@ -66,16 +66,8 @@ class PostImageStorageAdapterTest {
                 ListObjectsV2Response
                     .builder()
                     .contents(
-                        S3Object
-                            .builder()
-                            .key("posts/2026/06/a.png")
-                            .size(10L)
-                            .build(),
-                        S3Object
-                            .builder()
-                            .key("posts/2026/06/b.png")
-                            .size(20L)
-                            .build(),
+                        s3Object("posts/2026/06/a.png", 10),
+                        s3Object("posts/2026/06/b.png", 20),
                     ).isTruncated(false)
                     .build(),
             )
@@ -104,6 +96,51 @@ class PostImageStorageAdapterTest {
     }
 
     @Test
+    @DisplayName("listObjects는 continuation token과 limit 중간 절단을 truncated로 표시한다")
+    fun listObjectsMarksTruncatedWhenLimitCutsThroughPagedResponses() {
+        // given
+        val s3Client =
+            RecordingS3Client(
+                ListObjectsV2Response
+                    .builder()
+                    .contents(s3Object("posts/2026/06/a.png", 10))
+                    .nextContinuationToken("page-2")
+                    .isTruncated(true)
+                    .build(),
+                ListObjectsV2Response
+                    .builder()
+                    .contents(
+                        s3Object("posts/2026/06/b.png", 20),
+                        s3Object("posts/2026/06/c.png", 30),
+                    ).isTruncated(false)
+                    .build(),
+            )
+        val adapter =
+            PostImageStorageAdapter(
+                PostImageStorageProperties(
+                    enabled = true,
+                    bucket = TEST_BUCKET,
+                    keyPrefix = "posts",
+                ),
+            )
+        ReflectionTestUtils.setField(adapter, "s3Client", s3Client)
+
+        // when
+        val listing = adapter.listObjects("posts/2026/06", limit = 2)
+
+        // then
+        assertThat(s3Client.listObjectsRequests).hasSize(2)
+        assertThat(s3Client.listObjectsRequests[0].maxKeys()).isEqualTo(2)
+        assertThat(s3Client.listObjectsRequests[1].continuationToken()).isEqualTo("page-2")
+        assertThat(s3Client.listObjectsRequests[1].maxKeys()).isEqualTo(1)
+        assertThat(listing.isTruncated).isTrue()
+        assertThat(listing.objects).containsExactly(
+            PostImageStoragePort.StoredObjectSummary("posts/2026/06/a.png", 10),
+            PostImageStoragePort.StoredObjectSummary("posts/2026/06/b.png", 20),
+        )
+    }
+
+    @Test
     @DisplayName("listObjects는 post prefix 밖 inventory 요청을 거절한다")
     fun listObjectsRejectsPrefixOutsideConfiguredPostPrefix() {
         // given
@@ -125,11 +162,7 @@ class PostImageStorageAdapterTest {
                 ListObjectsV2Response
                     .builder()
                     .contents(
-                        S3Object
-                            .builder()
-                            .key("2026/06/root.png")
-                            .size(10L)
-                            .build(),
+                        s3Object("2026/06/root.png", 10),
                     ).isTruncated(false)
                     .build(),
             )
@@ -275,15 +308,29 @@ class PostImageStorageAdapterTest {
             0x00,
         )
 
+    private fun s3Object(
+        key: String,
+        size: Long,
+    ): S3Object =
+        S3Object
+            .builder()
+            .key(key)
+            .size(size)
+            .build()
+
     private class RecordingS3Client(
-        private val response: ListObjectsV2Response,
+        firstResponse: ListObjectsV2Response,
+        vararg otherResponses: ListObjectsV2Response,
     ) : S3Client {
+        private val responses = ArrayDeque(listOf(firstResponse, *otherResponses))
+        val listObjectsRequests = mutableListOf<ListObjectsV2Request>()
         var lastListObjectsRequest: ListObjectsV2Request? = null
             private set
 
         override fun listObjectsV2(listObjectsV2Request: ListObjectsV2Request): ListObjectsV2Response {
             lastListObjectsRequest = listObjectsV2Request
-            return response
+            listObjectsRequests += listObjectsV2Request
+            return responses.removeFirst()
         }
 
         override fun serviceName(): String = "s3"

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapterTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapterTest.kt
@@ -15,6 +15,10 @@ import java.io.ByteArrayInputStream
 
 @DisplayName("PostImageStorageAdapter 테스트")
 class PostImageStorageAdapterTest {
+    private companion object {
+        const val TEST_BUCKET = "test-bucket"
+    }
+
     @Test
     @DisplayName("post prefix 밖 object key는 storage 접근 전에 거절한다")
     fun `post object reader rejects keys outside configured post prefix before storage access`() {
@@ -79,7 +83,7 @@ class PostImageStorageAdapterTest {
             PostImageStorageAdapter(
                 PostImageStorageProperties(
                     enabled = true,
-                    bucket = "test-bucket",
+                    bucket = TEST_BUCKET,
                     keyPrefix = "posts",
                 ),
             )
@@ -89,7 +93,7 @@ class PostImageStorageAdapterTest {
         val listing = adapter.listObjects("posts/2026/06", limit = 25)
 
         // then
-        assertThat(s3Client.lastListObjectsRequest!!.bucket()).isEqualTo("test-bucket")
+        assertThat(s3Client.lastListObjectsRequest!!.bucket()).isEqualTo(TEST_BUCKET)
         assertThat(s3Client.lastListObjectsRequest!!.prefix()).isEqualTo("posts/2026/06/")
         assertThat(s3Client.lastListObjectsRequest!!.maxKeys()).isEqualTo(25)
         assertThat(listing.isTruncated).isFalse()
@@ -133,7 +137,7 @@ class PostImageStorageAdapterTest {
             PostImageStorageAdapter(
                 PostImageStorageProperties(
                     enabled = true,
-                    bucket = "test-bucket",
+                    bucket = TEST_BUCKET,
                     keyPrefix = "",
                 ),
             )
@@ -285,6 +289,7 @@ class PostImageStorageAdapterTest {
         override fun serviceName(): String = "s3"
 
         override fun close() {
+            // S3Client test double has no resources to close.
         }
     }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapterTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/storage/PostImageStorageAdapterTest.kt
@@ -113,6 +113,43 @@ class PostImageStorageAdapterTest {
     }
 
     @Test
+    @DisplayName("listObjects는 빈 keyPrefix에서 bucket root inventory를 조회한다")
+    fun listObjectsAllowsRootPrefixWhenConfiguredPrefixIsBlank() {
+        // given
+        val s3Client =
+            RecordingS3Client(
+                ListObjectsV2Response
+                    .builder()
+                    .contents(
+                        S3Object
+                            .builder()
+                            .key("2026/06/root.png")
+                            .size(10L)
+                            .build(),
+                    ).isTruncated(false)
+                    .build(),
+            )
+        val adapter =
+            PostImageStorageAdapter(
+                PostImageStorageProperties(
+                    enabled = true,
+                    bucket = "test-bucket",
+                    keyPrefix = "",
+                ),
+            )
+        ReflectionTestUtils.setField(adapter, "s3Client", s3Client)
+
+        // when
+        val listing = adapter.listObjects("", limit = 25)
+
+        // then
+        assertThat(s3Client.lastListObjectsRequest!!.prefix()).isEqualTo("")
+        assertThat(listing.objects).containsExactly(
+            PostImageStoragePort.StoredObjectSummary("2026/06/root.png", 10),
+        )
+    }
+
+    @Test
     @DisplayName("stream 이미지 업로드는 빈 contentLength를 storage 접근 전에 거절한다")
     fun rejectEmptyImageUploadBeforeStorageAccess() {
         // given

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageControllerTest.kt
@@ -108,6 +108,11 @@ class ApiV1PostImageControllerTest {
         override fun deletePostImage(objectKey: String) {}
 
         override fun deletePostFile(objectKey: String) {}
+
+        override fun listObjects(
+            prefix: String,
+            limit: Int,
+        ): PostImageStoragePort.StoredObjectListing = PostImageStoragePort.StoredObjectListing(emptyList(), isTruncated = false)
     }
 
     private class ByteAccessFailingMultipartFile(

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinderTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinderTest.kt
@@ -1,0 +1,124 @@
+package com.back.global.storage.application
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.springframework.scheduling.annotation.Scheduled
+import java.time.Instant
+
+class UploadedFileReconcileMetricsBinderTest {
+    @Test
+    fun `worker disabled runtime은 reconcile metrics refresh를 실행하지 않는다`() {
+        val retentionService = mock(UploadedFileRetentionService::class.java)
+        val binder =
+            UploadedFileReconcileMetricsBinder(
+                uploadedFileRetentionService = retentionService,
+                workerEnabled = false,
+                refreshEnabled = true,
+            )
+
+        binder.refreshSnapshot()
+
+        verifyNoInteractions(retentionService)
+    }
+
+    @Test
+    fun `reconcile diagnostics를 metric gauge로 노출한다`() {
+        val retentionService = mock(UploadedFileRetentionService::class.java)
+        given(retentionService.diagnoseCleanup()).willReturn(
+            diagnostics(
+                bucketOnlyObjectCount = 2,
+                dbOnlyMissingObjectCount = 3,
+                longLivedPendingDeleteCount = 4,
+                inventoryTruncated = true,
+            ),
+        )
+        val registry = SimpleMeterRegistry()
+        val binder =
+            UploadedFileReconcileMetricsBinder(
+                uploadedFileRetentionService = retentionService,
+                workerEnabled = true,
+                refreshEnabled = true,
+            )
+
+        binder.bindTo(registry)
+        binder.refreshSnapshot()
+
+        assertThat(registry.get("storage.uploaded_file.reconcile.bucket_only_objects").gauge().value()).isEqualTo(2.0)
+        assertThat(registry.get("storage.uploaded_file.reconcile.db_only_missing_objects").gauge().value()).isEqualTo(3.0)
+        assertThat(registry.get("storage.uploaded_file.reconcile.long_lived_pending_delete").gauge().value()).isEqualTo(4.0)
+        assertThat(registry.get("storage.uploaded_file.reconcile.inventory_truncated").gauge().value()).isEqualTo(1.0)
+        assertThat(registry.get("storage.uploaded_file.cleanup.refresh_failures").functionCounter().count()).isEqualTo(0.0)
+        verify(retentionService).diagnoseCleanup()
+    }
+
+    @Test
+    fun `diagnostics 실패는 cleanup refresh failure metric으로 누적한다`() {
+        val retentionService = mock(UploadedFileRetentionService::class.java)
+        given(retentionService.diagnoseCleanup()).willThrow(IllegalStateException("storage unavailable"))
+        val registry = SimpleMeterRegistry()
+        val binder =
+            UploadedFileReconcileMetricsBinder(
+                uploadedFileRetentionService = retentionService,
+                workerEnabled = true,
+                refreshEnabled = true,
+            )
+
+        binder.bindTo(registry)
+        binder.refreshSnapshot()
+        binder.refreshSnapshot()
+
+        assertThat(registry.get("storage.uploaded_file.cleanup.refresh_failures").functionCounter().count()).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `metrics refresh 기본 주기는 운영 inventory 부하를 줄이기 위해 60초다`() {
+        val scheduled =
+            UploadedFileReconcileMetricsBinder::class
+                .members
+                .single { it.name == "refreshSnapshot" }
+                .annotations
+                .filterIsInstance<Scheduled>()
+                .single()
+
+        assertThat(scheduled.fixedDelayString)
+            .isEqualTo("\${custom.storage.retention.reconcileMetricsRefreshFixedDelayMs:60000}")
+        assertThat(scheduled.initialDelayString)
+            .isEqualTo("\${custom.storage.retention.reconcileMetricsInitialDelayMs:60000}")
+    }
+
+    private fun diagnostics(
+        bucketOnlyObjectCount: Int = 0,
+        dbOnlyMissingObjectCount: Int = 0,
+        longLivedPendingDeleteCount: Long = 0,
+        inventoryTruncated: Boolean = false,
+    ): UploadedFileCleanupDiagnostics =
+        UploadedFileCleanupDiagnostics(
+            tempCount = 0,
+            activeCount = 0,
+            pendingDeleteCount = 0,
+            deletedCount = 0,
+            eligibleForPurgeCount = 0,
+            cleanupSafetyThreshold = 25,
+            blockedBySafetyThreshold = false,
+            oldestEligiblePurgeAfter = Instant.EPOCH,
+            sampleEligibleObjectKeys = emptyList(),
+            reconcile =
+                UploadedFileReconcileDiagnostics(
+                    objectPrefix = "posts/",
+                    inventoryLimit = 1_000,
+                    inventoryObjectCount = bucketOnlyObjectCount,
+                    inventoryTruncated = inventoryTruncated,
+                    bucketOnlyObjectCount = bucketOnlyObjectCount,
+                    sampleBucketOnlyObjectKeys = emptyList(),
+                    dbOnlyMissingObjectCount = dbOnlyMissingObjectCount,
+                    sampleDbOnlyObjectKeys = emptyList(),
+                    longLivedPendingDeleteCount = longLivedPendingDeleteCount,
+                    sampleLongLivedPendingDeleteObjectKeys = emptyList(),
+                ),
+        )
+}

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinderTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinderTest.kt
@@ -34,6 +34,7 @@ class UploadedFileReconcileMetricsBinderTest {
                 bucketOnlyObjectCount = 2,
                 dbOnlyMissingObjectCount = 3,
                 longLivedPendingDeleteCount = 4,
+                inventoryAvailable = false,
                 inventoryTruncated = true,
             ),
         )
@@ -51,6 +52,7 @@ class UploadedFileReconcileMetricsBinderTest {
         assertThat(registry.get("storage.uploaded_file.reconcile.bucket_only_objects").gauge().value()).isEqualTo(2.0)
         assertThat(registry.get("storage.uploaded_file.reconcile.db_only_missing_objects").gauge().value()).isEqualTo(3.0)
         assertThat(registry.get("storage.uploaded_file.reconcile.long_lived_pending_delete").gauge().value()).isEqualTo(4.0)
+        assertThat(registry.get("storage.uploaded_file.reconcile.inventory_available").gauge().value()).isEqualTo(0.0)
         assertThat(registry.get("storage.uploaded_file.reconcile.inventory_truncated").gauge().value()).isEqualTo(1.0)
         assertThat(registry.get("storage.uploaded_file.cleanup.refresh_failures").functionCounter().count()).isEqualTo(0.0)
         verify(retentionService).diagnoseCleanup()
@@ -95,6 +97,7 @@ class UploadedFileReconcileMetricsBinderTest {
         bucketOnlyObjectCount: Int = 0,
         dbOnlyMissingObjectCount: Int = 0,
         longLivedPendingDeleteCount: Long = 0,
+        inventoryAvailable: Boolean = true,
         inventoryTruncated: Boolean = false,
     ): UploadedFileCleanupDiagnostics =
         UploadedFileCleanupDiagnostics(
@@ -112,6 +115,7 @@ class UploadedFileReconcileMetricsBinderTest {
                     objectPrefix = "posts/",
                     inventoryLimit = 1_000,
                     inventoryObjectCount = bucketOnlyObjectCount,
+                    inventoryAvailable = inventoryAvailable,
                     inventoryTruncated = inventoryTruncated,
                     bucketOnlyObjectCount = bucketOnlyObjectCount,
                     sampleBucketOnlyObjectKeys = emptyList(),

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinderTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinderTest.kt
@@ -36,6 +36,7 @@ class UploadedFileReconcileMetricsBinderTest {
                 longLivedPendingDeleteCount = 4,
                 inventoryAvailable = false,
                 inventoryTruncated = true,
+                dbRowsTruncated = true,
             ),
         )
         val registry = SimpleMeterRegistry()
@@ -54,6 +55,7 @@ class UploadedFileReconcileMetricsBinderTest {
         assertThat(registry.get("storage.uploaded_file.reconcile.long_lived_pending_delete").gauge().value()).isEqualTo(4.0)
         assertThat(registry.get("storage.uploaded_file.reconcile.inventory_available").gauge().value()).isEqualTo(0.0)
         assertThat(registry.get("storage.uploaded_file.reconcile.inventory_truncated").gauge().value()).isEqualTo(1.0)
+        assertThat(registry.get("storage.uploaded_file.reconcile.db_rows_truncated").gauge().value()).isEqualTo(1.0)
         assertThat(registry.get("storage.uploaded_file.cleanup.refresh_failures").functionCounter().count()).isEqualTo(0.0)
         verify(retentionService).diagnoseCleanup()
     }
@@ -99,6 +101,7 @@ class UploadedFileReconcileMetricsBinderTest {
         longLivedPendingDeleteCount: Long = 0,
         inventoryAvailable: Boolean = true,
         inventoryTruncated: Boolean = false,
+        dbRowsTruncated: Boolean = false,
     ): UploadedFileCleanupDiagnostics =
         UploadedFileCleanupDiagnostics(
             tempCount = 0,
@@ -117,6 +120,7 @@ class UploadedFileReconcileMetricsBinderTest {
                     inventoryObjectCount = bucketOnlyObjectCount,
                     inventoryAvailable = inventoryAvailable,
                     inventoryTruncated = inventoryTruncated,
+                    dbRowsTruncated = dbRowsTruncated,
                     bucketOnlyObjectCount = bucketOnlyObjectCount,
                     sampleBucketOnlyObjectKeys = emptyList(),
                     dbOnlyMissingObjectCount = dbOnlyMissingObjectCount,

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinderTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileReconcileMetricsBinderTest.kt
@@ -14,6 +14,7 @@ class UploadedFileReconcileMetricsBinderTest {
     @Test
     fun `worker disabled runtime은 reconcile metrics refresh를 실행하지 않는다`() {
         val retentionService = mock(UploadedFileRetentionService::class.java)
+        val registry = SimpleMeterRegistry()
         val binder =
             UploadedFileReconcileMetricsBinder(
                 uploadedFileRetentionService = retentionService,
@@ -21,8 +22,10 @@ class UploadedFileReconcileMetricsBinderTest {
                 refreshEnabled = true,
             )
 
+        binder.bindTo(registry)
         binder.refreshSnapshot()
 
+        assertThat(registry.get("storage.uploaded_file.reconcile.inventory_available").gauge().value()).isEqualTo(0.0)
         verifyNoInteractions(retentionService)
     }
 

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
@@ -174,14 +174,51 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
         verify(postImageStoragePort).deletePostImage("posts/2026/03/delete-fail.png")
     }
 
-    private fun newService(repository: UploadedFileRepositoryPort): UploadedFileRetentionService =
+    @Test
+    fun `cleanup diagnostics는 object storage listing 실패 시 degraded reconcile만 반환한다`() {
+        `when`(postImageStoragePort.listObjects("posts/", 1000))
+            .thenThrow(IllegalStateException("storage unavailable"))
+        val service = newService(SuccessfulRepository())
+
+        val diagnostics = service.diagnoseCleanup()
+
+        assertThat(diagnostics.tempCount).isEqualTo(0)
+        assertThat(diagnostics.eligibleForPurgeCount).isEqualTo(0)
+        assertThat(diagnostics.reconcile.objectPrefix).isEqualTo("posts/")
+        assertThat(diagnostics.reconcile.inventoryAvailable).isFalse()
+        assertThat(diagnostics.reconcile.repairMode).isEqualTo("dry-run-degraded")
+        assertThat(diagnostics.reconcile.bucketOnlyObjectCount).isEqualTo(0)
+        assertThat(diagnostics.reconcile.dbOnlyMissingObjectCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `cleanup diagnostics는 reconcile prefix 기본값을 storage keyPrefix에서 파생한다`() {
+        `when`(postImageStoragePort.listObjects("custom-posts/", 1000))
+            .thenReturn(PostImageStoragePort.StoredObjectListing(emptyList(), isTruncated = false))
+        val service =
+            newService(
+                repository = SuccessfulRepository(),
+                storageProperties = PostImageStorageProperties(keyPrefix = "custom-posts"),
+            )
+
+        val diagnostics = service.diagnoseCleanup()
+
+        assertThat(diagnostics.reconcile.objectPrefix).isEqualTo("custom-posts/")
+        verify(postImageStoragePort).listObjects("custom-posts/", 1000)
+    }
+
+    private fun newService(
+        repository: UploadedFileRepositoryPort,
+        storageProperties: PostImageStorageProperties = PostImageStorageProperties(),
+        retentionProperties: UploadedFileRetentionProperties = UploadedFileRetentionProperties(),
+    ): UploadedFileRetentionService =
         UploadedFileRetentionService(
             registrationService =
                 UploadedFileRegistrationService(
                     uploadedFileRepository = repository,
                     postImageStoragePort = postImageStoragePort,
-                    storageProperties = PostImageStorageProperties(),
-                    retentionProperties = UploadedFileRetentionProperties(),
+                    storageProperties = storageProperties,
+                    retentionProperties = retentionProperties,
                     transactionManager = transactionManager,
                     clock = clock,
                     prodSequenceGuardService = prodSequenceGuardService,
@@ -189,16 +226,16 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
             postAttachmentRetentionService =
                 PostAttachmentRetentionService(
                     uploadedFileRepository = repository,
-                    storageProperties = PostImageStorageProperties(),
-                    retentionProperties = UploadedFileRetentionProperties(),
+                    storageProperties = storageProperties,
+                    retentionProperties = retentionProperties,
                     clock = clock,
                 ),
             profileImageRetentionService =
                 ProfileImageRetentionService(
                     uploadedFileRepository = repository,
                     postImageStoragePort = postImageStoragePort,
-                    storageProperties = PostImageStorageProperties(),
-                    retentionProperties = UploadedFileRetentionProperties(),
+                    storageProperties = storageProperties,
+                    retentionProperties = retentionProperties,
                     transactionManager = transactionManager,
                     clock = clock,
                 ),
@@ -206,7 +243,8 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
                 UploadedFilePurgeService(
                     uploadedFileRepository = repository,
                     postImageStoragePort = postImageStoragePort,
-                    retentionProperties = UploadedFileRetentionProperties(),
+                    storageProperties = storageProperties,
+                    retentionProperties = retentionProperties,
                     referenceQueryService =
                         UploadedFileReferenceQueryService(
                             postRepository = postRepository,

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
@@ -298,6 +298,30 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
             .containsExactly("posts/2026/03/deleted-but-present.png")
     }
 
+    @Test
+    fun `cleanup summary는 object storage inventory를 조회하지 않는다`() {
+        val repository = SuccessfulRepository()
+        repository.save(
+            UploadedFile(
+                id = 1,
+                objectKey = "posts/2026/03/old-temp.png",
+                bucket = "test-bucket",
+                contentType = "image/png",
+                fileSize = 128,
+                status = UploadedFileStatus.TEMP,
+                purgeAfter = Instant.parse("2026-06-18T00:00:00Z"),
+            ),
+        )
+        val service = newService(repository)
+
+        val summary = service.diagnoseCleanupSummary()
+
+        assertThat(summary.eligibleForPurgeCount).isEqualTo(1)
+        assertThat(summary.blockedBySafetyThreshold).isFalse()
+        assertThat(summary.oldestEligiblePurgeAfter).isEqualTo(Instant.parse("2026-06-18T00:00:00Z"))
+        verifyNoInteractions(postImageStoragePort)
+    }
+
     private fun newService(
         repository: UploadedFileRepositoryPort,
         storageProperties: PostImageStorageProperties = PostImageStorageProperties(),

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
@@ -176,19 +176,34 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
 
     @Test
     fun `cleanup diagnostics는 object storage listing 실패 시 degraded reconcile만 반환한다`() {
+        val repository = SuccessfulRepository()
+        repository.save(
+            UploadedFile(
+                id = 1,
+                objectKey = "posts/2026/03/stale-pending-delete.png",
+                bucket = "test-bucket",
+                contentType = "image/png",
+                fileSize = 128,
+                status = UploadedFileStatus.PENDING_DELETE,
+                purgeAfter = Instant.parse("2026-05-19T00:00:00Z"),
+            ),
+        )
         `when`(postImageStoragePort.listObjects("posts/", 1000))
             .thenThrow(IllegalStateException("storage unavailable"))
-        val service = newService(SuccessfulRepository())
+        val service = newService(repository)
 
         val diagnostics = service.diagnoseCleanup()
 
         assertThat(diagnostics.tempCount).isEqualTo(0)
-        assertThat(diagnostics.eligibleForPurgeCount).isEqualTo(0)
+        assertThat(diagnostics.eligibleForPurgeCount).isEqualTo(1)
         assertThat(diagnostics.reconcile.objectPrefix).isEqualTo("posts/")
         assertThat(diagnostics.reconcile.inventoryAvailable).isFalse()
         assertThat(diagnostics.reconcile.repairMode).isEqualTo("dry-run-degraded")
         assertThat(diagnostics.reconcile.bucketOnlyObjectCount).isEqualTo(0)
         assertThat(diagnostics.reconcile.dbOnlyMissingObjectCount).isEqualTo(0)
+        assertThat(diagnostics.reconcile.longLivedPendingDeleteCount).isEqualTo(1)
+        assertThat(diagnostics.reconcile.sampleLongLivedPendingDeleteObjectKeys)
+            .containsExactly("posts/2026/03/stale-pending-delete.png")
     }
 
     @Test
@@ -246,6 +261,41 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
 
         assertThat(diagnostics.reconcile.dbRowsTruncated).isTrue()
         assertThat(diagnostics.reconcile.dbOnlyMissingObjectCount).isEqualTo(1000)
+    }
+
+    @Test
+    fun `cleanup diagnostics는 DELETED row가 있는 bucket object를 bucket only drift로 표시한다`() {
+        val repository = SuccessfulRepository()
+        repository.save(
+            UploadedFile(
+                id = 1,
+                objectKey = "posts/2026/03/deleted-but-present.png",
+                bucket = "test-bucket",
+                contentType = "image/png",
+                fileSize = 128,
+                status = UploadedFileStatus.DELETED,
+            ),
+        )
+        `when`(postImageStoragePort.listObjects("posts/", 1000))
+            .thenReturn(
+                PostImageStoragePort.StoredObjectListing(
+                    objects =
+                        listOf(
+                            PostImageStoragePort.StoredObjectSummary(
+                                objectKey = "posts/2026/03/deleted-but-present.png",
+                                size = 128,
+                            ),
+                        ),
+                    isTruncated = false,
+                ),
+            )
+        val service = newService(repository)
+
+        val diagnostics = service.diagnoseCleanup()
+
+        assertThat(diagnostics.reconcile.bucketOnlyObjectCount).isEqualTo(1)
+        assertThat(diagnostics.reconcile.sampleBucketOnlyObjectKeys)
+            .containsExactly("posts/2026/03/deleted-but-present.png")
     }
 
     private fun newService(
@@ -310,7 +360,7 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
 
         override fun findByObjectKeyIn(objectKeys: Collection<String>): List<UploadedFile> = objectKeys.mapNotNull(store::get)
 
-        override fun countByStatus(status: UploadedFileStatus): Long = 0
+        override fun countByStatus(status: UploadedFileStatus): Long = store.values.count { it.status == status }.toLong()
 
         override fun findByPurposeAndOwnerTypeAndOwnerIdAndStatusNotOrderByCreatedAtDescIdDesc(
             purpose: com.back.global.storage.domain.UploadedFilePurpose,
@@ -329,13 +379,25 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
         override fun countByStatusInAndPurgeAfterLessThanEqual(
             statuses: Collection<UploadedFileStatus>,
             purgeAfter: Instant,
-        ): Long = 0
+        ): Long =
+            store.values
+                .count { uploadedFile ->
+                    uploadedFile.status in statuses &&
+                        uploadedFile.purgeAfter?.let { !it.isAfter(purgeAfter) } == true
+                }.toLong()
 
         override fun findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
             statuses: Collection<UploadedFileStatus>,
             purgeAfter: Instant,
             pageable: org.springframework.data.domain.Pageable,
-        ): List<UploadedFile> = emptyList()
+        ): List<UploadedFile> =
+            store.values
+                .filter { uploadedFile ->
+                    uploadedFile.status in statuses &&
+                        uploadedFile.purgeAfter?.let { !it.isAfter(purgeAfter) } == true
+                }.sortedWith(compareBy<UploadedFile> { it.purgeAfter }.thenBy { it.id })
+                .drop(pageable.offset.toInt())
+                .take(pageable.pageSize)
 
         override fun findByStatusInAndObjectKeyStartingWithOrderByIdAsc(
             statuses: Collection<UploadedFileStatus>,

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
@@ -405,75 +405,8 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
                 ),
         )
 
-    private class SuccessfulRepository : UploadedFileRepositoryPort {
-        private val store = linkedMapOf<String, UploadedFile>()
-
-        override fun save(entity: UploadedFile): UploadedFile {
-            store[entity.objectKey] = entity
-            return entity
-        }
-
-        override fun flush() {}
-
-        override fun findByObjectKey(objectKey: String): UploadedFile? = store[objectKey]
-
-        override fun findByObjectKeyIn(objectKeys: Collection<String>): List<UploadedFile> = objectKeys.mapNotNull(store::get)
-
-        override fun countByStatus(status: UploadedFileStatus): Long = store.values.count { it.status == status }.toLong()
-
-        override fun findByPurposeAndOwnerTypeAndOwnerIdAndStatusNotOrderByCreatedAtDescIdDesc(
-            purpose: com.back.global.storage.domain.UploadedFilePurpose,
-            ownerType: com.back.global.storage.domain.UploadedFileOwnerType,
-            ownerId: Long,
-            status: UploadedFileStatus,
-        ): List<UploadedFile> = emptyList()
-
-        override fun findByIdAndPurposeAndOwnerTypeAndOwnerId(
-            id: Long,
-            purpose: com.back.global.storage.domain.UploadedFilePurpose,
-            ownerType: com.back.global.storage.domain.UploadedFileOwnerType,
-            ownerId: Long,
-        ): UploadedFile? = null
-
-        override fun countByStatusInAndPurgeAfterLessThanEqual(
-            statuses: Collection<UploadedFileStatus>,
-            purgeAfter: Instant,
-        ): Long =
-            store.values
-                .count { uploadedFile ->
-                    uploadedFile.status in statuses &&
-                        uploadedFile.purgeAfter?.let { !it.isAfter(purgeAfter) } == true
-                }.toLong()
-
-        override fun findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
-            statuses: Collection<UploadedFileStatus>,
-            purgeAfter: Instant,
-            pageable: org.springframework.data.domain.Pageable,
-        ): List<UploadedFile> =
-            store.values
-                .filter { uploadedFile ->
-                    uploadedFile.status in statuses &&
-                        uploadedFile.purgeAfter?.let { !it.isAfter(purgeAfter) } == true
-                }.sortedWith(compareBy<UploadedFile> { it.purgeAfter }.thenBy { it.id })
-                .drop(pageable.offset.toInt())
-                .take(pageable.pageSize)
-
-        override fun findByStatusInAndObjectKeyStartingWithOrderByIdAsc(
-            statuses: Collection<UploadedFileStatus>,
-            objectKeyPrefix: String,
-            pageable: org.springframework.data.domain.Pageable,
-        ): List<UploadedFile> =
-            store.values
-                .filter { it.status in statuses && it.objectKey.startsWith(objectKeyPrefix) }
-                .sortedBy { it.id }
-                .drop(pageable.offset.toInt())
-                .take(pageable.pageSize)
-    }
-
-    private class AlwaysFailingRepository(
-        private val failure: RuntimeException,
-    ) : UploadedFileRepositoryPort {
-        override fun save(entity: UploadedFile): UploadedFile = throw failure
+    private abstract class EmptyUploadedFileRepository : UploadedFileRepositoryPort {
+        override fun save(entity: UploadedFile): UploadedFile = entity
 
         override fun flush() {}
 
@@ -515,9 +448,64 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
         ): List<UploadedFile> = emptyList()
     }
 
+    private class SuccessfulRepository : EmptyUploadedFileRepository() {
+        private val store = linkedMapOf<String, UploadedFile>()
+
+        override fun save(entity: UploadedFile): UploadedFile {
+            store[entity.objectKey] = entity
+            return entity
+        }
+
+        override fun findByObjectKey(objectKey: String): UploadedFile? = store[objectKey]
+
+        override fun findByObjectKeyIn(objectKeys: Collection<String>): List<UploadedFile> = objectKeys.mapNotNull(store::get)
+
+        override fun countByStatus(status: UploadedFileStatus): Long = store.values.count { it.status == status }.toLong()
+
+        override fun countByStatusInAndPurgeAfterLessThanEqual(
+            statuses: Collection<UploadedFileStatus>,
+            purgeAfter: Instant,
+        ): Long =
+            store.values
+                .count { uploadedFile ->
+                    uploadedFile.status in statuses &&
+                        uploadedFile.purgeAfter?.let { !it.isAfter(purgeAfter) } == true
+                }.toLong()
+
+        override fun findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
+            statuses: Collection<UploadedFileStatus>,
+            purgeAfter: Instant,
+            pageable: org.springframework.data.domain.Pageable,
+        ): List<UploadedFile> =
+            store.values
+                .filter { uploadedFile ->
+                    uploadedFile.status in statuses &&
+                        uploadedFile.purgeAfter?.let { !it.isAfter(purgeAfter) } == true
+                }.sortedWith(compareBy<UploadedFile> { it.purgeAfter }.thenBy { it.id })
+                .drop(pageable.offset.toInt())
+                .take(pageable.pageSize)
+
+        override fun findByStatusInAndObjectKeyStartingWithOrderByIdAsc(
+            statuses: Collection<UploadedFileStatus>,
+            objectKeyPrefix: String,
+            pageable: org.springframework.data.domain.Pageable,
+        ): List<UploadedFile> =
+            store.values
+                .filter { it.status in statuses && it.objectKey.startsWith(objectKeyPrefix) }
+                .sortedBy { it.id }
+                .drop(pageable.offset.toInt())
+                .take(pageable.pageSize)
+    }
+
+    private class AlwaysFailingRepository(
+        private val failure: RuntimeException,
+    ) : EmptyUploadedFileRepository() {
+        override fun save(entity: UploadedFile): UploadedFile = throw failure
+    }
+
     private class SequenceDriftRecoveringRepository(
         private val firstConflict: DataIntegrityViolationException,
-    ) : UploadedFileRepositoryPort {
+    ) : EmptyUploadedFileRepository() {
         private val store = linkedMapOf<String, UploadedFile>()
         var saveCallCount: Int = 0
             private set
@@ -538,44 +526,9 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
         }
 
         override fun findByObjectKey(objectKey: String): UploadedFile? = store[objectKey]
-
-        override fun findByObjectKeyIn(objectKeys: Collection<String>): List<UploadedFile> = objectKeys.mapNotNull(store::get)
-
-        override fun countByStatus(status: UploadedFileStatus): Long = 0
-
-        override fun findByPurposeAndOwnerTypeAndOwnerIdAndStatusNotOrderByCreatedAtDescIdDesc(
-            purpose: com.back.global.storage.domain.UploadedFilePurpose,
-            ownerType: com.back.global.storage.domain.UploadedFileOwnerType,
-            ownerId: Long,
-            status: UploadedFileStatus,
-        ): List<UploadedFile> = emptyList()
-
-        override fun findByIdAndPurposeAndOwnerTypeAndOwnerId(
-            id: Long,
-            purpose: com.back.global.storage.domain.UploadedFilePurpose,
-            ownerType: com.back.global.storage.domain.UploadedFileOwnerType,
-            ownerId: Long,
-        ): UploadedFile? = null
-
-        override fun countByStatusInAndPurgeAfterLessThanEqual(
-            statuses: Collection<UploadedFileStatus>,
-            purgeAfter: Instant,
-        ): Long = 0
-
-        override fun findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
-            statuses: Collection<UploadedFileStatus>,
-            purgeAfter: Instant,
-            pageable: org.springframework.data.domain.Pageable,
-        ): List<UploadedFile> = emptyList()
-
-        override fun findByStatusInAndObjectKeyStartingWithOrderByIdAsc(
-            statuses: Collection<UploadedFileStatus>,
-            objectKeyPrefix: String,
-            pageable: org.springframework.data.domain.Pageable,
-        ): List<UploadedFile> = emptyList()
     }
 
-    private class ExistingObjectKeyRecoveringRepository : UploadedFileRepositoryPort {
+    private class ExistingObjectKeyRecoveringRepository : EmptyUploadedFileRepository() {
         private var conflictReturned = false
         private val existing =
             UploadedFile(
@@ -607,41 +560,6 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
         }
 
         override fun findByObjectKey(objectKey: String): UploadedFile? = store[objectKey]
-
-        override fun findByObjectKeyIn(objectKeys: Collection<String>): List<UploadedFile> = objectKeys.mapNotNull(store::get)
-
-        override fun countByStatus(status: UploadedFileStatus): Long = 0
-
-        override fun findByPurposeAndOwnerTypeAndOwnerIdAndStatusNotOrderByCreatedAtDescIdDesc(
-            purpose: com.back.global.storage.domain.UploadedFilePurpose,
-            ownerType: com.back.global.storage.domain.UploadedFileOwnerType,
-            ownerId: Long,
-            status: UploadedFileStatus,
-        ): List<UploadedFile> = emptyList()
-
-        override fun findByIdAndPurposeAndOwnerTypeAndOwnerId(
-            id: Long,
-            purpose: com.back.global.storage.domain.UploadedFilePurpose,
-            ownerType: com.back.global.storage.domain.UploadedFileOwnerType,
-            ownerId: Long,
-        ): UploadedFile? = null
-
-        override fun countByStatusInAndPurgeAfterLessThanEqual(
-            statuses: Collection<UploadedFileStatus>,
-            purgeAfter: Instant,
-        ): Long = 0
-
-        override fun findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
-            statuses: Collection<UploadedFileStatus>,
-            purgeAfter: Instant,
-            pageable: org.springframework.data.domain.Pageable,
-        ): List<UploadedFile> = emptyList()
-
-        override fun findByStatusInAndObjectKeyStartingWithOrderByIdAsc(
-            statuses: Collection<UploadedFileStatus>,
-            objectKeyPrefix: String,
-            pageable: org.springframework.data.domain.Pageable,
-        ): List<UploadedFile> = emptyList()
     }
 
     private class NoopTransactionManager : PlatformTransactionManager {

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
@@ -28,6 +28,12 @@ import java.time.Instant
 import java.time.ZoneOffset
 
 class UploadedFileRetentionServiceConflictRecoveryTest {
+    private companion object {
+        const val POSTS_PREFIX = "posts/"
+        const val CUSTOM_POSTS_PREFIX = "custom-posts/"
+        const val TEST_BUCKET = "test-bucket"
+    }
+
     private val postRepository = mock(PostRepositoryPort::class.java)
     private val memberAttrRepository = mock(MemberAttrRepositoryPort::class.java)
     private val postImageStoragePort = mock(PostImageStoragePort::class.java)
@@ -181,14 +187,14 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
             UploadedFile(
                 id = 1,
                 objectKey = "posts/2026/03/stale-pending-delete.png",
-                bucket = "test-bucket",
+                bucket = TEST_BUCKET,
                 contentType = "image/png",
                 fileSize = 128,
                 status = UploadedFileStatus.PENDING_DELETE,
                 purgeAfter = Instant.parse("2026-05-19T00:00:00Z"),
             ),
         )
-        `when`(postImageStoragePort.listObjects("posts/", 1000))
+        `when`(postImageStoragePort.listObjects(POSTS_PREFIX, 1000))
             .thenThrow(IllegalStateException("storage unavailable"))
         val service = newService(repository)
 
@@ -196,7 +202,7 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
 
         assertThat(diagnostics.tempCount).isEqualTo(0)
         assertThat(diagnostics.eligibleForPurgeCount).isEqualTo(1)
-        assertThat(diagnostics.reconcile.objectPrefix).isEqualTo("posts/")
+        assertThat(diagnostics.reconcile.objectPrefix).isEqualTo(POSTS_PREFIX)
         assertThat(diagnostics.reconcile.inventoryAvailable).isFalse()
         assertThat(diagnostics.reconcile.repairMode).isEqualTo("dry-run-degraded")
         assertThat(diagnostics.reconcile.bucketOnlyObjectCount).isEqualTo(0)
@@ -208,7 +214,7 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
 
     @Test
     fun `cleanup diagnostics는 reconcile prefix 기본값을 storage keyPrefix에서 파생한다`() {
-        `when`(postImageStoragePort.listObjects("custom-posts/", 1000))
+        `when`(postImageStoragePort.listObjects(CUSTOM_POSTS_PREFIX, 1000))
             .thenReturn(PostImageStoragePort.StoredObjectListing(emptyList(), isTruncated = false))
         val service =
             newService(
@@ -218,8 +224,8 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
 
         val diagnostics = service.diagnoseCleanup()
 
-        assertThat(diagnostics.reconcile.objectPrefix).isEqualTo("custom-posts/")
-        verify(postImageStoragePort).listObjects("custom-posts/", 1000)
+        assertThat(diagnostics.reconcile.objectPrefix).isEqualTo(CUSTOM_POSTS_PREFIX)
+        verify(postImageStoragePort).listObjects(CUSTOM_POSTS_PREFIX, 1000)
     }
 
     @Test
@@ -246,14 +252,14 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
                 UploadedFile(
                     id = index.toLong() + 1,
                     objectKey = "posts/2026/03/db-row-$index.png",
-                    bucket = "test-bucket",
+                    bucket = TEST_BUCKET,
                     contentType = "image/png",
                     fileSize = 128,
                     status = UploadedFileStatus.ACTIVE,
                 ),
             )
         }
-        `when`(postImageStoragePort.listObjects("posts/", 1000))
+        `when`(postImageStoragePort.listObjects(POSTS_PREFIX, 1000))
             .thenReturn(PostImageStoragePort.StoredObjectListing(emptyList(), isTruncated = false))
         val service = newService(repository)
 
@@ -264,19 +270,48 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
     }
 
     @Test
+    fun `cleanup diagnostics는 inventory가 잘렸으면 DB only missing 계산을 보류한다`() {
+        val repository = SuccessfulRepository()
+        repository.save(
+            UploadedFile(
+                id = 1,
+                objectKey = "posts/2026/03/db-present-but-inventory-truncated.png",
+                bucket = TEST_BUCKET,
+                contentType = "image/png",
+                fileSize = 128,
+                status = UploadedFileStatus.ACTIVE,
+            ),
+        )
+        `when`(postImageStoragePort.listObjects(POSTS_PREFIX, 1000))
+            .thenReturn(
+                PostImageStoragePort.StoredObjectListing(
+                    objects = emptyList(),
+                    isTruncated = true,
+                ),
+            )
+        val service = newService(repository)
+
+        val diagnostics = service.diagnoseCleanup()
+
+        assertThat(diagnostics.reconcile.inventoryTruncated).isTrue()
+        assertThat(diagnostics.reconcile.dbOnlyMissingObjectCount).isZero()
+        assertThat(diagnostics.reconcile.sampleDbOnlyObjectKeys).isEmpty()
+    }
+
+    @Test
     fun `cleanup diagnostics는 DELETED row가 있는 bucket object를 bucket only drift로 표시한다`() {
         val repository = SuccessfulRepository()
         repository.save(
             UploadedFile(
                 id = 1,
                 objectKey = "posts/2026/03/deleted-but-present.png",
-                bucket = "test-bucket",
+                bucket = TEST_BUCKET,
                 contentType = "image/png",
                 fileSize = 128,
                 status = UploadedFileStatus.DELETED,
             ),
         )
-        `when`(postImageStoragePort.listObjects("posts/", 1000))
+        `when`(postImageStoragePort.listObjects(POSTS_PREFIX, 1000))
             .thenReturn(
                 PostImageStoragePort.StoredObjectListing(
                     objects =
@@ -305,7 +340,7 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
             UploadedFile(
                 id = 1,
                 objectKey = "posts/2026/03/old-temp.png",
-                bucket = "test-bucket",
+                bucket = TEST_BUCKET,
                 contentType = "image/png",
                 fileSize = 128,
                 status = UploadedFileStatus.TEMP,

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
@@ -207,6 +207,47 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
         verify(postImageStoragePort).listObjects("custom-posts/", 1000)
     }
 
+    @Test
+    fun `cleanup diagnostics는 빈 storage keyPrefix를 bucket root prefix로 보존한다`() {
+        `when`(postImageStoragePort.listObjects("", 1000))
+            .thenReturn(PostImageStoragePort.StoredObjectListing(emptyList(), isTruncated = false))
+        val service =
+            newService(
+                repository = SuccessfulRepository(),
+                storageProperties = PostImageStorageProperties(keyPrefix = ""),
+            )
+
+        val diagnostics = service.diagnoseCleanup()
+
+        assertThat(diagnostics.reconcile.objectPrefix).isEqualTo("")
+        verify(postImageStoragePort).listObjects("", 1000)
+    }
+
+    @Test
+    fun `cleanup diagnostics는 DB reconcile row truncation을 표시한다`() {
+        val repository = SuccessfulRepository()
+        repeat(1001) { index ->
+            repository.save(
+                UploadedFile(
+                    id = index.toLong() + 1,
+                    objectKey = "posts/2026/03/db-row-$index.png",
+                    bucket = "test-bucket",
+                    contentType = "image/png",
+                    fileSize = 128,
+                    status = UploadedFileStatus.ACTIVE,
+                ),
+            )
+        }
+        `when`(postImageStoragePort.listObjects("posts/", 1000))
+            .thenReturn(PostImageStoragePort.StoredObjectListing(emptyList(), isTruncated = false))
+        val service = newService(repository)
+
+        val diagnostics = service.diagnoseCleanup()
+
+        assertThat(diagnostics.reconcile.dbRowsTruncated).isTrue()
+        assertThat(diagnostics.reconcile.dbOnlyMissingObjectCount).isEqualTo(1000)
+    }
+
     private fun newService(
         repository: UploadedFileRepositoryPort,
         storageProperties: PostImageStorageProperties = PostImageStorageProperties(),
@@ -300,7 +341,12 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
             statuses: Collection<UploadedFileStatus>,
             objectKeyPrefix: String,
             pageable: org.springframework.data.domain.Pageable,
-        ): List<UploadedFile> = emptyList()
+        ): List<UploadedFile> =
+            store.values
+                .filter { it.status in statuses && it.objectKey.startsWith(objectKeyPrefix) }
+                .sortedBy { it.id }
+                .drop(pageable.offset.toInt())
+                .take(pageable.pageSize)
     }
 
     private class AlwaysFailingRepository(

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceConflictRecoveryTest.kt
@@ -229,6 +229,8 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
 
         override fun findByObjectKey(objectKey: String): UploadedFile? = store[objectKey]
 
+        override fun findByObjectKeyIn(objectKeys: Collection<String>): List<UploadedFile> = objectKeys.mapNotNull(store::get)
+
         override fun countByStatus(status: UploadedFileStatus): Long = 0
 
         override fun findByPurposeAndOwnerTypeAndOwnerIdAndStatusNotOrderByCreatedAtDescIdDesc(
@@ -255,6 +257,12 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
             purgeAfter: Instant,
             pageable: org.springframework.data.domain.Pageable,
         ): List<UploadedFile> = emptyList()
+
+        override fun findByStatusInAndObjectKeyStartingWithOrderByIdAsc(
+            statuses: Collection<UploadedFileStatus>,
+            objectKeyPrefix: String,
+            pageable: org.springframework.data.domain.Pageable,
+        ): List<UploadedFile> = emptyList()
     }
 
     private class AlwaysFailingRepository(
@@ -265,6 +273,8 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
         override fun flush() {}
 
         override fun findByObjectKey(objectKey: String): UploadedFile? = null
+
+        override fun findByObjectKeyIn(objectKeys: Collection<String>): List<UploadedFile> = emptyList()
 
         override fun countByStatus(status: UploadedFileStatus): Long = 0
 
@@ -290,6 +300,12 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
         override fun findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
             statuses: Collection<UploadedFileStatus>,
             purgeAfter: Instant,
+            pageable: org.springframework.data.domain.Pageable,
+        ): List<UploadedFile> = emptyList()
+
+        override fun findByStatusInAndObjectKeyStartingWithOrderByIdAsc(
+            statuses: Collection<UploadedFileStatus>,
+            objectKeyPrefix: String,
             pageable: org.springframework.data.domain.Pageable,
         ): List<UploadedFile> = emptyList()
     }
@@ -318,6 +334,8 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
 
         override fun findByObjectKey(objectKey: String): UploadedFile? = store[objectKey]
 
+        override fun findByObjectKeyIn(objectKeys: Collection<String>): List<UploadedFile> = objectKeys.mapNotNull(store::get)
+
         override fun countByStatus(status: UploadedFileStatus): Long = 0
 
         override fun findByPurposeAndOwnerTypeAndOwnerIdAndStatusNotOrderByCreatedAtDescIdDesc(
@@ -342,6 +360,12 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
         override fun findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
             statuses: Collection<UploadedFileStatus>,
             purgeAfter: Instant,
+            pageable: org.springframework.data.domain.Pageable,
+        ): List<UploadedFile> = emptyList()
+
+        override fun findByStatusInAndObjectKeyStartingWithOrderByIdAsc(
+            statuses: Collection<UploadedFileStatus>,
+            objectKeyPrefix: String,
             pageable: org.springframework.data.domain.Pageable,
         ): List<UploadedFile> = emptyList()
     }
@@ -379,6 +403,8 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
 
         override fun findByObjectKey(objectKey: String): UploadedFile? = store[objectKey]
 
+        override fun findByObjectKeyIn(objectKeys: Collection<String>): List<UploadedFile> = objectKeys.mapNotNull(store::get)
+
         override fun countByStatus(status: UploadedFileStatus): Long = 0
 
         override fun findByPurposeAndOwnerTypeAndOwnerIdAndStatusNotOrderByCreatedAtDescIdDesc(
@@ -403,6 +429,12 @@ class UploadedFileRetentionServiceConflictRecoveryTest {
         override fun findByStatusInAndPurgeAfterLessThanEqualOrderByPurgeAfterAsc(
             statuses: Collection<UploadedFileStatus>,
             purgeAfter: Instant,
+            pageable: org.springframework.data.domain.Pageable,
+        ): List<UploadedFile> = emptyList()
+
+        override fun findByStatusInAndObjectKeyStartingWithOrderByIdAsc(
+            statuses: Collection<UploadedFileStatus>,
+            objectKeyPrefix: String,
             pageable: org.springframework.data.domain.Pageable,
         ): List<UploadedFile> = emptyList()
     }

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceTest.kt
@@ -1,6 +1,7 @@
 package com.back.global.storage.application
 
 import com.back.boundedContexts.member.domain.shared.memberMixin.PROFILE_IMG_URL
+import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
 import com.back.global.app.AppConfig
 import com.back.global.storage.adapter.persistence.UploadedFileRepository
 import com.back.global.storage.domain.UploadedFile
@@ -294,6 +295,8 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
     @Test
     fun `cleanup 진단은 purge 후보 수와 샘플 object key를 보여준다`() {
         val objectKey = "posts/2026/03/diagnostics-temp.png"
+        given(postImageStoragePort.listObjects("posts/", 1000))
+            .willReturn(PostImageStoragePort.StoredObjectListing(emptyList(), isTruncated = false))
 
         uploadedFileRetentionService.registerTempUpload(
             objectKey = objectKey,
@@ -313,6 +316,68 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
         assertThat(diagnostics.eligibleForPurgeCount).isGreaterThanOrEqualTo(1)
         assertThat(diagnostics.sampleEligibleObjectKeys).contains(objectKey)
         assertThat(directDiagnostics.sampleEligibleObjectKeys).contains(objectKey)
+    }
+
+    @Test
+    fun `cleanup 진단은 bucket only와 DB only object drift를 dry-run으로 보여준다`() {
+        uploadedFileRepository.deleteAll()
+
+        val existingKey = "posts/2026/03/reconcile-existing.png"
+        val missingKey = "posts/2026/03/reconcile-db-only.png"
+        val longPendingKey = "posts/2026/03/reconcile-pending-delete.png"
+        val orphanKey = "posts/2026/03/reconcile-bucket-only.png"
+        val oldPurgeAfter = Instant.now(clock).minusSeconds(retentionProperties.longPendingDeleteSeconds + 60)
+
+        uploadedFileRepository.save(
+            UploadedFile(
+                objectKey = existingKey,
+                bucket = "test-bucket",
+                contentType = "image/png",
+                fileSize = 128,
+                status = UploadedFileStatus.ACTIVE,
+            ),
+        )
+        uploadedFileRepository.save(
+            UploadedFile(
+                objectKey = missingKey,
+                bucket = "test-bucket",
+                contentType = "image/png",
+                fileSize = 256,
+                status = UploadedFileStatus.ACTIVE,
+            ),
+        )
+        uploadedFileRepository.save(
+            UploadedFile(
+                objectKey = longPendingKey,
+                bucket = "test-bucket",
+                contentType = "image/png",
+                fileSize = 512,
+                status = UploadedFileStatus.PENDING_DELETE,
+                purgeAfter = oldPurgeAfter,
+            ),
+        )
+        given(postImageStoragePort.listObjects("posts/", 1000))
+            .willReturn(
+                PostImageStoragePort.StoredObjectListing(
+                    objects =
+                        listOf(
+                            PostImageStoragePort.StoredObjectSummary(existingKey, 128),
+                            PostImageStoragePort.StoredObjectSummary(orphanKey, 64),
+                        ),
+                    isTruncated = false,
+                ),
+            )
+
+        val diagnostics = uploadedFileRetentionService.diagnoseCleanup(sampleSize = 5).reconcile
+
+        assertThat(diagnostics.repairMode).isEqualTo("dry-run")
+        assertThat(diagnostics.objectPrefix).isEqualTo("posts/")
+        assertThat(diagnostics.bucketOnlyObjectCount).isEqualTo(1)
+        assertThat(diagnostics.sampleBucketOnlyObjectKeys).containsExactly(orphanKey)
+        assertThat(diagnostics.dbOnlyMissingObjectCount).isEqualTo(2)
+        assertThat(diagnostics.sampleDbOnlyObjectKeys).contains(missingKey, longPendingKey)
+        assertThat(diagnostics.longLivedPendingDeleteCount).isEqualTo(1)
+        assertThat(diagnostics.sampleLongLivedPendingDeleteObjectKeys).containsExactly(longPendingKey)
     }
 
     @Test

--- a/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/storage/application/UploadedFileRetentionServiceTest.kt
@@ -295,7 +295,7 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
     @Test
     fun `cleanup 진단은 purge 후보 수와 샘플 object key를 보여준다`() {
         val objectKey = "posts/2026/03/diagnostics-temp.png"
-        given(postImageStoragePort.listObjects("posts/", 1000))
+        given(postImageStoragePort.listObjects(POSTS_PREFIX, 1000))
             .willReturn(PostImageStoragePort.StoredObjectListing(emptyList(), isTruncated = false))
 
         uploadedFileRetentionService.registerTempUpload(
@@ -331,7 +331,7 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
         uploadedFileRepository.save(
             UploadedFile(
                 objectKey = existingKey,
-                bucket = "test-bucket",
+                bucket = TEST_BUCKET,
                 contentType = "image/png",
                 fileSize = 128,
                 status = UploadedFileStatus.ACTIVE,
@@ -340,7 +340,7 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
         uploadedFileRepository.save(
             UploadedFile(
                 objectKey = missingKey,
-                bucket = "test-bucket",
+                bucket = TEST_BUCKET,
                 contentType = "image/png",
                 fileSize = 256,
                 status = UploadedFileStatus.ACTIVE,
@@ -349,14 +349,14 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
         uploadedFileRepository.save(
             UploadedFile(
                 objectKey = longPendingKey,
-                bucket = "test-bucket",
+                bucket = TEST_BUCKET,
                 contentType = "image/png",
                 fileSize = 512,
                 status = UploadedFileStatus.PENDING_DELETE,
                 purgeAfter = oldPurgeAfter,
             ),
         )
-        given(postImageStoragePort.listObjects("posts/", 1000))
+        given(postImageStoragePort.listObjects(POSTS_PREFIX, 1000))
             .willReturn(
                 PostImageStoragePort.StoredObjectListing(
                     objects =
@@ -371,7 +371,7 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
         val diagnostics = uploadedFileRetentionService.diagnoseCleanup(sampleSize = 5).reconcile
 
         assertThat(diagnostics.repairMode).isEqualTo("dry-run")
-        assertThat(diagnostics.objectPrefix).isEqualTo("posts/")
+        assertThat(diagnostics.objectPrefix).isEqualTo(POSTS_PREFIX)
         assertThat(diagnostics.bucketOnlyObjectCount).isEqualTo(1)
         assertThat(diagnostics.sampleBucketOnlyObjectKeys).containsExactly(orphanKey)
         assertThat(diagnostics.dbOnlyMissingObjectCount).isEqualTo(2)
@@ -542,6 +542,9 @@ class UploadedFileRetentionServiceTest : BaseUploadedFileRetentionServiceIntegra
     }
 
     companion object {
+        private const val POSTS_PREFIX = "posts/"
+        private const val TEST_BUCKET = "test-bucket"
+
         @JvmStatic
         @BeforeAll
         fun setUpAppConfig() {

--- a/back/src/test/kotlin/com/back/global/system/adapter/web/ApiV1AdmSystemControllerTest.kt
+++ b/back/src/test/kotlin/com/back/global/system/adapter/web/ApiV1AdmSystemControllerTest.kt
@@ -6,6 +6,7 @@ import com.back.boundedContexts.post.application.service.PostSearchEngineMirrorS
 import com.back.global.security.application.AuthSecurityEventDto
 import com.back.global.security.domain.SecurityUser
 import com.back.global.storage.application.UploadedFileCleanupDiagnostics
+import com.back.global.storage.application.UploadedFileReconcileDiagnostics
 import com.back.global.system.application.AdminDashboardAuthSecuritySnapshot
 import com.back.global.system.application.AdminDashboardSignupMailSnapshot
 import com.back.global.system.application.AdminDashboardSnapshot
@@ -358,6 +359,9 @@ class ApiV1AdmSystemControllerTest : BaseAdmSystemControllerWebMvcTest() {
             jsonPath("$.eligibleForPurgeCount") { isNumber() }
             jsonPath("$.cleanupSafetyThreshold") { isNumber() }
             jsonPath("$.sampleEligibleObjectKeys") { isArray() }
+            jsonPath("$.reconcile.repairMode") { value("dry-run") }
+            jsonPath("$.reconcile.bucketOnlyObjectCount") { value(1) }
+            jsonPath("$.reconcile.dbOnlyMissingObjectCount") { value(1) }
         }
     }
 
@@ -564,6 +568,19 @@ class ApiV1AdmSystemControllerTest : BaseAdmSystemControllerWebMvcTest() {
             blockedBySafetyThreshold = false,
             oldestEligiblePurgeAfter = Instant.parse("2026-03-13T00:00:00Z"),
             sampleEligibleObjectKeys = listOf("posts/2026/test.png"),
+            reconcile =
+                UploadedFileReconcileDiagnostics(
+                    objectPrefix = "posts/",
+                    inventoryLimit = 1000,
+                    inventoryObjectCount = 2,
+                    inventoryTruncated = false,
+                    bucketOnlyObjectCount = 1,
+                    sampleBucketOnlyObjectKeys = listOf("posts/2026/orphan.png"),
+                    dbOnlyMissingObjectCount = 1,
+                    sampleDbOnlyObjectKeys = listOf("posts/2026/missing.png"),
+                    longLivedPendingDeleteCount = 1,
+                    sampleLongLivedPendingDeleteObjectKeys = listOf("posts/2026/old-pending.png"),
+                ),
         )
 
     private fun adminDashboardSnapshot(): AdminDashboardSnapshot =

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -5272,6 +5272,61 @@
             "items" : {
               "type" : "string"
             }
+          },
+          "reconcile" : {
+            "$ref" : "#/components/schemas/UploadedFileReconcileDiagnostics"
+          }
+        }
+      },
+      "UploadedFileReconcileDiagnostics" : {
+        "type" : "object",
+        "properties" : {
+          "objectPrefix" : {
+            "type" : "string"
+          },
+          "inventoryLimit" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "inventoryObjectCount" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "inventoryTruncated" : {
+            "type" : "boolean"
+          },
+          "bucketOnlyObjectCount" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "sampleBucketOnlyObjectKeys" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "dbOnlyMissingObjectCount" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "sampleDbOnlyObjectKeys" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "longLivedPendingDeleteCount" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "sampleLongLivedPendingDeleteObjectKeys" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "repairMode" : {
+            "type" : "string"
           }
         }
       },

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -5292,6 +5292,9 @@
             "type" : "integer",
             "format" : "int32"
           },
+          "inventoryAvailable" : {
+            "type" : "boolean"
+          },
           "inventoryTruncated" : {
             "type" : "boolean"
           },

--- a/front/contracts/openapi/openapi.json
+++ b/front/contracts/openapi/openapi.json
@@ -5298,6 +5298,9 @@
           "inventoryTruncated" : {
             "type" : "boolean"
           },
+          "dbRowsTruncated" : {
+            "type" : "boolean"
+          },
           "bucketOnlyObjectCount" : {
             "type" : "integer",
             "format" : "int32"

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -2225,6 +2225,25 @@ export interface components {
             /** Format: date-time */
             oldestEligiblePurgeAfter?: string;
             sampleEligibleObjectKeys?: string[];
+            reconcile?: components["schemas"]["UploadedFileReconcileDiagnostics"];
+        };
+        UploadedFileReconcileDiagnostics: {
+            objectPrefix?: string;
+            /** Format: int32 */
+            inventoryLimit?: number;
+            /** Format: int32 */
+            inventoryObjectCount?: number;
+            inventoryTruncated?: boolean;
+            /** Format: int32 */
+            bucketOnlyObjectCount?: number;
+            sampleBucketOnlyObjectKeys?: string[];
+            /** Format: int32 */
+            dbOnlyMissingObjectCount?: number;
+            sampleDbOnlyObjectKeys?: string[];
+            /** Format: int64 */
+            longLivedPendingDeleteCount?: number;
+            sampleLongLivedPendingDeleteObjectKeys?: string[];
+            repairMode?: string;
         };
         StreamDiagnostics: {
             /** Format: int32 */

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -2235,6 +2235,7 @@ export interface components {
             inventoryObjectCount?: number;
             inventoryAvailable?: boolean;
             inventoryTruncated?: boolean;
+            dbRowsTruncated?: boolean;
             /** Format: int32 */
             bucketOnlyObjectCount?: number;
             sampleBucketOnlyObjectKeys?: string[];

--- a/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
+++ b/front/packages/shared-contracts/src/generated/backend-openapi.d.ts
@@ -2233,6 +2233,7 @@ export interface components {
             inventoryLimit?: number;
             /** Format: int32 */
             inventoryObjectCount?: number;
+            inventoryAvailable?: boolean;
             inventoryTruncated?: boolean;
             /** Format: int32 */
             bucketOnlyObjectCount?: number;


### PR DESCRIPTION
## 관련 이슈

close #1143

## 작업 배경

- `UploadedFile` DB 상태와 S3/MinIO object inventory를 양방향으로 대조하는 diagnostics가 없어 bucket-only object, DB-only missing object, 장기 `PENDING_DELETE` 상태를 운영에서 구분하기 어려웠습니다.
- 기존 cleanup diagnostics는 DB status count와 purge candidate 중심이라 object storage와 DB 사이 drift를 alert 기준으로 노출하지 못했습니다.

## 작업 내용

- `PostImageStoragePort`에 prefix 기반 object listing 계약을 추가하고 S3 adapter에서 configured post prefix 밖 listing 요청을 거절하도록 구현했습니다.
- `/adm/system/storage/cleanup` diagnostics에 `reconcile` summary를 추가해 bucket-only object, DB-only missing object, long-lived `PENDING_DELETE`, inventory truncation, sample object key, `repairMode=dry-run`을 반환합니다.
- `storage.uploaded_file.reconcile.*` gauge와 `storage.uploaded_file.cleanup.refresh_failures` counter를 추가해 운영 alert가 drift 증가와 refresh 실패를 감지할 수 있게 했습니다.
- backend OpenAPI snapshot과 frontend shared contract generated type을 갱신했습니다.
- repair/delete/status 변경은 이번 PR에 넣지 않고 dry-run report와 metric 노출로 제한했습니다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back test --tests "*UploadedFile*"`: BUILD SUCCESSFUL
  - `back/gradlew -p back test --tests "*PostImageStorageAdapterTest"`: BUILD SUCCESSFUL
  - `back/gradlew -p back test --tests "*ApiV1PostImageControllerTest"`: BUILD SUCCESSFUL
  - `back/gradlew -p back test --tests "*ApiV1AdmSystemControllerTest"`: BUILD SUCCESSFUL
  - `back/gradlew -p back test --tests "*UploadedFileReconcileMetricsBinderTest"`: BUILD SUCCESSFUL
  - `back/gradlew -p back ktlintCheck`: BUILD SUCCESSFUL
  - `back/gradlew -p back test`: BUILD SUCCESSFUL
  - `yarn --cwd front contracts:generate`: Done
  - `yarn --cwd front contracts:check`: generated types are up-to-date
  - `git diff --check`: exit 0
  - `CURRENT_TASK_SLUG=issue-1143-uploaded-file-reconcile bash tools/guards/current-task-preflight.sh`: ok
  - pre-commit hook `OpenApiContractExportTest`: BUILD SUCCESSFUL

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| object inventory listing | backend local | `PostImageStorageAdapterTest` | S3 `listObjectsV2` bucket/prefix/limit assertion | 통과 |
| reconcile diagnostics | backend local | `UploadedFileRetentionServiceTest` | bucket-only, DB-only missing, long-lived pending-delete fixture | 통과 |
| admin cleanup response | backend local | `ApiV1AdmSystemControllerTest` | JSON path `$.reconcile.*` assertion | 통과 |
| metrics/alert surface | backend local | `UploadedFileReconcileMetricsBinderTest` | `storage.uploaded_file.reconcile.*`, `storage.uploaded_file.cleanup.refresh_failures` metric assertion | 통과 |
| OpenAPI contract | local generated artifact | `yarn --cwd front contracts:check` | `front/contracts/openapi/openapi.json`, generated `backend-openapi.d.ts` | 최신 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `UploadedFilePurgeService.diagnoseReconcile`: inventory가 truncated이면 DB-only missing 계산을 0으로 억제해 partial inventory false positive를 피합니다.
  - `UploadedFileReconcileMetricsBinder`: metric 등록과 refresh를 분리하고 scheduled initial delay를 둬 테스트/시작 시점의 불필요한 object storage 호출을 막았습니다.
  - repair는 의도적으로 dry-run만 추가했습니다. 실제 삭제/status 변경은 별도 승인과 audit log 설계가 필요합니다.

## 리스크

- inventory limit 기본값은 1,000개입니다. object 수가 limit을 넘으면 `inventoryTruncated=true`로 보고하고 DB-only missing은 false positive 방지를 위해 계산하지 않습니다.
- metric refresh는 object storage listing을 수행하므로 운영에서는 `custom.storage.retention.reconcileMetricsRefreshFixedDelayMs`로 주기를 조정해야 합니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3 객체 목록 조회를 접두어(prefix) 기반으로 제공하며, 결과 잘림(truncation) 여부와 페이징을 함께 처리합니다.
  * 업로드 파일 리컨실(정합) 진단 정보/요약과 관련 메트릭(게이지/리프레시 실패 카운터)이 추가되었습니다.
  * 리컨실용 보관 설정(접두어/인벤토리 한도/장기 pending 삭제 기준)이 구성으로 확장됐습니다.
  * 관리 대시보드 정리 스냅샷이 요약 진단 데이터로 갱신됩니다.
* **Bug Fixes**
  * 접두어 정규화·검증을 강화해 허용되지 않은 경로 접근과 목록 조회 요청이 더 엄격히 제어됩니다.
  * 인벤토리/DB 잘림(truncation) 상황에서 진단 계산이 안정적으로 반영됩니다.
* **Tests**
  * 객체 목록 조회, 리컨실/정리 진단, 메트릭 노출 및 예외 처리 시나리오 테스트가 추가·확장됐습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->