### PR TITLE
[Fix] Demo seed profile gate

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -93,6 +93,14 @@
 - `PostSearchCachePolicyResolver`는 빈 검색어는 `SEARCH_DEFAULT`, 길이 28자 이상 또는 token 4개 이상 또는 높은 unique ratio 검색어는 `SEARCH_NO_STORE`, 길이 16자 이상은 `SEARCH_SHORT`, 나머지는 `SEARCH_DEFAULT`로 분류한다.
 - `PostPublicReadCachePolicies`는 feed/explore/detail/bootstrap/tag/search/related author별 TTL을 가진다. 정책 변경 시 ETag seed builder와 cache invalidation scope가 같은 응답 변수를 반영하는지 함께 확인한다.
 
+### Demo seed 점검
+
+- 실행 조건: `local`/`dev`/`test` profile + `custom.bootstrap.seed-demo-data-enabled=true`
+- 운영 유사 DB 점검:
+  `select id, email, username, role from member where email in ('system@test.com','holding@test.com','admin@test.com','user1@test.com','user2@test.com','user3@test.com');`
+  `select id, title, published, listed from post where title in ('제목 1','제목 2','제목 3','비공개 글');`
+- 발견 시 외부 접근을 먼저 차단하고, 계정 권한 제거 또는 데이터 삭제 후 seed flag/profile 설정을 재확인한다.
+
 ### 업로드 retention 흐름
 
 게시글 이미지와 첨부파일 업로드는 `ApiV1PostImageController`, `PostImageStorageAdapter`, `UploadedFileRetentionService`가 나누어 처리한다.

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap/MemberNotProdInitData.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap/MemberNotProdInitData.kt
@@ -4,6 +4,7 @@ import com.back.boundedContexts.member.application.port.input.MemberUseCase
 import com.back.global.app.AdminProperties
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.ApplicationRunner
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
@@ -15,7 +16,12 @@ import org.springframework.transaction.annotation.Transactional
  * MemberNotProdInitData는 환경별 초기 데이터/부트스트랩 로직을 담당합니다.
  * 애플리케이션 기동 시 필요한 기본 상태를 안전하게 준비합니다.
  */
-@Profile("!prod")
+@Profile("local", "dev", "test")
+@ConditionalOnProperty(
+    prefix = "custom.bootstrap",
+    name = ["seed-demo-data-enabled"],
+    havingValue = "true",
+)
 @Configuration
 class MemberNotProdInitData(
     private val memberUseCase: MemberUseCase,

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap/MemberNotProdInitData.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap/MemberNotProdInitData.kt
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional
  * MemberNotProdInitData는 환경별 초기 데이터/부트스트랩 로직을 담당합니다.
  * 애플리케이션 기동 시 필요한 기본 상태를 안전하게 준비합니다.
  */
-@Profile("local", "dev", "test")
+@Profile("(local | dev | test) & !prod & !staging & !preview & !qa & !release")
 @ConditionalOnProperty(
     prefix = "custom.bootstrap",
     name = ["seed-demo-data-enabled"],

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/bootstrap/PostNotProdInitData.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/bootstrap/PostNotProdInitData.kt
@@ -7,6 +7,7 @@ import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
 import com.back.standard.extensions.getOrThrow
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.ApplicationRunner
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
@@ -18,7 +19,12 @@ import org.springframework.transaction.annotation.Transactional
  * PostNotProdInitData는 환경별 초기 데이터/부트스트랩 로직을 담당합니다.
  * 애플리케이션 기동 시 필요한 기본 상태를 안전하게 준비합니다.
  */
-@Profile("!prod")
+@Profile("local", "dev", "test")
+@ConditionalOnProperty(
+    prefix = "custom.bootstrap",
+    name = ["seed-demo-data-enabled"],
+    havingValue = "true",
+)
 @Configuration
 class PostNotProdInitData(
     private val memberUseCase: MemberUseCase,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/bootstrap/PostNotProdInitData.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/bootstrap/PostNotProdInitData.kt
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional
  * PostNotProdInitData는 환경별 초기 데이터/부트스트랩 로직을 담당합니다.
  * 애플리케이션 기동 시 필요한 기본 상태를 안전하게 준비합니다.
  */
-@Profile("local", "dev", "test")
+@Profile("(local | dev | test) & !prod & !staging & !preview & !qa & !release")
 @ConditionalOnProperty(
     prefix = "custom.bootstrap",
     name = ["seed-demo-data-enabled"],

--- a/back/src/main/resources/application-test.yaml
+++ b/back/src/main/resources/application-test.yaml
@@ -24,6 +24,8 @@ spring:
           batch_size: 0
           order_inserts: false
 custom:
+  bootstrap:
+    seed-demo-data-enabled: true
   member:
     signup:
       enabled: true

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/bootstrap/SeedDemoDataProfileConditionTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/bootstrap/SeedDemoDataProfileConditionTest.kt
@@ -59,4 +59,17 @@ class SeedDemoDataProfileConditionTest {
                 assertThat(context).doesNotHaveBean(PostNotProdInitData::class.java)
             }
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["prod,dev", "staging,test", "preview,local", "qa,dev", "release,test"])
+    fun `mixed prod-like profile does not load demo seed beans even with opt-in flag`(profiles: String) {
+        runner
+            .withPropertyValues(
+                "spring.profiles.active=$profiles",
+                "custom.bootstrap.seed-demo-data-enabled=true",
+            ).run { context ->
+                assertThat(context).doesNotHaveBean(MemberNotProdInitData::class.java)
+                assertThat(context).doesNotHaveBean(PostNotProdInitData::class.java)
+            }
+    }
 }

--- a/back/src/test/kotlin/com/back/boundedContexts/member/adapter/bootstrap/SeedDemoDataProfileConditionTest.kt
+++ b/back/src/test/kotlin/com/back/boundedContexts/member/adapter/bootstrap/SeedDemoDataProfileConditionTest.kt
@@ -1,0 +1,62 @@
+package com.back.boundedContexts.member.adapter.bootstrap
+
+import com.back.boundedContexts.member.application.port.input.MemberUseCase
+import com.back.boundedContexts.post.adapter.bootstrap.PostNotProdInitData
+import com.back.boundedContexts.post.application.port.input.PostUseCase
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.global.app.AdminProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.Mockito.mock
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import java.util.function.Supplier
+
+class SeedDemoDataProfileConditionTest {
+    private val runner =
+        ApplicationContextRunner()
+            .withUserConfiguration(
+                MemberNotProdInitData::class.java,
+                PostNotProdInitData::class.java,
+            ).withBean(MemberUseCase::class.java, Supplier { mock(MemberUseCase::class.java) })
+            .withBean(PostUseCase::class.java, Supplier { mock(PostUseCase::class.java) })
+            .withBean(PostRepositoryPort::class.java, Supplier { mock(PostRepositoryPort::class.java) })
+            .withBean(AdminProperties::class.java, Supplier { AdminProperties(username = "admin", email = "admin@test.com") })
+
+    @ParameterizedTest
+    @ValueSource(strings = ["local", "dev", "test"])
+    fun `explicit safe profile with opt-in flag loads demo seed beans`(profile: String) {
+        runner
+            .withPropertyValues(
+                "spring.profiles.active=$profile",
+                "custom.bootstrap.seed-demo-data-enabled=true",
+            ).run { context ->
+                assertThat(context).hasSingleBean(MemberNotProdInitData::class.java)
+                assertThat(context).hasSingleBean(PostNotProdInitData::class.java)
+            }
+    }
+
+    @Test
+    fun `safe profile without opt-in flag does not load demo seed beans`() {
+        runner
+            .withPropertyValues("spring.profiles.active=local")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(MemberNotProdInitData::class.java)
+                assertThat(context).doesNotHaveBean(PostNotProdInitData::class.java)
+            }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["staging", "preview", "qa", "release", "prod"])
+    fun `prod-like profile does not load demo seed beans even with opt-in flag`(profile: String) {
+        runner
+            .withPropertyValues(
+                "spring.profiles.active=$profile",
+                "custom.bootstrap.seed-demo-data-enabled=true",
+            ).run { context ->
+                assertThat(context).doesNotHaveBean(MemberNotProdInitData::class.java)
+                assertThat(context).doesNotHaveBean(PostNotProdInitData::class.java)
+            }
+    }
+}


### PR DESCRIPTION
## 관련 이슈

close #1188

## 작업 배경

- demo seed bootstrap이 `!prod` 조건에만 묶여 있어 staging, preview, qa, release 같은 비운영 공개 환경에서 샘플 계정과 글이 로드될 수 있었다.

## 작업 내용

- demo seed bootstrap profile을 `local`, `dev`, `test`로 제한했다.
- `custom.bootstrap.seed-demo-data-enabled=true` opt-in 조건을 추가했다.
- `test` profile 설정에는 기존 통합 테스트용 opt-in 값을 명시했다.
- profile/property 조합별 로드 여부를 검증하는 조건 테스트를 추가했다.
- 운영 점검용 SQL과 조치 절차를 `back/README.md`에 정리했다.

## 검증

- 실행한 명령과 결과:
- `back/gradlew -p back ktlintCheck`: exit 0
- `back/gradlew -p back test --rerun-tasks --tests com.back.boundedContexts.member.adapter.bootstrap.SeedDemoDataProfileConditionTest`: exit 0, 동일 조건 2회 연속 통과
- `back/gradlew -p back test -PtestInfraMode=compose --rerun-tasks`: exit 0
- `git diff --check`: exit 0
- changed-file blocked keyword scan: no matches
- commit hook: OpenAPI export + `yarn contracts:check` 통과
- Codex CLI re-review: actionable comments 0
- PR checks: Backend CI, Frontend CI, Security, SonarCloud, Vercel 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| style | local | `back/gradlew -p back ktlintCheck` | command output | 통과 |
| seed 조건 | local | `back/gradlew -p back test --rerun-tasks --tests com.back.boundedContexts.member.adapter.bootstrap.SeedDemoDataProfileConditionTest` | command output | 2회 연속 통과 |
| backend regression | local compose | `back/gradlew -p back test -PtestInfraMode=compose --rerun-tasks` | command output | 통과 |
| diff hygiene | local | `git diff --check` + blocked keyword scan | command output | 통과 |
| contracts | local hook | commit hook OpenAPI export + `yarn contracts:check` | hook output | 통과 |
| PR CI | GitHub Actions | Backend CI, Frontend CI, Security, SonarCloud, Vercel | PR #1204 checks | 통과 |
| review | GitHub PR review | Codex CLI fallback + re-review | PR #1204 reviews | initial 1 finding fixed, re-review 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `@Profile` expression과 `custom.bootstrap.seed-demo-data-enabled` 조건이 같이 걸리는지 확인하면 된다.

## 리스크

- 외부 공개 비운영 환경에서는 flag를 켜도 profile이 허용 목록 밖이면 demo seed가 로드되지 않는다.
- 로컬 개발과 테스트 profile은 flag가 필요하므로 새 환경 추가 시 설정 누락 여부를 확인해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.