### PR TITLE
[Chore] 개인정보 출시 체크리스트 evidence 자동 동기화

### DIFF
--- a/docs/design/privacy-launch-gate-checklist.md
+++ b/docs/design/privacy-launch-gate-checklist.md
@@ -2,6 +2,8 @@
 
 이 문서는 `aquila-blog` 상용 출시 전 개인정보·법적 고지·동의·외부처리·보유기간·운영 대응을 한 번에 판정하는 decision artifact다. 일반 release gate는 `docs/design/launch-gate-operations.md`를 따르고, 개인정보/법무 항목은 이 문서가 우선한다.
 
+Follow-up matrix의 source of truth는 `legal/privacy-launch-controls.json`이다. `node tools/privacy/validate-launch-gate-checklist.mjs`는 각 control의 issue 상태, launch 판정, evidence reference, feature flag 비활성 evidence, 정책 시행일/deploy SHA 연결 source가 이 문서와 drift되면 실패한다.
+
 ## Current Decision
 
 | 항목 | 현재 판정 | 근거 | 다음 조치 |

--- a/legal/privacy-launch-controls.json
+++ b/legal/privacy-launch-controls.json
@@ -1,0 +1,198 @@
+{
+  "version": 1,
+  "releaseLinkage": {
+    "policyEffectiveDateSource": "legal/policies/privacy.ko-KR.v1.0.2.yaml",
+    "deployShaSource": "AQUILA_BUILD_SHA",
+    "evidenceArtifacts": [
+      "front/src/apis/backend/legal.ts",
+      "back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/ActiveLegalDocumentMetadata.kt",
+      "front/src/pages/_document.tsx"
+    ]
+  },
+  "controls": [
+    {
+      "issue": 994,
+      "status": "Closed",
+      "category": "필수 출시 전 완료",
+      "target": "데이터맵, 법적 근거 registry",
+      "evidenceRequirement": "`legal/data-map/*.yaml`와 공개 정책 참조",
+      "launchDecision": "완료",
+      "evidenceArtifacts": ["legal/data-map/processing-activities.yaml", "legal/data-map/legal-basis-matrix.yaml"]
+    },
+    {
+      "issue": 995,
+      "status": "Closed",
+      "category": "필수 출시 전 완료",
+      "target": "정책 버전관리와 공개 페이지",
+      "evidenceRequirement": "`legal/policies/*.yaml`, `/privacy`, `/terms`, `/cookies`",
+      "launchDecision": "완료",
+      "evidenceArtifacts": ["legal/policies/privacy.ko-KR.v1.0.2.yaml", "front/src/routes/LegalPolicy/LegalPolicyPage.tsx"]
+    },
+    {
+      "issue": 996,
+      "status": "Closed",
+      "category": "필수 출시 전 완료",
+      "target": "이메일 가입 동의와 증빙 저장",
+      "evidenceRequirement": "backend acceptance version/hash, signup flow evidence",
+      "launchDecision": "완료",
+      "evidenceArtifacts": ["front/e2e/legal-policy-pages.spec.ts", "back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance"]
+    },
+    {
+      "issue": 997,
+      "status": "Closed",
+      "category": "필수 출시 전 완료",
+      "target": "Kakao OAuth 신규 가입 pending 동의",
+      "evidenceRequirement": "OAuth 신규 가입 동의 flow evidence",
+      "launchDecision": "완료",
+      "evidenceArtifacts": ["front/e2e/legal-policy-pages.spec.ts", "back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance"]
+    },
+    {
+      "issue": 998,
+      "status": "Open",
+      "category": "필수 출시 전 완료",
+      "target": "회원가입 token/email URL 노출 제거",
+      "evidenceRequirement": "token hash 저장, URL/log redaction 테스트",
+      "launchDecision": "차단",
+      "evidenceArtifacts": ["issue #998"]
+    },
+    {
+      "issue": 999,
+      "status": "Closed",
+      "category": "필수 출시 전 완료",
+      "target": "권리 요청, export, 계정 탈퇴",
+      "evidenceRequirement": "privacy request/export/delete 테스트",
+      "launchDecision": "완료",
+      "evidenceArtifacts": ["front/e2e/privacy-tracking-consent.spec.ts", "docs/legal/data-subject-request-runbook.md"]
+    },
+    {
+      "issue": 1000,
+      "status": "Open",
+      "category": "필수 출시 전 완료",
+      "target": "보유기간 설정과 자동 파기 job",
+      "evidenceRequirement": "retention config, scheduled deletion test, dry-run log",
+      "launchDecision": "차단",
+      "evidenceArtifacts": ["legal/data-map/retention-matrix.yaml", "issue #1000"]
+    },
+    {
+      "issue": 1001,
+      "status": "Open",
+      "category": "필수 출시 전 완료",
+      "target": "로그 최소화와 민감정보 redaction",
+      "evidenceRequirement": "request/application log redaction test, sample log",
+      "launchDecision": "차단",
+      "evidenceArtifacts": ["issue #1001"]
+    },
+    {
+      "issue": 1002,
+      "status": "Closed",
+      "category": "필수 출시 전 완료",
+      "target": "analytics/cookie consent manager와 opt-out",
+      "evidenceRequirement": "`/settings/privacy` consent UI, `privacy.optionalTrackingConsent.v1` structured storage, tracking pre-consent/withdrawal e2e",
+      "launchDecision": "완료",
+      "evidenceArtifacts": ["front/e2e/privacy-tracking-consent.spec.ts", "front/e2e/browser-storage-registry.spec.ts"]
+    },
+    {
+      "issue": 1003,
+      "status": "Open",
+      "category": "필수 출시 전 완료",
+      "target": "Gemini tag recommendation 외부 처리 안전화",
+      "evidenceRequirement": "default disabled config, redaction/cache regression test",
+      "launchDecision": "차단",
+      "disabledByFlag": true,
+      "disabledEvidence": ["deploy/env/env.contract.json", ".github/workflows/deploy.yml"],
+      "evidenceArtifacts": ["issue #1003"]
+    },
+    {
+      "issue": 1004,
+      "status": "Open",
+      "category": "필수 출시 전 완료",
+      "target": "backup 암호화, deletion tombstone, restore privacy guard",
+      "evidenceRequirement": "backup artifact encryption, restore drill, deletion tombstone evidence",
+      "launchDecision": "차단",
+      "evidenceArtifacts": ["docs/legal/backup-restore-privacy-runbook.md", "tools/test/verify-external-backup-restore-drill.sh", "issue #1004"]
+    },
+    {
+      "issue": 1005,
+      "status": "Closed",
+      "category": "필수 출시 전 완료",
+      "target": "침해사고 대응 runbook",
+      "evidenceRequirement": "`docs/legal/*.md`, tabletop exercise template, owner/contact/evidence 절차",
+      "launchDecision": "완료",
+      "evidenceArtifacts": ["docs/legal/privacy-incident-runbook.md", "docs/legal/privacy-tabletop-exercise-template.md"]
+    },
+    {
+      "issue": 1006,
+      "status": "Open",
+      "category": "필수 출시 전 완료",
+      "target": "정책·코드 privacy drift gate",
+      "evidenceRequirement": "CI command, failing fixture example, passing workflow link",
+      "launchDecision": "차단",
+      "evidenceArtifacts": ["tools/privacy/ci-privacy-gate.mjs", "issue #1006"]
+    },
+    {
+      "issue": 1007,
+      "status": "Closed",
+      "category": "필수 출시 전 완료",
+      "target": "신규 개인정보 수집 feature flag 동결",
+      "evidenceRequirement": "`back/gradlew -p back ciFastCheck --rerun-tasks` 2회 연속 exit 0, `yarn --cwd front build` 2회 exit 0, privacy data-map/env contract validator exit 0",
+      "launchDecision": "완료",
+      "disabledByFlag": true,
+      "disabledEvidence": ["deploy/env/env.contract.json", ".github/workflows/deploy.yml"],
+      "evidenceArtifacts": ["tools/legal/validate-privacy-data-map.mjs", "deploy/env/env.contract.json"]
+    },
+    {
+      "issue": 1008,
+      "status": "Open",
+      "category": "필수 출시 전 완료",
+      "target": "기존 사용자 재동의와 legacy 고지 migration",
+      "evidenceRequirement": "legacy account migration, re-consent prompt, audit log evidence",
+      "launchDecision": "차단",
+      "evidenceArtifacts": ["issue #1008"]
+    },
+    {
+      "issue": 1024,
+      "status": "Closed",
+      "category": "필수 출시 전 완료",
+      "target": "공개 정책과 legal acceptance version/hash 단일화",
+      "evidenceRequirement": "`ActiveLegalDocumentMetadata`와 public policy hash evidence",
+      "launchDecision": "완료",
+      "evidenceArtifacts": ["front/src/apis/backend/legal.ts", "back/src/main/kotlin/com/back/boundedContexts/member/subContexts/legalAcceptance/application/service/ActiveLegalDocumentMetadata.kt"]
+    },
+    {
+      "issue": 1025,
+      "status": "Closed",
+      "category": "필수 출시 전 완료",
+      "target": "effective 정책의 내부 검토 문구 제거",
+      "evidenceRequirement": "`reviewRequired=0`, internal phrase validator, page e2e",
+      "launchDecision": "완료",
+      "evidenceArtifacts": ["tools/legal/validate-legal-policies.mjs", "front/e2e/legal-policy-pages.spec.ts"]
+    },
+    {
+      "issue": 1026,
+      "status": "Closed",
+      "category": "출시 후 보완 가능",
+      "target": "법적 정책 탐색성과 원문 검증 UX",
+      "evidenceRequirement": "policy URL, TOC, hash/download 검증, live page evidence",
+      "launchDecision": "완료",
+      "evidenceArtifacts": ["front/src/routes/LegalPolicy/LegalPolicyPage.tsx", "front/e2e/legal-policy-pages.spec.ts"]
+    },
+    {
+      "issue": 1027,
+      "status": "Closed",
+      "category": "필수 출시 전 완료",
+      "target": "cookie/sessionStorage/localStorage inventory",
+      "evidenceRequirement": "browser storage registry, retention mapping evidence",
+      "launchDecision": "완료",
+      "evidenceArtifacts": ["front/e2e/browser-storage-registry.spec.ts", "legal/data-map/retention-matrix.yaml"]
+    },
+    {
+      "issue": 1028,
+      "status": "Closed",
+      "category": "필수 출시 전 완료",
+      "target": "정책·동의·추적 회귀 검증 세트",
+      "evidenceRequirement": "legal policy and tracking regression test output",
+      "launchDecision": "완료",
+      "evidenceArtifacts": ["front/e2e/legal-policy-pages.spec.ts", "front/e2e/privacy-tracking-consent.spec.ts"]
+    }
+  ]
+}

--- a/tools/privacy/ci-privacy-gate.mjs
+++ b/tools/privacy/ci-privacy-gate.mjs
@@ -17,6 +17,14 @@ const checks = [
     name: "legal validator failure fixtures",
     command: [process.execPath, "--test", "tools/test/legal-policy-validator-fixtures.test.mjs"],
   },
+  {
+    name: "privacy launch checklist evidence sync",
+    command: [process.execPath, "tools/privacy/validate-launch-gate-checklist.mjs"],
+  },
+  {
+    name: "privacy launch checklist failure fixtures",
+    command: [process.execPath, "--test", "tools/test/privacy-launch-gate-fixtures.test.mjs"],
+  },
 ]
 
 for (const check of checks) {

--- a/tools/privacy/validate-launch-gate-checklist.mjs
+++ b/tools/privacy/validate-launch-gate-checklist.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+import fs from "node:fs"
+import path from "node:path"
+
+const repoRoot = path.resolve(import.meta.dirname, "../..")
+const controlsPath = path.resolve(
+  repoRoot,
+  process.env.PRIVACY_LAUNCH_CONTROLS_PATH || "legal/privacy-launch-controls.json",
+)
+const checklistPath = path.resolve(
+  repoRoot,
+  process.env.PRIVACY_LAUNCH_CHECKLIST_PATH || "docs/design/privacy-launch-gate-checklist.md",
+)
+
+const fail = (message) => {
+  console.error(`[privacy-launch-gate] ${message}`)
+  process.exitCode = 1
+}
+
+const readJson = (filePath) => JSON.parse(fs.readFileSync(filePath, "utf8"))
+const readText = (filePath) => fs.readFileSync(filePath, "utf8")
+const normalizeCell = (value) => value.trim()
+
+const parseIssueMatrix = (markdown) => {
+  const rows = new Map()
+  for (const line of markdown.split(/\r?\n/)) {
+    if (!line.startsWith("| #")) continue
+    const cells = line.split("|").slice(1, -1).map(normalizeCell)
+    if (cells.length !== 6) continue
+    const issue = Number(cells[0].replace(/^#/, ""))
+    if (!Number.isInteger(issue)) continue
+    rows.set(issue, {
+      issue,
+      status: cells[1],
+      category: cells[2],
+      target: cells[3],
+      evidenceRequirement: cells[4],
+      launchDecision: cells[5],
+    })
+  }
+  return rows
+}
+
+const requireNonEmptyString = (value, label) => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail(`${label} is required`)
+  }
+}
+
+const requireStringArray = (value, label) => {
+  if (!Array.isArray(value) || value.length === 0) {
+    fail(`${label} must contain at least one evidence reference`)
+    return
+  }
+  value.forEach((entry, index) => requireNonEmptyString(entry, `${label}[${index}]`))
+}
+
+const validateControl = (control) => {
+  const label = `#${control.issue}`
+  if (!Number.isInteger(control.issue)) fail(`${label} issue must be an integer`)
+  if (control.status !== "Open" && control.status !== "Closed") {
+    fail(`${label} status must be Open or Closed`)
+  }
+  requireNonEmptyString(control.category, `${label} category`)
+  requireNonEmptyString(control.target, `${label} target`)
+  requireNonEmptyString(control.evidenceRequirement, `${label} evidenceRequirement`)
+  requireNonEmptyString(control.launchDecision, `${label} launchDecision`)
+  requireStringArray(control.evidenceArtifacts, `${label} evidenceArtifacts`)
+
+  if (control.status === "Open" && control.launchDecision !== "차단") {
+    fail(`${label} open control must block launch`)
+  }
+  if (control.status === "Closed" && control.launchDecision === "차단") {
+    fail(`${label} closed control must not block launch`)
+  }
+  if (control.disabledByFlag === true) {
+    requireStringArray(control.disabledEvidence, `${label} disabledEvidence`)
+  }
+}
+
+const assertChecklistRowMatches = (control, row) => {
+  const label = `#${control.issue}`
+  if (!row) {
+    fail(`${label} is missing from checklist matrix`)
+    return
+  }
+  for (const key of ["status", "category", "target", "evidenceRequirement", "launchDecision"]) {
+    if (row[key] !== control[key]) {
+      fail(`${label} checklist ${key} drift: expected "${control[key]}", actual "${row[key]}"`)
+    }
+  }
+}
+
+const source = readJson(controlsPath)
+const checklist = readText(checklistPath)
+const matrixRows = parseIssueMatrix(checklist)
+
+if (source.version !== 1) fail("source version must be 1")
+if (!source.releaseLinkage || typeof source.releaseLinkage !== "object") {
+  fail("releaseLinkage is required")
+} else {
+  requireNonEmptyString(source.releaseLinkage.policyEffectiveDateSource, "releaseLinkage.policyEffectiveDateSource")
+  requireNonEmptyString(source.releaseLinkage.deployShaSource, "releaseLinkage.deployShaSource")
+  requireStringArray(source.releaseLinkage.evidenceArtifacts, "releaseLinkage.evidenceArtifacts")
+}
+
+if (!Array.isArray(source.controls) || source.controls.length === 0) {
+  fail("controls must contain at least one control")
+} else {
+  const seen = new Set()
+  for (const control of source.controls) {
+    if (seen.has(control.issue)) fail(`#${control.issue} is duplicated`)
+    seen.add(control.issue)
+    validateControl(control)
+    assertChecklistRowMatches(control, matrixRows.get(control.issue))
+  }
+
+  for (const issue of matrixRows.keys()) {
+    if (!seen.has(issue)) fail(`#${issue} exists in checklist matrix but not structured source`)
+  }
+}
+
+if (process.exitCode) process.exit(process.exitCode)
+console.log(`[privacy-launch-gate] ok: ${source.controls.length} controls verified`)

--- a/tools/test/privacy-launch-gate-fixtures.test.mjs
+++ b/tools/test/privacy-launch-gate-fixtures.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+const repoRoot = path.resolve(import.meta.dirname, "../..")
+const validatorPath = path.join(repoRoot, "tools/privacy/validate-launch-gate-checklist.mjs")
+const sourcePath = path.join(repoRoot, "legal/privacy-launch-controls.json")
+const checklistPath = path.join(repoRoot, "docs/design/privacy-launch-gate-checklist.md")
+
+const createFixture = () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "privacy-launch-gate-"))
+  const sourceFixturePath = path.join(fixtureRoot, "privacy-launch-controls.json")
+  const checklistFixturePath = path.join(fixtureRoot, "privacy-launch-gate-checklist.md")
+  fs.copyFileSync(sourcePath, sourceFixturePath)
+  fs.copyFileSync(checklistPath, checklistFixturePath)
+  return { sourceFixturePath, checklistFixturePath }
+}
+
+const runValidator = ({ sourceFixturePath, checklistFixturePath }) =>
+  spawnSync(process.execPath, [validatorPath], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PRIVACY_LAUNCH_CONTROLS_PATH: sourceFixturePath,
+      PRIVACY_LAUNCH_CHECKLIST_PATH: checklistFixturePath,
+    },
+    encoding: "utf8",
+  })
+
+test("privacy launch gate fixture passes with synchronized source and checklist", () => {
+  const fixture = createFixture()
+  const result = runValidator(fixture)
+
+  assert.equal(result.status, 0)
+  assert.match(result.stdout, /controls verified/)
+})
+
+test("privacy launch gate fixture fails when evidence reference is missing", () => {
+  const fixture = createFixture()
+  const source = JSON.parse(fs.readFileSync(fixture.sourceFixturePath, "utf8"))
+  source.controls[0].evidenceArtifacts = []
+  fs.writeFileSync(fixture.sourceFixturePath, `${JSON.stringify(source, null, 2)}\n`)
+
+  const result = runValidator(fixture)
+
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr, /evidenceArtifacts must contain at least one evidence reference/)
+})
+
+test("privacy launch gate fixture fails when checklist matrix drifts", () => {
+  const fixture = createFixture()
+  const checklist = fs.readFileSync(fixture.checklistFixturePath, "utf8")
+  fs.writeFileSync(
+    fixture.checklistFixturePath,
+    checklist.replace("| #998 | Open |", "| #998 | Closed |"),
+  )
+
+  const result = runValidator(fixture)
+
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr, /#998 checklist status drift/)
+})


### PR DESCRIPTION
## 관련 이슈

close #1141

## 작업 배경

- Privacy launch checklist의 follow-up matrix가 수동 Markdown이라 control 상태와 evidence reference drift를 CI에서 잡기 어렵습니다.

## 작업 내용

- `legal/privacy-launch-controls.json`을 추가해 launch control의 issue 상태, launch 판정, evidence reference, feature flag 비활성 evidence, 정책 시행일/deploy SHA source를 구조화했습니다.
- checklist matrix가 structured source와 다르면 실패하는 validator를 추가했습니다.
- evidence 누락과 checklist drift를 검증하는 fixture test를 추가했습니다.
- 기존 privacy gate에 checklist sync validator와 fixture test를 연결했습니다.

## 검증

- 실행한 명령과 결과:
  - `node tools/privacy/ci-privacy-gate.mjs`: exit 0
  - `node --test tools/test/privacy-launch-gate-fixtures.test.mjs`: 3 passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| privacy gate | local | `node tools/privacy/ci-privacy-gate.mjs` | legal policy/data-map/checklist sync 모두 ok | 통과 |
| missing evidence fixture | local | `node --test tools/test/privacy-launch-gate-fixtures.test.mjs` | evidence 없는 control fixture 실패 확인 | 통과 |
| checklist drift fixture | local | `node --test tools/test/privacy-launch-gate-fixtures.test.mjs` | #998 상태 drift fixture 실패 확인 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `legal/privacy-launch-controls.json`의 evidence reference와 checklist validator의 drift 비교입니다.

## 리스크

- Checklist row를 수정할 때 structured source를 함께 갱신하지 않으면 security workflow가 실패합니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] 자동 리뷰 상태를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
