### PR TITLE
[Fix] 로컬 Playwright CFT crash 경로 차단

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "build": "node scripts/with-test-lock.mjs --resource front-verify --label build -- next build",
     "postinstall": "node scripts/patch-lodash-template.cjs",
     "start": "next start",
-    "playwright": "node scripts/with-test-lock.mjs --resource front-verify --label playwright -- playwright",
+    "playwright": "PLAYWRIGHT_LOCAL_CHROMIUM_CHANNEL=false node scripts/with-test-lock.mjs --resource front-verify --label playwright -- playwright",
     "playwright:preflight": "node scripts/check-playwright-local-launcher.mjs",
     "contracts:fetch": "node scripts/openapi/fetch-openapi.mjs",
     "contracts:generate": "openapi-typescript contracts/openapi/openapi.json -o packages/shared-contracts/src/generated/backend-openapi.d.ts",

--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -18,6 +18,10 @@ const playwrightOutputDir =
     "playwright",
     (process.env.PLAYWRIGHT_RUN_ID?.trim() || `pid-${process.pid}`).replace(/[^A-Za-z0-9._-]+/g, "-")
   )
+const shouldUseChromiumChannel =
+  process.platform === "darwin" &&
+  !process.env.CI &&
+  process.env.PLAYWRIGHT_LOCAL_CHROMIUM_CHANNEL !== "false"
 const inheritedEnv = { ...process.env }
 const resolvedBackendInternalUrl = inheritedEnv.BACKEND_INTERNAL_URL || "http://127.0.0.1:1"
 const shouldEnableAdminGuardQaBypassByDefault =
@@ -34,6 +38,7 @@ const defaultProjects = [
     name: "chromium",
     use: {
       ...devices["Desktop Chrome"],
+      ...(shouldUseChromiumChannel ? { channel: "chromium" as const } : {}),
     },
   },
 ]
@@ -43,6 +48,7 @@ const liveMultiBrowserProjects = [
     name: "chromium",
     use: {
       ...devices["Desktop Chrome"],
+      ...(shouldUseChromiumChannel ? { channel: "chromium" as const } : {}),
     },
   },
   {

--- a/front/scripts/check-playwright-local-launcher.mjs
+++ b/front/scripts/check-playwright-local-launcher.mjs
@@ -4,54 +4,45 @@ import { fileURLToPath } from "url"
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 const configPath = path.join(projectRoot, "playwright.config.ts")
+const packageJsonPath = path.join(projectRoot, "package.json")
 const configSource = fs.readFileSync(configPath, "utf8")
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"))
 
 const requiredContracts = [
   {
-    id: "default-chromium-project",
-    pattern: /const defaultProjects = \[\s*{\s*name:\s*"chromium",\s*use:\s*{\s*\.\.\.devices\["Desktop Chrome"\],\s*},\s*},\s*\]/s,
+    id: "darwin-channel-guard",
+    source: configSource,
+    pattern:
+      /const shouldUseChromiumChannel =\s*process\.platform === "darwin" &&\s*!process\.env\.CI &&\s*process\.env\.PLAYWRIGHT_LOCAL_CHROMIUM_CHANNEL !== "false"/,
   },
   {
-    id: "live-chromium-project",
-    pattern: /const liveMultiBrowserProjects = \[\s*{\s*name:\s*"chromium",\s*use:\s*{\s*\.\.\.devices\["Desktop Chrome"\],\s*},\s*},/s,
+    id: "chromium-channel",
+    source: configSource,
+    pattern: /channel:\s*"chromium"\s+as const/,
+  },
+  {
+    id: "yarn-playwright-cft-opt-out",
+    source: packageJson.scripts?.playwright || "",
+    pattern: /PLAYWRIGHT_LOCAL_CHROMIUM_CHANNEL=false/,
   },
 ]
 
 const missing = requiredContracts
-  .filter((contract) => !contract.pattern.test(configSource))
+  .filter((contract) => !contract.pattern.test(contract.source))
   .map((contract) => contract.id)
 
-const forbiddenContracts = [
-  {
-    id: "darwin-local-channel-flag",
-    pattern: /shouldUseChromiumChannel/,
-  },
-  {
-    id: "forced-chromium-channel",
-    pattern: /channel:\s*["']chromium["']/,
-  },
-  {
-    id: "darwin-local-channel-assertion",
-    pattern: /assertDarwinLocalChromiumChannel/,
-  },
-]
-
-const presentForbidden = forbiddenContracts
-  .filter((contract) => contract.pattern.test(configSource))
-  .map((contract) => contract.id)
-
-if (missing.length === 0 && presentForbidden.length === 0) process.exit(0)
+if (missing.length === 0) {
+  process.exit(0)
+}
 
 console.error(
   [
     "[playwright-preflight] Playwright local chromium launcher contract drift detected.",
-    "로컬 기본 Playwright 실행은 Google Chrome for Testing/channel=chromium 경로를 강제하지 않아야 합니다.",
+    "raw macOS Playwright guard는 유지하고 yarn playwright 진입점만 CFT crash 경로를 opt-out 해야 합니다.",
     `config: ${configPath}`,
-    missing.length > 0 ? `missing: ${missing.join(", ")}` : null,
-    presentForbidden.length > 0 ? `forbidden: ${presentForbidden.join(", ")}` : null,
-  ]
-    .filter(Boolean)
-    .join("\n")
+    `package: ${packageJsonPath}`,
+    `missing: ${missing.join(", ")}`,
+  ].join("\n")
 )
 
 process.exit(1)


### PR DESCRIPTION
## 관련 이슈

close #1178

## 작업 배경

- PR #1180이 CI와 리뷰 후 merge되지 않은 채 닫혔고, 원격 head branch도 삭제되어 기존 PR reopen이 실패했습니다.
- `refs/pull/1180/head`의 최종 변경을 현재 `main` 위에 복구해 로컬 Playwright CFT crash 회피 경로를 다시 반영합니다.

## 작업 내용

- macOS/non-CI raw Playwright 실행의 `channel: "chromium"` guard를 유지합니다.
- repo 표준 `yarn playwright` 진입점에만 `PLAYWRIGHT_LOCAL_CHROMIUM_CHANNEL=false`를 적용해 CFT crash 경로를 opt-out 합니다.
- `playwright:preflight`가 raw guard와 yarn opt-out 계약을 함께 검사합니다.

## 검증

- 실행한 명령과 결과:
  - `yarn --cwd front playwright:preflight`: exit 0
  - `git diff --check HEAD~1..HEAD`: exit 0
  - `yarn --cwd front build`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Playwright launcher 계약 | macOS local | `yarn --cwd front playwright:preflight` | command output | raw guard + yarn opt-out 계약 확인, exit 0 |
| diff whitespace | local | `git diff --check HEAD~1..HEAD` | command output | exit 0 |
| frontend build | local | `yarn --cwd front build` | command output | Next.js production build 성공 |
| Chrome crash 재현 | local | 미실행 | QA 제공 crash report 기준. 동일 popup 재발 방지를 위해 Chrome/Playwright 브라우저 실행은 수행하지 않음 | 재발 위험 검증 제외 사유 명시 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: PR #1180의 최종 리뷰 반영 상태를 current `main`에 다시 얹은 복구 PR입니다.

## 리스크

- raw `npx playwright` 직접 실행은 macOS channel guard를 유지합니다.
- repo 표준 `yarn playwright`/`test:e2e:*` 진입점에서는 CFT crash 경로를 우회합니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
