### PR TITLE
[Test] Frontend release UI QA gate 보강

### DIFF
--- a/.github/workflows/reusable-frontend-verify.yml
+++ b/.github/workflows/reusable-frontend-verify.yml
@@ -152,6 +152,22 @@ jobs:
         working-directory: front
         run: yarn contracts:check
 
+      - name: Run frontend unit tests
+        if: steps.changes.outputs.frontend == 'true'
+        working-directory: front
+        run: yarn test:unit
+
+      - name: Upload frontend unit test report
+        if: always() && steps.changes.outputs.frontend == 'true'
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: front-unit-test-report
+          path: |
+            front/playwright-report-unit
+            front/test-results/unit
+          if-no-files-found: warn
+          retention-days: 3
+
       - name: Upload OpenAPI contract drift report
         if: failure() && steps.changes.outputs.frontend == 'true'
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -228,6 +244,24 @@ jobs:
         env:
           NEXT_PUBLIC_SIGNUP_ENABLED: "true"
         run: yarn test:e2e:smoke
+
+      - name: Run release UI QA e2e
+        if: steps.changes.outputs.frontend == 'true' && github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/release'))
+        working-directory: front
+        env:
+          NEXT_PUBLIC_SIGNUP_ENABLED: "true"
+        run: yarn test:e2e:release-ui-qa
+
+      - name: Upload release UI QA report
+        if: always() && steps.changes.outputs.frontend == 'true' && github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/release'))
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: front-release-ui-qa-report
+          path: |
+            front/playwright-report
+            front/test-results
+          if-no-files-found: warn
+          retention-days: 3
 
       - name: Run legal privacy e2e
         if: steps.changes.outputs.frontend == 'true'

--- a/front/package.json
+++ b/front/package.json
@@ -31,6 +31,7 @@
     "test:e2e:perf": "yarn playwright:preflight && node scripts/run-playwright-perf.mjs",
     "test:e2e:a11y": "yarn playwright:preflight && env -u NO_COLOR PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 yarn playwright test e2e/accessibility.spec.ts",
     "test:e2e:live": "yarn playwright:preflight && node scripts/run-live-e2e.mjs",
+    "test:unit": "yarn playwright test --config=playwright.unit.config.ts",
     "storybook": "HOME=$PWD/.storybook-home CI=1 STORYBOOK_DISABLE_TELEMETRY=1 STORYBOOK_DISABLE_UPDATE_CHECK=1 storybook dev -p 6006",
     "storybook:build:raw": "HOME=$PWD/.storybook-home CI=1 STORYBOOK_DISABLE_TELEMETRY=1 STORYBOOK_DISABLE_UPDATE_CHECK=1 storybook build",
     "storybook:build": "yarn storybook:build:raw",

--- a/front/playwright.unit.config.ts
+++ b/front/playwright.unit.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./tests/unit",
+  outputDir: "test-results/unit",
+  timeout: 10_000,
+  expect: {
+    timeout: 1_000,
+  },
+  fullyParallel: true,
+  workers: 1,
+  reporter: process.env.CI
+    ? [["github"], ["html", { outputFolder: "playwright-report-unit", open: "never" }]]
+    : [["list"]],
+})

--- a/front/src/apis/backend/cloud.ts
+++ b/front/src/apis/backend/cloud.ts
@@ -303,7 +303,7 @@ const isMatchingVideoUploadSessionFile = (session: CloudVideoUploadSession, file
   // Server-side NFC normalization or metadata truncation must not discard a resumable session.
   session.byteSize === file.size
 
-const isDefinitiveStaleVideoUploadSessionError = (error: unknown) =>
+export const isDefinitiveStaleVideoUploadSessionError = (error: unknown) =>
   error instanceof ApiError && (error.status === 404 || error.status === 410)
 
 type ResolvedVideoUploadSession =
@@ -339,7 +339,7 @@ const resolveVideoUploadSession = async (
   return { kind: "inProgress", session }
 }
 
-const isExplicitUploadAbort = (error: unknown, signal?: AbortSignal) => {
+export const isExplicitUploadAbort = (error: unknown, signal?: AbortSignal) => {
   if (signal?.aborted) return true
   if (!(error instanceof Error)) return false
   return error.name === "AbortError"

--- a/front/src/hooks/useAuthSession.ts
+++ b/front/src/hooks/useAuthSession.ts
@@ -60,6 +60,29 @@ export type AuthMember = {
   legalReconsent?: LegalReconsentStatus | null
 }
 
+type AuthSessionFetchDecisionInput = {
+  hasCachedSnapshot: boolean
+  hasCachedMemberSnapshot: boolean
+  hasCachedAnonymousSnapshot: boolean
+  serverProbeSnapshot: boolean | undefined
+  anonymousProbeSuppressed: boolean
+}
+
+export const shouldFetchAuthSession = ({
+  hasCachedSnapshot,
+  hasCachedMemberSnapshot,
+  hasCachedAnonymousSnapshot,
+  serverProbeSnapshot,
+  anonymousProbeSuppressed,
+}: AuthSessionFetchDecisionInput) => {
+  if (hasCachedMemberSnapshot) return true
+  if (hasCachedAnonymousSnapshot && serverProbeSnapshot !== true) return false
+  if (anonymousProbeSuppressed) return false
+  if (serverProbeSnapshot === false) return false
+  if (serverProbeSnapshot === true) return true
+  return !hasCachedSnapshot
+}
+
 const useAuthSession = () => {
   const router = useRouter()
   const [isMounted, setIsMounted] = useState(false)
@@ -76,14 +99,13 @@ const useAuthSession = () => {
   // SSR에서 "쿠키 없음"이 확정된 anonymous(null)은 재검증을 건너뛰어
   // 비로그인 사용자의 불필요한 401(auth/me) 반복을 줄인다.
   // 단, SSR 검증 실패(undefined)로 들어온 경우에는 클라이언트에서 재검증한다.
-  const shouldFetchAuthMe = (() => {
-    if (hasCachedMemberSnapshot) return true
-    if (hasCachedAnonymousSnapshot && serverProbeSnapshot !== true) return false
-    if (readAnonymousProbeSuppressed()) return false
-    if (serverProbeSnapshot === false) return false
-    if (serverProbeSnapshot === true) return true
-    return !hasCachedSnapshot
-  })()
+  const shouldFetchAuthMe = shouldFetchAuthSession({
+    hasCachedSnapshot,
+    hasCachedMemberSnapshot,
+    hasCachedAnonymousSnapshot,
+    serverProbeSnapshot,
+    anonymousProbeSuppressed: readAnonymousProbeSuppressed(),
+  })
   const query = useQuery({
     queryKey: queryKey.authMe(),
     queryFn: async () => {

--- a/front/src/libs/markdown/components/MarkdownRendererRootTableToggleStyles.ts
+++ b/front/src/libs/markdown/components/MarkdownRendererRootTableToggleStyles.ts
@@ -79,6 +79,7 @@ export const markdownRendererRootTableToggleStyles = (theme: Theme) => css`
     max-width: 100%;
     min-width: 0;
     margin: 30px 0;
+    overflow-x: hidden;
   }
 
   .aq-table-scroll {
@@ -196,6 +197,23 @@ export const markdownRendererRootTableToggleStyles = (theme: Theme) => css`
   .aq-table tbody tr:last-child td,
   .aq-table tbody tr:last-child th {
     border-bottom: 0;
+  }
+
+  @media (max-width: 820px) {
+    table,
+    .aq-table {
+      width: 100%;
+      min-width: 100%;
+      max-width: 100%;
+      table-layout: fixed;
+    }
+
+    table[data-overflow-mode="wide"],
+    .aq-table.aq-table-wide {
+      width: max-content;
+      min-width: 100%;
+      max-width: none;
+    }
   }
 
 `

--- a/front/src/routes/Detail/PostDetail/PostHeader.styles.ts
+++ b/front/src/routes/Detail/PostDetail/PostHeader.styles.ts
@@ -53,6 +53,7 @@ export const StyledWrapper = styled.header `
     color: #646a73;
     font-size: 1.125rem;
     line-height: 1.75;
+    overflow-wrap: anywhere;
     word-break: keep-all;
   }
 

--- a/front/tests/unit/frontend-logic.spec.ts
+++ b/front/tests/unit/frontend-logic.spec.ts
@@ -1,0 +1,218 @@
+import { expect, test } from "@playwright/test"
+import { ApiError } from "../../src/apis/backend/client"
+import {
+  isDefinitiveStaleVideoUploadSessionError,
+  isExplicitUploadAbort,
+} from "../../src/apis/backend/cloud"
+import {
+  buildExploreCursorPath,
+  buildFeedCursorPath,
+  toValidPage,
+  toValidPageSize,
+} from "../../src/apis/backend/posts/PostApiRequestModel"
+import { shouldFetchAuthSession } from "../../src/hooks/useAuthSession"
+import { normalizeApiRequestPath } from "../../src/libs/backend/requestPath"
+import { parseMarkdownSegments } from "../../src/libs/markdown/renderingSegmentModel"
+import {
+  hasOptionalTrackingConsent,
+  OPTIONAL_TRACKING_CONSENT_STORAGE_KEY,
+  readOptionalTrackingConsent,
+} from "../../src/libs/privacy/optionalTrackingConsentCore"
+import { normalizeNextPath } from "../../src/libs/router"
+
+const createStorage = (): Storage => {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear() {
+      store.clear()
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null
+    },
+    removeItem(key: string) {
+      store.delete(key)
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value)
+    },
+  }
+}
+
+const setGlobal = (key: "window" | "navigator", value: unknown) => {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, key)
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value,
+    writable: true,
+  })
+  return () => {
+    if (previous) {
+      Object.defineProperty(globalThis, key, previous)
+    } else {
+      delete (globalThis as Record<string, unknown>)[key]
+    }
+  }
+}
+
+const withBrowserState = (run: (storage: Storage, navigatorValue: { globalPrivacyControl?: boolean }) => void) => {
+  const storage = createStorage()
+  const navigatorValue = {
+    doNotTrack: "0",
+    globalPrivacyControl: false,
+    sendBeacon: () => true,
+  }
+  const restoreWindow = setGlobal("window", {
+    dispatchEvent: () => true,
+    localStorage: storage,
+    location: { origin: "http://localhost" },
+    navigator: navigatorValue,
+  })
+  const restoreNavigator = setGlobal("navigator", navigatorValue)
+
+  try {
+    run(storage, navigatorValue)
+  } finally {
+    restoreNavigator()
+    restoreWindow()
+  }
+}
+
+test.describe("frontend pure logic contracts", () => {
+  test("safe redirect paths reject external and data-route inputs", () => {
+    expect(normalizeNextPath("/admin/posts?tag=release")).toBe("/admin/posts?tag=release")
+    expect(normalizeNextPath("//evil.example/path", "/")).toBe("/")
+    expect(normalizeNextPath("https://evil.example/path", "/")).toBe("/")
+    expect(normalizeNextPath("/_next/data/build-id/posts/42.json?next=https%3A%2F%2Fevil.example&tag=qa")).toBe(
+      "/posts/42?tag=qa"
+    )
+  })
+
+  test("backend request paths stay allow-listed and relative", () => {
+    expect(normalizeApiRequestPath("/post/api/v1/posts/feed/cursor?cursor=abc")).toBe(
+      "/post/api/v1/posts/feed/cursor?cursor=abc"
+    )
+    expect(normalizeApiRequestPath("/signup/api/v1/email/start")).toBe("/signup/api/v1/email/start")
+    expect(() => normalizeApiRequestPath("https://api.example.com/member/api/v1/auth/me")).toThrow(
+      /Absolute URL/
+    )
+    expect(() => normalizeApiRequestPath("/post/api/v1/%E0%A4%A/admin")).toThrow(/Path traversal/)
+    expect(() => normalizeApiRequestPath("/internal/health")).toThrow(/allow-listed/)
+  })
+
+  test("markdown card URLs keep safe values and strip unsafe values", () => {
+    const segments = parseMarkdownSegments(`<!-- aq-bookmark {"thumbnailUrl":"javascript:alert(1)"} -->
+:::bookmark javascript:alert(1)
+Unsafe
+description
+:::
+
+<!-- aq-embed {"embedUrl":"https://www.youtube.com/embed/abc"} -->
+:::embed https://www.youtube.com/watch?v=abc
+Safe
+caption
+:::`)
+
+    const bookmark = segments.find((segment) => segment.type === "bookmark")
+    const embed = segments.find((segment) => segment.type === "embed")
+
+    expect(bookmark).toMatchObject({ type: "bookmark", url: "" })
+    expect(bookmark).not.toHaveProperty("thumbnailUrl")
+    expect(embed).toMatchObject({
+      type: "embed",
+      embedUrl: "https://www.youtube.com/embed/abc",
+      url: "https://www.youtube.com/watch?v=abc",
+    })
+  })
+
+  test("upload recovery predicates separate stale sessions from transient failures", () => {
+    expect(isDefinitiveStaleVideoUploadSessionError(new ApiError(404, "/upload-session", ""))).toBe(true)
+    expect(isDefinitiveStaleVideoUploadSessionError(new ApiError(410, "/upload-session", ""))).toBe(true)
+    expect(isDefinitiveStaleVideoUploadSessionError(new ApiError(503, "/upload-session", ""))).toBe(false)
+
+    const abortController = new AbortController()
+    abortController.abort()
+    expect(isExplicitUploadAbort(new Error("network closed"), abortController.signal)).toBe(true)
+    expect(isExplicitUploadAbort(new DOMException("Upload aborted", "AbortError"))).toBe(true)
+    expect(isExplicitUploadAbort(new Error("network closed"))).toBe(false)
+  })
+
+  test("optional tracking consent respects stored state and browser opt-out", () => {
+    withBrowserState((storage, navigatorValue) => {
+      expect(readOptionalTrackingConsent()).toBeNull()
+
+      storage.setItem(
+        OPTIONAL_TRACKING_CONSENT_STORAGE_KEY,
+        JSON.stringify({
+          categories: { analytics: true, rum: true },
+          source: "settings",
+          state: "granted",
+          updatedAt: "2026-06-29T00:00:00.000Z",
+          version: 1,
+        })
+      )
+
+      expect(readOptionalTrackingConsent()).toMatchObject({ state: "granted" })
+      expect(hasOptionalTrackingConsent()).toBe(true)
+      navigatorValue.globalPrivacyControl = true
+      expect(hasOptionalTrackingConsent()).toBe(false)
+    })
+  })
+
+  test("auth session fetch decision preserves cached anonymous and member states", () => {
+    expect(
+      shouldFetchAuthSession({
+        anonymousProbeSuppressed: false,
+        hasCachedAnonymousSnapshot: false,
+        hasCachedMemberSnapshot: true,
+        hasCachedSnapshot: true,
+        serverProbeSnapshot: false,
+      })
+    ).toBe(true)
+    expect(
+      shouldFetchAuthSession({
+        anonymousProbeSuppressed: false,
+        hasCachedAnonymousSnapshot: true,
+        hasCachedMemberSnapshot: false,
+        hasCachedSnapshot: true,
+        serverProbeSnapshot: false,
+      })
+    ).toBe(false)
+    expect(
+      shouldFetchAuthSession({
+        anonymousProbeSuppressed: true,
+        hasCachedAnonymousSnapshot: false,
+        hasCachedMemberSnapshot: false,
+        hasCachedSnapshot: false,
+        serverProbeSnapshot: undefined,
+      })
+    ).toBe(false)
+    expect(
+      shouldFetchAuthSession({
+        anonymousProbeSuppressed: false,
+        hasCachedAnonymousSnapshot: false,
+        hasCachedMemberSnapshot: false,
+        hasCachedSnapshot: false,
+        serverProbeSnapshot: true,
+      })
+    ).toBe(true)
+  })
+
+  test("post pagination builders clamp page size and trim cursors", () => {
+    expect(toValidPage(Number.NaN)).toBe(1)
+    expect(toValidPage(-5)).toBe(1)
+    expect(toValidPageSize(99)).toBe(30)
+    expect(toValidPageSize(-5)).toBe(1)
+    expect(buildFeedCursorPath({ cursor: "  abc  ", order: "asc", pageSize: 99 })).toBe(
+      "/post/api/v1/posts/feed/cursor?sort=CREATED_AT_ASC&pageSize=30&cursor=abc"
+    )
+    expect(buildExploreCursorPath({ cursor: "", tag: "  TypeScript  ", pageSize: 2 })).toBe(
+      "/post/api/v1/posts/explore/cursor?tag=TypeScript&sort=CREATED_AT&pageSize=2"
+    )
+  })
+})


### PR DESCRIPTION
## 관련 이슈

close #1137

## 작업 배경

- release UI QA는 script만 있고 reusable frontend 검증에서 실행되지 않아 main/release 경로의 화면 폭 회귀를 놓칠 수 있었습니다.
- 빠른 PR 경로는 유지하면서 순수 로직 단위 검사를 추가합니다.

## 작업 내용

- frontend 변경 시 Playwright unit gate와 report artifact를 reusable 검증에 추가했습니다.
- main/release branch의 non-PR 실행에서만 release UI QA e2e와 report artifact가 실행되도록 연결했습니다.
- unit 검사를 위해 browser 없는 Playwright config와 순수 로직 계약 spec을 추가했습니다.
- release UI QA가 드러낸 모바일 상세 table/header overflow를 좁은 CSS 규칙으로 보정했습니다.

## 검증

- 실행한 명령과 결과:
- `yarn --cwd front test:unit`: 7 passed, 2회 연속 통과
- `yarn --cwd front lint`: exit 0
- `yarn --cwd front build`: exit 0
- `yarn --cwd front playwright:preflight`: exit 0
- `yarn --cwd front playwright test e2e/smoke-detail-rendering.spec.ts:640 --workers=1`: 1 passed
- `yarn --cwd front test:e2e:release-ui-qa`: 7 passed, 최종 patch 후 통과
- `yarn --cwd front test:e2e:smoke`: 71 passed
- `git diff --check`: exit 0
- changed-file blocked word scan: no matches
- commit hook: contracts check, build, bundle-size check, smoke e2e 통과
- GitHub `frontend-ci / frontend-ci`: success, unit step success, release UI QA step skipped on PR by condition
- GitHub security/quality checks: success 또는 configured skip
- Codex CLI review: Actionable comments posted 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Unit gate | local darwin | `yarn --cwd front test:unit` | terminal output, 7 passed twice | Pass |
| Release UI QA | local chromium | `yarn --cwd front test:e2e:release-ui-qa` | terminal output, 7 passed | Pass |
| Smoke regression | local chromium | `yarn --cwd front test:e2e:smoke` | terminal output, 71 passed | Pass |
| Build and bundle | local darwin | commit hook build and bundle-size check | terminal output, budget status OK | Pass |
| PR CI | GitHub Actions | `frontend-ci / frontend-ci` | https://github.com/AquilaXk/aquila-blog/actions/runs/28372406452 | Pass |
| Code review | GitHub PR review | Codex CLI review | https://github.com/AquilaXk/aquila-blog/pull/1207#pullrequestreview-4591886139 | Pass |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: reusable workflow 조건식과 mobile table/header overflow 보정 범위
- CodeRabbit은 rate limit으로 실제 리뷰를 시작하지 못했고, Codex CLI review를 PR review로 게시했습니다.

## 리스크

- release UI QA는 main/release non-PR 경로에서만 실행되므로 PR fast path 시간 증가는 unit gate 수준으로 제한됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.