### PR TITLE
[Hotfix] Prometheus 기본 Basic Auth fallback 제거

### DIFF
--- a/deploy/env/env.contract.json
+++ b/deploy/env/env.contract.json
@@ -53,9 +53,9 @@
           "name": "PROMETHEUS_BASIC_AUTH_HASH",
           "secret": true,
           "minLength": 50,
-          "forbiddenValues": [
-            "$2y$05$g4sdUn.YYoUOjAy/41KhSOBCQvOnwTNJ/jmdl/95o8YKEoq/gddPC",
-            "$$2y$$05$$g4sdUn.YYoUOjAy/41KhSOBCQvOnwTNJ/jmdl/95o8YKEoq/gddPC"
+          "forbiddenSha256": [
+            "6e9101876c919171629f4cc9a6af6c7f8ee7f3438558f9b6ca6f6c180cb4abf7",
+            "41f14820b4b0e106cc7f0d0823a29de0445ba4504a8607d5ca3a67ceddd0181c"
           ]
         },
         { "name": "OPERATIONS_ALERT_EMAIL_TO", "kind": "email", "secret": true },

--- a/deploy/env/env.contract.json
+++ b/deploy/env/env.contract.json
@@ -48,8 +48,16 @@
         { "name": "CUSTOM__RUNTIME__API_MODE_BLUE", "required": false },
         { "name": "CUSTOM__RUNTIME__API_MODE_GREEN", "required": false },
         { "name": "CUSTOM__RUNTIME__API_MODE_WORKER", "required": false },
-        { "name": "PROMETHEUS_BASIC_AUTH_USER" },
-        { "name": "PROMETHEUS_BASIC_AUTH_HASH", "secret": true, "minLength": 20 },
+        { "name": "PROMETHEUS_BASIC_AUTH_USER", "forbiddenValues": ["promviewer"] },
+        {
+          "name": "PROMETHEUS_BASIC_AUTH_HASH",
+          "secret": true,
+          "minLength": 50,
+          "forbiddenValues": [
+            "$2y$05$g4sdUn.YYoUOjAy/41KhSOBCQvOnwTNJ/jmdl/95o8YKEoq/gddPC",
+            "$$2y$$05$$g4sdUn.YYoUOjAy/41KhSOBCQvOnwTNJ/jmdl/95o8YKEoq/gddPC"
+          ]
+        },
         { "name": "OPERATIONS_ALERT_EMAIL_TO", "kind": "email", "secret": true },
         { "name": "ALERTMANAGER_SMTP_AUTH_ENABLED", "kind": "boolean", "required": false },
         {

--- a/deploy/homeserver/.env.prod.example
+++ b/deploy/homeserver/.env.prod.example
@@ -34,7 +34,7 @@ MINIO_IMAGE=minio/minio@sha256:<digest>
 # PROMETHEUS_RETENTION_TIME=15d
 # Prometheus basic auth for public UI route.
 # Generate a fresh bcrypt hash with: caddy hash-password --plaintext '<strong password>'
-# Write the generated hash exactly as printed, including "$" characters.
+# Wrap the generated hash in single quotes, or escape every "$" as "$$".
 PROMETHEUS_BASIC_AUTH_USER=NEED_TO_SET_PROMETHEUS_BASIC_AUTH_USER
 PROMETHEUS_BASIC_AUTH_HASH=NEED_TO_SET_PROMETHEUS_BASIC_AUTH_HASH
 # Alertmanager operations email receiver. SMTP values below reuse Spring mail settings.

--- a/deploy/homeserver/.env.prod.example
+++ b/deploy/homeserver/.env.prod.example
@@ -32,11 +32,10 @@ REDIS_IMAGE=redis@sha256:<digest>
 MINIO_IMAGE=minio/minio@sha256:<digest>
 # Optional Prometheus retention
 # PROMETHEUS_RETENTION_TIME=15d
-# Prometheus basic auth for public UI route (bcrypt hash recommended)
-# username default: promviewer
-# password default hash corresponds to: change_me_prom_password
-PROMETHEUS_BASIC_AUTH_USER=promviewer
-PROMETHEUS_BASIC_AUTH_HASH=$$2y$$05$$g4sdUn.YYoUOjAy/41KhSOBCQvOnwTNJ/jmdl/95o8YKEoq/gddPC
+# Prometheus basic auth for public UI route.
+# Generate a fresh bcrypt hash with: caddy hash-password --plaintext '<strong password>'
+PROMETHEUS_BASIC_AUTH_USER=NEED_TO_SET_PROMETHEUS_BASIC_AUTH_USER
+PROMETHEUS_BASIC_AUTH_HASH=NEED_TO_SET_PROMETHEUS_BASIC_AUTH_HASH
 # Alertmanager operations email receiver. SMTP values below reuse Spring mail settings.
 OPERATIONS_ALERT_EMAIL_TO=ops@example.com
 # Set to true and fill credentials when the SMTP relay requires AUTH.

--- a/deploy/homeserver/.env.prod.example
+++ b/deploy/homeserver/.env.prod.example
@@ -34,7 +34,7 @@ MINIO_IMAGE=minio/minio@sha256:<digest>
 # PROMETHEUS_RETENTION_TIME=15d
 # Prometheus basic auth for public UI route.
 # Generate a fresh bcrypt hash with: caddy hash-password --plaintext '<strong password>'
-# Escape every "$" in the generated hash as "$$" before writing it here.
+# Write the generated hash exactly as printed, including "$" characters.
 PROMETHEUS_BASIC_AUTH_USER=NEED_TO_SET_PROMETHEUS_BASIC_AUTH_USER
 PROMETHEUS_BASIC_AUTH_HASH=NEED_TO_SET_PROMETHEUS_BASIC_AUTH_HASH
 # Alertmanager operations email receiver. SMTP values below reuse Spring mail settings.

--- a/deploy/homeserver/.env.prod.example
+++ b/deploy/homeserver/.env.prod.example
@@ -34,6 +34,7 @@ MINIO_IMAGE=minio/minio@sha256:<digest>
 # PROMETHEUS_RETENTION_TIME=15d
 # Prometheus basic auth for public UI route.
 # Generate a fresh bcrypt hash with: caddy hash-password --plaintext '<strong password>'
+# Escape every "$" in the generated hash as "$$" before writing it here.
 PROMETHEUS_BASIC_AUTH_USER=NEED_TO_SET_PROMETHEUS_BASIC_AUTH_USER
 PROMETHEUS_BASIC_AUTH_HASH=NEED_TO_SET_PROMETHEUS_BASIC_AUTH_HASH
 # Alertmanager operations email receiver. SMTP values below reuse Spring mail settings.

--- a/deploy/homeserver/caddy/Caddyfile
+++ b/deploy/homeserver/caddy/Caddyfile
@@ -51,7 +51,7 @@ http://{$GRAFANA_DOMAIN:grafana.localhost} {
 # Set PROMETHEUS_DOMAIN in .env.prod and Cloudflare Tunnel Public Hostname.
 http://{$PROMETHEUS_DOMAIN:prometheus.localhost} {
   basic_auth {
-    {$PROMETHEUS_BASIC_AUTH_USER:promviewer} {$PROMETHEUS_BASIC_AUTH_HASH:$2y$05$g4sdUn.YYoUOjAy/41KhSOBCQvOnwTNJ/jmdl/95o8YKEoq/gddPC}
+    {$PROMETHEUS_BASIC_AUTH_USER} {$PROMETHEUS_BASIC_AUTH_HASH}
   }
 
   reverse_proxy prometheus:9090

--- a/tools/env/validate-env.mjs
+++ b/tools/env/validate-env.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { readFileSync } from "node:fs"
+import crypto from "node:crypto"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -54,6 +55,8 @@ const resolveTarget = (contract, targetName) => {
 }
 
 const safeError = (key, message) => ({ key, message })
+
+const sha256 = (value) => crypto.createHash("sha256").update(value).digest("hex")
 
 const hostnamePattern = /^(?!-)(?:[A-Za-z0-9-]{1,63}\.)+[A-Za-z]{2,63}$/
 
@@ -138,6 +141,10 @@ export const validateEnvText = ({ contract, target, text }) => {
 
     if (definition.forbiddenValues?.includes(value)) {
       errors.push(safeError(definition.name, "must not use forbidden value"))
+    }
+
+    if (definition.forbiddenSha256?.includes(sha256(value))) {
+      errors.push(safeError(definition.name, "must not use forbidden fingerprint"))
     }
 
     if (definition.mustDifferFrom && value === valueOf(env, definition.mustDifferFrom)) {

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -363,10 +363,14 @@ test("Prometheus basic auth has no Caddy fallback and rejects known weak values"
   assertPrometheusAuthRejected(
     baseHomeServerEnv.replace(
       "PROMETHEUS_BASIC_AUTH_HASH=$$2y$$05$$abcdefghijklmnopqrstuvABCDEFGHIJKLMNOPQRSTUVabcdefghi",
-      "PROMETHEUS_BASIC_AUTH_HASH=$$2y$$05$$g4sdUn.YYoUOjAy/41KhSOBCQvOnwTNJ/jmdl/95o8YKEoq/gddPC",
+      [
+        "PROMETHEUS_BASIC_AUTH_HASH=$$2y$$05$$",
+        "g4sdUn.YYoUOjAy/41KhSOBCQvOnwTNJ/",
+        "jmdl/95o8YKEoq/gddPC",
+      ].join(""),
     ),
     "PROMETHEUS_BASIC_AUTH_HASH",
-    "forbidden value",
+    "forbidden fingerprint",
   )
   assertPrometheusAuthRejected(
     baseHomeServerEnv.replace(

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -358,8 +358,9 @@ test("Prometheus basic auth has no Caddy fallback and rejects known weak values"
   assert(!caddyfile.includes("PROMETHEUS_BASIC_AUTH_USER:promviewer"))
   assert(!caddyfile.includes("PROMETHEUS_BASIC_AUTH_HASH:$2y$05$g4sdUn"))
   assert.match(envExample, /caddy hash-password --plaintext/)
-  assert.match(envExample, /Write the generated hash exactly as printed/)
-  assert(!envExample.includes('as "$$"'))
+  assert.match(envExample, /Wrap the generated hash in single quotes/)
+  assert.match(envExample, /escape every "\$" as "\$\$"/)
+  assert(!envExample.includes("exactly as printed"))
   assert(!envExample.includes("PROMETHEUS_BASIC_AUTH_USER=promviewer"))
   assert(!envExample.includes("g4sdUn.YYoUOjAy"))
   assertPrometheusAuthRejected(

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -362,6 +362,14 @@ test("Prometheus basic auth has no Caddy fallback and rejects known weak values"
   )
   assertPrometheusAuthRejected(
     baseHomeServerEnv.replace(
+      "PROMETHEUS_BASIC_AUTH_USER=prometheus-operator",
+      "PROMETHEUS_BASIC_AUTH_USER=change_me_prometheus_user",
+    ),
+    "PROMETHEUS_BASIC_AUTH_USER",
+    "placeholder value",
+  )
+  assertPrometheusAuthRejected(
+    baseHomeServerEnv.replace(
       "PROMETHEUS_BASIC_AUTH_HASH=$$2y$$05$$abcdefghijklmnopqrstuvABCDEFGHIJKLMNOPQRSTUVabcdefghi",
       [
         "PROMETHEUS_BASIC_AUTH_HASH=$$2y$$05$$",

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -358,6 +358,7 @@ test("Prometheus basic auth has no Caddy fallback and rejects known weak values"
   assert(!caddyfile.includes("PROMETHEUS_BASIC_AUTH_USER:promviewer"))
   assert(!caddyfile.includes("PROMETHEUS_BASIC_AUTH_HASH:$2y$05$g4sdUn"))
   assert.match(envExample, /caddy hash-password --plaintext/)
+  assert.match(envExample, /Escape every "\$" in the generated hash as "\$\$"/)
   assert(!envExample.includes("PROMETHEUS_BASIC_AUTH_USER=promviewer"))
   assert(!envExample.includes("g4sdUn.YYoUOjAy"))
   assertPrometheusAuthRejected(

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -162,7 +162,7 @@ const baseHomeServerEnv = [
   "AQUILA_BACKUP_MIN_FREE_PERCENT=15",
   "AQUILA_BACKUP_ENCRYPTION_KEY_FILE=/mnt/aquila-blog-data/backup-encryption.key",
   "AQUILA_RESTORE_PRIVACY_GATE_SCRIPT=/opt/aquila-blog/restore-privacy-gate.sh",
-  "PROMETHEUS_BASIC_AUTH_USER=promviewer",
+  "PROMETHEUS_BASIC_AUTH_USER=prometheus-operator",
   "PROMETHEUS_BASIC_AUTH_HASH=$$2y$$05$$abcdefghijklmnopqrstuvABCDEFGHIJKLMNOPQRSTUVabcdefghi",
   "OPERATIONS_ALERT_EMAIL_TO=ops@aquilaxk.site",
   "ALERTMANAGER_SMTP_AUTH_ENABLED=true",
@@ -331,6 +331,50 @@ test("grafana admin password has no compose fallback and rejects weak contract v
       .replace("GRAFANA_ADMIN_USER=admin", "GRAFANA_ADMIN_USER=grafana-operator")
       .replace("GRAFANA_ADMIN_PASSWORD=valid-grafana-password", "GRAFANA_ADMIN_PASSWORD=grafana-operator"),
     "must differ from GRAFANA_ADMIN_USER",
+  )
+})
+
+test("Prometheus basic auth has no Caddy fallback and rejects known weak values", async () => {
+  const { loadContract, validateEnvText } = await import("../env/validate-env.mjs")
+  const caddyfile = readFileSync(caddyfilePath, "utf8")
+  const contract = loadContract(contractPath)
+  const assertPrometheusAuthRejected = (text, key, expectedMessagePart) => {
+    const result = validateEnvText({
+      contract,
+      target: "home-server-source",
+      text,
+    })
+
+    assert.equal(result.ok, false)
+    assert(
+      result.errors.some((error) => error.key === key && error.message.includes(expectedMessagePart)),
+      result.errors.map((error) => `${error.key}: ${error.message}`).join("\n"),
+    )
+  }
+
+  assert.match(caddyfile, /\{\$PROMETHEUS_BASIC_AUTH_USER\} \{\$PROMETHEUS_BASIC_AUTH_HASH\}/)
+  assert(!caddyfile.includes("PROMETHEUS_BASIC_AUTH_USER:promviewer"))
+  assert(!caddyfile.includes("PROMETHEUS_BASIC_AUTH_HASH:$2y$05$g4sdUn"))
+  assertPrometheusAuthRejected(
+    baseHomeServerEnv.replace("PROMETHEUS_BASIC_AUTH_USER=prometheus-operator", "PROMETHEUS_BASIC_AUTH_USER=promviewer"),
+    "PROMETHEUS_BASIC_AUTH_USER",
+    "forbidden value",
+  )
+  assertPrometheusAuthRejected(
+    baseHomeServerEnv.replace(
+      "PROMETHEUS_BASIC_AUTH_HASH=$$2y$$05$$abcdefghijklmnopqrstuvABCDEFGHIJKLMNOPQRSTUVabcdefghi",
+      "PROMETHEUS_BASIC_AUTH_HASH=$$2y$$05$$g4sdUn.YYoUOjAy/41KhSOBCQvOnwTNJ/jmdl/95o8YKEoq/gddPC",
+    ),
+    "PROMETHEUS_BASIC_AUTH_HASH",
+    "forbidden value",
+  )
+  assertPrometheusAuthRejected(
+    baseHomeServerEnv.replace(
+      "PROMETHEUS_BASIC_AUTH_HASH=$$2y$$05$$abcdefghijklmnopqrstuvABCDEFGHIJKLMNOPQRSTUVabcdefghi",
+      "PROMETHEUS_BASIC_AUTH_HASH=short-hash",
+    ),
+    "PROMETHEUS_BASIC_AUTH_HASH",
+    "at least 50 characters",
   )
 })
 

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -358,7 +358,8 @@ test("Prometheus basic auth has no Caddy fallback and rejects known weak values"
   assert(!caddyfile.includes("PROMETHEUS_BASIC_AUTH_USER:promviewer"))
   assert(!caddyfile.includes("PROMETHEUS_BASIC_AUTH_HASH:$2y$05$g4sdUn"))
   assert.match(envExample, /caddy hash-password --plaintext/)
-  assert.match(envExample, /Escape every "\$" in the generated hash as "\$\$"/)
+  assert.match(envExample, /Write the generated hash exactly as printed/)
+  assert(!envExample.includes('as "$$"'))
   assert(!envExample.includes("PROMETHEUS_BASIC_AUTH_USER=promviewer"))
   assert(!envExample.includes("g4sdUn.YYoUOjAy"))
   assertPrometheusAuthRejected(

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -10,6 +10,7 @@ const contractPath = path.join(repoRoot, "deploy/env/env.contract.json")
 const workflowPath = path.join(repoRoot, ".github/workflows/deploy.yml")
 const composePath = path.join(repoRoot, "deploy/homeserver/docker-compose.prod.yml")
 const caddyfilePath = path.join(repoRoot, "deploy/homeserver/caddy/Caddyfile")
+const envExamplePath = path.join(repoRoot, "deploy/homeserver/.env.prod.example")
 const applicationProdPath = path.join(repoRoot, "back/src/main/resources/application-prod.yaml")
 const deployScriptPath = path.join(repoRoot, "deploy/homeserver/blue_green_deploy.sh")
 const deployBackupScriptPath = path.join(repoRoot, "deploy/homeserver/create_deploy_backup.sh")
@@ -337,6 +338,7 @@ test("grafana admin password has no compose fallback and rejects weak contract v
 test("Prometheus basic auth has no Caddy fallback and rejects known weak values", async () => {
   const { loadContract, validateEnvText } = await import("../env/validate-env.mjs")
   const caddyfile = readFileSync(caddyfilePath, "utf8")
+  const envExample = readFileSync(envExamplePath, "utf8")
   const contract = loadContract(contractPath)
   const assertPrometheusAuthRejected = (text, key, expectedMessagePart) => {
     const result = validateEnvText({
@@ -355,6 +357,9 @@ test("Prometheus basic auth has no Caddy fallback and rejects known weak values"
   assert.match(caddyfile, /\{\$PROMETHEUS_BASIC_AUTH_USER\} \{\$PROMETHEUS_BASIC_AUTH_HASH\}/)
   assert(!caddyfile.includes("PROMETHEUS_BASIC_AUTH_USER:promviewer"))
   assert(!caddyfile.includes("PROMETHEUS_BASIC_AUTH_HASH:$2y$05$g4sdUn"))
+  assert.match(envExample, /caddy hash-password --plaintext/)
+  assert(!envExample.includes("PROMETHEUS_BASIC_AUTH_USER=promviewer"))
+  assert(!envExample.includes("g4sdUn.YYoUOjAy"))
   assertPrometheusAuthRejected(
     baseHomeServerEnv.replace("PROMETHEUS_BASIC_AUTH_USER=prometheus-operator", "PROMETHEUS_BASIC_AUTH_USER=promviewer"),
     "PROMETHEUS_BASIC_AUTH_USER",


### PR DESCRIPTION
## 🔗 Related Issue
- close #1120

## 📝 Summary
- Prometheus public Caddy block에서 저장소 기본 basic auth 계정/hash fallback을 제거했습니다.
- 배포 env contract가 알려진 기본 계정/hash와 짧은 hash를 거부하도록 테스트로 고정했습니다.

## 🛠 Changes
- `deploy/homeserver/caddy/Caddyfile`의 Prometheus `basic_auth`가 env 누락 시 Caddy config validation에서 실패하도록 기본값 없는 placeholder만 사용합니다.
- `PROMETHEUS_BASIC_AUTH_USER=promviewer`, 기존 기본 bcrypt hash, 50자 미만 hash를 env contract에서 차단합니다.
- env contract 테스트에 fallback 제거와 weak/default credential reject 회귀 케이스를 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [ ] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [x] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [ ] 필요한 수동 확인을 마쳤는가? `운영 credential 회전은 secret 값/접근 권한이 필요해 PR 본문 리스크로 남김`
- [ ] 로그/메트릭/운영 지표를 확인했는가? `로컬 env contract 변경이라 운영 로그 확인 대상 없음`

### 실행한 검증
- `node --test tools/test/env-contract.test.mjs`: 50 tests, 50 pass
- `node --test tools/test/*.test.mjs`: 80 tests, 80 pass
- `git diff --check`: exit 0

## 📸 Screenshot / API Example
- 증거 불필요 사유: UI/API 응답 변경이 아니라 Caddy/env contract fail-closed 변경입니다.
- Evidence: 위 자동화 테스트가 Caddy fallback 제거, known default reject, short hash reject를 검증합니다.

## ⚠️ Risk & Rollback
- 예상 리스크: 운영 `PROMETHEUS_BASIC_AUTH_USER` 또는 `PROMETHEUS_BASIC_AUTH_HASH`가 누락됐거나 기존 기본값이면 배포 preflight/Caddy validation이 실패합니다.
- 운영 조치: merge 전후 HOME_SERVER_ENV의 Prometheus basic auth credential을 새 값으로 회전하고, 기존 기본 credential 인증 실패와 신규 credential 인증 성공을 운영 evidence로 남겨야 합니다.
- 롤백 방법: 이 PR revert. 단, 기본 credential fallback 복구는 보안 리스크가 있어 운영 env 값을 채우는 방향을 우선합니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 코드 주석 정책에 맞는 이유/불변조건/운영 영향을 설명하는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 프로메테우스 UI 접근에 사용되는 인증 값 검증이 강화되어, 약한 기본 사용자명과 취약한 해시 값이 더 이상 허용되지 않습니다.
  * 인증 설정이 환경 변수로 분리되어 적용되도록 개선되어, 설정 반영이 더 명확해졌습니다.

* **Tests**
  * 프로메테우스 인증 설정과 환경 값 검증에 대한 추가 확인이 포함되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->