### PR TITLE
[Style] P2-1 오류 페이지(404/500) editorial 재설계 (#1223)

### DIFF
--- a/front/src/components/error/ErrorFallbackView.tsx
+++ b/front/src/components/error/ErrorFallbackView.tsx
@@ -11,13 +11,13 @@ type ErrorFallbackViewProps = {
 
 const copyByVariant = {
   global: {
-    status: "500",
+    status: "ERROR · 500",
     title: "문제가 발생했습니다",
     description:
       "예상하지 못한 오류로 화면을 표시하지 못했습니다. 오류 ID를 남겨두고 다시 시도하거나 홈으로 이동하세요.",
   },
   surface: {
-    status: "!",
+    status: "RENDER ERROR",
     title: "콘텐츠를 표시하지 못했습니다",
     description:
       "이 영역을 렌더링하는 중 오류가 발생했습니다. 작성 중인 내용은 브라우저에 남아 있으며 다시 시도할 수 있습니다.",
@@ -51,63 +51,66 @@ export const ErrorFallbackView = ({ variant, errorId, onRetry }: ErrorFallbackVi
   )
 }
 
+// 패밀리룩(1223): 중앙 정렬 제네릭 + 필 버튼 → 좌측 정렬 에디토리얼(모노 라벨 +
+// 대형 헤드라인 + 헤어라인 + 사각/잉크 컨트롤). 색은 전부 공용 토큰.
+const monoLabel = `"SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace`
+
 const StyledWrapper = styled.section`
-  display: grid;
-  place-items: center;
+  display: block;
   min-height: min(72vh, 42rem);
-  padding: clamp(2rem, 6vw, 4.5rem) 1rem;
-  color: #111827;
+  padding: clamp(2.5rem, 8vw, 5rem) clamp(1rem, 5vw, 2rem);
+  color: ${({ theme }) => theme.colors.gray12};
 
   .shell {
+    width: min(100%, 46rem);
+    margin: 0 auto;
     display: grid;
-    gap: 1.25rem;
-    justify-items: center;
-    width: min(100%, 38rem);
-    text-align: center;
+    gap: 1.1rem;
   }
 
   .status {
-    display: grid;
-    place-items: center;
-    width: 4.25rem;
-    height: 4.25rem;
-    border: 1px solid #d1d5db;
-    border-radius: 50%;
-    background: #f9fafb;
-    color: #374151;
-    font-size: 1.35rem;
-    font-weight: 800;
+    font-family: ${monoLabel};
+    font-size: 11px;
+    font-weight: 760;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: ${({ theme }) => theme.colors.gray10};
   }
 
   .copy {
     display: grid;
-    gap: 0.7rem;
+    gap: 0.85rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid ${({ theme }) => theme.publicDesign.border};
   }
 
   h1 {
     margin: 0;
-    font-size: clamp(1.55rem, 4vw, 2.2rem);
-    line-height: 1.2;
-    letter-spacing: 0;
+    font-size: clamp(1.9rem, 5vw, 2.8rem);
+    line-height: 1.15;
+    font-weight: 800;
+    letter-spacing: -0.02em;
   }
 
   p {
     margin: 0;
-    color: #4b5563;
+    max-width: 40rem;
+    color: ${({ theme }) => theme.colors.gray11};
     line-height: 1.7;
   }
 
   span {
-    color: #6b7280;
-    font-size: 0.88rem;
+    font-family: ${monoLabel};
+    color: ${({ theme }) => theme.colors.gray10};
+    font-size: 0.82rem;
     font-weight: 700;
   }
 
   .actions {
     display: flex;
     flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.7rem;
+    gap: 0.6rem;
+    margin-top: 0.4rem;
   }
 
   button,
@@ -116,11 +119,11 @@ const StyledWrapper = styled.section`
     align-items: center;
     justify-content: center;
     min-height: 44px;
-    padding: 0 1rem;
-    border: 1px solid #d1d5db;
-    border-radius: 999px;
-    background: #ffffff;
-    color: #111827;
+    padding: 0 1.1rem;
+    border: 1px solid ${({ theme }) => theme.publicDesign.borderStrong};
+    border-radius: 6px;
+    background: transparent;
+    color: ${({ theme }) => theme.colors.gray12};
     font: inherit;
     font-size: 0.92rem;
     font-weight: 800;
@@ -128,9 +131,17 @@ const StyledWrapper = styled.section`
     cursor: pointer;
   }
 
-  button:hover,
+  a {
+    border-color: ${({ theme }) => theme.colors.gray12};
+    background: ${({ theme }) => theme.colors.gray12};
+    color: ${({ theme }) => theme.publicDesign.pageBackgroundColor};
+  }
+
+  button:hover {
+    border-color: ${({ theme }) => theme.colors.gray12};
+  }
+
   a:hover {
-    border-color: #9ca3af;
-    background: #f3f4f6;
+    opacity: 0.88;
   }
 `

--- a/front/src/routes/Error/index.tsx
+++ b/front/src/routes/Error/index.tsx
@@ -1,26 +1,24 @@
 import styled from "@emotion/styled"
 import Link from "next/link"
 
-import AppIcon from "src/components/icons/AppIcon"
-
+// 패밀리룩(1223): "4?4" 제네릭 중앙 정렬 + 필 버튼 → 좌측 정렬 에디토리얼(모노 라벨 +
+// 대형 헤드라인 + 헤어라인 + 사각/잉크 컨트롤). 404/500이 동일 오류 UI 문법을 공유한다.
 const CustomError = () => {
   return (
     <StyledWrapper>
-      <div className="wrapper">
-        <div className="top">
-          <div>4</div>
-          <AppIcon name="question" className="questionIcon" />
-          <div>4</div>
-        </div>
+      <div className="shell">
+        <div className="status">ERROR · 404</div>
         <div className="copy">
-          <strong>찾을 수 없는 페이지입니다.</strong>
+          <h1>찾을 수 없는 페이지입니다.</h1>
           <p>
-            주소가 바뀌었거나 삭제된 글일 수 있습니다. 홈으로 돌아가 최신
-            글이나 블로그 소개부터 다시 확인하세요.
+            주소가 바뀌었거나 삭제된 글일 수 있습니다. 홈으로 돌아가 최신 글이나 블로그 소개부터 다시
+            확인하세요.
           </p>
         </div>
         <div className="actions">
-          <Link href="/">홈으로 이동</Link>
+          <Link href="/" className="primary">
+            홈으로 이동
+          </Link>
           <Link href="/about">블로그 소개</Link>
         </div>
       </div>
@@ -30,89 +28,86 @@ const CustomError = () => {
 
 export default CustomError
 
+const monoLabel = `"SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace`
+
 const StyledWrapper = styled.div`
-  margin: 0 auto;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-  padding-top: 3rem;
-  padding-bottom: 3rem;
-  border-radius: 1.5rem;
-  max-width: 56rem;
-  background: transparent;
-  border: 1px solid transparent;
-  box-shadow: none;
+  display: block;
+  min-height: min(72vh, 42rem);
+  padding: clamp(2.5rem, 8vw, 5rem) clamp(1rem, 5vw, 2rem);
+  color: ${({ theme }) => theme.colors.gray12};
 
-  .wrapper {
+  .shell {
+    width: min(100%, 46rem);
+    margin: 0 auto;
+    display: grid;
+    gap: 1.1rem;
+  }
+
+  .status {
+    font-family: ${monoLabel};
+    font-size: 11px;
+    font-weight: 760;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: ${({ theme }) => theme.colors.gray10};
+  }
+
+  .copy {
+    display: grid;
+    gap: 0.85rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid ${({ theme }) => theme.publicDesign.border};
+  }
+
+  .copy h1 {
+    margin: 0;
+    font-size: clamp(1.9rem, 5vw, 2.8rem);
+    line-height: 1.15;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+  }
+
+  .copy p {
+    margin: 0;
+    max-width: 40rem;
+    color: ${({ theme }) => theme.colors.gray11};
+    line-height: 1.7;
+  }
+
+  .actions {
     display: flex;
-    padding-top: 5rem;
-    padding-bottom: 5rem;
-    flex-direction: column;
-    gap: 2.5rem;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    margin-top: 0.4rem;
+  }
+
+  .actions a {
+    display: inline-flex;
     align-items: center;
-    > .top {
-      display: flex;
-      align-items: center;
-      gap: 0.3rem;
-      font-size: 3.75rem;
-      line-height: 1;
+    justify-content: center;
+    min-height: 44px;
+    padding: 0 1.1rem;
+    border: 1px solid ${({ theme }) => theme.publicDesign.borderStrong};
+    border-radius: 6px;
+    background: transparent;
+    color: ${({ theme }) => theme.colors.gray12};
+    text-decoration: none;
+    font-size: 0.92rem;
+    font-weight: 800;
+    transition: border-color 0.16s ease, opacity 0.16s ease;
+  }
 
-      .questionIcon {
-        font-size: 3.1rem;
-        flex: 0 0 auto;
-        color: inherit;
-      }
-    }
+  .actions a.primary {
+    border-color: ${({ theme }) => theme.colors.gray12};
+    background: ${({ theme }) => theme.colors.gray12};
+    color: ${({ theme }) => theme.publicDesign.pageBackgroundColor};
+  }
 
-    > .copy {
-      display: grid;
-      gap: 0.72rem;
-      max-width: 34rem;
-      text-align: center;
-    }
+  .actions a:hover {
+    border-color: ${({ theme }) => theme.colors.gray12};
+  }
 
-    > .copy strong {
-      font-size: 1.875rem;
-      line-height: 2.25rem;
-      color: ${({ theme }) => theme.colors.gray12};
-    }
-
-    > .copy p {
-      margin: 0;
-      color: ${({ theme }) => theme.colors.gray10};
-      line-height: 1.7;
-    }
-
-    > .actions {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      justify-content: center;
-      gap: 0.72rem;
-    }
-
-    > .actions a {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-height: 44px;
-      padding: 0 1rem;
-      border-radius: 999px;
-      border: 1px solid ${({ theme }) => theme.colors.gray6};
-      background: ${({ theme }) => theme.colors.gray1};
-      color: ${({ theme }) => theme.colors.gray12};
-      text-decoration: none;
-      font-size: 0.92rem;
-      font-weight: 700;
-      transition:
-        transform 0.16s ease,
-        border-color 0.16s ease,
-        background-color 0.16s ease;
-    }
-
-    > .actions a:hover {
-      transform: translateY(-1px);
-      border-color: ${({ theme }) => theme.colors.gray8};
-      background: ${({ theme }) => theme.colors.gray2};
-    }
+  .actions a.primary:hover {
+    opacity: 0.88;
   }
 `


### PR DESCRIPTION
## 관련 이슈

close #1223

패밀리룩 umbrella #1217의 P2-1.

## 작업 내용

- 404(`routes/Error`)·500(`components/error/ErrorFallbackView`)을 좌측 정렬 에디토리얼 단일 컬럼으로 재설계: 모노 대문자 라벨(`ERROR · 404`/`ERROR · 500`) + 대형 extraBold 헤드라인 + 헤어라인 구획.
- 필 버튼(999px) → 사각 컨트롤(6px). 홈 이동은 잉크 블랙 primary, 보조는 아웃라인.
- "4?4" 아이콘 조합 제거, 두 페이지가 하나의 오류 UI 문법을 공유.
- 하드코딩 그레이(`#111827`/`#d1d5db`/`#f9fafb` 등) → 공용 토큰.
- `ErrorBoundary` 폴백은 `ErrorFallbackView`를 그대로 사용해 함께 적용.

## 검증

- `yarn --cwd front build`: 성공 / `check-design-colors.mjs`: ok / `next lint`: 오류 없음
- 게이트: `rg "#[0-9a-fA-F]{3,6}" front/src/routes/Error front/src/components/error` → 무결과
- `e2e/error-boundary.spec.ts`의 role/text 셀렉터(heading "문제가 발생했습니다", "다시 시도", "홈으로 이동") 유지
- 잉크 블랙 primary / 아웃라인 / 모노 라벨 대비 AA 만족

## 리뷰어 메모

- 재현: 존재하지 않는 경로(404), `/_qa/error-boundary`(강제 오류) 확인.
- 스크린샷 증거는 umbrella 계획대로 마지막 일괄 캡처.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
