### PR TITLE
[Chore] Frontend toolchain drift 정리

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -5,7 +5,7 @@
 ## Stack
 
 - Next.js Pages Router
-- React 18 + TypeScript
+- React 19 + TypeScript
 - TanStack Query (SSR hydrate + client cache)
 - Emotion
 - Playwright (smoke/perf/live E2E)
@@ -17,16 +17,18 @@
 - `/about` 소개 페이지
 - `/admin` 운영 허브
 - `/admin/profile` 관리자 프로필 관리
-- `/admin/posts/new` 글 작성/수정 (AI 태그 추천 포함)
+- `/admin/posts/new` 글 작성/수정
 - `/admin/tools` 시스템 운영 도구
 
 ## 실행
 
 ```bash
 cd front
-yarn install
+yarn install --frozen-lockfile
 yarn dev
 ```
+
+Node.js 20.x와 Yarn 1.22.22를 기준으로 실행합니다. `package.json`의 `engines.node`는 CI의 Node 20 런타임과 맞춥니다.
 
 ## 필수 환경변수
 
@@ -41,12 +43,17 @@ yarn dev
 | --- | --- |
 | `NEXT_PUBLIC_UPTIME_KUMA_STATUS_PATH` | 관리자 도구의 상태 페이지 임베드 경로 |
 | `NEXT_PUBLIC_MONITORING_EMBED_URL` | 관리자 도구의 모니터링 iframe URL(예: Grafana kiosk URL) |
+| `NEXT_PUBLIC_LOGS_EMBED_URL` | 관리자 도구의 로그 iframe URL |
 | `NEXT_PUBLIC_PROMETHEUS_URL` | 관리자 도구의 Prometheus 바로가기 URL |
 | `NEXT_PUBLIC_NOTIFICATION_STREAM_MODE` | 알림 전송 모드(`auto`, `polling-only`, `sse`) |
+| `NEXT_PUBLIC_SIGNUP_ENABLED` | 회원가입 화면 활성화 여부 |
+| `NEXT_PUBLIC_RUM_SAMPLE_RATE` | Web Vitals 수집 샘플 비율 |
 | `UPTIME_KUMA_PROXY_ORIGIN` | `/status/*` rewrite 대상 오리진 |
 | `PLAYWRIGHT_BASE_URL` | live E2E 대상 URL |
 | `BUNDLE_BUDGET_MARGIN_PERCENT` | 번들 예산 허용 오차(%) |
 | `BUNDLE_BUDGET_ENFORCEMENT` | `strict` 또는 `warn` |
+| `E2E_ADMIN_EMAIL` | live E2E 관리자 이메일 |
+| `E2E_ADMIN_PASSWORD` | live E2E 관리자 비밀번호 |
 
 ## 인증/세션 동작 요약
 
@@ -77,10 +84,10 @@ yarn contracts:check
 cd front
 yarn lint
 yarn build
+yarn check:bundle-size
 yarn test:e2e:smoke
 yarn test:e2e:perf
 yarn test:e2e:live
-yarn check:bundle-size
 ```
 
 ## 번들 예산

--- a/front/package.json
+++ b/front/package.json
@@ -3,6 +3,9 @@
   "version": "1.3.0",
   "private": true,
   "packageManager": "yarn@1.22.22",
+  "engines": {
+    "node": ">=20 <21"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/front/scripts/patch-lodash-template.cjs
+++ b/front/scripts/patch-lodash-template.cjs
@@ -1,7 +1,23 @@
 const fs = require("node:fs")
+const crypto = require("node:crypto")
 
 const templatePath = require.resolve("lodash/template")
+const originalSha256 = "3e995a1962c52317214e6411c40487a50bbd3cdd40deb83941bc3f85cdd9c976"
+const patchedSha256 = "46094496a50579f3112ec77abb38ab1e2fb05a51f09162e6a74bafa55a485c50"
+
+const sha256 = (value) => crypto.createHash("sha256").update(value).digest("hex")
+
 let source = fs.readFileSync(templatePath, "utf8")
+const sourceSha256 = sha256(source)
+
+if (sourceSha256 === patchedSha256) {
+  process.exit(0)
+}
+
+if (sourceSha256 !== originalSha256) {
+  throw new Error(`Unexpected lodash template module checksum at ${templatePath}: ${sourceSha256}`)
+}
+
 let patched = source
 
 if (patched.includes("assignWith(") && !patched.includes("assignWith = require('./assignWith')")) {
@@ -19,10 +35,14 @@ if (patched.includes("arrayEach(") && !patched.includes("arrayEach = require('./
 }
 
 if (patched === source) {
-  process.exit(0)
+  throw new Error(`Unable to patch lodash template module at ${templatePath}`)
 }
 
-if (!patched.includes("assignWith = require('./assignWith')") || !patched.includes("arrayEach = require('./_arrayEach')")) {
+if (
+  !patched.includes("assignWith = require('./assignWith')") ||
+  !patched.includes("arrayEach = require('./_arrayEach')") ||
+  sha256(patched) !== patchedSha256
+) {
   throw new Error(`Unable to patch lodash template module at ${templatePath}`)
 }
 


### PR DESCRIPTION
## 관련 이슈

close #1140

## 작업 배경

- Frontend install/runtime 계약과 README가 현재 package/CI 상태와 달라 재현성이 낮았습니다.
- lodash template patch는 아직 필요하므로 제거 대신 checksum gate로 예상 입력만 수정하도록 고정했습니다.

## 작업 내용

- `front/package.json`에 Node 20.x engines 계약을 추가했습니다.
- `front/scripts/patch-lodash-template.cjs`에 원본/패치 후 sha256 검증과 idempotent 처리를 추가했습니다.
- `front/README.md`의 React 버전, install 명령, Node/Yarn 기준, 환경변수, 검증 명령을 현재 상태에 맞췄습니다.

## 검증

- 실행한 명령과 결과:
  - `node front/scripts/patch-lodash-template.cjs` 2회: 원본 복원 후 첫 실행 patch 성공, 두 번째 실행 exit 0
  - `yarn --cwd front install --frozen-lockfile`: local Node v24.11.1에서 engines mismatch로 exit 1
  - `YARN_IGNORE_ENGINES=1 yarn --cwd front install --frozen-lockfile`: exit 0
  - `YARN_IGNORE_ENGINES=1 yarn --cwd front build`: exit 0
  - `node --check front/scripts/patch-lodash-template.cjs`: exit 0
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| patch checksum | local | patch script 2회 실행 | command output | 원본 patch 후 재실행 통과 |
| Node runtime contract | local | `yarn --cwd front install --frozen-lockfile` | command output | Node v24.11.1 mismatch로 실패 |
| install | local | `YARN_IGNORE_ENGINES=1 yarn --cwd front install --frozen-lockfile` | command output | 통과 |
| build | local | `YARN_IGNORE_ENGINES=1 yarn --cwd front build` | command output | 통과 |
| README drift | PR diff | package/README 비교 | PR diff | 현재 package 기준 반영 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: checksum이 예상 lodash template 입력만 허용하도록 막는 부분

## 리스크

- local Node 20 실행 파일이 없어 exact install/build는 CI의 Node 20 환경에서 최종 확인됩니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] 자동 리뷰 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 설치 및 실행 안내가 최신 환경 기준(React 19, Node.js 20.x, Yarn 1.22.22)으로 업데이트되었습니다.
  * 선택 환경변수와 검증 절차 안내가 보강되어 설정과 테스트 실행 순서가 더 명확해졌습니다.

* **변경 사항**
  * 지원되는 Node.js 버전이 `20.x`로 명시되었습니다.
  * 패치 검증이 강화되어 더 안정적으로 실행되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->