### PR TITLE
[Fix] 공개 글 첨부파일 익명 다운로드 권한 모델 정리

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageController.kt
@@ -283,12 +283,8 @@ class ApiV1PostImageController(
             return ResponseEntity
                 .status(HttpStatus.NOT_MODIFIED)
                 .eTag(etag)
-                .cacheControl(
-                    CacheControl
-                        .maxAge(30, TimeUnit.DAYS)
-                        .cachePublic()
-                        .immutable(),
-                ).build()
+                .cacheControl(CacheControl.noStore())
+                .build()
         }
 
         val storedFile =
@@ -311,12 +307,7 @@ class ApiV1PostImageController(
                 .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
                 .header("X-Content-Type-Options", "nosniff")
                 .eTag(etag)
-                .cacheControl(
-                    CacheControl
-                        .maxAge(30, TimeUnit.DAYS)
-                        .cachePublic()
-                        .immutable(),
-                )
+                .cacheControl(CacheControl.noStore())
 
         val finalizedBuilder =
             storedFile.contentLength

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageController.kt
@@ -1,12 +1,16 @@
 package com.back.boundedContexts.post.adapter.web
 
 import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
 import com.back.boundedContexts.post.config.PostImageStorageProperties
 import com.back.global.app.AppConfig
 import com.back.global.exception.application.AppException
 import com.back.global.rsData.RsData
 import com.back.global.storage.application.UploadedFileRetentionService
+import com.back.global.storage.application.port.output.UploadedFileRepositoryPort
+import com.back.global.storage.domain.UploadedFileOwnerType
 import com.back.global.storage.domain.UploadedFilePurpose
+import com.back.global.storage.domain.UploadedFileStatus
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.core.io.InputStreamResource
 import org.springframework.core.io.Resource
@@ -37,6 +41,8 @@ class ApiV1PostImageController(
     private val postImageStorageService: PostImageStoragePort,
     private val postImageStorageProperties: PostImageStorageProperties,
     private val uploadedFileRetentionService: UploadedFileRetentionService,
+    private val uploadedFileRepository: UploadedFileRepositoryPort,
+    private val postRepository: PostRepositoryPort,
 ) {
     companion object {
         private const val POST_IMAGE_MAX_FILE_SIZE_BYTES = 8L * 1024 * 1024
@@ -264,6 +270,8 @@ class ApiV1PostImageController(
                 "잘못된 첨부 파일 경로입니다.",
                 "첨부 파일을 찾을 수 없습니다.",
             )
+        ensurePublicPostFile(objectKey)
+
         val etag =
             "\"" +
                 Base64
@@ -301,6 +309,7 @@ class ApiV1PostImageController(
                 .ok()
                 .contentType(MediaType.parseMediaType(storedFile.contentType))
                 .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
+                .header("X-Content-Type-Options", "nosniff")
                 .eTag(etag)
                 .cacheControl(
                     CacheControl
@@ -317,6 +326,22 @@ class ApiV1PostImageController(
 
         return finalizedBuilder.body(InputStreamResource(storedFile.inputStream))
     }
+
+    private fun ensurePublicPostFile(objectKey: String) {
+        val uploadedFile = uploadedFileRepository.findByObjectKey(objectKey) ?: throw postFileNotFound()
+        if (
+            uploadedFile.purpose != UploadedFilePurpose.POST_FILE ||
+            uploadedFile.status != UploadedFileStatus.ACTIVE ||
+            uploadedFile.ownerType != UploadedFileOwnerType.POST
+        ) {
+            throw postFileNotFound()
+        }
+
+        val postId = uploadedFile.ownerId?.takeIf { it > 0L } ?: throw postFileNotFound()
+        if (postRepository.findPublicDetailById(postId) == null) throw postFileNotFound()
+    }
+
+    private fun postFileNotFound(): AppException = AppException("404-1", "첨부 파일을 찾을 수 없습니다.")
 
     private fun extractObjectKey(
         request: HttpServletRequest,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/config/PostSecurityConfigurer.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/config/PostSecurityConfigurer.kt
@@ -29,6 +29,7 @@ class PostSecurityConfigurer : PublicApiRouteContributor {
             PublicApiRouteSpec("/post/api/*/posts/tags", HttpMethod.GET),
             PublicApiRouteSpec("/post/api/*/posts/{id:\\d+}", HttpMethod.GET),
             PublicApiRouteSpec("/post/api/*/images/**", HttpMethod.GET),
+            PublicApiRouteSpec("/post/api/*/files/**", HttpMethod.GET),
             PublicApiRouteSpec("/post/api/*/posts/{id:\\d+}/hit", HttpMethod.POST),
             PublicApiRouteSpec("/post/api/*/posts/{postId:\\d+}/comments", HttpMethod.GET),
             PublicApiRouteSpec("/post/api/*/posts/{postId:\\d+}/comments/{id:\\d+}", HttpMethod.GET),

--- a/back/src/main/kotlin/com/back/boundedContexts/post/config/PostSecurityConfigurer.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/config/PostSecurityConfigurer.kt
@@ -30,6 +30,7 @@ class PostSecurityConfigurer : PublicApiRouteContributor {
             PublicApiRouteSpec("/post/api/*/posts/{id:\\d+}", HttpMethod.GET),
             PublicApiRouteSpec("/post/api/*/images/**", HttpMethod.GET),
             PublicApiRouteSpec("/post/api/*/files/**", HttpMethod.GET),
+            PublicApiRouteSpec("/post/api/*/files/**", HttpMethod.HEAD),
             PublicApiRouteSpec("/post/api/*/posts/{id:\\d+}/hit", HttpMethod.POST),
             PublicApiRouteSpec("/post/api/*/posts/{postId:\\d+}/comments", HttpMethod.GET),
             PublicApiRouteSpec("/post/api/*/posts/{postId:\\d+}/comments/{id:\\d+}", HttpMethod.GET),

--- a/back/src/main/kotlin/com/back/global/security/config/ApiRateLimitBackstopFilter.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/ApiRateLimitBackstopFilter.kt
@@ -223,6 +223,7 @@ class ApiRateLimitBackstopFilter(
                 Regex("^/post/api/v\\d+/posts/\\d+/comments$"),
                 Regex("^/post/api/v\\d+/posts/\\d+/comments/\\d+$"),
                 Regex("^/post/api/v\\d+/images/.*"),
+                Regex("^/post/api/v\\d+/files/.*"),
                 Regex("^/system/api/v\\d+/adm/cloud/files/\\d+/external-content$"),
             )
         private val PUBLIC_DETAIL_PATH = Regex("^/post/api/v\\d+/posts/\\d+$")

--- a/back/src/main/kotlin/com/back/global/security/config/ApiRuntimeBoundaryFilter.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/ApiRuntimeBoundaryFilter.kt
@@ -110,6 +110,7 @@ class ApiRuntimeBoundaryFilter(
                 Regex("^/post/api/v1/posts$"),
                 Regex("^/post/api/v1/posts/\\d+/comments$"),
                 Regex("^/post/api/v1/posts/\\d+/comments/\\d+$"),
+                Regex("^/post/api/v1/files/.*"),
                 Regex("^/system/api/v1/adm/cloud/files/\\d+/external-content$"),
             )
         private val PUBLIC_DETAIL_PATH = Regex("^/post/api/v1/posts/\\d+$")

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageControllerTest.kt
@@ -178,9 +178,11 @@ class ApiV1PostImageControllerTest {
             val objectKey = "posts/2026/03/${status.name.lowercase()}.pdf"
             val uploadedFile =
                 postFile(objectKey).apply {
+                    attachToPost(12L, UploadedFilePurpose.POST_FILE)
                     this.status = status
                 }
             `when`(uploadedFileRepository.findByObjectKey(objectKey)).thenReturn(uploadedFile)
+            `when`(postRepository.findPublicDetailById(12L)).thenReturn(publicPost(12L))
 
             assertPostFileNotFound(objectKey)
 

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageControllerTest.kt
@@ -121,7 +121,37 @@ class ApiV1PostImageControllerTest {
         assertThat(response.headers.contentLength).isEqualTo(storedBytes.size.toLong())
         assertThat(response.headers.getFirst(HttpHeaders.CONTENT_DISPOSITION)).contains("attachment").contains("manual.pdf")
         assertThat(response.headers.getFirst("X-Content-Type-Options")).isEqualTo("nosniff")
+        assertThat(response.headers.cacheControl).isEqualTo("no-store")
         assertThat(postImageStorageService.fileDownloads).containsExactly(objectKey)
+    }
+
+    @Test
+    @DisplayName("게시글 첨부파일 304 응답은 재검증 가능한 캐시를 남기지 않는다")
+    fun `files 다운로드 304는 no store cache policy를 반환한다`() {
+        val objectKey = "posts/2026/03/cached.pdf"
+        val uploadedFile = postFile(objectKey).apply { attachToPost(11L, UploadedFilePurpose.POST_FILE) }
+        `when`(uploadedFileRepository.findByObjectKey(objectKey)).thenReturn(uploadedFile)
+        `when`(postRepository.findPublicDetailById(11L)).thenReturn(publicPost(11L))
+        postImageStorageService.files[objectKey] =
+            PostImageStoragePort.StoredObject(
+                inputStream = ByteArrayInputStream("pdf".toByteArray()),
+                contentType = "application/pdf",
+                contentLength = 3L,
+                originalFilename = "cached.pdf",
+            )
+        val firstResponse = controller.getPostFile(fileRequest(objectKey))
+        postImageStorageService.fileDownloads.clear()
+
+        val conditionalRequest =
+            fileRequest(objectKey).apply {
+                addHeader(HttpHeaders.IF_NONE_MATCH, requireNotNull(firstResponse.headers.eTag))
+            }
+
+        val response = controller.getPostFile(conditionalRequest)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_MODIFIED)
+        assertThat(response.headers.cacheControl).isEqualTo("no-store")
+        assertThat(postImageStorageService.fileDownloads).isEmpty()
     }
 
     @Test

--- a/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageControllerTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/adapter/web/ApiV1PostImageControllerTest.kt
@@ -1,16 +1,29 @@
 package com.back.boundedContexts.post.adapter.web
 
+import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.post.application.port.output.PostImageStoragePort
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
 import com.back.boundedContexts.post.config.PostImageStorageProperties
+import com.back.boundedContexts.post.domain.Post
 import com.back.global.app.AppConfig
+import com.back.global.exception.application.AppException
 import com.back.global.storage.application.UploadedFileRetentionService
+import com.back.global.storage.application.port.output.UploadedFileRepositoryPort
+import com.back.global.storage.domain.UploadedFile
 import com.back.global.storage.domain.UploadedFilePurpose
+import com.back.global.storage.domain.UploadedFileStatus
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.web.multipart.MultipartFile
 import java.io.ByteArrayInputStream
 import java.io.InputStream
@@ -30,11 +43,15 @@ class ApiV1PostImageControllerTest {
 
     private val postImageStorageService = FakePostImageStoragePort()
     private val uploadedFileRetentionService = mock(UploadedFileRetentionService::class.java)
+    private val uploadedFileRepository = mock(UploadedFileRepositoryPort::class.java)
+    private val postRepository = mock(PostRepositoryPort::class.java)
     private val controller =
         ApiV1PostImageController(
             postImageStorageService = postImageStorageService,
             postImageStorageProperties = PostImageStorageProperties(maxFileSizeBytes = 10 * 1024 * 1024),
             uploadedFileRetentionService = uploadedFileRetentionService,
+            uploadedFileRepository = uploadedFileRepository,
+            postRepository = postRepository,
         )
 
     @Test
@@ -81,6 +98,94 @@ class ApiV1PostImageControllerTest {
         )
     }
 
+    @Test
+    @DisplayName("게시글 첨부파일 다운로드는 공개 ACTIVE POST_FILE만 반환한다")
+    fun `files 다운로드는 공개 ACTIVE POST_FILE만 반환한다`() {
+        val objectKey = "posts/2026/03/manual.pdf"
+        val storedBytes = "pdf".toByteArray()
+        val uploadedFile = postFile(objectKey).apply { attachToPost(10L, UploadedFilePurpose.POST_FILE) }
+        `when`(uploadedFileRepository.findByObjectKey(objectKey)).thenReturn(uploadedFile)
+        `when`(postRepository.findPublicDetailById(10L)).thenReturn(publicPost(10L))
+        postImageStorageService.files[objectKey] =
+            PostImageStoragePort.StoredObject(
+                inputStream = ByteArrayInputStream(storedBytes),
+                contentType = "application/pdf",
+                contentLength = storedBytes.size.toLong(),
+                originalFilename = "manual.pdf",
+            )
+
+        val response = controller.getPostFile(fileRequest(objectKey))
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.headers.contentType.toString()).isEqualTo("application/pdf")
+        assertThat(response.headers.contentLength).isEqualTo(storedBytes.size.toLong())
+        assertThat(response.headers.getFirst(HttpHeaders.CONTENT_DISPOSITION)).contains("attachment").contains("manual.pdf")
+        assertThat(response.headers.getFirst("X-Content-Type-Options")).isEqualTo("nosniff")
+        assertThat(postImageStorageService.fileDownloads).containsExactly(objectKey)
+    }
+
+    @Test
+    @DisplayName("게시글 첨부파일 다운로드는 비공개 게시글 연결 파일을 숨긴다")
+    fun `files 다운로드는 비공개 게시글 연결 파일을 숨긴다`() {
+        val objectKey = "posts/2026/03/private.pdf"
+        val uploadedFile = postFile(objectKey).apply { attachToPost(20L, UploadedFilePurpose.POST_FILE) }
+        `when`(uploadedFileRepository.findByObjectKey(objectKey)).thenReturn(uploadedFile)
+        `when`(postRepository.findPublicDetailById(20L)).thenReturn(null)
+
+        assertPostFileNotFound(objectKey)
+
+        assertThat(postImageStorageService.fileDownloads).isEmpty()
+    }
+
+    @Test
+    @DisplayName("게시글 첨부파일 다운로드는 TEMP PENDING_DELETE DELETED 파일을 숨긴다")
+    fun `files 다운로드는 비활성 파일을 숨긴다`() {
+        listOf(
+            UploadedFileStatus.TEMP,
+            UploadedFileStatus.PENDING_DELETE,
+            UploadedFileStatus.DELETED,
+        ).forEach { status ->
+            val objectKey = "posts/2026/03/${status.name.lowercase()}.pdf"
+            val uploadedFile =
+                postFile(objectKey).apply {
+                    this.status = status
+                }
+            `when`(uploadedFileRepository.findByObjectKey(objectKey)).thenReturn(uploadedFile)
+
+            assertPostFileNotFound(objectKey)
+
+            assertThat(postImageStorageService.fileDownloads).isEmpty()
+            verifyNoInteractions(postRepository)
+        }
+    }
+
+    private fun assertPostFileNotFound(objectKey: String) {
+        assertThatThrownBy { controller.getPostFile(fileRequest(objectKey)) }
+            .isInstanceOf(AppException::class.java)
+            .hasMessageContaining("첨부 파일을 찾을 수 없습니다.")
+    }
+
+    private fun fileRequest(objectKey: String): MockHttpServletRequest = MockHttpServletRequest("GET", "/post/api/v1/files/$objectKey")
+
+    private fun postFile(objectKey: String): UploadedFile =
+        UploadedFile(
+            objectKey = objectKey,
+            bucket = "blog-images",
+            contentType = "application/pdf",
+            fileSize = 3L,
+            purpose = UploadedFilePurpose.POST_FILE,
+        )
+
+    private fun publicPost(id: Long): Post =
+        Post(
+            id = id,
+            author = Member(1L, "admin", null, "관리자"),
+            title = "공개 글",
+            content = "본문",
+            published = true,
+            listed = true,
+        )
+
     private class FakePostImageStoragePort : PostImageStoragePort {
         var nextImageKey: String = "posts/placeholder/image.png"
         var nextFileKey: String = "posts/placeholder/file.bin"
@@ -88,6 +193,8 @@ class ApiV1PostImageControllerTest {
         var lastFileContentLength: Long? = null
         var lastImageBytes: ByteArray = ByteArray(0)
         var lastFileBytes: ByteArray = ByteArray(0)
+        val files = mutableMapOf<String, PostImageStoragePort.StoredObject>()
+        val fileDownloads = mutableListOf<String>()
 
         override fun uploadPostImage(request: PostImageStoragePort.UploadImageRequest): String {
             lastImageContentLength = request.contentLength
@@ -103,7 +210,10 @@ class ApiV1PostImageControllerTest {
 
         override fun getPostImage(objectKey: String): PostImageStoragePort.StoredObject? = null
 
-        override fun getPostFile(objectKey: String): PostImageStoragePort.StoredObject? = null
+        override fun getPostFile(objectKey: String): PostImageStoragePort.StoredObject? {
+            fileDownloads += objectKey
+            return files[objectKey]
+        }
 
         override fun deletePostImage(objectKey: String) {}
 

--- a/back/src/test/kotlin/com/back/global/security/config/ApiRateLimitBackstopFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/ApiRateLimitBackstopFilterTest.kt
@@ -71,16 +71,12 @@ class ApiRateLimitBackstopFilterTest {
     fun `external cloud content get and head use public read bucket`() {
         val redis = InMemoryRedisKeyValuePort()
         val filter = createFilter(redis = redis, publicReadLimitPerMinute = 2)
-        val path = "/system/api/v1/adm/cloud/files/12/external-content"
 
-        assertThat(runFilter(filter, "GET", path).status).isEqualTo(HttpServletResponse.SC_OK)
-        assertThat(runFilter(filter, "HEAD", path).status).isEqualTo(HttpServletResponse.SC_OK)
-
-        val limited = runFilter(filter, "GET", path)
-
-        assertThat(limited.status).isEqualTo(429)
-        assertThat(limited.contentAsString).contains("public-read")
-        assertThat(redis.expiredKeys()).anyMatch { it.contains("public-read") }
+        assertPublicReadBucketLimit(
+            filter = filter,
+            redis = redis,
+            path = "/system/api/v1/adm/cloud/files/12/external-content",
+        )
     }
 
     @Test
@@ -88,11 +84,21 @@ class ApiRateLimitBackstopFilterTest {
     fun `post file get and head use public read bucket`() {
         val redis = InMemoryRedisKeyValuePort()
         val filter = createFilter(redis = redis, publicReadLimitPerMinute = 2)
-        val path = "/post/api/v1/files/posts/2026/03/manual.pdf"
 
+        assertPublicReadBucketLimit(
+            filter = filter,
+            redis = redis,
+            path = "/post/api/v1/files/posts/2026/03/manual.pdf",
+        )
+    }
+
+    private fun assertPublicReadBucketLimit(
+        filter: ApiRateLimitBackstopFilter,
+        redis: InMemoryRedisKeyValuePort,
+        path: String,
+    ) {
         assertThat(runFilter(filter, "GET", path).status).isEqualTo(HttpServletResponse.SC_OK)
         assertThat(runFilter(filter, "HEAD", path).status).isEqualTo(HttpServletResponse.SC_OK)
-
         val limited = runFilter(filter, "GET", path)
 
         assertThat(limited.status).isEqualTo(429)

--- a/back/src/test/kotlin/com/back/global/security/config/ApiRateLimitBackstopFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/ApiRateLimitBackstopFilterTest.kt
@@ -84,6 +84,23 @@ class ApiRateLimitBackstopFilterTest {
     }
 
     @Test
+    @DisplayName("게시글 첨부파일 GET HEAD는 public read bucket으로 제한한다")
+    fun `post file get and head use public read bucket`() {
+        val redis = InMemoryRedisKeyValuePort()
+        val filter = createFilter(redis = redis, publicReadLimitPerMinute = 2)
+        val path = "/post/api/v1/files/posts/2026/03/manual.pdf"
+
+        assertThat(runFilter(filter, "GET", path).status).isEqualTo(HttpServletResponse.SC_OK)
+        assertThat(runFilter(filter, "HEAD", path).status).isEqualTo(HttpServletResponse.SC_OK)
+
+        val limited = runFilter(filter, "GET", path)
+
+        assertThat(limited.status).isEqualTo(429)
+        assertThat(limited.contentAsString).contains("public-read")
+        assertThat(redis.expiredKeys()).anyMatch { it.contains("public-read") }
+    }
+
+    @Test
     @DisplayName("비활성화, actuator, OPTIONS 요청은 rate limit을 건너뛴다")
     fun `disabled actuator and options requests bypass filter`() {
         val disabled = createFilter(redis = InMemoryRedisKeyValuePort(), enabled = false, publicReadLimitPerMinute = 1)

--- a/back/src/test/kotlin/com/back/global/security/config/ApiRuntimeBoundaryFilterTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/ApiRuntimeBoundaryFilterTest.kt
@@ -39,6 +39,21 @@ class ApiRuntimeBoundaryFilterTest {
     }
 
     @Test
+    @DisplayName("read 모드에서 게시글 첨부파일 GET HEAD 경로는 차단하지 않는다")
+    fun `read mode allows post file get and head endpoints`() {
+        val filter = ApiRuntimeBoundaryFilter("read", createApiCorsPolicy())
+
+        for (method in listOf("GET", "HEAD")) {
+            val request = MockHttpServletRequest(method, "/post/api/v1/files/posts/2026/03/manual.pdf")
+            val response = MockHttpServletResponse()
+
+            filter.doFilter(request, response, MockFilterChain())
+
+            assertThat(response.status).isEqualTo(HttpServletResponse.SC_OK)
+        }
+    }
+
+    @Test
     @DisplayName("런타임 경계 503 응답에도 CORS 헤더를 포함한다")
     fun `blocked runtime boundary response includes cors headers`() {
         val filter = ApiRuntimeBoundaryFilter("read", createApiCorsPolicy())

--- a/back/src/test/kotlin/com/back/support/SecurityConfigEndpointExposureWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/support/SecurityConfigEndpointExposureWebMvcTest.kt
@@ -49,6 +49,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 import tools.jackson.databind.ObjectMapper
@@ -298,6 +300,9 @@ class SecurityConfigProdEndpointExposureWebMvcTest : SecurityConfigEndpointExpos
         mvc.get("/post/api/v1/files/posts/2026/03/manual.pdf").andExpect {
             status { isInternalServerError() }
         }
+        mvc
+            .perform(head("/post/api/v1/files/posts/2026/03/manual.pdf"))
+            .andExpect(status().isInternalServerError)
     }
 
     @Test

--- a/back/src/test/kotlin/com/back/support/SecurityConfigEndpointExposureWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/support/SecurityConfigEndpointExposureWebMvcTest.kt
@@ -293,6 +293,14 @@ class SecurityConfigProdEndpointExposureWebMvcTest : SecurityConfigEndpointExpos
     }
 
     @Test
+    @DisplayName("prod에서 공개 첨부 파일 다운로드는 익명 보안 체인을 통과해 handler 계층까지 도달한다")
+    fun `prod keeps post file download public`() {
+        mvc.get("/post/api/v1/files/posts/2026/03/manual.pdf").andExpect {
+            status { isInternalServerError() }
+        }
+    }
+
+    @Test
     @DisplayName("prod에서 liveness probe는 익명 보안 체인을 통과해 no-handler까지 도달한다")
     fun `prod keeps liveness probe public`() {
         mvc.get("/actuator/health/liveness").andExpect {

--- a/deploy/homeserver/caddy/Caddyfile
+++ b/deploy/homeserver/caddy/Caddyfile
@@ -160,7 +160,7 @@ http://{$API_DOMAIN} {
 
   # read 런타임 분리: 공개 read API를 별도 upstream으로 점진 분리할 수 있다.
   @publicReadFallback {
-    path /post/api/v1/posts/search /post/api/v1/posts/tags /post/api/v1/posts/feed/cursor /post/api/v1/posts/explore/cursor /post/api/v1/posts/* /post/api/v1/posts/*/comments /post/api/v1/posts/*/comments/* /system/api/v1/adm/cloud/files/*/external-content
+    path /post/api/v1/posts/search /post/api/v1/posts/tags /post/api/v1/posts/feed/cursor /post/api/v1/posts/explore/cursor /post/api/v1/posts/* /post/api/v1/posts/*/comments /post/api/v1/posts/*/comments/* /post/api/v1/files/* /system/api/v1/adm/cloud/files/*/external-content
     method GET HEAD OPTIONS
   }
   handle @publicReadFallback {


### PR DESCRIPTION
## 관련 이슈

close #1122

## 작업 배경

- 공개 글 본문에서 발급되는 `/post/api/v1/files/**` 첨부 URL이 익명 공개 read 경로에 포함되지 않았고, 다운로드 컨트롤러가 object storage 존재 여부만 확인해 `UploadedFile` 상태와 공개 post 연결 상태를 검증하지 못했습니다.

## 작업 내용

- 첨부파일 다운로드 전에 `UploadedFile`이 `POST_FILE`, `ACTIVE`, `POST` owner이고 owner post가 공개 상세 조회 대상인지 확인하도록 변경했습니다.
- 허용되지 않는 임시, 비공개 post 연결, 삭제 예정, 삭제 첨부는 storage 조회 전에 404 응답으로 숨기도록 테스트를 추가했습니다.
- `/post/api/*/files/**`를 Spring Security public route, runtime read boundary, API rate-limit public-read bucket, homeserver Caddy read fallback 경로에 추가했습니다.
- 다운로드 응답에 `Content-Disposition: attachment`, `X-Content-Type-Options: nosniff`, `Cache-Control: no-store`를 적용하고 304 응답도 no-store로 맞췄습니다.
- SonarCloud duplication gate 실패를 해결하기 위해 public-read rate-limit 반복 검증을 helper로 모았습니다.

## 검증

- 실행한 명령과 결과:
  - `./back/gradlew -p back test --tests '*ApiV1PostImageController*' --tests '*ApiRuntimeBoundaryFilter*' --tests '*ApiRateLimitBackstopFilter*' --tests '*SecurityConfigProdEndpointExposureWebMvcTest*'`: exit 0
  - `./back/gradlew -p back test --tests '*ApiRateLimitBackstopFilter*'`: exit 0
  - `./back/gradlew -p back ktlintCheck`: exit 0
  - `./back/gradlew -p back test --rerun-tasks`: exit 0, 1회차
  - `./back/gradlew -p back test --rerun-tasks`: exit 0, 2회차
  - `codex review --base origin/main --title "[Fix] 공개 글 첨부파일 익명 다운로드 권한 모델 정리 최종 재검토"`: actionable comments 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 공개 첨부파일 다운로드 권한 | local backend test | `ApiV1PostImageControllerTest` | targeted Gradle test exit 0 | 공개 `ACTIVE POST_FILE`만 200, 비공개/TEMP/PENDING_DELETE/DELETED는 storage 조회 전 404 |
| 공개 첨부파일 cache policy | local backend test | `ApiV1PostImageControllerTest` | targeted Gradle test exit 0 | 파일 다운로드 200/304 모두 `Cache-Control: no-store` |
| 공개 read 경로 동기화 | local backend test | runtime/rate-limit/security endpoint tests | targeted Gradle test exit 0 | `/post/api/v1/files/**` GET/HEAD가 read runtime, public-read bucket, prod anonymous security chain을 통과 |
| SonarCloud duplication gate | GitHub PR check | SonarCloud Code Analysis | https://sonarcloud.io/dashboard?id=AquilaXk_aquila-blog&pullRequest=1176 | Quality Gate passed, duplication on new code 0.0% |
| CI | GitHub Actions | `gh pr checks 1176` | https://github.com/AquilaXk/aquila-blog/actions/runs/28342233081/job/83958764224 | backend-ci pass, frontend/security/codeql checks pass |
| 코드리뷰 | GitHub PR review | CodeRabbit + Codex CLI fallback | https://github.com/AquilaXk/aquila-blog/pull/1176#pullrequestreview-4588415872 | latest Codex fallback review actionable comments 0, review threads resolved |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `ApiV1PostImageController.ensurePublicPostFile`의 404 숨김 조건과 `/files/**` 경로가 Security, runtime boundary, rate-limit, Caddy에 동일하게 반영됐는지 확인 부탁드립니다.

## 리스크

- 기존에 공개 글에 연결되지 않은 첨부 object key를 직접 호출하던 비공식 접근은 404로 바뀝니다. 공개 글 본문에 정상 연결된 `ACTIVE POST_FILE` 다운로드는 유지됩니다.
- Caddy `@publicReadFallback`은 기존 정책대로 upstream security header를 strip하고 API domain 전역 header를 적용합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
