### PR TITLE
[Style] P1-3 관리자 글관리·클라우드·프로필·도구 pastel 상태 면 정리 (#1221)

### DIFF
--- a/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
+++ b/front/src/routes/Admin/AdminCloudWorkspace.styles.ts
@@ -1351,25 +1351,23 @@ export const StatusPill = styled.span`
   max-width: 5.6rem;
   border-radius: 2px;
   padding: 0.22rem 0.45rem;
-  background: ${surfaceAccent};
+  background: ${surfaceRaised};
   color: ${accentGold};
   font-size: 0.7rem;
   font-weight: 850;
   text-align: center;
   white-space: nowrap;
 
+  /* 패밀리룩(1221): 파스텔 상태 면 대신 중립 base + 상태 텍스트 */
   &[data-status="failed"] {
-    background: ${({ theme }) => theme.colors.statusDangerSurface};
     color: ${({ theme }) => theme.colors.statusDangerText};
   }
 
   &[data-status="cancelled"] {
-    background: ${({ theme }) => theme.colors.gray3};
     color: ${({ theme }) => theme.colors.gray10};
   }
 
   &[data-status="done"] {
-    background: ${({ theme }) => theme.colors.statusSuccessSurface};
     color: ${({ theme }) => theme.colors.statusSuccessText};
   }
 `

--- a/front/src/routes/Admin/AdminPostsWorkspaceFeedbackLayer.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspaceFeedbackLayer.tsx
@@ -187,13 +187,14 @@ const ConfirmDialog = styled.div`
   }
 `
 
+// 패밀리룩(1221): 파스텔 danger 버튼 → danger 아웃라인 사각 컨트롤
 const ConfirmButton = styled.button<{ "data-tone": "danger" }>`
-  border: 0;
-  background: ${({ theme }) => theme.colors.statusDangerSurface};
+  border: 1px solid ${({ theme }) => theme.colors.statusDangerBorder};
+  background: transparent;
   color: ${({ theme }) => theme.colors.statusDangerText};
   min-height: 40px;
   padding: 0 0.85rem;
-  border-radius: 10px;
+  border-radius: 8px;
   font-size: 0.92rem;
   font-weight: 800;
   cursor: pointer;

--- a/front/src/routes/Admin/AdminPostsWorkspacePageSections.tsx
+++ b/front/src/routes/Admin/AdminPostsWorkspacePageSections.tsx
@@ -145,7 +145,6 @@ export const RecentActionList = styled.ul`
 
   li[data-tone="error"] {
     border-color: ${({ theme }) => theme.colors.statusDangerBorder};
-    background: ${({ theme }) => theme.colors.statusDangerSurface};
   }
 
   .copy {
@@ -183,7 +182,6 @@ export const RecentActionList = styled.ul`
 
   li[data-tone="error"] .stateLabel {
     border-color: ${({ theme }) => theme.colors.statusDangerBorder};
-    background: ${({ theme }) => theme.colors.statusDangerSurface};
     color: ${({ theme }) => theme.colors.statusDangerText};
   }
 

--- a/front/src/routes/Admin/AdminProfileWorkspace.styles.layout.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspace.styles.layout.ts
@@ -189,8 +189,7 @@ export const SectionStateBadge = styled.span`
 
   &[data-tone="dirty"] {
     border-color: ${({ theme }) => theme.colors.orange7};
-    color: ${({ theme }) => theme.colors.orange10};
-    background: ${({ theme }) => theme.colors.orange2};
+    color: ${({ theme }) => theme.colors.orange11};
   }
 
   &[data-tone="published"] {

--- a/front/src/routes/Admin/AdminProfileWorkspace.styles.sections.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspace.styles.sections.ts
@@ -12,7 +12,6 @@ import {
 } from "src/routes/Admin/AdminSurfacePrimitives"
 import {
   adminWarningBadgeBorder,
-  adminWarningBadgeSurface,
   adminWarningBadgeText,
 } from "src/routes/Admin/adminColorTokens"
 import { BaseButton, PublishButton } from "./AdminProfileWorkspace.styles.tokens"
@@ -280,21 +279,19 @@ export const ToastCard = styled.div`
   line-height: 1.58;
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
 
+  /* 패밀리룩(1221): 토스트는 파스텔 tone 면 대신 중립 카드 + tone 보더/텍스트 */
   &[data-tone="success"] {
     border-color: ${({ theme }) => theme.colors.green8};
-    background: ${({ theme }) => theme.colors.green3};
     color: ${({ theme }) => theme.colors.green11};
   }
 
   &[data-tone="error"] {
     border-color: ${({ theme }) => theme.colors.red8};
-    background: ${({ theme }) => theme.colors.red3};
     color: ${({ theme }) => theme.colors.red11};
   }
 
   &[data-tone="loading"] {
     border-color: ${adminWarningBadgeBorder()};
-    background: ${adminWarningBadgeSurface()};
     color: ${adminWarningBadgeText()};
   }
 `

--- a/front/src/routes/Admin/AdminProfileWorkspace.styles.tokens.ts
+++ b/front/src/routes/Admin/AdminProfileWorkspace.styles.tokens.ts
@@ -96,17 +96,8 @@ export const PrimaryButton = styled(BaseButton)`
   }
 `
 
-export const PublishButton = styled(PrimaryButton)`
-  border-color: ${({ theme }) => theme.colors.green8};
-  background: ${({ theme }) => theme.colors.green3};
-  color: ${({ theme }) => theme.colors.green11};
-
-  &:hover:not(:disabled) {
-    border-color: ${({ theme }) => theme.colors.green9};
-    background: ${({ theme }) => theme.colors.green4};
-    color: ${({ theme }) => theme.colors.green12};
-  }
-`
+// 패밀리룩(1221): 발행 버튼은 그린 파스텔 대신 기준 accent primary 컨트롤을 쓴다.
+export const PublishButton = PrimaryButton
 
 export const MiniButton = styled(BaseButton)`
   min-height: 0;

--- a/front/src/routes/Admin/AdminToolsWorkspace.styles.layout.ts
+++ b/front/src/routes/Admin/AdminToolsWorkspace.styles.layout.ts
@@ -14,7 +14,6 @@ import {
 import {
   adminActionGroupSurface,
   adminWarningBadgeBorder,
-  adminWarningBadgeSurface,
   adminWarningBadgeText,
 } from "src/routes/Admin/adminColorTokens"
 
@@ -29,19 +28,16 @@ export const InlineNotice = styled.p`
 
   &[data-tone="warning"] {
     border-color: ${adminWarningBadgeBorder()};
-    background: ${adminWarningBadgeSurface()};
     color: ${adminWarningBadgeText()};
   }
 
   &[data-tone="danger"] {
     border-color: ${({ theme }) => theme.colors.statusDangerBorder};
-    background: ${({ theme }) => theme.colors.statusDangerSurface};
     color: ${({ theme }) => theme.colors.statusDangerText};
   }
 
   &[data-tone="success"] {
     border-color: ${({ theme }) => theme.colors.statusSuccessBorder};
-    background: ${({ theme }) => theme.colors.statusSuccessSurface};
     color: ${({ theme }) => theme.colors.statusSuccessText};
   }
 `
@@ -182,7 +178,6 @@ export const ActionToneBadge = styled(AdminStatusPill)`
 
   &[data-tone="danger"] {
     border-color: ${({ theme }) => theme.colors.statusDangerBorder};
-    background: ${({ theme }) => theme.colors.statusDangerSurface};
     color: ${({ theme }) => theme.colors.statusDangerText};
   }
 

--- a/front/src/routes/Admin/AdminToolsWorkspace.styles.tokens.ts
+++ b/front/src/routes/Admin/AdminToolsWorkspace.styles.tokens.ts
@@ -17,7 +17,6 @@ import {
   adminSurface,
   adminSurfaceRaised,
   adminWarningBadgeBorder,
-  adminWarningBadgeSurface,
   adminWarningBadgeText,
 } from "src/routes/Admin/adminColorTokens"
 
@@ -204,7 +203,7 @@ export const WorkspaceSection = styled.section`
   }
 
   &[data-tone="danger"] {
-    background: linear-gradient(180deg, ${({ theme }) => theme.colors.gray2} 0%, rgba(239, 68, 68, 0.08) 100%);
+    background: ${({ theme }) => theme.colors.gray2};
     border-color: ${({ theme }) => theme.colors.statusDangerBorder};
   }
 `
@@ -213,22 +212,20 @@ export const SectionHeading = styled(AdminSectionHeading)`
   align-items: flex-start;
 `
 
+// 패밀리룩(1221): 상태 배지는 파스텔 면 대신 헤어라인 보더 + 상태 텍스트로 표현.
 export const StatusBadge = styled(AdminStatusPill)`
   min-height: 34px;
   padding: 0 0.78rem;
   border-color: ${adminWarningBadgeBorder()};
-  background: ${adminWarningBadgeSurface()};
   color: ${adminWarningBadgeText()};
 
   &[data-tone="success"] {
     border-color: ${({ theme }) => theme.colors.statusSuccessBorder};
-    background: ${({ theme }) => theme.colors.statusSuccessSurface};
     color: ${({ theme }) => theme.colors.statusSuccessText};
   }
 
   &[data-tone="danger"] {
     border-color: ${({ theme }) => theme.colors.statusDangerBorder};
-    background: ${({ theme }) => theme.colors.statusDangerSurface};
     color: ${({ theme }) => theme.colors.statusDangerText};
   }
 `
@@ -239,19 +236,16 @@ export const FreshnessBadge = styled(AdminStatusPill)`
 
   &[data-tone="fresh"] {
     border-color: ${({ theme }) => theme.colors.statusSuccessBorder};
-    background: ${({ theme }) => theme.colors.statusSuccessSurface};
     color: ${({ theme }) => theme.colors.statusSuccessText};
   }
 
   &[data-tone="aging"] {
     border-color: ${({ theme }) => theme.colors.orange7};
-    background: ${({ theme }) => theme.colors.orange2};
-    color: ${({ theme }) => theme.colors.orange10};
+    color: ${({ theme }) => theme.colors.orange11};
   }
 
   &[data-tone="stale"] {
     border-color: ${({ theme }) => theme.colors.gray6};
-    background: ${({ theme }) => theme.colors.gray2};
     color: ${({ theme }) => theme.colors.gray10};
   }
 `


### PR DESCRIPTION
## 관련 이슈

close #1221

패밀리룩 umbrella #1217의 P1-3.

## 작업 내용

관리자 작업 화면 4종의 파스텔 상태 박스/칩/버튼을 패밀리룩 상태 문법(헤어라인 보더 + 상태 텍스트, 면 채색 없음)으로 정리.

- **Tools**: `StatusBadge`/`FreshnessBadge`/상태 배지의 파스텔 surface fill 제거, danger 패널의 red gradient → 중립 면, aging 텍스트 `orange10`→`orange11`(대비 확보), 미사용 import 정리.
- **Profile**: 토스트(success/error/loading) → 중립 카드 + tone 보더/텍스트, dirty 상태 파스텔 제거(`orange11`), `PublishButton` green 파스텔 → 기준 accent primary alias.
- **Cloud**: `StatusPill`을 중립 base + 상태 텍스트로(파스텔 accent/status 면 제거).
- **Posts**: 오류 alert row/라벨 파스텔 제거(danger 아웃라인), 삭제 confirm 버튼 → danger 아웃라인 사각 컨트롤.

`AdminSurfacePrimitives`(공유)의 상태 칩은 #1220에서 이미 헤어라인화됨.

## 검증

- `yarn --cwd front build`: 성공 / `check-design-colors.mjs`: ok / `next lint`: 오류 없음
- 잔여 파스텔 status surface: `rg "statusSuccessSurface|statusDangerSurface|green3|red3|orange2" <파일들>` → 무결과
- 상태 텍스트(success/warn/danger)가 중립 base 위에서 WCAG AA(>=4.5) 만족(계산 확인)

## 리뷰어 메모

- 상태 색은 면(surface)이 아니라 보더/텍스트에만. selected/active accent tint(현재 위치 어포던스)와 로딩 스켈레톤 shimmer는 유지.
- 필터 box-in-box는 이미 헤어라인 구획이라 구조 변경 없이 상태 면만 정리.
- 스크린샷 증거는 umbrella 계획대로 마지막 일괄 캡처.

## 리스크

- 관리자 4개 워크스페이스 상태 표현 시각 변경. 마크업/셀렉터 유지.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
