### PR TITLE
[Build] Spring Boot Java runtime 검증선 갱신

### DIFF
--- a/.github/workflows/reusable-backend-quality.yml
+++ b/.github/workflows/reusable-backend-quality.yml
@@ -246,12 +246,12 @@ jobs:
             echo "- backend-heavy checks skipped"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         if: steps.changes.outputs.backend == 'true'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
-          java-version: "24"
+          java-version: "25"
           cache: gradle
 
       - name: Validate Flyway migration naming

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,11 +52,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
-          java-version: "24"
+          java-version: "25"
           cache: gradle
 
       - name: Run backend dependency vulnerability scan
@@ -119,12 +119,12 @@ jobs:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         if: matrix.language == 'java-kotlin'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
-          java-version: "24"
+          java-version: "25"
           cache: gradle
 
       - name: Build JVM sources for CodeQL

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -49,11 +49,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
-          java-version: "24"
+          java-version: "25"
           cache: gradle
 
       - name: Generate backend coverage

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Spring Boot + Kotlin API
 
 ### Prerequisites
 
-- Java 24
+- Java 25 LTS
 - Node.js LTS
 - Yarn Classic 1.22.x
 - Docker / Docker Compose

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -4,8 +4,8 @@
 # 1️⃣ JDK Source Stage
 # =========================
 # Digest pin source:
-# docker buildx imagetools inspect eclipse-temurin:24-jdk
-FROM eclipse-temurin:24-jdk@sha256:7493205ffe6caa8074fa8a06a276bb1c5ac41d3dd0fd43a0db66d7f776e80b3e AS jdk-source
+# docker buildx imagetools inspect eclipse-temurin:25-jdk
+FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64 AS jdk-source
 
 # =========================
 # 2️⃣ Build Stage
@@ -55,19 +55,19 @@ RUN set -e \
 # =========================
 # Oracle GraalVM base can require x86-64-v3 on older CPUs.
 # Use Temurin for broader CPU compatibility.
-FROM eclipse-temurin:24-jdk@sha256:7493205ffe6caa8074fa8a06a276bb1c5ac41d3dd0fd43a0db66d7f776e80b3e AS extractor
+FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64 AS extractor
 
 WORKDIR /app
 
 COPY --from=builder /app/build/libs/*.jar app.jar
 
-# Spring Boot layered jar 추출 (deprecation 경고는 무시해도 됨 — Spring Boot 4.x에서 tools extract 명령은 다른 디렉토리 구조를 생성함)
-RUN java -Djarmode=layertools -jar app.jar extract
+# Spring Boot 4.1 tools jarmode extracts a thin runnable jar plus lib directory.
+RUN java -Djarmode=tools -jar app.jar extract
 
 # =========================
 # 4️⃣ Runtime Stage
 # =========================
-FROM eclipse-temurin:24-jdk@sha256:7493205ffe6caa8074fa8a06a276bb1c5ac41d3dd0fd43a0db66d7f776e80b3e
+FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64
 
 ENV LANG=ko_KR.UTF-8
 ENV LC_ALL=ko_KR.UTF-8
@@ -75,11 +75,9 @@ ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.en
 
 WORKDIR /app
 
-# Spring Boot layers (변경 빈도 낮은 순 → 높은 순으로 배치해 캐시 효율 극대화)
-COPY --from=extractor /app/dependencies/ ./
-COPY --from=extractor /app/snapshot-dependencies/ ./
-COPY --from=extractor /app/spring-boot-loader/ ./
-COPY --from=extractor /app/application/ ./
+# Spring Boot extracted app (library jars first for Docker cache reuse)
+COPY --from=extractor /app/app/lib/ ./lib/
+COPY --from=extractor /app/app/app.jar ./app.jar
 
 # ── t3.micro JVM 최적화 ──
 ENTRYPOINT ["java", \
@@ -89,4 +87,5 @@ ENTRYPOINT ["java", \
   "-XX:+ExitOnOutOfMemoryError", \
   "-XX:+AlwaysPreTouch", \
   "-Dspring.profiles.active=prod", \
-  "org.springframework.boot.loader.launch.JarLauncher"]
+  "-jar", \
+  "app.jar"]

--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -1,8 +1,10 @@
+import org.gradle.api.tasks.compile.JavaCompile
+
 plugins {
     kotlin("jvm") version "2.2.21"
     kotlin("plugin.spring") version "2.2.21"
     jacoco
-    id("org.springframework.boot") version "4.0.3"
+    id("org.springframework.boot") version "4.1.0"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("plugin.jpa") version "2.2.21"
     kotlin("kapt") version "2.2.21"
@@ -20,8 +22,12 @@ description = "back"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(24)
+        languageVersion = JavaLanguageVersion.of(25)
     }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(24)
 }
 
 repositories {

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2AuthorizationRequestResolver.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2AuthorizationRequestResolver.kt
@@ -27,7 +27,7 @@ class CustomOAuth2AuthorizationRequestResolver(
 
     override fun resolve(
         request: HttpServletRequest,
-        clientRegistrationId: String?,
+        clientRegistrationId: String,
     ): OAuth2AuthorizationRequest? = delegate.resolve(request, clientRegistrationId)?.let { customizeState(it, request) }
 
     private fun customizeState(

--- a/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserService.kt
+++ b/back/src/main/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserService.kt
@@ -46,7 +46,9 @@ class CustomOAuth2UserService(
 
     @Transactional
     override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
-        val oAuth2User = delegate.loadUser(userRequest)
+        val oAuth2User =
+            delegate.loadUser(userRequest)
+                ?: throw InternalAuthenticationServiceException("OAuth2 provider returned no user.")
         val provider = OAuth2Provider.from(userRequest.clientRegistration.registrationId)
         val profilePayload =
             when (provider) {
@@ -76,7 +78,9 @@ class CustomOidcUserService(
 
     @Transactional
     override fun loadUser(userRequest: OidcUserRequest): OidcUser {
-        val oidcUser = delegate.loadUser(userRequest)
+        val oidcUser =
+            delegate.loadUser(userRequest)
+                ?: throw InternalAuthenticationServiceException("OIDC provider returned no user.")
         val provider = OAuth2Provider.from(userRequest.clientRegistration.registrationId)
         val profilePayload =
             when (provider) {

--- a/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserServiceTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/oauth2/CustomOAuth2UserServiceTest.kt
@@ -11,6 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.springframework.security.authentication.InternalAuthenticationServiceException
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.client.registration.ClientRegistration
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
@@ -113,7 +114,7 @@ class CustomOAuth2UserServiceTest {
         assertThat(principal.attributes["sub"]).isEqualTo("oidc-user-id")
         assertThat(principal.claims["nickname"]).isEqualTo("OIDC닉네임")
         assertThat(principal.idToken).isSameAs(idToken)
-        assertThat(principal.userInfo.subject).isEqualTo("oidc-user-id")
+        assertThat(principal.userInfo!!.subject).isEqualTo("oidc-user-id")
     }
 
     @Test
@@ -193,6 +194,43 @@ class CustomOAuth2UserServiceTest {
             )
         }.isInstanceOf(IllegalStateException::class.java)
             .hasMessage("Unsupported provider: google")
+    }
+
+    @Test
+    fun `OAuth2 provider user가 없으면 명시적으로 거부한다`() {
+        val service =
+            CustomOAuth2UserService(RecordingMemberUseCase().proxy, RecordingOAuthSignupUseCase()).apply {
+                delegate = OAuth2UserService<OAuth2UserRequest, OAuth2User> { null }
+            }
+
+        assertThatThrownBy {
+            service.loadUser(
+                OAuth2UserRequest(kakaoClientRegistration(userNameAttributeName = "id"), accessToken()),
+            )
+        }.isInstanceOf(InternalAuthenticationServiceException::class.java)
+            .hasMessage("OAuth2 provider returned no user.")
+    }
+
+    @Test
+    fun `OIDC provider user가 없으면 명시적으로 거부한다`() {
+        val idToken =
+            OidcIdToken(
+                "id-token",
+                Instant.EPOCH,
+                Instant.EPOCH.plusSeconds(60),
+                mapOf("sub" to "oidc-user-id"),
+            )
+        val service =
+            CustomOidcUserService(RecordingMemberUseCase().proxy, RecordingOAuthSignupUseCase()).apply {
+                delegate = OAuth2UserService<OidcUserRequest, OidcUser> { null }
+            }
+
+        assertThatThrownBy {
+            service.loadUser(
+                OidcUserRequest(kakaoClientRegistration(userNameAttributeName = "sub"), accessToken(), idToken),
+            )
+        }.isInstanceOf(InternalAuthenticationServiceException::class.java)
+            .hasMessage("OIDC provider returned no user.")
     }
 
     private fun kakaoClientRegistration(

--- a/back/src/test/kotlin/com/back/global/security/config/oauth2/OAuth2AuthorizationRequestResolverTest.kt
+++ b/back/src/test/kotlin/com/back/global/security/config/oauth2/OAuth2AuthorizationRequestResolverTest.kt
@@ -49,7 +49,7 @@ class OAuth2AuthorizationRequestResolverTest {
             .isNotBlank()
         assertThat(authorizationRequest.attributes[OidcParameterNames.NONCE] as String)
             .isNotBlank()
-        assertThat(OAuth2State.decode(authorizationRequest.state).redirectUrl).isEqualTo("/admin")
+        assertThat(OAuth2State.decode(authorizationRequest.state!!).redirectUrl).isEqualTo("/admin")
     }
 
     private fun kakaoClientRegistration(): ClientRegistration {


### PR DESCRIPTION
## 관련 이슈

close #1139

## 작업 배경

- Backend Spring Boot와 Java runtime 기준을 출시 전 지원선으로 갱신한다.
- Kotlin 2.2.21은 JVM target 25를 아직 지원하지 않아 runtime/toolchain은 25로 올리고 Java bytecode release는 24로 고정한다.

## 작업 내용

- Spring Boot Gradle plugin을 4.1.0으로 올리고 Java toolchain을 25로 갱신했다.
- Backend CI, Security, SonarCloud workflow의 JDK를 Temurin 25로 맞췄다.
- Backend Docker image를 Temurin 25 digest로 갱신하고 Spring Boot 4.1 `tools` jarmode 추출 구조에 맞춰 runtime 실행 방식을 `java -jar app.jar`로 바꿨다.
- Spring Security 7.1 API 변화에 맞춰 OAuth2 resolver signature와 OAuth2/OIDC user nullability 처리를 명시화했다.
- README backend prerequisite을 Java 25 LTS로 갱신했다.

## 검증

- 실행한 명령과 결과:
  - `docker buildx imagetools inspect eclipse-temurin:25-jdk`: index digest `sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64` 확인
  - Context7 Spring Boot 4.1.0 문서 확인: Java 25 지원 범위와 `-Djarmode=tools ... extract` 사용 확인
  - `./back/gradlew -p back ktlintCheck --no-daemon`: exit 0
  - `./back/gradlew -p back clean check --no-daemon`: exit 0
  - `docker build -f back/Dockerfile back`: exit 0
  - `YARN_IGNORE_ENGINES=1 git commit -m "build(back): Spring Boot Java runtime 검증선 갱신"`: pre-commit OpenAPI export와 `front` contract check 통과 후 commit 생성
  - `./back/gradlew -p back dependencyCheckAnalyze`: 로컬 NVD API key가 없어 데이터 갱신 대기 상태로 중단, PR Security workflow에서 secret 기반 검증 예정

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Java 25 image digest | local Docker | `docker buildx imagetools inspect eclipse-temurin:25-jdk` | digest `sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64` | 통과 |
| Backend lint | local macOS | `./back/gradlew -p back ktlintCheck --no-daemon` | terminal output `BUILD SUCCESSFUL` | 통과 |
| Backend test/check | local macOS | `./back/gradlew -p back clean check --no-daemon` | terminal output `BUILD SUCCESSFUL in 2m 9s` | 통과 |
| Backend Docker image | local Docker | `docker build -f back/Dockerfile back` | image export manifest `sha256:615a558aa8d402126931b991ef0c343edd3fc9bd57d0e464640c094422b6a791` | 통과 |
| Contract hook | local macOS | `YARN_IGNORE_ENGINES=1 git commit ...` | pre-commit OpenAPI export and `contracts:check` output | 통과 |
| Dependency scan | GitHub Actions | Security workflow | https://github.com/AquilaXk/aquila-blog/actions/runs/28348938567/job/83977743950 | 통과 |
| Backend CI | GitHub Actions | backend workflow | https://github.com/AquilaXk/aquila-blog/actions/runs/28348938643/job/83977744124 | 통과 |
| Static security analysis | GitHub Actions | CodeQL workflow | https://github.com/AquilaXk/aquila-blog/actions/runs/28348938567/job/83977743956 | 통과 |

## 리뷰어 메모

- Kotlin JVM target 25 미지원으로 Java compile release만 24로 고정했다.
- Spring Boot 4.1 추출 결과는 `/app/app/lib`와 `/app/app/app.jar` 구조라 기존 layer directory COPY를 제거했다.

## 리스크

- Runtime은 Java 25로 전환되지만 Kotlin bytecode target은 24다. Kotlin compiler가 25 target을 지원하면 별도 작업으로 맞출 수 있다.
- Local dependency scan은 NVD key 없는 환경에서 완료하지 못했으나 PR Security workflow에서 통과했다.
- 자동 리뷰가 quota 상태로 실제 review thread를 만들지 못했고, 외부 대체 리뷰 명령은 private diff 전송 정책으로 차단되어 merge 전 QA 결정이 필요하다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] 자동 리뷰 상태를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
