### PR TITLE
[Fix] Cloud 업로드 전체 파일 메모리 적재 제거

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudController.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudController.kt
@@ -40,8 +40,6 @@ import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
-import java.io.ByteArrayOutputStream
-import java.io.InputStream
 import java.nio.charset.StandardCharsets
 import io.swagger.v3.oas.annotations.parameters.RequestBody as OpenApiRequestBody
 
@@ -102,7 +100,8 @@ class ApiV1AdmCloudController(
                 originalFilename = file.originalFilename,
                 clientOriginalFilename = clientFilename,
                 contentType = file.contentType,
-                bytes = file.bytes,
+                inputStream = file.inputStream,
+                contentLength = file.size,
                 folderPath = folderPath,
             )
 
@@ -193,7 +192,8 @@ class ApiV1AdmCloudController(
             ownerMemberId = securityUser.id,
             sessionId = sessionId,
             partNumber = partNumber,
-            bytes = readBoundedPartBytes(request.inputStream, expectedBytes),
+            inputStream = request.inputStream,
+            contentLength = contentLength,
         )
     }
 
@@ -450,26 +450,5 @@ class ApiV1AdmCloudController(
             }
 
         return start..end
-    }
-
-    private fun readBoundedPartBytes(
-        input: InputStream,
-        expectedBytes: Long,
-    ): ByteArray {
-        val output = ByteArrayOutputStream()
-        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-        var total = 0L
-
-        while (true) {
-            val read = input.read(buffer)
-            if (read < 0) break
-            total += read
-            if (total > expectedBytes) {
-                throw AppException("400-1", "업로드 조각 크기가 올바르지 않습니다.")
-            }
-            output.write(buffer, 0, read)
-        }
-
-        return output.toByteArray()
     }
 }

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -60,54 +60,55 @@ class CloudFileService(
         inputStream: InputStream,
         contentLength: Long,
         folderPath: String?,
-    ): CloudFileDto {
-        if (contentLength <= 0) throw AppException("400-1", "클라우드 파일이 비어 있습니다.")
-        val normalizedFolderPath = normalizeFolderPath(folderPath)
-        val safeFilename = normalizeFilename(clientOriginalFilename?.takeIf(String::isNotBlank) ?: originalFilename)
-        val tempFile = copyToTempFile(inputStream, contentLength)
-        try {
-            val detected = detectContent(tempFile, contentType, safeFilename)
-            validateFileSize(contentLength, detected)
-            val objectKey =
-                buildObjectKey(
-                    ownerMemberId = ownerMemberId,
-                    folderPath = normalizedFolderPath,
-                    originalFilename = safeFilename,
-                )
+    ): CloudFileDto =
+        inputStream.use { source ->
+            if (contentLength <= 0) throw AppException("400-1", "클라우드 파일이 비어 있습니다.")
+            val normalizedFolderPath = normalizeFolderPath(folderPath)
+            val safeFilename = normalizeFilename(clientOriginalFilename?.takeIf(String::isNotBlank) ?: originalFilename)
+            val tempFile = copyToTempFile(source, contentLength)
+            try {
+                val detected = detectContent(tempFile, contentType, safeFilename)
+                validateFileSize(contentLength, detected)
+                val objectKey =
+                    buildObjectKey(
+                        ownerMemberId = ownerMemberId,
+                        folderPath = normalizedFolderPath,
+                        originalFilename = safeFilename,
+                    )
 
-            // 선언 MIME만 믿지 않고 파일 시그니처로 media kind를 확정해 preview spoofing을 막는다.
-            val uploadResult =
-                Files.newInputStream(tempFile).use { uploadStream ->
-                    cloudStoragePort.upload(
-                        CloudStoragePort.UploadRequest(
-                            objectKey = objectKey,
-                            inputStream = uploadStream,
-                            contentLength = contentLength,
-                            contentType = detected.contentType,
+                // 선언 MIME만 믿지 않고 파일 시그니처로 media kind를 확정해 preview spoofing을 막는다.
+                val uploadResult =
+                    Files.newInputStream(tempFile).use { uploadStream ->
+                        cloudStoragePort.upload(
+                            CloudStoragePort.UploadRequest(
+                                objectKey = objectKey,
+                                inputStream = uploadStream,
+                                contentLength = contentLength,
+                                contentType = detected.contentType,
+                                originalFilename = safeFilename,
+                            ),
+                        )
+                    }
+
+                val saved =
+                    cloudFileRepository.save(
+                        CloudFile.create(
+                            ownerMemberId = ownerMemberId,
+                            objectKey = uploadResult.objectKey,
                             originalFilename = safeFilename,
+                            contentType = detected.contentType,
+                            byteSize = contentLength,
+                            mediaKind = detected.mediaKind,
+                            folderPath = normalizedFolderPath,
+                            checksumSha256 = uploadResult.checksumSha256,
                         ),
                     )
-                }
 
-            val saved =
-                cloudFileRepository.save(
-                    CloudFile.create(
-                        ownerMemberId = ownerMemberId,
-                        objectKey = uploadResult.objectKey,
-                        originalFilename = safeFilename,
-                        contentType = detected.contentType,
-                        byteSize = contentLength,
-                        mediaKind = detected.mediaKind,
-                        folderPath = normalizedFolderPath,
-                        checksumSha256 = uploadResult.checksumSha256,
-                    ),
-                )
-
-            return saved.toDto()
-        } finally {
-            Files.deleteIfExists(tempFile)
+                return saved.toDto()
+            } finally {
+                deleteTempFileQuietly(tempFile)
+            }
         }
-    }
 
     @Transactional(readOnly = true)
     fun listFiles(
@@ -333,6 +334,9 @@ class CloudFileService(
                         val read = input.read(buffer)
                         if (read < 0) break
                         total += read
+                        if (total > expectedLength) {
+                            throw AppException("400-1", "클라우드 파일 크기가 올바르지 않습니다.")
+                        }
                         output.write(buffer, 0, read)
                     }
                 }
@@ -342,9 +346,13 @@ class CloudFileService(
             }
             return tempFile
         } catch (ex: Exception) {
-            Files.deleteIfExists(tempFile)
+            deleteTempFileQuietly(tempFile)
             throw ex
         }
+    }
+
+    private fun deleteTempFileQuietly(tempFile: Path) {
+        runCatching { Files.deleteIfExists(tempFile) }
     }
 
     private fun recoverUtf8MojibakeFilename(raw: String): String {

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileService.kt
@@ -11,8 +11,11 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionSynchronization
 import org.springframework.transaction.support.TransactionSynchronizationManager
+import java.io.InputStream
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
 import java.text.Normalizer
 import java.time.Clock
 import java.time.Instant
@@ -20,6 +23,7 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import java.util.UUID
+import java.util.zip.ZipFile
 
 data class CloudFileDto(
     val id: Long,
@@ -53,47 +57,56 @@ class CloudFileService(
         originalFilename: String?,
         clientOriginalFilename: String? = null,
         contentType: String?,
-        bytes: ByteArray,
+        inputStream: InputStream,
+        contentLength: Long,
         folderPath: String?,
     ): CloudFileDto {
-        if (bytes.isEmpty()) throw AppException("400-1", "클라우드 파일이 비어 있습니다.")
+        if (contentLength <= 0) throw AppException("400-1", "클라우드 파일이 비어 있습니다.")
         val normalizedFolderPath = normalizeFolderPath(folderPath)
         val safeFilename = normalizeFilename(clientOriginalFilename?.takeIf(String::isNotBlank) ?: originalFilename)
-        val detected = detectContent(bytes, contentType, safeFilename)
-        validateFileSize(bytes.size.toLong(), detected)
-        val objectKey =
-            buildObjectKey(
-                ownerMemberId = ownerMemberId,
-                folderPath = normalizedFolderPath,
-                originalFilename = safeFilename,
-            )
-
-        // 선언 MIME만 믿지 않고 파일 시그니처로 media kind를 확정해 preview spoofing을 막는다.
-        val uploadResult =
-            cloudStoragePort.upload(
-                CloudStoragePort.UploadRequest(
-                    objectKey = objectKey,
-                    bytes = bytes,
-                    contentType = detected.contentType,
-                    originalFilename = safeFilename,
-                ),
-            )
-
-        val saved =
-            cloudFileRepository.save(
-                CloudFile.create(
+        val tempFile = copyToTempFile(inputStream, contentLength)
+        try {
+            val detected = detectContent(tempFile, contentType, safeFilename)
+            validateFileSize(contentLength, detected)
+            val objectKey =
+                buildObjectKey(
                     ownerMemberId = ownerMemberId,
-                    objectKey = uploadResult.objectKey,
-                    originalFilename = safeFilename,
-                    contentType = detected.contentType,
-                    byteSize = bytes.size.toLong(),
-                    mediaKind = detected.mediaKind,
                     folderPath = normalizedFolderPath,
-                    checksumSha256 = uploadResult.checksumSha256,
-                ),
-            )
+                    originalFilename = safeFilename,
+                )
 
-        return saved.toDto()
+            // 선언 MIME만 믿지 않고 파일 시그니처로 media kind를 확정해 preview spoofing을 막는다.
+            val uploadResult =
+                Files.newInputStream(tempFile).use { uploadStream ->
+                    cloudStoragePort.upload(
+                        CloudStoragePort.UploadRequest(
+                            objectKey = objectKey,
+                            inputStream = uploadStream,
+                            contentLength = contentLength,
+                            contentType = detected.contentType,
+                            originalFilename = safeFilename,
+                        ),
+                    )
+                }
+
+            val saved =
+                cloudFileRepository.save(
+                    CloudFile.create(
+                        ownerMemberId = ownerMemberId,
+                        objectKey = uploadResult.objectKey,
+                        originalFilename = safeFilename,
+                        contentType = detected.contentType,
+                        byteSize = contentLength,
+                        mediaKind = detected.mediaKind,
+                        folderPath = normalizedFolderPath,
+                        checksumSha256 = uploadResult.checksumSha256,
+                    ),
+                )
+
+            return saved.toDto()
+        } finally {
+            Files.deleteIfExists(tempFile)
+        }
     }
 
     @Transactional(readOnly = true)
@@ -306,6 +319,34 @@ class CloudFileService(
             .toByteArray(StandardCharsets.US_ASCII)
             .size
 
+    private fun copyToTempFile(
+        inputStream: InputStream,
+        expectedLength: Long,
+    ): Path {
+        val tempFile = Files.createTempFile("cloud-upload-", ".tmp")
+        try {
+            var total = 0L
+            inputStream.use { input ->
+                Files.newOutputStream(tempFile).use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        total += read
+                        output.write(buffer, 0, read)
+                    }
+                }
+            }
+            if (total != expectedLength) {
+                throw AppException("400-1", "클라우드 파일 크기가 올바르지 않습니다.")
+            }
+            return tempFile
+        } catch (ex: Exception) {
+            Files.deleteIfExists(tempFile)
+            throw ex
+        }
+    }
+
     private fun recoverUtf8MojibakeFilename(raw: String): String {
         if (raw.isBlank()) return raw
         if (raw.any { it in '가'..'힣' }) return raw
@@ -387,13 +428,14 @@ class CloudFileService(
     }
 
     private fun detectContent(
-        bytes: ByteArray,
+        file: Path,
         declaredContentType: String?,
         filename: String,
     ): DetectedContent {
         val normalizedDeclared = normalizeContentType(declaredContentType)
+        val header = readHeader(file, 16)
         val detected =
-            detectFromSignature(bytes, filename)
+            detectFromSignature(file, header, filename)
                 ?: throw AppException("400-1", "지원하지 않는 클라우드 파일 형식입니다.")
 
         if (
@@ -426,6 +468,7 @@ class CloudFileService(
     }
 
     private fun detectFromSignature(
+        file: Path,
         bytes: ByteArray,
         filename: String,
     ): DetectedContent? {
@@ -474,100 +517,49 @@ class CloudFileService(
         ) {
             return DetectedContent("video/webm", CloudFileMediaKind.VIDEO)
         }
-        if (filename.substringAfterLast(".", "").lowercase(Locale.ROOT) == "hwpx" && isHwpxPackage(bytes)) {
+        if (filename.substringAfterLast(".", "").lowercase(Locale.ROOT) == "hwpx" && isHwpxPackage(file)) {
             return DetectedContent(HWPX_CONTENT_TYPE, CloudFileMediaKind.DOCUMENT)
         }
-        if (filename.substringAfterLast(".", "").lowercase(Locale.ROOT) == "zip" && isValidZipArchive(bytes)) {
+        if (filename.substringAfterLast(".", "").lowercase(Locale.ROOT) == "zip" && isValidZipArchive(file)) {
             return DetectedContent(ZIP_CONTENT_TYPE, CloudFileMediaKind.DOCUMENT)
         }
 
         return null
     }
 
-    private fun isZipSignature(bytes: ByteArray): Boolean =
-        bytes.size >= 4 &&
-            bytes.copyOfRange(0, 4).toList() in ZIP_SIGNATURES
+    private fun readHeader(
+        file: Path,
+        maxBytes: Int,
+    ): ByteArray = Files.newInputStream(file).use { it.readNBytes(maxBytes) }
 
-    private fun isHwpxPackage(bytes: ByteArray): Boolean {
-        if (!isZipSignature(bytes)) return false
+    private fun isHwpxPackage(file: Path): Boolean {
+        if (!isZipSignature(readHeader(file, 4))) return false
 
-        val entries = readZipCentralDirectoryEntryNames(bytes)
+        val entries = readZipEntryNames(file)
 
         return HWPX_MANIFEST_ENTRY in entries && entries.any { it in HWPX_DOCUMENT_ENTRIES }
     }
 
-    private fun isValidZipArchive(bytes: ByteArray): Boolean = isZipSignature(bytes) && parseZipCentralDirectoryEntryNames(bytes) != null
+    private fun isValidZipArchive(file: Path): Boolean =
+        isZipSignature(readHeader(file, 4)) &&
+            runCatching {
+                ZipFile(file.toFile()).use { zip -> zip.entries().hasMoreElements() || Files.size(file) >= ZIP_EOCD_MIN_SIZE }
+            }.getOrDefault(false)
 
-    private fun readZipCentralDirectoryEntryNames(bytes: ByteArray): Set<String> = parseZipCentralDirectoryEntryNames(bytes).orEmpty()
+    private fun isZipSignature(bytes: ByteArray): Boolean =
+        bytes.size >= 4 &&
+            bytes.copyOfRange(0, 4).toList() in ZIP_SIGNATURES
 
-    private fun parseZipCentralDirectoryEntryNames(bytes: ByteArray): Set<String>? {
-        val endRecordOffset = findZipEndOfCentralDirectoryOffset(bytes) ?: return null
-        val entryCount = readUInt16Le(bytes, endRecordOffset + ZIP_EOCD_TOTAL_ENTRY_COUNT_OFFSET)
-        val centralDirectorySize = readUInt32Le(bytes, endRecordOffset + ZIP_EOCD_DIRECTORY_SIZE_OFFSET)
-        val centralDirectoryOffset = readUInt32Le(bytes, endRecordOffset + ZIP_EOCD_DIRECTORY_OFFSET)
-        if (centralDirectorySize > bytes.size || centralDirectoryOffset > bytes.size) return null
-
-        val directoryStart = centralDirectoryOffset.toInt()
-        val directoryEnd = (centralDirectoryOffset + centralDirectorySize).takeIf { it <= bytes.size }?.toInt() ?: return null
-        val names = mutableSetOf<String>()
-        var offset = directoryStart
-        var scannedCount = 0
-
-        while (
-            offset + ZIP_CENTRAL_DIRECTORY_HEADER_SIZE <= directoryEnd &&
-            scannedCount < entryCount
-        ) {
-            if (!hasSignature(bytes, offset, ZIP_CENTRAL_DIRECTORY_FILE_HEADER_SIGNATURE)) return null
-
-            val nameLength = readUInt16Le(bytes, offset + ZIP_CENTRAL_DIRECTORY_NAME_LENGTH_OFFSET)
-            val extraLength = readUInt16Le(bytes, offset + ZIP_CENTRAL_DIRECTORY_EXTRA_LENGTH_OFFSET)
-            val commentLength = readUInt16Le(bytes, offset + ZIP_CENTRAL_DIRECTORY_COMMENT_LENGTH_OFFSET)
-            val nameOffset = offset + ZIP_CENTRAL_DIRECTORY_HEADER_SIZE
-            val nextOffset = nameOffset + nameLength + extraLength + commentLength
-            if (nameOffset + nameLength > directoryEnd || nextOffset > directoryEnd) return null
-
-            names += String(bytes, nameOffset, nameLength, StandardCharsets.UTF_8).replace('\\', '/')
-            offset = nextOffset
-            scannedCount++
-        }
-
-        if (scannedCount != entryCount || offset != directoryEnd) return null
-
-        return names
-    }
-
-    private fun findZipEndOfCentralDirectoryOffset(bytes: ByteArray): Int? {
-        val firstSearchOffset = maxOf(0, bytes.size - ZIP_EOCD_MAX_SEARCH_LENGTH)
-        for (offset in bytes.size - ZIP_EOCD_MIN_SIZE downTo firstSearchOffset) {
-            if (hasSignature(bytes, offset, ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE)) return offset
-        }
-        return null
-    }
-
-    private fun hasSignature(
-        bytes: ByteArray,
-        offset: Int,
-        signature: ByteArray,
-    ): Boolean {
-        if (offset < 0 || offset + signature.size > bytes.size) return false
-        return signature.indices.all { index -> bytes[offset + index] == signature[index] }
-    }
-
-    private fun readUInt16Le(
-        bytes: ByteArray,
-        offset: Int,
-    ): Int =
-        (bytes[offset].toInt() and 0xFF) or
-            ((bytes[offset + 1].toInt() and 0xFF) shl 8)
-
-    private fun readUInt32Le(
-        bytes: ByteArray,
-        offset: Int,
-    ): Long =
-        (bytes[offset].toLong() and 0xFF) or
-            ((bytes[offset + 1].toLong() and 0xFF) shl 8) or
-            ((bytes[offset + 2].toLong() and 0xFF) shl 16) or
-            ((bytes[offset + 3].toLong() and 0xFF) shl 24)
+    private fun readZipEntryNames(file: Path): Set<String> =
+        runCatching {
+            ZipFile(file.toFile()).use { zip ->
+                zip
+                    .entries()
+                    .asSequence()
+                    .map { it.name.replace('\\', '/') }
+                    .toSet()
+            }
+        }.getOrDefault(emptySet())
 
     private data class DetectedContent(
         val contentType: String,

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionService.kt
@@ -31,6 +31,7 @@ private val CLOUD_VIDEO_UPLOAD_DATE_PATH_FORMATTER = DateTimeFormatter.ofPattern
 private const val CLOUD_VIDEO_UPLOAD_MAX_FILENAME_CODE_POINTS = 255L
 private const val CLOUD_VIDEO_UPLOAD_MAX_FILENAME_METADATA_ENCODED_BYTES = 1024
 private const val CLOUD_VIDEO_UPLOAD_MAX_MULTIPART_PARTS = 10_000L
+private const val INVALID_PART_SIZE_MESSAGE = "업로드 조각 크기가 올바르지 않습니다."
 
 data class CloudVideoUploadSessionDto(
     val id: Long,
@@ -524,7 +525,7 @@ class CloudVideoUploadSessionService(
                 session.partSizeBytes
             }
         if (contentLength != expectedSize) {
-            throw AppException("400-1", "업로드 조각 크기가 올바르지 않습니다.")
+            throw AppException("400-1", INVALID_PART_SIZE_MESSAGE)
         }
     }
 
@@ -543,14 +544,14 @@ class CloudVideoUploadSessionService(
                         if (read < 0) break
                         total += read
                         if (total > expectedLength) {
-                            throw AppException("400-1", "업로드 조각 크기가 올바르지 않습니다.")
+                            throw AppException("400-1", INVALID_PART_SIZE_MESSAGE)
                         }
                         output.write(buffer, 0, read)
                     }
                 }
             }
             if (total != expectedLength) {
-                throw AppException("400-1", "업로드 조각 크기가 올바르지 않습니다.")
+                throw AppException("400-1", INVALID_PART_SIZE_MESSAGE)
             }
             return tempFile
         } catch (ex: Exception) {

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionService.kt
@@ -14,8 +14,11 @@ import com.back.global.storage.config.CloudStorageProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import java.io.InputStream
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
 import java.text.Normalizer
 import java.time.Clock
 import java.time.Instant
@@ -173,70 +176,83 @@ class CloudVideoUploadSessionService(
         ownerMemberId: Long,
         sessionId: Long,
         partNumber: Int,
-        bytes: ByteArray,
+        inputStream: InputStream,
+        contentLength: Long,
     ): CloudVideoUploadPartResultDto {
         val session = findMutableSession(ownerMemberId, sessionId)
         validatePartNumber(session, partNumber)
-        validatePartBytes(session, partNumber, bytes)
-        validateFirstPartSignature(session, partNumber, bytes)
+        validatePartSize(session, partNumber, contentLength)
+        val tempFile = copyPartToTempFile(inputStream, contentLength)
+        try {
+            validateFirstPartSignature(session, partNumber, tempFile)
 
-        val existing = partRepository.findBySessionIdAndPartNumber(session.id, partNumber)
-        if (existing != null) {
-            if (existing.byteSize != bytes.size.toLong()) {
-                throw AppException("409-1", "이미 다른 크기의 업로드 조각이 저장되어 있습니다.")
+            val existing = partRepository.findBySessionIdAndPartNumber(session.id, partNumber)
+            if (existing != null) {
+                if (existing.byteSize != contentLength) {
+                    throw AppException("409-1", "이미 다른 크기의 업로드 조각이 저장되어 있습니다.")
+                }
+                return CloudVideoUploadPartResultDto(
+                    session = session.toDto(partRepository.findBySessionId(session.id)),
+                    part = existing.toDto(),
+                )
             }
-            return CloudVideoUploadPartResultDto(
-                session = session.toDto(partRepository.findBySessionId(session.id)),
-                part = existing.toDto(),
+
+            claimStatus(
+                session,
+                expectedStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
+                nextStatus = CloudVideoUploadSessionStatus.UPLOADING_PART,
+                conflictMessage = "다른 업로드 작업이 진행 중입니다.",
             )
+            val uploadResult =
+                try {
+                    Files.newInputStream(tempFile).use { partStream ->
+                        cloudStoragePort.uploadMultipartPart(
+                            CloudStoragePort.MultipartUploadPartRequest(
+                                objectKey = session.objectKey,
+                                uploadId = requireUploadId(session),
+                                partNumber = partNumber,
+                                inputStream = partStream,
+                                contentLength = contentLength,
+                            ),
+                        )
+                    }
+                } catch (ex: RuntimeException) {
+                    releasePartUploadClaim(session.id)
+                    throw ex
+                }
+            val savedPart =
+                try {
+                    partRepository.save(
+                        CloudVideoUploadPart(
+                            sessionId = session.id,
+                            partNumber = partNumber,
+                            eTag = uploadResult.eTag,
+                            byteSize = contentLength,
+                        ),
+                    )
+                } catch (ex: RuntimeException) {
+                    markFailed(
+                        session.id,
+                        CloudVideoUploadSessionStatus.UPLOADING_PART,
+                        "multipart part metadata save failed: ${ex.message}",
+                    )
+                    throw ex
+                }
+            transitionStatus(
+                session.id,
+                expectedStatus = CloudVideoUploadSessionStatus.UPLOADING_PART,
+                nextStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
+            )
+            session.transitionTo(CloudVideoUploadSessionStatus.IN_PROGRESS, clock.instant())
+            val parts = partRepository.findBySessionId(session.id)
+
+            return CloudVideoUploadPartResultDto(
+                session = session.toDto(parts),
+                part = savedPart.toDto(),
+            )
+        } finally {
+            Files.deleteIfExists(tempFile)
         }
-
-        claimStatus(
-            session,
-            expectedStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
-            nextStatus = CloudVideoUploadSessionStatus.UPLOADING_PART,
-            conflictMessage = "다른 업로드 작업이 진행 중입니다.",
-        )
-        val uploadResult =
-            try {
-                cloudStoragePort.uploadMultipartPart(
-                    CloudStoragePort.MultipartUploadPartRequest(
-                        objectKey = session.objectKey,
-                        uploadId = requireUploadId(session),
-                        partNumber = partNumber,
-                        bytes = bytes,
-                    ),
-                )
-            } catch (ex: RuntimeException) {
-                releasePartUploadClaim(session.id)
-                throw ex
-            }
-        val savedPart =
-            try {
-                partRepository.save(
-                    CloudVideoUploadPart(
-                        sessionId = session.id,
-                        partNumber = partNumber,
-                        eTag = uploadResult.eTag,
-                        byteSize = bytes.size.toLong(),
-                    ),
-                )
-            } catch (ex: RuntimeException) {
-                markFailed(session.id, CloudVideoUploadSessionStatus.UPLOADING_PART, "multipart part metadata save failed: ${ex.message}")
-                throw ex
-            }
-        transitionStatus(
-            session.id,
-            expectedStatus = CloudVideoUploadSessionStatus.UPLOADING_PART,
-            nextStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
-        )
-        session.transitionTo(CloudVideoUploadSessionStatus.IN_PROGRESS, clock.instant())
-        val parts = partRepository.findBySessionId(session.id)
-
-        return CloudVideoUploadPartResultDto(
-            session = session.toDto(parts),
-            part = savedPart.toDto(),
-        )
     }
 
     fun complete(
@@ -494,29 +510,61 @@ class CloudVideoUploadSessionService(
         }
     }
 
-    private fun validatePartBytes(
+    private fun validatePartSize(
         session: CloudVideoUploadSession,
         partNumber: Int,
-        bytes: ByteArray,
+        contentLength: Long,
     ) {
-        if (bytes.isEmpty()) throw AppException("400-1", "업로드 조각이 비어 있습니다.")
+        if (contentLength <= 0) throw AppException("400-1", "업로드 조각이 비어 있습니다.")
         val expectedSize =
             if (partNumber == session.totalParts) {
                 session.byteSize - (session.partSizeBytes * (partNumber - 1))
             } else {
                 session.partSizeBytes
             }
-        if (bytes.size.toLong() != expectedSize) {
+        if (contentLength != expectedSize) {
             throw AppException("400-1", "업로드 조각 크기가 올바르지 않습니다.")
+        }
+    }
+
+    private fun copyPartToTempFile(
+        inputStream: InputStream,
+        expectedLength: Long,
+    ): Path {
+        val tempFile = Files.createTempFile("cloud-upload-part-", ".tmp")
+        try {
+            var total = 0L
+            inputStream.use { input ->
+                Files.newOutputStream(tempFile).use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        total += read
+                        if (total > expectedLength) {
+                            throw AppException("400-1", "업로드 조각 크기가 올바르지 않습니다.")
+                        }
+                        output.write(buffer, 0, read)
+                    }
+                }
+            }
+            if (total != expectedLength) {
+                throw AppException("400-1", "업로드 조각 크기가 올바르지 않습니다.")
+            }
+            return tempFile
+        } catch (ex: Exception) {
+            Files.deleteIfExists(tempFile)
+            throw ex
         }
     }
 
     private fun validateFirstPartSignature(
         session: CloudVideoUploadSession,
         partNumber: Int,
-        bytes: ByteArray,
+        file: Path,
     ) {
         if (partNumber != 1) return
+        val bytes = Files.newInputStream(file).use { it.readNBytes(12) }
         val detected =
             detectVideoFromSignature(bytes)
                 ?: throw AppException("400-1", "지원하지 않는 동영상 파일 형식입니다.")

--- a/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionService.kt
@@ -178,82 +178,83 @@ class CloudVideoUploadSessionService(
         partNumber: Int,
         inputStream: InputStream,
         contentLength: Long,
-    ): CloudVideoUploadPartResultDto {
-        val session = findMutableSession(ownerMemberId, sessionId)
-        validatePartNumber(session, partNumber)
-        validatePartSize(session, partNumber, contentLength)
-        val tempFile = copyPartToTempFile(inputStream, contentLength)
-        try {
-            validateFirstPartSignature(session, partNumber, tempFile)
+    ): CloudVideoUploadPartResultDto =
+        inputStream.use { source ->
+            val session = findMutableSession(ownerMemberId, sessionId)
+            validatePartNumber(session, partNumber)
+            validatePartSize(session, partNumber, contentLength)
+            val tempFile = copyPartToTempFile(source, contentLength)
+            try {
+                validateFirstPartSignature(session, partNumber, tempFile)
 
-            val existing = partRepository.findBySessionIdAndPartNumber(session.id, partNumber)
-            if (existing != null) {
-                if (existing.byteSize != contentLength) {
-                    throw AppException("409-1", "이미 다른 크기의 업로드 조각이 저장되어 있습니다.")
+                val existing = partRepository.findBySessionIdAndPartNumber(session.id, partNumber)
+                if (existing != null) {
+                    if (existing.byteSize != contentLength) {
+                        throw AppException("409-1", "이미 다른 크기의 업로드 조각이 저장되어 있습니다.")
+                    }
+                    return CloudVideoUploadPartResultDto(
+                        session = session.toDto(partRepository.findBySessionId(session.id)),
+                        part = existing.toDto(),
+                    )
                 }
-                return CloudVideoUploadPartResultDto(
-                    session = session.toDto(partRepository.findBySessionId(session.id)),
-                    part = existing.toDto(),
-                )
-            }
 
-            claimStatus(
-                session,
-                expectedStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
-                nextStatus = CloudVideoUploadSessionStatus.UPLOADING_PART,
-                conflictMessage = "다른 업로드 작업이 진행 중입니다.",
-            )
-            val uploadResult =
-                try {
-                    Files.newInputStream(tempFile).use { partStream ->
-                        cloudStoragePort.uploadMultipartPart(
-                            CloudStoragePort.MultipartUploadPartRequest(
-                                objectKey = session.objectKey,
-                                uploadId = requireUploadId(session),
+                claimStatus(
+                    session,
+                    expectedStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
+                    nextStatus = CloudVideoUploadSessionStatus.UPLOADING_PART,
+                    conflictMessage = "다른 업로드 작업이 진행 중입니다.",
+                )
+                val uploadResult =
+                    try {
+                        Files.newInputStream(tempFile).use { partStream ->
+                            cloudStoragePort.uploadMultipartPart(
+                                CloudStoragePort.MultipartUploadPartRequest(
+                                    objectKey = session.objectKey,
+                                    uploadId = requireUploadId(session),
+                                    partNumber = partNumber,
+                                    inputStream = partStream,
+                                    contentLength = contentLength,
+                                ),
+                            )
+                        }
+                    } catch (ex: RuntimeException) {
+                        releasePartUploadClaim(session.id)
+                        throw ex
+                    }
+                val savedPart =
+                    try {
+                        partRepository.save(
+                            CloudVideoUploadPart(
+                                sessionId = session.id,
                                 partNumber = partNumber,
-                                inputStream = partStream,
-                                contentLength = contentLength,
+                                eTag = uploadResult.eTag,
+                                byteSize = contentLength,
                             ),
                         )
+                    } catch (ex: RuntimeException) {
+                        markFailed(
+                            session.id,
+                            CloudVideoUploadSessionStatus.UPLOADING_PART,
+                            "multipart part metadata save failed: ${ex.message}",
+                        )
+                        throw ex
                     }
-                } catch (ex: RuntimeException) {
-                    releasePartUploadClaim(session.id)
-                    throw ex
-                }
-            val savedPart =
-                try {
-                    partRepository.save(
-                        CloudVideoUploadPart(
-                            sessionId = session.id,
-                            partNumber = partNumber,
-                            eTag = uploadResult.eTag,
-                            byteSize = contentLength,
-                        ),
-                    )
-                } catch (ex: RuntimeException) {
-                    markFailed(
-                        session.id,
-                        CloudVideoUploadSessionStatus.UPLOADING_PART,
-                        "multipart part metadata save failed: ${ex.message}",
-                    )
-                    throw ex
-                }
-            transitionStatus(
-                session.id,
-                expectedStatus = CloudVideoUploadSessionStatus.UPLOADING_PART,
-                nextStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
-            )
-            session.transitionTo(CloudVideoUploadSessionStatus.IN_PROGRESS, clock.instant())
-            val parts = partRepository.findBySessionId(session.id)
+                transitionStatus(
+                    session.id,
+                    expectedStatus = CloudVideoUploadSessionStatus.UPLOADING_PART,
+                    nextStatus = CloudVideoUploadSessionStatus.IN_PROGRESS,
+                )
+                session.transitionTo(CloudVideoUploadSessionStatus.IN_PROGRESS, clock.instant())
+                val parts = partRepository.findBySessionId(session.id)
 
-            return CloudVideoUploadPartResultDto(
-                session = session.toDto(parts),
-                part = savedPart.toDto(),
-            )
-        } finally {
-            Files.deleteIfExists(tempFile)
+                return CloudVideoUploadPartResultDto(
+                    session = session.toDto(parts),
+                    part = savedPart.toDto(),
+                )
+            } finally {
+                deleteTempFileQuietly(tempFile)
+            }
         }
-    }
 
     fun complete(
         ownerMemberId: Long,
@@ -553,9 +554,13 @@ class CloudVideoUploadSessionService(
             }
             return tempFile
         } catch (ex: Exception) {
-            Files.deleteIfExists(tempFile)
+            deleteTempFileQuietly(tempFile)
             throw ex
         }
+    }
+
+    private fun deleteTempFileQuietly(tempFile: Path) {
+        runCatching { Files.deleteIfExists(tempFile) }
     }
 
     private fun validateFirstPartSignature(

--- a/back/src/main/kotlin/com/back/global/storage/adapter/CloudStorageAdapter.kt
+++ b/back/src/main/kotlin/com/back/global/storage/adapter/CloudStorageAdapter.kt
@@ -28,6 +28,7 @@ import java.net.URI
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import java.security.DigestInputStream
 import java.security.MessageDigest
 
 @Service
@@ -51,24 +52,27 @@ class CloudStorageAdapter(
     override fun upload(request: CloudStoragePort.UploadRequest): CloudStoragePort.UploadResult {
         val client = requireClient()
         validateObjectKey(request.objectKey)
+        val digest = MessageDigest.getInstance("SHA-256")
 
         try {
-            client.putObject(
-                PutObjectRequest
-                    .builder()
-                    .bucket(properties.bucket)
-                    .key(request.objectKey)
-                    .contentType(request.contentType)
-                    .metadata(
-                        mapOf(
-                            "original-filename" to
-                                URLEncoder
-                                    .encode(request.originalFilename, StandardCharsets.UTF_8)
-                                    .replace("+", "%20"),
-                        ),
-                    ).build(),
-                RequestBody.fromBytes(request.bytes),
-            )
+            DigestInputStream(request.inputStream, digest).use { body ->
+                client.putObject(
+                    PutObjectRequest
+                        .builder()
+                        .bucket(properties.bucket)
+                        .key(request.objectKey)
+                        .contentType(request.contentType)
+                        .metadata(
+                            mapOf(
+                                "original-filename" to
+                                    URLEncoder
+                                        .encode(request.originalFilename, StandardCharsets.UTF_8)
+                                        .replace("+", "%20"),
+                            ),
+                        ).build(),
+                    RequestBody.fromInputStream(body, request.contentLength),
+                )
+            }
         } catch (e: Exception) {
             logger.error("Cloud file upload failed (objectKey={})", request.objectKey, e)
             throw AppException("500-1", "클라우드 파일 업로드에 실패했습니다.")
@@ -76,7 +80,7 @@ class CloudStorageAdapter(
 
         return CloudStoragePort.UploadResult(
             objectKey = request.objectKey,
-            checksumSha256 = sha256Hex(request.bytes),
+            checksumSha256 = digest.digest().toHex(),
         )
     }
 
@@ -180,17 +184,19 @@ class CloudStorageAdapter(
 
         return try {
             val response =
-                client.uploadPart(
-                    UploadPartRequest
-                        .builder()
-                        .bucket(properties.bucket)
-                        .key(request.objectKey)
-                        .uploadId(request.uploadId)
-                        .partNumber(request.partNumber)
-                        .contentLength(request.bytes.size.toLong())
-                        .build(),
-                    RequestBody.fromBytes(request.bytes),
-                )
+                request.inputStream.use { body ->
+                    client.uploadPart(
+                        UploadPartRequest
+                            .builder()
+                            .bucket(properties.bucket)
+                            .key(request.objectKey)
+                            .uploadId(request.uploadId)
+                            .partNumber(request.partNumber)
+                            .contentLength(request.contentLength)
+                            .build(),
+                        RequestBody.fromInputStream(body, request.contentLength),
+                    )
+                }
 
             CloudStoragePort.MultipartUploadPartResult(
                 partNumber = request.partNumber,
@@ -420,11 +426,7 @@ class CloudStorageAdapter(
         return runCatching { URLDecoder.decode(encoded, StandardCharsets.UTF_8) }.getOrNull()
     }
 
-    private fun sha256Hex(bytes: ByteArray): String =
-        MessageDigest
-            .getInstance("SHA-256")
-            .digest(bytes)
-            .joinToString("") { "%02x".format(it) }
+    private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
 
     companion object {
         private val ENV_REFERENCE_REGEX = Regex("^\\$\\{([A-Za-z_][A-Za-z0-9_]*)(?::-(.*))?}$")

--- a/back/src/main/kotlin/com/back/global/storage/application/port/output/CloudStoragePort.kt
+++ b/back/src/main/kotlin/com/back/global/storage/application/port/output/CloudStoragePort.kt
@@ -5,7 +5,8 @@ import java.io.InputStream
 interface CloudStoragePort {
     class UploadRequest(
         val objectKey: String,
-        val bytes: ByteArray,
+        val inputStream: InputStream,
+        val contentLength: Long,
         val contentType: String,
         val originalFilename: String,
     ) {
@@ -14,14 +15,16 @@ interface CloudStoragePort {
                 (
                     other is UploadRequest &&
                         objectKey == other.objectKey &&
-                        bytes.contentEquals(other.bytes) &&
+                        inputStream === other.inputStream &&
+                        contentLength == other.contentLength &&
                         contentType == other.contentType &&
                         originalFilename == other.originalFilename
                 )
 
         override fun hashCode(): Int {
             var result = objectKey.hashCode()
-            result = 31 * result + bytes.contentHashCode()
+            result = 31 * result + System.identityHashCode(inputStream)
+            result = 31 * result + contentLength.hashCode()
             result = 31 * result + contentType.hashCode()
             result = 31 * result + originalFilename.hashCode()
             return result
@@ -30,7 +33,7 @@ interface CloudStoragePort {
         override fun toString(): String =
             "UploadRequest(" +
                 "objectKey=$objectKey, " +
-                "bytes=${bytes.size} bytes, " +
+                "contentLength=$contentLength bytes, " +
                 "contentType=$contentType, " +
                 "originalFilename=$originalFilename" +
                 ")"
@@ -56,7 +59,8 @@ interface CloudStoragePort {
         val objectKey: String,
         val uploadId: String,
         val partNumber: Int,
-        val bytes: ByteArray,
+        val inputStream: InputStream,
+        val contentLength: Long,
     ) {
         override fun equals(other: Any?): Boolean =
             this === other ||
@@ -65,14 +69,16 @@ interface CloudStoragePort {
                         objectKey == other.objectKey &&
                         uploadId == other.uploadId &&
                         partNumber == other.partNumber &&
-                        bytes.contentEquals(other.bytes)
+                        inputStream === other.inputStream &&
+                        contentLength == other.contentLength
                 )
 
         override fun hashCode(): Int {
             var result = objectKey.hashCode()
             result = 31 * result + uploadId.hashCode()
             result = 31 * result + partNumber
-            result = 31 * result + bytes.contentHashCode()
+            result = 31 * result + System.identityHashCode(inputStream)
+            result = 31 * result + contentLength.hashCode()
             return result
         }
     }

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudControllerWebMvcTest.kt
@@ -8,10 +8,12 @@ import com.back.boundedContexts.cloud.application.service.CloudVideoUploadPartRe
 import com.back.boundedContexts.cloud.application.service.CloudVideoUploadSessionDto
 import com.back.boundedContexts.cloud.model.CloudFileMediaKind
 import com.back.boundedContexts.cloud.model.CloudVideoUploadSessionStatus
+import com.back.global.exception.application.AppException
 import com.back.global.security.domain.SecurityUser
 import com.back.global.storage.application.port.output.CloudStoragePort
 import com.back.support.BaseAdmCloudControllerWebMvcTest
 import jakarta.servlet.http.HttpServletRequest
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -21,6 +23,7 @@ import org.mockito.BDDMockito.then
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.mock.web.DelegatingServletInputStream
 import org.springframework.mock.web.MockMultipartFile
@@ -32,7 +35,9 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.multipart
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.put
+import org.springframework.web.multipart.MultipartFile
 import java.io.ByteArrayInputStream
+import java.io.InputStream
 import java.time.Instant
 
 @DisplayName("관리자 클라우드 WebMvc 테스트")
@@ -109,12 +114,13 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
         val uploadBytes = "png".toByteArray()
         given(
             cloudFileService.upload(
-                ownerMemberId = 7L,
-                originalFilename = "photo.png",
-                clientOriginalFilename = "사진 원본.png",
-                contentType = "image/png",
-                bytes = uploadBytes,
-                folderPath = "photos",
+                ownerMemberId = ArgumentMatchers.eq(7L),
+                originalFilename = ArgumentMatchers.eq("photo.png"),
+                clientOriginalFilename = ArgumentMatchers.eq("사진 원본.png"),
+                contentType = ArgumentMatchers.eq("image/png"),
+                inputStream = anyInputStream(),
+                contentLength = ArgumentMatchers.eq(uploadBytes.size.toLong()),
+                folderPath = ArgumentMatchers.eq("photos"),
             ),
         ).willReturn(item)
 
@@ -130,6 +136,48 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
                 jsonPath("$.data.id") { value(11) }
                 jsonPath("$.data.ownerMemberId") { value(7) }
             }
+    }
+
+    @Test
+    @DisplayName("관리자 upload는 MultipartFile bytes 복사 없이 stream으로 위임한다")
+    fun `관리자 upload는 MultipartFile bytes 복사 없이 stream으로 위임한다`() {
+        val item = sampleDto(id = 12L, ownerMemberId = 7L, originalFilename = "manual.pdf")
+        given(
+            cloudFileService.upload(
+                ownerMemberId = ArgumentMatchers.eq(7L),
+                originalFilename = ArgumentMatchers.eq("manual.pdf"),
+                clientOriginalFilename = ArgumentMatchers.eq(null),
+                contentType = ArgumentMatchers.eq("application/pdf"),
+                inputStream = anyInputStream(),
+                contentLength = ArgumentMatchers.eq(8L),
+                folderPath = ArgumentMatchers.eq("docs"),
+            ),
+        ).willReturn(item)
+        val controller =
+            ApiV1AdmCloudController(
+                cloudFileService,
+                cloudVideoUploadSessionService,
+                cloudExternalPlaybackTokenService,
+            )
+
+        val response =
+            controller.upload(
+                securityUser = adminUser(id = 7L),
+                file = ByteAccessFailingMultipartFile("file", "manual.pdf", "application/pdf", "%PDF-1.7".toByteArray()),
+                folderPath = "docs",
+                clientFilename = null,
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
+        then(cloudFileService).should().upload(
+            ownerMemberId = ArgumentMatchers.eq(7L),
+            originalFilename = ArgumentMatchers.eq("manual.pdf"),
+            clientOriginalFilename = ArgumentMatchers.eq(null),
+            contentType = ArgumentMatchers.eq("application/pdf"),
+            inputStream = anyInputStream(),
+            contentLength = ArgumentMatchers.eq(8L),
+            folderPath = ArgumentMatchers.eq("docs"),
+        )
     }
 
     @Test
@@ -230,7 +278,8 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
                 ownerMemberId = ArgumentMatchers.eq(7L),
                 sessionId = ArgumentMatchers.eq(21L),
                 partNumber = ArgumentMatchers.eq(1),
-                bytes = byteArrayContentEquals(chunkBytes),
+                inputStream = anyInputStream(),
+                contentLength = ArgumentMatchers.eq(chunkBytes.size.toLong()),
             ),
         ).willReturn(
             CloudVideoUploadPartResultDto(
@@ -300,8 +349,8 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
     }
 
     @Test
-    @DisplayName("대용량 동영상 조각 chunked body가 기대 크기를 넘으면 읽는 중 거절한다")
-    fun `대용량 동영상 조각 chunked body가 기대 크기를 넘으면 읽는 중 거절한다`() {
+    @DisplayName("대용량 동영상 조각 chunked body는 service stream 검증으로 위임한다")
+    fun `대용량 동영상 조각 chunked body는 service stream 검증으로 위임한다`() {
         val request = mock(HttpServletRequest::class.java)
         given(request.contentLengthLong).willReturn(-1)
         given(request.inputStream)
@@ -314,6 +363,15 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
                     totalParts = 1,
                 ),
             )
+        given(
+            cloudVideoUploadSessionService.uploadPart(
+                ownerMemberId = ArgumentMatchers.eq(7L),
+                sessionId = ArgumentMatchers.eq(21L),
+                partNumber = ArgumentMatchers.eq(1),
+                inputStream = anyInputStream(),
+                contentLength = ArgumentMatchers.eq(-1L),
+            ),
+        ).willThrow(AppException("400-1", "업로드 조각 크기가 올바르지 않습니다."))
 
         val controller =
             ApiV1AdmCloudController(
@@ -332,7 +390,13 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
         }.hasMessageContaining("업로드 조각 크기가 올바르지 않습니다.")
 
         then(cloudVideoUploadSessionService).should().getSession(ownerMemberId = 7L, sessionId = 21L)
-        then(cloudVideoUploadSessionService).shouldHaveNoMoreInteractions()
+        then(cloudVideoUploadSessionService).should().uploadPart(
+            ownerMemberId = ArgumentMatchers.eq(7L),
+            sessionId = ArgumentMatchers.eq(21L),
+            partNumber = ArgumentMatchers.eq(1),
+            inputStream = anyInputStream(),
+            contentLength = ArgumentMatchers.eq(-1L),
+        )
     }
 
     @Test
@@ -905,10 +969,7 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
             failureReason = null,
         )
 
-    private fun byteArrayContentEquals(expected: ByteArray): ByteArray =
-        ArgumentMatchers.argThat<ByteArray> { actual ->
-            actual != null && actual.contentEquals(expected)
-        } ?: ByteArray(0)
+    private fun anyInputStream(): InputStream = ArgumentMatchers.any(InputStream::class.java) ?: ByteArrayInputStream(ByteArray(0))
 
     private class CloseAwareInputStream(
         bytes: ByteArray,
@@ -918,6 +979,34 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
         override fun close() {
             closed = true
             super.close()
+        }
+    }
+
+    private class ByteAccessFailingMultipartFile(
+        private val name: String,
+        private val originalFilename: String,
+        private val contentType: String,
+        private val content: ByteArray,
+    ) : MultipartFile {
+        override fun getName(): String = name
+
+        override fun getOriginalFilename(): String = originalFilename
+
+        override fun getContentType(): String = contentType
+
+        override fun isEmpty(): Boolean = content.isEmpty()
+
+        override fun getSize(): Long = content.size.toLong()
+
+        override fun getBytes(): ByteArray =
+            throw AssertionError(
+                "controller must pass upload content as stream without reading MultipartFile.bytes",
+            )
+
+        override fun getInputStream(): InputStream = ByteArrayInputStream(content)
+
+        override fun transferTo(dest: java.io.File) {
+            dest.outputStream().use { it.write(content) }
         }
     }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudControllerWebMvcTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/adapter/web/ApiV1AdmCloudControllerWebMvcTest.kt
@@ -40,6 +40,8 @@ import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.time.Instant
 
+private const val PDF_CONTENT_TYPE = "application/pdf"
+
 @DisplayName("관리자 클라우드 WebMvc 테스트")
 class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
     @Test
@@ -147,7 +149,7 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
                 ownerMemberId = ArgumentMatchers.eq(7L),
                 originalFilename = ArgumentMatchers.eq("manual.pdf"),
                 clientOriginalFilename = ArgumentMatchers.eq(null),
-                contentType = ArgumentMatchers.eq("application/pdf"),
+                contentType = ArgumentMatchers.eq(PDF_CONTENT_TYPE),
                 inputStream = anyInputStream(),
                 contentLength = ArgumentMatchers.eq(8L),
                 folderPath = ArgumentMatchers.eq("docs"),
@@ -163,7 +165,7 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
         val response =
             controller.upload(
                 securityUser = adminUser(id = 7L),
-                file = ByteAccessFailingMultipartFile("file", "manual.pdf", "application/pdf", "%PDF-1.7".toByteArray()),
+                file = ByteAccessFailingMultipartFile("file", "manual.pdf", PDF_CONTENT_TYPE, "%PDF-1.7".toByteArray()),
                 folderPath = "docs",
                 clientFilename = null,
             )
@@ -173,7 +175,7 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
             ownerMemberId = ArgumentMatchers.eq(7L),
             originalFilename = ArgumentMatchers.eq("manual.pdf"),
             clientOriginalFilename = ArgumentMatchers.eq(null),
-            contentType = ArgumentMatchers.eq("application/pdf"),
+            contentType = ArgumentMatchers.eq(PDF_CONTENT_TYPE),
             inputStream = anyInputStream(),
             contentLength = ArgumentMatchers.eq(8L),
             folderPath = ArgumentMatchers.eq("docs"),
@@ -931,7 +933,7 @@ class ApiV1AdmCloudControllerWebMvcTest : BaseAdmCloudControllerWebMvcTest() {
         id: Long,
         ownerMemberId: Long,
         originalFilename: String,
-        contentType: String = "application/pdf",
+        contentType: String = PDF_CONTENT_TYPE,
         byteSize: Long = 9L,
         mediaKind: CloudFileMediaKind = CloudFileMediaKind.DOCUMENT,
     ): CloudFileDto =

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -136,6 +136,19 @@ class CloudFileServiceTest {
         }.isInstanceOf(AppException::class.java)
             .hasMessageContaining("파일 크기")
 
+        assertThatThrownBy {
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "long.pdf",
+                clientOriginalFilename = null,
+                contentType = "application/pdf",
+                inputStream = ByteArrayInputStream("%PDF-1.7".toByteArray()),
+                contentLength = 4,
+                folderPath = "docs",
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("파일 크기")
+
         assertThat(storage.uploaded).isEmpty()
         assertThat(repository.savedFiles).isEmpty()
     }

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -33,6 +33,24 @@ class CloudFileServiceTest {
             clock = Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneOffset.UTC),
         )
 
+    private fun CloudFileService.upload(
+        ownerMemberId: Long,
+        originalFilename: String?,
+        clientOriginalFilename: String? = null,
+        contentType: String?,
+        bytes: ByteArray,
+        folderPath: String?,
+    ): CloudFileDto =
+        upload(
+            ownerMemberId = ownerMemberId,
+            originalFilename = originalFilename,
+            clientOriginalFilename = clientOriginalFilename,
+            contentType = contentType,
+            inputStream = ByteArrayInputStream(bytes),
+            contentLength = bytes.size.toLong(),
+            folderPath = folderPath,
+        )
+
     @Test
     @DisplayName("업로드 시 ownerMemberId와 cloud prefix를 metadata에 고정한다")
     fun `upload는 ownerMemberId와 cloud prefix를 metadata에 고정한다`() {
@@ -168,7 +186,7 @@ class CloudFileServiceTest {
         assertThat(result.originalFilename).isEqualTo("portfolio.pdf")
         assertThat(result.byteSize).isEqualTo(seventeenMbPdf.size.toLong())
         assertThat(result.mediaKind).isEqualTo(CloudFileMediaKind.DOCUMENT)
-        assertThat(storage.uploaded.single().bytes).hasSize(seventeenMbPdf.size)
+        assertThat(storage.uploaded.single().contentLength).isEqualTo(seventeenMbPdf.size.toLong())
     }
 
     @Test
@@ -951,19 +969,22 @@ class CloudFileServiceTest {
     }
 
     @Test
-    @DisplayName("UploadRequest는 bytes 내용을 기준으로 동일성을 비교한다")
-    fun `UploadRequest는 bytes 내용을 기준으로 동일성을 비교한다`() {
+    @DisplayName("UploadRequest는 stream identity와 contentLength를 기준으로 동일성을 비교한다")
+    fun `UploadRequest는 stream identity와 contentLength를 기준으로 동일성을 비교한다`() {
+        val inputStream = ByteArrayInputStream("%PDF-1.7".toByteArray())
         val first =
             CloudStoragePort.UploadRequest(
                 objectKey = "cloud/7/docs/file.pdf",
-                bytes = "%PDF-1.7".toByteArray(),
+                inputStream = inputStream,
+                contentLength = 8,
                 contentType = "application/pdf",
                 originalFilename = "file.pdf",
             )
         val second =
             CloudStoragePort.UploadRequest(
                 objectKey = "cloud/7/docs/file.pdf",
-                bytes = "%PDF-1.7".toByteArray(),
+                inputStream = inputStream,
+                contentLength = 8,
                 contentType = "application/pdf",
                 originalFilename = "file.pdf",
             )
@@ -971,18 +992,19 @@ class CloudFileServiceTest {
         assertThat(first).isEqualTo(second)
         assertThat(first.hashCode()).isEqualTo(second.hashCode())
         assertThat(first.objectKey).isEqualTo("cloud/7/docs/file.pdf")
-        assertThat(first.bytes).containsExactly(*"%PDF-1.7".toByteArray())
+        assertThat(first.contentLength).isEqualTo(8)
         assertThat(first.contentType).isEqualTo("application/pdf")
         assertThat(first.originalFilename).isEqualTo("file.pdf")
         assertThat(first).isNotEqualTo(
             CloudStoragePort.UploadRequest(
                 objectKey = "cloud/7/docs/other.pdf",
-                bytes = "%PDF-1.7".toByteArray(),
+                inputStream = inputStream,
+                contentLength = 8,
                 contentType = "application/pdf",
                 originalFilename = "file.pdf",
             ),
         )
-        assertThat(first.toString()).contains("bytes=8 bytes")
+        assertThat(first.toString()).contains("contentLength=8 bytes")
     }
 
     @Test

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudFileServiceTest.kt
@@ -40,16 +40,29 @@ class CloudFileServiceTest {
         contentType: String?,
         bytes: ByteArray,
         folderPath: String?,
-    ): CloudFileDto =
-        upload(
-            ownerMemberId = ownerMemberId,
-            originalFilename = originalFilename,
-            clientOriginalFilename = clientOriginalFilename,
-            contentType = contentType,
-            inputStream = ByteArrayInputStream(bytes),
-            contentLength = bytes.size.toLong(),
-            folderPath = folderPath,
-        )
+    ): CloudFileDto {
+        val inputStream = ByteArrayInputStream(bytes)
+        return if (clientOriginalFilename == null) {
+            upload(
+                ownerMemberId = ownerMemberId,
+                originalFilename = originalFilename,
+                contentType = contentType,
+                inputStream = inputStream,
+                contentLength = bytes.size.toLong(),
+                folderPath = folderPath,
+            )
+        } else {
+            upload(
+                ownerMemberId = ownerMemberId,
+                originalFilename = originalFilename,
+                clientOriginalFilename = clientOriginalFilename,
+                contentType = contentType,
+                inputStream = inputStream,
+                contentLength = bytes.size.toLong(),
+                folderPath = folderPath,
+            )
+        }
+    }
 
     @Test
     @DisplayName("업로드 시 ownerMemberId와 cloud prefix를 metadata에 고정한다")
@@ -102,6 +115,26 @@ class CloudFileServiceTest {
             )
         }.isInstanceOf(AppException::class.java)
             .hasMessageContaining("콘텐츠 타입이 일치하지 않습니다")
+
+        assertThat(storage.uploaded).isEmpty()
+        assertThat(repository.savedFiles).isEmpty()
+    }
+
+    @Test
+    @DisplayName("업로드 stream 길이가 선언 길이와 다르면 storage 저장 전에 차단한다")
+    fun `upload는 stream 길이 불일치를 storage 저장 전에 차단한다`() {
+        assertThatThrownBy {
+            service.upload(
+                ownerMemberId = 7L,
+                originalFilename = "short.pdf",
+                clientOriginalFilename = null,
+                contentType = "application/pdf",
+                inputStream = ByteArrayInputStream("%PDF-1.7".toByteArray()),
+                contentLength = 128,
+                folderPath = "docs",
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("파일 크기")
 
         assertThat(storage.uploaded).isEmpty()
         assertThat(repository.savedFiles).isEmpty()

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionServiceTest.kt
@@ -44,6 +44,20 @@ class CloudVideoUploadSessionServiceTest {
             clock = clock,
         )
 
+    private fun CloudVideoUploadSessionService.uploadPart(
+        ownerMemberId: Long,
+        sessionId: Long,
+        partNumber: Int,
+        bytes: ByteArray,
+    ): CloudVideoUploadPartResultDto =
+        uploadPart(
+            ownerMemberId = ownerMemberId,
+            sessionId = sessionId,
+            partNumber = partNumber,
+            inputStream = ByteArrayInputStream(bytes),
+            contentLength = bytes.size.toLong(),
+        )
+
     private fun createService(clock: Clock): CloudVideoUploadSessionService =
         CloudVideoUploadSessionService(
             sessionRepository = sessionRepository,
@@ -230,7 +244,14 @@ class CloudVideoUploadSessionServiceTest {
                         String::class.java,
                     ),
                 CloudVideoUploadSessionService::class.java
-                    .getMethod("uploadPart", java.lang.Long.TYPE, java.lang.Long.TYPE, Integer.TYPE, ByteArray::class.java),
+                    .getMethod(
+                        "uploadPart",
+                        java.lang.Long.TYPE,
+                        java.lang.Long.TYPE,
+                        Integer.TYPE,
+                        java.io.InputStream::class.java,
+                        java.lang.Long.TYPE,
+                    ),
                 CloudVideoUploadSessionService::class.java
                     .getMethod("complete", java.lang.Long.TYPE, java.lang.Long.TYPE),
                 CloudVideoUploadSessionService::class.java
@@ -835,28 +856,32 @@ class CloudVideoUploadSessionServiceTest {
     }
 
     @Test
-    @DisplayName("multipart part request는 ByteArray 내용을 기준으로 equals와 hashCode를 계산한다")
-    fun `multipart part request는 ByteArray 내용 기준으로 비교한다`() {
+    @DisplayName("multipart part request는 stream identity와 contentLength 기준으로 equals와 hashCode를 계산한다")
+    fun `multipart part request는 stream identity와 contentLength 기준으로 비교한다`() {
+        val inputStream = ByteArrayInputStream(byteArrayOf(1, 2, 3))
         val first =
             CloudStoragePort.MultipartUploadPartRequest(
                 objectKey = "cloud/7/movie.mp4",
                 uploadId = "upload-1",
                 partNumber = 1,
-                bytes = byteArrayOf(1, 2, 3),
+                inputStream = inputStream,
+                contentLength = 3,
             )
         val second =
             CloudStoragePort.MultipartUploadPartRequest(
                 objectKey = "cloud/7/movie.mp4",
                 uploadId = "upload-1",
                 partNumber = 1,
-                bytes = byteArrayOf(1, 2, 3),
+                inputStream = inputStream,
+                contentLength = 3,
             )
         val different =
             CloudStoragePort.MultipartUploadPartRequest(
                 objectKey = "cloud/7/movie.mp4",
                 uploadId = "upload-1",
                 partNumber = 1,
-                bytes = byteArrayOf(1, 2, 4),
+                inputStream = ByteArrayInputStream(byteArrayOf(1, 2, 3)),
+                contentLength = 3,
             )
 
         assertThat(first).isEqualTo(second)

--- a/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionServiceTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/cloud/application/service/CloudVideoUploadSessionServiceTest.kt
@@ -468,6 +468,58 @@ class CloudVideoUploadSessionServiceTest {
     }
 
     @Test
+    @DisplayName("조각 stream이 선언 길이보다 짧으면 storage에 올리지 않는다")
+    fun `조각 upload는 짧은 stream을 storage 저장 전에 차단한다`() {
+        val session =
+            service.createSession(
+                ownerMemberId = 7L,
+                originalFilename = "movie.mp4",
+                contentType = "video/mp4",
+                byteSize = TEST_PART_SIZE_BYTES,
+                folderPath = "",
+            )
+
+        assertThatThrownBy {
+            service.uploadPart(
+                ownerMemberId = 7L,
+                sessionId = session.id,
+                partNumber = 1,
+                inputStream = ByteArrayInputStream(ByteArray(0)),
+                contentLength = TEST_PART_SIZE_BYTES,
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("조각 크기")
+
+        assertThat(storage.multipartParts).isEmpty()
+    }
+
+    @Test
+    @DisplayName("조각 stream이 선언 길이보다 길면 storage에 올리지 않는다")
+    fun `조각 upload는 긴 stream을 storage 저장 전에 차단한다`() {
+        val session =
+            service.createSession(
+                ownerMemberId = 7L,
+                originalFilename = "movie.mp4",
+                contentType = "video/mp4",
+                byteSize = TEST_PART_SIZE_BYTES,
+                folderPath = "",
+            )
+
+        assertThatThrownBy {
+            service.uploadPart(
+                ownerMemberId = 7L,
+                sessionId = session.id,
+                partNumber = 1,
+                inputStream = ByteArrayInputStream(mp4Part(TEST_PART_SIZE_BYTES.toInt() + 1)),
+                contentLength = TEST_PART_SIZE_BYTES,
+            )
+        }.isInstanceOf(AppException::class.java)
+            .hasMessageContaining("조각 크기")
+
+        assertThat(storage.multipartParts).isEmpty()
+    }
+
+    @Test
     @DisplayName("콘텐츠 타입과 첫 조각 시그니처가 다르면 업로드를 거절한다")
     fun `콘텐츠 타입과 첫 조각 시그니처가 다르면 업로드를 거절한다`() {
         val session =


### PR DESCRIPTION
## 관련 이슈

close #1142

## 작업 배경

- Cloud 관리자 파일 업로드와 multipart part 업로드가 payload를 byte array 계약으로 전달해 큰 파일에서 heap 사용량이 커질 수 있었다.

## 작업 내용

- Cloud upload service/controller/storage port 계약을 content length가 있는 stream 기반으로 변경했다.
- Cloud storage adapter의 단일 upload와 multipart part upload body 생성을 stream 기반으로 바꿨다.
- controller가 MultipartFile bytes를 읽지 않는 회귀 테스트와 stream 길이 불일치 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
- `back/gradlew -p back test --tests "*CloudStorageAdapterTest" --tests "*CloudFileServiceTest" --tests "*CloudVideoUploadSessionServiceTest" --tests "*ApiV1AdmCloudControllerWebMvcTest"`: exit 0
- `back/gradlew -p back ciFastCoverageVerification jacocoPrReport jacocoPrFullCoverageReport`: exit 0
- `back/gradlew -p back ktlintCheck`: exit 0
- `back/gradlew -p back test`: exit 0
- `git diff --check`: exit 0
- static search: upload production path에서 `MultipartFile.bytes`, `RequestBody.fromBytes` 미사용 확인. 회귀 테스트 메시지 1건만 의도적으로 남음.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| targeted backend tests | local | Gradle targeted test | command output | pass |
| backend coverage gate | local | filtered line coverage check | command output | pass |
| backend style | local | ktlintCheck | command output | pass |
| backend regression | local | full backend test | command output | pass |
| upload payload contract | local | static search | command output | production path match 없음 |

## 리뷰어 메모

- 먼저 볼 지점: CloudStoragePort request 계약과 CloudFileService/CloudVideoUploadSessionService의 temp file cleanup 경로.

## 리스크

- 업로드 처리 경로가 stream 기반으로 바뀌었으므로 storage SDK 요청 body 생성과 temp file 삭제 경로가 핵심 리스크다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] 리뷰 상태를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 업로드와 동영상 조각 업로드가 스트리밍 방식으로 처리되어, 대용량 파일도 더 안정적으로 전송할 수 있게 되었습니다.
  - 업로드 중 파일 형식과 콘텐츠를 더 정확하게 판별하도록 개선되었습니다.

- **Bug Fixes**
  - 선언된 파일 크기와 실제 전송 크기가 일치하지 않으면 업로드가 중단되도록 강화되었습니다.
  - 멀티파트 업로드에서도 스트림 기반 검증이 적용되어 오류 가능성을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->