### PR TITLE
[Style] P1-1 인증·설정 페이지 editorial 패밀리룩 재설계 (#1219)

### DIFF
--- a/front/e2e/helpers/perfFixtures.ts
+++ b/front/e2e/helpers/perfFixtures.ts
@@ -611,7 +611,6 @@ export const getThemeSurfaceFingerprint = async (page: Page) =>
       summaryBg: readStyle('[data-rum-section="summary"]', "backgroundColor"),
       summaryBorder: readStyle('[data-rum-section="summary"]', "borderTopColor"),
       authShellBg: readStyle('[data-auth-shell="true"]', "backgroundColor"),
-      authShellBorder: readStyle('[data-auth-shell="true"]', "borderTopColor"),
     }
   })
 

--- a/front/e2e/perf-layout.spec.ts
+++ b/front/e2e/perf-layout.spec.ts
@@ -455,8 +455,8 @@ test.describe("성능 레이아웃과 표면 예산", () => {
     expect(fingerprint.headerBg).not.toBe("rgb(255, 255, 255)")
     expect(fingerprint.headerBg).not.toBe(fingerprint.bodyBg)
     expect(fingerprint.themeToggleLabel).toBe("테마 전환")
-    expect(fingerprint.authShellBg).toBe("rgb(255, 255, 255)")
-    expect(fingerprint.authShellBorder).toBe("rgb(215, 224, 234)")
+    // 패밀리룩(1219): 인증 셸은 라운드 카드 → 투명 에디토리얼 컬럼. 카드 면/보더가 없어야 한다.
+    expect(fingerprint.authShellBg).toBe("rgba(0, 0, 0, 0)")
   }
 })
 })

--- a/front/src/components/auth/AuthEntryModal.styles.ts
+++ b/front/src/components/auth/AuthEntryModal.styles.ts
@@ -349,8 +349,8 @@ export const Modal = styled.div`
     }
 
     &.isOn .switch {
-      background: rgba(18, 184, 134, 0.44);
-      border-color: rgba(18, 184, 134, 0.76);
+      background: ${({ theme }) => `color-mix(in srgb, ${theme.publicDesign.accent} 44%, transparent)`};
+      border-color: ${({ theme }) => `color-mix(in srgb, ${theme.publicDesign.accent} 76%, transparent)`};
     }
 
     &.isOn .thumb {
@@ -358,7 +358,7 @@ export const Modal = styled.div`
     }
 
     &.isOn .state {
-      color: ${({ theme }) => theme.colors.green10};
+      color: ${({ theme }) => theme.publicDesign.accent};
     }
   }
 
@@ -387,15 +387,24 @@ export const Modal = styled.div`
     }
   }
 
+  /* 패밀리룩(1219): 파스텔 오류 박스 → 상태 dot + 텍스트 */
   .inlineError {
     margin: 0;
-    border-radius: 10px;
-    border: 1px solid ${({ theme }) => theme.colors.statusDangerBorder};
-    background: ${({ theme }) => theme.colors.statusDangerSurface};
+    display: flex;
+    gap: 0.5rem;
     color: ${({ theme }) => theme.colors.statusDangerText};
-    padding: 0.66rem 0.76rem;
     font-size: 0.84rem;
     line-height: 1.5;
+
+    &::before {
+      content: "";
+      flex: 0 0 auto;
+      width: 6px;
+      height: 6px;
+      margin-top: 0.42rem;
+      border-radius: 999px;
+      background: currentColor;
+    }
   }
 
   .primaryAction,
@@ -488,19 +497,19 @@ export const Modal = styled.div`
     gap: 0.9rem;
   }
 
+  /* 패밀리룩(1219): 파스텔 성공 카드 → 좌측 헤어라인 rule + 중립 텍스트 */
   .sentCard {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr);
     gap: 0.8rem;
-    padding: 0.95rem 1rem;
-    border-radius: 16px;
-    border: 1px solid ${({ theme }) => theme.colors.statusSuccessBorder};
-    background: ${({ theme }) => theme.colors.statusSuccessSurface};
-    color: ${({ theme }) => theme.colors.green11};
+    padding: 0.1rem 0 0.1rem 0.9rem;
+    border-left: 2px solid ${({ theme }) => theme.colors.statusSuccessText};
+    color: ${({ theme }) => theme.colors.gray12};
 
     svg {
       font-size: 1.3rem;
       margin-top: 0.1rem;
+      color: ${({ theme }) => theme.colors.statusSuccessText};
     }
 
     strong {

--- a/front/src/components/auth/AuthShell.tsx
+++ b/front/src/components/auth/AuthShell.tsx
@@ -58,29 +58,23 @@ const Main = styled.main `
 const Backdrop = styled.div `
   position: absolute;
   inset: 0;
-  background:
-    ${({ theme }) => theme.colors.gray1};
+  background: ${({ theme }) => theme.publicDesign.pageBackgroundColor};
 `;
+// 패밀리룩(1219): 라운드 카드 셸 + 그림자 제거 → 여백으로 구획하는 에디토리얼 단일 컬럼.
 const Shell = styled.section `
   position: relative;
   z-index: 1;
-  width: min(520px, 100%);
-  border: 1px solid ${({ theme }) => (theme.colors.gray5)};
-  border-radius: ${({ theme }) => ("22px")};
-  overflow: hidden;
-  background: ${({ theme }) => (theme.colors.gray1)};
-  box-shadow: ${({ theme }) => theme.scheme === "light"
-    ? "0 18px 40px rgba(15, 23, 42, 0.08)"
-    : "0 18px 40px rgba(0, 0, 0, 0.3)"};
+  width: min(480px, 100%);
+  background: transparent;
 `;
 const FormPanel = styled.section `
-  padding: 1.6rem 1.35rem 1.28rem;
+  padding: 0.4rem 0.2rem 1.28rem;
   background: transparent;
   display: grid;
   align-content: start;
 
   @media (max-width: 720px) {
-    padding: 1.2rem 0.9rem 1rem;
+    padding: 0.2rem 0 1rem;
   }
 `;
 const Top = styled.div `
@@ -107,32 +101,34 @@ const SubTitle = styled.p `
   color: ${({ theme }) => theme.colors.gray11};
   line-height: 1.6;
 `;
+// 패밀리룩(1219): 필형 탭 → 헤어라인 위 밑줄 강조 사각 탭.
 const Tabs = styled.div `
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.42rem;
-  margin-bottom: 1.08rem;
+  display: flex;
+  gap: 1.4rem;
+  margin-bottom: 1.4rem;
+  border-bottom: 1px solid ${({ theme }) => theme.publicDesign.border};
 `;
 const ActiveTab = styled.div `
-  border-radius: ${({ theme }) => ("11px")};
-  border: 1px solid ${({ theme }) => (theme.colors.gray6)};
-  background: ${({ theme }) => theme.scheme === "light"
-    ? theme.colors.gray2
-    : theme.colors.gray3};
+  margin-bottom: -1px;
+  padding: 0 0 0.62rem;
+  border-bottom: 2px solid ${({ theme }) => theme.colors.gray12};
   color: ${({ theme }) => theme.colors.gray12};
-  padding: 0.66rem 0.76rem;
-  text-align: center;
+  font-size: 0.95rem;
   font-weight: 700;
 `;
 const PassiveTab = styled(Link) `
-  border-radius: ${({ theme }) => ("11px")};
-  border: 1px solid ${({ theme }) => (theme.colors.gray5)};
-  background: ${({ theme }) => theme.publicDesign.pageBackgroundColor};
-  color: ${({ theme }) => theme.colors.gray11};
-  padding: 0.66rem 0.76rem;
+  margin-bottom: -1px;
+  padding: 0 0 0.62rem;
+  border-bottom: 2px solid transparent;
+  color: ${({ theme }) => theme.colors.gray10};
+  font-size: 0.95rem;
   text-align: center;
   text-decoration: none;
   font-weight: 600;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.gray12};
+  }
 `;
 const Body = styled.div `
   form {

--- a/front/src/components/auth/IpSecurityInfoModal.tsx
+++ b/front/src/components/auth/IpSecurityInfoModal.tsx
@@ -127,12 +127,14 @@ const Header = styled.header`
   }
 `
 
+// 패밀리룩(1219): 그린 파스텔 badge/라벨 → 헤어라인 사각 + 절제된 accent
 const LockMark = styled.div`
   width: 46px;
   height: 46px;
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.green7};
-  background: ${({ theme }) => theme.colors.green3};
+  border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.colors.gray6};
+  background: transparent;
+  color: ${({ theme }) => theme.publicDesign.accent};
   display: grid;
   place-items: center;
   font-size: 1.3rem;
@@ -140,7 +142,7 @@ const LockMark = styled.div`
 
 const Eyebrow = styled.small`
   display: inline-block;
-  color: ${({ theme }) => theme.colors.green10};
+  color: ${({ theme }) => theme.publicDesign.accent};
   font-weight: 800;
   margin-bottom: 0.26rem;
   letter-spacing: 0.02em;
@@ -176,8 +178,8 @@ const ModeCard = styled.article`
   }
 
   &[data-mode="on"] {
-    border-color: ${({ theme }) => theme.colors.green8};
-    box-shadow: inset 0 0 0 1px rgba(18, 184, 134, 0.2);
+    border-color: ${({ theme }) => theme.publicDesign.accent};
+    box-shadow: ${({ theme }) => `inset 0 0 0 1px color-mix(in srgb, ${theme.publicDesign.accent} 30%, transparent)`};
   }
 `
 

--- a/front/src/components/auth/LoginPage.styles.ts
+++ b/front/src/components/auth/LoginPage.styles.ts
@@ -1,20 +1,18 @@
 import styled from "@emotion/styled"
 
+// 패밀리룩(1219): 라운드+그림자 카드 입력 → 낮은 라운드 사각 컨트롤(그림자 제거).
 export const NaverField = styled.div`
   position: relative;
   border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 14px;
+  border-radius: 8px;
   background: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray1 : theme.colors.gray2)};
   min-height: 76px;
   padding: 1.55rem 0.92rem 0.48rem;
-  box-shadow: ${({ theme }) =>
-    theme.scheme === "light" ? "0 1px 0 rgba(15, 23, 42, 0.03)" : "none"};
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 
   &[data-active="true"] {
-    border-color: ${({ theme }) => theme.colors.gray7};
-    box-shadow: ${({ theme }) =>
-      theme.scheme === "light" ? "0 0 0 2px rgba(148, 163, 184, 0.12)" : "0 0 0 2px rgba(148, 163, 184, 0.1)"};
+    border-color: ${({ theme }) => theme.colors.gray8};
+    box-shadow: 0 0 0 2px ${({ theme }) => theme.publicDesign.accentMuted};
   }
 `
 
@@ -90,7 +88,7 @@ export const GhostIconButton = styled.button`
   height: 44px;
   padding: 0;
   border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 999px;
+  border-radius: 8px;
   background: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray1 : theme.colors.gray2)};
   color: ${({ theme }) => theme.colors.gray10};
   font-size: 0.72rem;
@@ -227,8 +225,8 @@ export const IpSecurityToggle = styled.button`
   }
 
   &[data-on="true"] .switch {
-    background: rgba(18, 184, 134, 0.44);
-    border-color: rgba(18, 184, 134, 0.76);
+    background: ${({ theme }) => `color-mix(in srgb, ${theme.publicDesign.accent} 44%, transparent)`};
+    border-color: ${({ theme }) => `color-mix(in srgb, ${theme.publicDesign.accent} 76%, transparent)`};
   }
 
   &[data-on="true"] .thumb {
@@ -236,7 +234,7 @@ export const IpSecurityToggle = styled.button`
   }
 
   &[data-on="true"] .state {
-    color: ${({ theme }) => theme.colors.green10};
+    color: ${({ theme }) => theme.publicDesign.accent};
   }
 `
 
@@ -291,26 +289,43 @@ export const PrimaryButton = styled.button`
   }
 `
 
+// 패밀리룩(1219): 파스텔 상태 박스 → 상태 dot + 텍스트(면 채색/보더 제거).
 export const ErrorText = styled.p`
   margin: 0;
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.statusDangerBorder};
-  background: ${({ theme }) => theme.colors.statusDangerSurface};
+  display: flex;
+  gap: 0.5rem;
   color: ${({ theme }) => theme.colors.statusDangerText};
-  padding: 0.82rem 0.9rem;
   font-size: 0.9rem;
   line-height: 1.55;
+
+  &::before {
+    content: "";
+    flex: 0 0 auto;
+    width: 6px;
+    height: 6px;
+    margin-top: 0.5rem;
+    border-radius: 999px;
+    background: currentColor;
+  }
 `
 
 export const SuccessText = styled.p`
   margin: 0;
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.statusSuccessBorder};
-  background: ${({ theme }) => theme.colors.statusSuccessSurface};
-  color: ${({ theme }) => theme.colors.statusSuccessText};
-  padding: 0.82rem 0.9rem;
+  display: flex;
+  gap: 0.5rem;
+  color: ${({ theme }) => theme.colors.gray12};
   font-size: 0.87rem;
   line-height: 1.65;
+
+  &::before {
+    content: "";
+    flex: 0 0 auto;
+    width: 6px;
+    height: 6px;
+    margin-top: 0.55rem;
+    border-radius: 999px;
+    background: ${({ theme }) => theme.colors.statusSuccessText};
+  }
 
   strong {
     font-weight: 800;

--- a/front/src/pages/signup.tsx
+++ b/front/src/pages/signup.tsx
@@ -278,7 +278,7 @@ const GhostIconButton = styled.button`
   height: 30px;
   padding: 0;
   border: 1px solid ${({ theme }) => theme.colors.gray6};
-  border-radius: 999px;
+  border-radius: 8px;
   background: ${({ theme }) => (theme.scheme === "light" ? theme.colors.gray1 : theme.colors.gray2)};
   color: ${({ theme }) => theme.colors.gray10};
   font-size: 0.72rem;
@@ -301,16 +301,17 @@ const GhostIconButton = styled.button`
   }
 `
 
+// 패밀리룩(1219): 그린 필 발행 버튼 → 낮은 라운드 사각 accent 컨트롤(scheme별 글자색)
 const PrimaryButton = styled.button`
   border: 0;
-  border-radius: 12px;
+  border-radius: 8px;
   padding: 0.84rem 1rem;
-  background: #12b886;
-  color: #fff;
+  background: ${({ theme }) => theme.publicDesign.accent};
+  color: ${({ theme }) => (theme.scheme === "light" ? theme.colors.accentControlText : theme.colors.gray1)};
   font-weight: 700;
   cursor: pointer;
   box-shadow: ${({ theme }) =>
-    theme.scheme === "light" ? "0 10px 22px rgba(18, 184, 134, 0.18)" : "none"};
+    theme.scheme === "light" ? `0 10px 22px color-mix(in srgb, ${theme.publicDesign.accent} 18%, transparent)` : "none"};
   transition: filter 0.16s ease, box-shadow 0.16s ease;
 
   &:hover:not(:disabled) {
@@ -351,7 +352,7 @@ const RequiredConsentBox = styled.div`
     width: 16px;
     height: 16px;
     margin-top: 0.16rem;
-    accent-color: #12b886;
+    accent-color: ${({ theme }) => theme.publicDesign.accent};
     flex: 0 0 auto;
   }
 
@@ -363,26 +364,43 @@ const RequiredConsentBox = styled.div`
   }
 `
 
+// 패밀리룩(1219): 파스텔 상태 박스 → 상태 dot + 텍스트
 const ErrorText = styled.p`
   margin: 0;
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.statusDangerBorder};
-  background: ${({ theme }) => theme.colors.statusDangerSurface};
+  display: flex;
+  gap: 0.5rem;
   color: ${({ theme }) => theme.colors.statusDangerText};
-  padding: 0.82rem 0.9rem;
   font-size: 0.9rem;
   line-height: 1.55;
+
+  &::before {
+    content: "";
+    flex: 0 0 auto;
+    width: 6px;
+    height: 6px;
+    margin-top: 0.5rem;
+    border-radius: 999px;
+    background: currentColor;
+  }
 `
 
 const SuccessText = styled.p`
   margin: 0;
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.statusSuccessBorder};
-  background: ${({ theme }) => theme.colors.statusSuccessSurface};
-  color: ${({ theme }) => theme.colors.statusSuccessText};
-  padding: 0.82rem 0.9rem;
+  display: flex;
+  gap: 0.5rem;
+  color: ${({ theme }) => theme.colors.gray12};
   font-size: 0.9rem;
   line-height: 1.65;
+
+  &::before {
+    content: "";
+    flex: 0 0 auto;
+    width: 6px;
+    height: 6px;
+    margin-top: 0.55rem;
+    border-radius: 999px;
+    background: ${({ theme }) => theme.colors.statusSuccessText};
+  }
 
   strong {
     word-break: break-all;

--- a/front/src/pages/signup/social/complete.tsx
+++ b/front/src/pages/signup/social/complete.tsx
@@ -507,13 +507,14 @@ const ErrorPanel = styled.div`
   gap: 0.8rem;
 `
 
+// 패밀리룩(1219): 그린 필 → 낮은 라운드 사각 accent 컨트롤
 const PrimaryButton = styled.button`
   min-width: 140px;
-  border: 1px solid ${({ theme }) => theme.colors.green8};
-  border-radius: 14px;
+  border: 0;
+  border-radius: 8px;
   padding: 0.9rem 1rem;
-  background: ${({ theme }) => theme.colors.green9};
-  color: #fff;
+  background: ${({ theme }) => theme.publicDesign.accent};
+  color: ${({ theme }) => (theme.scheme === "light" ? theme.colors.accentControlText : theme.colors.gray1)};
   font-weight: 700;
   cursor: pointer;
 

--- a/front/src/pages/signup/verify.tsx
+++ b/front/src/pages/signup/verify.tsx
@@ -566,13 +566,14 @@ const ErrorPanel = styled.div`
   gap: 0.8rem;
 `
 
+// 패밀리룩(1219): 그린 그라디언트 필 → 낮은 라운드 사각 accent 컨트롤
 const PrimaryButton = styled.button`
   min-width: 140px;
-  border: 1px solid ${({ theme }) => theme.colors.green8};
-  border-radius: 14px;
+  border: 0;
+  border-radius: 8px;
   padding: 0.9rem 1rem;
-  background: linear-gradient(135deg, #10b981, #34d399);
-  color: #fff;
+  background: ${({ theme }) => theme.publicDesign.accent};
+  color: ${({ theme }) => (theme.scheme === "light" ? theme.colors.accentControlText : theme.colors.gray1)};
   font-weight: 700;
   cursor: pointer;
 

--- a/front/src/routes/Settings/SettingsLayout.tsx
+++ b/front/src/routes/Settings/SettingsLayout.tsx
@@ -103,29 +103,27 @@ export const settingsStyles = `
     line-height: 1.6;
   }
 
+  /* 패밀리룩(1219): 필형 탭 그룹 → 헤어라인 위 밑줄 강조 사각 탭 */
   .tabs {
     display: inline-flex;
-    gap: 4px;
-    padding: 4px;
-    border: 1px solid var(--aq-border);
-    border-radius: 8px;
-    background: var(--aq-surface-elevated);
+    gap: 1.4rem;
+    border-bottom: 1px solid var(--aq-border);
   }
 
   .settingsPage .tabs a {
-    min-width: 92px;
-    padding: 9px 12px;
-    border-radius: 6px;
+    padding: 0 0 10px;
+    margin-bottom: -1px;
+    border-bottom: 2px solid transparent;
     color: var(--aq-text-secondary);
     text-align: center;
     text-decoration: none;
-    font-weight: 700;
+    font-weight: 600;
   }
 
   .settingsPage .tabs a.active {
     color: var(--aq-text);
-    background: var(--aq-surface);
-    box-shadow: 0 1px 2px rgba(15, 23, 32, 0.08);
+    border-bottom-color: var(--aq-text);
+    font-weight: 700;
   }
 
   .settingsGrid {
@@ -135,11 +133,10 @@ export const settingsStyles = `
     margin-top: 24px;
   }
 
+  /* 패밀리룩(1219): 라운드 카드 패널 → 헤어라인 구획 섹션(면/그림자 제거) */
   .panel {
-    padding: 22px;
-    border: 1px solid var(--aq-border);
-    border-radius: 8px;
-    background: var(--aq-surface);
+    padding: 24px 0 0;
+    border-top: 1px solid var(--aq-border);
   }
 
   .panel h2 {


### PR DESCRIPTION
## 관련 이슈

close #1219

패밀리룩 umbrella #1217의 P1-1. 선행 #1218(공용 토큰) 위에서 진행.

## 작업 배경

- 로그인/회원가입/설정이 "ACCESS PORTAL" 라운드 카드 + 그림자 + 파란/초록 필 버튼 + 파스텔 안내 박스의 전형적 SaaS 카드 문법으로, 출시 기준 3원칙(AI스럽지 않게, 박스에 다 넣지 않게)을 위반하는 이탈 폭이 가장 큰 공개 화면이었다.

## 작업 내용

- **AuthShell**: 라운드 카드 셸(border-radius 22px)·그림자 제거 → 여백으로 구획하는 에디토리얼 단일 컬럼. 필형 탭 → 헤어라인 위 밑줄 강조 사각 탭. backdrop을 종이 캔버스(pageBackgroundColor)로.
- **LoginPage 컨트롤**: 라운드+그림자 카드 입력 → 낮은 라운드(8px) 사각 컨트롤. pill(999px) 아이콘 버튼 → 사각. IP 보안 토글 green → accent. 파스텔 오류/성공 박스 → 상태 dot + 텍스트.
- **AuthEntryModal(헤더 진입 모달)**: 토글 green → accent, 파스텔 오류 박스 → dot+텍스트, 파스텔 성공 카드 → 좌측 헤어라인 rule + 중립 텍스트.
- **IpSecurityInfoModal**: green 파스텔 badge/eyebrow/모드 카드 → 헤어라인 사각 + 절제된 accent.
- **Settings(Layout/Account/Privacy)**: 필형 탭 그룹 → 밑줄 사각 탭, 라운드 카드 패널 → 헤어라인 구획 섹션(면/그림자 제거).
- **signup/verify/social 페이지**: green 필/그라디언트 발행 버튼 → 사각 accent 컨트롤. `#12b886`·`#10b981`·`#34d399`·`#fff` 등 하드코딩 hex 제거. 파스텔 상태 박스 → dot+텍스트.

카카오 로그인 버튼(`SocialAuthButtons`)은 공식 디자인 그대로 유지. 채운 컨트롤 글자색은 다크에서 accent가 밝은 블루이므로 어두운 글자(gray1)로 두어 WCAG AA 대비(>=4.5)를 만족한다.

## 검증

- `yarn --cwd front build`: 성공
- `node front/scripts/check-design-colors.mjs`: ok
- `next lint`(변경 파일): 경고/오류 없음
- rg 게이트: `rg "#[0-9a-fA-F]{3,6}" front/src/components/auth front/src/routes/Settings` → 무결과
- signup 계열 하드코딩 hex: `rg "#[0-9a-fA-F]{3,6}" front/src/pages/signup*` → 무결과
- 접근성: 새 accent 컨트롤/텍스트 pairing 대비 계산 모두 >=4.5

## 검증 증거

| 항목 | 확인 방법 | 결과 |
| --- | --- | --- |
| auth/settings 하드코딩 제거 | `rg "#[0-9a-fA-F]{3,6}" front/src/components/auth front/src/routes/Settings` | 무결과(통과) |
| signup 페이지 하드코딩 제거 | `rg "#[0-9a-fA-F]{3,6}" front/src/pages/signup.tsx front/src/pages/signup/verify.tsx front/src/pages/signup/social/complete.tsx` | 무결과(통과) |
| 빌드 | `yarn --cwd front build` | Done |
| 디자인 컬러 가드 | `check-design-colors.mjs` | ok |

## 리뷰어 메모

- 먼저 볼 지점: AuthShell 카드 제거 + 탭 재설계, 파스텔 상태 박스 → dot+텍스트 패턴, signup 계열 발행 버튼 accent 치환.
- 기능/접근성(IP 토글, 로그인 유지, 동의 체크, 포커스 링) 유지. 카카오 버튼 원형 유지.
- 스크린샷 증거는 umbrella 계획대로 마지막에 일괄 캡처 예정(이 PR에서는 스킵).

## 리스크

- 인증·설정·회원가입 화면 시각 재설계. 마크업 구조/클래스·기능 셀렉터는 유지해 e2e 회귀를 최소화.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
