### PR TITLE
[Fix] FeedPostDto 매핑 실패 dummy row 제거

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryService.kt
@@ -2,8 +2,10 @@ package com.back.boundedContexts.post.application.service
 
 import com.back.boundedContexts.post.application.port.input.PostPublicReadQueryUseCase
 import com.back.boundedContexts.post.application.port.input.PostUseCase
+import com.back.boundedContexts.post.domain.Post
 import com.back.boundedContexts.post.dto.CursorFeedPageDto
 import com.back.boundedContexts.post.dto.FeedPostDto
+import com.back.boundedContexts.post.dto.FeedPostDtoMappingFailureType
 import com.back.boundedContexts.post.dto.PostWithContentDto
 import com.back.boundedContexts.post.dto.PublicPostDetailContentCacheDto
 import com.back.boundedContexts.post.dto.PublicPostDetailMetaCacheDto
@@ -291,7 +293,7 @@ class PostPublicReadQueryService(
                         authorId = authorId,
                         excludePostId = excludePostId,
                         limit = limit.coerceIn(1, 12),
-                    ).map(FeedPostDto::from)
+                    ).mapNotNull(::toFeedPostDto)
             }
         }
 
@@ -674,11 +676,18 @@ class PostPublicReadQueryService(
             (detail.contentHtml?.length ?: 0) +
             256
 
-    private fun toFeedPostDtoPage(postPage: PagedResult<com.back.boundedContexts.post.domain.Post>): PageDto<FeedPostDto> =
-        PageDto(postPage.map(FeedPostDto::from))
+    private fun toFeedPostDtoPage(postPage: PagedResult<Post>): PageDto<FeedPostDto> =
+        PageDto(
+            PagedResult(
+                content = postPage.content.mapNotNull(::toFeedPostDto),
+                page = postPage.page,
+                pageSize = postPage.pageSize,
+                totalElements = postPage.totalElements,
+            ),
+        )
 
     private fun toCursorFeedPageDto(
-        rows: List<com.back.boundedContexts.post.domain.Post>,
+        rows: List<Post>,
         pageSize: Int,
     ): CursorFeedPageDto {
         if (rows.isEmpty()) {
@@ -692,16 +701,50 @@ class PostPublicReadQueryService(
 
         val hasNext = rows.size > pageSize
         val currentRows = if (hasNext) rows.take(pageSize) else rows
-        val last = currentRows.last()
-        val nextCursor = if (hasNext) encodeCursor(last.createdAt, last.id) else null
+        val mappedRows =
+            currentRows.mapNotNull { row ->
+                toFeedPostDto(row)?.let { dto -> FeedPostRow(row, dto) }
+            }
+        val last = mappedRows.lastOrNull()?.post
+        val nextCursor = if (hasNext && last != null) encodeCursor(last.createdAt, last.id) else null
 
         return CursorFeedPageDto(
-            content = currentRows.map(FeedPostDto::from),
+            content = mappedRows.map(FeedPostRow::dto),
             pageSize = pageSize,
-            hasNext = hasNext,
+            hasNext = hasNext && last != null,
             nextCursor = nextCursor,
         )
     }
+
+    private fun toFeedPostDto(post: Post): FeedPostDto? =
+        runCatching {
+            FeedPostDto.from(post, ::recordFeedPostDtoMappingFailure)
+        }.getOrElse { exception ->
+            recordFeedPostDtoMappingFailure(post.id, FeedPostDtoMappingFailureType.CORE, exception)
+            null
+        }
+
+    private fun recordFeedPostDtoMappingFailure(
+        postId: Long,
+        failureType: FeedPostDtoMappingFailureType,
+        exception: Throwable,
+    ) {
+        logger.warn(
+            "post_feed_dto_mapping_failed postId={} failureType={} exception={}",
+            postId,
+            failureType.metricTag,
+            exception::class.java.simpleName,
+            exception,
+        )
+        meterRegistry
+            ?.counter("post.feed.dto.mapping.failure", "failureType", failureType.metricTag)
+            ?.increment()
+    }
+
+    private data class FeedPostRow(
+        val post: Post,
+        val dto: FeedPostDto,
+    )
 
     private fun requireCursorSort(sort: PostSearchSortType1): PostSearchSortType1 {
         if (sort == PostSearchSortType1.CREATED_AT || sort == PostSearchSortType1.CREATED_AT_ASC) {

--- a/back/src/main/kotlin/com/back/boundedContexts/post/dto/FeedPostDto.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/dto/FeedPostDto.kt
@@ -1,8 +1,6 @@
 package com.back.boundedContexts.post.dto
 
-import com.back.boundedContexts.member.domain.shared.memberMixin.defaultProfileImageUrl
 import com.back.boundedContexts.post.domain.Post
-import org.slf4j.LoggerFactory
 import java.time.Instant
 
 data class FeedPostDto(
@@ -25,57 +23,80 @@ data class FeedPostDto(
     val hitCount: Int,
 ) {
     companion object {
-        private val log = LoggerFactory.getLogger(FeedPostDto::class.java)
-        private const val FALLBACK_SUMMARY = "미리보기를 불러오지 못했습니다."
+        private const val UNAVAILABLE_SUMMARY = "미리보기를 불러오지 못했습니다."
 
-        fun from(post: Post): FeedPostDto =
+        fun from(
+            post: Post,
+            reportFailure: FeedPostDtoMappingFailureReporter = { _, _, _ -> },
+        ): FeedPostDto {
+            val postId = post.id
+            val content = post.content
+            val meta = extractMeta(postId, content, reportFailure)
+            val preview = extractPreview(postId, content, reportFailure)
+
+            return FeedPostDto(
+                id = postId,
+                createdAt = post.createdAt,
+                modifiedAt = post.modifiedAt,
+                authorId = post.author.id,
+                authorName = post.author.name,
+                authorUsername = post.author.username,
+                authorProfileImgUrl = post.author.profileImgUrlVersionedOrDefault,
+                title = post.title,
+                thumbnail = preview.thumbnail,
+                summary = preview.summary,
+                tags = meta.tags,
+                category = meta.categories,
+                published = post.published,
+                listed = post.listed,
+                likesCount = post.likesCount,
+                commentsCount = post.commentsCount,
+                hitCount = post.hitCount,
+            )
+        }
+
+        private fun extractMeta(
+            postId: Long,
+            content: String,
+            reportFailure: FeedPostDtoMappingFailureReporter,
+        ): PostMetaExtractor.PostMeta =
             runCatching {
-                val meta = PostMetaExtractor.extract(post.content)
-                val preview = PostPreviewExtractor.extract(post.content)
-
-                FeedPostDto(
-                    id = post.id,
-                    createdAt = post.createdAt,
-                    modifiedAt = post.modifiedAt,
-                    authorId = post.author.id,
-                    authorName = post.author.name,
-                    authorUsername = post.author.username,
-                    authorProfileImgUrl = post.author.profileImgUrlVersionedOrDefault,
-                    title = post.title,
-                    thumbnail = preview.thumbnail,
-                    summary = preview.summary,
-                    tags = meta.tags,
-                    category = meta.categories,
-                    published = post.published,
-                    listed = post.listed,
-                    likesCount = post.likesCount,
-                    commentsCount = post.commentsCount,
-                    hitCount = post.hitCount,
-                )
+                PostMetaExtractor.extract(content)
             }.getOrElse { exception ->
-                log.error("FeedPostDto mapping failed. postId={}", post.id, exception)
-
-                FeedPostDto(
-                    id = post.id,
-                    createdAt = post.createdAt,
-                    modifiedAt = post.modifiedAt,
-                    authorId = runCatching { post.author.id }.getOrDefault(0),
-                    authorName = runCatching { post.author.name }.getOrDefault("unknown"),
-                    authorUsername = runCatching { post.author.username }.getOrDefault("unknown"),
-                    authorProfileImgUrl =
-                        runCatching { post.author.profileImgUrlVersionedOrDefault }
-                            .getOrDefault(defaultProfileImageUrl()),
-                    title = runCatching { post.title }.getOrDefault("제목 없음"),
-                    thumbnail = null,
-                    summary = FALLBACK_SUMMARY,
+                reportFailure(postId, FeedPostDtoMappingFailureType.META, exception)
+                PostMetaExtractor.PostMeta(
                     tags = emptyList(),
-                    category = emptyList(),
-                    published = post.published,
-                    listed = post.listed,
-                    likesCount = runCatching { post.likesCount }.getOrDefault(0),
-                    commentsCount = runCatching { post.commentsCount }.getOrDefault(0),
-                    hitCount = runCatching { post.hitCount }.getOrDefault(0),
+                    categories = emptyList(),
+                )
+            }
+
+        private fun extractPreview(
+            postId: Long,
+            content: String,
+            reportFailure: FeedPostDtoMappingFailureReporter,
+        ): PostPreviewExtractor.Preview =
+            runCatching {
+                PostPreviewExtractor.extract(content)
+            }.getOrElse { exception ->
+                reportFailure(postId, FeedPostDtoMappingFailureType.PREVIEW, exception)
+                PostPreviewExtractor.Preview(
+                    thumbnail = null,
+                    summary = UNAVAILABLE_SUMMARY,
                 )
             }
     }
 }
+
+enum class FeedPostDtoMappingFailureType(
+    val metricTag: String,
+) {
+    PREVIEW("preview"),
+    META("meta"),
+    CORE("core"),
+}
+
+typealias FeedPostDtoMappingFailureReporter = (
+    postId: Long,
+    failureType: FeedPostDtoMappingFailureType,
+    exception: Throwable,
+) -> Unit

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryServiceFeedDtoMappingTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryServiceFeedDtoMappingTest.kt
@@ -1,0 +1,111 @@
+package com.back.boundedContexts.post.application.service
+
+import com.back.boundedContexts.member.domain.shared.Member
+import com.back.boundedContexts.post.application.port.input.PostUseCase
+import com.back.boundedContexts.post.domain.Post
+import com.back.global.app.AppConfig
+import com.back.standard.dto.page.PagedResult
+import com.back.standard.dto.post.type1.PostSearchSortType1
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.mock
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import java.time.Instant
+
+@DisplayName("공개 게시글 feed DTO 매핑")
+class PostPublicReadQueryServiceFeedDtoMappingTest {
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun initAppConfig() {
+            AppConfig(
+                siteBackUrl = "https://api.example.com",
+                siteFrontUrl = "https://example.com",
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("핵심 필드 매핑 실패 행은 feed 응답에서 제외하고 metric을 기록한다")
+    fun excludesCoreMappingFailureRowFromFeed() {
+        val postUseCase = mock(PostUseCase::class.java)
+        val meterRegistry = SimpleMeterRegistry()
+        val service = createService(postUseCase, meterRegistry)
+        val validPost = postByAuthor(id = 10L)
+        val invalidPost = postWithoutAuditTimestamps(id = 11L)
+        given(postUseCase.findPagedByKw("", PostSearchSortType1.CREATED_AT, 1, 10))
+            .willReturn(
+                PagedResult(
+                    content = listOf(validPost, invalidPost),
+                    page = 1,
+                    pageSize = 10,
+                    totalElements = 2,
+                ),
+            )
+
+        val page = service.getPublicFeed(1, 10, PostSearchSortType1.CREATED_AT)
+
+        assertThat(page.content.map { it.id }).containsExactly(10L)
+        assertThat(page.pageable.totalElements).isEqualTo(2)
+        assertThat(
+            meterRegistry
+                .get("post.feed.dto.mapping.failure")
+                .tag("failureType", "core")
+                .counter()
+                .count(),
+        ).isEqualTo(1.0)
+    }
+
+    private fun createService(
+        postUseCase: PostUseCase,
+        meterRegistry: SimpleMeterRegistry,
+    ): PostPublicReadQueryService =
+        PostPublicReadQueryService(
+            postUseCase = postUseCase,
+            postReadBulkheadService =
+                PostReadBulkheadService(
+                    enabled = false,
+                    acquireTimeoutMs = 0,
+                    feedMaxConcurrent = 1,
+                    exploreMaxConcurrent = 1,
+                    searchMaxConcurrent = 1,
+                    detailMaxConcurrent = 1,
+                    tagsMaxConcurrent = 1,
+                ),
+            cacheManager = ConcurrentMapCacheManager(),
+            meterRegistry = meterRegistry,
+            cursorSigningSecret = "test-secret",
+            detailContentCacheMaxChars = 120000,
+            detailSnapshotCacheMaxChars = 180000,
+        )
+
+    private fun postByAuthor(id: Long): Post =
+        postWithoutAuditTimestamps(id).apply {
+            createdAt = Instant.parse("2026-01-02T00:00:00Z")
+            modifiedAt = Instant.parse("2026-01-02T00:01:00Z")
+        }
+
+    private fun postWithoutAuditTimestamps(id: Long): Post =
+        Post(
+            id = id,
+            author =
+                Member(
+                    id = 1L,
+                    username = "aquila-login",
+                    password = null,
+                    nickname = "아퀼라",
+                    email = null,
+                ).apply {
+                    createdAt = Instant.parse("2026-01-01T00:00:00Z")
+                    modifiedAt = Instant.parse("2026-01-01T00:01:00Z")
+                },
+            title = "작성자 매핑",
+            content = "본문",
+            published = true,
+            listed = true,
+        )
+}

--- a/back/src/test/kotlin/com/back/boundedContexts/post/dto/PostAuthorDtoMappingTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/dto/PostAuthorDtoMappingTest.kt
@@ -4,6 +4,7 @@ import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.post.domain.Post
 import com.back.global.app.AppConfig
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -31,6 +32,47 @@ class PostAuthorDtoMappingTest {
 
         assertThat(dto.authorName).isEqualTo("아퀼라")
         assertThat(dto.authorUsername).isEqualTo("aquila-login")
+    }
+
+    @Test
+    @DisplayName("feed DTO는 핵심 필드 매핑 실패를 가짜 행으로 변환하지 않는다")
+    fun doesNotCreateDummyFeedRowWhenCoreMappingFails() {
+        val post = postByAuthor(username = "aquila-login", nickname = "아퀼라")
+        val uninitializedPost =
+            Post(
+                id = post.id,
+                author = post.author,
+                title = post.title,
+                content = post.content,
+                published = post.published,
+                listed = post.listed,
+            )
+
+        assertThatThrownBy { FeedPostDto.from(uninitializedPost) }
+            .isInstanceOf(UninitializedPropertyAccessException::class.java)
+    }
+
+    @Test
+    @DisplayName("feed DTO는 미리보기와 메타데이터 실패만 보조 필드로 제한한다")
+    fun keepsPreviewAndMetaFailuresInAuxiliaryFields() {
+        val post = postByAuthor(username = "aquila-login", nickname = "아퀼라")
+        val failureTypes = mutableListOf<FeedPostDtoMappingFailureType>()
+        setContentFieldToNull(post)
+
+        val dto =
+            FeedPostDto.from(post) { _, failureType, _ ->
+                failureTypes += failureType
+            }
+
+        assertThat(dto.authorName).isEqualTo("아퀼라")
+        assertThat(dto.authorUsername).isEqualTo("aquila-login")
+        assertThat(dto.thumbnail).isNull()
+        assertThat(dto.tags).isEmpty()
+        assertThat(dto.category).isEmpty()
+        assertThat(failureTypes).containsExactly(
+            FeedPostDtoMappingFailureType.META,
+            FeedPostDtoMappingFailureType.PREVIEW,
+        )
     }
 
     @Test
@@ -70,5 +112,12 @@ class PostAuthorDtoMappingTest {
             createdAt = Instant.parse("2026-01-02T00:00:00Z")
             modifiedAt = Instant.parse("2026-01-02T00:01:00Z")
         }
+    }
+
+    private fun setContentFieldToNull(post: Post) {
+        Post::class.java
+            .getDeclaredField("content")
+            .apply { isAccessible = true }
+            .set(post, null)
     }
 }


### PR DESCRIPTION
## 관련 이슈

close #1190

## 작업 배경

- `FeedPostDto.from()` 전체를 감싸던 catch-all fallback이 core field 실패까지 `unknown`, `제목 없음`, `0` count row로 바꿀 수 있었습니다.
- feed 응답은 전체 실패 대신 core mapping 실패 row만 제외하고, preview/meta 실패는 보조 필드 범위로 제한해야 합니다.

## 작업 내용

- `FeedPostDto.from()`의 dummy DTO fallback을 제거하고 core field mapping 실패는 호출자에게 예외로 전달되게 했습니다.
- preview/meta 추출 실패만 summary/thumbnail/tags/category 보조 필드 fallback으로 제한하고 `failureType=preview|meta` reporter를 호출하게 했습니다.
- public read service에서 feed DTO core failure row를 `mapNotNull`로 제외하고 `post.feed.dto.mapping.failure` counter와 warn log를 남기게 했습니다.
- core failure row 제외와 metric tag, preview/meta 보조 fallback 범위를 backend 테스트로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew ktlintCheck` at repo root: 실패, root Gradle wrapper 없음
  - `./back/gradlew ktlintCheck` at repo root: 실패, Gradle project root가 repo root로 잡힘
  - `(cd back && ./gradlew ktlintCheck)`: BUILD SUCCESSFUL, exit 0, 2회 연속 통과
  - `(cd back && ./gradlew test --tests com.back.boundedContexts.post.dto.PostAuthorDtoMappingTest --tests com.back.boundedContexts.post.application.service.PostPublicReadQueryServiceFeedDtoMappingTest)`: BUILD SUCCESSFUL, exit 0, 2회 연속 통과
  - `rg 'unknown|제목 없음|authorId = 0|defaultProfileImageUrl|FALLBACK_SUMMARY' back/src/main/kotlin/com/back/boundedContexts/post/dto/FeedPostDto.kt`: no matches, exit 1
  - `PATH=/Users/aquila/.jetbrains-codegpt/node-v20.11.1-darwin-arm64/bin:$PATH git commit -m 'fix(back): feed dto dummy row 제거'`: pre-commit OpenAPI export/test and `yarn contracts:check` passed, commit `30339fea`
  - `gh pr checks 1198 --repo AquilaXk/aquila-blog --watch=false`: backend-ci, CodeQL, CodeRabbit, SonarCloud, frontend-ci, privacy-drift-gate pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| ktlint | local darwin / JDK 25 | `back` Gradle wrapper | command output | 통과 |
| FeedPostDto core failure | local backend test | `PostAuthorDtoMappingTest` | `doesNotCreateDummyFeedRowWhenCoreMappingFails` | dummy row 미생성 확인 |
| preview/meta fallback 범위 | local backend test | `PostAuthorDtoMappingTest` | `keepsPreviewAndMetaFailuresInAuxiliaryFields` | `failureType=meta,preview` 확인 |
| core row 제외/metric | local backend test | `PostPublicReadQueryServiceFeedDtoMappingTest` | metric `post.feed.dto.mapping.failure{failureType=core}` count 1 | 통과 |
| dummy 문자열 제거 | local rg | FeedPostDto production file 검색 | no matches | 통과 |
| CI/review gate | GitHub Actions / CodeRabbit | PR checks/review thread 확인 | `gh pr checks 1198`, unresolved active thread 없음 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `FeedPostDto.from()`의 core/preview/meta 실패 경계와 `PostPublicReadQueryService.toFeedPostDto()`의 row 제외/metric 처리입니다.

## 리스크

- core field mapping이 깨진 post row는 feed 응답 content에서 제외됩니다. 기존처럼 dummy row로 보정하지 않으므로 장애가 metric/log로 드러납니다.
- page `totalElements`는 repository paging 원본 값을 유지합니다. content row 제외와 total count 차이는 core mapping failure가 있을 때만 발생합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
