### PR TITLE
[Fix] 로컬 Playwright CFT crash 경로 차단

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -14,7 +14,7 @@
     "build": "node scripts/with-test-lock.mjs --resource front-verify --label build -- next build",
     "postinstall": "node scripts/patch-lodash-template.cjs",
     "start": "next start",
-    "playwright": "node scripts/with-test-lock.mjs --resource front-verify --label playwright -- playwright",
+    "playwright": "PLAYWRIGHT_LOCAL_CHROMIUM_CHANNEL=false node scripts/with-test-lock.mjs --resource front-verify --label playwright -- playwright",
     "playwright:preflight": "node scripts/check-playwright-local-launcher.mjs",
     "contracts:fetch": "node scripts/openapi/fetch-openapi.mjs",
     "contracts:generate": "openapi-typescript contracts/openapi/openapi.json -o packages/shared-contracts/src/generated/backend-openapi.d.ts",

--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -18,6 +18,10 @@ const playwrightOutputDir =
     "playwright",
     (process.env.CODEX_THREAD_ID?.trim() || `pid-${process.pid}`).replace(/[^A-Za-z0-9._-]+/g, "-")
   )
+const shouldUseChromiumChannel =
+  process.platform === "darwin" &&
+  !process.env.CI &&
+  process.env.PLAYWRIGHT_LOCAL_CHROMIUM_CHANNEL !== "false"
 const inheritedEnv = { ...process.env }
 const resolvedBackendInternalUrl = inheritedEnv.BACKEND_INTERNAL_URL || "http://127.0.0.1:1"
 const shouldEnableAdminGuardQaBypassByDefault =
@@ -32,14 +36,20 @@ if (inheritedEnv.FORCE_COLOR && Object.prototype.hasOwnProperty.call(inheritedEn
 const defaultProjects = [
   {
     name: "chromium",
-    use: { ...devices["Desktop Chrome"] },
+    use: {
+      ...devices["Desktop Chrome"],
+      ...(shouldUseChromiumChannel ? { channel: "chromium" as const } : {}),
+    },
   },
 ]
 
 const liveMultiBrowserProjects = [
   {
     name: "chromium",
-    use: { ...devices["Desktop Chrome"] },
+    use: {
+      ...devices["Desktop Chrome"],
+      ...(shouldUseChromiumChannel ? { channel: "chromium" as const } : {}),
+    },
   },
   {
     name: "webkit",

--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -18,7 +18,6 @@ const playwrightOutputDir =
     "playwright",
     (process.env.CODEX_THREAD_ID?.trim() || `pid-${process.pid}`).replace(/[^A-Za-z0-9._-]+/g, "-")
   )
-const shouldUseChromiumChannel = process.platform === "darwin" && !process.env.CI
 const inheritedEnv = { ...process.env }
 const resolvedBackendInternalUrl = inheritedEnv.BACKEND_INTERNAL_URL || "http://127.0.0.1:1"
 const shouldEnableAdminGuardQaBypassByDefault =
@@ -33,43 +32,20 @@ if (inheritedEnv.FORCE_COLOR && Object.prototype.hasOwnProperty.call(inheritedEn
 const defaultProjects = [
   {
     name: "chromium",
-    use: {
-      ...devices["Desktop Chrome"],
-      ...(shouldUseChromiumChannel ? { channel: "chromium" as const } : {}),
-    },
+    use: { ...devices["Desktop Chrome"] },
   },
 ]
 
 const liveMultiBrowserProjects = [
   {
     name: "chromium",
-    use: {
-      ...devices["Desktop Chrome"],
-      ...(shouldUseChromiumChannel ? { channel: "chromium" as const } : {}),
-    },
+    use: { ...devices["Desktop Chrome"] },
   },
   {
     name: "webkit",
     use: { ...devices["Desktop Safari"] },
   },
 ]
-
-const assertDarwinLocalChromiumChannel = (
-  projects: Array<{ name: string; use?: { channel?: string } }>
-) => {
-  if (!shouldUseChromiumChannel) return
-
-  for (const project of projects) {
-    if (project.name !== "chromium") continue
-    if (project.use?.channel === "chromium") continue
-    throw new Error(
-      "Local darwin Playwright chromium project must use channel=chromium to avoid the chromium_headless_shell permission regression."
-    )
-  }
-}
-
-assertDarwinLocalChromiumChannel(defaultProjects)
-assertDarwinLocalChromiumChannel(liveMultiBrowserProjects)
 
 const playwrightReporters: NonNullable<ReturnType<typeof defineConfig>["reporter"]> = process.env.CI
   ? [["github"], ["html", { open: "never" }]]

--- a/front/scripts/check-playwright-local-launcher.mjs
+++ b/front/scripts/check-playwright-local-launcher.mjs
@@ -6,39 +6,27 @@ const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "
 const configPath = path.join(projectRoot, "playwright.config.ts")
 const configSource = fs.readFileSync(configPath, "utf8")
 
-const requiredContracts = [
-  {
-    id: "darwin-local-flag",
-    pattern: /const shouldUseChromiumChannel = process\.platform === "darwin" && !process\.env\.CI/,
-  },
+const forbiddenContracts = [
   {
     id: "chromium-channel",
-    pattern: /channel:\s*"chromium"\s+as const/,
-  },
-  {
-    id: "darwin-local-assertion",
-    pattern: /assertDarwinLocalChromiumChannel\(defaultProjects\)/,
-  },
-  {
-    id: "darwin-local-assertion-live",
-    pattern: /assertDarwinLocalChromiumChannel\(liveMultiBrowserProjects\)/,
+    pattern: /channel:\s*"chromium"/,
   },
 ]
 
-const missing = requiredContracts
-  .filter((contract) => !contract.pattern.test(configSource))
+const present = forbiddenContracts
+  .filter((contract) => contract.pattern.test(configSource))
   .map((contract) => contract.id)
 
-if (missing.length === 0) {
+if (present.length === 0) {
   process.exit(0)
 }
 
 console.error(
   [
     "[playwright-preflight] Playwright local chromium launcher contract drift detected.",
-    "로컬 darwin에서는 chromium_headless_shell이 아니라 channel=chromium(new headless) 경로를 강제해야 합니다.",
+    "로컬 Playwright 기본값은 Google Chrome for Testing.app 경로를 강제하지 않아야 합니다.",
     `config: ${configPath}`,
-    `missing: ${missing.join(", ")}`,
+    `forbidden: ${present.join(", ")}`,
   ].join("\n")
 )
 

--- a/front/scripts/check-playwright-local-launcher.mjs
+++ b/front/scripts/check-playwright-local-launcher.mjs
@@ -4,29 +4,43 @@ import { fileURLToPath } from "url"
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 const configPath = path.join(projectRoot, "playwright.config.ts")
+const packageJsonPath = path.join(projectRoot, "package.json")
 const configSource = fs.readFileSync(configPath, "utf8")
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"))
 
-const forbiddenContracts = [
+const requiredContracts = [
+  {
+    id: "darwin-channel-guard",
+    source: configSource,
+    pattern: /const shouldUseChromiumChannel =\s*process\.platform === "darwin" &&\s*!process\.env\.CI &&\s*process\.env\.PLAYWRIGHT_LOCAL_CHROMIUM_CHANNEL !== "false"/,
+  },
   {
     id: "chromium-channel",
-    pattern: /channel:\s*"chromium"/,
+    source: configSource,
+    pattern: /channel:\s*"chromium"\s+as const/,
+  },
+  {
+    id: "yarn-playwright-cft-opt-out",
+    source: packageJson.scripts?.playwright || "",
+    pattern: /PLAYWRIGHT_LOCAL_CHROMIUM_CHANNEL=false/,
   },
 ]
 
-const present = forbiddenContracts
-  .filter((contract) => contract.pattern.test(configSource))
+const missing = requiredContracts
+  .filter((contract) => !contract.pattern.test(contract.source))
   .map((contract) => contract.id)
 
-if (present.length === 0) {
+if (missing.length === 0) {
   process.exit(0)
 }
 
 console.error(
   [
     "[playwright-preflight] Playwright local chromium launcher contract drift detected.",
-    "로컬 Playwright 기본값은 Google Chrome for Testing.app 경로를 강제하지 않아야 합니다.",
+    "raw macOS Playwright guard는 유지하고 yarn playwright 진입점만 CFT crash 경로를 opt-out 해야 합니다.",
     `config: ${configPath}`,
-    `forbidden: ${present.join(", ")}`,
+    `package: ${packageJsonPath}`,
+    `missing: ${missing.join(", ")}`,
   ].join("\n")
 )
 


### PR DESCRIPTION
## 관련 이슈

close #1178

## 작업 배경

- QA가 제공한 macOS crash report에서 로컬 테스트 중 `Google Chrome for Testing.app`이 `TransformProcessType` 중 abort 했다.
- 기존 macOS raw Playwright guard는 유지해야 하지만, repo의 `yarn playwright` 진입점에서는 CFT crash 경로를 피해야 한다.

## 작업 내용

- macOS/non-CI `channel=chromium` guard는 유지했다.
- `yarn playwright` 진입점에 `PLAYWRIGHT_LOCAL_CHROMIUM_CHANNEL=false`를 추가해 repo 테스트 스크립트에서 CFT 경로를 opt-out 했다.
- `playwright:preflight`가 raw guard와 yarn 진입점 opt-out 계약을 함께 검사하도록 바꿨다.

## 검증

- 실행한 명령과 결과:
- `yarn --cwd front playwright:preflight`: exit 0
- `git diff --check`: exit 0
- `yarn --cwd front build`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Playwright launcher 계약 | macOS local | `yarn --cwd front playwright:preflight` | 명령 출력 | raw guard + yarn opt-out 계약 확인, exit 0 |
| 프론트 빌드 | local | `yarn --cwd front build` | 명령 출력 | Next.js production build 성공 |
| Chrome crash 재현 | local | 미실행 | QA 제공 crash report 기준. 동일 popup 재발 방지를 위해 Chrome/Playwright 브라우저 실행은 수행하지 않음 | 재발 위험 검증 제외 사유 명시 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `front/package.json`의 yarn Playwright opt-out과 `front/playwright.config.ts`의 raw macOS guard 유지

## 리스크

- raw `npx playwright` 직접 실행은 기존 macOS channel guard를 유지한다. repo 표준 `yarn playwright`/`test:e2e:*` 진입점에서 CFT crash 경로를 우회한다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.