### PR TITLE
[Fix] monitoring scrape alert delivery cleanup

### DIFF
--- a/deploy/homeserver/docker-compose.prod.yml
+++ b/deploy/homeserver/docker-compose.prod.yml
@@ -83,6 +83,9 @@ services:
           printf '%s\n' '  group_interval: 5m'
           printf '%s\n' '  repeat_interval: 4h'
           printf '%s\n' '  routes:'
+          printf '%s\n' '    - receiver: drop'
+          printf '%s\n' '      matchers:'
+          printf '%s\n' '        - alertname=~"Aquila(PublicEdgeProbeScrapeDown|DockerRuntimeProbeScrapeDown|BackWorkerScrapeDown)"'
           printf '%s\n' '    - receiver: operations-email'
           printf '%s\n' '      matchers:'
           printf '%s\n' '        - severity=~"critical|warning"'
@@ -93,6 +96,14 @@ services:
           printf '%s\n' '    email_configs:'
           printf '      - to: %s\n' "$$OPERATIONS_ALERT_EMAIL_TO"
           printf '%s\n' '        send_resolved: true'
+          printf '%s\n' '        headers:'
+          printf '%s\n' '          Subject: "Aquila {{ .Status }}: {{ .CommonLabels.alertname }} ({{ .CommonLabels.severity }})"'
+          printf '%s\n' '        text: |-'
+          printf '%s\n' '          Status: {{ .Status }}'
+          printf '%s\n' '          Alert: {{ .CommonLabels.alertname }}'
+          printf '%s\n' '          Severity: {{ .CommonLabels.severity }}'
+          printf '%s\n' '          Summary: {{ .CommonAnnotations.summary }}'
+          printf '%s\n' '          Description: {{ .CommonAnnotations.description }}'
         } > /tmp/alertmanager.yml
         exec /bin/alertmanager --config.file=/tmp/alertmanager.yml --storage.path=/alertmanager
     environment:
@@ -209,7 +220,7 @@ services:
       - "--services"
       - "cloudflared,back_blue,back_green,back_read,back_admin,back_worker,db_1,redis_1,minio_1"
       - "--readiness-targets"
-      - "api=back-blue:8080,api=back-green:8080,read=back-read:8080,admin=back-admin:8080,worker=back_worker:8080"
+      - "api=back-blue:8080,api=back-green:8080,read=back-read:8080,admin=back-admin:8080,worker=back-worker:8080"
     volumes:
       - ./monitoring/docker-runtime-probe.mjs:/app/docker-runtime-probe.mjs:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -377,6 +388,10 @@ services:
       - db_1
       - redis_1
       - minio_1
+    networks:
+      default:
+        aliases:
+          - back-worker
 
   db_1:
     image: ${DB_IMAGE}

--- a/deploy/homeserver/monitoring/prometheus.yml
+++ b/deploy/homeserver/monitoring/prometheus.yml
@@ -44,7 +44,7 @@ scrape_configs:
           component: admin
           deploy_color: admin
       - targets:
-          - back_worker:8080
+          - back-worker:8080
         labels:
           service: aquila-back
           component: worker

--- a/tools/test/env-contract.test.mjs
+++ b/tools/test/env-contract.test.mjs
@@ -1759,7 +1759,7 @@ test("prometheus scrapes backend runtimes with color and component labels", () =
     "utf8",
   )
 
-  for (const target of ["back-blue:8080", "back-green:8080", "back-read:8080", "back-admin:8080", "back_worker:8080"]) {
+  for (const target of ["back-blue:8080", "back-green:8080", "back-read:8080", "back-admin:8080", "back-worker:8080"]) {
     assert.match(prometheus, new RegExp(`- ${target.replace(".", "\\.")}`))
   }
 

--- a/tools/test/monitoring-alerts.test.mjs
+++ b/tools/test/monitoring-alerts.test.mjs
@@ -76,6 +76,10 @@ test("operations alert email channel is wired through env contract, compose, and
   assert.match(compose, /operations-email/)
   assert.match(compose, /email_configs:/)
   assert.match(compose, /send_resolved: true/)
+  assert.match(compose, /alertname=~"Aquila\(PublicEdgeProbeScrapeDown\|DockerRuntimeProbeScrapeDown\|BackWorkerScrapeDown\)"/)
+  assert.match(compose, /Subject: "Aquila \{\{ \.Status \}\}: \{\{ \.CommonLabels\.alertname \}\} \(\{\{ \.CommonLabels\.severity \}\}\)"/)
+  assert.match(compose, /text: \|-/)
+  assert.match(compose, /Alert: \{\{ \.CommonLabels\.alertname \}\}/)
   assert.doesNotMatch(compose, /monitoring\/alertmanager\.yml:\/etc\/alertmanager\/alertmanager\.yml:ro/)
   assert.match(compose, /alertmanager_data:$/m)
 


### PR DESCRIPTION
## Summary
close #1235

- Drop noisy self-monitoring scrape alerts before operations email routing.
- Add readable Alertmanager email subject/body for remaining service-impact alerts.
- Scrape the worker runtime through an RFC-compatible `back-worker` alias instead of the underscore service hostname.

## Root Cause
- Alertmanager routed all warning/critical alerts to email on the repeat interval, including self-monitoring scrape-down alerts.
- The worker metrics target used a Docker service hostname with an underscore, which Tomcat rejects in the `Host` header with HTTP 400.

## Verification
- `node --test tools/test/monitoring-alerts.test.mjs tools/test/env-contract.test.mjs`: 57 pass
- `bash -n deploy/homeserver/blue_green_deploy.sh deploy/homeserver/check_deploy_status.sh deploy/homeserver/steady_state_guard.sh`: pass
- Homeserver: `http://back-worker:8080/actuator/prometheus` returned HTTP 200
- Homeserver: Prometheus active target `back-worker:8080` health is up
- Homeserver: scrape-down alert names absent from Prometheus and Alertmanager active alert APIs
- Homeserver: `bash deploy/homeserver/check_deploy_status.sh` returned `result=PASS`

## Deployment
- This patch has already been applied to the homeserver for immediate mitigation.
- Merging keeps the same fix in the repository so future deploys do not overwrite it.