### PR TITLE
[Fix] 비운영 초기 seed 데이터를 명시 허용 환경으로 제한

### DIFF
--- a/.github/workflows/reusable-backend-quality.yml
+++ b/.github/workflows/reusable-backend-quality.yml
@@ -156,7 +156,7 @@ jobs:
           exit 1
 
       - name: Test release planner guards
-        run: node --test tools/test/release-plan.test.mjs tools/test/flyway-deploy-safety.test.mjs tools/test/comment-jacoco-summary.test.mjs
+        run: node --test tools/test/release-plan.test.mjs tools/test/flyway-deploy-safety.test.mjs tools/test/comment-jacoco-summary.test.mjs tools/test/demo-seed-prod-gate.test.mjs
 
       - name: Guard forbidden AI docs and tool metadata
         run: bash tools/guards/check-forbidden-tracked-files.sh

--- a/back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap/MemberNotProdInitData.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap/MemberNotProdInitData.kt
@@ -2,12 +2,13 @@ package com.back.boundedContexts.member.adapter.bootstrap
 
 import com.back.boundedContexts.member.application.port.input.MemberUseCase
 import com.back.global.app.AdminProperties
+import com.back.global.app.config.DemoSeedDataCondition
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Conditional
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
-import org.springframework.context.annotation.Profile
 import org.springframework.core.annotation.Order
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional
  * MemberNotProdInitData는 환경별 초기 데이터/부트스트랩 로직을 담당합니다.
  * 애플리케이션 기동 시 필요한 기본 상태를 안전하게 준비합니다.
  */
-@Profile("!prod")
+@Conditional(DemoSeedDataCondition::class)
 @Configuration
 class MemberNotProdInitData(
     private val memberUseCase: MemberUseCase,

--- a/back/src/main/kotlin/com/back/boundedContexts/post/adapter/bootstrap/PostNotProdInitData.kt
+++ b/back/src/main/kotlin/com/back/boundedContexts/post/adapter/bootstrap/PostNotProdInitData.kt
@@ -4,13 +4,14 @@ import com.back.boundedContexts.member.application.port.input.MemberUseCase
 import com.back.boundedContexts.member.domain.shared.Member
 import com.back.boundedContexts.post.application.port.input.PostUseCase
 import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.global.app.config.DemoSeedDataCondition
 import com.back.standard.extensions.getOrThrow
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Conditional
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
-import org.springframework.context.annotation.Profile
 import org.springframework.core.annotation.Order
 import org.springframework.transaction.annotation.Transactional
 
@@ -18,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional
  * PostNotProdInitData는 환경별 초기 데이터/부트스트랩 로직을 담당합니다.
  * 애플리케이션 기동 시 필요한 기본 상태를 안전하게 준비합니다.
  */
-@Profile("!prod")
+@Conditional(DemoSeedDataCondition::class)
 @Configuration
 class PostNotProdInitData(
     private val memberUseCase: MemberUseCase,

--- a/back/src/main/kotlin/com/back/global/app/config/DemoSeedDataCondition.kt
+++ b/back/src/main/kotlin/com/back/global/app/config/DemoSeedDataCondition.kt
@@ -32,7 +32,7 @@ class DemoSeedDataCondition : Condition {
         fun isProdLikeProfile(profile: String): Boolean {
             val normalized = profile.trim().lowercase(Locale.ROOT)
             return DENIED_PROFILE_PREFIXES.any { denied ->
-                normalized == denied || normalized.startsWith("$denied-")
+                normalized.startsWith(denied)
             }
         }
     }

--- a/back/src/main/kotlin/com/back/global/app/config/DemoSeedDataCondition.kt
+++ b/back/src/main/kotlin/com/back/global/app/config/DemoSeedDataCondition.kt
@@ -1,0 +1,39 @@
+package com.back.global.app.config
+
+import org.springframework.context.annotation.Condition
+import org.springframework.context.annotation.ConditionContext
+import org.springframework.core.type.AnnotatedTypeMetadata
+import java.util.Locale
+
+class DemoSeedDataCondition : Condition {
+    override fun matches(
+        context: ConditionContext,
+        metadata: AnnotatedTypeMetadata,
+    ): Boolean {
+        val environment = context.environment
+        val enabled =
+            environment.getProperty(
+                "custom.bootstrap.seed-demo-data-enabled",
+                Boolean::class.java,
+                false,
+            )
+        if (!enabled) return false
+
+        val activeProfiles = environment.activeProfiles.map { it.lowercase(Locale.ROOT) }
+        if (activeProfiles.none { it in ALLOWED_PROFILES }) return false
+
+        return activeProfiles.none(::isProdLikeProfile)
+    }
+
+    companion object {
+        private val ALLOWED_PROFILES = setOf("local", "dev", "test")
+        private val DENIED_PROFILE_PREFIXES = listOf("prod", "staging", "preview", "qa", "release")
+
+        fun isProdLikeProfile(profile: String): Boolean {
+            val normalized = profile.trim().lowercase(Locale.ROOT)
+            return DENIED_PROFILE_PREFIXES.any { denied ->
+                normalized == denied || normalized.startsWith("$denied-")
+            }
+        }
+    }
+}

--- a/back/src/main/resources/application.yaml
+++ b/back/src/main/resources/application.yaml
@@ -135,6 +135,8 @@ management:
         task.processor.handler.duration: 0.95,0.99
         task.processor.fetch.limit: 0.95,0.99
 custom:
+  bootstrap:
+    seed-demo-data-enabled: ${CUSTOM__BOOTSTRAP__SEED_DEMO_DATA_ENABLED:false}
   dbBaseName: blog
   dev:
     cookieDomain: localhost

--- a/back/src/test/kotlin/com/back/global/app/config/DemoSeedDataConditionTest.kt
+++ b/back/src/test/kotlin/com/back/global/app/config/DemoSeedDataConditionTest.kt
@@ -48,27 +48,30 @@ class DemoSeedDataConditionTest {
 
     @Test
     fun `prod-like profiles do not load demo seed beans even when flag is true`() {
-        listOf("prod", "staging", "preview", "qa", "release", "release-candidate").forEach { profile ->
+        listOf("prod", "production", "staging", "preview", "qa", "release", "release-candidate", "releasecandidate")
+            .forEach { profile ->
+                contextRunner
+                    .withPropertyValues(
+                        "spring.profiles.active=$profile",
+                        "custom.bootstrap.seed-demo-data-enabled=true",
+                    ).run { context ->
+                        assertThat(context).doesNotHaveBean(MemberNotProdInitData::class.java)
+                        assertThat(context).doesNotHaveBean(PostNotProdInitData::class.java)
+                    }
+            }
+    }
+
+    @Test
+    fun `prod-like profile wins when combined with allowed profile`() {
+        listOf("test,preview", "dev,production", "test,releasecandidate").forEach { profiles ->
             contextRunner
                 .withPropertyValues(
-                    "spring.profiles.active=$profile",
+                    "spring.profiles.active=$profiles",
                     "custom.bootstrap.seed-demo-data-enabled=true",
                 ).run { context ->
                     assertThat(context).doesNotHaveBean(MemberNotProdInitData::class.java)
                     assertThat(context).doesNotHaveBean(PostNotProdInitData::class.java)
                 }
         }
-    }
-
-    @Test
-    fun `prod-like profile wins when combined with allowed profile`() {
-        contextRunner
-            .withPropertyValues(
-                "spring.profiles.active=test,preview",
-                "custom.bootstrap.seed-demo-data-enabled=true",
-            ).run { context ->
-                assertThat(context).doesNotHaveBean(MemberNotProdInitData::class.java)
-                assertThat(context).doesNotHaveBean(PostNotProdInitData::class.java)
-            }
     }
 }

--- a/back/src/test/kotlin/com/back/global/app/config/DemoSeedDataConditionTest.kt
+++ b/back/src/test/kotlin/com/back/global/app/config/DemoSeedDataConditionTest.kt
@@ -1,0 +1,74 @@
+package com.back.global.app.config
+
+import com.back.boundedContexts.member.adapter.bootstrap.MemberNotProdInitData
+import com.back.boundedContexts.member.application.port.input.MemberUseCase
+import com.back.boundedContexts.post.adapter.bootstrap.PostNotProdInitData
+import com.back.boundedContexts.post.application.port.input.PostUseCase
+import com.back.boundedContexts.post.application.port.output.PostRepositoryPort
+import com.back.global.app.AdminProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+@DisplayName("DemoSeedDataCondition 테스트")
+class DemoSeedDataConditionTest {
+    private val contextRunner =
+        ApplicationContextRunner()
+            .withUserConfiguration(
+                MemberNotProdInitData::class.java,
+                PostNotProdInitData::class.java,
+            ).withBean(MemberUseCase::class.java, { mock(MemberUseCase::class.java) })
+            .withBean(PostUseCase::class.java, { mock(PostUseCase::class.java) })
+            .withBean(PostRepositoryPort::class.java, { mock(PostRepositoryPort::class.java) })
+            .withBean(AdminProperties::class.java, { AdminProperties(username = "admin", email = "admin@test.com") })
+
+    @Test
+    fun `test profile and explicit flag load demo seed beans`() {
+        contextRunner
+            .withPropertyValues(
+                "spring.profiles.active=test",
+                "custom.bootstrap.seed-demo-data-enabled=true",
+            ).run { context ->
+                assertThat(context).hasSingleBean(MemberNotProdInitData::class.java)
+                assertThat(context).hasSingleBean(PostNotProdInitData::class.java)
+            }
+    }
+
+    @Test
+    fun `allowed profile without explicit flag does not load demo seed beans`() {
+        contextRunner
+            .withPropertyValues("spring.profiles.active=local")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(MemberNotProdInitData::class.java)
+                assertThat(context).doesNotHaveBean(PostNotProdInitData::class.java)
+            }
+    }
+
+    @Test
+    fun `prod-like profiles do not load demo seed beans even when flag is true`() {
+        listOf("prod", "staging", "preview", "qa", "release", "release-candidate").forEach { profile ->
+            contextRunner
+                .withPropertyValues(
+                    "spring.profiles.active=$profile",
+                    "custom.bootstrap.seed-demo-data-enabled=true",
+                ).run { context ->
+                    assertThat(context).doesNotHaveBean(MemberNotProdInitData::class.java)
+                    assertThat(context).doesNotHaveBean(PostNotProdInitData::class.java)
+                }
+        }
+    }
+
+    @Test
+    fun `prod-like profile wins when combined with allowed profile`() {
+        contextRunner
+            .withPropertyValues(
+                "spring.profiles.active=test,preview",
+                "custom.bootstrap.seed-demo-data-enabled=true",
+            ).run { context ->
+                assertThat(context).doesNotHaveBean(MemberNotProdInitData::class.java)
+                assertThat(context).doesNotHaveBean(PostNotProdInitData::class.java)
+            }
+    }
+}

--- a/back/src/test/kotlin/com/back/support/BaseIntegrationTest.kt
+++ b/back/src/test/kotlin/com/back/support/BaseIntegrationTest.kt
@@ -7,6 +7,7 @@ import org.springframework.test.context.TestPropertySource
 @TestPropertySource(
     properties = [
         "custom.task.processor.enabled=false",
+        "custom.bootstrap.seed-demo-data-enabled=true",
     ],
 )
 abstract class BaseIntegrationTest

--- a/docs/design/demo-seed-data-prod-like-check.md
+++ b/docs/design/demo-seed-data-prod-like-check.md
@@ -1,0 +1,34 @@
+# Demo Seed Data Prod-Like Check
+
+## 목적
+
+#1188 정책에 따라 demo seed 회원과 게시글은 `local`, `dev`, `test` profile에서 `custom.bootstrap.seed-demo-data-enabled=true`일 때만 생성되어야 한다. `staging`, `preview`, `qa`, `release*`, `prod*` profile이나 외부에 노출되는 운영 유사 DB에서는 아래 흔적이 없어야 한다.
+
+## 배포 전 설정 점검
+
+- `CUSTOM__BOOTSTRAP__SEED_DEMO_DATA_ENABLED`는 운영 유사 환경에서 설정하지 않거나 `false`로 둔다.
+- backend active profile에 `staging`, `preview`, `qa`, `release*`, `prod*`가 포함되면 demo seed bean은 flag가 `true`여도 로드되지 않아야 한다.
+- CI release gate는 `.github/workflows`, `deploy`, production application config에 `admin@test.com`, `user*@test.com`, `"1234"`, `제목 1`, `비공개 글` 같은 demo seed 흔적이 들어오면 실패해야 한다.
+
+## 기존 데이터 점검 Query
+
+운영 유사 DB에서 실제 schema/table 명을 확인한 뒤 실행한다. 기본 JPA table 명은 `member`, `post`다.
+
+```sql
+select id, email, login_id, nickname, is_admin
+from member
+where email in ('system@test.com', 'holding@test.com', 'admin@test.com', 'user1@test.com', 'user2@test.com', 'user3@test.com')
+   or login_id in ('system', 'holding', 'admin', 'user1', 'user2', 'user3');
+
+select id, title, published, listed, author_id
+from post
+where title in ('제목 1', '제목 2', '제목 3', '비공개 글')
+   or content in ('내용 1', '내용 2', '내용 3', '비공개 내용');
+```
+
+## 발견 시 정리 원칙
+
+- 외부 노출 계정이면 먼저 password/session/api key를 폐기하고 admin 권한을 제거한다.
+- demo 게시글은 운영자가 소유권과 노출 여부를 확인한 뒤 삭제 또는 비공개 전환한다.
+- 실제 이용자가 같은 email/title을 정당하게 사용 중이면 자동 삭제하지 말고 issue에 증거와 판단을 남긴다.
+- 정리 후 위 query를 재실행해 0건 또는 승인된 예외만 남는지 기록한다.

--- a/tools/guards/check-demo-seed-prod-traces.mjs
+++ b/tools/guards/check-demo-seed-prod-traces.mjs
@@ -19,6 +19,7 @@ const forbiddenRuntimePatterns = [
   /holding@test\.com/,
   /user[0-9]+@test\.com/,
   /["']1234["']/,
+  /\b[A-Z0-9_.-]*PASSWORD[A-Z0-9_.-]*\s*[:=]\s*["']?1234["']?(?=\s|$)/im,
   /제목 1/,
   /비공개 글/,
 ]

--- a/tools/guards/check-demo-seed-prod-traces.mjs
+++ b/tools/guards/check-demo-seed-prod-traces.mjs
@@ -25,6 +25,15 @@ const forbiddenRuntimePatterns = [
 
 const readTextFile = (relativePath) => readFileSync(path.join(repoRoot, relativePath), "utf8")
 
+const isScannableRuntimeFile = (relativePath) => {
+  const basename = path.basename(relativePath)
+  return (
+    basename.startsWith(".env") ||
+    path.extname(basename) === "" ||
+    /\.(ya?ml|json|sh|mjs|md|properties|env)$/.test(relativePath)
+  )
+}
+
 const walk = (relativePath) => {
   const absolutePath = path.join(repoRoot, relativePath)
   const stat = statSync(absolutePath)
@@ -49,7 +58,7 @@ for (const relativePath of seedConfigFiles) {
 }
 
 for (const relativePath of forbiddenRuntimeTargets.flatMap(walk)) {
-  if (!/\.(ya?ml|json|sh|mjs|md|properties)$/.test(relativePath)) continue
+  if (!isScannableRuntimeFile(relativePath)) continue
   const source = readTextFile(relativePath)
   for (const pattern of forbiddenRuntimePatterns) {
     if (pattern.test(source)) fail(`${relativePath} contains forbidden demo seed trace: ${pattern}`)

--- a/tools/guards/check-demo-seed-prod-traces.mjs
+++ b/tools/guards/check-demo-seed-prod-traces.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import path from "node:path"
+
+const repoRoot = path.resolve(import.meta.dirname, "../..")
+const seedConfigFiles = [
+  "back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap/MemberNotProdInitData.kt",
+  "back/src/main/kotlin/com/back/boundedContexts/post/adapter/bootstrap/PostNotProdInitData.kt",
+]
+const forbiddenRuntimeTargets = [
+  ".github/workflows",
+  "deploy",
+  "back/src/main/resources/application.yaml",
+  "back/src/main/resources/application-prod.yaml",
+]
+const forbiddenRuntimePatterns = [
+  /admin@test\.com/,
+  /system@test\.com/,
+  /holding@test\.com/,
+  /user[0-9]+@test\.com/,
+  /["']1234["']/,
+  /제목 1/,
+  /비공개 글/,
+]
+
+const readTextFile = (relativePath) => readFileSync(path.join(repoRoot, relativePath), "utf8")
+
+const walk = (relativePath) => {
+  const absolutePath = path.join(repoRoot, relativePath)
+  const stat = statSync(absolutePath)
+  if (!stat.isDirectory()) return [relativePath]
+
+  return readdirSync(absolutePath, { withFileTypes: true }).flatMap((entry) => {
+    const child = path.posix.join(relativePath, entry.name)
+    if (entry.isDirectory()) return walk(child)
+    return child
+  })
+}
+
+const fail = (message) => {
+  console.error(`[demo-seed-prod-gate] ${message}`)
+  process.exitCode = 1
+}
+
+for (const relativePath of seedConfigFiles) {
+  const source = readTextFile(relativePath)
+  if (source.includes('@Profile("!prod")')) fail(`${relativePath} must not use @Profile("!prod")`)
+  if (!source.includes("DemoSeedDataCondition")) fail(`${relativePath} must use DemoSeedDataCondition`)
+}
+
+for (const relativePath of forbiddenRuntimeTargets.flatMap(walk)) {
+  if (!/\.(ya?ml|json|sh|mjs|md|properties)$/.test(relativePath)) continue
+  const source = readTextFile(relativePath)
+  for (const pattern of forbiddenRuntimePatterns) {
+    if (pattern.test(source)) fail(`${relativePath} contains forbidden demo seed trace: ${pattern}`)
+  }
+}
+
+if (!process.exitCode) {
+  console.log("[demo-seed-prod-gate] ok")
+}

--- a/tools/test/demo-seed-prod-gate.test.mjs
+++ b/tools/test/demo-seed-prod-gate.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+const repoRoot = path.resolve(import.meta.dirname, "../..")
+const guardPath = path.join(repoRoot, "tools/guards/check-demo-seed-prod-traces.mjs")
+
+test("demo seed prod gate passes current runtime artifacts", () => {
+  const output = execFileSync(process.execPath, [guardPath], { cwd: repoRoot, encoding: "utf8" })
+  assert.match(output, /\[demo-seed-prod-gate] ok/)
+})
+
+test("demo seed prod gate rejects prod-like runtime seed traces", () => {
+  const workDir = mkdtempSync(path.join(tmpdir(), "aquila-demo-seed-gate-"))
+  try {
+    mkdirSync(path.join(workDir, "tools/guards"), { recursive: true })
+    mkdirSync(path.join(workDir, ".github/workflows"), { recursive: true })
+    mkdirSync(path.join(workDir, "deploy"), { recursive: true })
+    mkdirSync(path.join(workDir, "back/src/main/resources"), { recursive: true })
+    mkdirSync(path.join(workDir, "back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap"), { recursive: true })
+    mkdirSync(path.join(workDir, "back/src/main/kotlin/com/back/boundedContexts/post/adapter/bootstrap"), { recursive: true })
+
+    writeFileSync(
+      path.join(workDir, "tools/guards/check-demo-seed-prod-traces.mjs"),
+      readFileSync(guardPath, "utf8"),
+    )
+    writeFileSync(
+      path.join(workDir, "back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap/MemberNotProdInitData.kt"),
+      "class MemberNotProdInitData // DemoSeedDataCondition\n",
+    )
+    writeFileSync(
+      path.join(workDir, "back/src/main/kotlin/com/back/boundedContexts/post/adapter/bootstrap/PostNotProdInitData.kt"),
+      "class PostNotProdInitData // DemoSeedDataCondition\n",
+    )
+    writeFileSync(path.join(workDir, "back/src/main/resources/application.yaml"), "custom: {}\n")
+    writeFileSync(path.join(workDir, "back/src/main/resources/application-prod.yaml"), "custom: {}\n")
+    writeFileSync(path.join(workDir, ".github/workflows/deploy.yml"), "seed: admin@test.com\n")
+
+    assert.throws(
+      () => execFileSync(process.execPath, ["tools/guards/check-demo-seed-prod-traces.mjs"], { cwd: workDir, encoding: "utf8" }),
+      /forbidden demo seed trace/,
+    )
+  } finally {
+    rmSync(workDir, { recursive: true, force: true })
+  }
+})

--- a/tools/test/demo-seed-prod-gate.test.mjs
+++ b/tools/test/demo-seed-prod-gate.test.mjs
@@ -47,3 +47,39 @@ test("demo seed prod gate rejects prod-like runtime seed traces", () => {
     rmSync(workDir, { recursive: true, force: true })
   }
 })
+
+test("demo seed prod gate rejects deploy env seed traces", () => {
+  const workDir = mkdtempSync(path.join(tmpdir(), "aquila-demo-seed-env-gate-"))
+  try {
+    mkdirSync(path.join(workDir, "tools/guards"), { recursive: true })
+    mkdirSync(path.join(workDir, ".github/workflows"), { recursive: true })
+    mkdirSync(path.join(workDir, "deploy/homeserver"), { recursive: true })
+    mkdirSync(path.join(workDir, "back/src/main/resources"), { recursive: true })
+    mkdirSync(path.join(workDir, "back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap"), { recursive: true })
+    mkdirSync(path.join(workDir, "back/src/main/kotlin/com/back/boundedContexts/post/adapter/bootstrap"), { recursive: true })
+
+    writeFileSync(
+      path.join(workDir, "tools/guards/check-demo-seed-prod-traces.mjs"),
+      readFileSync(guardPath, "utf8"),
+    )
+    writeFileSync(
+      path.join(workDir, "back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap/MemberNotProdInitData.kt"),
+      "class MemberNotProdInitData // DemoSeedDataCondition\n",
+    )
+    writeFileSync(
+      path.join(workDir, "back/src/main/kotlin/com/back/boundedContexts/post/adapter/bootstrap/PostNotProdInitData.kt"),
+      "class PostNotProdInitData // DemoSeedDataCondition\n",
+    )
+    writeFileSync(path.join(workDir, "back/src/main/resources/application.yaml"), "custom: {}\n")
+    writeFileSync(path.join(workDir, "back/src/main/resources/application-prod.yaml"), "custom: {}\n")
+    writeFileSync(path.join(workDir, ".github/workflows/deploy.yml"), "name: deploy\n")
+    writeFileSync(path.join(workDir, "deploy/homeserver/.env.prod"), "ADMIN_EMAIL=admin@test.com\n")
+
+    assert.throws(
+      () => execFileSync(process.execPath, ["tools/guards/check-demo-seed-prod-traces.mjs"], { cwd: workDir, encoding: "utf8" }),
+      /forbidden demo seed trace/,
+    )
+  } finally {
+    rmSync(workDir, { recursive: true, force: true })
+  }
+})

--- a/tools/test/demo-seed-prod-gate.test.mjs
+++ b/tools/test/demo-seed-prod-gate.test.mjs
@@ -83,3 +83,39 @@ test("demo seed prod gate rejects deploy env seed traces", () => {
     rmSync(workDir, { recursive: true, force: true })
   }
 })
+
+test("demo seed prod gate rejects unquoted deploy demo passwords", () => {
+  const workDir = mkdtempSync(path.join(tmpdir(), "aquila-demo-seed-password-gate-"))
+  try {
+    mkdirSync(path.join(workDir, "tools/guards"), { recursive: true })
+    mkdirSync(path.join(workDir, ".github/workflows"), { recursive: true })
+    mkdirSync(path.join(workDir, "deploy/homeserver"), { recursive: true })
+    mkdirSync(path.join(workDir, "back/src/main/resources"), { recursive: true })
+    mkdirSync(path.join(workDir, "back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap"), { recursive: true })
+    mkdirSync(path.join(workDir, "back/src/main/kotlin/com/back/boundedContexts/post/adapter/bootstrap"), { recursive: true })
+
+    writeFileSync(
+      path.join(workDir, "tools/guards/check-demo-seed-prod-traces.mjs"),
+      readFileSync(guardPath, "utf8"),
+    )
+    writeFileSync(
+      path.join(workDir, "back/src/main/kotlin/com/back/boundedContexts/member/adapter/bootstrap/MemberNotProdInitData.kt"),
+      "class MemberNotProdInitData // DemoSeedDataCondition\n",
+    )
+    writeFileSync(
+      path.join(workDir, "back/src/main/kotlin/com/back/boundedContexts/post/adapter/bootstrap/PostNotProdInitData.kt"),
+      "class PostNotProdInitData // DemoSeedDataCondition\n",
+    )
+    writeFileSync(path.join(workDir, "back/src/main/resources/application.yaml"), "custom: {}\n")
+    writeFileSync(path.join(workDir, "back/src/main/resources/application-prod.yaml"), "custom: {}\n")
+    writeFileSync(path.join(workDir, ".github/workflows/deploy.yml"), "name: deploy\n")
+    writeFileSync(path.join(workDir, "deploy/homeserver/.env.prod"), "ADMIN_PASSWORD=1234\n")
+
+    assert.throws(
+      () => execFileSync(process.execPath, ["tools/guards/check-demo-seed-prod-traces.mjs"], { cwd: workDir, encoding: "utf8" }),
+      /forbidden demo seed trace/,
+    )
+  } finally {
+    rmSync(workDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## 🔗 Related Issue
- close #1188

## 📝 Summary
- 비운영 demo seed member/post runner가 `!prod` negative profile 대신 명시 허용 profile과 opt-in flag에서만 로드되도록 제한합니다.
- prod-like profile과 운영 배포 산출물에 demo seed 흔적이 섞이지 않도록 context test, release gate, 운영 점검 runbook을 추가합니다.

## 🛠 Changes
- `MemberNotProdInitData`, `PostNotProdInitData`에 `DemoSeedDataCondition`을 적용해 `local`, `dev`, `test` profile + `custom.bootstrap.seed-demo-data-enabled=true`에서만 seed bean 후보가 되도록 했습니다.
- 기본 설정은 `CUSTOM__BOOTSTRAP__SEED_DEMO_DATA_ENABLED:false`로 닫고, 기존 Spring integration test base에서만 seed opt-in을 명시했습니다.
- prod-like profile(`prod`, `staging`, `preview`, `qa`, `release*`)과 허용 profile 혼합 상황을 context test로 고정했습니다.
- release planner guard에 demo seed prod gate를 연결하고, 운영 유사 DB 점검 query/runbook을 `docs/design/demo-seed-data-prod-like-check.md`에 추가했습니다.

## 🎯 Scope
- [ ] Frontend
- [x] Backend
- [ ] Editor / Content Rendering
- [ ] Admin / Dashboard
- [ ] Performance / Bundle / Runtime
- [x] Infra / CI / Ops
- [x] Docs

## ✅ Validation
- [x] 자동화 테스트를 수행했는가?
- [x] 필요한 수동 확인을 마쳤는가?
- [x] 로그/메트릭/운영 지표를 확인했는가?

### 실행한 검증
- `CURRENT_TASK_SLUG=issue-1188-restrict-seed-demo-data bash tools/guards/current-task-preflight.sh`: exit 0
- `git diff --check`: exit 0
- `node tools/guards/check-demo-seed-prod-traces.mjs`: exit 0, `[demo-seed-prod-gate] ok`
- `node --test tools/test/release-plan.test.mjs tools/test/flyway-deploy-safety.test.mjs tools/test/comment-jacoco-summary.test.mjs tools/test/demo-seed-prod-gate.test.mjs`: 18 pass, exit 0. 동일 조건 2회 연속 통과 확인.
- `./gradlew ktlintCheck` in `back`: exit 0. 동일 조건 2회 연속 통과 확인.
- `./gradlew test --tests com.back.global.app.config.DemoSeedDataConditionTest --tests com.back.boundedContexts.member.adapter.bootstrap.MemberNotProdInitDataTest --tests com.back.boundedContexts.post.adapter.bootstrap.PostNotProdInitDataTest` in `back`: BUILD SUCCESSFUL, exit 0
- `./gradlew test` in `back`: BUILD SUCCESSFUL, exit 0
- `./gradlew test --rerun-tasks` in `back`: BUILD SUCCESSFUL, 11 actionable tasks executed, exit 0
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" yarn --cwd front contracts:check`: exit 0, generated types up-to-date
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" git commit -m "fix(back): demo seed profile 제한"`: pre-commit OpenAPI export + `yarn contracts:check` 통과 후 commit `6b5edd25` 생성

## 📸 Screenshot / API Example
- UI/API 응답 변경이 아니라 backend bootstrap 조건, CI guard, 운영 문서 변경입니다.
- 증거: `DemoSeedDataConditionTest`가 profile/flag 조건을 검증하고, `tools/test/demo-seed-prod-gate.test.mjs`가 운영 산출물에 demo seed trace가 들어오면 gate가 실패함을 검증합니다.

## ⚠️ Risk & Rollback
- 예상 리스크: test profile에서 seed data가 필요한 Spring integration test는 `BaseIntegrationTest`의 opt-in property에 의존합니다. 새 test base가 seed bean을 직접 사용할 경우 같은 property를 명시해야 합니다.
- 롤백 방법: 이 PR의 commit `6b5edd25`를 revert하면 기존 `!prod` profile seed 동작과 workflow 구성이 복구됩니다.

## ☑️ Checklist
- [x] 관련 이슈를 정확히 연결했는가?
- [x] base branch가 `main`인지 다시 확인했는가?
- [x] PR 범위 밖 변경을 제외했는가?
- [x] 필요한 테스트와 검증 결과를 본문에 남겼는가?
- [x] SEO/권한/캐시/배포 영향이 있다면 본문에 설명했는가?
- [x] API 계약 또는 운영 문서 변경이 있다면 함께 반영했는가?
- [x] 새 코드 주석이 있다면 [코드 주석 정책](https://github.com/AquilaXk/aquila-blog/blob/main/docs/design/code-comment-policy.md)에 맞는 이유/불변조건/운영 영향을 설명하는가?
