### PR TITLE
[Style] P1-4 에디터 발행 버튼·상태 알림 editorial 정합 (#1222)

### DIFF
--- a/front/src/routes/Admin/EditorStudioComposeAssistantPanelParts.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeAssistantPanelParts.tsx
@@ -368,9 +368,9 @@ export const ComposeStatusRow = styled.div`
     line-height: 1.48;
   }
 
+  /* 패밀리룩(1222): 파스텔 상태 알림 면 → 헤어라인 보더 + 상태 텍스트 */
   &[data-tone="loading"] {
     border-color: ${({ theme }) => theme.colors.blue7};
-    background: ${({ theme }) => theme.colors.blue3};
 
     span {
       color: ${({ theme }) => theme.colors.blue11};
@@ -379,7 +379,6 @@ export const ComposeStatusRow = styled.div`
 
   &[data-tone="success"] {
     border-color: ${({ theme }) => theme.colors.green7};
-    background: ${({ theme }) => theme.colors.green3};
 
     span {
       color: ${({ theme }) => theme.colors.green11};
@@ -388,7 +387,6 @@ export const ComposeStatusRow = styled.div`
 
   &[data-tone="error"] {
     border-color: ${({ theme }) => theme.colors.red7};
-    background: ${({ theme }) => theme.colors.red3};
 
     span {
       color: ${({ theme }) => theme.colors.red11};

--- a/front/src/routes/Admin/EditorStudioComposeMobileChrome.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeMobileChrome.tsx
@@ -133,19 +133,17 @@ const MobileComposeStatusBar = styled.div`
       letter-spacing: -0.01em;
     }
 
+    /* 패밀리룩(1222): 파스텔 상태 면 → 헤어라인 보더(면 채색 제거) */
     &[data-tone="loading"] {
       border-color: ${({ theme }) => theme.colors.blue7};
-      background: color-mix(in srgb, ${({ theme }) => theme.colors.blue3} 82%, transparent);
     }
 
     &[data-tone="success"] {
       border-color: ${({ theme }) => theme.colors.green7};
-      background: color-mix(in srgb, ${({ theme }) => theme.colors.green3} 84%, transparent);
     }
 
     &[data-tone="error"] {
       border-color: ${({ theme }) => theme.colors.red7};
-      background: color-mix(in srgb, ${({ theme }) => theme.colors.red3} 84%, transparent);
     }
   }
 `

--- a/front/src/routes/Admin/EditorStudioComposeWorkspace.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeWorkspace.tsx
@@ -235,17 +235,18 @@ const Button = styled.button `
     cursor: not-allowed;
   }
 `;
+// 패밀리룩(1222): 파란 발행 버튼 하드코딩 → 공용 accent 사각 컨트롤(scheme별 글자색)
 const PrimaryButton = styled(Button) `
   border-radius: 6px;
   padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => (theme.scheme === "dark" ? "#0a58ca" : "#0969da")};
-  background: ${({ theme }) => (theme.scheme === "dark" ? "#0a58ca" : "#0969da")};
-  color: ${({ theme }) => theme.colors.accentControlText};
+  border-color: ${({ theme }) => theme.publicDesign.accent};
+  background: ${({ theme }) => theme.publicDesign.accent};
+  color: ${({ theme }) => (theme.scheme === "light" ? theme.colors.accentControlText : theme.colors.gray1)};
   font-weight: 700;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => (theme.scheme === "dark" ? "#084298" : "#075bb5")};
-    background: ${({ theme }) => (theme.scheme === "dark" ? "#084298" : "#075bb5")};
-    color: ${({ theme }) => theme.colors.accentControlText};
+    border-color: ${({ theme }) => theme.publicDesign.accentHover};
+    background: ${({ theme }) => theme.publicDesign.accentHover};
+    color: ${({ theme }) => (theme.scheme === "light" ? theme.colors.accentControlText : theme.colors.gray1)};
   }
 `;

--- a/front/src/routes/Admin/EditorStudioComposeWritingSurfaceParts.tsx
+++ b/front/src/routes/Admin/EditorStudioComposeWritingSurfaceParts.tsx
@@ -439,17 +439,18 @@ export const Button = styled.button `
     cursor: not-allowed;
   }
 `;
+// 패밀리룩(1222): 파란 발행 버튼 하드코딩 → 공용 accent 사각 컨트롤(scheme별 글자색)
 export const PrimaryButton = styled(Button) `
   border-radius: 6px;
   padding: 0.6rem 0.88rem;
-  border-color: ${({ theme }) => (theme.scheme === "dark" ? "#0a58ca" : "#0969da")};
-  background: ${({ theme }) => (theme.scheme === "dark" ? "#0a58ca" : "#0969da")};
-  color: ${({ theme }) => theme.colors.accentControlText};
+  border-color: ${({ theme }) => theme.publicDesign.accent};
+  background: ${({ theme }) => theme.publicDesign.accent};
+  color: ${({ theme }) => (theme.scheme === "light" ? theme.colors.accentControlText : theme.colors.gray1)};
   font-weight: 700;
 
   &:hover:not(:disabled) {
-    border-color: ${({ theme }) => (theme.scheme === "dark" ? "#084298" : "#075bb5")};
-    background: ${({ theme }) => (theme.scheme === "dark" ? "#084298" : "#075bb5")};
-    color: ${({ theme }) => theme.colors.accentControlText};
+    border-color: ${({ theme }) => theme.publicDesign.accentHover};
+    background: ${({ theme }) => theme.publicDesign.accentHover};
+    color: ${({ theme }) => (theme.scheme === "light" ? theme.colors.accentControlText : theme.colors.gray1)};
   }
 `;

--- a/front/src/routes/Admin/EditorStudioPublishModalStyles.tsx
+++ b/front/src/routes/Admin/EditorStudioPublishModalStyles.tsx
@@ -472,22 +472,20 @@ export const PublishModalNotice = styled.div`
     background: transparent;
   }
 
+  /* 패밀리룩(1222): 파스텔 상태 알림 면 → 헤어라인 보더 + 상태 텍스트 */
   &[data-tone="loading"] {
     color: ${({ theme }) => theme.colors.blue11};
     border: 1px solid ${({ theme }) => theme.colors.blue7};
-    background: ${({ theme }) => theme.colors.blue3};
   }
 
   &[data-tone="success"] {
     color: ${({ theme }) => theme.colors.green11};
     border: 1px solid ${({ theme }) => theme.colors.green7};
-    background: ${({ theme }) => theme.colors.green3};
   }
 
   &[data-tone="error"] {
     color: ${({ theme }) => theme.colors.red11};
     border: 1px solid ${({ theme }) => theme.colors.red7};
-    background: ${({ theme }) => theme.colors.red3};
   }
 
   @media (max-width: 720px) {


### PR DESCRIPTION
## 관련 이슈

close #1222

패밀리룩 umbrella #1217의 P1-4. umbrella rg 게이트 중 `EditorStudioCompose*` 4히트 소유.

## 작업 내용

- **발행 버튼**(`ComposeWorkspace`/`WritingSurfaceParts` PrimaryButton): 하드코딩 `#0969da`/`#0a58ca`(+hover `#075bb5`/`#084298`) → 공용 `publicDesign.accent`/`accentHover` 사각 컨트롤. 다크에서 accent가 밝은 블루라 글자색을 `gray1`로 두어 WCAG AA(>=4.5) 확보.
- **상태 알림 블록**(`AssistantPanelParts`/`PublishModalStyles`/`MobileChrome`): `blue3`/`green3`/`red3` 파스텔 surface fill 제거 → 헤어라인 보더 + 상태 텍스트.
- selected/active accent tint(현재 선택 어포던스)와 스켈레톤 shimmer는 유지.

## 검증

- `yarn --cwd front build`: 성공 / `check-design-colors.mjs`: ok / `next lint`: 오류 없음
- 게이트: `rg "#0969da|#0a58ca" front/src/routes/Admin/EditorStudio*` → 무결과
- 잔여 파스텔 status surface(compose/publish): 무결과
- 발행 버튼 글자색 대비 계산 AA 만족(light: white/#155eef, dark: gray1/#78a7ff)

## 리뷰어 메모

- 본문 미리보기의 `#0969da`(markdown 2건)는 #1224 소유로 이 PR 범위 밖.
- 발행/작성/미리보기 플로우와 셀렉터는 유지(발행 버튼 텍스트 "발행" 등).
- 스크린샷 증거는 umbrella 계획대로 마지막 일괄 캡처.

## 리스크

- 에디터 발행 버튼/상태 알림 시각 변경. 마크업/셀렉터 유지.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
