### PR TITLE
[Fix] Cursor boundary audit timestamp 누락 방어

### DIFF
--- a/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryService.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryService.kt
@@ -105,7 +105,7 @@ class PostPublicReadQueryService(
                     postUseCase.findPublicByCursor(
                         cursorCreatedAt = parsedCursor?.createdAt,
                         cursorId = parsedCursor?.id,
-                        limit = safePageSize + 1,
+                        limit = safePageSize + 2,
                         sort = safeSort,
                     )
                 toCursorFeedPageDto(rows, safePageSize)
@@ -186,7 +186,7 @@ class PostPublicReadQueryService(
                         tag = normalizedTag,
                         cursorCreatedAt = parsedCursor?.createdAt,
                         cursorId = parsedCursor?.id,
-                        limit = safePageSize + 1,
+                        limit = safePageSize + 2,
                         sort = safeSort,
                     )
                 toCursorFeedPageDto(rows, safePageSize)
@@ -331,7 +331,7 @@ class PostPublicReadQueryService(
                             postUseCase.findPublicByCursor(
                                 cursorCreatedAt = null,
                                 cursorId = null,
-                                limit = safePageSize + 1,
+                                limit = safePageSize + 2,
                                 sort = safeSort,
                             )
                         } else {
@@ -339,7 +339,7 @@ class PostPublicReadQueryService(
                                 tag = normalizedTag,
                                 cursorCreatedAt = null,
                                 cursorId = null,
-                                limit = safePageSize + 1,
+                                limit = safePageSize + 2,
                                 sort = safeSort,
                             )
                         }
@@ -697,15 +697,25 @@ class PostPublicReadQueryService(
             )
         }
 
-        val hasNext = rows.size > pageSize
-        val currentRows = if (hasNext) rows.take(pageSize) else rows
+        val cursorRows = rows.mapNotNull(::toCursorPostRow)
+        if (cursorRows.isEmpty()) {
+            return CursorFeedPageDto(
+                content = emptyList(),
+                pageSize = pageSize,
+                hasNext = false,
+                nextCursor = null,
+            )
+        }
+
+        val hasNext = cursorRows.size > pageSize
+        val currentRows = cursorRows.take(pageSize)
         val mappedRows =
             currentRows.mapNotNull { row ->
-                toFeedPostDto(row)?.let { dto -> FeedPostRow(row, dto) }
+                toFeedPostDto(row.post)?.let { dto -> FeedPostRow(row.post, dto) }
             }
         val nextCursor =
             if (hasNext) {
-                currentRows.lastOrNull()?.let { encodeCursor(it.createdAt, it.id) }
+                currentRows.lastOrNull()?.let { encodeCursor(it.createdAt, it.post.id) }
             } else {
                 null
             }
@@ -746,6 +756,11 @@ class PostPublicReadQueryService(
     private data class FeedPostRow(
         val post: Post,
         val dto: FeedPostDto,
+    )
+
+    private data class CursorPostRow(
+        val post: Post,
+        val createdAt: Instant,
     )
 
     private fun requireCursorSort(sort: PostSearchSortType1): PostSearchSortType1 {
@@ -797,6 +812,17 @@ class PostPublicReadQueryService(
     ): String {
         val payload = "${createdAt.toEpochMilli()}:$id"
         return "$payload:${signCursorPayload(payload)}"
+    }
+
+    private fun toCursorPostRow(post: Post): CursorPostRow? {
+        val createdAt =
+            try {
+                post.createdAt
+            } catch (exception: UninitializedPropertyAccessException) {
+                recordFeedPostDtoMappingFailure(post.id, FeedPostDtoMappingFailureType.CORE, exception)
+                return null
+            }
+        return CursorPostRow(post, createdAt)
     }
 
     private fun signCursorPayload(payload: String): String {

--- a/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryServiceFeedDtoMappingTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/post/application/service/PostPublicReadQueryServiceFeedDtoMappingTest.kt
@@ -21,6 +21,8 @@ import java.time.Instant
 @DisplayName("공개 게시글 feed DTO 매핑")
 class PostPublicReadQueryServiceFeedDtoMappingTest {
     companion object {
+        private const val MAPPING_FAILURE_METRIC = "post.feed.dto.mapping.failure"
+
         @JvmStatic
         @BeforeAll
         fun initAppConfig() {
@@ -55,7 +57,7 @@ class PostPublicReadQueryServiceFeedDtoMappingTest {
         assertThat(page.pageable.totalElements).isEqualTo(2)
         assertThat(
             meterRegistry
-                .get("post.feed.dto.mapping.failure")
+                .get(MAPPING_FAILURE_METRIC)
                 .tag("failureType", "core")
                 .counter()
                 .count(),
@@ -74,7 +76,7 @@ class PostPublicReadQueryServiceFeedDtoMappingTest {
             postUseCase.findPublicByCursor(
                 cursorCreatedAt = null,
                 cursorId = null,
-                limit = 2,
+                limit = 3,
                 sort = PostSearchSortType1.CREATED_AT,
             ),
         ).willReturn(listOf(invalidBoundaryPost, nextRawPost))
@@ -82,7 +84,7 @@ class PostPublicReadQueryServiceFeedDtoMappingTest {
             postUseCase.findPublicByCursor(
                 cursorCreatedAt = Instant.parse("2026-01-02T00:00:00Z"),
                 cursorId = 20L,
-                limit = 2,
+                limit = 3,
                 sort = PostSearchSortType1.CREATED_AT,
             ),
         ).willReturn(listOf(nextRawPost))
@@ -97,7 +99,38 @@ class PostPublicReadQueryServiceFeedDtoMappingTest {
         assertThat(nextPage.hasNext).isFalse()
         assertThat(
             meterRegistry
-                .get("post.feed.dto.mapping.failure")
+                .get(MAPPING_FAILURE_METRIC)
+                .tag("failureType", "core")
+                .counter()
+                .count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    @DisplayName("cursor feed는 boundary row의 audit timestamp가 없어도 다음 row를 숨기지 않는다")
+    fun doesNotHideNextRowWhenFilteredBoundaryRowHasNoAuditTimestamp() {
+        val postUseCase = mock(PostUseCase::class.java)
+        val meterRegistry = SimpleMeterRegistry()
+        val service = createService(postUseCase, meterRegistry)
+        val invalidBoundaryPost = postWithoutAuditTimestamps(id = 22L)
+        val nextRawPost = postByAuthor(id = 23L)
+        given(
+            postUseCase.findPublicByCursor(
+                cursorCreatedAt = null,
+                cursorId = null,
+                limit = 3,
+                sort = PostSearchSortType1.CREATED_AT,
+            ),
+        ).willReturn(listOf(invalidBoundaryPost, nextRawPost))
+
+        val page = service.getPublicFeedByCursor(null, 1, PostSearchSortType1.CREATED_AT)
+
+        assertThat(page.content.map { it.id }).containsExactly(23L)
+        assertThat(page.hasNext).isFalse()
+        assertThat(page.nextCursor).isNull()
+        assertThat(
+            meterRegistry
+                .get(MAPPING_FAILURE_METRIC)
                 .tag("failureType", "core")
                 .counter()
                 .count(),


### PR DESCRIPTION
## 관련 이슈

close #1202

## 작업 배경

- #1200 이후 cursor feed에서 raw boundary row의 audit timestamp가 비어 있으면 cursor 생성 중 요청이 실패할 수 있는 경로를 확인했다.
- timestamp가 없는 row를 응답에서 제외하더라도 뒤의 정상 row와 cursor 진행은 숨기지 않아야 한다.

## 작업 내용

- cursor feed 변환 전에 cursor 생성 가능한 row만 분리한다.
- timestamp 누락 row는 mapping failure metric에 기록하고 cursor 후보에서 제외한다.
- raw over-fetch sentinel 기준으로 hasNext를 유지해 다음 페이지 진행 신호를 보존한다.
- timestamp 누락 boundary row가 있어도 다음 정상 row가 응답되는 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `back/gradlew -p back ktlintCheck`: BUILD SUCCESSFUL
  - `back/gradlew -p back test --rerun-tasks --tests com.back.boundedContexts.post.application.service.PostPublicReadQueryServiceFeedDtoMappingTest`: BUILD SUCCESSFUL, 2회 연속 통과
  - `back/gradlew -p back test -PtestInfraMode=compose --rerun-tasks`: BUILD SUCCESSFUL
  - commit hook `OpenApiContractExportTest`: BUILD SUCCESSFUL
  - commit hook `yarn contracts:check`: generated types are up-to-date
  - 추가 코드리뷰: actionable correctness issue 없음

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| ktlint | local | `back/gradlew -p back ktlintCheck` | local command output | BUILD SUCCESSFUL |
| cursor 회귀 테스트 | local | `back/gradlew -p back test --rerun-tasks --tests com.back.boundedContexts.post.application.service.PostPublicReadQueryServiceFeedDtoMappingTest` | local command output, 2회 실행 | BUILD SUCCESSFUL |
| backend 회귀 | local compose | `back/gradlew -p back test -PtestInfraMode=compose --rerun-tasks` | local command output | BUILD SUCCESSFUL |
| 계약 drift | local hook | `OpenApiContractExportTest`, `yarn contracts:check` | commit hook output | up-to-date |
| 코드리뷰 | local | 추가 코드리뷰 | local review output | actionable correctness issue 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `toCursorFeedPageDto`의 raw sentinel 기준 `hasNext` 유지와 `toCursorPostRow`의 timestamp 방어

## 리스크

- timestamp 누락 row가 over-fetch window에 섞이면 다음 페이지 요청이 1회 더 발생할 수 있다. 글을 숨기거나 500을 반환하는 것보다 낮은 리스크로 판단했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 대체 코드리뷰 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.