### PR TITLE
[Style] 글 상세 작성자 닉네임 크기 조정

### DIFF
--- a/front/src/routes/Detail/PostDetail/PostHeader.styles.ts
+++ b/front/src/routes/Detail/PostDetail/PostHeader.styles.ts
@@ -126,8 +126,9 @@ export const StyledWrapper = styled.header `
 
     strong {
       color: #111216;
-      font-size: 0.8125rem;
+      font-size: 0.9375rem;
       font-weight: 800;
+      line-height: 1.25;
       overflow-wrap: anywhere;
     }
   }


### PR DESCRIPTION
## 🔗 Related Issue
- close #1175

## 📝 Summary
- 글 상세 헤더의 작성자 닉네임을 38px 프로필 사진에 맞춰 13px급에서 15px급으로 키웠습니다.
- 작성자 액션, 프로필 이미지, markdown 렌더링 로직은 건드리지 않았습니다.

## 🛠 Changes
- `front/src/routes/Detail/PostDetail/PostHeader.styles.ts`의 `.authorText strong` font-size를 `0.9375rem`으로 조정하고 line-height를 고정했습니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [ ] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `yarn --cwd front build`: exit 0
- `node front/scripts/check-bundle-size.mjs`: exit 0, `/posts/[id]` gzip 159.5KB / budget 168.6KB
- `yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`: 8 passed
- commit hook `yarn test:e2e:smoke`: 69 passed
- Browser plugin: `iab` backend unavailable, `agent.browsers.list()` returned `[]`; Playwright screenshot fallback used
- `yarn --cwd front playwright screenshot --viewport-size=1440,900 http://localhost:3000/posts/507 /tmp/post-detail-author-desktop.png`: exit 0
- `yarn --cwd front playwright screenshot --viewport-size=393,852 http://localhost:3000/posts/507 /tmp/post-detail-author-mobile.png`: exit 0

## 📸 Screenshot / API Example
- Desktop evidence: `/tmp/post-detail-author-desktop.png` shows avatar and nickname aligned without overlap.
- Mobile evidence: `/tmp/post-detail-author-mobile.png` shows avatar and nickname aligned without overlap.

## ⚠️ Risk & Rollback
- 예상 리스크: 작성자명이 긴 경우 줄바꿈이 기존보다 약간 빨라질 수 있습니다. `overflow-wrap: anywhere`는 유지했습니다.
- 롤백 방법: 이 커밋을 revert하면 이전 13px급 닉네임 크기로 돌아갑니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 코드 주석 정책에 맞는 이유/불변조건/운영 영향을 설명하는가?