### PR TITLE
[Style] P1-2 관리자 셸·허브·대시보드 pastel 상태 surface 정리 (#1220)

### DIFF
--- a/front/src/routes/Admin/AdminDashboardWorkspace.styles.layout.ts
+++ b/front/src/routes/Admin/AdminDashboardWorkspace.styles.layout.ts
@@ -12,7 +12,6 @@ import {
   adminBorderStrong,
   adminControlText,
   adminSurface,
-  adminSurfaceAccent,
   adminSurfaceRaised,
   adminTeal,
   adminTealBorder,
@@ -125,7 +124,6 @@ export const StatusChip = styled.span`
 
   &[data-tone="good"] {
     border-color: ${adminTealBorder};
-    background: ${adminSurfaceAccent};
     color: ${adminTeal};
   }
 
@@ -353,11 +351,11 @@ export const StatusDot = styled.i`
   border-radius: 50%;
   flex: 0 0 auto;
   background: ${adminTeal};
-  box-shadow: 0 0 0 4px rgba(17, 145, 112, 0.12);
+  box-shadow: 0 0 0 4px color-mix(in srgb, ${adminTeal} 14%, transparent);
 
   &[data-tone="warn"] {
     background: ${adminAccentText};
-    box-shadow: 0 0 0 4px rgba(180, 83, 9, 0.14);
+    box-shadow: 0 0 0 4px color-mix(in srgb, ${adminAccentText} 14%, transparent);
   }
 
   &[data-tone="neutral"] {

--- a/front/src/routes/Admin/AdminDashboardWorkspace.styles.priority.ts
+++ b/front/src/routes/Admin/AdminDashboardWorkspace.styles.priority.ts
@@ -9,7 +9,6 @@ import {
 import {
   adminBorder,
   adminSurface,
-  adminSurfaceAccent,
   adminTeal,
   adminTealBorder,
   adminTextPrimary,
@@ -219,7 +218,6 @@ export const PrioritySummary = styled.div`
 
   &[data-tone="good"] {
     border-color: ${adminTealBorder};
-    background: ${adminSurfaceAccent};
     color: ${adminTeal};
   }
 

--- a/front/src/routes/Admin/AdminHubSurface.styles.ts
+++ b/front/src/routes/Admin/AdminHubSurface.styles.ts
@@ -7,7 +7,6 @@ import {
   adminControlText,
   adminGoldTintFocus,
   adminSurface,
-  adminSurfaceAccent,
   adminSurfaceRaised,
   adminTeal,
   adminTealBorder,
@@ -327,7 +326,6 @@ export const ContentRow = styled.a`
 
   &[data-tone="good"] small {
     border-color: ${adminTealBorder};
-    background: ${adminSurfaceAccent};
     color: ${adminTeal};
   }
 `
@@ -387,7 +385,7 @@ export const StatusRow = styled.div`
     height: 0.48rem;
     border-radius: 50%;
     background: ${adminTeal};
-    box-shadow: 0 0 0 4px rgba(17, 145, 112, 0.12);
+    box-shadow: 0 0 0 4px ${adminGoldTintFocus};
   }
 
   strong {

--- a/front/src/routes/Admin/AdminSurfacePrimitives.tsx
+++ b/front/src/routes/Admin/AdminSurfacePrimitives.tsx
@@ -428,20 +428,16 @@ export const AdminInfoStatusItem = styled.div`
   background: ${({ theme }) => adminMutedSurface(theme)};
 
   &[data-tone="good"] {
-    background: ${({ theme }) => theme.colors.statusSuccessSurface};
     color: ${({ theme }) => theme.colors.statusSuccessText};
 
-    span,
     strong {
       color: ${({ theme }) => theme.colors.statusSuccessText};
     }
   }
 
   &[data-tone="warn"] {
-    background: ${({ theme }) => theme.colors.orange2};
     color: ${({ theme }) => theme.colors.orange10};
 
-    span,
     strong {
       color: ${({ theme }) => theme.colors.orange10};
     }
@@ -491,27 +487,24 @@ export const AdminStatusPill = styled.span<{ $size?: "sm" | "md" }>`
     color: ${({ theme }) => adminMutedText(theme)};
   }
 
+  /* 패밀리룩(1220): 상태 칩은 파스텔 면 대신 헤어라인 보더 + 상태 텍스트로 표현한다. */
   &[data-tone="accent"] {
     border-color: ${({ theme }) => adminStrongBorder(theme)};
-    background: ${({ theme }) => adminAccentSurface(theme)};
     color: ${adminGold};
   }
 
   &[data-tone="success"] {
     border-color: ${({ theme }) => theme.colors.statusSuccessBorder};
-    background: ${({ theme }) => theme.colors.statusSuccessSurface};
     color: ${({ theme }) => theme.colors.statusSuccessText};
   }
 
   &[data-tone="warn"] {
     border-color: ${({ theme }) => theme.colors.orange7};
-    background: ${({ theme }) => theme.colors.orange2};
     color: ${({ theme }) => theme.colors.orange10};
   }
 
   &[data-tone="danger"] {
     border-color: ${({ theme }) => theme.colors.statusDangerBorder};
-    background: ${({ theme }) => theme.colors.statusDangerSurface};
     color: ${({ theme }) => theme.colors.statusDangerText};
   }
 `

--- a/front/src/routes/Admin/AdminSurfacePrimitives.tsx
+++ b/front/src/routes/Admin/AdminSurfacePrimitives.tsx
@@ -436,10 +436,10 @@ export const AdminInfoStatusItem = styled.div`
   }
 
   &[data-tone="warn"] {
-    color: ${({ theme }) => theme.colors.orange10};
+    color: ${({ theme }) => theme.colors.orange11};
 
     strong {
-      color: ${({ theme }) => theme.colors.orange10};
+      color: ${({ theme }) => theme.colors.orange11};
     }
   }
 
@@ -500,7 +500,7 @@ export const AdminStatusPill = styled.span<{ $size?: "sm" | "md" }>`
 
   &[data-tone="warn"] {
     border-color: ${({ theme }) => theme.colors.orange7};
-    color: ${({ theme }) => theme.colors.orange10};
+    color: ${({ theme }) => theme.colors.orange11};
   }
 
   &[data-tone="danger"] {


### PR DESCRIPTION
## 관련 이슈

close #1220

패밀리룩 umbrella #1217의 P1-2.

## 작업 배경

- 관리자 화면의 파스텔 상태 박스/칩(연두/주황/하늘 surface)이 전형적 AI 대시보드 문법.
- 진단 근거 스크린샷(2026-06-24) 이후 코드가 진화해 KPI는 이미 헤어라인 메트릭 스트립(투명 카드 + 내부 border-right rule), 셸 캔버스는 #1218에서 공용 토큰으로 정합된 상태. 잔여 이탈은 파스텔 상태 surface.

## 작업 내용

- **AdminSurfacePrimitives**(셸/#1221 공용): 상태 row(`data-tone` good/warn)와 `AdminStatusPill`(accent/success/warn/danger)의 파스텔 surface fill 제거 → 상태는 헤어라인 보더 + 상태 텍스트로만 표현.
- **Hub**: `[data-tone="good"]` 배지의 파스텔 accent surface fill 제거(보더+텍스트 유지), 상태 dot의 off-palette green glow → accent tint.
- **Dashboard**: `[data-tone="good"]` 배지 파스텔 fill 제거, `StatusDot`의 green/orange glow → accent `color-mix`.
- 사용처가 사라진 `adminSurfaceAccent` import 정리(슬롯 자체는 셸 nav 활성/#1221이 공용 사용 → 유지).

## 검증

- `yarn --cwd front build`: 성공
- `check-design-colors.mjs`: ok / `next lint`(변경 파일): 오류 없음
- 상태 텍스트(success/warn/danger)가 중립 base 위에서 WCAG AA(>=4.5) 만족(계산 확인)
- e2e source-contract(AdminStatusPill/MetricCard export 구조) 유지

## 리뷰어 메모

- KPI 카드→테이블 재설계는 이미 헤어라인화되어 있어 이번 범위에서 구조 변경 없음(스타일 fill 제거 위주).
- 셸 nav 활성 상태의 subtle accent tint는 "현재 위치" 어포던스로 유지.
- 스크린샷 증거는 umbrella 계획대로 마지막 일괄 캡처.

## 리스크

- 공유 프리미티브(AdminSurfacePrimitives) 변경으로 관리자 전 화면 상태 표현에 파급. 구조/셀렉터는 유지.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
