### PR TITLE
[Hotfix] 요청 query 민감정보 로그 redaction 적용

### DIFF
--- a/back/src/main/kotlin/com/back/global/exception/config/ExceptionHandler.kt
+++ b/back/src/main/kotlin/com/back/global/exception/config/ExceptionHandler.kt
@@ -3,6 +3,7 @@ package com.back.global.exception.config
 import com.back.global.exception.application.AppException
 import com.back.global.jpa.application.ProdSequenceGuardService
 import com.back.global.rsData.RsData
+import com.back.global.web.logging.SensitiveQueryRedactor
 import jakarta.persistence.OptimisticLockException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.ConstraintViolationException
@@ -16,10 +17,10 @@ import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.MissingRequestHeaderException
-import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.multipart.MaxUploadSizeExceededException
 import org.springframework.web.multipart.MultipartException
+import org.springframework.web.bind.annotation.ExceptionHandler as SpringExceptionHandler
 
 @RestControllerAdvice
 class ExceptionHandler(
@@ -28,7 +29,7 @@ class ExceptionHandler(
 ) {
     private val logger = LoggerFactory.getLogger(ExceptionHandler::class.java)
 
-    @ExceptionHandler(NoSuchElementException::class)
+    @SpringExceptionHandler(NoSuchElementException::class)
     fun handleNoSuchElementException(
         @Suppress("UNUSED_PARAMETER") ex: NoSuchElementException,
     ): ResponseEntity<RsData<Void>> =
@@ -36,7 +37,7 @@ class ExceptionHandler(
             .status(HttpStatus.NOT_FOUND)
             .body(RsData("404-1", "해당 데이터가 존재하지 않습니다."))
 
-    @ExceptionHandler(ConstraintViolationException::class)
+    @SpringExceptionHandler(ConstraintViolationException::class)
     fun handleConstraintViolationException(e: ConstraintViolationException): ResponseEntity<RsData<Void>> {
         val message =
             e.constraintViolations
@@ -57,7 +58,7 @@ class ExceptionHandler(
             .body(RsData("400-1", message))
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException::class)
+    @SpringExceptionHandler(MethodArgumentNotValidException::class)
     fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<RsData<Void>> {
         val message =
             e.bindingResult
@@ -73,7 +74,7 @@ class ExceptionHandler(
             .body(RsData("400-1", message))
     }
 
-    @ExceptionHandler(HttpMessageNotReadableException::class)
+    @SpringExceptionHandler(HttpMessageNotReadableException::class)
     fun handleHttpMessageNotReadableException(
         @Suppress("UNUSED_PARAMETER") e: HttpMessageNotReadableException,
     ): ResponseEntity<RsData<Void>> =
@@ -81,14 +82,14 @@ class ExceptionHandler(
             .status(HttpStatus.BAD_REQUEST)
             .body(RsData("400-1", "요청 본문이 올바르지 않습니다."))
 
-    @ExceptionHandler(MaxUploadSizeExceededException::class)
+    @SpringExceptionHandler(MaxUploadSizeExceededException::class)
     fun handleMaxUploadSizeExceededException(
         ex: MaxUploadSizeExceededException,
         request: HttpServletRequest,
     ): ResponseEntity<RsData<Void>> {
         val method = sanitizeLogValue(request.method, MAX_METHOD_LENGTH)
         val path = sanitizeLogValue(request.requestURI, MAX_PATH_LENGTH)
-        val reason = sanitizeLogValue(ex.message, MAX_QUERY_LENGTH)
+        val reason = SensitiveQueryRedactor.redactText(ex.message, MAX_QUERY_LENGTH)
         logger.warn(
             "multipart_request_too_large method={} path={} reason={}",
             method,
@@ -100,14 +101,14 @@ class ExceptionHandler(
             .body(RsData("413-1", "업로드 가능한 파일 용량을 초과했습니다. 허용 크기 이내 파일로 다시 시도해주세요."))
     }
 
-    @ExceptionHandler(MultipartException::class)
+    @SpringExceptionHandler(MultipartException::class)
     fun handleMultipartException(
         ex: MultipartException,
         request: HttpServletRequest,
     ): ResponseEntity<RsData<Void>> {
         val method = sanitizeLogValue(request.method, MAX_METHOD_LENGTH)
         val path = sanitizeLogValue(request.requestURI, MAX_PATH_LENGTH)
-        val reason = sanitizeLogValue(ex.message, MAX_QUERY_LENGTH)
+        val reason = SensitiveQueryRedactor.redactText(ex.message, MAX_QUERY_LENGTH)
         logger.warn(
             "multipart_request_rejected method={} path={} reason={}",
             method,
@@ -119,7 +120,7 @@ class ExceptionHandler(
             .body(RsData("400-1", "업로드 요청 형식이 올바르지 않습니다. 파일을 다시 선택해주세요."))
     }
 
-    @ExceptionHandler(MissingRequestHeaderException::class)
+    @SpringExceptionHandler(MissingRequestHeaderException::class)
     fun handleMissingRequestHeaderException(e: MissingRequestHeaderException): ResponseEntity<RsData<Void>> =
         ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
@@ -134,7 +135,7 @@ class ExceptionHandler(
                 ),
             )
 
-    @ExceptionHandler(AppException::class)
+    @SpringExceptionHandler(AppException::class)
     fun handleAppException(
         ex: AppException,
         request: HttpServletRequest,
@@ -142,15 +143,17 @@ class ExceptionHandler(
         if (ex.rsData.statusCode >= 500) {
             val method = sanitizeLogValue(request.method, MAX_METHOD_LENGTH)
             val path = sanitizeLogValue(request.requestURI, MAX_PATH_LENGTH)
-            val query = normalizeQueryString(request.queryString)
+            val query = SensitiveQueryRedactor.redactQuery(request.queryString, MAX_QUERY_LENGTH)
+            val exceptionMessage = SensitiveQueryRedactor.redactText(ex.message, MAX_QUERY_LENGTH)
             logger.error(
-                "app_exception status={} method={} path={} query={} resultCode={}",
+                "app_exception status={} method={} path={} query={} resultCode={} exceptionClass={} exceptionMessage={}",
                 ex.rsData.statusCode,
                 method,
                 path,
                 query,
                 ex.rsData.resultCode,
-                ex,
+                ex::class.qualifiedName,
+                exceptionMessage,
             )
         }
 
@@ -166,7 +169,7 @@ class ExceptionHandler(
         return response.body(ex.rsData)
     }
 
-    @ExceptionHandler(DataIntegrityViolationException::class)
+    @SpringExceptionHandler(DataIntegrityViolationException::class)
     fun handleDataIntegrityViolationException(ex: DataIntegrityViolationException): ResponseEntity<RsData<Void>> {
         val repaired = prodSequenceGuardService?.repairIfSequenceDrift(ex) == true
         logger.warn("Data integrity violation", ex)
@@ -184,7 +187,7 @@ class ExceptionHandler(
             )
     }
 
-    @ExceptionHandler(
+    @SpringExceptionHandler(
         OptimisticLockingFailureException::class,
         OptimisticLockException::class,
     )
@@ -195,27 +198,29 @@ class ExceptionHandler(
             .body(RsData("409-1", "다른 요청이 먼저 반영되어 충돌이 발생했습니다. 최신 상태를 확인 후 다시 시도해주세요."))
     }
 
-    @ExceptionHandler(Exception::class)
+    @SpringExceptionHandler(Exception::class)
     fun handleUnexpectedException(
         ex: Exception,
         request: HttpServletRequest,
     ): ResponseEntity<RsData<Void>> {
         val method = sanitizeLogValue(request.method, MAX_METHOD_LENGTH)
         val path = sanitizeLogValue(request.requestURI, MAX_PATH_LENGTH)
-        val query = normalizeQueryString(request.queryString)
+        val query = SensitiveQueryRedactor.redactQuery(request.queryString, MAX_QUERY_LENGTH)
+        val exceptionMessage = SensitiveQueryRedactor.redactText(ex.message, MAX_QUERY_LENGTH)
+        val exceptionStack = SensitiveQueryRedactor.redactText(ex.stackTraceToString(), MAX_EXCEPTION_STACK_LENGTH)
         logger.error(
-            "unhandled_server_exception method={} path={} query={}",
+            "unhandled_server_exception method={} path={} query={} exceptionClass={} exceptionMessage={} exceptionStack={}",
             method,
             path,
             query,
-            ex,
+            ex::class.qualifiedName,
+            exceptionMessage,
+            exceptionStack,
         )
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(RsData("500-1", "서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요."))
     }
-
-    private fun normalizeQueryString(rawQuery: String?): String = sanitizeLogValue(rawQuery, MAX_QUERY_LENGTH)
 
     private fun sanitizeLogValue(
         raw: String?,
@@ -239,6 +244,7 @@ class ExceptionHandler(
         private const val MAX_METHOD_LENGTH = 16
         private const val MAX_PATH_LENGTH = 512
         private const val MAX_QUERY_LENGTH = 512
+        private const val MAX_EXCEPTION_STACK_LENGTH = 4096
         private val LOG_CONTROL_CHAR_REGEX = Regex("[\\x00-\\x1F\\x7F]")
     }
 }

--- a/back/src/main/kotlin/com/back/global/web/config/RequestCorrelationFilter.kt
+++ b/back/src/main/kotlin/com/back/global/web/config/RequestCorrelationFilter.kt
@@ -1,5 +1,6 @@
 package com.back.global.web.config
 
+import com.back.global.web.logging.SensitiveQueryRedactor
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -41,7 +42,7 @@ class RequestCorrelationFilter(
             val elapsedMs = (System.nanoTime() - startNs) / 1_000_000
             val method = sanitizeLogValue(request.method, MAX_METHOD_LENGTH)
             val path = sanitizeLogValue(request.requestURI, MAX_PATH_LENGTH)
-            val query = normalizeQueryString(request.queryString)
+            val query = SensitiveQueryRedactor.redactQuery(request.queryString, MAX_QUERY_LENGTH)
             val status = response.status
             val remoteIp = resolveClientIp(request)
 
@@ -96,8 +97,6 @@ class RequestCorrelationFilter(
             sanitizeLogValue(request.remoteAddr, MAX_REMOTE_IP_LENGTH)
         }
     }
-
-    private fun normalizeQueryString(rawQuery: String?): String = sanitizeLogValue(rawQuery, MAX_QUERY_LENGTH)
 
     private fun sanitizeLogValue(
         raw: String?,

--- a/back/src/main/kotlin/com/back/global/web/logging/SensitiveQueryRedactor.kt
+++ b/back/src/main/kotlin/com/back/global/web/logging/SensitiveQueryRedactor.kt
@@ -4,6 +4,7 @@ object SensitiveQueryRedactor {
     const val DEFAULT_MAX_LENGTH = 512
     private const val REDACTED = "[REDACTED]"
     private val controlCharRegex = Regex("[\\x00-\\x1F\\x7F]")
+    private val queryPairSeparatorRegex = Regex("[&;]")
     private val queryTokenInTextRegex = Regex("(^|[?&;\\s])([A-Za-z0-9_.%-]+)=([^&?\\s]*)")
     private val exactSensitiveKeys =
         setOf(
@@ -35,7 +36,7 @@ object SensitiveQueryRedactor {
         if (sanitized.isBlank()) return "-"
 
         return sanitized
-            .split("&")
+            .split(queryPairSeparatorRegex)
             .joinToString("&") { part -> redactQueryPart(part) }
             .take(maxLength)
     }

--- a/back/src/main/kotlin/com/back/global/web/logging/SensitiveQueryRedactor.kt
+++ b/back/src/main/kotlin/com/back/global/web/logging/SensitiveQueryRedactor.kt
@@ -1,0 +1,94 @@
+package com.back.global.web.logging
+
+object SensitiveQueryRedactor {
+    const val DEFAULT_MAX_LENGTH = 512
+    private const val REDACTED = "[REDACTED]"
+    private val controlCharRegex = Regex("[\\x00-\\x1F\\x7F]")
+    private val queryTokenInTextRegex = Regex("(^|[?&;\\s])([A-Za-z0-9_.%-]+)=([^&?\\s]*)")
+    private val exactSensitiveKeys =
+        setOf(
+            "code",
+            "state",
+            "token",
+            "key",
+            "secret",
+            "password",
+            "email",
+            "apikey",
+            "accesstoken",
+            "refreshtoken",
+            "sessionkey",
+            "verificationtoken",
+            "signature",
+            "q",
+            "kw",
+            "query",
+            "search",
+            "keyword",
+        )
+
+    fun redactQuery(
+        rawQuery: String?,
+        maxLength: Int = DEFAULT_MAX_LENGTH,
+    ): String {
+        val sanitized = sanitize(rawQuery)
+        if (sanitized.isBlank()) return "-"
+
+        return sanitized
+            .split("&")
+            .joinToString("&") { part -> redactQueryPart(part) }
+            .take(maxLength)
+    }
+
+    fun redactText(
+        raw: String?,
+        maxLength: Int,
+    ): String {
+        val sanitized = sanitize(raw)
+        if (sanitized.isBlank()) return "-"
+
+        return queryTokenInTextRegex
+            .replace(sanitized) { match ->
+                val prefix = match.groupValues[1]
+                val key = match.groupValues[2]
+                val value = match.groupValues[3]
+                if (isSensitiveKey(key)) {
+                    "$prefix$key=$REDACTED"
+                } else {
+                    "$prefix$key=$value"
+                }
+            }.take(maxLength)
+    }
+
+    private fun redactQueryPart(part: String): String {
+        val separatorIndex = part.indexOf("=")
+        val rawKey = if (separatorIndex >= 0) part.substring(0, separatorIndex) else part
+        val key = sanitize(rawKey)
+        if (key.isBlank()) return "-"
+
+        if (isSensitiveKey(key)) return "$key=$REDACTED"
+        if (separatorIndex < 0) return key
+
+        val value = sanitize(part.substring(separatorIndex + 1))
+        return "$key=$value"
+    }
+
+    private fun isSensitiveKey(rawKey: String): Boolean {
+        val normalized = rawKey.filter { it.isLetterOrDigit() }.lowercase()
+        return normalized in exactSensitiveKeys ||
+            normalized.endsWith("token") ||
+            normalized.endsWith("secret") ||
+            normalized.endsWith("password") ||
+            normalized.endsWith("email") ||
+            normalized.endsWith("signature")
+    }
+
+    private fun sanitize(raw: String?): String =
+        raw
+            .orEmpty()
+            .replace('\r', ' ')
+            .replace('\n', ' ')
+            .replace('\t', ' ')
+            .replace(controlCharRegex, "?")
+            .trim()
+}

--- a/back/src/test/kotlin/com/back/global/exception/config/ExceptionHandlerLogRedactionTest.kt
+++ b/back/src/test/kotlin/com/back/global/exception/config/ExceptionHandlerLogRedactionTest.kt
@@ -1,0 +1,81 @@
+package com.back.global.exception.config
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import com.back.global.exception.application.AppException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockHttpServletRequest
+
+@DisplayName("ExceptionHandler 로그 redaction 테스트")
+class ExceptionHandlerLogRedactionTest {
+    @Test
+    @DisplayName("5xx AppException 로그는 민감 query value를 남기지 않는다")
+    fun `app exception log redacts sensitive query values`() {
+        val handler = ExceptionHandler()
+        val request =
+            MockHttpServletRequest("GET", "/member/api/v1/signup/email/verify").apply {
+                queryString = "token=LEAK_TEST_123&email=test@example.com"
+            }
+        val appender = attachListAppender()
+
+        try {
+            handler.handleAppException(AppException("500-9", "failed token=LEAK_TEST_123"), request)
+        } finally {
+            detachListAppender(appender)
+        }
+
+        val message = appender.list.single().formattedMessage
+        assertThat(message)
+            .contains("query=token=[REDACTED]&email=[REDACTED]")
+            .contains("exceptionMessage=500-9 : failed token=[REDACTED]")
+            .doesNotContain("LEAK_TEST_123")
+            .doesNotContain("test@example.com")
+    }
+
+    @Test
+    @DisplayName("unexpected exception message 안의 URL query도 마스킹한다")
+    fun `unexpected exception log redacts query tokens inside exception message`() {
+        val handler = ExceptionHandler()
+        val request =
+            MockHttpServletRequest("GET", "/login/oauth2/code/kakao").apply {
+                queryString = "code=LEAK_TEST_123&state=STATE_123&page=1"
+            }
+        val appender = attachListAppender()
+
+        val response =
+            try {
+                handler.handleUnexpectedException(
+                    RuntimeException("failed url=/login/oauth2/code/kakao?code=LEAK_TEST_123&state=STATE_123"),
+                    request,
+                )
+            } finally {
+                detachListAppender(appender)
+            }
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        assertThat(appender.list.single().formattedMessage)
+            .contains("query=code=[REDACTED]&state=[REDACTED]&page=1")
+            .contains("?code=[REDACTED]&state=[REDACTED]")
+            .contains("exceptionStack=java.lang.RuntimeException")
+            .doesNotContain("LEAK_TEST_123")
+            .doesNotContain("STATE_123")
+    }
+
+    private fun attachListAppender(): ListAppender<ILoggingEvent> {
+        val logger = LoggerFactory.getLogger(ExceptionHandler::class.java) as Logger
+        return ListAppender<ILoggingEvent>().also {
+            it.start()
+            logger.addAppender(it)
+        }
+    }
+
+    private fun detachListAppender(appender: ListAppender<ILoggingEvent>) {
+        val logger = LoggerFactory.getLogger(ExceptionHandler::class.java) as Logger
+        logger.detachAppender(appender)
+    }
+}

--- a/back/src/test/kotlin/com/back/global/web/config/RequestCorrelationFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/web/config/RequestCorrelationFilterTest.kt
@@ -1,0 +1,63 @@
+package com.back.global.web.config
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+@DisplayName("RequestCorrelationFilter 테스트")
+class RequestCorrelationFilterTest {
+    @Test
+    @DisplayName("slow request 로그는 민감 query value를 남기지 않는다")
+    fun `slow request log redacts sensitive query values`() {
+        val filter = RequestCorrelationFilter(slowRequestThresholdMs = 0)
+        val request =
+            MockHttpServletRequest("GET", "/post/api/v1/posts/search").apply {
+                queryString = "token=LEAK_TEST_123&kw=private&page=1"
+                remoteAddr = "203.0.113.10"
+            }
+        val response = MockHttpServletResponse()
+        val appender = attachListAppender()
+
+        try {
+            filter.doFilter(
+                request,
+                response,
+                FilterChain { _: ServletRequest, servletResponse: ServletResponse ->
+                    (servletResponse as HttpServletResponse).status = HttpServletResponse.SC_OK
+                },
+            )
+        } finally {
+            detachListAppender(appender)
+        }
+
+        val messages = appender.list.map { it.formattedMessage }
+        assertThat(messages).hasSize(1)
+        assertThat(messages.single())
+            .contains("query=token=[REDACTED]&kw=[REDACTED]&page=1")
+            .doesNotContain("LEAK_TEST_123")
+            .doesNotContain("private")
+    }
+
+    private fun attachListAppender(): ListAppender<ILoggingEvent> {
+        val logger = LoggerFactory.getLogger(RequestCorrelationFilter::class.java) as Logger
+        return ListAppender<ILoggingEvent>().also {
+            it.start()
+            logger.addAppender(it)
+        }
+    }
+
+    private fun detachListAppender(appender: ListAppender<ILoggingEvent>) {
+        val logger = LoggerFactory.getLogger(RequestCorrelationFilter::class.java) as Logger
+        logger.detachAppender(appender)
+    }
+}

--- a/back/src/test/kotlin/com/back/global/web/logging/SensitiveQueryRedactorTest.kt
+++ b/back/src/test/kotlin/com/back/global/web/logging/SensitiveQueryRedactorTest.kt
@@ -33,12 +33,13 @@ class SensitiveQueryRedactorTest {
     fun `redacts token-like key variants and control characters`() {
         val redacted =
             SensitiveQueryRedactor.redactQuery(
-                "access_token=LEAK_TEST_123&refreshToken=REFRESH_SECRET&name=ok\r\nnext",
+                "access_token=LEAK_TEST_123;refreshToken=REFRESH_SECRET&name=ok\r\nnext",
             )
 
         assertThat(redacted)
             .contains("access_token=[REDACTED]")
             .contains("refreshToken=[REDACTED]")
+            .contains("access_token=[REDACTED]&refreshToken=[REDACTED]")
             .contains("name=ok  next")
             .doesNotContain("LEAK_TEST_123")
             .doesNotContain("REFRESH_SECRET")

--- a/back/src/test/kotlin/com/back/global/web/logging/SensitiveQueryRedactorTest.kt
+++ b/back/src/test/kotlin/com/back/global/web/logging/SensitiveQueryRedactorTest.kt
@@ -1,0 +1,63 @@
+package com.back.global.web.logging
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("SensitiveQueryRedactor 테스트")
+class SensitiveQueryRedactorTest {
+    @Test
+    @DisplayName("민감 query key의 value만 마스킹하고 비민감 key는 유지한다")
+    fun `redacts sensitive query values`() {
+        val redacted =
+            SensitiveQueryRedactor.redactQuery(
+                "code=LEAK_TEST_123&state=STATE_123&email=test@example.com&page=2&apiKey=API_SECRET&kw=private",
+            )
+
+        assertThat(redacted)
+            .contains("code=[REDACTED]")
+            .contains("state=[REDACTED]")
+            .contains("email=[REDACTED]")
+            .contains("apiKey=[REDACTED]")
+            .contains("kw=[REDACTED]")
+            .contains("page=2")
+            .doesNotContain("LEAK_TEST_123")
+            .doesNotContain("STATE_123")
+            .doesNotContain("test@example.com")
+            .doesNotContain("API_SECRET")
+            .doesNotContain("private")
+    }
+
+    @Test
+    @DisplayName("camelCase/snake_case 토큰 key와 control character를 함께 처리한다")
+    fun `redacts token-like key variants and control characters`() {
+        val redacted =
+            SensitiveQueryRedactor.redactQuery(
+                "access_token=LEAK_TEST_123&refreshToken=REFRESH_SECRET&name=ok\r\nnext",
+            )
+
+        assertThat(redacted)
+            .contains("access_token=[REDACTED]")
+            .contains("refreshToken=[REDACTED]")
+            .contains("name=ok  next")
+            .doesNotContain("LEAK_TEST_123")
+            .doesNotContain("REFRESH_SECRET")
+    }
+
+    @Test
+    @DisplayName("exception message 안의 query token도 마스킹한다")
+    fun `redacts sensitive query tokens inside text`() {
+        val redacted =
+            SensitiveQueryRedactor.redactText(
+                "failed url=/login/oauth2/code/kakao?code=LEAK_TEST_123&state=STATE_123 page=2",
+                maxLength = 512,
+            )
+
+        assertThat(redacted)
+            .contains("?code=[REDACTED]")
+            .contains("&state=[REDACTED]")
+            .contains("page=2")
+            .doesNotContain("LEAK_TEST_123")
+            .doesNotContain("STATE_123")
+    }
+}

--- a/deploy/homeserver/caddy/Caddyfile
+++ b/deploy/homeserver/caddy/Caddyfile
@@ -113,11 +113,23 @@ http://{$API_DOMAIN} {
   @notificationSse path /member/api/v1/notifications/stream
   log_skip @notificationSse
 
+  @oauthCallbackSensitive path /login/oauth2/code/*
+  log_skip @oauthCallbackSensitive
+
   @signupVerifySensitive path /member/api/v1/signup/email/verify
   log_skip @signupVerifySensitive
 
+  @socialSignupSensitive path /member/api/v1/signup/social/pending /member/api/v1/signup/social/complete
+  log_skip @socialSignupSensitive
+
+  @accountDeletionSensitive path /member/api/v1/privacy/account
+  log_skip @accountDeletionSensitive
+
   @cloudExternalContentSensitive path /system/api/v1/adm/cloud/files/*/external-content
   log_skip @cloudExternalContentSensitive
+
+  @publicSearchSensitive path /post/api/v1/posts/search
+  log_skip @publicSearchSensitive
 
   handle @notificationSse {
     header {

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -273,6 +273,34 @@ test("Caddy routes tokenized cloud external content through public read upstream
   assert(readProxyIndex < adminMatcherIndex, "public read proxy must be declared before admin API matcher")
 })
 
+test("Caddy access logs skip sensitive query routes before proxying", () => {
+  const caddyfile = readFileSync(caddyfilePath, "utf8")
+  const apiBlockIndex = caddyfile.indexOf("http://{$API_DOMAIN}")
+  const proxyIndex = caddyfile.indexOf("reverse_proxy {$ADMIN_API_UPSTREAM:back_blue}:8080", apiBlockIndex)
+  const publicReadMatcherIndex = caddyfile.indexOf("@publicReadFallback")
+  const sensitiveRoutes = [
+    ["@oauthCallbackSensitive", "path /login/oauth2/code/*"],
+    ["@socialSignupSensitive", "path /member/api/v1/signup/social/pending /member/api/v1/signup/social/complete"],
+    ["@accountDeletionSensitive", "path /member/api/v1/privacy/account"],
+    ["@publicSearchSensitive", "path /post/api/v1/posts/search"],
+  ]
+
+  assert.notEqual(apiBlockIndex, -1, "API domain block must be configured")
+  assert.notEqual(proxyIndex, -1, "admin proxy handling must be configured")
+  assert.notEqual(publicReadMatcherIndex, -1, "public read matcher must be configured")
+
+  for (const [matcherName, pathMatcher] of sensitiveRoutes) {
+    const matcherIndex = caddyfile.indexOf(`${matcherName} ${pathMatcher}`)
+    const skipIndex = caddyfile.indexOf(`log_skip ${matcherName}`)
+
+    assert.notEqual(matcherIndex, -1, `${matcherName} matcher must be configured`)
+    assert.notEqual(skipIndex, -1, `${matcherName} access log skip must be configured`)
+    assert(skipIndex > matcherIndex, `${matcherName} log_skip must reference the sensitive matcher`)
+    assert(skipIndex < proxyIndex, `${matcherName} log_skip must be declared before admin proxy handling`)
+    assert(skipIndex < publicReadMatcherIndex, `${matcherName} log_skip must be declared before read routing`)
+  }
+})
+
 test("home-server-source contract allows no-auth operations alert SMTP relay", async () => {
   const { loadContract, validateEnvText } = await import("../env/validate-env.mjs")
   const noAuthEnv = baseHomeServerEnv

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -276,8 +276,8 @@ test("Caddy routes tokenized cloud external content through public read upstream
 test("Caddy access logs skip sensitive query routes before proxying", () => {
   const caddyfile = readFileSync(caddyfilePath, "utf8")
   const apiBlockIndex = caddyfile.indexOf("http://{$API_DOMAIN}")
-  const proxyIndex = caddyfile.indexOf("reverse_proxy {$ADMIN_API_UPSTREAM:back_blue}:8080", apiBlockIndex)
-  const publicReadMatcherIndex = caddyfile.indexOf("@publicReadFallback")
+  const adminHandleIndex = caddyfile.indexOf("handle @adminApi {", apiBlockIndex)
+  const publicReadHandleIndex = caddyfile.indexOf("handle @publicReadFallback {", apiBlockIndex)
   const sensitiveRoutes = [
     ["@oauthCallbackSensitive", "path /login/oauth2/code/*"],
     ["@socialSignupSensitive", "path /member/api/v1/signup/social/pending /member/api/v1/signup/social/complete"],
@@ -286,8 +286,8 @@ test("Caddy access logs skip sensitive query routes before proxying", () => {
   ]
 
   assert.notEqual(apiBlockIndex, -1, "API domain block must be configured")
-  assert.notEqual(proxyIndex, -1, "admin proxy handling must be configured")
-  assert.notEqual(publicReadMatcherIndex, -1, "public read matcher must be configured")
+  assert.notEqual(adminHandleIndex, -1, "admin API handle must be configured")
+  assert.notEqual(publicReadHandleIndex, -1, "public read handle must be configured")
 
   for (const [matcherName, pathMatcher] of sensitiveRoutes) {
     const matcherIndex = caddyfile.indexOf(`${matcherName} ${pathMatcher}`)
@@ -296,8 +296,8 @@ test("Caddy access logs skip sensitive query routes before proxying", () => {
     assert.notEqual(matcherIndex, -1, `${matcherName} matcher must be configured`)
     assert.notEqual(skipIndex, -1, `${matcherName} access log skip must be configured`)
     assert(skipIndex > matcherIndex, `${matcherName} log_skip must reference the sensitive matcher`)
-    assert(skipIndex < proxyIndex, `${matcherName} log_skip must be declared before admin proxy handling`)
-    assert(skipIndex < publicReadMatcherIndex, `${matcherName} log_skip must be declared before read routing`)
+    assert(skipIndex < adminHandleIndex, `${matcherName} log_skip must be declared before admin API handling`)
+    assert(skipIndex < publicReadHandleIndex, `${matcherName} log_skip must be declared before public read handling`)
   }
 })
 


### PR DESCRIPTION
## 관련 이슈

close #1121

## 작업 배경

- 5xx/slow request/application exception 로그와 Caddy access log가 민감 query value를 평문으로 남길 수 있어 출시 전 차단이 필요했습니다.
- 대상 값은 OAuth `code/state`, signup/social/cloud token, email, password/key/secret/signature, 검색어 계열 query입니다.

## 작업 내용

- `SensitiveQueryRedactor`를 추가해 backend request/error 로그가 민감 query value와 exception message/stack 내부 query token을 `[REDACTED]`로 기록하게 했습니다.
- `RequestCorrelationFilter`와 `ExceptionHandler`가 같은 redactor를 사용하도록 통합했습니다.
- Caddy access log에서 OAuth callback, signup social, account deletion, public search 등 민감 query 가능성이 있는 경로를 proxy 전에 `log_skip`하도록 확장했습니다.
- backend redaction 단위 테스트와 filter/exception 로그 테스트, Caddy log skip 계약 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/test/env-contract.test.mjs`: pass 51, fail 0
  - `./back/gradlew -p back test --tests '*SensitiveQueryRedactor*' --tests '*RequestCorrelationFilter*' --tests '*ExceptionHandler*'`: `BUILD SUCCESSFUL`
  - `./back/gradlew -p back ktlintCheck`: `BUILD SUCCESSFUL`
  - `./back/gradlew -p back test --rerun-tasks`: `BUILD SUCCESSFUL` 2회 연속
  - `git commit`: pre-commit OpenAPI export/check-contract-drift `BUILD SUCCESSFUL`, `contracts:check` up-to-date

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| app query redaction | local backend | `SensitiveQueryRedactor`, `RequestCorrelationFilter`, `ExceptionHandler` targeted test | Gradle output: `BUILD SUCCESSFUL` | `LEAK_TEST_123` 미노출 검증 통과 |
| Caddy sensitive access log skip | local Node test | `node --test tools/test/env-contract.test.mjs` | Node test output: pass 51, fail 0 | 민감 route `log_skip` 계약 통과 |
| backend style/regression | local backend | `./back/gradlew -p back ktlintCheck`, `./back/gradlew -p back test --rerun-tasks` 2회 | Gradle output: `BUILD SUCCESSFUL` | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `ExceptionHandler`는 Throwable 객체를 직접 넘기지 않고 redacted message/stack 문자열을 제한 길이로 남깁니다. 원문 throwable message에 URL query가 들어와도 로그 저장 경로에 평문 token이 남지 않게 하기 위한 변경입니다.

## 리스크

- unhandled exception 로그의 stack trace가 기존 ThrowableProxy 형식이 아니라 단일 redacted 문자열 필드로 바뀝니다. 검색성은 유지하지만 로그 렌더링 형식은 달라질 수 있습니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 서버 오류 및 요청 로그에서 쿼리, 메시지, 스택 트레이스의 민감 정보가 자동으로 가려지도록 개선했습니다.
  * 느린 요청과 예외 로그에 남는 URL/쿼리 값의 노출을 줄였습니다.
* **New Features**
  * 민감한 파라미터를 식별해 마스킹하는 새 로그 처리 기능이 추가되었습니다.
* **Tests**
  * 민감 정보가 로그에 남지 않는지 확인하는 테스트가 추가되었습니다.
  * 특정 경로의 접근 로그 스킵 설정이 올바른지 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->