### PR TITLE
[Fix] 공개 프로필 static fallback 캐시와 관측 강화

### DIFF
--- a/front/e2e/smoke-public-shell.spec.ts
+++ b/front/e2e/smoke-public-shell.spec.ts
@@ -234,10 +234,13 @@ test.describe("core smoke public shell", () => {
   )
   expect(homePageSource).toContain("resolveStaticAdminProfileSeed")
   expect(homePageSource).toContain("initialAdminProfileSource")
+  expect(homePageSource).toContain('initialAdminProfileSource === "static-fallback"')
   expect(aboutPageSource).toContain("initialAdminProfileSource")
+  expect(aboutPageSource).toContain("resolvePublicAdminProfileCacheControl")
   expect(postDetailPageSource).toContain("queryKey.adminProfile()")
   expect(postDetailPageSource).toContain("initialAdminProfile")
   expect(postDetailPageSource).toContain('initialAdminProfileSource === "static-fallback"')
+  expect(appSource).toContain("shouldRefetchAdminProfileSource")
   expect(appSource).toContain("initialAdminProfileShouldRefetch")
   expect(rootLayoutSource).toContain('pathname[1] !== "_"')
   expect(rootLayoutSource).toContain(
@@ -282,6 +285,32 @@ test.describe("core smoke public shell", () => {
     profile: { blogDesign: "legacy", legacyBlogScheme: "dark" },
     source: "static-fallback",
   })
+})
+
+  test("about fallback profile 응답은 public cache로 저장하지 않는다", async ({ page }) => {
+  await page.route("**/member/api/v1/auth/me", async (route) => {
+    await route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({ resultCode: "401-1", msg: "unauthorized" }),
+    })
+  })
+  await page.route("**/member/api/v1/members/adminProfile", async (route) => {
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ resultCode: "503-1", msg: "profile unavailable" }),
+    })
+  })
+
+  const staticFallbackResponse = await page.goto("/about")
+  expect(staticFallbackResponse?.headers()["cache-control"]).toBe("private, no-store")
+  expect(staticFallbackResponse?.headers()["server-timing"]).toContain('desc="static-fallback"')
+
+  await addPublicAboutSnapshotCookie(page)
+  const cookieSnapshotResponse = await page.goto("/about")
+  expect(cookieSnapshotResponse?.headers()["cache-control"]).toBe("private, no-store")
+  expect(cookieSnapshotResponse?.headers()["server-timing"]).toContain('desc="cookie-snapshot"')
 })
 
   test("about 자기소개 문구는 작성 개행을 유지하는 white-space 계약을 가진다", async ({ page }) => {

--- a/front/src/libs/adminProfileSource.ts
+++ b/front/src/libs/adminProfileSource.ts
@@ -1,0 +1,8 @@
+export type StaticAdminProfileSeedSource = "published" | "static-fallback"
+export type PublicAdminProfileSource =
+  | StaticAdminProfileSeedSource
+  | "cookie-snapshot"
+
+export const shouldRefetchAdminProfileSource = (
+  source?: PublicAdminProfileSource | null
+) => source !== "published"

--- a/front/src/libs/server/adminProfile.ts
+++ b/front/src/libs/server/adminProfile.ts
@@ -8,13 +8,12 @@ import {
   normalizeBlogDesign,
   normalizeLegacyBlogScheme,
 } from "src/libs/profileWorkspace"
+import type { PublicAdminProfileSource, StaticAdminProfileSeedSource } from "src/libs/adminProfileSource"
 import { serverApiFetch } from "./backend"
 
 type FetchServerAdminProfileOptions = {
   timeoutMs?: number
 }
-
-export type StaticAdminProfileSeedSource = "published" | "static-fallback"
 
 type StaticAdminProfileSeed = {
   profile: AdminProfile
@@ -25,6 +24,21 @@ type FetchStaticAdminProfile = () => Promise<AdminProfile>
 
 const ADMIN_PROFILE_SNAPSHOT_COOKIE = "admin_profile_snapshot_v1"
 const ADMIN_PROFILE_SNAPSHOT_MAX_STALE_MS = 1000 * 60 * 60 * 6
+const PUBLISHED_PROFILE_CACHE_CONTROL = "public, s-maxage=60, stale-while-revalidate=300"
+const TRANSIENT_PROFILE_CACHE_CONTROL = "private, no-store"
+
+export const resolvePublicAdminProfileCacheControl = ({
+  debugSsr,
+  hasAuthCookie,
+  source,
+}: {
+  debugSsr: boolean
+  hasAuthCookie: boolean
+  source: PublicAdminProfileSource
+}) => {
+  if (debugSsr || hasAuthCookie || source !== "published") return TRANSIENT_PROFILE_CACHE_CONTROL
+  return PUBLISHED_PROFILE_CACHE_CONTROL
+}
 
 const readCookieValue = (req: IncomingMessage, key: string) => {
   const rawCookie = req.headers.cookie || ""
@@ -178,6 +192,6 @@ export const resolvePublicAdminProfileSnapshot = (req: IncomingMessage) => {
 
   return {
     profile: buildStaticAdminProfileSnapshot(),
-    source: "static-snapshot" as const,
+    source: "static-fallback" as const,
   }
 }

--- a/front/src/libs/server/guestPage.ts
+++ b/front/src/libs/server/guestPage.ts
@@ -7,13 +7,13 @@ import type { AdminProfile } from "src/hooks/useAdminProfile"
 import {
   fetchServerAdminProfile,
   resolvePublicAdminProfileSnapshot,
-  type StaticAdminProfileSeedSource,
 } from "./adminProfile"
+import type { PublicAdminProfileSource } from "src/libs/adminProfileSource"
 
 export type GuestPageProps = {
   dehydratedState: DehydratedState
   initialProfileSnapshot: AdminProfile | null
-  initialAdminProfileSource: StaticAdminProfileSeedSource
+  initialAdminProfileSource: PublicAdminProfileSource
 }
 
 export const getGuestPageProps = async (
@@ -33,8 +33,9 @@ export const getGuestPageProps = async (
   const fallbackProfileSnapshot = resolvePublicAdminProfileSnapshot(req)
   const publishedProfile = await fetchServerAdminProfile(req, { timeoutMs: 900 })
   const initialProfileSnapshot = publishedProfile ?? fallbackProfileSnapshot.profile
-  const initialAdminProfileSource: StaticAdminProfileSeedSource =
-    publishedProfile || fallbackProfileSnapshot.source === "cookie-snapshot" ? "published" : "static-fallback"
+  const initialAdminProfileSource: PublicAdminProfileSource = publishedProfile
+    ? "published"
+    : fallbackProfileSnapshot.source
 
   return {
     props: {

--- a/front/src/libs/server/postDetailPage.ts
+++ b/front/src/libs/server/postDetailPage.ts
@@ -8,8 +8,8 @@ import type { AdminProfile } from "src/hooks/useAdminProfile"
 import { createQueryClient } from "src/libs/react-query"
 import {
   resolveStaticAdminProfileSeed,
-  type StaticAdminProfileSeedSource,
 } from "src/libs/server/adminProfile"
+import type { StaticAdminProfileSeedSource } from "src/libs/adminProfileSource"
 import { TPostComment } from "src/types"
 
 export { resolveStaticAdminProfileSeed } from "src/libs/server/adminProfile"
@@ -107,6 +107,7 @@ export const buildCanonicalPostDetailStaticPaths = async (): Promise<GetStaticPa
         pageSize: DETAIL_PREBUILD_COUNT,
       })
     } catch {
+      console.warn("[post-detail-static-paths] bootstrap failed; using blocking fallback only")
       return {
         posts: [],
       }

--- a/front/src/pages/_app.tsx
+++ b/front/src/pages/_app.tsx
@@ -11,6 +11,8 @@ import { GlobalErrorBoundary } from "src/components/error/ErrorBoundary"
 import createEmotionCache from "src/libs/emotion/createEmotionCache"
 import { useOptionalTrackingConsent } from "src/libs/privacy/optionalTrackingConsent"
 import { createQueryClient } from "src/libs/react-query"
+import type { PublicAdminProfileSource } from "src/libs/adminProfileSource"
+import { shouldRefetchAdminProfileSource } from "src/libs/adminProfileSource"
 import { useState } from "react"
 import "katex/dist/katex.min.css"
 
@@ -25,14 +27,14 @@ const OptionalVercelTelemetry = dynamic(
 type AppPageProps = AppPropsWithLayout["pageProps"] & {
   initialAdminProfile?: AdminProfile | null
   initialProfileSnapshot?: AdminProfile | null
-  initialAdminProfileSource?: "published" | "static-fallback"
+  initialAdminProfileSource?: PublicAdminProfileSource
 }
 
 function App({ Component, pageProps, emotionCache = clientSideEmotionCache }: AppPropsWithLayout) {
   const getLayout = Component.getLayout || ((page) => page)
   const appPageProps = pageProps as AppPageProps
   const initialAdminProfile = appPageProps.initialAdminProfile ?? appPageProps.initialProfileSnapshot ?? null
-  const initialAdminProfileShouldRefetch = appPageProps.initialAdminProfileSource === "static-fallback"
+  const initialAdminProfileShouldRefetch = shouldRefetchAdminProfileSource(appPageProps.initialAdminProfileSource)
   const [queryClient] = useState(createQueryClient)
   const router = useRouter()
   const optionalTrackingAllowed = useOptionalTrackingConsent()

--- a/front/src/pages/about.tsx
+++ b/front/src/pages/about.tsx
@@ -21,9 +21,10 @@ import {
   buildStaticAdminProfileSnapshot,
   fetchServerAdminProfile,
   hasServerAuthCookie,
+  resolvePublicAdminProfileCacheControl,
   resolvePublicAdminProfileSnapshot,
-  type StaticAdminProfileSeedSource,
 } from "src/libs/server/adminProfile"
+import { shouldRefetchAdminProfileSource, type PublicAdminProfileSource } from "src/libs/adminProfileSource"
 import { appendSsrDebugTiming, isSsrDebugEnabled, timed } from "src/libs/server/serverTiming"
 import { resolveContactLinks, resolveRenderableProfileLinkHref, resolveServiceLinks } from "src/libs/utils/profileCardLinks"
 
@@ -43,14 +44,18 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
       : hasAuthCookie
         ? buildStaticAdminProfileSnapshot()
         : fallbackProfileSnapshot?.profile || buildStaticAdminProfileSnapshot()
-  const initialAdminProfileSource: StaticAdminProfileSeedSource =
+  const initialAdminProfileSource: PublicAdminProfileSource =
     adminProfileResult.ok && adminProfileResult.value
       ? "published"
-      : "static-fallback"
+      : fallbackProfileSnapshot?.source || "static-fallback"
 
   res.setHeader(
     "Cache-Control",
-    !debugSsr && !hasAuthCookie ? "public, s-maxage=60, stale-while-revalidate=300" : "private, no-store"
+    resolvePublicAdminProfileCacheControl({
+      debugSsr,
+      hasAuthCookie,
+      source: initialAdminProfileSource,
+    })
   )
   appendSsrDebugTiming(req, res, [
     {
@@ -78,11 +83,11 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
 
 type AboutPageProps = {
   initialAdminProfile: AdminProfile | null
-  initialAdminProfileSource: StaticAdminProfileSeedSource
+  initialAdminProfileSource: PublicAdminProfileSource
 }
 
 const AboutPage: NextPageWithLayout<AboutPageProps> = ({ initialAdminProfile, initialAdminProfileSource }) => {
-  const shouldRefreshProfile = initialAdminProfileSource !== "published"
+  const shouldRefreshProfile = shouldRefetchAdminProfileSource(initialAdminProfileSource)
   const adminProfile = useAdminProfile(initialAdminProfile, {
     refetchOnMount: shouldRefreshProfile,
     staleTimeMs: shouldRefreshProfile ? 0 : undefined,

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -11,8 +11,8 @@ import { dehydrate } from "@tanstack/react-query"
 import { AdminProfile } from "src/hooks/useAdminProfile"
 import {
   resolveStaticAdminProfileSeed,
-  type StaticAdminProfileSeedSource,
 } from "src/libs/server/adminProfile"
+import type { StaticAdminProfileSeedSource } from "src/libs/adminProfileSource"
 import type { TPost } from "src/types"
 import { FEED_EXPLORE_PAGE_SIZE } from "src/constants/feed"
 import { setAdminProfileCache } from "src/hooks/useAdminProfile"
@@ -127,7 +127,9 @@ export const getStaticProps: GetStaticProps = async () => {
       initialHomeBootstrapStatus: status,
     },
     revalidate:
-      IS_QA_STATIC_SHELL_MODE || !postsLoaded ? HOME_QA_SHELL_REVALIDATE_SECONDS : HOME_ISR_REVALIDATE_SECONDS,
+      IS_QA_STATIC_SHELL_MODE || !postsLoaded || initialAdminProfileSource === "static-fallback"
+        ? HOME_QA_SHELL_REVALIDATE_SECONDS
+        : HOME_ISR_REVALIDATE_SECONDS,
   }
 }
 

--- a/front/src/pages/posts/[id].tsx
+++ b/front/src/pages/posts/[id].tsx
@@ -11,6 +11,7 @@ import {
   buildCanonicalPostDetailStaticPaths,
   buildCanonicalPostDetailStaticProps,
 } from "src/libs/server/postDetailPage"
+import type { PublicAdminProfileSource } from "src/libs/adminProfileSource"
 import { buildPostDetailMetadata } from "src/routes/Detail/PostDetail/postDetailMetadataModel"
 
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -25,7 +26,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 type DetailPageProps = {
   initialComments: TPostComment[] | null
   initialAdminProfile: AdminProfile | null
-  initialAdminProfileSource: "published" | "static-fallback"
+  initialAdminProfileSource: PublicAdminProfileSource
 }
 
 const CanonicalPostPage: NextPageWithLayout<DetailPageProps> = ({


### PR DESCRIPTION
## 관련 이슈

close #1191

## 작업 배경

- 공개 프로필 fetch 실패 또는 cookie snapshot 사용 시 source별 cache 정책이 분리되지 않아 static profile이 public cache/SEO 흐름에 남을 수 있었습니다.
- fallback 발생 여부를 테스트와 Server-Timing source로 확인할 수 있게 정리했습니다.

## 작업 내용

- `published`, `static-fallback`, `cookie-snapshot` source 타입을 분리하고 non-published source는 client refetch 대상으로 유지했습니다.
- `/about` SSR cache header를 source 기준으로 분기해 static/cookie fallback 응답은 `private, no-store`로 처리했습니다.
- 홈 ISR은 profile static fallback source면 짧은 revalidate로 낮추고, post detail prebuild bootstrap 실패는 warning을 남기게 했습니다.
- public shell e2e에 cache header와 Server-Timing source 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `PATH=/Users/aquila/.jetbrains-codegpt/node-v20.11.1-darwin-arm64/bin:$PATH yarn --cwd front playwright:preflight`: exit 0
  - `PATH=/Users/aquila/.jetbrains-codegpt/node-v20.11.1-darwin-arm64/bin:$PATH yarn --cwd front playwright test e2e/smoke-public-shell.spec.ts --grep 'about fallback profile 응답은 public cache로 저장하지 않는다' --workers=1`: 1 passed, exit 0, 2회 연속 통과
  - `PATH=/Users/aquila/.jetbrains-codegpt/node-v20.11.1-darwin-arm64/bin:$PATH yarn --cwd front playwright test e2e/smoke-public-shell.spec.ts --grep 'post detail adminProfile seed는 published와 fallback source를 구분한다' --workers=1`: 1 passed, exit 0, 2회 연속 통과
  - `PATH=/Users/aquila/.jetbrains-codegpt/node-v20.11.1-darwin-arm64/bin:$PATH yarn --cwd front playwright test e2e/smoke-public-shell.spec.ts --workers=1`: 9 passed, exit 0, 2회 연속 통과
  - `PATH=/Users/aquila/.jetbrains-codegpt/node-v20.11.1-darwin-arm64/bin:$PATH yarn --cwd front playwright test e2e/smoke.spec.ts e2e/mobile-layout.spec.ts --workers=1`: 8 passed, exit 0, 2회 연속 통과
  - `PATH=/Users/aquila/.jetbrains-codegpt/node-v20.11.1-darwin-arm64/bin:$PATH yarn --cwd front build`: exit 0, 2회 연속 통과
  - `PATH=/Users/aquila/.jetbrains-codegpt/node-v20.11.1-darwin-arm64/bin:$PATH yarn --cwd front check:bundle-size`: `/`, `/posts/[id]`, `/admin` raw/gzip/brotli OK, 2회 연속 통과
  - `gh pr checks 1197 --repo AquilaXk/aquila-blog --watch=false`: frontend-ci, backend-ci, CodeQL, SonarCloud, CodeRabbit, Vercel pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| About static fallback cache | Chromium local | backend profile 503 mock 후 `/about` 응답 header 확인 | `e2e/smoke-public-shell.spec.ts` `about fallback profile 응답은 public cache로 저장하지 않는다` | `Cache-Control: private, no-store`, `Server-Timing desc=static-fallback` 확인 |
| About cookie snapshot cache | Chromium local | cookie snapshot 설정 후 `/about` 응답 header 확인 | `e2e/smoke-public-shell.spec.ts` 동일 테스트 | `Cache-Control: private, no-store`, `Server-Timing desc=cookie-snapshot` 확인 |
| 공개 렌더링 회귀 | local build/e2e | build, bundle-size, public shell, smoke/mobile | 명령 출력: build exit 0, bundle-size OK, public shell 9 passed, smoke/mobile 8 passed | 통과 |
| CI/review gate | GitHub Actions / CodeRabbit | PR checks/review thread 확인 | `gh pr checks 1197`, unresolved active thread 없음 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `front/src/libs/adminProfileSource.ts`, `front/src/libs/server/adminProfile.ts`, `front/src/pages/about.tsx`, `front/e2e/smoke-public-shell.spec.ts`

## 리스크

- static/cookie fallback 상태에서는 public cache 대신 private no-store가 적용되어 장애 중 캐시 효율이 낮아질 수 있습니다. 정상 published profile source는 기존 public cache를 유지합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
