### PR TITLE
[Test] 보안 커버리지 baseline 재분류

### DIFF
--- a/back/config/jacoco-coverage-baseline-excludes.txt
+++ b/back/config/jacoco-coverage-baseline-excludes.txt
@@ -153,8 +153,6 @@ com/back/global/revalidate/dto/PurgePostReadCachesPayload.class
 com/back/global/revalidate/dto/RevalidateHomePayload.class
 com/back/global/rsData/RsData$Companion.class
 com/back/global/security/adapter/persistence/AuthSecurityEventPersistenceAdapter.class
-com/back/global/security/application/AuthSecurityEventService.class
-com/back/global/security/application/HtmlContentSanitizer.class
 com/back/global/security/application/SecurityTipProvider.class
 com/back/global/security/config/ApiDefaultCacheControlFilter.class
 com/back/global/security/config/ApiRuntimeBoundaryFilter.class
@@ -162,14 +160,8 @@ com/back/global/security/config/CustomAuthenticationFilter.class
 com/back/global/security/config/CustomUserDetailsService.class
 com/back/global/security/config/oauth2/CustomOAuth2AuthorizationRequestResolver.class
 com/back/global/security/config/oauth2/CustomOAuth2LoginSuccessHandler.class
-com/back/global/security/config/oauth2/CustomOAuth2UserService.class
-com/back/global/security/config/oauth2/OAuth2Provider$Companion.class
-com/back/global/security/config/oauth2/OAuth2Provider.class
 com/back/global/security/config/oauth2/application/OAuth2State$Companion.class
-com/back/global/security/config/oauth2/application/OAuth2State.class
 com/back/global/security/domain/SecurityUser.class
-com/back/global/security/model/AuthSecurityEvent.class
-com/back/global/storage/application/UploadedFileRetentionService.class
 com/back/global/storage/application/UploadedFileUrlCodec.class
 com/back/global/storage/adapter/CloudStorageAdapter.class
 com/back/global/storage/model/UploadedFile.class

--- a/back/config/jacoco-coverage-baseline-lock.txt
+++ b/back/config/jacoco-coverage-baseline-lock.txt
@@ -153,8 +153,6 @@ com/back/global/revalidate/dto/PurgePostReadCachesPayload.class
 com/back/global/revalidate/dto/RevalidateHomePayload.class
 com/back/global/rsData/RsData$Companion.class
 com/back/global/security/adapter/persistence/AuthSecurityEventPersistenceAdapter.class
-com/back/global/security/application/AuthSecurityEventService.class
-com/back/global/security/application/HtmlContentSanitizer.class
 com/back/global/security/application/SecurityTipProvider.class
 com/back/global/security/config/ApiDefaultCacheControlFilter.class
 com/back/global/security/config/ApiRuntimeBoundaryFilter.class
@@ -162,14 +160,8 @@ com/back/global/security/config/CustomAuthenticationFilter.class
 com/back/global/security/config/CustomUserDetailsService.class
 com/back/global/security/config/oauth2/CustomOAuth2AuthorizationRequestResolver.class
 com/back/global/security/config/oauth2/CustomOAuth2LoginSuccessHandler.class
-com/back/global/security/config/oauth2/CustomOAuth2UserService.class
-com/back/global/security/config/oauth2/OAuth2Provider$Companion.class
-com/back/global/security/config/oauth2/OAuth2Provider.class
 com/back/global/security/config/oauth2/application/OAuth2State$Companion.class
-com/back/global/security/config/oauth2/application/OAuth2State.class
 com/back/global/security/domain/SecurityUser.class
-com/back/global/security/model/AuthSecurityEvent.class
-com/back/global/storage/application/UploadedFileRetentionService.class
 com/back/global/storage/application/UploadedFileUrlCodec.class
 com/back/global/storage/adapter/CloudStorageAdapter.class
 com/back/global/storage/model/UploadedFile.class


### PR DESCRIPTION
## 관련 이슈

close #1136

## 작업 배경

- JaCoCo 100% gate는 static/baseline 제외 후 기준이므로, 이미 테스트로 덮인 보안/운영 class가 baseline에 남아 있으면 실제 위험 커버리지 신호가 흐려집니다.
- full report에서 line missed 0으로 확인된 항목만 baseline과 lock에서 함께 제거해 재추가 시 다시 승인 diff가 보이게 합니다.

## 작업 내용

- `back/config/jacoco-coverage-baseline-excludes.txt`에서 full line coverage가 확인된 보안/운영 class 8개를 제거했습니다.
- `back/config/jacoco-coverage-baseline-lock.txt`에서도 같은 8개를 제거해 baseline과 lock 기준을 맞췄습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test jacocoPrFullCoverageReport`: BUILD SUCCESSFUL
  - `./gradlew ciFastCheck`: BUILD SUCCESSFUL
  - `./gradlew ciFastCheck`: BUILD SUCCESSFUL
  - `node --test tools/test/comment-jacoco-summary.test.mjs`: tests 1, pass 1
  - `git diff --check`: exit 0
  - `rg <금지어 패턴> back/config/jacoco-coverage-baseline-excludes.txt back/config/jacoco-coverage-baseline-lock.txt`: no matches
  - GitHub PR checks: all pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Backend coverage gate | local macOS / JDK | `./gradlew ciFastCheck` 2회 | command output | BUILD SUCCESSFUL 2회 |
| Coverage summary split | local macOS / Node | `node --test tools/test/comment-jacoco-summary.test.mjs` | TAP output | tests 1, pass 1 |
| Baseline 축소 수치 | local macOS | `tools/ci/comment-jacoco-summary.py` output | Baseline 제외 클래스 `200`개, filtered line `100.00%`, full line `81.76%` | 통과 |
| 금지어 스캔 | local macOS | changed config files scan | no matches | 통과 |
| PR checks | GitHub Actions | PR #1210 checks | backend-ci, Security, CodeQL, SonarCloud | 통과 |
| Review gate | GitHub PR review | Codex CLI review | Actionable comments posted: 0 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 제거된 8개 class가 full report에서 line missed 0으로 확인된 항목인지와 baseline/lock 삭제가 같은 목록인지 확인하면 됩니다.

## 리스크

- coverage gate가 더 엄격해지는 변경입니다. 해당 class에 미커버 라인이 다시 생기면 `ciFastCheck`가 실패합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
