### PR TITLE
[Fix] Feed DTO row 필터링 후 cursor/cache 보정

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryService.kt
@@ -218,11 +218,9 @@ class PostPublicReadQueryService(
                 if (isSearchNegativeCached(page, pageSize, sort, kw)) {
                     return@withSearchPermit PageDto(PagedResult(emptyList(), page, pageSize, 0))
                 }
-                val pageDto =
-                    toFeedPostDtoPage(
-                        postUseCase.findPagedByKw(kw, sort, page, pageSize),
-                    )
-                if (shouldCacheSearchNegative(page, kw) && pageDto.content.isEmpty()) {
+                val postPage = postUseCase.findPagedByKw(kw, sort, page, pageSize)
+                val pageDto = toFeedPostDtoPage(postPage)
+                if (shouldCacheSearchNegative(page, kw) && postPage.content.isEmpty()) {
                     cacheManager
                         .getCache(PostQueryCacheNames.SEARCH_NEGATIVE)
                         ?.put(buildSearchCacheKey(page, pageSize, sort, kw), true)
@@ -705,13 +703,17 @@ class PostPublicReadQueryService(
             currentRows.mapNotNull { row ->
                 toFeedPostDto(row)?.let { dto -> FeedPostRow(row, dto) }
             }
-        val last = mappedRows.lastOrNull()?.post
-        val nextCursor = if (hasNext && last != null) encodeCursor(last.createdAt, last.id) else null
+        val nextCursor =
+            if (hasNext) {
+                currentRows.lastOrNull()?.let { encodeCursor(it.createdAt, it.id) }
+            } else {
+                null
+            }
 
         return CursorFeedPageDto(
             content = mappedRows.map(FeedPostRow::dto),
             pageSize = pageSize,
-            hasNext = hasNext && last != null,
+            hasNext = hasNext && nextCursor != null,
             nextCursor = nextCursor,
         )
     }

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryServiceFeedDtoMappingTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryServiceFeedDtoMappingTest.kt
@@ -12,7 +12,9 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.then
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 import java.time.Instant
 
@@ -60,6 +62,63 @@ class PostPublicReadQueryServiceFeedDtoMappingTest {
         ).isEqualTo(1.0)
     }
 
+    @Test
+    @DisplayName("cursor feed는 제외된 row가 있어도 소비한 raw boundary로 다음 cursor를 만든다")
+    fun advancesCursorByConsumedRawBoundaryWhenRowIsFiltered() {
+        val postUseCase = mock(PostUseCase::class.java)
+        val meterRegistry = SimpleMeterRegistry()
+        val service = createService(postUseCase, meterRegistry)
+        val invalidBoundaryPost = postWithMissingAuthor(id = 20L)
+        val nextRawPost = postByAuthor(id = 21L)
+        given(
+            postUseCase.findPublicByCursor(
+                cursorCreatedAt = null,
+                cursorId = null,
+                limit = 2,
+                sort = PostSearchSortType1.CREATED_AT,
+            ),
+        ).willReturn(listOf(invalidBoundaryPost, nextRawPost))
+
+        val page = service.getPublicFeedByCursor(null, 1, PostSearchSortType1.CREATED_AT)
+
+        assertThat(page.content).isEmpty()
+        assertThat(page.hasNext).isTrue()
+        assertThat(page.nextCursor).isNotBlank()
+        assertThat(
+            meterRegistry
+                .get("post.feed.dto.mapping.failure")
+                .tag("failureType", "core")
+                .counter()
+                .count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    @DisplayName("search는 매핑 실패로 빈 응답이 되어도 negative cache를 기록하지 않는다")
+    fun doesNotNegativeCacheSearchWhenRowsAreFilteredByMappingFailure() {
+        val postUseCase = mock(PostUseCase::class.java)
+        val service = createService(postUseCase, SimpleMeterRegistry())
+        val invalidPost = postWithMissingAuthor(id = 30L)
+        given(postUseCase.findPagedByKw("kw", PostSearchSortType1.CREATED_AT, 1, 10))
+            .willReturn(
+                PagedResult(
+                    content = listOf(invalidPost),
+                    page = 1,
+                    pageSize = 10,
+                    totalElements = 1,
+                ),
+            )
+
+        val firstPage = service.getPublicSearch(1, 10, "kw", PostSearchSortType1.CREATED_AT)
+        val secondPage = service.getPublicSearch(1, 10, "kw", PostSearchSortType1.CREATED_AT)
+
+        assertThat(firstPage.content).isEmpty()
+        assertThat(secondPage.content).isEmpty()
+        then(postUseCase)
+            .should(times(2))
+            .findPagedByKw("kw", PostSearchSortType1.CREATED_AT, 1, 10)
+    }
+
     private fun createService(
         postUseCase: PostUseCase,
         meterRegistry: SimpleMeterRegistry,
@@ -87,6 +146,14 @@ class PostPublicReadQueryServiceFeedDtoMappingTest {
         postWithoutAuditTimestamps(id).apply {
             createdAt = Instant.parse("2026-01-02T00:00:00Z")
             modifiedAt = Instant.parse("2026-01-02T00:01:00Z")
+        }
+
+    private fun postWithMissingAuthor(id: Long): Post =
+        postByAuthor(id).also { post ->
+            Post::class.java
+                .getDeclaredField("author")
+                .apply { isAccessible = true }
+                .set(post, null)
         }
 
     private fun postWithoutAuditTimestamps(id: Long): Post =

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryServiceFeedDtoMappingTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryServiceFeedDtoMappingTest.kt
@@ -78,12 +78,23 @@ class PostPublicReadQueryServiceFeedDtoMappingTest {
                 sort = PostSearchSortType1.CREATED_AT,
             ),
         ).willReturn(listOf(invalidBoundaryPost, nextRawPost))
+        given(
+            postUseCase.findPublicByCursor(
+                cursorCreatedAt = Instant.parse("2026-01-02T00:00:00Z"),
+                cursorId = 20L,
+                limit = 2,
+                sort = PostSearchSortType1.CREATED_AT,
+            ),
+        ).willReturn(listOf(nextRawPost))
 
         val page = service.getPublicFeedByCursor(null, 1, PostSearchSortType1.CREATED_AT)
+        val nextPage = service.getPublicFeedByCursor(page.nextCursor, 1, PostSearchSortType1.CREATED_AT)
 
         assertThat(page.content).isEmpty()
         assertThat(page.hasNext).isTrue()
         assertThat(page.nextCursor).isNotBlank()
+        assertThat(nextPage.content.map { it.id }).containsExactly(21L)
+        assertThat(nextPage.hasNext).isFalse()
         assertThat(
             meterRegistry
                 .get("post.feed.dto.mapping.failure")


### PR DESCRIPTION
## 관련 이슈

close #1199

## 작업 배경

- #1198에서 DTO 매핑 실패 row를 제외한 뒤 cursor pagination과 search negative cache가 mapped content만 기준으로 판단할 수 있는 문제가 확인됐습니다.

## 작업 내용

- search negative cache 기록 조건을 mapped DTO 결과가 아니라 repository raw page empty 여부로 변경했습니다.
- cursor feed의 `nextCursor`를 마지막 mapped row가 아니라 소비한 raw boundary row 기준으로 계산하도록 보정했습니다.
- filtered row가 page boundary에 있어도 cursor가 전진하는 테스트를 추가했습니다.
- raw result가 있는데 DTO mapping 실패로 empty response가 된 search 요청은 negative cache를 기록하지 않는 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
- `back/gradlew -p back ktlintCheck`: BUILD SUCCESSFUL
- `back/gradlew -p back test --rerun-tasks --tests 'com.back.boundedContexts.post.application.service.PostPublicReadQueryServiceFeedDtoMappingTest'`: BUILD SUCCESSFUL, 2회 연속 통과
- `back/gradlew -p back test -PtestInfraMode=compose --rerun-tasks`: BUILD SUCCESSFUL
- commit hook: OpenAPI export + `yarn contracts:check` 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Kotlin style | local clean worktree | ktlintCheck | command output | 통과 |
| cursor/cache regression | local clean worktree | targeted JUnit 2회 | command output | 통과 |
| backend regression | local clean worktree compose infra | full backend test | command output | 통과 |
| OpenAPI contract | local clean worktree | commit hook | command output | 통과 |
| Screenshot | N/A | backend service 변경 | 증거 불필요 사유: UI 변경 없음 | N/A |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `getPublicSearch()` negative cache 조건과 `toCursorFeedPageDto()` cursor boundary 계산

## 리스크

- mapping 실패 row가 boundary에 있으면 응답 content가 비어도 `hasNext=true`가 될 수 있습니다. 이는 소비한 raw row를 건너뛰기 위한 의도된 동작입니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 대체 리뷰 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 공개 피드와 검색 결과에서 일부 항목이 표시되지 않더라도, 다음 페이지 정보가 더 안정적으로 계산되도록 개선했습니다.
  * 매핑되지 않은 결과가 있어도 커서 기반 페이지네이션이 올바르게 이어지도록 조정했습니다.
  * 검색 결과가 비어 보이는 경우에도 불필요하게 다음 조회가 막히지 않도록 동작을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->