### PR TITLE
[Style] P2-3 공개 페이지(메인·Legal) 마감 polish (#1225)

### DIFF
--- a/front/e2e/perf-layout.spec.ts
+++ b/front/e2e/perf-layout.spec.ts
@@ -239,13 +239,16 @@ test.describe("성능 레이아웃과 표면 예산", () => {
       expect(searchWidth).toBeLessThanOrEqual(190)
       expect(searchHeight).toBe(34)
       expect(searchY).toBeGreaterThanOrEqual(620)
-      expect(searchY).toBeLessThanOrEqual(700)
+      // 패밀리룩(1225): 모바일 메타(Focus/Updated/Repository)를 좁은 3열 → 전폭 행 스택으로
+      // 바꾸면서 히어로가 약간 높아져 검색바 Y가 ~732로 내려간다(의도된 레이아웃).
+      expect(searchY).toBeLessThanOrEqual(745)
       expect(firstCardWidth).toBeGreaterThanOrEqual(360)
       expect(firstCardWidth).toBeLessThanOrEqual(370)
       expect(firstCardHeight).toBeGreaterThanOrEqual(340)
       expect(firstCardHeight).toBeLessThanOrEqual(430)
       expect(firstCardY).toBeGreaterThanOrEqual(700)
-      expect(firstCardY).toBeLessThanOrEqual(820)
+      // 패밀리룩(1225): 위 메타 스택 변경으로 첫 카드 Y도 동일하게 아래로 이동한다.
+      expect(firstCardY).toBeLessThanOrEqual(855)
       continue
     }
 

--- a/front/src/pages/legal/history.tsx
+++ b/front/src/pages/legal/history.tsx
@@ -133,11 +133,19 @@ const StyledWrapper = styled.div`
     gap: 0.5rem;
   }
 
+  /* 패밀리룩(1225): 항목마다 반복되는 파란 링크 노이즈 완화 → 절제된 muted 링크 */
   a {
-    color: ${({ theme }) => theme.colors.accentLink};
-    font-weight: 760;
+    color: ${({ theme }) => theme.colors.gray11};
+    font-weight: 600;
+    font-size: 0.85rem;
     text-decoration: underline;
+    text-decoration-color: ${({ theme }) => theme.colors.gray7};
     text-underline-offset: 3px;
+  }
+
+  a:hover {
+    color: ${({ theme }) => theme.publicDesign.accent};
+    text-decoration-color: currentColor;
   }
 
   @media (max-width: 680px) {

--- a/front/src/routes/Feed/index.tsx
+++ b/front/src/routes/Feed/index.tsx
@@ -221,8 +221,16 @@ const IntroCard = styled.section`
       line-height: 1.5;
     }
 
-    .noteRow {
+    /* 패밀리룩(1225): 모바일에서 3열 메타가 좁아 줄바꿈이 어색 → 전폭 행으로 스택 */
+    .homeNote {
       grid-template-columns: minmax(0, 1fr);
+      gap: 10px;
+    }
+
+    .noteRow {
+      grid-template-columns: 88px minmax(0, 1fr);
+      align-items: baseline;
+      gap: 12px;
     }
   }
 `

--- a/front/src/routes/LegalPolicy/LegalPolicyPage.tsx
+++ b/front/src/routes/LegalPolicy/LegalPolicyPage.tsx
@@ -270,9 +270,10 @@ const StyledWrapper = styled.div`
     margin-top: 1.1rem;
   }
 
+  /* 패밀리룩(1225): 본문 링크를 절제된 포인트 컬러(공용 accent)로, 굵기 완화 */
   a {
-    color: ${({ theme }) => theme.colors.accentLink};
-    font-weight: 700;
+    color: ${({ theme }) => theme.publicDesign.accent};
+    font-weight: 600;
     text-decoration: underline;
     text-underline-offset: 3px;
   }


### PR DESCRIPTION
## 관련 이슈

close #1225

패밀리룩 umbrella #1217의 P2-3(마감). 이 PR 병합으로 #1217 하위 이슈 8종이 모두 완료된다.

## 작업 내용

- **메인 모바일 메타**(Focus/Updated/Repository): 768px 이하에서 `.homeNote`가 1024px 규칙의 `repeat(3, ...)`를 그대로 물려받아 3열로 좁게 줄바꿈되던 문제 → 전폭 행으로 스택(라벨 88px + 값).
- **legal/history**: 항목마다 반복되던 파란 링크(현재 문서/버전 문서) 노이즈 → 절제된 muted 링크 + hover accent.
- **legal 본문 링크**: `accentLink`(#0081f1, 대비 3.8) → 공용 `publicDesign.accent`(#155eef, 대비 5.4) + 굵기 완화(절제된 포인트 컬러 + a11y 개선).
- `feedUiTokens`는 변경 없음(공용 토큰과 충돌 없음).

## 검증

- `yarn --cwd front build`: 성공 / `check-design-colors.mjs`: ok / `next lint`: 오류 없음
- 링크 마크업/role·href 유지 → `legal-policy-pages` 셀렉터(현재 문서/버전 문서) 호환
- ✅ umbrella 최종 게이트 무결과(이전 PR에서 달성 유지)

## 리뷰어 메모

- 모바일 390px에서 메타 3항목이 전폭 스택으로 자연스럽게 배치되는지가 핵심.
- 스크린샷 증거는 umbrella 계획대로 마지막 일괄 캡처 예정.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 모바일 피드 화면에서 메타 정보와 콘텐츠 정렬이 더 안정적으로 보이도록 레이아웃을 조정했습니다.

* **Style**
  * 법률/이용 안내 페이지의 링크 색상, 굵기, 밑줄 스타일을 더 차분한 톤으로 다듬었습니다.
  * 모바일에서 목록 간격과 열 구성을 개선해 가독성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->