### PR TITLE
[Fix] 피드 카드 summary/category placeholder 노출 제거

### DIFF
--- a/front/e2e/smoke-feed-search.spec.ts
+++ b/front/e2e/smoke-feed-search.spec.ts
@@ -73,6 +73,35 @@ test.describe("core smoke feed and search", () => {
   await expect(firstCard.locator(".imageFallback")).toContainText("깨진 썸네일 fallback")
 })
 
+  test("피드 카드는 빈 summary/category placeholder를 실제 데이터처럼 렌더링하지 않는다", async ({ page }) => {
+  await mockFeedEndpoints(page)
+  await page.route("**/post/api/v1/posts/feed**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(
+        createExplorePage("빈 표시값 카드", "", {
+          category: [],
+          summary: "핵심 내용을 정리 중입니다.",
+          tags: [],
+          thumbnail: "https://cdn.example.invalid/empty-card.png",
+        })
+      ),
+    })
+  })
+  await page.route("https://cdn.example.invalid/empty-card.png", async (route) => route.abort("failed"))
+
+  await page.goto("/")
+
+  const firstCard = page.locator('[data-ui="feed-post-card"]').first()
+  await expect(firstCard.locator(".tagRow")).toHaveCount(0)
+  await expect(firstCard.locator(".summary")).toHaveCount(0)
+  await expect(firstCard.locator(".imageFallback")).toBeVisible()
+  await expect(firstCard.locator(".imageFallback")).toContainText("빈 표시값 카드")
+  await expect(firstCard.locator(".imageFallback")).not.toContainText("Engineering")
+  await expect(firstCard).not.toContainText("핵심 내용을 정리 중입니다.")
+})
+
   test("홈 topic rail은 실제 태그 count 상위 항목을 표시하고 tag 탐색으로 연결한다", async ({ page }) => {
   const capturedTag: string[] = []
 

--- a/front/src/routes/Feed/PostList/PostCard.tsx
+++ b/front/src/routes/Feed/PostList/PostCard.tsx
@@ -30,8 +30,9 @@ const toDisplayCategoryLabels = (post: TPost) => {
   const labels = [...(post.category ?? []), ...(post.tags ?? [])]
     .filter((tag) => !INTERNAL_CATEGORY_TAGS.has(tag))
     .map((tag) => splitCategoryDisplay(tag).label)
+    .filter(Boolean)
   const uniqueLabels = Array.from(new Set(labels))
-  return uniqueLabels.length > 0 ? uniqueLabels : ["Engineering"]
+  return uniqueLabels
 }
 
 const PostCard: React.FC<Props> = ({ data, layout = "regular", index = 0 }) => {
@@ -40,7 +41,7 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular", index = 0 }) => {
     data?.date?.start_date || data.createdTime,
     CONFIG.lang
   )
-  const summary = normalizeCardSummary(data.summary)
+  const summary = normalizeCardSummary(data.summary, { fallback: "" })
   const likesCount = data.likesCount ?? 0
   const commentsCount = data.commentsCount ?? 0
   const categoryLabels = toDisplayCategoryLabels(data)
@@ -86,19 +87,23 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular", index = 0 }) => {
           {String(index + 1).padStart(2, "0")}
         </span>
         <div className="content">
-          <div className="tagRow">
-            {categoryLabels.map((categoryLabel) => (
-              <span className="tag" key={categoryLabel}>
-                {categoryLabel.toUpperCase()}
-              </span>
-            ))}
-          </div>
+          {categoryLabels.length > 0 && (
+            <div className="tagRow">
+              {categoryLabels.map((categoryLabel) => (
+                <span className="tag" key={categoryLabel}>
+                  {categoryLabel.toUpperCase()}
+                </span>
+              ))}
+            </div>
+          )}
           <header>
             <h2>{data.title}</h2>
           </header>
-          <div className="summary">
-            <p>{summary}</p>
-          </div>
+          {summary && (
+            <div className="summary">
+              <p>{summary}</p>
+            </div>
+          )}
           <div className="meta">
             <span>{createdAtText}</span>
             <span className="dot">·</span>
@@ -135,8 +140,8 @@ const PostCard: React.FC<Props> = ({ data, layout = "regular", index = 0 }) => {
                 }}
               />
             ) : (
-              <div className="imageFallback" aria-hidden="true">
-                <span className="coverCategory">{coverCategoryLabel}</span>
+              <div className="imageFallback" data-ui="feed-card-brand-cover" aria-hidden="true">
+                {coverCategoryLabel && <span className="coverCategory">{coverCategoryLabel}</span>}
                 <strong>{data.title}</strong>
                 <span className="coverBrand">AquilaLog</span>
               </div>


### PR DESCRIPTION
## 🔗 Related Issue
- close #1192

## 📝 Summary
- 피드 카드에서 빈 summary/category를 실제 데이터처럼 보이게 하던 placeholder 표시를 제거했습니다.
- category/tags가 없으면 tag row를 숨기고, summary가 없거나 placeholder 문구면 summary 영역을 렌더링하지 않습니다.

## 🛠 Changes
- `PostCard`의 빈 category 기본값 `Engineering`을 제거했습니다.
- 카드 summary는 표시 fallback 없이 정규화하고, 빈 값이면 영역 자체를 생략합니다.
- thumbnail fallback은 category가 없어도 제목과 `AquilaLog` 중심으로 유지됩니다.
- 빈 summary/category fixture e2e를 추가해 tag row, summary 영역, `Engineering` 문구가 렌더링되지 않는 것을 검증합니다.

## 🎯 Scope
- [x] Frontend
- [ ] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [ ] Infra / CI / Ops
- [ ] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [ ] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `PATH=/Users/aquila/.jetbrains-codegpt/node-v20.11.1-darwin-arm64/bin:$PATH yarn --cwd front playwright:preflight`: exit 0
- `PATH=/Users/aquila/.jetbrains-codegpt/node-v20.11.1-darwin-arm64/bin:$PATH yarn --cwd front playwright test e2e/smoke-feed-search.spec.ts --workers=1`: 13 passed, exit 0, 2회 연속 통과
- `PATH=/Users/aquila/.jetbrains-codegpt/node-v20.11.1-darwin-arm64/bin:$PATH yarn --cwd front build`: exit 0, 2회 연속 통과
- `PATH=/Users/aquila/.jetbrains-codegpt/node-v20.11.1-darwin-arm64/bin:$PATH yarn --cwd front check:bundle-size`: /, /posts/[id], /admin raw/gzip/brotli 모두 OK, 2회 연속 통과

## 📸 Screenshot / API Example
- 별도 스크린샷 대신 fixture e2e에서 빈 summary/category 카드의 DOM을 직접 검증했습니다: `.tagRow` 0개, `.summary` 0개, thumbnail fallback 표시, `Engineering`/`핵심 내용을 정리 중입니다.` 미노출.

## ⚠️ Risk & Rollback
- 예상 리스크: summary/category 부재 카드의 세로 여백이 기존 placeholder 표시 때보다 줄어듭니다.
- 롤백 방법: 이 PR의 `PostCard` 렌더링 조건과 e2e fixture 변경을 되돌립니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 [코드 주석 정책](https://github.com/AquilaXk/aquila-blog/blob/main/docs/design/code-comment-policy.md)에 맞는 이유/불변조건/운영 영향을 설명하는가?